### PR TITLE
Fix Edit-mode broadcast loop end-to-end (closes #17)

### DIFF
--- a/crates/maestro-daemon/src/lib.rs
+++ b/crates/maestro-daemon/src/lib.rs
@@ -10,9 +10,9 @@ mod variable_resolver;
 
 use std::collections::HashMap;
 use std::net::SocketAddr;
-use std::path::PathBuf;
-use std::sync::Arc;
-use std::time::Duration;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
 use axum::extract::ws::{Message, WebSocket};
@@ -70,6 +70,31 @@ struct AppState {
     repo_root: PathBuf,
     port: u16,
     merge_lock: tokio::sync::Mutex<()>,
+    /// Paths the daemon has just written. The pipeline watcher consults this map
+    /// and suppresses `pipeline_changed` broadcasts for paths it sees within the
+    /// TTL window — that's how we tell our own writes apart from external ones
+    /// (vim, git checkout, future Pipeline Manager) without ignoring the latter.
+    recent_writes: Arc<Mutex<HashMap<PathBuf, Instant>>>,
+}
+
+/// TTL during which a recorded self-write suppresses watcher broadcasts.
+/// Larger than the debouncer interval (1s) with margin for filesystem latency.
+pub(crate) const SELF_WRITE_TTL: Duration = Duration::from_secs(2);
+
+/// Entries older than this are GCed when a new write is recorded.
+const SELF_WRITE_GC: Duration = Duration::from_secs(5);
+
+/// Record a path the daemon is about to write so the file watcher can skip its
+/// own broadcast when notify reports the change. Call this *before* `std::fs::write`
+/// — the watcher otherwise races against the insert.
+fn mark_self_write(map: &Mutex<HashMap<PathBuf, Instant>>, path: &Path) {
+    let now = Instant::now();
+    let mut guard = match map.lock() {
+        Ok(g) => g,
+        Err(p) => p.into_inner(),
+    };
+    guard.retain(|_, t| now.duration_since(*t) < SELF_WRITE_GC);
+    guard.insert(path.to_path_buf(), now);
 }
 
 #[derive(Deserialize)]
@@ -213,7 +238,13 @@ pub async fn serve(addr: SocketAddr, repo_root: PathBuf) -> Result<DaemonHandle>
     let (event_tx, _) = broadcast::channel::<event_log::Event>(256);
     let (pipeline_tx, _) = broadcast::channel::<serde_json::Value>(64);
 
-    let watcher = pipeline_watcher::spawn_watcher(repo_root.clone(), pipeline_tx.clone());
+    let recent_writes: Arc<Mutex<HashMap<PathBuf, Instant>>> = Arc::new(Mutex::new(HashMap::new()));
+
+    let watcher = pipeline_watcher::spawn_watcher(
+        repo_root.clone(),
+        pipeline_tx.clone(),
+        recent_writes.clone(),
+    );
 
     let listener = tokio::net::TcpListener::bind(addr)
         .await
@@ -229,6 +260,7 @@ pub async fn serve(addr: SocketAddr, repo_root: PathBuf) -> Result<DaemonHandle>
         repo_root,
         port: bound_addr.port(),
         merge_lock: tokio::sync::Mutex::new(()),
+        recent_writes,
     });
 
     let app = build_router(state);
@@ -553,6 +585,7 @@ async fn save_pipeline(
             .into_response();
     }
 
+    mark_self_write(&state.recent_writes, &path);
     if let Err(e) = std::fs::write(&path, &req.yaml) {
         return (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -567,6 +600,7 @@ async fn save_pipeline(
         if let Some(parent) = prompt_path.parent() {
             let _ = std::fs::create_dir_all(parent);
         }
+        mark_self_write(&state.recent_writes, &prompt_path);
         if let Err(e) = std::fs::write(&prompt_path, content) {
             warn!("failed to write prompt for {node_id}: {e}");
         }
@@ -2126,6 +2160,7 @@ mod tests {
             repo_root: std::env::current_dir().unwrap(),
             port: 0,
             merge_lock: tokio::sync::Mutex::new(()),
+            recent_writes: Arc::new(Mutex::new(HashMap::new())),
         })
     }
 
@@ -3021,6 +3056,7 @@ mod tests {
             repo_root: dir.to_path_buf(),
             port: 0,
             merge_lock: tokio::sync::Mutex::new(()),
+            recent_writes: Arc::new(Mutex::new(HashMap::new())),
         })
     }
 

--- a/crates/maestro-daemon/src/pipeline_watcher.rs
+++ b/crates/maestro-daemon/src/pipeline_watcher.rs
@@ -1,14 +1,18 @@
+use std::collections::HashMap;
 use std::path::PathBuf;
-use std::sync::Arc;
-use std::time::Duration;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant, SystemTime};
 
 use notify_debouncer_mini::{new_debouncer, DebouncedEventKind};
 use tokio::sync::broadcast;
 use tracing::{info, warn};
 
+use crate::SELF_WRITE_TTL;
+
 pub fn spawn_watcher(
     repo_root: PathBuf,
     event_tx: broadcast::Sender<serde_json::Value>,
+    recent_writes: Arc<Mutex<HashMap<PathBuf, Instant>>>,
 ) -> Option<notify_debouncer_mini::Debouncer<notify::RecommendedWatcher>> {
     let repo_pipelines_dir = repo_root.join(".maestro").join("pipelines");
     let user_pipelines_dir = std::env::var_os("HOME")
@@ -16,6 +20,19 @@ pub fn spawn_watcher(
         .map(|h| h.join(".maestro").join("pipelines"));
 
     let tx = Arc::new(event_tx);
+    // Last observed content-mtime per path. Used to filter out spurious events
+    // notify reports for read-only opens (we observed the watcher firing on
+    // plain `read_to_string` calls — see Bug F notes in #17). Tracking mtime
+    // gives a content-based answer regardless of which inotify mask the
+    // platform actually surfaces.
+    let mtimes: Arc<Mutex<HashMap<PathBuf, SystemTime>>> = Arc::new(Mutex::new(HashMap::new()));
+    // Pre-populate from the dirs we're about to watch so the very first event
+    // for a known file can compare against a real value (otherwise we'd treat
+    // the platform's initial debounced batch as a content change).
+    seed_mtimes(&mtimes, &repo_pipelines_dir);
+    if let Some(ref user_dir) = user_pipelines_dir {
+        seed_mtimes(&mtimes, user_dir);
+    }
 
     let mut debouncer = match new_debouncer(
         Duration::from_secs(1),
@@ -28,6 +45,18 @@ pub fn spawn_watcher(
                 let path = &event.path;
                 let ext = path.extension().and_then(|e| e.to_str());
                 if ext != Some("yaml") && ext != Some("md") {
+                    continue;
+                }
+
+                if !content_actually_changed(&mtimes, path) {
+                    continue;
+                }
+
+                if is_recent_self_write(&recent_writes, path) {
+                    info!(
+                        "Pipeline file changed (self-write, suppressed): {}",
+                        path.display()
+                    );
                     continue;
                 }
 
@@ -99,4 +128,85 @@ pub fn spawn_watcher(
     }
 
     Some(debouncer)
+}
+
+fn is_recent_self_write(map: &Mutex<HashMap<PathBuf, Instant>>, path: &std::path::Path) -> bool {
+    let guard = match map.lock() {
+        Ok(g) => g,
+        Err(p) => p.into_inner(),
+    };
+    guard
+        .get(path)
+        .is_some_and(|t| t.elapsed() < SELF_WRITE_TTL)
+}
+
+/// Walks `dir` (yaml at the top level, md inside `*.prompts/` subdirs) and
+/// records the current mtime of each file we care about. Run once at startup
+/// so `content_actually_changed` has a reference point for files that already
+/// exist when the daemon boots.
+fn seed_mtimes(map: &Mutex<HashMap<PathBuf, SystemTime>>, dir: &std::path::Path) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    let mut guard = match map.lock() {
+        Ok(g) => g,
+        Err(p) => p.into_inner(),
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let ext = path.extension().and_then(|e| e.to_str());
+        if path.is_file() && ext == Some("yaml") {
+            if let Ok(t) = entry.metadata().and_then(|m| m.modified()) {
+                guard.insert(path, t);
+            }
+        } else if path.is_dir()
+            && path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.ends_with(".prompts"))
+        {
+            if let Ok(prompts) = std::fs::read_dir(&path) {
+                for p in prompts.flatten() {
+                    let pp = p.path();
+                    if pp.extension().and_then(|e| e.to_str()) == Some("md") {
+                        if let Ok(t) = p.metadata().and_then(|m| m.modified()) {
+                            guard.insert(pp, t);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Compares the file's current modified-time against the last value we saw and
+/// records the new one. Returns true only if the mtime advanced — events without
+/// a real content change (read-only opens, atime-only updates) are filtered
+/// out by this check. If the file is missing (deletion), returns true so the
+/// caller still emits a `pipeline_changed` and the frontend can refetch.
+fn content_actually_changed(
+    map: &Mutex<HashMap<PathBuf, SystemTime>>,
+    path: &std::path::Path,
+) -> bool {
+    let current = std::fs::metadata(path).and_then(|m| m.modified()).ok();
+    let mut guard = match map.lock() {
+        Ok(g) => g,
+        Err(p) => p.into_inner(),
+    };
+    match current {
+        Some(now) => {
+            let prev = guard.get(path).copied();
+            if prev == Some(now) {
+                false
+            } else {
+                guard.insert(path.to_path_buf(), now);
+                true
+            }
+        }
+        None => {
+            // File no longer there — let the frontend learn about it.
+            guard.remove(path);
+            true
+        }
+    }
 }

--- a/crates/maestro-daemon/tests/edit_self_write_loop.rs
+++ b/crates/maestro-daemon/tests/edit_self_write_loop.rs
@@ -1,0 +1,194 @@
+//! Layer 3a — proves Bug E (#17) is fixed: the daemon's `pipeline_watcher` no
+//! longer broadcasts `pipeline_changed` for writes the daemon performed itself
+//! (PUT /pipelines/:id), but still broadcasts for external writes.
+
+mod common;
+
+use std::time::Duration;
+
+use common::{ws_text, TestDaemon};
+use futures_util::{SinkExt, StreamExt};
+use tokio::time::timeout;
+use tokio_tungstenite::tungstenite::protocol::Message;
+
+const PIPELINE_NAME: &str = "editable";
+const INITIAL_YAML: &str = r#"name: editable
+version: "1.0"
+nodes:
+  - id: worker
+    type: doc-only
+    prompt_file: prompts/worker.md
+    inputs:
+      - name: task
+    outputs:
+      - name: result
+"#;
+
+const UPDATED_YAML: &str = r#"name: editable
+version: "1.0"
+nodes:
+  - id: worker
+    type: doc-only
+    prompt_file: prompts/worker.md
+    inputs:
+      - name: task
+      - name: extra
+    outputs:
+      - name: result
+"#;
+
+fn seed_pipeline(repo: &std::path::Path) -> anyhow::Result<()> {
+    let dir = repo.join(".maestro").join("pipelines");
+    std::fs::create_dir_all(&dir)?;
+    std::fs::write(dir.join(format!("{PIPELINE_NAME}.yaml")), INITIAL_YAML)?;
+    Ok(())
+}
+
+fn pipeline_path(repo: &std::path::Path) -> std::path::PathBuf {
+    repo.join(".maestro")
+        .join("pipelines")
+        .join(format!("{PIPELINE_NAME}.yaml"))
+}
+
+/// Read pipeline_changed events for `pipeline_id` until the deadline elapses or
+/// the WS closes. Discards `ready` / `heartbeat`. Returns the first match found,
+/// or `None` if the deadline hit silence.
+async fn next_pipeline_changed_for(
+    ws: &mut tokio_tungstenite::WebSocketStream<
+        tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+    >,
+    pipeline_id: &str,
+    deadline: Duration,
+) -> Option<serde_json::Value> {
+    let result = timeout(deadline, async {
+        loop {
+            let next = ws.next().await?;
+            let msg = next.ok()?;
+            let Some(text) = ws_text(&msg) else {
+                continue;
+            };
+            let parsed: serde_json::Value = serde_json::from_str(text).ok()?;
+            if parsed["type"] == "pipeline_changed" && parsed["pipeline_id"] == pipeline_id {
+                return Some(parsed);
+            }
+        }
+    })
+    .await;
+    result.ok().flatten()
+}
+
+#[tokio::test]
+async fn put_pipeline_does_not_trigger_self_broadcast() {
+    let daemon = TestDaemon::spawn(seed_pipeline).await.unwrap();
+
+    let mut ws = daemon.connect_ws().await.unwrap();
+    // drain the initial `ready`
+    let _ = ws.next().await.unwrap().unwrap();
+
+    let body = serde_json::json!({ "yaml": UPDATED_YAML, "prompts": {} });
+    let resp = reqwest::Client::new()
+        .put(format!("{}/pipelines/{}", daemon.url(), PIPELINE_NAME))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200, "PUT should succeed");
+
+    // Watcher debounce is 1s + self-write TTL is 2s. 3s of silence proves the
+    // suppression worked end-to-end.
+    let evt = next_pipeline_changed_for(&mut ws, PIPELINE_NAME, Duration::from_secs(3)).await;
+    assert!(
+        evt.is_none(),
+        "expected no pipeline_changed broadcast for self-write, got {evt:?}"
+    );
+}
+
+#[tokio::test]
+async fn external_write_still_triggers_broadcast() {
+    let daemon = TestDaemon::spawn(seed_pipeline).await.unwrap();
+
+    let mut ws = daemon.connect_ws().await.unwrap();
+    let _ = ws.next().await.unwrap().unwrap();
+
+    // Write directly to disk — bypassing the API. This is what vim / git checkout
+    // / a future Pipeline Manager looks like to the watcher. The fix must NOT
+    // break detection of these.
+    std::fs::write(pipeline_path(daemon.repo_root()), UPDATED_YAML).unwrap();
+
+    let evt = next_pipeline_changed_for(&mut ws, PIPELINE_NAME, Duration::from_secs(4))
+        .await
+        .expect("external write should still emit pipeline_changed within 4s");
+
+    assert_eq!(evt["type"], "pipeline_changed");
+    assert_eq!(evt["pipeline_id"], PIPELINE_NAME);
+}
+
+#[tokio::test]
+async fn read_only_get_does_not_trigger_broadcast() {
+    // Bug F: notify-debouncer-mini reports events for plain reads on this
+    // platform, which previously fed into a self-perpetuating broadcast loop
+    // (broadcast → frontend GETs → watcher fires → broadcast). The mtime
+    // dedup filter must catch these.
+    let daemon = TestDaemon::spawn(seed_pipeline).await.unwrap();
+
+    let mut ws = daemon.connect_ws().await.unwrap();
+    let _ = ws.next().await.unwrap().unwrap();
+
+    // GET the pipeline a few times. Each call invokes std::fs::read_to_string
+    // inside the daemon, which the watcher used to amplify into a broadcast.
+    for _ in 0..3 {
+        reqwest::get(format!("{}/pipelines/{}", daemon.url(), PIPELINE_NAME))
+            .await
+            .unwrap()
+            .error_for_status()
+            .unwrap();
+    }
+
+    // Generous window: the mini debouncer aggregates over 1s, give it a couple
+    // of cycles to be sure nothing arrives.
+    let evt = next_pipeline_changed_for(&mut ws, PIPELINE_NAME, Duration::from_secs(3)).await;
+    assert!(
+        evt.is_none(),
+        "GET should not produce pipeline_changed, got {evt:?}"
+    );
+}
+
+#[tokio::test]
+async fn external_write_after_self_write_ttl_expiry_still_broadcasts() {
+    // Regression check: the TTL is *time-bounded*, not "once and forever".
+    // After 2s + safety margin, an external write to the same path must trigger
+    // the broadcast again. This proves we don't accidentally permanently mute
+    // a path after the daemon writes it.
+    let daemon = TestDaemon::spawn(seed_pipeline).await.unwrap();
+
+    let mut ws = daemon.connect_ws().await.unwrap();
+    let _ = ws.next().await.unwrap().unwrap();
+
+    let body = serde_json::json!({ "yaml": UPDATED_YAML, "prompts": {} });
+    reqwest::Client::new()
+        .put(format!("{}/pipelines/{}", daemon.url(), PIPELINE_NAME))
+        .json(&body)
+        .send()
+        .await
+        .unwrap()
+        .error_for_status()
+        .unwrap();
+
+    // Wait past the 2s self-write TTL. The first PUT's debounced event will
+    // fire ~1s after the write and be suppressed; we sleep enough to clear the
+    // window before doing the external write.
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    // Drain anything that snuck in (heartbeat etc.) so the next assertion
+    // reflects events caused by *our* external write.
+    let _ = timeout(Duration::from_millis(50), ws.next()).await;
+
+    std::fs::write(pipeline_path(daemon.repo_root()), INITIAL_YAML).unwrap();
+    let evt = next_pipeline_changed_for(&mut ws, PIPELINE_NAME, Duration::from_secs(4))
+        .await
+        .expect("post-TTL external write should broadcast");
+    assert_eq!(evt["pipeline_id"], PIPELINE_NAME);
+
+    // Force-close the socket so the daemon's WS handler exits cleanly.
+    let _ = ws.send(Message::Close(None)).await;
+}

--- a/docs/testing/scenarios/edit-and-save.md
+++ b/docs/testing/scenarios/edit-and-save.md
@@ -1,32 +1,85 @@
 # Scenario — `edit-and-save`
 
-> Layer 5 (agentic) per ADR 0004. Manual trigger; an agent executes the steps
-> and emits the verdict format below.
-
-**Status**: skeleton — content lands with #17 once the file-watcher self-write
-loop is fixed.
+> Layer 5 (agentic) per ADR 0004. Manual trigger: an agent executes the steps
+> and emits the verdict format below. Asserts the regression fix landed for
+> Bug E (#17) — the daemon-side self-write loop and Bug F (read-triggered
+> watcher events) which together caused edits to vanish ~1.5 s after typing.
 
 ## Setup
 
-- Maestro daemon running on the user's repo (`maestro daemon`).
-- Frontend reachable in a browser (Chrome DevTools MCP / Playwright).
-- A pipeline `editable.yaml` exists in `.maestro/pipelines/` — at least one
-  node, simple structure.
+- Daemon running on the user's repo (default `http://127.0.0.1:5172`).
+- Frontend reachable in a browser. Chrome DevTools MCP preferred; Playwright
+  MCP works as a fallback.
+- A test pipeline named `edit-and-save-scenario.yaml` seeded in
+  `.maestro/pipelines/`. If it isn't already there, the agent creates it
+  before driving the UI:
+
+  ```yaml
+  name: edit-and-save-scenario
+  version: "1.0"
+  nodes:
+    - id: alpha
+      type: doc-only
+      prompt_file: edit-and-save-scenario.prompts/alpha.md
+      inputs:
+        - name: in
+      outputs:
+        - name: out
+      view: { x: 100, y: 100 }
+    - id: beta
+      type: doc-only
+      prompt_file: edit-and-save-scenario.prompts/beta.md
+      inputs:
+        - name: in
+      outputs:
+        - name: out
+      view: { x: 400, y: 100 }
+  edges: []
+  ```
 
 ## Steps the agent executes
 
-1. Open the UI and switch to Edit mode.
-2. Modify a node's prompt content (type a recognizable marker like
-   `__edit_marker_<timestamp>__`).
-3. Add a new node by drag-drop or command.
-4. Wait at least 3 seconds (debounce + roundtrip + save).
-5. Reload the page.
-6. Confirm the marker text and the new node persist after reload.
-7. Read `.maestro/pipelines/editable.yaml` from disk and assert the marker is
-   present in the YAML or its sidecar prompt file.
-8. Negative check: while still in Edit mode, leave the cursor in a node prompt
-   for ~5 seconds. The cursor must not jump or lose focus, and the typed text
-   must not be erased mid-edit.
+1. Open the UI, confirm the **`Daemon: connected`** label is visible in the
+   status bar.
+2. Click the **edit-mode toggle** (pencil icon, top-right). Verify the badge
+   switches from `Run` to `Edit`.
+3. Click the `edit-and-save-scenario` row in the **Pipelines** sidebar. The
+   canvas should render two nodes (`alpha`, `beta`).
+4. Click the `alpha` node. The **Node Inspector** opens on the right with a
+   `Prompt` textarea (placeholder `Enter the node's role prompt...`).
+5. In the prompt textarea, type `MARKER_<timestamp>_FIRST` and stop typing.
+6. **Wait at least 2.5 s** without further interaction. This covers:
+    - the 1.5 s frontend save debounce, then
+    - the 1 s daemon watcher debounce.
+   The textarea **must still display the marker text** during this entire
+   window. Take a screenshot when the wait ends.
+7. **Without leaving Edit mode**, in the same textarea append
+   `_THEN_SECOND_<timestamp>` to the existing content. The full value should
+   now read `MARKER_<timestamp>_FIRST_THEN_SECOND_<timestamp>`.
+8. Wait another 3 s, then assert the textarea **still contains both markers
+   end-to-end**. (Without the fix, the broadcast triggered by step 5's save
+   would have wiped the second marker before this point.)
+9. Reload the page (`F5` or `navigate_page` again). Re-toggle Edit mode,
+   re-open the pipeline, click `alpha`. Assert the textarea **persists the
+   full combined value** after reload.
+10. Read `.maestro/pipelines/edit-and-save-scenario.prompts/alpha.md` from
+    disk. Its content **must equal** the full combined marker value — proves
+    the second save reached the backend rather than being eaten by the
+    self-write race.
+
+## Negative checks
+
+- During step 6 wait, the cursor must **not** jump to position 0; if a reload
+  fires, the textarea remounts and focus is lost. If the cursor still has
+  focus and the marker is intact, the broadcast was correctly suppressed.
+- During step 8, the daemon log (if visible) should contain
+  `(self-write, suppressed)` lines for both the YAML and the prompt sidecar.
+
+## Cleanup
+
+- Delete `.maestro/pipelines/edit-and-save-scenario.yaml`.
+- Delete `.maestro/pipelines/edit-and-save-scenario.prompts/` if it was
+  created during the run.
 
 ## Verdict format
 
@@ -34,10 +87,15 @@ loop is fixed.
 {
   "verdict": "PASS" | "FAIL",
   "evidence": [
-    "<one observation per line>"
+    "step 1: status bar shows 'Daemon: connected' (screenshot 1)",
+    "step 6: after 2.5 s wait, textarea still reads MARKER_…_FIRST",
+    "step 8: textarea reads MARKER_…_FIRST_THEN_SECOND_… (no wipe)",
+    "step 10: alpha.md on disk equals MARKER_…_FIRST_THEN_SECOND_…"
   ],
   "anomalies": [
-    "<optional>"
+    "<optional — surprising-but-non-fatal observations>"
   ]
 }
 ```
+
+A single failed assertion ⇒ `verdict: "FAIL"`. Don't half-pass.

--- a/frontend/e2e/edit-self-write.spec.ts
+++ b/frontend/e2e/edit-self-write.spec.ts
@@ -1,0 +1,89 @@
+import { test, expect } from "@playwright/test";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Layer 3b — UI witness for Bug E (#17). Without the daemon-side fix, edits
+// would be wiped by the broadcast/reload cycle: the daemon's PUT triggers a
+// watcher event, the frontend reloads from disk, and any keystrokes typed
+// between the save and the broadcast are erased.
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const WORKSPACE_ROOT = path.resolve(__dirname, "..", "..");
+const PIPELINE_NAME = `e2e-edit-self-write-${process.pid}-${Date.now()}`;
+const PIPELINE_DIR = path.join(WORKSPACE_ROOT, ".maestro", "pipelines");
+const PIPELINE_PATH = path.join(PIPELINE_DIR, `${PIPELINE_NAME}.yaml`);
+const PROMPTS_DIR = path.join(PIPELINE_DIR, `${PIPELINE_NAME}.prompts`);
+
+// `prompt_file` follows the convention save_pipeline writes to (`<id>.prompts/<node>.md`)
+// so the GET roundtrip can read back what the PUT wrote.
+const SEED_YAML = `name: ${PIPELINE_NAME}
+version: "1.0"
+nodes:
+  - id: alpha
+    type: doc-only
+    prompt_file: ${PIPELINE_NAME}.prompts/alpha.md
+    inputs:
+      - name: in
+    outputs:
+      - name: out
+    view: { x: 100, y: 100 }
+  - id: beta
+    type: doc-only
+    prompt_file: ${PIPELINE_NAME}.prompts/beta.md
+    inputs:
+      - name: in
+    outputs:
+      - name: out
+    view: { x: 400, y: 100 }
+edges: []
+`;
+
+test.beforeAll(async () => {
+  await fs.mkdir(PIPELINE_DIR, { recursive: true });
+  await fs.writeFile(PIPELINE_PATH, SEED_YAML);
+});
+
+test.afterAll(async () => {
+  await fs.rm(PIPELINE_PATH, { force: true });
+  await fs.rm(PROMPTS_DIR, { recursive: true, force: true });
+});
+
+test("post-save keystrokes survive the broadcast cycle (#17)", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.getByText("Daemon: connected")).toBeVisible({ timeout: 10_000 });
+
+  await page.locator('[title="Toggle edit mode"]').click();
+  await page.getByRole("button", { name: new RegExp(PIPELINE_NAME) }).click();
+  await page.getByText("alpha", { exact: true }).first().click();
+
+  const promptArea = page.getByPlaceholder("Enter the node's role prompt...");
+  await expect(promptArea).toBeVisible();
+
+  // First edit: triggers a save 1500 ms later (editStore debounce).
+  await promptArea.fill("MARKER_A");
+
+  // Wait past the save flush. With the bug present, the watcher would now fire
+  // ~1 s later, the frontend would reloadPipeline, and our second fill would
+  // race the SET state and lose.
+  await page.waitForTimeout(1900);
+
+  // Second edit, performed in the danger window between the daemon's write
+  // and the (would-be) broadcast.
+  await promptArea.fill("MARKER_A_then_MARKER_B");
+
+  // Cover the entire potential broadcast/reload window.
+  await page.waitForTimeout(3000);
+
+  await expect(promptArea).toHaveValue("MARKER_A_then_MARKER_B");
+
+  // Persistence: the followup save flushed MARKER_B to disk.
+  await page.reload();
+  await expect(page.getByText("Daemon: connected")).toBeVisible({ timeout: 10_000 });
+  await page.locator('[title="Toggle edit mode"]').click();
+  await page.getByRole("button", { name: new RegExp(PIPELINE_NAME) }).click();
+  await page.getByText("alpha", { exact: true }).first().click();
+
+  const reloaded = page.getByPlaceholder("Enter the node's role prompt...");
+  await expect(reloaded).toHaveValue("MARKER_A_then_MARKER_B");
+});

--- a/frontend/src/stores/editStore.ts
+++ b/frontend/src/stores/editStore.ts
@@ -138,7 +138,13 @@ function dumpYaml(val: unknown, indent: number): string {
         const child = dumpYaml(v, indent + 1);
         if (typeof v === "object" && v !== null && !Array.isArray(v)) {
           const lines = child.split("\n");
-          return `${prefix}- ${lines[0]}\n${lines.slice(1).map((l) => `${prefix}  ${l}`).join("\n")}`;
+          // The recursive call already indented continuation lines at indent+1,
+          // which lines up with the column where the first key lands after `- `
+          // — so pass them through verbatim.
+          const rest = lines.slice(1).join("\n");
+          return rest
+            ? `${prefix}- ${lines[0]}\n${rest}`
+            : `${prefix}- ${lines[0]}`;
         }
         return `${prefix}- ${child}`;
       })


### PR DESCRIPTION
## Summary

Closes **#17**. Resolves the user-visible symptom *"edits silently disappear ~1.5 s after the action"* in Edit mode by fixing three coupled bugs at once:

1. **Self-write loop** (#17 as written) — daemon's pipeline watcher rebroadcast its own writes back to the frontend, causing reload races.
2. **Read-triggered watcher events (Bug F, new)** — `notify-debouncer-mini` was firing for plain reads on this platform, perpetuating the broadcast loop even after the self-write fix.
3. **Frontend YAML serializer (new)** — `dumpYaml` in `editStore.ts` produced invalid indentation for objects nested in arrays; every `PUT /pipelines/:id` returned 400, so edits never reached disk.

Originally only (1) was in scope, but (1) alone doesn't make the symptom go away — (2) keeps the loop running and (3) prevents persistence. Discussion in the issue thread led to the broader fix.

## How

- `AppState` gains `recent_writes: Arc<Mutex<HashMap<PathBuf, Instant>>>`. `save_pipeline` marks each path before `std::fs::write`; the watcher skips broadcasts for paths it sees within a 2 s TTL. External writes still flow through — verified by tests.
- The watcher tracks last-seen mtime per path. Events without an mtime advance (read-only opens, atime-only updates) are filtered. Pre-populated at startup so the first event for an existing file has a reference.
- `dumpYaml`'s array-of-objects branch no longer adds extra indent to continuation lines that already carry their own — the recursion did the work, the wrapper was double-counting.

## Test plan

- [x] `cargo test --workspace` — 192 tests, includes 4 new layer 3a tests in `tests/edit_self_write_loop.rs` (self-write suppressed, external write broadcasts, GET doesn't broadcast, post-TTL external write still broadcasts).
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] `bash tests/smoke.sh` (layer 4)
- [x] Frontend `npm run typecheck` and `npm run lint`
- [x] Playwright `npm run e2e` (2 specs incl. new `edit-self-write.spec.ts` that types past the save window and asserts no wipe + persistence after reload)
- [x] Layer 5 scenario authored at `docs/testing/scenarios/edit-and-save.md` (manual agent-driven flow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)