### PR TITLE
fix(canvas): anchor edge condition pill at the path's arc-length midpoint (#176)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1384,7 +1384,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "maestro-daemon"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/maestro-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "0.1.10"
+version = "0.1.11"
 license = "MIT"
 
 [workspace.dependencies]

--- a/frontend/src/components/OrthogonalEdge.tsx
+++ b/frontend/src/components/OrthogonalEdge.tsx
@@ -10,6 +10,7 @@ import {
 import { routeOrthogonal, type Point, type Rect } from "../lib/orthogonalRouter";
 import {
   pathToSvg,
+  pathMidpoint,
   segmentHandles,
   dragSegment,
   reanchorWaypoints,
@@ -182,7 +183,10 @@ export default function OrthogonalEdge({
     ? "var(--color-edge-selected, #fdba74)"
     : data?.strokeColor ?? "var(--color-fg-4)";
 
-  const labelPoint = points[Math.floor(points.length / 2)] ?? targetPt;
+  // Anchor the condition pill at the path's arc-length midpoint (#176) — the
+  // median vertex drifts off-center on unbalanced routes and stacks sibling
+  // pills on shared bends.
+  const labelPoint = pathMidpoint(points) ?? targetPt;
 
   return (
     <>

--- a/frontend/src/lib/edgePath.test.ts
+++ b/frontend/src/lib/edgePath.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   pathToSvg,
+  pathMidpoint,
   segmentHandles,
   dragSegment,
   reanchorWaypoints,
@@ -34,6 +35,78 @@ describe("pathToSvg", () => {
   it("returns an empty string for fewer than two points", () => {
     expect(pathToSvg([{ x: 1, y: 1 }])).toBe("");
     expect(pathToSvg([])).toBe("");
+  });
+});
+
+describe("pathMidpoint", () => {
+  it("returns the center of a straight two-point route", () => {
+    const pts: Point[] = [
+      { x: 0, y: 0 },
+      { x: 200, y: 0 },
+    ];
+    expect(pathMidpoint(pts)).toEqual({ x: 100, y: 0 });
+  });
+
+  it("lands on the long branch of an unbalanced L-route, not the corner", () => {
+    // 300px horizontal run then 60px vertical drop: total 360, half 180. The
+    // median vertex is the corner at (300, 0); the true midpoint is 180px along
+    // the horizontal branch.
+    const pts: Point[] = [
+      { x: 0, y: 0 },
+      { x: 300, y: 0 },
+      { x: 300, y: 60 },
+    ];
+    const mid = pathMidpoint(pts);
+    expect(mid).toEqual({ x: 180, y: 0 });
+    // Regression guard for #176: must NOT be the median vertex.
+    expect(mid).not.toEqual(pts[1]);
+  });
+
+  it("interpolates within the correct segment of a multi-waypoint route", () => {
+    // Manual route: 100 right, 80 down, 100 right. Total 280, half 140 — that
+    // is 40px into the vertical segment at x=100.
+    const pts: Point[] = [
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+      { x: 100, y: 80 },
+      { x: 200, y: 80 },
+    ];
+    expect(pathMidpoint(pts)).toEqual({ x: 100, y: 40 });
+  });
+
+  it("separates sibling edges whose median vertices coincide (#176 stacking)", () => {
+    // Two edges leaving the same node share bends, so their median vertices
+    // carry the same x and the pills stack. Their arc-length midpoints differ
+    // because the routes have different total lengths.
+    const shortRoute: Point[] = [
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+      { x: 100, y: 40 },
+      { x: 160, y: 40 },
+    ];
+    const longRoute: Point[] = [
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+      { x: 100, y: 200 },
+      { x: 400, y: 200 },
+    ];
+    // Median vertices coincide on the shared bend column...
+    expect(shortRoute[2].x).toBe(longRoute[2].x);
+    // ...but the arc-length midpoints do not.
+    expect(pathMidpoint(shortRoute)).not.toEqual(pathMidpoint(longRoute));
+  });
+
+  it("returns null for a degenerate path (< 2 points) so the caller can fall back", () => {
+    expect(pathMidpoint([])).toBeNull();
+    expect(pathMidpoint([{ x: 5, y: 5 }])).toBeNull();
+  });
+
+  it("handles coincident endpoints (zero total length) without dividing by zero", () => {
+    const pts: Point[] = [
+      { x: 10, y: 10 },
+      { x: 10, y: 10 },
+    ];
+    expect(pathMidpoint(pts)).toEqual({ x: 10, y: 10 });
   });
 });
 

--- a/frontend/src/lib/edgePath.ts
+++ b/frontend/src/lib/edgePath.ts
@@ -27,6 +27,43 @@ export function connectionPreviewPath(source: Point, target: Point): string {
   return pathToSvg(routeOrthogonal({ source, target, obstacles: [] }));
 }
 
+/**
+ * The point at half the polyline's total arc length (#176). This is where the
+ * condition pill is anchored: the median *vertex* (`points[len/2]`) ignores
+ * segment lengths entirely — on an unbalanced L-route it lands exactly on the
+ * corner, and sibling edges sharing bends stack their pills on the same vertex.
+ * Walking the segments to `totalLength / 2` centers the label on the visible
+ * stroke instead. Returns null for a degenerate path (< 2 points) so the
+ * caller can pick its own fallback.
+ */
+export function pathMidpoint(points: Point[]): Point | null {
+  if (points.length < 2) return null;
+
+  let totalLength = 0;
+  for (let i = 0; i < points.length - 1; i++) {
+    totalLength +=
+      Math.abs(points[i + 1].x - points[i].x) +
+      Math.abs(points[i + 1].y - points[i].y);
+  }
+  // All segments zero-length (endpoints coincide): any vertex is the midpoint.
+  if (totalLength === 0) return { ...points[0] };
+
+  let remaining = totalLength / 2;
+  for (let i = 0; i < points.length - 1; i++) {
+    const a = points[i];
+    const b = points[i + 1];
+    // Orthogonal segments: length is the Manhattan distance (one axis is 0).
+    const segLength = Math.abs(b.x - a.x) + Math.abs(b.y - a.y);
+    if (remaining <= segLength) {
+      const t = remaining / segLength;
+      return { x: a.x + (b.x - a.x) * t, y: a.y + (b.y - a.y) * t };
+    }
+    remaining -= segLength;
+  }
+  // Floating-point underrun past the last segment: clamp to the end.
+  return { ...points[points.length - 1] };
+}
+
 export type SegmentOrientation = "horizontal" | "vertical";
 
 export interface SegmentHandle {


### PR DESCRIPTION
## Summary
- Anchor the edge condition pill at the rendered path's arc-length midpoint (`pathMidpoint` in `frontend/src/lib/edgePath.ts`, used by `OrthogonalEdge.tsx`) instead of the median vertex.
- Fixes sibling condition pills stacking on the same vertex (e.g. `Verdict != Pass` and `Verdict = Pass` both anchored at the same point, masking each other).
- Bump version to 0.1.11.

## Validation
- Quantitative check on a live run with 9 orthogonal edges (4 conditional): offset between each pill anchor and `path.getPointAtLength(len/2)` is < 0.1 px (previously 14 to 137 px off).
- `tsc -b --noEmit` clean, `npm run build` clean, `vitest run src/lib/edgePath.test.ts`: 27 passed (incl. 6 new `pathMidpoint` tests).

Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)