### PR TITLE
feat(ui): typed-confirmation gate for archiving a live run (#98)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1688,7 +1688,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "0.1.22"
+version = "0.1.23"
 license = "MIT"
 
 [workspace.dependencies]

--- a/crates/pdo-daemon/src/prompt_augmenter.rs
+++ b/crates/pdo-daemon/src/prompt_augmenter.rs
@@ -490,6 +490,8 @@ curl -X POST {daemon_url}/runs/{run_id}/commands \
   -d '{{"kind":"cleanup_run"}}'
 ```
 
+**Never call `cleanup_run` on your own initiative.** It is destructive and irreversible: it kills every active node session and removes the run's worktrees, branches, and artifacts from disk. Always check with the user first and wait for explicit confirmation before issuing it — even if you believe the run is stuck or finished.
+
 ### 8. rename_run
 
 Set or update the display name of this run.
@@ -1203,6 +1205,22 @@ mod tests {
     fn manager_preamble_omits_auto_name_instruction_when_name_provided() {
         let preamble = build_manager_preamble("run-1", "http://localhost:5172", false);
         assert!(!preamble.contains("No display name was provided"));
+    }
+
+    #[test]
+    fn manager_preamble_cleanup_run_has_self_initiative_guardrail() {
+        let preamble = build_manager_preamble("run-1", "http://localhost:5172", false);
+        let section7 = preamble
+            .split("### 7. cleanup_run")
+            .nth(1)
+            .expect("preamble should contain the cleanup_run section")
+            .split("### 8.")
+            .next()
+            .expect("cleanup_run section should be delimited by section 8");
+        assert!(
+            section7.contains("Never call `cleanup_run` on your own initiative"),
+            "section 7 should carry the self-initiative guardrail, got: {section7}"
+        );
     }
 
     // --- image port type preamble tests ---

--- a/frontend/src/components/CleanupConfirmModal.test.tsx
+++ b/frontend/src/components/CleanupConfirmModal.test.tsx
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import CleanupConfirmModal from "./CleanupConfirmModal";
+
+// A realistic run id: `slice(-7)` === "abc1234".
+const RUN_ID = "20260622-091516-abc1234";
+const SHORT_ID = "abc1234";
+
+describe("CleanupConfirmModal", () => {
+  describe("live run (gated)", () => {
+    it("renders the 'hasn't finished' consequence copy and the expected short id", () => {
+      render(
+        <CleanupConfirmModal
+          runId={RUN_ID}
+          isLive
+          onConfirm={vi.fn()}
+          onCancel={vi.fn()}
+        />,
+      );
+      expect(screen.getByText(/hasn't finished/)).toBeInTheDocument();
+      // The expected short id is shown inline so the friction is derivable on screen.
+      expect(screen.getByText(SHORT_ID)).toBeInTheDocument();
+    });
+
+    it("disables the confirm button on mount and a stray click does not archive", () => {
+      const onConfirm = vi.fn();
+      render(
+        <CleanupConfirmModal
+          runId={RUN_ID}
+          isLive
+          onConfirm={onConfirm}
+          onCancel={vi.fn()}
+        />,
+      );
+      const button = screen.getByTestId("cleanup-confirm-button");
+      expect(button).toBeDisabled();
+      fireEvent.click(button);
+      expect(onConfirm).not.toHaveBeenCalled();
+    });
+
+    it("keeps the button disabled for the wrong text, enables it for the short id", () => {
+      const onConfirm = vi.fn();
+      render(
+        <CleanupConfirmModal
+          runId={RUN_ID}
+          isLive
+          onConfirm={onConfirm}
+          onCancel={vi.fn()}
+        />,
+      );
+      const input = screen.getByTestId("cleanup-confirm-input");
+      const button = screen.getByTestId("cleanup-confirm-button");
+
+      fireEvent.change(input, { target: { value: "wrong" } });
+      expect(button).toBeDisabled();
+      fireEvent.click(button);
+      expect(onConfirm).not.toHaveBeenCalled();
+
+      fireEvent.change(input, { target: { value: SHORT_ID } });
+      expect(button).toBeEnabled();
+      fireEvent.click(button);
+      expect(onConfirm).toHaveBeenCalledTimes(1);
+    });
+
+    it("submits on Enter only once the short id is typed", () => {
+      const onConfirm = vi.fn();
+      render(
+        <CleanupConfirmModal
+          runId={RUN_ID}
+          isLive
+          onConfirm={onConfirm}
+          onCancel={vi.fn()}
+        />,
+      );
+      const input = screen.getByTestId("cleanup-confirm-input");
+
+      fireEvent.keyDown(input, { key: "Enter" });
+      expect(onConfirm).not.toHaveBeenCalled();
+
+      fireEvent.change(input, { target: { value: SHORT_ID } });
+      fireEvent.keyDown(input, { key: "Enter" });
+      expect(onConfirm).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("terminal run (light)", () => {
+    it("renders the light copy with no typed gate and confirms on a single click", () => {
+      const onConfirm = vi.fn();
+      render(
+        <CleanupConfirmModal
+          runId={RUN_ID}
+          onConfirm={onConfirm}
+          onCancel={vi.fn()}
+        />,
+      );
+      expect(screen.getByText(/remove worktrees and artifacts/)).toBeInTheDocument();
+      // No typed-confirmation input on the terminal branch.
+      expect(screen.queryByTestId("cleanup-confirm-input")).toBeNull();
+
+      const button = screen.getByTestId("cleanup-confirm-button");
+      expect(button).toBeEnabled();
+      fireEvent.click(button);
+      expect(onConfirm).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("calls onCancel from the cancel button and never confirms on render", () => {
+    const onConfirm = vi.fn();
+    const onCancel = vi.fn();
+    render(
+      <CleanupConfirmModal
+        runId={RUN_ID}
+        isLive
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+      />,
+    );
+    expect(onConfirm).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByText("Cancel"));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/CleanupConfirmModal.tsx
+++ b/frontend/src/components/CleanupConfirmModal.tsx
@@ -1,25 +1,84 @@
+import { useEffect, useState } from "react";
+
 interface Props {
+  runId: string;
   onConfirm: () => void;
   onCancel: () => void;
   isLive?: boolean;
 }
 
+// Spelled out so the consequences of archiving a *live* run are explicit. The
+// "hasn't finished" phrasing is asserted by the unit test — keep it literal.
+const LIVE_BODY =
+  "This run hasn't finished. Archiving it now kills every active node session, " +
+  "removes the run's worktrees and artifacts from disk, and marks the run " +
+  "archived. Event history is kept, but in-flight prompts and outputs are lost.";
+
 export default function CleanupConfirmModal({
+  runId,
   onConfirm,
   onCancel,
   isLive = false,
 }: Props) {
+  // The 7-hex unique suffix (clean, no dash) of the run id. Run-specific so the
+  // user proves they are archiving the run they think they are.
+  const shortId = runId.slice(-7);
+  const [confirmText, setConfirmText] = useState("");
+  const canConfirm = confirmText.trim() === shortId;
+
+  // Escape-to-cancel parity with ConfirmDeleteModal. Deliberately NO global
+  // Enter listener: on the live branch Enter-to-submit is gated by the input's
+  // own onKeyDown, so it can never bypass the typed confirmation.
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onCancel();
+    }
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [onCancel]);
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
       <div className="w-[360px] rounded-lg border border-line bg-bg-2 p-4 shadow-lg">
-        <h3 className="font-medium text-fg" style={{ fontSize: "13px" }}>
-          {isLive ? "Stop and Cleanup Run" : "Cleanup Run"}
-        </h3>
-        <p className="mt-2 text-fg-3" style={{ fontSize: "12px" }}>
-          {isLive
-            ? "This will kill all active node sessions, then remove worktrees and artifacts. Event history is kept. Proceed?"
-            : "This will remove worktrees and artifacts. Event history is kept. Proceed?"}
-        </p>
+        {isLive ? (
+          <>
+            <h3 className="font-medium text-fg" style={{ fontSize: "13px" }}>
+              Archive this run before it completes?
+            </h3>
+            <p className="mt-2 text-fg-3" style={{ fontSize: "12px" }}>
+              {LIVE_BODY}
+            </p>
+            <label className="mt-3 block text-fg-3" style={{ fontSize: "12px" }}>
+              Type{" "}
+              <code className="rounded bg-bg-4 px-1 py-0.5 font-mono text-fg">
+                {shortId}
+              </code>{" "}
+              to confirm
+            </label>
+            <input
+              className="mt-1.5 w-full rounded-md border border-line-strong bg-bg-3 px-2.5 py-1.5 font-mono text-fg placeholder:text-fg-4 focus:border-acc focus:outline-none"
+              style={{ fontSize: "12px" }}
+              placeholder={shortId}
+              value={confirmText}
+              onChange={(e) => setConfirmText(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && canConfirm) onConfirm();
+              }}
+              data-testid="cleanup-confirm-input"
+              autoFocus
+            />
+          </>
+        ) : (
+          <>
+            <h3 className="font-medium text-fg" style={{ fontSize: "13px" }}>
+              Cleanup Run
+            </h3>
+            <p className="mt-2 text-fg-3" style={{ fontSize: "12px" }}>
+              This will remove worktrees and artifacts. Event history is kept.
+              Proceed?
+            </p>
+          </>
+        )}
         <div className="mt-4 flex justify-end gap-2">
           <button
             onClick={onCancel}
@@ -30,10 +89,16 @@ export default function CleanupConfirmModal({
           </button>
           <button
             onClick={onConfirm}
-            className="cursor-pointer rounded-md bg-st-failed px-3 py-1.5 text-white transition-colors hover:bg-st-failed/80"
+            disabled={isLive && !canConfirm}
+            className={
+              isLive
+                ? "cursor-pointer rounded-md bg-st-failed px-3 py-1.5 text-white transition-colors hover:bg-st-failed/80 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-st-failed"
+                : "cursor-pointer rounded-md bg-st-failed px-3 py-1.5 text-white transition-colors hover:bg-st-failed/80"
+            }
             style={{ fontSize: "11.5px" }}
+            data-testid="cleanup-confirm-button"
           >
-            {isLive ? "Stop & Cleanup" : "Cleanup"}
+            {isLive ? "Archive run" : "Cleanup"}
           </button>
         </div>
       </div>

--- a/frontend/src/components/RunsListPanel.tsx
+++ b/frontend/src/components/RunsListPanel.tsx
@@ -181,6 +181,7 @@ export default function RunsListPanel({
 
       {confirmCleanup && (
         <CleanupConfirmModal
+          runId={confirmCleanup.runId}
           isLive={
             isLiveRun(confirmCleanup.status)
           }

--- a/frontend/src/components/UnifiedLeftPanel.tsx
+++ b/frontend/src/components/UnifiedLeftPanel.tsx
@@ -471,6 +471,7 @@ export default function UnifiedLeftPanel({
 
       {confirmCleanup && (
         <CleanupConfirmModal
+          runId={confirmCleanup.runId}
           isLive={
             isLiveRun(confirmCleanup.status)
           }


### PR DESCRIPTION
Closes #98.

Archiving a still-live run is the most destructive action in PDO: a single click on the trash icon killed every active node session and deleted the run's worktrees/artifacts. This adds friction on two fronts.

## UI — `CleanupConfirmModal`
When the run is live (`running` / `awaiting_user` / `paused`), the destructive button stays disabled until the user types the run's 7-hex short id. The short id is shown inline so it stays derivable even when the run displays by name. Terminal runs keep the existing light single-click confirm. Escape cancels; Enter submits only through the gated input. Both call sites (`UnifiedLeftPanel`, `RunsListPanel`) pass the new required `runId` prop.

## Manager prompt — `prompt_augmenter`
Adds a `cleanup_run`-scoped guardrail inside section 7 of the manager preamble: never archive on its own initiative; wait for explicit user confirmation even if the run looks stuck or finished.

## Tests & verification
- New vitest component test (`CleanupConfirmModal.test.tsx`): stray-click guard, typed gate, terminal light path — **6/6 green**.
- Rust unit test asserting the guardrail sits within section 7 of the preamble.
- Tester node (this run) drove the **real component in a browser**: button disabled on mount, stays disabled under wrong input, enables only on the correct 7-hex id, fires `onConfirm` exactly once; terminal path remains single-click. `npm run build` clean (2414 modules, 0 type errors); `cargo build -p pdo-daemon` clean.

Also bumps workspace version `0.1.22` → `0.1.23` (frontend stays `0.0.0` per convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)