### PR TITLE
refactor(daemon): extract run_advance module from lib.rs (#235)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1688,7 +1688,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "0.1.40"
+version = "0.1.41"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "0.1.40"
+version = "0.1.41"
 license = "MIT"
 
 [workspace.dependencies]

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -26,6 +26,7 @@ pub mod pipeline_migrator;
 mod pipeline_watcher;
 mod prompt_augmenter;
 mod pty_bridge;
+mod run_advance;
 #[allow(dead_code)]
 mod scheduler;
 mod scheduler_dispatcher;
@@ -3482,84 +3483,12 @@ async fn reload_run_state(
     Some((events, run_state))
 }
 
+/// Thin shim over the single-pass advancement tick now owned by
+/// [`run_advance::advance_run`] (#235). Kept under its original name so the many
+/// call sites (node-done, mark-node-done, pipeline-modification, run start) need
+/// no churn; the sequence itself lives in exactly one place.
 async fn spawn_ready_after_event(state: &AppState, run_id: &str) {
-    let events = match load_events(&state.db, run_id).await {
-        Ok(e) => e,
-        Err(e) => {
-            error!("spawn_ready_after_event: failed to load events for {run_id}: {e}");
-            return;
-        }
-    };
-    let Some(run_state) = event_log::project(&events) else {
-        return;
-    };
-
-    if run_state.status != event_log::RunStatus::Running
-        && run_state.status != event_log::RunStatus::AwaitingUser
-    {
-        return;
-    }
-
-    let repo_root = effective_repo_root(state, &run_state);
-    let pipeline_path = resolve_run_pipeline_path(&repo_root, run_id, &run_state.pipeline_name);
-    let Ok(yaml) = std::fs::read_to_string(&pipeline_path) else {
-        return;
-    };
-    let Ok(parse_result) = pipeline::parse_pipeline(&yaml) else {
-        return;
-    };
-    let pipeline = parse_result.pipeline;
-
-    let resolved_vars = resolve_run_variables(&pipeline, &events);
-    let ready = scheduler_dispatcher::compute_ready_to_spawn(&pipeline, &run_state);
-    let loop_seed_actions = scheduler::seed_pending_loops(&pipeline, &run_state, &resolved_vars);
-
-    if ready.is_empty() && loop_seed_actions.is_empty() {
-        // Pipeline was modified but no new nodes need spawning. If all current
-        // pipeline nodes are completed, re-complete the run so it doesn't stay
-        // dangling in Running state after a trivial YAML edit.
-        maybe_complete_run(state, run_id, &pipeline, &run_state).await;
-        return;
-    }
-
-    let worktree_dir = worktree_dir_for_run(&repo_root, run_id);
-    let artifacts_dir = worktree_dir.join(".pdo").join("artifacts");
-
-    let spawn_ctx = SpawnContext {
-        pipeline: &pipeline,
-        run_id,
-        pipeline_path: &pipeline_path,
-        worktree_dir: &worktree_dir,
-        artifacts_dir: &artifacts_dir,
-        resolved_vars: &resolved_vars,
-        repo_root: &repo_root,
-    };
-
-    for rs in &ready {
-        if let Some(node) = pipeline.nodes.iter().find(|n| n.id == rs.node_id) {
-            spawn_node(state, &spawn_ctx, node, rs.iter).await;
-        }
-    }
-
-    for action in &loop_seed_actions {
-        match action {
-            scheduler::SchedulerAction::LoopIterStarted { .. } => {
-                emit_loop_action(state, run_id, action).await;
-            }
-            scheduler::SchedulerAction::Spawn { node_id, iter } => {
-                if let Some(node) = pipeline.nodes.iter().find(|n| n.id == *node_id) {
-                    spawn_node(state, &spawn_ctx, node, *iter).await;
-                }
-            }
-            _ => {}
-        }
-    }
-
-    info!(
-        "spawn_ready_after_event: spawned {} node(s) and seeded {} loop action(s) for run {run_id}",
-        ready.len(),
-        loop_seed_actions.len()
-    );
+    run_advance::advance_run(state, run_id).await;
 }
 
 /// Re-drive nodes throttled into `waiting` by the session cap, across *all*
@@ -3614,37 +3543,11 @@ async fn retry_waiting_nodes(state: &AppState) {
             resolved_vars: &resolved_vars,
             repo_root: &repo_root,
         };
-        for rs in &waiting {
-            if let Some(node) = pipeline.nodes.iter().find(|n| n.id == rs.node_id) {
-                spawn_node(state, &spawn_ctx, node, rs.iter).await;
-            }
-        }
-    }
-}
-
-async fn maybe_complete_run(
-    state: &AppState,
-    run_id: &str,
-    pipeline: &pipeline::PipelineDef,
-    run_state: &event_log::RunState,
-) {
-    if run_state.status != event_log::RunStatus::Running {
-        return;
-    }
-    let pipeline_node_ids: Vec<String> = pipeline.nodes.iter().map(|n| n.id.clone()).collect();
-    if run_state.all_nodes_completed(&pipeline_node_ids) {
-        let run_completed = event_log::Event {
-            id: None,
-            run_id: run_id.to_string(),
-            ts: event_log::now_iso(),
-            kind: event_log::EventKind::RunCompleted,
-            node_id: None,
-            iter: None,
-            payload: None,
-        };
-        if let Err(e) = append_event(state, &run_completed).await {
-            error!("failed to append run_completed: {e}");
-        }
+        // Shares the spawn loop with `advance_run`, but keeps `waiting_nodes`
+        // as the ready set and stays out of `maybe_complete_run`: this is an
+        // all-runs admission sweep, and `RunCompleted` is not de-duped — only
+        // the per-run single-pass path may emit it (#235).
+        run_advance::spawn_each(state, &spawn_ctx, &waiting).await;
     }
 }
 
@@ -5899,26 +5802,9 @@ async fn handle_merge_resolver_done(
             }
         };
         if let Some(run_state) = event_log::project(&events) {
-            if run_state.status == event_log::RunStatus::Running {
-                let expected_node_ids: Vec<String> = if !run_state.node_defs.is_empty() {
-                    run_state.node_defs.iter().map(|nd| nd.id.clone()).collect()
-                } else {
-                    run_state.nodes.keys().cloned().collect()
-                };
-                let all_done = run_state.all_nodes_completed(&expected_node_ids);
-                if all_done {
-                    let run_completed = event_log::Event {
-                        id: None,
-                        run_id: run_id.to_string(),
-                        ts: event_log::now_iso(),
-                        kind: event_log::EventKind::RunCompleted,
-                        node_id: None,
-                        iter: None,
-                        payload: None,
-                    };
-                    let _ = append_event(state, &run_completed).await;
-                }
-            }
+            let expected_node_ids = run_advance::expected_completion_node_ids(&run_state);
+            run_advance::maybe_complete_run(state, run_id, &expected_node_ids, &run_state, false)
+                .await;
         }
     }
 
@@ -6177,28 +6063,9 @@ async fn node_done(
             return (StatusCode::OK, "ok").into_response();
         }
 
-        let expected_node_ids: Vec<String> = if !run_state.node_defs.is_empty() {
-            run_state.node_defs.iter().map(|nd| nd.id.clone()).collect()
-        } else {
-            run_state.nodes.keys().cloned().collect()
-        };
-
-        let all_done = run_state.all_nodes_completed(&expected_node_ids);
-
-        if all_done && run_state.status == event_log::RunStatus::Running {
-            let run_completed = event_log::Event {
-                id: None,
-                run_id: run_id.clone(),
-                ts: event_log::now_iso(),
-                kind: event_log::EventKind::RunCompleted,
-                node_id: None,
-                iter: None,
-                payload: None,
-            };
-            if let Err(e) = append_event(&state, &run_completed).await {
-                error!("failed to append run_completed: {e}");
-            }
-        }
+        let expected_node_ids = run_advance::expected_completion_node_ids(&run_state);
+        run_advance::maybe_complete_run(&state, &run_id, &expected_node_ids, &run_state, false)
+            .await;
     }
 
     info!("Node {node_id} completed in run {run_id}");
@@ -6894,33 +6761,20 @@ async fn run_command(
                     }
                 };
                 if let Some(run_state) = event_log::project(&events) {
-                    if run_state.status != event_log::RunStatus::Halted {
-                        let expected_node_ids: Vec<String> = if !run_state.node_defs.is_empty() {
-                            run_state.node_defs.iter().map(|nd| nd.id.clone()).collect()
-                        } else {
-                            run_state.nodes.keys().cloned().collect()
-                        };
-
-                        let all_done = run_state.all_nodes_completed(&expected_node_ids);
-
-                        if all_done
-                            && (run_state.status == event_log::RunStatus::Running
-                                || run_state.status == event_log::RunStatus::AwaitingUser)
-                        {
-                            let run_completed = event_log::Event {
-                                id: None,
-                                run_id: run_id.clone(),
-                                ts: event_log::now_iso(),
-                                kind: event_log::EventKind::RunCompleted,
-                                node_id: None,
-                                iter: None,
-                                payload: None,
-                            };
-                            if let Err(e) = append_event(&state, &run_completed).await {
-                                error!("failed to append run_completed: {e}");
-                            }
-                        }
-                    }
+                    // The just-finished node was interactive, so the run can
+                    // still project as `AwaitingUser` here — this path completes
+                    // on `Running` OR `AwaitingUser` (flag = true), unlike the
+                    // other single-pass sites (#235).
+                    let expected_node_ids =
+                        run_advance::expected_completion_node_ids(&run_state);
+                    run_advance::maybe_complete_run(
+                        &state,
+                        &run_id,
+                        &expected_node_ids,
+                        &run_state,
+                        true,
+                    )
+                    .await;
                 }
             }
 

--- a/crates/pdo-daemon/src/run_advance.rs
+++ b/crates/pdo-daemon/src/run_advance.rs
@@ -1,0 +1,418 @@
+//! Run advancement — the single-pass "tick" that drives a live Run forward.
+//!
+//! Issue #235: the sequence *load events → [`event_log::project`] → compute what
+//! is ready → [`spawn_node`] → maybe complete the Run* was re-implemented inline
+//! at several call sites in `lib.rs`. This module owns that single-pass tick
+//! behind one entry point — [`advance_run`] — so the sequence lives in exactly
+//! one place.
+//!
+//! Scope (slice-1): only the **single-pass** family is consolidated here. The
+//! two-pass *edge-firing* sites (`handle_node_completion` /
+//! `re_evaluate_after_command`) keep their load-bearing `reload_run_state`
+//! re-projection in `lib.rs` and are deferred to a tracked follow-up — they
+//! have no integration backstop yet (see the #235 plan, §5 follow-up A).
+//!
+//! Non-reentrancy (ADR-0009 / #122): [`advance_run`] calls [`spawn_node`], the
+//! pure `scheduler*` evaluators, and `append_event`/`emit_*` in a **linear**
+//! sequence. It never calls another advancement helper or itself, and never
+//! wires scheduler-driving code onto `event_tx`. [`spawn_node`] stays a leaf.
+
+use tracing::{error, info};
+
+use crate::event_log;
+use crate::pipeline;
+use crate::scheduler;
+use crate::scheduler_dispatcher;
+use crate::{
+    append_event, effective_repo_root, emit_loop_action, load_events, resolve_run_pipeline_path,
+    resolve_run_variables, spawn_node, worktree_dir_for_run, AppState, SpawnContext,
+};
+
+/// Advance one Run by a single tick: spawn whatever the scheduler says is ready
+/// (plus any pending loop-iteration seeds), or — when there is nothing left to
+/// spawn — complete the Run if every expected node is done.
+///
+/// A no-op unless the run is `Running` or `AwaitingUser`. This is the canonical
+/// body the inline `spawn_ready_after_event` used to carry; every former call
+/// site reaches it (directly or through the `spawn_ready_after_event` shim).
+pub(crate) async fn advance_run(state: &AppState, run_id: &str) {
+    let events = match load_events(&state.db, run_id).await {
+        Ok(e) => e,
+        Err(e) => {
+            error!("advance_run: failed to load events for {run_id}: {e}");
+            return;
+        }
+    };
+    let Some(run_state) = event_log::project(&events) else {
+        return;
+    };
+
+    if run_state.status != event_log::RunStatus::Running
+        && run_state.status != event_log::RunStatus::AwaitingUser
+    {
+        return;
+    }
+
+    let repo_root = effective_repo_root(state, &run_state);
+    let pipeline_path = resolve_run_pipeline_path(&repo_root, run_id, &run_state.pipeline_name);
+    let Ok(yaml) = std::fs::read_to_string(&pipeline_path) else {
+        return;
+    };
+    let Ok(parse_result) = pipeline::parse_pipeline(&yaml) else {
+        return;
+    };
+    let pipeline = parse_result.pipeline;
+
+    let resolved_vars = resolve_run_variables(&pipeline, &events);
+    let ready = scheduler_dispatcher::compute_ready_to_spawn(&pipeline, &run_state);
+    let loop_seed_actions = scheduler::seed_pending_loops(&pipeline, &run_state, &resolved_vars);
+
+    if ready.is_empty() && loop_seed_actions.is_empty() {
+        // Pipeline was modified but no new nodes need spawning. If all current
+        // pipeline nodes are completed, re-complete the run so it doesn't stay
+        // dangling in Running state after a trivial YAML edit. The expected set
+        // here is the *current* pipeline (post-modification), not the run's
+        // frozen snapshot — that is why this site derives ids from
+        // `pipeline.nodes` rather than [`expected_completion_node_ids`].
+        let pipeline_node_ids: Vec<String> =
+            pipeline.nodes.iter().map(|n| n.id.clone()).collect();
+        maybe_complete_run(state, run_id, &pipeline_node_ids, &run_state, false).await;
+        return;
+    }
+
+    let worktree_dir = worktree_dir_for_run(&repo_root, run_id);
+    let artifacts_dir = worktree_dir.join(".pdo").join("artifacts");
+
+    let spawn_ctx = SpawnContext {
+        pipeline: &pipeline,
+        run_id,
+        pipeline_path: &pipeline_path,
+        worktree_dir: &worktree_dir,
+        artifacts_dir: &artifacts_dir,
+        resolved_vars: &resolved_vars,
+        repo_root: &repo_root,
+    };
+
+    spawn_each(state, &spawn_ctx, &ready).await;
+
+    for action in &loop_seed_actions {
+        match action {
+            scheduler::SchedulerAction::LoopIterStarted { .. } => {
+                emit_loop_action(state, run_id, action).await;
+            }
+            scheduler::SchedulerAction::Spawn { node_id, iter } => {
+                if let Some(node) = pipeline.nodes.iter().find(|n| n.id == *node_id) {
+                    spawn_node(state, &spawn_ctx, node, *iter).await;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    info!(
+        "advance_run: spawned {} node(s) and seeded {} loop action(s) for run {run_id}",
+        ready.len(),
+        loop_seed_actions.len()
+    );
+}
+
+/// Spawn each node in `ready_set` (in the order given) through [`spawn_node`].
+///
+/// Shared by [`advance_run`] (ready set = [`scheduler_dispatcher::compute_ready_to_spawn`])
+/// and `retry_waiting_nodes` (ready set = [`scheduler_dispatcher::waiting_nodes`]).
+/// The caller-supplied order is honoured verbatim — under the session cap it
+/// decides who grabs the last free slot, so it must not be re-sorted here.
+/// `spawn_node` re-checks admission per node, so a node that still can't get a
+/// slot simply stays `Waiting`.
+pub(crate) async fn spawn_each(
+    state: &AppState,
+    spawn_ctx: &SpawnContext<'_>,
+    ready_set: &[scheduler_dispatcher::ReadySpawn],
+) {
+    for rs in ready_set {
+        if let Some(node) = spawn_ctx.pipeline.nodes.iter().find(|n| n.id == rs.node_id) {
+            spawn_node(state, spawn_ctx, node, rs.iter).await;
+        }
+    }
+}
+
+/// The set of node ids that must all be `Completed` for the Run to be done, as
+/// seen from a *node-done* site.
+///
+/// Prefer the run's own `node_defs` snapshot (frozen at run start, so a mid-run
+/// YAML edit can't change what "all done" means for an in-flight run); fall back
+/// to whatever nodes have appeared in the log when no snapshot exists (legacy
+/// runs). This reproduces the inline derivation the node-done / mark-node-done /
+/// merge-resolver-done sites used before consolidation.
+///
+/// NB: [`advance_run`]'s own completion branch deliberately uses a *different*
+/// set (`pipeline.nodes`, the post-modification pipeline) — see its comment.
+pub(crate) fn expected_completion_node_ids(run_state: &event_log::RunState) -> Vec<String> {
+    if !run_state.node_defs.is_empty() {
+        run_state.node_defs.iter().map(|nd| nd.id.clone()).collect()
+    } else {
+        run_state.nodes.keys().cloned().collect()
+    }
+}
+
+/// Pure decision: should a `RunCompleted` be emitted for this projected state?
+///
+/// True iff the run is in a completion-permitting status **and** every expected
+/// node is `Completed`. The permitted status is `Running`; setting
+/// `complete_when_awaiting_user` widens it to also include `AwaitingUser` — the
+/// `mark_node_done` path, where the just-finished node was interactive so the
+/// run can still project as `AwaitingUser` at the completion check. Every other
+/// caller permits only `Running`.
+///
+/// Pure over the projected `RunState` (AC#4: state in → decision out, no HTTP),
+/// so the gate is unit-tested directly below.
+pub(crate) fn should_complete_run(
+    run_state: &event_log::RunState,
+    expected_node_ids: &[String],
+    complete_when_awaiting_user: bool,
+) -> bool {
+    let status_permits = run_state.status == event_log::RunStatus::Running
+        || (complete_when_awaiting_user
+            && run_state.status == event_log::RunStatus::AwaitingUser);
+    status_permits && run_state.all_nodes_completed(expected_node_ids)
+}
+
+/// Emit exactly one `RunCompleted` if [`should_complete_run`] says so.
+///
+/// The single home for run-completion emission on the single-pass paths: the
+/// `advance_run` "nothing ready" branch and the three node-done sites
+/// (`node_done`, the `mark_node_done` command arm, `handle_merge_resolver_done`)
+/// all route here. `append_event` does **not** de-dup `RunCompleted`, so this
+/// must stay the only completion emitter on these paths — never call it from an
+/// all-runs/waiting sweep.
+pub(crate) async fn maybe_complete_run(
+    state: &AppState,
+    run_id: &str,
+    expected_node_ids: &[String],
+    run_state: &event_log::RunState,
+    complete_when_awaiting_user: bool,
+) {
+    if !should_complete_run(run_state, expected_node_ids, complete_when_awaiting_user) {
+        return;
+    }
+    let run_completed = event_log::Event {
+        id: None,
+        run_id: run_id.to_string(),
+        ts: event_log::now_iso(),
+        kind: event_log::EventKind::RunCompleted,
+        node_id: None,
+        iter: None,
+        payload: None,
+    };
+    if let Err(e) = append_event(state, &run_completed).await {
+        error!("failed to append run_completed: {e}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::event_log::{NodeDefInfo, NodeState, NodeStatus, RunState, RunStatus};
+    use crate::pipeline::{NodeDef, NodeType, PipelineDef, Port, PortType};
+    use crate::scheduler_dispatcher::compute_ready_to_spawn;
+    use pretty_assertions::assert_eq;
+    use std::collections::HashMap;
+
+    // --- fixtures -----------------------------------------------------------
+
+    fn doc_node(id: &str) -> NodeDef {
+        NodeDef {
+            id: id.into(),
+            name: id.into(),
+            node_type: NodeType::DocOnly,
+            inputs: vec![Port {
+                name: "task".into(),
+                repeated: false,
+                side: None,
+                port_type: PortType::Markdown,
+                frontmatter: None,
+                when: None,
+                description: None,
+            }],
+            outputs: vec![Port {
+                name: "out".into(),
+                repeated: false,
+                side: None,
+                port_type: PortType::Markdown,
+                frontmatter: None,
+                when: None,
+                description: None,
+            }],
+            interactive: false,
+            view: None,
+            max_iter: None,
+            over: None,
+        }
+    }
+
+    /// A pipeline of root DocOnly nodes (no edges) — every node is immediately
+    /// ready, so `compute_ready_to_spawn` reflects pure declaration order.
+    fn roots_pipeline(ids: &[&str]) -> PipelineDef {
+        PipelineDef {
+            name: "roots".into(),
+            version: None,
+            variables: HashMap::new(),
+            nodes: ids.iter().map(|id| doc_node(id)).collect(),
+            edges: Vec::new(),
+            loops: Vec::new(),
+            prompt_required: true,
+        }
+    }
+
+    fn node_def_info(id: &str) -> NodeDefInfo {
+        NodeDefInfo {
+            id: id.into(),
+            name: None,
+            node_type: "doc-only".into(),
+            view_x: None,
+            view_y: None,
+            inputs: Vec::new(),
+            outputs: Vec::new(),
+        }
+    }
+
+    fn completed_node(id: &str) -> NodeState {
+        NodeState {
+            node_id: id.into(),
+            status: NodeStatus::Completed,
+            iter: 1,
+            started_at: Some("t0".into()),
+            completed_at: Some("t1".into()),
+            failure_reason: None,
+            iterations: Vec::new(),
+            frontmatter_retries: 0,
+            frontmatter_violations: Vec::new(),
+        }
+    }
+
+    fn running_node(id: &str) -> NodeState {
+        NodeState {
+            node_id: id.into(),
+            status: NodeStatus::Running,
+            iter: 1,
+            started_at: Some("t0".into()),
+            completed_at: None,
+            failure_reason: None,
+            iterations: Vec::new(),
+            frontmatter_retries: 0,
+            frontmatter_violations: Vec::new(),
+        }
+    }
+
+    // --- ready-set order (AC#4: state in -> spawn order out) ---------------
+
+    #[test]
+    fn ready_set_preserves_yaml_declaration_order() {
+        // Declared gamma, alpha, beta (NOT alphabetical). The spawn order must
+        // follow YAML declaration order — it decides who grabs the last free
+        // slot under the session cap, so a HashSet/re-sort would be a regression.
+        let pipeline = roots_pipeline(&["gamma", "alpha", "beta"]);
+        let state = RunState::new("run-1".into(), "roots".into());
+
+        let ready: Vec<String> = compute_ready_to_spawn(&pipeline, &state)
+            .into_iter()
+            .map(|r| r.node_id)
+            .collect();
+
+        assert_eq!(ready, vec!["gamma", "alpha", "beta"]);
+    }
+
+    // --- expected-id derivation (protects the STEP-4 dup collapse) ---------
+
+    #[test]
+    fn expected_ids_prefer_node_defs_snapshot() {
+        // node_defs present -> authoritative, even when extra nodes leaked into
+        // the live `nodes` map. This is the frozen run snapshot.
+        let mut state = RunState::new("run-1".into(), "p".into());
+        state.node_defs = vec![node_def_info("a"), node_def_info("b")];
+        state.nodes.insert("a".into(), completed_node("a"));
+        state.nodes.insert("ghost".into(), running_node("ghost"));
+
+        let mut ids = expected_completion_node_ids(&state);
+        ids.sort();
+        assert_eq!(ids, vec!["a".to_string(), "b".to_string()]);
+    }
+
+    #[test]
+    fn expected_ids_fall_back_to_node_keys_when_no_snapshot() {
+        let mut state = RunState::new("run-1".into(), "p".into());
+        state.nodes.insert("x".into(), completed_node("x"));
+        state.nodes.insert("y".into(), running_node("y"));
+
+        let mut ids = expected_completion_node_ids(&state);
+        ids.sort();
+        assert_eq!(ids, vec!["x".to_string(), "y".to_string()]);
+    }
+
+    // --- completion gate (AC#4: state in -> complete? out, no HTTP) --------
+
+    fn state_with(status: RunStatus, nodes: &[(&str, NodeState)]) -> RunState {
+        let mut s = RunState::new("run-1".into(), "p".into());
+        s.status = status;
+        for (id, n) in nodes {
+            s.nodes.insert((*id).into(), n.clone());
+        }
+        s
+    }
+
+    #[test]
+    fn completes_when_running_and_all_expected_done() {
+        let s = state_with(
+            RunStatus::Running,
+            &[("a", completed_node("a")), ("b", completed_node("b"))],
+        );
+        let expected = vec!["a".to_string(), "b".to_string()];
+        assert!(should_complete_run(&s, &expected, false));
+    }
+
+    #[test]
+    fn stays_running_when_work_remains() {
+        let s = state_with(
+            RunStatus::Running,
+            &[("a", completed_node("a")), ("b", running_node("b"))],
+        );
+        let expected = vec!["a".to_string(), "b".to_string()];
+        assert!(!should_complete_run(&s, &expected, false));
+    }
+
+    #[test]
+    fn empty_expected_set_never_completes() {
+        // all_nodes_completed is false on an empty set (not vacuous-true): a run
+        // with no expected nodes is not "all done".
+        let s = state_with(RunStatus::Running, &[]);
+        assert!(!should_complete_run(&s, &[], false));
+    }
+
+    #[test]
+    fn awaiting_user_does_not_complete_by_default() {
+        // The single-pass / merge-resolver / node_done sites permit ONLY Running.
+        let s = state_with(RunStatus::AwaitingUser, &[("a", completed_node("a"))]);
+        let expected = vec!["a".to_string()];
+        assert!(!should_complete_run(&s, &expected, false));
+    }
+
+    #[test]
+    fn awaiting_user_completes_only_when_flag_set() {
+        // The mark_node_done command arm (interactive node just finished) opts in.
+        let s = state_with(RunStatus::AwaitingUser, &[("a", completed_node("a"))]);
+        let expected = vec!["a".to_string()];
+        assert!(should_complete_run(&s, &expected, true));
+    }
+
+    #[test]
+    fn terminal_status_never_completes_even_when_all_done() {
+        for status in [RunStatus::Completed, RunStatus::Failed, RunStatus::Halted] {
+            let s = state_with(status.clone(), &[("a", completed_node("a"))]);
+            let expected = vec!["a".to_string()];
+            assert!(
+                !should_complete_run(&s, &expected, true),
+                "status {status:?} must not re-complete"
+            );
+        }
+    }
+}


### PR DESCRIPTION
Extracts the Run-advancement logic out of the 15.6k-line `lib.rs` god module into a dedicated `run_advance` module, a behaviour-preserving backend-only refactor.

## What changed
- New `crates/pdo-daemon/src/run_advance.rs` (single-pass tick behind `advance_run`).
- `lib.rs`: `spawn_ready_after_event` becomes a one-line delegate to `run_advance::advance_run` (call sites unchanged).
- The three single-pass completion duplicates collapse into one `run_advance::maybe_complete_run`, preserving their original status gates exactly (`handle_merge_resolver_done` → false, `node_done` → false, `run_command`'s `mark_node_done` arm → true).
- `should_complete_run` is pure (state → bool); status gate widens to `AwaitingUser` only under `complete_when_awaiting_user`.
- The all-runs sweep (`retry_waiting_nodes`) stays out of `maybe_complete_run` to avoid the non-deduped `RunCompleted` emit.
- The two-pass edge-firing sites (`handle_node_completion`, `re_evaluate_after_command`) and the stall path (`run_stall_reason`) are intentionally left untouched (tracked follow-up).

## Verification
- `cargo build -p pdo-daemon` and `cargo clippy -p pdo-daemon`: 0 errors, 0 code warnings.
- 9 new pure no-HTTP unit tests cover the completion gate (AC#4).
- Validation node verdict: **Pass** (diff matches the behaviour-preservation contract line-for-line).

Also bumps workspace version to 0.1.41.

Closes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)