### PR TITLE
feat(#342): pipeline tab context-menu mass-close + single-tab mode — v0.1.76

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -908,6 +908,14 @@ Le daemon écoute sur `127.0.0.1:<port>` uniquement. Pas d'auth, pas de TLS, pas
 - **Historique d'édition (undo/redo)** (#226) : pile **par onglet** des états d'édition successifs du canvas (Ctrl/Cmd+Z annuler, Ctrl/Cmd+Shift+Z ou Ctrl+Y rétablir, plus deux boutons toolbar), scopée à l'**édition** (positions, nœuds, edges, loops, métadonnées) — **exclut l'état de Run** (statuts/overlay) et les prompts. In-memory (vidée au reload, pas de persistance cross-session), plafonnée. Vidée sur reload-propre / "Take theirs" / "Reload changes" ; conservée à travers un Save. À distinguer de l'**historique** d'un Run (events SQLite) et des fires d'un Trigger. Cf. ADR-0014.
 - **Pas de git intégration v1.** Le user fait ses commits manuellement s'il versionne.
 
+### Onglets de pipeline (canvas)
+
+Un **onglet de pipeline** (ou *onglet canvas*) = un document ouvert dans la zone centrale : un `PipelineDef` + ses prompts + son historique d'undo, matérialisé par une entrée de `openTabs` et un onglet de la `TabBar`. À **ne pas confondre** avec les **onglets de liste** du panneau gauche (`Runs | Triggers | Library`) ni l'**onglet info** de la toolbar — ceux-là basculent une vue, ne se ferment ni ne se « désactivent » jamais.
+
+- **Onglet de run** — onglet dont le contexte est un Run (id `__run__<run-id>`, `scope: "run"`), ouvert au clic sur un Run ; édite le snapshot run-scope (cf. *Édition pendant un Run*). Un onglet **de template** (scope `repo`/`library`/`user`) édite la template en bibliothèque.
+- **Onglet actif** — l'unique onglet affiché (`activeTabId`). Fermer l'actif réactive le dernier onglet restant.
+- **Mode mono-onglet** *(préférence UI, #342)* — comportement optionnel : ouvrir une pipeline **remplace** l'onglet courant au lieu d'en empiler un nouveau (au plus un onglet à la fois). Préférence **purement UI, par-poste**, persistée en `localStorage` (`pdo.ui.tabsDisabled`) au même titre que la taille des panneaux et les bannières masquées — **hors `instance_config`** : ADR-0015 ne couvre que les réglages runtime daemon-wide, pas une préférence de présentation locale. Basculer en mono-onglet avec plusieurs onglets ouverts referme les autres (confirmation si l'un est *dirty*). _Éviter_ « mode document » (collision avec *document* = artefact du Blackboard) et « onglets désactivés » comme nom d'état (verbe du toggle, évoque à tort les onglets de liste de gauche).
+
 ### Création d'un nouveau nœud
 
 - **From scratch** : "+ Add node" → nœud vide à remplir.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "0.1.75"
+version = "0.1.76"
 license = "MIT"
 
 [workspace.dependencies]

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,6 +21,7 @@ import SettingsModal from "./components/SettingsModal";
 import ConflictModal from "./components/ConflictModal";
 import PipelineChangedModal from "./components/PipelineChangedModal";
 import SaveErrorModal from "./components/SaveErrorModal";
+import ConfirmCloseTabsModal from "./components/ConfirmCloseTabsModal";
 import { shouldPromptLibraryUpdate } from "./hooks/useLibraryPipelines";
 import { useRecentReposStore } from "./stores/recentReposStore";
 import type { TabId } from "./components/PipelineInfoPanel";
@@ -181,6 +182,11 @@ export default function App() {
   const resolveConflict = useEditStore((s) => s.resolveConflict);
   const reloadFromLibrary = useEditStore((s) => s.reloadFromLibrary);
   const clearSaveError = useEditStore((s) => s.clearSaveError);
+  // #342: a single-tab open/replace parked because it would discard unsaved
+  // work — resolved by the global confirm modal below.
+  const pendingSingleTab = useEditStore((s) => s.pendingSingleTab);
+  const confirmPendingSingleTab = useEditStore((s) => s.confirmPendingSingleTab);
+  const cancelPendingSingleTab = useEditStore((s) => s.cancelPendingSingleTab);
 
   // Track which library-YAML version we've already prompted about for a given
   // run-scoped tab. Re-prompting only when the library changes again avoids
@@ -788,6 +794,14 @@ export default function App() {
         error={saveErrorTab?.saveError ?? null}
         onDismiss={handleDismissSaveError}
         onViewYaml={handleViewYaml}
+      />
+      {/* #342: single-tab open/replace (and enable-collapse) that would discard
+          unsaved work parks here for a global confirmation. */}
+      <ConfirmCloseTabsModal
+        open={pendingSingleTab != null}
+        tabs={pendingSingleTab?.victims ?? []}
+        onCancel={cancelPendingSingleTab}
+        onConfirm={confirmPendingSingleTab}
       />
       {runNowError && (
         <div

--- a/frontend/src/components/ConfirmCloseTabsModal.test.tsx
+++ b/frontend/src/components/ConfirmCloseTabsModal.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import ConfirmCloseTabsModal from "./ConfirmCloseTabsModal";
+import type { OpenPipeline } from "../stores/editStore";
+
+function tab(id: string, over: Partial<OpenPipeline> = {}): OpenPipeline {
+  return {
+    id,
+    scope: "repo",
+    pipeline: { name: id, version: "1.0", variables: {}, nodes: [], edges: [] },
+    prompts: {},
+    diagnostics: [],
+    dirty: false,
+    externalDirty: false,
+    ...over,
+  };
+}
+
+describe("ConfirmCloseTabsModal (#342)", () => {
+  it("renders nothing when closed", () => {
+    const { container } = render(
+      <ConfirmCloseTabsModal open={false} tabs={[]} onCancel={() => {}} onConfirm={() => {}} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("names only the unsaved tabs (ignores clean and externalDirty ones)", () => {
+    render(
+      <ConfirmCloseTabsModal
+        open
+        tabs={[tab("clean"), tab("edited", { dirty: true }), tab("flash", { externalDirty: true })]}
+        onCancel={() => {}}
+        onConfirm={() => {}}
+      />,
+    );
+    expect(screen.getByText("edited.yaml")).toBeInTheDocument();
+    expect(screen.queryByText("clean.yaml")).not.toBeInTheDocument();
+    expect(screen.queryByText("flash.yaml")).not.toBeInTheDocument();
+  });
+
+  it("counts a conflict / saveError tab as unsaved", () => {
+    render(
+      <ConfirmCloseTabsModal
+        open
+        tabs={[
+          tab("conf", { dirty: true, conflict: { pipeline: tab("x").pipeline, prompts: {}, diagnostics: [] } }),
+          tab("err", { dirty: true, saveError: { message: "boom" } }),
+        ]}
+        onCancel={() => {}}
+        onConfirm={() => {}}
+      />,
+    );
+    expect(screen.getByText("conf.yaml")).toBeInTheDocument();
+    expect(screen.getByText("err.yaml")).toBeInTheDocument();
+  });
+
+  it("fires onConfirm / onCancel from the buttons", () => {
+    const onConfirm = vi.fn();
+    const onCancel = vi.fn();
+    render(
+      <ConfirmCloseTabsModal open tabs={[tab("a", { dirty: true })]} onCancel={onCancel} onConfirm={onConfirm} />,
+    );
+    fireEvent.click(screen.getByTestId("close-tabs-confirm"));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByTestId("close-tabs-cancel"));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels on a backdrop click", () => {
+    const onCancel = vi.fn();
+    render(<ConfirmCloseTabsModal open tabs={[tab("a", { dirty: true })]} onCancel={onCancel} onConfirm={() => {}} />);
+    fireEvent.click(screen.getByTestId("close-tabs-backdrop"));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels on Escape and does NOT confirm on Enter (destructive-action footgun)", () => {
+    const onConfirm = vi.fn();
+    const onCancel = vi.fn();
+    render(<ConfirmCloseTabsModal open tabs={[tab("a", { dirty: true })]} onCancel={onCancel} onConfirm={onConfirm} />);
+    fireEvent.keyDown(document, { key: "Enter" });
+    expect(onConfirm).not.toHaveBeenCalled();
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/ConfirmCloseTabsModal.tsx
+++ b/frontend/src/components/ConfirmCloseTabsModal.tsx
@@ -1,0 +1,89 @@
+import { useEffect } from "react";
+import type { OpenPipeline } from "../stores/editStore";
+import { hasUnsavedWork } from "../stores/editStore";
+
+interface Props {
+  open: boolean;
+  /**
+   * The tabs a mass-close / replace would discard (#342). Only the ones holding
+   * unsaved work are named — a save-error or unresolved conflict counts, since
+   * closing the tab would drop that too.
+   */
+  tabs: OpenPipeline[];
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+/**
+ * All-or-nothing confirmation shown before a close/replace would throw away
+ * unsaved work (#342). Replicated locally rather than sharing `DestroyLoopModal`
+ * (same house pattern as #339): the two modals only look alike, coupling them
+ * would drag loop-specific copy into the tabs feature.
+ *
+ * Deliberately no Enter→confirm binding (unlike `DestroyLoopModal`): this is a
+ * destructive action and the user may have just been typing — an accidental
+ * Enter must not discard their work. Escape cancels.
+ */
+export default function ConfirmCloseTabsModal({ open, tabs, onCancel, onConfirm }: Props) {
+  useEffect(() => {
+    if (!open) return;
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onCancel();
+    }
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [open, onCancel]);
+
+  if (!open) return null;
+
+  const unsaved = tabs.filter(hasUnsavedWork);
+  const plural = unsaved.length > 1;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      data-testid="close-tabs-backdrop"
+      onClick={onCancel}
+    >
+      <div
+        className="w-[380px] rounded-lg border border-line bg-bg-2 p-4 shadow-lg"
+        style={{ fontSize: "12px" }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3 className="font-medium text-fg" style={{ fontSize: "13px" }}>
+          Discard unsaved changes?
+        </h3>
+        <p className="mt-2 text-fg-2">
+          {plural ? `${unsaved.length} tabs have` : "1 tab has"} unsaved changes:{" "}
+          {unsaved.map((tab, i) => (
+            <span key={tab.id}>
+              {i > 0 && ", "}
+              <code className="rounded bg-bg-4 px-1 py-0.5 font-mono text-fg">
+                {tab.id}.yaml
+              </code>
+            </span>
+          ))}
+          . Closing {plural ? "them" : "it"} throws those changes away.
+        </p>
+        <div className="mt-4 flex justify-end gap-2">
+          <button
+            onClick={onCancel}
+            data-testid="close-tabs-cancel"
+            className="rounded-md border border-line-strong bg-bg-3 px-3 py-1.5 text-fg-2 transition-colors hover:bg-bg-4"
+            style={{ fontSize: "11.5px" }}
+          >
+            Cancel
+          </button>
+          <button
+            onClick={onConfirm}
+            data-testid="close-tabs-confirm"
+            className="rounded-md bg-st-failed px-3 py-1.5 text-white transition-colors hover:bg-st-failed/80"
+            style={{ fontSize: "11.5px" }}
+          >
+            Close {plural ? "tabs" : "tab"} anyway
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/SettingsModal.test.tsx
+++ b/frontend/src/components/SettingsModal.test.tsx
@@ -10,6 +10,7 @@ vi.mock("../api", () => ({
 }));
 
 import SettingsModal from "./SettingsModal";
+import { useEditStore } from "../stores/editStore";
 import type { InstanceSettings } from "../types";
 
 function sample(overrides: Partial<InstanceSettings> = {}): InstanceSettings {
@@ -122,5 +123,61 @@ describe("SettingsModal", () => {
     const cap = await screen.findByTestId("setting-session-cap");
     fireEvent.change(cap, { target: { value: "40" } });
     expect(await screen.findByTestId("settings-cap-advisory")).toBeInTheDocument();
+  });
+});
+
+describe("SettingsModal — Interface / single-tab toggle (#342)", () => {
+  beforeEach(() => {
+    fetchSettingsMock.mockReset();
+    updateSettingsMock.mockReset();
+    localStorage.clear();
+    // Reset the shared store so a prior test's toggle doesn't leak in.
+    useEditStore.setState({ singleTabMode: false, pendingSingleTab: null, openTabs: [], activeTabId: null });
+  });
+
+  it("persists to localStorage at the change, WITHOUT the numeric Save button", async () => {
+    fetchSettingsMock.mockResolvedValue(sample());
+    render(<SettingsModal open onClose={() => {}} />);
+
+    const toggle = await screen.findByTestId("setting-tabs-disabled");
+    expect(toggle).toHaveAttribute("aria-checked", "false");
+
+    fireEvent.click(toggle);
+
+    // Written immediately — no `settings-save` click, no PUT.
+    expect(localStorage.getItem("pdo.ui.tabsDisabled")).toBe("true");
+    expect(useEditStore.getState().singleTabMode).toBe(true);
+    expect(updateSettingsMock).not.toHaveBeenCalled();
+    expect(toggle).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("toggles back off and writes false", async () => {
+    fetchSettingsMock.mockResolvedValue(sample());
+    render(<SettingsModal open onClose={() => {}} />);
+    const toggle = await screen.findByTestId("setting-tabs-disabled");
+    fireEvent.click(toggle);
+    fireEvent.click(toggle);
+    expect(localStorage.getItem("pdo.ui.tabsDisabled")).toBe("false");
+    expect(useEditStore.getState().singleTabMode).toBe(false);
+  });
+
+  it("stays reachable when GET /settings fails (Trap A — lives in the outer modal)", async () => {
+    // Daemon 500: settings never load, the numeric form never mounts…
+    fetchSettingsMock.mockRejectedValue(new Error("500"));
+    render(<SettingsModal open onClose={() => {}} />);
+
+    // …but the toggle is present and functional.
+    const toggle = await screen.findByTestId("setting-tabs-disabled");
+    expect(screen.queryByTestId("setting-session-cap")).not.toBeInTheDocument();
+    fireEvent.click(toggle);
+    expect(localStorage.getItem("pdo.ui.tabsDisabled")).toBe("true");
+  });
+
+  it("seeds the toggle from the current store state", async () => {
+    useEditStore.setState({ singleTabMode: true });
+    fetchSettingsMock.mockResolvedValue(sample());
+    render(<SettingsModal open onClose={() => {}} />);
+    const toggle = await screen.findByTestId("setting-tabs-disabled");
+    expect(toggle).toHaveAttribute("aria-checked", "true");
   });
 });

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { X } from "lucide-react";
 import { useSettings } from "../hooks/useSettings";
+import { useEditStore } from "../stores/editStore";
 import type { InstanceSettings, SettingField, UpdateSettingsRequest } from "../types";
 import SessionCounter from "./SessionCounter";
 
@@ -60,6 +61,12 @@ export default function SettingsModal({ open, onClose, liveSessions = 0, onSaved
           </button>
         </div>
 
+        {/* Interface (#342): a per-client UI pref, NOT a daemon knob. It lives in
+            the OUTER modal (always rendered when open), so it stays reachable
+            even if `GET /settings` fails and the numeric form never mounts
+            (Trap A). */}
+        <InterfaceSection />
+
         {settings ? (
           <SettingsForm
             // Re-seed if the loaded config changes (refetch / restart).
@@ -80,6 +87,53 @@ export default function SettingsModal({ open, onClose, liveSessions = 0, onSaved
           </div>
         )}
       </div>
+    </div>
+  );
+}
+
+/**
+ * Per-client UI preferences (#342). Currently just the single-tab toggle. The
+ * value persists to localStorage AT THE CHANGE via `setSingleTabMode` (Trap B) —
+ * NOT batched behind the numeric form's Save button (which PUTs to the daemon).
+ */
+function InterfaceSection() {
+  const singleTabMode = useEditStore((s) => s.singleTabMode);
+  const setSingleTabMode = useEditStore((s) => s.setSingleTabMode);
+
+  return (
+    <div className="border-b border-line px-4 py-4">
+      <h3 className="font-medium text-fg-2" style={{ fontSize: "12px" }}>
+        Interface
+      </h3>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={singleTabMode}
+        data-testid="setting-tabs-disabled"
+        onClick={() => setSingleTabMode(!singleTabMode)}
+        className="mt-3 flex w-full items-center justify-between gap-3 rounded-md border border-line-strong bg-bg-3 px-3 py-2 text-left transition-colors hover:border-acc"
+      >
+        <span className="flex flex-col gap-0.5">
+          <span className="font-medium text-fg-2" style={{ fontSize: "11.5px" }}>
+            Single-tab mode
+          </span>
+          <span className="text-fg-4" style={{ fontSize: "10.5px" }}>
+            Opening a pipeline or run replaces the current tab instead of stacking a
+            new one. Enabling it closes the other open tabs.
+          </span>
+        </span>
+        <span
+          className={`relative h-3.5 w-6 shrink-0 rounded-full transition-colors ${
+            singleTabMode ? "bg-acc" : "bg-fg-5"
+          }`}
+        >
+          <span
+            className={`absolute top-0.5 h-2.5 w-2.5 rounded-full bg-bg-1 transition-all ${
+              singleTabMode ? "left-3" : "left-0.5"
+            }`}
+          />
+        </span>
+      </button>
     </div>
   );
 }

--- a/frontend/src/components/TabBar.test.tsx
+++ b/frontend/src/components/TabBar.test.tsx
@@ -1,0 +1,147 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import TabBar from "./TabBar";
+import { useEditStore } from "../stores/editStore";
+import type { OpenPipeline } from "../stores/editStore";
+
+function tab(id: string, over: Partial<OpenPipeline> = {}): OpenPipeline {
+  return {
+    id,
+    scope: "repo",
+    pipeline: { name: id, version: "1.0", variables: {}, nodes: [], edges: [] },
+    prompts: {},
+    diagnostics: [],
+    dirty: false,
+    externalDirty: false,
+    ...over,
+  };
+}
+
+function seed(tabs: OpenPipeline[], activeTabId: string) {
+  useEditStore.setState({
+    openTabs: tabs,
+    activeTabId,
+    selection: { kind: "none", id: null },
+    history: {},
+    singleTabMode: false,
+    pendingSingleTab: null,
+    lastSavedAt: {},
+  });
+}
+
+/** Right-click the tab button that owns `tab-title-<id>`. */
+function rightClickTab(id: string) {
+  const btn = screen.getByTestId(`tab-title-${id}`).closest("button")!;
+  fireEvent.contextMenu(btn);
+}
+
+beforeEach(() => {
+  // jsdom doesn't implement scrollIntoView (called by TabBar's active-tab effect).
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+describe("TabBar context menu (#342)", () => {
+  it("renders one tab per open pipeline", () => {
+    seed([tab("a"), tab("b")], "a");
+    render(<TabBar />);
+    expect(screen.getByTestId("tab-title-a")).toBeInTheDocument();
+    expect(screen.getByTestId("tab-title-b")).toBeInTheDocument();
+  });
+
+  it("opens a 4-item menu on right-click", () => {
+    seed([tab("a"), tab("b"), tab("c")], "a");
+    render(<TabBar />);
+    rightClickTab("b");
+    expect(screen.getByTestId("tab-context-menu")).toBeInTheDocument();
+    expect(screen.getByTestId("tab-ctx-close")).toBeInTheDocument();
+    expect(screen.getByTestId("tab-ctx-close-others")).toBeInTheDocument();
+    expect(screen.getByTestId("tab-ctx-close-right")).toBeInTheDocument();
+    expect(screen.getByTestId("tab-ctx-close-all")).toBeInTheDocument();
+  });
+
+  it("disables 'Close to the right' on the last tab, enables it otherwise", () => {
+    seed([tab("a"), tab("b"), tab("c")], "a");
+    render(<TabBar />);
+    rightClickTab("c");
+    expect(screen.getByTestId("tab-ctx-close-right")).toBeDisabled();
+    // Re-open on a non-last tab.
+    fireEvent.keyDown(document, { key: "Escape" });
+    rightClickTab("a");
+    expect(screen.getByTestId("tab-ctx-close-right")).not.toBeDisabled();
+  });
+
+  it("disables 'Close others' / 'Close all' when a single tab is open", () => {
+    seed([tab("only")], "only");
+    render(<TabBar />);
+    rightClickTab("only");
+    expect(screen.getByTestId("tab-ctx-close-others")).toBeDisabled();
+    expect(screen.getByTestId("tab-ctx-close-all")).toBeDisabled();
+    expect(screen.getByTestId("tab-ctx-close")).not.toBeDisabled();
+  });
+
+  it("Escape dismisses the menu without closing anything", () => {
+    seed([tab("a"), tab("b")], "a");
+    render(<TabBar />);
+    rightClickTab("a");
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.queryByTestId("tab-context-menu")).not.toBeInTheDocument();
+    expect(useEditStore.getState().openTabs).toHaveLength(2);
+  });
+
+  it("a backdrop click dismisses the menu", () => {
+    seed([tab("a"), tab("b")], "a");
+    const { container } = render(<TabBar />);
+    rightClickTab("a");
+    // The z-40 backdrop is the first fixed-inset div.
+    const backdrop = container.querySelector(".fixed.inset-0")!;
+    fireEvent.click(backdrop);
+    expect(screen.queryByTestId("tab-context-menu")).not.toBeInTheDocument();
+  });
+
+  it("'Close all' on clean tabs closes everything with no confirmation", () => {
+    seed([tab("a"), tab("b"), tab("c")], "a");
+    render(<TabBar />);
+    rightClickTab("a");
+    fireEvent.click(screen.getByTestId("tab-ctx-close-all"));
+    // No modal, and the store emptied.
+    expect(screen.queryByTestId("close-tabs-confirm")).not.toBeInTheDocument();
+    expect(useEditStore.getState().openTabs).toEqual([]);
+    // Menu closed before any modal could show.
+    expect(screen.queryByTestId("tab-context-menu")).not.toBeInTheDocument();
+  });
+
+  it("'Close others' with a dirty victim confirms first; confirm closes them", () => {
+    seed([tab("a"), tab("b", { dirty: true }), tab("c")], "a");
+    render(<TabBar />);
+    rightClickTab("a");
+    fireEvent.click(screen.getByTestId("tab-ctx-close-others"));
+
+    // Menu gone, confirmation up, dirty victim named — nothing closed yet.
+    expect(screen.queryByTestId("tab-context-menu")).not.toBeInTheDocument();
+    expect(screen.getByTestId("close-tabs-confirm")).toBeInTheDocument();
+    expect(screen.getByText("b.yaml")).toBeInTheDocument();
+    expect(useEditStore.getState().openTabs).toHaveLength(3);
+
+    fireEvent.click(screen.getByTestId("close-tabs-confirm"));
+    expect(useEditStore.getState().openTabs.map((t) => t.id)).toEqual(["a"]);
+  });
+
+  it("'Close others' with a dirty victim can be cancelled, keeping every tab", () => {
+    seed([tab("a"), tab("b", { dirty: true }), tab("c")], "a");
+    render(<TabBar />);
+    rightClickTab("a");
+    fireEvent.click(screen.getByTestId("tab-ctx-close-others"));
+    fireEvent.click(screen.getByTestId("close-tabs-cancel"));
+    expect(useEditStore.getState().openTabs).toHaveLength(3);
+    expect(useEditStore.getState().openTabs[1].dirty).toBe(true);
+  });
+
+  it("'Close others' on all-clean tabs closes immediately (no modal)", () => {
+    seed([tab("a"), tab("b"), tab("c")], "a");
+    render(<TabBar />);
+    rightClickTab("a");
+    fireEvent.click(screen.getByTestId("tab-ctx-close-others"));
+    expect(screen.queryByTestId("close-tabs-confirm")).not.toBeInTheDocument();
+    expect(useEditStore.getState().openTabs.map((t) => t.id)).toEqual(["a"]);
+  });
+});

--- a/frontend/src/components/TabBar.tsx
+++ b/frontend/src/components/TabBar.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Save, X } from "lucide-react";
-import { useEditStore } from "../stores/editStore";
+import { useEditStore, hasUnsavedWork } from "../stores/editStore";
+import type { OpenPipeline } from "../stores/editStore";
+import ConfirmCloseTabsModal from "./ConfirmCloseTabsModal";
 
 function useRelativeTime(ts: number | undefined): string | null {
   const [now, setNow] = useState(() => Date.now());
@@ -26,9 +28,31 @@ export default function TabBar() {
   const activeTabId = useEditStore((s) => s.activeTabId);
   const setActiveTab = useEditStore((s) => s.setActiveTab);
   const closeTab = useEditStore((s) => s.closeTab);
+  const closeTabs = useEditStore((s) => s.closeTabs);
   const save = useEditStore((s) => s.save);
   const lastSavedAt = useEditStore((s) => s.lastSavedAt);
   const tabRefs = useRef<Map<string, HTMLButtonElement>>(new Map());
+
+  // Right-click context menu (#342): viewport coords so it doesn't drift when
+  // the tab strip scrolls. Null = closed.
+  const [menu, setMenu] = useState<{ x: number; y: number; tabId: string } | null>(null);
+  // A mass-close awaiting confirmation because it would discard unsaved work.
+  const [pendingClose, setPendingClose] = useState<{ ids: string[]; victims: OpenPipeline[] } | null>(null);
+
+  // Gate a close request on unsaved work: confirm if any target tab is unsaved,
+  // else close atomically. The single × keeps its silent drop (unchanged); the
+  // menu is the explicit path, so it never loses work without asking.
+  const requestClose = useCallback(
+    (ids: string[]) => {
+      const victims = openTabs.filter((t) => ids.includes(t.id));
+      if (victims.some(hasUnsavedWork)) {
+        setPendingClose({ ids, victims });
+      } else {
+        closeTabs(ids);
+      }
+    },
+    [openTabs, closeTabs],
+  );
 
   const anyDirty = openTabs.some((t) => t.dirty);
   const activeLastSaved = activeTabId ? lastSavedAt[activeTabId] : undefined;
@@ -53,6 +77,7 @@ export default function TabBar() {
   if (openTabs.length === 0) return null;
 
   return (
+    <>
     <div className="flex h-[30px] shrink-0 items-end border-b border-line bg-bg-2">
       <div
         className="flex min-w-0 flex-1 items-end gap-px overflow-x-auto px-1"
@@ -67,6 +92,10 @@ export default function TabBar() {
               key={tab.id}
               ref={(el) => setTabRef(tab.id, el)}
               onClick={() => setActiveTab(tab.id)}
+              onContextMenu={(e) => {
+                e.preventDefault();
+                setMenu({ x: e.clientX, y: e.clientY, tabId: tab.id });
+              }}
               className={`group flex shrink-0 cursor-pointer items-center gap-1.5 rounded-t-md border border-b-0 px-2.5 py-1 transition-colors ${
                 isActive
                   ? "border-line bg-bg-1 text-fg"
@@ -115,5 +144,117 @@ export default function TabBar() {
         </button>
       </div>
     </div>
+
+      {menu && (
+        <TabContextMenu
+          x={menu.x}
+          y={menu.y}
+          tabId={menu.tabId}
+          openTabs={openTabs}
+          onDismiss={() => setMenu(null)}
+          onSelect={(ids) => {
+            // Close the menu BEFORE the confirm modal opens: both are z-50, so
+            // leaving the menu up would let it sit over the modal.
+            setMenu(null);
+            requestClose(ids);
+          }}
+        />
+      )}
+
+      <ConfirmCloseTabsModal
+        open={pendingClose != null}
+        tabs={pendingClose?.victims ?? []}
+        onCancel={() => setPendingClose(null)}
+        onConfirm={() => {
+          if (pendingClose) closeTabs(pendingClose.ids);
+          setPendingClose(null);
+        }}
+      />
+    </>
+  );
+}
+
+/**
+ * Right-click menu for a tab (#342). A local `fixed z-50` div in the house
+ * style (clone of `EditCanvas`'s ContextMenu, not base-ui) — positioned in
+ * viewport coords so it survives a scroll of the tab strip. Dismisses on a
+ * backdrop click OR Escape (`LibraryDropdown` only handles mousedown; the menu
+ * must also close on Escape).
+ */
+function TabContextMenu({
+  x,
+  y,
+  tabId,
+  openTabs,
+  onSelect,
+  onDismiss,
+}: {
+  x: number;
+  y: number;
+  tabId: string;
+  openTabs: OpenPipeline[];
+  onSelect: (ids: string[]) => void;
+  onDismiss: () => void;
+}) {
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onDismiss();
+    }
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [onDismiss]);
+
+  const index = openTabs.findIndex((t) => t.id === tabId);
+  const single = openTabs.length <= 1;
+  const isLast = index >= 0 && index === openTabs.length - 1;
+  const otherIds = openTabs.filter((t) => t.id !== tabId).map((t) => t.id);
+  const rightIds = index < 0 ? [] : openTabs.slice(index + 1).map((t) => t.id);
+  const allIds = openTabs.map((t) => t.id);
+
+  return (
+    <>
+      <div className="fixed inset-0 z-40" onClick={onDismiss} />
+      <div
+        className="fixed z-50 rounded-lg border border-line bg-bg-4 py-1 shadow-lg"
+        style={{ left: x, top: y, fontSize: "11.5px", minWidth: 150 }}
+        data-testid="tab-context-menu"
+      >
+        <MenuItem testid="tab-ctx-close" onClick={() => onSelect([tabId])}>
+          Close
+        </MenuItem>
+        <MenuItem testid="tab-ctx-close-others" disabled={single} onClick={() => onSelect(otherIds)}>
+          Close others
+        </MenuItem>
+        <MenuItem testid="tab-ctx-close-right" disabled={isLast} onClick={() => onSelect(rightIds)}>
+          Close to the right
+        </MenuItem>
+        <MenuItem testid="tab-ctx-close-all" disabled={single} onClick={() => onSelect(allIds)}>
+          Close all
+        </MenuItem>
+      </div>
+    </>
+  );
+}
+
+function MenuItem({
+  testid,
+  disabled,
+  onClick,
+  children,
+}: {
+  testid: string;
+  disabled?: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      data-testid={testid}
+      disabled={disabled}
+      onClick={onClick}
+      className="flex w-full cursor-pointer items-center px-3 py-1.5 text-left text-fg-2 hover:bg-bg-3 hover:text-fg disabled:pointer-events-none disabled:opacity-40"
+    >
+      {children}
+    </button>
   );
 }

--- a/frontend/src/lib/uiPrefs.test.ts
+++ b/frontend/src/lib/uiPrefs.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { loadTabsDisabled, saveTabsDisabled } from "./uiPrefs";
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("uiPrefs — tabsDisabled (#342)", () => {
+  it("round-trips true/false through save/load", () => {
+    saveTabsDisabled(true);
+    expect(loadTabsDisabled()).toBe(true);
+    saveTabsDisabled(false);
+    expect(loadTabsDisabled()).toBe(false);
+  });
+
+  it("persists under the pdo.ui.tabsDisabled key", () => {
+    saveTabsDisabled(true);
+    expect(localStorage.getItem("pdo.ui.tabsDisabled")).toBe("true");
+  });
+
+  it("defaults to false when the key is absent (multi-tab default)", () => {
+    expect(loadTabsDisabled()).toBe(false);
+  });
+
+  it("defaults to false for non-JSON garbage", () => {
+    localStorage.setItem("pdo.ui.tabsDisabled", "not-json{");
+    expect(loadTabsDisabled()).toBe(false);
+  });
+
+  it("defaults to false when the stored value is not a boolean", () => {
+    localStorage.setItem("pdo.ui.tabsDisabled", JSON.stringify("true"));
+    expect(loadTabsDisabled()).toBe(false);
+    localStorage.setItem("pdo.ui.tabsDisabled", JSON.stringify(1));
+    expect(loadTabsDisabled()).toBe(false);
+  });
+
+  it("degrades to false when localStorage.getItem throws (private mode)", () => {
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("SecurityError");
+    });
+    expect(loadTabsDisabled()).toBe(false);
+  });
+
+  it("swallows a throwing setItem (quota / disabled) without raising", () => {
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("QuotaExceededError");
+    });
+    expect(() => saveTabsDisabled(true)).not.toThrow();
+  });
+});

--- a/frontend/src/lib/uiPrefs.ts
+++ b/frontend/src/lib/uiPrefs.ts
@@ -1,0 +1,34 @@
+/**
+ * Per-client UI presentation preferences (#342).
+ *
+ * Deliberately OUTSIDE `instance_config`: ADR-0015 covers only daemon-wide
+ * runtime knobs (stored → env → default), where a value has a meaningful env
+ * tier and a single daemon-wide scope. A local presentation preference has
+ * neither — two browsers pointed at the same daemon would fight over one
+ * stored row. Same discipline as `useResizableLayout` / `dismissedBanners`
+ * (the `pdo.*` localStorage namespace): guard BOTH read and write so private
+ * mode / a disabled or full store degrades to an in-memory default for the
+ * session instead of throwing.
+ */
+const KEY = "pdo.ui.tabsDisabled";
+
+/** Whether single-tab mode is enabled. Absent / unparseable → `false` (the
+ *  default is multi-tab, so a fresh client accumulates tabs). */
+export function loadTabsDisabled(): boolean {
+  try {
+    const raw = localStorage.getItem(KEY);
+    if (raw == null) return false;
+    const v: unknown = JSON.parse(raw);
+    return typeof v === "boolean" ? v : false;
+  } catch {
+    return false;
+  }
+}
+
+export function saveTabsDisabled(v: boolean): void {
+  try {
+    localStorage.setItem(KEY, JSON.stringify(v));
+  } catch {
+    // quota / disabled / private mode → in-memory only for this session
+  }
+}

--- a/frontend/src/stores/editStore.test.ts
+++ b/frontend/src/stores/editStore.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { useEditStore, serializePipeline } from "./editStore";
+import type { OpenPipeline, Selection } from "./editStore";
 import { generatedRegionId } from "../lib/loopRegions";
 import { pipelinesEquivalent } from "../hooks/useLibraryPipelines";
 import { savePipeline, fetchPipeline, saveRunPipeline, deletePipeline } from "../api";
@@ -104,6 +105,7 @@ function seedTab(id = "test-pipeline", dirty = true) {
 }
 
 beforeEach(() => {
+  localStorage.clear();
   useEditStore.setState({
     pipelines: [],
     openTabs: [],
@@ -111,6 +113,8 @@ beforeEach(() => {
     selection: { kind: "none", id: null },
     lastSavedAt: {},
     history: {},
+    singleTabMode: false,
+    pendingSingleTab: null,
   });
   vi.clearAllMocks();
 });
@@ -2356,5 +2360,268 @@ describe("openPipeline (#320 / #216 canvas-open)", () => {
   it("passes scope undefined when omitted (repo/user resolution)", async () => {
     await useEditStore.getState().openPipeline("pipe-repo");
     expect(mockFetchPipeline).toHaveBeenCalledWith("pipe-repo", undefined);
+  });
+});
+
+// #342 — mass-close primitive + single-tab mode.
+describe("closeTabs (#342 atomic mass-close)", () => {
+  function mkTab(id: string, over: Partial<OpenPipeline> = {}): OpenPipeline {
+    return {
+      id,
+      scope: "repo",
+      pipeline: { name: id, version: "1.0", variables: {}, nodes: [], edges: [] },
+      prompts: {},
+      diagnostics: [],
+      dirty: false,
+      externalDirty: false,
+      ...over,
+    };
+  }
+  function seedTabs(tabs: OpenPipeline[], activeTabId: string, selection: Selection = { kind: "none", id: null }) {
+    useEditStore.setState({ openTabs: tabs, activeTabId, selection });
+  }
+
+  it("recomputes activeTabId to the rightmost survivor when the active tab closes", () => {
+    seedTabs([mkTab("a"), mkTab("b"), mkTab("c")], "b");
+    useEditStore.getState().closeTabs(["b"]);
+    const s = useEditStore.getState();
+    expect(s.openTabs.map((t) => t.id)).toEqual(["a", "c"]);
+    expect(s.activeTabId).toBe("c");
+    expect(s.selection).toEqual({ kind: "none", id: null });
+  });
+
+  it("leaves activeTabId unchanged when only background tabs close", () => {
+    seedTabs([mkTab("a"), mkTab("b"), mkTab("c")], "b");
+    useEditStore.getState().closeTabs(["a"]);
+    const s = useEditStore.getState();
+    expect(s.openTabs.map((t) => t.id)).toEqual(["b", "c"]);
+    expect(s.activeTabId).toBe("b");
+  });
+
+  it("never points activeTabId at a tab that was just closed", () => {
+    // Close both non-active tabs surrounding the active one.
+    seedTabs([mkTab("a"), mkTab("b"), mkTab("c")], "b");
+    useEditStore.getState().closeTabs(["a", "c"]);
+    const s = useEditStore.getState();
+    expect(s.activeTabId).toBe("b");
+  });
+
+  it("preserves the selection reference when a background tab closes (unlike closeTab)", () => {
+    const sel = { kind: "node" as const, id: "n1" };
+    seedTabs([mkTab("a"), mkTab("b")], "a", sel);
+    useEditStore.getState().closeTabs(["b"]);
+    // Same reference — no needless reconciliation churn.
+    expect(useEditStore.getState().selection).toBe(sel);
+  });
+
+  it("resets selection when the active tab is among those closed", () => {
+    const sel = { kind: "node" as const, id: "n1" };
+    seedTabs([mkTab("a"), mkTab("b")], "a", sel);
+    useEditStore.getState().closeTabs(["a"]);
+    const s = useEditStore.getState();
+    expect(s.activeTabId).toBe("b");
+    expect(s.selection).toEqual({ kind: "none", id: null });
+  });
+
+  it("drops each closed tab's history slot by id, keeping survivors", () => {
+    seedTabs([mkTab("a"), mkTab("b"), mkTab("c")], "a");
+    const h = () => ({ past: [], future: [], lastKey: null, lastAt: 0 });
+    useEditStore.setState({ history: { a: h(), b: h(), c: h() } });
+    useEditStore.getState().closeTabs(["a", "c"]);
+    const hist = useEditStore.getState().history;
+    expect(hist.a).toBeUndefined();
+    expect(hist.c).toBeUndefined();
+    expect(hist.b).toBeDefined();
+  });
+
+  it("closing every tab empties openTabs and nulls activeTabId (Close all)", () => {
+    seedTabs([mkTab("a"), mkTab("b")], "a");
+    useEditStore.getState().closeTabs(["a", "b"]);
+    const s = useEditStore.getState();
+    expect(s.openTabs).toEqual([]);
+    expect(s.activeTabId).toBeNull();
+  });
+
+  it("is a clean no-op on an empty id list (Close-to-the-right of the last tab)", () => {
+    seedTabs([mkTab("a"), mkTab("b")], "b");
+    useEditStore.getState().closeTabs([]);
+    const s = useEditStore.getState();
+    expect(s.openTabs.map((t) => t.id)).toEqual(["a", "b"]);
+    expect(s.activeTabId).toBe("b");
+  });
+});
+
+describe("single-tab mode (#342)", () => {
+  function mkTab(id: string, over: Partial<OpenPipeline> = {}): OpenPipeline {
+    return {
+      id,
+      scope: "repo",
+      pipeline: { name: id, version: "1.0", variables: {}, nodes: [], edges: [] },
+      prompts: {},
+      diagnostics: [],
+      dirty: false,
+      externalDirty: false,
+      ...over,
+    };
+  }
+
+  describe("seam: openPipeline / openRunPipeline replace instead of append", () => {
+    it("openPipeline replaces the current tab when singleTabMode is on and nothing is dirty", async () => {
+      useEditStore.setState({ singleTabMode: true, openTabs: [mkTab("a")], activeTabId: "a" });
+      await useEditStore.getState().openPipeline("pipe-b");
+      const s = useEditStore.getState();
+      expect(s.openTabs.map((t) => t.id)).toEqual(["pipe-b"]);
+      expect(s.activeTabId).toBe("pipe-b");
+      expect(s.pendingSingleTab).toBeNull();
+    });
+
+    it("openRunPipeline replaces the current tab when singleTabMode is on", async () => {
+      useEditStore.setState({ singleTabMode: true, openTabs: [mkTab("a")], activeTabId: "a" });
+      await useEditStore.getState().openRunPipeline("run-1");
+      const s = useEditStore.getState();
+      expect(s.openTabs.map((t) => t.id)).toEqual(["__run__run-1"]);
+      expect(s.openTabs[0].runId).toBe("run-1");
+    });
+
+    it("drops the evicted tab's undo history on replace", async () => {
+      const h = { past: [makePipeline([makeNode()])], future: [], lastKey: null, lastAt: 0 };
+      useEditStore.setState({
+        singleTabMode: true,
+        openTabs: [mkTab("a")],
+        activeTabId: "a",
+        history: { a: h },
+      });
+      await useEditStore.getState().openPipeline("pipe-b");
+      expect(useEditStore.getState().history["a"]).toBeUndefined();
+    });
+
+    it("still appends (never replaces) when singleTabMode is off", async () => {
+      useEditStore.setState({ singleTabMode: false, openTabs: [mkTab("a")], activeTabId: "a" });
+      await useEditStore.getState().openPipeline("pipe-b");
+      expect(useEditStore.getState().openTabs.map((t) => t.id)).toEqual(["a", "pipe-b"]);
+    });
+
+    it("re-activates an already-open tab without replacing or re-fetching", async () => {
+      useEditStore.setState({ singleTabMode: true, openTabs: [mkTab("a"), mkTab("pipe-b")], activeTabId: "a" });
+      mockFetchPipeline.mockClear();
+      await useEditStore.getState().openPipeline("pipe-b");
+      const s = useEditStore.getState();
+      // Already open → the early return activates it; no fetch, no eviction.
+      expect(mockFetchPipeline).not.toHaveBeenCalled();
+      expect(s.activeTabId).toBe("pipe-b");
+      expect(s.openTabs.map((t) => t.id)).toEqual(["a", "pipe-b"]);
+    });
+
+    it("parks (does NOT replace) when the evicted tab is dirty, then confirm applies it", async () => {
+      useEditStore.setState({
+        singleTabMode: true,
+        openTabs: [mkTab("a", { dirty: true })],
+        activeTabId: "a",
+      });
+      await useEditStore.getState().openPipeline("pipe-b");
+      // Parked — the dirty tab is untouched until the user decides.
+      let s = useEditStore.getState();
+      expect(s.pendingSingleTab).not.toBeNull();
+      expect(s.pendingSingleTab!.tab!.id).toBe("pipe-b");
+      expect(s.pendingSingleTab!.victims.map((t) => t.id)).toEqual(["a"]);
+      expect(s.openTabs.map((t) => t.id)).toEqual(["a"]);
+
+      useEditStore.getState().confirmPendingSingleTab();
+      s = useEditStore.getState();
+      expect(s.openTabs.map((t) => t.id)).toEqual(["pipe-b"]);
+      expect(s.activeTabId).toBe("pipe-b");
+      expect(s.pendingSingleTab).toBeNull();
+    });
+
+    it("cancel keeps the dirty tab and drops the parked open", async () => {
+      useEditStore.setState({
+        singleTabMode: true,
+        openTabs: [mkTab("a", { dirty: true })],
+        activeTabId: "a",
+      });
+      await useEditStore.getState().openPipeline("pipe-b");
+      useEditStore.getState().cancelPendingSingleTab();
+      const s = useEditStore.getState();
+      expect(s.pendingSingleTab).toBeNull();
+      expect(s.openTabs.map((t) => t.id)).toEqual(["a"]);
+      expect(s.openTabs[0].dirty).toBe(true);
+    });
+
+    it("parks when the evicted tab carries an unresolved conflict (implies dirty)", async () => {
+      useEditStore.setState({
+        singleTabMode: true,
+        openTabs: [mkTab("a", { dirty: true, conflict: { pipeline: makePipeline(), prompts: {}, diagnostics: [] } })],
+        activeTabId: "a",
+      });
+      await useEditStore.getState().openPipeline("pipe-b");
+      expect(useEditStore.getState().pendingSingleTab).not.toBeNull();
+    });
+
+    it("ignores externalDirty (a hot-reload flash is not unsaved work)", async () => {
+      useEditStore.setState({
+        singleTabMode: true,
+        openTabs: [mkTab("a", { externalDirty: true })],
+        activeTabId: "a",
+      });
+      await useEditStore.getState().openPipeline("pipe-b");
+      // Replaced directly — no confirmation for a transient external flag.
+      expect(useEditStore.getState().openTabs.map((t) => t.id)).toEqual(["pipe-b"]);
+      expect(useEditStore.getState().pendingSingleTab).toBeNull();
+    });
+  });
+
+  describe("setSingleTabMode", () => {
+    it("persists to localStorage immediately at the change (Trap B)", () => {
+      useEditStore.getState().setSingleTabMode(true);
+      expect(localStorage.getItem("pdo.ui.tabsDisabled")).toBe("true");
+      expect(useEditStore.getState().singleTabMode).toBe(true);
+      useEditStore.getState().setSingleTabMode(false);
+      expect(localStorage.getItem("pdo.ui.tabsDisabled")).toBe("false");
+    });
+
+    it("collapses to the active tab when enabling with several clean tabs", () => {
+      useEditStore.setState({ openTabs: [mkTab("a"), mkTab("b"), mkTab("c")], activeTabId: "b" });
+      useEditStore.getState().setSingleTabMode(true);
+      const s = useEditStore.getState();
+      expect(s.openTabs.map((t) => t.id)).toEqual(["b"]);
+      expect(s.activeTabId).toBe("b");
+      expect(s.pendingSingleTab).toBeNull();
+    });
+
+    it("parks the collapse when a non-active tab is dirty, keeping the active one on confirm", () => {
+      useEditStore.setState({
+        openTabs: [mkTab("a", { dirty: true }), mkTab("b"), mkTab("c")],
+        activeTabId: "b",
+      });
+      useEditStore.getState().setSingleTabMode(true);
+      let s = useEditStore.getState();
+      // Nothing closed yet; the collapse is parked (tab === null).
+      expect(s.pendingSingleTab).not.toBeNull();
+      expect(s.pendingSingleTab!.tab).toBeNull();
+      expect(s.openTabs).toHaveLength(3);
+      // ...but the pref persisted immediately regardless of the confirmation.
+      expect(s.singleTabMode).toBe(true);
+      expect(localStorage.getItem("pdo.ui.tabsDisabled")).toBe("true");
+
+      useEditStore.getState().confirmPendingSingleTab();
+      s = useEditStore.getState();
+      expect(s.openTabs.map((t) => t.id)).toEqual(["b"]);
+      expect(s.activeTabId).toBe("b");
+      expect(s.pendingSingleTab).toBeNull();
+    });
+
+    it("does nothing to tabs when disabling (accumulation resumes)", () => {
+      useEditStore.setState({ singleTabMode: true, openTabs: [mkTab("a")], activeTabId: "a" });
+      useEditStore.getState().setSingleTabMode(false);
+      expect(useEditStore.getState().openTabs.map((t) => t.id)).toEqual(["a"]);
+      expect(useEditStore.getState().singleTabMode).toBe(false);
+    });
+
+    it("is a no-op collapse when only one tab is open", () => {
+      useEditStore.setState({ openTabs: [mkTab("a")], activeTabId: "a" });
+      useEditStore.getState().setSingleTabMode(true);
+      expect(useEditStore.getState().openTabs.map((t) => t.id)).toEqual(["a"]);
+      expect(useEditStore.getState().pendingSingleTab).toBeNull();
+    });
   });
 });

--- a/frontend/src/stores/editStore.ts
+++ b/frontend/src/stores/editStore.ts
@@ -18,6 +18,7 @@ import {
   saveLibraryPipeline,
 } from "../api";
 import { generateNodeId } from "../lib/nanoid";
+import { loadTabsDisabled, saveTabsDisabled } from "../lib/uiPrefs";
 import {
   generatedRegionId,
   materializeMissingRegions,
@@ -82,6 +83,34 @@ export interface OpenPipeline {
 }
 
 /**
+ * A tab holds unsaved work that a close/replace would silently discard (#342).
+ * `conflict`/`saveError` both imply `dirty` (a conflict is only recorded inside
+ * `if (tab.dirty)`, a save-error follows a failed save that leaves `dirty`), but
+ * we spell them out so the guard reads as "would we lose anything the user can't
+ * get back". `externalDirty` is intentionally excluded — it's the transient
+ * 2 s hot-reload flash, not user work.
+ */
+export function hasUnsavedWork(t: OpenPipeline): boolean {
+  return t.dirty || t.conflict != null || t.saveError != null;
+}
+
+/**
+ * A single-tab-mode gesture (#342) parked because confirming it would discard
+ * unsaved work. Resolved by a global confirm modal: `confirmPendingSingleTab`
+ * performs it, `cancelPendingSingleTab` drops it (keeping the tabs).
+ *
+ * - `tab` set → an open-replace: `tab` becomes the sole tab, every current tab
+ *   is discarded.
+ * - `tab` null → the enable-toggle collapse: the active tab is kept, the others
+ *   (`victims`) are closed.
+ */
+export interface PendingSingleTab {
+  tab: OpenPipeline | null;
+  /** Tabs that will be discarded; the modal names the unsaved ones. */
+  victims: OpenPipeline[];
+}
+
+/**
  * Per-tab undo/redo history (ADR-0014 / #226). Entries are whole `PipelineDef`
  * object references captured *before* a structural mutation — NOT deep clones.
  * This is safe only because every store mutation is copy-on-write (it rebuilds
@@ -113,11 +142,32 @@ interface EditState {
   // with a selector, never stored.
   history: Record<string, TabHistory>;
 
+  // Single-tab mode (#342): at most one pipeline/run tab. A per-client UI pref
+  // (localStorage, NOT instance_config) seeded once at store creation. When on,
+  // opening a pipeline/run REPLACES the current tab instead of appending.
+  singleTabMode: boolean;
+  // A parked single-tab gesture awaiting confirmation (would discard unsaved
+  // work). Null when nothing is pending.
+  pendingSingleTab: PendingSingleTab | null;
+
   loadPipelines: () => Promise<void>;
   openPipeline: (id: string, scope?: PipelineScope) => Promise<void>;
   openRunPipeline: (runId: string) => Promise<void>;
   closeRunPipeline: (runId: string) => void;
   closeTab: (id: string) => void;
+  // Atomic mass-close (#342): removes every id in ONE `set()`. Never loop
+  // `closeTab` — the App reconciliation (#247/#320) runs at render on a
+  // reference change of `selection`/`activeTabId`, so intermediate states where
+  // `activeTabId` points at a closing tab flash the center panel and can
+  // self-close the Trigger detail.
+  closeTabs: (ids: string[]) => void;
+  // Single-tab pref (#342). Persists to localStorage immediately (at the toggle
+  // change, not on a Save button) and, when enabling with several tabs open,
+  // collapses to the active tab (parking for confirmation if any other is
+  // unsaved).
+  setSingleTabMode: (v: boolean) => void;
+  confirmPendingSingleTab: () => void;
+  cancelPendingSingleTab: () => void;
   setActiveTab: (id: string) => void;
   setSelection: (sel: Selection) => void;
   setScrollToPort: (port: string | null) => void;
@@ -481,6 +531,45 @@ function droppedHistory(
   return next;
 }
 
+// Single-tab replace (#342): `tab` becomes the sole open tab, every `victims`
+// tab is discarded (its undo stack dropped per id — a reused `__run__<runId>`
+// must not inherit a stale stack, ADR-0014). One `set()` patch, no loop.
+function replaceWithTab(
+  state: EditState,
+  tab: OpenPipeline,
+  victims: OpenPipeline[],
+): Partial<EditState> {
+  const history = victims.reduce((h, v) => droppedHistory(h, v.id), state.history);
+  return {
+    openTabs: [tab],
+    activeTabId: tab.id,
+    selection: { kind: "none", id: null },
+    history,
+    pendingSingleTab: null,
+  };
+}
+
+// Compute the store patch for placing a freshly-opened tab (#342). Multi-tab:
+// append + activate. Single-tab: replace the current tab — but if the replace
+// would discard unsaved work, PARK it for confirmation instead of destroying it
+// (the caller has already fetched, so the tab object is ready to apply on
+// confirm). Callers pass a tab whose id is NOT already open (the early-return in
+// openPipeline/openRunPipeline handles the already-open case).
+function placeOpenedTab(state: EditState, tab: OpenPipeline): Partial<EditState> {
+  if (!state.singleTabMode) {
+    return {
+      openTabs: [...state.openTabs, tab],
+      activeTabId: tab.id,
+      selection: { kind: "none", id: null },
+    };
+  }
+  const victims = state.openTabs.filter((t) => t.id !== tab.id);
+  if (victims.some(hasUnsavedWork)) {
+    return { pendingSingleTab: { tab, victims } };
+  }
+  return replaceWithTab(state, tab, victims);
+}
+
 function edgeReferencesNode(edge: EdgeDef, nodeId: string): boolean {
   if (edge.source.node === nodeId) return true;
   return "node" in edge.target && (edge.target as { node: string }).node === nodeId;
@@ -531,6 +620,8 @@ export const useEditStore = create<EditState>((set, get) => ({
   scrollToPort: null,
   lastSavedAt: {},
   history: {},
+  singleTabMode: loadTabsDisabled(),
+  pendingSingleTab: null,
 
   loadPipelines: async () => {
     try {
@@ -562,11 +653,9 @@ export const useEditStore = create<EditState>((set, get) => ({
         libraryId: null,
         libraryScope: null,
       };
-      set((s) => ({
-        openTabs: [...s.openTabs, tab],
-        activeTabId: id,
-        selection: { kind: "none", id: null },
-      }));
+      // Single-tab mode replaces the current tab (or parks for confirmation);
+      // multi-tab appends (#342).
+      set((s) => placeOpenedTab(s, tab));
     } catch {
       // ignore
     }
@@ -593,11 +682,9 @@ export const useEditStore = create<EditState>((set, get) => ({
         libraryId: null,
         libraryScope: null,
       };
-      set((s) => ({
-        openTabs: [...s.openTabs, tab],
-        activeTabId: tabId,
-        selection: { kind: "none", id: null },
-      }));
+      // Single-tab mode replaces the current tab (or parks for confirmation);
+      // multi-tab appends (#342).
+      set((s) => placeOpenedTab(s, tab));
     } catch {
       // ignore
     }
@@ -625,6 +712,64 @@ export const useEditStore = create<EditState>((set, get) => ({
       };
     });
   },
+
+  closeTabs: (ids: string[]) => {
+    set((s) => {
+      const drop = new Set(ids);
+      const tabs = s.openTabs.filter((t) => !drop.has(t.id));
+      const activeClosed = s.activeTabId != null && drop.has(s.activeTabId);
+      // Recompute the active tab ONCE, and only when the active one closed —
+      // never point it at a tab in `drop`. Rightmost survivor (mirror
+      // `closeTab`/`removePipeline`), or null when everything closed.
+      const activeTabId = activeClosed
+        ? (tabs.length > 0 ? tabs[tabs.length - 1].id : null)
+        : s.activeTabId;
+      // Only reset `selection` when the active tab was closed — the
+      // `removePipeline` semantics, NOT the unconditional reset of `closeTab`.
+      // Keeping the reference stable when a background tab closes avoids a
+      // needless render-phase reconciliation pass (#247/#320).
+      const selection = activeClosed ? { kind: "none" as const, id: null } : s.selection;
+      // DROP each closed tab's undo history by id (ADR-0014). Missing an id
+      // would leak its stack and let a reused id inherit a stale one.
+      const history = ids.reduce((h, id) => droppedHistory(h, id), s.history);
+      return { openTabs: tabs, activeTabId, selection, history };
+    });
+  },
+
+  setSingleTabMode: (v: boolean) => {
+    // Persist AT THE CHANGE (Trap B): the pref is per-client, independent of the
+    // daemon and of the numeric Save button. Update the store so the seams read
+    // the mode hot without touching localStorage.
+    saveTabsDisabled(v);
+    set({ singleTabMode: v });
+    if (!v) return; // disabling never closes anything — accumulation resumes.
+    const s = get();
+    if (s.openTabs.length <= 1) return; // already at most one tab
+    const victims = s.openTabs.filter((t) => t.id !== s.activeTabId);
+    if (victims.length === 0) return;
+    if (victims.some(hasUnsavedWork)) {
+      // Park (tab === null ⇒ collapse: keep the active tab, close the rest).
+      set({ pendingSingleTab: { tab: null, victims } });
+    } else {
+      get().closeTabs(victims.map((t) => t.id));
+    }
+  },
+
+  confirmPendingSingleTab: () => {
+    const p = get().pendingSingleTab;
+    if (!p) return;
+    if (p.tab) {
+      // Open-replace: apply the parked tab as the sole tab.
+      set((s) => replaceWithTab(s, p.tab!, p.victims));
+    } else {
+      // Enable-collapse: close the others, keep the active tab. `closeTabs`
+      // already drops their history and leaves the active selection intact.
+      get().closeTabs(p.victims.map((t) => t.id));
+      set({ pendingSingleTab: null });
+    }
+  },
+
+  cancelPendingSingleTab: () => set({ pendingSingleTab: null }),
 
   setActiveTab: (id: string) => {
     set({ activeTabId: id, selection: { kind: "none", id: null } });


### PR DESCRIPTION
## Résumé

Améliore le système d'onglets de pipeline (canvas) sur deux axes :

**Tranche A — menu contextuel + fermeture en masse.** Clic droit sur un onglet ouvre un menu à 4 items : *Close* / *Close others* / *Close to the right* / *Close all*. La fermeture est atomique (`closeTabs` en un seul `set()`), sans flash. La garde dirty ne nomme dans la modale de confirmation que le travail réellement non sauvé (`dirty || conflict || saveError`).

**Tranche B — mode mono-onglet.** Une section « Interface » dans les Settings expose un toggle *Single-tab mode*, persisté dans `localStorage["pdo.ui.tabsDisabled"]` au change (pas de bouton Save). En mode mono-onglet, ouvrir une pipeline remplace l'onglet actif ; si celui-ci est sale, l'ouverture est *parkée* derrière la modale globale (App) qui protège tout travail non sauvé.

## Validation

- Build #342 propre : `typecheck` PASS, `vitest` **1191 passed / 0 failed**, `build` PASS ; tous les fichiers modifiés passent le lint.
- Test agentique (chrome-devtools MCP) sur stack isolée : les 12 étapes des deux tranches se comportent comme spécifié (atomicité, garde dirty, persistance localStorage, sémantique de park). Console propre.
- Réserve hors périmètre : 2 erreurs de lint **préexistantes** sur `RunFilters.tsx` (identiques à `main`, introduites par #336) — à traiter séparément, non régressif.

Closes #342
