### PR TITLE
fix(#353): repeated inputs pool COMPLETED source iters, not a raw iter-* glob — v0.1.78

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -26,7 +26,7 @@ Un Node se définit par :
 - **Nom** — identifiant lisible affiché dans le canvas.
 - **Prompt système** — le rôle, écrit dans la zone de texte qui s'ouvre à l'édition.
 - **Ports de sortie — déclarés.** Un ou plusieurs documents produits, chacun un port nommé : c'est le **contrat de production** du Node (avec son schéma de frontmatter optionnel, cf. *Blackboard*). Multi-fan-out supporté (le Debugger sort `repro_steps` + `screenshots`). Rendu : **un dot vert par document**, drag-source des edges, librement placé.
-- **Ports d'entrée — émergents.** Un Node ne **déclare pas** ses entrées : elles sont *dérivées des edges entrantes*. Connecter `debugger.repro_steps` vers un Node y crée de facto une entrée `repro_steps` (le nom suit le document amont). Plusieurs edges de même nom **poolent** dans une seule entrée-liste — pooling **sémantique**, jamais un groupement visuel des flèches : chaque flèche atterrit où le designer veut sur le Node, **sans dot d'entrée**. Sur collision de noms *distincts*, on qualifie par source. L'accumulation cross-itérations (glob `iter-*`) est un flag `repeated` porté par l'**edge**, pas par l'entrée.
+- **Ports d'entrée — émergents.** Un Node ne **déclare pas** ses entrées : elles sont *dérivées des edges entrantes*. Connecter `debugger.repro_steps` vers un Node y crée de facto une entrée `repro_steps` (le nom suit le document amont). Plusieurs edges de même nom **poolent** dans une seule entrée-liste — pooling **sémantique**, jamais un groupement visuel des flèches : chaque flèche atterrit où le designer veut sur le Node, **sans dot d'entrée**. Sur collision de noms *distincts*, on qualifie par source. L'accumulation cross-itérations (les itérations *completed* de la source, cf. #353 — pas un glob `iter-*` brut) est un flag `repeated` porté par l'**edge**, pas par l'entrée.
 
 Asymétrie assumée (et déjà présente dans le typage : output = contrat vérifié, input = best-effort) : le Node *connaît* ses sorties, *découvre* ses entrées au câblage. Conséquence sur la bibliothèque : un Node réutilisable porte ses **outputs + rôle + type**, pas ses inputs (purement pipeline-spécifiques).
 
@@ -136,7 +136,7 @@ loops:
 - **Par-boucle**, keyé sur l'`id` : une boucle = un `iter`. Tout nœud **membre** estampille ses artefacts avec l'`iter` courant. Un nœud hors boucle garde l'`iter` de ses propres runs (1 s'il n'a couru qu'une fois) : il n'est **jamais re-spawné par un lap** (#195/#199 — seul un vrai cycle émergent ou le moteur de région peut re-lancer un nœud déjà complété ; un membre n'est jamais spawné au-delà de `max_iter`).
 - **Résolution d'inputs** (canonique, #194/#210 — module `input_resolution`) : un input se résout vers **la dernière itération complétée** du nœud source — jamais l'artefact d'une itération échouée, jamais un alignement positionnel sur l'`iter` du consommateur. Un feeder externe à une boucle continue de servir son artefact complété à n'importe quel lap.
 - `bounded` : le compteur **incrémente quand une re-entry fire**, et l'entrée est re-spawnée **une seule fois par lap** même si plusieurs re-entries firent (coalescées — absorbe le double-spawn iter+1 de #108). La barrière de lap dans un body multi-nœuds est le fan-in naturel du nœud de jointure, pas une machinerie dédiée.
-- Adressage et accumulation inchangés : `reviewer/iter-2/review/output.md` ; un input `repeated: true` glob `iter-*/<port>` → un artefact par lap, ordonné.
+- Adressage et accumulation inchangés : `reviewer/iter-2/review/output.md` ; un input `repeated: true` accumule **les itérations COMPLETED de la source** (`iter-<N>/<port>`, une par lap, ordonnées par N) — même quarantaine que la résolution simple : une itération échouée reste sur disque mais n'est jamais poolée (#194/#210/#353), donc jamais un glob `iter-*` disque brut.
 
 ### Sortie de boucle
 
@@ -195,7 +195,7 @@ Le **Blackboard** est le store partagé où vivent tous les artefacts d'un Pipel
 - **Localisation** : `<pipeline-worktree>/.pdo/artifacts/`. Suit la branche du Pipeline Run. Part au cleanup **du worktree** — mais est d'abord copié vers le *Blackboard archivé* global (`~/.pdo/runs/<run-id>/artifacts/`, lecture seule, survit au cleanup ; cf. §*Cleanup vs archive* et ADR-0020).
 - **Format** : markdown brut (`.md`) avec **YAML frontmatter** pour les métadonnées structurées (verdict, statut, références, etc.). Le corps reste lisible humainement, le frontmatter est parsable par le runtime.
 - **Wires** : dans l'éditeur, un wire de `Node A → Node B` n'est pas un transport ; c'est une **déclaration de dépendance**. Le runtime traduit en : *"avant de lancer B, attendre que A ait posé son artefact ; l'input port de B le lit depuis le Blackboard"*.
-- **Cycles + accumulation** : chaque tour de cycle écrit dans un sous-dossier `iter-<N>/`. Les ports d'entrée qui veulent accumuler (ex. `reviews_bloquantes`) lisent un glob `iter-*/review.md` → liste naturellement ordonnée.
+- **Cycles + accumulation** : chaque tour de cycle écrit dans un sous-dossier `iter-<N>/`. Les ports d'entrée qui veulent accumuler (ex. `reviews_bloquantes`) lisent **les itérations COMPLETED de la source** (`iter-<N>/review.md`, ordonnées par N) — une itération échouée reste sur disque (forensique) mais est **exclue** de la résolution (#194/#210/#353), donc jamais un glob `iter-*` brut.
 
 **Blackboard archivé** *(terme)* : copie **durable et lecture seule** du Blackboard d'un Run (plus son `pipeline.yaml` + `pipeline.prompts/`), écrite sous `~/.pdo/runs/<run-id>/` (store **global**, hors du `run_dir` repo-local) au moment de l'archivage, **avant** la suppression du worktree. Contrairement au Blackboard vif (qui *part au cleanup*), il **survit** au cleanup — c'est ce qui permet de rouvrir un Run `archived` et d'accéder à ses outputs (canvas réhydraté en lecture seule via `GET /runs/<id>/pipeline`). **N'est pas** récupéré par `cleanup_run` (repo-local) ; sa suppression relève du `forget` (cf. §*Cleanup vs archive*, ADR-0020).
 
@@ -213,7 +213,7 @@ Chaque artefact produit par un NodeRun a un chemin canonique :
 
 **Résolution des inputs** :
 - Wire simple → input port lit `<artifacts>/<source-node>/iter-<latest>/<port>.md`.
-- Wire d'accumulation (port marqué `repeated`, typiquement le port `reviews_bloquantes` côté Implementer dans un cycle) → input port lit le glob `<artifacts>/<source>/iter-*/<port>.md`, ordonné par N.
+- Wire d'accumulation (port marqué `repeated`, typiquement le port `reviews_bloquantes` côté Implementer dans un cycle) → input port lit **les itérations COMPLETED de la source** (`<artifacts>/<source>/iter-<N>/<port>.md`, ordonné par N ; les itérations échouées sont en quarantaine, #194/#210/#353), **jamais** un glob `iter-*` disque brut. L'autorité est la projection (`RunState::completed_iters`), pas l'énumération du répertoire — sinon deux autorités divergeraient sur « quelle itération compte ».
 
 ### Frontmatter — minimal
 
@@ -305,7 +305,7 @@ Le préambule contient au minimum :
 
 - **Inputs disponibles** :
   - Pour chaque port d'entrée : nom du port + chemin absolu sur disque + (optionnel) inline du contenu si court.
-  - Ex. *"Tu as accès à : `plan` (lis `<artifacts>/planner-1/iter-1/plan.md`), `task` (lis `<artifacts>/planner-1/iter-1/task.md`), `reviews_bloquantes` (lis tous les fichiers `<artifacts>/reviewer-1/iter-*/review.md`)."*
+  - Ex. *"Tu as accès à : `plan` (lis `<artifacts>/planner-1/iter-1/plan.md`), `task` (lis `<artifacts>/planner-1/iter-1/task.md`), `reviews_bloquantes` (lis chaque fichier des itérations *completed* de la source, énumérées explicitement — ex. `<artifacts>/reviewer-1/iter-2/review.md`)."*
 - **Outputs attendus** :
   - Pour chaque port de sortie : chemin où écrire + schéma de frontmatter requis.
   - Ex. *"Tu dois produire à `<artifacts>/reviewer-1/iter-2/review.md` un fichier markdown avec frontmatter YAML contenant le champ `verdict: PASS | FAIL`. Le contenu détaillé (blocking issues, justifications) va dans le corps."*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "0.1.77"
+version = "0.1.78"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "0.1.77"
+version = "0.1.78"
 license = "MIT"
 
 [workspace.dependencies]

--- a/crates/pdo-daemon/src/event_log.rs
+++ b/crates/pdo-daemon/src/event_log.rs
@@ -448,6 +448,37 @@ impl RunState {
         from_history.or_else(|| (node.status == NodeStatus::Completed).then_some(node.iter))
     }
 
+    /// Every `Completed` iteration of `node_id`, ascending and de-duplicated
+    /// (#353).
+    ///
+    /// The full set of iterations whose artifacts are resolvable as inputs —
+    /// failed/stopped iterations are quarantined (their artifacts stay on disk
+    /// for forensics but never resolve). A `repeated`/pooled input accumulates
+    /// across exactly this set, so a raw `iter-*` disk enumeration (which cannot
+    /// tell a failed iteration from a completed one) is never the authority.
+    /// Falls back to the head `iter` when the head status is `Completed` but no
+    /// per-iteration history exists (legacy states), mirroring
+    /// [`latest_completed_iter`] — of which this is the set-valued twin
+    /// (`latest_completed_iter` == `completed_iters().last()`). Empty when the
+    /// node has no completed iteration (or does not exist).
+    pub fn completed_iters(&self, node_id: &str) -> Vec<i64> {
+        let Some(node) = self.nodes.get(node_id) else {
+            return Vec::new();
+        };
+        let mut iters: Vec<i64> = node
+            .iterations
+            .iter()
+            .filter(|it| it.status == NodeStatus::Completed)
+            .map(|it| it.iter)
+            .collect();
+        if iters.is_empty() && node.status == NodeStatus::Completed {
+            iters.push(node.iter);
+        }
+        iters.sort_unstable();
+        iters.dedup();
+        iters
+    }
+
     /// True iff `node_ids` is non-empty AND every id resolves to a node whose
     /// status is `Completed`.
     ///
@@ -3655,6 +3686,65 @@ mod tests {
     fn latest_completed_iter_is_none_for_an_absent_node() {
         let s = run_with(vec![]);
         assert_eq!(s.latest_completed_iter("ghost"), None);
+    }
+
+    #[test]
+    fn completed_iters_quarantines_failed_and_returns_all_completed() {
+        // #353: reviewer failed iter 1, completed iters 2 and 3. A repeated
+        // input pools ONLY the completed set — iter 1 is quarantined.
+        let s = run_with(vec![node_state(
+            "reviewer",
+            NodeStatus::Completed,
+            3,
+            &[
+                (1, NodeStatus::Failed),
+                (2, NodeStatus::Completed),
+                (3, NodeStatus::Completed),
+            ],
+        )]);
+        assert_eq!(s.completed_iters("reviewer"), vec![2, 3]);
+        // The set-valued twin agrees with the scalar rule on its max.
+        assert_eq!(
+            s.completed_iters("reviewer").last().copied(),
+            s.latest_completed_iter("reviewer")
+        );
+    }
+
+    #[test]
+    fn completed_iters_keeps_a_completed_iter_before_a_later_failure() {
+        // A hole in the middle: completed 1, failed 2, completed 3 → {1, 3}.
+        // Proves the set is genuinely discrete, not a contiguous range an
+        // `iter-*` glob could stand in for.
+        let s = run_with(vec![node_state(
+            "reviewer",
+            NodeStatus::Completed,
+            3,
+            &[
+                (1, NodeStatus::Completed),
+                (2, NodeStatus::Failed),
+                (3, NodeStatus::Completed),
+            ],
+        )]);
+        assert_eq!(s.completed_iters("reviewer"), vec![1, 3]);
+    }
+
+    #[test]
+    fn completed_iters_falls_back_to_head_when_history_is_empty() {
+        // Legacy state: head Completed, no per-iteration history recorded.
+        let s = run_with(vec![node_state("a", NodeStatus::Completed, 4, &[])]);
+        assert_eq!(s.completed_iters("a"), vec![4]);
+    }
+
+    #[test]
+    fn completed_iters_is_empty_when_nothing_completed_or_node_absent() {
+        let running = run_with(vec![node_state(
+            "a",
+            NodeStatus::Running,
+            1,
+            &[(1, NodeStatus::Running)],
+        )]);
+        assert!(running.completed_iters("a").is_empty());
+        assert!(run_with(vec![]).completed_iters("ghost").is_empty());
     }
 
     #[test]

--- a/crates/pdo-daemon/src/input_resolution.rs
+++ b/crates/pdo-daemon/src/input_resolution.rs
@@ -55,6 +55,33 @@ pub fn resolved_source_iters(
         .collect()
 }
 
+/// Resolves, for one consumer node, the full set of COMPLETED source
+/// iterations of every incoming edge: a map `source node id -> blessed iters`
+/// (#353). The `repeated`/pooled twin of [`resolved_source_iters`] — where that
+/// picks the single latest-completed iter per source, this returns *every*
+/// completed iter, because a `repeated` input accumulates across all of them.
+/// Failed iterations are excluded ([`RunState::completed_iters`] is the single
+/// home for the rule), so the raw `iter-*` disk glob is never the authority. No
+/// positional `consumer_iter` fallback: a source with nothing completed yet
+/// contributes an empty pool (there is genuinely nothing blessed to read).
+pub fn resolved_source_completed_iters(
+    pipeline: &PipelineDef,
+    run_state: &RunState,
+    node_id: &str,
+) -> HashMap<String, Vec<i64>> {
+    pipeline
+        .edges
+        .iter()
+        .filter(|e| e.target.node == node_id)
+        .map(|e| {
+            (
+                e.source.node.clone(),
+                run_state.completed_iters(&e.source.node),
+            )
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -188,5 +215,65 @@ mod tests {
         let resolved = resolved_source_iters(&pipeline, &state, "tester", 1);
         assert_eq!(resolved.get("griller"), Some(&2));
         assert_eq!(resolved.get("impl"), Some(&1));
+    }
+
+    #[test]
+    fn resolved_source_completed_iters_pools_completed_only_per_source() {
+        // #353: the set-valued twin. `griller` failed iter 1 then completed
+        // iters 2 and 3; `impl` completed iter 1. A pooled consumer resolves
+        // each source to its FULL completed set (griller → {2,3}, not just 3),
+        // with the failed iter 1 quarantined.
+        use crate::pipeline::{EdgeDef, EdgeEndpoint, PipelineDef};
+        let pipeline = PipelineDef {
+            name: "pool".into(),
+            version: None,
+            variables: HashMap::new(),
+            nodes: vec![],
+            edges: vec![
+                EdgeDef {
+                    source: EdgeEndpoint {
+                        node: "griller".into(),
+                        port: "review".into(),
+                    },
+                    target: EdgeEndpoint {
+                        node: "impl".into(),
+                        port: "reviews".into(),
+                    },
+                    repeated: true,
+                    ..Default::default()
+                },
+                EdgeDef {
+                    source: EdgeEndpoint {
+                        node: "impl".into(),
+                        port: "out".into(),
+                    },
+                    target: EdgeEndpoint {
+                        node: "sink".into(),
+                        port: "code".into(),
+                    },
+                    ..Default::default()
+                },
+            ],
+            loops: vec![],
+            notes: Vec::new(),
+            prompt_required: true,
+        };
+        let state = state_with(vec![
+            node_with_iterations(
+                "griller",
+                &[
+                    (1, NodeStatus::Failed),
+                    (2, NodeStatus::Completed),
+                    (3, NodeStatus::Completed),
+                ],
+            ),
+            node_with_iterations("impl", &[(1, NodeStatus::Completed)]),
+        ]);
+
+        let for_impl = resolved_source_completed_iters(&pipeline, &state, "impl");
+        assert_eq!(for_impl.get("griller"), Some(&vec![2, 3]));
+
+        let for_sink = resolved_source_completed_iters(&pipeline, &state, "sink");
+        assert_eq!(for_sink.get("impl"), Some(&vec![1]));
     }
 }

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -4519,18 +4519,28 @@ async fn spawn_node(
             Vec::new()
         };
 
-        // Canonical input resolution (#194 / #210): re-project the run state at
-        // spawn time so each input path follows its source's latest COMPLETED
-        // iteration — a failed iteration's artifacts are never consumed, and an
-        // external feeder keeps serving its completed iter at any lap.
-        let source_iters = match reload_run_state(state, run_id).await {
-            Some((_, fresh_state)) => input_resolution::resolved_source_iters(
-                spawn_ctx.pipeline,
-                &fresh_state,
-                &node.id,
-                iter,
+        // Canonical input resolution (#194 / #210 / #353): re-project the run
+        // state at spawn time so each input path follows its source's COMPLETED
+        // iteration(s) — a failed iteration's artifacts are never consumed. For
+        // single-file inputs that is the latest completed iter (`source_iters`);
+        // for `repeated`/pooled inputs it is the full completed set
+        // (`source_completed_iters`), so a raw `iter-*` glob never re-includes a
+        // quarantined iteration.
+        let (source_iters, source_completed_iters) = match reload_run_state(state, run_id).await {
+            Some((_, fresh_state)) => (
+                input_resolution::resolved_source_iters(
+                    spawn_ctx.pipeline,
+                    &fresh_state,
+                    &node.id,
+                    iter,
+                ),
+                input_resolution::resolved_source_completed_iters(
+                    spawn_ctx.pipeline,
+                    &fresh_state,
+                    &node.id,
+                ),
             ),
-            None => HashMap::new(),
+            None => (HashMap::new(), HashMap::new()),
         };
 
         // Precompute whether the Start prompt carries content so `build_preamble`
@@ -4568,6 +4578,7 @@ async fn spawn_node(
             input_images,
             start_prompt_present,
             source_iters,
+            source_completed_iters,
         };
 
         let full_prompt = prompt_augmenter::build_full_prompt(&aug_ctx, &role_prompt);
@@ -7326,7 +7337,10 @@ async fn node_io(
 
     let artifacts_dir = archived_or_live_artifacts_dir(&state, &run_state, &run_id);
 
-    let io = node_io_resolver::resolve(&pipeline, &artifacts_dir, &node_id, iter);
+    // #353: the resolver consults the projection for `repeated`/pooled inputs
+    // (failed iterations are quarantined from the pool), so it needs the run
+    // state, not just the parsed pipeline + disk.
+    let io = node_io_resolver::resolve(&pipeline, &run_state, &artifacts_dir, &node_id, iter);
     Json(io).into_response()
 }
 

--- a/crates/pdo-daemon/src/node_io_resolver.rs
+++ b/crates/pdo-daemon/src/node_io_resolver.rs
@@ -28,7 +28,13 @@ pub struct NodeIO {
     pub outputs: Vec<PortIO>,
 }
 
-pub fn resolve(pipeline: &PipelineDef, artifacts_dir: &Path, node_id: &str, iter: i64) -> NodeIO {
+pub fn resolve(
+    pipeline: &PipelineDef,
+    run_state: &crate::event_log::RunState,
+    artifacts_dir: &Path,
+    node_id: &str,
+    iter: i64,
+) -> NodeIO {
     let node = pipeline.nodes.iter().find(|n| n.id == node_id);
     let node = match node {
         Some(n) => n,
@@ -56,7 +62,13 @@ pub fn resolve(pipeline: &PipelineDef, artifacts_dir: &Path, node_id: &str, iter
         let mut files = Vec::new();
         if edge.repeated {
             let source_dir = artifacts_dir.join(&edge.source.node);
-            files.extend(glob_repeated(&source_dir, &edge.source.port));
+            // #353: pool only the source's COMPLETED iterations — the event
+            // projection is the authority, not a raw `iter-*` disk enumeration
+            // (which would surface a failed iteration's leftover artifact). This
+            // is the same rule the spawn-time preamble uses, kept in one home
+            // (`RunState::completed_iters`).
+            let blessed = run_state.completed_iters(&edge.source.node);
+            files.extend(glob_repeated(&source_dir, &edge.source.port, &blessed));
         } else {
             let path = crate::blackboard::artifact_path(
                 artifacts_dir,
@@ -241,7 +253,7 @@ fn list_image_files(artifacts_dir: &Path, port_dir: &Path) -> Vec<FileInfo> {
     files
 }
 
-fn glob_repeated(source_dir: &Path, port_name: &str) -> Vec<FileInfo> {
+fn glob_repeated(source_dir: &Path, port_name: &str, blessed_iters: &[i64]) -> Vec<FileInfo> {
     let mut results = Vec::new();
 
     let Ok(entries) = std::fs::read_dir(source_dir) else {
@@ -254,7 +266,10 @@ fn glob_repeated(source_dir: &Path, port_name: &str) -> Vec<FileInfo> {
         .filter_map(|e| {
             let name = e.file_name().to_string_lossy().to_string();
             let n = name.strip_prefix("iter-")?.parse::<i64>().ok()?;
-            Some((n, e.path()))
+            // #353: keep only iterations the projection blessed as Completed. A
+            // failed iteration's dir is still on disk (forensics) but must never
+            // be pooled as an input.
+            blessed_iters.contains(&n).then_some((n, e.path()))
         })
         .collect();
 
@@ -286,9 +301,47 @@ fn glob_repeated(source_dir: &Path, port_name: &str) -> Vec<FileInfo> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::event_log::{IterationInfo, NodeState, NodeStatus, RunState};
     use crate::pipeline::{EdgeDef, EdgeEndpoint, NodeDef, NodeType, Port, PortType};
     use pretty_assertions::assert_eq;
     use std::fs;
+
+    /// A projection where no node is known: the non-`repeated` branch (which
+    /// resolves positionally by consumer `iter`) is unaffected by it, so most
+    /// tests pass this.
+    fn empty_state() -> RunState {
+        RunState::new("run-1".into(), "test".into())
+    }
+
+    /// A projection carrying one node's per-iteration statuses — drives the
+    /// `repeated` branch's completed-iter filter (#353).
+    fn state_with(node_id: &str, iters: &[(i64, NodeStatus)]) -> RunState {
+        let head = iters.last().cloned().unwrap_or((1, NodeStatus::Pending));
+        let mut s = RunState::new("run-1".into(), "test".into());
+        s.nodes.insert(
+            node_id.to_string(),
+            NodeState {
+                node_id: node_id.to_string(),
+                status: head.1,
+                iter: head.0,
+                started_at: None,
+                completed_at: None,
+                failure_reason: None,
+                iterations: iters
+                    .iter()
+                    .map(|(i, st)| IterationInfo {
+                        iter: *i,
+                        status: st.clone(),
+                        started_at: None,
+                        completed_at: None,
+                    })
+                    .collect(),
+                frontmatter_retries: 0,
+                frontmatter_violations: Vec::new(),
+            },
+        );
+        s
+    }
 
     fn simple_pipeline() -> PipelineDef {
         PipelineDef {
@@ -381,7 +434,7 @@ mod tests {
         fs::create_dir_all(&artifacts).unwrap();
 
         let pipeline = simple_pipeline();
-        let io = resolve(&pipeline, &artifacts, "implementer", 1);
+        let io = resolve(&pipeline, &empty_state(), &artifacts, "implementer", 1);
 
         assert_eq!(io.inputs.len(), 1);
         assert_eq!(io.inputs[0].port, "plan");
@@ -400,7 +453,7 @@ mod tests {
         fs::write(dir.join("output.md"), "# My plan\nDo stuff.").unwrap();
 
         let pipeline = simple_pipeline();
-        let io = resolve(&pipeline, &artifacts, "implementer", 1);
+        let io = resolve(&pipeline, &empty_state(), &artifacts, "implementer", 1);
 
         assert!(io.inputs[0].files[0].exists);
         assert!(io.inputs[0].files[0].size.unwrap() > 0);
@@ -419,7 +472,7 @@ mod tests {
         .unwrap();
 
         let pipeline = simple_pipeline();
-        let io = resolve(&pipeline, &artifacts, "implementer", 1);
+        let io = resolve(&pipeline, &empty_state(), &artifacts, "implementer", 1);
 
         assert_eq!(io.outputs.len(), 1);
         assert_eq!(io.outputs[0].port, "summary");
@@ -436,7 +489,7 @@ mod tests {
         fs::create_dir_all(&artifacts).unwrap();
 
         let pipeline = simple_pipeline();
-        let io = resolve(&pipeline, &artifacts, "implementer", 1);
+        let io = resolve(&pipeline, &empty_state(), &artifacts, "implementer", 1);
 
         assert_eq!(io.outputs.len(), 1);
         assert!(!io.outputs[0].files[0].exists);
@@ -445,6 +498,8 @@ mod tests {
 
     #[test]
     fn repeated_port_glob_expansion() {
+        // A pooled input accumulates every COMPLETED source iteration (#353).
+        // Here reviewer completed all three laps, so all three are pooled.
         let tmp = tempfile::tempdir().unwrap();
         let artifacts = tmp.path().join("artifacts");
 
@@ -453,7 +508,7 @@ mod tests {
             fs::create_dir_all(&dir).unwrap();
             fs::write(
                 dir.join("output.md"),
-                format!("---\nverdict: FAIL\n---\n\nIter {i} review"),
+                format!("---\nverdict: PASS\n---\n\nIter {i} review"),
             )
             .unwrap();
         }
@@ -533,7 +588,15 @@ mod tests {
             prompt_required: true,
         };
 
-        let io = resolve(&pipeline, &artifacts, "implementer", 4);
+        let state = state_with(
+            "reviewer",
+            &[
+                (1, NodeStatus::Completed),
+                (2, NodeStatus::Completed),
+                (3, NodeStatus::Completed),
+            ],
+        );
+        let io = resolve(&pipeline, &state, &artifacts, "implementer", 4);
 
         assert_eq!(io.inputs.len(), 1);
         assert!(io.inputs[0].repeated);
@@ -553,6 +616,94 @@ mod tests {
     }
 
     #[test]
+    fn repeated_pool_excludes_a_failed_source_iteration() {
+        // #353 regression: reviewer's iter-1 FAILED (its artifact is on disk for
+        // forensics) and iter-2 COMPLETED. The pooled input must contain ONLY
+        // iter-2 — the projection quarantines the failed iteration, and the raw
+        // `iter-*` disk enumeration is no longer the authority.
+        let tmp = tempfile::tempdir().unwrap();
+        let artifacts = tmp.path().join("artifacts");
+        for i in 1..=2 {
+            let dir = artifacts.join(format!("reviewer/iter-{i}/review"));
+            fs::create_dir_all(&dir).unwrap();
+            fs::write(dir.join("output.md"), format!("iter {i}")).unwrap();
+        }
+
+        let pipeline = PipelineDef {
+            name: "cycle".into(),
+            version: None,
+            variables: HashMap::new(),
+            nodes: vec![
+                NodeDef {
+                    id: "reviewer".into(),
+                    name: "reviewer".into(),
+                    node_type: NodeType::DocOnly,
+                    inputs: vec![],
+                    outputs: vec![Port {
+                        name: "review".into(),
+                        repeated: false,
+                        side: None,
+                        port_type: PortType::Markdown,
+                        frontmatter: None,
+                        when: None,
+                        description: None,
+                    }],
+                    interactive: false,
+                    view: None,
+                    max_iter: None,
+                    over: None,
+                    model: None,
+                },
+                NodeDef {
+                    id: "implementer".into(),
+                    name: "implementer".into(),
+                    node_type: NodeType::CodeMutating,
+                    inputs: vec![],
+                    outputs: vec![],
+                    interactive: false,
+                    view: None,
+                    max_iter: None,
+                    over: None,
+                    model: None,
+                },
+            ],
+            edges: vec![EdgeDef {
+                source: EdgeEndpoint {
+                    node: "reviewer".into(),
+                    port: "review".into(),
+                },
+                target: EdgeEndpoint {
+                    node: "implementer".into(),
+                    port: "reviews".into(),
+                },
+                repeated: true,
+                ..Default::default()
+            }],
+            loops: Vec::new(),
+            notes: Vec::new(),
+            prompt_required: true,
+        };
+
+        let state = state_with(
+            "reviewer",
+            &[(1, NodeStatus::Failed), (2, NodeStatus::Completed)],
+        );
+        let io = resolve(&pipeline, &state, &artifacts, "implementer", 3);
+
+        assert_eq!(io.inputs.len(), 1);
+        assert!(io.inputs[0].repeated);
+        assert_eq!(
+            io.inputs[0].files.len(),
+            1,
+            "the failed iter-1 must be quarantined from the pool"
+        );
+        assert_eq!(
+            io.inputs[0].files[0].path,
+            "reviewer/iter-2/review/output.md"
+        );
+    }
+
+    #[test]
     fn entry_node_with_no_edges_gets_input_md() {
         let tmp = tempfile::tempdir().unwrap();
         let artifacts = tmp.path().join("artifacts");
@@ -561,7 +712,7 @@ mod tests {
         fs::write(input_dir.join("output.md"), "Do the thing").unwrap();
 
         let pipeline = simple_pipeline();
-        let io = resolve(&pipeline, &artifacts, "planner", 1);
+        let io = resolve(&pipeline, &empty_state(), &artifacts, "planner", 1);
 
         assert_eq!(io.inputs.len(), 1);
         assert_eq!(io.inputs[0].port, "task");
@@ -684,7 +835,7 @@ mod tests {
             fs::write(dir.join("output.md"), format!("from {dir_name}")).unwrap();
         }
 
-        let io = resolve(&pipeline, &artifacts, "merger", 1);
+        let io = resolve(&pipeline, &empty_state(), &artifacts, "merger", 1);
 
         assert_eq!(io.inputs.len(), 1);
         assert_eq!(io.inputs[0].port, "docs");
@@ -762,7 +913,7 @@ mod tests {
             prompt_required: true,
         };
 
-        let io = resolve(&pipeline, &artifacts, "implementer", 1);
+        let io = resolve(&pipeline, &empty_state(), &artifacts, "implementer", 1);
 
         assert_eq!(io.inputs.len(), 1);
         assert_eq!(io.inputs[0].port, "plan");
@@ -839,7 +990,7 @@ mod tests {
             prompt_required: true,
         };
 
-        let io = resolve(&pipeline, &artifacts, "sink", 1);
+        let io = resolve(&pipeline, &empty_state(), &artifacts, "sink", 1);
 
         // One logical input, pooled into a list of both source files.
         assert_eq!(io.inputs.len(), 1);
@@ -919,7 +1070,7 @@ mod tests {
             prompt_required: true,
         };
 
-        let io = resolve(&pipeline, &artifacts, "sink", 1);
+        let io = resolve(&pipeline, &empty_state(), &artifacts, "sink", 1);
 
         assert_eq!(io.inputs.len(), 2);
         assert_eq!(io.inputs[0].port, "plan");
@@ -937,7 +1088,7 @@ mod tests {
         fs::create_dir_all(&artifacts).unwrap();
 
         let pipeline = simple_pipeline();
-        let io = resolve(&pipeline, &artifacts, "nonexistent", 1);
+        let io = resolve(&pipeline, &empty_state(), &artifacts, "nonexistent", 1);
 
         assert!(io.inputs.is_empty());
         assert!(io.outputs.is_empty());

--- a/crates/pdo-daemon/src/node_primitives.rs
+++ b/crates/pdo-daemon/src/node_primitives.rs
@@ -145,6 +145,11 @@ pub fn start_node(params: &StartNodeParams<'_>) -> StartNodeResult {
             params.node_id,
             params.iter,
         ),
+        source_completed_iters: crate::input_resolution::resolved_source_completed_iters(
+            params.pipeline,
+            params.run_state,
+            params.node_id,
+        ),
     };
 
     let full_prompt = crate::prompt_augmenter::build_full_prompt(&aug_ctx, &role_prompt);
@@ -292,12 +297,28 @@ fn resolve_inputs(
 
         if let Some(edge) = matching_edge {
             let resolved = if input_port.repeated {
-                let source_dir = params.artifacts_dir.join(&edge.source.node);
-                format!(
-                    "{}/iter-*/{}/output.md",
-                    source_dir.to_string_lossy(),
-                    edge.source.port
-                )
+                // #353: enumerate the source's COMPLETED-iteration artifact
+                // paths (newline-separated), never an `iter-*` glob. This
+                // forensic `node_started.input_paths` record must reflect the
+                // same projection-blessed set the preamble/env hand the node —
+                // a raw disk glob would advertise a failed iteration's leftover
+                // artifact as a resolvable input.
+                params
+                    .run_state
+                    .completed_iters(&edge.source.node)
+                    .into_iter()
+                    .map(|it| {
+                        blackboard::artifact_path(
+                            params.artifacts_dir,
+                            &edge.source.node,
+                            it,
+                            &edge.source.port,
+                        )
+                        .to_string_lossy()
+                        .to_string()
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n")
             } else {
                 // Canonical resolution (#194 / #210): the source's latest
                 // COMPLETED iteration, never a failed iteration's artifact.
@@ -959,7 +980,12 @@ mod tests {
     }
 
     #[test]
-    fn start_node_resolves_repeated_port_with_glob() {
+    fn start_node_resolves_repeated_port_to_completed_iter_paths() {
+        // #353: a repeated port resolves to the newline-separated set of the
+        // source's COMPLETED iterations — NOT an `iter-*` glob. Here reviewer
+        // failed iter-1 and completed iter-2 and iter-3, so the forensic
+        // `input_paths` record lists iter-2 and iter-3 only; the quarantined
+        // iter-1 never appears, and no glob leaks through.
         let pipeline = PipelineDef {
             name: "test".into(),
             version: None,
@@ -974,7 +1000,41 @@ mod tests {
             prompt_required: true,
         };
 
-        let run_state = empty_run_state();
+        let mut run_state = empty_run_state();
+        run_state.nodes.insert(
+            "reviewer".into(),
+            NodeState {
+                node_id: "reviewer".into(),
+                status: NodeStatus::Completed,
+                iter: 3,
+                started_at: Some("t0".into()),
+                completed_at: Some("t1".into()),
+                failure_reason: None,
+                iterations: vec![
+                    IterationInfo {
+                        iter: 1,
+                        status: NodeStatus::Failed,
+                        started_at: Some("t0".into()),
+                        completed_at: None,
+                    },
+                    IterationInfo {
+                        iter: 2,
+                        status: NodeStatus::Completed,
+                        started_at: Some("t0".into()),
+                        completed_at: Some("t1".into()),
+                    },
+                    IterationInfo {
+                        iter: 3,
+                        status: NodeStatus::Completed,
+                        started_at: Some("t0".into()),
+                        completed_at: Some("t1".into()),
+                    },
+                ],
+                frontmatter_retries: 0,
+                frontmatter_violations: Vec::new(),
+            },
+        );
+
         let tmp = tempfile::tempdir().unwrap();
         let artifacts_dir = tmp.path().join("artifacts");
         std::fs::create_dir_all(&artifacts_dir).unwrap();
@@ -987,7 +1047,7 @@ mod tests {
         let params = StartNodeParams {
             run_id: "run-1",
             node_id: "implementer",
-            iter: 1,
+            iter: 4,
             overrides: None,
             pipeline: &pipeline,
             run_state: &run_state,
@@ -1003,8 +1063,22 @@ mod tests {
 
         let input_paths = resolve_inputs(&params, node);
         let reviews_path = input_paths.get("reviews").unwrap();
-        assert!(reviews_path.contains("iter-*"));
-        assert!(reviews_path.contains("review"));
+        let lines: Vec<&str> = reviews_path.lines().collect();
+        assert_eq!(
+            lines.len(),
+            2,
+            "only completed iters 2 and 3: {reviews_path}"
+        );
+        assert!(lines[0].ends_with("reviewer/iter-2/review/output.md"));
+        assert!(lines[1].ends_with("reviewer/iter-3/review/output.md"));
+        assert!(
+            !reviews_path.contains("iter-*"),
+            "must not be a glob (#353): {reviews_path}"
+        );
+        assert!(
+            !reviews_path.contains("iter-1"),
+            "the failed iteration must be quarantined: {reviews_path}"
+        );
     }
 
     #[test]

--- a/crates/pdo-daemon/src/pipeline.rs
+++ b/crates/pdo-daemon/src/pipeline.rs
@@ -185,8 +185,10 @@ pub struct EdgeDef {
     #[serde(default, rename = "else", skip_serializing_if = "is_false")]
     pub is_else: bool,
     /// `repeated: true` marks an edge whose source artifact accumulates across
-    /// iterations: the resolver globs `iter-*` and pools every match into the
-    /// emergent input. Loop accumulation ("read all laps") lives on the edge,
+    /// iterations: the resolver pools the source's COMPLETED iterations into the
+    /// emergent input — failed iterations are quarantined, so it is the
+    /// projection-blessed set (`RunState::completed_iters`), never a raw `iter-*`
+    /// disk glob (#353). Loop accumulation ("read all laps") lives on the edge,
     /// not on a declared input port (ADR-0011 / #149).
     #[serde(default, skip_serializing_if = "is_false")]
     pub repeated: bool,
@@ -1772,8 +1774,9 @@ edges:
     #[test]
     fn parses_repeated_flag_on_edge() {
         // `repeated` is an edge property (ADR-0011 / #149): it marks an edge whose
-        // source artifact accumulates across iterations (glob `iter-*`). It lives
-        // on the edge, not on a declared input port.
+        // source artifact accumulates across iterations (the source's COMPLETED
+        // iters — failed ones quarantined, not a raw `iter-*` glob, #353). It
+        // lives on the edge, not on a declared input port.
         let yaml = with_start_end(
             r#"
 name: repeated-edge

--- a/crates/pdo-daemon/src/prompt_augmenter.rs
+++ b/crates/pdo-daemon/src/prompt_augmenter.rs
@@ -5,7 +5,14 @@ use crate::pipeline::{NodeDef, PipelineDef, PortType, IMAGE_EXTENSIONS};
 
 pub struct InputResolution {
     pub port_name: String,
-    pub path: PathBuf,
+    /// Resolved artifact path(s). A single-file input (non-`repeated`, or the
+    /// Start prompt) resolves to exactly one path — the source's latest
+    /// completed iteration (#194). A `repeated`/pooled input resolves to one
+    /// path per COMPLETED source iteration (#353): failed iterations are
+    /// quarantined, so this is a discrete projection-blessed set, never an
+    /// `iter-*` disk glob. Empty for a `repeated` input whose source has not
+    /// completed any iteration yet.
+    pub paths: Vec<PathBuf>,
     pub repeated: bool,
     /// True when this input is sourced from the Start node's user prompt
     /// (`_input/output.md`). The entry node's prompt label adapts to
@@ -52,6 +59,13 @@ pub struct AugmentContext<'a> {
     /// map falls back to the consumer's own `iter` (positional), preserving
     /// override/injection flows where nothing has completed yet.
     pub source_iters: HashMap<String, i64>,
+    /// Per-source set of COMPLETED iterations for this NodeRun's incoming edges
+    /// (#353). A `repeated`/pooled input resolves to one artifact path per iter
+    /// in this set (failed iterations quarantined), instead of a raw `iter-*`
+    /// glob that would re-include them. Precomputed at spawn from
+    /// `input_resolution::resolved_source_completed_iters`; a source absent from
+    /// the map (or with an empty set) contributes no pooled files yet.
+    pub source_completed_iters: HashMap<String, Vec<i64>>,
 }
 
 pub fn discover_input_images(artifacts_dir: &Path) -> Vec<String> {
@@ -113,14 +127,31 @@ pub fn resolve_input_paths(ctx: &AugmentContext<'_>) -> Vec<InputResolution> {
             .iter()
             .any(|n| n.id == *source_node && n.node_type == crate::pipeline::NodeType::Start);
 
-        let path = if is_start {
-            crate::blackboard::input_path(ctx.artifacts_dir)
+        let paths = if is_start {
+            vec![crate::blackboard::input_path(ctx.artifacts_dir)]
         } else if repeated {
-            ctx.artifacts_dir
-                .join(source_node)
-                .join("iter-*")
-                .join(&edge.source.port)
-                .join("output.md")
+            // #353: a `repeated`/pooled input accumulates the source's COMPLETED
+            // iterations only. The projection (`source_completed_iters`) is the
+            // single authority; the old `iter-*` disk glob is gone because it
+            // could not tell a failed iteration's leftover artifact from a
+            // completed one. An empty/absent set means nothing has completed
+            // yet — a genuinely empty pool, not a glob pointing at poison.
+            ctx.source_completed_iters
+                .get(source_node.as_str())
+                .map(|iters| {
+                    iters
+                        .iter()
+                        .map(|&it| {
+                            crate::blackboard::artifact_path(
+                                ctx.artifacts_dir,
+                                source_node,
+                                it,
+                                &edge.source.port,
+                            )
+                        })
+                        .collect()
+                })
+                .unwrap_or_default()
         } else {
             // Canonical resolution (#194): read the source's latest completed
             // iteration, never a failed iteration's artifact and never a
@@ -130,17 +161,17 @@ pub fn resolve_input_paths(ctx: &AugmentContext<'_>) -> Vec<InputResolution> {
                 .get(source_node.as_str())
                 .copied()
                 .unwrap_or(ctx.iter);
-            crate::blackboard::artifact_path(
+            vec![crate::blackboard::artifact_path(
                 ctx.artifacts_dir,
                 source_node,
                 source_iter,
                 &edge.source.port,
-            )
+            )]
         };
 
         inputs.push(InputResolution {
             port_name: edge.target.port.clone(),
-            path,
+            paths,
             repeated,
             from_start: is_start,
         });
@@ -149,7 +180,7 @@ pub fn resolve_input_paths(ctx: &AugmentContext<'_>) -> Vec<InputResolution> {
     if inputs.is_empty() && ctx.node.inputs.iter().any(|p| p.name == "task") {
         inputs.push(InputResolution {
             port_name: "task".into(),
-            path: crate::blackboard::input_path(ctx.artifacts_dir),
+            paths: vec![crate::blackboard::input_path(ctx.artifacts_dir)],
             repeated: false,
             from_start: true,
         });
@@ -224,8 +255,11 @@ fn var_value_to_env_string(value: &serde_yaml::Value) -> String {
 /// resolution the preamble uses — a single source of truth, not a second path.
 ///
 /// - `PDO_ARTIFACTS_DIR` — the Blackboard root.
-/// - `PDO_INPUT_<PORT>` — absolute path (or `iter-*` glob) of each resolved input.
-/// - `PDO_INPUT_<PORT>_REPEATED=1` — set when that input is a `repeated` glob.
+/// - `PDO_INPUT_<PORT>` — absolute path of each resolved input. For a `repeated`
+///   input it is the newline-separated list of the source's COMPLETED-iteration
+///   artifact paths (#353) — NOT an `iter-*` glob, which the script's bash would
+///   re-expand on disk and thereby re-include quarantined (failed) iterations.
+/// - `PDO_INPUT_<PORT>_REPEATED=1` — set when that input is `repeated` (a list).
 /// - `PDO_OUTPUT_<PORT>` — absolute path the script writes its `output.md` to.
 /// - `PDO_VAR_<NAME>` — each resolved pipeline variable (sorted for determinism).
 ///
@@ -243,8 +277,26 @@ pub fn build_script_env(ctx: &AugmentContext<'_>) -> Vec<(String, String)> {
         let key = format!("PDO_INPUT_{}", env_name_suffix(&input.port_name));
         if input.repeated {
             env.push((format!("{key}_REPEATED"), "1".to_string()));
+            // #353: the value is the newline-separated set of blessed (completed)
+            // iteration paths — not an `iter-*` glob. A script iterates it with
+            // e.g. `while IFS= read -r f; do …; done <<< "$PDO_INPUT_<PORT>"`.
+            let joined = input
+                .paths
+                .iter()
+                .map(|p| p.to_string_lossy())
+                .collect::<Vec<_>>()
+                .join("\n");
+            env.push((key, joined));
+        } else {
+            // Non-`repeated` inputs (and the Start prompt) always resolve to
+            // exactly one path.
+            let path = input
+                .paths
+                .first()
+                .map(|p| p.to_string_lossy().into_owned())
+                .unwrap_or_default();
+            env.push((key, path));
         }
-        env.push((key, input.path.to_string_lossy().into_owned()));
     }
 
     for output in resolve_output_paths(ctx) {
@@ -329,38 +381,52 @@ pub fn build_preamble(ctx: &AugmentContext<'_>) -> String {
         preamble.push_str("No inputs.\n\n");
     } else {
         for input in &inputs {
+            // `from_start` and non-`repeated` inputs always resolve to exactly
+            // one path; a `repeated` input carries a discrete set (0..N).
+            let single = input.paths.first();
             // Entry-node prompt adapts to `prompt_required` (#158): when the
             // pipeline is prompt-optional and no prompt was supplied, the node
             // must source its own work; when a prompt is supplied it is merely
             // additional info layered on the node's own brief.
             if input.from_start && !ctx.pipeline.prompt_required {
+                let path_display = single.map(|p| p.display().to_string()).unwrap_or_default();
                 if ctx.start_prompt_present {
                     preamble.push_str(&format!(
                         "- `{}` (additional info): read `{}`. \
                          This is supplementary context — your role prompt below is the primary brief.\n",
-                        input.port_name,
-                        input.path.display()
+                        input.port_name, path_display
                     ));
                 } else {
                     preamble.push_str(&format!(
                         "- `{}`: No prompt was provided for this run. \
                          Source your own work from your role prompt below \
                          (an empty `{}` is expected).\n",
-                        input.port_name,
-                        input.path.display()
+                        input.port_name, path_display
                     ));
                 }
             } else if input.repeated {
-                preamble.push_str(&format!(
-                    "- `{}` (accumulated): read all files matching `{}`\n",
-                    input.port_name,
-                    input.path.display()
-                ));
+                // #353: list the source's completed-iteration files explicitly
+                // rather than an `iter-*` glob, so the agent never reads a
+                // quarantined (failed) iteration whose artifact still sits on disk.
+                if input.paths.is_empty() {
+                    preamble.push_str(&format!(
+                        "- `{}` (accumulated): no completed source iterations yet — nothing to read.\n",
+                        input.port_name
+                    ));
+                } else {
+                    preamble.push_str(&format!(
+                        "- `{}` (accumulated): read all of these files:\n",
+                        input.port_name
+                    ));
+                    for path in &input.paths {
+                        preamble.push_str(&format!("  - `{}`\n", path.display()));
+                    }
+                }
             } else {
+                let path_display = single.map(|p| p.display().to_string()).unwrap_or_default();
                 preamble.push_str(&format!(
                     "- `{}`: read `{}`\n",
-                    input.port_name,
-                    input.path.display()
+                    input.port_name, path_display
                 ));
             }
         }
@@ -761,6 +827,7 @@ mod tests {
             input_images: Vec::new(),
             start_prompt_present: false,
             source_iters: HashMap::new(),
+            source_completed_iters: HashMap::new(),
         }
     }
 
@@ -775,8 +842,8 @@ mod tests {
         assert_eq!(inputs.len(), 1);
         assert_eq!(inputs[0].port_name, "task");
         assert_eq!(
-            inputs[0].path,
-            PathBuf::from("/repo/.pdo/artifacts/_input/output.md")
+            inputs[0].paths,
+            vec![PathBuf::from("/repo/.pdo/artifacts/_input/output.md")]
         );
         assert!(!inputs[0].repeated);
     }
@@ -862,8 +929,11 @@ mod tests {
 
     #[test]
     fn script_env_marks_repeated_inputs() {
-        // A `repeated` edge → PDO_INPUT_<PORT> is an iter-* glob + a _REPEATED=1
-        // flag so the script knows to glob rather than read a single file.
+        // #248 / #353: a `repeated` edge → PDO_INPUT_<PORT> is the
+        // newline-separated list of the source's COMPLETED-iteration paths
+        // (here planner completed iters 1 and 2), plus a _REPEATED=1 flag. It is
+        // NOT an `iter-*` glob — a glob would re-expand on disk in the script's
+        // bash and re-include quarantined (failed) iterations.
         let mut pipeline = sample_pipeline();
         pipeline.nodes.push(NodeDef {
             id: "collector".into(),
@@ -891,18 +961,24 @@ mod tests {
         });
         let node = pipeline.nodes.iter().find(|n| n.id == "collector").unwrap();
         let vars = HashMap::new();
-        let ctx = sample_ctx(&pipeline, node, &vars);
+        let mut ctx = sample_ctx(&pipeline, node, &vars);
+        ctx.source_completed_iters = HashMap::from([("planner".to_string(), vec![1, 2])]);
 
         let env: HashMap<String, String> = build_script_env(&ctx).into_iter().collect();
         assert_eq!(
             env.get("PDO_INPUT_LAPS_REPEATED").map(String::as_str),
             Some("1")
         );
+        let laps = env.get("PDO_INPUT_LAPS").expect("PDO_INPUT_LAPS set");
+        assert_eq!(
+            laps,
+            "/repo/.pdo/artifacts/planner/iter-1/plan/output.md\n\
+             /repo/.pdo/artifacts/planner/iter-2/plan/output.md",
+            "repeated input is a newline-separated blessed set, not a glob: {env:?}"
+        );
         assert!(
-            env.get("PDO_INPUT_LAPS")
-                .map(|v| v.contains("iter-*"))
-                .unwrap_or(false),
-            "repeated input is a glob: {env:?}"
+            !laps.contains("iter-*"),
+            "must not be an iter-* glob (#353): {env:?}"
         );
     }
 
@@ -1003,8 +1079,10 @@ mod tests {
         assert_eq!(inputs.len(), 1);
         assert_eq!(inputs[0].port_name, "plan");
         assert_eq!(
-            inputs[0].path,
-            PathBuf::from("/repo/.pdo/artifacts/planner/iter-1/plan/output.md")
+            inputs[0].paths,
+            vec![PathBuf::from(
+                "/repo/.pdo/artifacts/planner/iter-1/plan/output.md"
+            )]
         );
     }
 
@@ -1047,8 +1125,10 @@ mod tests {
         let inputs = resolve_input_paths(&ctx);
         assert_eq!(inputs.len(), 1);
         assert_eq!(
-            inputs[0].path,
-            PathBuf::from("/repo/.pdo/artifacts/planner/iter-2/plan/output.md")
+            inputs[0].paths,
+            vec![PathBuf::from(
+                "/repo/.pdo/artifacts/planner/iter-2/plan/output.md"
+            )]
         );
     }
 
@@ -1093,15 +1173,15 @@ mod tests {
         assert_eq!(inputs.len(), 1);
         assert_eq!(inputs[0].port_name, "plan");
         assert_eq!(
-            inputs[0].path,
-            PathBuf::from("/repo/.pdo/artifacts/planner/iter-1/plan/output.md")
+            inputs[0].paths,
+            vec![PathBuf::from(
+                "/repo/.pdo/artifacts/planner/iter-1/plan/output.md"
+            )]
         );
     }
 
-    #[test]
-    fn repeated_flag_read_off_edge_in_preamble() {
-        // #149: `repeated` (accumulate across iterations) lives on the EDGE, not
-        // on a declared input port. The preamble globs `iter-*` accordingly.
+    fn repeated_edge_pipeline() -> (PipelineDef, &'static str) {
+        // planner --(repeated)--> implementer.plans
         let mut pipeline = sample_pipeline();
         pipeline.nodes.push(NodeDef {
             id: "implementer".into(),
@@ -1130,22 +1210,90 @@ mod tests {
             repeated: true,
             ..Default::default()
         });
+        (pipeline, "implementer")
+    }
 
-        let node = &pipeline.nodes[1];
+    #[test]
+    fn repeated_flag_read_off_edge_in_preamble() {
+        // #149 / #353: `repeated` (accumulate across iterations) lives on the
+        // EDGE, not on a declared input port. It resolves to the discrete set of
+        // the source's COMPLETED iterations (here planner completed only iter 1)
+        // — an explicit list, never an `iter-*` glob.
+        let (pipeline, target) = repeated_edge_pipeline();
+        let node = pipeline.nodes.iter().find(|n| n.id == target).unwrap();
         let vars = HashMap::new();
-        let ctx = sample_ctx(&pipeline, node, &vars);
+        let mut ctx = sample_ctx(&pipeline, node, &vars);
+        ctx.source_completed_iters = HashMap::from([("planner".to_string(), vec![1])]);
 
         let inputs = resolve_input_paths(&ctx);
         assert_eq!(inputs.len(), 1);
         assert_eq!(inputs[0].port_name, "plans");
         assert!(inputs[0].repeated, "repeated comes from the edge");
         assert_eq!(
-            inputs[0].path,
-            PathBuf::from("/repo/.pdo/artifacts/planner/iter-*/plan/output.md")
+            inputs[0].paths,
+            vec![PathBuf::from(
+                "/repo/.pdo/artifacts/planner/iter-1/plan/output.md"
+            )]
         );
 
         let preamble = build_preamble(&ctx);
         assert!(preamble.contains("`plans` (accumulated)"));
+        assert!(preamble.contains("planner/iter-1/plan/output.md"));
+    }
+
+    #[test]
+    fn repeated_input_pools_completed_iters_and_quarantines_failed() {
+        // #353 regression: planner failed iter 1 then completed iters 2 and 3.
+        // The pooled input must list ONLY iter-2 and iter-3 — the failed iter-1
+        // artifact, still on disk, is never surfaced to the agent, and no
+        // `iter-*` glob (which would re-include it) appears anywhere.
+        let (pipeline, target) = repeated_edge_pipeline();
+        let node = pipeline.nodes.iter().find(|n| n.id == target).unwrap();
+        let vars = HashMap::new();
+        let mut ctx = sample_ctx(&pipeline, node, &vars);
+        ctx.source_completed_iters = HashMap::from([("planner".to_string(), vec![2, 3])]);
+
+        let inputs = resolve_input_paths(&ctx);
+        assert_eq!(inputs.len(), 1);
+        assert!(inputs[0].repeated);
+        assert_eq!(
+            inputs[0].paths,
+            vec![
+                PathBuf::from("/repo/.pdo/artifacts/planner/iter-2/plan/output.md"),
+                PathBuf::from("/repo/.pdo/artifacts/planner/iter-3/plan/output.md"),
+            ]
+        );
+
+        let preamble = build_preamble(&ctx);
+        assert!(preamble.contains("planner/iter-2/plan/output.md"));
+        assert!(preamble.contains("planner/iter-3/plan/output.md"));
+        assert!(
+            !preamble.contains("iter-1"),
+            "the failed iteration must not leak into the preamble"
+        );
+        assert!(
+            !preamble.contains("iter-*"),
+            "a raw glob would re-include the quarantined iteration (#353)"
+        );
+    }
+
+    #[test]
+    fn repeated_input_with_no_completed_source_iter_is_an_empty_pool() {
+        // #353: on the first lap the source has completed nothing yet, so the
+        // pool is genuinely empty — no glob pointing at not-yet-blessed dirs.
+        let (pipeline, target) = repeated_edge_pipeline();
+        let node = pipeline.nodes.iter().find(|n| n.id == target).unwrap();
+        let vars = HashMap::new();
+        let ctx = sample_ctx(&pipeline, node, &vars); // source_completed_iters empty
+
+        let inputs = resolve_input_paths(&ctx);
+        assert_eq!(inputs.len(), 1);
+        assert!(inputs[0].repeated);
+        assert!(inputs[0].paths.is_empty());
+
+        let preamble = build_preamble(&ctx);
+        assert!(preamble.contains("no completed source iterations yet"));
+        assert!(!preamble.contains("iter-*"));
     }
 
     #[test]
@@ -1324,13 +1472,13 @@ mod tests {
 
         let plan_input = inputs.iter().find(|i| i.port_name == "plan").unwrap();
         assert_eq!(
-            plan_input.path,
+            plan_input.paths[0],
             PathBuf::from("/repo/.pdo/artifacts/planner/iter-1/plan/output.md")
         );
 
         let ctx_input = inputs.iter().find(|i| i.port_name == "context").unwrap();
         assert_eq!(
-            ctx_input.path,
+            ctx_input.paths[0],
             PathBuf::from("/repo/.pdo/artifacts/researcher/iter-1/context/output.md")
         );
 

--- a/docs/adr/0017-script-node.md
+++ b/docs/adr/0017-script-node.md
@@ -40,7 +40,13 @@ se complète sur exit 0 / échoue sinon, et — en v1 — n'obtient pas de sous-
   `outputs_validator` s'applique, mais **fail-fast** (pas de retry interactif : la
   session a déjà quitté, il n'y a plus d'agent à relancer). Les répertoires des ports
   de sortie sont **pré-créés au spawn** (un `> "$PDO_OUTPUT_out"` échouerait sur un
-  parent manquant).
+  parent manquant). Un input `repeated` arrive comme la **liste séparée par des
+  sauts de ligne** des chemins des itérations COMPLETED de la source (plus
+  `PDO_INPUT_<PORT>_REPEATED=1`), **pas** un glob `iter-*` : un glob se ré-étendrait
+  sur disque dans le bash du script et ré-inclurait les itérations échouées mises en
+  quarantaine (#353). Le script itère p. ex. `while IFS= read -r f; do …; done <<<
+  "$PDO_INPUT_<PORT>"` (les valeurs env sont single-quotées par `wrap_with_env`, donc
+  les sauts de ligne survivent ; pool vide ⇒ variable vide).
 - **Le seam de test `tmux_cmd_override` est contourné pour un script.** Pour un agent,
   l'override remplace `claude` par un stub pour que la CI ne lance jamais de vrai
   claude. Un script *est* du bash déterministe : l'override ne doit pas l'écraser.


### PR DESCRIPTION
Closes #353.

## What
`repeated`/pooled inputs previously globbed `iter-*` on disk, which could pool a **failed** iteration's leftover artifact and break the loop quarantine invariant. This replaces the raw disk glob in all three resolution paths with a single projection authority — `RunState::completed_iters(node)` — that quarantines failed/stopped iterations.

- `prompt_augmenter.rs` — agent preamble lists each completed-iter file explicitly; script env `PDO_INPUT_<PORT>` is a newline-separated blessed list (not a glob bash would re-expand).
- `node_io_resolver.rs` — `/io` inspector endpoint (`resolve` now takes `&RunState`; filters on-disk `iter-N` dirs to the blessed set).
- `node_primitives.rs` — forensic `node_started.input_paths` record.
- `InputResolution.path: PathBuf` → `paths: Vec<PathBuf>`.

Docs updated: CONTEXT.md, `pipeline.rs` doc-comments, ADR-0017.

## Validation
Clean build (`cargo build -p pdo-daemon`, 0 errors). Regression tests added at every touched layer asserting failed iters are excluded, no glob remains anywhere, and the pool is empty before a source completes anything (implementer reports 1215 lib + 1365 integ green). Verdict from the pipeline's tester node: **Pass** (headless daemon-internal fix, no live UI surface in this run).

Version bumped to v0.1.78.

🤖 Generated with [Claude Code](https://claude.com/claude-code)