### PR TITLE
feat(#312): arrow-key navigation in the fullscreen image viewer — v0.1.61

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1952,7 +1952,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "0.1.60"
+version = "0.1.61"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "0.1.60"
+version = "0.1.61"
 license = "MIT"
 
 [workspace.dependencies]

--- a/frontend/src/components/ImageLightbox.test.tsx
+++ b/frontend/src/components/ImageLightbox.test.tsx
@@ -4,53 +4,149 @@ import { describe, it, expect, vi } from "vitest";
 import ImageLightbox from "./ImageLightbox";
 
 describe("ImageLightbox", () => {
-  it("renders the image at the given src", () => {
-    render(<ImageLightbox src="/runs/r1/artifact?path=a.png" onClose={() => {}} />);
+  it("renders the image at the given index", () => {
+    render(
+      <ImageLightbox
+        images={["/runs/r1/artifact?path=a.png"]}
+        index={0}
+        onClose={() => {}}
+      />,
+    );
     const img = screen.getByTestId("lightbox-image");
     expect(img.getAttribute("src")).toBe("/runs/r1/artifact?path=a.png");
   });
 
   it("closes on Escape", () => {
     const onClose = vi.fn();
-    render(<ImageLightbox src="/x.png" onClose={onClose} />);
+    render(<ImageLightbox images={["/x.png"]} index={0} onClose={onClose} />);
     fireEvent.keyDown(window, { key: "Escape" });
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
   it("closes when the backdrop is clicked", () => {
     const onClose = vi.fn();
-    render(<ImageLightbox src="/x.png" onClose={onClose} />);
+    render(<ImageLightbox images={["/x.png"]} index={0} onClose={onClose} />);
     fireEvent.click(screen.getByTestId("image-lightbox"));
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
   it("closes when the image itself is clicked", () => {
     const onClose = vi.fn();
-    render(<ImageLightbox src="/x.png" onClose={onClose} />);
+    render(<ImageLightbox images={["/x.png"]} index={0} onClose={onClose} />);
     fireEvent.click(screen.getByTestId("lightbox-image"));
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
   it("closes via the close button", () => {
     const onClose = vi.fn();
-    render(<ImageLightbox src="/x.png" onClose={onClose} />);
+    render(<ImageLightbox images={["/x.png"]} index={0} onClose={onClose} />);
     fireEvent.click(screen.getByTestId("lightbox-close"));
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  it("does not close on other keys", () => {
+  it("does not close on unrelated keys", () => {
     const onClose = vi.fn();
-    render(<ImageLightbox src="/x.png" onClose={onClose} />);
-    fireEvent.keyDown(window, { key: "ArrowLeft" });
+    render(<ImageLightbox images={["/x.png"]} index={0} onClose={onClose} />);
     fireEvent.keyDown(window, { key: "a" });
     expect(onClose).not.toHaveBeenCalled();
   });
 
   it("removes its keydown listener on unmount", () => {
     const onClose = vi.fn();
-    const { unmount } = render(<ImageLightbox src="/x.png" onClose={onClose} />);
+    const { unmount } = render(
+      <ImageLightbox images={["/x.png"]} index={0} onClose={onClose} />,
+    );
     unmount();
     fireEvent.keyDown(window, { key: "Escape" });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("ArrowRight advances to the next image", () => {
+    render(
+      <ImageLightbox images={["/a.png", "/b.png", "/c.png"]} index={0} onClose={() => {}} />,
+    );
+    fireEvent.keyDown(window, { key: "ArrowRight" });
+    expect(screen.getByTestId("lightbox-image").getAttribute("src")).toBe("/b.png");
+  });
+
+  it("ArrowLeft retreats to the previous image", () => {
+    render(
+      <ImageLightbox images={["/a.png", "/b.png", "/c.png"]} index={1} onClose={() => {}} />,
+    );
+    fireEvent.keyDown(window, { key: "ArrowLeft" });
+    expect(screen.getByTestId("lightbox-image").getAttribute("src")).toBe("/a.png");
+  });
+
+  it("clamps at the end (ArrowRight on the last image is a no-op, no wrap)", () => {
+    const onClose = vi.fn();
+    render(
+      <ImageLightbox images={["/a.png", "/b.png", "/c.png"]} index={2} onClose={onClose} />,
+    );
+    fireEvent.keyDown(window, { key: "ArrowRight" });
+    expect(screen.getByTestId("lightbox-image").getAttribute("src")).toBe("/c.png");
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("clamps at the start (ArrowLeft on the first image is a no-op, no wrap)", () => {
+    const onClose = vi.fn();
+    render(
+      <ImageLightbox images={["/a.png", "/b.png", "/c.png"]} index={0} onClose={onClose} />,
+    );
+    fireEvent.keyDown(window, { key: "ArrowLeft" });
+    expect(screen.getByTestId("lightbox-image").getAttribute("src")).toBe("/a.png");
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("is inert for a single image: arrows do nothing, chevrons/counter absent", () => {
+    const onClose = vi.fn();
+    render(<ImageLightbox images={["/a.png"]} index={0} onClose={onClose} />);
+    fireEvent.keyDown(window, { key: "ArrowRight" });
+    fireEvent.keyDown(window, { key: "ArrowLeft" });
+    expect(screen.getByTestId("lightbox-image").getAttribute("src")).toBe("/a.png");
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("lightbox-prev")).toBeNull();
+    expect(screen.queryByTestId("lightbox-next")).toBeNull();
+    expect(screen.queryByTestId("lightbox-counter")).toBeNull();
+  });
+
+  it("shows a counter and chevrons whose disabled state tracks the ends", () => {
+    render(
+      <ImageLightbox images={["/a.png", "/b.png", "/c.png"]} index={0} onClose={() => {}} />,
+    );
+    expect(screen.getByTestId("lightbox-counter").textContent).toBe("1 of 3");
+    // At index 0: prev disabled, next enabled.
+    expect((screen.getByTestId("lightbox-prev") as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByTestId("lightbox-next") as HTMLButtonElement).disabled).toBe(false);
+
+    // Clicking next advances the counter and the image.
+    fireEvent.click(screen.getByTestId("lightbox-next"));
+    expect(screen.getByTestId("lightbox-counter").textContent).toBe("2 of 3");
+    expect(screen.getByTestId("lightbox-image").getAttribute("src")).toBe("/b.png");
+
+    // Advance to the last image: next becomes disabled.
+    fireEvent.click(screen.getByTestId("lightbox-next"));
+    expect(screen.getByTestId("lightbox-counter").textContent).toBe("3 of 3");
+    expect((screen.getByTestId("lightbox-next") as HTMLButtonElement).disabled).toBe(true);
+    expect((screen.getByTestId("lightbox-prev") as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it("clicking a chevron does not close the viewer", () => {
+    const onClose = vi.fn();
+    render(
+      <ImageLightbox images={["/a.png", "/b.png"]} index={0} onClose={onClose} />,
+    );
+    fireEvent.click(screen.getByTestId("lightbox-next"));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("does not react to arrows after unmount", () => {
+    const onClose = vi.fn();
+    const { unmount } = render(
+      <ImageLightbox images={["/a.png", "/b.png"]} index={0} onClose={onClose} />,
+    );
+    unmount();
+    // No crash / no state effect: the listener was removed on unmount.
+    fireEvent.keyDown(window, { key: "ArrowRight" });
     expect(onClose).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/ImageLightbox.tsx
+++ b/frontend/src/components/ImageLightbox.tsx
@@ -1,39 +1,78 @@
-import { useCallback, useEffect } from "react";
-import { X } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { X, ChevronLeft, ChevronRight } from "lucide-react";
 
 interface Props {
-  /** Fully-resolved image URL to display at full size. */
-  src: string;
+  /** Ordered, fully-resolved image URLs the viewer can page through. */
+  images: string[];
+  /** Index into `images` of the image that was clicked (seeds the cursor). */
+  index: number;
   alt?: string;
   onClose: () => void;
 }
 
 /**
- * Full-viewport overlay that shows a single image as large as the viewport
- * allows (capped at 95vw/95vh, scaled down to fit, never blown up past the
- * card it was opened from). Closes on Escape, backdrop click, clicking the
- * image, or the close button.
+ * Full-viewport overlay that shows an image as large as the viewport allows
+ * (capped at 95vw/95vh, scaled down to fit, never blown up past the card it
+ * was opened from). Closes on Escape, backdrop click, clicking the image, or
+ * the close button.
+ *
+ * List-aware (#312): given the whole ordered `images` list plus the clicked
+ * `index`, the left/right arrow keys (and the ‹ › chevrons) move between them.
+ * Navigation clamps at both ends — arrowing past the last/first image is a
+ * no-op, matching every other sequence-nav surface in the app (no wrap). The
+ * chevrons + "N of M" counter only render when there is more than one image.
  *
  * Rendered as a `fixed inset-0` layer above any modal (z-60 > the modal's
  * z-50), so it works both inside MarkdownArtifactModal and standalone from the
  * NodeDetailPanel thumbnails.
  */
-export default function ImageLightbox({ src, alt = "", onClose }: Props) {
+export default function ImageLightbox({ images, index, alt = "", onClose }: Props) {
+  const [current, setCurrent] = useState(index);
+  // Re-seed if a caller reopens at a different index WITHOUT unmounting
+  // ("adjust state during render" — no effect, no flash). Today every caller
+  // conditionally renders the lightbox so it remounts on each open, but this
+  // keeps us correct if a caller ever swaps images while mounted.
+  const [seed, setSeed] = useState(index);
+  if (index !== seed) {
+    setSeed(index);
+    setCurrent(index);
+  }
+
+  const hasPrev = current > 0;
+  const hasNext = current < images.length - 1;
+  const goPrev = useCallback(() => setCurrent((c) => Math.max(0, c - 1)), []);
+  const goNext = useCallback(
+    () => setCurrent((c) => Math.min(images.length - 1, c + 1)),
+    [images.length],
+  );
+
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
       if (e.key === "Escape") {
         // Stop the event from also reaching a parent modal's Escape handler.
         e.stopPropagation();
         onClose();
+      } else if (e.key === "ArrowLeft") {
+        // stopPropagation is hygiene; preventDefault stops the background page
+        // from scrolling on the arrow key.
+        e.stopPropagation();
+        e.preventDefault();
+        goPrev();
+      } else if (e.key === "ArrowRight") {
+        e.stopPropagation();
+        e.preventDefault();
+        goNext();
       }
     },
-    [onClose],
+    [onClose, goPrev, goNext],
   );
 
   useEffect(() => {
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [handleKeyDown]);
+
+  const src = images[current] ?? images[0];
 
   return (
     <div
@@ -72,6 +111,45 @@ export default function ImageLightbox({ src, alt = "", onClose }: Props) {
         }}
         data-testid="lightbox-image"
       />
+      {images.length > 1 && (
+        <>
+          <button
+            type="button"
+            onClick={(e) => {
+              // Mandatory: the overlay and the image both close on click, so an
+              // un-stopped chevron click would close the viewer.
+              e.stopPropagation();
+              goPrev();
+            }}
+            disabled={!hasPrev}
+            className="absolute left-4 top-1/2 -translate-y-1/2 rounded p-1.5 text-fg-3 hover:bg-bg-3 hover:text-fg disabled:opacity-30"
+            aria-label="Previous image"
+            data-testid="lightbox-prev"
+          >
+            <ChevronLeft size={28} />
+          </button>
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              goNext();
+            }}
+            disabled={!hasNext}
+            className="absolute right-4 top-1/2 -translate-y-1/2 rounded p-1.5 text-fg-3 hover:bg-bg-3 hover:text-fg disabled:opacity-30"
+            aria-label="Next image"
+            data-testid="lightbox-next"
+          >
+            <ChevronRight size={28} />
+          </button>
+          <span
+            className="absolute bottom-4 left-1/2 -translate-x-1/2 font-mono text-fg-3"
+            style={{ fontSize: "11px" }}
+            data-testid="lightbox-counter"
+          >
+            {current + 1} of {images.length}
+          </span>
+        </>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/MarkdownArtifactModal.tsx
+++ b/frontend/src/components/MarkdownArtifactModal.tsx
@@ -89,8 +89,9 @@ export default function MarkdownArtifactModal({
   const isImage = portType === "image" || portType === "image_list";
   const [content, setContent] = useState<string | null>(null);
   const [loading, setLoading] = useState(!isImage);
-  // URL of the image currently shown fullscreen in the lightbox, or null.
-  const [lightboxSrc, setLightboxSrc] = useState<string | null>(null);
+  // The ordered image list + clicked index currently shown fullscreen in the
+  // lightbox, or null when it is closed (#312).
+  const [lightbox, setLightbox] = useState<{ images: string[]; index: number } | null>(null);
 
   useEffect(() => {
     if (isImage) return;
@@ -138,8 +139,10 @@ export default function MarkdownArtifactModal({
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
       // While the lightbox is open it owns Escape (close lightbox, not the
-      // modal) and we suppress file/iter navigation behind it.
-      if (lightboxSrc !== null) return;
+      // modal) and the arrow keys (page images, not files/iters) — this guard
+      // is the ONLY thing preventing double-navigation: both listeners are on
+      // `window`, where stopPropagation between them is a no-op.
+      if (lightbox !== null) return;
       if (e.key === "Escape") onClose();
       if (e.key === "ArrowLeft") {
         if (isRepeated && fileIndex > 0) setFileIndex(fileIndex - 1);
@@ -150,7 +153,7 @@ export default function MarkdownArtifactModal({
         else goNextIter();
       }
     },
-    [lightboxSrc, onClose, isRepeated, fileIndex, total, goPrevIter, goNextIter],
+    [lightbox, onClose, isRepeated, fileIndex, total, goPrevIter, goNextIter],
   );
 
   useEffect(() => {
@@ -263,7 +266,7 @@ export default function MarkdownArtifactModal({
               filesLoading={filesLoading}
               fileIndex={fileIndex}
               portType={portType}
-              onZoom={setLightboxSrc}
+              onZoom={(images, index) => setLightbox({ images, index })}
             />
           ) : (
             <>
@@ -301,7 +304,11 @@ export default function MarkdownArtifactModal({
                             alt={alt ?? ""}
                             className="cursor-zoom-in rounded transition-opacity hover:opacity-90"
                             onClick={() => {
-                              if (url) setLightboxSrc(url);
+                              // A markdown-embedded <img> is rendered in
+                              // isolation by react-markdown — there is no
+                              // collected list to page through, so it is an
+                              // honest single-image set.
+                              if (url) setLightbox({ images: [url], index: 0 });
                             }}
                           />
                         );
@@ -347,10 +354,11 @@ export default function MarkdownArtifactModal({
         </div>
       </div>
 
-      {lightboxSrc && (
+      {lightbox && (
         <ImageLightbox
-          src={lightboxSrc}
-          onClose={() => setLightboxSrc(null)}
+          images={lightbox.images}
+          index={lightbox.index}
+          onClose={() => setLightbox(null)}
         />
       )}
     </div>
@@ -381,7 +389,7 @@ function ImageBody({
   filesLoading: boolean;
   fileIndex: number;
   portType: PortType;
-  onZoom: (src: string) => void;
+  onZoom: (images: string[], index: number) => void;
 }) {
   const existingFiles = files.filter((f) => f.exists);
 
@@ -410,7 +418,12 @@ function ImageBody({
               src={artifactUrl(runId, f.path)}
               alt={f.path.split("/").pop() ?? ""}
               className="max-h-[60vh] w-full cursor-zoom-in rounded border border-line object-contain transition-opacity hover:opacity-90"
-              onClick={() => onZoom(artifactUrl(runId, f.path))}
+              onClick={() =>
+                onZoom(
+                  existingFiles.map((ef) => artifactUrl(runId, ef.path)),
+                  i,
+                )
+              }
               data-testid={`gallery-image-${i}`}
             />
             <span
@@ -425,7 +438,8 @@ function ImageBody({
     );
   }
 
-  const current = existingFiles[fileIndex] ?? existingFiles[0];
+  const currentIdx = existingFiles[fileIndex] ? fileIndex : 0;
+  const current = existingFiles[currentIdx];
   if (!current) return null;
 
   return (
@@ -434,7 +448,12 @@ function ImageBody({
         src={artifactUrl(runId, current.path)}
         alt={current.path.split("/").pop() ?? ""}
         className="max-h-[60vh] max-w-full cursor-zoom-in rounded border border-line object-contain transition-opacity hover:opacity-90"
-        onClick={() => onZoom(artifactUrl(runId, current.path))}
+        onClick={() =>
+          onZoom(
+            existingFiles.map((f) => artifactUrl(runId, f.path)),
+            currentIdx,
+          )
+        }
         data-testid="image-viewer-img"
       />
       <span className="font-mono text-fg-4" style={{ fontSize: "10px" }}>

--- a/frontend/src/components/NodeDetailPanel.tsx
+++ b/frontend/src/components/NodeDetailPanel.tsx
@@ -851,8 +851,9 @@ function PortRow({
   const firstFile = port.files[0];
   const anyExists = port.files.some((f) => f.exists);
   const portType = port.port_type ?? "markdown";
-  // URL of the thumbnail currently shown fullscreen in the lightbox, or null.
-  const [lightboxSrc, setLightboxSrc] = useState<string | null>(null);
+  // The ordered image list + clicked index currently shown fullscreen in the
+  // lightbox, or null when it is closed (#312).
+  const [lightbox, setLightbox] = useState<{ images: string[]; index: number } | null>(null);
   const isImage = portType === "image" || portType === "image_list";
 
   let dotClass = "bg-fg-5";
@@ -952,9 +953,17 @@ function PortRow({
               className="h-12 w-12 cursor-zoom-in rounded border border-line object-cover transition-opacity hover:opacity-80"
               onClick={(e) => {
                 // Open this thumbnail fullscreen instead of bubbling up to the
-                // row button (which opens the artifact modal).
+                // row button (which opens the artifact modal). Snapshot the
+                // FULL imageFiles list (not the .slice(0,4) shown as
+                // thumbnails) so arrows reach images behind the +N chip; `i`
+                // is a valid index into the full array since the slice starts
+                // at 0. A snapshot at click time is immune to poll churn
+                // (NodeDetailPanel re-polls IO ~every 1s).
                 e.stopPropagation();
-                setLightboxSrc(artifactUrl(runId, f.path));
+                setLightbox({
+                  images: imageFiles.map((im) => artifactUrl(runId, im.path)),
+                  index: i,
+                });
               }}
               data-testid={`thumbnail-${i}`}
             />
@@ -988,8 +997,12 @@ function PortRow({
     </>
   );
 
-  const lightbox = lightboxSrc && (
-    <ImageLightbox src={lightboxSrc} onClose={() => setLightboxSrc(null)} />
+  const lightboxEl = lightbox && (
+    <ImageLightbox
+      images={lightbox.images}
+      index={lightbox.index}
+      onClose={() => setLightbox(null)}
+    />
   );
 
   if (anyExists) {
@@ -1003,7 +1016,7 @@ function PortRow({
         >
           {children}
         </button>
-        {lightbox}
+        {lightboxEl}
       </>
     );
   }
@@ -1014,7 +1027,7 @@ function PortRow({
       style={gridStyle}
     >
       {children}
-      {lightbox}
+      {lightboxEl}
     </div>
   );
 }

--- a/frontend/src/components/StartInspector.tsx
+++ b/frontend/src/components/StartInspector.tsx
@@ -14,8 +14,9 @@ interface Props {
 export default function StartInspector({ startNode, runId, nodeId }: Props) {
   const [inputText, setInputText] = useState<string | null>(null);
   const [modalOpen, setModalOpen] = useState(false);
-  // URL of the input image currently shown fullscreen, or null (issue #145).
-  const [lightboxSrc, setLightboxSrc] = useState<string | null>(null);
+  // The ordered image list + clicked index currently shown fullscreen, or null
+  // when the lightbox is closed (issue #145, arrow-nav #312).
+  const [lightbox, setLightbox] = useState<{ images: string[]; index: number } | null>(null);
 
   // Images uploaded with the run are stored in `_input/` alongside the prompt.
   const inputImages = startNode.input_images ?? [];
@@ -92,13 +93,20 @@ export default function StartInspector({ startNode, runId, nodeId }: Props) {
               Input images
             </div>
             <div className="flex flex-wrap gap-2">
-              {inputImages.map((name) => {
+              {inputImages.map((name, i) => {
                 const src = artifactUrl(runId, `_input/${name}`);
                 return (
                   <button
                     key={name}
                     type="button"
-                    onClick={() => setLightboxSrc(src)}
+                    onClick={() =>
+                      setLightbox({
+                        images: inputImages.map((n) =>
+                          artifactUrl(runId, `_input/${n}`),
+                        ),
+                        index: i,
+                      })
+                    }
                     title={name}
                     className="overflow-hidden rounded border border-line bg-bg-0 transition-opacity hover:opacity-80"
                   >
@@ -135,8 +143,12 @@ export default function StartInspector({ startNode, runId, nodeId }: Props) {
         />
       )}
 
-      {lightboxSrc && (
-        <ImageLightbox src={lightboxSrc} onClose={() => setLightboxSrc(null)} />
+      {lightbox && (
+        <ImageLightbox
+          images={lightbox.images}
+          index={lightbox.index}
+          onClose={() => setLightbox(null)}
+        />
       )}
     </aside>
   );


### PR DESCRIPTION
## What

Adds ArrowLeft/ArrowRight navigation between images in the fullscreen image viewer (`ImageLightbox`), with a "N of M" counter and prev/next chevrons that clamp (no wrap) at both ends. Escape closes only the lightbox (the underlying artifact modal's own keydown handler is guarded so there's no double-dismiss). Both entry points — the artifact-modal gallery and the `NodeDetailPanel` thumbnail — feed the lightbox the full image list.

Closes #312.

## Scope

Frontend-only (5 files) + version bump to **v0.1.61**.

## Validation (agentic tester — Pass)

- `npm run typecheck`, `npm run lint`, `npm run build` — all pass (only pre-existing chunk-size warnings).
- Unit suite **1024/1024** pass (`ImageLightbox.test.tsx` 15/15).
- Real-browser visual ID (Chrome MCP) against a live 2-image output: ArrowLeft/ArrowRight page the lightbox, counter tracks, chevrons disable at the ends, no wrap, Escape closes only the lightbox (modal stays), both entry points wired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)