### PR TITLE
fix(tests): stop cargo test leaking real claude sessions; reap tmux sockets (#181)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1384,7 +1384,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "maestro-daemon"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/maestro-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "0.1.3"
+version = "0.1.4"
 license = "MIT"
 
 [workspace.dependencies]

--- a/crates/maestro-daemon/src/lib.rs
+++ b/crates/maestro-daemon/src/lib.rs
@@ -111,6 +111,11 @@ struct AppState {
     /// individually and non-recursively (see `pipeline_watcher::watch_run_dir`),
     /// so run creation must register each new run dir here.
     run_watcher: Arc<Mutex<Option<pipeline_watcher::PipelineDebouncer>>>,
+    /// Per-daemon override for the `claude …` tail of spawned tmux scripts.
+    /// `None` in production (real claude); `Some(cmd)` in tests, seeded via
+    /// [`DaemonConfig`] by `TestDaemon::spawn`, so no test ever launches real
+    /// claude and no `std::env::set_var` race can clobber it (#181).
+    tmux_cmd_override: Option<String>,
 }
 
 impl AppState {
@@ -327,7 +332,46 @@ impl DaemonHandle {
     }
 }
 
+/// Boot-time configuration for a daemon instance.
+///
+/// Carries the knobs that must be decided *per daemon* rather than read from
+/// process-global env in the hot path. Production builds this from the
+/// environment ([`DaemonConfig::from_env`]); tests construct it directly so two
+/// daemons in the same test process can't race on a shared env var (#181).
+#[derive(Debug, Clone, Default)]
+pub struct DaemonConfig {
+    /// Replaces the `claude …` tail in spawned tmux scripts when `Some`. Tests
+    /// set this (e.g. `Some("exec sleep 600")`) so node sessions run a harmless
+    /// command instead of launching a real `claude` process. `None` →
+    /// production default (real claude).
+    pub tmux_cmd_override: Option<String>,
+}
+
+impl DaemonConfig {
+    /// Build config from the environment — the production / CLI daemon path.
+    ///
+    /// Reads [`tmux_session_manager::TMUX_CMD_OVERRIDE_ENV`] exactly once, here
+    /// at boot, preserving the documented env seam for an operator launching a
+    /// real `maestro daemon` while keeping that read out of the spawn hot path.
+    pub fn from_env() -> Self {
+        Self {
+            tmux_cmd_override: std::env::var(tmux_session_manager::TMUX_CMD_OVERRIDE_ENV).ok(),
+        }
+    }
+}
+
 pub async fn serve(addr: SocketAddr, repo_root: PathBuf) -> Result<DaemonHandle> {
+    serve_with_config(addr, repo_root, DaemonConfig::from_env()).await
+}
+
+/// Like [`serve`], but takes an explicit [`DaemonConfig`] instead of reading the
+/// environment. Tests use this to seed a per-daemon `tmux_cmd_override` without
+/// mutating process-global env.
+pub async fn serve_with_config(
+    addr: SocketAddr,
+    repo_root: PathBuf,
+    config: DaemonConfig,
+) -> Result<DaemonHandle> {
     let db_dir = repo_root.join(".maestro");
     std::fs::create_dir_all(&db_dir).context("failed to create .maestro directory")?;
     let db_path = db_dir.join("maestro.db");
@@ -372,6 +416,7 @@ pub async fn serve(addr: SocketAddr, repo_root: PathBuf) -> Result<DaemonHandle>
         merge_lock: tokio::sync::Mutex::new(()),
         recent_writes,
         run_watcher: run_watcher.clone(),
+        tmux_cmd_override: config.tmux_cmd_override,
     });
 
     // The orphan sweep — and every other tmux call this daemon makes —
@@ -2263,6 +2308,7 @@ async fn spawn_node(
         &node.id,
         iter,
         state.port,
+        state.tmux_cmd_override.as_deref(),
     ) {
         error!("failed to spawn tmux session: {e}");
     }
@@ -3213,6 +3259,7 @@ fn spawn_manager_session(
         "__manager__",
         0,
         state.port,
+        state.tmux_cmd_override.as_deref(),
     ) {
         error!("failed to spawn manager tmux session: {e}");
     } else {
@@ -3901,6 +3948,7 @@ async fn node_pane(
                 &node_id,
                 iter,
                 state.port,
+                state.tmux_cmd_override.as_deref(),
             ) {
                 warn!("Failed to resume session {session_name}: {e}");
                 return Json(PaneResponse {
@@ -4154,6 +4202,7 @@ async fn spawn_merge_resolver(
         MERGE_RESOLVER_NODE_ID,
         1,
         state.port,
+        state.tmux_cmd_override.as_deref(),
     ) {
         error!("failed to spawn merge resolver tmux session: {e}");
         let fail_event = event_log::Event {
@@ -4698,6 +4747,7 @@ async fn node_start(
         pipeline_path: &pipeline_path,
         resolved_vars: &resolved_vars,
         daemon_port: state.port,
+        tmux_cmd_override: state.tmux_cmd_override.as_deref(),
     };
 
     let result = node_primitives::start_node(&params);
@@ -4916,6 +4966,7 @@ async fn node_retry(
         pipeline_path: &pipeline_path,
         resolved_vars: &resolved_vars,
         daemon_port: state.port,
+        tmux_cmd_override: state.tmux_cmd_override.as_deref(),
     };
 
     let start_result = node_primitives::start_node(&start_params);
@@ -7160,6 +7211,10 @@ mod tests {
             merge_lock: tokio::sync::Mutex::new(()),
             recent_writes: Arc::new(Mutex::new(HashMap::new())),
             run_watcher: Arc::new(Mutex::new(None)),
+            // Self-destructing no-op: should any test POST /runs and reach the
+            // spawn path, the node session runs `true` and exits immediately —
+            // never real claude, never a lingering session (#181).
+            tmux_cmd_override: Some("exec true".to_string()),
         })
     }
 
@@ -8564,6 +8619,10 @@ mod tests {
             merge_lock: tokio::sync::Mutex::new(()),
             recent_writes: Arc::new(Mutex::new(HashMap::new())),
             run_watcher: Arc::new(Mutex::new(None)),
+            // Self-destructing no-op: should any test POST /runs and reach the
+            // spawn path, the node session runs `true` and exits immediately —
+            // never real claude, never a lingering session (#181).
+            tmux_cmd_override: Some("exec true".to_string()),
         })
     }
 
@@ -9431,8 +9490,17 @@ mod tests {
     #[test]
     fn cli_parses_daemon_subcommand() {
         let cli = Cli::try_parse_from(["maestro", "daemon"]).unwrap();
+        // With no `--port`, clap resolves the port from `MAESTRO_PORT` if set,
+        // otherwise `DEFAULT_PORT` (see the `#[arg(env = "MAESTRO_PORT", ...)]`
+        // on the Daemon variant). Compute the expectation the same way so the
+        // test is deterministic whether or not the ambient env carries
+        // `MAESTRO_PORT` — e.g. when the suite itself runs inside a Maestro node.
+        let expected = std::env::var("MAESTRO_PORT")
+            .ok()
+            .and_then(|v| v.parse::<u16>().ok())
+            .unwrap_or(DEFAULT_PORT);
         match cli.command {
-            Commands::Daemon { port } => assert_eq!(port, DEFAULT_PORT),
+            Commands::Daemon { port } => assert_eq!(port, expected),
             _ => panic!("expected Daemon subcommand"),
         }
     }
@@ -11187,6 +11255,10 @@ edges: []
             merge_lock: tokio::sync::Mutex::new(()),
             recent_writes: Arc::new(Mutex::new(HashMap::new())),
             run_watcher: Arc::new(Mutex::new(None)),
+            // Self-destructing no-op: should any test POST /runs and reach the
+            // spawn path, the node session runs `true` and exits immediately —
+            // never real claude, never a lingering session (#181).
+            tmux_cmd_override: Some("exec true".to_string()),
         });
         let app = build_router(state);
 
@@ -11354,6 +11426,10 @@ edges: []
             merge_lock: tokio::sync::Mutex::new(()),
             recent_writes: Arc::new(Mutex::new(HashMap::new())),
             run_watcher: Arc::new(Mutex::new(None)),
+            // Self-destructing no-op: should any test POST /runs and reach the
+            // spawn path, the node session runs `true` and exits immediately —
+            // never real claude, never a lingering session (#181).
+            tmux_cmd_override: Some("exec true".to_string()),
         });
         let app = build_router(state);
 

--- a/crates/maestro-daemon/src/node_primitives.rs
+++ b/crates/maestro-daemon/src/node_primitives.rs
@@ -37,6 +37,9 @@ pub struct StartNodeParams<'a> {
     pub pipeline_path: &'a Path,
     pub resolved_vars: &'a HashMap<String, serde_yaml::Value>,
     pub daemon_port: u16,
+    /// Per-daemon override for the `claude …` tail of the spawned tmux script.
+    /// Threaded from `AppState.tmux_cmd_override`; `None` → real claude (#181).
+    pub tmux_cmd_override: Option<&'a str>,
 }
 
 pub struct StartNodeResult {
@@ -137,6 +140,7 @@ pub fn start_node(params: &StartNodeParams<'_>) -> StartNodeResult {
         params.node_id,
         params.iter,
         params.daemon_port,
+        params.tmux_cmd_override,
     ) {
         return StartNodeResult {
             outcome: PrimitiveOutcome::Rejected {
@@ -640,6 +644,7 @@ mod tests {
             pipeline_path: &tmp.path().join("pipeline.yaml"),
             resolved_vars: &HashMap::new(),
             daemon_port: 5172,
+            tmux_cmd_override: Some("exec true"),
         };
 
         let result = start_node(&params);
@@ -675,6 +680,7 @@ mod tests {
             pipeline_path: &tmp.path().join("pipeline.yaml"),
             resolved_vars: &HashMap::new(),
             daemon_port: 5172,
+            tmux_cmd_override: Some("exec true"),
         };
 
         let result = start_node(&params);
@@ -730,6 +736,7 @@ mod tests {
             pipeline_path: &tmp.path().join("pipeline.yaml"),
             resolved_vars: &HashMap::new(),
             daemon_port: 5172,
+            tmux_cmd_override: Some("exec true"),
         };
 
         let input_paths = resolve_inputs(&params, node);
@@ -784,6 +791,7 @@ mod tests {
             pipeline_path: &tmp.path().join("pipeline.yaml"),
             resolved_vars: &HashMap::new(),
             daemon_port: 5172,
+            tmux_cmd_override: Some("exec true"),
         };
 
         let input_paths = resolve_inputs(&params, node);
@@ -824,6 +832,7 @@ mod tests {
             pipeline_path: &tmp.path().join("pipeline.yaml"),
             resolved_vars: &HashMap::new(),
             daemon_port: 5172,
+            tmux_cmd_override: Some("exec true"),
         };
 
         let input_paths = resolve_inputs(&params, node);
@@ -888,6 +897,7 @@ mod tests {
             pipeline_path: &tmp.path().join("pipeline.yaml"),
             resolved_vars: &HashMap::new(),
             daemon_port: 5172,
+            tmux_cmd_override: Some("exec true"),
         };
 
         let input_paths = resolve_inputs(&params, node);
@@ -933,6 +943,7 @@ mod tests {
             pipeline_path: &tmp.path().join("pipeline.yaml"),
             resolved_vars: &HashMap::new(),
             daemon_port: 5172,
+            tmux_cmd_override: Some("exec true"),
         };
 
         let input_paths = resolve_inputs(&params, node);
@@ -983,6 +994,7 @@ mod tests {
             pipeline_path: &tmp.path().join("pipeline.yaml"),
             resolved_vars: &HashMap::new(),
             daemon_port: 5172,
+            tmux_cmd_override: Some("exec true"),
         };
 
         let input_paths = resolve_inputs(&params, node);
@@ -1235,6 +1247,7 @@ mod tests {
             pipeline_path: &tmp.path().join("pipeline.yaml"),
             resolved_vars: &HashMap::new(),
             daemon_port: 5172,
+            tmux_cmd_override: Some("exec true"),
         };
 
         let result = start_node(&params);

--- a/crates/maestro-daemon/src/pipeline_migrator.rs
+++ b/crates/maestro-daemon/src/pipeline_migrator.rs
@@ -444,7 +444,9 @@ fn dissolve_foreaches(doc: &mut serde_yaml::Value) -> Result<(), String> {
         );
         region.insert(
             serde_yaml::Value::String("members".into()),
-            serde_yaml::Value::Sequence(members.into_iter().map(serde_yaml::Value::String).collect()),
+            serde_yaml::Value::Sequence(
+                members.into_iter().map(serde_yaml::Value::String).collect(),
+            ),
         );
         regions.push(serde_yaml::Value::Mapping(region));
     }
@@ -2386,16 +2388,18 @@ edges:
 
         // The entering edge enters the member directly: lister:plan -> worker.
         assert!(
-            parsed.edges.iter().any(|e| {
-                e.source.node == "aBcD1234" && e.target.node == "wRkR5678"
-            }),
+            parsed
+                .edges
+                .iter()
+                .any(|e| { e.source.node == "aBcD1234" && e.target.node == "wRkR5678" }),
             "entering edge should land on the member directly"
         );
         // The barrier edge leaves the member to the done target: worker -> end.
         assert!(
-            parsed.edges.iter().any(|e| {
-                e.source.node == "wRkR5678" && e.target.node == "end"
-            }),
+            parsed
+                .edges
+                .iter()
+                .any(|e| { e.source.node == "wRkR5678" && e.target.node == "end" }),
             "barrier edge should leave the member to the done target"
         );
 

--- a/crates/maestro-daemon/src/tmux_session_manager.rs
+++ b/crates/maestro-daemon/src/tmux_session_manager.rs
@@ -11,7 +11,12 @@ use anyhow::{Context, Result};
 use tracing::info;
 
 /// Env var that replaces the `claude …` tail in the tmux script.
-/// Used by integration tests to spawn `sleep 60` instead of claude.
+///
+/// Read **once at daemon boot** by [`crate::DaemonConfig::from_env`] and then
+/// carried as per-daemon config — never consulted in the spawn hot path. Tests
+/// must seed the override through [`crate::DaemonConfig`] / `TestDaemon`, not by
+/// mutating this process-global env (which races across cargo's parallel test
+/// threads and is `unsafe`/UB-prone under the 2024 edition).
 pub const TMUX_CMD_OVERRIDE_ENV: &str = "MAESTRO_TMUX_CMD_OVERRIDE";
 
 /// Compute the per-daemon tmux socket name (`tmux -L <name>`) for a daemon
@@ -119,28 +124,43 @@ fn wrap_with_env(
 
 /// Construct the script tmux launches for a node run.
 ///
-/// The default tail can be overridden via `TMUX_CMD_OVERRIDE_ENV`.
+/// `tmux_cmd_override` replaces the default `claude …` tail when `Some` — the
+/// per-daemon test seam (see [`TMUX_CMD_OVERRIDE_ENV`]). `None` → production
+/// claude invocation.
 pub fn build_tmux_script(
     run_id: &str,
     node_id: &str,
     iter: i64,
     daemon_port: u16,
     prompt_path: &Path,
+    tmux_cmd_override: Option<&str>,
 ) -> String {
-    let tail_cmd = std::env::var(TMUX_CMD_OVERRIDE_ENV).unwrap_or_else(|_| {
-        format!(
+    let tail_cmd = match tmux_cmd_override {
+        Some(cmd) => cmd.to_string(),
+        None => format!(
             "exec claude --dangerously-skip-permissions \"$(cat {})\"",
             sh_single_quote(&prompt_path.to_string_lossy())
-        )
-    });
+        ),
+    };
 
     wrap_with_env(run_id, node_id, iter, daemon_port, &tail_cmd)
 }
 
 /// Build a resume script that uses `claude --continue` in the same working_dir.
-fn build_resume_script(run_id: &str, node_id: &str, iter: i64, daemon_port: u16) -> String {
-    let tail_cmd = std::env::var(TMUX_CMD_OVERRIDE_ENV)
-        .unwrap_or_else(|_| "exec claude --dangerously-skip-permissions --continue".to_string());
+///
+/// `tmux_cmd_override` replaces the default `claude --continue` tail when
+/// `Some` — the per-daemon test seam.
+fn build_resume_script(
+    run_id: &str,
+    node_id: &str,
+    iter: i64,
+    daemon_port: u16,
+    tmux_cmd_override: Option<&str>,
+) -> String {
+    let tail_cmd = match tmux_cmd_override {
+        Some(cmd) => cmd.to_string(),
+        None => "exec claude --dangerously-skip-permissions --continue".to_string(),
+    };
 
     wrap_with_env(run_id, node_id, iter, daemon_port, &tail_cmd)
 }
@@ -160,6 +180,14 @@ pub fn manager_session_name(run_id: &str) -> String {
 }
 
 /// Spawn a detached tmux session for a NodeRun.
+///
+/// `tmux_cmd_override` (per-daemon config, `AppState.tmux_cmd_override`)
+/// replaces the `claude …` tail when `Some` — how tests run a harmless command
+/// instead of launching real claude.
+// The session identity (name + run/node/iter), working dir, daemon port, and
+// command override are all irreducible inputs to a spawn; bundling them into a
+// struct would only move the argument list, not shorten it.
+#[allow(clippy::too_many_arguments)]
 pub fn spawn(
     session_name: &str,
     prompt: &str,
@@ -168,13 +196,21 @@ pub fn spawn(
     node_id: &str,
     iter: i64,
     daemon_port: u16,
+    tmux_cmd_override: Option<&str>,
 ) -> Result<()> {
     let prompt_dir = working_dir.join(".maestro").join("prompts");
     std::fs::create_dir_all(&prompt_dir)?;
     let prompt_path = prompt_dir.join(format!("{node_id}-iter-{iter}.md"));
     std::fs::write(&prompt_path, prompt)?;
 
-    let script = build_tmux_script(run_id, node_id, iter, daemon_port, &prompt_path);
+    let script = build_tmux_script(
+        run_id,
+        node_id,
+        iter,
+        daemon_port,
+        &prompt_path,
+        tmux_cmd_override,
+    );
     let socket = tmux_socket_name(daemon_port);
 
     let output = tmux(&socket)
@@ -203,8 +239,9 @@ pub fn resume(
     node_id: &str,
     iter: i64,
     daemon_port: u16,
+    tmux_cmd_override: Option<&str>,
 ) -> Result<()> {
-    let script = build_resume_script(run_id, node_id, iter, daemon_port);
+    let script = build_resume_script(run_id, node_id, iter, daemon_port, tmux_cmd_override);
     let socket = tmux_socket_name(daemon_port);
 
     let output = tmux(&socket)
@@ -527,19 +564,27 @@ mod tests {
 
     #[test]
     fn build_script_default_and_override() {
-        std::env::remove_var(TMUX_CMD_OVERRIDE_ENV);
         let prompt_path = Path::new("/tmp/test-prompt.md");
-        let script = build_tmux_script("run-abc", "solo", 1, 5172, prompt_path);
+
+        // None → production claude tail.
+        let script = build_tmux_script("run-abc", "solo", 1, 5172, prompt_path, None);
         assert!(script.starts_with("exec bash -c "));
         assert!(script.contains("exec claude --dangerously-skip-permissions"));
         assert!(script.contains("MAESTRO_RUN_ID"));
         assert!(script.contains("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1"));
 
-        std::env::set_var(TMUX_CMD_OVERRIDE_ENV, "exec sleep 60");
-        let script = build_tmux_script("run-abc", "solo", 1, 5172, prompt_path);
+        // Some(..) → override tail, no claude. The override is passed as a
+        // parameter (per-daemon config), never read from process-global env.
+        let script = build_tmux_script(
+            "run-abc",
+            "solo",
+            1,
+            5172,
+            prompt_path,
+            Some("exec sleep 60"),
+        );
         assert!(script.contains("exec sleep 60"));
         assert!(!script.contains("claude"));
-        std::env::remove_var(TMUX_CMD_OVERRIDE_ENV);
     }
 
     #[test]

--- a/crates/maestro-daemon/tests/cli_complete_does_not_panic.rs
+++ b/crates/maestro-daemon/tests/cli_complete_does_not_panic.rs
@@ -81,10 +81,11 @@ fn git_init_with_commit(repo: &std::path::Path) -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn maestro_complete_does_not_panic_and_marks_node_done() {
-    // Bypass spawn_tmux_session entirely so the test doesn't need claude/tmux.
-    std::env::set_var(maestro_daemon::TMUX_CMD_OVERRIDE_ENV, "true");
-
-    let daemon = TestDaemon::spawn(seed).await.unwrap();
+    // Bypass spawn_tmux_session entirely so the test doesn't need claude/tmux:
+    // the node session runs `true` (exits immediately) instead of claude.
+    let daemon = TestDaemon::spawn_with_override(seed, Some("true".to_string()))
+        .await
+        .unwrap();
 
     let body = serde_json::json!({ "pipeline": PIPELINE_NAME, "input": "hello" });
     let resp = reqwest::Client::new()
@@ -163,16 +164,14 @@ async fn maestro_complete_does_not_panic_and_marks_node_done() {
         run["nodes"][NODE_ID]["status"], "completed",
         "node should be marked completed; run state was: {run}"
     );
-
-    std::env::remove_var(maestro_daemon::TMUX_CMD_OVERRIDE_ENV);
 }
 
 #[tokio::test]
 async fn maestro_fail_does_not_panic() {
     // Same panic path through `reqwest::blocking` — covers the `fail` arm too.
-    std::env::set_var(maestro_daemon::TMUX_CMD_OVERRIDE_ENV, "true");
-
-    let daemon = TestDaemon::spawn(seed).await.unwrap();
+    let daemon = TestDaemon::spawn_with_override(seed, Some("true".to_string()))
+        .await
+        .unwrap();
 
     let body = serde_json::json!({ "pipeline": PIPELINE_NAME, "input": "x" });
     let resp = reqwest::Client::new()
@@ -208,6 +207,4 @@ async fn maestro_fail_does_not_panic() {
         !stderr.contains("panicked"),
         "maestro fail must not panic. stderr=\n{stderr}"
     );
-
-    std::env::remove_var(maestro_daemon::TMUX_CMD_OVERRIDE_ENV);
 }

--- a/crates/maestro-daemon/tests/common/mod.rs
+++ b/crates/maestro-daemon/tests/common/mod.rs
@@ -9,7 +9,7 @@ use std::net::SocketAddr;
 use std::path::Path;
 
 use anyhow::Result;
-use maestro_daemon::{serve, DaemonHandle};
+use maestro_daemon::{serve_with_config, DaemonConfig, DaemonHandle};
 use tempfile::TempDir;
 use tokio::net::TcpStream;
 use tokio_tungstenite::tungstenite::protocol::Message;
@@ -25,7 +25,26 @@ impl TestDaemon {
     /// Spawn a fresh daemon backed by a tempdir. The `setup` callback receives the
     /// tempdir path and may seed it (write yaml, init a git repo, etc.) before the
     /// daemon starts.
+    ///
+    /// The daemon is seeded with a **harmless tmux command override** (a long
+    /// `sleep`) so any node session it spawns runs that instead of launching a
+    /// real `claude` process. This is per-daemon config — no process-global
+    /// `std::env::set_var` — so parallel tests can't race on it (#181). Tests
+    /// that need a different tail (e.g. an immediately-exiting command) use
+    /// [`TestDaemon::spawn_with_override`].
     pub async fn spawn<F>(setup: F) -> Result<Self>
+    where
+        F: FnOnce(&Path) -> Result<()>,
+    {
+        Self::spawn_with_override(setup, Some("exec sleep 600".to_string())).await
+    }
+
+    /// Like [`TestDaemon::spawn`] but with an explicit tmux command override.
+    ///
+    /// - `Some(cmd)` → spawned node/manager sessions run `cmd` instead of claude.
+    /// - `None` → real `claude` (no test should pass this; it exists only for
+    ///   completeness / parity with production config).
+    pub async fn spawn_with_override<F>(setup: F, tmux_cmd_override: Option<String>) -> Result<Self>
     where
         F: FnOnce(&Path) -> Result<()>,
     {
@@ -41,9 +60,10 @@ impl TestDaemon {
         let tempdir = tempfile::tempdir()?;
         setup(tempdir.path())?;
 
-        let handle = serve(
+        let handle = serve_with_config(
             SocketAddr::from(([127, 0, 0, 1], 0)),
             tempdir.path().to_path_buf(),
+            DaemonConfig { tmux_cmd_override },
         )
         .await?;
 
@@ -97,6 +117,37 @@ impl Drop for TestDaemon {
     fn drop(&mut self) {
         if let Some(handle) = self.handle.take() {
             handle.task.abort();
+        }
+
+        // Tear down the daemon's private tmux socket (#181). `task.abort()` only
+        // stops the in-process axum task — the tmux *server* and the
+        // `claude`/`sleep` children the daemon spawned via `tmux new-session`
+        // are separate processes that would otherwise outlive the test, leaking
+        // sessions and (without the command override) real claude. The socket is
+        // scoped per daemon-port (`maestro-<port>`), so killing its server can
+        // only reap *this* daemon's sessions — never another test's or a live
+        // daemon's. Best-effort throughout: a missing socket / absent tmux is
+        // fine.
+        let socket = self.tmux_socket();
+        let _ = std::process::Command::new("tmux")
+            .args(["-L", &socket, "kill-server"])
+            .output();
+
+        // `kill-server` terminates the server but leaves the stale socket *file*
+        // behind, and a test body that already killed the server itself leaves
+        // one too. Unlink it so no `maestro-<port>` socket survives the test.
+        // The socket name embeds this daemon's unique ephemeral port, so it is
+        // ours alone — never the live daemon (`maestro-6172`) or a sibling test.
+        // tmux stores sockets under `${TMUX_TMPDIR:-/tmp}/tmux-<uid>/`; we don't
+        // know our uid without libc, so unlink the file from every readable
+        // `tmux-*` dir there (only the matching name is touched).
+        let tmux_tmp = std::env::var("TMUX_TMPDIR").unwrap_or_else(|_| "/tmp".to_string());
+        if let Ok(entries) = std::fs::read_dir(&tmux_tmp) {
+            for entry in entries.flatten() {
+                if entry.file_name().to_string_lossy().starts_with("tmux-") {
+                    let _ = std::fs::remove_file(entry.path().join(&socket));
+                }
+            }
         }
     }
 }

--- a/crates/maestro-daemon/tests/multi_iter.rs
+++ b/crates/maestro-daemon/tests/multi_iter.rs
@@ -107,10 +107,6 @@ async fn create_run(daemon_url: &str) -> String {
 /// events for each node, and then we manually mark the node done and verify.
 #[tokio::test]
 async fn multi_iter_projection_via_daemon() {
-    unsafe {
-        std::env::set_var("MAESTRO_TMUX_CMD_OVERRIDE", "exec sleep 300");
-    }
-
     let daemon = TestDaemon::spawn(seed).await.unwrap();
     let run_id = create_run(&daemon.url()).await;
 

--- a/crates/maestro-daemon/tests/node_io.rs
+++ b/crates/maestro-daemon/tests/node_io.rs
@@ -133,10 +133,6 @@ fn seed_artifacts(repo: &std::path::Path, run_id: &str) {
 
 #[tokio::test]
 async fn io_endpoint_returns_port_paths_and_frontmatter() {
-    unsafe {
-        std::env::set_var("MAESTRO_TMUX_CMD_OVERRIDE", "exec sleep 300");
-    }
-
     let daemon = TestDaemon::spawn(seed).await.unwrap();
     let run_id = create_run(&daemon.url()).await;
 
@@ -199,10 +195,6 @@ async fn io_endpoint_returns_404_before_run_creation() {
 
 #[tokio::test]
 async fn artifact_endpoint_returns_markdown_content() {
-    unsafe {
-        std::env::set_var("MAESTRO_TMUX_CMD_OVERRIDE", "exec sleep 300");
-    }
-
     let daemon = TestDaemon::spawn(seed).await.unwrap();
     let run_id = create_run(&daemon.url()).await;
 

--- a/crates/maestro-daemon/tests/node_prompt.rs
+++ b/crates/maestro-daemon/tests/node_prompt.rs
@@ -99,11 +99,6 @@ async fn create_run(daemon_url: &str) -> String {
 /// with the deterministic preamble sections.
 #[tokio::test]
 async fn prompt_endpoint_returns_augmented_prompt_after_run_creation() {
-    // Override tmux command so the test doesn't require `claude` on PATH
-    unsafe {
-        std::env::set_var("MAESTRO_TMUX_CMD_OVERRIDE", "exec sleep 300");
-    }
-
     let daemon = TestDaemon::spawn(seed).await.unwrap();
     let run_id = create_run(&daemon.url()).await;
 

--- a/crates/maestro-daemon/tests/run_scoped_pipeline.rs
+++ b/crates/maestro-daemon/tests/run_scoped_pipeline.rs
@@ -77,11 +77,19 @@ fn git_init_with_commit(repo: &std::path::Path) -> anyhow::Result<()> {
 }
 
 /// Wait for a `pipeline_modified` event on the WebSocket for a given run_id.
+///
+/// `expected_kind` filters on `payload.kind` ("yaml" | "prompt"). A single run
+/// can legitimately surface *both* kinds close together — creating a run writes
+/// the run-scoped `pipeline.yaml` snapshot (a "yaml" event) around the same time
+/// the watcher picks up prompt-file changes — so a caller that asserts on a
+/// specific kind must skip the other one rather than grab whichever arrives
+/// first (#182). Pass `None` to accept any `pipeline_modified` for the run.
 async fn next_pipeline_modified_event(
     ws: &mut tokio_tungstenite::WebSocketStream<
         tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
     >,
     run_id: &str,
+    expected_kind: Option<&str>,
     deadline: Duration,
 ) -> Option<serde_json::Value> {
     let result = timeout(deadline, async {
@@ -94,7 +102,10 @@ async fn next_pipeline_modified_event(
             let parsed: serde_json::Value = serde_json::from_str(text).ok()?;
             if parsed["type"] == "event" {
                 if let Some(event) = parsed.get("event") {
-                    if event["kind"] == "pipeline_modified" && event["run_id"] == run_id {
+                    if event["kind"] == "pipeline_modified"
+                        && event["run_id"] == run_id
+                        && expected_kind.is_none_or(|k| event["payload"]["kind"] == k)
+                    {
                         return Some(event.clone());
                     }
                 }
@@ -178,7 +189,7 @@ async fn external_write_to_run_pipeline_emits_pipeline_modified() {
     // Should receive a pipeline_modified event within the debounce window.
     // The watcher may also have picked up the initial prompt copy, so we look
     // for any pipeline_modified event for this run_id.
-    let evt = next_pipeline_modified_event(&mut ws, &run_id, Duration::from_secs(4))
+    let evt = next_pipeline_modified_event(&mut ws, &run_id, None, Duration::from_secs(4))
         .await
         .expect("external write to run-scoped pipeline should emit pipeline_modified within 4s");
 
@@ -234,9 +245,10 @@ async fn external_prompt_edit_in_run_emits_pipeline_modified() {
         .join("planner.md");
     std::fs::write(&prompt_path, "You are an EDITED planner.\n").unwrap();
 
-    let evt = next_pipeline_modified_event(&mut ws, &run_id, Duration::from_secs(4))
-        .await
-        .expect("external prompt edit should emit pipeline_modified within 4s");
+    let evt =
+        next_pipeline_modified_event(&mut ws, &run_id, Some("prompt"), Duration::from_secs(4))
+            .await
+            .expect("external prompt edit should emit pipeline_modified within 4s");
 
     assert_eq!(evt["kind"], "pipeline_modified");
     assert_eq!(evt["run_id"], run_id);
@@ -290,9 +302,6 @@ async fn adding_node_to_run_pipeline_triggers_scheduler_spawn() {
         eprintln!("tmux not on PATH — skipping");
         return;
     }
-
-    // Use sleep as a substitute for claude
-    std::env::set_var("MAESTRO_TMUX_CMD_OVERRIDE", "exec sleep 300");
 
     let daemon = TestDaemon::spawn(seed).await.unwrap();
     let run_id = create_run(&daemon.url()).await;
@@ -402,7 +411,6 @@ edges:
     let _ = Command::new("tmux")
         .args(["-L", &daemon.tmux_socket(), "kill-server"])
         .output();
-    std::env::remove_var("MAESTRO_TMUX_CMD_OVERRIDE");
 
     assert!(
         evt.is_some(),
@@ -634,8 +642,6 @@ async fn removing_node_from_run_pipeline_prevents_spawn() {
         return;
     }
 
-    std::env::set_var("MAESTRO_TMUX_CMD_OVERRIDE", "exec sleep 300");
-
     let daemon = TestDaemon::spawn(seed_two_node).await.unwrap();
     let run_id = create_two_node_run(&daemon.url()).await;
 
@@ -730,7 +736,6 @@ edges:
     let _ = Command::new("tmux")
         .args(["-L", &daemon.tmux_socket(), "kill-server"])
         .output();
-    std::env::remove_var("MAESTRO_TMUX_CMD_OVERRIDE");
 
     assert!(
         evt.is_none(),

--- a/crates/maestro-daemon/tests/session_cap_admission.rs
+++ b/crates/maestro-daemon/tests/session_cap_admission.rs
@@ -8,17 +8,18 @@
 //! impossible to satisfy if managers were counted.
 //!
 //! Node *state* (running vs waiting) is projected from the event log, so the
-//! assertions do not depend on a real tmux server being present; the
-//! `MAESTRO_TMUX_CMD_OVERRIDE` just keeps a missing `claude` binary from
-//! polluting logs. Single-test file by design — `set_var` mutates process-global
-//! state and we don't want a sibling test racing it.
+//! assertions do not depend on a real tmux server being present; the per-daemon
+//! `tmux_cmd_override` (seeded by `TestDaemon::spawn`) just keeps a missing
+//! `claude` binary from polluting logs. Single-test file by design — the session
+//! cap is still set via process-global `set_var(MAESTRO_SESSION_CAP)`, so a
+//! sibling test must not race it.
 
 mod common;
 
 use std::time::Duration;
 
 use common::TestDaemon;
-use maestro_daemon::{admission::SESSION_CAP_ENV, TMUX_CMD_OVERRIDE_ENV};
+use maestro_daemon::admission::SESSION_CAP_ENV;
 
 const PIPELINE_NAME: &str = "cap-solo";
 const NODE_ID: &str = "solo";
@@ -127,10 +128,9 @@ async fn wait_for_status(daemon: &TestDaemon, run_id: &str, want: &str) -> Optio
 async fn over_cap_node_waits_then_starts_when_a_slot_frees() {
     // Cap the whole daemon to a single live NodeRun session.
     std::env::set_var(SESSION_CAP_ENV, "1");
-    // Avoid needing a real `claude` on PATH; tmux may or may not be present —
-    // either way the node *state* is projected from the event log.
-    std::env::set_var(TMUX_CMD_OVERRIDE_ENV, "exec sleep 60");
 
+    // `TestDaemon::spawn` seeds a harmless `sleep` override per-daemon, so node
+    // sessions stay alive (occupying slots) without needing real `claude`.
     let daemon = TestDaemon::spawn(seed).await.unwrap();
 
     // Run 1: its solo node takes the only slot.
@@ -176,5 +176,4 @@ async fn over_cap_node_waits_then_starts_when_a_slot_frees() {
     }
 
     std::env::remove_var(SESSION_CAP_ENV);
-    std::env::remove_var(TMUX_CMD_OVERRIDE_ENV);
 }

--- a/crates/maestro-daemon/tests/start_node.rs
+++ b/crates/maestro-daemon/tests/start_node.rs
@@ -94,10 +94,6 @@ async fn create_run(daemon_url: &str) -> String {
 
 #[tokio::test]
 async fn run_state_includes_start_node_with_entry_targets() {
-    unsafe {
-        std::env::set_var("MAESTRO_TMUX_CMD_OVERRIDE", "exec sleep 300");
-    }
-
     let daemon = TestDaemon::spawn(seed).await.unwrap();
     let run_id = create_run(&daemon.url()).await;
 
@@ -134,10 +130,6 @@ async fn run_state_includes_start_node_with_entry_targets() {
 
 #[tokio::test]
 async fn run_state_includes_end_node_with_pending_port() {
-    unsafe {
-        std::env::set_var("MAESTRO_TMUX_CMD_OVERRIDE", "exec sleep 300");
-    }
-
     let daemon = TestDaemon::spawn(seed).await.unwrap();
     let run_id = create_run(&daemon.url()).await;
 
@@ -191,10 +183,6 @@ fn build_multipart(fields: &[(&str, &str)], images: &[(&str, &[u8])]) -> (Vec<u8
 
 #[tokio::test]
 async fn run_state_includes_uploaded_input_images() {
-    unsafe {
-        std::env::set_var("MAESTRO_TMUX_CMD_OVERRIDE", "exec sleep 300");
-    }
-
     // Minimal valid PNG header bytes — enough for the daemon to accept + store.
     const PNG: &[u8] = b"\x89PNG\r\n\x1a\n\x00\x00\x00\x0dIHDR";
 
@@ -259,10 +247,6 @@ async fn run_state_includes_uploaded_input_images() {
 
 #[tokio::test]
 async fn artifact_endpoint_serves_input_md() {
-    unsafe {
-        std::env::set_var("MAESTRO_TMUX_CMD_OVERRIDE", "exec sleep 300");
-    }
-
     let daemon = TestDaemon::spawn(seed).await.unwrap();
     let run_id = create_run(&daemon.url()).await;
 

--- a/crates/maestro-daemon/tests/sub_worktree_survive.rs
+++ b/crates/maestro-daemon/tests/sub_worktree_survive.rs
@@ -99,10 +99,6 @@ async fn create_run(daemon_url: &str) -> String {
 /// directory must still exist on disk and the prompt endpoint must return 200.
 #[tokio::test]
 async fn sub_worktree_survives_node_completion() {
-    unsafe {
-        std::env::set_var("MAESTRO_TMUX_CMD_OVERRIDE", "exec sleep 300");
-    }
-
     let daemon = TestDaemon::spawn(seed).await.unwrap();
     let run_id = create_run(&daemon.url()).await;
 
@@ -186,10 +182,6 @@ async fn sub_worktree_survives_node_completion() {
 /// they now survive merge.
 #[tokio::test]
 async fn cleanup_run_removes_surviving_sub_worktrees() {
-    unsafe {
-        std::env::set_var("MAESTRO_TMUX_CMD_OVERRIDE", "exec sleep 300");
-    }
-
     let daemon = TestDaemon::spawn(seed).await.unwrap();
     let run_id = create_run(&daemon.url()).await;
 

--- a/crates/maestro-daemon/tests/tmux_lifecycle.rs
+++ b/crates/maestro-daemon/tests/tmux_lifecycle.rs
@@ -14,9 +14,10 @@ use common::TestDaemon;
 use maestro_daemon::tmux_session_manager;
 
 /// Tests in this file mutate process-wide env vars
-/// (MAESTRO_TMUX_CMD_OVERRIDE, MAESTRO_REAPER_*_SECS, MAESTRO_DAEMON_NO_CLEANUP)
-/// and assert on timing-sensitive reaper behaviour. They MUST run
-/// serially or one test will see another's values.
+/// (MAESTRO_REAPER_*_SECS, MAESTRO_DAEMON_NO_CLEANUP) and assert on
+/// timing-sensitive reaper behaviour. They MUST run serially or one test will
+/// see another's values. (The tmux command override is per-daemon config now —
+/// `TestDaemon::spawn`'s harmless `sleep` default — not a process-global env.)
 static SERIAL: Mutex<()> = Mutex::new(());
 
 fn serial_guard() -> std::sync::MutexGuard<'static, ()> {
@@ -158,6 +159,10 @@ async fn wait_for_session_gone(socket: &str, session: &str, timeout: Duration) -
 /// Layer 3a: After node completion, the reaper kills the session once
 /// the TTL expires. Uses fast TTL (2s) and reaper interval (1s).
 #[tokio::test]
+// Holds the process-wide `serial_guard()` MutexGuard across `.await`s to keep
+// the env-var-sensitive reaper tests from racing each other — intentional, and
+// the same allow the rest of the crate uses for serialized async tests.
+#[allow(clippy::await_holding_lock)]
 async fn reaper_kills_completed_session_after_ttl() {
     if !tmux_available() {
         eprintln!("tmux not on PATH — skipping");
@@ -165,10 +170,6 @@ async fn reaper_kills_completed_session_after_ttl() {
     }
     let _serial = serial_guard();
 
-    std::env::set_var(
-        tmux_session_manager::TMUX_CMD_OVERRIDE_ENV,
-        "exec sleep 300",
-    );
     std::env::set_var(tmux_session_manager::REAPER_TTL_SECS_ENV, "2");
     std::env::set_var(tmux_session_manager::REAPER_INTERVAL_SECS_ENV, "1");
 
@@ -216,13 +217,16 @@ async fn reaper_kills_completed_session_after_ttl() {
     );
 
     // Clean up env
-    std::env::remove_var(tmux_session_manager::TMUX_CMD_OVERRIDE_ENV);
     std::env::remove_var(tmux_session_manager::REAPER_TTL_SECS_ENV);
     std::env::remove_var(tmux_session_manager::REAPER_INTERVAL_SECS_ENV);
 }
 
 /// Layer 3a: At daemon boot, pre-existing orphan maestro-* sessions get swept.
 #[tokio::test]
+// Holds the process-wide `serial_guard()` MutexGuard across `.await`s to keep
+// the env-var-sensitive reaper tests from racing each other — intentional, and
+// the same allow the rest of the crate uses for serialized async tests.
+#[allow(clippy::await_holding_lock)]
 async fn orphan_sweep_at_boot_kills_stale_session() {
     if !tmux_available() {
         eprintln!("tmux not on PATH — skipping");
@@ -230,10 +234,6 @@ async fn orphan_sweep_at_boot_kills_stale_session() {
     }
     let _serial = serial_guard();
 
-    std::env::set_var(
-        tmux_session_manager::TMUX_CMD_OVERRIDE_ENV,
-        "exec sleep 300",
-    );
     std::env::set_var(tmux_session_manager::REAPER_TTL_SECS_ENV, "0");
     std::env::set_var(tmux_session_manager::REAPER_INTERVAL_SECS_ENV, "1");
 
@@ -259,7 +259,6 @@ async fn orphan_sweep_at_boot_kills_stale_session() {
         "orphan session should be killed by the periodic reaper (run absent from event log)"
     );
 
-    std::env::remove_var(tmux_session_manager::TMUX_CMD_OVERRIDE_ENV);
     std::env::remove_var(tmux_session_manager::REAPER_TTL_SECS_ENV);
     std::env::remove_var(tmux_session_manager::REAPER_INTERVAL_SECS_ENV);
 }
@@ -271,6 +270,10 @@ async fn orphan_sweep_at_boot_kills_stale_session() {
 /// follow-up: the only safe behaviour for a nested daemon is to be
 /// completely passive on tmux state.
 #[tokio::test]
+// Holds the process-wide `serial_guard()` MutexGuard across `.await`s to keep
+// the env-var-sensitive reaper tests from racing each other — intentional, and
+// the same allow the rest of the crate uses for serialized async tests.
+#[allow(clippy::await_holding_lock)]
 async fn nested_daemon_skips_orphan_sweep_and_reaper() {
     if !tmux_available() {
         eprintln!("tmux not on PATH — skipping");
@@ -278,10 +281,6 @@ async fn nested_daemon_skips_orphan_sweep_and_reaper() {
     }
     let _serial = serial_guard();
 
-    std::env::set_var(
-        tmux_session_manager::TMUX_CMD_OVERRIDE_ENV,
-        "exec sleep 300",
-    );
     std::env::set_var(tmux_session_manager::REAPER_TTL_SECS_ENV, "0");
     std::env::set_var(tmux_session_manager::REAPER_INTERVAL_SECS_ENV, "1");
     std::env::set_var("MAESTRO_DAEMON_NO_CLEANUP", "1");
@@ -310,13 +309,16 @@ async fn nested_daemon_skips_orphan_sweep_and_reaper() {
         .args(["-L", &socket, "kill-session", "-t", orphan_session])
         .output();
     std::env::remove_var("MAESTRO_DAEMON_NO_CLEANUP");
-    std::env::remove_var(tmux_session_manager::TMUX_CMD_OVERRIDE_ENV);
     std::env::remove_var(tmux_session_manager::REAPER_TTL_SECS_ENV);
     std::env::remove_var(tmux_session_manager::REAPER_INTERVAL_SECS_ENV);
 }
 
 /// Layer 3a: Kill a session manually, hit /pane, assert a fresh session appears.
 #[tokio::test]
+// Holds the process-wide `serial_guard()` MutexGuard across `.await`s to keep
+// the env-var-sensitive reaper tests from racing each other — intentional, and
+// the same allow the rest of the crate uses for serialized async tests.
+#[allow(clippy::await_holding_lock)]
 async fn dead_session_respawn_via_pane_endpoint() {
     if !tmux_available() {
         eprintln!("tmux not on PATH — skipping");
@@ -324,10 +326,6 @@ async fn dead_session_respawn_via_pane_endpoint() {
     }
     let _serial = serial_guard();
 
-    std::env::set_var(
-        tmux_session_manager::TMUX_CMD_OVERRIDE_ENV,
-        "exec sleep 300",
-    );
     // Long TTL so the reaper doesn't interfere
     std::env::set_var(tmux_session_manager::REAPER_TTL_SECS_ENV, "3600");
     std::env::set_var(tmux_session_manager::REAPER_INTERVAL_SECS_ENV, "3600");
@@ -373,7 +371,6 @@ async fn dead_session_respawn_via_pane_endpoint() {
 
     // Clean up
     tmux_session_manager::kill(&socket, &session);
-    std::env::remove_var(tmux_session_manager::TMUX_CMD_OVERRIDE_ENV);
     std::env::remove_var(tmux_session_manager::REAPER_TTL_SECS_ENV);
     std::env::remove_var(tmux_session_manager::REAPER_INTERVAL_SECS_ENV);
 }

--- a/crates/maestro-daemon/tests/tmux_run_spawn.rs
+++ b/crates/maestro-daemon/tests/tmux_run_spawn.rs
@@ -2,17 +2,17 @@
 //! script that invokes `claude --dangerously-skip-permissions` and keeps the
 //! tmux session alive until that process exits.
 //!
-//! The lifecycle test substitutes `claude` with `sleep 60` via
-//! `MAESTRO_TMUX_CMD_OVERRIDE` so the test box doesn't actually need claude
-//! on PATH. Single-test file by design — `set_var` mutates process-global
-//! state and we don't want a sibling test racing it.
+//! The lifecycle test substitutes `claude` with a harmless `sleep` via the
+//! per-daemon `tmux_cmd_override` config (`TestDaemon::spawn`'s default), so the
+//! test box doesn't actually need claude on PATH and no process-global env is
+//! mutated (#181).
 
 mod common;
 
 use std::time::Duration;
 
 use common::TestDaemon;
-use maestro_daemon::{build_tmux_script, TMUX_CMD_OVERRIDE_ENV};
+use maestro_daemon::build_tmux_script;
 
 const PIPELINE_NAME: &str = "minimal-tmux";
 const NODE_ID: &str = "solo";
@@ -83,11 +83,9 @@ fn git_init_with_commit(repo: &std::path::Path) -> anyhow::Result<()> {
 fn build_tmux_script_uses_exec_bash_and_invokes_claude() {
     // Acceptance: the constructed command string contains
     // `claude --dangerously-skip-permissions` and the `exec bash -c` shape.
-    // We make sure the override env is unset so we get the production tail.
-    std::env::remove_var(TMUX_CMD_OVERRIDE_ENV);
-
+    // `None` override → production claude tail.
     let prompt_path = std::path::Path::new("/tmp/maestro-test/solo-iter-1.md");
-    let script = build_tmux_script("run-abc", "solo", 1, 5172, prompt_path);
+    let script = build_tmux_script("run-abc", "solo", 1, 5172, prompt_path, None);
 
     assert!(
         script.starts_with("exec bash -c "),
@@ -122,10 +120,9 @@ async fn tmux_session_alive_after_run_spawn() {
         return;
     }
 
-    // Substitute claude → sleep 60. Set BEFORE spawning the daemon so
-    // `build_tmux_script` reads the override at run-creation time.
-    std::env::set_var(TMUX_CMD_OVERRIDE_ENV, "exec sleep 60");
-
+    // `TestDaemon::spawn` seeds a harmless `sleep` override per-daemon, so the
+    // spawned node session stays alive (for the poll below) without launching
+    // real claude.
     let daemon = TestDaemon::spawn(seed).await.unwrap();
     // The daemon spawns sessions on its own scoped tmux socket (`tmux -L`),
     // not the default server — inspect/kill through the same socket.
@@ -164,8 +161,6 @@ async fn tmux_session_alive_after_run_spawn() {
     let _ = std::process::Command::new("tmux")
         .args(["-L", &socket, "kill-session", "-t", &session])
         .output();
-
-    std::env::remove_var(TMUX_CMD_OVERRIDE_ENV);
 
     assert!(
         alive,

--- a/crates/maestro-daemon/tests/trigger_scheduler.rs
+++ b/crates/maestro-daemon/tests/trigger_scheduler.rs
@@ -13,7 +13,6 @@
 mod common;
 
 use common::TestDaemon;
-use maestro_daemon::TMUX_CMD_OVERRIDE_ENV;
 
 const PIPELINE_NAME: &str = "auditor";
 const PIPELINE_YAML: &str = r#"name: auditor
@@ -162,7 +161,6 @@ async fn get_trigger(daemon: &TestDaemon, trigger_id: &str) -> serde_json::Value
 
 #[tokio::test]
 async fn due_trigger_creates_a_run_with_triggered_by_provenance() {
-    std::env::set_var(TMUX_CMD_OVERRIDE_ENV, "exec sleep 60");
     let daemon = TestDaemon::spawn(seed).await.unwrap();
 
     let trigger = create_trigger(&daemon, "nightly audit", "* * * * *").await;
@@ -199,12 +197,10 @@ async fn due_trigger_creates_a_run_with_triggered_by_provenance() {
     );
 
     cleanup_runs(&daemon).await;
-    std::env::remove_var(TMUX_CMD_OVERRIDE_ENV);
 }
 
 #[tokio::test]
 async fn overlap_skip_while_previous_run_is_live() {
-    std::env::set_var(TMUX_CMD_OVERRIDE_ENV, "exec sleep 60");
     let daemon = TestDaemon::spawn(seed).await.unwrap();
 
     let trigger = create_trigger(&daemon, "overlapping", "* * * * *").await;
@@ -239,12 +235,10 @@ async fn overlap_skip_while_previous_run_is_live() {
     assert_eq!(fires[1]["outcome"].as_str(), Some("fired"));
 
     cleanup_runs(&daemon).await;
-    std::env::remove_var(TMUX_CMD_OVERRIDE_ENV);
 }
 
 #[tokio::test]
 async fn missed_slots_are_forward_only_no_backfill() {
-    std::env::set_var(TMUX_CMD_OVERRIDE_ENV, "exec sleep 60");
     let daemon = TestDaemon::spawn(seed).await.unwrap();
 
     // Hourly trigger; force it long-overdue (as if the daemon were off for days).
@@ -281,7 +275,6 @@ async fn missed_slots_are_forward_only_no_backfill() {
     );
 
     cleanup_runs(&daemon).await;
-    std::env::remove_var(TMUX_CMD_OVERRIDE_ENV);
 }
 
 /// The resolved Run input is recorded in the `run_started` event payload; this
@@ -305,7 +298,6 @@ async fn run_started_input(daemon: &TestDaemon, run_id: &str) -> String {
 
 #[tokio::test]
 async fn guard_exit_zero_fires_with_stdout_as_input() {
-    std::env::set_var(TMUX_CMD_OVERRIDE_ENV, "exec sleep 60");
     let daemon = TestDaemon::spawn(seed).await.unwrap();
 
     // Guard exits 0 and prints work to do; its stdout becomes the Run input.
@@ -329,12 +321,10 @@ async fn guard_exit_zero_fires_with_stdout_as_input() {
     assert_eq!(fires[0]["outcome"].as_str(), Some("fired"));
 
     cleanup_runs(&daemon).await;
-    std::env::remove_var(TMUX_CMD_OVERRIDE_ENV);
 }
 
 #[tokio::test]
 async fn guard_exit_nonzero_skips_without_firing() {
-    std::env::set_var(TMUX_CMD_OVERRIDE_ENV, "exec sleep 60");
     let daemon = TestDaemon::spawn(seed).await.unwrap();
 
     // Guard exits non-zero: no work to do, so no Run is created.
@@ -350,13 +340,10 @@ async fn guard_exit_nonzero_skips_without_firing() {
     );
     let fires = list_fires(&daemon, &trigger_id).await;
     assert_eq!(fires[0]["outcome"].as_str(), Some("guard-exit-nonzero"));
-
-    std::env::remove_var(TMUX_CMD_OVERRIDE_ENV);
 }
 
 #[tokio::test]
 async fn guard_timeout_records_guard_error_and_skips() {
-    std::env::set_var(TMUX_CMD_OVERRIDE_ENV, "exec sleep 60");
     // Shrink the guard timeout so a hung guard times out fast in the test.
     std::env::set_var(maestro_daemon::GUARD_TIMEOUT_MS_OVERRIDE_ENV, "200");
     let daemon = TestDaemon::spawn(seed).await.unwrap();
@@ -381,12 +368,10 @@ async fn guard_timeout_records_guard_error_and_skips() {
     );
 
     std::env::remove_var(maestro_daemon::GUARD_TIMEOUT_MS_OVERRIDE_ENV);
-    std::env::remove_var(TMUX_CMD_OVERRIDE_ENV);
 }
 
 #[tokio::test]
 async fn dangling_pipeline_reference_yields_error_outcome_and_stops_firing() {
-    std::env::set_var(TMUX_CMD_OVERRIDE_ENV, "exec sleep 60");
     let daemon = TestDaemon::spawn(seed).await.unwrap();
 
     let trigger = create_trigger(&daemon, "audit", "* * * * *").await;
@@ -422,13 +407,10 @@ async fn dangling_pipeline_reference_yields_error_outcome_and_stops_firing() {
         "a dangling-ref Trigger must stop firing (next_fire cleared)"
     );
     assert_eq!(t["last_outcome"].as_str(), Some("error"));
-
-    std::env::remove_var(TMUX_CMD_OVERRIDE_ENV);
 }
 
 #[tokio::test]
 async fn dangling_target_repo_reference_yields_error_outcome() {
-    std::env::set_var(TMUX_CMD_OVERRIDE_ENV, "exec sleep 60");
     let daemon = TestDaemon::spawn(seed).await.unwrap();
 
     // A target repo that does not exist at fire time (deleted/renamed).
@@ -462,8 +444,6 @@ async fn dangling_target_repo_reference_yields_error_outcome() {
     );
     let fires = list_fires(&daemon, &trigger_id).await;
     assert_eq!(fires[0]["outcome"].as_str(), Some("error"));
-
-    std::env::remove_var(TMUX_CMD_OVERRIDE_ENV);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What

Ships the fix for #181: `cargo test` was spawning **real** `claude` sessions and `TestDaemon::drop` never reaped them, so test runs left orphaned tmux sessions behind (and burned tokens).

Three root-cause legs addressed:
1. **Default-to-claude:** `build_tmux_script`/`build_resume_script` now take `Option<&str>`; `TestDaemon::spawn` seeds a per-daemon harmless `exec sleep 600` override by default, so tests never invoke real `claude`. Production (`None`) is unchanged — still `exec claude --dangerously-skip-permissions`.
2. **Absent teardown:** `TestDaemon::drop` now `kill-server`s its **private** `maestro-<port>` tmux socket and unlinks the socket file. The socket name embeds the daemon's unique ephemeral port, so it can never reap the live daemon's or a sibling test's sessions.
3. **Racy process-global env:** the override moved from a global `MAESTRO_TMUX_CMD_OVERRIDE` `set_var`/`remove_var` to per-daemon `DaemonConfig`, read from env once at boot only for the operator seam.

## Verification

- Production `cargo build` and full `cargo build --tests` (all 16 changed files) compile cleanly — proves the new `Option<&str>` parameter is threaded through every spawn/resume call site.
- Behavioural check of the pure `build_tmux_script`: `None` → still emits `claude`; `Some("exec sleep 600")` → no `claude`.
- Visual-tester node verdict: **Pass**.

## Notes

- Bumps workspace version `0.1.3` → `0.1.4`.
- Fix is pure Rust (`crates/maestro-daemon`), no frontend change.

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)