### PR TITLE
feat(repos): filesystem explorer to browse and pick a repo (#131)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1688,7 +1688,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "0.1.32"
+version = "0.1.33"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "0.1.32"
+version = "0.1.33"
 license = "MIT"
 
 [workspace.dependencies]

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -765,6 +765,212 @@ async fn repos_recent(State(state): State<Arc<AppState>>) -> Response {
     }
 }
 
+// --- GET /repos/browse (issue #131): filesystem explorer ---
+//
+// Lists directories one level at a time so the webapp can browse and pick a target
+// repo visually (the recents combobox covers the common case; this covers first-time
+// / visual selection). Read-only, single-level, no recursion. Deliberately NOT
+// hardened against path traversal — fs-exposure scoping is carved out to #260; this
+// endpoint only browses what the local 127.0.0.1 single-user daemon can already reach
+// via `/repos/validate`. The contract here mirrors its `/repos/*` siblings.
+
+#[derive(Deserialize)]
+struct BrowseQuery {
+    /// Absolute directory to list. Omitted → the default chain (`$HOME → repo_root →
+    /// /`). The frontend only ever sends absolute paths; a relative one is a caller
+    /// bug (→ 400).
+    #[serde(default)]
+    path: Option<String>,
+}
+
+#[derive(Serialize)]
+struct BrowseEntry {
+    name: String,
+    /// `canonical_dir.join(name)` — NOT re-canonicalized, so a symlinked child keeps
+    /// the path the user clicked rather than collapsing to its target.
+    path: String,
+    /// Cheap `.git`-presence hint (NOT a `git rev-parse` subprocess). A hint, not a
+    /// gate: every folder stays pickable and the authoritative validation runs at
+    /// selection time via `/repos/validate` (ADR-0001 — sharp tool, not safe tool).
+    is_git_repo: bool,
+    is_symlink: bool,
+}
+
+/// Why the requested browse root could not be resolved into a listable directory.
+#[derive(Debug, PartialEq, Eq)]
+enum BrowseRootError {
+    /// `path` was provided but is not absolute (caller bug → 400).
+    Relative,
+    /// No directory in the default chain (`$HOME → repo_root → /`) exists as a
+    /// directory (pathological → 500). `/` virtually always exists, so this is rare.
+    NoDefault,
+}
+
+/// First existing directory in `[home, repo_root, "/"]`. `None` only when none of the
+/// three is an existing directory.
+fn default_chain(home: Option<&Path>, repo_root: &Path) -> Option<PathBuf> {
+    if let Some(h) = home {
+        if h.is_dir() {
+            return Some(h.to_path_buf());
+        }
+    }
+    if repo_root.is_dir() {
+        return Some(repo_root.to_path_buf());
+    }
+    let root = Path::new("/");
+    if root.is_dir() {
+        return Some(root.to_path_buf());
+    }
+    None
+}
+
+/// Resolve the directory to list. Pure w.r.t. the environment: `home`/`repo_root` are
+/// injected (never reads the real `$HOME`) so it stays deterministic under cargo's
+/// parallel test threads (ADR-0004).
+fn resolve_browse_root(
+    path: Option<&str>,
+    home: Option<&Path>,
+    repo_root: &Path,
+) -> Result<PathBuf, BrowseRootError> {
+    match path {
+        Some(p) => {
+            let pb = PathBuf::from(p);
+            if !pb.is_absolute() {
+                return Err(BrowseRootError::Relative);
+            }
+            if pb.is_dir() {
+                Ok(pb)
+            } else if pb.is_file() {
+                // A file path → list its parent (the user pointed inside a folder).
+                Ok(pb.parent().map(Path::to_path_buf).unwrap_or(pb))
+            } else {
+                // Non-existent (e.g. a stale/half-typed combobox value) → clamp to the
+                // default so the explorer opens gracefully instead of erroring.
+                default_chain(home, repo_root).ok_or(BrowseRootError::NoDefault)
+            }
+        }
+        None => default_chain(home, repo_root).ok_or(BrowseRootError::NoDefault),
+    }
+}
+
+/// Human label for the in-body `error` when a navigable directory can't be listed.
+fn browse_io_label(e: &std::io::Error) -> &'static str {
+    match e.kind() {
+        std::io::ErrorKind::PermissionDenied => "permission denied",
+        std::io::ErrorKind::NotFound => "not found",
+        _ => "could not read directory",
+    }
+}
+
+async fn repos_browse(
+    State(state): State<Arc<AppState>>,
+    Query(q): Query<BrowseQuery>,
+) -> Response {
+    // The repo's idiom for the home dir — there is no `dirs` crate (cf.
+    // stale_detector.rs). Injected into the pure resolver so the handler stays a thin
+    // shell over testable logic.
+    let home = std::env::var("HOME").ok().map(PathBuf::from);
+    let resolved = match resolve_browse_root(q.path.as_deref(), home.as_deref(), &state.repo_root) {
+        Ok(p) => p,
+        Err(BrowseRootError::Relative) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({ "error": "path must be an absolute path" })),
+            )
+                .into_response();
+        }
+        Err(BrowseRootError::NoDefault) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({
+                    "error": "could not resolve a default browse directory"
+                })),
+            )
+                .into_response();
+        }
+    };
+
+    // Canonicalize the requested dir ONLY (resolves `..`, cleans the path, surfaces
+    // ELOOP/NotFound). Children are NOT re-canonicalized — that would collapse
+    // symlinks and show a path the user didn't click. On failure (the dir vanished
+    // since the is_dir check, or a symlink loop) fall back to the un-canonicalized
+    // path so the read_dir below produces a clean in-body error, never a 500/panic.
+    let canonical_dir = std::fs::canonicalize(&resolved).unwrap_or(resolved);
+    let parent = canonical_dir
+        .parent()
+        .map(|p| p.to_string_lossy().into_owned());
+
+    let read = match std::fs::read_dir(&canonical_dir) {
+        Ok(rd) => rd,
+        Err(e) => {
+            // Navigable-but-unlistable (EACCES, etc.): 200 with an in-body error and
+            // the breadcrumb preserved, so the user is never stranded on a blank pane.
+            return Json(serde_json::json!({
+                "path": canonical_dir.to_string_lossy(),
+                "parent": parent,
+                "entries": Vec::<BrowseEntry>::new(),
+                "truncated": false,
+                "error": format!("{}: {}", browse_io_label(&e), canonical_dir.display()),
+            }))
+            .into_response();
+        }
+    };
+
+    const CAP: usize = 1000;
+    let mut entries: Vec<BrowseEntry> = Vec::new();
+    let mut truncated = false;
+    for child in read {
+        let child = match child {
+            Ok(c) => c,
+            Err(_) => continue, // skip an entry that can't be stat'd mid-listing
+        };
+        let name = child.file_name().to_string_lossy().into_owned();
+        if name.starts_with('.') {
+            continue; // dotfiles hidden (MVP, no toggle); `.`/`..` never yielded here
+        }
+        // `file_type()` does NOT follow the link (cheap lstat) → correct for the flag.
+        let is_symlink = child.file_type().map(|t| t.is_symlink()).unwrap_or(false);
+        // TRAP: `DirEntry::metadata()` lstat's (no follow) and would report every
+        // symlinked dir as non-dir. The FREE `std::fs::metadata` FOLLOWS the link —
+        // use it for the is-dir decision. Broken link / loop → Err → false → skipped.
+        let is_dir = std::fs::metadata(child.path())
+            .map(|m| m.is_dir())
+            .unwrap_or(false);
+        if !is_dir {
+            continue; // dirs only; files and symlink-to-file dropped
+        }
+        let entry_path = canonical_dir.join(&name);
+        let is_git_repo = entry_path.join(".git").exists();
+        entries.push(BrowseEntry {
+            name,
+            path: entry_path.to_string_lossy().into_owned(),
+            is_git_repo,
+            is_symlink,
+        });
+        if entries.len() > CAP {
+            // Early-stop: a (CAP+1)th surviving dir proves there are > CAP, which is
+            // all `truncated` needs — stop stat-ing the rest.
+            truncated = true;
+            break;
+        }
+    }
+
+    // Case-insensitive, stable sort (ties keep read_dir order).
+    entries.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+    if entries.len() > CAP {
+        entries.truncate(CAP); // keep the alphabetically-first CAP
+    }
+
+    Json(serde_json::json!({
+        "path": canonical_dir.to_string_lossy(),
+        "parent": parent,
+        "entries": entries,
+        "truncated": truncated,
+        "error": serde_json::Value::Null,
+    }))
+    .into_response()
+}
+
 // --- Trigger endpoints ---
 
 #[derive(Deserialize)]
@@ -1387,6 +1593,9 @@ fn build_router(state: Arc<AppState>) -> Router {
         .route("/repos/branches", get(repos_branches))
         .route("/repos/validate", get(repos_validate))
         .route("/repos/recent", get(repos_recent))
+        // Filesystem explorer (#131). `/repos` is already whitelisted in the vite
+        // proxy and matches by prefix — no `vite.config.ts` edit needed.
+        .route("/repos/browse", get(repos_browse))
         .route("/triggers", get(list_triggers).post(create_trigger))
         // Static segment beside the `{trigger_id}` param: axum 0.8 allows this
         // (cf. `/library/pipelines` next to `/library/{name}/…`), and the
@@ -16491,6 +16700,85 @@ edges:
             .unwrap();
         let repos: Vec<String> = serde_json::from_slice(&body).unwrap();
         assert_eq!(repos, vec!["/repo/real"]);
+    }
+
+    // --- GET /repos/browse default-root resolution (issue #131) ---
+    //
+    // `resolve_browse_root` is pure w.r.t. the environment (home/repo_root injected),
+    // so these never touch the real `$HOME` and are safe under cargo's parallel test
+    // threads. Each test seeds real temp dirs so the `is_dir`/`is_file` probes are
+    // deterministic.
+
+    #[test]
+    fn resolve_browse_root_explicit_existing_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_root = tempfile::tempdir().unwrap();
+        let got = resolve_browse_root(
+            Some(tmp.path().to_str().unwrap()),
+            None,
+            repo_root.path(),
+        )
+        .unwrap();
+        assert_eq!(got, tmp.path());
+    }
+
+    #[test]
+    fn resolve_browse_root_file_resolves_to_parent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join("notes.txt");
+        std::fs::write(&file, "x").unwrap();
+        let repo_root = tempfile::tempdir().unwrap();
+        let got =
+            resolve_browse_root(Some(file.to_str().unwrap()), None, repo_root.path()).unwrap();
+        assert_eq!(got, tmp.path());
+    }
+
+    #[test]
+    fn resolve_browse_root_nonexistent_clamps_to_home() {
+        let home = tempfile::tempdir().unwrap();
+        let repo_root = tempfile::tempdir().unwrap();
+        let got = resolve_browse_root(
+            Some("/this/path/definitely/does/not/exist/131"),
+            Some(home.path()),
+            repo_root.path(),
+        )
+        .unwrap();
+        assert_eq!(got, home.path(), "non-existent path clamps to the default (home)");
+    }
+
+    #[test]
+    fn resolve_browse_root_relative_path_errors() {
+        let repo_root = tempfile::tempdir().unwrap();
+        let err = resolve_browse_root(Some("relative/path"), None, repo_root.path()).unwrap_err();
+        assert_eq!(err, BrowseRootError::Relative);
+    }
+
+    #[test]
+    fn resolve_browse_root_none_uses_home() {
+        let home = tempfile::tempdir().unwrap();
+        let repo_root = tempfile::tempdir().unwrap();
+        let got = resolve_browse_root(None, Some(home.path()), repo_root.path()).unwrap();
+        assert_eq!(got, home.path());
+    }
+
+    #[test]
+    fn resolve_browse_root_none_without_home_uses_repo_root() {
+        let repo_root = tempfile::tempdir().unwrap();
+        let got = resolve_browse_root(None, None, repo_root.path()).unwrap();
+        assert_eq!(got, repo_root.path());
+    }
+
+    #[test]
+    fn resolve_browse_root_falls_through_to_filesystem_root() {
+        // No home, and a repo_root that does not exist → falls through to `/`
+        // (which always exists), so the chain never collapses in practice.
+        let got = resolve_browse_root(
+            None,
+            None,
+            Path::new("/this/repo/root/does/not/exist/131"),
+        )
+        .unwrap();
+        assert_eq!(got, Path::new("/"));
     }
 
     // --- prompt-optional run creation (#158) ---

--- a/crates/pdo-daemon/tests/repos_browse.rs
+++ b/crates/pdo-daemon/tests/repos_browse.rs
@@ -1,0 +1,171 @@
+//! Layer 3a (real-daemon) tests for `GET /repos/browse` (issue #131).
+//!
+//! Boots a real `TestDaemon` and drives the explicit-`?path=` branch against a known
+//! directory tree seeded on the real filesystem. The default-root branch
+//! (`$HOME → repo_root → /`) is covered by the pure `resolve_browse_root` unit tests
+//! in `lib.rs` — driving it here would couple the test to the CI environment's
+//! `$HOME`, so we deliberately stay on the explicit branch.
+
+mod common;
+
+use std::os::unix::fs::symlink;
+use std::process::Command;
+
+use common::TestDaemon;
+use tempfile::TempDir;
+
+/// Seed a deterministic tree the assertions bind to:
+/// - `alpha-project`  git repo (has `.git`)         → `is_git_repo: true`
+/// - `beta-plain`     plain dir (no `.git`)          → `is_git_repo: false`
+/// - `.hidden-dir`    dotfile dir                    → hidden (absent)
+/// - `zeta-link`      symlink → alpha-project        → listed, `is_symlink: true`
+/// - `notes.txt`      plain file                     → filtered out (dirs only)
+fn seed_tree() -> TempDir {
+    let root = tempfile::tempdir().unwrap();
+    let p = root.path();
+
+    // A real git repo (bare `git init` is enough to create `.git`).
+    std::fs::create_dir(p.join("alpha-project")).unwrap();
+    let out = Command::new("git")
+        .args(["init"])
+        .current_dir(p.join("alpha-project"))
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "git init should succeed");
+
+    std::fs::create_dir(p.join("beta-plain")).unwrap();
+    std::fs::create_dir(p.join(".hidden-dir")).unwrap();
+    symlink(p.join("alpha-project"), p.join("zeta-link")).unwrap();
+    std::fs::write(p.join("notes.txt"), "notes").unwrap();
+
+    root
+}
+
+async fn browse(daemon: &TestDaemon, path: Option<&str>) -> reqwest::Response {
+    let url = match path {
+        Some(p) => format!(
+            "{}/repos/browse?path={}",
+            daemon.url(),
+            urlencoding_encode(p)
+        ),
+        None => format!("{}/repos/browse", daemon.url()),
+    };
+    reqwest::get(url).await.unwrap()
+}
+
+/// Minimal percent-encoder for path query values (avoids a new dev-dependency).
+/// Only encodes the handful of bytes that matter for a filesystem path in a query.
+fn urlencoding_encode(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for b in s.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' | b'/' => {
+                out.push(b as char)
+            }
+            _ => out.push_str(&format!("%{b:02X}")),
+        }
+    }
+    out
+}
+
+#[tokio::test]
+async fn browse_lists_dirs_only_with_flags_sorted() {
+    let daemon = TestDaemon::spawn(|_repo_root| Ok(())).await.unwrap();
+    let tree = seed_tree();
+    let tree_path = tree.path().to_str().unwrap();
+
+    let resp = browse(&daemon, Some(tree_path)).await;
+    assert_eq!(resp.status(), 200);
+    let json: serde_json::Value = resp.json().await.unwrap();
+
+    assert!(json["error"].is_null(), "no error on a readable dir");
+    assert_eq!(json["truncated"], false);
+    assert!(
+        json["parent"].is_string(),
+        "a tempdir is never the filesystem root, so parent is set"
+    );
+
+    let entries = json["entries"].as_array().unwrap();
+    let names: Vec<&str> = entries
+        .iter()
+        .map(|e| e["name"].as_str().unwrap())
+        .collect();
+
+    // Dirs only, dotfiles hidden, files filtered, case-insensitive alpha order.
+    assert_eq!(
+        names,
+        vec!["alpha-project", "beta-plain", "zeta-link"],
+        "dirs-only, .hidden-dir + notes.txt excluded, alpha-sorted"
+    );
+
+    let by_name = |n: &str| entries.iter().find(|e| e["name"] == n).unwrap();
+    assert_eq!(
+        by_name("alpha-project")["is_git_repo"], true,
+        "alpha-project has .git → flagged"
+    );
+    assert_eq!(
+        by_name("beta-plain")["is_git_repo"], false,
+        "beta-plain has no .git → not flagged"
+    );
+    assert_eq!(
+        by_name("alpha-project")["is_symlink"], false,
+        "alpha-project is a real dir"
+    );
+    assert_eq!(
+        by_name("zeta-link")["is_symlink"], true,
+        "zeta-link is a symlink → flagged"
+    );
+
+    // Entry paths are `dir.join(name)` (canonicalized parent + verbatim child name),
+    // not re-canonicalized — so the symlink keeps the path the user would click.
+    let zeta_path = by_name("zeta-link")["path"].as_str().unwrap();
+    assert!(
+        zeta_path.ends_with("/zeta-link"),
+        "symlink entry path keeps its own name, got {zeta_path}"
+    );
+}
+
+#[tokio::test]
+async fn browse_relative_path_is_400() {
+    let daemon = TestDaemon::spawn(|_repo_root| Ok(())).await.unwrap();
+    let resp = browse(&daemon, Some("relative/not/absolute")).await;
+    assert_eq!(resp.status(), 400, "relative path is a caller bug → 400");
+    let json: serde_json::Value = resp.json().await.unwrap();
+    assert!(
+        json["error"].as_str().unwrap().contains("absolute"),
+        "error mentions the absolute-path requirement"
+    );
+}
+
+#[tokio::test]
+async fn browse_file_path_lists_its_parent() {
+    let daemon = TestDaemon::spawn(|_repo_root| Ok(())).await.unwrap();
+    let tree = seed_tree();
+    let file = tree.path().join("notes.txt");
+
+    let resp = browse(&daemon, Some(file.to_str().unwrap())).await;
+    assert_eq!(resp.status(), 200);
+    let json: serde_json::Value = resp.json().await.unwrap();
+    assert!(json["error"].is_null());
+
+    // Listing the file's parent yields the same dir listing as browsing the dir.
+    let names: Vec<&str> = json["entries"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|e| e["name"].as_str().unwrap())
+        .collect();
+    assert_eq!(names, vec!["alpha-project", "beta-plain", "zeta-link"]);
+}
+
+#[tokio::test]
+async fn browse_nonexistent_path_clamps_gracefully() {
+    let daemon = TestDaemon::spawn(|_repo_root| Ok(())).await.unwrap();
+    // A stale/half-typed absolute path that does not exist → clamps to the default
+    // chain and returns 200 (the explorer opens gracefully, never errors).
+    let resp = browse(&daemon, Some("/this/path/does/not/exist/131")).await;
+    assert_eq!(resp.status(), 200);
+    let json: serde_json::Value = resp.json().await.unwrap();
+    assert!(json["error"].is_null(), "clamped open is a clean 200");
+    assert!(json["path"].is_string());
+}

--- a/docs/testing/scenarios/repo-explorer-pick.md
+++ b/docs/testing/scenarios/repo-explorer-pick.md
@@ -1,0 +1,177 @@
+# Scenario — `repo-explorer-pick`
+
+> Layer 5 (agentic) per ADR 0004. Manual trigger: an agent drives a **real browser**
+> (Chrome DevTools MCP preferred; Playwright MCP fallback) plus **Bash** (to seed a
+> deterministic directory tree on the real filesystem) and emits the verdict format
+> below. Asserts #131: a loupe icon on the repo combobox opens a **filesystem
+> explorer** that lists directories one level at a time (dirs only, dotfiles hidden,
+> git repos flagged, symlinks flagged, alpha-sorted), navigates up/down, **picks a
+> folder through the existing validation path** (green border + branch loading for a
+> git repo; red border for a non-repo), **degrades gracefully** on an unreadable
+> directory (inline error, breadcrumb kept, never a blank pane or crash), and that
+> the **nested modal** behaves (backdrop-click and Escape close only the explorer,
+> never the parent New Run modal).
+>
+> jsdom can't hit-test real click-bubbling or exercise the real filesystem, so this
+> Layer-5 + the Playwright spec `frontend/e2e/repo-explorer-pick.spec.ts` are the only
+> layers that exercise the *real* browse path end to end. Treat this scenario as the
+> human-equivalent acceptance gate.
+
+## Setup
+
+- A PDO daemon running on the user's repo. Discover the port — commonly
+  `http://127.0.0.1:5172` (debug dev), `6160` (installed prod), or `6172`; find it
+  with `ss -ltnp | grep -i pdo` and use that base URL for both the browser and any
+  API calls.
+- Frontend reachable in a browser at that base URL (the daemon serves the embedded
+  `frontend/dist`). **The build under test must already include the #131 changes** —
+  if validating a local branch, rebuild the frontend and re-embed before driving the
+  UI (the daemon serves the *embedded* bundle, not the vite dev server, unless you
+  point the browser at a vite dev port).
+- The agent runs as a **non-root** user (so `chmod 000` actually denies the daemon;
+  if running as root, the EACCES step is inconclusive — note it as an anomaly, do not
+  fail the run on it).
+
+### Seed a deterministic directory tree (Bash)
+
+The explorer browses the *real* filesystem, so seed a known tree the assertions can
+bind to. Use a fixed path and recreate it idempotently:
+
+```bash
+ROOT=/tmp/pdo-l5-repo-explorer
+rm -rf "$ROOT"; mkdir -p "$ROOT"
+# a real git repo  → must show a git dot AND validate green
+git init -q "$ROOT/alpha-project" && git -C "$ROOT/alpha-project" config user.email t@t.co \
+  && git -C "$ROOT/alpha-project" config user.name t \
+  && (cd "$ROOT/alpha-project" && echo hi > README.md && git add . && git commit -qm init)
+# a plain directory (no .git) → no dot; pickable but validates RED
+mkdir -p "$ROOT/beta-plain"
+# a dotfile directory → MUST be hidden in the listing
+mkdir -p "$ROOT/.hidden-dir"
+# a symlink to a directory → listed, flagged as a symlink, navigable
+ln -s "$ROOT/alpha-project" "$ROOT/zeta-link"
+# an unreadable directory → navigating IN must degrade gracefully (EACCES)
+mkdir -p "$ROOT/noaccess"; chmod 000 "$ROOT/noaccess"
+# a plain file → MUST NOT appear (dirs only)
+echo "notes" > "$ROOT/notes.txt"
+ls -la "$ROOT"
+```
+
+Expected listing of `$ROOT` (case-insensitive alpha, dirs only, dotfiles hidden):
+**`alpha-project`, `beta-plain`, `noaccess`, `zeta-link`** — and **not** `.hidden-dir`
+(dotfile) nor `notes.txt` (file). `alpha-project` carries a git dot; `zeta-link`
+carries a symlink marker.
+
+Restore permissions in cleanup (`chmod 755 "$ROOT/noaccess"`) so `rm -rf` works.
+
+## Steps the agent executes — open + listing
+
+1. Open the UI; confirm the **`Daemon: connected`** label is visible in the status
+   bar.
+2. Open the **New Run** modal (the "New Run" / "+" affordance). Confirm the modal
+   panel is visible (`data-testid="target-repo-input"` present).
+3. **Open-at logic (Option B):** clear the repo input and type the seed root
+   `/tmp/pdo-l5-repo-explorer` into `[data-testid="target-repo-input"]`. Then click
+   the loupe trigger `[data-testid="repo-browse-trigger"]`.
+4. The explorer modal `[data-testid="repo-browser-modal"]` appears. Assert its
+   breadcrumb `[data-testid="repo-browse-path"]` shows `/tmp/pdo-l5-repo-explorer`
+   (Option B opened at the typed absolute path, not `$HOME`).
+5. **Listing correctness.** Read the entry rows `[data-testid="repo-browse-entry"]`:
+   - Exactly **4** rows, in order: `alpha-project`, `beta-plain`, `noaccess`,
+     `zeta-link` (case-insensitive alpha).
+   - `.hidden-dir` is **absent** (dotfile hidden).
+   - `notes.txt` is **absent** (files filtered; dirs only).
+   - `alpha-project` shows a **git indicator** (the `is_git_repo` dot); `beta-plain`
+     does **not**.
+   - `zeta-link` shows a **symlink marker** (`is_symlink`).
+
+## Steps — navigate + pick (the happy path through existing validation)
+
+6. Click the `zeta-link` entry. Assert the explorer navigates **into** it (breadcrumb
+   updates; because it points at the git repo, the listing is that repo's top level —
+   e.g. empty of sub-dirs, which is fine). This proves a symlinked dir is navigable.
+7. Click the **up** affordance `[data-testid="repo-browse-up"]` until the breadcrumb
+   is back at `/tmp/pdo-l5-repo-explorer`. (Up is enabled because `parent != null`.)
+8. **Pick a git repo:** click `alpha-project` to navigate into it, then click
+   **Select this folder** `[data-testid="repo-browse-select"]`. (If the build also
+   supports picking a git-dotted entry directly, that path is acceptable too — fork
+   F2.) Assert:
+   - The explorer closes; the **New Run modal stays open**.
+   - The repo input value is now `/tmp/pdo-l5-repo-explorer/alpha-project`.
+   - Within ~1s (existing 400ms debounce → `/repos/validate` → `/repos/branches`),
+     the input border turns **green** and `[data-testid="repo-valid"]` ("Valid git
+     repository") is visible.
+   - The **Source branch** select `[data-testid="source-branch-select"]` appears and
+     is populated (at least `main`). This proves the pick reused the existing
+     validation/branch-loading flow with **no new logic**.
+9. **Pick a non-git folder:** re-open the loupe (it opens at the current value's dir —
+   `alpha-project`), click up to `/tmp/pdo-l5-repo-explorer`, navigate into
+   `beta-plain`, **Select this folder**. Assert:
+   - Input value is `/tmp/pdo-l5-repo-explorer/beta-plain`.
+   - The border turns **red** and `[data-testid="repo-error"]` shows a
+     "not a git repository" message (any folder is pickable — ADR-0001 — and the
+     authoritative `git` validation gates it).
+   - The Launch button `[data-testid="launch-button"]` is **disabled**.
+
+## Steps — graceful degrade (unreadable directory)
+
+10. Re-open the explorer and navigate to `/tmp/pdo-l5-repo-explorer`. Click the
+    `noaccess` entry. Assert (non-root):
+    - The explorer **does not crash or blank out**: an inline error
+      `[data-testid="repo-browse-error"]` is visible (e.g. "permission denied").
+    - The breadcrumb still shows the path (`.../noaccess` or stays at the parent —
+      either is acceptable as long as the user is not stranded on a blank pane).
+    - The New Run modal is **still open** and the explorer is **still usable** (click
+      up returns to a readable listing). No uncaught exception reached the devtools
+      console.
+    - *(If running as root, EACCES won't trigger — record this step as
+      `inconclusive (root)` in anomalies, do not FAIL.)*
+
+## Steps — nested-modal interaction (must not close the parent)
+
+11. With the explorer open, click its **backdrop** `[data-testid="repo-browse-backdrop"]`
+    (empty space outside the panel). Assert: the **explorer closes** AND the **New Run
+    modal remains open** (`[data-testid="target-repo-input"]` still visible). This is
+    the click-bubble guard (`stopPropagation` on the `z-[60]` backdrop).
+12. Re-open the explorer. Press **Escape**. Assert: the **explorer closes** AND the
+    New Run modal **remains open**. Press Escape **again**: now the recents dropdown
+    (if open) closes / nothing breaks — the parent modal must still be open (it has no
+    Escape handler). This proves Escape is scoped to the top-most layer
+    (`!explorerOpen` gate on the combobox listener).
+
+## Cleanup
+
+- `chmod 755 /tmp/pdo-l5-repo-explorer/noaccess && rm -rf /tmp/pdo-l5-repo-explorer`.
+- Close the New Run modal (Cancel/X). No run was launched, so there is nothing to
+  archive and no tmux session was spawned by this scenario.
+
+## Verdict format
+
+```json
+{
+  "verdict": "PASS" | "FAIL",
+  "evidence": [
+    "setup: seeded /tmp/pdo-l5-repo-explorer with alpha-project(git), beta-plain, .hidden-dir, zeta-link(symlink), noaccess(000), notes.txt",
+    "step 1: status bar 'Daemon: connected'",
+    "step 4: loupe opened explorer at typed path /tmp/pdo-l5-repo-explorer (Option B)",
+    "step 5: 4 entries [alpha-project, beta-plain, noaccess, zeta-link]; .hidden-dir and notes.txt absent; alpha-project git-dotted; zeta-link symlink-marked",
+    "step 6-7: zeta-link navigable (symlinked dir); up returns to root",
+    "step 8: picked alpha-project -> input filled, green border + 'Valid git repository', source-branch populated (main) — reused existing validation",
+    "step 9: picked beta-plain -> red border 'not a git repository', Launch disabled (any folder pickable, git gates)",
+    "step 10: clicked noaccess -> inline 'permission denied', no blank pane, no console exception, modal still open",
+    "step 11: explorer backdrop click closed explorer only; New Run modal stayed open",
+    "step 12: Escape closed explorer only; parent modal stayed open"
+  ],
+  "anomalies": [
+    "<optional — e.g. running as root so step 10 EACCES inconclusive; truncation banner if seed dir unexpectedly large; symlink marker styling nit>"
+  ]
+}
+```
+
+A single failed assertion ⇒ `verdict: "FAIL"`. Don't half-pass. The
+non-negotiable assertions are: **step 5** (dirs-only + dotfiles-hidden + correct
+flags — the listing contract), **step 8** (pick reuses the existing green-border /
+branch-loading validation, no new logic), **step 10** (graceful degrade, never a
+crash/blank — the EACCES case is the one the explorer hits constantly in real use),
+and **step 11/12** (the nested modal never closes the parent). Any of those failing
+is an automatic `FAIL` regardless of the happy path.

--- a/frontend/e2e/repo-explorer-pick.spec.ts
+++ b/frontend/e2e/repo-explorer-pick.spec.ts
@@ -1,0 +1,125 @@
+import { test, expect } from "@playwright/test";
+import { execSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+// Layer 3b (real browser ↔ real daemon) for the #131 filesystem explorer. The
+// explorer browses the *real* filesystem, so we seed a deterministic tree on disk
+// the assertions bind to, then drive the loupe → navigate → pick flow and assert the
+// pick reuses the existing validation path (green border + branch loading).
+
+const ROOT = path.join(os.tmpdir(), `pdo-e2e-repo-explorer-${process.pid}-${Date.now()}`);
+const ALPHA = path.join(ROOT, "alpha-project");
+const BETA = path.join(ROOT, "beta-plain");
+
+test.beforeAll(() => {
+  fs.rmSync(ROOT, { recursive: true, force: true });
+  fs.mkdirSync(ALPHA, { recursive: true });
+  // A real git repo with a commit on `main` so /repos/branches returns a branch.
+  execSync(
+    "git init -b main && git config user.email t@t.co && git config user.name t && " +
+      "echo hi > README.md && git add . && git commit -qm init",
+    { cwd: ALPHA },
+  );
+  fs.mkdirSync(BETA); // plain dir, no .git → validates RED
+  fs.mkdirSync(path.join(ROOT, ".hidden-dir")); // dotfile → hidden
+  fs.symlinkSync(ALPHA, path.join(ROOT, "zeta-link")); // symlink → listed + flagged
+  fs.writeFileSync(path.join(ROOT, "notes.txt"), "notes"); // file → filtered out
+});
+
+test.afterAll(() => {
+  fs.rmSync(ROOT, { recursive: true, force: true });
+});
+
+test("explorer lists dirs-only, navigates, and picks a git repo through validation", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await expect(page.getByText("Daemon: connected")).toBeVisible({ timeout: 10_000 });
+
+  await page.getByRole("button", { name: "New Run" }).click();
+  await expect(page.getByTestId("target-repo-input")).toBeVisible();
+
+  // Open-at (Option B): type the seed root, then open the explorer there.
+  await page.getByTestId("target-repo-input").fill(ROOT);
+  await page.getByTestId("repo-browse-trigger").click();
+
+  await expect(page.getByTestId("repo-browser-modal")).toBeVisible();
+  await expect(page.getByTestId("repo-browse-path")).toHaveText(ROOT);
+
+  // Listing: dirs only, dotfile + file excluded, alpha-sorted.
+  const entries = page.getByTestId("repo-browse-entry");
+  await expect(entries).toHaveCount(3);
+  await expect(entries.nth(0)).toContainText("alpha-project");
+  await expect(entries.nth(1)).toContainText("beta-plain");
+  await expect(entries.nth(2)).toContainText("zeta-link");
+  await expect(page.getByText(".hidden-dir")).toHaveCount(0);
+  await expect(page.getByText("notes.txt")).toHaveCount(0);
+  // alpha-project is git-flagged; zeta-link is symlink-flagged.
+  await expect(page.getByTestId("repo-browse-git-dot")).toHaveCount(1);
+  await expect(page.getByTestId("repo-browse-symlink")).toHaveCount(1);
+
+  // Navigate into the git repo, then pick the current folder.
+  await entries.nth(0).click();
+  await expect(page.getByTestId("repo-browse-path")).toHaveText(ALPHA);
+  await page.getByTestId("repo-browse-select").click();
+
+  // Explorer closes; the New Run modal stays open; the pick flowed through onChange.
+  await expect(page.getByTestId("repo-browser-modal")).toBeHidden();
+  await expect(page.getByTestId("target-repo-input")).toHaveValue(ALPHA);
+
+  // The pick reused the existing validation/branch-loading flow — no new logic.
+  await expect(page.getByTestId("repo-valid")).toBeVisible({ timeout: 10_000 });
+  await expect(page.getByTestId("source-branch-select")).toBeVisible();
+  await expect(page.getByTestId("source-branch-select")).toContainText("main");
+});
+
+test("picking a non-git folder validates red (any folder pickable, git gates)", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await expect(page.getByText("Daemon: connected")).toBeVisible({ timeout: 10_000 });
+
+  await page.getByRole("button", { name: "New Run" }).click();
+  await expect(page.getByTestId("target-repo-input")).toBeVisible();
+
+  await page.getByTestId("target-repo-input").fill(ROOT);
+  await page.getByTestId("repo-browse-trigger").click();
+  await expect(page.getByTestId("repo-browser-modal")).toBeVisible();
+
+  // beta-plain has no .git → pickable, but validates red.
+  await page.getByTestId("repo-browse-entry").nth(1).click();
+  await expect(page.getByTestId("repo-browse-path")).toHaveText(BETA);
+  await page.getByTestId("repo-browse-select").click();
+
+  await expect(page.getByTestId("target-repo-input")).toHaveValue(BETA);
+  await expect(page.getByTestId("repo-error")).toBeVisible({ timeout: 10_000 });
+  await expect(page.getByTestId("repo-valid")).toBeHidden();
+});
+
+test("nested modal: Escape closes only the explorer, never the parent", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await expect(page.getByText("Daemon: connected")).toBeVisible({ timeout: 10_000 });
+
+  await page.getByRole("button", { name: "New Run" }).click();
+  await expect(page.getByTestId("target-repo-input")).toBeVisible();
+
+  await page.getByTestId("target-repo-input").fill(ROOT);
+  await page.getByTestId("repo-browse-trigger").click();
+  await expect(page.getByTestId("repo-browser-modal")).toBeVisible();
+
+  await page.keyboard.press("Escape");
+  await expect(page.getByTestId("repo-browser-modal")).toBeHidden();
+  // The parent New Run modal must still be open.
+  await expect(page.getByTestId("target-repo-input")).toBeVisible();
+
+  // Backdrop click also closes only the explorer.
+  await page.getByTestId("repo-browse-trigger").click();
+  await expect(page.getByTestId("repo-browser-modal")).toBeVisible();
+  await page.getByTestId("repo-browse-backdrop").click({ position: { x: 5, y: 5 } });
+  await expect(page.getByTestId("repo-browser-modal")).toBeHidden();
+  await expect(page.getByTestId("target-repo-input")).toBeVisible();
+});

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -350,6 +350,41 @@ export async function fetchRecentRepos(): Promise<string[]> {
   return resp.json();
 }
 
+// --- Filesystem explorer (#131) ---
+
+export interface BrowseEntry {
+  name: string;
+  path: string;
+  is_git_repo: boolean;
+  is_symlink: boolean;
+}
+
+export interface BrowseResponse {
+  /** The directory actually listed (canonicalized). */
+  path: string;
+  /** Parent directory, or null only at the filesystem root. */
+  parent: string | null;
+  entries: BrowseEntry[];
+  /** True iff the post-filter directory count exceeded the listing cap. */
+  truncated: boolean;
+  /** Non-null when the dir was navigable but unlistable (e.g. permission denied). */
+  error: string | null;
+}
+
+/**
+ * List the directories inside `path` (or the daemon's default root when omitted).
+ * 200 always carries the {@link BrowseResponse} shape — including the in-body
+ * `error` for navigable-but-unlistable dirs — so callers branch on `data.error`.
+ * Only genuine caller/system bugs (relative path → 400, collapsed default → 500)
+ * throw here.
+ */
+export async function browseRepos(path?: string): Promise<BrowseResponse> {
+  const qs = path ? `?path=${encodeURIComponent(path)}` : "";
+  const resp = await fetch(`${BASE}/repos/browse${qs}`);
+  if (!resp.ok) throw new Error(`GET /repos/browse failed: ${resp.status}`);
+  return resp.json();
+}
+
 export async function killNode(
   runId: string,
   nodeId: string,

--- a/frontend/src/components/RepoCombobox.test.tsx
+++ b/frontend/src/components/RepoCombobox.test.tsx
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import RepoCombobox from "./RepoCombobox";
+import type { BrowseResponse } from "../api";
+import { browseRepos } from "../api";
+
+vi.mock("../api", () => ({
+  browseRepos: vi.fn(),
+}));
+
+const mockedBrowse = vi.mocked(browseRepos);
+
+const ROOT_RESPONSE: BrowseResponse = {
+  path: "/home/user/projects",
+  parent: "/home/user",
+  entries: [
+    { name: "alpha", path: "/home/user/projects/alpha", is_git_repo: true, is_symlink: false },
+    { name: "beta", path: "/home/user/projects/beta", is_git_repo: false, is_symlink: false },
+    {
+      name: "zeta-link",
+      path: "/home/user/projects/zeta-link",
+      is_git_repo: false,
+      is_symlink: true,
+    },
+  ],
+  truncated: false,
+  error: null,
+};
+
+function renderCombobox(overrides: Partial<Parameters<typeof RepoCombobox>[0]> = {}) {
+  const props = {
+    value: "",
+    onChange: vi.fn(),
+    recentRepos: [],
+    repoValid: null,
+    repoValidating: false,
+    repoError: null,
+    borderClass: "",
+    ...overrides,
+  };
+  render(<RepoCombobox {...props} />);
+  return props;
+}
+
+beforeEach(() => {
+  mockedBrowse.mockReset();
+  mockedBrowse.mockResolvedValue(ROOT_RESPONSE);
+});
+
+describe("RepoCombobox filesystem explorer (#131)", () => {
+  it("renders the loupe trigger", () => {
+    renderCombobox();
+    expect(screen.getByTestId("repo-browse-trigger")).toBeInTheDocument();
+  });
+
+  it("opens the explorer on loupe click and lists the entries", async () => {
+    renderCombobox();
+    fireEvent.click(screen.getByTestId("repo-browse-trigger"));
+
+    expect(await screen.findByTestId("repo-browser-modal")).toBeInTheDocument();
+    const rows = await screen.findAllByTestId("repo-browse-entry");
+    expect(rows).toHaveLength(3);
+    // alpha-project carries the git indicator, only one of the three.
+    expect(screen.getAllByTestId("repo-browse-git-dot")).toHaveLength(1);
+    // zeta-link carries the symlink marker, only one of the three.
+    expect(screen.getAllByTestId("repo-browse-symlink")).toHaveLength(1);
+    // Breadcrumb shows the listed directory.
+    expect(screen.getByTestId("repo-browse-path")).toHaveTextContent("/home/user/projects");
+  });
+
+  it("opens at the current absolute value (Option B)", async () => {
+    renderCombobox({ value: "/abs/repo/path" });
+    fireEvent.click(screen.getByTestId("repo-browse-trigger"));
+    await waitFor(() => expect(mockedBrowse).toHaveBeenCalledWith("/abs/repo/path"));
+  });
+
+  it("opens at the backend default when the value is not an absolute path", async () => {
+    renderCombobox({ value: "not-absolute" });
+    fireEvent.click(screen.getByTestId("repo-browse-trigger"));
+    await waitFor(() => expect(mockedBrowse).toHaveBeenCalledWith(undefined));
+  });
+
+  it("navigates into a clicked entry", async () => {
+    renderCombobox();
+    fireEvent.click(screen.getByTestId("repo-browse-trigger"));
+    const rows = await screen.findAllByTestId("repo-browse-entry");
+    fireEvent.click(rows[0]); // alpha
+    await waitFor(() =>
+      expect(mockedBrowse).toHaveBeenCalledWith("/home/user/projects/alpha"),
+    );
+  });
+
+  it("navigates up to the parent when up is clicked", async () => {
+    renderCombobox();
+    fireEvent.click(screen.getByTestId("repo-browse-trigger"));
+    await screen.findByTestId("repo-browser-modal");
+    fireEvent.click(screen.getByTestId("repo-browse-up"));
+    await waitFor(() => expect(mockedBrowse).toHaveBeenCalledWith("/home/user"));
+  });
+
+  it("disables the up affordance at the filesystem root (parent null)", async () => {
+    mockedBrowse.mockResolvedValue({ ...ROOT_RESPONSE, path: "/", parent: null });
+    renderCombobox();
+    fireEvent.click(screen.getByTestId("repo-browse-trigger"));
+    await screen.findByTestId("repo-browser-modal");
+    await waitFor(() => expect(screen.getByTestId("repo-browse-up")).toBeDisabled());
+  });
+
+  it("picks the current directory through onChange and closes", async () => {
+    const props = renderCombobox();
+    fireEvent.click(screen.getByTestId("repo-browse-trigger"));
+    await screen.findByTestId("repo-browser-modal");
+    fireEvent.click(screen.getByTestId("repo-browse-select"));
+    expect(props.onChange).toHaveBeenCalledWith("/home/user/projects");
+    await waitFor(() =>
+      expect(screen.queryByTestId("repo-browser-modal")).not.toBeInTheDocument(),
+    );
+  });
+
+  it("closes only the explorer on backdrop click", async () => {
+    renderCombobox();
+    fireEvent.click(screen.getByTestId("repo-browse-trigger"));
+    await screen.findByTestId("repo-browser-modal");
+    fireEvent.click(screen.getByTestId("repo-browse-backdrop"));
+    await waitFor(() =>
+      expect(screen.queryByTestId("repo-browser-modal")).not.toBeInTheDocument(),
+    );
+  });
+
+  it("closes the explorer on Escape", async () => {
+    renderCombobox();
+    fireEvent.click(screen.getByTestId("repo-browse-trigger"));
+    await screen.findByTestId("repo-browser-modal");
+    fireEvent.keyDown(document, { key: "Escape" });
+    await waitFor(() =>
+      expect(screen.queryByTestId("repo-browser-modal")).not.toBeInTheDocument(),
+    );
+  });
+
+  it("surfaces an in-body error inline and keeps the breadcrumb", async () => {
+    mockedBrowse.mockResolvedValue({
+      path: "/home/user/projects/noaccess",
+      parent: "/home/user/projects",
+      entries: [],
+      truncated: false,
+      error: "permission denied: /home/user/projects/noaccess",
+    });
+    renderCombobox();
+    fireEvent.click(screen.getByTestId("repo-browse-trigger"));
+    expect(await screen.findByTestId("repo-browse-error")).toHaveTextContent(
+      "permission denied",
+    );
+    // Breadcrumb is preserved — the user is not stranded on a blank pane.
+    expect(screen.getByTestId("repo-browse-path")).toHaveTextContent(
+      "/home/user/projects/noaccess",
+    );
+  });
+
+  it("shows a truncation note when the listing is capped", async () => {
+    mockedBrowse.mockResolvedValue({ ...ROOT_RESPONSE, truncated: true });
+    renderCombobox();
+    fireEvent.click(screen.getByTestId("repo-browse-trigger"));
+    expect(await screen.findByText(/Showing first 1000/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/RepoCombobox.tsx
+++ b/frontend/src/components/RepoCombobox.tsx
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Check } from "lucide-react";
+import { ArrowUp, Check, Folder, FolderGit2, Link2, Search } from "lucide-react";
+import { browseRepos } from "../api";
+import type { BrowseEntry } from "../api";
 
 interface Props {
   value: string;
@@ -34,6 +36,16 @@ export default function RepoCombobox({
   const containerRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
+  // --- Filesystem explorer (#131): a self-contained nested modal. Picking flows
+  // through the existing `onChange` → validation path, so no new selection logic. ---
+  const [explorerOpen, setExplorerOpen] = useState(false);
+  const [currentDir, setCurrentDir] = useState("");
+  const [parent, setParent] = useState<string | null>(null);
+  const [entries, setEntries] = useState<BrowseEntry[]>([]);
+  const [browseLoading, setBrowseLoading] = useState(false);
+  const [browseError, setBrowseError] = useState<string | null>(null);
+  const [truncated, setTruncated] = useState(false);
+
   const filtered = recentRepos.filter((r) =>
     r.toLowerCase().includes(value.toLowerCase()),
   );
@@ -53,6 +65,43 @@ export default function RepoCombobox({
     [onChange],
   );
 
+  // Navigate the explorer to `path` (omit → backend default root). Always lands on a
+  // 200 shape: an in-body `error` (e.g. permission denied) is surfaced inline while
+  // the breadcrumb is kept, so the user is never stranded on a blank pane.
+  const navigateTo = useCallback(async (path?: string) => {
+    setBrowseLoading(true);
+    setBrowseError(null);
+    try {
+      const data = await browseRepos(path);
+      setCurrentDir(data.path);
+      setParent(data.parent);
+      setEntries(data.entries);
+      setTruncated(data.truncated);
+      setBrowseError(data.error);
+    } catch (e) {
+      setBrowseError(e instanceof Error ? e.message : "Failed to browse");
+    } finally {
+      setBrowseLoading(false);
+    }
+  }, []);
+
+  const openExplorer = useCallback(() => {
+    setDropdownOpen(false);
+    setExplorerOpen(true);
+    // Open-at (Option B): a current absolute value opens at that dir (usually the
+    // last repo, pre-filled from recents); else the backend default. A stale value
+    // degrades gracefully — the backend clamps a non-existent path to the default.
+    const start = value.trim().startsWith("/") ? value.trim() : undefined;
+    void navigateTo(start);
+  }, [value, navigateTo]);
+
+  const pickCurrentDir = useCallback(() => {
+    // Pick the folder the user is standing in (git-dotted or not — ADR-0001: any
+    // folder is pickable; the authoritative git check gates it downstream).
+    onChange(currentDir);
+    setExplorerOpen(false);
+  }, [currentDir, onChange]);
+
   useEffect(() => {
     function handleClickOutside(e: MouseEvent) {
       if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
@@ -63,28 +112,57 @@ export default function RepoCombobox({
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, []);
 
+  // Recents-dropdown Escape — gated on `!explorerOpen` so it never fires while the
+  // explorer is the top layer (the two sibling document listeners fire in
+  // registration order, so `stopPropagation` alone would be unreliable here).
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
-      if (e.key === "Escape") setDropdownOpen(false);
+      if (e.key === "Escape" && !explorerOpen) setDropdownOpen(false);
     }
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
-  }, []);
+  }, [explorerOpen]);
+
+  // Explorer Escape — active only while open; closes the explorer alone. The parent
+  // New Run modal has no Escape handler, so it is never at risk.
+  useEffect(() => {
+    if (!explorerOpen) return;
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        setExplorerOpen(false);
+      }
+    }
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [explorerOpen]);
 
   return (
     <div ref={containerRef} className="relative">
-      <input
-        ref={inputRef}
-        id="target-repo"
-        className={`w-full rounded-md border bg-bg-3 px-2.5 py-1.5 font-mono text-fg placeholder:text-fg-4 transition-colors focus:outline-none ${borderClass}`}
-        style={{ fontSize: "12px" }}
-        placeholder="/path/to/your/repo"
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        onFocus={handleFocus}
-        data-testid="target-repo-input"
-        autoComplete="off"
-      />
+      <div className="relative">
+        <input
+          ref={inputRef}
+          id="target-repo"
+          className={`w-full rounded-md border bg-bg-3 px-2.5 py-1.5 pr-9 font-mono text-fg placeholder:text-fg-4 transition-colors focus:outline-none ${borderClass}`}
+          style={{ fontSize: "12px" }}
+          placeholder="/path/to/your/repo"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          onFocus={handleFocus}
+          data-testid="target-repo-input"
+          autoComplete="off"
+        />
+        <button
+          type="button"
+          onClick={openExplorer}
+          className="absolute inset-y-0 right-0 flex items-center px-2.5 text-fg-4 transition-colors hover:text-fg-2"
+          title="Browse for a repository"
+          aria-label="Browse for a repository"
+          data-testid="repo-browse-trigger"
+        >
+          <Search size={14} />
+        </button>
+      </div>
       {repoValidating && (
         <span className="text-fg-4" style={{ fontSize: "10.5px" }}>
           Validating...
@@ -140,6 +218,132 @@ export default function RepoCombobox({
             );
           })}
         </ul>
+      )}
+
+      {/* Filesystem explorer (#131). Own full-screen backdrop at z-[60] (above the
+          parent modal's z-50); `stopPropagation` keeps a backdrop click from bubbling
+          up the React tree to the parent New Run modal's close handler. */}
+      {explorerOpen && (
+        <div
+          className="fixed inset-0 z-[60] flex items-center justify-center bg-black/50"
+          data-testid="repo-browse-backdrop"
+          onClick={(e) => {
+            e.stopPropagation();
+            setExplorerOpen(false);
+          }}
+        >
+          <div
+            className="flex max-h-[70vh] w-[460px] flex-col rounded-lg border border-line bg-bg-4 shadow-xl"
+            data-testid="repo-browser-modal"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {/* Header: up affordance + breadcrumb */}
+            <div className="flex items-center gap-2 border-b border-line px-3 py-2">
+              <button
+                type="button"
+                onClick={() => parent && void navigateTo(parent)}
+                disabled={parent == null}
+                className="flex shrink-0 items-center justify-center rounded p-1 text-fg-3 transition-colors hover:bg-bg-5 hover:text-fg disabled:opacity-30 disabled:hover:bg-transparent"
+                title="Up one level"
+                aria-label="Up one level"
+                data-testid="repo-browse-up"
+              >
+                <ArrowUp size={14} />
+              </button>
+              <span
+                className="min-w-0 flex-1 truncate font-mono text-fg-2"
+                style={{ fontSize: "11.5px" }}
+                title={currentDir}
+                data-testid="repo-browse-path"
+              >
+                {currentDir || "…"}
+              </span>
+            </div>
+
+            {/* Body: entry list */}
+            <div className="min-h-[120px] flex-1 overflow-y-auto">
+              {browseError && (
+                <div
+                  className="px-3 py-2 font-mono text-st-failed"
+                  style={{ fontSize: "11px" }}
+                  data-testid="repo-browse-error"
+                >
+                  {browseError}
+                </div>
+              )}
+              {truncated && (
+                <div className="px-3 py-1 text-fg-4" style={{ fontSize: "10.5px" }}>
+                  Showing first 1000 folders
+                </div>
+              )}
+              {browseLoading && entries.length === 0 && (
+                <div className="px-3 py-2 text-fg-4" style={{ fontSize: "11.5px" }}>
+                  Loading…
+                </div>
+              )}
+              {!browseLoading && !browseError && entries.length === 0 && (
+                <div className="px-3 py-2 text-fg-4" style={{ fontSize: "11.5px" }}>
+                  No subfolders here
+                </div>
+              )}
+              <ul>
+                {entries.map((entry) => (
+                  <li key={entry.path}>
+                    <button
+                      type="button"
+                      onClick={() => void navigateTo(entry.path)}
+                      className="flex w-full items-center gap-2 px-3 py-1.5 text-left transition-colors hover:bg-bg-5"
+                      data-testid="repo-browse-entry"
+                    >
+                      {entry.is_git_repo ? (
+                        <FolderGit2
+                          size={14}
+                          className="shrink-0 text-acc"
+                          data-testid="repo-browse-git-dot"
+                        />
+                      ) : (
+                        <Folder size={14} className="shrink-0 text-fg-4" />
+                      )}
+                      <span className="min-w-0 flex-1 truncate font-mono text-fg" style={{ fontSize: "12px" }}>
+                        {entry.name}
+                      </span>
+                      {entry.is_symlink && (
+                        <Link2
+                          size={12}
+                          className="shrink-0 text-fg-4"
+                          aria-label="symlink"
+                          data-testid="repo-browse-symlink"
+                        />
+                      )}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            {/* Footer: cancel + pick-current-dir */}
+            <div className="flex items-center justify-end gap-2 border-t border-line px-3 py-2">
+              <button
+                type="button"
+                onClick={() => setExplorerOpen(false)}
+                className="rounded-md px-3 py-1.5 text-fg-3 transition-colors hover:text-fg"
+                style={{ fontSize: "11.5px" }}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={pickCurrentDir}
+                disabled={!currentDir}
+                className="rounded-md bg-acc px-3 py-1.5 font-medium text-bg-1 transition-opacity hover:opacity-90 disabled:opacity-40"
+                style={{ fontSize: "11.5px" }}
+                data-testid="repo-browse-select"
+              >
+                Select this folder
+              </button>
+            </div>
+          </div>
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary

Implements **#131** — a filesystem explorer to browse and visually pick a repo in the New Run flow.

- New backend route `GET /repos/browse` (`resolve_browse_root` + `repos_browse` in `lib.rs`) — lists directories only, hides dotfiles, flags `.git`-presence (git repo hint) and symlinks, follows symlinks for the is-dir decision via free `std::fs::metadata` (avoids the `DirEntry::metadata` lstat trap), caps at 1000 entries with `truncated`, case-insensitive sort, in-body `error` on HTTP 200 for navigable-but-unlistable dirs.
- `resolve_browse_root` fork handling: relative path -> `Relative` (400), file -> parent, non-existent -> clamp to default, `None` -> `$HOME -> repo_root -> /` chain.
- Frontend explorer in `RepoCombobox` (loupe trigger opens a nested modal): breadcrumb navigation, drill in / up, git-repo green markers, "Select this folder" -> `onChange` -> existing validate flow; Escape and backdrop clicks close only the explorer, leaving the parent New Run modal open.
- Tests: L1 (`resolve_browse_root`, 7 cases) + L3a integration (`tests/repos_browse.rs`, 4 cases), `RepoCombobox.test.tsx` (vitest), e2e spec, and an L5 scenario.

## Verification

Tester verdict: **Pass**. Frontend `typecheck` / `lint` / `build` clean; backend `cargo build --tests` 0 errors. Explorer behaviors confirmed in a real Chrome session against the shipped `RepoCombobox` (open-at-prefilled-path, dirs-only + dotfiles hidden + sort, git markers, drill/up, pick -> green "Valid git repository" + branches, Escape/backdrop isolation).

Version bumped `0.1.32` -> `0.1.33`.

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)
