### PR TITLE
feat(ui): render mermaid diagrams in artifact markdown (#240)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1688,7 +1688,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "0.1.25"
+version = "0.1.26"
 license = "MIT"
 
 [workspace.dependencies]

--- a/docs/adr/0013-client-side-mermaid-rendering.md
+++ b/docs/adr/0013-client-side-mermaid-rendering.md
@@ -1,0 +1,94 @@
+# Rendu mermaid client-side — `strict` sans CSP, version épinglée
+
+PDO affiche le corps markdown des artefacts de NodeRun dans `MarkdownArtifactModal`
+(l'unique instanciation de `react-markdown`, donc *toute* la surface markdown
+agent-authored : aucune autre vue ne rend du texte markdown — les autres surfaces
+n'affichent que métadonnées et vignettes d'images). #240 demande de rendre les blocs
+` ```mermaid ` du corps en vrais diagrammes plutôt qu'en code fencé brut.
+
+Le contenu rendu est **écrit par un agent Claude Code** — donc atteignable par
+prompt-injection : un agent compromis ou dérivé peut émettre du mermaid hostile.
+mermaid compile ce source en SVG, et ce SVG doit être injecté dans le DOM via
+`dangerouslySetInnerHTML` — **le premier de tout le frontend**. L'app n'a **aucune
+CSP** (vérifié : rien côté daemon Axum ni côté HTML servi ; le daemon écoute
+`127.0.0.1`, mono-user, sans auth ni TLS). Il n'y a donc pas de filet réseau derrière
+le sink : la sécurité repose entièrement sur le sanitizer.
+
+**Décision.** On rend le mermaid **client-side**, dans un composant `MermaidDiagram`
+monté depuis l'override `pre` de `MarkdownArtifactModal`, avec :
+
+- **`securityLevel: 'strict'`** (mermaid injecte le texte des labels comme *texte*,
+  échappe le HTML, et passe son SVG par le DOMPurify qu'il **embarque déjà**, configuré
+  pour préserver les `<foreignObject>`). On retient `strict` plutôt que `sandbox`
+  (iframe) : `strict` garde le diagramme intégré au flux markdown et au sizing du modal ;
+  `sandbox` isole plus fort mais casse l'intégration visuelle et ajoute scroll/sizing
+  d'iframe. Décision owner-ratifiée 2026-06-22.
+- **`mermaid` épinglé `^11.15.0`.** La version *fait partie de la frontière de sécurité*,
+  pas un détail de dépendance. Plancher justifié par la **chaîne de GHSA publiée
+  2026-05-11, corrigée en 11.15.0** (CVE-2026-41149 `classDef` HTML-injection ;
+  GHSA-xcj9-5m2h-648r et GHSA-87f9-hvmw-gh4p CSS-injection ; GHSA-6m6c-36f7-fhxh DoS
+  Gantt). Les CVE XSS antérieures (CVE-2025-54880/54881, sequence/architecture) sont
+  déjà corrigées en 11.10.0 — donc couvertes a fortiori. Ne jamais dé-épingler sous ce
+  plancher.
+- **`secure: [...]` verrouillé + `suppressErrorRendering: true`** à l'`initialize`, pour
+  qu'une frontmatter / un `%%{init}%%` par-diagramme ne puisse pas ré-élever le niveau de
+  sécurité à l'exécution. `securityLevel` et `suppressErrorRendering` sont déjà dans le
+  `secure` par défaut ; on le pose **explicitement** pour rendre le verrou visible en
+  review.
+- **Pas de passe DOMPurify applicative *par défaut*.** mermaid sanitise déjà en interne
+  sous `strict` avec la config qui préserve les labels `<foreignObject>` ; une passe
+  applicative *en config par défaut* **casse** ces labels **et** rate la classe de CVE
+  visée (le texte non-fiable atteint le sink *avant* le sanitizer de mermaid). On épingle
+  la version à la place. (Nuance : une passe *correctement configurée* —
+  `USE_PROFILES:{svg:true,svgFilters:true}, ADD_TAGS:['foreignObject']` — serait une
+  défense-en-profondeur valide ; on ne la retient pas v1 pour ne pas ajouter une
+  dépendance non-semver à la frontière de sécurité.)
+- **Dégradation douce** : tout échec de `parse`/`render` retombe sur le `<pre><code>`
+  brut (le diagramme reste lisible comme source). C'est cohérent avec la posture
+  *surface, ne masque pas* de PDO — **à ne pas confondre** avec *Sharp tool* (ADR-0001),
+  qui parle du refus de contraindre le **design de pipeline**, pas du rendu UI.
+
+**Pourquoi.** Le contenu est agent-authored et prompt-injection-reachable, donc on ne
+peut pas le traiter comme du HTML de confiance. Sans CSP, le sink
+`dangerouslySetInnerHTML` n'a qu'une seule ligne de défense : le sanitizer. `strict` +
+version épinglée + config verrouillée fait du sanitizer interne de mermaid cette ligne,
+sur une cible *mono-user, local, `127.0.0.1`* où la surface d'attaque réseau est minime.
+
+Alternatives considérées :
+
+- **`securityLevel: 'sandbox'` (iframe)** — rejeté comme défaut, mais conservé comme
+  bascule défensive. Isolation plus forte (le SVG vit dans un iframe sandboxé, hors du DOM
+  principal), donc vraie défense-en-profondeur vu l'absence de CSP. Perd l'intégration au
+  flux markdown et complique le sizing dans un modal de 560px. *Consciemment* retenu comme
+  l'alternative-sécurité, pas comme un oubli.
+- **Pas de mermaid (laisser le code fencé brut)** — rejeté : c'est le besoin même de #240.
+  Le fallback `<pre><code>` *est* cet état, mais en chemin d'erreur uniquement.
+- **Prérendu server-side (daemon → SVG)** — rejeté : déplace un moteur de rendu lourd
+  (headless browser / node) dans un daemon Rust mono-user, alourdit le build et l'embed du
+  binaire, et n'élimine pas le besoin d'injecter du SVG côté client. Sur-ingénierie pour
+  une cible locale.
+- **Passe DOMPurify applicative en plus (v1)** — rejeté pour v1 (voir Décision) : casse les
+  labels `<foreignObject>` en config par défaut, et DOMPurify n'est pas semver, ajoutant
+  une dérive de sécurité au lieu d'en retirer.
+
+Conséquences :
+
+- **Premier `dangerouslySetInnerHTML` du frontend.** Le pattern existe désormais ; tout
+  futur sink raw-HTML doit être tenu au même standard (source de confiance ou sanitizer
+  audité).
+- **`mermaid` devient une dépendance security-sensitive.** Toute bump/downgrade passe par
+  la grille « est-ce que ça reste ≥ plancher CVE (11.15.0) ? ». Lazy `import()` pour
+  code-splitter (mermaid est lourd, >500 kB) — sans impact sécurité.
+- **Risque résiduel assumé — pas de CSP.** Si une CVE mermaid franchit `strict` *avant*
+  qu'on bump, il n'y a aucun second rideau. Le risque est borné par la cible (mono-user,
+  `127.0.0.1`, sans auth — un attaquant capable d'écrire le mermaid via un agent a déjà un
+  pied dans l'environnement local) et atténué par le pin `^11.15.0` + la config verrouillée.
+  **Mitigation recommandée en fast-follow** : ajouter une CSP minimale app-wide
+  (`script-src 'self'` sans `'unsafe-inline'`, `object-src 'none'`, `base-uri 'none'`) —
+  contrôle le plus rentable, app-wide, qui neutralise l'exécution de script de tout futur
+  bypass `strict` sans réverer le choix `strict`-over-`sandbox` (contrairement à `sandbox`,
+  une CSP ne casse ni les liens intra-app ni le sizing SVG). Tracé comme dette de sécurité
+  explicite.
+
+Interagit avec ADR-0004 (la couche de test qui valide ce rendu est Layer 3b Playwright +
+Layer 5 agentique, jsdom ne pouvant pas exécuter mermaid faute de `getBBox`).

--- a/docs/testing/scenarios/render-mermaid-artifact.md
+++ b/docs/testing/scenarios/render-mermaid-artifact.md
@@ -1,0 +1,198 @@
+# Scenario — `render-mermaid-artifact`
+
+> Layer 5 (agentic) per ADR 0004. Manual trigger: an agent drives a real browser
+> (Chrome DevTools MCP preferred; Playwright MCP fallback) and emits the verdict
+> format below. Asserts #240: a ` ```mermaid ` fenced block in an artifact's
+> markdown body renders as an inline **SVG diagram** in `MarkdownArtifactModal`,
+> styled to the dark palette; invalid mermaid **degrades gracefully** to the raw
+> `<pre><code>` source (never a blank pane, never a thrown error); and the security
+> posture (ADR-0013: `securityLevel: 'strict'`, no script execution) holds.
+>
+> jsdom cannot execute mermaid (no `getBBox`), so this Layer-5 + the Playwright
+> spec `frontend/e2e/render-mermaid-artifact.spec.ts` are the only layers that
+> exercise the *real* render path. Treat this scenario as the human-equivalent
+> acceptance gate.
+
+## Setup
+
+- A PDO daemon running on the user's repo. Discover the port — commonly
+  `http://127.0.0.1:5172` (debug dev), `6160` (installed prod), or `6172`; find it
+  with `ss -ltnp | grep -i pdo` and use that base URL for both the browser and the
+  `POST /runs` call.
+- Frontend reachable in a browser at that base URL (the daemon serves the embedded
+  `frontend/dist`). **The build under test must already include the #240 changes** —
+  if validating a local branch, rebuild the frontend and re-embed before driving the
+  UI (the daemon serves the *embedded* bundle, not the vite dev server, unless you
+  point the browser at a vite dev port).
+- `WORKSPACE_ROOT` = the repo the daemon runs against (where `.pdo/` lives).
+
+### Seed a pipeline + run + artifacts
+
+The scenario does not need a live Claude session — it seeds the artifact files on
+disk directly (the same seam the e2e suite uses). Steps:
+
+1. Write `.pdo/pipelines/render-mermaid-scenario.yaml`:
+
+   ```yaml
+   name: render-mermaid-scenario
+   version: "1.0"
+   nodes:
+     - id: diagrammer
+       name: diagrammer
+       type: doc-only
+       prompt_file: render-mermaid-scenario.prompts/diagrammer.md
+       outputs:
+         - name: good       # valid flowchart → must render an <svg>
+         - name: complex    # valid sequence diagram w/ labels → render + dark theme
+         - name: bad         # invalid syntax → must fall back to <pre><code>
+         - name: xss          # hostile payload → must NOT execute script
+       view: { x: 200, y: 200 }
+   edges: []
+   ```
+
+   And `.pdo/pipelines/render-mermaid-scenario.prompts/diagrammer.md` with any
+   one-line body (e.g. `Draw diagrams.`).
+
+2. `POST {baseURL}/runs` with JSON body `{"pipeline": "render-mermaid-scenario",
+   "input": "mermaid layer5"}`. Expect `201`; capture `run_id` from the response.
+
+3. Seed the four artifacts. **Path convention is
+   `.pdo/runs/<run_id>/worktree/.pdo/artifacts/<node>/iter-<n>/<port>/output.md`** —
+   the per-port subdirectory + `output.md`, NOT a flat `<port>.md` (the older e2e
+   specs use the stale flat form; do not copy them):
+
+   - `diagrammer/iter-1/good/output.md`:
+     ````markdown
+     ## Flow
+
+     ```mermaid
+     graph TD;
+       A[Start] --> B{Decision};
+       B -->|yes| C[Ship];
+       B -->|no| D[Iterate];
+     ```
+     ````
+   - `diagrammer/iter-1/complex/output.md`:
+     ````markdown
+     ## Sequence
+
+     ```mermaid
+     sequenceDiagram
+       participant U as User
+       participant D as Daemon
+       U->>D: POST /runs
+       D-->>U: 201 run_id
+     ```
+     ````
+   - `diagrammer/iter-1/bad/output.md`:
+     ````markdown
+     ## Broken
+
+     ```mermaid
+     this is not ::: valid mermaid @@@ ->> nonsense
+     ```
+     ````
+   - `diagrammer/iter-1/xss/output.md` — a payload that, pre-fix or under a weak
+     security level, would execute script; under ADR-0013's `strict` it must render
+     inertly or fall back, **never** pop a dialog:
+     ````markdown
+     ## Hostile
+
+     ```mermaid
+     graph LR
+       A["<img src=x onerror='window.__mermaidXss=1'>"] --> B[B]
+     ```
+     ````
+
+## Steps the agent executes — render path
+
+1. Open the UI; confirm the **`Daemon: connected`** label is visible in the status
+   bar.
+2. Click the run row for `run_id` (the list shows the first 8 chars —
+   `run_id.slice(0,8)`).
+3. Wait for the canvas (`.react-flow`) to render; click the **`diagrammer`** node.
+4. Wait for the **`Outputs`** section; the four ports (`good`, `complex`, `bad`,
+   `xss`) appear as clickable `button.port-row` cards (a card is only clickable once
+   its file exists on disk — it does, from Setup).
+5. **Valid flowchart (`good`):** click the `good` port card. In the modal
+   (`.artifact-markdown`):
+   - Assert an element `[data-testid="mermaid-diagram"]` is visible **and contains an
+     `<svg>`** with non-zero width and height (a real rendered diagram, not the raw
+     fence). Read its bounding box to confirm `width > 0 && height > 0`.
+   - Assert the modal does **not** show the literal text `graph TD` as code (i.e. the
+     fence was consumed, not printed verbatim).
+   - Assert no console error was thrown by mermaid (check the devtools console; a
+     benign >500 kB chunk warning at load is acceptable, a thrown render error is not).
+   - Close the modal (Escape).
+6. **Sequence diagram + dark theme (`complex`):** open the `complex` port card.
+   - Assert `[data-testid="mermaid-diagram"] svg` is visible with non-zero box.
+   - Assert the diagram is themed dark, not the mermaid light default: sample a node
+     rectangle's computed `fill` (or the SVG root/background) and confirm it is a dark
+     palette colour (e.g. matches `#1a1e25`/`#14171d` family), **not** white
+     `#ffffff`/`#ECECFF` (mermaid's default light fills). Screenshot for the evidence
+     trail.
+   - Close the modal.
+7. **Invalid syntax → graceful degrade (`bad`):** open the `bad` port card.
+   - Assert the modal is **not blank** and shows the raw source as a fallback: either
+     `[data-testid="mermaid-error"]` is visible, **or** the raw fence text
+     (`this is not ::: valid mermaid`) is shown inside a `.artifact-markdown pre code`.
+   - Assert **no** `[data-testid="mermaid-diagram"] svg` rendered for this port.
+   - Assert no uncaught exception reached the console (the failure was caught and
+     degraded, per ADR-0013).
+   - Close the modal.
+
+## Steps — security (ADR-0013 strict)
+
+8. **Hostile payload (`xss`):** before opening, in the devtools console set a probe
+   baseline and ensure `window.__mermaidXss` is `undefined`.
+9. Open the `xss` port card. Wait for the modal to settle (render or fallback).
+10. Assert **no JS executed from the payload**:
+    - `window.__mermaidXss` is still `undefined` (the `onerror` never fired).
+    - No `alert`/`dialog` was triggered (no pending dialog handler hit).
+    - Either a diagram rendered with the label as **inert text** (the `<img onerror>`
+      neutralised by mermaid's strict DOMPurify) or it fell back to `<pre><code>` —
+      both are acceptable; script execution is not.
+11. Close the modal.
+
+## Negative control — plain markdown still works
+
+12. (Optional, if a non-mermaid markdown port is handy, or reuse an existing run's
+    `.md` output.) Open any artifact whose body has **no** mermaid fence. Assert it
+    renders as normal markdown (headings, lists, code blocks in other languages shown
+    as plain `<pre><code>`), and that a regular ` ```bash ` or ` ```ts ` fence is
+    **not** swallowed by the mermaid path — it must still appear as a code block.
+    This proves the `pre`/`code` override only intercepts `language-mermaid`.
+
+## Cleanup
+
+- Delete `.pdo/pipelines/render-mermaid-scenario.yaml` and the
+  `render-mermaid-scenario.prompts/` dir.
+- Optionally archive/clean the seeded run (`POST {baseURL}/runs/<run_id>/archive`
+  or the project's cleanup path) so it doesn't linger in the Runs list. The daemon
+  may have spawned a `pdo-<run_id>-diagrammer-iter-1` tmux session under the stubbed
+  command — kill it with `tmux kill-session -t pdo-<run_id>-diagrammer-iter-1` if
+  present (kill-session by full name only, never `kill <pid>` — per the reaper rule).
+
+## Verdict format
+
+```json
+{
+  "verdict": "PASS" | "FAIL",
+  "evidence": [
+    "setup: pipeline seeded, run <id> created (201), 4 artifacts written at <port>/output.md paths",
+    "step 1: status bar shows 'Daemon: connected'",
+    "step 5: 'good' port renders [data-testid=mermaid-diagram] > svg with non-zero bbox; no raw 'graph TD' text; no thrown console error",
+    "step 6: 'complex' renders an svg themed dark (node fill ~#1a1e25, not #ffffff/#ECECFF)",
+    "step 7: 'bad' degrades to raw <pre><code> (or [data-testid=mermaid-error]); no svg; no uncaught exception",
+    "step 10: 'xss' — window.__mermaidXss undefined, no dialog fired; label inert or fell back",
+    "step 12: a non-mermaid ```ts fence still renders as a normal code block (override is mermaid-only)"
+  ],
+  "anomalies": [
+    "<optional — e.g. diagram overflowed the 560px modal without horizontal scroll; light-theme fill leaked; chunk-size warning>"
+  ]
+}
+```
+
+A single failed assertion ⇒ `verdict: "FAIL"`. Don't half-pass. The security
+assertion (step 10) and the graceful-degrade assertion (step 7) are non-negotiable:
+either failing is an automatic `FAIL` regardless of the happy path.

--- a/frontend/e2e/render-mermaid-artifact.spec.ts
+++ b/frontend/e2e/render-mermaid-artifact.spec.ts
@@ -1,0 +1,294 @@
+import { test, expect, type Page } from "@playwright/test";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { expectNonZeroBBox } from "./assertions";
+
+// Layer 3b — mermaid rendering in MarkdownArtifactModal (#240, ADR-0013).
+// jsdom can't execute mermaid (no SVG getBBox), so this is the meaningful
+// automated layer for the real render path. It proves: a valid ```mermaid fence
+// renders an inline dark-themed <svg>; invalid mermaid degrades to raw
+// <pre><code> (never blank, never a thrown error); a hostile payload does NOT
+// execute script under securityLevel:'strict'; and a non-mermaid fence is left
+// as a normal code block.
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const WORKSPACE_ROOT = path.resolve(__dirname, "..", "..");
+const PIPELINE_NAME = `e2e-render-mermaid-${process.pid}-${Date.now()}`;
+const PIPELINE_DIR = path.join(WORKSPACE_ROOT, ".pdo", "pipelines");
+const PIPELINE_PATH = path.join(PIPELINE_DIR, `${PIPELINE_NAME}.yaml`);
+const PROMPTS_DIR = path.join(PIPELINE_DIR, `${PIPELINE_NAME}.prompts`);
+
+// A valid pipeline needs exactly one `start` node (one `user_prompt` output) and
+// one `end` node (one `result` input); see crates/pdo-daemon/src/pipeline.rs. The
+// `start` auto-emits the prompt so `diagrammer` spawns (stubbed by sleep); we seed
+// its output artifacts on disk and read them back through the node-IO API.
+const SEED_YAML = `name: ${PIPELINE_NAME}
+version: "1.0"
+nodes:
+  - id: start
+    name: Start
+    type: start
+    outputs:
+      - { name: user_prompt, side: right }
+    view: { x: 0, y: 200 }
+  - id: diagrammer
+    name: diagrammer
+    type: doc-only
+    prompt_file: ${PIPELINE_NAME}.prompts/diagrammer.md
+    inputs:
+      - { name: in, side: left }
+    outputs:
+      - name: good
+      - name: complex
+      - name: bad
+      - name: xss
+      - name: plain
+    view: { x: 200, y: 200 }
+  - id: end
+    name: End
+    type: end
+    inputs:
+      - { name: result, side: top }
+    view: { x: 400, y: 200 }
+edges:
+  - source: { node: start, port: user_prompt }
+    target: { node: diagrammer, port: in }
+  - source: { node: diagrammer, port: good }
+    target: { node: end, port: result }
+`;
+
+const ROLE_PROMPT = "You draw diagrams.\n";
+
+// Per-port artifact bodies. The daemon resolves a markdown output port to
+// `<node>/iter-1/<port>/output.md` (see crates/pdo-daemon/src/blackboard.rs);
+// the flat `<port>.md` layout in older specs does NOT match that resolver.
+const ARTIFACTS: Record<string, string> = {
+  good: `## Flow
+
+\`\`\`mermaid
+graph TD;
+  A[Start] --> B{Decision};
+  B -->|yes| C[Ship];
+  B -->|no| D[Iterate];
+\`\`\`
+`,
+  complex: `## Sequence
+
+\`\`\`mermaid
+sequenceDiagram
+  participant U as User
+  participant D as Daemon
+  U->>D: POST /runs
+  D-->>U: 201 run_id
+\`\`\`
+`,
+  bad: `## Broken
+
+\`\`\`mermaid
+this is not ::: valid mermaid @@@ ->> nonsense
+\`\`\`
+`,
+  xss: `## Hostile
+
+\`\`\`mermaid
+graph LR
+  A["<img src=x onerror='window.__mermaidXss=1'>"] --> B[B]
+\`\`\`
+`,
+  plain: `## Plain
+
+\`\`\`ts
+const x: number = 1;
+\`\`\`
+`,
+};
+
+let runId: string;
+
+test.beforeAll(async () => {
+  process.env.PDO_TMUX_CMD_OVERRIDE = "exec sleep 600";
+  await fs.mkdir(PROMPTS_DIR, { recursive: true });
+  await fs.writeFile(PIPELINE_PATH, SEED_YAML);
+  await fs.writeFile(path.join(PROMPTS_DIR, "diagrammer.md"), ROLE_PROMPT);
+});
+
+test.afterAll(async () => {
+  await fs.rm(PIPELINE_PATH, { force: true });
+  await fs.rm(PROMPTS_DIR, { recursive: true, force: true });
+  delete process.env.PDO_TMUX_CMD_OVERRIDE;
+  if (runId) {
+    const { execSync } = await import("node:child_process");
+    try {
+      // kill-session only — never `kill <pid>` (would take down the tmux server).
+      execSync(`tmux kill-session -t pdo-${runId}-diagrammer-iter-1`, {
+        stdio: "ignore",
+      });
+    } catch {
+      // session may already be dead
+    }
+  }
+});
+
+async function createRunAndSeedArtifacts(baseURL: string) {
+  const resp = await fetch(`${baseURL}/runs`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ pipeline: PIPELINE_NAME, input: "mermaid layer3b" }),
+  });
+  expect(resp.status).toBe(201);
+  const json = await resp.json();
+  runId = json.run_id;
+
+  const iterDir = path.join(
+    WORKSPACE_ROOT,
+    ".pdo",
+    "runs",
+    runId,
+    "worktree",
+    ".pdo",
+    "artifacts",
+    "diagrammer",
+    "iter-1",
+  );
+  for (const [port, body] of Object.entries(ARTIFACTS)) {
+    const portDir = path.join(iterDir, port);
+    await fs.mkdir(portDir, { recursive: true });
+    await fs.writeFile(path.join(portDir, "output.md"), body);
+  }
+  return runId;
+}
+
+async function openNode(page: Page) {
+  await page.goto("/");
+  await expect(page.getByText("Daemon: connected")).toBeVisible({
+    timeout: 10_000,
+  });
+  await page.getByText(runId.slice(0, 8)).first().click({ timeout: 5_000 });
+
+  const reactFlow = page.locator(".react-flow");
+  await expect(reactFlow).toBeVisible({ timeout: 5_000 });
+  await page.waitForTimeout(500);
+
+  const node = page.getByText("diagrammer", { exact: true }).first();
+  await expect(node).toBeVisible({ timeout: 3_000 });
+  await node.click();
+
+  // Opening a live run auto-selects the running node with its terminal expanded
+  // fullscreen (App.tsx initialTerminalExpanded), which hides the Inputs/Outputs
+  // pane. Collapse the terminal to reveal the output port cards.
+  const detailsPane = page.locator('[data-testid="details-pane"]');
+  const expandToggle = page.locator('[data-testid="term-expand"]');
+  await expect(expandToggle).toBeVisible({ timeout: 5_000 });
+  if (!(await detailsPane.isVisible())) {
+    await expandToggle.click();
+  }
+  await expect(detailsPane).toBeVisible({ timeout: 5_000 });
+}
+
+async function openPort(page: Page, port: string) {
+  const card = page
+    .locator("button.port-row")
+    .filter({ hasText: new RegExp(`^${port}`) });
+  await expect(card).toBeVisible({ timeout: 5_000 });
+  await card.click();
+  await expect(page.locator(".artifact-markdown")).toBeVisible({
+    timeout: 3_000,
+  });
+}
+
+async function closeModal(page: Page) {
+  await page.keyboard.press("Escape");
+  await expect(page.locator(".artifact-markdown")).not.toBeVisible({
+    timeout: 2_000,
+  });
+}
+
+test("renders, degrades, secures and ignores non-mermaid fences", async ({
+  page,
+  baseURL,
+}) => {
+  // Surface any uncaught page exception — a caught parse/render failure must
+  // never bubble up as one (ADR-0013).
+  const pageErrors: string[] = [];
+  page.on("pageerror", (e) => pageErrors.push(String(e)));
+  // A hostile payload must never trigger a dialog.
+  page.on("dialog", async (d) => {
+    pageErrors.push(`unexpected dialog: ${d.message()}`);
+    await d.dismiss();
+  });
+
+  await createRunAndSeedArtifacts(baseURL!);
+  await openNode(page);
+
+  // 1) Valid flowchart → an <svg> with a non-zero box; the fence text is consumed.
+  await openPort(page, "good");
+  const goodSvg = page.locator('[data-testid="mermaid-diagram"] svg');
+  await expect(goodSvg).toBeVisible({ timeout: 10_000 });
+  await expectNonZeroBBox(goodSvg);
+  await expect(page.locator(".artifact-markdown")).not.toContainText(
+    "graph TD",
+  );
+  await closeModal(page);
+
+  // 2) Sequence diagram → rendered with the dark theme (node fill not white).
+  await openPort(page, "complex");
+  const complexSvg = page.locator('[data-testid="mermaid-diagram"] svg');
+  await expect(complexSvg).toBeVisible({ timeout: 10_000 });
+  await expectNonZeroBBox(complexSvg);
+  const fills = await complexSvg.evaluate((svg) => {
+    const out: string[] = [];
+    svg
+      .querySelectorAll<SVGElement>("rect, polygon, path, circle")
+      .forEach((el) => {
+        const f = getComputedStyle(el).fill;
+        if (f && f !== "none") out.push(f);
+      });
+    return out;
+  });
+  const toRgb = (s: string) =>
+    s.match(/\d+/g)?.slice(0, 3).map(Number) ?? null;
+  const isLight = (rgb: number[]) =>
+    (rgb[0] === 255 && rgb[1] === 255 && rgb[2] === 255) || // white
+    (rgb[0] === 236 && rgb[1] === 236 && rgb[2] === 255); // mermaid default #ECECFF
+  const rgbs = fills.map(toRgb).filter((v): v is number[] => v !== null);
+  expect(rgbs.length).toBeGreaterThan(0);
+  expect(rgbs.some((rgb) => !isLight(rgb))).toBe(true); // at least one dark shape
+  expect(rgbs.every((rgb) => !isLight(rgb))).toBe(true); // no light-theme leak
+  await closeModal(page);
+
+  // 3) Invalid mermaid → graceful degrade to raw <pre><code>, no diagram.
+  await openPort(page, "bad");
+  const errFallback = page.locator('[data-testid="mermaid-error"]');
+  await expect(errFallback).toBeVisible({ timeout: 10_000 });
+  await expect(errFallback).toContainText("this is not ::: valid mermaid");
+  await expect(
+    page.locator('[data-testid="mermaid-diagram"] svg'),
+  ).toHaveCount(0);
+  await closeModal(page);
+
+  // 4) Security (strict): hostile payload must not execute script.
+  expect(await page.evaluate(() => (window as Window & { __mermaidXss?: number }).__mermaidXss)).toBeUndefined();
+  await openPort(page, "xss");
+  // Wait for the modal to settle into either a diagram or the fallback.
+  await expect(
+    page.locator(
+      '[data-testid="mermaid-diagram"], [data-testid="mermaid-error"]',
+    ),
+  ).toBeVisible({ timeout: 10_000 });
+  await page.waitForTimeout(300); // give any (blocked) onerror a chance to fire
+  expect(await page.evaluate(() => (window as Window & { __mermaidXss?: number }).__mermaidXss)).toBeUndefined();
+  await closeModal(page);
+
+  // 5) Negative control: a non-mermaid fence stays a normal code block.
+  await openPort(page, "plain");
+  const md = page.locator(".artifact-markdown");
+  await expect(md).toContainText("const x: number = 1;");
+  await expect(
+    page.locator('[data-testid="mermaid-diagram"]'),
+  ).toHaveCount(0);
+  await expect(page.locator('[data-testid="mermaid-error"]')).toHaveCount(0);
+  await closeModal(page);
+
+  expect(pageErrors).toEqual([]);
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,6 +20,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^1.14.0",
+        "mermaid": "^11.15.0",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
         "react-markdown": "^10.1.0",
@@ -58,6 +59,19 @@
       "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@antfu/install-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
+      "integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "package-manager-detector": "^1.3.0",
+        "tinyexec": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
     },
     "node_modules/@asamuzakjp/css-color": {
       "version": "5.1.11",
@@ -584,6 +598,12 @@
         }
       }
     },
+    "node_modules/@braintree/sanitize-url": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
+      "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
+      "license": "MIT"
+    },
     "node_modules/@bramus/specificity": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
@@ -596,6 +616,12 @@
       "bin": {
         "specificity": "bin/cli.js"
       }
+    },
+    "node_modules/@chevrotain/types": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
+      "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
+      "license": "Apache-2.0"
     },
     "node_modules/@csstools/color-helpers": {
       "version": "6.0.2",
@@ -1208,6 +1234,23 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "license": "MIT"
+    },
+    "node_modules/@iconify/utils": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.3.tgz",
+      "integrity": "sha512-LPKOXPn/zV+zis1oOfGWogaXVpqUybF3ZS6SCZIsz8vg0ivVp9+fVqyYB7xq0aiST/VhUQYGO1qo6uoYSiEJqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@antfu/install-pkg": "^1.1.0",
+        "@iconify/types": "^2.0.0",
+        "import-meta-resolve": "^4.2.0"
+      }
+    },
     "node_modules/@inquirer/ansi": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.5.tgz",
@@ -1333,6 +1376,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@mermaid-js/parser": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.1.tgz",
+      "integrity": "sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@chevrotain/types": "~11.1.1"
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
@@ -2629,10 +2681,100 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/d3": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
+      "license": "MIT"
+    },
     "node_modules/@types/d3-color": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
       "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
       "license": "MIT"
     },
     "node_modules/@types/d3-drag": {
@@ -2644,6 +2786,54 @@
         "@types/d3-selection": "*"
       }
     },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+      "license": "MIT"
+    },
     "node_modules/@types/d3-interpolate": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
@@ -2653,10 +2843,76 @@
         "@types/d3-color": "*"
       }
     },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
+      "integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/d3-selection": {
       "version": "3.0.11",
       "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
       "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "license": "MIT"
     },
     "node_modules/@types/d3-transition": {
@@ -2715,6 +2971,12 @@
       "dependencies": {
         "@types/estree": "*"
       }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
     },
     "node_modules/@types/hast": {
       "version": "3.0.4",
@@ -2789,6 +3051,13 @@
       "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
       "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
       "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -3050,6 +3319,16 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
       "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
       "license": "ISC"
+    },
+    "node_modules/@upsetjs/venn.js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
+      "integrity": "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "d3-selection": "^3.0.0",
+        "d3-transition": "^3.0.1"
+      }
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.1",
@@ -3933,6 +4212,15 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/cose-base": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
+      "integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^1.0.0"
+      }
+    },
     "node_modules/cosmiconfig": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
@@ -4012,11 +4300,173 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/cytoscape": {
+      "version": "3.34.0",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.0.tgz",
+      "integrity": "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/cytoscape-cose-bilkent": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
+      "integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^1.0.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
+      "integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^2.2.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/cose-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
+      "integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^2.0.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/layout-base": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
+      "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
+      "license": "MIT"
+    },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-color": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
       "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
       "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
       "engines": {
         "node": ">=12"
       }
@@ -4043,11 +4493,113 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/d3-ease": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
       "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
       "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
@@ -4064,11 +4616,152 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-sankey": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1 - 2",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-sankey/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "license": "ISC"
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-selection": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
       "engines": {
         "node": ">=12"
       }
@@ -4117,6 +4810,16 @@
         "node": ">=12"
       }
     },
+    "node_modules/dagre-d3-es": {
+      "version": "7.0.14",
+      "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz",
+      "integrity": "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==",
+      "license": "MIT",
+      "dependencies": {
+        "d3": "^7.9.0",
+        "lodash-es": "^4.17.21"
+      }
+    },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
@@ -4139,6 +4842,12 @@
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -4247,6 +4956,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -4303,6 +5021,15 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/dotenv": {
       "version": "17.4.2",
@@ -4454,6 +5181,16 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.48.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.48.1.tgz",
+      "integrity": "sha512-wfnXlwd5I75eXRtdD2vuEs50xHHESECDsGD7yiQnfFVNoa5522NwXEbmgo98LfiukSQHs+mBM7/YG3qKJB9/mQ==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -5288,6 +6025,12 @@
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
     },
+    "node_modules/hachure-fill": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
+      "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
+      "license": "MIT"
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -5494,6 +6237,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -5525,6 +6278,15 @@
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
       "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
       "license": "MIT"
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/ip-address": {
       "version": "10.1.0",
@@ -5946,6 +6708,31 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/katex": {
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -5956,6 +6743,11 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/khroma": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
+      "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="
+    },
     "node_modules/kleur": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
@@ -5964,6 +6756,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/layout-base": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
+      "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
+      "license": "MIT"
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -6250,6 +7048,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "license": "MIT"
+    },
     "node_modules/log-symbols": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
@@ -6334,6 +7138,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/marked": {
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
+      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/math-intrinsics": {
@@ -6668,6 +7484,35 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/mermaid": {
+      "version": "11.15.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.15.0.tgz",
+      "integrity": "sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@braintree/sanitize-url": "^7.1.1",
+        "@iconify/utils": "^3.0.2",
+        "@mermaid-js/parser": "^1.1.1",
+        "@types/d3": "^7.4.3",
+        "@upsetjs/venn.js": "^2.0.0",
+        "cytoscape": "^3.33.1",
+        "cytoscape-cose-bilkent": "^4.1.0",
+        "cytoscape-fcose": "^2.2.0",
+        "d3": "^7.9.0",
+        "d3-sankey": "^0.12.3",
+        "dagre-d3-es": "7.0.14",
+        "dayjs": "^1.11.19",
+        "dompurify": "^3.3.1",
+        "es-toolkit": "^1.45.1",
+        "katex": "^0.16.25",
+        "khroma": "^2.1.0",
+        "marked": "^16.3.0",
+        "roughjs": "^4.6.6",
+        "stylis": "^4.3.6",
+        "ts-dedent": "^2.2.0",
+        "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0"
       }
     },
     "node_modules/micromark": {
@@ -7692,6 +8537,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-manager-detector": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
+      "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
+      "license": "MIT"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -7785,6 +8636,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
       "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "license": "MIT"
+    },
+    "node_modules/path-data-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
+      "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
       "license": "MIT"
     },
     "node_modules/path-exists": {
@@ -7891,6 +8748,22 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/points-on-curve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
+      "integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
+      "license": "MIT"
+    },
+    "node_modules/points-on-path": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
+      "integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
+      "license": "MIT",
+      "dependencies": {
+        "path-data-parser": "0.1.0",
+        "points-on-curve": "0.2.0"
       }
     },
     "node_modules/postcss": {
@@ -8353,6 +9226,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense"
+    },
     "node_modules/rolldown": {
       "version": "1.0.0-rc.17",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
@@ -8391,6 +9270,18 @@
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
       "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
       "license": "MIT"
+    },
+    "node_modules/roughjs": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
+      "integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hachure-fill": "^0.5.2",
+        "path-data-parser": "^0.1.0",
+        "points-on-curve": "^0.2.0",
+        "points-on-path": "^0.2.1"
+      }
     },
     "node_modules/router": {
       "version": "2.2.0",
@@ -8452,6 +9343,12 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -8900,6 +9797,12 @@
         "inline-style-parser": "0.2.7"
       }
     },
+    "node_modules/stylis": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
+      "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
+      "license": "MIT"
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -8965,7 +9868,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
       "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -9092,6 +9994,15 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/ts-dedent": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.3.0.tgz",
+      "integrity": "sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.10"
       }
     },
     "node_modules/ts-morph": {
@@ -9409,6 +10320,19 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
     },
     "node_modules/validate-npm-package-name": {
       "version": "7.0.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.14.0",
+    "mermaid": "^11.15.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "react-markdown": "^10.1.0",

--- a/frontend/src/components/MarkdownArtifactModal.mermaid.test.tsx
+++ b/frontend/src/components/MarkdownArtifactModal.mermaid.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// This suite uses the REAL react-markdown (no mock) so the `components.pre`
+// override that routes a ```mermaid fence to <MermaidDiagram> is exercised end
+// to end. jsdom cannot run mermaid's render path (no SVG getBBox), so this layer
+// only asserts the graceful-degrade branch (invalid mermaid → raw <pre><code>)
+// and the negative control (a non-mermaid fence stays a plain code block). The
+// real SVG render is covered by e2e/render-mermaid-artifact.spec.ts (#240).
+
+const fetchArtifactMock = vi.fn();
+const fetchNodeIOMock = vi.fn();
+
+vi.mock("../api", () => ({
+  fetchArtifact: (...args: unknown[]) => fetchArtifactMock(...args),
+  fetchNodeIO: (...args: unknown[]) => fetchNodeIOMock(...args),
+  artifactUrl: (runId: string, path: string) =>
+    `/runs/${runId}/artifact?path=${encodeURIComponent(path)}`,
+}));
+
+import MarkdownArtifactModal from "./MarkdownArtifactModal";
+import type { FileInfo } from "../api";
+
+function makeFile(path: string, exists = true): FileInfo {
+  return { path, exists, size: 0, frontmatter: null };
+}
+
+function renderModal() {
+  return render(
+    <MarkdownArtifactModal
+      runId="run-1"
+      portName="out"
+      source={{
+        kind: "static",
+        files: [makeFile("artifacts/node/iter-1/out/output.md")],
+      }}
+      onClose={() => {}}
+    />,
+  );
+}
+
+describe("MarkdownArtifactModal mermaid fence", () => {
+  beforeEach(() => {
+    fetchArtifactMock.mockReset();
+    fetchNodeIOMock.mockReset();
+  });
+
+  it("degrades an invalid mermaid fence to the raw source fallback", async () => {
+    const badSource = "this is not ::: valid mermaid @@@ ->> nonsense";
+    fetchArtifactMock.mockResolvedValue(
+      `## Broken\n\n\`\`\`mermaid\n${badSource}\n\`\`\`\n`,
+    );
+
+    renderModal();
+
+    // mermaid is lazily imported and parsed asynchronously; the fallback only
+    // appears once parse() resolves false (or the import/parse throws), so allow
+    // a generous timeout for the first dynamic import under jsdom.
+    const fallback = await screen.findByTestId(
+      "mermaid-error",
+      {},
+      { timeout: 15_000 },
+    );
+    expect(fallback).toHaveTextContent(badSource);
+    // The failed diagram never produced an <svg>.
+    expect(screen.queryByTestId("mermaid-diagram")).not.toBeInTheDocument();
+  }, 20_000);
+
+  it("leaves a non-mermaid fenced code block as a plain code block", async () => {
+    fetchArtifactMock.mockResolvedValue(
+      "## Code\n\n```ts\nconst x: number = 1;\n```\n",
+    );
+
+    renderModal();
+
+    // The override intercepts only language-mermaid, so a ```ts fence renders as
+    // a normal <pre><code> block — never as a diagram or the mermaid fallback.
+    const code = await screen.findByText(/const x: number = 1;/);
+    expect(code.closest("pre")).not.toBeNull();
+    expect(screen.queryByTestId("mermaid-diagram")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("mermaid-error")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/MarkdownArtifactModal.tsx
+++ b/frontend/src/components/MarkdownArtifactModal.tsx
@@ -5,7 +5,9 @@ import remarkGfm from "remark-gfm";
 import { fetchArtifact, fetchNodeIO, artifactUrl } from "../api";
 import type { FileInfo } from "../api";
 import type { IterationInfo, PortType } from "../types";
+import type { Element } from "hast";
 import ImageLightbox from "./ImageLightbox";
+import MermaidDiagram from "./MermaidDiagram";
 
 export type ArtifactSource =
   | { kind: "static"; files: FileInfo[] }
@@ -303,6 +305,32 @@ export default function MarkdownArtifactModal({
                             }}
                           />
                         );
+                      },
+                      // A ```mermaid fenced block parses to
+                      // <pre><code class="language-mermaid">src</code></pre>.
+                      // Detect it on the child <code> and unwrap to a rendered
+                      // SVG diagram; every other block falls through to a plain
+                      // <pre>. We override `pre` (not `code`) to avoid emitting a
+                      // <div> inside a <pre> (invalid nesting). Regular ```ts /
+                      // ```bash fences are untouched. (#240)
+                      pre: ({ node, children, ...rest }) => {
+                        const child = node?.children?.[0];
+                        const isMermaid =
+                          child?.type === "element" &&
+                          child.tagName === "code" &&
+                          (
+                            (child.properties?.className as string[]) ?? []
+                          ).includes("language-mermaid");
+                        if (isMermaid) {
+                          const codeEl = child as Element;
+                          const text = codeEl.children?.[0];
+                          const source =
+                            text && text.type === "text"
+                              ? text.value.replace(/\n$/, "")
+                              : "";
+                          return <MermaidDiagram source={source} />;
+                        }
+                        return <pre {...rest}>{children}</pre>;
                       },
                     }}
                   >

--- a/frontend/src/components/MermaidDiagram.tsx
+++ b/frontend/src/components/MermaidDiagram.tsx
@@ -1,0 +1,116 @@
+import { useEffect, useId, useState } from "react";
+
+// Dark-only theme variables (ADR-0013). mermaid bakes colours into the generated
+// SVG's <style>, so CSS `var()` won't resolve inside it — we pass resolved hex
+// values mapped to the PDO palette (see frontend/src/index.css `@theme`).
+const DARK_THEME_VARS = {
+  background: "#14171d", // bg-2 (modal body)
+  primaryColor: "#1a1e25", // bg-3 node fill
+  primaryBorderColor: "#2a313b", // line-strong
+  primaryTextColor: "#e6e8eb", // fg
+  secondaryColor: "#232831", // bg-4
+  secondaryBorderColor: "#2a313b",
+  secondaryTextColor: "#aab1bd", // fg-2
+  tertiaryColor: "#0f1115", // bg-1
+  tertiaryBorderColor: "#1f242c", // line
+  tertiaryTextColor: "#aab1bd",
+  lineColor: "#767e8c", // fg-3 (edge stroke, visible on dark)
+  textColor: "#aab1bd", // fg-2
+  mainBkg: "#1a1e25",
+  nodeBorder: "#2a313b",
+  nodeTextColor: "#e6e8eb",
+  edgeLabelBackground: "#14171d", // opaque chip so labels stay legible
+  noteBkgColor: "#232831",
+  noteBorderColor: "#2a313b",
+  noteTextColor: "#e6e8eb",
+  clusterBkg: "#0f1115",
+  clusterBorder: "#1f242c",
+  activeTaskBkgColor: "#10b981", // acc
+  titleColor: "#e6e8eb",
+  fontSize: "12px",
+} as const;
+
+// Initialize ONCE at module scope. initialize() is synchronous (returns void).
+// `secure` is set explicitly so a per-diagram %%{init}%% / frontmatter directive
+// cannot downgrade securityLevel at runtime (ADR-0013). Under `strict`, click
+// handlers are disabled, so bindFunctions is never needed.
+let initialized = false;
+async function ensureMermaid() {
+  const mermaid = (await import("mermaid")).default; // lazy → code-split out of initial bundle
+  if (!initialized) {
+    mermaid.initialize({
+      startOnLoad: false,
+      securityLevel: "strict",
+      suppressErrorRendering: true,
+      theme: "base",
+      themeVariables: DARK_THEME_VARS,
+      fontFamily: '"Geist", ui-sans-serif, system-ui, -apple-system, sans-serif',
+      secure: [
+        "secure",
+        "securityLevel",
+        "startOnLoad",
+        "maxTextSize",
+        "suppressErrorRendering",
+        "maxEdges",
+      ],
+    });
+    initialized = true;
+  }
+  return mermaid;
+}
+
+export default function MermaidDiagram({ source }: { source: string }) {
+  const rawId = useId();
+  // useId() emits delimiter chars unsafe in the `#${id}` selector mermaid builds
+  // internally: ':' in React 19.0, guillemets '«»' in 19.1+ (we ship 19.2). Strip
+  // everything outside [a-zA-Z0-9_-]; the broad regex is intentionally version-proof.
+  const id = "mermaid-" + rawId.replace(/[^a-zA-Z0-9_-]/g, "");
+  const [svg, setSvg] = useState<string | null>(null);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false; // StrictMode double-invoke + iter-nav races
+    (async () => {
+      try {
+        const mermaid = await ensureMermaid();
+        // parse is ASYNC. With suppressErrors it resolves `false` on bad input or a
+        // truthy { diagramType } object on success — gate on truthiness, NOT === true.
+        const ok = await mermaid.parse(source, { suppressErrors: true });
+        if (cancelled) return;
+        if (!ok) {
+          setFailed(true);
+          return;
+        }
+        // render is ASYNC, resolves { svg }. Needs a live DOM (getBBox) → fails under
+        // jsdom (that's why the meaningful test layer is Playwright, not vitest).
+        const { svg } = await mermaid.render(id, source);
+        if (cancelled) return;
+        setSvg(svg);
+      } catch {
+        if (!cancelled) setFailed(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [source, id]);
+
+  if (failed) {
+    // Graceful degrade: show the raw source as a code block (ADR-0013, surface-don't-mask).
+    return (
+      <pre data-testid="mermaid-error">
+        <code>{source}</code>
+      </pre>
+    );
+  }
+  if (svg == null) return <div className="mermaid-block" aria-busy="true" />;
+  // svg is already DOMPurify-sanitized internally by mermaid under `strict`
+  // (foreignObject-preserving config). Do NOT add an app-level default DOMPurify pass.
+  return (
+    <div
+      className="mermaid-block"
+      data-testid="mermaid-diagram"
+      dangerouslySetInnerHTML={{ __html: svg }}
+    />
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -756,3 +756,20 @@ body {
   padding: 0.25em 0.75em;
   color: var(--color-fg-3);
 }
+/* #240 — mermaid diagram inside an artifact. Clamp wide diagrams to the 560px
+   modal; scroll horizontally if they still overflow; center otherwise. */
+.artifact-markdown .mermaid-block {
+  margin: 0.75em 0;
+  max-width: 100%;
+  overflow-x: auto;
+  text-align: center;
+  background: var(--color-bg-0);
+  border: 1px solid var(--color-line);
+  border-radius: 5px;
+  padding: 10px;
+}
+.artifact-markdown .mermaid-block svg {
+  max-width: 100% !important; /* override mermaid's inline max-width attr */
+  height: auto;
+  display: inline-block;
+}


### PR DESCRIPTION
Closes #240.

Renders fenced \`\`\`mermaid blocks in artifact markdown as inline SVG diagrams, client-side.

## What

- New \`MermaidDiagram\` component renders mermaid sources to SVG via the \`mermaid\` lib (pinned \`^11.15.0\`), with \`securityLevel: 'strict'\` so hostile labels can't execute script.
- \`MarkdownArtifactModal\` overrides the \`pre\` renderer to detect \`language-mermaid\` fences and route them to \`MermaidDiagram\`; all other fences stay as normal code blocks.
- Invalid mermaid degrades gracefully to the raw source in a \`<pre><code>\` (no blank, no thrown error).
- Dark theme styling clamped to \`max-width:100%\`; mermaid + diagram chunks code-split out of the main bundle.
- ADR-0013 documents the client-side rendering decision; Layer-5 scenario + Playwright e2e spec added.

## Validation

- \`tsc -b\`, \`eslint .\`, \`vite build\` all clean.
- Full vitest suite **829 passed / 69 files**, incl. new \`MarkdownArtifactModal.mermaid.test.tsx\`.
- Tester verdict **PASS**: all four acceptance behaviours (valid render, invalid degrade, XSS blocked under strict mode, non-mermaid fences untouched) verified in a real Chrome browser against the real component.

Version bumped 0.1.25 → 0.1.26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)