### PR TITLE
feat(#353): repeated inputs resolve via projection, not a raw iter-* disk glob — v0.1.78

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -136,7 +136,7 @@ loops:
 - **Par-boucle**, keyé sur l'`id` : une boucle = un `iter`. Tout nœud **membre** estampille ses artefacts avec l'`iter` courant. Un nœud hors boucle garde l'`iter` de ses propres runs (1 s'il n'a couru qu'une fois) : il n'est **jamais re-spawné par un lap** (#195/#199 — seul un vrai cycle émergent ou le moteur de région peut re-lancer un nœud déjà complété ; un membre n'est jamais spawné au-delà de `max_iter`).
 - **Résolution d'inputs** (canonique, #194/#210 — module `input_resolution`) : un input se résout vers **la dernière itération complétée** du nœud source — jamais l'artefact d'une itération échouée, jamais un alignement positionnel sur l'`iter` du consommateur. Un feeder externe à une boucle continue de servir son artefact complété à n'importe quel lap.
 - `bounded` : le compteur **incrémente quand une re-entry fire**, et l'entrée est re-spawnée **une seule fois par lap** même si plusieurs re-entries firent (coalescées — absorbe le double-spawn iter+1 de #108). La barrière de lap dans un body multi-nœuds est le fan-in naturel du nœud de jointure, pas une machinerie dédiée.
-- Adressage et accumulation inchangés : `reviewer/iter-2/review/output.md` ; un input `repeated: true` glob `iter-*/<port>` → un artefact par lap, ordonné.
+- Adressage inchangé : `reviewer/iter-2/review/output.md`. L'accumulation (`repeated: true`) suit la **même quarantaine** que la résolution simple ci-dessus : un artefact par lap **complété** du nœud source (les itérations échouées/interrompues restent sur disque mais ne sont jamais poolées), ordonné par N — la résolution passe par la projection (`RunState::completed_iters`), jamais par un glob `iter-*` brut du disque (#353).
 
 ### Sortie de boucle
 
@@ -213,7 +213,7 @@ Chaque artefact produit par un NodeRun a un chemin canonique :
 
 **Résolution des inputs** :
 - Wire simple → input port lit `<artifacts>/<source-node>/iter-<latest>/<port>.md`.
-- Wire d'accumulation (port marqué `repeated`, typiquement le port `reviews_bloquantes` côté Implementer dans un cycle) → input port lit le glob `<artifacts>/<source>/iter-*/<port>.md`, ordonné par N.
+- Wire d'accumulation (port marqué `repeated`, typiquement le port `reviews_bloquantes` côté Implementer dans un cycle) → input port lit un artefact par **itération complétée** du nœud source (`<artifacts>/<source>/iter-<N>/<port>.md`), ordonné par N. La résolution passe par la projection (`input_resolution` / `RunState::completed_iters`), **pas** par un glob `iter-*` du disque : une itération échouée qui a laissé un `output.md` n'est jamais poolée (#353).
 
 ### Frontmatter — minimal
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "0.1.77"
+version = "0.1.78"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "0.1.77"
+version = "0.1.78"
 license = "MIT"
 
 [workspace.dependencies]

--- a/crates/pdo-daemon/src/event_log.rs
+++ b/crates/pdo-daemon/src/event_log.rs
@@ -448,6 +448,43 @@ impl RunState {
         from_history.or_else(|| (node.status == NodeStatus::Completed).then_some(node.iter))
     }
 
+    /// All `Completed` iterations of `node_id`, ascending (#353).
+    ///
+    /// The set-valued twin of [`latest_completed_iter`], for `repeated`/pooled
+    /// inputs that accumulate one artifact per completed lap. Failed/Stopped/
+    /// Stale iters are quarantined (their artifacts stay on disk but are never
+    /// resolvable as inputs). Falls back to `vec![head_iter]` when the head
+    /// status is `Completed` but no per-iteration history exists (legacy
+    /// states). Empty when the node has no completed iteration or does not
+    /// exist.
+    ///
+    /// `NodeState.iterations` is already sorted by `iter` and deduplicated by
+    /// `(node, iter)` in [`project`], so the history filter yields an ascending,
+    /// duplicate-free `Vec` — no `BTreeSet` needed.
+    ///
+    /// Invariant: `completed_iters(n).last().copied() == latest_completed_iter(n)`.
+    /// `latest_completed_iter` is NOT reimplemented on top of this: the spawn
+    /// path is hot and calls it per resolution, so it avoids the `Vec` alloc.
+    pub fn completed_iters(&self, node_id: &str) -> Vec<i64> {
+        let Some(node) = self.nodes.get(node_id) else {
+            return Vec::new();
+        };
+        let from_history: Vec<i64> = node
+            .iterations
+            .iter()
+            .filter(|it| it.status == NodeStatus::Completed)
+            .map(|it| it.iter)
+            .collect();
+        if !from_history.is_empty() {
+            return from_history;
+        }
+        if node.status == NodeStatus::Completed {
+            vec![node.iter]
+        } else {
+            Vec::new()
+        }
+    }
+
     /// True iff `node_ids` is non-empty AND every id resolves to a node whose
     /// status is `Completed`.
     ///
@@ -3655,6 +3692,62 @@ mod tests {
     fn latest_completed_iter_is_none_for_an_absent_node() {
         let s = run_with(vec![]);
         assert_eq!(s.latest_completed_iter("ghost"), None);
+    }
+
+    #[test]
+    fn completed_iters_quarantines_a_failed_iter_in_the_middle_of_the_set() {
+        // #353: a repeated/pooled source that failed iter 2 must pool iters 1
+        // and 3 only — the failed iter's artifact stays on disk but is never
+        // resolvable.
+        let s = run_with(vec![node_state(
+            "reviewer",
+            NodeStatus::Completed,
+            3,
+            &[
+                (1, NodeStatus::Completed),
+                (2, NodeStatus::Failed),
+                (3, NodeStatus::Completed),
+            ],
+        )]);
+        assert_eq!(s.completed_iters("reviewer"), vec![1, 3]);
+    }
+
+    #[test]
+    fn completed_iters_falls_back_to_head_when_history_is_empty() {
+        // Legacy state: head status Completed, no per-iteration history.
+        let s = run_with(vec![node_state("a", NodeStatus::Completed, 4, &[])]);
+        assert_eq!(s.completed_iters("a"), vec![4]);
+    }
+
+    #[test]
+    fn completed_iters_is_empty_when_nothing_completed_or_node_absent() {
+        let running = run_with(vec![node_state(
+            "a",
+            NodeStatus::Running,
+            1,
+            &[(1, NodeStatus::Running)],
+        )]);
+        assert_eq!(running.completed_iters("a"), Vec::<i64>::new());
+        assert_eq!(running.completed_iters("ghost"), Vec::<i64>::new());
+    }
+
+    #[test]
+    fn completed_iters_last_equals_latest_completed_iter() {
+        // Documented invariant: the set's max is the single-input resolution.
+        let s = run_with(vec![node_state(
+            "a",
+            NodeStatus::Completed,
+            3,
+            &[
+                (1, NodeStatus::Completed),
+                (2, NodeStatus::Failed),
+                (3, NodeStatus::Completed),
+            ],
+        )]);
+        assert_eq!(
+            s.completed_iters("a").last().copied(),
+            s.latest_completed_iter("a")
+        );
     }
 
     #[test]

--- a/crates/pdo-daemon/src/input_resolution.rs
+++ b/crates/pdo-daemon/src/input_resolution.rs
@@ -55,6 +55,35 @@ pub fn resolved_source_iters(
         .collect()
 }
 
+/// For one consumer node, the set of completed source iterations of every
+/// `repeated` incoming edge: `source node id -> completed iters (asc)` (#353).
+///
+/// The set-valued twin of [`resolved_source_iters`], for `repeated`/pooled
+/// inputs that accumulate one artifact per completed source lap. Only
+/// `repeated` edges are included (non-repeated inputs resolve via
+/// [`resolved_source_iters`]). Keyed by source node id, consistent with that
+/// map. Delegates to [`RunState::completed_iters`] — the single authority; the
+/// disk is never scanned for iterations, only read at the blessed ones. A
+/// source with no completed iteration maps to an empty `Vec` (the pool is
+/// empty — never a raw `iter-*` glob, which cannot exclude a failed iter).
+pub fn resolved_repeated_iters(
+    pipeline: &PipelineDef,
+    run_state: &RunState,
+    node_id: &str,
+) -> HashMap<String, Vec<i64>> {
+    pipeline
+        .edges
+        .iter()
+        .filter(|e| e.target.node == node_id && e.repeated)
+        .map(|e| {
+            (
+                e.source.node.clone(),
+                run_state.completed_iters(&e.source.node),
+            )
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -188,5 +217,100 @@ mod tests {
         let resolved = resolved_source_iters(&pipeline, &state, "tester", 1);
         assert_eq!(resolved.get("griller"), Some(&2));
         assert_eq!(resolved.get("impl"), Some(&1));
+    }
+
+    #[test]
+    fn resolved_repeated_iters_pools_only_completed_source_iters() {
+        // #353: a `repeated` edge reviewer→impl. The reviewer failed iter 2, so
+        // the pool is {1, 3} — the failed iter is quarantined, never globbed in.
+        // A second, non-repeated edge is ignored (it resolves via source_iter).
+        use crate::pipeline::{EdgeDef, EdgeEndpoint, PipelineDef};
+        let pipeline = PipelineDef {
+            name: "cycle".into(),
+            version: None,
+            variables: HashMap::new(),
+            nodes: vec![],
+            edges: vec![
+                EdgeDef {
+                    source: EdgeEndpoint {
+                        node: "reviewer".into(),
+                        port: "review".into(),
+                    },
+                    target: EdgeEndpoint {
+                        node: "impl".into(),
+                        port: "reviews".into(),
+                    },
+                    repeated: true,
+                    ..Default::default()
+                },
+                EdgeDef {
+                    source: EdgeEndpoint {
+                        node: "planner".into(),
+                        port: "plan".into(),
+                    },
+                    target: EdgeEndpoint {
+                        node: "impl".into(),
+                        port: "plan".into(),
+                    },
+                    repeated: false,
+                    ..Default::default()
+                },
+            ],
+            loops: vec![],
+            notes: Vec::new(),
+            prompt_required: true,
+        };
+        let state = state_with(vec![
+            node_with_iterations(
+                "reviewer",
+                &[
+                    (1, NodeStatus::Completed),
+                    (2, NodeStatus::Failed),
+                    (3, NodeStatus::Completed),
+                ],
+            ),
+            node_with_iterations("planner", &[(1, NodeStatus::Completed)]),
+        ]);
+        let resolved = resolved_repeated_iters(&pipeline, &state, "impl");
+        assert_eq!(resolved.get("reviewer"), Some(&vec![1, 3]));
+        assert_eq!(
+            resolved.get("planner"),
+            None,
+            "non-repeated edges are excluded — they resolve via resolved_source_iters"
+        );
+    }
+
+    #[test]
+    fn resolved_repeated_iters_empty_pool_when_source_has_no_completed_iter() {
+        // #353 D6: a repeated source that has not completed any iteration yet
+        // maps to an empty Vec — the pool is empty, not a raw glob.
+        use crate::pipeline::{EdgeDef, EdgeEndpoint, PipelineDef};
+        let pipeline = PipelineDef {
+            name: "cycle".into(),
+            version: None,
+            variables: HashMap::new(),
+            nodes: vec![],
+            edges: vec![EdgeDef {
+                source: EdgeEndpoint {
+                    node: "reviewer".into(),
+                    port: "review".into(),
+                },
+                target: EdgeEndpoint {
+                    node: "impl".into(),
+                    port: "reviews".into(),
+                },
+                repeated: true,
+                ..Default::default()
+            }],
+            loops: vec![],
+            notes: Vec::new(),
+            prompt_required: true,
+        };
+        let state = state_with(vec![node_with_iterations(
+            "reviewer",
+            &[(1, NodeStatus::Running)],
+        )]);
+        let resolved = resolved_repeated_iters(&pipeline, &state, "impl");
+        assert_eq!(resolved.get("reviewer"), Some(&Vec::<i64>::new()));
     }
 }

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -4523,14 +4523,25 @@ async fn spawn_node(
         // spawn time so each input path follows its source's latest COMPLETED
         // iteration — a failed iteration's artifacts are never consumed, and an
         // external feeder keeps serving its completed iter at any lap.
-        let source_iters = match reload_run_state(state, run_id).await {
-            Some((_, fresh_state)) => input_resolution::resolved_source_iters(
-                spawn_ctx.pipeline,
-                &fresh_state,
-                &node.id,
-                iter,
+        // #353: alongside the single-input source iters, resolve the `repeated`
+        // pools from the SAME fresh projection — one artifact per COMPLETED
+        // source iteration, so a failed iter's artifact is never pooled and no
+        // raw `iter-*` glob reaches the agent/script.
+        let (source_iters, repeated_iters) = match reload_run_state(state, run_id).await {
+            Some((_, fresh_state)) => (
+                input_resolution::resolved_source_iters(
+                    spawn_ctx.pipeline,
+                    &fresh_state,
+                    &node.id,
+                    iter,
+                ),
+                input_resolution::resolved_repeated_iters(
+                    spawn_ctx.pipeline,
+                    &fresh_state,
+                    &node.id,
+                ),
             ),
-            None => HashMap::new(),
+            None => (HashMap::new(), HashMap::new()),
         };
 
         // Precompute whether the Start prompt carries content so `build_preamble`
@@ -4568,6 +4579,7 @@ async fn spawn_node(
             input_images,
             start_prompt_present,
             source_iters,
+            repeated_iters,
         };
 
         let full_prompt = prompt_augmenter::build_full_prompt(&aug_ctx, &role_prompt);
@@ -7326,7 +7338,10 @@ async fn node_io(
 
     let artifacts_dir = archived_or_live_artifacts_dir(&state, &run_state, &run_id);
 
-    let io = node_io_resolver::resolve(&pipeline, &artifacts_dir, &node_id, iter);
+    // #353: the resolver reads `repeated` pools through the projection (already
+    // projected above, valid for live + archived runs), so a failed iteration's
+    // artifact on disk is never surfaced as resolvable.
+    let io = node_io_resolver::resolve(&pipeline, &artifacts_dir, &node_id, iter, &run_state);
     Json(io).into_response()
 }
 

--- a/crates/pdo-daemon/src/node_io_resolver.rs
+++ b/crates/pdo-daemon/src/node_io_resolver.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 
 use serde::Serialize;
 
+use crate::event_log::RunState;
 use crate::frontmatter_parser;
 use crate::pipeline::{self, PipelineDef, PortType};
 
@@ -28,7 +29,22 @@ pub struct NodeIO {
     pub outputs: Vec<PortIO>,
 }
 
-pub fn resolve(pipeline: &PipelineDef, artifacts_dir: &Path, node_id: &str, iter: i64) -> NodeIO {
+/// Resolve the input/output file view of `node_id` at `iter` for the inspector
+/// `/io` endpoint.
+///
+/// `run_state` is the run's projection (#353): `repeated`/pooled inputs enumerate
+/// one file per COMPLETED source iteration via [`RunState::completed_iters`], so
+/// the inspector shows the *resolvable* set — not "everything on disk", which
+/// would surface artifacts of failed iterations. Works identically for live and
+/// archived runs (#315): the projection comes from the durable event log, never
+/// purged by archival; only *where files are read* differs.
+pub fn resolve(
+    pipeline: &PipelineDef,
+    artifacts_dir: &Path,
+    node_id: &str,
+    iter: i64,
+    run_state: &RunState,
+) -> NodeIO {
     let node = pipeline.nodes.iter().find(|n| n.id == node_id);
     let node = match node {
         Some(n) => n,
@@ -55,8 +71,12 @@ pub fn resolve(pipeline: &PipelineDef, artifacts_dir: &Path, node_id: &str, iter
 
         let mut files = Vec::new();
         if edge.repeated {
+            // #353: pool one file per COMPLETED source iteration, resolved via
+            // the projection — never a raw `iter-*` disk scan, which would
+            // surface a failed iteration's artifact.
             let source_dir = artifacts_dir.join(&edge.source.node);
-            files.extend(glob_repeated(&source_dir, &edge.source.port));
+            let completed = run_state.completed_iters(&edge.source.node);
+            files.extend(glob_repeated(&source_dir, &edge.source.port, &completed));
         } else {
             let path = crate::blackboard::artifact_path(
                 artifacts_dir,
@@ -241,7 +261,13 @@ fn list_image_files(artifacts_dir: &Path, port_dir: &Path) -> Vec<FileInfo> {
     files
 }
 
-fn glob_repeated(source_dir: &Path, port_name: &str) -> Vec<FileInfo> {
+/// Collect one `output.md` per COMPLETED source iteration, ascending.
+///
+/// `completed` is the set of source iterations the projection blesses (#353).
+/// The disk is still walked to find the `iter-N` directories, but an iter is
+/// kept only if it is in `completed` — a failed iteration that left an
+/// `output.md` on disk is quarantined, never pooled.
+fn glob_repeated(source_dir: &Path, port_name: &str, completed: &[i64]) -> Vec<FileInfo> {
     let mut results = Vec::new();
 
     let Ok(entries) = std::fs::read_dir(source_dir) else {
@@ -254,7 +280,7 @@ fn glob_repeated(source_dir: &Path, port_name: &str) -> Vec<FileInfo> {
         .filter_map(|e| {
             let name = e.file_name().to_string_lossy().to_string();
             let n = name.strip_prefix("iter-")?.parse::<i64>().ok()?;
-            Some((n, e.path()))
+            completed.contains(&n).then_some((n, e.path()))
         })
         .collect();
 
@@ -286,9 +312,44 @@ fn glob_repeated(source_dir: &Path, port_name: &str) -> Vec<FileInfo> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::event_log::{IterationInfo, NodeState, NodeStatus};
     use crate::pipeline::{EdgeDef, EdgeEndpoint, NodeDef, NodeType, Port, PortType};
     use pretty_assertions::assert_eq;
     use std::fs;
+
+    /// A run projection where a non-repeated wire is resolved — the `iter` arg
+    /// carries the resolution, so `completed_iters` is never consulted.
+    fn empty_run_state() -> RunState {
+        RunState::new("run-1".into(), "test".into())
+    }
+
+    /// A run projection marking `node_id`'s `iters` as the given statuses, so
+    /// `completed_iters` (the #353 authority) resolves a `repeated` pool.
+    fn run_state_with(node_id: &str, iters: &[(i64, NodeStatus)]) -> RunState {
+        let (head_iter, head_status) = iters.last().cloned().unwrap_or((1, NodeStatus::Pending));
+        let node = NodeState {
+            node_id: node_id.to_string(),
+            status: head_status,
+            iter: head_iter,
+            started_at: None,
+            completed_at: None,
+            failure_reason: None,
+            iterations: iters
+                .iter()
+                .map(|(iter, status)| IterationInfo {
+                    iter: *iter,
+                    status: status.clone(),
+                    started_at: None,
+                    completed_at: None,
+                })
+                .collect(),
+            frontmatter_retries: 0,
+            frontmatter_violations: Vec::new(),
+        };
+        let mut s = RunState::new("run-1".into(), "test".into());
+        s.nodes.insert(node_id.to_string(), node);
+        s
+    }
 
     fn simple_pipeline() -> PipelineDef {
         PipelineDef {
@@ -381,7 +442,7 @@ mod tests {
         fs::create_dir_all(&artifacts).unwrap();
 
         let pipeline = simple_pipeline();
-        let io = resolve(&pipeline, &artifacts, "implementer", 1);
+        let io = resolve(&pipeline, &artifacts, "implementer", 1, &empty_run_state());
 
         assert_eq!(io.inputs.len(), 1);
         assert_eq!(io.inputs[0].port, "plan");
@@ -400,7 +461,7 @@ mod tests {
         fs::write(dir.join("output.md"), "# My plan\nDo stuff.").unwrap();
 
         let pipeline = simple_pipeline();
-        let io = resolve(&pipeline, &artifacts, "implementer", 1);
+        let io = resolve(&pipeline, &artifacts, "implementer", 1, &empty_run_state());
 
         assert!(io.inputs[0].files[0].exists);
         assert!(io.inputs[0].files[0].size.unwrap() > 0);
@@ -419,7 +480,7 @@ mod tests {
         .unwrap();
 
         let pipeline = simple_pipeline();
-        let io = resolve(&pipeline, &artifacts, "implementer", 1);
+        let io = resolve(&pipeline, &artifacts, "implementer", 1, &empty_run_state());
 
         assert_eq!(io.outputs.len(), 1);
         assert_eq!(io.outputs[0].port, "summary");
@@ -436,29 +497,16 @@ mod tests {
         fs::create_dir_all(&artifacts).unwrap();
 
         let pipeline = simple_pipeline();
-        let io = resolve(&pipeline, &artifacts, "implementer", 1);
+        let io = resolve(&pipeline, &artifacts, "implementer", 1, &empty_run_state());
 
         assert_eq!(io.outputs.len(), 1);
         assert!(!io.outputs[0].files[0].exists);
         assert!(io.outputs[0].files[0].frontmatter.is_none());
     }
 
-    #[test]
-    fn repeated_port_glob_expansion() {
-        let tmp = tempfile::tempdir().unwrap();
-        let artifacts = tmp.path().join("artifacts");
-
-        for i in 1..=3 {
-            let dir = artifacts.join(format!("reviewer/iter-{i}/review"));
-            fs::create_dir_all(&dir).unwrap();
-            fs::write(
-                dir.join("output.md"),
-                format!("---\nverdict: FAIL\n---\n\nIter {i} review"),
-            )
-            .unwrap();
-        }
-
-        let pipeline = PipelineDef {
+    /// reviewer → implementer, `repeated` edge feeding port `reviews`.
+    fn reviewer_cycle_pipeline() -> PipelineDef {
+        PipelineDef {
             name: "cycle".into(),
             version: None,
             variables: HashMap::new(),
@@ -531,9 +579,35 @@ mod tests {
             loops: Vec::new(),
             notes: Vec::new(),
             prompt_required: true,
-        };
+        }
+    }
 
-        let io = resolve(&pipeline, &artifacts, "implementer", 4);
+    #[test]
+    fn repeated_port_glob_expansion() {
+        let tmp = tempfile::tempdir().unwrap();
+        let artifacts = tmp.path().join("artifacts");
+
+        for i in 1..=3 {
+            let dir = artifacts.join(format!("reviewer/iter-{i}/review"));
+            fs::create_dir_all(&dir).unwrap();
+            fs::write(
+                dir.join("output.md"),
+                format!("---\nverdict: FAIL\n---\n\nIter {i} review"),
+            )
+            .unwrap();
+        }
+
+        let pipeline = reviewer_cycle_pipeline();
+        // The reviewer completed all three laps: the pool is all three files.
+        let run_state = run_state_with(
+            "reviewer",
+            &[
+                (1, NodeStatus::Completed),
+                (2, NodeStatus::Completed),
+                (3, NodeStatus::Completed),
+            ],
+        );
+        let io = resolve(&pipeline, &artifacts, "implementer", 4, &run_state);
 
         assert_eq!(io.inputs.len(), 1);
         assert!(io.inputs[0].repeated);
@@ -553,6 +627,49 @@ mod tests {
     }
 
     #[test]
+    fn repeated_pool_excludes_a_failed_iteration_on_disk() {
+        // #353 acceptance regression: iter-1, iter-2, iter-3 all wrote an
+        // output.md on disk, but the projection marks iter-2 FAILED. The pool
+        // must be iter-1 + iter-3 only — the failed iter's artifact is
+        // quarantined even though it sits right there on disk. This is the test
+        // that fails before the fix (the raw glob returned all three).
+        let tmp = tempfile::tempdir().unwrap();
+        let artifacts = tmp.path().join("artifacts");
+        for i in 1..=3 {
+            let dir = artifacts.join(format!("reviewer/iter-{i}/review"));
+            fs::create_dir_all(&dir).unwrap();
+            fs::write(dir.join("output.md"), format!("Iter {i} review")).unwrap();
+        }
+
+        let pipeline = reviewer_cycle_pipeline();
+        let run_state = run_state_with(
+            "reviewer",
+            &[
+                (1, NodeStatus::Completed),
+                (2, NodeStatus::Failed),
+                (3, NodeStatus::Completed),
+            ],
+        );
+        let io = resolve(&pipeline, &artifacts, "implementer", 4, &run_state);
+
+        assert_eq!(io.inputs.len(), 1);
+        assert!(io.inputs[0].repeated);
+        assert_eq!(
+            io.inputs[0].files.len(),
+            2,
+            "the failed iter-2 is quarantined despite being on disk"
+        );
+        assert_eq!(
+            io.inputs[0].files[0].path,
+            "reviewer/iter-1/review/output.md"
+        );
+        assert_eq!(
+            io.inputs[0].files[1].path,
+            "reviewer/iter-3/review/output.md"
+        );
+    }
+
+    #[test]
     fn entry_node_with_no_edges_gets_input_md() {
         let tmp = tempfile::tempdir().unwrap();
         let artifacts = tmp.path().join("artifacts");
@@ -561,7 +678,7 @@ mod tests {
         fs::write(input_dir.join("output.md"), "Do the thing").unwrap();
 
         let pipeline = simple_pipeline();
-        let io = resolve(&pipeline, &artifacts, "planner", 1);
+        let io = resolve(&pipeline, &artifacts, "planner", 1, &empty_run_state());
 
         assert_eq!(io.inputs.len(), 1);
         assert_eq!(io.inputs[0].port, "task");
@@ -684,7 +801,7 @@ mod tests {
             fs::write(dir.join("output.md"), format!("from {dir_name}")).unwrap();
         }
 
-        let io = resolve(&pipeline, &artifacts, "merger", 1);
+        let io = resolve(&pipeline, &artifacts, "merger", 1, &empty_run_state());
 
         assert_eq!(io.inputs.len(), 1);
         assert_eq!(io.inputs[0].port, "docs");
@@ -762,7 +879,7 @@ mod tests {
             prompt_required: true,
         };
 
-        let io = resolve(&pipeline, &artifacts, "implementer", 1);
+        let io = resolve(&pipeline, &artifacts, "implementer", 1, &empty_run_state());
 
         assert_eq!(io.inputs.len(), 1);
         assert_eq!(io.inputs[0].port, "plan");
@@ -839,7 +956,7 @@ mod tests {
             prompt_required: true,
         };
 
-        let io = resolve(&pipeline, &artifacts, "sink", 1);
+        let io = resolve(&pipeline, &artifacts, "sink", 1, &empty_run_state());
 
         // One logical input, pooled into a list of both source files.
         assert_eq!(io.inputs.len(), 1);
@@ -919,7 +1036,7 @@ mod tests {
             prompt_required: true,
         };
 
-        let io = resolve(&pipeline, &artifacts, "sink", 1);
+        let io = resolve(&pipeline, &artifacts, "sink", 1, &empty_run_state());
 
         assert_eq!(io.inputs.len(), 2);
         assert_eq!(io.inputs[0].port, "plan");
@@ -937,7 +1054,7 @@ mod tests {
         fs::create_dir_all(&artifacts).unwrap();
 
         let pipeline = simple_pipeline();
-        let io = resolve(&pipeline, &artifacts, "nonexistent", 1);
+        let io = resolve(&pipeline, &artifacts, "nonexistent", 1, &empty_run_state());
 
         assert!(io.inputs.is_empty());
         assert!(io.outputs.is_empty());

--- a/crates/pdo-daemon/src/node_primitives.rs
+++ b/crates/pdo-daemon/src/node_primitives.rs
@@ -145,6 +145,11 @@ pub fn start_node(params: &StartNodeParams<'_>) -> StartNodeResult {
             params.node_id,
             params.iter,
         ),
+        repeated_iters: crate::input_resolution::resolved_repeated_iters(
+            params.pipeline,
+            params.run_state,
+            params.node_id,
+        ),
     };
 
     let full_prompt = crate::prompt_augmenter::build_full_prompt(&aug_ctx, &role_prompt);
@@ -271,6 +276,18 @@ fn resolve_inputs(
 ) -> HashMap<String, String> {
     let mut input_paths = HashMap::new();
 
+    // #353: `repeated` pools resolve through the projection — one concrete path
+    // per COMPLETED source iteration, never a raw `iter-*` disk glob (which would
+    // pool a failed iteration's artifact). Keyed by source node and filtered on
+    // `edge.repeated`, consistent with the other two resolvers; the declared
+    // `input_port.repeated` flag is NOT the authority (edge-based model, #149 /
+    // ADR-0011). This map backs only the forensic `NodeStarted` payload.
+    let repeated_iters = crate::input_resolution::resolved_repeated_iters(
+        params.pipeline,
+        params.run_state,
+        params.node_id,
+    );
+
     for input_port in &node.inputs {
         if let Some(override_path) = params
             .overrides
@@ -291,13 +308,28 @@ fn resolve_inputs(
             .find(|e| e.target.node == params.node_id && e.target.port == input_port.name);
 
         if let Some(edge) = matching_edge {
-            let resolved = if input_port.repeated {
-                let source_dir = params.artifacts_dir.join(&edge.source.node);
-                format!(
-                    "{}/iter-*/{}/output.md",
-                    source_dir.to_string_lossy(),
-                    edge.source.port
-                )
+            let resolved = if edge.repeated {
+                // Concrete completed-iteration paths, `\n`-joined (this HashMap
+                // is mono-value; the payload is forensic, not machine-read).
+                repeated_iters
+                    .get(&edge.source.node)
+                    .map(|iters| {
+                        iters
+                            .iter()
+                            .map(|&n| {
+                                blackboard::artifact_path(
+                                    params.artifacts_dir,
+                                    &edge.source.node,
+                                    n,
+                                    &edge.source.port,
+                                )
+                                .to_string_lossy()
+                                .to_string()
+                            })
+                            .collect::<Vec<_>>()
+                            .join("\n")
+                    })
+                    .unwrap_or_default()
             } else {
                 // Canonical resolution (#194 / #210): the source's latest
                 // COMPLETED iteration, never a failed iteration's artifact.
@@ -958,8 +990,35 @@ mod tests {
         assert!(input_paths.contains_key("research"));
     }
 
+    fn completed_node_iters(id: &str, iters: &[(i64, NodeStatus)]) -> NodeState {
+        let (head_iter, head_status) = iters.last().cloned().unwrap_or((1, NodeStatus::Pending));
+        NodeState {
+            node_id: id.into(),
+            status: head_status,
+            iter: head_iter,
+            started_at: Some("t0".into()),
+            completed_at: None,
+            failure_reason: None,
+            iterations: iters
+                .iter()
+                .map(|(iter, status)| IterationInfo {
+                    iter: *iter,
+                    status: status.clone(),
+                    started_at: Some("t0".into()),
+                    completed_at: None,
+                })
+                .collect(),
+            frontmatter_retries: 0,
+            frontmatter_violations: Vec::new(),
+        }
+    }
+
     #[test]
-    fn start_node_resolves_repeated_port_with_glob() {
+    fn start_node_resolves_repeated_port_via_projection() {
+        // #353: a `repeated` edge resolves (in the forensic NodeStarted payload)
+        // to the concrete completed-iteration paths from the projection, NOT a
+        // raw `iter-*` glob. `repeated` is read off the EDGE (#149), and the
+        // reviewer's failed iter-2 is quarantined even though it may be on disk.
         let pipeline = PipelineDef {
             name: "test".into(),
             version: None,
@@ -968,13 +1027,27 @@ mod tests {
                 make_node("reviewer", NodeType::DocOnly, &["task"], &["review"]),
                 make_node_with_repeated_input("implementer", "reviews"),
             ],
-            edges: vec![make_edge("reviewer", "review", "implementer", "reviews")],
+            edges: vec![EdgeDef {
+                repeated: true,
+                ..make_edge("reviewer", "review", "implementer", "reviews")
+            }],
             loops: Vec::new(),
             notes: Vec::new(),
             prompt_required: true,
         };
 
-        let run_state = empty_run_state();
+        let mut run_state = empty_run_state();
+        run_state.nodes.insert(
+            "reviewer".into(),
+            completed_node_iters(
+                "reviewer",
+                &[
+                    (1, NodeStatus::Completed),
+                    (2, NodeStatus::Failed),
+                    (3, NodeStatus::Completed),
+                ],
+            ),
+        );
         let tmp = tempfile::tempdir().unwrap();
         let artifacts_dir = tmp.path().join("artifacts");
         std::fs::create_dir_all(&artifacts_dir).unwrap();
@@ -1003,8 +1076,18 @@ mod tests {
 
         let input_paths = resolve_inputs(&params, node);
         let reviews_path = input_paths.get("reviews").unwrap();
-        assert!(reviews_path.contains("iter-*"));
-        assert!(reviews_path.contains("review"));
+        assert!(
+            !reviews_path.contains("iter-*"),
+            "no raw glob: {reviews_path}"
+        );
+        assert!(reviews_path.contains("iter-1/review/output.md"));
+        assert!(reviews_path.contains("iter-3/review/output.md"));
+        assert!(
+            !reviews_path.contains("iter-2"),
+            "failed iter-2 is quarantined: {reviews_path}"
+        );
+        // The two paths are newline-joined (mono-value forensic HashMap).
+        assert_eq!(reviews_path.lines().count(), 2);
     }
 
     #[test]

--- a/crates/pdo-daemon/src/prompt_augmenter.rs
+++ b/crates/pdo-daemon/src/prompt_augmenter.rs
@@ -5,7 +5,11 @@ use crate::pipeline::{NodeDef, PipelineDef, PortType, IMAGE_EXTENSIONS};
 
 pub struct InputResolution {
     pub port_name: String,
-    pub path: PathBuf,
+    /// The concrete artifact path(s) this input resolves to. A single wire is a
+    /// one-element list; a `repeated`/pooled input (#353) is one path per
+    /// COMPLETED source iteration (empty when the source has completed none —
+    /// never a raw `iter-*` glob, which cannot exclude a failed iter).
+    pub paths: Vec<PathBuf>,
     pub repeated: bool,
     /// True when this input is sourced from the Start node's user prompt
     /// (`_input/output.md`). The entry node's prompt label adapts to
@@ -52,6 +56,14 @@ pub struct AugmentContext<'a> {
     /// map falls back to the consumer's own `iter` (positional), preserving
     /// override/injection flows where nothing has completed yet.
     pub source_iters: HashMap<String, i64>,
+    /// Set-valued resolution for `repeated`/pooled inputs (#353): for each
+    /// source node feeding a `repeated` incoming edge, its COMPLETED iterations
+    /// (ascending), per `input_resolution::resolved_repeated_iters`. Precomputed
+    /// by the daemon (this module is pure and cannot hold a `RunState`). A
+    /// source absent from the map (or mapping to an empty `Vec`) pools nothing —
+    /// failed iterations are quarantined, and no raw `iter-*` glob is ever
+    /// handed to an agent or script.
+    pub repeated_iters: HashMap<String, Vec<i64>>,
 }
 
 pub fn discover_input_images(artifacts_dir: &Path) -> Vec<String> {
@@ -113,14 +125,30 @@ pub fn resolve_input_paths(ctx: &AugmentContext<'_>) -> Vec<InputResolution> {
             .iter()
             .any(|n| n.id == *source_node && n.node_type == crate::pipeline::NodeType::Start);
 
-        let path = if is_start {
-            crate::blackboard::input_path(ctx.artifacts_dir)
+        let paths: Vec<PathBuf> = if is_start {
+            vec![crate::blackboard::input_path(ctx.artifacts_dir)]
         } else if repeated {
-            ctx.artifacts_dir
-                .join(source_node)
-                .join("iter-*")
-                .join(&edge.source.port)
-                .join("output.md")
+            // #353: enumerate one concrete path per COMPLETED source iteration,
+            // resolved via the projection (`repeated_iters`) — never a raw
+            // `iter-*` glob, which cannot exclude a failed iteration's artifact.
+            // A source with no completed iter (absent from the map) pools
+            // nothing (D6).
+            ctx.repeated_iters
+                .get(source_node.as_str())
+                .map(|iters| {
+                    iters
+                        .iter()
+                        .map(|&n| {
+                            crate::blackboard::artifact_path(
+                                ctx.artifacts_dir,
+                                source_node,
+                                n,
+                                &edge.source.port,
+                            )
+                        })
+                        .collect()
+                })
+                .unwrap_or_default()
         } else {
             // Canonical resolution (#194): read the source's latest completed
             // iteration, never a failed iteration's artifact and never a
@@ -130,17 +158,17 @@ pub fn resolve_input_paths(ctx: &AugmentContext<'_>) -> Vec<InputResolution> {
                 .get(source_node.as_str())
                 .copied()
                 .unwrap_or(ctx.iter);
-            crate::blackboard::artifact_path(
+            vec![crate::blackboard::artifact_path(
                 ctx.artifacts_dir,
                 source_node,
                 source_iter,
                 &edge.source.port,
-            )
+            )]
         };
 
         inputs.push(InputResolution {
             port_name: edge.target.port.clone(),
-            path,
+            paths,
             repeated,
             from_start: is_start,
         });
@@ -149,7 +177,7 @@ pub fn resolve_input_paths(ctx: &AugmentContext<'_>) -> Vec<InputResolution> {
     if inputs.is_empty() && ctx.node.inputs.iter().any(|p| p.name == "task") {
         inputs.push(InputResolution {
             port_name: "task".into(),
-            path: crate::blackboard::input_path(ctx.artifacts_dir),
+            paths: vec![crate::blackboard::input_path(ctx.artifacts_dir)],
             repeated: false,
             from_start: true,
         });
@@ -224,8 +252,12 @@ fn var_value_to_env_string(value: &serde_yaml::Value) -> String {
 /// resolution the preamble uses — a single source of truth, not a second path.
 ///
 /// - `PDO_ARTIFACTS_DIR` — the Blackboard root.
-/// - `PDO_INPUT_<PORT>` — absolute path (or `iter-*` glob) of each resolved input.
-/// - `PDO_INPUT_<PORT>_REPEATED=1` — set when that input is a `repeated` glob.
+/// - `PDO_INPUT_<PORT>` — absolute path of each resolved input. A `repeated`
+///   input holds one path per COMPLETED source iteration, `\n`-separated (empty
+///   when nothing has completed); a single wire holds exactly one path (#353).
+/// - `PDO_INPUT_<PORT>_REPEATED=1` — set when that input is a `repeated`/pooled
+///   input, so a script knows to `readarray -t files <<< "$PDO_INPUT_<PORT>"`
+///   (and to `pdo skip` when the value is empty).
 /// - `PDO_OUTPUT_<PORT>` — absolute path the script writes its `output.md` to.
 /// - `PDO_VAR_<NAME>` — each resolved pipeline variable (sorted for determinism).
 ///
@@ -244,7 +276,18 @@ pub fn build_script_env(ctx: &AugmentContext<'_>) -> Vec<(String, String)> {
         if input.repeated {
             env.push((format!("{key}_REPEATED"), "1".to_string()));
         }
-        env.push((key, input.path.to_string_lossy().into_owned()));
+        // #353: a `repeated` input is one path per completed source iteration,
+        // `\n`-separated (empty when none completed). `sh_single_quote` in
+        // `wrap_with_env` preserves the newlines verbatim, and a newline (not a
+        // space) keeps paths that contain spaces splittable. A single wire is a
+        // one-element list, so its value is unchanged.
+        let value = input
+            .paths
+            .iter()
+            .map(|p| p.to_string_lossy())
+            .collect::<Vec<_>>()
+            .join("\n");
+        env.push((key, value));
     }
 
     for output in resolve_output_paths(ctx) {
@@ -334,34 +377,52 @@ pub fn build_preamble(ctx: &AugmentContext<'_>) -> String {
             // must source its own work; when a prompt is supplied it is merely
             // additional info layered on the node's own brief.
             if input.from_start && !ctx.pipeline.prompt_required {
+                // `from_start` is always a single path.
+                let path = input
+                    .paths
+                    .first()
+                    .map(|p| p.display().to_string())
+                    .unwrap_or_default();
                 if ctx.start_prompt_present {
                     preamble.push_str(&format!(
                         "- `{}` (additional info): read `{}`. \
                          This is supplementary context — your role prompt below is the primary brief.\n",
-                        input.port_name,
-                        input.path.display()
+                        input.port_name, path
                     ));
                 } else {
                     preamble.push_str(&format!(
                         "- `{}`: No prompt was provided for this run. \
                          Source your own work from your role prompt below \
                          (an empty `{}` is expected).\n",
-                        input.port_name,
-                        input.path.display()
+                        input.port_name, path
                     ));
                 }
             } else if input.repeated {
-                preamble.push_str(&format!(
-                    "- `{}` (accumulated): read all files matching `{}`\n",
-                    input.port_name,
-                    input.path.display()
-                ));
+                // #353: enumerate one concrete path per completed source
+                // iteration — a raw `iter-*` glob would re-include failed iters.
+                // Empty pool → an explicit line, never an orphan glob (ADR-0004,
+                // no silent behaviour).
+                if input.paths.is_empty() {
+                    preamble.push_str(&format!(
+                        "- `{}` (accumulated): no completed iterations yet — nothing to read.\n",
+                        input.port_name
+                    ));
+                } else {
+                    preamble.push_str(&format!(
+                        "- `{}` (accumulated): read all of these files:\n",
+                        input.port_name
+                    ));
+                    for path in &input.paths {
+                        preamble.push_str(&format!("  - {}\n", path.display()));
+                    }
+                }
             } else {
-                preamble.push_str(&format!(
-                    "- `{}`: read `{}`\n",
-                    input.port_name,
-                    input.path.display()
-                ));
+                let path = input
+                    .paths
+                    .first()
+                    .map(|p| p.display().to_string())
+                    .unwrap_or_default();
+                preamble.push_str(&format!("- `{}`: read `{}`\n", input.port_name, path));
             }
         }
         preamble.push('\n');
@@ -761,6 +822,7 @@ mod tests {
             input_images: Vec::new(),
             start_prompt_present: false,
             source_iters: HashMap::new(),
+            repeated_iters: HashMap::new(),
         }
     }
 
@@ -775,7 +837,7 @@ mod tests {
         assert_eq!(inputs.len(), 1);
         assert_eq!(inputs[0].port_name, "task");
         assert_eq!(
-            inputs[0].path,
+            inputs[0].paths[0],
             PathBuf::from("/repo/.pdo/artifacts/_input/output.md")
         );
         assert!(!inputs[0].repeated);
@@ -860,10 +922,7 @@ mod tests {
         );
     }
 
-    #[test]
-    fn script_env_marks_repeated_inputs() {
-        // A `repeated` edge → PDO_INPUT_<PORT> is an iter-* glob + a _REPEATED=1
-        // flag so the script knows to glob rather than read a single file.
+    fn script_with_repeated_laps_pipeline() -> PipelineDef {
         let mut pipeline = sample_pipeline();
         pipeline.nodes.push(NodeDef {
             id: "collector".into(),
@@ -889,20 +948,54 @@ mod tests {
             repeated: true,
             ..Default::default()
         });
+        pipeline
+    }
+
+    #[test]
+    fn script_env_marks_repeated_inputs_as_newline_separated_concrete_paths() {
+        // #353: a `repeated` edge → PDO_INPUT_<PORT> is the `\n`-joined list of
+        // concrete completed-iteration paths (no `iter-*` glob) + a _REPEATED=1
+        // flag so the script `readarray -t files <<< "$PDO_INPUT_<PORT>"`.
+        let pipeline = script_with_repeated_laps_pipeline();
         let node = pipeline.nodes.iter().find(|n| n.id == "collector").unwrap();
         let vars = HashMap::new();
-        let ctx = sample_ctx(&pipeline, node, &vars);
+        let mut ctx = sample_ctx(&pipeline, node, &vars);
+        ctx.repeated_iters = HashMap::from([("planner".to_string(), vec![1, 2])]);
 
         let env: HashMap<String, String> = build_script_env(&ctx).into_iter().collect();
         assert_eq!(
             env.get("PDO_INPUT_LAPS_REPEATED").map(String::as_str),
             Some("1")
         );
-        assert!(
-            env.get("PDO_INPUT_LAPS")
-                .map(|v| v.contains("iter-*"))
-                .unwrap_or(false),
-            "repeated input is a glob: {env:?}"
+        let laps = env.get("PDO_INPUT_LAPS").expect("PDO_INPUT_LAPS is set");
+        assert!(!laps.contains("iter-*"), "no raw glob: {laps:?}");
+        assert_eq!(
+            laps,
+            "/repo/.pdo/artifacts/planner/iter-1/plan/output.md\n\
+             /repo/.pdo/artifacts/planner/iter-2/plan/output.md",
+            "newline-separated concrete paths (a path may contain spaces)"
+        );
+    }
+
+    #[test]
+    fn script_env_repeated_empty_pool_keeps_flag_and_empties_value() {
+        // #353 D3: a repeated source with nothing completed → PDO_INPUT_<PORT>
+        // is present but empty, _REPEATED=1 still set, so a script can detect
+        // "repeated but empty" and `pdo skip`.
+        let pipeline = script_with_repeated_laps_pipeline();
+        let node = pipeline.nodes.iter().find(|n| n.id == "collector").unwrap();
+        let vars = HashMap::new();
+        let ctx = sample_ctx(&pipeline, node, &vars); // repeated_iters empty
+
+        let env: HashMap<String, String> = build_script_env(&ctx).into_iter().collect();
+        assert_eq!(
+            env.get("PDO_INPUT_LAPS_REPEATED").map(String::as_str),
+            Some("1")
+        );
+        assert_eq!(
+            env.get("PDO_INPUT_LAPS").map(String::as_str),
+            Some(""),
+            "present but empty when nothing has completed"
         );
     }
 
@@ -1003,7 +1096,7 @@ mod tests {
         assert_eq!(inputs.len(), 1);
         assert_eq!(inputs[0].port_name, "plan");
         assert_eq!(
-            inputs[0].path,
+            inputs[0].paths[0],
             PathBuf::from("/repo/.pdo/artifacts/planner/iter-1/plan/output.md")
         );
     }
@@ -1047,7 +1140,7 @@ mod tests {
         let inputs = resolve_input_paths(&ctx);
         assert_eq!(inputs.len(), 1);
         assert_eq!(
-            inputs[0].path,
+            inputs[0].paths[0],
             PathBuf::from("/repo/.pdo/artifacts/planner/iter-2/plan/output.md")
         );
     }
@@ -1093,15 +1186,14 @@ mod tests {
         assert_eq!(inputs.len(), 1);
         assert_eq!(inputs[0].port_name, "plan");
         assert_eq!(
-            inputs[0].path,
+            inputs[0].paths[0],
             PathBuf::from("/repo/.pdo/artifacts/planner/iter-1/plan/output.md")
         );
     }
 
-    #[test]
-    fn repeated_flag_read_off_edge_in_preamble() {
+    fn repeated_edge_pipeline() -> PipelineDef {
         // #149: `repeated` (accumulate across iterations) lives on the EDGE, not
-        // on a declared input port. The preamble globs `iter-*` accordingly.
+        // on a declared input port. planner → implementer, port `plans`.
         let mut pipeline = sample_pipeline();
         pipeline.nodes.push(NodeDef {
             id: "implementer".into(),
@@ -1130,22 +1222,68 @@ mod tests {
             repeated: true,
             ..Default::default()
         });
+        pipeline
+    }
 
+    #[test]
+    fn repeated_input_enumerates_concrete_completed_iter_paths() {
+        // #353: `repeated` resolves to one concrete path per COMPLETED source
+        // iteration (via the projected `repeated_iters` set), NEVER a raw
+        // `iter-*` glob. planner completed iters 1 and 3 (iter 2 failed) → the
+        // pool is iter-1 + iter-3, and the failed iter-2 is quarantined.
+        let pipeline = repeated_edge_pipeline();
         let node = &pipeline.nodes[1];
         let vars = HashMap::new();
-        let ctx = sample_ctx(&pipeline, node, &vars);
+        let mut ctx = sample_ctx(&pipeline, node, &vars);
+        ctx.repeated_iters = HashMap::from([("planner".to_string(), vec![1, 3])]);
 
         let inputs = resolve_input_paths(&ctx);
         assert_eq!(inputs.len(), 1);
         assert_eq!(inputs[0].port_name, "plans");
         assert!(inputs[0].repeated, "repeated comes from the edge");
         assert_eq!(
-            inputs[0].path,
-            PathBuf::from("/repo/.pdo/artifacts/planner/iter-*/plan/output.md")
+            inputs[0].paths,
+            vec![
+                PathBuf::from("/repo/.pdo/artifacts/planner/iter-1/plan/output.md"),
+                PathBuf::from("/repo/.pdo/artifacts/planner/iter-3/plan/output.md"),
+            ]
         );
+        for p in &inputs[0].paths {
+            assert!(
+                !p.to_string_lossy().contains("iter-*"),
+                "no raw glob survives to the agent"
+            );
+        }
 
         let preamble = build_preamble(&ctx);
         assert!(preamble.contains("`plans` (accumulated)"));
+        assert!(preamble.contains("planner/iter-1/plan/output.md"));
+        assert!(preamble.contains("planner/iter-3/plan/output.md"));
+        assert!(
+            !preamble.contains("iter-2"),
+            "the failed iteration is never enumerated"
+        );
+    }
+
+    #[test]
+    fn repeated_input_with_empty_pool_is_an_explicit_line_not_a_glob() {
+        // #353 D6 / ADR-0004: a repeated source with no completed iteration
+        // yields an empty path list. The preamble says so explicitly (never an
+        // orphan glob), and PDO_INPUT_<PORT> is empty while _REPEATED=1 stays.
+        let pipeline = repeated_edge_pipeline();
+        let node = &pipeline.nodes[1];
+        let vars = HashMap::new();
+        let ctx = sample_ctx(&pipeline, node, &vars); // repeated_iters empty
+
+        let inputs = resolve_input_paths(&ctx);
+        assert_eq!(inputs.len(), 1);
+        assert!(inputs[0].repeated);
+        assert!(inputs[0].paths.is_empty(), "empty pool when none completed");
+
+        let preamble = build_preamble(&ctx);
+        assert!(preamble.contains("`plans` (accumulated)"));
+        assert!(preamble.contains("no completed iterations yet"));
+        assert!(!preamble.contains("iter-*"));
     }
 
     #[test]
@@ -1324,13 +1462,13 @@ mod tests {
 
         let plan_input = inputs.iter().find(|i| i.port_name == "plan").unwrap();
         assert_eq!(
-            plan_input.path,
+            plan_input.paths[0],
             PathBuf::from("/repo/.pdo/artifacts/planner/iter-1/plan/output.md")
         );
 
         let ctx_input = inputs.iter().find(|i| i.port_name == "context").unwrap();
         assert_eq!(
-            ctx_input.path,
+            ctx_input.paths[0],
             PathBuf::from("/repo/.pdo/artifacts/researcher/iter-1/context/output.md")
         );
 

--- a/docs/adr/0017-script-node.md
+++ b/docs/adr/0017-script-node.md
@@ -41,6 +41,17 @@ se complète sur exit 0 / échoue sinon, et — en v1 — n'obtient pas de sous-
   session a déjà quitté, il n'y a plus d'agent à relancer). Les répertoires des ports
   de sortie sont **pré-créés au spawn** (un `> "$PDO_OUTPUT_out"` échouerait sur un
   parent manquant).
+- **Encodage d'un input `repeated`/poolé (#353).** Un input d'accumulation résout vers
+  **un chemin par itération *complétée*** du nœud source (via la projection
+  `RunState::completed_iters`, jamais un glob `iter-*` du disque : une itération
+  échouée qui a laissé un `output.md` n'est jamais poolée). `PDO_INPUT_<PORT>` porte
+  donc la **liste de ces chemins absolus, séparés par des sauts de ligne** (`\n`), et
+  `PDO_INPUT_<PORT>_REPEATED=1` reste posé. Le saut de ligne (et non l'espace) est
+  choisi parce qu'un chemin d'artefact peut contenir des espaces ; `wrap_with_env`
+  single-quote la valeur, donc les `\n` survivent verbatim en bash. Idiome de
+  consommation : `readarray -t files <<< "$PDO_INPUT_<PORT>"`. Un pool **vide** (aucune
+  itération complétée) → `PDO_INPUT_<PORT>=` vide, `_REPEATED=1` toujours présent : le
+  script détecte « repeated mais vide » et peut `pdo skip`.
 - **Le seam de test `tmux_cmd_override` est contourné pour un script.** Pour un agent,
   l'override remplace `claude` par un stub pour que la CI ne lance jamais de vrai
   claude. Un script *est* du bash déterministe : l'override ne doit pas l'écraser.


### PR DESCRIPTION
## Summary

Closes #353. Fixes a latent correctness defect where `repeated` / pooled inputs enumerated `iter-*` directories on disk directly, bypassing the event projection — so an artifact from a **failed** iteration (whose `iter-N/` dir still exists on disk) could silently be pooled into a downstream consumer.

All three `repeated` resolvers now route through a single set-valued authority on `RunState` (`completed_iters` / `resolved_repeated_iters`), deleting the raw `iter-*` globs. One authority (the projection), one place the rule lives.

## Changes

- `event_log.rs` — new set-valued `RunState::completed_iters` / `resolved_repeated_iters` authority.
- `node_io_resolver.rs` — `glob_repeated` filters against the projection-blessed completed set instead of a raw `read_dir`.
- `prompt_augmenter.rs` — the agent-preamble / script-env `repeated` branch resolves concrete completed-iter paths from the projection.
- `lib.rs` — `/io` inspector endpoint and the forensic `NodeStarted` payload consult the same authority.
- `input_resolution.rs` — `InputResolution` now carries a `paths` vector of concrete completed-iter artifacts.
- `CONTEXT.md`, `docs/adr/0017-script-node.md` — doc updates.
- Version bump 0.1.77 → 0.1.78.

## Acceptance criteria

- [x] A `repeated` / pooled input never resolves an artifact from a non-`Completed` iteration of its source node.
- [x] Regression test: source writes on `iter-N`, **fails**, completes on `iter-N+1`; downstream `repeated` consumer pools only the completed iters (fixture includes a failed `iter-N/` dir on disk). Proven to have teeth (fails on pre-fix behaviour).
- [x] `glob_repeated` and the `repeated` branch resolve against the projection-blessed iter set, not a raw `iter-*` glob.
- [x] The rule is testable at its interface (events → resolved iters) without an on-disk failed-iter fixture.

## Verification

- `cargo build -p pdo-daemon` — 0 errors.
- `cargo +stable test -p pdo-daemon` — lib 1216 passed / 0 failed; all integration binaries green.
- `cargo +stable clippy --all-targets` + `cargo +stable fmt --check` — clean.
- 13 issue-specific tests pass; AC#2 regression test verified to fail on pre-fix behaviour.
- Live end-to-end through the `/io` HTTP endpoint + node-inspector UI: a run with reviewer iter-1 Completed / iter-2 Failed / iter-3 Completed (all three on disk) pools only iter-1 + iter-3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)