### PR TITLE
feat(#409): sandbox mode copy end-to-end — deref escaping symlinks + best-effort walk + trust seed

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -822,7 +822,10 @@ La complétion est signalée **depuis l'UI**, par un bouton "Mark complete" sur 
 > conteneur** (#406, *Exécution (conteneur)*) + **câblage run-advance** (#407 : prep eager fail-fast,
 > wrapping des tails au chokepoint, kill/cleanup/boot/run-shell) fixé par **ADR-0030** (modèle
 > d'exécution : réseau/uid, trou d'auth assumé v1 lié à #260) + **observabilité** (#408 : `merge_back`
-> câblé à la transition terminale + `cleanup_run`, seam `transcripts_root` pour coût/stale). Reste
+> câblé à la transition terminale + `cleanup_run`, seam `transcripts_root` pour coût/stale) +
+> **mode `copy` de bout en bout** (#409 : vérifie `prepare`(allowlist copy) → conteneur →
+> `merge_back` ; même câblage mode-agnostique que #407, ne diffère de `pure` que par le seed de
+> `prepare` — deref des symlinks échappants + walk best-effort en sus). Reste
 > **différé** : précédence des sources du mode (#410), fourniture par registry (#411).
 
 **Sandbox** :
@@ -850,11 +853,20 @@ Le `.claude.json` vit à côté (`~/.pdo/sandbox/<run-id>/.claude.json`), monté
 **`prepare(mode, run_id)`** :
 Seede le *staged Claude home* selon le mode. **`copy`** : recopie une **liste explicite** de
 `~/.claude` (skills, plugins, agents, commands, output-styles, settings[.local].json, credentials,
-`*.md` global) + `~/.claude.json` verbatim ; **exclut `projects/`** et tout état hôte volumineux
-(`history.jsonl`, `session-env/`, …). **`pure`** : uniquement `.credentials.json` + un `.claude.json`
-minimal (onboarding validé + confiance pré-accordée à la racine du Run). Dans les deux modes,
-`projects/` est créé **vide** (puits de transcripts runtime). Symlinks et bits exécutables préservés.
-_Éviter_ : « init », « seed » seul.
+`*.md` global) + `~/.claude.json` verbatim, **avec la confiance de la racine du Run mergée** dedans
+(#409 D5 — sinon un Run autonome se bloquerait sur le dialogue « trust this folder ? ») ; **exclut
+`projects/`** et tout état hôte volumineux (`history.jsonl`, `session-env/`, …). Les symlinks qui
+**sortent** de `~/.claude` (skills liés à `~/.agents`) sont **déréférencés** (recréés verbatim ils
+dangleraient dans le conteneur) ; les liens intra-arbre (`node_modules/.bin`) restent des liens. Walk
+**best-effort par entrée** : un `~/.claude` volatil ne fait jamais échouer le Run. **`pure`** :
+uniquement `.credentials.json` + un `.claude.json` minimal (onboarding validé + confiance
+pré-accordée à la racine du Run). Dans les deux modes, `projects/` est créé **vide** (puits de
+transcripts runtime). Bits exécutables préservés. **Volume/PII (#409)** : `copy` pèse **~1 Go/run**
+(dominé par `plugins/*/node_modules`, requis par les serveurs MCP *in-container* — délibérément non
+strippés) et expose en plus le profil PII (`oauthAccount`/`userID`/`emailAddress`) + settings + `.md`
+globaux que `pure` retient (choix conscient, aligné sur le trou d'auth d'ADR-0030). Dette disque : le
+staging n'est purgé qu'au `cleanup_run` (surveiller vs la récurrence disque connue). _Éviter_ :
+« init », « seed » seul.
 
 **`merge_back(run_id)`** :
 À la transition terminale du Run **et** à `cleanup_run` : recopie **uniquement** les `*.jsonl` de
@@ -980,6 +992,12 @@ absent (idempotent). C'est **le** verbe « destroy / destruction » réservé pa
   (`run_cost`) + stale (`stale_detector`) via le seam `transcripts_root` (staging si Run sandboxé
   vivant, `~/.claude/projects/` sinon) ; garde `ensure_ready`-ou-échec ajouté à `resume_run` (re-arme
   le conteneur après reboot hôte).
+- **Vérifié e2e (#409)** : le mode `copy` tourne le **même câblage mode-agnostique** que #407 (aucun
+  net-new run-advance) ; il ne diffère de `pure` que par le seed de `prepare` — deref des symlinks
+  **échappants** (les skills liés à `~/.agents` ne danglent plus), walk **best-effort**, et confiance
+  `repo_root` mergée dans le `.claude.json` copié (D5). Aucune écriture de config ne revient vers
+  l'hôte (`merge_back` reste jsonl-only). Couvert par unit + 4 tests layer-3 (`sandbox_tracer`) + le
+  Feature Path agentique L5 (Docker réel).
 - **Différé** : injection `/etc/passwd`+`/etc/group` pour uid hôte ≠ 1000 (sudo +
   Node `os.userInfo()`) (issue de suivi) ; précédence des sources du mode (run → trigger →
   `default_sandbox`, pattern ADR-0015) (#410) ; **fourniture par registry** (pull GHCR +

--- a/crates/pdo-daemon/src/sandbox_run.rs
+++ b/crates/pdo-daemon/src/sandbox_run.rs
@@ -200,15 +200,18 @@ pub(crate) fn ensure_ready(ctx: &SandboxContext) -> Result<()> {
         return Ok(()); // off: gated by callers; no docker touched.
     };
 
-    // 1. Stage the Claude home ONCE. The ~98 MB `copy` walk (and the `pure` seed)
+    // 1. Stage the Claude home ONCE. The ~1 GB `copy` walk (and the `pure` seed)
     //    must not repeat on every ensure_ready — gate on the staging dir already
-    //    existing. `pure` pre-approves the trust dialog on `repo_root`, the common
-    //    ancestor of the pipeline worktree AND every node sub-worktree.
+    //    existing. BOTH sandboxed modes pre-approve the trust dialog on `repo_root`,
+    //    the common ancestor of the pipeline worktree AND every node sub-worktree:
+    //    `pure` writes a minimal `.claude.json`; `copy` (#409, D5) merges the trust
+    //    into the copied host `.claude.json` (else a repo the host never opened
+    //    would block an autonomous Run on the "trust this folder?" dialog).
     let staging_dir = sandbox_staging::staging_dir_for_run(&ctx.sandbox_root, &ctx.run_id);
     if !staging_dir.exists() {
         let trusted_root = match ctx.mode {
-            SandboxMode::Pure => Some(ctx.repo_root.as_path()),
-            _ => None,
+            SandboxMode::Pure | SandboxMode::Copy => Some(ctx.repo_root.as_path()),
+            SandboxMode::Off => None,
         };
         sandbox_staging::prepare(
             &ctx.home_root,
@@ -451,6 +454,29 @@ mod tests {
         assert!(
             sentinel.exists(),
             "staging must not be re-prepared when present"
+        );
+    }
+
+    #[test]
+    fn ensure_ready_copy_seeds_trust_for_repo_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (docker, _log) = write_fake_docker(tmp.path());
+        let ctx = test_ctx(tmp.path(), docker, SandboxMode::Copy);
+
+        retry_etxtbsy(|| ensure_ready(&ctx)).unwrap();
+
+        // #409 D5: copy stages a `.claude.json`, and ensure_ready pre-approves the
+        // Run's repo_root trust dialog in it — even when the host had no
+        // `.claude.json` (an autonomous Run must not block on "trust this folder?").
+        let staged = sandbox_staging::staged_claude_json(&ctx.sandbox_root, "r1");
+        assert!(staged.is_file(), "copy staging writes a .claude.json");
+        let json: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&staged).unwrap()).unwrap();
+        let key = ctx.repo_root.to_string_lossy().into_owned();
+        assert_eq!(
+            json["projects"][&key]["hasTrustDialogAccepted"],
+            serde_json::json!(true),
+            "copy must pre-approve the repo_root trust dialog: {json}"
         );
     }
 

--- a/crates/pdo-daemon/src/sandbox_staging.rs
+++ b/crates/pdo-daemon/src/sandbox_staging.rs
@@ -15,9 +15,20 @@
 //!
 //! ## Décisions de conception (voir la section « Sandbox » de `CONTEXT.md`)
 //! - **`copy` = allowlist, jamais denylist.** Copier « tout `~/.claude` sauf
-//!   `projects/` » embarquerait ~98 Mo d'état hôte (`history.jsonl`,
+//!   `projects/` » embarquerait tout l'état hôte transitoire (`history.jsonl`,
 //!   `session-env/`, `file-history/`…) — fuite d'isolation + fragile aux futures
 //!   versions de Claude Code. On copie une liste explicite.
+//! - **Volume assumé ~1 Go/run** (#409, mesuré ; dominé par `plugins/*/node_modules`,
+//!   requis par les serveurs MCP *dans* le conteneur — délibérément non strippés).
+//!   Dette disque : le staging n'est purgé qu'au `cleanup_run` → à surveiller au
+//!   regard de la récurrence disque connue (recette janitor pour l'usage massif).
+//! - **Symlinks échappants déréférencés** (#409). Une part notable des skills sont
+//!   des liens relatifs vers `~/.agents` (hors `~/.claude`, ni copié ni monté) :
+//!   recréés verbatim ils dangleraient dans le conteneur (skills invisibles).
+//!   [`copy_tree_preserving`] copie donc le CONTENU réel des liens qui **sortent** de
+//!   l'arbre `~/.claude` ; les liens **intra-arbre** (cycles `node_modules/.bin`)
+//!   restent des liens. Walk **best-effort par entrée** : un `~/.claude` volumineux
+//!   que d'autres process Claude mutent ne doit jamais faire échouer le Run.
 //! - **`merge_back` récurse.** ~42 % des transcripts vivent dans
 //!   `projects/<enc>/<uuid>/subagents/*.jsonl` (profondeur 9). Le copy-set doit
 //!   *égaler* le read-set de [`crate::run_cost`] (`collect_jsonl_recursive`),
@@ -33,6 +44,7 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use anyhow::{Context, Result};
+use tracing::warn;
 
 /// Comment le *staged Claude home* d'un Run est seedé. `off` (PRD) n'est PAS une
 /// variante : le caller skippe simplement [`prepare`] (pas de branche no-op dans
@@ -81,8 +93,11 @@ pub(crate) fn staged_claude_json(sandbox_root: &Path, run_id: &str) -> PathBuf {
 /// Seede le *staged Claude home* et renvoie sa racine (`<sandbox_root>/<run_id>`).
 ///
 /// Idempotent (`create_dir_all` ; copy-or-overwrite). `trusted_root` : racine à
-/// pré-approuver dans le `.claude.json` en mode `pure` (`None` = objet nu). En
-/// mode `copy`, `trusted_root` est ignoré (la confiance hôte est copiée verbatim).
+/// pré-approuver dans le `.claude.json`. En mode `pure`, `None` = objet nu. En
+/// mode `copy` (#409), une racine fournie est **mergée** dans le `.claude.json`
+/// hôte copié (les autres clés/projets préservés, 0600 réappliqué) — le repo du
+/// Run est ainsi trusté même si l'hôte ne l'avait jamais ouvert (sinon un Run
+/// autonome se bloquerait sur le dialogue « trust this folder ? »).
 pub(crate) fn prepare(
     home_root: &Path,
     sandbox_root: &Path,
@@ -105,11 +120,16 @@ pub(crate) fn prepare(
             for name in COPY_ALLOWLIST_FILES {
                 copy_file_if_present(&src.join(name), &home.join(name))?;
             }
-            // Allowlist dirs : walk préservant symlinks + mode. `projects/` EXCLU.
+            // Allowlist dirs : walk préservant les symlinks intra-arbre + mode,
+            // déréférençant les liens échappants (#409). `projects/` EXCLU.
+            // `copy_root` = la racine canonique `~/.claude` : tout symlink dont la
+            // cible sort de cet arbre est copié déréférencé (sa cible réelle n'est
+            // ni copiée ni montée → danglerait). Best-effort par entrée.
+            let copy_root = std::fs::canonicalize(&src).unwrap_or_else(|_| src.clone());
             for name in COPY_ALLOWLIST_DIRS {
                 let dir_src = src.join(name);
                 if dir_src.is_dir() {
-                    copy_tree_preserving(&dir_src, &home.join(name))?;
+                    copy_tree_preserving(&dir_src, &home.join(name), &copy_root, 0);
                 }
             }
             // `.claude.json` sibling, verbatim (mode préservé). Chemin explicite :
@@ -118,6 +138,12 @@ pub(crate) fn prepare(
                 &home_root.join(".claude.json"),
                 &staged_claude_json(sandbox_root, run_id),
             )?;
+            // D5 (#409) : garantir que le repo du Run est trusté. `copy` s'appuie
+            // sur le `.claude.json` hôte, qui peut n'avoir jamais ouvert ce repo →
+            // Run autonome bloqué sur le dialogue de confiance. Merge non-destructif.
+            if let Some(root) = trusted_root {
+                seed_trust_in_claude_json(&staged_claude_json(sandbox_root, run_id), root)?;
+            }
         }
         Mode::Pure => {
             // Auth = `.credentials.json` seul (`oauthAccount`/`userID` de
@@ -266,40 +292,182 @@ fn set_mode_0600(path: &Path) -> Result<()> {
         .with_context(|| format!("chmod 0600 {}", path.display()))
 }
 
-/// Walk `src` → `dst` en **préservant symlinks et bits exécutables**. Marche par
-/// entrée via [`std::fs::symlink_metadata`] (ne suit PAS les liens) :
-/// - symlink → recréé verbatim (jamais déréférencé : cycles `node_modules/.bin`,
-///   liens cassés, bloat `~/.agents` inlinés) ;
+/// Profondeur de récursion max du walk `copy` — garde-fou défensif contre un cycle
+/// pathologique de symlinks **échappants** (les liens intra-arbre sont recréés,
+/// jamais suivis, donc ne peuvent pas boucler ; seuls les échappants déréférencés
+/// récursent dans un arbre étranger). Un vrai `~/.claude` fait quelques niveaux.
+const MAX_COPY_DEPTH: u32 = 64;
+
+/// Walk `src` → `dst` en **préservant les bits exécutables** et en traitant les
+/// symlinks selon qu'ils **restent dans** l'arbre copié ou en **sortent** (voir
+/// [`stage_symlink`]). Marche par entrée via [`std::fs::symlink_metadata`] (ne suit
+/// PAS les liens) :
+/// - symlink → [`stage_symlink`] (verbatim si intra-`copy_root`, déréférencé sinon) ;
 /// - dir → `create_dir_all` + récursion ;
 /// - file → [`std::fs::copy`] (préserve le mode/exec bit gratis sous Unix) ;
 /// - autre (socket/fifo/device) → skip.
 ///
+/// **Best-effort par entrée** (#409, D3) : toute op ratée (`create_dir`, `read_dir`,
+/// `stat`, `copy`, `symlink`) est loggée en `warn!` et **sautée** — la fonction ne
+/// remonte jamais d'erreur. Un `~/.claude` volumineux et volatil (autres process
+/// Claude qui mutent `node_modules`) ne doit pas faire échouer le Run.
+///
+/// `copy_root` = racine (canonique) au-delà de laquelle une cible de symlink est
+/// jugée « échappante ». `depth` = profondeur courante ([`MAX_COPY_DEPTH`]).
+///
 /// N.B. : ne PAS réutiliser `copy_dir_all` de `lib.rs` — il n'est pas
 /// symlink-aware (`std::fs::copy` déréférence).
-fn copy_tree_preserving(src: &Path, dst: &Path) -> Result<()> {
-    std::fs::create_dir_all(dst).with_context(|| format!("create dir {}", dst.display()))?;
-    let entries = std::fs::read_dir(src).with_context(|| format!("read dir {}", src.display()))?;
+fn copy_tree_preserving(src: &Path, dst: &Path, copy_root: &Path, depth: u32) {
+    if depth > MAX_COPY_DEPTH {
+        warn!(
+            "sandbox copy: max depth {MAX_COPY_DEPTH} exceeded at {}, skipping subtree",
+            src.display()
+        );
+        return;
+    }
+    if let Err(e) = std::fs::create_dir_all(dst) {
+        warn!(
+            "sandbox copy: cannot create {} ({e:#}); skipping subtree",
+            dst.display()
+        );
+        return;
+    }
+    let Ok(entries) = std::fs::read_dir(src) else {
+        warn!("sandbox copy: cannot read dir {}; skipping subtree", src.display());
+        return;
+    };
     for entry in entries.flatten() {
         let from = entry.path();
         let to = dst.join(entry.file_name());
-        let md =
-            std::fs::symlink_metadata(&from).with_context(|| format!("stat {}", from.display()))?;
+        let Ok(md) = std::fs::symlink_metadata(&from) else {
+            warn!("sandbox copy: cannot stat {}; skipping entry", from.display());
+            continue;
+        };
         let ft = md.file_type();
         if ft.is_symlink() {
-            let target = std::fs::read_link(&from)
-                .with_context(|| format!("read_link {}", from.display()))?;
-            // Idempotence : une exécution antérieure a pu laisser un lien/fichier.
-            let _ = std::fs::remove_file(&to);
-            std::os::unix::fs::symlink(&target, &to)
-                .with_context(|| format!("symlink {} -> {}", to.display(), target.display()))?;
+            stage_symlink(&from, &to, copy_root, depth);
         } else if ft.is_dir() {
-            copy_tree_preserving(&from, &to)?;
+            copy_tree_preserving(&from, &to, copy_root, depth + 1);
         } else if ft.is_file() {
-            std::fs::copy(&from, &to)
-                .with_context(|| format!("copy {} -> {}", from.display(), to.display()))?;
+            if let Err(e) = std::fs::copy(&from, &to) {
+                warn!(
+                    "sandbox copy: skip file {} -> {} ({e:#})",
+                    from.display(),
+                    to.display()
+                );
+            }
         }
         // else : socket/fifo/device → skip silencieux.
     }
+}
+
+/// Traite une entrée symlink d'un walk `copy`. Une cible **intra-arbre** (toujours
+/// sous `copy_root`, ex. `../semver/bin/x` ou un sibling) est recréée **verbatim** —
+/// préserve les cycles `node_modules/.bin` et les liens relatifs. Une cible qui
+/// **échappe** `copy_root` (ex. un skill lié à `~/.agents/…`, ou un lien absolu)
+/// **danglerait** dans le conteneur (sa cible réelle n'est ni copiée ni montée) →
+/// on **déréférence** : le contenu réel est copié à la place. La cible déréférencée
+/// devient son propre `copy_root` pour que ses liens internes qui y restent restent
+/// des liens. Cible cassée / illisible → skip (best-effort, jamais d'échec).
+fn stage_symlink(from: &Path, to: &Path, copy_root: &Path, depth: u32) {
+    let Ok(link_target) = std::fs::read_link(from) else {
+        warn!("sandbox copy: skip unreadable symlink {}", from.display());
+        return;
+    };
+    // Résoudre la cible en chemin absolu (relatif → joint au parent du lien) puis
+    // canonicaliser : sert à tester l'échappement ET à atteindre le contenu réel.
+    // Un lien cassé/bouclant fait échouer `canonicalize` → skip (jamais d'échec).
+    let resolved = if link_target.is_absolute() {
+        link_target.clone()
+    } else {
+        match from.parent() {
+            Some(parent) => parent.join(&link_target),
+            None => link_target.clone(),
+        }
+    };
+    let Ok(canonical) = std::fs::canonicalize(&resolved) else {
+        warn!(
+            "sandbox copy: skip broken symlink {} -> {}",
+            from.display(),
+            link_target.display()
+        );
+        return;
+    };
+    if canonical.starts_with(copy_root) {
+        // Intra-arbre → recréer le lien verbatim (cible d'origine, non résolue).
+        let _ = std::fs::remove_file(to);
+        if let Err(e) = std::os::unix::fs::symlink(&link_target, to) {
+            warn!(
+                "sandbox copy: skip symlink {} -> {} ({e:#})",
+                to.display(),
+                link_target.display()
+            );
+        }
+    } else if canonical.is_dir() {
+        // Échappant (dossier) → déréférencer ; la cible réelle est son copy_root.
+        copy_tree_preserving(&canonical, to, &canonical, depth + 1);
+    } else if canonical.is_file() {
+        // Échappant (fichier) → copier le contenu déréférencé (mode préservé).
+        let _ = std::fs::remove_file(to);
+        if let Err(e) = std::fs::copy(&canonical, to) {
+            warn!(
+                "sandbox copy: skip deref file {} -> {} ({e:#})",
+                canonical.display(),
+                to.display()
+            );
+        }
+    }
+    // else : échappant non-régulier (socket/fifo) → skip.
+}
+
+/// Merge non-destructif d'une confiance pour `trusted_root` dans le `.claude.json`
+/// (existant ou frais) du staging `copy` (#409, D5). Préserve toutes les autres
+/// clés/projets (profil `oauthAccount`, autres repos trustés…) et réapplique 0600
+/// (le fichier peut porter un token). Un `.claude.json` illisible/corrompu est
+/// remplacé par un objet nu + la confiance (dégradation gracieuse, pas d'échec dur).
+fn seed_trust_in_claude_json(path: &Path, trusted_root: &Path) -> Result<()> {
+    let mut value = match std::fs::read_to_string(path) {
+        Ok(body) => serde_json::from_str(&body).unwrap_or_else(|_| serde_json::json!({})),
+        Err(_) => serde_json::json!({}),
+    };
+    if !value.is_object() {
+        value = serde_json::json!({});
+    }
+    let obj = value.as_object_mut().expect("value forced to object above");
+    // Onboarding : défensif, aligne `copy` sur la garantie `pure` sans écraser une
+    // valeur hôte existante.
+    obj.entry("hasCompletedOnboarding")
+        .or_insert_with(|| serde_json::json!(true));
+    let projects = obj
+        .entry("projects")
+        .or_insert_with(|| serde_json::json!({}));
+    if !projects.is_object() {
+        *projects = serde_json::json!({});
+    }
+    let projects = projects.as_object_mut().expect("projects forced to object");
+    let key = trusted_root.to_string_lossy().into_owned();
+    let entry = projects.entry(key).or_insert_with(|| serde_json::json!({}));
+    if !entry.is_object() {
+        *entry = serde_json::json!({});
+    }
+    let entry = entry.as_object_mut().expect("project entry forced to object");
+    entry.insert(
+        "hasTrustDialogAccepted".to_string(),
+        serde_json::json!(true),
+    );
+    entry.insert(
+        "hasCompletedProjectOnboarding".to_string(),
+        serde_json::json!(true),
+    );
+
+    let body = serde_json::to_string_pretty(&value).context("serialize copy .claude.json")?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("create parent {}", parent.display()))?;
+    }
+    std::fs::write(path, body)
+        .with_context(|| format!("write copy .claude.json {}", path.display()))?;
+    set_mode_0600(path)?;
     Ok(())
 }
 
@@ -404,8 +572,12 @@ mod tests {
             "#!/bin/sh\necho hi\n",
             0o755,
         );
-        // Symlink relatif à l'intérieur de skills/foo → skill.md.
+        // Symlink relatif à l'intérieur de skills/foo → skill.md (INTRA-arbre).
         std::os::unix::fs::symlink("skill.md", claude.join("skills/foo/link.md")).unwrap();
+        // Symlink ÉCHAPPANT : ~/.claude/skills/esc → ~/.agents/skills/esc (hors
+        // ~/.claude). `../../.agents/…` depuis ~/.claude/skills/ résout à <home>/.agents.
+        write(&home.join(".agents/skills/esc/SKILL.md"), "# escaped skill\n");
+        std::os::unix::fs::symlink("../../.agents/skills/esc", claude.join("skills/esc")).unwrap();
         write(&claude.join("plugins/bar/plugin.json"), "{}\n");
         write(&claude.join("agents/a.md"), "agent\n");
         write(&claude.join("commands/c.md"), "cmd\n");
@@ -573,6 +745,100 @@ mod tests {
         assert!(!home.join(".credentials.json").exists());
         assert!(!staged_claude_json(sandbox_dir.path(), "run1").exists());
         assert!(home.join("projects").is_dir());
+    }
+
+    #[test]
+    fn prepare_copy_dereferences_escaping_symlink() {
+        let home_dir = tempfile::tempdir().unwrap();
+        let sandbox_dir = tempfile::tempdir().unwrap();
+        fabricate_home(home_dir.path());
+
+        prepare(home_dir.path(), sandbox_dir.path(), Mode::Copy, "run1", None).unwrap();
+        let home = staged_claude_home(sandbox_dir.path(), "run1");
+
+        // Le skill lié à ~/.agents (hors ~/.claude) est DÉRÉFÉRENCÉ : son contenu
+        // atterrit comme fichier régulier, jamais un symlink dangling (sa cible
+        // n'étant ni copiée ni montée, un lien verbatim disparaîtrait du conteneur).
+        let esc = home.join("skills/esc/SKILL.md");
+        let esc_md = std::fs::symlink_metadata(&esc).unwrap();
+        assert!(
+            esc_md.file_type().is_file(),
+            "le skill échappant doit être déréférencé en fichier régulier"
+        );
+        assert_eq!(std::fs::read_to_string(&esc).unwrap(), "# escaped skill\n");
+        assert!(
+            !std::fs::symlink_metadata(home.join("skills/esc"))
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+            "le dossier déréférencé ne doit pas être un lien"
+        );
+
+        // Non-régression : le lien INTRA-arbre reste un symlink (cible verbatim).
+        let intra = home.join("skills/foo/link.md");
+        assert!(
+            std::fs::symlink_metadata(&intra)
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+            "le lien intra-arbre doit rester un symlink"
+        );
+        assert_eq!(std::fs::read_link(&intra).unwrap(), PathBuf::from("skill.md"));
+    }
+
+    #[test]
+    fn prepare_copy_is_best_effort_on_unreadable_entry() {
+        let home_dir = tempfile::tempdir().unwrap();
+        let sandbox_dir = tempfile::tempdir().unwrap();
+        let claude = home_dir.path().join(".claude");
+        // Un bon fichier + un symlink CASSÉ (cible inexistante) dans le même dir.
+        write(&claude.join("skills/good/skill.md"), "# good\n");
+        std::os::unix::fs::symlink("/nonexistent/pdo-broken-xyz", claude.join("skills/broken"))
+            .unwrap();
+
+        // Ne panique pas / n'échoue pas malgré l'entrée cassée (D3).
+        prepare(home_dir.path(), sandbox_dir.path(), Mode::Copy, "run1", None).unwrap();
+        let home = staged_claude_home(sandbox_dir.path(), "run1");
+
+        // Le bon fichier est copié ; l'entrée cassée est sautée (rien de staged).
+        assert!(home.join("skills/good/skill.md").is_file());
+        assert!(
+            std::fs::symlink_metadata(home.join("skills/broken")).is_err(),
+            "le symlink cassé doit être sauté, pas recréé"
+        );
+    }
+
+    #[test]
+    fn prepare_copy_seeds_trust_for_repo_root() {
+        let home_dir = tempfile::tempdir().unwrap();
+        let sandbox_dir = tempfile::tempdir().unwrap();
+        fabricate_home(home_dir.path()); // `.claude.json` hôte porte `oauthAccount`
+        let trusted = Path::new("/repo/root");
+
+        prepare(
+            home_dir.path(),
+            sandbox_dir.path(),
+            Mode::Copy,
+            "run1",
+            Some(trusted),
+        )
+        .unwrap();
+
+        let staged = staged_claude_json(sandbox_dir.path(), "run1");
+        let json: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&staged).unwrap()).unwrap();
+        // Merge NON-destructif : les clés hôte survivent.
+        assert_eq!(json["host"], serde_json::json!("profile"));
+        assert_eq!(json["oauthAccount"]["x"], serde_json::json!(1));
+        // Confiance seedée pour le repo du Run.
+        let entry = &json["projects"]["/repo/root"];
+        assert_eq!(entry["hasTrustDialogAccepted"], serde_json::json!(true));
+        assert_eq!(
+            entry["hasCompletedProjectOnboarding"],
+            serde_json::json!(true)
+        );
+        // 0600 réappliqué (le fichier peut porter un token).
+        assert_eq!(mode_of(&staged), 0o600);
     }
 
     // -- prepare (pure) ------------------------------------------------------

--- a/crates/pdo-daemon/src/sandbox_staging.rs
+++ b/crates/pdo-daemon/src/sandbox_staging.rs
@@ -333,14 +333,20 @@ fn copy_tree_preserving(src: &Path, dst: &Path, copy_root: &Path, depth: u32) {
         return;
     }
     let Ok(entries) = std::fs::read_dir(src) else {
-        warn!("sandbox copy: cannot read dir {}; skipping subtree", src.display());
+        warn!(
+            "sandbox copy: cannot read dir {}; skipping subtree",
+            src.display()
+        );
         return;
     };
     for entry in entries.flatten() {
         let from = entry.path();
         let to = dst.join(entry.file_name());
         let Ok(md) = std::fs::symlink_metadata(&from) else {
-            warn!("sandbox copy: cannot stat {}; skipping entry", from.display());
+            warn!(
+                "sandbox copy: cannot stat {}; skipping entry",
+                from.display()
+            );
             continue;
         };
         let ft = md.file_type();
@@ -450,7 +456,9 @@ fn seed_trust_in_claude_json(path: &Path, trusted_root: &Path) -> Result<()> {
     if !entry.is_object() {
         *entry = serde_json::json!({});
     }
-    let entry = entry.as_object_mut().expect("project entry forced to object");
+    let entry = entry
+        .as_object_mut()
+        .expect("project entry forced to object");
     entry.insert(
         "hasTrustDialogAccepted".to_string(),
         serde_json::json!(true),
@@ -576,7 +584,10 @@ mod tests {
         std::os::unix::fs::symlink("skill.md", claude.join("skills/foo/link.md")).unwrap();
         // Symlink ÉCHAPPANT : ~/.claude/skills/esc → ~/.agents/skills/esc (hors
         // ~/.claude). `../../.agents/…` depuis ~/.claude/skills/ résout à <home>/.agents.
-        write(&home.join(".agents/skills/esc/SKILL.md"), "# escaped skill\n");
+        write(
+            &home.join(".agents/skills/esc/SKILL.md"),
+            "# escaped skill\n",
+        );
         std::os::unix::fs::symlink("../../.agents/skills/esc", claude.join("skills/esc")).unwrap();
         write(&claude.join("plugins/bar/plugin.json"), "{}\n");
         write(&claude.join("agents/a.md"), "agent\n");
@@ -753,7 +764,14 @@ mod tests {
         let sandbox_dir = tempfile::tempdir().unwrap();
         fabricate_home(home_dir.path());
 
-        prepare(home_dir.path(), sandbox_dir.path(), Mode::Copy, "run1", None).unwrap();
+        prepare(
+            home_dir.path(),
+            sandbox_dir.path(),
+            Mode::Copy,
+            "run1",
+            None,
+        )
+        .unwrap();
         let home = staged_claude_home(sandbox_dir.path(), "run1");
 
         // Le skill lié à ~/.agents (hors ~/.claude) est DÉRÉFÉRENCÉ : son contenu
@@ -783,7 +801,10 @@ mod tests {
                 .is_symlink(),
             "le lien intra-arbre doit rester un symlink"
         );
-        assert_eq!(std::fs::read_link(&intra).unwrap(), PathBuf::from("skill.md"));
+        assert_eq!(
+            std::fs::read_link(&intra).unwrap(),
+            PathBuf::from("skill.md")
+        );
     }
 
     #[test]
@@ -797,7 +818,14 @@ mod tests {
             .unwrap();
 
         // Ne panique pas / n'échoue pas malgré l'entrée cassée (D3).
-        prepare(home_dir.path(), sandbox_dir.path(), Mode::Copy, "run1", None).unwrap();
+        prepare(
+            home_dir.path(),
+            sandbox_dir.path(),
+            Mode::Copy,
+            "run1",
+            None,
+        )
+        .unwrap();
         let home = staged_claude_home(sandbox_dir.path(), "run1");
 
         // Le bon fichier est copié ; l'entrée cassée est sautée (rien de staged).

--- a/crates/pdo-daemon/tests/sandbox_tracer.rs
+++ b/crates/pdo-daemon/tests/sandbox_tracer.rs
@@ -479,3 +479,333 @@ async fn kill_node_targets_the_container() {
         log_text(&log)
     );
 }
+
+// -- #409: mode `copy` de bout en bout ---------------------------------------
+//
+// The harness collocates `home_root == host_home == repo_root == tempdir`
+// (`sandbox_home_override`), so the fake host `~/.claude` lives at
+// `<repo>/.claude`. It is fabricated AFTER spawn (untracked, out of the seed
+// commit) and BEFORE `start_run` (eager prep reads it). The fake `docker exec`
+// cannot run the container body, so a real end-to-end `copy` run (skills actually
+// loaded, kernel isolation, real auth) is the Layer-5 job (FP-409). Layer-3 proves
+// what PDO **stages** and the **argv/mounts** it hands `docker create`.
+
+/// Fabricate a realistic host `~/.claude` (+ sibling `.claude.json`) under `home`.
+/// Mirrors the unit `sandbox_staging::fabricate_home`: allowlist dirs/files, an
+/// INTRA-tree symlink, an ESCAPING symlink to `~/.agents` (deref target, #409 D2),
+/// 0600 creds, bulky host state that must be EXCLUDED, a pre-existing host
+/// transcript under `projects/`, and a profile `.claude.json` with `oauthAccount`.
+fn fabricate_host_claude(home: &Path) {
+    let claude = home.join(".claude");
+    let write = |p: PathBuf, c: &str| {
+        std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+        std::fs::write(&p, c).unwrap();
+    };
+    let write_mode = |p: PathBuf, c: &str, mode: u32| {
+        std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+        std::fs::write(&p, c).unwrap();
+        std::fs::set_permissions(&p, std::fs::Permissions::from_mode(mode)).unwrap();
+    };
+    // Allowlist dirs.
+    write(claude.join("skills/foo/skill.md"), "# skill\n");
+    write_mode(claude.join("skills/foo/run.sh"), "#!/bin/sh\necho hi\n", 0o755);
+    // INTRA-tree symlink (stays a link).
+    std::os::unix::fs::symlink("skill.md", claude.join("skills/foo/link.md")).unwrap();
+    // ESCAPING skill → ~/.agents/skills/esc (outside ~/.claude): must be
+    // dereferenced into the staged tree, else it dangles in the container.
+    write(home.join(".agents/skills/esc/SKILL.md"), "# escaped skill\n");
+    std::os::unix::fs::symlink("../../.agents/skills/esc", claude.join("skills/esc")).unwrap();
+    write(claude.join("plugins/bar/plugin.json"), "{}\n");
+    write(claude.join("agents/a.md"), "agent\n");
+    write(claude.join("commands/c.md"), "cmd\n");
+    write(claude.join("output-styles/s.md"), "style\n");
+    // Allowlist files (hooks live inside settings.json).
+    write(claude.join("settings.json"), r#"{"hooks":{"Stop":[]}}"#);
+    write(claude.join("settings.local.json"), r#"{"local":true}"#);
+    write_mode(claude.join(".credentials.json"), r#"{"token":"secret"}"#, 0o600);
+    write(claude.join("CLAUDE.md"), "# global\n");
+    write(claude.join("RTK.md"), "# rtk\n");
+    // Bulky host state — must stay EXCLUDED from the staging.
+    write(claude.join("history.jsonl"), "{\"cmd\":\"ls\"}\n");
+    write(claude.join("file-history/big.bin"), "xxxxxxxxxx");
+    write(claude.join("session-env/env-1/data"), "junk");
+    // Pre-existing host transcript — `prepare` must NOT copy it.
+    write(claude.join("projects/-enc-host/old.jsonl"), "{\"host\":1}\n");
+    // Sibling profile `.claude.json` (PII-bearing; copy stages it verbatim + trust).
+    write(
+        home.join(".claude.json"),
+        r#"{"host":"profile","oauthAccount":{"x":1}}"#,
+    );
+}
+
+/// The staged Claude home of a run under the tempdir override
+/// (`<repo>/.pdo/sandbox/<run>/claude-home`).
+fn staged_home(daemon: &TestDaemon, run_id: &str) -> PathBuf {
+    daemon
+        .repo_root()
+        .join(".pdo/sandbox")
+        .join(run_id)
+        .join("claude-home")
+}
+
+/// The staged `.claude.json` sibling (`<repo>/.pdo/sandbox/<run>/.claude.json`).
+fn staged_json(daemon: &TestDaemon, run_id: &str) -> PathBuf {
+    daemon
+        .repo_root()
+        .join(".pdo/sandbox")
+        .join(run_id)
+        .join(".claude.json")
+}
+
+/// Every `-v` mount spec (the arg following each `-v`) in the fake-docker argv log.
+fn mount_specs(log: &Path) -> Vec<String> {
+    let lines: Vec<String> = log_text(log).lines().map(str::to_string).collect();
+    let mut specs = Vec::new();
+    let mut iter = lines.iter();
+    while let Some(line) = iter.next() {
+        if line == "-v" {
+            if let Some(spec) = iter.next() {
+                specs.push(spec.clone());
+            }
+        }
+    }
+    specs
+}
+
+// -- Test 7: copy stages the allowlist (deref + trust) and completes ---------
+
+#[tokio::test]
+async fn copy_run_stages_allowlist_and_completes() {
+    ensure_pdo_on_path();
+    let (_fake_dir, docker, _log) = write_fake_docker();
+    let daemon =
+        TestDaemon::spawn_with_docker_override(seed("#!/usr/bin/env bash\ntrue\n"), docker)
+            .await
+            .unwrap();
+    fabricate_host_claude(daemon.repo_root());
+
+    let run_id = start_run(&daemon, Some("copy")).await;
+    let run = get_run(&daemon, &run_id).await;
+    assert_eq!(run["sandbox"], "copy", "run must project sandbox=copy: {run}");
+
+    // Node reaches Running ⇒ eager prep (incl. the copy walk + trust seed) is done.
+    let run = wait_node_status(&daemon, &run_id, "running").await;
+    assert_eq!(run["nodes"][NODE_ID]["status"], "running", "run: {run}");
+
+    let home = staged_home(&daemon, &run_id);
+    assert!(
+        wait_until(|| home.join("settings.json").is_file()).await,
+        "staged settings.json should exist once the node is running"
+    );
+
+    // Allowlist dirs staged.
+    assert!(home.join("skills/foo/skill.md").is_file());
+    assert!(home.join("plugins/bar/plugin.json").is_file());
+    assert!(home.join("agents/a.md").is_file());
+    assert!(home.join("commands/c.md").is_file());
+    assert!(home.join("output-styles/s.md").is_file());
+    // #409 D2: the escaping skill is DEREFERENCED into a regular file (not a
+    // dangling symlink) — exercised through the real prep path, not just a unit.
+    let esc = home.join("skills/esc/SKILL.md");
+    assert!(
+        std::fs::symlink_metadata(&esc)
+            .unwrap()
+            .file_type()
+            .is_file(),
+        "the escaping skill must be dereferenced, not a dangling symlink"
+    );
+    assert_eq!(std::fs::read_to_string(&esc).unwrap(), "# escaped skill\n");
+    // Allowlist files (hooks live inside settings.json).
+    assert!(std::fs::read_to_string(home.join("settings.json"))
+        .unwrap()
+        .contains("hooks"));
+    assert!(home.join("settings.local.json").is_file());
+    assert!(home.join(".credentials.json").is_file());
+    assert!(home.join("CLAUDE.md").is_file());
+    assert!(home.join("RTK.md").is_file());
+
+    // `.claude.json` sibling (OUTSIDE claude-home/): host profile preserved verbatim
+    // + trust seeded for the Run's repo_root (#409 D5).
+    let staged = staged_json(&daemon, &run_id);
+    let json: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&staged).unwrap()).unwrap();
+    assert_eq!(
+        json["oauthAccount"]["x"],
+        serde_json::json!(1),
+        "host profile keys preserved verbatim: {json}"
+    );
+    let repo_key = daemon.repo_root().to_string_lossy().into_owned();
+    assert_eq!(
+        json["projects"][&repo_key]["hasTrustDialogAccepted"],
+        serde_json::json!(true),
+        "copy seeds trust for the Run's repo_root: {json}"
+    );
+    assert!(
+        !home.join(".claude.json").exists(),
+        ".claude.json must NOT live inside claude-home/"
+    );
+
+    // projects/ staged EMPTY (host transcripts never copied).
+    assert!(home.join("projects").is_dir());
+    assert_eq!(std::fs::read_dir(home.join("projects")).unwrap().count(), 0);
+
+    // Drive the run terminal (simulate the container's output + `pdo complete`).
+    write_node_output(&daemon, &run_id, "copy output\n");
+    simulate_node_done(&daemon, &run_id).await;
+    let run = wait_run_status(&daemon, &run_id, "completed").await;
+    assert_eq!(run["status"], "completed", "copy run must complete: {run}");
+}
+
+// -- Test 8: copy excludes projects/ and bulky host state --------------------
+
+#[tokio::test]
+async fn copy_excludes_projects_and_bulky_host_state() {
+    ensure_pdo_on_path();
+    let (_fake_dir, docker, _log) = write_fake_docker();
+    let daemon =
+        TestDaemon::spawn_with_docker_override(seed("#!/usr/bin/env bash\ntrue\n"), docker)
+            .await
+            .unwrap();
+    fabricate_host_claude(daemon.repo_root());
+
+    let run_id = start_run(&daemon, Some("copy")).await;
+    wait_node_status(&daemon, &run_id, "running").await;
+
+    let home = staged_home(&daemon, &run_id);
+    assert!(
+        wait_until(|| home.join("settings.json").is_file()).await,
+        "staging should be seeded once the node is running"
+    );
+
+    // Bulky/transient host state is NEVER staged (allowlist, not denylist).
+    assert!(!home.join("history.jsonl").exists());
+    assert!(!home.join("file-history").exists());
+    assert!(!home.join("session-env").exists());
+    // Host transcripts are never copied by prepare; projects/ is created EMPTY.
+    assert!(!home.join("projects/-enc-host/old.jsonl").exists());
+    assert!(home.join("projects").is_dir());
+    assert_eq!(std::fs::read_dir(home.join("projects")).unwrap().count(), 0);
+}
+
+// -- Test 9: the real host ~/.claude is never a mount SOURCE -----------------
+
+#[tokio::test]
+async fn copy_never_mounts_the_real_host_claude() {
+    ensure_pdo_on_path();
+    let (_fake_dir, docker, log) = write_fake_docker();
+    let daemon =
+        TestDaemon::spawn_with_docker_override(seed("#!/usr/bin/env bash\ntrue\n"), docker)
+            .await
+            .unwrap();
+    fabricate_host_claude(daemon.repo_root());
+
+    let run_id = start_run(&daemon, Some("copy")).await;
+    // `container inspect` → ABSENT → ensure_running does `create` (mounts logged).
+    assert!(
+        wait_until(|| log_text(&log).contains("create")).await,
+        "prep must `docker create` the container; log:\n{}",
+        log_text(&log)
+    );
+
+    let specs = mount_specs(&log);
+    let host_claude = daemon.repo_root().join(".claude");
+    let host_json = daemon.repo_root().join(".claude.json");
+
+    // Positive: the STAGED home is mounted at <repo>/.claude — source = staging.
+    let expected_home_mount = format!(
+        "{}:{}:rw",
+        staged_home(&daemon, &run_id).display(),
+        host_claude.display()
+    );
+    assert!(
+        specs.contains(&expected_home_mount),
+        "staged home must mount to <repo>/.claude (source = staging); specs={specs:?}"
+    );
+
+    // Negative (load-bearing): NO mount has the real host `.claude`/`.claude.json`
+    // as its SOURCE. Inspect the source SEGMENT (split ':'), never `contains` — the
+    // mount TARGET `<repo>/.claude` coincides on disk with the fake host here
+    // (override home == repo_root), so a substring check would false-positive.
+    for spec in &specs {
+        let source = spec.split(':').next().unwrap_or(spec);
+        assert_ne!(
+            source,
+            host_claude.display().to_string(),
+            "the real host ~/.claude must never be a mount source; spec={spec}"
+        );
+        assert_ne!(
+            source,
+            host_json.display().to_string(),
+            "the real host ~/.claude.json must never be a mount source; spec={spec}"
+        );
+    }
+}
+
+// -- Test 10: no host config write-back; transcripts DO flow back ------------
+
+#[tokio::test]
+async fn copy_completes_without_host_config_writeback() {
+    ensure_pdo_on_path();
+    let (_fake_dir, docker, _log) = write_fake_docker();
+    let daemon =
+        TestDaemon::spawn_with_docker_override(seed("#!/usr/bin/env bash\ntrue\n"), docker)
+            .await
+            .unwrap();
+    fabricate_host_claude(daemon.repo_root());
+
+    let host_claude = daemon.repo_root().join(".claude");
+    let host_json = daemon.repo_root().join(".claude.json");
+    // Snapshot the host config BEFORE the run (bytes, load-bearing).
+    let settings_before = std::fs::read(host_claude.join("settings.json")).unwrap();
+    let json_before = std::fs::read(&host_json).unwrap();
+
+    let run_id = start_run(&daemon, Some("copy")).await;
+    wait_node_status(&daemon, &run_id, "running").await;
+    write_node_output(&daemon, &run_id, "done\n");
+    simulate_node_done(&daemon, &run_id).await;
+    wait_run_status(&daemon, &run_id, "completed").await;
+
+    let staging = daemon.repo_root().join(".pdo/sandbox").join(&run_id);
+    assert!(
+        wait_until(|| staging.exists()).await,
+        "staging must exist before cleanup: {staging:?}"
+    );
+
+    // Plant a transcript in the staged projects/ sink: the cleanup merge_back must
+    // land it on the host (positive), while config stays untouched (negative).
+    let staged_proj = staged_home(&daemon, &run_id).join("projects/-enc-test");
+    std::fs::create_dir_all(&staged_proj).unwrap();
+    std::fs::write(staged_proj.join("t.jsonl"), "{\"line\":1}\n").unwrap();
+
+    let resp = post_command(
+        &daemon,
+        &run_id,
+        serde_json::json!({ "kind": "cleanup_run" }),
+    )
+    .await;
+    assert!(resp.status().is_success(), "cleanup_run should archive");
+    wait_run_status(&daemon, &run_id, "archived").await;
+
+    // AC: NO config write ever comes back to the host. Copy + trust seeding all
+    // land in the STAGED tree; the host config stays byte-identical.
+    assert_eq!(
+        std::fs::read(host_claude.join("settings.json")).unwrap(),
+        settings_before,
+        "host settings.json must be byte-identical (no write-back)"
+    );
+    assert_eq!(
+        std::fs::read(&host_json).unwrap(),
+        json_before,
+        "host .claude.json must be byte-identical (trust seeding writes only the staged copy)"
+    );
+    // Positive counterpart: transcripts DO merge back to the host projects dir.
+    assert!(
+        host_claude.join("projects/-enc-test/t.jsonl").is_file(),
+        "merge_back must land staged transcripts on the host"
+    );
+    // And the staging is purged.
+    assert!(
+        !staging.exists(),
+        "cleanup must purge the staging dir: {staging:?}"
+    );
+}

--- a/crates/pdo-daemon/tests/sandbox_tracer.rs
+++ b/crates/pdo-daemon/tests/sandbox_tracer.rs
@@ -508,12 +508,19 @@ fn fabricate_host_claude(home: &Path) {
     };
     // Allowlist dirs.
     write(claude.join("skills/foo/skill.md"), "# skill\n");
-    write_mode(claude.join("skills/foo/run.sh"), "#!/bin/sh\necho hi\n", 0o755);
+    write_mode(
+        claude.join("skills/foo/run.sh"),
+        "#!/bin/sh\necho hi\n",
+        0o755,
+    );
     // INTRA-tree symlink (stays a link).
     std::os::unix::fs::symlink("skill.md", claude.join("skills/foo/link.md")).unwrap();
     // ESCAPING skill → ~/.agents/skills/esc (outside ~/.claude): must be
     // dereferenced into the staged tree, else it dangles in the container.
-    write(home.join(".agents/skills/esc/SKILL.md"), "# escaped skill\n");
+    write(
+        home.join(".agents/skills/esc/SKILL.md"),
+        "# escaped skill\n",
+    );
     std::os::unix::fs::symlink("../../.agents/skills/esc", claude.join("skills/esc")).unwrap();
     write(claude.join("plugins/bar/plugin.json"), "{}\n");
     write(claude.join("agents/a.md"), "agent\n");
@@ -522,7 +529,11 @@ fn fabricate_host_claude(home: &Path) {
     // Allowlist files (hooks live inside settings.json).
     write(claude.join("settings.json"), r#"{"hooks":{"Stop":[]}}"#);
     write(claude.join("settings.local.json"), r#"{"local":true}"#);
-    write_mode(claude.join(".credentials.json"), r#"{"token":"secret"}"#, 0o600);
+    write_mode(
+        claude.join(".credentials.json"),
+        r#"{"token":"secret"}"#,
+        0o600,
+    );
     write(claude.join("CLAUDE.md"), "# global\n");
     write(claude.join("RTK.md"), "# rtk\n");
     // Bulky host state — must stay EXCLUDED from the staging.
@@ -530,7 +541,10 @@ fn fabricate_host_claude(home: &Path) {
     write(claude.join("file-history/big.bin"), "xxxxxxxxxx");
     write(claude.join("session-env/env-1/data"), "junk");
     // Pre-existing host transcript — `prepare` must NOT copy it.
-    write(claude.join("projects/-enc-host/old.jsonl"), "{\"host\":1}\n");
+    write(
+        claude.join("projects/-enc-host/old.jsonl"),
+        "{\"host\":1}\n",
+    );
     // Sibling profile `.claude.json` (PII-bearing; copy stages it verbatim + trust).
     write(
         home.join(".claude.json"),
@@ -586,7 +600,10 @@ async fn copy_run_stages_allowlist_and_completes() {
 
     let run_id = start_run(&daemon, Some("copy")).await;
     let run = get_run(&daemon, &run_id).await;
-    assert_eq!(run["sandbox"], "copy", "run must project sandbox=copy: {run}");
+    assert_eq!(
+        run["sandbox"], "copy",
+        "run must project sandbox=copy: {run}"
+    );
 
     // Node reaches Running ⇒ eager prep (incl. the copy walk + trust seed) is done.
     let run = wait_node_status(&daemon, &run_id, "running").await;


### PR DESCRIPTION
## Sandbox F — mode `copy` de bout en bout (slice #409)

Closes #409

Dernière tranche fonctionnelle du PRD #403 (sandbox Docker par run). Le mode `copy`
stage une **allowlist** du `~/.claude` hôte dans un home isolé (`~/.pdo/sandbox/<run>/claude-home`),
monté ensuite dans le conteneur du Run — skills et config isolés côté conteneur.

### Contenu
- `sandbox_staging.rs` : `stage_symlink` classe intra-arbre vs échappant (`canonicalize` +
  `starts_with(copy_root)`) et **déréférence** les liens échappants ; `copy_tree_preserving`
  best-effort par entrée (`warn!`+skip, borné `MAX_COPY_DEPTH=64`) ; `seed_trust_in_claude_json`
  merge la confiance de façon non-destructive et réapplique `0600`.
- `sandbox_run.rs` : `ensure_ready` câble `Pure | Copy → Some(repo_root)`, `Off → None`
  (câblage mode-agnostique de #407, conforme D1 ; pas de net-new run-advance).
- `sandbox_tracer.rs` : 4 tests layer-3 dédiés (deref, exclusions allowlist, trust seed,
  no host config write-back).
- `CONTEXT.md` : section Sandbox amendée (deref, best-effort, trust seed, volume ~1 Go, PII, dette disque).

### Validation
Barrière CI reproduite sur `+stable` (miroir du job `rust`) : `fmt --check` PASS, `check`
0 warning, `test --workspace` **1557 passed / 0 failed**, `clippy -D warnings` 0 warning.
Smoke conteneur réel : le home produit par le vrai `prepare(Mode::Copy)` est correctement
consommé dans l'image `pdo-sandbox` content-hashée (deref, exclusions, trust seed, `claude 2.1.218` présent).

Pas de bump de version (release en fin de PRD). Hors scope : #410 (précédence), #411 (registry).
