### PR TITLE
feat(daemon): per-node Claude model selection (#296)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -34,6 +34,16 @@ Distinct de :
 
 - **NodeRun** *(à valider)* — l'exécution d'un Node au sein d'un Pipeline Run précis. Un NodeRun = une session tmux Claude Code dans un sous-worktree dédié, avec un statut (pending/running/done/failed).
 
+### Modèle (par node)
+
+Chaque Node peut porter un **modèle** optionnel (`model: Option<String>`) : l'identifiant du modèle Claude avec lequel sa session est lancée (`claude --model <x>`). Absent ⇒ le node utilise le modèle par défaut du compte (aucun `--model` n'est passé). Permet de payer un modèle capable là où le raisonnement est dur (Planner, Reviewer) et un modèle économique sur les nodes mécaniques.
+
+- **Texte libre, pass-through, aucune validation** : la valeur est un alias (`opus`, `sonnet`, `haiku`, `opusplan`, `fable`…) ou un id complet (`claude-opus-4-8`), transmise verbatim à `claude`. Un id invalide fait échouer `claude` au démarrage — *sharp tool*, responsabilité du designer (ADR-0001). Pas d'enum fermé qui périmerait à chaque sortie de modèle.
+- **Sémantique, pas layout** : le modèle fait partie de l'identité du pipeline (il change *quel agent* tourne). Il entre donc dans le **diff sémantique**, contrairement à `view`/`mode`/`waypoints`/`target_side`. Deux pipelines ne différant que par le modèle d'un node comparent **différent**.
+- **S'applique aux nodes qui lancent un agent** : `doc-only`, `code-mutating`, `merge`. Les nodes structurels (`start`, `end`) ne lancent pas de session → pas de modèle.
+- **Resume** : une session reprise (`claude --continue`) **conserve son modèle** d'origine (garanti par la doc Claude Code), donc pas besoin de re-passer `--model` au resume.
+- **Défaut daemon-wide hors-scope** : un `default_model` d'instance viendra plus tard via `instance_config` (ADR-0015). _Éviter_ : « modèle global », « modèle du run » (le modèle est *par node*, jamais par run).
+
 ## Dataflow
 
 Modèle (A) — **document-first, code en side-channel** :

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1688,7 +1688,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "0.1.52"
+version = "0.1.53"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "0.1.52"
+version = "0.1.53"
 license = "MIT"
 
 [workspace.dependencies]

--- a/crates/pdo-daemon/src/graph_resolver.rs
+++ b/crates/pdo-daemon/src/graph_resolver.rs
@@ -369,6 +369,7 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
+            model: None,
         }
     }
 
@@ -423,6 +424,7 @@ mod tests {
                 max_iter,
             ))),
             over: None,
+            model: None,
         }
     }
 

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -3410,6 +3410,7 @@ async fn spawn_node(
         iter,
         state.port,
         state.tmux_cmd_override.as_deref(),
+        node.model.as_deref(),
     ) {
         error!("failed to spawn tmux session: {e}");
     }
@@ -4570,6 +4571,7 @@ fn spawn_manager_session(
         0,
         state.port,
         state.tmux_cmd_override.as_deref(),
+        None, // manager has no NodeDef — always the account default (#296)
     ) {
         error!("failed to spawn manager tmux session: {e}");
     } else {
@@ -6226,6 +6228,7 @@ async fn spawn_merge_resolver(
         1,
         state.port,
         state.tmux_cmd_override.as_deref(),
+        None, // __merge_resolver__ has no NodeDef — account default (#296)
     ) {
         error!("failed to spawn merge resolver tmux session: {e}");
         let fail_event = event_log::Event {
@@ -11662,6 +11665,7 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
+            model: None,
         }
     }
 
@@ -16004,6 +16008,7 @@ mod tests {
                 view: None,
                 max_iter: None,
                 over: None,
+                model: None,
             }],
             edges: vec![EdgeDef {
                 source: EdgeEndpoint {
@@ -16054,6 +16059,7 @@ mod tests {
                 view: None,
                 max_iter: None,
                 over: None,
+                model: None,
             }],
             edges: vec![EdgeDef {
                 source: EdgeEndpoint {

--- a/crates/pdo-daemon/src/library_store.rs
+++ b/crates/pdo-daemon/src/library_store.rs
@@ -903,6 +903,7 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
+            model: None,
         }
     }
 

--- a/crates/pdo-daemon/src/loop_region.rs
+++ b/crates/pdo-daemon/src/loop_region.rs
@@ -394,6 +394,7 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
+            model: None,
         }
     }
 

--- a/crates/pdo-daemon/src/mutation_validator.rs
+++ b/crates/pdo-daemon/src/mutation_validator.rs
@@ -213,6 +213,7 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
+            model: None,
         }
     }
 
@@ -229,6 +230,7 @@ mod tests {
                 max_iter,
             ))),
             over: None,
+            model: None,
         }
     }
 

--- a/crates/pdo-daemon/src/node_io_resolver.rs
+++ b/crates/pdo-daemon/src/node_io_resolver.rs
@@ -322,6 +322,7 @@ mod tests {
                     view: None,
                     max_iter: None,
                     over: None,
+                    model: None,
                 },
                 NodeDef {
                     id: "implementer".into(),
@@ -349,6 +350,7 @@ mod tests {
                     view: None,
                     max_iter: None,
                     over: None,
+                    model: None,
                 },
             ],
             edges: vec![EdgeDef {
@@ -478,6 +480,7 @@ mod tests {
                     view: None,
                     max_iter: None,
                     over: None,
+                    model: None,
                 },
                 NodeDef {
                     id: "implementer".into(),
@@ -505,6 +508,7 @@ mod tests {
                     view: None,
                     max_iter: None,
                     over: None,
+                    model: None,
                 },
             ],
             edges: vec![EdgeDef {
@@ -592,6 +596,7 @@ mod tests {
                     view: None,
                     max_iter: None,
                     over: None,
+                    model: None,
                 },
                 NodeDef {
                     id: "b".into(),
@@ -611,6 +616,7 @@ mod tests {
                     view: None,
                     max_iter: None,
                     over: None,
+                    model: None,
                 },
                 NodeDef {
                     id: "merger".into(),
@@ -630,6 +636,7 @@ mod tests {
                     view: None,
                     max_iter: None,
                     over: None,
+                    model: None,
                 },
             ],
             edges: vec![
@@ -716,6 +723,7 @@ mod tests {
                     view: None,
                     max_iter: None,
                     over: None,
+                    model: None,
                 },
                 NodeDef {
                     id: "implementer".into(),
@@ -728,6 +736,7 @@ mod tests {
                     view: None,
                     max_iter: None,
                     over: None,
+                    model: None,
                 },
             ],
             edges: vec![EdgeDef {
@@ -793,6 +802,7 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
+            model: None,
         };
         let mk_edge = |src: &str| EdgeDef {
             source: EdgeEndpoint {
@@ -871,6 +881,7 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
+            model: None,
         };
         let mk_edge = |src: &str, port: &str| EdgeDef {
             source: EdgeEndpoint {

--- a/crates/pdo-daemon/src/node_primitives.rs
+++ b/crates/pdo-daemon/src/node_primitives.rs
@@ -169,6 +169,7 @@ pub fn start_node(params: &StartNodeParams<'_>) -> StartNodeResult {
         params.iter,
         params.daemon_port,
         params.tmux_cmd_override,
+        node.model.as_deref(),
     ) {
         return StartNodeResult {
             outcome: PrimitiveOutcome::Rejected {
@@ -487,6 +488,7 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
+            model: None,
         }
     }
 
@@ -517,6 +519,7 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
+            model: None,
         }
     }
 

--- a/crates/pdo-daemon/src/outputs_validator.rs
+++ b/crates/pdo-daemon/src/outputs_validator.rs
@@ -281,6 +281,7 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
+            model: None,
         }
     }
 

--- a/crates/pdo-daemon/src/pipeline.rs
+++ b/crates/pdo-daemon/src/pipeline.rs
@@ -125,6 +125,12 @@ pub struct NodeDef {
     pub max_iter: Option<serde_yaml::Value>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub over: Option<String>,
+    /// Optional per-node model override (#296): free-text pass-through to
+    /// `claude --model <x>` when the node spawns. Absent ⇒ account default
+    /// (no flag emitted, launch command byte-identical to the legacy path).
+    /// Semantic, not layout — included in the pipeline diff (ADR-0001).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -3152,6 +3158,72 @@ nodes:
             .find(|n| n.id == "ab000001")
             .unwrap();
         assert_eq!(fe.over.as_deref(), Some("tasks"));
+    }
+
+    #[test]
+    fn parses_node_model_and_round_trips() {
+        // #296: an agent-spawning node may carry a `model:` override. It parses
+        // into `NodeDef.model` and survives a serialize → re-parse round-trip.
+        let yaml = with_start_end(
+            r#"
+name: per-node-model
+nodes:
+  - id: ab000001
+    name: implementer
+    type: code-mutating
+    model: opus
+    outputs:
+      - name: code
+"#,
+        );
+        let result = parse_pipeline(&yaml).unwrap();
+        let node = result
+            .pipeline
+            .nodes
+            .iter()
+            .find(|n| n.id == "ab000001")
+            .unwrap();
+        assert_eq!(node.model.as_deref(), Some("opus"));
+
+        // Round-trips: re-serialize, re-parse — the model survives.
+        let serialized = serde_yaml::to_string(&result.pipeline).unwrap();
+        let result2 = parse_pipeline(&serialized).unwrap();
+        let node2 = result2
+            .pipeline
+            .nodes
+            .iter()
+            .find(|n| n.id == "ab000001")
+            .unwrap();
+        assert_eq!(node2.model.as_deref(), Some("opus"));
+    }
+
+    #[test]
+    fn node_model_defaults_to_none() {
+        // A node with no `model:` parses to `None` and is never serialized —
+        // the absence gate that keeps an unset node byte-identical to a library
+        // twin with no model (#296, the "diverged forever" guard).
+        let yaml = with_start_end(
+            r#"
+name: no-model
+nodes:
+  - id: ab000001
+    name: implementer
+    type: code-mutating
+    outputs:
+      - name: code
+"#,
+        );
+        let result = parse_pipeline(&yaml).unwrap();
+        let node = result
+            .pipeline
+            .nodes
+            .iter()
+            .find(|n| n.id == "ab000001")
+            .unwrap();
+        assert!(node.model.is_none());
+        // Absent ⇒ never serialized (clean file, round-trips by absence).
+        let serialized = serde_yaml::to_string(&result.pipeline).unwrap();
+        assert!(!serialized.contains("model:"));
     }
 
     #[test]

--- a/crates/pdo-daemon/src/pipeline_migrator.rs
+++ b/crates/pdo-daemon/src/pipeline_migrator.rs
@@ -2186,6 +2186,7 @@ edges:
             view: None,
             max_iter: None,
             over: None,
+            model: None,
         }
     }
 
@@ -2216,6 +2217,7 @@ edges:
             view: None,
             max_iter: None,
             over: None,
+            model: None,
         }
     }
 
@@ -2246,6 +2248,7 @@ edges:
             view: None,
             max_iter: None,
             over: None,
+            model: None,
         }
     }
 

--- a/crates/pdo-daemon/src/prompt_augmenter.rs
+++ b/crates/pdo-daemon/src/prompt_augmenter.rs
@@ -585,6 +585,7 @@ mod tests {
                 view: None,
                 max_iter: None,
                 over: None,
+                model: None,
             }],
             edges: vec![],
             loops: Vec::new(),
@@ -717,6 +718,7 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
+            model: None,
         });
         pipeline.edges.push(EdgeDef {
             source: EdgeEndpoint {
@@ -775,6 +777,7 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
+            model: None,
         });
 
         let node = &pipeline.nodes[1]; // implementer
@@ -805,6 +808,7 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
+            model: None,
         });
         pipeline.edges.push(EdgeDef {
             source: EdgeEndpoint {
@@ -850,6 +854,7 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
+            model: None,
         });
         pipeline.edges.push(EdgeDef {
             source: EdgeEndpoint {
@@ -952,6 +957,7 @@ mod tests {
                     view: None,
                     max_iter: None,
                     over: None,
+                    model: None,
                 },
                 NodeDef {
                     id: "researcher".into(),
@@ -971,6 +977,7 @@ mod tests {
                     view: None,
                     max_iter: None,
                     over: None,
+                    model: None,
                 },
                 NodeDef {
                     id: "implementer".into(),
@@ -1009,6 +1016,7 @@ mod tests {
                     view: None,
                     max_iter: None,
                     over: None,
+                    model: None,
                 },
             ],
             edges: vec![
@@ -1115,6 +1123,7 @@ mod tests {
                 view: None,
                 max_iter: None,
                 over: None,
+                model: None,
             }],
             edges: vec![],
             loops: Vec::new(),
@@ -1302,6 +1311,7 @@ mod tests {
                 view: None,
                 max_iter: None,
                 over: None,
+                model: None,
             }],
             edges: vec![],
             loops: Vec::new(),
@@ -1350,6 +1360,7 @@ mod tests {
                 view: None,
                 max_iter: None,
                 over: None,
+                model: None,
             }],
             edges: vec![],
             loops: Vec::new(),
@@ -1393,6 +1404,7 @@ mod tests {
                 view: None,
                 max_iter: None,
                 over: None,
+                model: None,
             }],
             edges: vec![],
             loops: Vec::new(),

--- a/crates/pdo-daemon/src/run_advance.rs
+++ b/crates/pdo-daemon/src/run_advance.rs
@@ -384,6 +384,7 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
+            model: None,
         }
     }
 

--- a/crates/pdo-daemon/src/scheduler.rs
+++ b/crates/pdo-daemon/src/scheduler.rs
@@ -1125,6 +1125,7 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
+            model: None,
         }
     }
 
@@ -1147,6 +1148,7 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
+            model: None,
         }
     }
 
@@ -2285,6 +2287,7 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
+            model: None,
         }
     }
 
@@ -3000,6 +3003,7 @@ mod tests {
                 max_iter,
             ))),
             over: None,
+            model: None,
         }
     }
 
@@ -3513,6 +3517,7 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
+            model: None,
         }
     }
 
@@ -3756,6 +3761,7 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
+            model: None,
         }
     }
 

--- a/crates/pdo-daemon/src/scheduler_dispatcher.rs
+++ b/crates/pdo-daemon/src/scheduler_dispatcher.rs
@@ -81,6 +81,7 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
+            model: None,
         }
     }
 

--- a/crates/pdo-daemon/src/switch_router.rs
+++ b/crates/pdo-daemon/src/switch_router.rs
@@ -58,6 +58,7 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
+            model: None,
         }
     }
 

--- a/crates/pdo-daemon/src/tmux_session_manager.rs
+++ b/crates/pdo-daemon/src/tmux_session_manager.rs
@@ -127,6 +127,10 @@ fn wrap_with_env(
 /// `tmux_cmd_override` replaces the default `claude …` tail when `Some` — the
 /// per-daemon test seam (see [`TMUX_CMD_OVERRIDE_ENV`]). `None` → production
 /// claude invocation.
+///
+/// `model` is the per-node model override (#296). `Some(m)` inserts
+/// `--model '<m>'` into the launch; `None` reproduces the legacy command
+/// byte-for-byte (no flag emitted). Ignored when `tmux_cmd_override` is `Some`.
 pub fn build_tmux_script(
     run_id: &str,
     node_id: &str,
@@ -134,13 +138,24 @@ pub fn build_tmux_script(
     daemon_port: u16,
     prompt_path: &Path,
     tmux_cmd_override: Option<&str>,
+    model: Option<&str>,
 ) -> String {
     let tail_cmd = match tmux_cmd_override {
         Some(cmd) => cmd.to_string(),
-        None => format!(
-            "exec claude --dangerously-skip-permissions \"$(cat {})\"",
-            sh_single_quote(&prompt_path.to_string_lossy())
-        ),
+        None => {
+            // `Some` ⇒ a single-quoted `--model '<m>' ` with a trailing space;
+            // `None` ⇒ empty string, so the command collapses to the exact
+            // legacy literal (one space before the `"$(cat …)"`).
+            let model_flag = match model {
+                Some(m) => format!("--model {} ", sh_single_quote(m)),
+                None => String::new(),
+            };
+            format!(
+                "exec claude --dangerously-skip-permissions {}\"$(cat {})\"",
+                model_flag,
+                sh_single_quote(&prompt_path.to_string_lossy())
+            )
+        }
     };
 
     wrap_with_env(run_id, node_id, iter, daemon_port, &tail_cmd)
@@ -150,6 +165,12 @@ pub fn build_tmux_script(
 ///
 /// `tmux_cmd_override` replaces the default `claude --continue` tail when
 /// `Some` — the per-daemon test seam.
+///
+/// No `--model` is threaded here (#296): a resumed session keeps the model it
+/// was launched with — "Resumed sessions started with `claude --resume`,
+/// `--continue`, or the `/resume` picker keep the model they were using when
+/// the transcript was saved" (https://code.claude.com/docs/en/model-config).
+/// So `--continue` never silently downgrades the per-node model.
 fn build_resume_script(
     run_id: &str,
     node_id: &str,
@@ -197,6 +218,7 @@ pub fn spawn(
     iter: i64,
     daemon_port: u16,
     tmux_cmd_override: Option<&str>,
+    model: Option<&str>,
 ) -> Result<()> {
     let prompt_dir = working_dir.join(".pdo").join("prompts");
     std::fs::create_dir_all(&prompt_dir)?;
@@ -210,6 +232,7 @@ pub fn spawn(
         daemon_port,
         &prompt_path,
         tmux_cmd_override,
+        model,
     );
     let socket = tmux_socket_name(daemon_port);
 
@@ -615,7 +638,7 @@ mod tests {
         let prompt_path = Path::new("/tmp/test-prompt.md");
 
         // None → production claude tail.
-        let script = build_tmux_script("run-abc", "solo", 1, 5172, prompt_path, None);
+        let script = build_tmux_script("run-abc", "solo", 1, 5172, prompt_path, None, None);
         assert!(script.starts_with("exec bash -c "));
         assert!(script.contains("exec claude --dangerously-skip-permissions"));
         assert!(script.contains("PDO_RUN_ID"));
@@ -630,9 +653,53 @@ mod tests {
             5172,
             prompt_path,
             Some("exec sleep 60"),
+            None,
         );
         assert!(script.contains("exec sleep 60"));
         assert!(!script.contains("claude"));
+    }
+
+    #[test]
+    fn build_script_omits_model_when_none() {
+        // #296: the `None` model path must reproduce the legacy command
+        // byte-for-byte — no `--model`, exactly one space before `"$(cat …)"`.
+        // This is the byte-identity guard: adding the flag must not perturb the
+        // default launch.
+        let prompt_path = Path::new("/tmp/test-prompt.md");
+        let script = build_tmux_script("run-abc", "solo", 1, 5172, prompt_path, None, None);
+        assert!(!script.contains("--model"), "no model flag when unset: {script}");
+        // The exact legacy tail, single space before the cat substitution.
+        assert!(
+            script.contains("exec claude --dangerously-skip-permissions \"$(cat "),
+            "legacy tail must be byte-identical: {script}"
+        );
+    }
+
+    #[test]
+    fn build_script_inserts_model_when_some() {
+        // #296: `Some(model)` inserts a single-quoted `--model '<m>'` between
+        // `--dangerously-skip-permissions` and the prompt `cat` substitution.
+        //
+        // The whole tail is re-wrapped in `bash -c '…'` by `wrap_with_env`, so
+        // the single quotes around the model value get rewritten by
+        // `sh_single_quote` as `'\''` — i.e. `--model 'opus'` becomes
+        // `--model '\''opus'\''` in the final script bytes.
+        let prompt_path = Path::new("/tmp/test-prompt.md");
+        let script =
+            build_tmux_script("run-abc", "solo", 1, 5172, prompt_path, None, Some("opus"));
+        assert!(script.contains("--model"), "model flag present: {script}");
+        assert!(
+            script.contains(r"--model '\''opus'\''"),
+            "model value single-quoted (bash -c escaping): {script}"
+        );
+        // The flag sits right after the base flag, before the prompt cat.
+        assert!(
+            script.contains(r"--dangerously-skip-permissions --model '\''opus'\'' "),
+            "model flag must sit right after the base flag: {script}"
+        );
+        let model_at = script.find("--model").unwrap();
+        let cat_at = script.find("$(cat").unwrap();
+        assert!(model_at < cat_at, "model flag must precede the prompt cat: {script}");
     }
 
     #[test]

--- a/crates/pdo-daemon/tests/tmux_run_spawn.rs
+++ b/crates/pdo-daemon/tests/tmux_run_spawn.rs
@@ -85,7 +85,7 @@ fn build_tmux_script_uses_exec_bash_and_invokes_claude() {
     // `claude --dangerously-skip-permissions` and the `exec bash -c` shape.
     // `None` override → production claude tail.
     let prompt_path = std::path::Path::new("/tmp/pdo-test/solo-iter-1.md");
-    let script = build_tmux_script("run-abc", "solo", 1, 5172, prompt_path, None);
+    let script = build_tmux_script("run-abc", "solo", 1, 5172, prompt_path, None, None);
 
     assert!(
         script.starts_with("exec bash -c "),

--- a/frontend/src/components/MergeInspector.test.tsx
+++ b/frontend/src/components/MergeInspector.test.tsx
@@ -99,4 +99,20 @@ describe("MergeInspector", () => {
     render(<MergeInspector />);
     expect(screen.getByText(/Merge nodes wait for all upstream/)).toBeInTheDocument();
   });
+
+  // #296: a merge node spawns an agent, so its model is settable here too.
+  it("writes the typed model onto the merge node", () => {
+    setStoreState(makeMergeNode());
+    render(<MergeInspector />);
+    const input = screen.getByTestId("merge-model-input");
+    fireEvent.change(input, { target: { value: "opus" } });
+    const node = useEditStore.getState().openTabs[0].pipeline.nodes.find((n) => n.id === "mg1");
+    expect(node?.model).toBe("opus");
+  });
+
+  it("renders a seeded model as the input value", () => {
+    setStoreState(makeMergeNode({ model: "sonnet" }));
+    render(<MergeInspector />);
+    expect((screen.getByTestId("merge-model-input") as HTMLInputElement).value).toBe("sonnet");
+  });
 });

--- a/frontend/src/components/MergeInspector.tsx
+++ b/frontend/src/components/MergeInspector.tsx
@@ -34,6 +34,24 @@ export default function MergeInspector() {
             className="w-full rounded border border-line-strong bg-bg-3 px-2 py-1 text-fg outline-none focus:border-acc"
           />
         </Field>
+        {/* Model (#296): a merge node spawns an agent, so its model is settable
+            here too. Free-text pass-through to `claude --model <x>`; empty ⇒
+            null ⇒ never serialized ⇒ account default. */}
+        <Field label="Model">
+          <input
+            list="pdo-model-aliases"
+            data-testid="merge-model-input"
+            placeholder="default model"
+            value={node.model ?? ""}
+            onChange={(e) => updateNode(node.id, { model: e.target.value || null })}
+            className="w-full rounded border border-line-strong bg-bg-3 px-2 py-1 text-fg outline-none focus:border-acc"
+          />
+          <datalist id="pdo-model-aliases">
+            {["sonnet", "opus", "haiku", "opusplan", "fable"].map((m) => (
+              <option key={m} value={m} />
+            ))}
+          </datalist>
+        </Field>
 
         <SectionHead title="Ports" />
         <Field label="Input">

--- a/frontend/src/components/NodeInspector.test.tsx
+++ b/frontend/src/components/NodeInspector.test.tsx
@@ -159,6 +159,40 @@ describe("NodeInspector — pooled emergent inputs (#153)", () => {
   });
 });
 
+describe("NodeInspector — per-node model field (#296)", () => {
+  it("writes the typed model onto the node and marks the tab dirty", () => {
+    seedTabWithReviewer(false, "Review this code.");
+    renderInspector({ libraryEntries: [], onLibraryChanged: () => {} });
+
+    const input = screen.getByTestId("node-model-input");
+    fireEvent.change(input, { target: { value: "opus" } });
+
+    const tab = useEditStore.getState().openTabs[0];
+    expect(tab.pipeline.nodes[0].model).toBe("opus");
+    expect(tab.dirty).toBe(true);
+  });
+
+  it("clears the model to null when emptied (stays unset, never serialized)", () => {
+    seedTabWithReviewer(false, "Review this code.");
+    // Seed a model so we can watch it clear.
+    useEditStore.getState().updateNode("rv1", { model: "opus" });
+    renderInspector({ libraryEntries: [], onLibraryChanged: () => {} });
+
+    const input = screen.getByTestId("node-model-input");
+    expect((input as HTMLInputElement).value).toBe("opus");
+
+    fireEvent.change(input, { target: { value: "" } });
+    expect(useEditStore.getState().openTabs[0].pipeline.nodes[0].model).toBeNull();
+  });
+
+  it("renders a seeded model as the input value", () => {
+    seedTabWithReviewer(false, "Review this code.");
+    useEditStore.getState().updateNode("rv1", { model: "haiku" });
+    renderInspector({ libraryEntries: [], onLibraryChanged: () => {} });
+    expect((screen.getByTestId("node-model-input") as HTMLInputElement).value).toBe("haiku");
+  });
+});
+
 describe("NodeInspector StarButton — library save is independent of pipeline save", () => {
   it("Save to library works when pipeline is dirty (no longer requires save first)", () => {
     seedTabWithReviewer(true, "Review this code.");

--- a/frontend/src/components/NodeInspector.tsx
+++ b/frontend/src/components/NodeInspector.tsx
@@ -168,6 +168,25 @@ export default function NodeInspector({
           </div>
         </Tooltip>
 
+        {/* Model (#296): free-text pass-through to `claude --model <x>`; the
+            datalist offers the common aliases but any full id is accepted.
+            Empty ⇒ null ⇒ never serialized ⇒ account default. */}
+        <Field label="Model">
+          <input
+            list="pdo-model-aliases"
+            data-testid="node-model-input"
+            placeholder="default model"
+            value={node.model ?? ""}
+            onChange={(e) => handleField("model", e.target.value || null)}
+            className="w-full rounded border border-line-strong bg-bg-3 px-2 py-1 text-fg outline-none focus:border-acc"
+          />
+          <datalist id="pdo-model-aliases">
+            {["sonnet", "opus", "haiku", "opusplan", "fable"].map((m) => (
+              <option key={m} value={m} />
+            ))}
+          </datalist>
+        </Field>
+
         {/* Prompt */}
         <SectionHead title="Prompt" />
         <textarea

--- a/frontend/src/hooks/useLibraryPipelines.test.ts
+++ b/frontend/src/hooks/useLibraryPipelines.test.ts
@@ -216,6 +216,27 @@ describe("pipelinesEquivalent", () => {
     });
     expect(pipelinesEquivalent(a, b)).toBe(false);
   });
+
+  // #296: the per-node model is SEMANTIC — two nodes differing only by model
+  // must diverge (unlike layout). Emitted only-when-set, so an unset node and a
+  // no-model twin stay equivalent (the "diverged forever" guard).
+  it("flags a real per-node model change", () => {
+    const a = def({ nodes: [node("a", { model: "opus" })] });
+    const b = def({ nodes: [node("a", { model: "sonnet" })] });
+    expect(pipelinesEquivalent(a, b)).toBe(false);
+  });
+
+  it("treats identical per-node models as equivalent", () => {
+    const a = def({ nodes: [node("a", { model: "opus" })] });
+    const b = def({ nodes: [node("a", { model: "opus" })] });
+    expect(pipelinesEquivalent(a, b)).toBe(true);
+  });
+
+  it("treats an unset model as equivalent to an absent one (no false diverge)", () => {
+    const a = def({ nodes: [node("a", { model: null })] });
+    const b = def({ nodes: [node("a")] });
+    expect(pipelinesEquivalent(a, b)).toBe(true);
+  });
 });
 
 describe("computePipelineSyncState", () => {

--- a/frontend/src/stores/editStore.test.ts
+++ b/frontend/src/stores/editStore.test.ts
@@ -1064,6 +1064,25 @@ describe("serializePipeline round-trip: YAML structural correctness", () => {
     expect(serializePipeline(absent)).not.toContain("prompt_required");
   });
 
+  it("emits a per-node model override when set (#296)", () => {
+    const impl: NodeDef = {
+      id: "impl", name: "implementer", type: "code-mutating",
+      inputs: [], outputs: [{ name: "code", repeated: false, side: "right" }],
+      interactive: false, view: { x: 200, y: 0 }, model: "opus",
+    };
+    const yaml = serializePipeline(makeFullPipeline([impl]));
+    expect(yaml).toContain("model: opus");
+  });
+
+  it("omits model when unset — the byte-identical / no-diverge default (#296)", () => {
+    const impl: NodeDef = {
+      id: "impl", name: "implementer", type: "code-mutating",
+      inputs: [], outputs: [{ name: "code", repeated: false, side: "right" }],
+      interactive: false, view: { x: 200, y: 0 },
+    };
+    expect(serializePipeline(makeFullPipeline([impl]))).not.toContain("model:");
+  });
+
   it("serializes output port with frontmatter at correct indentation", () => {
     const reviewer: NodeDef = {
       id: "reviewer", name: "reviewer", type: "doc-only",

--- a/frontend/src/stores/editStore.ts
+++ b/frontend/src/stores/editStore.ts
@@ -202,6 +202,10 @@ export function pipelineToYamlObject(p: PipelineDef): Record<string, unknown> {
       type: n.type,
     };
     if (n.interactive) node.interactive = true;
+    // Per-node model override (#296): semantic (compared in the pipeline diff),
+    // emitted only when set so an unset node and a library twin with no model
+    // both produce objects without the key and stay `synced`, not `diverged`.
+    if (n.model) node.model = n.model;
     // A collection's `over` driver now lives on the `loops:` region, not on any
     // node (#151) — no node-level `over` serialization.
     if (n.inputs.length > 0)

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -350,6 +350,9 @@ export interface NodeDef {
   view?: { x: number; y: number } | null;
   max_iter?: number | string | null;
   over?: string | null;
+  /** Optional per-node model override (#296): free-text pass-through to
+   *  `claude --model <x>`. Absent/null ⇒ account default (no flag). */
+  model?: string | null;
 }
 
 export interface EdgeEndpoint {


### PR DESCRIPTION
## Summary

Adds an optional per-node Claude model override (`NodeDef.model`) that threads to `claude --model <x>` at spawn. The `None` path is proven byte-identical to the legacy launch; serialization emits the field only when set, so unset nodes / library twins stay `synced` rather than falsely `diverged`.

- Backend: `NodeDef.model: Option<String>`, threaded through spawn (`tmux_session_manager`), scheduler, pipeline (de)serialization, primitives, migrator, prompt augmenter, switch router, outputs validator, run_advance.
- Frontend: **Model** field in `NodeInspector` and `MergeInspector` (free-text + datalist of aliases `sonnet/opus/haiku/opusplan/fable`), wired to `editStore`; `types.ts` + `useLibraryPipelines` round-trip.
- Docs: CONTEXT.md glossary term "Modèle (par node)".
- Release: version bump 0.1.52 → 0.1.53.

## Validation (agentic node, verdict: Pass)

- `cargo build --workspace` clean (incl. 47 test `NodeDef` literals backfilled with `model: None`).
- Rust: `cargo test -p pdo-daemon` — 0 failed (~1206 tests), incl. 4 new guards (`build_script_omits_model_when_none`, `build_script_inserts_model_when_some`, `parses_node_model_and_round_trips`, `node_model_defaults_to_none`).
- Frontend: `npx vitest run` — 975/975 pass; `tsc -b` clean.
- End-to-end in the running app (chrome-devtools-mcp): Model field renders in both inspectors, marks the tab dirty, and its value round-trips into the pipeline YAML on disk that feeds the spawn command.

Closes #296

🤖 Generated with [Claude Code](https://claude.com/claude-code)