### PR TITLE
feat(#377): stats modal — cross-run aggregates filterable by period — v0.1.97

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -496,6 +496,28 @@ Le panneau d'info d'un Run expose un petit bloc de stats (cf. #100, #272). **Qua
 - **LOC** (lignes changées par le Run) : `git diff --numstat` en **trois-points** (`HEAD...pdo/run-<run-id>`) — la base est le **point de fork** (merge-base), donc stable même si `main` avance (un diff deux-points dériverait). **Exclut `.pdo/`** (artefacts/prompts générés ne sont pas du code produit ; protégé par `.gitignore` mais un pathspec `:(exclude).pdo/` défensif couvre les repos cibles externes). **Dérivé du git, live-only** : la branche `pdo/run-<run-id>` est supprimée au cleanup → la stat affiche **« — »** pour un Run archivé/nettoyé (branche absente = `None`), à distinguer de **« 0 »** (diff réellement vide). Même schéma que le snapshot de pane qui survit au reap.
 - **Coût (est.)** : `Some { usd, partial }` **dérivé à la lecture**, jamais persisté (comme LOC), dans `run_cost::compute_run_cost`. Agrège TOUTES les sessions du Run (nœuds, manager, merge-resolver, subagents) via prefix-glob sur `~/.claude/projects/`. `None` → « — » quand aucun transcript n'est trouvé. **Plus durable que LOC** : le cleanup supprime la branche (LOC → « — ») mais **pas** `~/.claude/projects/`, donc un Run archivé garde son coût. `partial: true` (un modèle non tarifé a contribué, donc exclu) → borne basse, signalée par un « † » dans l'UI. Encodeur de chemin **propre** (`cc_project_dirname`), volontairement distinct de `stale_detector::encode_working_dir` (bogué, à corriger séparément — cf. ADR-0022 et le doc-comment).
 
+### Statistiques d'instance (cockpit, #377)
+
+Modale **Stats** (sœur de Settings, icône dédiée dans le TopBar) : agrégats **transverses** filtrables
+par période, à distinguer des **Statistiques de Run** (par-run, panneau d'info). Dérivés à la lecture,
+**jamais matérialisés** (ADR-0029, préserve ADR-0022) :
+
+- **Deux endpoints** : `GET /stats/overview` (SQL bon marché, index `events(kind,ts)` +
+  `trigger_fires(ts)`) et `GET /stats/cost` (lourd, lazy, memo RAM `(run_id, mtime-max)`).
+- **Runs/erreurs/sessions par période** : `GROUP BY strftime` sur `events` — erreurs = `run_failed`
+  (`run_skipped` **exclu**), sessions = `node_started` (démarrages, re-spawns inclus, manager exclu).
+- **Fires par pipeline** : `LEFT JOIN triggers` sur `pipeline_id` — un fire orphelin (trigger
+  supprimé, pas de cascade) tombe dans « (deleted trigger) ». **Triggers ayant créé un run** =
+  `outcome='fired'` (⟺ `run_id` non-null) ; KPI = N distincts sur M activés.
+- **Coût par période/pipeline/projet** : scalaire par-run (ADR-0022) **plié côté app** — « par
+  pipeline » via `pipeline_id` (sinon `pipeline_name`), « par projet » via `effective_repo` (pas de
+  bucket « Unassigned », cf. *Repo cible*). **Somme de bornes basses** : un bucket avec ≥ 1 run
+  `partial` est borne-basse (`†`) ; les runs sans transcript sont exclus de la somme mais comptés
+  (`null`), un bucket sans coût calculable affiche « — » (jamais `$0`).
+- **`pipeline_id` dans `RunStarted`** (fallback `pipeline_name`) : « par pipeline » survit à un
+  renommage (cf. #230). La période est un état de vue **côté client** (pas `instance_config`). La
+  bibliothèque de graphes (recharts) est **lazy-loaded** (premier `React.lazy` du repo).
+
 ### Diff de Run (surface de relecture)
 
 Le panneau d'info d'un Run expose une section **Diff** repliable (#116, #376) qui rend le patch git du Run comme surface de relecture — distincte de la stat **LOC** (qui n'en compte que les lignes) et du **diff sémantique** (comparaison de pipelines, star synced/diverged). Trois portées :

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "0.1.96"
+version = "0.1.97"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "0.1.96"
+version = "0.1.97"
 license = "MIT"
 
 [workspace.dependencies]

--- a/crates/pdo-daemon/src/event_log.rs
+++ b/crates/pdo-daemon/src/event_log.rs
@@ -371,6 +371,13 @@ pub struct RunState {
     /// Provenance: the id of the Trigger that created this Run, if any.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub triggered_by: Option<String>,
+    /// The library pipeline id this Run was created from (#377). Written to the
+    /// `RunStarted` payload going forward; consumers (aggregated "by pipeline"
+    /// stats) fall back to `pipeline_name` when it is absent — historical runs,
+    /// bare-API/multipart creates, retries — so grouping survives a rename
+    /// (#230). Additive and backward-compatible.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pipeline_id: Option<String>,
     /// Cumulative count of `NodeStarted` events for this Run — i.e. how many
     /// Claude Code NodeRun sessions it spawned (issue #100). A **raw** count,
     /// not deduplicated by `(node, iter)`: a legal re-spawn at the same
@@ -415,6 +422,7 @@ impl RunState {
             target_repo: None,
             source_branch: None,
             triggered_by: None,
+            pipeline_id: None,
             sessions_spawned: 0,
             loc: None,
             cost: None,
@@ -670,6 +678,9 @@ fn apply_run_event(state: &mut RunState, event: &Event) {
                 }
                 if let Some(tb) = payload.get("triggered_by").and_then(|v| v.as_str()) {
                     state.triggered_by = Some(tb.to_string());
+                }
+                if let Some(pid) = payload.get("pipeline_id").and_then(|v| v.as_str()) {
+                    state.pipeline_id = Some(pid.to_string());
                 }
 
                 let input_images = payload
@@ -4005,6 +4016,7 @@ mod tests {
                 "2026-02-01T00:00:00.000Z",
                 Some(serde_json::json!({
                     "pipeline_name": "golden-pipe",
+                    "pipeline_id": "lib-golden-pipe",
                     "name": "Golden Run",
                     "input": "exercise every concern",
                     "image_filenames": ["screenshot.png"],
@@ -4468,6 +4480,7 @@ mod tests {
                     "node_id": "worker", "started_at": "2026-02-01T00:02:02.000Z", "status": "completed"
                 }
             },
+            "pipeline_id": "lib-golden-pipe",
             "pipeline_name": "golden-pipe",
             "run_id": "run-golden",
             "sessions_spawned": 8,

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -37,6 +37,7 @@ mod scheduler_dispatcher;
 mod scheduler_interpreter;
 mod service_unit;
 pub mod stale_detector;
+mod stats;
 mod switch_router;
 pub mod tmux_session_manager;
 pub mod transition_guard;
@@ -2888,6 +2889,13 @@ fn build_router(state: Arc<AppState>) -> Router {
         // {effective, source, stored, env, default} view; `PUT` writes the
         // stored tier (fail-fast validation).
         .route("/settings", get(get_settings).put(put_settings))
+        // Instance stats cockpit (#377, ADR-0029). New top-level `/stats` prefix
+        // → added to the vite dev proxy whitelist so a dev-mode GET hits the
+        // daemon instead of the SPA fallback. `overview` is cheap indexed SQL;
+        // `cost` fans the memoized per-run cost over the visible period (lazy,
+        // fetched only when the cost tab is shown).
+        .route("/stats/overview", get(stats::stats_overview))
+        .route("/stats/cost", get(stats::stats_cost))
         .route(
             "/triggers/{trigger_id}",
             get(get_trigger).patch(patch_trigger).delete(delete_trigger),
@@ -2915,6 +2923,16 @@ async fn init_db(db: &sqlx::SqlitePool) -> Result<()> {
     .execute(db)
     .await
     .context("failed to create events table")?;
+
+    // #377 / ADR-0029: the daemon's first index. `GET /stats/overview` runs
+    // `WHERE kind = ? AND ts >= ? AND ts < ? GROUP BY strftime(...)` over
+    // `events`; the composite `(kind, ts)` is leftmost-prefix optimal for it.
+    // `CREATE INDEX IF NOT EXISTS` is natively idempotent, so it needs no PRAGMA
+    // guard (unlike the `ALTER … ADD COLUMN` migrations in `trigger_store`).
+    sqlx::query("CREATE INDEX IF NOT EXISTS idx_events_kind_ts ON events(kind, ts)")
+        .execute(db)
+        .await
+        .context("failed to create idx_events_kind_ts")?;
 
     // #328 / ADR-0024: tombstones for forgotten runs — a run_id present here
     // can never receive events again (guard in `append_event`).
@@ -5664,6 +5682,15 @@ async fn create_run_inner(
     if let Some(ref trigger_id) = req.triggered_by {
         if !trigger_id.is_empty() {
             run_payload["triggered_by"] = serde_json::json!(trigger_id);
+        }
+    }
+    // #377: carry the library pipeline id in the payload (mirrors `triggered_by`)
+    // so aggregated "by pipeline" stats survive a pipeline rename (#230). The
+    // consumer falls back to `pipeline_name` when this is absent (historical
+    // runs, bare-API/multipart creates without a library id, retries).
+    if let Some(ref pid) = req.pipeline_id {
+        if !pid.is_empty() {
+            run_payload["pipeline_id"] = serde_json::json!(pid);
         }
     }
     if !images.is_empty() {
@@ -9319,7 +9346,10 @@ async fn run_command(
                 pipeline: pipeline_name,
                 input,
                 variables,
-                pipeline_id: None,
+                // #377: preserve the library pipeline id (when the original run
+                // carried one) so the retried run stays in the same "by pipeline"
+                // stats bucket rather than falling back to the name.
+                pipeline_id: run_state.pipeline_id.clone(),
                 target_repo,
                 source_branch,
                 name: None,

--- a/crates/pdo-daemon/src/run_cost.rs
+++ b/crates/pdo-daemon/src/run_cost.rs
@@ -27,7 +27,10 @@
 //!   was observed) are skipped line-by-line, never `?`-propagated.
 
 use crate::event_log::CostStat;
+use std::collections::HashMap;
 use std::path::Path;
+use std::sync::{Mutex, OnceLock};
+use std::time::UNIX_EPOCH;
 
 // Source: https://platform.claude.com/docs/en/about-claude/pricing (fetched 2026-07-06).
 // Per-MTok list prices `(family_key, input, output)`. UPDATE when Anthropic
@@ -254,6 +257,111 @@ pub fn compute_run_cost(repo_root: &Path, run_id: &str) -> Option<CostStat> {
         return None;
     }
     Some(aggregate(lines.into_iter()))
+}
+
+// --- Read-side memo for the aggregate cost path (#377 / ADR-0029) ------------
+//
+// The Stats modal's `/stats/cost` endpoint fans [`compute_run_cost`] out over
+// every run in the visible period — the exact anti-fan-out ADR-0022 kept off the
+// `/runs` list handler. This memo is ADR-0022's *sanctioned escape hatch*: a
+// derive-on-read RAM cache keyed on `(run_id, max transcript mtime)`, NEVER
+// persisted (no snapshot table, no metric-freezing event). A transcript change
+// bumps the mtime and so invalidates the entry naturally. It is touched ONLY by
+// [`compute_run_cost_cached`] (the aggregate path); `get_run`'s single-run read
+// keeps calling [`compute_run_cost`] directly, so ADR-0022's per-read contract
+// is byte-identical there.
+
+/// Memo key: `(run_id, max transcript mtime in epoch millis)`. A transcript
+/// change bumps the mtime, so the key changes and the old entry is bypassed.
+type CostMemoKey = (String, i64);
+/// The memoized value is exactly what [`compute_run_cost`] returns (`None` = no
+/// transcript dir), so a hit is byte-identical to a recompute.
+type CostMemoMap = HashMap<CostMemoKey, Option<CostStat>>;
+
+static COST_MEMO: OnceLock<Mutex<CostMemoMap>> = OnceLock::new();
+
+/// Soft cap on memo entries. On overflow the whole map is cleared — dropping the
+/// cache is correctness-preserving (a miss just recomputes), so this bounds RAM
+/// without pulling in an `lru` crate. `CostStat` is 16 bytes, so this is roomy.
+const COST_MEMO_CAP: usize = 4096;
+
+fn cost_memo() -> &'static Mutex<CostMemoMap> {
+    COST_MEMO.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Recurse a project dir, folding the max `*.jsonl` mtime (epoch millis) into
+/// `max_ms`. Mirrors [`collect_jsonl_recursive`]'s traversal but `stat`s only —
+/// no file contents are read.
+fn max_mtime_recursive(dir: &Path, max_ms: &mut i64) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            max_mtime_recursive(&path, max_ms);
+        } else if path.extension().and_then(|e| e.to_str()) == Some("jsonl") {
+            if let Ok(ms) = entry
+                .metadata()
+                .and_then(|m| m.modified())
+                .map(|t| t.duration_since(UNIX_EPOCH).unwrap_or_default().as_millis() as i64)
+            {
+                if ms > *max_ms {
+                    *max_ms = ms;
+                }
+            }
+        }
+    }
+}
+
+/// Max mtime (epoch millis) across every `*.jsonl` transcript that contributes
+/// to `run_id`'s cost — the same recursive glob [`compute_run_cost`] aggregates.
+/// `0` when no transcript dir/file exists yet (so a later write bumps the key and
+/// invalidates the memo). A pure `stat` walk: no file contents are read, so it is
+/// far cheaper than the aggregate it guards.
+pub fn max_transcript_mtime_millis(repo_root: &Path, run_id: &str) -> i64 {
+    let Ok(home) = std::env::var("HOME") else {
+        return 0;
+    };
+    let run_dir = repo_root.join(".pdo").join("runs").join(run_id);
+    let prefix = format!("{}-", cc_project_dirname(&run_dir));
+    let projects = Path::new(&home).join(".claude").join("projects");
+    let Ok(entries) = std::fs::read_dir(&projects) else {
+        return 0;
+    };
+    let mut max_ms: i64 = 0;
+    for entry in entries.flatten() {
+        if !entry.file_name().to_string_lossy().starts_with(&prefix) {
+            continue;
+        }
+        max_mtime_recursive(&entry.path(), &mut max_ms);
+    }
+    max_ms
+}
+
+/// Memoized [`compute_run_cost`]: byte-identical result, cached on
+/// `(run_id, max transcript mtime)` (see the module memo above). Used only by
+/// the `/stats/cost` aggregate (period-bounded fan-out); `get_run`'s single-run
+/// path is deliberately left calling [`compute_run_cost`] directly so ADR-0022's
+/// per-read contract is unchanged.
+pub fn compute_run_cost_cached(repo_root: &Path, run_id: &str) -> Option<CostStat> {
+    let key = (
+        run_id.to_string(),
+        max_transcript_mtime_millis(repo_root, run_id),
+    );
+    {
+        let guard = cost_memo().lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(hit) = guard.get(&key) {
+            return hit.clone();
+        }
+    }
+    let value = compute_run_cost(repo_root, run_id);
+    let mut guard = cost_memo().lock().unwrap_or_else(|e| e.into_inner());
+    if guard.len() >= COST_MEMO_CAP {
+        guard.clear();
+    }
+    guard.insert(key, value.clone());
+    value
 }
 
 #[cfg(test)]
@@ -576,6 +684,129 @@ mod tests {
         let _home = TempHome::new();
         let repo = tempfile::tempdir().unwrap();
         assert!(compute_run_cost(repo.path(), "no-such-run").is_none());
+    }
+
+    // --- compute_run_cost_cached / memo (#377) ---
+
+    /// Write a single-line transcript for `run_id`'s worktree and return the
+    /// `.jsonl` path so the test can manipulate its mtime.
+    fn seed_transcript(home: &Path, repo: &Path, run_id: &str, line: &str) -> std::path::PathBuf {
+        let worktree = repo.join(".pdo").join("runs").join(run_id).join("worktree");
+        let proj = home
+            .join(".claude")
+            .join("projects")
+            .join(cc_project_dirname(&worktree));
+        std::fs::create_dir_all(&proj).unwrap();
+        let file = proj.join("s.jsonl");
+        std::fs::write(&file, format!("{line}\n")).unwrap();
+        file
+    }
+
+    #[test]
+    fn cached_matches_uncached() {
+        let home = TempHome::new();
+        let repo = tempfile::tempdir().unwrap();
+        let run_id = "memo-eq";
+        seed_transcript(
+            home.path(),
+            repo.path(),
+            run_id,
+            &assistant("m1", "r1", "claude-opus-4-8", 1_000_000, 0),
+        );
+        let direct = compute_run_cost(repo.path(), run_id);
+        let cached = compute_run_cost_cached(repo.path(), run_id);
+        assert_eq!(direct, cached);
+        assert!((cached.unwrap().usd - 5.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn cached_re_serves_from_memo_when_mtime_is_unchanged() {
+        let home = TempHome::new();
+        let repo = tempfile::tempdir().unwrap();
+        let run_id = "memo-hit";
+        let file = seed_transcript(
+            home.path(),
+            repo.path(),
+            run_id,
+            &assistant("m1", "r1", "claude-opus-4-8", 1_000_000, 0),
+        );
+        let orig =
+            filetime::FileTime::from_last_modification_time(&std::fs::metadata(&file).unwrap());
+
+        // First call: memoize $5 under (run_id, mtime).
+        let first = compute_run_cost_cached(repo.path(), run_id).unwrap();
+        assert!((first.usd - 5.0).abs() < 1e-9);
+
+        // Rewrite with a DIFFERENT cost ($10) but force the mtime back — the key
+        // is unchanged, so the memo must re-serve the stale $5.
+        std::fs::write(
+            &file,
+            format!(
+                "{}\n",
+                assistant("m2", "r2", "claude-opus-4-8", 2_000_000, 0)
+            ),
+        )
+        .unwrap();
+        filetime::set_file_mtime(&file, orig).unwrap();
+        let hit = compute_run_cost_cached(repo.path(), run_id).unwrap();
+        assert!((hit.usd - 5.0).abs() < 1e-9, "memo hit should re-serve $5");
+        // But the uncached path sees the new content ($10) — proving the file
+        // really changed and the hit above was the cache, not a recompute.
+        let direct = compute_run_cost(repo.path(), run_id).unwrap();
+        assert!((direct.usd - 10.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn cached_recomputes_when_mtime_bumps() {
+        let home = TempHome::new();
+        let repo = tempfile::tempdir().unwrap();
+        let run_id = "memo-bump";
+        let file = seed_transcript(
+            home.path(),
+            repo.path(),
+            run_id,
+            &assistant("m1", "r1", "claude-opus-4-8", 1_000_000, 0),
+        );
+        let orig =
+            filetime::FileTime::from_last_modification_time(&std::fs::metadata(&file).unwrap());
+        let first = compute_run_cost_cached(repo.path(), run_id).unwrap();
+        assert!((first.usd - 5.0).abs() < 1e-9);
+
+        // New content AND a bumped mtime → new key → recompute picks up $10.
+        std::fs::write(
+            &file,
+            format!(
+                "{}\n",
+                assistant("m2", "r2", "claude-opus-4-8", 2_000_000, 0)
+            ),
+        )
+        .unwrap();
+        let bumped = filetime::FileTime::from_unix_time(orig.unix_seconds() + 10, 0);
+        filetime::set_file_mtime(&file, bumped).unwrap();
+        let recomputed = compute_run_cost_cached(repo.path(), run_id).unwrap();
+        assert!(
+            (recomputed.usd - 10.0).abs() < 1e-9,
+            "a bumped mtime must invalidate the memo"
+        );
+    }
+
+    #[test]
+    fn max_transcript_mtime_is_zero_without_a_transcript_and_positive_with_one() {
+        let home = TempHome::new();
+        let repo = tempfile::tempdir().unwrap();
+        assert_eq!(
+            max_transcript_mtime_millis(repo.path(), "no-such-run"),
+            0,
+            "no transcript dir → 0 (so a later write bumps the key)"
+        );
+        let run_id = "mtime-run";
+        seed_transcript(
+            home.path(),
+            repo.path(),
+            run_id,
+            &assistant("m1", "r1", "claude-opus-4-8", 1000, 0),
+        );
+        assert!(max_transcript_mtime_millis(repo.path(), run_id) > 0);
     }
 
     #[test]

--- a/crates/pdo-daemon/src/stats.rs
+++ b/crates/pdo-daemon/src/stats.rs
@@ -1,0 +1,680 @@
+//! Instance-stats cockpit (#377, ADR-0029): cross-run, period-filterable
+//! aggregates for the Stats modal. Two endpoints split by cost class:
+//!
+//! - [`stats_overview`] — **Class A**, cheap indexed SQL. Runs/errors/sessions
+//!   per period (`GROUP BY strftime` over `events`, backed by
+//!   `idx_events_kind_ts`), fires per pipeline (`LEFT JOIN triggers`, backed by
+//!   `idx_trigger_fires_ts`), and the "triggers that created a run" KPI.
+//! - [`stats_cost`] — **Class B**, heavy. Enumerates the `run_started` events in
+//!   the period, resolves each run's estimated cost through the memoized
+//!   [`crate::run_cost::compute_run_cost_cached`], and folds the per-run scalars
+//!   app-side into by-period / by-pipeline / by-project buckets (cost has no
+//!   pipeline/project dimension in SQL, and "by project" needs the
+//!   `effective_repo_root` runtime fallback).
+//!
+//! Everything is derived on read — no snapshot table, no metric-freezing event
+//! (preserves ADR-0022). Aggregated cost is a **sum of lower bounds**: partial
+//! runs (an unpriced model) and null-cost runs (no transcript) are counted
+//! separately so a bucket is never silently undercounted (ADR-0001 honesty).
+
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use axum::extract::{Query, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use serde::{Deserialize, Serialize};
+
+use crate::event_log::CostStat;
+use crate::AppState;
+
+/// Query string shared by both endpoints: an ISO-8601 `[from, to)` window and a
+/// bucket granularity. Mirrors the `State + Query` signature of
+/// `list_reapable_runs`, but the body is indexed aggregate SQL, not per-run
+/// replay.
+#[derive(Debug, Deserialize)]
+pub struct StatsQuery {
+    /// Inclusive lower bound (ISO-8601, e.g. `2026-07-15T00:00:00Z`).
+    pub from: String,
+    /// Exclusive upper bound.
+    pub to: String,
+    /// `day` | `week` | `month`.
+    pub bucket: String,
+}
+
+/// Map a bucket granularity to its SQLite `strftime` format. `None` for an
+/// unknown granularity (the handler answers `400`).
+fn strftime_fmt(bucket: &str) -> Option<&'static str> {
+    match bucket {
+        "day" => Some("%Y-%m-%d"),
+        "week" => Some("%Y-W%W"),
+        "month" => Some("%Y-%m"),
+        _ => None,
+    }
+}
+
+// --- Overview (Class A) ------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct BucketCount {
+    pub bucket: String,
+    pub count: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct PipelineFireCount {
+    /// The trigger's `pipeline_id`, or `"(deleted trigger)"` for an orphan fire
+    /// (the trigger row was deleted; there is no cascade, so the fire survives
+    /// and must be surfaced, never dropped — hence the `LEFT JOIN`).
+    pub pipeline_id: String,
+    pub count: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct TriggersCreatedRuns {
+    /// Fires whose `outcome = 'fired'` (⟺ a run was created) in the window.
+    pub fired: i64,
+    /// Distinct triggers that fired at least once in the window.
+    pub distinct_triggers: i64,
+    /// Triggers currently `enabled` (a point-in-time count, not windowed).
+    pub enabled_triggers: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct StatsOverview {
+    /// Sorted union of period labels across runs/errors/sessions — the ordered
+    /// x-axis the client renders against.
+    pub buckets: Vec<String>,
+    pub runs: Vec<BucketCount>,
+    pub errors: Vec<BucketCount>,
+    pub sessions: Vec<BucketCount>,
+    pub fires_by_pipeline: Vec<PipelineFireCount>,
+    pub triggers_created_runs: TriggersCreatedRuns,
+}
+
+/// Count events of one `kind` per period bucket. Backed by `idx_events_kind_ts`.
+async fn count_events_by_bucket(
+    db: &sqlx::SqlitePool,
+    fmt: &str,
+    kind: &str,
+    from: &str,
+    to: &str,
+) -> Result<Vec<BucketCount>, sqlx::Error> {
+    let rows = sqlx::query_as::<_, (String, i64)>(
+        "SELECT strftime(?, ts) AS bucket, COUNT(*) AS count \
+         FROM events WHERE kind = ? AND ts >= ? AND ts < ? \
+         GROUP BY bucket ORDER BY bucket",
+    )
+    .bind(fmt)
+    .bind(kind)
+    .bind(from)
+    .bind(to)
+    .fetch_all(db)
+    .await?;
+    Ok(rows
+        .into_iter()
+        .map(|(bucket, count)| BucketCount { bucket, count })
+        .collect())
+}
+
+/// Fires per pipeline in the window. `LEFT JOIN` so an orphan fire (deleted
+/// trigger — no cascade) still counts, bucketed as `"(deleted trigger)"`.
+async fn fires_by_pipeline(
+    db: &sqlx::SqlitePool,
+    from: &str,
+    to: &str,
+) -> Result<Vec<PipelineFireCount>, sqlx::Error> {
+    let rows = sqlx::query_as::<_, (String, i64)>(
+        "SELECT COALESCE(t.pipeline_id, '(deleted trigger)') AS pk, COUNT(*) AS count \
+         FROM trigger_fires f LEFT JOIN triggers t ON f.trigger_id = t.id \
+         WHERE f.ts >= ? AND f.ts < ? \
+         GROUP BY pk ORDER BY count DESC, pk",
+    )
+    .bind(from)
+    .bind(to)
+    .fetch_all(db)
+    .await?;
+    Ok(rows
+        .into_iter()
+        .map(|(pipeline_id, count)| PipelineFireCount { pipeline_id, count })
+        .collect())
+}
+
+/// The "triggers that created a run" KPI: fired count, distinct fired triggers,
+/// and the current enabled-trigger count.
+async fn triggers_created_runs(
+    db: &sqlx::SqlitePool,
+    from: &str,
+    to: &str,
+) -> Result<TriggersCreatedRuns, sqlx::Error> {
+    let (fired, distinct_triggers, enabled_triggers) = sqlx::query_as::<_, (i64, i64, i64)>(
+        "SELECT \
+           (SELECT COUNT(*) FROM trigger_fires WHERE outcome = 'fired' AND ts >= ?1 AND ts < ?2) AS fired, \
+           (SELECT COUNT(DISTINCT trigger_id) FROM trigger_fires WHERE outcome = 'fired' AND ts >= ?1 AND ts < ?2) AS distinct_triggers, \
+           (SELECT COUNT(*) FROM triggers WHERE enabled = 1) AS enabled_triggers",
+    )
+    .bind(from)
+    .bind(to)
+    .fetch_one(db)
+    .await?;
+    Ok(TriggersCreatedRuns {
+        fired,
+        distinct_triggers,
+        enabled_triggers,
+    })
+}
+
+/// Assemble the full overview payload (testable without an `AppState`).
+async fn compute_overview(
+    db: &sqlx::SqlitePool,
+    fmt: &str,
+    from: &str,
+    to: &str,
+) -> Result<StatsOverview, sqlx::Error> {
+    // `run_skipped` is NOT an error (invariant #4): errors = `run_failed` only.
+    let runs = count_events_by_bucket(db, fmt, "run_started", from, to).await?;
+    let errors = count_events_by_bucket(db, fmt, "run_failed", from, to).await?;
+    // Sessions = `node_started` starts (re-spawns and loop laps included, manager
+    // excluded by construction) — the same cumulative count as the per-run stat.
+    let sessions = count_events_by_bucket(db, fmt, "node_started", from, to).await?;
+    let fires = fires_by_pipeline(db, from, to).await?;
+    let created = triggers_created_runs(db, from, to).await?;
+
+    let mut labels: BTreeSet<String> = BTreeSet::new();
+    for series in [&runs, &errors, &sessions] {
+        for row in series {
+            labels.insert(row.bucket.clone());
+        }
+    }
+
+    Ok(StatsOverview {
+        buckets: labels.into_iter().collect(),
+        runs,
+        errors,
+        sessions,
+        fires_by_pipeline: fires,
+        triggers_created_runs: created,
+    })
+}
+
+/// `GET /stats/overview` — Class A cheap indexed SQL.
+pub async fn stats_overview(
+    State(state): State<Arc<AppState>>,
+    Query(q): Query<StatsQuery>,
+) -> Response {
+    let Some(fmt) = strftime_fmt(&q.bucket) else {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": format!("invalid bucket: {}", q.bucket) })),
+        )
+            .into_response();
+    };
+    match compute_overview(&state.db, fmt, &q.from, &q.to).await {
+        Ok(overview) => Json(overview).into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({ "error": format!("stats overview failed: {e}") })),
+        )
+            .into_response(),
+    }
+}
+
+// --- Cost (Class B) ----------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct CostPeriodBucket {
+    pub bucket: String,
+    /// Sum of priced per-run costs (a lower bound — see `partial`/`null`).
+    pub usd: f64,
+    /// Runs in this bucket whose cost is a lower bound (an unpriced model).
+    pub partial: i64,
+    /// Runs in this bucket with no transcript (excluded from `usd`, surfaced so
+    /// the bucket is never silently undercounted). Serialized as `"null"`.
+    #[serde(rename = "null")]
+    pub null_count: i64,
+    /// Total runs folded into this bucket (priced + partial + null).
+    pub runs: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct CostKeyBucket {
+    pub key: String,
+    pub usd: f64,
+    pub partial: i64,
+    #[serde(rename = "null")]
+    pub null_count: i64,
+    pub runs: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct StatsCost {
+    pub by_period: Vec<CostPeriodBucket>,
+    pub by_pipeline: Vec<CostKeyBucket>,
+    pub by_project: Vec<CostKeyBucket>,
+}
+
+/// One run's contribution to the cost fold: its period bucket, pipeline key,
+/// project key, and resolved cost (`None` = no transcript).
+struct CostRow {
+    bucket: String,
+    pipeline: String,
+    project: String,
+    cost: Option<CostStat>,
+}
+
+#[derive(Default, Clone)]
+struct CostAcc {
+    usd: f64,
+    partial: i64,
+    null_count: i64,
+    runs: i64,
+}
+
+impl CostAcc {
+    fn add(&mut self, cost: &Option<CostStat>) {
+        self.runs += 1;
+        match cost {
+            Some(c) => {
+                self.usd += c.usd;
+                if c.partial {
+                    self.partial += 1;
+                }
+            }
+            None => self.null_count += 1,
+        }
+    }
+}
+
+/// Fold per-run cost rows into the three categorical breakdowns. Pure — the
+/// handler does the DB enumeration and cost resolution, this only accumulates,
+/// so it is unit-testable with synthetic rows.
+fn fold_cost(rows: &[CostRow]) -> StatsCost {
+    use std::collections::HashMap;
+    let mut by_period: HashMap<&str, CostAcc> = HashMap::new();
+    let mut by_pipeline: HashMap<&str, CostAcc> = HashMap::new();
+    let mut by_project: HashMap<&str, CostAcc> = HashMap::new();
+    for r in rows {
+        by_period.entry(&r.bucket).or_default().add(&r.cost);
+        by_pipeline.entry(&r.pipeline).or_default().add(&r.cost);
+        by_project.entry(&r.project).or_default().add(&r.cost);
+    }
+
+    // by_period sorts by label (chronological); the categorical axes sort by
+    // spend desc, then key, for a stable, meaningful order.
+    let mut period: Vec<CostPeriodBucket> = by_period
+        .into_iter()
+        .map(|(bucket, a)| CostPeriodBucket {
+            bucket: bucket.to_string(),
+            usd: a.usd,
+            partial: a.partial,
+            null_count: a.null_count,
+            runs: a.runs,
+        })
+        .collect();
+    period.sort_by(|a, b| a.bucket.cmp(&b.bucket));
+
+    let to_key_buckets = |map: HashMap<&str, CostAcc>| {
+        let mut v: Vec<CostKeyBucket> = map
+            .into_iter()
+            .map(|(key, a)| CostKeyBucket {
+                key: key.to_string(),
+                usd: a.usd,
+                partial: a.partial,
+                null_count: a.null_count,
+                runs: a.runs,
+            })
+            .collect();
+        v.sort_by(|a, b| {
+            b.usd
+                .partial_cmp(&a.usd)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| a.key.cmp(&b.key))
+        });
+        v
+    };
+
+    StatsCost {
+        by_period: period,
+        by_pipeline: to_key_buckets(by_pipeline),
+        by_project: to_key_buckets(by_project),
+    }
+}
+
+/// `GET /stats/cost` — Class B, memo + app-side fold. Heavy (fans over the
+/// `~/.claude` corpus); fetched lazily by the client only when the cost tab is
+/// shown.
+pub async fn stats_cost(
+    State(state): State<Arc<AppState>>,
+    Query(q): Query<StatsQuery>,
+) -> Response {
+    let Some(fmt) = strftime_fmt(&q.bucket) else {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": format!("invalid bucket: {}", q.bucket) })),
+        )
+            .into_response();
+    };
+
+    // Cheap SQL: every `run_started` in the window, with its period bucket
+    // (identical strftime to the overview endpoint) and payload.
+    let rows = match sqlx::query_as::<_, (String, String, Option<String>)>(
+        "SELECT run_id, strftime(?, ts) AS bucket, payload \
+         FROM events WHERE kind = 'run_started' AND ts >= ? AND ts < ? ORDER BY ts",
+    )
+    .bind(fmt)
+    .bind(&q.from)
+    .bind(&q.to)
+    .fetch_all(&state.db)
+    .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": format!("stats cost failed: {e}") })),
+            )
+                .into_response();
+        }
+    };
+
+    let mut cost_rows: Vec<CostRow> = Vec::with_capacity(rows.len());
+    for (run_id, bucket, payload) in rows {
+        let payload: serde_json::Value = payload
+            .as_deref()
+            .and_then(|p| serde_json::from_str(p).ok())
+            .unwrap_or(serde_json::Value::Null);
+
+        // Pipeline key: `pipeline_id` going forward (#377), else the (always
+        // present) `pipeline_name` — so grouping survives a rename (#230).
+        let pipeline = payload
+            .get("pipeline_id")
+            .and_then(|v| v.as_str())
+            .or_else(|| payload.get("pipeline_name").and_then(|v| v.as_str()))
+            .unwrap_or("(unknown)")
+            .to_string();
+
+        // "By project" = `effective_repo_root`: the run's `target_repo`, else the
+        // daemon repo root. No "Unassigned" bucket (invariant #6, #258).
+        let target_repo = payload.get("target_repo").and_then(|v| v.as_str());
+        let repo_root: PathBuf = target_repo
+            .map(PathBuf::from)
+            .unwrap_or_else(|| state.repo_root.clone());
+        let project = repo_root.to_string_lossy().into_owned();
+
+        let cost = crate::run_cost::compute_run_cost_cached(&repo_root, &run_id);
+        cost_rows.push(CostRow {
+            bucket,
+            pipeline,
+            project,
+            cost,
+        });
+    }
+
+    Json(fold_cost(&cost_rows)).into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn mem_db() -> sqlx::SqlitePool {
+        let db = sqlx::sqlite::SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .unwrap();
+        crate::init_db(&db).await.unwrap();
+        db
+    }
+
+    /// Insert a `run_started` + a terminal event for a run.
+    async fn seed_run(
+        db: &sqlx::SqlitePool,
+        run_id: &str,
+        pipeline_name: &str,
+        target_repo: &str,
+        day: &str,
+        terminal: &str,
+    ) {
+        let payload =
+            serde_json::json!({ "pipeline_name": pipeline_name, "target_repo": target_repo })
+                .to_string();
+        sqlx::query(
+            "INSERT INTO events (run_id, ts, kind, payload) VALUES (?, ?, 'run_started', ?)",
+        )
+        .bind(run_id)
+        .bind(format!("{day}T09:00:00.000Z"))
+        .bind(&payload)
+        .execute(db)
+        .await
+        .unwrap();
+        sqlx::query("INSERT INTO events (run_id, ts, kind, payload) VALUES (?, ?, ?, NULL)")
+            .bind(run_id)
+            .bind(format!("{day}T09:05:00.000Z"))
+            .bind(terminal)
+            .execute(db)
+            .await
+            .unwrap();
+    }
+
+    async fn seed_session(db: &sqlx::SqlitePool, run_id: &str, day: &str) {
+        sqlx::query(
+            "INSERT INTO events (run_id, ts, kind, node_id, iter) VALUES (?, ?, 'node_started', 'doer', 0)",
+        )
+        .bind(run_id)
+        .bind(format!("{day}T09:01:00.000Z"))
+        .execute(db)
+        .await
+        .unwrap();
+    }
+
+    /// The FP-377 oracle fixture (6 runs across three days).
+    async fn seed_oracle(db: &sqlx::SqlitePool) {
+        seed_run(db, "r1", "alpha", "/proj/A", "2026-07-15", "run_completed").await;
+        seed_run(db, "r2", "alpha", "/proj/A", "2026-07-15", "run_failed").await;
+        seed_run(db, "r3", "beta", "/proj/B", "2026-07-16", "run_completed").await;
+        seed_run(db, "r4", "beta", "/proj/B", "2026-07-16", "run_completed").await;
+        seed_run(db, "r5", "alpha", "/proj/A", "2026-07-17", "run_skipped").await;
+        seed_run(db, "r6", "beta", "/proj/B", "2026-07-17", "run_failed").await;
+        seed_session(db, "r1", "2026-07-15").await;
+        seed_session(db, "r3", "2026-07-16").await;
+        seed_session(db, "r4", "2026-07-16").await;
+    }
+
+    const FROM: &str = "2026-07-15T00:00:00Z";
+    const TO: &str = "2026-07-18T00:00:00Z";
+
+    #[tokio::test]
+    async fn overview_runs_errors_sessions_per_day() {
+        let db = mem_db().await;
+        seed_oracle(&db).await;
+        let ov = compute_overview(&db, "%Y-%m-%d", FROM, TO).await.unwrap();
+
+        assert_eq!(
+            ov.runs,
+            vec![
+                BucketCount {
+                    bucket: "2026-07-15".into(),
+                    count: 2
+                },
+                BucketCount {
+                    bucket: "2026-07-16".into(),
+                    count: 2
+                },
+                BucketCount {
+                    bucket: "2026-07-17".into(),
+                    count: 2
+                },
+            ]
+        );
+        // Errors = run_failed only; run_skipped (r5) is NOT an error.
+        assert_eq!(
+            ov.errors,
+            vec![
+                BucketCount {
+                    bucket: "2026-07-15".into(),
+                    count: 1
+                },
+                BucketCount {
+                    bucket: "2026-07-17".into(),
+                    count: 1
+                },
+            ]
+        );
+        let total_errors: i64 = ov.errors.iter().map(|b| b.count).sum();
+        assert_eq!(total_errors, 2, "run_skipped must not inflate errors");
+        // Sessions = node_started, cumulative = 3.
+        let total_sessions: i64 = ov.sessions.iter().map(|b| b.count).sum();
+        assert_eq!(total_sessions, 3);
+        // buckets = sorted union across the three series.
+        assert_eq!(ov.buckets, vec!["2026-07-15", "2026-07-16", "2026-07-17"]);
+    }
+
+    #[tokio::test]
+    async fn overview_period_bounds_are_half_open() {
+        let db = mem_db().await;
+        seed_oracle(&db).await;
+        // A window that ends exactly at the 17th 00:00 excludes the 17th's runs.
+        let ov = compute_overview(&db, "%Y-%m-%d", FROM, "2026-07-17T00:00:00Z")
+            .await
+            .unwrap();
+        let total_runs: i64 = ov.runs.iter().map(|b| b.count).sum();
+        assert_eq!(total_runs, 4, "half-open [from, to): the 17th is excluded");
+    }
+
+    #[tokio::test]
+    async fn fires_left_join_surfaces_orphan_as_deleted_trigger() {
+        let db = mem_db().await;
+        // One live trigger + fires; plus a fire from a trigger that no longer exists.
+        sqlx::query(
+            "INSERT INTO triggers (id, name, pipeline_id, cron, enabled, created_at) \
+             VALUES ('t1', 'nightly', 'alpha', '0 2 * * *', 1, '2026-07-14T00:00:00.000Z')",
+        )
+        .execute(&db)
+        .await
+        .unwrap();
+        for (ts, outcome, run) in [
+            ("2026-07-15T09:00:00.000Z", "fired", Some("r1")),
+            ("2026-07-17T09:00:00.000Z", "fired", Some("r5")),
+            ("2026-07-16T02:00:00.000Z", "skipped-overlap", None),
+        ] {
+            sqlx::query(
+                "INSERT INTO trigger_fires (trigger_id, ts, outcome, run_id) VALUES ('t1', ?, ?, ?)",
+            )
+            .bind(ts)
+            .bind(outcome)
+            .bind(run)
+            .execute(&db)
+            .await
+            .unwrap();
+        }
+        // Orphan fire: trigger 't-gone' has no row in `triggers`.
+        sqlx::query(
+            "INSERT INTO trigger_fires (trigger_id, ts, outcome, run_id) \
+             VALUES ('t-gone', '2026-07-16T05:00:00.000Z', 'fired', 'rX')",
+        )
+        .execute(&db)
+        .await
+        .unwrap();
+
+        let fires = fires_by_pipeline(&db, FROM, TO).await.unwrap();
+        // alpha = 3 (2 fired + 1 skipped), orphan = 1 under "(deleted trigger)".
+        let alpha = fires.iter().find(|f| f.pipeline_id == "alpha").unwrap();
+        assert_eq!(alpha.count, 3);
+        let orphan = fires
+            .iter()
+            .find(|f| f.pipeline_id == "(deleted trigger)")
+            .unwrap();
+        assert_eq!(orphan.count, 1);
+
+        let created = triggers_created_runs(&db, FROM, TO).await.unwrap();
+        // 3 fires with outcome='fired' (r1, r5, rX), from 1 distinct existing +
+        // 1 orphan = 2 distinct trigger_ids; 1 enabled trigger.
+        assert_eq!(created.fired, 3);
+        assert_eq!(created.distinct_triggers, 2);
+        assert_eq!(created.enabled_triggers, 1);
+    }
+
+    #[test]
+    fn fold_cost_sums_and_propagates_partial_and_null() {
+        let rows = vec![
+            CostRow {
+                bucket: "2026-07-15".into(),
+                pipeline: "alpha".into(),
+                project: "/proj/A".into(),
+                cost: Some(CostStat {
+                    usd: 1.0,
+                    partial: false,
+                }),
+            },
+            CostRow {
+                bucket: "2026-07-15".into(),
+                pipeline: "alpha".into(),
+                project: "/proj/A".into(),
+                cost: Some(CostStat {
+                    usd: 2.0,
+                    partial: true,
+                }),
+            },
+            CostRow {
+                bucket: "2026-07-16".into(),
+                pipeline: "beta".into(),
+                project: "/proj/B".into(),
+                cost: None, // no transcript
+            },
+        ];
+        let c = fold_cost(&rows);
+
+        // by_period: the 15th sums 1.0 + 2.0 with one partial run; the 16th is
+        // all-null (usd 0, null 1).
+        let d15 = c
+            .by_period
+            .iter()
+            .find(|b| b.bucket == "2026-07-15")
+            .unwrap();
+        assert!((d15.usd - 3.0).abs() < 1e-9);
+        assert_eq!(d15.partial, 1);
+        assert_eq!(d15.null_count, 0);
+        assert_eq!(d15.runs, 2);
+        let d16 = c
+            .by_period
+            .iter()
+            .find(|b| b.bucket == "2026-07-16")
+            .unwrap();
+        assert_eq!(d16.usd, 0.0);
+        assert_eq!(d16.null_count, 1);
+        assert_eq!(d16.runs, 1);
+        // by_period is chronological.
+        assert_eq!(
+            c.by_period
+                .iter()
+                .map(|b| b.bucket.as_str())
+                .collect::<Vec<_>>(),
+            vec!["2026-07-15", "2026-07-16"]
+        );
+
+        // by_pipeline: alpha carries all the spend (sorted first, desc by usd).
+        assert_eq!(c.by_pipeline[0].key, "alpha");
+        assert!((c.by_pipeline[0].usd - 3.0).abs() < 1e-9);
+        assert_eq!(c.by_pipeline[0].partial, 1);
+        assert_eq!(c.by_pipeline[0].runs, 2);
+        let beta = c.by_pipeline.iter().find(|b| b.key == "beta").unwrap();
+        assert_eq!(beta.usd, 0.0);
+        assert_eq!(beta.null_count, 1);
+
+        // by_project mirrors the pipeline split here.
+        assert_eq!(c.by_project[0].key, "/proj/A");
+        assert!((c.by_project[0].usd - 3.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn strftime_fmt_maps_known_buckets_only() {
+        assert_eq!(strftime_fmt("day"), Some("%Y-%m-%d"));
+        assert_eq!(strftime_fmt("week"), Some("%Y-W%W"));
+        assert_eq!(strftime_fmt("month"), Some("%Y-%m"));
+        assert_eq!(strftime_fmt("year"), None);
+        assert_eq!(strftime_fmt(""), None);
+    }
+}

--- a/crates/pdo-daemon/src/trigger_store.rs
+++ b/crates/pdo-daemon/src/trigger_store.rs
@@ -209,6 +209,19 @@ pub async fn init(db: &SqlitePool) -> Result<(), sqlx::Error> {
         }
     }
 
+    // #377 / ADR-0029: back the `GET /stats/overview` fires-per-period query
+    // (`WHERE ts >= ? AND ts < ? GROUP BY strftime`) and the fires-per-pipeline
+    // `LEFT JOIN triggers`. `CREATE INDEX IF NOT EXISTS` is natively idempotent,
+    // so it needs no PRAGMA guard (cf. the `CREATE TABLE IF NOT EXISTS` above).
+    sqlx::query("CREATE INDEX IF NOT EXISTS idx_trigger_fires_ts ON trigger_fires(ts)")
+        .execute(db)
+        .await?;
+    sqlx::query(
+        "CREATE INDEX IF NOT EXISTS idx_trigger_fires_trigger ON trigger_fires(trigger_id)",
+    )
+    .execute(db)
+    .await?;
+
     Ok(())
 }
 

--- a/docs/adr/0029-aggregated-stats-derive-and-index.md
+++ b/docs/adr/0029-aggregated-stats-derive-and-index.md
@@ -1,0 +1,48 @@
+# Statistiques d'instance agrégées : dérivées à la lecture + indexées, jamais matérialisées
+
+## Contexte
+
+#377 ajoute une **modale de stats** (cockpit d'observabilité opérateur) : runs/sessions/erreurs par
+période, fires de trigger par pipeline, et **coût estimé** par période/pipeline/projet, filtrables.
+Tout est aujourd'hui *par-run* (`load_events(run_id)`) ou *par-trigger* ; aucune requête transverse
+par période n'existe, le daemon n'a **aucun index**, et le coût (ADR-0022) est dérivé-à-la-lecture,
+sans cache, volontairement **exclu du handler de liste** (anti-fan-out). Une modale « coût toutes
+runs » est exactement ce fan-out interdit : mesuré à 2 502 transcripts / 1,1 Go localement.
+
+## Décision
+
+- **Dérivé à la lecture, jamais matérialisé.** Pas de table de snapshot de coût, pas d'`EventKind`
+  qui fige une métrique. **Préserve ADR-0022** (Shape B, snapshot à la complétion, explicitement
+  rejeté) et ADR-0001 (outil tranchant, étiquetage honnête).
+- **Deux classes, deux endpoints.** `GET /stats/overview` = SQL bon marché, index-backed
+  (`GROUP BY strftime`). `GET /stats/cost` = lourd, lazy, derrière un **memo RAM `(run_id,
+  mtime-max)`** (l'échappatoire sanctionnée par ADR-0022 lignes 84-85), borné à la période visible ;
+  le chemin single-run de `get_run` reste inchangé.
+- **Deux index idempotents** au boot : `events(kind, ts)` et `trigger_fires(ts)`
+  (`CREATE INDEX IF NOT EXISTS`, nativement idempotent — pas de garde PRAGMA, contrairement aux
+  `ALTER ADD COLUMN` de #239/#244).
+- **`pipeline_id` porté par `RunStarted`** (fallback `pipeline_name`) pour que « par pipeline »
+  survive un renommage (#230). Additif, rétro-compatible.
+- **Axes catégoriels du coût pliés côté app (Rust).** Le coût est un scalaire par-run sans dimension
+  pipeline/projet ; « par projet » = `effective_repo_root` (fallback runtime absent des tables). Les
+  cinq séries *nommées* (runs/sessions/erreurs/fires-par-pipeline/triggers-ayant-créé-un-run) restent
+  du SQL pur indexé.
+- **Étiquetage honnête agrégé (load-bearing).** Un bucket est une **somme de bornes basses** : tout
+  run `partial` (modèle non tarifé) rend le bucket borne-basse (`†`). Les runs sans transcript sont
+  exclus de la somme mais **comptés (`null`)** et exposés, jamais silencieusement sous-comptés.
+
+## Conséquences
+
+- **Positif.** Réactif (SQL indexé + memo), zéro dépendance réseau, aucune divergence possible avec
+  l'event log (source de vérité unique), le coût reste consultable pour un run archivé.
+- **Négatif / assumé.** Le memo vit en RAM (perdu au restart, reconstruit à la demande). La table de
+  prix reste à maintenir à la main (ADR-0022). « Sessions/période » compte les *démarrages* de
+  session (`node_started`), re-spawns et laps de boucle inclus (cohérent avec la stat par-run).
+
+## Alternatives rejetées
+
+- **Table de snapshot de coût / EventKind figeant une métrique** — viole ADR-0022, sous-compte au
+  `resume_run`.
+- **Coût au handler de liste / full-scan par ouverture** — le fan-out interdit (2 502 fichiers).
+- **INNER JOIN fires↔triggers** — perdrait les fires orphelins (pas de cascade au delete).
+- **Bucket « Unassigned » pour les runs sans repo** — contredit §521/#258 (`effective_repo`).

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -25,6 +25,7 @@
         "react-dom": "^19.2.5",
         "react-markdown": "^10.1.0",
         "react-resizable-panels": "^4.11.0",
+        "recharts": "^3.9.2",
         "remark-gfm": "^4.0.1",
         "shadcn": "^4.7.0",
         "tailwind-merge": "^3.5.0",
@@ -2020,6 +2021,32 @@
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.17",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
@@ -2291,7 +2318,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@tailwindcss/node": {
@@ -3063,6 +3095,12 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@types/validate-npm-package-name": {
@@ -4873,6 +4911,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
+    },
     "node_modules/decode-named-character-reference": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
@@ -5443,6 +5487,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/eventsource": {
       "version": "3.0.7",
@@ -6219,6 +6269,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/immer": {
+      "version": "11.1.15",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.15.tgz",
+      "integrity": "sha512-VrNANlmnWQnh5COXIIOQXM9oOJw7naGKlBT74ZOOR6lpVXc3gFEu9FJLDFcpCJ2j+NWr8TIwtWD//T6ZX6TKiQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/import-fresh": {
@@ -9024,7 +9084,6 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
       "license": "MIT",
       "peer": true
     },
@@ -9055,6 +9114,29 @@
         "react": ">=18"
       }
     },
+    "node_modules/react-redux": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-resizable-panels": {
       "version": "4.11.0",
       "resolved": "https://registry.npmjs.org/react-resizable-panels/-/react-resizable-panels-4.11.0.tgz",
@@ -9081,6 +9163,36 @@
         "node": ">= 4"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.9.2.tgz",
+      "integrity": "sha512-G4fy+Pk46RaXgwWMh+Nzhyo/lbFAVqXo9gtetlyehe6Ehge9CsgDuOTwQDD+i1+llaLktNBiNq4bhnGlDRXFtw==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^11.1.8",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.2.0",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -9093,6 +9205,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/remark-gfm": {
@@ -9180,9 +9307,9 @@
       }
     },
     "node_modules/reselect": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
-      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
+      "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
       "license": "MIT"
     },
     "node_modules/resolve-from": {
@@ -10378,6 +10505,28 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,6 +30,7 @@
     "react-dom": "^19.2.5",
     "react-markdown": "^10.1.0",
     "react-resizable-panels": "^4.11.0",
+    "recharts": "^3.9.2",
     "remark-gfm": "^4.0.1",
     "shadcn": "^4.7.0",
     "tailwind-merge": "^3.5.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Settings } from "lucide-react";
+import { Settings, BarChart3 } from "lucide-react";
 import { useDaemonSocket } from "./hooks/useDaemonSocket";
 import type { ConnectionStatus } from "./hooks/useDaemonSocket";
 import { useResizableLayout } from "./hooks/useResizableLayout";
@@ -18,6 +18,7 @@ import NodeDetailPanel from "./components/NodeDetailPanel";
 import RunInfoSidebar from "./components/RunInfoSidebar";
 import NewRunModal, { RUN_INTENT } from "./components/NewRunModal";
 import SettingsModal from "./components/SettingsModal";
+import StatsModal from "./components/StatsModal";
 import ConflictModal from "./components/ConflictModal";
 import PipelineChangedModal from "./components/PipelineChangedModal";
 import SaveErrorModal from "./components/SaveErrorModal";
@@ -164,6 +165,7 @@ export default function App() {
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
   const [newRunModalOpen, setNewRunModalOpen] = useState(false);
   const [settingsModalOpen, setSettingsModalOpen] = useState(false);
+  const [statsModalOpen, setStatsModalOpen] = useState(false);
   // #386: how the always-mounted New Run modal should open. Drives a one-shot
   // reset on every reopen so a dismissed "Edit trigger" can't leak into a fresh
   // "New run" / "New trigger". Defaults to a plain run.
@@ -672,7 +674,10 @@ export default function App() {
   return (
     <TooltipProvider>
     <div className="flex h-full flex-col bg-bg-1 text-fg">
-      <TopBar onOpenSettings={() => setSettingsModalOpen(true)} />
+      <TopBar
+        onOpenSettings={() => setSettingsModalOpen(true)}
+        onOpenStats={() => setStatsModalOpen(true)}
+      />
       <main className="min-h-0 flex-1">
         <ResizablePanelGroup
           orientation="horizontal"
@@ -846,6 +851,7 @@ export default function App() {
         liveSessions={sessions.live}
         onSaved={refreshSessions}
       />
+      <StatsModal open={statsModalOpen} onClose={() => setStatsModalOpen(false)} />
       <ConflictModal
         open={conflictTab != null}
         pipelineId={conflictTab?.id ?? ""}
@@ -897,7 +903,13 @@ export default function App() {
   );
 }
 
-function TopBar({ onOpenSettings }: { onOpenSettings: () => void }) {
+function TopBar({
+  onOpenSettings,
+  onOpenStats,
+}: {
+  onOpenSettings: () => void;
+  onOpenStats: () => void;
+}) {
   return (
     <header
       className="flex h-[44px] shrink-0 items-center gap-3 border-b border-line bg-bg-2 px-3"
@@ -918,15 +930,25 @@ function TopBar({ onOpenSettings }: { onOpenSettings: () => void }) {
         PDO
       </div>
 
-      {/* Right-aligned gear → instance settings (#129). */}
-      <button
-        onClick={onOpenSettings}
-        aria-label="Settings"
-        data-testid="open-settings"
-        className="ml-auto grid h-6 w-6 place-items-center rounded text-fg-3 transition-colors hover:bg-bg-5 hover:text-fg"
-      >
-        <Settings size={15} />
-      </button>
+      {/* Right-aligned action group: stats (#377) then the settings gear (#129). */}
+      <div className="ml-auto flex items-center gap-1">
+        <button
+          onClick={onOpenStats}
+          aria-label="Open stats"
+          data-testid="open-stats"
+          className="grid h-6 w-6 place-items-center rounded text-fg-3 transition-colors hover:bg-bg-5 hover:text-fg"
+        >
+          <BarChart3 size={15} />
+        </button>
+        <button
+          onClick={onOpenSettings}
+          aria-label="Settings"
+          data-testid="open-settings"
+          className="grid h-6 w-6 place-items-center rounded text-fg-3 transition-colors hover:bg-bg-5 hover:text-fg"
+        >
+          <Settings size={15} />
+        </button>
+      </div>
     </header>
   );
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,4 +1,4 @@
-import type { PipelineListEntry, PipelineDetail, PipelineDef, RunListEntry, RunState, PortDef, PortSide, PortType, FrontmatterFieldDecl, Trigger, TriggerFire, DaemonStatus, InstanceSettings, UpdateSettingsRequest } from "./types";
+import type { PipelineListEntry, PipelineDetail, PipelineDef, RunListEntry, RunState, PortDef, PortSide, PortType, FrontmatterFieldDecl, Trigger, TriggerFire, DaemonStatus, InstanceSettings, UpdateSettingsRequest, StatsOverview, StatsCost } from "./types";
 
 const BASE = "";
 
@@ -148,6 +148,32 @@ export function updateSettings(
   patch: UpdateSettingsRequest,
 ): Promise<InstanceSettings> {
   return request<InstanceSettings>("PUT", "/settings", { body: patch });
+}
+
+/**
+ * Cheap instance stats over `[from, to)` bucketed by `bucket` (#377): runs,
+ * errors (`run_failed`), sessions, fires-per-pipeline, and the "triggers that
+ * created a run" KPI. Indexed SQL — safe to fetch on modal open.
+ */
+export function fetchStatsOverview(
+  from: string,
+  to: string,
+  bucket: string,
+): Promise<StatsOverview> {
+  return request<StatsOverview>("GET", "/stats/overview", { query: { from, to, bucket } });
+}
+
+/**
+ * Estimated cost over `[from, to)`, folded by period/pipeline/project (#377,
+ * ADR-0022/0029). Heavy (memoized per-run cost fanned over the window) — fetch
+ * lazily, only when the cost tab is shown.
+ */
+export function fetchStatsCost(
+  from: string,
+  to: string,
+  bucket: string,
+): Promise<StatsCost> {
+  return request<StatsCost>("GET", "/stats/cost", { query: { from, to, bucket } });
 }
 
 export function fetchRun(runId: string): Promise<RunState> {

--- a/frontend/src/components/PipelineInfoPanel.tsx
+++ b/frontend/src/components/PipelineInfoPanel.tsx
@@ -7,6 +7,7 @@ import type { LibraryPipelineEntry } from "../api";
 import type { RunState, PipelineDef } from "../types";
 import { isLiveRun } from "../types";
 import { formatDuration, useRunDuration } from "../lib/runDuration";
+import { formatEstCost } from "../lib/costLabel";
 import { serializePipeline } from "../stores/editStore";
 import { highlightYaml } from "./yamlHighlight";
 
@@ -258,18 +259,17 @@ function InfoTab({
             </StatRow>
             <StatRow label="Est. cost" testid="stat-cost">
               {run.cost ? (
-                <span
-                  className="flex items-center gap-1"
-                  title={
-                    "Estimate from local Claude Code token usage × public list prices — not an invoice." +
-                    (run.cost.partial
-                      ? " Lower bound: an unpriced model was excluded."
-                      : "")
-                  }
-                >
-                  ~${run.cost.usd.toFixed(run.cost.usd < 1 ? 4 : 2)}
-                  {run.cost.partial && <span className="text-st-await">†</span>}
-                </span>
+                (() => {
+                  // Shared honesty helper (#272/#377): same vocabulary as the
+                  // aggregated Stats charts.
+                  const c = formatEstCost(run.cost.usd, run.cost.partial);
+                  return (
+                    <span className="flex items-center gap-1" title={c.title}>
+                      {c.text}
+                      {c.dagger && <span className="text-st-await">†</span>}
+                    </span>
+                  );
+                })()
               ) : (
                 "—"
               )}

--- a/frontend/src/components/StatsCharts.tsx
+++ b/frontend/src/components/StatsCharts.tsx
@@ -1,0 +1,282 @@
+import {
+  BarChart,
+  Bar,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip as RTooltip,
+  Legend,
+  CartesianGrid,
+  ResponsiveContainer,
+} from "recharts";
+import type { StatsOverview, StatsCost, StatsCostBucket } from "../types";
+import { formatBucketCost } from "../lib/costLabel";
+
+// This module is the ONLY importer of `recharts`, so it is code-split via
+// `React.lazy` in StatsModal (the first lazy chunk in the repo) — recharts stays
+// out of the main bundle and loads when the Stats modal first opens.
+
+export type StatsTab = "runs" | "sessions" | "triggers" | "cost";
+
+// Palette — reads on the dark UI; deliberately not the brand accent so series
+// stay distinguishable.
+const C = {
+  runs: "#58a6ff",
+  errors: "#f85149",
+  sessions: "#a371f7",
+  fires: "#3fb950",
+  cost: "#d29922",
+  grid: "#30363d",
+  axis: "#8b949e",
+} as const;
+
+const AXIS_PROPS = {
+  stroke: C.axis,
+  tick: { fill: C.axis, fontSize: 10 },
+} as const;
+
+function ChartFrame({ children }: { children: React.ReactElement }) {
+  return (
+    <div style={{ width: "100%", height: 220 }}>
+      <ResponsiveContainer width="100%" height="100%">
+        {children}
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
+function EmptyNote({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="px-1 py-8 text-center text-fg-4" style={{ fontSize: "11.5px" }}>
+      {children}
+    </div>
+  );
+}
+
+/** Merge two per-bucket count series onto the ordered `buckets` x-axis. */
+function mergeCounts(
+  buckets: string[],
+  a: { bucket: string; count: number }[],
+  b: { bucket: string; count: number }[],
+): { bucket: string; runs: number; errors: number }[] {
+  const am = new Map(a.map((r) => [r.bucket, r.count]));
+  const bm = new Map(b.map((r) => [r.bucket, r.count]));
+  return buckets.map((bucket) => ({
+    bucket,
+    runs: am.get(bucket) ?? 0,
+    errors: bm.get(bucket) ?? 0,
+  }));
+}
+
+function RunsTab({ overview }: { overview: StatsOverview }) {
+  if (overview.buckets.length === 0) return <EmptyNote>No runs in this period.</EmptyNote>;
+  const data = mergeCounts(overview.buckets, overview.runs, overview.errors);
+  return (
+    <div data-testid="stats-chart-runs">
+      <ChartFrame>
+        <BarChart data={data} margin={{ top: 8, right: 8, left: -18, bottom: 0 }}>
+          <CartesianGrid stroke={C.grid} strokeDasharray="3 3" vertical={false} />
+          <XAxis dataKey="bucket" {...AXIS_PROPS} />
+          <YAxis allowDecimals={false} {...AXIS_PROPS} />
+          <RTooltip
+            contentStyle={{ background: "#161b22", border: `1px solid ${C.grid}`, fontSize: 11 }}
+          />
+          <Legend wrapperStyle={{ fontSize: 11 }} />
+          <Bar dataKey="runs" name="Runs" fill={C.runs} radius={[2, 2, 0, 0]} />
+          <Bar dataKey="errors" name="Errors (failed)" fill={C.errors} radius={[2, 2, 0, 0]} />
+        </BarChart>
+      </ChartFrame>
+    </div>
+  );
+}
+
+function SessionsTab({ overview }: { overview: StatsOverview }) {
+  if (overview.buckets.length === 0)
+    return <EmptyNote>No node sessions in this period.</EmptyNote>;
+  const sm = new Map(overview.sessions.map((r) => [r.bucket, r.count]));
+  const data = overview.buckets.map((bucket) => ({ bucket, sessions: sm.get(bucket) ?? 0 }));
+  return (
+    <div data-testid="stats-chart-sessions">
+      <ChartFrame>
+        <LineChart data={data} margin={{ top: 8, right: 8, left: -18, bottom: 0 }}>
+          <CartesianGrid stroke={C.grid} strokeDasharray="3 3" vertical={false} />
+          <XAxis dataKey="bucket" {...AXIS_PROPS} />
+          <YAxis allowDecimals={false} {...AXIS_PROPS} />
+          <RTooltip
+            contentStyle={{ background: "#161b22", border: `1px solid ${C.grid}`, fontSize: 11 }}
+          />
+          <Line
+            type="monotone"
+            dataKey="sessions"
+            name="Node sessions started"
+            stroke={C.sessions}
+            strokeWidth={2}
+            dot={{ r: 2 }}
+          />
+        </LineChart>
+      </ChartFrame>
+    </div>
+  );
+}
+
+function TriggersTab({ overview }: { overview: StatsOverview }) {
+  const kpi = overview.triggers_created_runs;
+  return (
+    <div data-testid="stats-chart-triggers" className="flex flex-col gap-3">
+      <div className="flex flex-wrap gap-2" style={{ fontSize: "11px" }}>
+        <span
+          className="rounded bg-bg-3 px-2 py-1 text-fg-2"
+          data-testid="stats-kpi-created-runs"
+        >
+          Fires that created a run: <span className="font-mono text-fg">{kpi.fired}</span>
+        </span>
+        <span className="rounded bg-bg-3 px-2 py-1 text-fg-2" data-testid="stats-kpi-distinct">
+          <span className="font-mono text-fg">{kpi.distinct_triggers}</span> of{" "}
+          <span className="font-mono text-fg">{kpi.enabled_triggers}</span> enabled triggers fired
+        </span>
+      </div>
+      {overview.fires_by_pipeline.length === 0 ? (
+        <EmptyNote>No trigger fires in this period.</EmptyNote>
+      ) : (
+        <ChartFrame>
+          <BarChart
+            data={overview.fires_by_pipeline}
+            margin={{ top: 8, right: 8, left: -18, bottom: 0 }}
+          >
+            <CartesianGrid stroke={C.grid} strokeDasharray="3 3" vertical={false} />
+            <XAxis dataKey="pipeline_id" {...AXIS_PROPS} />
+            <YAxis allowDecimals={false} {...AXIS_PROPS} />
+            <RTooltip
+              contentStyle={{ background: "#161b22", border: `1px solid ${C.grid}`, fontSize: 11 }}
+            />
+            <Bar dataKey="count" name="Fires" fill={C.fires} radius={[2, 2, 0, 0]} />
+          </BarChart>
+        </ChartFrame>
+      )}
+    </div>
+  );
+}
+
+/** One labelled cost row carrying the honesty vocabulary (`~$` / `†` / `—`). */
+function CostRow({ label, bucket }: { label: string; bucket: StatsCostBucket }) {
+  const c = formatBucketCost(bucket.usd, bucket.partial, bucket.null, bucket.runs);
+  return (
+    <div
+      className="flex items-center justify-between rounded bg-bg-3 px-2 py-1"
+      style={{ fontSize: "10.5px" }}
+      data-testid="stats-cost-row"
+      title={c.title}
+    >
+      <span className="text-fg-3">{label}</span>
+      <span className={`flex items-center gap-1 font-mono ${c.empty ? "text-fg-4" : "text-fg-2"}`}>
+        {c.text}
+        {c.dagger && (
+          <span className="text-st-await" title={c.title}>
+            †
+          </span>
+        )}
+      </span>
+    </div>
+  );
+}
+
+function CostSection({
+  title,
+  rows,
+}: {
+  title: string;
+  rows: { label: string; bucket: StatsCostBucket }[];
+}) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <h4 className="font-medium text-fg-2" style={{ fontSize: "11px" }}>
+        {title}
+      </h4>
+      {rows.length === 0 ? (
+        <EmptyNote>No runs in this period.</EmptyNote>
+      ) : (
+        <div className="flex flex-col gap-1">
+          {rows.map((r) => (
+            <CostRow key={r.label} label={r.label} bucket={r.bucket} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function CostTab({ cost, error }: { cost: StatsCost | null; error: string | null }) {
+  if (error)
+    return (
+      <div
+        className="rounded-md border border-st-failed/30 bg-st-failed-bg px-3 py-2 text-st-failed"
+        style={{ fontSize: "11.5px" }}
+        data-testid="stats-cost-error"
+      >
+        {error}
+      </div>
+    );
+  // No synchronous loading flag (see useStats): null cost + no error = fetching.
+  if (!cost) return <EmptyNote>Loading cost…</EmptyNote>;
+
+  const periodBars = cost.by_period.map((b) => ({ label: b.bucket, usd: b.usd }));
+  const hasSpend = cost.by_period.some((b) => b.usd > 0);
+
+  return (
+    <div className="flex flex-col gap-4" data-testid="stats-chart-cost">
+      <div className="text-fg-4" style={{ fontSize: "10.5px" }} data-testid="stats-cost-disclaimer">
+        Estimates from local Claude Code token usage × public list prices — not an invoice. A bucket
+        with any partial run is a lower bound (†); runs with no transcript are excluded (shown as —).
+      </div>
+
+      {hasSpend && (
+        <ChartFrame>
+          <BarChart data={periodBars} margin={{ top: 8, right: 8, left: -8, bottom: 0 }}>
+            <CartesianGrid stroke={C.grid} strokeDasharray="3 3" vertical={false} />
+            <XAxis dataKey="label" {...AXIS_PROPS} />
+            <YAxis {...AXIS_PROPS} tickFormatter={(v) => `$${v}`} />
+            <RTooltip
+              contentStyle={{ background: "#161b22", border: `1px solid ${C.grid}`, fontSize: 11 }}
+              formatter={(value) => {
+                const v = typeof value === "number" ? value : Number(value) || 0;
+                return [`~$${v.toFixed(v < 1 ? 4 : 2)}`, "est. cost"];
+              }}
+            />
+            <Bar dataKey="usd" name="Est. cost" fill={C.cost} radius={[2, 2, 0, 0]} />
+          </BarChart>
+        </ChartFrame>
+      )}
+
+      <CostSection
+        title="By period"
+        rows={cost.by_period.map((b) => ({ label: b.bucket, bucket: b }))}
+      />
+      <CostSection
+        title="By pipeline"
+        rows={cost.by_pipeline.map((b) => ({ label: b.key, bucket: b }))}
+      />
+      <CostSection
+        title="By project"
+        rows={cost.by_project.map((b) => ({ label: b.key, bucket: b }))}
+      />
+    </div>
+  );
+}
+
+export interface StatsChartsProps {
+  tab: StatsTab;
+  overview: StatsOverview | null;
+  cost: StatsCost | null;
+  costError: string | null;
+}
+
+/** The chart surface for the active tab. Lazy-loaded (so recharts is code-split
+ *  out of the main bundle). */
+export default function StatsCharts({ tab, overview, cost, costError }: StatsChartsProps) {
+  if (tab === "cost") return <CostTab cost={cost} error={costError} />;
+  if (!overview) return <EmptyNote>Loading…</EmptyNote>;
+  if (tab === "runs") return <RunsTab overview={overview} />;
+  if (tab === "sessions") return <SessionsTab overview={overview} />;
+  return <TriggersTab overview={overview} />;
+}

--- a/frontend/src/components/StatsModal.tsx
+++ b/frontend/src/components/StatsModal.tsx
@@ -1,0 +1,197 @@
+import { Suspense, lazy, useEffect, useMemo, useState } from "react";
+import { X } from "lucide-react";
+import { useStats } from "../hooks/useStats";
+import type { StatsTab } from "./StatsCharts";
+
+// First `React.lazy` in the repo (#377): recharts is heavy, so StatsCharts (its
+// only importer) is code-split and loads when the modal first opens.
+const StatsCharts = lazy(() => import("./StatsCharts"));
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+type Preset = "7d" | "30d" | "90d" | "all";
+
+interface Period {
+  from: string;
+  to: string;
+  bucket: string;
+}
+
+const PRESETS: { id: Preset; label: string }[] = [
+  { id: "7d", label: "7 days" },
+  { id: "30d", label: "30 days" },
+  { id: "90d", label: "90 days" },
+  { id: "all", label: "All time" },
+];
+
+const TABS: { id: StatsTab; label: string }[] = [
+  { id: "runs", label: "Runs" },
+  { id: "sessions", label: "Sessions" },
+  { id: "triggers", label: "Triggers" },
+  { id: "cost", label: "Cost" },
+];
+
+/** UTC midnight of `d`, as an ISO-Z string — aligns with the daemon's UTC `ts`
+ *  and its `strftime` day bucketing. */
+function utcDayStart(d: Date): string {
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate())).toISOString();
+}
+
+/**
+ * Resolve a preset to a half-open `[from, to)` window + a bucket granularity —
+ * pure client-side view state (invariant #7: NOT `instance_config`). `to` is the
+ * start of tomorrow (UTC) so all of today is included.
+ */
+function presetPeriod(preset: Preset): Period {
+  const now = new Date();
+  const tomorrow = new Date(now);
+  tomorrow.setUTCDate(tomorrow.getUTCDate() + 1);
+  const to = utcDayStart(tomorrow);
+
+  const daysAgo = (n: number): string => {
+    const d = new Date(now);
+    d.setUTCDate(d.getUTCDate() - n);
+    return utcDayStart(d);
+  };
+
+  switch (preset) {
+    case "7d":
+      return { from: daysAgo(6), to, bucket: "day" };
+    case "30d":
+      return { from: daysAgo(29), to, bucket: "day" };
+    case "90d":
+      return { from: daysAgo(89), to, bucket: "week" };
+    case "all":
+      return { from: "1970-01-01T00:00:00.000Z", to, bucket: "month" };
+  }
+}
+
+/**
+ * Instance stats cockpit (#377, ADR-0029): a sister of SettingsModal, opened from
+ * the TopBar. Cross-run aggregates filterable by period — runs/errors, node
+ * sessions, trigger fires, and estimated cost (framed honestly). Two-endpoint
+ * split: the overview loads on open; the cost tab lazily fetches `/stats/cost`
+ * and code-splits recharts on first view.
+ */
+export default function StatsModal({ open, onClose }: Props) {
+  const [preset, setPreset] = useState<Preset>("30d");
+  const [tab, setTab] = useState<StatsTab>("runs");
+  const period = useMemo(() => presetPeriod(preset), [preset]);
+
+  const { overview, cost, error, costError } = useStats(
+    open,
+    period.from,
+    period.to,
+    period.bucket,
+    tab === "cost",
+  );
+
+  // Escape-to-close (grafted from MarkdownArtifactModal — SettingsModal lacks it).
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={onClose}
+    >
+      <div
+        className="flex max-h-[85vh] w-[720px] flex-col rounded-lg border border-line bg-bg-4 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+        data-testid="stats-modal"
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-line px-4 py-3">
+          <h2 className="font-semibold text-fg" style={{ fontSize: "13.5px" }}>
+            Stats
+          </h2>
+          <button
+            onClick={onClose}
+            aria-label="Close stats"
+            className="grid h-6 w-6 place-items-center rounded text-fg-3 transition-colors hover:bg-bg-5 hover:text-fg"
+          >
+            <X size={14} />
+          </button>
+        </div>
+
+        {/* Period picker + tabs */}
+        <div className="flex flex-col gap-2 border-b border-line px-4 py-3">
+          <div className="flex items-center gap-1" role="group" aria-label="Period">
+            {PRESETS.map((p) => (
+              <button
+                key={p.id}
+                type="button"
+                aria-pressed={preset === p.id}
+                data-testid={`stats-period-${p.id}`}
+                onClick={() => setPreset(p.id)}
+                className={`rounded-md border px-2.5 py-1 transition-colors ${
+                  preset === p.id
+                    ? "border-acc bg-acc/15 text-fg"
+                    : "border-line-strong bg-bg-3 text-fg-2 hover:bg-bg-4"
+                }`}
+                style={{ fontSize: "11px" }}
+              >
+                {p.label}
+              </button>
+            ))}
+          </div>
+          <div className="flex items-center gap-1" role="tablist" aria-label="Stats sections">
+            {TABS.map((t) => (
+              <button
+                key={t.id}
+                type="button"
+                role="tab"
+                aria-selected={tab === t.id}
+                data-testid={`stats-tab-${t.id}`}
+                onClick={() => setTab(t.id)}
+                className={`rounded-md px-2.5 py-1 transition-colors ${
+                  tab === t.id ? "bg-bg-5 text-fg" : "text-fg-3 hover:bg-bg-3 hover:text-fg-2"
+                }`}
+                style={{ fontSize: "11.5px" }}
+              >
+                {t.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Body */}
+        <div className="min-h-[260px] flex-1 overflow-y-auto px-4 py-4">
+          {error && (
+            <div
+              className="mb-3 rounded-md border border-st-failed/30 bg-st-failed-bg px-3 py-2 text-st-failed"
+              style={{ fontSize: "11.5px" }}
+              data-testid="stats-error"
+            >
+              {error}
+            </div>
+          )}
+          <Suspense
+            fallback={
+              <div
+                className="px-1 py-8 text-center text-fg-4"
+                style={{ fontSize: "11.5px" }}
+                data-testid="stats-charts-loading"
+              >
+                Loading charts…
+              </div>
+            }
+          >
+            <StatsCharts tab={tab} overview={overview} cost={cost} costError={costError} />
+          </Suspense>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useStats.test.ts
+++ b/frontend/src/hooks/useStats.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { useStats } from "./useStats";
+import * as api from "../api";
+import type { StatsOverview, StatsCost } from "../types";
+
+vi.mock("../api", () => ({
+  fetchStatsOverview: vi.fn(),
+  fetchStatsCost: vi.fn(),
+}));
+
+const OVERVIEW: StatsOverview = {
+  buckets: ["2026-07-15"],
+  runs: [{ bucket: "2026-07-15", count: 2 }],
+  errors: [],
+  sessions: [],
+  fires_by_pipeline: [],
+  triggers_created_runs: { fired: 0, distinct_triggers: 0, enabled_triggers: 1 },
+};
+
+const COST: StatsCost = { by_period: [], by_pipeline: [], by_project: [] };
+
+beforeEach(() => {
+  vi.mocked(api.fetchStatsOverview).mockReset().mockResolvedValue(OVERVIEW);
+  vi.mocked(api.fetchStatsCost).mockReset().mockResolvedValue(COST);
+});
+
+describe("useStats (#377)", () => {
+  it("fetches overview eagerly on open, but not cost", async () => {
+    const { result } = renderHook(() => useStats(true, "F", "T", "day", false));
+    await waitFor(() => expect(result.current.overview).toEqual(OVERVIEW));
+    expect(api.fetchStatsOverview).toHaveBeenCalledWith("F", "T", "day");
+    expect(api.fetchStatsCost).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch anything while closed", async () => {
+    renderHook(() => useStats(false, "F", "T", "day", true));
+    await Promise.resolve();
+    expect(api.fetchStatsOverview).not.toHaveBeenCalled();
+    expect(api.fetchStatsCost).not.toHaveBeenCalled();
+  });
+
+  it("fetches cost lazily, only once the cost tab is active (two-endpoint split)", async () => {
+    const { result, rerender } = renderHook(
+      ({ costActive }) => useStats(true, "F", "T", "day", costActive),
+      { initialProps: { costActive: false } },
+    );
+    await waitFor(() => expect(result.current.overview).toEqual(OVERVIEW));
+    expect(api.fetchStatsCost).not.toHaveBeenCalled();
+
+    rerender({ costActive: true });
+    await waitFor(() => expect(result.current.cost).toEqual(COST));
+    expect(api.fetchStatsCost).toHaveBeenCalledWith("F", "T", "day");
+  });
+
+  it("refetches overview when the period changes", async () => {
+    const { rerender } = renderHook(
+      ({ bucket }) => useStats(true, "F", "T", bucket, false),
+      { initialProps: { bucket: "day" } },
+    );
+    await waitFor(() => expect(api.fetchStatsOverview).toHaveBeenCalledTimes(1));
+    rerender({ bucket: "week" });
+    await waitFor(() => expect(api.fetchStatsOverview).toHaveBeenCalledTimes(2));
+    expect(api.fetchStatsOverview).toHaveBeenLastCalledWith("F", "T", "week");
+  });
+
+  it("surfaces an overview fetch error", async () => {
+    vi.mocked(api.fetchStatsOverview).mockRejectedValueOnce(new Error("boom"));
+    const { result } = renderHook(() => useStats(true, "F", "T", "day", false));
+    await waitFor(() => expect(result.current.error).toBe("boom"));
+  });
+
+  it("surfaces a cost fetch error only for the cost class", async () => {
+    vi.mocked(api.fetchStatsCost).mockRejectedValueOnce(new Error("cost-boom"));
+    const { result } = renderHook(() => useStats(true, "F", "T", "day", true));
+    await waitFor(() => expect(result.current.costError).toBe("cost-boom"));
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/frontend/src/hooks/useStats.ts
+++ b/frontend/src/hooks/useStats.ts
@@ -1,0 +1,71 @@
+import { useEffect, useState } from "react";
+import { fetchStatsOverview, fetchStatsCost } from "../api";
+import type { StatsOverview, StatsCost } from "../types";
+
+/**
+ * State for the Stats modal (#377, ADR-0029). Two-endpoint split by cost class:
+ *
+ * - **overview** (cheap indexed SQL) is fetched whenever the modal is open and
+ *   the period `(from, to, bucket)` changes.
+ * - **cost** (heavy, memoized) is fetched lazily — only once `costActive` is
+ *   true (the user opened the cost tab) — and then refetched on period change.
+ *   This keeps `/stats/cost` off the modal-open path (the two-endpoint split).
+ *
+ * Loading is derived from data-presence by the consumer (like `useSettings`,
+ * whose open-effect never sets state synchronously); this hook only writes state
+ * from the async callbacks, and — unlike `useSettings` — it *surfaces* an
+ * `error`/`costError` rather than swallowing it, so a failed fetch (or a failed
+ * lazy chunk on the cost tab) is visible, not a blank tab.
+ */
+export function useStats(
+  open: boolean,
+  from: string,
+  to: string,
+  bucket: string,
+  costActive: boolean,
+) {
+  const [overview, setOverview] = useState<StatsOverview | null>(null);
+  const [cost, setCost] = useState<StatsCost | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [costError, setCostError] = useState<string | null>(null);
+
+  // Overview: eager on open + on every period change.
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    fetchStatsOverview(from, to, bucket)
+      .then((data) => {
+        if (!cancelled) {
+          setOverview(data);
+          setError(null);
+        }
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, from, to, bucket]);
+
+  // Cost: lazy — only once the cost tab is active, then on period change too.
+  useEffect(() => {
+    if (!open || !costActive) return;
+    let cancelled = false;
+    fetchStatsCost(from, to, bucket)
+      .then((data) => {
+        if (!cancelled) {
+          setCost(data);
+          setCostError(null);
+        }
+      })
+      .catch((e) => {
+        if (!cancelled) setCostError(e instanceof Error ? e.message : String(e));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, costActive, from, to, bucket]);
+
+  return { overview, cost, error, costError };
+}

--- a/frontend/src/lib/costLabel.test.ts
+++ b/frontend/src/lib/costLabel.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import {
+  costPrecision,
+  formatEstCost,
+  formatBucketCost,
+} from "./costLabel";
+
+describe("costPrecision", () => {
+  it("uses 4 decimals below $1 and 2 at or above", () => {
+    expect(costPrecision(0.0525)).toBe(4);
+    expect(costPrecision(0.999)).toBe(4);
+    expect(costPrecision(1)).toBe(2);
+    expect(costPrecision(12.5)).toBe(2);
+  });
+});
+
+describe("formatEstCost (single run, #272)", () => {
+  it("renders ~$ at 2 decimals for >= $1, no dagger, estimate tooltip", () => {
+    const c = formatEstCost(1.23, false);
+    expect(c.text).toBe("~$1.23");
+    expect(c.dagger).toBe(false);
+    expect(c.title).toMatch(/estimate/i);
+    expect(c.title).not.toMatch(/lower bound/i);
+  });
+
+  it("renders 4 decimals for a sub-dollar estimate", () => {
+    expect(formatEstCost(0.0525, false).text).toBe("~$0.0525");
+  });
+
+  it("flags a partial estimate with a dagger and a lower-bound tooltip", () => {
+    const c = formatEstCost(2.5, true);
+    expect(c.text).toBe("~$2.50");
+    expect(c.dagger).toBe(true);
+    expect(c.title).toMatch(/lower bound/i);
+  });
+});
+
+describe("formatBucketCost (aggregate, #377)", () => {
+  it("sums a plain bucket with no partial/null contributions", () => {
+    const c = formatBucketCost(3.4, 0, 0, 2);
+    expect(c.text).toBe("~$3.40");
+    expect(c.dagger).toBe(false);
+    expect(c.empty).toBe(false);
+    expect(c.title).toMatch(/estimate/i);
+    expect(c.title).not.toMatch(/lower bound/i);
+    expect(c.title).not.toMatch(/no transcript/i);
+  });
+
+  it("marks a bucket with a partial run as a lower bound and counts it", () => {
+    const c = formatBucketCost(5.0, 1, 0, 3);
+    expect(c.dagger).toBe(true);
+    expect(c.text).toBe("~$5.00");
+    expect(c.title).toMatch(/lower bound/i);
+    expect(c.title).toMatch(/1 partial run\b/);
+  });
+
+  it("pluralises partial run count", () => {
+    expect(formatBucketCost(5.0, 2, 0, 4).title).toMatch(/2 partial runs/);
+  });
+
+  it("surfaces null-cost runs in the tooltip without inflating the figure", () => {
+    const c = formatBucketCost(2.0, 0, 1, 3);
+    expect(c.text).toBe("~$2.00");
+    expect(c.empty).toBe(false);
+    expect(c.title).toMatch(/1 run had no transcript \(excluded\)/);
+  });
+
+  it("renders — (never $0) for a bucket with no priced runs (all null)", () => {
+    const c = formatBucketCost(0, 0, 3, 3);
+    expect(c.text).toBe("—");
+    expect(c.empty).toBe(true);
+    expect(c.text).not.toContain("$");
+    // The tooltip still explains why it is empty.
+    expect(c.title).toMatch(/3 runs had no transcript/);
+  });
+
+  it("renders — for a bucket with no runs at all", () => {
+    const c = formatBucketCost(0, 0, 0, 0);
+    expect(c.text).toBe("—");
+    expect(c.empty).toBe(true);
+  });
+});

--- a/frontend/src/lib/costLabel.ts
+++ b/frontend/src/lib/costLabel.ts
@@ -1,0 +1,87 @@
+// Honest cost labelling, shared by the per-run stat (PipelineInfoPanel, #272)
+// and the aggregated Stats charts (#377). ADR-0001 (sharp tool, honest labels) +
+// ADR-0022 (estimate from local transcripts, never an invoice): every cost the
+// UI shows is framed as an estimate; any unpriced-model contribution makes it a
+// lower bound (`†`); an uncomputable/empty bucket renders `—`, never `$0`.
+//
+// The vocabulary lives here ONCE so the per-run row and the charts stay
+// byte-identical.
+
+/** Adaptive precision: sub-dollar estimates show 4 decimals, else 2 (#272). */
+export function costPrecision(usd: number): number {
+  return usd < 1 ? 4 : 2;
+}
+
+/** Base note framing any cost figure as an estimate (matches `/estimate/i`). */
+export const COST_ESTIMATE_NOTE =
+  "Estimate from local Claude Code token usage × public list prices — not an invoice.";
+
+/** Lower-bound clause appended when an unpriced model was excluded (matches
+ *  `/lower bound/i`). Byte-identical between the per-run row and the charts. */
+export const COST_LOWER_BOUND_NOTE = " Lower bound: an unpriced model was excluded.";
+
+export interface CostLabel {
+  /** Display text, e.g. `~$1.2345`. */
+  text: string;
+  /** Whether to render the `†` lower-bound marker. */
+  dagger: boolean;
+  /** Full tooltip string. */
+  title: string;
+}
+
+/**
+ * Format a single run's estimated cost (#272): `~$X` at adaptive precision, with
+ * a `†` marker and a "lower bound" note when the estimate excluded an unpriced
+ * model.
+ */
+export function formatEstCost(usd: number, partial: boolean): CostLabel {
+  return {
+    text: `~$${usd.toFixed(costPrecision(usd))}`,
+    dagger: partial,
+    title: COST_ESTIMATE_NOTE + (partial ? COST_LOWER_BOUND_NOTE : ""),
+  };
+}
+
+export interface CostBucketLabel extends CostLabel {
+  /** Nothing priced (no runs, or every run lacked a transcript) → render `—`. */
+  empty: boolean;
+}
+
+function plural(n: number, word: string): string {
+  return `${n} ${word}${n === 1 ? "" : "s"}`;
+}
+
+/**
+ * Format an aggregated cost bucket (#377). A bucket is a **sum of lower bounds**:
+ *
+ * - any `partial` run makes the whole bucket a lower bound (`†`);
+ * - runs with no transcript (`nullCount`) are excluded from `usd` but surfaced
+ *   in the tooltip so the bucket is never silently undercounted;
+ * - a bucket with nothing priced (`runs === 0`, or every run was null) renders
+ *   `—`, never `$0` (a wrong number, not a placeholder).
+ */
+export function formatBucketCost(
+  usd: number,
+  partialCount: number,
+  nullCount: number,
+  runs: number,
+): CostBucketLabel {
+  const priced = runs - nullCount;
+  const empty = priced <= 0;
+  const partial = partialCount > 0;
+
+  let title = COST_ESTIMATE_NOTE;
+  if (partial) {
+    title += `${COST_LOWER_BOUND_NOTE} (${plural(partialCount, "partial run")}).`;
+  }
+  if (nullCount > 0) {
+    title += ` ${plural(nullCount, "run")} had no transcript (excluded).`;
+  }
+
+  return {
+    text: empty ? "—" : `~$${usd.toFixed(costPrecision(usd))}`,
+    dagger: partial,
+    title,
+    empty,
+  };
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -542,3 +542,67 @@ export interface PipelineDetail {
   prompts: Record<string, string>;
   diagnostics: string[];
 }
+
+// --- Instance stats cockpit (#377, ADR-0029) --------------------------------
+// Mirrors the daemon's `GET /stats/overview` (cheap indexed SQL) and
+// `GET /stats/cost` (memoized per-run cost, app-folded) payloads.
+
+export interface StatsBucketCount {
+  /** Period label (e.g. `2026-07-15`), as produced by SQLite `strftime`. */
+  bucket: string;
+  count: number;
+}
+
+export interface StatsPipelineFireCount {
+  /** Trigger's `pipeline_id`, or `"(deleted trigger)"` for an orphan fire. */
+  pipeline_id: string;
+  count: number;
+}
+
+export interface StatsTriggersCreatedRuns {
+  /** Fires whose outcome was `fired` (⟺ a run was created) in the window. */
+  fired: number;
+  /** Distinct triggers that fired at least once in the window. */
+  distinct_triggers: number;
+  /** Triggers currently enabled (point-in-time, not windowed). */
+  enabled_triggers: number;
+}
+
+export interface StatsOverview {
+  /** Sorted union of period labels across runs/errors/sessions (the x-axis). */
+  buckets: string[];
+  runs: StatsBucketCount[];
+  /** `run_failed` only — `run_skipped` is NOT an error. */
+  errors: StatsBucketCount[];
+  /** `node_started` starts (re-spawns and loop laps included, manager excluded). */
+  sessions: StatsBucketCount[];
+  fires_by_pipeline: StatsPipelineFireCount[];
+  triggers_created_runs: StatsTriggersCreatedRuns;
+}
+
+/** A cost breakdown row. Cost is a **sum of lower bounds**: `partial` runs and
+ *  `null` runs (no transcript, excluded from `usd`) are counted separately so
+ *  the number is never silently undercounted (ADR-0001 / ADR-0022). */
+export interface StatsCostBucket {
+  usd: number;
+  /** Runs whose cost is a lower bound (an unpriced model was excluded). */
+  partial: number;
+  /** Runs with no transcript, excluded from `usd` but surfaced. */
+  null: number;
+  /** Total runs folded here (priced + partial + null). */
+  runs: number;
+}
+
+export interface StatsCostPeriodBucket extends StatsCostBucket {
+  bucket: string;
+}
+
+export interface StatsCostKeyBucket extends StatsCostBucket {
+  key: string;
+}
+
+export interface StatsCost {
+  by_period: StatsCostPeriodBucket[];
+  by_pipeline: StatsCostKeyBucket[];
+  by_project: StatsCostKeyBucket[];
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -28,6 +28,9 @@ export default defineConfig({
       '/triggers': daemonTarget,
       '/stale': daemonTarget,
       '/settings': daemonTarget,
+      // #377: instance stats cockpit. New top-level `/stats` prefix, so it needs
+      // its own proxy entry (else dev GET /stats/* lies with a SPA 200).
+      '/stats': daemonTarget,
     },
   },
   test: {


### PR DESCRIPTION
Cross-run stats modal: cost / sessions / triggers / runs aggregates, filterable by period.

Backend: `stats.rs` (windowed indexed SQL — `run_skipped` excluded from errors, `LEFT JOIN triggers`, pure `fold_cost`), `run_cost.rs` RAM memo keyed on `(run_id, max transcript mtime)` (single-run path unchanged, ADR-0022 byte-identical), `pipeline_id` `RunStarted` field with `pipeline_name` fallback + updated golden. ADR-0029.

Frontend: `StatsModal` + lazy `StatsCharts` (first `React.lazy`, recharts code-split into its own chunk), `useStats` hook, shared `costLabel` (`—`-never-`$0` vocabulary). Two-endpoint split: `/stats/overview` on open, `/stats/cost` only on the Cost tab. Vite proxy whitelist updated for `/stats/*`.

Validated: CI-equivalent gate (fmt/clippy/tsc/eslint clean, Rust 1298/0, vitest 1319/0), FP-377 Level-5 agentic test against a hand-seeded SQLite oracle across three independent sources, and a diff read.

Version bumped to v0.1.97.

Closes #377