### PR TITLE
chore(release): v0.1.101 — resolve v0.1.100 version collision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "0.1.100"
+version = "0.1.101"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "0.1.100"
+version = "0.1.101"
 license = "MIT"
 
 [workspace.dependencies]


### PR DESCRIPTION
PRs #428 and #429 merged 16 seconds apart and both bumped the same line `0.1.99` -> `0.1.100`. Because the textual change was identical, git merged both without conflict — two distinct commits on `main` now claim `v0.1.100`, so the version no longer identifies a build.

Bumps to `0.1.101` so the tip is unambiguous. No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)