### PR TITLE
feat(#320): clicking a trigger opens its pipeline in the canvas — v0.1.63

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1952,7 +1952,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "0.1.62"
+version = "0.1.63"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "0.1.62"
+version = "0.1.63"
 license = "MIT"
 
 [workspace.dependencies]

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import { useLibraryPipelines } from "./hooks/useLibraryPipelines";
 import { fetchRuns, fetchRun, fetchTriggers, fetchSessions } from "./api";
 import { pickLatestLiveNode } from "./lib/pickLatestLiveNode";
 import { rightPaneOwner } from "./lib/rightPaneOwner";
+import { shouldClearTriggerOnCanvasFocus } from "./lib/triggerCanvasReconcile";
 import type { RunListEntry, RunState, NodeState, Trigger, DaemonStatus } from "./types";
 import { isLiveRun } from "./types";
 import SessionCounter from "./components/SessionCounter";
@@ -139,6 +140,14 @@ export default function App() {
   const { sessions, refresh: refreshSessions } = useSessions();
   const { triggers, refresh: refreshTriggers } = useTriggers();
   const [selectedTriggerId, setSelectedTriggerId] = useState<string | null>(null);
+  // #320: the tab id (=== pipeline_id) that selecting a Trigger opened in the
+  // canvas. The reconciliation below reads it to tell the Trigger's OWN
+  // openPipeline focus change apart from a genuine user canvas interaction.
+  // State (not a ref) because the reconciliation reads it *during render*, and
+  // it's always set alongside `selectedTriggerId` (which re-renders anyway), so
+  // there's no extra render — while a ref read during render is a React
+  // anti-pattern the compiler lint (`react-hooks/refs`) rejects.
+  const [triggerOpenedTabId, setTriggerOpenedTabId] = useState<string | null>(null);
   const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
   const { run: selectedRun, select: selectRun, refresh: refreshRun } = useSelectedRun();
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
@@ -155,6 +164,7 @@ export default function App() {
   const loadPipelines = useEditStore((s) => s.loadPipelines);
   const openRunPipeline = useEditStore((s) => s.openRunPipeline);
   const closeRunPipeline = useEditStore((s) => s.closeRunPipeline);
+  const openPipeline = useEditStore((s) => s.openPipeline);
   const selection = useEditStore((s) => s.selection);
   const setSelection = useEditStore((s) => s.setSelection);
   const openTabs = useEditStore((s) => s.openTabs);
@@ -215,8 +225,25 @@ export default function App() {
     lastCanvasFocus.selection !== selection ||
     lastCanvasFocus.tabId !== editActiveTabId
   ) {
+    // setLastCanvasFocus MUST stay unconditional — gating it would make this
+    // block re-fire every render (infinite loop).
     setLastCanvasFocus({ selection, tabId: editActiveTabId });
-    if (selectedTriggerId !== null) setSelectedTriggerId(null);
+    // #320: skip clearing the Trigger when this focus change is the Trigger's
+    // OWN openPipeline landing — i.e. the tab it opened is now active with
+    // nothing selected. A genuine canvas reclaim differs and STILL clears
+    // (preserving #247): a node/edge/region select makes selection.kind !==
+    // "none", and switching to another tab makes editActiveTabId !==
+    // triggerOpenedTabId.
+    if (
+      shouldClearTriggerOnCanvasFocus({
+        selectedTriggerId,
+        editActiveTabId,
+        selectionKind: selection.kind,
+        triggerOpenedTabId,
+      })
+    ) {
+      setSelectedTriggerId(null);
+    }
   }
 
   const selectedTrigger =
@@ -246,8 +273,18 @@ export default function App() {
       setSelectedRunId(null);
       setSelectedNodeId(null);
       selectRun(null);
+      // #320: also open the pipeline this Trigger would launch, in the canvas.
+      // Resolve scope the way the daemon resolves it at FIRE time (library-first,
+      // repo/user fallback): if the id is in the library store, open with scope
+      // "library"; otherwise let the daemon resolve a repo/user file (undefined).
+      const trig = triggers.find((t) => t.id === triggerId);
+      if (trig) {
+        const inLibrary = libraryPipelines.some((p) => p.id === trig.pipeline_id);
+        setTriggerOpenedTabId(trig.pipeline_id);
+        openPipeline(trig.pipeline_id, inLibrary ? "library" : undefined);
+      }
     },
-    [selectRun],
+    [selectRun, triggers, libraryPipelines, openPipeline],
   );
 
   const handleCloseNewRunModal = useCallback(() => {

--- a/frontend/src/lib/rightPaneOwner.test.ts
+++ b/frontend/src/lib/rightPaneOwner.test.ts
@@ -30,6 +30,15 @@ describe("rightPaneOwner", () => {
     ).toBe("trigger");
   });
 
+  // #320: clicking a trigger opens its pipeline in the canvas (hasEditTab
+  // becomes true) while the trigger detail must stay on the right. That is
+  // exactly `triggerSelected && hasEditTab → "trigger"` — pin it against drift.
+  it("keeps the trigger detail while its pipeline owns the canvas (#320)", () => {
+    expect(
+      rightPaneOwner({ triggerSelected: true, infoPanelOpen: false, hasEditTab: true }),
+    ).toBe("trigger");
+  });
+
   it("lets the info overlay win over a selected trigger", () => {
     expect(
       rightPaneOwner({ triggerSelected: true, infoPanelOpen: true, hasEditTab: false }),

--- a/frontend/src/lib/triggerCanvasReconcile.test.ts
+++ b/frontend/src/lib/triggerCanvasReconcile.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { shouldClearTriggerOnCanvasFocus } from "./triggerCanvasReconcile";
+import type { TriggerCanvasFocusInputs } from "./triggerCanvasReconcile";
+
+// A Trigger is selected and it opened pipeline "pipe-a" in the canvas — the
+// baseline #320 state. Individual tests override the fields that matter.
+const base: TriggerCanvasFocusInputs = {
+  selectedTriggerId: "trig-1",
+  editActiveTabId: "pipe-a",
+  selectionKind: "none",
+  triggerOpenedTabId: "pipe-a",
+};
+
+describe("shouldClearTriggerOnCanvasFocus (#320)", () => {
+  it("keeps the Trigger on its own openPipeline landing (fresh tab)", () => {
+    // editActiveTabId === triggerOpenedTabId, selection none → the Trigger's
+    // own open, not a reclaim.
+    expect(shouldClearTriggerOnCanvasFocus(base)).toBe(false);
+  });
+
+  it("keeps the Trigger when its pipeline was already the active tab", () => {
+    // The already-open branch of openPipeline resets selection to none without
+    // changing activeTabId — the ref still equals the active tab.
+    expect(
+      shouldClearTriggerOnCanvasFocus({ ...base, selectionKind: "none" }),
+    ).toBe(false);
+  });
+
+  it("clears on a node selection (a genuine #247 reclaim)", () => {
+    expect(
+      shouldClearTriggerOnCanvasFocus({ ...base, selectionKind: "node" }),
+    ).toBe(true);
+  });
+
+  it("clears on an edge selection", () => {
+    expect(
+      shouldClearTriggerOnCanvasFocus({ ...base, selectionKind: "edge" }),
+    ).toBe(true);
+  });
+
+  it("clears on a region selection", () => {
+    expect(
+      shouldClearTriggerOnCanvasFocus({ ...base, selectionKind: "region" }),
+    ).toBe(true);
+  });
+
+  it("clears when switching to / opening a different tab (tabId !== ref)", () => {
+    expect(
+      shouldClearTriggerOnCanvasFocus({ ...base, editActiveTabId: "pipe-b" }),
+    ).toBe(true);
+  });
+
+  it("clears when a focus change lands with no trigger-opened tab recorded", () => {
+    // No Trigger-opened tab (ref null) but a Trigger is somehow selected and the
+    // canvas focus changed → treat as a reclaim and clear.
+    expect(
+      shouldClearTriggerOnCanvasFocus({ ...base, triggerOpenedTabId: null }),
+    ).toBe(true);
+  });
+
+  it("is a no-op when no Trigger is selected (never clears what isn't there)", () => {
+    expect(
+      shouldClearTriggerOnCanvasFocus({ ...base, selectedTriggerId: null }),
+    ).toBe(false);
+    // Even on an obvious reclaim shape, a null selection stays a no-op.
+    expect(
+      shouldClearTriggerOnCanvasFocus({
+        selectedTriggerId: null,
+        editActiveTabId: "pipe-b",
+        selectionKind: "node",
+        triggerOpenedTabId: "pipe-a",
+      }),
+    ).toBe(false);
+  });
+
+  it("still keeps the Trigger on a deselect-to-empty on its own tab (not a reclaim)", () => {
+    // Explicitly pinning the #320 edge case: blank-canvas click leaves kind
+    // "none" on the Trigger's own tab — keep.
+    expect(
+      shouldClearTriggerOnCanvasFocus({
+        selectedTriggerId: "trig-1",
+        editActiveTabId: "pipe-a",
+        selectionKind: "none",
+        triggerOpenedTabId: "pipe-a",
+      }),
+    ).toBe(false);
+  });
+});

--- a/frontend/src/lib/triggerCanvasReconcile.ts
+++ b/frontend/src/lib/triggerCanvasReconcile.ts
@@ -1,0 +1,45 @@
+export interface TriggerCanvasFocusInputs {
+  /** The currently-selected Trigger id, or null when none is selected. */
+  selectedTriggerId: string | null;
+  /** The active edit-tab id (=== pipeline id for a Trigger-opened tab). */
+  editActiveTabId: string | null;
+  /** The kind of the current canvas selection (`selection.kind`). */
+  selectionKind: string;
+  /** The tab id that selecting a Trigger opened, or null (the ref value). */
+  triggerOpenedTabId: string | null;
+}
+
+/**
+ * Decide whether a canvas-focus change should clear the selected Trigger (#320).
+ *
+ * Selecting a Trigger now *also* opens the pipeline it would launch in the
+ * canvas (`App.handleSelectTrigger`), which changes the canvas focus. PDO's
+ * #247 reconciliation clears the selected Trigger whenever the canvas focus
+ * changes — so, naively, the Trigger's own `openPipeline` would immediately
+ * close the Trigger detail it just opened.
+ *
+ * This function is the guard that tells those two apart:
+ *  - **Keep** (return `false`) when the focus change is the Trigger's OWN
+ *    open — the tab it opened is now active (`editActiveTabId ===
+ *    triggerOpenedTabId`) with nothing selected (`selectionKind === "none"`).
+ *    This also covers re-selecting a Trigger whose pipeline is already the
+ *    active tab: `openPipeline` resets `selection` to `none` without changing
+ *    the active tab, so both clauses still hold.
+ *  - **Clear** (return `true`) on a genuine #247 reclaim: a node/edge/region
+ *    selection makes `selectionKind !== "none"`, and switching to / opening a
+ *    different tab makes `editActiveTabId !== triggerOpenedTabId`. Deselecting
+ *    to empty on the Trigger's own tab is *not* a reclaim — it keeps the
+ *    Trigger, matching #320 intent.
+ *  - **No-op** (return `false`) when no Trigger is selected — there is nothing
+ *    to clear, so a stale `triggerOpenedTabId` ref is inert.
+ */
+export function shouldClearTriggerOnCanvasFocus(
+  input: TriggerCanvasFocusInputs,
+): boolean {
+  if (input.selectedTriggerId === null) return false;
+  const isTriggerOwnOpen =
+    input.triggerOpenedTabId !== null &&
+    input.editActiveTabId === input.triggerOpenedTabId &&
+    input.selectionKind === "none";
+  return !isTriggerOwnOpen;
+}

--- a/frontend/src/stores/editStore.test.ts
+++ b/frontend/src/stores/editStore.test.ts
@@ -2133,3 +2133,52 @@ describe("undo/redo history (ADR-0014 / #226)", () => {
     });
   });
 });
+
+// openPipeline is the action #320 wires to a Trigger click: it opens the
+// trigger's pipeline in the canvas. These pin the three behaviors App relies on
+// — fresh append + activate + selection reset, re-activate without duplicating,
+// and scope forwarding (library-first, matching the daemon's fire-time resolve).
+describe("openPipeline (#320 / #216 canvas-open)", () => {
+  it("appends a tab, activates it, and resets selection to none on a fresh open", async () => {
+    useEditStore.setState({
+      openTabs: [],
+      activeTabId: null,
+      selection: { kind: "node", id: "some-node" },
+    });
+
+    await useEditStore.getState().openPipeline("pipe-a");
+
+    const state = useEditStore.getState();
+    expect(state.openTabs.map((t) => t.id)).toEqual(["pipe-a"]);
+    expect(state.activeTabId).toBe("pipe-a");
+    expect(state.selection).toEqual({ kind: "none", id: null });
+  });
+
+  it("re-activates an already-open tab without duplicating or re-fetching", async () => {
+    await useEditStore.getState().openPipeline("pipe-a");
+    // Simulate the user navigating away (another tab active, something selected).
+    useEditStore.setState({
+      activeTabId: null,
+      selection: { kind: "node", id: "n1" },
+    });
+
+    await useEditStore.getState().openPipeline("pipe-a");
+
+    const state = useEditStore.getState();
+    expect(state.openTabs.filter((t) => t.id === "pipe-a")).toHaveLength(1);
+    expect(state.activeTabId).toBe("pipe-a");
+    expect(state.selection).toEqual({ kind: "none", id: null });
+    // The already-open branch short-circuits before re-fetching.
+    expect(mockFetchPipeline).toHaveBeenCalledTimes(1);
+  });
+
+  it("forwards the scope arg to fetchPipeline for a library-scoped open", async () => {
+    await useEditStore.getState().openPipeline("pipe-lib", "library");
+    expect(mockFetchPipeline).toHaveBeenCalledWith("pipe-lib", "library");
+  });
+
+  it("passes scope undefined when omitted (repo/user resolution)", async () => {
+    await useEditStore.getState().openPipeline("pipe-repo");
+    expect(mockFetchPipeline).toHaveBeenCalledWith("pipe-repo", undefined);
+  });
+});


### PR DESCRIPTION
## What

Clicking a trigger row now opens, in the centre canvas, the pipeline that trigger would launch — while the trigger's detail panel stays on the right.

Implements the user journey from #320: selecting a trigger surfaces its target pipeline in the canvas, with the `TriggerDetailPanel` intact. A new pure `shouldClearTriggerOnCanvasFocus` guard preserves the #247 pane-ownership behaviour: a genuine canvas node-click still reclaims the right pane for the Node Inspector.

## Changes (frontend-only)

- `frontend/src/App.tsx` — on trigger select, `openPipeline(trigger.pipeline_id)`; ref-guarded so the trigger's own landing isn't self-closed by #247 reconciliation.
- `frontend/src/lib/triggerCanvasReconcile.ts` (+ test) — pure `shouldClearTriggerOnCanvasFocus` helper.
- `frontend/src/stores/editStore.test.ts` — `openPipeline` coverage.
- `frontend/src/lib/rightPaneOwner.test.ts` — #320 pane-ownership pin.

## Validation

- `npm run typecheck`, `npm run build`, `eslint`: clean.
- `npm run test`: 1038 passed / 80 files (incl. new `triggerCanvasReconcile` (9), `editStore.openPipeline` (4), `rightPaneOwner` #320 pin).
- Agentic visual test (headless Chromium against the running daemon, read-only): clicking **PDO Triage** opened `auto-triage` in the canvas with the detail panel intact; clicking a canvas node then reclaimed the right pane (#247 preserved). No console errors.

Version bumped to v0.1.63.

Closes #320

🤖 Generated with [Claude Code](https://claude.com/claude-code)
