### PR TITLE
fix(#352): round-trip legacy type:loop node's max_iter on save — v0.1.79

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "0.1.78"
+version = "0.1.79"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "0.1.78"
+version = "0.1.79"
 license = "MIT"
 
 [workspace.dependencies]

--- a/frontend/src/stores/editStore.test.ts
+++ b/frontend/src/stores/editStore.test.ts
@@ -839,10 +839,10 @@ describe("editStore.flushPendingSaves", () => {
 });
 
 describe("serializePipeline (via save) emits structural node fields", () => {
-  // The legacy Loop node carried a node-level `max_iter` (#171 removed it). A
-  // bounded loop is now a `loops:` region whose `max_iter` is serialized on the
-  // region, not on any node — so no node ever emits `max_iter`.
-  it("never emits a node-level max_iter (loop node removed, #171)", async () => {
+  // A regular node carries no node-level `max_iter` — the region model keeps the
+  // bound on the `loops:` block (ADR-0011). So an ordinary node must serialize
+  // clean, with no stray `max_iter` key.
+  it("does not emit max_iter for a node without one", async () => {
     const docNode = makeNode({ id: "doc1", type: "doc-only" });
     seedTabWithPipeline(makePipeline([docNode]));
 
@@ -850,6 +850,58 @@ describe("serializePipeline (via save) emits structural node fields", () => {
 
     const yaml = mockSavePipeline.mock.calls[0][1];
     expect(yaml).not.toMatch(/max_iter/);
+  });
+
+  // #352 regression: a legacy `type: loop` node still carries a node-level
+  // `max_iter` the daemon validates (`pipeline.rs` `NodeType::Loop`). The loader
+  // hydrates it, so the serializer MUST round-trip it — otherwise the save is
+  // rejected ("loop node '<id>' must declare 'max_iter'") and nothing persists.
+  // `type: "loop"` is a legacy value no longer in the `NodeType` union, hence the
+  // cast; the fix keys off the presence of `max_iter`, not the type string.
+  it("round-trips a legacy type:loop node's max_iter (#352)", async () => {
+    const loopNode: NodeDef = {
+      ...makeNode({ id: "qdtXejYS", name: "loop" }),
+      type: "loop" as unknown as NodeDef["type"],
+      max_iter: 3,
+      inputs: [
+        { name: "in", repeated: false },
+        { name: "break", repeated: false },
+      ],
+      outputs: [
+        { name: "body", repeated: false },
+        { name: "done", repeated: false },
+      ],
+    };
+    seedTabWithPipeline(makePipeline([loopNode]));
+
+    await useEditStore.getState().save("test-tab");
+
+    const yaml = mockSavePipeline.mock.calls[0][1];
+    expect(yaml).toMatch(/max_iter: 3/);
+  });
+
+  // A `$var` bound must survive verbatim (max_iter can be a variable reference,
+  // like the region model — see NodeDef.max_iter: number | string).
+  it("round-trips a legacy loop node's $var max_iter verbatim (#352)", async () => {
+    const loopNode: NodeDef = {
+      ...makeNode({ id: "spinner", name: "loop" }),
+      type: "loop" as unknown as NodeDef["type"],
+      max_iter: "$rounds",
+      inputs: [
+        { name: "in", repeated: false },
+        { name: "break", repeated: false },
+      ],
+      outputs: [
+        { name: "body", repeated: false },
+        { name: "done", repeated: false },
+      ],
+    };
+    seedTabWithPipeline(makePipeline([loopNode]));
+
+    await useEditStore.getState().save("test-tab");
+
+    const yaml = mockSavePipeline.mock.calls[0][1];
+    expect(yaml).toMatch(/max_iter: \$rounds/);
   });
 
   // ForEach-node `over` serialization and `over`-reset-on-edge-delete tests were

--- a/frontend/src/stores/editStore.ts
+++ b/frontend/src/stores/editStore.ts
@@ -281,6 +281,16 @@ export function pipelineToYamlObject(p: PipelineDef): Record<string, unknown> {
     // emitted only when set so an unset node and a library twin with no model
     // both produce objects without the key and stay `synced`, not `diverged`.
     if (n.model) node.model = n.model;
+    // Legacy `type: loop` nodes (pre-region model, ADR-0011) carry a node-level
+    // `max_iter` that the daemon still requires and validates
+    // (`pipeline.rs` `NodeType::Loop`). The current model emits `max_iter` on the
+    // `loops:` region below, not on any node — but a legacy loop node has no
+    // matching region, so if its bound isn't round-tripped here the daemon
+    // rejects the save with "loop node '<id>' must declare 'max_iter'" and
+    // nothing persists (#352). Bounded loops are the only nodes that carry
+    // `node.max_iter` (regular nodes never set it), so its presence is the
+    // signal — this mirrors the region emit and keeps non-loop nodes clean.
+    if (n.max_iter !== undefined && n.max_iter !== null) node.max_iter = n.max_iter;
     // A collection's `over` driver now lives on the `loops:` region, not on any
     // node (#151) — no node-level `over` serialization.
     if (n.inputs.length > 0)


### PR DESCRIPTION
## What

Editing and saving a legacy `type: loop` pipeline was rejected by the daemon with HTTP 400 because the frontend serializer (`pipelineToYamlObject` in `editStore.ts`) dropped `max_iter` on the round-trip. The daemon has always been correct: `NodeType::Loop` requires `max_iter` (`crates/pdo-daemon/src/pipeline.rs`), so the truncated payload failed parsing.

The one-line fix re-emits `max_iter` from the node model on save, so both a numeric bound and a `$var` string survive the round-trip.

## Tests

- `frontend/src/stores/editStore.test.ts` — two new #352 regression cases seed the exact `review-loop.yaml` shape (numeric + `$var` bounds), drive the real `save()` path, and assert the POST payload keeps `max_iter`.
- Red→green verified: neutralizing the fix makes both cases fail with the truncated payload that produced the 400; restoring it makes them pass.

## Validation

Tester verdict: **Pass**. Clean frontend build (`tsc -b && vite build`), 148 tests green.

Closes #352

🤖 Generated with [Claude Code](https://claude.com/claude-code)