### PR TITLE
fix(#371): duplicated library row usable without reload — v0.1.86

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "0.1.85"
+version = "0.1.86"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "0.1.85"
+version = "0.1.86"
 license = "MIT"
 
 [workspace.dependencies]

--- a/frontend/src/components/UnifiedLeftPanel.test.tsx
+++ b/frontend/src/components/UnifiedLeftPanel.test.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -582,6 +583,155 @@ describe("UnifiedLeftPanel library duplicate (#224)", () => {
       expect(mockDuplicateLibraryPipeline).toHaveBeenCalledWith("fixture"),
     );
     await waitFor(() => expect(onChanged).toHaveBeenCalled());
+  });
+});
+
+// #371 — after Duplicate, the new copy row must be immediately usable (proper
+// button, "library" badge, opens on click) WITHOUT a full page reload. The bug:
+// the duplicate handler refreshed only /library/pipelines, so the copy landed
+// there tagged with its raw storage scope "user" and — being absent from
+// /pipelines — fell through to the degraded block-2 <div> (wrong "user" badge,
+// no button role, dead click). A reload re-fetched /pipelines (where the daemon
+// tags the copy scope:"library"), which repaired all three symptoms. The fix
+// re-fetches /pipelines right after the duplicate, so the copy lands in the
+// block-1 button path at once. Both Copy affordances route through the same
+// handleDuplicate seam, so they can never drift apart again.
+describe("UnifiedLeftPanel duplicate is usable without reload (#371)", () => {
+  const original: PipelineListEntry = {
+    id: "planner",
+    name: "planner",
+    scope: "library",
+    path: "/home/u/.pdo/library/pipelines/planner.yaml",
+    node_count: 3,
+    modified: null,
+    variables: {},
+  };
+  // /pipelines shape of the copy: the daemon scans the library dir and tags it
+  // scope:"library", so it belongs in block 1 (proper button, "library" badge).
+  const copyPipe: PipelineListEntry = {
+    ...original,
+    id: "planner-copy",
+    name: "planner (copy)",
+    path: "/home/u/.pdo/library/pipelines/planner-copy.yaml",
+  };
+  // /library/pipelines shape of the same copy: raw storage scope "user" — the
+  // value that rendered the degraded block-2 row before the fix.
+  const copyLib: LibraryPipelineEntry = {
+    id: "planner-copy",
+    name: "planner (copy)",
+    scope: "user",
+    node_count: 3,
+    modified: null,
+    yaml: "name: planner (copy)\n",
+    pipeline: { name: "planner (copy)", version: "1.0", variables: {}, nodes: [], edges: [] },
+    prompts: {},
+  };
+
+  it("moves the copy from the degraded block-2 <div> to a proper block-1 button (block-1 Copy)", async () => {
+    // /pipelines: only the original at mount; original + copy (both tagged
+    // scope:"library") on the post-duplicate re-fetch the fix now performs.
+    mockFetchPipelines.mockReset();
+    mockFetchPipelines
+      .mockResolvedValueOnce([original])
+      .mockResolvedValue([original, copyPipe]);
+    mockDuplicateLibraryPipeline.mockResolvedValueOnce({
+      id: "planner-copy",
+      scope: "user",
+      entry: null,
+    });
+
+    // A stateful parent that mirrors App: onLibraryPipelinesChanged adds the
+    // copy (raw "user" scope) to the /library/pipelines prop — exactly the
+    // refresh that, ALONE, produced the degraded row before the fix.
+    function Harness() {
+      const [lib, setLib] = useState<LibraryPipelineEntry[]>([]);
+      return (
+        <UnifiedLeftPanel
+          runs={[]}
+          selectedRunId={null}
+          onSelectRun={noop}
+          onNewRun={noop}
+          libraryPipelines={lib}
+          onLibraryPipelinesChanged={() => setLib([copyLib])}
+        />
+      );
+    }
+
+    render(<Harness />);
+    fireEvent.click(screen.getByRole("tab", { name: "Library" }));
+    await screen.findByText("planner");
+    expect(screen.queryByText("planner (copy)")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("library-duplicate-button"));
+
+    // The copy is now a real <button> (role) named for the copy, carrying the
+    // "library" badge — not the degraded "user" <div>. Pre-fix this row stayed
+    // a library-only <div>, so findByRole would time out.
+    const copyRow = await screen.findByRole("button", { name: /planner \(copy\)/ });
+    expect(within(copyRow).getByText("library")).toBeInTheDocument();
+    // No degraded library-only row survives: once /pipelines carries the copy,
+    // the block-2 name-absence filter drops it.
+    expect(screen.queryByTestId("library-only-entry")).not.toBeInTheDocument();
+  });
+
+  it("surfaces the copy as a block-1 button when duplicating from a block-2 library-only row (block-2 Copy)", async () => {
+    const solo: PipelineListEntry = {
+      id: "solo",
+      name: "solo",
+      scope: "library",
+      path: "/home/u/.pdo/library/pipelines/solo.yaml",
+      node_count: 2,
+      modified: null,
+      variables: {},
+    };
+    const soloCopy: PipelineListEntry = {
+      ...solo,
+      id: "solo-copy",
+      name: "solo (copy)",
+      path: "/home/u/.pdo/library/pipelines/solo-copy.yaml",
+    };
+    const soloLibOnly: LibraryPipelineEntry = {
+      id: "solo",
+      name: "solo",
+      scope: "user",
+      node_count: 2,
+      modified: null,
+      yaml: "name: solo\n",
+      pipeline: { name: "solo", version: "1.0", variables: {}, nodes: [], edges: [] },
+      prompts: {},
+    };
+    // /pipelines empty at mount ⇒ `solo` renders as a block-2 library-only row;
+    // the fix's re-fetch then returns both entries tagged scope:"library".
+    mockFetchPipelines.mockReset();
+    mockFetchPipelines
+      .mockResolvedValueOnce([])
+      .mockResolvedValue([solo, soloCopy]);
+    mockDuplicateLibraryPipeline.mockResolvedValueOnce({
+      id: "solo-copy",
+      scope: "user",
+      entry: null,
+    });
+
+    render(
+      <UnifiedLeftPanel
+        runs={[]}
+        selectedRunId={null}
+        onSelectRun={noop}
+        onNewRun={noop}
+        libraryPipelines={[soloLibOnly]}
+        onLibraryPipelinesChanged={noop}
+      />,
+    );
+    fireEvent.click(screen.getByRole("tab", { name: "Library" }));
+    // The block-2 library-only row carries the duplicate affordance.
+    await screen.findByTestId("library-only-entry");
+
+    fireEvent.click(screen.getByTestId("library-duplicate-button"));
+
+    // loadPipelines() (the block-2 handler now shares it) re-fetches /pipelines,
+    // landing the copy in the clickable, "library"-badged block-1 path.
+    const copyRow = await screen.findByRole("button", { name: /solo \(copy\)/ });
+    expect(within(copyRow).getByText("library")).toBeInTheDocument();
   });
 });
 

--- a/frontend/src/components/UnifiedLeftPanel.tsx
+++ b/frontend/src/components/UnifiedLeftPanel.tsx
@@ -199,6 +199,32 @@ export default function UnifiedLeftPanel({
     }
   }
 
+  // #224/#371 — duplicate a library template. One shared seam for both Copy
+  // affordances (the block-1 scope:"library" row and the block-2 library-only
+  // row) so they can never again drift apart. Busy-guarded (a double-click on
+  // the Copy icon fires once), then refreshes BOTH pipeline lists:
+  //   - loadPipelines() re-fetches the authoritative /pipelines, where the
+  //     daemon tags the copy scope:"library" — so it lands in the proper
+  //     block-1 button path at once: a clickable, correctly-badged row.
+  //   - onLibraryPipelinesChanged() re-fetches /library/pipelines.
+  // Refreshing only the latter (the pre-#371 behaviour) left the copy in the
+  // degraded block-2 <div>: wrong "user" badge, no button role, dead click,
+  // until a full page reload. The New/Import handlers already loadPipelines()
+  // the same way; only Duplicate had drifted.
+  async function handleDuplicate(id: string) {
+    if (duplicatingId === id) return;
+    setDuplicatingId(id);
+    try {
+      await duplicateLibraryPipeline(id);
+      await loadPipelines();
+      onLibraryPipelinesChanged(); // refresh; do NOT auto-open the copy
+    } catch {
+      /* ignore */
+    } finally {
+      setDuplicatingId(null);
+    }
+  }
+
   // One run row, rendered identically whether the list is flat or grouped by
   // repo (#258). Extracted so both code paths share the exact same markup.
   function renderRunRow(run: RunListEntry) {
@@ -655,15 +681,9 @@ export default function UnifiedLeftPanel({
                   <span
                     className="hidden shrink-0 group-hover:inline-flex"
                     data-testid="library-duplicate-button"
-                    onClick={async (e) => {
+                    onClick={(e) => {
                       e.stopPropagation();
-                      if (duplicatingId === p.id) return;
-                      setDuplicatingId(p.id);
-                      try {
-                        await duplicateLibraryPipeline(p.id);
-                        onLibraryPipelinesChanged(); // refresh; do NOT auto-open the copy
-                      } catch { /* ignore */ }
-                      finally { setDuplicatingId(null); }
+                      handleDuplicate(p.id);
                     }}
                     role="button"
                     title="Duplicate pipeline"
@@ -730,15 +750,9 @@ export default function UnifiedLeftPanel({
                 <span
                   className="hidden shrink-0 group-hover:inline-flex"
                   data-testid="library-duplicate-button"
-                  onClick={async (e) => {
+                  onClick={(e) => {
                     e.stopPropagation();
-                    if (duplicatingId === lp.id) return;
-                    setDuplicatingId(lp.id);
-                    try {
-                      await duplicateLibraryPipeline(lp.id);
-                      onLibraryPipelinesChanged(); // refresh; do NOT auto-open the copy
-                    } catch { /* ignore */ }
-                    finally { setDuplicatingId(null); }
+                    handleDuplicate(lp.id);
                   }}
                   role="button"
                   title="Duplicate pipeline"


### PR DESCRIPTION
## What

Fixes the degraded duplicated library row: after clicking **Duplicate** on a library pipeline, the new `… (copy)` row now appears immediately as a real, focusable `<button>` with the correct `library` badge and opens on click — no page reload required.

## Root cause

The two inline Duplicate handlers only called `onLibraryPipelinesChanged()`. The copy landed in the degraded block-2 path (raw `user` scope, dead `<div>`, no-op click) until a full `/pipelines` re-fetch. The fix unifies both handlers into one `handleDuplicate(id)` seam that also calls `loadPipelines()` to re-fetch the authoritative `/pipelines`, so the copy immediately routes through the block-1 `<button>` path (`scope:"library"`).

## Changes

- `frontend/src/components/UnifiedLeftPanel.tsx` — unify Duplicate handlers into one `handleDuplicate(id)` that re-fetches `/pipelines`.
- `frontend/src/components/UnifiedLeftPanel.test.tsx` — regression coverage.
- Version bump → **v0.1.86**.

## Verification

Frontend build clean (`tsc -b && vite build` → exit 0). Verified live in an isolated stack (Playwright): copy row appears immediately with `library` badge, is a native `<button>`, `library-only-entry` count is 0, and clicking the copy opens it in the editor. No reload, no regression.

Closes #371

🤖 Generated with [Claude Code](https://claude.com/claude-code)
