### PR TITLE
feat(#324): node model picker uses the standard dropdown — v0.1.68

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "0.1.67"
+version = "0.1.68"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "0.1.67"
+version = "0.1.68"
 license = "MIT"
 
 [workspace.dependencies]

--- a/frontend/src/components/MergeInspector.test.tsx
+++ b/frontend/src/components/MergeInspector.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, it, expect, beforeEach } from "vitest";
 import MergeInspector from "./MergeInspector";
 import { useEditStore } from "../stores/editStore";
@@ -100,19 +101,20 @@ describe("MergeInspector", () => {
     expect(screen.getByText(/Merge nodes wait for all upstream/)).toBeInTheDocument();
   });
 
-  // #296: a merge node spawns an agent, so its model is settable here too.
-  it("writes the typed model onto the merge node", () => {
+  // #296/#324: a merge node spawns an agent, so its model is settable here too.
+  it("writes the picked model onto the merge node", async () => {
+    const user = userEvent.setup();
     setStoreState(makeMergeNode());
     render(<MergeInspector />);
-    const input = screen.getByTestId("merge-model-input");
-    fireEvent.change(input, { target: { value: "opus" } });
+    await user.click(screen.getByTestId("merge-model-trigger"));
+    await user.click(await screen.findByTestId("merge-model-option-opus"));
     const node = useEditStore.getState().openTabs[0].pipeline.nodes.find((n) => n.id === "mg1");
     expect(node?.model).toBe("opus");
   });
 
-  it("renders a seeded model as the input value", () => {
+  it("renders a seeded model on the trigger", () => {
     setStoreState(makeMergeNode({ model: "sonnet" }));
     render(<MergeInspector />);
-    expect((screen.getByTestId("merge-model-input") as HTMLInputElement).value).toBe("sonnet");
+    expect(screen.getByTestId("merge-model-trigger")).toHaveTextContent("sonnet");
   });
 });

--- a/frontend/src/components/MergeInspector.tsx
+++ b/frontend/src/components/MergeInspector.tsx
@@ -1,5 +1,6 @@
 import { useEditStore } from "../stores/editStore";
 import { SectionHead, Field } from "./InspectorPrimitives";
+import ModelPicker from "./ModelPicker";
 
 export default function MergeInspector() {
   const openTabs = useEditStore((s) => s.openTabs);
@@ -34,23 +35,14 @@ export default function MergeInspector() {
             className="w-full rounded border border-line-strong bg-bg-3 px-2 py-1 text-fg outline-none focus:border-acc"
           />
         </Field>
-        {/* Model (#296): a merge node spawns an agent, so its model is settable
-            here too. Free-text pass-through to `claude --model <x>`; empty ⇒
-            null ⇒ never serialized ⇒ account default. */}
+        {/* Model (#296/#324): a merge node spawns an agent, so its model is
+            settable here too. Dropdown + Custom… escape hatch (see ModelPicker). */}
         <Field label="Model">
-          <input
-            list="pdo-model-aliases"
-            data-testid="merge-model-input"
-            placeholder="default model"
-            value={node.model ?? ""}
-            onChange={(e) => updateNode(node.id, { model: e.target.value || null })}
-            className="w-full rounded border border-line-strong bg-bg-3 px-2 py-1 text-fg outline-none focus:border-acc"
+          <ModelPicker
+            value={node.model ?? null}
+            onChange={(v) => updateNode(node.id, { model: v })}
+            testid="merge-model"
           />
-          <datalist id="pdo-model-aliases">
-            {["sonnet", "opus", "haiku", "opusplan", "fable"].map((m) => (
-              <option key={m} value={m} />
-            ))}
-          </datalist>
         </Field>
 
         <SectionHead title="Ports" />

--- a/frontend/src/components/ModelPicker.test.tsx
+++ b/frontend/src/components/ModelPicker.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import ModelPicker from "./ModelPicker";
+
+describe("ModelPicker (#324)", () => {
+  it("shows the placeholder when value is null", () => {
+    render(<ModelPicker value={null} onChange={() => {}} testid="node-model" />);
+    expect(screen.getByTestId("node-model-trigger")).toHaveTextContent("default model");
+  });
+
+  it("shows an alias value on the trigger", () => {
+    render(<ModelPicker value="opus" onChange={() => {}} testid="node-model" />);
+    expect(screen.getByTestId("node-model-trigger")).toHaveTextContent("opus");
+  });
+
+  it("shows an arbitrary full id on the trigger (never cleared)", () => {
+    render(<ModelPicker value="claude-fable-5" onChange={() => {}} testid="node-model" />);
+    expect(screen.getByTestId("node-model-trigger")).toHaveTextContent("claude-fable-5");
+  });
+
+  it("opens a menu with Default, the five aliases and Custom…", async () => {
+    const user = userEvent.setup();
+    render(<ModelPicker value={null} onChange={() => {}} testid="node-model" />);
+
+    await user.click(screen.getByTestId("node-model-trigger"));
+
+    expect(await screen.findByTestId("node-model-option-default")).toBeInTheDocument();
+    for (const m of ["sonnet", "opus", "haiku", "opusplan", "fable"]) {
+      expect(screen.getByTestId(`node-model-option-${m}`)).toBeInTheDocument();
+    }
+    expect(screen.getByTestId("node-model-option-custom")).toBeInTheDocument();
+  });
+
+  it("clicking an alias calls onChange with the alias", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<ModelPicker value={null} onChange={onChange} testid="node-model" />);
+
+    await user.click(screen.getByTestId("node-model-trigger"));
+    await user.click(await screen.findByTestId("node-model-option-opus"));
+
+    expect(onChange).toHaveBeenCalledWith("opus");
+  });
+
+  it("clicking Default calls onChange(null)", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<ModelPicker value="opus" onChange={onChange} testid="node-model" />);
+
+    await user.click(screen.getByTestId("node-model-trigger"));
+    await user.click(await screen.findByTestId("node-model-option-default"));
+
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+
+  it("Custom… opens a pre-filled input; Enter commits the full id", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<ModelPicker value="opus" onChange={onChange} testid="node-model" />);
+
+    await user.click(screen.getByTestId("node-model-trigger"));
+    await user.click(await screen.findByTestId("node-model-option-custom"));
+
+    const input = (await screen.findByTestId("node-model-input")) as HTMLInputElement;
+    expect(input.value).toBe("opus");
+
+    await user.clear(input);
+    await user.type(input, "claude-fable-5{Enter}");
+
+    expect(onChange).toHaveBeenCalledWith("claude-fable-5");
+    // Back to trigger mode.
+    expect(screen.queryByTestId("node-model-input")).toBeNull();
+    expect(screen.getByTestId("node-model-trigger")).toBeInTheDocument();
+  });
+
+  it("Custom… with an empty commit calls onChange(null)", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<ModelPicker value="opus" onChange={onChange} testid="node-model" />);
+
+    await user.click(screen.getByTestId("node-model-trigger"));
+    await user.click(await screen.findByTestId("node-model-option-custom"));
+
+    const input = (await screen.findByTestId("node-model-input")) as HTMLInputElement;
+    await user.clear(input);
+    await user.keyboard("{Enter}");
+
+    expect(onChange).toHaveBeenCalledWith(null);
+    expect(screen.queryByTestId("node-model-input")).toBeNull();
+  });
+});

--- a/frontend/src/components/ModelPicker.tsx
+++ b/frontend/src/components/ModelPicker.tsx
@@ -1,0 +1,107 @@
+import { useState } from "react";
+import { ChevronDown } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+} from "./ui/dropdown-menu";
+
+/* Model (#296/#324): free-text pass-through to `claude --model <x>`. The menu
+   offers the common aliases for convenience, but any full id is accepted via
+   the Custom… escape hatch — no validation, no closed enum (CONTEXT.md: an
+   enum would perish; an invalid id must fail loud in `claude` itself).
+   Empty / Default ⇒ null ⇒ never serialized ⇒ account default. */
+
+const ALIASES = ["sonnet", "opus", "haiku", "opusplan", "fable"];
+
+const ITEM_CLASSES =
+  "flex cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-fg-2 transition-colors hover:bg-bg-4";
+
+export default function ModelPicker({
+  value,
+  onChange,
+  testid,
+}: {
+  value: string | null;
+  onChange: (v: string | null) => void;
+  testid: string; // "node-model" | "merge-model"
+}) {
+  // Custom mode is a transient edit state: the closed trigger always displays
+  // the current value (alias or arbitrary full id — a hand-authored YAML
+  // `model:` must render, never be cleared).
+  const [editing, setEditing] = useState(false);
+
+  if (editing) {
+    return (
+      <input
+        autoFocus
+        defaultValue={value ?? ""}
+        data-testid={`${testid}-input`}
+        placeholder="default model"
+        className="w-full rounded border border-line-strong bg-bg-3 px-2 py-1 text-fg outline-none focus:border-acc"
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            onChange(e.currentTarget.value.trim() || null);
+            setEditing(false);
+          } else if (e.key === "Escape") {
+            setEditing(false);
+          }
+        }}
+        onBlur={(e) => {
+          onChange(e.currentTarget.value.trim() || null);
+          setEditing(false);
+        }}
+      />
+    );
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        data-testid={`${testid}-trigger`}
+        className="flex w-full cursor-pointer items-center justify-between rounded border border-line-strong bg-bg-3 px-2 py-1 text-left text-fg outline-none transition-colors hover:bg-bg-4 focus:border-acc data-[popup-open]:border-acc"
+      >
+        <span className={value ? "font-mono" : "text-fg-4"}>
+          {value ?? "default model"}
+        </span>
+        <ChevronDown size={10} className="shrink-0 text-fg-4" />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        className="min-w-[180px] rounded-md border border-line-strong bg-bg-3 p-1 shadow-lg"
+        side="bottom"
+        align="start"
+      >
+        <DropdownMenuItem
+          data-testid={`${testid}-option-default`}
+          className={`${ITEM_CLASSES} ${value == null ? "bg-bg-4" : ""}`}
+          style={{ fontSize: "11px" }}
+          onClick={() => onChange(null)}
+        >
+          Default
+        </DropdownMenuItem>
+        {ALIASES.map((m) => (
+          <DropdownMenuItem
+            key={m}
+            data-testid={`${testid}-option-${m}`}
+            className={`${ITEM_CLASSES} font-mono ${value === m ? "bg-bg-4" : ""}`}
+            style={{ fontSize: "11px" }}
+            onClick={() => onChange(m)}
+          >
+            {m}
+          </DropdownMenuItem>
+        ))}
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          data-testid={`${testid}-option-custom`}
+          className={ITEM_CLASSES}
+          style={{ fontSize: "11px" }}
+          onClick={() => setEditing(true)}
+        >
+          Custom…
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/frontend/src/components/NodeInspector.test.tsx
+++ b/frontend/src/components/NodeInspector.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import NodeInspector from "./NodeInspector";
 import type { LibraryEntry } from "../api";
 import { saveToLibrary, deleteFromLibrary } from "../api";
@@ -175,7 +176,7 @@ describe("NodeInspector — script node surface (#248)", () => {
     expect(screen.getByTestId("script-body")).toBeInTheDocument();
     expect(screen.getByTestId("script-help")).toBeInTheDocument();
     // A script launches no agent — the model field must be absent.
-    expect(screen.queryByTestId("node-model-input")).toBeNull();
+    expect(screen.queryByTestId("node-model-trigger")).toBeNull();
   });
 
   it("shows a static script type label, not the doc-only/code-mutating toggle", () => {
@@ -223,37 +224,46 @@ describe("NodeInspector — pooled emergent inputs (#153)", () => {
   });
 });
 
-describe("NodeInspector — per-node model field (#296)", () => {
-  it("writes the typed model onto the node and marks the tab dirty", () => {
+describe("NodeInspector — per-node model field (#296/#324)", () => {
+  it("writes the picked model onto the node and marks the tab dirty", async () => {
+    const user = userEvent.setup();
     seedTabWithReviewer(false, "Review this code.");
     renderInspector({ libraryEntries: [], onLibraryChanged: () => {} });
 
-    const input = screen.getByTestId("node-model-input");
-    fireEvent.change(input, { target: { value: "opus" } });
+    await user.click(screen.getByTestId("node-model-trigger"));
+    await user.click(await screen.findByTestId("node-model-option-opus"));
 
     const tab = useEditStore.getState().openTabs[0];
     expect(tab.pipeline.nodes[0].model).toBe("opus");
     expect(tab.dirty).toBe(true);
   });
 
-  it("clears the model to null when emptied (stays unset, never serialized)", () => {
+  it("clears the model to null via Default (stays unset, never serialized)", async () => {
+    const user = userEvent.setup();
     seedTabWithReviewer(false, "Review this code.");
     // Seed a model so we can watch it clear.
     useEditStore.getState().updateNode("rv1", { model: "opus" });
     renderInspector({ libraryEntries: [], onLibraryChanged: () => {} });
 
-    const input = screen.getByTestId("node-model-input");
-    expect((input as HTMLInputElement).value).toBe("opus");
+    expect(screen.getByTestId("node-model-trigger")).toHaveTextContent("opus");
 
-    fireEvent.change(input, { target: { value: "" } });
+    await user.click(screen.getByTestId("node-model-trigger"));
+    await user.click(await screen.findByTestId("node-model-option-default"));
     expect(useEditStore.getState().openTabs[0].pipeline.nodes[0].model).toBeNull();
   });
 
-  it("renders a seeded model as the input value", () => {
+  it("renders a seeded alias on the trigger", () => {
     seedTabWithReviewer(false, "Review this code.");
     useEditStore.getState().updateNode("rv1", { model: "haiku" });
     renderInspector({ libraryEntries: [], onLibraryChanged: () => {} });
-    expect((screen.getByTestId("node-model-input") as HTMLInputElement).value).toBe("haiku");
+    expect(screen.getByTestId("node-model-trigger")).toHaveTextContent("haiku");
+  });
+
+  it("renders a seeded arbitrary full id on the trigger (free text survives)", () => {
+    seedTabWithReviewer(false, "Review this code.");
+    useEditStore.getState().updateNode("rv1", { model: "claude-opus-4-8" });
+    renderInspector({ libraryEntries: [], onLibraryChanged: () => {} });
+    expect(screen.getByTestId("node-model-trigger")).toHaveTextContent("claude-opus-4-8");
   });
 });
 

--- a/frontend/src/components/NodeInspector.tsx
+++ b/frontend/src/components/NodeInspector.tsx
@@ -5,6 +5,7 @@ import type { NodeDef, NodeType, PortDef } from "../types";
 import { SectionHead, Field } from "./InspectorPrimitives";
 import OutputPortCard from "./OutputPortCard";
 import PooledInputRow from "./PooledInputRow";
+import ModelPicker from "./ModelPicker";
 import { derivePooledInputs } from "../lib/derivePooledInputs";
 import { Tooltip } from "./ui/tooltip";
 import type { LibraryEntry } from "../api";
@@ -186,25 +187,16 @@ export default function NodeInspector({
           </div>
         </Tooltip>
 
-        {/* Model (#296): free-text pass-through to `claude --model <x>`; the
-            datalist offers the common aliases but any full id is accepted.
-            Empty ⇒ null ⇒ never serialized ⇒ account default. Hidden for a
-            script node (#248): it launches no agent, so it has no model. */}
+        {/* Model (#296/#324): dropdown + Custom… escape hatch (see ModelPicker).
+            Hidden for a script node (#248): it launches no agent, so it has no
+            model. */}
         {!isScript && (
           <Field label="Model">
-            <input
-              list="pdo-model-aliases"
-              data-testid="node-model-input"
-              placeholder="default model"
-              value={node.model ?? ""}
-              onChange={(e) => handleField("model", e.target.value || null)}
-              className="w-full rounded border border-line-strong bg-bg-3 px-2 py-1 text-fg outline-none focus:border-acc"
+            <ModelPicker
+              value={node.model ?? null}
+              onChange={(v) => handleField("model", v)}
+              testid="node-model"
             />
-            <datalist id="pdo-model-aliases">
-              {["sonnet", "opus", "haiku", "opusplan", "fable"].map((m) => (
-                <option key={m} value={m} />
-              ))}
-            </datalist>
           </Field>
         )}
 


### PR DESCRIPTION
Closes #324

Replaces the Node Inspector model input+datalist with the app's standard dropdown (Default, alias list, Custom… free-text). #296 pass-through contract preserved (arbitrary model ids verbatim, Default ⇒ null).

Validated visually (Playwright, isolated vite) + 30 unit tests pass (ModelPicker/NodeInspector/MergeInspector).

🤖 Generated with [Claude Code](https://claude.com/claude-code)