### PR TITLE
feat(#307): add-node dropdown (Node | Note) + inert canvas note (ADR-0018)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -175,6 +175,19 @@ Les inputs sont **émergents** (#149) : une flèche entrante n'atterrit pas sur 
 
 ---
 
+## Note (note de canvas)
+
+Une **Note** est une annotation de documentation **inerte** posée sur le canvas : un texte libre que le designer épingle près d'un groupe de nœuds pour expliquer une intention (« ce loop est borné à 3 exprès », « TODO câbler l'edge d'épuisement »). Elle **n'est pas un Node** — aucun titre/`name`, aucun type (`doc-only`/`code-mutating`/`merge`/`script`), aucun port, aucune edge, aucune session, aucune place dans le dataflow ni l'ordonnancement : le runtime l'**ignore entièrement**.
+
+- **Persistée dans un bloc racine `notes:`** du YAML (sibling de `loops:`/`edges:`, jamais dans `nodes:`), chaque entrée = `{ id, content, view }`. C'est la forme éprouvée de `loops:` — une entité nommée de premier niveau, rendue sur le canvas, qui n'est délibérément **pas** un type de nœud (cf. ADR-0018).
+- **`content` = texte brut en v1** — pas de markdown, pour ne pas ouvrir une 2ᵉ surface `react-markdown` ni le sink `dangerouslySetInnerHTML` d'ADR-0013. Édité dans l'inspecteur (clic sur la note), pas inline sur la carte.
+- **`view` = layout, pas sémantique** — même classe que `view`/`mode`/`waypoints`/`target_side` : persiste **dans le fichier** (une note partagée suit le workflow) mais est **exclu du diff sémantique** ; deux pipelines ne différant que par leurs notes comparent **égaux** (le star « synced/diverged » ne bouge pas). La puce « non sauvegardé » (dirty), elle, s'allume — normal. Taille pilotée par le contenu en v1 ; redimensionnement différé.
+- **Mutable pendant un Run** : inerte, aucune session à orphaner — `mutation_validator` ne doit jamais rejeter l'ajout/édition/suppression d'une note sur un Run actif (contraste avec la suppression d'un node non-`pending`, interdite par ADR-0007).
+
+_Éviter_ : « commentaire » (évoque un commentaire YAML `#` ou un commentaire d'issue GitHub), et « placeholder annoté » (qui est, lui, un **vrai** nœud `doc-only` produit par l'import de workflow, ADR-0016).
+
+---
+
 ## Blackboard
 
 Le **Blackboard** est le store partagé où vivent tous les artefacts d'un Pipeline Run. Toutes les sorties documentaires de tous les NodeRuns y sont persistées et adressées par chemin.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1952,7 +1952,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "0.1.57"
+version = "0.1.58"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "0.1.57"
+version = "0.1.58"
 license = "MIT"
 
 [workspace.dependencies]

--- a/crates/pdo-daemon/src/graph_resolver.rs
+++ b/crates/pdo-daemon/src/graph_resolver.rs
@@ -479,6 +479,7 @@ mod tests {
             nodes,
             edges,
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         }
     }

--- a/crates/pdo-daemon/src/input_resolution.rs
+++ b/crates/pdo-daemon/src/input_resolution.rs
@@ -175,6 +175,7 @@ mod tests {
                 },
             ],
             loops: vec![],
+            notes: Vec::new(),
             prompt_required: true,
         };
         let state = state_with(vec![

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -11660,6 +11660,7 @@ mod tests {
             nodes: vec![doc_node_def("a"), doc_node_def("b")],
             edges: vec![edge("a", "b")],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: false,
         }
     }
@@ -11785,6 +11786,7 @@ mod tests {
             nodes: vec![doc_node_def("a"), doc_node_def("b")],
             edges: vec![conditional_edge],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: false,
         };
         let mut run_state = event_log::RunState::new("20260613-loop".into(), "cond".into());
@@ -16071,6 +16073,7 @@ mod tests {
                 ..Default::default()
             }],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -16122,6 +16125,7 @@ mod tests {
                 ..Default::default()
             }],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -16827,6 +16831,7 @@ edges: []
                 ..Default::default()
             }],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -16915,6 +16920,7 @@ edges: []
                 ..Default::default()
             }],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 

--- a/crates/pdo-daemon/src/loop_region.rs
+++ b/crates/pdo-daemon/src/loop_region.rs
@@ -429,6 +429,7 @@ mod tests {
                 edge("rev", "review", "impl", "review"),
             ],
             loops: vec![],
+            notes: Vec::new(),
             prompt_required: true,
         };
         let region = LoopRegion {
@@ -543,6 +544,7 @@ mod tests {
                 },
             ],
             loops: vec![],
+            notes: Vec::new(),
             prompt_required: true,
         };
         let region = LoopRegion {
@@ -611,6 +613,7 @@ mod tests {
                 edge("worker", "out", "worker", "again"),
             ],
             loops: vec![],
+            notes: Vec::new(),
             prompt_required: true,
         };
         let region = LoopRegion {
@@ -673,6 +676,7 @@ mod tests {
                 max_iter: Some(serde_yaml::Value::Number(3.into())),
                 over: None,
             }],
+            notes: Vec::new(),
             prompt_required: true,
         };
         // Deleting back-edge A (index 2) still leaves the impl->rev->mid->impl
@@ -743,6 +747,7 @@ mod tests {
                 },
             ],
             loops: vec![],
+            notes: Vec::new(),
             prompt_required: true,
         };
         let region = LoopRegion {
@@ -882,6 +887,7 @@ mod tests {
                 edge("merge", "merged", "end", "result"),
             ],
             loops: vec![],
+            notes: Vec::new(),
             prompt_required: true,
         };
         let region = LoopRegion {

--- a/crates/pdo-daemon/src/mutation_validator.rs
+++ b/crates/pdo-daemon/src/mutation_validator.rs
@@ -242,6 +242,7 @@ mod tests {
             nodes,
             edges: vec![],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         }
     }

--- a/crates/pdo-daemon/src/node_io_resolver.rs
+++ b/crates/pdo-daemon/src/node_io_resolver.rs
@@ -369,6 +369,7 @@ mod tests {
                 ..Default::default()
             }],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         }
     }
@@ -528,6 +529,7 @@ mod tests {
                 ..Default::default()
             }],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -672,6 +674,7 @@ mod tests {
                 },
             ],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -755,6 +758,7 @@ mod tests {
                 ..Default::default()
             }],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -831,6 +835,7 @@ mod tests {
             ],
             edges: vec![mk_edge("a"), mk_edge("b")],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -910,6 +915,7 @@ mod tests {
             ],
             edges: vec![mk_edge("planner", "plan"), mk_edge("designer", "spec")],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 

--- a/crates/pdo-daemon/src/node_primitives.rs
+++ b/crates/pdo-daemon/src/node_primitives.rs
@@ -649,6 +649,7 @@ mod tests {
             nodes: vec![make_node("worker", NodeType::DocOnly, &["task"], &["out"])],
             edges: vec![],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -691,6 +692,7 @@ mod tests {
             nodes: vec![],
             edges: vec![],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -733,6 +735,7 @@ mod tests {
             ],
             edges: vec![make_edge("planner", "plan", "implementer", "plan")],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -789,6 +792,7 @@ mod tests {
             ],
             edges: vec![make_edge("planner", "plan", "implementer", "plan")],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -840,6 +844,7 @@ mod tests {
             nodes: vec![make_node("entry", NodeType::DocOnly, &["task"], &["out"])],
             edges: vec![],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -894,6 +899,7 @@ mod tests {
                 make_edge("researcher", "research", "implementer", "research"),
             ],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -947,6 +953,7 @@ mod tests {
             ],
             edges: vec![make_edge("reviewer", "review", "implementer", "reviews")],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -994,6 +1001,7 @@ mod tests {
             ],
             edges: vec![make_edge("reviewer", "review", "implementer", "review")],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -1255,6 +1263,7 @@ mod tests {
             nodes: vec![make_node("worker", NodeType::DocOnly, &["task"], &["out"])],
             edges: vec![],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 

--- a/crates/pdo-daemon/src/outputs_validator.rs
+++ b/crates/pdo-daemon/src/outputs_validator.rs
@@ -266,6 +266,7 @@ mod tests {
             nodes,
             edges: Vec::new(),
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         }
     }

--- a/crates/pdo-daemon/src/pipeline.rs
+++ b/crates/pdo-daemon/src/pipeline.rs
@@ -261,6 +261,24 @@ pub struct LoopRegion {
     pub over: Option<String>,
 }
 
+/// An inert canvas note (#307 / ADR-0018): a documentation post-it laid on the
+/// canvas. It has no title, no port, no edge; it is never spawned, lives outside
+/// the DAG and the runtime. It travels with the shared pipeline file but is
+/// *layout, not semantics* — excluded from the semantic pipeline-diff (the
+/// synced/diverged star does not move when a note is created/moved/edited/deleted).
+/// The Rust field is MANDATORY: the frontend rehydrates from the daemon-parsed
+/// `PipelineDef`, never the raw YAML — without this field serde would drop the
+/// note silently and it would vanish on reload (#307 / lesson #296).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Note {
+    pub id: String,
+    pub content: String,
+    /// Canvas position. Absent ⇒ not yet placed; reuses `ViewPosition` like
+    /// `NodeDef.view`. Omitted from YAML when `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub view: Option<ViewPosition>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PipelineDef {
     pub name: String,
@@ -275,6 +293,11 @@ pub struct PipelineDef {
     /// loops; round-trips when present.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub loops: Vec<LoopRegion>,
+    /// Inert canvas notes (#307 / ADR-0018). Absent on pipelines with no notes;
+    /// round-trips when present. Layout, not semantics — excluded from the
+    /// pipeline-diff on the frontend but persisted verbatim here.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub notes: Vec<Note>,
     /// Whether a manual Run must be launched with a non-empty user prompt (#158).
     /// Defaults to `true` (the prompt is mandatory) and is omitted from YAML in
     /// that case, so prompt-required pipelines stay clean. When `false`, a Run
@@ -371,6 +394,7 @@ const KNOWN_TOP_LEVEL_KEYS: &[&str] = &[
     "nodes",
     "edges",
     "loops",
+    "notes",
     "prompt_required",
 ];
 
@@ -3765,6 +3789,12 @@ loops:
     kind: bounded
     members: [ab000001, ab000002]
     max_iter: "$max_iter_review"
+notes:
+  - id: note-1
+    content: "remember to bound this loop"
+    view:
+      x: 120.0
+      y: 240.0
 "#;
         let result = parse_pipeline(yaml).unwrap();
         assert!(

--- a/crates/pdo-daemon/src/pipeline_migrator.rs
+++ b/crates/pdo-daemon/src/pipeline_migrator.rs
@@ -2286,6 +2286,7 @@ edges:
                 make_edge("impl-b", "out", "reviewer", "in"),
             ],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
         let diags = lint_missing_merge(&pipeline);
@@ -2313,6 +2314,7 @@ edges:
                 make_edge("merger", "merged", "downstream", "in"),
             ],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
         let diags = lint_missing_merge(&pipeline);
@@ -2332,6 +2334,7 @@ edges:
             nodes: vec![make_cm_node("impl-a"), make_doc_node("reviewer")],
             edges: vec![make_edge("impl-a", "out", "reviewer", "in")],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
         let diags = lint_missing_merge(&pipeline);
@@ -2354,6 +2357,7 @@ edges:
                 make_edge("plan-b", "out", "summary", "in"),
             ],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
         let diags = lint_missing_merge(&pipeline);

--- a/crates/pdo-daemon/src/prompt_augmenter.rs
+++ b/crates/pdo-daemon/src/prompt_augmenter.rs
@@ -714,6 +714,7 @@ mod tests {
             }],
             edges: vec![],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         }
     }
@@ -1277,6 +1278,7 @@ mod tests {
                 },
             ],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -1352,6 +1354,7 @@ mod tests {
             }],
             edges: vec![],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -1540,6 +1543,7 @@ mod tests {
             }],
             edges: vec![],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
         let node = &pipeline.nodes[0];
@@ -1589,6 +1593,7 @@ mod tests {
             }],
             edges: vec![],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
         let node = &pipeline.nodes[0];
@@ -1633,6 +1638,7 @@ mod tests {
             }],
             edges: vec![],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
         let node = &pipeline.nodes[0];

--- a/crates/pdo-daemon/src/run_advance.rs
+++ b/crates/pdo-daemon/src/run_advance.rs
@@ -398,6 +398,7 @@ mod tests {
             nodes: ids.iter().map(|id| doc_node(id)).collect(),
             edges: Vec::new(),
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         }
     }

--- a/crates/pdo-daemon/src/scheduler.rs
+++ b/crates/pdo-daemon/src/scheduler.rs
@@ -1277,6 +1277,7 @@ mod tests {
                 make_edge("implementer", "summary", "reviewer", "summary"),
             ],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -1301,6 +1302,7 @@ mod tests {
                 make_edge("implementer", "summary", "reviewer", "summary"),
             ],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -1324,6 +1326,7 @@ mod tests {
             ],
             edges: vec![make_edge("planner", "plan", "implementer", "plan")],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -1351,6 +1354,7 @@ mod tests {
                 make_edge("planner", "plan", "impl-b", "plan"),
             ],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -1379,6 +1383,7 @@ mod tests {
                 make_edge("impl-b", "summary", "merger", "summary-b"),
             ],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -1416,6 +1421,7 @@ mod tests {
                 make_edge("c", "out", "d", "in-c"),
             ],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -1439,6 +1445,7 @@ mod tests {
             ],
             edges: vec![make_edge("a", "out", "b", "in")],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -1464,6 +1471,7 @@ mod tests {
             ],
             edges: vec![make_edge("a", "out", "b", "in")],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -1496,6 +1504,7 @@ mod tests {
                 "Blocked after {iter} iterations on {node-id}",
             )],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -1539,6 +1548,7 @@ mod tests {
                 ..Default::default()
             }],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -1571,6 +1581,7 @@ mod tests {
                 make_edge("reviewer", "review", "implementer", "review"),
             ],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -1608,6 +1619,7 @@ mod tests {
                 make_edge("a", "out", "c", "in"),
             ],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -1660,6 +1672,7 @@ mod tests {
                 make_cond_edge("classifier", "triage", "backlog", "triage", None, true),
             ],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -1723,6 +1736,7 @@ mod tests {
                 make_cond_edge("classifier", "triage", "backlog", "triage", None, true),
             ],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -1806,6 +1820,7 @@ mod tests {
                 make_edge("backlog", "note", "merge1", "branches"),
             ],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         }
     }
@@ -1913,6 +1928,7 @@ mod tests {
                 make_end_edge("merge1", "merged", "done"),
             ],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         }
     }
@@ -1983,6 +1999,7 @@ mod tests {
                 make_end_edge("merge1", "merged", "done"),
             ],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         }
     }
@@ -2065,6 +2082,7 @@ mod tests {
                 make_end_edge("classifier", "triage", "direct-done"),
             ],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         }
     }
@@ -2153,6 +2171,7 @@ mod tests {
                 make_end_edge("merge1", "merged", "done"),
             ],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         }
     }
@@ -2249,6 +2268,7 @@ mod tests {
             ],
             edges: vec![make_end_edge("reviewer", "review", "Run halted")],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -2337,6 +2357,7 @@ mod tests {
                 make_edge("sw", "default", "c-default", "in"),
             ],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -2384,6 +2405,7 @@ mod tests {
                 make_edge("sw", "default", "c-default", "in"),
             ],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -2429,6 +2451,7 @@ mod tests {
             ],
             edges: vec![make_edge("sw", "pass", "downstream", "in")],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -2486,6 +2509,7 @@ mod tests {
                 make_edge("sw", "default", "default-handler", "in"),
             ],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -2563,6 +2587,7 @@ mod tests {
                 make_edge("sw", "default", "default-handler", "in"),
             ],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -2622,6 +2647,7 @@ mod tests {
                 make_edge("sw", "default", "rework", "in"),
             ],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -2675,6 +2701,7 @@ mod tests {
                 make_edge("sw", "default", "rework", "in"),
             ],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -2740,6 +2767,7 @@ mod tests {
                 make_edge("sw", "second", "second-handler", "in"),
             ],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -2798,6 +2826,7 @@ mod tests {
                 make_edge("sw", "default", "default-handler", "in"),
             ],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -2857,6 +2886,7 @@ mod tests {
                 make_edge("sw", "pass", "downstream", "in"),
             ],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -2902,6 +2932,7 @@ mod tests {
                 make_edge("sw", "default", "default-handler", "in"),
             ],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -3025,6 +3056,7 @@ mod tests {
                 make_edge("loop1", "body", "worker", "in"),
             ],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -3050,6 +3082,7 @@ mod tests {
                 make_edge("loop1", "body", "impl", "in"),
             ],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -3088,6 +3121,7 @@ mod tests {
                 make_edge("sw", "pass", "loop1", "break"),
             ],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -3121,6 +3155,7 @@ mod tests {
                 make_edge("sw", "default", "impl", "in"),
             ],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -3177,6 +3212,7 @@ mod tests {
                 make_edge("loop1", "done", "end", "result"),
             ],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -3226,6 +3262,7 @@ mod tests {
                 make_edge("loop1", "done", "downstream", "in"),
             ],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -3287,6 +3324,7 @@ mod tests {
                 make_edge("loop1", "done", "end", "result"),
             ],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -3363,6 +3401,7 @@ mod tests {
                 make_edge("loop1", "done", "end", "result"),
             ],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -3412,6 +3451,7 @@ mod tests {
                 make_edge("reviewer", "review", "loop1", "break"),
             ],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -3459,6 +3499,7 @@ mod tests {
                 make_edge("loop1", "done", "downstream", "in"),
             ],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -3540,6 +3581,7 @@ mod tests {
                 make_edge("loop1", "body", "impl", "in"),
             ],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
         let state = empty_run_state();
@@ -3575,6 +3617,7 @@ mod tests {
                 make_edge("loop1", "body", "impl", "in"),
             ],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
         let state = empty_run_state();
@@ -3605,6 +3648,7 @@ mod tests {
                 make_edge("loop1", "body", "impl", "in"),
             ],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
         let mut state = empty_run_state();
@@ -3633,6 +3677,7 @@ mod tests {
             nodes: vec![make_start_node("start"), make_loop_node("loop1", 5)],
             edges: vec![],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
         let state = empty_run_state();
@@ -3658,6 +3703,7 @@ mod tests {
                 make_edge("loop1", "body", "impl", "in"),
             ],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
         let mut state = empty_run_state();
@@ -3688,6 +3734,7 @@ mod tests {
                 make_edge("loop1", "body", "b", "in"),
             ],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
         let state = empty_run_state();
@@ -3783,6 +3830,7 @@ mod tests {
                 make_edge("fe1", "done", "end", "result"),
             ],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -3834,6 +3882,7 @@ mod tests {
                 make_edge("fe1", "done", "end", "result"),
             ],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -3900,6 +3949,7 @@ mod tests {
                 make_edge("fe1", "done", "end", "result"),
             ],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -3950,6 +4000,7 @@ mod tests {
                 make_edge("fe1", "done", "end", "result"),
             ],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -4013,6 +4064,7 @@ mod tests {
                 make_edge("fe1", "done", "end", "result"),
             ],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -4064,6 +4116,7 @@ mod tests {
             ],
             edges: vec![make_edge("fe1", "body", "worker", "in")],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -4127,6 +4180,7 @@ mod tests {
                 make_edge("fe1", "done", "end", "result"),
             ],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -4189,6 +4243,7 @@ mod tests {
                 make_edge("fe1", "done", "end", "result"),
             ],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -4453,6 +4508,7 @@ edges:
                 max_iter: Some(serde_yaml::Value::Number(max_iter.into())),
                 over: None,
             }],
+            notes: Vec::new(),
             prompt_required: true,
         }
     }
@@ -4706,6 +4762,7 @@ edges:
                 make_end_edge("tester", "screens_fixed", "done"),
             ],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -4890,6 +4947,7 @@ edges:
                 make_end_edge("impl", "code", "done"),
             ],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 
@@ -4979,6 +5037,7 @@ edges:
                 max_iter: Some(serde_yaml::Value::Number(max_iter.into())),
                 over: None,
             }],
+            notes: Vec::new(),
             prompt_required: true,
         }
     }

--- a/crates/pdo-daemon/src/scheduler_dispatcher.rs
+++ b/crates/pdo-daemon/src/scheduler_dispatcher.rs
@@ -186,6 +186,7 @@ mod tests {
             ],
             edges: vec![make_edge("planner", "plan", "implementer", "plan")],
             loops: Vec::new(),
+            notes: Vec::new(),
             prompt_required: true,
         };
 

--- a/crates/pdo-daemon/src/workflow_importer.rs
+++ b/crates/pdo-daemon/src/workflow_importer.rs
@@ -869,6 +869,7 @@ impl Importer {
             nodes,
             edges: self.edges.clone(),
             loops: self.loops.clone(),
+            notes: Vec::new(),
             prompt_required: true,
         }
     }

--- a/crates/pdo-daemon/tests/notes_round_trip.rs
+++ b/crates/pdo-daemon/tests/notes_round_trip.rs
@@ -1,0 +1,127 @@
+//! Layer 3a — canvas-note round-trip (#307 / ADR-0018): a top-level `notes:`
+//! block survives load → PUT (identity save) → GET, in BOTH the raw `yaml`
+//! string AND the daemon-parsed `pipeline` form. The parsed form is the decisive
+//! assertion: the frontend rehydrates from `pipeline`, never the raw YAML — a
+//! missing Rust field would let the note live on disk yet vanish from the UI on
+//! reload (the D2 failure mode).
+
+mod common;
+
+use common::TestDaemon;
+
+const NOTE_MARKER: &str = "NOTE-307 — bounded loop volontairement limité à 3";
+
+fn pipeline_with_note_yaml() -> String {
+    format!(
+        r#"name: notes-roundtrip
+version: "1.0"
+nodes:
+  - id: start
+    name: Start
+    type: start
+    outputs:
+      - name: user_prompt
+  - id: end
+    name: End
+    type: end
+    inputs:
+      - name: result
+edges:
+  - source: {{ node: start, port: user_prompt }}
+    target: {{ node: end, port: result }}
+notes:
+  - id: note-abc
+    content: "{NOTE_MARKER}"
+    view:
+      x: 128.0
+      y: 256.0
+"#
+    )
+}
+
+#[tokio::test]
+async fn note_round_trips_through_save_in_yaml_and_parsed_form() {
+    let daemon = TestDaemon::spawn(|repo| {
+        let dir = repo.join(".pdo").join("pipelines");
+        std::fs::create_dir_all(&dir)?;
+        std::fs::write(dir.join("notes-roundtrip.yaml"), pipeline_with_note_yaml())?;
+        Ok(())
+    })
+    .await
+    .unwrap();
+
+    let client = reqwest::Client::new();
+
+    // GET — the note must be present in both the raw yaml and the parsed form
+    // right out of the loader (parse-time), before any save round-trip.
+    let resp = client
+        .get(format!("{}/pipelines/notes-roundtrip", daemon.url()))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let detail: serde_json::Value = resp.json().await.unwrap();
+
+    let yaml = detail["yaml"].as_str().unwrap();
+    assert!(
+        yaml.contains("notes:") && yaml.contains(NOTE_MARKER),
+        "raw yaml should carry the top-level notes block; got:\n{yaml}"
+    );
+
+    let notes = detail["pipeline"]["notes"]
+        .as_array()
+        .expect("parsed pipeline must expose a `notes` array (missing Rust field?)");
+    assert_eq!(notes.len(), 1, "expected exactly one parsed note");
+    assert_eq!(notes[0]["id"], "note-abc");
+    assert_eq!(notes[0]["content"], NOTE_MARKER);
+    assert_eq!(notes[0]["view"]["x"], 128.0);
+    assert_eq!(notes[0]["view"]["y"], 256.0);
+
+    // PUT (identity save)
+    let body = serde_json::json!({ "yaml": yaml, "prompts": {} });
+    let resp = client
+        .put(format!("{}/pipelines/notes-roundtrip", daemon.url()))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        200,
+        "PUT rejected its own YAML: {:?}",
+        resp.text().await
+    );
+
+    // GET again — the note must survive the save round-trip in both forms.
+    let resp = client
+        .get(format!("{}/pipelines/notes-roundtrip", daemon.url()))
+        .send()
+        .await
+        .unwrap();
+    let detail2: serde_json::Value = resp.json().await.unwrap();
+
+    let yaml2 = detail2["yaml"].as_str().unwrap();
+    assert!(
+        yaml2.contains("notes:") && yaml2.contains(NOTE_MARKER),
+        "note dropped from yaml after round-trip; got:\n{yaml2}"
+    );
+
+    let notes2 = detail2["pipeline"]["notes"]
+        .as_array()
+        .expect("parsed pipeline must still expose `notes` after round-trip");
+    assert_eq!(notes2.len(), 1, "note count changed after round-trip");
+    assert_eq!(notes2[0]["content"], NOTE_MARKER);
+    assert_eq!(notes2[0]["view"]["x"], 128.0);
+
+    // The note must never leak into the DAG: it is not a node.
+    let node_ids: Vec<&str> = detail2["pipeline"]["nodes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|n| n["id"].as_str().unwrap())
+        .collect();
+    assert!(
+        !node_ids.contains(&"note-abc"),
+        "a note must never appear in pipeline.nodes; got {node_ids:?}"
+    );
+}

--- a/docs/adr/0018-canvas-note-model.md
+++ b/docs/adr/0018-canvas-note-model.md
@@ -19,10 +19,18 @@ Le runtime **ignore entièrement** ce bloc — il n'entre ni dans l'ordonnanceme
 le dataflow, ni dans le graphe de nœuds (les consommateurs itèrent `pipeline.nodes`,
 jamais `pipeline.notes`).
 
-- **`content` = sémantique, `view` = layout.** `view` (position, et plus tard taille)
-  suit la règle établie du `view` d'un nœud et du `mode`/`waypoints`/`target_side` d'une
-  edge : persisté dans le fichier, **exclu du diff sémantique**. `content` est du texte
-  brut en v1 (markdown = enhancement ultérieur qui rouvre ADR-0013).
+- **Layout, pas sémantique — le bloc `notes:` entier est exclu du diff (défaut v1).**
+  Comme le `view` d'un nœud et le `mode`/`waypoints`/`target_side` d'une edge, une note
+  est persistée dans le fichier (elle voyage avec le pipeline partagé) mais **exclue du
+  diff sémantique** : `comparablePipelineObject` fait `delete obj.notes`, donc
+  **créer / déplacer / éditer / supprimer** une note ne fait **jamais** bouger le star
+  synced/diverged (la puce « non sauvegardé » s'allume, elle, comme pour tout déplacement
+  de nœud). C'est le défaut *R1* — classification « layout intégral » (position **et**
+  contenu hors diff), retenu parce qu'une note est de la documentation, pas de la donnée
+  d'orchestration. Point de ratification humaine réversible en ~1 ligne : si le reviewer
+  juge que « documentation = donnée sémantique », on strip **uniquement** `n.view` et on
+  garde `content` (éditer une note marquerait alors « diverged », la déplacer non).
+  `content` est du texte brut en v1 (markdown = enhancement ultérieur qui rouvre ADR-0013).
 - **Rendu = custom element xyflow** (ADR-0003). Un « xyflow node » de type `note` est un
   détail de rendu React-Flow et n'est **pas** un PDO `NodeType` — la distinction est
   volontaire et load-bearing.

--- a/docs/adr/0018-canvas-note-model.md
+++ b/docs/adr/0018-canvas-note-model.md
@@ -1,0 +1,85 @@
+# Note de canvas — bloc racine `notes:`, jamais un type de nœud
+
+Le canvas gagne des **notes** : des annotations de documentation inertes que le
+designer épingle près d'un groupe de nœuds pour expliquer une intention (#307). Le
+« + » de la toolbar devient un dropdown (Node | Note). L'instinct par défaut — « c'est
+un élément du canvas, donc un type de nœud » — vient d'être renforcé par ADR-0017
+(`script` = nouvel arm `NodeType`). Mais une note ne s'exécute jamais, ne spawne aucune
+session, ne produit aucun artefact et n'a pas d'état terminal : la traiter comme un
+`NodeType` forcerait chaque `match NodeType` + le scheduler / spawn / admission /
+`outputs_validator` / détection-de-vie à gérer un arm « qui ne tourne pas », avec le
+risque qu'une note soit accidentellement schedulée. Le coût est mesuré : `NodeType` est
+référencé dans **16 fichiers Rust** (313 occurrences ; `graph_resolver.rs` seul en a 77),
+dont ≥ 3 `match` exhaustifs qui casseraient à la compilation et une nuée d'arms `_ =>`
+qui avaleraient silencieusement une note comme un nœud de DAG.
+
+**Décision : modéliser les notes comme un bloc racine `notes:` du YAML** (sibling de
+`loops:`/`edges:`), chaque entrée `struct Note { id, content, view: Option<ViewPosition> }`.
+Le runtime **ignore entièrement** ce bloc — il n'entre ni dans l'ordonnancement, ni dans
+le dataflow, ni dans le graphe de nœuds (les consommateurs itèrent `pipeline.nodes`,
+jamais `pipeline.notes`).
+
+- **`content` = sémantique, `view` = layout.** `view` (position, et plus tard taille)
+  suit la règle établie du `view` d'un nœud et du `mode`/`waypoints`/`target_side` d'une
+  edge : persisté dans le fichier, **exclu du diff sémantique**. `content` est du texte
+  brut en v1 (markdown = enhancement ultérieur qui rouvre ADR-0013).
+- **Rendu = custom element xyflow** (ADR-0003). Un « xyflow node » de type `note` est un
+  détail de rendu React-Flow et n'est **pas** un PDO `NodeType` — la distinction est
+  volontaire et load-bearing.
+- **Champ Rust `notes` obligatoire** sur `PipelineDef` (+ émission TS livrée dans le même
+  changement, cf. #296). Le frontend ne parse jamais le YAML : il consomme la forme
+  **parsée par le daemon**. Une note écrite dans le fichier mais absente de `PipelineDef`
+  survit au fichier mais **disparaît au reload** (drop silencieux de serde, parser
+  lenient). `"notes"` doit aussi entrer dans `KNOWN_TOP_LEVEL_KEYS` (sinon warning
+  parasite `unknown field 'notes' (ignored)`, attrapé par le gate
+  `known_keys_cover_serialized_pipeline`).
+
+**Pourquoi.** Suit la forme éprouvée du bloc `loops:` (ADR-0011 : entité nommée de
+premier niveau, rendue sur le canvas, jamais un nœud) et l'instinct « pas de nouveau type
+de nœud » d'ADR-0016. Sort la note du chemin d'exécution **par construction**, au lieu de
+la neutraliser par des gardes disséminés qu'un refactor futur oublierait. Divergence
+assumée d'avec ADR-0017 : `script` méritait un arm `NodeType` *parce qu'il s'exécute* ;
+une note ne s'exécute pas. Le critère n'est pas « est-ce sur le canvas » mais « est-ce que
+ça tourne ».
+
+**Alternatives écartées.**
+- **`NodeType::note`** — réutilise l'infra de nœud (render / sélection / drag / undo /
+  persistance / bibliothèque), mais impose de gérer un arm non-exécutant sur ~16 fichiers
+  (scheduler, spawn, admission, validateurs, détection de vie) et laisse fuir le risque
+  d'un scheduling accidentel. Rejeté : le coût de « nœud qui n'est pas un nœud » dépasse
+  la réutilisation.
+- **Annotation éphémère xyflow, non persistée** (ou stockée dans un blob `meta`) — zéro
+  schéma, mais la note ne voyage pas avec le pipeline partagé ni ne survit au reload.
+  Rejeté : une note *est* de la documentation durable.
+
+**Conséquences.**
+- Nouveau plumbing frontend (render / sélection / drag / undo) **non partagé** avec les
+  nœuds. Trois pièges « la note n'est pas un node » à neutraliser explicitement :
+  persistance du drag (`updateNodeViews` ne mappe que `pipeline.nodes`), Delete du
+  context-menu (`nodes.find` → no-op sur une note), et ne jamais confondre le type de
+  rendu xyflow avec un `NodeType`.
+- Les notes vivent sur `PipelineDef.notes` → couvertes par l'undo COW d'ADR-0014
+  gratuitement, **à condition** que chaque reducer réaffecte le tableau (jamais de mutation
+  en place, sinon corruption d'undo silencieuse).
+- `mutation_validator` doit laisser les notes **librement mutables pendant un Run**
+  (inertes, aucune session à orphaner) ; un edit de note émet `PipelineModified{kind:"yaml"}`
+  → relecture scheduler no-op (ADR-0007).
+- Décision de schéma persistant : une fois des pipelines `notes:` dans la nature, basculer
+  vers `NodeType::note` exigerait le `pipeline_migrator` **plus** le travail sur les 16
+  fichiers évité ici. Réversible par migration, donc « difficile à inverser ».
+
+**Portée v1 (différé).**
+- **Contenu markdown / mermaid** dans les notes : rouvre ADR-0013 (2ᵉ surface
+  react-markdown + sink `dangerouslySetInnerHTML`, contenu humain-mais-rendu = nouvelle
+  classe de confiance) → exigera son propre ADR/amendement. v1 = texte brut.
+- **Note redimensionnable** (champ `size` layout-class à threader sur 5 couches et à
+  strip du diff) : fast-follow. v1 = taille pilotée par le contenu.
+- **Note en bibliothèque** (`POST /library/nodes`) : une note est pipeline-spécifique, pas
+  un artefact réutilisable.
+- Imbrication note↔loop-region, couleurs, ancrage/pin.
+
+**Relations.** Suit ADR-0011 (bloc top-level nommé, non-nœud) et l'instinct d'ADR-0016
+(pas de nouveau type de nœud). Diverge délibérément d'ADR-0017 (arm `NodeType` réservé à
+ce qui s'exécute). Hérite d'ADR-0003 (rendu xyflow), ADR-0014 (undo COW), ADR-0007
+(édition pendant un Run). Protège la frontière d'ADR-0013 en restant texte brut. Ne
+supersede aucun ADR.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -30,6 +30,7 @@ import StartInspector from "./components/StartInspector";
 import EndInspector from "./components/EndInspector";
 import EdgeDetailPanel from "./components/EdgeDetailPanel";
 import RegionInspector from "./components/RegionInspector";
+import NoteInspector from "./components/NoteInspector";
 import TriggerDetailPanel from "./components/TriggerDetailPanel";
 import type { TriggerPrefill } from "./components/NewRunModal";
 import { deriveEdgeTrigger } from "./lib/edgeTrigger";
@@ -339,9 +340,9 @@ export default function App() {
   useEffect(() => {
     if (!selectedRun) return;
     if (selection.kind === "node" && selection.id) return;
-    // An explicit region/edge selection (#150 / #147) wins over the auto-snap:
-    // the user opened an inspector and must keep it on a live run.
-    if (selection.kind === "region" || selection.kind === "edge") return;
+    // An explicit region/edge/note selection (#150 / #147 / #307) wins over the
+    // auto-snap: the user opened an inspector and must keep it on a live run.
+    if (selection.kind === "region" || selection.kind === "edge" || selection.kind === "note") return;
     if (!LIVE_RUN_STATUSES.has(selectedRun.status)) return;
     const nodeId = pickLatestLiveNode(selectedRun);
     if (!nodeId) return;
@@ -597,6 +598,8 @@ export default function App() {
                   <EdgeDetailPanel trigger={edgeTrigger} />
                 ) : selection.kind === "region" ? (
                   <RegionInspector />
+                ) : selection.kind === "note" ? (
+                  <NoteInspector />
                 ) : null}
                 {selection.kind === "none" && isEditingRun && selectedRun && (
                   <RunInfoSidebar run={selectedRun} />

--- a/frontend/src/components/EditCanvas.test.ts
+++ b/frontend/src/components/EditCanvas.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   buildLoopRegionNodes,
+  buildNoteNodes,
   deriveEditEdges,
   deriveEditNodes,
   deriveLoopRegions,
@@ -662,5 +663,65 @@ describe("buildLoopRegionNodes — region box must not intercept edge clicks (is
     const p = regionPipeline();
     p.loops = [{ id: "solo", kind: "bounded", members: ["impl"], max_iter: 3 }];
     expect(buildLoopRegionNodes(p, null)).toHaveLength(0);
+  });
+});
+
+describe("buildNoteNodes — inert canvas notes (#307 / ADR-0018)", () => {
+  function notePipeline(): PipelineDef {
+    return {
+      name: "with-notes",
+      version: "1.0",
+      variables: {},
+      nodes: [],
+      edges: [],
+      notes: [
+        { id: "n1", content: "first note", view: { x: 120, y: 240 } },
+        { id: "n2", content: "second note", view: { x: 300, y: 80 } },
+      ],
+    };
+  }
+
+  it("renders one draggable/selectable `note` node per note at its view position", () => {
+    const nodes = buildNoteNodes(notePipeline());
+    expect(nodes).toHaveLength(2);
+    const [a, b] = nodes;
+    expect(a.id).toBe("n1");
+    expect(a.type).toBe("note");
+    expect(a.position).toEqual({ x: 120, y: 240 });
+    expect(a.draggable).toBe(true);
+    expect(a.selectable).toBe(true);
+    expect(b.id).toBe("n2");
+    expect(b.position).toEqual({ x: 300, y: 80 });
+  });
+
+  it("marks notes non-connectable so no edge can ever attach (inert)", () => {
+    for (const n of buildNoteNodes(notePipeline())) {
+      expect(n.connectable).toBe(false);
+    }
+  });
+
+  it("carries the content through to node data for canvas rendering", () => {
+    const n = buildNoteNodes(notePipeline())[0];
+    expect((n.data as { content: string }).content).toBe("first note");
+    expect((n.data as { noteId: string }).noteId).toBe("n1");
+  });
+
+  it("falls back to a default position when a note has no view", () => {
+    const p: PipelineDef = {
+      name: "p",
+      version: "1.0",
+      variables: {},
+      nodes: [],
+      edges: [],
+      notes: [{ id: "n1", content: "no view" }],
+    };
+    const n = buildNoteNodes(p)[0];
+    expect(typeof n.position.x).toBe("number");
+    expect(typeof n.position.y).toBe("number");
+  });
+
+  it("produces no note nodes when the pipeline has none", () => {
+    const p: PipelineDef = { name: "p", version: "1.0", variables: {}, nodes: [], edges: [] };
+    expect(buildNoteNodes(p)).toHaveLength(0);
   });
 });

--- a/frontend/src/components/EditCanvas.tsx
+++ b/frontend/src/components/EditCanvas.tsx
@@ -17,7 +17,7 @@ import {
 import "@xyflow/react/dist/style.css";
 import type { LoopKind, NodeDef, NodeStatus, NodeType, PortBrief, PortSide, RunState } from "../types";
 import type { LibraryEntry, LibraryPipelineEntry } from "../api";
-import { buildLoopRegionNodes, deriveEditEdges, deriveEditNodes, edgeIndexFromId } from "./editNodeDerivation";
+import { buildLoopRegionNodes, buildNoteNodes, deriveEditEdges, deriveEditNodes, edgeIndexFromId } from "./editNodeDerivation";
 import { useEditStore } from "../stores/editStore";
 import { generateNodeId } from "../lib/nanoid";
 import { collectionFanoutNudges, regionsDestroyedByEdgeRemoval } from "../lib/loopRegions";
@@ -26,6 +26,7 @@ import PortRow from "./PortRow";
 import { NodeTypeIcon, CodeDocMarker } from "./NodeTypeIcon";
 import { NodeCard } from "./NodeCard";
 import { LoopRegionNode } from "./LoopRegionNode";
+import { NoteNode } from "./NoteNode";
 import { MergeEditNode } from "./MergeNode";
 import OrthogonalEdge from "./OrthogonalEdge";
 import EditToolbar from "./EditToolbar";
@@ -226,7 +227,7 @@ export function EditNode({ data, id, selected }: NodeProps<Node<EditNodeData>>) 
   );
 }
 
-const nodeTypes = { edit: EditNode, merge: MergeEditNode, loopRegion: LoopRegionNode };
+const nodeTypes = { edit: EditNode, merge: MergeEditNode, loopRegion: LoopRegionNode, note: NoteNode };
 const edgeTypes = { orthogonal: OrthogonalEdge };
 
 const DEFAULT_NODE_NAMES: Partial<Record<NodeType, string>> = {
@@ -257,10 +258,13 @@ function EditCanvasInner({ libraryEntries, libraryPipelines, onLibraryDelete, on
   const deleteEdge = useEditStore((s) => s.deleteEdge);
   const updateEdge = useEditStore((s) => s.updateEdge);
   const addNodeToStore = useEditStore((s) => s.addNode);
+  const addNoteToStore = useEditStore((s) => s.addNote);
+  const moveNote = useEditStore((s) => s.moveNote);
+  const deleteNote = useEditStore((s) => s.deleteNote);
   const [contextMenu, setContextMenu] = useState<{
     x: number;
     y: number;
-    type: "node" | "edge";
+    type: "node" | "edge" | "note";
     id: string;
     edgeIndex?: number;
   } | null>(null);
@@ -319,7 +323,11 @@ function EditCanvasInner({ libraryEntries, libraryPipelines, onLibraryDelete, on
     // cards, and given `pointer-events: none` so edges crossing the box stay
     // clickable (#167).
     const regionNodes: Node[] = buildLoopRegionNodes(pipeline, activeRunState);
-    return [...regionNodes, ...cards];
+    // Inert canvas notes (#307 / ADR-0018) render as draggable/selectable cards
+    // with no handle. They carry no run status, so they're derived from the
+    // pipeline alone (independent of run state).
+    const noteNodes: Node[] = buildNoteNodes(pipeline);
+    return [...regionNodes, ...cards, ...noteNodes];
   }, [pipeline, activeRunState]);
   const derivedEdges = useMemo(
     () => (pipeline ? deriveEditEdges(pipeline) : []),
@@ -369,17 +377,24 @@ function EditCanvasInner({ libraryEntries, libraryPipelines, onLibraryDelete, on
   const onNodeDragStop = useCallback(
     (_: unknown, _node: Node, nodes: Node[]) => {
       // xyflow hands us EVERY dragged node (the selected set, or just [node] for
-      // a single drag) with final positions, in ONE call (#232). Persist them
-      // all in one batched store write — pre-fix we ignored this 3rd arg and
-      // wrote only the grabbed node, so every other selected node snapped back.
-      // Defensively skip the decorative loop-region boxes (already
-      // draggable:false, but belt-and-suspenders against config drift).
-      const moved = nodes
-        .filter((n) => n.type !== "loopRegion")
-        .map((n) => ({ id: n.id, x: n.position.x, y: n.position.y }));
-      if (moved.length > 0) updateNodeViews(moved);
+      // a single drag) with final positions, in ONE call (#232). Partition by
+      // type: pipeline nodes persist via `updateNodeViews`, notes via `moveNote`
+      // (#307 trap #1). A note is NOT in `pipeline.nodes`, so `updateNodeViews`
+      // would silently drop its move (unknown id → ignored) and it would snap
+      // back on the next re-derivation. Decorative loop-region boxes are skipped
+      // (draggable:false already, belt-and-suspenders against config drift).
+      const movedNodes: { id: string; x: number; y: number }[] = [];
+      for (const n of nodes) {
+        if (n.type === "loopRegion") continue;
+        if (n.type === "note") {
+          moveNote(n.id, n.position.x, n.position.y);
+          continue;
+        }
+        movedNodes.push({ id: n.id, x: n.position.x, y: n.position.y });
+      }
+      if (movedNodes.length > 0) updateNodeViews(movedNodes);
     },
-    [updateNodeViews],
+    [updateNodeViews, moveNote],
   );
 
   const handleNodeContextMenu = useCallback(
@@ -387,6 +402,18 @@ function EditCanvasInner({ libraryEntries, libraryPipelines, onLibraryDelete, on
       event.preventDefault();
       // Loop-region boxes are decorative, not pipeline nodes — no context menu.
       if (node.type === "loopRegion") return;
+      // A note (#307 trap #2) is NOT in `pipeline.nodes`, so the node lookup
+      // below would miss it and its Delete would call `deleteNode(noteId)` — a
+      // no-op. Give it its own `"note"` menu whose Delete routes to `deleteNote`.
+      if (node.type === "note") {
+        setContextMenu({
+          x: event.clientX,
+          y: event.clientY,
+          type: "note",
+          id: node.id,
+        });
+        return;
+      }
       const nodeDef = pipeline?.nodes.find((n) => n.id === node.id);
       if (nodeDef?.type === "start" || nodeDef?.type === "end") return;
       setContextMenu({
@@ -573,10 +600,20 @@ function EditCanvasInner({ libraryEntries, libraryPipelines, onLibraryDelete, on
     addNodeToStore(newNode);
   };
 
+  const handleAddNote = () => {
+    // A note (#307 / ADR-0018) is created empty and selected, positioned at the
+    // viewport centre — same drop logic as a node. It carries no ports/name/type.
+    const id = generateNodeId();
+    const view = computeDropPosition();
+    addNoteToStore({ id, content: "", view });
+    setSelection({ kind: "note", id: null, noteId: id });
+  };
+
   return (
     <div className="relative flex-1" ref={reactFlowRef}>
       <EditToolbar
         onAddNode={handleAddNode}
+        onAddNote={handleAddNote}
         libraryEntries={libraryEntries}
         onLibraryDelete={onLibraryDelete}
         getDropPosition={computeDropPosition}
@@ -623,6 +660,13 @@ function EditCanvasInner({ libraryEntries, libraryPipelines, onLibraryDelete, on
             // Region boxes are decorative; clicking one is a no-op (they fall
             // back to the pane selection path via their pass-through body).
             if (node.type === "loopRegion") return;
+            // A note (#307) opens the NoteInspector, not the node inspector — it
+            // is a canvas concept, not a pipeline node.
+            if (node.type === "note") {
+              setSelection({ kind: "note", id: null, noteId: node.id });
+              onCloseInfo?.();
+              return;
+            }
             setSelection({ kind: "node", id: node.id });
             onCloseInfo?.();
           }}
@@ -660,6 +704,10 @@ function EditCanvasInner({ libraryEntries, libraryPipelines, onLibraryDelete, on
           {...contextMenu}
           onDeleteNode={() => {
             deleteNode(contextMenu.id);
+            setContextMenu(null);
+          }}
+          onDeleteNote={() => {
+            deleteNote(contextMenu.id);
             setContextMenu(null);
           }}
           onDuplicateNode={() => {
@@ -705,14 +753,16 @@ function ContextMenu({
   y,
   type,
   onDeleteNode,
+  onDeleteNote,
   onDuplicateNode,
   onDeleteEdge,
   onClose,
 }: {
   x: number;
   y: number;
-  type: "node" | "edge";
+  type: "node" | "edge" | "note";
   onDeleteNode: () => void;
+  onDeleteNote: () => void;
   onDuplicateNode: () => void;
   onDeleteEdge: () => void;
   onClose: () => void;
@@ -739,6 +789,16 @@ function ContextMenu({
               Delete
             </button>
           </>
+        ) : type === "note" ? (
+          // #307 trap #2: a note's Delete must call `deleteNote`, not
+          // `deleteNode` (which would no-op on an id absent from pipeline.nodes).
+          <button
+            data-testid="context-menu-delete"
+            onClick={onDeleteNote}
+            className="flex w-full cursor-pointer items-center px-3 py-1.5 text-left text-st-failed hover:bg-bg-4"
+          >
+            Delete note
+          </button>
         ) : (
           <button
             onClick={onDeleteEdge}

--- a/frontend/src/components/EditToolbar.test.tsx
+++ b/frontend/src/components/EditToolbar.test.tsx
@@ -9,10 +9,12 @@ import type { TabHistory } from "../stores/editStore";
 
 describe("EditToolbar", () => {
   const onAddNode = vi.fn();
+  const onAddNote = vi.fn();
   const onLibraryDelete = vi.fn();
 
   beforeEach(() => {
     onAddNode.mockClear();
+    onAddNote.mockClear();
     onLibraryDelete.mockClear();
   });
 
@@ -21,6 +23,7 @@ describe("EditToolbar", () => {
       <TooltipProvider>
         <EditToolbar
           onAddNode={onAddNode}
+          onAddNote={onAddNote}
           libraryEntries={[]}
           onLibraryDelete={onLibraryDelete}
         />
@@ -41,10 +44,34 @@ describe("EditToolbar", () => {
     expect(screen.queryByTestId("toolbar-loop")).toBeNull();
   });
 
-  it("add button calls onAddNode with code-mutating", () => {
+  it("add button opens a Node|Note dropdown (#307)", async () => {
+    const user = userEvent.setup();
     renderToolbar();
-    fireEvent.click(screen.getByTestId("toolbar-add"));
+    // The `+` is now a dropdown trigger, not a direct add — clicking it opens
+    // the menu instead of immediately adding a node.
+    await user.click(screen.getByTestId("toolbar-add"));
+    expect(await screen.findByTestId("add-menu-node")).toBeInTheDocument();
+    expect(screen.getByTestId("add-menu-note")).toBeInTheDocument();
+    expect(onAddNode).not.toHaveBeenCalled();
+    expect(onAddNote).not.toHaveBeenCalled();
+  });
+
+  it("dropdown Node item calls onAddNode with code-mutating (#307)", async () => {
+    const user = userEvent.setup();
+    renderToolbar();
+    await user.click(screen.getByTestId("toolbar-add"));
+    await user.click(await screen.findByTestId("add-menu-node"));
     expect(onAddNode).toHaveBeenCalledWith("code-mutating");
+    expect(onAddNote).not.toHaveBeenCalled();
+  });
+
+  it("dropdown Note item calls onAddNote (#307)", async () => {
+    const user = userEvent.setup();
+    renderToolbar();
+    await user.click(screen.getByTestId("toolbar-add"));
+    await user.click(await screen.findByTestId("add-menu-note"));
+    expect(onAddNote).toHaveBeenCalledTimes(1);
+    expect(onAddNode).not.toHaveBeenCalled();
   });
 
   it("merge button calls onAddNode with merge", () => {
@@ -64,16 +91,8 @@ describe("EditToolbar", () => {
     const user = userEvent.setup();
     renderToolbar();
 
-    await user.hover(screen.getByTestId("toolbar-add"));
-    await waitFor(() => {
-      expect(screen.getByTestId("tooltip-content")).toHaveTextContent("New node");
-    });
-
-    fireEvent.pointerDown(screen.getByTestId("toolbar-add"));
-    await waitFor(() => {
-      expect(screen.queryByTestId("tooltip-content")).not.toBeInTheDocument();
-    });
-
+    // #307: the `+` is now a dropdown trigger (no tooltip); the library/merge
+    // sibling buttons keep their tooltips.
     await user.hover(screen.getByTestId("toolbar-library"));
     await waitFor(() => {
       expect(screen.getByTestId("tooltip-content")).toHaveTextContent("Library");
@@ -127,7 +146,7 @@ describe("EditToolbar undo/redo buttons (ADR-0014 / #226)", () => {
   function renderToolbar() {
     return render(
       <TooltipProvider>
-        <EditToolbar onAddNode={onAddNode} libraryEntries={[]} onLibraryDelete={onLibraryDelete} />
+        <EditToolbar onAddNode={onAddNode} onAddNote={vi.fn()} libraryEntries={[]} onLibraryDelete={onLibraryDelete} />
       </TooltipProvider>,
     );
   }

--- a/frontend/src/components/EditToolbar.tsx
+++ b/frontend/src/components/EditToolbar.tsx
@@ -1,12 +1,19 @@
-import { Plus, GitMerge, Info, Undo2, Redo2, SquareTerminal } from "lucide-react";
+import { Plus, GitMerge, Info, Undo2, Redo2, SquareTerminal, Box, StickyNote } from "lucide-react";
 import type { NodeType } from "../types";
 import type { LibraryEntry } from "../api";
 import { Tooltip } from "./ui/tooltip";
 import LibraryDropdown from "./LibraryDropdown";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from "./ui/dropdown-menu";
 import { useEditStore } from "../stores/editStore";
 
 interface Props {
   onAddNode: (type: NodeType) => void;
+  onAddNote: () => void;
   libraryEntries: LibraryEntry[];
   onLibraryDelete: (name: string) => void;
   getDropPosition?: () => { x: number; y: number };
@@ -14,7 +21,7 @@ interface Props {
   onToggleInfo?: () => void;
 }
 
-export default function EditToolbar({ onAddNode, libraryEntries, onLibraryDelete, getDropPosition, infoOpen, onToggleInfo }: Props) {
+export default function EditToolbar({ onAddNode, onAddNote, libraryEntries, onLibraryDelete, getDropPosition, infoOpen, onToggleInfo }: Props) {
   // Read undo/redo straight from the store (ADR-0014 / #226): they have no
   // component-local dependency, unlike the prop-drilled add/merge callbacks, so
   // the point-of-use selector idiom is the right fit. `canUndo`/`canRedo` are
@@ -35,15 +42,42 @@ export default function EditToolbar({ onAddNode, libraryEntries, onLibraryDelete
       className="absolute left-3 top-3 z-10 flex items-center gap-0.5 rounded-md border border-line bg-bg-2/90 p-1 backdrop-blur-sm shadow-lg"
       data-testid="edit-toolbar"
     >
-      <Tooltip content="New node · N">
-        <button
+      {/* #307: the `+` is now a dropdown — create a Node (current behaviour) or
+          a canvas Note. The trigger keeps `data-testid="toolbar-add"`; the
+          sibling merge/script buttons are unchanged. */}
+      <DropdownMenu>
+        <DropdownMenuTrigger
           data-testid="toolbar-add"
-          onClick={() => onAddNode("code-mutating")}
-          className="grid h-7 w-7 cursor-pointer place-items-center rounded text-fg-3 transition-colors hover:bg-bg-4 hover:text-fg active:bg-acc active:text-bg-0"
+          className="grid h-7 w-7 cursor-pointer place-items-center rounded text-fg-3 transition-colors hover:bg-bg-4 hover:text-fg active:bg-acc active:text-bg-0 data-[popup-open]:bg-bg-4 data-[popup-open]:text-fg"
+          aria-label="Add"
         >
           <Plus size={14} />
-        </button>
-      </Tooltip>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          className="min-w-[160px] rounded-md border border-line-strong bg-bg-3 p-1 shadow-lg"
+          side="bottom"
+          align="start"
+        >
+          <DropdownMenuItem
+            data-testid="add-menu-node"
+            className="flex cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-fg-2 transition-colors hover:bg-bg-4"
+            style={{ fontSize: "11.5px" }}
+            onClick={() => onAddNode("code-mutating")}
+          >
+            <Box size={13} className="shrink-0 text-fg-4" />
+            <span>Node</span>
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            data-testid="add-menu-note"
+            className="flex cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-fg-2 transition-colors hover:bg-bg-4"
+            style={{ fontSize: "11.5px" }}
+            onClick={() => onAddNote()}
+          >
+            <StickyNote size={13} className="shrink-0 text-fg-4" />
+            <span>Note</span>
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
 
       <span className="mx-0.5 h-4 w-px bg-line" />
 

--- a/frontend/src/components/NoteInspector.test.tsx
+++ b/frontend/src/components/NoteInspector.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, beforeEach } from "vitest";
+import NoteInspector from "./NoteInspector";
+import { useEditStore } from "../stores/editStore";
+import type { PipelineDef, NoteDef } from "../types";
+
+function makePipeline(notes: NoteDef[]): PipelineDef {
+  return {
+    name: "test-pipeline",
+    variables: {},
+    nodes: [],
+    edges: [],
+    notes,
+  };
+}
+
+function selectNote(notes: NoteDef[], noteId: string) {
+  useEditStore.setState({
+    openTabs: [
+      {
+        id: "tab1",
+        scope: "repo",
+        pipeline: makePipeline(notes),
+        prompts: {},
+        diagnostics: [],
+        dirty: false,
+        externalDirty: false,
+      },
+    ],
+    activeTabId: "tab1",
+    selection: { kind: "note", id: null, noteId },
+  });
+}
+
+const note: NoteDef = { id: "n1", content: "hello note", view: { x: 10, y: 20 } };
+
+describe("NoteInspector (#307)", () => {
+  beforeEach(() => {
+    useEditStore.setState({
+      openTabs: [],
+      activeTabId: null,
+      selection: { kind: "none", id: null },
+    });
+  });
+
+  it("renders nothing when the selection is not a note", () => {
+    useEditStore.setState({
+      openTabs: [
+        {
+          id: "tab1",
+          scope: "repo",
+          pipeline: makePipeline([note]),
+          prompts: {},
+          diagnostics: [],
+          dirty: false,
+          externalDirty: false,
+        },
+      ],
+      activeTabId: "tab1",
+      selection: { kind: "none", id: null },
+    });
+    const { container } = render(<NoteInspector />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("shows a stripped inspector: a Note header and a single content textarea", () => {
+    selectNote([note], "n1");
+    render(<NoteInspector />);
+    expect(screen.getByTestId("note-inspector")).toBeInTheDocument();
+    expect(screen.getByText("Note")).toBeInTheDocument();
+    const textarea = screen.getByTestId("note-content");
+    expect(textarea).toHaveValue("hello note");
+    // No node-style affordances: no name/type/ports/model, no star button.
+    expect(screen.queryByTestId("star-button")).toBeNull();
+    expect(screen.queryByText(/model/i)).toBeNull();
+  });
+
+  it("commits content edits to the note via updateNote", () => {
+    selectNote([note], "n1");
+    render(<NoteInspector />);
+    fireEvent.change(screen.getByTestId("note-content"), {
+      target: { value: "edited body" },
+    });
+    const tab = useEditStore.getState().openTabs[0];
+    expect(tab.pipeline.notes!.find((n) => n.id === "n1")!.content).toBe("edited body");
+  });
+
+  it("renders nothing when the selected note id is missing", () => {
+    selectNote([note], "does-not-exist");
+    const { container } = render(<NoteInspector />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/frontend/src/components/NoteInspector.tsx
+++ b/frontend/src/components/NoteInspector.tsx
@@ -1,0 +1,60 @@
+import { StickyNote } from "lucide-react";
+import { useEditStore } from "../stores/editStore";
+import { SectionHead } from "./InspectorPrimitives";
+
+/**
+ * Inspector for an inert canvas note (#307 / ADR-0018). Opened by clicking a
+ * note on the canvas. A note has no title, no ports, no type, no model — just
+ * free-text `content`, edited here in a single textarea. Editing is COW and
+ * undo-tracked (`updateNote`); it flips the tab's dirty flag but never moves the
+ * synced/diverged star (a note is layout, not semantics — see
+ * `comparablePipelineObject`). Content is plain text in v1 (no markdown render).
+ */
+export default function NoteInspector() {
+  const openTabs = useEditStore((s) => s.openTabs);
+  const activeTabId = useEditStore((s) => s.activeTabId);
+  const selection = useEditStore((s) => s.selection);
+  const updateNote = useEditStore((s) => s.updateNote);
+
+  const tab = openTabs.find((t) => t.id === activeTabId);
+  if (!tab || selection.kind !== "note" || !selection.noteId) return null;
+
+  const note = (tab.pipeline.notes ?? []).find((n) => n.id === selection.noteId);
+  if (!note) return null;
+
+  return (
+    <aside
+      className="flex h-full flex-col bg-bg-2 overflow-y-auto"
+      data-testid="note-inspector"
+    >
+      <div className="flex items-center gap-2 border-b border-line px-3 py-2">
+        <StickyNote size={14} className="shrink-0 text-acc" />
+        <div className="min-w-0">
+          <div className="truncate font-medium text-fg" style={{ fontSize: "12.5px" }}>
+            Note
+          </div>
+          <div className="mt-0.5 text-fg-4" style={{ fontSize: "10px" }}>
+            canvas note — documentation only
+          </div>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-3 p-3" style={{ fontSize: "11.5px" }}>
+        <SectionHead title="Content" />
+        <textarea
+          value={note.content}
+          onChange={(e) => updateNote(note.id, { content: e.target.value })}
+          data-testid="note-content"
+          rows={8}
+          placeholder="Write a note…"
+          className="w-full resize-y rounded border border-line-strong bg-bg-3 px-2 py-1.5 text-fg outline-none focus:border-acc"
+          style={{ fontSize: "11.5px", lineHeight: 1.5 }}
+        />
+        <div className="text-fg-4" style={{ fontSize: "10px", lineHeight: 1.6 }}>
+          A note is inert: it never runs, has no ports, and does not affect the
+          pipeline diff (the synced/diverged star stays put).
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/frontend/src/components/NoteNode.tsx
+++ b/frontend/src/components/NoteNode.tsx
@@ -1,0 +1,52 @@
+import { type Node, type NodeProps } from "@xyflow/react";
+import { StickyNote } from "lucide-react";
+import { useEditStore } from "../stores/editStore";
+import { SELECTION_RING_STYLE } from "../nodeStyles";
+
+/**
+ * Data carried by a `note` canvas node (#307 / ADR-0018). A note is an inert
+ * documentation post-it: no title, no port, no edge, never spawned, outside the
+ * DAG and the runtime. Unlike a `loopRegion` box (decorative, non-interactive)
+ * a note IS draggable and selectable — but never connectable (it renders no
+ * `<Handle>`, so no edge can attach). The `note` xyflow node `type` is a canvas
+ * concern only: it is NOT a PDO `NodeType`.
+ */
+export interface NoteNodeData {
+  noteId: string;
+  content: string;
+  [key: string]: unknown;
+}
+
+export function NoteNode({ data, id, selected }: NodeProps<Node<NoteNodeData>>) {
+  const selection = useEditStore((s) => s.selection);
+  // OR-in xyflow's own `selected` (mirror of `EditNode`, #232) so a note lit as
+  // part of a multi-select group drag shows the accent ring too, not only the
+  // note the Zustand single-selection tracks.
+  const isSelected =
+    selected || (selection.kind === "note" && selection.noteId === id);
+
+  return (
+    <div
+      data-testid="note-card"
+      data-note-id={data.noteId}
+      className="rounded-md border border-dashed border-line-strong bg-st-await-bg px-3 py-2 text-fg-2"
+      style={{
+        width: 200,
+        fontSize: "12px",
+        whiteSpace: "pre-wrap",
+        wordBreak: "break-word",
+        ...(isSelected ? SELECTION_RING_STYLE : undefined),
+      }}
+    >
+      <div className="mb-1 flex items-center gap-1.5 text-fg-4" style={{ fontSize: "10px" }}>
+        <StickyNote size={12} className="shrink-0" />
+        <span style={{ textTransform: "uppercase", letterSpacing: "0.05em" }}>Note</span>
+      </div>
+      {data.content ? (
+        data.content
+      ) : (
+        <span className="text-fg-5 italic">Empty note — click to edit</span>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/editNodeDerivation.ts
+++ b/frontend/src/components/editNodeDerivation.ts
@@ -289,6 +289,28 @@ export function buildLoopRegionNodes(
     }));
 }
 
+/**
+ * Builds the xyflow `note` nodes for every inert canvas note (#307 / ADR-0018).
+ * A note is draggable and selectable but NOT connectable — it renders no handle,
+ * so no edge can ever attach. Missing `view` falls back to a default spot, like
+ * a node with no persisted position. Notes are a canvas concept, never part of
+ * `pipeline.nodes`; they carry no run status and never colour.
+ */
+export function buildNoteNodes(pipeline: PipelineDef): Node[] {
+  return (pipeline.notes ?? []).map((note, i) => ({
+    id: note.id,
+    type: "note",
+    position: {
+      x: note.view?.x ?? 240,
+      y: note.view?.y ?? 80 + i * 120,
+    },
+    data: { noteId: note.id, content: note.content },
+    draggable: true,
+    selectable: true,
+    connectable: false,
+  }));
+}
+
 const OP_SYMBOLS: Record<string, string> = {
   eq: "=",
   neq: "!=",

--- a/frontend/src/hooks/useLibraryPipelines.test.ts
+++ b/frontend/src/hooks/useLibraryPipelines.test.ts
@@ -108,6 +108,42 @@ describe("pipelinesEquivalent", () => {
     expect(pipelinesEquivalent(a, b)).toBe(true);
   });
 
+  // #307: canvas notes are LAYOUT, not semantics (default R1 = full-layout).
+  // Two pipelines differing only by their notes — presence, content, OR
+  // position — must compare equal so the synced/diverged star never moves.
+  it("ignores a note added on one side so notes don't count as divergence", () => {
+    const a = def({ nodes: [node("a")] });
+    const b = def({
+      nodes: [node("a")],
+      notes: [{ id: "n1", content: "todo: bound this loop", view: { x: 5, y: 5 } }],
+    });
+    expect(pipelinesEquivalent(a, b)).toBe(true);
+  });
+
+  it("ignores note content edits (full-layout classification, R1 default)", () => {
+    const a = def({
+      nodes: [node("a")],
+      notes: [{ id: "n1", content: "original", view: { x: 5, y: 5 } }],
+    });
+    const b = def({
+      nodes: [node("a")],
+      notes: [{ id: "n1", content: "edited", view: { x: 5, y: 5 } }],
+    });
+    expect(pipelinesEquivalent(a, b)).toBe(true);
+  });
+
+  it("ignores note position moves", () => {
+    const a = def({
+      nodes: [node("a")],
+      notes: [{ id: "n1", content: "x", view: { x: 0, y: 0 } }],
+    });
+    const b = def({
+      nodes: [node("a")],
+      notes: [{ id: "n1", content: "x", view: { x: 400, y: 250 } }],
+    });
+    expect(pipelinesEquivalent(a, b)).toBe(true);
+  });
+
   it("still flags a real edge difference (target change) despite routing exclusion", () => {
     const base = { source: { node: "a", port: "out" } };
     const a = def({

--- a/frontend/src/hooks/useLibraryPipelines.ts
+++ b/frontend/src/hooks/useLibraryPipelines.ts
@@ -20,7 +20,10 @@ export type PipelineLibrarySyncState = "outline" | "synced" | "diverged";
 // Layout is stripped from both sides before comparison:
 //   - node `view: { x, y }` — node positions,
 //   - edge `mode` + `waypoints` — orthogonal routing / manual pins (#154),
-//   - edge `target_side` — incoming-edge anchor side / drop position (#168).
+//   - edge `target_side` — incoming-edge anchor side / drop position (#168),
+//   - the whole `notes:` block — inert canvas notes (#307 / ADR-0018): a note is
+//     documentation layout, so two pipelines differing only by their notes
+//     compare equal and the synced/diverged star does not move.
 // Library pipelines don't carry layout, and even a starred local pipeline can
 // be freely rearranged (move a node, pin an edge route) without that
 // registering as "diverged". Layout travels in the file (so a shared workflow
@@ -46,6 +49,11 @@ function comparablePipelineObject(p: PipelineDef): Record<string, unknown> {
       delete edge.target_side;
     }
   }
+  // #307: canvas notes are layout, not semantics — strip the whole block (the
+  // strip half of the emit/strip couple in pipelineToYamlObject). Both content
+  // and position are excluded, so editing/moving/adding/deleting a note never
+  // moves the star (R1 default: full-layout classification).
+  delete obj.notes;
   return obj;
 }
 

--- a/frontend/src/stores/editStore.test.ts
+++ b/frontend/src/stores/editStore.test.ts
@@ -128,6 +128,92 @@ describe("addNode", () => {
   });
 });
 
+describe("note reducers (#307 / ADR-0018)", () => {
+  it("addNote appends an inert note and dirties the tab", () => {
+    seedTabWithPipeline(makePipeline());
+    useEditStore.getState().addNote({ id: "n1", content: "hi", view: { x: 10, y: 20 } });
+
+    const tab = useEditStore.getState().openTabs[0];
+    expect(tab.pipeline.notes).toHaveLength(1);
+    expect(tab.pipeline.notes![0]).toEqual({ id: "n1", content: "hi", view: { x: 10, y: 20 } });
+    expect(tab.dirty).toBe(true);
+    // A note is never a node — it must not leak into pipeline.nodes.
+    expect(tab.pipeline.nodes).toHaveLength(0);
+  });
+
+  it("addNote is copy-on-write (does not mutate the previous array)", () => {
+    seedTabWithPipeline(makePipeline());
+    useEditStore.getState().addNote({ id: "n1", content: "a" });
+    const first = useEditStore.getState().openTabs[0].pipeline.notes;
+    useEditStore.getState().addNote({ id: "n2", content: "b" });
+    const second = useEditStore.getState().openTabs[0].pipeline.notes;
+    // New array reference each time — the undo snapshot's array stays frozen.
+    expect(second).not.toBe(first);
+    expect(first).toHaveLength(1);
+    expect(second).toHaveLength(2);
+  });
+
+  it("updateNote edits content in place by id", () => {
+    seedTabWithPipeline(makePipeline());
+    useEditStore.getState().addNote({ id: "n1", content: "before", view: { x: 0, y: 0 } });
+    useEditStore.getState().updateNote("n1", { content: "after" });
+
+    const note = useEditStore.getState().openTabs[0].pipeline.notes![0];
+    expect(note.content).toBe("after");
+    // Position untouched by a content edit.
+    expect(note.view).toEqual({ x: 0, y: 0 });
+  });
+
+  it("moveNote sets a rounded position without touching content", () => {
+    seedTabWithPipeline(makePipeline());
+    useEditStore.getState().addNote({ id: "n1", content: "keep", view: { x: 0, y: 0 } });
+    useEditStore.getState().moveNote("n1", 12.7, 40.2);
+
+    const note = useEditStore.getState().openTabs[0].pipeline.notes![0];
+    expect(note.view).toEqual({ x: 13, y: 40 });
+    expect(note.content).toBe("keep");
+  });
+
+  it("deleteNote removes the note and clears the selection", () => {
+    seedTabWithPipeline(makePipeline());
+    useEditStore.getState().addNote({ id: "n1", content: "x" });
+    useEditStore.getState().addNote({ id: "n2", content: "y" });
+    useEditStore.setState({ selection: { kind: "note", id: null, noteId: "n1" } });
+
+    useEditStore.getState().deleteNote("n1");
+
+    const state = useEditStore.getState();
+    expect(state.openTabs[0].pipeline.notes!.map((n) => n.id)).toEqual(["n2"]);
+    expect(state.selection).toEqual({ kind: "none", id: null });
+  });
+
+  it("undo restores the note state before the last mutation (COW, ADR-0014)", () => {
+    seedTabWithPipeline(makePipeline());
+    useEditStore.getState().addNote({ id: "n1", content: "original", view: { x: 0, y: 0 } });
+    // A fresh content edit (distinct coalesce key window is irrelevant here — it
+    // is a separate reducer call, so it records its own history entry).
+    useEditStore.getState().updateNote("n1", { content: "edited" });
+    expect(useEditStore.getState().openTabs[0].pipeline.notes![0].content).toBe("edited");
+
+    useEditStore.getState().undo();
+    expect(useEditStore.getState().openTabs[0].pipeline.notes![0].content).toBe("original");
+
+    useEditStore.getState().undo();
+    // Back before the note existed at all.
+    expect(useEditStore.getState().openTabs[0].pipeline.notes ?? []).toHaveLength(0);
+  });
+
+  it("serializePipeline emits a top-level notes block (round-trip shape)", () => {
+    seedTabWithPipeline(makePipeline());
+    useEditStore.getState().addNote({ id: "n1", content: "remember", view: { x: 3, y: 4 } });
+    const yaml = serializePipeline(useEditStore.getState().openTabs[0].pipeline);
+    expect(yaml).toContain("notes:");
+    expect(yaml).toContain("remember");
+    // Not nested under a node.
+    expect(yaml).toMatch(/\nnotes:/);
+  });
+});
+
 describe("updateNodeViews — batched group-move position write (#232)", () => {
   function seedThree() {
     const a = makeNode({ id: "aaaa1111", name: "a", view: { x: 100, y: 100 } });

--- a/frontend/src/stores/editStore.ts
+++ b/frontend/src/stores/editStore.ts
@@ -7,7 +7,7 @@ import type {
   EdgeDef,
 } from "../types";
 import type { LibraryPipelineScope } from "../api";
-import type { LoopRegion } from "../types";
+import type { LoopRegion, NoteDef } from "../types";
 import {
   fetchPipeline,
   fetchPipelines,
@@ -24,7 +24,7 @@ import {
   regionsDestroyedByEdgeRemoval,
 } from "../lib/loopRegions";
 
-export type SelectionKind = "node" | "edge" | "region" | "none";
+export type SelectionKind = "node" | "edge" | "region" | "note" | "none";
 
 export interface Selection {
   kind: SelectionKind;
@@ -41,6 +41,12 @@ export interface Selection {
    * inspector and `updateRegion` use. Undefined for other selections.
    */
   regionId?: string;
+  /**
+   * The selected canvas note's `id` when `kind === "note"` (#307). Notes carry
+   * a stable `id`, so the id is the selection key the note inspector and
+   * `updateNote`/`moveNote`/`deleteNote` use. Undefined for other selections.
+   */
+  noteId?: string;
 }
 
 export interface ConflictData {
@@ -135,6 +141,17 @@ interface EditState {
 
   // Region mutations (ADR-0011 / #150) — edit a bounded region's bound live.
   updateRegion: (regionId: string, updates: Partial<LoopRegion>) => void;
+
+  // Note mutations (#307 / ADR-0018) — inert canvas notes. All are COW and
+  // history-tracked (ADR-0014): they live on `PipelineDef.notes`, so a
+  // reference snapshot covers them for free as long as each reducer reassigns
+  // the array rather than mutating in place.
+  addNote: (note: NoteDef) => void;
+  updateNote: (noteId: string, updates: Partial<NoteDef>) => void;
+  // Position-only write for a note drag; coalesced at the drag-stop call site
+  // (mirror of `updateNodeViews`), so a whole drag folds into one undo step.
+  moveNote: (noteId: string, x: number, y: number) => void;
+  deleteNote: (noteId: string) => void;
 
   // Pipeline-level mutations
   updatePipelineMeta: (updates: Partial<Pick<PipelineDef, "name" | "version" | "variables" | "prompt_required">>) => void;
@@ -271,6 +288,18 @@ export function pipelineToYamlObject(p: PipelineDef): Record<string, unknown> {
       if (r.max_iter !== undefined && r.max_iter !== null)
         region.max_iter = r.max_iter;
       return region;
+    });
+  }
+
+  // Inert canvas notes (#307 / ADR-0018) — a top-level `notes:` block, sibling
+  // of `loops:`. Emitted only when present so note-less pipelines stay clean and
+  // round-trip identically. This is the emit half of the emit/strip couple: the
+  // strip (`comparablePipelineObject`) keeps notes out of the semantic diff.
+  if (p.notes && p.notes.length > 0) {
+    obj.notes = p.notes.map((n) => {
+      const note: Record<string, unknown> = { id: n.id, content: n.content };
+      if (n.view) note.view = { x: n.view.x, y: n.view.y };
+      return note;
     });
   }
 
@@ -737,6 +766,42 @@ export const useEditStore = create<EditState>((set, get) => ({
         r.id === regionId ? { ...r, ...updates } : r,
       );
     }, { coalesceKey: `updateRegion:${regionId}:${Object.keys(updates).sort().join(",")}` }));
+  },
+
+  addNote: (note: NoteDef) => {
+    set((s) => mutateActiveTabWithHistory(s, (tab) => {
+      tab.pipeline.notes = [...(tab.pipeline.notes ?? []), note];
+    }));
+  },
+
+  updateNote: (noteId: string, updates: Partial<NoteDef>) => {
+    // Tracked (unlike `updatePrompt`): a note's content is edit data that must
+    // ride the undo stack. Coalesced per-note so a burst of keystrokes folds
+    // into one undo step (mirror of `updateRegion`).
+    set((s) => mutateActiveTabWithHistory(s, (tab) => {
+      tab.pipeline.notes = (tab.pipeline.notes ?? []).map((n) =>
+        n.id === noteId ? { ...n, ...updates } : n,
+      );
+    }, { coalesceKey: `updateNote:${noteId}:${Object.keys(updates).sort().join(",")}` }));
+  },
+
+  moveNote: (noteId: string, x: number, y: number) => {
+    set((s) => mutateActiveTabWithHistory(s, (tab) => {
+      tab.pipeline.notes = (tab.pipeline.notes ?? []).map((n) =>
+        n.id === noteId ? { ...n, view: { x: Math.round(x), y: Math.round(y) } } : n,
+      );
+    }));
+  },
+
+  deleteNote: (noteId: string) => {
+    set((s) => ({
+      ...mutateActiveTabWithHistory(s, (tab) => {
+        tab.pipeline.notes = (tab.pipeline.notes ?? []).filter((n) => n.id !== noteId);
+      }),
+      // Clear selection unconditionally (mirror `deleteNode`/`deleteEdge`): the
+      // deleted note's inspector must close.
+      selection: { kind: "none" as const, id: null },
+    }));
   },
 
   updatePipelineMeta: (updates) => {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -433,6 +433,22 @@ export interface LoopRegion {
   over?: string | null;
 }
 
+/**
+ * An inert canvas note (#307 / ADR-0018): a documentation post-it laid on the
+ * canvas. It has no title, no port, no edge; it is never spawned and lives
+ * outside the DAG and the runtime. Clicking it opens the detail panel to edit
+ * its `content`. Like `view`/`waypoints`/`target_side` it is LAYOUT, not
+ * semantics: it travels in the pipeline file but is excluded from the semantic
+ * pipeline-diff (`comparablePipelineObject`), so the synced/diverged star does
+ * not move when a note is created/moved/edited/deleted. Note the `note` xyflow
+ * node `type` is a canvas concern only — it is NOT a PDO `NodeType`.
+ */
+export interface NoteDef {
+  id: string;
+  content: string;
+  view?: { x: number; y: number } | null;
+}
+
 export interface PipelineDef {
   name: string;
   version?: string | null;
@@ -441,6 +457,8 @@ export interface PipelineDef {
   edges: EdgeDef[];
   /** Named bounded loop regions (ADR-0011 / #148). Absent when there are none. */
   loops?: LoopRegion[];
+  /** Inert canvas notes (#307 / ADR-0018). Absent when there are none. */
+  notes?: NoteDef[];
   /**
    * Whether a manual Run must supply a non-empty prompt (#158). Defaults to
    * `true` (prompt mandatory) and is omitted from YAML in that case. When


### PR DESCRIPTION
Closes #307.

## What

The add-node `+` toolbar becomes a dropdown offering **Node** or **Note**. Notes are inert canvas cards: a single free-text `content`, a position, no ports, no wiring, no participation in run execution. They persist via a new top-level `notes:` block in the pipeline YAML (backed by a real Rust `notes: Vec<Note>` field), survive reload in parsed form, and are ignored by the library-sync star.

See ADR-0018 (canvas note model) + CONTEXT glossary entry.

## Design decisions (ADR-0018)

- Top-level `notes:` block (not nested under nodes) — notes are not `NodeType`.
- Rust field is **mandatory**: without it the parsed form drops notes on reload.
- `KNOWN_KEYS` drift-guard warns (not silent-loss) on unknown keys.
- Library star: emit strips `notes` (coupled emit+strip) — editing/adding notes keeps the star `synced`; only node changes diverge it.
- Three traps neutralised: drag-persist (notes route to `moveNote`), delete no-op (`deleteNote` ≠ `deleteNode`), `NodeType` pollution (note ids never appear in `pipeline.nodes`).

## Validation — Layer-5 agentic test: **PASS**

Full `cargo build` green (frontend embedded + Rust daemon). Isolated daemon on `:6172` (prod `:6160` untouched). Nominal path A→I + 4 adversarial probes all pass, each UI observation cross-checked with a disk/HTTP/`data-sync-state` side-effect proof. The decisive test — the Rust `notes` field surfacing in the GET's parsed form so a note survives reload — is green.

Targeted unit tests: Rust `note_round_trips_through_save_in_yaml_and_parsed_form` + `known_keys_cover_serialized_pipeline` ok; frontend 203 vitest tests across 5 files, 100% pass.

## Release

- Version bumped `0.1.57` → `0.1.58`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)