### PR TITLE
feat(ui): run stats panel — duration, node sessions, lines changed (#100)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -424,7 +424,13 @@ Plusieurs Runs du même pipeline (ou de pipelines différents) peuvent tourner s
 
 `<run-id>` = slug `<timestamp>-<short-uuid>` pour rester lisible humainement et garanti unique.
 
----
+### Statistiques de Run
+
+Le panneau d'info d'un Run expose un petit bloc de stats (cf. #100). Trois métriques retenues ; le **coût** (tokens/$) est **hors-scope** — aucune télémétrie de coût fiable n'existe côté machine utilisateur (la télémétrie Claude Code y est redirigée).
+
+- **Durée** : temps écoulé entre `started_at` et `completed_at`. **Dérivée à l'affichage** (frontend) à partir des deux timestamps déjà projetés depuis l'event log — pas de `duration_ms` backend (qui figerait un Run vivant). Horloge **live** (tick) tant que le Run est vivant (`Running`/`AwaitingUser`/`Paused`) ; figée à `completed_at` à l'entrée terminale. La durée est du **wall-clock** : un Run `Paused` continue de compter (le temps de pause est inclus).
+- **Sessions de nœud lancées** (*node sessions started*) : **compte cumulatif** des événements `NodeStarted` sur tout le Run. Mesure les sessions tmux NodeRun réellement spawnées — **y compris** les re-spawns au **même** `(node, iter)` (restart/recovery), donc ≥ le nombre de `(node, iter)` distincts (une projection dédupliquée par `(node, iter)` *sous-compterait*). Le **Pipeline Manager** n'émet pas `NodeStarted` → exclu par construction (« exclure le manager » est un no-op). Distinct de la gauge « sessions vivantes » du cap (cf. *Cap de sessions concurrentes*).
+- **LOC** (lignes changées par le Run) : `git diff --numstat` en **trois-points** (`HEAD...pdo/run-<run-id>`) — la base est le **point de fork** (merge-base), donc stable même si `main` avance (un diff deux-points dériverait). **Exclut `.pdo/`** (artefacts/prompts générés ne sont pas du code produit ; protégé par `.gitignore` mais un pathspec `:(exclude).pdo/` défensif couvre les repos cibles externes). **Dérivé du git, live-only** : la branche `pdo/run-<run-id>` est supprimée au cleanup → la stat affiche **« — »** pour un Run archivé/nettoyé (branche absente = `None`), à distinguer de **« 0 »** (diff réellement vide). Même schéma que le snapshot de pane qui survit au reap.
 
 ## Repo cible (`target_repo`)
 
@@ -617,7 +623,7 @@ Borne globale, daemon-wide, sur le nombre de **sessions NodeRun (Claude Code)** 
 - **Admission par spawn de nœud**, pas par Run : quand le scheduler veut spawner un NodeRun et que `live_sessions + 1 > cap`, le nœud passe en état **`waiting`** jusqu'à libération d'un slot, puis spawn. Le Run est admis immédiatement ; ce sont les *nœuds* qui s'étranglent.
 - **Les sessions Pipeline Manager ne comptent pas** dans le cap (légères, 1/Run ; les compter risquerait un soft-deadlock où N managers saturent le budget sans laisser de slot au travail réel).
 - **Valeur configurable** sur la page de réglages instance-wide (#129, n'existe pas encore).
-- **Compteur de sessions** dans la **barre de statut basse** (avec les autres infos techniques), ex. « 7/10 », vire à l'ambre à l'approche du cap pour rendre le throttling lisible avant qu'il morde.
+- **Compteur de sessions** dans la **barre de statut basse** (avec les autres infos techniques), ex. « 7/10 », vire à l'ambre à l'approche du cap pour rendre le throttling lisible avant qu'il morde. C'est une **gauge instantanée** (sessions *vivantes* à l'instant T, au plus une par nœud) — **à ne pas confondre** avec la stat **« Sessions de nœud lancées »** d'un Run (total *cumulatif* des `NodeStarted`, cf. *Statistiques de Run* dans le cycle de vie).
 - **Admission atomique (check-and-reserve, #213)** : la décision d'admission (compter les sessions vivantes → décider → réserver le slot en appendant `NodeStarted`/`NodeWaiting`) est sérialisée par un verrou (`admission_lock`). Sans lui, des spawns concurrents (retries des nœuds `waiting` sur plusieurs Runs) observent tous le même slot libre et dépassent le cap.
 
 ### Cycle de vie process — résilience (fail-fast, #213)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1688,7 +1688,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "0.1.30"
+version = "0.1.31"
 license = "MIT"
 
 [workspace.dependencies]

--- a/crates/pdo-daemon/src/event_log.rs
+++ b/crates/pdo-daemon/src/event_log.rs
@@ -225,6 +225,17 @@ pub struct SwitchState {
     pub evaluated_at: String,
 }
 
+/// Lines-of-code delta for a Run, derived live from `git diff --numstat` of the
+/// run branch against its fork point (issue #100). Live-only: it is **not**
+/// snapshotted into the event log (J2), so once the run branch is cleaned up it
+/// becomes uncomputable and the field is dropped (`None` → UI shows "—").
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LocStat {
+    pub insertions: u64,
+    pub deletions: u64,
+    pub files_changed: u64,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RunState {
     pub run_id: String,
@@ -259,6 +270,19 @@ pub struct RunState {
     /// Provenance: the id of the Trigger that created this Run, if any.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub triggered_by: Option<String>,
+    /// Cumulative count of `NodeStarted` events for this Run — i.e. how many
+    /// Claude Code NodeRun sessions it spawned (issue #100). A **raw** count,
+    /// not deduplicated by `(node, iter)`: a legal re-spawn at the same
+    /// `(node, iter)` (restart/recovery) counts again, so this is always ≥ the
+    /// number of distinct iterations shown. The Pipeline Manager emits no
+    /// `NodeStarted`, so it is excluded by construction.
+    #[serde(default)]
+    pub sessions_spawned: u64,
+    /// Lines changed for the Run (issue #100). `None` (not `Some(0)`) when the
+    /// run branch is gone (archived/cleaned) — the UI renders "—" vs "0".
+    /// Derived on read, never persisted; see [`LocStat`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub loc: Option<LocStat>,
 }
 
 impl RunState {
@@ -283,6 +307,8 @@ impl RunState {
             target_repo: None,
             source_branch: None,
             triggered_by: None,
+            sessions_spawned: 0,
+            loc: None,
         }
     }
 }
@@ -436,6 +462,11 @@ pub fn project(events: &[Event]) -> Option<RunState> {
             }
             EventKind::NodeStarted => {
                 if let Some(ref node_id) = event.node_id {
+                    // Raw count of node sessions spawned (#100). Incremented per
+                    // `NodeStarted` (not per distinct `(node, iter)`), inside the
+                    // node-id guard so only real node spawns count — the manager
+                    // emits no `NodeStarted`.
+                    state.sessions_spawned += 1;
                     let iter = event.iter.unwrap_or(1);
                     let iteration = IterationInfo {
                         iter,
@@ -1221,6 +1252,46 @@ mod tests {
         let state = project(&events).unwrap();
         assert_eq!(state.status, RunStatus::Running);
         assert_eq!(state.nodes["planner"].status, NodeStatus::Running);
+    }
+
+    #[test]
+    fn sessions_spawned_counts_raw_node_started_not_distinct_iters() {
+        // #100: `sessions_spawned` is the RAW count of `NodeStarted` events, so
+        // a legal re-spawn at the SAME (node, iter) — restart/recovery — counts
+        // again. A distinct-(node,iter) count would undercount real sessions.
+        let mut second_a = make_event(EventKind::NodeStarted, Some("a"), Some(1));
+        second_a.ts = "2026-01-01T00:05:00.000Z".into();
+        let events = vec![
+            make_event(EventKind::RunStarted, None, None),
+            make_event(EventKind::NodeStarted, Some("a"), Some(1)),
+            make_event(EventKind::NodeStarted, Some("b"), Some(1)),
+            second_a, // same (a, 1) again — restart/recovery
+        ];
+
+        let state = project(&events).unwrap();
+        // 3 raw NodeStarted events, even though only 2 distinct (node, iter).
+        assert_eq!(state.sessions_spawned, 3);
+
+        // Sanity: the projection still dedups iterations by (node, iter), so the
+        // raw counter must be >= the distinct-iteration total it would yield.
+        let distinct_iters: usize = state.nodes.values().map(|n| n.iterations.len()).sum();
+        assert_eq!(distinct_iters, 2);
+        assert!(state.sessions_spawned as usize >= distinct_iters);
+    }
+
+    #[test]
+    fn sessions_spawned_ignores_manager_and_non_started_events() {
+        // The manager emits no `NodeStarted` (it spawns outside the event-log
+        // node path), and a `NodeWaiting` (throttled, no session) must not count.
+        let events = vec![
+            make_event(EventKind::RunStarted, None, None),
+            make_event(EventKind::NodeWaiting, Some("a"), Some(1)),
+            make_event(EventKind::NodeStarted, Some("a"), Some(1)),
+            make_event(EventKind::NodeCompleted, Some("a"), Some(1)),
+            make_event(EventKind::RunCompleted, None, None),
+        ];
+        let state = project(&events).unwrap();
+        assert_eq!(state.sessions_spawned, 1);
     }
 
     #[test]

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -8017,7 +8017,83 @@ fn copy_pipeline_to_run(
     Ok(())
 }
 
+/// Parse `git diff --numstat` output into a [`LocStat`] (issue #100).
+///
+/// numstat rows are `added\tdeleted\tpath`. For **binary** files git emits `-`
+/// in the count columns: we skip their +/- contribution but still count the
+/// file. A blank/short line (no path) is not a numstat row and is ignored. An
+/// empty input yields `{0, 0, 0}` — the caller distinguishes that (clean diff,
+/// `Some`) from an uncomputable diff (`None`).
+fn parse_numstat(stdout: &str) -> event_log::LocStat {
+    let mut insertions = 0u64;
+    let mut deletions = 0u64;
+    let mut files_changed = 0u64;
+    for line in stdout.lines() {
+        let mut cols = line.splitn(3, '\t');
+        let added = cols.next().unwrap_or("");
+        let deleted = cols.next().unwrap_or("");
+        // A valid numstat row has a third (path) column; otherwise it is not a
+        // numstat line (e.g. a blank trailing line).
+        if cols.next().is_none() {
+            continue;
+        }
+        files_changed += 1;
+        // Binary files report `-`; `parse` fails and contributes nothing.
+        if let Ok(a) = added.parse::<u64>() {
+            insertions += a;
+        }
+        if let Ok(d) = deleted.parse::<u64>() {
+            deletions += d;
+        }
+    }
+    event_log::LocStat {
+        insertions,
+        deletions,
+        files_changed,
+    }
+}
+
+/// Lines changed for a Run, from `git diff --numstat HEAD...pdo/run-<id>` with
+/// `.pdo/` excluded (issue #100). Returns `None` when the diff is uncomputable
+/// (git missing, not a repo, run branch gone after cleanup) so the UI renders
+/// "—"; a successful but empty diff returns `Some({0, 0, 0})` → UI "0".
+///
+/// Uses a **three-dot** range so the base is the merge-base (the run's fork
+/// point): the count stays correct even as `main` advances past the fork
+/// (two-dot would drift and report later main commits as deletions).
+fn compute_run_loc(repo_root: &std::path::Path, run_id: &str) -> Option<event_log::LocStat> {
+    let range = format!("HEAD...pdo/run-{run_id}");
+    let output = std::process::Command::new("git")
+        // `:(exclude).pdo/` is a literal pathspec argv element (no shell). `.pdo/`
+        // is gitignored here, but the exclusion is defensive for external target
+        // repos that may commit it.
+        .args([
+            "diff",
+            "--numstat",
+            &range,
+            "--",
+            ".",
+            ":(exclude).pdo/",
+        ])
+        .current_dir(repo_root)
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        // Missing run branch (`unknown revision`), not a repo, etc. → "—".
+        return None;
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    Some(parse_numstat(&stdout))
+}
+
 fn augment_run_state_from_disk(run_state: &mut event_log::RunState, repo_root: &std::path::Path) {
+    // LOC is independent of the run YAML: the run branch lives in `repo_root`,
+    // not the run dir, so a missing/unparseable YAML must not suppress an
+    // otherwise-valid LOC. Compute it before the YAML early-return below.
+    run_state.loc = compute_run_loc(repo_root, &run_state.run_id);
+
     let yaml_path = run_scoped_pipeline_path(repo_root, &run_state.run_id);
     let Ok(yaml) = std::fs::read_to_string(&yaml_path) else {
         return;
@@ -9117,6 +9193,46 @@ mod tests {
         ];
         for ev in &events {
             append_event(state, ev).await.unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn get_run_payload_carries_sessions_spawned_and_omits_cost() {
+        // #100 AC#1/#5: GET /runs/:id exposes `sessions_spawned` (a number) and
+        // never a cost/token/price field (cost is out of scope). `loc` is
+        // omitted here because the seeded run has no `pdo/run-<id>` branch.
+        let state = test_state().await;
+        let run_id = "stats-payload";
+        seed_completed_run(&state, run_id).await; // exactly one NodeStarted
+
+        let app = build_router(state.clone());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/runs/{run_id}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: serde_json::Value = serde_json::from_slice(
+            &axum::body::to_bytes(resp.into_body(), usize::MAX)
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(body["sessions_spawned"], 1);
+        // No run branch for this seeded run → `loc` is omitted (None), not Some(0).
+        assert!(body.get("loc").is_none() || body["loc"].is_null());
+        // Cost is out of scope: assert no cost/token/price key leaked onto the payload.
+        for key in body.as_object().unwrap().keys() {
+            let lk = key.to_lowercase();
+            assert!(
+                !lk.contains("cost") && !lk.contains("token") && !lk.contains("price"),
+                "unexpected cost-like field on /runs payload: {key}"
+            );
         }
     }
 
@@ -10322,6 +10438,129 @@ mod tests {
         std::fs::write(dir.join("README.md"), "# test\n").unwrap();
         run(&["add", "README.md"]);
         run(&["commit", "-m", "initial"]);
+    }
+
+    #[test]
+    fn parse_numstat_sums_text_and_counts_binary_without_lines() {
+        // #100: text rows sum +/- ; binary rows show `-` so contribute 0 lines
+        // but still count as a changed file. A trailing blank line is ignored.
+        let out = "3\t1\tsrc/a.rs\n2\t1\tsrc/b.rs\n-\t-\tassets/logo.png\n\n";
+        let loc = parse_numstat(out);
+        assert_eq!(
+            loc,
+            event_log::LocStat {
+                insertions: 5,
+                deletions: 2,
+                files_changed: 3,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_numstat_empty_is_zero() {
+        assert_eq!(
+            parse_numstat(""),
+            event_log::LocStat {
+                insertions: 0,
+                deletions: 0,
+                files_changed: 0,
+            }
+        );
+    }
+
+    #[test]
+    fn compute_run_loc_three_dot_excludes_pdo_and_drops_when_branch_gone() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path();
+        init_test_repo(repo);
+        let git = |args: &[&str]| {
+            let out = std::process::Command::new("git")
+                .args(args)
+                .current_dir(repo)
+                .output()
+                .unwrap();
+            assert!(
+                out.status.success(),
+                "git {args:?} failed: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+            out
+        };
+
+        // Base file on HEAD so the run branch can delete a line from it.
+        std::fs::write(repo.join("code.txt"), "keep1\nremove\nkeep2\n").unwrap();
+        git(&["add", "code.txt"]);
+        git(&["commit", "-m", "add code"]);
+
+        let default_branch =
+            String::from_utf8_lossy(&git(&["rev-parse", "--abbrev-ref", "HEAD"]).stdout)
+                .trim()
+                .to_string();
+        let run_id = "loc-test";
+        let branch = format!("pdo/run-{run_id}");
+
+        // Run branch: a +3/-1 source diff PLUS a tracked `.pdo/` change that must
+        // be excluded (so files_changed stays 1, not 2).
+        git(&["checkout", "-b", &branch]);
+        std::fs::write(repo.join("code.txt"), "keep1\nadd1\nadd2\nadd3\nkeep2\n").unwrap();
+        std::fs::create_dir_all(repo.join(".pdo")).unwrap();
+        std::fs::write(repo.join(".pdo/noise.txt"), "a\nb\nc\nd\n").unwrap();
+        git(&["add", "-A"]);
+        git(&["commit", "-m", "run changes"]);
+        git(&["checkout", &default_branch]);
+
+        let loc = compute_run_loc(repo, run_id).expect("branch present -> Some");
+        assert_eq!(
+            loc,
+            event_log::LocStat {
+                insertions: 3,
+                deletions: 1,
+                files_changed: 1,
+            },
+            ".pdo/ excluded so only code.txt counts"
+        );
+
+        // Three-dot base = fork point: advancing HEAD after the fork must NOT
+        // change the run's LOC (two-dot would report the new commit as deletions).
+        std::fs::write(repo.join("other.txt"), "x\ny\n").unwrap();
+        git(&["add", "other.txt"]);
+        git(&["commit", "-m", "advance main"]);
+        let loc_after = compute_run_loc(repo, run_id).expect("still Some");
+        assert_eq!(
+            loc_after, loc,
+            "three-dot base stays at the fork point as HEAD advances"
+        );
+
+        // Branch gone (cleanup) -> None -> UI renders "—" (not "0").
+        git(&["branch", "-D", &branch]);
+        assert!(
+            compute_run_loc(repo, run_id).is_none(),
+            "missing run branch -> None"
+        );
+    }
+
+    #[test]
+    fn compute_run_loc_clean_diff_is_some_zero_not_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path();
+        init_test_repo(repo);
+        let run_id = "loc-clean";
+        // Branch at HEAD with no divergence: a successful but EMPTY diff must be
+        // Some({0,0,0}) (UI "0"), distinct from None (UI "—").
+        let out = std::process::Command::new("git")
+            .args(["branch", &format!("pdo/run-{run_id}")])
+            .current_dir(repo)
+            .output()
+            .unwrap();
+        assert!(out.status.success());
+        assert_eq!(
+            compute_run_loc(repo, run_id).expect("branch present -> Some"),
+            event_log::LocStat {
+                insertions: 0,
+                deletions: 0,
+                files_changed: 0,
+            }
+        );
     }
 
     #[test]

--- a/crates/pdo-daemon/tests/trigger_scheduler.rs
+++ b/crates/pdo-daemon/tests/trigger_scheduler.rs
@@ -726,7 +726,12 @@ async fn patch_disable_then_enable_pauses_and_resumes_firing() {
 #[tokio::test]
 async fn patch_edits_schedule_input_and_overlap_and_recomputes_next_fire() {
     let daemon = TestDaemon::spawn(seed).await.unwrap();
-    let trigger = create_trigger(&daemon, "editable", "0 9 * * *").await;
+    // Daily at minute 07: a minute `*/15` (fires at :00/:15/:30/:45) can never
+    // land on, so the post-edit `next_fire_at` is guaranteed to differ from the
+    // original regardless of the wall-clock at test time. (A `0 9 * * *` seed
+    // would collide with `*/15` whenever "now" falls in (08:45, 09:00], making
+    // the recompute assertion below flaky around that minute each day.)
+    let trigger = create_trigger(&daemon, "editable", "7 9 * * *").await;
     let trigger_id = trigger["id"].as_str().unwrap().to_string();
     let original_next = trigger["next_fire_at"].as_str().unwrap().to_string();
 

--- a/docs/testing/scenarios/run-stats-panel.md
+++ b/docs/testing/scenarios/run-stats-panel.md
@@ -1,0 +1,175 @@
+# Scenario — `run-stats-panel`
+
+> Layer 5 (agentic) per ADR 0004. Manual trigger: an agent executes the steps
+> below and emits the verdict format at the bottom. Asserts that a Run's **Info
+> panel** displays a **Stats** block with three live-correct metrics — **Duration**
+> (client-derived, ticking while the run is alive), **Node sessions started**
+> (cumulative `NodeStarted` count, manager excluded), and **Lines changed / LOC**
+> (`git diff --numstat` of the run branch, `.pdo/`-excluded, `—` once cleaned) —
+> and that **cost is absent** (out of scope, #100). The agent cross-checks every
+> rendered value against the daemon endpoint AND against git / event-log ground
+> truth, the way a careful human reviewer would.
+
+## Setup
+
+- Daemon running and built **from the source tree under test** (`pdo daemon`, or
+  `cargo run -p pdo-daemon` with `PDO_SKIP_FRONTEND_BUILD` unset so the embedded
+  frontend is current).
+- Resolve the base URL once:
+  `PORT=${PDO_PORT:-$(ss -ltnp 2>/dev/null | grep -oE '127.0.0.1:(5172|6172|6160)' | head -1 | cut -d: -f2)}; PORT=${PORT:-5172}; BASE=http://127.0.0.1:$PORT`
+  Confirm `curl -sf $BASE/sessions | jq .` returns 200 with `{live,cap,version}`.
+- Frontend reachable in a browser. **Chrome DevTools MCP preferred**; Playwright MCP
+  is the fallback. (If `:5174`/your vite serves a *different* tree, prefer the
+  daemon-embedded UI at `$BASE` so you're testing the tree under test.)
+- `curl`, `jq`, `git`, and `sqlite3` on PATH.
+- `REPO=$(git rev-parse --show-toplevel)` — the target repo where `pdo/run-*`
+  branches and the event-log DB live.
+- Locate the event-log DB: `DB=$(find "$REPO/.pdo" -maxdepth 2 -name '*.db' | head -1)`.
+  Confirm it has an `events` table: `sqlite3 "$DB" '.tables' | grep -q events`.
+
+### Pick the runs to inspect
+
+`curl -sf $BASE/runs | jq -r '.[] | "\(.run_id)\t\(.status)"'`
+
+- **LIVE** = a run whose status is `running` / `awaiting_user` / `paused`. Used for
+  the *ticking duration* assertion. If none exists, you MAY launch one (see the
+  `run-minimal` scenario) — but that costs API budget; otherwise **skip** the
+  ticking assertions and note it in `anomalies`.
+- **TERMINAL+branch** = a `completed` / `failed` / `halted` run whose branch still
+  exists: `git -C "$REPO" rev-parse --verify "pdo/run-<id>" >/dev/null 2>&1`. Used
+  for the LOC and *frozen duration* assertions. Prefer one that touched code.
+- **ARCHIVED/cleaned** = a run whose `pdo/run-<id>` branch does **not** resolve
+  (cleaned up). Used for the LOC-`—` assertion. If none exists, skip and note it.
+
+## Steps the agent executes
+
+### Step 1 — `GET /runs/:id` carries the new stat fields (refs #100)
+
+For the TERMINAL+branch run id `$R`:
+
+1. `curl -sf "$BASE/runs/$R" | jq '{status, started_at, completed_at, sessions_spawned, loc}'`
+2. Assert HTTP 200 and a JSON object.
+3. Assert `sessions_spawned` is a **number ≥ 1**.
+4. Assert `started_at` is a non-null ISO-8601 `…Z` string and (terminal run)
+   `completed_at` is non-null.
+5. Assert `loc` is either an object `{insertions, deletions, files_changed}` (all
+   numbers) **or** null/absent. Record which.
+6. Assert there is **no `cost` field** anywhere in the payload (`jq 'has("cost")'`
+   is `false`; `jq` for any key matching `/cost|token|price/i` finds nothing). Cost
+   is out of scope and must not have leaked in.
+
+### Step 2 — `sessions_spawned` equals the raw `NodeStarted` count (ground truth)
+
+1. `EXPECT_SESS=$(sqlite3 "$DB" "SELECT count(*) FROM events WHERE run_id='$R' AND kind='node_started';")`
+2. Assert `sessions_spawned == $EXPECT_SESS` — a **raw** event count, not deduplicated.
+3. Compute distinct iterations:
+   `DISTINCT=$(sqlite3 "$DB" "SELECT count(*) FROM (SELECT DISTINCT node_id, iter FROM events WHERE run_id='$R' AND kind='node_started');")`
+   Assert `sessions_spawned >= $DISTINCT` (raw ≥ distinct). If `>` , that's the
+   restart/recovery case the stat is designed to count — record it as positive
+   evidence, not an anomaly.
+4. Manager sanity: confirm a `pdo-mgr-$R` style session exists (or existed) yet the
+   manager contributes **0** to the count — i.e. there are **no** `node_started`
+   rows with a manager node id (`sqlite3 "$DB" "SELECT count(*) FROM events WHERE run_id='$R' AND kind='node_started' AND node_id LIKE '%manager%';"` is 0).
+
+### Step 3 — `loc` equals an independent numstat, with `.pdo/` excluded (ground truth)
+
+For the TERMINAL+branch run (branch resolves):
+
+1. Recompute LOC the way the feature should:
+   ```
+   git -C "$REPO" diff --numstat HEAD...pdo/run-$R -- . ':(exclude).pdo/'
+   ```
+   Sum column 1 → `INS`, column 2 → `DEL` (treat `-` binary rows as 0/0 but count
+   the file), row count → `FILES`.
+2. Assert the API `loc` equals `{insertions:INS, deletions:DEL, files_changed:FILES}`.
+3. **`.pdo/` exclusion proof:** recompute *without* the exclusion
+   (`git -C "$REPO" diff --numstat HEAD...pdo/run-$R`). If the two totals differ
+   (the run wrote tracked `.pdo/` content), assert the API matched the **excluded**
+   value, not the unexcluded one. If they're equal, note that `.pdo/` happened to be
+   untracked here (still consistent).
+4. Three-dot proof (no drift): `git -C "$REPO" diff --numstat HEAD..pdo/run-$R`
+   (two-dot) may differ from three-dot if `main` advanced since the fork. The API
+   must match the **three-dot** value. If two-dot == three-dot here, note that main
+   has not advanced (assertion still holds).
+
+For the ARCHIVED/cleaned run (branch absent): assert the API `loc` is **null/absent**.
+
+### Step 4 — UI Stats block renders and matches the endpoint (refs #100)
+
+1. Open the UI at `$BASE` in the browser. Select the TERMINAL+branch run `$R` from
+   the Runs list (left panel) so a run-scoped tab opens.
+2. In the run **Info** panel, locate the **Stats** block (it sits just above the
+   diff section). Assert all three rows are present: a **Duration**, a **Node
+   sessions started** (or equivalent non-"Sessions"-bare label, see Step 6), and a
+   **Lines changed / LOC** row.
+3. **Node sessions started:** assert the displayed integer equals `sessions_spawned`
+   from Step 1 — character-for-character (allowing a thousands separator, e.g.
+   `1,234`).
+4. **Lines changed:** assert the UI shows `+INS` and `−DEL` (matching Step 3). If
+   the API `loc` was null (cleaned run), assert the UI shows **`—`** (an em/en dash),
+   **not** `0` and not `+0 −0`.
+5. **Duration:** assert the displayed duration ≈ `completed_at − started_at` for the
+   terminal run (within the rounding of the chosen format, e.g. whole seconds).
+6. Take a screenshot of the Stats block as evidence.
+
+### Step 5 — Duration ticks live, then freezes (refs #100)
+
+If a LIVE run `$L` is available:
+
+1. Open run `$L`'s Info panel. Read the Duration value `D1`.
+2. Wait ~4 seconds (do not reload). Read the Duration value `D2`.
+3. Assert `D2 > D1` — the duration **ticks** on a live run without a reload.
+4. Assert `D1` ≈ `now − started_at` from `curl -sf "$BASE/runs/$L" | jq -r .started_at`
+   (within a few seconds).
+5. Switch to (or reload) the TERMINAL run `$R`. Read its Duration twice ~4s apart and
+   assert it is **identical** both times — a terminal run's duration is **frozen**.
+
+If no LIVE run exists, skip 1–4 and record in `anomalies`; still run 5.
+
+### Step 6 — No naming collision with the live-sessions gauge (refs #100)
+
+1. Assert the Stats block's session label is **not** the bare word "Sessions" — it
+   reads "Node sessions started" (or the FR "Sessions de nœud lancées"), to avoid
+   confusion with the footer gauge.
+2. Assert the footer (bottom status bar) still shows the live **"X/Y"** sessions
+   gauge and that it reflects `GET /sessions` `{live,cap}` — a **different, live**
+   number from the cumulative stat. The two must be visibly distinct concepts.
+
+## Negative checks
+
+- `grep -rniE '\bcost\b|tokens?|price|\$[0-9]' frontend/src/components/PipelineInfoPanel.tsx`
+  returns no cost/token/price rendering in the stats block (cost is out of scope).
+- `curl -sf "$BASE/runs/$R" | jq 'paths | map(tostring) | join(".")' | grep -iE 'cost|token'`
+  returns nothing (no cost field on the payload).
+- `frontend/package.json` version is unchanged (`"0.0.0"`); this feature does not bump it.
+- `frontend/vite.config.ts` proxy whitelist is unchanged (the stats ride on the
+  already-proxied `/runs/:id`; no new route was added).
+
+## Cleanup
+
+- If you launched a run for Step 5, stop/clean it the way `run-minimal` prescribes;
+  otherwise the scenario is read-only. Close browser pages you opened. **Never** stop
+  or clean a run/daemon you did not create.
+
+## Verdict format
+
+```json
+{
+  "verdict": "PASS" | "FAIL",
+  "evidence": [
+    "step 1: /runs/:id returns sessions_spawned=<N> and loc=<obj|null>; no cost field",
+    "step 2: sessions_spawned == node_started count <N> (raw), >= distinct (node,iter) <M>; manager contributes 0",
+    "step 3: loc matches three-dot numstat +<INS>/-<DEL> over <FILES> files, .pdo/ excluded",
+    "step 3: archived run loc is null (branch gone)",
+    "step 4: Info-panel Stats block renders Duration / Node sessions started / Lines changed, matching the endpoint; cleaned run shows — not 0",
+    "step 5: live run duration ticks (D2>D1) and ~= now-started; terminal run duration frozen across reads",
+    "step 6: stat label is not bare 'Sessions'; footer X/Y live gauge still works and is distinct",
+    "negative: no cost/token rendering in panel or payload; package.json 0.0.0; proxy whitelist unchanged"
+  ],
+  "anomalies": [
+    "<optional — e.g. no live run available so ticking assertions skipped; daemon not built from this tree; .pdo/ untracked so exclusion was a no-op here>"
+  ]
+}
+```
+
+A single failed assertion ⇒ `verdict: "FAIL"`. Don't half-pass.

--- a/frontend/src/components/PipelineInfoPanel.stats.test.tsx
+++ b/frontend/src/components/PipelineInfoPanel.stats.test.tsx
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { renderHook, act } from "@testing-library/react";
+import type { RunState } from "../types";
+
+// DiffSection (rendered by the panel) fetches lazily on expand, but mock the api
+// module anyway so the unit test never touches the network.
+vi.mock("../api", () => ({
+  fetchRunDiff: vi.fn().mockResolvedValue(""),
+  fetchNodeDiff: vi.fn().mockResolvedValue(""),
+}));
+
+import PipelineInfoPanel from "./PipelineInfoPanel";
+import { formatDuration, useRunDuration } from "../lib/runDuration";
+
+function makeRun(overrides: Partial<RunState> = {}): RunState {
+  return {
+    run_id: "test-run-stats",
+    status: "completed",
+    pipeline_name: "test-pipe",
+    input: "test input",
+    started_at: "2026-05-14T00:00:00.000Z",
+    completed_at: "2026-05-14T00:01:30.000Z",
+    nodes: {},
+    edges: [],
+    node_defs: [],
+    start_node: null,
+    end_node: null,
+    merge_resolver: null,
+    loop_states: {},
+    foreach_states: {},
+    sessions_spawned: 1234,
+    loc: { insertions: 10, deletions: 3, files_changed: 2 },
+    ...overrides,
+  };
+}
+
+function renderPanel(run: RunState | null) {
+  return render(
+    <PipelineInfoPanel
+      run={run}
+      pipeline={null}
+      libraryPipelines={[]}
+      onLibraryChanged={() => {}}
+      onClose={() => {}}
+    />,
+  );
+}
+
+describe("formatDuration", () => {
+  it("renders a compact h/m/s ladder", () => {
+    expect(formatDuration(0)).toBe("0s");
+    expect(formatDuration(45_000)).toBe("45s");
+    expect(formatDuration(4 * 60_000 + 12_000)).toBe("4m 12s");
+    expect(formatDuration(60 * 60_000 + 23 * 60_000)).toBe("1h 23m");
+  });
+
+  it("returns null for missing/negative/non-finite input", () => {
+    expect(formatDuration(null)).toBeNull();
+    expect(formatDuration(-1)).toBeNull();
+    expect(formatDuration(Infinity)).toBeNull();
+  });
+});
+
+describe("useRunDuration", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("freezes at completed_at for a terminal run and does not tick", () => {
+    const { result } = renderHook(() =>
+      useRunDuration("2026-01-01T00:00:00.000Z", "2026-01-01T00:01:30.000Z", "completed"),
+    );
+    expect(result.current).toBe(90_000);
+    act(() => {
+      vi.advanceTimersByTime(5_000);
+    });
+    expect(result.current).toBe(90_000);
+  });
+
+  it("ticks every second while the run is live", () => {
+    vi.setSystemTime(new Date("2026-01-01T00:00:10.000Z"));
+    const { result } = renderHook(() =>
+      useRunDuration("2026-01-01T00:00:00.000Z", null, "running"),
+    );
+    expect(result.current).toBe(10_000);
+    act(() => {
+      vi.advanceTimersByTime(3_000);
+    });
+    expect(result.current).toBe(13_000);
+  });
+
+  it("keeps ticking through Paused (wall-clock, J3)", () => {
+    vi.setSystemTime(new Date("2026-01-01T00:00:05.000Z"));
+    const { result } = renderHook(() =>
+      useRunDuration("2026-01-01T00:00:00.000Z", null, "paused"),
+    );
+    expect(result.current).toBe(5_000);
+    act(() => {
+      vi.advanceTimersByTime(2_000);
+    });
+    expect(result.current).toBe(7_000);
+  });
+
+  it("returns null without a start timestamp", () => {
+    const { result } = renderHook(() => useRunDuration(null, null, "running"));
+    expect(result.current).toBeNull();
+  });
+});
+
+describe("PipelineInfoPanel — Stats block (#100)", () => {
+  it("renders Duration, Node sessions started and Lines changed", () => {
+    renderPanel(makeRun());
+    const stats = screen.getByTestId("run-stats");
+    expect(stats).toBeInTheDocument();
+
+    // Duration: 90s terminal -> "1m 30s".
+    expect(screen.getByTestId("stat-duration")).toHaveTextContent("1m 30s");
+    // Sessions: raw cumulative count with a thousands separator.
+    expect(screen.getByTestId("stat-sessions")).toHaveTextContent(
+      "Node sessions started",
+    );
+    expect(screen.getByTestId("stat-sessions")).toHaveTextContent("1,234");
+    // LOC: +10 / −3 over 2 files.
+    const loc = screen.getByTestId("stat-loc");
+    expect(loc).toHaveTextContent("+10");
+    expect(loc).toHaveTextContent("−3");
+    expect(loc).toHaveTextContent("2 files");
+  });
+
+  it("labels the sessions stat without the bare word 'Sessions' (no collision)", () => {
+    renderPanel(makeRun());
+    expect(screen.queryByText("Sessions")).toBeNull();
+    expect(screen.getByText("Node sessions started")).toBeInTheDocument();
+  });
+
+  it("renders '—' for Lines changed when loc is null (cleaned run), not '0'", () => {
+    renderPanel(makeRun({ status: "archived", loc: null }));
+    const loc = screen.getByTestId("stat-loc");
+    expect(loc).toHaveTextContent("—");
+    expect(loc).not.toHaveTextContent("+0");
+  });
+
+  it("shows a live ticking indicator only for a live run", () => {
+    const { rerender } = renderPanel(
+      makeRun({ status: "running", completed_at: null }),
+    );
+    expect(screen.getByTestId("stat-duration-live")).toBeInTheDocument();
+
+    rerender(
+      <PipelineInfoPanel
+        run={makeRun({ status: "completed" })}
+        pipeline={null}
+        libraryPipelines={[]}
+        onLibraryChanged={() => {}}
+        onClose={() => {}}
+      />,
+    );
+    expect(screen.queryByTestId("stat-duration-live")).toBeNull();
+  });
+
+  it("does not render the Stats block without a run", () => {
+    renderPanel(null);
+    expect(screen.queryByTestId("run-stats")).toBeNull();
+  });
+
+  it("does not render any cost/token/price field (out of scope)", () => {
+    const { container } = renderPanel(makeRun());
+    expect(container.textContent ?? "").not.toMatch(/cost|token|price|\$\d/i);
+  });
+});

--- a/frontend/src/components/PipelineInfoPanel.tsx
+++ b/frontend/src/components/PipelineInfoPanel.tsx
@@ -5,9 +5,32 @@ import TmuxTerminal from "./TmuxTerminal";
 import DiffSection from "./DiffSection";
 import type { LibraryPipelineEntry } from "../api";
 import type { RunState, PipelineDef } from "../types";
+import { isLiveRun } from "../types";
+import { formatDuration, useRunDuration } from "../lib/runDuration";
 import { serializePipeline } from "../stores/editStore";
 
 export type TabId = "info" | "manager" | "yaml";
+
+function StatRow({
+  label,
+  children,
+  testid,
+}: {
+  label: string;
+  children: React.ReactNode;
+  testid?: string;
+}) {
+  return (
+    <div
+      className="flex items-center justify-between rounded bg-bg-3 px-2 py-1"
+      style={{ fontSize: "10.5px" }}
+      data-testid={testid}
+    >
+      <span className="text-fg-3">{label}</span>
+      <span className="font-mono text-fg-4">{children}</span>
+    </div>
+  );
+}
 
 interface Props {
   run: RunState | null;
@@ -147,6 +170,10 @@ function InfoTab({
   pipelineName: string;
   variables: [string, { default: unknown }][];
 }) {
+  const durationMs = useRunDuration(run?.started_at, run?.completed_at, run?.status);
+  const durationLabel = formatDuration(durationMs);
+  const durationTicking = run != null && run.completed_at == null && isLiveRun(run.status);
+
   return (
     <>
       <div className="border-b border-line px-3 py-3" style={{ fontSize: "11.5px" }}>
@@ -186,6 +213,51 @@ function InfoTab({
           </div>
         )}
       </div>
+
+      {run && (
+        <div
+          className="border-b border-line px-3 py-3"
+          style={{ fontSize: "11.5px" }}
+          data-testid="run-stats"
+        >
+          <SectionHead title="Stats" />
+          <div className="mt-2 flex flex-col gap-1">
+            <StatRow label="Duration" testid="stat-duration">
+              <span className="flex items-center gap-1.5">
+                {durationLabel ?? "—"}
+                {durationTicking && (
+                  <span
+                    className="h-1.5 w-1.5 rounded-full bg-st-running animate-pulse"
+                    title="live"
+                    data-testid="stat-duration-live"
+                  />
+                )}
+              </span>
+            </StatRow>
+            <StatRow label="Node sessions started" testid="stat-sessions">
+              {(run.sessions_spawned ?? 0).toLocaleString()}
+            </StatRow>
+            <StatRow label="Lines changed" testid="stat-loc">
+              {run.loc ? (
+                <span className="flex items-center gap-1.5">
+                  <span className="text-st-done">
+                    +{run.loc.insertions.toLocaleString()}
+                  </span>
+                  <span className="text-st-failed">
+                    −{run.loc.deletions.toLocaleString()}
+                  </span>
+                  <span className="text-fg-4">
+                    {run.loc.files_changed.toLocaleString()}{" "}
+                    {run.loc.files_changed === 1 ? "file" : "files"}
+                  </span>
+                </span>
+              ) : (
+                "—"
+              )}
+            </StatRow>
+          </div>
+        </div>
+      )}
 
       <DiffSection run={run} />
 

--- a/frontend/src/lib/runDuration.ts
+++ b/frontend/src/lib/runDuration.ts
@@ -1,0 +1,48 @@
+import { useState, useEffect } from "react";
+import { isLiveRun } from "../types";
+import type { RunStatus } from "../types";
+
+/**
+ * Format an elapsed-milliseconds duration as a compact ladder (`1h 23m` /
+ * `4m 12s` / `45s`). Returns `null` for a missing/negative/non-finite input so
+ * the caller can render "—". Zero-dep (no date library in the repo). (#100)
+ */
+export function formatDuration(ms: number | null): string | null {
+  if (ms == null || !Number.isFinite(ms) || ms < 0) return null;
+  const totalSecs = Math.floor(ms / 1000);
+  const secs = totalSecs % 60;
+  const mins = Math.floor(totalSecs / 60) % 60;
+  const hrs = Math.floor(totalSecs / 3600);
+  if (hrs > 0) return `${hrs}h ${mins}m`;
+  if (mins > 0) return `${mins}m ${secs}s`;
+  return `${secs}s`;
+}
+
+/**
+ * Wall-clock duration of a run in milliseconds, derived client-side (#100).
+ * Ticks once a second while the run is live and not yet completed; freezes at
+ * `completed_at` once terminal. Returns `null` when `startedAt` is missing or
+ * unparseable. Wall-clock includes paused spans (J3). Modeled on
+ * `useRelativeTime` in TabBar.tsx.
+ */
+export function useRunDuration(
+  startedAt: string | null | undefined,
+  completedAt: string | null | undefined,
+  status: RunStatus | undefined,
+): number | null {
+  const [now, setNow] = useState(() => Date.now());
+  const ticking = !!startedAt && completedAt == null && status != null && isLiveRun(status);
+
+  useEffect(() => {
+    if (!ticking) return;
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, [ticking]);
+
+  if (!startedAt) return null;
+  const start = Date.parse(startedAt);
+  if (Number.isNaN(start)) return null;
+  const end = completedAt ? Date.parse(completedAt) : now;
+  if (Number.isNaN(end)) return null;
+  return Math.max(0, end - start);
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -211,6 +211,18 @@ export interface RunState {
   foreach_states?: Record<string, ForEachStateInfo>;
   target_repo?: string | null;
   source_branch?: string | null;
+  /**
+   * Cumulative count of NodeRun sessions this run spawned — raw `NodeStarted`
+   * count, not distinct `(node, iter)`; manager excluded (#100). Defaults to 0
+   * on older payloads.
+   */
+  sessions_spawned?: number;
+  /**
+   * Lines changed for the run (`git diff --numstat` of the run branch, `.pdo/`
+   * excluded), or null/absent once the branch is gone (archived/cleaned) — the
+   * UI renders "—" in that case, never "0" (#100).
+   */
+  loc?: { insertions: number; deletions: number; files_changed: number } | null;
 }
 
 export interface DaemonEvent {


### PR DESCRIPTION
## Summary

Adds a **Stats** block to a Run's Info panel (issue #100), rendering three metrics above the Diff section:

- **Duration** — real elapsed time; frozen for terminal runs, live-ticking with a pulsing dot for running ones (computed from `started_at`/`completed_at`).
- **Node sessions started** — cumulative count of `NodeStarted` events (manager excluded), distinct from the footer's live `N / cap sessions` gauge.
- **Lines changed** — `+ins −del N files` from a three-dot `git diff --numstat HEAD...pdo/run-<id>` with `.pdo/` excluded; `—` (em-dash) when unavailable, distinct from `0`.

Cost/token/LOC-pricing is **out of scope** (carved out during triage) and intentionally absent from both UI and payload.

## Changes

- `crates/pdo-daemon`: `event_log.rs` + `lib.rs` compute `sessions_spawned` and `loc` and expose them on the run detail endpoint.
- `frontend`: `PipelineInfoPanel.tsx` Stats block, `runDuration.ts` freeze/tick helper, `types.ts` fields, `PipelineInfoPanel.stats.test.tsx` (12 cases).
- Docs: CONTEXT.md glossary + `docs/testing/scenarios/run-stats-panel.md` Layer-5 scenario.
- Version bump `0.1.30 → 0.1.31`.

## Verification

Tester node verdict: **Pass**. Build clean (`tsc -b && vite build`, `cargo build`); frontend suite **881/881**; the two backend computations cross-checked against real event-log counts and `git numstat` ground truth (three-dot-vs-two-dot drift + `.pdo/` exclusion reproduced).

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)
