### PR TITLE
Fix Node Run tmux spawn primitive (closes #18)

### DIFF
--- a/crates/maestro-daemon/src/lib.rs
+++ b/crates/maestro-daemon/src/lib.rs
@@ -2024,6 +2024,74 @@ fn create_worktree(
 
 // --- tmux ---
 
+/// Env var that, when set, replaces the `claude --dangerously-skip-permissions ...`
+/// tail of the tmux script. Used by integration tests to spawn `sleep 60` instead
+/// of actually launching Claude Code.
+pub const TMUX_CMD_OVERRIDE_ENV: &str = "MAESTRO_TMUX_CMD_OVERRIDE";
+
+/// Quote a value so it survives expansion inside a single-quoted bash string.
+/// Wraps in `'…'` and escapes any embedded single quote as `'\''`.
+fn sh_single_quote(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('\'');
+    for ch in s.chars() {
+        if ch == '\'' {
+            out.push_str("'\\''");
+        } else {
+            out.push(ch);
+        }
+    }
+    out.push('\'');
+    out
+}
+
+/// Construct the script tmux launches for a node run.
+///
+/// Shape:
+/// ```text
+/// exec bash -c '<exports> && <tail_cmd>'
+/// ```
+/// where `tail_cmd` defaults to `exec claude --dangerously-skip-permissions "$(cat <prompt>)"`.
+/// Both `exec`s are deliberate so the tmux session leader becomes claude (signals
+/// propagate, the session lives exactly as long as claude). The default can be
+/// overridden via `TMUX_CMD_OVERRIDE_ENV` for tests that don't have claude on PATH.
+///
+/// Verified empirically (2026-05-06): `claude "<prompt>"` is accepted as the
+/// initial message in interactive mode — the prompt-as-arg form works, no
+/// `tmux send-keys` fallback needed. First launch in a fresh worktree path
+/// also triggers claude's one-time "trust this folder" dialog; the user must
+/// confirm before the prompt lands. That gate is orthogonal to this primitive.
+///
+/// Public so integration tests can assert the produced shape without invoking tmux.
+pub fn build_tmux_script(
+    run_id: &str,
+    node_id: &str,
+    iter: i64,
+    daemon_port: u16,
+    prompt_path: &std::path::Path,
+) -> String {
+    let tail_cmd = std::env::var(TMUX_CMD_OVERRIDE_ENV).unwrap_or_else(|_| {
+        format!(
+            "exec claude --dangerously-skip-permissions \"$(cat {})\"",
+            sh_single_quote(&prompt_path.to_string_lossy())
+        )
+    });
+
+    let inner = format!(
+        "export MAESTRO_RUN_ID={run_id_q} && \
+         export MAESTRO_NODE_ID={node_id_q} && \
+         export MAESTRO_NODE_ITER={iter_q} && \
+         export MAESTRO_DAEMON_URL={daemon_url_q} && \
+         {tail_cmd}",
+        run_id_q = sh_single_quote(run_id),
+        node_id_q = sh_single_quote(node_id),
+        iter_q = sh_single_quote(&iter.to_string()),
+        daemon_url_q = sh_single_quote(&format!("http://localhost:{daemon_port}")),
+    );
+
+    format!("exec bash -c {}", sh_single_quote(&inner))
+}
+
 fn spawn_tmux_session(
     session_name: &str,
     prompt: &str,
@@ -2033,32 +2101,17 @@ fn spawn_tmux_session(
     iter: i64,
     daemon_port: u16,
 ) -> Result<()> {
-    // Write prompt to a temp file the agent can read
     let prompt_dir = working_dir.join(".maestro").join("prompts");
     std::fs::create_dir_all(&prompt_dir)?;
     let prompt_path = prompt_dir.join(format!("{node_id}-iter-{iter}.md"));
     std::fs::write(&prompt_path, prompt)?;
 
-    // Build the command that runs inside tmux
-    let claude_cmd = format!(
-        "export MAESTRO_RUN_ID='{run_id}' && \
-         export MAESTRO_NODE_ID='{node_id}' && \
-         export MAESTRO_NODE_ITER='{iter}' && \
-         export MAESTRO_DAEMON_URL='http://localhost:{daemon_port}' && \
-         echo 'Maestro NodeRun: {node_id} iter {iter}' && \
-         echo 'Prompt file: {}' && \
-         echo '---' && \
-         cat '{}' && \
-         echo '---' && \
-         echo 'Run: maestro complete when done, maestro fail --reason \"...\" on failure'",
-        prompt_path.display(),
-        prompt_path.display(),
-    );
+    let script = build_tmux_script(run_id, node_id, iter, daemon_port, &prompt_path);
 
     let output = std::process::Command::new("tmux")
         .args(["new-session", "-d", "-s", session_name, "-c"])
         .arg(working_dir)
-        .arg(&claude_cmd)
+        .arg(&script)
         .output()
         .context("failed to run tmux new-session")?;
 

--- a/crates/maestro-daemon/src/main.rs
+++ b/crates/maestro-daemon/src/main.rs
@@ -1,9 +1,8 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::Parser;
 use maestro_daemon::{run_complete, run_daemon, run_fail, Cli, Commands};
 
-#[tokio::main]
-async fn main() -> Result<()> {
+fn main() -> Result<()> {
     let cli = Cli::parse();
     match cli.command {
         Commands::Daemon { port } => {
@@ -14,7 +13,14 @@ async fn main() -> Result<()> {
                 )
                 .with_writer(std::io::stderr)
                 .init();
-            run_daemon(port).await
+            // Only the daemon needs a tokio runtime. `run_complete` / `run_fail`
+            // use `reqwest::blocking` and panic on shutdown if invoked from
+            // within `#[tokio::main]`'s runtime context.
+            tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()
+                .context("failed to build tokio runtime")?
+                .block_on(run_daemon(port))
         }
         Commands::Complete => run_complete(),
         Commands::Fail { reason } => run_fail(reason),

--- a/crates/maestro-daemon/src/main.rs
+++ b/crates/maestro-daemon/src/main.rs
@@ -10,8 +10,9 @@ async fn main() -> Result<()> {
             tracing_subscriber::fmt()
                 .with_env_filter(
                     tracing_subscriber::EnvFilter::try_from_default_env()
-                        .unwrap_or_else(|_| "maestro_daemon=info".into()),
+                        .unwrap_or_else(|_| "maestro_daemon=info,info".into()),
                 )
+                .with_writer(std::io::stderr)
                 .init();
             run_daemon(port).await
         }

--- a/crates/maestro-daemon/tests/cli_complete_does_not_panic.rs
+++ b/crates/maestro-daemon/tests/cli_complete_does_not_panic.rs
@@ -1,0 +1,190 @@
+//! Layer 3a — proves the `maestro complete` / `maestro fail` CLI commands
+//! exit cleanly instead of panicking on tokio runtime shutdown when invoked
+//! from inside a tmux NodeRun session.
+//!
+//! Surfaced while running the run-minimal scenario for #18: the spawn primitive
+//! worked, claude wrote the artifact, but `maestro complete` panicked with
+//! "Cannot drop a runtime in a context where blocking is not allowed" — the
+//! sync subcommands were running inside `#[tokio::main]`'s async context and
+//! `reqwest::blocking` could not safely shut down its inner runtime there.
+//!
+//! These tests spawn the real `maestro` binary in a subprocess (mirroring what
+//! claude does inside the tmux session) and assert clean exit codes against a
+//! live TestDaemon.
+
+mod common;
+
+use std::process::Command;
+use std::time::Duration;
+
+use common::TestDaemon;
+
+const PIPELINE_NAME: &str = "cli-cycle";
+const NODE_ID: &str = "solo";
+const PIPELINE_YAML: &str = r#"name: cli-cycle
+version: "1.0"
+nodes:
+  - id: solo
+    type: doc-only
+    inputs:
+      - name: in
+    outputs:
+      - name: out
+"#;
+
+fn seed(repo: &std::path::Path) -> anyhow::Result<()> {
+    let pipelines_dir = repo.join(".maestro").join("pipelines");
+    std::fs::create_dir_all(&pipelines_dir)?;
+    std::fs::write(
+        pipelines_dir.join(format!("{PIPELINE_NAME}.yaml")),
+        PIPELINE_YAML,
+    )?;
+    git_init_with_commit(repo)?;
+    Ok(())
+}
+
+fn git_init_with_commit(repo: &std::path::Path) -> anyhow::Result<()> {
+    let run = |args: &[&str]| -> anyhow::Result<()> {
+        let out = Command::new("git").args(args).current_dir(repo).output()?;
+        if !out.status.success() {
+            anyhow::bail!(
+                "git {:?} failed: {}",
+                args,
+                String::from_utf8_lossy(&out.stderr)
+            );
+        }
+        Ok(())
+    };
+    run(&["init", "-q", "-b", "main"])?;
+    run(&["config", "user.email", "test@example.com"])?;
+    run(&["config", "user.name", "Test"])?;
+    run(&["config", "commit.gpgsign", "false"])?;
+    std::fs::write(repo.join(".gitignore"), ".maestro/runs/\n")?;
+    run(&["add", "."])?;
+    run(&["commit", "-q", "-m", "init"])?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn maestro_complete_does_not_panic_and_marks_node_done() {
+    // Bypass spawn_tmux_session entirely so the test doesn't need claude/tmux.
+    std::env::set_var(maestro_daemon::TMUX_CMD_OVERRIDE_ENV, "true");
+
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+
+    let body = serde_json::json!({ "pipeline": PIPELINE_NAME, "input": "hello" });
+    let resp = reqwest::Client::new()
+        .post(format!("{}/runs", daemon.url()))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 201);
+    let run_id = resp.json::<serde_json::Value>().await.unwrap()["run_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Give the daemon a beat to record node_started, otherwise /done fights
+    // an in-flight write.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // Sanity: the daemon is reachable from this process via async reqwest.
+    reqwest::get(format!("{}/runs", daemon.url()))
+        .await
+        .expect("daemon should be reachable from test process")
+        .error_for_status()
+        .expect("/runs should return 2xx");
+
+    let url = daemon.url();
+    let run_id_clone = run_id.clone();
+    let bin = env!("CARGO_BIN_EXE_maestro");
+    // Run the subprocess on a blocking task so the host runtime stays free to
+    // serve the daemon's HTTP requests while `maestro complete` blocks on its
+    // own reqwest call.
+    let output = tokio::task::spawn_blocking(move || {
+        Command::new(bin)
+            .arg("complete")
+            .env("MAESTRO_RUN_ID", &run_id_clone)
+            .env("MAESTRO_NODE_ID", NODE_ID)
+            .env("MAESTRO_NODE_ITER", "1")
+            .env("MAESTRO_DAEMON_URL", &url)
+            .output()
+            .expect("failed to spawn maestro complete")
+    })
+    .await
+    .expect("blocking task panicked");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        !stderr.contains("panicked"),
+        "maestro complete must not panic. stderr=\n{stderr}\nstdout=\n{stdout}"
+    );
+    assert!(
+        output.status.success(),
+        "maestro complete should exit 0 against a live daemon. \
+         exit={:?}\nstderr=\n{stderr}\nstdout=\n{stdout}",
+        output.status.code()
+    );
+
+    // Side-effect: the daemon now treats the node as done.
+    let run = reqwest::get(format!("{}/runs/{run_id}", daemon.url()))
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    assert_eq!(
+        run["nodes"][NODE_ID]["status"], "completed",
+        "node should be marked completed; run state was: {run}"
+    );
+
+    std::env::remove_var(maestro_daemon::TMUX_CMD_OVERRIDE_ENV);
+}
+
+#[tokio::test]
+async fn maestro_fail_does_not_panic() {
+    // Same panic path through `reqwest::blocking` — covers the `fail` arm too.
+    std::env::set_var(maestro_daemon::TMUX_CMD_OVERRIDE_ENV, "true");
+
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+
+    let body = serde_json::json!({ "pipeline": PIPELINE_NAME, "input": "x" });
+    let resp = reqwest::Client::new()
+        .post(format!("{}/runs", daemon.url()))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    let run_id = resp.json::<serde_json::Value>().await.unwrap()["run_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let url = daemon.url();
+    let run_id_clone = run_id.clone();
+    let bin = env!("CARGO_BIN_EXE_maestro");
+    let output = tokio::task::spawn_blocking(move || {
+        Command::new(bin)
+            .args(["fail", "--reason", "test-induced failure"])
+            .env("MAESTRO_RUN_ID", &run_id_clone)
+            .env("MAESTRO_NODE_ID", NODE_ID)
+            .env("MAESTRO_NODE_ITER", "1")
+            .env("MAESTRO_DAEMON_URL", &url)
+            .output()
+            .expect("failed to spawn maestro fail")
+    })
+    .await
+    .expect("blocking task panicked");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("panicked"),
+        "maestro fail must not panic. stderr=\n{stderr}"
+    );
+
+    std::env::remove_var(maestro_daemon::TMUX_CMD_OVERRIDE_ENV);
+}

--- a/crates/maestro-daemon/tests/log_level_default.rs
+++ b/crates/maestro-daemon/tests/log_level_default.rs
@@ -1,0 +1,64 @@
+//! Layer 3a — proves Bug C (#18) is fixed: when `RUST_LOG` is unset, the daemon
+//! emits at least one INFO-level line to stderr instead of silently swallowing
+//! diagnostics. The hours we burned debugging Bug A came from this very
+//! near-silent default.
+//!
+//! Spawns the `maestro` binary in a subprocess with `RUST_LOG` removed so the
+//! tracing subscriber falls through to the default filter. The startup banner
+//! `Maestro daemon listening on http://...` is emitted at INFO from `serve()`.
+
+use std::io::Read;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+#[test]
+fn info_logs_emitted_when_rust_log_is_unset() {
+    let bin = env!("CARGO_BIN_EXE_maestro");
+
+    // Daemon writes `.maestro/maestro.db` under CWD; point it at a tempdir so
+    // it doesn't pollute the package directory when run under cargo test.
+    let tempdir = tempfile::tempdir().expect("tempdir");
+
+    let mut child = std::process::Command::new(bin)
+        .current_dir(tempdir.path())
+        .args(["daemon", "--port", "0"])
+        .env_remove("RUST_LOG")
+        .env_remove("MAESTRO_TMUX_CMD_OVERRIDE")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("failed to spawn maestro daemon");
+
+    // Pipe reads block, and the daemon stays up indefinitely — drain stderr
+    // on a worker thread into a shared buffer and let the main thread observe
+    // it after a fixed window.
+    let stderr = child.stderr.take().expect("stderr pipe missing");
+    let buf = Arc::new(Mutex::new(String::new()));
+    let buf_w = Arc::clone(&buf);
+
+    let reader = std::thread::spawn(move || {
+        let mut stderr = stderr;
+        let mut chunk = [0u8; 4096];
+        while let Ok(n) = stderr.read(&mut chunk) {
+            if n == 0 {
+                break;
+            }
+            if let Ok(mut g) = buf_w.lock() {
+                g.push_str(&String::from_utf8_lossy(&chunk[..n]));
+            }
+        }
+    });
+
+    // 2s gives the runtime time to bind, log, and flush even on slow CI.
+    std::thread::sleep(Duration::from_secs(2));
+
+    let _ = child.kill();
+    let _ = child.wait();
+    let _ = reader.join();
+
+    let collected = buf.lock().map(|g| g.clone()).unwrap_or_default();
+    assert!(
+        collected.contains("INFO") || collected.contains("listening"),
+        "expected an INFO-level startup line in stderr; got:\n---\n{collected}\n---"
+    );
+}

--- a/crates/maestro-daemon/tests/tmux_run_spawn.rs
+++ b/crates/maestro-daemon/tests/tmux_run_spawn.rs
@@ -1,0 +1,173 @@
+//! Layer 3a — proves Bug A (#18) is fixed: `spawn_tmux_session` produces a
+//! script that invokes `claude --dangerously-skip-permissions` and keeps the
+//! tmux session alive until that process exits.
+//!
+//! The lifecycle test substitutes `claude` with `sleep 60` via
+//! `MAESTRO_TMUX_CMD_OVERRIDE` so the test box doesn't actually need claude
+//! on PATH. Single-test file by design — `set_var` mutates process-global
+//! state and we don't want a sibling test racing it.
+
+mod common;
+
+use std::time::Duration;
+
+use common::TestDaemon;
+use maestro_daemon::{build_tmux_script, TMUX_CMD_OVERRIDE_ENV};
+
+const PIPELINE_NAME: &str = "minimal-tmux";
+const NODE_ID: &str = "solo";
+const PIPELINE_YAML: &str = r#"name: minimal-tmux
+version: "1.0"
+nodes:
+  - id: solo
+    type: doc-only
+    inputs:
+      - name: in
+    outputs:
+      - name: out
+"#;
+
+fn seed(repo: &std::path::Path) -> anyhow::Result<()> {
+    let pipelines_dir = repo.join(".maestro").join("pipelines");
+    std::fs::create_dir_all(&pipelines_dir)?;
+    std::fs::write(
+        pipelines_dir.join(format!("{PIPELINE_NAME}.yaml")),
+        PIPELINE_YAML,
+    )?;
+
+    // git worktree add (used by create_run) requires a real repo with a HEAD.
+    git_init_with_commit(repo)?;
+    Ok(())
+}
+
+fn git_init_with_commit(repo: &std::path::Path) -> anyhow::Result<()> {
+    let run = |args: &[&str]| -> anyhow::Result<()> {
+        let out = std::process::Command::new("git")
+            .args(args)
+            .current_dir(repo)
+            .output()?;
+        if !out.status.success() {
+            anyhow::bail!(
+                "git {:?} failed: {}",
+                args,
+                String::from_utf8_lossy(&out.stderr)
+            );
+        }
+        Ok(())
+    };
+    run(&["init", "-q", "-b", "main"])?;
+    run(&["config", "user.email", "test@example.com"])?;
+    run(&["config", "user.name", "Test"])?;
+    run(&["config", "commit.gpgsign", "false"])?;
+    std::fs::write(repo.join(".gitignore"), ".maestro/runs/\n")?;
+    run(&["add", "."])?;
+    run(&["commit", "-q", "-m", "init"])?;
+    Ok(())
+}
+
+#[test]
+fn build_tmux_script_uses_exec_bash_and_invokes_claude() {
+    // Acceptance: the constructed command string contains
+    // `claude --dangerously-skip-permissions` and the `exec bash -c` shape.
+    // We make sure the override env is unset so we get the production tail.
+    std::env::remove_var(TMUX_CMD_OVERRIDE_ENV);
+
+    let prompt_path = std::path::Path::new("/tmp/maestro-test/solo-iter-1.md");
+    let script = build_tmux_script("run-abc", "solo", 1, 5172, prompt_path);
+
+    assert!(
+        script.starts_with("exec bash -c "),
+        "script should start with `exec bash -c `; got: {script}"
+    );
+    assert!(
+        script.contains("exec claude --dangerously-skip-permissions"),
+        "script must invoke claude with --dangerously-skip-permissions; got: {script}"
+    );
+    // The script is wrapped in `bash -c '...'`, so single quotes around the
+    // embedded prompt path get rewritten as `'\''`. We just need to see that
+    // the path appears inside a `cat …` command substitution.
+    assert!(
+        script.contains("$(cat ") && script.contains("/tmp/maestro-test/solo-iter-1.md"),
+        "script must `cat` the prompt file inside command substitution; got: {script}"
+    );
+    assert!(
+        script.contains("export MAESTRO_RUN_ID=") && script.contains("run-abc"),
+        "script must export MAESTRO_RUN_ID; got: {script}"
+    );
+    assert!(
+        script.contains("export MAESTRO_DAEMON_URL=") && script.contains("http://localhost:5172"),
+        "script must export MAESTRO_DAEMON_URL; got: {script}"
+    );
+}
+
+#[tokio::test]
+async fn tmux_session_alive_after_run_spawn() {
+    // tmux must be present for this test to be meaningful.
+    if !tmux_available() {
+        eprintln!("tmux not on PATH — skipping tmux_session_alive_after_run_spawn");
+        return;
+    }
+
+    // Substitute claude → sleep 60. Set BEFORE spawning the daemon so
+    // `build_tmux_script` reads the override at run-creation time.
+    std::env::set_var(TMUX_CMD_OVERRIDE_ENV, "exec sleep 60");
+
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+
+    let body = serde_json::json!({
+        "pipeline": PIPELINE_NAME,
+        "input": "test input",
+    });
+    let resp = reqwest::Client::new()
+        .post(format!("{}/runs", daemon.url()))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 201, "POST /runs should succeed");
+    let resp_json: serde_json::Value = resp.json().await.unwrap();
+    let run_id = resp_json["run_id"].as_str().unwrap().to_string();
+
+    let session = format!("maestro-{run_id}-{NODE_ID}-iter-1");
+
+    // Poll for up to 5s — spawn_node runs async work (worktree, prompt write,
+    // tmux exec) before the session appears.
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    let mut alive = false;
+    while std::time::Instant::now() < deadline {
+        if tmux_has_session(&session) {
+            alive = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    // Always best-effort kill regardless of outcome so a flake doesn't leak
+    // a sleep 60 process.
+    let _ = std::process::Command::new("tmux")
+        .args(["kill-session", "-t", &session])
+        .output();
+
+    std::env::remove_var(TMUX_CMD_OVERRIDE_ENV);
+
+    assert!(
+        alive,
+        "expected tmux session `{session}` to exist within 5s of POST /runs"
+    );
+}
+
+fn tmux_available() -> bool {
+    std::process::Command::new("tmux")
+        .arg("-V")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn tmux_has_session(session: &str) -> bool {
+    std::process::Command::new("tmux")
+        .args(["has-session", "-t", session])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}

--- a/docs/testing/scenarios/run-minimal.md
+++ b/docs/testing/scenarios/run-minimal.md
@@ -1,27 +1,103 @@
 # Scenario — `run-minimal`
 
-> Layer 5 (agentic) per ADR 0004. Manual trigger; an agent executes the steps
-> and emits the verdict format below.
-
-**Status**: skeleton — content lands with #18 once the tmux/claude spawn primitive
-works end-to-end.
+> Layer 5 (agentic) per ADR 0004. Manual trigger: an agent executes the steps
+> below and emits the verdict format at the bottom. Asserts that #18's
+> `spawn_tmux_session` rewrite actually launches `claude` with the right prompt
+> and that the tmux session lives long enough for the user to attach.
 
 ## Setup
 
-- Maestro daemon running on the user's repo (`maestro daemon`).
-- Frontend reachable in a browser controlled by Chrome DevTools MCP or Playwright.
-- A pipeline `minimal-run.yaml` exists in `.maestro/pipelines/` (single doc-only
-  node, prompt asking the agent to write a one-line artifact).
+- Maestro daemon running on the user's repo (`maestro daemon`). Daemon URL
+  defaults to `http://127.0.0.1:5172`.
+- Frontend reachable in a browser. Chrome DevTools MCP preferred; Playwright
+  MCP works as a fallback.
+- `claude` available on `PATH` (the daemon shells out to `claude
+  --dangerously-skip-permissions "$(cat <prompt>)"`).
+- A pipeline `run-minimal-scenario.yaml` exists in `.maestro/pipelines/`. If it
+  isn't already there, the agent creates it before driving the UI:
+
+  ```yaml
+  name: run-minimal-scenario
+  version: "1.0"
+  nodes:
+    - id: only
+      type: doc-only
+      prompt_file: run-minimal-scenario.prompts/only.md
+      inputs:
+        - name: in
+      outputs:
+        - name: out
+      view: { x: 100, y: 100 }
+  edges: []
+  ```
+
+  And `.maestro/pipelines/run-minimal-scenario.prompts/only.md`:
+
+  ```
+  Reply with exactly the line `MAESTRO_RUN_MINIMAL_OK` and then call the
+  `maestro complete` command. Do nothing else.
+  ```
 
 ## Steps the agent executes
 
-1. (TBD with #18) Open the UI; confirm pipeline appears in the New Run picker.
-2. Submit a new run; capture the `run_id`.
-3. Observe the DAG node animate to "running" within ~2s.
-4. `tmux capture-pane -p -t maestro-<run_id>-<node_id>-iter-1` and assert the
-   pane shows claude prompting (not just `echo` or `cat`).
-5. Wait for the run to reach `completed` (or fail with rationale).
-6. Confirm the artifact file exists in `.maestro/runs/<run_id>/worktree/.maestro/artifacts/`.
+1. Open the UI; confirm the **`Daemon: connected`** label is visible.
+2. Open the **New Run** modal. Pick `run-minimal-scenario`. Provide any input
+   string (e.g. `hello`). Click **Launch**. Capture the resulting `run_id`
+   from the URL or the run-list panel.
+3. Within ~2 s, the DAG node `only` should animate to **`running`**.
+4. From a shell on the host, list tmux sessions and assert one matches
+   `maestro-<run_id>-only-iter-1`:
+
+   ```bash
+   tmux ls | grep "maestro-<run_id>-only-iter-1"
+   ```
+
+5. `tmux capture-pane -p -t maestro-<run_id>-only-iter-1`. The pane content
+   must show the **claude TUI**, not just an `echo`/`cat` shell. Acceptable
+   first-launch states:
+   - The "Quick safety check: Is this a project you created or one you trust?"
+     dialog. **First launch in a fresh worktree path always lands here.**
+     The agent confirms with `tmux send-keys -t maestro-<run_id>-only-iter-1
+     Enter`.
+   - After confirmation: the chat view, with the prompt body
+     ("Reply with exactly the line …") visible as the **first user message**.
+
+   Take a screenshot of the pane after the trust dialog clears.
+6. Wait up to ~30 s for claude to reply with `MAESTRO_RUN_MINIMAL_OK` and call
+   `maestro complete`. Re-capture the pane and assert the literal string
+   `MAESTRO_RUN_MINIMAL_OK` is present.
+7. Refresh the run view in the UI; the node `only` should now read
+   **`completed`**.
+8. Confirm the artifact file exists:
+
+   ```bash
+   ls .maestro/runs/<run_id>/worktree/.maestro/artifacts/
+   ```
+
+   At minimum `_input.md` is present; depending on what claude wrote, an
+   `only.md` artifact may also be there.
+
+## Negative checks
+
+- **Tmux session must persist** until `maestro complete` is called. If the
+  session dies within a few seconds of launch (the original Bug A symptom),
+  capture the pane *before* it dies (via repeated `tmux capture-pane` polls)
+  and report the failure — that is the regression this scenario exists to
+  catch.
+- **No `echo Maestro NodeRun: …` banner** — that string was the old broken
+  command. If you see it, you're on the pre-#18 build.
+- **Daemon stderr (visible if the agent is running `maestro daemon` in the
+  foreground) should contain INFO lines** like `Spawned tmux session: …`. If
+  it's silent, Bug C is back.
+
+## Cleanup
+
+- Kill the tmux session if still alive:
+  `tmux kill-session -t maestro-<run_id>-only-iter-1`.
+- Delete the worktree:
+  `git worktree remove --force .maestro/runs/<run_id>/worktree`.
+- Delete `.maestro/pipelines/run-minimal-scenario.yaml` and its `.prompts/`
+  dir if the agent created them in step 0.
 
 ## Verdict format
 
@@ -29,10 +105,15 @@ works end-to-end.
 {
   "verdict": "PASS" | "FAIL",
   "evidence": [
-    "<one observation per line, e.g. 'tmux pane shows claude UI'>"
+    "step 4: tmux session 'maestro-<run_id>-only-iter-1' present",
+    "step 5: pane shows claude TUI (trust dialog → chat view)",
+    "step 6: pane contains 'MAESTRO_RUN_MINIMAL_OK'",
+    "step 7: UI shows node 'only' as completed"
   ],
   "anomalies": [
-    "<optional — anything unexpected>"
+    "<optional — surprising-but-non-fatal observations>"
   ]
 }
 ```
+
+A single failed assertion ⇒ `verdict: "FAIL"`. Don't half-pass.


### PR DESCRIPTION
## Summary

- Rewrites `spawn_tmux_session` so it actually invokes `claude --dangerously-skip-permissions "$(cat <prompt>)"` via `exec bash -c '…'`. The prior body never invoked claude, so the session died before any agent ran (Bug A) and the user could never attach to a working agent (Bug B).
- Widens the tracing default to `maestro_daemon=info,info` and routes it to stderr so the daemon stops being silent without `RUST_LOG` (Bug C).
- Extracts `build_tmux_script` as a public, pure helper so tests can assert the produced shape; adds `MAESTRO_TMUX_CMD_OVERRIDE` so tests substitute `sleep 60` for claude.
- **Bonus fix surfaced by the layer-5 scenario**: drops `#[tokio::main]` so `maestro complete` / `maestro fail` no longer panic on `reqwest::blocking` runtime shutdown (those subcommands ran inside the outer tokio runtime and tripped tokio's "cannot drop a runtime from async context" check). Without this, the spawn primitive works but the run never reaches `completed`.

Empirically verified (2026-05-06) that `claude "<prompt>"` accepts the prompt as initial message — no `tmux send-keys` fallback needed.

## Layer-5 scenario verdict

Ran `docs/testing/scenarios/run-minimal.md` end-to-end against the local daemon (`./target/debug/maestro daemon --port 5172`):

```json
{
  "verdict": "PASS",
  "evidence": [
    "step 1: status bar shows 'Daemon: connected'",
    "step 2: POST /runs returned run_id=20260506-182924-a956a4f, UI animated node 'only' to 'running' within ~2s",
    "step 4: tmux ls shows 'maestro-20260506-182924-a956a4f-only-iter-1' alive after launch",
    "step 5: claude TUI visible in pane with 'bypass permissions on' indicator (no trust dialog because parent repo already trusted)",
    "step 6: artifact .maestro/runs/<id>/worktree/.maestro/artifacts/only/iter-1/out.md == 'MAESTRO_RUN_MINIMAL_OK'",
    "step 7: UI shows run + node as 'completed' at 18:29:38 (14s after launch)",
    "daemon log emits INFO 'Spawned tmux session', 'Node only completed' — Bug C fix live"
  ],
  "anomalies": [
    "First scenario run hit the maestro complete panic — fixed in commit 184e2c0; second run (above) PASSed clean."
  ]
}
```

## Test plan

- [x] Layer 3a: `build_tmux_script_uses_exec_bash_and_invokes_claude` — string-shape assertion.
- [x] Layer 3a: `tmux_session_alive_after_run_spawn` — POST /runs with override env, polls `tmux has-session` for 5 s.
- [x] Layer 3a: `info_logs_emitted_when_rust_log_is_unset` — subprocess capture of INFO line in tempdir CWD.
- [x] Layer 3a: `maestro_complete_does_not_panic_and_marks_node_done` — subprocess against TestDaemon, asserts no panic + node moves to `completed`.
- [x] Layer 3a: `maestro_fail_does_not_panic` — same panic path on the `fail` arm.
- [x] Layer 5: `run-minimal` scenario PASS end-to-end (live verdict above).
- [x] `cargo test --workspace` clean, `cargo fmt`, `cargo clippy --workspace --all-targets` clean.

## Unblocks

Per #18, the same primitive will be reused by #10 (Pipeline Manager session) with a different prompt and session-naming convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)