### PR TITLE
refactor(daemon): unify create_sub_worktree onto worktree_ops (#298)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1688,7 +1688,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "0.1.51"
+version = "0.1.52"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "0.1.51"
+version = "0.1.52"
 license = "MIT"
 
 [workspace.dependencies]

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -3226,7 +3226,7 @@ async fn spawn_node(
             &sub_branch,
             &pipeline_branch,
         ) {
-            error!("failed to create sub-worktree for {}: {e}", node.id);
+            error!("failed to create sub-worktree for {}: {e:#}", node.id);
             return;
         }
         orphan_to_reap = Some((sub_wt_dir.clone(), sub_branch));

--- a/crates/pdo-daemon/src/node_primitives.rs
+++ b/crates/pdo-daemon/src/node_primitives.rs
@@ -1,12 +1,11 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
-use anyhow::Result;
 use serde::Serialize;
 
 use crate::event_log::{self, EventKind, NodeStatus};
 use crate::pipeline::{self, PipelineDef};
-use crate::worktree_ops::{sub_worktree_branch, sub_worktree_path};
+use crate::worktree_ops::{create_sub_worktree, sub_worktree_branch, sub_worktree_path};
 use crate::{blackboard, tmux_session_manager};
 
 // ---------------------------------------------------------------------------
@@ -89,7 +88,7 @@ pub fn start_node(params: &StartNodeParams<'_>) -> StartNodeResult {
         {
             return StartNodeResult {
                 outcome: PrimitiveOutcome::Rejected {
-                    reason: format!("failed to create sub-worktree: {e}"),
+                    reason: format!("failed to create sub-worktree: {e:#}"),
                 },
                 events: vec![],
             };
@@ -441,40 +440,6 @@ pub fn inject_outputs(params: &InjectOutputsParams<'_>) -> InjectOutputsResult {
         outcome: PrimitiveOutcome::Executed,
         written_paths,
     }
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-// `sub_worktree_path` / `sub_worktree_branch` are the canonical path/branch
-// helpers, shared from `worktree_ops` (issue #276 de-dup). `create_sub_worktree`
-// below stays a local copy: it diverges from `worktree_ops`' version in error
-// handling (plain `{e}` render, no `info!` log) — unifying it is a behavior
-// decision tracked separately, not a mechanical de-dup.
-
-fn create_sub_worktree(
-    repo_root: &Path,
-    sub_worktree_dir: &Path,
-    sub_branch: &str,
-    base_branch: &str,
-) -> Result<()> {
-    std::fs::create_dir_all(sub_worktree_dir.parent().unwrap_or(Path::new(".")))?;
-
-    let output = std::process::Command::new("git")
-        .args(["worktree", "add", "-b", sub_branch])
-        .arg(sub_worktree_dir)
-        .arg(base_branch)
-        .current_dir(repo_root)
-        .output()
-        .map_err(|e| anyhow::anyhow!("failed to run git worktree add for sub-worktree: {e}"))?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("git worktree add (sub) failed: {stderr}");
-    }
-
-    Ok(())
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/pdo-daemon/src/worktree_ops.rs
+++ b/crates/pdo-daemon/src/worktree_ops.rs
@@ -636,4 +636,34 @@ mod tests {
             "sub-branch must be deleted after reap"
         );
     }
+
+    #[test]
+    fn create_sub_worktree_spawn_failure_preserves_os_cause() {
+        // Regression guard (#298): on the spawn-failure branch the OS-level
+        // io::Error must survive as a *queryable* `source()`, i.e. a 2-link anyhow
+        // chain [context, io::Error]. The pre-#298 duplicate used
+        // `map_err(anyhow!("…: {e}"))`, which flattened the cause into the message
+        // → a 1-link chain. Asserting the chain length (not the OS-specific string)
+        // makes this test portable and gives it teeth against a regression to the
+        // flattening form.
+        let tmp = tempfile::tempdir().unwrap();
+
+        // repo_root does NOT exist → git's chdir(current_dir) fails with ENOENT
+        // *before* exec, so `.output()` returns Err(io::Error) (the spawn-failure
+        // branch). This holds even if `git` is not installed on the runner.
+        let nonexistent_repo = tmp.path().join("no-such-repo");
+
+        // sub_worktree_dir's parent IS a valid writable temp path, so the earlier
+        // `create_dir_all(parent)?` succeeds and does not shield the .output() error.
+        let sub_wt_dir = tmp.path().join("sub").join("iter-1");
+
+        let err = create_sub_worktree(&nonexistent_repo, &sub_wt_dir, "pdo/sub-x", "base")
+            .expect_err("spawn must fail when repo_root does not exist");
+
+        assert_eq!(
+            err.chain().count(),
+            2,
+            "OS cause must be preserved as a distinct source(); got chain: {err:#}"
+        );
+    }
 }


### PR DESCRIPTION
Closes #298.

Deletes the private `create_sub_worktree` duplicate in `node_primitives` and routes `start_node` through the canonical `worktree_ops` helper. Standardises on `.context(…)` so the OS-level `io::Error` stays queryable as `source()`, and renders the full chain with `{e:#}` at the Start/Retry call site so the reason string is byte-identical to today. The scheduler-site log is rendered with `{e:#}` for symmetry.

DRY + regression-prevention; no user-visible behavior change. Follow-up to #276 (`bd8020b`).

## Validation
- `cargo build -p pdo-daemon` — 0 errors.
- Regression test `create_sub_worktree_spawn_failure_preserves_os_cause` — independently verified to have teeth (reverting to the pre-#298 flattening `map_err(anyhow!("…: {e}"))` form fails it with `chain().count()` `left: 1, right: 2`; `.context()` passes with a 2-link chain preserving the OS cause as a distinct `source()`).
- Full daemon suite `cargo test -p pdo-daemon` — 1202 passed (incl. the new regression test and `spawn_abort_recovery`).
- `cargo clippy --workspace --all-targets -- -D warnings` — exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)