### PR TITLE
fix(inspector): default finished-run node to Run tab (#271)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1688,7 +1688,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "0.1.41"
+version = "0.1.42"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "0.1.41"
+version = "0.1.42"
 license = "MIT"
 
 [workspace.dependencies]

--- a/frontend/e2e/failed-node.spec.ts
+++ b/frontend/e2e/failed-node.spec.ts
@@ -92,10 +92,11 @@ async function createRunAndFailNode(baseURL: string, page: import("@playwright/t
   expect(failResp.status()).toBe(200);
 }
 
-// Open the run, select the worker node, and switch the right pane to the Run
-// inspector tab. A failed run is not "active", so the inspector defaults to the
-// Edit tab; the failure banner / Mark-complete button live in the Run pane
-// (NodeDetailPanel), so the test must click the Run tab to reveal them.
+// Open the run, select the worker node, and ensure the right pane shows the Run
+// inspector tab. Post-#271 a run tab (live OR terminal) defaults to the Run
+// pane, so clicking the Run tab here is a no-op on the already-active tab; we
+// keep the explicit click to stay robust to a stale per-tab override. The
+// failure banner / Mark-complete button live in the Run pane (NodeDetailPanel).
 async function selectFailedWorker(page: import("@playwright/test").Page) {
   await page.getByText(runId.slice(0, 8)).first().click({ timeout: 5_000 });
   await page.waitForTimeout(500);

--- a/frontend/e2e/inspector-tabs.spec.ts
+++ b/frontend/e2e/inspector-tabs.spec.ts
@@ -4,12 +4,13 @@ import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { openPipelineForEdit } from "./helpers";
 
-// Layer 3b — Inspector Run/Edit tabs (refs #68, refs #1).
+// Layer 3b — Inspector Run/Edit tabs (refs #68, refs #1, refs #271).
 // Verifies:
 // 1. Run and Edit tabs render when a node is selected.
 // 2. Default tab: active Run → Run; idle pipeline → Edit.
 // 3. Tab selection is sticky across node selections, resets on reload.
 // 4. Pending node shows placeholder and resolved inputs.
+// 5. Terminal run (failed) → Run tab default, not Edit (#271).
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const WORKSPACE_ROOT = path.resolve(__dirname, "..", "..");
@@ -181,6 +182,69 @@ test("idle pipeline: Edit tab default", async ({ page }) => {
     "data-active",
     "true",
   );
+});
+
+test("terminal run: clicking a node defaults to Run tab (#271)", async ({
+  page,
+  baseURL,
+}) => {
+  await page.goto("/");
+  await expect(page.getByText("Daemon: connected")).toBeVisible({
+    timeout: 10_000,
+  });
+
+  const resp = await page.request.post(`${baseURL}/runs`, {
+    multipart: { pipeline: PIPELINE_NAME, input: "terminal tab test" },
+  });
+  expect(resp.status()).toBe(201);
+  const { run_id } = await resp.json();
+
+  // Drive the run to a TERMINAL status by failing the running node.
+  await page.waitForTimeout(1_000);
+  const failResp = await page.request.post(
+    `${baseURL}/runs/${run_id}/nodes/worker-a/fail`,
+    { data: { reason: "e2e #271 terminal tab", iter: 1 } },
+  );
+  expect(failResp.ok()).toBeTruthy();
+
+  // Guard the trap: wait until the RUN status is genuinely terminal and is
+  // NOT one of the statuses that already defaulted to Run pre-fix
+  // ({running, awaiting_user, halted}). node_fail appends RunFailed, so the
+  // run resolves to `failed`.
+  await expect
+    .poll(
+      async () => {
+        const r = await page.request.get(`${baseURL}/runs/${run_id}`);
+        return (await r.json()).status as string;
+      },
+      { timeout: 10_000 },
+    )
+    .toMatch(/^(failed|completed|skipped|archived)$/);
+
+  // Open the terminal run and select a regular node.
+  await page.getByText(run_id.slice(0, 8)).first().click({ timeout: 5_000 });
+  await page.waitForTimeout(500);
+  await page
+    .locator('.react-flow__node[data-id="worker-a"]')
+    .click({ timeout: 5_000 });
+
+  // #271: terminal run now defaults to the Run tab (pre-fix this was Edit).
+  await expect(page.getByTestId("inspector-tab-run")).toHaveAttribute(
+    "data-active",
+    "true",
+    { timeout: 5_000 },
+  );
+  // And it shows the Outputs surface, not the edit form.
+  await expect(page.getByTestId("inspector-pane-run")).toBeVisible();
+
+  const { execSync } = await import("node:child_process");
+  for (const s of [`pdo-${run_id}-worker-a-iter-1`, `pdo-mgr-${run_id}`]) {
+    try {
+      execSync(`tmux kill-session -t ${s}`, { stdio: "ignore" });
+    } catch {
+      // ok — session may already be gone
+    }
+  }
 });
 
 test("pending node: Run tab shows placeholder and resolved inputs", async ({

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -255,7 +255,7 @@ export default function App() {
   }, []);
 
   const { activeTab: inspectorTab, setActiveTab: setInspectorTab } =
-    useInspectorTab(editActiveTabId, selectedRun?.status ?? null, isEditingRun);
+    useInspectorTab(editActiveTabId, isEditingRun);
 
   const runNode =
     selection.kind === "node" && selection.id && selectedRun

--- a/frontend/src/hooks/useInspectorTab.test.ts
+++ b/frontend/src/hooks/useInspectorTab.test.ts
@@ -3,51 +3,39 @@ import { describe, it, expect } from "vitest";
 import { useInspectorTab } from "./useInspectorTab";
 
 describe("useInspectorTab", () => {
-  it("defaults to 'run' when editing an active run", () => {
-    const { result } = renderHook(() =>
-      useInspectorTab("tab-1", "running", true),
-    );
+  // After #271 the default depends only on whether the tab is a run tab; run
+  // status no longer gates it. The status-named cases below intentionally
+  // exercise the same code path — they document that ALL run statuses (live
+  // and terminal) default to the Run tab, and guard against a status gate
+  // being re-introduced.
+  it("defaults to 'run' on a live run", () => {
+    const { result } = renderHook(() => useInspectorTab("tab-1", true));
     expect(result.current.activeTab).toBe("run");
   });
 
-  it("defaults to 'run' for awaiting_user status", () => {
-    const { result } = renderHook(() =>
-      useInspectorTab("tab-1", "awaiting_user", true),
-    );
+  it("defaults to 'run' on a completed run (#271)", () => {
+    const { result } = renderHook(() => useInspectorTab("tab-1", true));
     expect(result.current.activeTab).toBe("run");
   });
 
-  it("defaults to 'run' for halted status", () => {
-    const { result } = renderHook(() =>
-      useInspectorTab("tab-1", "halted", true),
-    );
+  it("defaults to 'run' on a failed/terminal run (#271)", () => {
+    const { result } = renderHook(() => useInspectorTab("tab-1", true));
     expect(result.current.activeTab).toBe("run");
   });
 
-  it("defaults to 'edit' when not editing a run", () => {
-    const { result } = renderHook(() =>
-      useInspectorTab("tab-1", null, false),
-    );
-    expect(result.current.activeTab).toBe("edit");
+  it("defaults to 'run' on an archived run (#271)", () => {
+    const { result } = renderHook(() => useInspectorTab("tab-1", true));
+    expect(result.current.activeTab).toBe("run");
   });
 
-  it("defaults to 'edit' for completed run", () => {
-    const { result } = renderHook(() =>
-      useInspectorTab("tab-1", "completed", true),
-    );
-    expect(result.current.activeTab).toBe("edit");
-  });
-
-  it("defaults to 'edit' for archived run", () => {
-    const { result } = renderHook(() =>
-      useInspectorTab("tab-1", "archived", true),
-    );
+  it("defaults to 'edit' when not editing a run (library draft)", () => {
+    const { result } = renderHook(() => useInspectorTab("tab-1", false));
     expect(result.current.activeTab).toBe("edit");
   });
 
   it("user override is sticky across re-renders", () => {
     const { result, rerender } = renderHook(() =>
-      useInspectorTab("tab-1", "running", true),
+      useInspectorTab("tab-1", true),
     );
     expect(result.current.activeTab).toBe("run");
 
@@ -60,9 +48,7 @@ describe("useInspectorTab", () => {
 
   it("resets override when pipelineKey changes", () => {
     let key = "tab-1";
-    const { result, rerender } = renderHook(() =>
-      useInspectorTab(key, "running", true),
-    );
+    const { result, rerender } = renderHook(() => useInspectorTab(key, true));
 
     act(() => result.current.setActiveTab("edit"));
     expect(result.current.activeTab).toBe("edit");
@@ -70,12 +56,5 @@ describe("useInspectorTab", () => {
     key = "tab-2";
     rerender();
     expect(result.current.activeTab).toBe("run");
-  });
-
-  it("defaults to 'edit' when isEditingRun is false even with active status", () => {
-    const { result } = renderHook(() =>
-      useInspectorTab("tab-1", "running", false),
-    );
-    expect(result.current.activeTab).toBe("edit");
   });
 });

--- a/frontend/src/hooks/useInspectorTab.ts
+++ b/frontend/src/hooks/useInspectorTab.ts
@@ -2,11 +2,8 @@ import { useState, useCallback } from "react";
 
 export type InspectorTab = "run" | "edit";
 
-const ACTIVE_RUN_STATUSES = new Set(["running", "awaiting_user", "halted"]);
-
 export function useInspectorTab(
   pipelineKey: string | null,
-  runStatus: string | null,
   isEditingRun: boolean,
 ) {
   const [state, setState] = useState<{
@@ -23,9 +20,10 @@ export function useInspectorTab(
     [pipelineKey],
   );
 
-  const isActiveRun =
-    isEditingRun && runStatus != null && ACTIVE_RUN_STATUSES.has(runStatus);
-  const contextDefault: InspectorTab = isActiveRun ? "run" : "edit";
+  // #271: any run tab — live OR terminal — defaults to the Run view so a
+  // finished node lands on its Outputs. Non-run tabs (library drafts) → edit.
+  // The user's manual choice (tabOverride) still wins and is sticky per tab.
+  const contextDefault: InspectorTab = isEditingRun ? "run" : "edit";
   const activeTab = tabOverride ?? contextDefault;
 
   return { activeTab, setActiveTab };


### PR DESCRIPTION
## What

Clicking a finished node on a run canvas now defaults to the **Run** tab (terminal + Inputs/**Outputs**) instead of the **Edit** template, so a finished node lands on its output artifacts.

Closes #271.

## Why

Pre-fix, the inspector's context default was gated by `ACTIVE_RUN_STATUSES = {running, awaiting_user, halted}`. A `completed` / `failed` / `archived` run is **not** in that set, so clicking a finished node sent the inspector to the **Edit** template — the wrong default for inspecting a terminal run.

## Change

- `useInspectorTab.ts`: drop the `runStatus` param and the `ACTIVE_RUN_STATUSES` gate. Any run tab (live **or** terminal) now defaults to `"run"`; non-run tabs (library drafts) default to `"edit"`. The user's sticky manual override (`tabOverride`) still wins.
- `App.tsx`: update the single call site to the new 2-arg signature `useInspectorTab(editActiveTabId, isEditingRun)`.
- Tests: `useInspectorTab.test.ts` updated to the 2-arg signature (live/completed/failed/archived → `run`, library → `edit`, sticky override + reset-on-key-change preserved); new `inspector-tabs.spec.ts` e2e coverage; `failed-node.spec.ts` updated.
- `chore(release)`: bump workspace version `0.1.41 → 0.1.42` (frontend stays `0.0.0` per convention).

## Validation (tester verdict: Pass)

- `npm run build` (`tsc -b && vite build`) — exit 0, clean typecheck of the dropped-param cleanup.
- `vitest run useInspectorTab.test.ts` — 7 passed.
- Visual confirmation against the live daemon: opened a **completed** run, clicked a finished node → inspector opened on the **Run** tab with Inputs/Outputs (the decisive case the old gate sent to Edit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
