### PR TITLE
fix(canvas): portal output-port hover label to body so it tracks the cursor (#174)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1384,7 +1384,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "maestro-daemon"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/maestro-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "0.1.8"
+version = "0.1.9"
 license = "MIT"
 
 [workspace.dependencies]

--- a/frontend/src/components/OutputPortDot.test.tsx
+++ b/frontend/src/components/OutputPortDot.test.tsx
@@ -61,6 +61,28 @@ describe("OutputPortDot", () => {
     expect(label.style.pointerEvents).toBe("none");
   });
 
+  it("portals the floating label to document.body, not inside the (transformed) flow pane (#174)", () => {
+    // In the real app the dot lives inside `.react-flow__viewport`, whose
+    // pan/zoom `transform` is the containing block for `position: fixed`,
+    // displacing/scaling the label by the viewport matrix. Portaling the
+    // label to <body> takes it out of that transformed subtree so `fixed`
+    // resolves against the real viewport again.
+    const { container } = render(
+      <OutputPortDot id="body" side="right" index={0} total={1} />,
+      { wrapper: Wrapper },
+    );
+    const dot = container.querySelector(".port-dot") as HTMLElement;
+    fireEvent.pointerEnter(dot, { clientX: 120, clientY: 80 });
+
+    const label = screen.getByText("body");
+    expect(label.classList.contains("port-dot-lbl")).toBe(true);
+    // the label must NOT be a descendant of the component's render subtree…
+    expect(container.contains(label)).toBe(false);
+    // …it is a direct child of <body>.
+    expect(label.parentElement).toBe(document.body);
+    expect(label.style.position).toBe("fixed");
+  });
+
   it("positions the floating label offset from the cursor and tracks it", () => {
     const { container } = render(
       <OutputPortDot id="body" side="right" index={0} total={1} />,

--- a/frontend/src/components/OutputPortDot.tsx
+++ b/frontend/src/components/OutputPortDot.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { createPortal } from "react-dom";
 import { Handle, Position } from "@xyflow/react";
 import type { PortSide } from "../types";
 
@@ -53,19 +54,26 @@ export default function OutputPortDot({
         onPointerMove={(e) => setCursor({ x: e.clientX, y: e.clientY })}
         onPointerLeave={() => setCursor(null)}
       />
-      {cursor && (
-        <span
-          className="port-dot-lbl"
-          style={{
-            position: "fixed",
-            left: cursor.x + LABEL_OFFSET_X,
-            top: cursor.y + LABEL_OFFSET_Y,
-            pointerEvents: "none",
-          }}
-        >
-          {id}
-        </span>
-      )}
+      {cursor &&
+        /* Portal to <body> so `position: fixed` resolves against the real
+         * viewport. Rendered inline, the label lives inside React Flow's
+         * `.react-flow__viewport`, whose pan/zoom `transform` becomes the
+         * containing block for fixed positioning and displaces/scales the
+         * label by the viewport matrix (#174). */
+        createPortal(
+          <span
+            className="port-dot-lbl"
+            style={{
+              position: "fixed",
+              left: cursor.x + LABEL_OFFSET_X,
+              top: cursor.y + LABEL_OFFSET_Y,
+              pointerEvents: "none",
+            }}
+          >
+            {id}
+          </span>,
+          document.body,
+        )}
     </>
   );
 }


### PR DESCRIPTION
## Summary

Fixes the output-port hover label landing far from the cursor/dot when the canvas pane is zoomed or panned.

The floating port-name label is now portalled to `document.body` via `createPortal`, taking it out of React Flow's transformed `.react-flow__viewport` subtree so `position: fixed` resolves against the real viewport instead of the transformed ancestor.

## Verification (visual, Pass)

- `tsc --noEmit`: no errors; `npm run build`: succeeds.
- Live repro driven via chrome-devtools-mcp against the running daemon:
  - Label paints at exactly `cursor + 12px` with **0 px** displacement at both fit zoom (0.967×) and 2.0× zoom.
  - Label is a direct child of `<body>` and no longer inside `.react-flow__viewport`.
  - Shows the human-readable port name; clears on leave.
- Under the bug, the rendered position was displaced by the viewport matrix (~277 px off at fit zoom, off-screen at 2.0×).

Also bumps version to 0.1.9.

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)