### PR TITLE
fix(ui): trigger detail pane no longer blanks once a run is opened (#247)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1688,7 +1688,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "0.1.21"
+version = "0.1.22"
 license = "MIT"
 
 [workspace.dependencies]

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import { useLibrary } from "./hooks/useLibrary";
 import { useLibraryPipelines } from "./hooks/useLibraryPipelines";
 import { fetchRuns, fetchRun, fetchTriggers, fetchSessions } from "./api";
 import { pickLatestLiveNode } from "./lib/pickLatestLiveNode";
+import { rightPaneOwner } from "./lib/rightPaneOwner";
 import type { RunListEntry, RunState, Trigger, DaemonStatus } from "./types";
 import SessionCounter from "./components/SessionCounter";
 import UnifiedLeftPanel from "./components/UnifiedLeftPanel";
@@ -188,12 +189,45 @@ export default function App() {
   const isEditingRun = editTab?.scope === "run";
   const hasEditTab = editTab != null;
 
-  // The Trigger backing the right-panel detail view (#162). Shown when a Trigger
-  // is selected and no pipeline/run edit tab owns the canvas.
+  // The Trigger backing the right-panel detail view (#162), shown whenever a
+  // Trigger is selected and the info overlay is closed — even while a run-edit
+  // tab owns the canvas (#247).
+  //
+  // A Trigger detail and a canvas selection compete for the right pane (#247).
+  // The Trigger now wins over a *persistent* run-edit tab (see rightPaneOwner),
+  // so we need an explicit way for the canvas to reclaim the pane — otherwise a
+  // once-selected Trigger would shadow every later node/edge/region inspector.
+  // Selecting a Trigger touches neither `selection` nor the active tab, so the
+  // canvas-focus signal below never fires on a fresh Trigger selection; any
+  // later canvas focus (a node/edge/region selection, or a tab switch/open —
+  // all of which change `selection` or `editActiveTabId`) clears it. Adjusting
+  // state during render (React's recommended reset-on-change pattern) rather
+  // than in an effect avoids painting one stale frame of the Trigger detail.
+  const [lastCanvasFocus, setLastCanvasFocus] = useState({
+    selection,
+    tabId: editActiveTabId,
+  });
+  if (
+    lastCanvasFocus.selection !== selection ||
+    lastCanvasFocus.tabId !== editActiveTabId
+  ) {
+    setLastCanvasFocus({ selection, tabId: editActiveTabId });
+    if (selectedTriggerId !== null) setSelectedTriggerId(null);
+  }
+
   const selectedTrigger =
     selectedTriggerId != null
       ? triggers.find((t) => t.id === selectedTriggerId) ?? null
       : null;
+
+  // Which view owns the right-hand detail pane (#247). A selected Trigger now
+  // wins over a persistent run-edit tab; the canvas-focus reconciliation above
+  // clears `selectedTriggerId` the moment the canvas is touched again.
+  const paneOwner = rightPaneOwner({
+    triggerSelected: selectedTrigger != null,
+    infoPanelOpen,
+    hasEditTab,
+  });
 
   const openTriggerModal = useCallback((prefill: TriggerPrefill | null) => {
     setTriggerPrefill(prefill);
@@ -508,13 +542,13 @@ export default function App() {
           <ResizableHandle />
 
           <ResizablePanel defaultSize={layout.defaultLayout.right} minSize={minSizePx} id="right" className="panel-r">
-            {selectedTrigger && !hasEditTab && !infoPanelOpen ? (
+            {paneOwner === "trigger" && selectedTrigger ? (
               <TriggerDetailPanel
                 key={selectedTrigger.id}
                 trigger={selectedTrigger}
                 onSelectRun={handleSelectRun}
               />
-            ) : infoPanelOpen ? (
+            ) : paneOwner === "info" ? (
               <PipelineInfoPanel
                 key={infoPanelInitialTab ?? "default"}
                 run={isEditingRun ? selectedRun : null}
@@ -525,7 +559,7 @@ export default function App() {
                 initialTab={infoPanelInitialTab}
                 scrollToLine={infoPanelScrollToLine}
               />
-            ) : hasEditTab ? (
+            ) : paneOwner === "editTab" ? (
               <>
                 {selection.kind === "node" && editNodeType != null && editNodeType !== "start" && editNodeType !== "end" ? (
                   <InspectorTabs activeTab={inspectorTab} onTabChange={setInspectorTab}>

--- a/frontend/src/lib/rightPaneOwner.test.ts
+++ b/frontend/src/lib/rightPaneOwner.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { rightPaneOwner } from "./rightPaneOwner";
+import type { RightPaneInputs } from "./rightPaneOwner";
+
+const base: RightPaneInputs = {
+  triggerSelected: false,
+  infoPanelOpen: false,
+  hasEditTab: false,
+};
+
+describe("rightPaneOwner", () => {
+  it("falls back to the legacy node path when nothing is focused", () => {
+    expect(rightPaneOwner(base)).toBe("selectedNode");
+  });
+
+  it("shows the edit-tab inspector when a tab owns the canvas", () => {
+    expect(rightPaneOwner({ ...base, hasEditTab: true })).toBe("editTab");
+  });
+
+  it("shows the trigger detail when only a trigger is selected", () => {
+    expect(rightPaneOwner({ ...base, triggerSelected: true })).toBe("trigger");
+  });
+
+  // The regression at the heart of #247: opening a run leaves a persistent edit
+  // tab, so selecting a trigger afterwards must STILL surface its detail. The
+  // old `!hasEditTab` guard routed this to "editTab" and blanked the pane.
+  it("lets the trigger win over a persistent edit tab (#247)", () => {
+    expect(
+      rightPaneOwner({ triggerSelected: true, infoPanelOpen: false, hasEditTab: true }),
+    ).toBe("trigger");
+  });
+
+  it("lets the info overlay win over a selected trigger", () => {
+    expect(
+      rightPaneOwner({ triggerSelected: true, infoPanelOpen: true, hasEditTab: false }),
+    ).toBe("info");
+  });
+
+  it("lets the info overlay win over everything", () => {
+    expect(
+      rightPaneOwner({ triggerSelected: true, infoPanelOpen: true, hasEditTab: true }),
+    ).toBe("info");
+  });
+
+  it("shows the edit tab when neither trigger nor info is active", () => {
+    expect(
+      rightPaneOwner({ triggerSelected: false, infoPanelOpen: false, hasEditTab: true }),
+    ).toBe("editTab");
+  });
+
+  // Exhaustive truth table over the three boolean inputs, pinning the full
+  // precedence (info > trigger > editTab > selectedNode) against drift.
+  it("matches the full precedence truth table", () => {
+    const expected: Array<[RightPaneInputs, string]> = [
+      [{ triggerSelected: false, infoPanelOpen: false, hasEditTab: false }, "selectedNode"],
+      [{ triggerSelected: false, infoPanelOpen: false, hasEditTab: true }, "editTab"],
+      [{ triggerSelected: false, infoPanelOpen: true, hasEditTab: false }, "info"],
+      [{ triggerSelected: false, infoPanelOpen: true, hasEditTab: true }, "info"],
+      [{ triggerSelected: true, infoPanelOpen: false, hasEditTab: false }, "trigger"],
+      [{ triggerSelected: true, infoPanelOpen: false, hasEditTab: true }, "trigger"],
+      [{ triggerSelected: true, infoPanelOpen: true, hasEditTab: false }, "info"],
+      [{ triggerSelected: true, infoPanelOpen: true, hasEditTab: true }, "info"],
+    ];
+    for (const [input, want] of expected) {
+      expect(rightPaneOwner(input)).toBe(want);
+    }
+  });
+});

--- a/frontend/src/lib/rightPaneOwner.ts
+++ b/frontend/src/lib/rightPaneOwner.ts
@@ -1,0 +1,37 @@
+export type RightPaneOwner = "info" | "trigger" | "editTab" | "selectedNode";
+
+export interface RightPaneInputs {
+  /** A Trigger is selected in the left panel — its detail should own the pane. */
+  triggerSelected: boolean;
+  /** The pipeline/run info overlay is toggled open from the canvas. */
+  infoPanelOpen: boolean;
+  /** An edit tab (pipeline or run) owns the centre canvas. */
+  hasEditTab: boolean;
+}
+
+/**
+ * Decide which view owns the right-hand detail pane.
+ *
+ * Precedence (highest first):
+ *  1. `info`    — the explicit pipeline/run info overlay, toggled from the canvas.
+ *  2. `trigger` — a Trigger is selected in the left panel. It wins over an open
+ *                 edit tab: opening a run leaves a *persistent* edit tab behind
+ *                 (`hasEditTab` stays true forever after, since the run tab never
+ *                 closes on its own), so the previous `selectedTrigger && !hasEditTab`
+ *                 guard made the Trigger detail — and its Fire history — permanently
+ *                 unreachable once any run had been opened (#247). The canvas
+ *                 reclaims the pane from a Trigger by clearing the Trigger
+ *                 selection on the next canvas selection / tab switch, NOT through
+ *                 this precedence (see the reconciliation effect in App).
+ *  3. `editTab` — a node/edge/region selection or the run/pipeline inspector for
+ *                 the active edit tab.
+ *  4. `selectedNode` — the legacy no-tab node detail path.
+ *
+ * The four owners are mutually exclusive: callers render exactly one branch.
+ */
+export function rightPaneOwner(input: RightPaneInputs): RightPaneOwner {
+  if (input.infoPanelOpen) return "info";
+  if (input.triggerSelected) return "trigger";
+  if (input.hasEditTab) return "editTab";
+  return "selectedNode";
+}


### PR DESCRIPTION
Closes #247.

## Problem
Once a run had been opened, the right detail pane could no longer navigate to a library-run or trigger detail (no fire history, no auto-fire toggle). Opening a run set `hasEditTab = true` permanently, and the guard `selectedTrigger && !hasEditTab` made the trigger detail unreachable.

## Fix (frontend-only)
- Extract right-pane precedence into `lib/rightPaneOwner.ts`: `info > trigger > editTab > selectedNode`, so a selected trigger wins over a persistent edit tab.
- Adjust state during render so a canvas selection / tab change resets `selectedTriggerId` to `null` (canvas reclaims the pane without permanently masking inspectors).
- Add `lib/rightPaneOwner.test.ts` (8/8 truth-table cases, incl. the `trigger + hasEditTab → trigger` regression).

## Validation
- `tsc -b`: 0 errors. `vite build`: OK. `vitest run rightPaneOwner.test.ts`: 8/8 pass.
- Visual tester node reproduced the exact #247 regression scenario against the running app and confirmed the trigger detail (config + full fire history) now renders with a run open, and the canvas correctly reclaims the pane afterward. Verdict: **Pass**.

Ships as v0.1.22 (backend version bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)