### PR TITLE
fix(#373): reactivate stale-detection Stale/AutoComplete (encoder fix + assess_node carve) — v0.1.99

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "0.1.98"
+version = "0.1.99"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "0.1.98"
+version = "0.1.99"
 license = "MIT"
 
 [workspace.dependencies]

--- a/crates/pdo-daemon/src/event_log.rs
+++ b/crates/pdo-daemon/src/event_log.rs
@@ -93,6 +93,13 @@ pub enum EventKind {
     /// Behaviour-preserving no-op in projection — the node stays Running;
     /// recovery is deferred (Slice 2/3). Wire form: `"node_blocked_on_limit"`.
     NodeBlockedOnLimit,
+    /// Informational (#373 Unit A): the stale sweep found a node idle past the
+    /// threshold with valid outputs — it *would* auto-complete, but the terminal
+    /// reap/advance is trust-gated (Unit B / ADR-0012), so under the `Observe`
+    /// policy this non-terminal marker is emitted instead of `NodeAutoCompleted`.
+    /// Behaviour-preserving no-op in projection — the node stays Running.
+    /// Wire form: `"node_auto_complete_observed"`.
+    NodeAutoCompleteObserved,
     PipelineLint,
     PipelineModified,
     RunCompleted,
@@ -609,10 +616,13 @@ pub fn project(events: &[Event]) -> Option<RunState> {
                 apply_pipeline_event(&mut state, event)
             }
 
-            // #290: informational only — the node stays in its current status
-            // (Running). Behaviour-preserving no-op, exactly like `PipelineLint`;
-            // recovery/unblocking is deferred (Slice 2/3). No node/run state touched.
-            EventKind::NodeBlockedOnLimit => {}
+            // #290 / #373: informational only — the node stays in its current
+            // status (Running). Behaviour-preserving no-op, exactly like
+            // `PipelineLint`. `NodeBlockedOnLimit` recovery is deferred (Slice
+            // 2/3); `NodeAutoCompleteObserved` is the observe-only marker whose
+            // terminal counterpart (`NodeAutoCompleted`) is trust-gated to Unit
+            // B (#373 / ADR-0012). No node/run state touched.
+            EventKind::NodeBlockedOnLimit | EventKind::NodeAutoCompleteObserved => {}
 
             EventKind::CommandIssued => apply_command_event(&mut state, event),
         }
@@ -3263,6 +3273,7 @@ mod tests {
             EventKind::NodeAutoCompleted,
             EventKind::NodeStale,
             EventKind::NodeBlockedOnLimit,
+            EventKind::NodeAutoCompleteObserved,
             EventKind::RunPaused,
             EventKind::RunResumed,
         ];
@@ -3271,6 +3282,7 @@ mod tests {
             "\"node_auto_completed\"",
             "\"node_stale\"",
             "\"node_blocked_on_limit\"",
+            "\"node_auto_complete_observed\"",
             "\"run_paused\"",
             "\"run_resumed\"",
         ];

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -6753,6 +6753,58 @@ fn gather_session_death_diagnostics(
     }
 }
 
+/// Sweep-time [`stale_detector::NodeProbes`] adapter (#373): binds one running
+/// node's tmux + filesystem context so [`stale_detector::assess_node`] can run
+/// the whole detection pipeline with real I/O injected. Every method is a
+/// side-effect-free read; the sweep itself performs the reap/spawn side effects
+/// keyed off the returned detection.
+struct SweepNodeProbes<'a> {
+    socket: &'a str,
+    session_name: &'a str,
+    working_dir: &'a Path,
+    pipeline_path: &'a Path,
+    artifacts_dir: &'a Path,
+    run_id: &'a str,
+    node_id: &'a str,
+    iter: i64,
+    running: &'a [(String, i64)],
+}
+
+impl stale_detector::NodeProbes for SweepNodeProbes<'_> {
+    fn session_alive(&self) -> bool {
+        tmux_session_manager::session_exists(self.socket, self.session_name)
+    }
+
+    fn jsonl_mtime(&self) -> Option<std::time::SystemTime> {
+        stale_detector::find_session_jsonl(self.working_dir)
+            .and_then(|p| std::fs::metadata(&p).ok())
+            .and_then(|m| m.modified().ok())
+    }
+
+    fn validate_outputs(&self) -> bool {
+        stale_detector::validate_outputs(
+            self.pipeline_path,
+            self.node_id,
+            self.iter,
+            self.artifacts_dir,
+        )
+    }
+
+    fn capture_pane(&self) -> Option<String> {
+        tmux_session_manager::capture(self.socket, self.session_name)
+    }
+
+    fn session_death_diagnostics(&self) -> stale_detector::SessionDeathDiagnostics {
+        gather_session_death_diagnostics(
+            self.socket,
+            self.run_id,
+            self.node_id,
+            self.iter,
+            self.running,
+        )
+    }
+}
+
 async fn run_stale_detection(state: &AppState) {
     // Record liveness at sweep start (#251): a wedged sweep freezes this value
     // while an isolated panic still advances it, so `GET /stale/health` answers
@@ -6824,97 +6876,57 @@ async fn run_stale_detection(state: &AppState) {
             };
 
             let session_name = tmux_session_manager::node_session_name(run_id, node_id, *iter);
-            let session_alive = tmux_session_manager::session_exists(&socket, &session_name);
 
-            let jsonl_mtime = stale_detector::find_session_jsonl(&working_dir)
-                .and_then(|p| std::fs::metadata(&p).ok())
-                .and_then(|m| m.modified().ok());
-
-            let artifacts_valid = if jsonl_mtime
-                .and_then(|mt| now.duration_since(mt).ok())
-                .is_some_and(|age| age >= stale_detector::STALE_THRESHOLD)
-            {
-                Some(stale_detector::validate_outputs(
-                    &pipeline_path,
-                    node_id,
-                    *iter,
-                    &artifacts_dir,
-                ))
-            } else {
-                None
+            // #373: the whole probe → gate → decide → events → diagnostics →
+            // usage-limit-dedup pipeline lives in `assess_node`, with all tmux +
+            // filesystem I/O injected via this adapter. The sweep only appends
+            // the returned events and runs the reap/spawn side effects below.
+            let probes = SweepNodeProbes {
+                socket: &socket,
+                session_name: &session_name,
+                working_dir: &working_dir,
+                pipeline_path: &pipeline_path,
+                artifacts_dir: &artifacts_dir,
+                run_id,
+                node_id,
+                iter: *iter,
+                running: &running,
             };
 
-            let probe = stale_detector::NodeProbe {
-                session_alive,
-                jsonl_mtime,
+            // #373 Unit A: auto-complete is OBSERVE-ONLY. Re-arming the terminal
+            // reap/advance is the trust-gated Unit B decision (ADR-0012) — it can
+            // fire falsely on a node mid a legitimate >STALE_THRESHOLD tool call
+            // whose outputs already validate. `Stale` (recoverable, session stays
+            // alive) and `SessionDied` ship live.
+            let assessment = stale_detector::assess_node(
+                &probes,
+                &events,
+                run_id,
+                node_id,
+                *iter,
                 now,
-                artifacts_valid,
-            };
+                stale_detector::AutoCompletePolicy::Observe,
+            );
 
-            let detection = stale_detector::decide(&probe);
-            if detection == stale_detector::Detection::Ok {
-                // #290 (Slice 1, observability only): a node can be alive &
-                // non-stale yet stuck on Claude Code's usage-limit menu (a
-                // host-level prompt, no progress). Detect it, flag it, and KEEP
-                // THE NODE RUNNING — no recovery here (deferred to Slice 2/3).
-                if let Some(pane) = tmux_session_manager::capture(&socket, &session_name) {
-                    if stale_detector::detect_usage_limit(&pane) {
-                        blocked_on_limit_count += 1;
-                        // Rising-edge de-dup: emit once per (node, iter) episode,
-                        // else a held menu would emit every ~30 s sweep tick. The
-                        // durable event log (reloaded fresh each sweep) is the
-                        // dedup key, so this also survives a daemon restart.
-                        let already = events.iter().any(|e| {
-                            e.kind == event_log::EventKind::NodeBlockedOnLimit
-                                && e.node_id.as_deref() == Some(node_id.as_str())
-                                && e.iter == Some(*iter)
-                        });
-                        if !already {
-                            let ev = event_log::Event {
-                                id: None,
-                                run_id: run_id.to_string(),
-                                ts: event_log::now_iso(),
-                                kind: event_log::EventKind::NodeBlockedOnLimit,
-                                node_id: Some(node_id.to_string()),
-                                iter: Some(*iter),
-                                payload: Some(serde_json::json!({ "signal": "usage_limit_menu" })),
-                            };
-                            if let Err(e) = append_event(state, &ev).await {
-                                error!("Stale detector: failed to append NodeBlockedOnLimit: {e}");
-                            }
-                        }
-                    }
-                }
-                continue;
+            if assessment.blocked_on_limit {
+                blocked_on_limit_count += 1;
             }
 
-            let mut events = stale_detector::detection_events(&detection, run_id, node_id, *iter);
-
-            // #234: when a node's session is found dead, capture the diagnostic
-            // context *now* (cheaply available, gone moments later) and fold it
-            // into the NodeFailed payload. Otherwise the daemon records only the
-            // symptom and every occurrence forces from-scratch RCA.
-            let session_death_diag =
-                (detection == stale_detector::Detection::SessionDied).then(|| {
-                    let diag =
-                        gather_session_death_diagnostics(&socket, run_id, node_id, *iter, &running);
-                    stale_detector::attach_diagnostics(&mut events, &diag);
-                    diag
-                });
-
-            for event in &events {
-                // Transition guard (#212): append_event re-validates against
-                // the freshly projected state, so a node that terminated
-                // organically since this loop's snapshot never receives a
-                // late NodeStale / NodeAutoCompleted (dropped as a no-op).
+            for event in &assessment.events {
+                // Transition guard (#212): append_event re-validates against the
+                // freshly projected state, so a node that terminated organically
+                // since this loop's snapshot never receives a late
+                // NodeStale/NodeFailed (dropped as a no-op). The informational
+                // markers (NodeBlockedOnLimit, NodeAutoCompleteObserved) are not
+                // lifecycle transitions and pass straight through.
                 if let Err(e) = append_event(state, event).await {
                     error!("Stale detector: failed to append event: {e}");
                 }
             }
 
-            match detection {
+            match assessment.detection {
                 stale_detector::Detection::SessionDied => {
-                    let diag = session_death_diag.unwrap_or_default();
+                    let diag = assessment.session_death_diagnostics.unwrap_or_default();
                     info!(
                         "Stale detector: node {node_id} in run {run_id} — session died \
                          (tmux_server_alive={:?}, correlated_deaths={}, \
@@ -6931,17 +6943,15 @@ async fn run_stale_detection(state: &AppState) {
                     retry_waiting_nodes(state).await;
                 }
                 stale_detector::Detection::AutoComplete => {
+                    // #373 Unit A observe-only: `assess_node` emitted the
+                    // non-terminal NodeAutoCompleteObserved marker (node stays
+                    // Running); we deliberately do NOT reap / spawn / retry. Under
+                    // `AutoCompletePolicy::Act` (Unit B) this arm would reap the
+                    // idle session and advance the pipeline.
                     info!(
-                        "Stale detector: node {node_id} in run {run_id} — auto-completing (idle + valid outputs)"
+                        "Stale detector: node {node_id} in run {run_id} — WOULD auto-complete \
+                         (idle + valid outputs); observe-only (#373 Unit A), node left Running"
                     );
-                    // Reap on terminal state (#205): the idle session is still
-                    // live — snapshot its pane then kill it so it never lingers
-                    // toward the tmux-collapse point (#77/#78).
-                    reap_node_session(state, &repo_root, run_id, node_id, *iter);
-                    spawn_ready_after_event(state, run_id).await;
-                    // The node completed: its slot freed. Re-drive throttled
-                    // `waiting` nodes across all runs (#159).
-                    retry_waiting_nodes(state).await;
                 }
                 stale_detector::Detection::Stale => {
                     info!(

--- a/crates/pdo-daemon/src/run_cost.rs
+++ b/crates/pdo-daemon/src/run_cost.rs
@@ -16,11 +16,12 @@
 //!   transcript. We dedup by `(message.id, requestId)`, keeping the first — the
 //!   `usage` is byte-identical within a group, so keep-one is exact (matches
 //!   `ccusage`). Without it the number is 2–3× too high.
-//! - **Own path encoder.** [`crate::stale_detector::encode_working_dir`] is buggy
-//!   for PDO dirs (strips the leading `/`, doesn't map `.`), so it returns `None`
-//!   for every node. Cost uses its own correct [`cc_project_dirname`] and does
-//!   NOT touch the shared fn (fixing it re-activates dead stale-detection logic
-//!   — a separate, riskier change; see the doc-comment there).
+//! - **Path encoder.** [`cc_project_dirname`] maps a working dir to the name CC
+//!   writes under `~/.claude/projects/`. Since #373 it delegates to the (now
+//!   correct) [`crate::stale_detector::encode_working_dir`] — one source of
+//!   truth. Historically it reimplemented the mapping to route around a bug in
+//!   that function (it stripped the leading `/` and left `.` unmapped, so the
+//!   stale-detector's mtime probe resolved `None` for every node).
 //! - **Cache tokens don't overlap `input_tokens`.** CC's `input_tokens` excludes
 //!   cache tokens, so the four buckets sum without subtraction (matches ccusage).
 //! - **Tolerant parsing.** Torn writes (an interleaved-flush `clauclaude-opus-4-8`
@@ -197,13 +198,11 @@ fn aggregate(lines: impl Iterator<Item = Line>) -> CostStat {
 /// Verified against real dirs: `/home/u/.pdo/runs/X/worktree` →
 /// `-home-u--pdo-runs-X-worktree`.
 ///
-/// This deliberately does NOT reuse [`crate::stale_detector::encode_working_dir`],
-/// which is buggy (see module docs and the cross-reference there).
+/// Delegates to [`crate::stale_detector::encode_working_dir`], the single source
+/// of truth for this encoding. (Historically this reimplemented the mapping to
+/// route around a bug in that function; #373 fixed and unified them.)
 pub fn cc_project_dirname(path: &Path) -> String {
-    path.to_string_lossy()
-        .chars()
-        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
-        .collect()
+    crate::stale_detector::encode_working_dir(path)
 }
 
 /// Recursively collect every parseable cost line from `*.jsonl` under `dir`.

--- a/crates/pdo-daemon/src/stale_detector.rs
+++ b/crates/pdo-daemon/src/stale_detector.rs
@@ -82,6 +82,16 @@ pub struct NodeProbe {
     pub artifacts_valid: Option<bool>,
 }
 
+/// Whether a node's transcript is idle past [`STALE_THRESHOLD`] as of `now`.
+///
+/// The **single source** of the threshold comparison (#373): both [`decide`]
+/// (the staleness authority) and [`assess_node`] (which consults it only to
+/// gate the costly outputs validation) go through here, so the gate is never
+/// re-implemented. A future `mtime` (clock skew) counts as not-idle.
+fn idle_past_threshold(mtime: SystemTime, now: SystemTime) -> bool {
+    now.duration_since(mtime).unwrap_or(Duration::ZERO) >= STALE_THRESHOLD
+}
+
 /// Pure decision logic: given the probe results, determine the detection.
 pub fn decide(probe: &NodeProbe) -> Detection {
     if !probe.session_alive {
@@ -92,8 +102,7 @@ pub fn decide(probe: &NodeProbe) -> Detection {
         return Detection::Ok;
     };
 
-    let age = probe.now.duration_since(mtime).unwrap_or(Duration::ZERO);
-    if age < STALE_THRESHOLD {
+    if !idle_past_threshold(mtime, probe.now) {
         return Detection::Ok;
     }
 
@@ -103,24 +112,26 @@ pub fn decide(probe: &NodeProbe) -> Detection {
     }
 }
 
-/// Encode a working directory path the same way Claude Code does for its
-/// projects directory.
+/// Encode a working directory path exactly as Claude Code names its
+/// `~/.claude/projects/` directory: every non-`[A-Za-z0-9]` char maps to `-`
+/// (case preserved, runs NOT collapsed). So a leading `/` becomes a leading `-`
+/// and `.pdo`/`.claude` become `--pdo`/`--claude`.
 ///
-/// Example: `/home/user/project` → `home-user-project`
+/// Example: `/home/user/project` → `-home-user-project`; a PDO node dir like
+/// `/home/u/.pdo/runs/X/worktree` → `-home-u--pdo-runs-X-worktree`.
 ///
-/// KNOWN BUG (do not fix here in a cost slice): this strips the leading `/` and
-/// does not map `.`, so a PDO node dir like `/home/u/.pdo/runs/X/worktree`
-/// encodes to `home-u--pdo-runs-X-worktree` **without** the leading `-` CC
-/// actually uses — [`find_session_jsonl`] then returns `None` for every PDO
-/// node, leaving the mtime-based stale/auto-complete probe effectively dead.
-/// Fixing it re-activates that probe (a real behavioral change, #251-adjacent),
-/// so it needs its own tests/validation. Cost estimation (#272) needs the
-/// correct dir name and therefore uses its own [`crate::run_cost::cc_project_dirname`]
-/// to stay isolated from this fix.
+/// This is the single source of truth for the CC project-dir encoding;
+/// [`crate::run_cost::cc_project_dirname`] delegates here.
+///
+/// History (#373): this previously stripped the leading `/` and left `.`
+/// intact, so [`find_session_jsonl`] resolved `None` for *every* PDO node and
+/// the mtime-based `Stale`/`AutoComplete` branches of [`decide`] were dead in
+/// production. Fixed and verified against real on-disk dirs.
 pub fn encode_working_dir(dir: &Path) -> String {
-    let s = dir.to_string_lossy();
-    let stripped = s.strip_prefix('/').unwrap_or(&s);
-    stripped.replace('/', "-")
+    dir.to_string_lossy()
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+        .collect()
 }
 
 /// Find the most recently modified `.jsonl` file in the Claude Code projects
@@ -217,6 +228,245 @@ pub fn detection_events(
         iter: Some(iter),
         payload: Some(serde_json::json!({ "reason": reason })),
     }]
+}
+
+/// Injected I/O for [`assess_node`]. The impure sweep layer ([`crate::lib`])
+/// implements this against tmux + the filesystem for one running node; unit
+/// tests supply a fake so the whole probe → gate → decide → events →
+/// diagnostics → dedup pipeline runs without a daemon.
+///
+/// Every method is a side-effect-free *read*: the reap/spawn side effects stay
+/// in the sweep, keyed off [`Assessment::detection`].
+pub trait NodeProbes {
+    /// Is the node's tmux session still alive?
+    fn session_alive(&self) -> bool;
+
+    /// mtime of the newest Claude Code transcript for this node's working dir,
+    /// or `None` when no transcript dir/file resolves.
+    fn jsonl_mtime(&self) -> Option<SystemTime>;
+
+    /// Do the node's declared outputs validate against the pipeline? Consulted
+    /// by [`assess_node`] **only** once the idle threshold is crossed, so the
+    /// (relatively costly) validation never runs on a fresh node.
+    fn validate_outputs(&self) -> bool;
+
+    /// Best-effort capture of the node's tmux pane, for the usage-limit menu
+    /// probe (#290). Only called on the `Ok` path (an alive, non-stale node).
+    fn capture_pane(&self) -> Option<String>;
+
+    /// Best-effort session-death forensics (#234). Gathered lazily — only when
+    /// the session is found dead — so no tmux/proc I/O runs on a healthy node.
+    fn session_death_diagnostics(&self) -> SessionDeathDiagnostics;
+}
+
+/// Whether the mtime-based auto-complete path is allowed to *act* (reap the
+/// idle session and advance the pipeline) or only to be *observed* (#373).
+///
+/// Auto-complete is irreversible and can fire falsely on a node mid a
+/// legitimate >[`STALE_THRESHOLD`] tool call whose outputs already validate, so
+/// re-arming the terminal action is trust-gated (ADR-0012). Unit A ships
+/// [`Observe`](Self::Observe): [`assess_node`] emits the non-terminal
+/// [`event_log::EventKind::NodeAutoCompleteObserved`] marker (node stays
+/// Running) instead of the terminal `NodeAutoCompleted`. Flipping the sweep to
+/// [`Act`](Self::Act) is the Unit B change.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AutoCompletePolicy {
+    /// Emit an observe-only marker; never reap/advance. (#373 Unit A.)
+    Observe,
+    /// Emit the terminal `NodeAutoCompleted`; the sweep reaps + advances.
+    Act,
+}
+
+/// Outcome of [`assess_node`]: the raw detection plus the events to append and
+/// the observability the sweep needs. The impure caller appends
+/// [`Self::events`] and runs any reap/spawn side effects keyed off
+/// [`Self::detection`].
+///
+/// Not `PartialEq`/`Eq`: [`event_log::Event`]'s payload is a
+/// `serde_json::Value` (no `Eq`), and callers/tests inspect the fields
+/// individually rather than compare a whole `Assessment`.
+#[derive(Debug, Clone)]
+pub struct Assessment {
+    /// Raw detection from [`decide`] (before the [`AutoCompletePolicy`] is
+    /// applied to the auto-complete event shape). The sweep drives its
+    /// reap/spawn side effects off this.
+    pub detection: Detection,
+    /// Events to append. A `SessionDied` failure already carries its
+    /// diagnostics; an `Observe`-policy auto-complete carries a non-terminal
+    /// `NodeAutoCompleteObserved`; a usage-limit menu carries a (deduped)
+    /// `NodeBlockedOnLimit`. Empty for a nominal `Ok` node.
+    pub events: Vec<event_log::Event>,
+    /// True when the node is alive & non-stale but its pane shows Claude Code's
+    /// usage-limit menu — feeds the per-sweep `blocked_on_limit` gauge (#290).
+    /// Set on every sweep the menu is visible, independent of event dedup.
+    pub blocked_on_limit: bool,
+    /// The session-death forensics gathered on the `SessionDied` path (`None`
+    /// otherwise), surfaced so the sweep can log the structured fields (#234)
+    /// without re-running the probe or re-parsing the event payload.
+    pub session_death_diagnostics: Option<SessionDeathDiagnostics>,
+}
+
+/// True when an event of `kind` for `(node_id, iter)` already exists in
+/// `prior_events` — the rising-edge de-dup key for the informational markers
+/// (`NodeBlockedOnLimit`, `NodeAutoCompleteObserved`). Pure over the event log
+/// snapshot the sweep already loaded, so a held condition emits one event, not
+/// one per ~30 s sweep tick, and the dedup survives a daemon restart.
+fn episode_has_event(
+    prior_events: &[event_log::Event],
+    kind: &EventKind,
+    node_id: &str,
+    iter: i64,
+) -> bool {
+    prior_events
+        .iter()
+        .any(|e| &e.kind == kind && e.node_id.as_deref() == Some(node_id) && e.iter == Some(iter))
+}
+
+fn informational_event(
+    kind: EventKind,
+    run_id: &str,
+    node_id: &str,
+    iter: i64,
+    payload: serde_json::Value,
+) -> event_log::Event {
+    event_log::Event {
+        id: None,
+        run_id: run_id.to_string(),
+        ts: event_log::now_iso(),
+        kind,
+        node_id: Some(node_id.to_string()),
+        iter: Some(iter),
+        payload: Some(payload),
+    }
+}
+
+/// The stale-detection policy for a single running node, with all I/O injected
+/// via `probes` (#373). This is the one place the whole pipeline lives:
+///
+/// ```text
+/// probes → STALE_THRESHOLD gate → decide → detection_events
+///        → attach_diagnostics (SessionDied) → usage-limit-dedup (Ok)
+/// ```
+///
+/// so [`crate::lib`]'s sweep is reduced to a loop that builds a [`NodeProbes`]
+/// adapter, calls this, appends [`Assessment::events`], and runs the reap/spawn
+/// side effects keyed off [`Assessment::detection`].
+///
+/// The `STALE_THRESHOLD` gate has a **single source**: [`decide`].
+/// `assess_node` consults [`NodeProbes::validate_outputs`] only once the idle
+/// age has (potentially) crossed the threshold, so a fresh node never pays for
+/// outputs validation — but the gating *decision* itself is not duplicated
+/// here, it is [`decide`]'s.
+///
+/// `prior_events` is the run's event-log snapshot, used purely for the
+/// rising-edge de-dup of the informational markers (see [`episode_has_event`]).
+pub fn assess_node(
+    probes: &impl NodeProbes,
+    prior_events: &[event_log::Event],
+    run_id: &str,
+    node_id: &str,
+    iter: i64,
+    now: SystemTime,
+    auto_complete_policy: AutoCompletePolicy,
+) -> Assessment {
+    let session_alive = probes.session_alive();
+    let jsonl_mtime = probes.jsonl_mtime();
+
+    // Validate outputs only once the transcript is idle past the threshold,
+    // via the SAME [`idle_past_threshold`] gate `decide` uses — this avoids the
+    // validation I/O on a fresh node without re-implementing the gate. `decide`
+    // remains the sole authority on the Ok/Stale/AutoComplete partition.
+    let threshold_crossed = jsonl_mtime.is_some_and(|mt| idle_past_threshold(mt, now));
+    let artifacts_valid = threshold_crossed.then(|| probes.validate_outputs());
+
+    let probe = NodeProbe {
+        session_alive,
+        jsonl_mtime,
+        now,
+        artifacts_valid,
+    };
+    let detection = decide(&probe);
+
+    match detection {
+        Detection::Ok => {
+            // Alive & non-stale, but maybe wedged on Claude Code's usage-limit
+            // menu (#290): observability only — the node keeps running. The
+            // gauge counts every sweep the menu is visible; the event is emitted
+            // once per (node, iter) episode.
+            let blocked_on_limit = probes
+                .capture_pane()
+                .is_some_and(|pane| detect_usage_limit(&pane));
+            let events = if blocked_on_limit
+                && !episode_has_event(prior_events, &EventKind::NodeBlockedOnLimit, node_id, iter)
+            {
+                vec![informational_event(
+                    EventKind::NodeBlockedOnLimit,
+                    run_id,
+                    node_id,
+                    iter,
+                    serde_json::json!({ "signal": "usage_limit_menu" }),
+                )]
+            } else {
+                vec![]
+            };
+            Assessment {
+                detection,
+                events,
+                blocked_on_limit,
+                session_death_diagnostics: None,
+            }
+        }
+        Detection::SessionDied => {
+            let mut events = detection_events(&detection, run_id, node_id, iter);
+            let diag = probes.session_death_diagnostics();
+            attach_diagnostics(&mut events, &diag);
+            Assessment {
+                detection,
+                events,
+                blocked_on_limit: false,
+                session_death_diagnostics: Some(diag),
+            }
+        }
+        Detection::AutoComplete => {
+            // #373 Unit A: re-arming the terminal auto-complete (reap + advance)
+            // is trust-gated. Under `Observe`, emit a deduped non-terminal marker
+            // so the node stays Running and the "would auto-complete" moment is
+            // durably visible; under `Act`, emit the real terminal event.
+            let events = match auto_complete_policy {
+                AutoCompletePolicy::Act => detection_events(&detection, run_id, node_id, iter),
+                AutoCompletePolicy::Observe => {
+                    if episode_has_event(
+                        prior_events,
+                        &EventKind::NodeAutoCompleteObserved,
+                        node_id,
+                        iter,
+                    ) {
+                        vec![]
+                    } else {
+                        vec![informational_event(
+                            EventKind::NodeAutoCompleteObserved,
+                            run_id,
+                            node_id,
+                            iter,
+                            serde_json::json!({ "reason": "idle_valid_outputs_observe_only" }),
+                        )]
+                    }
+                }
+            };
+            Assessment {
+                detection,
+                events,
+                blocked_on_limit: false,
+                session_death_diagnostics: None,
+            }
+        }
+        Detection::Stale => Assessment {
+            events: detection_events(&detection, run_id, node_id, iter),
+            detection,
+            blocked_on_limit: false,
+            session_death_diagnostics: None,
+        },
+    }
 }
 
 /// Best-effort diagnostic context captured the moment a node's session is found
@@ -370,24 +620,53 @@ mod tests {
         assert_eq!(strip_ansi("\x1b[1m❯\x1b[0m x"), "❯ x");
     }
 
-    // --- encode_working_dir ---
+    // --- encode_working_dir (#373: matches Claude Code's real scheme) ---
 
     #[test]
-    fn encode_basic_path() {
+    fn encode_basic_path_keeps_leading_dash() {
+        // Every non-alphanumeric maps to `-`, so a leading `/` becomes `-`.
         assert_eq!(
             encode_working_dir(Path::new("/home/user/project")),
-            "home-user-project"
+            "-home-user-project"
         );
     }
 
     #[test]
     fn encode_root() {
-        assert_eq!(encode_working_dir(Path::new("/")), "");
+        assert_eq!(encode_working_dir(Path::new("/")), "-");
     }
 
     #[test]
     fn encode_deeply_nested() {
-        assert_eq!(encode_working_dir(Path::new("/a/b/c/d/e")), "a-b-c-d-e");
+        assert_eq!(encode_working_dir(Path::new("/a/b/c/d/e")), "-a-b-c-d-e");
+    }
+
+    #[test]
+    fn encode_maps_dot_to_dash() {
+        // #373 root cause: a real PDO node dir carries `.pdo` (→ `--pdo`) and a
+        // leading `-`. Before the fix this produced `home-...-.pdo-...` and
+        // resolved nothing under ~/.claude/projects.
+        assert_eq!(
+            encode_working_dir(Path::new("/home/u/.pdo/runs/X/worktree")),
+            "-home-u--pdo-runs-X-worktree"
+        );
+    }
+
+    #[test]
+    fn encode_matches_cc_project_dirname() {
+        // The two encoders are unified on one implementation (#373): they must
+        // never drift again.
+        for dir in [
+            "/home/llenoir/Documents/perso/Maestro/.pdo/runs/2026-abc/nodes/n1/iter-1",
+            "/home/u/.claude",
+            "/tmp/x.y.z",
+        ] {
+            assert_eq!(
+                encode_working_dir(Path::new(dir)),
+                crate::run_cost::cc_project_dirname(Path::new(dir)),
+                "encode_working_dir and cc_project_dirname must agree for {dir}"
+            );
+        }
     }
 
     // --- decide (pure logic) ---
@@ -805,6 +1084,42 @@ SwapFree:         204800 kB
         assert!(find_session_jsonl(Path::new("/tmp/testdir")).is_none());
     }
 
+    #[test]
+    fn find_jsonl_resolves_a_real_pdo_node_dir() {
+        // #373 regression: a representative PDO node working dir (absolute,
+        // carries `.pdo`) must resolve to the transcript CC actually writes —
+        // i.e. under the leading-dash, `--pdo` name. Pre-fix this looked up
+        // `home-...-.pdo-...` and found nothing, so the mtime probe was dead.
+        let home_guard = TempHome::new();
+        let home = home_guard.path();
+
+        let node_dir =
+            Path::new("/home/llenoir/Documents/perso/Maestro/.pdo/runs/20260623-100032-9b8331b/nodes/gzpYZA2m/iter-1");
+
+        // The transcript dir CC writes: leading `-`, `.pdo` → `--pdo`.
+        let cc_name = home
+            .join(".claude")
+            .join("projects")
+            .join("-home-llenoir-Documents-perso-Maestro--pdo-runs-20260623-100032-9b8331b-nodes-gzpYZA2m-iter-1");
+        std::fs::create_dir_all(&cc_name).unwrap();
+        std::fs::write(cc_name.join("session.jsonl"), "{}").unwrap();
+
+        // The encoder now produces exactly that name …
+        assert_eq!(
+            home.join(".claude")
+                .join("projects")
+                .join(encode_working_dir(node_dir)),
+            cc_name
+        );
+        // … so the probe resolves the transcript.
+        let found = find_session_jsonl(node_dir);
+        assert!(
+            found.is_some(),
+            "find_session_jsonl must resolve a real PDO node transcript after the #373 fix"
+        );
+        assert_eq!(found.unwrap().file_name().unwrap(), "session.jsonl");
+    }
+
     // --- validate_outputs (integration with outputs_validator) ---
 
     #[test]
@@ -847,5 +1162,276 @@ SwapFree:         204800 kB
             1,
             &artifacts_dir
         ));
+    }
+
+    // --- assess_node (#373: whole sweep-policy pipeline with fake I/O) ---
+
+    /// A fully controllable [`NodeProbes`] fake. `validate_calls` records how
+    /// many times `validate_outputs` ran so a test can prove the threshold gate
+    /// short-circuits the (costly) validation on a fresh node.
+    struct FakeProbes {
+        session_alive: bool,
+        jsonl_mtime: Option<SystemTime>,
+        outputs_valid: bool,
+        pane: Option<String>,
+        diagnostics: SessionDeathDiagnostics,
+        validate_calls: std::cell::Cell<usize>,
+    }
+
+    impl FakeProbes {
+        /// Alive, transcript idle `age` old, outputs `valid`, no pane.
+        fn idle(age: Duration, valid: bool) -> Self {
+            Self {
+                session_alive: true,
+                jsonl_mtime: Some(SystemTime::now() - age),
+                outputs_valid: valid,
+                pane: None,
+                diagnostics: SessionDeathDiagnostics::default(),
+                validate_calls: std::cell::Cell::new(0),
+            }
+        }
+    }
+
+    impl NodeProbes for FakeProbes {
+        fn session_alive(&self) -> bool {
+            self.session_alive
+        }
+        fn jsonl_mtime(&self) -> Option<SystemTime> {
+            self.jsonl_mtime
+        }
+        fn validate_outputs(&self) -> bool {
+            self.validate_calls.set(self.validate_calls.get() + 1);
+            self.outputs_valid
+        }
+        fn capture_pane(&self) -> Option<String> {
+            self.pane.clone()
+        }
+        fn session_death_diagnostics(&self) -> SessionDeathDiagnostics {
+            self.diagnostics.clone()
+        }
+    }
+
+    fn assess(probes: &FakeProbes, policy: AutoCompletePolicy) -> Assessment {
+        assess_node(probes, &[], "run1", "worker", 1, SystemTime::now(), policy)
+    }
+
+    #[test]
+    fn assess_dead_session_fails_with_diagnostics() {
+        let probes = FakeProbes {
+            session_alive: false,
+            jsonl_mtime: Some(SystemTime::now() - Duration::from_secs(300)),
+            outputs_valid: true, // must be ignored: dead session wins
+            pane: None,
+            diagnostics: SessionDeathDiagnostics {
+                tmux_server_alive: Some(false),
+                correlated_deaths: 2,
+                ..Default::default()
+            },
+            validate_calls: std::cell::Cell::new(0),
+        };
+        let a = assess(&probes, AutoCompletePolicy::Observe);
+        assert_eq!(a.detection, Detection::SessionDied);
+        assert_eq!(a.events.len(), 1);
+        assert_eq!(a.events[0].kind, EventKind::NodeFailed);
+        // #234: diagnostics folded into the failure payload AND surfaced for the
+        // sweep's structured log.
+        assert_eq!(
+            a.events[0].payload.as_ref().unwrap()["diagnostics"]["correlated_deaths"],
+            serde_json::json!(2)
+        );
+        assert_eq!(a.session_death_diagnostics.unwrap().correlated_deaths, 2);
+        assert!(!a.blocked_on_limit);
+    }
+
+    #[test]
+    fn assess_fresh_node_is_ok_and_skips_validation() {
+        // Alive, transcript touched 60 s ago (< threshold): Ok, no events, and —
+        // the single-source gate — outputs validation is never invoked.
+        let probes = FakeProbes::idle(Duration::from_secs(60), true);
+        let a = assess(&probes, AutoCompletePolicy::Observe);
+        assert_eq!(a.detection, Detection::Ok);
+        assert!(a.events.is_empty());
+        assert_eq!(
+            probes.validate_calls.get(),
+            0,
+            "validate_outputs must NOT run before the threshold is crossed"
+        );
+    }
+
+    #[test]
+    fn assess_no_transcript_is_ok_and_skips_validation() {
+        let probes = FakeProbes {
+            session_alive: true,
+            jsonl_mtime: None,
+            outputs_valid: true,
+            pane: None,
+            diagnostics: SessionDeathDiagnostics::default(),
+            validate_calls: std::cell::Cell::new(0),
+        };
+        let a = assess(&probes, AutoCompletePolicy::Observe);
+        assert_eq!(a.detection, Detection::Ok);
+        assert!(a.events.is_empty());
+        assert_eq!(probes.validate_calls.get(), 0);
+    }
+
+    #[test]
+    fn assess_idle_invalid_outputs_is_stale() {
+        let probes = FakeProbes::idle(Duration::from_secs(200), false);
+        let a = assess(&probes, AutoCompletePolicy::Observe);
+        assert_eq!(a.detection, Detection::Stale);
+        assert_eq!(a.events.len(), 1);
+        assert_eq!(a.events[0].kind, EventKind::NodeStale);
+        assert_eq!(
+            probes.validate_calls.get(),
+            1,
+            "validate_outputs must run once past the threshold"
+        );
+    }
+
+    #[test]
+    fn assess_idle_valid_outputs_observe_only_is_non_terminal() {
+        // The core #373 Unit A guard: idle + valid outputs would auto-complete,
+        // but under Observe it must NOT emit the terminal NodeAutoCompleted —
+        // only the non-terminal observed marker.
+        let probes = FakeProbes::idle(Duration::from_secs(200), true);
+        let a = assess(&probes, AutoCompletePolicy::Observe);
+        assert_eq!(a.detection, Detection::AutoComplete);
+        assert_eq!(a.events.len(), 1);
+        assert_eq!(a.events[0].kind, EventKind::NodeAutoCompleteObserved);
+        assert_ne!(a.events[0].kind, EventKind::NodeAutoCompleted);
+    }
+
+    #[test]
+    fn assess_idle_valid_outputs_act_emits_terminal_auto_completed() {
+        // Unit B shape (behind the policy): the same detection, but Act emits the
+        // real terminal event the sweep would reap/advance on.
+        let probes = FakeProbes::idle(Duration::from_secs(200), true);
+        let a = assess(&probes, AutoCompletePolicy::Act);
+        assert_eq!(a.detection, Detection::AutoComplete);
+        assert_eq!(a.events.len(), 1);
+        assert_eq!(a.events[0].kind, EventKind::NodeAutoCompleted);
+    }
+
+    #[test]
+    fn assess_observe_marker_is_deduped_per_episode() {
+        // A held idle+valid node must emit the observed marker once, not once
+        // per sweep: a prior marker for this (node, iter) suppresses re-emission.
+        let probes = FakeProbes::idle(Duration::from_secs(200), true);
+        let prior = vec![event_log::Event {
+            id: None,
+            run_id: "run1".to_string(),
+            ts: event_log::now_iso(),
+            kind: EventKind::NodeAutoCompleteObserved,
+            node_id: Some("worker".to_string()),
+            iter: Some(1),
+            payload: None,
+        }];
+        let a = assess_node(
+            &probes,
+            &prior,
+            "run1",
+            "worker",
+            1,
+            SystemTime::now(),
+            AutoCompletePolicy::Observe,
+        );
+        assert_eq!(a.detection, Detection::AutoComplete);
+        assert!(
+            a.events.is_empty(),
+            "a second observe marker for the same episode must be suppressed"
+        );
+    }
+
+    #[test]
+    fn assess_usage_limit_menu_flags_blocked_and_emits_once() {
+        let probes = FakeProbes {
+            session_alive: true,
+            jsonl_mtime: Some(SystemTime::now() - Duration::from_secs(30)), // fresh → Ok
+            outputs_valid: false,
+            pane: Some("❯ 1. Stop and wait for limit to reset".to_string()),
+            diagnostics: SessionDeathDiagnostics::default(),
+            validate_calls: std::cell::Cell::new(0),
+        };
+        let a = assess(&probes, AutoCompletePolicy::Observe);
+        assert_eq!(a.detection, Detection::Ok);
+        assert!(
+            a.blocked_on_limit,
+            "usage-limit menu must set the gauge flag"
+        );
+        assert_eq!(a.events.len(), 1);
+        assert_eq!(a.events[0].kind, EventKind::NodeBlockedOnLimit);
+    }
+
+    #[test]
+    fn assess_usage_limit_gauge_set_but_event_deduped() {
+        // On a subsequent sweep the menu is still up: the gauge still counts it,
+        // but the event is not re-emitted (rising-edge dedup).
+        let probes = FakeProbes {
+            session_alive: true,
+            jsonl_mtime: Some(SystemTime::now() - Duration::from_secs(30)),
+            outputs_valid: false,
+            pane: Some("Stop and wait for limit to reset".to_string()),
+            diagnostics: SessionDeathDiagnostics::default(),
+            validate_calls: std::cell::Cell::new(0),
+        };
+        let prior = vec![event_log::Event {
+            id: None,
+            run_id: "run1".to_string(),
+            ts: event_log::now_iso(),
+            kind: EventKind::NodeBlockedOnLimit,
+            node_id: Some("worker".to_string()),
+            iter: Some(1),
+            payload: None,
+        }];
+        let a = assess_node(
+            &probes,
+            &prior,
+            "run1",
+            "worker",
+            1,
+            SystemTime::now(),
+            AutoCompletePolicy::Observe,
+        );
+        assert!(
+            a.blocked_on_limit,
+            "gauge counts every sweep the menu is up"
+        );
+        assert!(
+            a.events.is_empty(),
+            "the blocked event is emitted only once"
+        );
+    }
+
+    #[test]
+    fn assess_ok_node_without_menu_is_silent() {
+        let probes = FakeProbes {
+            session_alive: true,
+            jsonl_mtime: Some(SystemTime::now() - Duration::from_secs(30)),
+            outputs_valid: false,
+            pane: Some("● Running: cargo test".to_string()),
+            diagnostics: SessionDeathDiagnostics::default(),
+            validate_calls: std::cell::Cell::new(0),
+        };
+        let a = assess(&probes, AutoCompletePolicy::Observe);
+        assert_eq!(a.detection, Detection::Ok);
+        assert!(!a.blocked_on_limit);
+        assert!(a.events.is_empty());
+    }
+
+    #[test]
+    fn assess_dead_session_takes_precedence_over_idle_mtime() {
+        // A dead session with an idle transcript must resolve SessionDied, never
+        // Stale/AutoComplete — decide checks liveness first, and assess_node must
+        // preserve that ordering.
+        let probes = FakeProbes {
+            session_alive: false,
+            jsonl_mtime: Some(SystemTime::now() - Duration::from_secs(500)),
+            outputs_valid: false,
+            pane: None,
+            diagnostics: SessionDeathDiagnostics::default(),
+            validate_calls: std::cell::Cell::new(0),
+        };
+        let a = assess(&probes, AutoCompletePolicy::Observe);
+        assert_eq!(a.detection, Detection::SessionDied);
     }
 }

--- a/crates/pdo-daemon/tests/stale_mtime_detection.rs
+++ b/crates/pdo-daemon/tests/stale_mtime_detection.rs
@@ -1,0 +1,257 @@
+//! Layer 3a — #373: the mtime-based `Stale` / `AutoComplete` branches, dead in
+//! production for so long because `encode_working_dir` resolved the wrong
+//! Claude Code project dir, are proven end-to-end through the *real* daemon
+//! sweep here (ADR-0004 règle d'or: a resilience invariant is closed at layer
+//! ≥3, not with fake-probe unit tests alone).
+//!
+//! The sweep reads `$HOME/.claude/projects/<encode_working_dir(dir)>` for a
+//! node's transcript. This binary sets `HOME` process-global to a temp dir and
+//! plants a back-dated transcript at the exact encoded path — the whole point of
+//! the #373 encoder fix is that this path now resolves. A single test keeps the
+//! process-global `HOME` uncontended.
+
+mod common;
+
+use std::time::{Duration, SystemTime};
+
+use common::TestDaemon;
+use pdo_daemon::stale_detector;
+use pdo_daemon::tmux_session_manager;
+
+const PIPELINE_NAME: &str = "stale-mtime";
+const NODE_ID: &str = "worker";
+const PIPELINE_YAML: &str = r#"name: stale-mtime
+version: "1.0"
+nodes:
+  - id: start
+    name: Start
+    type: start
+    outputs:
+      - name: user_prompt
+  - id: worker
+    name: worker
+    type: doc-only
+    inputs:
+      - name: in
+    outputs:
+      - name: out
+  - id: end
+    name: End
+    type: end
+    inputs:
+      - name: result
+edges:
+  - source: { node: start, port: user_prompt }
+    target: { node: worker, port: in }
+"#;
+
+fn tmux_available() -> bool {
+    std::process::Command::new("tmux")
+        .arg("-V")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn tmux_has_session(socket: &str, session: &str) -> bool {
+    std::process::Command::new("tmux")
+        .args(["-L", socket, "has-session", "-t", session])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn seed(repo: &std::path::Path) -> anyhow::Result<()> {
+    let pipelines_dir = repo.join(".pdo").join("pipelines");
+    std::fs::create_dir_all(&pipelines_dir)?;
+    std::fs::write(
+        pipelines_dir.join(format!("{PIPELINE_NAME}.yaml")),
+        PIPELINE_YAML,
+    )?;
+    let run = |args: &[&str]| -> anyhow::Result<()> {
+        let out = std::process::Command::new("git")
+            .args(args)
+            .current_dir(repo)
+            .output()?;
+        if !out.status.success() {
+            anyhow::bail!(
+                "git {:?} failed: {}",
+                args,
+                String::from_utf8_lossy(&out.stderr)
+            );
+        }
+        Ok(())
+    };
+    run(&["init", "-q", "-b", "main"])?;
+    run(&["config", "user.email", "test@example.com"])?;
+    run(&["config", "user.name", "Test"])?;
+    run(&["config", "commit.gpgsign", "false"])?;
+    std::fs::write(repo.join(".gitignore"), ".pdo/runs/\n")?;
+    run(&["add", "."])?;
+    run(&["commit", "-q", "-m", "init"])?;
+    Ok(())
+}
+
+async fn create_run(daemon_url: &str) -> String {
+    let body = serde_json::json!({ "pipeline": PIPELINE_NAME, "input": "test input" });
+    let resp = reqwest::Client::new()
+        .post(format!("{daemon_url}/runs"))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 201);
+    let json: serde_json::Value = resp.json().await.unwrap();
+    json["run_id"].as_str().unwrap().to_string()
+}
+
+async fn wait_for_session(socket: &str, session: &str, timeout: Duration) -> bool {
+    let deadline = std::time::Instant::now() + timeout;
+    while std::time::Instant::now() < deadline {
+        if tmux_has_session(socket, session) {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    false
+}
+
+async fn node_status(daemon_url: &str, run_id: &str, node: &str) -> Option<String> {
+    let resp = reqwest::Client::new()
+        .get(format!("{daemon_url}/runs/{run_id}"))
+        .send()
+        .await
+        .unwrap();
+    let json: serde_json::Value = resp.json().await.unwrap();
+    json["nodes"][node]["status"].as_str().map(String::from)
+}
+
+async fn event_kinds(daemon_url: &str, run_id: &str) -> Vec<String> {
+    let resp = reqwest::Client::new()
+        .get(format!("{daemon_url}/runs/{run_id}/events"))
+        .send()
+        .await
+        .unwrap();
+    let events: Vec<serde_json::Value> = resp.json().await.unwrap();
+    events
+        .iter()
+        .filter_map(|e| e["kind"].as_str().map(String::from))
+        .collect()
+}
+
+/// Plant a Claude Code transcript for `working_dir` under the (temp) HOME, its
+/// mtime back-dated `age` so the sweep sees the node idle past the threshold.
+fn plant_idle_transcript(home: &std::path::Path, working_dir: &std::path::Path, age: Duration) {
+    let encoded = stale_detector::encode_working_dir(working_dir);
+    let proj = home.join(".claude").join("projects").join(encoded);
+    std::fs::create_dir_all(&proj).unwrap();
+    let jsonl = proj.join("session.jsonl");
+    std::fs::write(&jsonl, "{}\n").unwrap();
+    filetime::set_file_mtime(
+        &jsonl,
+        filetime::FileTime::from_system_time(SystemTime::now() - age),
+    )
+    .unwrap();
+}
+
+/// #373 end-to-end: with the encoder fixed, an idle node's transcript resolves,
+/// so `decide` reaches the `Stale` / `AutoComplete` arms that were dead in prod.
+/// One sweep must
+///   (a) mark an idle node with **incomplete** outputs `stale` (re-armed live),
+///   (b) leave an idle node with **valid** outputs `running` and emit the
+///       non-terminal `node_auto_complete_observed` marker (observe-only, Unit
+///       A) — never the terminal `node_auto_completed`.
+#[tokio::test]
+async fn idle_transcript_reactivates_stale_and_observe_only_autocomplete() {
+    if !tmux_available() {
+        eprintln!("tmux not on PATH — skipping");
+        return;
+    }
+
+    // The sweep reads $HOME; point it at a temp dir we own so planting a
+    // transcript can't touch the real ~/.claude. Single test in this binary, so
+    // the process-global set is uncontended. Preserve real HOME for git's global
+    // config (worktree creation) via GIT_CONFIG_GLOBAL.
+    let home = tempfile::tempdir().unwrap();
+    if let Some(real) = std::env::var_os("HOME") {
+        std::env::set_var(
+            "GIT_CONFIG_GLOBAL",
+            std::path::Path::new(&real).join(".gitconfig"),
+        );
+    }
+    std::env::set_var("HOME", home.path());
+
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+    let socket = daemon.tmux_socket();
+    let repo_root = daemon.repo_root().to_path_buf();
+
+    // --- Run A: idle + incomplete outputs → Stale ---
+    let run_stale = create_run(&daemon.url()).await;
+    let session_a = tmux_session_manager::node_session_name(&run_stale, NODE_ID, 1);
+    assert!(
+        wait_for_session(&socket, &session_a, Duration::from_secs(5)).await,
+        "run A node session should appear"
+    );
+    let workdir_a = repo_root
+        .join(".pdo/runs")
+        .join(&run_stale)
+        .join("worktree");
+    plant_idle_transcript(home.path(), &workdir_a, Duration::from_secs(300));
+
+    // --- Run B: idle + VALID outputs → AutoComplete (observe-only) ---
+    let run_observe = create_run(&daemon.url()).await;
+    let session_b = tmux_session_manager::node_session_name(&run_observe, NODE_ID, 1);
+    assert!(
+        wait_for_session(&socket, &session_b, Duration::from_secs(5)).await,
+        "run B node session should appear"
+    );
+    let workdir_b = repo_root
+        .join(".pdo/runs")
+        .join(&run_observe)
+        .join("worktree");
+    // Write the worker's declared `out` artifact so validation passes.
+    let out_dir = workdir_b.join(".pdo/artifacts/worker/iter-1/out");
+    std::fs::create_dir_all(&out_dir).unwrap();
+    std::fs::write(out_dir.join("output.md"), "# Output\nDone.").unwrap();
+    plant_idle_transcript(home.path(), &workdir_b, Duration::from_secs(300));
+
+    // One real sweep handles both runs.
+    daemon.run_stale_detection_tick().await;
+
+    // (a) Re-armed Stale: the node is marked stale (session stays alive; this is
+    // the intended #251 safety net, recoverable via resume_run).
+    assert_eq!(
+        node_status(&daemon.url(), &run_stale, NODE_ID)
+            .await
+            .as_deref(),
+        Some("stale"),
+        "#373: an idle node with incomplete outputs must be marked stale — the \
+         branch that was dead in prod before the encoder fix"
+    );
+
+    // (b) Observe-only AutoComplete: node stays running, marker emitted, and the
+    // terminal event is NOT appended.
+    assert_eq!(
+        node_status(&daemon.url(), &run_observe, NODE_ID)
+            .await
+            .as_deref(),
+        Some("running"),
+        "#373 Unit A: auto-complete is observe-only — the node must stay Running"
+    );
+    let kinds = event_kinds(&daemon.url(), &run_observe).await;
+    assert!(
+        kinds.iter().any(|k| k == "node_auto_complete_observed"),
+        "observe-only path must emit node_auto_complete_observed; saw {kinds:?}"
+    );
+    assert!(
+        !kinds.iter().any(|k| k == "node_auto_completed"),
+        "observe-only path must NOT emit the terminal node_auto_completed; saw {kinds:?}"
+    );
+
+    // Cleanup best-effort.
+    for s in [&session_a, &session_b] {
+        let _ = std::process::Command::new("tmux")
+            .args(["-L", &socket, "kill-session", "-t", s])
+            .output();
+    }
+}


### PR DESCRIPTION
Reactivates the daemon's stale-node detection, which was silently dead in prod.

## Root cause
`stale_detector::encode_working_dir` diverged from Claude Code's real
`~/.claude/projects/` dirname encoding on two axes: it stripped the leading `/`
(should become `-`) and left `.` intact (should become `-`). Every PDO worktree
is an absolute path containing `.pdo`, so `find_session_jsonl` returned `None`
for every node → `decide()` could only ever reach `Ok`/`SessionDied`, leaving
the `Stale` and `AutoComplete` arms unreachable.

## Fix
- `encode_working_dir` now maps all non-alphanumerics to `-`, and
  `run_cost::cc_project_dirname` delegates to it (single source, can't drift).
- Idle threshold single-sourced via `idle_past_threshold(mtime, now)`, used by
  both `decide` and `assess_node`.
- Carved node assessment behind a `NodeProbes` trait + `assess_node(...) -> Assessment`;
  the lib.rs sweep is now a thin loop over a `SweepNodeProbes` adapter.
- `Stale` re-armed live (recoverable via `resume_run`, the intended #251 net).
- `AutoComplete` ships **observe-only**: `AutoCompletePolicy::Observe` logs
  "WOULD auto-complete" and emits the non-terminal `NodeAutoCompleteObserved`
  marker (projection no-op, node stays Running). No reap/advance. Live promotion
  stays human-gated (Unit B).

## Tests
- 12 fake-probe `assess_node` unit tests + rewritten encoder tests + a real-dir
  `find_jsonl` resolution test.
- New Layer-3 integration test `tests/stale_mtime_detection.rs`: real daemon
  sweep with a back-dated planted transcript, asserting both re-armed `Stale`
  and observe-only `AutoComplete`.

Tester verdict: **PASS** (clean build; root cause proven fixed against the live
session's on-disk transcript).

Closes #373
