### PR TITLE
fix(canvas): reconcile loop regions on node deletion (#173)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1384,7 +1384,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "maestro-daemon"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/maestro-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "0.1.4"
+version = "0.1.5"
 license = "MIT"
 
 [workspace.dependencies]

--- a/frontend/src/components/EditCanvas.tsx
+++ b/frontend/src/components/EditCanvas.tsx
@@ -15,7 +15,7 @@ import {
   ReactFlowProvider,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
-import type { NodeDef, NodeStatus, NodeType, PortBrief, PortSide, RunState } from "../types";
+import type { LoopKind, NodeDef, NodeStatus, NodeType, PortBrief, PortSide, RunState } from "../types";
 import type { LibraryEntry, LibraryPipelineEntry } from "../api";
 import { buildLoopRegionNodes, deriveEditEdges, deriveEditNodes, edgeIndexFromId } from "./editNodeDerivation";
 import { useEditStore } from "../stores/editStore";
@@ -59,9 +59,10 @@ interface EditNodeData {
   // Filenames of images uploaded with the run's input. Only the start marker
   // surfaces these (issue #145); undefined/empty on every other node.
   inputImages?: string[];
-  // Compact `⇉ ...` badge when this node is the single member of a collection
-  // region (#151). Absent on non-member nodes.
-  collectionBadge?: string;
+  // Compact badge when this node is the single member of a loop region: a
+  // collection (`⇉ ...`, #151) or a single-member bounded loop (`↻ ...`, #173).
+  // Absent on non-member nodes and on multi-member regions (boxed instead).
+  loopBadge?: { text: string; kind: LoopKind };
   [key: string]: unknown;
 }
 
@@ -144,14 +145,18 @@ export function EditNode({ data, id }: NodeProps<Node<EditNodeData>>) {
         <NodeTypeIcon type={data.nodeType} size={14} className={`shrink-0 ${iconColor}`} />
         <span className="font-medium text-fg">{data.label}</span>
         <CodeDocMarker type={data.nodeType} />
-        {data.collectionBadge && (
+        {data.loopBadge && (
           <span
-            data-testid="collection-badge"
+            data-testid={data.loopBadge.kind === "collection" ? "collection-badge" : "loop-badge"}
             className="ml-auto shrink-0 rounded border border-acc px-1.5 font-mono text-acc"
             style={{ fontSize: 10, lineHeight: "16px" }}
-            title="collection region — fans out one lap per item"
+            title={
+              data.loopBadge.kind === "collection"
+                ? "collection region — fans out one lap per item"
+                : "bounded loop region — one member"
+            }
           >
-            {data.collectionBadge}
+            {data.loopBadge.text}
           </span>
         )}
       </div>

--- a/frontend/src/components/editNodeDerivation.test.ts
+++ b/frontend/src/components/editNodeDerivation.test.ts
@@ -158,26 +158,46 @@ describe("deriveLoopRegions — collection regions (#151)", () => {
   });
 
   it("attaches a `⇉` collection badge to the single member's card", () => {
-    // The single-member collection's member card carries a `collectionBadge`
-    // (the `⇉ ...` text) so the canvas can render the compact badge on the card
-    // rather than a box.
+    // The single-member collection's member card carries a `loopBadge` (the
+    // `⇉ ...` text, kind `collection`) so the canvas can render the compact badge
+    // on the card rather than a box.
     const p = pipelineWith(
       [node("fixer", "code-mutating", ["fix"])],
       [{ id: "per-issue", kind: "collection", over: "issues", members: ["fixer"] }],
     );
     const cards = deriveEditNodes(p, null);
     const fixer = cards.find((c) => c.id === "fixer")!;
-    expect(fixer.data.collectionBadge).toContain("⇉");
-    expect(fixer.data.collectionBadge).toContain("over issues");
+    const badge = fixer.data.loopBadge as { text: string; kind: string } | undefined;
+    expect(badge?.kind).toBe("collection");
+    expect(badge?.text).toContain("⇉");
+    expect(badge?.text).toContain("over issues");
   });
 
-  it("does not attach a collection badge to a node that is no member", () => {
+  it("attaches a `↻` badge to a single-member bounded loop's card (#173)", () => {
+    // A bounded region reduced to one present member (e.g. a member node was
+    // deleted, leaving a self-loop survivor) draws no box, so it must render a
+    // compact `↻ <counter>` badge — otherwise the loop is invisible on the
+    // canvas. The glyph is the loop glyph, not the collection `⇉`.
+    const p = pipelineWith(
+      [node("worker", "code-mutating", ["out"])],
+      [{ id: "spin", kind: "bounded", members: ["worker"], max_iter: 4 }],
+    );
+    const cards = deriveEditNodes(p, null);
+    const worker = cards.find((c) => c.id === "worker")!;
+    const badge = worker.data.loopBadge as { text: string; kind: string } | undefined;
+    expect(badge?.kind).toBe("bounded");
+    expect(badge?.text).toContain("↻");
+    expect(badge?.text).toContain("max 4");
+    expect(badge?.text).not.toContain("⇉");
+  });
+
+  it("does not attach a loop badge to a node that is no member", () => {
     const p = pipelineWith(
       [node("fixer", "code-mutating", ["fix"]), node("other", "doc-only", ["x"])],
       [{ id: "per-issue", kind: "collection", over: "issues", members: ["fixer"] }],
     );
     const cards = deriveEditNodes(p, null);
     const other = cards.find((c) => c.id === "other")!;
-    expect(other.data.collectionBadge).toBeUndefined();
+    expect(other.data.loopBadge).toBeUndefined();
   });
 });

--- a/frontend/src/components/editNodeDerivation.ts
+++ b/frontend/src/components/editNodeDerivation.ts
@@ -40,17 +40,25 @@ export function deriveEditNodes(
   pipeline: PipelineDef,
   runState: RunState | null | undefined,
 ): Node[] {
-  // Single-member collection regions (#151) render as a compact `⇉ ...` badge
-  // on the member's card (no box). Pre-compute the badge text keyed by member.
-  const collectionBadgeByMember = new Map<string, string>();
+  // A single-member loop region renders as a compact badge on the member's card
+  // instead of a box (ADR-0011 / #148, #151; the LoopRegion type's "compact
+  // badge (1 member)"). A `collection` reads `⇉ <fan-out>`; a single-member
+  // `bounded` region (a self-loop, or a multi-member loop reduced to one present
+  // member, e.g. after a member is deleted — #173) reads `↻ <counter>`,
+  // mirroring the box header — so a one-member loop is never invisible (it draws
+  // no box). Keyed by member id; the kind drives the glyph and the title.
+  const loopBadgeByMember = new Map<string, { text: string; kind: LoopRegion["kind"] }>();
   for (const region of deriveLoopRegions(pipeline, runState)) {
-    if (region.kind === "collection" && region.badgeMemberId != null) {
-      collectionBadgeByMember.set(region.badgeMemberId, `⇉ ${region.counterText}`);
-    }
+    if (region.badgeMemberId == null) continue;
+    const symbol = region.kind === "collection" ? "⇉" : "↻";
+    loopBadgeByMember.set(region.badgeMemberId, {
+      text: `${symbol} ${region.counterText}`,
+      kind: region.kind,
+    });
   }
   return pipeline.nodes.map((n, i) => {
     const status = statusForNode(n.id, runState);
-    const collectionBadge = collectionBadgeByMember.get(n.id);
+    const loopBadge = loopBadgeByMember.get(n.id);
     if (n.type === "merge") {
       return {
         id: n.id,
@@ -89,9 +97,10 @@ export function deriveEditNodes(
         inputs: n.inputs.map((p) => ({ name: p.name, side: p.side ?? "left", description: p.description })),
         outputs: n.outputs.map((p) => ({ name: p.name, side: p.side ?? "right", description: p.description })),
         interactive: n.interactive,
-        // Compact `⇉ ...` badge for the single member of a collection region
-        // (#151). Absent on non-member nodes. Undefined ⇒ no badge.
-        collectionBadge,
+        // Compact badge for the single member of a loop region: `⇉ ...` for a
+        // collection (#151) or `↻ ...` for a single-member bounded loop (#173).
+        // Absent on non-member nodes and multi-member regions (boxed instead).
+        loopBadge,
       },
     };
   });

--- a/frontend/src/lib/loopRegions.test.ts
+++ b/frontend/src/lib/loopRegions.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { collectionFanoutNudges, regionsDestroyedByEdgeRemoval } from "./loopRegions";
+import {
+  collectionFanoutNudges,
+  reconcileLoopRegions,
+  regionsDestroyedByEdgeRemoval,
+} from "./loopRegions";
 import type { EdgeDef, NodeDef, PipelineDef } from "../types";
 
 // A bare review loop: start -> impl -> rev, with rev -> impl closing the cycle.
@@ -70,6 +74,98 @@ describe("regionsDestroyedByEdgeRemoval (#150)", () => {
       loops: [{ id: "per-issue", kind: "collection", over: "issues", members: ["fixer"] }],
     };
     expect(regionsDestroyedByEdgeRemoval(p, 0)).toEqual([]);
+  });
+});
+
+function edge(s: string, sp: string, t: string, tp: string): EdgeDef {
+  return { source: { node: s, port: sp }, target: { node: t, port: tp } };
+}
+
+describe("reconcileLoopRegions — node deletion repairs the loops: block (#173)", () => {
+  it("destroys a bounded region whose last cycle went with the deleted member, ghost id and all", () => {
+    // Post-deletion of `rev` from [impl, rev]: rev and its edges (impl->rev,
+    // rev->impl) are gone, leaving only start->impl. The region no longer closes
+    // a cycle and names a node that no longer exists — it is destroyed, not left
+    // as an orphan with a dangling member id.
+    const p: PipelineDef = {
+      name: "rl",
+      variables: {},
+      nodes: [plainNode("start"), plainNode("impl")],
+      edges: [edge("start", "out", "impl", "task")],
+      loops: [{ id: "review_loop", kind: "bounded", members: ["impl", "rev"], max_iter: 3 }],
+    };
+    expect(reconcileLoopRegions(p)).toEqual([]);
+  });
+
+  it("prunes the ghost id but keeps the region when the survivors still close a cycle", () => {
+    // [a, b, c] closed by a<->b AND a<->c. Deleting c removes a->c / c->a, but
+    // a<->b still cycles, so the region survives with c pruned from members.
+    const p: PipelineDef = {
+      name: "p",
+      variables: {},
+      nodes: [plainNode("a"), plainNode("b")],
+      edges: [edge("a", "out", "b", "in"), edge("b", "out", "a", "in")],
+      loops: [{ id: "r", kind: "bounded", members: ["a", "b", "c"], max_iter: 3 }],
+    };
+    const out = reconcileLoopRegions(p);
+    expect(out).toHaveLength(1);
+    expect(out[0].members).toEqual(["a", "b"]);
+    expect(out[0].max_iter).toBe(3);
+  });
+
+  it("keeps a single-member bounded region when the survivor self-loops, pruned to it", () => {
+    // The other member is deleted but the survivor carries a self-edge — still a
+    // valid (one-member) bounded loop. Kept, with the ghost member pruned.
+    const p: PipelineDef = {
+      name: "p",
+      variables: {},
+      nodes: [plainNode("worker")],
+      edges: [edge("worker", "out", "worker", "again")],
+      loops: [{ id: "spin", kind: "bounded", members: ["worker", "rev"], max_iter: 4 }],
+    };
+    const out = reconcileLoopRegions(p);
+    expect(out).toHaveLength(1);
+    expect(out[0].members).toEqual(["worker"]);
+  });
+
+  it("drops a bounded region left with no present members", () => {
+    const p: PipelineDef = {
+      name: "p",
+      variables: {},
+      nodes: [plainNode("a")],
+      edges: [],
+      loops: [{ id: "r", kind: "bounded", members: ["gone1", "gone2"], max_iter: 3 }],
+    };
+    expect(reconcileLoopRegions(p)).toEqual([]);
+  });
+
+  it("prunes a collection region's ghost member but keeps it (born by gesture, not a cycle)", () => {
+    const p: PipelineDef = {
+      name: "p",
+      variables: {},
+      nodes: [plainNode("fixer")],
+      edges: [],
+      loops: [{ id: "per-issue", kind: "collection", over: "issues", members: ["fixer", "gone"] }],
+    };
+    const out = reconcileLoopRegions(p);
+    expect(out).toHaveLength(1);
+    expect(out[0].members).toEqual(["fixer"]);
+  });
+
+  it("drops a collection region emptied of present members", () => {
+    const p: PipelineDef = {
+      name: "p",
+      variables: {},
+      nodes: [],
+      edges: [],
+      loops: [{ id: "per-issue", kind: "collection", over: "issues", members: ["gone"] }],
+    };
+    expect(reconcileLoopRegions(p)).toEqual([]);
+  });
+
+  it("leaves regions untouched when the deleted node was no member (cycle intact)", () => {
+    const p = reviewLoop(); // [impl, rev] all present, the cycle is intact
+    expect(reconcileLoopRegions(p)).toEqual(p.loops);
   });
 });
 

--- a/frontend/src/lib/loopRegions.ts
+++ b/frontend/src/lib/loopRegions.ts
@@ -180,6 +180,44 @@ export function regionsDestroyedByEdgeRemoval(
 }
 
 /**
+ * Reconciles the `loops:` regions against the current node set after a node has
+ * been deleted (ADR-0011 / #150 / #173). Deleting a node also drops every edge
+ * that referenced it — which can take a bounded region's **last** cycle — and
+ * always leaves the deleted id dangling in any region's `members`. This rebuilds
+ * the region list so it can never name a node absent from the graph nor keep an
+ * orphan (cycle-less) bounded region:
+ *
+ *  - every region's `members` is pruned to nodes still present (no ghost ids —
+ *    a loop never lists a node that doesn't exist);
+ *  - a `bounded` region that no longer closes a cycle is dropped (its bound and
+ *    iteration state go with the deleted node — the same destroy-on-last-cycle
+ *    rule the edge path applies in `regionsDestroyedByEdgeRemoval`);
+ *  - a region left with no present members is dropped.
+ *
+ * `pipeline` is the graph AFTER the node and its edges have been removed. A
+ * `collection` region is born by gesture, not topology (#151), so it is kept on
+ * its remaining members (only an emptied-out collection is dropped).
+ */
+export function reconcileLoopRegions(pipeline: PipelineDef): LoopRegion[] {
+  const present = new Set(pipeline.nodes.map((n) => n.id));
+  const out: LoopRegion[] = [];
+  for (const region of pipeline.loops ?? []) {
+    const members = region.members.filter((m) => present.has(m));
+    if (members.length === 0) continue;
+    const pruned =
+      members.length === region.members.length ? region : { ...region, members };
+    if (
+      pruned.kind === "bounded" &&
+      !regionHasCycle(pruned, pipeline.nodes, pipeline.edges)
+    ) {
+      continue;
+    }
+    out.push(pruned);
+  }
+  return out;
+}
+
+/**
  * Info-only nudges (ADR-0001 sharp tool, never auto-wraps) suggesting a
  * collection fan-out (#151): when a `list`-typed output port feeds a downstream
  * node that is NOT already a member of a collection region, offer the explicit

--- a/frontend/src/stores/editStore.test.ts
+++ b/frontend/src/stores/editStore.test.ts
@@ -294,6 +294,84 @@ describe("deleteEdge removes a region whose last cycle it destroys (ADR-0011 / #
   });
 });
 
+describe("deleteNode reconciles loop regions (ADR-0011 / #173)", () => {
+  function edge(s: string, t: string): EdgeDef {
+    return { source: { node: s, port: "out" }, target: { node: t, port: "in" } };
+  }
+
+  it("destroys an orphaned bounded region when a member node is deleted (no ghost id persists)", () => {
+    const a = makeNode({ id: "aaaa1111", name: "impl" });
+    const b = makeNode({ id: "bbbb2222", name: "rev" });
+    const pipeline = makePipeline(
+      [a, b],
+      [edge("aaaa1111", "bbbb2222"), edge("bbbb2222", "aaaa1111")],
+    );
+    pipeline.loops = [
+      { id: "review_loop", kind: "bounded", members: ["aaaa1111", "bbbb2222"], max_iter: 3 },
+    ];
+    seedTabWithPipeline(pipeline);
+
+    // Deleting `rev` also drops the rev -> impl back-edge: the region no longer
+    // closes a cycle, so it is destroyed rather than left as an orphan whose
+    // `members` still names the deleted node.
+    useEditStore.getState().deleteNode("bbbb2222");
+
+    const tab = useEditStore.getState().openTabs[0];
+    expect(tab.pipeline.nodes.map((n) => n.id)).toEqual(["aaaa1111"]);
+    expect(tab.pipeline.loops ?? []).toHaveLength(0);
+    expect(tab.dirty).toBe(true);
+    expect(useEditStore.getState().selection).toEqual({ kind: "none", id: null });
+  });
+
+  it("prunes the deleted member from a surviving region's members (no ghost id)", () => {
+    const a = makeNode({ id: "aaaa1111", name: "impl" });
+    const b = makeNode({ id: "bbbb2222", name: "rev" });
+    const c = makeNode({ id: "cccc3333", name: "mid" });
+    // Two cycles close {a,b,c}: b -> a AND c -> a.
+    const pipeline = makePipeline(
+      [a, b, c],
+      [
+        edge("aaaa1111", "bbbb2222"), // a -> b
+        edge("bbbb2222", "aaaa1111"), // b -> a  (cycle 1)
+        edge("aaaa1111", "cccc3333"), // a -> c
+        edge("cccc3333", "aaaa1111"), // c -> a  (cycle 2)
+      ],
+    );
+    pipeline.loops = [
+      { id: "review_loop", kind: "bounded", members: ["aaaa1111", "bbbb2222", "cccc3333"], max_iter: 3 },
+    ];
+    seedTabWithPipeline(pipeline);
+
+    // Deleting `mid` removes a->c / c->a, but a<->b still closes the region: it
+    // survives with `mid` pruned from `members`.
+    useEditStore.getState().deleteNode("cccc3333");
+
+    const tab = useEditStore.getState().openTabs[0];
+    expect(tab.pipeline.loops).toHaveLength(1);
+    expect(tab.pipeline.loops![0].members).toEqual(["aaaa1111", "bbbb2222"]);
+  });
+
+  it("leaves a region intact when a non-member node is deleted", () => {
+    const start = makeNode({ id: "ssss0000", name: "start", type: "start" });
+    const a = makeNode({ id: "aaaa1111", name: "impl" });
+    const b = makeNode({ id: "bbbb2222", name: "rev" });
+    const pipeline = makePipeline(
+      [start, a, b],
+      [edge("ssss0000", "aaaa1111"), edge("aaaa1111", "bbbb2222"), edge("bbbb2222", "aaaa1111")],
+    );
+    pipeline.loops = [
+      { id: "review_loop", kind: "bounded", members: ["aaaa1111", "bbbb2222"], max_iter: 3 },
+    ];
+    seedTabWithPipeline(pipeline);
+
+    useEditStore.getState().deleteNode("ssss0000");
+
+    const tab = useEditStore.getState().openTabs[0];
+    expect(tab.pipeline.loops).toHaveLength(1);
+    expect(tab.pipeline.loops![0].members).toEqual(["aaaa1111", "bbbb2222"]);
+  });
+});
+
 describe("updateRegion edits a region's max_iter (ADR-0011 / #150)", () => {
   function edge(s: string, t: string): EdgeDef {
     return { source: { node: s, port: "out" }, target: { node: t, port: "in" } };

--- a/frontend/src/stores/editStore.ts
+++ b/frontend/src/stores/editStore.ts
@@ -17,7 +17,11 @@ import {
   saveLibraryPipeline,
 } from "../api";
 import { generateNodeId } from "../lib/nanoid";
-import { materializeMissingRegions, regionsDestroyedByEdgeRemoval } from "../lib/loopRegions";
+import {
+  materializeMissingRegions,
+  reconcileLoopRegions,
+  regionsDestroyedByEdgeRemoval,
+} from "../lib/loopRegions";
 
 export type SelectionKind = "node" | "edge" | "region" | "none";
 
@@ -499,6 +503,17 @@ export const useEditStore = create<EditState>((set, get) => ({
       ...mutateActiveTab(s, (tab) => {
         tab.pipeline.nodes = tab.pipeline.nodes.filter((n) => n.id !== nodeId);
         tab.pipeline.edges = tab.pipeline.edges.filter((e) => !edgeReferencesNode(e, nodeId));
+        // Reconcile loop regions against the removed node (ADR-0011 / #173).
+        // Deleting a node also drops the edges that referenced it, which can take
+        // a bounded region's last cycle, and always leaves the deleted id
+        // dangling in any region's `members`. Mirror the edge path's
+        // destroy-on-last-cycle rule (`deleteEdge`): prune the id from every
+        // region and drop a bounded region that no longer closes a cycle, so
+        // neither an orphan region nor a ghost member id is ever written to the
+        // saved pipeline file.
+        if (tab.pipeline.loops && tab.pipeline.loops.length > 0) {
+          tab.pipeline.loops = reconcileLoopRegions(tab.pipeline);
+        }
       }),
       selection: { kind: "none" as const, id: null },
     }));


### PR DESCRIPTION
Ships the fix for #173 (loop region reconciliation on node deletion).

## What

Deleting a node that was a member of a bounded loop region used to leave the now-cycle-less `loops:` entry in place and keep the deleted id in its `members` — an orphan region plus a ghost member id persisted to the saved pipeline file (and could feed the scheduler).

`editStore.deleteNode` filtered nodes/edges but never touched `tab.pipeline.loops`. This PR adds the matching reconciliation (mirroring `deleteEdge`):

- new `reconcileLoopRegions(pipeline)` in `loopRegions.ts`: prune each region's members to present nodes, drop a bounded region that no longer closes a cycle (reusing `regionHasCycle`), drop emptied regions; keep collection regions on their remaining members.
- `deleteNode` calls it after filtering — no orphan region or ghost member id reaches the saved file.
- restore the documented single-member badge for bounded regions (a loop reduced to one present member renders a `↻` badge).

Also bumps the workspace version `0.1.4` → `0.1.5`.

## Validation

Independent Tester node (Maestro `bugfix-auto` run) drove the **fixed** frontend in a live browser against two repro fixtures:

- **Repro A** (destroy on last cycle): deleting the node carrying the only back-edge **destroys** the region — no `loops:` block persists.
- **Repro B** (prune-and-keep): deleting a tail member **prunes the ghost id** while keeping the region whose survivors still close a cycle.

`tsc -b` + `vite build` clean; touched unit suites green (92 passed). Verdict: **Pass**.

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)
