### PR TITLE
feat(triggers): bounded-concurrency `allow` overlap mode (#239)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -460,6 +460,8 @@ Risque assumé : un guard qui renvoie toujours le même work + un pipeline qui n
 
 Un Trigger **ne fire pas** si **son propre** Run précédent est encore vivant (`running`/`awaiting_user`/`blocked`). Le tick est sauté (loggué « skipped — previous run still active »), pas mis en file. Justification : ferme la fenêtre de course du dedup-par-label (Q4) — tant que le fixer-run-1 travaille l'issue #42, l'issue reste `ready-for-agent`, donc sans skip les polls suivants re-firent sur #42. Le skip est le défaut, surchargeable en `allow` par-Trigger pour qui veut des fires concurrents.
 
+**Recouvrement borné — `allow` + `max_concurrent`** (#239) : `allow` accepte un plafond optionnel `max_concurrent` (entier ≥ 1, nullable). `None`/vide ⇒ concurrence illimitée (compat ascendante des `allow` existants) ; `Some(m)` ⇒ fire tant que le Trigger a `< m` Runs vivants *à lui*, puis skip. Les trois modes se ramènent à un **plafond effectif** unique : `skip` ⇒ plafond 1 (jamais d'empilement sur son propre Run vivant), `allow+None` ⇒ illimité, `allow+Some(m)` ⇒ m. La décision (`fire_decision::overlap_ceiling`) et la gate du guard passent toutes deux par ce même plafond, donc le guard ne tourne jamais sur un tick qu'on sauterait. Le décompte est dérivé de la provenance `triggered_by` (Runs vivants), pas d'un état neuf : un Run qui se termine libère un slot.
+
 **Pas d'empilement de Runs en attente.** On ne crée jamais un Run entièrement « en attente ». La seule attente possible est *au niveau nœud* (back-pressure du cap de sessions, ci-dessous), à l'intérieur d'un Run déjà admis.
 
 ### Mécanisme cron & cycle de vie
@@ -475,11 +477,11 @@ Un Trigger **ne fire pas** si **son propre** Run précédent est encore vivant (
 
 Les Triggers vivent dans une **nouvelle table `triggers`** de `~/.pdo/pdo.db`, *pas* en YAML sur disque. Un Trigger est de la **config + état de scheduling** (créé via modale, pas un artefact canvas-backed comme un pipeline), et son état mutable (`enabled`, `next_fire_at`, `last_fired_at`, `last_outcome`) serait réécrit à chaque tick — mauvais fit YAML. La requête centrale du scheduler (« quels Triggers sont dûs ») est une requête indexée triviale.
 
-Ligne : `id, name, pipeline_id, target_repo, source_branch, input_template, variables(JSON), cron, guard_command(nullable), overlap_policy, enabled, next_fire_at, last_fired_at, last_outcome`.
+Ligne : `id, name, pipeline_id, target_repo, source_branch, input_template, variables(JSON), cron, guard_command(nullable), overlap_policy, max_concurrent(nullable), enabled, next_fire_at, last_fired_at, last_outcome`. (Pas de migration runner : la colonne `max_concurrent` est ajoutée à `init` via un `ALTER TABLE … ADD COLUMN` idempotent, gardé par un `pragma_table_info`, pour migrer les `pdo.db` antérieurs à #239.)
 
 Ne viole pas l'event-sourcing : l'event log reste la vérité du **Run** (keyé `run_id`) ; un Trigger *produit* des Runs (eux event-sourcés normalement, avec provenance `triggered_by`).
 
-**Table `trigger_fires`** (audit) : un enregistrement horodaté par tick significatif — `fired→run_id` / `skipped-overlap` / `guard-exit-nonzero` / `guard-error`. Répond à la question #1 du debug (« pourquoi mon Trigger n'a pas firé cette nuit ? »). L'onglet Triggers la lit pour « last fired / last skipped + raison ».
+**Table `trigger_fires`** (audit) : un enregistrement horodaté par tick significatif — `fired→run_id` / `skipped-overlap` / `guard-exit-nonzero` / `guard-error`. Répond à la question #1 du debug (« pourquoi mon Trigger n'a pas firé cette nuit ? »). L'onglet Triggers la lit pour « last fired / last skipped + raison ». Un skip dû au plafond borné (#239) **réutilise l'outcome `skipped-overlap`** (pas de nouveau statut à apprendre à l'UI), le plafond étant porté dans la *raison* (« max concurrent runs reached (2/2) ») — la colonne raison du panneau d'historique répond au « pourquoi » précisément.
 
 ### UI — onglet Triggers
 

--- a/crates/pdo-daemon/src/fire_decision.rs
+++ b/crates/pdo-daemon/src/fire_decision.rs
@@ -15,8 +15,25 @@
 pub enum OverlapPolicy {
     /// Skip this tick while the previous Run is live (the default).
     Skip,
-    /// Allow a concurrent fire.
+    /// Allow a concurrent fire — unbounded, or capped by `max_concurrent` (#239).
     Allow,
+}
+
+/// Effective concurrency ceiling for one tick. `None` = unbounded (#239).
+///
+///   Skip        → Some(1)  (never stack on my own live run)
+///   Allow+None  → None     (unbounded)
+///   Allow+Some  → Some(m)  (m clamped to >= 1 defensively, so a stray 0 from a
+///                           legacy/unvalidated row can never make a bounded-allow
+///                           Trigger fire forever — `n < 0` is never true)
+///
+/// The scheduler's guard-gate and `decide` both route through here so the cap can
+/// never drift between "should the guard run?" and "should we fire?".
+pub fn overlap_ceiling(overlap: OverlapPolicy, max_concurrent: Option<usize>) -> Option<usize> {
+    match overlap {
+        OverlapPolicy::Skip => Some(1),
+        OverlapPolicy::Allow => max_concurrent.map(|m| m.max(1)),
+    }
 }
 
 /// Outcome of running a guard command (slice #161 will populate this; the
@@ -37,7 +54,13 @@ pub struct FireInputs<'a> {
     pub enabled: bool,
     pub due: bool,
     pub overlap: OverlapPolicy,
-    pub has_live_run: bool,
+    /// Count of this Trigger's *own* live Runs at tick time (#239). With
+    /// `OverlapPolicy::Skip` any count >= 1 skips; with `Allow` it is compared
+    /// against the `max_concurrent` ceiling.
+    pub live_run_count: usize,
+    /// Bounded-`allow` ceiling: max simultaneous live Runs (#239). `None` =
+    /// unbounded. Ignored entirely unless `overlap == Allow`.
+    pub max_concurrent: Option<usize>,
     /// `None` when the trigger has no guard (cron-only).
     pub guard: Option<GuardResult>,
     /// Static input template configured on the trigger (may be empty).
@@ -63,6 +86,8 @@ pub enum FireDecision {
 pub enum SkipReason {
     /// The Trigger's own previous Run is still active.
     OverlapPreviousRunLive,
+    /// The Trigger is at its bounded-`allow` ceiling: `live` >= `max` (#239).
+    OverlapMaxConcurrentReached { live: usize, max: usize },
     /// Guard exited non-zero (no work to do).
     GuardExitNonZero,
     /// Guard could not be evaluated (spawn error or timeout).
@@ -76,11 +101,22 @@ pub fn decide(inputs: &FireInputs) -> FireDecision {
         return FireDecision::Skip { reason: None };
     }
 
-    // Overlap policy: never stack on the Trigger's own live Run unless allowed.
-    if inputs.has_live_run && inputs.overlap == OverlapPolicy::Skip {
-        return FireDecision::Skip {
-            reason: Some(SkipReason::OverlapPreviousRunLive),
-        };
+    // Overlap policy collapses to one effective ceiling (#239): `skip` ⇒ 1,
+    // `allow+None` ⇒ unbounded, `allow+Some(m)` ⇒ m. Fire iff the count is below
+    // the ceiling.
+    if let Some(ceiling) = overlap_ceiling(inputs.overlap, inputs.max_concurrent) {
+        if inputs.live_run_count >= ceiling {
+            let reason = match inputs.overlap {
+                OverlapPolicy::Skip => SkipReason::OverlapPreviousRunLive,
+                OverlapPolicy::Allow => SkipReason::OverlapMaxConcurrentReached {
+                    live: inputs.live_run_count,
+                    max: ceiling,
+                },
+            };
+            return FireDecision::Skip {
+                reason: Some(reason),
+            };
+        }
     }
 
     // Guard branches (slice #161). Cron-only triggers pass `None`.
@@ -136,7 +172,8 @@ mod tests {
             enabled: true,
             due: true,
             overlap: OverlapPolicy::Skip,
-            has_live_run: false,
+            live_run_count: 0,
+            max_concurrent: None,
             guard: None,
             input_template: "do the thing",
             prompt_required: true,
@@ -164,7 +201,7 @@ mod tests {
     #[test]
     fn due_with_live_run_and_skip_policy_skips_with_overlap_reason() {
         let inputs = FireInputs {
-            has_live_run: true,
+            live_run_count: 1,
             overlap: OverlapPolicy::Skip,
             ..base()
         };
@@ -179,7 +216,7 @@ mod tests {
     #[test]
     fn due_with_live_run_and_allow_policy_fires() {
         let inputs = FireInputs {
-            has_live_run: true,
+            live_run_count: 1,
             overlap: OverlapPolicy::Allow,
             ..base()
         };
@@ -189,6 +226,101 @@ mod tests {
                 input: "do the thing".to_string()
             }
         );
+    }
+
+    // --- #239: bounded-`allow` concurrency cap ---
+
+    #[test]
+    fn allow_unbounded_fires_regardless_of_count() {
+        let inputs = FireInputs {
+            overlap: OverlapPolicy::Allow,
+            max_concurrent: None,
+            live_run_count: 5,
+            ..base()
+        };
+        assert_eq!(
+            decide(&inputs),
+            FireDecision::Fire {
+                input: "do the thing".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn allow_bounded_fires_below_cap() {
+        let inputs = FireInputs {
+            overlap: OverlapPolicy::Allow,
+            max_concurrent: Some(2),
+            live_run_count: 1,
+            ..base()
+        };
+        assert_eq!(
+            decide(&inputs),
+            FireDecision::Fire {
+                input: "do the thing".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn allow_bounded_skips_at_cap() {
+        let inputs = FireInputs {
+            overlap: OverlapPolicy::Allow,
+            max_concurrent: Some(2),
+            live_run_count: 2,
+            ..base()
+        };
+        assert_eq!(
+            decide(&inputs),
+            FireDecision::Skip {
+                reason: Some(SkipReason::OverlapMaxConcurrentReached { live: 2, max: 2 })
+            }
+        );
+    }
+
+    #[test]
+    fn allow_bounded_skips_above_cap() {
+        let inputs = FireInputs {
+            overlap: OverlapPolicy::Allow,
+            max_concurrent: Some(2),
+            live_run_count: 3,
+            ..base()
+        };
+        assert_eq!(
+            decide(&inputs),
+            FireDecision::Skip {
+                reason: Some(SkipReason::OverlapMaxConcurrentReached { live: 3, max: 2 })
+            }
+        );
+    }
+
+    #[test]
+    fn skip_policy_ignores_max_concurrent() {
+        // Regression: a stray `max_concurrent` is inert under the `skip` policy —
+        // the ceiling is always 1, so any live run skips with the previous-run
+        // reason (not the bounded-allow one).
+        let inputs = FireInputs {
+            overlap: OverlapPolicy::Skip,
+            max_concurrent: Some(5),
+            live_run_count: 1,
+            ..base()
+        };
+        assert_eq!(
+            decide(&inputs),
+            FireDecision::Skip {
+                reason: Some(SkipReason::OverlapPreviousRunLive)
+            }
+        );
+    }
+
+    #[test]
+    fn overlap_ceiling_collapses_each_mode() {
+        assert_eq!(overlap_ceiling(OverlapPolicy::Skip, None), Some(1));
+        assert_eq!(overlap_ceiling(OverlapPolicy::Skip, Some(9)), Some(1));
+        assert_eq!(overlap_ceiling(OverlapPolicy::Allow, None), None);
+        assert_eq!(overlap_ceiling(OverlapPolicy::Allow, Some(3)), Some(3));
+        // Defensive clamp: a stray 0 must never become an unfireable ceiling.
+        assert_eq!(overlap_ceiling(OverlapPolicy::Allow, Some(0)), Some(1));
     }
 
     #[test]

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -726,10 +726,39 @@ struct CreateTriggerRequest {
     guard_command: Option<String>,
     #[serde(default = "default_overlap_policy")]
     overlap_policy: String,
+    /// Bounded-`allow` ceiling (#239): max simultaneous live Runs. `None` =
+    /// unbounded. Inert unless `overlap_policy == "allow"`.
+    #[serde(default)]
+    max_concurrent: Option<i64>,
 }
 
 fn default_overlap_policy() -> String {
     "skip".to_string()
+}
+
+/// Validate a `max_concurrent` cap (#239): when present it must be >= 1. `None`
+/// (unbounded) is always valid. Shared by create and patch so the rule can't
+/// drift between them. A cap set while `overlap_policy == "skip"` is accepted —
+/// it stays inert (the frontend nulls it; the API is lenient).
+fn validate_max_concurrent(v: Option<i64>) -> Result<(), &'static str> {
+    match v {
+        Some(n) if n < 1 => Err("max_concurrent must be >= 1"),
+        _ => Ok(()),
+    }
+}
+
+/// Deserialize a double-`Option` PATCH field so a present `null` maps to
+/// `Some(None)` (explicit "clear to NULL"), distinct from absent → `None`
+/// ("leave untouched"). serde's default for `Option<Option<T>>` collapses both to
+/// `None`; this helper — only invoked when the key is present — recovers the
+/// three-way distinction. #239 needs it: editing a bounded `allow` Trigger back to
+/// blank must clear the stored cap to unbounded, not silently keep the old value.
+fn deserialize_double_option<'de, D, T>(deserializer: D) -> Result<Option<Option<T>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    Ok(Some(Option::<T>::deserialize(deserializer)?))
 }
 
 /// The first scheduled fire for a freshly created or rescheduled Trigger, as
@@ -770,6 +799,15 @@ async fn create_trigger(
                 .into_response();
         }
     };
+
+    // A bounded-allow cap, when present, must be >= 1 (#239).
+    if let Err(msg) = validate_max_concurrent(req.max_concurrent) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": msg })),
+        )
+            .into_response();
+    }
 
     // Resolve the target pipeline and its prompt_required flag.
     let yaml =
@@ -846,6 +884,7 @@ async fn create_trigger(
         } else {
             "skip".to_string()
         },
+        max_concurrent: req.max_concurrent,
         next_fire_at,
     };
 
@@ -956,6 +995,13 @@ struct PatchTriggerRequest {
     guard_command: Option<Option<String>>,
     #[serde(default)]
     variables: Option<HashMap<String, serde_yaml::Value>>,
+    /// Bounded-`allow` ceiling (#239), double-wrapped: absent = leave, present
+    /// `null` = clear to unbounded, `n` = set. The custom deserializer is what
+    /// makes the present-`null` → `Some(None)` distinction reachable from JSON
+    /// (the sibling `Option<Option<_>>` fields above use plain `#[serde(default)]`,
+    /// where present-`null` collapses to `None` and cannot clear).
+    #[serde(default, deserialize_with = "deserialize_double_option")]
+    max_concurrent: Option<Option<i64>>,
 }
 
 async fn patch_trigger(
@@ -1022,6 +1068,17 @@ async fn patch_trigger(
         }
     }
 
+    // Validate a max_concurrent edit (Some(Some(n)) sets; Some(None) clears) (#239).
+    if let Some(Some(n)) = req.max_concurrent {
+        if let Err(msg) = validate_max_concurrent(Some(n)) {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({ "error": msg })),
+            )
+                .into_response();
+        }
+    }
+
     // Re-apply the fire_decision reject rule against the *resulting* config: if
     // the pipeline requires a prompt and the edit would leave neither a guard
     // nor an input template, refuse (mirrors create-time validation).
@@ -1065,6 +1122,7 @@ async fn patch_trigger(
                 "skip".to_string()
             }
         }),
+        max_concurrent: req.max_concurrent,
         next_fire_at,
     };
 
@@ -1457,16 +1515,20 @@ async fn count_global_live_sessions(db: &sqlx::SqlitePool) -> usize {
 
 // --- Trigger scheduler ---
 
-/// Whether the Trigger's *own* previous Run is still live. Scans projected Run
-/// state for a run carrying this `triggered_by` whose status is live.
-async fn trigger_has_live_run(db: &sqlx::SqlitePool, trigger_id: &str) -> bool {
+/// How many of the Trigger's *own* Runs are still live (#239). Scans projected
+/// Run state for runs carrying this `triggered_by` whose status is live. A
+/// finished/failed Run drops out of the count, freeing a slot — exactly the
+/// "max simultaneous *live*" semantics, with no new state to track. Same O(runs)
+/// projection scan as before, just without the short-circuit.
+async fn trigger_live_run_count(db: &sqlx::SqlitePool, trigger_id: &str) -> usize {
     let run_ids = match load_all_run_ids(db).await {
         Ok(ids) => ids,
         Err(e) => {
             warn!("trigger scheduler: failed to load run ids: {e}");
-            return false;
+            return 0;
         }
     };
+    let mut count = 0usize;
     for run_id in run_ids {
         let events = match load_events(db, &run_id).await {
             Ok(e) => e,
@@ -1474,11 +1536,11 @@ async fn trigger_has_live_run(db: &sqlx::SqlitePool, trigger_id: &str) -> bool {
         };
         if let Some(state) = event_log::project(&events) {
             if state.triggered_by.as_deref() == Some(trigger_id) && state.status.is_live() {
-                return true;
+                count += 1;
             }
         }
     }
-    false
+    count
 }
 
 /// Load a Trigger's target pipeline yaml from the library (falling back to a
@@ -1594,13 +1656,24 @@ async fn run_trigger_scheduler_tick(state: &AppState) {
             continue;
         }
 
-        let has_live = trigger_has_live_run(&state.db, &trigger.id).await;
+        let live_count = trigger_live_run_count(&state.db, &trigger.id).await;
         let prompt_required = trigger_prompt_required(state, &trigger);
 
         // Run the guard (if any) off the tick, bounded by a hard timeout, but
         // only when overlap wouldn't already skip — never spend a guard run on a
-        // tick we'd skip anyway.
-        let overlap_skips = has_live && trigger.overlap_policy != "allow";
+        // tick we'd skip anyway. Route this through the same `overlap_ceiling`
+        // the decision core uses (#239) so the guard-gate can never drift from
+        // the fire decision (fire past the cap, or waste a guard run at it).
+        let overlap = if trigger.overlap_policy == "allow" {
+            fire_decision::OverlapPolicy::Allow
+        } else {
+            fire_decision::OverlapPolicy::Skip
+        };
+        let overlap_skips = fire_decision::overlap_ceiling(
+            overlap,
+            trigger.max_concurrent.map(|m| m.max(0) as usize),
+        )
+        .is_some_and(|ceiling| live_count >= ceiling);
         let guard = match (&trigger.guard_command, overlap_skips) {
             (Some(cmd), false) if !cmd.trim().is_empty() => {
                 let cwd = trigger_guard_cwd(state, &trigger);
@@ -1609,7 +1682,7 @@ async fn run_trigger_scheduler_tick(state: &AppState) {
             _ => None,
         };
 
-        let plan = trigger_scheduler::plan_tick(&trigger, now, has_live, guard, prompt_required);
+        let plan = trigger_scheduler::plan_tick(&trigger, now, live_count, guard, prompt_required);
 
         // Recompute the next fire (forward-only).
         if let Err(e) =

--- a/crates/pdo-daemon/src/trigger_scheduler.rs
+++ b/crates/pdo-daemon/src/trigger_scheduler.rs
@@ -35,12 +35,14 @@ pub struct TickPlan {
 
 /// Decide what to do for one Trigger at `now`, given the observable world.
 ///
-/// `has_live_run` is whether the Trigger's *own* previous Run is still active.
-/// `guard` is the guard result (always `None` in the cron-only slice).
+/// `live_run_count` is the number of the Trigger's *own* Runs still live (#239):
+/// compared against the overlap ceiling (`skip` ⇒ 1, bounded `allow` ⇒
+/// `max_concurrent`). `guard` is the guard result (always `None` in the cron-only
+/// slice).
 pub fn plan_tick(
     trigger: &Trigger,
     now: DateTime<Utc>,
-    has_live_run: bool,
+    live_run_count: usize,
     guard: Option<GuardResult>,
     prompt_required: bool,
 ) -> TickPlan {
@@ -94,7 +96,11 @@ pub fn plan_tick(
         enabled: trigger.enabled,
         due,
         overlap,
-        has_live_run,
+        live_run_count,
+        // Store holds `Option<i64>`; convert to the decision core's `usize` at
+        // this one boundary (clamp a stray negative to 0, then `overlap_ceiling`
+        // clamps a 0 ceiling up to 1 defensively).
+        max_concurrent: trigger.max_concurrent.map(|m| m.max(0) as usize),
         guard,
         input_template: &trigger.input_template,
         prompt_required,
@@ -126,6 +132,16 @@ fn record_for(decision: &FireDecision) -> Option<FireRecord> {
         } => Some(FireRecord {
             outcome: "skipped-overlap".to_string(),
             reason: Some("previous run still active".to_string()),
+            run_id: None,
+        }),
+        // A bounded-`allow` skip keeps the `skipped-overlap` outcome (#239) — no
+        // new status-dot to teach the UI — but carries the cap in its reason so
+        // the history panel answers "why" precisely.
+        FireDecision::Skip {
+            reason: Some(SkipReason::OverlapMaxConcurrentReached { live, max }),
+        } => Some(FireRecord {
+            outcome: "skipped-overlap".to_string(),
+            reason: Some(format!("max concurrent runs reached ({live}/{max})")),
             run_id: None,
         }),
         FireDecision::Skip {
@@ -168,6 +184,7 @@ mod tests {
             cron: cron.to_string(),
             guard_command: None,
             overlap_policy: "skip".to_string(),
+            max_concurrent: None,
             enabled: true,
             next_fire_at: next_fire_at.map(str::to_string),
             last_fired_at: None,
@@ -183,7 +200,7 @@ mod tests {
     fn due_cron_only_trigger_plans_a_fire_and_recomputes_next() {
         let t = trigger("* * * * *", Some("2026-06-06T10:00:00.000Z"));
         let now = at("2026-06-06T10:00:30.000Z");
-        let plan = plan_tick(&t, now, false, None, false);
+        let plan = plan_tick(&t, now, 0, None, false);
         assert_eq!(
             plan.decision,
             FireDecision::Fire {
@@ -202,7 +219,7 @@ mod tests {
     fn overlap_skip_while_own_run_is_live_records_skip_and_still_recomputes() {
         let t = trigger("* * * * *", Some("2026-06-06T10:00:00.000Z"));
         let now = at("2026-06-06T10:00:30.000Z");
-        let plan = plan_tick(&t, now, true, None, false);
+        let plan = plan_tick(&t, now, 1, None, false);
         assert!(matches!(
             plan.decision,
             FireDecision::Skip { reason: Some(_) }
@@ -217,10 +234,48 @@ mod tests {
     }
 
     #[test]
+    fn bounded_allow_skip_at_cap_records_skipped_overlap_with_count() {
+        // #239: an `allow` Trigger at its `max_concurrent` cap skips, audited as
+        // `skipped-overlap` with the cap in the reason, and the schedule still
+        // advances.
+        let mut t = trigger("* * * * *", Some("2026-06-06T10:00:00.000Z"));
+        t.overlap_policy = "allow".to_string();
+        t.max_concurrent = Some(2);
+        let now = at("2026-06-06T10:00:30.000Z");
+        let plan = plan_tick(&t, now, 2, None, false);
+        assert!(matches!(
+            plan.decision,
+            FireDecision::Skip { reason: Some(_) }
+        ));
+        let record = plan.record.as_ref().unwrap();
+        assert_eq!(record.outcome, "skipped-overlap");
+        assert!(
+            record.reason.as_deref().unwrap().contains("(2/2)"),
+            "reason must carry the cap: {:?}",
+            record.reason
+        );
+        assert_eq!(
+            plan.next_fire_at.as_deref(),
+            Some("2026-06-06T10:01:00.000Z")
+        );
+    }
+
+    #[test]
+    fn bounded_allow_below_cap_fires() {
+        let mut t = trigger("* * * * *", Some("2026-06-06T10:00:00.000Z"));
+        t.overlap_policy = "allow".to_string();
+        t.max_concurrent = Some(2);
+        let now = at("2026-06-06T10:00:30.000Z");
+        let plan = plan_tick(&t, now, 1, None, false);
+        assert!(matches!(plan.decision, FireDecision::Fire { .. }));
+        assert_eq!(plan.record.as_ref().unwrap().outcome, "fired");
+    }
+
+    #[test]
     fn not_due_trigger_is_a_silent_noop_with_no_audit_row() {
         let t = trigger("* * * * *", Some("2999-01-01T00:00:00.000Z"));
         let now = at("2026-06-06T10:00:30.000Z");
-        let plan = plan_tick(&t, now, false, None, false);
+        let plan = plan_tick(&t, now, 0, None, false);
         assert_eq!(plan.decision, FireDecision::Skip { reason: None });
         assert!(plan.record.is_none());
     }
@@ -231,7 +286,7 @@ mod tests {
         // jumps forward from `now`, never replaying the missed slots.
         let t = trigger("0 * * * *", Some("2026-06-01T09:00:00.000Z"));
         let now = at("2026-06-06T10:30:00.000Z");
-        let plan = plan_tick(&t, now, false, None, false);
+        let plan = plan_tick(&t, now, 0, None, false);
         assert!(matches!(plan.decision, FireDecision::Fire { .. }));
         // The single next fire is the *next* hourly slot after now, not a
         // backfill of June 1.
@@ -245,7 +300,7 @@ mod tests {
     fn invalid_cron_yields_error_outcome_and_stops_firing() {
         let t = trigger("not a cron", Some("2026-06-06T10:00:00.000Z"));
         let now = at("2026-06-06T10:00:30.000Z");
-        let plan = plan_tick(&t, now, false, None, false);
+        let plan = plan_tick(&t, now, 0, None, false);
         assert!(matches!(plan.decision, FireDecision::Reject { .. }));
         assert_eq!(plan.record.as_ref().unwrap().outcome, "error");
         // No next fire: the broken trigger stops firing until edited.
@@ -258,7 +313,7 @@ mod tests {
         let mut t = trigger("* * * * *", Some("2020-01-01T00:00:00.000Z"));
         t.enabled = false;
         let now = at("2026-06-06T10:00:30.000Z");
-        let plan = plan_tick(&t, now, false, None, false);
+        let plan = plan_tick(&t, now, 0, None, false);
         assert_eq!(plan.decision, FireDecision::Skip { reason: None });
         assert!(plan.record.is_none());
     }

--- a/crates/pdo-daemon/src/trigger_store.rs
+++ b/crates/pdo-daemon/src/trigger_store.rs
@@ -38,6 +38,10 @@ pub struct Trigger {
     pub guard_command: Option<String>,
     /// `"skip"` (default) or `"allow"`.
     pub overlap_policy: String,
+    /// Bounded-`allow` ceiling: max simultaneous live Runs of this Trigger (#239).
+    /// `None` = unbounded (also the effective value under the `skip` policy).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_concurrent: Option<i64>,
     pub enabled: bool,
     /// The next scheduled fire, as **canonical UTC RFC3339-millis** (`…Z`).
     /// Every writer (create/edit in `lib.rs`, the scheduler's `set_next_fire`)
@@ -65,6 +69,8 @@ pub struct NewTrigger {
     pub cron: String,
     pub guard_command: Option<String>,
     pub overlap_policy: String,
+    /// Bounded-`allow` ceiling (#239); `None` = unbounded.
+    pub max_concurrent: Option<i64>,
     /// First scheduled fire, computed by the caller from the cron expression.
     pub next_fire_at: Option<String>,
 }
@@ -106,6 +112,7 @@ pub async fn init(db: &SqlitePool) -> Result<(), sqlx::Error> {
             cron TEXT NOT NULL,
             guard_command TEXT,
             overlap_policy TEXT NOT NULL DEFAULT 'skip',
+            max_concurrent INTEGER,
             enabled INTEGER NOT NULL DEFAULT 1,
             next_fire_at TEXT,
             last_fired_at TEXT,
@@ -129,6 +136,23 @@ pub async fn init(db: &SqlitePool) -> Result<(), sqlx::Error> {
     .execute(db)
     .await?;
 
+    // Additive migration (#239): a `~/.pdo/pdo.db` created before this column
+    // existed got the table via `CREATE TABLE IF NOT EXISTS` above, which is a
+    // no-op there — so the column must be added out-of-band. There is no
+    // migration runner; this PRAGMA-guarded ALTER is the only durable path. The
+    // guard keeps it idempotent (a bare `ALTER … ADD COLUMN` errors "duplicate
+    // column name" on an already-migrated DB), and is preferred over swallowing
+    // the ALTER error blindly — a swallowed error would hide genuine failures.
+    let has_col = sqlx::query("SELECT 1 FROM pragma_table_info('triggers') WHERE name = 'max_concurrent'")
+        .fetch_optional(db)
+        .await?
+        .is_some();
+    if !has_col {
+        sqlx::query("ALTER TABLE triggers ADD COLUMN max_concurrent INTEGER")
+            .execute(db)
+            .await?;
+    }
+
     Ok(())
 }
 
@@ -149,8 +173,8 @@ pub async fn create(db: &SqlitePool, new: NewTrigger) -> Result<Trigger, sqlx::E
         "INSERT INTO triggers
             (id, name, pipeline_id, pipeline_name, target_repo, source_branch,
              input_template, variables, cron, guard_command, overlap_policy,
-             enabled, next_fire_at, last_fired_at, last_outcome, created_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, NULL, NULL, ?)",
+             max_concurrent, enabled, next_fire_at, last_fired_at, last_outcome, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, NULL, NULL, ?)",
     )
     .bind(&id)
     .bind(&new.name)
@@ -163,6 +187,7 @@ pub async fn create(db: &SqlitePool, new: NewTrigger) -> Result<Trigger, sqlx::E
     .bind(&new.cron)
     .bind(&new.guard_command)
     .bind(&new.overlap_policy)
+    .bind(new.max_concurrent)
     .bind(&new.next_fire_at)
     .bind(&now)
     .execute(db)
@@ -186,6 +211,7 @@ fn row_to_trigger(row: &sqlx::sqlite::SqliteRow) -> Trigger {
         cron: row.get("cron"),
         guard_command: row.get("guard_command"),
         overlap_policy: row.get("overlap_policy"),
+        max_concurrent: row.get("max_concurrent"),
         enabled: row.get::<i64, _>("enabled") != 0,
         next_fire_at: row.get("next_fire_at"),
         last_fired_at: row.get("last_fired_at"),
@@ -333,6 +359,9 @@ pub struct UpdateTrigger {
     pub cron: Option<String>,
     pub guard_command: Option<Option<String>>,
     pub overlap_policy: Option<String>,
+    /// Bounded-`allow` ceiling (#239), double-wrapped like the other nullable
+    /// fields: `None` leaves it, `Some(None)` clears to NULL, `Some(Some(n))` sets.
+    pub max_concurrent: Option<Option<i64>>,
     pub next_fire_at: Option<Option<String>>,
 }
 
@@ -346,6 +375,7 @@ impl UpdateTrigger {
             && self.cron.is_none()
             && self.guard_command.is_none()
             && self.overlap_policy.is_none()
+            && self.max_concurrent.is_none()
             && self.next_fire_at.is_none()
     }
 }
@@ -387,6 +417,9 @@ pub async fn update(
     if edit.overlap_policy.is_some() {
         sets.push("overlap_policy = ?");
     }
+    if edit.max_concurrent.is_some() {
+        sets.push("max_concurrent = ?");
+    }
     if edit.next_fire_at.is_some() {
         sets.push("next_fire_at = ?");
     }
@@ -416,6 +449,9 @@ pub async fn update(
     }
     if let Some(v) = &edit.overlap_policy {
         query = query.bind(v.clone());
+    }
+    if let Some(v) = &edit.max_concurrent {
+        query = query.bind(*v);
     }
     if let Some(v) = &edit.next_fire_at {
         query = query.bind(v.clone());
@@ -465,6 +501,7 @@ mod tests {
             cron: cron.to_string(),
             guard_command: None,
             overlap_policy: "skip".to_string(),
+            max_concurrent: None,
             next_fire_at: Some("2026-06-06T10:00:00.000Z".to_string()),
         }
     }
@@ -761,5 +798,164 @@ mod tests {
             .is_empty());
         set_enabled(&db, &t.id, true).await.unwrap();
         assert!(get(&db, &t.id).await.unwrap().unwrap().enabled);
+    }
+
+    // --- #239: bounded-`allow` max_concurrent persistence ---
+
+    #[tokio::test]
+    async fn create_then_get_round_trips_max_concurrent() {
+        let db = test_db().await;
+
+        let mut bounded = sample("bounded", "0 9 * * *");
+        bounded.overlap_policy = "allow".to_string();
+        bounded.max_concurrent = Some(3);
+        let created = create(&db, bounded).await.unwrap();
+        assert_eq!(created.max_concurrent, Some(3));
+        assert_eq!(
+            get(&db, &created.id).await.unwrap().unwrap().max_concurrent,
+            Some(3)
+        );
+
+        // The default (unbounded) round-trips as NULL.
+        let unbounded = create(&db, sample("unbounded", "0 9 * * *"))
+            .await
+            .unwrap();
+        assert_eq!(unbounded.max_concurrent, None);
+        assert_eq!(
+            get(&db, &unbounded.id).await.unwrap().unwrap().max_concurrent,
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn update_sets_and_clears_max_concurrent() {
+        let db = test_db().await;
+        let t = create(&db, sample("capped", "0 9 * * *")).await.unwrap();
+        assert_eq!(t.max_concurrent, None);
+
+        // Some(Some(n)) sets it.
+        update(
+            &db,
+            &t.id,
+            UpdateTrigger {
+                max_concurrent: Some(Some(5)),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            get(&db, &t.id).await.unwrap().unwrap().max_concurrent,
+            Some(5)
+        );
+
+        // An unrelated edit (None) leaves it untouched.
+        update(
+            &db,
+            &t.id,
+            UpdateTrigger {
+                input_template: Some("changed".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            get(&db, &t.id).await.unwrap().unwrap().max_concurrent,
+            Some(5)
+        );
+
+        // Some(None) clears it back to NULL.
+        update(
+            &db,
+            &t.id,
+            UpdateTrigger {
+                max_concurrent: Some(None),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(get(&db, &t.id).await.unwrap().unwrap().max_concurrent, None);
+    }
+
+    /// #239 migration: a `~/.pdo/pdo.db` created before `max_concurrent` existed
+    /// must pick up the column on the next `init`, idempotently. `init`'s
+    /// `CREATE TABLE IF NOT EXISTS` is a no-op against a pre-existing table, so
+    /// the PRAGMA-guarded `ALTER` is the only path that migrates it. This builds
+    /// the legacy schema by hand (the real failure mode `sqlite::memory:` after a
+    /// plain `init` cannot reproduce, since a fresh DB already has the column).
+    #[tokio::test]
+    async fn init_is_idempotent_and_adds_max_concurrent_to_legacy_table() {
+        let db = sqlx::sqlite::SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .unwrap();
+
+        // Pre-#239 schema: the `triggers` table WITHOUT `max_concurrent`.
+        sqlx::query(
+            "CREATE TABLE triggers (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                pipeline_id TEXT NOT NULL,
+                pipeline_name TEXT NOT NULL DEFAULT '',
+                target_repo TEXT,
+                source_branch TEXT,
+                input_template TEXT NOT NULL DEFAULT '',
+                variables JSON NOT NULL DEFAULT '{}',
+                cron TEXT NOT NULL,
+                guard_command TEXT,
+                overlap_policy TEXT NOT NULL DEFAULT 'skip',
+                enabled INTEGER NOT NULL DEFAULT 1,
+                next_fire_at TEXT,
+                last_fired_at TEXT,
+                last_outcome TEXT,
+                created_at TEXT NOT NULL
+            )",
+        )
+        .execute(&db)
+        .await
+        .unwrap();
+
+        // A legacy row predating the column.
+        sqlx::query(
+            "INSERT INTO triggers (id, name, pipeline_id, cron, created_at)
+             VALUES ('trg-legacy', 'legacy', 'lib-pipe', '0 9 * * *', '2026-01-01T00:00:00.000Z')",
+        )
+        .execute(&db)
+        .await
+        .unwrap();
+
+        // The column does not exist yet.
+        let before = sqlx::query(
+            "SELECT 1 FROM pragma_table_info('triggers') WHERE name = 'max_concurrent'",
+        )
+        .fetch_optional(&db)
+        .await
+        .unwrap();
+        assert!(before.is_none(), "precondition: legacy table lacks the column");
+
+        // init migrates it additively.
+        init(&db).await.unwrap();
+
+        let after = sqlx::query(
+            "SELECT 1 FROM pragma_table_info('triggers') WHERE name = 'max_concurrent'",
+        )
+        .fetch_optional(&db)
+        .await
+        .unwrap();
+        assert!(after.is_some(), "init must add the max_concurrent column");
+
+        // The legacy row reads back with a NULL (unbounded) cap.
+        let migrated = get(&db, "trg-legacy").await.unwrap().unwrap();
+        assert_eq!(migrated.max_concurrent, None);
+
+        // A second init is a no-op (the PRAGMA guard prevents a duplicate-column ALTER).
+        init(&db).await.unwrap();
+        assert_eq!(
+            get(&db, "trg-legacy").await.unwrap().unwrap().max_concurrent,
+            None
+        );
     }
 }

--- a/crates/pdo-daemon/tests/trigger_scheduler.rs
+++ b/crates/pdo-daemon/tests/trigger_scheduler.rs
@@ -122,6 +122,33 @@ async fn create_trigger_with_guard(
     resp.json().await.unwrap()
 }
 
+/// Create a Trigger with an explicit overlap policy and optional concurrency cap
+/// (#239). `max_concurrent: None` posts no cap (unbounded under `allow`).
+async fn create_trigger_with_overlap(
+    daemon: &TestDaemon,
+    name: &str,
+    cron: &str,
+    overlap_policy: &str,
+    max_concurrent: Option<i64>,
+) -> reqwest::Response {
+    let mut body = serde_json::json!({
+        "name": name,
+        "pipeline_id": PIPELINE_NAME,
+        "cron": cron,
+        "input_template": "audit the codebase",
+        "overlap_policy": overlap_policy,
+    });
+    if let Some(m) = max_concurrent {
+        body["max_concurrent"] = serde_json::json!(m);
+    }
+    reqwest::Client::new()
+        .post(format!("{}/triggers", daemon.url()))
+        .json(&body)
+        .send()
+        .await
+        .unwrap()
+}
+
 async fn list_runs(daemon: &TestDaemon) -> Vec<serde_json::Value> {
     reqwest::Client::new()
         .get(format!("{}/runs", daemon.url()))
@@ -235,6 +262,64 @@ async fn overlap_skip_while_previous_run_is_live() {
     assert_eq!(fires[1]["outcome"].as_str(), Some("fired"));
 
     cleanup_runs(&daemon).await;
+}
+
+#[tokio::test]
+async fn bounded_allow_fires_up_to_cap_then_skips() {
+    // #239: an `allow` Trigger with max_concurrent=2 fires while fewer than 2 of
+    // its own Runs are live, then skips once the cap is reached. Each fire leaves
+    // a live Run (the seed pipeline's `solo` node stays running), so the live
+    // count climbs 0 → 1 → 2 and the third tick skips.
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+
+    let resp = create_trigger_with_overlap(&daemon, "bounded", "* * * * *", "allow", Some(2)).await;
+    assert_eq!(resp.status(), 201, "POST /triggers (bounded allow) should succeed");
+    let trigger: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(
+        trigger["max_concurrent"].as_i64(),
+        Some(2),
+        "the cap must round-trip on create"
+    );
+    let trigger_id = trigger["id"].as_str().unwrap().to_string();
+
+    // Tick 1: 0 < 2 → fire. One live Run.
+    daemon.force_trigger_due(&trigger_id).await;
+    daemon.run_trigger_tick().await;
+    assert_eq!(list_runs(&daemon).await.len(), 1, "first fire (0<2)");
+
+    // Tick 2: 1 < 2 → fire. Two live Runs (concurrency allowed under the cap).
+    daemon.force_trigger_due(&trigger_id).await;
+    daemon.run_trigger_tick().await;
+    assert_eq!(list_runs(&daemon).await.len(), 2, "second fire (1<2)");
+
+    // Tick 3: 2 >= 2 → skip. Still two Runs.
+    daemon.force_trigger_due(&trigger_id).await;
+    daemon.run_trigger_tick().await;
+    assert_eq!(
+        list_runs(&daemon).await.len(),
+        2,
+        "third tick must skip at the cap (2>=2)"
+    );
+
+    // The skip is audited as skipped-overlap, with the cap in the reason.
+    let fires = list_fires(&daemon, &trigger_id).await;
+    assert_eq!(fires[0]["outcome"].as_str(), Some("skipped-overlap"));
+    assert!(
+        fires[0]["reason"].as_str().unwrap_or("").contains("2/2"),
+        "the skip reason must carry the cap, got {:?}",
+        fires[0]["reason"]
+    );
+
+    cleanup_runs(&daemon).await;
+}
+
+#[tokio::test]
+async fn create_rejects_zero_max_concurrent() {
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+    let resp = create_trigger_with_overlap(&daemon, "zero", "* * * * *", "allow", Some(0)).await;
+    assert_eq!(resp.status(), 400, "max_concurrent=0 must be rejected");
+    let err: serde_json::Value = resp.json().await.unwrap();
+    assert!(err["error"].as_str().unwrap().contains("max_concurrent"));
 }
 
 #[tokio::test]
@@ -610,6 +695,7 @@ async fn patch_edits_schedule_input_and_overlap_and_recomputes_next_fire() {
             "cron": "*/15 * * * *",
             "input_template": "do the new thing",
             "overlap_policy": "allow",
+            "max_concurrent": 4,
         }),
     )
     .await;
@@ -619,12 +705,44 @@ async fn patch_edits_schedule_input_and_overlap_and_recomputes_next_fire() {
     assert_eq!(after["cron"].as_str(), Some("*/15 * * * *"));
     assert_eq!(after["input_template"].as_str(), Some("do the new thing"));
     assert_eq!(after["overlap_policy"].as_str(), Some("allow"));
+    // The bounded-allow cap round-trips on GET (#239).
+    assert_eq!(after["max_concurrent"].as_i64(), Some(4));
     // Changing the schedule recomputes next_fire_at forward from the new cron.
     let new_next = after["next_fire_at"].as_str().unwrap();
     assert_ne!(
         new_next, original_next,
         "a schedule edit must recompute next_fire_at"
     );
+
+    // Clearing the cap (Some(null)) returns it to unbounded.
+    let resp = patch_trigger(
+        &daemon,
+        &trigger_id,
+        serde_json::json!({ "max_concurrent": null }),
+    )
+    .await;
+    assert_eq!(resp.status(), 200);
+    assert!(
+        get_trigger(&daemon, &trigger_id).await["max_concurrent"].is_null(),
+        "patching max_concurrent to null must clear the cap"
+    );
+}
+
+#[tokio::test]
+async fn patch_rejects_zero_max_concurrent() {
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+    let trigger = create_trigger(&daemon, "audit", "0 9 * * *").await;
+    let trigger_id = trigger["id"].as_str().unwrap().to_string();
+
+    let resp = patch_trigger(
+        &daemon,
+        &trigger_id,
+        serde_json::json!({ "max_concurrent": 0 }),
+    )
+    .await;
+    assert_eq!(resp.status(), 400, "patching max_concurrent=0 must be rejected");
+    let err: serde_json::Value = resp.json().await.unwrap();
+    assert!(err["error"].as_str().unwrap().contains("max_concurrent"));
 }
 
 #[tokio::test]

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -245,6 +245,8 @@ export interface CreateTriggerRequest {
   variables?: Record<string, unknown>;
   guard_command?: string;
   overlap_policy?: string;
+  /** Bounded-`allow` ceiling (#239): max simultaneous live Runs; omit/undefined = unbounded. */
+  max_concurrent?: number | null;
 }
 
 export async function fetchTriggers(): Promise<Trigger[]> {
@@ -287,6 +289,8 @@ export interface UpdateTriggerRequest {
   source_branch?: string | null;
   guard_command?: string | null;
   variables?: Record<string, unknown>;
+  /** Bounded-`allow` ceiling (#239): number sets, null clears to unbounded, undefined leaves unchanged. */
+  max_concurrent?: number | null;
 }
 
 export async function updateTrigger(

--- a/frontend/src/components/NewRunModal.test.tsx
+++ b/frontend/src/components/NewRunModal.test.tsx
@@ -801,6 +801,64 @@ describe("NewRunModal — Trigger mode (#160)", () => {
       );
     });
   });
+
+  // --- #239: bounded-allow overlap control ---
+
+  it("reveals the max-concurrent input only when the allow checkbox is checked", async () => {
+    await selectPipelineAndRepo();
+    fireEvent.click(screen.getByTestId("mode-trigger"));
+    expect(screen.getByTestId("overlap-allow-checkbox")).toBeInTheDocument();
+    expect(screen.queryByTestId("max-concurrent-input")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("overlap-allow-checkbox"));
+    expect(screen.getByTestId("max-concurrent-input")).toBeInTheDocument();
+  });
+
+  it("creates an allow trigger with the chosen max_concurrent cap", async () => {
+    await selectPipelineAndRepo();
+    fireEvent.click(screen.getByTestId("mode-trigger"));
+    fireEvent.change(screen.getByTestId("trigger-name-input"), {
+      target: { value: "Bounded" },
+    });
+    fireEvent.click(screen.getByTestId("overlap-allow-checkbox"));
+    fireEvent.change(screen.getByTestId("max-concurrent-input"), {
+      target: { value: "2" },
+    });
+
+    vi.useRealTimers();
+    fireEvent.click(screen.getByTestId("create-trigger-button"));
+
+    await waitFor(() => {
+      expect(createTrigger).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "Bounded",
+          overlap_policy: "allow",
+          max_concurrent: 2,
+        }),
+      );
+    });
+  });
+
+  it("creates a skip trigger with no cap when the box is unchecked", async () => {
+    await selectPipelineAndRepo();
+    fireEvent.click(screen.getByTestId("mode-trigger"));
+    fireEvent.change(screen.getByTestId("trigger-name-input"), {
+      target: { value: "Default" },
+    });
+
+    vi.useRealTimers();
+    fireEvent.click(screen.getByTestId("create-trigger-button"));
+
+    await waitFor(() => {
+      expect(createTrigger).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "Default",
+          overlap_policy: "skip",
+          max_concurrent: undefined,
+        }),
+      );
+    });
+  });
 });
 
 describe("NewRunModal — run-now and edit from a Trigger (#162)", () => {
@@ -918,5 +976,43 @@ describe("NewRunModal — run-now and edit from a Trigger (#162)", () => {
     });
     // Editing never creates a brand-new trigger.
     expect(createTrigger).not.toHaveBeenCalled();
+  });
+
+  it("edit-prefills the allow checkbox and cap from a bounded-allow trigger (#239)", async () => {
+    const bounded = { ...sampleTrigger, overlap_policy: "allow", max_concurrent: 3 };
+    render(
+      <NewRunModal
+        open={true}
+        onClose={noop}
+        onCreated={noop}
+        prefillTrigger={{ trigger: bounded, mode: "edit" }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("mode-trigger")).toHaveAttribute("aria-selected", "true");
+    });
+    // The box is pre-checked and the cap input pre-filled.
+    await waitFor(() => {
+      expect(screen.getByTestId("overlap-allow-checkbox")).toBeChecked();
+    });
+    expect(screen.getByTestId("max-concurrent-input")).toHaveValue(3);
+
+    // Saving round-trips the policy + cap (no silent reset to skip).
+    await vi.advanceTimersByTimeAsync(500);
+    await waitFor(() => expect(validateRepo).toHaveBeenCalledWith("/home/user/project"));
+    vi.useRealTimers();
+    await waitFor(() => expect(screen.getByTestId("save-trigger-button")).toBeEnabled());
+    fireEvent.click(screen.getByTestId("save-trigger-button"));
+
+    await waitFor(() => {
+      expect(updateTrigger).toHaveBeenCalledWith(
+        "trg-9",
+        expect.objectContaining({
+          overlap_policy: "allow",
+          max_concurrent: 3,
+        }),
+      );
+    });
   });
 });

--- a/frontend/src/components/NewRunModal.tsx
+++ b/frontend/src/components/NewRunModal.tsx
@@ -48,6 +48,11 @@ export default function NewRunModal({ open, onClose, onCreated, prefillTrigger =
   const [dailyMinute, setDailyMinute] = useState(0);
   const [rawCron, setRawCron] = useState("");
   const [guardCommand, setGuardCommand] = useState("");
+  // Overlap policy (#239): unchecked → "skip"; checked → "allow", with an
+  // optional concurrency cap (blank = unbounded). `maxConcurrent` is a string so
+  // an empty input maps cleanly to "no cap".
+  const [allowOverlap, setAllowOverlap] = useState(false);
+  const [maxConcurrent, setMaxConcurrent] = useState("");
   const [varsOpen, setVarsOpen] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -121,6 +126,10 @@ export default function NewRunModal({ open, onClose, onCreated, prefillTrigger =
       setEditingTriggerId(trigger.id);
       setTriggerName(trigger.name);
       setGuardCommand(trigger.guard_command ?? "");
+      // Overlap policy (#239): round-trip the real policy instead of resetting it
+      // to skip. Pre-check the box for an `allow` Trigger and fill its cap.
+      setAllowOverlap(trigger.overlap_policy === "allow");
+      setMaxConcurrent(trigger.max_concurrent != null ? String(trigger.max_concurrent) : "");
       // Map the stored cron back onto a preset (or the raw escape hatch).
       const preset = cronToPreset(trigger.cron);
       setCronPresetId(preset);
@@ -404,7 +413,11 @@ export default function NewRunModal({ open, onClose, onCreated, prefillTrigger =
           guard_command: guardCommand.trim() || null,
           target_repo: targetRepo.trim() || null,
           source_branch: sourceBranch || null,
-          overlap_policy: undefined,
+          // Round-trip the real overlap policy (#239). Previously hard-coded to
+          // `undefined`, which silently reset every edited trigger toward skip.
+          // `null` clears a stale cap when overlap is off or the input is blank.
+          overlap_policy: allowOverlap ? "allow" : "skip",
+          max_concurrent: allowOverlap && maxConcurrent.trim() ? Number(maxConcurrent) : null,
           variables,
         });
       } else {
@@ -416,6 +429,8 @@ export default function NewRunModal({ open, onClose, onCreated, prefillTrigger =
           guard_command: guardCommand.trim() || undefined,
           target_repo: targetRepo.trim() || undefined,
           source_branch: sourceBranch || undefined,
+          overlap_policy: allowOverlap ? "allow" : "skip",
+          max_concurrent: allowOverlap && maxConcurrent.trim() ? Number(maxConcurrent) : undefined,
           variables,
         });
       }
@@ -423,6 +438,8 @@ export default function NewRunModal({ open, onClose, onCreated, prefillTrigger =
       setTriggerName("");
       setInput("");
       setGuardCommand("");
+      setAllowOverlap(false);
+      setMaxConcurrent("");
       setOverrides({});
       setMode("run");
       setEditingTriggerId(null);
@@ -447,6 +464,8 @@ export default function NewRunModal({ open, onClose, onCreated, prefillTrigger =
     resolvedCron,
     input,
     guardCommand,
+    allowOverlap,
+    maxConcurrent,
     targetRepo,
     sourceBranch,
     flushPendingSaves,
@@ -838,6 +857,42 @@ export default function NewRunModal({ open, onClose, onCreated, prefillTrigger =
                   <span className="text-fg-4" style={{ fontSize: "10.5px" }}>
                     Runs before each fire from the target repo. Exit 0 fires (its stdout becomes the
                     Run input); a non-zero exit skips. Bounded by a 60s timeout.
+                  </span>
+                </div>
+
+                {/* Overlap policy (#239): allow concurrent fires, optionally capped. */}
+                <div className="flex flex-col gap-1.5">
+                  <label
+                    className="flex items-center gap-1.5 font-medium text-fg-2"
+                    style={{ fontSize: "11.5px" }}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={allowOverlap}
+                      onChange={(e) => setAllowOverlap(e.target.checked)}
+                      className="accent-acc"
+                      data-testid="overlap-allow-checkbox"
+                    />
+                    Allow concurrent fires
+                  </label>
+                  {allowOverlap && (
+                    <div className="flex items-center gap-1.5" style={{ fontSize: "11px" }}>
+                      <span className="text-fg-3">Max concurrent runs</span>
+                      <input
+                        type="number"
+                        min={1}
+                        placeholder="∞"
+                        value={maxConcurrent}
+                        onChange={(e) => setMaxConcurrent(e.target.value)}
+                        className="w-16 rounded border border-line-strong bg-bg-3 px-1.5 py-0.5 text-fg focus:border-acc focus:outline-none"
+                        data-testid="max-concurrent-input"
+                      />
+                      <span className="text-fg-4">Blank = unlimited</span>
+                    </div>
+                  )}
+                  <span className="text-fg-4" style={{ fontSize: "10.5px" }}>
+                    By default a trigger skips a tick while its previous run is still live. Allow
+                    concurrent fires to let runs stack, optionally capped at N simultaneous runs.
                   </span>
                 </div>
               </div>

--- a/frontend/src/components/TriggerDetailPanel.test.tsx
+++ b/frontend/src/components/TriggerDetailPanel.test.tsx
@@ -106,4 +106,34 @@ describe("TriggerDetailPanel", () => {
     render(<TriggerDetailPanel trigger={trigger()} onSelectRun={noop} />);
     expect(await screen.findByText(/no fires yet/i)).toBeInTheDocument();
   });
+
+  it("shows the concurrency cap for a bounded-allow trigger (#239)", () => {
+    render(
+      <TriggerDetailPanel
+        trigger={trigger({ overlap_policy: "allow", max_concurrent: 3 })}
+        onSelectRun={noop}
+      />,
+    );
+    expect(screen.getByTestId("trigger-detail-overlap")).toHaveTextContent("max 3 concurrent");
+  });
+
+  it("shows unlimited for an allow trigger without a cap (#239)", () => {
+    render(
+      <TriggerDetailPanel
+        trigger={trigger({ overlap_policy: "allow", max_concurrent: null })}
+        onSelectRun={noop}
+      />,
+    );
+    expect(screen.getByTestId("trigger-detail-overlap")).toHaveTextContent(/unlimited/i);
+  });
+
+  it("shows skip (default) for a skip trigger (#239 regression)", () => {
+    render(
+      <TriggerDetailPanel
+        trigger={trigger({ overlap_policy: "skip" })}
+        onSelectRun={noop}
+      />,
+    );
+    expect(screen.getByTestId("trigger-detail-overlap")).toHaveTextContent("skip (default)");
+  });
 });

--- a/frontend/src/components/TriggerDetailPanel.tsx
+++ b/frontend/src/components/TriggerDetailPanel.tsx
@@ -100,7 +100,11 @@ export default function TriggerDetailPanel({ trigger, onSelectRun }: Props) {
 
         <ConfigRow icon={<Layers size={12} />} label="Overlap">
           <span className="text-fg-2" data-testid="trigger-detail-overlap">
-            {trigger.overlap_policy === "allow" ? "allow (concurrent fires)" : "skip (default)"}
+            {trigger.overlap_policy === "allow"
+              ? trigger.max_concurrent != null
+                ? `allow (max ${trigger.max_concurrent} concurrent)`
+                : "allow (unlimited concurrent fires)"
+              : "skip (default)"}
           </span>
         </ConfigRow>
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -52,6 +52,8 @@ export interface Trigger {
   cron: string;
   guard_command?: string | null;
   overlap_policy: string;
+  /** Bounded-`allow` ceiling (#239): max simultaneous live Runs; null = unbounded. */
+  max_concurrent?: number | null;
   enabled: boolean;
   next_fire_at?: string | null;
   last_fired_at?: string | null;


### PR DESCRIPTION
Closes #239.

## What

Adds a **bounded-concurrency `allow`** overlap mode for triggers: a fired run can overlap previous fires up to a configurable cap, instead of only the all-or-nothing `skip` / unbounded `allow`.

- **Backend**: `fire_decision::overlap_ceiling` collapses the three modes — `skip` → 1, `allow + None` → unbounded, `allow + Some(m)` → `m`, with a defensive clamp so a stray `0` can never make a trigger unfireable. New `max_concurrent` column on triggers via a PRAGMA-guarded, idempotent additive migration (`trigger_store.rs`). `PATCH` uses a `deserialize_double_option` helper so `max_concurrent: null` clears the cap (back to unbounded) over real JSON.
- **Frontend**: the previously-hard-coded-off "Allow concurrent fires" checkbox now renders; checking it reveals "Max concurrent runs" (blank = unlimited). Edit round-trips correctly (box pre-checked, cap pre-filled). Detail panel shows `allow (max N concurrent)` / `allow (unlimited concurrent fires)` / `skip (default)`.

## Validation

Implemented by the `auto-issue-implement` pipeline and independently re-validated by a dedicated agentic-tester node (verdict **Pass**) against an isolated full-stack daemon (fresh DB, real browser + curl):

- API round-trip: `allow + max_concurrent:2` → 200; `max_concurrent:0` → **400** (`must be >= 1`); `PATCH null` clears cap; re-set works.
- UI create → store → display loop verified end-to-end with screenshots.
- Test suites re-run green: `cargo test -p pdo-daemon --lib` **954 passed**, `--test trigger_scheduler` **23 passed** (incl. `bounded_allow_fires_up_to_cap_then_skips`), `vitest` **798 passed**.

## Out of scope (pre-existing)

Sibling `PATCH` fields (`target_repo`, `source_branch`, `guard_command`) still use plain `#[serde(default)]` and so can't be cleared to NULL via HTTP `null` — only `max_concurrent` got the double-option helper. Documented with a follow-up note; unrelated to #239.
