### PR TITLE
fix(runtime): graceful no-op via `pdo skip` for empty-pool runs (#245)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1688,7 +1688,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "0.1.20"
+version = "0.1.21"
 license = "MIT"
 
 [workspace.dependencies]

--- a/crates/pdo-daemon/src/admission.rs
+++ b/crates/pdo-daemon/src/admission.rs
@@ -175,6 +175,15 @@ mod tests {
     }
 
     #[test]
+    fn excludes_skipped_run_with_a_running_node() {
+        // #245: a graceful no-op (Skipped) is terminal; a node still projected
+        // Running inside it is a phantom and must not consume an admission slot.
+        let mut skipped = run_with_nodes("r1", &[("a", NodeStatus::Running)]);
+        skipped.status = RunStatus::Skipped;
+        assert_eq!(count_live_node_sessions([&skipped]), 0);
+    }
+
+    #[test]
     fn counts_a_running_node_in_a_paused_run() {
         // Regression guard: Paused is *live*, not terminal. Don't over-exclude
         // it — a paused run's Running node still holds its session and slot.

--- a/crates/pdo-daemon/src/event_log.rs
+++ b/crates/pdo-daemon/src/event_log.rs
@@ -67,6 +67,11 @@ pub enum EventKind {
     PipelineModified,
     RunCompleted,
     RunFailed,
+    /// Graceful no-op (#245): the run fired but there was legitimately nothing
+    /// to do (e.g. an auto-issue selector found its eligible pool emptied
+    /// between guard-eval and node-run). A distinct terminal status from
+    /// `RunFailed` so honest history is not polluted with spurious failures.
+    RunSkipped,
     RunHalted,
     RunPaused,
     RunResumed,
@@ -93,6 +98,10 @@ pub enum RunStatus {
     AwaitingUser,
     Completed,
     Failed,
+    /// Graceful no-op terminal state (#245): the run fired but had nothing to
+    /// do. Terminal and non-`is_live`, distinct from `Completed` (did work) and
+    /// `Failed` (genuine error), so "fired but nothing to do" stays honest.
+    Skipped,
     Halted,
     Paused,
     Archived,
@@ -103,9 +112,10 @@ impl RunStatus {
     /// live, its session-holding nodes still consume an admission slot and a new
     /// trigger fire is blocked by an overlapping run.
     ///
-    /// `Completed`/`Failed`/`Halted`/`Archived` are terminal: such a run spawns
-    /// no new work, so its nodes hold no live session (#215). `Halted` is
-    /// terminal-but-resumable but, while halted, holds nothing either.
+    /// `Completed`/`Failed`/`Skipped`/`Halted`/`Archived` are terminal: such a
+    /// run spawns no new work, so its nodes hold no live session (#215).
+    /// `Skipped` is a graceful no-op (#245); `Halted` is terminal-but-resumable
+    /// but, while halted, holds nothing either.
     pub fn is_live(&self) -> bool {
         matches!(
             self,
@@ -793,6 +803,14 @@ pub fn project(events: &[Event]) -> Option<RunState> {
                 state.status = RunStatus::Failed;
                 state.completed_at = Some(event.ts.clone());
             }
+            EventKind::RunSkipped => {
+                // Graceful no-op (#245): terminal, like RunFailed/RunCompleted.
+                // The run reached no `end` node (the selector short-circuited),
+                // so end-node ports stay pending — only the run status reflects
+                // "fired but nothing to do".
+                state.status = RunStatus::Skipped;
+                state.completed_at = Some(event.ts.clone());
+            }
             EventKind::RunHalted => {
                 state.status = RunStatus::Halted;
                 state.completed_at = Some(event.ts.clone());
@@ -1093,6 +1111,38 @@ mod tests {
         assert_eq!(node.status, NodeStatus::Failed);
         assert_eq!(node.failure_reason.as_deref(), Some("could not complete"));
         assert!(node.frontmatter_violations.is_empty());
+    }
+
+    #[test]
+    fn run_skipped_is_a_distinct_terminal_status() {
+        // #245: a graceful no-op completes the selector node and marks the run
+        // Skipped — distinct from Completed (did work) and Failed (error).
+        let events = vec![
+            make_event(EventKind::RunStarted, None, None),
+            make_event(EventKind::NodeStarted, Some("selector"), Some(1)),
+            make_event_with_payload(
+                EventKind::NodeCompleted,
+                Some("selector"),
+                serde_json::json!({ "skipped": true, "reason": "no eligible issue" }),
+            ),
+            make_event_with_payload(
+                EventKind::RunSkipped,
+                None,
+                serde_json::json!({ "reason": "no eligible issue" }),
+            ),
+        ];
+
+        let state = project(&events).unwrap();
+        assert_eq!(state.status, RunStatus::Skipped);
+        assert!(!state.status.is_live(), "skipped run must not be live");
+        assert!(state.completed_at.is_some());
+        // The node that skipped is honestly terminal-Completed (it ran and
+        // reached a decision); only the run reflects "nothing to do".
+        assert_eq!(state.nodes["selector"].status, NodeStatus::Completed);
+        assert!(
+            !is_stalled(&state),
+            "a terminal Skipped run is never stalled"
+        );
     }
 
     #[test]

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -95,6 +95,15 @@ pub enum Commands {
         #[arg(long)]
         reason: String,
     },
+    /// Graceful no-op (#245): there is legitimately nothing to do, so end the
+    /// run as `skipped` instead of `failed`. Use when a node cannot do its work
+    /// because the input/pool is empty (e.g. an auto-issue selector whose
+    /// eligible issues were all claimed between guard-eval and node-run), NOT
+    /// for genuine errors — reserve `fail` for those.
+    Skip {
+        #[arg(long)]
+        reason: String,
+    },
 }
 
 struct AppState {
@@ -236,6 +245,13 @@ struct NodeFailRequest {
 }
 
 #[derive(Deserialize)]
+struct NodeSkipRequest {
+    reason: String,
+    #[serde(default)]
+    iter: Option<i64>,
+}
+
+#[derive(Deserialize)]
 struct RunCommandRequest {
     kind: String,
     #[serde(default)]
@@ -337,6 +353,34 @@ pub fn run_fail(reason: String) -> Result<()> {
 
     if resp.status().is_success() {
         eprintln!("Node {nid} marked failed.");
+    } else {
+        let status = resp.status();
+        let body = resp.text().unwrap_or_default();
+        anyhow::bail!("daemon returned {status}: {body}");
+    }
+    Ok(())
+}
+
+/// Graceful no-op (#245): mark the current node done-but-skipped and end the run
+/// as `skipped` rather than `failed`. Short-circuits downstream (the run reaches
+/// no `end` node) so a fired-into-an-empty-pool run stays out of the failure
+/// signal.
+pub fn run_skip(reason: String) -> Result<()> {
+    let url = cli_daemon_url();
+    let rid = cli_run_id()?;
+    let nid = cli_node_id()?;
+    let iter = cli_node_iter();
+
+    let endpoint = format!("{url}/runs/{rid}/nodes/{nid}/skip");
+    let client = reqwest::blocking::Client::new();
+    let resp = client
+        .post(&endpoint)
+        .json(&serde_json::json!({ "reason": reason, "iter": iter }))
+        .send()
+        .context("failed to reach daemon")?;
+
+    if resp.status().is_success() {
+        eprintln!("Node {nid} skipped (graceful no-op); run marked skipped.");
     } else {
         let status = resp.status();
         let body = resp.text().unwrap_or_default();
@@ -1256,6 +1300,7 @@ fn build_router(state: Arc<AppState>) -> Router {
         .route("/runs/{run_id}/events", get(get_run_events))
         .route("/runs/{run_id}/nodes/{node_id}/done", post(node_done))
         .route("/runs/{run_id}/nodes/{node_id}/fail", post(node_fail))
+        .route("/runs/{run_id}/nodes/{node_id}/skip", post(node_skip))
         .route("/runs/{run_id}/nodes/{node_id}/pane", get(node_pane))
         .route("/runs/{run_id}/nodes/{node_id}/prompt", get(node_prompt))
         .route("/runs/{run_id}/nodes/{node_id}/io", get(node_io))
@@ -5691,6 +5736,119 @@ async fn node_fail(
     (StatusCode::OK, "ok").into_response()
 }
 
+/// Graceful no-op (#245). A node that legitimately has nothing to do (e.g. an
+/// auto-issue selector whose eligible pool emptied between guard-eval and
+/// node-run) calls `pdo skip --reason …` instead of `pdo fail`. The node is
+/// recorded as completed (it ran and reached a decision) and the run ends in the
+/// distinct terminal state `Skipped` — short-circuiting downstream so no bogus
+/// input is propagated, and keeping the failure signal honest. Reserve `fail`
+/// for genuine errors.
+async fn node_skip(
+    State(state): State<Arc<AppState>>,
+    AxumPath((run_id, node_id)): AxumPath<(String, String)>,
+    Json(req): Json<NodeSkipRequest>,
+) -> Response {
+    let iter = req.iter.unwrap_or(1);
+
+    let events = match load_events(&state.db, &run_id).await {
+        Ok(e) => e,
+        Err(e) => {
+            return (StatusCode::INTERNAL_SERVER_ERROR, format!("error: {e}")).into_response();
+        }
+    };
+
+    let pre_run_state = match event_log::project(&events) {
+        Some(s) => s,
+        None => {
+            return (StatusCode::NOT_FOUND, "run not found").into_response();
+        }
+    };
+
+    // Same guard as a completion (#212): the skip terminalizes the node as
+    // Completed, so a duplicate skip / a skip on a terminal run must be
+    // rejected/no-op'd exactly like `node_done`, never double-appended.
+    let completion_probe = event_log::Event {
+        id: None,
+        run_id: run_id.clone(),
+        ts: event_log::now_iso(),
+        kind: event_log::EventKind::NodeCompleted,
+        node_id: Some(node_id.clone()),
+        iter: Some(iter),
+        payload: None,
+    };
+    match transition_guard::validate_transition(Some(&pre_run_state), &completion_probe) {
+        transition_guard::Verdict::Reject { reason } => {
+            warn!("node_skip rejected for {node_id} iter {iter} in run {run_id}: {reason}");
+            return (
+                StatusCode::CONFLICT,
+                Json(serde_json::json!({ "error": reason })),
+            )
+                .into_response();
+        }
+        transition_guard::Verdict::NoOp { reason } => {
+            info!("node_skip no-op for {node_id} iter {iter} in run {run_id}: {reason}");
+            return (
+                StatusCode::OK,
+                Json(serde_json::json!({ "ok": true, "noop": true, "reason": reason })),
+            )
+                .into_response();
+        }
+        transition_guard::Verdict::Allow => {}
+    }
+
+    // Terminalize the node as Completed with a no-op marker. A graceful no-op
+    // produced no outputs and made no code changes, so — unlike `node_done` —
+    // we deliberately skip the sub-worktree merge and output validation: there
+    // is nothing to merge or validate, and the run will not reach downstream.
+    let node_completed = event_log::Event {
+        id: None,
+        run_id: run_id.clone(),
+        ts: event_log::now_iso(),
+        kind: event_log::EventKind::NodeCompleted,
+        node_id: Some(node_id.clone()),
+        iter: Some(iter),
+        payload: Some(serde_json::json!({ "skipped": true, "reason": req.reason })),
+    };
+    if let Err(e) = append_event(&state, &node_completed).await {
+        return (StatusCode::INTERNAL_SERVER_ERROR, format!("error: {e}")).into_response();
+    }
+
+    // Reap on terminal state (#205): snapshot the pane then kill the session.
+    let repo_root = effective_repo_root(&state, &pre_run_state);
+    reap_node_session(&state, &repo_root, &run_id, &node_id, iter);
+
+    // End the run as a graceful no-op (#245) — distinct from RunFailed. This
+    // short-circuits downstream: `spawn_ready_after_event` only spawns for a
+    // Running/AwaitingUser run, so no downstream node is dispatched on a
+    // now-`Skipped` run.
+    let run_skipped = event_log::Event {
+        id: None,
+        run_id: run_id.clone(),
+        ts: event_log::now_iso(),
+        kind: event_log::EventKind::RunSkipped,
+        node_id: None,
+        iter: None,
+        payload: Some(serde_json::json!({ "reason": req.reason })),
+    };
+    if let Err(e) = append_event(&state, &run_skipped).await {
+        error!("failed to append run_skipped: {e}");
+    }
+
+    // The run ended: its other NodeRun sessions (if any) will be reaped, freeing
+    // slots. Re-drive throttled `waiting` nodes in other runs (#159).
+    retry_waiting_nodes(&state).await;
+
+    info!(
+        "Node {node_id} skipped (graceful no-op) in run {run_id}: {}",
+        req.reason
+    );
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({ "ok": true, "skipped": true, "reason": req.reason })),
+    )
+        .into_response()
+}
+
 async fn node_start(
     State(state): State<Arc<AppState>>,
     AxumPath((run_id, node_id)): AxumPath<(String, String)>,
@@ -6807,6 +6965,7 @@ async fn run_command(
                 run_state.status,
                 event_log::RunStatus::Completed
                     | event_log::RunStatus::Failed
+                    | event_log::RunStatus::Skipped
                     | event_log::RunStatus::Halted
             );
             if !is_terminal {
@@ -8688,6 +8847,141 @@ mod tests {
             run_state.nodes["worker"].status,
             event_log::NodeStatus::Failed
         );
+    }
+
+    #[tokio::test]
+    async fn node_skip_marks_run_skipped_not_failed() {
+        // #245: a graceful no-op terminalizes the node as Completed and the run
+        // as Skipped — never Failed, and downstream is short-circuited.
+        let state = test_state().await;
+
+        let run_id = "test-skip-run";
+        let run_started = event_log::Event {
+            id: None,
+            run_id: run_id.into(),
+            ts: event_log::now_iso(),
+            kind: event_log::EventKind::RunStarted,
+            node_id: None,
+            iter: None,
+            payload: Some(serde_json::json!({ "pipeline_name": "test" })),
+        };
+        append_event(&state, &run_started).await.unwrap();
+
+        let node_started = event_log::Event {
+            id: None,
+            run_id: run_id.into(),
+            ts: event_log::now_iso(),
+            kind: event_log::EventKind::NodeStarted,
+            node_id: Some("selector".into()),
+            iter: Some(1),
+            payload: None,
+        };
+        append_event(&state, &node_started).await.unwrap();
+
+        let app = build_router(state.clone());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/runs/test-skip-run/nodes/selector/skip")
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"reason": "no eligible issue"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let events = load_events(&state.db, run_id).await.unwrap();
+        let run_state = event_log::project(&events).unwrap();
+        assert_eq!(run_state.status, event_log::RunStatus::Skipped);
+        assert_ne!(run_state.status, event_log::RunStatus::Failed);
+        // The selector itself is honestly terminal-Completed, not Failed.
+        assert_eq!(
+            run_state.nodes["selector"].status,
+            event_log::NodeStatus::Completed
+        );
+        // No RunFailed event was ever appended.
+        assert!(
+            !events
+                .iter()
+                .any(|e| e.kind == event_log::EventKind::RunFailed),
+            "graceful no-op must not append a RunFailed event"
+        );
+    }
+
+    #[tokio::test]
+    async fn duplicate_node_skip_cannot_corrupt_a_terminal_run() {
+        // The first skip terminalizes the run (Skipped). A second skip is then
+        // rejected by the transition guard (409 — "run is Skipped, resume
+        // first"), exactly like a duplicate `pdo complete` on a terminal run
+        // (#212). Crucially, it must NEVER double-append RunSkipped/NodeCompleted.
+        let state = test_state().await;
+
+        let run_id = "test-skip-idem";
+        append_event(
+            &state,
+            &event_log::Event {
+                id: None,
+                run_id: run_id.into(),
+                ts: event_log::now_iso(),
+                kind: event_log::EventKind::RunStarted,
+                node_id: None,
+                iter: None,
+                payload: Some(serde_json::json!({ "pipeline_name": "test" })),
+            },
+        )
+        .await
+        .unwrap();
+        append_event(
+            &state,
+            &event_log::Event {
+                id: None,
+                run_id: run_id.into(),
+                ts: event_log::now_iso(),
+                kind: event_log::EventKind::NodeStarted,
+                node_id: Some("selector".into()),
+                iter: Some(1),
+                payload: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        let app = build_router(state.clone());
+        let skip = || {
+            app.clone().oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/runs/test-skip-idem/nodes/selector/skip")
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"reason": "nothing to do"}"#))
+                    .unwrap(),
+            )
+        };
+
+        assert_eq!(skip().await.unwrap().status(), StatusCode::OK);
+        // Second skip: rejected because the run is already terminal (Skipped).
+        assert_eq!(skip().await.unwrap().status(), StatusCode::CONFLICT);
+
+        let events = load_events(&state.db, run_id).await.unwrap();
+        let skips = events
+            .iter()
+            .filter(|e| e.kind == event_log::EventKind::RunSkipped)
+            .count();
+        assert_eq!(skips, 1, "duplicate skip must not double-append RunSkipped");
+        let completions = events
+            .iter()
+            .filter(|e| e.kind == event_log::EventKind::NodeCompleted)
+            .count();
+        assert_eq!(
+            completions, 1,
+            "duplicate skip must not re-complete the node"
+        );
+        // And the run is still cleanly Skipped — not flipped to Failed.
+        let run_state = event_log::project(&events).unwrap();
+        assert_eq!(run_state.status, event_log::RunStatus::Skipped);
     }
 
     async fn seed_completed_run(state: &Arc<AppState>, run_id: &str) {

--- a/crates/pdo-daemon/src/main.rs
+++ b/crates/pdo-daemon/src/main.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use clap::Parser;
-use pdo_daemon::{run_complete, run_daemon, run_fail, Cli, Commands};
+use pdo_daemon::{run_complete, run_daemon, run_fail, run_skip, Cli, Commands};
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
@@ -24,5 +24,6 @@ fn main() -> Result<()> {
         }
         Commands::Complete => run_complete(),
         Commands::Fail { reason } => run_fail(reason),
+        Commands::Skip { reason } => run_skip(reason),
     }
 }

--- a/crates/pdo-daemon/src/prompt_augmenter.rs
+++ b/crates/pdo-daemon/src/prompt_augmenter.rs
@@ -356,6 +356,13 @@ pub fn build_preamble(ctx: &AugmentContext<'_>) -> String {
              If you cannot complete the task, signal failure:\n\
              ```\n\
              pdo fail --reason \"<description of the problem>\"\n\
+             ```\n\n\
+             If there is legitimately nothing to do — your input/pool is empty \
+             through no error (e.g. the eligible items were all claimed before \
+             you ran) — record a graceful no-op instead of a failure. This ends \
+             the run as `skipped` (not `failed`) and short-circuits downstream:\n\
+             ```\n\
+             pdo skip --reason \"<why there is nothing to do>\"\n\
              ```\n\n",
         );
     }
@@ -615,6 +622,8 @@ mod tests {
         let preamble = build_preamble(&ctx);
         assert!(preamble.contains("pdo complete"));
         assert!(preamble.contains("pdo fail --reason"));
+        // #245: non-interactive nodes learn the graceful no-op primitive.
+        assert!(preamble.contains("pdo skip --reason"));
     }
 
     #[test]

--- a/frontend/src/components/RunsListPanel.test.tsx
+++ b/frontend/src/components/RunsListPanel.test.tsx
@@ -44,9 +44,21 @@ describe("RunsListPanel run status rendering", () => {
     expect(dot).toBeInTheDocument();
   });
 
+  it("renders a skipped (graceful no-op) run with its own slate dot (#245)", () => {
+    const runs: RunListEntry[] = [
+      { run_id: "run-1", pipeline_name: "noop-pipe", status: "skipped", started_at: null },
+    ];
+    renderPanel({ runs });
+    const dot = document.querySelector(".bg-st-skipped");
+    expect(dot).toBeInTheDocument();
+    // A skipped run is terminal: it must not read as failed/running.
+    expect(document.querySelector(".bg-st-failed")).not.toBeInTheDocument();
+    expect(document.querySelector(".bg-st-running")).not.toBeInTheDocument();
+  });
+
   it("renders all run statuses without errors", () => {
     const statuses: RunListEntry["status"][] = [
-      "running", "awaiting_user", "completed", "failed", "halted", "paused", "archived",
+      "running", "awaiting_user", "completed", "failed", "skipped", "halted", "paused", "archived",
     ];
     const runs: RunListEntry[] = statuses.map((status, i) => ({
       run_id: `run-${i}`,

--- a/frontend/src/components/RunsListPanel.tsx
+++ b/frontend/src/components/RunsListPanel.tsx
@@ -11,6 +11,7 @@ const STATUS_STYLES: Record<RunStatus, { dot: string; bg: string }> = {
   awaiting_user: { dot: "bg-st-await", bg: "bg-st-await-bg" },
   completed: { dot: "bg-st-done", bg: "bg-st-done-bg" },
   failed: { dot: "bg-st-failed", bg: "bg-st-failed-bg" },
+  skipped: { dot: "bg-st-skipped", bg: "bg-st-skipped-bg" },
   halted: { dot: "bg-st-blocked", bg: "bg-st-blocked-bg" },
   paused: { dot: "bg-st-paused", bg: "bg-st-paused-bg" },
   archived: { dot: "bg-st-archived", bg: "bg-st-archived-bg" },

--- a/frontend/src/components/UnifiedLeftPanel.tsx
+++ b/frontend/src/components/UnifiedLeftPanel.tsx
@@ -16,6 +16,7 @@ const STATUS_STYLES: Record<RunStatus, { dot: string }> = {
   awaiting_user: { dot: "bg-st-await" },
   completed: { dot: "bg-st-done" },
   failed: { dot: "bg-st-failed" },
+  skipped: { dot: "bg-st-skipped" },
   halted: { dot: "bg-st-blocked" },
   paused: { dot: "bg-st-paused" },
   archived: { dot: "bg-st-archived" },

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -56,6 +56,10 @@
   --color-st-blocked-bg: rgba(249, 115, 22, 0.14);
   --color-st-failed: #ef4444;
   --color-st-failed-bg: rgba(239, 68, 68, 0.14);
+  /* Graceful no-op terminal (#245): a calm slate, distinct from failed (red),
+     done (green) and archived (gray) — "fired but nothing to do". */
+  --color-st-skipped: #64748b;
+  --color-st-skipped-bg: rgba(100, 116, 139, 0.14);
   --color-st-archived: #6b7280;
   --color-st-stopped: #9ca3af;
   --color-st-stopped-bg: rgba(156, 163, 175, 0.14);

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,4 +1,4 @@
-export type RunStatus = "running" | "awaiting_user" | "completed" | "failed" | "halted" | "paused" | "archived";
+export type RunStatus = "running" | "awaiting_user" | "completed" | "failed" | "skipped" | "halted" | "paused" | "archived";
 export type NodeStatus = "pending" | "running" | "awaiting_user" | "completed" | "failed" | "stopped" | "stale";
 
 export function isLiveRun(status: RunStatus): boolean {


### PR DESCRIPTION
## What

Graceful no-op primitive: `pdo skip --reason "<why>"`. When a node legitimately has nothing to do (e.g. an auto-issue selector whose eligible pool emptied between guard-eval and node-run), it ends the run in a new distinct terminal status `Skipped` instead of polluting the failure signal with a spurious `Failed`.

## Changes

- **`event_log`**: new `EventKind::RunSkipped` + `RunStatus::Skipped` (terminal, non-`is_live`); projection sets the run `Skipped` and stamps `completed_at`.
- **`lib.rs`**: `Commands::Skip { reason }` CLI + `run_skip()` client + `POST /runs/{run}/nodes/{node}/skip` handler. Reuses the completion transition guard (idempotent: duplicate skip / skip-on-terminal is rejected/no-op'd, never double-appended), terminalizes the node as `Completed` with a `skipped` marker, deliberately skips the sub-worktree merge + output validation (nothing to merge), reaps the session, appends `RunSkipped`, re-drives throttled nodes.
- **`admission.rs`**: a `Running` node inside a `Skipped` run is a phantom and consumes no admission slot.
- **`prompt_augmenter.rs`**: non-interactive nodes are taught the `pdo skip` primitive in the preamble.
- **Frontend**: `RunStatus` union gains `"skipped"`; `--color-st-skipped` slate (`#64748b`), non-pulsing, distinct from failed/done/running; rendered in `RunsListPanel` + `UnifiedLeftPanel`.
- **Version**: workspace `0.1.20` -> `0.1.21`.

## Validation

Build clean (frontend `tsc -b && vite build`, backend `cargo build`). Backend unit tests cover the happy path (`node_skip_marks_run_skipped_not_failed`) and idempotency (`duplicate_node_skip_cannot_corrupt_a_terminal_run`); projection + admission tests added. Frontend `RunsListPanel.test.tsx` 11 passing incl. the new slate-dot case, confirmed visually in a real browser (computed `#64748b`, steady). Verdict from the visual tester node: **Pass**.

Closes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)
