### PR TITLE
feat(daemon): deterministic placeholder name for prompt-less runs (#184)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -424,6 +424,16 @@ Plusieurs Runs du même pipeline (ou de pipelines différents) peuvent tourner s
 
 `<run-id>` = slug `<timestamp>-<short-uuid>` pour rester lisible humainement et garanti unique.
 
+**Nom placeholder (placeholder name)** :
+Nom lisible posé par le daemon au spawn du Run, déterministe et immédiat (dérivé du timestamp du
+run-id), garanti présent même pour un Run prompt-less ou déclenché par Trigger.
+_Éviter_ : nom temporaire, titre par défaut.
+
+**Nom descriptif (descriptive name)** :
+Nom lisible posé best-effort par le Pipeline Manager dans son propre tour, une fois qu'il sait ce que
+fait le Run ; remplace le placeholder s'il aboutit, sans jamais le supprimer (un Run a toujours un nom).
+_Éviter_ : nom final, nom auto, rename automatique.
+
 ### Statistiques de Run
 
 Le panneau d'info d'un Run expose un petit bloc de stats (cf. #100). Trois métriques retenues ; le **coût** (tokens/$) est **hors-scope** — aucune télémétrie de coût fiable n'existe côté machine utilisateur (la télémétrie Claude Code y est redirigée).
@@ -518,6 +528,7 @@ Agent conversationnel attaché à un Pipeline Run. Permet à l'utilisateur de **
 
 - **Un manager par Run.** Spawn automatique au démarrage du Run dans une session tmux dédiée nommée `pdo-mgr-<run-id>`. Persiste tant que le Run n'est pas cleanup (donc aussi après success/failed/blocked, pour interrogation post-mortem).
 - **Pas de polling actif.** Le manager ne tourne effectivement que quand l'utilisateur lui parle. Quand attaché, il lit l'état frais à la demande.
+- **Nommage descriptif dans son propre tour.** Quand un Run porte un *nom placeholder* (posé par le daemon au spawn, cf. *cycle de vie*), le manager lui donne un *nom descriptif* via `rename_run` **best-effort, à l'intérieur de son propre tour** — une fois qu'il sait ce que fait le Run, jamais réveillé par le daemon ni par un nœud (cohérent avec « Pas de polling actif »). Pour un Run prompt-less purement non-attendu, le manager n'a souvent jamais le contexte : le placeholder persiste, et c'est le comportement voulu (#184).
 
 ### Implémentation
 
@@ -542,6 +553,7 @@ Toutes exposées comme endpoints `POST /runs/<id>/commands` du daemon :
 | `mark_node_done` | Force la complétion d'un NodeRun (cas typique : nœud `interactive: true` que l'utilisateur signale fini) |
 | `inject_artifact` | Pose un artefact à la main dans le Blackboard |
 | `cleanup_run` | Supprime branches, worktrees, artefacts, événements |
+| `rename_run` | Donne au Run un nom descriptif (remplace le nom placeholder posé au spawn) |
 
 L'effet de chaque commande est l'**append d'un événement** dans l'event log. Le runtime consomme ces événements et agit en conséquence.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1688,7 +1688,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "0.1.39"
+version = "0.1.40"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "0.1.39"
+version = "0.1.40"
 license = "MIT"
 
 [workspace.dependencies]

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -4095,6 +4095,33 @@ fn validate_run_input(prompt_required: bool, input: &str) -> Result<(), String> 
     Ok(())
 }
 
+/// Deterministic placeholder display name for a run created with neither a
+/// user-supplied name nor any input to summarise (the prompt-less / unattended
+/// case, #184). Derived from the run-id's own `YYYYMMDD-HHMMSS` timestamp prefix
+/// — no extra clock read, so it is deterministic and matches the run-id. run-ids
+/// are always `YYYYMMDD-HHMMSS-xxxxxxx` (≥ 23 ASCII chars), so `[..15]` is the
+/// timestamp and cannot panic on a char boundary.
+fn placeholder_run_name(run_id: &str) -> String {
+    format!("Untitled run {}", &run_id[..15])
+}
+
+/// Decide how the daemon should treat naming for a run at spawn (#184).
+///
+/// Three mutually-exclusive cases, gated on `req.input` (NOT on the pipeline's
+/// `prompt_required` flag): a user-supplied name always wins; otherwise an empty
+/// input means there is nothing to summarise yet, so the daemon sets a
+/// deterministic placeholder and the manager renames best-effort later; a
+/// non-empty input lets the manager derive the name immediately from `_input`.
+fn run_name_hint(name: Option<&str>, input: &str) -> prompt_augmenter::RunNameHint {
+    if name.is_some_and(|n| !n.is_empty()) {
+        prompt_augmenter::RunNameHint::UserProvided
+    } else if input.trim().is_empty() {
+        prompt_augmenter::RunNameHint::Placeholder
+    } else {
+        prompt_augmenter::RunNameHint::DeriveFromInput
+    }
+}
+
 async fn create_run_core(
     state: &AppState,
     req: CreateRunRequest,
@@ -4238,10 +4265,18 @@ async fn create_run_inner(
     if let Some(ref branch) = req.source_branch {
         run_payload["source_branch"] = serde_json::json!(branch);
     }
-    if let Some(ref name) = req.name {
-        if !name.is_empty() {
-            run_payload["name"] = serde_json::json!(name);
-        }
+    // Naming decision (#184), shared between the payload write here and the
+    // manager spawn below so they can never disagree. The user's name wins; with
+    // no name, an empty input gets a deterministic placeholder (the prompt-less
+    // case), and a non-empty input is left unnamed so the manager derives it.
+    let name_hint = run_name_hint(req.name.as_deref(), &req.input);
+    let display_name: Option<String> = match name_hint {
+        prompt_augmenter::RunNameHint::UserProvided => req.name.clone(),
+        prompt_augmenter::RunNameHint::Placeholder => Some(placeholder_run_name(&run_id)),
+        prompt_augmenter::RunNameHint::DeriveFromInput => None,
+    };
+    if let Some(name) = &display_name {
+        run_payload["name"] = serde_json::json!(name);
     }
     if let Some(ref trigger_id) = req.triggered_by {
         if !trigger_id.is_empty() {
@@ -4320,8 +4355,7 @@ async fn create_run_inner(
 
     spawn_ready_after_event(state, &run_id).await;
 
-    let needs_name = req.name.as_ref().is_none_or(|n| n.is_empty());
-    spawn_manager_session(state, &run_id, &worktree_dir, needs_name);
+    spawn_manager_session(state, &run_id, &worktree_dir, name_hint);
 
     info!("Run {run_id} started for pipeline {}", pipeline.name);
 
@@ -4332,7 +4366,7 @@ fn spawn_manager_session(
     state: &AppState,
     run_id: &str,
     worktree_dir: &std::path::Path,
-    needs_name: bool,
+    name_hint: prompt_augmenter::RunNameHint,
 ) {
     let daemon_url = format!("http://localhost:{}", state.port);
 
@@ -4346,7 +4380,7 @@ fn spawn_manager_session(
     .unwrap_or_default();
 
     let full_prompt =
-        prompt_augmenter::build_manager_prompt(run_id, &daemon_url, &static_prompt, needs_name);
+        prompt_augmenter::build_manager_prompt(run_id, &daemon_url, &static_prompt, name_hint);
 
     let session_name = tmux_session_manager::manager_session_name(run_id);
     if let Err(e) = tmux_session_manager::spawn(
@@ -17025,6 +17059,43 @@ edges:
     #[test]
     fn prompt_optional_pipeline_still_accepts_a_prompt() {
         assert!(validate_run_input(false, "extra context").is_ok());
+    }
+
+    // --- placeholder display name for prompt-less runs (#184) ---
+
+    #[test]
+    fn placeholder_name_is_deterministic_from_run_id_timestamp() {
+        assert_eq!(
+            placeholder_run_name("20260629-150013-4a2f1c0"),
+            "Untitled run 20260629-150013"
+        );
+    }
+
+    #[test]
+    fn run_name_hint_matrix() {
+        use prompt_augmenter::RunNameHint;
+        // A user-supplied (non-empty) name always wins, regardless of input.
+        assert_eq!(
+            run_name_hint(Some("My Run"), ""),
+            RunNameHint::UserProvided
+        );
+        assert_eq!(
+            run_name_hint(Some("My Run"), "some input"),
+            RunNameHint::UserProvided
+        );
+        // No name + no (meaningful) input → deterministic placeholder.
+        assert_eq!(run_name_hint(None, ""), RunNameHint::Placeholder);
+        assert_eq!(run_name_hint(None, "   \n\t "), RunNameHint::Placeholder);
+        assert_eq!(run_name_hint(Some(""), ""), RunNameHint::Placeholder);
+        // No name but real input → manager derives the name from `_input`.
+        assert_eq!(
+            run_name_hint(None, "do a thing"),
+            RunNameHint::DeriveFromInput
+        );
+        assert_eq!(
+            run_name_hint(Some(""), "do a thing"),
+            RunNameHint::DeriveFromInput
+        );
     }
 
     // --- launch validation: dangling port references (#211 / #206) ---

--- a/crates/pdo-daemon/src/prompt_augmenter.rs
+++ b/crates/pdo-daemon/src/prompt_augmenter.rs
@@ -404,11 +404,25 @@ pub fn build_full_prompt(ctx: &AugmentContext<'_>, role_prompt: &str) -> String 
     format!("{preamble}---\n\n{role_prompt}")
 }
 
-pub fn build_manager_preamble(run_id: &str, daemon_url: &str, needs_name: bool) -> String {
-    let auto_name_instruction = if needs_name {
-        "\n**No display name was provided for this run.** As your first action, read the user input from the `_input` artifact and issue a `rename_run` command with a short, descriptive name (2–5 words) that captures the intent of the run.\n".to_string()
-    } else {
-        String::new()
+/// How the manager should treat run naming, decided by the daemon at spawn (#184).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum RunNameHint {
+    /// The user supplied a display name — do not rename.
+    UserProvided,
+    /// No name, but there is input to summarise — name it now from `_input`.
+    DeriveFromInput,
+    /// No name and no input; a deterministic placeholder was set. Rename best-effort,
+    /// only once enough is known, never by polling.
+    Placeholder,
+}
+
+pub fn build_manager_preamble(run_id: &str, daemon_url: &str, name_hint: RunNameHint) -> String {
+    let auto_name_instruction = match name_hint {
+        RunNameHint::UserProvided => String::new(),
+        RunNameHint::DeriveFromInput =>
+            "\n**No display name was provided for this run.** As your first action, read the user input from the `_input` artifact and issue a `rename_run` command with a short, descriptive name (2–5 words) that captures the intent of the run.\n".to_string(),
+        RunNameHint::Placeholder =>
+            "\n**This run has a placeholder display name** (`Untitled run …`) because it started without a prompt — its real purpose only becomes clear once its nodes do work. Do **not** rename it as your first action, and do **not** poll or block waiting for nodes. Instead, *when you have enough context to know what this run is actually doing* (typically once nodes have produced output, e.g. when the user later engages you), give it a short, descriptive name (2–5 words) via the `rename_run` command. This is best-effort: if you never gain enough context, leave the placeholder in place.\n".to_string(),
     };
 
     format!(
@@ -519,9 +533,9 @@ pub fn build_manager_prompt(
     run_id: &str,
     daemon_url: &str,
     role_prompt: &str,
-    needs_name: bool,
+    name_hint: RunNameHint,
 ) -> String {
-    let preamble = build_manager_preamble(run_id, daemon_url, needs_name);
+    let preamble = build_manager_preamble(run_id, daemon_url, name_hint);
     format!("{preamble}{role_prompt}")
 }
 
@@ -1157,15 +1171,19 @@ mod tests {
 
     #[test]
     fn manager_preamble_contains_run_id_and_daemon_url() {
-        let preamble =
-            build_manager_preamble("20260507-120000-abc1234", "http://localhost:5172", false);
+        let preamble = build_manager_preamble(
+            "20260507-120000-abc1234",
+            "http://localhost:5172",
+            RunNameHint::UserProvided,
+        );
         assert!(preamble.contains("20260507-120000-abc1234"));
         assert!(preamble.contains("http://localhost:5172"));
     }
 
     #[test]
     fn manager_preamble_contains_all_eight_commands() {
-        let preamble = build_manager_preamble("run-1", "http://localhost:5172", false);
+        let preamble =
+            build_manager_preamble("run-1", "http://localhost:5172", RunNameHint::UserProvided);
         for cmd in [
             "extend_cycle",
             "resume_run",
@@ -1185,7 +1203,8 @@ mod tests {
 
     #[test]
     fn manager_preamble_contains_curl_examples() {
-        let preamble = build_manager_preamble("run-1", "http://localhost:5172", false);
+        let preamble =
+            build_manager_preamble("run-1", "http://localhost:5172", RunNameHint::UserProvided);
         assert!(preamble.contains("curl -X POST"));
         assert!(preamble.contains("Content-Type: application/json"));
     }
@@ -1196,28 +1215,44 @@ mod tests {
             "run-1",
             "http://localhost:5172",
             "You are the Pipeline Manager.",
-            false,
+            RunNameHint::UserProvided,
         );
         assert!(prompt.contains("# Pipeline Manager Runtime Preamble"));
         assert!(prompt.contains("You are the Pipeline Manager."));
     }
 
     #[test]
-    fn manager_preamble_includes_auto_name_instruction_when_needs_name() {
-        let preamble = build_manager_preamble("run-1", "http://localhost:5172", true);
+    fn manager_preamble_derive_from_input_keeps_existing_instruction() {
+        let preamble =
+            build_manager_preamble("run-1", "http://localhost:5172", RunNameHint::DeriveFromInput);
         assert!(preamble.contains("No display name was provided"));
         assert!(preamble.contains("rename_run"));
     }
 
     #[test]
-    fn manager_preamble_omits_auto_name_instruction_when_name_provided() {
-        let preamble = build_manager_preamble("run-1", "http://localhost:5172", false);
+    fn manager_preamble_placeholder_is_best_effort_no_poll() {
+        let preamble =
+            build_manager_preamble("run-1", "http://localhost:5172", RunNameHint::Placeholder);
+        assert!(preamble.contains("placeholder display name"));
+        assert!(preamble.contains("rename_run"));
+        assert!(preamble.contains("best-effort"));
+        assert!(preamble.contains("do **not** poll"));
+        // The placeholder rename must NOT be front-loaded as the manager's first action.
+        assert!(!preamble.contains("As your first action"));
+    }
+
+    #[test]
+    fn manager_preamble_user_provided_has_no_naming_instruction() {
+        let preamble =
+            build_manager_preamble("run-1", "http://localhost:5172", RunNameHint::UserProvided);
         assert!(!preamble.contains("No display name was provided"));
+        assert!(!preamble.contains("placeholder display name"));
     }
 
     #[test]
     fn manager_preamble_cleanup_run_has_self_initiative_guardrail() {
-        let preamble = build_manager_preamble("run-1", "http://localhost:5172", false);
+        let preamble =
+            build_manager_preamble("run-1", "http://localhost:5172", RunNameHint::UserProvided);
         let section7 = preamble
             .split("### 7. cleanup_run")
             .nth(1)

--- a/crates/pdo-daemon/tests/run_naming.rs
+++ b/crates/pdo-daemon/tests/run_naming.rs
@@ -1,0 +1,181 @@
+//! Layer 3a — placeholder display name for prompt-less runs (#184).
+//!
+//! Boots a real TestDaemon over a `prompt_required: false` pipeline, then proves
+//! the daemon's naming decision end-to-end through `POST /runs` + `GET /runs`:
+//!
+//!   - empty input + no name  → the daemon writes a deterministic
+//!     `"Untitled run <ts>"` placeholder (the always-on win of #184).
+//!   - non-empty input + no name → NO placeholder; the name stays absent so the
+//!     Pipeline Manager can derive it from `_input`.
+//!
+//! The actual manager *rename* is best-effort real-`claude` behaviour and is not
+//! assertable here (the harness runs `sleep`, not `claude`); the preamble wording
+//! is covered by the pure tests in `prompt_augmenter`.
+
+mod common;
+
+use common::TestDaemon;
+
+const PIPELINE_NAME: &str = "naming-test";
+const NODE_ID: &str = "worker";
+
+// `prompt_required: false` so a run with empty input is accepted at creation
+// (the create handler rejects empty input on a prompt-required pipeline, #158).
+const PIPELINE_YAML: &str = r#"name: naming-test
+version: "1.0"
+prompt_required: false
+nodes:
+  - id: start
+    name: Start
+    type: start
+    outputs:
+      - name: user_prompt
+  - id: worker
+    name: worker
+    type: doc-only
+    inputs:
+      - name: task
+    outputs:
+      - name: result
+  - id: end
+    name: End
+    type: end
+    inputs:
+      - name: result
+edges:
+  - source: { node: start, port: user_prompt }
+    target: { node: worker, port: task }
+"#;
+
+const ROLE_PROMPT: &str = "You are a worker. Do the task.\n";
+
+fn seed(repo: &std::path::Path) -> anyhow::Result<()> {
+    let pipelines_dir = repo.join(".pdo").join("pipelines");
+    std::fs::create_dir_all(&pipelines_dir)?;
+    std::fs::write(
+        pipelines_dir.join(format!("{PIPELINE_NAME}.yaml")),
+        PIPELINE_YAML,
+    )?;
+
+    let prompts_dir = pipelines_dir.join(format!("{PIPELINE_NAME}.prompts"));
+    std::fs::create_dir_all(&prompts_dir)?;
+    std::fs::write(prompts_dir.join(format!("{NODE_ID}.md")), ROLE_PROMPT)?;
+
+    git_init_with_commit(repo)?;
+    Ok(())
+}
+
+fn git_init_with_commit(repo: &std::path::Path) -> anyhow::Result<()> {
+    let run = |args: &[&str]| -> anyhow::Result<()> {
+        let out = std::process::Command::new("git")
+            .args(args)
+            .current_dir(repo)
+            .output()?;
+        if !out.status.success() {
+            anyhow::bail!(
+                "git {:?} failed: {}",
+                args,
+                String::from_utf8_lossy(&out.stderr)
+            );
+        }
+        Ok(())
+    };
+    run(&["init", "-q", "-b", "main"])?;
+    run(&["config", "user.email", "test@example.com"])?;
+    run(&["config", "user.name", "Test"])?;
+    run(&["config", "commit.gpgsign", "false"])?;
+    std::fs::write(repo.join(".gitignore"), ".pdo/runs/\n")?;
+    run(&["add", "."])?;
+    run(&["commit", "-q", "-m", "init"])?;
+    Ok(())
+}
+
+/// `POST /runs` with the given body, asserting 201, returning the new run id.
+async fn create_run(daemon_url: &str, body: serde_json::Value) -> String {
+    let resp = reqwest::Client::new()
+        .post(format!("{daemon_url}/runs"))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 201, "POST /runs should succeed for {body}");
+    let json: serde_json::Value = resp.json().await.unwrap();
+    json["run_id"].as_str().unwrap().to_string()
+}
+
+/// Fetch `GET /runs` and return the entry for `run_id`.
+async fn run_entry(daemon_url: &str, run_id: &str) -> serde_json::Value {
+    let resp = reqwest::get(format!("{daemon_url}/runs")).await.unwrap();
+    assert_eq!(resp.status(), 200);
+    let body: Vec<serde_json::Value> = resp.json().await.unwrap();
+    body.into_iter()
+        .find(|r| r["run_id"] == run_id)
+        .unwrap_or_else(|| panic!("run {run_id} should appear in GET /runs"))
+}
+
+/// A prompt-less run (empty input, no name) gets a deterministic placeholder
+/// name written by the daemon at spawn — visible immediately in GET /runs.
+#[tokio::test]
+async fn prompt_less_run_gets_placeholder_name() {
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+
+    let run_id = create_run(
+        &daemon.url(),
+        serde_json::json!({ "pipeline": PIPELINE_NAME, "input": "" }),
+    )
+    .await;
+
+    let entry = run_entry(&daemon.url(), &run_id).await;
+    let name = entry["name"]
+        .as_str()
+        .expect("prompt-less run must carry a placeholder name in GET /runs");
+    assert!(
+        name.starts_with("Untitled run "),
+        "placeholder name should start with 'Untitled run ', got: {name:?}"
+    );
+    // The placeholder is derived from the run-id's own timestamp prefix.
+    assert_eq!(
+        name,
+        format!("Untitled run {}", &run_id[..15]),
+        "placeholder must match the run-id timestamp"
+    );
+}
+
+/// A run launched *with* input but no name gets NO placeholder — the name stays
+/// absent so the manager can derive it from `_input`. Gating is on the input,
+/// not on `prompt_required`.
+#[tokio::test]
+async fn run_with_input_but_no_name_has_no_placeholder() {
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+
+    let run_id = create_run(
+        &daemon.url(),
+        serde_json::json!({ "pipeline": PIPELINE_NAME, "input": "do a thing" }),
+    )
+    .await;
+
+    let entry = run_entry(&daemon.url(), &run_id).await;
+    assert!(
+        entry.get("name").is_none() || entry["name"].is_null(),
+        "run with input must NOT get a placeholder name, got: {:?}",
+        entry.get("name")
+    );
+}
+
+/// A user-supplied name is honoured verbatim and not overwritten by a placeholder.
+#[tokio::test]
+async fn user_named_run_keeps_its_name() {
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+
+    let run_id = create_run(
+        &daemon.url(),
+        serde_json::json!({ "pipeline": PIPELINE_NAME, "input": "", "name": "My Run" }),
+    )
+    .await;
+
+    let entry = run_entry(&daemon.url(), &run_id).await;
+    assert_eq!(
+        entry["name"], "My Run",
+        "a user-supplied name must be preserved"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #184.

A run created with no name and no input (the prompt-less / trigger-launched case) was nameless until a manager renamed it — and for unattended runs that never happened, leaving a raw run-id slice in the UI. This gives such runs a deterministic, human-readable placeholder at spawn.

- `placeholder_run_name(run_id)` → `"Untitled run <YYYYMMDD-HHMMSS>"` (pure, panic-safe ASCII slice).
- `run_name_hint(name, input)`: the three-way naming decision, gated on `input.trim().is_empty()` (**not** `prompt_required`). Computed once in `create_run_inner` and shared between the `RunStarted` payload write and the manager spawn so they can never disagree.
- `prompt_augmenter`: `needs_name: bool` → `RunNameHint` enum (`UserProvided` / `DeriveFromInput` / `Placeholder`) with a 3-state manager instruction. Placeholder wording is best-effort (no active polling per CONTEXT.md); a placeholder persisting on an unattended run is intended.
- `CONTEXT.md`: `rename_run` command row + placeholder/descriptive-name glossary + "pas de polling actif" cross-ref.
- Version bump 0.1.39 → 0.1.40.

No frontend change, no ADR.

## Tests

Pure `run_name_hint` matrix + placeholder unit test; `prompt_augmenter` preamble enum tests; `tests/run_naming.rs` layer-3a (prompt-less → placeholder, with-input → none, user name preserved). Tester verdict: **Pass** (daemon library builds clean; naming logic correct, gated on the right condition, single-sourced, panic-safe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)