### PR TITLE
fix(lifecycle): capture diagnostic context at session-died detection (#234)

### DIFF
--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -5103,6 +5103,33 @@ fn branch_is_merged_into(repo_root: &std::path::Path, branch: &str, into: &str) 
 
 // --- Stale detection ---
 
+/// Read MemAvailable and SwapFree (KB) from /proc/meminfo (#234).
+/// Returns (None, None) if /proc/meminfo is unavailable.
+fn read_meminfo() -> (Option<u64>, Option<u64>) {
+    let body = match std::fs::read_to_string("/proc/meminfo") {
+        Ok(s) => s,
+        Err(_) => return (None, None),
+    };
+    let mut avail = None;
+    let mut swap = None;
+    for line in body.lines() {
+        if avail.is_none() && line.starts_with("MemAvailable:") {
+            if let Some(val) = line.split_whitespace().nth(1) {
+                avail = val.parse::<u64>().ok();
+            }
+        }
+        if swap.is_none() && line.starts_with("SwapFree:") {
+            if let Some(val) = line.split_whitespace().nth(1) {
+                swap = val.parse::<u64>().ok();
+            }
+        }
+        if avail.is_some() && swap.is_some() {
+            break;
+        }
+    }
+    (avail, swap)
+}
+
 async fn run_stale_detection(state: &AppState) {
     // Record liveness at sweep start (#251): a wedged sweep freezes this value
     // while an isolated panic still advances it, so `GET /stale/health` answers
@@ -5157,6 +5184,12 @@ async fn run_stale_detection(state: &AppState) {
         let pipeline_path = resolve_run_pipeline_path(&repo_root, run_id, &run_state.pipeline_name);
 
         let running = stale_detector::running_nodes(&run_state);
+        // Per-sweep trackers for diagnostics (#234).
+        let mut session_died_per_run: std::collections::HashMap<String, usize> =
+            std::collections::HashMap::new();
+        // Read /proc/meminfo once per sweep, not once per node.
+        let (mem_available_kb, swap_free_kb) = read_meminfo();
+
         for (node_id, iter) in &running {
             let node_type = find_node_type(&run_state, node_id);
             let is_cm = matches!(node_type, Some("code-mutating") | Some("merge"));
@@ -5200,7 +5233,20 @@ async fn run_stale_detection(state: &AppState) {
                 continue;
             }
 
-            let events = stale_detector::detection_events(&detection, run_id, node_id, *iter);
+            let mut events = stale_detector::detection_events(&detection, run_id, node_id, *iter);
+            // Enrich NodeFailed (SessionDied) payloads with diagnostics (#234).
+            if detection == stale_detector::Detection::SessionDied {
+                *session_died_per_run.entry(run_id.to_string()).or_insert(0) += 1;
+                let correlated = session_died_per_run.get(run_id).copied();
+                let diag = stale_detector::Diagnostics {
+                    tmux_server_alive: Some(tmux_session_manager::server_alive(&socket)),
+                    mem_available_kb,
+                    swap_free_kb,
+                    correlated_deaths: correlated,
+                };
+                stale_detector::attach_diagnostics(&mut events, &diag);
+            }
+
             for event in &events {
                 // Transition guard (#212): append_event re-validates against
                 // the freshly projected state, so a node that terminated

--- a/crates/pdo-daemon/src/stale_detector.rs
+++ b/crates/pdo-daemon/src/stale_detector.rs
@@ -167,6 +167,36 @@ pub fn running_nodes(run_state: &event_log::RunState) -> Vec<(String, i64)> {
         .collect()
 }
 
+/// Diagnostics captured at session-died detection time (#234).
+/// Pure data — all I/O is gathered by the caller in lib.rs before calling
+/// [`attach_diagnostics`].
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct Diagnostics {
+    /// Whether the tmux server/socket is alive (`tmux -L <socket> ls` rc).
+    pub tmux_server_alive: Option<bool>,
+    /// Available memory in KB from /proc/meminfo (MemAvailable).
+    pub mem_available_kb: Option<u64>,
+    /// Free swap in KB from /proc/meminfo (SwapFree).
+    pub swap_free_kb: Option<u64>,
+    /// How many of this run's running nodes also died in the same sweep.
+    pub correlated_deaths: Option<usize>,
+}
+
+/// Attach [`Diagnostics`] to `NodeFailed` events in-place.
+///
+/// Pure function: the caller has already gathered all I/O and passes the
+/// completed [`Diagnostics`] value. Only `NodeFailed` events are enriched;
+/// other event kinds are left untouched.
+pub fn attach_diagnostics(events: &mut [event_log::Event], diag: &Diagnostics) {
+    for event in events.iter_mut() {
+        if event.kind != event_log::EventKind::NodeFailed {
+            continue;
+        }
+        let payload = event.payload.get_or_insert_with(|| serde_json::json!({}));
+        payload["diagnostics"] = serde_json::json!(diag);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -529,5 +559,109 @@ mod tests {
             1,
             &artifacts_dir
         ));
+    }
+
+    // --- attach_diagnostics ---
+
+    #[test]
+    fn attach_diagnostics_enriches_node_failed_event() {
+        use crate::event_log::{Event, EventKind};
+
+        let mut events = vec![Event {
+            id: None,
+            run_id: "r1".into(),
+            ts: "2026-06-29T00:00:00Z".into(),
+            kind: EventKind::NodeFailed,
+            node_id: Some("n1".into()),
+            iter: Some(1),
+            payload: Some(serde_json::json!({ "reason": "session_died: ..." })),
+        }];
+
+        let diag = Diagnostics {
+            tmux_server_alive: Some(false),
+            mem_available_kb: Some(8_388_608),
+            swap_free_kb: Some(2_097_152),
+            correlated_deaths: Some(2),
+        };
+
+        attach_diagnostics(&mut events, &diag);
+
+        let payload = events[0].payload.as_ref().unwrap();
+        assert_eq!(payload["reason"], "session_died: ...");
+        let d = &payload["diagnostics"];
+        assert_eq!(d["tmux_server_alive"], serde_json::json!(false));
+        assert_eq!(d["mem_available_kb"], serde_json::json!(8_388_608));
+        assert_eq!(d["swap_free_kb"], serde_json::json!(2_097_152));
+        assert_eq!(d["correlated_deaths"], serde_json::json!(2));
+    }
+
+    #[test]
+    fn attach_diagnostics_skips_non_node_failed_events() {
+        use crate::event_log::{Event, EventKind};
+
+        let mut events = vec![Event {
+            id: None,
+            run_id: "r1".into(),
+            ts: "2026-06-29T00:00:00Z".into(),
+            kind: EventKind::NodeStale,
+            node_id: Some("n1".into()),
+            iter: Some(1),
+            payload: Some(serde_json::json!({ "reason": "idle" })),
+        }];
+
+        let diag = Diagnostics {
+            tmux_server_alive: Some(true),
+            mem_available_kb: None,
+            swap_free_kb: None,
+            correlated_deaths: None,
+        };
+
+        attach_diagnostics(&mut events, &diag);
+
+        let payload = events[0].payload.as_ref().unwrap();
+        // Non-NodeFailed events should NOT get diagnostics attached
+        assert!(payload.get("diagnostics").is_none());
+        assert_eq!(payload["reason"], "idle");
+    }
+
+    #[test]
+    fn attach_diagnostics_creates_payload_if_missing() {
+        use crate::event_log::{Event, EventKind};
+
+        let mut events = vec![Event {
+            id: None,
+            run_id: "r1".into(),
+            ts: "2026-06-29T00:00:00Z".into(),
+            kind: EventKind::NodeFailed,
+            node_id: Some("n1".into()),
+            iter: Some(1),
+            payload: None,
+        }];
+
+        let diag = Diagnostics {
+            tmux_server_alive: Some(true),
+            mem_available_kb: None,
+            swap_free_kb: None,
+            correlated_deaths: None,
+        };
+
+        attach_diagnostics(&mut events, &diag);
+
+        let payload = events[0].payload.as_ref().unwrap();
+        let d = &payload["diagnostics"];
+        assert_eq!(d["tmux_server_alive"], serde_json::json!(true));
+    }
+
+    #[test]
+    fn attach_diagnostics_empty_events_no_panic() {
+        let mut events: Vec<event_log::Event> = vec![];
+        let diag = Diagnostics {
+            tmux_server_alive: None,
+            mem_available_kb: None,
+            swap_free_kb: None,
+            correlated_deaths: None,
+        };
+        attach_diagnostics(&mut events, &diag);
+        assert!(events.is_empty());
     }
 }

--- a/crates/pdo-daemon/src/tmux_session_manager.rs
+++ b/crates/pdo-daemon/src/tmux_session_manager.rs
@@ -291,6 +291,16 @@ pub fn kill(socket: &str, session_name: &str) {
         .output();
 }
 
+/// Check whether the tmux server for a given socket is alive (#234).
+/// Runs `tmux -L <socket> ls` and returns true if the server responds.
+pub fn server_alive(socket: &str) -> bool {
+    tmux(socket)
+        .arg("ls")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
 /// Check whether a tmux session exists.
 pub fn session_exists(socket: &str, session_name: &str) -> bool {
     tmux(socket)


### PR DESCRIPTION
Closes #234

## What

Per the triage scoping (2026-06-25), this PR implements **Item 2** only: capture diagnostic context at `session_died` detection time, before reaping.

Three new fields are added to the `NodeFailed` event payload and logged at detection:

- **`tmux_server_alive`** — whether the tmux server/socket is still reachable (`tmux -L <socket> ls` rc). Instantly classifies every occurrence in the issue history.
- **`mem_available_kb` / `swap_free_kb`** — raw `/proc/meminfo` snapshot so OOM pressure is on the record without kernel-log access.
- **`correlated_deaths`** — count of this run's running nodes also session-dead in the same sweep.

## How

Three files changed:

1. **`tmux_session_manager.rs`** — new `server_alive()` function (mirrors `session_exists()` pattern, uses `tmux -L <socket> ls`).
2. **`stale_detector.rs`** — new `Diagnostics` struct + pure `attach_diagnostics()` helper. 4 new unit tests.
3. **`lib.rs`** — `read_meminfo()` helper reads `/proc/meminfo` once per sweep. `run_stale_detection` gathers diagnostics and enriches `NodeFailed` events before append.

## Verification

- `cargo check --lib` passes with no new warnings
- All 29 stale_detector tests pass (4 new + 25 existing)
- Pre-existing clippy lint (`unnecessary_sort_by` at lib.rs:1009) is unrelated to these changes

## Platform note

Full test suite cannot run on Windows (frontend build dependencies, native tmux commands). CI on Linux is the real verification gate. All pure-logic changes compile and unit-test cleanly.
