### PR TITLE
feat(version): wire footer version to the daemon's CARGO_PKG_VERSION (#139)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -722,6 +722,12 @@ Cf. ADR-0003.
 - Plus tard : formula Homebrew (macOS), package AUR (Arch).
 - Plus tard (v2) : wrapper Tauri pour distribution desktop native, qui réutilise le même daemon Rust + le même frontend.
 
+### Versioning (#139)
+
+- **Source de vérité unique** : le champ `version` du `Cargo.toml` workspace. C'est la seule version bumpée au release.
+- **`frontend/package.json` reste à `0.0.0`** en permanence : le frontend n'est pas un artefact distribué séparément — il est buildé puis embarqué dans le binaire du daemon au `cargo build`. Sa version npm n'a pas de sens et ne doit jamais être synchronisée.
+- **Exposition** : le daemon expose sa version compilée (`CARGO_PKG_VERSION`) dans le payload de `GET /sessions` (l'endpoint status-bar) ; le footer de l'UI l'affiche. Pas de décorrélation possible daemon/frontend en prod : c'est le même binaire. En dev, le footer montre la version du daemon debug réellement joignable.
+
 ### Mono-user, local
 
 Le daemon écoute sur `127.0.0.1:<port>` uniquement. Pas d'auth, pas de TLS, pas de multi-user. Single-user local par design. Tout ce qu'il faut pour ça : SQLite locale, FS local, tmux local, git local. Pas de dépendance réseau.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -722,6 +722,13 @@ Cf. ADR-0003.
 - Plus tard : formula Homebrew (macOS), package AUR (Arch).
 - Plus tard (v2) : wrapper Tauri pour distribution desktop native, qui réutilise le même daemon Rust + le même frontend.
 
+### Versioning (#139)
+
+- **Source de vérité unique : le `version` du `Cargo.toml` workspace.** `frontend/package.json` reste à `0.0.0` en permanence — intentionnel, ne jamais le bumper (le release flow ne touche que Cargo.toml).
+- Le daemon expose sa version compilée (`CARGO_PKG_VERSION`) dans la réponse de **`GET /sessions`** (`{ live, cap, version }`), l'endpoint qui alimente déjà la status-bar. Pas de route `GET /version` dédiée : un champ JSON additionnel est rétro-compatible et évite une entrée de plus dans la whitelist du proxy vite dev.
+- Le footer affiche `v<version>` à partir de ce payload, rafraîchi au mount et à chaque event WebSocket. Tant que le daemon n'a pas répondu, **rien n'est rendu** (pas de placeholder) ; le dot de connexion signale déjà l'injoignabilité.
+- En prod le binaire embarque le frontend, donc daemon et UI ne peuvent pas diverger. En dev le footer montre la version du daemon debug réellement joignable.
+
 ### Mono-user, local
 
 Le daemon écoute sur `127.0.0.1:<port>` uniquement. Pas d'auth, pas de TLS, pas de multi-user. Single-user local par design. Tout ce qu'il faut pour ça : SQLite locale, FS local, tmux local, git local. Pas de dépendance réseau.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1384,7 +1384,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "maestro-daemon"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/maestro-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "0.1.12"
+version = "0.1.13"
 license = "MIT"
 
 [workspace.dependencies]

--- a/crates/maestro-daemon/src/lib.rs
+++ b/crates/maestro-daemon/src/lib.rs
@@ -3300,13 +3300,19 @@ fn yaml_value_to_json(val: &serde_yaml::Value) -> serde_json::Value {
     }
 }
 
-/// `GET /sessions` — the live NodeRun-session count and the configured cap,
-/// for the bottom status-bar counter (admission control, #159). Manager
-/// sessions are excluded by construction (they are not nodes).
+/// `GET /sessions` — the live NodeRun-session count, the configured cap, and
+/// the daemon version, for the bottom status bar (admission control #159,
+/// version display #139). Manager sessions are excluded by construction (they
+/// are not nodes).
 async fn sessions(State(state): State<Arc<AppState>>) -> Response {
     let live = count_global_live_sessions(&state.db).await;
     let cap = admission::configured_cap();
-    Json(serde_json::json!({ "live": live, "cap": cap })).into_response()
+    Json(serde_json::json!({
+        "live": live,
+        "cap": cap,
+        "version": env!("CARGO_PKG_VERSION"),
+    }))
+    .into_response()
 }
 
 async fn list_runs(State(state): State<Arc<AppState>>) -> Response {
@@ -7358,6 +7364,11 @@ mod tests {
         assert!(
             json["cap"].as_u64().unwrap() >= 1,
             "cap should be a positive integer"
+        );
+        assert_eq!(
+            json["version"],
+            env!("CARGO_PKG_VERSION"),
+            "the status-bar payload carries the daemon version (#139)"
         );
     }
 

--- a/crates/maestro-daemon/src/lib.rs
+++ b/crates/maestro-daemon/src/lib.rs
@@ -102,6 +102,12 @@ struct AppState {
     repo_root: PathBuf,
     port: u16,
     merge_lock: tokio::sync::Mutex<()>,
+    /// Serializes Trigger scheduler ticks. A tick is read-decide-write
+    /// (`due_triggers` → guard subprocess → `set_next_fire`) with an await on
+    /// the guard in the middle; two concurrent ticks (the 30 s background loop
+    /// and the `run_trigger_tick` test seam) can otherwise both see the same
+    /// Trigger as due and double-fire it.
+    trigger_tick_lock: tokio::sync::Mutex<()>,
     /// Paths the daemon has just written. The pipeline watcher consults this map
     /// and suppresses `pipeline_changed` broadcasts for paths it sees within the
     /// TTL window — that's how we tell our own writes apart from external ones
@@ -418,6 +424,7 @@ pub async fn serve_with_config(
         repo_root,
         port: bound_addr.port(),
         merge_lock: tokio::sync::Mutex::new(()),
+        trigger_tick_lock: tokio::sync::Mutex::new(()),
         recent_writes,
         run_watcher: run_watcher.clone(),
         tmux_cmd_override: config.tmux_cmd_override,
@@ -1417,6 +1424,8 @@ fn trigger_guard_cwd(state: &AppState, trigger: &trigger_store::Trigger) -> Path
 /// Run one scheduler tick: fire every due Trigger that the decision admits,
 /// recording every significant outcome and recomputing each next fire.
 async fn run_trigger_scheduler_tick(state: &AppState) {
+    // At most one tick in flight: see `AppState::trigger_tick_lock`.
+    let _tick = state.trigger_tick_lock.lock().await;
     let now_str = event_log::now_iso();
     let due = match trigger_store::due_triggers(&state.db, &now_str).await {
         Ok(t) => t,
@@ -7221,6 +7230,7 @@ mod tests {
             repo_root: std::env::current_dir().unwrap(),
             port: 0,
             merge_lock: tokio::sync::Mutex::new(()),
+            trigger_tick_lock: tokio::sync::Mutex::new(()),
             recent_writes: Arc::new(Mutex::new(HashMap::new())),
             run_watcher: Arc::new(Mutex::new(None)),
             // Self-destructing no-op: should any test POST /runs and reach the
@@ -8634,6 +8644,7 @@ mod tests {
             repo_root: dir.to_path_buf(),
             port: 0,
             merge_lock: tokio::sync::Mutex::new(()),
+            trigger_tick_lock: tokio::sync::Mutex::new(()),
             recent_writes: Arc::new(Mutex::new(HashMap::new())),
             run_watcher: Arc::new(Mutex::new(None)),
             // Self-destructing no-op: should any test POST /runs and reach the
@@ -11270,6 +11281,7 @@ edges: []
             repo_root: repo.clone(),
             port: 0,
             merge_lock: tokio::sync::Mutex::new(()),
+            trigger_tick_lock: tokio::sync::Mutex::new(()),
             recent_writes: Arc::new(Mutex::new(HashMap::new())),
             run_watcher: Arc::new(Mutex::new(None)),
             // Self-destructing no-op: should any test POST /runs and reach the
@@ -11441,6 +11453,7 @@ edges: []
             repo_root: repo.clone(),
             port: 0,
             merge_lock: tokio::sync::Mutex::new(()),
+            trigger_tick_lock: tokio::sync::Mutex::new(()),
             recent_writes: Arc::new(Mutex::new(HashMap::new())),
             run_watcher: Arc::new(Mutex::new(None)),
             // Self-destructing no-op: should any test POST /runs and reach the

--- a/crates/maestro-daemon/tests/smoke_daemon.rs
+++ b/crates/maestro-daemon/tests/smoke_daemon.rs
@@ -21,6 +21,22 @@ async fn runs_endpoint_returns_empty_array_on_fresh_daemon() {
 }
 
 #[tokio::test]
+async fn sessions_endpoint_reports_daemon_version() {
+    // The footer reads the daemon version from `GET /sessions` (#139). The
+    // integration test crate compiles with the same package version, so
+    // strict equality against CARGO_PKG_VERSION is valid.
+    let daemon = TestDaemon::spawn(|_repo_root| Ok(())).await.unwrap();
+
+    let resp = reqwest::get(format!("{}/sessions", daemon.url()))
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 200);
+    let json: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(json["version"].as_str(), Some(env!("CARGO_PKG_VERSION")));
+}
+
+#[tokio::test]
 async fn ws_emits_ready_on_connect() {
     let daemon = TestDaemon::spawn(|_repo_root| Ok(())).await.unwrap();
 

--- a/crates/maestro-daemon/tests/trigger_scheduler.rs
+++ b/crates/maestro-daemon/tests/trigger_scheduler.rs
@@ -324,6 +324,44 @@ async fn guard_exit_zero_fires_with_stdout_as_input() {
 }
 
 #[tokio::test]
+async fn concurrent_ticks_fire_a_due_trigger_exactly_once() {
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+
+    // The guard sleeps long enough that a second tick starting mid-guard would
+    // also read the trigger as due (next_fire is only recomputed after the
+    // guard returns) and double-fire it — the race between the 30 s background
+    // loop and the test seam that made `guard_exit_zero_fires_with_stdout_as_input`
+    // flake under full-suite load. Ticks must serialize. The yearly cron keeps
+    // the recomputed next fire far away, so the second tick can't be
+    // legitimately due again. Keep the sleep under the 200 ms guard-timeout
+    // override that `guard_timeout_records_guard_error_and_skips` sets
+    // process-wide (std::env is shared across parallel tests).
+    let trigger = create_trigger_with_guard(
+        &daemon,
+        "racer",
+        "0 0 1 1 *",
+        "sleep 0.15; printf 'issue-7'",
+    )
+    .await;
+    let trigger_id = trigger["id"].as_str().unwrap().to_string();
+
+    daemon.force_trigger_due(&trigger_id).await;
+    tokio::join!(daemon.run_trigger_tick(), daemon.run_trigger_tick());
+
+    let runs = list_runs(&daemon).await;
+    assert_eq!(runs.len(), 1, "concurrent ticks must not double-fire");
+
+    let fired = list_fires(&daemon, &trigger_id)
+        .await
+        .iter()
+        .filter(|f| f["outcome"].as_str() == Some("fired"))
+        .count();
+    assert_eq!(fired, 1, "exactly one 'fired' record");
+
+    cleanup_runs(&daemon).await;
+}
+
+#[tokio::test]
 async fn guard_exit_nonzero_skips_without_firing() {
     let daemon = TestDaemon::spawn(seed).await.unwrap();
 

--- a/docs/testing/scenarios/daemon-version-display.md
+++ b/docs/testing/scenarios/daemon-version-display.md
@@ -1,0 +1,98 @@
+# Scenario — `daemon-version-display`
+
+> Layer 5 (agentic) per ADR 0004. Manual trigger: an agent executes the steps
+> below and emits the verdict format at the bottom. Asserts that the daemon
+> exposes its compiled version (`CARGO_PKG_VERSION`) on `GET /sessions` and
+> that the UI footer displays that live version instead of the historical
+> hardcoded `v0.1.0` (#139).
+
+## Setup
+
+- Daemon running and built **from the source tree under test** (`maestro daemon`,
+  or `cargo run -p maestro-daemon` with `MAESTRO_SKIP_FRONTEND_BUILD` unset so
+  the embedded frontend is current). Daemon URL defaults to
+  `http://127.0.0.1:5172`; honor `MAESTRO_PORT` if set.
+- Frontend reachable in a browser. Chrome DevTools MCP preferred; Playwright
+  MCP works as a fallback.
+- `curl` and `jq` on PATH.
+- Record the expected version up front:
+  `EXPECTED=$(grep -m1 '^version' Cargo.toml | cut -d'"' -f2)` from the repo
+  root of the tree the daemon was built from.
+
+## Steps the agent executes
+
+### Step 1 — `GET /sessions` carries the daemon version (refs #139)
+
+1. `curl -sf http://127.0.0.1:5172/sessions | jq .`
+2. Assert HTTP status is **200** and the body is a JSON object.
+3. Assert the object still has numeric `live` and `cap` fields (regression:
+   the status-bar counter payload must be intact).
+4. Assert it has a string `version` field matching `^\d+\.\d+\.\d+`.
+5. Assert `version` equals `$EXPECTED` (the Cargo.toml workspace version of
+   the tree the daemon was built from). If the running daemon was *not* built
+   from this tree, report that as an anomaly and keep only assertions 1–4.
+
+### Step 2 — Footer displays the endpoint's version (refs #139)
+
+1. Open the UI in the browser. Confirm the footer (bottom status bar) shows
+   the daemon connection dot and the session counter.
+2. Assert the footer contains the exact text `v<version>` where `<version>`
+   is the value returned in Step 1 — character-for-character equality, not
+   just a semver-shaped string.
+3. Assert the footer does **not** contain `v0.1.0`, *unless* Step 1 itself
+   returned `0.1.0` (the assertion that matters is endpoint↔footer equality).
+4. Take a screenshot of the footer as evidence.
+
+### Step 3 — Version survives reload and stays consistent
+
+1. Reload the page.
+2. Assert the footer shows the same `v<version>` after reload.
+3. Re-run the Step 1 `curl` and assert the response is unchanged.
+
+### Step 4 — Unknown version renders nothing, not a lie
+
+1. With the daemon **stopped** (only do this if you started the daemon
+   yourself for this scenario — never stop a user's live daemon; otherwise
+   skip and note it), load the UI from a separately served frontend (e.g.
+   vite dev server) so the page itself still loads.
+2. Assert the footer shows **no version string at all** (no `v0.1.0`, no
+   placeholder) while the daemon is unreachable, and that the connection
+   label reads `Daemon: disconnected`.
+3. Restart the daemon; after the WebSocket reconnects, assert the version
+   reappears in the footer **without a manual page reload** (the sessions
+   payload is re-fetched on WS events).
+
+## Negative checks
+
+- `grep -rn "v0\.1\.0" frontend/src/` returns no matches (the hardcoded
+  literal is gone from source).
+- `frontend/package.json` still says `"version": "0.0.0"` (it must NOT have
+  been bumped — Cargo.toml is the single source of truth).
+- `frontend/vite.config.ts` proxy whitelist is unchanged (no `/version`
+  entry was needed; the field rides on the already-proxied `/sessions`).
+
+## Cleanup
+
+- If you started a daemon for this scenario, stop it. Close browser pages you
+  opened. Nothing else: the scenario is read-only.
+
+## Verdict format
+
+```json
+{
+  "verdict": "PASS" | "FAIL",
+  "evidence": [
+    "step 1: /sessions returns 200 with live, cap and version=<X.Y.Z>",
+    "step 1: version equals Cargo.toml workspace version",
+    "step 2: footer displays v<X.Y.Z>, identical to the endpoint value",
+    "step 3: value stable across reload",
+    "step 4: no version rendered while daemon down; reappears on reconnect",
+    "negative: no hardcoded v0.1.0 in frontend/src; package.json still 0.0.0"
+  ],
+  "anomalies": [
+    "<optional — surprising-but-non-fatal observations, e.g. daemon not built from this tree>"
+  ]
+}
+```
+
+A single failed assertion ⇒ `verdict: "FAIL"`. Don't half-pass.

--- a/frontend/e2e/footer-version.spec.ts
+++ b/frontend/e2e/footer-version.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from "@playwright/test";
+
+// Layer 3b (testing pyramid per ADR 0004). The footer version must mirror the
+// daemon's compiled version exposed on GET /sessions (#139) — the assertion
+// that matters is endpoint↔footer equality, not any specific literal.
+
+test("footer displays the daemon version from GET /sessions", async ({ page }) => {
+  const resp = await page.request.get("/sessions");
+  expect(resp.status()).toBe(200);
+  const body = await resp.json();
+  const version: string = body.version;
+  expect(version).toMatch(/^\d+\.\d+\.\d+/);
+
+  await page.goto("/");
+
+  const footer = page.locator("footer");
+  await expect(footer.getByText(`v${version}`, { exact: true })).toBeVisible({
+    timeout: 10_000,
+  });
+
+  // Guard against the historical hardcoded literal resurfacing — unless the
+  // daemon genuinely runs 0.1.0, in which case the equality check above
+  // already covered it.
+  if (version !== "0.1.0") {
+    await expect(footer.getByText("v0.1.0", { exact: true })).toHaveCount(0);
+  }
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,7 +6,7 @@ import { useLibrary } from "./hooks/useLibrary";
 import { useLibraryPipelines } from "./hooks/useLibraryPipelines";
 import { fetchRuns, fetchRun, fetchTriggers, fetchSessions } from "./api";
 import { pickLatestLiveNode } from "./lib/pickLatestLiveNode";
-import type { RunListEntry, RunState, Trigger, SessionCount } from "./types";
+import type { RunListEntry, RunState, Trigger, DaemonStatus } from "./types";
 import SessionCounter from "./components/SessionCounter";
 import UnifiedLeftPanel from "./components/UnifiedLeftPanel";
 import NodeDetailPanel from "./components/NodeDetailPanel";
@@ -63,7 +63,7 @@ function useRuns() {
 }
 
 function useSessions() {
-  const [sessions, setSessions] = useState<SessionCount>({ live: 0, cap: 0 });
+  const [sessions, setSessions] = useState<DaemonStatus>({ live: 0, cap: 0 });
 
   const refresh = useCallback(async () => {
     try {
@@ -723,7 +723,7 @@ function StatusBar({
   sessions,
 }: {
   status: ConnectionStatus;
-  sessions: SessionCount;
+  sessions: DaemonStatus;
 }) {
   const { dot: dotClass, label } = STATUS_CONFIG[status];
 
@@ -738,7 +738,7 @@ function StatusBar({
       </span>
       <span className="flex-1" />
       <SessionCounter live={sessions.live} cap={sessions.cap} />
-      <span>v0.1.0</span>
+      {sessions.version && <span>v{sessions.version}</span>}
     </footer>
   );
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -284,6 +284,16 @@ export default function App() {
     }
   }, [refreshRuns, refreshSessions, refreshTriggers]);
 
+  // A WS reconnect usually means the daemon restarted — possibly as a different
+  // binary, so the /sessions payload (version included, #139) may be stale. An
+  // idle daemon emits no event afterwards, so the subscribe-side refresh never
+  // fires; re-fetch on every transition to "connected".
+  useEffect(() => {
+    if (status === "connected") {
+      refreshSessions();
+    }
+  }, [status, refreshSessions]);
+
   // On a live run with nothing selected, snap selection to the latest
   // running (or awaiting_user) node so the user immediately sees its terminal.
   // Re-fires whenever the user deselects on a still-live run.

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,4 +1,4 @@
-import type { PipelineListEntry, PipelineDetail, PipelineDef, RunListEntry, RunState, PortDef, PortSide, PortType, FrontmatterFieldDecl, Trigger, TriggerFire, SessionCount } from "./types";
+import type { PipelineListEntry, PipelineDetail, PipelineDef, RunListEntry, RunState, PortDef, PortSide, PortType, FrontmatterFieldDecl, Trigger, TriggerFire, DaemonStatus } from "./types";
 
 const BASE = "";
 
@@ -18,7 +18,7 @@ export async function fetchRuns(): Promise<RunListEntry[]> {
   return resp.json();
 }
 
-export async function fetchSessions(): Promise<SessionCount> {
+export async function fetchSessions(): Promise<DaemonStatus> {
   const resp = await fetch(`${BASE}/sessions`);
   if (!resp.ok) throw new Error(`GET /sessions failed: ${resp.status}`);
   return resp.json();

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -6,12 +6,14 @@ export function isLiveRun(status: RunStatus): boolean {
 }
 
 /**
- * Live NodeRun-session count and the configured global cap, for the bottom
- * status-bar counter (#159 / ADR-0012). Manager sessions are excluded.
+ * Live NodeRun-session count, the configured global cap, and the daemon
+ * version, for the bottom status bar (#159 / ADR-0012, #139). Manager
+ * sessions are excluded. `version` is absent until the daemon has responded.
  */
-export interface SessionCount {
+export interface DaemonStatus {
   live: number;
   cap: number;
+  version?: string;
 }
 // `for-each` was removed (ADR-0011 / #151): a fan-out is now a `collection`
 // loop region, not a node. The backend keeps the variant only to migrate old


### PR DESCRIPTION
Closes #139

## Contenu

- **#139 — version du footer câblée sur le daemon** : `GET /sessions` expose `version` (`CARGO_PKG_VERSION`) en plus de `live`/`cap` ; le footer affiche `v<version>` depuis ce payload (rien tant que le daemon n'a pas répondu). Pas de nouvelle route, donc pas d'entrée proxy vite. `frontend/package.json` reste à `0.0.0` — Cargo.toml est l'unique source de vérité (décision documentée dans CONTEXT.md).
- **fix(ui)** : re-fetch de `/sessions` à chaque reconnexion WS — sans ça, après un restart du daemon avec UI ouverte et daemon idle, le footer restait sur l'état initial (pas de version, cap 0) jusqu'au reload. Trouvé par le scénario agentique (step 4.3).
- **fix(triggers)** : sérialisation des ticks du scheduler de triggers (mutex) — deux ticks concurrents (boucle 30 s + seam de test) pouvaient double-tirer un trigger « due » ; c'était la cause du flake de `guard_exit_zero_fires_with_stdout_as_input`. Test de régression inclus.
- **chore(release)** : bump workspace `0.1.12 → 0.1.13`.
- Scénario Layer 5 `docs/testing/scenarios/daemon-version-display.md` + e2e `footer-version.spec.ts`.

## Validation

- `cargo test` workspace : 956 verts (par l'implementer, pré-merge) ; vitest 768/768 et `tsc --noEmit` re-passés post-fix reconnexion.
- Scénario agentique exécuté en conditions réelles (daemon isolé port 6199 buildé depuis cet arbre, UI via Playwright) : 4 steps + checks négatifs verts, captures dans le Blackboard du run `20260610-140021-e182bb5`.
- Gap connu : pas d'e2e automatisé du cas reconnexion (le harnais Playwright gère le daemon en `webServer` unique, restart mid-spec impossible proprement).

## Contexte run

Produit par le run Maestro `20260610-140021-e182bb5` (pipeline auto-issue-implement), consolidé manuellement par le Pipeline Manager après les stalls scheduler documentés dans #201 et #206.

🤖 Generated with [Claude Code](https://claude.com/claude-code)