### PR TITLE
fix(#370): unify input resolution into one resolve_consumer_inputs seam — v0.1.84

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "0.1.83"
+version = "0.1.84"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "0.1.83"
+version = "0.1.84"
 license = "MIT"
 
 [workspace.dependencies]

--- a/crates/pdo-daemon/src/input_resolution.rs
+++ b/crates/pdo-daemon/src/input_resolution.rs
@@ -1,4 +1,4 @@
-//! Canonical input resolution (#194 / #210).
+//! Canonical input resolution (#194 / #210 / #353 / #370).
 //!
 //! THE single rule deciding which upstream iteration a consumer NodeRun reads
 //! its inputs from: **the latest iteration of the source node that
@@ -7,13 +7,22 @@
 //! iter 1 keeps serving its iter-1 artifact to consumers at any lap — it is
 //! never dragged into a loop lap (#195/#199).
 //!
-//! Every production resolution path delegates here:
-//! - `prompt_augmenter::resolve_input_paths` (spawn-time preamble),
-//! - `node_primitives::resolve_inputs` (manual `start_node`).
+//! [`resolve_consumer_inputs`] is the single edge-walk that turns a consumer's
+//! incoming edges into concrete Blackboard paths, with that iteration decision
+//! baked in. Every production resolution path projects over it — none walks the
+//! edges itself (#370):
+//! - `prompt_augmenter::resolve_input_paths` (spawn-time preamble + script env),
+//! - `node_primitives::resolve_inputs` (manual `start_node` forensic payload),
+//! - `node_io_resolver::resolve` (the inspector `/io` endpoint + `node_done`).
 //!
-//! This is a pure module: projected run state in, resolved iters out.
+//! This is a pure module: it takes the pre-resolved iteration maps (built by
+//! [`resolved_source_iters`] / [`resolved_repeated_iters`] from a `RunState`)
+//! rather than a `RunState` itself, so `prompt_augmenter` — which is pure and
+//! cannot hold a `RunState` — shares the exact same walk. Callers holding a
+//! `RunState` build the two maps first.
 
 use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 
 use crate::event_log::RunState;
 use crate::pipeline::PipelineDef;
@@ -80,6 +89,108 @@ pub fn resolved_repeated_iters(
                 e.source.node.clone(),
                 run_state.completed_iters(&e.source.node),
             )
+        })
+        .collect()
+}
+
+/// One consumer input, fully resolved to concrete Blackboard path(s).
+///
+/// The neutral shape all three consumers project over (#370): the inspector
+/// adds `FileInfo`/frontmatter + a disk stat, the preamble adds prose and reads
+/// `from_start`, the forensic payload flattens `paths` to a `\n`-joined string.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedInput {
+    /// The consumer-side (target) port this input feeds.
+    pub port: String,
+    /// True when the source is the Start node — the input is the run's user
+    /// prompt (`_input/output.md`), not a per-iteration artifact.
+    pub from_start: bool,
+    /// True when the edge accumulates across iterations (#149 / #353).
+    pub repeated: bool,
+    /// The concrete resolved path(s): exactly one for a single wire or a
+    /// Start-sourced prompt; one per COMPLETED source iteration for a
+    /// `repeated`/pooled input (empty when the source has completed none —
+    /// never a raw `iter-*` glob).
+    pub paths: Vec<PathBuf>,
+}
+
+/// THE single edge-walk turning a consumer's incoming edges into concrete input
+/// paths, with the iteration decision delegated to [`source_iter`] /
+/// completed-iters (#194 / #210 / #353). One [`ResolvedInput`] per incoming
+/// edge, in edge-declaration order; pooling of same-named edges is a projection
+/// concern left to each consumer.
+///
+/// Pure: it consumes the pre-resolved iteration maps — `source_iters` from
+/// [`resolved_source_iters`] (covers every incoming edge) and `repeated_iters`
+/// from [`resolved_repeated_iters`] (repeated edges only). A non-repeated source
+/// absent from `source_iters` falls back to `consumer_iter` (positional), the
+/// same fallback [`source_iter`] applies for override/injection flows; a
+/// repeated source absent from `repeated_iters` pools nothing.
+pub fn resolve_consumer_inputs(
+    pipeline: &PipelineDef,
+    artifacts_dir: &Path,
+    node_id: &str,
+    consumer_iter: i64,
+    source_iters: &HashMap<String, i64>,
+    repeated_iters: &HashMap<String, Vec<i64>>,
+) -> Vec<ResolvedInput> {
+    pipeline
+        .edges
+        .iter()
+        .filter(|e| e.target.node == node_id)
+        .map(|edge| {
+            let source_node = &edge.source.node;
+            // A Start-sourced edge reads the run's user prompt (`_input`), never
+            // a per-iteration artifact — the canonical rule `prompt_augmenter`
+            // has always applied; unified here so every consumer agrees (#370).
+            let from_start = pipeline
+                .nodes
+                .iter()
+                .any(|n| n.id == *source_node && n.node_type == crate::pipeline::NodeType::Start);
+
+            let repeated = edge.repeated;
+            let paths = if from_start {
+                vec![crate::blackboard::input_path(artifacts_dir)]
+            } else if repeated {
+                // #353: one concrete path per COMPLETED source iteration.
+                repeated_iters
+                    .get(source_node.as_str())
+                    .map(|iters| {
+                        iters
+                            .iter()
+                            .map(|&n| {
+                                crate::blackboard::artifact_path(
+                                    artifacts_dir,
+                                    source_node,
+                                    n,
+                                    &edge.source.port,
+                                )
+                            })
+                            .collect()
+                    })
+                    .unwrap_or_default()
+            } else {
+                // #194 / #370: the source's latest COMPLETED iteration, never
+                // the consumer's positional `iter` (which a cross-iteration or
+                // external feeder never produced).
+                let it = source_iters
+                    .get(source_node.as_str())
+                    .copied()
+                    .unwrap_or(consumer_iter);
+                vec![crate::blackboard::artifact_path(
+                    artifacts_dir,
+                    source_node,
+                    it,
+                    &edge.source.port,
+                )]
+            };
+
+            ResolvedInput {
+                port: edge.target.port.clone(),
+                from_start,
+                repeated,
+                paths,
+            }
         })
         .collect()
 }
@@ -312,5 +423,171 @@ mod tests {
         )]);
         let resolved = resolved_repeated_iters(&pipeline, &state, "impl");
         assert_eq!(resolved.get("reviewer"), Some(&Vec::<i64>::new()));
+    }
+
+    // -----------------------------------------------------------------------
+    // resolve_consumer_inputs — THE single edge-walk all three consumers
+    // (node_io_resolver, prompt_augmenter, node_primitives) project over (#370).
+    // Asserting the iteration decision here asserts it for every consumer.
+    // -----------------------------------------------------------------------
+
+    use std::path::{Path, PathBuf};
+
+    fn node_def(id: &str, node_type: crate::pipeline::NodeType) -> crate::pipeline::NodeDef {
+        crate::pipeline::NodeDef {
+            id: id.into(),
+            name: id.into(),
+            node_type,
+            inputs: vec![],
+            outputs: vec![],
+            interactive: false,
+            view: None,
+            max_iter: None,
+            over: None,
+            model: None,
+        }
+    }
+
+    fn wire_pipeline(repeated: bool, source_type: crate::pipeline::NodeType) -> PipelineDef {
+        use crate::pipeline::{EdgeDef, EdgeEndpoint};
+        PipelineDef {
+            name: "wire".into(),
+            version: None,
+            variables: HashMap::new(),
+            nodes: vec![
+                node_def("planner", source_type),
+                node_def("implementer", crate::pipeline::NodeType::CodeMutating),
+            ],
+            edges: vec![EdgeDef {
+                source: EdgeEndpoint {
+                    node: "planner".into(),
+                    port: "plan".into(),
+                },
+                target: EdgeEndpoint {
+                    node: "implementer".into(),
+                    port: "plan".into(),
+                },
+                repeated,
+                ..Default::default()
+            }],
+            loops: vec![],
+            notes: Vec::new(),
+            prompt_required: true,
+        }
+    }
+
+    /// Build the two iteration maps the way every RunState-holding consumer does,
+    /// then run the shared seam — exercising the exact production path.
+    fn resolve_over_seam(
+        pipeline: &PipelineDef,
+        state: &RunState,
+        artifacts: &Path,
+        node_id: &str,
+        consumer_iter: i64,
+    ) -> Vec<ResolvedInput> {
+        let source_iters = resolved_source_iters(pipeline, state, node_id, consumer_iter);
+        let repeated_iters = resolved_repeated_iters(pipeline, state, node_id);
+        resolve_consumer_inputs(
+            pipeline,
+            artifacts,
+            node_id,
+            consumer_iter,
+            &source_iters,
+            &repeated_iters,
+        )
+    }
+
+    #[test]
+    fn resolve_consumer_inputs_single_wire_reads_latest_completed_source() {
+        // #370 core guard (RED→GREEN): a non-repeated edge whose source FAILED at
+        // iter-1 then COMPLETED at iter-2 resolves to iter-2 — the source's
+        // latest-completed iter — no matter the consumer's own iter. This is the
+        // one decision node_io_resolver used to get wrong (it read the consumer's
+        // iter positionally); all three consumers now inherit this assertion.
+        let pipeline = wire_pipeline(false, crate::pipeline::NodeType::DocOnly);
+        let state = state_with(vec![node_with_iterations(
+            "planner",
+            &[(1, NodeStatus::Failed), (2, NodeStatus::Completed)],
+        )]);
+        let artifacts = Path::new("/artifacts");
+
+        // The consumer reads at lap 1 AND at lap 3 — both resolve to iter-2.
+        for consumer_iter in [1, 3] {
+            let resolved =
+                resolve_over_seam(&pipeline, &state, artifacts, "implementer", consumer_iter);
+            assert_eq!(resolved.len(), 1);
+            assert_eq!(resolved[0].port, "plan");
+            assert!(!resolved[0].repeated);
+            assert!(!resolved[0].from_start);
+            assert_eq!(
+                resolved[0].paths,
+                vec![PathBuf::from("/artifacts/planner/iter-2/plan/output.md")],
+                "resolves to the source's latest-completed iter, not consumer_iter={consumer_iter}"
+            );
+        }
+    }
+
+    #[test]
+    fn resolve_consumer_inputs_repeated_pools_only_completed_iters() {
+        // #353 within the unified seam: a repeated edge enumerates one concrete
+        // path per COMPLETED source iter (iter-2 failed → quarantined), ascending.
+        let pipeline = wire_pipeline(true, crate::pipeline::NodeType::DocOnly);
+        let state = state_with(vec![node_with_iterations(
+            "planner",
+            &[
+                (1, NodeStatus::Completed),
+                (2, NodeStatus::Failed),
+                (3, NodeStatus::Completed),
+            ],
+        )]);
+        let resolved =
+            resolve_over_seam(&pipeline, &state, Path::new("/artifacts"), "implementer", 4);
+        assert_eq!(resolved.len(), 1);
+        assert!(resolved[0].repeated);
+        assert_eq!(
+            resolved[0].paths,
+            vec![
+                PathBuf::from("/artifacts/planner/iter-1/plan/output.md"),
+                PathBuf::from("/artifacts/planner/iter-3/plan/output.md"),
+            ]
+        );
+    }
+
+    #[test]
+    fn resolve_consumer_inputs_start_source_reads_the_run_prompt() {
+        // A Start-sourced edge resolves to the run's `_input/output.md`, never a
+        // per-iteration artifact — unified from prompt_augmenter so node_io and
+        // node_primitives agree (#370).
+        let pipeline = wire_pipeline(false, crate::pipeline::NodeType::Start);
+        let state = state_with(vec![node_with_iterations(
+            "planner",
+            &[(1, NodeStatus::Completed)],
+        )]);
+        let resolved =
+            resolve_over_seam(&pipeline, &state, Path::new("/artifacts"), "implementer", 1);
+        assert_eq!(resolved.len(), 1);
+        assert!(resolved[0].from_start);
+        assert_eq!(
+            resolved[0].paths,
+            vec![PathBuf::from("/artifacts/_input/output.md")]
+        );
+    }
+
+    #[test]
+    fn resolve_consumer_inputs_falls_back_to_consumer_iter_when_source_unstarted() {
+        // Override/injection flows: nothing completed → the path points where the
+        // artifact will appear (positional consumer_iter), preserving prior
+        // behaviour for start_node-ahead-of-deps.
+        let pipeline = wire_pipeline(false, crate::pipeline::NodeType::DocOnly);
+        let state = state_with(vec![node_with_iterations(
+            "planner",
+            &[(1, NodeStatus::Running)],
+        )]);
+        let resolved =
+            resolve_over_seam(&pipeline, &state, Path::new("/artifacts"), "implementer", 2);
+        assert_eq!(
+            resolved[0].paths,
+            vec![PathBuf::from("/artifacts/planner/iter-2/plan/output.md")]
+        );
     }
 }

--- a/crates/pdo-daemon/src/node_io_resolver.rs
+++ b/crates/pdo-daemon/src/node_io_resolver.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use serde::Serialize;
 
@@ -57,37 +57,36 @@ pub fn resolve(
     };
 
     // Inputs are EMERGENT (#149): derived from incoming edges, not declared on
-    // the node. Each edge contributes files to a logical input named after its
-    // target endpoint (which inherits the source document name). Several
-    // same-named edges POOL into one list input. `repeated` (accumulate
-    // `iter-*`) is read off the edge, never off a declared port.
+    // the node. The edge-walk + iteration decision (source's latest-COMPLETED
+    // iter for a single wire, COMPLETED iters for a `repeated` pool) lives in
+    // ONE place — `input_resolution::resolve_consumer_inputs` (#370) — never
+    // re-derived here. This resolver's own job is the projection: add a disk
+    // stat (`FileInfo`) per resolved path, and POOL same-named edges into one
+    // logical list input.
+    let source_iters =
+        crate::input_resolution::resolved_source_iters(pipeline, run_state, node_id, iter);
+    let repeated_iters =
+        crate::input_resolution::resolved_repeated_iters(pipeline, run_state, node_id);
+    let resolved = crate::input_resolution::resolve_consumer_inputs(
+        pipeline,
+        artifacts_dir,
+        node_id,
+        iter,
+        &source_iters,
+        &repeated_iters,
+    );
+
     let mut inputs: Vec<PortIO> = Vec::new();
     let mut input_index: HashMap<String, usize> = HashMap::new();
 
-    for edge in &pipeline.edges {
-        if edge.target.node != node_id {
-            continue;
-        }
+    for input in resolved {
+        let files: Vec<FileInfo> = input
+            .paths
+            .iter()
+            .map(|p| file_info(artifacts_dir, p))
+            .collect();
 
-        let mut files = Vec::new();
-        if edge.repeated {
-            // #353: pool one file per COMPLETED source iteration, resolved via
-            // the projection — never a raw `iter-*` disk scan, which would
-            // surface a failed iteration's artifact.
-            let source_dir = artifacts_dir.join(&edge.source.node);
-            let completed = run_state.completed_iters(&edge.source.node);
-            files.extend(glob_repeated(&source_dir, &edge.source.port, &completed));
-        } else {
-            let path = crate::blackboard::artifact_path(
-                artifacts_dir,
-                &edge.source.node,
-                iter,
-                &edge.source.port,
-            );
-            files.push(file_info(artifacts_dir, &path));
-        }
-
-        match input_index.get(&edge.target.port) {
+        match input_index.get(&input.port) {
             // Pool same-named edges into one logical list input. Once two edges
             // share a target name the input is a list (repeated), regardless of
             // each edge's own flag.
@@ -97,10 +96,10 @@ pub fn resolve(
                 pooled.files.extend(files);
             }
             None => {
-                input_index.insert(edge.target.port.clone(), inputs.len());
+                input_index.insert(input.port.clone(), inputs.len());
                 inputs.push(PortIO {
-                    port: edge.target.port.clone(),
-                    repeated: edge.repeated,
+                    port: input.port,
+                    repeated: input.repeated,
                     port_type: PortType::Markdown,
                     files,
                 });
@@ -279,54 +278,6 @@ fn list_image_files(artifacts_dir: &Path, port_dir: &Path) -> Vec<FileInfo> {
     files
 }
 
-/// Collect one `output.md` per COMPLETED source iteration, ascending.
-///
-/// `completed` is the set of source iterations the projection blesses (#353).
-/// The disk is still walked to find the `iter-N` directories, but an iter is
-/// kept only if it is in `completed` — a failed iteration that left an
-/// `output.md` on disk is quarantined, never pooled.
-fn glob_repeated(source_dir: &Path, port_name: &str, completed: &[i64]) -> Vec<FileInfo> {
-    let mut results = Vec::new();
-
-    let Ok(entries) = std::fs::read_dir(source_dir) else {
-        return results;
-    };
-
-    let mut iter_dirs: Vec<(i64, PathBuf)> = entries
-        .filter_map(|e| e.ok())
-        .filter(|e| e.file_type().ok().is_some_and(|ft| ft.is_dir()))
-        .filter_map(|e| {
-            let name = e.file_name().to_string_lossy().to_string();
-            let n = name.strip_prefix("iter-")?.parse::<i64>().ok()?;
-            completed.contains(&n).then_some((n, e.path()))
-        })
-        .collect();
-
-    iter_dirs.sort_by_key(|(n, _)| *n);
-
-    let artifacts_dir = source_dir.parent().unwrap_or(source_dir);
-
-    for (_, dir) in iter_dirs {
-        let file_path = dir.join(port_name).join("output.md");
-        let exists = file_path.exists();
-        let size = if exists {
-            std::fs::metadata(&file_path).ok().map(|m| m.len())
-        } else {
-            None
-        };
-        if exists {
-            results.push(FileInfo {
-                path: relative_path(artifacts_dir, &file_path),
-                exists,
-                size,
-                frontmatter: None,
-            });
-        }
-    }
-
-    results
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -483,6 +434,41 @@ mod tests {
 
         assert!(io.inputs[0].files[0].exists);
         assert!(io.inputs[0].files[0].size.unwrap() > 0);
+    }
+
+    #[test]
+    fn simple_wire_resolves_cross_iteration_to_latest_completed_source() {
+        // #370 regression (RED→GREEN): a consumer reading at iter-2 from a
+        // non-repeated edge whose source only ever COMPLETED at iter-1 (the
+        // textbook external-feeder / loop-member case) must resolve to the
+        // source's latest-completed iteration (iter-1), NOT its own positional
+        // iter-2 — a path that never existed. Before the fix, the simple-wire
+        // branch walked the edge on the consumer's `iter` and reported the input
+        // "missing", the one escapee of the #194/#210/#353 quarantine invariant.
+        let tmp = tempfile::tempdir().unwrap();
+        let artifacts = tmp.path().join("artifacts");
+        let dir = artifacts.join("planner/iter-1/plan");
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("output.md"), "# Plan\nfrom the feeder's only lap").unwrap();
+
+        let pipeline = simple_pipeline();
+        // The planner (feeder) completed only at iter-1; the implementer reads
+        // it at lap 2.
+        let run_state = run_state_with("planner", &[(1, NodeStatus::Completed)]);
+        let io = resolve(&pipeline, &artifacts, "implementer", 2, &run_state);
+
+        assert_eq!(io.inputs.len(), 1);
+        assert_eq!(io.inputs[0].port, "plan");
+        assert!(!io.inputs[0].repeated);
+        assert_eq!(io.inputs[0].files.len(), 1);
+        assert_eq!(
+            io.inputs[0].files[0].path, "planner/iter-1/plan/output.md",
+            "resolves to the source's latest-completed iter, not the consumer's iter-2"
+        );
+        assert!(
+            io.inputs[0].files[0].exists,
+            "the feeder's iter-1 artifact exists and must be surfaced, not reported missing"
+        );
     }
 
     #[test]

--- a/crates/pdo-daemon/src/node_primitives.rs
+++ b/crates/pdo-daemon/src/node_primitives.rs
@@ -274,20 +274,41 @@ fn resolve_inputs(
     params: &StartNodeParams<'_>,
     node: &pipeline::NodeDef,
 ) -> HashMap<String, String> {
-    let mut input_paths = HashMap::new();
-
-    // #353: `repeated` pools resolve through the projection — one concrete path
-    // per COMPLETED source iteration, never a raw `iter-*` disk glob (which would
-    // pool a failed iteration's artifact). Keyed by source node and filtered on
-    // `edge.repeated`, consistent with the other two resolvers; the declared
-    // `input_port.repeated` flag is NOT the authority (edge-based model, #149 /
-    // ADR-0011). This map backs only the forensic `NodeStarted` payload.
+    // Project over the single edge-walk (#370): the iteration decision (source's
+    // latest-COMPLETED iter for a single wire, COMPLETED iters for a `repeated`
+    // pool — never a raw `iter-*` disk glob, #353) lives in
+    // `input_resolution::resolve_consumer_inputs`, not re-derived here. This
+    // path is keyed on the node's DECLARED inputs (the forensic `NodeStarted`
+    // payload is a per-declared-port, mono-value map) and layers overrides + the
+    // entry-node `task` fallback on top; a `repeated` pool flattens to a
+    // `\n`-joined string.
+    let source_iters = crate::input_resolution::resolved_source_iters(
+        params.pipeline,
+        params.run_state,
+        params.node_id,
+        params.iter,
+    );
     let repeated_iters = crate::input_resolution::resolved_repeated_iters(
         params.pipeline,
         params.run_state,
         params.node_id,
     );
+    let resolved = crate::input_resolution::resolve_consumer_inputs(
+        params.pipeline,
+        params.artifacts_dir,
+        params.node_id,
+        params.iter,
+        &source_iters,
+        &repeated_iters,
+    );
+    // First resolved input per target port — preserves the previous
+    // first-matching-edge semantics when several edges share a target port.
+    let mut by_port: HashMap<&str, &crate::input_resolution::ResolvedInput> = HashMap::new();
+    for r in &resolved {
+        by_port.entry(r.port.as_str()).or_insert(r);
+    }
 
+    let mut input_paths = HashMap::new();
     for input_port in &node.inputs {
         if let Some(override_path) = params
             .overrides
@@ -301,53 +322,14 @@ fn resolve_inputs(
             continue;
         }
 
-        let matching_edge = params
-            .pipeline
-            .edges
-            .iter()
-            .find(|e| e.target.node == params.node_id && e.target.port == input_port.name);
-
-        if let Some(edge) = matching_edge {
-            let resolved = if edge.repeated {
-                // Concrete completed-iteration paths, `\n`-joined (this HashMap
-                // is mono-value; the payload is forensic, not machine-read).
-                repeated_iters
-                    .get(&edge.source.node)
-                    .map(|iters| {
-                        iters
-                            .iter()
-                            .map(|&n| {
-                                blackboard::artifact_path(
-                                    params.artifacts_dir,
-                                    &edge.source.node,
-                                    n,
-                                    &edge.source.port,
-                                )
-                                .to_string_lossy()
-                                .to_string()
-                            })
-                            .collect::<Vec<_>>()
-                            .join("\n")
-                    })
-                    .unwrap_or_default()
-            } else {
-                // Canonical resolution (#194 / #210): the source's latest
-                // COMPLETED iteration, never a failed iteration's artifact.
-                let source_iter = crate::input_resolution::source_iter(
-                    params.run_state,
-                    &edge.source.node,
-                    params.iter,
-                );
-                blackboard::artifact_path(
-                    params.artifacts_dir,
-                    &edge.source.node,
-                    source_iter,
-                    &edge.source.port,
-                )
-                .to_string_lossy()
-                .to_string()
-            };
-            input_paths.insert(input_port.name.clone(), resolved);
+        if let Some(r) = by_port.get(input_port.name.as_str()) {
+            let joined = r
+                .paths
+                .iter()
+                .map(|p| p.to_string_lossy().to_string())
+                .collect::<Vec<_>>()
+                .join("\n");
+            input_paths.insert(input_port.name.clone(), joined);
         } else if input_port.name == "task" {
             let path = blackboard::input_path(params.artifacts_dir);
             input_paths.insert(input_port.name.clone(), path.to_string_lossy().to_string());
@@ -1142,6 +1124,73 @@ mod tests {
         assert!(
             review_path.contains("iter-3"),
             "should resolve to iter-3 (latest), got: {review_path}"
+        );
+    }
+
+    #[test]
+    fn resolve_inputs_reads_latest_completed_not_failed_iter() {
+        // #370 guard (the node_primitives projection): a non-repeated
+        // cross-iteration edge whose source FAILED at iter-1 then COMPLETED at
+        // iter-2 must record iter-2 in the forensic payload — never the failed
+        // iter-1, and never the consumer's positional iter.
+        let pipeline = PipelineDef {
+            name: "test".into(),
+            version: None,
+            variables: HashMap::new(),
+            nodes: vec![
+                make_node("reviewer", NodeType::DocOnly, &["task"], &["review"]),
+                make_node("implementer", NodeType::DocOnly, &["review"], &["summary"]),
+            ],
+            edges: vec![make_edge("reviewer", "review", "implementer", "review")],
+            loops: Vec::new(),
+            notes: Vec::new(),
+            prompt_required: true,
+        };
+
+        let mut run_state = empty_run_state();
+        run_state.nodes.insert(
+            "reviewer".into(),
+            completed_node_iters(
+                "reviewer",
+                &[(1, NodeStatus::Failed), (2, NodeStatus::Completed)],
+            ),
+        );
+
+        let tmp = tempfile::tempdir().unwrap();
+        let artifacts_dir = tmp.path().join("artifacts");
+        std::fs::create_dir_all(&artifacts_dir).unwrap();
+
+        let node = pipeline
+            .nodes
+            .iter()
+            .find(|n| n.id == "implementer")
+            .unwrap();
+        let params = StartNodeParams {
+            run_id: "run-1",
+            node_id: "implementer",
+            iter: 1,
+            overrides: None,
+            pipeline: &pipeline,
+            run_state: &run_state,
+            artifacts_dir: &artifacts_dir,
+            worktree_dir: tmp.path(),
+            repo_root: tmp.path(),
+            pipeline_path: &tmp.path().join("pipeline.yaml"),
+            resolved_vars: &HashMap::new(),
+            daemon_port: 5172,
+            tmux_cmd_override: Some("exec true"),
+            default_model: None,
+        };
+
+        let input_paths = resolve_inputs(&params, node);
+        let review_path = input_paths.get("review").unwrap();
+        assert!(
+            review_path.contains("iter-2/review/output.md"),
+            "resolves to the latest-completed iter-2, got: {review_path}"
+        );
+        assert!(
+            !review_path.contains("iter-1"),
+            "the failed iter-1 is quarantined, got: {review_path}"
         );
     }
 

--- a/crates/pdo-daemon/src/prompt_augmenter.rs
+++ b/crates/pdo-daemon/src/prompt_augmenter.rs
@@ -106,73 +106,28 @@ pub fn read_start_prompt_present(artifacts_dir: &Path) -> std::io::Result<bool> 
 }
 
 pub fn resolve_input_paths(ctx: &AugmentContext<'_>) -> Vec<InputResolution> {
-    let mut inputs = Vec::new();
-
-    for edge in &ctx.pipeline.edges {
-        if edge.target.node != ctx.node.id {
-            continue;
-        }
-
-        // `repeated` lives on the edge (#149): inputs are emergent, derived from
-        // incoming edges, so the accumulate-across-iterations flag rides the edge
-        // rather than a declared input port.
-        let repeated = edge.repeated;
-
-        let source_node = &edge.source.node;
-        let is_start = ctx
-            .pipeline
-            .nodes
-            .iter()
-            .any(|n| n.id == *source_node && n.node_type == crate::pipeline::NodeType::Start);
-
-        let paths: Vec<PathBuf> = if is_start {
-            vec![crate::blackboard::input_path(ctx.artifacts_dir)]
-        } else if repeated {
-            // #353: enumerate one concrete path per COMPLETED source iteration,
-            // resolved via the projection (`repeated_iters`) — never a raw
-            // `iter-*` glob, which cannot exclude a failed iteration's artifact.
-            // A source with no completed iter (absent from the map) pools
-            // nothing (D6).
-            ctx.repeated_iters
-                .get(source_node.as_str())
-                .map(|iters| {
-                    iters
-                        .iter()
-                        .map(|&n| {
-                            crate::blackboard::artifact_path(
-                                ctx.artifacts_dir,
-                                source_node,
-                                n,
-                                &edge.source.port,
-                            )
-                        })
-                        .collect()
-                })
-                .unwrap_or_default()
-        } else {
-            // Canonical resolution (#194): read the source's latest completed
-            // iteration, never a failed iteration's artifact and never a
-            // positional iter the source has not produced.
-            let source_iter = ctx
-                .source_iters
-                .get(source_node.as_str())
-                .copied()
-                .unwrap_or(ctx.iter);
-            vec![crate::blackboard::artifact_path(
-                ctx.artifacts_dir,
-                source_node,
-                source_iter,
-                &edge.source.port,
-            )]
-        };
-
-        inputs.push(InputResolution {
-            port_name: edge.target.port.clone(),
-            paths,
-            repeated,
-            from_start: is_start,
-        });
-    }
+    // Project over the single edge-walk (#370): the iteration decision (source's
+    // latest-completed iter, completed-iters pool, Start → `_input`) lives in
+    // `input_resolution::resolve_consumer_inputs`, fed the precomputed maps the
+    // daemon injected (this module is pure and cannot hold a `RunState`). The
+    // preamble/script-env are then pure projections over the result — one
+    // `InputResolution` per incoming edge, no independent edge-walk.
+    let mut inputs: Vec<InputResolution> = crate::input_resolution::resolve_consumer_inputs(
+        ctx.pipeline,
+        ctx.artifacts_dir,
+        &ctx.node.id,
+        ctx.iter,
+        &ctx.source_iters,
+        &ctx.repeated_iters,
+    )
+    .into_iter()
+    .map(|r| InputResolution {
+        port_name: r.port,
+        paths: r.paths,
+        repeated: r.repeated,
+        from_start: r.from_start,
+    })
+    .collect();
 
     if inputs.is_empty() && ctx.node.inputs.iter().any(|p| p.name == "task") {
         inputs.push(InputResolution {

--- a/crates/pdo-daemon/tests/node_io.rs
+++ b/crates/pdo-daemon/tests/node_io.rs
@@ -179,6 +179,84 @@ async fn io_endpoint_returns_port_paths_and_frontmatter() {
         .output();
 }
 
+/// #370 (AC4): the `/io` endpoint — which backs the NodeRun inputs panel and the
+/// `node_done` node-IO surface — must resolve a non-repeated cross-iteration edge
+/// to the source's latest-COMPLETED iteration, not the consumer's own `iter`.
+///
+/// Scenario: the planner (a feeder) completes only at iter-1; the endpoint is
+/// then asked for the implementer's inputs at iter-2 (as a loop member reading an
+/// external feeder would be). The input must resolve to `planner/iter-1/...`
+/// (which exists), never `planner/iter-2/...` (which never existed). Before the
+/// fix the simple-wire branch walked the edge on the consumer's iter and reported
+/// the input "missing".
+#[tokio::test]
+async fn io_endpoint_resolves_cross_iteration_input_to_latest_completed_source() {
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+    let run_id = create_run(&daemon.url()).await;
+
+    // The planner produced its only lap at iter-1.
+    let planner_dir = daemon
+        .repo_root()
+        .join(".pdo/runs")
+        .join(&run_id)
+        .join("worktree/.pdo/artifacts/planner/iter-1/plan");
+    std::fs::create_dir_all(&planner_dir).unwrap();
+    std::fs::write(planner_dir.join("output.md"), "# Plan\n\nthe feeder's only lap").unwrap();
+
+    // Mark the planner COMPLETED at iter-1 so the projection records it (output
+    // seeded above lets output validation pass, refs #36).
+    let resp = reqwest::Client::new()
+        .post(format!("{}/runs/{}/nodes/planner/done", daemon.url(), run_id))
+        .json(&serde_json::json!({ "iter": 1 }))
+        .send()
+        .await
+        .unwrap();
+    assert!(
+        resp.status().is_success(),
+        "planner done should succeed: {}",
+        resp.status()
+    );
+    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+    // Ask for the implementer's inputs at LAP 2. The planner never ran iter-2.
+    let resp = reqwest::get(format!(
+        "{}/runs/{}/nodes/implementer/io?iter=2",
+        daemon.url(),
+        run_id,
+    ))
+    .await
+    .unwrap();
+    assert_eq!(resp.status(), 200);
+    let io: serde_json::Value = resp.json().await.unwrap();
+
+    let inputs = io["inputs"].as_array().unwrap();
+    assert_eq!(inputs.len(), 1, "implementer should have 1 input port");
+    assert_eq!(inputs[0]["port"], "plan");
+    let path = inputs[0]["files"][0]["path"].as_str().unwrap();
+    assert!(
+        path.contains("planner/iter-1/plan/output.md"),
+        "must resolve to the feeder's latest-completed iter-1, got: {path}"
+    );
+    assert!(
+        !path.contains("iter-2"),
+        "must NOT resolve to the consumer's positional iter-2, got: {path}"
+    );
+    assert_eq!(
+        inputs[0]["files"][0]["exists"], true,
+        "the iter-1 feeder artifact exists and must be surfaced, not reported missing"
+    );
+
+    // Cleanup
+    for session in [
+        format!("pdo-{run_id}-planner-iter-1"),
+        format!("pdo-{run_id}-implementer-iter-1"),
+    ] {
+        let _ = std::process::Command::new("tmux")
+            .args(["kill-session", "-t", &session])
+            .output();
+    }
+}
+
 #[tokio::test]
 async fn io_endpoint_returns_404_before_run_creation() {
     let daemon = TestDaemon::spawn(seed).await.unwrap();


### PR DESCRIPTION
## What

`node_io_resolver::resolve` was the one edge-walker that never delegated to `input_resolution`: its simple-wire branch resolved a non-repeated edge on the **consumer's** iter instead of the source's latest-completed iter. A loop member at iter N reading a feeder external to the loop (completed only at iter-1) built `source/iter-N/...` — a path that never existed — and the NodeRun inputs panel (`GET /io`) reported the input "missing", silently violating the failed-iter / external-feeder quarantine invariant.

## Fix + deepening

- New single seam `input_resolution::resolve_consumer_inputs` owns the edge-walk + iteration decision + concrete Blackboard path construction, one `ResolvedInput` per incoming edge. Pure, so `prompt_augmenter` shares the exact same walk.
- `node_io_resolver`, `prompt_augmenter` and `node_primitives` are now thin projections over it — none walks `pipeline.edges` itself. The bespoke `glob_repeated` helper is deleted.
- `/io` JSON shape unchanged: no frontend change needed.

## Tests (RED→GREEN, all ACs)

- `node_io_resolver::simple_wire_resolves_cross_iteration_to_latest_completed_source`
- `input_resolution` seam tests ×4 (single-wire latest-completed at laps 1 & 3, repeated pool excludes failed iter, Start→_input, unstarted positional fallback)
- `node_primitives::resolve_inputs_reads_latest_completed_not_failed_iter`
- `tests/node_io::io_endpoint_resolves_cross_iteration_input_to_latest_completed_source` (AC4 end-to-end)

Verified by the Tester node (Verdict: **Pass**). `cargo build` clean, 1261 lib tests green after rebasing onto #333 (v0.1.83). Version bumped to **v0.1.84**.

Closes #370

🤖 Generated with [Claude Code](https://claude.com/claude-code)