### PR TITLE
refactor(daemon): make prompt_augmenter::build_preamble pure (#274)

### DIFF
--- a/.pdo/pipelines/review-loop.yaml
+++ b/.pdo/pipelines/review-loop.yaml
@@ -1,0 +1,72 @@
+name: review-loop
+version: "1.0"
+nodes:
+  - id: start
+    name: Start
+    type: start
+    outputs:
+      - { name: user_prompt, side: right }
+  - id: qdtXejYS
+    name: loop
+    type: loop
+    max_iter: 3
+    inputs:
+      - { name: in, side: left }
+      - { name: break, side: left }
+    outputs:
+      - { name: body, side: right }
+      - { name: done, side: right }
+    view: { x: 100, y: 160 }
+  - id: XBG5Cxkn
+    name: implementer
+    type: code-mutating
+    inputs:
+      - { name: task, side: left }
+    outputs:
+      - { name: code, side: right }
+    view: { x: 335, y: 249 }
+  - id: Qws9KzRZ
+    name: reviewer
+    type: doc-only
+    inputs:
+      - { name: code, side: left }
+    outputs:
+      - name: review
+        side: right
+        frontmatter:
+          verdict:
+            type: enum
+            allowed: [PASS, APPROVED, FAIL, NEEDS_WORK]
+    view: { x: 500, y: 100 }
+  - id: tmkRzihO
+    name: switch
+    type: switch
+    inputs:
+      - { name: in, side: left }
+    outputs:
+      - name: pass
+        side: right
+        when:
+          verdict:
+                      in: [PASS, APPROVED]
+      - { name: default, side: right }
+    view: { x: 700, y: 100 }
+  - id: end
+    name: End
+    type: end
+    inputs:
+      - { name: result, side: left }
+auto_merge_resolver: true
+edges:
+  - source: { node: start, port: user_prompt }
+    target: { node: qdtXejYS, port: in }
+  - source: { node: qdtXejYS, port: body }
+    target: { node: XBG5Cxkn, port: task }
+  - source: { node: XBG5Cxkn, port: code }
+    target: { node: Qws9KzRZ, port: code }
+  - source: { node: Qws9KzRZ, port: review }
+    target: { node: tmkRzihO, port: in }
+  - source: { node: tmkRzihO, port: pass }
+    target: { node: qdtXejYS, port: break }
+  - source: { node: qdtXejYS, port: done }
+    target: { node: end, port: result }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1688,7 +1688,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "0.1.35"
+version = "0.1.36"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "0.1.35"
+version = "0.1.36"
 license = "MIT"
 
 [workspace.dependencies]

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -3076,6 +3076,28 @@ async fn spawn_node(
         None => HashMap::new(),
     };
 
+    // Precompute whether the Start prompt carries content so `build_preamble`
+    // stays pure (#274). Gate on `!prompt_required` (the only branch that
+    // consults it), NOT on the edge-based `is_entry_node` — that would regress
+    // the `task`-port fallback (a node with no incoming edge still reads from
+    // `_input`). On a genuine I/O error, fail toward "prompt present" and log:
+    // a false negative would silently discard the run's actual brief.
+    let start_prompt_present = if spawn_ctx.pipeline.prompt_required {
+        false // value is never consulted for prompt-required pipelines — skip the read
+    } else {
+        match prompt_augmenter::read_start_prompt_present(spawn_ctx.artifacts_dir) {
+            Ok(present) => present,
+            Err(e) => {
+                warn!(
+                    "entry-node input read failed (run {run_id} node {} iter {iter}): {e}; \
+                     assuming a prompt is present",
+                    node.id
+                );
+                true // fail toward "prompt present" — never tell the agent "no prompt" on an I/O error
+            }
+        }
+    };
+
     let aug_ctx = prompt_augmenter::AugmentContext {
         pipeline: spawn_ctx.pipeline,
         node,
@@ -3087,6 +3109,7 @@ async fn spawn_node(
         foreach_context,
         source_worktree_dir: has_sub_worktree.then_some(working_dir.as_path()),
         input_images,
+        start_prompt_present,
         source_iters,
     };
 

--- a/crates/pdo-daemon/src/node_primitives.rs
+++ b/crates/pdo-daemon/src/node_primitives.rs
@@ -101,6 +101,27 @@ pub fn start_node(params: &StartNodeParams<'_>) -> StartNodeResult {
     let canonical_path = pipeline::canonical_prompt_path(params.pipeline_path, params.node_id);
     let role_prompt = std::fs::read_to_string(&canonical_path).unwrap_or_default();
 
+    // Precompute the Start-prompt-present bool here too: the manual start/retry
+    // endpoints produce the entry-node preamble, so they must read it as well
+    // (#274). Same gating and error posture as the live spawn site.
+    let start_prompt_present = if params.pipeline.prompt_required {
+        false
+    } else {
+        match crate::prompt_augmenter::read_start_prompt_present(params.artifacts_dir) {
+            Ok(present) => present,
+            Err(e) => {
+                tracing::warn!(
+                    "entry-node input read failed (run {} node {} iter {}): {e}; \
+                     assuming a prompt is present",
+                    params.run_id,
+                    params.node_id,
+                    params.iter
+                );
+                true
+            }
+        }
+    };
+
     let aug_ctx = crate::prompt_augmenter::AugmentContext {
         pipeline: params.pipeline,
         node,
@@ -112,6 +133,7 @@ pub fn start_node(params: &StartNodeParams<'_>) -> StartNodeResult {
         foreach_context: None,
         source_worktree_dir: has_sub_worktree.then_some(working_dir.as_path()),
         input_images: Vec::new(),
+        start_prompt_present,
         source_iters: crate::input_resolution::resolved_source_iters(
             params.pipeline,
             params.run_state,

--- a/crates/pdo-daemon/src/prompt_augmenter.rs
+++ b/crates/pdo-daemon/src/prompt_augmenter.rs
@@ -41,6 +41,11 @@ pub struct AugmentContext<'a> {
     /// pipeline worktree (doc-only, switch, loop, etc.).
     pub source_worktree_dir: Option<&'a Path>,
     pub input_images: Vec<String>,
+    /// Whether the Start node's user prompt (`_input/output.md`) carries any
+    /// non-whitespace content. Precomputed by the daemon (it owns the artifacts
+    /// dir and handles the read error); `build_preamble` stays pure. Only consulted
+    /// for the prompt-optional entry-node preamble (#158, #274).
+    pub start_prompt_present: bool,
     /// Canonical input resolution (#194 / #210): for each upstream source node,
     /// the iteration whose artifacts this NodeRun reads (the source's latest
     /// COMPLETED iteration, per `input_resolution`). A source absent from the
@@ -76,13 +81,15 @@ pub fn discover_input_images(artifacts_dir: &Path) -> Vec<String> {
     images
 }
 
-/// Whether the Start-sourced user prompt (`_input/output.md`) carries any
-/// non-whitespace content. Used to adapt the entry-node preamble for
-/// prompt-optional pipelines (#158).
-fn start_input_has_content(artifacts_dir: &Path) -> bool {
+/// Read whether the Start-sourced user prompt (`_input/output.md`) carries any
+/// non-whitespace content. `Ok(false)` when the file is absent — the expected
+/// prompt-optional case, not an error. `Err` only on a genuine I/O failure, so the
+/// caller can surface it instead of silently reporting "no prompt" (#274).
+pub fn read_start_prompt_present(artifacts_dir: &Path) -> std::io::Result<bool> {
     match std::fs::read_to_string(crate::blackboard::input_path(artifacts_dir)) {
-        Ok(text) => !text.trim().is_empty(),
-        Err(_) => false,
+        Ok(text) => Ok(!text.trim().is_empty()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(e) => Err(e),
     }
 }
 
@@ -202,7 +209,7 @@ pub fn build_preamble(ctx: &AugmentContext<'_>) -> String {
             // must source its own work; when a prompt is supplied it is merely
             // additional info layered on the node's own brief.
             if input.from_start && !ctx.pipeline.prompt_required {
-                if start_input_has_content(ctx.artifacts_dir) {
+                if ctx.start_prompt_present {
                     preamble.push_str(&format!(
                         "- `{}` (additional info): read `{}`. \
                          This is supplementary context — your role prompt below is the primary brief.\n",
@@ -577,6 +584,7 @@ mod tests {
             foreach_context: None,
             source_worktree_dir: None,
             input_images: Vec::new(),
+            start_prompt_present: false,
             source_iters: HashMap::new(),
         }
     }
@@ -1426,19 +1434,12 @@ mod tests {
         );
     }
 
-    // --- entry-node preamble adapts to prompt_required (#158) ---
-
-    /// Build a `_input/output.md` artifact with the given content under a fresh
-    /// temp artifacts dir, returning the dir (kept alive by the TempDir guard).
-    fn artifacts_with_input(content: Option<&str>) -> tempfile::TempDir {
-        let tmp = tempfile::tempdir().unwrap();
-        let input_dir = tmp.path().join("_input");
-        std::fs::create_dir_all(&input_dir).unwrap();
-        if let Some(text) = content {
-            std::fs::write(input_dir.join("output.md"), text).unwrap();
-        }
-        tmp
-    }
+    // --- entry-node preamble adapts to prompt_required (#158, #274) ---
+    //
+    // These are now pure string-in -> string-out: each mutates the precomputed
+    // `ctx.start_prompt_present` bool, no temp dir or FS access (#274). The matrix
+    // {prompt_required} x {start_prompt_present} collapses to 3 distinct phrasings
+    // because the bool is dead when a prompt is required.
 
     #[test]
     fn entry_preamble_tells_node_to_source_own_work_when_prompt_optional_and_empty() {
@@ -1446,9 +1447,8 @@ mod tests {
         pipeline.prompt_required = false;
         let node = &pipeline.nodes[0];
         let vars = HashMap::new();
-        let tmp = artifacts_with_input(None);
         let mut ctx = sample_ctx(&pipeline, node, &vars);
-        ctx.artifacts_dir = tmp.path();
+        ctx.start_prompt_present = false;
 
         let preamble = build_preamble(&ctx);
         assert!(
@@ -1463,9 +1463,8 @@ mod tests {
         pipeline.prompt_required = false;
         let node = &pipeline.nodes[0];
         let vars = HashMap::new();
-        let tmp = artifacts_with_input(Some("some extra context"));
         let mut ctx = sample_ctx(&pipeline, node, &vars);
-        ctx.artifacts_dir = tmp.path();
+        ctx.start_prompt_present = true;
 
         let preamble = build_preamble(&ctx);
         assert!(
@@ -1481,18 +1480,59 @@ mod tests {
     #[test]
     fn entry_preamble_unchanged_for_prompt_required_pipeline() {
         // The default (prompt-required) keeps the plain input label — neither the
-        // "additional info" nor the "source your own work" wording leaks in.
+        // "additional info" nor the "source your own work" wording leaks in, and
+        // the precomputed bool must not change that (it is dead for this branch).
         let pipeline = sample_pipeline();
         assert!(pipeline.prompt_required);
         let node = &pipeline.nodes[0];
         let vars = HashMap::new();
-        let tmp = artifacts_with_input(Some("do the task"));
-        let mut ctx = sample_ctx(&pipeline, node, &vars);
-        ctx.artifacts_dir = tmp.path();
 
-        let preamble = build_preamble(&ctx);
-        assert!(!preamble.contains("No prompt was provided"));
-        assert!(!preamble.contains("additional info"));
-        assert!(preamble.contains("## Inputs"));
+        for present in [false, true] {
+            let mut ctx = sample_ctx(&pipeline, node, &vars);
+            ctx.start_prompt_present = present;
+
+            let preamble = build_preamble(&ctx);
+            assert!(
+                !preamble.contains("No prompt was provided"),
+                "start_prompt_present={present} must not leak into a prompt-required pipeline"
+            );
+            assert!(
+                !preamble.contains("additional info"),
+                "start_prompt_present={present} must not leak into a prompt-required pipeline"
+            );
+            assert!(preamble.contains("## Inputs"));
+        }
+    }
+
+    // --- read_start_prompt_present reader (#274) ---
+
+    #[test]
+    fn read_start_prompt_present_true_when_content() {
+        let tmp = tempfile::tempdir().unwrap();
+        let input_dir = tmp.path().join("_input");
+        std::fs::create_dir_all(&input_dir).unwrap();
+        std::fs::write(input_dir.join("output.md"), "do the task").unwrap();
+
+        assert!(read_start_prompt_present(tmp.path()).unwrap());
+    }
+
+    #[test]
+    fn read_start_prompt_present_false_when_whitespace_only() {
+        let tmp = tempfile::tempdir().unwrap();
+        let input_dir = tmp.path().join("_input");
+        std::fs::create_dir_all(&input_dir).unwrap();
+        std::fs::write(input_dir.join("output.md"), "   \n").unwrap();
+
+        assert!(!read_start_prompt_present(tmp.path()).unwrap());
+    }
+
+    #[test]
+    fn read_start_prompt_present_false_when_file_absent() {
+        // A missing `_input/output.md` is the expected prompt-optional case, not
+        // an I/O error: NotFound maps to Ok(false), never Err.
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path()).unwrap();
+
+        assert!(!read_start_prompt_present(tmp.path()).unwrap());
     }
 }


### PR DESCRIPTION
## Summary

Makes `prompt_augmenter::build_preamble` a pure string-in → string-out function by hoisting the `_input/output.md` filesystem read out to both spawn sites. Closes #274.

- New `AugmentContext::start_prompt_present: bool`, precomputed by the daemon (which owns the artifacts dir and the read error). `build_preamble` no longer touches the filesystem.
- `start_input_has_content` → `read_start_prompt_present(artifacts_dir) -> io::Result<bool>`: `Ok(false)` on `NotFound` (the expected prompt-optional case), `Err` only on a genuine I/O failure.
- Both spawn sites (`lib.rs::spawn_node`, `node_primitives.rs::start_node`) gate the read on `!prompt_required` (preserving the `task`-port fallback) and, on a genuine I/O error, fail toward "prompt present" with a `warn!` instead of silently reporting "no prompt".
- The `prompt_augmenter` entry-node tests become pure (`ctx.start_prompt_present` toggled directly, no temp dirs).

## Out-of-scope but necessary

Restores `.pdo/pipelines/review-loop.yaml`, accidentally deleted in `e3cfb8b`. It is `include_str!`'d by three test modules (`lib.rs`, `pipeline.rs`, `pipeline_migrator.rs`), so `cargo test` does not compile on `main` without it. Restored **byte-identical** to `e3cfb8b^`.

## Verification

- `cargo build -p pdo-daemon` → clean.
- `cargo test -p pdo-daemon --lib 'prompt_augmenter::tests'` → 37 passed, 0 failed (pure unit tests; no daemon spawn).
- Tester verdict: **Pass** (behaviour-preserving on every happy path; the single intentional delta is the I/O-error path).

Includes version bump to v0.1.36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)