### PR TITLE
fix(install): install.sh exits 1 & leaks tmpdir on successful install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -42,7 +42,11 @@ download_and_verify() {
   local archive="pdo-${VERSION}-${PLATFORM}.tar.gz"
   local checksum_file="pdo-${VERSION}-SHA256SUMS.txt"
 
-  local tmpdir
+  # Deliberately NOT `local`: the EXIT trap below fires at script exit, long
+  # after this function has returned. A `local tmpdir` is out of scope by then,
+  # so under `set -u` the trap's `$tmpdir` is an unbound variable — which errors,
+  # skips the cleanup (leaking the temp dir), and makes the whole script exit 1
+  # even on a successful install. A script-global keeps it visible to the trap.
   tmpdir="$(mktemp -d)"
   trap 'rm -rf "$tmpdir"' EXIT
 


### PR DESCRIPTION
The release `install.sh` runs under `set -euo pipefail` with an `EXIT` trap `rm -rf "$tmpdir"`, but `$tmpdir` is declared `local` inside `download_and_verify` — it's out of scope by the time the trap fires at script exit. Under `set -u` that's an **unbound variable**, so:

- the temp-dir cleanup is skipped (leaks a `/tmp/tmp.*` dir every run), and
- the script **exits 1 even on a fully successful install** → `curl … | bash` looks like it failed and breaks `&&` chaining.

Fix: make `tmpdir` a script-global (drop `local`) so the trap can see it. Verified locally and against the live v0.1.63 release asset: exit **0**, temp dir removed, `pdo 0.1.63` installed. Already hot-fixed the v0.1.63 release's attached `install.sh`; this lands the same fix in the repo for future releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)