### PR TITLE
feat(daemon): expose force-spawn to manager + UI (#204)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -554,12 +554,13 @@ Toutes exposées comme endpoints `POST /runs/<id>/commands` du daemon :
 | `inject_artifact` | Pose un artefact à la main dans le Blackboard |
 | `cleanup_run` | Supprime branches, worktrees, artefacts, événements |
 | `rename_run` | Donne au Run un nom descriptif (remplace le nom placeholder posé au spawn) |
+| `start_node` | Spawne un NodeRun immédiatement, sans attendre la complétion amont (force-spawn) ; inputs résolus best-effort ; refusé (`409`) si le Run n'accepte pas de spawn ou si le cap de sessions est atteint |
 
 L'effet de chaque commande est l'**append d'un événement** dans l'event log. Le runtime consomme ces événements et agit en conséquence.
 
 ### Ce que le manager ne peut **pas** faire
 
-- **Spawner des sous-agents ad hoc.** Pas d'orchestration probabiliste émergente. Le manager parle, lit, et exécute des commandes prédéfinies. Si l'utilisateur veut une investigation profonde, il attache directement la session tmux du nœud concerné.
+- **Spawner des sous-agents ad hoc hors-DAG.** Pas d'orchestration probabiliste émergente. Le manager parle, lit, et exécute des commandes prédéfinies. Il peut en revanche force-spawn un nœud **déjà déclaré** dans le DAG via `start_node` (hors ordre de dépendance). Si l'utilisateur veut une investigation profonde, il attache directement la session tmux du nœud concerné.
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1688,7 +1688,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "0.1.44"
+version = "0.1.45"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "0.1.44"
+version = "0.1.45"
 license = "MIT"
 
 [workspace.dependencies]

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -6238,11 +6238,43 @@ async fn node_skip(
         .into_response()
 }
 
+/// REST entry point for the UI **Start** button (#204): force-spawn `node_id`
+/// out of dependency order. A thin wrapper — all logic and guards live in the
+/// shared [`force_spawn_node`] helper, which the `start_node` manager
+/// `/commands` kind also calls, so the two consumers can never drift.
 async fn node_start(
     State(state): State<Arc<AppState>>,
     AxumPath((run_id, node_id)): AxumPath<(String, String)>,
 ) -> Response {
-    let events = match load_events(&state.db, &run_id).await {
+    force_spawn_node(&state, &run_id, &node_id).await
+}
+
+/// Force-spawn a node now, without waiting for its upstream producers to
+/// complete (#204). The single implementation behind both consumers: the UI
+/// **Start** button (REST `POST .../nodes/{node}/start` → [`node_start`]) and
+/// the Pipeline Manager `start_node` `/commands` kind. Keeping the body here
+/// means the guards below live in exactly one place.
+///
+/// Guards run **before** any side effect, in order:
+///  - run must exist (`404`) and the node must not already be `Running` (`409`);
+///  - **D4 (orphan-session fix):** the derived `NodeStarted` is pre-validated
+///    through [`transition_guard`] *before* the primitive spawns its tmux
+///    session. `node_primitives::start_node` spawns the session and only then
+///    returns the event for the caller to append, so leaning on `append_event`'s
+///    backstop alone would leave an orphan session (and a lying `200`) whenever
+///    the run cannot accept a start. `RunStatus::is_live()` is deliberately
+///    *not* the predicate: it admits `Paused`, which the append backstop
+///    (`run_accepts_lifecycle` = `Running`/`AwaitingUser`) rejects — that gap
+///    would orphan a session on a paused run. Pre-validating the actual event
+///    with the same guard the backstop uses keeps the two in lockstep and also
+///    refuses a concurrent live iteration. Mirrors `spawn_node`'s own probe.
+///  - **D5 (cap fail-fast):** acquire `admission_lock` and reject with `409` if
+///    spawning one more session would exceed the global cap (#77/#78). The lock
+///    is held across the spawn + append so the check-and-reserve is atomic, as
+///    `spawn_node` does. Force-spawn fails fast rather than queueing to
+///    `waiting` — "start now" must not silently defer.
+async fn force_spawn_node(state: &Arc<AppState>, run_id: &str, node_id: &str) -> Response {
+    let events = match load_events(&state.db, run_id).await {
         Ok(e) => e,
         Err(e) => {
             return (StatusCode::INTERNAL_SERVER_ERROR, format!("error: {e}")).into_response();
@@ -6259,7 +6291,7 @@ async fn node_start(
         }
     };
 
-    if let Some(ns) = run_state.nodes.get(&node_id) {
+    if let Some(ns) = run_state.nodes.get(node_id) {
         if ns.status == event_log::NodeStatus::Running {
             return (
                 StatusCode::CONFLICT,
@@ -6269,9 +6301,39 @@ async fn node_start(
         }
     }
 
-    let repo_root = effective_repo_root(&state, &run_state);
+    let iter = run_state
+        .nodes
+        .get(node_id)
+        .map(|ns| ns.iter + 1)
+        .unwrap_or(1);
+
+    // D4 (#204): pre-validate the start against the SAME transition guard that
+    // backstops `append_event`, BEFORE the primitive spawns a tmux session — so
+    // a start refused by the backstop never leaves an orphan session behind.
+    let started_probe = event_log::Event {
+        id: None,
+        run_id: run_id.to_string(),
+        ts: event_log::now_iso(),
+        kind: event_log::EventKind::NodeStarted,
+        node_id: Some(node_id.to_string()),
+        iter: Some(iter),
+        payload: None,
+    };
+    match transition_guard::validate_transition(Some(&run_state), &started_probe) {
+        transition_guard::Verdict::Allow => {}
+        transition_guard::Verdict::NoOp { reason }
+        | transition_guard::Verdict::Reject { reason } => {
+            return (
+                StatusCode::CONFLICT,
+                Json(serde_json::json!({ "error": reason })),
+            )
+                .into_response();
+        }
+    }
+
+    let repo_root = effective_repo_root(state, &run_state);
     let pipeline_path = {
-        let run_scoped = run_scoped_pipeline_path(&repo_root, &run_id);
+        let run_scoped = run_scoped_pipeline_path(&repo_root, run_id);
         if run_scoped.exists() {
             run_scoped
         } else {
@@ -6286,19 +6348,13 @@ async fn node_start(
     };
     let pipeline_def = parse_result.pipeline;
 
-    let iter = run_state
-        .nodes
-        .get(&node_id)
-        .map(|ns| ns.iter + 1)
-        .unwrap_or(1);
-
-    let worktree_dir = worktree_dir_for_run(&repo_root, &run_id);
+    let worktree_dir = worktree_dir_for_run(&repo_root, run_id);
     let artifacts_dir = worktree_dir.join(".pdo").join("artifacts");
     let resolved_vars = resolve_run_variables(&pipeline_def, &events);
 
     let params = node_primitives::StartNodeParams {
-        run_id: &run_id,
-        node_id: &node_id,
+        run_id,
+        node_id,
         iter,
         overrides: None,
         pipeline: &pipeline_def,
@@ -6312,17 +6368,38 @@ async fn node_start(
         tmux_cmd_override: state.tmux_cmd_override.as_deref(),
     };
 
+    // D5 (#204): admission cap as an atomic check-and-reserve. Hold the lock
+    // from the count until the reservation event is appended — exactly as
+    // `spawn_node` does — so concurrent force-spawns can't both claim the same
+    // free slot and overshoot the cap toward the tmux-server collapse point
+    // (#77/#78). Force-spawn fails fast at the cap instead of queueing to
+    // `waiting`, which would defeat "start now".
+    let _admission_guard = state.admission_lock.lock().await;
+    let cap = admission::configured_cap();
+    let live = count_global_live_sessions(&state.db).await;
+    if !admission::can_admit(live, cap) {
+        return (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({
+                "error": "session cap reached",
+                "live_sessions": live,
+                "cap": cap,
+            })),
+        )
+            .into_response();
+    }
+
     let result = node_primitives::start_node(&params);
 
     for ev in &result.events {
-        if let Err(e) = append_event(&state, ev).await {
+        if let Err(e) = append_event(state, ev).await {
             error!("failed to append event: {e}");
         }
     }
 
     match result.outcome {
         node_primitives::PrimitiveOutcome::Executed => {
-            info!("node_start: started {node_id} iter {iter} in run {run_id}");
+            info!("force_spawn_node: started {node_id} iter {iter} in run {run_id}");
             (
                 StatusCode::OK,
                 Json(serde_json::json!({ "ok": true, "iter": iter })),
@@ -7220,6 +7297,40 @@ async fn run_command(
 
             info!("restart_node: node {node_id} iter {iter} in run {run_id}");
             (StatusCode::OK, Json(serde_json::json!({ "ok": true }))).into_response()
+        }
+        "start_node" => {
+            // Force-spawn a node out of dependency order (#204). The manager
+            // twin of the UI Start button: both funnel through `force_spawn_node`,
+            // which derives the iteration and owns the run-status (D4) and
+            // admission-cap (D5) guards. `req.iter` is deliberately ignored —
+            // letting the manager pin an iter would fight that derivation.
+            let Some(node_id) = req.node_id else {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(serde_json::json!({ "error": "node_id required for start_node" })),
+                )
+                    .into_response();
+            };
+
+            // Audit the manager's intent before acting, mirroring the other
+            // command arms' `CommandIssued` parity event.
+            let cmd_event = event_log::Event {
+                id: None,
+                run_id: run_id.clone(),
+                ts: event_log::now_iso(),
+                kind: event_log::EventKind::CommandIssued,
+                node_id: Some(node_id.clone()),
+                iter: None,
+                payload: Some(serde_json::json!({
+                    "command": "start_node",
+                    "node_id": node_id,
+                })),
+            };
+            if let Err(e) = append_event(&state, &cmd_event).await {
+                error!("failed to append start_node command event: {e}");
+            }
+
+            force_spawn_node(&state, &run_id, &node_id).await
         }
         "inject_artifact" => {
             let Some(path) = req.path else {
@@ -16278,6 +16389,183 @@ edges: []
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    // --- Force-spawn via the `start_node` manager command (#204) ---
+
+    /// Append a run-level terminal event directly (not lifecycle-guarded), so a
+    /// test can drive a seeded run to a terminal status without spawning nodes.
+    async fn seed_run_terminal(state: &Arc<AppState>, run_id: &str, kind: event_log::EventKind) {
+        let ev = event_log::Event {
+            id: None,
+            run_id: run_id.into(),
+            ts: event_log::now_iso(),
+            kind,
+            node_id: None,
+            iter: None,
+            payload: None,
+        };
+        append_event(state, &ev).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn start_node_command_force_spawns_pending_node() {
+        // Happy path: the `start_node` /commands kind force-spawns a pending
+        // worker on a live run, returns 200, and lands a NodeStarted event
+        // (proving the spawn went through `force_spawn_node`).
+        let tmp = tempfile::tempdir().unwrap();
+        write_test_pipeline(tmp.path(), "test-pipe");
+        let state = test_state_with_dir(tmp.path()).await;
+        let run_id = "start-cmd-ok";
+        seed_run_for_node_control(&state, run_id, "test-pipe").await;
+
+        let app = build_router(state.clone());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/runs/{run_id}/commands"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({ "kind": "start_node", "node_id": "worker" })
+                            .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let events = load_events(&state.db, run_id).await.unwrap();
+        // The audit CommandIssued event landed...
+        assert!(
+            events.iter().any(|e| e.kind == event_log::EventKind::CommandIssued
+                && e.payload
+                    .as_ref()
+                    .and_then(|p| p.get("command"))
+                    .and_then(|c| c.as_str())
+                    == Some("start_node")),
+            "expected a start_node CommandIssued audit event"
+        );
+        // ...and so did the NodeStarted the force-spawn produced.
+        assert!(
+            events.iter().any(|e| e.kind == event_log::EventKind::NodeStarted
+                && e.node_id.as_deref() == Some("worker")),
+            "expected a NodeStarted event for the force-spawned worker"
+        );
+    }
+
+    #[tokio::test]
+    async fn start_node_command_requires_node_id() {
+        let state = test_state().await;
+        let run_id = "start-cmd-no-node";
+        seed_run_for_node_control(&state, run_id, "test-pipe").await;
+
+        let app = build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/runs/{run_id}/commands"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({ "kind": "start_node" }).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn force_spawn_on_terminal_run_is_rejected_without_orphan_session() {
+        // D4 (#204) orphan-session regression: force-spawning on a terminal run
+        // must be rejected with 409 BEFORE the tmux session is spawned. Pre-fix
+        // the primitive spawned first and the handler returned 200 while the
+        // NodeStarted append was silently rejected — an orphan session + lying
+        // 200. We assert the 409 (only the pre-spawn guard produces it) and that
+        // no NodeStarted event ever landed.
+        let tmp = tempfile::tempdir().unwrap();
+        write_test_pipeline(tmp.path(), "test-pipe");
+        let state = test_state_with_dir(tmp.path()).await;
+        let run_id = "start-terminal";
+        seed_run_for_node_control(&state, run_id, "test-pipe").await;
+        seed_run_terminal(&state, run_id, event_log::EventKind::RunCompleted).await;
+
+        let app = build_router(state.clone());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/runs/{run_id}/nodes/worker/start"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+
+        let events = load_events(&state.db, run_id).await.unwrap();
+        assert!(
+            !events
+                .iter()
+                .any(|e| e.kind == event_log::EventKind::NodeStarted),
+            "no NodeStarted may be appended when force-spawn is rejected on a terminal run"
+        );
+    }
+
+    #[tokio::test]
+    async fn force_spawn_at_session_cap_is_rejected() {
+        // D5 (#204): force-spawn must fail fast with 409 when the global session
+        // cap is already reached, rather than push past it toward tmux-server
+        // collapse (#77/#78). Seed `DEFAULT_SESSION_CAP` live sessions in a
+        // filler run so the assertion holds for any configured cap ≤ default
+        // (race-free vs the env-var cap test — no global state touched).
+        let tmp = tempfile::tempdir().unwrap();
+        write_test_pipeline(tmp.path(), "test-pipe");
+        let state = test_state_with_dir(tmp.path()).await;
+
+        let filler = "cap-filler";
+        seed_run_for_node_control(&state, filler, "test-pipe").await;
+        for i in 0..admission::DEFAULT_SESSION_CAP {
+            seed_node_started(&state, filler, &format!("filler-{i}"), 1).await;
+        }
+        assert_eq!(
+            count_global_live_sessions(&state.db).await,
+            admission::DEFAULT_SESSION_CAP
+        );
+
+        let run_id = "cap-target";
+        seed_run_for_node_control(&state, run_id, "test-pipe").await;
+
+        let app = build_router(state.clone());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/runs/{run_id}/nodes/worker/start"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["error"], "session cap reached");
+
+        // The target's worker must not have started.
+        let events = load_events(&state.db, run_id).await.unwrap();
+        assert!(
+            !events
+                .iter()
+                .any(|e| e.kind == event_log::EventKind::NodeStarted),
+            "no NodeStarted may be appended when force-spawn is rejected at the cap"
+        );
     }
 
     #[tokio::test]

--- a/crates/pdo-daemon/src/prompt_augmenter.rs
+++ b/crates/pdo-daemon/src/prompt_augmenter.rs
@@ -523,6 +523,16 @@ curl -X POST {daemon_url}/runs/{run_id}/commands \
   -d '{{"kind":"rename_run","name":"<display name>"}}'
 ```
 
+### 9. start_node
+
+Force-spawn a node now, without waiting for its upstream producers to complete. Use when you deliberately want to start a node ahead of its dependencies. Inputs resolve best-effort: any not-yet-produced upstream artifact resolves to the path where it *will* appear, so the node may run against missing or stale inputs. This is reversible — `restart_node` or `kill_node` it if it ran too early.
+
+```bash
+curl -X POST {daemon_url}/runs/{run_id}/commands \
+  -H 'Content-Type: application/json' \
+  -d '{{"kind":"start_node","node_id":"<node-id>"}}'
+```
+
 ---
 
 "#

--- a/frontend/e2e/force-start-pending-node.spec.ts
+++ b/frontend/e2e/force-start-pending-node.spec.ts
@@ -1,0 +1,132 @@
+import { test, expect } from "@playwright/test";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { cleanupRuns } from "./helpers";
+
+// Layer 3b — force-spawn a pending node via the UI Start button (#204).
+//
+// NOTE: this is NOT the unrelated `start-node.spec.ts` (that tests the canvas
+// Start pseudo-node / StartInspector, #30). Here we test the Start *button* the
+// NodeDetailPanel shows on a `pending` node, which force-spawns it out of
+// dependency order through `POST /runs/{id}/nodes/{node}/start`.
+//
+// Chain: start → worker-a → worker-b → end. The daemon's e2e tmux stub keeps a
+// node "running" (`sleep`), so worker-a runs and worker-b stays pending. We
+// select worker-b, click its Start button, and assert worker-b transitions to
+// running ahead of worker-a ever completing.
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const WORKSPACE_ROOT = path.resolve(__dirname, "..", "..");
+const PIPELINE_NAME = `e2e-force-start-${process.pid}-${Date.now()}`;
+const PIPELINE_DIR = path.join(WORKSPACE_ROOT, ".pdo", "pipelines");
+const PIPELINE_PATH = path.join(PIPELINE_DIR, `${PIPELINE_NAME}.yaml`);
+
+const SEED_YAML = `name: ${PIPELINE_NAME}
+version: "1.0"
+variables: {}
+nodes:
+  - id: start
+    name: Start
+    type: start
+    inputs: []
+    outputs:
+      - name: user_prompt
+    view: { x: 0, y: 100 }
+  - id: worker-a
+    name: Worker A
+    type: doc-only
+    inputs:
+      - name: in
+    outputs:
+      - name: out
+    view: { x: 200, y: 100 }
+  - id: worker-b
+    name: Worker B
+    type: doc-only
+    inputs:
+      - name: in
+    outputs:
+      - name: out
+    view: { x: 400, y: 100 }
+  - id: end
+    name: End
+    type: end
+    inputs:
+      - name: result
+    outputs: []
+    view: { x: 600, y: 100 }
+edges:
+  - source: { node: start, port: user_prompt }
+    target: { node: worker-a, port: in }
+  - source: { node: worker-a, port: out }
+    target: { node: worker-b, port: in }
+  - source: { node: worker-b, port: out }
+    target: { node: end, port: result }
+`;
+
+let runId: string | undefined;
+
+test.beforeAll(async () => {
+  await fs.mkdir(PIPELINE_DIR, { recursive: true });
+  await fs.writeFile(PIPELINE_PATH, SEED_YAML);
+});
+
+test.afterAll(async () => {
+  await cleanupRuns(runId);
+  await fs.rm(PIPELINE_PATH, { force: true });
+});
+
+test("Start button force-spawns a pending downstream node", async ({
+  page,
+  baseURL,
+}) => {
+  await page.goto("/");
+  await expect(page.getByText("Daemon: connected")).toBeVisible({
+    timeout: 10_000,
+  });
+
+  // Create a run — worker-a runs (held by the daemon's `sleep` stub),
+  // worker-b stays pending behind it.
+  const resp = await page.request.post(`${baseURL}/runs`, {
+    multipart: { pipeline: PIPELINE_NAME, input: "force-start test" },
+  });
+  expect(resp.status()).toBe(201);
+  ({ run_id: runId } = await resp.json());
+
+  // worker-a should reach running so the pipeline is genuinely live.
+  await expect(async () => {
+    const r = await page.request.get(`${baseURL}/runs/${runId}`);
+    expect(r.status()).toBe(200);
+    expect((await r.json()).nodes?.["worker-a"]?.status).toBe("running");
+  }).toPass({ timeout: 10_000 });
+
+  // Select the run, then the pending downstream node.
+  await page.getByText(runId!.slice(0, 8)).first().click({ timeout: 5_000 });
+  await page.waitForTimeout(500);
+  await page
+    .locator('.react-flow__node[data-id="worker-b"]')
+    .click({ timeout: 5_000 });
+
+  // The Run tab is active for a live run; the pending node shows its placeholder
+  // and — post-#204 — the Start button in the controls bar.
+  await expect(page.getByTestId("inspector-tab-run")).toHaveAttribute(
+    "data-active",
+    "true",
+    { timeout: 5_000 },
+  );
+  await expect(page.getByTestId("pending-placeholder")).toBeVisible({
+    timeout: 5_000,
+  });
+
+  const startBtn = page.getByTestId("start-btn");
+  await expect(startBtn).toBeVisible({ timeout: 5_000 });
+  await startBtn.click();
+
+  // worker-b should transition to running ahead of worker-a completing.
+  await expect(async () => {
+    const r = await page.request.get(`${baseURL}/runs/${runId}`);
+    expect(r.status()).toBe(200);
+    expect((await r.json()).nodes?.["worker-b"]?.status).toBe("running");
+  }).toPass({ timeout: 10_000 });
+});

--- a/frontend/src/components/NodeDetailPanel.test.tsx
+++ b/frontend/src/components/NodeDetailPanel.test.tsx
@@ -22,6 +22,7 @@ const tmuxUnmountCount = { current: 0 };
 const killNodeMock = vi.fn().mockResolvedValue(undefined);
 const restartNodeMock = vi.fn().mockResolvedValue(undefined);
 const stopNodeMock = vi.fn().mockResolvedValue(undefined);
+const startNodeMock = vi.fn().mockResolvedValue({ ok: true, iter: 1 });
 const retryNodeMock = vi.fn().mockResolvedValue({ ok: true, iter: 2, invalidated: [] });
 const retryNodePreviewMock = vi.fn().mockResolvedValue({ downstream: [], affected_count: 0, with_artifacts: [] });
 
@@ -34,7 +35,7 @@ vi.mock("../api", () => ({
   stopNode: (...args: unknown[]) => stopNodeMock(...args),
   retryNode: (...args: unknown[]) => retryNodeMock(...args),
   retryNodePreview: (...args: unknown[]) => retryNodePreviewMock(...args),
-  startNode: vi.fn(),
+  startNode: (...args: unknown[]) => startNodeMock(...args),
   attachSession: vi.fn(),
   artifactUrl: (runId: string, path: string) => `/runs/${runId}/artifact?path=${encodeURIComponent(path)}`,
 }));
@@ -104,6 +105,7 @@ describe("NodeDetailPanel", () => {
     killNodeMock.mockClear();
     restartNodeMock.mockClear();
     stopNodeMock.mockClear();
+    startNodeMock.mockClear();
     retryNodeMock.mockClear();
     retryNodePreviewMock.mockClear();
     retryNodePreviewMock.mockResolvedValue({ downstream: [], affected_count: 0, with_artifacts: [] });
@@ -769,13 +771,18 @@ describe("NodeDetailPanel", () => {
       expect(stopBtn).toBeDisabled();
     });
 
-    it("does not show controls when node is pending", () => {
+    it("shows controls with a disabled Stop and a Start button when node is pending (#204)", () => {
+      // Un-gating the controls bar for pending nodes (#204) exposes the Start
+      // button. The Stop button stays present but disabled (only `running` can
+      // be stopped).
       render(
         <TooltipProvider>
           <NodeDetailPanel node={makeNode({ status: "pending" })} runId="run-1" />
         </TooltipProvider>,
       );
-      expect(screen.queryByTestId("node-controls")).not.toBeInTheDocument();
+      expect(screen.getByTestId("node-controls")).toBeInTheDocument();
+      expect(screen.getByTestId("stop-btn")).toBeDisabled();
+      expect(screen.getByTestId("start-btn")).toBeInTheDocument();
     });
 
     it("does not show controls for archived runs", () => {
@@ -863,6 +870,54 @@ describe("NodeDetailPanel", () => {
       });
       expect(retryNodePreviewMock).toHaveBeenCalledWith("run-1", "test-node");
       expect(retryNodeMock).toHaveBeenCalledWith("run-1", "test-node");
+    });
+  });
+
+  describe("Start button (#204)", () => {
+    it("shows a Start button on a pending node", () => {
+      render(
+        <TooltipProvider>
+          <NodeDetailPanel node={makeNode({ status: "pending" })} runId="run-1" />
+        </TooltipProvider>,
+      );
+      const startBtn = screen.getByTestId("start-btn");
+      expect(startBtn).toBeInTheDocument();
+      expect(startBtn).toHaveTextContent("Start");
+    });
+
+    it("clicking Start force-spawns the node via startNode API", async () => {
+      render(
+        <TooltipProvider>
+          <NodeDetailPanel node={makeNode({ status: "pending" })} runId="run-1" />
+        </TooltipProvider>,
+      );
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("start-btn"));
+      });
+      expect(startNodeMock).toHaveBeenCalledWith("run-1", "test-node");
+    });
+
+    it("does not show a Start button on a running node", () => {
+      render(
+        <TooltipProvider>
+          <NodeDetailPanel node={makeNode({ status: "running" })} runId="run-1" />
+        </TooltipProvider>,
+      );
+      expect(screen.queryByTestId("start-btn")).not.toBeInTheDocument();
+    });
+
+    it("does not show a Start button on a pending node of an archived run", () => {
+      render(
+        <TooltipProvider>
+          <NodeDetailPanel
+            node={makeNode({ status: "pending" })}
+            runId="run-1"
+            isArchived
+          />
+        </TooltipProvider>,
+      );
+      expect(screen.queryByTestId("start-btn")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("node-controls")).not.toBeInTheDocument();
     });
   });
 

--- a/frontend/src/components/NodeDetailPanel.tsx
+++ b/frontend/src/components/NodeDetailPanel.tsx
@@ -13,6 +13,7 @@ import {
   markNodeDone,
   killNode,
   restartNode,
+  startNode,
   stopNode,
   retryNode,
   retryNodePreview,
@@ -208,6 +209,17 @@ export default function NodeDetailPanel({
     }
   }, [runId, node.node_id]);
 
+  // #204: force-spawn a pending node out of dependency order. The daemon owns
+  // the run-status gate (a non-spawnable run returns 409), so a click on a
+  // pending node in a terminal run just no-ops with a caught error.
+  const handleStart = useCallback(async () => {
+    try {
+      await startNode(runId, node.node_id);
+    } catch {
+      // best-effort
+    }
+  }, [runId, node.node_id]);
+
   const handleMarkComplete = useCallback(async () => {
     setMissingOutputs(null);
     try {
@@ -260,7 +272,7 @@ export default function NodeDetailPanel({
         </div>
       </div>
 
-      {!isArchived && node.status !== "pending" && (
+      {!isArchived && (
         <div
           className="flex items-center gap-1.5 border-b border-line px-3 py-1.5"
           data-testid="node-controls"
@@ -279,6 +291,17 @@ export default function NodeDetailPanel({
             <Square size={10} />
             Stop
           </button>
+          {node.status === "pending" && (
+            <button
+              data-testid="start-btn"
+              onClick={handleStart}
+              className={RETRY_BUTTON_CLASS}
+              style={RETRY_BUTTON_STYLE}
+            >
+              <Play size={10} />
+              Start
+            </button>
+          )}
           <RetryPlayButton status={node.status} onClick={handleRetry} />
         </div>
       )}


### PR DESCRIPTION
## Summary

Exposes **force-spawn** (start a node before its upstream dependencies complete) to both the **manager** and the **UI** — issue #204. The daemon-side force-spawn primitive already existed (shipped via #124); this work wires it through the two missing surfaces.

### Daemon
- New shared `force_spawn_node` helper, used by both entry points.
- New `start_node` `/commands` arm (with a `CommandIssued` audit event and `400` when `node_id` is missing).
- **D4** pre-spawn transition guard: returns `409` *before* any tmux session is created, so a non-live run never leaves an orphaned session.
- **D5** admission-cap fail-fast.
- Manager preamble gains command #9 (`start_node`).

### Frontend
- `NodeDetailPanel` renders a **▷ Start** button, scoped to `pending` nodes only (hidden on `running` and on archived runs). Click calls `startNode(runId, nodeId)` against the existing `/start` REST route.

## Testing
- Frontend: `tsc -b && vite build` clean; `vitest run NodeDetailPanel.test.tsx` → 60 passed (incl. 5 new #204 assertions).
- Daemon: `cargo build` clean; 4 new `#[tokio::test]`s for the daemon paths (run in CI per ADR-0004).
- Agentic visual test (FP-204): pending node → click Start → transitions to running, Start affordance correctly disappears.

Closes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)
