### PR TITLE
feat(#411): sandbox image hybride — pull GHCR + fallback build + image_source

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,3 +106,64 @@ jobs:
             artifacts/pdo-*.tar.gz \
             artifacts/pdo-*-SHA256SUMS.txt \
             install.sh
+
+  image:
+    name: Sandbox image (GHCR)
+    runs-on: ubuntu-latest
+    # Job ADDITIF : PAS de `needs:` — un hoquet registry ne doit jamais faire échouer/retarder
+    # la release binaire. Tourne en parallèle, échoue indépendamment. La landmine rustls des
+    # jobs `build`/`release` est intacte : ce job ne partage aucun step avec eux (#411 D13).
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compute content-addressed tag + image ref
+        id: meta
+        run: |
+          set -euo pipefail
+          DF="crates/pdo-daemon/assets/sandbox/Dockerfile"
+          # Hash canonique — byte-identique à sandbox_image.rs::dockerfile_hash.
+          # sha256sum imprime "<64hex>  <file>" ; cut -c1-12 = 12 premiers hex.
+          HASH="$(sha256sum "$DF" | cut -c1-12)"
+          # Self-check parité (§2.9) : prouve que le sha256sum|cut de CE runner matche la
+          # constante figée dans sandbox_image.rs (test dockerfile_tag_stable_and_edit_sensitive).
+          # Attrape une dérive bash/coreutils invisible au test Rust. ~1 ms, sans cargo.
+          EXPECT="5804eefb8f92"
+          GOT="$(printf 'FROM ubuntu:24.04\nRUN apt-get update\n' | sha256sum | cut -c1-12)"
+          if [ "$GOT" != "$EXPECT" ]; then
+            echo "::error::sandbox hash-algo drift: bash=$GOT rust-pinned=$EXPECT"; exit 1
+          fi
+          OWNER="${GITHUB_REPOSITORY_OWNER,,}"   # GHCR exige un chemin lowercase (Loulen→loulen).
+          IMAGE="ghcr.io/${OWNER}/pdo-sandbox"
+          echo "hash=${HASH}"   >> "$GITHUB_OUTPUT"
+          echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
+          echo "Publishing ${IMAGE}:h-${HASH} (+ :latest)"
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
+
+      - uses: docker/build-push-action@v7
+        with:
+          context: crates/pdo-daemon/assets/sandbox
+          file: crates/pdo-daemon/assets/sandbox/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          provenance: false
+          # `--label` (annotation de manifest) lie le package au repo SANS toucher les octets
+          # du Dockerfile → hash invariant (D2). Le 1er push auto-linke via GITHUB_TOKEN.
+          labels: |
+            org.opencontainers.image.source=https://github.com/Loulen/prompt-driven-orchestrator
+          # `latest` est INFORMATIF : le daemon ne tire QUE `h-<hash>` (content-addressed). L'AC
+          # coche « aux deux tags » ; un reviewer peut retirer `latest` (pointeur mutable que le
+          # content-hash évite, cf. CONTEXT.md « Éviter : latest »).
+          tags: |
+            ${{ steps.meta.outputs.image }}:h-${{ steps.meta.outputs.hash }}
+            ${{ steps.meta.outputs.image }}:latest

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -825,8 +825,9 @@ La complétion est signalée **depuis l'UI**, par un bouton "Mark complete" sur 
 > câblé à la transition terminale + `cleanup_run`, seam `transcripts_root` pour coût/stale) +
 > **mode `copy` de bout en bout** (#409 : vérifie `prepare`(allowlist copy) → conteneur →
 > `merge_back` ; même câblage mode-agnostique que #407, ne diffère de `pure` que par le seed de
-> `prepare` — deref des symlinks échappants + walk best-effort en sus). Reste
-> **différé** : précédence des sources du mode (#410), fourniture par registry (#411).
+> `prepare` — deref des symlinks échappants + walk best-effort en sus) + **fourniture hybride de
+> l'image** (#411 : `ensure_image` pull GHCR-puis-retag / fallback build, réglage `image_source`,
+> job release GHCR). Reste **différé** : précédence des sources du mode (#410).
 
 **Sandbox** :
 Propriété **par Run**, **immuable après création**, portée par l'événement de création (projetée
@@ -901,8 +902,8 @@ L'**exécution** de l'image (instanciation en conteneur, mounts, réseau) → #4
 **Image sandbox (`pdo-sandbox:h-<hash>`)** :
 L'image Docker dans laquelle tournent les sessions d'un Run sandboxé. Son tag est le **hash du
 contenu du Dockerfile** (`h-<hash>`), pas une version : deux Dockerfiles identiques → même tag, une
-édition → tag différent. Identité **adressée par contenu** — c'est elle qui rendra plus tard une
-image tirée d'un registry et une image buildée localement interchangeables sous le même nom (#411).
+édition → tag différent. Identité **adressée par contenu** — c'est elle qui rend une image tirée
+d'un registry et une image buildée localement **interchangeables sous le même nom** (#411).
 _Éviter_ : « image latest », « tag de version », « image du conteneur » (l'image n'est pas le
 conteneur, #406).
 
@@ -915,11 +916,33 @@ Dockerfile **embarqué** (source de vérité dans le binaire) et le **seedé** (
 disque) ; « image de base ».
 
 **`ensure_image()`** :
-Garantit que `pdo-sandbox:h-<hash>` existe **localement** : présente → réutilise ; absente →
-`docker build` depuis le Dockerfile sur disque ; échec → erreur explicite (consommée par le
-fail-fast du Run). Ne tire **rien** d'un registry en #405 (chemin pull/GHCR + précédence
-`image_source` → #411). _Éviter_ : « pull », « build » seul (ensure = build-**si-absent**),
-« warm-up ».
+Garantit que `pdo-sandbox:h-<hash>` existe **localement** et retourne **toujours** le ref local
+(invariant `sandbox_container`) : présente → réutilise (**fast-path**, zéro réseau) ; absente et
+`image_source=registry` (défaut) → `docker pull` le ref GHCR puis **retag** sous le ref local, avec
+**fallback build** si le pull échoue (offline / 404 / registry down) ; `image_source=dockerfile` →
+`docker build` direct depuis le Dockerfile sur disque, **jamais** de pull ; échec de build → erreur
+explicite (consommée par le fail-fast du Run). _Éviter_ : « ensure = build-**seul** » (c'est
+build-**si-absent**, et pull-**d'abord** en registry), « warm-up ».
+
+**`image_source` (par-daemon)** :
+Le réglage qui pilote d'où `ensure_image` tire l'image : `registry` (défaut, pull GHCR-puis-retag +
+fallback build) | `dockerfile` (build local direct). **Par-daemon**, jamais par-Run (à la différence
+du **mode** sandbox porté par `RunStarted`) : colonne additive `instance_config`, précédence
+`stored → env (PDO_SANDBOX_IMAGE_SOURCE) → default(registry)` (ADR-0015), éditable dans la Settings
+UI. _Éviter_ : « mode registry » (le mode = off/copy/pure), « image_source par run ».
+
+**`registry_image_ref` / `ghcr.io/loulen/pdo-sandbox`** :
+Le ref GHCR de l'image publiée, `ghcr.io/loulen/pdo-sandbox:h-<hash>` — **même hash** que le ref
+local, d'où l'interchangeabilité. Owner **lowercasé** (`Loulen`→`loulen` : GHCR rejette l'uppercase).
+Poussé par un job release additif (multi-arch, tags `h-<hash>` + `latest`). _Éviter_ : « latest »
+(le daemon ne tire que `h-<hash>` ; `latest` est informatif), « tag de version ».
+
+**`pull_image` / `tag_image`** :
+Les deux effets docker du chemin registry : `pull_image` = `docker pull <registry_ref>` (`Ok(true)`
+si tiré, `Ok(false)` si non-zéro → fallback build ; le stderr de progression n'est **pas** un
+signal d'échec, seul l'exit code compte) ; `tag_image` = `docker tag <registry_ref> <local_ref>`
+(le retag qui garde `sandbox_container` inchangé). _Éviter_ : confondre `pull` (réseau) et
+`ensure`/`build` (local).
 
 ### Exécution (conteneur)
 
@@ -998,10 +1021,21 @@ absent (idempotent). C'est **le** verbe « destroy / destruction » réservé pa
   `repo_root` mergée dans le `.claude.json` copié (D5). Aucune écriture de config ne revient vers
   l'hôte (`merge_back` reste jsonl-only). Couvert par unit + 4 tests layer-3 (`sandbox_tracer`) + le
   Feature Path agentique L5 (Docker réel).
+- **Fourniture hybride de l'image (#411)** : `ensure_image` devient hybride — fast-path local, puis
+  en `registry` (défaut) `pull_image` GHCR + `tag_image` sous le ref local, **fallback build** si le
+  pull rate ; en `dockerfile`, build direct. Valeur de retour **toujours le ref local** → aucun
+  changement dans `sandbox_container`. Réglage **par-daemon** `image_source` (`instance_config`,
+  résolveur `stored → env → default(registry)` partagé par `ensure_image` **et** `GET /settings`,
+  0 drift #373), éditable dans la Settings UI (`<select>`). `context_from_state` devient **async**
+  (lit `instance_config` frais au bord) ; `ensure_ready` reste sync. La release publie l'image sur
+  GHCR (job additif, multi-arch, tags `h-<hash>` + `latest`) avec parité hash bash/Rust. Pull anonyme
+  sur image publique → trou d'auth #260 inchangé. Couvert par unit (`sandbox_image`/`instance_config`
+  /settings) + 2 tests layer-3 (`sandbox_tracer` : pull vs build selon `image_source`) + FP-411 (L5,
+  Docker réel).
 - **Différé** : injection `/etc/passwd`+`/etc/group` pour uid hôte ≠ 1000 (sudo +
   Node `os.userInfo()`) (issue de suivi) ; précédence des sources du mode (run → trigger →
-  `default_sandbox`, pattern ADR-0015) (#410) ; **fourniture par registry** (pull GHCR +
-  `image_source`) (#411).
+  `default_sandbox`, pattern ADR-0015) (#410) ; auto-flip de la visibilité publique du package GHCR
+  (non supporté par l'API → manuel one-time après la 1ʳᵉ release, #411).
 
 ### Ambiguïté signalée
 « sandbox » désigne deux choses : (1) cette feature (exécution conteneurisée d'un Run, #403) ;

--- a/crates/pdo-daemon/src/boot_recovery.rs
+++ b/crates/pdo-daemon/src/boot_recovery.rs
@@ -138,7 +138,7 @@ pub(crate) async fn run_boot_recovery(state: &AppState) {
         // downstream spawn would fail loud on a still-missing container. No-op for
         // `off`.
         if !run_state.sandbox.is_off() {
-            match crate::sandbox_run::context_from_state(state, &run_state) {
+            match crate::sandbox_run::context_from_state(state, &run_state).await {
                 Ok(ctx) => {
                     match tokio::task::spawn_blocking(move || crate::sandbox_run::ensure_ready(&ctx))
                         .await

--- a/crates/pdo-daemon/src/instance_config.rs
+++ b/crates/pdo-daemon/src/instance_config.rs
@@ -42,6 +42,13 @@ pub struct InstanceConfig {
     /// then the account default (no `--model`). Free-text pass-through, no enum
     /// (ADR-0001): an invalid id fails loud in `claude`.
     pub default_model: Option<String>,
+    /// Stored sandbox image source (`"registry"` | `"dockerfile"`), or `None` when
+    /// unset (#411). `None` falls through to the env seam
+    /// ([`crate::sandbox_image::IMAGE_SOURCE_ENV`]) then the built-in default
+    /// (`registry`). `Some("")` is the clear sentinel — [`update`] normalises it to
+    /// SQL `NULL` so it never wins precedence. The resolver
+    /// ([`crate::sandbox_image::image_source_with`]) owns the precedence.
+    pub image_source: Option<String>,
     /// RFC3339-millis UTC timestamp of the last write (or the seed).
     pub updated_at: String,
 }
@@ -62,6 +69,9 @@ pub struct UpdateInstanceConfig {
     pub reaper_ttl_secs: Option<i64>,
     pub guard_timeout_secs: Option<i64>,
     pub default_model: Option<String>,
+    /// Set the sandbox image source (#411). `Some("")` clears it back to unset (the
+    /// same `""`-sentinel discipline as `default_model`); `None` leaves it untouched.
+    pub image_source: Option<String>,
 }
 
 impl UpdateInstanceConfig {
@@ -70,6 +80,7 @@ impl UpdateInstanceConfig {
             && self.reaper_ttl_secs.is_none()
             && self.guard_timeout_secs.is_none()
             && self.default_model.is_none()
+            && self.image_source.is_none()
     }
 }
 
@@ -88,6 +99,7 @@ pub async fn init(db: &SqlitePool) -> Result<(), sqlx::Error> {
             guard_timeout_secs INTEGER,
             default_model      TEXT,
             triggers_paused    INTEGER,
+            image_source       TEXT,
             updated_at         TEXT NOT NULL
         )",
     )
@@ -134,6 +146,22 @@ pub async fn init(db: &SqlitePool) -> Result<(), sqlx::Error> {
             .await?;
     }
 
+    // Additive migration for pre-#411 databases: the `image_source` column is absent
+    // on tables created before sandbox image provisioning gained a registry/dockerfile
+    // knob. Same guarded `ADD COLUMN` idiom as `default_model`/`triggers_paused` above
+    // — safe on every boot.
+    let has_image_source = sqlx::query(
+        "SELECT 1 FROM pragma_table_info('instance_config') WHERE name = 'image_source'",
+    )
+    .fetch_optional(db)
+    .await?
+    .is_some();
+    if !has_image_source {
+        sqlx::query("ALTER TABLE instance_config ADD COLUMN image_source TEXT")
+            .execute(db)
+            .await?;
+    }
+
     Ok(())
 }
 
@@ -143,6 +171,7 @@ fn row_to_config(row: &sqlx::sqlite::SqliteRow) -> InstanceConfig {
         reaper_ttl_secs: row.get("reaper_ttl_secs"),
         guard_timeout_secs: row.get("guard_timeout_secs"),
         default_model: row.get("default_model"),
+        image_source: row.get("image_source"),
         updated_at: row.get("updated_at"),
     }
 }
@@ -182,6 +211,9 @@ pub async fn update(
     if edit.default_model.is_some() {
         sets.push("default_model = ?");
     }
+    if edit.image_source.is_some() {
+        sets.push("image_source = ?");
+    }
     // Always bump the write timestamp on a real edit.
     sets.push("updated_at = ?");
 
@@ -204,6 +236,12 @@ pub async fn update(
         // never persist: it would win the `stored → env → default` precedence
         // and both shadow the env/account default and reach the tail as an
         // empty `--model` value. Storing NULL restores fall-through.
+        query = query.bind(if v.is_empty() { None } else { Some(v) });
+    }
+    if let Some(v) = edit.image_source {
+        // "" = clear sentinel → SQL NULL (#411, mirrors default_model). The resolver
+        // then falls back env→default(registry); a stored "" would otherwise win
+        // precedence and be treated as unset only by the empty-string filter.
         query = query.bind(if v.is_empty() { None } else { Some(v) });
     }
     query = query.bind(crate::event_log::now_iso());
@@ -268,6 +306,7 @@ mod tests {
         assert_eq!(cfg.reaper_ttl_secs, None);
         assert_eq!(cfg.guard_timeout_secs, None);
         assert_eq!(cfg.default_model, None);
+        assert_eq!(cfg.image_source, None);
         assert!(!cfg.updated_at.is_empty(), "seed must stamp updated_at");
     }
 
@@ -340,6 +379,129 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(updated.default_model.as_deref(), Some("haiku"));
+    }
+
+    #[tokio::test]
+    async fn update_sets_image_source() {
+        let db = test_db().await;
+        let updated = update(
+            &db,
+            UpdateInstanceConfig {
+                image_source: Some("dockerfile".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(updated.image_source.as_deref(), Some("dockerfile"));
+        // A re-read confirms persistence (not just the returned row).
+        assert_eq!(
+            get(&db).await.unwrap().image_source.as_deref(),
+            Some("dockerfile")
+        );
+        // Sibling knobs stay untouched.
+        assert_eq!(updated.default_model, None);
+    }
+
+    #[tokio::test]
+    async fn update_clears_image_source_on_empty_string() {
+        // "" is the clear sentinel: it resets the column to NULL (mirrors #347), so
+        // the resolver falls back env→default(registry).
+        let db = test_db().await;
+        update(
+            &db,
+            UpdateInstanceConfig {
+                image_source: Some("dockerfile".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        let cleared = update(
+            &db,
+            UpdateInstanceConfig {
+                image_source: Some(String::new()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            cleared.image_source, None,
+            "empty string must clear the stored image source back to NULL"
+        );
+    }
+
+    #[tokio::test]
+    async fn image_source_only_edit_is_not_a_noop() {
+        // Guard-rail for the `is_empty()` addition: an edit touching ONLY image_source
+        // (all other knobs None) must still write. Without the `image_source.is_none()`
+        // clause it would fall into the no-op branch and silently never persist.
+        let db = test_db().await;
+        let updated = update(
+            &db,
+            UpdateInstanceConfig {
+                image_source: Some("registry".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(updated.image_source.as_deref(), Some("registry"));
+    }
+
+    #[tokio::test]
+    async fn init_migrates_pre_image_source_schema() {
+        // Installs created before #411 lack the `image_source` column. Simulate the
+        // pre-#411 schema (also missing default_model + triggers_paused, so this
+        // covers the triple guarded ALTER), then prove `init` adds the column
+        // idempotently and it is writable afterwards, without clobbering the stored
+        // knob.
+        let db = sqlx::sqlite::SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .unwrap();
+        sqlx::query(
+            "CREATE TABLE instance_config (
+                id                 INTEGER PRIMARY KEY CHECK (id = 1),
+                session_cap        INTEGER,
+                reaper_ttl_secs    INTEGER,
+                guard_timeout_secs INTEGER,
+                updated_at         TEXT NOT NULL
+            )",
+        )
+        .execute(&db)
+        .await
+        .unwrap();
+        sqlx::query("INSERT INTO instance_config (id, session_cap, updated_at) VALUES (1, 11, ?)")
+            .bind(crate::event_log::now_iso())
+            .execute(&db)
+            .await
+            .unwrap();
+
+        init(&db).await.unwrap();
+        init(&db).await.unwrap(); // idempotent
+
+        let cfg = get(&db).await.unwrap();
+        assert_eq!(
+            cfg.session_cap,
+            Some(11),
+            "existing knob must survive the ALTER"
+        );
+        assert_eq!(cfg.image_source, None, "new column defaults to NULL");
+
+        // And the migrated column is writable.
+        let updated = update(
+            &db,
+            UpdateInstanceConfig {
+                image_source: Some("dockerfile".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(updated.image_source.as_deref(), Some("dockerfile"));
     }
 
     #[tokio::test]

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -5854,7 +5854,7 @@ async fn create_run_inner(
             // Build the sandbox context from the just-projected Run (mode is
             // immutable). A vanished/half-projected state → fail loud.
             let ctx = match reload_run_state(&task_state, &task_run_id).await {
-                Some((_, rs)) => match sandbox_run::context_from_state(&task_state, &rs) {
+                Some((_, rs)) => match sandbox_run::context_from_state(&task_state, &rs).await {
                     Ok(ctx) => ctx,
                     Err(e) => {
                         fail_run_sandbox_prep(
@@ -6074,6 +6074,26 @@ fn settings_field_str(
     })
 }
 
+/// String sibling of [`settings_field`] for an *enum* knob with a built-in NON-null
+/// default (#411 `image_source`). Same `{effective, source, stored, env, default}`
+/// shape as [`settings_field_str`], but `effective`/`default` are always present
+/// strings (there is a meaningful built-in default, unlike `default_model`).
+fn settings_field_enum(
+    effective: &str,
+    source: &str,
+    stored: Option<&str>,
+    env: Option<&str>,
+    default: &str,
+) -> serde_json::Value {
+    serde_json::json!({
+        "effective": effective,
+        "source": source,
+        "stored": stored,
+        "env": env,
+        "default": default,
+    })
+}
+
 /// Build the `GET /settings` view: per knob, the effective value, the winning
 /// tier, and every tier's raw value (#129, ADR-0015). The `effective` value is
 /// computed by each knob's own resolver, so it can never drift from what the
@@ -6137,11 +6157,33 @@ async fn build_settings_view(db: &sqlx::SqlitePool) -> Result<serde_json::Value,
         "default"
     };
 
+    // --- sandbox image source (enum ; built-in default `registry`) (#411) ---
+    // The empty-string filter mirrors the resolver: a stored `""` is treated as
+    // unset. `effective` is computed by the SAME resolver ensure_image consumes, so
+    // the disclosed value can never drift from what the daemon actually uses (#373).
+    let img_stored = cfg.image_source.as_deref().filter(|s| !s.is_empty());
+    let img_env = sandbox_image::env_image_source();
+    let img_effective = sandbox_image::image_source_with(cfg.image_source.clone());
+    let img_source = if img_stored.is_some() {
+        "stored"
+    } else if img_env.is_some() {
+        "env"
+    } else {
+        "default"
+    };
+
     Ok(serde_json::json!({
         "session_cap": settings_field(cap_effective, cap_source, cfg.session_cap, cap_env, cap_default),
         "reaper_ttl_secs": settings_field(ttl_effective, ttl_source, cfg.reaper_ttl_secs, ttl_env, ttl_default),
         "guard_timeout_secs": settings_field(guard_effective, guard_source, cfg.guard_timeout_secs, guard_env_ms, guard_default),
         "default_model": settings_field_str(dm_effective.as_deref(), dm_source, dm_stored, dm_env.as_deref()),
+        "image_source": settings_field_enum(
+            img_effective.as_str(),
+            img_source,
+            img_stored,
+            img_env.as_deref(),
+            sandbox_image::ImageSource::DEFAULT.as_str(),
+        ),
         "updated_at": cfg.updated_at,
     }))
 }
@@ -6190,6 +6232,13 @@ async fn put_settings(
     if let Some(g) = req.guard_timeout_secs {
         if !(1..=600).contains(&g) {
             return bad("guard_timeout_secs must be between 1 and 600 seconds");
+        }
+    }
+    if let Some(s) = req.image_source.as_deref() {
+        // "" = clear sentinel (accepted, normalised to NULL by `update`); any other
+        // non-variant → 400 (fail-fast, no silent default) (#411).
+        if !s.is_empty() && sandbox_image::ImageSource::parse(s).is_none() {
+            return bad("image_source must be `registry` or `dockerfile`");
         }
     }
 
@@ -9278,7 +9327,7 @@ async fn run_command(
             // `docker build`) or fail EXPLICITLY — never a silent host fallback.
             // Mirrors the run-shell guard (#407 D11).
             if !run_state.sandbox.is_off() {
-                let prep = match sandbox_run::context_from_state(&state, &run_state) {
+                let prep = match sandbox_run::context_from_state(&state, &run_state).await {
                     Ok(ctx) => tokio::task::spawn_blocking(move || sandbox_run::ensure_ready(&ctx))
                         .await
                         .unwrap_or_else(|je| {
@@ -10265,7 +10314,7 @@ async fn open_run_shell(
     // runs, so the container may be down. Resurrect it here, or fail EXPLICITLY —
     // never fall back to a silent host bash.
     if !run_state.sandbox.is_off() {
-        let prep = match sandbox_run::context_from_state(&state, &run_state) {
+        let prep = match sandbox_run::context_from_state(&state, &run_state).await {
             Ok(ctx) => tokio::task::spawn_blocking(move || sandbox_run::ensure_ready(&ctx))
                 .await
                 .unwrap_or_else(|je| Err(anyhow::anyhow!("sandbox ensure_ready panicked: {je}"))),
@@ -22455,6 +22504,27 @@ edges:
         // `env` reads the process-global PDO_DEFAULT_MODEL; a concurrent
         // env-mutating unit test could transiently shadow it, so we assert the
         // effective/source pairing only in the stored-wins tests below.
+
+        // image_source (#411): enum knob with a built-in default `registry`. On a
+        // fresh row (and no PDO_SANDBOX_IMAGE_SOURCE — no test ever sets it) the
+        // stored tier is null and the resolver falls through to the built-in default.
+        let img = &view["image_source"];
+        assert!(
+            img["stored"].is_null(),
+            "image_source.stored must be null on a fresh row: {img}"
+        );
+        assert_eq!(
+            img["default"], "registry",
+            "built-in default is registry: {img}"
+        );
+        assert_eq!(
+            img["effective"], "registry",
+            "effective falls to default: {img}"
+        );
+        assert_eq!(
+            img["source"], "default",
+            "source is the built-in default: {img}"
+        );
     }
 
     #[tokio::test]
@@ -22564,5 +22634,56 @@ edges:
         // The second edit must not clear the cap set by the first.
         assert_eq!(view["session_cap"]["stored"], 7);
         assert_eq!(view["reaper_ttl_secs"]["stored"], 200);
+    }
+
+    #[tokio::test]
+    async fn put_settings_persists_image_source() {
+        // Stored always wins over env/default, so the effective/source assertions
+        // are race-free (#411).
+        let state = test_state().await;
+        let (status, view) = put_settings_resp(&state, r#"{"image_source": "dockerfile"}"#).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(view["image_source"]["stored"], "dockerfile");
+        assert_eq!(view["image_source"]["source"], "stored");
+        assert_eq!(view["image_source"]["effective"], "dockerfile");
+        assert_eq!(view["image_source"]["default"], "registry");
+
+        // Re-GET confirms persistence.
+        let reget = get_settings_json(&state).await;
+        assert_eq!(reget["image_source"]["stored"], "dockerfile");
+        assert_eq!(reget["image_source"]["effective"], "dockerfile");
+    }
+
+    #[tokio::test]
+    async fn put_settings_clears_image_source_on_empty_string() {
+        // "" is the clear sentinel: accepted (not 400), resets the stored tier to
+        // null so the resolver falls back to the built-in default `registry` (#411).
+        let state = test_state().await;
+        put_settings_resp(&state, r#"{"image_source": "dockerfile"}"#).await;
+        let (status, view) = put_settings_resp(&state, r#"{"image_source": ""}"#).await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "empty string must be accepted, not 400"
+        );
+        assert!(
+            view["image_source"]["stored"].is_null(),
+            "empty string clears the stored image source: {}",
+            view["image_source"]
+        );
+        assert_eq!(view["image_source"]["source"], "default");
+        assert_eq!(view["image_source"]["effective"], "registry");
+    }
+
+    #[tokio::test]
+    async fn put_settings_rejects_invalid_image_source() {
+        // A non-variant token is rejected 400 before anything is persisted (#411).
+        let state = test_state().await;
+        let (status, body) = put_settings_resp(&state, r#"{"image_source": "ecr"}"#).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert!(body["error"].is_string(), "400 must carry an error: {body}");
+        // Store untouched (still the default).
+        let view = get_settings_json(&state).await;
+        assert!(view["image_source"]["stored"].is_null());
     }
 }

--- a/crates/pdo-daemon/src/sandbox_image.rs
+++ b/crates/pdo-daemon/src/sandbox_image.rs
@@ -1,4 +1,4 @@
-//! Fourniture de l'image sandbox par build local (#405, slice B du PRD #403).
+//! Fourniture de l'image sandbox (#405 build local, slice B du PRD #403 ; #411 pull GHCR hybride).
 //!
 //! Miroir de [`crate::worktree_ops`] / [`crate::sandbox_staging`] : pas d'`AppState`,
 //! pas d'async, pas de lecture d'env dans le cœur — `&Path`/`&str`/`&[u8]` in,
@@ -6,16 +6,21 @@
 //! ne sont lus QUE par les résolveurs de bord.
 //!
 //! Ce module garantit qu'une image `pdo-sandbox:h-<hash>` (tag = hash du CONTENU du
-//! Dockerfile) existe localement, en la buildant depuis le Dockerfile sur disque quand
-//! elle est absente. Les slices sœurs le CONSOMMENT :
+//! Dockerfile) existe localement. [`ensure_image`] est **hybride** (#411) : si l'image
+//! n'est pas déjà locale et que la source est [`ImageSource::Registry`] (défaut), il
+//! `docker pull ghcr.io/loulen/pdo-sandbox:h-<hash>` puis retague vers le ref local ;
+//! un pull raté (offline / tag absent / registry down) retombe sur le build local, et
+//! [`ImageSource::Dockerfile`] build directement sans jamais tirer. La valeur de retour
+//! reste TOUJOURS le ref local `pdo-sandbox:h-<hash>` (le même [`dockerfile_hash`] côté
+//! pull et build), donc [`crate::sandbox_container`] est inchangé. Les slices sœurs le
+//! CONSOMMENT :
 //! - #406 instancie un conteneur à partir de l'image ;
 //! - #407 câble [`ensure_image`] dans le run-advance (ADR-0030) — via `spawn_blocking`
-//!   car `docker build` est bloquant et long ;
-//! - #411 ajoutera le pull GHCR en amont du build local, en réutilisant [`dockerfile_hash`].
+//!   car `docker build`/`docker pull` sont bloquants et longs.
 //!
 //! Le tag est **adressé par contenu**, pas versionné :
 //! rationale (content-hash vs semver ; interchangeabilité pull #411 / build local)
-//! -> ADR-0030 (#407).
+//! -> ADR-0030 (#407, pt 7).
 
 #![allow(dead_code)] // Tracer bullet : consommé par #406/#407, non câblé dans cette slice.
 
@@ -70,9 +75,23 @@ pub(crate) fn dockerfile_hash(dockerfile_bytes: &[u8]) -> String {
     full[..12].to_string()
 }
 
-/// Ref locale `pdo-sandbox:h-<hash>`. (GHCR #411 formatera son propre préfixe autour du même hash.)
+/// Ref locale `pdo-sandbox:h-<hash>`. (GHCR #411 formate son propre préfixe autour du même hash.)
 pub(crate) fn local_image_ref(dockerfile_bytes: &[u8]) -> String {
     format!("pdo-sandbox:h-{}", dockerfile_hash(dockerfile_bytes))
+}
+
+/// Namespace GHCR de l'image publiée (#411). Owner lowercasé (GHCR rejette l'uppercase).
+/// MÊME hash que [`local_image_ref`] → pull et build local interchangeables sous le même contenu
+/// (ADR-0030 pt 7). `release.yml` construit ce même chemin en bash (`${GITHUB_REPOSITORY_OWNER,,}`).
+pub(crate) const REGISTRY_NAMESPACE: &str = "ghcr.io/loulen/pdo-sandbox";
+
+/// Ref registry `ghcr.io/loulen/pdo-sandbox:h-<hash>` (MÊME hash que [`local_image_ref`], donc pull
+/// et build sont interchangeables sous le ref local après retag).
+pub(crate) fn registry_image_ref(dockerfile_bytes: &[u8]) -> String {
+    format!(
+        "{REGISTRY_NAMESPACE}:h-{}",
+        dockerfile_hash(dockerfile_bytes)
+    )
 }
 
 // -- effets fs (sync std::fs, anyhow + .context) -----------------------------
@@ -151,13 +170,63 @@ pub(crate) fn build_image(
     Ok(())
 }
 
-/// Provisionneur idempotent (seul point d'entrée de #406/#407) :
-/// seed si absent -> lit octets disque -> tag -> présente ? `Ok(tag)` : build -> `Ok(tag)`.
+/// `docker pull <registry_ref>` (réseau, image PUBLIQUE, sans auth) : `Ok(true)` si exit 0 (tirée),
+/// `Ok(false)` si exit != 0 (offline / 404 tag absent / registry down → fallback build). `docker`
+/// introuvable (spawn `NotFound`) → `Err` explicite (jamais de fallback silencieux masquant Docker
+/// absent — miroir strict d'[`image_exists`]). Le stderr de PROGRESSION de `docker pull` n'est PAS
+/// un signal d'échec : seul l'exit code compte.
+pub(crate) fn pull_image(docker_bin: &str, registry_ref: &str) -> Result<bool> {
+    match Command::new(docker_bin)
+        .args(["pull", registry_ref])
+        .output()
+    {
+        Ok(output) => Ok(output.status.success()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            Err(anyhow::Error::new(e)).context(DOCKER_NOT_FOUND_MSG)
+        }
+        Err(e) => Err(e).context("failed to run `docker pull` while fetching the sandbox image"),
+    }
+}
+
+/// `docker tag <src> <dst>` : retague l'image tirée sous le ref local content-addressé, pour que
+/// [`crate::sandbox_container`] reçoive TOUJOURS `pdo-sandbox:h-<hash>` (pull ou build → même nom).
+/// Idempotent. Non-zéro → bail avec stderr (reason actionnable d'un `RunFailed`, US-16), miroir de
+/// [`build_image`]. `docker` introuvable → `Err` explicite (comme [`pull_image`]).
+pub(crate) fn tag_image(docker_bin: &str, src: &str, dst: &str) -> Result<()> {
+    let output = match Command::new(docker_bin).args(["tag", src, dst]).output() {
+        Ok(output) => output,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Err(anyhow::Error::new(e)).context(DOCKER_NOT_FOUND_MSG);
+        }
+        Err(e) => return Err(e).context("failed to run `docker tag` for the sandbox image"),
+    };
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!(
+            "failed to retag the pulled sandbox image `{src}` as `{dst}` — \
+             `docker tag` exited with {}: {stderr}",
+            output.status
+        );
+    }
+    Ok(())
+}
+
+/// Provisionneur idempotent **hybride** (seul point d'entrée de #406/#407) : garantit que le ref
+/// local `pdo-sandbox:h-<hash>` existe et le retourne TOUJOURS (invariant `sandbox_container`).
 ///
-/// **Sync délibéré (D3)** : `docker build` est un travail bloquant et long, sa place est dans le
-/// `spawn_blocking` du caller async (#407), pas dans une tâche tokio ; garder ce module sync
-/// laisse aussi les tests en `#[test]` simples.
-pub(crate) fn ensure_image(docker_bin: &str, sandbox_root: &Path) -> Result<String> {
+/// Ordre (D7) : seed → lit octets → `local_ref` → **fast-path `image_exists(local_ref)` (zéro
+/// réseau, offline-safe)** → si [`ImageSource::Registry`] : `docker pull` le `registry_ref`, OK →
+/// `docker tag` vers `local_ref` → retour ; pull raté → fallthrough vers le build local → retour ;
+/// build KO → `Err`. [`ImageSource::Dockerfile`] : build direct, **jamais** de pull.
+///
+/// **Sync délibéré (D3)** : `docker build`/`docker pull` sont bloquants et longs, leur place est
+/// dans le `spawn_blocking` du caller async (#407), pas dans une tâche tokio ; garder ce module
+/// sync laisse aussi les tests en `#[test]` simples.
+pub(crate) fn ensure_image(
+    docker_bin: &str,
+    sandbox_root: &Path,
+    source: ImageSource,
+) -> Result<String> {
     // 1. Seed le Dockerfile si absent (édition utilisateur préservée).
     seed_dockerfile(sandbox_root, EMBEDDED_DOCKERFILE)?;
     // 2. Octets bruts sur disque = entrée EXACTE du hash ET du build (jamais normaliser).
@@ -168,13 +237,25 @@ pub(crate) fn ensure_image(docker_bin: &str, sandbox_root: &Path) -> Result<Stri
             dockerfile.display()
         )
     })?;
-    // 3. Tag adressé par contenu.
-    let tag = local_image_ref(&bytes);
-    // 4. Présente localement -> pas de build.
-    if image_exists(docker_bin, &tag)? {
-        return Ok(tag);
+    // 3. Ref local content-addressé = TOUJOURS la valeur de retour (invariant sandbox_container).
+    let local_ref = local_image_ref(&bytes);
+    // 4. FAST PATH — précède TOUT réseau : image déjà locale → ni pull ni build (offline-safe).
+    if image_exists(docker_bin, &local_ref)? {
+        return Ok(local_ref);
     }
-    // 5. Contexte de build dédié VIDE (D8 : jamais sandbox_root, siblings = staging par-run).
+    // 5. Registry : PULL avant build. OK → retag sous le ref local → retour. Échec (offline / 404 /
+    //    registry down) → fallthrough vers le build local ci-dessous.
+    if matches!(source, ImageSource::Registry) {
+        let registry_ref = registry_image_ref(&bytes);
+        if pull_image(docker_bin, &registry_ref)? {
+            tag_image(docker_bin, &registry_ref, &local_ref)?;
+            return Ok(local_ref);
+        }
+    }
+    // 6. Build local (mode dockerfile OU fallback d'un pull raté). Contexte dédié VIDE (D8 : jamais
+    //    sandbox_root, siblings = staging par-run). v1: double-build concurrent premier-run accepté
+    //    (deux `docker build -t <même tag>` sont sûrs — daemon sérialise + cache, la sonde
+    //    court-circuite le 2e run) ; ajouter un lock par tag si ça mord.
     let context_dir = build_context_dir(sandbox_root);
     std::fs::create_dir_all(&context_dir).with_context(|| {
         format!(
@@ -182,12 +263,8 @@ pub(crate) fn ensure_image(docker_bin: &str, sandbox_root: &Path) -> Result<Stri
             context_dir.display()
         )
     })?;
-    // 6. Build. v1: double-build concurrent premier-run accepté (deux `docker build -t <même
-    //    tag>` sont sûrs — daemon sérialise + cache, la sonde court-circuite le 2e run) ;
-    //    ajouter un lock par tag si ça mord.
-    build_image(docker_bin, &tag, &dockerfile, &context_dir)?;
-    // 7.
-    Ok(tag)
+    build_image(docker_bin, &local_ref, &dockerfile, &context_dir)?;
+    Ok(local_ref)
 }
 
 // -- résolveurs de bord (seuls lecteurs d'env) -------------------------------
@@ -204,6 +281,66 @@ pub(crate) fn default_sandbox_root_from_env() -> Option<PathBuf> {
     Some(home.join(".pdo").join("sandbox"))
 }
 
+/// D'où [`ensure_image`] tire l'image (#411). **Par-daemon**, PAS par-Run : contrairement à
+/// [`crate::event_log::SandboxMode`], NE PAS la porter sur `RunStarted`. Défini dans ce module
+/// feuille (provisionnement) ; le sens de dépendance config → sandbox_image existe déjà → 0 cycle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) enum ImageSource {
+    /// Pull `ghcr.io/loulen/pdo-sandbox:h-<hash>`, retag local, build en fallback. **Défaut.**
+    #[default]
+    Registry,
+    /// Ne jamais tirer : build local depuis le Dockerfile seedé (comportement #405).
+    Dockerfile,
+}
+
+impl ImageSource {
+    /// Le tier défaut (jamais `None`), surfacé par `GET /settings`.
+    pub(crate) const DEFAULT: ImageSource = ImageSource::Registry;
+
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            ImageSource::Registry => "registry",
+            ImageSource::Dockerfile => "dockerfile",
+        }
+    }
+
+    /// Parse la forme filaire ; `None` pour tout token inconnu (le validateur PUT les rejette ;
+    /// le résolveur les traite comme unset défensivement). Miroir de `ServiceHealthOverride::parse`.
+    pub(crate) fn parse(s: &str) -> Option<ImageSource> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "registry" => Some(ImageSource::Registry),
+            "dockerfile" => Some(ImageSource::Dockerfile),
+            _ => None,
+        }
+    }
+}
+
+/// Env var overridant la source stockée (tier optionnel). Lue UNE fois au bord, jamais dans le
+/// cœur — miroir de [`DOCKER_CMD_OVERRIDE_ENV`].
+pub(crate) const IMAGE_SOURCE_ENV: &str = "PDO_SANDBOX_IMAGE_SOURCE";
+
+/// Tier env pour la disclosure `GET /settings` : `Some("registry"|"dockerfile")` si un
+/// `PDO_SANDBOX_IMAGE_SOURCE` valide est posé, sinon `None` (unset/invalide).
+pub(crate) fn env_image_source() -> Option<String> {
+    std::env::var(IMAGE_SOURCE_ENV)
+        .ok()
+        .as_deref()
+        .and_then(ImageSource::parse)
+        .map(|s| s.as_str().to_string())
+}
+
+/// Source effective, précédence `stored → env → default(Registry)` (#411, ADR-0015). Une valeur
+/// stockée vide/invalide est traitée comme unset (miroir de la sentinelle `""` + du validateur PUT).
+/// SOURCE UNIQUE consommée par [`ensure_image`] ET `build_settings_view` (0 drift, leçon #373).
+pub(crate) fn image_source_with(stored: Option<String>) -> ImageSource {
+    stored
+        .as_deref()
+        .filter(|s| !s.is_empty())
+        .and_then(ImageSource::parse)
+        .or_else(|| env_image_source().and_then(|s| ImageSource::parse(&s)))
+        .unwrap_or(ImageSource::DEFAULT)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -215,18 +352,40 @@ mod tests {
         format!("'{}'", s.replace('\'', "'\\''"))
     }
 
+    /// Comportement canné du faux `docker`, un exit code (+ stderr) par sous-commande. `Default` =
+    /// **registry heureux** : image absente (inspect 1) → `pull` réussit (0) → `tag` réussit (0),
+    /// build jamais atteint. Chaque test ne surcharge que les champs qui l'intéressent (#411).
+    #[derive(Clone)]
+    struct FakeSpec {
+        inspect_exit: i32,
+        build_exit: i32,
+        build_stderr: String,
+        pull_exit: i32,
+        pull_stderr: String,
+        tag_exit: i32,
+    }
+
+    impl Default for FakeSpec {
+        fn default() -> Self {
+            FakeSpec {
+                inspect_exit: 1,
+                build_exit: 0,
+                build_stderr: String::new(),
+                pull_exit: 0,
+                pull_stderr: String::new(),
+                tag_exit: 0,
+            }
+        }
+    }
+
     /// Écrit un faux `docker` exécutable dans `dir` et renvoie `(bin, argv_log)`. `bin` est passé
     /// comme `docker_bin` ; `argv_log` accumule l'argv de chaque invocation (une ligne par arg),
     /// pour les assertions d'argv. Aucune mutation d'`std::env` (D2 : race parallèle cargo).
     ///
-    /// Branche sur `$1` (`image` -> inspect, `build` -> build) et NON sur `"$1 $2"` : un vrai
-    /// `docker build -t …` a `$2 = "-t"`, donc `"$1 $2" = "build -t"` ne matcherait pas `build`.
-    fn write_fake_docker(
-        dir: &Path,
-        inspect_exit: i32,
-        build_exit: i32,
-        build_stderr: &str,
-    ) -> (PathBuf, PathBuf) {
+    /// Branche sur `$1` (`image`→inspect, `pull`→pull, `tag`→tag, `build`→build) et NON sur
+    /// `"$1 $2"` : un vrai `docker build -t …` a `$2 = "-t"`, donc `"$1 $2" = "build -t"` ne
+    /// matcherait pas `build`. Le stderr de `pull` (progression) et de `build` est configurable.
+    fn write_fake_docker(dir: &Path, spec: &FakeSpec) -> (PathBuf, PathBuf) {
         let bin = dir.join("fake-docker");
         let argv_log = dir.join("argv.log");
         let script = format!(
@@ -234,11 +393,18 @@ mod tests {
              printf '%s\\n' \"$@\" >> \"{log}\"\n\
              case \"$1\" in\n\
              image) exit {inspect_exit} ;;\n\
-             build) printf '%s' {stderr} >&2; exit {build_exit} ;;\n\
+             pull) printf '%s' {pull_stderr} >&2; exit {pull_exit} ;;\n\
+             tag) exit {tag_exit} ;;\n\
+             build) printf '%s' {build_stderr} >&2; exit {build_exit} ;;\n\
              *) exit 0 ;;\n\
              esac\n",
             log = argv_log.display(),
-            stderr = shell_single_quote(build_stderr),
+            inspect_exit = spec.inspect_exit,
+            pull_stderr = shell_single_quote(&spec.pull_stderr),
+            pull_exit = spec.pull_exit,
+            tag_exit = spec.tag_exit,
+            build_stderr = shell_single_quote(&spec.build_stderr),
+            build_exit = spec.build_exit,
         );
         std::fs::write(&bin, script).unwrap();
         std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
@@ -254,6 +420,31 @@ mod tests {
             Some(i) => lines[i..].to_vec(),
             None => Vec::new(),
         }
+    }
+
+    /// Regroupe le log d'argv plat en invocations : chaque appel docker que ce fake gère commence
+    /// par un mot-clé de sous-commande connu (`image`/`pull`/`tag`/`build`) — une ligne qui en
+    /// matche un ouvre une nouvelle invocation (les refs `pdo-sandbox:h-…`/`ghcr.io/…` ne sont
+    /// jamais des mots-clés nus, donc pas de faux départ).
+    fn invocations(argv_log: &Path) -> Vec<Vec<String>> {
+        let content = std::fs::read_to_string(argv_log).unwrap_or_default();
+        let starts = ["image", "pull", "tag", "build"];
+        let mut invs: Vec<Vec<String>> = Vec::new();
+        for line in content.lines() {
+            if starts.contains(&line) {
+                invs.push(vec![line.to_string()]);
+            } else if let Some(last) = invs.last_mut() {
+                last.push(line.to_string());
+            }
+        }
+        invs
+    }
+
+    /// Argv de la première invocation dont `$1 == name` (`None` si absente).
+    fn invocation(argv_log: &Path, name: &str) -> Option<Vec<String>> {
+        invocations(argv_log)
+            .into_iter()
+            .find(|inv| inv.first().map(String::as_str) == Some(name))
     }
 
     fn docker_str(bin: &Path) -> String {
@@ -289,10 +480,19 @@ mod tests {
     #[test]
     fn present_image_skips_build() {
         let tmp = tempfile::tempdir().unwrap();
-        let (docker, argv_log) = write_fake_docker(tmp.path(), 0, 0, "");
+        let (docker, argv_log) = write_fake_docker(
+            tmp.path(),
+            &FakeSpec {
+                inspect_exit: 0,
+                ..Default::default()
+            },
+        );
         let sandbox_root = tmp.path().join("sandbox");
 
-        let tag = retry_etxtbsy(|| ensure_image(&docker_str(&docker), &sandbox_root)).unwrap();
+        let tag = retry_etxtbsy(|| {
+            ensure_image(&docker_str(&docker), &sandbox_root, ImageSource::Dockerfile)
+        })
+        .unwrap();
 
         assert_eq!(tag, local_image_ref(EMBEDDED_DOCKERFILE.as_bytes()));
         assert!(
@@ -304,10 +504,19 @@ mod tests {
     #[test]
     fn absent_image_builds_then_returns_tag() {
         let tmp = tempfile::tempdir().unwrap();
-        let (docker, argv_log) = write_fake_docker(tmp.path(), 1, 0, "");
+        let (docker, argv_log) = write_fake_docker(
+            tmp.path(),
+            &FakeSpec {
+                inspect_exit: 1,
+                ..Default::default()
+            },
+        );
         let sandbox_root = tmp.path().join("sandbox");
 
-        let tag = retry_etxtbsy(|| ensure_image(&docker_str(&docker), &sandbox_root)).unwrap();
+        let tag = retry_etxtbsy(|| {
+            ensure_image(&docker_str(&docker), &sandbox_root, ImageSource::Dockerfile)
+        })
+        .unwrap();
 
         assert_eq!(tag, local_image_ref(EMBEDDED_DOCKERFILE.as_bytes()));
         assert_eq!(
@@ -326,10 +535,21 @@ mod tests {
     #[test]
     fn build_failure_is_explicit_error() {
         let tmp = tempfile::tempdir().unwrap();
-        let (docker, _) = write_fake_docker(tmp.path(), 1, 1, "boom: base image missing");
+        let (docker, _) = write_fake_docker(
+            tmp.path(),
+            &FakeSpec {
+                inspect_exit: 1,
+                build_exit: 1,
+                build_stderr: "boom: base image missing".to_string(),
+                ..Default::default()
+            },
+        );
         let sandbox_root = tmp.path().join("sandbox");
 
-        let err = retry_etxtbsy(|| ensure_image(&docker_str(&docker), &sandbox_root)).unwrap_err();
+        let err = retry_etxtbsy(|| {
+            ensure_image(&docker_str(&docker), &sandbox_root, ImageSource::Dockerfile)
+        })
+        .unwrap_err();
 
         let msg = format!("{err:#}");
         assert!(
@@ -348,7 +568,12 @@ mod tests {
         let sandbox_root = tmp.path().join("sandbox");
         let missing = tmp.path().join("no-such-docker");
 
-        let err = ensure_image(&docker_str(&missing), &sandbox_root).unwrap_err();
+        let err = ensure_image(
+            &docker_str(&missing),
+            &sandbox_root,
+            ImageSource::Dockerfile,
+        )
+        .unwrap_err();
 
         let msg = format!("{err:#}");
         assert!(
@@ -370,11 +595,20 @@ mod tests {
     #[test]
     fn seeds_dockerfile_when_absent_then_builds() {
         let tmp = tempfile::tempdir().unwrap();
-        let (docker, _) = write_fake_docker(tmp.path(), 1, 0, "");
+        let (docker, _) = write_fake_docker(
+            tmp.path(),
+            &FakeSpec {
+                inspect_exit: 1,
+                ..Default::default()
+            },
+        );
         let sandbox_root = tmp.path().join("sandbox");
         assert!(!dockerfile_path(&sandbox_root).exists());
 
-        retry_etxtbsy(|| ensure_image(&docker_str(&docker), &sandbox_root)).unwrap();
+        retry_etxtbsy(|| {
+            ensure_image(&docker_str(&docker), &sandbox_root, ImageSource::Dockerfile)
+        })
+        .unwrap();
 
         let seeded = std::fs::read(dockerfile_path(&sandbox_root)).unwrap();
         assert_eq!(
@@ -387,14 +621,23 @@ mod tests {
     #[test]
     fn edited_on_disk_dockerfile_is_preserved_and_drives_tag() {
         let tmp = tempfile::tempdir().unwrap();
-        let (docker, argv_log) = write_fake_docker(tmp.path(), 1, 0, "");
+        let (docker, argv_log) = write_fake_docker(
+            tmp.path(),
+            &FakeSpec {
+                inspect_exit: 1,
+                ..Default::default()
+            },
+        );
         let sandbox_root = tmp.path().join("sandbox");
         // Pré-écrire un Dockerfile ÉDITÉ (différent de l'embarqué).
         std::fs::create_dir_all(&sandbox_root).unwrap();
         let edited: &[u8] = b"FROM ubuntu:24.04\nRUN echo edited\n";
         std::fs::write(dockerfile_path(&sandbox_root), edited).unwrap();
 
-        let tag = retry_etxtbsy(|| ensure_image(&docker_str(&docker), &sandbox_root)).unwrap();
+        let tag = retry_etxtbsy(|| {
+            ensure_image(&docker_str(&docker), &sandbox_root, ImageSource::Dockerfile)
+        })
+        .unwrap();
 
         // (a) Octets inchangés : pas d'écrasement.
         assert_eq!(
@@ -411,10 +654,19 @@ mod tests {
     #[test]
     fn build_context_is_not_sandbox_root() {
         let tmp = tempfile::tempdir().unwrap();
-        let (docker, argv_log) = write_fake_docker(tmp.path(), 1, 0, "");
+        let (docker, argv_log) = write_fake_docker(
+            tmp.path(),
+            &FakeSpec {
+                inspect_exit: 1,
+                ..Default::default()
+            },
+        );
         let sandbox_root = tmp.path().join("sandbox");
 
-        retry_etxtbsy(|| ensure_image(&docker_str(&docker), &sandbox_root)).unwrap();
+        retry_etxtbsy(|| {
+            ensure_image(&docker_str(&docker), &sandbox_root, ImageSource::Dockerfile)
+        })
+        .unwrap();
 
         let argv = build_argv(&argv_log);
         let ctx = argv.last().unwrap();
@@ -443,5 +695,287 @@ mod tests {
         // `release.yml`/#411 produiront en bash :
         //   printf 'FROM ubuntu:24.04\nRUN apt-get update\n' | sha256sum | cut -c1-12
         assert_eq!(h, "5804eefb8f92");
+    }
+
+    // -- #411 : chemin hybride registry (pull → retag / fallback build) ---------
+
+    #[test]
+    fn registry_pull_ok_retags_and_skips_build() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Default = registry heureux : inspect 1 (absent) → pull 0 → tag 0.
+        let (docker, argv_log) = write_fake_docker(tmp.path(), &FakeSpec::default());
+        let sandbox_root = tmp.path().join("sandbox");
+
+        let tag = retry_etxtbsy(|| {
+            ensure_image(&docker_str(&docker), &sandbox_root, ImageSource::Registry)
+        })
+        .unwrap();
+
+        let local_ref = local_image_ref(EMBEDDED_DOCKERFILE.as_bytes());
+        let registry_ref = registry_image_ref(EMBEDDED_DOCKERFILE.as_bytes());
+        assert_eq!(tag, local_ref);
+        // `pull` fut invoqué sur le ref registry content-addressé.
+        assert_eq!(
+            invocation(&argv_log, "pull"),
+            Some(vec!["pull".to_string(), registry_ref.clone()]),
+            "pull must target the registry ref"
+        );
+        // `tag` retague registry_ref → local_ref (l'invariant sandbox_container).
+        assert_eq!(
+            invocation(&argv_log, "tag"),
+            Some(vec![
+                "tag".to_string(),
+                registry_ref.clone(),
+                local_ref.clone()
+            ]),
+            "tag must retag the pulled ref under the local ref"
+        );
+        // Aucun build : le pull a réussi.
+        assert!(
+            build_argv(&argv_log).is_empty(),
+            "a successful pull must skip the build; log:\n{}",
+            std::fs::read_to_string(&argv_log).unwrap_or_default()
+        );
+    }
+
+    #[test]
+    fn registry_pull_ok_returns_local_not_registry_ref() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (docker, _) = write_fake_docker(tmp.path(), &FakeSpec::default());
+        let sandbox_root = tmp.path().join("sandbox");
+
+        let tag = retry_etxtbsy(|| {
+            ensure_image(&docker_str(&docker), &sandbox_root, ImageSource::Registry)
+        })
+        .unwrap();
+
+        // Retour TOUJOURS le ref local (prouve sandbox_container 0-change) — jamais le ref GHCR.
+        assert_eq!(tag, local_image_ref(EMBEDDED_DOCKERFILE.as_bytes()));
+        assert!(
+            tag.starts_with("pdo-sandbox:h-"),
+            "must return the local ref: {tag}"
+        );
+        assert!(
+            !tag.contains("ghcr.io"),
+            "must never leak the registry ref to sandbox_container: {tag}"
+        );
+    }
+
+    #[test]
+    fn registry_pull_ok_ignores_stderr_progress() {
+        let tmp = tempfile::tempdir().unwrap();
+        // `docker pull` writes progress to stderr while succeeding (exit 0). Progress
+        // is NOT a failure signal — only the exit code counts.
+        let (docker, argv_log) = write_fake_docker(
+            tmp.path(),
+            &FakeSpec {
+                pull_stderr: "h-abc: Pulling from loulen/pdo-sandbox\nStatus: Downloaded\n"
+                    .to_string(),
+                ..Default::default()
+            },
+        );
+        let sandbox_root = tmp.path().join("sandbox");
+
+        let tag = retry_etxtbsy(|| {
+            ensure_image(&docker_str(&docker), &sandbox_root, ImageSource::Registry)
+        })
+        .unwrap();
+
+        assert_eq!(tag, local_image_ref(EMBEDDED_DOCKERFILE.as_bytes()));
+        assert!(invocation(&argv_log, "tag").is_some(), "must still retag");
+        assert!(
+            build_argv(&argv_log).is_empty(),
+            "stderr progress must not trigger a build"
+        );
+    }
+
+    #[test]
+    fn registry_pull_fail_falls_back_to_build() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Pull fails (offline / 404 / registry down) → fallback build.
+        let (docker, argv_log) = write_fake_docker(
+            tmp.path(),
+            &FakeSpec {
+                pull_exit: 1,
+                ..Default::default()
+            },
+        );
+        let sandbox_root = tmp.path().join("sandbox");
+
+        let tag = retry_etxtbsy(|| {
+            ensure_image(&docker_str(&docker), &sandbox_root, ImageSource::Registry)
+        })
+        .unwrap();
+
+        assert_eq!(tag, local_image_ref(EMBEDDED_DOCKERFILE.as_bytes()));
+        assert!(
+            invocation(&argv_log, "pull").is_some(),
+            "pull was attempted"
+        );
+        assert!(
+            invocation(&argv_log, "tag").is_none(),
+            "a failed pull must NOT retag"
+        );
+        assert!(
+            !build_argv(&argv_log).is_empty(),
+            "a failed pull must fall back to a local build; log:\n{}",
+            std::fs::read_to_string(&argv_log).unwrap_or_default()
+        );
+    }
+
+    #[test]
+    fn registry_pull_fail_then_build_fail_is_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (docker, _) = write_fake_docker(
+            tmp.path(),
+            &FakeSpec {
+                pull_exit: 1,
+                build_exit: 1,
+                build_stderr: "boom: base image missing".to_string(),
+                ..Default::default()
+            },
+        );
+        let sandbox_root = tmp.path().join("sandbox");
+
+        let err = retry_etxtbsy(|| {
+            ensure_image(&docker_str(&docker), &sandbox_root, ImageSource::Registry)
+        })
+        .unwrap_err();
+
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("failed to build the sandbox image"),
+            "pull-then-build-fail must surface the build error (US-16): {msg}"
+        );
+        assert!(
+            msg.contains("boom: base image missing"),
+            "the docker build stderr must be preserved: {msg}"
+        );
+    }
+
+    #[test]
+    fn dockerfile_mode_never_pulls() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (docker, argv_log) = write_fake_docker(tmp.path(), &FakeSpec::default());
+        let sandbox_root = tmp.path().join("sandbox");
+
+        let tag = retry_etxtbsy(|| {
+            ensure_image(&docker_str(&docker), &sandbox_root, ImageSource::Dockerfile)
+        })
+        .unwrap();
+
+        assert_eq!(tag, local_image_ref(EMBEDDED_DOCKERFILE.as_bytes()));
+        assert!(
+            !build_argv(&argv_log).is_empty(),
+            "dockerfile mode builds locally"
+        );
+        assert!(
+            invocation(&argv_log, "pull").is_none(),
+            "dockerfile mode must NEVER pull"
+        );
+        assert!(
+            invocation(&argv_log, "tag").is_none(),
+            "dockerfile mode must NEVER retag"
+        );
+    }
+
+    #[test]
+    fn local_present_skips_network_in_registry_mode() {
+        let tmp = tempfile::tempdir().unwrap();
+        // inspect 0 → image already local → fast-path returns before any network.
+        let (docker, argv_log) = write_fake_docker(
+            tmp.path(),
+            &FakeSpec {
+                inspect_exit: 0,
+                ..Default::default()
+            },
+        );
+        let sandbox_root = tmp.path().join("sandbox");
+
+        let tag = retry_etxtbsy(|| {
+            ensure_image(&docker_str(&docker), &sandbox_root, ImageSource::Registry)
+        })
+        .unwrap();
+
+        assert_eq!(tag, local_image_ref(EMBEDDED_DOCKERFILE.as_bytes()));
+        assert!(
+            invocation(&argv_log, "pull").is_none(),
+            "fast-path must skip pull (offline-safe reuse)"
+        );
+        assert!(
+            invocation(&argv_log, "tag").is_none(),
+            "fast-path must skip tag"
+        );
+        assert!(
+            build_argv(&argv_log).is_empty(),
+            "fast-path must skip build"
+        );
+    }
+
+    #[test]
+    fn docker_missing_errors_in_registry_mode() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sandbox_root = tmp.path().join("sandbox");
+        let missing = tmp.path().join("no-such-docker");
+
+        // Even in registry mode, Docker-absent is a hard error at the fast-path probe
+        // — never a silent host fallback (US-16). Same guarantee as dockerfile mode.
+        let err =
+            ensure_image(&docker_str(&missing), &sandbox_root, ImageSource::Registry).unwrap_err();
+
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("Docker") && msg.contains("not found on PATH"),
+            "docker-absent message expected: {msg}"
+        );
+        assert!(
+            err.chain().count() >= 2,
+            "the io::Error source must be preserved in the anyhow chain"
+        );
+        assert!(
+            !build_context_dir(&sandbox_root).exists(),
+            "no build context must be created when docker is absent"
+        );
+    }
+
+    #[test]
+    fn image_source_parse_and_resolver() {
+        // parse: round-trip + case-insensitive + unknown → None. PURE, no env mutation.
+        assert_eq!(ImageSource::parse("registry"), Some(ImageSource::Registry));
+        assert_eq!(
+            ImageSource::parse("dockerfile"),
+            Some(ImageSource::Dockerfile)
+        );
+        assert_eq!(ImageSource::parse("REGISTRY"), Some(ImageSource::Registry));
+        assert_eq!(
+            ImageSource::parse("  dockerfile  "),
+            Some(ImageSource::Dockerfile)
+        );
+        assert_eq!(ImageSource::parse("ecr"), None);
+        assert_eq!(ImageSource::parse(""), None);
+        // as_str round-trips both variants; the built-in default is Registry.
+        assert_eq!(ImageSource::Registry.as_str(), "registry");
+        assert_eq!(ImageSource::Dockerfile.as_str(), "dockerfile");
+        assert_eq!(ImageSource::DEFAULT, ImageSource::Registry);
+
+        // resolver: a concrete stored value wins; empty/invalid falls through to
+        // env→default (no test sets PDO_SANDBOX_IMAGE_SOURCE, so default = Registry).
+        assert_eq!(image_source_with(None), ImageSource::Registry);
+        assert_eq!(
+            image_source_with(Some(String::new())),
+            ImageSource::Registry
+        );
+        assert_eq!(
+            image_source_with(Some("ecr".to_string())),
+            ImageSource::Registry
+        );
+        assert_eq!(
+            image_source_with(Some("dockerfile".to_string())),
+            ImageSource::Dockerfile
+        );
+        assert_eq!(
+            image_source_with(Some("registry".to_string())),
+            ImageSource::Registry
+        );
     }
 }

--- a/crates/pdo-daemon/src/sandbox_run.rs
+++ b/crates/pdo-daemon/src/sandbox_run.rs
@@ -60,6 +60,10 @@ pub(crate) struct SandboxContext {
     pub(crate) gid: u32,
     /// Host `pdo` binary, bind-mounted read-only at `/usr/local/bin/pdo`.
     pub(crate) pdo_bin: PathBuf,
+    /// Where to source the image (#411): resolved once at the edge from
+    /// `instance_config` (stored → env → default Registry). Passed to
+    /// `sandbox_image::ensure_image` in the sync path — no DB access in the core.
+    pub(crate) image_source: sandbox_image::ImageSource,
 }
 
 impl SandboxContext {
@@ -76,9 +80,17 @@ impl SandboxContext {
 /// Resolve a [`SandboxContext`] from the daemon state + a projected Run. The one
 /// edge function that reads `AppState` / the environment; the core is pure values.
 ///
+/// **Async** (#411): reads a fresh `instance_config` at the boundary to resolve the
+/// image source (stored → env → default Registry), so a `PUT /settings` takes effect
+/// at the next ensure — consistent with the cap/TTL/model seams. A DB read error is
+/// swallowed (falls back env→default), never failing the prep.
+///
 /// Fails (loud) when `$HOME` is unset or the current exe path can't be resolved —
 /// a sandboxed Run must never fall back to a half-configured container silently.
-pub(crate) fn context_from_state(state: &AppState, run_state: &RunState) -> Result<SandboxContext> {
+pub(crate) async fn context_from_state(
+    state: &AppState,
+    run_state: &RunState,
+) -> Result<SandboxContext> {
     let repo_root = crate::effective_repo_root(state, run_state);
     let run_worktree = crate::worktree_ops::worktree_dir_for_run(&repo_root, &run_state.run_id);
     // Home root: the per-daemon override (layer-3 harness) wins; else the real
@@ -87,6 +99,14 @@ pub(crate) fn context_from_state(state: &AppState, run_state: &RunState) -> Resu
     let (home_root, sandbox_root) = sandbox_home_roots(state)?;
     let host_home = home_root.clone();
     let pdo_bin = sandbox_container::pdo_bin_path()?;
+    // Read fresh at each prep → a PUT /settings takes effect at the next ensure
+    // (ADR-0015), like the cap/TTL/model seams. A DB error falls back env→default,
+    // never failing the prep.
+    let stored_image_source = crate::instance_config::get(&state.db)
+        .await
+        .ok()
+        .and_then(|c| c.image_source);
+    let image_source = sandbox_image::image_source_with(stored_image_source);
     Ok(SandboxContext {
         docker_bin: docker_bin(state),
         run_id: run_state.run_id.clone(),
@@ -100,6 +120,7 @@ pub(crate) fn context_from_state(state: &AppState, run_state: &RunState) -> Resu
         uid: sandbox_container::host_uid(),
         gid: sandbox_container::host_gid(),
         pdo_bin,
+        image_source,
     })
 }
 
@@ -223,10 +244,12 @@ pub(crate) fn ensure_ready(ctx: &SandboxContext) -> Result<()> {
         .with_context(|| format!("failed to stage the sandbox home for run {}", ctx.run_id))?;
     }
 
-    // 2. Ensure the content-addressed image (`pdo-sandbox:h-<hash>`) exists,
-    //    building it from the seeded Dockerfile on the first machine run.
-    let image_ref = sandbox_image::ensure_image(&ctx.docker_bin, &ctx.sandbox_root)
-        .context("failed to ensure the sandbox image")?;
+    // 2. Ensure the content-addressed image (`pdo-sandbox:h-<hash>`) exists —
+    //    pull-then-retag from GHCR (registry, default), or build it from the seeded
+    //    Dockerfile (dockerfile mode / pull fallback), per `ctx.image_source` (#411).
+    let image_ref =
+        sandbox_image::ensure_image(&ctx.docker_bin, &ctx.sandbox_root, ctx.image_source)
+            .context("failed to ensure the sandbox image")?;
 
     // 3. Assemble the container spec + ensure the long-lived container is up.
     let staged_home = sandbox_staging::staged_claude_home(&ctx.sandbox_root, &ctx.run_id);
@@ -390,6 +413,9 @@ mod tests {
             uid: 1000,
             gid: 1000,
             pdo_bin: tmp.join("pdo"),
+            // Dockerfile → build-probe path (network-free); keeps the existing
+            // ensure_ready assertions (image inspect + build/create) intact (#411).
+            image_source: sandbox_image::ImageSource::Dockerfile,
         }
     }
 

--- a/crates/pdo-daemon/tests/sandbox_tracer.rs
+++ b/crates/pdo-daemon/tests/sandbox_tracer.rs
@@ -826,3 +826,106 @@ async fn copy_completes_without_host_config_writeback() {
         "cleanup must purge the staging dir: {staging:?}"
     );
 }
+
+// -- #411: image_source drives the acquisition path (pull vs build) ----------
+//
+// Like `write_fake_docker` but cans `image inspect` → ABSENT (exit 1), so
+// `ensure_image` proceeds past the fast-path to acquire the image: a `docker pull`
+// in registry mode (which the fake succeeds → retag, no build), or a `docker build`
+// in dockerfile mode (never a pull). Every other subcommand — `pull`, `tag`,
+// `build`, `container`(create+start), `exec`, `rm` — exits 0. Lets the tracer
+// observe, on a real daemon, which acquisition path the stored `image_source` picks.
+fn write_fake_docker_image_absent() -> (TempDir, String, PathBuf) {
+    let dir = tempfile::tempdir().unwrap();
+    let bin = dir.path().join("fake-docker");
+    let log = dir.path().join("argv.log");
+    let sq = |s: &str| format!("'{}'", s.replace('\'', "'\\''"));
+    let script = format!(
+        "#!/usr/bin/env bash\n\
+         printf '%s\\n' \"$@\" >> {log}\n\
+         case \"$1\" in\n\
+         image) exit 1 ;;\n\
+         container) printf '%s' 'Error: No such container' >&2; exit 1 ;;\n\
+         *) exit 0 ;;\n\
+         esac\n",
+        log = sq(&log.display().to_string()),
+    );
+    std::fs::write(&bin, script).unwrap();
+    std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
+    (dir, bin.to_str().unwrap().to_string(), log)
+}
+
+/// `PUT /settings {"image_source": <source>}` against the real daemon.
+async fn put_image_source(daemon: &TestDaemon, source: &str) {
+    let resp = reqwest::Client::new()
+        .put(format!("{}/settings", daemon.url()))
+        .json(&serde_json::json!({ "image_source": source }))
+        .send()
+        .await
+        .unwrap();
+    assert!(
+        resp.status().is_success(),
+        "PUT /settings image_source={source} should succeed: {}",
+        resp.status()
+    );
+}
+
+/// Whether a docker subcommand keyword appears as a standalone argv line (`$1`).
+fn log_has_subcommand(log: &Path, name: &str) -> bool {
+    log_text(log).lines().any(|l| l == name)
+}
+
+// -- Test 11: registry mode pulls the image (no build on a successful pull) --
+
+#[tokio::test]
+async fn registry_mode_pulls_the_sandbox_image() {
+    ensure_pdo_on_path();
+    let (_fake_dir, docker, log) = write_fake_docker_image_absent();
+    let daemon =
+        TestDaemon::spawn_with_docker_override(seed("#!/usr/bin/env bash\ntrue\n"), docker)
+            .await
+            .unwrap();
+
+    // Store registry mode BEFORE starting the run — eager prep reads it fresh.
+    put_image_source(&daemon, "registry").await;
+    let _run_id = start_run(&daemon, Some("pure")).await;
+
+    // ensure_image (image absent) attempts a pull before any build.
+    assert!(
+        wait_until(|| log_has_subcommand(&log, "pull")).await,
+        "registry mode must `docker pull` the sandbox image; log:\n{}",
+        log_text(&log)
+    );
+    // The fake pull succeeds (exit 0) → retag → NO fallback build.
+    assert!(
+        !log_has_subcommand(&log, "build"),
+        "a successful pull must NOT fall back to a local build; log:\n{}",
+        log_text(&log)
+    );
+}
+
+// -- Test 12: dockerfile mode builds locally, never pulls --------------------
+
+#[tokio::test]
+async fn dockerfile_mode_builds_never_pulls() {
+    ensure_pdo_on_path();
+    let (_fake_dir, docker, log) = write_fake_docker_image_absent();
+    let daemon =
+        TestDaemon::spawn_with_docker_override(seed("#!/usr/bin/env bash\ntrue\n"), docker)
+            .await
+            .unwrap();
+
+    put_image_source(&daemon, "dockerfile").await;
+    let _run_id = start_run(&daemon, Some("pure")).await;
+
+    assert!(
+        wait_until(|| log_has_subcommand(&log, "build")).await,
+        "dockerfile mode must `docker build` the sandbox image; log:\n{}",
+        log_text(&log)
+    );
+    assert!(
+        !log_has_subcommand(&log, "pull"),
+        "dockerfile mode must NEVER pull; log:\n{}",
+        log_text(&log)
+    );
+}

--- a/docs/adr/0030-sandbox-execution-model.md
+++ b/docs/adr/0030-sandbox-execution-model.md
@@ -46,10 +46,21 @@ PID 1 = tini). Les guards de Trigger restent hôte (décision de fiançailles, p
    arbre porteur ; les sessions sœurs survivent (le client `docker exec` tué côté tmux ne tue pas le
    process conteneur, reparenté sur PID 1).
 
-7. **Tag image adressé par contenu.** `pdo-sandbox:h-<hash>` où `<hash>` = SHA-256[..12] des octets
-   exacts du Dockerfile sur disque. Deux Dockerfiles identiques → même tag ; une édition → rebuild.
-   C'est l'identité qui rendra plus tard image tirée d'un registry et image buildée localement
-   interchangeables sous le même nom (#411). `.gitattributes` épingle `eol=lf` pour la reproductibilité.
+7. **Tag image adressé par contenu + fourniture hybride (#411).** `pdo-sandbox:h-<hash>` où
+   `<hash>` = SHA-256[..12] des octets exacts du Dockerfile sur disque. Deux Dockerfiles identiques →
+   même tag ; une édition → rebuild. `.gitattributes` épingle `eol=lf` pour la reproductibilité.
+   C'est l'identité qui rend une image **tirée d'un registry** et une image **buildée localement**
+   interchangeables sous le même nom. Un réglage **par-daemon** `image_source`
+   (`registry` défaut | `dockerfile`, précédence `stored → env → default`, ADR-0015) pilote
+   `ensure_image` : en `registry`, si l'image n'est pas déjà locale, `docker pull
+   ghcr.io/loulen/pdo-sandbox:h-<hash>` puis **retag** sous le ref local, avec **fallback build** si
+   le pull échoue (offline / 404 tag absent / registry down) ; en `dockerfile`, build direct, jamais
+   de pull. La valeur de retour est **toujours le ref local** → `sandbox_container` inchangé (reçoit
+   `pdo-sandbox:h-<hash>` que l'image vienne d'un pull ou d'un build). Le pull est **anonyme** sur une
+   image **publique** : aucune nouvelle surface d'auth, le trou d'auth #260 reste **inchangé**. La
+   release publie l'image sur GHCR (job additif indépendant, multi-arch `amd64`+`arm64`, tags
+   `h-<hash>` + `latest` informatif) ; le hash CI (bash `sha256sum | cut`) est byte-identique au Rust,
+   gardé par un self-check de parité.
 
 8. **Mode immuable par Run.** `off`|`copy`|`pure` est porté par `RunStarted`, projeté une fois, jamais
    muté. Un Run reste sandboxé (ou non) toute sa vie : sinon `claude --continue` (resume) ne

--- a/frontend/src/components/SettingsModal.test.tsx
+++ b/frontend/src/components/SettingsModal.test.tsx
@@ -22,6 +22,8 @@ function sample(overrides: Partial<InstanceSettings> = {}): InstanceSettings {
     guard_timeout_secs: { effective: 60, source: "default", stored: null, env: null, default: 60 },
     // Unset by default (account default): effective/stored/env/default all null.
     default_model: { effective: null, source: "default", stored: null, env: null, default: null },
+    // Image source (#411): built-in default `registry`, nothing stored/env.
+    image_source: { effective: "registry", source: "default", stored: null, env: null, default: "registry" },
     updated_at: "2026-07-01T10:00:00.000Z",
     ...overrides,
   };
@@ -180,6 +182,67 @@ describe("SettingsModal", () => {
     render(<SettingsModal open onClose={() => {}} />);
     const note = await screen.findByTestId("setting-source-default-model");
     expect(note).toHaveTextContent("PDO_DEFAULT_MODEL=sonnet");
+    expect(note).toHaveTextContent(/overridden/i);
+  });
+
+  it("seeds the image-source select from the effective value (#411)", async () => {
+    fetchSettingsMock.mockResolvedValue(sample());
+    render(<SettingsModal open onClose={() => {}} />);
+    const select = (await screen.findByTestId("setting-image-source")) as HTMLSelectElement;
+    expect(select.value).toBe("registry");
+  });
+
+  it("saves the picked image source (#411)", async () => {
+    fetchSettingsMock.mockResolvedValue(sample());
+    updateSettingsMock.mockResolvedValue(
+      sample({
+        image_source: {
+          effective: "dockerfile",
+          source: "stored",
+          stored: "dockerfile",
+          env: null,
+          default: "registry",
+        },
+      }),
+    );
+    const onClose = vi.fn();
+    render(<SettingsModal open onClose={onClose} />);
+
+    const select = await screen.findByTestId("setting-image-source");
+    fireEvent.change(select, { target: { value: "dockerfile" } });
+    fireEvent.click(screen.getByTestId("settings-save"));
+
+    await waitFor(() => expect(updateSettingsMock).toHaveBeenCalledTimes(1));
+    // Only the image source changed; the numeric knobs stay at their effective values.
+    expect(updateSettingsMock).toHaveBeenCalledWith({ image_source: "dockerfile" });
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+
+  it("does not send image_source when left unchanged (#411)", async () => {
+    fetchSettingsMock.mockResolvedValue(sample());
+    const onClose = vi.fn();
+    render(<SettingsModal open onClose={onClose} />);
+    await screen.findByTestId("setting-image-source");
+    fireEvent.click(screen.getByTestId("settings-save"));
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+    expect(updateSettingsMock).not.toHaveBeenCalled();
+  });
+
+  it("discloses a shadowed env source for the image source (#411)", async () => {
+    fetchSettingsMock.mockResolvedValue(
+      sample({
+        image_source: {
+          effective: "dockerfile",
+          source: "stored",
+          stored: "dockerfile",
+          env: "registry",
+          default: "registry",
+        },
+      }),
+    );
+    render(<SettingsModal open onClose={() => {}} />);
+    const note = await screen.findByTestId("setting-source-image-source");
+    expect(note).toHaveTextContent("PDO_SANDBOX_IMAGE_SOURCE=registry");
     expect(note).toHaveTextContent(/overridden/i);
   });
 });

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -164,6 +164,11 @@ function SettingsForm({ settings, liveSessions, save, onClose, onSaved }: FormPr
   // Model is `null` when unset (account default); ModelPicker speaks the same
   // `string | null` contract as the per-node inspector (#296/#324/#347).
   const [model, setModel] = useState<string | null>(() => settings.default_model.effective);
+  // Sandbox image source (#411): a closed enum with a built-in `registry` default,
+  // so `effective` is always a present string (the `?? "registry"` is belt-and-braces).
+  const [imageSource, setImageSource] = useState<string>(
+    () => settings.image_source.effective ?? "registry",
+  );
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -207,6 +212,12 @@ function SettingsForm({ settings, liveSessions, save, onClose, onSaved }: FormPr
     // sent when it actually changed (avoids a needless clear/no-op PUT).
     if (model !== settings.default_model.effective) {
       patch.default_model = model ?? "";
+    }
+
+    // Image source (#411): a concrete enum variant, only sent when it changed. The
+    // select never emits "" — the clear path is backend-only.
+    if (imageSource !== settings.image_source.effective) {
+      patch.image_source = imageSource;
     }
 
     // Nothing changed → close without a round-trip.
@@ -305,6 +316,44 @@ function SettingsForm({ settings, liveSessions, save, onClose, onSaved }: FormPr
             data-testid="setting-source-default-model"
           >
             {modelSourceNote(settings.default_model)}
+          </div>
+        </div>
+
+        {/* Sandbox image source (#411): where a sandboxed run's image comes from —
+            pull from GHCR (default) or build locally. A closed enum → native
+            <select> (NOT the free-text ModelPicker). It only ever emits a concrete
+            variant; the "" clear sentinel is backend-only. */}
+        <div className="flex flex-col gap-1.5">
+          <label
+            htmlFor="setting-image-source"
+            className="font-medium text-fg-2"
+            style={{ fontSize: "11.5px" }}
+          >
+            Sandbox image source
+          </label>
+          <select
+            id="setting-image-source"
+            data-testid="setting-image-source"
+            value={imageSource}
+            onChange={(e) => setImageSource(e.target.value)}
+            className="w-full rounded-md border border-line-strong bg-bg-3 px-2.5 py-1.5 font-mono text-fg transition-colors focus:border-acc focus:outline-none"
+            style={{ fontSize: "12px" }}
+          >
+            <option value="registry">registry (pull from GHCR)</option>
+            <option value="dockerfile">dockerfile (build locally)</option>
+          </select>
+          <div className="text-fg-4" style={{ fontSize: "10.5px" }}>
+            Where a sandboxed run's image comes from.{" "}
+            <span className="font-mono">registry</span> pulls the content-addressed image from
+            GHCR and falls back to a local build; <span className="font-mono">dockerfile</span>{" "}
+            always builds it locally from the seeded Dockerfile.
+          </div>
+          <div
+            className="text-fg-3"
+            style={{ fontSize: "10.5px" }}
+            data-testid="setting-source-image-source"
+          >
+            {imageSourceSourceNote(settings.image_source)}
           </div>
         </div>
 
@@ -433,4 +482,19 @@ function modelSourceNote(field: StringSettingField): string {
     return `Source: env ${envDisplay ?? "PDO_DEFAULT_MODEL"}.`;
   }
   return `Source: your Claude account default (no --model).`;
+}
+
+/** Which tier the sandbox image source comes from (#411). Unlike default_model there
+ *  IS a built-in default (`registry`). Discloses a shadowed env var too. */
+function imageSourceSourceNote(field: StringSettingField): string {
+  const envDisplay = field.env ? `PDO_SANDBOX_IMAGE_SOURCE=${field.env}` : null;
+  if (field.source === "stored") {
+    return envDisplay
+      ? `Source: stored value (wins). Env ${envDisplay} is set but overridden.`
+      : `Source: stored value (overrides env and default).`;
+  }
+  if (field.source === "env") {
+    return `Source: env ${envDisplay ?? "PDO_SANDBOX_IMAGE_SOURCE"}.`;
+  }
+  return `Source: built-in default (${field.default ?? "registry"}).`;
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -77,12 +77,19 @@ export interface StringSettingField {
   default: string | null;
 }
 
-/** The full `GET /settings` view (#129, ADR-0015; default_model #347). */
+/** The full `GET /settings` view (#129, ADR-0015; default_model #347; image_source #411). */
 export interface InstanceSettings {
   session_cap: SettingField;
   reaper_ttl_secs: SettingField;
   guard_timeout_secs: SettingField;
   default_model: StringSettingField;
+  /**
+   * Sandbox image source (#411): `"registry"` (pull from GHCR, default) or
+   * `"dockerfile"` (build locally). A closed enum with a built-in `registry`
+   * default, so every tier (`effective`/`default`) is a present string — it reuses
+   * {@link StringSettingField} (a superset) even though it is never null.
+   */
+  image_source: StringSettingField;
   updated_at: string;
 }
 
@@ -98,6 +105,9 @@ export interface UpdateSettingsRequest {
   reaper_ttl_secs?: number;
   guard_timeout_secs?: number;
   default_model?: string;
+  /** Sandbox image source (#411): `"registry"` | `"dockerfile"`. The `<select>` only
+   *  ever sends a concrete variant — the `""` clear sentinel is backend-only. */
+  image_source?: string;
 }
 // `for-each` was removed (ADR-0011 / #151): a fan-out is now a `collection`
 // loop region, not a node. The backend keeps the variant only to migrate old


### PR DESCRIPTION
## Sandbox H — image hybride (GHCR pull + fallback build local + `image_source`)

Slice H du PRD #403. Fournit l'image sandbox de façon hybride :

- `ensure_image(.., source)` retourne **toujours** un `local_ref` → `sandbox_container` reste 0-change.
  - mode `registry` (défaut) : fast-path image locale présente → sinon `pull` GHCR puis re-tag → **fallback build** local si le pull échoue.
  - mode `dockerfile` : build direct, **jamais** de pull.
- `ImageSource` (`registry` | `dockerfile`) par-daemon, exposé dans les Settings (`<select>` + persistance + rejet 400 sur valeur invalide).
- Colonne `image_source` `TEXT` (ALTER guardé) ; défaut `registry` résolu dans le **résolveur**, pas dans la colonne.
- Publication GHCR `ghcr.io/loulen/pdo-sandbox` multi-arch (buildx amd64+arm64) ; lien package↔repo via `--label` **au build** (le hash reste invariant).
- Job `release.yml` indépendant (`needs: ∅`) avec self-check de parité du hash (`5804eefb8f92`).
- Tag = identité stable du Dockerfile on-disk (`sha256[..12]`), interchangeable pull/build ; conforme ADR-0030 pt 7.

### Validation (verdict Pass)
- `cargo +stable build/test/clippy -p pdo-daemon` : vert, 0 warning. `sandbox_image` 17/17, `sandbox_tracer` 12/12 (dont 2 tests L3 #411 sur argv docker réels : registry→`pull`, dockerfile→`build`).
- Frontend : `npm run lint` clean, `npm test` 1328 passed (`SettingsModal` 19).
- FP-411 (Docker réel v29.2.1) : Settings UI (défaut/bascule/persistance/rejet 400) ✓ ; mode `dockerfile` = build sans pull ✓ ; mode `registry` = pull `denied` → fallback build ✓ ; identité de tag `pdo-sandbox:h-9a67637571a4` partagée entre les deux modes ✓.

Écart hors périmètre observé (non bloquant) : les runs sandbox `pure` finissent `session_died` alors que le script tourne bien in-container — course de suivi de session tmux/conteneur dans la couche **#406/#407**, ne touche pas le diff de #411. À tracer comme suivi.

Closes #411
