### PR TITLE
fix(e2e): target output port by name, not .first(), post-#370

### DIFF
--- a/frontend/e2e/cold-start-integration.spec.ts
+++ b/frontend/e2e/cold-start-integration.spec.ts
@@ -135,12 +135,15 @@ test("cold-start full flow: run → node → modal, no console errors", async ({
   // 5. Select the worker node and reveal the Run inspector details pane.
   await openRunNodeDetails(page, runId, "worker");
 
-  // 6. Open the output modal from the seeded `result` output port card (the one
-  // port-row that is a button; a no-files port renders as a non-interactive div).
+  // 6. Open the output modal from the seeded `result` output port card. Target
+  // it by port name, not `.first()`: since #370 fixed input resolution, the
+  // node's resolved input renders as a clickable `button.port-row` too, so the
+  // first button is no longer guaranteed to be the output. A no-files port still
+  // renders as a non-interactive div. The port name is the button's leading text.
   const portCard = page
     .getByTestId("inspector-pane-run")
     .locator("button.port-row")
-    .first();
+    .filter({ hasText: /^result/ });
   await expect(portCard).toBeVisible({ timeout: 5_000 });
   await portCard.click();
 

--- a/frontend/e2e/node-io-modal.spec.ts
+++ b/frontend/e2e/node-io-modal.spec.ts
@@ -100,12 +100,17 @@ async function createRunAndSeedArtifacts(page: Page, baseURL: string) {
   return runId;
 }
 
-/** The seeded `review` output card (the one port-row that is a button). */
+/**
+ * The seeded `review` output card. Target it by port name, not `.first()`:
+ * since #370 fixed input resolution, the reviewer's resolved `task` input also
+ * renders as a clickable `button.port-row`, so the first button is no longer
+ * guaranteed to be the output. The port name is the button's leading text.
+ */
 function reviewCard(page: Page) {
   return page
     .getByTestId("inspector-pane-run")
     .locator("button.port-row")
-    .first();
+    .filter({ hasText: /^review/ });
 }
 
 test("clicking anywhere on port card opens modal with markdown + frontmatter", async ({


### PR DESCRIPTION
## Why

`#370` fixed input resolution so a node's Start-sourced input now resolves to a real file. In the Run inspector that flips the input port card from a non-interactive `div.port-row` to a clickable `button.port-row`, so `button.port-row.first()` grabs the **input**, not the seeded output. The output modal then shows the run input text and `toContainText("Result"/"Review")` fails.

This is why the `Frontend E2E (layer 3b)` job has been red on `main` since #370 (both `cold-start-integration` and `node-io-modal`). Product behaviour is correct — the tests' `.first()` assumption went stale.

## What

Test-only. Filter `button.port-row` by the output port name (`/^result/`, `/^review/`), matching the robust pattern `render-html`/`render-mermaid` already use (the port name is the button's leading text).

## Verification

- `npx playwright test cold-start-integration node-io-modal` → **6 passed, 0 failed**
- `tsc -b` + eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)