### PR TITLE
fix(terminal): stop auto-expanding terminal on live-node auto-select (#270)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -657,6 +657,7 @@ ADR-0005. L'option A historique (preview read-only + spawn d'une fenêtre OS nat
 - **Statut** (pending / running / awaiting_user / done / failed / blocked) — projeté depuis l'event log.
 - **Terminal interactif inline** dans le panneau de détail du nœud, rendu via xterm.js. Le daemon expose `WS /sessions/<id>/pty` : pour chaque connexion, il spawn `tmux attach -t <session>` dans un PTY (crate `portable-pty`) et bridge les bytes I/O entre le browser et le PTY. Bidirectionnel : l'utilisateur tape dedans, voit la sortie en temps réel. Plus de polling 1-2 s — la WebSocket pousse.
 - **Icônes du panneau** : (1) **agrandir** — le terminal occupe tout l'espace vertical du panneau de détail ; (2) **détacher** — fallback opt-in qui spawn une fenêtre OS native (`gnome-terminal`/`konsole`/`Terminal.app`/`kitty`) attachée à la session via `tmux attach`. Garde un escape hatch pour les cas limite (copy-paste exotique, freeze WebSocket).
+- **« agrandir » est toujours un geste utilisateur explicite (#270)** : ni la sélection d'un nœud, ni l'auto-snap sur le nœud vivant à l'entrée d'un Run live n'agrandit le terminal de lui-même. On garde l'auto-sélection du nœud vivant ; seule l'expansion forcée est retirée. Un réglage rendant l'auto-agrandissement opt-in est différé à la page de réglages (#129, n'existe pas encore).
 
 Détection du terminal natif (pour l'icône détacher) : variable `PDO_TERMINAL` ou heuristique sur `$TERM_PROGRAM` / OS / `which`.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1688,7 +1688,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "0.1.45"
+version = "0.1.46"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "0.1.45"
+version = "0.1.46"
 license = "MIT"
 
 [workspace.dependencies]

--- a/frontend/e2e/initial-prompt.spec.ts
+++ b/frontend/e2e/initial-prompt.spec.ts
@@ -103,12 +103,22 @@ test("selecting a running node shows initial prompt with ## Inputs", async ({
     await runTab.click();
   }
 
-  // The auto-selected live node opens with the terminal expanded fullscreen,
-  // which hides the details pane (Inputs/Outputs/Initial Prompt). Collapse the
-  // terminal via its expand toggle to reveal the details pane.
+  // #270 regression: entering a live run auto-selects the live node, but its
+  // terminal must NOT be expanded by default — the details pane shows first.
+  await expect(page.getByTestId("details-pane")).toBeVisible({ timeout: 5_000 });
+  await expect(page.getByTestId("terminal-fullsize")).toHaveCount(0);
+
+  // Post-#270 the auto-selected live node opens with the terminal NOT expanded,
+  // so the details pane (Inputs/Outputs/Initial Prompt) is visible by default.
+  // Only toggle the terminal's expand button when the pane isn't already shown
+  // (keeps the spec green in both pre- and post-fix worlds).
+  const detailsPane = page.getByTestId("details-pane");
   const expandToggle = page.getByTestId("term-expand");
   await expect(expandToggle).toBeVisible({ timeout: 5_000 });
-  await expandToggle.click();
+  if (!(await detailsPane.isVisible())) {
+    await expandToggle.click();
+  }
+  await expect(detailsPane).toBeVisible({ timeout: 5_000 });
 
   // The Initial Prompt section is collapsed by default (post-refonte
   // NodeDetailPanel.PromptSection) — expand it to reveal the prompt block.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -159,11 +159,6 @@ export default function App() {
   const resolveConflict = useEditStore((s) => s.resolveConflict);
   const reloadFromLibrary = useEditStore((s) => s.reloadFromLibrary);
   const clearSaveError = useEditStore((s) => s.clearSaveError);
-  // Tracks the node id last filled in by auto-selection. Used to decide
-  // whether to start the terminal in fullsize for the current selection.
-  const [autoSelectedNodeId, setAutoSelectedNodeId] = useState<string | null>(
-    null,
-  );
 
   // Track which library-YAML version we've already prompted about for a given
   // run-scoped tab. Re-prompting only when the library changes again avoids
@@ -275,7 +270,6 @@ export default function App() {
           runId={selectedRun.run_id}
           isArchived={isArchived}
           nodeName={selectedRun.node_defs?.find((d) => d.id === selection.id)?.name}
-          initialTerminalExpanded={isAutoSelected}
         />
       );
     }
@@ -344,16 +338,7 @@ export default function App() {
     const nodeId = pickLatestLiveNode(selectedRun);
     if (!nodeId) return;
     setSelection({ kind: "node", id: nodeId });
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- bounded cascade: setSelection above takes the kind!="none" branch on the next run, so this effect won't re-fire and tag a second node.
-    setAutoSelectedNodeId(nodeId);
   }, [selectedRun, selection.kind, selection.id, setSelection]);
-
-  // The marker only counts while it matches the current selection; once the
-  // user picks a different node manually, the comparison falls to false.
-  const isAutoSelected =
-    selection.kind === "node" &&
-    selection.id != null &&
-    selection.id === autoSelectedNodeId;
 
   const handleSelectRun = useCallback(
     async (runId: string) => {
@@ -636,7 +621,6 @@ export default function App() {
                     runId={selectedRun.run_id}
                     isArchived={isArchived}
                     nodeName={selectedRun.node_defs?.find((d) => d.id === selectedNodeId)?.name}
-                    initialTerminalExpanded={selectedNodeId != null && selectedNodeId === autoSelectedNodeId}
                   />
                 )}
                 {!selectedNode && selectedNodeType !== "start" && isArchived && selectedRun && (


### PR DESCRIPTION
## What

Entering a live run still auto-selects the latest live node, but its terminal no longer mounts expanded. The details pane (Inputs/Outputs/Initial Prompt) shows first; "agrandir" stays an explicit user gesture.

Removes the `autoSelectedNodeId` marker that drove `initialTerminalExpanded` at both `NodeDetailPanel` call sites; auto-snap (`setSelection`) is kept. The `NodeDetailPanel initialTerminalExpanded` prop is preserved as the seam for the future opt-in setting (#129).

## Changes
- `App.tsx`: drop `autoSelectedNodeId` state, `isAutoSelected` derivation, the `setAutoSelectedNodeId` tag + its eslint-disable, and the prop at both call sites (rely on `initialTerminalExpanded ?? false`).
- `initial-prompt.spec.ts`: make the collapse click conditional + add a #270 regression guard (`details-pane` visible).
- `CONTEXT.md`: document the invariant under the tmux-bridge section.
- `chore(release)`: bump workspace version 0.1.45 -> 0.1.46.

## Validation
Tester verdict **Pass**: clean `tsc -b && vite build`, `eslint` green, targeted vitest 67/67, and a daemon-free Playwright visual confirming the auto-selected live node now mounts terminal-collapsed with `details-pane` visible (vs. the re-simulated old fullscreen behaviour).

Closes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)