### PR TITLE
feat(#345): export a node to YAML + add a node from YAML (round-trip) — v0.1.81

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -922,6 +922,7 @@ Un **onglet de pipeline** (ou *onglet canvas*) = un document ouvert dans la zone
 - **From scratch** : "+ Add node" → nœud vide à remplir.
 - **Duplicate existing** : right-click sur un nœud → copie avec id auto-incrémenté.
 - **Depuis la bibliothèque** : drag-drop d'un node favori (cf. *Bibliothèque* ci-dessous).
+- **Depuis un YAML** (#345) : "+ Add node" → *Add node from YAML…* — colle une définition de nœud (presse-papier) **ou** charge un fichier `.yaml`, validée côté daemon (`POST /nodes/parse`, même forme qu'une entrée de la bibliothèque de nodes), et instancie le nœud sur le **canvas** (id régénéré, sans arête, comme le *duplicate*). Round-trip **natif et sans perte** du *Export as YAML…* (menu contextuel du nœud, pur front-end). À **ne pas confondre** avec l'*Import de workflow* (format *étranger* CC → **brouillon de pipeline** en bibliothèque, avec perte — ADR-0016). _Éviter_ : « importer/import » (réservé au workflow ; deux affordances « Import » côte à côte brouilleraient le modèle mental) et « coller/paste » comme **nom du concept** (le fichier est aussi supporté).
 - **Pas de library de templates PDO-shipped en v1** (cohérent avec ADR-0001 : pas d'opinion vendor sur "à quoi ressemble un Implementer"). La bibliothèque est exclusivement user-managed.
 
 ---
@@ -930,7 +931,7 @@ Un **onglet de pipeline** (ou *onglet canvas*) = un document ouvert dans la zone
 
 `~/.pdo/library/` — store user-managed à deux niveaux :
 
-- **Nodes** (`~/.pdo/library/nodes/`) — nodes réutilisables d'une pipeline à l'autre. Drag-drop depuis le panneau bibliothèque vers le canvas pour les instancier. Endpoint daemon `POST /library/nodes` accepte une node spec inline ; la création n'est jamais bloquée par un état "pipeline dirty".
+- **Nodes** (`~/.pdo/library/nodes/`) — nodes réutilisables d'une pipeline à l'autre. Drag-drop depuis le panneau bibliothèque vers le canvas pour les instancier. Endpoint daemon `POST /library/nodes` accepte une node spec inline ; la création n'est jamais bloquée par un état "pipeline dirty". Une entrée porte désormais le `model` par-node (#296/#345) : la bibliothèque de nodes est **model-aware** (elle le droppait silencieusement avant), et une entrée est aussi la forme d'un *Export as YAML…* (elle s'importe telle quelle via *Add node from YAML…*).
 - **Pipelines** (`~/.pdo/library/pipelines/`) — pipelines complètes templatées. C'est cette liste qui peuple le **dropdown du modal "+ New Run"**. Bouton favoriter dans le panneau info de la toolbar pour ajouter / retirer une pipeline de la bibliothèque.
 
 Le clone d'une pipeline depuis la bibliothèque vers `<repo>/.pdo/runs/<run-id>/pipeline.yaml` se produit au démarrage d'un Run. Les modifs pendant un Run propagent vers la template d'origine (auto-sync montant, ADR-0007).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "0.1.80"
+version = "0.1.81"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "0.1.80"
+version = "0.1.81"
 license = "MIT"
 
 [workspace.dependencies]

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -2676,6 +2676,10 @@ fn build_router(state: Arc<AppState>) -> Router {
         .route("/sessions/{run_id}/shell", post(open_run_shell))
         .route("/library", get(list_library))
         .route("/library", post(save_to_library))
+        // #345 — parse a single node's YAML into a canvas-instantiable spec.
+        // Disk-free; NEW top-level `/nodes` prefix ⇒ added to the vite proxy
+        // whitelist (frontend/vite.config.ts) so dev POSTs don't 404 as SPA.
+        .route("/nodes/parse", post(parse_node_yaml))
         .route(
             "/library/{name}",
             axum::routing::delete(delete_from_library),
@@ -3820,6 +3824,10 @@ struct SaveToLibraryRequest {
     outputs: Vec<pipeline::Port>,
     #[serde(default)]
     interactive: bool,
+    /// Per-node model override (#345/#296). Optional so a pre-#345 client that
+    /// omits it still stars a node (as model-less), rather than 400-ing.
+    #[serde(default)]
+    model: Option<String>,
     #[serde(default)]
     prompt: String,
 }
@@ -3834,6 +3842,7 @@ async fn save_to_library(
         inputs: req.inputs,
         outputs: req.outputs,
         interactive: req.interactive,
+        model: req.model,
         max_iter: None,
         branches: None,
         prompt: req.prompt,
@@ -3873,12 +3882,146 @@ async fn instantiate_from_library(AxumPath(name): AxumPath<String>) -> Response 
                     "inputs": entry.inputs,
                     "outputs": entry.outputs,
                     "interactive": entry.interactive,
+                    // #345/#296: carry the per-node model so instantiating a
+                    // library node restores its override, not the default.
+                    "model": entry.model,
                 },
                 "prompt": prompt,
             }))
             .into_response()
         }
         None => (StatusCode::NOT_FOUND, "entry not found").into_response(),
+    }
+}
+
+/// Request body for `POST /nodes/parse` (#345): the raw YAML text of a single
+/// node (from a paste or an uploaded `.yaml`). Same field feeds both channels.
+#[derive(serde::Deserialize)]
+struct ParseNodeRequest {
+    yaml: String,
+}
+
+/// Node-library `LibraryEntry` fields plus the two identity/layout keys the
+/// canvas instantiation intentionally regenerates (`id`) or re-centres (`view`).
+/// Any *other* root key is surfaced as an ignored-field warning (ADR-0001/#268:
+/// no silent loss). Kept in sync with `library_store::LibraryEntry`.
+const KNOWN_NODE_KEYS: &[&str] = &[
+    "name",
+    "type",
+    "inputs",
+    "outputs",
+    "interactive",
+    "model",
+    "max_iter",
+    "branches",
+    "prompt",
+    // Accepted-and-dropped, not a semantic loss → no warning.
+    "id",
+    "view",
+];
+
+fn node_parse_error(msg: impl Into<String>) -> Response {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(serde_json::json!({ "error": msg.into() })),
+    )
+        .into_response()
+}
+
+/// Pure core of `POST /nodes/parse` (#345), split from the axum handler so it is
+/// unit-testable without a router/AppState (the endpoint is disk-free and
+/// stateless). Returns the JSON body on success; `Err(msg)` is the verbatim
+/// 400 `{error}` message.
+///
+/// This is the daemon-side locus the node import reuses — the front carries no
+/// YAML parser, so this keeps a single source of truth (serde structs +
+/// `pipeline::normalize_node_value`) for node coercion. It never reads/writes
+/// the node library and never calls `parse_pipeline` (which requires a top-level
+/// `name:` AND a `nodes:` list).
+///
+/// Hard failures (`Err`): invalid YAML, non-mapping root, a whole pipeline
+/// pasted by mistake, missing `name`, retired `for-each`. Soft losses
+/// (defaulted/coerced type, ignored unknown keys) ride back in `warnings[]` with
+/// the node still produced — mirroring `/library/import`.
+fn parse_node_spec(yaml: &str) -> Result<serde_json::Value, String> {
+    // 1. YAML syntax. A parse error is a hard failure (verbatim serde message).
+    let mut value: serde_yaml::Value =
+        serde_yaml::from_str(yaml).map_err(|e| format!("invalid YAML: {e}"))?;
+
+    // 2. Root must be a mapping — a node is a map. A bare scalar/sequence gets a
+    //    clear message instead of a downstream serde type error.
+    let Some(map) = value.as_mapping() else {
+        return Err(
+            "expected a single node definition (a YAML mapping), got a non-mapping document"
+                .to_string(),
+        );
+    };
+
+    // 3. Whole-pipeline-pasted-by-mistake: a `nodes:` or `edges:` root is a
+    //    pipeline, not a node. Reject with a clear message rather than serde's
+    //    cryptic "missing field `type`" (D3 / validation matrix).
+    if map.contains_key(serde_yaml::Value::String("nodes".into()))
+        || map.contains_key(serde_yaml::Value::String("edges".into()))
+    {
+        return Err(
+            "this looks like a whole pipeline, not a node — paste a single node's YAML \
+             (import a full pipeline from the pipeline library instead)"
+                .to_string(),
+        );
+    }
+
+    // 4. `name` is the node's identity — a hard requirement, checked here for a
+    //    clean message (serde would otherwise say "missing field `name`").
+    if map.get(serde_yaml::Value::String("name".into())).is_none() {
+        return Err("missing required field: name".to_string());
+    }
+
+    // 5. Normalize the node `type` in place — shared with `parse_pipeline`:
+    //    default/coerce to doc-only (warnings), refuse retired `for-each`.
+    let mut warnings: Vec<String> = pipeline::normalize_node_value(&mut value)
+        .map_err(|e| format!("{e}"))?
+        .into_iter()
+        .map(|d| d.message)
+        .collect();
+
+    // 6. Surface every root key serde will silently ignore (ADR-0001/#268).
+    if let Some(m) = value.as_mapping() {
+        for key in m.keys() {
+            if let Some(k) = key.as_str() {
+                if !KNOWN_NODE_KEYS.contains(&k) {
+                    warnings.push(format!("unknown field '{k}' (ignored)"));
+                }
+            }
+        }
+    }
+
+    // 7. Deserialize the (normalized) map into a LibraryEntry. `prompt` defaults
+    //    to empty (a structural node carries none); unknown fields are ignored.
+    let entry: library_store::LibraryEntry =
+        serde_yaml::from_value(value).map_err(|e| format!("{e}"))?;
+
+    Ok(serde_json::json!({
+        "spec": {
+            "name": entry.name,
+            "type": entry.node_type,
+            "inputs": entry.inputs,
+            "outputs": entry.outputs,
+            "interactive": entry.interactive,
+            "model": entry.model,
+            "max_iter": entry.max_iter,
+            "branches": entry.branches,
+        },
+        "prompt": entry.prompt,
+        "warnings": warnings,
+    }))
+}
+
+/// `POST /nodes/parse` (#345 / ADR-0016): thin axum wrapper over
+/// `parse_node_spec` — 200 with `{spec, prompt, warnings}` or 400 `{error}`.
+async fn parse_node_yaml(Json(req): Json<ParseNodeRequest>) -> Response {
+    match parse_node_spec(&req.yaml) {
+        Ok(body) => Json(body).into_response(),
+        Err(msg) => node_parse_error(msg),
     }
 }
 
@@ -11208,6 +11351,182 @@ mod tests {
         use std::sync::atomic::{AtomicU16, Ordering};
         static NEXT: AtomicU16 = AtomicU16::new(20000);
         NEXT.fetch_add(1, Ordering::Relaxed)
+    }
+
+    // --- POST /nodes/parse (#345): single-node YAML → canvas-instantiable spec.
+    // The core (`parse_node_spec`) is a pure fn, so most cases test it directly;
+    // two router oneshots confirm the route is actually mounted (the FP's
+    // headline "404 blocking" risk) and maps Ok/Err to 200/400. ---
+
+    #[test]
+    fn parse_node_spec_happy_path_library_shape() {
+        // Exactly what the front export emits (LibraryEntry shape) → no warnings.
+        let body = parse_node_spec(
+            "name: Writer\ntype: doc-only\noutputs:\n  - name: adr\nprompt: |\n  Write an ADR.\n",
+        )
+        .unwrap();
+        assert_eq!(body["spec"]["type"], "doc-only");
+        assert_eq!(body["spec"]["name"], "Writer");
+        assert_eq!(body["spec"]["outputs"][0]["name"], "adr");
+        assert_eq!(body["prompt"], "Write an ADR.\n");
+        assert_eq!(body["warnings"].as_array().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn parse_node_spec_missing_name_is_hard_error() {
+        let err = parse_node_spec("type: doc-only\n").unwrap_err();
+        assert!(err.contains("name"), "{err}");
+    }
+
+    #[test]
+    fn parse_node_spec_invalid_yaml_is_hard_error() {
+        let err = parse_node_spec("name: [unterminated\n").unwrap_err();
+        assert!(err.contains("invalid YAML"), "{err}");
+    }
+
+    #[test]
+    fn parse_node_spec_non_mapping_root_is_hard_error() {
+        let err = parse_node_spec("- just a list item\n").unwrap_err();
+        assert!(err.contains("mapping"), "{err}");
+    }
+
+    #[test]
+    fn parse_node_spec_whole_pipeline_is_hard_error() {
+        for yaml in ["name: p\nnodes: []\n", "name: p\nedges: []\n"] {
+            let err = parse_node_spec(yaml).unwrap_err();
+            assert!(err.contains("whole pipeline"), "{err}");
+        }
+    }
+
+    #[test]
+    fn parse_node_spec_foreach_is_hard_error() {
+        for t in ["for-each", "foreach"] {
+            let err = parse_node_spec(&format!("name: n\ntype: {t}\n")).unwrap_err();
+            assert!(
+                err.contains("removed") && err.contains("pdo migrate"),
+                "{err}"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_node_spec_missing_type_defaults_doc_only_with_warning() {
+        let body = parse_node_spec("name: n\n").unwrap();
+        assert_eq!(body["spec"]["type"], "doc-only");
+        let ws = body["warnings"].as_array().unwrap();
+        assert!(
+            ws.iter()
+                .any(|m| m.as_str().unwrap().contains("missing 'type'")),
+            "{ws:?}"
+        );
+    }
+
+    #[test]
+    fn parse_node_spec_unknown_type_coerces_doc_only_with_warning() {
+        let body = parse_node_spec("name: n\ntype: bogus\n").unwrap();
+        assert_eq!(body["spec"]["type"], "doc-only");
+        let ws = body["warnings"].as_array().unwrap();
+        assert!(
+            ws.iter()
+                .any(|m| m.as_str().unwrap().contains("unknown node type 'bogus'")),
+            "{ws:?}"
+        );
+    }
+
+    #[test]
+    fn parse_node_spec_legacy_types_kept_verbatim() {
+        // Legacy switch/loop are NOT coerced to doc-only (silent semantic loss is
+        // forbidden, ADR-0001/#268) — imported as-is (a soft warning is fine).
+        for t in ["switch", "loop"] {
+            let body = parse_node_spec(&format!("name: n\ntype: {t}\n")).unwrap();
+            assert_eq!(body["spec"]["type"], t, "legacy {t} must survive");
+        }
+    }
+
+    #[test]
+    fn parse_node_spec_unknown_field_warns_but_still_parses() {
+        let body = parse_node_spec("name: n\ntype: doc-only\nwidget: 3\n").unwrap();
+        assert_eq!(body["spec"]["type"], "doc-only");
+        let ws = body["warnings"].as_array().unwrap();
+        assert!(
+            ws.iter()
+                .any(|m| m.as_str().unwrap().contains("unknown field 'widget'")),
+            "{ws:?}"
+        );
+    }
+
+    #[test]
+    fn parse_node_spec_drops_id_and_view_without_warning() {
+        // id is regenerated on add, view re-centred — dropping them is not a loss.
+        let body = parse_node_spec("name: n\ntype: doc-only\nid: keepme\nview:\n  x: 1\n  y: 2\n")
+            .unwrap();
+        assert_eq!(body["warnings"].as_array().unwrap().len(), 0);
+        assert!(body["spec"].get("id").is_none());
+    }
+
+    #[test]
+    fn parse_node_spec_model_round_trips() {
+        let body = parse_node_spec("name: n\ntype: code-mutating\nmodel: opus\n").unwrap();
+        assert_eq!(body["spec"]["model"], "opus");
+        // A node on the account default omits `model:` → null in the spec.
+        let plain = parse_node_spec("name: n\ntype: doc-only\n").unwrap();
+        assert!(plain["spec"]["model"].is_null());
+    }
+
+    #[test]
+    fn parse_node_spec_prompt_absent_defaults_empty() {
+        let body = parse_node_spec("name: n\ntype: doc-only\n").unwrap();
+        assert_eq!(body["prompt"], "");
+    }
+
+    #[tokio::test]
+    async fn nodes_parse_route_is_mounted_and_returns_spec() {
+        let app = build_router(test_state().await);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/nodes/parse")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_string(&serde_json::json!({
+                            "yaml": "name: n\ntype: doc-only\nprompt: |\n  hi\n"
+                        }))
+                        .unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: serde_json::Value = serde_json::from_slice(
+            &axum::body::to_bytes(resp.into_body(), usize::MAX)
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(body["spec"]["type"], "doc-only");
+        assert_eq!(body["prompt"], "hi\n");
+    }
+
+    #[tokio::test]
+    async fn nodes_parse_route_returns_400_on_missing_name() {
+        let app = build_router(test_state().await);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/nodes/parse")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_string(&serde_json::json!({ "yaml": "type: doc-only\n" }))
+                            .unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     }
 
     async fn test_state() -> Arc<AppState> {

--- a/crates/pdo-daemon/src/library_store.rs
+++ b/crates/pdo-daemon/src/library_store.rs
@@ -15,10 +15,20 @@ pub struct LibraryEntry {
     pub outputs: Vec<pipeline::Port>,
     #[serde(default)]
     pub interactive: bool,
+    /// Per-node model override (#296 / #345). Added with the YAML node
+    /// export/import: the node library is now model-aware (it silently dropped
+    /// the model before). Optional + skip-if-none, so pre-#345 entries and nodes
+    /// on the account default round-trip byte-identically.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_iter: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub branches: Option<u32>,
+    /// Defaulted (#345): a structural node exported to YAML carries no prompt,
+    /// and `POST /nodes/parse` must accept a prompt-less node map. Existing
+    /// library files always carry a prompt, so this is purely additive.
+    #[serde(default)]
     pub prompt: String,
 }
 
@@ -179,6 +189,9 @@ pub fn entry_from_node(node: &pipeline::NodeDef, prompt: &str) -> LibraryEntry {
         inputs: node.inputs.clone(),
         outputs: node.outputs.clone(),
         interactive: node.interactive,
+        // #345/#296: carry the per-node model so a starred node stays synced
+        // instead of flipping to `diverged` the moment it has an override.
+        model: node.model.clone(),
         max_iter: None,
         branches: None,
         prompt: prompt.to_string(),
@@ -957,6 +970,7 @@ mod tests {
                 inputs: vec![],
                 outputs: vec![],
                 interactive: false,
+                model: None,
                 max_iter: None,
                 branches: None,
                 prompt: "first".to_string(),
@@ -1020,6 +1034,8 @@ mod tests {
         let entry = LibraryEntry {
             name: "Complex Node".to_string(),
             node_type: pipeline::NodeType::CodeMutating,
+            // #345/#296: a per-node model must round-trip losslessly.
+            model: Some("opus".to_string()),
             inputs: vec![
                 pipeline::Port {
                     name: "plan".to_string(),
@@ -1066,8 +1082,42 @@ mod tests {
         };
 
         let yaml = serde_yaml::to_string(&entry).unwrap();
+        // #345/#296: the per-node model rides through the YAML.
+        assert!(yaml.contains("model: opus"), "yaml missing model:\n{yaml}");
         let parsed: LibraryEntry = serde_yaml::from_str(&yaml).unwrap();
         assert_eq!(parsed, entry);
+    }
+
+    #[test]
+    fn yaml_round_trip_model_absent_is_omitted() {
+        // A node on the account default (model: None) must not emit a `model:`
+        // key, and must round-trip to None (#345/#296 — skip_serializing_if).
+        let entry = LibraryEntry {
+            name: "Plain".to_string(),
+            node_type: pipeline::NodeType::DocOnly,
+            inputs: vec![],
+            outputs: vec![],
+            interactive: false,
+            model: None,
+            max_iter: None,
+            branches: None,
+            prompt: "hi".to_string(),
+        };
+        let yaml = serde_yaml::to_string(&entry).unwrap();
+        assert!(!yaml.contains("model:"), "model: leaked into yaml:\n{yaml}");
+        let parsed: LibraryEntry = serde_yaml::from_str(&yaml).unwrap();
+        assert_eq!(parsed, entry);
+        assert_eq!(parsed.model, None);
+    }
+
+    #[test]
+    fn entry_from_node_carries_model() {
+        // #345/#296: a node with a per-node model must produce a model-aware
+        // library entry (previously the model was silently dropped).
+        let mut node = make_node("Modelled");
+        node.model = Some("sonnet".to_string());
+        let entry = entry_from_node(&node, "prompt");
+        assert_eq!(entry.model, Some("sonnet".to_string()));
     }
 
     #[test]
@@ -1079,6 +1129,7 @@ mod tests {
                 inputs: vec![],
                 outputs: vec![],
                 interactive: false,
+                model: None,
                 max_iter: None,
                 branches: None,
                 prompt: "p".to_string(),
@@ -1398,6 +1449,7 @@ mod tests {
         let entry = LibraryEntry {
             name: "Typed Node".to_string(),
             node_type: pipeline::NodeType::DocOnly,
+            model: None,
             inputs: vec![
                 pipeline::Port {
                     name: "task".to_string(),
@@ -1487,6 +1539,7 @@ mod tests {
             let entry = LibraryEntry {
                 name: "Schema Node".to_string(),
                 node_type: pipeline::NodeType::CodeMutating,
+                model: None,
                 inputs: vec![pipeline::Port {
                     name: "in".to_string(),
                     repeated: false,

--- a/crates/pdo-daemon/src/pipeline.rs
+++ b/crates/pdo-daemon/src/pipeline.rs
@@ -397,6 +397,80 @@ const KNOWN_TOP_LEVEL_KEYS: &[&str] = &[
     "prompt_required",
 ];
 
+/// The node `type` strings the parser accepts verbatim. Anything else is coerced
+/// to `doc-only` with a warning (see `normalize_node_value`); `for-each`/`foreach`
+/// are refused outright (retired in ADR-0011).
+pub const VALID_NODE_TYPES: &[&str] = &[
+    "doc-only",
+    "code-mutating",
+    "start",
+    "end",
+    "switch",
+    "loop",
+    "merge",
+    // #248: without this, a `type: script` node is silently rewritten to
+    // `doc-only` with only a diagnostic (see the layer-1 test).
+    "script",
+];
+
+/// Normalize one node's raw YAML `type` field in place, returning any warnings.
+/// This is the per-node pass `parse_pipeline` runs over each element of the
+/// `nodes:` sequence, factored out so the single-node `POST /nodes/parse`
+/// endpoint (#345) shares exactly the same coercion rules — one source of truth
+/// for node-type handling:
+///
+/// - `for-each` / `foreach` → hard `Err` (the type was removed in ADR-0011;
+///   coercing a fan-out to `doc-only` would run each item's work zero times).
+/// - missing `type` → default to `doc-only` (noisy warning).
+/// - unknown `type` → coerce to `doc-only` (noisy warning).
+/// - a known type (incl. legacy `switch`/`loop`) → left untouched, no warning.
+///
+/// A non-mapping value (e.g. a stray scalar in the `nodes:` list) is a no-op.
+pub fn normalize_node_value(
+    node_val: &mut serde_yaml::Value,
+) -> Result<Vec<Diagnostic>, ParseError> {
+    let mut diagnostics = Vec::new();
+    let Some(node_map) = node_val.as_mapping_mut() else {
+        return Ok(diagnostics);
+    };
+    let type_key = serde_yaml::Value::String("type".into());
+    let node_id = node_map
+        .get(serde_yaml::Value::String("id".into()))
+        .and_then(|v| v.as_str())
+        .unwrap_or("<unknown>")
+        .to_string();
+
+    match node_map.get(&type_key).and_then(|v| v.as_str()) {
+        // ForEach is RETIRED (ADR-0011 / #269): a hard refusal, not the
+        // warn+coerce below — silently rewriting a fan-out node to doc-only
+        // would run each item's work zero times.
+        Some(t @ ("for-each" | "foreach")) => {
+            return Err(ParseError::MissingField(format!(
+                "node '{node_id}': node type '{t}' was removed (ADR-0011) — \
+                 run `pdo migrate` to convert it to a collection loop region"
+            )));
+        }
+        None => {
+            diagnostics.push(Diagnostic {
+                severity: Severity::Warning,
+                message: format!("node '{node_id}': missing 'type', defaulting to 'doc-only'"),
+            });
+            node_map.insert(type_key, serde_yaml::Value::String("doc-only".into()));
+        }
+        Some(t) if !VALID_NODE_TYPES.contains(&t) => {
+            diagnostics.push(Diagnostic {
+                severity: Severity::Warning,
+                message: format!(
+                    "node '{node_id}': unknown node type '{t}', defaulting to 'doc-only'"
+                ),
+            });
+            node_map.insert(type_key, serde_yaml::Value::String("doc-only".into()));
+        }
+        _ => {}
+    }
+    Ok(diagnostics)
+}
+
 pub fn parse_pipeline(yaml: &str) -> Result<ParseResult, ParseError> {
     let mut raw: serde_yaml::Value = serde_yaml::from_str(yaml)?;
 
@@ -410,18 +484,6 @@ pub fn parse_pipeline(yaml: &str) -> Result<ParseResult, ParseError> {
     }
 
     let mut diagnostics = Vec::new();
-    let valid_types = [
-        "doc-only",
-        "code-mutating",
-        "start",
-        "end",
-        "switch",
-        "loop",
-        "merge",
-        // #248: without this, a `type: script` node is silently rewritten to
-        // `doc-only` with only a diagnostic (see the layer-1 test).
-        "script",
-    ];
 
     if let Some(nodes) = raw
         .as_mapping_mut()
@@ -429,45 +491,8 @@ pub fn parse_pipeline(yaml: &str) -> Result<ParseResult, ParseError> {
         .and_then(|v| v.as_sequence_mut())
     {
         for node_val in nodes.iter_mut() {
-            if let Some(node_map) = node_val.as_mapping_mut() {
-                let type_key = serde_yaml::Value::String("type".into());
-                let node_id = node_map
-                    .get(serde_yaml::Value::String("id".into()))
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("<unknown>")
-                    .to_string();
-
-                match node_map.get(&type_key).and_then(|v| v.as_str()) {
-                    // ForEach is RETIRED (ADR-0011 / #269): a hard refusal, not
-                    // the warn+coerce below — silently rewriting a fan-out node
-                    // to doc-only would run each item's work zero times.
-                    Some(t @ ("for-each" | "foreach")) => {
-                        return Err(ParseError::MissingField(format!(
-                            "node '{node_id}': node type '{t}' was removed (ADR-0011) — \
-                             run `pdo migrate` to convert it to a collection loop region"
-                        )));
-                    }
-                    None => {
-                        diagnostics.push(Diagnostic {
-                            severity: Severity::Warning,
-                            message: format!(
-                                "node '{node_id}': missing 'type', defaulting to 'doc-only'"
-                            ),
-                        });
-                        node_map.insert(type_key, serde_yaml::Value::String("doc-only".into()));
-                    }
-                    Some(t) if !valid_types.contains(&t) => {
-                        diagnostics.push(Diagnostic {
-                            severity: Severity::Warning,
-                            message: format!(
-                                "node '{node_id}': unknown node type '{t}', defaulting to 'doc-only'"
-                            ),
-                        });
-                        node_map.insert(type_key, serde_yaml::Value::String("doc-only".into()));
-                    }
-                    _ => {}
-                }
-            }
+            // Per-node type normalization, shared with `POST /nodes/parse` (#345).
+            diagnostics.extend(normalize_node_value(node_val)?);
         }
     }
 
@@ -3205,6 +3230,109 @@ edges: []
                 "refusal must name `pdo migrate`, got: {msg}"
             );
         }
+    }
+
+    // --- normalize_node_value: the per-node pass shared by parse_pipeline and
+    // the single-node `POST /nodes/parse` endpoint (#345). ---
+
+    fn node_value(yaml: &str) -> serde_yaml::Value {
+        serde_yaml::from_str(yaml).unwrap()
+    }
+
+    fn type_str(v: &serde_yaml::Value) -> Option<String> {
+        v.as_mapping()
+            .and_then(|m| m.get(serde_yaml::Value::String("type".into())))
+            .and_then(|t| t.as_str())
+            .map(str::to_string)
+    }
+
+    #[test]
+    fn normalize_node_value_defaults_missing_type() {
+        let mut v = node_value("id: n1\nname: X\n");
+        let diags = normalize_node_value(&mut v).unwrap();
+        assert_eq!(diags.len(), 1);
+        assert!(
+            diags[0].message.contains("missing 'type'"),
+            "{}",
+            diags[0].message
+        );
+        assert_eq!(type_str(&v).as_deref(), Some("doc-only"));
+    }
+
+    #[test]
+    fn normalize_node_value_coerces_unknown_type() {
+        let mut v = node_value("id: n1\nname: X\ntype: bogus\n");
+        let diags = normalize_node_value(&mut v).unwrap();
+        assert_eq!(diags.len(), 1);
+        assert!(
+            diags[0].message.contains("unknown node type 'bogus'"),
+            "{}",
+            diags[0].message
+        );
+        assert_eq!(type_str(&v).as_deref(), Some("doc-only"));
+    }
+
+    #[test]
+    fn normalize_node_value_leaves_known_types_untouched() {
+        for t in VALID_NODE_TYPES {
+            let mut v = node_value(&format!("id: n1\nname: X\ntype: {t}\n"));
+            let diags = normalize_node_value(&mut v).unwrap();
+            assert!(diags.is_empty(), "type {t} should not warn");
+            assert_eq!(type_str(&v).as_deref(), Some(*t));
+        }
+    }
+
+    #[test]
+    fn normalize_node_value_refuses_foreach() {
+        for t in ["for-each", "foreach"] {
+            let mut v = node_value(&format!("id: n1\nname: X\ntype: {t}\n"));
+            let err = normalize_node_value(&mut v).unwrap_err().to_string();
+            assert!(
+                err.contains("removed") && err.contains("pdo migrate"),
+                "{err}"
+            );
+        }
+    }
+
+    #[test]
+    fn normalize_node_value_ignores_non_mapping() {
+        // A stray non-mapping element (e.g. a scalar in the nodes list) is a
+        // no-op: no diagnostics, no mutation.
+        let mut v = node_value("- a scalar");
+        let before = v.clone();
+        let diags = normalize_node_value(&mut v).unwrap();
+        assert!(diags.is_empty());
+        assert_eq!(v, before);
+    }
+
+    #[test]
+    fn normalize_node_value_matches_parse_pipeline_diagnostic() {
+        // Golden: the factored per-node pass emits exactly the diagnostic the
+        // full pipeline parse emits for the same node — single source of truth,
+        // so the refactor is behaviour-preserving.
+        let mut node = node_value("id: n1\nname: X\ntype: bogus\n");
+        let node_diags = normalize_node_value(&mut node).unwrap();
+        let yaml = with_start_end(
+            r#"
+name: t
+nodes:
+  - id: n1
+    name: X
+    type: bogus
+edges: []
+"#,
+        );
+        let msgs: Vec<String> = parse_pipeline(&yaml)
+            .unwrap()
+            .diagnostics
+            .iter()
+            .map(|d| d.message.clone())
+            .collect();
+        assert!(
+            msgs.iter().any(|m| *m == node_diags[0].message),
+            "parse_pipeline diagnostics {msgs:?} must include {:?}",
+            node_diags[0].message
+        );
     }
 
     #[test]

--- a/docs/adr/0016-workflow-import-parse-mechanism.md
+++ b/docs/adr/0016-workflow-import-parse-mechanism.md
@@ -39,5 +39,10 @@ complète.
 - **Reconnaissance de boucle gardée sur la présence d'un `agent()` dans le corps** : un `while`/`for`
   de plomberie (double-décodage des `args`, retry `JSON.parse`) ne matérialise **pas** une boucle —
   sinon un `bounded` fantôme. Même garde pour `if` → edge conditionnelle.
-</content>
-</invoke>
+- **Réutilisé pour l'import d'un nœud YAML unique** (#345) : `POST /nodes/parse` applique le même
+  locus *parse-côté-daemon + canal `warnings[]`* à un **nœud nu** (désérialise une `LibraryEntry`,
+  pas une pipeline ; disk-free — ni lecture ni écriture de la bibliothèque). Différence de nature :
+  c'est un round-trip **natif et sans perte** (l'export d'un nœud produit exactement cette forme),
+  pas la décompilation *avec perte* d'un format étranger — d'où le nom produit *Add node from YAML…*
+  et non « import ». Le refus de `for-each` / le défaut-`doc-only` sont partagés via
+  `pipeline::normalize_node_value`, seule source de vérité de la coercition de type.

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -751,6 +751,9 @@ export interface LibraryEntry {
   inputs: LibraryPort[];
   outputs: LibraryPort[];
   interactive: boolean;
+  /** Per-node model override (#296/#345) — the node library is model-aware.
+   * Absent/null ⇒ account default. */
+  model?: string | null;
   max_iter?: number | null;
   branches?: number | null;
   prompt: string;
@@ -768,6 +771,8 @@ export interface LibrarySaveSpec {
   inputs: LibraryPort[];
   outputs: LibraryPort[];
   interactive: boolean;
+  /** Per-node model override (#296/#345). Omit/undefined ⇒ account default. */
+  model?: string | null;
   prompt: string;
 }
 
@@ -795,6 +800,8 @@ export interface InstantiateResult {
     inputs: LibraryPort[];
     outputs: LibraryPort[];
     interactive: boolean;
+    /** Per-node model override (#296/#345). Null ⇒ account default. */
+    model?: string | null;
   };
   prompt: string;
 }
@@ -804,6 +811,47 @@ export async function instantiateFromLibrary(name: string): Promise<InstantiateR
     method: "POST",
   });
   if (!resp.ok) throw new Error(`POST /library/${name}/instantiate failed: ${resp.status}`);
+  return resp.json();
+}
+
+/**
+ * Parsed form of a single node's YAML (#345): the `POST /nodes/parse` 200 body.
+ * `spec` is `LibraryEntry`-shaped (same as {@link InstantiateResult}) plus the
+ * legacy `max_iter`/`branches`; `warnings` carries soft losses (coerced/unknown
+ * fields) with the node still created. A hard failure throws (400 `{error}`).
+ */
+export interface ParseNodeResult {
+  spec: {
+    name: string;
+    type: string;
+    inputs: LibraryPort[];
+    outputs: LibraryPort[];
+    interactive: boolean;
+    model?: string | null;
+    max_iter?: number | string | null;
+    branches?: number | null;
+  };
+  prompt: string;
+  warnings: string[];
+}
+
+/**
+ * Validate a single node's YAML on the daemon (#345 / ADR-0016) and get back a
+ * canvas-instantiable spec. The front holds no YAML parser: it POSTs the raw
+ * text (paste OR uploaded `.yaml`) and the daemon parses with the same serde
+ * structs the pipeline parser uses. Mirror of {@link importWorkflow}: a 400
+ * body carries a verbatim `error`; a 200 carries `{spec, prompt, warnings}`.
+ */
+export async function parseNodeYaml(yaml: string): Promise<ParseNodeResult> {
+  const resp = await fetch(`${BASE}/nodes/parse`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ yaml }),
+  });
+  if (!resp.ok) {
+    const body = await resp.json().catch(() => null);
+    throw new Error(body?.error ?? `POST /nodes/parse failed: ${resp.status}`);
+  }
   return resp.json();
 }
 

--- a/frontend/src/components/AddNodeFromYamlModal.test.tsx
+++ b/frontend/src/components/AddNodeFromYamlModal.test.tsx
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import AddNodeFromYamlModal from "./AddNodeFromYamlModal";
+import { useEditStore } from "../stores/editStore";
+import type { ParseNodeResult } from "../api";
+
+// Keep the real `libraryPortToPortDef`; only `parseNodeYaml` is stubbed per-test.
+vi.mock("../api", async (orig) => {
+  const actual = await orig<typeof import("../api")>();
+  return { ...actual, parseNodeYaml: vi.fn() };
+});
+vi.mock("../lib/nanoid", () => ({ generateNodeId: () => "fresh-node-id" }));
+
+import { parseNodeYaml } from "../api";
+const mockParse = vi.mocked(parseNodeYaml);
+
+function seedTab() {
+  useEditStore.setState({
+    openTabs: [
+      {
+        id: "t1",
+        scope: "repo",
+        pipeline: { name: "p", version: "1.0", variables: {}, nodes: [], edges: [] },
+        prompts: {},
+        diagnostics: [],
+        dirty: false,
+        externalDirty: false,
+      },
+    ],
+    activeTabId: "t1",
+    selection: { kind: "none", id: null },
+    history: {},
+  });
+}
+
+function okResult(overrides: Partial<ParseNodeResult> = {}): ParseNodeResult {
+  return {
+    spec: {
+      name: "Imported",
+      type: "doc-only",
+      inputs: [],
+      outputs: [{ name: "out", repeated: false, side: "right" }],
+      interactive: false,
+      model: null,
+      ...(overrides.spec ?? {}),
+    },
+    prompt: "the prompt",
+    warnings: [],
+    ...overrides,
+  } as ParseNodeResult;
+}
+
+const drop = () => ({ x: 100, y: 200 });
+
+beforeEach(() => {
+  seedTab();
+  mockParse.mockReset();
+});
+
+describe("AddNodeFromYamlModal (#345)", () => {
+  it("paste + submit creates a fresh, selected node and closes (no warnings)", async () => {
+    mockParse.mockResolvedValue(okResult());
+    const onClose = vi.fn();
+    render(<AddNodeFromYamlModal getDropPosition={drop} onClose={onClose} />);
+
+    fireEvent.change(screen.getByTestId("add-node-yaml-textarea"), {
+      target: { value: "name: Imported\ntype: doc-only\n" },
+    });
+    fireEvent.click(screen.getByTestId("add-node-yaml-submit"));
+
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+    const st = useEditStore.getState();
+    const nodes = st.openTabs[0].pipeline.nodes;
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0].id).toBe("fresh-node-id");
+    expect(nodes[0].name).toBe("Imported");
+    expect(nodes[0].view).toEqual({ x: 100, y: 200 });
+    expect(st.openTabs[0].prompts["fresh-node-id"]).toBe("the prompt");
+    expect(st.selection).toEqual({ kind: "node", id: "fresh-node-id" });
+  });
+
+  it("the created node is undoable in one step", async () => {
+    mockParse.mockResolvedValue(okResult());
+    render(<AddNodeFromYamlModal getDropPosition={drop} onClose={() => {}} />);
+    fireEvent.change(screen.getByTestId("add-node-yaml-textarea"), {
+      target: { value: "name: Imported\ntype: doc-only\n" },
+    });
+    fireEvent.click(screen.getByTestId("add-node-yaml-submit"));
+    await waitFor(() => expect(useEditStore.getState().openTabs[0].pipeline.nodes).toHaveLength(1));
+    useEditStore.getState().undo();
+    expect(useEditStore.getState().openTabs[0].pipeline.nodes).toHaveLength(0);
+  });
+
+  it("a hard error shows a red box, creates no node, and keeps the modal open", async () => {
+    mockParse.mockRejectedValue(new Error("this is a whole pipeline, not a node"));
+    const onClose = vi.fn();
+    render(<AddNodeFromYamlModal getDropPosition={drop} onClose={onClose} />);
+    fireEvent.change(screen.getByTestId("add-node-yaml-textarea"), {
+      target: { value: "name: p\nnodes: []\n" },
+    });
+    fireEvent.click(screen.getByTestId("add-node-yaml-submit"));
+
+    expect(await screen.findByTestId("add-node-yaml-error")).toHaveTextContent(/whole pipeline/);
+    expect(onClose).not.toHaveBeenCalled();
+    expect(useEditStore.getState().openTabs[0].pipeline.nodes).toHaveLength(0);
+  });
+
+  it("warnings create the node AND show the amber list (does not auto-close)", async () => {
+    mockParse.mockResolvedValue(
+      okResult({ warnings: ["node 'x': unknown node type 'bogus', defaulting to 'doc-only'"] }),
+    );
+    const onClose = vi.fn();
+    render(<AddNodeFromYamlModal getDropPosition={drop} onClose={onClose} />);
+    fireEvent.change(screen.getByTestId("add-node-yaml-textarea"), {
+      target: { value: "name: x\ntype: bogus\n" },
+    });
+    fireEvent.click(screen.getByTestId("add-node-yaml-submit"));
+
+    expect(await screen.findByTestId("add-node-yaml-warnings")).toHaveTextContent(/bogus/);
+    expect(onClose).not.toHaveBeenCalled();
+    expect(useEditStore.getState().openTabs[0].pipeline.nodes).toHaveLength(1);
+  });
+
+  it("a .yaml upload fills the textarea from the file text", async () => {
+    render(<AddNodeFromYamlModal getDropPosition={drop} onClose={() => {}} />);
+    const file = new File(["name: FromFile\ntype: doc-only\n"], "node.yaml", {
+      type: "text/yaml",
+    });
+    fireEvent.change(screen.getByTestId("add-node-yaml-file"), { target: { files: [file] } });
+    await waitFor(() =>
+      expect((screen.getByTestId("add-node-yaml-textarea") as HTMLTextAreaElement).value).toContain(
+        "name: FromFile",
+      ),
+    );
+  });
+});

--- a/frontend/src/components/AddNodeFromYamlModal.tsx
+++ b/frontend/src/components/AddNodeFromYamlModal.tsx
@@ -1,0 +1,177 @@
+import { useState } from "react";
+import type { NodeDef, NodeType } from "../types";
+import { parseNodeYaml, libraryPortToPortDef } from "../api";
+import { useEditStore } from "../stores/editStore";
+import { generateNodeId } from "../lib/nanoid";
+
+/**
+ * Add a node to the canvas from YAML (#345): paste a node definition OR upload a
+ * `.yaml`, validated by the daemon (`POST /nodes/parse`), then instantiated as a
+ * fresh, disconnected node — a new id, placed at the drop position, selected —
+ * exactly like Duplicate / a library insert. NOT called "import" (that term is
+ * reserved for the lossy foreign-workflow decompiler, ADR-0016).
+ *
+ * Two-channel result idiom, verbatim from `ImportWorkflowModal`: a red `error`
+ * box for hard failures (blocks, modal stays open, NO node created) and an amber
+ * `warnings` list for soft losses (node created, "Done"). The YAML is only ever
+ * rendered inside a `<textarea>` as plain text — no markdown/HTML (ADR-0013/0018).
+ */
+export default function AddNodeFromYamlModal({
+  getDropPosition,
+  onClose,
+}: {
+  getDropPosition: () => { x: number; y: number };
+  onClose: () => void;
+}) {
+  const [yaml, setYaml] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [warnings, setWarnings] = useState<string[] | null>(null);
+  const addNode = useEditStore((s) => s.addNode);
+  const updatePrompt = useEditStore((s) => s.updatePrompt);
+  const setSelection = useEditStore((s) => s.setSelection);
+
+  async function handleFile(file: File | null) {
+    setError(null);
+    setWarnings(null);
+    if (!file) return;
+    // The `.yaml` is read client-side and its text drops straight into the
+    // textarea — the same single value feeds paste and upload (nothing is sent
+    // until Submit), so the user can review/edit before creating the node.
+    setYaml(await file.text());
+  }
+
+  async function handleSubmit() {
+    if (!yaml.trim() || submitting) return;
+    setSubmitting(true);
+    setError(null);
+    setWarnings(null);
+    try {
+      const result = await parseNodeYaml(yaml);
+      // Mirror LibraryDropdown.handleAdd: fresh id, drop-position, addNode
+      // (snapshots undo in one step), then the prompt sidecar. Cast covers the
+      // legacy `switch`/`loop` the TS union omits (soft-warned by the daemon).
+      const newId = generateNodeId();
+      const node: NodeDef = {
+        id: newId,
+        name: result.spec.name,
+        type: result.spec.type as NodeType,
+        inputs: result.spec.inputs.map((p) => libraryPortToPortDef(p, "left")),
+        outputs: result.spec.outputs.map((p) => libraryPortToPortDef(p, "right")),
+        interactive: result.spec.interactive,
+        model: result.spec.model ?? null,
+        view: getDropPosition(),
+      };
+      addNode(node);
+      updatePrompt(newId, result.prompt);
+      setSelection({ kind: "node", id: newId });
+
+      const w = result.warnings ?? [];
+      if (w.length > 0) {
+        // Node created, but surface the soft losses (ADR-0001) before closing.
+        setWarnings(w);
+      } else {
+        onClose();
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      data-testid="add-node-yaml-backdrop"
+      onClick={onClose}
+    >
+      <div
+        className="w-[440px] max-w-[90vw] rounded-lg border border-line bg-bg-4 p-4"
+        style={{ fontSize: "12px" }}
+        data-testid="add-node-yaml-modal"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="mb-1 font-medium text-fg">Add node from YAML</div>
+        <p className="mb-3 text-fg-4" style={{ fontSize: "11px" }}>
+          Paste a node definition or load a <code>.yaml</code> file. It is
+          validated by the daemon, then added to the canvas with a fresh id and
+          no edges — like a duplicate.
+        </p>
+
+        <label className="mb-1 block text-fg-3" style={{ fontSize: "11px" }}>
+          Node YAML
+        </label>
+        <textarea
+          value={yaml}
+          onChange={(e) => {
+            setYaml(e.target.value);
+            setError(null);
+            setWarnings(null);
+          }}
+          disabled={warnings != null}
+          placeholder={"name: My node\ntype: doc-only\nprompt: |\n  ..."}
+          data-testid="add-node-yaml-textarea"
+          className="mb-2 h-40 w-full resize-y rounded border border-line-strong bg-bg-3 px-2 py-1.5 font-mono text-fg outline-none focus:border-acc disabled:opacity-60"
+          style={{ fontSize: "11px", lineHeight: "1.5" }}
+        />
+
+        <input
+          type="file"
+          accept=".yaml,.yml"
+          data-testid="add-node-yaml-file"
+          disabled={warnings != null}
+          onChange={(e) => handleFile(e.target.files?.[0] ?? null)}
+          className="mb-3 w-full rounded border border-line-strong bg-bg-3 px-2 py-1.5 text-fg outline-none file:mr-2 file:rounded file:border-0 file:bg-bg-4 file:px-2 file:py-0.5 file:text-fg-3"
+        />
+
+        {error && (
+          <div
+            className="mb-3 rounded border border-st-failed/40 bg-st-failed/10 px-2 py-1.5 text-st-failed"
+            style={{ fontSize: "11px" }}
+            data-testid="add-node-yaml-error"
+          >
+            {error}
+          </div>
+        )}
+
+        {warnings && (
+          <div
+            className="mb-3 max-h-40 overflow-y-auto rounded border border-st-await/40 bg-st-await/10 px-2 py-1.5 text-fg-2"
+            style={{ fontSize: "11px" }}
+            data-testid="add-node-yaml-warnings"
+          >
+            <div className="mb-1 font-medium text-st-await">
+              Node added with {warnings.length} warning
+              {warnings.length === 1 ? "" : "s"}:
+            </div>
+            <ul className="list-disc pl-4">
+              {warnings.map((w, i) => (
+                <li key={i}>{w}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        <div className="flex justify-end gap-2">
+          <button
+            onClick={onClose}
+            className="rounded border border-line-strong bg-bg-3 px-3 py-1 text-fg-3 transition-colors hover:text-fg"
+          >
+            {warnings ? "Done" : "Cancel"}
+          </button>
+          {!warnings && (
+            <button
+              onClick={handleSubmit}
+              disabled={!yaml.trim() || submitting}
+              data-testid="add-node-yaml-submit"
+              className="rounded bg-acc px-3 py-1 font-medium text-bg-0 transition-colors hover:bg-acc-dim disabled:opacity-50"
+            >
+              {submitting ? "Adding…" : "Add node"}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/EditCanvas.tsx
+++ b/frontend/src/components/EditCanvas.tsx
@@ -30,6 +30,8 @@ import { NoteNode } from "./NoteNode";
 import { MergeEditNode } from "./MergeNode";
 import OrthogonalEdge from "./OrthogonalEdge";
 import EditToolbar from "./EditToolbar";
+import ExportNodeYamlModal from "./ExportNodeYamlModal";
+import AddNodeFromYamlModal from "./AddNodeFromYamlModal";
 import LintBanner, { type LintBannerItem } from "./LintBanner";
 import DragConnectionLine from "./DragConnectionLine";
 import { DragHighlightProvider, useIsDropTarget } from "./DragHighlightContext";
@@ -282,6 +284,11 @@ function EditCanvasInner({ libraryEntries, libraryPipelines, onLibraryDelete, on
     edgeIndex: number;
     loopIds: string[];
   } | null>(null);
+  // #345: id of the node whose "Export as YAML…" modal is open (null = closed),
+  // and whether the "Add node from YAML…" modal is open. Both are edit-mode
+  // affordances gated with the rest of the context menu / toolbar on readOnly.
+  const [exportNodeId, setExportNodeId] = useState<string | null>(null);
+  const [addFromYamlOpen, setAddFromYamlOpen] = useState(false);
   const reactFlowRef = useRef<HTMLDivElement>(null);
   const reactFlow = useReactFlow();
   const [isDraggingEdge, setIsDraggingEdge] = useState(false);
@@ -650,11 +657,18 @@ function EditCanvasInner({ libraryEntries, libraryPipelines, onLibraryDelete, on
     setSelection({ kind: "note", id: null, noteId: id });
   };
 
+  // #345: resolve the export-modal target live, so a delete/undo that removes it
+  // mid-modal drops back to null (closes the modal) rather than showing a stale node.
+  const exportNode = exportNodeId
+    ? pipeline.nodes.find((n) => n.id === exportNodeId) ?? null
+    : null;
+
   return (
     <div className="relative flex-1" ref={reactFlowRef}>
       <EditToolbar
         onAddNode={handleAddNode}
         onAddNote={handleAddNote}
+        onAddNodeFromYaml={() => setAddFromYamlOpen(true)}
         libraryEntries={libraryEntries}
         onLibraryDelete={onLibraryDelete}
         getDropPosition={computeDropPosition}
@@ -759,6 +773,10 @@ function EditCanvasInner({ libraryEntries, libraryPipelines, onLibraryDelete, on
             duplicateNode(contextMenu.id);
             setContextMenu(null);
           }}
+          onExportNode={() => {
+            setExportNodeId(contextMenu.id);
+            setContextMenu(null);
+          }}
           onFanOut={(field) => {
             if (contextMenu.fanoutMembers && contextMenu.fanoutMembers.length > 0) {
               createCollectionRegion(contextMenu.fanoutMembers, field);
@@ -795,6 +813,25 @@ function EditCanvasInner({ libraryEntries, libraryPipelines, onLibraryDelete, on
           setPendingDestroy(null);
         }}
       />
+
+      {/* #345: Export the selected node as YAML. The node is looked up live so a
+          concurrent edit/delete simply closes the modal (node → undefined). */}
+      {exportNode && (
+        <ExportNodeYamlModal
+          node={exportNode}
+          prompt={tab.prompts[exportNode.id] ?? ""}
+          onClose={() => setExportNodeId(null)}
+        />
+      )}
+
+      {/* #345: Add a node from pasted/uploaded YAML, placed at the viewport
+          centre (same drop logic as + Add node / a library insert). */}
+      {addFromYamlOpen && (
+        <AddNodeFromYamlModal
+          getDropPosition={computeDropPosition}
+          onClose={() => setAddFromYamlOpen(false)}
+        />
+      )}
     </div>
   );
 }
@@ -807,6 +844,7 @@ function ContextMenu({
   onDeleteNode,
   onDeleteNote,
   onDuplicateNode,
+  onExportNode,
   onFanOut,
   onDeleteEdge,
   onClose,
@@ -818,6 +856,7 @@ function ContextMenu({
   onDeleteNode: () => void;
   onDeleteNote: () => void;
   onDuplicateNode: () => void;
+  onExportNode: () => void;
   onFanOut: (field: string) => void;
   onDeleteEdge: () => void;
   onClose: () => void;
@@ -851,6 +890,14 @@ function ContextMenu({
                 Fan out over "{field}"
               </button>
             ))}
+            {/* #345: front-only export of this node to YAML (no daemon). */}
+            <button
+              data-testid="ctx-export-node"
+              onClick={onExportNode}
+              className="flex w-full cursor-pointer items-center px-3 py-1.5 text-left text-fg-2 hover:bg-bg-4 hover:text-fg"
+            >
+              Export as YAML…
+            </button>
             <button
               onClick={onDeleteNode}
               className="flex w-full cursor-pointer items-center px-3 py-1.5 text-left text-st-failed hover:bg-bg-4"

--- a/frontend/src/components/EditToolbar.test.tsx
+++ b/frontend/src/components/EditToolbar.test.tsx
@@ -10,11 +10,13 @@ import type { TabHistory } from "../stores/editStore";
 describe("EditToolbar", () => {
   const onAddNode = vi.fn();
   const onAddNote = vi.fn();
+  const onAddNodeFromYaml = vi.fn();
   const onLibraryDelete = vi.fn();
 
   beforeEach(() => {
     onAddNode.mockClear();
     onAddNote.mockClear();
+    onAddNodeFromYaml.mockClear();
     onLibraryDelete.mockClear();
   });
 
@@ -24,6 +26,7 @@ describe("EditToolbar", () => {
         <EditToolbar
           onAddNode={onAddNode}
           onAddNote={onAddNote}
+          onAddNodeFromYaml={onAddNodeFromYaml}
           libraryEntries={[]}
           onLibraryDelete={onLibraryDelete}
         />
@@ -62,6 +65,18 @@ describe("EditToolbar", () => {
     await user.click(screen.getByTestId("toolbar-add"));
     await user.click(await screen.findByTestId("add-menu-node"));
     expect(onAddNode).toHaveBeenCalledWith("code-mutating");
+    expect(onAddNote).not.toHaveBeenCalled();
+  });
+
+  it("dropdown has an 'Add node from YAML…' item that calls onAddNodeFromYaml (#345)", async () => {
+    const user = userEvent.setup();
+    renderToolbar();
+    await user.click(screen.getByTestId("toolbar-add"));
+    const item = await screen.findByTestId("add-menu-node-from-yaml");
+    expect(item).toBeInTheDocument();
+    await user.click(item);
+    expect(onAddNodeFromYaml).toHaveBeenCalledTimes(1);
+    expect(onAddNode).not.toHaveBeenCalled();
     expect(onAddNote).not.toHaveBeenCalled();
   });
 
@@ -146,7 +161,7 @@ describe("EditToolbar undo/redo buttons (ADR-0014 / #226)", () => {
   function renderToolbar() {
     return render(
       <TooltipProvider>
-        <EditToolbar onAddNode={onAddNode} onAddNote={vi.fn()} libraryEntries={[]} onLibraryDelete={onLibraryDelete} />
+        <EditToolbar onAddNode={onAddNode} onAddNote={vi.fn()} onAddNodeFromYaml={vi.fn()} libraryEntries={[]} onLibraryDelete={onLibraryDelete} />
       </TooltipProvider>,
     );
   }

--- a/frontend/src/components/EditToolbar.tsx
+++ b/frontend/src/components/EditToolbar.tsx
@@ -1,4 +1,4 @@
-import { Plus, GitMerge, Info, Undo2, Redo2, SquareTerminal, Box, StickyNote } from "lucide-react";
+import { Plus, GitMerge, Info, Undo2, Redo2, SquareTerminal, Box, StickyNote, FilePlus } from "lucide-react";
 import type { NodeType } from "../types";
 import type { LibraryEntry } from "../api";
 import { Tooltip } from "./ui/tooltip";
@@ -14,6 +14,8 @@ import { useEditStore } from "../stores/editStore";
 interface Props {
   onAddNode: (type: NodeType) => void;
   onAddNote: () => void;
+  // #345: open the "Add node from YAML…" modal (paste/upload a node definition).
+  onAddNodeFromYaml: () => void;
   libraryEntries: LibraryEntry[];
   onLibraryDelete: (name: string) => void;
   getDropPosition?: () => { x: number; y: number };
@@ -25,7 +27,7 @@ interface Props {
   readOnly?: boolean;
 }
 
-export default function EditToolbar({ onAddNode, onAddNote, libraryEntries, onLibraryDelete, getDropPosition, infoOpen, onToggleInfo, readOnly = false }: Props) {
+export default function EditToolbar({ onAddNode, onAddNote, onAddNodeFromYaml, libraryEntries, onLibraryDelete, getDropPosition, infoOpen, onToggleInfo, readOnly = false }: Props) {
   // Read undo/redo straight from the store (ADR-0014 / #226): they have no
   // component-local dependency, unlike the prop-drilled add/merge callbacks, so
   // the point-of-use selector idiom is the right fit. `canUndo`/`canRedo` are
@@ -84,12 +86,24 @@ export default function EditToolbar({ onAddNode, onAddNote, libraryEntries, onLi
                 <StickyNote size={13} className="shrink-0 text-fg-4" />
                 <span>Note</span>
               </DropdownMenuItem>
+              {/* #345: 4th way to create a node — from a pasted/uploaded YAML
+                  definition. `FilePlus`, NOT `FileUp` (which belongs to the
+                  foreign-workflow import). */}
+              <DropdownMenuItem
+                data-testid="add-menu-node-from-yaml"
+                className="flex cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-fg-2 transition-colors hover:bg-bg-4"
+                style={{ fontSize: "11.5px" }}
+                onClick={() => onAddNodeFromYaml()}
+              >
+                <FilePlus size={13} className="shrink-0 text-fg-4" />
+                <span>Add node from YAML…</span>
+              </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
 
           <span className="mx-0.5 h-4 w-px bg-line" />
 
-          <LibraryDropdown entries={libraryEntries} onDelete={onLibraryDelete} getDropPosition={getDropPosition} />
+          <LibraryDropdown entries={libraryEntries} onDelete={onLibraryDelete} getDropPosition={getDropPosition} onAddNodeFromYaml={onAddNodeFromYaml} />
 
           {/* No ForEach add-button: a fan-out is a `collection` loop region
               (#151), created by selecting the member(s) and fanning out over a

--- a/frontend/src/components/ExportNodeYamlModal.test.tsx
+++ b/frontend/src/components/ExportNodeYamlModal.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import ExportNodeYamlModal from "./ExportNodeYamlModal";
+import type { NodeDef } from "../types";
+
+function node(overrides: Partial<NodeDef> = {}): NodeDef {
+  return {
+    id: "n1abc",
+    name: "Writer",
+    type: "doc-only",
+    inputs: [],
+    outputs: [{ name: "adr", repeated: false, side: "right" }],
+    interactive: false,
+    view: { x: 0, y: 0 },
+    ...overrides,
+  };
+}
+
+describe("ExportNodeYamlModal (#345)", () => {
+  it("renders the node's YAML with a block-scalar prompt and no id", () => {
+    render(
+      <ExportNodeYamlModal node={node()} prompt={"Do the thing.\nCarefully."} onClose={() => {}} />,
+    );
+    const pre = screen.getByTestId("export-node-yaml");
+    expect(pre.textContent).toContain("name: Writer");
+    expect(pre.textContent).toContain("prompt: |");
+    expect(pre.textContent).toContain("Do the thing.");
+    expect(pre.textContent).not.toContain("n1abc"); // id omitted
+  });
+
+  it("Copy writes the YAML to the clipboard and flashes Copied!", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+    render(<ExportNodeYamlModal node={node()} prompt="Hello." onClose={() => {}} />);
+    fireEvent.click(screen.getByTestId("export-node-copy"));
+    await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
+    expect(writeText.mock.calls[0][0]).toContain("name: Writer");
+    expect(await screen.findByText("Copied!")).toBeInTheDocument();
+  });
+
+  it("Download builds a blob and clicks an anchor with a slugified .yaml name", () => {
+    const createURL = vi.fn().mockReturnValue("blob:fake");
+    const revoke = vi.fn();
+    (URL as unknown as { createObjectURL: unknown }).createObjectURL = createURL;
+    (URL as unknown as { revokeObjectURL: unknown }).revokeObjectURL = revoke;
+    let downloadName = "";
+    const clickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(function (this: HTMLAnchorElement) {
+        downloadName = this.download;
+      });
+    render(<ExportNodeYamlModal node={node({ name: "My Node" })} prompt="p" onClose={() => {}} />);
+    fireEvent.click(screen.getByTestId("export-node-download"));
+    expect(createURL).toHaveBeenCalledTimes(1);
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(downloadName).toBe("my-node.yaml");
+    clickSpy.mockRestore();
+  });
+
+  it("closes on the Close button and on Escape", () => {
+    const onClose = vi.fn();
+    render(<ExportNodeYamlModal node={node()} prompt="p" onClose={onClose} />);
+    fireEvent.click(screen.getByTestId("export-node-close"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/components/ExportNodeYamlModal.tsx
+++ b/frontend/src/components/ExportNodeYamlModal.tsx
@@ -1,0 +1,139 @@
+import { useEffect, useMemo, useState } from "react";
+import { Copy, Download, Check } from "lucide-react";
+import type { NodeDef } from "../types";
+import { exportNodeAsYaml } from "../stores/editStore";
+import { highlightYaml } from "./PipelineInfoPanel";
+
+/**
+ * Export a single node's definition as YAML (#345). Pure front-end: the YAML is
+ * serialized from the in-memory node (no daemon round-trip), shown syntax-
+ * highlighted, and offered for copy or `.yaml` download. The output is the
+ * node-library shape — directly re-importable via `Add node from YAML…`.
+ *
+ * The YAML is rendered as plain text in a `<pre>` (never markdown/HTML), so this
+ * stays outside the `dangerouslySetInnerHTML` boundary (ADR-0013/0018).
+ */
+export default function ExportNodeYamlModal({
+  node,
+  prompt,
+  onClose,
+}: {
+  node: NodeDef;
+  prompt: string;
+  onClose: () => void;
+}) {
+  const yaml = useMemo(() => exportNodeAsYaml(node, prompt), [node, prompt]);
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [onClose]);
+
+  useEffect(() => {
+    if (!copied) return;
+    const t = setTimeout(() => setCopied(false), 1500);
+    return () => clearTimeout(t);
+  }, [copied]);
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(yaml);
+      setCopied(true);
+    } catch {
+      // Clipboard denied (permissions / insecure context) — no toast; the user
+      // can still select the <pre> text manually.
+    }
+  }
+
+  function handleDownload() {
+    const blob = new Blob([yaml], { type: "text/yaml" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `${slug(node.name ?? node.id)}.yaml`;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      data-testid="export-node-backdrop"
+      onClick={onClose}
+    >
+      <div
+        className="flex max-h-[80vh] w-[560px] max-w-[90vw] flex-col rounded-lg border border-line bg-bg-2 shadow-lg"
+        style={{ fontSize: "12px" }}
+        data-testid="export-node-modal"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between border-b border-line px-4 py-3">
+          <div className="min-w-0">
+            <h3 className="font-medium text-fg" style={{ fontSize: "13px" }}>
+              Export as YAML
+            </h3>
+            <p className="mt-0.5 truncate text-fg-4" style={{ fontSize: "11px" }}>
+              {node.name ?? node.id}
+            </p>
+          </div>
+        </div>
+
+        <pre
+          className="min-h-0 flex-1 overflow-auto border-b border-line bg-bg-1 p-3 font-mono text-fg-3 select-text"
+          style={{ fontSize: "11px", lineHeight: "1.6", tabSize: 2 }}
+          data-testid="export-node-yaml"
+        >
+          {highlightYaml(yaml)}
+        </pre>
+
+        <div className="flex justify-end gap-2 px-4 py-3">
+          <button
+            onClick={handleCopy}
+            data-testid="export-node-copy"
+            className="flex items-center gap-1.5 rounded-md border border-line-strong bg-bg-3 px-3 py-1.5 text-fg-2 transition-colors hover:bg-bg-4"
+            style={{ fontSize: "11.5px" }}
+          >
+            {copied ? <Check size={13} className="text-st-done" /> : <Copy size={13} />}
+            {copied ? "Copied!" : "Copy"}
+          </button>
+          <button
+            onClick={handleDownload}
+            data-testid="export-node-download"
+            className="flex items-center gap-1.5 rounded-md border border-line-strong bg-bg-3 px-3 py-1.5 text-fg-2 transition-colors hover:bg-bg-4"
+            style={{ fontSize: "11.5px" }}
+          >
+            <Download size={13} />
+            Download .yaml
+          </button>
+          <button
+            onClick={onClose}
+            data-testid="export-node-close"
+            className="rounded-md bg-acc px-3 py-1.5 font-medium text-bg-0 transition-colors hover:bg-acc-dim"
+            style={{ fontSize: "11.5px" }}
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Slug for the download filename — mirror of the daemon's `slugify`: lowercase,
+ * keep `[a-z0-9_-]`, spaces → `-`, everything else dropped; empty ⇒ `node`.
+ */
+function slug(name: string): string {
+  let out = "";
+  for (const ch of name) {
+    if (/[a-zA-Z0-9_-]/.test(ch)) out += ch.toLowerCase();
+    else if (ch === " ") out += "-";
+  }
+  return out || "node";
+}

--- a/frontend/src/components/ExportNodeYamlModal.tsx
+++ b/frontend/src/components/ExportNodeYamlModal.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { Copy, Download, Check } from "lucide-react";
 import type { NodeDef } from "../types";
 import { exportNodeAsYaml } from "../stores/editStore";
-import { highlightYaml } from "./PipelineInfoPanel";
+import { highlightYaml } from "./yamlHighlight";
 
 /**
  * Export a single node's definition as YAML (#345). Pure front-end: the YAML is

--- a/frontend/src/components/LibraryDropdown.test.tsx
+++ b/frontend/src/components/LibraryDropdown.test.tsx
@@ -119,4 +119,20 @@ describe("LibraryDropdown", () => {
     fireEvent.click(screen.getByTestId("toolbar-library"));
     expect(screen.getByText("A".repeat(60))).toBeInTheDocument();
   });
+
+  it("offers 'Add node from YAML…' when the callback is provided, and fires it (#345)", () => {
+    const onAddNodeFromYaml = vi.fn();
+    renderDropdown({ entries: [], onDelete: vi.fn(), onAddNodeFromYaml });
+    fireEvent.click(screen.getByTestId("toolbar-library"));
+    const entry = screen.getByTestId("library-add-node-from-yaml");
+    expect(entry).toBeInTheDocument();
+    fireEvent.click(entry);
+    expect(onAddNodeFromYaml).toHaveBeenCalledTimes(1);
+  });
+
+  it("omits the 'Add node from YAML…' entry when no callback is given", () => {
+    renderDropdown({ entries: [], onDelete: vi.fn() });
+    fireEvent.click(screen.getByTestId("toolbar-library"));
+    expect(screen.queryByTestId("library-add-node-from-yaml")).toBeNull();
+  });
 });

--- a/frontend/src/components/LibraryDropdown.tsx
+++ b/frontend/src/components/LibraryDropdown.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from "react";
-import { BookOpen, Plus, Trash2 } from "lucide-react";
+import { BookOpen, Plus, Trash2, FilePlus } from "lucide-react";
 import type { LibraryEntry } from "../api";
 import { instantiateFromLibrary, libraryPortToPortDef } from "../api";
 import { useEditStore } from "../stores/editStore";
@@ -16,10 +16,15 @@ export default function LibraryDropdown({
   entries,
   onDelete,
   getDropPosition,
+  onAddNodeFromYaml,
 }: {
   entries: LibraryEntry[];
   onDelete: (name: string) => void;
   getDropPosition?: () => { x: number; y: number };
+  // #345 (Slice 3): open the "Add node from YAML…" modal from the library too,
+  // covering the issue's "+ or the library" affordance. Optional so existing
+  // callers/tests that omit it still compile.
+  onAddNodeFromYaml?: () => void;
 }) {
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
@@ -54,6 +59,8 @@ export default function LibraryDropdown({
         inputs: result.spec.inputs.map((p) => libraryPortToPortDef(p, "left")),
         outputs: result.spec.outputs.map((p) => libraryPortToPortDef(p, "right")),
         interactive: result.spec.interactive,
+        // #296/#345: the library is now model-aware — restore the per-node model.
+        model: result.spec.model ?? null,
         view,
       };
       addNode(node);
@@ -100,6 +107,23 @@ export default function LibraryDropdown({
               autoFocus
             />
           </div>
+
+          {/* #345 (Slice 3): create a node from a YAML definition, alongside the
+              saved library entries — the issue's "+ or the library" affordance. */}
+          {onAddNodeFromYaml && (
+            <button
+              data-testid="library-add-node-from-yaml"
+              onClick={() => {
+                setOpen(false);
+                onAddNodeFromYaml();
+              }}
+              className="flex w-full cursor-pointer items-center gap-2 border-b border-line px-3 py-1.5 text-left text-fg-2 transition-colors hover:bg-bg-3 hover:text-fg"
+              style={{ fontSize: "11px" }}
+            >
+              <FilePlus size={12} className="shrink-0 text-fg-4" />
+              <span>Add node from YAML…</span>
+            </button>
+          )}
 
           <div className="flex-1 overflow-y-auto">
             {filtered.length === 0 && entries.length === 0 && (

--- a/frontend/src/components/NodeInspector.test.tsx
+++ b/frontend/src/components/NodeInspector.test.tsx
@@ -393,6 +393,8 @@ describe("NodeInspector StarButton — library save is independent of pipeline s
       inputs: [{ name: "in", repeated: false, side: "left" }],
       outputs: [{ name: "out", repeated: false, side: "right" }],
       interactive: false,
+      // #345/#296: the library is model-aware; a model-less node sends null.
+      model: null,
       prompt: "Review this code.",
     });
   });

--- a/frontend/src/components/NodeInspector.tsx
+++ b/frontend/src/components/NodeInspector.tsx
@@ -404,6 +404,9 @@ function StarButton({
         ...(p.when ? { when: p.when } : {}),
       })),
       interactive: node.interactive,
+      // #296/#345: persist the per-node model so the library is model-aware and
+      // a modelled node stays synced instead of flipping to diverged.
+      model: node.model ?? null,
       prompt,
     };
   }
@@ -440,6 +443,8 @@ function StarButton({
         inputs: result.spec.inputs.map((p) => libraryPortToPortDef(p, "left")),
         outputs: result.spec.outputs.map((p) => libraryPortToPortDef(p, "right")),
         interactive: result.spec.interactive,
+        // #296/#345: reset the per-node model from the library entry too.
+        model: result.spec.model ?? null,
       });
       updatePromptFn(result.prompt);
       setPopoverOpen(false);

--- a/frontend/src/components/PipelineInfoPanel.tsx
+++ b/frontend/src/components/PipelineInfoPanel.tsx
@@ -342,7 +342,9 @@ function YamlTab({ pipeline, scrollToLine }: { pipeline: PipelineDef | null; scr
   );
 }
 
-function highlightYaml(yaml: string, errorLine?: number): React.ReactNode {
+// Exported for reuse by the node-export modal (#345), which renders the same
+// syntax-highlighted YAML `<pre>` as this panel's YAML tab.
+export function highlightYaml(yaml: string, errorLine?: number): React.ReactNode {
   const lines = yaml.split("\n");
   return lines.map((line, i) => {
     const lineNum = i + 1;

--- a/frontend/src/components/PipelineInfoPanel.tsx
+++ b/frontend/src/components/PipelineInfoPanel.tsx
@@ -8,6 +8,7 @@ import type { RunState, PipelineDef } from "../types";
 import { isLiveRun } from "../types";
 import { formatDuration, useRunDuration } from "../lib/runDuration";
 import { serializePipeline } from "../stores/editStore";
+import { highlightYaml } from "./yamlHighlight";
 
 export type TabId = "info" | "manager" | "yaml";
 
@@ -340,86 +341,6 @@ function YamlTab({ pipeline, scrollToLine }: { pipeline: PipelineDef | null; scr
       </pre>
     </div>
   );
-}
-
-// Exported for reuse by the node-export modal (#345), which renders the same
-// syntax-highlighted YAML `<pre>` as this panel's YAML tab.
-export function highlightYaml(yaml: string, errorLine?: number): React.ReactNode {
-  const lines = yaml.split("\n");
-  return lines.map((line, i) => {
-    const lineNum = i + 1;
-    const isError = errorLine != null && lineNum === errorLine;
-    const commentIdx = line.indexOf("#");
-    return (
-      <span
-        key={i}
-        className={isError ? "bg-st-failed/20" : undefined}
-        data-line={lineNum}
-      >
-        {commentIdx >= 0 ? (
-          <>
-            {highlightLine(line.slice(0, commentIdx))}
-            <span className="text-fg-4 italic">{line.slice(commentIdx)}</span>
-          </>
-        ) : (
-          highlightLine(line)
-        )}
-        {i < lines.length - 1 ? "\n" : null}
-      </span>
-    );
-  });
-}
-
-function highlightLine(line: string): React.ReactNode {
-  const keyMatch = line.match(/^(\s*-?\s*)([a-zA-Z_][\w]*)\s*:/);
-  if (keyMatch) {
-    const [, indent, key] = keyMatch;
-    const rest = line.slice(keyMatch[0].length);
-    return (
-      <>
-        {indent}
-        <span className="text-acc">{key}</span>
-        <span className="text-fg-4">:</span>
-        {highlightValue(rest)}
-      </>
-    );
-  }
-
-  const listMatch = line.match(/^(\s*-\s+)(.*)/);
-  if (listMatch) {
-    const [, prefix, rest] = listMatch;
-    return (
-      <>
-        <span className="text-fg-4">{prefix}</span>
-        {highlightValue(rest)}
-      </>
-    );
-  }
-
-  return line;
-}
-
-function highlightValue(value: string): React.ReactNode {
-  const trimmed = value.trimStart();
-  const leading = value.slice(0, value.length - trimmed.length);
-
-  if (/^".*"$/.test(trimmed) || /^'.*'$/.test(trimmed)) {
-    return <>{leading}<span className="text-st-await">{trimmed}</span></>;
-  }
-
-  if (/^(true|false|null)$/.test(trimmed)) {
-    return <>{leading}<span className="text-st-running">{trimmed}</span></>;
-  }
-
-  if (/^-?\d+(\.\d+)?$/.test(trimmed)) {
-    return <>{leading}<span className="text-st-done">{trimmed}</span></>;
-  }
-
-  if (/^\{.*\}$/.test(trimmed)) {
-    return <>{leading}<span className="text-fg-3">{trimmed}</span></>;
-  }
-
-  return <>{leading}<span className="text-fg-2">{trimmed}</span></>;
 }
 
 function formatVariableValue(value: unknown): string {

--- a/frontend/src/components/RunFilters.tsx
+++ b/frontend/src/components/RunFilters.tsx
@@ -6,49 +6,22 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
 } from "./ui/dropdown-menu";
+import {
+  EMPTY_RUN_FILTER,
+  MANUAL_TRIGGER,
+  NONE,
+  pipelineKey,
+  repoKey,
+  triggerKey,
+  type RunFilterValue,
+} from "./runFilter";
 
-/* #336 — client-side filters for the Runs list. Option sets are derived from
-   the runs themselves (never from the live library/trigger stores) so runs of
-   renamed or deleted pipelines/triggers stay filterable. The daemon already
-   ships every axis on `GET /runs` (`effective_repo`, `pipeline_name`,
-   `triggered_by`); filtering is a pure view-layer computation. */
-
-/** Sentinel filter values for rows whose axis key is absent/empty. */
-export const MANUAL_TRIGGER = "__manual__";
-const NONE = "__none__";
-
-export interface RunFilterValue {
-  repo: string | null;
-  pipeline: string | null;
-  /** A trigger id, or MANUAL_TRIGGER for manually launched runs. */
-  trigger: string | null;
-}
-
-export const EMPTY_RUN_FILTER: RunFilterValue = {
-  repo: null,
-  pipeline: null,
-  trigger: null,
-};
-
-/** The filter key for a run on each axis (empty/missing values bucket to a sentinel). */
-function repoKey(r: RunListEntry): string {
-  return r.effective_repo && r.effective_repo.length > 0 ? r.effective_repo : NONE;
-}
-function pipelineKey(r: RunListEntry): string {
-  const name = r.pipeline_name ?? "";
-  return name.trim().length > 0 ? name : NONE;
-}
-function triggerKey(r: RunListEntry): string {
-  return r.triggered_by ?? MANUAL_TRIGGER;
-}
-
-/** AND predicate over the three axes; a null axis means "All". */
-export function runMatchesFilter(r: RunListEntry, f: RunFilterValue): boolean {
-  if (f.repo !== null && repoKey(r) !== f.repo) return false;
-  if (f.pipeline !== null && pipelineKey(r) !== f.pipeline) return false;
-  if (f.trigger !== null && triggerKey(r) !== f.trigger) return false;
-  return true;
-}
+/* #336 — client-side filters for the Runs list. The filter model
+   (`RunFilterValue`, `runMatchesFilter`, sentinels, per-axis keys) lives in
+   `runFilter.ts` so this file only exports a component (React Fast Refresh).
+   This module is the view: it derives option sets from the runs themselves
+   (never from the live library/trigger stores) so runs of renamed or deleted
+   pipelines/triggers stay filterable. */
 
 function uniqueSorted(values: string[]): string[] {
   return [...new Set(values)].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));

--- a/frontend/src/components/UnifiedLeftPanel.tsx
+++ b/frontend/src/components/UnifiedLeftPanel.tsx
@@ -8,7 +8,8 @@ import { groupByRepo } from "../lib/groupByRepo";
 import CleanupConfirmModal from "./CleanupConfirmModal";
 import ConfirmDeleteModal from "./ConfirmDeleteModal";
 import ForgetRunModal from "./ForgetRunModal";
-import RunFilters, { EMPTY_RUN_FILTER, runMatchesFilter } from "./RunFilters";
+import RunFilters from "./RunFilters";
+import { EMPTY_RUN_FILTER, runMatchesFilter } from "./runFilter";
 import RunShellModal from "./RunShellModal";
 import TriggersListPanel from "./TriggersListPanel";
 

--- a/frontend/src/components/runFilter.ts
+++ b/frontend/src/components/runFilter.ts
@@ -1,0 +1,50 @@
+import type { RunListEntry } from "../types";
+
+/* #336 — the client-side filter model for the Runs list. Option sets are
+   derived from the runs themselves (never from the live library/trigger
+   stores) so runs of renamed or deleted pipelines/triggers stay filterable.
+   The daemon already ships every axis on `GET /runs` (`effective_repo`,
+   `pipeline_name`, `triggered_by`); filtering is a pure view-layer computation.
+
+   This lives in its own module (#345) so `RunFilters.tsx` only exports a
+   component: the non-component exports below (an object constant and a
+   function) would otherwise break React Fast Refresh
+   (`react-refresh/only-export-components`), mirroring the `highlightYaml`
+   → `yamlHighlight.tsx` split. */
+
+/** Sentinel filter values for rows whose axis key is absent/empty. */
+export const MANUAL_TRIGGER = "__manual__";
+export const NONE = "__none__";
+
+export interface RunFilterValue {
+  repo: string | null;
+  pipeline: string | null;
+  /** A trigger id, or MANUAL_TRIGGER for manually launched runs. */
+  trigger: string | null;
+}
+
+export const EMPTY_RUN_FILTER: RunFilterValue = {
+  repo: null,
+  pipeline: null,
+  trigger: null,
+};
+
+/** The filter key for a run on each axis (empty/missing values bucket to a sentinel). */
+export function repoKey(r: RunListEntry): string {
+  return r.effective_repo && r.effective_repo.length > 0 ? r.effective_repo : NONE;
+}
+export function pipelineKey(r: RunListEntry): string {
+  const name = r.pipeline_name ?? "";
+  return name.trim().length > 0 ? name : NONE;
+}
+export function triggerKey(r: RunListEntry): string {
+  return r.triggered_by ?? MANUAL_TRIGGER;
+}
+
+/** AND predicate over the three axes; a null axis means "All". */
+export function runMatchesFilter(r: RunListEntry, f: RunFilterValue): boolean {
+  if (f.repo !== null && repoKey(r) !== f.repo) return false;
+  if (f.pipeline !== null && pipelineKey(r) !== f.pipeline) return false;
+  if (f.trigger !== null && triggerKey(r) !== f.trigger) return false;
+  return true;
+}

--- a/frontend/src/components/yamlHighlight.tsx
+++ b/frontend/src/components/yamlHighlight.tsx
@@ -1,0 +1,84 @@
+import type { ReactNode } from "react";
+
+// Syntax-highlight a YAML document into React nodes (#100, #345). Shared by the
+// pipeline YAML tab (`PipelineInfoPanel`) and the node-export modal
+// (`ExportNodeYamlModal`). It lives in its own module so neither component file
+// exports both a component and this helper, which would break React Fast
+// Refresh (`react-refresh/only-export-components`).
+export function highlightYaml(yaml: string, errorLine?: number): ReactNode {
+  const lines = yaml.split("\n");
+  return lines.map((line, i) => {
+    const lineNum = i + 1;
+    const isError = errorLine != null && lineNum === errorLine;
+    const commentIdx = line.indexOf("#");
+    return (
+      <span
+        key={i}
+        className={isError ? "bg-st-failed/20" : undefined}
+        data-line={lineNum}
+      >
+        {commentIdx >= 0 ? (
+          <>
+            {highlightLine(line.slice(0, commentIdx))}
+            <span className="text-fg-4 italic">{line.slice(commentIdx)}</span>
+          </>
+        ) : (
+          highlightLine(line)
+        )}
+        {i < lines.length - 1 ? "\n" : null}
+      </span>
+    );
+  });
+}
+
+function highlightLine(line: string): ReactNode {
+  const keyMatch = line.match(/^(\s*-?\s*)([a-zA-Z_][\w]*)\s*:/);
+  if (keyMatch) {
+    const [, indent, key] = keyMatch;
+    const rest = line.slice(keyMatch[0].length);
+    return (
+      <>
+        {indent}
+        <span className="text-acc">{key}</span>
+        <span className="text-fg-4">:</span>
+        {highlightValue(rest)}
+      </>
+    );
+  }
+
+  const listMatch = line.match(/^(\s*-\s+)(.*)/);
+  if (listMatch) {
+    const [, prefix, rest] = listMatch;
+    return (
+      <>
+        <span className="text-fg-4">{prefix}</span>
+        {highlightValue(rest)}
+      </>
+    );
+  }
+
+  return line;
+}
+
+function highlightValue(value: string): ReactNode {
+  const trimmed = value.trimStart();
+  const leading = value.slice(0, value.length - trimmed.length);
+
+  if (/^".*"$/.test(trimmed) || /^'.*'$/.test(trimmed)) {
+    return <>{leading}<span className="text-st-await">{trimmed}</span></>;
+  }
+
+  if (/^(true|false|null)$/.test(trimmed)) {
+    return <>{leading}<span className="text-st-running">{trimmed}</span></>;
+  }
+
+  if (/^-?\d+(\.\d+)?$/.test(trimmed)) {
+    return <>{leading}<span className="text-st-done">{trimmed}</span></>;
+  }
+
+  if (/^\{.*\}$/.test(trimmed)) {
+    return <>{leading}<span className="text-fg-3">{trimmed}</span></>;
+  }
+
+  return <>{leading}<span className="text-fg-2">{trimmed}</span></>;
+}

--- a/frontend/src/hooks/useLibrary.test.ts
+++ b/frontend/src/hooks/useLibrary.test.ts
@@ -58,6 +58,20 @@ describe("computeSyncState", () => {
     expect(computeSyncState(node, "You review code.", entries)).toBe("diverged");
   });
 
+  it("returns diverged when the per-node model differs (#296/#345)", () => {
+    // A node that gains a model but whose library twin has none must flip to
+    // diverged — silent model loss is forbidden (ADR-0001).
+    const node = makeNode({ model: "opus" });
+    const entries = [makeEntry()];
+    expect(computeSyncState(node, "You review code.", entries)).toBe("diverged");
+  });
+
+  it("returns synced when node and entry share the same model (#296/#345)", () => {
+    const node = makeNode({ model: "opus" });
+    const entries = [makeEntry({ model: "opus" })];
+    expect(computeSyncState(node, "You review code.", entries)).toBe("synced");
+  });
+
   it("returns diverged when interactive differs", () => {
     const node = makeNode({ interactive: true });
     const entries = [makeEntry()];

--- a/frontend/src/hooks/useLibrary.ts
+++ b/frontend/src/hooks/useLibrary.ts
@@ -66,6 +66,9 @@ export function computeSyncState(
   if (
     entry.type === node.type &&
     entry.interactive === node.interactive &&
+    // #296/#345: the per-node model is part of the node's identity — a model
+    // change must flip the star to diverged (silent loss is forbidden, ADR-0001).
+    (entry.model ?? null) === (node.model ?? null) &&
     entry.prompt === prompt &&
     portsMatch(node.inputs, entry.inputs) &&
     portsMatch(node.outputs, entry.outputs)

--- a/frontend/src/stores/editStore.test.ts
+++ b/frontend/src/stores/editStore.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { useEditStore, serializePipeline } from "./editStore";
+import { useEditStore, serializePipeline, exportNodeAsYaml } from "./editStore";
 import type { OpenPipeline, Selection } from "./editStore";
 import { generatedRegionId } from "../lib/loopRegions";
 import { pipelinesEquivalent } from "../hooks/useLibraryPipelines";
@@ -2675,5 +2675,65 @@ describe("single-tab mode (#342)", () => {
       expect(useEditStore.getState().openTabs.map((t) => t.id)).toEqual(["a"]);
       expect(useEditStore.getState().pendingSingleTab).toBeNull();
     });
+  });
+});
+
+describe("exportNodeAsYaml (#345)", () => {
+  function node(overrides: Partial<NodeDef> = {}): NodeDef {
+    return {
+      id: "abc12345",
+      name: "Reviewer",
+      type: "doc-only",
+      inputs: [],
+      outputs: [{ name: "review", repeated: false, side: "right" }],
+      interactive: false,
+      view: { x: 42, y: 99 },
+      ...overrides,
+    };
+  }
+
+  it("emits a multi-line prompt as a block scalar, not a JSON-escaped single line", () => {
+    const yaml = exportNodeAsYaml(node(), "Line one.\nLine two.");
+    expect(yaml).toContain("prompt: |");
+    expect(yaml).toContain("  Line one.");
+    expect(yaml).toContain("  Line two.");
+    // The naive `dumpYaml` path would emit "Line one.\nLine two." — assert we don't.
+    expect(yaml).not.toContain('"Line one.\\nLine two."');
+  });
+
+  it("omits id, view, and any edges (a node carries none)", () => {
+    const yaml = exportNodeAsYaml(node(), "p");
+    expect(yaml).not.toMatch(/(^|\n)id:/);
+    expect(yaml).not.toContain("view:");
+    expect(yaml).not.toContain("abc12345");
+    expect(yaml).not.toContain("edges");
+  });
+
+  it("includes model when set and omits it when unset (#296)", () => {
+    expect(exportNodeAsYaml(node({ model: "opus" }), "p")).toContain("model: opus");
+    expect(exportNodeAsYaml(node({ model: null }), "p")).not.toContain("model:");
+  });
+
+  it("emits interactive only when true", () => {
+    expect(exportNodeAsYaml(node({ interactive: true }), "p")).toContain("interactive: true");
+    expect(exportNodeAsYaml(node({ interactive: false }), "p")).not.toContain("interactive:");
+  });
+
+  it("omits a port's default side but keeps a non-default one", () => {
+    // right is the default output side → omitted for a clean, minimal YAML.
+    expect(exportNodeAsYaml(node(), "p")).not.toContain("side:");
+    const topped = exportNodeAsYaml(
+      node({ outputs: [{ name: "review", repeated: false, side: "top" }] }),
+      "p",
+    );
+    expect(topped).toContain("side: top");
+  });
+
+  it("emits an empty prompt as an explicit empty string", () => {
+    expect(exportNodeAsYaml(node(), "")).toContain('prompt: ""');
+  });
+
+  it("is library-entry-shaped: name + type at the root", () => {
+    expect(exportNodeAsYaml(node(), "p").startsWith("name: Reviewer\ntype: doc-only")).toBe(true);
   });
 });

--- a/frontend/src/stores/editStore.test.ts
+++ b/frontend/src/stores/editStore.test.ts
@@ -2701,6 +2701,23 @@ describe("exportNodeAsYaml (#345)", () => {
     expect(yaml).not.toContain('"Line one.\\nLine two."');
   });
 
+  it("preserves a trailing newline via clip + a physical trailing newline (#345 round-trip)", () => {
+    const yaml = exportNodeAsYaml(node(), "Line one.\nLine two.\n");
+    // Clip (`|2`, not `|2-`) is chosen …
+    expect(yaml).toContain("prompt: |2\n");
+    expect(yaml).not.toContain("prompt: |2-");
+    // … and the source must actually end in a newline for clip to keep it.
+    // Without this the trailing `\n` is silently dropped on round-trip.
+    expect(yaml.endsWith("  Line two.\n")).toBe(true);
+  });
+
+  it("strips (no phantom newline) when the prompt has no trailing newline", () => {
+    const yaml = exportNodeAsYaml(node(), "Line one.\nLine two.");
+    expect(yaml).toContain("prompt: |2-\n");
+    expect(yaml.endsWith("  Line two.")).toBe(true);
+    expect(yaml.endsWith("\n")).toBe(false);
+  });
+
   it("omits id, view, and any edges (a node carries none)", () => {
     const yaml = exportNodeAsYaml(node(), "p");
     expect(yaml).not.toMatch(/(^|\n)id:/);

--- a/frontend/src/stores/editStore.ts
+++ b/frontend/src/stores/editStore.ts
@@ -407,9 +407,11 @@ function portToYamlObject(port: PortDef, defaultSide: PortSide): Record<string, 
 // regardless of the prompt's own leading whitespace — without it, a first line
 // more-indented than a later one would make YAML end the block early and
 // misparse the rest. The chomping indicator preserves the exact trailing
-// newline: `|-` (strip) when the prompt has none, `|` (clip) keeps exactly one
-// when it does — so an import→export round-trip is byte-stable. Empty prompt →
-// `prompt: ""` (a block scalar cannot express the empty string).
+// newline: `|2-` (strip) when the prompt has none, `|2` (clip) keeps exactly
+// one when it does — and clip only keeps a newline the source physically ends
+// in, so we emit that newline below. An import→export round-trip is thus
+// byte-stable. Empty prompt → `prompt: ""` (a block scalar cannot express the
+// empty string).
 function promptToBlockScalar(prompt: string): string {
   if (prompt === "") return 'prompt: ""';
   const hasTrailingNewline = prompt.endsWith("\n");
@@ -419,7 +421,11 @@ function promptToBlockScalar(prompt: string): string {
     .split("\n")
     .map((line) => (line.length > 0 ? `  ${line}` : ""))
     .join("\n");
-  return `prompt: ${indicator}\n${indented}`;
+  // Clip (`|2`) only keeps a trailing newline that physically ends the source,
+  // so emit that newline when the prompt has one; strip (`|2-`) needs none.
+  // Without this the `\n` is silently dropped and the round-trip diverges (the
+  // stripped node then re-exports as `|2-`), so the two indicators are a no-op.
+  return `prompt: ${indicator}\n${indented}${hasTrailingNewline ? "\n" : ""}`;
 }
 
 /**

--- a/frontend/src/stores/editStore.ts
+++ b/frontend/src/stores/editStore.ts
@@ -5,6 +5,8 @@ import type {
   PipelineDef,
   NodeDef,
   EdgeDef,
+  PortDef,
+  PortSide,
 } from "../types";
 import type { LibraryPipelineScope } from "../api";
 import type { LoopRegion, NoteDef } from "../types";
@@ -379,6 +381,76 @@ export function pipelineToYamlObject(p: PipelineDef): Record<string, unknown> {
 
 export function serializePipeline(p: PipelineDef): string {
   return yamlStringify(pipelineToYamlObject(p));
+}
+
+// Serialize one authored port to the node-library YAML shape (#345), mirroring
+// `pipelineToYamlObject`'s per-port emit: `name` always; the rest only when
+// non-default so a plain port stays a clean `- name: x`. `side` is omitted when
+// it equals the direction's default (left for inputs, right for outputs) — the
+// value the daemon/`libraryPortToPortDef` re-fill on import, so it round-trips
+// by absence.
+function portToYamlObject(port: PortDef, defaultSide: PortSide): Record<string, unknown> {
+  const p: Record<string, unknown> = { name: port.name };
+  if (port.repeated) p.repeated = true;
+  if (port.side && port.side !== defaultSide) p.side = port.side;
+  if (port.port_type && port.port_type !== "markdown") p.port_type = port.port_type;
+  if (port.frontmatter) p.frontmatter = port.frontmatter;
+  if (port.when) p.when = port.when;
+  return p;
+}
+
+// Emit a prompt as a YAML block scalar (#345) — the readable, copy-pasteable
+// form the issue asks for. NOT via `dumpYaml`: that JSON-escapes any multi-line
+// string onto a single illegible line (see the string branch of `dumpYaml`).
+//
+// An explicit indentation indicator (`|2` / `|2-`) fixes the block indent at 2
+// regardless of the prompt's own leading whitespace — without it, a first line
+// more-indented than a later one would make YAML end the block early and
+// misparse the rest. The chomping indicator preserves the exact trailing
+// newline: `|-` (strip) when the prompt has none, `|` (clip) keeps exactly one
+// when it does — so an import→export round-trip is byte-stable. Empty prompt →
+// `prompt: ""` (a block scalar cannot express the empty string).
+function promptToBlockScalar(prompt: string): string {
+  if (prompt === "") return 'prompt: ""';
+  const hasTrailingNewline = prompt.endsWith("\n");
+  const body = hasTrailingNewline ? prompt.slice(0, -1) : prompt;
+  const indicator = hasTrailingNewline ? "|2" : "|2-";
+  const indented = body
+    .split("\n")
+    .map((line) => (line.length > 0 ? `  ${line}` : ""))
+    .join("\n");
+  return `prompt: ${indicator}\n${indented}`;
+}
+
+/**
+ * Serialize a single node to the node-library YAML shape (#345): the same map a
+ * `~/.pdo/library/*.yaml` file carries, so the output is directly re-importable
+ * via `Add node from YAML…` and an actual library file exports/imports the same
+ * way. Structural fields go through `dumpYaml`; the prompt is appended by hand
+ * as a block scalar (see `promptToBlockScalar`).
+ *
+ * NEVER emits `id` (regenerated on add), `view` (re-centred), edges (they live
+ * at pipeline level), or `over` (a region driver, not a node field). Legacy
+ * `max_iter` (bounded-loop nodes) is emitted only when present. `model` (#296)
+ * is emitted when set so a per-node override round-trips.
+ */
+export function exportNodeAsYaml(node: NodeDef, prompt: string): string {
+  const obj: Record<string, unknown> = {
+    name: node.name ?? "",
+    type: node.type,
+  };
+  if (node.interactive) obj.interactive = true;
+  if (node.model) obj.model = node.model;
+  // Legacy bounded-loop nodes carry a node-level `max_iter` the daemon still
+  // requires; regular nodes never set it, so its presence is the signal.
+  if (node.max_iter !== undefined && node.max_iter !== null) obj.max_iter = node.max_iter;
+  if (node.inputs.length > 0) {
+    obj.inputs = node.inputs.map((p) => portToYamlObject(p, "left"));
+  }
+  if (node.outputs.length > 0) {
+    obj.outputs = node.outputs.map((p) => portToYamlObject(p, "right"));
+  }
+  return `${yamlStringify(obj)}\n${promptToBlockScalar(prompt)}`;
 }
 
 function yamlStringify(obj: unknown): string {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -21,6 +21,9 @@ export default defineConfig({
       '/runs': daemonTarget,
       '/pipelines': daemonTarget,
       '/library': daemonTarget,
+      // #345: POST /nodes/parse — a top-level route, so it needs its own proxy
+      // entry (else dev GET/POST lie: SPA 200 / POST 404).
+      '/nodes': daemonTarget,
       '/repos': daemonTarget,
       '/triggers': daemonTarget,
       '/stale': daemonTarget,


### PR DESCRIPTION
## #345 — Exporter / ajouter une node en YAML (round-trip)

Ajoute l'export d'une node vers du YAML et l'ajout d'une node depuis du YAML, en round-trip, dans l'éditeur de pipeline.

- **Export as YAML…** (frontend) sur une node : émet un `LibraryEntry` nu (`format` + `model`), `id`/`view`/`edges` omis, scalaire de bloc `prompt: |` avec sa fin de ligne préservée.
- **Add node from YAML…** (via `POST /nodes/parse`) : valide le YAML, rejette (400) un pipeline complet (`nodes:`/`edges:`) ou du YAML invalide, pose la node sur le canvas avec un id frais et sans arêtes.
- Extraction de `highlightYaml → yamlHighlight.tsx` et du modèle de filtre Runs → `runFilter.ts` (verdit le lint frontend, extraction pure préservant le comportement).

Validation : CI-équivalent tout vert (typecheck/lint/build/vitest 1229 + suite Rust 1389), extraction pure confirmée par 8 tests de composant et un drive navigateur, feature #345 vérifiée end-to-end sur le binaire fraîchement construit.

Closes #345

🤖 Generated with [Claude Code](https://claude.com/claude-code)
