### PR TITLE
feat(#333): rendered HTML output port (`html`) — static, sandboxed review surface — v0.1.83

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -215,6 +215,13 @@ Chaque artefact produit par un NodeRun a un chemin canonique :
 - Wire simple → input port lit `<artifacts>/<source-node>/iter-<latest>/<port>.md`.
 - Wire d'accumulation (port marqué `repeated`, typiquement le port `reviews_bloquantes` côté Implementer dans un cycle) → input port lit un artefact par **itération complétée** du nœud source (`<artifacts>/<source>/iter-<N>/<port>.md`), ordonné par N. La résolution passe par la projection (`input_resolution` / `RunState::completed_iters`), **pas** par un glob `iter-*` du disque : une itération échouée qui a laissé un `output.md` n'est jamais poolée (#353).
 
+**html** *(type de port de sortie)* :
+Un port de sortie dont l'artefact est un `output.html` **rendu** dans une iframe `sandbox=""`
+(`srcDoc`), pour une relecture experte confortable — HTML + CSS **statiques**, **aucun JS exécuté**
+(même classe de confiance « contenu rendu » qu'ADR-0013/0018 ; voir ADR-0028). Surface de relecture,
+**non consommée en aval** en v1. Le daemon ne sert jamais l'artefact en `text/html`.
+_Éviter_ : « aperçu HTML interactif » (la variante JS est hors périmètre v1).
+
 ### Frontmatter — minimal
 
 Les artefacts sont des `.md` avec **frontmatter YAML minimale**. La frontmatter sert au *runtime* (parser un verdict, savoir quoi router) — **pas** à structurer le contenu. Tout ce qui est destiné à être lu par un autre LLM (issues bloquantes, justifications, recommandations) reste dans le **corps** markdown.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "0.1.82"
+version = "0.1.83"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "0.1.82"
+version = "0.1.83"
 license = "MIT"
 
 [workspace.dependencies]

--- a/crates/pdo-daemon/src/blackboard.rs
+++ b/crates/pdo-daemon/src/blackboard.rs
@@ -11,6 +11,20 @@ pub fn artifact_path(artifacts_dir: &Path, node_id: &str, iter: i64, port_name: 
     port_dir(artifacts_dir, node_id, iter, port_name).join("output.md")
 }
 
+/// Path of an `html` output port's file (#333). Parallel to `artifact_path`
+/// (`output.md`): an html port materializes a single `output.html` in the
+/// port's directory. A dedicated helper localizes the `output.html` choice to
+/// the three output sites that emit it, keeping the type-blind input side
+/// (which reads `output.md`) untouched.
+pub fn artifact_path_html(
+    artifacts_dir: &Path,
+    node_id: &str,
+    iter: i64,
+    port_name: &str,
+) -> PathBuf {
+    port_dir(artifacts_dir, node_id, iter, port_name).join("output.html")
+}
+
 #[allow(dead_code)]
 pub fn artifact_exists(artifacts_dir: &Path, node_id: &str, iter: i64, port_name: &str) -> bool {
     artifact_path(artifacts_dir, node_id, iter, port_name).exists()
@@ -44,6 +58,36 @@ mod tests {
             path,
             PathBuf::from("/repo/.pdo/artifacts/reviewer/iter-3/review/output.md")
         );
+    }
+
+    #[test]
+    fn html_artifact_path_uses_output_html() {
+        let dir = Path::new("/repo/.pdo/artifacts");
+        let path = artifact_path_html(dir, "designer", 1, "report");
+        assert_eq!(
+            path,
+            PathBuf::from("/repo/.pdo/artifacts/designer/iter-1/report/output.html")
+        );
+    }
+
+    #[test]
+    fn html_artifact_path_honors_iteration() {
+        let dir = Path::new("/repo/.pdo/artifacts");
+        let path = artifact_path_html(dir, "designer", 4, "report");
+        assert_eq!(
+            path,
+            PathBuf::from("/repo/.pdo/artifacts/designer/iter-4/report/output.html")
+        );
+    }
+
+    #[test]
+    fn html_and_markdown_paths_share_a_port_dir_but_differ_in_filename() {
+        let dir = Path::new("/repo/.pdo/artifacts");
+        let md = artifact_path(dir, "designer", 1, "report");
+        let html = artifact_path_html(dir, "designer", 1, "report");
+        assert_eq!(md.parent(), html.parent());
+        assert_ne!(md, html);
+        assert_eq!(html.file_name().unwrap(), "output.html");
     }
 
     #[test]

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -7549,6 +7549,14 @@ async fn artifact(
         Some("jpg" | "jpeg") => "image/jpeg",
         Some("webp") => "image/webp",
         Some("gif") => "image/gif",
+        // #333 / ADR-0028: an `.html` artifact (html output port) DELIBERATELY
+        // falls through to `text/markdown`. Do NOT add `Some("html") =>
+        // "text/html"`: serving agent-authored HTML as a top-level document at
+        // the daemon origin (127.0.0.1, no auth, no CSP) would let it execute
+        // arbitrary script. The html artifact is only ever rendered client-side
+        // in a sandboxed iframe. The `.html → text/markdown` invariant is
+        // locked by the `artifact_serves_html_as_text_markdown_never_text_html`
+        // regression test.
         _ => "text/markdown",
     };
 
@@ -17530,6 +17538,57 @@ mod tests {
             .unwrap();
         let text = String::from_utf8_lossy(&body);
         assert!(text.contains("# Plan"));
+    }
+
+    // #333 / ADR-0028 security invariant: an `output.html` artifact is served as
+    // `text/markdown`, NEVER `text/html`. Serving it as a top-level HTML
+    // document at the daemon origin (no auth, no CSP) would execute
+    // agent-authored (prompt-injectable) script. The html artifact is only ever
+    // rendered client-side inside a sandboxed iframe. This test fails loudly if
+    // a future contributor "helpfully" maps `.html → text/html`.
+    #[tokio::test]
+    async fn artifact_serves_html_as_text_markdown_never_text_html() {
+        let tmp = tempfile::tempdir().unwrap();
+        let run_id = "artifact-html-mime";
+        seed_io_test(tmp.path(), run_id);
+        // Seed a real html artifact under a port dir (canonicalize needs it).
+        let html_body = "<!doctype html><html><body><h1>Report</h1>\
+             <script>window.__pdo_pwned=1</script></body></html>";
+        std::fs::write(
+            tmp.path()
+                .join(".pdo/runs")
+                .join(run_id)
+                .join("worktree/.pdo/artifacts/planner/iter-1/plan/output.html"),
+            html_body,
+        )
+        .unwrap();
+        let state = test_state_with_dir(tmp.path()).await;
+        seed_io_run_events(&state, run_id).await;
+
+        let app = build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!(
+                        "/runs/{run_id}/artifact?path=planner/iter-1/plan/output.html"
+                    ))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let ct = resp.headers().get("content-type").unwrap();
+        assert_eq!(ct, "text/markdown");
+        assert_ne!(ct, "text/html");
+        // The body is returned verbatim (the daemon does not sanitize) — the
+        // safety comes entirely from the non-executable content type + the
+        // client-side sandboxed iframe.
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let text = String::from_utf8_lossy(&body);
+        assert_eq!(text, html_body);
     }
 
     #[tokio::test]

--- a/crates/pdo-daemon/src/node_io_resolver.rs
+++ b/crates/pdo-daemon/src/node_io_resolver.rs
@@ -149,6 +149,24 @@ pub fn resolve(
                     files: vec![info],
                 });
             }
+            // #333: an html port lists its single `output.html`. Plain
+            // `file_info` (not `file_info_with_frontmatter`): html has no
+            // frontmatter to parse.
+            PortType::Html => {
+                let path = crate::blackboard::artifact_path_html(
+                    artifacts_dir,
+                    node_id,
+                    iter,
+                    &output_port.name,
+                );
+                let info = file_info(artifacts_dir, &path);
+                outputs.push(PortIO {
+                    port: output_port.name.clone(),
+                    repeated: output_port.repeated,
+                    port_type: output_port.port_type,
+                    files: vec![info],
+                });
+            }
         }
     }
 
@@ -1058,5 +1076,81 @@ mod tests {
 
         assert!(io.inputs.is_empty());
         assert!(io.outputs.is_empty());
+    }
+
+    // --- html output port (#333) ---
+
+    /// A single `designer` node with one `html` output port `report`.
+    fn html_output_pipeline() -> PipelineDef {
+        PipelineDef {
+            name: "html-test".into(),
+            version: None,
+            variables: HashMap::new(),
+            nodes: vec![NodeDef {
+                id: "designer".into(),
+                name: "designer".into(),
+                node_type: NodeType::DocOnly,
+                inputs: vec![],
+                outputs: vec![Port {
+                    name: "report".into(),
+                    repeated: false,
+                    side: None,
+                    port_type: PortType::Html,
+                    frontmatter: None,
+                    when: None,
+                    description: None,
+                }],
+                interactive: false,
+                view: None,
+                max_iter: None,
+                over: None,
+                model: None,
+            }],
+            edges: Vec::new(),
+            loops: Vec::new(),
+            notes: Vec::new(),
+            prompt_required: true,
+        }
+    }
+
+    #[test]
+    fn html_output_port_lists_output_html_with_html_type() {
+        let tmp = tempfile::tempdir().unwrap();
+        let artifacts = tmp.path().join("artifacts");
+        let dir = artifacts.join("designer/iter-1/report");
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("output.html"), "<h1>Report</h1>").unwrap();
+
+        let pipeline = html_output_pipeline();
+        let io = resolve(&pipeline, &artifacts, "designer", 1, &empty_run_state());
+
+        assert_eq!(io.outputs.len(), 1);
+        assert_eq!(io.outputs[0].port, "report");
+        assert_eq!(io.outputs[0].port_type, PortType::Html);
+        assert_eq!(io.outputs[0].files.len(), 1);
+        assert_eq!(
+            io.outputs[0].files[0].path,
+            "designer/iter-1/report/output.html"
+        );
+        assert!(io.outputs[0].files[0].exists);
+        // html carries no frontmatter — plain file_info, never parsed.
+        assert!(io.outputs[0].files[0].frontmatter.is_none());
+    }
+
+    #[test]
+    fn html_output_port_missing_file_reports_output_html_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let artifacts = tmp.path().join("artifacts");
+        fs::create_dir_all(&artifacts).unwrap();
+
+        let pipeline = html_output_pipeline();
+        let io = resolve(&pipeline, &artifacts, "designer", 1, &empty_run_state());
+
+        assert_eq!(io.outputs.len(), 1);
+        assert_eq!(
+            io.outputs[0].files[0].path,
+            "designer/iter-1/report/output.html"
+        );
+        assert!(!io.outputs[0].files[0].exists);
     }
 }

--- a/crates/pdo-daemon/src/outputs_validator.rs
+++ b/crates/pdo-daemon/src/outputs_validator.rs
@@ -100,6 +100,18 @@ pub fn validate(
                     }
                 }
             }
+            // #333: an html port validates on the existence of its `output.html`
+            // only — an exact mirror of the non-`repeated` markdown arm. No
+            // frontmatter parsing (html carries none) and no emptiness check
+            // (markdown doesn't test non-empty either; a broken/empty page is
+            // caught by the human reviewer, which is the whole point).
+            PortType::Html => {
+                let path =
+                    crate::blackboard::artifact_path_html(artifacts_dir, node_id, iter, &port.name);
+                if !path.exists() {
+                    missing.push(port.name.clone());
+                }
+            }
         }
     }
 
@@ -791,5 +803,70 @@ mod tests {
         let pipeline = make_pipeline(vec![make_node("node", vec![image_list_port("gallery")])]);
         let result = validate(&pipeline, "node", 1, artifacts);
         assert!(matches!(result, Err(ValidationError::MissingOutputs(ref m)) if m == &["gallery"]));
+    }
+
+    // --- html port: existence of output.html only (#333) ---
+
+    fn html_port(name: &str) -> Port {
+        Port {
+            name: name.into(),
+            repeated: false,
+            side: None,
+            port_type: PortType::Html,
+            frontmatter: None,
+            when: None,
+            description: None,
+        }
+    }
+
+    fn write_html(dir: &Path, node_id: &str, iter: i64, port_name: &str, content: &str) {
+        let d = dir
+            .join(node_id)
+            .join(format!("iter-{iter}"))
+            .join(port_name);
+        std::fs::create_dir_all(&d).unwrap();
+        std::fs::write(d.join("output.html"), content).unwrap();
+    }
+
+    #[test]
+    fn html_port_with_output_html_passes() {
+        let tmp = TempDir::new().unwrap();
+        let artifacts = tmp.path();
+        write_html(artifacts, "designer", 1, "report", "<h1>ok</h1>");
+        let pipeline = make_pipeline(vec![make_node("designer", vec![html_port("report")])]);
+        assert!(validate(&pipeline, "designer", 1, artifacts).is_ok());
+    }
+
+    #[test]
+    fn html_port_without_output_html_is_missing() {
+        let tmp = TempDir::new().unwrap();
+        let artifacts = tmp.path();
+        let pipeline = make_pipeline(vec![make_node("designer", vec![html_port("report")])]);
+        let result = validate(&pipeline, "designer", 1, artifacts);
+        assert!(matches!(result, Err(ValidationError::MissingOutputs(ref m)) if m == &["report"]));
+    }
+
+    #[test]
+    fn html_port_ignores_a_stray_output_md() {
+        // A parasitic `output.md` in the html port dir must not be mistaken for
+        // the html artifact — only `output.html` counts.
+        let tmp = TempDir::new().unwrap();
+        let artifacts = tmp.path();
+        write_artifact(artifacts, "designer", 1, "report", "# not the artifact");
+        let pipeline = make_pipeline(vec![make_node("designer", vec![html_port("report")])]);
+        let result = validate(&pipeline, "designer", 1, artifacts);
+        assert!(matches!(result, Err(ValidationError::MissingOutputs(ref m)) if m == &["report"]));
+    }
+
+    #[test]
+    fn html_port_does_not_validate_frontmatter() {
+        // An html artifact carries no frontmatter; the frontmatter-schema pass
+        // skips non-markdown ports, so even content that looks like a broken
+        // frontmatter fence passes as long as the file exists.
+        let tmp = TempDir::new().unwrap();
+        let artifacts = tmp.path();
+        write_html(artifacts, "designer", 1, "report", "---\nnot: really\n");
+        let pipeline = make_pipeline(vec![make_node("designer", vec![html_port("report")])]);
+        assert!(validate(&pipeline, "designer", 1, artifacts).is_ok());
     }
 }

--- a/crates/pdo-daemon/src/pipeline.rs
+++ b/crates/pdo-daemon/src/pipeline.rs
@@ -65,6 +65,10 @@ pub enum PortType {
     Markdown,
     Image,
     ImageList,
+    /// #333: a rendered, static HTML artifact (`output.html`). A leaf review
+    /// surface displayed in a sandboxed iframe (no JS), never consumed
+    /// downstream in v1 (ADR-0028).
+    Html,
 }
 
 pub const IMAGE_EXTENSIONS: &[&str] = &["png", "jpg", "jpeg", "webp", "gif"];
@@ -3631,6 +3635,55 @@ edges:
         assert_eq!(designer.outputs[1].port_type, PortType::ImageList);
         assert_eq!(designer.outputs[2].name, "report");
         assert_eq!(designer.outputs[2].port_type, PortType::Markdown);
+    }
+
+    #[test]
+    fn port_type_html_deserializes_and_round_trips() {
+        // #333: a `port_type: html` output survives load → save. The daemon read
+        // path maps it to PortType::Html (not the markdown default), and the
+        // serde snake_case rename emits it back as the bare scalar `html`.
+        let yaml = r#"
+name: test
+nodes:
+  - id: start
+    name: Start
+    type: start
+    outputs:
+      - name: user_prompt
+  - id: designer
+    name: Designer
+    type: doc-only
+    inputs:
+      - name: task
+    outputs:
+      - name: report
+        port_type: html
+  - id: end
+    name: End
+    type: end
+    inputs:
+      - name: result
+edges:
+  - source: { node: start, port: user_prompt }
+    target: { node: designer, port: task }
+  - source: { node: designer, port: report }
+    target: { node: end, port: result }
+"#;
+        let result = parse_pipeline(yaml).unwrap();
+        let designer = result
+            .pipeline
+            .nodes
+            .iter()
+            .find(|n| n.id == "designer")
+            .unwrap();
+        assert_eq!(designer.outputs[0].name, "report");
+        assert_eq!(designer.outputs[0].port_type, PortType::Html);
+
+        // Enum-level serde round-trip: html <-> "html".
+        let rendered = serde_yaml::to_string(&PortType::Html).unwrap();
+        assert_eq!(rendered.trim(), "html");
+        let back: PortType = serde_yaml::from_str("html").unwrap();
+        assert_eq!(back, PortType::Html);
     }
 
     #[test]

--- a/crates/pdo-daemon/src/prompt_augmenter.rs
+++ b/crates/pdo-daemon/src/prompt_augmenter.rs
@@ -204,6 +204,14 @@ pub fn resolve_output_paths(ctx: &AugmentContext<'_>) -> Vec<OutputDeclaration> 
                     ctx.iter,
                     &port.name,
                 ),
+                // #333: an html port's declared path is its `output.html` file
+                // (parallel to markdown's `output.md`), not the port dir.
+                PortType::Html => crate::blackboard::artifact_path_html(
+                    ctx.artifacts_dir,
+                    &ctx.node.id,
+                    ctx.iter,
+                    &port.name,
+                ),
             };
             OutputDeclaration {
                 port_name: port.name.clone(),
@@ -338,7 +346,10 @@ pub fn precreate_output_dirs(ctx: &AugmentContext<'_>) {
     for output in resolve_output_paths(ctx) {
         let dir = match output.port_type {
             PortType::Image | PortType::ImageList => output.path.clone(),
-            PortType::Markdown => output
+            // #333: html resolves to a file path (`.../output.html`) like
+            // markdown, so pre-create its parent directory — a `script` node's
+            // `> "$PDO_OUTPUT_x"` redirect fails on a missing parent.
+            PortType::Markdown | PortType::Html => output
                 .path
                 .parent()
                 .map(|p| p.to_path_buf())
@@ -501,6 +512,23 @@ pub fn build_preamble(ctx: &AugmentContext<'_>) -> String {
                             }
                         }
                     }
+                }
+                // #333: bespoke instruction — no frontmatter block, and the
+                // agent must know the page renders offline in a scriptless
+                // sandboxed iframe (ADR-0028), so it can't rely on JS.
+                PortType::Html => {
+                    preamble.push_str(&format!(
+                        "- `{}` (html): write a single self-contained HTML file to `{}`\n\
+                         \x20 Inline all CSS in a `<style>` tag and use no external network \
+                         requests (no CDN links, web fonts, or remote assets) — the artifact is \
+                         rendered offline.\n\
+                         \x20 **JavaScript will NOT run**: the file is displayed in a sandboxed \
+                         iframe with scripts disabled. Do not rely on `<script>`, inline event \
+                         handlers, or any interactivity — everything must be conveyed through \
+                         static HTML and CSS.\n",
+                        output.port_name,
+                        output.path.display(),
+                    ));
                 }
             }
         }

--- a/docs/adr/0028-html-output-port.md
+++ b/docs/adr/0028-html-output-port.md
@@ -1,0 +1,64 @@
+# ADR-0028 — Type de port de sortie `html` : artefact HTML rendu, statique et sandboxé
+
+Date : 2026-07-18 · Statut : accepté · Issue : #333
+
+## Contexte
+
+Les ports de sortie sont des répertoires typés (ADR-0010) : `markdown` (`output.md`), `image`,
+`image_list`. La relecture experte (expert-in-the-loop, ADR-0012) se fait aujourd'hui sur du markdown
+brut. #333 veut un artefact **HTML rendu** pour une relecture plus confortable.
+
+Le contenu d'un artefact est **écrit par un agent Claude Code**, donc atteignable par prompt-injection —
+exactement le modèle de menace d'ADR-0013 (rendu mermaid), mais pire : du HTML arbitraire, pas un SVG
+compilé. L'app n'a **aucune CSP** et le daemon écoute `127.0.0.1` sans auth. ADR-0018 (note de canvas)
+a explicitement différé toute nouvelle surface de contenu rendu à « son propre ADR » : c'est celui-ci.
+
+## Décision
+
+Ajouter un quatrième type de port `html`. Périmètre v1 : **document statique** (HTML + CSS), **JS non
+exécuté** (tranché « statique » par l'owner).
+
+- **Production.** L'agent (ou un node `script`) écrit un unique **`output.html`** dans le répertoire du
+  port (helper `blackboard::artifact_path_html`, parallèle à `artifact_path`). `outputs_validator`
+  vérifie l'existence du fichier (miroir de markdown) ; pas de frontmatter.
+- **Rendu.** L'inspecteur ouvre l'artefact dans une **`<iframe sandbox="" srcDoc={texte}>`** : liste de
+  permissions vide → pas d'exécution de script, origine opaque, pas de soumission de formulaire, pas de
+  navigation top-level. Le HTML transite par la prop `srcDoc` (jamais `dangerouslySetInnerHTML`). C'est
+  la route d'isolation « iframe sandboxée » qu'ADR-0013 avait conservée comme alternative défensive,
+  ici appliquée à une classe de contenu où le `securityLevel: strict` in-DOM n'a pas de sens.
+- **Le daemon ne sert JAMAIS l'artefact en `text/html`.** La route `/artifact` mappe l'extension à la
+  main ; `.html` tombe dans `_ => "text/markdown"`. Servir `text/html` ferait de
+  `/artifact?path=x.html` un document navigable exécutant du script agent à l'origine daemon. La mime
+  map reste **inchangée** et un test de régression verrouille `.html → text/markdown`.
+- **`html` est une surface de relecture, non consommée en aval** (v1). Rien ne route sur son contenu ;
+  la résolution d'input du runtime est aveugle au type et lit `output.md`, donc un port html branché en
+  aval résout vers un fichier absent — même comportement qu'un port image aujourd'hui.
+
+## Alternatives rejetées
+
+- **Variante interactive (JS exécuté).** Rouvrirait le fork sécurité-vs-fonction de #240 sur un daemon
+  sans auth/CSP → ADR + issue dédiés. Hors périmètre v1.
+- **Servir `.html` en `text/html` + `<iframe src>`.** Crée un document top-level exécutable à l'origine
+  daemon, contournant la sandbox du viewer. Interdit.
+- **Réutiliser `output.md` pour porter le HTML.** Nom de fichier trompeur sur disque et à l'archivage ;
+  un `artifact_path_html` dédié est plus honnête pour un coût minime.
+- **Enforcement dur « pas d'edge depuis un port html ».** Net-new, sans template (image/image_list ne
+  sont pas non plus protégés), forcerait une décision cohérente pour tous les leaf → follow-up.
+
+## Conséquences
+
+- **Pas de `dangerouslySetInnerHTML`** : contrairement à ADR-0013, ce sink n'est pas utilisé ; le HTML
+  vit dans une iframe hors du DOM principal. Défense-en-profondeur réelle malgré l'absence de CSP.
+- Résiduel : un `<meta http-equiv="refresh">` ou un lien dans l'iframe sandboxée peut au plus
+  auto-naviguer l'iframe (nuisance phishing/redirection), sans exécution de code ni accès à l'origine.
+- L'artefact est préservé à l'archivage gratuitement (ADR-0020, c'est un fichier du Blackboard) ; la
+  route de lecture résout la copie durable à l'identique.
+- Dette : la CSP app-wide (dette ADR-0013) reste un fast-follow orthogonal, non bloquant.
+
+## Relations
+
+Étend ADR-0010 (4e type de port) en en **restreignant** la clause « consommable » à une surface de
+relecture. Applique la route iframe-sandbox conservée par ADR-0013. Lève le report d'ADR-0018 (« toute
+surface de contenu rendu exige son propre ADR »). Non contraint par ADR-0008 (aucun contrat frontmatter
+amont). Indépendant d'ADR-0012 (n'initie aucun effet durable). Préservé à l'archivage par ADR-0020. Ne
+supersede aucun ADR.

--- a/frontend/e2e/render-html-artifact.spec.ts
+++ b/frontend/e2e/render-html-artifact.spec.ts
@@ -1,0 +1,210 @@
+import { test, expect, type Page } from "@playwright/test";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Layer 3b — html output port rendering in MarkdownArtifactModal (#333,
+// ADR-0028). This is the PERMANENT home of the "the script never runs"
+// invariant (resilience is not a Happy Path — see docs/test-scenarios/README).
+//
+// It proves, against a real daemon + browser, that an `html` output port whose
+// artifact contains a hostile `<script>` + `<img onerror>` payload is rendered
+// in an `<iframe sandbox="" srcDoc=...>` where:
+//   - the sandbox attribute is a literal empty allow-list (no `allow-scripts`),
+//   - the benign HTML/CSS still renders,
+//   - no script executes (no dialog, no `window.__pdo_pwned`, no page error).
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const WORKSPACE_ROOT = path.resolve(__dirname, "..", "..");
+const PIPELINE_NAME = `e2e-render-html-${process.pid}-${Date.now()}`;
+const PIPELINE_DIR = path.join(WORKSPACE_ROOT, ".pdo", "pipelines");
+const PIPELINE_PATH = path.join(PIPELINE_DIR, `${PIPELINE_NAME}.yaml`);
+const PROMPTS_DIR = path.join(PIPELINE_DIR, `${PIPELINE_NAME}.prompts`);
+
+// One `start` (auto-emits the prompt) → `designer` (an html output port) →
+// `end`. `designer` spawns under the tmux stub (kept "running" by `sleep`); we
+// seed its `output.html` on disk and read it back through the node-IO API.
+const SEED_YAML = `name: ${PIPELINE_NAME}
+version: "1.0"
+nodes:
+  - id: start
+    name: Start
+    type: start
+    outputs:
+      - { name: user_prompt, side: right }
+    view: { x: 0, y: 200 }
+  - id: designer
+    name: designer
+    type: doc-only
+    prompt_file: ${PIPELINE_NAME}.prompts/designer.md
+    inputs:
+      - { name: in, side: left }
+    outputs:
+      - name: report
+        port_type: html
+    view: { x: 200, y: 200 }
+  - id: end
+    name: End
+    type: end
+    inputs:
+      - { name: result, side: top }
+    view: { x: 400, y: 200 }
+edges:
+  - source: { node: start, port: user_prompt }
+    target: { node: designer, port: in }
+  - source: { node: designer, port: report }
+    target: { node: end, port: result }
+`;
+
+const ROLE_PROMPT = "You write HTML reports.\n";
+
+// A hostile artifact: it tries to run script two ways (a bare <script> and an
+// <img onerror>) and to escape to the parent window. Under `sandbox=""` neither
+// path can execute. The benign <h1> must still render.
+const HOSTILE_HTML = `<!doctype html>
+<html>
+  <head><style>h1 { color: rebeccapurple; }</style></head>
+  <body>
+    <h1 data-testid="report-heading">Quarterly Report</h1>
+    <script>window.top.__pdo_pwned = 1; window.__pdo_pwned = 1;</script>
+    <img src="x" onerror="window.top.__pdo_pwned = 1" />
+  </body>
+</html>
+`;
+
+let runId: string;
+
+test.beforeAll(async () => {
+  await fs.mkdir(PROMPTS_DIR, { recursive: true });
+  await fs.writeFile(PIPELINE_PATH, SEED_YAML);
+  await fs.writeFile(path.join(PROMPTS_DIR, "designer.md"), ROLE_PROMPT);
+});
+
+test.afterAll(async () => {
+  await fs.rm(PIPELINE_PATH, { force: true });
+  await fs.rm(PROMPTS_DIR, { recursive: true, force: true });
+  if (runId) {
+    const { execSync } = await import("node:child_process");
+    try {
+      // kill-session only — never `kill <pid>` (would take down the tmux server).
+      execSync(`tmux kill-session -t pdo-${runId}-designer-iter-1`, {
+        stdio: "ignore",
+      });
+    } catch {
+      // session may already be dead
+    }
+  }
+});
+
+async function createRunAndSeedArtifact(baseURL: string) {
+  const resp = await fetch(`${baseURL}/runs`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ pipeline: PIPELINE_NAME, input: "html layer3b" }),
+  });
+  expect(resp.status).toBe(201);
+  const json = await resp.json();
+  runId = json.run_id;
+
+  // The daemon resolves an html output port to
+  // `<node>/iter-1/<port>/output.html` (crates/pdo-daemon/src/blackboard.rs).
+  const portDir = path.join(
+    WORKSPACE_ROOT,
+    ".pdo",
+    "runs",
+    runId,
+    "worktree",
+    ".pdo",
+    "artifacts",
+    "designer",
+    "iter-1",
+    "report",
+  );
+  await fs.mkdir(portDir, { recursive: true });
+  await fs.writeFile(path.join(portDir, "output.html"), HOSTILE_HTML);
+  return runId;
+}
+
+async function openNode(page: Page) {
+  await page.goto("/");
+  await expect(page.getByText("Daemon: connected")).toBeVisible({
+    timeout: 10_000,
+  });
+  await page
+    .getByText(runId.slice(0, 20))
+    .first()
+    .click({ timeout: 5_000, position: { x: 5, y: 5 } });
+
+  const reactFlow = page.locator(".react-flow");
+  await expect(reactFlow).toBeVisible({ timeout: 5_000 });
+  await page.waitForTimeout(500);
+
+  const node = page.getByText("designer", { exact: true }).first();
+  await expect(node).toBeVisible({ timeout: 3_000 });
+  await node.click();
+
+  // Opening a live run auto-selects the running node with its terminal expanded
+  // fullscreen, hiding the Inputs/Outputs pane. Collapse it to reveal the port
+  // cards.
+  const detailsPane = page.locator('[data-testid="details-pane"]');
+  const expandToggle = page.locator('[data-testid="term-expand"]');
+  await expect(expandToggle).toBeVisible({ timeout: 5_000 });
+  if (!(await detailsPane.isVisible())) {
+    await expandToggle.click();
+  }
+  await expect(detailsPane).toBeVisible({ timeout: 5_000 });
+}
+
+test("renders an html artifact in a scriptless sandboxed iframe", async ({
+  page,
+  baseURL,
+}) => {
+  const pageErrors: string[] = [];
+  page.on("pageerror", (e) => pageErrors.push(String(e)));
+  // A hostile payload must never trigger a dialog.
+  page.on("dialog", async (d) => {
+    pageErrors.push(`unexpected dialog: ${d.message()}`);
+    await d.dismiss();
+  });
+
+  await createRunAndSeedArtifact(baseURL!);
+  await openNode(page);
+
+  // Open the html port row.
+  const portRow = page
+    .locator("button.port-row")
+    .filter({ hasText: /^report/ });
+  await expect(portRow).toBeVisible({ timeout: 5_000 });
+  await portRow.click();
+
+  // The artifact renders inside the sandboxed iframe.
+  const frame = page.locator('[data-testid="html-artifact-frame"]');
+  await expect(frame).toBeVisible({ timeout: 5_000 });
+
+  // Security invariant: the sandbox allow-list is literally empty — scripts are
+  // never enabled.
+  const sandbox = await frame.getAttribute("sandbox");
+  expect(sandbox).toBe("");
+  expect(sandbox ?? "").not.toContain("allow-scripts");
+
+  // The HTML flows through `srcDoc`, so the raw hostile text is present as the
+  // attribute value (but inert).
+  const srcdoc = await frame.getAttribute("srcdoc");
+  expect(srcdoc).toContain("Quarterly Report");
+  expect(srcdoc).toContain("<script>");
+
+  // The benign HTML/CSS actually renders inside the (null-origin) frame.
+  const heading = page
+    .frameLocator('[data-testid="html-artifact-frame"]')
+    .locator('[data-testid="report-heading"]');
+  await expect(heading).toHaveText("Quarterly Report", { timeout: 5_000 });
+
+  // Give any (blocked) script/onerror a chance to fire, then prove none did.
+  await page.waitForTimeout(300);
+  expect(
+    await page.evaluate(
+      () => (window as Window & { __pdo_pwned?: number }).__pdo_pwned,
+    ),
+  ).toBeUndefined();
+  expect(pageErrors).toEqual([]);
+});

--- a/frontend/src/components/MarkdownArtifactModal.test.tsx
+++ b/frontend/src/components/MarkdownArtifactModal.test.tsx
@@ -342,4 +342,65 @@ describe("MarkdownArtifactModal", () => {
       expect(onClose).toHaveBeenCalledTimes(1);
     });
   });
+
+  // #333 / ADR-0028: an html port renders its fetched text inside a sandboxed
+  // iframe — NOT through react-markdown, and never with `allow-scripts`.
+  describe("html port rendering", () => {
+    it("renders a sandbox='' iframe whose srcDoc is the fetched text", async () => {
+      const html =
+        "<!doctype html><h1>Report</h1><script>window.__pdo_pwned=1</script>";
+      fetchArtifactMock.mockResolvedValue(html);
+
+      render(
+        <MarkdownArtifactModal
+          runId="run-1"
+          portName="report"
+          portType="html"
+          source={{
+            kind: "static",
+            files: [makeFile("artifacts/node/iter-1/report/output.html")],
+          }}
+          onClose={() => {}}
+        />,
+      );
+
+      const frame = await screen.findByTestId("html-artifact-frame");
+      // The HTML flows through the `srcDoc` prop, never into the parent DOM.
+      expect(frame.getAttribute("srcdoc")).toBe(html);
+      // Empty allow-list: the attribute is present and literally empty.
+      expect(frame.getAttribute("sandbox")).toBe("");
+      // The non-negotiable security invariant: scripts are never allowed.
+      expect(frame.getAttribute("sandbox")).not.toContain("allow-scripts");
+      // The artifact is fetched as text (like markdown), not an image.
+      expect(fetchArtifactMock).toHaveBeenCalledWith(
+        "run-1",
+        "artifacts/node/iter-1/report/output.html",
+      );
+      // It is not rendered as markdown or an image.
+      expect(screen.queryByTestId("image-viewer")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("image-gallery")).not.toBeInTheDocument();
+    });
+
+    it("shows a placeholder (no iframe) when the html file does not exist", async () => {
+      render(
+        <MarkdownArtifactModal
+          runId="run-1"
+          portName="report"
+          portType="html"
+          source={{
+            kind: "static",
+            files: [makeFile("artifacts/node/iter-1/report/output.html", false)],
+          }}
+          onClose={() => {}}
+        />,
+      );
+
+      await act(async () => {});
+
+      expect(screen.queryByTestId("html-artifact-frame")).not.toBeInTheDocument();
+      expect(screen.getByText("File does not exist yet.")).toBeInTheDocument();
+      // A non-existent file must never trigger a fetch.
+      expect(fetchArtifactMock).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/frontend/src/components/MarkdownArtifactModal.tsx
+++ b/frontend/src/components/MarkdownArtifactModal.tsx
@@ -87,6 +87,10 @@ export default function MarkdownArtifactModal({
   const hasIterNav = source.kind === "iter-nav" && iterNumbers.length > 1;
 
   const isImage = portType === "image" || portType === "image_list";
+  // #333: an html port renders its fetched text inside a sandboxed iframe. Like
+  // markdown (and unlike image), its content flows through `fetchArtifact`, so
+  // the fetch effect below (which only short-circuits on `isImage`) still runs.
+  const isHtml = portType === "html";
   const [content, setContent] = useState<string | null>(null);
   const [loading, setLoading] = useState(!isImage);
   // The ordered image list + clicked index currently shown fullscreen in the
@@ -268,6 +272,37 @@ export default function MarkdownArtifactModal({
               portType={portType}
               onZoom={(images, index) => setLightbox({ images, index })}
             />
+          ) : isHtml ? (
+            /*
+             * #333 / ADR-0028: render the html artifact in a maximally isolated
+             * iframe. SECURITY INVARIANTS — DO NOT RELAX:
+             *  - `sandbox=""` is a literal empty allow-list: no scripts, opaque
+             *    origin, no form submission, no top-level navigation. NEVER add
+             *    `allow-scripts` / `allow-forms` / `allow-same-origin` — that
+             *    would let agent-authored (prompt-injectable) HTML execute.
+             *  - The HTML is passed via the `srcDoc` PROP, never
+             *    `dangerouslySetInnerHTML` and never concatenated into the
+             *    parent DOM.
+             *  - Uses raw `content` (fetched text), not `bodyContent` (which
+             *    strips a leading `---` frontmatter fence html doesn't have).
+             */
+            filesLoading || loading ? (
+              <span className="text-fg-4" style={{ fontSize: "11px" }}>
+                Loading...
+              </span>
+            ) : file?.exists ? (
+              <iframe
+                data-testid="html-artifact-frame"
+                sandbox=""
+                srcDoc={content ?? ""}
+                title={portName}
+                className="h-[70vh] w-full rounded border border-line bg-white"
+              />
+            ) : (
+              <span className="text-fg-4" style={{ fontSize: "11px" }}>
+                File does not exist yet.
+              </span>
+            )
           ) : (
             <>
               {/* Frontmatter card */}

--- a/frontend/src/components/NodeDetailPanel.tsx
+++ b/frontend/src/components/NodeDetailPanel.tsx
@@ -940,6 +940,9 @@ function PortRow({
   // lightbox, or null when it is closed (#312).
   const [lightbox, setLightbox] = useState<{ images: string[]; index: number } | null>(null);
   const isImage = portType === "image" || portType === "image_list";
+  // #333: an html port shows a type badge for parity with image ports (its
+  // artifact is otherwise a single markdown-like file row).
+  const isHtml = portType === "html";
 
   let dotClass = "bg-fg-5";
   if (anyExists && port.repeated && port.files.length > 1) {
@@ -988,7 +991,7 @@ function PortRow({
               repeated
             </span>
           )}
-          {isImage && (
+          {(isImage || isHtml) && (
             <span
               className="rounded border border-line-strong bg-bg-4 px-1 py-px font-mono text-fg-4"
               style={{ fontSize: "9px" }}

--- a/frontend/src/components/OutputPortCard.test.tsx
+++ b/frontend/src/components/OutputPortCard.test.tsx
@@ -127,4 +127,26 @@ describe("OutputPortCard — O3 tab-head card", () => {
     fireEvent.change(screen.getByTestId("port-type-select"), { target: { value: "image" } });
     expect(onUpdate).toHaveBeenCalledWith({ port_type: "image" });
   });
+
+  // #333: the HTML port type is a selectable option, and (like image) selecting
+  // it hides the frontmatter schema editor (html carries no frontmatter).
+  it("offers an HTML option in the port type selector", () => {
+    render(<OutputPortCard {...baseProps} />, { wrapper: Wrapper });
+    const select = screen.getByTestId("port-type-select") as HTMLSelectElement;
+    const values = Array.from(select.options).map((o) => o.value);
+    expect(values).toContain("html");
+  });
+
+  it("hides schema editor when port type is html", () => {
+    const port = { ...baseProps.port, port_type: "html" as const };
+    render(<OutputPortCard {...baseProps} port={port} />, { wrapper: Wrapper });
+    expect(screen.queryByTestId("output-schema-editor")).toBeNull();
+  });
+
+  it("calls onUpdate with port_type html when selected", () => {
+    const onUpdate = vi.fn();
+    render(<OutputPortCard {...baseProps} onUpdate={onUpdate} />, { wrapper: Wrapper });
+    fireEvent.change(screen.getByTestId("port-type-select"), { target: { value: "html" } });
+    expect(onUpdate).toHaveBeenCalledWith({ port_type: "html" });
+  });
 });

--- a/frontend/src/components/OutputPortCard.tsx
+++ b/frontend/src/components/OutputPortCard.tsx
@@ -8,6 +8,7 @@ const PORT_TYPE_OPTIONS: { value: PortType; label: string }[] = [
   { value: "markdown", label: "Markdown" },
   { value: "image", label: "Image" },
   { value: "image_list", label: "Image List" },
+  { value: "html", label: "HTML" },
 ];
 
 interface OutputPortCardProps {

--- a/frontend/src/stores/editStore.test.ts
+++ b/frontend/src/stores/editStore.test.ts
@@ -1744,6 +1744,34 @@ describe("serializePipeline persists port_type", () => {
     // implicitly and never appear in the YAML.
     expect(yaml).not.toContain("port_type: markdown");
   });
+
+  // #333: an `html` output port round-trips as `port_type: html` (emitted only
+  // because it is non-default), so a saved pipeline preserves it.
+  it("emits port_type: html for an html output port", () => {
+    const designer: NodeDef = {
+      id: "designer0",
+      name: "Designer",
+      type: "doc-only",
+      inputs: [],
+      outputs: [
+        { name: "report", repeated: false, side: "right", port_type: "html" },
+        { name: "notes", repeated: false, side: "right" },
+      ],
+      interactive: false,
+      view: { x: 0, y: 0 },
+    };
+    const yaml = serializePipeline({
+      name: "html-port-test",
+      version: "1.0",
+      variables: {},
+      nodes: [designer],
+      edges: [],
+    });
+    const occurrences = yaml.match(/port_type: html/g) ?? [];
+    expect(occurrences.length).toBe(1);
+    // The default-markdown "notes" port never carries a port_type.
+    expect(yaml).not.toContain("port_type: markdown");
+  });
 });
 
 describe("updateNode propagates port changes to edges", () => {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -382,7 +382,7 @@ export interface PipelineListEntry {
 }
 
 export type PortSide = "left" | "right" | "top" | "bottom";
-export type PortType = "markdown" | "image" | "image_list";
+export type PortType = "markdown" | "image" | "image_list" | "html";
 
 export interface PortDef {
   name: string;


### PR DESCRIPTION
## Summary

Adds a rendered **HTML artifact output port** (`port_type: html`) — a static, sandboxed surface for expert-in-the-loop review of agent-authored HTML.

- A node output declared `port_type: html` resolves to `output.html` and renders inside an `<iframe sandbox="" srcDoc=…>`; agent-authored JavaScript **never executes** (empty allow-list, no `allow-scripts`), while static HTML + CSS render correctly.
- The input side stays type-blind (reads `output.md`), so `html` is leaf-by-construction. 5 exhaustive `match` arms, no `_` wildcard.
- The `/artifact` mime map deliberately keeps `.html → text/markdown` (with an in-code guard comment + regression test) so the route can never serve `text/html`.
- Inspector shows an `html` type badge (parity with image); clicking the port opens `MarkdownArtifactModal` rendering the sandboxed iframe.

## Validation

- **CI-equivalent (`+stable`)**: all 8 steps green — `cargo check`/`test`/`clippy -D warnings`/`fmt --check`, and frontend `typecheck`/`lint`/`build`. 11 new `html` tests across `blackboard`/`outputs_validator`/`node_io_resolver`/`pipeline` + the `/artifact` mime regression pass.
- **Live agentic test (chrome-devtools-mcp)**: reproduced the ADR-0028 threat model against a real daemon + browser with a hostile `output.html` (`<script>` + `<img onerror>`). Node-IO reported `port_type: html`; `/artifact` returned `content-type: text/markdown`; the modal rendered the styled artifact with the JS status marker staying `SAFE` (no script ran). Programmatic check confirmed `sandbox=""`, `srcDoc` set, `src` absent, no `dangerouslySetInnerHTML`, `window.__pdo_pwned` undefined.

Closes #333

🤖 Generated with [Claude Code](https://claude.com/claude-code)