### PR TITLE
feat(#407): sandbox tracer bullet — run-advance wiring + ADR-0030

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -819,8 +819,10 @@ La complétion est signalée **depuis l'UI**, par un bouton "Mark complete" sur 
 
 > Section seedée par #404, complétée par les slices suivantes du PRD #403. Couvert **ici** :
 > staging fs (#404) + **fourniture de l'image** (#405, *Image (fourniture)*) + **exécution /
-> conteneur** (#406, *Exécution (conteneur)*). Le **câblage** dans le run-advance et le modèle
-> d'exécution formel (réseau/auth) restent **différés à ADR-0030 / #407** — ne pas les fixer ici.
+> conteneur** (#406, *Exécution (conteneur)*) + **câblage run-advance** (#407 : prep eager fail-fast,
+> wrapping des tails au chokepoint, kill/cleanup/boot/run-shell) fixé par **ADR-0030** (modèle
+> d'exécution : réseau/uid, trou d'auth assumé v1 lié à #260). Reste **différé** : `merge_back` +
+> observabilité (#408), précédence des sources du mode (#410), fourniture par registry (#411).
 
 **Sandbox** :
 Propriété **par Run**, **immuable après création**, portée par l'événement de création (projetée
@@ -860,7 +862,9 @@ de sous-agents `<uuid>/subagents/*.jsonl`), sous le **même dirname encodé** (c
 conteneur, garanti par les identity mounts, ADR-0030). **Idempotent** : copie ssi le fichier hôte est
 absent ou plus court (transcripts append-only) ; ne réécrit jamais un fichier hôte. Aucune autre
 écriture vers l'hôte. **Jeté délibérément (v1)** : settings, statsig, todos, `history.jsonl`,
-shell-snapshots — tout sauf les transcripts (#403 US-29). _Éviter_ : « sync », « flush », « commit ».
+shell-snapshots — tout sauf les transcripts (#403 US-29). **Câblage dans le run-advance = #408**
+(pas #407) : d'ici là un Run sandboxé est aveugle pour le coût/stale, trou d'observabilité assumé
+(ADR-0030). _Éviter_ : « sync », « flush », « commit ».
 
 **`teardown(run_id)`** :
 Purge le *staging dir* du Run ; sans effet s'il est déjà absent. _Éviter_ : « cleanup » (réservé à
@@ -955,12 +959,16 @@ absent (idempotent). C'est **le** verbe « destroy / destruction » réservé pa
   `ensure_running` (#406) ; ses **identity mounts** rendent le chemin de travail identique
   hôte/conteneur (d'où le même dirname encodé pour `merge_back`), et toutes les tails y entrent par le
   **préfixe `docker exec`** portant un **marqueur de session**. Kill ciblé + `remove` au `cleanup_run`.
-- **Différé (hors #404-#406)** : injection `/etc/passwd`+`/etc/group` pour uid hôte ≠ 1000 (sudo +
+- **Câblé (#407, ADR-0030)** : `prepare`/`ensure_image`/`ensure_running`/`exec_prefix` dans le
+  run-advance — prep eager fail-fast au create (Docker indispo → `RunFailed`, zéro spawn hôte),
+  wrapping des tails au chokepoint `build_tmux_script` (`off` byte-identique), kill ciblé dans
+  `reap_node_session`/`kill_node`/`restart_node`, `remove`+`teardown` au `cleanup_run`,
+  `ensure_running` à `boot_recovery` (Run live) et `open_run_shell` (ressuscite-ou-échoue).
+- **Différé** : `merge_back` **dans le run-advance** + observabilité coût/stale (seam
+  `transcripts_root`) (#408) ; injection `/etc/passwd`+`/etc/group` pour uid hôte ≠ 1000 (sudo +
   Node `os.userInfo()`) (issue de suivi) ; précédence des sources du mode (run → trigger →
-  `default_sandbox`, pattern ADR-0015) (#410) ; seam `transcripts_root` (#408) ; **fourniture par
-  registry** (pull GHCR + `image_source`) (#411) ; **câblage** de
-  `prepare`/`ensure_image`/`ensure_running`/`exec_prefix`/`merge_back` dans le run-advance +
-  **ADR-0030** (modèle d'exécution : réseau/auth) (#407).
+  `default_sandbox`, pattern ADR-0015) (#410) ; **fourniture par registry** (pull GHCR +
+  `image_source`) (#411).
 
 ### Ambiguïté signalée
 « sandbox » désigne deux choses : (1) cette feature (exécution conteneurisée d'un Run, #403) ;

--- a/crates/pdo-daemon/src/boot_recovery.rs
+++ b/crates/pdo-daemon/src/boot_recovery.rs
@@ -131,6 +131,33 @@ pub(crate) async fn run_boot_recovery(state: &AppState) {
             continue;
         }
 
+        // #407 D10: a live sandboxed Run needs its container back after a daemon
+        // restart — reconcile it here (before the orphan scan). Synchronous effect
+        // via spawn_blocking (ensure_ready may build/probe docker); failure is
+        // logged, not fatal — the orphan/stall handling below still runs, and a
+        // downstream spawn would fail loud on a still-missing container. No-op for
+        // `off`.
+        if !run_state.sandbox.is_off() {
+            match crate::sandbox_run::context_from_state(state, &run_state) {
+                Ok(ctx) => {
+                    match tokio::task::spawn_blocking(move || crate::sandbox_run::ensure_ready(&ctx))
+                        .await
+                    {
+                        Ok(Ok(())) => {}
+                        Ok(Err(e)) => warn!(
+                            "Boot recovery: failed to ensure sandbox container for run {run_id}: {e:#}"
+                        ),
+                        Err(je) => warn!(
+                            "Boot recovery: sandbox ensure_ready panicked for run {run_id}: {je}"
+                        ),
+                    }
+                }
+                Err(e) => warn!(
+                    "Boot recovery: failed to build sandbox context for run {run_id}: {e:#}"
+                ),
+            }
+        }
+
         // (1) Orphaned live nodes: Running/AwaitingUser with no tmux session.
         let orphaned: Vec<(String, i64)> = run_state
             .nodes

--- a/crates/pdo-daemon/src/boot_recovery.rs
+++ b/crates/pdo-daemon/src/boot_recovery.rs
@@ -152,9 +152,9 @@ pub(crate) async fn run_boot_recovery(state: &AppState) {
                         ),
                     }
                 }
-                Err(e) => warn!(
-                    "Boot recovery: failed to build sandbox context for run {run_id}: {e:#}"
-                ),
+                Err(e) => {
+                    warn!("Boot recovery: failed to build sandbox context for run {run_id}: {e:#}")
+                }
             }
         }
 

--- a/crates/pdo-daemon/src/event_log.rs
+++ b/crates/pdo-daemon/src/event_log.rs
@@ -177,6 +177,36 @@ impl RunStatus {
     }
 }
 
+/// How a Run is isolated (#403 / #407). A **per-Run, immutable** property carried
+/// on `RunStarted`, projected once into [`RunState::sandbox`], never mutated for
+/// the Run's whole life — a resumed session matches its transcript by working-dir
+/// path, so flipping the mode mid-life would break `claude --continue`.
+///
+/// - `Off` — historical host execution (no Docker, byte-identical legacy launch);
+/// - `Copy` — sandboxed, staged Claude home seeded by copying an allowlist of the
+///   host `~/.claude`;
+/// - `Pure` — sandboxed, staged Claude home seeded with credentials + trust only.
+///
+/// The wire form is exactly `off`/`copy`/`pure`. `Default` is `Off` so an absent
+/// payload field (historical runs, bare-API creates) projects to the host path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SandboxMode {
+    #[default]
+    Off,
+    Copy,
+    Pure,
+}
+
+impl SandboxMode {
+    /// Whether this Run runs on the host (the legacy, no-Docker path). The whole
+    /// sandbox wiring is gated on `!is_off()`, so the `off` parcours never touches
+    /// a single new line.
+    pub fn is_off(self) -> bool {
+        matches!(self, SandboxMode::Off)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum NodeStatus {
@@ -373,6 +403,11 @@ pub struct RunState {
     pub switch_states: HashMap<String, SwitchState>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub target_repo: Option<String>,
+    /// Isolation mode for this Run (#403 / #407). Immutable: set once from the
+    /// `RunStarted` payload, never mutated. Absent payload field → `Off` (the
+    /// legacy host path), so historical runs and bare-API creates stay off.
+    #[serde(default)]
+    pub sandbox: SandboxMode,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_branch: Option<String>,
     /// Provenance: the id of the Trigger that created this Run, if any.
@@ -427,6 +462,7 @@ impl RunState {
             collection_states: HashMap::new(),
             switch_states: HashMap::new(),
             target_repo: None,
+            sandbox: SandboxMode::Off,
             source_branch: None,
             triggered_by: None,
             pipeline_id: None,
@@ -682,6 +718,15 @@ fn apply_run_event(state: &mut RunState, event: &Event) {
                 }
                 if let Some(tr) = payload.get("target_repo").and_then(|v| v.as_str()) {
                     state.target_repo = Some(tr.to_string());
+                }
+                // #407: isolation mode, projected once and never mutated. Absent
+                // (or malformed) → the `Off` default (host path). Never panics —
+                // this applier runs before the transition guard.
+                if let Some(sandbox) = payload
+                    .get("sandbox")
+                    .and_then(|v| serde_json::from_value::<SandboxMode>(v.clone()).ok())
+                {
+                    state.sandbox = sandbox;
                 }
                 if let Some(sb) = payload.get("source_branch").and_then(|v| v.as_str()) {
                     state.source_branch = Some(sb.to_string());
@@ -4509,7 +4554,8 @@ mod tests {
                 "sw": { "chosen_branch": "pass", "evaluated_at": "2026-02-01T00:05:00.000Z", "switch_node_id": "sw" }
             },
             "target_repo": "Loulen/prompt-driven-orchestrator",
-            "triggered_by": "trigger-7"
+            "triggered_by": "trigger-7",
+            "sandbox": "off"
         });
         assert_eq!(actual, expected);
     }

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -33,6 +33,7 @@ mod run_advance;
 mod run_cost;
 mod sandbox_container;
 mod sandbox_image;
+mod sandbox_run;
 mod sandbox_staging;
 #[allow(dead_code)]
 mod scheduler;
@@ -217,6 +218,15 @@ struct AppState {
     /// [`DaemonConfig`] by `TestDaemon::spawn`, so no test ever launches real
     /// claude and no `std::env::set_var` race can clobber it (#181).
     tmux_cmd_override: Option<String>,
+    /// Per-daemon override for the `docker` binary the sandbox wiring shells out
+    /// to (#407). `None` in production (real `docker`); `Some(cmd)` in the
+    /// layer-3 harness. Seeded via [`DaemonConfig`], mirroring `tmux_cmd_override`
+    /// (#181) — never a process-global `std::env` read in the hot path.
+    docker_cmd_override: Option<String>,
+    /// Per-daemon sandbox home-root override (#407). `None` in production (real
+    /// `$HOME`); `Some(dir)` in the layer-3 harness so staging lands under the
+    /// test's tempdir. Seeded via [`DaemonConfig`].
+    sandbox_home_override: Option<PathBuf>,
     /// Epoch-millis of the **start** of the most recent Trigger scheduler tick,
     /// or `0` if it has never ticked. Process-lifetime only (a restart resets it
     /// *and* revives the scheduler). Surfaced by `GET /triggers/health` so a
@@ -326,6 +336,12 @@ struct CreateRunRequest {
     /// the trigger scheduler; absent for manual runs.
     #[serde(default)]
     triggered_by: Option<String>,
+    /// Isolation mode for this Run (#403 / #407). `#[serde(default)]` → `Off`, so
+    /// an absent field means the historical host path. Trigger fires pass `Off`
+    /// (source precedence run → trigger → default_sandbox is #410); this slice
+    /// only accepts the mode via the `POST /runs` parameter.
+    #[serde(default)]
+    sandbox: event_log::SandboxMode,
 }
 
 #[derive(Serialize)]
@@ -1443,6 +1459,20 @@ pub struct DaemonConfig {
     /// detection). Armed by `PDO_SERVICE_HEALTH` (`persistent`|`ephemeral`|
     /// `unknown`); tests set it directly.
     pub service_health_override: Option<ServiceHealthOverride>,
+    /// Per-daemon override for the `docker` binary invoked by the sandbox wiring
+    /// (#407). Mirrors `tmux_cmd_override` (#181): `None` in production (real
+    /// `docker`); `Some(cmd)` in the layer-3 harness points every sandbox docker
+    /// call at a fake executable, so no test needs a real daemon or a global
+    /// `std::env::set_var` race. Read once at boot from
+    /// [`sandbox_image::DOCKER_CMD_OVERRIDE_ENV`].
+    pub docker_cmd_override: Option<String>,
+    /// Per-daemon override for the sandbox **home root** (#407 testability seam).
+    /// `None` in production → the real `$HOME` (staging under `$HOME/.pdo/sandbox`,
+    /// `.claude` copied from `$HOME/.claude`). `Some(dir)` points staging + the
+    /// `.claude` source + the container-home mount at `dir` instead, so a layer-3
+    /// test stages under its own tempdir and never touches the real home. Read
+    /// once at boot from `PDO_SANDBOX_HOME_OVERRIDE`.
+    pub sandbox_home_override: Option<PathBuf>,
 }
 
 impl DaemonConfig {
@@ -1472,6 +1502,14 @@ impl DaemonConfig {
             service_health_override: std::env::var("PDO_SERVICE_HEALTH")
                 .ok()
                 .and_then(|v| ServiceHealthOverride::parse(&v)),
+            // Sandbox docker seam (#407), sibling of PDO_TMUX_CMD_OVERRIDE — read
+            // once at boot, `None`/unset in prod (real docker).
+            docker_cmd_override: std::env::var(sandbox_image::DOCKER_CMD_OVERRIDE_ENV).ok(),
+            // Sandbox home-root seam (#407) — `None`/unset in prod (real $HOME).
+            sandbox_home_override: std::env::var("PDO_SANDBOX_HOME_OVERRIDE")
+                .ok()
+                .filter(|s| !s.is_empty())
+                .map(PathBuf::from),
         }
     }
 }
@@ -1563,6 +1601,8 @@ pub async fn serve_with_config(
         recent_writes,
         run_watcher: run_watcher.clone(),
         tmux_cmd_override: config.tmux_cmd_override,
+        docker_cmd_override: config.docker_cmd_override,
+        sandbox_home_override: config.sandbox_home_override,
         last_trigger_tick_ms: Arc::new(std::sync::atomic::AtomicI64::new(0)),
         panic_on_trigger_name: config.panic_on_trigger_name,
         last_stale_tick_ms: Arc::new(std::sync::atomic::AtomicI64::new(0)),
@@ -3458,7 +3498,7 @@ fn detach_terminal_tail<F>(
 
 /// Run one scheduler tick: fire every due Trigger that the decision admits,
 /// recording every significant outcome and recomputing each next fire.
-async fn run_trigger_scheduler_tick(state: &AppState) {
+async fn run_trigger_scheduler_tick(state: &Arc<AppState>) {
     // At most one tick in flight: see `AppState::trigger_tick_lock`.
     let _tick = state.trigger_tick_lock.lock().await;
     let now = chrono::Utc::now();
@@ -3545,7 +3585,7 @@ async fn run_trigger_scheduler_tick(state: &AppState) {
 /// Returns the persisted audit record (with `run_id` filled on a fire), or
 /// `None` when the evaluation was a silent no-op.
 async fn fire_one_trigger(
-    state: &AppState,
+    state: &Arc<AppState>,
     trigger: &trigger_store::Trigger,
     now: chrono::DateTime<chrono::Utc>,
     source: trigger_scheduler::FireSource,
@@ -3619,6 +3659,9 @@ async fn fire_one_trigger(
                 source_branch: trigger.source_branch.clone(),
                 name: None,
                 triggered_by: Some(trigger.id.clone()),
+                // #407: trigger fires run on the host. Source precedence
+                // (run → trigger → default_sandbox) is #410.
+                sandbox: event_log::SandboxMode::Off,
             };
             let record = match create_run_inner(state, req, Vec::new()).await {
                 Ok(run_id) => trigger_store::FireRecord {
@@ -5399,6 +5442,9 @@ async fn parse_multipart_create_run(
         source_branch,
         name,
         triggered_by: None,
+        // #407: the multipart (browser) create path runs on the host; the UI
+        // sandbox selector is #410. The tracer bullet drives `pure` via JSON.
+        sandbox: event_log::SandboxMode::Off,
     };
     Ok((req, images))
 }
@@ -5499,7 +5545,7 @@ fn run_name_hint(name: Option<&str>, input: &str) -> prompt_augmenter::RunNameHi
 }
 
 async fn create_run_core(
-    state: &AppState,
+    state: &Arc<AppState>,
     req: CreateRunRequest,
     images: Vec<ImageFile>,
 ) -> Response {
@@ -5514,7 +5560,7 @@ async fn create_run_core(
 /// `Response`; the trigger scheduler calls it directly to learn the run id for
 /// `triggered_by` provenance.
 async fn create_run_inner(
-    state: &AppState,
+    state: &Arc<AppState>,
     req: CreateRunRequest,
     images: Vec<ImageFile>,
 ) -> Result<String, (StatusCode, serde_json::Value)> {
@@ -5666,6 +5712,11 @@ async fn create_run_inner(
     if let Some(ref target) = req.target_repo {
         run_payload["target_repo"] = serde_json::json!(target);
     }
+    // #407: carry the isolation mode only when it is NOT `off`, so `off` payloads
+    // stay byte-identical to the historical shape (back-compat: absence → Off).
+    if !req.sandbox.is_off() {
+        run_payload["sandbox"] = serde_json::json!(req.sandbox);
+    }
     if let Some(ref branch) = req.source_branch {
         run_payload["source_branch"] = serde_json::json!(branch);
     }
@@ -5766,13 +5817,102 @@ async fn create_run_inner(
         }
     }
 
-    spawn_ready_after_event(state, &run_id).await;
-
-    spawn_manager_session(state, &run_id, &worktree_dir, name_hint);
+    if req.sandbox.is_off() {
+        // Historical host path — inline, byte-identical to pre-#407. NO docker.
+        spawn_ready_after_event(state, &run_id).await;
+        spawn_manager_session(state, &run_id, &worktree_dir, name_hint, req.sandbox);
+    } else {
+        // #407 D3/D4: eager fail-fast prep on a detached, panic-isolated task
+        // (mirror ADR-0023 — the 201 must not block on a first-run `docker
+        // build`). Image + container + staging are guaranteed BEFORE the first
+        // node/manager spawn; any Docker unavailability → `RunFailed`, ZERO host
+        // spawn (never a silent host fallback for a sandboxed Run's work, US-16).
+        let sandbox = req.sandbox;
+        let task_state = state.clone();
+        let task_run_id = run_id.clone();
+        let task_worktree = worktree_dir.clone();
+        tokio::spawn(async move {
+            // Build the sandbox context from the just-projected Run (mode is
+            // immutable). A vanished/half-projected state → fail loud.
+            let ctx = match reload_run_state(&task_state, &task_run_id).await {
+                Some((_, rs)) => match sandbox_run::context_from_state(&task_state, &rs) {
+                    Ok(ctx) => ctx,
+                    Err(e) => {
+                        fail_run_sandbox_prep(
+                            &task_state,
+                            &task_run_id,
+                            &format!("sandbox prep failed: {e:#}"),
+                        )
+                        .await;
+                        return;
+                    }
+                },
+                None => {
+                    fail_run_sandbox_prep(
+                        &task_state,
+                        &task_run_id,
+                        "sandbox prep failed: run state disappeared before prep",
+                    )
+                    .await;
+                    return;
+                }
+            };
+            // `ensure_ready` is blocking (docker build/probe) → run it under
+            // `spawn_blocking`, which also isolates its panic into a `JoinError`.
+            match tokio::task::spawn_blocking(move || sandbox_run::ensure_ready(&ctx)).await {
+                Ok(Ok(())) => {
+                    spawn_ready_after_event(&task_state, &task_run_id).await;
+                    spawn_manager_session(
+                        &task_state,
+                        &task_run_id,
+                        &task_worktree,
+                        name_hint,
+                        sandbox,
+                    );
+                }
+                Ok(Err(e)) => {
+                    fail_run_sandbox_prep(
+                        &task_state,
+                        &task_run_id,
+                        &format!("sandbox prep failed: {e:#}"),
+                    )
+                    .await;
+                }
+                Err(join_err) => {
+                    fail_run_sandbox_prep(
+                        &task_state,
+                        &task_run_id,
+                        &format!("sandbox prep panicked: {join_err}"),
+                    )
+                    .await;
+                }
+            }
+        });
+    }
 
     info!("Run {run_id} started for pipeline {}", pipeline.name);
 
     Ok(run_id)
+}
+
+/// Fail a sandboxed Run *loud* when its eager prep can't complete (#407 D4).
+/// `RunFailed` is terminal + unguarded (mirror `fail_spawn_before_start`): a Run
+/// whose container never came up must move terminal, never wedge `Running` with
+/// no live node — and NEVER fall back to a host spawn.
+async fn fail_run_sandbox_prep(state: &AppState, run_id: &str, reason: &str) {
+    error!("Run {run_id}: sandbox prep failed — {reason}");
+    let run_failed = event_log::Event {
+        id: None,
+        run_id: run_id.to_string(),
+        ts: event_log::now_iso(),
+        kind: event_log::EventKind::RunFailed,
+        node_id: None,
+        iter: None,
+        payload: Some(serde_json::json!({ "reason": reason })),
+    };
+    if let Err(e) = append_event(state, &run_failed).await {
+        error!("Run {run_id}: failed to append RunFailed after sandbox prep failure: {e}");
+    }
 }
 
 fn spawn_manager_session(
@@ -5780,6 +5920,7 @@ fn spawn_manager_session(
     run_id: &str,
     worktree_dir: &std::path::Path,
     name_hint: prompt_augmenter::RunNameHint,
+    sandbox: event_log::SandboxMode,
 ) {
     let daemon_url = format!("http://localhost:{}", state.port);
 
@@ -5796,6 +5937,15 @@ fn spawn_manager_session(
         prompt_augmenter::build_manager_prompt(run_id, &daemon_url, &static_prompt, name_hint);
 
     let session_name = tmux_session_manager::manager_session_name(run_id);
+    // #407: the manager runs inside the Run's container too when sandboxed. Marker
+    // = the manager session name; workdir = the pipeline worktree.
+    let sandbox_wrap = (!sandbox.is_off()).then(|| tmux_session_manager::SandboxWrap {
+        docker_bin: state.docker_cmd_override.as_deref().unwrap_or("docker"),
+        uid: sandbox_container::host_uid(),
+        gid: sandbox_container::host_gid(),
+        marker: &session_name,
+        workdir: worktree_dir,
+    });
     if let Err(e) = tmux_session_manager::spawn(
         &session_name,
         &full_prompt,
@@ -5807,6 +5957,7 @@ fn spawn_manager_session(
         state.tmux_cmd_override.as_deref(),
         // manager has no NodeDef — always an agent at the account default (#296)
         tmux_session_manager::SessionTail::Agent { model: None },
+        sandbox_wrap.as_ref(),
     ) {
         error!("failed to spawn manager tmux session: {e}");
     } else {
@@ -6942,7 +7093,7 @@ async fn run_stale_detection(state: &AppState) {
                     // The session is already gone; reaping captures whatever
                     // remains (usually nothing) and is a no-op otherwise. Its
                     // slot freed. Re-drive throttled `waiting` nodes (#159).
-                    reap_node_session(state, &repo_root, run_id, node_id, *iter);
+                    reap_node_session(state, &repo_root, run_id, node_id, *iter, run_state.sandbox);
                     retry_waiting_nodes(state).await;
                 }
                 stale_detector::Detection::AutoComplete => {
@@ -7167,6 +7318,17 @@ async fn node_pane(
         );
 
         if working_dir.exists() {
+            // #407: a resumed sandboxed session re-enters its container (6th tail
+            // path). Marker = the session name; workdir = the node's working dir.
+            let sandbox_wrap = (!run_state.sandbox.is_off()).then(|| {
+                tmux_session_manager::SandboxWrap {
+                    docker_bin: state.docker_cmd_override.as_deref().unwrap_or("docker"),
+                    uid: sandbox_container::host_uid(),
+                    gid: sandbox_container::host_gid(),
+                    marker: &session_name,
+                    workdir: &working_dir,
+                }
+            });
             if let Err(e) = tmux_session_manager::resume(
                 &session_name,
                 &working_dir,
@@ -7175,6 +7337,7 @@ async fn node_pane(
                 iter,
                 state.port,
                 state.tmux_cmd_override.as_deref(),
+                sandbox_wrap.as_ref(),
             ) {
                 warn!("Failed to resume session {session_name}: {e}");
                 return Json(PaneResponse {
@@ -7423,6 +7586,13 @@ async fn spawn_merge_resolver(
     let prompt = load_merge_resolver_prompt(&state.repo_root);
     let session_name = tmux_session_manager::node_session_name(run_id, MERGE_RESOLVER_NODE_ID, 1);
 
+    // #407: the merge resolver runs inside the Run's container when sandboxed.
+    // Project the (immutable) mode; default `off` if the state can't be reloaded.
+    let sandbox_mode = reload_run_state(state, run_id)
+        .await
+        .map(|(_, s)| s.sandbox)
+        .unwrap_or_default();
+
     let resolver_started = event_log::Event {
         id: None,
         run_id: run_id.to_string(),
@@ -7438,6 +7608,13 @@ async fn spawn_merge_resolver(
     };
     let _ = append_event(state, &resolver_started).await;
 
+    let sandbox_wrap = (!sandbox_mode.is_off()).then(|| tmux_session_manager::SandboxWrap {
+        docker_bin: state.docker_cmd_override.as_deref().unwrap_or("docker"),
+        uid: sandbox_container::host_uid(),
+        gid: sandbox_container::host_gid(),
+        marker: &session_name,
+        workdir: worktree_dir,
+    });
     if let Err(e) = tmux_session_manager::spawn(
         &session_name,
         &prompt,
@@ -7449,6 +7626,7 @@ async fn spawn_merge_resolver(
         state.tmux_cmd_override.as_deref(),
         // __merge_resolver__ has no NodeDef — agent at the account default (#296)
         tmux_session_manager::SessionTail::Agent { model: None },
+        sandbox_wrap.as_ref(),
     ) {
         error!("failed to spawn merge resolver tmux session: {e}");
         let fail_event = event_log::Event {
@@ -7859,11 +8037,13 @@ async fn node_done(
     let tail_state = state.clone();
     let tail_run = run_id.clone();
     let tail_node = node_id.clone();
+    // #407: the Run's (immutable) sandbox mode for the targeted container kill.
+    let tail_sandbox = pre_run_state.sandbox;
     detach_terminal_tail("node_done", state.clone(), run_id, node_id, async move {
         // Reap on terminal state (#205): snapshot the pane then kill the session,
         // so a completed node never holds a live session toward the tmux-collapse
         // point (#77/#78). Post-mortem inspection survives via the snapshot.
-        reap_node_session(&tail_state, &repo_root, &tail_run, &tail_node, iter);
+        reap_node_session(&tail_state, &repo_root, &tail_run, &tail_node, iter, tail_sandbox);
 
         // Shared post-`NodeCompleted` tail (#275): fire this node's edges, advance the
         // run, re-drive throttled waiters, then the single completion gate. Everything
@@ -7917,13 +8097,15 @@ async fn node_fail(
     detach_terminal_tail("node_fail", state.clone(), run_id, node_id, async move {
         // Reap on terminal state (#205): snapshot the pane then kill the session.
         // Post-mortem inspection of the failed node survives via the snapshot.
-        let repo_root = match load_events(&tail_state.db, &tail_run).await {
+        // #407: capture repo_root AND the immutable sandbox mode from the same
+        // projection (the targeted container kill needs the mode).
+        let (repo_root, tail_sandbox) = match load_events(&tail_state.db, &tail_run).await {
             Ok(evs) => event_log::project(&evs)
-                .map(|s| effective_repo_root(&tail_state, &s))
-                .unwrap_or_else(|| tail_state.repo_root.clone()),
-            Err(_) => tail_state.repo_root.clone(),
+                .map(|s| (effective_repo_root(&tail_state, &s), s.sandbox))
+                .unwrap_or_else(|| (tail_state.repo_root.clone(), event_log::SandboxMode::Off)),
+            Err(_) => (tail_state.repo_root.clone(), event_log::SandboxMode::Off),
         };
-        reap_node_session(&tail_state, &repo_root, &tail_run, &tail_node, iter);
+        reap_node_session(&tail_state, &repo_root, &tail_run, &tail_node, iter, tail_sandbox);
 
         // Mark the run as failed
         let run_failed = event_log::Event {
@@ -8016,9 +8198,10 @@ async fn node_skip(
     let tail_run = run_id.clone();
     let tail_node = node_id.clone();
     let reason = req.reason.clone();
+    let tail_sandbox = pre_run_state.sandbox;
     detach_terminal_tail("node_skip", state.clone(), run_id, node_id, async move {
         // Reap on terminal state (#205): snapshot the pane then kill the session.
-        reap_node_session(&tail_state, &repo_root, &tail_run, &tail_node, iter);
+        reap_node_session(&tail_state, &repo_root, &tail_run, &tail_node, iter, tail_sandbox);
 
         // End the run as a graceful no-op (#245) — distinct from RunFailed. This
         // short-circuits downstream: `spawn_ready_after_event` only spawns for a
@@ -8178,6 +8361,7 @@ async fn force_spawn_node(state: &Arc<AppState>, run_id: &str, node_id: &str) ->
         resolved_vars: &resolved_vars,
         daemon_port: state.port,
         tmux_cmd_override: state.tmux_cmd_override.as_deref(),
+        docker_cmd_override: state.docker_cmd_override.as_deref(),
         // #347: resolve fresh so a force-spawn honours the instance default too
         // (wiring only one seam would leave this path at the account default —
         // a silent bug visible only on a manual force-spawn).
@@ -8280,7 +8464,7 @@ async fn node_stop(
     // killed, so the stopped node's post-mortem pane survives. `stop_node`
     // kills the session too (idempotent — reap already killed it).
     let repo_root = effective_repo_root(&state, &run_state);
-    reap_node_session(&state, &repo_root, &run_id, &node_id, iter);
+    reap_node_session(&state, &repo_root, &run_id, &node_id, iter, run_state.sandbox);
 
     let params = node_primitives::StopNodeParams {
         run_id: &run_id,
@@ -8428,6 +8612,7 @@ async fn node_retry(
         resolved_vars: &resolved_vars,
         daemon_port: state.port,
         tmux_cmd_override: state.tmux_cmd_override.as_deref(),
+        docker_cmd_override: state.docker_cmd_override.as_deref(),
         // #347: retry honours the instance default like the live scheduler path.
         default_model: stored_default_model(&state.db).await,
     };
@@ -9010,6 +9195,19 @@ async fn run_command(
 
             let session_name = tmux_session_manager::node_session_name(&run_id, &node_id, iter);
             tmux_session_manager::kill(&state.tmux_socket(), &session_name);
+            // #407: also kill the process tree inside the container (best-effort,
+            // no-op for `off`). The tmux-side `docker exec` client death leaves the
+            // reparented container process alive.
+            let kill_sandbox = reload_run_state(&state, &run_id)
+                .await
+                .map(|(_, s)| s.sandbox)
+                .unwrap_or_default();
+            sandbox_run::kill_session_best_effort(
+                state.docker_cmd_override.as_deref().unwrap_or("docker"),
+                kill_sandbox,
+                &run_id,
+                &session_name,
+            );
 
             let fail_event = event_log::Event {
                 id: None,
@@ -9094,6 +9292,19 @@ async fn run_command(
             // Kill existing session
             let session_name = tmux_session_manager::node_session_name(&run_id, &node_id, iter);
             tmux_session_manager::kill(&state.tmux_socket(), &session_name);
+            // #407: also kill the in-container process tree before the re-spawn
+            // (best-effort, no-op for `off`) so the old session's container
+            // process doesn't linger alongside the new one.
+            let restart_sandbox = reload_run_state(&state, &run_id)
+                .await
+                .map(|(_, s)| s.sandbox)
+                .unwrap_or_default();
+            sandbox_run::kill_session_best_effort(
+                state.docker_cmd_override.as_deref().unwrap_or("docker"),
+                restart_sandbox,
+                &run_id,
+                &session_name,
+            );
 
             let cmd_event = event_log::Event {
                 id: None,
@@ -9367,6 +9578,9 @@ async fn run_command(
                 source_branch,
                 name: None,
                 triggered_by: None,
+                // #407: a retry preserves the original Run's isolation mode
+                // (immutable per-Run property projected from RunStarted).
+                sandbox: run_state.sandbox,
             };
             let new_run_resp = create_run_core(&state, new_run_req, Vec::new()).await;
 
@@ -9926,7 +10140,47 @@ async fn open_run_shell(
             .into_response();
     }
 
-    match tmux_session_manager::spawn_shell(&session, &worktree, &run_id, state.port) {
+    // #407 D11: a sandboxed run's shell must enter its container. The container
+    // lives from create to cleanup_run (= archive), coextensive with shell
+    // eligibility — EXCEPT after a host reboot, where boot_recovery skips terminal
+    // runs, so the container may be down. Resurrect it here, or fail EXPLICITLY —
+    // never fall back to a silent host bash.
+    if !run_state.sandbox.is_off() {
+        let prep = match sandbox_run::context_from_state(&state, &run_state) {
+            Ok(ctx) => tokio::task::spawn_blocking(move || sandbox_run::ensure_ready(&ctx))
+                .await
+                .unwrap_or_else(|je| {
+                    Err(anyhow::anyhow!("sandbox ensure_ready panicked: {je}"))
+                }),
+            Err(e) => Err(e),
+        };
+        if let Err(e) = prep {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({
+                    "error": format!("sandbox container unavailable: {e:#}")
+                })),
+            )
+                .into_response();
+        }
+    }
+
+    // #407: the run shell enters the Run's container when sandboxed. Marker =
+    // the shell session name; workdir = the pipeline worktree.
+    let sandbox_wrap = (!run_state.sandbox.is_off()).then(|| tmux_session_manager::SandboxWrap {
+        docker_bin: state.docker_cmd_override.as_deref().unwrap_or("docker"),
+        uid: sandbox_container::host_uid(),
+        gid: sandbox_container::host_gid(),
+        marker: &session,
+        workdir: &worktree,
+    });
+    match tmux_session_manager::spawn_shell(
+        &session,
+        &worktree,
+        &run_id,
+        state.port,
+        sandbox_wrap.as_ref(),
+    ) {
         Ok(()) => {
             info!("Opened run shell {session} in {}", worktree.display());
             (
@@ -10095,6 +10349,24 @@ async fn cleanup_run(state: &AppState, run_id: &str) -> Response {
     // #316: kill any ad-hoc run shell before the worktree is torn down.
     let shell_session = tmux_session_manager::shell_session_name(run_id);
     tmux_session_manager::kill(&socket, &shell_session);
+
+    // #407 D9: destroy the sandbox container + purge its staging BEFORE any
+    // `git worktree remove` below — the container bind-mounts the repo, so a live
+    // worktree removal under it would hit a busy mount. Best-effort. `merge_back`
+    // is intentionally NOT wired here (→ observability slice #408). No-op for
+    // `off`.
+    if !run_state.sandbox.is_off() {
+        match sandbox_run::sandbox_home_roots(state) {
+            Ok((_, sandbox_root)) => sandbox_run::cleanup(
+                state.docker_cmd_override.as_deref().unwrap_or("docker"),
+                &sandbox_root,
+                run_id,
+            ),
+            Err(e) => {
+                warn!("cleanup_run: cannot purge sandbox staging for run {run_id}: {e:#}")
+            }
+        }
+    }
 
     let repo_root = effective_repo_root(state, &run_state);
     let run_dir = repo_root.join(".pdo").join("runs").join(run_id);
@@ -11083,6 +11355,7 @@ fn reap_node_session(
     run_id: &str,
     node_id: &str,
     iter: i64,
+    sandbox: event_log::SandboxMode,
 ) {
     let socket = state.tmux_socket();
     let session = tmux_session_manager::node_session_name(run_id, node_id, iter);
@@ -11098,6 +11371,16 @@ fn reap_node_session(
     }
 
     tmux_session_manager::kill(&socket, &session);
+    // #407 D8: killing the tmux-side `docker exec` client leaves the container
+    // process (reparented onto PID 1) alive — double it with a targeted in-
+    // container kill that scans `/proc` for this session's marker. Best-effort,
+    // no-op for `off`. Marker == the session name (so the /proc scan hits it).
+    sandbox_run::kill_session_best_effort(
+        state.docker_cmd_override.as_deref().unwrap_or("docker"),
+        sandbox,
+        run_id,
+        &session,
+    );
     info!("Reaped tmux session {session} on terminal transition");
 }
 
@@ -11464,6 +11747,8 @@ mod tests {
             // spawn path, the node session runs `true` and exits immediately —
             // never real claude, never a lingering session (#181).
             tmux_cmd_override: Some("exec true".to_string()),
+            docker_cmd_override: None,
+            sandbox_home_override: None,
             last_trigger_tick_ms: Arc::new(std::sync::atomic::AtomicI64::new(0)),
             panic_on_trigger_name: None,
             last_stale_tick_ms: Arc::new(std::sync::atomic::AtomicI64::new(0)),
@@ -11504,6 +11789,8 @@ mod tests {
             recent_writes: Arc::new(Mutex::new(HashMap::new())),
             run_watcher: Arc::new(Mutex::new(None)),
             tmux_cmd_override: Some("exec true".to_string()),
+            docker_cmd_override: None,
+            sandbox_home_override: None,
             last_trigger_tick_ms: Arc::new(std::sync::atomic::AtomicI64::new(0)),
             panic_on_trigger_name: None,
             last_stale_tick_ms: Arc::new(std::sync::atomic::AtomicI64::new(0)),
@@ -14960,6 +15247,8 @@ mod tests {
             // spawn path, the node session runs `true` and exits immediately —
             // never real claude, never a lingering session (#181).
             tmux_cmd_override: Some("exec true".to_string()),
+            docker_cmd_override: None,
+            sandbox_home_override: None,
             last_trigger_tick_ms: Arc::new(std::sync::atomic::AtomicI64::new(0)),
             panic_on_trigger_name: None,
             last_stale_tick_ms: Arc::new(std::sync::atomic::AtomicI64::new(0)),
@@ -19282,6 +19571,8 @@ edges: []
             // spawn path, the node session runs `true` and exits immediately —
             // never real claude, never a lingering session (#181).
             tmux_cmd_override: Some("exec true".to_string()),
+            docker_cmd_override: None,
+            sandbox_home_override: None,
             last_trigger_tick_ms: Arc::new(std::sync::atomic::AtomicI64::new(0)),
             panic_on_trigger_name: None,
             last_stale_tick_ms: Arc::new(std::sync::atomic::AtomicI64::new(0)),
@@ -19469,6 +19760,8 @@ edges: []
             // spawn path, the node session runs `true` and exits immediately —
             // never real claude, never a lingering session (#181).
             tmux_cmd_override: Some("exec true".to_string()),
+            docker_cmd_override: None,
+            sandbox_home_override: None,
             last_trigger_tick_ms: Arc::new(std::sync::atomic::AtomicI64::new(0)),
             panic_on_trigger_name: None,
             last_stale_tick_ms: Arc::new(std::sync::atomic::AtomicI64::new(0)),

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -7320,15 +7320,14 @@ async fn node_pane(
         if working_dir.exists() {
             // #407: a resumed sandboxed session re-enters its container (6th tail
             // path). Marker = the session name; workdir = the node's working dir.
-            let sandbox_wrap = (!run_state.sandbox.is_off()).then(|| {
-                tmux_session_manager::SandboxWrap {
+            let sandbox_wrap =
+                (!run_state.sandbox.is_off()).then(|| tmux_session_manager::SandboxWrap {
                     docker_bin: state.docker_cmd_override.as_deref().unwrap_or("docker"),
                     uid: sandbox_container::host_uid(),
                     gid: sandbox_container::host_gid(),
                     marker: &session_name,
                     workdir: &working_dir,
-                }
-            });
+                });
             if let Err(e) = tmux_session_manager::resume(
                 &session_name,
                 &working_dir,
@@ -8043,7 +8042,14 @@ async fn node_done(
         // Reap on terminal state (#205): snapshot the pane then kill the session,
         // so a completed node never holds a live session toward the tmux-collapse
         // point (#77/#78). Post-mortem inspection survives via the snapshot.
-        reap_node_session(&tail_state, &repo_root, &tail_run, &tail_node, iter, tail_sandbox);
+        reap_node_session(
+            &tail_state,
+            &repo_root,
+            &tail_run,
+            &tail_node,
+            iter,
+            tail_sandbox,
+        );
 
         // Shared post-`NodeCompleted` tail (#275): fire this node's edges, advance the
         // run, re-drive throttled waiters, then the single completion gate. Everything
@@ -8105,7 +8111,14 @@ async fn node_fail(
                 .unwrap_or_else(|| (tail_state.repo_root.clone(), event_log::SandboxMode::Off)),
             Err(_) => (tail_state.repo_root.clone(), event_log::SandboxMode::Off),
         };
-        reap_node_session(&tail_state, &repo_root, &tail_run, &tail_node, iter, tail_sandbox);
+        reap_node_session(
+            &tail_state,
+            &repo_root,
+            &tail_run,
+            &tail_node,
+            iter,
+            tail_sandbox,
+        );
 
         // Mark the run as failed
         let run_failed = event_log::Event {
@@ -8201,7 +8214,14 @@ async fn node_skip(
     let tail_sandbox = pre_run_state.sandbox;
     detach_terminal_tail("node_skip", state.clone(), run_id, node_id, async move {
         // Reap on terminal state (#205): snapshot the pane then kill the session.
-        reap_node_session(&tail_state, &repo_root, &tail_run, &tail_node, iter, tail_sandbox);
+        reap_node_session(
+            &tail_state,
+            &repo_root,
+            &tail_run,
+            &tail_node,
+            iter,
+            tail_sandbox,
+        );
 
         // End the run as a graceful no-op (#245) — distinct from RunFailed. This
         // short-circuits downstream: `spawn_ready_after_event` only spawns for a
@@ -8464,7 +8484,14 @@ async fn node_stop(
     // killed, so the stopped node's post-mortem pane survives. `stop_node`
     // kills the session too (idempotent — reap already killed it).
     let repo_root = effective_repo_root(&state, &run_state);
-    reap_node_session(&state, &repo_root, &run_id, &node_id, iter, run_state.sandbox);
+    reap_node_session(
+        &state,
+        &repo_root,
+        &run_id,
+        &node_id,
+        iter,
+        run_state.sandbox,
+    );
 
     let params = node_primitives::StopNodeParams {
         run_id: &run_id,
@@ -10149,9 +10176,7 @@ async fn open_run_shell(
         let prep = match sandbox_run::context_from_state(&state, &run_state) {
             Ok(ctx) => tokio::task::spawn_blocking(move || sandbox_run::ensure_ready(&ctx))
                 .await
-                .unwrap_or_else(|je| {
-                    Err(anyhow::anyhow!("sandbox ensure_ready panicked: {je}"))
-                }),
+                .unwrap_or_else(|je| Err(anyhow::anyhow!("sandbox ensure_ready panicked: {je}"))),
             Err(e) => Err(e),
         };
         if let Err(e) = prep {

--- a/crates/pdo-daemon/src/node_primitives.rs
+++ b/crates/pdo-daemon/src/node_primitives.rs
@@ -221,15 +221,14 @@ pub fn start_node(params: &StartNodeParams<'_>) -> StartNodeResult {
         tmux_session_manager::node_session_name(params.run_id, params.node_id, params.iter);
     // #407: wrap the tail into the Run's container when sandboxed (manual
     // force-spawn / restart door, #204). Marker = the session name (kill target).
-    let sandbox_wrap = (!params.run_state.sandbox.is_off()).then(|| {
-        tmux_session_manager::SandboxWrap {
+    let sandbox_wrap =
+        (!params.run_state.sandbox.is_off()).then(|| tmux_session_manager::SandboxWrap {
             docker_bin: params.docker_cmd_override.unwrap_or("docker"),
             uid: crate::sandbox_container::host_uid(),
             gid: crate::sandbox_container::host_gid(),
             marker: &session_name,
             workdir: &working_dir,
-        }
-    });
+        });
     if let Err(e) = tmux_session_manager::spawn(
         &session_name,
         spawn_prompt,

--- a/crates/pdo-daemon/src/node_primitives.rs
+++ b/crates/pdo-daemon/src/node_primitives.rs
@@ -40,6 +40,10 @@ pub struct StartNodeParams<'a> {
     /// Per-daemon override for the `claude …` tail of the spawned tmux script.
     /// Threaded from `AppState.tmux_cmd_override`; `None` → real claude (#181).
     pub tmux_cmd_override: Option<&'a str>,
+    /// Per-daemon `docker` binary override for the sandbox wiring (#407), threaded
+    /// from `AppState.docker_cmd_override`; `None` → real `docker`. Used only when
+    /// `run_state.sandbox != off` to wrap the tail into the Run's container.
+    pub docker_cmd_override: Option<&'a str>,
     /// Instance-wide default model, already resolved `stored → env → None` by the
     /// caller (#347). `start_node` is sync and DB-less, so the async force-spawn
     /// / retry callers resolve it and pass it in; the node's own `model:` still
@@ -215,6 +219,17 @@ pub fn start_node(params: &StartNodeParams<'_>) -> StartNodeResult {
 
     let session_name =
         tmux_session_manager::node_session_name(params.run_id, params.node_id, params.iter);
+    // #407: wrap the tail into the Run's container when sandboxed (manual
+    // force-spawn / restart door, #204). Marker = the session name (kill target).
+    let sandbox_wrap = (!params.run_state.sandbox.is_off()).then(|| {
+        tmux_session_manager::SandboxWrap {
+            docker_bin: params.docker_cmd_override.unwrap_or("docker"),
+            uid: crate::sandbox_container::host_uid(),
+            gid: crate::sandbox_container::host_gid(),
+            marker: &session_name,
+            workdir: &working_dir,
+        }
+    });
     if let Err(e) = tmux_session_manager::spawn(
         &session_name,
         spawn_prompt,
@@ -225,6 +240,7 @@ pub fn start_node(params: &StartNodeParams<'_>) -> StartNodeResult {
         params.daemon_port,
         params.tmux_cmd_override,
         tail,
+        sandbox_wrap.as_ref(),
     ) {
         return StartNodeResult {
             outcome: PrimitiveOutcome::Rejected {
@@ -701,6 +717,7 @@ mod tests {
             resolved_vars: &HashMap::new(),
             daemon_port: 5172,
             tmux_cmd_override: Some("exec true"),
+            docker_cmd_override: None,
             default_model: None,
         };
 
@@ -739,6 +756,7 @@ mod tests {
             resolved_vars: &HashMap::new(),
             daemon_port: 5172,
             tmux_cmd_override: Some("exec true"),
+            docker_cmd_override: None,
             default_model: None,
         };
 
@@ -797,6 +815,7 @@ mod tests {
             resolved_vars: &HashMap::new(),
             daemon_port: 5172,
             tmux_cmd_override: Some("exec true"),
+            docker_cmd_override: None,
             default_model: None,
         };
 
@@ -854,6 +873,7 @@ mod tests {
             resolved_vars: &HashMap::new(),
             daemon_port: 5172,
             tmux_cmd_override: Some("exec true"),
+            docker_cmd_override: None,
             default_model: None,
         };
 
@@ -897,6 +917,7 @@ mod tests {
             resolved_vars: &HashMap::new(),
             daemon_port: 5172,
             tmux_cmd_override: Some("exec true"),
+            docker_cmd_override: None,
             default_model: None,
         };
 
@@ -964,6 +985,7 @@ mod tests {
             resolved_vars: &HashMap::new(),
             daemon_port: 5172,
             tmux_cmd_override: Some("exec true"),
+            docker_cmd_override: None,
             default_model: None,
         };
 
@@ -1053,6 +1075,7 @@ mod tests {
             resolved_vars: &HashMap::new(),
             daemon_port: 5172,
             tmux_cmd_override: Some("exec true"),
+            docker_cmd_override: None,
             default_model: None,
         };
 
@@ -1116,6 +1139,7 @@ mod tests {
             resolved_vars: &HashMap::new(),
             daemon_port: 5172,
             tmux_cmd_override: Some("exec true"),
+            docker_cmd_override: None,
             default_model: None,
         };
 
@@ -1179,6 +1203,7 @@ mod tests {
             resolved_vars: &HashMap::new(),
             daemon_port: 5172,
             tmux_cmd_override: Some("exec true"),
+            docker_cmd_override: None,
             default_model: None,
         };
 
@@ -1438,6 +1463,7 @@ mod tests {
             resolved_vars: &HashMap::new(),
             daemon_port: 5172,
             tmux_cmd_override: Some("exec true"),
+            docker_cmd_override: None,
             default_model: None,
         };
 

--- a/crates/pdo-daemon/src/node_spawn.rs
+++ b/crates/pdo-daemon/src/node_spawn.rs
@@ -163,10 +163,7 @@ pub(crate) async fn spawn_node(
     // #407: the Run's isolation mode (immutable, projected from RunStarted). When
     // not `off`, the tail below is wrapped to run inside `pdo-sbx-<run_id>`. Read
     // from the guard projection — `sandbox` never changes over a Run's life.
-    let run_sandbox = projected
-        .as_ref()
-        .map(|s| s.sandbox)
-        .unwrap_or_default();
+    let run_sandbox = projected.as_ref().map(|s| s.sandbox).unwrap_or_default();
 
     // #248 / ADR-0017: refuse to spawn a `script` node with an empty body — it
     // would `bash <empty>` → exit 0 → a silent no-op masquerading as success.

--- a/crates/pdo-daemon/src/node_spawn.rs
+++ b/crates/pdo-daemon/src/node_spawn.rs
@@ -54,6 +54,9 @@ pub(crate) struct SpawnDeps<'a> {
     pub(crate) panic_on_spawn: &'a std::sync::atomic::AtomicBool,
     pub(crate) port: u16,
     pub(crate) tmux_cmd_override: Option<&'a str>,
+    /// Per-daemon `docker` binary override for the sandbox wiring (#407), `Copy`
+    /// like the rest of the bundle. `None` in production (real `docker`).
+    pub(crate) docker_cmd_override: Option<&'a str>,
 }
 
 impl<'a> SpawnDeps<'a> {
@@ -66,6 +69,7 @@ impl<'a> SpawnDeps<'a> {
             panic_on_spawn: &state.panic_on_spawn,
             port: state.port,
             tmux_cmd_override: state.tmux_cmd_override.as_deref(),
+            docker_cmd_override: state.docker_cmd_override.as_deref(),
         }
     }
 }
@@ -155,6 +159,14 @@ pub(crate) async fn spawn_node(
             return SpawnOutcome::Refused { reason };
         }
     }
+
+    // #407: the Run's isolation mode (immutable, projected from RunStarted). When
+    // not `off`, the tail below is wrapped to run inside `pdo-sbx-<run_id>`. Read
+    // from the guard projection — `sandbox` never changes over a Run's life.
+    let run_sandbox = projected
+        .as_ref()
+        .map(|s| s.sandbox)
+        .unwrap_or_default();
 
     // #248 / ADR-0017: refuse to spawn a `script` node with an empty body — it
     // would `bash <empty>` → exit 0 → a silent no-op masquerading as success.
@@ -460,6 +472,16 @@ pub(crate) async fn spawn_node(
     } else {
         &full_prompt
     };
+    // #407: wrap the tail in `docker exec … pdo-sbx-<run>` when sandboxed. The
+    // marker MUST equal the session name (the kill path scans `/proc` for it), and
+    // the workdir is the node's own working dir.
+    let sandbox_wrap = (!run_sandbox.is_off()).then(|| tmux_session_manager::SandboxWrap {
+        docker_bin: deps.docker_cmd_override.unwrap_or("docker"),
+        uid: crate::sandbox_container::host_uid(),
+        gid: crate::sandbox_container::host_gid(),
+        marker: &session_name,
+        workdir: &working_dir,
+    });
     if let Err(e) = tmux_session_manager::spawn(
         &session_name,
         spawn_prompt,
@@ -470,6 +492,7 @@ pub(crate) async fn spawn_node(
         deps.port,
         deps.tmux_cmd_override,
         tail,
+        sandbox_wrap.as_ref(),
     ) {
         error!("failed to spawn tmux session: {e}");
     }

--- a/crates/pdo-daemon/src/sandbox_container.rs
+++ b/crates/pdo-daemon/src/sandbox_container.rs
@@ -781,7 +781,10 @@ mod tests {
             "/repo/.pdo/runs/r1/nodes/n1/iter-1",
             "pdo-sbx-r1",
         ]);
-        assert_eq!(args, expected, "catalogue `-e K=V` inséré avant le conteneur");
+        assert_eq!(
+            args, expected,
+            "catalogue `-e K=V` inséré avant le conteneur"
+        );
         // Invariant : PDO_DAEMON_URL jamais re-passé, même présent dans le catalogue.
         assert!(
             !args.iter().any(|a| a.contains("PDO_DAEMON_URL")),

--- a/crates/pdo-daemon/src/sandbox_container.rs
+++ b/crates/pdo-daemon/src/sandbox_container.rs
@@ -172,7 +172,34 @@ pub(crate) fn exec_prefix(
     workdir: &Path,
     marker: &str,
 ) -> Vec<String> {
-    vec![
+    // Delegate with an empty catalogue: the output stays byte-identical to the
+    // #406 golden (the base three `-e` only, no per-node values).
+    exec_prefix_with_env(run_id, uid, gid, workdir, marker, &[])
+}
+
+/// Like [`exec_prefix`] but forwards a **dynamic per-node env catalogue** into the
+/// container as explicit `-e KEY=VALUE` (#407, D6). A `script` node's I/O arrives
+/// as env vars (`PDO_ARTIFACTS_DIR`, `PDO_INPUT_<port>`, `PDO_OUTPUT_<port>`,
+/// `PDO_VAR_<name>`), whose values are known at spawn time but are **not** among
+/// the statically-forwarded `-e PDO_NODE_ID`/`-e PDO_NODE_ITER` — a bare `-e KEY`
+/// only forwards a host-shell value, and the host shell exports none of the
+/// catalogue in sandbox mode (D6). So they must be passed as valued `-e KEY=VALUE`
+/// inserted **before** the container name.
+///
+/// **Never `PDO_DAEMON_URL`** (a valued or bare `-e` would clobber the
+/// host-gateway URL posted at `create`): it is filtered here as a belt-and-braces
+/// invariant, even though the catalogue should never contain it. Order is FIGÉ by
+/// the golden test: the base three `-e` first, then each catalogue `-e K=V` in
+/// order, then `--user`, `-w`, container.
+pub(crate) fn exec_prefix_with_env(
+    run_id: &str,
+    uid: u32,
+    gid: u32,
+    workdir: &Path,
+    marker: &str,
+    extra_env: &[(String, String)],
+) -> Vec<String> {
+    let mut args = vec![
         "exec".to_string(),
         "-i".to_string(),
         "-t".to_string(),
@@ -182,12 +209,22 @@ pub(crate) fn exec_prefix(
         "PDO_NODE_ID".to_string(),
         "-e".to_string(),
         "PDO_NODE_ITER".to_string(),
-        "--user".to_string(),
-        format!("{uid}:{gid}"),
-        "-w".to_string(),
-        workdir.display().to_string(),
-        container_name(run_id),
-    ]
+    ];
+    for (k, v) in extra_env {
+        // Invariant: PDO_DAEMON_URL is posed at create → host.docker.internal; a
+        // re-passed `-e` (bare or valued) would clobber the gateway.
+        if k == "PDO_DAEMON_URL" {
+            continue;
+        }
+        args.push("-e".to_string());
+        args.push(format!("{k}={v}"));
+    }
+    args.push("--user".to_string());
+    args.push(format!("{uid}:{gid}"));
+    args.push("-w".to_string());
+    args.push(workdir.display().to_string());
+    args.push(container_name(run_id));
+    args
 }
 
 // -- effets docker (sync std::process::Command, anyhow + .context) -----------
@@ -695,6 +732,71 @@ mod tests {
         assert!(
             !args.iter().any(|a| a.contains("PDO_DAEMON_URL")),
             "exec_prefix ne doit jamais re-passer PDO_DAEMON_URL"
+        );
+    }
+
+    // -- 2b. exec_prefix_with_env golden : catalogue script (#407, D6) --------
+
+    #[test]
+    fn exec_prefix_with_env_golden() {
+        let wt = Path::new("/repo/.pdo/runs/r1/nodes/n1/iter-1");
+        // A realistic `script` node catalogue (order preserved), plus a
+        // PDO_DAEMON_URL that MUST be filtered out (invariant).
+        let env = vec![
+            (
+                "PDO_ARTIFACTS_DIR".to_string(),
+                "/repo/.pdo/runs/r1/worktree/.pdo/artifacts".to_string(),
+            ),
+            (
+                "PDO_OUTPUT_out".to_string(),
+                "/repo/.pdo/runs/r1/worktree/.pdo/artifacts/n1/iter-1/out/output.md".to_string(),
+            ),
+            ("PDO_VAR_x".to_string(), "hello".to_string()),
+            // Adversarial: must be dropped, never forwarded.
+            (
+                "PDO_DAEMON_URL".to_string(),
+                "http://localhost:6172".to_string(),
+            ),
+        ];
+        let args = exec_prefix_with_env("r1", 1000, 1000, wt, "pdo-r1-n1-iter-1", &env);
+        let expected = strings(&[
+            "exec",
+            "-i",
+            "-t",
+            "-e",
+            "PDO_SBX_SESSION=pdo-r1-n1-iter-1",
+            "-e",
+            "PDO_NODE_ID",
+            "-e",
+            "PDO_NODE_ITER",
+            "-e",
+            "PDO_ARTIFACTS_DIR=/repo/.pdo/runs/r1/worktree/.pdo/artifacts",
+            "-e",
+            "PDO_OUTPUT_out=/repo/.pdo/runs/r1/worktree/.pdo/artifacts/n1/iter-1/out/output.md",
+            "-e",
+            "PDO_VAR_x=hello",
+            "--user",
+            "1000:1000",
+            "-w",
+            "/repo/.pdo/runs/r1/nodes/n1/iter-1",
+            "pdo-sbx-r1",
+        ]);
+        assert_eq!(args, expected, "catalogue `-e K=V` inséré avant le conteneur");
+        // Invariant : PDO_DAEMON_URL jamais re-passé, même présent dans le catalogue.
+        assert!(
+            !args.iter().any(|a| a.contains("PDO_DAEMON_URL")),
+            "PDO_DAEMON_URL doit être filtré du catalogue"
+        );
+    }
+
+    #[test]
+    fn exec_prefix_empty_env_equals_bare_prefix() {
+        // exec_prefix (délégation `&[]`) == exec_prefix_with_env(&[]) : garde de
+        // non-régression du golden #406.
+        let wt = Path::new("/repo/.pdo/runs/r1/nodes/n1/iter-1");
+        assert_eq!(
+            exec_prefix("r1", 1000, 1000, wt, "m"),
+            exec_prefix_with_env("r1", 1000, 1000, wt, "m", &[]),
         );
     }
 

--- a/crates/pdo-daemon/src/sandbox_image.rs
+++ b/crates/pdo-daemon/src/sandbox_image.rs
@@ -260,13 +260,39 @@ mod tests {
         bin.to_str().unwrap().to_string()
     }
 
+    /// Under `cargo test --workspace`, exec-ing a **freshly written** binary can
+    /// return `ETXTBSY` (os error 26): a sibling test that `fork`+`exec`s at the
+    /// same instant transiently inherits the write fd of this test's fake docker
+    /// (rust-lang/rust#45719). Prod never exec-s a freshly-written binary
+    /// (`docker` is stable), so the retry lives HERE, not in the core. Mirrors the
+    /// identical guard in [`crate::sandbox_container`]'s tests.
+    fn retry_etxtbsy<T>(mut op: impl FnMut() -> Result<T>) -> Result<T> {
+        for _ in 0..100 {
+            match op() {
+                Err(e) if is_etxtbsy(&e) => {
+                    std::thread::sleep(std::time::Duration::from_millis(5));
+                }
+                other => return other,
+            }
+        }
+        op()
+    }
+
+    fn is_etxtbsy(e: &anyhow::Error) -> bool {
+        e.chain().any(|c| {
+            c.downcast_ref::<std::io::Error>()
+                .and_then(std::io::Error::raw_os_error)
+                == Some(26)
+        })
+    }
+
     #[test]
     fn present_image_skips_build() {
         let tmp = tempfile::tempdir().unwrap();
         let (docker, argv_log) = write_fake_docker(tmp.path(), 0, 0, "");
         let sandbox_root = tmp.path().join("sandbox");
 
-        let tag = ensure_image(&docker_str(&docker), &sandbox_root).unwrap();
+        let tag = retry_etxtbsy(|| ensure_image(&docker_str(&docker), &sandbox_root)).unwrap();
 
         assert_eq!(tag, local_image_ref(EMBEDDED_DOCKERFILE.as_bytes()));
         assert!(
@@ -281,7 +307,7 @@ mod tests {
         let (docker, argv_log) = write_fake_docker(tmp.path(), 1, 0, "");
         let sandbox_root = tmp.path().join("sandbox");
 
-        let tag = ensure_image(&docker_str(&docker), &sandbox_root).unwrap();
+        let tag = retry_etxtbsy(|| ensure_image(&docker_str(&docker), &sandbox_root)).unwrap();
 
         assert_eq!(tag, local_image_ref(EMBEDDED_DOCKERFILE.as_bytes()));
         assert_eq!(
@@ -303,7 +329,7 @@ mod tests {
         let (docker, _) = write_fake_docker(tmp.path(), 1, 1, "boom: base image missing");
         let sandbox_root = tmp.path().join("sandbox");
 
-        let err = ensure_image(&docker_str(&docker), &sandbox_root).unwrap_err();
+        let err = retry_etxtbsy(|| ensure_image(&docker_str(&docker), &sandbox_root)).unwrap_err();
 
         let msg = format!("{err:#}");
         assert!(
@@ -348,7 +374,7 @@ mod tests {
         let sandbox_root = tmp.path().join("sandbox");
         assert!(!dockerfile_path(&sandbox_root).exists());
 
-        ensure_image(&docker_str(&docker), &sandbox_root).unwrap();
+        retry_etxtbsy(|| ensure_image(&docker_str(&docker), &sandbox_root)).unwrap();
 
         let seeded = std::fs::read(dockerfile_path(&sandbox_root)).unwrap();
         assert_eq!(
@@ -368,7 +394,7 @@ mod tests {
         let edited: &[u8] = b"FROM ubuntu:24.04\nRUN echo edited\n";
         std::fs::write(dockerfile_path(&sandbox_root), edited).unwrap();
 
-        let tag = ensure_image(&docker_str(&docker), &sandbox_root).unwrap();
+        let tag = retry_etxtbsy(|| ensure_image(&docker_str(&docker), &sandbox_root)).unwrap();
 
         // (a) Octets inchangés : pas d'écrasement.
         assert_eq!(
@@ -388,7 +414,7 @@ mod tests {
         let (docker, argv_log) = write_fake_docker(tmp.path(), 1, 0, "");
         let sandbox_root = tmp.path().join("sandbox");
 
-        ensure_image(&docker_str(&docker), &sandbox_root).unwrap();
+        retry_etxtbsy(|| ensure_image(&docker_str(&docker), &sandbox_root)).unwrap();
 
         let argv = build_argv(&argv_log);
         let ctx = argv.last().unwrap();

--- a/crates/pdo-daemon/src/sandbox_run.rs
+++ b/crates/pdo-daemon/src/sandbox_run.rs
@@ -1,0 +1,433 @@
+//! Run-advance wiring for the sandbox (#407, slice D / tracer bullet of PRD #403).
+//!
+//! The three pure modules — [`crate::sandbox_staging`] (#404),
+//! [`crate::sandbox_image`] (#405), [`crate::sandbox_container`] (#406) — each own
+//! one facet (home staging / image / container) and read no `AppState`. This
+//! module is the thin **orchestration layer** that consumes them: it assembles a
+//! [`SandboxContext`] value at the daemon boundary ([`context_from_state`], the
+//! only reader of `AppState`), then the core ([`ensure_ready`], [`cleanup`]) works
+//! from explicit values only — mirroring the pure-module discipline.
+//!
+//! What #407 wires (and what it does NOT):
+//! - [`ensure_ready`] — stage the Claude home once, ensure the image, ensure the
+//!   container is up. Called at create-time (eager fail-fast), `boot_recovery`
+//!   (reconcile a live sandboxed Run), and `open_run_shell` (resurrect). Sync and
+//!   possibly long (`docker build` on the first machine run) → async callers wrap
+//!   it in `spawn_blocking`.
+//! - [`cleanup`] — destroy the container + purge the staging at `cleanup_run`.
+//!   **`merge_back` is NOT wired here** — it belongs to the observability slice
+//!   #408 (together with the `transcripts_root` seam), so a `pure`/`copy` Run is
+//!   deliberately blind to cost / stale-detection until then. That is an
+//!   *observability* gap, not a correctness/liveness one: session-death detection
+//!   is transcript-independent and stays alive.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use tracing::warn;
+
+use crate::event_log::{RunState, SandboxMode};
+use crate::{sandbox_container, sandbox_image, sandbox_staging, AppState};
+
+/// Everything [`ensure_ready`] / [`cleanup`] need, assembled once at the boundary
+/// by [`context_from_state`] from `AppState` + the projected `RunState`. Holds
+/// owned values so the core never reaches back into `AppState`.
+pub(crate) struct SandboxContext {
+    /// The `docker` binary to invoke (`state.docker_cmd_override` → `"docker"`).
+    pub(crate) docker_bin: String,
+    pub(crate) run_id: String,
+    pub(crate) mode: SandboxMode,
+    /// Effective repo root — bind-mounted rw at its host path. One mount covers
+    /// the repo + every node sub-worktree under `.pdo/runs/` + `.pdo/prompts`.
+    pub(crate) repo_root: PathBuf,
+    /// The Run's pipeline worktree (`-w` cosmetic at create; the `pure` trust
+    /// dialog is seeded on `repo_root`, the common ancestor of every worktree).
+    pub(crate) run_worktree: PathBuf,
+    pub(crate) daemon_port: u16,
+    /// Host `$HOME` — source of `.claude` for `prepare`.
+    pub(crate) home_root: PathBuf,
+    /// `$HOME/.pdo/sandbox` — per-Run staging lives under `<sandbox_root>/<run>`.
+    pub(crate) sandbox_root: PathBuf,
+    /// Host `$HOME` again, as the mount-target root for `.claude`/`.claude.json`
+    /// inside the container (kept distinct from `home_root` to mirror the two
+    /// pure-module params it feeds, even though both resolve to `$HOME`).
+    pub(crate) host_home: PathBuf,
+    pub(crate) uid: u32,
+    pub(crate) gid: u32,
+    /// Host `pdo` binary, bind-mounted read-only at `/usr/local/bin/pdo`.
+    pub(crate) pdo_bin: PathBuf,
+}
+
+impl SandboxContext {
+    /// [`sandbox_staging::Mode`] for this Run, or `None` for `off` (no staging).
+    fn staging_mode(&self) -> Option<sandbox_staging::Mode> {
+        match self.mode {
+            SandboxMode::Off => None,
+            SandboxMode::Copy => Some(sandbox_staging::Mode::Copy),
+            SandboxMode::Pure => Some(sandbox_staging::Mode::Pure),
+        }
+    }
+}
+
+/// Resolve a [`SandboxContext`] from the daemon state + a projected Run. The one
+/// edge function that reads `AppState` / the environment; the core is pure values.
+///
+/// Fails (loud) when `$HOME` is unset or the current exe path can't be resolved —
+/// a sandboxed Run must never fall back to a half-configured container silently.
+pub(crate) fn context_from_state(state: &AppState, run_state: &RunState) -> Result<SandboxContext> {
+    let repo_root = crate::effective_repo_root(state, run_state);
+    let run_worktree = crate::worktree_ops::worktree_dir_for_run(&repo_root, &run_state.run_id);
+    // Home root: the per-daemon override (layer-3 harness) wins; else the real
+    // `$HOME`. `home_root == host_home` (both the same `$HOME`); the sandbox
+    // staging root derives from it (`<home>/.pdo/sandbox`).
+    let (home_root, sandbox_root) = sandbox_home_roots(state)?;
+    let host_home = home_root.clone();
+    let pdo_bin = sandbox_container::pdo_bin_path()?;
+    Ok(SandboxContext {
+        docker_bin: docker_bin(state),
+        run_id: run_state.run_id.clone(),
+        mode: run_state.sandbox,
+        repo_root,
+        run_worktree,
+        daemon_port: state.port,
+        home_root,
+        sandbox_root,
+        host_home,
+        uid: sandbox_container::host_uid(),
+        gid: sandbox_container::host_gid(),
+        pdo_bin,
+    })
+}
+
+/// `(home_root, sandbox_root)` honouring the per-daemon override (#407 test seam):
+/// `Some(dir)` → `(dir, dir/.pdo/sandbox)`; else the real `$HOME` via
+/// [`sandbox_staging::default_roots_from_env`].
+pub(crate) fn sandbox_home_roots(state: &AppState) -> Result<(PathBuf, PathBuf)> {
+    if let Some(home) = &state.sandbox_home_override {
+        let sandbox_root = home.join(".pdo").join("sandbox");
+        return Ok((home.clone(), sandbox_root));
+    }
+    sandbox_staging::default_roots_from_env()
+        .context("HOME is not set; cannot resolve the sandbox staging root")
+}
+
+/// The `docker` binary this daemon uses (per-daemon override → `"docker"`).
+pub(crate) fn docker_bin(state: &AppState) -> String {
+    state
+        .docker_cmd_override
+        .clone()
+        .unwrap_or_else(|| "docker".to_string())
+}
+
+/// Guarantee the Run's sandbox is ready to accept `docker exec` tails: staged
+/// home present, image built, container up. Idempotent — safe to call at
+/// create-time, boot recovery, spawn-time, and run-shell open.
+///
+/// **Sync and potentially long** (`docker build` on the first machine run):
+/// async callers MUST wrap it in `tokio::task::spawn_blocking` so the executor
+/// isn't blocked. `off` is a defensive no-op (callers already gate on
+/// `!sandbox.is_off()`).
+pub(crate) fn ensure_ready(ctx: &SandboxContext) -> Result<()> {
+    let Some(mode) = ctx.staging_mode() else {
+        return Ok(()); // off: gated by callers; no docker touched.
+    };
+
+    // 1. Stage the Claude home ONCE. The ~98 MB `copy` walk (and the `pure` seed)
+    //    must not repeat on every ensure_ready — gate on the staging dir already
+    //    existing. `pure` pre-approves the trust dialog on `repo_root`, the common
+    //    ancestor of the pipeline worktree AND every node sub-worktree.
+    let staging_dir = sandbox_staging::staging_dir_for_run(&ctx.sandbox_root, &ctx.run_id);
+    if !staging_dir.exists() {
+        let trusted_root = match ctx.mode {
+            SandboxMode::Pure => Some(ctx.repo_root.as_path()),
+            _ => None,
+        };
+        sandbox_staging::prepare(
+            &ctx.home_root,
+            &ctx.sandbox_root,
+            mode,
+            &ctx.run_id,
+            trusted_root,
+        )
+        .with_context(|| format!("failed to stage the sandbox home for run {}", ctx.run_id))?;
+    }
+
+    // 2. Ensure the content-addressed image (`pdo-sandbox:h-<hash>`) exists,
+    //    building it from the seeded Dockerfile on the first machine run.
+    let image_ref = sandbox_image::ensure_image(&ctx.docker_bin, &ctx.sandbox_root)
+        .context("failed to ensure the sandbox image")?;
+
+    // 3. Assemble the container spec + ensure the long-lived container is up.
+    let staged_home = sandbox_staging::staged_claude_home(&ctx.sandbox_root, &ctx.run_id);
+    let staged_json = sandbox_staging::staged_claude_json(&ctx.sandbox_root, &ctx.run_id);
+    let spec = sandbox_container::ContainerSpec {
+        image_ref: &image_ref,
+        repo_root: &ctx.repo_root,
+        run_worktree: &ctx.run_worktree,
+        staged_home: &staged_home,
+        staged_json: &staged_json,
+        pdo_bin: &ctx.pdo_bin,
+        host_home: &ctx.host_home,
+        uid: ctx.uid,
+        gid: ctx.gid,
+        daemon_port: ctx.daemon_port,
+    };
+    sandbox_container::ensure_running(&ctx.docker_bin, &ctx.run_id, &spec)
+        .context("failed to ensure the sandbox container is running")?;
+
+    Ok(())
+}
+
+/// Destroy the Run's container and purge its staging (`cleanup_run`, #407 D9).
+///
+/// Best-effort: never fails the archival. **The caller must invoke this BEFORE
+/// `git worktree remove`** — the container bind-mounts the repo, so removing a
+/// live worktree under it would hit a busy mount. `merge_back` is intentionally
+/// absent (→ #408).
+pub(crate) fn cleanup(docker_bin: &str, sandbox_root: &Path, run_id: &str) {
+    if let Err(e) = sandbox_container::remove(docker_bin, run_id) {
+        warn!("sandbox cleanup: failed to remove container for run {run_id} (best-effort): {e:#}");
+    }
+    // `teardown` is already best-effort (swallows fs errors); log nothing extra.
+    let _ = sandbox_staging::teardown(sandbox_root, run_id);
+}
+
+/// Best-effort **targeted** kill of one session's process tree inside the Run's
+/// container (#407 D8). No-op for `off`. The `docker exec` client killed on the
+/// tmux side does NOT kill the container process (reparented onto PID 1), so this
+/// separate exec scans `/proc/*/environ` for the session marker and signals only
+/// the matching tree — sibling sessions survive.
+pub(crate) fn kill_session_best_effort(
+    docker_bin: &str,
+    sandbox: SandboxMode,
+    run_id: &str,
+    marker: &str,
+) {
+    if sandbox.is_off() {
+        return;
+    }
+    if let Err(e) = sandbox_container::kill_session_in_container(
+        docker_bin,
+        run_id,
+        marker,
+        sandbox_container::host_uid(),
+        sandbox_container::host_gid(),
+    ) {
+        warn!(
+            "sandbox targeted kill of session {marker} in run {run_id} failed (best-effort): {e:#}"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+
+    fn q(s: &str) -> String {
+        format!("'{}'", s.replace('\'', "'\\''"))
+    }
+
+    /// A fake `docker` that logs argv and canned-responds so `ensure_ready`
+    /// reaches its container step without a real daemon: `image inspect` → exit 0
+    /// (image present, no build), `container inspect` → `true` (up, no create).
+    /// Mirrors the per-module fakes (no `std::env` mutation — threaded as
+    /// `docker_bin`).
+    fn write_fake_docker(dir: &Path) -> (String, PathBuf) {
+        let bin = dir.join("fake-docker");
+        let log = dir.join("argv.log");
+        let script = format!(
+            "#!/usr/bin/env bash\n\
+             printf '%s\\n' \"$@\" >> {log}\n\
+             case \"$1\" in\n\
+             image) exit 0 ;;\n\
+             container) printf 'true'; exit 0 ;;\n\
+             *) exit 0 ;;\n\
+             esac\n",
+            log = q(&log.display().to_string()),
+        );
+        std::fs::write(&bin, script).unwrap();
+        std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
+        (bin.to_str().unwrap().to_string(), log)
+    }
+
+    fn log_lines(log: &Path) -> Vec<String> {
+        std::fs::read_to_string(log)
+            .unwrap_or_default()
+            .lines()
+            .map(str::to_string)
+            .collect()
+    }
+
+    /// Retry an op that returns `Result` on `ETXTBSY` (os error 26): exec-ing a
+    /// freshly-written fake binary can transiently race a sibling test's
+    /// fork/exec (rust-lang/rust#45719). Mirrors the guard in `sandbox_image` /
+    /// `sandbox_container` tests.
+    fn retry_etxtbsy<T>(mut op: impl FnMut() -> Result<T>) -> Result<T> {
+        for _ in 0..100 {
+            match op() {
+                Err(e)
+                    if e.chain().any(|c| {
+                        c.downcast_ref::<std::io::Error>()
+                            .and_then(std::io::Error::raw_os_error)
+                            == Some(26)
+                    }) =>
+                {
+                    std::thread::sleep(std::time::Duration::from_millis(5));
+                }
+                other => return other,
+            }
+        }
+        op()
+    }
+
+    /// Run a best-effort side-effect op (returns `()`, swallows ETXTBSY) until a
+    /// predicate on the log holds — re-invoking on the transient exec race. The
+    /// ops here (`cleanup`/`kill`) are idempotent, so a re-invocation is safe.
+    fn retry_side_effect(mut op: impl FnMut(), mut ready: impl FnMut() -> bool) -> bool {
+        for _ in 0..100 {
+            op();
+            if ready() {
+                return true;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+        ready()
+    }
+
+    /// Build a context rooted under temp dirs (bypasses the env/exe resolvers).
+    fn test_ctx(tmp: &Path, docker_bin: String, mode: SandboxMode) -> SandboxContext {
+        let home = tmp.join("home");
+        std::fs::create_dir_all(home.join(".claude")).unwrap();
+        std::fs::write(home.join(".claude/.credentials.json"), "{}").unwrap();
+        SandboxContext {
+            docker_bin,
+            run_id: "r1".to_string(),
+            mode,
+            repo_root: tmp.join("repo"),
+            run_worktree: tmp.join("repo/.pdo/runs/r1/worktree"),
+            daemon_port: 6172,
+            home_root: home.clone(),
+            sandbox_root: tmp.join("sandbox"),
+            host_home: home,
+            uid: 1000,
+            gid: 1000,
+            pdo_bin: tmp.join("pdo"),
+        }
+    }
+
+    #[test]
+    fn ensure_ready_stages_probes_image_and_container() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (docker, log) = write_fake_docker(tmp.path());
+        let ctx = test_ctx(tmp.path(), docker, SandboxMode::Pure);
+
+        retry_etxtbsy(|| ensure_ready(&ctx)).unwrap();
+
+        // Staging seeded (pure → credentials + .claude.json + empty projects/).
+        let staging = sandbox_staging::staging_dir_for_run(&ctx.sandbox_root, "r1");
+        assert!(staging.exists(), "staging dir must be created");
+        assert!(
+            sandbox_staging::staged_claude_json(&ctx.sandbox_root, "r1").is_file(),
+            "pure staging writes a .claude.json"
+        );
+        // Docker was probed for image + container (present → no build/create).
+        let lines = log_lines(&log);
+        assert!(lines.contains(&"image".to_string()), "image inspected");
+        assert!(lines.contains(&"container".to_string()), "container probed");
+        assert!(!lines.contains(&"build".to_string()), "present image → no build");
+        assert!(
+            !lines.contains(&"create".to_string()),
+            "running container → no create"
+        );
+    }
+
+    #[test]
+    fn ensure_ready_off_is_noop() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (docker, log) = write_fake_docker(tmp.path());
+        let ctx = test_ctx(tmp.path(), docker, SandboxMode::Off);
+
+        ensure_ready(&ctx).unwrap();
+
+        assert!(
+            !tmp.path().join("sandbox").exists(),
+            "off must not stage anything"
+        );
+        assert!(!log.exists(), "off must not invoke docker");
+    }
+
+    #[test]
+    fn ensure_ready_does_not_restage_when_present() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (docker, _) = write_fake_docker(tmp.path());
+        let ctx = test_ctx(tmp.path(), docker, SandboxMode::Pure);
+
+        retry_etxtbsy(|| ensure_ready(&ctx)).unwrap();
+        // Drop a sentinel into the staging dir; a second ensure_ready must NOT
+        // re-run prepare (which would recreate/rewrite the tree).
+        let staging = sandbox_staging::staging_dir_for_run(&ctx.sandbox_root, "r1");
+        let sentinel = staging.join("SENTINEL");
+        std::fs::write(&sentinel, "keep").unwrap();
+
+        retry_etxtbsy(|| ensure_ready(&ctx)).unwrap();
+        assert!(sentinel.exists(), "staging must not be re-prepared when present");
+    }
+
+    #[test]
+    fn cleanup_removes_container_and_staging() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (docker, log) = write_fake_docker(tmp.path());
+        let sandbox_root = tmp.path().join("sandbox");
+        // Seed a staging dir to be torn down.
+        std::fs::create_dir_all(sandbox_staging::staged_claude_home(&sandbox_root, "r1")).unwrap();
+        assert!(sandbox_staging::staging_dir_for_run(&sandbox_root, "r1").exists());
+
+        // `cleanup` is idempotent + best-effort (swallows ETXTBSY); retry until the
+        // container-remove is logged.
+        let logged = retry_side_effect(
+            || cleanup(&docker, &sandbox_root, "r1"),
+            || {
+                let l = log_lines(&log);
+                l.len() >= 3 && l[..3] == ["rm", "-f", "pdo-sbx-r1"]
+            },
+        );
+        assert!(
+            logged,
+            "cleanup removes the container; log: {:?}",
+            log_lines(&log)
+        );
+        assert!(
+            !sandbox_staging::staging_dir_for_run(&sandbox_root, "r1").exists(),
+            "cleanup purges the staging"
+        );
+    }
+
+    #[test]
+    fn kill_session_off_is_noop() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (docker, log) = write_fake_docker(tmp.path());
+        kill_session_best_effort(&docker, SandboxMode::Off, "r1", "pdo-r1-n1-iter-1");
+        assert!(!log.exists(), "off must not invoke docker to kill");
+    }
+
+    #[test]
+    fn kill_session_pure_execs_marker() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (docker, log) = write_fake_docker(tmp.path());
+        let logged = retry_side_effect(
+            || kill_session_best_effort(&docker, SandboxMode::Pure, "r1", "pdo-r1-n1-iter-1"),
+            || {
+                let l = log_lines(&log);
+                !l.is_empty()
+                    && l[0] == "exec"
+                    && l.iter().any(|x| x.contains("PDO_SBX_SESSION=pdo-r1-n1-iter-1"))
+            },
+        );
+        assert!(
+            logged,
+            "targeted kill must exec with the session marker; log: {:?}",
+            log_lines(&log)
+        );
+    }
+}

--- a/crates/pdo-daemon/src/sandbox_run.rs
+++ b/crates/pdo-daemon/src/sandbox_run.rs
@@ -335,7 +335,10 @@ mod tests {
         let lines = log_lines(&log);
         assert!(lines.contains(&"image".to_string()), "image inspected");
         assert!(lines.contains(&"container".to_string()), "container probed");
-        assert!(!lines.contains(&"build".to_string()), "present image → no build");
+        assert!(
+            !lines.contains(&"build".to_string()),
+            "present image → no build"
+        );
         assert!(
             !lines.contains(&"create".to_string()),
             "running container → no create"
@@ -371,7 +374,10 @@ mod tests {
         std::fs::write(&sentinel, "keep").unwrap();
 
         retry_etxtbsy(|| ensure_ready(&ctx)).unwrap();
-        assert!(sentinel.exists(), "staging must not be re-prepared when present");
+        assert!(
+            sentinel.exists(),
+            "staging must not be re-prepared when present"
+        );
     }
 
     #[test]
@@ -421,7 +427,8 @@ mod tests {
                 let l = log_lines(&log);
                 !l.is_empty()
                     && l[0] == "exec"
-                    && l.iter().any(|x| x.contains("PDO_SBX_SESSION=pdo-r1-n1-iter-1"))
+                    && l.iter()
+                        .any(|x| x.contains("PDO_SBX_SESSION=pdo-r1-n1-iter-1"))
             },
         );
         assert!(

--- a/crates/pdo-daemon/src/sandbox_staging.rs
+++ b/crates/pdo-daemon/src/sandbox_staging.rs
@@ -9,8 +9,8 @@
 //! [`prepare`] (seeder), [`merge_back`] (récupérer les transcripts), [`teardown`]
 //! (purger). Les slices sœurs le **consomment** mais ne sont **pas** ici :
 //! - #406 monte `claude-home/` → `$HOME/.claude` et `.claude.json` → `$HOME/.claude.json` ;
-//! - #407 câble `prepare`/`merge_back`/`teardown` dans le run-advance (ADR-0030) ;
-//! - #408 pointe stale-detection/coût vers le staging (seam `transcripts_root`).
+//! - #407 câble `prepare`/`teardown` dans le run-advance (ADR-0030) ;
+//! - #408 câble `merge_back` + pointe stale-detection/coût vers le staging (seam `transcripts_root`).
 //!
 //! ## Décisions de conception (voir la section « Sandbox » de `CONTEXT.md`)
 //! - **`copy` = allowlist, jamais denylist.** Copier « tout `~/.claude` sauf

--- a/crates/pdo-daemon/src/tmux_session_manager.rs
+++ b/crates/pdo-daemon/src/tmux_session_manager.rs
@@ -132,7 +132,10 @@ fn sh_quote_arg(s: &str) -> String {
     let safe = !s.is_empty()
         && s.bytes().all(|b| {
             b.is_ascii_alphanumeric()
-                || matches!(b, b'_' | b'-' | b'.' | b'/' | b'=' | b':' | b',' | b'@' | b'+')
+                || matches!(
+                    b,
+                    b'_' | b'-' | b'.' | b'/' | b'=' | b':' | b',' | b'@' | b'+'
+                )
         });
     if safe {
         s.to_string()
@@ -540,7 +543,14 @@ pub fn resume(
     tmux_cmd_override: Option<&str>,
     sandbox: Option<&SandboxWrap<'_>>,
 ) -> Result<()> {
-    let script = build_resume_script(run_id, node_id, iter, daemon_port, tmux_cmd_override, sandbox);
+    let script = build_resume_script(
+        run_id,
+        node_id,
+        iter,
+        daemon_port,
+        tmux_cmd_override,
+        sandbox,
+    );
     let socket = tmux_socket_name(daemon_port);
 
     let output = tmux(&socket)
@@ -1592,7 +1602,10 @@ mod tests {
             SessionTail::Agent { model: None },
             None,
         );
-        assert!(!with_none.contains("docker"), "off path must not mention docker: {with_none}");
+        assert!(
+            !with_none.contains("docker"),
+            "off path must not mention docker: {with_none}"
+        );
         assert!(!with_none.contains("pdo-sbx-"), "{with_none}");
         assert!(
             with_none.contains("exec claude --dangerously-skip-permissions \"$(cat "),

--- a/crates/pdo-daemon/src/tmux_session_manager.rs
+++ b/crates/pdo-daemon/src/tmux_session_manager.rs
@@ -123,6 +123,81 @@ fn sh_single_quote(s: &str) -> String {
     out
 }
 
+/// Single-quote a shell word only when it contains a character that isn't safe
+/// bare. Keeps the emitted `docker exec …` argv readable (and its golden stable):
+/// simple tokens (`docker`, `exec`, `-i`, `PDO_OUTPUT_out=/a/b`, `1000:1000`) stay
+/// bare; anything with a space / quote / `$` / glob char is quoted. Used only to
+/// splice the `docker exec` argv into the `bash -c` tail string.
+fn sh_quote_arg(s: &str) -> String {
+    let safe = !s.is_empty()
+        && s.bytes().all(|b| {
+            b.is_ascii_alphanumeric()
+                || matches!(b, b'_' | b'-' | b'.' | b'/' | b'=' | b':' | b',' | b'@' | b'+')
+        });
+    if safe {
+        s.to_string()
+    } else {
+        sh_single_quote(s)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Sandbox wrapping (#407)
+// ---------------------------------------------------------------------------
+
+/// Threaded into [`build_tmux_script`] / [`build_resume_script`] when a Run is
+/// sandboxed (`sandbox != off`, #407). When present, the node's tail is wrapped in
+/// a `docker exec … pdo-sbx-<run_id> bash -lc '<tail>'` so it runs **inside** the
+/// Run's long-lived container instead of on the host.
+///
+/// The base `PDO_*` env exports still run on the *host* side of the wrapper
+/// (harmless), so `off` byte-identity is preserved when this is `None`.
+/// `PDO_DAEMON_URL=localhost` is therefore **not** re-forwarded into the container
+/// (the create posted `host.docker.internal`); the dynamic per-node catalogue (a
+/// `script` node's `PDO_INPUT_*`/`PDO_OUTPUT_*`/…) is forwarded as explicit
+/// `-e K=V` on the exec, since a bare host export wouldn't cross the exec.
+pub struct SandboxWrap<'a> {
+    /// The `docker` binary to invoke (per-daemon override → `"docker"`).
+    pub docker_bin: &'a str,
+    pub uid: u32,
+    pub gid: u32,
+    /// The session marker: **MUST** equal the tmux session name the kill path uses
+    /// (`PDO_SBX_SESSION`), or the targeted `/proc` kill misses its tree.
+    pub marker: &'a str,
+    /// The node's working dir → `docker exec -w <workdir>` (the load-bearing cwd
+    /// inside the container).
+    pub workdir: &'a Path,
+}
+
+/// Splice the container-exec prefix (from [`crate::sandbox_container`]) around a
+/// base tail: `docker <exec argv incl. -e K=V> pdo-sbx-<run> bash -lc '<tail>'`.
+/// The base tail is single-quoted as one `bash -lc` argument; `wrap_with_env`
+/// then single-quotes the whole thing again for its outer `bash -c` (the same
+/// double-quoting the `--model` path already relies on).
+fn wrap_tail_in_docker_exec(
+    run_id: &str,
+    wrap: &SandboxWrap<'_>,
+    extra_env: &[(String, String)],
+    base_tail: &str,
+) -> String {
+    let mut argv = vec![wrap.docker_bin.to_string()];
+    argv.extend(crate::sandbox_container::exec_prefix_with_env(
+        run_id,
+        wrap.uid,
+        wrap.gid,
+        wrap.workdir,
+        wrap.marker,
+        extra_env,
+    ));
+    argv.push("bash".to_string());
+    argv.push("-lc".to_string());
+    argv.push(base_tail.to_string());
+    argv.iter()
+        .map(|a| sh_quote_arg(a))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
 // ---------------------------------------------------------------------------
 // Script builder (pub for assertion in layer-3a tests)
 // ---------------------------------------------------------------------------
@@ -225,6 +300,10 @@ fn build_script_tail(prompt_path: &Path, timeout_secs: u64) -> String {
 ///
 /// `tail` selects the launch: [`SessionTail::Agent`] with the per-node `model`
 /// (#296), or [`SessionTail::Script`] with its `timeout` and I/O env catalogue.
+// Every argument is an irreducible input to the script the session runs (identity,
+// working context, launch selector, sandbox wrap); a struct would only move the
+// list, not shorten it — same rationale as `spawn`.
+#[allow(clippy::too_many_arguments)]
 pub fn build_tmux_script(
     run_id: &str,
     node_id: &str,
@@ -233,6 +312,7 @@ pub fn build_tmux_script(
     prompt_path: &Path,
     tmux_cmd_override: Option<&str>,
     tail: SessionTail<'_>,
+    sandbox: Option<&SandboxWrap<'_>>,
 ) -> String {
     const NO_ENV: &[(String, String)] = &[];
     let (tail_cmd, extra_env): (String, &[(String, String)]) = match tail {
@@ -273,7 +353,19 @@ pub fn build_tmux_script(
         }
     };
 
-    wrap_with_env(run_id, node_id, iter, daemon_port, extra_env, &tail_cmd)
+    // #407: when sandboxed, the node's tail runs INSIDE the container via a
+    // `docker exec … bash -lc '<tail>'`. The per-node catalogue is forwarded on
+    // the exec as explicit `-e K=V` (never PDO_DAEMON_URL); the host-side base env
+    // exports still run (harmless) so `PDO_DAEMON_URL=localhost` is not carried
+    // in. `wrap_with_env` then gets an EMPTY `extra_env` — the catalogue crossed
+    // the exec, not the host export — keeping the host wrapper minimal.
+    match sandbox {
+        Some(wrap) => {
+            let docker_tail = wrap_tail_in_docker_exec(run_id, wrap, extra_env, &tail_cmd);
+            wrap_with_env(run_id, node_id, iter, daemon_port, NO_ENV, &docker_tail)
+        }
+        None => wrap_with_env(run_id, node_id, iter, daemon_port, extra_env, &tail_cmd),
+    }
 }
 
 /// Build a resume script that uses `claude --continue` in the same working_dir.
@@ -292,13 +384,24 @@ fn build_resume_script(
     iter: i64,
     daemon_port: u16,
     tmux_cmd_override: Option<&str>,
+    sandbox: Option<&SandboxWrap<'_>>,
 ) -> String {
     let tail_cmd = match tmux_cmd_override {
         Some(cmd) => cmd.to_string(),
         None => "exec claude --dangerously-skip-permissions --continue".to_string(),
     };
 
-    wrap_with_env(run_id, node_id, iter, daemon_port, &[], &tail_cmd)
+    // #407: the 6th tail path (`claude --continue`) is wrapped identically — a
+    // resumed sandboxed session re-enters the same container. `--continue` matches
+    // its transcript by working-dir path; the container mounts the repo at the
+    // same host path, so the path (hence the transcript) still matches.
+    match sandbox {
+        Some(wrap) => {
+            let docker_tail = wrap_tail_in_docker_exec(run_id, wrap, &[], &tail_cmd);
+            wrap_with_env(run_id, node_id, iter, daemon_port, &[], &docker_tail)
+        }
+        None => wrap_with_env(run_id, node_id, iter, daemon_port, &[], &tail_cmd),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -343,6 +446,7 @@ pub fn spawn(
     daemon_port: u16,
     tmux_cmd_override: Option<&str>,
     tail: SessionTail<'_>,
+    sandbox: Option<&SandboxWrap<'_>>,
 ) -> Result<()> {
     let prompt_dir = working_dir.join(".pdo").join("prompts");
     std::fs::create_dir_all(&prompt_dir)?;
@@ -357,6 +461,7 @@ pub fn spawn(
         &prompt_path,
         tmux_cmd_override,
         tail,
+        sandbox,
     );
     let socket = tmux_socket_name(daemon_port);
 
@@ -389,6 +494,7 @@ pub fn spawn_shell(
     working_dir: &Path,
     run_id: &str,
     daemon_port: u16,
+    sandbox: Option<&SandboxWrap<'_>>,
 ) -> Result<()> {
     // prompt_path is unused for `SessionTail::Shell` (bash has no prompt);
     // pass the working_dir as a harmless placeholder.
@@ -400,6 +506,7 @@ pub fn spawn_shell(
         working_dir,
         None,
         SessionTail::Shell,
+        sandbox,
     );
     let socket = tmux_socket_name(daemon_port);
 
@@ -422,6 +529,7 @@ pub fn spawn_shell(
 }
 
 /// Resume a dead session via `claude --continue` in the original working_dir.
+#[allow(clippy::too_many_arguments)]
 pub fn resume(
     session_name: &str,
     working_dir: &Path,
@@ -430,8 +538,9 @@ pub fn resume(
     iter: i64,
     daemon_port: u16,
     tmux_cmd_override: Option<&str>,
+    sandbox: Option<&SandboxWrap<'_>>,
 ) -> Result<()> {
-    let script = build_resume_script(run_id, node_id, iter, daemon_port, tmux_cmd_override);
+    let script = build_resume_script(run_id, node_id, iter, daemon_port, tmux_cmd_override, sandbox);
     let socket = tmux_socket_name(daemon_port);
 
     let output = tmux(&socket)
@@ -911,6 +1020,7 @@ mod tests {
             prompt_path,
             None,
             SessionTail::Agent { model: None },
+            None,
         );
         assert!(script.starts_with("exec bash -c "));
         assert!(script.contains("exec claude --dangerously-skip-permissions"));
@@ -927,6 +1037,7 @@ mod tests {
             prompt_path,
             Some("exec sleep 60"),
             SessionTail::Agent { model: None },
+            None,
         );
         assert!(script.contains("exec sleep 60"));
         assert!(!script.contains("claude"));
@@ -947,6 +1058,7 @@ mod tests {
             prompt_path,
             None,
             SessionTail::Agent { model: None },
+            None,
         );
         assert!(
             !script.contains("--model"),
@@ -979,6 +1091,7 @@ mod tests {
             SessionTail::Agent {
                 model: Some("opus"),
             },
+            None,
         );
         assert!(script.contains("--model"), "model flag present: {script}");
         assert!(
@@ -1013,6 +1126,7 @@ mod tests {
             prompt_path,
             None,
             SessionTail::Agent { model: Some("") },
+            None,
         );
         assert!(
             !script.contains("--model"),
@@ -1106,6 +1220,7 @@ mod tests {
                 timeout_secs: 42,
                 env: &[],
             },
+            None,
         );
         assert!(script.starts_with("exec bash -c "));
         assert!(
@@ -1154,6 +1269,7 @@ mod tests {
                 timeout_secs: 60,
                 env: &[],
             },
+            None,
         );
         assert!(
             !script.contains("sleep 99"),
@@ -1192,6 +1308,7 @@ mod tests {
                 timeout_secs: 60,
                 env: &env,
             },
+            None,
         );
         assert!(
             script.contains("export PDO_INPUT_TASK="),
@@ -1226,6 +1343,7 @@ mod tests {
             prompt_path,
             None,
             SessionTail::Shell,
+            None,
         );
         assert!(script.starts_with("exec bash -c "));
         assert!(
@@ -1261,6 +1379,7 @@ mod tests {
             prompt_path,
             Some("exec sleep 600"),
             SessionTail::Shell,
+            None,
         );
         assert!(
             !script.contains("sleep 600"),
@@ -1317,6 +1436,188 @@ mod tests {
         assert_eq!(
             manager_session_name("20260506-143000-a3f1b2c"),
             "pdo-mgr-20260506-143000-a3f1b2c"
+        );
+    }
+
+    // -- #407 sandbox wrapping goldens --------------------------------------
+
+    fn sample_wrap<'a>(marker: &'a str, workdir: &'a Path) -> SandboxWrap<'a> {
+        SandboxWrap {
+            docker_bin: "docker",
+            uid: 1000,
+            gid: 1000,
+            marker,
+            workdir,
+        }
+    }
+
+    #[test]
+    fn sandbox_wraps_agent_tail_in_docker_exec() {
+        // #407 D5: a sandboxed agent tail runs INSIDE `pdo-sbx-<run>` via a
+        // `docker exec … bash -lc '<exec claude …>'`. The host env exports still
+        // run (harmless); the marker equals the session name (the kill target).
+        let prompt_path = Path::new("/repo/.pdo/runs/r1/worktree/.pdo/prompts/solo-iter-1.md");
+        let wt = Path::new("/repo/.pdo/runs/r1/nodes/solo/iter-1");
+        let wrap = sample_wrap("pdo-r1-solo-iter-1", wt);
+        let script = build_tmux_script(
+            "r1",
+            "solo",
+            1,
+            6172,
+            prompt_path,
+            None,
+            SessionTail::Agent { model: None },
+            Some(&wrap),
+        );
+        // Host wrapper preserved.
+        assert!(script.starts_with("exec bash -c "), "{script}");
+        assert!(script.contains("export PDO_RUN_ID="), "{script}");
+        // The container-exec prefix, in canonical order.
+        assert!(
+            script.contains(
+                "docker exec -i -t -e PDO_SBX_SESSION=pdo-r1-solo-iter-1 \
+                 -e PDO_NODE_ID -e PDO_NODE_ITER --user 1000:1000 \
+                 -w /repo/.pdo/runs/r1/nodes/solo/iter-1 pdo-sbx-r1 bash -lc"
+            ),
+            "docker exec prefix missing/wrong: {script}"
+        );
+        // The claude tail runs inside the container.
+        assert!(
+            script.contains("exec claude --dangerously-skip-permissions"),
+            "{script}"
+        );
+        // PDO_DAEMON_URL appears ONCE (the host export), never re-forwarded on the
+        // exec (would clobber the host-gateway URL posted at create).
+        assert_eq!(
+            script.matches("PDO_DAEMON_URL").count(),
+            1,
+            "PDO_DAEMON_URL must not be re-forwarded into the container: {script}"
+        );
+    }
+
+    #[test]
+    fn sandbox_wraps_script_tail_with_env_catalogue() {
+        // #407 D6: a `script` node's dynamic catalogue crosses the exec as
+        // explicit `-e K=V` (a bare host export wouldn't cross), NOT as a host
+        // export — so each catalogue key appears exactly once (on the exec).
+        let prompt_path = Path::new("/repo/.pdo/runs/r1/worktree/.pdo/prompts/solo-iter-1.md");
+        let wt = Path::new("/repo/.pdo/runs/r1/worktree");
+        let wrap = sample_wrap("pdo-r1-solo-iter-1", wt);
+        let env = vec![
+            (
+                "PDO_ARTIFACTS_DIR".to_string(),
+                "/repo/.pdo/runs/r1/worktree/.pdo/artifacts".to_string(),
+            ),
+            (
+                "PDO_OUTPUT_out".to_string(),
+                "/repo/.pdo/runs/r1/worktree/.pdo/artifacts/solo/iter-1/out/output.md".to_string(),
+            ),
+            ("PDO_VAR_x".to_string(), "hello".to_string()),
+        ];
+        let script = build_tmux_script(
+            "r1",
+            "solo",
+            1,
+            6172,
+            prompt_path,
+            None,
+            SessionTail::Script {
+                timeout_secs: 60,
+                env: &env,
+            },
+            Some(&wrap),
+        );
+        assert!(
+            script.contains("-e PDO_ARTIFACTS_DIR=/repo/.pdo/runs/r1/worktree/.pdo/artifacts"),
+            "{script}"
+        );
+        assert!(
+            script.contains(
+                "-e PDO_OUTPUT_out=/repo/.pdo/runs/r1/worktree/.pdo/artifacts/solo/iter-1/out/output.md"
+            ),
+            "{script}"
+        );
+        assert!(script.contains("-e PDO_VAR_x=hello"), "{script}");
+        // The catalogue is NOT host-exported (only the base four are): each key
+        // appears exactly once, on the exec.
+        assert_eq!(
+            script.matches("PDO_ARTIFACTS_DIR").count(),
+            1,
+            "catalogue must cross the exec once, not also host-exported: {script}"
+        );
+        // The body runs under timeout, self-signalling — inside the container.
+        assert!(script.contains("timeout 60s bash"), "{script}");
+        assert!(script.contains("pdo complete"), "{script}");
+        assert_eq!(script.matches("PDO_DAEMON_URL").count(), 1, "{script}");
+    }
+
+    #[test]
+    fn sandbox_wraps_shell_tail() {
+        // #407: the run shell family is wrapped too — the respawn loop runs in the
+        // container.
+        let wt = Path::new("/repo/.pdo/runs/r1/worktree");
+        let wrap = sample_wrap("pdo-shell-r1", wt);
+        let script = build_tmux_script(
+            "r1",
+            "__shell__",
+            0,
+            6172,
+            wt,
+            None,
+            SessionTail::Shell,
+            Some(&wrap),
+        );
+        assert!(
+            script.contains("-e PDO_SBX_SESSION=pdo-shell-r1"),
+            "shell marker = shell session name: {script}"
+        );
+        assert!(
+            script.contains("while true; do bash -i; sleep 0.2; done"),
+            "shell respawn loop preserved inside the container: {script}"
+        );
+    }
+
+    #[test]
+    fn sandbox_none_is_byte_identical() {
+        // #407 invariant: with no `SandboxWrap`, the emitted bytes are exactly the
+        // legacy (host) command — no docker anywhere on the `off` parcours.
+        let prompt_path = Path::new("/tmp/p.md");
+        let with_none = build_tmux_script(
+            "r",
+            "n",
+            1,
+            5172,
+            prompt_path,
+            None,
+            SessionTail::Agent { model: None },
+            None,
+        );
+        assert!(!with_none.contains("docker"), "off path must not mention docker: {with_none}");
+        assert!(!with_none.contains("pdo-sbx-"), "{with_none}");
+        assert!(
+            with_none.contains("exec claude --dangerously-skip-permissions \"$(cat "),
+            "legacy tail preserved byte-for-byte: {with_none}"
+        );
+    }
+
+    #[test]
+    fn build_resume_script_wraps_continue_in_docker_exec() {
+        // #407: the 6th tail path (`claude --continue`) is wrapped identically.
+        let wt = Path::new("/repo/.pdo/runs/r1/nodes/solo/iter-1");
+        let wrap = sample_wrap("pdo-r1-solo-iter-1", wt);
+        let wrapped = build_resume_script("r1", "solo", 1, 6172, None, Some(&wrap));
+        assert!(
+            wrapped.contains("docker exec -i -t -e PDO_SBX_SESSION=pdo-r1-solo-iter-1"),
+            "{wrapped}"
+        );
+        assert!(wrapped.contains("pdo-sbx-r1 bash -lc"), "{wrapped}");
+        assert!(wrapped.contains("--continue"), "{wrapped}");
+        // off path unchanged.
+        let off = build_resume_script("r1", "solo", 1, 6172, None, None);
+        assert!(!off.contains("docker"), "{off}");
+        assert!(
+            off.contains("exec claude --dangerously-skip-permissions --continue"),
+            "{off}"
         );
     }
 }

--- a/crates/pdo-daemon/tests/common/mod.rs
+++ b/crates/pdo-daemon/tests/common/mod.rs
@@ -69,6 +69,50 @@ impl TestDaemon {
                 panic_on_stale_sweep: false,
                 panic_on_spawn: false,
                 service_health_override: None,
+                docker_cmd_override: None,
+                sandbox_home_override: None,
+            },
+        )
+        .await?;
+
+        Ok(Self {
+            addr: handle.addr,
+            tempdir,
+            handle: Some(handle),
+        })
+    }
+
+    /// Spawn a daemon whose sandbox wiring shells out to a **fake `docker`** (#407).
+    ///
+    /// `docker_cmd` is the command every sandbox docker call runs instead of the
+    /// real binary (e.g. a script that logs its argv and canned-responds to
+    /// `inspect`/`create`/`start`/`exec`/`rm`). The tmux tail stays the harmless
+    /// `exec true` so a sandboxed node's *host-side* wrapper collapses instantly —
+    /// no real claude, no lingering session. Per-daemon config, no `std::env`
+    /// race (#181). No docker teardown in `Drop`: the fake creates no real
+    /// container.
+    pub async fn spawn_with_docker_override<F>(setup: F, docker_cmd: String) -> Result<Self>
+    where
+        F: FnOnce(&Path) -> Result<()>,
+    {
+        std::env::remove_var("PDO_NODE_ID");
+
+        let tempdir = tempfile::tempdir()?;
+        setup(tempdir.path())?;
+
+        let handle = serve_with_config(
+            SocketAddr::from(([127, 0, 0, 1], 0)),
+            tempdir.path().to_path_buf(),
+            DaemonConfig {
+                tmux_cmd_override: Some("exec true".to_string()),
+                panic_on_trigger_name: None,
+                panic_on_stale_sweep: false,
+                panic_on_spawn: false,
+                service_health_override: None,
+                docker_cmd_override: Some(docker_cmd),
+                // #407: stage the sandbox home UNDER the tempdir so the test never
+                // touches the real `$HOME` (`~/.pdo/sandbox`, `~/.claude`).
+                sandbox_home_override: Some(tempdir.path().to_path_buf()),
             },
         )
         .await?;
@@ -103,6 +147,8 @@ impl TestDaemon {
                 panic_on_stale_sweep: false,
                 panic_on_spawn: false,
                 service_health_override: None,
+                docker_cmd_override: None,
+                sandbox_home_override: None,
             },
         )
         .await?;

--- a/crates/pdo-daemon/tests/run_shell.rs
+++ b/crates/pdo-daemon/tests/run_shell.rs
@@ -407,6 +407,7 @@ async fn reaper_kills_shell_of_absent_run() {
         daemon.repo_root(),
         bogus_run,
         daemon.addr.port(),
+        None,
     )
     .unwrap();
     assert!(pdo_daemon::tmux_session_manager::session_exists(
@@ -451,6 +452,7 @@ async fn reaper_kills_shell_of_archived_run() {
         daemon.repo_root(),
         &run_id,
         daemon.addr.port(),
+        None,
     )
     .unwrap();
     assert!(pdo_daemon::tmux_session_manager::session_exists(

--- a/crates/pdo-daemon/tests/sandbox_tracer.rs
+++ b/crates/pdo-daemon/tests/sandbox_tracer.rs
@@ -1,0 +1,468 @@
+//! Layer 3a — sandbox tracer bullet (#407, slice D of PRD #403).
+//!
+//! Drives `POST /runs` against a **real daemon** with a **fake `docker`** (via
+//! `docker_cmd_override`) and a tempdir-scoped sandbox home (via
+//! `sandbox_home_override`), so no test needs Docker, touches the real `$HOME`,
+//! or launches real claude. Asserts the run-advance wiring:
+//!   1. a `pure` run projects `sandbox=pure`, prep runs (`create`+`start`), the
+//!      node tail is wrapped (`docker exec … pdo-sbx-<run>`), and the run completes;
+//!   2. Docker unavailable → `RunFailed`, ZERO host spawn (no `NodeStarted`);
+//!   3. an `off` run invokes docker NOT AT ALL (argv log empty) and completes on
+//!      the host, byte-for-byte as before;
+//!   4. `cleanup_run` removes the container (`rm -f pdo-sbx-<run>`) + purges staging;
+//!   5. `boot_recovery` re-ensures a live sandboxed run's container;
+//!   6. killing a sandboxed node issues a targeted in-container `docker exec` kill
+//!      carrying the session marker.
+//!
+//! The real end-to-end run (a live container, `pdo complete` from inside it) is
+//! the Layer-5 job — a fake `docker exec` cannot run the node's body, so tests
+//! that need a terminal state SIMULATE the container's callback by POSTing the
+//! node-done endpoint (exactly what `pdo complete` does over HTTP).
+
+mod common;
+
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::Once;
+use std::time::{Duration, Instant};
+
+use common::TestDaemon;
+use tempfile::TempDir;
+
+const NODE_ID: &str = "notify";
+
+/// `start → notify(script, output `out`) → end`, with `end` fed from `notify.out`,
+/// so completing `notify` (with its output present) drives the whole run terminal.
+const PIPELINE_YAML: &str = r#"name: sbx-cycle
+version: "1.0"
+nodes:
+  - id: start
+    name: Start
+    type: start
+    outputs:
+      - name: user_prompt
+  - id: notify
+    name: notify
+    type: script
+    outputs:
+      - name: out
+  - id: end
+    name: End
+    type: end
+    inputs:
+      - name: result
+edges:
+  - source: { node: start, port: user_prompt }
+    target: { node: notify, port: in }
+  - source: { node: notify, port: out }
+    target: { node: end, port: result }
+"#;
+
+fn ensure_pdo_on_path() {
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        let bin = Path::new(env!("CARGO_BIN_EXE_pdo"));
+        let dir = bin.parent().expect("pdo binary has a parent dir");
+        let existing = std::env::var("PATH").unwrap_or_default();
+        std::env::set_var("PATH", format!("{}:{}", dir.display(), existing));
+    });
+}
+
+fn git_init_with_commit(repo: &Path) -> anyhow::Result<()> {
+    let run = |args: &[&str]| -> anyhow::Result<()> {
+        let out = Command::new("git").args(args).current_dir(repo).output()?;
+        if !out.status.success() {
+            anyhow::bail!("git {args:?} failed: {}", String::from_utf8_lossy(&out.stderr));
+        }
+        Ok(())
+    };
+    run(&["init", "-q", "-b", "main"])?;
+    run(&["config", "user.email", "test@example.com"])?;
+    run(&["config", "user.name", "Test"])?;
+    run(&["config", "commit.gpgsign", "false"])?;
+    std::fs::write(repo.join(".gitignore"), ".pdo/runs/\n")?;
+    run(&["add", "."])?;
+    run(&["commit", "-q", "-m", "init"])?;
+    Ok(())
+}
+
+fn seed(body: &str) -> impl FnOnce(&Path) -> anyhow::Result<()> {
+    let body = body.to_string();
+    move |repo: &Path| {
+        let pipelines_dir = repo.join(".pdo").join("pipelines");
+        std::fs::create_dir_all(&pipelines_dir)?;
+        std::fs::write(pipelines_dir.join("sbx-cycle.yaml"), PIPELINE_YAML)?;
+        let prompts_dir = pipelines_dir.join("sbx-cycle.prompts");
+        std::fs::create_dir_all(&prompts_dir)?;
+        std::fs::write(prompts_dir.join(format!("{NODE_ID}.md")), &body)?;
+        git_init_with_commit(repo)?;
+        Ok(())
+    }
+}
+
+/// Write a fake `docker` into a test-owned dir and return `(dir, docker_path, log)`.
+/// Logs every invocation's argv (one line per arg) to `argv.log`. Canned:
+/// `image inspect` → present (exit 0, no build); `container inspect` → ABSENT
+/// (exit 1 + sentinel), so `ensure_running` does `create` + `start`; every other
+/// subcommand exits 0. `sq` single-quotes the embedded log path.
+fn write_fake_docker() -> (TempDir, String, PathBuf) {
+    let dir = tempfile::tempdir().unwrap();
+    let bin = dir.path().join("fake-docker");
+    let log = dir.path().join("argv.log");
+    let sq = |s: &str| format!("'{}'", s.replace('\'', "'\\''"));
+    let script = format!(
+        "#!/usr/bin/env bash\n\
+         printf '%s\\n' \"$@\" >> {log}\n\
+         case \"$1\" in\n\
+         image) exit 0 ;;\n\
+         container) printf '%s' 'Error: No such container' >&2; exit 1 ;;\n\
+         *) exit 0 ;;\n\
+         esac\n",
+        log = sq(&log.display().to_string()),
+    );
+    std::fs::write(&bin, script).unwrap();
+    std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
+    (dir, bin.to_str().unwrap().to_string(), log)
+}
+
+fn log_text(log: &Path) -> String {
+    std::fs::read_to_string(log).unwrap_or_default()
+}
+
+/// `POST /runs` with an optional `sandbox` mode. Returns the new run id.
+async fn start_run(daemon: &TestDaemon, sandbox: Option<&str>) -> String {
+    let mut body = serde_json::json!({ "pipeline": "sbx-cycle", "input": "hello" });
+    if let Some(mode) = sandbox {
+        body["sandbox"] = serde_json::json!(mode);
+    }
+    let resp = reqwest::Client::new()
+        .post(format!("{}/runs", daemon.url()))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 201, "POST /runs should create the run");
+    resp.json::<serde_json::Value>().await.unwrap()["run_id"]
+        .as_str()
+        .unwrap()
+        .to_string()
+}
+
+async fn get_run(daemon: &TestDaemon, run_id: &str) -> serde_json::Value {
+    reqwest::get(format!("{}/runs/{run_id}", daemon.url()))
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap()
+}
+
+async fn wait_until<F>(mut pred: F) -> bool
+where
+    F: FnMut() -> bool,
+{
+    let deadline = Instant::now() + Duration::from_secs(30);
+    while Instant::now() < deadline {
+        if pred() {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    pred()
+}
+
+async fn wait_run_status(daemon: &TestDaemon, run_id: &str, expected: &str) -> serde_json::Value {
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let mut last = serde_json::Value::Null;
+    while Instant::now() < deadline {
+        let run = get_run(daemon, run_id).await;
+        if run["status"] == expected {
+            return run;
+        }
+        last = run;
+        tokio::time::sleep(Duration::from_millis(150)).await;
+    }
+    last
+}
+
+async fn wait_node_status(daemon: &TestDaemon, run_id: &str, expected: &str) -> serde_json::Value {
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let mut last = serde_json::Value::Null;
+    while Instant::now() < deadline {
+        let run = get_run(daemon, run_id).await;
+        if run["nodes"][NODE_ID]["status"] == expected {
+            return run;
+        }
+        last = run;
+        tokio::time::sleep(Duration::from_millis(150)).await;
+    }
+    last
+}
+
+async fn post_command(daemon: &TestDaemon, run_id: &str, body: serde_json::Value) -> reqwest::Response {
+    reqwest::Client::new()
+        .post(format!("{}/runs/{run_id}/commands", daemon.url()))
+        .json(&body)
+        .send()
+        .await
+        .unwrap()
+}
+
+/// Simulate the container writing the node's declared output to the shared mount
+/// (host path == container path). Written on the host before the simulated
+/// `pdo complete` so node-done's output validation passes.
+fn write_node_output(daemon: &TestDaemon, run_id: &str, content: &str) {
+    let out = daemon
+        .repo_root()
+        .join(".pdo/runs")
+        .join(run_id)
+        .join("worktree/.pdo/artifacts")
+        .join(NODE_ID)
+        .join("iter-1/out/output.md");
+    std::fs::create_dir_all(out.parent().unwrap()).unwrap();
+    std::fs::write(&out, content).unwrap();
+}
+
+async fn simulate_node_done(daemon: &TestDaemon, run_id: &str) {
+    let resp = reqwest::Client::new()
+        .post(format!("{}/runs/{run_id}/nodes/{NODE_ID}/done", daemon.url()))
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .unwrap();
+    assert!(
+        resp.status().is_success(),
+        "simulated pdo complete should succeed: {}",
+        resp.status()
+    );
+}
+
+// -- Test 1: pure run wires end-to-end ---------------------------------------
+
+#[tokio::test]
+async fn pure_run_prepares_wraps_and_completes() {
+    ensure_pdo_on_path();
+    let (_fake_dir, docker, log) = write_fake_docker();
+    let daemon = TestDaemon::spawn_with_docker_override(
+        seed("#!/usr/bin/env bash\ntrue\n"),
+        docker,
+    )
+    .await
+    .unwrap();
+
+    let run_id = start_run(&daemon, Some("pure")).await;
+
+    // (a) The mode is projected onto the Run from RunStarted.
+    let run = get_run(&daemon, &run_id).await;
+    assert_eq!(run["sandbox"], "pure", "run must project sandbox=pure: {run}");
+
+    // (b) Eager prep created + started the container (ensure_ready).
+    assert!(
+        wait_until(|| {
+            let t = log_text(&log);
+            t.contains("create") && t.contains("start")
+        })
+        .await,
+        "prep must create+start the container; log:\n{}",
+        log_text(&log)
+    );
+
+    // (c) The node's tail was wrapped: a `docker exec … pdo-sbx-<run>` launched it.
+    assert!(
+        wait_until(|| {
+            let t = log_text(&log);
+            t.contains("exec") && t.contains(&format!("pdo-sbx-{run_id}"))
+        })
+        .await,
+        "the node tail must run via `docker exec pdo-sbx-{run_id}`; log:\n{}",
+        log_text(&log)
+    );
+
+    // (d) The node reaches Running (NodeStarted appended after prep OK). The
+    // container would write its output to the shared mount then call `pdo
+    // complete`; we simulate both (write the output on the host = same path, then
+    // POST node-done) and assert the whole run reaches `completed`.
+    let run = wait_node_status(&daemon, &run_id, "running").await;
+    assert_eq!(run["nodes"][NODE_ID]["status"], "running", "run: {run}");
+    write_node_output(&daemon, &run_id, "hello from the sandbox\n");
+    simulate_node_done(&daemon, &run_id).await;
+    let run = wait_run_status(&daemon, &run_id, "completed").await;
+    assert_eq!(run["status"], "completed", "pure run must complete: {run}");
+}
+
+// -- Test 2: Docker unavailable → RunFailed, no host spawn -------------------
+
+#[tokio::test]
+async fn docker_unavailable_fails_run_with_no_host_spawn() {
+    ensure_pdo_on_path();
+    // A docker binary that does not exist: `ensure_image` hits ErrorKind::NotFound.
+    let daemon = TestDaemon::spawn_with_docker_override(
+        seed("#!/usr/bin/env bash\ntrue\n"),
+        "/nonexistent/pdo-fake-docker-xyz".to_string(),
+    )
+    .await
+    .unwrap();
+
+    let run_id = start_run(&daemon, Some("pure")).await;
+
+    let run = wait_run_status(&daemon, &run_id, "failed").await;
+    assert_eq!(
+        run["status"], "failed",
+        "a sandboxed run must fail loud when Docker is unavailable: {run}"
+    );
+    // ZERO host spawn: the node was never started (no host fallback).
+    assert!(
+        run["nodes"].get(NODE_ID).is_none()
+            || run["nodes"][NODE_ID]["status"] == serde_json::Value::Null,
+        "no NodeStarted — the sandboxed node must NOT fall back to a host spawn: {run}"
+    );
+}
+
+// -- Test 3: off run invokes no docker, completes on the host ----------------
+
+#[tokio::test]
+async fn off_run_never_invokes_docker() {
+    ensure_pdo_on_path();
+    let (_fake_dir, docker, log) = write_fake_docker();
+    // A real body that writes its declared output and self-signals `pdo complete`
+    // on the host (off path). The sentinel is untracked → passes the
+    // doc-only-effect clean guard.
+    let daemon = TestDaemon::spawn_with_docker_override(
+        seed(
+            "#!/usr/bin/env bash\nset -euo pipefail\n\
+             echo ok > OFF_SENTINEL\n\
+             printf 'off output\\n' > \"$PDO_OUTPUT_OUT\"\n",
+        ),
+        docker,
+    )
+    .await
+    .unwrap();
+
+    // No `sandbox` param → Off → host execution.
+    let run_id = start_run(&daemon, None).await;
+    let run = wait_run_status(&daemon, &run_id, "completed").await;
+    assert_eq!(run["status"], "completed", "off run must complete on host: {run}");
+    assert_eq!(run["sandbox"], "off", "default mode is off: {run}");
+
+    // Docker was NEVER invoked on the off parcours.
+    assert_eq!(
+        log_text(&log),
+        "",
+        "the `off` path must not invoke docker at all"
+    );
+}
+
+// -- Test 4: cleanup_run removes the container + purges staging ---------------
+
+#[tokio::test]
+async fn cleanup_run_removes_container_and_staging() {
+    ensure_pdo_on_path();
+    let (_fake_dir, docker, log) = write_fake_docker();
+    let daemon = TestDaemon::spawn_with_docker_override(
+        seed("#!/usr/bin/env bash\ntrue\n"),
+        docker,
+    )
+    .await
+    .unwrap();
+
+    let run_id = start_run(&daemon, Some("pure")).await;
+    wait_node_status(&daemon, &run_id, "running").await;
+    write_node_output(&daemon, &run_id, "done\n");
+    simulate_node_done(&daemon, &run_id).await;
+    wait_run_status(&daemon, &run_id, "completed").await;
+
+    // Staging landed under the tempdir home override (hermetic).
+    let staging = daemon
+        .repo_root()
+        .join(".pdo/sandbox")
+        .join(&run_id);
+    assert!(
+        wait_until(|| staging.exists()).await,
+        "staging dir should exist before cleanup: {staging:?}"
+    );
+
+    let resp = post_command(&daemon, &run_id, serde_json::json!({ "kind": "cleanup_run" })).await;
+    assert!(resp.status().is_success(), "cleanup_run should archive");
+    wait_run_status(&daemon, &run_id, "archived").await;
+
+    // The container was removed and the staging purged.
+    assert!(
+        log_text(&log).contains(&format!("pdo-sbx-{run_id}")) && log_text(&log).contains("rm"),
+        "cleanup must `docker rm -f pdo-sbx-{run_id}`; log:\n{}",
+        log_text(&log)
+    );
+    assert!(!staging.exists(), "cleanup must purge the staging dir: {staging:?}");
+}
+
+// -- Test 5: boot_recovery re-ensures a live sandboxed container -------------
+
+#[tokio::test]
+async fn boot_recovery_reensures_sandbox_container() {
+    ensure_pdo_on_path();
+    let (_fake_dir, docker, log) = write_fake_docker();
+    let daemon = TestDaemon::spawn_with_docker_override(
+        seed("#!/usr/bin/env bash\ntrue\n"),
+        docker,
+    )
+    .await
+    .unwrap();
+
+    let run_id = start_run(&daemon, Some("pure")).await;
+    let count_creates = |log: &Path| log_text(log).lines().filter(|l| *l == "create").count();
+
+    // Wait for the first prep to create+start (so the run is live), targeting
+    // this run's container.
+    assert!(
+        wait_until(|| {
+            let t = log_text(&log);
+            t.contains("create") && t.contains("start") && t.contains(&format!("pdo-sbx-{run_id}"))
+        })
+        .await,
+        "initial prep must create+start pdo-sbx-{run_id}; log:\n{}",
+        log_text(&log)
+    );
+    let creates_before = count_creates(&log);
+
+    // Boot recovery reconciles the live sandboxed run — re-ensures the container.
+    daemon.run_boot_recovery_tick().await;
+
+    assert!(
+        count_creates(&log) > creates_before,
+        "boot_recovery must re-ensure the container (a fresh create); log:\n{}",
+        log_text(&log)
+    );
+}
+
+// -- Test 6: killing a sandboxed node targets the container ------------------
+
+#[tokio::test]
+async fn kill_node_targets_the_container() {
+    ensure_pdo_on_path();
+    let (_fake_dir, docker, log) = write_fake_docker();
+    let daemon = TestDaemon::spawn_with_docker_override(
+        seed("#!/usr/bin/env bash\ntrue\n"),
+        docker,
+    )
+    .await
+    .unwrap();
+
+    let run_id = start_run(&daemon, Some("pure")).await;
+    wait_node_status(&daemon, &run_id, "running").await;
+
+    let resp = post_command(
+        &daemon,
+        &run_id,
+        serde_json::json!({ "kind": "kill_node", "node_id": NODE_ID, "iter": 1 }),
+    )
+    .await;
+    assert!(resp.status().is_success(), "kill_node should succeed");
+
+    let marker = format!("PDO_SBX_SESSION=pdo-{run_id}-{NODE_ID}-iter-1");
+    assert!(
+        wait_until(|| log_text(&log).contains(&marker)).await,
+        "kill must issue a targeted in-container exec carrying the session marker \
+         `{marker}`; log:\n{}",
+        log_text(&log)
+    );
+}

--- a/crates/pdo-daemon/tests/sandbox_tracer.rs
+++ b/crates/pdo-daemon/tests/sandbox_tracer.rs
@@ -73,7 +73,10 @@ fn git_init_with_commit(repo: &Path) -> anyhow::Result<()> {
     let run = |args: &[&str]| -> anyhow::Result<()> {
         let out = Command::new("git").args(args).current_dir(repo).output()?;
         if !out.status.success() {
-            anyhow::bail!("git {args:?} failed: {}", String::from_utf8_lossy(&out.stderr));
+            anyhow::bail!(
+                "git {args:?} failed: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
         }
         Ok(())
     };
@@ -200,7 +203,11 @@ async fn wait_node_status(daemon: &TestDaemon, run_id: &str, expected: &str) -> 
     last
 }
 
-async fn post_command(daemon: &TestDaemon, run_id: &str, body: serde_json::Value) -> reqwest::Response {
+async fn post_command(
+    daemon: &TestDaemon,
+    run_id: &str,
+    body: serde_json::Value,
+) -> reqwest::Response {
     reqwest::Client::new()
         .post(format!("{}/runs/{run_id}/commands", daemon.url()))
         .json(&body)
@@ -226,7 +233,10 @@ fn write_node_output(daemon: &TestDaemon, run_id: &str, content: &str) {
 
 async fn simulate_node_done(daemon: &TestDaemon, run_id: &str) {
     let resp = reqwest::Client::new()
-        .post(format!("{}/runs/{run_id}/nodes/{NODE_ID}/done", daemon.url()))
+        .post(format!(
+            "{}/runs/{run_id}/nodes/{NODE_ID}/done",
+            daemon.url()
+        ))
         .json(&serde_json::json!({}))
         .send()
         .await
@@ -244,18 +254,19 @@ async fn simulate_node_done(daemon: &TestDaemon, run_id: &str) {
 async fn pure_run_prepares_wraps_and_completes() {
     ensure_pdo_on_path();
     let (_fake_dir, docker, log) = write_fake_docker();
-    let daemon = TestDaemon::spawn_with_docker_override(
-        seed("#!/usr/bin/env bash\ntrue\n"),
-        docker,
-    )
-    .await
-    .unwrap();
+    let daemon =
+        TestDaemon::spawn_with_docker_override(seed("#!/usr/bin/env bash\ntrue\n"), docker)
+            .await
+            .unwrap();
 
     let run_id = start_run(&daemon, Some("pure")).await;
 
     // (a) The mode is projected onto the Run from RunStarted.
     let run = get_run(&daemon, &run_id).await;
-    assert_eq!(run["sandbox"], "pure", "run must project sandbox=pure: {run}");
+    assert_eq!(
+        run["sandbox"], "pure",
+        "run must project sandbox=pure: {run}"
+    );
 
     // (b) Eager prep created + started the container (ensure_ready).
     assert!(
@@ -342,7 +353,10 @@ async fn off_run_never_invokes_docker() {
     // No `sandbox` param → Off → host execution.
     let run_id = start_run(&daemon, None).await;
     let run = wait_run_status(&daemon, &run_id, "completed").await;
-    assert_eq!(run["status"], "completed", "off run must complete on host: {run}");
+    assert_eq!(
+        run["status"], "completed",
+        "off run must complete on host: {run}"
+    );
     assert_eq!(run["sandbox"], "off", "default mode is off: {run}");
 
     // Docker was NEVER invoked on the off parcours.
@@ -359,12 +373,10 @@ async fn off_run_never_invokes_docker() {
 async fn cleanup_run_removes_container_and_staging() {
     ensure_pdo_on_path();
     let (_fake_dir, docker, log) = write_fake_docker();
-    let daemon = TestDaemon::spawn_with_docker_override(
-        seed("#!/usr/bin/env bash\ntrue\n"),
-        docker,
-    )
-    .await
-    .unwrap();
+    let daemon =
+        TestDaemon::spawn_with_docker_override(seed("#!/usr/bin/env bash\ntrue\n"), docker)
+            .await
+            .unwrap();
 
     let run_id = start_run(&daemon, Some("pure")).await;
     wait_node_status(&daemon, &run_id, "running").await;
@@ -373,16 +385,18 @@ async fn cleanup_run_removes_container_and_staging() {
     wait_run_status(&daemon, &run_id, "completed").await;
 
     // Staging landed under the tempdir home override (hermetic).
-    let staging = daemon
-        .repo_root()
-        .join(".pdo/sandbox")
-        .join(&run_id);
+    let staging = daemon.repo_root().join(".pdo/sandbox").join(&run_id);
     assert!(
         wait_until(|| staging.exists()).await,
         "staging dir should exist before cleanup: {staging:?}"
     );
 
-    let resp = post_command(&daemon, &run_id, serde_json::json!({ "kind": "cleanup_run" })).await;
+    let resp = post_command(
+        &daemon,
+        &run_id,
+        serde_json::json!({ "kind": "cleanup_run" }),
+    )
+    .await;
     assert!(resp.status().is_success(), "cleanup_run should archive");
     wait_run_status(&daemon, &run_id, "archived").await;
 
@@ -392,7 +406,10 @@ async fn cleanup_run_removes_container_and_staging() {
         "cleanup must `docker rm -f pdo-sbx-{run_id}`; log:\n{}",
         log_text(&log)
     );
-    assert!(!staging.exists(), "cleanup must purge the staging dir: {staging:?}");
+    assert!(
+        !staging.exists(),
+        "cleanup must purge the staging dir: {staging:?}"
+    );
 }
 
 // -- Test 5: boot_recovery re-ensures a live sandboxed container -------------
@@ -401,12 +418,10 @@ async fn cleanup_run_removes_container_and_staging() {
 async fn boot_recovery_reensures_sandbox_container() {
     ensure_pdo_on_path();
     let (_fake_dir, docker, log) = write_fake_docker();
-    let daemon = TestDaemon::spawn_with_docker_override(
-        seed("#!/usr/bin/env bash\ntrue\n"),
-        docker,
-    )
-    .await
-    .unwrap();
+    let daemon =
+        TestDaemon::spawn_with_docker_override(seed("#!/usr/bin/env bash\ntrue\n"), docker)
+            .await
+            .unwrap();
 
     let run_id = start_run(&daemon, Some("pure")).await;
     let count_creates = |log: &Path| log_text(log).lines().filter(|l| *l == "create").count();
@@ -440,12 +455,10 @@ async fn boot_recovery_reensures_sandbox_container() {
 async fn kill_node_targets_the_container() {
     ensure_pdo_on_path();
     let (_fake_dir, docker, log) = write_fake_docker();
-    let daemon = TestDaemon::spawn_with_docker_override(
-        seed("#!/usr/bin/env bash\ntrue\n"),
-        docker,
-    )
-    .await
-    .unwrap();
+    let daemon =
+        TestDaemon::spawn_with_docker_override(seed("#!/usr/bin/env bash\ntrue\n"), docker)
+            .await
+            .unwrap();
 
     let run_id = start_run(&daemon, Some("pure")).await;
     wait_node_status(&daemon, &run_id, "running").await;

--- a/crates/pdo-daemon/tests/tmux_run_spawn.rs
+++ b/crates/pdo-daemon/tests/tmux_run_spawn.rs
@@ -94,6 +94,7 @@ fn build_tmux_script_uses_exec_bash_and_invokes_claude() {
         prompt_path,
         None,
         SessionTail::Agent { model: None },
+        None,
     );
 
     assert!(

--- a/docs/adr/0030-sandbox-execution-model.md
+++ b/docs/adr/0030-sandbox-execution-model.md
@@ -1,0 +1,125 @@
+# ADR-0030 — Modèle d'exécution de la Sandbox (conteneur par Run)
+
+> Statut : accepted (#407, tracer bullet du PRD #403). Vocabulaire : CONTEXT.md § « Sandbox ».
+> Consolide aussi la rationale du tag image content-hashé (#405) — pas d'ADR séparé.
+
+Un Run en mode `copy`/`pure` exécute **toutes ses tails** (nœuds agents, manager, merge-resolver,
+nœuds `script`, run-shell) dans un unique conteneur long-vécu `pdo-sbx-<run-id>` (`sleep infinity`,
+PID 1 = tini). Les guards de Trigger restent hôte (décision de fiançailles, pas de travail de Run).
+
+## Ce qu'on décide
+
+1. **Identity mounts.** Le repo cible est bind-monté rw à son **chemin absolu hôte** (un seul mount
+   couvre repo + tous les worktrees de nœuds sous `.pdo/runs/` + `.pdo/prompts`) ; le *staged Claude
+   home* → `$HOME/.claude`, son `.claude.json` sibling → `$HOME/.claude.json`, le binaire `pdo` hôte
+   → `/usr/local/bin/pdo:ro`. Le conteneur adopte l'**uid/gid hôte** (`--user` numérique). Résultat :
+   le chemin de travail est identique des deux côtés → le dirname encodé des transcripts matche
+   (pré-requis du merge-back, câblé en #408).
+
+2. **Staging par Run.** `~/.pdo/sandbox/<run-id>/` (jamais le vrai `~/.claude`), seedé par `prepare`
+   selon le mode, purgé par `teardown` au `cleanup_run`. En `pure`, la confiance (`hasTrustDialogAccepted`)
+   est pré-accordée à la **racine du repo** — l'ancêtre commun du worktree de pipeline ET de tous les
+   worktrees de nœuds, donc héritée par chaque cwd de session.
+
+3. **Réseau = host-gateway + `PDO_DAEMON_URL`.** Le conteneur joint le daemon hôte via
+   `--add-host host.docker.internal:host-gateway` + `PDO_DAEMON_URL=http://host.docker.internal:<port>`
+   posé **au create** (jamais re-passé à l'exec — un `-e` nu re-forwarderait le `localhost` hôte et
+   clobbererait la gateway). C'est ce qui permet au `pdo complete`/`fail`/`skip` in-container de
+   rappeler le daemon.
+
+4. **Préparation eager fail-fast.** Image + conteneur + staging sont garantis prêts **avant le premier
+   spawn** ; toute indisponibilité de Docker → `RunFailed` explicite. **Jamais de fallback hôte
+   silencieux** pour le travail d'un Run sandboxé. La prep tourne sur une tâche détachée (le
+   `docker build` du 1er run machine ne doit pas bloquer le 201 — cohérent ADR-0023) ; `ensure_ready`
+   étant bloquant, il vit dans un `spawn_blocking` (panic isolée en `JoinError` → `RunFailed`).
+
+5. **Wrapping au chokepoint unique.** Toutes les familles de tails funnel par `build_tmux_script`
+   (+ `build_resume_script` pour le `claude --continue`) : quand le Run est sandboxé, la tail est
+   enveloppée en `docker exec … pdo-sbx-<run> bash -lc '<tail>'`. Les exports d'env de base restent
+   côté **hôte** (inoffensifs) — d'où l'invariant `off` **byte-identique** quand le wrapping est absent.
+   Le catalogue d'env **dynamique** d'un nœud `script` (`PDO_ARTIFACTS_DIR`/`PDO_INPUT_*`/`PDO_OUTPUT_*`/
+   `PDO_VAR_*`) traverse l'exec en `-e KEY=VALUE` **explicites** (un `-e` nu ne forwarderait que la
+   valeur du shell hôte, que la sandbox n'exporte pas) — **jamais `PDO_DAEMON_URL`**.
+
+6. **Kill ciblé.** Un kill de session est doublé d'un `docker exec` séparé qui scanne `/proc/*/environ`
+   pour le marqueur de session (`PDO_SBX_SESSION` = le nom de session tmux) et `TERM`→`KILL` le seul
+   arbre porteur ; les sessions sœurs survivent (le client `docker exec` tué côté tmux ne tue pas le
+   process conteneur, reparenté sur PID 1).
+
+7. **Tag image adressé par contenu.** `pdo-sandbox:h-<hash>` où `<hash>` = SHA-256[..12] des octets
+   exacts du Dockerfile sur disque. Deux Dockerfiles identiques → même tag ; une édition → rebuild.
+   C'est l'identité qui rendra plus tard image tirée d'un registry et image buildée localement
+   interchangeables sous le même nom (#411). `.gitattributes` épingle `eol=lf` pour la reproductibilité.
+
+8. **Mode immuable par Run.** `off`|`copy`|`pure` est porté par `RunStarted`, projeté une fois, jamais
+   muté. Un Run reste sandboxé (ou non) toute sa vie : sinon `claude --continue` (resume) ne
+   retrouverait pas son transcript (indexé par chemin de travail). En #407 le mode n'arrive que par le
+   paramètre de l'API `POST /runs` ; les fires de Trigger passent `off` (précédence des sources #410).
+
+## Pourquoi (le trou d'auth assumé v1)
+
+Le daemon expose une API HTTP **non authentifiée**, liée à `0.0.0.0` (lib.rs, #260 CLOSED — choix
+délibéré d'accès LAN). N'importe quel code dans le conteneur (y compris un agent prompt-injecté) peut
+appeler **tout** endpoint via la gateway, pas seulement sa propre complétion.
+
+On l'accepte pour v1 **parce que ce n'est pas net-new** : un nœud hôte **non** sandboxé tourne déjà
+en `claude --dangerously-skip-permissions` avec exactement le même accès non authentifié au daemon
+(`PDO_DAEMON_URL=http://localhost:<port>`). Le conteneur n'est qu'un client de plus sur un socket
+déjà atteignable depuis tout le LAN — un **sous-ensemble strict** de l'exposition que #260 assume, pas
+une extension.
+
+On **ne prétend donc pas** que la sandbox est une frontière de sécurité réseau/creds en v1 : elle
+tourne en uid/gid hôte, bind-monte le repo rw à son chemin hôte, et stage de vraies credentials
+Claude (`.credentials.json`) avec réseau sortant ouvert. Sa **seule** valeur sécurité v1 est un
+**blast radius filesystem réduit par défaut** (pas d'accès ambiant au reste de `$HOME`, aux autres
+repos, à `~/.ssh`) + le **containment de l'arbre de process** (kill ciblé). Utile, mais inutile face
+à un adversaire déterminé ou injecté.
+
+Fermer le trou (auth de l'API daemon, ou tokens de complétion scopés par Run) est **différé au
+chantier d'auth du daemon, lié à #260**. D'ici là, un Run sandboxé n'est pas plus fiable vis-à-vis de
+l'hôte qu'un Run hôte.
+
+## Alternatives écartées
+
+- **`docker run -d` par session** (conteneur éphémère par nœud) : rejeté — un conteneur par-Run
+  long-vécu rend kill et destruction ciblés, partage les mounts, et amortit le coût de démarrage.
+- **Fallback hôte si Docker absent** : rejeté frontalement (#403 US-16) — masquerait l'isolation
+  demandée ; fail-fast `RunFailed` à la place.
+- **`--restart unless-stopped`** : rejeté — PDO possède le cycle de vie ; ressusciterait des
+  conteneurs que PDO croit finis.
+- **Envelopper `wrap_with_env` entier dans le `docker exec`** (au lieu d'`-e` explicites) : rejeté —
+  ré-exporterait `PDO_DAEMON_URL=localhost` dans le conteneur et casserait la gateway.
+
+## Limites acceptées
+
+- **Observabilité en attente de #408.** `merge_back` n'est PAS câblé en #407 : coût (`run_cost`) et
+  détection stale/AutoComplete (`stale_detector`) sont **aveugles** pour un Run sandboxé (ils lisent
+  `~/.claude/projects/`, vide) ; les transcripts sont purgés au `cleanup_run`. Trou
+  d'**observabilité**, pas de correction : **session-died** (la détection critique pour la liveness)
+  est transcript-indépendante et reste vivante. #408 referme (merge_back + seam `transcripts_root`).
+- **uid hôte ≠ 1000.** `sudo` (getpwuid avant NOPASSWD) et `claude` (`os.userInfo()`) peuvent casser
+  faute d'entrée `/etc/passwd` ; ubuntu:24.04 livre `ubuntu`=1000 → le cas laptop courant résout.
+  Injection `/etc/passwd`+`/etc/group` différée à une issue de suivi (ne PAS éditer le Dockerfile,
+  content-hashé).
+- **run-shell in-container** peut être *moins* fidèle pour l'inspection statique (les mounts identité
+  donnent déjà la parité fichiers) et perd les outils `sudo`-installés éphémères. On garde le
+  wrapping pour l'uniformité + zéro divergence hôte silencieuse (`ensure_running`-or-fail).
+
+## Relations
+
+- **ADR-0004** (stratégie de test) : golden des tails wrappées (unit) + layer-3 (Docker indispo →
+  RunFailed, off inchangé, cleanup/boot/kill) via les seams `docker_cmd_override` +
+  `sandbox_home_override` (per-daemon, #181) — jamais d'`std::env` global ni de vrai Docker en CI.
+- **ADR-0009** (3 couches) : le wrapping vit au chokepoint `build_tmux_script` ; `ensure_ready` est un
+  effet atomique qui ne réentre jamais le scheduler.
+- **ADR-0012** (autonomie gagnée) : la sandbox réduit le blast radius par défaut du travail autonome ;
+  le cap global reste la primitive de sûreté.
+- **ADR-0015** (précédence config) : la source du mode (run → trigger → `default_sandbox`) est #410 ;
+  #407 n'accepte que le param API.
+- **ADR-0020 / ADR-0021** (archivage / run-shell) : le conteneur vit de la création au `cleanup_run`
+  (= archive), coextensif à la fenêtre d'éligibilité du run-shell ; après un reboot hôte,
+  `open_run_shell` ressuscite le conteneur (`ensure_running`-or-fail), car `boot_recovery` saute les
+  Runs terminaux.
+- **ADR-0023** (advance détaché) : la prep eager suit la même forme détachée + panic-isolée →
+  `RunFailed`.
+- **#260** : trou d'auth du daemon ; fermeture de la sandbox liée à ce chantier.


### PR DESCRIPTION
Closes #407

## Sandbox D — tracer bullet (run pure end-to-end via API)

Final slice of the #403 sandbox PRD: wires the sandbox tracer bullet into run-advance and lands ADR-0030 (sandbox execution model).

### Scope
- `sandbox_run.rs` — run-advance wiring for the sandbox path (build tmux script + resume; eager prep detached → `RunFailed`; `off` byte-identical passthrough; `run-shell` ensure-or-fail; static `exec_prefix` drops script env → explicit `-e K=V`).
- ADR-0030 documents the execution model; notes the pre-existing daemon auth gap (#260) with ~0 widening.
- `docker_cmd_override` test seam for hermetic layer-3 coverage.

### Validation (integration slice — no version bump)
CI-equivalent gate run on `+stable` (matching `dtolnay/rust-toolchain@stable`):

| Step | Result |
|------|--------|
| `cargo check --workspace --all-targets` | PASS |
| `cargo test --workspace` | PASS — 1536 passed / 0 failed |
| `cargo clippy --workspace --all-targets -- -D warnings` | PASS — 0 lints |
| `cargo fmt --all --check` | PASS |
| `bash tests/smoke.sh` | PASS |

The 6 layer-3 tests in `tests/sandbox_tracer.rs` pass (happy-path, docker-unavailable fail-fast with zero host spawn, `off` path leaves docker's command log empty, cleanup, targeted `/proc` kill). All use a fake docker binary + hermetic tempdir home override — no prod daemon or real containers touched.

Targets the `integration/prd-403-sandbox` branch; version bump/release deferred to end of PRD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
