### PR TITLE
feat(#248): add script node type — deterministic author bash, no LLM (ADR-0017)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -19,7 +19,7 @@ Contrairement à : Liza (pipelines YAML), Langgraph (conditional edges + LLM-rou
 
 ## Node
 
-Unité atomique d'un Pipeline. Un **Node** représente un rôle d'agent — typiquement une instance de Claude Code à laquelle on confie un prompt système qui définit sa mission (Implementer, Planner, Reviewer, etc.).
+Unité atomique d'un Pipeline. Un **Node** représente un rôle. La plupart des nodes lancent une instance de Claude Code à laquelle on confie un prompt système qui définit sa mission (Implementer, Planner, Reviewer, etc.). Un node **`script`** fait exception : il exécute du **bash déterministe fourni par l'auteur**, sans LLM (cf. *Node `script`* ci-dessous, ADR-0017).
 
 Un Node se définit par :
 
@@ -43,6 +43,16 @@ Chaque Node peut porter un **modèle** optionnel (`model: Option<String>`) : l'i
 - **S'applique aux nodes qui lancent un agent** : `doc-only`, `code-mutating`, `merge`. Les nodes structurels (`start`, `end`) ne lancent pas de session → pas de modèle.
 - **Resume** : une session reprise (`claude --continue`) **conserve son modèle** d'origine (garanti par la doc Claude Code), donc pas besoin de re-passer `--model` au resume.
 - **Défaut daemon-wide hors-scope** : un `default_model` d'instance viendra plus tard via `instance_config` (ADR-0015). _Éviter_ : « modèle global », « modèle du run » (le modèle est *par node*, jamais par run).
+
+### Node `script` — exécution déterministe (ADR-0017)
+
+Un node **`script`** exécute le bash de l'auteur au lieu de lancer Claude. Il tourne dans une **session tmux** (attachable comme tout NodeRun, ADR-0005) dont le tail est `timeout N bash <corps>` : **exit 0 ⇒ node `completed`**, non-zéro ou timeout ⇒ `failed`. En v1 il est d'**effet doc-only** (pas de sous-worktree ; tourne dans le worktree du Run ; doit le laisser propre).
+
+- **I/O par variables d'environnement** (un script ne lit pas le préambule prose) : `PDO_INPUT_<PORT>`, `PDO_OUTPUT_<PORT>`, `PDO_ARTIFACTS_DIR`, `PDO_VAR_<NAME>`, plus les `PDO_RUN_ID/NODE_ID/NODE_ITER/DAEMON_URL` habituels. Le script écrit lui-même `output.md` à `$PDO_OUTPUT_<port>` ; pour piloter une edge `when:`, il y écrit sa propre frontmatter YAML. `outputs_validator` s'applique en **fail-fast** (pas de retry interactif — la session a quitté).
+- **Corps** stocké dans le slot prompt du node (`<pipeline>.prompts/<node>.md`). Un corps vide fait échouer le lancement (fail-loud, pas de no-op silencieux).
+- **Pas de `model`** (aucun agent lancé). Le seam de test `tmux_cmd_override` ne s'applique pas à un script (le bash *est* déterministe, donc testable sans stub).
+- **Sécurité** : équivalent au guard de Trigger et au bash d'un agent — le bash de l'auteur dans son propre pipeline, aucune nouvelle frontière de confiance (#260 reste le contrôle réel).
+- **Sharp tool** : un script doc-only qui fait `git commit` laisse l'arbre propre et passe le garde d'immutabilité — c'est la responsabilité de l'auteur.
 
 ## Dataflow
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1952,7 +1952,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "0.1.56"
+version = "0.1.57"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "0.1.56"
+version = "0.1.57"
 license = "MIT"
 
 [workspace.dependencies]

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -3246,6 +3246,31 @@ async fn spawn_node(
         }
     }
 
+    // #248 / ADR-0017: refuse to spawn a `script` node with an empty body — it
+    // would `bash <empty>` → exit 0 → a silent no-op masquerading as success.
+    // `create_run` guards this at launch, but the scheduler and `restart_node`
+    // reach `spawn_node` directly, and a mid-run edit could have emptied a
+    // pending script's body since launch. Fail loud (before admission / any side
+    // effect) rather than silently no-op.
+    if node.node_type == pipeline::NodeType::Script {
+        let body_path = pipeline::canonical_prompt_path(spawn_ctx.pipeline_path, &node.id);
+        let body_empty = std::fs::read_to_string(&body_path)
+            .map(|s| s.trim().is_empty())
+            .unwrap_or(true);
+        if body_empty {
+            fail_spawn_before_start(
+                state,
+                spawn_ctx.repo_root,
+                run_id,
+                &node.id,
+                None,
+                &format!("script node {} has an empty body", node.id),
+            )
+            .await;
+            return;
+        }
+    }
+
     // Admission control (#159 / #213): bound the number of live NodeRun
     // sessions daemon-wide. The check is an ATOMIC check-and-reserve — the
     // `admission_lock` is held from the count until the reservation event
@@ -3404,6 +3429,17 @@ async fn spawn_node(
 
         let full_prompt = prompt_augmenter::build_full_prompt(&aug_ctx, &role_prompt);
 
+        // A `script` node (#248 / ADR-0017) runs the author's bash instead of
+        // Claude. Compute its I/O env catalogue and pre-create its output dirs
+        // here (inside the panic-isolated span, next to `aug_ctx`) and hand the
+        // env back to the spawn below — a script can't read the prose preamble.
+        let script_env = if node.node_type == pipeline::NodeType::Script {
+            prompt_augmenter::precreate_output_dirs(&aug_ctx);
+            prompt_augmenter::build_script_env(&aug_ctx)
+        } else {
+            Vec::new()
+        };
+
         let node_started = event_log::Event {
             id: None,
             run_id: run_id.to_string(),
@@ -3422,6 +3458,7 @@ async fn spawn_node(
                     pipeline::NodeType::Loop => "loop",
                     pipeline::NodeType::ForEach => "for-each",
                     pipeline::NodeType::Merge => "merge",
+                    pipeline::NodeType::Script => "script",
                 },
             })),
         };
@@ -3431,7 +3468,7 @@ async fn spawn_node(
         append_event(state, &node_started)
             .await
             .context("failed to append node_started")?;
-        Ok::<String, anyhow::Error>(full_prompt)
+        Ok::<(String, Vec<(String, String)>), anyhow::Error>((full_prompt, script_env))
     });
 
     let span_outcome = futures_util::future::FutureExt::catch_unwind(span).await;
@@ -3442,8 +3479,8 @@ async fn spawn_node(
     // session.
     drop(admission_guard);
 
-    let full_prompt = match span_outcome {
-        Ok(Ok(full_prompt)) => full_prompt,
+    let (full_prompt, script_env) = match span_outcome {
+        Ok(Ok(pair)) => pair,
         Ok(Err(e)) => {
             fail_spawn_before_start(
                 state,
@@ -3475,16 +3512,30 @@ async fn spawn_node(
     };
 
     let session_name = tmux_session_manager::node_session_name(run_id, &node.id, iter);
+    let is_script = node.node_type == pipeline::NodeType::Script;
+    let tail = if is_script {
+        tmux_session_manager::SessionTail::Script {
+            timeout_secs: tmux_session_manager::SCRIPT_TIMEOUT_SECS,
+            env: &script_env,
+        }
+    } else {
+        tmux_session_manager::SessionTail::Agent {
+            model: node.model.as_deref(),
+        }
+    };
+    // A script node executes the RAW bash body (`role_prompt`), never the
+    // augmented prompt — the preamble is prose an agent reads, not runnable bash.
+    let spawn_prompt: &str = if is_script { &role_prompt } else { &full_prompt };
     if let Err(e) = tmux_session_manager::spawn(
         &session_name,
-        &full_prompt,
+        spawn_prompt,
         &working_dir,
         run_id,
         &node.id,
         iter,
         state.port,
         state.tmux_cmd_override.as_deref(),
-        node.model.as_deref(),
+        tail,
     ) {
         error!("failed to spawn tmux session: {e}");
     }
@@ -4484,6 +4535,34 @@ async fn create_run_inner(
         ));
     }
 
+    // Refuse the launch on an empty `script` body (#248 / ADR-0017). A `script`
+    // node runs `bash <body>`; an empty body exits 0 and masquerades as success —
+    // a silent no-op with no error anywhere. Fail loud at launch, like a dangling
+    // edge, so the author fixes it before the run starts (no run is created).
+    let empty_scripts: Vec<String> = pipeline
+        .nodes
+        .iter()
+        .filter(|n| n.node_type == pipeline::NodeType::Script)
+        .filter(|n| {
+            let path = pipeline::canonical_prompt_path(&pipeline_path, &n.id);
+            std::fs::read_to_string(&path)
+                .map(|s| s.trim().is_empty())
+                .unwrap_or(true)
+        })
+        .map(|n| n.id.clone())
+        .collect();
+    if !empty_scripts.is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            serde_json::json!({
+                "error": format!(
+                    "cannot launch run: script node(s) have an empty body: {}",
+                    empty_scripts.join(", ")
+                ),
+            }),
+        ));
+    }
+
     // Empty input is allowed only for prompt-optional pipelines (#158).
     if let Err(msg) = validate_run_input(pipeline.prompt_required, &req.input) {
         return Err((StatusCode::BAD_REQUEST, serde_json::json!({ "error": msg })));
@@ -4645,7 +4724,8 @@ fn spawn_manager_session(
         0,
         state.port,
         state.tmux_cmd_override.as_deref(),
-        None, // manager has no NodeDef — always the account default (#296)
+        // manager has no NodeDef — always an agent at the account default (#296)
+        tmux_session_manager::SessionTail::Agent { model: None },
     ) {
         error!("failed to spawn manager tmux session: {e}");
     } else {
@@ -5804,6 +5884,28 @@ async fn node_pane(
 
     if is_latest_iter && !iter_is_terminal && node_state.status != event_log::NodeStatus::Pending {
         let node_type = find_node_type(&run_state, &node_id).unwrap_or("doc-only");
+
+        // #248 / ADR-0017: never resume a `script` node via `claude --continue`.
+        // A script runs deterministic bash, not an LLM; `resume` would launch a
+        // full Claude session in the run's shared worktree — the opposite of the
+        // contract. A dead-but-non-terminal script session can't be "continued";
+        // serve its last snapshot if we have one, else mark it unavailable.
+        if node_type == "script" {
+            let snapshot_path = pane_snapshot_path(&repo_root, &run_id, &node_id, iter);
+            let (content, source) = match std::fs::read_to_string(&snapshot_path) {
+                Ok(c) => (c, "snapshot"),
+                Err(_) => ("Script session no longer available".to_string(), "unavailable"),
+            };
+            return Json(PaneResponse {
+                content,
+                session_name,
+                resumed: false,
+                stale: false,
+                source,
+            })
+            .into_response();
+        }
+
         let working_dir = tmux_session_manager::working_dir_for_node(
             &repo_root, &run_id, &node_id, iter, node_type,
         );
@@ -6074,7 +6176,8 @@ async fn spawn_merge_resolver(
         1,
         state.port,
         state.tmux_cmd_override.as_deref(),
-        None, // __merge_resolver__ has no NodeDef — account default (#296)
+        // __merge_resolver__ has no NodeDef — agent at the account default (#296)
+        tmux_session_manager::SessionTail::Agent { model: None },
     ) {
         error!("failed to spawn merge resolver tmux session: {e}");
         let fail_event = event_log::Event {
@@ -6360,7 +6463,12 @@ async fn node_done(
                 }
             }
         }
-        Some("doc-only") => match worktree_has_tracked_changes(&worktree_dir) {
+        // A `script` node (#248 / ADR-0017) is doc-only-effect in v1: like a
+        // doc-only node it runs in the run's shared worktree and must leave
+        // tracked files clean (untracked artifacts are fine — the guard ignores
+        // `??`). The sharp-tool caveat (a script that `git commit`s leaves a
+        // clean tree and passes) is documented in ADR-0017.
+        Some("doc-only") | Some("script") => match worktree_has_tracked_changes(&worktree_dir) {
             Ok(true) => {
                 let fail_event = event_log::Event {
                     id: None,
@@ -8875,6 +8983,7 @@ fn node_def_from_pipeline(n: &pipeline::NodeDef) -> event_log::NodeDefInfo {
             pipeline::NodeType::Loop => "loop".into(),
             pipeline::NodeType::ForEach => "for-each".into(),
             pipeline::NodeType::Merge => "merge".into(),
+            pipeline::NodeType::Script => "script".into(),
         },
         view_x: n.view.as_ref().map(|v| v.x),
         view_y: n.view.as_ref().map(|v| v.y),
@@ -8983,6 +9092,71 @@ async fn check_output_validation_with_retry(
     else {
         return None;
     };
+
+    // A `script` node (#248 / ADR-0017) has already exited by the time this runs
+    // — there is no live agent to nudge. So any validation failure is terminal:
+    // fail-fast (mirror the exhausted-retry branch) instead of the interactive
+    // corrective loop, which would `send-keys` into a dead session and strand the
+    // node behind a bare 409.
+    let is_script = parse_result
+        .pipeline
+        .nodes
+        .iter()
+        .find(|n| n.id == node_id)
+        .map(|n| n.node_type == pipeline::NodeType::Script)
+        .unwrap_or(false);
+    if is_script {
+        let detail = match &validation_error {
+            outputs_validator::ValidationError::MissingOutputs(missing) => {
+                serde_json::json!({ "kind": "missing_outputs", "missing": missing })
+            }
+            outputs_validator::ValidationError::FrontmatterMismatch(violations) => {
+                let details: Vec<serde_json::Value> = violations
+                    .iter()
+                    .map(|v| serde_json::json!({ "port": v.port, "field": v.field, "reason": v.reason }))
+                    .collect();
+                serde_json::json!({ "kind": "frontmatter_mismatch", "violations": details })
+            }
+        };
+        let fail_event = event_log::Event {
+            id: None,
+            run_id: run_id.to_string(),
+            ts: event_log::now_iso(),
+            kind: event_log::EventKind::NodeFailed,
+            node_id: Some(node_id.to_string()),
+            iter: Some(iter),
+            payload: Some(serde_json::json!({
+                "reason": "script output validation failed",
+                "detail": detail,
+            })),
+        };
+        let _ = append_event(state, &fail_event).await;
+
+        let run_failed = event_log::Event {
+            id: None,
+            run_id: run_id.to_string(),
+            ts: event_log::now_iso(),
+            kind: event_log::EventKind::RunFailed,
+            node_id: None,
+            iter: None,
+            payload: Some(serde_json::json!({
+                "reason": format!("script node {node_id} failed output validation")
+            })),
+        };
+        let _ = append_event(state, &run_failed).await;
+
+        warn!("script node {node_id} failed output validation in run {run_id} — fail-fast");
+        return Some(
+            (
+                StatusCode::OK,
+                Json(serde_json::json!({
+                    "status": "script_validation_failed",
+                    "detail": detail,
+                })),
+            )
+                .into_response(),
+        );
+    }
 
     match validation_error {
         outputs_validator::ValidationError::MissingOutputs(missing) => Some(

--- a/crates/pdo-daemon/src/mutation_validator.rs
+++ b/crates/pdo-daemon/src/mutation_validator.rs
@@ -679,6 +679,37 @@ mod tests {
     }
 
     #[test]
+    fn rejects_retyping_running_script_node() {
+        // #248 / ADR-0007(d): a live `script` node is immutable including its
+        // type — retyping it away (script → doc-only) mid-run would desync the
+        // live pipeline from the run snapshot exactly as for any other node.
+        let old = pipeline(vec![simple_node("a", pipeline::NodeType::Script)]);
+        let new = pipeline(vec![simple_node("a", pipeline::NodeType::DocOnly)]);
+        let rs = run_state_with_nodes(vec![("a", event_log::NodeStatus::Running)]);
+
+        let result = validate_run_mutation(&old, &new, &rs);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].node_id, "a");
+        assert!(
+            result[0].reason.contains("type") && result[0].reason.contains("running"),
+            "reason must explain the retype rejection; got: {}",
+            result[0].reason
+        );
+    }
+
+    #[test]
+    fn allows_retyping_pending_script_node() {
+        // A not-yet-spawned script node has no session/snapshot to desync — its
+        // type is freely editable before it runs.
+        let old = pipeline(vec![simple_node("a", pipeline::NodeType::Script)]);
+        let new = pipeline(vec![simple_node("a", pipeline::NodeType::CodeMutating)]);
+        let rs = run_state_with_nodes(vec![("a", event_log::NodeStatus::Pending)]);
+
+        let result = validate_run_mutation(&old, &new, &rs);
+        assert!(result.is_empty(), "retyping a pending script node is allowed; got: {result:?}");
+    }
+
+    #[test]
     fn allows_changing_type_of_not_yet_spawned_node() {
         // Extended taxonomy (#211, ADR-0007 silent case): a node not yet
         // spawned (pending, or absent from run state) has no session and no

--- a/crates/pdo-daemon/src/node_primitives.rs
+++ b/crates/pdo-daemon/src/node_primitives.rs
@@ -144,6 +144,44 @@ pub fn start_node(params: &StartNodeParams<'_>) -> StartNodeResult {
 
     let full_prompt = crate::prompt_augmenter::build_full_prompt(&aug_ctx, &role_prompt);
 
+    // A `script` node (#248 / ADR-0017) runs the author's bash instead of Claude:
+    // its I/O arrives as env vars (a script can't read the prose preamble) and
+    // its declared output dirs must exist before the body's `>` redirect runs.
+    // Critically, the file `bash` executes must be the RAW body, not the
+    // augmented prompt — the preamble is prose an agent reads, not runnable bash.
+    let is_script = node.node_type == pipeline::NodeType::Script;
+
+    // #248 / ADR-0017: an empty script body would `bash <empty>` → exit 0 → a
+    // silent no-op that masquerades as success. `create_run` refuses this at
+    // launch; guard the manual force-spawn / restart door here too (this
+    // primitive backs the `start_node` command, #204) so the hole stays closed.
+    if is_script && role_prompt.trim().is_empty() {
+        return StartNodeResult {
+            outcome: PrimitiveOutcome::Rejected {
+                reason: format!("script node '{}' has an empty body", params.node_id),
+            },
+            events: vec![],
+        };
+    }
+
+    let spawn_prompt: &str = if is_script { &role_prompt } else { &full_prompt };
+    let script_env = if is_script {
+        crate::prompt_augmenter::precreate_output_dirs(&aug_ctx);
+        crate::prompt_augmenter::build_script_env(&aug_ctx)
+    } else {
+        Vec::new()
+    };
+    let tail = if is_script {
+        tmux_session_manager::SessionTail::Script {
+            timeout_secs: tmux_session_manager::SCRIPT_TIMEOUT_SECS,
+            env: &script_env,
+        }
+    } else {
+        tmux_session_manager::SessionTail::Agent {
+            model: node.model.as_deref(),
+        }
+    };
+
     let node_started = event_log::Event {
         id: None,
         run_id: params.run_id.to_string(),
@@ -162,14 +200,14 @@ pub fn start_node(params: &StartNodeParams<'_>) -> StartNodeResult {
         tmux_session_manager::node_session_name(params.run_id, params.node_id, params.iter);
     if let Err(e) = tmux_session_manager::spawn(
         &session_name,
-        &full_prompt,
+        spawn_prompt,
         &working_dir,
         params.run_id,
         params.node_id,
         params.iter,
         params.daemon_port,
         params.tmux_cmd_override,
-        node.model.as_deref(),
+        tail,
     ) {
         return StartNodeResult {
             outcome: PrimitiveOutcome::Rejected {
@@ -285,6 +323,7 @@ fn node_type_str(nt: &pipeline::NodeType) -> &'static str {
         pipeline::NodeType::Loop => "loop",
         pipeline::NodeType::ForEach => "for-each",
         pipeline::NodeType::Merge => "merge",
+        pipeline::NodeType::Script => "script",
     }
 }
 

--- a/crates/pdo-daemon/src/pipeline.rs
+++ b/crates/pdo-daemon/src/pipeline.rs
@@ -28,15 +28,26 @@ pub enum NodeType {
     Loop,
     ForEach,
     Merge,
+    /// A node that runs author-written bash deterministically instead of
+    /// launching Claude (#248 / ADR-0017). Runs in a tmux session (attachable
+    /// like any NodeRun) whose tail is `timeout N bash <body>`: exit 0 ⇒ node
+    /// completes, non-zero/timeout ⇒ node fails. v1 is doc-only-effect (no
+    /// sub-worktree; runs in the run's shared worktree).
+    Script,
 }
 
 impl NodeType {
-    /// A *regular* node (doc-only / code-mutating) declares no inputs: its inputs
-    /// are emergent, derived from incoming edges and named after the edge target
-    /// port (#149 / ADR-0011). Structural nodes (start/end/switch/loop/for-each/
-    /// merge) keep their required, declared input ports.
+    /// A *regular* node (doc-only / code-mutating / script) declares no inputs:
+    /// its inputs are emergent, derived from incoming edges and named after the
+    /// edge target port (#149 / ADR-0011). Structural nodes (start/end/switch/
+    /// loop/for-each/merge) keep their required, declared input ports. A `script`
+    /// node consumes whole artifacts by edge just like a work node, so its inputs
+    /// are emergent too (#248).
     pub fn has_emergent_inputs(&self) -> bool {
-        matches!(self, NodeType::DocOnly | NodeType::CodeMutating)
+        matches!(
+            self,
+            NodeType::DocOnly | NodeType::CodeMutating | NodeType::Script
+        )
     }
 }
 
@@ -385,6 +396,9 @@ pub fn parse_pipeline(yaml: &str) -> Result<ParseResult, ParseError> {
         "loop",
         "for-each",
         "merge",
+        // #248: without this, a `type: script` node is silently rewritten to
+        // `doc-only` with only a diagnostic (see the layer-1 test).
+        "script",
     ];
 
     if let Some(nodes) = raw
@@ -2122,6 +2136,97 @@ nodes:
         assert!(mg.inputs[0].repeated);
         assert_eq!(mg.outputs.len(), 1);
         assert_eq!(mg.outputs[0].name, "merged");
+    }
+
+    // --- Script node tests (#248 / ADR-0017) ---
+
+    #[test]
+    fn parses_script_node() {
+        let yaml = with_start_end(
+            r#"
+name: script-test
+nodes:
+  - id: ab000001
+    name: notify
+    type: script
+    outputs:
+      - name: out
+"#,
+        );
+        let result = parse_pipeline(&yaml).unwrap();
+        let node = result
+            .pipeline
+            .nodes
+            .iter()
+            .find(|n| n.id == "ab000001")
+            .unwrap();
+        assert_eq!(node.node_type, NodeType::Script);
+        assert_eq!(node.outputs.len(), 1);
+        assert_eq!(node.outputs[0].name, "out");
+    }
+
+    #[test]
+    fn script_node_is_not_rewritten_to_doc_only() {
+        // ⚠️ silent-failure guard: `script` must be in `valid_types`, else
+        // `parse_pipeline` degrades the node to `doc-only` with a diagnostic.
+        let yaml = with_start_end(
+            r#"
+name: script-not-rewritten
+nodes:
+  - id: ab000001
+    name: notify
+    type: script
+"#,
+        );
+        let result = parse_pipeline(&yaml).unwrap();
+        let node = result
+            .pipeline
+            .nodes
+            .iter()
+            .find(|n| n.id == "ab000001")
+            .unwrap();
+        assert_eq!(node.node_type, NodeType::Script, "must not degrade to doc-only");
+        assert!(
+            !result
+                .diagnostics
+                .iter()
+                .any(|d| d.message.contains("ab000001")),
+            "no rewrite diagnostic for a valid script node: {:?}",
+            result.diagnostics
+        );
+    }
+
+    #[test]
+    fn script_node_has_emergent_inputs() {
+        assert!(NodeType::Script.has_emergent_inputs());
+    }
+
+    #[test]
+    fn script_node_roundtrips_via_serde() {
+        let node = NodeDef {
+            id: "s1".into(),
+            name: "notify".into(),
+            node_type: NodeType::Script,
+            inputs: vec![],
+            outputs: vec![Port {
+                name: "out".into(),
+                repeated: false,
+                side: None,
+                port_type: PortType::Markdown,
+                frontmatter: None,
+                when: None,
+                description: None,
+            }],
+            interactive: false,
+            view: None,
+            max_iter: None,
+            over: None,
+            model: None,
+        };
+        let yaml = serde_yaml::to_string(&node).unwrap();
+        assert!(yaml.contains("type: script"), "serializes to kebab: {yaml}");
+        let back: NodeDef = serde_yaml::from_str(&yaml).unwrap();
+        assert_eq!(back.node_type, NodeType::Script);
     }
 
     #[test]

--- a/crates/pdo-daemon/src/prompt_augmenter.rs
+++ b/crates/pdo-daemon/src/prompt_augmenter.rs
@@ -186,6 +186,131 @@ pub fn resolve_output_paths(ctx: &AugmentContext<'_>) -> Vec<OutputDeclaration> 
         .collect()
 }
 
+/// Sanitize a port / variable name into an env-var suffix: ASCII-upper-cased,
+/// every non-alphanumeric byte replaced with `_` (#248). `out` → `OUT`,
+/// `my-port.v2` → `MY_PORT_V2`.
+fn env_name_suffix(name: &str) -> String {
+    name.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() {
+                c.to_ascii_uppercase()
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+/// Render a pipeline-variable value as the raw string a `script` node's bash
+/// reads from `$PDO_VAR_<NAME>` (#248). Scalars are emitted verbatim — NOT via
+/// `serde_yaml::to_string`, which would quote bool-/number-looking strings
+/// (`"true"` → `'true'`) and leak those quotes into the env value. Sequences and
+/// mappings have no natural scalar form, so they are emitted as compact JSON a
+/// script can parse deterministically (e.g. with `jq`).
+fn var_value_to_env_string(value: &serde_yaml::Value) -> String {
+    match value {
+        serde_yaml::Value::Null => String::new(),
+        serde_yaml::Value::Bool(b) => b.to_string(),
+        serde_yaml::Value::Number(n) => n.to_string(),
+        serde_yaml::Value::String(s) => s.clone(),
+        other => serde_json::to_string(other).unwrap_or_default(),
+    }
+}
+
+/// Build the `PDO_*` environment catalogue handed to a `script` node's bash
+/// (#248 / ADR-0017). A script can't read the prose preamble, so its inputs,
+/// outputs, artifacts root, and pipeline variables arrive as environment
+/// variables. Mirrors the `resolve_input_paths` / `resolve_output_paths`
+/// resolution the preamble uses — a single source of truth, not a second path.
+///
+/// - `PDO_ARTIFACTS_DIR` — the Blackboard root.
+/// - `PDO_INPUT_<PORT>` — absolute path (or `iter-*` glob) of each resolved input.
+/// - `PDO_INPUT_<PORT>_REPEATED=1` — set when that input is a `repeated` glob.
+/// - `PDO_OUTPUT_<PORT>` — absolute path the script writes its `output.md` to.
+/// - `PDO_VAR_<NAME>` — each resolved pipeline variable (sorted for determinism).
+///
+/// The base four (`PDO_RUN_ID`/`NODE_ID`/`NODE_ITER`/`DAEMON_URL`) are exported
+/// by `tmux_session_manager::wrap_with_env` and are *not* repeated here.
+pub fn build_script_env(ctx: &AugmentContext<'_>) -> Vec<(String, String)> {
+    let mut env = Vec::new();
+
+    env.push((
+        "PDO_ARTIFACTS_DIR".to_string(),
+        ctx.artifacts_dir.to_string_lossy().into_owned(),
+    ));
+
+    for input in resolve_input_paths(ctx) {
+        let key = format!("PDO_INPUT_{}", env_name_suffix(&input.port_name));
+        if input.repeated {
+            env.push((format!("{key}_REPEATED"), "1".to_string()));
+        }
+        env.push((key, input.path.to_string_lossy().into_owned()));
+    }
+
+    for output in resolve_output_paths(ctx) {
+        env.push((
+            format!("PDO_OUTPUT_{}", env_name_suffix(&output.port_name)),
+            output.path.to_string_lossy().into_owned(),
+        ));
+    }
+
+    // HashMap iteration order is non-deterministic; sort so the emitted script
+    // bytes are stable (test determinism, ADR-0002 mechanical determinism).
+    let mut vars: Vec<_> = ctx.variables.iter().collect();
+    vars.sort_by(|a, b| a.0.cmp(b.0));
+    for (name, value) in vars {
+        env.push((
+            format!("PDO_VAR_{}", env_name_suffix(name)),
+            var_value_to_env_string(value),
+        ));
+    }
+
+    // Name sanitization (`env_name_suffix`) can collapse distinct port/variable
+    // names onto the same env key (`foo-bar` and `foo_bar` → `PDO_INPUT_FOO_BAR`),
+    // and the last export silently wins. That is a per-spec mapping (the plan's
+    // "non-alnum → _"), but a silent shadow is a footgun — surface it loudly so
+    // an author can rename, rather than debugging a script that read the wrong
+    // path (ADR-0004 « jamais de comportement silencieux »).
+    let mut seen = std::collections::HashSet::new();
+    for (key, _) in &env {
+        if !seen.insert(key.as_str()) {
+            tracing::warn!(
+                "script node {}: env var {key} is set more than once — port/variable \
+                 names collide after sanitization; the last value wins",
+                ctx.node.id
+            );
+        }
+    }
+
+    env
+}
+
+/// Pre-create the directory of every declared output port for a `script` node
+/// (#248). Agents create these lazily via the Write tool, but a bash
+/// `> "$PDO_OUTPUT_out"` fails on a missing parent. For a Markdown port the path
+/// is `.../output.md` (create its parent); for an image port it is a directory
+/// (create it directly). Best-effort: a failure here is not fatal — the script's
+/// own redirect will surface any real problem.
+pub fn precreate_output_dirs(ctx: &AugmentContext<'_>) {
+    for output in resolve_output_paths(ctx) {
+        let dir = match output.port_type {
+            PortType::Image | PortType::ImageList => output.path.clone(),
+            PortType::Markdown => output
+                .path
+                .parent()
+                .map(|p| p.to_path_buf())
+                .unwrap_or(output.path),
+        };
+        if let Err(e) = std::fs::create_dir_all(&dir) {
+            tracing::warn!(
+                "failed to pre-create output dir {} for script node {}: {e}",
+                dir.display(),
+                ctx.node.id
+            );
+        }
+    }
+}
+
 pub fn build_preamble(ctx: &AugmentContext<'_>) -> String {
     let inputs = resolve_input_paths(ctx);
     let outputs = resolve_output_paths(ctx);
@@ -644,6 +769,106 @@ mod tests {
         assert_eq!(
             outputs[0].path,
             PathBuf::from("/repo/.pdo/artifacts/planner/iter-1/plan/output.md")
+        );
+    }
+
+    #[test]
+    fn script_env_catalogue_is_built_from_the_same_resolution() {
+        // #248: a script node's I/O arrives as PDO_* env vars derived from the
+        // same input/output resolution the prose preamble uses.
+        let pipeline = sample_pipeline();
+        let node = &pipeline.nodes[0]; // planner: input `task`, output `plan`
+        let mut vars = HashMap::new();
+        vars.insert(
+            "max_iter".into(),
+            serde_yaml::Value::Number(serde_yaml::Number::from(5)),
+        );
+        let ctx = sample_ctx(&pipeline, node, &vars);
+
+        let env: HashMap<String, String> = build_script_env(&ctx).into_iter().collect();
+
+        assert_eq!(
+            env.get("PDO_ARTIFACTS_DIR").map(String::as_str),
+            Some("/repo/.pdo/artifacts")
+        );
+        assert_eq!(
+            env.get("PDO_INPUT_TASK").map(String::as_str),
+            Some("/repo/.pdo/artifacts/_input/output.md")
+        );
+        assert_eq!(
+            env.get("PDO_OUTPUT_PLAN").map(String::as_str),
+            Some("/repo/.pdo/artifacts/planner/iter-1/plan/output.md")
+        );
+        assert_eq!(env.get("PDO_VAR_MAX_ITER").map(String::as_str), Some("5"));
+    }
+
+    #[test]
+    fn script_env_var_values_are_raw_not_yaml_quoted() {
+        // #248 regression: serde_yaml::to_string quotes bool-/number-looking
+        // strings ("true" → 'true'); those quotes must NOT leak into the env
+        // value a script's bash reads. A script consumes raw bytes, so
+        // `[ "$PDO_VAR_FLAG" = "true" ]` must compare against `true`, not `'true'`.
+        let pipeline = sample_pipeline();
+        let node = &pipeline.nodes[0];
+        let mut vars = HashMap::new();
+        vars.insert("flag".into(), serde_yaml::Value::String("true".into()));
+        vars.insert("port".into(), serde_yaml::Value::String("8080".into()));
+        vars.insert(
+            "count".into(),
+            serde_yaml::Value::Number(serde_yaml::Number::from(3)),
+        );
+        vars.insert("enabled".into(), serde_yaml::Value::Bool(true));
+        vars.insert("plain".into(), serde_yaml::Value::String("hello world".into()));
+        let ctx = sample_ctx(&pipeline, node, &vars);
+
+        let env: HashMap<String, String> = build_script_env(&ctx).into_iter().collect();
+        assert_eq!(env.get("PDO_VAR_FLAG").map(String::as_str), Some("true"));
+        assert_eq!(env.get("PDO_VAR_PORT").map(String::as_str), Some("8080"));
+        assert_eq!(env.get("PDO_VAR_COUNT").map(String::as_str), Some("3"));
+        assert_eq!(env.get("PDO_VAR_ENABLED").map(String::as_str), Some("true"));
+        assert_eq!(env.get("PDO_VAR_PLAIN").map(String::as_str), Some("hello world"));
+    }
+
+    #[test]
+    fn script_env_marks_repeated_inputs() {
+        // A `repeated` edge → PDO_INPUT_<PORT> is an iter-* glob + a _REPEATED=1
+        // flag so the script knows to glob rather than read a single file.
+        let mut pipeline = sample_pipeline();
+        pipeline.nodes.push(NodeDef {
+            id: "collector".into(),
+            name: "collector".into(),
+            node_type: NodeType::Script,
+            inputs: vec![],
+            outputs: vec![],
+            interactive: false,
+            view: None,
+            max_iter: None,
+            over: None,
+            model: None,
+        });
+        pipeline.edges.push(EdgeDef {
+            source: EdgeEndpoint {
+                node: "planner".into(),
+                port: "plan".into(),
+            },
+            target: EdgeEndpoint {
+                node: "collector".into(),
+                port: "laps".into(),
+            },
+            repeated: true,
+            ..Default::default()
+        });
+        let node = pipeline.nodes.iter().find(|n| n.id == "collector").unwrap();
+        let vars = HashMap::new();
+        let ctx = sample_ctx(&pipeline, node, &vars);
+
+        let env: HashMap<String, String> = build_script_env(&ctx).into_iter().collect();
+        assert_eq!(env.get("PDO_INPUT_LAPS_REPEATED").map(String::as_str), Some("1"));
+        assert!(
+            env.get("PDO_INPUT_LAPS")
+                .map(|v| v.contains("iter-*"))
+                .unwrap_or(false),
+            "repeated input is a glob: {env:?}"
         );
     }
 

--- a/crates/pdo-daemon/src/tmux_session_manager.rs
+++ b/crates/pdo-daemon/src/tmux_session_manager.rs
@@ -53,6 +53,33 @@ fn enable_mouse(socket: &str, session_name: &str) {
         .output();
 }
 
+/// Default wall-clock bound for a `script` node's bash body (#248 / ADR-0017).
+/// Mirrors the trigger guard's 60 s (`guard_runner`). A script has no JSONL, so
+/// the stale-detector can never fire on it — the in-wrapper `timeout` is the
+/// *only* thing that bounds a hung script, hence it is mandatory, not optional.
+pub const SCRIPT_TIMEOUT_SECS: u64 = 60;
+
+/// What a spawned tmux session runs after the shared `PDO_*` env exports.
+///
+/// The default is [`SessionTail::Agent`] — launch `claude` with the node's
+/// prompt. A [`SessionTail::Script`] node (#248 / ADR-0017) instead runs the
+/// author's bash body under a `timeout` and self-signals via `pdo complete` /
+/// `pdo fail` — no LLM, no `tmux_cmd_override` (a script *is* deterministic
+/// bash, so the test seam must not clobber it).
+pub enum SessionTail<'a> {
+    /// Agent node / manager / merge-resolver. `model` is the per-node model
+    /// override (#296); `None` ⇒ account default (byte-identical legacy launch).
+    Agent { model: Option<&'a str> },
+    /// Script node (#248). Runs `timeout <secs>s bash <body>` then completes on
+    /// exit 0 / fails otherwise. `env` is the `PDO_INPUT_*`/`PDO_OUTPUT_*`/… I/O
+    /// catalogue exported before the body (a script can't read the prose
+    /// preamble).
+    Script {
+        timeout_secs: u64,
+        env: &'a [(String, String)],
+    },
+}
+
 /// Env var that overrides the reaper TTL (seconds). Default: 3600 (1 h).
 pub const REAPER_TTL_SECS_ENV: &str = "PDO_REAPER_TTL_SECS";
 
@@ -99,20 +126,32 @@ fn sh_single_quote(s: &str) -> String {
 /// pushes `end_session`, claude tears down, opens `/dev/tty` (ENXIO inside the
 /// tmux pane), writes `~/.claude.json`, and force-exits via `kill(getpid(),
 /// SIGKILL)`. That's the "Tester dies silently 20–60 s in" bug.
+///
+/// `extra_env` are additional `export K=V` pairs injected *after* the base four
+/// and the CCR suppression, before the tail. Agents pass `&[]`, so the emitted
+/// bytes are identical to the legacy command (the #296 byte-identity discipline)
+/// — only `script` nodes populate it with the `PDO_INPUT_*`/`PDO_OUTPUT_*`/…
+/// catalogue.
 fn wrap_with_env(
     run_id: &str,
     node_id: &str,
     iter: i64,
     daemon_port: u16,
+    extra_env: &[(String, String)],
     tail_cmd: &str,
 ) -> String {
+    let extra_exports: String = extra_env
+        .iter()
+        .map(|(k, v)| format!("export {k}={} && ", sh_single_quote(v)))
+        .collect();
+
     let inner = format!(
         "export PDO_RUN_ID={run_id_q} && \
          export PDO_NODE_ID={node_id_q} && \
          export PDO_NODE_ITER={iter_q} && \
          export PDO_DAEMON_URL={daemon_url_q} && \
          export CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1 && \
-         {tail_cmd}",
+         {extra_exports}{tail_cmd}",
         run_id_q = sh_single_quote(run_id),
         node_id_q = sh_single_quote(node_id),
         iter_q = sh_single_quote(&iter.to_string()),
@@ -122,15 +161,53 @@ fn wrap_with_env(
     format!("exec bash -c {}", sh_single_quote(&inner))
 }
 
+/// Build the `exec claude …` tail for an agent node. `model` `Some(m)` inserts
+/// `--model '<m>'`; `None` reproduces the legacy command byte-for-byte.
+fn build_agent_tail(prompt_path: &Path, model: Option<&str>) -> String {
+    // `Some` ⇒ a single-quoted `--model '<m>' ` with a trailing space;
+    // `None` ⇒ empty string, so the command collapses to the exact legacy
+    // literal (one space before the `"$(cat …)"`).
+    let model_flag = match model {
+        Some(m) => format!("--model {} ", sh_single_quote(m)),
+        None => String::new(),
+    };
+    format!(
+        "exec claude --dangerously-skip-permissions {}\"$(cat {})\"",
+        model_flag,
+        sh_single_quote(&prompt_path.to_string_lossy())
+    )
+}
+
+/// Build the bash tail for a `script` node (#248 / ADR-0017).
+///
+/// Runs the author's body under `timeout` then self-signals: exit 0 ⇒
+/// `pdo complete` (with a `pdo fail` fallback so a post-success output-validation
+/// rejection still terminates the node); exit 124 (timeout) or any non-zero ⇒
+/// `pdo fail` with a diagnostic reason. **Not** `exec`-ed: unlike the agent tail
+/// (`exec claude`), the wrapper must run the bash *and then* run `pdo`, so it is
+/// a plain sequence. Ordering `pdo complete` before shell exit makes the node
+/// terminal before the session dies (#304).
+fn build_script_tail(prompt_path: &Path, timeout_secs: u64) -> String {
+    let body = sh_single_quote(&prompt_path.to_string_lossy());
+    format!(
+        "timeout {timeout_secs}s bash {body} ; ec=$? ; \
+         if [ $ec -eq 0 ]; then pdo complete || pdo fail --reason \"output validation failed after script success\" ; \
+         elif [ $ec -eq 124 ]; then pdo fail --reason \"script timed out after {timeout_secs}s\" ; \
+         else pdo fail --reason \"script exited $ec\" ; fi"
+    )
+}
+
 /// Construct the script tmux launches for a node run.
 ///
 /// `tmux_cmd_override` replaces the default `claude …` tail when `Some` — the
 /// per-daemon test seam (see [`TMUX_CMD_OVERRIDE_ENV`]). `None` → production
-/// claude invocation.
+/// claude invocation. **Ignored for a [`SessionTail::Script`]** node: a script
+/// *is* deterministic bash, so the override must not clobber it (a strictly
+/// stronger property — a script node is end-to-end testable in CI with zero
+/// stubbing).
 ///
-/// `model` is the per-node model override (#296). `Some(m)` inserts
-/// `--model '<m>'` into the launch; `None` reproduces the legacy command
-/// byte-for-byte (no flag emitted). Ignored when `tmux_cmd_override` is `Some`.
+/// `tail` selects the launch: [`SessionTail::Agent`] with the per-node `model`
+/// (#296), or [`SessionTail::Script`] with its `timeout` and I/O env catalogue.
 pub fn build_tmux_script(
     run_id: &str,
     node_id: &str,
@@ -138,27 +215,23 @@ pub fn build_tmux_script(
     daemon_port: u16,
     prompt_path: &Path,
     tmux_cmd_override: Option<&str>,
-    model: Option<&str>,
+    tail: SessionTail<'_>,
 ) -> String {
-    let tail_cmd = match tmux_cmd_override {
-        Some(cmd) => cmd.to_string(),
-        None => {
-            // `Some` ⇒ a single-quoted `--model '<m>' ` with a trailing space;
-            // `None` ⇒ empty string, so the command collapses to the exact
-            // legacy literal (one space before the `"$(cat …)"`).
-            let model_flag = match model {
-                Some(m) => format!("--model {} ", sh_single_quote(m)),
-                None => String::new(),
+    const NO_ENV: &[(String, String)] = &[];
+    let (tail_cmd, extra_env): (String, &[(String, String)]) = match tail {
+        SessionTail::Script { timeout_secs, env } => {
+            (build_script_tail(prompt_path, timeout_secs), env)
+        }
+        SessionTail::Agent { model } => {
+            let cmd = match tmux_cmd_override {
+                Some(cmd) => cmd.to_string(),
+                None => build_agent_tail(prompt_path, model),
             };
-            format!(
-                "exec claude --dangerously-skip-permissions {}\"$(cat {})\"",
-                model_flag,
-                sh_single_quote(&prompt_path.to_string_lossy())
-            )
+            (cmd, NO_ENV)
         }
     };
 
-    wrap_with_env(run_id, node_id, iter, daemon_port, &tail_cmd)
+    wrap_with_env(run_id, node_id, iter, daemon_port, extra_env, &tail_cmd)
 }
 
 /// Build a resume script that uses `claude --continue` in the same working_dir.
@@ -183,7 +256,7 @@ fn build_resume_script(
         None => "exec claude --dangerously-skip-permissions --continue".to_string(),
     };
 
-    wrap_with_env(run_id, node_id, iter, daemon_port, &tail_cmd)
+    wrap_with_env(run_id, node_id, iter, daemon_port, &[], &tail_cmd)
 }
 
 // ---------------------------------------------------------------------------
@@ -218,7 +291,7 @@ pub fn spawn(
     iter: i64,
     daemon_port: u16,
     tmux_cmd_override: Option<&str>,
-    model: Option<&str>,
+    tail: SessionTail<'_>,
 ) -> Result<()> {
     let prompt_dir = working_dir.join(".pdo").join("prompts");
     std::fs::create_dir_all(&prompt_dir)?;
@@ -232,7 +305,7 @@ pub fn spawn(
         daemon_port,
         &prompt_path,
         tmux_cmd_override,
-        model,
+        tail,
     );
     let socket = tmux_socket_name(daemon_port);
 
@@ -638,7 +711,15 @@ mod tests {
         let prompt_path = Path::new("/tmp/test-prompt.md");
 
         // None → production claude tail.
-        let script = build_tmux_script("run-abc", "solo", 1, 5172, prompt_path, None, None);
+        let script = build_tmux_script(
+            "run-abc",
+            "solo",
+            1,
+            5172,
+            prompt_path,
+            None,
+            SessionTail::Agent { model: None },
+        );
         assert!(script.starts_with("exec bash -c "));
         assert!(script.contains("exec claude --dangerously-skip-permissions"));
         assert!(script.contains("PDO_RUN_ID"));
@@ -653,7 +734,7 @@ mod tests {
             5172,
             prompt_path,
             Some("exec sleep 60"),
-            None,
+            SessionTail::Agent { model: None },
         );
         assert!(script.contains("exec sleep 60"));
         assert!(!script.contains("claude"));
@@ -666,7 +747,15 @@ mod tests {
         // This is the byte-identity guard: adding the flag must not perturb the
         // default launch.
         let prompt_path = Path::new("/tmp/test-prompt.md");
-        let script = build_tmux_script("run-abc", "solo", 1, 5172, prompt_path, None, None);
+        let script = build_tmux_script(
+            "run-abc",
+            "solo",
+            1,
+            5172,
+            prompt_path,
+            None,
+            SessionTail::Agent { model: None },
+        );
         assert!(!script.contains("--model"), "no model flag when unset: {script}");
         // The exact legacy tail, single space before the cat substitution.
         assert!(
@@ -685,8 +774,15 @@ mod tests {
         // `sh_single_quote` as `'\''` — i.e. `--model 'opus'` becomes
         // `--model '\''opus'\''` in the final script bytes.
         let prompt_path = Path::new("/tmp/test-prompt.md");
-        let script =
-            build_tmux_script("run-abc", "solo", 1, 5172, prompt_path, None, Some("opus"));
+        let script = build_tmux_script(
+            "run-abc",
+            "solo",
+            1,
+            5172,
+            prompt_path,
+            None,
+            SessionTail::Agent { model: Some("opus") },
+        );
         assert!(script.contains("--model"), "model flag present: {script}");
         assert!(
             script.contains(r"--model '\''opus'\''"),
@@ -700,6 +796,88 @@ mod tests {
         let model_at = script.find("--model").unwrap();
         let cat_at = script.find("$(cat").unwrap();
         assert!(model_at < cat_at, "model flag must precede the prompt cat: {script}");
+    }
+
+    #[test]
+    fn build_script_tail_runs_bash_and_self_signals() {
+        // #248: a script node's tail runs the author's bash under `timeout`,
+        // then completes on exit 0 / fails on non-zero or timeout. No claude,
+        // and the tail is NOT `exec`-ed (the wrapper must run bash *then* pdo).
+        let prompt_path = Path::new("/tmp/body.md");
+        let script = build_tmux_script(
+            "run-abc",
+            "solo",
+            1,
+            5172,
+            prompt_path,
+            None,
+            SessionTail::Script {
+                timeout_secs: 42,
+                env: &[],
+            },
+        );
+        assert!(script.starts_with("exec bash -c "));
+        assert!(!script.contains("claude"), "script node launches no claude: {script}");
+        assert!(script.contains("timeout 42s bash"), "runs body under timeout: {script}");
+        assert!(script.contains("pdo complete"), "completes on success: {script}");
+        assert!(script.contains("pdo fail --reason"), "fails otherwise: {script}");
+        assert!(script.contains("script exited $ec"), "reports the exit code: {script}");
+        assert!(script.contains("script timed out after 42s"), "reports timeout: {script}");
+        // Base env is still exported.
+        assert!(script.contains("PDO_RUN_ID"));
+        assert!(script.contains("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1"));
+    }
+
+    #[test]
+    fn build_script_tail_bypasses_cmd_override() {
+        // #248: the test seam (`tmux_cmd_override`) swaps claude for a stub so CI
+        // never launches real claude. A script IS deterministic bash, so the
+        // override must NOT clobber it — the wrapper is built unconditionally.
+        let prompt_path = Path::new("/tmp/body.md");
+        let script = build_tmux_script(
+            "run-abc",
+            "solo",
+            1,
+            5172,
+            prompt_path,
+            Some("exec sleep 99"),
+            SessionTail::Script {
+                timeout_secs: 60,
+                env: &[],
+            },
+        );
+        assert!(!script.contains("sleep 99"), "override ignored for scripts: {script}");
+        assert!(script.contains("timeout 60s bash"), "script tail preserved: {script}");
+    }
+
+    #[test]
+    fn build_script_tail_injects_env_catalogue() {
+        // #248: a script can't read the prose preamble, so its I/O arrives as env
+        // vars, exported before the body — after the base four (byte-identity for
+        // agents preserved: they pass an empty env).
+        let prompt_path = Path::new("/tmp/body.md");
+        let env = vec![
+            ("PDO_INPUT_TASK".to_string(), "/art/_input/output.md".to_string()),
+            ("PDO_OUTPUT_OUT".to_string(), "/art/solo/iter-1/out/output.md".to_string()),
+        ];
+        let script = build_tmux_script(
+            "run-abc",
+            "solo",
+            1,
+            5172,
+            prompt_path,
+            None,
+            SessionTail::Script {
+                timeout_secs: 60,
+                env: &env,
+            },
+        );
+        assert!(script.contains("export PDO_INPUT_TASK="), "input env exported: {script}");
+        assert!(script.contains("export PDO_OUTPUT_OUT="), "output env exported: {script}");
+        // The env exports precede the body invocation.
+        let env_at = script.find("PDO_OUTPUT_OUT").unwrap();
+        let body_at = script.find("timeout 60s bash").unwrap();
+        assert!(env_at < body_at, "env must be exported before the body runs: {script}");
     }
 
     #[test]

--- a/crates/pdo-daemon/tests/script_node.rs
+++ b/crates/pdo-daemon/tests/script_node.rs
@@ -1,0 +1,314 @@
+//! Layer 3a — `script` node type (#248 / ADR-0017).
+//!
+//! A script node runs the author's bash in a tmux session (bash instead of
+//! `claude`) and self-signals via `pdo complete` / `pdo fail`. This is the
+//! *only* node type that is end-to-end testable in CI with **zero stubbing**:
+//! the script IS deterministic bash, so it bypasses the `tmux_cmd_override`
+//! test seam entirely (the daemon's default `exec sleep 600` override does not
+//! touch it). These tests drive `POST /runs` → poll `GET /runs/{id}` and assert
+//! on the real terminal state the bash produced.
+//!
+//! The tmux session's wrapper calls bare `pdo complete`/`pdo fail`, so the
+//! built `pdo` binary must be resolvable on PATH inside the session. The tmux
+//! server inherits the daemon (= test process) environment at first spawn, so
+//! we prepend `CARGO_BIN_EXE_pdo`'s directory to PATH once before spawning.
+
+mod common;
+
+use std::process::Command;
+use std::sync::Once;
+use std::time::Duration;
+
+use common::TestDaemon;
+
+const PIPELINE_NAME: &str = "script-cycle";
+const NODE_ID: &str = "notify";
+
+/// A `start → script → end` pipeline. The script declares one output port
+/// (`out`); its bash body is seeded per-test into the node's prompt slot.
+const PIPELINE_YAML: &str = r#"name: script-cycle
+version: "1.0"
+nodes:
+  - id: start
+    name: Start
+    type: start
+    outputs:
+      - name: user_prompt
+  - id: notify
+    name: notify
+    type: script
+    outputs:
+      - name: out
+  - id: end
+    name: End
+    type: end
+    inputs:
+      - name: result
+edges:
+  - source: { node: start, port: user_prompt }
+    target: { node: notify, port: in }
+  - source: { node: notify, port: out }
+    target: { node: end, port: result }
+"#;
+
+/// A pipeline where the script declares NO output port (the Discord-ping shape:
+/// a pure side effect). `outputs_validator` no-ops for it. `end` is fed straight
+/// from `start` so the run can complete without an output from `notify`.
+const PIPELINE_YAML_NO_OUTPUT: &str = r#"name: script-noout
+version: "1.0"
+nodes:
+  - id: start
+    name: Start
+    type: start
+    outputs:
+      - name: user_prompt
+  - id: notify
+    name: notify
+    type: script
+  - id: end
+    name: End
+    type: end
+    inputs:
+      - name: result
+edges:
+  - source: { node: start, port: user_prompt }
+    target: { node: notify, port: in }
+  - source: { node: start, port: user_prompt }
+    target: { node: end, port: result }
+"#;
+
+fn ensure_pdo_on_path() {
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        let bin = std::path::Path::new(env!("CARGO_BIN_EXE_pdo"));
+        let dir = bin.parent().expect("pdo binary has a parent dir");
+        let existing = std::env::var("PATH").unwrap_or_default();
+        std::env::set_var("PATH", format!("{}:{}", dir.display(), existing));
+    });
+}
+
+fn git_init_with_commit(repo: &std::path::Path) -> anyhow::Result<()> {
+    let run = |args: &[&str]| -> anyhow::Result<()> {
+        let out = Command::new("git").args(args).current_dir(repo).output()?;
+        if !out.status.success() {
+            anyhow::bail!("git {:?} failed: {}", args, String::from_utf8_lossy(&out.stderr));
+        }
+        Ok(())
+    };
+    run(&["init", "-q", "-b", "main"])?;
+    run(&["config", "user.email", "test@example.com"])?;
+    run(&["config", "user.name", "Test"])?;
+    run(&["config", "commit.gpgsign", "false"])?;
+    std::fs::write(repo.join(".gitignore"), ".pdo/runs/\n")?;
+    run(&["add", "."])?;
+    run(&["commit", "-q", "-m", "init"])?;
+    Ok(())
+}
+
+/// Seed the pipeline YAML + the script node's bash body (into its prompt slot).
+fn seed_with(yaml: &str, name: &str, body: &str) -> impl FnOnce(&std::path::Path) -> anyhow::Result<()> {
+    let yaml = yaml.to_string();
+    let name = name.to_string();
+    let body = body.to_string();
+    move |repo: &std::path::Path| {
+        let pipelines_dir = repo.join(".pdo").join("pipelines");
+        std::fs::create_dir_all(&pipelines_dir)?;
+        std::fs::write(pipelines_dir.join(format!("{name}.yaml")), &yaml)?;
+        let prompts_dir = pipelines_dir.join(format!("{name}.prompts"));
+        std::fs::create_dir_all(&prompts_dir)?;
+        std::fs::write(prompts_dir.join(format!("{NODE_ID}.md")), &body)?;
+        git_init_with_commit(repo)?;
+        Ok(())
+    }
+}
+
+async fn start_run(daemon: &TestDaemon, pipeline: &str) -> String {
+    let body = serde_json::json!({ "pipeline": pipeline, "input": "hello" });
+    let resp = reqwest::Client::new()
+        .post(format!("{}/runs", daemon.url()))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 201, "POST /runs should create the run");
+    resp.json::<serde_json::Value>().await.unwrap()["run_id"]
+        .as_str()
+        .unwrap()
+        .to_string()
+}
+
+/// Poll `GET /runs/{id}` until `nodes[node_id].status` reaches `expected`, or
+/// time out. Returns the final run JSON.
+async fn wait_for_node_status(
+    daemon: &TestDaemon,
+    run_id: &str,
+    node_id: &str,
+    expected: &str,
+) -> serde_json::Value {
+    let deadline = Duration::from_secs(30);
+    let started = std::time::Instant::now();
+    let mut last = serde_json::Value::Null;
+    while started.elapsed() < deadline {
+        let run = reqwest::get(format!("{}/runs/{run_id}", daemon.url()))
+            .await
+            .unwrap()
+            .json::<serde_json::Value>()
+            .await
+            .unwrap();
+        let status = run["nodes"][node_id]["status"].as_str().unwrap_or("");
+        if status == expected {
+            return run;
+        }
+        // Terminal-but-unexpected: fail fast rather than spin the full timeout.
+        if matches!(status, "failed" | "completed") && status != expected {
+            return run;
+        }
+        last = run;
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+    last
+}
+
+#[tokio::test]
+async fn script_node_completes_on_exit_zero() {
+    ensure_pdo_on_path();
+    // Body: write a sentinel (untracked → passes the doc-only-effect clean
+    // guard) and the declared output via $PDO_OUTPUT_OUT.
+    let body = "#!/usr/bin/env bash\nset -euo pipefail\n\
+        echo ok > SENTINEL_SCRIPT\n\
+        printf 'hello from a script node\\n' > \"$PDO_OUTPUT_OUT\"\n";
+    let daemon = TestDaemon::spawn(seed_with(PIPELINE_YAML, PIPELINE_NAME, body))
+        .await
+        .unwrap();
+
+    let run_id = start_run(&daemon, PIPELINE_NAME).await;
+    let run = wait_for_node_status(&daemon, &run_id, NODE_ID, "completed").await;
+    assert_eq!(
+        run["nodes"][NODE_ID]["status"], "completed",
+        "script node should complete on exit 0; run was: {run}"
+    );
+
+    // The author-written output.md is present with the expected bytes.
+    let out = daemon
+        .repo_root()
+        .join(".pdo/runs")
+        .join(&run_id)
+        .join("worktree/.pdo/artifacts")
+        .join(NODE_ID)
+        .join("iter-1/out/output.md");
+    let content = std::fs::read_to_string(&out).expect("output.md should exist");
+    assert!(content.contains("hello from a script node"), "output bytes: {content}");
+
+    // The side effect landed in the run's shared worktree.
+    let sentinel = daemon
+        .repo_root()
+        .join(".pdo/runs")
+        .join(&run_id)
+        .join("worktree/SENTINEL_SCRIPT");
+    assert!(sentinel.exists(), "sentinel side-effect should exist at {sentinel:?}");
+}
+
+#[tokio::test]
+async fn script_node_fails_on_nonzero_exit() {
+    ensure_pdo_on_path();
+    // A non-zero exit fails the node before any output check, so the declared
+    // output port in PIPELINE_YAML is irrelevant here.
+    let body = "#!/usr/bin/env bash\nexit 7\n";
+    let daemon = TestDaemon::spawn(seed_with(PIPELINE_YAML, PIPELINE_NAME, body))
+        .await
+        .unwrap();
+
+    let run_id = start_run(&daemon, PIPELINE_NAME).await;
+    let run = wait_for_node_status(&daemon, &run_id, NODE_ID, "failed").await;
+    assert_eq!(
+        run["nodes"][NODE_ID]["status"], "failed",
+        "a non-zero exit must fail the node; run was: {run}"
+    );
+    let reason = run["nodes"][NODE_ID]["failure_reason"].as_str().unwrap_or("");
+    assert!(reason.contains("exited 7"), "reason should name the exit code; got: {reason}");
+}
+
+#[tokio::test]
+async fn script_node_timeout_exit_code_fails_with_timeout_reason() {
+    ensure_pdo_on_path();
+    // A body that exits 124 is indistinguishable to the wrapper from a real
+    // `timeout` expiry (which also exits 124) — this exercises the exit-code →
+    // timeout-reason mapping without waiting out the 60s wall-clock bound.
+    let body = "#!/usr/bin/env bash\nexit 124\n";
+    let daemon = TestDaemon::spawn(seed_with(PIPELINE_YAML, PIPELINE_NAME, body))
+        .await
+        .unwrap();
+
+    let run_id = start_run(&daemon, PIPELINE_NAME).await;
+    let run = wait_for_node_status(&daemon, &run_id, NODE_ID, "failed").await;
+    assert_eq!(run["nodes"][NODE_ID]["status"], "failed", "run was: {run}");
+    let reason = run["nodes"][NODE_ID]["failure_reason"].as_str().unwrap_or("");
+    assert!(reason.contains("timed out"), "reason should say timed out; got: {reason}");
+}
+
+#[tokio::test]
+async fn script_node_with_no_output_completes() {
+    ensure_pdo_on_path();
+    // The Discord-ping shape: a pure side effect, zero declared outputs.
+    // `outputs_validator` no-ops (no ports), so exit 0 ⇒ completed.
+    let body = "#!/usr/bin/env bash\nset -euo pipefail\necho pinged > PING_SENTINEL\n";
+    let daemon = TestDaemon::spawn(seed_with(PIPELINE_YAML_NO_OUTPUT, "script-noout", body))
+        .await
+        .unwrap();
+
+    let run_id = start_run(&daemon, "script-noout").await;
+    let run = wait_for_node_status(&daemon, &run_id, NODE_ID, "completed").await;
+    assert_eq!(
+        run["nodes"][NODE_ID]["status"], "completed",
+        "a no-output script should complete on exit 0; run was: {run}"
+    );
+    let sentinel = daemon
+        .repo_root()
+        .join(".pdo/runs")
+        .join(&run_id)
+        .join("worktree/PING_SENTINEL");
+    assert!(sentinel.exists(), "side effect should have run at {sentinel:?}");
+}
+
+#[tokio::test]
+async fn empty_script_body_refuses_launch() {
+    ensure_pdo_on_path();
+    // An empty body would `bash <empty>` → exit 0 → silent no-op. The launch is
+    // refused (400) with no run created, mirroring the dangling-edge refusal.
+    let daemon = TestDaemon::spawn(seed_with(PIPELINE_YAML, PIPELINE_NAME, "   \n"))
+        .await
+        .unwrap();
+
+    let body = serde_json::json!({ "pipeline": PIPELINE_NAME, "input": "hello" });
+    let resp = reqwest::Client::new()
+        .post(format!("{}/runs", daemon.url()))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400, "empty script body must refuse the launch");
+    let err = resp.json::<serde_json::Value>().await.unwrap();
+    assert!(
+        err["error"].as_str().unwrap_or("").contains("empty body"),
+        "error should name the empty body; got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn script_node_missing_declared_output_fails_fast() {
+    ensure_pdo_on_path();
+    // Declares output `out` (PIPELINE_YAML) but writes nothing → output
+    // validation finds a missing output. A script has already exited, so there
+    // is no agent to nudge: the node must fail-fast, not strand behind a 409.
+    let body = "#!/usr/bin/env bash\ntrue\n";
+    let daemon = TestDaemon::spawn(seed_with(PIPELINE_YAML, PIPELINE_NAME, body))
+        .await
+        .unwrap();
+
+    let run_id = start_run(&daemon, PIPELINE_NAME).await;
+    let run = wait_for_node_status(&daemon, &run_id, NODE_ID, "failed").await;
+    assert_eq!(
+        run["nodes"][NODE_ID]["status"], "failed",
+        "missing declared output must fail-fast; run was: {run}"
+    );
+}

--- a/crates/pdo-daemon/tests/tmux_run_spawn.rs
+++ b/crates/pdo-daemon/tests/tmux_run_spawn.rs
@@ -13,6 +13,7 @@ use std::time::Duration;
 
 use common::TestDaemon;
 use pdo_daemon::build_tmux_script;
+use pdo_daemon::tmux_session_manager::SessionTail;
 
 const PIPELINE_NAME: &str = "minimal-tmux";
 const NODE_ID: &str = "solo";
@@ -85,7 +86,15 @@ fn build_tmux_script_uses_exec_bash_and_invokes_claude() {
     // `claude --dangerously-skip-permissions` and the `exec bash -c` shape.
     // `None` override → production claude tail.
     let prompt_path = std::path::Path::new("/tmp/pdo-test/solo-iter-1.md");
-    let script = build_tmux_script("run-abc", "solo", 1, 5172, prompt_path, None, None);
+    let script = build_tmux_script(
+        "run-abc",
+        "solo",
+        1,
+        5172,
+        prompt_path,
+        None,
+        SessionTail::Agent { model: None },
+    );
 
     assert!(
         script.starts_with("exec bash -c "),

--- a/docs/adr/0017-script-node.md
+++ b/docs/adr/0017-script-node.md
@@ -1,0 +1,76 @@
+# Node `script` — bash déterministe de l'auteur comme node first-class
+
+Aujourd'hui, *tout* node qui exécute (doc-only, code-mutating, merge) lance une
+session Claude Code dans tmux et se signale terminé via `pdo complete`
+(`node_primitives::start_node`). CONTEXT.md définit d'ailleurs un Node comme « une
+instance de Claude Code ». Or #248 (pipeline « discord chat ») veut un effet de bord
+**déterministe** — envoyer une notification Discord au démarrage — sans dépenser un
+tour de LLM. Le node `Merge` mécanique décrit par ADR-0006 n'a jamais été câblé
+(`merge_action.rs` est du code mort) : il n'existe donc, à ce jour, aucun node qui
+produise du travail et atteigne un état terminal **sans Claude**.
+
+**Décision : ajouter un node `script`, mécanique et productif, qui exécute le bash de
+l'auteur dans une session tmux (comme un node agent, mais bash au lieu de `claude`),
+se complète sur exit 0 / échoue sinon, et — en v1 — n'obtient pas de sous-worktree
+(effet doc-only : il tourne dans le worktree du Run et doit le laisser propre).**
+
+- **Exécution dans tmux, pas hors-bande.** Le tail de `build_tmux_script` bascule vers
+  un wrapper `timeout N bash <corps>; exit-code → pdo complete|fail` au lieu de
+  `exec claude`. Choisi **contre** l'alternative « tâche async in-daemon (clone de
+  `guard_runner`) » : cette dernière donnait une complétion par code de retour propre
+  mais violait l'invariant « tout NodeRun est attachable » (CONTEXT.md, *Deliberate,
+  then autonomous*) et ADR-0005 (observabilité par xterm inline), et forçait un
+  garde `node_type=="script"` sur six sites critiques de détection de vie
+  (`stale_detector`, `boot_recovery` ×2, diagnostics de mort de session, `admission`,
+  bridge PTY frontend). Rester dans tmux réutilise spawn/attach/reap/`node_done`/
+  `outputs_validator`/admission tels quels, et la session survit à un redémarrage du
+  daemon (tmux est un process séparé). Le coût : la complétion passe par le wrapper
+  (pas d'attente directe du code de retour) et un script hung sans `timeout` serait
+  invisible à la détection de vie (pas de JSONL) — d'où le `timeout` obligatoire dans
+  le wrapper (défaut 60 s, `SCRIPT_TIMEOUT_SECS`, `timeout` sort 124 ⇒ échec).
+- **Le corps exécuté est le bash brut, pas le prompt augmenté.** Un node agent reçoit
+  un préambule prose (`build_full_prompt`) ; un script `bash`-erait ce préambule comme
+  du code. Le spawn écrit donc le **`role_prompt` brut** (le corps) dans le fichier
+  que `bash` exécute, jamais le prompt augmenté.
+- **Contrat d'I/O par variables d'environnement.** Un script ne lit pas le préambule
+  prose des agents. Le runtime injecte `PDO_INPUT_<PORT>`, `PDO_OUTPUT_<PORT>`,
+  `PDO_ARTIFACTS_DIR`, `PDO_VAR_<NAME>` (en plus des `PDO_RUN_ID/NODE_ID/NODE_ITER/
+  DAEMON_URL` déjà présents). Le script écrit lui-même son `output.md` à
+  `$PDO_OUTPUT_<port>` (frontmatter compris s'il veut piloter une edge `when:`) ;
+  `outputs_validator` s'applique, mais **fail-fast** (pas de retry interactif : la
+  session a déjà quitté, il n'y a plus d'agent à relancer). Les répertoires des ports
+  de sortie sont **pré-créés au spawn** (un `> "$PDO_OUTPUT_out"` échouerait sur un
+  parent manquant).
+- **Le seam de test `tmux_cmd_override` est contourné pour un script.** Pour un agent,
+  l'override remplace `claude` par un stub pour que la CI ne lance jamais de vrai
+  claude. Un script *est* du bash déterministe : l'override ne doit pas l'écraser.
+  Conséquence (une force) : un node script est testable de bout en bout en CI **sans
+  aucun stub** — une propriété strictement plus forte que n'importe quel node agent.
+- **Corps stocké dans le slot prompt du node** (`<pipeline>.prompts/<node>.md`),
+  réutilisé verbatim — aucun nouveau champ de sérialisation, aucun changement de
+  watcher, réutilisation en bibliothèque gratuite. Un corps vide fait **échouer le
+  lancement** (fail-loud, comme une edge pendante), fermant le trou du no-op silencieux.
+- **Sécurité.** Le bash d'un script ≡ le guard de Trigger (`sh -c` par le daemon) ≡
+  le bash d'un agent (via `claude`) : même surface, aucune nouvelle frontière de
+  confiance. C'est le bash *de l'auteur, dans son propre pipeline* — à distinguer du
+  JS tiers importé qu'ADR-0016 encadre. Le vrai contrôle reste le binding `0.0.0.0`
+  sans auth du daemon (#260), hors scope ici.
+
+**Alternatives écartées.** (A) *Pas de nouveau type ; un node code-mutating dont le
+prompt dit « lance exactement ce bash »* — non déterministe, brûle un tour de LLM,
+rate l'objectif. (B) *Modéliser l'étape comme un guard/trigger* — un guard est un
+prédicat booléen d'edge, pas un node producteur d'artefact. (C) *Une primitive
+runtime « command » générique (ADR-0009 couche 2)* — invisible dans l'éditeur visuel,
+non composable par l'auteur de pipeline. (D) *Tâche async in-daemon (clone de
+`guard_runner`)* — voir la décision ci-dessus (violait ADR-0005 + 6 gardes de vie).
+
+**Relations.** Étend la famille « mécanique/déterministe » d'ADR-0002 du *routage* à
+l'*exécution* de node. Instance la plus tranchante d'ADR-0001 (bash arbitraire).
+Hérite d'ADR-0005 (tmux). N'est **pas** contraint par ADR-0008 (un script ne
+référence aucun champ de frontmatter amont ; il consomme des artefacts entiers en
+fichiers). Ne supersede aucun ADR. Le code mort `merge_action.rs` (divergence
+ADR-0006) reste hors scope (follow-up).
+
+**Portée v1 (différé).** Effet code-mutating pour un script (sous-worktree +
+merge-back) ; `timeout_secs` configurable par node ; durcissement du garde doc-only
+contre `git commit` (contrôle de non-déplacement de HEAD).

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -285,6 +285,11 @@ export default function App() {
   function inspectorEditPane() {
     switch (editNodeType) {
       case "merge": return <MergeInspector />;
+      // #248: `script` reuses NodeInspector, which shows the Script (bash) editor
+      // and hides the model field / doc-only↔code-mutating toggle for it.
+      // Without this case a script node would fall through and — before the
+      // in-inspector conditionals — render the wrong (agent) surface.
+      case "script":
       default: return (
         <NodeInspector
           libraryEntries={libraryEntries}

--- a/frontend/src/components/EditCanvas.nodes.test.tsx
+++ b/frontend/src/components/EditCanvas.nodes.test.tsx
@@ -211,6 +211,41 @@ describe("EditNode emergent anchoring keyed on node type (issue #175)", () => {
   });
 });
 
+describe("EditNode script node card (#248)", () => {
+  function scriptProps() {
+    return {
+      ...markerProps({ nodeType: "script" }),
+      id: "notify",
+      data: {
+        label: "notify",
+        nodeId: "notify",
+        nodeType: "script" as NodeType,
+        status: "pending" as NodeStatus,
+        reached: false,
+        inputs: [],
+        outputs: [{ name: "out", side: "right" as const }],
+        interactive: false,
+      },
+    } as unknown as Parameters<typeof EditNode>[0];
+  }
+
+  it("renders the terminal (script) icon, not the agent glyph", () => {
+    render(<EditNode {...scriptProps()} />, { wrapper: Wrapper });
+    expect(screen.getByTestId("node-icon-script")).toBeTruthy();
+    expect(screen.queryByTestId("node-icon-agent")).toBeNull();
+  });
+
+  it("grows all four body-anchor handles (emergent inputs, like a work node)", () => {
+    const { container } = render(<EditNode {...scriptProps()} />, { wrapper: Wrapper });
+    const handleIds = Array.from(container.querySelectorAll(".react-flow__handle")).map((h) =>
+      h.getAttribute("data-handleid"),
+    );
+    for (const side of ["left", "right", "top", "bottom"]) {
+      expect(handleIds).toContain(`__anchor:${side}`);
+    }
+  });
+});
+
 describe("EditNode Start marker — input images on the canvas (issue #145)", () => {
   it("renders one image chip per uploaded image, tagged by filename", () => {
     render(

--- a/frontend/src/components/EditCanvas.tsx
+++ b/frontend/src/components/EditCanvas.tsx
@@ -232,6 +232,7 @@ const edgeTypes = { orthogonal: OrthogonalEdge };
 const DEFAULT_NODE_NAMES: Partial<Record<NodeType, string>> = {
   "code-mutating": "implementer",
   "merge": "merge",
+  "script": "script",
 };
 
 interface EditCanvasProps {
@@ -551,6 +552,15 @@ function EditCanvasInner({ libraryEntries, libraryPipelines, onLibraryDelete, on
           id, name, type, interactive: false, view,
           inputs: [{ name: "branches", repeated: true, side: "left" }],
           outputs: [{ name: "merged", repeated: false, side: "right" }],
+        };
+        break;
+      case "script":
+        // #248: a script node's inputs are emergent (edge-derived), like a work
+        // node — it declares none. One default output for its `output.md`.
+        newNode = {
+          id, name, type, interactive: false, view,
+          inputs: [],
+          outputs: [{ name: "out", repeated: false, side: "right" }],
         };
         break;
       default:

--- a/frontend/src/components/EditToolbar.test.tsx
+++ b/frontend/src/components/EditToolbar.test.tsx
@@ -53,6 +53,13 @@ describe("EditToolbar", () => {
     expect(onAddNode).toHaveBeenCalledWith("merge");
   });
 
+  it("script button calls onAddNode with script (#248)", () => {
+    renderToolbar();
+    expect(screen.getByTestId("toolbar-script")).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("toolbar-script"));
+    expect(onAddNode).toHaveBeenCalledWith("script");
+  });
+
   it("tooltips render the correct text on hover", async () => {
     const user = userEvent.setup();
     renderToolbar();

--- a/frontend/src/components/EditToolbar.tsx
+++ b/frontend/src/components/EditToolbar.tsx
@@ -1,4 +1,4 @@
-import { Plus, GitMerge, Info, Undo2, Redo2 } from "lucide-react";
+import { Plus, GitMerge, Info, Undo2, Redo2, SquareTerminal } from "lucide-react";
 import type { NodeType } from "../types";
 import type { LibraryEntry } from "../api";
 import { Tooltip } from "./ui/tooltip";
@@ -60,6 +60,16 @@ export default function EditToolbar({ onAddNode, libraryEntries, onLibraryDelete
           className="grid h-7 w-7 cursor-pointer place-items-center rounded text-fg-3 transition-colors hover:bg-bg-4 hover:text-fg active:bg-acc active:text-bg-0"
         >
           <GitMerge size={14} />
+        </button>
+      </Tooltip>
+
+      <Tooltip content="Script node (deterministic bash)">
+        <button
+          data-testid="toolbar-script"
+          onClick={() => onAddNode("script")}
+          className="grid h-7 w-7 cursor-pointer place-items-center rounded text-fg-3 transition-colors hover:bg-bg-4 hover:text-fg active:bg-acc active:text-bg-0"
+        >
+          <SquareTerminal size={14} />
         </button>
       </Tooltip>
 

--- a/frontend/src/components/NodeInspector.test.tsx
+++ b/frontend/src/components/NodeInspector.test.tsx
@@ -129,8 +129,72 @@ function seedPooledReviewPipeline() {
   });
 }
 
+function seedTabWithScript(prompt = "echo hi\n") {
+  useEditStore.setState({
+    openTabs: [
+      {
+        id: "p1",
+        scope: "repo",
+        pipeline: {
+          name: "p1",
+          version: "1.0",
+          variables: {},
+          nodes: [
+            {
+              id: "sc1",
+              name: "notify",
+              type: "script",
+              interactive: false,
+              inputs: [],
+              outputs: [{ name: "out", repeated: false, side: "right" }],
+              view: { x: 0, y: 0 },
+            },
+          ],
+          edges: [],
+        },
+        prompts: { sc1: prompt },
+        diagnostics: [],
+        dirty: false,
+        externalDirty: false,
+      },
+    ],
+    activeTabId: "p1",
+    selection: { kind: "node", id: "sc1" },
+  });
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
+});
+
+describe("NodeInspector — script node surface (#248)", () => {
+  it("shows the Script (bash) body editor and hides the model field", () => {
+    seedTabWithScript();
+    renderInspector({ libraryEntries: [], onLibraryChanged: () => {} });
+
+    expect(screen.getByTestId("script-body")).toBeInTheDocument();
+    expect(screen.getByTestId("script-help")).toBeInTheDocument();
+    // A script launches no agent — the model field must be absent.
+    expect(screen.queryByTestId("node-model-input")).toBeNull();
+  });
+
+  it("shows a static script type label, not the doc-only/code-mutating toggle", () => {
+    seedTabWithScript();
+    renderInspector({ libraryEntries: [], onLibraryChanged: () => {} });
+    expect(screen.getByTestId("script-type-label")).toBeInTheDocument();
+  });
+
+  it("persists edits to the bash body and marks the tab dirty", () => {
+    seedTabWithScript("echo old\n");
+    renderInspector({ libraryEntries: [], onLibraryChanged: () => {} });
+
+    const body = screen.getByTestId("script-body");
+    fireEvent.change(body, { target: { value: "curl -X POST $PDO_DAEMON_URL\n" } });
+
+    const tab = useEditStore.getState().openTabs[0];
+    expect(tab.prompts["sc1"]).toBe("curl -X POST $PDO_DAEMON_URL\n");
+    expect(tab.dirty).toBe(true);
+  });
 });
 
 describe("NodeInspector — pooled emergent inputs (#153)", () => {

--- a/frontend/src/components/NodeInspector.tsx
+++ b/frontend/src/components/NodeInspector.tsx
@@ -62,6 +62,11 @@ export default function NodeInspector({
   // not declared on the node. Same-named edges pool into one list input.
   const pooledInputs = derivePooledInputs(tab.pipeline, node.id);
 
+  // #248: a `script` node runs deterministic bash, not an agent — so its type is
+  // fixed (no doc-only↔code-mutating toggle), it has no model, and its "prompt"
+  // is a bash body whose I/O arrives as PDO_* env vars, not a prose preamble.
+  const isScript = node.type === "script";
+
   function handleField(field: keyof NodeDef, value: unknown) {
     updateNode(node!.id, { [field]: value } as Partial<NodeDef>);
   }
@@ -128,25 +133,38 @@ export default function NodeInspector({
 
         {/* Type */}
         <SectionHead title="Type" />
-        <div className="flex gap-1">
-          {(["code-mutating", "doc-only"] as NodeType[]).map((t) => (
-            <Tooltip key={t} content={TYPE_TOOLTIPS[t] ?? t}>
-              <button
-                onClick={() => handleField("type", t)}
-                className={`flex-1 cursor-pointer rounded border px-2 py-1 font-medium transition-colors ${
-                  node.type === t
-                    ? t === "code-mutating"
-                      ? "border-acc bg-acc-bg text-acc"
-                      : "border-fg-4 bg-bg-3 text-fg"
-                    : "border-line-strong bg-bg-3 text-fg-4 hover:text-fg-3"
-                }`}
-                style={{ fontSize: "10px" }}
-              >
-                {t}
-              </button>
-            </Tooltip>
-          ))}
-        </div>
+        {isScript ? (
+          // #248: a script node's type is fixed. Show a static label rather than
+          // the doc-only↔code-mutating toggle (which can't even express "script"
+          // and would silently retype the node away on click).
+          <div
+            data-testid="script-type-label"
+            className="rounded border border-fg-4 bg-bg-3 px-2 py-1 font-medium text-fg"
+            style={{ fontSize: "10px" }}
+          >
+            script (deterministic bash)
+          </div>
+        ) : (
+          <div className="flex gap-1">
+            {(["code-mutating", "doc-only"] as NodeType[]).map((t) => (
+              <Tooltip key={t} content={TYPE_TOOLTIPS[t] ?? t}>
+                <button
+                  onClick={() => handleField("type", t)}
+                  className={`flex-1 cursor-pointer rounded border px-2 py-1 font-medium transition-colors ${
+                    node.type === t
+                      ? t === "code-mutating"
+                        ? "border-acc bg-acc-bg text-acc"
+                        : "border-fg-4 bg-bg-3 text-fg"
+                      : "border-line-strong bg-bg-3 text-fg-4 hover:text-fg-3"
+                  }`}
+                  style={{ fontSize: "10px" }}
+                >
+                  {t}
+                </button>
+              </Tooltip>
+            ))}
+          </div>
+        )}
 
         {/* Behavior */}
         <SectionHead title="Behavior" />
@@ -170,31 +188,51 @@ export default function NodeInspector({
 
         {/* Model (#296): free-text pass-through to `claude --model <x>`; the
             datalist offers the common aliases but any full id is accepted.
-            Empty ⇒ null ⇒ never serialized ⇒ account default. */}
-        <Field label="Model">
-          <input
-            list="pdo-model-aliases"
-            data-testid="node-model-input"
-            placeholder="default model"
-            value={node.model ?? ""}
-            onChange={(e) => handleField("model", e.target.value || null)}
-            className="w-full rounded border border-line-strong bg-bg-3 px-2 py-1 text-fg outline-none focus:border-acc"
-          />
-          <datalist id="pdo-model-aliases">
-            {["sonnet", "opus", "haiku", "opusplan", "fable"].map((m) => (
-              <option key={m} value={m} />
-            ))}
-          </datalist>
-        </Field>
+            Empty ⇒ null ⇒ never serialized ⇒ account default. Hidden for a
+            script node (#248): it launches no agent, so it has no model. */}
+        {!isScript && (
+          <Field label="Model">
+            <input
+              list="pdo-model-aliases"
+              data-testid="node-model-input"
+              placeholder="default model"
+              value={node.model ?? ""}
+              onChange={(e) => handleField("model", e.target.value || null)}
+              className="w-full rounded border border-line-strong bg-bg-3 px-2 py-1 text-fg outline-none focus:border-acc"
+            />
+            <datalist id="pdo-model-aliases">
+              {["sonnet", "opus", "haiku", "opusplan", "fable"].map((m) => (
+                <option key={m} value={m} />
+              ))}
+            </datalist>
+          </Field>
+        )}
 
-        {/* Prompt */}
-        <SectionHead title="Prompt" />
+        {/* Prompt / Script body. For a script node (#248) this textarea holds the
+            bash body; its I/O arrives as PDO_* env vars, not a prose preamble. */}
+        <SectionHead title={isScript ? "Script (bash)" : "Prompt"} />
+        {isScript && (
+          <p
+            data-testid="script-help"
+            className="rounded border border-acc/30 bg-acc/5 px-2 py-1.5 text-fg-3"
+            style={{ fontSize: "10.5px", lineHeight: "1.5" }}
+          >
+            Author-written bash, run deterministically (no LLM). Inputs/outputs
+            arrive as env vars: <code>$PDO_INPUT_&lt;PORT&gt;</code>,{" "}
+            <code>$PDO_OUTPUT_&lt;PORT&gt;</code>, <code>$PDO_ARTIFACTS_DIR</code>,{" "}
+            <code>$PDO_VAR_&lt;NAME&gt;</code>. Write your <code>output.md</code> to{" "}
+            <code>$PDO_OUTPUT_&lt;PORT&gt;</code> (add YAML frontmatter to drive a{" "}
+            <code>when:</code> edge). Exit 0 ⇒ node completes; non-zero or timeout
+            ⇒ fails. Runs in the run's shared worktree — leave tracked files clean.
+          </p>
+        )}
         <textarea
+          data-testid={isScript ? "script-body" : undefined}
           value={promptContent}
           onChange={(e) => updatePrompt(node.id, e.target.value)}
           className="min-h-[120px] w-full resize-y rounded border border-line-strong bg-bg-3 px-2 py-1.5 font-mono text-fg outline-none focus:border-acc"
           style={{ fontSize: "11px", lineHeight: "1.5" }}
-          placeholder="Enter the node's role prompt..."
+          placeholder={isScript ? "#!/usr/bin/env bash\n# e.g. curl -X POST \"$DISCORD_WEBHOOK\" ..." : "Enter the node's role prompt..."}
         />
 
         {/* Inputs — emergent (#149): derived from incoming edges, read-only.

--- a/frontend/src/components/NodeTypeIcon.tsx
+++ b/frontend/src/components/NodeTypeIcon.tsx
@@ -1,4 +1,4 @@
-import { User, GitMerge, Play, Square, Code, FileText } from "lucide-react";
+import { User, GitMerge, Play, Square, Code, FileText, SquareTerminal } from "lucide-react";
 import type { NodeType } from "../types";
 
 interface IconProps {
@@ -15,6 +15,9 @@ export function NodeTypeIcon({ type, size = 14, className }: IconProps) {
       return <Play data-testid="node-icon-start" size={size} className={className} />;
     case "end":
       return <Square data-testid="node-icon-end" size={size} className={className} />;
+    case "script":
+      // #248: a script node runs deterministic bash, not an agent.
+      return <SquareTerminal data-testid="node-icon-script" size={size} className={className} />;
     default:
       return <User data-testid="node-icon-agent" size={size} className={className} />;
   }

--- a/frontend/src/lib/anchorSide.test.ts
+++ b/frontend/src/lib/anchorSide.test.ts
@@ -4,6 +4,7 @@ import {
   anchorHandleId,
   sideFromAnchorHandle,
   anchorsByDropOnBody,
+  isEmergentInputNode,
 } from "./anchorSide";
 
 // A 200x80 card whose top-left is at (100, 100); centre is (200, 140).
@@ -86,6 +87,20 @@ describe("anchorHandleId / sideFromAnchorHandle round-trip", () => {
     expect(sideFromAnchorHandle("result")).toBeNull();
     expect(sideFromAnchorHandle(null)).toBeNull();
     expect(sideFromAnchorHandle(undefined)).toBeNull();
+  });
+});
+
+describe("isEmergentInputNode", () => {
+  it("treats work nodes and script as emergent-input (#149 / #248)", () => {
+    expect(isEmergentInputNode("doc-only")).toBe(true);
+    expect(isEmergentInputNode("code-mutating")).toBe(true);
+    expect(isEmergentInputNode("script")).toBe(true);
+  });
+
+  it("keeps structural nodes on their declared, fixed-side ports", () => {
+    expect(isEmergentInputNode("start")).toBe(false);
+    expect(isEmergentInputNode("end")).toBe(false);
+    expect(isEmergentInputNode("merge")).toBe(false);
   });
 });
 

--- a/frontend/src/lib/anchorSide.ts
+++ b/frontend/src/lib/anchorSide.ts
@@ -29,7 +29,9 @@ export const ANCHOR_SIDES: readonly PortSide[] = ["left", "right", "top", "botto
  * their declared, fixed-side ports and are never re-anchored by drop position.
  */
 export function isEmergentInputNode(type: NodeType): boolean {
-  return type === "doc-only" || type === "code-mutating";
+  // #248: a `script` node consumes whole artifacts by edge like a work node, so
+  // its inputs are emergent too — anchor incoming edges to the body by drop.
+  return type === "doc-only" || type === "code-mutating" || type === "script";
 }
 
 /**

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -52,7 +52,9 @@ export interface UpdateSettingsRequest {
 // `for-each` was removed (ADR-0011 / #151): a fan-out is now a `collection`
 // loop region, not a node. The backend keeps the variant only to migrate old
 // YAML into a region. `loop` was likewise removed in #171.
-export type NodeType = "doc-only" | "code-mutating" | "start" | "end" | "merge";
+// `script` (#248 / ADR-0017) runs author-written bash deterministically instead
+// of launching Claude; the FE union is not 1:1 with the backend enum.
+export type NodeType = "doc-only" | "code-mutating" | "start" | "end" | "merge" | "script";
 
 export interface RunListEntry {
   run_id: string;


### PR DESCRIPTION
## Summary

Adds a first-class **`script`** node type: a deterministic node that runs author-provided bash as part of a workflow, with **no LLM** in the loop (ADR-0017). Exit 0 ⇒ Completed with declared outputs written; non-zero ⇒ Failed with the exact reason.

- Backend: `script` node type wired through pipeline parse/roundtrip, prompt/env augmentation (`$PDO_INPUT_*`, `$PDO_OUTPUT_*`, `$PDO_ARTIFACTS_DIR`, `$PDO_VAR_*`), tmux self-signalling tail, mutation-validator guard (no retype of a live script).
- Frontend: Script node toolbar button (`SquareTerminal`), inspector with static TYPE label + no Model field + BASH body editor and env help block.
- Docs: `docs/adr/0017-script-node.md`, CONTEXT.md.
- Version bump 0.1.56 → 0.1.57.

## Validation

Independently validated (FP-248): green unit (15/15) + integration (6/6, real bash + real tmux, zero stubs) suites, plus a live browser run proving exit 0 ⇒ Completed (real file written) and exit 7 ⇒ Failed ("script exited 7"). Deterministic ~125 ms spawn→reap, no LLM.

Closes #248

🤖 Generated with [Claude Code](https://claude.com/claude-code)