### PR TITLE
fix(#385): close Pipeline Info overlay on active-tab change — v0.1.98

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "0.1.97"
+version = "0.1.98"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "0.1.97"
+version = "0.1.98"
 license = "MIT"
 
 [workspace.dependencies]

--- a/frontend/e2e/pipeline-info-panel.spec.ts
+++ b/frontend/e2e/pipeline-info-panel.spec.ts
@@ -17,13 +17,17 @@ async function dismissConflictIfPresent(page: Page): Promise<void> {
   }
 }
 
-// Layer 3b — Pipeline info panel (refs #56, #69, ADR 0004).
+// Layer 3b — Pipeline info panel (refs #56, #69, #385, ADR 0004).
 // Verifies:
 // 1. Clicking the toolbar `i` icon opens the PipelineInfoPanel.
 // 2. The panel shows pipeline metadata (name).
 // 3. During a Run, a terminal element is present for the manager session.
 // 4. Clicking a node in the canvas auto-closes the info panel (#69).
 // 5. YAML tab shows serialized pipeline and updates on canvas mutation (#69).
+// 6. Selecting a DIFFERENT run auto-closes the info panel (#385), including two
+//    runs of the same pipeline; reselecting the already-active run is a no-op.
+// 7. Selecting a Trigger closes the info panel and surfaces the Trigger detail
+//    from behind it (#385 — info outranks trigger in rightPaneOwner until closed).
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const WORKSPACE_ROOT = path.resolve(__dirname, "..", "..");
@@ -291,4 +295,137 @@ test("library tab after a run: panel shows template, not the previous run", asyn
       // ok
     }
   }
+});
+
+// Shared tmux cleanup for a run created by the #385 cases below.
+async function killRunSessions(runId: string): Promise<void> {
+  const { execSync } = await import("node:child_process");
+  for (const session of [`pdo-${runId}-worker-iter-1`, `pdo-mgr-${runId}`]) {
+    try {
+      execSync(`tmux kill-session -t ${session}`, { stdio: "ignore" });
+    } catch {
+      // ok
+    }
+  }
+}
+
+test("selecting a different run closes the pipeline info panel (#385)", async ({
+  page,
+  baseURL,
+}) => {
+  await page.goto("/");
+  await expect(page.getByText("Daemon: connected")).toBeVisible({
+    timeout: 10_000,
+  });
+
+  // Two runs of the SAME pipeline — run tabs are keyed __run__<id>, so switching
+  // between them still moves activeTabId (the make-or-break edge case for #385).
+  const mkRun = async (): Promise<string> => {
+    const r = await page.request.post(`${baseURL}/runs`, {
+      multipart: { pipeline: PIPELINE_NAME, input: "e2e #385" },
+    });
+    expect(r.status()).toBe(201);
+    return (await r.json()).run_id as string;
+  };
+  const runA = await mkRun();
+  const runB = await mkRun();
+
+  // Select run A and open the info overlay on it.
+  await page
+    .getByText(runA.slice(0, 20))
+    .first()
+    .click({ timeout: 5_000, position: { x: 5, y: 5 } });
+  await page.waitForTimeout(500);
+  const infoBtn = page.getByTestId("toolbar-info");
+  await expect(infoBtn).toBeVisible({ timeout: 3_000 });
+  await infoBtn.click();
+  const infoPanel = page.getByTestId("pipeline-info-panel");
+  await expect(infoPanel).toBeVisible({ timeout: 3_000 });
+
+  // Select the OTHER run → the overlay must auto-close (#385).
+  await page
+    .getByText(runB.slice(0, 20))
+    .first()
+    .click({ timeout: 5_000, position: { x: 5, y: 5 } });
+  await expect(infoPanel).not.toBeVisible({ timeout: 3_000 });
+
+  // Reselecting the SAME (now-active) run must NOT reopen the overlay (no-op):
+  // activeTabId is unchanged, so #385 does not fire.
+  await page
+    .getByText(runB.slice(0, 20))
+    .first()
+    .click({ timeout: 5_000, position: { x: 5, y: 5 } });
+  await page.waitForTimeout(300);
+  await expect(infoPanel).not.toBeVisible();
+
+  await killRunSessions(runA);
+  await killRunSessions(runB);
+});
+
+test("selecting a Trigger surfaces its detail from behind the open info panel (#385)", async ({
+  page,
+  baseURL,
+}) => {
+  await page.goto("/");
+  await expect(page.getByText("Daemon: connected")).toBeVisible({
+    timeout: 10_000,
+  });
+
+  // Seed a Trigger for PIPELINE_NAME. `input_template` is required because the
+  // seeded pipeline is prompt_required by default (a cron-only trigger would be
+  // rejected). cron never fires within the test window.
+  const trigResp = await page.request.post(`${baseURL}/triggers`, {
+    data: {
+      name: `e2e-385-${process.pid}`,
+      pipeline_id: PIPELINE_NAME,
+      cron: "0 0 1 1 *",
+      input_template: "e2e #385 trigger",
+    },
+  });
+  expect(trigResp.status()).toBe(201);
+  const triggerId = (await trigResp.json()).id as string;
+
+  // A run gives the info overlay a tab (__run__<id>) that is DIFFERENT from the
+  // Trigger's pipeline template tab, so selecting the Trigger genuinely moves
+  // activeTabId (avoids the "pipeline already active" no-op).
+  const runResp = await page.request.post(`${baseURL}/runs`, {
+    multipart: { pipeline: PIPELINE_NAME, input: "e2e #385 trigger-run" },
+  });
+  expect(runResp.status()).toBe(201);
+  const runId = (await runResp.json()).run_id as string;
+
+  // Reload so the mount refresh picks up the seeded trigger + run.
+  await page.reload();
+  await expect(page.getByText("Daemon: connected")).toBeVisible({
+    timeout: 10_000,
+  });
+
+  // Open the info overlay on the run tab.
+  await page
+    .getByText(runId.slice(0, 20))
+    .first()
+    .click({ timeout: 5_000, position: { x: 5, y: 5 } });
+  await page.waitForTimeout(500);
+  const infoBtn = page.getByTestId("toolbar-info");
+  await expect(infoBtn).toBeVisible({ timeout: 3_000 });
+  await infoBtn.click();
+  const infoPanel = page.getByTestId("pipeline-info-panel");
+  await expect(infoPanel).toBeVisible({ timeout: 3_000 });
+
+  // Switch the LEFT panel to the Triggers tab (does NOT touch activeTabId, so
+  // the overlay stays open) and click the Trigger row.
+  await page.getByRole("tab", { name: "Triggers" }).click();
+  const triggerRow = page.getByTestId("trigger-row").first();
+  await expect(triggerRow).toBeVisible({ timeout: 3_000 });
+  await triggerRow.click();
+
+  // The overlay must close AND the Trigger detail must surface (before the fix
+  // the detail stayed hidden behind the overlay — info outranks trigger).
+  await expect(infoPanel).not.toBeVisible({ timeout: 3_000 });
+  await expect(page.getByTestId("trigger-detail-panel")).toBeVisible({
+    timeout: 3_000,
+  });
+
+  await page.request.delete(`${baseURL}/triggers/${triggerId}`);
+  await killRunSessions(runId);
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import { fetchRuns, fetchRun, fetchTriggers, fetchSessions, fetchTriggersHealth,
 import { pickLatestLiveNode } from "./lib/pickLatestLiveNode";
 import { rightPaneOwner } from "./lib/rightPaneOwner";
 import { shouldClearTriggerOnCanvasFocus } from "./lib/triggerCanvasReconcile";
+import { shouldCloseInfoOnTabChange } from "./lib/infoPanelReconcile";
 import type { RunListEntry, RunState, NodeState, Trigger, DaemonStatus } from "./types";
 import { isLiveRun } from "./types";
 import SessionCounter from "./components/SessionCounter";
@@ -281,6 +282,32 @@ export default function App() {
     ) {
       setSelectedTriggerId(null);
     }
+  }
+
+  // #385: the Pipeline Info peek overlay is tab-scoped and shadows the right
+  // pane while open (rightPaneOwner gives it top precedence). Close it when the
+  // active tab changes — selecting a different run/library-pipeline (left
+  // panel), a Trigger opening its pipeline, or a TabBar switch all move
+  // `editActiveTabId`. Canvas node/edge/note clicks already close it via
+  // EditCanvas.onCloseInfo.
+  //
+  // Same render-time reset-on-change idiom as the #320 block above (adjust
+  // state during render, not in an effect, to avoid painting one stale frame).
+  // CRITICAL: advance `lastInfoTabId` UNCONDITIONALLY — if the advance were
+  // gated on `infoPanelOpen`, the tracker would go stale while the overlay is
+  // closed and spuriously close the NEXT overlay one frame after it opens on a
+  // new tab (and gating would also re-fire this block every render). `useState`
+  // (not a ref): the value is read during render, which react-hooks/refs
+  // forbids — the same reason `triggerOpenedTabId` above is state.
+  const [lastInfoTabId, setLastInfoTabId] = useState<string | null>(editActiveTabId);
+  if (lastInfoTabId !== editActiveTabId) {
+    const closeInfo = shouldCloseInfoOnTabChange({
+      prevTabId: lastInfoTabId,
+      nextTabId: editActiveTabId,
+      infoOpen: infoPanelOpen,
+    });
+    setLastInfoTabId(editActiveTabId); // UNCONDITIONAL — mirrors the #320 block
+    if (closeInfo) setInfoPanelOpen(false);
   }
 
   const selectedTrigger =

--- a/frontend/src/lib/infoPanelReconcile.test.ts
+++ b/frontend/src/lib/infoPanelReconcile.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { shouldCloseInfoOnTabChange } from "./infoPanelReconcile";
+import type { InfoPanelReconcileInputs } from "./infoPanelReconcile";
+
+describe("shouldCloseInfoOnTabChange (#385)", () => {
+  it("closes when the tab changed and the overlay is open", () => {
+    expect(shouldCloseInfoOnTabChange({ prevTabId: "a", nextTabId: "b", infoOpen: true })).toBe(true);
+  });
+
+  it("stays open when the tab did not change (reselect same run/tab)", () => {
+    expect(shouldCloseInfoOnTabChange({ prevTabId: "a", nextTabId: "a", infoOpen: true })).toBe(false);
+  });
+
+  it("no-op when the overlay is already closed", () => {
+    expect(shouldCloseInfoOnTabChange({ prevTabId: "a", nextTabId: "b", infoOpen: false })).toBe(false);
+  });
+
+  // Two runs of the SAME pipeline still differ — run tabs are keyed
+  // `__run__<runId>`. This is the make-or-break edge case for #385.
+  it("closes when switching between two runs of the same pipeline", () => {
+    expect(
+      shouldCloseInfoOnTabChange({ prevTabId: "__run__A", nextTabId: "__run__B", infoOpen: true }),
+    ).toBe(true);
+  });
+
+  // Full truth table — enumerate every combination (test-everything rule).
+  it("matches the full truth table", () => {
+    const cases: Array<[InfoPanelReconcileInputs, boolean]> = [
+      [{ prevTabId: "a", nextTabId: "a", infoOpen: false }, false],
+      [{ prevTabId: "a", nextTabId: "a", infoOpen: true }, false],
+      [{ prevTabId: "a", nextTabId: "b", infoOpen: false }, false],
+      [{ prevTabId: "a", nextTabId: "b", infoOpen: true }, true],
+      [{ prevTabId: null, nextTabId: "__run__b", infoOpen: true }, true],
+      [{ prevTabId: "a", nextTabId: null, infoOpen: true }, true],
+      [{ prevTabId: null, nextTabId: null, infoOpen: true }, false],
+      [{ prevTabId: null, nextTabId: null, infoOpen: false }, false],
+    ];
+    for (const [input, want] of cases) expect(shouldCloseInfoOnTabChange(input)).toBe(want);
+  });
+});

--- a/frontend/src/lib/infoPanelReconcile.ts
+++ b/frontend/src/lib/infoPanelReconcile.ts
@@ -1,0 +1,30 @@
+export interface InfoPanelReconcileInputs {
+  /** The active edit-tab id captured at the previous render (the tracker snapshot). */
+  prevTabId: string | null;
+  /** The active edit-tab id now. */
+  nextTabId: string | null;
+  /** Whether the Pipeline Info peek overlay is currently open. */
+  infoOpen: boolean;
+}
+
+/**
+ * Decide whether the Pipeline Info peek overlay should auto-close because the
+ * active edit tab changed (#385).
+ *
+ * The overlay is toggled from the canvas and given TOP precedence by
+ * `rightPaneOwner`, so while open it shadows whatever inspector the right pane
+ * would otherwise show. Its content is bound to the ACTIVE tab (that tab's
+ * pipeline / run), so when the active tab changes the overlay is describing a
+ * tab that is no longer in focus — closing it is the coherent choice.
+ *
+ * Selecting a different run/library-pipeline/trigger-pipeline, and switching
+ * tabs, all move `activeTabId` (run tabs are keyed `__run__<runId>`, so two
+ * runs of the SAME pipeline still differ). Reselecting the already-active tab
+ * leaves `activeTabId` unchanged (`prevTabId === nextTabId`) → keep it open.
+ *
+ * Keyed on the tab id, NOT on `selection`: the live-run auto-snap effect mutates
+ * `selection` (none → node) with no user intent, which would spuriously close.
+ */
+export function shouldCloseInfoOnTabChange(input: InfoPanelReconcileInputs): boolean {
+  return input.infoOpen && input.prevTabId !== input.nextTabId;
+}


### PR DESCRIPTION
Closes #385

The Pipeline Info peek overlay dismissed itself on canvas node/edge/note clicks but not when a different run/pipeline was selected in the left panel or a tab was switched — leaving it stranded on top of the new selection. All those selections converge on the editStore `activeTabId`, so it's now watched at render time and the overlay closes on a genuine tab change.

- New pure predicate `lib/infoPanelReconcile.ts` (`shouldCloseInfoOnTabChange`) with a truth-table unit test, mirroring `rightPaneOwner` / `triggerCanvasReconcile`.
- `App.tsx`: `lastInfoTabId` render-time tracker (advanced unconditionally, next to the #320 `lastCanvasFocus` block).
- Incidentally fixes the latent bug where selecting a Trigger left its detail hidden behind the overlay.
- Two new #385 Playwright e2e cases (different-run close incl. same-pipeline runs; Trigger detail surfaces).

Validation: full CI-equivalent build green (npm ci / vitest 1324✓ / eslint / tsc / vite build / `cargo +stable build`) plus live visual confirmation via chrome-devtools on an isolated stack (two runs of the same pipeline — the make-or-break keyed-tab case). Version bumped to v0.1.98.

🤖 Generated with [Claude Code](https://claude.com/claude-code)