### PR TITLE
fix(runs): surface a stalled run with an amber dot (#180)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1384,7 +1384,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "maestro-daemon"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/maestro-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "0.1.5"
+version = "0.1.6"
 license = "MIT"
 
 [workspace.dependencies]

--- a/crates/maestro-daemon/src/event_log.rs
+++ b/crates/maestro-daemon/src/event_log.rs
@@ -837,6 +837,41 @@ pub fn project(events: &[Event]) -> Option<RunState> {
     Some(state)
 }
 
+/// Is this Run *stalled* (#180)? A run with no node currently `running` or
+/// `waiting` and no active merge resolver, where at least one node has gone
+/// `stale`, has nothing left to drive it forward: the stale node's session is
+/// wedged (idle with incomplete outputs, per `stale_detector`) so its
+/// downstream can never be scheduled, and the scheduler — which reacts to every
+/// event — has produced no other active node. The run is therefore stuck with
+/// no forward progress, which CONTEXT.md's "never a silent stall" requires us
+/// to surface (amber dot) instead of leaving it looking active.
+///
+/// This is a **display-only** derivation: the run's canonical `status` stays
+/// `Running`, so stale detection keeps probing it and the stalled state clears
+/// automatically as soon as activity resumes (a `NodeStarted`/`NodeWaiting`
+/// flips a node back to active, or the stale node completes). We deliberately
+/// avoid a persisted `RunStatus::Stale` variant — the condition is recomputed
+/// from the projection on every read.
+pub fn is_stalled(run: &RunState) -> bool {
+    if run.status != RunStatus::Running {
+        return false;
+    }
+
+    let has_active_node = run
+        .nodes
+        .values()
+        .any(|n| matches!(n.status, NodeStatus::Running | NodeStatus::Waiting));
+    let resolver_active = run
+        .merge_resolver
+        .as_ref()
+        .is_some_and(|mr| mr.status == NodeStatus::Running);
+    if has_active_node || resolver_active {
+        return false;
+    }
+
+    run.nodes.values().any(|n| n.status == NodeStatus::Stale)
+}
+
 pub fn now_iso() -> String {
     chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
 }
@@ -2648,5 +2683,168 @@ mod tests {
             !routes.contains_key("other_loop"),
             "an unrouted sibling region has no route entry"
         );
+    }
+
+    // --- is_stalled: run-level stale derivation (#180) ---
+
+    #[test]
+    fn stalled_when_only_node_went_stale() {
+        // A node went stale and nothing else is running/waiting: the run has no
+        // forward progress, yet its canonical status stays Running.
+        let events = vec![
+            make_event_with_payload(
+                EventKind::RunStarted,
+                None,
+                serde_json::json!({ "pipeline_name": "wedged" }),
+            ),
+            make_event(EventKind::NodeStarted, Some("worker"), Some(1)),
+            make_event(EventKind::NodeStale, Some("worker"), Some(1)),
+        ];
+        let state = project(&events).unwrap();
+        assert_eq!(state.status, RunStatus::Running, "status stays Running");
+        assert_eq!(state.nodes["worker"].status, NodeStatus::Stale);
+        assert!(is_stalled(&state), "all-idle with a stale node => stalled");
+    }
+
+    #[test]
+    fn not_stalled_when_another_node_still_running() {
+        // One branch is stale but a sibling is still running: the run is making
+        // progress and must NOT be flagged stale.
+        let events = vec![
+            make_event_with_payload(
+                EventKind::RunStarted,
+                None,
+                serde_json::json!({ "pipeline_name": "fan-out" }),
+            ),
+            make_event(EventKind::NodeStarted, Some("a"), Some(1)),
+            make_event(EventKind::NodeStarted, Some("b"), Some(1)),
+            make_event(EventKind::NodeStale, Some("a"), Some(1)),
+        ];
+        let state = project(&events).unwrap();
+        assert!(
+            !is_stalled(&state),
+            "a still-running sibling means the run is progressing"
+        );
+    }
+
+    #[test]
+    fn not_stalled_when_a_node_is_waiting() {
+        // A node throttled by the session cap (Waiting) is pending forward
+        // progress, so a stale sibling does not make the run stalled.
+        let events = vec![
+            make_event_with_payload(
+                EventKind::RunStarted,
+                None,
+                serde_json::json!({ "pipeline_name": "capped" }),
+            ),
+            make_event(EventKind::NodeStarted, Some("a"), Some(1)),
+            make_event(EventKind::NodeStale, Some("a"), Some(1)),
+            make_event(EventKind::NodeWaiting, Some("b"), Some(1)),
+        ];
+        let state = project(&events).unwrap();
+        assert_eq!(state.nodes["b"].status, NodeStatus::Waiting);
+        assert!(!is_stalled(&state), "a waiting node is not a stall");
+    }
+
+    #[test]
+    fn stalled_clears_when_stale_node_resumes() {
+        // AC: "A Run that resumes activity leaves the stale state." The same
+        // node restarting (e.g. manual retry) flips it back to Running.
+        let mut events = vec![
+            make_event_with_payload(
+                EventKind::RunStarted,
+                None,
+                serde_json::json!({ "pipeline_name": "recover" }),
+            ),
+            make_event(EventKind::NodeStarted, Some("worker"), Some(1)),
+            make_event(EventKind::NodeStale, Some("worker"), Some(1)),
+        ];
+        assert!(is_stalled(&project(&events).unwrap()));
+
+        events.push(make_event(EventKind::NodeStarted, Some("worker"), Some(2)));
+        let state = project(&events).unwrap();
+        assert_eq!(state.nodes["worker"].status, NodeStatus::Running);
+        assert!(
+            !is_stalled(&state),
+            "resumed activity clears the stalled overlay"
+        );
+    }
+
+    #[test]
+    fn not_stalled_without_any_stale_node() {
+        // A plain mid-execution run (running node, no stale) is not stalled.
+        let events = vec![
+            make_event_with_payload(
+                EventKind::RunStarted,
+                None,
+                serde_json::json!({ "pipeline_name": "healthy" }),
+            ),
+            make_event(EventKind::NodeStarted, Some("worker"), Some(1)),
+        ];
+        assert!(!is_stalled(&project(&events).unwrap()));
+    }
+
+    #[test]
+    fn not_stalled_when_paused() {
+        // A paused run with a stale node is intentionally idle, not stalled.
+        let events = vec![
+            make_event_with_payload(
+                EventKind::RunStarted,
+                None,
+                serde_json::json!({ "pipeline_name": "paused" }),
+            ),
+            make_event(EventKind::NodeStarted, Some("worker"), Some(1)),
+            make_event(EventKind::NodeStale, Some("worker"), Some(1)),
+            make_event(EventKind::RunPaused, None, None),
+        ];
+        let state = project(&events).unwrap();
+        assert_eq!(state.status, RunStatus::Paused);
+        assert!(!is_stalled(&state), "a paused run is never stalled");
+    }
+
+    #[test]
+    fn not_stalled_when_merge_resolver_active() {
+        // A running merge resolver is forward progress even if a node is stale.
+        let events = vec![
+            make_event_with_payload(
+                EventKind::RunStarted,
+                None,
+                serde_json::json!({ "pipeline_name": "merging" }),
+            ),
+            make_event(EventKind::NodeStarted, Some("worker"), Some(1)),
+            make_event(EventKind::NodeStale, Some("worker"), Some(1)),
+            make_event_with_payload(
+                EventKind::MergeResolverStarted,
+                None,
+                serde_json::json!({ "conflicting_node_id": "worker", "iter": 1 }),
+            ),
+        ];
+        let state = project(&events).unwrap();
+        assert_eq!(
+            state.merge_resolver.as_ref().unwrap().status,
+            NodeStatus::Running
+        );
+        assert!(
+            !is_stalled(&state),
+            "an active merge resolver means the run is still progressing"
+        );
+    }
+
+    #[test]
+    fn not_stalled_when_completed() {
+        // A completed run has no stale nodes and a terminal status.
+        let events = vec![
+            make_event_with_payload(
+                EventKind::RunStarted,
+                None,
+                serde_json::json!({ "pipeline_name": "done" }),
+            ),
+            make_event(EventKind::NodeStarted, Some("worker"), Some(1)),
+            make_event(EventKind::NodeCompleted, Some("worker"), Some(1)),
+            make_event(EventKind::RunCompleted, None, None),
+        ];
+        let state = project(&events).unwrap();
+        assert_eq!(state.status, RunStatus::Completed);
+        assert!(!is_stalled(&state));
     }
 }

--- a/crates/maestro-daemon/src/lib.rs
+++ b/crates/maestro-daemon/src/lib.rs
@@ -176,6 +176,10 @@ struct RunListEntry {
     run_id: String,
     pipeline_name: String,
     status: event_log::RunStatus,
+    /// Display-only "no forward progress" overlay (#180): true when the run has
+    /// no running/waiting node and a stale node, so its dot renders amber even
+    /// though `status` stays `running`. Derived per read by `event_log::is_stalled`.
+    stalled: bool,
     started_at: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
@@ -3320,10 +3324,12 @@ async fn list_runs(State(state): State<Arc<AppState>>) -> Response {
             Err(_) => continue,
         };
         if let Some(run_state) = event_log::project(&events) {
+            let stalled = event_log::is_stalled(&run_state);
             runs.push(RunListEntry {
                 run_id: run_state.run_id,
                 pipeline_name: run_state.pipeline_name,
                 status: run_state.status,
+                stalled,
                 started_at: run_state.started_at,
                 name: run_state.name,
                 triggered_by: run_state.triggered_by,

--- a/frontend/src/components/RunsListPanel.test.tsx
+++ b/frontend/src/components/RunsListPanel.test.tsx
@@ -59,6 +59,30 @@ describe("RunsListPanel run status rendering", () => {
       expect(screen.getByText(`pipe-${status}`)).toBeInTheDocument();
     }
   });
+
+  it("renders a stalled run with an amber, steady dot (#180)", () => {
+    // A stalled run keeps status "running" but must surface amber and NOT pulse.
+    const runs: RunListEntry[] = [
+      { run_id: "run-1", pipeline_name: "stuck-pipe", status: "running", stalled: true, started_at: null },
+    ];
+    renderPanel({ runs });
+    const dot = document.querySelector(".bg-st-stale");
+    expect(dot).toBeInTheDocument();
+    expect(dot?.className).not.toContain("animate-pulse");
+    // It must not fall through to the active-running blue dot.
+    expect(document.querySelector(".bg-st-running")).not.toBeInTheDocument();
+  });
+
+  it("renders a genuinely-running (not stalled) run blue and pulsing", () => {
+    const runs: RunListEntry[] = [
+      { run_id: "run-1", pipeline_name: "live-pipe", status: "running", stalled: false, started_at: null },
+    ];
+    renderPanel({ runs });
+    const dot = document.querySelector(".bg-st-running");
+    expect(dot).toBeInTheDocument();
+    expect(dot?.className).toContain("animate-pulse");
+    expect(document.querySelector(".bg-st-stale")).not.toBeInTheDocument();
+  });
 });
 
 describe("RunsListPanel Library section", () => {

--- a/frontend/src/components/RunsListPanel.tsx
+++ b/frontend/src/components/RunsListPanel.tsx
@@ -86,7 +86,12 @@ export default function RunsListPanel({
         )}
         {runs.map((run) => {
           const isSelected = run.run_id === selectedRunId;
-          const { dot } = STATUS_STYLES[run.status] ?? STATUS_STYLES.running;
+          // A stalled run (no node running/waiting, nothing schedulable; #180)
+          // is surfaced amber and steady, overriding its still-`running`
+          // canonical status — "never a silent stall."
+          const dot = run.stalled
+            ? "bg-st-stale"
+            : (STATUS_STYLES[run.status] ?? STATUS_STYLES.running).dot;
           const isArchived = run.status === "archived";
           const canCleanup = !isArchived;
 
@@ -103,7 +108,7 @@ export default function RunsListPanel({
             >
               <span
                 className={`h-2 w-2 shrink-0 rounded-full ${dot} ${
-                  run.status === "running" ? "animate-pulse" : ""
+                  run.status === "running" && !run.stalled ? "animate-pulse" : ""
                 }`}
               />
               <div className="min-w-0 flex-1">

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -22,6 +22,12 @@ export interface RunListEntry {
   run_id: string;
   pipeline_name: string;
   status: RunStatus;
+  /**
+   * Display-only "no forward progress" overlay (#180): true when the run has no
+   * running/waiting node and a stale node. The dot renders amber and steady
+   * even though `status` stays `"running"`. Derived server-side per read.
+   */
+  stalled?: boolean;
   started_at: string | null;
   name?: string | null;
   /** Provenance: the id of the Trigger that created this Run, if any (#160). */


### PR DESCRIPTION
Ships the fix for #180: a Run with no running/waiting node and at least one stale node is stuck with no forward progress, yet the runs-list dot still rendered blue + pulsing — identical to a genuinely-active run, violating CONTEXT.md's "never a silent stall".

## What changed
- `event_log::is_stalled(&RunState)`: `status==Running` ∧ no Running/Waiting node ∧ no active merge resolver ∧ ≥1 Stale node. The canonical status stays `Running`, so stale detection keeps probing and the overlay self-clears when activity resumes.
- Exposed as `stalled: bool` on `RunListEntry` (`GET /runs`).
- Frontend renders `bg-st-stale` (amber) and suppresses the pulse when `run.stalled`.
- `chore: bump version to 0.1.6`.

## Validation
- Backend: 8 unit tests on the `is_stalled` predicate.
- Frontend: 2 `RunsListPanel` tests (amber+steady when stalled; blue+pulsing otherwise) — 10/10 component tests pass.
- Independent validation node confirmed a clean `cargo build` + `vite build`, the real component renders the correct classes, and a real-browser check resolves them to amber-steady (`#d97706`) vs blue-pulsing (`#3b82f6`).

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)
