### PR TITLE
feat(ui): group-move nodes persist every selected node's position (#232)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -753,7 +753,7 @@ Le daemon écoute sur `127.0.0.1:<port>` uniquement. Pas d'auth, pas de TLS, pas
 
 ### Persistance et hot-reload
 
-- **Auto-save debounced** (1-2 s d'inactivité) sur toutes les modifications du canvas. Pas de "Ctrl+S", pas de modal. Le canvas EST le fichier YAML + les fichiers prompts.
+- **Save explicite** (#35) : un bouton **Save** dans la barre d'onglets, le raccourci **Cmd/Ctrl+S**, et un **flush automatique au lancement d'un Run** (toutes les modifs non sauvegardées sont écrites avant de démarrer le Run). Pas d'auto-save debounced. Le canvas EST le fichier YAML + les fichiers prompts.
 - **Hot-reload bidirectionnel** : PDO watch les fichiers (`fswatch`/`inotify`). Édition externe (Vim, VS Code) → re-parse et re-render. Last-write-wins.
 - **Pas de git intégration v1.** Le user fait ses commits manuellement s'il versionne.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1688,7 +1688,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "0.1.24"
+version = "0.1.25"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "0.1.24"
+version = "0.1.25"
 license = "MIT"
 
 [workspace.dependencies]

--- a/docs/testing/scenarios/group-move-nodes.md
+++ b/docs/testing/scenarios/group-move-nodes.md
@@ -1,0 +1,145 @@
+# Scenario — `group-move-nodes`
+
+> Layer 5 (agentic) per ADR 0004. Manual trigger: an agent drives a real
+> browser and emits the verdict format below. Asserts the #232 fix: box-/
+> additive-selecting several nodes on the edit canvas and dragging them moves
+> **every** selected node, persists all their positions to disk, and leaves
+> un-selected nodes untouched. Pre-fix, only the grabbed node persisted — every
+> other selected node snapped back, and Save silently dropped their moves.
+
+## Setup
+
+- Daemon running on the user's repo (default `http://127.0.0.1:5172`).
+- Frontend reachable in a browser. Chrome DevTools MCP preferred; Playwright
+  MCP works as a fallback.
+- A test pipeline named `group-move-scenario.yaml` seeded in `.pdo/pipelines/`.
+  If it isn't already there, the agent creates it before driving the UI:
+
+  ```yaml
+  # Inputs are emergent (#149): work nodes declare OUTPUTS only; inputs derive
+  # from incoming edges. Only End keeps a declared `result` input (structural).
+  # Three work nodes are stacked vertically with clear space so a drag never
+  # overlaps a neighbour.
+  name: group-move-scenario
+  version: "1.0"
+  nodes:
+    - id: start
+      name: Start
+      type: start
+      outputs:
+        - name: user_prompt
+      view: { x: 0, y: 300 }
+    - id: alpha
+      name: alpha
+      type: doc-only
+      outputs:
+        - name: out
+      view: { x: 240, y: 100 }
+    - id: beta
+      name: beta
+      type: doc-only
+      outputs:
+        - name: out
+      view: { x: 240, y: 320 }
+    - id: gamma
+      name: gamma
+      type: doc-only
+      outputs:
+        - name: out
+      view: { x: 240, y: 540 }
+    - id: end
+      name: End
+      type: end
+      inputs:
+        - name: result
+      view: { x: 520, y: 300 }
+  edges:
+    - source: { node: start, port: user_prompt }
+      target: { node: alpha, port: out }
+    - source: { node: alpha, port: out }
+      target: { node: beta, port: out }
+    - source: { node: beta, port: out }
+      target: { node: gamma, port: out }
+    - source: { node: gamma, port: out }
+      target: { node: end, port: result }
+  ```
+
+## Steps the agent executes — group move
+
+1. Open the UI, confirm the **`Daemon: connected`** label is visible in the
+   status bar.
+2. Click the `group-move-scenario` row in the **Library** sidebar. The canvas
+   renders five nodes (`Start`, `alpha`, `beta`, `gamma`, `End`).
+3. Record the on-canvas position of `alpha`, `beta`, and `gamma` (read each
+   `.react-flow__node[data-id="…"]`'s `transform: translate(Xpx, Ypx)` — the
+   translate values are FLOW units and mirror the stored `view`). Call these
+   `alpha0`, `beta0`, `gamma0`.
+4. **Multi-select `alpha` and `beta`.** Either:
+   - **Additive click:** click `alpha`, then hold **Control** (Linux/Windows;
+     **Meta/⌘** on macOS) and click `beta`. Both should now show the green
+     selection ring; **or**
+   - **Box-select:** hold **Shift** and drag a marquee that encloses only
+     `alpha` and `beta` (not `gamma`).
+5. Assert **both `alpha` and `beta` show the accent selection ring** during the
+   selection (the ring lights on every selected node, not just the
+   last-clicked one — the #232 highlight fix). `gamma` shows **no** ring.
+6. **Drag the group:** grab `beta` and drag it by a clear delta (e.g. ~+170px
+   x, ~-60px y on screen). Use an incremental drag (several small mouse moves
+   with a short wait between, then release) — xyflow's d3-drag ignores a single
+   atomic move. `alpha` should visibly ride along with `beta`.
+7. After releasing, record the new on-canvas positions `alpha1`, `beta1`,
+   `gamma1`. Assert:
+   - `beta` moved: `beta1 ≠ beta0`.
+   - **`alpha` moved by the same delta as `beta`** (`alpha1 - alpha0 ≈
+     beta1 - beta0`). This is the core regression: pre-fix `alpha` snapped back
+     to `alpha0` after the drop.
+   - `gamma` did **not** move (`gamma1 ≈ gamma0`).
+8. Assert the tab title shows the dirty indicator **`•`** and the **Save**
+   button is **enabled**.
+9. Click **Save** (or press `Ctrl+S` / `Cmd+S`). Assert the dirty indicator
+   clears and **"Saved …"** appears (`data-testid="saved-ago"`).
+10. Reload the page (`F5` / `navigate_page`). Re-open `group-move-scenario`.
+11. Read `.pdo/pipelines/group-move-scenario.yaml` from disk. Assert:
+    - `alpha`'s `view:` and `beta`'s `view:` both shifted from the seed by the
+      **same delta** (the flow-unit delta of the drag; allow ±1 for rounding).
+    - `gamma`'s `view:` is **unchanged** from the seed (`{ x: 240, y: 540 }`).
+    - This proves every selected node's move was persisted, not just the
+      grabbed one — pre-fix only `beta`'s `view:` would have changed.
+
+## Negative control — single-node drag (no regression)
+
+12. With the pipeline still open, click `gamma` alone (no modifier) so only
+    `gamma` is selected (the ring lights on `gamma`, clears on `alpha`/`beta`).
+13. Drag `gamma` by a clear delta. Release.
+14. Assert `gamma` moved and **neither `alpha` nor `beta` moved**.
+15. Click **Save**. Reload. Read the YAML and assert only `gamma`'s `view:`
+    changed from step 11's state; `alpha`/`beta` are untouched. A single drag
+    still persists exactly one node — the fix didn't widen the blast radius.
+
+## Cleanup
+
+- Delete `.pdo/pipelines/group-move-scenario.yaml`.
+- Delete `.pdo/pipelines/group-move-scenario.prompts/` if it was created.
+
+## Verdict format
+
+```json
+{
+  "verdict": "PASS" | "FAIL",
+  "evidence": [
+    "step 1: status bar shows 'Daemon: connected'",
+    "step 5: both alpha and beta show the selection ring; gamma does not",
+    "step 7: alpha moved by the same delta as beta; gamma did not move",
+    "step 8: tab shows dirty indicator '•', Save button enabled",
+    "step 9: dirty indicator cleared, 'Saved …' visible",
+    "step 11: on disk, alpha.view and beta.view shifted by the same delta; gamma.view unchanged",
+    "step 14: single-node drag moved only gamma; alpha/beta unmoved",
+    "step 15: on disk, only gamma.view changed on the single drag"
+  ],
+  "anomalies": [
+    "<optional — e.g. external-edit conflict dialog surfaced on save during a live run>"
+  ]
+}
+```
+
+A single failed assertion ⇒ `verdict: "FAIL"`. Don't half-pass.

--- a/frontend/e2e/group-move-nodes.spec.ts
+++ b/frontend/e2e/group-move-nodes.spec.ts
@@ -1,0 +1,171 @@
+import { test, expect, type Locator } from "@playwright/test";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { openPipelineForEdit } from "./helpers";
+
+// Layer 3b — #232 group-move-nodes fix.
+// Box-/additive-selecting several nodes and dragging them as a group must move
+// ALL selected nodes, not just the grabbed one. Pre-fix, onNodeDragStop wrote
+// only the grabbed node's `view`; the re-derivation then reset every other
+// selected node back to its stored position (the "snap-back" bug). This test is
+// the discriminating check: after a two-node group drag, BOTH selected nodes
+// keep the new delta and the un-selected node is untouched. Pre-fix, exactly
+// one of the two moves and the other reverts.
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const WORKSPACE_ROOT = path.resolve(__dirname, "..", "..");
+const PIPELINE_NAME = `e2e-group-move-${process.pid}-${Date.now()}`;
+const PIPELINE_DIR = path.join(WORKSPACE_ROOT, ".pdo", "pipelines");
+const PIPELINE_PATH = path.join(PIPELINE_DIR, `${PIPELINE_NAME}.yaml`);
+const PROMPTS_DIR = path.join(PIPELINE_DIR, `${PIPELINE_NAME}.prompts`);
+
+// A valid post-refonte pipeline (ADR-0011): exactly one `start` and one `end`,
+// every node named. Three work nodes (`alpha`, `beta`, `gamma`) are stacked
+// vertically with clear space so a drag never overlaps a neighbour. We
+// multi-select alpha+beta, grab beta, and drag; gamma is the negative control.
+const SEED_YAML = `name: ${PIPELINE_NAME}
+version: "1.0"
+nodes:
+  - id: start
+    name: Start
+    type: start
+    outputs:
+      - { name: user_prompt, side: right }
+    view: { x: 0, y: 300 }
+  - id: alpha
+    name: alpha
+    type: doc-only
+    inputs:
+      - { name: in, side: left }
+    outputs:
+      - { name: out, side: right }
+    view: { x: 240, y: 100 }
+  - id: beta
+    name: beta
+    type: doc-only
+    inputs:
+      - { name: in, side: left }
+    outputs:
+      - { name: out, side: right }
+    view: { x: 240, y: 320 }
+  - id: gamma
+    name: gamma
+    type: doc-only
+    inputs:
+      - { name: in, side: left }
+    outputs:
+      - { name: out, side: right }
+    view: { x: 240, y: 540 }
+  - id: end
+    name: End
+    type: end
+    inputs:
+      - { name: result, side: left }
+    view: { x: 520, y: 300 }
+edges:
+  - source: { node: start, port: user_prompt }
+    target: { node: alpha, port: in }
+  - source: { node: alpha, port: out }
+    target: { node: beta, port: in }
+  - source: { node: beta, port: out }
+    target: { node: gamma, port: in }
+  - source: { node: gamma, port: out }
+    target: { node: end, port: result }
+`;
+
+test.beforeAll(async () => {
+  await fs.mkdir(PIPELINE_DIR, { recursive: true });
+  await fs.writeFile(PIPELINE_PATH, SEED_YAML);
+});
+
+test.afterAll(async () => {
+  await fs.rm(PIPELINE_PATH, { force: true });
+  await fs.rm(PROMPTS_DIR, { recursive: true, force: true });
+});
+
+// xyflow renders each node at `transform: translate(Xpx, Ypx)` in FLOW units
+// (zoom is applied to the viewport container, not per-node), so the translate
+// values mirror the node's stored `view` coords. Parse them off the inline
+// style.
+async function nodePos(node: Locator): Promise<{ x: number; y: number }> {
+  return node.evaluate((el) => {
+    const t = (el as HTMLElement).style.transform || getComputedStyle(el).transform;
+    const m = t.match(/translate\(\s*(-?[\d.]+)px,\s*(-?[\d.]+)px\)/);
+    if (m) return { x: parseFloat(m[1]), y: parseFloat(m[2]) };
+    const mm = t.match(/matrix\(([^)]+)\)/);
+    if (mm) {
+      const p = mm[1].split(",").map((n) => parseFloat(n));
+      return { x: p[4], y: p[5] };
+    }
+    return { x: 0, y: 0 };
+  });
+}
+
+test("group drag moves every selected node, not just the grabbed one (#232)", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.getByText("Daemon: connected")).toBeVisible({ timeout: 10_000 });
+
+  await openPipelineForEdit(page, PIPELINE_NAME);
+
+  const alpha = page.locator('.react-flow__node[data-id="alpha"]');
+  const beta = page.locator('.react-flow__node[data-id="beta"]');
+  const gamma = page.locator('.react-flow__node[data-id="gamma"]');
+  await expect(alpha).toBeVisible({ timeout: 5_000 });
+  await expect(beta).toBeVisible();
+  await expect(gamma).toBeVisible();
+
+  const alpha0 = await nodePos(alpha);
+  const beta0 = await nodePos(beta);
+  const gamma0 = await nodePos(gamma);
+
+  // Multi-select alpha + beta: plain click alpha, then Control+click beta
+  // (Control is the Linux/Windows multi-selection modifier).
+  await alpha.click();
+  await page.keyboard.down("Control");
+  await beta.click();
+  await page.keyboard.up("Control");
+
+  // Drag the grabbed node (beta) with the proven incremental recipe — xyflow's
+  // d3-drag ignores a single atomic move, so we step the mouse and let each
+  // frame fire. Both selected nodes ride along.
+  const box = await beta.boundingBox();
+  if (!box) throw new Error("beta bounding box not found");
+  const sx = box.x + box.width / 2;
+  const sy = box.y + box.height / 2;
+  const dx = 170;
+  const dy = -60;
+
+  await page.mouse.move(sx, sy);
+  await page.mouse.down();
+  const steps = 5;
+  for (let i = 1; i <= steps; i++) {
+    await page.mouse.move(sx + (dx * i) / steps, sy + (dy * i) / steps);
+    await page.waitForTimeout(50);
+  }
+  await page.mouse.up();
+
+  // Let onNodeDragStop → store write → re-derivation → setNodes settle.
+  await page.waitForTimeout(300);
+
+  const alpha1 = await nodePos(alpha);
+  const beta1 = await nodePos(beta);
+  const gamma1 = await nodePos(gamma);
+
+  const dAlpha = { x: alpha1.x - alpha0.x, y: alpha1.y - alpha0.y };
+  const dBeta = { x: beta1.x - beta0.x, y: beta1.y - beta0.y };
+  const dGamma = { x: gamma1.x - gamma0.x, y: gamma1.y - gamma0.y };
+
+  // Sanity: the grabbed node actually moved (rules out a no-op drag).
+  expect(Math.abs(dBeta.x) + Math.abs(dBeta.y)).toBeGreaterThan(10);
+
+  // DISCRIMINATING ASSERTION: alpha (the OTHER selected node) moved by the same
+  // delta as beta. Pre-fix, alpha's view was never written, so the
+  // re-derivation snapped it back (dAlpha ≈ 0 ≠ dBeta) and this fails.
+  expect(dAlpha.x).toBeCloseTo(dBeta.x, 0);
+  expect(dAlpha.y).toBeCloseTo(dBeta.y, 0);
+
+  // Negative control: gamma was never selected, so it must not move.
+  expect(Math.abs(dGamma.x)).toBeLessThan(2);
+  expect(Math.abs(dGamma.y)).toBeLessThan(2);
+});

--- a/frontend/src/components/EditCanvas.tsx
+++ b/frontend/src/components/EditCanvas.tsx
@@ -77,9 +77,12 @@ interface EditNodeData {
 }
 
 // Exported for unit tests; co-located with the canvas it renders.
-export function EditNode({ data, id }: NodeProps<Node<EditNodeData>>) {
+export function EditNode({ data, id, selected }: NodeProps<Node<EditNodeData>>) {
   const selection = useEditStore((s) => s.selection);
-  const isSelected = selection.kind === "node" && selection.id === id;
+  // OR-in xyflow's own `selected` (#232) so every node in a multi-select group
+  // lights the accent ring during a drag, not just the last-clicked one the
+  // Zustand single-selection tracks.
+  const isSelected = selected || (selection.kind === "node" && selection.id === id);
   const isDropTarget = useIsDropTarget(id);
   const reached = data.reached ?? false;
   // A reached start/end marker borrows the green "completed" cadre (border +
@@ -245,7 +248,7 @@ function EditCanvasInner({ libraryEntries, libraryPipelines, onLibraryDelete, on
   const openTabs = useEditStore((s) => s.openTabs);
   const activeTabId = useEditStore((s) => s.activeTabId);
   const setSelection = useEditStore((s) => s.setSelection);
-  const updateNode = useEditStore((s) => s.updateNode);
+  const updateNodeViews = useEditStore((s) => s.updateNodeViews);
   const addEdgeToStore = useEditStore((s) => s.addEdge);
   const deleteNode = useEditStore((s) => s.deleteNode);
   const duplicateNode = useEditStore((s) => s.duplicateNode);
@@ -362,12 +365,19 @@ function EditCanvasInner({ libraryEntries, libraryPipelines, onLibraryDelete, on
   );
 
   const onNodeDragStop = useCallback(
-    (_: unknown, node: Node) => {
-      updateNode(node.id, {
-        view: { x: Math.round(node.position.x), y: Math.round(node.position.y) },
-      });
+    (_: unknown, _node: Node, nodes: Node[]) => {
+      // xyflow hands us EVERY dragged node (the selected set, or just [node] for
+      // a single drag) with final positions, in ONE call (#232). Persist them
+      // all in one batched store write — pre-fix we ignored this 3rd arg and
+      // wrote only the grabbed node, so every other selected node snapped back.
+      // Defensively skip the decorative loop-region boxes (already
+      // draggable:false, but belt-and-suspenders against config drift).
+      const moved = nodes
+        .filter((n) => n.type !== "loopRegion")
+        .map((n) => ({ id: n.id, x: n.position.x, y: n.position.y }));
+      if (moved.length > 0) updateNodeViews(moved);
     },
-    [updateNode],
+    [updateNodeViews],
   );
 
   const handleNodeContextMenu = useCallback(

--- a/frontend/src/components/MergeNode.tsx
+++ b/frontend/src/components/MergeNode.tsx
@@ -16,9 +16,12 @@ interface MergeEditData {
   [key: string]: unknown;
 }
 
-export function MergeEditNode({ data, id }: NodeProps<Node<MergeEditData>>) {
+export function MergeEditNode({ data, id, selected }: NodeProps<Node<MergeEditData>>) {
   const selection = useEditStore((s) => s.selection);
-  const isSelected = selection.kind === "node" && selection.id === id;
+  // OR-in xyflow's `selected` (#232) so a merge node in a multi-select group
+  // lights the ring during a drag too — mirrors MergeRunNode, which already
+  // takes `selected` from props.
+  const isSelected = selected || (selection.kind === "node" && selection.id === id);
   const isDropTarget = useIsDropTarget(id);
 
   return (

--- a/frontend/src/stores/editStore.test.ts
+++ b/frontend/src/stores/editStore.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { useEditStore, serializePipeline } from "./editStore";
+import { pipelinesEquivalent } from "../hooks/useLibraryPipelines";
 import { savePipeline, fetchPipeline, saveRunPipeline, deletePipeline } from "../api";
 import type { PipelineDef, NodeDef, EdgeDef } from "../types";
 
@@ -123,6 +124,90 @@ describe("addNode", () => {
     expect(tab.pipeline.nodes).toHaveLength(1);
     expect(tab.pipeline.nodes[0].id).toBe("abc12345");
     expect(tab.pipeline.nodes[0].name).toBe("worker");
+  });
+});
+
+describe("updateNodeViews — batched group-move position write (#232)", () => {
+  function seedThree() {
+    const a = makeNode({ id: "aaaa1111", name: "a", view: { x: 100, y: 100 } });
+    const b = makeNode({ id: "bbbb2222", name: "b", view: { x: 200, y: 200 } });
+    const c = makeNode({ id: "cccc3333", name: "c", view: { x: 300, y: 300 } });
+    seedTabWithPipeline(makePipeline([a, b, c]));
+  }
+
+  it("writes new views for every moved node and leaves un-moved nodes untouched", () => {
+    seedThree();
+
+    useEditStore.getState().updateNodeViews([
+      { id: "aaaa1111", x: 150, y: 160 },
+      { id: "bbbb2222", x: 250, y: 260 },
+    ]);
+
+    const nodes = useEditStore.getState().openTabs[0].pipeline.nodes;
+    expect(nodes.find((n) => n.id === "aaaa1111")!.view).toEqual({ x: 150, y: 160 });
+    expect(nodes.find((n) => n.id === "bbbb2222")!.view).toEqual({ x: 250, y: 260 });
+    // C was not in the update list — its original view must be preserved.
+    expect(nodes.find((n) => n.id === "cccc3333")!.view).toEqual({ x: 300, y: 300 });
+  });
+
+  it("sets dirty:true after a non-empty move", () => {
+    seedThree();
+    expect(useEditStore.getState().openTabs[0].dirty).toBe(false);
+
+    useEditStore.getState().updateNodeViews([{ id: "aaaa1111", x: 5, y: 6 }]);
+
+    expect(useEditStore.getState().openTabs[0].dirty).toBe(true);
+  });
+
+  it("is a no-op on an empty array (does not dirty the tab)", () => {
+    seedThree();
+    expect(useEditStore.getState().openTabs[0].dirty).toBe(false);
+
+    useEditStore.getState().updateNodeViews([]);
+
+    expect(useEditStore.getState().openTabs[0].dirty).toBe(false);
+  });
+
+  it("rounds fractional input coordinates (matching the single-node drag)", () => {
+    seedThree();
+
+    useEditStore.getState().updateNodeViews([
+      { id: "aaaa1111", x: 12.7, y: 34.2 },
+      { id: "bbbb2222", x: -5.4, y: 99.5 },
+    ]);
+
+    const nodes = useEditStore.getState().openTabs[0].pipeline.nodes;
+    expect(nodes.find((n) => n.id === "aaaa1111")!.view).toEqual({ x: 13, y: 34 });
+    expect(nodes.find((n) => n.id === "bbbb2222")!.view).toEqual({ x: -5, y: 100 });
+  });
+
+  it("silently ignores unknown ids", () => {
+    seedThree();
+
+    useEditStore.getState().updateNodeViews([
+      { id: "aaaa1111", x: 1, y: 2 },
+      { id: "does-not-exist", x: 9, y: 9 },
+    ]);
+
+    const nodes = useEditStore.getState().openTabs[0].pipeline.nodes;
+    expect(nodes).toHaveLength(3);
+    expect(nodes.find((n) => n.id === "aaaa1111")!.view).toEqual({ x: 1, y: 2 });
+  });
+
+  it("a group move is layout-only (semantically equivalent to the pre-move pipeline)", () => {
+    seedThree();
+    const before = structuredClone(useEditStore.getState().openTabs[0].pipeline);
+
+    useEditStore.getState().updateNodeViews([
+      { id: "aaaa1111", x: 999, y: 888 },
+      { id: "bbbb2222", x: 777, y: 666 },
+      { id: "cccc3333", x: 555, y: 444 },
+    ]);
+
+    const after = useEditStore.getState().openTabs[0].pipeline;
+    // Position is layout, not semantics: comparablePipelineObject strips `view`,
+    // so the moved pipeline must not register as a library divergence (#168).
+    expect(pipelinesEquivalent(before, after)).toBe(true);
   });
 });
 

--- a/frontend/src/stores/editStore.ts
+++ b/frontend/src/stores/editStore.ts
@@ -94,6 +94,10 @@ interface EditState {
   // Node mutations
   addNode: (node: NodeDef) => void;
   updateNode: (nodeId: string, updates: Partial<NodeDef>) => void;
+  // Batched position write for a group drag (#232): xyflow's onNodeDragStop
+  // hands us every dragged node at once; persist all their `view` coords in one
+  // store mutation (one re-derivation, one dirty/save unit).
+  updateNodeViews: (updates: { id: string; x: number; y: number }[]) => void;
   deleteNode: (nodeId: string) => void;
   duplicateNode: (nodeId: string) => void;
 
@@ -498,6 +502,24 @@ export const useEditStore = create<EditState>((set, get) => ({
           propagatePortChangesToEdges(tab, nodeId, oldNode.outputs, updates.outputs, "outputs");
         }
       }
+    }));
+  },
+
+  updateNodeViews: (updates: { id: string; x: number; y: number }[]) => {
+    if (updates.length === 0) return; // no-op: don't dirty/re-render on an empty drag
+    set((s) => mutateActiveTab(s, (tab) => {
+      // Round x/y exactly as the single-node drag did, so a group drag writes
+      // the same integer coords. One `set` = one re-derivation = one dirty/save
+      // unit. Positions never touch edges, so this skips
+      // propagatePortChangesToEdges. Unknown ids match nothing and are ignored
+      // (same as updateNode).
+      const moved = new Map(
+        updates.map((u) => [u.id, { x: Math.round(u.x), y: Math.round(u.y) }]),
+      );
+      tab.pipeline.nodes = tab.pipeline.nodes.map((n) => {
+        const view = moved.get(n.id);
+        return view ? { ...n, view } : n;
+      });
     }));
   },
 


### PR DESCRIPTION
## What

Group-moving multiple selected nodes on the edit canvas now persists **every** selected node's new position, not just the grabbed one.

Closes #232.

## Why

Pre-fix, `onNodeDragStop` ignored xyflow's 3rd argument (the full set of dragged nodes) and wrote only the grabbed node via `updateNode`. Every other node in a box-/additive-selection snapped back on drop, and Save silently dropped their moves — a "lying Save button".

## Changes

- **`editStore.ts`** — new `updateNodeViews([{id,x,y}])` batched action: one `set` = one re-derivation = one dirty/save unit; rounds coords exactly as the single-node path did; unknown ids are ignored.
- **`EditCanvas.tsx`** — `onNodeDragStop` now persists *all* dragged nodes in one batched write; filters out decorative `loopRegion` boxes. `EditNode` OR-ins xyflow's own `selected` so every node in a multi-select group lights the accent ring during a drag.
- **`MergeNode.tsx`** — same `selected` OR-in for merge nodes.
- Tests: `editStore.test.ts` covers the batched write (dirty, empty no-op, rounding, unknown-id, layout-equivalence); `e2e/group-move-nodes.spec.ts` + a Layer-5 scenario doc.
- Version bump to `0.1.25`.

## Validation

Tester verdict: **Pass**. Confirmed in the live UI (both selected nodes move by an identical delta, control node untouched) and at the persistence layer (on-disk YAML writes both selected nodes' coords). `npm run build` green; targeted vitest green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
