### PR TITLE
fix(library): surface Copy on scope:"library" rows (#273)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1688,7 +1688,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "0.1.34"
+version = "0.1.35"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "0.1.34"
+version = "0.1.35"
 license = "MIT"
 
 [workspace.dependencies]

--- a/frontend/src/components/UnifiedLeftPanel.test.tsx
+++ b/frontend/src/components/UnifiedLeftPanel.test.tsx
@@ -405,6 +405,57 @@ describe("UnifiedLeftPanel library duplicate (#224)", () => {
     expect(screen.queryByTestId("library-duplicate-button")).not.toBeInTheDocument();
     expect(screen.queryByTestId("library-only-entry")).not.toBeInTheDocument();
   });
+
+  // #273 — regression: once /pipelines began merging library-scope entries
+  // (#216), a user-scoped library pipeline appears in BOTH lists with the same
+  // name. The block-2 name-absence filter then drops it (its name matches a
+  // /pipelines row), so the only Copy button used to vanish. Block 1 must now
+  // carry its own Copy on scope:"library" rows.
+  it("keeps the Copy button reachable when a scope:'library' row also sits in /pipelines (#273)", async () => {
+    // The regression's exact condition: same NAME in BOTH lists.
+    mockFetchPipelines.mockResolvedValueOnce([
+      {
+        id: "fixture",
+        name: "fixture", // == libOnly.name
+        scope: "library", // the regression's scope
+        path: "/home/u/.pdo/library/pipelines/fixture.yaml",
+        node_count: 3,
+        modified: null,
+        variables: {},
+      } satisfies PipelineListEntry,
+    ]);
+    renderWithLib(); // libraryPipelines={[libOnly]}, opens Library tab
+    await screen.findByText("fixture"); // block-1 scope:library row mounts
+    // DOM-PRESENCE, not hover-visual: jsdom does not apply Tailwind group-hover.
+    // libOnly is filtered out of block 2 (name match) ⇒ exactly one button.
+    expect(screen.getByTestId("library-duplicate-button")).toBeInTheDocument();
+    expect(screen.queryByTestId("library-only-entry")).not.toBeInTheDocument();
+  });
+
+  it("the #273 block-1 Copy calls duplicateLibraryPipeline(id) and refreshes", async () => {
+    const onChanged = vi.fn();
+    mockFetchPipelines.mockResolvedValueOnce([
+      {
+        id: "fixture",
+        name: "fixture",
+        scope: "library",
+        path: "/home/u/.pdo/library/pipelines/fixture.yaml",
+        node_count: 3,
+        modified: null,
+        variables: {},
+      } satisfies PipelineListEntry,
+    ]);
+    renderWithLib(onChanged);
+    await screen.findByText("fixture");
+
+    fireEvent.click(screen.getByTestId("library-duplicate-button"));
+
+    // p.id is the HOME library file-stem — the same id the endpoint resolves.
+    await waitFor(() =>
+      expect(mockDuplicateLibraryPipeline).toHaveBeenCalledWith("fixture"),
+    );
+    await waitFor(() => expect(onChanged).toHaveBeenCalled());
+  });
 });
 
 // #227 — Deleting a starred pipeline must be able to cascade-remove its durable

--- a/frontend/src/components/UnifiedLeftPanel.tsx
+++ b/frontend/src/components/UnifiedLeftPanel.tsx
@@ -438,6 +438,35 @@ export default function UnifiedLeftPanel({
                 >
                   {badge.label}
                 </span>
+                {/* #273: scope:"library" rows now appear here in block 1 (the
+                    /pipelines scope-merge from #216 means they no longer fall
+                    through to the library-only block below). Surface the same
+                    Copy affordance #224 shipped, gated on identity (scope), not
+                    the name-absence filter that block 2 uses. `p.id` is the HOME
+                    library file-stem — duplicateLibraryPipeline resolves it. */}
+                {p.scope === "library" && (
+                  <span
+                    className="hidden shrink-0 group-hover:inline-flex"
+                    data-testid="library-duplicate-button"
+                    onClick={async (e) => {
+                      e.stopPropagation();
+                      if (duplicatingId === p.id) return;
+                      setDuplicatingId(p.id);
+                      try {
+                        await duplicateLibraryPipeline(p.id);
+                        onLibraryPipelinesChanged(); // refresh; do NOT auto-open the copy
+                      } catch { /* ignore */ }
+                      finally { setDuplicatingId(null); }
+                    }}
+                    role="button"
+                    title="Duplicate pipeline"
+                  >
+                    <Copy
+                      size={14}
+                      className="text-fg-4 transition-colors hover:text-acc"
+                    />
+                  </span>
+                )}
                 <span
                   className="hidden shrink-0 group-hover:inline-flex"
                   onClick={(e) => {


### PR DESCRIPTION
## What

Surface the **Copy** (duplicate) affordance on `scope:"library"` rows in the
main Library list (block 1 of `UnifiedLeftPanel`).

## Why

After #216 merged HOME-library entries into `GET /pipelines` as
`scope:"library"`, user-scoped library pipelines appear in **both** lists. The
library-only block (block 2) is gated by a name-absence filter that then always
empties for them, so the duplicate button (shipped in #224) never mounted and
**Copy became unreachable** in the UI — the regression #273 reports.

## Fix (Shape A, additive)

Render a `Copy` span on block-1 rows gated on `p.scope === "library"`, mirroring
block 2's #224 handler exactly (busy-guard, `duplicateLibraryPipeline(p.id)`,
refresh, same testid/icon). Block 2's name-absence filter is left intact
(load-bearing: prevents double rows). Delete/star paths untouched. Frontend-only.

## Tests

- Two new vitest regression cases reproducing the exact condition (same name in
  both lists): reachability + block-1 Copy calls `duplicateLibraryPipeline(id)`
  and refreshes.
- Tester verified end-to-end against the live daemon (chrome-devtools): Copy
  reachable on a library row, duplicate written to disk, original state restored.

Closes #273

🤖 Generated with [Claude Code](https://claude.com/claude-code)
