### PR TITLE
fix(triggers): allow repointing a trigger to another pipeline (#230)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1688,7 +1688,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "0.1.19"
+version = "0.1.20"
 license = "MIT"
 
 [workspace.dependencies]

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -979,6 +979,11 @@ async fn get_trigger(
 struct PatchTriggerRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     name: Option<String>,
+    /// Repoint the Trigger to a different library pipeline (#230). Validated
+    /// against the library/repo before applying; the denormalised display name
+    /// and a revived next-fire follow from it.
+    #[serde(default)]
+    pipeline_id: Option<String>,
     #[serde(default)]
     enabled: Option<bool>,
     #[serde(default)]
@@ -1057,6 +1062,55 @@ async fn patch_trigger(
         }
     }
 
+    // A pipeline repoint (#230): the target must exist. Resolve and parse its
+    // YAML to capture the display name (denormalised on the row) and the
+    // prompt_required flag (used by the reject rule below). A no-op repoint to
+    // the same id is ignored. Without this, serde silently dropped `pipeline_id`
+    // and a Trigger could never be moved off a wrong or renamed pipeline.
+    let mut repoint: Option<(String, String)> = None;
+    let mut repoint_prompt_required: Option<bool> = None;
+    if let Some(ref new_pid) = req.pipeline_id {
+        if *new_pid != existing.pipeline_id {
+            let yaml = library_store::pipelines::get_yaml(&state.repo_root, new_pid).or_else(|| {
+                std::fs::read_to_string(resolve_pipeline_path(&state.repo_root, new_pid)).ok()
+            });
+            let yaml = match yaml {
+                Some(y) => y,
+                None => {
+                    return (
+                        StatusCode::BAD_REQUEST,
+                        Json(serde_json::json!({
+                            "error": format!("pipeline not found: {new_pid}")
+                        })),
+                    )
+                        .into_response();
+                }
+            };
+            match pipeline::parse_pipeline(&yaml) {
+                Ok(r) => {
+                    repoint_prompt_required = Some(r.pipeline.prompt_required);
+                    repoint = Some((new_pid.clone(), r.pipeline.name.clone()));
+                }
+                Err(e) => {
+                    return (
+                        StatusCode::BAD_REQUEST,
+                        Json(serde_json::json!({ "error": format!("pipeline parse error: {e}") })),
+                    )
+                        .into_response();
+                }
+            }
+            // Revive the next fire from the existing cron unless a schedule edit
+            // already recomputed it, so a Trigger that went dormant on a
+            // pipeline-id rename comes back to life on repoint instead of
+            // staying dead (Sharp tool; ADR-0012).
+            if next_fire_at.is_none() {
+                if let Ok(schedule) = cron_schedule::CronSchedule::parse(&existing.cron) {
+                    next_fire_at = Some(first_next_fire(&schedule));
+                }
+            }
+        }
+    }
+
     // Validate a target-repo edit (Some(Some(path)) means set; Some(None) clears).
     if let Some(Some(ref repo)) = req.target_repo {
         if let Err(msg) = validate_target_repo(repo) {
@@ -1090,7 +1144,10 @@ async fn patch_trigger(
         .input_template
         .clone()
         .unwrap_or_else(|| existing.input_template.clone());
-    let prompt_required = trigger_prompt_required(&state, &existing);
+    // When repointing, the reject rule must judge the *new* pipeline's
+    // prompt_required, not the old one's.
+    let prompt_required =
+        repoint_prompt_required.unwrap_or_else(|| trigger_prompt_required(&state, &existing));
     if prompt_required
         && resulting_guard.as_deref().unwrap_or("").trim().is_empty()
         && resulting_input.trim().is_empty()
@@ -1107,6 +1164,8 @@ async fn patch_trigger(
 
     let edit = trigger_store::UpdateTrigger {
         name: req.name,
+        pipeline_id: repoint.as_ref().map(|(id, _)| id.clone()),
+        pipeline_name: repoint.as_ref().map(|(_, name)| name.clone()),
         target_repo: req.target_repo,
         source_branch: req.source_branch,
         input_template: req.input_template,
@@ -10111,6 +10170,17 @@ mod tests {
         std::fs::write(pipelines_dir.join(format!("{name}.yaml")), yaml).unwrap();
     }
 
+    /// A prompt-optional repo pipeline, so trigger create/repoint never trips the
+    /// prompt-required reject rule in these route tests.
+    fn write_optional_pipeline(dir: &std::path::Path, id: &str) {
+        let pipelines_dir = dir.join(".pdo").join("pipelines");
+        std::fs::create_dir_all(&pipelines_dir).unwrap();
+        let yaml = format!(
+            "name: {id}\nversion: \"1.0\"\nprompt_required: false\nnodes:\n{START_END_YAML}  - id: worker\n    name: worker\n    type: doc-only\n    inputs:\n      - name: task\n    outputs:\n      - name: result\n"
+        );
+        std::fs::write(pipelines_dir.join(format!("{id}.yaml")), yaml).unwrap();
+    }
+
     #[tokio::test]
     async fn sync_run_pipeline_writes_canonical_prompt_path() {
         // #231: run-scoped sync must write each prompt to the canonical
@@ -10254,6 +10324,142 @@ mod tests {
         assert_eq!(required["prompt_required"], serde_json::json!(true));
         let optional = list.iter().find(|p| p["id"] == "optional-pipe").unwrap();
         assert_eq!(optional["prompt_required"], serde_json::json!(false));
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn patch_trigger_repoints_to_another_pipeline() {
+        // #230: PATCH /triggers/{id} {pipeline_id} must move the trigger to the
+        // new pipeline — id *and* denormalised name — and persist it, instead of
+        // serde silently dropping an unknown field. Driven end-to-end through the
+        // router so the deserialization path itself is under test.
+        let _home = FakeHome::new();
+        let tmp = tempfile::tempdir().unwrap();
+        write_optional_pipeline(tmp.path(), "watch-pipe");
+        write_optional_pipeline(tmp.path(), "weekly-pipe");
+        let state = test_state_with_dir(tmp.path()).await;
+        let app = build_router(state.clone());
+
+        // Create a trigger bound to watch-pipe.
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/triggers")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({
+                            "name": "PDO Weekly",
+                            "pipeline_id": "watch-pipe",
+                            "cron": "0 4 * * 1",
+                            "input_template": "x"
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let created: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let id = created["id"].as_str().unwrap().to_string();
+        assert_eq!(created["pipeline_id"], "watch-pipe");
+        assert_eq!(created["pipeline_name"], "watch-pipe");
+
+        // Repoint it to weekly-pipe.
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("PATCH")
+                    .uri(format!("/triggers/{id}"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({ "pipeline_id": "weekly-pipe" }).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let updated: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(updated["pipeline_id"], "weekly-pipe");
+        assert_eq!(updated["pipeline_name"], "weekly-pipe");
+
+        // Persisted in the store, not merely echoed back.
+        let after = trigger_store::get(&state.db, &id).await.unwrap().unwrap();
+        assert_eq!(after.pipeline_id, "weekly-pipe");
+        assert_eq!(after.pipeline_name, "weekly-pipe");
+        // The repoint revived the next fire from the trigger's own cron.
+        assert!(after.next_fire_at.is_some());
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn patch_trigger_rejects_repoint_to_unknown_pipeline() {
+        // #230: a repoint to a non-existent pipeline is a loud 400, never a
+        // silent success that leaves the trigger dangling.
+        let _home = FakeHome::new();
+        let tmp = tempfile::tempdir().unwrap();
+        write_optional_pipeline(tmp.path(), "watch-pipe");
+        let state = test_state_with_dir(tmp.path()).await;
+        let app = build_router(state.clone());
+
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/triggers")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({
+                            "name": "T",
+                            "pipeline_id": "watch-pipe",
+                            "cron": "0 4 * * 1",
+                            "input_template": "x"
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let id = serde_json::from_slice::<serde_json::Value>(&body).unwrap()["id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("PATCH")
+                    .uri(format!("/triggers/{id}"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({ "pipeline_id": "ghost-pipe" }).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+
+        // The trigger is left exactly as it was.
+        let after = trigger_store::get(&state.db, &id).await.unwrap().unwrap();
+        assert_eq!(after.pipeline_id, "watch-pipe");
     }
 
     #[tokio::test]

--- a/crates/pdo-daemon/src/trigger_store.rs
+++ b/crates/pdo-daemon/src/trigger_store.rs
@@ -352,6 +352,12 @@ pub async fn set_next_fire(
 #[derive(Debug, Clone, Default)]
 pub struct UpdateTrigger {
     pub name: Option<String>,
+    /// Repoint the Trigger to a different library pipeline (#230). The route is
+    /// responsible for validating the target exists; both `pipeline_id` and the
+    /// denormalised `pipeline_name` are updated together so list rendering can't
+    /// show a stale name.
+    pub pipeline_id: Option<String>,
+    pub pipeline_name: Option<String>,
     pub target_repo: Option<Option<String>>,
     pub source_branch: Option<Option<String>>,
     pub input_template: Option<String>,
@@ -368,6 +374,8 @@ pub struct UpdateTrigger {
 impl UpdateTrigger {
     fn is_empty(&self) -> bool {
         self.name.is_none()
+            && self.pipeline_id.is_none()
+            && self.pipeline_name.is_none()
             && self.target_repo.is_none()
             && self.source_branch.is_none()
             && self.input_template.is_none()
@@ -395,6 +403,12 @@ pub async fn update(
     let mut sets: Vec<&str> = Vec::new();
     if edit.name.is_some() {
         sets.push("name = ?");
+    }
+    if edit.pipeline_id.is_some() {
+        sets.push("pipeline_id = ?");
+    }
+    if edit.pipeline_name.is_some() {
+        sets.push("pipeline_name = ?");
     }
     if edit.target_repo.is_some() {
         sets.push("target_repo = ?");
@@ -427,6 +441,12 @@ pub async fn update(
     let sql = format!("UPDATE triggers SET {} WHERE id = ?", sets.join(", "));
     let mut query = sqlx::query(&sql);
     if let Some(v) = &edit.name {
+        query = query.bind(v.clone());
+    }
+    if let Some(v) = &edit.pipeline_id {
+        query = query.bind(v.clone());
+    }
+    if let Some(v) = &edit.pipeline_name {
         query = query.bind(v.clone());
     }
     if let Some(v) = &edit.target_repo {
@@ -773,6 +793,44 @@ mod tests {
             .unwrap()
             .guard_command
             .is_none());
+    }
+
+    #[tokio::test]
+    async fn update_can_repoint_pipeline() {
+        // #230: a Trigger must be movable to a different pipeline. Both the id and
+        // the denormalised display name update together; unrelated fields survive.
+        let db = test_db().await;
+        let t = create(&db, sample("repointable", "0 9 * * *")).await.unwrap();
+        assert_eq!(t.pipeline_id, "lib-pipe-1");
+        assert_eq!(t.pipeline_name, "Auditor");
+
+        update(
+            &db,
+            &t.id,
+            UpdateTrigger {
+                pipeline_id: Some("lib-pipe-2".to_string()),
+                pipeline_name: Some("Bugfixer".to_string()),
+                next_fire_at: Some(Some("2027-03-01T00:00:00.000Z".to_string())),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        let after = get(&db, &t.id).await.unwrap().unwrap();
+        assert_eq!(after.pipeline_id, "lib-pipe-2");
+        assert_eq!(after.pipeline_name, "Bugfixer");
+        // A revived next fire (the dormant-on-rename recovery path).
+        assert_eq!(
+            after.next_fire_at.as_deref(),
+            Some("2027-03-01T00:00:00.000Z")
+        );
+        // Everything else is left untouched.
+        assert_eq!(after.name, "repointable");
+        assert_eq!(after.cron, "0 9 * * *");
+        assert_eq!(after.input_template, "audit the codebase");
+        assert_eq!(after.target_repo.as_deref(), Some("/repos/foo"));
+        assert!(after.enabled);
     }
 
     #[tokio::test]

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -281,6 +281,8 @@ export async function fetchTrigger(triggerId: string): Promise<Trigger> {
  */
 export interface UpdateTriggerRequest {
   name?: string;
+  /** Repoint the trigger to a different pipeline (#230). Validated server-side. */
+  pipeline_id?: string;
   enabled?: boolean;
   cron?: string;
   input_template?: string;

--- a/frontend/src/components/NewRunModal.test.tsx
+++ b/frontend/src/components/NewRunModal.test.tsx
@@ -883,6 +883,7 @@ describe("NewRunModal — run-now and edit from a Trigger (#162)", () => {
   beforeEach(() => {
     vi.mocked(fetchPipelines).mockResolvedValue([
       makePipeline({ id: "p1", name: "Auditor", scope: "repo", prompt_required: false }),
+      makePipeline({ id: "p2", name: "Bugfixer", scope: "repo", prompt_required: false }),
     ]);
   });
 
@@ -969,6 +970,9 @@ describe("NewRunModal — run-now and edit from a Trigger (#162)", () => {
         "trg-9",
         expect.objectContaining({
           name: "Nightly audit",
+          // The current pipeline is always sent so an unchanged edit is a no-op
+          // repoint server-side (#230).
+          pipeline_id: "p1",
           cron: "0 * * * *",
           input_template: "audit harder",
         }),
@@ -1014,5 +1018,46 @@ describe("NewRunModal — run-now and edit from a Trigger (#162)", () => {
         }),
       );
     });
+  });
+
+  it("edit repoints the trigger to the newly selected pipeline (#230)", async () => {
+    render(
+      <NewRunModal
+        open={true}
+        onClose={noop}
+        onCreated={noop}
+        prefillTrigger={{ trigger: sampleTrigger, mode: "edit" }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("mode-trigger")).toHaveAttribute("aria-selected", "true");
+    });
+    // Prefilled with the trigger's current pipeline.
+    await waitFor(() => {
+      expect(screen.getByTestId("pipeline-select")).toHaveValue("p1");
+    });
+
+    // Let the debounced repo validation resolve so the form is submittable.
+    await vi.advanceTimersByTimeAsync(500);
+    await waitFor(() => expect(validateRepo).toHaveBeenCalledWith("/home/user/project"));
+
+    // Change the pipeline — the dropdown is interactive in edit mode, and the
+    // change must now actually reach the server (it used to be silently dropped).
+    fireEvent.change(screen.getByTestId("pipeline-select"), {
+      target: { value: "p2" },
+    });
+
+    vi.useRealTimers();
+    await waitFor(() => expect(screen.getByTestId("save-trigger-button")).toBeEnabled());
+    fireEvent.click(screen.getByTestId("save-trigger-button"));
+
+    await waitFor(() => {
+      expect(updateTrigger).toHaveBeenCalledWith(
+        "trg-9",
+        expect.objectContaining({ pipeline_id: "p2" }),
+      );
+    });
+    expect(createTrigger).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/NewRunModal.tsx
+++ b/frontend/src/components/NewRunModal.tsx
@@ -405,9 +405,12 @@ export default function NewRunModal({ open, onClose, onCreated, prefillTrigger =
       await flushPendingSaves();
       if (editingTriggerId) {
         // Edit (#162): PATCH the existing Trigger's editable fields. `Some(None)`
-        // semantics: an emptied guard clears it.
+        // semantics: an emptied guard clears it. `pipeline_id` repoints the
+        // trigger to a different pipeline (#230) — previously the editable
+        // dropdown was a phantom control whose change was silently dropped.
         await updateTrigger(editingTriggerId, {
           name: triggerName.trim(),
+          pipeline_id: selectedPipeline.id,
           cron: resolvedCron,
           input_template: input.trim(),
           guard_command: guardCommand.trim() || null,


### PR DESCRIPTION
## What

Fixes #230 — a Trigger silently orphaned when its pipeline id is renamed, with no API path to repoint it (the `pipeline_id` field was missing from the `PATCH /triggers/{id}` body, and the Edit-modal pipeline dropdown was a phantom control whose change was dropped).

## Changes

- **Backend** (`lib.rs`, `trigger_store.rs`): `PATCH /triggers/{id}` now accepts `pipeline_id`. On repoint it validates the target pipeline exists (**400** on unknown / parse error), denormalises `pipeline_name`, re-judges `prompt_required` against the new pipeline, and revives `next_fire`. `trigger_store::update` persists `pipeline_id`/`pipeline_name` (dynamic SET clause + matching bind order).
- **Frontend** (`api.ts`, `NewRunModal.tsx`): the Edit-trigger pipeline dropdown now actually drives the repoint — the save sends `pipeline_id`.
- **Tests**: backend router/store tests (`patch_trigger_repoints_to_another_pipeline`, `patch_trigger_rejects_repoint_to_unknown_pipeline`, `update_can_repoint_pipeline`); frontend tests asserting the PATCH carries `pipeline_id`.
- **Release**: workspace version `0.1.19` → `0.1.20`.

## Verification

- Visual tester node verdict: **Pass** (live browser repro of the exact #230 orphan scenario; captured PATCH carries `pipeline_id`).
- Rebased cleanly onto latest `main` (on top of #242, the bounded-concurrency overlap feature, which touched the same trigger files). Conflict in `NewRunModal.test.tsx` resolved by keeping both the #239 and #230 tests.
- Frontend: `npm run build` (tsc + vite) clean; `vitest NewRunModal.test.tsx` → **54 passed**.
- Backend: `cargo test --no-run -p pdo-daemon` (merged tree) compiles, incl. test module.

Closes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)
