### PR TITLE
feat(#327): truthful loop-command responses (ADR-0025) — v0.1.70

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -598,7 +598,9 @@ Toutes exposées comme endpoints `POST /runs/<id>/commands` du daemon :
 
 | Commande | Effet |
 |---|---|
-| `extend_cycle` | Augmente le `max_iter` d'un cycle bloqué de N et relance |
+| `bump_region` | Accorde N itérations supplémentaires à une région de boucle bornée (`region_id` = id de la région `loops:`) et relance |
+| `end_region` | Déclenche la complétion d'une région de boucle bornée sans itération supplémentaire |
+| `extend_cycle` | (Legacy, cycles `$var` hors région) Augmente le `max_iter` d'un cycle bloqué de N et relance. Cible = le nœud porteur de l'arête de cycle sortante (nœud de condition de sortie), jamais la tête. Refusé (`409`) si le nœud est membre d'une région `loops:` bornée — utiliser `bump_region` |
 | `resume_run` | Relance le Run depuis l'état actuel (utile post-conflit résolu manuellement) |
 | `kill_node` | Tue un NodeRun en cours |
 | `restart_node` | Re-spawn un NodeRun (perd l'état tmux courant) |
@@ -609,6 +611,15 @@ Toutes exposées comme endpoints `POST /runs/<id>/commands` du daemon :
 | `start_node` | Spawne un NodeRun immédiatement, sans attendre la complétion amont (force-spawn) ; inputs résolus best-effort ; refusé (`409`) si le Run n'accepte pas de spawn ou si le cap de sessions est atteint |
 
 L'effet de chaque commande est l'**append d'un événement** dans l'event log. Le runtime consomme ces événements et agit en conséquence.
+
+### Contrat de réponse des commandes (ADR-0025)
+
+Les commandes de pilotage de boucle (`extend_cycle`, `bump_region`, `end_region`, `resume_run`) disent la vérité sur leur effet :
+
+- **Cible inconnue** (`node_id` ou `region_id` absent du pipeline du Run — snapshot du Run, pas la bibliothèque) → `400` `{"error":"node '<id>' not found in pipeline"}` (resp. `region '<id>'`). La validation précède l'append du `CommandIssued` **et** la levée du `Halted` : une commande rejetée ne modifie pas l'event log.
+- **Mauvais mécanisme** (`extend_cycle` sur un membre de région bornée) → `409` `{"error":"node '<id>' is a member of loop region '<region>'; use bump_region with region_id '<region>'"}`.
+- **Valide mais sans effet immédiat** (itération encore vivante, région déjà complétée, throttle d'admission) → `200` `{"ok":true,"noop":true,"reason":"..."}` (même convention que `mark_node_done`).
+- **Effet réel** → `200` `{"ok":true,"spawned":[{"node_id":...,"iter":...}]}`.
 
 ### Ce que le manager ne peut **pas** faire
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "0.1.69"
+version = "0.1.70"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "0.1.69"
+version = "0.1.70"
 license = "MIT"
 
 [workspace.dependencies]

--- a/crates/pdo-daemon/src/event_log.rs
+++ b/crates/pdo-daemon/src/event_log.rs
@@ -2329,6 +2329,42 @@ mod tests {
     }
 
     #[test]
+    fn replayed_junk_extend_cycle_leaves_projection_identical() {
+        // ADR-0025 / #327 replay safety: validate-before-append means NEW logs
+        // never gain an extend_cycle for an unknown node, but OLD logs may
+        // already contain one. Its consumers are inert for unknown keys, so the
+        // projection must be identical with or without the junk command.
+        let base = vec![
+            make_event_with_payload(
+                EventKind::RunStarted,
+                None,
+                serde_json::json!({ "pipeline_name": "p" }),
+            ),
+            make_event(EventKind::NodeStarted, Some("worker"), Some(1)),
+            make_event(EventKind::NodeCompleted, Some("worker"), Some(1)),
+        ];
+        let mut with_junk = base.clone();
+        with_junk.insert(
+            2,
+            Event {
+                kind: EventKind::CommandIssued,
+                payload: Some(serde_json::json!({
+                    "command": "extend_cycle",
+                    "node_id": "no-such-node",
+                    "additional_iter": 3,
+                })),
+                ..make_event(EventKind::CommandIssued, None, None)
+            },
+        );
+        let clean = project(&base).unwrap();
+        let junked = project(&with_junk).unwrap();
+        assert_eq!(clean.status, junked.status);
+        assert_eq!(clean.nodes.len(), junked.nodes.len());
+        assert_eq!(clean.nodes["worker"].status, junked.nodes["worker"].status);
+        assert_eq!(clean.loop_states.len(), junked.loop_states.len());
+    }
+
+    #[test]
     fn command_issued_unknown_command_is_noop() {
         let events = vec![
             make_event_with_payload(

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -4076,12 +4076,32 @@ fn find_foreach_context(
     None
 }
 
+/// What actually happened in a `spawn_node` call (ADR-0025 / #327). Every exit
+/// path is distinguishable so callers that must tell the truth about a
+/// re-scheduling (`re_evaluate_after_command`) can report the real effect
+/// instead of assuming success. Callers on fire-and-forget paths simply drop it
+/// (intentionally not `#[must_use]`).
+#[derive(Debug, Clone)]
+enum SpawnOutcome {
+    /// A tmux session was launched and `NodeStarted` recorded.
+    Spawned,
+    /// Admission cap reached: the node entered `waiting` (`NodeWaiting`
+    /// appended); `retry_waiting_nodes` re-drives it later.
+    Throttled,
+    /// The transition guard refused the spawn before any side effect
+    /// (already live / already completed iteration).
+    Refused { reason: String },
+    /// The spawn aborted (empty script body, worktree creation failure,
+    /// panic/error in the isolated span) — a failure was recorded.
+    Failed { reason: String },
+}
+
 async fn spawn_node(
     state: &AppState,
     spawn_ctx: &SpawnContext<'_>,
     node: &pipeline::NodeDef,
     iter: i64,
-) {
+) -> SpawnOutcome {
     let run_id = spawn_ctx.run_id;
 
     // Transition guard (#212): refuse an illegal NodeStarted BEFORE any side
@@ -4103,7 +4123,7 @@ async fn spawn_node(
         transition_guard::Verdict::NoOp { reason }
         | transition_guard::Verdict::Reject { reason } => {
             warn!("spawn_node refused for {} iter {iter}: {reason}", node.id);
-            return;
+            return SpawnOutcome::Refused { reason };
         }
     }
 
@@ -4119,16 +4139,10 @@ async fn spawn_node(
             .map(|s| s.trim().is_empty())
             .unwrap_or(true);
         if body_empty {
-            fail_spawn_before_start(
-                state,
-                spawn_ctx.repo_root,
-                run_id,
-                &node.id,
-                None,
-                &format!("script node {} has an empty body", node.id),
-            )
-            .await;
-            return;
+            let reason = format!("script node {} has an empty body", node.id);
+            fail_spawn_before_start(state, spawn_ctx.repo_root, run_id, &node.id, None, &reason)
+                .await;
+            return SpawnOutcome::Failed { reason };
         }
     }
 
@@ -4160,7 +4174,7 @@ async fn spawn_node(
             "node {} throttled into waiting ({live}/{cap} sessions live)",
             node.id
         );
-        return;
+        return SpawnOutcome::Throttled;
     }
 
     let canonical_path = pipeline::canonical_prompt_path(spawn_ctx.pipeline_path, &node.id);
@@ -4187,7 +4201,9 @@ async fn spawn_node(
             &pipeline_branch,
         ) {
             error!("failed to create sub-worktree for {}: {e:#}", node.id);
-            return;
+            return SpawnOutcome::Failed {
+                reason: format!("failed to create sub-worktree for {}: {e:#}", node.id),
+            };
         }
         orphan_to_reap = Some((sub_wt_dir.clone(), sub_branch));
         sub_wt_dir
@@ -4346,32 +4362,34 @@ async fn spawn_node(
     let (full_prompt, script_env) = match span_outcome {
         Ok(Ok(pair)) => pair,
         Ok(Err(e)) => {
+            let reason = format!("spawn of node {} aborted before start: {e}", node.id);
             fail_spawn_before_start(
                 state,
                 spawn_ctx.repo_root,
                 run_id,
                 &node.id,
                 orphan_to_reap.as_ref(),
-                &format!("spawn of node {} aborted before start: {e}", node.id),
+                &reason,
             )
             .await;
-            return;
+            return SpawnOutcome::Failed { reason };
         }
         Err(panic) => {
+            let reason = format!(
+                "spawn of node {} panicked before start: {}",
+                node.id,
+                panic_payload_message(panic.as_ref())
+            );
             fail_spawn_before_start(
                 state,
                 spawn_ctx.repo_root,
                 run_id,
                 &node.id,
                 orphan_to_reap.as_ref(),
-                &format!(
-                    "spawn of node {} panicked before start: {}",
-                    node.id,
-                    panic_payload_message(panic.as_ref())
-                ),
+                &reason,
             )
             .await;
-            return;
+            return SpawnOutcome::Failed { reason };
         }
     };
 
@@ -4422,6 +4440,8 @@ async fn spawn_node(
             error!("failed to append node_awaiting_user: {e}");
         }
     }
+
+    SpawnOutcome::Spawned
 }
 
 /// Extract a human-readable message from a caught panic payload.
@@ -8328,6 +8348,59 @@ async fn run_command(
                     .into_response();
             }
 
+            // ADR-0025 / #327: validate the target against the run's pipeline
+            // SNAPSHOT before any event is appended — a rejected command must
+            // leave no trace in the log. Snapshot-first (`resolve_run_pipeline_path`)
+            // so a library edit after launch can't affect an in-flight run.
+            let events = match load_events(&state.db, &run_id).await {
+                Ok(e) => e,
+                Err(e) => {
+                    return (StatusCode::INTERNAL_SERVER_ERROR, format!("error: {e}"))
+                        .into_response();
+                }
+            };
+            let run_state = match event_log::project(&events) {
+                Some(s) => s,
+                None => {
+                    return (StatusCode::NOT_FOUND, "run not found").into_response();
+                }
+            };
+            let repo_root = effective_repo_root(&state, &run_state);
+            let pipeline_path =
+                resolve_run_pipeline_path(&repo_root, &run_id, &run_state.pipeline_name);
+            if let Some(pipeline) = std::fs::read_to_string(&pipeline_path)
+                .ok()
+                .and_then(|yaml| pipeline::parse_pipeline(&yaml).ok())
+                .map(|p| p.pipeline)
+            {
+                if !pipeline.nodes.iter().any(|n| n.id == node_id) {
+                    return (
+                        StatusCode::BAD_REQUEST,
+                        Json(serde_json::json!({
+                            "error": format!("node '{node_id}' not found in pipeline")
+                        })),
+                    )
+                        .into_response();
+                }
+                if let Some(region) = loop_region::bounded_region_for_member(&pipeline, &node_id) {
+                    return (
+                        StatusCode::CONFLICT,
+                        Json(serde_json::json!({
+                            "error": format!(
+                                "node '{node_id}' is a member of loop region '{}'; \
+                                 use bump_region with region_id '{}'",
+                                region.id, region.id
+                            )
+                        })),
+                    )
+                        .into_response();
+                }
+            } else {
+                // An unreadable/unparsable snapshot can't be validated against;
+                // stay permissive (legacy behavior) rather than reject blind.
+                warn!("extend_cycle: pipeline snapshot unreadable for run {run_id}; skipping target validation");
+            }
+
             let cmd_event = event_log::Event {
                 id: None,
                 run_id: run_id.clone(),
@@ -8344,20 +8417,6 @@ async fn run_command(
             if let Err(e) = append_event(&state, &cmd_event).await {
                 return (StatusCode::INTERNAL_SERVER_ERROR, format!("error: {e}")).into_response();
             }
-
-            let events = match load_events(&state.db, &run_id).await {
-                Ok(e) => e,
-                Err(e) => {
-                    return (StatusCode::INTERNAL_SERVER_ERROR, format!("error: {e}"))
-                        .into_response();
-                }
-            };
-            let run_state = match event_log::project(&events) {
-                Some(s) => s,
-                None => {
-                    return (StatusCode::NOT_FOUND, "run not found").into_response();
-                }
-            };
 
             if run_state.status == event_log::RunStatus::Halted
                 || run_state.status == event_log::RunStatus::Failed
@@ -8377,10 +8436,10 @@ async fn run_command(
             }
 
             // Re-evaluate outgoing edges with the extended cycle
-            re_evaluate_after_command(&state, &run_id).await;
+            let summary = re_evaluate_after_command(&state, &run_id).await;
 
             info!("extend_cycle: node {node_id} +{additional_iter} in run {run_id}");
-            (StatusCode::OK, Json(serde_json::json!({ "ok": true }))).into_response()
+            (StatusCode::OK, Json(summary.into_response_body())).into_response()
         }
         // The Pipeline Manager routes a loop region BY ID (ADR-0011 / #152):
         // `bump_region` runs N more iterations; `end_region` fires its
@@ -8427,6 +8486,46 @@ async fn run_command(
                 })
             };
 
+            // ADR-0025 / #327: validate the region against the run's pipeline
+            // SNAPSHOT before any event is appended — an unknown region_id must
+            // leave no trace in the log.
+            let events = match load_events(&state.db, &run_id).await {
+                Ok(e) => e,
+                Err(e) => {
+                    return (StatusCode::INTERNAL_SERVER_ERROR, format!("error: {e}"))
+                        .into_response();
+                }
+            };
+            let run_state = match event_log::project(&events) {
+                Some(s) => s,
+                None => {
+                    return (StatusCode::NOT_FOUND, "run not found").into_response();
+                }
+            };
+            let repo_root = effective_repo_root(&state, &run_state);
+            let pipeline_path =
+                resolve_run_pipeline_path(&repo_root, &run_id, &run_state.pipeline_name);
+            if let Some(pipeline) = std::fs::read_to_string(&pipeline_path)
+                .ok()
+                .and_then(|yaml| pipeline::parse_pipeline(&yaml).ok())
+                .map(|p| p.pipeline)
+            {
+                if !pipeline.loops.iter().any(|r| r.id == region_id) {
+                    return (
+                        StatusCode::BAD_REQUEST,
+                        Json(serde_json::json!({
+                            "error": format!("region '{region_id}' not found in pipeline")
+                        })),
+                    )
+                        .into_response();
+                }
+            } else {
+                warn!(
+                    "{}: pipeline snapshot unreadable for run {run_id}; skipping region validation",
+                    req.kind
+                );
+            }
+
             let cmd_event = event_log::Event {
                 id: None,
                 run_id: run_id.clone(),
@@ -8442,19 +8541,6 @@ async fn run_command(
 
             // Continue the run: an exhausted-unrouted region halts the run, so
             // lift the Halt/Failed back to Running before re-evaluating.
-            let events = match load_events(&state.db, &run_id).await {
-                Ok(e) => e,
-                Err(e) => {
-                    return (StatusCode::INTERNAL_SERVER_ERROR, format!("error: {e}"))
-                        .into_response();
-                }
-            };
-            let run_state = match event_log::project(&events) {
-                Some(s) => s,
-                None => {
-                    return (StatusCode::NOT_FOUND, "run not found").into_response();
-                }
-            };
             if run_state.status == event_log::RunStatus::Halted
                 || run_state.status == event_log::RunStatus::Failed
             {
@@ -8472,10 +8558,10 @@ async fn run_command(
                 }
             }
 
-            re_evaluate_after_command(&state, &run_id).await;
+            let summary = re_evaluate_after_command(&state, &run_id).await;
 
             info!("{}: region {region_id} in run {run_id}", req.kind);
-            (StatusCode::OK, Json(serde_json::json!({ "ok": true }))).into_response()
+            (StatusCode::OK, Json(summary.into_response_body())).into_response()
         }
         "pause_run" => {
             let events = match load_events(&state.db, &run_id).await {
@@ -8579,10 +8665,10 @@ async fn run_command(
                 &tmux_session_manager::shell_session_name(&run_id),
             );
 
-            re_evaluate_after_command(&state, &run_id).await;
+            let summary = re_evaluate_after_command(&state, &run_id).await;
 
             info!("resume_run: run {run_id}");
-            (StatusCode::OK, Json(serde_json::json!({ "ok": true }))).into_response()
+            (StatusCode::OK, Json(summary.into_response_body())).into_response()
         }
         "kill_node" => {
             let Some(node_id) = req.node_id else {
@@ -8964,20 +9050,88 @@ async fn run_command(
     }
 }
 
+/// The run reached a terminal state during a post-command re-evaluation
+/// (ADR-0025 / #327).
+#[derive(Debug, Clone)]
+enum ReEvalTerminal {
+    Completed,
+    Halted(String),
+}
+
+/// The real effect of a post-command re-evaluation (ADR-0025 / #327): which
+/// nodes were actually spawned, which candidate spawns were skipped (and why),
+/// and whether the run went terminal. Command handlers surface this in their
+/// response body instead of an unconditional `{ok:true}`.
+#[derive(Debug, Default)]
+struct ReEvalSummary {
+    /// `(node_id, iter)` pairs whose spawn genuinely launched a session.
+    spawned: Vec<(String, i64)>,
+    /// Human-readable reasons for candidate spawns that did NOT launch
+    /// (guard skips, throttling, spawn failures).
+    skipped: Vec<String>,
+    terminal: Option<ReEvalTerminal>,
+}
+
+impl ReEvalSummary {
+    fn record_spawn(&mut self, node_id: &str, iter: i64, outcome: SpawnOutcome) {
+        match outcome {
+            SpawnOutcome::Spawned => self.spawned.push((node_id.to_string(), iter)),
+            SpawnOutcome::Throttled => self.skipped.push(format!(
+                "node '{node_id}' iter {iter} throttled into waiting (session cap)"
+            )),
+            SpawnOutcome::Refused { reason } | SpawnOutcome::Failed { reason } => {
+                self.skipped.push(reason)
+            }
+        }
+    }
+
+    /// The truthful command-response body (ADR-0025). Spawns happened →
+    /// `{ok, spawned}`; nothing launched → `{ok, noop, reason}`.
+    fn into_response_body(self) -> serde_json::Value {
+        if !self.spawned.is_empty() {
+            let spawned: Vec<serde_json::Value> = self
+                .spawned
+                .into_iter()
+                .map(|(node_id, iter)| serde_json::json!({ "node_id": node_id, "iter": iter }))
+                .collect();
+            return serde_json::json!({ "ok": true, "spawned": spawned });
+        }
+        let reason = match &self.terminal {
+            Some(ReEvalTerminal::Completed) => "run completed".to_string(),
+            Some(ReEvalTerminal::Halted(msg)) => format!("run halted: {msg}"),
+            None => {
+                if self.skipped.is_empty() {
+                    "no eligible spawn".to_string()
+                } else {
+                    self.skipped.join("; ")
+                }
+            }
+        };
+        serde_json::json!({ "ok": true, "noop": true, "reason": reason })
+    }
+}
+
 /// Re-evaluate the scheduler after a command (resume_run, extend_cycle).
 /// Loads the pipeline and run state, resolves variables (including cycle extensions),
 /// then re-evaluates outgoing edges of all completed nodes to find newly ready spawns.
-async fn re_evaluate_after_command(state: &AppState, run_id: &str) {
+/// Returns what actually happened so command handlers can tell the truth
+/// (ADR-0025 / #327).
+async fn re_evaluate_after_command(state: &AppState, run_id: &str) -> ReEvalSummary {
+    let mut summary = ReEvalSummary::default();
     let events = match load_events(&state.db, run_id).await {
         Ok(e) => e,
         Err(e) => {
             error!("re_evaluate_after_command: failed to load events: {e}");
-            return;
+            summary.skipped.push(format!("failed to load events: {e}"));
+            return summary;
         }
     };
     let run_state = match event_log::project(&events) {
         Some(s) => s,
-        None => return,
+        None => {
+            summary.skipped.push("run not found".to_string());
+            return summary;
+        }
     };
 
     let repo_root = effective_repo_root(state, &run_state);
@@ -8990,10 +9144,12 @@ async fn re_evaluate_after_command(state: &AppState, run_id: &str) {
         }
     };
     let Ok(yaml) = std::fs::read_to_string(&pipeline_path) else {
-        return;
+        summary.skipped.push("pipeline file unreadable".to_string());
+        return summary;
     };
     let Ok(parse_result) = pipeline::parse_pipeline(&yaml) else {
-        return;
+        summary.skipped.push("pipeline failed to parse".to_string());
+        return summary;
     };
 
     let pipeline = parse_result.pipeline;
@@ -9090,8 +9246,10 @@ async fn re_evaluate_after_command(state: &AppState, run_id: &str) {
                         transition_guard::spawn_superfluous(&run_state, node_id, *iter)
                     {
                         info!("re_evaluate_after_command: skip spawn — {reason}");
+                        summary.skipped.push(reason);
                     } else if let Some(node) = pipeline.nodes.iter().find(|n| n.id == *node_id) {
-                        spawn_node(state, &spawn_ctx, node, *iter).await;
+                        let outcome = spawn_node(state, &spawn_ctx, node, *iter).await;
+                        summary.record_spawn(node_id, *iter, outcome);
                     }
                 }
                 scheduler::SchedulerAction::Halt { message } => {
@@ -9102,11 +9260,13 @@ async fn re_evaluate_after_command(state: &AppState, run_id: &str) {
                         Some(serde_json::json!({ "message": message })),
                     )
                     .await;
-                    return;
+                    summary.terminal = Some(ReEvalTerminal::Halted(message.clone()));
+                    return summary;
                 }
                 scheduler::SchedulerAction::Complete => {
                     emit_run_event(state, run_id, event_log::EventKind::RunCompleted, None).await;
-                    return;
+                    summary.terminal = Some(ReEvalTerminal::Completed);
+                    return summary;
                 }
                 scheduler::SchedulerAction::SwitchRouted {
                     node_id,
@@ -9150,7 +9310,7 @@ async fn re_evaluate_after_command(state: &AppState, run_id: &str) {
     // Pass 1 may have appended events; re-project so pass 2 sees fresh state
     // (same race fix as handle_node_completion).
     let Some((fresh_events, fresh_run_state)) = reload_run_state(state, run_id).await else {
-        return;
+        return summary;
     };
     let mut fresh_resolved_vars = resolve_run_variables(&pipeline, &fresh_events);
     for (ext_node_id, additional) in &extensions {
@@ -9193,13 +9353,16 @@ async fn re_evaluate_after_command(state: &AppState, run_id: &str) {
                         transition_guard::spawn_superfluous(&fresh_run_state, node_id, *iter)
                     {
                         info!("re_evaluate_after_command(loop): skip spawn — {reason}");
+                        summary.skipped.push(reason);
                     } else if let Some(node) = pipeline.nodes.iter().find(|n| n.id == *node_id) {
-                        spawn_node(state, &fresh_spawn_ctx, node, *iter).await;
+                        let outcome = spawn_node(state, &fresh_spawn_ctx, node, *iter).await;
+                        summary.record_spawn(node_id, *iter, outcome);
                     }
                 }
                 scheduler::SchedulerAction::Complete => {
                     emit_run_event(state, run_id, event_log::EventKind::RunCompleted, None).await;
-                    return;
+                    summary.terminal = Some(ReEvalTerminal::Completed);
+                    return summary;
                 }
                 _ => emit_loop_action(state, run_id, action).await,
             }
@@ -9225,18 +9388,23 @@ async fn re_evaluate_after_command(state: &AppState, run_id: &str) {
                         transition_guard::spawn_superfluous(&fresh_run_state, node_id, *iter)
                     {
                         info!("re_evaluate_after_command(foreach): skip spawn — {reason}");
+                        summary.skipped.push(reason);
                     } else if let Some(node) = pipeline.nodes.iter().find(|n| n.id == *node_id) {
-                        spawn_node(state, &fresh_spawn_ctx, node, *iter).await;
+                        let outcome = spawn_node(state, &fresh_spawn_ctx, node, *iter).await;
+                        summary.record_spawn(node_id, *iter, outcome);
                     }
                 }
                 scheduler::SchedulerAction::Complete => {
                     emit_run_event(state, run_id, event_log::EventKind::RunCompleted, None).await;
-                    return;
+                    summary.terminal = Some(ReEvalTerminal::Completed);
+                    return summary;
                 }
                 _ => emit_foreach_action(state, run_id, action).await,
             }
         }
     }
+
+    summary
 }
 
 /// Extract variable references ($name) from when clauses on Switch output ports

--- a/crates/pdo-daemon/src/loop_region.rs
+++ b/crates/pdo-daemon/src/loop_region.rs
@@ -180,6 +180,21 @@ pub fn resolve_region_max_iter(
     }
 }
 
+/// The bounded region `node_id` is a member of, if any (ADR-0025 / #327).
+/// Membership means the node's iteration is governed by the region engine —
+/// `bump_region` is the right lever for it, never `extend_cycle`. The head /
+/// entry node of a region is a member like any other. Returns the first
+/// matching `bounded` region.
+pub fn bounded_region_for_member<'a>(
+    pipeline: &'a PipelineDef,
+    node_id: &str,
+) -> Option<&'a LoopRegion> {
+    pipeline
+        .loops
+        .iter()
+        .find(|r| r.kind == LoopKind::Bounded && r.members.iter().any(|m| m == node_id))
+}
+
 /// The bounded region a `node_id` is an entry of, *and* the given edge re-enters
 /// (ADR-0011 / #148). Used by the scheduler to recognise that a fired edge into
 /// `target` is a region re-entry (back-edge) rather than a plain forward edge, so

--- a/crates/pdo-daemon/src/prompt_augmenter.rs
+++ b/crates/pdo-daemon/src/prompt_augmenter.rs
@@ -566,17 +566,31 @@ You manage **run `{run_id}`**.
 
 All commands are issued via `POST {daemon_url}/runs/{run_id}/commands` with a JSON body.
 
-### 1. extend_cycle
+### 1. bump_region
 
-Increment the iteration ceiling for a cycle and re-evaluate outgoing conditions.
+Grant a bounded loop region N more iterations and re-evaluate. This is THE lever for any node that belongs to a loop region — never `extend_cycle`.
 
 ```bash
 curl -X POST {daemon_url}/runs/{run_id}/commands \
   -H 'Content-Type: application/json' \
-  -d '{{"kind":"extend_cycle","node_id":"<node-id>","additional_iter":<N>}}'
+  -d '{{"kind":"bump_region","region_id":"<region-id>","additional_iter":<N>}}'
 ```
 
-### 2. resume_run
+**Finding the `region_id`:** it is a key of `loop_states` in `curl {daemon_url}/runs/{run_id}` (the `loop_node_id` of `loop_iter_started` events). Caveat: a region still on its first lap has **no** `loop_states` entry yet — read the pipeline definition's `loops:` block in that case. An unknown `region_id` is rejected with 400 before anything is recorded.
+
+The response tells you what actually happened: `{{"ok":true,"spawned":[…]}}` when nodes were re-launched, or `{{"ok":true,"noop":true,"reason":"…"}}` when nothing was eligible yet (e.g. the region's current iteration is still running — the extra laps then apply when it finishes).
+
+### 2. end_region
+
+Fire a bounded loop region's completion now (route its exit) instead of running more laps. Same `region_id` discovery and same truthful response body as `bump_region`.
+
+```bash
+curl -X POST {daemon_url}/runs/{run_id}/commands \
+  -H 'Content-Type: application/json' \
+  -d '{{"kind":"end_region","region_id":"<region-id>"}}'
+```
+
+### 3. resume_run
 
 Re-run the scheduler from the current state. Use after a manual conflict resolution or after extending a cycle on a halted run.
 
@@ -586,7 +600,7 @@ curl -X POST {daemon_url}/runs/{run_id}/commands \
   -d '{{"kind":"resume_run"}}'
 ```
 
-### 3. kill_node
+### 4. kill_node
 
 Kill a running NodeRun's tmux session and emit `node_failed`.
 
@@ -596,7 +610,7 @@ curl -X POST {daemon_url}/runs/{run_id}/commands \
   -d '{{"kind":"kill_node","node_id":"<node-id>","iter":<N>}}'
 ```
 
-### 4. restart_node
+### 5. restart_node
 
 Kill a NodeRun and re-spawn it fresh (same iter, new session).
 
@@ -606,7 +620,7 @@ curl -X POST {daemon_url}/runs/{run_id}/commands \
   -d '{{"kind":"restart_node","node_id":"<node-id>","iter":<N>}}'
 ```
 
-### 5. mark_node_done
+### 6. mark_node_done
 
 Force-complete a NodeRun (typically an interactive node the user has finished with).
 
@@ -616,7 +630,7 @@ curl -X POST {daemon_url}/runs/{run_id}/commands \
   -d '{{"kind":"mark_node_done","node_id":"<node-id>","iter":<N>}}'
 ```
 
-### 6. inject_artifact
+### 7. inject_artifact
 
 Write an artifact directly into the Blackboard.
 
@@ -626,7 +640,7 @@ curl -X POST {daemon_url}/runs/{run_id}/commands \
   -d '{{"kind":"inject_artifact","path":"<node-id>/iter-<N>/<port>/output.md","content":"<markdown content>"}}'
 ```
 
-### 7. cleanup_run
+### 8. cleanup_run
 
 Archive the run: remove worktrees, branches, and artifacts from disk. Events are preserved.
 
@@ -638,7 +652,7 @@ curl -X POST {daemon_url}/runs/{run_id}/commands \
 
 **Never call `cleanup_run` on your own initiative.** It is destructive and irreversible: it kills every active node session and removes the run's worktrees, branches, and artifacts from disk. Always check with the user first and wait for explicit confirmation before issuing it — even if you believe the run is stuck or finished.
 
-### 8. rename_run
+### 9. rename_run
 
 Set or update the display name of this run.
 
@@ -648,7 +662,7 @@ curl -X POST {daemon_url}/runs/{run_id}/commands \
   -d '{{"kind":"rename_run","name":"<display name>"}}'
 ```
 
-### 9. start_node
+### 10. start_node
 
 Force-spawn a node now, without waiting for its upstream producers to complete. Use when you deliberately want to start a node ahead of its dependencies. Inputs resolve best-effort: any not-yet-produced upstream artifact resolves to the path where it *will* appear, so the node may run against missing or stale inputs. This is reversible — `restart_node` or `kill_node` it if it ran too early.
 
@@ -656,6 +670,16 @@ Force-spawn a node now, without waiting for its upstream producers to complete. 
 curl -X POST {daemon_url}/runs/{run_id}/commands \
   -H 'Content-Type: application/json' \
   -d '{{"kind":"start_node","node_id":"<node-id>"}}'
+```
+
+### 11. extend_cycle (legacy)
+
+Increment the iteration ceiling of a *legacy drawn cycle* (a pipeline without a `loops:` block) and re-evaluate. `node_id` is the node whose **outgoing exit condition** references the `$max_iter`-style variable to bump — never the cycle's head/entry node. For any node that belongs to a bounded loop region this command is rejected with 409 — use `bump_region` instead. An unknown `node_id` is rejected with 400. Same truthful response body as `bump_region`.
+
+```bash
+curl -X POST {daemon_url}/runs/{run_id}/commands \
+  -H 'Content-Type: application/json' \
+  -d '{{"kind":"extend_cycle","node_id":"<node-id>","additional_iter":<N>}}'
 ```
 
 ---
@@ -1437,10 +1461,12 @@ mod tests {
     }
 
     #[test]
-    fn manager_preamble_contains_all_eight_commands() {
+    fn manager_preamble_contains_all_commands() {
         let preamble =
             build_manager_preamble("run-1", "http://localhost:5172", RunNameHint::UserProvided);
         for cmd in [
+            "bump_region",
+            "end_region",
             "extend_cycle",
             "resume_run",
             "kill_node",
@@ -1449,6 +1475,7 @@ mod tests {
             "inject_artifact",
             "cleanup_run",
             "rename_run",
+            "start_node",
         ] {
             assert!(
                 preamble.contains(cmd),
@@ -1512,17 +1539,46 @@ mod tests {
     fn manager_preamble_cleanup_run_has_self_initiative_guardrail() {
         let preamble =
             build_manager_preamble("run-1", "http://localhost:5172", RunNameHint::UserProvided);
-        let section7 = preamble
-            .split("### 7. cleanup_run")
+        let section = preamble
+            .split("### 8. cleanup_run")
             .nth(1)
             .expect("preamble should contain the cleanup_run section")
-            .split("### 8.")
+            .split("### 9.")
             .next()
-            .expect("cleanup_run section should be delimited by section 8");
+            .expect("cleanup_run section should be delimited by section 9");
         assert!(
-            section7.contains("Never call `cleanup_run` on your own initiative"),
-            "section 7 should carry the self-initiative guardrail, got: {section7}"
+            preamble.contains("### 9. rename_run"),
+            "renumbering drifted: section 9 should be rename_run"
         );
+        assert!(
+            section.contains("Never call `cleanup_run` on your own initiative"),
+            "cleanup_run section should carry the self-initiative guardrail, got: {section}"
+        );
+    }
+
+    #[test]
+    fn manager_preamble_region_commands_lead_and_extend_cycle_is_legacy() {
+        // ADR-0025 / #327: bump_region/end_region are the primary loop levers
+        // (sections 1-2, with the region_id discovery recipe + lap-1 caveat);
+        // extend_cycle is demoted to a legacy section with explicit target
+        // semantics.
+        let preamble =
+            build_manager_preamble("run-1", "http://localhost:5172", RunNameHint::UserProvided);
+        assert!(preamble.contains("### 1. bump_region"));
+        assert!(preamble.contains("### 2. end_region"));
+        assert!(preamble.contains("extend_cycle (legacy)"));
+        let bump = preamble.find("### 1. bump_region").unwrap();
+        let legacy = preamble.find("extend_cycle (legacy)").unwrap();
+        assert!(bump < legacy, "bump_region must come before extend_cycle");
+        // region_id discovery recipe + first-lap caveat
+        assert!(preamble.contains("loop_states"));
+        assert!(preamble.contains("first lap"));
+        // legacy target semantics: exit-condition node, never the head
+        assert!(preamble.contains("never the cycle's head/entry node"));
+        assert!(preamble.contains("rejected with 409"));
+        // truthful response contract (ADR-0025) is documented
+        assert!(preamble.contains("\"noop\":true"));
+        assert!(preamble.contains("\"spawned\""));
     }
 
     // --- image port type preamble tests ---

--- a/crates/pdo-daemon/src/scheduler.rs
+++ b/crates/pdo-daemon/src/scheduler.rs
@@ -562,9 +562,7 @@ fn forward_spawn_iter(
         }
     };
 
-    let member_region = pipeline.loops.iter().find(|r| {
-        r.kind == crate::pipeline::LoopKind::Bounded && r.members.iter().any(|m| m == target_id)
-    });
+    let member_region = crate::loop_region::bounded_region_for_member(pipeline, target_id);
     if let Some(region) = member_region {
         let max = crate::loop_region::resolve_region_max_iter(region, resolved_vars);
         if proposed > max {

--- a/crates/pdo-daemon/tests/loop_command_truth.rs
+++ b/crates/pdo-daemon/tests/loop_command_truth.rs
@@ -1,0 +1,355 @@
+//! Layer 3a — ADR-0025 / #327: `extend_cycle`, `bump_region`, `end_region` and
+//! `resume_run` tell the truth. Validation happens against the run's pipeline
+//! snapshot BEFORE any event is appended (a rejected command leaves no trace in
+//! the event log), and the 200 body reports the re-scheduling's real effect
+//! (`{ok,spawned:[…]}` or `{ok,noop:true,reason}`), never a blind `{ok:true}`.
+
+mod common;
+
+use std::process::Command;
+
+use common::TestDaemon;
+
+const LOOP_PIPELINE_NAME: &str = "loop-truth-test";
+const LOOP_PIPELINE_YAML: &str = r#"name: loop-truth-test
+version: "1.0"
+nodes:
+  - id: start
+    name: Start
+    type: start
+    outputs:
+      - name: user_prompt
+  - id: worker
+    name: worker
+    type: doc-only
+    inputs:
+      - name: task
+    outputs:
+      - name: result
+  - id: end
+    name: End
+    type: end
+    inputs:
+      - name: result
+edges:
+  - source: { node: start, port: user_prompt }
+    target: { node: worker, port: task }
+  - source: { node: worker, port: result }
+    target: { node: worker, port: task }
+  - source: { node: worker, port: result }
+    target: { node: end, port: result }
+    when: "iter >= max"
+loops:
+  - id: review_loop
+    kind: bounded
+    members: [worker]
+    max_iter: 3
+"#;
+
+const LEGACY_PIPELINE_NAME: &str = "legacy-truth-test";
+const LEGACY_PIPELINE_YAML: &str = r#"name: legacy-truth-test
+version: "1.0"
+nodes:
+  - id: start
+    name: Start
+    type: start
+    outputs:
+      - name: user_prompt
+  - id: planner
+    name: planner
+    type: doc-only
+    inputs:
+      - name: task
+    outputs:
+      - name: plan
+  - id: end
+    name: End
+    type: end
+    inputs:
+      - name: result
+edges:
+  - source: { node: start, port: user_prompt }
+    target: { node: planner, port: task }
+"#;
+
+fn seed(repo: &std::path::Path) -> anyhow::Result<()> {
+    let pipelines_dir = repo.join(".pdo").join("pipelines");
+    std::fs::create_dir_all(&pipelines_dir)?;
+    for (name, yaml, prompt_node) in [
+        (LOOP_PIPELINE_NAME, LOOP_PIPELINE_YAML, "worker"),
+        (LEGACY_PIPELINE_NAME, LEGACY_PIPELINE_YAML, "planner"),
+    ] {
+        std::fs::write(pipelines_dir.join(format!("{name}.yaml")), yaml)?;
+        let prompts_dir = pipelines_dir.join(format!("{name}.prompts"));
+        std::fs::create_dir_all(&prompts_dir)?;
+        std::fs::write(
+            prompts_dir.join(format!("{prompt_node}.md")),
+            "You are a test node.\n",
+        )?;
+    }
+    git_init_with_commit(repo)?;
+    Ok(())
+}
+
+fn git_init_with_commit(repo: &std::path::Path) -> anyhow::Result<()> {
+    let run = |args: &[&str]| -> anyhow::Result<()> {
+        let out = Command::new("git").args(args).current_dir(repo).output()?;
+        if !out.status.success() {
+            anyhow::bail!(
+                "git {} failed: {}",
+                args.join(" "),
+                String::from_utf8_lossy(&out.stderr)
+            );
+        }
+        Ok(())
+    };
+    run(&["init", "-b", "main"])?;
+    run(&["config", "user.email", "test@test.com"])?;
+    run(&["config", "user.name", "Test"])?;
+    std::fs::write(repo.join("README.md"), "test")?;
+    run(&["add", "."])?;
+    run(&["commit", "-m", "init"])?;
+    Ok(())
+}
+
+async fn create_run(daemon_url: &str, pipeline: &str) -> String {
+    let body = serde_json::json!({
+        "pipeline": pipeline,
+        "input": "test input",
+        "variables": {}
+    });
+    let resp = reqwest::Client::new()
+        .post(format!("{daemon_url}/runs"))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    let status = resp.status();
+    let text = resp.text().await.unwrap_or_default();
+    assert_eq!(status, 201, "POST /runs should succeed, got body: {text}");
+    let json: serde_json::Value = serde_json::from_str(&text).unwrap();
+    json["run_id"].as_str().unwrap().to_string()
+}
+
+async fn post_command(
+    daemon_url: &str,
+    run_id: &str,
+    body: serde_json::Value,
+) -> (reqwest::StatusCode, serde_json::Value) {
+    let resp = reqwest::Client::new()
+        .post(format!("{daemon_url}/runs/{run_id}/commands"))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    let status = resp.status();
+    let text = resp.text().await.unwrap_or_default();
+    let json: serde_json::Value = serde_json::from_str(&text).unwrap_or(serde_json::Value::Null);
+    (status, json)
+}
+
+/// The run's `command_issued` events matching a given `command` payload.
+async fn command_events(daemon_url: &str, run_id: &str, command: &str) -> Vec<serde_json::Value> {
+    let resp = reqwest::Client::new()
+        .get(format!("{daemon_url}/runs/{run_id}/events"))
+        .send()
+        .await
+        .unwrap();
+    let json: serde_json::Value = resp.json().await.unwrap();
+    json.as_array()
+        .cloned()
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|e| e["kind"] == "command_issued" && e["payload"]["command"] == command)
+        .collect()
+}
+
+#[tokio::test]
+async fn extend_cycle_unknown_node_is_400_and_leaves_no_trace() {
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+    let run_id = create_run(&daemon.url(), LEGACY_PIPELINE_NAME).await;
+
+    let (status, body) = post_command(
+        &daemon.url(),
+        &run_id,
+        serde_json::json!({ "kind": "extend_cycle", "node_id": "ghost", "additional_iter": 2 }),
+    )
+    .await;
+
+    assert_eq!(status, 400, "unknown node must be rejected, got {body}");
+    assert_eq!(
+        body["error"], "node 'ghost' not found in pipeline",
+        "message follows the start_node precedent"
+    );
+    // A rejection leaves NO trace: neither the extend_cycle CommandIssued nor
+    // a resume_run lift may have been appended.
+    assert!(
+        command_events(&daemon.url(), &run_id, "extend_cycle")
+            .await
+            .is_empty(),
+        "rejected extend_cycle must not append a CommandIssued"
+    );
+    assert!(
+        command_events(&daemon.url(), &run_id, "resume_run")
+            .await
+            .is_empty(),
+        "rejected extend_cycle must not lift a Halt"
+    );
+}
+
+#[tokio::test]
+async fn extend_cycle_on_region_member_is_409_naming_the_region() {
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+    let run_id = create_run(&daemon.url(), LOOP_PIPELINE_NAME).await;
+
+    // `worker` is both a member AND the entry/head of `review_loop` — the head
+    // is a member like any other, so it must be 409 too (grilling decision 1).
+    let (status, body) = post_command(
+        &daemon.url(),
+        &run_id,
+        serde_json::json!({ "kind": "extend_cycle", "node_id": "worker", "additional_iter": 2 }),
+    )
+    .await;
+
+    assert_eq!(status, 409, "region member must be rejected, got {body}");
+    let msg = body["error"].as_str().unwrap_or_default();
+    assert!(
+        msg.contains("'review_loop'") && msg.contains("bump_region"),
+        "409 must name the region and redirect to bump_region, got: {msg}"
+    );
+    assert!(
+        command_events(&daemon.url(), &run_id, "extend_cycle")
+            .await
+            .is_empty(),
+        "rejected extend_cycle must not append a CommandIssued"
+    );
+}
+
+#[tokio::test]
+async fn extend_cycle_on_legacy_pipeline_is_200_with_truthful_body() {
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+    let run_id = create_run(&daemon.url(), LEGACY_PIPELINE_NAME).await;
+
+    // No `loops:` block → legacy cycles keep working through extend_cycle.
+    let (status, body) = post_command(
+        &daemon.url(),
+        &run_id,
+        serde_json::json!({ "kind": "extend_cycle", "node_id": "planner", "additional_iter": 2 }),
+    )
+    .await;
+
+    assert_eq!(
+        status, 200,
+        "legacy extend_cycle must stay accepted: {body}"
+    );
+    assert_eq!(body["ok"], true);
+    // Truthful body: either something spawned, or an explicit noop with reason —
+    // never a bare `{ok:true}`.
+    let truthful =
+        body["spawned"].is_array() || (body["noop"] == true && body["reason"].is_string());
+    assert!(truthful, "body must report the real effect, got: {body}");
+    // And the command IS recorded this time.
+    assert_eq!(
+        command_events(&daemon.url(), &run_id, "extend_cycle")
+            .await
+            .len(),
+        1,
+        "accepted extend_cycle must append its CommandIssued"
+    );
+}
+
+#[tokio::test]
+async fn bump_region_unknown_region_is_400_and_leaves_no_trace() {
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+    let run_id = create_run(&daemon.url(), LOOP_PIPELINE_NAME).await;
+
+    let (status, body) = post_command(
+        &daemon.url(),
+        &run_id,
+        serde_json::json!({ "kind": "bump_region", "region_id": "ghost", "additional_iter": 2 }),
+    )
+    .await;
+
+    assert_eq!(status, 400, "unknown region must be rejected, got {body}");
+    assert_eq!(body["error"], "region 'ghost' not found in pipeline");
+    assert!(
+        command_events(&daemon.url(), &run_id, "bump_region")
+            .await
+            .is_empty(),
+        "rejected bump_region must not append a CommandIssued"
+    );
+}
+
+#[tokio::test]
+async fn end_region_unknown_region_is_400() {
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+    let run_id = create_run(&daemon.url(), LOOP_PIPELINE_NAME).await;
+
+    let (status, body) = post_command(
+        &daemon.url(),
+        &run_id,
+        serde_json::json!({ "kind": "end_region", "region_id": "ghost" }),
+    )
+    .await;
+
+    assert_eq!(status, 400, "unknown region must be rejected, got {body}");
+    assert_eq!(body["error"], "region 'ghost' not found in pipeline");
+    assert!(
+        command_events(&daemon.url(), &run_id, "end_region")
+            .await
+            .is_empty(),
+        "rejected end_region must not append a CommandIssued"
+    );
+}
+
+#[tokio::test]
+async fn bump_region_with_live_iteration_is_noop_with_reason() {
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+    let run_id = create_run(&daemon.url(), LOOP_PIPELINE_NAME).await;
+
+    // `worker` iter 1 is live (the harmless sleep session): nothing is eligible
+    // to re-spawn, so the truthful body is an explicit noop with a reason.
+    let (status, body) = post_command(
+        &daemon.url(),
+        &run_id,
+        serde_json::json!({ "kind": "bump_region", "region_id": "review_loop", "additional_iter": 2 }),
+    )
+    .await;
+
+    assert_eq!(status, 200, "valid bump_region must be accepted: {body}");
+    assert_eq!(body["ok"], true);
+    assert_eq!(
+        body["noop"], true,
+        "no spawn is possible while the lap is live, got: {body}"
+    );
+    assert!(
+        body["reason"].as_str().is_some_and(|r| !r.is_empty()),
+        "noop must carry a non-empty reason, got: {body}"
+    );
+    // The command IS recorded (it applies when the lap finishes).
+    assert_eq!(
+        command_events(&daemon.url(), &run_id, "bump_region")
+            .await
+            .len(),
+        1
+    );
+}
+
+#[tokio::test]
+async fn resume_run_reports_noop_when_nothing_to_spawn() {
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+    let run_id = create_run(&daemon.url(), LEGACY_PIPELINE_NAME).await;
+
+    let (status, body) = post_command(
+        &daemon.url(),
+        &run_id,
+        serde_json::json!({ "kind": "resume_run" }),
+    )
+    .await;
+
+    assert_eq!(status, 200, "resume_run stays accepted: {body}");
+    assert_eq!(body["ok"], true);
+    let truthful =
+        body["spawned"].is_array() || (body["noop"] == true && body["reason"].is_string());
+    assert!(truthful, "body must report the real effect, got: {body}");
+}

--- a/docs/adr/0025-truthful-loop-command-responses.md
+++ b/docs/adr/0025-truthful-loop-command-responses.md
@@ -1,0 +1,48 @@
+# ADR-0025 — Réponses véridiques des commandes de boucle (extend_cycle / bump_region / end_region / resume_run)
+
+Date : 2026-07-11 · Statut : accepté · Issue : #327
+
+## Contexte
+
+`extend_cycle` répondait `{ok:true}` inconditionnellement : node_id inconnu, membre d'une
+région bornée (mauvais mécanisme), ou itération encore vivante — dans tous les cas le
+handler appendait le `CommandIssued`, levait le `Halted`, relançait `re_evaluate_after_command`
+(qui retourne `()`) et affirmait le succès. `bump_region`/`end_region` avaient le même défaut
+pour un `region_id` inconnu. Résultat : boucles bornées non pilotables, Pipeline Manager
+trompé par ses propres commandes.
+
+L'issue proposait aussi de **déléguer** : résoudre tout membre de région vers la région et
+appliquer un `bump_region` implicite. Refusé après investigation : les deux commandes bumpent
+des cibles différentes, enregistrées comme événements différents, lus par des projections
+différentes (`collect_cycle_extensions` clé-nœud vs `collect_region_routes` clé-région), et un
+nœud à double rôle (membre de région portant sa propre arête `$var`) rend l'intention ambiguë.
+
+## Décision
+
+1. **Rejeter, pas déléguer.** `extend_cycle` sur un membre d'une région bornée → `409` nommant
+   la région (message actionnable : « use bump_region with region_id '<region>' »). Le
+   prédicat d'appartenance est le même que celui du scheduler (`loops` bornées, `members`
+   contient le nœud), extrait en helper partagé. La tête/entrée de région est un membre comme
+   un autre → `409` aussi. Les pipelines legacy (`loops:` vide) ne changent pas.
+2. **Valider avant d'écrire.** Cible inconnue → `400` avant l'append du `CommandIssued` et
+   avant la levée du `Halted`. Source de vérité = snapshot pipeline du Run
+   (`resolve_run_pipeline_path`), pas la bibliothèque. Sans risque de replay : les collecteurs
+   tolèrent déjà les clés inconnues, les vieux logs projettent à l'identique.
+3. **Dire l'effet.** `spawn_node` retourne un `SpawnOutcome`
+   (Spawned/Throttled/Refused/Failed), `re_evaluate_after_command` agrège un `ReEvalSummary`.
+   Les handlers répondent `{"ok":true,"spawned":[...]}` si effet, ou
+   `{"ok":true,"noop":true,"reason":...}` sinon (convention `mark_node_done`). Décision
+   synchrone : le détachement ADR-0023 ne couvre que la queue de `node_done`, pas ce chemin.
+4. **Documenter le pilotage de région.** Le préambule du manager gagne `bump_region`/`end_region`
+   en section 1 (recette de découverte du region_id : clés de `loop_states` dans
+   `GET /runs/{id}`, `loop_node_id` des `LoopIterStarted` ; une région au lap 1 n'a pas encore
+   d'entrée `loop_states`) ; `extend_cycle` est rétrogradé legacy avec sa sémantique de cible
+   explicite (nœud de condition de sortie, jamais la tête).
+
+## Conséquences
+
+- Nouveau statut `400`/`409` visible des clients ; le frontend ne parse pas ces corps
+  aujourd'hui (throw générique sur non-2xx) — pas de casse, enrichissement possible ensuite.
+- Un nœud à double rôle est poussé vers `bump_region` : le compteur de région est la borne
+  autoritaire pour tout ce qui est dans la région (évite le double-bump d'un même lap).
+- `resume_run` n'a pas d'identifiant cible : il n'a que le volet « dire l'effet » (noop/spawned).

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -470,13 +470,24 @@ export async function pauseRun(runId: string): Promise<void> {
   if (!resp.ok) throw new Error(`pause_run failed: ${resp.status}`);
 }
 
+/** Extract the daemon's `{"error": "..."}` body message, if any (ADR-0025). */
+async function errorBodyMessage(resp: Response): Promise<string> {
+  try {
+    const body = await resp.json();
+    if (body && typeof body.error === "string") return `: ${body.error}`;
+  } catch {
+    // non-JSON body — fall through to the status-only message
+  }
+  return "";
+}
+
 export async function resumeRun(runId: string): Promise<void> {
   const resp = await fetch(`${BASE}/runs/${encodeURIComponent(runId)}/commands`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ kind: "resume_run" }),
   });
-  if (!resp.ok) throw new Error(`resume_run failed: ${resp.status}`);
+  if (!resp.ok) throw new Error(`resume_run failed: ${resp.status}${await errorBodyMessage(resp)}`);
 }
 
 /**
@@ -490,7 +501,7 @@ export async function endRegion(runId: string, regionId: string): Promise<void> 
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ kind: "end_region", region_id: regionId }),
   });
-  if (!resp.ok) throw new Error(`end_region failed: ${resp.status}`);
+  if (!resp.ok) throw new Error(`end_region failed: ${resp.status}${await errorBodyMessage(resp)}`);
 }
 
 /**
@@ -512,7 +523,7 @@ export async function bumpRegion(
       additional_iter: additionalIter,
     }),
   });
-  if (!resp.ok) throw new Error(`bump_region failed: ${resp.status}`);
+  if (!resp.ok) throw new Error(`bump_region failed: ${resp.status}${await errorBodyMessage(resp)}`);
 }
 
 export async function retryAll(runId: string): Promise<CreateRunResponse> {


### PR DESCRIPTION
Closes #327.

Implements ADR-0025: loop commands (`extend_cycle`, `bump_region`, `end_region`, `resume_run`) now tell the truth.

- Invalid commands are **rejected** (400 unknown node/region, 409 extend_cycle on a bounded-loop member, naming the region and redirecting to `bump_region`) with **no event-log trace**.
- Accepted commands report their real effect: `{ok, spawned}` or `{ok, noop, reason}` — never a bare `{ok:true}` again.
- Manager preamble promotes `bump_region`/`end_region` (section 1-2) and demotes `extend_cycle` to legacy.
- Validation: FP-327 agentic run PASS on isolated stack (daemon :6207), 7/7 dedicated integration tests (`loop_command_truth`), legacy pipelines regression-checked, zero console errors in UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)