### PR TITLE
feat(#410): sandbox FE run-level + sources de config — précédence, sonde Docker, visibilité de la prep

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -827,7 +827,9 @@ La complétion est signalée **depuis l'UI**, par un bouton "Mark complete" sur 
 > `merge_back` ; même câblage mode-agnostique que #407, ne diffère de `pure` que par le seed de
 > `prepare` — deref des symlinks échappants + walk best-effort en sus) + **fourniture hybride de
 > l'image** (#411 : `ensure_image` pull GHCR-puis-retag / fallback build, réglage `image_source`,
-> job release GHCR). Reste **différé** : précédence des sources du mode (#410).
+> job release GHCR) + **exposition run-level + sources de config** (#410 : sélecteur tri-état du
+> NewRunModal grisé par la **sonde Docker**, badge + bannière `sandbox_prep`, défaut d'instance
+> `default_sandbox`, défaut par-Trigger `sandbox`, **précédence** résolue par `effective_sandbox`).
 
 **Sandbox** :
 Propriété **par Run**, **immuable après création**, portée par l'événement de création (projetée
@@ -835,7 +837,9 @@ dans l'état du Run). Tri-état `off` | `copy` | `pure` : `off` = comportement h
 sur l'hôte, défaut) ; `copy` / `pure` = toutes les tails du Run s'exécutent dans un conteneur dédié.
 C'est une propriété de l'**environnement d'exécution**, jamais de la sémantique du pipeline (le YAML
 reste intouché — #403 US-5). Modèle d'exécution (conteneur `pdo-sbx-<run-id>`, identity mounts, uid
-hôte, trou réseau/auth) → **ADR-0030 / #407**.
+hôte, trou réseau/auth) → **ADR-0030 / #407**. La **source** du mode suit la précédence **choix
+explicite du Run → défaut par-Trigger → `default_sandbox` d'instance** (résolveur pur
+`effective_sandbox`, #410) ; `off` reste le plancher.
 _Éviter_ : « mode conteneur », « isolation » seul (ambigu) ; ne pas confondre avec l'attribut
 `sandbox=""` de l'iframe du port de sortie `html` (#333, ADR-0028) — sans rapport.
 
@@ -995,6 +999,52 @@ Suppression du conteneur (`docker rm -f pdo-sbx-<run-id>`) à `cleanup_run` ; sa
 absent (idempotent). C'est **le** verbe « destroy / destruction » réservé par `teardown`. _Éviter_ :
 « teardown » (= purge du staging dir, #404), « cleanup » (= niveau Run).
 
+### Exposition run-level + sources de config (#410)
+
+Périmètre **utilisateur** : d'où vient le mode d'un Run, comment on le choisit/le voit. L'exécution
+elle-même est inchangée (#406/#407). Landé par #410.
+
+**`effective_sandbox` (résolveur de précédence)** :
+Fonction **pure** (`event_log`) `(explicit: Option<SandboxMode>, trigger: Option<SandboxMode>,
+instance_default: SandboxMode) → SandboxMode` : le **premier `Some` gagne**, `instance_default` est le
+plancher. Appelée **une fois** au chokepoint `create_run_inner` (où JSON, multipart et fire de Trigger
+convergent), juste avant le gel du mode dans `RunStarted` (immuable, ADR-0030 pt 8). _Éviter_ :
+« merge », « override », « fusion des modes ».
+
+**`default_sandbox` (défaut d'instance)** :
+Défaut du mode sandbox **par-daemon** : colonne **nullable** `instance_config` (`off`/`copy`/`pure`,
+`""` = sentinelle clear → NULL). Résolveur `default_sandbox_with` (`stored → env(`PDO_DEFAULT_SANDBOX`)
+→ default(`off`)`, ADR-0015), lu **frais** au bord et partagé par `create_run_inner` **et** `GET
+/settings` (0 drift #373, miroir exact d'`image_source`). Éditable dans la Settings UI (`<select>`).
+_Éviter_ : confondre avec `image_source` (provisionnement d'image, orthogonal) ; « mode d'instance ».
+
+**Défaut par-Trigger (`Trigger.sandbox`)** :
+Mode par défaut d'un **Trigger** : colonne **nullable** `sandbox` sur `triggers`. `None` = **déférer**
+à `default_sandbox`. Édité dans le NewRunModal en mode Trigger, **clearable** via
+`deserialize_double_option` (présent-`null` = repasse à l'héritage ; précédent `max_concurrent` #239 —
+**pas** les frères `guard_command`/`target_repo` en `serde(default)` qui ne savent pas clear).
+_Éviter_ : « sandbox du trigger » comme si le trigger s'exécutait (les guards restent hôte, ADR-0030).
+
+**Sonde Docker (`sandbox_docker`)** :
+Check de disponibilité host (`docker version`, exit 0 = disponible ; binaire absent →
+`DOCKER_NOT_FOUND_MSG` ; daemon injoignable → message dédié). **TTL-cachée** (~10 s) par-daemon,
+surfacée sur `GET /settings` comme `sandbox_docker {available, reason, checked_at}` (pas un
+`settings_field` : aucun tier stored/env/default) à côté du knob `default_sandbox`, pour un **seul**
+fetch du modal. Affordance **advisory** : grise les options `copy`/`pure` du sélecteur tri-état et
+clamp sur `off` ; le fail-fast du run-advance (ADR-0030 pt 4) reste le gate **autoritaire**. Passe par
+le seam `docker_cmd_override`. _Éviter_ : « Docker health », « sandbox available » (ambigu avec le
+mode), confondre avec `ensure_image`/`probe_state` (provisionnement/liveness par-Run).
+
+**Préparation du sandbox (`sandbox_prep`)** :
+État **additif** projeté sur le Run (`pending`|`ready`) qui rend visible la fenêtre de prep eager
+(ADR-0030 pt 4/10) : `SandboxPrepStarted` (avant `ensure_ready`) → `pending`, `SandboxPrepReady`
+(avant le 1er spawn) → `ready`. Événements **informationnels** (même grain que `NodeBlockedOnLimit` /
+`NodeAutoCompleteObserved`), émis au chokepoint `append_event`, **jamais** pour un Run `off`. N'altère
+**pas** `status` (reste `running`). Échec → `RunFailed` (pas d'événement de prep dédié). L'UI du Run
+affiche une **bannière** « préparation du sandbox » tant que `pending`, plus un **badge** `sandbox :
+copy|pure` persistant. _Éviter_ : « statut preparing » (écarté, pas un état de la machine à statut) ;
+l'inférence client (écartée : faux positifs advance-détaché/#159).
+
 ### Relations
 - Une **Sandbox** `copy`/`pure` possède un **staging dir** (`~/.pdo/sandbox/<run-id>/`) contenant un
   **staged Claude home** (`claude-home/`) + un `.claude.json` sibling.
@@ -1032,9 +1082,17 @@ absent (idempotent). C'est **le** verbe « destroy / destruction » réservé pa
   sur image publique → trou d'auth #260 inchangé. Couvert par unit (`sandbox_image`/`instance_config`
   /settings) + 2 tests layer-3 (`sandbox_tracer` : pull vs build selon `image_source`) + FP-411 (L5,
   Docker réel).
+- **Câblé (#410, ADR-0030 pt 8+10)** : **exposition run-level + sources de config**. Précédence
+  **réalisée** — résolveur pur `effective_sandbox(explicit, trigger, instance_default)` (run → trigger
+  → `default_sandbox`, plancher `off`) au chokepoint `create_run_inner` ; param filaire
+  `Option<SandboxMode>` (absent ≠ `off` explicite) ; `default_sandbox` colonne `instance_config`
+  (résolveur `default_sandbox_with`, `stored → env → default(off)`) ; défaut par-Trigger colonne
+  nullable `sandbox` (clearable `deserialize_double_option`, précédent #239). **Sonde Docker** advisory
+  (`GET /settings.sandbox_docker`, TTL-cachée) → grise `copy`/`pure` du sélecteur. **Visibilité prep**
+  via événements additifs `SandboxPrepStarted`/`Ready` → `RunState.sandbox_prep` (badge + bannière).
+  Testé layer-1 (résolveur pur) + unit (settings/probe) + FE (vitest) + FP-410 (L5, Docker réel).
 - **Différé** : injection `/etc/passwd`+`/etc/group` pour uid hôte ≠ 1000 (sudo +
-  Node `os.userInfo()`) (issue de suivi) ; précédence des sources du mode (run → trigger →
-  `default_sandbox`, pattern ADR-0015) (#410) ; auto-flip de la visibilité publique du package GHCR
+  Node `os.userInfo()`) (issue de suivi) ; auto-flip de la visibilité publique du package GHCR
   (non supporté par l'API → manuel one-time après la 1ʳᵉ release, #411).
 
 ### Ambiguïté signalée

--- a/crates/pdo-daemon/src/event_log.rs
+++ b/crates/pdo-daemon/src/event_log.rs
@@ -1666,7 +1666,11 @@ mod tests {
     #[test]
     fn explicit_wins_over_trigger_and_default() {
         assert_eq!(
-            effective_sandbox(Some(SandboxMode::Pure), Some(SandboxMode::Copy), SandboxMode::Off),
+            effective_sandbox(
+                Some(SandboxMode::Pure),
+                Some(SandboxMode::Copy),
+                SandboxMode::Off
+            ),
             SandboxMode::Pure
         );
     }
@@ -1704,7 +1708,10 @@ mod tests {
         // empty sentinel → unset → default (Off) (env not set in this harness).
         assert_eq!(default_sandbox_with(Some(String::new())), SandboxMode::Off);
         // garbage → unset → default.
-        assert_eq!(default_sandbox_with(Some("garbage".into())), SandboxMode::Off);
+        assert_eq!(
+            default_sandbox_with(Some("garbage".into())),
+            SandboxMode::Off
+        );
         // absent → default.
         assert_eq!(default_sandbox_with(None), SandboxMode::Off);
     }

--- a/crates/pdo-daemon/src/event_log.rs
+++ b/crates/pdo-daemon/src/event_log.rs
@@ -114,6 +114,17 @@ pub enum EventKind {
     RunResumed,
     RunArchived,
     RunRenamed,
+    /// Informational (#410): a sandboxed Run's image is being prepared (pull/build)
+    /// at the head of the detached prep task, before the first session spawns. Emitted
+    /// only on the create path and only when the resolved mode is `copy`/`pure` (the
+    /// `off` path stays byte-identical). Non-terminal: `status` stays `Running`, only
+    /// `RunState::sandbox_prep` moves to `pending`. Wire form: `"sandbox_prep_started"`.
+    SandboxPrepStarted,
+    /// Informational (#410): the sandbox image is ready and the container is about to
+    /// receive the first session. Projects `RunState::sandbox_prep` to `ready`. A
+    /// prep failure emits `RunFailed` instead (no dedicated failed-prep event). Wire
+    /// form: `"sandbox_prep_ready"`.
+    SandboxPrepReady,
     CommandIssued,
 }
 
@@ -199,12 +210,91 @@ pub enum SandboxMode {
 }
 
 impl SandboxMode {
+    /// The default tier (never `None`), surfaced by `GET /settings` and used as the
+    /// precedence floor: an install with no `default_sandbox` set runs `Off`, so the
+    /// legacy host path stays byte-identical (#410). Mirror of [`crate::sandbox_image::ImageSource::DEFAULT`].
+    pub const DEFAULT: SandboxMode = SandboxMode::Off;
+
     /// Whether this Run runs on the host (the legacy, no-Docker path). The whole
     /// sandbox wiring is gated on `!is_off()`, so the `off` parcours never touches
     /// a single new line.
     pub fn is_off(self) -> bool {
         matches!(self, SandboxMode::Off)
     }
+
+    /// The exact wire form: `off`/`copy`/`pure`. Mirror of `ImageSource::as_str`;
+    /// consumed by `build_settings_view` and the enum validators (#410).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            SandboxMode::Off => "off",
+            SandboxMode::Copy => "copy",
+            SandboxMode::Pure => "pure",
+        }
+    }
+
+    /// Parse the wire form; `None` for any unknown token (PUT validators reject
+    /// those, resolvers treat them defensively as unset). Case/whitespace-tolerant,
+    /// mirror of `ImageSource::parse` (#410).
+    pub fn parse(s: &str) -> Option<SandboxMode> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "off" => Some(SandboxMode::Off),
+            "copy" => Some(SandboxMode::Copy),
+            "pure" => Some(SandboxMode::Pure),
+            _ => None,
+        }
+    }
+}
+
+/// Env var overriding the stored instance default (optional tier). Read ONCE at the
+/// edge (create-run chokepoint + `build_settings_view` disclosure), never in the
+/// resolver core — mirror of [`crate::sandbox_image::IMAGE_SOURCE_ENV`] (#410).
+pub const DEFAULT_SANDBOX_ENV: &str = "PDO_DEFAULT_SANDBOX";
+
+/// Env tier for the settings disclosure / resolver: `Some(mode)` if a valid
+/// `PDO_DEFAULT_SANDBOX` is set, else `None` (unset/invalid).
+fn env_default_sandbox() -> Option<SandboxMode> {
+    std::env::var(DEFAULT_SANDBOX_ENV)
+        .ok()
+        .as_deref()
+        .and_then(SandboxMode::parse)
+}
+
+/// Instance default, precedence `stored → env → default(Off)`. A stored empty/invalid
+/// value is treated as unset (mirror of the `""` sentinel + PUT validator). SINGLE
+/// source shared by `create_run_inner` AND `build_settings_view` (0 drift, lesson #373).
+pub fn default_sandbox_with(stored: Option<String>) -> SandboxMode {
+    stored
+        .as_deref()
+        .filter(|s| !s.is_empty())
+        .and_then(SandboxMode::parse)
+        .or_else(env_default_sandbox)
+        .unwrap_or(SandboxMode::DEFAULT)
+}
+
+/// Precedence resolver (#410): `explicit → trigger → instance_default` (first `Some`
+/// wins, `instance_default` is the floor). Pure — no `AppState`/DB/Docker in scope;
+/// this is the layer-1 unit the "précédence testée" AC pins. `explicit` and `trigger`
+/// are mutually exclusive in production (a Run has one origin), but the 3-arg form is
+/// the canonical statement of the chain and keeps every arm exercised by the test.
+pub fn effective_sandbox(
+    explicit: Option<SandboxMode>,
+    trigger: Option<SandboxMode>,
+    instance_default: SandboxMode,
+) -> SandboxMode {
+    explicit.or(trigger).unwrap_or(instance_default)
+}
+
+/// Visibility of a sandboxed Run's one-time image preparation (#410). Additive to
+/// [`RunState`]: `status` is untouched (stays `Running`), so no status consumer is
+/// affected. Absent for `off` Runs and for historical/host runs. Projected from the
+/// additive [`EventKind::SandboxPrepStarted`]/[`EventKind::SandboxPrepReady`] pair.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SandboxPrepState {
+    /// The image is being pulled/built and the container has not yet received a session.
+    Pending,
+    /// The image is ready; the first session is about to spawn (or already has).
+    Ready,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -408,6 +498,13 @@ pub struct RunState {
     /// legacy host path), so historical runs and bare-API creates stay off.
     #[serde(default)]
     pub sandbox: SandboxMode,
+    /// One-time image-prep visibility for a sandboxed Run (#410). Additive: `None`
+    /// for `off`/historical runs; `pending` while the image is pulled/built at first
+    /// use; `ready` once the container is about to run. `status` is never touched —
+    /// this drives a banner, not admission/overlap/liveness logic. Survives a daemon
+    /// restart by event replay.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sandbox_prep: Option<SandboxPrepState>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_branch: Option<String>,
     /// Provenance: the id of the Trigger that created this Run, if any.
@@ -463,6 +560,7 @@ impl RunState {
             switch_states: HashMap::new(),
             target_repo: None,
             sandbox: SandboxMode::Off,
+            sandbox_prep: None,
             source_branch: None,
             triggered_by: None,
             pipeline_id: None,
@@ -615,7 +713,9 @@ pub fn project(events: &[Event]) -> Option<RunState> {
             | EventKind::RunPaused
             | EventKind::RunResumed
             | EventKind::RunRenamed
-            | EventKind::RunArchived => apply_run_event(&mut state, event),
+            | EventKind::RunArchived
+            | EventKind::SandboxPrepStarted
+            | EventKind::SandboxPrepReady => apply_run_event(&mut state, event),
 
             EventKind::NodeWaiting
             | EventKind::NodeStarted
@@ -838,6 +938,15 @@ fn apply_run_event(state: &mut RunState, event: &Event) {
             state.status = RunStatus::Archived;
             state.start_node = None;
             state.end_node = None;
+        }
+        // #410: additive image-prep visibility. Non-terminal — `status` untouched,
+        // only `sandbox_prep` moves. Emitted only for a sandboxed create (`copy`/`pure`);
+        // `off`/historical runs never carry these, so the field stays `None`.
+        EventKind::SandboxPrepStarted => {
+            state.sandbox_prep = Some(SandboxPrepState::Pending);
+        }
+        EventKind::SandboxPrepReady => {
+            state.sandbox_prep = Some(SandboxPrepState::Ready);
         }
         _ => {}
     }
@@ -1540,6 +1649,116 @@ mod tests {
             iter: None,
             payload: Some(payload),
         }
+    }
+
+    // -- Slice A (#410): precedence resolver + instance-default helper ---------
+
+    #[test]
+    fn explicit_off_beats_copy_default() {
+        // The bug #410 exists to fix: an explicit `off` must survive a `copy`/`pure`
+        // instance default — otherwise the default could never be overridden downward.
+        assert_eq!(
+            effective_sandbox(Some(SandboxMode::Off), None, SandboxMode::Copy),
+            SandboxMode::Off
+        );
+    }
+
+    #[test]
+    fn explicit_wins_over_trigger_and_default() {
+        assert_eq!(
+            effective_sandbox(Some(SandboxMode::Pure), Some(SandboxMode::Copy), SandboxMode::Off),
+            SandboxMode::Pure
+        );
+    }
+
+    #[test]
+    fn trigger_used_when_no_explicit() {
+        assert_eq!(
+            effective_sandbox(None, Some(SandboxMode::Pure), SandboxMode::Off),
+            SandboxMode::Pure
+        );
+        // A trigger's explicit `off` also stands over a `copy` instance default.
+        assert_eq!(
+            effective_sandbox(None, Some(SandboxMode::Off), SandboxMode::Copy),
+            SandboxMode::Off
+        );
+    }
+
+    #[test]
+    fn all_none_falls_to_instance_default() {
+        assert_eq!(
+            effective_sandbox(None, None, SandboxMode::Copy),
+            SandboxMode::Copy
+        );
+        assert_eq!(
+            effective_sandbox(None, None, SandboxMode::DEFAULT),
+            SandboxMode::Off
+        );
+    }
+
+    #[test]
+    fn default_sandbox_with_precedence() {
+        // stored valid wins.
+        assert_eq!(default_sandbox_with(Some("pure".into())), SandboxMode::Pure);
+        assert_eq!(default_sandbox_with(Some("copy".into())), SandboxMode::Copy);
+        // empty sentinel → unset → default (Off) (env not set in this harness).
+        assert_eq!(default_sandbox_with(Some(String::new())), SandboxMode::Off);
+        // garbage → unset → default.
+        assert_eq!(default_sandbox_with(Some("garbage".into())), SandboxMode::Off);
+        // absent → default.
+        assert_eq!(default_sandbox_with(None), SandboxMode::Off);
+    }
+
+    #[test]
+    fn sandbox_mode_parse_and_as_str_round_trip() {
+        for mode in [SandboxMode::Off, SandboxMode::Copy, SandboxMode::Pure] {
+            assert_eq!(SandboxMode::parse(mode.as_str()), Some(mode));
+        }
+        // case / whitespace tolerant, rejects unknown.
+        assert_eq!(SandboxMode::parse("  PURE "), Some(SandboxMode::Pure));
+        assert_eq!(SandboxMode::parse("nope"), None);
+    }
+
+    // -- Slice E (#410): sandbox-prep projection ------------------------------
+
+    #[test]
+    fn sandbox_prep_started_projects_pending_then_ready() {
+        let events = vec![
+            make_event_with_payload(
+                EventKind::RunStarted,
+                None,
+                serde_json::json!({ "pipeline_name": "p", "sandbox": "pure" }),
+            ),
+            make_event(EventKind::SandboxPrepStarted, None, None),
+        ];
+        let state = project(&events).unwrap();
+        assert_eq!(state.sandbox_prep, Some(SandboxPrepState::Pending));
+        // status untouched by the informational event.
+        assert_eq!(state.status, RunStatus::Running);
+
+        let mut ready = events;
+        ready.push(make_event(EventKind::SandboxPrepReady, None, None));
+        let state = project(&ready).unwrap();
+        assert_eq!(state.sandbox_prep, Some(SandboxPrepState::Ready));
+        assert_eq!(state.status, RunStatus::Running);
+    }
+
+    #[test]
+    fn off_run_never_carries_sandbox_prep() {
+        // Byte-identical `off` invariant: no prep events, field stays None (and is
+        // skipped from serialization).
+        let events = vec![
+            make_event_with_payload(
+                EventKind::RunStarted,
+                None,
+                serde_json::json!({ "pipeline_name": "p" }),
+            ),
+            make_event(EventKind::NodeStarted, Some("n1"), Some(1)),
+        ];
+        let state = project(&events).unwrap();
+        assert_eq!(state.sandbox_prep, None);
+        let value = serde_json::to_value(&state).unwrap();
+        assert!(value.get("sandbox_prep").is_none());
     }
 
     #[test]

--- a/crates/pdo-daemon/src/instance_config.rs
+++ b/crates/pdo-daemon/src/instance_config.rs
@@ -49,6 +49,14 @@ pub struct InstanceConfig {
     /// SQL `NULL` so it never wins precedence. The resolver
     /// ([`crate::sandbox_image::image_source_with`]) owns the precedence.
     pub image_source: Option<String>,
+    /// Stored instance-wide default sandbox mode (`"off"` | `"copy"` | `"pure"`), or
+    /// `None` when unset (#410). `None` falls through to the env seam
+    /// ([`crate::event_log::DEFAULT_SANDBOX_ENV`]) then the built-in default (`off`,
+    /// the byte-identical host path). `Some("")` is the clear sentinel — [`update`]
+    /// normalises it to SQL `NULL` so it never wins precedence. The resolver
+    /// ([`crate::event_log::default_sandbox_with`]) owns the precedence; the create-run
+    /// chokepoint then feeds it through [`crate::event_log::effective_sandbox`].
+    pub default_sandbox: Option<String>,
     /// RFC3339-millis UTC timestamp of the last write (or the seed).
     pub updated_at: String,
 }
@@ -72,6 +80,10 @@ pub struct UpdateInstanceConfig {
     /// Set the sandbox image source (#411). `Some("")` clears it back to unset (the
     /// same `""`-sentinel discipline as `default_model`); `None` leaves it untouched.
     pub image_source: Option<String>,
+    /// Set the instance-wide default sandbox mode (#410). `Some("")` clears it back to
+    /// unset (same `""`-sentinel as `default_model`/`image_source`); `None` leaves it
+    /// untouched.
+    pub default_sandbox: Option<String>,
 }
 
 impl UpdateInstanceConfig {
@@ -81,6 +93,7 @@ impl UpdateInstanceConfig {
             && self.guard_timeout_secs.is_none()
             && self.default_model.is_none()
             && self.image_source.is_none()
+            && self.default_sandbox.is_none()
     }
 }
 
@@ -100,6 +113,7 @@ pub async fn init(db: &SqlitePool) -> Result<(), sqlx::Error> {
             default_model      TEXT,
             triggers_paused    INTEGER,
             image_source       TEXT,
+            default_sandbox    TEXT,
             updated_at         TEXT NOT NULL
         )",
     )
@@ -162,6 +176,23 @@ pub async fn init(db: &SqlitePool) -> Result<(), sqlx::Error> {
             .await?;
     }
 
+    // Additive migration for pre-#410 databases: the `default_sandbox` column is absent
+    // on tables created before the run-level sandbox default landed. Same guarded
+    // `ADD COLUMN` idiom as the columns above — safe on every boot. NULLABLE, never
+    // `NOT NULL DEFAULT`: a non-null default would make the stored tier always win and
+    // break the `off`-by-default (byte-identical) precedence floor.
+    let has_default_sandbox = sqlx::query(
+        "SELECT 1 FROM pragma_table_info('instance_config') WHERE name = 'default_sandbox'",
+    )
+    .fetch_optional(db)
+    .await?
+    .is_some();
+    if !has_default_sandbox {
+        sqlx::query("ALTER TABLE instance_config ADD COLUMN default_sandbox TEXT")
+            .execute(db)
+            .await?;
+    }
+
     Ok(())
 }
 
@@ -172,6 +203,7 @@ fn row_to_config(row: &sqlx::sqlite::SqliteRow) -> InstanceConfig {
         guard_timeout_secs: row.get("guard_timeout_secs"),
         default_model: row.get("default_model"),
         image_source: row.get("image_source"),
+        default_sandbox: row.get("default_sandbox"),
         updated_at: row.get("updated_at"),
     }
 }
@@ -214,6 +246,9 @@ pub async fn update(
     if edit.image_source.is_some() {
         sets.push("image_source = ?");
     }
+    if edit.default_sandbox.is_some() {
+        sets.push("default_sandbox = ?");
+    }
     // Always bump the write timestamp on a real edit.
     sets.push("updated_at = ?");
 
@@ -242,6 +277,11 @@ pub async fn update(
         // "" = clear sentinel → SQL NULL (#411, mirrors default_model). The resolver
         // then falls back env→default(registry); a stored "" would otherwise win
         // precedence and be treated as unset only by the empty-string filter.
+        query = query.bind(if v.is_empty() { None } else { Some(v) });
+    }
+    if let Some(v) = edit.default_sandbox {
+        // "" = clear sentinel → SQL NULL (#410, mirrors default_model/image_source).
+        // The resolver then falls back env→default(off, the byte-identical host path).
         query = query.bind(if v.is_empty() { None } else { Some(v) });
     }
     query = query.bind(crate::event_log::now_iso());
@@ -307,6 +347,7 @@ mod tests {
         assert_eq!(cfg.guard_timeout_secs, None);
         assert_eq!(cfg.default_model, None);
         assert_eq!(cfg.image_source, None);
+        assert_eq!(cfg.default_sandbox, None);
         assert!(!cfg.updated_at.is_empty(), "seed must stamp updated_at");
     }
 
@@ -448,6 +489,127 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(updated.image_source.as_deref(), Some("registry"));
+    }
+
+    #[tokio::test]
+    async fn update_sets_default_sandbox() {
+        let db = test_db().await;
+        let updated = update(
+            &db,
+            UpdateInstanceConfig {
+                default_sandbox: Some("pure".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(updated.default_sandbox.as_deref(), Some("pure"));
+        // A re-read confirms persistence (not just the returned row).
+        assert_eq!(
+            get(&db).await.unwrap().default_sandbox.as_deref(),
+            Some("pure")
+        );
+        // Sibling knobs stay untouched.
+        assert_eq!(updated.image_source, None);
+    }
+
+    #[tokio::test]
+    async fn update_clears_default_sandbox_on_empty_string() {
+        // "" is the clear sentinel: it resets the column to NULL (mirrors #347/#411),
+        // so the resolver falls back env→default(off).
+        let db = test_db().await;
+        update(
+            &db,
+            UpdateInstanceConfig {
+                default_sandbox: Some("pure".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        let cleared = update(
+            &db,
+            UpdateInstanceConfig {
+                default_sandbox: Some(String::new()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            cleared.default_sandbox, None,
+            "empty string must clear the stored default sandbox back to NULL"
+        );
+    }
+
+    #[tokio::test]
+    async fn default_sandbox_only_edit_is_not_a_noop() {
+        // Guard-rail for the `is_empty()` addition: an edit touching ONLY
+        // default_sandbox (all other knobs None) must still write.
+        let db = test_db().await;
+        let updated = update(
+            &db,
+            UpdateInstanceConfig {
+                default_sandbox: Some("copy".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(updated.default_sandbox.as_deref(), Some("copy"));
+    }
+
+    #[tokio::test]
+    async fn init_migrates_pre_default_sandbox_schema() {
+        // Installs created before #410 lack the `default_sandbox` column. Simulate the
+        // pre-#410 schema (also missing default_model + triggers_paused + image_source),
+        // then prove `init` adds the column idempotently and it is writable afterwards,
+        // without clobbering the stored knob.
+        let db = sqlx::sqlite::SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .unwrap();
+        sqlx::query(
+            "CREATE TABLE instance_config (
+                id                 INTEGER PRIMARY KEY CHECK (id = 1),
+                session_cap        INTEGER,
+                reaper_ttl_secs    INTEGER,
+                guard_timeout_secs INTEGER,
+                updated_at         TEXT NOT NULL
+            )",
+        )
+        .execute(&db)
+        .await
+        .unwrap();
+        sqlx::query("INSERT INTO instance_config (id, session_cap, updated_at) VALUES (1, 13, ?)")
+            .bind(crate::event_log::now_iso())
+            .execute(&db)
+            .await
+            .unwrap();
+
+        init(&db).await.unwrap();
+        init(&db).await.unwrap(); // idempotent
+
+        let cfg = get(&db).await.unwrap();
+        assert_eq!(
+            cfg.session_cap,
+            Some(13),
+            "existing knob must survive the ALTER"
+        );
+        assert_eq!(cfg.default_sandbox, None, "new column defaults to NULL");
+
+        // And the migrated column is writable.
+        let updated = update(
+            &db,
+            UpdateInstanceConfig {
+                default_sandbox: Some("pure".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(updated.default_sandbox.as_deref(), Some("pure"));
     }
 
     #[tokio::test]

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -288,6 +288,14 @@ struct AppState {
     /// Surfaced as the `service` object on `/sessions`; drives the status bar's
     /// `ephemeral` pill.
     service_health: Arc<ServiceHealth>,
+    /// TTL cache (~10 s) of the Docker availability probe (#410), surfaced as
+    /// `sandbox_docker` on `GET /settings` so the NewRunModal can gray out
+    /// `copy`/`pure` when Docker is unreachable. Lazily refreshed by
+    /// `build_settings_view` when stale — never boot-once (a user may start Docker
+    /// mid-session) and never per-fetch (a `PUT` of an unrelated knob would pay a
+    /// docker round-trip). The refresh runs under `spawn_blocking` + a short
+    /// `timeout`, so a cold Docker daemon never hangs the `/settings` response.
+    docker_probe_cache: Arc<tokio::sync::Mutex<Option<(Instant, sandbox_image::DockerProbe)>>>,
 }
 
 impl AppState {
@@ -336,12 +344,14 @@ struct CreateRunRequest {
     /// the trigger scheduler; absent for manual runs.
     #[serde(default)]
     triggered_by: Option<String>,
-    /// Isolation mode for this Run (#403 / #407). `#[serde(default)]` → `Off`, so
-    /// an absent field means the historical host path. Trigger fires pass `Off`
-    /// (source precedence run → trigger → default_sandbox is #410); this slice
-    /// only accepts the mode via the `POST /runs` parameter.
+    /// Isolation mode for this Run (#403 / #407 / #410). `Option`, NOT
+    /// `SandboxMode`: `#[serde(default)]` → `None` distinguishes an **omitted** field
+    /// (defer to trigger/instance default) from an **explicit** `"off"` (which nothing
+    /// may override upward). This distinction is the fix that makes the "précédence"
+    /// AC satisfiable — see [`event_log::effective_sandbox`]. The chokepoint
+    /// (`create_run_inner`) resolves it once against the fresh instance default.
     #[serde(default)]
-    sandbox: event_log::SandboxMode,
+    sandbox: Option<event_log::SandboxMode>,
 }
 
 #[derive(Serialize)]
@@ -1614,6 +1624,7 @@ pub async fn serve_with_config(
         node_done_tail_gate: Arc::new(tokio::sync::Notify::new()),
         node_done_tail_gate_armed: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         service_health,
+        docker_probe_cache: Arc::new(tokio::sync::Mutex::new(None)),
     });
 
     // The orphan sweep — and every other tmux call this daemon makes —
@@ -2066,10 +2077,27 @@ struct CreateTriggerRequest {
     /// unbounded. Inert unless `overlap_policy == "allow"`.
     #[serde(default)]
     max_concurrent: Option<i64>,
+    /// Per-Trigger sandbox mode (#410): `"off"` | `"copy"` | `"pure"`, or absent/`null`
+    /// to inherit the instance default. Read at fire time and folded into the create
+    /// request's explicit tier.
+    #[serde(default)]
+    sandbox: Option<String>,
 }
 
 fn default_overlap_policy() -> String {
     "skip".to_string()
+}
+
+/// Validate a per-Trigger `sandbox` mode (#410): `None` (inherit) is always valid;
+/// a present value must be a known variant. Shared by create and patch so the rule
+/// cannot drift. Mirror of the `put_settings` `default_sandbox` validator.
+fn validate_trigger_sandbox(v: Option<&str>) -> Result<(), &'static str> {
+    match v {
+        Some(s) if event_log::SandboxMode::parse(s).is_none() => {
+            Err("sandbox must be `off`, `copy`, or `pure`")
+        }
+        _ => Ok(()),
+    }
 }
 
 /// Validate a `max_concurrent` cap (#239): when present it must be >= 1. `None`
@@ -2250,6 +2278,15 @@ async fn create_trigger(
             .into_response();
     }
 
+    // A per-Trigger sandbox mode, when present, must be a known variant (#410).
+    if let Err(msg) = validate_trigger_sandbox(req.sandbox.as_deref()) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": msg })),
+        )
+            .into_response();
+    }
+
     // Resolve the target pipeline and its prompt_required flag.
     let yaml =
         library_store::pipelines::get_yaml(&state.repo_root, &req.pipeline_id).or_else(|| {
@@ -2335,6 +2372,9 @@ async fn create_trigger(
             "skip".to_string()
         },
         max_concurrent: req.max_concurrent,
+        // #410: normalise `Some("")` to `None` (inherit the instance default), so an
+        // empty selector value never persists as a bogus stored mode.
+        sandbox: req.sandbox.filter(|s| !s.trim().is_empty()),
         next_fire_at,
     };
 
@@ -2474,6 +2514,12 @@ struct PatchTriggerRequest {
     /// where present-`null` collapses to `None` and cannot clear).
     #[serde(default, deserialize_with = "deserialize_double_option")]
     max_concurrent: Option<Option<i64>>,
+    /// Per-Trigger sandbox mode (#410), double-wrapped like `max_concurrent`: absent =
+    /// leave, present `null` = clear back to inheriting the instance default, `"mode"`
+    /// = set. The custom deserializer makes present-`null` → `Some(None)` reachable
+    /// from JSON — that is what lets the UI reset a Trigger to "use the instance default".
+    #[serde(default, deserialize_with = "deserialize_double_option")]
+    sandbox: Option<Option<String>>,
 }
 
 async fn patch_trigger(
@@ -2634,6 +2680,17 @@ async fn patch_trigger(
         }
     }
 
+    // Validate a sandbox edit (Some(Some(mode)) sets; Some(None) clears to inherit) (#410).
+    if let Some(Some(ref mode)) = req.sandbox {
+        if let Err(msg) = validate_trigger_sandbox(Some(mode)) {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({ "error": msg })),
+            )
+                .into_response();
+        }
+    }
+
     // Re-apply the fire_decision reject rule against the *resulting* config: if
     // the pipeline requires a prompt and the edit would leave neither a guard
     // nor an input template, refuse (mirrors create-time validation).
@@ -2683,6 +2740,10 @@ async fn patch_trigger(
             }
         }),
         max_concurrent: req.max_concurrent,
+        // #410: `Some(Some(mode))` sets, `Some(None)` clears back to inheriting the
+        // instance default, `None` leaves it. The FE maps the "use instance default"
+        // option to `null`, so an empty string never reaches here.
+        sandbox: req.sandbox,
         next_fire_at,
         // Fold the enable/disable toggle into the single UpdateTrigger write
         // (#372): the enable bit and the forward next_fire_at land in one atomic
@@ -3678,9 +3739,16 @@ async fn fire_one_trigger(
                 source_branch: trigger.source_branch.clone(),
                 name: None,
                 triggered_by: Some(trigger.id.clone()),
-                // #407: trigger fires run on the host. Source precedence
-                // (run → trigger → default_sandbox) is #410.
-                sandbox: event_log::SandboxMode::Off,
+                // #410: fold the Trigger's stored mode into the request's explicit
+                // tier. A Run has a single origin (a trigger fire is never also a
+                // run-level choice), so this is the sole non-`None` tier here; the
+                // chokepoint's `effective_sandbox(req.sandbox, None, default)` then
+                // resolves it against the instance default. A `None`/unparseable
+                // stored mode defers to the instance default.
+                sandbox: trigger
+                    .sandbox
+                    .as_deref()
+                    .and_then(event_log::SandboxMode::parse),
             };
             let record = match create_run_inner(state, req, Vec::new()).await {
                 Ok(run_id) => trigger_store::FireRecord {
@@ -5365,6 +5433,11 @@ async fn parse_multipart_create_run(
     let mut target_repo = None;
     let mut source_branch = None;
     let mut name = None;
+    // #410: an explicit sandbox mode may ride the multipart (browser) create when
+    // images are attached. Parsed into `Option<SandboxMode>` so an omitted field
+    // defers to the trigger/instance default at the chokepoint. An unknown token is
+    // treated as unset (defensive; the FE only ever sends valid variants).
+    let mut sandbox: Option<event_log::SandboxMode> = None;
     let mut images = Vec::new();
 
     while let Ok(Some(field)) = multipart.next_field().await {
@@ -5432,6 +5505,17 @@ async fn parse_multipart_create_run(
                     name = Some(v);
                 }
             }
+            "sandbox" => {
+                // #410: parse the explicit mode off the multipart form. Empty or
+                // unknown → leave `None` (defer to trigger/instance default).
+                let v = field
+                    .text()
+                    .await
+                    .map_err(|e| format!("bad field sandbox: {e}"))?;
+                if !v.is_empty() {
+                    sandbox = event_log::SandboxMode::parse(&v);
+                }
+            }
             "images" => {
                 let raw_filename = field.file_name().unwrap_or("image.png").to_string();
                 let data = field
@@ -5461,9 +5545,10 @@ async fn parse_multipart_create_run(
         source_branch,
         name,
         triggered_by: None,
-        // #407: the multipart (browser) create path runs on the host; the UI
-        // sandbox selector is #410. The tracer bullet drives `pure` via JSON.
-        sandbox: event_log::SandboxMode::Off,
+        // #410: the explicit sandbox mode threaded off the multipart form (browser
+        // create with attached images). `None` when the field is absent — the
+        // chokepoint then defers to the trigger/instance default.
+        sandbox,
     };
     Ok((req, images))
 }
@@ -5707,6 +5792,26 @@ async fn create_run_inner(
 
     let run_id = event_log::generate_run_id();
 
+    // #410 CHOKEPOINT: resolve the effective sandbox mode ONCE, here, where the JSON,
+    // multipart, and trigger-fire create paths converge — just before the mode is
+    // frozen into `RunStarted`. `req.sandbox` already carries either the explicit
+    // run-level choice (JSON/multipart) OR the trigger's mode (folded in at fire time,
+    // Slice C — a Run has a single origin), so the trigger arm stays `None` in
+    // production; the 3-arg resolver is still the canonical precedence chain, exercised
+    // by the layer-1 test. `default_sandbox` is read FRESH from the DB at the edge
+    // (mirror `image_source`, `sandbox_run.rs`), so a `PUT /settings` bites on the very
+    // next create with no restart. Absent everywhere → `Off` → the payload and events
+    // stay byte-identical to the legacy host path.
+    let stored_default = instance_config::get(&state.db)
+        .await
+        .ok()
+        .and_then(|c| c.default_sandbox);
+    let sandbox = event_log::effective_sandbox(
+        req.sandbox,
+        None,
+        event_log::default_sandbox_with(stored_default),
+    );
+
     let edge_infos: Vec<event_log::EdgeInfo> =
         pipeline.edges.iter().map(edge_info_from_pipeline).collect();
 
@@ -5731,10 +5836,10 @@ async fn create_run_inner(
     if let Some(ref target) = req.target_repo {
         run_payload["target_repo"] = serde_json::json!(target);
     }
-    // #407: carry the isolation mode only when it is NOT `off`, so `off` payloads
-    // stay byte-identical to the historical shape (back-compat: absence → Off).
-    if !req.sandbox.is_off() {
-        run_payload["sandbox"] = serde_json::json!(req.sandbox);
+    // #407/#410: carry the RESOLVED isolation mode only when it is NOT `off`, so `off`
+    // payloads stay byte-identical to the historical shape (back-compat: absence → Off).
+    if !sandbox.is_off() {
+        run_payload["sandbox"] = serde_json::json!(sandbox);
     }
     if let Some(ref branch) = req.source_branch {
         run_payload["source_branch"] = serde_json::json!(branch);
@@ -5836,21 +5941,33 @@ async fn create_run_inner(
         }
     }
 
-    if req.sandbox.is_off() {
+    if sandbox.is_off() {
         // Historical host path — inline, byte-identical to pre-#407. NO docker.
         spawn_ready_after_event(state, &run_id).await;
-        spawn_manager_session(state, &run_id, &worktree_dir, name_hint, req.sandbox);
+        spawn_manager_session(state, &run_id, &worktree_dir, name_hint, sandbox);
     } else {
         // #407 D3/D4: eager fail-fast prep on a detached, panic-isolated task
         // (mirror ADR-0023 — the 201 must not block on a first-run `docker
         // build`). Image + container + staging are guaranteed BEFORE the first
         // node/manager spawn; any Docker unavailability → `RunFailed`, ZERO host
         // spawn (never a silent host fallback for a sandboxed Run's work, US-16).
-        let sandbox = req.sandbox;
         let task_state = state.clone();
         let task_run_id = run_id.clone();
         let task_worktree = worktree_dir.clone();
         tokio::spawn(async move {
+            // #410: image-prep visibility. Informational, non-terminal — emitted at
+            // the HEAD of the detached task (before the long `ensure_ready`) so the UI
+            // shows "préparation du sandbox…" instead of a seemingly-stuck Run. Only
+            // reachable in this `sandbox != off` branch, so the `off` path stays
+            // byte-identical. Broadcast + `refreshRun` ride the `append_event`
+            // chokepoint for free.
+            emit_run_event(
+                &task_state,
+                &task_run_id,
+                event_log::EventKind::SandboxPrepStarted,
+                None,
+            )
+            .await;
             // Build the sandbox context from the just-projected Run (mode is
             // immutable). A vanished/half-projected state → fail loud.
             let ctx = match reload_run_state(&task_state, &task_run_id).await {
@@ -5880,6 +5997,17 @@ async fn create_run_inner(
             // `spawn_blocking`, which also isolates its panic into a `JoinError`.
             match tokio::task::spawn_blocking(move || sandbox_run::ensure_ready(&ctx)).await {
                 Ok(Ok(())) => {
+                    // #410: image ready, container about to receive the first session.
+                    // Emitted just before the spawn so the prep banner clears exactly
+                    // when work can start. A failed prep emits `RunFailed` instead (no
+                    // dedicated failed-prep event).
+                    emit_run_event(
+                        &task_state,
+                        &task_run_id,
+                        event_log::EventKind::SandboxPrepReady,
+                        None,
+                    )
+                    .await;
                     spawn_ready_after_event(&task_state, &task_run_id).await;
                     spawn_manager_session(
                         &task_state,
@@ -6094,11 +6222,61 @@ fn settings_field_enum(
     })
 }
 
+/// TTL of the Docker availability probe cache (#410). ~10 s: long enough that a
+/// burst of `/settings` fetches (modal open, a `PUT`) pays at most one docker
+/// round-trip, short enough that a user who starts Docker mid-session sees `copy`/
+/// `pure` un-gray within seconds.
+const DOCKER_PROBE_TTL: Duration = Duration::from_secs(10);
+/// Hard cap on how long the probe may block the `/settings` response (#410). A cold
+/// or wedged Docker daemon must never hang the settings page — on timeout we report
+/// `available: false` for this fetch and re-probe on the next.
+const DOCKER_PROBE_TIMEOUT: Duration = Duration::from_secs(3);
+
+/// Return the cached Docker availability probe, refreshing it under `spawn_blocking`
+/// with a short `timeout` when the cache is empty or older than [`DOCKER_PROBE_TTL`]
+/// (#410). Never shells out on the runtime thread; a timeout yields an
+/// `available: false` result (advisory only — the run-advance fail-fast stays the
+/// authoritative gate). Mirrors the `docker_bin` edge-resolution of the rest of the
+/// sandbox wiring.
+async fn docker_probe_cached(state: &AppState) -> sandbox_image::DockerProbe {
+    let mut guard = state.docker_probe_cache.lock().await;
+    if let Some((at, probe)) = guard.as_ref() {
+        if at.elapsed() < DOCKER_PROBE_TTL {
+            return probe.clone();
+        }
+    }
+    let docker_bin = state
+        .docker_cmd_override
+        .as_deref()
+        .unwrap_or("docker")
+        .to_string();
+    let probe = match tokio::time::timeout(
+        DOCKER_PROBE_TIMEOUT,
+        tokio::task::spawn_blocking(move || sandbox_image::probe_docker(&docker_bin)),
+    )
+    .await
+    {
+        Ok(Ok(p)) => p,
+        // Timed out or the blocking task panicked/joined-error: treat as unavailable
+        // for this fetch (advisory), and don't cache the transient failure long — a
+        // fresh probe runs next time the TTL check sees an entry we still stamp now.
+        _ => sandbox_image::DockerProbe {
+            available: false,
+            reason: Some(sandbox_image::DOCKER_DAEMON_UNREACHABLE_MSG.to_string()),
+        },
+    };
+    *guard = Some((Instant::now(), probe.clone()));
+    probe
+}
+
 /// Build the `GET /settings` view: per knob, the effective value, the winning
 /// tier, and every tier's raw value (#129, ADR-0015). The `effective` value is
 /// computed by each knob's own resolver, so it can never drift from what the
-/// daemon uses at spawn / sweep / tick time.
-async fn build_settings_view(db: &sqlx::SqlitePool) -> Result<serde_json::Value, sqlx::Error> {
+/// daemon uses at spawn / sweep / tick time. Also folds in the advisory
+/// `sandbox_docker` probe (#410) so the NewRunModal fetches the default AND Docker
+/// availability in one round-trip.
+async fn build_settings_view(state: &AppState) -> Result<serde_json::Value, sqlx::Error> {
+    let db = &state.db;
     let cfg = instance_config::get(db).await?;
 
     // --- session cap (count) ---
@@ -6172,6 +6350,33 @@ async fn build_settings_view(db: &sqlx::SqlitePool) -> Result<serde_json::Value,
         "default"
     };
 
+    // --- default sandbox mode (enum ; built-in default `off`) (#410) ---
+    // Same discipline as `image_source`: the empty-string filter treats a stored `""`
+    // as unset, and `effective` is computed by the SAME resolver the create-run
+    // chokepoint consumes, so the disclosed value can never drift (#373).
+    let sbx_stored = cfg.default_sandbox.as_deref().filter(|s| !s.is_empty());
+    let sbx_env = event_log::DEFAULT_SANDBOX_ENV;
+    let sbx_env_val = std::env::var(sbx_env)
+        .ok()
+        .as_deref()
+        .and_then(event_log::SandboxMode::parse)
+        .map(|m| m.as_str().to_string());
+    let sbx_effective = event_log::default_sandbox_with(cfg.default_sandbox.clone());
+    let sbx_source = if sbx_stored.is_some() {
+        "stored"
+    } else if sbx_env_val.is_some() {
+        "env"
+    } else {
+        "default"
+    };
+
+    // --- advisory Docker availability probe (#410) ---
+    // Folded into `GET /settings` (NOT a settings_field: no stored/env/default tier)
+    // so the modal learns the default AND whether Docker can run a sandbox in ONE
+    // fetch. Advisory: it grays out `copy`/`pure`, but the run-advance fail-fast
+    // (ADR-0030 pt 4) stays the authoritative gate.
+    let docker_probe = docker_probe_cached(state).await;
+
     Ok(serde_json::json!({
         "session_cap": settings_field(cap_effective, cap_source, cfg.session_cap, cap_env, cap_default),
         "reaper_ttl_secs": settings_field(ttl_effective, ttl_source, cfg.reaper_ttl_secs, ttl_env, ttl_default),
@@ -6184,6 +6389,18 @@ async fn build_settings_view(db: &sqlx::SqlitePool) -> Result<serde_json::Value,
             img_env.as_deref(),
             sandbox_image::ImageSource::DEFAULT.as_str(),
         ),
+        "default_sandbox": settings_field_enum(
+            sbx_effective.as_str(),
+            sbx_source,
+            sbx_stored,
+            sbx_env_val.as_deref(),
+            event_log::SandboxMode::DEFAULT.as_str(),
+        ),
+        "sandbox_docker": {
+            "available": docker_probe.available,
+            "reason": docker_probe.reason,
+            "checked_at": event_log::now_iso(),
+        },
         "updated_at": cfg.updated_at,
     }))
 }
@@ -6192,7 +6409,7 @@ async fn build_settings_view(db: &sqlx::SqlitePool) -> Result<serde_json::Value,
 /// `{effective, source, stored, env, default}` (#129, ADR-0015). `GET /sessions`
 /// stays the lean status-bar view; this is the settings page's rich view.
 async fn get_settings(State(state): State<Arc<AppState>>) -> Response {
-    match build_settings_view(&state.db).await {
+    match build_settings_view(&state).await {
         Ok(view) => Json(view).into_response(),
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -6241,9 +6458,16 @@ async fn put_settings(
             return bad("image_source must be `registry` or `dockerfile`");
         }
     }
+    if let Some(s) = req.default_sandbox.as_deref() {
+        // "" = clear sentinel (accepted, normalised to NULL by `update`); any other
+        // non-variant → 400 (fail-fast, no silent default) (#410).
+        if !s.is_empty() && event_log::SandboxMode::parse(s).is_none() {
+            return bad("default_sandbox must be `off`, `copy`, or `pure`");
+        }
+    }
 
     match instance_config::update(&state.db, req).await {
-        Ok(_) => match build_settings_view(&state.db).await {
+        Ok(_) => match build_settings_view(&state).await {
             Ok(view) => Json(view).into_response(),
             Err(e) => (
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -9746,9 +9970,12 @@ async fn run_command(
                 source_branch,
                 name: None,
                 triggered_by: None,
-                // #407: a retry preserves the original Run's isolation mode
-                // (immutable per-Run property projected from RunStarted).
-                sandbox: run_state.sandbox,
+                // #407/#410: a retry preserves the original Run's isolation mode
+                // (immutable per-Run property projected from RunStarted). Wrapped in
+                // `Some` so it is treated as EXPLICIT at the chokepoint — the resolver
+                // must honour it exactly, never letting a changed instance default
+                // silently re-sandbox (or un-sandbox) a retried Run.
+                sandbox: Some(run_state.sandbox),
             };
             let new_run_resp = create_run_core(&state, new_run_req, Vec::new()).await;
 
@@ -11939,6 +12166,7 @@ mod tests {
                 supervisor: "none".to_string(),
                 persistent: None,
             }),
+            docker_probe_cache: Arc::new(tokio::sync::Mutex::new(None)),
         })
     }
 
@@ -11976,6 +12204,7 @@ mod tests {
             node_done_tail_gate: Arc::new(tokio::sync::Notify::new()),
             node_done_tail_gate_armed: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             service_health: Arc::new(service_health),
+            docker_probe_cache: Arc::new(tokio::sync::Mutex::new(None)),
         })
     }
 
@@ -15528,6 +15757,7 @@ mod tests {
                 supervisor: "none".to_string(),
                 persistent: None,
             }),
+            docker_probe_cache: Arc::new(tokio::sync::Mutex::new(None)),
         })
     }
 
@@ -19852,6 +20082,7 @@ edges: []
                 supervisor: "none".to_string(),
                 persistent: None,
             }),
+            docker_probe_cache: Arc::new(tokio::sync::Mutex::new(None)),
         });
         let app = build_router(state);
 
@@ -20041,6 +20272,7 @@ edges: []
                 supervisor: "none".to_string(),
                 persistent: None,
             }),
+            docker_probe_cache: Arc::new(tokio::sync::Mutex::new(None)),
         });
         let app = build_router(state);
 
@@ -22685,5 +22917,74 @@ edges:
         // Store untouched (still the default).
         let view = get_settings_json(&state).await;
         assert!(view["image_source"]["stored"].is_null());
+    }
+
+    // --- #410: default_sandbox settings knob + sandbox_docker probe ---
+
+    #[tokio::test]
+    async fn put_settings_persists_default_sandbox() {
+        // Stored always wins over env/default, so the effective/source assertions are
+        // race-free (mirror of image_source, #411).
+        let state = test_state().await;
+        let (status, view) = put_settings_resp(&state, r#"{"default_sandbox": "pure"}"#).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(view["default_sandbox"]["stored"], "pure");
+        assert_eq!(view["default_sandbox"]["source"], "stored");
+        assert_eq!(view["default_sandbox"]["effective"], "pure");
+        assert_eq!(view["default_sandbox"]["default"], "off");
+
+        // Re-GET confirms persistence.
+        let reget = get_settings_json(&state).await;
+        assert_eq!(reget["default_sandbox"]["stored"], "pure");
+        assert_eq!(reget["default_sandbox"]["effective"], "pure");
+    }
+
+    #[tokio::test]
+    async fn put_settings_clears_default_sandbox_on_empty_string() {
+        // "" is the clear sentinel: accepted (not 400), resets the stored tier to null
+        // so the resolver falls back to the built-in default `off` (#410).
+        let state = test_state().await;
+        put_settings_resp(&state, r#"{"default_sandbox": "pure"}"#).await;
+        let (status, view) = put_settings_resp(&state, r#"{"default_sandbox": ""}"#).await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "empty string must be accepted, not 400"
+        );
+        assert!(
+            view["default_sandbox"]["stored"].is_null(),
+            "empty string clears the stored default sandbox: {}",
+            view["default_sandbox"]
+        );
+        assert_eq!(view["default_sandbox"]["source"], "default");
+        assert_eq!(view["default_sandbox"]["effective"], "off");
+    }
+
+    #[tokio::test]
+    async fn put_settings_rejects_invalid_default_sandbox() {
+        // A non-variant token is rejected 400 before anything is persisted (#410).
+        let state = test_state().await;
+        let (status, body) = put_settings_resp(&state, r#"{"default_sandbox": "vm"}"#).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert!(body["error"].is_string(), "400 must carry an error: {body}");
+        let view = get_settings_json(&state).await;
+        assert!(view["default_sandbox"]["stored"].is_null());
+    }
+
+    #[tokio::test]
+    async fn get_settings_surfaces_sandbox_docker_probe() {
+        // The advisory probe is folded into GET /settings (#410). `test_state` has no
+        // docker_cmd_override, so the real `docker` (absent in CI) → available:false
+        // with a reason. The shape must always be present regardless of the verdict.
+        let state = test_state().await;
+        let view = get_settings_json(&state).await;
+        let sd = &view["sandbox_docker"];
+        assert!(sd.get("available").is_some(), "available missing: {sd}");
+        assert!(sd["available"].is_boolean(), "available must be bool: {sd}");
+        assert!(sd.get("reason").is_some(), "reason key must be present: {sd}");
+        assert!(
+            sd["checked_at"].is_string(),
+            "checked_at must be a string: {sd}"
+        );
     }
 }

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -22981,7 +22981,10 @@ edges:
         let sd = &view["sandbox_docker"];
         assert!(sd.get("available").is_some(), "available missing: {sd}");
         assert!(sd["available"].is_boolean(), "available must be bool: {sd}");
-        assert!(sd.get("reason").is_some(), "reason key must be present: {sd}");
+        assert!(
+            sd.get("reason").is_some(),
+            "reason key must be present: {sd}"
+        );
         assert!(
             sd["checked_at"].is_string(),
             "checked_at must be a string: {sd}"

--- a/crates/pdo-daemon/src/sandbox_image.rs
+++ b/crates/pdo-daemon/src/sandbox_image.rs
@@ -48,6 +48,60 @@ pub(crate) const DOCKER_NOT_FOUND_MSG: &str =
     "sandbox run requires Docker, but the `docker` binary was not found on PATH — \
      install Docker or set this run's sandbox to `off`";
 
+/// Message when the `docker` binary IS present but its daemon is unreachable (#410).
+/// The precise reason the availability probe grays out `copy`/`pure` in the UI. This
+/// case and `DOCKER_NOT_FOUND_MSG` both collapse to `available: false` — no action is
+/// gated on the distinction (the probe is advisory; the run-advance fail-fast, ADR-0030
+/// pt 4, stays the authoritative gate) — so the cause survives only in `reason`.
+pub(crate) const DOCKER_DAEMON_UNREACHABLE_MSG: &str =
+    "the `docker` binary is present but the Docker daemon is unreachable — \
+     start Docker or set this run's sandbox to `off`";
+
+/// Advisory availability of a usable Docker for sandboxed Runs (#410). `available`
+/// gates nothing on its own (the run-advance fail-fast is authoritative); it drives
+/// the NewRunModal's greying of `copy`/`pure`. `reason` carries the human-readable
+/// cause when unavailable (one of the two messages above), `None` when available.
+#[derive(Debug, Clone)]
+pub(crate) struct DockerProbe {
+    pub available: bool,
+    pub reason: Option<String>,
+}
+
+/// Probe whether this host can launch a sandboxed Run, by forcing a round-trip to the
+/// Docker daemon: `docker version --format '{{.Server.Version}}'` (exit 0 ⇔ the daemon
+/// answered). Three signals collapse to two states: spawn `NotFound` → not installed
+/// (`DOCKER_NOT_FOUND_MSG`); any other spawn error or a non-zero exit → daemon
+/// unreachable (`DOCKER_DAEMON_UNREACHABLE_MSG`); exit 0 → available.
+///
+/// Sync `std::process`, mirror of the rest of this leaf module: `docker_bin` is
+/// threaded in (never read from `std::env` here), so the caller owns the env/timeout
+/// at the edge (`spawn_blocking` + `tokio::time::timeout`, never the runtime thread).
+/// Rejected alternatives (see plan D2): "binary on PATH" alone misses a stopped daemon
+/// — precisely the case to gray out; an `ensure_image` dry-run costs minutes + network.
+pub(crate) fn probe_docker(docker_bin: &str) -> DockerProbe {
+    match Command::new(docker_bin)
+        .args(["version", "--format", "{{.Server.Version}}"])
+        .output()
+    {
+        Ok(o) if o.status.success() => DockerProbe {
+            available: true,
+            reason: None,
+        },
+        Ok(_) => DockerProbe {
+            available: false,
+            reason: Some(DOCKER_DAEMON_UNREACHABLE_MSG.to_string()),
+        },
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => DockerProbe {
+            available: false,
+            reason: Some(DOCKER_NOT_FOUND_MSG.to_string()),
+        },
+        Err(_) => DockerProbe {
+            available: false,
+            reason: Some(DOCKER_NOT_FOUND_MSG.to_string()),
+        },
+    }
+}
+
 // -- path math (pur, sans IO) ------------------------------------------------
 
 /// `<sandbox_root>/Dockerfile` — emplacement canonique du Dockerfile seedé/buildé.
@@ -977,5 +1031,69 @@ mod tests {
             image_source_with(Some("registry".to_string())),
             ImageSource::Registry
         );
+    }
+
+    // -- Slice D (#410): Docker availability probe ---------------------------
+
+    /// Write a fake `docker` whose `version` subcommand exits with `version_exit`.
+    /// Threaded as `docker_bin` (no `std::env` mutation, D2 discipline).
+    fn write_fake_docker_version(dir: &Path, version_exit: i32) -> PathBuf {
+        let bin = dir.join("fake-docker-version");
+        let script = format!(
+            "#!/usr/bin/env bash\n\
+             case \"$1\" in\n\
+             version) echo '27.0.0'; exit {version_exit} ;;\n\
+             *) exit 0 ;;\n\
+             esac\n",
+        );
+        std::fs::write(&bin, script).unwrap();
+        std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
+        bin
+    }
+
+    /// Probe a freshly-written fake `docker`, retrying past a transient `NotFound`.
+    /// Exec-ing a just-written binary under `cargo test --workspace` can hit
+    /// `ETXTBSY` (rust-lang#45719), which `probe_docker` collapses to the
+    /// "not installed" verdict — indistinguishable, for an existing binary, from a
+    /// transient race. Since the binary IS on disk, a `NotFound` here means the
+    /// race; retry until the real verdict settles. (The genuinely-absent test uses a
+    /// path that never exists, so it does NOT go through this helper.)
+    fn probe_stable(bin: &Path) -> DockerProbe {
+        for _ in 0..100 {
+            let p = probe_docker(&docker_str(bin));
+            if p.reason.as_deref() != Some(DOCKER_NOT_FOUND_MSG) {
+                return p;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+        probe_docker(&docker_str(bin))
+    }
+
+    #[test]
+    fn probe_docker_reports_available_on_exit_zero() {
+        let tmp = tempfile::tempdir().unwrap();
+        let docker = write_fake_docker_version(tmp.path(), 0);
+        let probe = probe_stable(&docker);
+        assert!(probe.available, "exit 0 must report available");
+        assert!(probe.reason.is_none());
+    }
+
+    #[test]
+    fn probe_docker_reports_daemon_unreachable_on_nonzero_exit() {
+        let tmp = tempfile::tempdir().unwrap();
+        let docker = write_fake_docker_version(tmp.path(), 1);
+        let probe = probe_stable(&docker);
+        assert!(!probe.available, "a non-zero exit must report unavailable");
+        assert_eq!(probe.reason.as_deref(), Some(DOCKER_DAEMON_UNREACHABLE_MSG));
+    }
+
+    #[test]
+    fn probe_docker_reports_not_found_when_binary_absent() {
+        // A path that does not exist → spawn `NotFound` → the "not installed" message.
+        let tmp = tempfile::tempdir().unwrap();
+        let missing = tmp.path().join("no-such-docker");
+        let probe = probe_docker(missing.to_str().unwrap());
+        assert!(!probe.available);
+        assert_eq!(probe.reason.as_deref(), Some(DOCKER_NOT_FOUND_MSG));
     }
 }

--- a/crates/pdo-daemon/src/trigger_scheduler.rs
+++ b/crates/pdo-daemon/src/trigger_scheduler.rs
@@ -309,6 +309,7 @@ mod tests {
             guard_command: None,
             overlap_policy: "skip".to_string(),
             max_concurrent: None,
+            sandbox: None,
             enabled: true,
             next_fire_at: next_fire_at.map(str::to_string),
             last_fired_at: None,

--- a/crates/pdo-daemon/src/trigger_store.rs
+++ b/crates/pdo-daemon/src/trigger_store.rs
@@ -43,6 +43,13 @@ pub struct Trigger {
     /// `None` = unbounded (also the effective value under the `skip` policy).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_concurrent: Option<i64>,
+    /// Per-Trigger sandbox mode (`"off"` | `"copy"` | `"pure"`), or `None` to inherit
+    /// the instance default (#410). Read at fire time and folded into the create
+    /// request's explicit tier; the create chokepoint then resolves precedence
+    /// (run → trigger → instance default). Clearable back to `None` via the
+    /// double-`Option` `UpdateTrigger.sandbox` (mirror of `max_concurrent`, #239).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sandbox: Option<String>,
     pub enabled: bool,
     /// The next scheduled fire, as **canonical UTC RFC3339-millis** (`…Z`).
     /// Every writer (create/edit in `lib.rs`, the scheduler's `set_next_fire`)
@@ -72,6 +79,8 @@ pub struct NewTrigger {
     pub overlap_policy: String,
     /// Bounded-`allow` ceiling (#239); `None` = unbounded.
     pub max_concurrent: Option<i64>,
+    /// Per-Trigger sandbox mode (#410); `None` inherits the instance default.
+    pub sandbox: Option<String>,
     /// First scheduled fire, computed by the caller from the cron expression.
     pub next_fire_at: Option<String>,
 }
@@ -133,6 +142,7 @@ pub async fn init(db: &SqlitePool) -> Result<(), sqlx::Error> {
             guard_command TEXT,
             overlap_policy TEXT NOT NULL DEFAULT 'skip',
             max_concurrent INTEGER,
+            sandbox TEXT,
             enabled INTEGER NOT NULL DEFAULT 1,
             next_fire_at TEXT,
             last_fired_at TEXT,
@@ -174,6 +184,21 @@ pub async fn init(db: &SqlitePool) -> Result<(), sqlx::Error> {
             .is_some();
     if !has_col {
         sqlx::query("ALTER TABLE triggers ADD COLUMN max_concurrent INTEGER")
+            .execute(db)
+            .await?;
+    }
+
+    // Additive migration (#410): per-Trigger `sandbox` mode. Same PRAGMA-guarded
+    // `ALTER` precedent as `max_concurrent` above — a pre-#410 `~/.pdo/pdo.db` got
+    // the table via `CREATE TABLE IF NOT EXISTS`, a no-op there, so the column must
+    // be added out-of-band. NULLABLE: a NULL row inherits the instance default.
+    let has_sandbox =
+        sqlx::query("SELECT 1 FROM pragma_table_info('triggers') WHERE name = 'sandbox'")
+            .fetch_optional(db)
+            .await?
+            .is_some();
+    if !has_sandbox {
+        sqlx::query("ALTER TABLE triggers ADD COLUMN sandbox TEXT")
             .execute(db)
             .await?;
     }
@@ -242,8 +267,8 @@ pub async fn create(db: &SqlitePool, new: NewTrigger) -> Result<Trigger, sqlx::E
         "INSERT INTO triggers
             (id, name, pipeline_id, pipeline_name, target_repo, source_branch,
              input_template, variables, cron, guard_command, overlap_policy,
-             max_concurrent, enabled, next_fire_at, last_fired_at, last_outcome, created_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, NULL, NULL, ?)",
+             max_concurrent, sandbox, enabled, next_fire_at, last_fired_at, last_outcome, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, NULL, NULL, ?)",
     )
     .bind(&id)
     .bind(&new.name)
@@ -257,6 +282,7 @@ pub async fn create(db: &SqlitePool, new: NewTrigger) -> Result<Trigger, sqlx::E
     .bind(&new.guard_command)
     .bind(&new.overlap_policy)
     .bind(new.max_concurrent)
+    .bind(&new.sandbox)
     .bind(&new.next_fire_at)
     .bind(&now)
     .execute(db)
@@ -281,6 +307,7 @@ fn row_to_trigger(row: &sqlx::sqlite::SqliteRow) -> Trigger {
         guard_command: row.get("guard_command"),
         overlap_policy: row.get("overlap_policy"),
         max_concurrent: row.get("max_concurrent"),
+        sandbox: row.get("sandbox"),
         enabled: row.get::<i64, _>("enabled") != 0,
         next_fire_at: row.get("next_fire_at"),
         last_fired_at: row.get("last_fired_at"),
@@ -451,6 +478,12 @@ pub struct UpdateTrigger {
     /// Bounded-`allow` ceiling (#239), double-wrapped like the other nullable
     /// fields: `None` leaves it, `Some(None)` clears to NULL, `Some(Some(n))` sets.
     pub max_concurrent: Option<Option<i64>>,
+    /// Per-Trigger sandbox mode (#410), double-wrapped like `max_concurrent`: `None`
+    /// leaves it, `Some(None)` clears to NULL (= "inherit the instance default"),
+    /// `Some(Some(mode))` sets. The double-`Option` is load-bearing — a plain
+    /// `serde(default)` would make present-`null` indistinguishable from omitted, so
+    /// the UI could never reset a Trigger back to inheriting.
+    pub sandbox: Option<Option<String>>,
     pub next_fire_at: Option<Option<String>>,
     /// Enable/disable toggle (#372): `None` leaves the bit, `Some(v)` sets it.
     /// Folded in here so the enable bit and a forward `next_fire_at` land in one
@@ -471,6 +504,7 @@ impl UpdateTrigger {
             && self.guard_command.is_none()
             && self.overlap_policy.is_none()
             && self.max_concurrent.is_none()
+            && self.sandbox.is_none()
             && self.next_fire_at.is_none()
             && self.enabled.is_none()
     }
@@ -522,6 +556,9 @@ pub async fn update(
     if edit.max_concurrent.is_some() {
         sets.push("max_concurrent = ?");
     }
+    if edit.sandbox.is_some() {
+        sets.push("sandbox = ?");
+    }
     if edit.next_fire_at.is_some() {
         sets.push("next_fire_at = ?");
     }
@@ -564,6 +601,11 @@ pub async fn update(
     if let Some(v) = &edit.max_concurrent {
         query = query.bind(*v);
     }
+    if let Some(v) = &edit.sandbox {
+        // `Some(None)` → binds SQL NULL (inherit the instance default);
+        // `Some(Some(mode))` → binds the mode string. Mirror of `target_repo`.
+        query = query.bind(v.clone());
+    }
     if let Some(v) = &edit.next_fire_at {
         query = query.bind(v.clone());
     }
@@ -602,6 +644,7 @@ mod tests {
             guard_command: None,
             overlap_policy: "skip".to_string(),
             max_concurrent: None,
+            sandbox: None,
             next_fire_at: Some("2026-06-06T10:00:00.000Z".to_string()),
         }
     }
@@ -1214,6 +1257,79 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(get(&db, &t.id).await.unwrap().unwrap().max_concurrent, None);
+    }
+
+    // --- #410: per-Trigger sandbox persistence (mirror of max_concurrent) ---
+
+    #[tokio::test]
+    async fn create_then_get_round_trips_sandbox() {
+        let db = test_db().await;
+
+        let mut sandboxed = sample("sandboxed", "0 9 * * *");
+        sandboxed.sandbox = Some("pure".to_string());
+        let created = create(&db, sandboxed).await.unwrap();
+        assert_eq!(created.sandbox.as_deref(), Some("pure"));
+        assert_eq!(
+            get(&db, &created.id).await.unwrap().unwrap().sandbox.as_deref(),
+            Some("pure")
+        );
+
+        // The default (inherit instance) round-trips as NULL.
+        let inherit = create(&db, sample("inherit", "0 9 * * *")).await.unwrap();
+        assert_eq!(inherit.sandbox, None);
+        assert_eq!(get(&db, &inherit.id).await.unwrap().unwrap().sandbox, None);
+    }
+
+    #[tokio::test]
+    async fn update_sets_and_clears_sandbox() {
+        let db = test_db().await;
+        let t = create(&db, sample("sbx", "0 9 * * *")).await.unwrap();
+        assert_eq!(t.sandbox, None);
+
+        // Some(Some(mode)) sets it.
+        update(
+            &db,
+            &t.id,
+            UpdateTrigger {
+                sandbox: Some(Some("copy".to_string())),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            get(&db, &t.id).await.unwrap().unwrap().sandbox.as_deref(),
+            Some("copy")
+        );
+
+        // An unrelated edit (None) leaves it untouched.
+        update(
+            &db,
+            &t.id,
+            UpdateTrigger {
+                input_template: Some("changed".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            get(&db, &t.id).await.unwrap().unwrap().sandbox.as_deref(),
+            Some("copy")
+        );
+
+        // Some(None) clears it back to NULL (inherit the instance default).
+        update(
+            &db,
+            &t.id,
+            UpdateTrigger {
+                sandbox: Some(None),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(get(&db, &t.id).await.unwrap().unwrap().sandbox, None);
     }
 
     /// #239 migration: a `~/.pdo/pdo.db` created before `max_concurrent` existed

--- a/crates/pdo-daemon/src/trigger_store.rs
+++ b/crates/pdo-daemon/src/trigger_store.rs
@@ -1270,7 +1270,12 @@ mod tests {
         let created = create(&db, sandboxed).await.unwrap();
         assert_eq!(created.sandbox.as_deref(), Some("pure"));
         assert_eq!(
-            get(&db, &created.id).await.unwrap().unwrap().sandbox.as_deref(),
+            get(&db, &created.id)
+                .await
+                .unwrap()
+                .unwrap()
+                .sandbox
+                .as_deref(),
             Some("pure")
         );
 

--- a/crates/pdo-daemon/tests/sandbox_tracer.rs
+++ b/crates/pdo-daemon/tests/sandbox_tracer.rs
@@ -974,7 +974,11 @@ async fn create_trigger(daemon: &TestDaemon, sandbox: Option<&str>) -> String {
         .send()
         .await
         .unwrap();
-    assert_eq!(resp.status(), 201, "POST /triggers should create the trigger");
+    assert_eq!(
+        resp.status(),
+        201,
+        "POST /triggers should create the trigger"
+    );
     resp.json::<serde_json::Value>().await.unwrap()["id"]
         .as_str()
         .unwrap()

--- a/crates/pdo-daemon/tests/sandbox_tracer.rs
+++ b/crates/pdo-daemon/tests/sandbox_tracer.rs
@@ -929,3 +929,164 @@ async fn dockerfile_mode_builds_never_pulls() {
         log_text(&log)
     );
 }
+
+// -- #410: run-level exposure + sources of config ----------------------------
+
+async fn get_settings_json(daemon: &TestDaemon) -> serde_json::Value {
+    reqwest::get(format!("{}/settings", daemon.url()))
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap()
+}
+
+/// `PUT /settings {"default_sandbox": <mode>}` against the real daemon.
+async fn put_default_sandbox(daemon: &TestDaemon, mode: &str) {
+    let resp = reqwest::Client::new()
+        .put(format!("{}/settings", daemon.url()))
+        .json(&serde_json::json!({ "default_sandbox": mode }))
+        .send()
+        .await
+        .unwrap();
+    assert!(
+        resp.status().is_success(),
+        "PUT /settings default_sandbox={mode} should succeed: {}",
+        resp.status()
+    );
+}
+
+/// `POST /triggers` with an optional per-Trigger `sandbox` mode. Returns the id.
+/// A non-empty `input_template` keeps the prompt-required reject rule satisfied.
+async fn create_trigger(daemon: &TestDaemon, sandbox: Option<&str>) -> String {
+    let mut body = serde_json::json!({
+        "name": "sbx-trigger",
+        "pipeline_id": "sbx-cycle",
+        "cron": "0 9 * * *",
+        "input_template": "fired input",
+    });
+    if let Some(mode) = sandbox {
+        body["sandbox"] = serde_json::json!(mode);
+    }
+    let resp = reqwest::Client::new()
+        .post(format!("{}/triggers", daemon.url()))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 201, "POST /triggers should create the trigger");
+    resp.json::<serde_json::Value>().await.unwrap()["id"]
+        .as_str()
+        .unwrap()
+        .to_string()
+}
+
+/// Fire a trigger by forcing it due and running one scheduler tick, then return the
+/// resulting Run's id (the run whose `triggered_by` matches). Polls `GET /runs`.
+async fn fire_trigger_and_get_run(daemon: &TestDaemon, trigger_id: &str) -> String {
+    daemon.force_trigger_due(trigger_id).await;
+    daemon.run_trigger_tick().await;
+    let deadline = Instant::now() + Duration::from_secs(30);
+    while Instant::now() < deadline {
+        let runs = reqwest::get(format!("{}/runs", daemon.url()))
+            .await
+            .unwrap()
+            .json::<Vec<serde_json::Value>>()
+            .await
+            .unwrap();
+        if let Some(run) = runs.iter().find(|r| r["triggered_by"] == trigger_id) {
+            return run["run_id"].as_str().unwrap().to_string();
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    panic!("trigger {trigger_id} must have produced a Run within the deadline");
+}
+
+// -- Test 13: GET /settings surfaces Docker availability (advisory probe) -----
+
+#[tokio::test]
+async fn get_settings_reports_docker_available_with_working_fake() {
+    ensure_pdo_on_path();
+    // The standard fake docker answers `version` (via the `*) exit 0` arm) → the
+    // probe reports available.
+    let (_fake_dir, docker, _log) = write_fake_docker();
+    let daemon =
+        TestDaemon::spawn_with_docker_override(seed("#!/usr/bin/env bash\ntrue\n"), docker)
+            .await
+            .unwrap();
+
+    let view = get_settings_json(&daemon).await;
+    let sd = &view["sandbox_docker"];
+    assert_eq!(
+        sd["available"], true,
+        "a working docker must probe available: {sd}"
+    );
+    assert!(sd["reason"].is_null(), "available → no reason: {sd}");
+    assert!(sd["checked_at"].is_string(), "checked_at present: {sd}");
+}
+
+#[tokio::test]
+async fn get_settings_reports_docker_unavailable_when_binary_absent() {
+    ensure_pdo_on_path();
+    let daemon = TestDaemon::spawn_with_docker_override(
+        seed("#!/usr/bin/env bash\ntrue\n"),
+        "/nonexistent/pdo-fake-docker-probe".to_string(),
+    )
+    .await
+    .unwrap();
+
+    let view = get_settings_json(&daemon).await;
+    let sd = &view["sandbox_docker"];
+    assert_eq!(
+        sd["available"], false,
+        "an absent docker binary must probe unavailable: {sd}"
+    );
+    assert!(
+        sd["reason"].as_str().unwrap_or("").contains("docker"),
+        "unavailable must carry a human-readable reason: {sd}"
+    );
+}
+
+// -- Test 14: a per-Trigger sandbox mode fires sandboxed Runs -----------------
+
+#[tokio::test]
+async fn trigger_with_sandbox_pure_fires_pure_run() {
+    ensure_pdo_on_path();
+    let (_fake_dir, docker, _log) = write_fake_docker();
+    let daemon =
+        TestDaemon::spawn_with_docker_override(seed("#!/usr/bin/env bash\ntrue\n"), docker)
+            .await
+            .unwrap();
+
+    let trigger_id = create_trigger(&daemon, Some("pure")).await;
+    let run_id = fire_trigger_and_get_run(&daemon, &trigger_id).await;
+
+    let run = get_run(&daemon, &run_id).await;
+    assert_eq!(
+        run["sandbox"], "pure",
+        "a trigger with sandbox=pure must fire a pure Run: {run}"
+    );
+}
+
+// -- Test 15: a null-sandbox Trigger defers to the instance default -----------
+
+#[tokio::test]
+async fn trigger_without_sandbox_defers_to_instance_default() {
+    ensure_pdo_on_path();
+    let (_fake_dir, docker, _log) = write_fake_docker();
+    let daemon =
+        TestDaemon::spawn_with_docker_override(seed("#!/usr/bin/env bash\ntrue\n"), docker)
+            .await
+            .unwrap();
+
+    // Instance default = copy; the Trigger carries no sandbox → it inherits.
+    put_default_sandbox(&daemon, "copy").await;
+    let trigger_id = create_trigger(&daemon, None).await;
+    let run_id = fire_trigger_and_get_run(&daemon, &trigger_id).await;
+
+    let run = get_run(&daemon, &run_id).await;
+    assert_eq!(
+        run["sandbox"], "copy",
+        "a null-sandbox Trigger must defer to the instance default (copy): {run}"
+    );
+}

--- a/docs/adr/0030-sandbox-execution-model.md
+++ b/docs/adr/0030-sandbox-execution-model.md
@@ -64,8 +64,16 @@ PID 1 = tini). Les guards de Trigger restent hôte (décision de fiançailles, p
 
 8. **Mode immuable par Run.** `off`|`copy`|`pure` est porté par `RunStarted`, projeté une fois, jamais
    muté. Un Run reste sandboxé (ou non) toute sa vie : sinon `claude --continue` (resume) ne
-   retrouverait pas son transcript (indexé par chemin de travail). En #407 le mode n'arrive que par le
-   paramètre de l'API `POST /runs` ; les fires de Trigger passent `off` (précédence des sources #410).
+   retrouverait pas son transcript (indexé par chemin de travail). En #407 le mode n'arrivait que par
+   le paramètre de l'API `POST /runs`. Depuis **#410** il est **résolu** au chokepoint unique de
+   création (`create_run_inner`, où les trois parcours — JSON, multipart, fire de Trigger —
+   convergent) par le résolveur **pur** `event_log::effective_sandbox(explicit, trigger,
+   instance_default)`, précédence **choix explicite du Run → défaut par-Trigger → `default_sandbox`
+   d'instance** (plancher `off`). Le paramètre filaire devient `Option<SandboxMode>` (absent = `None`,
+   **distinct** d'un `off` explicite qu'un défaut `copy`/`pure` ne doit jamais surclasser).
+   `default_sandbox` est lu **frais** en base au bord (précédence `stored → env → default(off)`,
+   ADR-0015, miroir d'`image_source`). L'invariant `off` byte-identique tient : un mode résolu `off`
+   n'injecte rien dans le payload (chokepoint inchangé).
 
 9. **Observabilité (câblée #408).** `merge_back` est câblé dans le run-advance — à la **transition
    terminale** (chokepoint `append_event`, tâche détachée pour ne pas coupler la latence/l'échec de la
@@ -79,6 +87,21 @@ PID 1 = tini). Les guards de Trigger restent hôte (décision de fiançailles, p
    a échoué). `resume_run` re-arme d'abord le conteneur (`ensure_ready`-ou-échec, miroir du run-shell)
    car sans `--restart` il est down après un reboot hôte. **session-died** reste
    transcript-indépendante.
+
+10. **Visibilité de la préparation (#410).** La fenêtre de prep eager (point 4) devient observable via
+    deux événements **additifs et informationnels** — `SandboxPrepStarted` (en tête de la tâche
+    détachée, avant `ensure_ready`) / `SandboxPrepReady` (juste avant le 1er spawn) — émis au
+    chokepoint `append_event` (donc broadcast WS + `refreshRun` gratuits, aucune allowlist à toucher),
+    **jamais** pour un Run `off` (invariant `off` byte-identique préservé). Ils se projettent dans un
+    champ **additif** `RunState.sandbox_prep` (`pending`|`ready`) **sans** toucher `status` (qui reste
+    `running` : `is_live`/overlap/admission/reconcilers inchangés — même grain que `NodeBlockedOnLimit`
+    / `NodeAutoCompleteObserved`). On **écarte** un statut `Preparing` (blast radius sur toute la
+    machine à états + tous les consommateurs de statut) et l'**inférence client** (`running` + 0
+    session vive ⇒ preparing : faux positifs pendant la fenêtre d'advance détaché ADR-0023, le
+    throttling #159, et l'attente d'un successeur). L'échec de prep reste porté par `RunFailed`
+    (`fail_run_sandbox_prep`), **sans** événement de prep dédié. Fast-path (image locale) : la paire
+    Started/Ready bascule instantanément. **Non émis** au ré-armement (`resume_run`/`open_run_shell`) :
+    hors « premier usage ». Le marqueur `ready` survit à un restart daemon par replay du log.
 
 ## Pourquoi (le trou d'auth assumé v1)
 
@@ -133,8 +156,13 @@ l'hôte qu'un Run hôte.
   effet atomique qui ne réentre jamais le scheduler.
 - **ADR-0012** (autonomie gagnée) : la sandbox réduit le blast radius par défaut du travail autonome ;
   le cap global reste la primitive de sûreté.
-- **ADR-0015** (précédence config) : la source du mode (run → trigger → `default_sandbox`) est #410 ;
-  #407 n'accepte que le param API.
+- **ADR-0015** (précédence config) : la source du mode est **réalisée en #410** — résolveur pur
+  `effective_sandbox` (run → trigger → `default_sandbox`, plancher `off`), `default_sandbox` = nouvelle
+  colonne nullable d'`instance_config` (`stored → env → default`, résolveur `default_sandbox_with`
+  partagé create/`GET /settings`, 0 drift #373) ; défaut par-Trigger = colonne nullable `sandbox` sur
+  `triggers`, clearable via `deserialize_double_option` (précédent `max_concurrent` #239). La **sonde
+  Docker** (`docker version`, TTL-cachée, `GET /settings.sandbox_docker`) est **advisory** : le
+  fail-fast (point 4) reste le gate autoritaire.
 - **ADR-0020 / ADR-0021** (archivage / run-shell) : le conteneur vit de la création au `cleanup_run`
   (= archive), coextensif à la fenêtre d'éligibilité du run-shell ; après un reboot hôte,
   `open_run_shell` ressuscite le conteneur (`ensure_running`-or-fail), car `boot_recovery` saute les

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -344,6 +344,9 @@ export interface CreateRunRequest {
   target_repo?: string;
   source_branch?: string;
   name?: string;
+  /** Explicit sandbox mode (#410): `"off"` | `"copy"` | `"pure"`. Omitted → the
+   *  server defers to the trigger/instance default at the create chokepoint. */
+  sandbox?: string;
   images?: File[];
 }
 
@@ -363,6 +366,10 @@ export function createRun(req: CreateRunRequest): Promise<CreateRunResponse> {
     if (req.target_repo) form.append("target_repo", req.target_repo);
     if (req.source_branch) form.append("source_branch", req.source_branch);
     if (req.name) form.append("name", req.name);
+    // #410: thread the explicit sandbox mode through the multipart path too, so a
+    // sandboxed Run created WITH attached images keeps its mode (the daemon's
+    // multipart parser reads this field).
+    if (req.sandbox) form.append("sandbox", req.sandbox);
     for (const file of req.images!) {
       form.append("images", file, file.name);
     }
@@ -388,6 +395,9 @@ export interface CreateTriggerRequest {
   overlap_policy?: string;
   /** Bounded-`allow` ceiling (#239): max simultaneous live Runs; omit/undefined = unbounded. */
   max_concurrent?: number | null;
+  /** Per-Trigger sandbox mode (#410): `"off"` | `"copy"` | `"pure"`, or null/omit to
+   *  inherit the instance default. */
+  sandbox?: string | null;
 }
 
 export function fetchTriggers(): Promise<Trigger[]> {
@@ -421,6 +431,9 @@ export interface UpdateTriggerRequest {
   variables?: Record<string, unknown>;
   /** Bounded-`allow` ceiling (#239): number sets, null clears to unbounded, undefined leaves unchanged. */
   max_concurrent?: number | null;
+  /** Per-Trigger sandbox mode (#410): a mode string sets it, `null` clears back to
+   *  inheriting the instance default, `undefined` leaves it unchanged. */
+  sandbox?: string | null;
 }
 
 export function updateTrigger(

--- a/frontend/src/components/NewRunModal.test.tsx
+++ b/frontend/src/components/NewRunModal.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import NewRunModal from "./NewRunModal";
 import { useEditStore } from "../stores/editStore";
-import type { PipelineListEntry } from "../types";
+import type { InstanceSettings, PipelineListEntry } from "../types";
 
 const makePipeline = (overrides: Partial<PipelineListEntry> = {}): PipelineListEntry => ({
   id: "test-pipe",
@@ -17,6 +17,18 @@ const makePipeline = (overrides: Partial<PipelineListEntry> = {}): PipelineListE
 
 vi.mock("../api", () => ({
   fetchPipelines: vi.fn().mockResolvedValue([]),
+  // #410: the modal fetches settings on open (default_sandbox prefill +
+  // sandbox_docker greying). Default: off + Docker available. Tests override per case.
+  fetchSettings: vi.fn().mockResolvedValue({
+    session_cap: { effective: 20, source: "default", stored: null, env: null, default: 20 },
+    reaper_ttl_secs: { effective: 3600, source: "default", stored: null, env: null, default: 3600 },
+    guard_timeout_secs: { effective: 60, source: "default", stored: null, env: null, default: 60 },
+    default_model: { effective: null, source: "default", stored: null, env: null, default: null },
+    image_source: { effective: "registry", source: "default", stored: null, env: null, default: "registry" },
+    default_sandbox: { effective: "off", source: "default", stored: null, env: null, default: "off" },
+    sandbox_docker: { available: true, reason: null, checked_at: "2026-07-01T10:00:00.000Z" },
+    updated_at: "2026-07-01T10:00:00.000Z",
+  }),
   createRun: vi.fn().mockResolvedValue({ run_id: "test-run" }),
   createTrigger: vi.fn().mockResolvedValue({ id: "trg-test" }),
   updateTrigger: vi.fn().mockResolvedValue({ id: "trg-test" }),
@@ -32,7 +44,7 @@ vi.mock("../api", () => ({
   }),
 }));
 
-const { validateRepo, listBranches, createRun, createTrigger, updateTrigger, fetchPipelines, promotePipeline, testGuard } = await import("../api");
+const { validateRepo, listBranches, createRun, createTrigger, updateTrigger, fetchPipelines, fetchSettings, promotePipeline, testGuard } = await import("../api");
 
 const noop = () => {};
 
@@ -1298,5 +1310,131 @@ describe("NewRunModal — open-intent reset (#386)", () => {
       expect(screen.getByPlaceholderText(/free-text prompt/i)).toHaveValue("");
     });
     expect((screen.getByTestId("pipeline-select") as HTMLSelectElement).value).not.toBe("p1");
+  });
+});
+
+describe("NewRunModal — sandbox selector (#410)", () => {
+  function settingsFixture(overrides: Partial<InstanceSettings> = {}): InstanceSettings {
+    return {
+      session_cap: { effective: 20, source: "default", stored: null, env: null, default: 20 },
+      reaper_ttl_secs: { effective: 3600, source: "default", stored: null, env: null, default: 3600 },
+      guard_timeout_secs: { effective: 60, source: "default", stored: null, env: null, default: 60 },
+      default_model: { effective: null, source: "default", stored: null, env: null, default: null },
+      image_source: { effective: "registry", source: "default", stored: null, env: null, default: "registry" },
+      default_sandbox: { effective: "off", source: "default", stored: null, env: null, default: "off" },
+      sandbox_docker: { available: true, reason: null, checked_at: "2026-07-01T10:00:00.000Z" },
+      updated_at: "2026-07-01T10:00:00.000Z",
+      ...overrides,
+    };
+  }
+
+  it("prefills the run selector from the instance default", async () => {
+    vi.mocked(fetchSettings).mockResolvedValue(
+      settingsFixture({
+        default_sandbox: { effective: "copy", source: "stored", stored: "copy", env: null, default: "off" },
+      }),
+    );
+    vi.mocked(fetchPipelines).mockResolvedValue([makePipeline({ id: "p1", name: "P", scope: "repo" })]);
+    renderModal();
+    await waitFor(() => {
+      expect((screen.getByTestId("sandbox-select") as HTMLSelectElement).value).toBe("copy");
+    });
+  });
+
+  it("disables copy/pure and clamps to off when Docker is unavailable (availability wins over prefill)", async () => {
+    vi.mocked(fetchSettings).mockResolvedValue(
+      settingsFixture({
+        // The instance default is `pure`, but Docker is down: greying wins.
+        default_sandbox: { effective: "pure", source: "stored", stored: "pure", env: null, default: "off" },
+        sandbox_docker: { available: false, reason: "Docker daemon unreachable", checked_at: "x" },
+      }),
+    );
+    vi.mocked(fetchPipelines).mockResolvedValue([makePipeline({ id: "p1", name: "P", scope: "repo" })]);
+    renderModal();
+
+    const select = (await screen.findByTestId("sandbox-select")) as HTMLSelectElement;
+    // Clamped to off (never mints a Run doomed to RunFailed).
+    await waitFor(() => expect(select.value).toBe("off"));
+    // copy/pure options are disabled; the reason is surfaced.
+    const options = Array.from(select.options);
+    expect(options.find((o) => o.value === "copy")?.disabled).toBe(true);
+    expect(options.find((o) => o.value === "pure")?.disabled).toBe(true);
+    expect(screen.getByTestId("sandbox-docker-warning")).toHaveTextContent(/unreachable/i);
+  });
+
+  it("passes the chosen sandbox mode to createRun", async () => {
+    vi.mocked(fetchSettings).mockResolvedValue(
+      settingsFixture({
+        default_sandbox: { effective: "copy", source: "stored", stored: "copy", env: null, default: "off" },
+      }),
+    );
+    vi.mocked(fetchPipelines).mockResolvedValue([
+      makePipeline({ id: "p1", name: "Optional Pipeline", scope: "repo", prompt_required: false }),
+    ]);
+    renderModal();
+    await enterValidRepo();
+    // The prefill lands "copy".
+    await waitFor(() => {
+      expect((screen.getByTestId("sandbox-select") as HTMLSelectElement).value).toBe("copy");
+    });
+
+    vi.useRealTimers();
+    await waitFor(() => expect(screen.getByRole("button", { name: /launch/i })).toBeEnabled());
+    fireEvent.click(screen.getByRole("button", { name: /launch/i }));
+
+    await waitFor(() => {
+      expect(createRun).toHaveBeenCalledWith(expect.objectContaining({ sandbox: "copy" }));
+    });
+  });
+
+  it("offers a 'use instance default' option in trigger mode and sends null when picked", async () => {
+    vi.mocked(fetchPipelines).mockResolvedValue([
+      makePipeline({ id: "p1", name: "Auditor", scope: "repo", prompt_required: false }),
+    ]);
+    // A trigger whose sandbox is set to `pure` — prefills the select to `pure`.
+    const trigger = {
+      id: "trg-sbx",
+      name: "Nightly",
+      pipeline_id: "p1",
+      pipeline_name: "Auditor",
+      target_repo: "/home/user/project",
+      source_branch: "dev",
+      input_template: "audit",
+      variables: {},
+      cron: "0 9 * * *",
+      guard_command: null,
+      overlap_policy: "skip",
+      sandbox: "pure",
+      enabled: true,
+      next_fire_at: null,
+      last_fired_at: null,
+      last_outcome: null,
+    };
+    render(
+      <NewRunModal open={true} onClose={noop} onCreated={noop}
+        openIntent={{ kind: "edit-trigger", trigger }} />,
+    );
+
+    const select = (await screen.findByTestId("sandbox-select")) as HTMLSelectElement;
+    await waitFor(() => expect(select.value).toBe("pure"));
+    // Trigger mode exposes the inherit option.
+    expect(Array.from(select.options).some((o) => o.value === "")).toBe(true);
+
+    // Repo validation must resolve so Save is enabled.
+    await vi.advanceTimersByTimeAsync(500);
+    await waitFor(() => expect(validateRepo).toHaveBeenCalledWith("/home/user/project"));
+
+    // Reset to "use instance default" → the PATCH must clear it (null).
+    fireEvent.change(select, { target: { value: "" } });
+    vi.useRealTimers();
+    await waitFor(() => expect(screen.getByTestId("save-trigger-button")).toBeEnabled());
+    fireEvent.click(screen.getByTestId("save-trigger-button"));
+
+    await waitFor(() => {
+      expect(updateTrigger).toHaveBeenCalledWith(
+        "trg-sbx",
+        expect.objectContaining({ sandbox: null }),
+      );
+    });
   });
 });

--- a/frontend/src/components/NewRunModal.tsx
+++ b/frontend/src/components/NewRunModal.tsx
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ChevronDown, Clock, FolderGit2, GitBranch, ImagePlus, Save, Sparkles, Star, X } from "lucide-react";
-import type { PipelineListEntry, Trigger } from "../types";
+import type { InstanceSettings, PipelineListEntry, Trigger } from "../types";
 import type { TestGuardResponse } from "../api";
-import { createRun, createTrigger, updateTrigger, fetchPipelines, promotePipeline, validateRepo, listBranches, testGuard } from "../api";
+import { createRun, createTrigger, updateTrigger, fetchPipelines, fetchSettings, promotePipeline, validateRepo, listBranches, testGuard } from "../api";
 import { useEditStore } from "../stores/editStore";
 import { useRecentReposStore } from "../stores/recentReposStore";
 import RepoCombobox from "./RepoCombobox";
@@ -90,6 +90,15 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
   const [branchesLoading, setBranchesLoading] = useState(false);
 
   const [images, setImages] = useState<File[]>([]);
+
+  // Sandbox (#410). `settings` carries the instance `default_sandbox` (prefill) and
+  // the advisory `sandbox_docker` probe (greying). `sandbox` is the selector value:
+  // a concrete `off`/`copy`/`pure` in run mode; also `""` in trigger mode, meaning
+  // "inherit the instance default".
+  const [settings, setSettings] = useState<InstanceSettings | null>(null);
+  const [sandbox, setSandbox] = useState<string>("off");
+  const sandboxSeeded = useRef(false);
+
   const recentRepos = useRecentReposStore((s) => s.recentRepos);
   const refreshRecentRepos = useRecentReposStore((s) => s.refresh);
 
@@ -285,6 +294,49 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
     loadPipelines();
   }, [loadPipelines]);
 
+  // #410: fetch instance settings on open — the `default_sandbox` prefill AND the
+  // `sandbox_docker` availability probe arrive in one round-trip (the modal did not
+  // fetch settings before this slice).
+  useEffect(() => {
+    if (!open) return;
+    fetchSettings()
+      .then(setSettings)
+      .catch(() => {});
+  }, [open]);
+
+  // #410: seed the sandbox selector once per open, matched to the intent. Edit/new
+  // trigger seed synchronously (from the trigger / the "inherit" sentinel); a plain
+  // run waits for the settings fetch to prefill the instance default, CLAMPED to
+  // `off` when Docker is unavailable (availability wins over a `copy`/`pure` prefill
+  // so we never mint a Run doomed to a RunFailed the UI could have prevented).
+  useEffect(() => {
+    if (!open) {
+      sandboxSeeded.current = false;
+      return;
+    }
+    if (sandboxSeeded.current) return;
+    // One-shot seeding gated by the ref (bounded, does not re-fire) — the same
+    // pattern as the intent reset above, so the rule is opted out here too.
+    /* eslint-disable react-hooks/set-state-in-effect */
+    if (openIntent.kind === "edit-trigger") {
+      setSandbox(openIntent.trigger.sandbox ?? "");
+      sandboxSeeded.current = true;
+      return;
+    }
+    if (openIntent.kind === "new-trigger") {
+      setSandbox(""); // "" = inherit the instance default
+      sandboxSeeded.current = true;
+      return;
+    }
+    // run: prefill from the instance default once settings are loaded.
+    if (!settings) return;
+    const def = settings.default_sandbox.effective ?? "off";
+    const dockerOk = settings.sandbox_docker.available;
+    setSandbox(!dockerOk && def !== "off" ? "off" : def);
+    sandboxSeeded.current = true;
+    /* eslint-enable react-hooks/set-state-in-effect */
+  }, [open, openIntent, settings]);
+
   const repoPipelines = useMemo(
     () => pipelines.filter((p) => p.scope === "repo"),
     [pipelines],
@@ -419,6 +471,10 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
         target_repo: targetRepo.trim() || undefined,
         source_branch: sourceBranch || undefined,
         name: autoName ? undefined : runName.trim() || undefined,
+        // #410: the explicit run-level mode. Always concrete in run mode
+        // (off/copy/pure); sent explicitly so it wins the create-chokepoint
+        // precedence over any instance/trigger default.
+        sandbox: sandbox || undefined,
         images: images.length > 0 ? images : undefined,
       });
       onCreated(resp.run_id);
@@ -434,9 +490,15 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
     } finally {
       setSubmitting(false);
     }
-  }, [selectedPipeline, input, hasRequiredPrompt, overrides, onCreated, onClose, flushPendingSaves, repoValid, targetRepo, sourceBranch, autoName, runName, images, refreshRecentRepos]);
+  }, [selectedPipeline, input, hasRequiredPrompt, overrides, onCreated, onClose, flushPendingSaves, repoValid, targetRepo, sourceBranch, autoName, runName, images, sandbox, refreshRecentRepos]);
 
   const canLaunch = repoValid && selectedPipeline && hasRequiredPrompt;
+
+  // #410: advisory Docker greying. Only gate `copy`/`pure` once we KNOW Docker is
+  // unavailable (settings loaded && probe false); while settings load, stay
+  // optimistic. `sandboxReason` explains the greying (title + help text).
+  const dockerUnavailable = settings != null && !settings.sandbox_docker.available;
+  const sandboxReason = settings?.sandbox_docker.reason ?? undefined;
 
   // The cron expression the Trigger will be created with: a compiled preset or
   // the raw escape-hatch expression.
@@ -501,6 +563,9 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
           // `null` clears a stale cap when overlap is off or the input is blank.
           overlap_policy: allowOverlap ? "allow" : "skip",
           max_concurrent: allowOverlap && maxConcurrent.trim() ? Number(maxConcurrent) : null,
+          // #410: `""` (Use instance default) clears back to inheriting (`null`);
+          // a concrete mode sets it.
+          sandbox: sandbox || null,
           variables,
         });
       } else {
@@ -514,6 +579,8 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
           source_branch: sourceBranch || undefined,
           overlap_policy: allowOverlap ? "allow" : "skip",
           max_concurrent: allowOverlap && maxConcurrent.trim() ? Number(maxConcurrent) : undefined,
+          // #410: `""` (Use instance default) → `null` (inherit); a concrete mode sets it.
+          sandbox: sandbox || null,
           variables,
         });
       }
@@ -551,6 +618,7 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
     maxConcurrent,
     targetRepo,
     sourceBranch,
+    sandbox,
     flushPendingSaves,
     onTriggerSaved,
     onClose,
@@ -836,6 +904,50 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
               {selectedPipeline?.scope === "library" && selectedPipeline.drifted && (
                 <span className="text-st-blocked" style={{ fontSize: "10.5px" }} data-testid="drift-warning">
                   Source pipeline has changed — re-promote to update library copy
+                </span>
+              )}
+            </div>
+
+            {/* Sandbox (#410): the isolation mode. Run mode offers a concrete
+                off/copy/pure (prefilled from the instance default); Trigger mode adds
+                a leading "Use instance default" option. `copy`/`pure` are disabled
+                when the daemon reports Docker unavailable (advisory greying — the
+                run-advance fail-fast remains authoritative). */}
+            <div className="flex flex-col gap-1.5">
+              <label
+                htmlFor="sandbox-select"
+                className="font-medium text-fg-2"
+                style={{ fontSize: "11.5px" }}
+              >
+                Sandbox
+              </label>
+              <select
+                id="sandbox-select"
+                data-testid="sandbox-select"
+                value={sandbox}
+                onChange={(e) => setSandbox(e.target.value)}
+                title={dockerUnavailable ? sandboxReason : undefined}
+                className="w-full rounded-md border border-line-strong bg-bg-3 px-2.5 py-1.5 font-mono text-fg transition-colors focus:border-acc focus:outline-none disabled:opacity-40"
+                style={{ fontSize: "12px" }}
+              >
+                {mode === "trigger" && (
+                  <option value="">Use instance default</option>
+                )}
+                <option value="off">off (run on the host)</option>
+                <option value="copy" disabled={dockerUnavailable}>
+                  {dockerUnavailable ? "copy (Docker unavailable)" : "copy (Docker sandbox)"}
+                </option>
+                <option value="pure" disabled={dockerUnavailable}>
+                  {dockerUnavailable ? "pure (Docker unavailable)" : "pure (Docker sandbox)"}
+                </option>
+              </select>
+              {dockerUnavailable && (
+                <span
+                  className="text-fg-4"
+                  style={{ fontSize: "10.5px" }}
+                  data-testid="sandbox-docker-warning"
+                >
+                  {sandboxReason}
                 </span>
               )}
             </div>

--- a/frontend/src/components/PipelineInfoPanel.test.tsx
+++ b/frontend/src/components/PipelineInfoPanel.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { RunState } from "../types";
+
+// The badge/banner live in the InfoTab header, above DiffSection. Mock the heavy
+// children (network-fetching diff, tmux terminal) so the test stays focused on the
+// #410 sandbox surface and never touches the network.
+vi.mock("./DiffSection", () => ({ default: () => null }));
+vi.mock("./TmuxTerminal", () => ({ default: () => null }));
+
+import PipelineInfoPanel from "./PipelineInfoPanel";
+
+function makeRun(overrides: Partial<RunState> = {}): RunState {
+  return {
+    run_id: "run-abc1234567",
+    status: "running",
+    pipeline_name: "Test Pipeline",
+    name: null,
+    input: "do the thing",
+    started_at: "2026-07-01T10:00:00.000Z",
+    completed_at: null,
+    nodes: {},
+    edges: [],
+    node_defs: [],
+    start_node: null,
+    end_node: null,
+    merge_resolver: null,
+    ...overrides,
+  };
+}
+
+function renderPanel(run: RunState | null) {
+  return render(
+    <PipelineInfoPanel
+      run={run}
+      pipeline={null}
+      libraryPipelines={[]}
+      onLibraryChanged={() => {}}
+      onClose={() => {}}
+    />,
+  );
+}
+
+describe("PipelineInfoPanel — sandbox surface (#410)", () => {
+  it("shows the sandbox badge for a sandboxed run (pure)", () => {
+    renderPanel(makeRun({ sandbox: "pure" }));
+    const badge = screen.getByTestId("sandbox-badge");
+    expect(badge).toHaveTextContent(/sandbox:\s*pure/i);
+  });
+
+  it("shows the sandbox badge for a copy run", () => {
+    renderPanel(makeRun({ sandbox: "copy" }));
+    expect(screen.getByTestId("sandbox-badge")).toHaveTextContent(/sandbox:\s*copy/i);
+  });
+
+  it("omits the badge for an off/host run", () => {
+    renderPanel(makeRun({ sandbox: "off" }));
+    expect(screen.queryByTestId("sandbox-badge")).not.toBeInTheDocument();
+  });
+
+  it("omits the badge when sandbox is absent (historical/host run)", () => {
+    renderPanel(makeRun());
+    expect(screen.queryByTestId("sandbox-badge")).not.toBeInTheDocument();
+  });
+
+  it("shows the preparation banner while sandbox_prep is pending", () => {
+    renderPanel(makeRun({ sandbox: "pure", sandbox_prep: "pending" }));
+    expect(screen.getByTestId("sandbox-prep-banner")).toHaveTextContent(/preparing the sandbox/i);
+  });
+
+  it("hides the preparation banner once sandbox_prep is ready", () => {
+    renderPanel(makeRun({ sandbox: "pure", sandbox_prep: "ready" }));
+    expect(screen.queryByTestId("sandbox-prep-banner")).not.toBeInTheDocument();
+    // The badge stays visible after prep completes.
+    expect(screen.getByTestId("sandbox-badge")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/PipelineInfoPanel.tsx
+++ b/frontend/src/components/PipelineInfoPanel.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo, useRef, useEffect } from "react";
-import { Info, Terminal, X, FileText, Code } from "lucide-react";
+import { Info, Terminal, X, FileText, Code, Box, Loader } from "lucide-react";
 import { SectionHead } from "./InspectorPrimitives";
 import TmuxTerminal from "./TmuxTerminal";
 import DiffSection from "./DiffSection";
@@ -196,6 +196,19 @@ function InfoTab({
               {run ? `run ${run.run_id.slice(-8)} · ${pipeline?.version ?? "v1"}` : `template · ${pipeline?.version ?? "v1"}`}
             </div>
           </div>
+          {/* Sandbox badge (#410): shown for any sandboxed Run (copy/pure). An
+              `off`/host Run renders nothing — the field is absent on those. */}
+          {run?.sandbox && run.sandbox !== "off" && (
+            <span
+              className="flex shrink-0 items-center gap-1 rounded bg-bg-3 px-1.5 py-0.5 font-mono text-fg-3"
+              style={{ fontSize: "9.5px" }}
+              data-testid="sandbox-badge"
+              title={`This run is isolated in a Docker sandbox (${run.sandbox})`}
+            >
+              <Box size={10} className="shrink-0" />
+              sandbox: {run.sandbox}
+            </span>
+          )}
         </div>
 
         {variables.length > 0 && (
@@ -215,6 +228,24 @@ function InfoTab({
           </div>
         )}
       </div>
+
+      {/* Sandbox preparation banner (#410, amber): the image is being pulled/built
+          at first use. Only while `sandbox_prep === "pending"` — it clears to
+          `ready` once the container is about to run, so the Run never looks stuck. */}
+      {run?.sandbox_prep === "pending" && (
+        <div
+          className="flex items-center gap-2 border-b border-st-await/30 bg-st-await-bg px-3 py-2"
+          data-testid="sandbox-prep-banner"
+        >
+          <Loader size={14} className="shrink-0 animate-spin text-st-await" />
+          <span
+            className="text-st-await"
+            style={{ fontSize: "11.5px", fontWeight: 500 }}
+          >
+            Preparing the sandbox — pulling/building the image…
+          </span>
+        </div>
+      )}
 
       {run && (
         <div

--- a/frontend/src/components/SettingsModal.test.tsx
+++ b/frontend/src/components/SettingsModal.test.tsx
@@ -24,6 +24,10 @@ function sample(overrides: Partial<InstanceSettings> = {}): InstanceSettings {
     default_model: { effective: null, source: "default", stored: null, env: null, default: null },
     // Image source (#411): built-in default `registry`, nothing stored/env.
     image_source: { effective: "registry", source: "default", stored: null, env: null, default: "registry" },
+    // Default sandbox (#410): built-in default `off`, nothing stored/env.
+    default_sandbox: { effective: "off", source: "default", stored: null, env: null, default: "off" },
+    // Advisory Docker probe (#410): available by default in the fixture.
+    sandbox_docker: { available: true, reason: null, checked_at: "2026-07-01T10:00:00.000Z" },
     updated_at: "2026-07-01T10:00:00.000Z",
     ...overrides,
   };
@@ -243,6 +247,76 @@ describe("SettingsModal", () => {
     render(<SettingsModal open onClose={() => {}} />);
     const note = await screen.findByTestId("setting-source-image-source");
     expect(note).toHaveTextContent("PDO_SANDBOX_IMAGE_SOURCE=registry");
+    expect(note).toHaveTextContent(/overridden/i);
+  });
+
+  it("seeds the default-sandbox select from the effective value (#410)", async () => {
+    fetchSettingsMock.mockResolvedValue(
+      sample({
+        default_sandbox: {
+          effective: "pure",
+          source: "stored",
+          stored: "pure",
+          env: null,
+          default: "off",
+        },
+      }),
+    );
+    render(<SettingsModal open onClose={() => {}} />);
+    const select = (await screen.findByTestId("setting-default-sandbox")) as HTMLSelectElement;
+    expect(select.value).toBe("pure");
+  });
+
+  it("saves the picked default sandbox (#410)", async () => {
+    fetchSettingsMock.mockResolvedValue(sample());
+    updateSettingsMock.mockResolvedValue(
+      sample({
+        default_sandbox: {
+          effective: "copy",
+          source: "stored",
+          stored: "copy",
+          env: null,
+          default: "off",
+        },
+      }),
+    );
+    const onClose = vi.fn();
+    render(<SettingsModal open onClose={onClose} />);
+
+    const select = await screen.findByTestId("setting-default-sandbox");
+    fireEvent.change(select, { target: { value: "copy" } });
+    fireEvent.click(screen.getByTestId("settings-save"));
+
+    await waitFor(() => expect(updateSettingsMock).toHaveBeenCalledTimes(1));
+    expect(updateSettingsMock).toHaveBeenCalledWith({ default_sandbox: "copy" });
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+
+  it("does not send default_sandbox when left unchanged (#410)", async () => {
+    fetchSettingsMock.mockResolvedValue(sample());
+    const onClose = vi.fn();
+    render(<SettingsModal open onClose={onClose} />);
+    await screen.findByTestId("setting-default-sandbox");
+    fireEvent.click(screen.getByTestId("settings-save"));
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+    expect(updateSettingsMock).not.toHaveBeenCalled();
+  });
+
+  it("discloses a shadowed env source for the default sandbox (#410)", async () => {
+    fetchSettingsMock.mockResolvedValue(
+      sample({
+        default_sandbox: {
+          effective: "pure",
+          source: "stored",
+          stored: "pure",
+          env: "copy",
+          default: "off",
+        },
+      }),
+    );
+    render(<SettingsModal open onClose={() => {}} />);
+    const note = await screen.findByTestId("setting-source-default-sandbox");
+    expect(note).toHaveTextContent("PDO_DEFAULT_SANDBOX=copy");
     expect(note).toHaveTextContent(/overridden/i);
   });
 });

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -169,6 +169,11 @@ function SettingsForm({ settings, liveSessions, save, onClose, onSaved }: FormPr
   const [imageSource, setImageSource] = useState<string>(
     () => settings.image_source.effective ?? "registry",
   );
+  // Default sandbox mode (#410): a closed enum with a built-in `off` default, so
+  // `effective` is always present (the `?? "off"` is belt-and-braces).
+  const [defaultSandbox, setDefaultSandbox] = useState<string>(
+    () => settings.default_sandbox.effective ?? "off",
+  );
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -218,6 +223,12 @@ function SettingsForm({ settings, liveSessions, save, onClose, onSaved }: FormPr
     // select never emits "" — the clear path is backend-only.
     if (imageSource !== settings.image_source.effective) {
       patch.image_source = imageSource;
+    }
+
+    // Default sandbox mode (#410): a concrete enum variant, only sent when it
+    // changed. Like image_source, the select never emits "" (clear is backend-only).
+    if (defaultSandbox !== settings.default_sandbox.effective) {
+      patch.default_sandbox = defaultSandbox;
     }
 
     // Nothing changed → close without a round-trip.
@@ -354,6 +365,45 @@ function SettingsForm({ settings, liveSessions, save, onClose, onSaved }: FormPr
             data-testid="setting-source-image-source"
           >
             {imageSourceSourceNote(settings.image_source)}
+          </div>
+        </div>
+
+        {/* Default sandbox mode (#410): the isolation mode a Run uses when neither
+            the NewRunModal nor a firing Trigger specifies one. A closed enum →
+            native <select> (mirror of image_source). It only emits a concrete
+            variant; the "" clear sentinel is backend-only. */}
+        <div className="flex flex-col gap-1.5">
+          <label
+            htmlFor="setting-default-sandbox"
+            className="font-medium text-fg-2"
+            style={{ fontSize: "11.5px" }}
+          >
+            Default sandbox
+          </label>
+          <select
+            id="setting-default-sandbox"
+            data-testid="setting-default-sandbox"
+            value={defaultSandbox}
+            onChange={(e) => setDefaultSandbox(e.target.value)}
+            className="w-full rounded-md border border-line-strong bg-bg-3 px-2.5 py-1.5 font-mono text-fg transition-colors focus:border-acc focus:outline-none"
+            style={{ fontSize: "12px" }}
+          >
+            <option value="off">off (run on the host)</option>
+            <option value="copy">copy (Docker, copy your Claude home)</option>
+            <option value="pure">pure (Docker, credentials + trust only)</option>
+          </select>
+          <div className="text-fg-4" style={{ fontSize: "10.5px" }}>
+            The isolation mode a Run uses when neither the launch dialog nor a firing
+            Trigger picks one. <span className="font-mono">off</span> runs on the host;{" "}
+            <span className="font-mono">copy</span> and <span className="font-mono">pure</span>{" "}
+            run inside a Docker sandbox (require Docker).
+          </div>
+          <div
+            className="text-fg-3"
+            style={{ fontSize: "10.5px" }}
+            data-testid="setting-source-default-sandbox"
+          >
+            {defaultSandboxSourceNote(settings.default_sandbox)}
           </div>
         </div>
 
@@ -497,4 +547,19 @@ function imageSourceSourceNote(field: StringSettingField): string {
     return `Source: env ${envDisplay ?? "PDO_SANDBOX_IMAGE_SOURCE"}.`;
   }
   return `Source: built-in default (${field.default ?? "registry"}).`;
+}
+
+/** Which tier the instance default_sandbox comes from (#410). Like image_source there
+ *  IS a built-in default (`off`). Discloses a shadowed env var too. */
+function defaultSandboxSourceNote(field: StringSettingField): string {
+  const envDisplay = field.env ? `PDO_DEFAULT_SANDBOX=${field.env}` : null;
+  if (field.source === "stored") {
+    return envDisplay
+      ? `Source: stored value (wins). Env ${envDisplay} is set but overridden.`
+      : `Source: stored value (overrides env and default).`;
+  }
+  if (field.source === "env") {
+    return `Source: env ${envDisplay ?? "PDO_DEFAULT_SANDBOX"}.`;
+  }
+  return `Source: built-in default (${field.default ?? "off"}).`;
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -90,6 +90,24 @@ export interface InstanceSettings {
    * {@link StringSettingField} (a superset) even though it is never null.
    */
   image_source: StringSettingField;
+  /**
+   * Instance-wide default sandbox mode (#410): `"off"` (host, default), `"copy"`,
+   * or `"pure"`. A closed enum with a built-in `off` default, so every tier is a
+   * present string — reuses {@link StringSettingField} (a superset) though it is
+   * never null. The create-run chokepoint resolves precedence run → trigger → this.
+   */
+  default_sandbox: StringSettingField;
+  /**
+   * Advisory Docker availability probe (#410), folded into `GET /settings` so the
+   * NewRunModal learns the default AND whether Docker can run a sandbox in one fetch.
+   * `available: false` grays out `copy`/`pure` (`reason` explains why); the
+   * run-advance fail-fast stays the authoritative gate.
+   */
+  sandbox_docker: {
+    available: boolean;
+    reason: string | null;
+    checked_at: string;
+  };
   updated_at: string;
 }
 
@@ -108,6 +126,10 @@ export interface UpdateSettingsRequest {
   /** Sandbox image source (#411): `"registry"` | `"dockerfile"`. The `<select>` only
    *  ever sends a concrete variant — the `""` clear sentinel is backend-only. */
   image_source?: string;
+  /** Default sandbox mode (#410): `"off"` | `"copy"` | `"pure"`, or `""` to clear
+   *  back to the built-in default (`off`). Same `""`-sentinel discipline as
+   *  `default_model`/`image_source`. */
+  default_sandbox?: string;
 }
 // `for-each` was removed (ADR-0011 / #151): a fan-out is now a `collection`
 // loop region, not a node. The backend keeps the variant only to migrate old
@@ -162,6 +184,9 @@ export interface Trigger {
   overlap_policy: string;
   /** Bounded-`allow` ceiling (#239): max simultaneous live Runs; null = unbounded. */
   max_concurrent?: number | null;
+  /** Per-Trigger sandbox mode (#410): `"off"` | `"copy"` | `"pure"`, or null/absent
+   *  to inherit the instance default. Read at fire time. */
+  sandbox?: string | null;
   enabled: boolean;
   next_fire_at?: string | null;
   last_fired_at?: string | null;
@@ -312,6 +337,19 @@ export interface RunState {
   foreach_states?: Record<string, ForEachStateInfo>;
   target_repo?: string | null;
   source_branch?: string | null;
+  /**
+   * Isolation mode for this Run (#403 / #407 / #410). Absent on host/historical
+   * runs (projected as `off` server-side and skipped from the payload when off).
+   * Immutable once the Run started.
+   */
+  sandbox?: "off" | "copy" | "pure";
+  /**
+   * One-time image-prep visibility for a sandboxed Run (#410). `"pending"` while
+   * the image is pulled/built at first use; `"ready"` once the container is about
+   * to run; absent for host/off runs. Additive — `status` stays `"running"`
+   * throughout, so this drives a banner only.
+   */
+  sandbox_prep?: "pending" | "ready";
   /**
    * Cumulative count of NodeRun sessions this run spawned — raw `NodeStarted`
    * count, not distinct `(node, iter)`; manager excluded (#100). Defaults to 0


### PR DESCRIPTION
## Sandbox G — FE run-level + sources de config

Dernière slice du PRD #403 côté configuration : le mode sandbox devient choisissable **par run**, avec une précédence explicite entre trois sources.

### Ce que la slice apporte

- **Résolveur de précédence** (layer-1, pur) : `explicite (NewRunModal)` > `Trigger` > `défaut d'instance`. 5 tests de précédence.
- **NewRunModal** : sélecteur tri-état `off | copy | pure`, prérempli sur le défaut d'instance.
- **Sonde Docker** : si Docker est indisponible, le sélecteur **clampe sur `off`**, `copy`/`pure` passent `disabled` avec la raison remontée par le daemon (on ne fabrique pas un Run condamné). La disponibilité gagne sur le préremplissage.
- **Trigger** : quatrième option de tête `Use instance default` (valeur `""` → `null` en base) ; un Trigger non-null impose son mode aux Runs qu'il déclenche.
- **Défaut d'instance** : `default_sandbox` dans `instance_config` (migration additive), éditable depuis *Instance settings*, avec divulgation de la source (`stored` > `env PDO_DEFAULT_SANDBOX` > défaut intégré) et validation `400` sur valeur invalide.
- **Visibilité de la préparation** : événements `sandbox_prep_started` / `sandbox_prep_ready`, bandeau ambre + spinner pendant `pending`, badge `sandbox: <mode>` dans *Pipeline info*.

### Invariant `off`

Un Run `off` reste byte-identique au comportement pré-sandbox : aucune clé `sandbox` dans `run_started`, aucun `sandbox_prep`, aucun conteneur, aucune chrome sandbox dans l'UI. Couvert par `off_run_never_carries_sandbox_prep`, `off_run_never_invokes_docker` et `tmux_session_manager::tests::sandbox_none_is_byte_identical`.

### Validation

12 portes vertes en `cargo +stable` (fmt, check, test 1600 passed, clippy `-D warnings`, smoke, frontend typecheck/lint/build, e2e 73 passed, vitest 1342 passed). Validation agentique en Docker réel (29.2.1), navigateur piloté, 6/6 critères d'acceptation ; matrice de précédence prouvée sur 5 combinaisons ; clamp `off` vérifié avec un binaire Docker absent.

### Suivi hors périmètre (à filer séparément)

- **Course prep / `pipeline_watcher`** : en mode `copy` (prep ~42 s), l'écriture de `.pdo/runs/<id>/pipeline.yaml` déclenche une ré-évaluation qui spawn le nœud ~1 s après le début de la prep, avant que le conteneur existe — le run reste `running`. Antérieur à cette slice (`git diff 9e13b06..HEAD` ne touche ni `sandbox_run.rs`, ni `run_advance.rs`, ni `node_spawn.rs`, ni `pipeline_watcher.rs`) ; relève du câblage #406/#407. #410 a rendu la course *visible*, pas créée.
- **`npm test` (vitest) n'est lancé par aucun job CI** — les tests FE de cette slice ne gatent rien. Changement de politique CI.
- **`tests/smoke.sh` fuit un daemon par invocation** (trap sur le PID du sous-shell) — mécanisme concret derrière #422.

Pas de bump de version : la release du PRD #403 se fera une seule fois, à la fin.

Closes #410

🤖 Generated with [Claude Code](https://claude.com/claude-code)
