### PR TITLE
feat(#408): sandbox observability — transcripts_root seam + merge_back + resume fix

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -821,8 +821,9 @@ La complétion est signalée **depuis l'UI**, par un bouton "Mark complete" sur 
 > staging fs (#404) + **fourniture de l'image** (#405, *Image (fourniture)*) + **exécution /
 > conteneur** (#406, *Exécution (conteneur)*) + **câblage run-advance** (#407 : prep eager fail-fast,
 > wrapping des tails au chokepoint, kill/cleanup/boot/run-shell) fixé par **ADR-0030** (modèle
-> d'exécution : réseau/uid, trou d'auth assumé v1 lié à #260). Reste **différé** : `merge_back` +
-> observabilité (#408), précédence des sources du mode (#410), fourniture par registry (#411).
+> d'exécution : réseau/uid, trou d'auth assumé v1 lié à #260) + **observabilité** (#408 : `merge_back`
+> câblé à la transition terminale + `cleanup_run`, seam `transcripts_root` pour coût/stale). Reste
+> **différé** : précédence des sources du mode (#410), fourniture par registry (#411).
 
 **Sandbox** :
 Propriété **par Run**, **immuable après création**, portée par l'événement de création (projetée
@@ -862,9 +863,19 @@ de sous-agents `<uuid>/subagents/*.jsonl`), sous le **même dirname encodé** (c
 conteneur, garanti par les identity mounts, ADR-0030). **Idempotent** : copie ssi le fichier hôte est
 absent ou plus court (transcripts append-only) ; ne réécrit jamais un fichier hôte. Aucune autre
 écriture vers l'hôte. **Jeté délibérément (v1)** : settings, statsig, todos, `history.jsonl`,
-shell-snapshots — tout sauf les transcripts (#403 US-29). **Câblage dans le run-advance = #408**
-(pas #407) : d'ici là un Run sandboxé est aveugle pour le coût/stale, trou d'observabilité assumé
-(ADR-0030). _Éviter_ : « sync », « flush », « commit ».
+shell-snapshots — tout sauf les transcripts (#403 US-29). **Câblé dans le run-advance (#408)** : à la
+transition terminale (chokepoint `append_event`, tâche détachée) **et** à `cleanup_run` (avant
+`teardown`, synchrone), via le seam `transcripts_root` qui rend coût/stale sandbox-conscients. Double
+merge = état identique (idempotence). _Éviter_ : « sync », « flush », « commit ».
+
+**`transcripts_root(run_id)` (seam d'observabilité)** :
+La racine `projects/` que le coût (`run_cost`) et la stale-detection (`stale_detector`) lisent pour un
+Run. `off` → `~/.claude/projects/`. Sandboxé **vivant** → le staging
+(`~/.pdo/sandbox/<run-id>/claude-home/projects/`, transcripts en direct via l'identity mount) ;
+**après `cleanup_run`** → `~/.claude/projects/` (où `merge_back` a flushé). Dispatch keyé sur
+l'**existence du staging dir**, pas le statut terminal du Run (reste correct même si le merge terminal
+best-effort a échoué). L'encodage du cwd reste la source unique de vérité (`encode_working_dir`,
+#373) — le seam ne fait que substituer la base. _Éviter_ : « home », « projects dir » seul.
 
 **`teardown(run_id)`** :
 Purge le *staging dir* du Run ; sans effet s'il est déjà absent. _Éviter_ : « cleanup » (réservé à
@@ -964,8 +975,12 @@ absent (idempotent). C'est **le** verbe « destroy / destruction » réservé pa
   wrapping des tails au chokepoint `build_tmux_script` (`off` byte-identique), kill ciblé dans
   `reap_node_session`/`kill_node`/`restart_node`, `remove`+`teardown` au `cleanup_run`,
   `ensure_running` à `boot_recovery` (Run live) et `open_run_shell` (ressuscite-ou-échoue).
-- **Différé** : `merge_back` **dans le run-advance** + observabilité coût/stale (seam
-  `transcripts_root`) (#408) ; injection `/etc/passwd`+`/etc/group` pour uid hôte ≠ 1000 (sudo +
+- **Câblé (#408, ADR-0030)** : `merge_back` dans le run-advance — transition terminale (chokepoint
+  `append_event`, détaché) **et** `cleanup_run` (avant `teardown`, synchrone) ; observabilité coût
+  (`run_cost`) + stale (`stale_detector`) via le seam `transcripts_root` (staging si Run sandboxé
+  vivant, `~/.claude/projects/` sinon) ; garde `ensure_ready`-ou-échec ajouté à `resume_run` (re-arme
+  le conteneur après reboot hôte).
+- **Différé** : injection `/etc/passwd`+`/etc/group` pour uid hôte ≠ 1000 (sudo +
   Node `os.userInfo()`) (issue de suivi) ; précédence des sources du mode (run → trigger →
   `default_sandbox`, pattern ADR-0015) (#410) ; **fourniture par registry** (pull GHCR +
   `image_source`) (#411).

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -6512,8 +6512,8 @@ async fn get_run(
             // #408: read the cost transcripts from the sandboxed Run's staged home
             // while it is live, `~/.claude/projects/` otherwise. HOME absent →
             // degrade to the host root (never fail a read).
-            let (home_root, sandbox_root) = sandbox_run::sandbox_home_roots(&state)
-                .unwrap_or_else(|_| {
+            let (home_root, sandbox_root) =
+                sandbox_run::sandbox_home_roots(&state).unwrap_or_else(|_| {
                     let home = std::path::PathBuf::from(std::env::var("HOME").unwrap_or_default());
                     let sandbox = home.join(".pdo").join("sandbox");
                     (home, sandbox)
@@ -7038,7 +7038,9 @@ async fn run_stale_detection(state: &AppState) {
     let (home_root, sandbox_root) = match sandbox_run::sandbox_home_roots(state) {
         Ok(r) => r,
         Err(e) => {
-            warn!("stale sweep: cannot resolve sandbox home roots, treating all runs as host ({e:#})");
+            warn!(
+                "stale sweep: cannot resolve sandbox home roots, treating all runs as host ({e:#})"
+            );
             let home = std::path::PathBuf::from(std::env::var("HOME").unwrap_or_default());
             let sandbox = home.join(".pdo").join("sandbox");
             (home, sandbox)

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -3074,8 +3074,27 @@ pub(crate) async fn append_event_with(
 /// Thin `AppState` wrapper over [`append_event_with`] — the name every
 /// in-process caller already uses. The db-only core exists so `spawn_node`
 /// (#356) can append through a narrow `SpawnDeps` without the full `AppState`.
+///
+/// #408: this wrapper is also the single chokepoint for the terminal
+/// `merge_back` — the ~14 emitters of the 4 terminal Run events (§3.B of the
+/// plan) all funnel through here, and only here is `&AppState` available. After a
+/// SUCCESSFUL append of a terminal event, a sandboxed Run's staged transcripts
+/// are merged into `~/.claude/projects/` so cost + stale-detection see them once
+/// the staging is eventually purged. [`sandbox_run::merge_back_best_effort`] fires
+/// the walk on a detached task, so it never adds latency or a failure mode to the
+/// terminal transition (ADR-0023); it is idempotent, so a double-fire is safe.
 async fn append_event(state: &AppState, event: &event_log::Event) -> Result<()> {
-    append_event_with(&state.db, &state.event_tx, event).await
+    append_event_with(&state.db, &state.event_tx, event).await?;
+    if matches!(
+        event.kind,
+        event_log::EventKind::RunCompleted
+            | event_log::EventKind::RunFailed
+            | event_log::EventKind::RunSkipped
+            | event_log::EventKind::RunHalted
+    ) {
+        sandbox_run::merge_back_best_effort(state, &event.run_id).await;
+    }
+    Ok(())
 }
 
 /// #328 / ADR-0024: check whether a run_id has been tombstoned by forget.
@@ -6490,7 +6509,22 @@ async fn get_run(
     match event_log::project(&events) {
         Some(mut run_state) => {
             let repo_root = effective_repo_root(&state, &run_state);
-            augment_run_state_from_disk(&mut run_state, &repo_root);
+            // #408: read the cost transcripts from the sandboxed Run's staged home
+            // while it is live, `~/.claude/projects/` otherwise. HOME absent →
+            // degrade to the host root (never fail a read).
+            let (home_root, sandbox_root) = sandbox_run::sandbox_home_roots(&state)
+                .unwrap_or_else(|_| {
+                    let home = std::path::PathBuf::from(std::env::var("HOME").unwrap_or_default());
+                    let sandbox = home.join(".pdo").join("sandbox");
+                    (home, sandbox)
+                });
+            let projects_root = sandbox_run::transcripts_root(
+                run_state.sandbox,
+                &run_state.run_id,
+                &home_root,
+                &sandbox_root,
+            );
+            augment_run_state_from_disk(&mut run_state, &projects_root, &repo_root);
             Json(run_state).into_response()
         }
         None => (StatusCode::NOT_FOUND, "run not found").into_response(),
@@ -6916,6 +6950,12 @@ struct SweepNodeProbes<'a> {
     socket: &'a str,
     session_name: &'a str,
     working_dir: &'a Path,
+    /// The Claude Code `projects/` root to read this node's transcript from (#408
+    /// observability seam): the sandboxed Run's staged home while it is live,
+    /// `~/.claude/projects/` otherwise. Resolved once per Run in the sweep via
+    /// [`sandbox_run::transcripts_root`]; the encoded cwd segment is still derived
+    /// from `working_dir` (the single source of truth), never re-encoded here.
+    projects_root: &'a Path,
     pipeline_path: &'a Path,
     artifacts_dir: &'a Path,
     run_id: &'a str,
@@ -6930,7 +6970,7 @@ impl stale_detector::NodeProbes for SweepNodeProbes<'_> {
     }
 
     fn jsonl_mtime(&self) -> Option<std::time::SystemTime> {
-        stale_detector::find_session_jsonl(self.working_dir)
+        stale_detector::find_session_jsonl(self.projects_root, self.working_dir)
             .and_then(|p| std::fs::metadata(&p).ok())
             .and_then(|m| m.modified().ok())
     }
@@ -6991,6 +7031,20 @@ async fn run_stale_detection(state: &AppState) {
     let socket = state.tmux_socket();
     let now = std::time::SystemTime::now();
 
+    // #408: resolve the sandbox home roots once for the whole sweep. HOME absent
+    // must NOT abort the sweep (unlike `context_from_state` at create, which
+    // fails loud) — degrade to the host `~/.claude` root and log. `off` runs
+    // ignore `sandbox_root` anyway (the seam returns the host root for them).
+    let (home_root, sandbox_root) = match sandbox_run::sandbox_home_roots(state) {
+        Ok(r) => r,
+        Err(e) => {
+            warn!("stale sweep: cannot resolve sandbox home roots, treating all runs as host ({e:#})");
+            let home = std::path::PathBuf::from(std::env::var("HOME").unwrap_or_default());
+            let sandbox = home.join(".pdo").join("sandbox");
+            (home, sandbox)
+        }
+    };
+
     // #290 (Slice 1, observability only): count of live nodes found stuck on
     // Claude Code's usage-limit menu across this whole sweep. Recomputed each
     // sweep (leak-free — a node that leaves the live set drops out naturally);
@@ -7018,6 +7072,13 @@ async fn run_stale_detection(state: &AppState) {
         let artifacts_dir = worktree_dir.join(".pdo").join("artifacts");
         let pipeline_path = resolve_run_pipeline_path(&repo_root, run_id, &run_state.pipeline_name);
 
+        // #408: the Claude Code `projects/` root this Run's transcripts live under
+        // — the staged home while a sandboxed Run is live, `~/.claude/projects/`
+        // otherwise. The per-node encoded dirname is still derived from the
+        // node's `working_dir` inside the probe; the seam only swaps the base.
+        let projects_root =
+            sandbox_run::transcripts_root(run_state.sandbox, run_id, &home_root, &sandbox_root);
+
         let running = stale_detector::running_nodes(&run_state);
         for (node_id, iter) in &running {
             let node_type = find_node_type(&run_state, node_id);
@@ -7039,6 +7100,7 @@ async fn run_stale_detection(state: &AppState) {
                 socket: &socket,
                 session_name: &session_name,
                 working_dir: &working_dir,
+                projects_root: &projects_root,
                 pipeline_path: &pipeline_path,
                 artifacts_dir: &artifacts_dir,
                 run_id,
@@ -9205,6 +9267,34 @@ async fn run_command(
                 &tmux_session_manager::shell_session_name(&run_id),
             );
 
+            // #408 D5: resuming a sandboxed Run must re-arm its container before
+            // the scheduler `docker exec`s into it. Containers are created without
+            // `--restart` and `boot_recovery` skips terminal Runs, so after a host
+            // reboot the container is down — reviving a terminal sandboxed Run
+            // would otherwise spawn into a dead container ("failed to spawn tmux
+            // session"). Resurrect it (via `spawn_blocking`, `ensure_ready` may
+            // `docker build`) or fail EXPLICITLY — never a silent host fallback.
+            // Mirrors the run-shell guard (#407 D11).
+            if !run_state.sandbox.is_off() {
+                let prep = match sandbox_run::context_from_state(&state, &run_state) {
+                    Ok(ctx) => tokio::task::spawn_blocking(move || sandbox_run::ensure_ready(&ctx))
+                        .await
+                        .unwrap_or_else(|je| {
+                            Err(anyhow::anyhow!("sandbox ensure_ready panicked: {je}"))
+                        }),
+                    Err(e) => Err(e),
+                };
+                if let Err(e) = prep {
+                    return (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(serde_json::json!({
+                            "error": format!("sandbox container unavailable: {e:#}")
+                        })),
+                    )
+                        .into_response();
+                }
+            }
+
             let summary = re_evaluate_after_command(&state, &run_id).await;
 
             info!("resume_run: run {run_id}");
@@ -10375,20 +10465,24 @@ async fn cleanup_run(state: &AppState, run_id: &str) -> Response {
     let shell_session = tmux_session_manager::shell_session_name(run_id);
     tmux_session_manager::kill(&socket, &shell_session);
 
-    // #407 D9: destroy the sandbox container + purge its staging BEFORE any
-    // `git worktree remove` below — the container bind-mounts the repo, so a live
-    // worktree removal under it would hit a busy mount. Best-effort. `merge_back`
-    // is intentionally NOT wired here (→ observability slice #408). No-op for
-    // `off`.
+    // #407 D9 + #408 D-4: merge the transcripts back, then destroy the sandbox
+    // container + purge its staging, all BEFORE any `git worktree remove` below —
+    // the container bind-mounts the repo, so a live worktree removal under it
+    // would hit a busy mount. The tmux sessions were killed just above, so the
+    // staging is quiescent for the merge. `cleanup` merges first ("harvest before
+    // purge"), capturing any post-terminal growth (resume, late subagent flushes)
+    // the detached terminal merge missed; idempotent, so the double-merge is safe.
+    // Best-effort. No-op for `off`.
     if !run_state.sandbox.is_off() {
         match sandbox_run::sandbox_home_roots(state) {
-            Ok((_, sandbox_root)) => sandbox_run::cleanup(
+            Ok((home_root, sandbox_root)) => sandbox_run::cleanup(
                 state.docker_cmd_override.as_deref().unwrap_or("docker"),
+                &home_root,
                 &sandbox_root,
                 run_id,
             ),
             Err(e) => {
-                warn!("cleanup_run: cannot purge sandbox staging for run {run_id}: {e:#}")
+                warn!("cleanup_run: cannot merge/purge sandbox staging for run {run_id}: {e:#}")
             }
         }
     }
@@ -11010,14 +11104,20 @@ fn compute_run_loc(repo_root: &std::path::Path, run_id: &str) -> Option<event_lo
     Some(parse_numstat(&stdout))
 }
 
-fn augment_run_state_from_disk(run_state: &mut event_log::RunState, repo_root: &std::path::Path) {
+fn augment_run_state_from_disk(
+    run_state: &mut event_log::RunState,
+    projects_root: &std::path::Path,
+    repo_root: &std::path::Path,
+) {
     // LOC is independent of the run YAML: the run branch lives in `repo_root`,
     // not the run dir, so a missing/unparseable YAML must not suppress an
     // otherwise-valid LOC. Compute it before the YAML early-return below.
     run_state.loc = compute_run_loc(repo_root, &run_state.run_id);
     // Estimated cost (#272), likewise independent of the run YAML: it reads the
-    // Claude Code transcripts under `~/.claude/projects/`, not the run dir.
-    run_state.cost = run_cost::compute_run_cost(repo_root, &run_state.run_id);
+    // Claude Code transcripts under `projects_root` (the #408 seam — the staged
+    // home while a sandboxed Run is live, `~/.claude/projects/` otherwise), not
+    // the run dir. `repo_root` builds the run-id dir prefix, not the read root.
+    run_state.cost = run_cost::compute_run_cost(projects_root, repo_root, &run_state.run_id);
 
     let yaml_path = run_scoped_pipeline_path(repo_root, &run_state.run_id);
     let Ok(yaml) = std::fs::read_to_string(&yaml_path) else {
@@ -13557,6 +13657,85 @@ mod tests {
         );
     }
 
+    /// #408 (F4): `cleanup_run` merges a sandboxed Run's staged transcripts into
+    /// `~/.claude/projects/` (recursively — subagent jsonl included, non-jsonl
+    /// siblings excluded) BEFORE the staging is purged, via the real route. This
+    /// is the tmux-independent proof that `cleanup_run` → `sandbox_run::cleanup` →
+    /// `merge_back` is wired; the synchronous cleanup merge means no waiting.
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn cleanup_run_merges_sandbox_transcripts_to_host() {
+        let home = FakeHome::new();
+        let tmp = tempfile::tempdir().unwrap();
+        let run_id = "cleanup-merge";
+        // `docker rm -f` → `true` (no-op), so no real docker is ever spawned.
+        let state = test_state_with_dir_and_docker(tmp.path(), Some("true".to_string())).await;
+
+        // Seed a sandboxed (`copy`) run: RunStarted projects `sandbox=copy`.
+        append_event_with(
+            &state.db,
+            &state.event_tx,
+            &event_log::Event {
+                id: None,
+                run_id: run_id.into(),
+                ts: event_log::now_iso(),
+                kind: event_log::EventKind::RunStarted,
+                node_id: None,
+                iter: None,
+                payload: Some(serde_json::json!({
+                    "pipeline_name": "sbx-obs",
+                    "input": "x",
+                    "sandbox": "copy",
+                })),
+            },
+        )
+        .await
+        .unwrap();
+
+        // Plant a staged transcript tree: a top-level jsonl, a nested subagent
+        // jsonl (locks the recursion), and a non-jsonl sibling that must NOT land.
+        let staged_projects = home
+            .path()
+            .join(".pdo/sandbox")
+            .join(run_id)
+            .join("claude-home/projects");
+        let enc = "-some-enc-worktree";
+        let proj = staged_projects.join(enc);
+        std::fs::create_dir_all(proj.join("uuid-1/subagents")).unwrap();
+        std::fs::write(proj.join("main.jsonl"), "{\"line\":1}\n").unwrap();
+        std::fs::write(proj.join("uuid-1/subagents/side.jsonl"), "{\"line\":2}\n").unwrap();
+        std::fs::write(proj.join("notes.txt"), "not a transcript").unwrap();
+
+        assert_eq!(post_cleanup_run(&state, run_id).await, StatusCode::OK);
+
+        // Merged to the host projects dir, recursively, jsonl-only.
+        let host = home.path().join(".claude/projects").join(enc);
+        assert_eq!(
+            std::fs::read_to_string(host.join("main.jsonl")).unwrap(),
+            "{\"line\":1}\n",
+            "top-level transcript must be merged verbatim"
+        );
+        assert_eq!(
+            std::fs::read_to_string(host.join("uuid-1/subagents/side.jsonl")).unwrap(),
+            "{\"line\":2}\n",
+            "nested subagent transcript must be merged (recursion)"
+        );
+        assert!(
+            !host.join("notes.txt").exists(),
+            "non-jsonl siblings must NOT be merged"
+        );
+        // Staging purged after the merge; run Archived.
+        assert!(
+            !home.path().join(".pdo/sandbox").join(run_id).exists(),
+            "cleanup must purge the staging after merging"
+        );
+        let events = load_events(&state.db, run_id).await.unwrap();
+        assert_eq!(
+            event_log::project(&events).unwrap().status,
+            event_log::RunStatus::Archived
+        );
+    }
+
     /// R2: after archive (worktree gone), `GET /nodes/<n>/io` serves the correct
     /// payload from the durable store — the shape matches the live-run contract.
     #[tokio::test]
@@ -15249,6 +15428,16 @@ mod tests {
     }
 
     async fn test_state_with_dir(dir: &std::path::Path) -> Arc<AppState> {
+        test_state_with_dir_and_docker(dir, None).await
+    }
+
+    /// Like [`test_state_with_dir`] but with an explicit `docker_cmd_override` —
+    /// e.g. `Some("true")` so a sandboxed `cleanup_run`'s `docker rm -f` is a
+    /// no-op (never spawns the real `docker`, whether or not it is installed).
+    async fn test_state_with_dir_and_docker(
+        dir: &std::path::Path,
+        docker_cmd_override: Option<String>,
+    ) -> Arc<AppState> {
         let db = sqlx::sqlite::SqlitePoolOptions::new()
             .max_connections(1)
             .connect("sqlite::memory:")
@@ -15272,7 +15461,7 @@ mod tests {
             // spawn path, the node session runs `true` and exits immediately —
             // never real claude, never a lingering session (#181).
             tmux_cmd_override: Some("exec true".to_string()),
-            docker_cmd_override: None,
+            docker_cmd_override,
             sandbox_home_override: None,
             last_trigger_tick_ms: Arc::new(std::sync::atomic::AtomicI64::new(0)),
             panic_on_trigger_name: None,

--- a/crates/pdo-daemon/src/run_cost.rs
+++ b/crates/pdo-daemon/src/run_cost.rs
@@ -1,14 +1,20 @@
 //! Estimated USD cost of a Run (#272), derived on read from the per-message
 //! token `usage` recorded in each session's Claude Code transcript
-//! (`~/.claude/projects/<encoded-cwd>/*.jsonl`) × a hardcoded public price table.
+//! (`<projects_root>/<encoded-cwd>/*.jsonl`) × a hardcoded public price table.
+//!
+//! The `projects_root` is injected by the caller (the #408 observability seam,
+//! [`crate::sandbox_run::transcripts_root`]): `~/.claude/projects/` for an
+//! `off`/archived run, the staged home while a sandboxed run is live. This
+//! module never reads `$HOME` — one root in, path-math + `std::fs` out.
 //!
 //! This is an **estimate, not an invoice**: it uses public list prices (no
 //! enterprise discount), and any model absent from the table contributes $0 and
 //! flips the `partial` flag (lower-bound signalling). It mirrors `LocStat`'s
 //! "derived on read, never persisted" contract (see [`crate::event_log::CostStat`]),
 //! and happens to be *more* durable than LOC: archival deletes the run branch
-//! (so LOC → "—") but leaves `~/.claude/projects/` intact, so an archived run
-//! still shows its cost.
+//! (so LOC → "—") but leaves `~/.claude/projects/` intact (merge_back flushed a
+//! sandboxed run's transcripts there at cleanup), so an archived run still shows
+//! its cost.
 //!
 //! ## Correctness notes (each verified against real transcripts, ADR-0022)
 //! - **Dedup is mandatory.** Claude Code replays assistant messages on
@@ -234,18 +240,20 @@ fn collect_jsonl_recursive(dir: &Path, out: &mut Vec<Line>) {
 /// merge-resolver, and their subagents). `None` when no such dir exists (UI
 /// "—"); `Some { usd: 0.0, .. }` when dirs exist but carry no priced tokens.
 ///
-/// `repo_root` must be the run's **effective** repo root (honours `target_repo`)
-/// — pass the value the caller already resolved via `effective_repo_root`.
-pub fn compute_run_cost(repo_root: &Path, run_id: &str) -> Option<CostStat> {
-    let home = std::env::var("HOME").ok()?;
+/// `projects_root` is the Claude Code `projects/` root to read (the #408
+/// observability seam — `~/.claude/projects/` for an `off`/archived run, the
+/// staged home for a live sandboxed run). `repo_root` must be the run's
+/// **effective** repo root (honours `target_repo`) — pass the value the caller
+/// already resolved via `effective_repo_root`; it builds the run-id dir prefix,
+/// NOT the read root.
+pub fn compute_run_cost(projects_root: &Path, repo_root: &Path, run_id: &str) -> Option<CostStat> {
     let run_dir = repo_root.join(".pdo").join("runs").join(run_id);
     // Trailing '-' anchors the run_id: a run whose id is a lexical prefix of
     // another can't leak its sessions in (after run_id comes `-nodes`/`-worktree`).
     let prefix = format!("{}-", cc_project_dirname(&run_dir));
-    let projects = Path::new(&home).join(".claude").join("projects");
     let mut lines = Vec::new();
     let mut found = false;
-    for entry in std::fs::read_dir(&projects).ok()?.flatten() {
+    for entry in std::fs::read_dir(projects_root).ok()?.flatten() {
         if !entry.file_name().to_string_lossy().starts_with(&prefix) {
             continue;
         }
@@ -318,14 +326,10 @@ fn max_mtime_recursive(dir: &Path, max_ms: &mut i64) {
 /// `0` when no transcript dir/file exists yet (so a later write bumps the key and
 /// invalidates the memo). A pure `stat` walk: no file contents are read, so it is
 /// far cheaper than the aggregate it guards.
-pub fn max_transcript_mtime_millis(repo_root: &Path, run_id: &str) -> i64 {
-    let Ok(home) = std::env::var("HOME") else {
-        return 0;
-    };
+pub fn max_transcript_mtime_millis(projects_root: &Path, repo_root: &Path, run_id: &str) -> i64 {
     let run_dir = repo_root.join(".pdo").join("runs").join(run_id);
     let prefix = format!("{}-", cc_project_dirname(&run_dir));
-    let projects = Path::new(&home).join(".claude").join("projects");
-    let Ok(entries) = std::fs::read_dir(&projects) else {
+    let Ok(entries) = std::fs::read_dir(projects_root) else {
         return 0;
     };
     let mut max_ms: i64 = 0;
@@ -343,10 +347,16 @@ pub fn max_transcript_mtime_millis(repo_root: &Path, run_id: &str) -> i64 {
 /// the `/stats/cost` aggregate (period-bounded fan-out); `get_run`'s single-run
 /// path is deliberately left calling [`compute_run_cost`] directly so ADR-0022's
 /// per-read contract is unchanged.
-pub fn compute_run_cost_cached(repo_root: &Path, run_id: &str) -> Option<CostStat> {
+pub fn compute_run_cost_cached(
+    projects_root: &Path,
+    repo_root: &Path,
+    run_id: &str,
+) -> Option<CostStat> {
+    // Load-bearing: the SAME `projects_root` feeds the key (mtime) AND the value
+    // (aggregate). A mismatched root would desync the memo silently (#408 P1).
     let key = (
         run_id.to_string(),
-        max_transcript_mtime_millis(repo_root, run_id),
+        max_transcript_mtime_millis(projects_root, repo_root, run_id),
     );
     {
         let guard = cost_memo().lock().unwrap_or_else(|e| e.into_inner());
@@ -354,7 +364,7 @@ pub fn compute_run_cost_cached(repo_root: &Path, run_id: &str) -> Option<CostSta
             return hit.clone();
         }
     }
-    let value = compute_run_cost(repo_root, run_id);
+    let value = compute_run_cost(projects_root, repo_root, run_id);
     let mut guard = cost_memo().lock().unwrap_or_else(|e| e.into_inner());
     if guard.len() >= COST_MEMO_CAP {
         guard.clear();
@@ -568,47 +578,16 @@ mod tests {
     }
 
     // --- compute_run_cost (filesystem) ---
-
-    /// RAII guard swapping HOME for a temp dir while holding the crate-wide HOME
-    /// lock (mirrors `stale_detector::TempHome` / lib.rs `FakeHome`).
-    struct TempHome {
-        _lock: std::sync::MutexGuard<'static, ()>,
-        tmp: tempfile::TempDir,
-        prev: Option<std::ffi::OsString>,
-    }
-
-    impl TempHome {
-        fn new() -> Self {
-            let lock = crate::library_store::HOME_TEST_LOCK
-                .lock()
-                .unwrap_or_else(|e| e.into_inner());
-            let tmp = tempfile::tempdir().unwrap();
-            let prev = std::env::var_os("HOME");
-            std::env::set_var("HOME", tmp.path());
-            Self {
-                _lock: lock,
-                tmp,
-                prev,
-            }
-        }
-
-        fn path(&self) -> &Path {
-            self.tmp.path()
-        }
-    }
-
-    impl Drop for TempHome {
-        fn drop(&mut self) {
-            match self.prev.take() {
-                Some(p) => std::env::set_var("HOME", p),
-                None => std::env::remove_var("HOME"),
-            }
-        }
-    }
+    //
+    // Since #408 the `projects/` root is a parameter (the observability seam), so
+    // these tests plant transcripts under a tempdir root and pass it directly —
+    // no HOME swap, no crate-wide HOME lock, fully hermetic. A `projects` root
+    // stands in for either `~/.claude/projects/` or a sandboxed run's staged home.
 
     #[test]
     fn compute_run_cost_aggregates_and_dedups_across_sessions() {
-        let home = TempHome::new();
+        let home = tempfile::tempdir().unwrap();
+        let projects = home.path().join(".claude").join("projects");
         let repo = tempfile::tempdir().unwrap();
         let run_id = "20260706-abc-node";
         // A session cwd under the run dir (the worktree, where the manager runs).
@@ -618,11 +597,7 @@ mod tests {
             .join("runs")
             .join(run_id)
             .join("worktree");
-        let proj = home
-            .path()
-            .join(".claude")
-            .join("projects")
-            .join(cc_project_dirname(&worktree));
+        let proj = projects.join(cc_project_dirname(&worktree));
         std::fs::create_dir_all(&proj).unwrap();
 
         let l1 = assistant("msg_1", "req_1", "claude-opus-4-8", 1000, 500);
@@ -630,7 +605,7 @@ mod tests {
         // l1 replayed (same msg_1, req_1) → deduped.
         std::fs::write(proj.join("s.jsonl"), format!("{l1}\n{l1}\n{l2}\n")).unwrap();
 
-        let cost = compute_run_cost(repo.path(), run_id).unwrap();
+        let cost = compute_run_cost(&projects, repo.path(), run_id).unwrap();
         // (1000*5 + 500*25)/1e6 + (2000*5 + 1000*25)/1e6 = 0.0175 + 0.035 = 0.0525
         assert!((cost.usd - 0.0525).abs() < 1e-9, "usd = {}", cost.usd);
         assert!(!cost.partial);
@@ -638,7 +613,8 @@ mod tests {
 
     #[test]
     fn compute_run_cost_recurses_into_subagents() {
-        let home = TempHome::new();
+        let home = tempfile::tempdir().unwrap();
+        let projects = home.path().join(".claude").join("projects");
         let repo = tempfile::tempdir().unwrap();
         let run_id = "20260706-sub";
         let node = repo
@@ -649,11 +625,7 @@ mod tests {
             .join("nodes")
             .join("N")
             .join("iter-1");
-        let proj = home
-            .path()
-            .join(".claude")
-            .join("projects")
-            .join(cc_project_dirname(&node));
+        let proj = projects.join(cc_project_dirname(&node));
         let subagents = proj.join("uuid-1").join("subagents");
         std::fs::create_dir_all(&subagents).unwrap();
         std::fs::write(
@@ -673,28 +645,32 @@ mod tests {
         )
         .unwrap();
 
-        let cost = compute_run_cost(repo.path(), run_id).unwrap();
+        let cost = compute_run_cost(&projects, repo.path(), run_id).unwrap();
         // 1M input × $5/MTok, twice (main + subagent) = $10.
         assert!((cost.usd - 10.0).abs() < 1e-9, "usd = {}", cost.usd);
     }
 
     #[test]
     fn compute_run_cost_none_when_no_transcript_dir() {
-        let _home = TempHome::new();
+        let home = tempfile::tempdir().unwrap();
+        let projects = home.path().join(".claude").join("projects");
+        std::fs::create_dir_all(&projects).unwrap();
         let repo = tempfile::tempdir().unwrap();
-        assert!(compute_run_cost(repo.path(), "no-such-run").is_none());
+        assert!(compute_run_cost(&projects, repo.path(), "no-such-run").is_none());
     }
 
     // --- compute_run_cost_cached / memo (#377) ---
 
-    /// Write a single-line transcript for `run_id`'s worktree and return the
-    /// `.jsonl` path so the test can manipulate its mtime.
-    fn seed_transcript(home: &Path, repo: &Path, run_id: &str, line: &str) -> std::path::PathBuf {
+    /// Write a single-line transcript for `run_id`'s worktree under `projects` and
+    /// return the `.jsonl` path so the test can manipulate its mtime.
+    fn seed_transcript(
+        projects: &Path,
+        repo: &Path,
+        run_id: &str,
+        line: &str,
+    ) -> std::path::PathBuf {
         let worktree = repo.join(".pdo").join("runs").join(run_id).join("worktree");
-        let proj = home
-            .join(".claude")
-            .join("projects")
-            .join(cc_project_dirname(&worktree));
+        let proj = projects.join(cc_project_dirname(&worktree));
         std::fs::create_dir_all(&proj).unwrap();
         let file = proj.join("s.jsonl");
         std::fs::write(&file, format!("{line}\n")).unwrap();
@@ -703,28 +679,30 @@ mod tests {
 
     #[test]
     fn cached_matches_uncached() {
-        let home = TempHome::new();
+        let home = tempfile::tempdir().unwrap();
+        let projects = home.path().join(".claude").join("projects");
         let repo = tempfile::tempdir().unwrap();
         let run_id = "memo-eq";
         seed_transcript(
-            home.path(),
+            &projects,
             repo.path(),
             run_id,
             &assistant("m1", "r1", "claude-opus-4-8", 1_000_000, 0),
         );
-        let direct = compute_run_cost(repo.path(), run_id);
-        let cached = compute_run_cost_cached(repo.path(), run_id);
+        let direct = compute_run_cost(&projects, repo.path(), run_id);
+        let cached = compute_run_cost_cached(&projects, repo.path(), run_id);
         assert_eq!(direct, cached);
         assert!((cached.unwrap().usd - 5.0).abs() < 1e-9);
     }
 
     #[test]
     fn cached_re_serves_from_memo_when_mtime_is_unchanged() {
-        let home = TempHome::new();
+        let home = tempfile::tempdir().unwrap();
+        let projects = home.path().join(".claude").join("projects");
         let repo = tempfile::tempdir().unwrap();
         let run_id = "memo-hit";
         let file = seed_transcript(
-            home.path(),
+            &projects,
             repo.path(),
             run_id,
             &assistant("m1", "r1", "claude-opus-4-8", 1_000_000, 0),
@@ -733,7 +711,7 @@ mod tests {
             filetime::FileTime::from_last_modification_time(&std::fs::metadata(&file).unwrap());
 
         // First call: memoize $5 under (run_id, mtime).
-        let first = compute_run_cost_cached(repo.path(), run_id).unwrap();
+        let first = compute_run_cost_cached(&projects, repo.path(), run_id).unwrap();
         assert!((first.usd - 5.0).abs() < 1e-9);
 
         // Rewrite with a DIFFERENT cost ($10) but force the mtime back — the key
@@ -747,28 +725,29 @@ mod tests {
         )
         .unwrap();
         filetime::set_file_mtime(&file, orig).unwrap();
-        let hit = compute_run_cost_cached(repo.path(), run_id).unwrap();
+        let hit = compute_run_cost_cached(&projects, repo.path(), run_id).unwrap();
         assert!((hit.usd - 5.0).abs() < 1e-9, "memo hit should re-serve $5");
         // But the uncached path sees the new content ($10) — proving the file
         // really changed and the hit above was the cache, not a recompute.
-        let direct = compute_run_cost(repo.path(), run_id).unwrap();
+        let direct = compute_run_cost(&projects, repo.path(), run_id).unwrap();
         assert!((direct.usd - 10.0).abs() < 1e-9);
     }
 
     #[test]
     fn cached_recomputes_when_mtime_bumps() {
-        let home = TempHome::new();
+        let home = tempfile::tempdir().unwrap();
+        let projects = home.path().join(".claude").join("projects");
         let repo = tempfile::tempdir().unwrap();
         let run_id = "memo-bump";
         let file = seed_transcript(
-            home.path(),
+            &projects,
             repo.path(),
             run_id,
             &assistant("m1", "r1", "claude-opus-4-8", 1_000_000, 0),
         );
         let orig =
             filetime::FileTime::from_last_modification_time(&std::fs::metadata(&file).unwrap());
-        let first = compute_run_cost_cached(repo.path(), run_id).unwrap();
+        let first = compute_run_cost_cached(&projects, repo.path(), run_id).unwrap();
         assert!((first.usd - 5.0).abs() < 1e-9);
 
         // New content AND a bumped mtime → new key → recompute picks up $10.
@@ -782,7 +761,7 @@ mod tests {
         .unwrap();
         let bumped = filetime::FileTime::from_unix_time(orig.unix_seconds() + 10, 0);
         filetime::set_file_mtime(&file, bumped).unwrap();
-        let recomputed = compute_run_cost_cached(repo.path(), run_id).unwrap();
+        let recomputed = compute_run_cost_cached(&projects, repo.path(), run_id).unwrap();
         assert!(
             (recomputed.usd - 10.0).abs() < 1e-9,
             "a bumped mtime must invalidate the memo"
@@ -790,27 +769,73 @@ mod tests {
     }
 
     #[test]
+    fn cached_honors_the_injected_projects_root() {
+        // #408 P1: `compute_run_cost_cached` feeds the SAME `projects_root` to
+        // both the mtime key AND the aggregate value — so the cached path honors
+        // whichever root the seam picked (staging while live, host after cleanup).
+        // Mirrors production, where the two roots for a run never share an mtime:
+        // `merge_back` copies with `std::fs::copy` (no mtime preservation), so the
+        // host file lands with a newer mtime than the staging original. We back-
+        // date the host file to guarantee the two keys differ.
+        let home = tempfile::tempdir().unwrap();
+        let host = home.path().join(".claude").join("projects");
+        let staging = home.path().join("staging").join("projects");
+        let repo = tempfile::tempdir().unwrap();
+        let run_id = "memo-root";
+
+        // Host root: $5 (back-dated). Staging root: $10 (fresh). Same run_id.
+        let host_file = seed_transcript(
+            &host,
+            repo.path(),
+            run_id,
+            &assistant("m1", "r1", "claude-opus-4-8", 1_000_000, 0),
+        );
+        filetime::set_file_mtime(
+            &host_file,
+            filetime::FileTime::from_unix_time(1_600_000_000, 0),
+        )
+        .unwrap();
+        seed_transcript(
+            &staging,
+            repo.path(),
+            run_id,
+            &assistant("m2", "r2", "claude-opus-4-8", 2_000_000, 0),
+        );
+
+        let host_cost = compute_run_cost_cached(&host, repo.path(), run_id).unwrap();
+        let staging_cost = compute_run_cost_cached(&staging, repo.path(), run_id).unwrap();
+        assert!((host_cost.usd - 5.0).abs() < 1e-9, "host root → $5");
+        assert!(
+            (staging_cost.usd - 10.0).abs() < 1e-9,
+            "staging root → $10 (its own key/value, not the host's memo)"
+        );
+    }
+
+    #[test]
     fn max_transcript_mtime_is_zero_without_a_transcript_and_positive_with_one() {
-        let home = TempHome::new();
+        let home = tempfile::tempdir().unwrap();
+        let projects = home.path().join(".claude").join("projects");
+        std::fs::create_dir_all(&projects).unwrap();
         let repo = tempfile::tempdir().unwrap();
         assert_eq!(
-            max_transcript_mtime_millis(repo.path(), "no-such-run"),
+            max_transcript_mtime_millis(&projects, repo.path(), "no-such-run"),
             0,
             "no transcript dir → 0 (so a later write bumps the key)"
         );
         let run_id = "mtime-run";
         seed_transcript(
-            home.path(),
+            &projects,
             repo.path(),
             run_id,
             &assistant("m1", "r1", "claude-opus-4-8", 1000, 0),
         );
-        assert!(max_transcript_mtime_millis(repo.path(), run_id) > 0);
+        assert!(max_transcript_mtime_millis(&projects, repo.path(), run_id) > 0);
     }
 
     #[test]
     fn compute_run_cost_prefix_does_not_leak_across_runs() {
-        let home = TempHome::new();
+        let home = tempfile::tempdir().unwrap();
+        let projects = home.path().join(".claude").join("projects");
         let repo = tempfile::tempdir().unwrap();
         // Two runs where one id is a lexical prefix of the other.
         let other = repo
@@ -819,11 +844,7 @@ mod tests {
             .join("runs")
             .join("run-1x") // "run-1" is a prefix of "run-1x"
             .join("worktree");
-        let proj = home
-            .path()
-            .join(".claude")
-            .join("projects")
-            .join(cc_project_dirname(&other));
+        let proj = projects.join(cc_project_dirname(&other));
         std::fs::create_dir_all(&proj).unwrap();
         std::fs::write(
             proj.join("s.jsonl"),
@@ -832,6 +853,6 @@ mod tests {
         .unwrap();
 
         // Querying "run-1" must NOT pick up "run-1x"'s transcript.
-        assert!(compute_run_cost(repo.path(), "run-1").is_none());
+        assert!(compute_run_cost(&projects, repo.path(), "run-1").is_none());
     }
 }

--- a/crates/pdo-daemon/src/sandbox_run.rs
+++ b/crates/pdo-daemon/src/sandbox_run.rs
@@ -8,18 +8,22 @@
 //! only reader of `AppState`), then the core ([`ensure_ready`], [`cleanup`]) works
 //! from explicit values only — mirroring the pure-module discipline.
 //!
-//! What #407 wires (and what it does NOT):
+//! What this module wires:
 //! - [`ensure_ready`] — stage the Claude home once, ensure the image, ensure the
 //!   container is up. Called at create-time (eager fail-fast), `boot_recovery`
-//!   (reconcile a live sandboxed Run), and `open_run_shell` (resurrect). Sync and
+//!   (reconcile a live sandboxed Run), `open_run_shell` (resurrect), and
+//!   `resume_run` (re-arm a terminal Run after a host reboot, #408 D5). Sync and
 //!   possibly long (`docker build` on the first machine run) → async callers wrap
 //!   it in `spawn_blocking`.
-//! - [`cleanup`] — destroy the container + purge the staging at `cleanup_run`.
-//!   **`merge_back` is NOT wired here** — it belongs to the observability slice
-//!   #408 (together with the `transcripts_root` seam), so a `pure`/`copy` Run is
-//!   deliberately blind to cost / stale-detection until then. That is an
-//!   *observability* gap, not a correctness/liveness one: session-death detection
-//!   is transcript-independent and stays alive.
+//! - [`cleanup`] — merge the transcripts back, destroy the container, then purge
+//!   the staging at `cleanup_run`.
+//! - [`transcripts_root`] / [`merge_back_best_effort`] — the observability seam
+//!   (#408, ADR-0030 pt 9): cost ([`crate::run_cost`]) and stale-detection
+//!   ([`crate::stale_detector`]) read a sandboxed Run's transcripts from its
+//!   staged home while it is live, and `merge_back` lands them in `~/.claude`
+//!   at the terminal transition (via [`merge_back_best_effort`], the
+//!   `append_event` chokepoint) and again at `cleanup_run` (via [`cleanup`],
+//!   before `teardown`). session-death detection stays transcript-independent.
 
 use std::path::{Path, PathBuf};
 
@@ -119,6 +123,70 @@ pub(crate) fn docker_bin(state: &AppState) -> String {
         .unwrap_or_else(|| "docker".to_string())
 }
 
+/// The `projects/` root where cost ([`crate::run_cost`]) and stale-detection
+/// ([`crate::stale_detector`]) read a Run's Claude Code transcripts (#408). The
+/// SINGLE seam shared by both consumers.
+///
+/// - A sandboxed Run whose **staging still exists** (live / reapable / resumed)
+///   → its staged home (`<sandbox_root>/<run_id>/claude-home/projects/`), where
+///   `claude` writes in real time through the identity mount.
+/// - `off`, OR a sandboxed Run whose staging was purged by `cleanup_run` → the
+///   host `~/.claude/projects/`, where `merge_back` flushed the transcripts.
+///
+/// Dispatch is keyed on the **existence of the staging dir** (not the Run's
+/// terminal status): it stays correct even if the best-effort terminal
+/// `merge_back` failed, as long as the staging lives (cf. plan #408 D-1). The cwd
+/// encoding is unchanged — the caller still resolves the encoded dirname from
+/// this base via [`crate::stale_detector::encode_working_dir`], the single source
+/// of truth (#373); the seam only swaps the base `projects/` root.
+pub(crate) fn transcripts_root(
+    mode: SandboxMode,
+    run_id: &str,
+    home_root: &Path,
+    sandbox_root: &Path,
+) -> PathBuf {
+    if !mode.is_off() && sandbox_staging::staging_dir_for_run(sandbox_root, run_id).exists() {
+        sandbox_staging::staged_claude_home(sandbox_root, run_id).join("projects")
+    } else {
+        home_root.join(".claude").join("projects")
+    }
+}
+
+/// Merge a Run's staged transcripts back to `~/.claude/projects/` at its terminal
+/// transition (#408), so cost + stale-detection see them at the standard encoded
+/// dirname once the staging is eventually purged. No-op for `off`.
+///
+/// Never fails / slows the caller: it re-projects the Run (to read the final
+/// `sandbox` mode), resolves the roots, then fires the filesystem walk on a
+/// **detached** `spawn_blocking` — the terminal transition must not depend on
+/// this merge (ADR-0023). Idempotent (`merge_back` is copy-if-absent-or-larger),
+/// so a second terminal event or the later `cleanup_run` merge is safe. The
+/// caller (`append_event`) gates on the 4 terminal kinds first, so only terminal
+/// events pay the re-projection.
+pub(crate) async fn merge_back_best_effort(state: &AppState, run_id: &str) {
+    let Some((_, run_state)) = crate::reload_run_state(state, run_id).await else {
+        return;
+    };
+    if run_state.sandbox.is_off() {
+        return;
+    }
+    let (home_root, sandbox_root) = match sandbox_home_roots(state) {
+        Ok(r) => r,
+        Err(e) => {
+            warn!("merge_back: cannot resolve roots for run {run_id}: {e:#}");
+            return;
+        }
+    };
+    let rid = run_id.to_string();
+    // Fire-and-forget: capture owned values, do NOT `.await` (that would recouple
+    // the terminal transition to the merge's latency + JoinError).
+    tokio::task::spawn_blocking(move || {
+        if let Err(e) = sandbox_staging::merge_back(&home_root, &sandbox_root, &rid) {
+            warn!("sandbox merge_back for run {rid} failed (best-effort): {e:#}");
+        }
+    });
+}
+
 /// Guarantee the Run's sandbox is ready to accept `docker exec` tails: staged
 /// home present, image built, container up. Idempotent — safe to call at
 /// create-time, boot recovery, spawn-time, and run-shell open.
@@ -178,13 +246,19 @@ pub(crate) fn ensure_ready(ctx: &SandboxContext) -> Result<()> {
     Ok(())
 }
 
-/// Destroy the Run's container and purge its staging (`cleanup_run`, #407 D9).
+/// Merge the transcripts back, destroy the Run's container, then purge its
+/// staging (`cleanup_run`, #407 D9 + #408 D-4).
 ///
-/// Best-effort: never fails the archival. **The caller must invoke this BEFORE
-/// `git worktree remove`** — the container bind-mounts the repo, so removing a
-/// live worktree under it would hit a busy mount. `merge_back` is intentionally
-/// absent (→ #408).
-pub(crate) fn cleanup(docker_bin: &str, sandbox_root: &Path, run_id: &str) {
+/// Best-effort throughout: never fails the archival. **The caller must invoke
+/// this BEFORE `git worktree remove`** — the container bind-mounts the repo, so
+/// removing a live worktree under it would hit a busy mount. `merge_back` runs
+/// **first** ("harvest before purge" is an unskippable invariant): it is
+/// idempotent (copy-if-absent-or-larger), so this final pass — which captures any
+/// post-terminal growth (resume, late subagent flushes) the detached terminal
+/// merge missed — is safe even after that merge already ran.
+pub(crate) fn cleanup(docker_bin: &str, home_root: &Path, sandbox_root: &Path, run_id: &str) {
+    // Harvest BEFORE teardown wipes the staging. Best-effort (swallow the error).
+    let _ = sandbox_staging::merge_back(home_root, sandbox_root, run_id);
     if let Err(e) = sandbox_container::remove(docker_bin, run_id) {
         warn!("sandbox cleanup: failed to remove container for run {run_id} (best-effort): {e:#}");
     }
@@ -384,6 +458,7 @@ mod tests {
     fn cleanup_removes_container_and_staging() {
         let tmp = tempfile::tempdir().unwrap();
         let (docker, log) = write_fake_docker(tmp.path());
+        let home_root = tmp.path().join("home");
         let sandbox_root = tmp.path().join("sandbox");
         // Seed a staging dir to be torn down.
         std::fs::create_dir_all(sandbox_staging::staged_claude_home(&sandbox_root, "r1")).unwrap();
@@ -392,7 +467,7 @@ mod tests {
         // `cleanup` is idempotent + best-effort (swallows ETXTBSY); retry until the
         // container-remove is logged.
         let logged = retry_side_effect(
-            || cleanup(&docker, &sandbox_root, "r1"),
+            || cleanup(&docker, &home_root, &sandbox_root, "r1"),
             || {
                 let l = log_lines(&log);
                 l.len() >= 3 && l[..3] == ["rm", "-f", "pdo-sbx-r1"]
@@ -435,6 +510,119 @@ mod tests {
             logged,
             "targeted kill must exec with the session marker; log: {:?}",
             log_lines(&log)
+        );
+    }
+
+    // --- #408: cleanup harvests transcripts before teardown --------------------
+
+    #[test]
+    fn cleanup_merges_transcripts_before_purging_staging() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (docker, _log) = write_fake_docker(tmp.path());
+        let home_root = tmp.path().join("home");
+        let sandbox_root = tmp.path().join("sandbox");
+        // Seed a staged transcript under one encoded project dir.
+        let staged_projects = sandbox_staging::staged_claude_home(&sandbox_root, "r1").join("projects");
+        let proj = staged_projects.join("-enc-worktree");
+        std::fs::create_dir_all(&proj).unwrap();
+        std::fs::write(proj.join("s.jsonl"), "{\"line\":1}\n").unwrap();
+
+        retry_side_effect(
+            || cleanup(&docker, &home_root, &sandbox_root, "r1"),
+            || home_root.join(".claude/projects/-enc-worktree/s.jsonl").is_file(),
+        );
+
+        // merge_back landed the transcript in the host projects dir …
+        assert!(
+            home_root.join(".claude/projects/-enc-worktree/s.jsonl").is_file(),
+            "cleanup must merge transcripts to the host BEFORE teardown"
+        );
+        // … and teardown then purged the staging.
+        assert!(
+            !sandbox_staging::staging_dir_for_run(&sandbox_root, "r1").exists(),
+            "cleanup purges the staging after the merge"
+        );
+    }
+
+    // --- #408: transcripts_root seam (3 arms + root-invariance) ----------------
+
+    #[test]
+    fn transcripts_root_off_is_always_host() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        let sandbox_root = tmp.path().join("sandbox");
+        // Even if a staging dir happens to exist, `off` reads the host.
+        std::fs::create_dir_all(sandbox_staging::staging_dir_for_run(&sandbox_root, "r1")).unwrap();
+        assert_eq!(
+            transcripts_root(SandboxMode::Off, "r1", &home, &sandbox_root),
+            home.join(".claude").join("projects")
+        );
+    }
+
+    #[test]
+    fn transcripts_root_sandboxed_live_is_staging() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        let sandbox_root = tmp.path().join("sandbox");
+        // Staging present → live/reapable Run → read the staged home.
+        std::fs::create_dir_all(sandbox_staging::staging_dir_for_run(&sandbox_root, "r1")).unwrap();
+        assert_eq!(
+            transcripts_root(SandboxMode::Pure, "r1", &home, &sandbox_root),
+            sandbox_staging::staged_claude_home(&sandbox_root, "r1").join("projects")
+        );
+        // `copy` behaves identically.
+        assert_eq!(
+            transcripts_root(SandboxMode::Copy, "r1", &home, &sandbox_root),
+            sandbox_staging::staged_claude_home(&sandbox_root, "r1").join("projects")
+        );
+    }
+
+    #[test]
+    fn transcripts_root_sandboxed_after_cleanup_is_host() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        let sandbox_root = tmp.path().join("sandbox");
+        // No staging dir (post-`cleanup_run`) → read the host, where merge_back
+        // flushed. Keyed on staging EXISTENCE, not the Run's terminal status.
+        assert!(!sandbox_staging::staging_dir_for_run(&sandbox_root, "r1").exists());
+        assert_eq!(
+            transcripts_root(SandboxMode::Pure, "r1", &home, &sandbox_root),
+            home.join(".claude").join("projects")
+        );
+    }
+
+    #[test]
+    fn transcripts_root_encoding_is_root_invariant() {
+        // AC5: the seam only swaps the base `projects/` root — the per-cwd encoded
+        // segment stays the single source of truth (`encode_working_dir`, #373),
+        // never re-derived by the seam. So for a given cwd, appending the encoded
+        // segment to the seam-resolved root yields the same dirname regardless of
+        // which base (host vs staging) the seam picked.
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        let sandbox_root = tmp.path().join("sandbox");
+        let cwd = std::path::Path::new("/home/u/.pdo/runs/r1/worktree");
+        let enc = crate::stale_detector::encode_working_dir(cwd);
+
+        // Host arm (no staging).
+        let host = transcripts_root(SandboxMode::Pure, "r1", &home, &sandbox_root);
+        assert_eq!(host.join(&enc), home.join(".claude/projects").join(&enc));
+
+        // Staging arm (staging materialised) — same encoded segment appended.
+        std::fs::create_dir_all(sandbox_staging::staging_dir_for_run(&sandbox_root, "r1")).unwrap();
+        let staged = transcripts_root(SandboxMode::Pure, "r1", &home, &sandbox_root);
+        assert_eq!(
+            staged.join(&enc),
+            sandbox_staging::staged_claude_home(&sandbox_root, "r1")
+                .join("projects")
+                .join(&enc)
+        );
+        // The bases differ, but the trailing encoded segment is identical.
+        assert_eq!(host.file_name(), staged.file_name()); // both end in "projects"
+        assert_eq!(
+            host.join(&enc).file_name(),
+            staged.join(&enc).file_name(),
+            "the encoded cwd segment is root-invariant"
         );
     }
 }

--- a/crates/pdo-daemon/src/sandbox_run.rs
+++ b/crates/pdo-daemon/src/sandbox_run.rs
@@ -522,19 +522,26 @@ mod tests {
         let home_root = tmp.path().join("home");
         let sandbox_root = tmp.path().join("sandbox");
         // Seed a staged transcript under one encoded project dir.
-        let staged_projects = sandbox_staging::staged_claude_home(&sandbox_root, "r1").join("projects");
+        let staged_projects =
+            sandbox_staging::staged_claude_home(&sandbox_root, "r1").join("projects");
         let proj = staged_projects.join("-enc-worktree");
         std::fs::create_dir_all(&proj).unwrap();
         std::fs::write(proj.join("s.jsonl"), "{\"line\":1}\n").unwrap();
 
         retry_side_effect(
             || cleanup(&docker, &home_root, &sandbox_root, "r1"),
-            || home_root.join(".claude/projects/-enc-worktree/s.jsonl").is_file(),
+            || {
+                home_root
+                    .join(".claude/projects/-enc-worktree/s.jsonl")
+                    .is_file()
+            },
         );
 
         // merge_back landed the transcript in the host projects dir …
         assert!(
-            home_root.join(".claude/projects/-enc-worktree/s.jsonl").is_file(),
+            home_root
+                .join(".claude/projects/-enc-worktree/s.jsonl")
+                .is_file(),
             "cleanup must merge transcripts to the host BEFORE teardown"
         );
         // … and teardown then purged the staging.

--- a/crates/pdo-daemon/src/sandbox_staging.rs
+++ b/crates/pdo-daemon/src/sandbox_staging.rs
@@ -10,7 +10,8 @@
 //! (purger). Les slices sœurs le **consomment** mais ne sont **pas** ici :
 //! - #406 monte `claude-home/` → `$HOME/.claude` et `.claude.json` → `$HOME/.claude.json` ;
 //! - #407 câble `prepare`/`teardown` dans le run-advance (ADR-0030) ;
-//! - #408 câble `merge_back` + pointe stale-detection/coût vers le staging (seam `transcripts_root`).
+//! - #408 câble `merge_back` (transition terminale + `cleanup_run`) + pointe
+//!   stale-detection/coût vers le staging (seam [`crate::sandbox_run::transcripts_root`]).
 //!
 //! ## Décisions de conception (voir la section « Sandbox » de `CONTEXT.md`)
 //! - **`copy` = allowlist, jamais denylist.** Copier « tout `~/.claude` sauf
@@ -25,7 +26,8 @@
 //!   désarme l'onboarding mais PAS le dialogue « trust this folder ? » — un agent
 //!   non surveillé se bloquerait. On pré-approuve la racine du Run.
 
-#![allow(dead_code)] // Tracer bullet : consommé par #406/#407, non câblé dans cette slice.
+// #408: `merge_back` is now wired; the rest of the module (path-math + effects)
+// is consumed by #406/#407.
 
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};

--- a/crates/pdo-daemon/src/stale_detector.rs
+++ b/crates/pdo-daemon/src/stale_detector.rs
@@ -134,17 +134,17 @@ pub fn encode_working_dir(dir: &Path) -> String {
         .collect()
 }
 
-/// Find the most recently modified `.jsonl` file in the Claude Code projects
-/// directory for the given working directory.
-pub fn find_session_jsonl(working_dir: &Path) -> Option<PathBuf> {
-    let home = std::env::var("HOME").ok()?;
+/// Find the most recently modified `.jsonl` file for `working_dir` under the
+/// given Claude Code `projects/` root.
+///
+/// `projects_root` is the seam that lets a sandboxed Run's transcripts be read
+/// from its staged home while it is live (#408): the caller resolves it via
+/// [`crate::sandbox_run::transcripts_root`] (staging for a live sandboxed Run,
+/// `~/.claude/projects/` otherwise). The cwd encoding stays here, the single
+/// source of truth (#373) — the seam only swaps the base root.
+pub fn find_session_jsonl(projects_root: &Path, working_dir: &Path) -> Option<PathBuf> {
     let encoded = encode_working_dir(working_dir);
-    let projects_dir = PathBuf::from(home)
-        .join(".claude")
-        .join("projects")
-        .join(&encoded);
-
-    newest_jsonl_in(&projects_dir)
+    newest_jsonl_in(&projects_root.join(encoded))
 }
 
 fn newest_jsonl_in(dir: &Path) -> Option<PathBuf> {
@@ -997,53 +997,18 @@ SwapFree:         204800 kB
     }
 
     // --- find_session_jsonl (filesystem) ---
-
-    /// RAII guard that swaps HOME for a temp dir while holding the crate-wide
-    /// HOME lock. `find_session_jsonl` reads `$HOME`, and other test modules
-    /// (library_store, lib.rs FakeHome) also mutate HOME — without the lock,
-    /// parallel test threads clobber each other's HOME mid-test.
-    struct TempHome {
-        _lock: std::sync::MutexGuard<'static, ()>,
-        tmp: tempfile::TempDir,
-        prev: Option<std::ffi::OsString>,
-    }
-
-    impl TempHome {
-        fn new() -> Self {
-            let lock = crate::library_store::HOME_TEST_LOCK
-                .lock()
-                .unwrap_or_else(|e| e.into_inner());
-            let tmp = tempfile::tempdir().unwrap();
-            let prev = std::env::var_os("HOME");
-            std::env::set_var("HOME", tmp.path());
-            Self {
-                _lock: lock,
-                tmp,
-                prev,
-            }
-        }
-
-        fn path(&self) -> &Path {
-            self.tmp.path()
-        }
-    }
-
-    impl Drop for TempHome {
-        fn drop(&mut self) {
-            match self.prev.take() {
-                Some(p) => std::env::set_var("HOME", p),
-                None => std::env::remove_var("HOME"),
-            }
-        }
-    }
+    //
+    // Since #408 `find_session_jsonl` takes the `projects/` root as a param (the
+    // observability seam), so these tests inject a tempdir root directly — no HOME
+    // swap, no crate-wide HOME lock, fully hermetic.
 
     #[test]
     fn find_jsonl_returns_newest_file() {
-        let home_guard = TempHome::new();
-        let home = home_guard.path();
+        let tmp = tempfile::tempdir().unwrap();
+        let projects = tmp.path().join(".claude").join("projects");
 
         let encoded = encode_working_dir(Path::new("/home/user/project"));
-        let projects_dir = home.join(".claude").join("projects").join(&encoded);
+        let projects_dir = projects.join(&encoded);
         std::fs::create_dir_all(&projects_dir).unwrap();
 
         let old_file = projects_dir.join("old-session.jsonl");
@@ -1057,7 +1022,7 @@ SwapFree:         204800 kB
         let new_file = projects_dir.join("new-session.jsonl");
         std::fs::write(&new_file, "new").unwrap();
 
-        let result = find_session_jsonl(Path::new("/home/user/project"));
+        let result = find_session_jsonl(&projects, Path::new("/home/user/project"));
 
         assert!(result.is_some());
         assert_eq!(result.unwrap().file_name().unwrap(), "new-session.jsonl");
@@ -1065,23 +1030,24 @@ SwapFree:         204800 kB
 
     #[test]
     fn find_jsonl_no_dir_returns_none() {
-        let _home_guard = TempHome::new();
-        assert!(find_session_jsonl(Path::new("/nonexistent/dir")).is_none());
+        let tmp = tempfile::tempdir().unwrap();
+        let projects = tmp.path().join(".claude").join("projects");
+        assert!(find_session_jsonl(&projects, Path::new("/nonexistent/dir")).is_none());
     }
 
     #[test]
     fn find_jsonl_ignores_non_jsonl_files() {
-        let home_guard = TempHome::new();
-        let home = home_guard.path();
+        let tmp = tempfile::tempdir().unwrap();
+        let projects = tmp.path().join(".claude").join("projects");
 
         let encoded = encode_working_dir(Path::new("/tmp/testdir"));
-        let projects_dir = home.join(".claude").join("projects").join(&encoded);
+        let projects_dir = projects.join(&encoded);
         std::fs::create_dir_all(&projects_dir).unwrap();
 
         std::fs::write(projects_dir.join("notes.txt"), "not jsonl").unwrap();
         std::fs::write(projects_dir.join("data.json"), "not jsonl either").unwrap();
 
-        assert!(find_session_jsonl(Path::new("/tmp/testdir")).is_none());
+        assert!(find_session_jsonl(&projects, Path::new("/tmp/testdir")).is_none());
     }
 
     #[test]
@@ -1090,29 +1056,22 @@ SwapFree:         204800 kB
         // carries `.pdo`) must resolve to the transcript CC actually writes —
         // i.e. under the leading-dash, `--pdo` name. Pre-fix this looked up
         // `home-...-.pdo-...` and found nothing, so the mtime probe was dead.
-        let home_guard = TempHome::new();
-        let home = home_guard.path();
+        let tmp = tempfile::tempdir().unwrap();
+        let projects = tmp.path().join(".claude").join("projects");
 
         let node_dir =
             Path::new("/home/llenoir/Documents/perso/Maestro/.pdo/runs/20260623-100032-9b8331b/nodes/gzpYZA2m/iter-1");
 
         // The transcript dir CC writes: leading `-`, `.pdo` → `--pdo`.
-        let cc_name = home
-            .join(".claude")
-            .join("projects")
+        let cc_name = projects
             .join("-home-llenoir-Documents-perso-Maestro--pdo-runs-20260623-100032-9b8331b-nodes-gzpYZA2m-iter-1");
         std::fs::create_dir_all(&cc_name).unwrap();
         std::fs::write(cc_name.join("session.jsonl"), "{}").unwrap();
 
         // The encoder now produces exactly that name …
-        assert_eq!(
-            home.join(".claude")
-                .join("projects")
-                .join(encode_working_dir(node_dir)),
-            cc_name
-        );
+        assert_eq!(projects.join(encode_working_dir(node_dir)), cc_name);
         // … so the probe resolves the transcript.
-        let found = find_session_jsonl(node_dir);
+        let found = find_session_jsonl(&projects, node_dir);
         assert!(
             found.is_some(),
             "find_session_jsonl must resolve a real PDO node transcript after the #373 fix"

--- a/crates/pdo-daemon/src/stats.rs
+++ b/crates/pdo-daemon/src/stats.rs
@@ -381,8 +381,8 @@ pub async fn stats_cost(
 
     // #408: resolve the sandbox home roots once for the whole fold. HOME absent →
     // degrade to the host `~/.claude` root (never fail the aggregate).
-    let (home_root, sandbox_root) = crate::sandbox_run::sandbox_home_roots(&state)
-        .unwrap_or_else(|_| {
+    let (home_root, sandbox_root) =
+        crate::sandbox_run::sandbox_home_roots(&state).unwrap_or_else(|_| {
             let home = PathBuf::from(std::env::var("HOME").unwrap_or_default());
             let sandbox = home.join(".pdo").join("sandbox");
             (home, sandbox)

--- a/crates/pdo-daemon/src/stats.rs
+++ b/crates/pdo-daemon/src/stats.rs
@@ -379,6 +379,15 @@ pub async fn stats_cost(
         }
     };
 
+    // #408: resolve the sandbox home roots once for the whole fold. HOME absent →
+    // degrade to the host `~/.claude` root (never fail the aggregate).
+    let (home_root, sandbox_root) = crate::sandbox_run::sandbox_home_roots(&state)
+        .unwrap_or_else(|_| {
+            let home = PathBuf::from(std::env::var("HOME").unwrap_or_default());
+            let sandbox = home.join(".pdo").join("sandbox");
+            (home, sandbox)
+        });
+
     let mut cost_rows: Vec<CostRow> = Vec::with_capacity(rows.len());
     for (run_id, bucket, payload) in rows {
         let payload: serde_json::Value = payload
@@ -403,7 +412,18 @@ pub async fn stats_cost(
             .unwrap_or_else(|| state.repo_root.clone());
         let project = repo_root.to_string_lossy().into_owned();
 
-        let cost = crate::run_cost::compute_run_cost_cached(&repo_root, &run_id);
+        // #408: read the transcripts from the sandboxed Run's staged home while it
+        // is live (else `~/.claude/projects/`). Parse `sandbox` straight off the
+        // `run_started` payload (like `target_repo`/`pipeline_id`) — no full
+        // RunState projection, so the SQL stays cheap (no fan-out regression).
+        let sandbox = payload
+            .get("sandbox")
+            .and_then(|v| serde_json::from_value::<crate::event_log::SandboxMode>(v.clone()).ok())
+            .unwrap_or_default();
+        let projects_root =
+            crate::sandbox_run::transcripts_root(sandbox, &run_id, &home_root, &sandbox_root);
+
+        let cost = crate::run_cost::compute_run_cost_cached(&projects_root, &repo_root, &run_id);
         cost_rows.push(CostRow {
             bucket,
             pipeline,

--- a/crates/pdo-daemon/tests/common/mod.rs
+++ b/crates/pdo-daemon/tests/common/mod.rs
@@ -124,6 +124,53 @@ impl TestDaemon {
         })
     }
 
+    /// Spawn a daemon with a **fake `docker`** AND an explicit tmux tail override
+    /// (#408). Like [`TestDaemon::spawn_with_docker_override`] but the caller
+    /// chooses the tail: pass `Some("exec sleep 600")` so a sandboxed node's
+    /// session stays **alive** long enough to exercise the live-run observability
+    /// paths (cost + stale-detection reading the staged home). The default
+    /// docker-override harness pins the tail to `exec true`, which collapses the
+    /// session instantly — too short to prove "stale reads the staging".
+    ///
+    /// `sandbox_home_override` is the tempdir, so the staging
+    /// (`<tempdir>/.pdo/sandbox/<run>/…`) and the host `~/.claude`
+    /// (`<tempdir>/.claude/…`) both live under the test's own dir — hermetic, no
+    /// real `$HOME` touched.
+    pub async fn spawn_with_docker_and_tmux_override<F>(
+        setup: F,
+        docker_cmd: String,
+        tmux_cmd_override: Option<String>,
+    ) -> Result<Self>
+    where
+        F: FnOnce(&Path) -> Result<()>,
+    {
+        std::env::remove_var("PDO_NODE_ID");
+
+        let tempdir = tempfile::tempdir()?;
+        setup(tempdir.path())?;
+
+        let handle = serve_with_config(
+            SocketAddr::from(([127, 0, 0, 1], 0)),
+            tempdir.path().to_path_buf(),
+            DaemonConfig {
+                tmux_cmd_override,
+                panic_on_trigger_name: None,
+                panic_on_stale_sweep: false,
+                panic_on_spawn: false,
+                service_health_override: None,
+                docker_cmd_override: Some(docker_cmd),
+                sandbox_home_override: Some(tempdir.path().to_path_buf()),
+            },
+        )
+        .await?;
+
+        Ok(Self {
+            addr: handle.addr,
+            tempdir,
+            handle: Some(handle),
+        })
+    }
+
     /// Spawn a daemon that **panics** the scheduler tick when a due Trigger named
     /// `panic_name` is processed (#222 fault injection). Lets a test prove the
     /// panic is isolated and the scheduler keeps firing. Per-daemon config, so no

--- a/crates/pdo-daemon/tests/sandbox_observability.rs
+++ b/crates/pdo-daemon/tests/sandbox_observability.rs
@@ -1,0 +1,628 @@
+//! Layer 3a — sandbox observability (#408, slice E of PRD #403).
+//!
+//! Drives `POST /runs` against a **real daemon** with a **fake `docker`** and a
+//! tempdir-scoped sandbox home, so no test needs real Docker, touches the real
+//! `$HOME`, or launches real claude. Proves the `transcripts_root` seam + the
+//! `merge_back` wiring end-to-end (ADR-0004 règle d'or: an AC is closed at layer
+//! ≥3, not with fake-probe unit tests alone):
+//!   1. cost reads the STAGED home while a sandboxed Run is live (not `~/.claude`);
+//!   2. stale-detection reads the staged home while a sandboxed Run is live;
+//!   3. the terminal transition merges the staged transcripts into
+//!      `~/.claude/projects/` at the standard encoded dirname;
+//!   4. the second merge at `cleanup_run` is idempotent (byte-identical, one file);
+//!   5. resuming a sandboxed Run re-arms its container (ensure_ready) → 200;
+//!   6. resuming a sandboxed Run with Docker unavailable fails loud (500), never a
+//!      silent host fallback.
+//!
+//! For the LIVE-run paths (1, 2) the fake `docker exec` must keep the node's
+//! session alive — the default docker-override harness pins the tail to
+//! `exec true`, which collapses the session before the sweep can read the mtime
+//! (plan #408 P4). So [`write_live_docker`] actually *runs* the exec'd command
+//! (`sleep 600`) via a `sleep`-friendly tail, and the run uses
+//! [`common::TestDaemon::spawn_with_docker_and_tmux_override`] with `exec sleep 600`.
+
+mod common;
+
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::Once;
+use std::time::{Duration, Instant, SystemTime};
+
+use common::TestDaemon;
+use pdo_daemon::stale_detector::encode_working_dir;
+use tempfile::TempDir;
+
+const NODE_ID: &str = "worker";
+
+/// `start → worker(doc-only, in→out) → end`. A doc-only node uses the agent tail
+/// so `tmux_cmd_override` (`exec sleep 600`) is honoured — the session stays
+/// alive for the live-run observability paths. Completing `worker` (with its
+/// `out` present) drives the whole run terminal.
+const PIPELINE_YAML: &str = r#"name: sbx-obs
+version: "1.0"
+nodes:
+  - id: start
+    name: Start
+    type: start
+    outputs:
+      - name: user_prompt
+  - id: worker
+    name: worker
+    type: doc-only
+    inputs:
+      - name: in
+    outputs:
+      - name: out
+  - id: end
+    name: End
+    type: end
+    inputs:
+      - name: result
+edges:
+  - source: { node: start, port: user_prompt }
+    target: { node: worker, port: in }
+  - source: { node: worker, port: out }
+    target: { node: end, port: result }
+"#;
+
+fn ensure_pdo_on_path() {
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        let bin = Path::new(env!("CARGO_BIN_EXE_pdo"));
+        let dir = bin.parent().expect("pdo binary has a parent dir");
+        let existing = std::env::var("PATH").unwrap_or_default();
+        std::env::set_var("PATH", format!("{}:{}", dir.display(), existing));
+    });
+}
+
+fn tmux_available() -> bool {
+    Command::new("tmux")
+        .arg("-V")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn git_init_with_commit(repo: &Path) -> anyhow::Result<()> {
+    let run = |args: &[&str]| -> anyhow::Result<()> {
+        let out = Command::new("git").args(args).current_dir(repo).output()?;
+        if !out.status.success() {
+            anyhow::bail!(
+                "git {args:?} failed: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+        }
+        Ok(())
+    };
+    run(&["init", "-q", "-b", "main"])?;
+    run(&["config", "user.email", "test@example.com"])?;
+    run(&["config", "user.name", "Test"])?;
+    run(&["config", "commit.gpgsign", "false"])?;
+    std::fs::write(repo.join(".gitignore"), ".pdo/runs/\n")?;
+    run(&["add", "."])?;
+    run(&["commit", "-q", "-m", "init"])?;
+    Ok(())
+}
+
+fn seed(repo: &Path) -> anyhow::Result<()> {
+    let pipelines_dir = repo.join(".pdo").join("pipelines");
+    std::fs::create_dir_all(&pipelines_dir)?;
+    std::fs::write(pipelines_dir.join("sbx-obs.yaml"), PIPELINE_YAML)?;
+    // Preserve real HOME for git's global config while the daemon's sandbox home
+    // is overridden to the tempdir (git needs a usable global config to make
+    // worktrees). Harmless if HOME is unset.
+    git_init_with_commit(repo)?;
+    Ok(())
+}
+
+/// A fake `docker` whose `exec` **actually runs** the exec'd command, so a
+/// sandboxed node's `docker exec … bash -lc 'exec sleep 600'` keeps its tmux
+/// session alive (needed for the live-run paths). `image inspect` → present,
+/// `container inspect` → running (`true`), so `ensure_ready` never builds/creates.
+/// Logs every argv (one line per arg) to `argv.log`.
+fn write_live_docker() -> (TempDir, String, PathBuf) {
+    let dir = tempfile::tempdir().unwrap();
+    let bin = dir.path().join("fake-docker");
+    let log = dir.path().join("argv.log");
+    let sq = |s: &str| format!("'{}'", s.replace('\'', "'\\''"));
+    // On `exec`, shift past every flag up to AND including the `pdo-sbx-<run>`
+    // container name, then exec the remaining argv (`bash -lc '<tail>'`). No arg
+    // before the container name starts with `pdo-sbx-` (the session marker is
+    // `PDO_SBX_SESSION=pdo-<run>-<node>-…`, a distinct prefix), so the match is
+    // unambiguous.
+    let script = format!(
+        "#!/usr/bin/env bash\n\
+         printf '%s\\n' \"$@\" >> {log}\n\
+         case \"$1\" in\n\
+         image) exit 0 ;;\n\
+         container) printf 'true'; exit 0 ;;\n\
+         exec)\n\
+         shift\n\
+         while [ \"$#\" -gt 0 ]; do\n\
+         case \"$1\" in\n\
+         pdo-sbx-*) shift; break ;;\n\
+         *) shift ;;\n\
+         esac\n\
+         done\n\
+         exec \"$@\"\n\
+         ;;\n\
+         *) exit 0 ;;\n\
+         esac\n",
+        log = sq(&log.display().to_string()),
+    );
+    std::fs::write(&bin, &script).unwrap();
+    std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
+    (dir, bin.to_str().unwrap().to_string(), log)
+}
+
+fn log_text(log: &Path) -> String {
+    std::fs::read_to_string(log).unwrap_or_default()
+}
+
+async fn start_run(daemon: &TestDaemon, sandbox: Option<&str>) -> String {
+    let mut body = serde_json::json!({ "pipeline": "sbx-obs", "input": "hello" });
+    if let Some(mode) = sandbox {
+        body["sandbox"] = serde_json::json!(mode);
+    }
+    let resp = reqwest::Client::new()
+        .post(format!("{}/runs", daemon.url()))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 201, "POST /runs should create the run");
+    resp.json::<serde_json::Value>().await.unwrap()["run_id"]
+        .as_str()
+        .unwrap()
+        .to_string()
+}
+
+async fn get_run(daemon: &TestDaemon, run_id: &str) -> serde_json::Value {
+    reqwest::get(format!("{}/runs/{run_id}", daemon.url()))
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap()
+}
+
+async fn wait_until<F>(mut pred: F) -> bool
+where
+    F: FnMut() -> bool,
+{
+    let deadline = Instant::now() + Duration::from_secs(30);
+    while Instant::now() < deadline {
+        if pred() {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    pred()
+}
+
+async fn wait_node_status(daemon: &TestDaemon, run_id: &str, expected: &str) -> serde_json::Value {
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let mut last = serde_json::Value::Null;
+    while Instant::now() < deadline {
+        let run = get_run(daemon, run_id).await;
+        if run["nodes"][NODE_ID]["status"] == expected {
+            return run;
+        }
+        last = run;
+        tokio::time::sleep(Duration::from_millis(150)).await;
+    }
+    last
+}
+
+async fn wait_run_status(daemon: &TestDaemon, run_id: &str, expected: &str) -> serde_json::Value {
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let mut last = serde_json::Value::Null;
+    while Instant::now() < deadline {
+        let run = get_run(daemon, run_id).await;
+        if run["status"] == expected {
+            return run;
+        }
+        last = run;
+        tokio::time::sleep(Duration::from_millis(150)).await;
+    }
+    last
+}
+
+async fn post_command(
+    daemon: &TestDaemon,
+    run_id: &str,
+    body: serde_json::Value,
+) -> reqwest::Response {
+    reqwest::Client::new()
+        .post(format!("{}/runs/{run_id}/commands", daemon.url()))
+        .json(&body)
+        .send()
+        .await
+        .unwrap()
+}
+
+/// Write the worker's declared `out` artifact so node-done's output validation
+/// passes (host path == container path via the identity mount).
+fn write_node_output(daemon: &TestDaemon, run_id: &str, content: &str) {
+    let out = daemon
+        .repo_root()
+        .join(".pdo/runs")
+        .join(run_id)
+        .join("worktree/.pdo/artifacts")
+        .join(NODE_ID)
+        .join("iter-1/out/output.md");
+    std::fs::create_dir_all(out.parent().unwrap()).unwrap();
+    std::fs::write(&out, content).unwrap();
+}
+
+async fn simulate_node_done(daemon: &TestDaemon, run_id: &str) {
+    let resp = reqwest::Client::new()
+        .post(format!("{}/runs/{run_id}/nodes/{NODE_ID}/done", daemon.url()))
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .unwrap();
+    assert!(
+        resp.status().is_success(),
+        "simulated pdo complete should succeed: {}",
+        resp.status()
+    );
+}
+
+/// The Run's pipeline worktree (the doc-only worker's cwd — non-CM nodes run
+/// there). Both the cost prefix and the stale probe encode THIS path.
+fn worktree_dir(daemon: &TestDaemon, run_id: &str) -> PathBuf {
+    daemon
+        .repo_root()
+        .join(".pdo/runs")
+        .join(run_id)
+        .join("worktree")
+}
+
+/// The staged Claude `projects/` root for a sandboxed run (under the tempdir home).
+fn staging_projects(daemon: &TestDaemon, run_id: &str) -> PathBuf {
+    daemon
+        .repo_root()
+        .join(".pdo/sandbox")
+        .join(run_id)
+        .join("claude-home/projects")
+}
+
+/// The host `~/.claude/projects/` root (the tempdir home override).
+fn host_projects(daemon: &TestDaemon) -> PathBuf {
+    daemon.repo_root().join(".claude/projects")
+}
+
+/// One priced assistant transcript line: `input` opus-4-8 tokens (× $5/MTok).
+fn priced_line(id: &str, req: &str, input: u64) -> String {
+    format!(
+        r#"{{"type":"assistant","requestId":"{req}","message":{{"id":"{id}","model":"claude-opus-4-8","usage":{{"input_tokens":{input},"output_tokens":0}}}}}}"#
+    )
+}
+
+/// Plant a transcript for `run_id`'s worktree cwd under `projects_root`, returning
+/// the `.jsonl` path. Optionally back-date it so the stale sweep sees it idle.
+fn plant_transcript(
+    projects_root: &Path,
+    daemon: &TestDaemon,
+    run_id: &str,
+    body: &str,
+    age: Option<Duration>,
+) -> PathBuf {
+    let enc = encode_working_dir(&worktree_dir(daemon, run_id));
+    let proj = projects_root.join(enc);
+    std::fs::create_dir_all(&proj).unwrap();
+    let file = proj.join("s.jsonl");
+    std::fs::write(&file, body).unwrap();
+    if let Some(age) = age {
+        filetime::set_file_mtime(
+            &file,
+            filetime::FileTime::from_system_time(SystemTime::now() - age),
+        )
+        .unwrap();
+    }
+    file
+}
+
+// -- Test 1: cost reads the staged home while a sandboxed run is live ----------
+
+#[tokio::test]
+async fn cost_reads_staging_during_pure_run() {
+    if !tmux_available() {
+        eprintln!("tmux not on PATH — skipping");
+        return;
+    }
+    ensure_pdo_on_path();
+    let (_fake, docker, _log) = write_live_docker();
+    let daemon = TestDaemon::spawn_with_docker_and_tmux_override(
+        seed,
+        docker,
+        Some("exec sleep 600".to_string()),
+    )
+    .await
+    .unwrap();
+
+    let run_id = start_run(&daemon, Some("pure")).await;
+    // The worker reaches Running with a live (sleeping) session; its staging is
+    // seeded by the eager prep.
+    wait_node_status(&daemon, &run_id, "running").await;
+    assert!(
+        wait_until(|| staging_projects(&daemon, &run_id).parent().unwrap().exists()).await,
+        "the staging home must exist during a live sandboxed run"
+    );
+
+    // Staging: $5 (1M opus input). Host: $10 (2M) — bigger, to prove the seam
+    // sources the STAGING while the run is live, not `~/.claude`.
+    plant_transcript(
+        &staging_projects(&daemon, &run_id),
+        &daemon,
+        &run_id,
+        &format!("{}\n", priced_line("m1", "r1", 1_000_000)),
+        None,
+    );
+    plant_transcript(
+        &host_projects(&daemon),
+        &daemon,
+        &run_id,
+        &format!("{}\n", priced_line("m2", "r2", 2_000_000)),
+        None,
+    );
+
+    let run = get_run(&daemon, &run_id).await;
+    let usd = run["cost"]["usd"].as_f64().unwrap_or(-1.0);
+    assert!(
+        (usd - 5.0).abs() < 1e-9,
+        "cost must read the STAGED transcript ($5) during a live sandboxed run, \
+         not the larger host transcript ($10): cost = {}",
+        run["cost"]
+    );
+}
+
+// -- Test 2: stale-detection reads the staged home while live ------------------
+
+#[tokio::test]
+async fn stale_detection_reads_staging_during_pure_run() {
+    if !tmux_available() {
+        eprintln!("tmux not on PATH — skipping");
+        return;
+    }
+    ensure_pdo_on_path();
+    let (_fake, docker, _log) = write_live_docker();
+    let daemon = TestDaemon::spawn_with_docker_and_tmux_override(
+        seed,
+        docker,
+        Some("exec sleep 600".to_string()),
+    )
+    .await
+    .unwrap();
+
+    let run_id = start_run(&daemon, Some("pure")).await;
+    wait_node_status(&daemon, &run_id, "running").await;
+    assert!(
+        wait_until(|| staging_projects(&daemon, &run_id).parent().unwrap().exists()).await,
+        "the staging home must exist during a live sandboxed run"
+    );
+
+    // Idle (back-dated 300s) transcript in the STAGING only; outputs incomplete
+    // (worker `out` never written). If the sweep read `~/.claude` (empty) the
+    // node would stay Running — so `stale` proves it read the staging.
+    plant_transcript(
+        &staging_projects(&daemon, &run_id),
+        &daemon,
+        &run_id,
+        "{}\n",
+        Some(Duration::from_secs(300)),
+    );
+
+    daemon.run_stale_detection_tick().await;
+
+    let run = get_run(&daemon, &run_id).await;
+    assert_eq!(
+        run["nodes"][NODE_ID]["status"], "stale",
+        "stale-detection must read the STAGED transcript for a live sandboxed run: {run}"
+    );
+}
+
+// -- Test 3: terminal transition merges staging into ~/.claude/projects --------
+
+#[tokio::test]
+async fn terminal_merges_staging_into_host_claude_projects() {
+    if !tmux_available() {
+        eprintln!("tmux not on PATH — skipping");
+        return;
+    }
+    ensure_pdo_on_path();
+    let (_fake, docker, _log) = write_live_docker();
+    let daemon = TestDaemon::spawn_with_docker_and_tmux_override(
+        seed,
+        docker,
+        Some("exec sleep 600".to_string()),
+    )
+    .await
+    .unwrap();
+
+    let run_id = start_run(&daemon, Some("pure")).await;
+    wait_node_status(&daemon, &run_id, "running").await;
+    assert!(
+        wait_until(|| staging_projects(&daemon, &run_id).parent().unwrap().exists()).await,
+        "staging must exist before the terminal merge"
+    );
+    let body = format!("{}\n", priced_line("m1", "r1", 1_000_000));
+    plant_transcript(&staging_projects(&daemon, &run_id), &daemon, &run_id, &body, None);
+
+    // Drive the run terminal (worker output present → run completes).
+    write_node_output(&daemon, &run_id, "done\n");
+    simulate_node_done(&daemon, &run_id).await;
+    wait_run_status(&daemon, &run_id, "completed").await;
+
+    // The detached terminal merge lands the transcript in the host projects dir
+    // at the standard encoded dirname, verbatim.
+    let enc = encode_working_dir(&worktree_dir(&daemon, &run_id));
+    let host_file = host_projects(&daemon).join(&enc).join("s.jsonl");
+    assert!(
+        wait_until(|| host_file.is_file()).await,
+        "terminal merge must copy the transcript to {host_file:?}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&host_file).unwrap(),
+        body,
+        "the host transcript must be a verbatim copy of the staged one"
+    );
+    // Cost is still visible post-terminal (staging present → seam reads staging;
+    // either way the value is $5).
+    let run = get_run(&daemon, &run_id).await;
+    assert!(
+        (run["cost"]["usd"].as_f64().unwrap_or(-1.0) - 5.0).abs() < 1e-9,
+        "cost must stay $5 after the terminal transition: {run}"
+    );
+}
+
+// -- Test 4: double merge (terminal then cleanup) is byte-identical ------------
+
+#[tokio::test]
+async fn double_merge_terminal_then_cleanup_is_identical() {
+    if !tmux_available() {
+        eprintln!("tmux not on PATH — skipping");
+        return;
+    }
+    ensure_pdo_on_path();
+    let (_fake, docker, _log) = write_live_docker();
+    let daemon = TestDaemon::spawn_with_docker_and_tmux_override(
+        seed,
+        docker,
+        Some("exec sleep 600".to_string()),
+    )
+    .await
+    .unwrap();
+
+    let run_id = start_run(&daemon, Some("pure")).await;
+    wait_node_status(&daemon, &run_id, "running").await;
+    assert!(
+        wait_until(|| staging_projects(&daemon, &run_id).parent().unwrap().exists()).await,
+        "staging must exist"
+    );
+    let body = format!("{}\n", priced_line("m1", "r1", 1_000_000));
+    plant_transcript(&staging_projects(&daemon, &run_id), &daemon, &run_id, &body, None);
+
+    write_node_output(&daemon, &run_id, "done\n");
+    simulate_node_done(&daemon, &run_id).await;
+    wait_run_status(&daemon, &run_id, "completed").await;
+
+    let enc = encode_working_dir(&worktree_dir(&daemon, &run_id));
+    let host_dir = host_projects(&daemon).join(&enc);
+    let host_file = host_dir.join("s.jsonl");
+    assert!(
+        wait_until(|| host_file.is_file()).await,
+        "terminal merge must produce {host_file:?}"
+    );
+    let after_terminal = std::fs::read(&host_file).unwrap();
+
+    // Second merge at cleanup_run (before teardown), then archive.
+    let resp = post_command(&daemon, &run_id, serde_json::json!({ "kind": "cleanup_run" })).await;
+    assert!(resp.status().is_success(), "cleanup_run should archive");
+    wait_run_status(&daemon, &run_id, "archived").await;
+
+    // Byte-identical, exactly one file (no duplicate / `*.tmp` residue), and the
+    // staging is gone.
+    assert_eq!(
+        std::fs::read(&host_file).unwrap(),
+        after_terminal,
+        "the cleanup merge must be byte-identical to the terminal merge (idempotent)"
+    );
+    let files: Vec<_> = std::fs::read_dir(&host_dir)
+        .unwrap()
+        .flatten()
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .collect();
+    assert_eq!(
+        files,
+        vec!["s.jsonl".to_string()],
+        "exactly one merged file, no duplicate/tmp residue: {files:?}"
+    );
+    assert!(
+        !daemon
+            .repo_root()
+            .join(".pdo/sandbox")
+            .join(&run_id)
+            .exists(),
+        "cleanup must purge the staging after the merge"
+    );
+}
+
+// -- Test 5: resume re-arms the container (ensure_ready) -----------------------
+
+#[tokio::test]
+async fn resume_reengages_seam_and_ensures_container() {
+    if !tmux_available() {
+        eprintln!("tmux not on PATH — skipping");
+        return;
+    }
+    ensure_pdo_on_path();
+    let (_fake, docker, log) = write_live_docker();
+    let daemon = TestDaemon::spawn_with_docker_and_tmux_override(
+        seed,
+        docker,
+        Some("exec sleep 600".to_string()),
+    )
+    .await
+    .unwrap();
+
+    let run_id = start_run(&daemon, Some("pure")).await;
+    wait_node_status(&daemon, &run_id, "running").await;
+    write_node_output(&daemon, &run_id, "done\n");
+    simulate_node_done(&daemon, &run_id).await;
+    wait_run_status(&daemon, &run_id, "completed").await;
+
+    // Count container probes so far; resuming must run ensure_ready again (which
+    // always probes the container), so the count strictly increases.
+    let probes_before = log_text(&log).lines().filter(|l| *l == "container").count();
+
+    let resp = post_command(&daemon, &run_id, serde_json::json!({ "kind": "resume_run" })).await;
+    assert_eq!(
+        resp.status(),
+        200,
+        "resume of a sandboxed run must return OK once the container is ensured"
+    );
+
+    assert!(
+        wait_until(|| log_text(&log).lines().filter(|l| *l == "container").count() > probes_before)
+            .await,
+        "resume must re-arm the container via ensure_ready (a fresh container probe); log:\n{}",
+        log_text(&log)
+    );
+}
+
+// -- Test 6: resume fails loud when Docker is unavailable ----------------------
+
+#[tokio::test]
+async fn resume_fails_loud_when_docker_unavailable() {
+    ensure_pdo_on_path();
+    // A docker binary that does not exist: eager prep fails → RunFailed, and the
+    // resume guard's ensure_ready fails too → explicit 500, never a host fallback.
+    let daemon = TestDaemon::spawn_with_docker_and_tmux_override(
+        seed,
+        "/nonexistent/pdo-fake-docker-obs".to_string(),
+        Some("exec true".to_string()),
+    )
+    .await
+    .unwrap();
+
+    let run_id = start_run(&daemon, Some("pure")).await;
+    wait_run_status(&daemon, &run_id, "failed").await;
+
+    let resp = post_command(&daemon, &run_id, serde_json::json!({ "kind": "resume_run" })).await;
+    assert_eq!(
+        resp.status(),
+        500,
+        "resuming a sandboxed run with Docker unavailable must fail loud, not fall back to the host"
+    );
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert!(
+        body["error"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("sandbox container unavailable"),
+        "the 500 must name the sandbox-container failure: {body}"
+    );
+}

--- a/crates/pdo-daemon/tests/sandbox_observability.rs
+++ b/crates/pdo-daemon/tests/sandbox_observability.rs
@@ -258,7 +258,10 @@ fn write_node_output(daemon: &TestDaemon, run_id: &str, content: &str) {
 
 async fn simulate_node_done(daemon: &TestDaemon, run_id: &str) {
     let resp = reqwest::Client::new()
-        .post(format!("{}/runs/{run_id}/nodes/{NODE_ID}/done", daemon.url()))
+        .post(format!(
+            "{}/runs/{run_id}/nodes/{NODE_ID}/done",
+            daemon.url()
+        ))
         .json(&serde_json::json!({}))
         .send()
         .await
@@ -348,7 +351,11 @@ async fn cost_reads_staging_during_pure_run() {
     // seeded by the eager prep.
     wait_node_status(&daemon, &run_id, "running").await;
     assert!(
-        wait_until(|| staging_projects(&daemon, &run_id).parent().unwrap().exists()).await,
+        wait_until(|| staging_projects(&daemon, &run_id)
+            .parent()
+            .unwrap()
+            .exists())
+        .await,
         "the staging home must exist during a live sandboxed run"
     );
 
@@ -400,7 +407,11 @@ async fn stale_detection_reads_staging_during_pure_run() {
     let run_id = start_run(&daemon, Some("pure")).await;
     wait_node_status(&daemon, &run_id, "running").await;
     assert!(
-        wait_until(|| staging_projects(&daemon, &run_id).parent().unwrap().exists()).await,
+        wait_until(|| staging_projects(&daemon, &run_id)
+            .parent()
+            .unwrap()
+            .exists())
+        .await,
         "the staging home must exist during a live sandboxed run"
     );
 
@@ -445,11 +456,21 @@ async fn terminal_merges_staging_into_host_claude_projects() {
     let run_id = start_run(&daemon, Some("pure")).await;
     wait_node_status(&daemon, &run_id, "running").await;
     assert!(
-        wait_until(|| staging_projects(&daemon, &run_id).parent().unwrap().exists()).await,
+        wait_until(|| staging_projects(&daemon, &run_id)
+            .parent()
+            .unwrap()
+            .exists())
+        .await,
         "staging must exist before the terminal merge"
     );
     let body = format!("{}\n", priced_line("m1", "r1", 1_000_000));
-    plant_transcript(&staging_projects(&daemon, &run_id), &daemon, &run_id, &body, None);
+    plant_transcript(
+        &staging_projects(&daemon, &run_id),
+        &daemon,
+        &run_id,
+        &body,
+        None,
+    );
 
     // Drive the run terminal (worker output present → run completes).
     write_node_output(&daemon, &run_id, "done\n");
@@ -499,11 +520,21 @@ async fn double_merge_terminal_then_cleanup_is_identical() {
     let run_id = start_run(&daemon, Some("pure")).await;
     wait_node_status(&daemon, &run_id, "running").await;
     assert!(
-        wait_until(|| staging_projects(&daemon, &run_id).parent().unwrap().exists()).await,
+        wait_until(|| staging_projects(&daemon, &run_id)
+            .parent()
+            .unwrap()
+            .exists())
+        .await,
         "staging must exist"
     );
     let body = format!("{}\n", priced_line("m1", "r1", 1_000_000));
-    plant_transcript(&staging_projects(&daemon, &run_id), &daemon, &run_id, &body, None);
+    plant_transcript(
+        &staging_projects(&daemon, &run_id),
+        &daemon,
+        &run_id,
+        &body,
+        None,
+    );
 
     write_node_output(&daemon, &run_id, "done\n");
     simulate_node_done(&daemon, &run_id).await;
@@ -519,7 +550,12 @@ async fn double_merge_terminal_then_cleanup_is_identical() {
     let after_terminal = std::fs::read(&host_file).unwrap();
 
     // Second merge at cleanup_run (before teardown), then archive.
-    let resp = post_command(&daemon, &run_id, serde_json::json!({ "kind": "cleanup_run" })).await;
+    let resp = post_command(
+        &daemon,
+        &run_id,
+        serde_json::json!({ "kind": "cleanup_run" }),
+    )
+    .await;
     assert!(resp.status().is_success(), "cleanup_run should archive");
     wait_run_status(&daemon, &run_id, "archived").await;
 
@@ -578,7 +614,12 @@ async fn resume_reengages_seam_and_ensures_container() {
     // always probes the container), so the count strictly increases.
     let probes_before = log_text(&log).lines().filter(|l| *l == "container").count();
 
-    let resp = post_command(&daemon, &run_id, serde_json::json!({ "kind": "resume_run" })).await;
+    let resp = post_command(
+        &daemon,
+        &run_id,
+        serde_json::json!({ "kind": "resume_run" }),
+    )
+    .await;
     assert_eq!(
         resp.status(),
         200,
@@ -611,7 +652,12 @@ async fn resume_fails_loud_when_docker_unavailable() {
     let run_id = start_run(&daemon, Some("pure")).await;
     wait_run_status(&daemon, &run_id, "failed").await;
 
-    let resp = post_command(&daemon, &run_id, serde_json::json!({ "kind": "resume_run" })).await;
+    let resp = post_command(
+        &daemon,
+        &run_id,
+        serde_json::json!({ "kind": "resume_run" }),
+    )
+    .await;
     assert_eq!(
         resp.status(),
         500,

--- a/docs/adr/0022-estimated-cost-from-local-transcripts.md
+++ b/docs/adr/0022-estimated-cost-from-local-transcripts.md
@@ -86,6 +86,17 @@ persisté, et l'UI l'étiquette explicitement « est. ».
   N'ajoute **pas** le coût au handler de **liste** (`GET /runs`) : il éviterait un scan de
   transcripts fan-out par poll.
 
+## Amendement — Runs sandboxés (#408)
+
+Le read-source `~/.claude/projects/` n'est plus figé : `compute_run_cost` (et son memo
+`compute_run_cost_cached`) prennent un `transcripts_root` **injectable** — le seam
+`sandbox_run::transcripts_root` (ADR-0030 pt 9). Un Run sandboxé **vivant** lit son *staged home*
+(`~/.pdo/sandbox/<run-id>/claude-home/projects/`, alimenté en direct par l'identity mount) ; après
+`cleanup_run`, `merge_back` a flushé les transcripts vers `~/.claude/projects/` et la racine
+redevient le défaut hôte. Un Run `off` lit **toujours** `~/.claude/projects/` — invariant inchangé.
+Le memo garde la **même** racine pour la clé (`max mtime`) et la valeur (agrégat), donc pas de désync.
+La dédup `(message.id, requestId)` reste la garantie anti-double-comptage, quelle que soit la racine.
+
 ## Alternatives rejetées
 
 - **Embarquer / shell-out `ccusage`** — dépendance binaire/Node + réseau ; daemon network-free.

--- a/docs/adr/0030-sandbox-execution-model.md
+++ b/docs/adr/0030-sandbox-execution-model.md
@@ -56,6 +56,19 @@ PID 1 = tini). Les guards de Trigger restent hôte (décision de fiançailles, p
    retrouverait pas son transcript (indexé par chemin de travail). En #407 le mode n'arrive que par le
    paramètre de l'API `POST /runs` ; les fires de Trigger passent `off` (précédence des sources #410).
 
+9. **Observabilité (câblée #408).** `merge_back` est câblé dans le run-advance — à la **transition
+   terminale** (chokepoint `append_event`, tâche détachée pour ne pas coupler la latence/l'échec de la
+   transition, cohérent ADR-0023) **et** à `cleanup_run` (avant `teardown`, synchrone, pour capter la
+   croissance post-terminale : resume, flushs tardifs de sous-agents). Double merge = état identique
+   (copy-if-absent-or-larger idempotent). Coût (`run_cost`) et stale/AutoComplete (`stale_detector`)
+   deviennent sandbox-conscients via le seam `transcripts_root(mode, run_id, home_root, sandbox_root)`,
+   consommé par les **deux** (source unique, pas d'encodeur dupliqué — leçon #373) : Run sandboxé
+   **vivant** → le staging ; après `cleanup_run` → `~/.claude/projects/`. Dispatch **keyé sur
+   l'existence du staging dir** (pas le statut terminal : reste correct si le merge terminal best-effort
+   a échoué). `resume_run` re-arme d'abord le conteneur (`ensure_ready`-ou-échec, miroir du run-shell)
+   car sans `--restart` il est down après un reboot hôte. **session-died** reste
+   transcript-indépendante.
+
 ## Pourquoi (le trou d'auth assumé v1)
 
 Le daemon expose une API HTTP **non authentifiée**, liée à `0.0.0.0` (lib.rs, #260 CLOSED — choix
@@ -92,11 +105,6 @@ l'hôte qu'un Run hôte.
 
 ## Limites acceptées
 
-- **Observabilité en attente de #408.** `merge_back` n'est PAS câblé en #407 : coût (`run_cost`) et
-  détection stale/AutoComplete (`stale_detector`) sont **aveugles** pour un Run sandboxé (ils lisent
-  `~/.claude/projects/`, vide) ; les transcripts sont purgés au `cleanup_run`. Trou
-  d'**observabilité**, pas de correction : **session-died** (la détection critique pour la liveness)
-  est transcript-indépendante et reste vivante. #408 referme (merge_back + seam `transcripts_root`).
 - **uid hôte ≠ 1000.** `sudo` (getpwuid avant NOPASSWD) et `claude` (`os.userInfo()`) peuvent casser
   faute d'entrée `/etc/passwd` ; ubuntu:24.04 livre `ubuntu`=1000 → le cas laptop courant résout.
   Injection `/etc/passwd`+`/etc/group` différée à une issue de suivi (ne PAS éditer le Dockerfile,


### PR DESCRIPTION
Slice E du PRD #403 (sandbox Docker par run) : observabilité pendant qu'un run sandboxé est vivant.

## Contenu
- **Seam `transcripts_root`** : coût (`run_cost`, `stats`) et détection de staleness (`stale_detector`) lisent les transcripts depuis le home stagé tant que le run sandboxé tourne, plutôt que depuis `~/.claude` de l'hôte.
- **`merge_back` câblé** : récolte du home stagé vers `~/.claude/projects` sur la transition terminale du run et à `cleanup_run` (idempotent — double-merge terminal puis cleanup vérifié identique).
- **Correctif `resume_run`** : garde `ensure_ready`-ou-échec pour ré-armer le conteneur avant de reprendre.
- Docs : CONTEXT.md (section sandbox), ADR-0030 (modèle d'exécution sandbox), ADR-0022 (coût depuis transcripts locaux).
- Tests : `tests/sandbox_observability.rs` (6 tests, fake docker + tmux réel), chacun mappant un critère d'acceptation.

## Validation
Toutes les portes CI reproduites en `+stable` passent : `fmt --all --check`, `check --workspace --all-targets`, `clippy -D warnings` (0 warning), `test --workspace` (1549 passed / 0 failed). Le diff iter-2 (`dec1203`) est du re-formatage rustfmt pur, sans changement de comportement.

Cible : `integration/prd-403-sandbox`. Pas de bump de version (reste `0.1.99`).

Closes #408
