### PR TITLE
feat(#405): sandbox_image — Dockerfile embarqué, tag h-<hash>, build local, seed éditable

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Le Dockerfile sandbox est content-hashé (#405) : figer les fins de ligne pour que le
+# tag pdo-sandbox:h-<hash> soit identique quel que soit l'OS de checkout/build (release/GHCR #411).
+crates/pdo-daemon/assets/sandbox/Dockerfile text eol=lf

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -817,9 +817,10 @@ La complétion est signalée **depuis l'UI**, par un bouton "Mark complete" sur 
 
 ## Sandbox (exécution isolée d'un Run)
 
-> Section seedée par #404 (slice A du PRD #403). Périmètre : **staging fs pur, zéro
-> Docker**. Le modèle d'exécution (conteneur, identity mounts, réseau, image) est
-> **différé à ADR-0030 / #407** et complété par les slices suivantes — ne pas dupliquer ici.
+> Section seedée par #404, complétée par les slices suivantes du PRD #403. Couvert **ici** :
+> staging fs (#404) + **fourniture de l'image** (#405, cf. *Image (fourniture)*). Le modèle
+> d'**exécution** (conteneur, identity mounts, réseau) reste **différé à ADR-0030 / #406-#407**
+> — ne pas dupliquer ici.
 
 **Sandbox** :
 Propriété **par Run**, **immuable après création**, portée par l'événement de création (projetée
@@ -865,15 +866,46 @@ shell-snapshots — tout sauf les transcripts (#403 US-29). _Éviter_ : « sync 
 Purge le *staging dir* du Run ; sans effet s'il est déjà absent. _Éviter_ : « cleanup » (réservé à
 `cleanup_run`, niveau Run) et « destroy » (réservé à la destruction du conteneur, #406).
 
+### Image (fourniture)
+
+Périmètre **provisionnement** (fabrication + nommage de l'image), landé par #405 (`sandbox_image`).
+L'**exécution** de l'image (instanciation en conteneur, mounts, réseau) → #406/#407, ADR-0030.
+
+**Image sandbox (`pdo-sandbox:h-<hash>`)** :
+L'image Docker dans laquelle tournent les sessions d'un Run sandboxé. Son tag est le **hash du
+contenu du Dockerfile** (`h-<hash>`), pas une version : deux Dockerfiles identiques → même tag, une
+édition → tag différent. Identité **adressée par contenu** — c'est elle qui rendra plus tard une
+image tirée d'un registry et une image buildée localement interchangeables sous le même nom (#411).
+_Éviter_ : « image latest », « tag de version », « image du conteneur » (l'image n'est pas le
+conteneur, #406).
+
+**Dockerfile embarqué / seedé** :
+Le Dockerfile est **embarqué dans le binaire** (contenu minimal : Ubuntu, git, ripgrep, Claude Code
+auto-update off, sudo NOPASSWD ; ni tmux ni `pdo`, fournis par l'hôte). Au premier usage il est
+**seedé** sur disque à `~/.pdo/sandbox/Dockerfile`, puis **jamais écrasé** : l'utilisateur peut
+l'éditer, et l'édition change le hash donc le tag donc déclenche un rebuild. _Éviter_ : confondre le
+Dockerfile **embarqué** (source de vérité dans le binaire) et le **seedé** (copie éditable sur
+disque) ; « image de base ».
+
+**`ensure_image()`** :
+Garantit que `pdo-sandbox:h-<hash>` existe **localement** : présente → réutilise ; absente →
+`docker build` depuis le Dockerfile sur disque ; échec → erreur explicite (consommée par le
+fail-fast du Run). Ne tire **rien** d'un registry en #405 (chemin pull/GHCR + précédence
+`image_source` → #411). _Éviter_ : « pull », « build » seul (ensure = build-**si-absent**),
+« warm-up ».
+
 ### Relations
 - Une **Sandbox** `copy`/`pure` possède un **staging dir** (`~/.pdo/sandbox/<run-id>/`) contenant un
   **staged Claude home** (`claude-home/`) + un `.claude.json` sibling.
 - `prepare` seede → `merge_back` extrait les transcripts vers `~/.claude/projects/` → `teardown`
   supprime le staging dir.
+- Une **Sandbox** `copy`/`pure` s'exécute dans l'**image sandbox** `pdo-sandbox:h-<hash>`, garantie
+  présente par `ensure_image` (#405) ; l'instanciation d'un conteneur à partir d'elle → #406/ADR-0030.
 - **Différé (ne pas définir dans #404)** : préfixe `docker exec` des tails, conteneur
   `pdo-sbx-<run-id>`, identity mounts (#406, ADR-0030) ; précédence des sources du mode
   (run → trigger → `default_sandbox` d'instance, pattern ADR-0015) (#410) ; seam `transcripts_root`
-  pointant stale-detection/coût vers le staging (#408).
+  pointant stale-detection/coût vers le staging (#408) ; **fourniture par registry** (pull GHCR +
+  précédence `image_source`) (#411) — #405 ne couvre que le build local.
 
 ### Ambiguïté signalée
 « sandbox » désigne deux choses : (1) cette feature (exécution conteneurisée d'un Run, #403) ;

--- a/crates/pdo-daemon/assets/sandbox/Dockerfile
+++ b/crates/pdo-daemon/assets/sandbox/Dockerfile
@@ -1,0 +1,55 @@
+# PDO sandbox base image.
+#
+# Ce Dockerfile est content-hashé par le daemon pour dériver le tag
+# `pdo-sandbox:h-<hash>` (issue #405) : ses octets doivent rester stables/reproductibles.
+# La base est pinnée à un TAG (pas :latest) pour cette raison. Un tag flotte quand même
+# (Canonical republie ubuntu:24.04 avec des patches), donc un hash de Dockerfile stable
+# ne garantit PAS des layers bit-à-bit identiques ; pinner par digest (ubuntu:24.04@sha256:...)
+# si la repro bit-à-bit devient nécessaire. Le tag est le défaut pragmatique : lisible,
+# ramasse les patches sécu, et le daemon n'a besoin que du *texte du Dockerfile* stable.
+FROM ubuntu:24.04
+
+# Un seul layer apt, listes nettoyées, pour garder l'image petite.
+#   git, ca-certificates, curl -> outillage requis (curl lance aussi l'installeur)
+#   ripgrep                    -> backend de recherche de Claude Code (cf. USE_BUILTIN_RIPGREP)
+#   sudo                       -> l'utilisateur runtime peut `apt install` (NOPASSWD ci-dessous)
+# NON installés ici (fournis par l'HÔTE au runtime, par design #403) :
+#   tmux -> tourne sur l'HÔTE, jamais dans le conteneur
+#   pdo  -> le binaire `pdo` de l'hôte est bind-monté read-only au runtime
+RUN apt-get update \
+ && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      git \
+      ca-certificates \
+      curl \
+      ripgrep \
+      sudo \
+ && rm -rf /var/lib/apt/lists/*
+
+# sudo sans mot de passe pour tout utilisateur. Le conteneur tourne en uid:gid hôte
+# (`--user`), un uid arbitraire, donc la règle n'est pas liée à un nom d'utilisateur.
+# NOTE (validation réelle) : sudo appelle getpwuid() et abandonne avec "you do not exist
+# in the passwd database" si l'uid n'a pas d'entrée /etc/passwd. ubuntu:24.04 livre un
+# user `ubuntu` en uid 1000, donc le cas laptop courant (uid 1000) résout. Pour tout autre
+# uid hôte, le RUNTIME (#406) doit injecter une entrée passwd — hors périmètre de l'image.
+RUN echo 'ALL ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/pdo-nopasswd \
+ && chmod 0440 /etc/sudoers.d/pdo-nopasswd \
+ && visudo -cf /etc/sudoers.d/pdo-nopasswd
+
+# Installe Claude Code via l'installeur natif officiel (recommandé par Anthropic ; npm n'est
+# qu'un chemin de compat). L'installeur pose un launcher à $HOME/.local/bin/claude (symlink
+# vers un binaire self-contained), sous le home de root pendant le build -> PAS sur le PATH
+# d'un uid runtime arbitraire. On résout le vrai binaire et on le copie dans /usr/local/bin,
+# lisible+exécutable par tout uid, puis on supprime l'arbre d'install de root.
+RUN curl -fsSL https://claude.ai/install.sh | bash \
+ && install -D -m 0755 "$(readlink -f /root/.local/bin/claude)" /usr/local/bin/claude \
+ && rm -rf /root/.local /root/.claude /root/.cache
+
+# Désactive l'auto-update de Claude Code via ENV, volontairement (pas un settings.json baké) :
+# le runtime bind-monte HOME/.claude depuis le staged home (#404), ce qui SHADOWERAIT un
+# settings.json baké. Une env var posée dans l'image survit au mount et s'applique à l'uid runtime.
+#   DISABLE_AUTOUPDATER=1 -> stoppe le check de mise à jour en arrière-plan.
+#   USE_BUILTIN_RIPGREP=0 -> utilise le `rg` système apt-installé.
+ENV DISABLE_AUTOUPDATER=1 \
+    USE_BUILTIN_RIPGREP=0
+
+CMD ["claude"]

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -31,6 +31,7 @@ mod prompt_augmenter;
 mod pty_bridge;
 mod run_advance;
 mod run_cost;
+mod sandbox_image;
 mod sandbox_staging;
 #[allow(dead_code)]
 mod scheduler;

--- a/crates/pdo-daemon/src/sandbox_image.rs
+++ b/crates/pdo-daemon/src/sandbox_image.rs
@@ -1,0 +1,411 @@
+//! Fourniture de l'image sandbox par build local (#405, slice B du PRD #403).
+//!
+//! Miroir de [`crate::worktree_ops`] / [`crate::sandbox_staging`] : pas d'`AppState`,
+//! pas d'async, pas de lecture d'env dans le cœur — `&Path`/`&str`/`&[u8]` in,
+//! path-math ou `std::fs`/`std::process::Command` out. `HOME` et le binaire docker
+//! ne sont lus QUE par les résolveurs de bord.
+//!
+//! Ce module garantit qu'une image `pdo-sandbox:h-<hash>` (tag = hash du CONTENU du
+//! Dockerfile) existe localement, en la buildant depuis le Dockerfile sur disque quand
+//! elle est absente. Les slices sœurs le CONSOMMENT :
+//! - #406 instancie un conteneur à partir de l'image ;
+//! - #407 câble [`ensure_image`] dans le run-advance (ADR-0030) — via `spawn_blocking`
+//!   car `docker build` est bloquant et long ;
+//! - #411 ajoutera le pull GHCR en amont du build local, en réutilisant [`dockerfile_hash`].
+//!
+//! Le tag est **adressé par contenu**, pas versionné :
+//! rationale (content-hash vs semver ; interchangeabilité pull #411 / build local)
+//! -> ADR-0030 (#407).
+
+#![allow(dead_code)] // Tracer bullet : consommé par #406/#407, non câblé dans cette slice.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{Context, Result};
+use sha2::{Digest, Sha256};
+
+/// Dockerfile embarqué (source de vérité dans le binaire). Seedé sur disque au 1er usage.
+/// `.gitattributes` épingle `eol=lf` sur ce fichier : `include_str!` embarque les octets
+/// verbatim, donc un checkout CRLF changerait le hash (cf. D6 du plan #405).
+const EMBEDDED_DOCKERFILE: &str = include_str!("../assets/sandbox/Dockerfile");
+
+/// Env var pointant les invocations docker vers un exécutable fake (seam test/intégration).
+/// Miroir de [`crate::tmux_session_manager::TMUX_CMD_OVERRIDE_ENV`] : lue UNE fois au bord,
+/// jamais dans le cœur.
+pub const DOCKER_CMD_OVERRIDE_ENV: &str = "PDO_DOCKER_CMD_OVERRIDE";
+
+/// Message d'erreur unique quand le binaire `docker` est introuvable sur le PATH. Devient la
+/// `reason` d'un `RunFailed` (US-16) : jamais d'exécution silencieuse sur l'hôte.
+const DOCKER_NOT_FOUND_MSG: &str =
+    "sandbox run requires Docker, but the `docker` binary was not found on PATH — \
+     install Docker or set this run's sandbox to `off`";
+
+// -- path math (pur, sans IO) ------------------------------------------------
+
+/// `<sandbox_root>/Dockerfile` — emplacement canonique du Dockerfile seedé/buildé.
+pub(crate) fn dockerfile_path(sandbox_root: &Path) -> PathBuf {
+    sandbox_root.join("Dockerfile")
+}
+
+/// `<sandbox_root>/.build-ctx` — contexte de build dédié, gardé VIDE (cf. D8) : `~/.pdo/sandbox/`
+/// a pour siblings les staging dirs par-run (`<run-id>/claude-home/`, ~98 Mo, écrits
+/// concurremment) — l'utiliser comme contexte enverrait un tarball géant et racerait un run.
+pub(crate) fn build_context_dir(sandbox_root: &Path) -> PathBuf {
+    sandbox_root.join(".build-ctx")
+}
+
+// -- hash / tag (pur ; SINGLE SOURCE OF TRUTH pour #411 + release.yml) --------
+
+/// SHA-256 sur les octets EXACTS du Dockerfile fed à `docker build`, 12 hex minuscules.
+/// Équivalent CI CANONIQUE : `sha256sum Dockerfile | cut -c1-12`. Hasher les octets bruts ;
+/// **jamais normaliser** (pas de conversion `\r\n`, pas de fix de newline finale) — le
+/// hash-input DOIT == build-input, sinon réutilisation d'une image périmée (#411 hashe en bash).
+pub(crate) fn dockerfile_hash(dockerfile_bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(dockerfile_bytes);
+    let full = format!("{:x}", hasher.finalize());
+    full[..12].to_string()
+}
+
+/// Ref locale `pdo-sandbox:h-<hash>`. (GHCR #411 formatera son propre préfixe autour du même hash.)
+pub(crate) fn local_image_ref(dockerfile_bytes: &[u8]) -> String {
+    format!("pdo-sandbox:h-{}", dockerfile_hash(dockerfile_bytes))
+}
+
+// -- effets fs (sync std::fs, anyhow + .context) -----------------------------
+
+/// Écrit le Dockerfile `embedded` à son chemin canonique **si absent** ; sinon **ne touche
+/// à rien** (édition utilisateur préservée : une édition change le hash donc rebuild). Renvoie
+/// le chemin dans les deux cas.
+pub(crate) fn seed_dockerfile(sandbox_root: &Path, embedded: &str) -> Result<PathBuf> {
+    let path = dockerfile_path(sandbox_root);
+    if path.exists() {
+        return Ok(path); // édition utilisateur gagne
+    }
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("failed to seed sandbox Dockerfile at {}", path.display()))?;
+    }
+    std::fs::write(&path, embedded.as_bytes())
+        .with_context(|| format!("failed to seed sandbox Dockerfile at {}", path.display()))?;
+    Ok(path)
+}
+
+// -- effets docker (sync std::process::Command) ------------------------------
+
+/// `docker image inspect <tag>` (métadonnée locale, jamais de réseau) : `Ok(true)` si exit 0
+/// (présente), `Ok(false)` si exit != 0 (absente). `docker` introuvable (spawn `NotFound`) ->
+/// `Err` explicite préservant l'`io::Error` en source (chaîne à 2 maillons, cf. #298).
+pub(crate) fn image_exists(docker_bin: &str, tag: &str) -> Result<bool> {
+    match Command::new(docker_bin)
+        .args(["image", "inspect", tag])
+        .output()
+    {
+        Ok(output) => Ok(output.status.success()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            Err(anyhow::Error::new(e)).context(DOCKER_NOT_FOUND_MSG)
+        }
+        Err(e) => Err(e)
+            .context("failed to run `docker image inspect` while probing the sandbox image"),
+    }
+}
+
+/// `docker build -t <tag> -f <dockerfile> <context_dir>` ; bail non-zéro avec le stderr docker
+/// (chaque erreur est la `reason` actionnable d'un `RunFailed`, US-16).
+pub(crate) fn build_image(
+    docker_bin: &str,
+    tag: &str,
+    dockerfile: &Path,
+    context_dir: &Path,
+) -> Result<()> {
+    let output = match Command::new(docker_bin)
+        .arg("build")
+        .arg("-t")
+        .arg(tag)
+        .arg("-f")
+        .arg(dockerfile)
+        .arg(context_dir)
+        .output()
+    {
+        Ok(output) => output,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Err(anyhow::Error::new(e)).context(DOCKER_NOT_FOUND_MSG);
+        }
+        Err(e) => {
+            return Err(e)
+                .context("failed to run `docker build` while building the sandbox image");
+        }
+    };
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!(
+            "failed to build the sandbox image `{tag}` from {} — \
+             `docker build` exited with {}: {stderr}",
+            dockerfile.display(),
+            output.status
+        );
+    }
+    Ok(())
+}
+
+/// Provisionneur idempotent (seul point d'entrée de #406/#407) :
+/// seed si absent -> lit octets disque -> tag -> présente ? `Ok(tag)` : build -> `Ok(tag)`.
+///
+/// **Sync délibéré (D3)** : `docker build` est un travail bloquant et long, sa place est dans le
+/// `spawn_blocking` du caller async (#407), pas dans une tâche tokio ; garder ce module sync
+/// laisse aussi les tests en `#[test]` simples.
+pub(crate) fn ensure_image(docker_bin: &str, sandbox_root: &Path) -> Result<String> {
+    // 1. Seed le Dockerfile si absent (édition utilisateur préservée).
+    seed_dockerfile(sandbox_root, EMBEDDED_DOCKERFILE)?;
+    // 2. Octets bruts sur disque = entrée EXACTE du hash ET du build (jamais normaliser).
+    let dockerfile = dockerfile_path(sandbox_root);
+    let bytes = std::fs::read(&dockerfile).with_context(|| {
+        format!("failed to read sandbox Dockerfile at {}", dockerfile.display())
+    })?;
+    // 3. Tag adressé par contenu.
+    let tag = local_image_ref(&bytes);
+    // 4. Présente localement -> pas de build.
+    if image_exists(docker_bin, &tag)? {
+        return Ok(tag);
+    }
+    // 5. Contexte de build dédié VIDE (D8 : jamais sandbox_root, siblings = staging par-run).
+    let context_dir = build_context_dir(sandbox_root);
+    std::fs::create_dir_all(&context_dir).with_context(|| {
+        format!("failed to create sandbox build context at {}", context_dir.display())
+    })?;
+    // 6. Build. v1: double-build concurrent premier-run accepté (deux `docker build -t <même
+    //    tag>` sont sûrs — daemon sérialise + cache, la sonde court-circuite le 2e run) ;
+    //    ajouter un lock par tag si ça mord.
+    build_image(docker_bin, &tag, &dockerfile, &context_dir)?;
+    // 7.
+    Ok(tag)
+}
+
+// -- résolveurs de bord (seuls lecteurs d'env) -------------------------------
+
+/// Binaire docker : [`DOCKER_CMD_OVERRIDE_ENV`] sinon `"docker"`.
+pub(crate) fn docker_bin_from_env() -> String {
+    std::env::var(DOCKER_CMD_OVERRIDE_ENV).unwrap_or_else(|_| "docker".to_string())
+}
+
+/// Racine de staging par défaut `~/.pdo/sandbox` depuis `HOME` (un seul `PathBuf` : l'image est
+/// par-daemon, pas par-run). Miroir de [`crate::sandbox_staging::default_roots_from_env`].
+pub(crate) fn default_sandbox_root_from_env() -> Option<PathBuf> {
+    let home = PathBuf::from(std::env::var("HOME").ok()?);
+    Some(home.join(".pdo").join("sandbox"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+
+    /// Simple-quote une chaîne pour l'embarquer dans le script bash fake (D2 : aucune mutation
+    /// d'env — le fake est threadé comme `docker_bin`).
+    fn shell_single_quote(s: &str) -> String {
+        format!("'{}'", s.replace('\'', "'\\''"))
+    }
+
+    /// Écrit un faux `docker` exécutable dans `dir` et renvoie `(bin, argv_log)`. `bin` est passé
+    /// comme `docker_bin` ; `argv_log` accumule l'argv de chaque invocation (une ligne par arg),
+    /// pour les assertions d'argv. Aucune mutation d'`std::env` (D2 : race parallèle cargo).
+    ///
+    /// Branche sur `$1` (`image` -> inspect, `build` -> build) et NON sur `"$1 $2"` : un vrai
+    /// `docker build -t …` a `$2 = "-t"`, donc `"$1 $2" = "build -t"` ne matcherait pas `build`.
+    fn write_fake_docker(
+        dir: &Path,
+        inspect_exit: i32,
+        build_exit: i32,
+        build_stderr: &str,
+    ) -> (PathBuf, PathBuf) {
+        let bin = dir.join("fake-docker");
+        let argv_log = dir.join("argv.log");
+        let script = format!(
+            "#!/usr/bin/env bash\n\
+             printf '%s\\n' \"$@\" >> \"{log}\"\n\
+             case \"$1\" in\n\
+             image) exit {inspect_exit} ;;\n\
+             build) printf '%s' {stderr} >&2; exit {build_exit} ;;\n\
+             *) exit 0 ;;\n\
+             esac\n",
+            log = argv_log.display(),
+            stderr = shell_single_quote(build_stderr),
+        );
+        std::fs::write(&bin, script).unwrap();
+        std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
+        (bin, argv_log)
+    }
+
+    /// Argv de la (dernière) invocation `build` extraite du log. Vide si aucun build : le build
+    /// est la dernière invocation, on prend de la ligne `"build"` à la fin.
+    fn build_argv(argv_log: &Path) -> Vec<String> {
+        let content = std::fs::read_to_string(argv_log).unwrap_or_default();
+        let lines: Vec<String> = content.lines().map(str::to_string).collect();
+        match lines.iter().position(|l| l == "build") {
+            Some(i) => lines[i..].to_vec(),
+            None => Vec::new(),
+        }
+    }
+
+    fn docker_str(bin: &Path) -> String {
+        bin.to_str().unwrap().to_string()
+    }
+
+    #[test]
+    fn present_image_skips_build() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (docker, argv_log) = write_fake_docker(tmp.path(), 0, 0, "");
+        let sandbox_root = tmp.path().join("sandbox");
+
+        let tag = ensure_image(&docker_str(&docker), &sandbox_root).unwrap();
+
+        assert_eq!(tag, local_image_ref(EMBEDDED_DOCKERFILE.as_bytes()));
+        assert!(
+            build_argv(&argv_log).is_empty(),
+            "aucun build ne doit être lancé quand l'image est présente"
+        );
+    }
+
+    #[test]
+    fn absent_image_builds_then_returns_tag() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (docker, argv_log) = write_fake_docker(tmp.path(), 1, 0, "");
+        let sandbox_root = tmp.path().join("sandbox");
+
+        let tag = ensure_image(&docker_str(&docker), &sandbox_root).unwrap();
+
+        assert_eq!(tag, local_image_ref(EMBEDDED_DOCKERFILE.as_bytes()));
+        assert_eq!(
+            build_argv(&argv_log),
+            vec![
+                "build".to_string(),
+                "-t".to_string(),
+                tag.clone(),
+                "-f".to_string(),
+                dockerfile_path(&sandbox_root).display().to_string(),
+                build_context_dir(&sandbox_root).display().to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn build_failure_is_explicit_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (docker, _) = write_fake_docker(tmp.path(), 1, 1, "boom: base image missing");
+        let sandbox_root = tmp.path().join("sandbox");
+
+        let err = ensure_image(&docker_str(&docker), &sandbox_root).unwrap_err();
+
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("failed to build the sandbox image"),
+            "phrase de contexte manquante: {msg}"
+        );
+        assert!(
+            msg.contains("boom: base image missing"),
+            "stderr docker manquant (US-16 actionnable): {msg}"
+        );
+    }
+
+    #[test]
+    fn docker_binary_missing_errors_without_building() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sandbox_root = tmp.path().join("sandbox");
+        let missing = tmp.path().join("no-such-docker");
+
+        let err = ensure_image(&docker_str(&missing), &sandbox_root).unwrap_err();
+
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("Docker") && msg.contains("not found on PATH"),
+            "message docker-absent attendu: {msg}"
+        );
+        // Chaîne à 2 maillons : la source `io::NotFound` est préservée (#298).
+        assert!(
+            err.chain().count() >= 2,
+            "la source io::Error doit être préservée dans la chaîne anyhow"
+        );
+        // Le build ne doit jamais être atteint (la sonde échoue avant).
+        assert!(
+            !build_context_dir(&sandbox_root).exists(),
+            "aucun contexte de build ne doit être créé quand docker est absent"
+        );
+    }
+
+    #[test]
+    fn seeds_dockerfile_when_absent_then_builds() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (docker, _) = write_fake_docker(tmp.path(), 1, 0, "");
+        let sandbox_root = tmp.path().join("sandbox");
+        assert!(!dockerfile_path(&sandbox_root).exists());
+
+        ensure_image(&docker_str(&docker), &sandbox_root).unwrap();
+
+        let seeded = std::fs::read(dockerfile_path(&sandbox_root)).unwrap();
+        assert_eq!(
+            seeded,
+            EMBEDDED_DOCKERFILE.as_bytes(),
+            "le Dockerfile seedé doit être identique à l'embarqué"
+        );
+    }
+
+    #[test]
+    fn edited_on_disk_dockerfile_is_preserved_and_drives_tag() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (docker, argv_log) = write_fake_docker(tmp.path(), 1, 0, "");
+        let sandbox_root = tmp.path().join("sandbox");
+        // Pré-écrire un Dockerfile ÉDITÉ (différent de l'embarqué).
+        std::fs::create_dir_all(&sandbox_root).unwrap();
+        let edited: &[u8] = b"FROM ubuntu:24.04\nRUN echo edited\n";
+        std::fs::write(dockerfile_path(&sandbox_root), edited).unwrap();
+
+        let tag = ensure_image(&docker_str(&docker), &sandbox_root).unwrap();
+
+        // (a) Octets inchangés : pas d'écrasement.
+        assert_eq!(
+            std::fs::read(dockerfile_path(&sandbox_root)).unwrap(),
+            edited,
+            "le seed ne doit jamais écraser un Dockerfile existant"
+        );
+        // (b) Tag + argv reflètent le hash des octets ÉDITÉS, pas de l'embarqué.
+        assert_eq!(tag, local_image_ref(edited));
+        assert_ne!(tag, local_image_ref(EMBEDDED_DOCKERFILE.as_bytes()));
+        assert!(build_argv(&argv_log).contains(&tag));
+    }
+
+    #[test]
+    fn build_context_is_not_sandbox_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (docker, argv_log) = write_fake_docker(tmp.path(), 1, 0, "");
+        let sandbox_root = tmp.path().join("sandbox");
+
+        ensure_image(&docker_str(&docker), &sandbox_root).unwrap();
+
+        let argv = build_argv(&argv_log);
+        let ctx = argv.last().unwrap();
+        assert_eq!(ctx, &build_context_dir(&sandbox_root).display().to_string());
+        assert_ne!(ctx, &sandbox_root.display().to_string(), "piège D8");
+        assert!(ctx.ends_with(".build-ctx"));
+    }
+
+    #[test]
+    fn dockerfile_tag_stable_and_edit_sensitive() {
+        let base: &[u8] = b"FROM ubuntu:24.04\nRUN apt-get update\n";
+        // Stable pour un contenu identique.
+        assert_eq!(local_image_ref(base), local_image_ref(base));
+        // Change à l'édition.
+        let edited: &[u8] = b"FROM ubuntu:24.04\nRUN apt-get update\nRUN apt-get install -y git\n";
+        assert_ne!(dockerfile_hash(base), dockerfile_hash(edited));
+
+        let h = dockerfile_hash(base);
+        assert_eq!(h.len(), 12);
+        assert!(h.bytes().all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase()));
+        assert!(local_image_ref(base).starts_with("pdo-sandbox:h-"));
+
+        // GARDE-FOU PARITÉ CI : figer l'algo canonique. Épingle la sortie Rust au préfixe que
+        // `release.yml`/#411 produiront en bash :
+        //   printf 'FROM ubuntu:24.04\nRUN apt-get update\n' | sha256sum | cut -c1-12
+        assert_eq!(h, "5804eefb8f92");
+    }
+}


### PR DESCRIPTION
## Sandbox B — module `sandbox_image`

Slice B du PRD #403 (Sandbox Docker par run). Module backend pur (tracer-bullet `#![allow(dead_code)]`, câblé par #407) : Dockerfile embarqué, image adressée par contenu (tag `h-<hash>`, `sha256[..12]` des octets on-disk), build local à contexte vide, seed du Dockerfile éditable (write-if-absent).

### Contenu
- `crates/pdo-daemon/assets/sandbox/Dockerfile` — `ubuntu:24.04` + installeur natif Claude Code → `/usr/local/bin` (self-contained, exécutable sous uid arbitraire), `DISABLE_AUTOUPDATER=1`, `USE_BUILTIN_RIPGREP=0`, `rg` natif.
- `crates/pdo-daemon/src/sandbox_image.rs` — `ensure_image` / `local_image_ref` (tag content-addressed), seed write-if-absent, seam `PDO_DOCKER_CMD_OVERRIDE` → arg `docker_bin`.
- `.gitattributes` — `Dockerfile eol=lf` (canonicité du hash cross-plateforme).
- `CONTEXT.md` — section Image (fourniture).

### Validation (verdict Pass, node ecbJixkS)
- Build `cargo +stable` clean, clippy `-D warnings` 0 lint, suite `pdo-daemon` 1504/0, `sandbox_image` 8/8.
- Docker réel validé : Docker 29.2.1, image `pdo-sandbox:h-9a67637571a4` buildée depuis Dockerfile embarqué (contexte vide), `claude 2.1.218` OK en root ET uid hôte arbitraire (`--user 4711:4711`), `rg 14.1.0`, env baké conforme.
- Parité de hash **bash == Rust** confirmée des deux côtés.
- Réserve unique test-only non bloquante : flake `ETXTBSY` ~1/25 sur `present_image_skips_build` (artefact de harness, 0/17 repro ciblé) — à durcir opportunément via #407.

Pas de bump de version (release en fin de PRD). Cible : branche d'intégration `integration/prd-403-sandbox`.

Closes #405
