### PR TITLE
feat(#339): per-source delete (×) on pooled inputs in the node inspector — v0.1.75

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "0.1.74"
+version = "0.1.75"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "0.1.74"
+version = "0.1.75"
 license = "MIT"
 
 [workspace.dependencies]

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -390,6 +390,7 @@ export default function App() {
         <NodeInspector
           libraryEntries={libraryEntries}
           onLibraryChanged={refreshLibrary}
+          readOnly={isActiveRunArchived}
         />
       );
     }
@@ -694,6 +695,7 @@ export default function App() {
                   <NodeInspector
                     libraryEntries={libraryEntries}
                     onLibraryChanged={refreshLibrary}
+                    readOnly={isActiveRunArchived}
                   />
                 ) : selection.kind === "edge" ? (
                   <EdgeDetailPanel trigger={edgeTrigger} />

--- a/frontend/src/components/NodeInspector.test.tsx
+++ b/frontend/src/components/NodeInspector.test.tsx
@@ -267,6 +267,116 @@ describe("NodeInspector — per-node model field (#296/#324)", () => {
   });
 });
 
+// #339: self-feeding node — the self-edge pools as an input source even though
+// no edge is clickable on the canvas; its auto-materialized bounded region makes
+// the × go through the destroy-loop confirmation.
+function seedSelfFeedPipeline() {
+  useEditStore.setState({
+    openTabs: [
+      {
+        id: "p1",
+        scope: "repo",
+        pipeline: {
+          name: "p1",
+          version: "1.0",
+          variables: {},
+          nodes: [
+            {
+              id: "cc1",
+              name: "cycler",
+              type: "doc-only",
+              interactive: false,
+              inputs: [],
+              outputs: [{ name: "in", repeated: false, side: "right" }],
+              view: { x: 0, y: 0 },
+            },
+          ],
+          edges: [
+            { source: { node: "cc1", port: "in" }, target: { node: "cc1", port: "in" } },
+          ],
+          loops: [{ id: "self_loop", kind: "bounded", members: ["cc1"], max_iter: 3 }],
+        },
+        prompts: { cc1: "Loop." },
+        diagnostics: [],
+        dirty: false,
+        externalDirty: false,
+      },
+    ],
+    activeTabId: "p1",
+    selection: { kind: "node", id: "cc1" },
+  });
+}
+
+describe("NodeInspector — per-source input delete (#339)", () => {
+  it("deletes a non-cycle edge immediately and keeps the panel open on the node", () => {
+    seedPooledReviewPipeline();
+    renderInspector({ libraryEntries: [], onLibraryChanged: () => {} });
+
+    fireEvent.click(screen.getByTestId("pooled-input-review-delete-sec"));
+
+    const state = useEditStore.getState();
+    // The sec → impl edge is gone; perf → impl survives.
+    expect(state.openTabs[0].pipeline.edges).toEqual([
+      { source: { node: "perf", port: "review" }, target: { node: "impl", port: "review" } },
+    ]);
+    // Selection kept → the inspector does not self-close.
+    expect(state.selection).toEqual({ kind: "node", id: "impl" });
+    expect(screen.getByTestId("pooled-input-review")).toBeInTheDocument();
+    expect(screen.queryByTestId("destroy-loop-confirm")).toBeNull();
+  });
+
+  it("indices stay correct after a prior delete (re-derived each render)", () => {
+    seedPooledReviewPipeline();
+    renderInspector({ libraryEntries: [], onLibraryChanged: () => {} });
+
+    fireEvent.click(screen.getByTestId("pooled-input-review-delete-sec"));
+    // After the first delete the perf edge shifted to index 0 — the re-derived
+    // × must delete IT, not a stale index.
+    fireEvent.click(screen.getByTestId("pooled-input-review-delete-perf"));
+
+    expect(useEditStore.getState().openTabs[0].pipeline.edges).toHaveLength(0);
+    expect(useEditStore.getState().selection).toEqual({ kind: "node", id: "impl" });
+  });
+
+  it("self-edge (last cycle): × opens DestroyLoopModal; cancel leaves edge and loop", () => {
+    seedSelfFeedPipeline();
+    renderInspector({ libraryEntries: [], onLibraryChanged: () => {} });
+
+    fireEvent.click(screen.getByTestId("pooled-input-in-delete-cc1"));
+
+    expect(screen.getByTestId("destroy-loop-confirm")).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("destroy-loop-cancel"));
+
+    const tab = useEditStore.getState().openTabs[0];
+    expect(tab.pipeline.edges).toHaveLength(1);
+    expect(tab.pipeline.loops).toHaveLength(1);
+    expect(screen.queryByTestId("destroy-loop-confirm")).toBeNull();
+  });
+
+  it("self-edge (last cycle): confirm deletes the edge AND the loops: entry, panel stays open", () => {
+    seedSelfFeedPipeline();
+    renderInspector({ libraryEntries: [], onLibraryChanged: () => {} });
+
+    fireEvent.click(screen.getByTestId("pooled-input-in-delete-cc1"));
+    fireEvent.click(screen.getByTestId("destroy-loop-confirm"));
+
+    const state = useEditStore.getState();
+    expect(state.openTabs[0].pipeline.edges).toHaveLength(0);
+    expect(state.openTabs[0].pipeline.loops ?? []).toHaveLength(0);
+    expect(state.selection).toEqual({ kind: "node", id: "cc1" });
+    expect(screen.queryByTestId("destroy-loop-confirm")).toBeNull();
+  });
+
+  it("readOnly hides every × (archived gate) while rows still render", () => {
+    seedPooledReviewPipeline();
+    renderInspector({ libraryEntries: [], onLibraryChanged: () => {}, readOnly: true });
+
+    expect(screen.getByTestId("pooled-input-review")).toBeInTheDocument();
+    expect(screen.queryByTestId("pooled-input-review-delete-sec")).toBeNull();
+    expect(screen.queryByTestId("pooled-input-review-delete-perf")).toBeNull();
+  });
+});
+
 describe("NodeInspector StarButton — library save is independent of pipeline save", () => {
   it("Save to library works when pipeline is dirty (no longer requires save first)", () => {
     seedTabWithReviewer(true, "Review this code.");

--- a/frontend/src/components/NodeInspector.tsx
+++ b/frontend/src/components/NodeInspector.tsx
@@ -6,7 +6,9 @@ import { SectionHead, Field } from "./InspectorPrimitives";
 import OutputPortCard from "./OutputPortCard";
 import PooledInputRow from "./PooledInputRow";
 import ModelPicker from "./ModelPicker";
+import DestroyLoopModal from "./DestroyLoopModal";
 import { derivePooledInputs } from "../lib/derivePooledInputs";
+import { regionsDestroyedByEdgeRemoval } from "../lib/loopRegions";
 import { Tooltip } from "./ui/tooltip";
 import type { LibraryEntry } from "../api";
 import { saveToLibrary, deleteFromLibrary, instantiateFromLibrary, libraryPortToPortDef } from "../api";
@@ -21,20 +23,32 @@ const TYPE_TOOLTIPS: Record<string, string> = {
 export default function NodeInspector({
   libraryEntries,
   onLibraryChanged,
+  readOnly,
 }: {
   libraryEntries: LibraryEntry[];
   onLibraryChanged: () => void;
+  /** #339: hides the per-source input × — set for archived runs only
+   * (mirrors the canvas readOnly, #315/ADR-0020). Scoped to the × alone;
+   * the rest of the inspector's archived story is the #315 gap. */
+  readOnly?: boolean;
 }) {
   const openTabs = useEditStore((s) => s.openTabs);
   const activeTabId = useEditStore((s) => s.activeTabId);
   const selection = useEditStore((s) => s.selection);
   const updateNode = useEditStore((s) => s.updateNode);
   const updatePrompt = useEditStore((s) => s.updatePrompt);
+  const deleteEdge = useEditStore((s) => s.deleteEdge);
   const scrollToPort = useEditStore((s) => s.scrollToPort);
   const setScrollToPort = useEditStore((s) => s.setScrollToPort);
 
   const asideRef = useRef<HTMLElement>(null);
   const [highlightedPort, setHighlightedPort] = useState<string | null>(null);
+  // Pending destroy-loop confirmation (#339, mirrors EditCanvas #150): set when
+  // deleting an input source would remove a bounded region's last cycle.
+  const [pendingDestroy, setPendingDestroy] = useState<{
+    edgeIndex: number;
+    loopIds: string[];
+  } | null>(null);
 
   useEffect(() => {
     if (!scrollToPort) return;
@@ -67,6 +81,19 @@ export default function NodeInspector({
   // fixed (no doc-only↔code-mutating toggle), it has no model, and its "prompt"
   // is a bash body whose I/O arrives as PDO_* env vars, not a prose preamble.
   const isScript = node.type === "script";
+
+  // #339: delete one contributing edge of a pooled input — the canonical
+  // "delete an input" since inputs are emergent (#149/ADR-0011). Last-cycle
+  // deletions go through the same destroy-loop confirmation as the canvas;
+  // `keepSelection` keeps the inspector open on this node.
+  function handleDeleteSource(edgeIndex: number) {
+    const destroyed = regionsDestroyedByEdgeRemoval(tab!.pipeline, edgeIndex);
+    if (destroyed.length > 0) {
+      setPendingDestroy({ edgeIndex, loopIds: destroyed });
+    } else {
+      deleteEdge(edgeIndex, { keepSelection: true });
+    }
+  }
 
   function handleField(field: keyof NodeDef, value: unknown) {
     updateNode(node!.id, { [field]: value } as Partial<NodeDef>);
@@ -244,6 +271,7 @@ export default function NodeInspector({
                 input={input}
                 highlighted={highlightedPort === input.name}
                 isLast={i === pooledInputs.length - 1}
+                onDeleteSource={readOnly ? undefined : handleDeleteSource}
               />
             ))}
           </div>
@@ -265,6 +293,16 @@ export default function NodeInspector({
           ))}
         </div>
       </div>
+
+      <DestroyLoopModal
+        open={pendingDestroy != null}
+        loopIds={pendingDestroy?.loopIds ?? []}
+        onClose={() => setPendingDestroy(null)}
+        onConfirm={() => {
+          if (pendingDestroy) deleteEdge(pendingDestroy.edgeIndex, { keepSelection: true });
+          setPendingDestroy(null);
+        }}
+      />
     </aside>
   );
 }

--- a/frontend/src/components/PooledInputRow.test.tsx
+++ b/frontend/src/components/PooledInputRow.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import PooledInputRow from "./PooledInputRow";
+import type { PooledInput } from "../lib/derivePooledInputs";
+import { TooltipProvider } from "./ui/tooltip";
+
+const pooledReview: PooledInput = {
+  name: "review",
+  repeated: false,
+  sources: [
+    { nodeId: "sec", label: "security-reviewer", edgeIndex: 0 },
+    { nodeId: "perf", label: "perf-reviewer", edgeIndex: 3 },
+  ],
+};
+
+function renderRow(props: Parameters<typeof PooledInputRow>[0]) {
+  return render(
+    <TooltipProvider>
+      <PooledInputRow {...props} />
+    </TooltipProvider>,
+  );
+}
+
+describe("PooledInputRow — per-source delete (#339)", () => {
+  it("renders read-only (no ×) when onDeleteSource is absent — unchanged render", () => {
+    renderRow({ input: pooledReview });
+
+    expect(screen.getByTestId("pooled-input-review")).toHaveTextContent("security-reviewer");
+    expect(screen.getByTestId("pooled-input-review")).toHaveTextContent("perf-reviewer");
+    expect(screen.queryByTestId("pooled-input-review-delete-sec")).toBeNull();
+    expect(screen.queryByTestId("pooled-input-review-delete-perf")).toBeNull();
+  });
+
+  it("renders one × per source and reports each source's own edgeIndex", () => {
+    const onDeleteSource = vi.fn();
+    renderRow({ input: pooledReview, onDeleteSource });
+
+    fireEvent.click(screen.getByTestId("pooled-input-review-delete-sec"));
+    expect(onDeleteSource).toHaveBeenCalledWith(0);
+
+    fireEvent.click(screen.getByTestId("pooled-input-review-delete-perf"));
+    expect(onDeleteSource).toHaveBeenCalledWith(3);
+  });
+});

--- a/frontend/src/components/PooledInputRow.tsx
+++ b/frontend/src/components/PooledInputRow.tsx
@@ -11,10 +11,14 @@ export default function PooledInputRow({
   input,
   highlighted,
   isLast,
+  onDeleteSource,
 }: {
   input: PooledInput;
   highlighted?: boolean;
   isLast?: boolean;
+  /** Per-source delete (#339): deletes the contributing edge — the canonical
+   * "delete an input" since inputs are emergent. Absent → read-only render. */
+  onDeleteSource?: (edgeIndex: number) => void;
 }) {
   const pooled = input.sources.length > 1;
   return (
@@ -51,8 +55,25 @@ export default function PooledInputRow({
         </div>
         <div className="flex min-w-0 items-baseline gap-1 text-fg-3" style={{ fontSize: "10px" }}>
           <span className="shrink-0 text-fg-4 font-mono">{"←"}</span>
-          <span className="min-w-0 break-words font-mono">
-            {input.sources.map((s) => s.label).join(", ")}
+          <span className="flex min-w-0 flex-wrap items-baseline font-mono">
+            {input.sources.map((s, i) => (
+              <span key={s.edgeIndex} className="flex min-w-0 items-baseline break-words">
+                {s.label}
+                {onDeleteSource && (
+                  <Tooltip content="Delete this input source (removes the incoming edge).">
+                    <button
+                      data-testid={`pooled-input-${input.name}-delete-${s.nodeId}`}
+                      onClick={() => onDeleteSource(s.edgeIndex)}
+                      className="ml-0.5 cursor-pointer rounded px-0.5 text-fg-4 transition-colors hover:bg-bg-4 hover:text-fg"
+                      aria-label={`Delete input source ${s.label}`}
+                    >
+                      ×
+                    </button>
+                  </Tooltip>
+                )}
+                {i < input.sources.length - 1 && <span className="mr-1">,</span>}
+              </span>
+            ))}
           </span>
         </div>
       </div>

--- a/frontend/src/lib/derivePooledInputs.test.ts
+++ b/frontend/src/lib/derivePooledInputs.test.ts
@@ -28,7 +28,7 @@ describe("derivePooledInputs", () => {
     const inputs = derivePooledInputs(p, "implementer");
 
     expect(inputs).toEqual([
-      { name: "review", repeated: false, sources: [{ nodeId: "reviewer", label: "reviewer" }] },
+      { name: "review", repeated: false, sources: [{ nodeId: "reviewer", label: "reviewer", edgeIndex: 0 }] },
     ]);
   });
 
@@ -48,8 +48,8 @@ describe("derivePooledInputs", () => {
         name: "review",
         repeated: false,
         sources: [
-          { nodeId: "security-reviewer", label: "security-reviewer" },
-          { nodeId: "perf-reviewer", label: "perf-reviewer" },
+          { nodeId: "security-reviewer", label: "security-reviewer", edgeIndex: 0 },
+          { nodeId: "perf-reviewer", label: "perf-reviewer", edgeIndex: 1 },
         ],
       },
     ]);
@@ -81,7 +81,7 @@ describe("derivePooledInputs", () => {
     const inputs = derivePooledInputs(p, "loop-body");
 
     expect(inputs).toEqual([
-      { name: "lap", repeated: true, sources: [{ nodeId: "worker", label: "worker" }] },
+      { name: "lap", repeated: true, sources: [{ nodeId: "worker", label: "worker", edgeIndex: 0 }] },
     ]);
   });
 
@@ -93,11 +93,54 @@ describe("derivePooledInputs", () => {
 
     const inputs = derivePooledInputs(p, "implementer");
 
-    expect(inputs[0].sources).toEqual([{ nodeId: "rv-7", label: "rv-7" }]);
+    expect(inputs[0].sources).toEqual([{ nodeId: "rv-7", label: "rv-7", edgeIndex: 0 }]);
   });
 
   it("returns an empty list for a node with no incoming edges", () => {
     const p = pipeline([node("orphan")], []);
     expect(derivePooledInputs(p, "orphan")).toEqual([]);
+  });
+
+  it("carries the pipeline.edges index on each source, skipping unrelated edges (#339)", () => {
+    const p = pipeline(
+      [node("a"), node("b"), node("c")],
+      [
+        { source: { node: "a", port: "out" }, target: { node: "b", port: "out" } }, // unrelated
+        { source: { node: "a", port: "in" }, target: { node: "c", port: "in" } },
+        { source: { node: "b", port: "in" }, target: { node: "c", port: "in" } },
+      ],
+    );
+
+    const inputs = derivePooledInputs(p, "c");
+
+    expect(inputs).toHaveLength(1);
+    expect(inputs[0].sources.map((s) => s.edgeIndex)).toEqual([1, 2]);
+  });
+
+  it("yields a source row with its edgeIndex for a self-edge (#339 self-feed trap)", () => {
+    const p = pipeline(
+      [node("c")],
+      [{ source: { node: "c", port: "in" }, target: { node: "c", port: "in" } }],
+    );
+
+    const inputs = derivePooledInputs(p, "c");
+
+    expect(inputs).toEqual([
+      { name: "in", repeated: false, sources: [{ nodeId: "c", label: "c", edgeIndex: 0 }] },
+    ]);
+  });
+
+  it("gives two same-source same-named edges two sources with distinct indices", () => {
+    const p = pipeline(
+      [node("a"), node("c")],
+      [
+        { source: { node: "a", port: "in" }, target: { node: "c", port: "in" } },
+        { source: { node: "a", port: "in" }, target: { node: "c", port: "in" } },
+      ],
+    );
+
+    const inputs = derivePooledInputs(p, "c");
+
+    expect(inputs[0].sources.map((s) => s.edgeIndex)).toEqual([0, 1]);
   });
 });

--- a/frontend/src/lib/derivePooledInputs.ts
+++ b/frontend/src/lib/derivePooledInputs.ts
@@ -6,6 +6,10 @@ export interface PooledInputSource {
   nodeId: string;
   /** Display label for the source node (its name, falling back to its id). */
   label: string;
+  /** Index of the contributing edge in `pipeline.edges` — the handle for
+   * per-source deletion (#339). Re-derived every render, so it never goes
+   * stale across mutations. */
+  edgeIndex: number;
 }
 
 /**
@@ -35,7 +39,7 @@ export function derivePooledInputs(pipeline: PipelineDef, nodeId: string): Poole
   };
 
   const byName = new Map<string, PooledInput>();
-  for (const edge of pipeline.edges) {
+  for (const [edgeIndex, edge] of pipeline.edges.entries()) {
     if (edge.target.node !== nodeId) continue;
     const name = edge.target.port;
     let input = byName.get(name);
@@ -43,7 +47,7 @@ export function derivePooledInputs(pipeline: PipelineDef, nodeId: string): Poole
       input = { name, repeated: false, sources: [] };
       byName.set(name, input);
     }
-    input.sources.push({ nodeId: edge.source.node, label: labelOf(edge.source.node) });
+    input.sources.push({ nodeId: edge.source.node, label: labelOf(edge.source.node), edgeIndex });
     if (edge.repeated) input.repeated = true;
   }
 

--- a/frontend/src/stores/editStore.test.ts
+++ b/frontend/src/stores/editStore.test.ts
@@ -470,6 +470,56 @@ describe("deleteEdge removes a region whose last cycle it destroys (ADR-0011 / #
   });
 });
 
+describe("deleteEdge selection handling (#339)", () => {
+  function edge(s: string, t: string): EdgeDef {
+    return { source: { node: s, port: "out" }, target: { node: t, port: "in" } };
+  }
+
+  it("clears the selection by default (canvas behavior unchanged)", () => {
+    const a = makeNode({ id: "aaaa1111" });
+    const b = makeNode({ id: "bbbb2222" });
+    seedTabWithPipeline(makePipeline([a, b], [edge("aaaa1111", "bbbb2222")]));
+    useEditStore.setState({ selection: { kind: "node", id: "bbbb2222" } });
+
+    useEditStore.getState().deleteEdge(0);
+
+    expect(useEditStore.getState().selection).toEqual({ kind: "none", id: null });
+  });
+
+  it("keepSelection:true preserves the current node selection", () => {
+    const a = makeNode({ id: "aaaa1111" });
+    const b = makeNode({ id: "bbbb2222" });
+    seedTabWithPipeline(makePipeline([a, b], [edge("aaaa1111", "bbbb2222")]));
+    useEditStore.setState({ selection: { kind: "node", id: "bbbb2222" } });
+
+    useEditStore.getState().deleteEdge(0, { keepSelection: true });
+
+    expect(useEditStore.getState().openTabs[0].pipeline.edges).toHaveLength(0);
+    expect(useEditStore.getState().selection).toEqual({ kind: "node", id: "bbbb2222" });
+  });
+
+  it("keepSelection still prunes the loops: entry of a destroyed region", () => {
+    const a = makeNode({ id: "aaaa1111", name: "impl" });
+    const b = makeNode({ id: "bbbb2222", name: "rev" });
+    const pipeline = makePipeline(
+      [a, b],
+      [edge("aaaa1111", "bbbb2222"), edge("bbbb2222", "aaaa1111")],
+    );
+    pipeline.loops = [
+      { id: "review_loop", kind: "bounded", members: ["aaaa1111", "bbbb2222"], max_iter: 3 },
+    ];
+    seedTabWithPipeline(pipeline);
+    useEditStore.setState({ selection: { kind: "node", id: "aaaa1111" } });
+
+    useEditStore.getState().deleteEdge(1, { keepSelection: true });
+
+    const tab = useEditStore.getState().openTabs[0];
+    expect(tab.pipeline.edges).toHaveLength(1);
+    expect(tab.pipeline.loops ?? []).toHaveLength(0);
+    expect(useEditStore.getState().selection).toEqual({ kind: "node", id: "aaaa1111" });
+  });
+});
+
 describe("deleteNode reconciles loop regions (ADR-0011 / #173)", () => {
   function edge(s: string, t: string): EdgeDef {
     return { source: { node: s, port: "out" }, target: { node: t, port: "in" } };

--- a/frontend/src/stores/editStore.ts
+++ b/frontend/src/stores/editStore.ts
@@ -138,7 +138,10 @@ interface EditState {
   // draw-edge arrival-side stamp (#168) so a single edge-draw gesture folds into
   // ONE undo step instead of two (the `addEdge` push + a separate stamp push).
   updateEdge: (index: number, updates: Partial<EdgeDef>, opts?: { track?: boolean }) => void;
-  deleteEdge: (index: number) => void;
+  // `opts.keepSelection` keeps the current selection instead of clearing it —
+  // used by the inspector's per-source × (#339) so the panel stays open on the
+  // node whose input was just deleted. Canvas deletions keep the default clear.
+  deleteEdge: (index: number, opts?: { keepSelection?: boolean }) => void;
 
   // Region mutations (ADR-0011 / #150) — edit a bounded region's bound live.
   updateRegion: (regionId: string, updates: Partial<LoopRegion>) => void;
@@ -744,7 +747,7 @@ export const useEditStore = create<EditState>((set, get) => ({
     }));
   },
 
-  deleteEdge: (index: number) => {
+  deleteEdge: (index: number, opts?: { keepSelection?: boolean }) => {
     set((s) => ({
       ...mutateActiveTabWithHistory(s, (tab) => {
         // Destroy-loop on last-cycle removal (ADR-0011 / #150): if this edge was
@@ -760,7 +763,7 @@ export const useEditStore = create<EditState>((set, get) => ({
           tab.pipeline.loops = tab.pipeline.loops.filter((r) => !destroyed.has(r.id));
         }
       }),
-      selection: { kind: "none" as const, id: null },
+      selection: opts?.keepSelection ? s.selection : { kind: "none" as const, id: null },
     }));
   },
 


### PR DESCRIPTION
Closes #339

## What

Per-source delete (×) on pooled inputs in the node inspector:

- Each source row of a pooled input in the inspector gets its own × button (keyed by edge, no index skew after a prior delete).
- Self-feed sources (self-edge, unreachable on the canvas) are now deletable from the inspector; deleting the last cycle of a bounded region goes through the DestroyLoopModal guard (loop + badge removed on confirm, YAML saved without residual `loops:` block).
- Inspector stays open after a per-source delete (`deleteEdge` with `keepSelection`); canvas right-click delete keeps its previous close behavior.
- Gated on archived runs only: rows stay readable, no × rendered. Live-run Edit tab keeps the buttons (ADR-0007).

## Validation

- `npm test -- --run`: 1142/1142 green; typecheck ✅.
- FP-339 agentic validation passed (4 scenarios: self-feed trap, per-source precision + undo/redo, archived/live gating, canvas regression) on an isolated stack with visual confirmation.
- Known pre-existing: 2 `react-refresh/only-export-components` lint errors in `RunFilters.tsx` (introduced by #336 on main, unrelated to this diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)