### PR TITLE
fix(pipeline): run-scoped sync writes prompts to canonical dir, not flat prompts/ (#231)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1688,7 +1688,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "0.1.18"
+version = "0.1.19"
 license = "MIT"
 
 [workspace.dependencies]

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -446,6 +446,26 @@ pub async fn serve_with_config(
 
     init_db(&db).await?;
 
+    // #231: one-shot migration of prompts stranded in the flat
+    // `<repo>/.pdo/pipelines/prompts/` dir by the old run-scoped sync into each
+    // pipeline's canonical `<stem>.prompts/` dir. Runs before the file watcher
+    // attaches so the moves don't surface as spurious pipeline-modified events.
+    // A pure filesystem fix-up — unrelated to tmux, so it is not gated on
+    // `nested_daemon`. Scoped to the repo store (where the bug stranded prompts,
+    // and what the daemon owns); the writer fix + readers are store-agnostic, so
+    // any user-store pipeline self-heals on its next save.
+    {
+        let repo_pipelines = repo_root.join(".pdo").join("pipelines");
+        match pipeline_migrator::migrate_stranded_flat_prompts(&repo_pipelines) {
+            Ok(n) if n > 0 => info!(
+                "#231 migration: moved {n} stranded prompt(s) in {}",
+                repo_pipelines.display()
+            ),
+            Ok(_) => {}
+            Err(e) => warn!("#231 migration failed: {e}"),
+        }
+    }
+
     let (event_tx, _) = broadcast::channel::<event_log::Event>(256);
     let (pipeline_tx, _) = broadcast::channel::<serde_json::Value>(64);
 
@@ -4235,12 +4255,11 @@ fn sync_run_pipeline_to_template(
         return;
     }
 
-    let template_prompts_dir = template_path
-        .parent()
-        .unwrap_or(&state.repo_root)
-        .join("prompts");
+    // #231: write each prompt to the canonical `<dir>/<stem>.prompts/<id>.md`
+    // location every reader consults — NOT a flat `<dir>/prompts/<id>.md` dir
+    // (which no reader looks in, silently swallowing run-scoped prompt edits).
     for (node_id, content) in prompts {
-        let prompt_path = template_prompts_dir.join(format!("{node_id}.md"));
+        let prompt_path = pipeline::canonical_prompt_path(&template_path, node_id);
         if let Some(parent) = prompt_path.parent() {
             let _ = std::fs::create_dir_all(parent);
         }
@@ -10017,6 +10036,40 @@ mod tests {
             "name: {name}\nversion: \"1.0\"\nnodes:\n{START_END_YAML}  - id: worker\n    name: worker\n    type: doc-only\n    inputs:\n      - name: task\n    outputs:\n      - name: result\n"
         );
         std::fs::write(pipelines_dir.join(format!("{name}.yaml")), yaml).unwrap();
+    }
+
+    #[tokio::test]
+    async fn sync_run_pipeline_writes_canonical_prompt_path() {
+        // #231: run-scoped sync must write each prompt to the canonical
+        // `<stem>.prompts/<id>.md` (where every reader looks) — never the flat
+        // `prompts/<id>.md` dir that no reader consults.
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        write_test_pipeline(dir, "auto-issue");
+        let state = test_state_with_dir(dir).await;
+
+        let mut prompts = HashMap::new();
+        prompts.insert("worker".to_string(), "the role prompt".to_string());
+
+        let yaml = std::fs::read_to_string(
+            dir.join(".pdo").join("pipelines").join("auto-issue.yaml"),
+        )
+        .unwrap();
+        sync_run_pipeline_to_template(&state, "run-xyz", "auto-issue", &yaml, &prompts);
+
+        let pipelines = dir.join(".pdo").join("pipelines");
+        let canonical = pipelines.join("auto-issue.prompts").join("worker.md");
+        let flat = pipelines.join("prompts").join("worker.md");
+
+        assert_eq!(
+            std::fs::read_to_string(&canonical).unwrap(),
+            "the role prompt",
+            "prompt must be written to the canonical <stem>.prompts/ dir"
+        );
+        assert!(
+            !flat.exists(),
+            "the flat prompts/ dir must never be written"
+        );
     }
 
     /// RAII guard that sets HOME to a temporary directory and restores it on drop.

--- a/crates/pdo-daemon/src/pipeline_migrator.rs
+++ b/crates/pdo-daemon/src/pipeline_migrator.rs
@@ -1290,6 +1290,132 @@ pub fn migrate_all(pipelines_dir: &Path) -> Result<usize, String> {
     Ok(count)
 }
 
+/// One-shot boot migration for #231. The run-scoped pipeline save used to write
+/// node prompts to a flat `<pipelines>/prompts/<id>.md` directory that no reader
+/// ever consults — the canonical location is
+/// `<pipelines>/<stem>.prompts/<id>.md`. As a result, prompts edited from inside
+/// a run were saved to disk but appeared blank in the editor and to freshly
+/// spawned nodes.
+///
+/// For each pipeline YAML in `pipelines_dir`, every declared node id whose prompt
+/// is stranded in the flat dir is moved into that pipeline's canonical
+/// `<stem>.prompts/` dir. Node ids are globally unique (nanoids), so each flat
+/// file reattaches to at most one pipeline.
+///
+/// Move semantics mirror [`migrate_pipeline_file`]: a flat prompt is moved only
+/// when the canonical file is *missing*. An existing canonical file is never
+/// clobbered — it is authoritative (the writer fix keeps it current), and the
+/// stale flat duplicate is left in place so the conflict stays visible.
+///
+/// Afterward the flat dir is removed *only if the migration emptied it*. A
+/// non-empty remainder (a prompt for a deleted pipeline, or a flat duplicate of
+/// an existing canonical file) is preserved rather than destroyed.
+///
+/// Returns the number of prompt files moved.
+pub fn migrate_stranded_flat_prompts(pipelines_dir: &Path) -> Result<usize, String> {
+    let flat_dir = pipelines_dir.join("prompts");
+    if !flat_dir.is_dir() {
+        return Ok(0);
+    }
+
+    let entries = std::fs::read_dir(pipelines_dir)
+        .map_err(|e| format!("read dir {}: {e}", pipelines_dir.display()))?;
+
+    let mut moved = 0usize;
+    for entry in entries {
+        let entry = entry.map_err(|e| format!("dir entry: {e}"))?;
+        let path = entry.path();
+        let is_yaml = path
+            .extension()
+            .is_some_and(|ext| ext == "yaml" || ext == "yml");
+        if !is_yaml {
+            continue;
+        }
+
+        let yaml_text = match std::fs::read_to_string(&path) {
+            Ok(t) => t,
+            Err(e) => {
+                warn!(path = %path.display(), error = %e,
+                    "skipped flat-prompt migration: read failed");
+                continue;
+            }
+        };
+        let doc: serde_yaml::Value = match serde_yaml::from_str(&yaml_text) {
+            Ok(v) => v,
+            Err(e) => {
+                warn!(path = %path.display(), error = %e,
+                    "skipped flat-prompt migration: YAML parse failed");
+                continue;
+            }
+        };
+        let nodes = match doc.get("nodes").and_then(|n| n.as_sequence()) {
+            Some(seq) => seq,
+            None => continue,
+        };
+
+        for node in nodes {
+            let Some(node_id) = node.get("id").and_then(|v| v.as_str()) else {
+                continue;
+            };
+            let flat_path = flat_dir.join(format!("{node_id}.md"));
+            if !flat_path.is_file() {
+                continue;
+            }
+            let canonical = pipeline::canonical_prompt_path(&path, node_id);
+            if canonical.exists() {
+                // Canonical is authoritative; never clobber. Leave the dead flat
+                // duplicate so the flat dir survives and the conflict is visible.
+                warn!(
+                    flat = %flat_path.display(),
+                    canonical = %canonical.display(),
+                    "flat prompt has a canonical counterpart — leaving flat copy in place (#231)"
+                );
+                continue;
+            }
+            if let Some(parent) = canonical.parent() {
+                std::fs::create_dir_all(parent)
+                    .map_err(|e| format!("mkdir {}: {e}", parent.display()))?;
+            }
+            std::fs::rename(&flat_path, &canonical).map_err(|e| {
+                format!(
+                    "rename {} -> {}: {e}",
+                    flat_path.display(),
+                    canonical.display()
+                )
+            })?;
+            info!(
+                from = %flat_path.display(),
+                to = %canonical.display(),
+                "moved stranded flat prompt to canonical dir (#231)"
+            );
+            moved += 1;
+        }
+    }
+
+    // Remove the flat dir only if the migration emptied it. A non-empty
+    // remainder means files we could not reattach — preserve them.
+    match std::fs::read_dir(&flat_dir) {
+        Ok(mut it) => {
+            if it.next().is_none() {
+                match std::fs::remove_dir(&flat_dir) {
+                    Ok(()) => info!(path = %flat_dir.display(),
+                        "removed dead flat prompts dir (#231)"),
+                    Err(e) => warn!(path = %flat_dir.display(), error = %e,
+                        "failed to remove empty flat prompts dir"),
+                }
+            } else {
+                warn!(path = %flat_dir.display(),
+                    "flat prompts dir not empty after migration — \
+                     leaving unreattached prompts in place (#231)");
+            }
+        }
+        Err(e) => warn!(path = %flat_dir.display(), error = %e,
+            "could not re-scan flat prompts dir after migration"),
+    }
+
+    Ok(moved)
+}
+
 /// Detects fan-outs where 2+ code-mutating nodes share a common downstream
 /// target but no Merge node sits between them and the target.
 ///
@@ -2590,5 +2716,158 @@ edges:
             !parsed.edges.iter().any(|e| e.when.is_some() || e.is_else),
             "planner has no switch, so no conditional edges should appear"
         );
+    }
+
+    // --- #231: stranded flat-prompt boot migration ---
+
+    /// Writes a minimal pipeline YAML declaring the given node ids.
+    fn write_pipeline_with_nodes(dir: &Path, stem: &str, node_ids: &[&str]) {
+        let mut yaml = String::from("name: ");
+        yaml.push_str(stem);
+        yaml.push_str("\nversion: \"1.0\"\nnodes:\n");
+        for id in node_ids {
+            yaml.push_str(&format!(
+                "  - id: {id}\n    name: {id}\n    type: doc-only\n    outputs:\n      - name: out\n"
+            ));
+        }
+        yaml.push_str("edges: []\n");
+        std::fs::write(dir.join(format!("{stem}.yaml")), yaml).unwrap();
+    }
+
+    #[test]
+    fn migrate_flat_prompts_moves_to_canonical_and_removes_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        write_pipeline_with_nodes(dir, "auto-issue", &["AAAAAAAA", "BBBBBBBB"]);
+
+        let flat = dir.join("prompts");
+        std::fs::create_dir_all(&flat).unwrap();
+        std::fs::write(flat.join("AAAAAAAA.md"), "prompt A").unwrap();
+        std::fs::write(flat.join("BBBBBBBB.md"), "prompt B").unwrap();
+
+        let moved = migrate_stranded_flat_prompts(dir).unwrap();
+        assert_eq!(moved, 2);
+
+        // Both prompts now live in the canonical `<stem>.prompts/` dir, intact.
+        let canon = dir.join("auto-issue.prompts");
+        assert_eq!(
+            std::fs::read_to_string(canon.join("AAAAAAAA.md")).unwrap(),
+            "prompt A"
+        );
+        assert_eq!(
+            std::fs::read_to_string(canon.join("BBBBBBBB.md")).unwrap(),
+            "prompt B"
+        );
+        // The emptied flat dir is removed.
+        assert!(!flat.exists(), "flat prompts dir should be removed once emptied");
+    }
+
+    #[test]
+    fn migrate_flat_prompts_does_not_clobber_existing_canonical() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        write_pipeline_with_nodes(dir, "bugfix", &["CCCCCCCC"]);
+
+        // Canonical already holds authoritative text.
+        let canon = dir.join("bugfix.prompts");
+        std::fs::create_dir_all(&canon).unwrap();
+        std::fs::write(canon.join("CCCCCCCC.md"), "canonical text").unwrap();
+
+        // A stale flat duplicate exists.
+        let flat = dir.join("prompts");
+        std::fs::create_dir_all(&flat).unwrap();
+        std::fs::write(flat.join("CCCCCCCC.md"), "stale flat text").unwrap();
+
+        let moved = migrate_stranded_flat_prompts(dir).unwrap();
+        assert_eq!(moved, 0, "must not move when canonical exists");
+
+        // Canonical is untouched; the flat duplicate is preserved (not destroyed),
+        // so the conflict stays visible and the dir is kept.
+        assert_eq!(
+            std::fs::read_to_string(canon.join("CCCCCCCC.md")).unwrap(),
+            "canonical text"
+        );
+        assert!(flat.join("CCCCCCCC.md").exists());
+        assert!(flat.exists(), "non-empty flat dir must be preserved");
+    }
+
+    #[test]
+    fn migrate_flat_prompts_preserves_orphan_for_unknown_node() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        write_pipeline_with_nodes(dir, "alpha", &["KNOWN001"]);
+
+        let flat = dir.join("prompts");
+        std::fs::create_dir_all(&flat).unwrap();
+        std::fs::write(flat.join("KNOWN001.md"), "known").unwrap();
+        // No pipeline declares this id (e.g. a deleted pipeline).
+        std::fs::write(flat.join("ORPHAN99.md"), "orphan").unwrap();
+
+        let moved = migrate_stranded_flat_prompts(dir).unwrap();
+        assert_eq!(moved, 1);
+
+        assert_eq!(
+            std::fs::read_to_string(dir.join("alpha.prompts/KNOWN001.md")).unwrap(),
+            "known"
+        );
+        // The unmatched orphan is preserved, and so is the dir holding it.
+        assert!(flat.join("ORPHAN99.md").exists(), "orphan prompt must not be destroyed");
+        assert!(flat.exists());
+    }
+
+    #[test]
+    fn migrate_flat_prompts_noop_without_flat_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        write_pipeline_with_nodes(dir, "alpha", &["AAAAAAAA"]);
+        // No flat `prompts/` dir at all.
+        let moved = migrate_stranded_flat_prompts(dir).unwrap();
+        assert_eq!(moved, 0);
+    }
+
+    #[test]
+    fn migrate_flat_prompts_is_idempotent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        write_pipeline_with_nodes(dir, "auto-issue", &["AAAAAAAA"]);
+
+        let flat = dir.join("prompts");
+        std::fs::create_dir_all(&flat).unwrap();
+        std::fs::write(flat.join("AAAAAAAA.md"), "prompt A").unwrap();
+
+        assert_eq!(migrate_stranded_flat_prompts(dir).unwrap(), 1);
+        // Second run: flat dir is gone → no-op.
+        assert_eq!(migrate_stranded_flat_prompts(dir).unwrap(), 0);
+        assert_eq!(
+            std::fs::read_to_string(dir.join("auto-issue.prompts/AAAAAAAA.md")).unwrap(),
+            "prompt A"
+        );
+    }
+
+    #[test]
+    fn migrate_flat_prompts_routes_each_id_to_its_owning_pipeline() {
+        // Two pipelines, one flat prompt each — each must land in its own
+        // canonical dir (ids are globally unique).
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        write_pipeline_with_nodes(dir, "alpha", &["AAAAAAAA"]);
+        write_pipeline_with_nodes(dir, "beta", &["BBBBBBBB"]);
+
+        let flat = dir.join("prompts");
+        std::fs::create_dir_all(&flat).unwrap();
+        std::fs::write(flat.join("AAAAAAAA.md"), "a").unwrap();
+        std::fs::write(flat.join("BBBBBBBB.md"), "b").unwrap();
+
+        let moved = migrate_stranded_flat_prompts(dir).unwrap();
+        assert_eq!(moved, 2);
+        assert_eq!(
+            std::fs::read_to_string(dir.join("alpha.prompts/AAAAAAAA.md")).unwrap(),
+            "a"
+        );
+        assert_eq!(
+            std::fs::read_to_string(dir.join("beta.prompts/BBBBBBBB.md")).unwrap(),
+            "b"
+        );
+        assert!(!flat.exists());
     }
 }

--- a/crates/pdo-daemon/tests/run_scoped_pipeline.rs
+++ b/crates/pdo-daemon/tests/run_scoped_pipeline.rs
@@ -257,6 +257,61 @@ async fn external_prompt_edit_in_run_emits_pipeline_modified() {
     );
 }
 
+#[tokio::test]
+async fn run_scoped_save_syncs_prompt_to_canonical_template_dir() {
+    // #231: saving a prompt edit from inside a run (PUT /runs/:id/pipeline) must
+    // land in the template's canonical `<name>.prompts/` dir — the one every
+    // reader (GET /pipelines/:id, node spawn) consults — and never the flat
+    // `prompts/` dir that no reader looks in. A round-trip: the edit must then be
+    // visible to the normal editor via GET /pipelines/:id.
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+    let run_id = create_run(&daemon.url()).await;
+
+    const EDITED: &str = "You are an EDITED planner via run-scoped save.\n";
+    let resp = reqwest::Client::new()
+        .put(format!("{}/runs/{}/pipeline", daemon.url(), run_id))
+        .json(&serde_json::json!({
+            "yaml": PIPELINE_YAML,
+            "prompts": { "planner": EDITED }
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert!(
+        resp.status().is_success(),
+        "run-scoped save should succeed, got {}",
+        resp.status()
+    );
+
+    let pipelines = daemon.repo_root().join(".pdo").join("pipelines");
+
+    // The edit landed in the canonical template prompts dir...
+    let canonical = pipelines.join(format!("{PIPELINE_NAME}.prompts")).join("planner.md");
+    assert_eq!(
+        std::fs::read_to_string(&canonical).unwrap(),
+        EDITED,
+        "prompt must sync to the canonical <name>.prompts/ dir"
+    );
+
+    // ...and NOT in a flat `prompts/` dir.
+    assert!(
+        !pipelines.join("prompts").join("planner.md").exists(),
+        "run-scoped save must not write to the flat prompts/ dir"
+    );
+
+    // Round-trip: GET /pipelines/:id (the normal editor's source) shows the edit.
+    let resp = reqwest::get(format!("{}/pipelines/{PIPELINE_NAME}", daemon.url()))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(
+        body["prompts"]["planner"].as_str(),
+        Some(EDITED),
+        "normal editor should see the run-scoped prompt edit, got: {body:?}"
+    );
+}
+
 /// Wait for a specific event kind + node_id on the WebSocket.
 async fn next_event_for_node(
     ws: &mut tokio_tungstenite::WebSocketStream<


### PR DESCRIPTION
## What

Run-scoped pipeline saves (`PUT /runs/:id/pipeline`) wrote node prompts to a flat `<pipelines>/prompts/<id>.md` directory that no reader consults, so prompts edited inside a run showed blank in the editor and to freshly-spawned nodes.

This ships:
- **Writer fix:** `template_prompts_dir.join(...)` → `pipeline::canonical_prompt_path(&template_path, node_id)` so run-synced prompts land at the canonical `<stem>.prompts/<id>.md` every reader uses.
- **Recovery:** `pipeline_migrator::migrate_stranded_flat_prompts` re-homes prompts already stranded in the flat dir, with no-clobber / preserve-unreattachable / drain-then-remove / idempotent semantics.
- Unit test `sync_run_pipeline_writes_canonical_prompt_path` + integration test `run_scoped_pipeline.rs`.
- Release bump to v0.1.19.

## Verification

Tester verdict: **Pass** — clean `cargo build`, and the recovery path driven end-to-end against a reproduced stranding fixture (9/9 assertions).

Closes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)