### PR TITLE
feat(#406): sandbox_container — cycle de vie pdo-sbx-<run_id>, identity mounts, exec/kill ciblé

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -818,9 +818,9 @@ La complétion est signalée **depuis l'UI**, par un bouton "Mark complete" sur 
 ## Sandbox (exécution isolée d'un Run)
 
 > Section seedée par #404, complétée par les slices suivantes du PRD #403. Couvert **ici** :
-> staging fs (#404) + **fourniture de l'image** (#405, cf. *Image (fourniture)*). Le modèle
-> d'**exécution** (conteneur, identity mounts, réseau) reste **différé à ADR-0030 / #406-#407**
-> — ne pas dupliquer ici.
+> staging fs (#404) + **fourniture de l'image** (#405, *Image (fourniture)*) + **exécution /
+> conteneur** (#406, *Exécution (conteneur)*). Le **câblage** dans le run-advance et le modèle
+> d'exécution formel (réseau/auth) restent **différés à ADR-0030 / #407** — ne pas les fixer ici.
 
 **Sandbox** :
 Propriété **par Run**, **immuable après création**, portée par l'événement de création (projetée
@@ -894,18 +894,73 @@ fail-fast du Run). Ne tire **rien** d'un registry en #405 (chemin pull/GHCR + pr
 `image_source` → #411). _Éviter_ : « pull », « build » seul (ensure = build-**si-absent**),
 « warm-up ».
 
+### Exécution (conteneur)
+
+Périmètre **exécution** de l'image (instanciation, mounts, cycle de vie du conteneur), landé par
+#406 (`sandbox_container`). Le **câblage** run-advance et l'ADR-0030 qui fixe le modèle → #407.
+
+**Conteneur sandbox (`pdo-sbx-<run-id>`)** :
+Le conteneur **unique et long-vécu** d'un Run sandboxé, nommé de façon déterministe d'après le
+run-id, dormant (`sleep infinity`, PID 1 = `tini` via `--init`). Toutes les tails du Run y entrent
+par `docker exec` ; il naît au premier nœud, meurt au `cleanup_run`. Un nom par-Run rend kill et
+destruction **ciblés** (jamais un balayage global). _Éviter_ : « la sandbox » (= la feature/le
+mode), « VM », « image du conteneur » (l'image est le template, #405).
+
+**Identity mounts** :
+Les bind-mounts qui **répliquent l'identité de l'hôte** pour que le chemin de travail soit identique
+des deux côtés : repo cible monté rw à son **chemin absolu hôte** (couvre tous les worktrees de
+nœuds, sous `.pdo/runs/`), *staged Claude home* → `$HOME/.claude`, `.claude.json` sibling →
+`$HOME/.claude.json`, binaire `pdo` hôte monté ro dans le PATH, **uid/gid hôte** adoptés par le
+process (`--user`). C'est ce qui garantit le **même dirname encodé** que `merge_back`. _Éviter_ :
+« volumes » seul, « partage de fichiers ».
+
+**Préfixe `docker exec` (`exec_prefix`)** :
+La séquence d'arguments préposée à la tail d'un nœud pour la faire tourner **dans** le conteneur
+(`docker exec -it -e PDO_SBX_SESSION=… --user <uid>:<gid> -w <cwd> pdo-sbx-<run-id> …`) au lieu de
+l'hôte. En mode `off` le préfixe est **vide** (exécution hôte). Pur : construction d'argv, sans
+effet de bord. Ne re-passe jamais `PDO_DAEMON_URL` (posé au create vers `host.docker.internal`).
+_Éviter_ : « wrapper », « shim ».
+
+**Marqueur de session (`PDO_SBX_SESSION`)** :
+La **variable d'environnement** (`PDO_SBX_SESSION=<nom-de-session>`) posée sur **chaque** `docker
+exec`, **héritée par `claude` et toute sa descendance**. C'est la clé du **kill ciblé** : un scan
+`/proc/*/environ` la retrouve sur l'arbre de process de la session. Ce n'est **pas** un label Docker
+(réservé, non utilisé en v1). _Éviter_ : « tag » (réservé à l'image, #405), « label ».
+
+**`ensure_running(run_id)`** :
+Provisionneur **idempotent** du conteneur (miroir de `ensure_image`) : sonde `docker container
+inspect` → absent → `docker create` + `start` ; présent arrêté → `start` ; déjà up → no-op. La sonde
+**ne confond jamais** une erreur transitoire (daemon Docker down, permission) avec une absence.
+_Éviter_ : « launch », « boot », « run » seul.
+
+**Kill ciblé** :
+Arrêt du **seul** arbre de process porteur d'un **marqueur de session** donné, **dans** le conteneur
+partagé (`docker exec` séparé qui scanne `/proc`, `TERM` puis `KILL`) — les sessions sœurs du même
+Run **survivent**. Nécessaire car le client `docker exec` tué côté tmux ne tue pas le process
+conteneur (reparenté sur PID 1). Best-effort. Distinct de `remove` (destruction du conteneur
+entier). _Éviter_ : « stop all », « docker kill » (large).
+
+**`remove` / destruction du conteneur** :
+Suppression du conteneur (`docker rm -f pdo-sbx-<run-id>`) à `cleanup_run` ; sans effet s'il est déjà
+absent (idempotent). C'est **le** verbe « destroy / destruction » réservé par `teardown`. _Éviter_ :
+« teardown » (= purge du staging dir, #404), « cleanup » (= niveau Run).
+
 ### Relations
 - Une **Sandbox** `copy`/`pure` possède un **staging dir** (`~/.pdo/sandbox/<run-id>/`) contenant un
   **staged Claude home** (`claude-home/`) + un `.claude.json` sibling.
 - `prepare` seede → `merge_back` extrait les transcripts vers `~/.claude/projects/` → `teardown`
   supprime le staging dir.
-- Une **Sandbox** `copy`/`pure` s'exécute dans l'**image sandbox** `pdo-sandbox:h-<hash>`, garantie
-  présente par `ensure_image` (#405) ; l'instanciation d'un conteneur à partir d'elle → #406/ADR-0030.
-- **Différé (ne pas définir dans #404)** : préfixe `docker exec` des tails, conteneur
-  `pdo-sbx-<run-id>`, identity mounts (#406, ADR-0030) ; précédence des sources du mode
-  (run → trigger → `default_sandbox` d'instance, pattern ADR-0015) (#410) ; seam `transcripts_root`
-  pointant stale-detection/coût vers le staging (#408) ; **fourniture par registry** (pull GHCR +
-  précédence `image_source`) (#411) — #405 ne couvre que le build local.
+- Une **Sandbox** `copy`/`pure` s'exécute dans un **conteneur sandbox** (`pdo-sbx-<run-id>`)
+  instancié depuis l'**image sandbox** `pdo-sandbox:h-<hash>` (garantie par `ensure_image`, #405) via
+  `ensure_running` (#406) ; ses **identity mounts** rendent le chemin de travail identique
+  hôte/conteneur (d'où le même dirname encodé pour `merge_back`), et toutes les tails y entrent par le
+  **préfixe `docker exec`** portant un **marqueur de session**. Kill ciblé + `remove` au `cleanup_run`.
+- **Différé (hors #404-#406)** : injection `/etc/passwd`+`/etc/group` pour uid hôte ≠ 1000 (sudo +
+  Node `os.userInfo()`) (issue de suivi) ; précédence des sources du mode (run → trigger →
+  `default_sandbox`, pattern ADR-0015) (#410) ; seam `transcripts_root` (#408) ; **fourniture par
+  registry** (pull GHCR + `image_source`) (#411) ; **câblage** de
+  `prepare`/`ensure_image`/`ensure_running`/`exec_prefix`/`merge_back` dans le run-advance +
+  **ADR-0030** (modèle d'exécution : réseau/auth) (#407).
 
 ### Ambiguïté signalée
 « sandbox » désigne deux choses : (1) cette feature (exécution conteneurisée d'un Run, #403) ;

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1878,6 +1878,7 @@ dependencies = [
  "filetime",
  "futures-util",
  "insta",
+ "libc",
  "mime_guess",
  "notify",
  "notify-debouncer-mini",

--- a/crates/pdo-daemon/Cargo.toml
+++ b/crates/pdo-daemon/Cargo.toml
@@ -37,6 +37,7 @@ notify.workspace = true
 notify-debouncer-mini.workspace = true
 portable-pty.workspace = true
 futures-util = "0.3"
+libc = "0.2"
 sha2.workspace = true
 # TLS via rustls (pure-Rust, `ring`) instead of the default native-tls/OpenSSL:
 # openssl-sys can't cross-compile to aarch64-unknown-linux-gnu in the release

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -31,6 +31,7 @@ mod prompt_augmenter;
 mod pty_bridge;
 mod run_advance;
 mod run_cost;
+mod sandbox_container;
 mod sandbox_image;
 mod sandbox_staging;
 #[allow(dead_code)]

--- a/crates/pdo-daemon/src/sandbox_container.rs
+++ b/crates/pdo-daemon/src/sandbox_container.rs
@@ -1,0 +1,931 @@
+//! Cycle de vie du conteneur sandbox par Run (#406, slice C du PRD #403).
+//!
+//! Miroir de [`crate::sandbox_image`] / [`crate::sandbox_staging`] : pas d'`AppState`,
+//! pas d'async, pas de lecture d'env dans le cœur — `&Path`/`&str`/`Vec<String>` in,
+//! path-math ou `std::process::Command` out. `HOME`, l'uid/gid et le binaire courant
+//! ne sont lus QUE par les résolveurs de bord.
+//!
+//! Ce module gère le conteneur **unique et long-vécu** d'un Run sandboxé,
+//! `pdo-sbx-<run_id>` (dormant, `sleep infinity`, PID 1 = `tini` via `--init`), dans
+//! lequel toutes les sessions du Run entrent par `docker exec` :
+//! - [`create_args`] / [`container_name`] — construction PURE de l'argv `docker create`
+//!   (identity mounts, `--user uid:gid` hôte, `--add-host`, `--init`, image, `sleep infinity`) ;
+//! - [`ensure_running`] — machine à états idempotente (up → réutilise ; arrêté → `start` ;
+//!   absent → `create` + `start`) dont la sonde ne confond JAMAIS une erreur transitoire
+//!   (daemon Docker down, permission) avec une absence ;
+//! - [`exec_prefix`] — le préfixe `docker exec -it …` qu'un nœud préposera à sa tail `claude`,
+//!   avec forwarding d'env par-nœud et un marqueur de session ([`SESSION_MARKER_ENV`]) ;
+//! - [`kill_session_in_container`] — kill CIBLÉ : tue le seul arbre de process porteur du
+//!   marqueur (scan `/proc/*/environ`), les sessions sœurs survivent ;
+//! - [`remove`] — `docker rm -f` idempotent, au `cleanup_run`.
+//!
+//! Les slices sœurs le CONSOMMENT mais ne sont PAS ici :
+//! - #407 câble [`ensure_running`]/[`exec_prefix`]/[`kill_session_in_container`]/[`remove`]
+//!   dans le run-advance et écrit **l'ADR-0030** (modèle d'exécution : réseau/auth) ;
+//! - #405 fournit l'image (`ensure_image`) et le seam docker réutilisé ici
+//!   ([`crate::sandbox_image::docker_bin_from_env`] / `DOCKER_NOT_FOUND_MSG`).
+//!
+//! ## Décisions de conception (voir la section « Sandbox » de `CONTEXT.md`)
+//! - **Marqueur de session = variable d'env, pas label Docker.** [`SESSION_MARKER_ENV`] est
+//!   posé par `-e` sur CHAQUE `docker exec`, donc hérité par `claude` et toute sa descendance —
+//!   contrairement à un marqueur d'argv, que `exec claude` (qui écrase l'argv de `bash -c`)
+//!   laisserait tomber. Le kill ciblé scanne `/proc/*/environ` pour ce marqueur.
+//! - **`--user` toujours NUMÉRIQUE `uid:gid`.** `--user 1000` seul ferait résoudre le gid
+//!   primaire via `/etc/passwd` (absent pour un uid arbitraire) → gid 0, bug silencieux de
+//!   propriété. `-e HOME=` suffit aux écritures `~/.claude` de Claude Code.
+//! - **GAP DOCUMENTÉ (uid hôte ≠ 1000).** L'image `ubuntu:24.04` livre `ubuntu`=uid/gid 1000,
+//!   donc le cas laptop courant résout ENTIÈREMENT (passwd présent). Pour un uid hôte ≠ 1000 :
+//!   `sudo` casse (getpwuid avant NOPASSWD) et `claude` peut casser (`os.userInfo()`). L'injection
+//!   `/etc/passwd`+`/etc/group` (générer les lignes au `prepare`-time, bind-monter — pattern PDO)
+//!   est **différée à une issue de suivi** (cf. `assets/sandbox/Dockerfile:33`). NE PAS éditer le
+//!   Dockerfile ici : il est content-hashé (#405), toute édition périme l'image buildée.
+//! - **`PDO_DAEMON_URL` réécrit au CREATE, jamais re-passé à l'exec.** Côté hôte `wrap_with_env`
+//!   exporte `localhost:<port>` ; dans le conteneur `localhost` = le conteneur. Le create pose
+//!   donc `-e PDO_DAEMON_URL=http://host.docker.internal:<port>` (couplé à `--add-host`), et
+//!   [`exec_prefix`] ne re-passe JAMAIS cette var (un `-e PDO_DAEMON_URL` nu clobbererait la
+//!   gateway par le `localhost` hôte). L'exec ne forwarde que les vars PAR-NŒUD.
+
+#![allow(dead_code)] // Tracer bullet : consommé/câblé par #407, non câblé dans cette slice.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{Context, Result};
+
+use crate::sandbox_image::DOCKER_NOT_FOUND_MSG;
+
+/// Env var portée par CHAQUE `docker exec`, héritée par `claude` et toute sa descendance ;
+/// clé du kill ciblé (scan `/proc/*/environ`). N'est PAS un label Docker.
+pub(crate) const SESSION_MARKER_ENV: &str = "PDO_SBX_SESSION";
+
+// -- type valeur (assemblé par les résolveurs, nourrit les builders purs) ----
+
+/// Tout ce dont [`create_args`] a besoin pour construire l'argv `docker create` d'un conteneur
+/// sandbox. Assemblé par le caller (#407) à partir des résolveurs de bord + des sorties de
+/// #404/#405 ; les builders purs ne lisent jamais l'environnement.
+pub(crate) struct ContainerSpec<'a> {
+    /// `pdo-sandbox:h-<hash>` ([`crate::sandbox_image::local_image_ref`]).
+    pub image_ref: &'a str,
+    /// Repo cible, monté rw à son chemin absolu hôte — couvre repo + tous les worktrees de
+    /// nœuds (sous `.pdo/runs/`) + `.pdo/prompts` en UN seul mount.
+    pub repo_root: &'a Path,
+    /// `-w` au create : cwd par défaut du conteneur (cosmétique — le conteneur ne fait que
+    /// `sleep` ; le cwd load-bearing est par-exec, cf. [`exec_prefix`]).
+    pub run_worktree: &'a Path,
+    /// *Staged Claude home* (#404) → `<host_home>/.claude:rw`.
+    pub staged_home: &'a Path,
+    /// `.claude.json` sibling (#404) → `<host_home>/.claude.json:rw`.
+    pub staged_json: &'a Path,
+    /// Binaire `pdo` hôte → `/usr/local/bin/pdo:ro`.
+    pub pdo_bin: &'a Path,
+    /// `$HOME` hôte : `-e HOME=` + racine des cibles de mount `.claude`/`.claude.json`.
+    pub host_home: &'a Path,
+    /// uid hôte (`--user <uid>:<gid>`, numérique).
+    pub uid: u32,
+    /// gid hôte (`--user <uid>:<gid>`, numérique).
+    pub gid: u32,
+    /// Port du daemon hôte : `-e PDO_DAEMON_URL=http://host.docker.internal:<port>`.
+    pub daemon_port: u16,
+}
+
+// -- builders purs (golden-testés) -------------------------------------------
+
+/// Nom déterministe du conteneur d'un Run : `pdo-sbx-<run_id>`. Par-Run → kill/destruction
+/// CIBLÉS (jamais un balayage global).
+pub(crate) fn container_name(run_id: &str) -> String {
+    format!("pdo-sbx-{run_id}")
+}
+
+/// Argv `docker create` (après le binaire `docker`). Ordre canonique FIGÉ par le golden test :
+/// `--init`, `--name`, `--user` numérique, `--add-host`, `-w`, les 4 `-e`, les 4 `-v`, l'image,
+/// puis le trailing `sleep infinity` (le conteneur dort ; les tails entrent par `docker exec`).
+pub(crate) fn create_args(run_id: &str, spec: &ContainerSpec) -> Vec<String> {
+    vec![
+        "create".to_string(),
+        // --init : tini comme PID 1, reape les enfants reparentés après un kill ciblé (sinon
+        // zombies permanents, `sleep infinity` ne reape pas). Docker embarque tini >= 1.13.
+        "--init".to_string(),
+        "--name".to_string(),
+        container_name(run_id),
+        // --user NUMÉRIQUE (uid:gid) : `--user <uid>` seul résoudrait le gid via /etc/passwd
+        // (absent pour un uid arbitraire) → gid 0.
+        "--user".to_string(),
+        format!("{}:{}", spec.uid, spec.gid),
+        // --add-host : la gateway que `-e PDO_DAEMON_URL` ci-dessous pointe.
+        "--add-host".to_string(),
+        "host.docker.internal:host-gateway".to_string(),
+        // -w au create (cosmétique, satisfait l'AC ; load-bearing = par-exec).
+        "-w".to_string(),
+        spec.run_worktree.display().to_string(),
+        // Vars RUN-CONSTANTES, posées une fois au create.
+        "-e".to_string(),
+        format!("HOME={}", spec.host_home.display()),
+        "-e".to_string(),
+        format!(
+            "PDO_DAEMON_URL=http://host.docker.internal:{}",
+            spec.daemon_port
+        ),
+        "-e".to_string(),
+        format!("PDO_RUN_ID={run_id}"),
+        "-e".to_string(),
+        "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1".to_string(),
+        // Identity mounts. UN mount repo couvre repo + worktrees + prompts au MÊME chemin absolu
+        // (invariant load-bearing D3 : le dirname encodé de merge_back doit matcher).
+        "-v".to_string(),
+        format!("{r}:{r}:rw", r = spec.repo_root.display()),
+        "-v".to_string(),
+        format!(
+            "{}:{}:rw",
+            spec.staged_home.display(),
+            spec.host_home.join(".claude").display()
+        ),
+        "-v".to_string(),
+        format!(
+            "{}:{}:rw",
+            spec.staged_json.display(),
+            spec.host_home.join(".claude.json").display()
+        ),
+        "-v".to_string(),
+        format!("{}:/usr/local/bin/pdo:ro", spec.pdo_bin.display()),
+        // Image, puis la commande dormante.
+        spec.image_ref.to_string(),
+        "sleep".to_string(),
+        "infinity".to_string(),
+    ]
+}
+
+/// Préfixe `docker exec` d'une session de nœud (après le binaire `docker` ; #407 y ajoute la
+/// tail `claude`). Ordre canonique FIGÉ par le golden test.
+///
+/// - `-e PDO_SBX_SESSION=<marker>` : le marqueur hérité par `claude` et sa descendance (clé du
+///   kill ciblé) ;
+/// - `-e PDO_NODE_ID` / `-e PDO_NODE_ITER` NUS : forwardent la valeur du shell hôte que
+///   `wrap_with_env` a exportée (vars PAR-NŒUD qui varient dans le Run) ;
+/// - `-w <workdir>` : le worktree DU NŒUD (valeur load-bearing D3, ≠ le `-w` cosmétique du create).
+///
+/// **JAMAIS** `-e PDO_DAEMON_URL` ici (posé au create vers `host.docker.internal` ; un `-e`
+/// nu re-forwarderait le `localhost` hôte et clobbererait la gateway).
+pub(crate) fn exec_prefix(
+    run_id: &str,
+    uid: u32,
+    gid: u32,
+    workdir: &Path,
+    marker: &str,
+) -> Vec<String> {
+    vec![
+        "exec".to_string(),
+        "-i".to_string(),
+        "-t".to_string(),
+        "-e".to_string(),
+        format!("{SESSION_MARKER_ENV}={marker}"),
+        "-e".to_string(),
+        "PDO_NODE_ID".to_string(),
+        "-e".to_string(),
+        "PDO_NODE_ITER".to_string(),
+        "--user".to_string(),
+        format!("{uid}:{gid}"),
+        "-w".to_string(),
+        workdir.display().to_string(),
+        container_name(run_id),
+    ]
+}
+
+// -- effets docker (sync std::process::Command, anyhow + .context) -----------
+
+/// État du conteneur tel que résolu par la sonde. Privé : le monde extérieur voit
+/// [`ensure_running`], pas les états intermédiaires.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ContainerState {
+    Running,
+    Stopped,
+    Absent,
+}
+
+/// `docker container inspect -f '{{.State.Running}}' <name>` (sonde vérifiée sur Docker 29.2.1) :
+/// - exit 0 + stdout `true`  → [`ContainerState::Running`] ;
+/// - exit 0 + stdout `false` → [`ContainerState::Stopped`] ;
+/// - exit != 0 **et** stderr sentinelle `no such container`/`no such object` → [`ContainerState::Absent`] ;
+/// - exit != 0 avec TOUT AUTRE stderr, **ou** exit 0 avec un stdout inattendu, **ou** spawn
+///   `NotFound` → **`Err`** (jamais Absent : une erreur transitoire — daemon Docker down,
+///   permission — ne doit pas déclencher un `docker create` qui masquerait le vrai problème).
+fn probe_state(docker_bin: &str, name: &str) -> Result<ContainerState> {
+    let output = match Command::new(docker_bin)
+        .args(["container", "inspect", "-f", "{{.State.Running}}", name])
+        .output()
+    {
+        Ok(output) => output,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Err(anyhow::Error::new(e)).context(DOCKER_NOT_FOUND_MSG);
+        }
+        Err(e) => {
+            return Err(e).context(
+                "failed to run `docker container inspect` while probing the sandbox container",
+            );
+        }
+    };
+
+    if output.status.success() {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        match stdout.trim() {
+            "true" => Ok(ContainerState::Running),
+            "false" => Ok(ContainerState::Stopped),
+            other => anyhow::bail!(
+                "unexpected `docker container inspect` output while probing `{name}`: {other:?} \
+                 (expected `true`/`false`) — refusing to treat as an absent container"
+            ),
+        }
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if is_absent_stderr(&stderr) {
+            Ok(ContainerState::Absent)
+        } else {
+            anyhow::bail!(
+                "`docker container inspect {name}` failed transiently ({}): {stderr} \
+                 — refusing to treat a transient docker error as an absent container",
+                output.status
+            )
+        }
+    }
+}
+
+/// Provisionneur IDEMPOTENT du conteneur (miroir de [`crate::sandbox_image::ensure_image`]) :
+/// sonde → up → no-op ; arrêté → `start` ; absent → `create` + `start`. Toute erreur de sonde
+/// (transitoire, docker absent) remonte via `?` sans jamais être traitée comme une absence.
+pub(crate) fn ensure_running(docker_bin: &str, run_id: &str, spec: &ContainerSpec) -> Result<()> {
+    let name = container_name(run_id);
+    match probe_state(docker_bin, &name)? {
+        ContainerState::Running => Ok(()),
+        ContainerState::Stopped => start_container(docker_bin, &name),
+        ContainerState::Absent => {
+            create_container(docker_bin, run_id, spec)?;
+            start_container(docker_bin, &name)
+        }
+    }
+}
+
+/// `docker` + [`create_args`]. `create` et `start` sont DEUX primitives (pas `run -d`) : la
+/// branche Stopped a de toute façon besoin de `start`, et un conteneur arrêté ne se `run` pas à
+/// nouveau. Pas de `--restart` (PDO possède le cycle de vie ; `unless-stopped` ressusciterait des
+/// conteneurs que PDO croit finis → fuite). Course au create (v1, mono-appelant par `run_id`) :
+/// un stderr `Conflict … already in use` est mappé sur un **succès bénin** (le `start` suivant est
+/// idempotent).
+fn create_container(docker_bin: &str, run_id: &str, spec: &ContainerSpec) -> Result<()> {
+    let args = create_args(run_id, spec);
+    let output = match Command::new(docker_bin).args(&args).output() {
+        Ok(output) => output,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Err(anyhow::Error::new(e)).context(DOCKER_NOT_FOUND_MSG);
+        }
+        Err(e) => {
+            return Err(e).context("failed to run `docker create` for the sandbox container");
+        }
+    };
+    if output.status.success() {
+        return Ok(());
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if is_name_conflict_stderr(&stderr) {
+        return Ok(()); // course bénigne : le conteneur existe déjà, on enchaîne `start`.
+    }
+    anyhow::bail!(
+        "failed to create the sandbox container `{}` — `docker create` exited with {}: {stderr}",
+        container_name(run_id),
+        output.status
+    )
+}
+
+/// `docker start <name>` (`docker start` ne prend pas `-d`). Non-zéro → bail avec le stderr docker.
+fn start_container(docker_bin: &str, name: &str) -> Result<()> {
+    let output = match Command::new(docker_bin).args(["start", name]).output() {
+        Ok(output) => output,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Err(anyhow::Error::new(e)).context(DOCKER_NOT_FOUND_MSG);
+        }
+        Err(e) => {
+            return Err(e).context("failed to run `docker start` for the sandbox container");
+        }
+    };
+    if output.status.success() {
+        Ok(())
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!(
+            "failed to start the sandbox container `{name}` — `docker start` exited with {}: {stderr}",
+            output.status
+        )
+    }
+}
+
+/// Kill CIBLÉ : un `docker exec` SÉPARÉ qui scanne `/proc/*/environ` pour le marqueur puis
+/// `TERM` → `sleep 2` → `KILL`. Nécessaire car le client `docker exec` tué côté tmux ne tue pas
+/// le process conteneur (reparenté sur PID 1) ; les sessions SŒURS du même Run survivent.
+///
+/// **Aucun `-e SESSION_MARKER_ENV` sur ce kill exec** (sinon `sh`/`grep` se matcheraient
+/// eux-mêmes). Réutilise le même `--user <uid>:<gid>` (règle same-uid : un uid ne peut
+/// signaler / lire `/proc/environ` que de ses propres process). Best-effort : conteneur déjà
+/// absent (sentinelle) → `Ok`.
+pub(crate) fn kill_session_in_container(
+    docker_bin: &str,
+    run_id: &str,
+    marker: &str,
+    uid: u32,
+    gid: u32,
+) -> Result<()> {
+    let name = container_name(run_id);
+    let user = format!("{uid}:{gid}");
+    let script = kill_one_liner(marker);
+    let output = match Command::new(docker_bin)
+        .arg("exec")
+        .arg("--user")
+        .arg(&user)
+        .arg(&name)
+        .arg("sh")
+        .arg("-c")
+        .arg(&script)
+        .output()
+    {
+        Ok(output) => output,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Err(anyhow::Error::new(e)).context(DOCKER_NOT_FOUND_MSG);
+        }
+        Err(e) => {
+            return Err(e).context("failed to run `docker exec` to kill a sandbox session");
+        }
+    };
+    if output.status.success() {
+        return Ok(());
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if is_absent_stderr(&stderr) {
+        return Ok(()); // best-effort : plus de conteneur, plus rien à tuer.
+    }
+    anyhow::bail!(
+        "failed to kill session `{marker}` in sandbox container `{name}` — \
+         `docker exec` exited with {}: {stderr}",
+        output.status
+    )
+}
+
+/// `docker rm -f <name>` au `cleanup_run`. Idempotent : conteneur déjà absent (sentinelle) →
+/// `Ok`. C'est LE verbe « destroy / destruction » du conteneur (distinct de
+/// [`kill_session_in_container`], qui ne tue qu'un arbre de session).
+pub(crate) fn remove(docker_bin: &str, run_id: &str) -> Result<()> {
+    let name = container_name(run_id);
+    let output = match Command::new(docker_bin)
+        .arg("rm")
+        .arg("-f")
+        .arg(&name)
+        .output()
+    {
+        Ok(output) => output,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Err(anyhow::Error::new(e)).context(DOCKER_NOT_FOUND_MSG);
+        }
+        Err(e) => {
+            return Err(e).context("failed to run `docker rm -f` for the sandbox container");
+        }
+    };
+    if output.status.success() {
+        return Ok(());
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if is_absent_stderr(&stderr) {
+        return Ok(()); // idempotent : déjà supprimé.
+    }
+    anyhow::bail!(
+        "failed to remove the sandbox container `{name}` — `docker rm -f` exited with {}: {stderr}",
+        output.status
+    )
+}
+
+// -- helpers (privés) --------------------------------------------------------
+
+/// Sentinelle docker « conteneur absent », insensible à la casse. Couvre les deux libellés
+/// (`No such container` de `rm`/`exec`, `No such object` d'`inspect`). Une comparaison de
+/// substring, pas d'exit-code, car un exit != 0 peut aussi être transitoire.
+fn is_absent_stderr(stderr: &str) -> bool {
+    let s = stderr.to_lowercase();
+    s.contains("no such container") || s.contains("no such object")
+}
+
+/// Sentinelle docker « nom déjà pris » (course au create), insensible à la casse.
+fn is_name_conflict_stderr(stderr: &str) -> bool {
+    let s = stderr.to_lowercase();
+    s.contains("conflict") || s.contains("already in use")
+}
+
+/// One-liner `sh -c` du kill ciblé (marqueur single-quoté). `grep -qazx` : `-z` enregistrements
+/// NUL (`/environ` est NUL-séparé), `-x` match ligne ENTIÈRE (pas de faux positif sur un préfixe
+/// du marqueur d'une session sœur), `-a` force le mode texte. `TERM` puis, après 2 s, `KILL`.
+fn kill_one_liner(marker: &str) -> String {
+    let target = sh_single_quote(&format!("{SESSION_MARKER_ENV}={marker}"));
+    format!(
+        "t={target}; \
+k() {{ for e in /proc/[0-9]*/environ; do p=${{e%/environ}}; p=${{p#/proc/}}; \
+grep -qazx \"$t\" \"$e\" 2>/dev/null && kill -\"$1\" \"$p\" 2>/dev/null; done; }}; \
+k TERM; sleep 2; k KILL"
+    )
+}
+
+/// Single-quote une chaîne pour un `sh -c` (miroir de `tmux_session_manager::sh_single_quote`).
+fn sh_single_quote(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('\'');
+    for ch in s.chars() {
+        if ch == '\'' {
+            out.push_str("'\\''");
+        } else {
+            out.push(ch);
+        }
+    }
+    out.push('\'');
+    out
+}
+
+// -- résolveurs de bord (seuls lecteurs env/uid ; les tests injectent directement) -------
+
+/// `$HOME` hôte. `None` si absent. Câblé par le daemon (#407) ; les unit tests injectent des
+/// temp dirs et bypassent ce résolveur.
+pub(crate) fn host_home_from_env() -> Option<PathBuf> {
+    std::env::var("HOME").ok().map(PathBuf::from)
+}
+
+/// uid hôte via `getuid(2)` (syscall, pas d'env → pas de suffixe `_from_env`).
+pub(crate) fn host_uid() -> u32 {
+    // SAFETY: `getuid` a la signature `() -> uid_t`, ne prend aucun argument, ne déréférence
+    // aucun pointeur et réussit toujours (POSIX : « The getuid() function shall always be
+    // successful »). Aucune précondition à satisfaire.
+    unsafe { libc::getuid() }
+}
+
+/// gid hôte via `getgid(2)`.
+pub(crate) fn host_gid() -> u32 {
+    // SAFETY: idem [`host_uid`] — `getgid` ne prend aucun argument et réussit toujours.
+    unsafe { libc::getgid() }
+}
+
+/// Chemin du binaire `pdo` courant à bind-monter dans le conteneur (`/usr/local/bin/pdo:ro`).
+/// Miroir de l'usage `std::env::current_exe` de `lib.rs`.
+pub(crate) fn pdo_bin_path() -> Result<PathBuf> {
+    std::env::current_exe()
+        .context("failed to determine the pdo binary path to bind-mount into the sandbox container")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+
+    /// Single-quote pour l'embarquement dans le script bash du fake docker (aucune mutation
+    /// d'`std::env` : le fake est threadé comme `docker_bin`, cf. discipline #405 parallèle-cargo).
+    fn q(s: &str) -> String {
+        format!("'{}'", s.replace('\'', "'\\''"))
+    }
+
+    /// Comportement injecté du fake docker, par sous-commande. `Default` = tout exit 0, inspect
+    /// répond `true` (conteneur up).
+    #[derive(Clone)]
+    struct FakeSpec {
+        inspect_exit: i32,
+        inspect_stdout: String,
+        inspect_stderr: String,
+        create_exit: i32,
+        create_stderr: String,
+        start_exit: i32,
+        exec_exit: i32,
+        exec_stderr: String,
+        rm_exit: i32,
+        rm_stderr: String,
+    }
+
+    impl Default for FakeSpec {
+        fn default() -> Self {
+            Self {
+                inspect_exit: 0,
+                inspect_stdout: "true".to_string(),
+                inspect_stderr: String::new(),
+                create_exit: 0,
+                create_stderr: String::new(),
+                start_exit: 0,
+                exec_exit: 0,
+                exec_stderr: String::new(),
+                rm_exit: 0,
+                rm_stderr: String::new(),
+            }
+        }
+    }
+
+    /// Écrit un faux `docker` exécutable et renvoie `(docker_bin, argv_log)`. Branche sur `$1`
+    /// (`container`→inspect, `create`, `start`, `exec`, `rm`) et NON sur `"$1 $2"` : un vrai
+    /// `docker container inspect …` a `$2 = "inspect"`. Chaque invocation append son argv (une
+    /// ligne par arg) dans `argv.log`. Aucune mutation d'`std::env`.
+    fn write_fake_docker(dir: &Path, spec: &FakeSpec) -> (String, PathBuf) {
+        let bin = dir.join("fake-docker");
+        let log = dir.join("argv.log");
+        let script = format!(
+            "#!/usr/bin/env bash\n\
+             printf '%s\\n' \"$@\" >> {log}\n\
+             case \"$1\" in\n\
+             container) printf '%s' {ins_out}; printf '%s' {ins_err} >&2; exit {ins_exit} ;;\n\
+             create) printf '%s' {cr_err} >&2; exit {cr_exit} ;;\n\
+             start) exit {st_exit} ;;\n\
+             exec) printf '%s' {ex_err} >&2; exit {ex_exit} ;;\n\
+             rm) printf '%s' {rm_err} >&2; exit {rm_exit} ;;\n\
+             *) exit 0 ;;\n\
+             esac\n",
+            log = q(&log.display().to_string()),
+            ins_out = q(&spec.inspect_stdout),
+            ins_err = q(&spec.inspect_stderr),
+            ins_exit = spec.inspect_exit,
+            cr_err = q(&spec.create_stderr),
+            cr_exit = spec.create_exit,
+            st_exit = spec.start_exit,
+            ex_err = q(&spec.exec_stderr),
+            ex_exit = spec.exec_exit,
+            rm_err = q(&spec.rm_stderr),
+            rm_exit = spec.rm_exit,
+        );
+        std::fs::write(&bin, script).unwrap();
+        std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
+        (bin.to_str().unwrap().to_string(), log)
+    }
+
+    fn log_lines(log: &Path) -> Vec<String> {
+        std::fs::read_to_string(log)
+            .unwrap_or_default()
+            .lines()
+            .map(str::to_string)
+            .collect()
+    }
+
+    /// Fixtures possédant les chemins pointés par [`ContainerSpec`] (dont les refs empruntent).
+    struct Fixtures {
+        repo: PathBuf,
+        run_wt: PathBuf,
+        home: PathBuf,
+        json: PathBuf,
+        pdo: PathBuf,
+        host_home: PathBuf,
+        image: String,
+    }
+
+    impl Fixtures {
+        fn sample() -> Self {
+            Self {
+                repo: PathBuf::from("/repo"),
+                run_wt: PathBuf::from("/repo/.pdo/runs/r1/worktree"),
+                home: PathBuf::from("/sb/r1/claude-home"),
+                json: PathBuf::from("/sb/r1/.claude.json"),
+                pdo: PathBuf::from("/host/bin/pdo"),
+                host_home: PathBuf::from("/home/u"),
+                image: "pdo-sandbox:h-abc123".to_string(),
+            }
+        }
+
+        fn spec(&self) -> ContainerSpec<'_> {
+            ContainerSpec {
+                image_ref: &self.image,
+                repo_root: &self.repo,
+                run_worktree: &self.run_wt,
+                staged_home: &self.home,
+                staged_json: &self.json,
+                pdo_bin: &self.pdo,
+                host_home: &self.host_home,
+                uid: 1000,
+                gid: 1000,
+                daemon_port: 6172,
+            }
+        }
+    }
+
+    fn strings(items: &[&str]) -> Vec<String> {
+        items.iter().map(|s| s.to_string()).collect()
+    }
+
+    /// Sous `cargo test --workspace`, exec-er un binaire **fraîchement écrit** peut renvoyer
+    /// `ETXTBSY` (os error 26) : un autre test qui `fork`+`exec` au même instant hérite
+    /// transitoirement du fd d'écriture du fake docker (race Rust bien connue, rust-lang/rust#45719).
+    /// La prod n'exec JAMAIS un binaire fraîchement écrit (`docker` est stable) → le retry vit
+    /// ICI, pas dans le cœur. Une tentative ETXTBSY échoue **avant** que le script ne tourne, donc
+    /// elle n'écrit rien dans `argv.log` : les assertions d'argv restent exactes après retry.
+    fn retry_etxtbsy<T>(mut op: impl FnMut() -> Result<T>) -> Result<T> {
+        for _ in 0..100 {
+            match op() {
+                Err(e) if is_etxtbsy(&e) => {
+                    std::thread::sleep(std::time::Duration::from_millis(5));
+                }
+                other => return other,
+            }
+        }
+        op()
+    }
+
+    fn is_etxtbsy(e: &anyhow::Error) -> bool {
+        e.chain().any(|c| {
+            c.downcast_ref::<std::io::Error>()
+                .and_then(std::io::Error::raw_os_error)
+                == Some(26)
+        })
+    }
+
+    // -- 1. create_args golden (AC#1) ----------------------------------------
+
+    #[test]
+    fn create_args_golden() {
+        let fx = Fixtures::sample();
+        let args = create_args("r1", &fx.spec());
+        let expected = strings(&[
+            "create",
+            "--init",
+            "--name",
+            "pdo-sbx-r1",
+            "--user",
+            "1000:1000",
+            "--add-host",
+            "host.docker.internal:host-gateway",
+            "-w",
+            "/repo/.pdo/runs/r1/worktree",
+            "-e",
+            "HOME=/home/u",
+            "-e",
+            "PDO_DAEMON_URL=http://host.docker.internal:6172",
+            "-e",
+            "PDO_RUN_ID=r1",
+            "-e",
+            "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1",
+            "-v",
+            "/repo:/repo:rw",
+            "-v",
+            "/sb/r1/claude-home:/home/u/.claude:rw",
+            "-v",
+            "/sb/r1/.claude.json:/home/u/.claude.json:rw",
+            "-v",
+            "/host/bin/pdo:/usr/local/bin/pdo:ro",
+            "pdo-sandbox:h-abc123",
+            "sleep",
+            "infinity",
+        ]);
+        assert_eq!(args, expected);
+    }
+
+    // -- 2. exec_prefix golden (AC#1) ----------------------------------------
+
+    #[test]
+    fn exec_prefix_golden() {
+        let wt = Path::new("/repo/.pdo/runs/r1/nodes/n1/iter-1");
+        let args = exec_prefix("r1", 1000, 1000, wt, "pdo-r1-n1-iter-1");
+        let expected = strings(&[
+            "exec",
+            "-i",
+            "-t",
+            "-e",
+            "PDO_SBX_SESSION=pdo-r1-n1-iter-1",
+            "-e",
+            "PDO_NODE_ID",
+            "-e",
+            "PDO_NODE_ITER",
+            "--user",
+            "1000:1000",
+            "-w",
+            "/repo/.pdo/runs/r1/nodes/n1/iter-1",
+            "pdo-sbx-r1",
+        ]);
+        assert_eq!(args, expected);
+        // D4 : jamais PDO_DAEMON_URL sur l'exec (clobbererait la gateway du create).
+        assert!(
+            !args.iter().any(|a| a.contains("PDO_DAEMON_URL")),
+            "exec_prefix ne doit jamais re-passer PDO_DAEMON_URL"
+        );
+    }
+
+    // -- 3-8. ensure_running / probe (AC#2) ----------------------------------
+
+    #[test]
+    fn running_reuses() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (docker, log) = write_fake_docker(tmp.path(), &FakeSpec::default()); // inspect → true
+        let fx = Fixtures::sample();
+
+        retry_etxtbsy(|| ensure_running(&docker, "r1", &fx.spec())).unwrap();
+
+        let lines = log_lines(&log);
+        assert!(
+            lines.contains(&"container".to_string()) && lines.contains(&"inspect".to_string()),
+            "la sonde inspect doit avoir tourné"
+        );
+        assert!(
+            !lines.contains(&"create".to_string()),
+            "running → pas de create"
+        );
+        assert!(
+            !lines.contains(&"start".to_string()),
+            "running → pas de start"
+        );
+    }
+
+    #[test]
+    fn stopped_starts_only() {
+        let tmp = tempfile::tempdir().unwrap();
+        let spec = FakeSpec {
+            inspect_stdout: "false".to_string(),
+            ..Default::default()
+        };
+        let (docker, log) = write_fake_docker(tmp.path(), &spec);
+        let fx = Fixtures::sample();
+
+        retry_etxtbsy(|| ensure_running(&docker, "r1", &fx.spec())).unwrap();
+
+        let lines = log_lines(&log);
+        assert!(lines.contains(&"start".to_string()), "stopped → start");
+        assert!(
+            !lines.contains(&"create".to_string()),
+            "stopped → pas de create"
+        );
+    }
+
+    #[test]
+    fn absent_creates_then_starts() {
+        let tmp = tempfile::tempdir().unwrap();
+        let spec = FakeSpec {
+            inspect_exit: 1,
+            inspect_stdout: String::new(),
+            inspect_stderr: "Error: No such container: pdo-sbx-r1".to_string(),
+            ..Default::default()
+        };
+        let (docker, log) = write_fake_docker(tmp.path(), &spec);
+        let fx = Fixtures::sample();
+
+        retry_etxtbsy(|| ensure_running(&docker, "r1", &fx.spec())).unwrap();
+
+        let lines = log_lines(&log);
+        let create_pos = lines
+            .iter()
+            .position(|l| l == "create")
+            .expect("create attendu");
+        let start_pos = lines
+            .iter()
+            .position(|l| l == "start")
+            .expect("start attendu");
+        assert!(create_pos < start_pos, "create doit précéder start");
+        // Le create se termine par la commande dormante.
+        assert!(
+            lines.contains(&"sleep".to_string()) && lines.contains(&"infinity".to_string()),
+            "create doit poser `sleep infinity`"
+        );
+    }
+
+    #[test]
+    fn transient_not_absent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let spec = FakeSpec {
+            inspect_exit: 1,
+            inspect_stdout: String::new(),
+            inspect_stderr: "Cannot connect to the Docker daemon at unix:///var/run/docker.sock."
+                .to_string(),
+            ..Default::default()
+        };
+        let (docker, log) = write_fake_docker(tmp.path(), &spec);
+        let fx = Fixtures::sample();
+
+        let err = retry_etxtbsy(|| ensure_running(&docker, "r1", &fx.spec())).unwrap_err();
+
+        assert!(
+            format!("{err:#}").contains("transient"),
+            "une erreur docker transitoire doit être signalée comme telle: {err:#}"
+        );
+        assert!(
+            !log_lines(&log).contains(&"create".to_string()),
+            "erreur transitoire ≠ absent : jamais de create"
+        );
+    }
+
+    #[test]
+    fn unexpected_output_not_absent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let spec = FakeSpec {
+            inspect_stdout: "garbage".to_string(),
+            ..Default::default()
+        };
+        let (docker, log) = write_fake_docker(tmp.path(), &spec);
+        let fx = Fixtures::sample();
+
+        let err = retry_etxtbsy(|| ensure_running(&docker, "r1", &fx.spec())).unwrap_err();
+
+        assert!(
+            format!("{err:#}").contains("unexpected"),
+            "un stdout inattendu doit être une erreur, jamais une absence: {err:#}"
+        );
+        assert!(!log_lines(&log).contains(&"create".to_string()));
+    }
+
+    #[test]
+    fn docker_missing_errors() {
+        let tmp = tempfile::tempdir().unwrap();
+        let missing = tmp.path().join("no-such-docker");
+        let fx = Fixtures::sample();
+
+        let err = ensure_running(missing.to_str().unwrap(), "r1", &fx.spec()).unwrap_err();
+
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("Docker") && msg.contains("not found on PATH"),
+            "message docker-absent attendu: {msg}"
+        );
+        // Chaîne à 2 maillons : la source io::NotFound est préservée (#298).
+        assert!(
+            err.chain().count() >= 2,
+            "la source io::Error doit être préservée dans la chaîne anyhow"
+        );
+        // Aucune invocation docker n'a pu tourner → pas de log.
+        assert!(
+            !tmp.path().join("argv.log").exists(),
+            "docker absent → argv-log vide"
+        );
+    }
+
+    // -- 9. kill ciblé (AC#3) ------------------------------------------------
+
+    #[test]
+    fn kill_targets_only_marker() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (docker, log) = write_fake_docker(tmp.path(), &FakeSpec::default()); // exec → exit 0
+
+        retry_etxtbsy(|| kill_session_in_container(&docker, "r1", "pdo-r1-n1-iter-1", 1000, 1000))
+            .unwrap();
+
+        let lines = log_lines(&log);
+        assert_eq!(
+            lines[..6],
+            strings(&["exec", "--user", "1000:1000", "pdo-sbx-r1", "sh", "-c"])[..],
+            "argv du kill exec"
+        );
+        let one_liner = &lines[6];
+        assert!(
+            one_liner.contains("PDO_SBX_SESSION=pdo-r1-n1-iter-1"),
+            "le one-liner doit cibler CE marqueur: {one_liner}"
+        );
+        assert!(
+            !one_liner.contains("pdo-r1-n2-iter-1"),
+            "le one-liner ne doit PAS cibler une session sœur"
+        );
+        // `grep -qazx` : match ligne entière (pas de faux positif sur un préfixe).
+        assert!(
+            one_liner.contains("grep -qazx"),
+            "match exact NUL-record attendu"
+        );
+        // Pas de -e marqueur sur le kill exec (sinon sh/grep se matchent eux-mêmes).
+        assert!(
+            !lines.contains(&"-e".to_string()),
+            "pas de -e SESSION_MARKER_ENV sur le kill exec"
+        );
+    }
+
+    // -- 10-12. remove (AC#4 / AC#5) -----------------------------------------
+
+    #[test]
+    fn remove_present_ok() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (docker, log) = write_fake_docker(tmp.path(), &FakeSpec::default()); // rm → exit 0
+
+        retry_etxtbsy(|| remove(&docker, "r1")).unwrap();
+
+        assert_eq!(log_lines(&log), strings(&["rm", "-f", "pdo-sbx-r1"]));
+    }
+
+    #[test]
+    fn remove_absent_idempotent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let spec = FakeSpec {
+            rm_exit: 1,
+            rm_stderr: "Error: No such container: pdo-sbx-r1".to_string(),
+            ..Default::default()
+        };
+        let (docker, _) = write_fake_docker(tmp.path(), &spec);
+
+        // Idempotent : `rm -f` d'un conteneur absent → Ok.
+        retry_etxtbsy(|| remove(&docker, "r1")).unwrap();
+    }
+
+    #[test]
+    fn remove_docker_missing_errors() {
+        let tmp = tempfile::tempdir().unwrap();
+        let missing = tmp.path().join("no-such-docker");
+
+        let err = remove(missing.to_str().unwrap(), "r1").unwrap_err();
+
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("Docker") && msg.contains("not found on PATH"),
+            "message docker-absent attendu: {msg}"
+        );
+        assert!(err.chain().count() >= 2, "source io::Error préservée");
+    }
+
+    // -- 13. schéma de nom ---------------------------------------------------
+
+    #[test]
+    fn container_name_schema() {
+        assert_eq!(container_name("r"), "pdo-sbx-r");
+        assert_eq!(container_name("20260101-abcdef"), "pdo-sbx-20260101-abcdef");
+    }
+}

--- a/crates/pdo-daemon/src/sandbox_image.rs
+++ b/crates/pdo-daemon/src/sandbox_image.rs
@@ -37,7 +37,9 @@ pub const DOCKER_CMD_OVERRIDE_ENV: &str = "PDO_DOCKER_CMD_OVERRIDE";
 
 /// Message d'erreur unique quand le binaire `docker` est introuvable sur le PATH. Devient la
 /// `reason` d'un `RunFailed` (US-16) : jamais d'exécution silencieuse sur l'hôte.
-const DOCKER_NOT_FOUND_MSG: &str =
+/// `pub(crate)` : réutilisé verbatim par [`crate::sandbox_container`] (#406) — un seul message
+/// canonique docker-absent partagé par les deux modules sandbox.
+pub(crate) const DOCKER_NOT_FOUND_MSG: &str =
     "sandbox run requires Docker, but the `docker` binary was not found on PATH — \
      install Docker or set this run's sandbox to `off`";
 
@@ -106,8 +108,9 @@ pub(crate) fn image_exists(docker_bin: &str, tag: &str) -> Result<bool> {
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
             Err(anyhow::Error::new(e)).context(DOCKER_NOT_FOUND_MSG)
         }
-        Err(e) => Err(e)
-            .context("failed to run `docker image inspect` while probing the sandbox image"),
+        Err(e) => {
+            Err(e).context("failed to run `docker image inspect` while probing the sandbox image")
+        }
     }
 }
 
@@ -133,8 +136,7 @@ pub(crate) fn build_image(
             return Err(anyhow::Error::new(e)).context(DOCKER_NOT_FOUND_MSG);
         }
         Err(e) => {
-            return Err(e)
-                .context("failed to run `docker build` while building the sandbox image");
+            return Err(e).context("failed to run `docker build` while building the sandbox image");
         }
     };
     if !output.status.success() {
@@ -161,7 +163,10 @@ pub(crate) fn ensure_image(docker_bin: &str, sandbox_root: &Path) -> Result<Stri
     // 2. Octets bruts sur disque = entrée EXACTE du hash ET du build (jamais normaliser).
     let dockerfile = dockerfile_path(sandbox_root);
     let bytes = std::fs::read(&dockerfile).with_context(|| {
-        format!("failed to read sandbox Dockerfile at {}", dockerfile.display())
+        format!(
+            "failed to read sandbox Dockerfile at {}",
+            dockerfile.display()
+        )
     })?;
     // 3. Tag adressé par contenu.
     let tag = local_image_ref(&bytes);
@@ -172,7 +177,10 @@ pub(crate) fn ensure_image(docker_bin: &str, sandbox_root: &Path) -> Result<Stri
     // 5. Contexte de build dédié VIDE (D8 : jamais sandbox_root, siblings = staging par-run).
     let context_dir = build_context_dir(sandbox_root);
     std::fs::create_dir_all(&context_dir).with_context(|| {
-        format!("failed to create sandbox build context at {}", context_dir.display())
+        format!(
+            "failed to create sandbox build context at {}",
+            context_dir.display()
+        )
     })?;
     // 6. Build. v1: double-build concurrent premier-run accepté (deux `docker build -t <même
     //    tag>` sont sûrs — daemon sérialise + cache, la sonde court-circuite le 2e run) ;
@@ -400,7 +408,9 @@ mod tests {
 
         let h = dockerfile_hash(base);
         assert_eq!(h.len(), 12);
-        assert!(h.bytes().all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase()));
+        assert!(h
+            .bytes()
+            .all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase()));
         assert!(local_image_ref(base).starts_with("pdo-sandbox:h-"));
 
         // GARDE-FOU PARITÉ CI : figer l'algo canonique. Épingle la sortie Rust au préfixe que

--- a/crates/pdo-daemon/src/sandbox_staging.rs
+++ b/crates/pdo-daemon/src/sandbox_staging.rs
@@ -45,7 +45,8 @@ pub(crate) enum Mode {
 /// Fichiers de config top-level de `~/.claude` recopiés en mode `copy` (en plus
 /// des `*.md` captés par glob). `.credentials.json` préserve son mode 0600 via
 /// [`std::fs::copy`].
-const COPY_ALLOWLIST_FILES: &[&str] = &["settings.json", "settings.local.json", ".credentials.json"];
+const COPY_ALLOWLIST_FILES: &[&str] =
+    &["settings.json", "settings.local.json", ".credentials.json"];
 
 /// Dossiers de `~/.claude` recopiés en mode `copy` (walk préservant symlinks +
 /// bits exécutables). `projects/` est délibérément absent : jamais copié.
@@ -275,22 +276,20 @@ fn set_mode_0600(path: &Path) -> Result<()> {
 /// symlink-aware (`std::fs::copy` déréférence).
 fn copy_tree_preserving(src: &Path, dst: &Path) -> Result<()> {
     std::fs::create_dir_all(dst).with_context(|| format!("create dir {}", dst.display()))?;
-    let entries =
-        std::fs::read_dir(src).with_context(|| format!("read dir {}", src.display()))?;
+    let entries = std::fs::read_dir(src).with_context(|| format!("read dir {}", src.display()))?;
     for entry in entries.flatten() {
         let from = entry.path();
         let to = dst.join(entry.file_name());
-        let md = std::fs::symlink_metadata(&from)
-            .with_context(|| format!("stat {}", from.display()))?;
+        let md =
+            std::fs::symlink_metadata(&from).with_context(|| format!("stat {}", from.display()))?;
         let ft = md.file_type();
         if ft.is_symlink() {
-            let target =
-                std::fs::read_link(&from).with_context(|| format!("read_link {}", from.display()))?;
+            let target = std::fs::read_link(&from)
+                .with_context(|| format!("read_link {}", from.display()))?;
             // Idempotence : une exécution antérieure a pu laisser un lien/fichier.
             let _ = std::fs::remove_file(&to);
-            std::os::unix::fs::symlink(&target, &to).with_context(|| {
-                format!("symlink {} -> {}", to.display(), target.display())
-            })?;
+            std::os::unix::fs::symlink(&target, &to)
+                .with_context(|| format!("symlink {} -> {}", to.display(), target.display()))?;
         } else if ft.is_dir() {
             copy_tree_preserving(&from, &to)?;
         } else if ft.is_file() {
@@ -374,7 +373,11 @@ mod tests {
     const UUID: &str = "0f1e2d3c-aaaa-bbbb-cccc-ddddeeeeffff";
 
     fn mode_of(path: &Path) -> u32 {
-        std::fs::symlink_metadata(path).unwrap().permissions().mode() & 0o777
+        std::fs::symlink_metadata(path)
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777
     }
 
     fn write(path: &Path, content: &str) {
@@ -394,7 +397,11 @@ mod tests {
         let claude = home.join(".claude");
         // Allowlist dirs.
         write(&claude.join("skills/foo/skill.md"), "# skill\n");
-        write_mode(&claude.join("skills/foo/run.sh"), "#!/bin/sh\necho hi\n", 0o755);
+        write_mode(
+            &claude.join("skills/foo/run.sh"),
+            "#!/bin/sh\necho hi\n",
+            0o755,
+        );
         // Symlink relatif à l'intérieur de skills/foo → skill.md.
         std::os::unix::fs::symlink("skill.md", claude.join("skills/foo/link.md")).unwrap();
         write(&claude.join("plugins/bar/plugin.json"), "{}\n");
@@ -404,7 +411,11 @@ mod tests {
         // Allowlist files.
         write(&claude.join("settings.json"), r#"{"hooks":{"Stop":[]}}"#);
         write(&claude.join("settings.local.json"), r#"{"local":true}"#);
-        write_mode(&claude.join(".credentials.json"), r#"{"token":"secret"}"#, 0o600);
+        write_mode(
+            &claude.join(".credentials.json"),
+            r#"{"token":"secret"}"#,
+            0o600,
+        );
         write(&claude.join("CLAUDE.md"), "# global\n");
         write(&claude.join("RTK.md"), "# rtk\n");
         // État hôte volumineux — DOIT rester exclu.
@@ -412,9 +423,15 @@ mod tests {
         write(&claude.join("file-history/big.bin"), "xxxxxxxxxx");
         write(&claude.join("session-env/env-1/data"), "junk");
         // Transcripts hôte pré-existants — NE doivent PAS être copiés par prepare.
-        write(&claude.join(format!("projects/{ENC}/old.jsonl")), "{\"host\":1}\n");
+        write(
+            &claude.join(format!("projects/{ENC}/old.jsonl")),
+            "{\"host\":1}\n",
+        );
         // Sibling `.claude.json`.
-        write(&home.join(".claude.json"), r#"{"host":"profile","oauthAccount":{"x":1}}"#);
+        write(
+            &home.join(".claude.json"),
+            r#"{"host":"profile","oauthAccount":{"x":1}}"#,
+        );
     }
 
     // -- path math -----------------------------------------------------------
@@ -444,8 +461,14 @@ mod tests {
         let sandbox_dir = tempfile::tempdir().unwrap();
         fabricate_home(home_dir.path());
 
-        let staging =
-            prepare(home_dir.path(), sandbox_dir.path(), Mode::Copy, "run1", None).unwrap();
+        let staging = prepare(
+            home_dir.path(),
+            sandbox_dir.path(),
+            Mode::Copy,
+            "run1",
+            None,
+        )
+        .unwrap();
         assert_eq!(staging, staging_dir_for_run(sandbox_dir.path(), "run1"));
         let home = staged_claude_home(sandbox_dir.path(), "run1");
 
@@ -457,11 +480,17 @@ mod tests {
         assert!(home.join("output-styles/s.md").is_file());
         // Allowlist files présents (dont hooks-via-settings).
         let settings = std::fs::read_to_string(home.join("settings.json")).unwrap();
-        assert!(settings.contains("hooks"), "hooks vivent dans settings.json");
+        assert!(
+            settings.contains("hooks"),
+            "hooks vivent dans settings.json"
+        );
         assert!(home.join("settings.local.json").is_file());
         assert!(home.join(".credentials.json").is_file());
         assert!(home.join("CLAUDE.md").is_file());
-        assert!(home.join("RTK.md").is_file(), "*.md siblings captés par glob");
+        assert!(
+            home.join("RTK.md").is_file(),
+            "*.md siblings captés par glob"
+        );
 
         // `.claude.json` sibling copié verbatim (hors claude-home/).
         let staged_json = staged_claude_json(sandbox_dir.path(), "run1");
@@ -492,14 +521,27 @@ mod tests {
         let sandbox_dir = tempfile::tempdir().unwrap();
         fabricate_home(home_dir.path());
 
-        prepare(home_dir.path(), sandbox_dir.path(), Mode::Copy, "run1", None).unwrap();
+        prepare(
+            home_dir.path(),
+            sandbox_dir.path(),
+            Mode::Copy,
+            "run1",
+            None,
+        )
+        .unwrap();
         let home = staged_claude_home(sandbox_dir.path(), "run1");
 
         // Symlink recréé COMME lien, cible verbatim.
         let link = home.join("skills/foo/link.md");
         let md = std::fs::symlink_metadata(&link).unwrap();
-        assert!(md.file_type().is_symlink(), "le lien doit rester un symlink");
-        assert_eq!(std::fs::read_link(&link).unwrap(), PathBuf::from("skill.md"));
+        assert!(
+            md.file_type().is_symlink(),
+            "le lien doit rester un symlink"
+        );
+        assert_eq!(
+            std::fs::read_link(&link).unwrap(),
+            PathBuf::from("skill.md")
+        );
 
         // Exec bit conservé.
         assert_eq!(mode_of(&home.join("skills/foo/run.sh")), 0o755);
@@ -515,7 +557,14 @@ mod tests {
         write(&home_dir.path().join(".claude/settings.json"), "{}");
 
         // Ne doit pas paniquer / échouer sur les entrées absentes.
-        prepare(home_dir.path(), sandbox_dir.path(), Mode::Copy, "run1", None).unwrap();
+        prepare(
+            home_dir.path(),
+            sandbox_dir.path(),
+            Mode::Copy,
+            "run1",
+            None,
+        )
+        .unwrap();
         let home = staged_claude_home(sandbox_dir.path(), "run1");
         assert!(home.join("settings.json").is_file());
         assert!(!home.join("skills").exists());
@@ -532,7 +581,14 @@ mod tests {
         let sandbox_dir = tempfile::tempdir().unwrap();
         fabricate_home(home_dir.path()); // skills/settings existent → prouvent l'exclusion
 
-        prepare(home_dir.path(), sandbox_dir.path(), Mode::Pure, "run1", None).unwrap();
+        prepare(
+            home_dir.path(),
+            sandbox_dir.path(),
+            Mode::Pure,
+            "run1",
+            None,
+        )
+        .unwrap();
         let home = staged_claude_home(sandbox_dir.path(), "run1");
 
         // claude-home ne contient QUE `.credentials.json` + `projects/` (vide).
@@ -541,7 +597,10 @@ mod tests {
             .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
             .collect();
         names.sort();
-        assert_eq!(names, vec![".credentials.json".to_string(), "projects".to_string()]);
+        assert_eq!(
+            names,
+            vec![".credentials.json".to_string(), "projects".to_string()]
+        );
         assert_eq!(std::fs::read_dir(home.join("projects")).unwrap().count(), 0);
         assert!(!home.join("skills").exists());
         assert!(!home.join("settings.json").exists());
@@ -554,14 +613,21 @@ mod tests {
         .unwrap();
         assert_eq!(json["hasCompletedOnboarding"], serde_json::json!(true));
         assert!(json.get("projects").is_none(), "None → objet nu");
-        assert_eq!(mode_of(&staged_claude_json(sandbox_dir.path(), "run1")), 0o600);
+        assert_eq!(
+            mode_of(&staged_claude_json(sandbox_dir.path(), "run1")),
+            0o600
+        );
     }
 
     #[test]
     fn prepare_pure_seeds_trust_when_root_given() {
         let home_dir = tempfile::tempdir().unwrap();
         let sandbox_dir = tempfile::tempdir().unwrap();
-        write_mode(&home_dir.path().join(".claude/.credentials.json"), "{}", 0o600);
+        write_mode(
+            &home_dir.path().join(".claude/.credentials.json"),
+            "{}",
+            0o600,
+        );
         let trusted = Path::new("/repo/root");
 
         prepare(
@@ -580,7 +646,10 @@ mod tests {
         assert_eq!(json["hasCompletedOnboarding"], serde_json::json!(true));
         let entry = &json["projects"]["/repo/root"];
         assert_eq!(entry["hasTrustDialogAccepted"], serde_json::json!(true));
-        assert_eq!(entry["hasCompletedProjectOnboarding"], serde_json::json!(true));
+        assert_eq!(
+            entry["hasCompletedProjectOnboarding"],
+            serde_json::json!(true)
+        );
     }
 
     #[test]
@@ -588,7 +657,14 @@ mod tests {
         let home_dir = tempfile::tempdir().unwrap();
         let sandbox_dir = tempfile::tempdir().unwrap();
 
-        prepare(home_dir.path(), sandbox_dir.path(), Mode::Pure, "run1", None).unwrap();
+        prepare(
+            home_dir.path(),
+            sandbox_dir.path(),
+            Mode::Pure,
+            "run1",
+            None,
+        )
+        .unwrap();
 
         let json: serde_json::Value = serde_json::from_str(
             &std::fs::read_to_string(staged_claude_json(sandbox_dir.path(), "run1")).unwrap(),
@@ -602,7 +678,9 @@ mod tests {
 
     /// Écrit un transcript de staging (projects/<ENC>/...).
     fn stage_transcript(sandbox: &Path, run_id: &str, rel: &str, content: &str) {
-        let p = staged_claude_home(sandbox, run_id).join("projects").join(rel);
+        let p = staged_claude_home(sandbox, run_id)
+            .join("projects")
+            .join(rel);
         write(&p, content);
     }
 
@@ -624,15 +702,24 @@ mod tests {
             &format!("{ENC}/{UUID}/subagents/agent.jsonl"),
             "a\n",
         );
-        stage_transcript(sandbox, "run1", &format!("{ENC}/notes.md"), "not a transcript");
+        stage_transcript(
+            sandbox,
+            "run1",
+            &format!("{ENC}/notes.md"),
+            "not a transcript",
+        );
         stage_transcript(sandbox, "run1", &format!("{ENC}/.meta.json"), "{}");
 
         merge_back(home, sandbox, "run1").unwrap();
 
         let hp = host_projects(home);
-        assert_eq!(std::fs::read_to_string(hp.join(format!("{ENC}/sess.jsonl"))).unwrap(), "s\n");
         assert_eq!(
-            std::fs::read_to_string(hp.join(format!("{ENC}/{UUID}/subagents/agent.jsonl"))).unwrap(),
+            std::fs::read_to_string(hp.join(format!("{ENC}/sess.jsonl"))).unwrap(),
+            "s\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(hp.join(format!("{ENC}/{UUID}/subagents/agent.jsonl")))
+                .unwrap(),
             "a\n"
         );
         // Non-`.jsonl` jetés.
@@ -681,12 +768,18 @@ mod tests {
         // Resume (--continue) : le staging grossit → 2e merge capte la croissance.
         stage_transcript(sandbox, "run1", &rel, "l1\nl2\nl3\nl4\n");
         merge_back(home, sandbox, "run1").unwrap();
-        assert_eq!(std::fs::read_to_string(&host_file).unwrap(), "l1\nl2\nl3\nl4\n");
+        assert_eq!(
+            std::fs::read_to_string(&host_file).unwrap(),
+            "l1\nl2\nl3\nl4\n"
+        );
 
         // 3e appel sans changement → no-op (sentinelle de taille égale survit).
         std::fs::write(&host_file, "X1\nX2\nX3\nX4\n").unwrap();
         merge_back(home, sandbox, "run1").unwrap();
-        assert_eq!(std::fs::read_to_string(&host_file).unwrap(), "X1\nX2\nX3\nX4\n");
+        assert_eq!(
+            std::fs::read_to_string(&host_file).unwrap(),
+            "X1\nX2\nX3\nX4\n"
+        );
     }
 
     #[test]
@@ -720,7 +813,9 @@ mod tests {
         stage_transcript(sandbox, "run1", &format!("{ENC}/sess.jsonl"), "s\n");
 
         merge_back(home, sandbox, "run1").unwrap();
-        assert!(host_projects(home).join(format!("{ENC}/sess.jsonl")).is_file());
+        assert!(host_projects(home)
+            .join(format!("{ENC}/sess.jsonl"))
+            .is_file());
     }
 
     #[test]
@@ -768,7 +863,9 @@ mod tests {
             std::fs::read_to_string(home.join(".claude/history.jsonl")).unwrap(),
             "HOST-HISTORY"
         );
-        assert!(host_projects(home).join(format!("{ENC}/sess.jsonl")).is_file());
+        assert!(host_projects(home)
+            .join(format!("{ENC}/sess.jsonl"))
+            .is_file());
     }
 
     // -- teardown ------------------------------------------------------------
@@ -812,6 +909,8 @@ mod tests {
         teardown(sandbox, "run1").unwrap();
         assert!(!staging_dir_for_run(sandbox, "run1").exists());
         // Le transcript mergé côté hôte survit au teardown.
-        assert!(host_projects(home).join(format!("{ENC}/sess.jsonl")).is_file());
+        assert!(host_projects(home)
+            .join(format!("{ENC}/sess.jsonl"))
+            .is_file());
     }
 }


### PR DESCRIPTION
Closes #406

## Slice C du PRD #403 — module `sandbox_container`

Tracer bullet **non câblé** (`#![allow(dead_code)]`, câblage prévu par #407) : gère le cycle de vie du conteneur par run (`pdo-sbx-<run_id>`), les identity mounts et l'exec/kill ciblé.

### Décisions du plan grillé (D1–D7) respectées
- Marqueur de session = variable d'env `PDO_SBX_SESSION` (pas un label Docker) → hérité par `claude` et sa descendance.
- `--user` **numérique** `uid:gid` au create ; `--init` (reaper tini) + `--add-host host.docker.internal:host-gateway` + `PDO_DAEMON_URL` posé **au create** vers la gateway.
- `exec_prefix` pose `-w <worktree-du-nœud>` et **jamais** `-e PDO_DAEMON_URL`.
- `probe_state` ne confond jamais erreur transitoire et absence (pas de `create` masquant).
- Kill **ciblé** par scan `/proc/*/environ` (TERM → sleep 2 → KILL) : les sessions sœurs du même Run survivent ; `remove` idempotent.

### Support minimal et sain
`DOCKER_NOT_FOUND_MSG` → `pub(crate)`, reflows fmt whitespace-only (aucune sémantique), `mod sandbox_container;`, dépendance `libc = "0.2"` (Unix, cibles release Linux/macOS). CONTEXT.md étendu (section « Exécution (conteneur) », glossaire, relations).

### Suivi
Gap injection `passwd`/`group` pour uid ≠ 1000 différé à **#414** (open, `ready-for-agent`) — pas d'édition du Dockerfile (content-hashé).

### Gate CI-équivalente (`stable`) — verte
`cargo +stable fmt --check` clean · `clippy --workspace --all-targets -D warnings` 0 warning · `test --workspace` **1517 passed / 0 failed** (dont 13 tests fake-docker du module) · `build` vert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
