### PR TITLE
fix(#328): durable forget via forgotten_runs tombstone (ADR-0024) — v0.1.70

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -823,6 +823,16 @@ Pas de "permanent delete" v1 (mais cf. `forget` ci-dessous). Le bouton "Cleanup"
 
 L'event log **et** le Blackboard archivé peuvent grossir indéfiniment ; on évalue la taille avant de décider d'une politique de purge. Pas de v1. Le seul reclaim v1 du Blackboard archivé est le **`forget`** (`DELETE /runs/<id>`, autorisé sur un Run déjà `archived`) : il purge les events *et* `~/.pdo/runs/<id>`.
 
+### Forget durable
+
+Le `forget` (`DELETE /runs/<id>`) est **durable** (ADR-0024) : il pose un *tombstone* dans la table `forgotten_runs` et purge les events dans une même transaction. Conséquences :
+
+- `append_event` refuse **tout** kind d'événement pour un run_id tombstoné (garde `INSERT … WHERE NOT EXISTS`, sans fenêtre TOCTOU) — un écrivain tardif (session `pdo-mgr` orpheline, tail détaché post-#304/ADR-0023) ne peut plus ressusciter le run ; il logge l'erreur et continue.
+- `POST /runs/<id>/commands` et `POST …/nodes/<n>/done` répondent **410 Gone** pour un run oublié, avant tout side-effect.
+- `forget` tue en best-effort les sessions `pdo-mgr-<id>` / `pdo-shell-<id>` (un run oublié n'a plus rien à récupérer).
+- Un run_id oublié n'est **jamais réutilisable** (le tombstone bloque aussi `RunStarted`) ; les run_id sont horodatés, la collision est impraticable.
+- `project()` ne projette jamais un log sans `RunStarted` : un fragment événementiel orphelin rend `None` au lieu d'un fantôme `running` sans nom.
+
 ### Notifications
 
 Pas de notifications système v1. Le status icon dans la liste de gauche suffit. Si plus tard ça manque, on rajoute optionnellement (desktop notification API, opt-in). Pas avant.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "0.1.69"
+version = "0.1.70"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "0.1.69"
+version = "0.1.70"
 license = "MIT"
 
 [workspace.dependencies]

--- a/crates/pdo-daemon/src/event_log.rs
+++ b/crates/pdo-daemon/src/event_log.rs
@@ -548,6 +548,10 @@ pub fn project(events: &[Event]) -> Option<RunState> {
         }
     }
 
+    // #328: a log with no RunStarted is an invalid fragment (e.g. a late event
+    // appended after a forget) — never surface it as a phantom Running run.
+    state.started_at.as_ref()?;
+
     finalize(&mut state);
 
     Some(state)
@@ -1361,6 +1365,25 @@ mod tests {
     #[test]
     fn projects_empty_events_to_none() {
         assert!(project(&[]).is_none());
+    }
+
+    #[test]
+    fn lone_command_issued_projects_none() {
+        // #328: a log fragment with no RunStarted (e.g. a late event that
+        // slipped in around a forget) must never project as a phantom run.
+        let events = vec![make_event_with_payload(
+            EventKind::CommandIssued,
+            None,
+            serde_json::json!({ "kind": "extend_cycle" }),
+        )];
+        assert!(project(&events).is_none());
+    }
+
+    #[test]
+    fn lone_node_event_projects_none() {
+        // #328: same for node events — the exact ghost shape from the issue.
+        let events = vec![make_event(EventKind::NodeStopped, Some("n1"), Some(1))];
+        assert!(project(&events).is_none());
     }
 
     #[test]

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -2541,6 +2541,18 @@ async fn init_db(db: &sqlx::SqlitePool) -> Result<()> {
     .await
     .context("failed to create events table")?;
 
+    // #328 / ADR-0024: tombstones for forgotten runs — a run_id present here
+    // can never receive events again (guard in `append_event`).
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS forgotten_runs (
+            run_id TEXT PRIMARY KEY,
+            forgotten_at TEXT NOT NULL
+        )",
+    )
+    .execute(db)
+    .await
+    .context("failed to create forgotten_runs table")?;
+
     trigger_store::init(db)
         .await
         .context("failed to create trigger tables")?;
@@ -2587,8 +2599,12 @@ async fn append_event(state: &AppState, event: &event_log::Event) -> Result<()> 
         .to_string();
     let payload_str = event.payload.as_ref().map(|p| p.to_string());
 
-    sqlx::query(
-        "INSERT INTO events (run_id, ts, kind, node_id, iter, payload) VALUES (?, ?, ?, ?, ?, ?)",
+    // #328 / ADR-0024: refuse ALL kinds for a tombstoned run in the same
+    // statement as the insert (no TOCTOU window against a concurrent forget).
+    let result = sqlx::query(
+        "INSERT INTO events (run_id, ts, kind, node_id, iter, payload)
+         SELECT ?, ?, ?, ?, ?, ?
+         WHERE NOT EXISTS (SELECT 1 FROM forgotten_runs WHERE run_id = ?)",
     )
     .bind(&event.run_id)
     .bind(&event.ts)
@@ -2596,13 +2612,28 @@ async fn append_event(state: &AppState, event: &event_log::Event) -> Result<()> 
     .bind(&event.node_id)
     .bind(event.iter)
     .bind(&payload_str)
+    .bind(&event.run_id)
     .execute(&state.db)
     .await
     .context("failed to append event")?;
+    if result.rows_affected() == 0 {
+        anyhow::bail!("run {} has been forgotten", event.run_id);
+    }
 
     let _ = state.event_tx.send(event.clone());
 
     Ok(())
+}
+
+/// #328 / ADR-0024: check whether a run_id has been tombstoned by forget.
+async fn run_is_forgotten(db: &sqlx::SqlitePool, run_id: &str) -> Result<bool> {
+    let row: Option<(i64,)> =
+        sqlx::query_as("SELECT 1 FROM forgotten_runs WHERE run_id = ? LIMIT 1")
+            .bind(run_id)
+            .fetch_optional(db)
+            .await
+            .context("failed to query forgotten_runs")?;
+    Ok(row.is_some())
 }
 
 async fn emit_run_event(
@@ -7273,6 +7304,22 @@ async fn node_done(
 ) -> Response {
     let iter = body.and_then(|b| b.iter).unwrap_or(1);
 
+    // #328 / ADR-0024: refuse completions for a forgotten run BEFORE any side
+    // effect (sub-worktree merge in particular).
+    match run_is_forgotten(&state.db, &run_id).await {
+        Ok(true) => {
+            return (
+                StatusCode::GONE,
+                Json(serde_json::json!({ "error": format!("run {run_id} has been forgotten") })),
+            )
+                .into_response();
+        }
+        Ok(false) => {}
+        Err(e) => {
+            return (StatusCode::INTERNAL_SERVER_ERROR, format!("error: {e}")).into_response();
+        }
+    }
+
     // Post-#205: a node's tmux session is snapshot-then-killed *immediately* at
     // its terminal transition (see the "#205" reaps below), so post-mortem
     // preview survives via the persisted pane snapshot, not a lingering session.
@@ -8177,6 +8224,23 @@ async fn run_command(
     AxumPath(run_id): AxumPath<String>,
     Json(req): Json<RunCommandRequest>,
 ) -> Response {
+    // #328 / ADR-0024: a forgotten run accepts no commands — reject before any
+    // arm can append (extend_cycle appends CommandIssued before its own
+    // existence check) or trigger side effects.
+    match run_is_forgotten(&state.db, &run_id).await {
+        Ok(true) => {
+            return (
+                StatusCode::GONE,
+                Json(serde_json::json!({ "error": format!("run {run_id} has been forgotten") })),
+            )
+                .into_response();
+        }
+        Ok(false) => {}
+        Err(e) => {
+            return (StatusCode::INTERNAL_SERVER_ERROR, format!("error: {e}")).into_response();
+        }
+    }
+
     match req.kind.as_str() {
         "mark_node_done" => {
             let Some(node_id) = req.node_id else {
@@ -9742,13 +9806,35 @@ async fn forget_run(
             .into_response();
     }
 
-    if let Err(e) = sqlx::query("DELETE FROM events WHERE run_id = ?")
-        .bind(&run_id)
-        .execute(&state.db)
-        .await
-    {
+    // #328 / ADR-0024: tombstone + purge in one transaction — a late writer
+    // must never observe "events gone, no tombstone yet" and resurrect the run.
+    let purge = async {
+        let mut tx = state.db.begin().await?;
+        sqlx::query("INSERT OR IGNORE INTO forgotten_runs (run_id, forgotten_at) VALUES (?, ?)")
+            .bind(&run_id)
+            .bind(event_log::now_iso())
+            .execute(&mut *tx)
+            .await?;
+        sqlx::query("DELETE FROM events WHERE run_id = ?")
+            .bind(&run_id)
+            .execute(&mut *tx)
+            .await?;
+        tx.commit().await?;
+        anyhow::Ok(())
+    };
+    if let Err(e) = purge.await {
         error!("failed to delete events for {run_id}: {e}");
         return (StatusCode::INTERNAL_SERVER_ERROR, "event log error").into_response();
+    }
+
+    // A forgotten run has nothing left to recover: reap its manager/shell
+    // sessions so they can't keep POSTing commands. Best-effort.
+    let socket = state.tmux_socket();
+    for session in [
+        tmux_session_manager::manager_session_name(&run_id),
+        tmux_session_manager::shell_session_name(&run_id),
+    ] {
+        tmux_session_manager::kill(&socket, &session);
     }
 
     // #315 / ADR-0020: forget also reclaims the durable output store — without
@@ -11871,6 +11957,142 @@ mod tests {
         let events = load_events(&state.db, run_id).await.unwrap();
         assert!(events.is_empty(), "event log must be empty after forget");
         assert!(event_log::project(&events).is_none());
+
+        // #328: forget is durable — a late writer cannot resurrect the run.
+        let late = event_log::Event {
+            id: None,
+            run_id: run_id.to_string(),
+            ts: event_log::now_iso(),
+            kind: event_log::EventKind::NodeStopped,
+            node_id: Some("n1".into()),
+            iter: Some(1),
+            payload: None,
+        };
+        let err = append_event(&state, &late).await.unwrap_err();
+        assert!(
+            err.to_string().contains("has been forgotten"),
+            "unexpected error: {err}"
+        );
+        let events = load_events(&state.db, run_id).await.unwrap();
+        assert!(events.is_empty(), "late append must not write any event");
+
+        // GET /runs never re-lists the forgotten run.
+        let app = build_router(state.clone());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/runs")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: serde_json::Value = serde_json::from_slice(
+            &axum::body::to_bytes(resp.into_body(), usize::MAX)
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+        assert!(
+            !body.to_string().contains(run_id),
+            "forgotten run must not reappear in GET /runs: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn command_on_forgotten_run_returns_410() {
+        let state = test_state().await;
+        let run_id = "forget-410";
+        seed_completed_run(&state, run_id).await;
+        post_cleanup_run(&state, run_id).await;
+
+        let app = build_router(state.clone());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri(format!("/runs/{run_id}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // extend_cycle used to append CommandIssued before any existence check
+        // — the exact resurrection vector of #328.
+        let app = build_router(state.clone());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/runs/{run_id}/commands"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        r#"{"kind": "extend_cycle", "node_id": "n1", "additional_iter": 1}"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::GONE);
+
+        // node_done is also rejected before any side effect.
+        let app = build_router(state.clone());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/runs/{run_id}/nodes/n1/done"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"iter": 1}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::GONE);
+
+        let events = load_events(&state.db, run_id).await.unwrap();
+        assert!(events.is_empty(), "log must stay empty: {events:?}");
+    }
+
+    #[tokio::test]
+    async fn forget_is_atomic_tombstone() {
+        let state = test_state().await;
+        let run_id = "forget-tombstone";
+        seed_completed_run(&state, run_id).await;
+        post_cleanup_run(&state, run_id).await;
+
+        let app = build_router(state.clone());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri(format!("/runs/{run_id}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        assert!(run_is_forgotten(&state.db, run_id).await.unwrap());
+
+        // Re-forgetting a forgotten run: the log is gone, so it 404s (unchanged).
+        let app = build_router(state.clone());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri(format!("/runs/{run_id}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
     }
 
     #[tokio::test]

--- a/docs/adr/0024-forgotten-run-tombstone.md
+++ b/docs/adr/0024-forgotten-run-tombstone.md
@@ -1,0 +1,36 @@
+# ADR-0024 — Forget durable : tombstone des runs oubliés
+
+- **Statut** : accepté
+- **Date** : 2026-07-09
+- **Issue** : #328
+
+## Contexte
+
+Les runs sont projetés depuis l'event log (`SELECT DISTINCT run_id FROM events`). Le `forget` (`DELETE /runs/<id>`, autorisé sur un run `archived`) faisait uniquement `DELETE FROM events WHERE run_id = ?`. Tout événement écrit **après** ce delete pour le même `run_id` recréait un `DISTINCT run_id` sans métadonnées : `project()` fabriquait alors un `RunState` fantôme (`status: running`, `pipeline_name: ""`, `started_at: null`), republié aussitôt par `GET /runs` — inarchivable et non re-forgettable (forget exige `Archived`).
+
+Écrivains tardifs réels :
+
+1. **Session manager/zombie tmux** : `pdo-mgr-<id>` ou une session orpheline qui POSTe `/runs/<id>/commands` — l'arm `extend_cycle` appendait `CommandIssued` avant tout check d'existence.
+2. **Tail détaché post-#304 (ADR-0023)** : `detach_terminal_tail` est un `tokio::spawn` non traqué ; son reap + `advance_run` peut appender `NodeStarted`/`RunCompleted`/etc. après un forget concurrent.
+
+## Décision
+
+1. **Table `forgotten_runs`** (`run_id TEXT PRIMARY KEY, forgotten_at TEXT`), créée au boot (`CREATE TABLE IF NOT EXISTS`, pattern ADR-0015). `forget_run` insère le tombstone **et** purge les events dans **une même transaction sqlx** (première transaction du daemon) : aucun interleaving où les events sont partis mais le tombstone absent.
+2. **Garde dans `append_event`, tous kinds** : l'INSERT unique devient `INSERT … SELECT … WHERE NOT EXISTS (SELECT 1 FROM forgotten_runs WHERE run_id = ?)` ; `rows_affected == 0` → `Err("run <id> has been forgotten")`. Un seul statement : pas de fenêtre TOCTOU face à un forget concurrent. Les émetteurs (tail détaché, stale detector, `let _ = append_event(...)`) loggent l'erreur et continuent — ni panic ni retry.
+3. **410 Gone aux frontières HTTP** : `run_command` et `node_done` pré-vérifient le tombstone en tête de handler, avant tout side-effect (merge de sub-worktree en particulier).
+4. **Projection durcie** : `project()` retourne `None` si le log ne contient aucun `RunStarted` (`started_at` jamais posé). Les 43 call sites production sont None-tolerants ; aucun run légitime n'existe sans `RunStarted` (appendé en premier à la création, avant worktree et scheduling).
+5. **Kill best-effort des sessions** au forget : `pdo-mgr-<id>` et `pdo-shell-<id>` sont tuées (un run oublié n'a plus rien à récupérer — le « managers persist by design » ne vaut que pour un run dont le log existe).
+
+Conséquence assumée : un `run_id` oublié n'est **jamais réutilisable** (le tombstone bloque aussi `RunStarted`). Les run_id sont horodatés ; la collision est impraticable.
+
+## Alternatives rejetées
+
+- **Projection-only** (ne durcir que `project()`) : les events orphelins s'accumulent silencieusement en base pour un run censé avoir « entièrement disparu ».
+- **Event-tombstone conservé dans `events`** (ex. `RunForgotten`) : contredit le contrat de purge du forget et garde le `run_id` dans les `DISTINCT`.
+- **`RunStatus::Invalid`** pour les fragments : churn d'exhaustive-match sur tous les consommateurs pour représenter un état qui ne devrait pas exister.
+
+## Interactions
+
+- **ADR-0023 (tail détaché)** : le tail est précisément le second écrivain tardif ; son `Err` d'append est loggé par le `catch_unwind`/logging existant, sans panic ni retry.
+- **#212 (transition guard)** : `validate_transition(None, _) == Allow` — après durcissement de `project()`, c'est le tombstone qui bloque, pas le guard.
+- **ADR-0020 (forget purge aussi `~/.pdo/runs/<id>`)** : inchangé, conservé après la transaction.


### PR DESCRIPTION
Closes #328.

Durable forget: `forgotten_runs` tombstone table blocks late writers (`extend_cycle`, `node_done`) with HTTP 410 and prevents ghost-run resurrection after daemon restart (ADR-0024).

Validated end-to-end on an isolated stack (daemon :6198, copy of prod DB): forget → 410 on late writes → no ghost after reload nor daemon restart. Implementer reports 1324 tests green, clippy/fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)