### PR TITLE
fix(canvas): show edge segment handles only while the edge is selected (#178)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1384,7 +1384,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "maestro-daemon"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/maestro-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "0.1.11"
+version = "0.1.12"
 license = "MIT"
 
 [workspace.dependencies]

--- a/frontend/src/components/OrthogonalEdge.test.tsx
+++ b/frontend/src/components/OrthogonalEdge.test.tsx
@@ -1,8 +1,19 @@
-import { render, act } from "@testing-library/react";
-import { describe, it, expect, afterEach } from "vitest";
+import { render, act, fireEvent } from "@testing-library/react";
+import { describe, it, expect, afterEach, vi } from "vitest";
 import { ReactFlowProvider } from "@xyflow/react";
 import OrthogonalEdge, { type OrthogonalEdgeData } from "./OrthogonalEdge";
 import { useEditStore } from "../stores/editStore";
+
+// EdgeLabelRenderer portals into the `.react-flow__edgelabel-renderer` div of a
+// mounted <ReactFlow>, which doesn't exist under a bare provider. Render its
+// children inline instead so the segment handles land in the test container.
+vi.mock("@xyflow/react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@xyflow/react")>();
+  return {
+    ...actual,
+    EdgeLabelRenderer: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
 
 // OrthogonalEdge reads the selection from the global edit store (the same
 // source of truth the edge detail panel keys off). Reset it between tests so an
@@ -93,5 +104,80 @@ describe("OrthogonalEdge selection color (#177)", () => {
       useEditStore.getState().setSelection({ kind: "edge", id: null, edgeIndex: 0 });
     });
     expect(edgeStroke(container)).toContain("--color-edge-selected");
+  });
+});
+
+// Segment handles live in EdgeLabelRenderer as divs tagged
+// `edge-seg-handle-<edgeId>-<segmentIndex>`.
+function handleCount(container: HTMLElement): number {
+  return container.querySelectorAll('[data-testid^="edge-seg-handle-"]').length;
+}
+
+describe("OrthogonalEdge segment-handle visibility (#178)", () => {
+  it("renders no handles when the edge is not selected", () => {
+    const { container } = render(<OrthogonalEdge {...edgeProps(0)} />, { wrapper: Wrapper });
+    expect(handleCount(container)).toBe(0);
+  });
+
+  it("renders handles while the edge is selected, even without hover", () => {
+    const { container } = render(<OrthogonalEdge {...edgeProps(0)} />, { wrapper: Wrapper });
+    act(() => {
+      useEditStore.getState().setSelection({ kind: "edge", id: null, edgeIndex: 0 });
+    });
+    expect(handleCount(container)).toBeGreaterThan(0);
+  });
+
+  it("removes the handles immediately on deselect", () => {
+    const { container } = render(<OrthogonalEdge {...edgeProps(0)} />, { wrapper: Wrapper });
+    act(() => {
+      useEditStore.getState().setSelection({ kind: "edge", id: null, edgeIndex: 0 });
+    });
+    expect(handleCount(container)).toBeGreaterThan(0);
+    act(() => {
+      useEditStore.getState().setSelection({ kind: "none", id: null });
+    });
+    expect(handleCount(container)).toBe(0);
+  });
+
+  it("shows no handles on hover of an unselected edge", () => {
+    const { container } = render(<OrthogonalEdge {...edgeProps(0)} />, { wrapper: Wrapper });
+    const hit = container.querySelector('[data-testid="orthogonal-edge-hit-e-0"]');
+    if (!hit) throw new Error("hit path not found");
+    fireEvent.mouseEnter(hit);
+    expect(handleCount(container)).toBe(0);
+    // And nothing lingers after the mouse leaves either.
+    fireEvent.mouseLeave(hit);
+    expect(handleCount(container)).toBe(0);
+  });
+
+  it("hides handles on a deselected manual-mode edge", () => {
+    const { container } = render(
+      <OrthogonalEdge
+        {...edgeProps(0, { mode: "manual", waypoints: [{ x: 50, y: 40 }] })}
+      />,
+      { wrapper: Wrapper },
+    );
+    expect(handleCount(container)).toBe(0);
+  });
+
+  it("shows handles on a selected manual-mode edge", () => {
+    const { container } = render(
+      <OrthogonalEdge
+        {...edgeProps(0, { mode: "manual", waypoints: [{ x: 50, y: 40 }] })}
+      />,
+      { wrapper: Wrapper },
+    );
+    act(() => {
+      useEditStore.getState().setSelection({ kind: "edge", id: null, edgeIndex: 0 });
+    });
+    expect(handleCount(container)).toBeGreaterThan(0);
+  });
+
+  it("a different selected edge index keeps this edge's handles hidden", () => {
+    const { container } = render(<OrthogonalEdge {...edgeProps(0)} />, { wrapper: Wrapper });
+    act(() => {
+      useEditStore.getState().setSelection({ kind: "edge", id: null, edgeIndex: 3 });
+    });
+    expect(handleCount(container)).toBe(0);
   });
 });

--- a/frontend/src/components/OrthogonalEdge.tsx
+++ b/frontend/src/components/OrthogonalEdge.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, useCallback } from "react";
+import { useMemo, useCallback } from "react";
 import {
   BaseEdge,
   EdgeLabelRenderer,
@@ -41,9 +41,9 @@ export interface OrthogonalEdgeData extends Record<string, unknown> {
  * Orthogonal (right-angle) edge with manual-waypoint shaping (#154, design
  * screen 14). Auto edges pathfind around other nodes via `routeOrthogonal` and
  * re-route for free when a node moves (the path is recomputed every render from
- * live node positions). Hovering reveals perpendicular-only segment handles;
- * the first drag pins the route to persisted `manual` waypoints. The reset back
- * to auto lives in the edge detail panel.
+ * live node positions). Selecting the edge reveals perpendicular-only segment
+ * handles (#178); the first drag pins the route to persisted `manual`
+ * waypoints. The reset back to auto lives in the edge detail panel.
  */
 export default function OrthogonalEdge({
   id,
@@ -65,7 +65,6 @@ export default function OrthogonalEdge({
   // transient per-element `selected` flag, which is reset when edges are rebuilt.
   const selection = useEditStore((s) => s.selection);
   const { screenToFlowPosition } = useReactFlow();
-  const [hovered, setHovered] = useState(false);
 
   // Obstacle rects: every node except this edge's own source and target. Read
   // from the flow store so a node move re-renders the edge with fresh bounds.
@@ -196,15 +195,13 @@ export default function OrthogonalEdge({
           strokeDasharray: data?.dashed ? "6 3" : undefined,
         }}
       />
-      {/* Wide invisible hit area to make hover/handles forgiving. */}
+      {/* Wide invisible hit area to make click-to-select forgiving. */}
       <path
         d={d}
         fill="none"
         stroke="transparent"
         strokeWidth={14}
         style={{ pointerEvents: "stroke", cursor: "pointer" }}
-        onMouseEnter={() => setHovered(true)}
-        onMouseLeave={() => setHovered(false)}
         data-testid={`orthogonal-edge-hit-${id}`}
       />
       <EdgeLabelRenderer>
@@ -229,8 +226,10 @@ export default function OrthogonalEdge({
             {data.label}
           </div>
         )}
-        {/* Perpendicular-only segment handles, revealed on hover. */}
-        {(hovered || mode === "manual") &&
+        {/* Perpendicular-only segment handles, visible while the edge is
+            selected (#178) — never on mere hover, and gone on deselect even
+            for manual-mode edges. */}
+        {isSelected &&
           handles.map((h) => (
             <div
               key={h.segmentIndex}
@@ -238,7 +237,6 @@ export default function OrthogonalEdge({
               data-testid={`edge-seg-handle-${id}-${h.segmentIndex}`}
               onPointerDown={onHandleDrag(h.segmentIndex, h.orientation)}
               onContextMenu={onHandleDelete(h.segmentIndex)}
-              onMouseEnter={() => setHovered(true)}
               style={segHandleStyle(h.x, h.y, h.orientation, strokeColor)}
             />
           ))}


### PR DESCRIPTION
## Summary
- Edge segment direction handles were driven by `hovered || mode === "manual"`: they appeared on mere hover of an unselected edge, latched on after the mouse left (even intercepting clicks aimed at the edge hit path), vanished from a selected edge when the pointer moved away, and stuck permanently on manual-mode edges.
- Drive handle visibility purely from the store selection (the same derivation #177 introduced for the stroke) and drop the `hovered` latch; the wide hit path stays for click-to-select.
- Bump version to 0.1.12.

## Validation
- `npm run typecheck`, `npm run build`: clean.
- `npx vitest run src/components/OrthogonalEdge.test.tsx`: 12 passed, including 7 new `segment-handle visibility (#178)` tests.
- Visual repro via Playwright against a dev vite + daemon: all four repro symptoms gone (no handles on hover of unselected edge, no lingering handles intercepting clicks, handles persist on selected edge with mouse away, manual-mode edge drops handles on deselect).

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)