### PR TITLE
fix(canvas): anchor edges where dropped on connection-create (#219)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1688,7 +1688,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "0.1.15"
+version = "0.1.16"
 license = "MIT"
 
 [workspace.dependencies]

--- a/frontend/src/components/EditCanvas.tsx
+++ b/frontend/src/components/EditCanvas.tsx
@@ -404,7 +404,7 @@ function EditCanvasInner({ libraryEntries, libraryPipelines, onLibraryDelete, on
 
   const onConnectStart = useCallback(() => setIsDraggingEdge(true), []);
   const onConnectEnd = useCallback(
-    (_event: MouseEvent | TouchEvent, connectionState: FinalConnectionState) => {
+    (event: MouseEvent | TouchEvent, connectionState: FinalConnectionState) => {
       setIsDraggingEdge(false);
       setHoveredNodeId(null);
 
@@ -417,13 +417,22 @@ function EditCanvasInner({ libraryEntries, libraryPipelines, onLibraryDelete, on
       if (edgeIndex == null) return;
 
       const toNode = connectionState.toNode;
-      const drop = connectionState.to;
-      if (!toNode || !drop) return;
+      if (!toNode) return;
       const targetDef = pipeline?.nodes.find((n) => n.id === toNode.id);
       // Declared-port nodes (End's `result`) and structural nodes (merge) keep
       // their declared, fixed-side handle — never re-anchor those. Keyed on node
       // TYPE: a work node carrying a vestigial declared `in` still anchors (#175).
       if (!targetDef || !isEmergentInputNode(targetDef.type)) return;
+
+      // Where the user actually released, in FLOW coordinates. We read the raw
+      // pointer (not `connectionState.to`, which xyflow snaps to a handle centre)
+      // and convert it with `screenToFlowPosition` so it shares the target rect's
+      // coordinate space. The #219 bug compared `connectionState.to` (rendered px,
+      // zoom/pan-scaled) against a rect built from flow units, so `chooseAnchorSide`
+      // got mismatched spaces and the arrow landed on the wrong side.
+      const pointer = "changedTouches" in event ? event.changedTouches[0] : event;
+      if (!pointer) return;
+      const drop = reactFlow.screenToFlowPosition({ x: pointer.clientX, y: pointer.clientY });
 
       const rect = {
         x: toNode.internals.positionAbsolute.x,
@@ -438,7 +447,7 @@ function EditCanvasInner({ libraryEntries, libraryPipelines, onLibraryDelete, on
       if (side === "left") return;
       updateEdge(edgeIndex, { target_side: side });
     },
-    [pipeline, updateEdge],
+    [pipeline, reactFlow, updateEdge],
   );
   const onNodeMouseEnter = useCallback((_: ReactMouseEvent, node: Node) => setHoveredNodeId(node.id), []);
   const onNodeMouseLeave = useCallback(() => setHoveredNodeId(null), []);

--- a/frontend/src/lib/anchorSide.test.ts
+++ b/frontend/src/lib/anchorSide.test.ts
@@ -26,6 +26,53 @@ describe("chooseAnchorSide", () => {
   it("anchors bottom when the drop is near the bottom edge", () => {
     expect(chooseAnchorSide({ x: 200, y: 188 }, RECT)).toBe("bottom");
   });
+
+  it("keeps the legacy left default for a dead-centre drop", () => {
+    expect(chooseAnchorSide({ x: 200, y: 140 }, RECT)).toBe("left");
+  });
+
+  it("anchors by the side the drop lands on INSIDE the body, not only outside it", () => {
+    // The reporter drops on the node body (#219), not just past its edges.
+    expect(chooseAnchorSide({ x: 120, y: 140 }, RECT)).toBe("left"); // left interior
+    expect(chooseAnchorSide({ x: 280, y: 140 }, RECT)).toBe("right"); // right interior
+    expect(chooseAnchorSide({ x: 200, y: 110 }, RECT)).toBe("top"); // upper interior
+    expect(chooseAnchorSide({ x: 200, y: 170 }, RECT)).toBe("bottom"); // lower interior
+  });
+});
+
+describe("chooseAnchorSide — short, wide card (#219 regression)", () => {
+  // The default work node is short and wide (~160x35). The old
+  // perpendicular-distance-to-each-edge metric mis-resolved interior drops here:
+  // because the card is so short, almost any body drop sat nearer the top/bottom
+  // edges and spuriously anchored top/bottom. Normalising by half-extents fixes it.
+  const WIDE = { x: 0, y: 0, width: 160, height: 35 };
+
+  it("anchors LEFT for a drop in the left portion of the body (not top/bottom)", () => {
+    // Vertically centred, ~25% across. Old metric: top/bottom (17.5) beat left (40).
+    expect(chooseAnchorSide({ x: 40, y: 17 }, WIDE)).toBe("left");
+  });
+
+  it("anchors RIGHT for a drop in the right portion of the body (not top/bottom)", () => {
+    expect(chooseAnchorSide({ x: 130, y: 18 }, WIDE)).toBe("right");
+  });
+
+  it("keeps left as the centre default on a wide card (no spurious top/bottom)", () => {
+    expect(chooseAnchorSide({ x: 80, y: 17.5 }, WIDE)).toBe("left");
+  });
+
+  it("still anchors TOP when the drop genuinely aims at the top edge", () => {
+    expect(chooseAnchorSide({ x: 80, y: 2 }, WIDE)).toBe("top");
+  });
+
+  it("still anchors BOTTOM when the drop genuinely aims at the bottom edge", () => {
+    expect(chooseAnchorSide({ x: 80, y: 33 }, WIDE)).toBe("bottom");
+  });
+
+  it("prefers the horizontal side near a wide card's corner (aspect-ratio-aware)", () => {
+    // Near the bottom-right corner of a wide card the user is aiming at the long
+    // right side, not the short bottom one: |dx| (0.875) > |dy| (0.71) -> right.
+    expect(chooseAnchorSide({ x: 150, y: 30 }, WIDE)).toBe("right");
+  });
 });
 
 describe("anchorHandleId / sideFromAnchorHandle round-trip", () => {

--- a/frontend/src/lib/anchorSide.ts
+++ b/frontend/src/lib/anchorSide.ts
@@ -62,40 +62,41 @@ export function anchorsByDropOnBody(handleId: string | null | undefined): boolea
 /**
  * Chooses the side of a target card nearest a drop point (issue #168). When an
  * edge is dropped on a node's body (emergent input, ADR-0011 / #149), the
- * incoming arrow anchors on the side closest to where the user released — not
- * always the left. The decided rule: the side of the target card nearest the
- * drop point.
+ * incoming arrow anchors on the side the user aimed at — "the arrow goes where
+ * you drop it" (#219) — not always the left.
  *
- * The drop point may land inside the card or anywhere around it; we compare the
- * perpendicular distance to each of the four edges and pick the smallest. Ties
- * (equidistant edges) resolve in left, right, top, bottom order, so left wins
- * over right and the horizontal sides win over the vertical ones. (The overall
- * legacy left default is preserved by the caller, which persists a chosen side
- * only when it is NOT left — see `EditCanvas.onConnectEnd`.)
+ * The rule is the side a ray from the card centre through the drop point would
+ * exit: split the card into four triangular sectors by its diagonals and pick
+ * the sector the drop falls in. We measure the drop's offset from the centre
+ * NORMALISED by each half-extent, so the choice is aspect-ratio-aware.
+ *
+ * The earlier perpendicular-distance-to-each-edge metric (#219) was wrong on a
+ * non-square card: the default work node is short and wide (~160x35), so nearly
+ * any interior drop sits closer to the top/bottom edges than to the left/right
+ * ones and spuriously anchored top/bottom. Normalising by the half-extents
+ * removes that bias — a drop in the left third of a wide card resolves to left,
+ * not top.
+ *
+ * Ties resolve in left, right, top, bottom order: horizontal sides win over
+ * vertical ones (`|dx| >= |dy|`) and left wins over right (`dx <= 0`), so a
+ * dead-centre drop keeps the legacy left default. (That default is also enforced
+ * by the caller, which persists a chosen side only when it is NOT left — see
+ * `EditCanvas.onConnectEnd`.)
  */
 export function chooseAnchorSide(
   drop: { x: number; y: number },
   rect: AnchorRect,
 ): PortSide {
-  const left = Math.abs(drop.x - rect.x);
-  const right = Math.abs(drop.x - (rect.x + rect.width));
-  const top = Math.abs(drop.y - rect.y);
-  const bottom = Math.abs(drop.y - (rect.y + rect.height));
+  const halfW = rect.width / 2;
+  const halfH = rect.height / 2;
+  const cx = rect.x + halfW;
+  const cy = rect.y + halfH;
+  // Direction from the centre to the drop, scaled to the card's own aspect ratio.
+  const dx = halfW > 0 ? (drop.x - cx) / halfW : 0;
+  const dy = halfH > 0 ? (drop.y - cy) / halfH : 0;
 
-  // Ties resolve in left, right, top, bottom order (strict `<`), keeping the
-  // legacy left default stable for a centred drop.
-  let best: PortSide = "left";
-  let bestDist = left;
-  if (right < bestDist) {
-    best = "right";
-    bestDist = right;
+  if (Math.abs(dx) >= Math.abs(dy)) {
+    return dx > 0 ? "right" : "left";
   }
-  if (top < bestDist) {
-    best = "top";
-    bestDist = top;
-  }
-  if (bottom < bestDist) {
-    best = "bottom";
-  }
-  return best;
+  return dy > 0 ? "bottom" : "top";
 }


### PR DESCRIPTION
## What

Fixes the edge-anchor bug on connection-creation: new edges ignored the drop point and almost always landed on the **left** side; top/bottom were unreachable.

Two compounding defects (both confirmed by runtime debugging):

1. **Coordinate-space mismatch** in `EditCanvas.onConnectEnd` — the drop point (`connectionState.to`) was in rendered/pane pixels (zoom/pan-scaled) while the target rect was in flow units, so `chooseAnchorSide` compared incompatible spaces. Fixed by reading the raw release pointer and converting with `screenToFlowPosition`.
2. **`chooseAnchorSide`** used perpendicular edge distance, which mis-resolves on the short/wide default work node (~160×35). Replaced with an aspect-ratio-aware sector test, preserving the `left > right > top > bottom` tie order.

## Verification

- `tsc -b` clean, `vite build` OK, `vitest run src/lib/anchorSide.test.ts` → 16 passed (incl. the #219 regression block).
- Live browser repro (Visual tester node, Verdict: **Pass**): drops on right/top/bottom/left each anchored where released, confirmed via persisted `target_side`, rendered geometry, and screenshots.

Also bumps the workspace version to **0.1.16**.

Closes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)