### PR TITLE
fix(canvas): render the selected edge pastel orange, others grey (#177)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1384,7 +1384,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "maestro-daemon"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/maestro-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "0.1.9"
+version = "0.1.10"
 license = "MIT"
 
 [workspace.dependencies]

--- a/frontend/src/components/OrthogonalEdge.test.tsx
+++ b/frontend/src/components/OrthogonalEdge.test.tsx
@@ -1,0 +1,97 @@
+import { render, act } from "@testing-library/react";
+import { describe, it, expect, afterEach } from "vitest";
+import { ReactFlowProvider } from "@xyflow/react";
+import OrthogonalEdge, { type OrthogonalEdgeData } from "./OrthogonalEdge";
+import { useEditStore } from "../stores/editStore";
+
+// OrthogonalEdge reads the selection from the global edit store (the same
+// source of truth the edge detail panel keys off). Reset it between tests so an
+// edge is never accidentally rendered "selected".
+afterEach(() => {
+  useEditStore.getState().setSelection({ kind: "none", id: null });
+});
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  return <ReactFlowProvider>{children}</ReactFlowProvider>;
+}
+
+function edgeProps(edgeIndex: number, data?: Partial<OrthogonalEdgeData>) {
+  return {
+    id: `e-${edgeIndex}`,
+    source: "a",
+    target: "b",
+    sourceX: 0,
+    sourceY: 0,
+    targetX: 100,
+    targetY: 0,
+    markerEnd: "",
+    data: {
+      edgeIndex,
+      mode: null,
+      waypoints: null,
+      isConditional: false,
+      isElse: false,
+      // Derivation now hands every edge the grey default; selection recolors it.
+      strokeColor: "var(--color-fg-4)",
+      dashed: false,
+      ...data,
+    },
+  } as unknown as Parameters<typeof OrthogonalEdge>[0];
+}
+
+// The visible stroke lives on xyflow's BaseEdge `<path class="react-flow__edge-path">`.
+function edgeStroke(container: HTMLElement): string {
+  const path = container.querySelector<SVGPathElement>(".react-flow__edge-path");
+  if (!path) throw new Error("edge path not found");
+  return path.style.stroke;
+}
+
+describe("OrthogonalEdge selection color (#177)", () => {
+  it("renders grey when no edge is selected", () => {
+    const { container } = render(<OrthogonalEdge {...edgeProps(0)} />, { wrapper: Wrapper });
+    expect(edgeStroke(container)).toContain("--color-fg-4");
+    expect(edgeStroke(container)).not.toContain("--color-edge-selected");
+  });
+
+  it("turns pastel orange when this edge is the selected one", () => {
+    const { container } = render(<OrthogonalEdge {...edgeProps(0)} />, { wrapper: Wrapper });
+    act(() => {
+      useEditStore.getState().setSelection({ kind: "edge", id: null, edgeIndex: 0 });
+    });
+    expect(edgeStroke(container)).toContain("--color-edge-selected");
+  });
+
+  it("restores grey when the edge is deselected", () => {
+    const { container } = render(<OrthogonalEdge {...edgeProps(0)} />, { wrapper: Wrapper });
+    act(() => {
+      useEditStore.getState().setSelection({ kind: "edge", id: null, edgeIndex: 0 });
+    });
+    expect(edgeStroke(container)).toContain("--color-edge-selected");
+    act(() => {
+      useEditStore.getState().setSelection({ kind: "none", id: null });
+    });
+    expect(edgeStroke(container)).toContain("--color-fg-4");
+    expect(edgeStroke(container)).not.toContain("--color-edge-selected");
+  });
+
+  it("only the selected edge is orange — a different selected index leaves this one grey", () => {
+    // The store holds at most one selection, so at most one edge is ever orange.
+    const { container } = render(<OrthogonalEdge {...edgeProps(0)} />, { wrapper: Wrapper });
+    act(() => {
+      useEditStore.getState().setSelection({ kind: "edge", id: null, edgeIndex: 3 });
+    });
+    expect(edgeStroke(container)).toContain("--color-fg-4");
+    expect(edgeStroke(container)).not.toContain("--color-edge-selected");
+  });
+
+  it("a selected conditional/end edge is orange too — selection overrides any base color", () => {
+    const { container } = render(
+      <OrthogonalEdge {...edgeProps(0, { isConditional: true, dashed: true })} />,
+      { wrapper: Wrapper },
+    );
+    act(() => {
+      useEditStore.getState().setSelection({ kind: "edge", id: null, edgeIndex: 0 });
+    });
+    expect(edgeStroke(container)).toContain("--color-edge-selected");
+  });
+});

--- a/frontend/src/components/OrthogonalEdge.tsx
+++ b/frontend/src/components/OrthogonalEdge.tsx
@@ -57,6 +57,13 @@ export default function OrthogonalEdge({
   data,
 }: EdgeProps<Edge<OrthogonalEdgeData>>) {
   const updateEdge = useEditStore((s) => s.updateEdge);
+  // Selection drives the stroke color (#177). The store is the source of truth
+  // the edge detail panel keys off, so reading it here (mirroring `EditNode`'s
+  // own `isSelected` derivation) keeps the orange stroke and the open panel in
+  // lockstep — and the store guarantees a single selection, so at most one edge
+  // is orange at a time. It survives edge re-derivation too, unlike xyflow's
+  // transient per-element `selected` flag, which is reset when edges are rebuilt.
+  const selection = useEditStore((s) => s.selection);
   const { screenToFlowPosition } = useReactFlow();
   const [hovered, setHovered] = useState(false);
 
@@ -167,7 +174,13 @@ export default function OrthogonalEdge({
     [edgeIndex, mode, waypoints, points.length, updateEdge],
   );
 
-  const strokeColor = data?.strokeColor ?? "var(--color-fg-4)";
+  // Pastel orange when this edge is the selected one, grey otherwise (#177).
+  // The override flows through to the condition pill border and segment handles
+  // below, which both read `strokeColor`, so the whole edge reads as selected.
+  const isSelected = selection.kind === "edge" && selection.edgeIndex === edgeIndex;
+  const strokeColor = isSelected
+    ? "var(--color-edge-selected, #fdba74)"
+    : data?.strokeColor ?? "var(--color-fg-4)";
 
   const labelPoint = points[Math.floor(points.length / 2)] ?? targetPt;
 
@@ -179,7 +192,7 @@ export default function OrthogonalEdge({
         markerEnd={markerEnd}
         style={{
           stroke: strokeColor,
-          strokeWidth: 1.5,
+          strokeWidth: isSelected ? 2.5 : 1.5,
           strokeDasharray: data?.dashed ? "6 3" : undefined,
         }}
       />

--- a/frontend/src/components/editNodeDerivation.ts
+++ b/frontend/src/components/editNodeDerivation.ts
@@ -399,11 +399,13 @@ export function deriveEditEdges(pipeline: PipelineDef): Edge<EditEdgeData>[] {
     const isConditional = isElse || hasWhen;
 
     const isDashed = isEndEdge;
-    const strokeColor = isDashed
-      ? "var(--color-st-blocked, #f97316)"
-      : isConditional
-        ? "var(--color-acc)"
-        : "var(--color-fg-4)";
+    // Edge stroke color is no longer keyed on type (#177): every edge renders
+    // grey by default and the *selected* edge is recolored to pastel orange
+    // dynamically in `OrthogonalEdge` (selection is the dominant visual signal,
+    // PRD #143 — the prior conditional-green / end-orange tinting is dropped).
+    // The dash pattern still distinguishes the end edge; that's a separate
+    // signal carried by `isDashed`, untouched here.
+    const strokeColor = "var(--color-fg-4)";
 
     const label = isElse
       ? "else"

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -68,6 +68,10 @@
   /* Edit-mode chrome */
   --color-edit-tint: #a78bfa;
 
+  /* Selected edge — pastel orange (#177). Selection is the dominant edge signal
+     (PRD #143): the selected edge is orange, every other edge is grey. */
+  --color-edge-selected: #fdba74;
+
   /* Typography */
   --font-sans: "Geist", ui-sans-serif, system-ui, -apple-system, sans-serif;
   --font-mono: "Geist Mono", ui-monospace, "JetBrains Mono", "SF Mono", Menlo, monospace;


### PR DESCRIPTION
## Summary

Fixes #177 — the selected edge now renders pastel orange (`#fdba74`) while all other edges render grey, dropping the previous per-type colour tinting.

- `OrthogonalEdge.tsx`: colour the selected edge pastel orange (2.5px), others grey (1.5px)
- `editNodeDerivation.ts`: drop per-type edge tinting
- `index.css`: selected-edge styling
- `OrthogonalEdge.test.tsx`: 5 unit tests covering selected/unselected/dashed states

## Verification

Verified in the running app via chrome-devtools MCP (Library → `review-loop` → editor, 6 edges):
- Baseline: all 6 edges grey `rgb(82,90,104)`
- Click an edge: stroke becomes `rgb(253,186,116)` (`#fdba74`), width 2.5px, `selected: true`
- Single-selection invariant holds — at most one orange edge at a time
- Deselect (click canvas): all edges back to grey

`tsc -b && vite build` clean; `vitest run` 5/5 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
