### PR TITLE
fix(canvas): anchor emergent input edges by drop side, not always left (#175)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1384,7 +1384,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "maestro-daemon"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/maestro-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "0.1.7"
+version = "0.1.8"
 license = "MIT"
 
 [workspace.dependencies]

--- a/frontend/src/components/EditCanvas.nodes.test.tsx
+++ b/frontend/src/components/EditCanvas.nodes.test.tsx
@@ -153,6 +153,64 @@ describe("EditNode slim card (issue #149)", () => {
   });
 });
 
+describe("EditNode emergent anchoring keyed on node type (issue #175)", () => {
+  function nodeProps(
+    nodeType: NodeType,
+    inputs: { name: string; side: "left" | "right" | "top" | "bottom" }[],
+  ) {
+    return {
+      ...markerProps({ nodeType }),
+      id: nodeType,
+      data: {
+        label: nodeType,
+        nodeId: nodeType,
+        nodeType,
+        status: "pending" as NodeStatus,
+        reached: false,
+        inputs,
+        // End has no outputs; a work node's outputs are irrelevant to anchoring.
+        outputs: [],
+        interactive: false,
+      },
+    } as unknown as Parameters<typeof EditNode>[0];
+  }
+
+  it("grows all four body anchor handles on a work node that still carries a vestigial declared `in`", () => {
+    // Regression (#175): the old `inputs.length !== 1` gate suppressed the
+    // anchors on every real work node (each carries one declared `in`), so no
+    // edge could anchor by drop and they all snapped to the left. Anchoring is
+    // keyed on node TYPE now, so the per-side anchors appear regardless.
+    const { container } = render(
+      <EditNode {...nodeProps("code-mutating", [{ name: "in", side: "left" }])} />,
+      { wrapper: Wrapper },
+    );
+    const handleIds = Array.from(container.querySelectorAll(".react-flow__handle")).map((h) =>
+      h.getAttribute("data-handleid"),
+    );
+    for (const side of ["left", "right", "top", "bottom"]) {
+      expect(handleIds).toContain(`__anchor:${side}`);
+    }
+  });
+
+  it("keeps a declared-port node (End) on its declared side and grows no anchor handles (AC3)", () => {
+    // End's `result` is a fixed-side declared port: its body handle renders on
+    // the declared side (here `top`), not a hardcoded left, and it never grows
+    // the per-side drop anchors.
+    const { container } = render(
+      <EditNode {...nodeProps("end", [{ name: "result", side: "top" }])} />,
+      { wrapper: Wrapper },
+    );
+    const handles = Array.from(container.querySelectorAll(".react-flow__handle"));
+    const handleIds = handles.map((h) => h.getAttribute("data-handleid"));
+    for (const side of ["left", "right", "top", "bottom"]) {
+      expect(handleIds).not.toContain(`__anchor:${side}`);
+    }
+    const resultHandle = handles.find((h) => h.getAttribute("data-handleid") === "result");
+    expect(resultHandle).toBeTruthy();
+    expect(resultHandle!.getAttribute("data-handlepos")).toBe("top");
+  });
+});
+
 describe("EditNode Start marker — input images on the canvas (issue #145)", () => {
   it("renders one image chip per uploaded image, tagged by filename", () => {
     render(

--- a/frontend/src/components/EditCanvas.tsx
+++ b/frontend/src/components/EditCanvas.tsx
@@ -34,7 +34,7 @@ import DragConnectionLine from "./DragConnectionLine";
 import { DragHighlightProvider, useIsDropTarget } from "./DragHighlightContext";
 import PipelineStar from "./PipelineStar";
 import { usePipelineLibraryState } from "../hooks/useLibraryPipelines";
-import { anchorHandleId, anchorsByDropOnBody, chooseAnchorSide } from "../lib/anchorSide";
+import { anchorHandleId, anchorsByDropOnBody, chooseAnchorSide, isEmergentInputNode } from "../lib/anchorSide";
 
 // The four emergent body anchor handles (#168), each pinned to its side-centre
 // with the matching xyflow `Position` so a bound incoming edge arrives from that
@@ -45,6 +45,16 @@ const ANCHOR_HANDLE_SIDES: { side: PortSide; position: Position; style: React.CS
   { side: "top", position: Position.Top, style: { top: 0, left: "50%", transform: "translateX(-50%)" } },
   { side: "bottom", position: Position.Bottom, style: { bottom: 0, left: "50%", transform: "translateX(-50%)" } },
 ];
+
+// A declared input port's side maps to the xyflow `Position` its body handle
+// renders on, so a fixed-side declared port (End's `result`) arrives from its
+// own declared side rather than a hardcoded left (#168 / #175 AC3).
+const SIDE_TO_POSITION: Record<PortSide, Position> = {
+  left: Position.Left,
+  right: Position.Right,
+  top: Position.Top,
+  bottom: Position.Bottom,
+};
 
 interface EditNodeData {
   label: string;
@@ -87,17 +97,28 @@ export function EditNode({ data, id }: NodeProps<Node<EditNodeData>>) {
   const inputImages =
     data.nodeType === "start" ? (data.inputImages ?? []) : [];
 
+  // Emergent work nodes (`doc-only`/`code-mutating`) anchor incoming edges by
+  // drop position; declared-port nodes (End) keep their fixed side. Keyed on
+  // node TYPE so a work node carrying a vestigial declared `in` still anchors by
+  // drop (#175) rather than being mistaken for a fixed-side declared port.
+  const emergent = isEmergentInputNode(data.nodeType);
+  // A declared port's body handle arrives from its own declared side (#175 AC3),
+  // not a hardcoded left. Moot for emergent bodies (edges bind to the per-side
+  // anchor handles below), but kept consistent.
+  const bodyHandleSide = data.inputs[0]?.side ?? "left";
+
   return (
     <NodeCard status={cardStatus} selected={isSelected} style={{ minWidth: 160, fontSize: "12px" }}>
       {/* Emergent inputs (#149): NO input dots. An incoming arrow lands anywhere
           on the node body. A single invisible target handle covers the card and
           carries the drop highlight. The declared `result` input on the End node
-          keeps its handle id so routing to End still resolves; emergent nodes
-          render the highlight handle id-less. */}
+          keeps its handle id (and its declared-side `position`) so routing to End
+          still resolves on its own side; emergent nodes render the highlight
+          handle id-less and bind incoming edges to the per-side anchors below. */}
       <Handle
-        id={data.inputs.length === 1 ? data.inputs[0].name : undefined}
+        id={emergent ? undefined : data.inputs[0]?.name}
         type="target"
-        position={Position.Left}
+        position={SIDE_TO_POSITION[bodyHandleSide]}
         isConnectableStart={false}
         className={`emergent-body-target${isDropTarget ? " is-drop" : ""}`}
         style={{
@@ -112,13 +133,13 @@ export function EditNode({ data, id }: NodeProps<Node<EditNodeData>>) {
           opacity: isDropTarget ? 1 : 0,
         }}
       />
-      {/* Anchor-by-drop-position (#168): an emergent node also renders one
+      {/* Anchor-by-drop-position (#168): an emergent work node also renders one
           invisible side-centre target handle PER SIDE. An incoming edge binds to
           the handle for its persisted `target_side`, so xyflow anchors the arrow
           and derives the arrival geometry from that side (no forced left->right).
           Declared-input nodes (e.g. End's `result`) keep their fixed-side handle
           and never grow these. */}
-      {data.inputs.length !== 1 &&
+      {emergent &&
         ANCHOR_HANDLE_SIDES.map(({ side, position, style }) => (
           <Handle
             key={`anchor-${side}`}
@@ -388,9 +409,9 @@ function EditCanvasInner({ libraryEntries, libraryPipelines, onLibraryDelete, on
       setHoveredNodeId(null);
 
       // Anchor the just-drawn edge on the target side nearest the drop (#168).
-      // Only emergent bodies (no single declared input) anchor by drop position;
-      // declared/structural ports keep their fixed side. The edge `onConnect`
-      // appended is at `pendingEdgeIndexRef`.
+      // Only emergent work-node bodies anchor by drop position; declared and
+      // structural ports keep their fixed side. The edge `onConnect` appended is
+      // at `pendingEdgeIndexRef`.
       const edgeIndex = pendingEdgeIndexRef.current;
       pendingEdgeIndexRef.current = null;
       if (edgeIndex == null) return;
@@ -399,12 +420,10 @@ function EditCanvasInner({ libraryEntries, libraryPipelines, onLibraryDelete, on
       const drop = connectionState.to;
       if (!toNode || !drop) return;
       const targetDef = pipeline?.nodes.find((n) => n.id === toNode.id);
-      // Structural nodes and single-declared-input nodes (e.g. End's `result`)
-      // keep their declared, fixed-side handle — never re-anchor those.
-      if (!targetDef || targetDef.inputs.length === 1) return;
-      if (targetDef.type === "merge") {
-        return;
-      }
+      // Declared-port nodes (End's `result`) and structural nodes (merge) keep
+      // their declared, fixed-side handle — never re-anchor those. Keyed on node
+      // TYPE: a work node carrying a vestigial declared `in` still anchors (#175).
+      if (!targetDef || !isEmergentInputNode(targetDef.type)) return;
 
       const rect = {
         x: toNode.internals.positionAbsolute.x,

--- a/frontend/src/components/OrthogonalEdge.tsx
+++ b/frontend/src/components/OrthogonalEdge.tsx
@@ -98,9 +98,12 @@ export default function OrthogonalEdge({
       );
       return [sourcePt, ...anchored, targetPt];
     }
-    return routeOrthogonal({ source: sourcePt, target: targetPt, obstacles });
+    // Auto route: arrive from the persisted anchor side (#168 / #175) rather
+    // than always horizontally from the left. Manual routes (above) arrive
+    // however the user shaped their waypoints, so this only steers auto edges.
+    return routeOrthogonal({ source: sourcePt, target: targetPt, obstacles, targetSide: data?.targetSide });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [mode, waypoints, sourceX, sourceY, targetX, targetY, obstacles]);
+  }, [mode, waypoints, sourceX, sourceY, targetX, targetY, obstacles, data?.targetSide]);
 
   const d = pathToSvg(points);
   const handles = useMemo(() => segmentHandles(points), [points]);

--- a/frontend/src/components/editNodeDerivation.test.ts
+++ b/frontend/src/components/editNodeDerivation.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { deriveEditEdges, deriveEditNodes, deriveLoopRegions, runReachedEnd } from "./editNodeDerivation";
-import type { LoopRegion, NodeDef, NodeType, PipelineDef, RunStatus } from "../types";
+import type { LoopRegion, NodeDef, NodeType, PipelineDef, PortSide, RunStatus } from "../types";
 
 describe("runReachedEnd", () => {
   it("is true only when the run completed successfully", () => {
@@ -104,6 +104,67 @@ describe("deriveEditEdges targetHandle anchoring (#149)", () => {
     const edges = deriveEditEdges(p);
     expect(edges[0].targetHandle).toBe("__anchor:top");
     expect(edges[1].targetHandle).toBe("__anchor:bottom");
+  });
+});
+
+describe("deriveEditEdges — work node with a vestigial declared `in` still anchors by side (#175)", () => {
+  // The #149 migration to 0-input emergent nodes was never carried through to
+  // node creation or the on-disk pipeline YAMLs, so a real work node usually
+  // still carries a single declared `in`. The old `inputs.length === 1` gate
+  // mistook that for a fixed-side declared port and forced every incoming edge
+  // to the left handle. Anchoring is keyed on node TYPE now, so a 1-input work
+  // node anchors by drop on any side, exactly like a migrated 0-input one.
+  function workNode(id: string, type: NodeType, outputs: string[]): NodeDef {
+    return {
+      id,
+      name: id,
+      type,
+      // The vestigial declared `in` (side left) that real pipelines still carry.
+      inputs: [{ name: "in", repeated: false, side: "left" as const }],
+      outputs: outputs.map((name) => ({ name, repeated: false, side: "right" as const })),
+      interactive: false,
+    };
+  }
+
+  function pipelineWith(targetSide: PortSide | undefined): PipelineDef {
+    return {
+      name: "p",
+      variables: {},
+      nodes: [
+        {
+          id: "src",
+          name: "src",
+          type: "doc-only",
+          inputs: [],
+          outputs: [{ name: "plan", repeated: false, side: "right" as const }],
+          interactive: false,
+        },
+        workNode("dst", "code-mutating", ["code"]),
+      ],
+      edges: [
+        {
+          source: { node: "src", port: "plan" },
+          target: { node: "dst", port: "in" },
+          target_side: targetSide,
+        },
+      ],
+    };
+  }
+
+  it.each(["left", "right", "top", "bottom"] as const)(
+    "binds the incoming edge to the %s body anchor (not the declared `in` handle)",
+    (side) => {
+      const edges = deriveEditEdges(pipelineWith(side));
+      expect(edges[0].targetHandle).toBe(`__anchor:${side}`);
+      // The route is told to arrive from that side, not forced left->right.
+      expect(edges[0].data?.targetSide).toBe(side);
+    },
+  );
+
+  it("defaults to the left body anchor when no target_side is persisted (legacy)", () => {
+    const edges = deriveEditEdges(pipelineWith(undefined));
+    expect(edges[0].targetHandle).toBe("__anchor:left");
+    expect(edges[0].data?.targetSide).toBe("left");
   });
 });
 

--- a/frontend/src/components/editNodeDerivation.ts
+++ b/frontend/src/components/editNodeDerivation.ts
@@ -2,7 +2,7 @@ import type { Edge, Node } from "@xyflow/react";
 import { MarkerType } from "@xyflow/react";
 import type { EdgeWaypoint, LoopRegion, NodeStatus, NodeType, PipelineDef, PortSide, RunState, RunStatus } from "../types";
 import type { OrthogonalEdgeData } from "./OrthogonalEdge";
-import { anchorHandleId } from "../lib/anchorSide";
+import { anchorHandleId, isEmergentInputNode } from "../lib/anchorSide";
 
 /**
  * A run "reaches its end" when it terminates successfully (`completed`). At
@@ -353,14 +353,16 @@ export function edgeIndexFromId(edgeId: string): number | null {
  *
  * - Structural nodes (merge) render an id'd target handle per declared input
  *   via `PortPill`, so the edge keeps its declared port name.
- * - Regular `edit` nodes with a single declared input (e.g. the End node's
- *   `result`) keep that declared, side-fixed handle — those ports are
- *   unaffected by anchoring (#168).
- * - Emergent regular `edit` nodes (doc-only / code-mutating; 0 declared inputs,
- *   ADR-0011 / #149) render one body-covering target handle PER SIDE. The edge
- *   binds to the handle for its chosen `target_side` (#168) so the arrow anchors
- *   and routes from that side; absent a `target_side`, it binds to the left
- *   handle, reproducing the legacy left-anchored behaviour.
+ * - Declared-port `edit` nodes (the End node's `result`) keep that declared,
+ *   side-fixed handle — those ports are unaffected by anchoring (#168).
+ * - Emergent work nodes (`doc-only` / `code-mutating`, ADR-0011 / #149) render
+ *   one body-covering target handle PER SIDE. The edge binds to the handle for
+ *   its chosen `target_side` (#168) so the arrow anchors and routes from that
+ *   side; absent a `target_side`, it binds to the left handle, reproducing the
+ *   legacy left-anchored behaviour. This is keyed on node TYPE, not input count:
+ *   a work node still carrying a vestigial declared `in` (the un-finished #149
+ *   migration) is emergent all the same — keying on `inputs.length === 1`
+ *   instead forced every such node's arrows to the left (#175).
  */
 function resolveTargetHandle(
   target: PipelineDef["nodes"][number],
@@ -370,12 +372,12 @@ function resolveTargetHandle(
   if (target.type === "merge") {
     return declaredPort || null;
   }
-  // A single declared input owns a fixed-side handle; declared ports are
-  // unaffected by drop-position anchoring.
-  if (target.inputs.length === 1) {
-    return target.inputs[0].name;
+  // Declared-port nodes (End's `result`) keep their declared, fixed-side handle;
+  // they are unaffected by drop-position anchoring.
+  if (!isEmergentInputNode(target.type)) {
+    return target.inputs[0]?.name ?? declaredPort ?? null;
   }
-  // Emergent body: anchor on the chosen side (default left = legacy).
+  // Emergent work-node body: anchor on the chosen side (default left = legacy).
   return anchorHandleId(targetSide ?? "left");
 }
 

--- a/frontend/src/lib/anchorSide.ts
+++ b/frontend/src/lib/anchorSide.ts
@@ -1,4 +1,4 @@
-import type { PortSide } from "../types";
+import type { NodeType, PortSide } from "../types";
 
 /** An axis-aligned rectangle in canvas (flow) coordinates. */
 export interface AnchorRect {
@@ -10,6 +10,27 @@ export interface AnchorRect {
 
 /** The four sides an emergent body anchor can land on (#168). */
 export const ANCHOR_SIDES: readonly PortSide[] = ["left", "right", "top", "bottom"];
+
+/**
+ * Whether a node uses emergent inputs (ADR-0011 / #149, #168): incoming edges
+ * land anywhere on the node body and anchor on the side nearest the drop point,
+ * rather than binding to a declared, fixed-side input handle.
+ *
+ * The work-node types (`doc-only`, `code-mutating`) are emergent. This is keyed
+ * on the node TYPE, not the declared input count: the #149 migration that drops
+ * declared inputs was never carried through to node creation or the on-disk
+ * pipeline YAMLs, so a work node frequently still carries a single vestigial
+ * `in` input. Keying drop-anchoring on `inputs.length` therefore mis-classified
+ * every such node as a fixed-side declared port and forced its arrows to the
+ * left (the #175 bug). Keying on type makes both already-migrated (0-input) and
+ * legacy (1-input `in`) work nodes anchor by drop.
+ *
+ * `start` has no inputs; `end` (declared `result`) and structural `merge` keep
+ * their declared, fixed-side ports and are never re-anchored by drop position.
+ */
+export function isEmergentInputNode(type: NodeType): boolean {
+  return type === "doc-only" || type === "code-mutating";
+}
 
 /**
  * The xyflow handle id of the body-covering target handle on a given side

--- a/frontend/src/lib/orthogonalRouter.test.ts
+++ b/frontend/src/lib/orthogonalRouter.test.ts
@@ -87,3 +87,91 @@ describe("routeOrthogonal", () => {
     expect(pathCrosses(c, moved)).toBe(false);
   });
 });
+
+describe("routeOrthogonal — arrives from the anchored target side (#175)", () => {
+  // The segment just before the target tells us which side the arrow enters.
+  const target: Point = { x: 200, y: 100 };
+
+  it("defaults to a left arrival (legacy left->right) when no side is given", () => {
+    // Source to the left, vertically offset: the final segment runs in from the
+    // left (approach x < target.x, level with the target row).
+    const path = routeOrthogonal({ source: { x: 0, y: 0 }, target, obstacles: [] });
+    const approach = path[path.length - 2];
+    expect(isOrthogonal(path)).toBe(true);
+    expect(path[path.length - 1]).toEqual(target);
+    expect(approach.x).toBeLessThan(target.x);
+    expect(approach.y).toBeCloseTo(target.y, 6);
+  });
+
+  it("arrives horizontally from the right when target_side is right", () => {
+    // Natural geometry: source sits to the right of the target.
+    const path = routeOrthogonal({
+      source: { x: 400, y: 100 },
+      target,
+      obstacles: [],
+      targetSide: "right",
+    });
+    const approach = path[path.length - 2];
+    expect(isOrthogonal(path)).toBe(true);
+    expect(path[path.length - 1]).toEqual(target);
+    expect(approach.x).toBeGreaterThan(target.x);
+    expect(approach.y).toBeCloseTo(target.y, 6);
+  });
+
+  it("arrives vertically from above when target_side is top", () => {
+    // Natural geometry: source sits above the target.
+    const path = routeOrthogonal({
+      source: { x: 200, y: -100 },
+      target,
+      obstacles: [],
+      targetSide: "top",
+    });
+    const approach = path[path.length - 2];
+    expect(isOrthogonal(path)).toBe(true);
+    expect(path[path.length - 1]).toEqual(target);
+    expect(approach.y).toBeLessThan(target.y);
+    expect(approach.x).toBeCloseTo(target.x, 6);
+  });
+
+  it("arrives vertically from below when target_side is bottom", () => {
+    // Natural geometry: source sits below the target.
+    const path = routeOrthogonal({
+      source: { x: 200, y: 400 },
+      target,
+      obstacles: [],
+      targetSide: "bottom",
+    });
+    const approach = path[path.length - 2];
+    expect(isOrthogonal(path)).toBe(true);
+    expect(path[path.length - 1]).toEqual(target);
+    expect(approach.y).toBeGreaterThan(target.y);
+    expect(approach.x).toBeCloseTo(target.x, 6);
+  });
+
+  it("still enters from the right even when the source is to the left (turns in from outside)", () => {
+    // The hard case the legacy HVH got wrong: source left of target, but the
+    // arrow must still land on the right edge. The approach must come from
+    // x > target.x — never straight across the body from the left.
+    const path = routeOrthogonal({
+      source: { x: 0, y: 0 },
+      target,
+      obstacles: [],
+      targetSide: "right",
+    });
+    const approach = path[path.length - 2];
+    expect(isOrthogonal(path)).toBe(true);
+    expect(path[path.length - 1]).toEqual(target);
+    expect(approach.x).toBeGreaterThan(target.x);
+    expect(approach.y).toBeCloseTo(target.y, 6);
+  });
+
+  it("is deterministic for a given anchored side", () => {
+    const input = {
+      source: { x: 0, y: 0 },
+      target,
+      obstacles: [] as Rect[],
+      targetSide: "top" as const,
+    };
+    expect(routeOrthogonal(input)).toEqual(routeOrthogonal(input));
+  });
+});

--- a/frontend/src/lib/orthogonalRouter.ts
+++ b/frontend/src/lib/orthogonalRouter.ts
@@ -9,6 +9,8 @@
 // The router is intentionally a deep module with a tiny surface: callers hand
 // it geometry and get back a polyline, never the internal grid/search details.
 
+import type { PortSide } from "../types";
+
 export interface Point {
   x: number;
   y: number;
@@ -31,9 +33,23 @@ export interface RouteInput {
    * at a readable distance rather than grazing their borders.
    */
   margin?: number;
+  /**
+   * The target card side the arrow anchors on (#168 / #175). The bend-minimal
+   * path arrives perpendicular to this side, approaching from outside the card,
+   * instead of always horizontally from the left. Absent ⇒ `left` (legacy
+   * left-to-right arrival). Only the obstacle-free fast path honours this; the
+   * A* fallback (rare — only when a node blocks the straight route) arrives
+   * best-effort.
+   */
+  targetSide?: PortSide;
 }
 
 const DEFAULT_MARGIN = 16;
+
+// How far outside the target card the non-left arrival route turns in from, so
+// the final segment approaches the anchored side from outside the body rather
+// than crossing it (#175).
+const LEAD_IN = 22;
 
 /**
  * Routes a right-angle polyline from `source` to `target`. The returned array
@@ -49,8 +65,9 @@ const DEFAULT_MARGIN = 16;
 export function routeOrthogonal(input: RouteInput): Point[] {
   const { source, target, obstacles } = input;
   const margin = input.margin ?? DEFAULT_MARGIN;
+  const targetSide = input.targetSide ?? "left";
 
-  const simple = rawPath(source, target);
+  const simple = rawPath(source, target, targetSide);
   if (!obstacles.some((o) => polylineHitsRect(simple, o))) {
     return simple;
   }
@@ -59,19 +76,51 @@ export function routeOrthogonal(input: RouteInput): Point[] {
   return routed ?? simple;
 }
 
-// The bend-free orthogonal connection. Edges flow left-to-right by convention
-// (output dot on the right, lands on the target body), so the route leaves the
-// source horizontally, steps vertically at the horizontal midpoint, then
-// continues horizontally into the target — an "HVH" step. Collinear endpoints
-// collapse the redundant vertices.
-function rawPath(source: Point, target: Point): Point[] {
-  const midX = (source.x + target.x) / 2;
-  return simplify([
-    source,
-    { x: midX, y: source.y },
-    { x: midX, y: target.y },
-    target,
-  ]);
+// The lead-in point one stub outside the target along the anchored side's
+// outward normal — the final segment runs from here straight into the target,
+// so the arrow arrives perpendicular to `side` from outside the card (#175).
+function leadInPoint(target: Point, side: PortSide, stub: number): Point {
+  switch (side) {
+    case "right":
+      return { x: target.x + stub, y: target.y };
+    case "top":
+      return { x: target.x, y: target.y - stub };
+    case "bottom":
+      return { x: target.x, y: target.y + stub };
+    case "left":
+    default:
+      return { x: target.x - stub, y: target.y };
+  }
+}
+
+// The bend-minimal orthogonal connection. The route leaves the source
+// horizontally (output dots sit on the right by convention) and arrives
+// perpendicular to `targetSide` from outside the target card. `left` keeps the
+// legacy "HVH" step (vertical at the horizontal midpoint); the other sides turn
+// in via a lead-in stub so the arrow approaches the anchored side rather than
+// crossing the body. `simplify` collapses the redundant vertices — and, being
+// monotonicity-aware, preserves an intentional lead-in overshoot when the
+// source sits on the far side of the anchored edge.
+function rawPath(source: Point, target: Point, targetSide: PortSide = "left"): Point[] {
+  if (targetSide === "left") {
+    const midX = (source.x + target.x) / 2;
+    return simplify([
+      source,
+      { x: midX, y: source.y },
+      { x: midX, y: target.y },
+      target,
+    ]);
+  }
+  const lead = leadInPoint(target, targetSide, LEAD_IN);
+  if (targetSide === "right") {
+    // Final segment horizontal into the right edge: leave horizontally, jog
+    // vertically at the lead-in column, then run horizontally into the target.
+    return simplify([source, { x: lead.x, y: source.y }, lead, target]);
+  }
+  // top / bottom: final segment vertical into the top/bottom edge — leave
+  // horizontally into the target column, then run vertically through the lead-in
+  // into the target.
+  return simplify([source, { x: target.x, y: source.y }, lead, target]);
 }
 
 // Drops consecutive duplicate points and collinear midpoints so a straight run
@@ -88,8 +137,12 @@ function dedupe(points: Point[]): Point[] {
   return out;
 }
 
-// Removes interior vertices that lie on a straight run between their neighbours
-// (three collinear points collapse to two), keeping the polyline minimal.
+// Removes interior vertices that lie on a straight run *between* their
+// neighbours (three collinear, monotonic points collapse to two), keeping the
+// polyline minimal. A collinear vertex that overshoots — the path doubles back
+// on itself, as a lead-in stub does when the source sits on the far side of the
+// anchored edge (#175) — is kept, since dropping it would erase the detour and
+// send the arrow straight across the body.
 function simplify(points: Point[]): Point[] {
   const pts = dedupe(points);
   if (pts.length <= 2) return pts;
@@ -102,7 +155,12 @@ function simplify(points: Point[]): Point[] {
       Math.abs(prev.x - cur.x) < 1e-6 && Math.abs(cur.x - next.x) < 1e-6;
     const collinearY =
       Math.abs(prev.y - cur.y) < 1e-6 && Math.abs(cur.y - next.y) < 1e-6;
-    if (collinearX || collinearY) continue;
+    // `cur` is between its neighbours when they fall on opposite sides of it
+    // along the shared axis (product <= 0). Only then is it a redundant
+    // straight-run vertex; an overshoot (both neighbours on one side) is a real
+    // turn and must survive.
+    if (collinearX && (prev.y - cur.y) * (next.y - cur.y) <= 0) continue;
+    if (collinearY && (prev.x - cur.x) * (next.x - cur.x) <= 0) continue;
     out.push(cur);
   }
   out.push(pts[pts.length - 1]);


### PR DESCRIPTION
## What

Emergent (auto-derived) input edges on the canvas always anchored to the **left** of the target node, ignoring the declared/dropped `target_side`. This fixes the anchoring so incoming edges arrive on the side the port actually declares (or the side the edge was dropped on).

Closes #175.

## Changes

- The four side-anchor handles (`__anchor:left/right/top/bottom`) now render on the **work node that actually receives edges** (keyed on node type, not `inputs.length`).
- Declared ports render on their **declared side** via a new `SIDE_TO_POSITION` map instead of hardcoded `Position.Left`.
- Touches `EditCanvas.tsx`, `OrthogonalEdge.tsx`, `editNodeDerivation.ts`, `lib/anchorSide.ts`, `lib/orthogonalRouter.ts`, plus tests.
- Bumps workspace version `0.1.7 → 0.1.8`.

## Verification

- Build clean (`tsc -b && vite build`), no TypeScript errors.
- 41 targeted unit tests across `orthogonalRouter.test.ts`, `editNodeDerivation.test.ts`, `EditCanvas.nodes.test.tsx` pass.
- Live-app DOM audit on the `planner` canvas confirmed the post-fix anchoring: declared `top`-side ports render at top-center and incoming edges arrive vertically from the top (previously snapped left-center). The `start` node no longer carries spurious `__anchor:*` handles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
