### PR TITLE
feat(#304): detach run-advance from terminal handlers (ADR-0023) — v0.1.69

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -271,6 +271,10 @@ Quand un NodeRun signale `pdo complete`, le runtime parse la frontmatter de chaq
 
 Ce mécanisme évite de fail loud sur une erreur que l'agent peut typiquement corriger seul, tout en bornant la dérive (un agent qui boucle dans le mismatch finit failé en deux tours).
 
+### Avance détachée après transition terminale (#304, ADR-0023)
+
+Le 2xx de `pdo complete` (et `fail`/`skip`) signifie « ton événement terminal est durablement enregistré et l'avance est planifiée », **pas** « le run a avancé ». Après l'append de l'événement terminal (`NodeCompleted`/`NodeFailed`/marqueur skip), la queue du handler — reap de la session tmux + avance du run (spawn du successeur, finalisation du port `end`, `RunFailed`/`RunSkipped`, `retry_waiting_nodes`) — s'exécute sur une tâche `tokio::spawn` **détachée** de la requête HTTP. Raison : le reap tue la session tmux du client `pdo` lui-même ; inline, hyper annulait la future de la requête à la fermeture de la socket et l'avance était silencieusement perdue (run coincé `running`). Les erreurs de validation (guard, merge conflict, outputs) restent renvoyées in-request ; les erreurs d'avance surfacent via `RunFailed` + logs, jamais via la réponse HTTP. Un panic dans la queue détachée est isolé (`catch_unwind`) et émet un `RunFailed` explicite.
+
 ---
 
 ## Variables pipeline

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "0.1.68"
+version = "0.1.69"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "0.1.68"
+version = "0.1.69"
 license = "MIT"
 
 [workspace.dependencies]

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -232,6 +232,18 @@ struct AppState {
     /// spawn can be targeted deterministically. An `Arc<AtomicBool>` (not
     /// process-global env) so parallel test daemons never race (#181).
     panic_on_spawn: Arc<std::sync::atomic::AtomicBool>,
+    /// Test-only gate (#304): when armed, the detached terminal tail (reap +
+    /// run-advance spawned by `node_done`/`node_fail`/`node_skip`) parks at its
+    /// head until [`DaemonHandle::release_node_done_gate`] fires. Sits as the
+    /// FIRST instruction of the detached future, so it encodes the DETACH-vs-
+    /// inline divergence the regression test discriminates on: inline (pre-fix)
+    /// the wait lives in the request future and a client disconnect cancels it —
+    /// the advance is lost; detached it survives the drop and resumes on
+    /// release. Unarmed (production): a pure no-op. Sibling of `panic_on_spawn`
+    /// (#279) — per-daemon, never process-global env (#181).
+    node_done_tail_gate: Arc<tokio::sync::Notify>,
+    /// Whether the tail gate is currently armed. See [`Self::node_done_tail_gate`].
+    node_done_tail_gate_armed: Arc<std::sync::atomic::AtomicBool>,
     /// Persistent-service health (#156, D5), computed once at boot and cached
     /// here so the polled `GET /sessions` pays zero subprocess cost per request.
     /// Surfaced as the `service` object on `/sessions`; drives the status bar's
@@ -1096,6 +1108,27 @@ impl DaemonHandle {
             .store(true, std::sync::atomic::Ordering::Relaxed);
     }
 
+    /// Arm the terminal-tail gate (#304): the detached tail spawned by the next
+    /// `node_done`/`node_fail`/`node_skip` parks at its head until
+    /// [`Self::release_node_done_gate`]. Test seam only — lets a test hold the
+    /// run-advance open while it drops the client connection mid-window, then
+    /// prove the advance still happens (DETACH) instead of being cancelled
+    /// (inline / reorder-only). No-op in production (never armed).
+    pub fn arm_node_done_gate(&self) {
+        self.state
+            .node_done_tail_gate_armed
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+    }
+
+    /// Release the terminal-tail gate (#304): disarm, then wake every tail
+    /// parked at the gate. See [`Self::arm_node_done_gate`].
+    pub fn release_node_done_gate(&self) {
+        self.state
+            .node_done_tail_gate_armed
+            .store(false, std::sync::atomic::Ordering::SeqCst);
+        self.state.node_done_tail_gate.notify_waiters();
+    }
+
     /// Force a Trigger's next fire into the past so the next
     /// [`Self::run_trigger_tick`] treats it as due. Test seam only — production
     /// next-fire times come from the cron schedule.
@@ -1405,6 +1438,8 @@ pub async fn serve_with_config(
             config.panic_on_stale_sweep,
         )),
         panic_on_spawn: Arc::new(std::sync::atomic::AtomicBool::new(config.panic_on_spawn)),
+        node_done_tail_gate: Arc::new(tokio::sync::Notify::new()),
+        node_done_tail_gate_armed: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         service_health,
     });
 
@@ -2898,6 +2933,77 @@ async fn run_stale_detection_supervised(state: &Arc<AppState>) {
     .await;
 }
 
+/// Park until the terminal-tail gate is released (#304, test seam). Unarmed
+/// (production): returns immediately. The re-check between creating the
+/// `Notified` and awaiting it closes the release-vs-register race.
+async fn wait_node_done_tail_gate(state: &AppState) {
+    while state
+        .node_done_tail_gate_armed
+        .load(std::sync::atomic::Ordering::SeqCst)
+    {
+        let notified = state.node_done_tail_gate.notified();
+        if !state
+            .node_done_tail_gate_armed
+            .load(std::sync::atomic::Ordering::SeqCst)
+        {
+            break;
+        }
+        notified.await;
+    }
+}
+
+/// Detach the post-terminal-event tail of a CLI terminal handler
+/// (`node_done` / `node_fail` / `node_skip`) onto its own task (#304,
+/// ADR-0023). The `pdo` CLI runs *inside the node's own tmux session*, and the
+/// tail's first act is to reap that session — killing the HTTP client of the
+/// in-flight request. hyper then cancels the request future at its next
+/// `.await`, silently dropping the successor spawn / end-port finalization /
+/// `RunFailed`/`RunSkipped` append. Spawning the tail decouples it from the
+/// request future, so no client disconnect (self-inflicted or otherwise) can
+/// cancel the advance.
+///
+/// The tail carries its own panic isolation: a panic after the successor's
+/// `NodeStarted` or inside the completion gate escapes the #279 reconciler, and
+/// a bare `tokio::spawn` would swallow it into a never-awaited `JoinError`. So
+/// a panic is logged AND surfaced as `RunFailed` — never a silent stall
+/// (ADR-0004). `run_isolated` is not reused here: it only logs.
+fn detach_terminal_tail<F>(
+    label: &'static str,
+    state: Arc<AppState>,
+    run_id: String,
+    node_id: String,
+    fut: F,
+) where
+    F: std::future::Future<Output = ()> + Send + 'static,
+{
+    tokio::spawn(async move {
+        // Test gate (#304): MUST be the first instruction of the detached task
+        // — inline (pre-fix) this wait sat in the request future and the client
+        // disconnect cancelled it; here it survives the drop. No-op unarmed.
+        wait_node_done_tail_gate(&state).await;
+        let outcome =
+            futures_util::future::FutureExt::catch_unwind(std::panic::AssertUnwindSafe(fut)).await;
+        if let Err(panic) = outcome {
+            let msg = panic_payload_message(panic.as_ref());
+            let reason =
+                format!("run advance panicked after terminal event ({label}) for {node_id}: {msg}");
+            error!("Run {run_id}: {reason}");
+            let run_failed = event_log::Event {
+                id: None,
+                run_id: run_id.clone(),
+                ts: event_log::now_iso(),
+                kind: event_log::EventKind::RunFailed,
+                node_id: None,
+                iter: None,
+                payload: Some(serde_json::json!({ "reason": reason })),
+            };
+            if let Err(e) = append_event(&state, &run_failed).await {
+                error!("Run {run_id}: failed to append RunFailed after detached-tail panic: {e}");
+            }
+        }
+    });
+}
+
 /// Run one scheduler tick: fire every due Trigger that the decision admits,
 /// recording every significant outcome and recomputing each next fire.
 async fn run_trigger_scheduler_tick(state: &AppState) {
@@ -4102,7 +4208,10 @@ async fn spawn_node(
     // panic becomes a LOUD failure (reap the orphan, fail the run) instead of a
     // silent stall (ADR-0004 « jamais de stall silencieux »). A dropped
     // (cancelled) future can't be caught here; the periodic detector in
-    // `run_stall_reason` (#279 Layer 2) is the backstop for that path.
+    // `run_stall_reason` (#279 Layer 2) is the backstop for that path — and
+    // since #304 (ADR-0023) the `node_done` tail runs DETACHED from the request
+    // future, so the completing client's disconnect can no longer cancel this
+    // window in the first place.
     // `tokio::sync::Mutex` doesn't poison, so the DB / admission state stay
     // usable after a caught panic (the property `run_isolated` relies on too).
     let span = std::panic::AssertUnwindSafe(async {
@@ -7382,27 +7491,38 @@ async fn node_done(
         return (StatusCode::INTERNAL_SERVER_ERROR, format!("error: {e}")).into_response();
     }
 
-    // Reap on terminal state (#205): snapshot the pane then kill the session,
-    // so a completed node never holds a live session toward the tmux-collapse
-    // point (#77/#78). Post-mortem inspection survives via the snapshot.
-    reap_node_session(&state, &repo_root, &run_id, &node_id, iter);
+    // Detached tail (#304, ADR-0023): the reap below kills the very tmux
+    // session `pdo complete` runs in, closing this request's client socket —
+    // inline, hyper would cancel this future at its next `.await` and silently
+    // drop the advance (successor spawn / end-port finalization). Everything
+    // past the durable `NodeCompleted` append runs on its own task; the 2xx
+    // means "terminal event recorded, advance scheduled", not "advanced".
+    let tail_state = state.clone();
+    let tail_run = run_id.clone();
+    let tail_node = node_id.clone();
+    detach_terminal_tail("node_done", state.clone(), run_id, node_id, async move {
+        // Reap on terminal state (#205): snapshot the pane then kill the session,
+        // so a completed node never holds a live session toward the tmux-collapse
+        // point (#77/#78). Post-mortem inspection survives via the snapshot.
+        reap_node_session(&tail_state, &repo_root, &tail_run, &tail_node, iter);
 
-    // Shared post-`NodeCompleted` tail (#275): fire this node's edges, advance the
-    // run, re-drive throttled waiters, then the single completion gate. Everything
-    // above — guard, node-type merge / cleanliness check, output validation, the
-    // `NodeCompleted` append, and the reap — is this caller's head, untouched.
-    match run_advance::complete_node(
-        &state,
-        &run_id,
-        &node_id,
-        run_advance::CompletionOrder::CompletionFirst,
-        false,
-    )
-    .await
-    {
-        run_advance::CompletionOutcome::Halted => info!("Run {run_id} halted"),
-        _ => info!("Node {node_id} completed in run {run_id}"),
-    }
+        // Shared post-`NodeCompleted` tail (#275): fire this node's edges, advance the
+        // run, re-drive throttled waiters, then the single completion gate. Everything
+        // above — guard, node-type merge / cleanliness check, output validation, the
+        // `NodeCompleted` append — is the in-request head, untouched.
+        match run_advance::complete_node(
+            &tail_state,
+            &tail_run,
+            &tail_node,
+            run_advance::CompletionOrder::CompletionFirst,
+            false,
+        )
+        .await
+        {
+            run_advance::CompletionOutcome::Halted => info!("Run {tail_run} halted"),
+            _ => info!("Node {tail_node} completed in run {tail_run}"),
+        }
+    });
     (StatusCode::OK, "ok").into_response()
 }
 
@@ -7427,35 +7547,45 @@ async fn node_fail(
         return (StatusCode::INTERNAL_SERVER_ERROR, format!("error: {e}")).into_response();
     }
 
-    // Reap on terminal state (#205): snapshot the pane then kill the session.
-    // Post-mortem inspection of the failed node survives via the snapshot.
-    let repo_root = match load_events(&state.db, &run_id).await {
-        Ok(evs) => event_log::project(&evs)
-            .map(|s| effective_repo_root(&state, &s))
-            .unwrap_or_else(|| state.repo_root.clone()),
-        Err(_) => state.repo_root.clone(),
-    };
-    reap_node_session(&state, &repo_root, &run_id, &node_id, iter);
+    // Detached tail (#304, ADR-0023): same self-cancellation window as
+    // `node_done` — the reap kills `pdo fail`'s own session; inline, the
+    // `RunFailed` append below could be silently dropped, leaving the run
+    // `running` forever with a Failed node.
+    let tail_state = state.clone();
+    let tail_run = run_id.clone();
+    let tail_node = node_id.clone();
+    let reason = req.reason.clone();
+    detach_terminal_tail("node_fail", state.clone(), run_id, node_id, async move {
+        // Reap on terminal state (#205): snapshot the pane then kill the session.
+        // Post-mortem inspection of the failed node survives via the snapshot.
+        let repo_root = match load_events(&tail_state.db, &tail_run).await {
+            Ok(evs) => event_log::project(&evs)
+                .map(|s| effective_repo_root(&tail_state, &s))
+                .unwrap_or_else(|| tail_state.repo_root.clone()),
+            Err(_) => tail_state.repo_root.clone(),
+        };
+        reap_node_session(&tail_state, &repo_root, &tail_run, &tail_node, iter);
 
-    // Mark the run as failed
-    let run_failed = event_log::Event {
-        id: None,
-        run_id: run_id.clone(),
-        ts: event_log::now_iso(),
-        kind: event_log::EventKind::RunFailed,
-        node_id: None,
-        iter: None,
-        payload: Some(serde_json::json!({ "reason": req.reason })),
-    };
-    if let Err(e) = append_event(&state, &run_failed).await {
-        error!("failed to append run_failed: {e}");
-    }
+        // Mark the run as failed
+        let run_failed = event_log::Event {
+            id: None,
+            run_id: tail_run.clone(),
+            ts: event_log::now_iso(),
+            kind: event_log::EventKind::RunFailed,
+            node_id: None,
+            iter: None,
+            payload: Some(serde_json::json!({ "reason": reason })),
+        };
+        if let Err(e) = append_event(&tail_state, &run_failed).await {
+            error!("failed to append run_failed: {e}");
+        }
 
-    // The run failed: its other NodeRun sessions will be reaped, freeing slots.
-    // Re-drive throttled `waiting` nodes in other runs (#159).
-    retry_waiting_nodes(&state).await;
+        // The run failed: its other NodeRun sessions will be reaped, freeing slots.
+        // Re-drive throttled `waiting` nodes in other runs (#159).
+        retry_waiting_nodes(&tail_state).await;
 
-    info!("Node {node_id} failed in run {run_id}");
+        info!("Node {tail_node} failed in run {tail_run}");
+    });
     (StatusCode::OK, "ok").into_response()
 }
 
@@ -7536,35 +7666,42 @@ async fn node_skip(
         return (StatusCode::INTERNAL_SERVER_ERROR, format!("error: {e}")).into_response();
     }
 
-    // Reap on terminal state (#205): snapshot the pane then kill the session.
+    // Detached tail (#304, ADR-0023): same self-cancellation window as
+    // `node_done` — the reap kills `pdo skip`'s own session; inline, the
+    // `RunSkipped` append below could be silently dropped, leaving the run
+    // `running` forever.
     let repo_root = effective_repo_root(&state, &pre_run_state);
-    reap_node_session(&state, &repo_root, &run_id, &node_id, iter);
+    let tail_state = state.clone();
+    let tail_run = run_id.clone();
+    let tail_node = node_id.clone();
+    let reason = req.reason.clone();
+    detach_terminal_tail("node_skip", state.clone(), run_id, node_id, async move {
+        // Reap on terminal state (#205): snapshot the pane then kill the session.
+        reap_node_session(&tail_state, &repo_root, &tail_run, &tail_node, iter);
 
-    // End the run as a graceful no-op (#245) — distinct from RunFailed. This
-    // short-circuits downstream: `spawn_ready_after_event` only spawns for a
-    // Running/AwaitingUser run, so no downstream node is dispatched on a
-    // now-`Skipped` run.
-    let run_skipped = event_log::Event {
-        id: None,
-        run_id: run_id.clone(),
-        ts: event_log::now_iso(),
-        kind: event_log::EventKind::RunSkipped,
-        node_id: None,
-        iter: None,
-        payload: Some(serde_json::json!({ "reason": req.reason })),
-    };
-    if let Err(e) = append_event(&state, &run_skipped).await {
-        error!("failed to append run_skipped: {e}");
-    }
+        // End the run as a graceful no-op (#245) — distinct from RunFailed. This
+        // short-circuits downstream: `spawn_ready_after_event` only spawns for a
+        // Running/AwaitingUser run, so no downstream node is dispatched on a
+        // now-`Skipped` run.
+        let run_skipped = event_log::Event {
+            id: None,
+            run_id: tail_run.clone(),
+            ts: event_log::now_iso(),
+            kind: event_log::EventKind::RunSkipped,
+            node_id: None,
+            iter: None,
+            payload: Some(serde_json::json!({ "reason": reason })),
+        };
+        if let Err(e) = append_event(&tail_state, &run_skipped).await {
+            error!("failed to append run_skipped: {e}");
+        }
 
-    // The run ended: its other NodeRun sessions (if any) will be reaped, freeing
-    // slots. Re-drive throttled `waiting` nodes in other runs (#159).
-    retry_waiting_nodes(&state).await;
+        // The run ended: its other NodeRun sessions (if any) will be reaped, freeing
+        // slots. Re-drive throttled `waiting` nodes in other runs (#159).
+        retry_waiting_nodes(&tail_state).await;
 
-    info!(
-        "Node {node_id} skipped (graceful no-op) in run {run_id}: {}",
-        req.reason
-    );
+        info!("Node {tail_node} skipped (graceful no-op) in run {tail_run}: {reason}");
+    });
     (
         StatusCode::OK,
         Json(serde_json::json!({ "ok": true, "skipped": true, "reason": req.reason })),
@@ -10570,6 +10707,8 @@ mod tests {
             blocked_on_limit: Arc::new(std::sync::atomic::AtomicI64::new(0)),
             panic_on_stale_sweep: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             panic_on_spawn: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            node_done_tail_gate: Arc::new(tokio::sync::Notify::new()),
+            node_done_tail_gate_armed: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             // Neutral default (#156): tests that assert the `/sessions` service
             // field build their own state via `test_state_with_service_health`.
             service_health: Arc::new(ServiceHealth {
@@ -10608,6 +10747,8 @@ mod tests {
             blocked_on_limit: Arc::new(std::sync::atomic::AtomicI64::new(0)),
             panic_on_stale_sweep: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             panic_on_spawn: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            node_done_tail_gate: Arc::new(tokio::sync::Notify::new()),
+            node_done_tail_gate_armed: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             service_health: Arc::new(service_health),
         })
     }
@@ -11261,6 +11402,31 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
     }
 
+    /// The terminal tails of `node_done`/`node_fail`/`node_skip` are DETACHED
+    /// (#304, ADR-0023): the response returns before the run has advanced.
+    /// Tests that drive those handlers must poll to quiescence instead of
+    /// asserting synchronously after the response.
+    async fn wait_run_status(
+        state: &Arc<AppState>,
+        run_id: &str,
+        want: event_log::RunStatus,
+    ) -> event_log::RunState {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            let events = load_events(&state.db, run_id).await.unwrap();
+            if let Some(rs) = event_log::project(&events) {
+                if rs.status == want {
+                    return rs;
+                }
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "timed out waiting for run {run_id} to reach {want:?}"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+    }
+
     #[tokio::test]
     async fn node_done_and_run_lifecycle() {
         let state = test_state().await;
@@ -11305,10 +11471,8 @@ mod tests {
 
         assert_eq!(resp.status(), StatusCode::OK);
 
-        // Check the run is now completed
-        let events = load_events(&state.db, run_id).await.unwrap();
-        let run_state = event_log::project(&events).unwrap();
-        assert_eq!(run_state.status, event_log::RunStatus::Completed);
+        // Check the run reaches completed (detached tail, #304 — poll).
+        let run_state = wait_run_status(&state, run_id, event_log::RunStatus::Completed).await;
         assert_eq!(
             run_state.nodes["worker"].status,
             event_log::NodeStatus::Completed
@@ -11357,9 +11521,8 @@ mod tests {
 
         assert_eq!(resp.status(), StatusCode::OK);
 
-        let events = load_events(&state.db, run_id).await.unwrap();
-        let run_state = event_log::project(&events).unwrap();
-        assert_eq!(run_state.status, event_log::RunStatus::Failed);
+        // The RunFailed append lives in the detached tail (#304) — poll.
+        let run_state = wait_run_status(&state, run_id, event_log::RunStatus::Failed).await;
         assert_eq!(
             run_state.nodes["worker"].status,
             event_log::NodeStatus::Failed
@@ -11410,9 +11573,9 @@ mod tests {
 
         assert_eq!(resp.status(), StatusCode::OK);
 
+        // The RunSkipped append lives in the detached tail (#304) — poll.
+        let run_state = wait_run_status(&state, run_id, event_log::RunStatus::Skipped).await;
         let events = load_events(&state.db, run_id).await.unwrap();
-        let run_state = event_log::project(&events).unwrap();
-        assert_eq!(run_state.status, event_log::RunStatus::Skipped);
         assert_ne!(run_state.status, event_log::RunStatus::Failed);
         // The selector itself is honestly terminal-Completed, not Failed.
         assert_eq!(
@@ -11479,6 +11642,9 @@ mod tests {
         };
 
         assert_eq!(skip().await.unwrap().status(), StatusCode::OK);
+        // The RunSkipped append lives in the detached tail (#304): wait for the
+        // run to actually turn terminal before probing the duplicate.
+        wait_run_status(&state, run_id, event_log::RunStatus::Skipped).await;
         // Second skip: rejected because the run is already terminal (Skipped).
         assert_eq!(skip().await.unwrap().status(), StatusCode::CONFLICT);
 
@@ -12513,15 +12679,14 @@ mod tests {
             .unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
 
+        // The completion gate runs in the detached tail (#304) — poll to
+        // terminal, then assert the exactly-once invariant on the final log.
+        wait_run_status(&state, run_id, event_log::RunStatus::Completed).await;
         let events = load_events(&state.db, run_id).await.unwrap();
         assert_eq!(
             count_run_completed(&events),
             1,
             "node_done must emit exactly one RunCompleted"
-        );
-        assert_eq!(
-            event_log::project(&events).unwrap().status,
-            event_log::RunStatus::Completed
         );
     }
 
@@ -13902,6 +14067,8 @@ mod tests {
             blocked_on_limit: Arc::new(std::sync::atomic::AtomicI64::new(0)),
             panic_on_stale_sweep: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             panic_on_spawn: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            node_done_tail_gate: Arc::new(tokio::sync::Notify::new()),
+            node_done_tail_gate_armed: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             // Neutral default (#156): tests that assert the `/sessions` service
             // field build their own state via `test_state_with_service_health`.
             service_health: Arc::new(ServiceHealth {
@@ -18171,6 +18338,8 @@ edges: []
             blocked_on_limit: Arc::new(std::sync::atomic::AtomicI64::new(0)),
             panic_on_stale_sweep: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             panic_on_spawn: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            node_done_tail_gate: Arc::new(tokio::sync::Notify::new()),
+            node_done_tail_gate_armed: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             // Neutral default (#156): tests that assert the `/sessions` service
             // field build their own state via `test_state_with_service_health`.
             service_health: Arc::new(ServiceHealth {
@@ -18356,6 +18525,8 @@ edges: []
             blocked_on_limit: Arc::new(std::sync::atomic::AtomicI64::new(0)),
             panic_on_stale_sweep: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             panic_on_spawn: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            node_done_tail_gate: Arc::new(tokio::sync::Notify::new()),
+            node_done_tail_gate_armed: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             // Neutral default (#156): tests that assert the `/sessions` service
             // field build their own state via `test_state_with_service_health`.
             service_health: Arc::new(ServiceHealth {

--- a/crates/pdo-daemon/tests/common/mod.rs
+++ b/crates/pdo-daemon/tests/common/mod.rs
@@ -176,6 +176,23 @@ impl TestDaemon {
         }
     }
 
+    /// Arm the terminal-tail gate (#304 fault injection, test seam): the
+    /// detached tail of the next `node_done`/`node_fail`/`node_skip` parks at
+    /// its head until [`Self::release_node_done_gate`], holding the run-advance
+    /// window open so the test can drop the client connection inside it.
+    pub fn arm_node_done_gate(&self) {
+        if let Some(handle) = self.handle.as_ref() {
+            handle.arm_node_done_gate();
+        }
+    }
+
+    /// Release the terminal-tail gate (#304): disarm and wake parked tails.
+    pub fn release_node_done_gate(&self) {
+        if let Some(handle) = self.handle.as_ref() {
+            handle.release_node_done_gate();
+        }
+    }
+
     /// Force a Trigger's next fire into the past so the next tick treats it as
     /// due (test seam).
     pub async fn force_trigger_due(&self, trigger_id: &str) {

--- a/crates/pdo-daemon/tests/node_done_detach.rs
+++ b/crates/pdo-daemon/tests/node_done_detach.rs
@@ -1,0 +1,358 @@
+//! Layer 3a — proves #304 (ADR-0023) is fixed: the post-terminal-event tail of
+//! `node_done` / `node_fail` / `node_skip` (session reap + run advance /
+//! `RunFailed` / `RunSkipped`) is DETACHED from the HTTP request future, so a
+//! client disconnect mid-window — including the self-inflicted one where the
+//! reap kills the `pdo complete` client's own tmux session — can no longer
+//! cancel the advance.
+//!
+//! Determinism: hyper only cancels the in-flight future at its next `.await`
+//! after the FIN, so a bare "drop the socket fast" race is probabilistic. The
+//! `arm_node_done_gate` seam (sibling of `arm_spawn_panic`, #279) parks the
+//! tail at its head — the FIRST instruction of the detached task — while the
+//! test drops a raw TCP connection, then releases it. Under the pre-#304 inline
+//! code (or a reorder-only fix) the gate wait sits in the request future: the
+//! drop cancels it and releasing changes nothing → these tests go red. Under
+//! DETACH the tail survives the drop and resumes on release → green. That
+//! placement is the whole discriminator; do not "simplify" it away.
+//!
+//! Must run through `TestDaemon` (a real TCP listener): the in-lib `oneshot`
+//! router tests poll the handler future to completion regardless of any client,
+//! so the cancellation bug is invisible there.
+
+mod common;
+
+use std::time::Duration;
+
+use common::TestDaemon;
+use tokio::io::AsyncWriteExt;
+
+const PIPELINE_NAME: &str = "detach-tail";
+// start → a → b → end; doc-only nodes so completion needs no sub-worktree merge.
+const PIPELINE_YAML: &str = r#"name: detach-tail
+version: "1.0"
+nodes:
+  - id: start
+    name: Start
+    type: start
+    outputs:
+      - name: user_prompt
+  - id: a
+    name: a
+    type: doc-only
+    inputs:
+      - name: in
+    outputs:
+      - name: out
+  - id: b
+    name: b
+    type: doc-only
+    inputs:
+      - name: in
+    outputs:
+      - name: out
+  - id: end
+    name: End
+    type: end
+    inputs:
+      - name: result
+edges:
+  - source: { node: start, port: user_prompt }
+    target: { node: a, port: in }
+  - source: { node: a, port: out }
+    target: { node: b, port: in }
+  - source: { node: b, port: out }
+    target: { node: end, port: result }
+"#;
+
+fn seed(repo: &std::path::Path) -> anyhow::Result<()> {
+    let pipelines_dir = repo.join(".pdo").join("pipelines");
+    std::fs::create_dir_all(&pipelines_dir)?;
+    std::fs::write(
+        pipelines_dir.join(format!("{PIPELINE_NAME}.yaml")),
+        PIPELINE_YAML,
+    )?;
+    git_init_with_commit(repo)?;
+    Ok(())
+}
+
+fn git_init_with_commit(repo: &std::path::Path) -> anyhow::Result<()> {
+    let run = |args: &[&str]| -> anyhow::Result<()> {
+        let out = std::process::Command::new("git")
+            .args(args)
+            .current_dir(repo)
+            .output()?;
+        if !out.status.success() {
+            anyhow::bail!(
+                "git {:?} failed: {}",
+                args,
+                String::from_utf8_lossy(&out.stderr)
+            );
+        }
+        Ok(())
+    };
+    run(&["init", "-q", "-b", "main"])?;
+    run(&["config", "user.email", "test@example.com"])?;
+    run(&["config", "user.name", "Test"])?;
+    run(&["config", "commit.gpgsign", "false"])?;
+    std::fs::write(repo.join(".gitignore"), ".pdo/runs/\n")?;
+    run(&["add", "."])?;
+    run(&["commit", "-q", "-m", "init"])?;
+    Ok(())
+}
+
+async fn create_run(daemon: &TestDaemon) -> String {
+    let body = serde_json::json!({ "pipeline": PIPELINE_NAME, "input": "test input" });
+    let resp = reqwest::Client::new()
+        .post(format!("{}/runs", daemon.url()))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 201);
+    resp.json::<serde_json::Value>().await.unwrap()["run_id"]
+        .as_str()
+        .unwrap()
+        .to_string()
+}
+
+async fn events(daemon: &TestDaemon, run_id: &str) -> Vec<serde_json::Value> {
+    let v: serde_json::Value = reqwest::get(format!("{}/runs/{run_id}/events", daemon.url()))
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    v.as_array().cloned().unwrap_or_default()
+}
+
+async fn run_status(daemon: &TestDaemon, run_id: &str) -> Option<String> {
+    let runs: serde_json::Value = reqwest::get(format!("{}/runs", daemon.url()))
+        .await
+        .ok()?
+        .json()
+        .await
+        .ok()?;
+    runs.as_array()?
+        .iter()
+        .find(|r| r["run_id"].as_str() == Some(run_id))
+        .and_then(|r| r["status"].as_str())
+        .map(String::from)
+}
+
+/// Poll the run's events until `pred` matches one, or time out.
+async fn wait_for_event<F>(daemon: &TestDaemon, run_id: &str, what: &str, pred: F)
+where
+    F: Fn(&serde_json::Value) -> bool,
+{
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        if events(daemon, run_id).await.iter().any(&pred) {
+            return;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "timed out waiting for {what} in run {run_id}"
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+/// Satisfy output validation for a doc-only node before `pdo complete`: write
+/// the artifact its declared `out` port expects, exactly where the agent would.
+fn write_out_artifact(daemon: &TestDaemon, run_id: &str, node_id: &str) {
+    let dir = daemon
+        .repo_root()
+        .join(".pdo")
+        .join("runs")
+        .join(run_id)
+        .join("worktree")
+        .join(".pdo")
+        .join("artifacts")
+        .join(node_id)
+        .join("iter-1")
+        .join("out");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("output.md"), "artifact\n").unwrap();
+}
+
+/// Send a raw HTTP POST over a bare `TcpStream` and return the still-open
+/// stream WITHOUT reading the response. reqwest can't do this: the test must
+/// control exactly when the connection drops (mid-window, before the response).
+async fn raw_post(daemon: &TestDaemon, path: &str, body: &str) -> tokio::net::TcpStream {
+    let mut stream = tokio::net::TcpStream::connect(daemon.addr).await.unwrap();
+    let req = format!(
+        "POST {path} HTTP/1.1\r\nHost: x\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+        body.len()
+    );
+    stream.write_all(req.as_bytes()).await.unwrap();
+    stream.flush().await.unwrap();
+    stream
+}
+
+/// Drive one terminal transition through the drop-mid-window sequence:
+/// arm the gate → raw POST → wait for the in-request terminal event (proof the
+/// append happened and the tail is parked at the gate) → drop the socket (FIN
+/// before any response byte) → give hyper a beat to notice → release the gate.
+async fn terminal_transition_over_dropped_connection(
+    daemon: &TestDaemon,
+    run_id: &str,
+    path: &str,
+    body: &str,
+    terminal_event: &str,
+    node_id: &str,
+) {
+    daemon.arm_node_done_gate();
+    let stream = raw_post(daemon, path, body).await;
+    wait_for_event(daemon, run_id, terminal_event, |e| {
+        e["kind"] == terminal_event && e["node_id"] == node_id
+    })
+    .await;
+    drop(stream);
+    // Let the FIN propagate so hyper cancels the request future (pre-fix) while
+    // the tail is still parked — this is the window the bug lives in.
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    daemon.release_node_done_gate();
+}
+
+#[tokio::test]
+async fn node_done_survives_client_disconnect_and_spawns_successor() {
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+    let run_id = create_run(&daemon).await;
+
+    // Entry node `a` is spawned by run creation.
+    wait_for_event(&daemon, &run_id, "node_started for a", |e| {
+        e["kind"] == "node_started" && e["node_id"] == "a"
+    })
+    .await;
+
+    // Flush the run-creation `pipeline_modified` debounce (~1 s): its
+    // `spawn_ready_after_event` re-drive must land while `b` is NOT ready yet
+    // (a no-op), or it would rescue the cancelled advance and mask the bug.
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    write_out_artifact(&daemon, &run_id, "a");
+    terminal_transition_over_dropped_connection(
+        &daemon,
+        &run_id,
+        &format!("/runs/{run_id}/nodes/a/done"),
+        r#"{"iter": 1}"#,
+        "node_completed",
+        "a",
+    )
+    .await;
+
+    // The advance must survive the dropped connection: successor `b` spawns.
+    wait_for_event(&daemon, &run_id, "node_started for successor b", |e| {
+        e["kind"] == "node_started" && e["node_id"] == "b"
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn end_node_completes_run_over_dropped_connection() {
+    // The end-port wrinkle (recurrence e3e5ac3): the LAST node's completion
+    // fires the end-port deposit + `RunCompleted` inside the same cancelled
+    // future — the variant that escapes even the #279 reconciler.
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+    let run_id = create_run(&daemon).await;
+
+    wait_for_event(&daemon, &run_id, "node_started for a", |e| {
+        e["kind"] == "node_started" && e["node_id"] == "a"
+    })
+    .await;
+
+    // Complete `a` normally (gate unarmed) so `b` spawns.
+    write_out_artifact(&daemon, &run_id, "a");
+    let resp = reqwest::Client::new()
+        .post(format!("{}/runs/{run_id}/nodes/a/done", daemon.url()))
+        .json(&serde_json::json!({ "iter": 1 }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    wait_for_event(&daemon, &run_id, "node_started for b", |e| {
+        e["kind"] == "node_started" && e["node_id"] == "b"
+    })
+    .await;
+
+    write_out_artifact(&daemon, &run_id, "b");
+    terminal_transition_over_dropped_connection(
+        &daemon,
+        &run_id,
+        &format!("/runs/{run_id}/nodes/b/done"),
+        r#"{"iter": 1}"#,
+        "node_completed",
+        "b",
+    )
+    .await;
+
+    wait_for_event(&daemon, &run_id, "run_completed", |e| {
+        e["kind"] == "run_completed"
+    })
+    .await;
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        if run_status(&daemon, &run_id).await.as_deref() == Some("completed") {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "run must reach status `completed`, not wedge `running` with all nodes done"
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+#[tokio::test]
+async fn node_fail_emits_run_failed_over_dropped_connection() {
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+    let run_id = create_run(&daemon).await;
+
+    wait_for_event(&daemon, &run_id, "node_started for a", |e| {
+        e["kind"] == "node_started" && e["node_id"] == "a"
+    })
+    .await;
+
+    terminal_transition_over_dropped_connection(
+        &daemon,
+        &run_id,
+        &format!("/runs/{run_id}/nodes/a/fail"),
+        r#"{"iter": 1, "reason": "boom"}"#,
+        "node_failed",
+        "a",
+    )
+    .await;
+
+    // Pre-#304 the `RunFailed` append lived past the reap in the cancelled
+    // future: the node was Failed but the run stayed `running` forever.
+    wait_for_event(&daemon, &run_id, "run_failed", |e| {
+        e["kind"] == "run_failed"
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn node_skip_emits_run_skipped_over_dropped_connection() {
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+    let run_id = create_run(&daemon).await;
+
+    wait_for_event(&daemon, &run_id, "node_started for a", |e| {
+        e["kind"] == "node_started" && e["node_id"] == "a"
+    })
+    .await;
+
+    terminal_transition_over_dropped_connection(
+        &daemon,
+        &run_id,
+        &format!("/runs/{run_id}/nodes/a/skip"),
+        r#"{"iter": 1, "reason": "nothing to do"}"#,
+        "node_completed",
+        "a",
+    )
+    .await;
+
+    wait_for_event(&daemon, &run_id, "run_skipped", |e| {
+        e["kind"] == "run_skipped"
+    })
+    .await;
+}

--- a/docs/adr/0023-detached-run-advance.md
+++ b/docs/adr/0023-detached-run-advance.md
@@ -1,0 +1,79 @@
+# ADR-0023 — Detached run-advance after terminal node transitions
+
+## Status
+
+Accepted (ratified via Discord, 2026-07-03 — issue #304, Option A "DETACH").
+
+## Context
+
+A node signals its terminal transition through the in-session `pdo` CLI
+(`complete` / `fail` / `skip`), a `reqwest::blocking` one-shot running **inside
+the node's own tmux session**. The daemon's handler (`node_done`, `node_fail`,
+`node_skip`) appends the terminal event, then calls `reap_node_session` — which
+kills that very tmux session, i.e. the HTTP client of the in-flight request —
+and only then runs the rest of the work (successor spawn via
+`run_advance::complete_node`, `RunFailed`/`RunSkipped` append,
+`retry_waiting_nodes`).
+
+hyper 1.x (`half_close = false`) cancels the in-flight handler future at its
+next `.await` once the client socket closes. A cancelled future executes no
+`catch` and logs nothing: the successor spawn (or the end-port finalization /
+`RunCompleted`) is silently dropped. Only the 148 s idle reconciler (#279)
+notices — and the end-port variant escapes even that (run stuck `running` with
+all nodes completed, observed on `20260704-100029-e3e5ac3`). Five production
+recurrences were logged between 2026-07-02 and 2026-07-04; the bug even blocked
+its own fix from landing through the autonomous pipeline.
+
+A reorder-only fix (reap after advance) removes just the self-inflicted
+disconnect, not the class: any client disconnect mid-advance (crash, network,
+manual Ctrl-C on `pdo complete`) still cancels the advance, and no deterministic
+regression test can go green under it.
+
+## Decision
+
+After the terminal event (`NodeCompleted` / `NodeFailed` / skip marker) is
+durably appended, the remainder of the handler — session reap plus every
+state-advancing step — runs on a **detached `tokio::spawn` task**, decoupled
+from the HTTP request future. The handler returns its response immediately
+after spawning the task. Applies to all three CLI-facing terminal handlers:
+
+- `node_done`: reap + `run_advance::complete_node` (edge firing, successor
+  spawn, end-port finalization, `retry_waiting_nodes`, completion gate).
+- `node_fail`: reap + `RunFailed` append + `retry_waiting_nodes`.
+- `node_skip`: reap + `RunSkipped` append + `retry_waiting_nodes`.
+
+`handle_merge_resolver_done` and the `mark_node_done` command are **not**
+detached: neither reaps its own caller, so they have no self-cancellation
+window, and detaching them would only trade response-visible errors for
+fire-and-forget ones.
+
+The detached task is wrapped in panic isolation (`catch_unwind` over the tail):
+a panic is logged **and** surfaced as a `RunFailed` event
+(`{"reason": "run advance panicked after &lt;event&gt; for &lt;node&gt;: …"}`), because a
+panic landing after the successor's `NodeStarted` or inside the completion gate
+falls outside the #279 reconciler's coverage.
+
+## Consequences
+
+- **Contract change:** `pdo complete` (and `fail`/`skip`) receives its 2xx
+  **before** the run has advanced. The 2xx means "your terminal event is
+  durably recorded and the advance is scheduled", not "the run has advanced".
+  Advance errors surface via `RunFailed` + daemon logs, never via the HTTP
+  response. Validation errors (transition-guard reject/no-op, merge conflicts,
+  output-validation failures, append failures) still return in-request.
+- A client disconnect at any point can no longer cancel the advance — closing
+  the whole silent-abort class upstream of #279's guard, including the
+  end-port finalization drop.
+- The detached task is untracked (fire-and-forget), consistent with the
+  daemon's existing background fleet (reaper, stale detector, trigger
+  scheduler — all unjoined `tokio::spawn`). If the daemon dies between the 2xx
+  and the advance, boot recovery + the stall reconciler handle the wedged run
+  (reconcile-to-Failed, not resume) — same exposure as today, minus the
+  in-request window.
+- Concurrency is safe by existing construction: no lock is held across the
+  tail today (`merge_lock` is scoped to the merge block), and spawning is
+  idempotent (transition guard #212 + `compute_ready_to_spawn`), so a detached
+  advance racing `re_evaluate_after_command` cannot double-spawn.
+- Testability: this is the only shape under which the deterministic regression
+  test (client drops the TCP connection mid-window → successor still spawns /
+  run still completes) goes green; it stays red under reorder-only.


### PR DESCRIPTION
Closes #304.

Detaches run-advance (advance + reap) from terminal HTTP handlers per ADR-0023: after the terminal event is appended, the advance work runs on a detached task so a dropped client connection (the #304 / end-port `e3e5ac3` failure mode) can no longer abort `complete_node` mid-flight.

- New integration suite `node_done_detach` (4 tests, incl. `end_node_completes_run_over_dropped_connection`).
- ADR-0023 documents the contract: 2xx = event recorded, advance scheduled.
- Validated live: raw-TCP `node_done` with socket dropped after the terminal-event append → run still reaches `completed`, sessions reaped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)