### PR TITLE
feat(ui): group Runs & Triggers lists by project (target repo) (#258)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -426,6 +426,16 @@ Plusieurs Runs du même pipeline (ou de pipelines différents) peuvent tourner s
 
 ---
 
+## Repo cible (`target_repo`)
+
+Le **repo cible** d'un Run ou d'un Trigger est le dépôt git dans lequel il travaille (worktrees, artefacts, exécution du guard). Chemin absolu, stocké **verbatim** — jamais canonicalisé (`validate_target_repo`).
+
+- **Absent ⇒ `repo_root` du daemon.** Un Run/Trigger sans `target_repo` explicite s'exécute contre le dépôt racine du daemon. La résolution est **côté serveur** (`effective_repo_root`) : tout point de lecture qui a besoin d'un chemin concret (détail de Run, et désormais les listes Runs/Triggers) substitue `repo_root`. Conséquence : **pas de bucket « Unassigned »** — un Run sans cible et un Run ciblant explicitement le `repo_root` sont le *même* projet (≈ 46/101 runs de dev n'ont pas de `target_repo`).
+- **Clé de regroupement des listes (« par projet »).** Les listes Runs et Triggers se regroupent par repo cible résolu. Regroupement **conditionnel** : un en-tête par repo n'apparaît que si la liste contient **≥ 2 repos distincts** ; sinon (cas mono-repo courant) la liste reste **plate, identique à avant** — aucun en-tête, aucun badge ajouté. Seuil calculé **par liste** (l'onglet Runs et l'onglet Triggers sont indépendants) et sur **toutes** les lignes affichées, archivées comprises. Clé = chemin complet (deux repos de même basename ⇒ deux groupes distincts) ; libellé = basename, chemin complet au survol, **suffixe discriminant minimal** en cas de collision de basename (`/a/foo` + `/b/foo` ⇒ « a/foo » + « b/foo »). Tri des groupes : alphabétique par chemin complet (déterministe) ; ordre intra-groupe = ordre serveur préservé (Runs `run_id DESC`, Triggers `created_at DESC`).
+- **`effective_repo` (résolu) ≠ `target_repo` (brut).** Le champ brut `target_repo` (nullable) reste la valeur saisie par l'utilisateur — il pilote le badge repo de la ligne Trigger, le panneau détail, le pré-remplissage Run-now. Le champ résolu `effective_repo` (toujours concret, exposé par les *endpoints de liste* uniquement) ne sert qu'à la clé de regroupement. **On ne réécrit jamais `target_repo` côté serveur** : sinon badge/détail/pré-remplissage afficheraient un repo jamais saisi en mono-repo (régression). Le regroupement vit **côté client** (UI réversible) ; le serveur se contente de résoudre la clé.
+
+---
+
 ## Trigger
 
 Un **Trigger** est une liaison nommée et persistée entre une **condition de déclenchement** et un **template de Run**. Quand la condition se réalise, PDO crée un Pipeline Run *ordinaire* à partir du template.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1688,7 +1688,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "0.1.27"
+version = "0.1.28"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "0.1.27"
+version = "0.1.28"
 license = "MIT"
 
 [workspace.dependencies]

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -223,6 +223,22 @@ struct RunListEntry {
     /// Provenance: the Trigger that created this Run, if any.
     #[serde(skip_serializing_if = "Option::is_none")]
     triggered_by: Option<String>,
+    /// Resolved target repo for "group by project" (#258): the run's `target_repo`,
+    /// or the daemon's `repo_root` when unset (`effective_repo_root`). Always
+    /// concrete and always emitted; the client groups the Runs list by this key.
+    effective_repo: String,
+}
+
+/// A Trigger as returned by `GET /triggers`, wrapping the raw stored Trigger with
+/// a resolved `effective_repo` for the "group by project" view (#258). The raw
+/// `trigger.target_repo` stays untouched (it drives the row badge, the detail
+/// panel, and the Run-now pre-fill); `effective_repo` resolves a null target to
+/// the daemon's `repo_root` purely so the client can group by a concrete path.
+#[derive(Serialize)]
+struct TriggerListEntry {
+    #[serde(flatten)]
+    trigger: trigger_store::Trigger,
+    effective_repo: String,
 }
 
 #[derive(Serialize)]
@@ -953,7 +969,25 @@ async fn create_trigger(
 
 async fn list_triggers(State(state): State<Arc<AppState>>) -> Response {
     match trigger_store::list(&state.db).await {
-        Ok(triggers) => Json(triggers).into_response(),
+        Ok(triggers) => {
+            // Resolve each Trigger's repo for the "group by project" view (#258):
+            // a null `target_repo` resolves to the daemon's own repo_root. The raw
+            // `target_repo` is left untouched so the badge / detail / Run-now
+            // pre-fill keep showing only what the user actually set.
+            let repo_root = state.repo_root.to_string_lossy().into_owned();
+            let entries: Vec<TriggerListEntry> = triggers
+                .into_iter()
+                .map(|t| {
+                    let effective_repo =
+                        t.target_repo.clone().unwrap_or_else(|| repo_root.clone());
+                    TriggerListEntry {
+                        trigger: t,
+                        effective_repo,
+                    }
+                })
+                .collect();
+            Json(entries).into_response()
+        }
         Err(e) => {
             error!("failed to list triggers: {e}");
             (
@@ -4104,6 +4138,11 @@ async fn list_runs(State(state): State<Arc<AppState>>) -> Response {
         };
         if let Some(run_state) = event_log::project(&events) {
             let stalled = event_log::is_stalled(&run_state);
+            // Compute the resolved repo before moving `run_state`'s fields into
+            // the struct literal — `effective_repo_root` borrows `&run_state`.
+            let effective_repo = effective_repo_root(&state, &run_state)
+                .to_string_lossy()
+                .into_owned();
             runs.push(RunListEntry {
                 run_id: run_state.run_id,
                 pipeline_name: run_state.pipeline_name,
@@ -4112,6 +4151,7 @@ async fn list_runs(State(state): State<Arc<AppState>>) -> Response {
                 started_at: run_state.started_at,
                 name: run_state.name,
                 triggered_by: run_state.triggered_by,
+                effective_repo,
             });
         }
     }

--- a/crates/pdo-daemon/tests/runs_list_target_repo.rs
+++ b/crates/pdo-daemon/tests/runs_list_target_repo.rs
@@ -1,0 +1,240 @@
+//! Layer 3a — proves issue #258: the `/runs` and `/triggers` list endpoints emit
+//! a resolved `effective_repo` for the "group by project" view, while never
+//! mutating the raw `target_repo`. Validates:
+//! - `GET /runs` rows all carry a non-empty `effective_repo`; a run with no
+//!   `target_repo` resolves to the daemon's own repo_root (no "Unassigned").
+//! - `GET /triggers` rows carry a resolved `effective_repo`; the raw
+//!   `target_repo` of a null-target trigger stays null (no server-side rewrite).
+//! - The flattened Trigger fields (`name`, `cron`, …) stay top-level under the
+//!   `effective_repo` wrapper.
+
+mod common;
+
+use std::process::Command;
+
+use common::TestDaemon;
+
+const PIPELINE_NAME: &str = "by-repo-test";
+// `prompt_required: false` so a cron-only trigger with no input template is
+// accepted at creation (the create handler rejects an empty resolvable input on
+// a prompt-required pipeline).
+const PIPELINE_YAML: &str = r#"name: by-repo-test
+version: "1.0"
+prompt_required: false
+nodes:
+  - id: start
+    name: Start
+    type: start
+    outputs:
+      - name: user_prompt
+  - id: worker
+    name: worker
+    type: doc-only
+    inputs:
+      - name: task
+    outputs:
+      - name: result
+    view: { x: 100, y: 100 }
+  - id: end
+    name: End
+    type: end
+    inputs:
+      - name: result
+edges:
+  - source: { node: start, port: user_prompt }
+    target: { node: worker, port: task }
+"#;
+
+fn git_init_with_commit(repo: &std::path::Path) -> anyhow::Result<()> {
+    let run = |args: &[&str]| -> anyhow::Result<()> {
+        let out = Command::new("git").args(args).current_dir(repo).output()?;
+        if !out.status.success() {
+            anyhow::bail!(
+                "git {} failed: {}",
+                args.join(" "),
+                String::from_utf8_lossy(&out.stderr)
+            );
+        }
+        Ok(())
+    };
+    run(&["init", "-b", "main"])?;
+    run(&["config", "user.email", "test@test.com"])?;
+    run(&["config", "user.name", "Test"])?;
+    std::fs::write(repo.join("README.md"), "test")?;
+    run(&["add", "."])?;
+    run(&["commit", "-m", "init"])?;
+    Ok(())
+}
+
+fn seed_daemon_repo(repo: &std::path::Path) -> anyhow::Result<()> {
+    let pipelines_dir = repo.join(".pdo").join("pipelines");
+    std::fs::create_dir_all(&pipelines_dir)?;
+    std::fs::write(
+        pipelines_dir.join(format!("{PIPELINE_NAME}.yaml")),
+        PIPELINE_YAML,
+    )?;
+    let prompts_dir = pipelines_dir.join(format!("{PIPELINE_NAME}.prompts"));
+    std::fs::create_dir_all(&prompts_dir)?;
+    std::fs::write(prompts_dir.join("worker.md"), "You are a worker.")?;
+    git_init_with_commit(repo)?;
+    Ok(())
+}
+
+async fn create_run(daemon: &TestDaemon, body: serde_json::Value) -> String {
+    let resp = reqwest::Client::new()
+        .post(format!("{}/runs", daemon.url()))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 201, "POST /runs should succeed: {body:?}");
+    let json: serde_json::Value = resp.json().await.unwrap();
+    json["run_id"].as_str().unwrap().to_string()
+}
+
+async fn create_trigger(daemon: &TestDaemon, body: serde_json::Value) -> String {
+    let resp = reqwest::Client::new()
+        .post(format!("{}/triggers", daemon.url()))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        201,
+        "POST /triggers should succeed: {body:?}"
+    );
+    let json: serde_json::Value = resp.json().await.unwrap();
+    json["id"].as_str().unwrap().to_string()
+}
+
+#[tokio::test]
+async fn runs_list_carries_resolved_effective_repo() {
+    let daemon = TestDaemon::spawn(seed_daemon_repo).await.unwrap();
+
+    // Two distinct explicit target repos + one run with no target_repo.
+    let repo_a = tempfile::tempdir().unwrap();
+    git_init_with_commit(repo_a.path()).unwrap();
+    let repo_b = tempfile::tempdir().unwrap();
+    git_init_with_commit(repo_b.path()).unwrap();
+    let path_a = repo_a.path().to_str().unwrap().to_string();
+    let path_b = repo_b.path().to_str().unwrap().to_string();
+
+    create_run(
+        &daemon,
+        serde_json::json!({ "pipeline": PIPELINE_NAME, "input": "x", "target_repo": path_a }),
+    )
+    .await;
+    create_run(
+        &daemon,
+        serde_json::json!({ "pipeline": PIPELINE_NAME, "input": "x", "target_repo": path_b }),
+    )
+    .await;
+    // No target_repo → must resolve to the daemon's repo_root.
+    create_run(
+        &daemon,
+        serde_json::json!({ "pipeline": PIPELINE_NAME, "input": "x" }),
+    )
+    .await;
+
+    let rows: Vec<serde_json::Value> = reqwest::get(format!("{}/runs", daemon.url()))
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 3, "three runs created");
+
+    // Every row carries a non-empty effective_repo (always concrete).
+    for row in &rows {
+        let er = row["effective_repo"].as_str();
+        assert!(
+            er.is_some() && !er.unwrap().is_empty(),
+            "every run row must carry a non-empty effective_repo: {row:?}"
+        );
+        // No "Unassigned"/null bucket.
+        assert!(!row["effective_repo"].is_null());
+    }
+
+    let repo_root = daemon.repo_root().to_str().unwrap();
+    let effectives: Vec<&str> = rows
+        .iter()
+        .map(|r| r["effective_repo"].as_str().unwrap())
+        .collect();
+    assert!(effectives.contains(&path_a.as_str()));
+    assert!(effectives.contains(&path_b.as_str()));
+    // The null-target run resolved to the daemon's repo_root, not a separate bucket.
+    assert!(
+        effectives.contains(&repo_root),
+        "a run with no target_repo must resolve effective_repo to the daemon repo_root \
+         ({repo_root}); got {effectives:?}"
+    );
+}
+
+#[tokio::test]
+async fn triggers_list_resolves_effective_repo_without_mutating_raw_target() {
+    let daemon = TestDaemon::spawn(seed_daemon_repo).await.unwrap();
+
+    let repo_a = tempfile::tempdir().unwrap();
+    git_init_with_commit(repo_a.path()).unwrap();
+    let path_a = repo_a.path().to_str().unwrap().to_string();
+
+    // One trigger with an explicit target, one with none.
+    create_trigger(
+        &daemon,
+        serde_json::json!({
+            "name": "t-a1",
+            "pipeline_id": PIPELINE_NAME,
+            "cron": "0 0 1 1 *",
+            "target_repo": path_a,
+        }),
+    )
+    .await;
+    create_trigger(
+        &daemon,
+        serde_json::json!({
+            "name": "t-null",
+            "pipeline_id": PIPELINE_NAME,
+            "cron": "0 0 1 1 *",
+        }),
+    )
+    .await;
+
+    let rows: Vec<serde_json::Value> = reqwest::get(format!("{}/triggers", daemon.url()))
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 2);
+
+    let repo_root = daemon.repo_root().to_str().unwrap();
+    let by_name = |name: &str| rows.iter().find(|r| r["name"] == name).unwrap();
+
+    let t_a1 = by_name("t-a1");
+    assert_eq!(t_a1["target_repo"], serde_json::json!(path_a));
+    assert_eq!(t_a1["effective_repo"], serde_json::json!(path_a));
+
+    let t_null = by_name("t-null");
+    // Core no-regression guarantee: raw target_repo stays null (skip-serialized
+    // ⇒ absent), but effective_repo resolved to the daemon repo_root.
+    assert!(
+        t_null["target_repo"].is_null(),
+        "raw target_repo must NOT be rewritten server-side: {t_null:?}"
+    );
+    assert_eq!(t_null["effective_repo"], serde_json::json!(repo_root));
+
+    // The #[serde(flatten)] wrapper keeps every Trigger field top-level (the
+    // frontend reads name/cron/enabled/pipeline_name flat, not nested).
+    for r in &rows {
+        assert!(r["name"].is_string(), "name must stay top-level: {r:?}");
+        assert!(r["cron"].is_string(), "cron must stay top-level: {r:?}");
+        assert!(r["enabled"].is_boolean(), "enabled must stay top-level: {r:?}");
+        assert!(
+            r["pipeline_name"].is_string(),
+            "pipeline_name must stay top-level: {r:?}"
+        );
+        // The trigger must not be nested under a `trigger` key.
+        assert!(r.get("trigger").is_none(), "wrapper must flatten: {r:?}");
+    }
+}

--- a/docs/testing/scenarios/runs-triggers-by-repo.md
+++ b/docs/testing/scenarios/runs-triggers-by-repo.md
@@ -1,0 +1,188 @@
+# Scenario — `runs-triggers-by-repo`
+
+> Layer 5 (agentic) per ADR 0004. Manual trigger: an agent executes the steps
+> below by driving the **real UI in a browser** (Chrome DevTools MCP preferred;
+> Playwright MCP fallback) plus `curl`/`jq` against the daemon, exactly as a
+> human would, and emits the verdict JSON at the bottom. Asserts #258: the Runs
+> and Triggers lists **group by project (target repo)** — conditionally (only
+> when ≥ 2 distinct repos are present), with null `target_repo` resolved to the
+> daemon's `repo_root` (no "Unassigned" bucket), and the single-repo common case
+> left byte-identical to today.
+
+The behavior under test is a **display/grouping** concern. The cheap, deterministic
+vehicle is **Triggers** (creating a Trigger persists a row, it does not spawn a Run —
+create them **disabled** so they never fire during the test). Runs are validated at the
+API level always, and in the UI when the daemon already holds runs across ≥ 2 repos.
+
+## Setup
+
+- Daemon running and built **from the source tree under test** (`pdo daemon`, or
+  `cargo run -p pdo-daemon`). Do **not** restart or stop a daemon you did not start.
+- Discover the daemon URL: honor `$PDO_PORT`; otherwise probe known ports
+  (dev `6172`, prod `6160`, legacy `5172`) — pick the one whose `GET /sessions`
+  returns 200:
+  ```bash
+  for p in "${PDO_PORT:-}" 6172 6160 5172; do [ -n "$p" ] && \
+    curl -sf "http://127.0.0.1:$p/sessions" >/dev/null 2>&1 && { PORT=$p; break; }; done
+  echo "daemon on $PORT"
+  ```
+  (or `ss -ltnp | grep -i pdo` to find the listening port). Export `BASE=http://127.0.0.1:$PORT`.
+- Frontend reachable in a browser at `$BASE` (or the vite dev server proxying to it).
+  Chrome DevTools MCP preferred; Playwright MCP fallback.
+- `curl`, `jq`, `git`, `mktemp` on PATH.
+- Record the daemon's own repo root (the null-resolution target). It is the repo the
+  daemon was launched from. Capture it for later equality checks:
+  - Read it from any run that has **no** `target_repo`: see Step 1; or from the
+    daemon's launch cwd if known. Store as `REPO_ROOT`.
+- Pick an existing pipeline id to attach triggers to:
+  `PIPE=$(curl -sf "$BASE/pipelines" | jq -r '.[0].id')` (any valid id is fine; the
+  triggers stay disabled and never run it).
+- Create three throwaway git repos for seeding, plus a basename-collision pair:
+  ```bash
+  mk(){ d=$(mktemp -d "/tmp/pdo258-$1.XXXX"); git -C "$d" init -q; \
+        git -C "$d" -c user.email=a@b.c -c user.name=t commit -q --allow-empty -m init; echo "$d"; }
+  REPO_A=$(mk alpha)        # e.g. /tmp/pdo258-alpha.AB12
+  REPO_B=$(mk beta)         # e.g. /tmp/pdo258-beta.CD34
+  COL1=$(mktemp -d /tmp/pdo258-x.XXXX)/svc; COL2=$(mktemp -d /tmp/pdo258-y.XXXX)/svc
+  for c in "$COL1" "$COL2"; do mkdir -p "$c"; git -C "$c" init -q; \
+        git -C "$c" -c user.email=a@b.c -c user.name=t commit -q --allow-empty -m init; done
+  # COL1 and COL2 share basename "svc" but differ by parent → collision case.
+  ```
+
+## Steps the agent executes
+
+### Step 0 — Baseline: confirm the single-repo flat case is untouched (regression)
+1. Before seeding anything, open the UI, select the **Triggers** tab, and the **Runs**
+   tab. Take a screenshot of each.
+2. Via DOM, assert how many `data-testid="trigger-repo-group"` and
+   `data-testid="run-repo-group"` elements exist. Record both counts as the baseline.
+3. If the daemon currently holds triggers/runs spanning only **one** distinct repo,
+   assert **zero** `*-repo-group` headers are present (the list is flat — today's
+   behavior). If it already spans ≥ 2, record that the grouped state pre-exists and
+   note it (the Step-3/Step-4 assertions still apply).
+
+### Step 1 — API: `/runs` carries a resolved `effective_repo` (no Unassigned)
+1. `curl -sf "$BASE/runs" | jq '.[0]'`. Assert 200 and a JSON array.
+2. Assert **every** row has a non-empty string `effective_repo`
+   (`curl -sf "$BASE/runs" | jq -e 'all(.[]; .effective_repo | type=="string" and length>0)'`).
+3. Find a run with **no** raw target repo and confirm it still resolved:
+   pick any row, and assert that rows which do not target an explicit repo carry
+   `effective_repo == REPO_ROOT` (the daemon's own repo). If `REPO_ROOT` wasn't known
+   from Setup, derive it here as the most common `effective_repo` among rows and record
+   the assumption as an anomaly note.
+4. Assert there is **no** literal "Unassigned"/"unknown"/null bucket: no row has
+   `effective_repo` equal to `null`, `""`, `"Unassigned"`, or `"(none)"`.
+
+### Step 2 — Seed triggers across repos (disabled, so nothing fires)
+Create five disabled triggers via `POST $BASE/triggers` (Content-Type application/json),
+each `{"name": "...", "pipeline_id": "'$PIPE'", "cron": "0 0 1 1 *", "enabled": false,
+"target_repo": <as below>}`:
+- `t-a1`, `t-a2` → `target_repo = REPO_A`  (two triggers, same repo)
+- `t-b1`         → `target_repo = REPO_B`
+- `t-null`       → **omit** `target_repo` entirely (null → must resolve to `REPO_ROOT`)
+- (collision pair, used in Step 5) `t-c1` → `COL1`, `t-c2` → `COL2`
+Assert each POST returns 201. Record the created trigger ids for cleanup.
+
+### Step 3 — API: `/triggers` resolves null but never mutates raw `target_repo`
+1. `curl -sf "$BASE/triggers" | jq '.'`.
+2. For the `t-null` trigger: assert its raw **`target_repo` is null/absent** AND its
+   **`effective_repo == REPO_ROOT`** (null was resolved for grouping only, the raw field
+   was not rewritten — this is the core no-regression guarantee).
+3. For `t-a1`: assert `target_repo == REPO_A` **and** `effective_repo == REPO_A`.
+4. Assert the response rows still expose all the flat Trigger fields (`name`, `cron`,
+   `enabled`, `pipeline_name`) at top level (the `effective_repo` wrapper must not
+   nest the trigger).
+
+### Step 4 — UI: Triggers list is now grouped by repo
+1. In the browser, open the **Triggers** tab. Take a screenshot.
+2. Assert `data-testid="trigger-repo-group"` headers are now present and number **≥ 3**
+   (at minimum: `REPO_A`, `REPO_B`, `REPO_ROOT` — plus the two collision repos from
+   Step 2). The baseline from Step 0 must have increased.
+3. Read every `data-testid="trigger-repo-label"`. Assert:
+   - the `REPO_A` group's label equals the basename of `REPO_A` (e.g. `alpha.AB12`);
+   - the `t-null` trigger appears under the group whose `title` (hover/full-path
+     attribute) equals `REPO_ROOT` — i.e. it grouped with the daemon's own repo, **not**
+     a separate "Unassigned" group;
+   - the `t-a1` and `t-a2` rows sit under the **same** single `REPO_A` group (two
+     triggers, one header), in `created_at DESC` order (most-recent first).
+4. Hover the `REPO_A` header (or read its `title` attribute) and assert the **full path**
+   `REPO_A` is shown on hover while the visible label is the basename.
+5. Confirm the per-row **repo badge** behavior is unchanged: the `t-null` row shows **no**
+   repo badge (its raw `target_repo` is null), while `t-a1` shows a badge with the
+   `REPO_A` basename. (Regression guard for G1/G7.)
+
+### Step 5 — UI: basename collision renders two disambiguated groups
+1. Still on the Triggers tab, locate the two collision groups for `COL1` and `COL2`
+   (both basename `svc`).
+2. Assert they render as **two distinct** `trigger-repo-group` headers (not merged).
+3. Assert their `trigger-repo-label` texts are **disambiguated** (not both bare `svc`) —
+   they should show the minimal distinguishing trailing-path suffix (e.g. the differing
+   parent segment + `/svc`). Each header's `title` still carries the full path.
+
+### Step 6 — Runs UI grouping (conditional)
+1. If `GET /runs` (Step 1) shows **≥ 2 distinct** `effective_repo` values, open the
+   **Runs** tab, screenshot, and assert ≥ 2 `data-testid="run-repo-group"` headers
+   render, each with a `run-repo-label` (basename) and a `title` (full path), and that
+   runs sharing a repo sit under one header in most-recent-first order. Assert run rows
+   carry **no** per-row repo badge (header is the only repo surface — G2).
+2. If `/runs` shows only **one** distinct repo, assert the Runs tab renders **zero**
+   `run-repo-group` headers (flat — confirms the conditional rule and the no-regression
+   guarantee), and record that runs-UI grouping was exercised only at the API level
+   (Step 1) for this environment. Optionally, if you can safely seed runs (a
+   self-sufficient/`doc-only` pipeline exists and you will clean them up), create one run
+   targeting `REPO_A` and one targeting `REPO_B`, re-open the Runs tab, and assert the
+   two headers appear — then clean those runs up in Cleanup.
+
+### Step 7 — Per-list independence
+1. Compare the Runs tab and Triggers tab grouped states. Assert the "≥ 2 repos"
+   threshold is evaluated **per list**: e.g. with the seeded triggers spanning many repos
+   but runs spanning one, the **Triggers** tab is grouped while the **Runs** tab is flat
+   (or vice versa). The two tabs must not share a single threshold.
+
+## Negative checks
+- `grep -rn "Unassigned" frontend/src/` returns no matches related to repo grouping
+  (the design has no such bucket).
+- The daemon never mutates raw `target_repo`: re-run Step 3.2 — `t-null.target_repo`
+  stays null across repeated `GET /triggers`.
+- Single-repo regression: if you can momentarily view a single-repo list (Step 0 or
+  Step 6.2), confirm it is pixel-equivalent to before — no header row inserted, no new
+  badge on trigger rows whose `target_repo` is null.
+- `frontend/vite.config.ts` proxy whitelist is unchanged — `/runs` and `/triggers`
+  were already proxied; no new top-level route was added.
+
+## Cleanup
+- Delete every trigger created in Step 2: `DELETE $BASE/triggers/<id>` for each recorded
+  id (assert 204). Confirm `GET /triggers` no longer lists them.
+- If you seeded runs in Step 6, clean them up (cleanup/forget via the UI trash action or
+  the run cleanup endpoint) and confirm they leave the list.
+- Remove the temp repos: `rm -rf` the `/tmp/pdo258-*` dirs you created.
+- Close any browser pages you opened. Do not stop a daemon you did not start.
+
+## Verdict format
+
+```json
+{
+  "verdict": "PASS" | "FAIL",
+  "evidence": [
+    "step 0: baseline group-header counts recorded (runs=<n>, triggers=<n>)",
+    "step 1: /runs rows all carry non-empty effective_repo; null-target runs resolve to REPO_ROOT; no Unassigned",
+    "step 3: t-null has target_repo=null but effective_repo=REPO_ROOT; t-a1 target_repo==effective_repo==REPO_A; flat fields intact",
+    "step 4: Triggers tab shows >=3 repo-group headers; t-a1+t-a2 under one REPO_A group; t-null under REPO_ROOT group; label=basename, full path on hover; t-null shows no badge",
+    "step 5: COL1/COL2 render as two distinct groups with disambiguated labels (not both 'svc')",
+    "step 6: runs grouped in UI when >=2 repos, else flat with zero headers (conditional rule)",
+    "step 7: threshold evaluated per-list (triggers grouped while runs flat, or vice versa)",
+    "negative: raw target_repo never mutated; no Unassigned bucket; vite proxy unchanged"
+  ],
+  "screenshots": [
+    "<path/ref to Triggers-tab grouped screenshot>",
+    "<path/ref to Runs-tab screenshot>"
+  ],
+  "anomalies": [
+    "<optional — e.g. daemon not built from this tree; REPO_ROOT inferred rather than known; runs-UI validated at API level only>"
+  ]
+}
+```
+
+A single failed assertion ⇒ `verdict: "FAIL"`. Don't half-pass. If the feature is not
+yet implemented, the API fields (`effective_repo`) and the `*-repo-group` test ids will
+be absent — report `FAIL` with the missing pieces listed in `evidence`.

--- a/frontend/e2e/runs-triggers-by-repo.spec.ts
+++ b/frontend/e2e/runs-triggers-by-repo.spec.ts
@@ -1,0 +1,184 @@
+import { test, expect } from "@playwright/test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+// Layer 4 (e2e) per ADR 0004 — proves #258 end-to-end in a browser: the Runs and
+// Triggers lists group by project (target repo), conditionally (only when ≥ 2
+// distinct repos are present), with a null `target_repo` resolved to the daemon's
+// own repo_root (no "Unassigned" bucket) and the raw `target_repo` left untouched.
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const WORKSPACE_ROOT = path.resolve(__dirname, "..", "..");
+const PIPELINE_NAME = `e2e-by-repo-${process.pid}-${Date.now()}`;
+const PIPELINE_DIR = path.join(WORKSPACE_ROOT, ".pdo", "pipelines");
+const PIPELINE_PATH = path.join(PIPELINE_DIR, `${PIPELINE_NAME}.yaml`);
+const PROMPTS_DIR = path.join(PIPELINE_DIR, `${PIPELINE_NAME}.prompts`);
+
+// `prompt_required: false` so a cron-only trigger with no input template / guard
+// is accepted at creation.
+const SEED_YAML = `name: ${PIPELINE_NAME}
+version: "1.0"
+prompt_required: false
+nodes:
+  - id: start
+    name: Start
+    type: start
+    outputs:
+      - name: user_prompt
+    view: { x: 0, y: 100 }
+  - id: worker
+    name: Worker
+    type: doc-only
+    prompt_file: ${PIPELINE_NAME}.prompts/worker.md
+    inputs:
+      - name: task
+    outputs:
+      - name: result
+    view: { x: 200, y: 100 }
+  - id: end
+    name: End
+    type: end
+    inputs:
+      - name: result
+    view: { x: 400, y: 100 }
+edges:
+  - source: { node: start, port: user_prompt }
+    target: { node: worker, port: task }
+`;
+
+let repoA = "";
+let repoB = "";
+
+function gitInit(dir: string) {
+  execFileSync("git", ["init", "-b", "main"], { cwd: dir });
+  execFileSync("git", ["config", "user.email", "t@t.c"], { cwd: dir });
+  execFileSync("git", ["config", "user.name", "t"], { cwd: dir });
+  execFileSync("git", ["commit", "--allow-empty", "-m", "init"], { cwd: dir });
+}
+
+test.beforeAll(async () => {
+  await fs.mkdir(PROMPTS_DIR, { recursive: true });
+  await fs.writeFile(PIPELINE_PATH, SEED_YAML);
+  await fs.writeFile(path.join(PROMPTS_DIR, "worker.md"), "You are a worker.\n");
+  repoA = await fs.mkdtemp(path.join(os.tmpdir(), "pdo258-alpha-"));
+  repoB = await fs.mkdtemp(path.join(os.tmpdir(), "pdo258-beta-"));
+  gitInit(repoA);
+  gitInit(repoB);
+});
+
+test.afterAll(async () => {
+  await fs.rm(PIPELINE_PATH, { force: true });
+  await fs.rm(PROMPTS_DIR, { recursive: true, force: true });
+  if (repoA) await fs.rm(repoA, { recursive: true, force: true });
+  if (repoB) await fs.rm(repoB, { recursive: true, force: true });
+});
+
+// Wipe all triggers before each test so the daemon state is deterministic
+// regardless of `reuseExistingServer` or a prior local run. Safe: the e2e daemon
+// runs on its own dedicated port.
+test.beforeEach(async ({ page, baseURL }) => {
+  const resp = await page.request.get(`${baseURL}/triggers`);
+  const triggers = (await resp.json()) as Array<{ id: string }>;
+  for (const t of triggers) {
+    await page.request.delete(`${baseURL}/triggers/${t.id}`);
+  }
+});
+
+async function createTrigger(
+  page: import("@playwright/test").Page,
+  baseURL: string,
+  name: string,
+  targetRepo: string | null,
+) {
+  const data: Record<string, unknown> = {
+    name,
+    pipeline_id: PIPELINE_NAME,
+    cron: "0 0 1 1 *",
+  };
+  if (targetRepo) data.target_repo = targetRepo;
+  const resp = await page.request.post(`${baseURL}/triggers`, { data });
+  expect(resp.status(), `POST /triggers ${name}`).toBe(201);
+}
+
+async function openTriggersTab(page: import("@playwright/test").Page) {
+  await page.goto("/");
+  await expect(page.getByText("Daemon: connected")).toBeVisible({ timeout: 10_000 });
+  await page.getByRole("tab", { name: "Triggers" }).click();
+}
+
+test("Triggers list stays flat (no group header) when all triggers share one repo", async ({
+  page,
+  baseURL,
+}) => {
+  await createTrigger(page, baseURL!, "flat-1", repoA);
+  await createTrigger(page, baseURL!, "flat-2", repoA);
+
+  await openTriggersTab(page);
+
+  await expect(page.getByText("flat-1")).toBeVisible();
+  await expect(page.getByText("flat-2")).toBeVisible();
+  // Conditional rule: a single distinct repo ⇒ no group header (flat, as before).
+  await expect(page.getByTestId("trigger-repo-group")).toHaveCount(0);
+});
+
+test("Triggers list groups by repo across ≥2 repos; null target resolves to the daemon repo, no Unassigned", async ({
+  page,
+  baseURL,
+}) => {
+  await createTrigger(page, baseURL!, "g-a", repoA);
+  await createTrigger(page, baseURL!, "g-b", repoB);
+  await createTrigger(page, baseURL!, "g-null", null); // resolves to WORKSPACE_ROOT
+
+  await openTriggersTab(page);
+  await expect(page.getByText("g-a")).toBeVisible();
+
+  // Three distinct repos ⇒ three group headers.
+  await expect(page.getByTestId("trigger-repo-group")).toHaveCount(3);
+
+  const labels = await page.getByTestId("trigger-repo-label").allTextContents();
+  expect(labels).toContain(path.basename(repoA));
+  expect(labels).toContain(path.basename(repoB));
+  // The null-target trigger grouped under the daemon's own repo (basename), not
+  // a separate "Unassigned" bucket.
+  expect(labels).toContain(path.basename(WORKSPACE_ROOT));
+  expect(labels.join(" ")).not.toMatch(/unassigned/i);
+
+  // Group labels are sorted alphabetically by full path.
+  expect([...labels]).toEqual([...labels].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0)));
+
+  // Full path on hover: the repoA group header carries title=repoA.
+  const repoALabel = page
+    .getByTestId("trigger-repo-label")
+    .filter({ hasText: path.basename(repoA) });
+  await expect(repoALabel.locator("xpath=..")).toHaveAttribute("title", repoA);
+
+  // Raw target_repo unchanged: g-null shows NO badge; g-a shows a badge titled repoA.
+  const nullRow = page.getByTestId("trigger-row").filter({ hasText: "g-null" });
+  await expect(nullRow.locator(`[title="${WORKSPACE_ROOT}"]`)).toHaveCount(0);
+  const aRow = page.getByTestId("trigger-row").filter({ hasText: "g-a" });
+  await expect(aRow.locator(`[title="${repoA}"]`)).toHaveCount(1);
+});
+
+test("Runs list groups by repo when runs span ≥2 repos", async ({ page, baseURL }) => {
+  // Seed one run in each of two distinct repos (worker session is the e2e sleep stub).
+  for (const repo of [repoA, repoB]) {
+    const resp = await page.request.post(`${baseURL}/runs`, {
+      data: { pipeline: PIPELINE_NAME, input: "seed", target_repo: repo },
+    });
+    expect(resp.status()).toBe(201);
+  }
+
+  await page.goto("/");
+  await expect(page.getByText("Daemon: connected")).toBeVisible({ timeout: 10_000 });
+  // Runs is the default tab.
+  const labels = await page.getByTestId("run-repo-label").allTextContents();
+  expect(await page.getByTestId("run-repo-group").count()).toBeGreaterThanOrEqual(2);
+  expect(labels).toContain(path.basename(repoA));
+  expect(labels).toContain(path.basename(repoB));
+  // Run rows carry no per-row repo badge — the header is the only repo surface (G2).
+  // (The trigger-provenance badge is unrelated and absent for these manual runs.)
+  await expect(page.getByTestId("run-trigger-badge")).toHaveCount(0);
+});

--- a/frontend/src/components/TriggersListPanel.test.tsx
+++ b/frontend/src/components/TriggersListPanel.test.tsx
@@ -130,3 +130,59 @@ describe("TriggersListPanel", () => {
     expect(dot).toHaveAttribute("title", expect.stringContaining("fired"));
   });
 });
+
+// #258 — the Triggers list groups by project (target repo), conditionally: only
+// when ≥ 2 distinct repos are present. The single-repo case stays flat.
+describe("TriggersListPanel grouping by repo (#258)", () => {
+  it("stays flat (no repo-group header) when all triggers share one repo", () => {
+    renderPanel([
+      trigger({ id: "t1", name: "A", target_repo: "/repos/foo", effective_repo: "/repos/foo" }),
+      trigger({ id: "t2", name: "B", target_repo: "/repos/foo", effective_repo: "/repos/foo" }),
+    ]);
+    expect(screen.queryByTestId("trigger-repo-group")).not.toBeInTheDocument();
+    expect(screen.getByText("A")).toBeInTheDocument();
+    expect(screen.getByText("B")).toBeInTheDocument();
+  });
+
+  it("renders one repo-group header per distinct repo, alphabetical, when ≥ 2 repos", () => {
+    renderPanel([
+      trigger({ id: "t1", name: "A", target_repo: "/repos/zebra", effective_repo: "/repos/zebra" }),
+      trigger({ id: "t2", name: "B", target_repo: "/repos/alpha", effective_repo: "/repos/alpha" }),
+      trigger({ id: "t3", name: "C", target_repo: "/repos/zebra", effective_repo: "/repos/zebra" }),
+    ]);
+    expect(screen.getAllByTestId("trigger-repo-group")).toHaveLength(2);
+    const labels = screen
+      .getAllByTestId("trigger-repo-label")
+      .map((el) => el.textContent);
+    expect(labels).toEqual(["alpha", "zebra"]);
+  });
+
+  it("groups a null-target trigger under its resolved repo, with no per-row badge", () => {
+    renderPanel([
+      trigger({ id: "t1", name: "A", target_repo: "/repos/alpha", effective_repo: "/repos/alpha" }),
+      trigger({ id: "tn", name: "N", target_repo: null, effective_repo: "/repos/root" }),
+    ]);
+    const labels = screen
+      .getAllByTestId("trigger-repo-label")
+      .map((el) => el.textContent);
+    expect(labels).toEqual(["alpha", "root"]); // resolved repo, not a catch-all bucket
+
+    // The null-target row carries no repo badge (raw target_repo untouched);
+    // the badged row shows the full path on its badge's title.
+    const nRow = screen.getByText("N").closest('[data-testid="trigger-row"]') as HTMLElement;
+    expect(within(nRow).queryByTitle("/repos/root")).not.toBeInTheDocument();
+    const aRow = screen.getByText("A").closest('[data-testid="trigger-row"]') as HTMLElement;
+    expect(within(aRow).getByTitle("/repos/alpha")).toBeInTheDocument();
+  });
+
+  it("disambiguates the per-row badge label on a basename collision", () => {
+    renderPanel([
+      trigger({ id: "c1", name: "C1", target_repo: "/x/svc", effective_repo: "/x/svc" }),
+      trigger({ id: "c2", name: "C2", target_repo: "/y/svc", effective_repo: "/y/svc" }),
+    ]);
+    const c1Row = screen.getByText("C1").closest('[data-testid="trigger-row"]') as HTMLElement;
+    // Badge shows the minimal disambiguating suffix, not bare "svc".
+    expect(within(c1Row).getByText("x/svc")).toBeInTheDocument();
+    expect(within(c1Row).queryByText("svc")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/TriggersListPanel.tsx
+++ b/frontend/src/components/TriggersListPanel.tsx
@@ -2,6 +2,7 @@ import { Pencil, Play, Plus, Power, Trash2, Zap } from "lucide-react";
 import type { Trigger } from "../types";
 import { deleteTrigger, updateTrigger } from "../api";
 import { humanizeCron } from "../cronPresets";
+import { groupByRepo, repoGroupLabel } from "../lib/groupByRepo";
 
 interface Props {
   triggers: Trigger[];
@@ -68,6 +69,126 @@ export default function TriggersListPanel({
     }
   }
 
+  // Raw target repos actually set on rows — drives the per-row badge label so a
+  // colliding basename is disambiguated identically in the badge and the group
+  // header (#258 G7). Computed once per render.
+  const allRepos = triggers
+    .map((t) => t.target_repo)
+    .filter((r): r is string => !!r);
+
+  // One trigger row, rendered identically flat or grouped by repo (#258).
+  function renderTriggerRow(t: Trigger) {
+    const isSelected = t.id === selectedTriggerId;
+    const dot = outcomeDot(t.last_outcome);
+    return (
+      <button
+        key={t.id}
+        onClick={() => onSelectTrigger(t.id)}
+        className={`group flex w-full cursor-pointer items-center gap-2 border-b border-line-soft px-3 py-2 text-left transition-colors ${
+          isSelected ? "bg-bg-3 text-fg" : "text-fg-2 hover:bg-bg-3/50"
+        } ${t.enabled ? "" : "opacity-60"}`}
+        style={{ fontSize: "11.5px" }}
+        data-testid="trigger-row"
+      >
+        <span
+          className={`h-2 w-2 shrink-0 rounded-full ${dot}`}
+          title={lastOutcomeTooltip(t)}
+          data-testid="trigger-status-dot"
+        />
+        <div className="min-w-0 flex-1">
+          <div className="truncate font-medium">{t.name}</div>
+          <div
+            className="mt-0.5 flex items-center gap-1.5 truncate text-fg-4"
+            style={{ fontSize: "10px" }}
+          >
+            <span className="truncate font-mono">{t.pipeline_name}</span>
+            {t.target_repo && (
+              <span
+                className="shrink-0 rounded border border-line-strong px-1 py-px"
+                style={{ fontSize: "9px" }}
+                title={t.target_repo}
+              >
+                {repoGroupLabel(t.target_repo, allRepos)}
+              </span>
+            )}
+            <span className="shrink-0" aria-hidden="true">·</span>
+            <span className="shrink-0" data-testid="trigger-schedule">
+              {humanizeCron(t.cron)}
+            </span>
+          </div>
+        </div>
+        {!t.enabled && (
+          <span
+            className="shrink-0 rounded border border-line-strong px-1 py-px text-fg-4"
+            style={{ fontSize: "9px" }}
+          >
+            disabled
+          </span>
+        )}
+        {/* Hover actions: run-now, edit, delete. */}
+        <span className="hidden shrink-0 items-center gap-0.5 group-hover:inline-flex">
+          <span
+            role="button"
+            title="Run now (test this trigger)"
+            className="cursor-pointer rounded p-0.5 text-fg-4 transition-colors hover:bg-bg-4 hover:text-acc"
+            onClick={(e) => {
+              e.stopPropagation();
+              onRunNow?.(t);
+            }}
+            data-testid="trigger-run-now"
+          >
+            <Play size={12} />
+          </span>
+          <span
+            role="button"
+            title="Edit trigger"
+            className="cursor-pointer rounded p-0.5 text-fg-4 transition-colors hover:bg-bg-4 hover:text-fg"
+            onClick={(e) => {
+              e.stopPropagation();
+              onEditTrigger?.(t);
+            }}
+            data-testid="trigger-edit"
+          >
+            <Pencil size={12} />
+          </span>
+          <span
+            role="button"
+            title="Delete trigger"
+            className="cursor-pointer rounded p-0.5 text-fg-4 transition-colors hover:bg-bg-4 hover:text-st-failed"
+            onClick={(e) => {
+              e.stopPropagation();
+              void handleDelete(t.id);
+            }}
+            data-testid="trigger-delete"
+          >
+            <Trash2 size={12} />
+          </span>
+        </span>
+        {/* Enable/disable toggle — always visible so paused state is reversible. */}
+        <span
+          role="switch"
+          aria-checked={t.enabled}
+          aria-label={t.enabled ? "Disable trigger" : "Enable trigger"}
+          title={t.enabled ? "Disable trigger" : "Enable trigger"}
+          className={`shrink-0 cursor-pointer rounded p-0.5 transition-colors hover:bg-bg-4 ${
+            t.enabled ? "text-acc" : "text-fg-4"
+          }`}
+          onClick={(e) => {
+            e.stopPropagation();
+            void handleToggle(t);
+          }}
+          data-testid="trigger-toggle"
+        >
+          <Power size={12} />
+        </span>
+      </button>
+    );
+  }
+
+  // Group the Triggers list by project (#258) only when ≥ 2 distinct repos are
+  // present; otherwise `null` ⇒ the flat list, byte-identical to before.
+  const triggerGroups = groupByRepo(triggers, (t) => t.effective_repo);
+
   return (
     <div className="flex h-full flex-col" data-testid="triggers-list-panel">
       <div
@@ -106,113 +227,22 @@ export default function TriggersListPanel({
         </div>
       ) : (
         <div className="flex-1 overflow-y-auto">
-          {triggers.map((t) => {
-            const isSelected = t.id === selectedTriggerId;
-            const dot = outcomeDot(t.last_outcome);
-            return (
-              <button
-                key={t.id}
-                onClick={() => onSelectTrigger(t.id)}
-                className={`group flex w-full cursor-pointer items-center gap-2 border-b border-line-soft px-3 py-2 text-left transition-colors ${
-                  isSelected ? "bg-bg-3 text-fg" : "text-fg-2 hover:bg-bg-3/50"
-                } ${t.enabled ? "" : "opacity-60"}`}
-                style={{ fontSize: "11.5px" }}
-                data-testid="trigger-row"
-              >
-                <span
-                  className={`h-2 w-2 shrink-0 rounded-full ${dot}`}
-                  title={lastOutcomeTooltip(t)}
-                  data-testid="trigger-status-dot"
-                />
-                <div className="min-w-0 flex-1">
-                  <div className="truncate font-medium">{t.name}</div>
+          {triggerGroups === null
+            ? triggers.map(renderTriggerRow)
+            : triggerGroups.map((group) => (
+                <div key={group.repoPath} data-testid="trigger-repo-group">
                   <div
-                    className="mt-0.5 flex items-center gap-1.5 truncate text-fg-4"
+                    className="flex h-[22px] shrink-0 items-center border-b border-line-soft bg-bg-3/40 px-3 font-medium text-fg-3"
                     style={{ fontSize: "10px" }}
+                    title={group.repoPath}
                   >
-                    <span className="truncate font-mono">{t.pipeline_name}</span>
-                    {t.target_repo && (
-                      <span
-                        className="shrink-0 rounded border border-line-strong px-1 py-px"
-                        style={{ fontSize: "9px" }}
-                        title={t.target_repo}
-                      >
-                        {t.target_repo.split("/").pop()}
-                      </span>
-                    )}
-                    <span className="shrink-0" aria-hidden="true">·</span>
-                    <span className="shrink-0" data-testid="trigger-schedule">
-                      {humanizeCron(t.cron)}
+                    <span className="truncate" data-testid="trigger-repo-label">
+                      {group.label}
                     </span>
                   </div>
+                  {group.items.map(renderTriggerRow)}
                 </div>
-                {!t.enabled && (
-                  <span
-                    className="shrink-0 rounded border border-line-strong px-1 py-px text-fg-4"
-                    style={{ fontSize: "9px" }}
-                  >
-                    disabled
-                  </span>
-                )}
-                {/* Hover actions: run-now, edit, delete. */}
-                <span className="hidden shrink-0 items-center gap-0.5 group-hover:inline-flex">
-                  <span
-                    role="button"
-                    title="Run now (test this trigger)"
-                    className="cursor-pointer rounded p-0.5 text-fg-4 transition-colors hover:bg-bg-4 hover:text-acc"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onRunNow?.(t);
-                    }}
-                    data-testid="trigger-run-now"
-                  >
-                    <Play size={12} />
-                  </span>
-                  <span
-                    role="button"
-                    title="Edit trigger"
-                    className="cursor-pointer rounded p-0.5 text-fg-4 transition-colors hover:bg-bg-4 hover:text-fg"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onEditTrigger?.(t);
-                    }}
-                    data-testid="trigger-edit"
-                  >
-                    <Pencil size={12} />
-                  </span>
-                  <span
-                    role="button"
-                    title="Delete trigger"
-                    className="cursor-pointer rounded p-0.5 text-fg-4 transition-colors hover:bg-bg-4 hover:text-st-failed"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      void handleDelete(t.id);
-                    }}
-                    data-testid="trigger-delete"
-                  >
-                    <Trash2 size={12} />
-                  </span>
-                </span>
-                {/* Enable/disable toggle — always visible so paused state is reversible. */}
-                <span
-                  role="switch"
-                  aria-checked={t.enabled}
-                  aria-label={t.enabled ? "Disable trigger" : "Enable trigger"}
-                  title={t.enabled ? "Disable trigger" : "Enable trigger"}
-                  className={`shrink-0 cursor-pointer rounded p-0.5 transition-colors hover:bg-bg-4 ${
-                    t.enabled ? "text-acc" : "text-fg-4"
-                  }`}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    void handleToggle(t);
-                  }}
-                  data-testid="trigger-toggle"
-                >
-                  <Power size={12} />
-                </span>
-              </button>
-            );
-          })}
+              ))}
         </div>
       )}
     </div>

--- a/frontend/src/components/UnifiedLeftPanel.test.tsx
+++ b/frontend/src/components/UnifiedLeftPanel.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
 import UnifiedLeftPanel from "./UnifiedLeftPanel";
 import type { PipelineListEntry, RunListEntry } from "../types";
 import type { LibraryPipelineEntry } from "../api";
@@ -222,6 +222,61 @@ describe("UnifiedLeftPanel three-tab strip", () => {
     );
     fireEvent.click(screen.getByRole("tab", { name: "Triggers" }));
     expect(screen.getByText("Nightly audit")).toBeInTheDocument();
+  });
+});
+
+// #258 — the Runs list groups by project (target repo), conditionally: only when
+// the on-screen runs span ≥ 2 distinct repos. Single-repo stays flat (no header,
+// no per-row repo badge). The Runs tab is the default tab, so runs render at once.
+describe("UnifiedLeftPanel runs grouped by repo (#258)", () => {
+  it("stays flat (no repo-group header) when all runs share one repo", () => {
+    const runs: RunListEntry[] = [
+      { run_id: "r1", pipeline_name: "p", status: "running", started_at: null, effective_repo: "/repos/foo" },
+      { run_id: "r2", pipeline_name: "p", status: "completed", started_at: null, effective_repo: "/repos/foo" },
+    ];
+    renderPanel({ runs });
+    expect(screen.queryByTestId("run-repo-group")).not.toBeInTheDocument();
+    expect(screen.getAllByTestId("run-display-label")).toHaveLength(2);
+  });
+
+  it("renders one repo-group header per distinct repo, alphabetical, when ≥ 2 repos", () => {
+    const runs: RunListEntry[] = [
+      { run_id: "r1", pipeline_name: "p", status: "running", started_at: null, effective_repo: "/repos/zebra" },
+      { run_id: "r2", pipeline_name: "p", status: "completed", started_at: null, effective_repo: "/repos/alpha" },
+      { run_id: "r3", pipeline_name: "p", status: "running", started_at: null, effective_repo: "/repos/zebra" },
+    ];
+    renderPanel({ runs });
+    expect(screen.getAllByTestId("run-repo-group")).toHaveLength(2);
+    const labels = screen.getAllByTestId("run-repo-label").map((el) => el.textContent);
+    expect(labels).toEqual(["alpha", "zebra"]);
+    // The full path is available on the header for hover.
+    const alphaGroup = screen.getAllByTestId("run-repo-group")[0];
+    expect(within(alphaGroup).getByText("alpha").closest("div")).toHaveAttribute(
+      "title",
+      "/repos/alpha",
+    );
+  });
+
+  it("counts archived rows toward the threshold (a 2nd-repo archived run flips to grouped)", () => {
+    const runs: RunListEntry[] = [
+      { run_id: "r1", pipeline_name: "p", status: "running", started_at: null, effective_repo: "/repos/foo" },
+      { run_id: "r2", pipeline_name: "p", status: "archived", started_at: null, effective_repo: "/repos/bar" },
+    ];
+    renderPanel({ runs });
+    expect(screen.getAllByTestId("run-repo-group")).toHaveLength(2);
+  });
+
+  it("groups a null-target run (effective_repo resolved server-side) with no catch-all bucket", () => {
+    const runs: RunListEntry[] = [
+      { run_id: "r1", pipeline_name: "p", status: "running", started_at: null, effective_repo: "/repos/alpha" },
+      { run_id: "r2", pipeline_name: "p", status: "running", started_at: null, effective_repo: "/repos/root" },
+    ];
+    renderPanel({ runs });
+    const labels = screen.getAllByTestId("run-repo-label").map((el) => el.textContent);
+    // Exactly two groups, both resolved paths — a phantom catch-all bucket would
+    // add a third label.
+    expect(labels).toEqual(["alpha", "root"]);
+    expect(screen.getAllByTestId("run-repo-group")).toHaveLength(2);
   });
 });
 

--- a/frontend/src/components/UnifiedLeftPanel.tsx
+++ b/frontend/src/components/UnifiedLeftPanel.tsx
@@ -4,6 +4,7 @@ import { isLiveRun, type RunListEntry, type RunStatus, type PipelineListEntry, t
 import type { LibraryPipelineEntry } from "../api";
 import { cleanupRun, createPipeline, deleteLibraryPipeline, duplicateLibraryPipeline, forgetRun, renameRun } from "../api";
 import { useEditStore } from "../stores/editStore";
+import { groupByRepo } from "../lib/groupByRepo";
 import CleanupConfirmModal from "./CleanupConfirmModal";
 import ConfirmDeleteModal from "./ConfirmDeleteModal";
 import ForgetRunModal from "./ForgetRunModal";
@@ -138,6 +139,130 @@ export default function UnifiedLeftPanel({
     setDeleteTarget(null);
   }
 
+  // One run row, rendered identically whether the list is flat or grouped by
+  // repo (#258). Extracted so both code paths share the exact same markup.
+  function renderRunRow(run: RunListEntry) {
+    const isSelected = run.run_id === selectedRunId;
+    const { dot } = STATUS_STYLES[run.status] ?? STATUS_STYLES.running;
+    const isArchived = run.status === "archived";
+    const canCleanup = !isArchived;
+    const isRenaming = renamingRunId === run.run_id;
+
+    return (
+      <button
+        key={run.run_id}
+        onClick={() => onSelectRun(run.run_id)}
+        className={`group flex w-full cursor-pointer items-center gap-2 border-b border-line-soft px-3 py-2 text-left transition-colors ${
+          isSelected
+            ? "bg-bg-3 text-fg"
+            : "text-fg-2 hover:bg-bg-3/50"
+        } ${isArchived ? "opacity-60" : ""}`}
+        style={{ fontSize: "11.5px" }}
+      >
+        <span
+          className={`h-2 w-2 shrink-0 rounded-full ${dot} ${
+            run.status === "running" ? "animate-pulse" : ""
+          }`}
+        />
+        <div className="min-w-0 flex-1">
+          {isRenaming ? (
+            <input
+              ref={renameInputRef}
+              className="w-full rounded border border-acc bg-bg-3 px-1 py-0.5 font-medium text-fg outline-none"
+              style={{ fontSize: "11.5px" }}
+              value={renameValue}
+              onChange={(e) => setRenameValue(e.target.value)}
+              onBlur={() => commitRename()}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") commitRename();
+                if (e.key === "Escape") cancelRename();
+              }}
+              onClick={(e) => e.stopPropagation()}
+              data-testid="rename-input"
+            />
+          ) : (
+            <div className="truncate font-medium" data-testid="run-display-label">
+              {run.name || run.run_id.slice(0, 20)}
+            </div>
+          )}
+          <div
+            className="flex items-center gap-1.5 truncate font-mono text-fg-4"
+            style={{ fontSize: "10px" }}
+          >
+            <span className="truncate" data-testid="run-pipeline-name">
+              {run.pipeline_name}
+            </span>
+            {run.triggered_by && (
+              <span
+                role="button"
+                title="Created by a trigger — open the Triggers tab"
+                className="flex shrink-0 cursor-pointer items-center gap-0.5 rounded border border-acc px-1 text-acc"
+                style={{ fontSize: "9px" }}
+                data-testid="run-trigger-badge"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  if (run.triggered_by) onSelectTrigger?.(run.triggered_by);
+                  setActiveTab("triggers");
+                }}
+              >
+                <Zap size={8} />
+                trigger
+              </span>
+            )}
+          </div>
+        </div>
+        {!isRenaming && (
+          <span
+            role="button"
+            title="Rename run"
+            className="hidden shrink-0 cursor-pointer rounded p-0.5 text-fg-4 transition-colors hover:bg-bg-4 hover:text-fg-2 group-hover:inline-flex"
+            onClick={(e) => {
+              e.stopPropagation();
+              startRename(run);
+            }}
+            data-testid="rename-button"
+          >
+            <Pencil size={12} />
+          </span>
+        )}
+        {canCleanup && (
+          <span
+            role="button"
+            title={
+              isLiveRun(run.status)
+                ? "Stop and archive run"
+                : "Cleanup run"
+            }
+            className="hidden shrink-0 cursor-pointer rounded p-0.5 text-fg-4 transition-colors hover:bg-bg-4 hover:text-fg-2 group-hover:inline-flex"
+            onClick={(e) => {
+              e.stopPropagation();
+              setConfirmCleanup({ runId: run.run_id, status: run.status });
+            }}
+          >
+            <Trash2 size={12} />
+          </span>
+        )}
+        {isArchived && (
+          <span
+            role="button"
+            title="Forget this run permanently (event log + metadata)"
+            className="hidden shrink-0 cursor-pointer rounded p-0.5 text-fg-4 transition-colors hover:bg-bg-4 hover:text-st-failed group-hover:inline-flex"
+            onClick={(e) => {
+              e.stopPropagation();
+              setConfirmForget(run.run_id);
+            }}
+          >
+            <Trash2 size={12} />
+          </span>
+        )}
+      </button>
+    );
+  }
+
+  // Group the Runs list by project (#258) only when ≥ 2 distinct repos are
+  // present; otherwise `null` ⇒ the flat list, byte-identical to before.
+  const runGroups = groupByRepo(runs, (r) => r.effective_repo);
+
   const tabs: { id: LeftTab; label: string }[] = [
     { id: "runs", label: "Runs" },
     { id: "triggers", label: "Triggers" },
@@ -192,123 +317,22 @@ export default function UnifiedLeftPanel({
               No runs yet
             </div>
           )}
-          {runs.map((run) => {
-            const isSelected = run.run_id === selectedRunId;
-            const { dot } = STATUS_STYLES[run.status] ?? STATUS_STYLES.running;
-            const isArchived = run.status === "archived";
-            const canCleanup = !isArchived;
-            const isRenaming = renamingRunId === run.run_id;
-
-            return (
-              <button
-                key={run.run_id}
-                onClick={() => onSelectRun(run.run_id)}
-                className={`group flex w-full cursor-pointer items-center gap-2 border-b border-line-soft px-3 py-2 text-left transition-colors ${
-                  isSelected
-                    ? "bg-bg-3 text-fg"
-                    : "text-fg-2 hover:bg-bg-3/50"
-                } ${isArchived ? "opacity-60" : ""}`}
-                style={{ fontSize: "11.5px" }}
-              >
-                <span
-                  className={`h-2 w-2 shrink-0 rounded-full ${dot} ${
-                    run.status === "running" ? "animate-pulse" : ""
-                  }`}
-                />
-                <div className="min-w-0 flex-1">
-                  {isRenaming ? (
-                    <input
-                      ref={renameInputRef}
-                      className="w-full rounded border border-acc bg-bg-3 px-1 py-0.5 font-medium text-fg outline-none"
-                      style={{ fontSize: "11.5px" }}
-                      value={renameValue}
-                      onChange={(e) => setRenameValue(e.target.value)}
-                      onBlur={() => commitRename()}
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter") commitRename();
-                        if (e.key === "Escape") cancelRename();
-                      }}
-                      onClick={(e) => e.stopPropagation()}
-                      data-testid="rename-input"
-                    />
-                  ) : (
-                    <div className="truncate font-medium" data-testid="run-display-label">
-                      {run.name || run.run_id.slice(0, 20)}
-                    </div>
-                  )}
+          {runGroups === null
+            ? runs.map(renderRunRow)
+            : runGroups.map((group) => (
+                <div key={group.repoPath} data-testid="run-repo-group">
                   <div
-                    className="flex items-center gap-1.5 truncate font-mono text-fg-4"
+                    className="flex h-[22px] shrink-0 items-center border-b border-line-soft bg-bg-3/40 px-3 font-medium text-fg-3"
                     style={{ fontSize: "10px" }}
+                    title={group.repoPath}
                   >
-                    <span className="truncate" data-testid="run-pipeline-name">
-                      {run.pipeline_name}
+                    <span className="truncate" data-testid="run-repo-label">
+                      {group.label}
                     </span>
-                    {run.triggered_by && (
-                      <span
-                        role="button"
-                        title="Created by a trigger — open the Triggers tab"
-                        className="flex shrink-0 cursor-pointer items-center gap-0.5 rounded border border-acc px-1 text-acc"
-                        style={{ fontSize: "9px" }}
-                        data-testid="run-trigger-badge"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          if (run.triggered_by) onSelectTrigger?.(run.triggered_by);
-                          setActiveTab("triggers");
-                        }}
-                      >
-                        <Zap size={8} />
-                        trigger
-                      </span>
-                    )}
                   </div>
+                  {group.items.map(renderRunRow)}
                 </div>
-                {!isRenaming && (
-                  <span
-                    role="button"
-                    title="Rename run"
-                    className="hidden shrink-0 cursor-pointer rounded p-0.5 text-fg-4 transition-colors hover:bg-bg-4 hover:text-fg-2 group-hover:inline-flex"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      startRename(run);
-                    }}
-                    data-testid="rename-button"
-                  >
-                    <Pencil size={12} />
-                  </span>
-                )}
-                {canCleanup && (
-                  <span
-                    role="button"
-                    title={
-                      isLiveRun(run.status)
-                        ? "Stop and archive run"
-                        : "Cleanup run"
-                    }
-                    className="hidden shrink-0 cursor-pointer rounded p-0.5 text-fg-4 transition-colors hover:bg-bg-4 hover:text-fg-2 group-hover:inline-flex"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      setConfirmCleanup({ runId: run.run_id, status: run.status });
-                    }}
-                  >
-                    <Trash2 size={12} />
-                  </span>
-                )}
-                {isArchived && (
-                  <span
-                    role="button"
-                    title="Forget this run permanently (event log + metadata)"
-                    className="hidden shrink-0 cursor-pointer rounded p-0.5 text-fg-4 transition-colors hover:bg-bg-4 hover:text-st-failed group-hover:inline-flex"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      setConfirmForget(run.run_id);
-                    }}
-                  >
-                    <Trash2 size={12} />
-                  </span>
-                )}
-              </button>
-            );
-          })}
+              ))}
         </div>
         </div>
       )}

--- a/frontend/src/lib/groupByRepo.test.ts
+++ b/frontend/src/lib/groupByRepo.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from "vitest";
+import { groupByRepo, repoGroupLabel } from "./groupByRepo";
+
+interface Row {
+  id: string;
+  repo: string | null;
+}
+
+const repoOf = (r: Row) => r.repo;
+
+describe("groupByRepo", () => {
+  it("returns null for an empty list (nothing to group)", () => {
+    expect(groupByRepo([] as Row[], repoOf)).toBeNull();
+  });
+
+  it("returns null when every item shares one repo (flat, single-repo case)", () => {
+    const rows: Row[] = [
+      { id: "a", repo: "/repos/foo" },
+      { id: "b", repo: "/repos/foo" },
+    ];
+    expect(groupByRepo(rows, repoOf)).toBeNull();
+  });
+
+  it("returns null when only one distinct non-empty repo exists despite null rows", () => {
+    const rows: Row[] = [
+      { id: "a", repo: "/repos/foo" },
+      { id: "b", repo: null },
+    ];
+    // A single non-empty repo never trips the threshold — stays flat.
+    expect(groupByRepo(rows, repoOf)).toBeNull();
+  });
+
+  it("groups into ≥2 repos in alphabetical path order, items in input order", () => {
+    const rows: Row[] = [
+      { id: "z1", repo: "/repos/zebra" },
+      { id: "a1", repo: "/repos/alpha" },
+      { id: "z2", repo: "/repos/zebra" },
+      { id: "a2", repo: "/repos/alpha" },
+    ];
+    const groups = groupByRepo(rows, repoOf);
+    expect(groups).not.toBeNull();
+    expect(groups!.map((g) => g.repoPath)).toEqual([
+      "/repos/alpha",
+      "/repos/zebra",
+    ]);
+    // Within each group, input order is preserved.
+    expect(groups![0].items.map((r) => r.id)).toEqual(["a1", "a2"]);
+    expect(groups![1].items.map((r) => r.id)).toEqual(["z1", "z2"]);
+    // Labels are basenames when there's no collision.
+    expect(groups!.map((g) => g.label)).toEqual(["alpha", "zebra"]);
+  });
+
+  it("flips a single-repo list to grouped once a second repo appears (e.g. archived row)", () => {
+    const flat: Row[] = [
+      { id: "live", repo: "/repos/foo" },
+      { id: "archived", repo: "/repos/foo" },
+    ];
+    expect(groupByRepo(flat, repoOf)).toBeNull();
+
+    const mixed: Row[] = [
+      ...flat,
+      { id: "archived-other", repo: "/repos/bar" },
+    ];
+    const groups = groupByRepo(mixed, repoOf);
+    expect(groups).not.toBeNull();
+    expect(groups!.map((g) => g.repoPath)).toEqual([
+      "/repos/bar",
+      "/repos/foo",
+    ]);
+    expect(groups!.find((g) => g.repoPath === "/repos/foo")!.items.map((r) => r.id)).toEqual([
+      "live",
+      "archived",
+    ]);
+  });
+
+  it("places null/empty-repo items in a single nameless bucket when grouping is active", () => {
+    const rows: Row[] = [
+      { id: "a", repo: "/repos/foo" },
+      { id: "b", repo: "/repos/bar" },
+      { id: "n1", repo: null },
+      { id: "n2", repo: "" },
+    ];
+    const groups = groupByRepo(rows, repoOf);
+    expect(groups).not.toBeNull();
+    const nameless = groups!.find((g) => g.repoPath === "");
+    expect(nameless).toBeDefined();
+    expect(nameless!.label).toBe("");
+    expect(nameless!.items.map((r) => r.id)).toEqual(["n1", "n2"]);
+    // Empty key sorts first (lexicographic).
+    expect(groups![0].repoPath).toBe("");
+  });
+});
+
+describe("repoGroupLabel", () => {
+  it("returns the bare basename when no other path collides", () => {
+    expect(repoGroupLabel("/home/u/projects/maestro", ["/home/u/projects/maestro", "/other/repo"]))
+      .toBe("maestro");
+  });
+
+  it("disambiguates a two-way basename collision with the minimal trailing suffix", () => {
+    const all = ["/a/foo", "/b/foo"];
+    expect(repoGroupLabel("/a/foo", all)).toBe("a/foo");
+    expect(repoGroupLabel("/b/foo", all)).toBe("b/foo");
+  });
+
+  it("disambiguates a three-way collision, escalating k until all are unique", () => {
+    // Two share the parent `a`; only the grandparent distinguishes those two.
+    const all = ["/x/a/svc", "/y/a/svc", "/z/b/svc"];
+    // k=2 ("a/svc","a/svc","b/svc") is not all-unique → escalate to k=3.
+    expect(repoGroupLabel("/x/a/svc", all)).toBe("x/a/svc");
+    expect(repoGroupLabel("/y/a/svc", all)).toBe("y/a/svc");
+    // The non-colliding-at-k2 one still uses k=3 (uniform k across the group).
+    expect(repoGroupLabel("/z/b/svc", all)).toBe("z/b/svc");
+  });
+
+  it("treats repeated identical paths as one (no spurious suffix)", () => {
+    // Several triggers on the same repo: dedupe means no collision.
+    expect(repoGroupLabel("/repos/foo", ["/repos/foo", "/repos/foo", "/repos/foo"]))
+      .toBe("foo");
+  });
+
+  it("ignores leading/trailing slashes when computing segments", () => {
+    expect(repoGroupLabel("/a/foo/", ["/a/foo/", "/b/foo"])).toBe("a/foo");
+  });
+});

--- a/frontend/src/lib/groupByRepo.ts
+++ b/frontend/src/lib/groupByRepo.ts
@@ -1,0 +1,107 @@
+/**
+ * "Group by project" for the Runs and Triggers lists (#258). Pure, deterministic,
+ * client-side: the daemon only resolves each row's `effective_repo` (a concrete
+ * path); the grouping itself is a reversible view layer.
+ *
+ * See CONTEXT.md § "Repo cible (`target_repo`)" for the domain rules this encodes.
+ */
+
+export interface RepoGroup<T> {
+  /**
+   * The full effective-repo path that keys this group. Empty string only for the
+   * defensive nameless bucket (never produced by real daemon data, which always
+   * resolves `effective_repo` to a concrete path).
+   */
+  repoPath: string;
+  /**
+   * Display label: the path's basename, disambiguated to a minimal trailing-path
+   * suffix on basename collision (see {@link repoGroupLabel}). Empty for the
+   * nameless bucket.
+   */
+  label: string;
+  items: T[];
+}
+
+/** Path segments, dropping empty ones (leading `/`, doubled slashes, trailing `/`). */
+function segments(path: string): string[] {
+  return path.split("/").filter((s) => s.length > 0);
+}
+
+/** Basename of `path` (its last non-empty segment), or `path` itself if it has none. */
+function lastSegment(path: string): string {
+  const segs = segments(path);
+  return segs.length ? segs[segs.length - 1] : path;
+}
+
+/** The last `k` segments of `path` joined by `/` (e.g. `lastKSegments("/a/b/c", 2) === "b/c"`). */
+function lastKSegments(path: string, k: number): string {
+  const segs = segments(path);
+  return segs.slice(Math.max(0, segs.length - k)).join("/");
+}
+
+/**
+ * The display label for an effective-repo path: its basename, or — when another
+ * path in `allPaths` shares that basename — the minimal distinguishing
+ * trailing-path suffix (e.g. `/a/foo` + `/b/foo` ⇒ `a/foo`). Falls back to the
+ * full path if no trailing suffix can disambiguate (the full path is always
+ * available via the header's `title`). See plan G6.
+ */
+export function repoGroupLabel(path: string, allPaths: string[]): string {
+  const base = lastSegment(path);
+
+  // Distinct paths sharing this basename. Dedupe (so several triggers on the same
+  // repo don't force a useless suffix) and ensure `path` itself is considered.
+  const colliding = [...new Set([path, ...allPaths])].filter(
+    (p) => lastSegment(p) === base,
+  );
+  if (colliding.length <= 1) return base;
+
+  const maxK = Math.max(...colliding.map((p) => segments(p).length));
+  for (let k = 2; k <= maxK; k++) {
+    const joins = colliding.map((p) => lastKSegments(p, k));
+    if (new Set(joins).size === colliding.length) {
+      return lastKSegments(path, k);
+    }
+  }
+  return path; // safety fallback — never both bare basenames for a real collision.
+}
+
+/**
+ * Group `items` by their effective repo path, preserving input order within each
+ * group. Returns `null` when fewer than 2 distinct non-empty repos are present —
+ * the caller then renders the flat list, byte-identical to the pre-#258
+ * single-repo behavior.
+ *
+ * Groups are ordered alphabetically by full path (deterministic; groups don't
+ * reshuffle as rows are added). Labels are basenames, disambiguated on collision.
+ * An item whose `repoOf` is null/empty/undefined drops into a single nameless
+ * bucket and does not count toward the "≥ 2 distinct repos" threshold.
+ */
+export function groupByRepo<T>(
+  items: T[],
+  repoOf: (item: T) => string | null | undefined,
+): RepoGroup<T>[] | null {
+  // First-seen key insertion order; within-group push order (Map preserves both).
+  const buckets = new Map<string, T[]>();
+  for (const item of items) {
+    const raw = repoOf(item);
+    const key = raw == null || raw.length === 0 ? "" : raw;
+    const list = buckets.get(key);
+    if (list) list.push(item);
+    else buckets.set(key, [item]);
+  }
+
+  // Conditional grouping: need ≥ 2 distinct *non-empty* repos, else flat.
+  const distinctRepos = [...buckets.keys()].filter((k) => k.length > 0);
+  if (distinctRepos.length < 2) return null;
+
+  // Lexicographic (code-unit) ordering — locale-independent and stable.
+  const sortedKeys = [...buckets.keys()].sort((a, b) =>
+    a < b ? -1 : a > b ? 1 : 0,
+  );
+  return sortedKeys.map((key) => ({
+    repoPath: key,
+    label: key.length > 0 ? repoGroupLabel(key, distinctRepos) : "",
+    items: buckets.get(key)!,
+  }));
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -34,6 +34,12 @@ export interface RunListEntry {
   name?: string | null;
   /** Provenance: the id of the Trigger that created this Run, if any (#160). */
   triggered_by?: string | null;
+  /**
+   * Resolved target repo for "group by project" (#258): the run's `target_repo`,
+   * or the daemon's `repo_root` when unset. Always sent by the daemon; declared
+   * optional so existing test fixtures that omit it still typecheck.
+   */
+  effective_repo?: string;
 }
 
 /**
@@ -46,6 +52,12 @@ export interface Trigger {
   pipeline_id: string;
   pipeline_name: string;
   target_repo?: string | null;
+  /**
+   * Resolved target repo for "group by project" (#258): the raw `target_repo`,
+   * or the daemon's `repo_root` when unset. Sent only by the list endpoint
+   * (`GET /triggers`); the row badge / detail still read raw `target_repo`.
+   */
+  effective_repo?: string | null;
   source_branch?: string | null;
   input_template: string;
   variables: Record<string, unknown>;


### PR DESCRIPTION
## Group the Runs & Triggers lists by project (target repo)

Closes #258.

Both the **Runs** list and the **Triggers** list are now grouped by their resolved target repository:

- Each list groups rows under a repo header, shown **only when ≥ 2 distinct repos** are present — the single-repo case stays flat (byte-identical to before).
- A null `target_repo` resolves to the daemon's `repo_root` (via the existing `effective_repo_root`) — there is **no "Unassigned" bucket**.
- Headers are sorted alphabetically by full path; basename collisions are **disambiguated** (e.g. `x/svc` vs `y/svc`), and the full path is exposed on hover (`title`).
- Per-row repo badges are dropped once a group header carries the repo (no redundancy).

### Changes
- **Backend** (`crates/pdo-daemon/src/lib.rs`): `/runs` and `/triggers` payloads now carry `effective_repo`; `TriggerListEntry` uses `#[serde(flatten)]` so the raw `target_repo` is untouched.
- **Frontend**: new pure `groupByRepo` helper + grouping in `UnifiedLeftPanel` (Runs) and `TriggersListPanel` (Triggers); `types.ts` extended.
- **Tests**: L3 Rust integration test (`runs_list_target_repo.rs`), `groupByRepo` unit suite, panel component suites, e2e spec, L5 scenario doc.
- **Release**: bump workspace version to 0.1.28.

### Verification
- Rust + frontend compile clean.
- 48 targeted unit/component tests pass.
- Visual ID in a browser against the real built bundle: grouped behavior, alphabetical order, full-path hover, null→repo_root (no Unassigned), collision disambiguation, and the single-repo flat regression all confirmed (Tester verdict: **Pass**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
