### PR TITLE
fix(#386): reset New Run modal state on reopen via OpenIntent union — v0.1.94

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -439,6 +439,8 @@ Le runtime ne distingue pas (i) de (ii) : il pose le contenu utilisateur tel que
 
 L'input peut aussi être **construit interactivement** via un nœud d'entrée marqué `interactive: true` (cf. principe *Deliberate over autonomous*). Pattern typique : le user écrit un prompt brut court, attache la session du nœud d'entrée, l'agent grille jusqu'à un input structuré, le user "submit", le pipeline démarre vraiment.
 
+- **Saisie persistante de la modale New Run.** Le contenu saisi (prompt, repo cible, pipeline, overrides de variables, images) survit à une fermeture/réouverture de la modale — un `dismiss` accidentel ne le perd pas — et n'est vidé qu'après un **lancement réussi** (`POST /runs`).
+
 #### Images d'input
 
 Le user peut **téléverser des images** à côté du prompt texte (New Run modal). Le runtime les stocke dans `_input/` du Blackboard, à côté de `output.md`, et le préambule du nœud d'entrée les liste. Ces images sont **portées par le nœud Start** : le `StartNodeInfo` projeté expose `input_images` (les noms de fichiers, dans l'ordre de téléversement). L'UI les affiche en bandeau de vignettes sur la carte Start du canvas et en pleine taille (cliquables, lightbox) dans le StartInspector, aux côtés du prompt. Un Run sans image rend le nœud Start et le StartInspector à l'identique (prompt seul).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "0.1.93"
+version = "0.1.94"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "0.1.93"
+version = "0.1.94"
 license = "MIT"
 
 [workspace.dependencies]

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,7 +16,7 @@ import ServiceHealthIndicator from "./components/ServiceHealthIndicator";
 import UnifiedLeftPanel from "./components/UnifiedLeftPanel";
 import NodeDetailPanel from "./components/NodeDetailPanel";
 import RunInfoSidebar from "./components/RunInfoSidebar";
-import NewRunModal from "./components/NewRunModal";
+import NewRunModal, { RUN_INTENT } from "./components/NewRunModal";
 import SettingsModal from "./components/SettingsModal";
 import ConflictModal from "./components/ConflictModal";
 import PipelineChangedModal from "./components/PipelineChangedModal";
@@ -37,7 +37,7 @@ import EdgeDetailPanel from "./components/EdgeDetailPanel";
 import RegionInspector from "./components/RegionInspector";
 import NoteInspector from "./components/NoteInspector";
 import TriggerDetailPanel from "./components/TriggerDetailPanel";
-import type { TriggerPrefill } from "./components/NewRunModal";
+import type { OpenIntent } from "./components/NewRunModal";
 import { deriveEdgeTrigger } from "./lib/edgeTrigger";
 import { handleUndoRedoKeydown } from "./lib/undoRedoHotkeys";
 import InspectorTabs from "./components/InspectorTabs";
@@ -164,9 +164,10 @@ export default function App() {
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
   const [newRunModalOpen, setNewRunModalOpen] = useState(false);
   const [settingsModalOpen, setSettingsModalOpen] = useState(false);
-  // When the New Run modal is opened from a Trigger (run-now / edit), this holds
-  // the source Trigger and the intended mode (#162).
-  const [triggerPrefill, setTriggerPrefill] = useState<TriggerPrefill | null>(null);
+  // #386: how the always-mounted New Run modal should open. Drives a one-shot
+  // reset on every reopen so a dismissed "Edit trigger" can't leak into a fresh
+  // "New run" / "New trigger". Defaults to a plain run.
+  const [openIntent, setOpenIntent] = useState<OpenIntent>(RUN_INTENT);
   // #341: manual "Run now" — a refused fire (409: disabled / broken reference)
   // surfaces here as a dismissible banner.
   const [runNowError, setRunNowError] = useState<string | null>(null);
@@ -291,8 +292,8 @@ export default function App() {
     hasEditTab,
   });
 
-  const openTriggerModal = useCallback((prefill: TriggerPrefill | null) => {
-    setTriggerPrefill(prefill);
+  const openNewRunModal = useCallback((intent: OpenIntent) => {
+    setOpenIntent(intent);
     setNewRunModalOpen(true);
   }, []);
 
@@ -361,7 +362,9 @@ export default function App() {
 
   const handleCloseNewRunModal = useCallback(() => {
     setNewRunModalOpen(false);
-    setTriggerPrefill(null);
+    // Reset the intent to a plain run. Harmless while closed (the modal's reset
+    // only fires on open false→true), but keeps the next default-less open clean.
+    setOpenIntent(RUN_INTENT);
   }, []);
 
   const { activeTab: inspectorTab, setActiveTab: setInspectorTab } =
@@ -668,16 +671,16 @@ export default function App() {
               runs={runs}
               selectedRunId={selectedRunId}
               onSelectRun={handleSelectRun}
-              onNewRun={() => setNewRunModalOpen(true)}
+              onNewRun={() => openNewRunModal({ kind: "run" })}
               libraryPipelines={libraryPipelines}
               onLibraryPipelinesChanged={refreshLibraryPipelines}
               triggers={triggers}
               selectedTriggerId={selectedTriggerId}
               onSelectTrigger={handleSelectTrigger}
-              onNewTrigger={() => openTriggerModal(null)}
+              onNewTrigger={() => openNewRunModal({ kind: "new-trigger" })}
               onTriggersChanged={refreshTriggers}
               onRunNowTrigger={handleRunNowTrigger}
-              onEditTrigger={(t) => openTriggerModal({ trigger: t, mode: "edit" })}
+              onEditTrigger={(t) => openNewRunModal({ kind: "edit-trigger", trigger: t })}
               triggersPaused={triggersPaused}
               onTogglePause={handleTogglePause}
             />
@@ -820,7 +823,7 @@ export default function App() {
           handleCloseNewRunModal();
           handleRunCreated(runId);
         }}
-        prefillTrigger={triggerPrefill}
+        openIntent={openIntent}
         onTriggerSaved={refreshTriggers}
       />
       <SettingsModal

--- a/frontend/src/components/NewRunModal.test.tsx
+++ b/frontend/src/components/NewRunModal.test.tsx
@@ -1044,56 +1044,13 @@ describe("NewRunModal — run-now and edit from a Trigger (#162)", () => {
     ]);
   });
 
-  it("run-now opens in Run-now mode pre-filled from the trigger and creates a run (no guard)", async () => {
-    const onCreated = vi.fn();
-    render(
-      <NewRunModal
-        open={true}
-        onClose={noop}
-        onCreated={onCreated}
-        prefillTrigger={{ trigger: sampleTrigger, mode: "run" }}
-      />,
-    );
-
-    // Run-now mode is active (creates a Run, not a Trigger).
-    await waitFor(() => {
-      expect(screen.getByTestId("mode-run")).toHaveAttribute("aria-selected", "true");
-    });
-    // Prefilled repo + input.
-    await waitFor(() => {
-      expect(screen.getByLabelText(/target repository/i)).toHaveValue("/home/user/project");
-    });
-    expect(screen.getByPlaceholderText(/free-text prompt/i)).toHaveValue("audit the codebase");
-
-    // Let the debounced repo validation resolve so the form is launchable.
-    await vi.advanceTimersByTimeAsync(500);
-    await waitFor(() => expect(validateRepo).toHaveBeenCalledWith("/home/user/project"));
-
-    vi.useRealTimers();
-    await waitFor(() => expect(screen.getByRole("button", { name: /launch/i })).toBeEnabled());
-    fireEvent.click(screen.getByRole("button", { name: /launch/i }));
-
-    await waitFor(() => {
-      expect(createRun).toHaveBeenCalledWith(
-        expect.objectContaining({
-          pipeline_id: "p1",
-          input: "audit the codebase",
-          target_repo: "/home/user/project",
-        }),
-      );
-    });
-    // Run-now never creates or fires a guard.
-    expect(createTrigger).not.toHaveBeenCalled();
-    expect(updateTrigger).not.toHaveBeenCalled();
-  });
-
   it("edit opens in Trigger mode pre-filled and PATCHes the trigger on submit", async () => {
     render(
       <NewRunModal
         open={true}
         onClose={noop}
         onCreated={noop}
-        prefillTrigger={{ trigger: sampleTrigger, mode: "edit" }}
+        openIntent={{ kind: "edit-trigger", trigger: sampleTrigger }}
       />,
     );
 
@@ -1146,7 +1103,7 @@ describe("NewRunModal — run-now and edit from a Trigger (#162)", () => {
         open={true}
         onClose={noop}
         onCreated={noop}
-        prefillTrigger={{ trigger: bounded, mode: "edit" }}
+        openIntent={{ kind: "edit-trigger", trigger: bounded }}
       />,
     );
 
@@ -1183,7 +1140,7 @@ describe("NewRunModal — run-now and edit from a Trigger (#162)", () => {
         open={true}
         onClose={noop}
         onCreated={noop}
-        prefillTrigger={{ trigger: sampleTrigger, mode: "edit" }}
+        openIntent={{ kind: "edit-trigger", trigger: sampleTrigger }}
       />,
     );
 
@@ -1216,5 +1173,130 @@ describe("NewRunModal — run-now and edit from a Trigger (#162)", () => {
       );
     });
     expect(createTrigger).not.toHaveBeenCalled();
+  });
+});
+
+describe("NewRunModal — open-intent reset (#386)", () => {
+  const trigger = {
+    id: "trg-9",
+    name: "Nightly audit",
+    pipeline_id: "p1",
+    pipeline_name: "Auditor",
+    target_repo: "/home/user/project",
+    source_branch: "dev",
+    input_template: "audit the codebase",
+    variables: {},
+    cron: "*/15 * * * *",
+    guard_command: null,
+    overlap_policy: "allow",
+    enabled: true,
+    next_fire_at: null,
+    last_fired_at: null,
+    last_outcome: null,
+  };
+
+  it("edit → close → open(run) reopens as a clean New Run (kills the stale Edit-Trigger)", async () => {
+    const { rerender } = render(
+      <NewRunModal open={true} onClose={noop} onCreated={noop}
+        openIntent={{ kind: "edit-trigger", trigger }} />,
+    );
+
+    // Opened in Edit-Trigger mode (footer is Save).
+    await waitFor(() => {
+      expect(screen.getByTestId("mode-trigger")).toHaveAttribute("aria-selected", "true");
+    });
+    expect(screen.getByTestId("save-trigger-button")).toBeInTheDocument();
+
+    // Dismiss, then reopen as a plain run.
+    rerender(<NewRunModal open={false} onClose={noop} onCreated={noop}
+      openIntent={{ kind: "edit-trigger", trigger }} />);
+    rerender(<NewRunModal open={true} onClose={noop} onCreated={noop}
+      openIntent={{ kind: "run" }} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("mode-run")).toHaveAttribute("aria-selected", "true");
+    });
+    expect(screen.getByText("New Run")).toBeInTheDocument();
+    expect(screen.getByTestId("launch-button")).toBeInTheDocument();
+    // No trigger footer leaks — Finding B (silent PATCH of the wrong trigger).
+    expect(screen.queryByTestId("save-trigger-button")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("create-trigger-button")).not.toBeInTheDocument();
+    // Trigger-only fields aren't even rendered in run mode.
+    expect(screen.queryByTestId("trigger-name-input")).not.toBeInTheDocument();
+  });
+
+  it("edit → close → open(new-trigger) reopens as a blank Create Trigger (Finding B)", async () => {
+    const { rerender } = render(
+      <NewRunModal open={true} onClose={noop} onCreated={noop}
+        openIntent={{ kind: "edit-trigger", trigger }} />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("trigger-name-input")).toHaveValue("Nightly audit");
+    });
+    expect(screen.getByTestId("save-trigger-button")).toBeInTheDocument();
+
+    rerender(<NewRunModal open={false} onClose={noop} onCreated={noop}
+      openIntent={{ kind: "edit-trigger", trigger }} />);
+    rerender(<NewRunModal open={true} onClose={noop} onCreated={noop}
+      openIntent={{ kind: "new-trigger" }} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("mode-trigger")).toHaveAttribute("aria-selected", "true");
+    });
+    expect(screen.getByText("New Trigger")).toBeInTheDocument();
+    // Footer is Create (a fresh POST), NOT Save: editingTriggerId is cleared, so
+    // submitting can't silently PATCH the previously edited trigger.
+    expect(screen.getByTestId("create-trigger-button")).toBeInTheDocument();
+    expect(screen.queryByTestId("save-trigger-button")).not.toBeInTheDocument();
+    // The trigger name is blank, not the edited trigger's name.
+    expect(screen.getByTestId("trigger-name-input")).toHaveValue("");
+  });
+
+  it("new-trigger opens fresh in Trigger mode with no prior edit", async () => {
+    render(
+      <NewRunModal open={true} onClose={noop} onCreated={noop}
+        openIntent={{ kind: "new-trigger" }} />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("mode-trigger")).toHaveAttribute("aria-selected", "true");
+    });
+    expect(screen.getByText("New Trigger")).toBeInTheDocument();
+    expect(screen.getByTestId("create-trigger-button")).toBeInTheDocument();
+    expect(screen.queryByTestId("save-trigger-button")).not.toBeInTheDocument();
+  });
+
+  it("edit → close → open(run) clears the shared draft carried from the trigger (#386 Part 2)", async () => {
+    vi.mocked(fetchPipelines).mockResolvedValue([
+      makePipeline({ id: "p1", name: "Auditor", scope: "repo", prompt_required: false }),
+      makePipeline({ id: "p2", name: "Bugfixer", scope: "repo", prompt_required: false }),
+    ]);
+
+    const { rerender } = render(
+      <NewRunModal open={true} onClose={noop} onCreated={noop}
+        openIntent={{ kind: "edit-trigger", trigger }} />,
+    );
+
+    // The edit prefilled the shared draft from the trigger (prompt, repo, pipeline).
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText(/free-text prompt/i)).toHaveValue("audit the codebase");
+    });
+    await vi.advanceTimersByTimeAsync(500);
+    await waitFor(() => expect(validateRepo).toHaveBeenCalledWith("/home/user/project"));
+    await waitFor(() => {
+      expect(screen.getByTestId("pipeline-select")).toHaveValue("p1");
+    });
+
+    rerender(<NewRunModal open={false} onClose={noop} onCreated={noop}
+      openIntent={{ kind: "edit-trigger", trigger }} />);
+    rerender(<NewRunModal open={true} onClose={noop} onCreated={noop}
+      openIntent={{ kind: "run" }} />);
+
+    // A fresh run must not inherit the consulted trigger's prompt or pipeline.
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText(/free-text prompt/i)).toHaveValue("");
+    });
+    expect((screen.getByTestId("pipeline-select") as HTMLSelectElement).value).not.toBe("p1");
   });
 });

--- a/frontend/src/components/NewRunModal.tsx
+++ b/frontend/src/components/NewRunModal.tsx
@@ -24,26 +24,41 @@ const GUARD_VERDICT: Record<
 const ACCEPTED_IMAGE_TYPES = ["image/png", "image/jpeg", "image/gif", "image/webp", "image/svg+xml", "image/bmp"];
 
 /**
- * Open the modal pre-filled from an existing Trigger (#162). `mode: "run"`
- * opens Run-now mode to fire a one-off Run from the Trigger's template (the
- * guard is not executed). `mode: "edit"` opens Trigger mode bound to the
- * Trigger so submitting PATCHes it instead of creating a new one.
+ * How the always-mounted modal should open (#386). Because the modal is never
+ * unmounted (`if (!open) return null` below), its useState survives a close, so
+ * the open intent drives a one-shot reset on every reopen — a stale mode /
+ * trigger can no longer leak into a fresh open.
+ *
+ * - `run` — a plain New Run.
+ * - `new-trigger` — Trigger mode, blank, POSTs a new trigger.
+ * - `edit-trigger` — Trigger mode bound to `trigger`; submitting PATCHes it (#162).
+ *
+ * There is deliberately no "run-from-trigger" variant: since ADR-0027, "Run now"
+ * is a real fire (`POST /triggers/{id}/fire`), not a prefilled modal.
  */
-export interface TriggerPrefill {
-  trigger: Trigger;
-  mode: "run" | "edit";
-}
+export type OpenIntent =
+  | { kind: "run" }
+  | { kind: "new-trigger" }
+  | { kind: "edit-trigger"; trigger: Trigger };
+
+// Module constant: stabilises the `[open, openIntent]` dependency and serves as
+// the default on both sides (prop + destructuring) so a plain open doesn't mint
+// a new identity every render. Exported aside the component (an object constant,
+// so not covered by `allowConstantExport`); it never re-renders, so opting this
+// one line out of the Fast-Refresh rule is safe.
+// eslint-disable-next-line react-refresh/only-export-components
+export const RUN_INTENT: OpenIntent = { kind: "run" };
 
 interface Props {
   open: boolean;
   onClose: () => void;
   onCreated: (runId: string) => void;
-  prefillTrigger?: TriggerPrefill | null;
+  openIntent?: OpenIntent;
   /** Called after a trigger is created/edited so the list can refresh. */
   onTriggerSaved?: () => void;
 }
 
-export default function NewRunModal({ open, onClose, onCreated, prefillTrigger = null, onTriggerSaved }: Props) {
+export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN_INTENT, onTriggerSaved }: Props) {
   const [pipelines, setPipelines] = useState<PipelineListEntry[]>([]);
   const [selectedPipelineId, setSelectedPipelineId] = useState("");
   const [runName, setRunName] = useState("");
@@ -93,7 +108,7 @@ export default function NewRunModal({ open, onClose, onCreated, prefillTrigger =
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const prefillDone = useRef(false);
-  const triggerPrefillDone = useRef(false);
+  const openPrefillDone = useRef(false);
 
   const handleRepoChange = useCallback((value: string) => {
     setTargetRepo(value);
@@ -105,74 +120,127 @@ export default function NewRunModal({ open, onClose, onCreated, prefillTrigger =
     }
   }, []);
 
+  // #386: the modal is always-mounted (`if (!open) return null` below), so its
+  // useState survives a close. This one-shot, ref-gated effect resets the
+  // mode/trigger machine to match the open intent on every `open` false→true
+  // transition, so a stale "Edit trigger" state can't leak into a fresh "New
+  // run" / "New trigger" — and can't silently PATCH the previously edited
+  // trigger. Declared BEFORE the recent-repos effect on purpose.
   useEffect(() => {
-    // Skip the recent-repos default when prefilling from a Trigger — the
-    // Trigger's own repo wins.
-    if (open && !prefillDone.current && !prefillTrigger && recentRepos.length > 0 && !targetRepo) {
+    if (!open) {
+      openPrefillDone.current = false;
+      return;
+    }
+    if (openPrefillDone.current) return;
+    openPrefillDone.current = true;
+
+    // Provenance captured BEFORE any setEditingTriggerId(null): the shared-draft
+    // cleanup (#386 Part 2 / Finding D) must know we came from a trigger edit.
+    // This is complete because the dead run-mode prefill is gone —
+    // editingTriggerId is only ever set by an edit-trigger intent.
+    const cameFromTrigger = editingTriggerId != null;
+
+    // Any open throws away a stale guard verdict / error (#350) and a stale
+    // submit error.
+    setGuardTest(null);
+    setGuardTestError(null);
+    setError(null);
+
+    // One-shot reset: the `openPrefillDone` ref gates this to a single run per
+    // open, so the setState cascade is bounded and does not re-fire. The
+    // conditional setState calls below are deliberate (intent-dependent reset).
+    /* eslint-disable react-hooks/set-state-in-effect */
+    // Trigger-only fields: reset unconditionally on the "fresh" intents.
+    const blankTriggerFields = () => {
+      setTriggerName("");
+      setGuardCommand("");
+      setAllowOverlap(false);
+      setMaxConcurrent("");
+      setCronPresetId("daily");
+      setRawCron("");
+      setDailyHour(9);
+      setDailyMinute(0);
+    };
+    // #386 Part 2 (Finding D): only wipe the SHARED draft when we came from a
+    // trigger edit, so an ordinary New-run→New-run keeps its draft (the tested
+    // persistence). repoValid is cleared too, else the stale valid repo would
+    // auto-reselect the trigger's pipeline on the next render (:251).
+    const clearSharedIfFromTrigger = () => {
+      if (!cameFromTrigger) return;
+      setSelectedPipelineId("");
+      setInput("");
+      setOverrides({});
+      setTargetRepo("");
+      setRepoValid(null);
+      setRepoError(null);
+      setBranches([]);
+      setSourceBranch("");
+    };
+
+    switch (openIntent.kind) {
+      case "run":
+        setMode("run");
+        setEditingTriggerId(null);
+        blankTriggerFields();
+        clearSharedIfFromTrigger();
+        break;
+
+      case "new-trigger":
+        setMode("trigger");
+        setEditingTriggerId(null);
+        blankTriggerFields();
+        clearSharedIfFromTrigger();
+        break;
+
+      case "edit-trigger": {
+        const trigger = openIntent.trigger;
+        setMode("trigger");
+        setEditingTriggerId(trigger.id);
+        setSelectedPipelineId(trigger.pipeline_id);
+        setTargetRepo(trigger.target_repo ?? "");
+        setSourceBranch(trigger.source_branch ?? "");
+        setInput(trigger.input_template ?? "");
+        setOverrides(
+          Object.fromEntries(
+            Object.entries(trigger.variables ?? {}).map(([k, v]) => [k, String(v)]),
+          ),
+        );
+        setTriggerName(trigger.name);
+        setGuardCommand(trigger.guard_command ?? "");
+        // Overlap policy (#239): round-trip the real policy instead of resetting
+        // it to skip. Pre-check the box for an `allow` Trigger and fill its cap.
+        setAllowOverlap(trigger.overlap_policy === "allow");
+        setMaxConcurrent(trigger.max_concurrent != null ? String(trigger.max_concurrent) : "");
+        // Map the stored cron back onto a preset (or the raw escape hatch).
+        const preset = cronToPreset(trigger.cron);
+        setCronPresetId(preset);
+        if (preset === "custom") {
+          setRawCron(trigger.cron);
+        } else if (preset === "daily") {
+          const time = parseDailyTime(trigger.cron);
+          if (time) {
+            setDailyMinute(time.minute);
+            setDailyHour(time.hour);
+          }
+        }
+        break;
+      }
+    }
+    /* eslint-enable react-hooks/set-state-in-effect */
+  }, [open, openIntent]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    // Apply the recent-repos default only on the "fresh" intents (run /
+    // new-trigger); an edit-trigger's own repo wins, so it's excluded.
+    const freshEntry = openIntent.kind === "run" || openIntent.kind === "new-trigger";
+    if (open && !prefillDone.current && freshEntry && recentRepos.length > 0 && !targetRepo) {
       prefillDone.current = true;
       handleRepoChange(recentRepos[0]);
     }
     if (!open) {
       prefillDone.current = false;
     }
-  }, [open, recentRepos, targetRepo, handleRepoChange, prefillTrigger]);
-
-  // Prefill the form from a Trigger when opened for run-now or edit (#162).
-  useEffect(() => {
-    if (!open) {
-      triggerPrefillDone.current = false;
-      return;
-    }
-    if (triggerPrefillDone.current || !prefillTrigger) return;
-    triggerPrefillDone.current = true;
-
-    // A prefilled guard command carries no verdict yet (#350).
-    setGuardTest(null);
-    setGuardTestError(null);
-
-    // One-shot prefill: the `triggerPrefillDone` ref gates this to a single run
-    // per open, so the setState cascade is bounded and does not re-fire. The
-    // conditional setState calls below are deliberate (mode-dependent prefill).
-    /* eslint-disable react-hooks/set-state-in-effect */
-    const { trigger, mode: prefillMode } = prefillTrigger;
-    setSelectedPipelineId(trigger.pipeline_id);
-    setTargetRepo(trigger.target_repo ?? "");
-    setSourceBranch(trigger.source_branch ?? "");
-    setInput(trigger.input_template ?? "");
-    setOverrides(
-      Object.fromEntries(
-        Object.entries(trigger.variables ?? {}).map(([k, v]) => [k, String(v)]),
-      ),
-    );
-
-    if (prefillMode === "edit") {
-      setMode("trigger");
-      setEditingTriggerId(trigger.id);
-      setTriggerName(trigger.name);
-      setGuardCommand(trigger.guard_command ?? "");
-      // Overlap policy (#239): round-trip the real policy instead of resetting it
-      // to skip. Pre-check the box for an `allow` Trigger and fill its cap.
-      setAllowOverlap(trigger.overlap_policy === "allow");
-      setMaxConcurrent(trigger.max_concurrent != null ? String(trigger.max_concurrent) : "");
-      // Map the stored cron back onto a preset (or the raw escape hatch).
-      const preset = cronToPreset(trigger.cron);
-      setCronPresetId(preset);
-      if (preset === "custom") {
-        setRawCron(trigger.cron);
-      } else if (preset === "daily") {
-        const time = parseDailyTime(trigger.cron);
-        if (time) {
-          setDailyMinute(time.minute);
-          setDailyHour(time.hour);
-        }
-      }
-    } else {
-      // Run-now: fire a one-off Run from the template; never touch the guard.
-      setMode("run");
-      setEditingTriggerId(null);
-    }
-    /* eslint-enable react-hooks/set-state-in-effect */
-  }, [open, prefillTrigger]);
+  }, [open, recentRepos, targetRepo, handleRepoChange, openIntent]);
 
   useEffect(() => {
     if (!open || !targetRepo.trim()) return;


### PR DESCRIPTION
Closes #386.

## What

The always-mounted `NewRunModal` (`if (!open) return null`) kept its `useState` across a close, so a dismissed **Edit Trigger** leaked its `mode`/`editingTriggerId` into the next **New Run** / **New Trigger** — wrong header/footer, and a silent PATCH of the previously-edited trigger (Finding B).

Fix (Shape A): replace the `open` prop with a discriminated union `OpenIntent = run | new-trigger | edit-trigger{trigger}` plus a single one-shot, ref-gated reset effect that re-aligns state to the intent on every `open` false→true transition. Trigger-only fields reset unconditionally on the fresh intents; the shared Run draft (prompt/repo/pipeline/images) is preserved and only cleared when reopening after a trigger edit (Part 2 / Finding D). The dead run-mode prefill path (ADR-0027) is removed.

## Validation

- `npm run lint` / `tsc -b && vite build` — clean
- `vitest run` — **1295/1295** (65/65 on `NewRunModal.test.tsx`)
- Agentic (Visual ID) on a live isolated stack: New Run / New Trigger / Edit round-trip all confirmed; no silent PATCH, shared draft cleared as specified, non-regression on Edit prefill.

Frontend-only + workspace version bump to **v0.1.94**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)