### PR TITLE
feat(#426): sandbox I — vocabulaire off|minimal|full + plancher de staging garanti

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -823,35 +823,43 @@ La complétion est signalée **depuis l'UI**, par un bouton "Mark complete" sur 
 > wrapping des tails au chokepoint, kill/cleanup/boot/run-shell) fixé par **ADR-0030** (modèle
 > d'exécution : réseau/uid, trou d'auth assumé v1 lié à #260) + **observabilité** (#408 : `merge_back`
 > câblé à la transition terminale + `cleanup_run`, seam `transcripts_root` pour coût/stale) +
-> **mode `copy` de bout en bout** (#409 : vérifie `prepare`(allowlist copy) → conteneur →
-> `merge_back` ; même câblage mode-agnostique que #407, ne diffère de `pure` que par le seed de
+> **mode `full` de bout en bout** (#409 : vérifie `prepare`(allowlist `full`) → conteneur →
+> `merge_back` ; même câblage mode-agnostique que #407, ne diffère de `minimal` que par le seed de
 > `prepare` — deref des symlinks échappants + walk best-effort en sus) + **fourniture hybride de
 > l'image** (#411 : `ensure_image` pull GHCR-puis-retag / fallback build, réglage `image_source`,
 > job release GHCR) + **exposition run-level + sources de config** (#410 : sélecteur tri-état du
 > NewRunModal grisé par la **sonde Docker**, badge + bannière `sandbox_prep`, défaut d'instance
-> `default_sandbox`, défaut par-Trigger `sandbox`, **précédence** résolue par `effective_sandbox`).
+> `default_sandbox`, défaut par-Trigger `sandbox`, **précédence** résolue par `effective_sandbox`) +
+> **vocabulaire + plancher de garanties** (#426 : tri-état renommé `off` | `minimal` | `full` sans
+> alias, plancher tenu par `prepare` dans les **deux** modes — `remote-settings.json` consenti +
+> `skipDangerousModePermissionPrompt` dans le `settings.json` stagé ; **ADR-0031 §1** + amendement
+> **ADR-0030 §1**).
 
 > **Décidé au grilling 2026-07-24 (ADR-0031), pas encore en vigueur** — livré par les slices
-> post-validation du PRD : le tri-état devient `off` | `minimal` | `full` (ex-`pure`/`copy`, sans
-> alias), le plancher de staging devient une liste de **garanties**, et les valeurs non-`off`
-> deviennent des noms de **profil de staging**. Les trois termes concernés portent le même marqueur.
+> **profils** du PRD : les valeurs non-`off` deviennent des noms de **profil de staging** (liste
+> nommée, éditable, sélectionnable par Run et par Trigger), et une **entrée de profil** peut désigner
+> une exception `$HOME` hors `.claude`. Les deux termes concernés portent le même marqueur. Le
+> renommage du tri-état et le plancher de **garanties**, décidés au même grilling, sont **en vigueur**
+> depuis #426.
 
 **Sandbox** :
 Propriété **par Run**, **immuable après création**, portée par l'événement de création (projetée
-dans l'état du Run). Tri-état `off` | `copy` | `pure` : `off` = comportement historique (sessions
-sur l'hôte, défaut) ; `copy` / `pure` = toutes les tails du Run s'exécutent dans un conteneur dédié.
+dans l'état du Run). Tri-état `off` | `minimal` | `full` (renommé en #426, ex-`pure`/`copy`, **sans
+alias**) : `off` = comportement historique (sessions sur l'hôte, défaut) ; `minimal` / `full` =
+toutes les tails du Run s'exécutent dans un conteneur dédié.
 C'est une propriété de l'**environnement d'exécution**, jamais de la sémantique du pipeline (le YAML
 reste intouché — #403 US-5). Modèle d'exécution (conteneur `pdo-sbx-<run-id>`, identity mounts, uid
 hôte, trou réseau/auth) → **ADR-0030 / #407**. La **source** du mode suit la précédence **choix
 explicite du Run → défaut par-Trigger → `default_sandbox` d'instance** (résolveur pur
 `effective_sandbox`, #410) ; `off` reste le plancher.
 _Éviter_ : « mode conteneur », « isolation » seul (ambigu) ; ne pas confondre avec l'attribut
-`sandbox=""` de l'iframe du port de sortie `html` (#333, ADR-0028) — sans rapport.
+`sandbox=""` de l'iframe du port de sortie `html` (#333, ADR-0028) — sans rapport ; « `copy` » /
+« `pure` » (vocabulaire mort depuis #426, aucun alias).
 
 **Staging dir (répertoire de staging)** :
 Répertoire par Run sous `~/.pdo/sandbox/<run-id>/`, créé au démarrage d'un Run sandboxé et purgé à
-`cleanup_run`. Héberge le *staged Claude home* + un `.claude.json` sibling (+, une fois ADR-0031
-livré, un `home/` portant les **exceptions `$HOME`** déclarées par le profil). Le vrai `~/.claude`
+`cleanup_run`. Héberge le *staged Claude home* + un `.claude.json` sibling (+, une fois les
+**profils** livrés, un `home/` portant les **exceptions `$HOME`** déclarées par le profil). Le vrai `~/.claude`
 n'est **jamais** monté — et l'invariant s'étend au reste de `$HOME` : ce sont toujours des copies
 qui sont montées. Racines home/staging **injectables** (testabilité temp dirs + compat recette HP
 fake-HOME). _Éviter_ : « home copié », « sandbox dir » (collision avec la racine `~/.pdo/sandbox/`).
@@ -873,14 +881,17 @@ plus les évolutions futures du défaut. Le nom **et** la liste résolue sont ge
 création, tir de Trigger en échec, `RunFailed` en boot recovery), jamais de retombée silencieuse.
 _Éviter_ : « allowlist » seul (c'était la constante Rust d'avant), « preset », « template ».
 
-**Plancher de staging** _(décidé, pas encore en vigueur — ADR-0031)_ :
-Les **garanties** que `prepare` tient quel que soit le profil : credentials valides, managed
-settings de l'org **consentis** (baseline `remote-settings.json`), bypass permissions accepté,
-confiance pré-accordée à la racine du Run, `projects/` vide. Chaque garantie est satisfaite soit par
-une entrée du profil, soit par une **synthèse de repli** — c'est ce qui rend le décochage sûr sans
-l'interdire. Formulé en fichiers verrouillés, le plancher se contredirait dès `settings.json`
-(copié en `full`, synthétisé en `minimal`). _Éviter_ : « fichiers obligatoires », « liste
-verrouillée ».
+**Plancher de staging** :
+Les **garanties** que `prepare` tient dans les **deux** modes (`minimal` et `full`) — et demain quel
+que soit le **profil** : credentials valides (`.credentials.json`), managed settings de l'org
+**consentis** (copie de `~/.claude/remote-settings.json` quand elle existe), bypass permissions
+accepté (`skipDangerousModePermissionPrompt: true` **mergé** dans le `settings.json` copié en `full`,
+**synthétisé** en `minimal`), confiance pré-accordée à la racine du Run (dans le `.claude.json`
+stagé, #409), `projects/` **vide**. Chaque garantie est satisfaite soit par une **copie** de l'hôte,
+soit par une **synthèse de repli** — c'est ce qui rendra le décochage d'une entrée de profil sûr sans
+l'interdire (ADR-0031 §1). Formulé en fichiers verrouillés, le plancher se contredirait dès
+`settings.json` (copié en `full`, synthétisé en `minimal`). Réalisé en **#426**.
+_Éviter_ : « fichiers obligatoires », « liste verrouillée ».
 
 **Entrée de profil / exception `$HOME`** _(décidé, pas encore en vigueur — ADR-0031)_ :
 Une entrée est un chemin **relatif à `$HOME`** (`.claude/skills`, `.gitconfig`, `.config/gh`).
@@ -892,22 +903,27 @@ servie par le mount `.claude`. _Éviter_ : « fichier monté » (c'est une copie
 « exclusion » pour parler d'un décochage.
 
 **`prepare(mode, run_id)`** :
-Seede le *staged Claude home* selon le mode. **`copy`** : recopie une **liste explicite** de
-`~/.claude` (skills, plugins, agents, commands, output-styles, settings[.local].json, credentials,
-`*.md` global) + `~/.claude.json` verbatim, **avec la confiance de la racine du Run mergée** dedans
-(#409 D5 — sinon un Run autonome se bloquerait sur le dialogue « trust this folder ? ») ; **exclut
-`projects/`** et tout état hôte volumineux (`history.jsonl`, `session-env/`, …). Les symlinks qui
-**sortent** de `~/.claude` (skills liés à `~/.agents`) sont **déréférencés** (recréés verbatim ils
+Seede le *staged Claude home* selon le mode, en tenant le **plancher de staging** dans les deux cas.
+**`full`** : recopie une **liste explicite** de `~/.claude` (skills, plugins, agents, commands,
+output-styles, settings[.local].json, credentials, `*.md` global) + `~/.claude.json` verbatim ;
+**exclut `projects/`** et tout état hôte volumineux (`history.jsonl`, `session-env/`, …). Les symlinks
+qui **sortent** de `~/.claude` (skills liés à `~/.agents`) sont **déréférencés** (recréés verbatim ils
 dangleraient dans le conteneur) ; les liens intra-arbre (`node_modules/.bin`) restent des liens. Walk
-**best-effort par entrée** : un `~/.claude` volatil ne fait jamais échouer le Run. **`pure`** :
-uniquement `.credentials.json` + un `.claude.json` minimal (onboarding validé + confiance
-pré-accordée à la racine du Run). Dans les deux modes, `projects/` est créé **vide** (puits de
-transcripts runtime). Bits exécutables préservés. **Volume/PII (#409)** : `copy` pèse **~1 Go/run**
-(dominé par `plugins/*/node_modules`, requis par les serveurs MCP *in-container* — délibérément non
-strippés) et expose en plus le profil PII (`oauthAccount`/`userID`/`emailAddress`) + settings + `.md`
-globaux que `pure` retient (choix conscient, aligné sur le trou d'auth d'ADR-0030). Dette disque : le
-staging n'est purgé qu'au `cleanup_run` (surveiller vs la récurrence disque connue). _Éviter_ :
-« init », « seed » seul.
+**best-effort par entrée** : un `~/.claude` volatil ne fait jamais échouer le Run. **`minimal`** :
+n'apporte **rien** en propre — `minimal` *est* le plancher. Le **plancher**, mode-agnostique, tient
+ensuite les cinq garanties : `.credentials.json` copié ; `remote-settings.json` copié de `~/.claude/`
+quand il existe (absent → no-op loggé, jamais une erreur) ; `skipDangerousModePermissionPrompt: true`
+dans le `settings.json` stagé (**mergé** non destructivement dans la copie hôte en `full`,
+**synthétisé** en `minimal` — sans quoi la session bute sur le dialogue de bypass permissions) ;
+confiance de la racine du Run mergée dans le `.claude.json` stagé (#409 D5 — sinon un Run autonome se
+bloquerait sur le dialogue « trust this folder ? ») ; `projects/` créé **vide** (puits de transcripts
+runtime). Le plancher est le **writer unique** de `remote-settings.json` et de la clé de bypass : ni
+l'un ni l'autre n'est dans l'allowlist `full`. Bits exécutables préservés. **Volume/PII (#409)** :
+`full` pèse **~1 Go/run** (dominé par `plugins/*/node_modules`, requis par les serveurs MCP
+*in-container* — délibérément non strippés) et expose en plus le profil PII
+(`oauthAccount`/`userID`/`emailAddress`) + settings + `.md` globaux que `minimal` retient (choix
+conscient, aligné sur le trou d'auth d'ADR-0030). Dette disque : le staging n'est purgé qu'au
+`cleanup_run` (surveiller vs la récurrence disque connue). _Éviter_ : « init », « seed » seul.
 
 **`merge_back(run_id)`** :
 À la transition terminale du Run **et** à `cleanup_run` : recopie **uniquement** les `*.jsonl` de
@@ -969,7 +985,7 @@ Le réglage qui pilote d'où `ensure_image` tire l'image : `registry` (défaut, 
 fallback build) | `dockerfile` (build local direct). **Par-daemon**, jamais par-Run (à la différence
 du **mode** sandbox porté par `RunStarted`) : colonne additive `instance_config`, précédence
 `stored → env (PDO_SANDBOX_IMAGE_SOURCE) → default(registry)` (ADR-0015), éditable dans la Settings
-UI. _Éviter_ : « mode registry » (le mode = off/copy/pure), « image_source par run ».
+UI. _Éviter_ : « mode registry » (le mode = off/minimal/full), « image_source par run ».
 
 **`registry_image_ref` / `ghcr.io/loulen/pdo-sandbox`** :
 Le ref GHCR de l'image publiée, `ghcr.io/loulen/pdo-sandbox:h-<hash>` — **même hash** que le ref
@@ -1048,7 +1064,7 @@ convergent), juste avant le gel du mode dans `RunStarted` (immuable, ADR-0030 pt
 « merge », « override », « fusion des modes ».
 
 **`default_sandbox` (défaut d'instance)** :
-Défaut du mode sandbox **par-daemon** : colonne **nullable** `instance_config` (`off`/`copy`/`pure`,
+Défaut du mode sandbox **par-daemon** : colonne **nullable** `instance_config` (`off`/`minimal`/`full`,
 `""` = sentinelle clear → NULL). Résolveur `default_sandbox_with` (`stored → env(`PDO_DEFAULT_SANDBOX`)
 → default(`off`)`, ADR-0015), lu **frais** au bord et partagé par `create_run_inner` **et** `GET
 /settings` (0 drift #373, miroir exact d'`image_source`). Éditable dans la Settings UI (`<select>`).
@@ -1066,7 +1082,7 @@ Check de disponibilité host (`docker version`, exit 0 = disponible ; binaire ab
 `DOCKER_NOT_FOUND_MSG` ; daemon injoignable → message dédié). **TTL-cachée** (~10 s) par-daemon,
 surfacée sur `GET /settings` comme `sandbox_docker {available, reason, checked_at}` (pas un
 `settings_field` : aucun tier stored/env/default) à côté du knob `default_sandbox`, pour un **seul**
-fetch du modal. Affordance **advisory** : grise les options `copy`/`pure` du sélecteur tri-état et
+fetch du modal. Affordance **advisory** : grise les options `minimal`/`full` du sélecteur tri-état et
 clamp sur `off` ; le fail-fast du run-advance (ADR-0030 pt 4) reste le gate **autoritaire**. Passe par
 le seam `docker_cmd_override`. _Éviter_ : « Docker health », « sandbox available » (ambigu avec le
 mode), confondre avec `ensure_image`/`probe_state` (provisionnement/liveness par-Run).
@@ -1078,15 +1094,15 @@ mode), confondre avec `ensure_image`/`probe_state` (provisionnement/liveness par
 `NodeAutoCompleteObserved`), émis au chokepoint `append_event`, **jamais** pour un Run `off`. N'altère
 **pas** `status` (reste `running`). Échec → `RunFailed` (pas d'événement de prep dédié). L'UI du Run
 affiche une **bannière** « préparation du sandbox » tant que `pending`, plus un **badge** `sandbox :
-copy|pure` persistant. _Éviter_ : « statut preparing » (écarté, pas un état de la machine à statut) ;
+minimal|full` persistant. _Éviter_ : « statut preparing » (écarté, pas un état de la machine à statut) ;
 l'inférence client (écartée : faux positifs advance-détaché/#159).
 
 ### Relations
-- Une **Sandbox** `copy`/`pure` possède un **staging dir** (`~/.pdo/sandbox/<run-id>/`) contenant un
+- Une **Sandbox** `minimal`/`full` possède un **staging dir** (`~/.pdo/sandbox/<run-id>/`) contenant un
   **staged Claude home** (`claude-home/`) + un `.claude.json` sibling.
 - `prepare` seede → `merge_back` extrait les transcripts vers `~/.claude/projects/` → `teardown`
   supprime le staging dir.
-- Une **Sandbox** `copy`/`pure` s'exécute dans un **conteneur sandbox** (`pdo-sbx-<run-id>`)
+- Une **Sandbox** `minimal`/`full` s'exécute dans un **conteneur sandbox** (`pdo-sbx-<run-id>`)
   instancié depuis l'**image sandbox** `pdo-sandbox:h-<hash>` (garantie par `ensure_image`, #405) via
   `ensure_running` (#406) ; ses **identity mounts** rendent le chemin de travail identique
   hôte/conteneur (d'où le même dirname encodé pour `merge_back`), et toutes les tails y entrent par le
@@ -1101,8 +1117,8 @@ l'inférence client (écartée : faux positifs advance-détaché/#159).
   (`run_cost`) + stale (`stale_detector`) via le seam `transcripts_root` (staging si Run sandboxé
   vivant, `~/.claude/projects/` sinon) ; garde `ensure_ready`-ou-échec ajouté à `resume_run` (re-arme
   le conteneur après reboot hôte).
-- **Vérifié e2e (#409)** : le mode `copy` tourne le **même câblage mode-agnostique** que #407 (aucun
-  net-new run-advance) ; il ne diffère de `pure` que par le seed de `prepare` — deref des symlinks
+- **Vérifié e2e (#409)** : le mode `full` tourne le **même câblage mode-agnostique** que #407 (aucun
+  net-new run-advance) ; il ne diffère de `minimal` que par le seed de `prepare` — deref des symlinks
   **échappants** (les skills liés à `~/.agents` ne danglent plus), walk **best-effort**, et confiance
   `repo_root` mergée dans le `.claude.json` copié (D5). Aucune écriture de config ne revient vers
   l'hôte (`merge_back` reste jsonl-only). Couvert par unit + 4 tests layer-3 (`sandbox_tracer`) + le
@@ -1124,9 +1140,21 @@ l'inférence client (écartée : faux positifs advance-détaché/#159).
   `Option<SandboxMode>` (absent ≠ `off` explicite) ; `default_sandbox` colonne `instance_config`
   (résolveur `default_sandbox_with`, `stored → env → default(off)`) ; défaut par-Trigger colonne
   nullable `sandbox` (clearable `deserialize_double_option`, précédent #239). **Sonde Docker** advisory
-  (`GET /settings.sandbox_docker`, TTL-cachée) → grise `copy`/`pure` du sélecteur. **Visibilité prep**
+  (`GET /settings.sandbox_docker`, TTL-cachée) → grise `minimal`/`full` du sélecteur. **Visibilité prep**
   via événements additifs `SandboxPrepStarted`/`Ready` → `RunState.sandbox_prep` (badge + bannière).
   Testé layer-1 (résolveur pur) + unit (settings/probe) + FE (vitest) + FP-410 (L5, Docker réel).
+- **Réalisé (#426, ADR-0031 §1 + amendement ADR-0030 §1)** : **vocabulaire + plancher de garanties**.
+  Le tri-état est renommé `off` | `minimal` | `full`, **sans alias** de compatibilité (aucune valeur
+  persistée dans l'instance prod ni dev — les colonnes `default_sandbox`/`triggers.sandbox` n'y
+  existent même pas ; un alias n'aurait servi que des instances de validation jetables) ; un token
+  inconnu garde `parse() → None` et est désormais **loggé** aux trois décodeurs (projection
+  `RunStarted`, `default_sandbox_with`, tir de Trigger) — la dégradation va vers **moins**
+  d'isolation, elle ne doit pas être silencieuse. `prepare` tient le **plancher** dans les deux modes,
+  en deux phases (profil puis `enforce_staging_floor` mode-agnostique) : `minimal` est un bras de
+  `match` **vide**. Restent à livrer par les slices **profils** : le profil de staging lui-même (liste
+  nommée/éditable/sélectionnable, diff `disabled`/`extras`, défauts virtuels, gel dans `RunStarted`,
+  échec fort sur nom inconnu — ADR-0031 §2/§5/§6/§7), les **exceptions `$HOME`** (§3/§4, amendement
+  ADR-0030 §2/§3) et le réglage `dockerfile_path` (amendement ADR-0030 §5).
 - **Différé** : injection `/etc/passwd`+`/etc/group` pour uid hôte ≠ 1000 (sudo +
   Node `os.userInfo()`) (issue de suivi) ; auto-flip de la visibilité publique du package GHCR
   (non supporté par l'API → manuel one-time après la 1ʳᵉ release, #411).

--- a/crates/pdo-daemon/src/event_log.rs
+++ b/crates/pdo-daemon/src/event_log.rs
@@ -17,6 +17,7 @@
 use std::collections::{HashMap, HashSet};
 
 use serde::{Deserialize, Serialize};
+use tracing::warn;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EdgeInfo {
@@ -116,7 +117,7 @@ pub enum EventKind {
     RunRenamed,
     /// Informational (#410): a sandboxed Run's image is being prepared (pull/build)
     /// at the head of the detached prep task, before the first session spawns. Emitted
-    /// only on the create path and only when the resolved mode is `copy`/`pure` (the
+    /// only on the create path and only when the resolved mode is `full`/`minimal` (the
     /// `off` path stays byte-identical). Non-terminal: `status` stays `Running`, only
     /// `RunState::sandbox_prep` moves to `pending`. Wire form: `"sandbox_prep_started"`.
     SandboxPrepStarted,
@@ -194,19 +195,23 @@ impl RunStatus {
 /// path, so flipping the mode mid-life would break `claude --continue`.
 ///
 /// - `Off` — historical host execution (no Docker, byte-identical legacy launch);
-/// - `Copy` — sandboxed, staged Claude home seeded by copying an allowlist of the
-///   host `~/.claude`;
-/// - `Pure` — sandboxed, staged Claude home seeded with credentials + trust only.
+/// - `Full` — sandboxed, staged Claude home seeded by copying an allowlist of the
+///   host `~/.claude` (ex-`copy`, renamed in #426);
+/// - `Minimal` — sandboxed, staged Claude home seeded by the staging floor alone
+///   (ex-`pure`, renamed in #426).
 ///
-/// The wire form is exactly `off`/`copy`/`pure`. `Default` is `Off` so an absent
+/// The wire form is exactly `off`/`full`/`minimal`, with **no compatibility alias**
+/// for the old `copy`/`pure` tokens (ADR-0031 §1 + ADR-0030 amendment §1): an
+/// unknown token keeps yielding `None` from [`SandboxMode::parse`], which the
+/// resolvers treat as unset and now **log** (#426). `Default` is `Off` so an absent
 /// payload field (historical runs, bare-API creates) projects to the host path.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SandboxMode {
     #[default]
     Off,
-    Copy,
-    Pure,
+    Full,
+    Minimal,
 }
 
 impl SandboxMode {
@@ -222,13 +227,13 @@ impl SandboxMode {
         matches!(self, SandboxMode::Off)
     }
 
-    /// The exact wire form: `off`/`copy`/`pure`. Mirror of `ImageSource::as_str`;
+    /// The exact wire form: `off`/`full`/`minimal`. Mirror of `ImageSource::as_str`;
     /// consumed by `build_settings_view` and the enum validators (#410).
     pub fn as_str(self) -> &'static str {
         match self {
             SandboxMode::Off => "off",
-            SandboxMode::Copy => "copy",
-            SandboxMode::Pure => "pure",
+            SandboxMode::Full => "full",
+            SandboxMode::Minimal => "minimal",
         }
     }
 
@@ -238,8 +243,8 @@ impl SandboxMode {
     pub fn parse(s: &str) -> Option<SandboxMode> {
         match s.trim().to_ascii_lowercase().as_str() {
             "off" => Some(SandboxMode::Off),
-            "copy" => Some(SandboxMode::Copy),
-            "pure" => Some(SandboxMode::Pure),
+            "full" => Some(SandboxMode::Full),
+            "minimal" => Some(SandboxMode::Minimal),
             _ => None,
         }
     }
@@ -263,9 +268,19 @@ fn env_default_sandbox() -> Option<SandboxMode> {
 /// value is treated as unset (mirror of the `""` sentinel + PUT validator). SINGLE
 /// source shared by `create_run_inner` AND `build_settings_view` (0 drift, lesson #373).
 pub fn default_sandbox_with(stored: Option<String>) -> SandboxMode {
+    let stored = stored.filter(|s| !s.is_empty());
+    // #426: a stored token that no longer parses (a pre-rename `copy`/`pure` left in
+    // `instance_config`) silently demotes the whole instance to `off`. Say it out loud.
+    if let Some(raw) = stored.as_deref() {
+        if SandboxMode::parse(raw).is_none() {
+            warn!(
+                "stored default_sandbox `{raw}` is not a valid mode; falling back to the env/`off` \
+                 tier. `copy`/`pure` were renamed to `full`/`minimal` in #426, without alias."
+            );
+        }
+    }
     stored
         .as_deref()
-        .filter(|s| !s.is_empty())
         .and_then(SandboxMode::parse)
         .or_else(env_default_sandbox)
         .unwrap_or(SandboxMode::DEFAULT)
@@ -822,11 +837,21 @@ fn apply_run_event(state: &mut RunState, event: &Event) {
                 // #407: isolation mode, projected once and never mutated. Absent
                 // (or malformed) → the `Off` default (host path). Never panics —
                 // this applier runs before the transition guard.
-                if let Some(sandbox) = payload
-                    .get("sandbox")
-                    .and_then(|v| serde_json::from_value::<SandboxMode>(v.clone()).ok())
-                {
-                    state.sandbox = sandbox;
+                match payload.get("sandbox") {
+                    None => {}
+                    Some(raw) => match serde_json::from_value::<SandboxMode>(raw.clone()) {
+                        Ok(sandbox) => state.sandbox = sandbox,
+                        // #426: the rename dropped `copy`/`pure` with no alias, and the
+                        // degradation goes toward LESS isolation (`Off` → host bash in
+                        // `run-shell`, `cleanup_run` skipping `merge_back`/`teardown`,
+                        // cost reading the wrong transcripts root). Silent is not an
+                        // option: ADR-0030 pt 4 forbids an unlogged host fallback.
+                        Err(_) => warn!(
+                            "run_started carries an unreadable `sandbox` value ({raw}); \
+                             projecting `off` (host path). \
+                             `copy`/`pure` were renamed to `full`/`minimal` in #426, without alias."
+                        ),
+                    },
                 }
                 if let Some(sb) = payload.get("source_branch").and_then(|v| v.as_str()) {
                     state.source_branch = Some(sb.to_string());
@@ -940,7 +965,7 @@ fn apply_run_event(state: &mut RunState, event: &Event) {
             state.end_node = None;
         }
         // #410: additive image-prep visibility. Non-terminal — `status` untouched,
-        // only `sandbox_prep` moves. Emitted only for a sandboxed create (`copy`/`pure`);
+        // only `sandbox_prep` moves. Emitted only for a sandboxed create (`full`/`minimal`);
         // `off`/historical runs never carry these, so the field stays `None`.
         EventKind::SandboxPrepStarted => {
             state.sandbox_prep = Some(SandboxPrepState::Pending);
@@ -1654,11 +1679,11 @@ mod tests {
     // -- Slice A (#410): precedence resolver + instance-default helper ---------
 
     #[test]
-    fn explicit_off_beats_copy_default() {
-        // The bug #410 exists to fix: an explicit `off` must survive a `copy`/`pure`
+    fn explicit_off_beats_full_default() {
+        // The bug #410 exists to fix: an explicit `off` must survive a `full`/`minimal`
         // instance default — otherwise the default could never be overridden downward.
         assert_eq!(
-            effective_sandbox(Some(SandboxMode::Off), None, SandboxMode::Copy),
+            effective_sandbox(Some(SandboxMode::Off), None, SandboxMode::Full),
             SandboxMode::Off
         );
     }
@@ -1667,23 +1692,23 @@ mod tests {
     fn explicit_wins_over_trigger_and_default() {
         assert_eq!(
             effective_sandbox(
-                Some(SandboxMode::Pure),
-                Some(SandboxMode::Copy),
+                Some(SandboxMode::Minimal),
+                Some(SandboxMode::Full),
                 SandboxMode::Off
             ),
-            SandboxMode::Pure
+            SandboxMode::Minimal
         );
     }
 
     #[test]
     fn trigger_used_when_no_explicit() {
         assert_eq!(
-            effective_sandbox(None, Some(SandboxMode::Pure), SandboxMode::Off),
-            SandboxMode::Pure
+            effective_sandbox(None, Some(SandboxMode::Minimal), SandboxMode::Off),
+            SandboxMode::Minimal
         );
-        // A trigger's explicit `off` also stands over a `copy` instance default.
+        // A trigger's explicit `off` also stands over a `full` instance default.
         assert_eq!(
-            effective_sandbox(None, Some(SandboxMode::Off), SandboxMode::Copy),
+            effective_sandbox(None, Some(SandboxMode::Off), SandboxMode::Full),
             SandboxMode::Off
         );
     }
@@ -1691,8 +1716,8 @@ mod tests {
     #[test]
     fn all_none_falls_to_instance_default() {
         assert_eq!(
-            effective_sandbox(None, None, SandboxMode::Copy),
-            SandboxMode::Copy
+            effective_sandbox(None, None, SandboxMode::Full),
+            SandboxMode::Full
         );
         assert_eq!(
             effective_sandbox(None, None, SandboxMode::DEFAULT),
@@ -1703,8 +1728,11 @@ mod tests {
     #[test]
     fn default_sandbox_with_precedence() {
         // stored valid wins.
-        assert_eq!(default_sandbox_with(Some("pure".into())), SandboxMode::Pure);
-        assert_eq!(default_sandbox_with(Some("copy".into())), SandboxMode::Copy);
+        assert_eq!(
+            default_sandbox_with(Some("minimal".into())),
+            SandboxMode::Minimal
+        );
+        assert_eq!(default_sandbox_with(Some("full".into())), SandboxMode::Full);
         // empty sentinel → unset → default (Off) (env not set in this harness).
         assert_eq!(default_sandbox_with(Some(String::new())), SandboxMode::Off);
         // garbage → unset → default.
@@ -1718,12 +1746,32 @@ mod tests {
 
     #[test]
     fn sandbox_mode_parse_and_as_str_round_trip() {
-        for mode in [SandboxMode::Off, SandboxMode::Copy, SandboxMode::Pure] {
+        for mode in [SandboxMode::Off, SandboxMode::Full, SandboxMode::Minimal] {
             assert_eq!(SandboxMode::parse(mode.as_str()), Some(mode));
         }
         // case / whitespace tolerant, rejects unknown.
-        assert_eq!(SandboxMode::parse("  PURE "), Some(SandboxMode::Pure));
+        assert_eq!(SandboxMode::parse("  MINIMAL "), Some(SandboxMode::Minimal));
         assert_eq!(SandboxMode::parse("nope"), None);
+        // #426: the rename ships with NO compatibility alias — the pre-rename
+        // tokens are plain unknown tokens now.
+        assert_eq!(SandboxMode::parse("copy"), None);
+        assert_eq!(SandboxMode::parse("pure"), None);
+    }
+
+    /// #426: a pre-rename `copy`/`pure` in a persisted `RunStarted` degrades to
+    /// `Off` — the host path. The degradation is DELIBERATE (no alias, ADR-0031 §1)
+    /// but it goes toward LESS isolation, so `apply_run_event` logs it. This test
+    /// pins the choice so nobody "fixes" it into an alias by accident.
+    #[test]
+    fn run_started_with_a_pre_rename_sandbox_token_projects_off() {
+        let events = vec![make_event_with_payload(
+            EventKind::RunStarted,
+            None,
+            serde_json::json!({ "pipeline_name": "p", "sandbox": "copy" }),
+        )];
+        let state = project(&events).unwrap();
+        assert_eq!(state.sandbox, SandboxMode::Off);
+        assert_eq!(state.sandbox_prep, None);
     }
 
     // -- Slice E (#410): sandbox-prep projection ------------------------------
@@ -1734,7 +1782,7 @@ mod tests {
             make_event_with_payload(
                 EventKind::RunStarted,
                 None,
-                serde_json::json!({ "pipeline_name": "p", "sandbox": "pure" }),
+                serde_json::json!({ "pipeline_name": "p", "sandbox": "minimal" }),
             ),
             make_event(EventKind::SandboxPrepStarted, None, None),
         ];

--- a/crates/pdo-daemon/src/instance_config.rs
+++ b/crates/pdo-daemon/src/instance_config.rs
@@ -49,7 +49,7 @@ pub struct InstanceConfig {
     /// SQL `NULL` so it never wins precedence. The resolver
     /// ([`crate::sandbox_image::image_source_with`]) owns the precedence.
     pub image_source: Option<String>,
-    /// Stored instance-wide default sandbox mode (`"off"` | `"copy"` | `"pure"`), or
+    /// Stored instance-wide default sandbox mode (`"off"` | `"full"` | `"minimal"`), or
     /// `None` when unset (#410). `None` falls through to the env seam
     /// ([`crate::event_log::DEFAULT_SANDBOX_ENV`]) then the built-in default (`off`,
     /// the byte-identical host path). `Some("")` is the clear sentinel — [`update`]
@@ -497,17 +497,17 @@ mod tests {
         let updated = update(
             &db,
             UpdateInstanceConfig {
-                default_sandbox: Some("pure".to_string()),
+                default_sandbox: Some("minimal".to_string()),
                 ..Default::default()
             },
         )
         .await
         .unwrap();
-        assert_eq!(updated.default_sandbox.as_deref(), Some("pure"));
+        assert_eq!(updated.default_sandbox.as_deref(), Some("minimal"));
         // A re-read confirms persistence (not just the returned row).
         assert_eq!(
             get(&db).await.unwrap().default_sandbox.as_deref(),
-            Some("pure")
+            Some("minimal")
         );
         // Sibling knobs stay untouched.
         assert_eq!(updated.image_source, None);
@@ -521,7 +521,7 @@ mod tests {
         update(
             &db,
             UpdateInstanceConfig {
-                default_sandbox: Some("pure".to_string()),
+                default_sandbox: Some("minimal".to_string()),
                 ..Default::default()
             },
         )
@@ -550,13 +550,13 @@ mod tests {
         let updated = update(
             &db,
             UpdateInstanceConfig {
-                default_sandbox: Some("copy".to_string()),
+                default_sandbox: Some("full".to_string()),
                 ..Default::default()
             },
         )
         .await
         .unwrap();
-        assert_eq!(updated.default_sandbox.as_deref(), Some("copy"));
+        assert_eq!(updated.default_sandbox.as_deref(), Some("full"));
     }
 
     #[tokio::test]
@@ -603,13 +603,13 @@ mod tests {
         let updated = update(
             &db,
             UpdateInstanceConfig {
-                default_sandbox: Some("pure".to_string()),
+                default_sandbox: Some("minimal".to_string()),
                 ..Default::default()
             },
         )
         .await
         .unwrap();
-        assert_eq!(updated.default_sandbox.as_deref(), Some("pure"));
+        assert_eq!(updated.default_sandbox.as_deref(), Some("minimal"));
     }
 
     #[tokio::test]

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -290,7 +290,7 @@ struct AppState {
     service_health: Arc<ServiceHealth>,
     /// TTL cache (~10 s) of the Docker availability probe (#410), surfaced as
     /// `sandbox_docker` on `GET /settings` so the NewRunModal can gray out
-    /// `copy`/`pure` when Docker is unreachable. Lazily refreshed by
+    /// `full`/`minimal` when Docker is unreachable. Lazily refreshed by
     /// `build_settings_view` when stale — never boot-once (a user may start Docker
     /// mid-session) and never per-fetch (a `PUT` of an unrelated knob would pay a
     /// docker round-trip). The refresh runs under `spawn_blocking` + a short
@@ -2077,7 +2077,7 @@ struct CreateTriggerRequest {
     /// unbounded. Inert unless `overlap_policy == "allow"`.
     #[serde(default)]
     max_concurrent: Option<i64>,
-    /// Per-Trigger sandbox mode (#410): `"off"` | `"copy"` | `"pure"`, or absent/`null`
+    /// Per-Trigger sandbox mode (#410): `"off"` | `"full"` | `"minimal"`, or absent/`null`
     /// to inherit the instance default. Read at fire time and folded into the create
     /// request's explicit tier.
     #[serde(default)]
@@ -2094,7 +2094,7 @@ fn default_overlap_policy() -> String {
 fn validate_trigger_sandbox(v: Option<&str>) -> Result<(), &'static str> {
     match v {
         Some(s) if event_log::SandboxMode::parse(s).is_none() => {
-            Err("sandbox must be `off`, `copy`, or `pure`")
+            Err("sandbox must be `off`, `full`, or `minimal`")
         }
         _ => Ok(()),
     }
@@ -3744,11 +3744,21 @@ async fn fire_one_trigger(
                 // run-level choice), so this is the sole non-`None` tier here; the
                 // chokepoint's `effective_sandbox(req.sandbox, None, default)` then
                 // resolves it against the instance default. A `None`/unparseable
-                // stored mode defers to the instance default.
-                sandbox: trigger
-                    .sandbox
-                    .as_deref()
-                    .and_then(event_log::SandboxMode::parse),
+                // stored mode defers to the instance default. #426: an unparseable
+                // stored mode is logged — the rename dropped `copy`/`pure` with no
+                // alias, and the degradation goes toward LESS isolation.
+                sandbox: trigger.sandbox.as_deref().and_then(|raw| {
+                    let parsed = event_log::SandboxMode::parse(raw);
+                    if parsed.is_none() {
+                        warn!(
+                            "trigger {} carries an unreadable `sandbox` value ({raw}); deferring to \
+                             the instance default. `copy`/`pure` were renamed to `full`/`minimal` \
+                             in #426, without alias.",
+                            trigger.id
+                        );
+                    }
+                    parsed
+                }),
             };
             let record = match create_run_inner(state, req, Vec::new()).await {
                 Ok(run_id) => trigger_store::FireRecord {
@@ -6224,8 +6234,8 @@ fn settings_field_enum(
 
 /// TTL of the Docker availability probe cache (#410). ~10 s: long enough that a
 /// burst of `/settings` fetches (modal open, a `PUT`) pays at most one docker
-/// round-trip, short enough that a user who starts Docker mid-session sees `copy`/
-/// `pure` un-gray within seconds.
+/// round-trip, short enough that a user who starts Docker mid-session sees `full`/
+/// `minimal` un-gray within seconds.
 const DOCKER_PROBE_TTL: Duration = Duration::from_secs(10);
 /// Hard cap on how long the probe may block the `/settings` response (#410). A cold
 /// or wedged Docker daemon must never hang the settings page — on timeout we report
@@ -6373,7 +6383,7 @@ async fn build_settings_view(state: &AppState) -> Result<serde_json::Value, sqlx
     // --- advisory Docker availability probe (#410) ---
     // Folded into `GET /settings` (NOT a settings_field: no stored/env/default tier)
     // so the modal learns the default AND whether Docker can run a sandbox in ONE
-    // fetch. Advisory: it grays out `copy`/`pure`, but the run-advance fail-fast
+    // fetch. Advisory: it grays out `full`/`minimal`, but the run-advance fail-fast
     // (ADR-0030 pt 4) stays the authoritative gate.
     let docker_probe = docker_probe_cached(state).await;
 
@@ -6462,7 +6472,7 @@ async fn put_settings(
         // "" = clear sentinel (accepted, normalised to NULL by `update`); any other
         // non-variant → 400 (fail-fast, no silent default) (#410).
         if !s.is_empty() && event_log::SandboxMode::parse(s).is_none() {
-            return bad("default_sandbox must be `off`, `copy`, or `pure`");
+            return bad("default_sandbox must be `off`, `full`, or `minimal`");
         }
     }
 
@@ -13951,7 +13961,7 @@ mod tests {
         // `docker rm -f` → `true` (no-op), so no real docker is ever spawned.
         let state = test_state_with_dir_and_docker(tmp.path(), Some("true".to_string())).await;
 
-        // Seed a sandboxed (`copy`) run: RunStarted projects `sandbox=copy`.
+        // Seed a sandboxed (`full`) run: RunStarted projects `sandbox=full`.
         append_event_with(
             &state.db,
             &state.event_tx,
@@ -13965,7 +13975,7 @@ mod tests {
                 payload: Some(serde_json::json!({
                     "pipeline_name": "sbx-obs",
                     "input": "x",
-                    "sandbox": "copy",
+                    "sandbox": "full",
                 })),
             },
         )
@@ -22926,17 +22936,17 @@ edges:
         // Stored always wins over env/default, so the effective/source assertions are
         // race-free (mirror of image_source, #411).
         let state = test_state().await;
-        let (status, view) = put_settings_resp(&state, r#"{"default_sandbox": "pure"}"#).await;
+        let (status, view) = put_settings_resp(&state, r#"{"default_sandbox": "minimal"}"#).await;
         assert_eq!(status, StatusCode::OK);
-        assert_eq!(view["default_sandbox"]["stored"], "pure");
+        assert_eq!(view["default_sandbox"]["stored"], "minimal");
         assert_eq!(view["default_sandbox"]["source"], "stored");
-        assert_eq!(view["default_sandbox"]["effective"], "pure");
+        assert_eq!(view["default_sandbox"]["effective"], "minimal");
         assert_eq!(view["default_sandbox"]["default"], "off");
 
         // Re-GET confirms persistence.
         let reget = get_settings_json(&state).await;
-        assert_eq!(reget["default_sandbox"]["stored"], "pure");
-        assert_eq!(reget["default_sandbox"]["effective"], "pure");
+        assert_eq!(reget["default_sandbox"]["stored"], "minimal");
+        assert_eq!(reget["default_sandbox"]["effective"], "minimal");
     }
 
     #[tokio::test]
@@ -22944,7 +22954,7 @@ edges:
         // "" is the clear sentinel: accepted (not 400), resets the stored tier to null
         // so the resolver falls back to the built-in default `off` (#410).
         let state = test_state().await;
-        put_settings_resp(&state, r#"{"default_sandbox": "pure"}"#).await;
+        put_settings_resp(&state, r#"{"default_sandbox": "minimal"}"#).await;
         let (status, view) = put_settings_resp(&state, r#"{"default_sandbox": ""}"#).await;
         assert_eq!(
             status,

--- a/crates/pdo-daemon/src/sandbox_image.rs
+++ b/crates/pdo-daemon/src/sandbox_image.rs
@@ -49,7 +49,7 @@ pub(crate) const DOCKER_NOT_FOUND_MSG: &str =
      install Docker or set this run's sandbox to `off`";
 
 /// Message when the `docker` binary IS present but its daemon is unreachable (#410).
-/// The precise reason the availability probe grays out `copy`/`pure` in the UI. This
+/// The precise reason the availability probe grays out `full`/`minimal` in the UI. This
 /// case and `DOCKER_NOT_FOUND_MSG` both collapse to `available: false` — no action is
 /// gated on the distinction (the probe is advisory; the run-advance fail-fast, ADR-0030
 /// pt 4, stays the authoritative gate) — so the cause survives only in `reason`.
@@ -59,7 +59,7 @@ pub(crate) const DOCKER_DAEMON_UNREACHABLE_MSG: &str =
 
 /// Advisory availability of a usable Docker for sandboxed Runs (#410). `available`
 /// gates nothing on its own (the run-advance fail-fast is authoritative); it drives
-/// the NewRunModal's greying of `copy`/`pure`. `reason` carries the human-readable
+/// the NewRunModal's greying of `full`/`minimal`. `reason` carries the human-readable
 /// cause when unavailable (one of the two messages above), `None` when available.
 #[derive(Debug, Clone)]
 pub(crate) struct DockerProbe {

--- a/crates/pdo-daemon/src/sandbox_run.rs
+++ b/crates/pdo-daemon/src/sandbox_run.rs
@@ -44,8 +44,9 @@ pub(crate) struct SandboxContext {
     /// Effective repo root — bind-mounted rw at its host path. One mount covers
     /// the repo + every node sub-worktree under `.pdo/runs/` + `.pdo/prompts`.
     pub(crate) repo_root: PathBuf,
-    /// The Run's pipeline worktree (`-w` cosmetic at create; the `pure` trust
-    /// dialog is seeded on `repo_root`, the common ancestor of every worktree).
+    /// The Run's pipeline worktree (`-w` cosmetic at create; the trust dialog is
+    /// seeded by the staging floor on `repo_root`, the common ancestor of every
+    /// worktree, in BOTH sandboxed modes — #426).
     pub(crate) run_worktree: PathBuf,
     pub(crate) daemon_port: u16,
     /// Host `$HOME` — source of `.claude` for `prepare`.
@@ -71,8 +72,8 @@ impl SandboxContext {
     fn staging_mode(&self) -> Option<sandbox_staging::Mode> {
         match self.mode {
             SandboxMode::Off => None,
-            SandboxMode::Copy => Some(sandbox_staging::Mode::Copy),
-            SandboxMode::Pure => Some(sandbox_staging::Mode::Pure),
+            SandboxMode::Full => Some(sandbox_staging::Mode::Full),
+            SandboxMode::Minimal => Some(sandbox_staging::Mode::Minimal),
         }
     }
 }
@@ -221,17 +222,20 @@ pub(crate) fn ensure_ready(ctx: &SandboxContext) -> Result<()> {
         return Ok(()); // off: gated by callers; no docker touched.
     };
 
-    // 1. Stage the Claude home ONCE. The ~1 GB `copy` walk (and the `pure` seed)
-    //    must not repeat on every ensure_ready — gate on the staging dir already
-    //    existing. BOTH sandboxed modes pre-approve the trust dialog on `repo_root`,
-    //    the common ancestor of the pipeline worktree AND every node sub-worktree:
-    //    `pure` writes a minimal `.claude.json`; `copy` (#409, D5) merges the trust
-    //    into the copied host `.claude.json` (else a repo the host never opened
-    //    would block an autonomous Run on the "trust this folder?" dialog).
+    // 1. Stage the Claude home ONCE. The ~1 GB `full` walk must not repeat on
+    //    every ensure_ready — gate on the staging dir already existing.
+    //    `prepare` then holds the **staging floor** (#426, ADR-0031 §1) in BOTH
+    //    sandboxed modes, mode-agnostically: valid credentials, the org managed-
+    //    settings baseline, the accepted permissions bypass, trust pre-granted on
+    //    `repo_root` (the common ancestor of the pipeline worktree AND every node
+    //    sub-worktree), and an empty `projects/` sink. Each guarantee is met either
+    //    by a copy of the host file or by a fallback synthesis — which is why an
+    //    autonomous Run never blocks on the "trust this folder?", "managed settings
+    //    require approval" or bypass-permissions dialogs.
     let staging_dir = sandbox_staging::staging_dir_for_run(&ctx.sandbox_root, &ctx.run_id);
     if !staging_dir.exists() {
         let trusted_root = match ctx.mode {
-            SandboxMode::Pure | SandboxMode::Copy => Some(ctx.repo_root.as_path()),
+            SandboxMode::Minimal | SandboxMode::Full => Some(ctx.repo_root.as_path()),
             SandboxMode::Off => None,
         };
         sandbox_staging::prepare(
@@ -423,16 +427,17 @@ mod tests {
     fn ensure_ready_stages_probes_image_and_container() {
         let tmp = tempfile::tempdir().unwrap();
         let (docker, log) = write_fake_docker(tmp.path());
-        let ctx = test_ctx(tmp.path(), docker, SandboxMode::Pure);
+        let ctx = test_ctx(tmp.path(), docker, SandboxMode::Minimal);
 
         retry_etxtbsy(|| ensure_ready(&ctx)).unwrap();
 
-        // Staging seeded (pure → credentials + .claude.json + empty projects/).
+        // Staging seeded (minimal → floor only: credentials, remote-settings,
+        // settings.json, .claude.json, empty projects/).
         let staging = sandbox_staging::staging_dir_for_run(&ctx.sandbox_root, "r1");
         assert!(staging.exists(), "staging dir must be created");
         assert!(
             sandbox_staging::staged_claude_json(&ctx.sandbox_root, "r1").is_file(),
-            "pure staging writes a .claude.json"
+            "minimal staging writes a .claude.json"
         );
         // Docker was probed for image + container (present → no build/create).
         let lines = log_lines(&log);
@@ -467,7 +472,7 @@ mod tests {
     fn ensure_ready_does_not_restage_when_present() {
         let tmp = tempfile::tempdir().unwrap();
         let (docker, _) = write_fake_docker(tmp.path());
-        let ctx = test_ctx(tmp.path(), docker, SandboxMode::Pure);
+        let ctx = test_ctx(tmp.path(), docker, SandboxMode::Minimal);
 
         retry_etxtbsy(|| ensure_ready(&ctx)).unwrap();
         // Drop a sentinel into the staging dir; a second ensure_ready must NOT
@@ -484,25 +489,38 @@ mod tests {
     }
 
     #[test]
-    fn ensure_ready_copy_seeds_trust_for_repo_root() {
+    fn ensure_ready_full_seeds_trust_for_repo_root() {
         let tmp = tempfile::tempdir().unwrap();
         let (docker, _log) = write_fake_docker(tmp.path());
-        let ctx = test_ctx(tmp.path(), docker, SandboxMode::Copy);
+        let ctx = test_ctx(tmp.path(), docker, SandboxMode::Full);
 
         retry_etxtbsy(|| ensure_ready(&ctx)).unwrap();
 
-        // #409 D5: copy stages a `.claude.json`, and ensure_ready pre-approves the
+        // #409 D5: full stages a `.claude.json`, and ensure_ready pre-approves the
         // Run's repo_root trust dialog in it — even when the host had no
         // `.claude.json` (an autonomous Run must not block on "trust this folder?").
         let staged = sandbox_staging::staged_claude_json(&ctx.sandbox_root, "r1");
-        assert!(staged.is_file(), "copy staging writes a .claude.json");
+        assert!(staged.is_file(), "full staging writes a .claude.json");
         let json: serde_json::Value =
             serde_json::from_str(&std::fs::read_to_string(&staged).unwrap()).unwrap();
         let key = ctx.repo_root.to_string_lossy().into_owned();
         assert_eq!(
             json["projects"][&key]["hasTrustDialogAccepted"],
             serde_json::json!(true),
-            "copy must pre-approve the repo_root trust dialog: {json}"
+            "full must pre-approve the repo_root trust dialog: {json}"
+        );
+
+        // #426: the staging floor runs through the REAL caller, not just a direct
+        // `prepare` call. `test_ctx`'s home carries credentials only, so G3 lands on
+        // its synthesis branch.
+        let staged_settings =
+            sandbox_staging::staged_claude_home(&ctx.sandbox_root, "r1").join("settings.json");
+        let settings: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&staged_settings).unwrap()).unwrap();
+        assert_eq!(
+            settings["skipDangerousModePermissionPrompt"],
+            serde_json::json!(true),
+            "ensure_ready must hold the staging floor: {settings}"
         );
     }
 
@@ -545,11 +563,11 @@ mod tests {
     }
 
     #[test]
-    fn kill_session_pure_execs_marker() {
+    fn kill_session_minimal_execs_marker() {
         let tmp = tempfile::tempdir().unwrap();
         let (docker, log) = write_fake_docker(tmp.path());
         let logged = retry_side_effect(
-            || kill_session_best_effort(&docker, SandboxMode::Pure, "r1", "pdo-r1-n1-iter-1"),
+            || kill_session_best_effort(&docker, SandboxMode::Minimal, "r1", "pdo-r1-n1-iter-1"),
             || {
                 let l = log_lines(&log);
                 !l.is_empty()
@@ -626,12 +644,12 @@ mod tests {
         // Staging present → live/reapable Run → read the staged home.
         std::fs::create_dir_all(sandbox_staging::staging_dir_for_run(&sandbox_root, "r1")).unwrap();
         assert_eq!(
-            transcripts_root(SandboxMode::Pure, "r1", &home, &sandbox_root),
+            transcripts_root(SandboxMode::Minimal, "r1", &home, &sandbox_root),
             sandbox_staging::staged_claude_home(&sandbox_root, "r1").join("projects")
         );
-        // `copy` behaves identically.
+        // `full` behaves identically.
         assert_eq!(
-            transcripts_root(SandboxMode::Copy, "r1", &home, &sandbox_root),
+            transcripts_root(SandboxMode::Full, "r1", &home, &sandbox_root),
             sandbox_staging::staged_claude_home(&sandbox_root, "r1").join("projects")
         );
     }
@@ -645,7 +663,7 @@ mod tests {
         // flushed. Keyed on staging EXISTENCE, not the Run's terminal status.
         assert!(!sandbox_staging::staging_dir_for_run(&sandbox_root, "r1").exists());
         assert_eq!(
-            transcripts_root(SandboxMode::Pure, "r1", &home, &sandbox_root),
+            transcripts_root(SandboxMode::Minimal, "r1", &home, &sandbox_root),
             home.join(".claude").join("projects")
         );
     }
@@ -664,12 +682,12 @@ mod tests {
         let enc = crate::stale_detector::encode_working_dir(cwd);
 
         // Host arm (no staging).
-        let host = transcripts_root(SandboxMode::Pure, "r1", &home, &sandbox_root);
+        let host = transcripts_root(SandboxMode::Minimal, "r1", &home, &sandbox_root);
         assert_eq!(host.join(&enc), home.join(".claude/projects").join(&enc));
 
         // Staging arm (staging materialised) — same encoded segment appended.
         std::fs::create_dir_all(sandbox_staging::staging_dir_for_run(&sandbox_root, "r1")).unwrap();
-        let staged = transcripts_root(SandboxMode::Pure, "r1", &home, &sandbox_root);
+        let staged = transcripts_root(SandboxMode::Minimal, "r1", &home, &sandbox_root);
         assert_eq!(
             staged.join(&enc),
             sandbox_staging::staged_claude_home(&sandbox_root, "r1")

--- a/crates/pdo-daemon/src/sandbox_staging.rs
+++ b/crates/pdo-daemon/src/sandbox_staging.rs
@@ -14,7 +14,7 @@
 //!   stale-detection/coût vers le staging (seam [`crate::sandbox_run::transcripts_root`]).
 //!
 //! ## Décisions de conception (voir la section « Sandbox » de `CONTEXT.md`)
-//! - **`copy` = allowlist, jamais denylist.** Copier « tout `~/.claude` sauf
+//! - **`full` = allowlist, jamais denylist.** Copier « tout `~/.claude` sauf
 //!   `projects/` » embarquerait tout l'état hôte transitoire (`history.jsonl`,
 //!   `session-env/`, `file-history/`…) — fuite d'isolation + fragile aux futures
 //!   versions de Claude Code. On copie une liste explicite.
@@ -33,9 +33,14 @@
 //!   `projects/<enc>/<uuid>/subagents/*.jsonl` (profondeur 9). Le copy-set doit
 //!   *égaler* le read-set de [`crate::run_cost`] (`collect_jsonl_recursive`),
 //!   sinon le coût des runs sandboxés est sous-estimé (régression silencieuse).
-//! - **`pure` seede la confiance.** `{"hasCompletedOnboarding":true}` seul
-//!   désarme l'onboarding mais PAS le dialogue « trust this folder ? » — un agent
-//!   non surveillé se bloquerait. On pré-approuve la racine du Run.
+//! - **Le plancher de staging est mode-agnostique** (#426, ADR-0031 §1).
+//!   [`prepare`] est en **deux phases** : matérialisation du profil (ce que `full`
+//!   apporte en plus), puis [`enforce_staging_floor`] qui tient **cinq garanties**
+//!   dans les deux modes — chacune satisfaite soit par une copie de l'hôte, soit
+//!   par une synthèse de repli. `minimal` est donc un **bras de `match` vide** :
+//!   `minimal`, c'est exactement le plancher. Les trois garanties qui désarment un
+//!   dialogue bloquant (confiance, managed settings de l'org, bypass permissions)
+//!   ne sont pas cosmétiques : un agent non surveillé se figerait dessus.
 
 // #408: `merge_back` is now wired; the rest of the module (path-math + effects)
 // is consumed by #406/#407.
@@ -44,27 +49,50 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use anyhow::{Context, Result};
-use tracing::warn;
+use tracing::{info, warn};
 
 /// Comment le *staged Claude home* d'un Run est seedé. `off` (PRD) n'est PAS une
 /// variante : le caller skippe simplement [`prepare`] (pas de branche no-op dans
-/// la couche fs).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "lowercase")]
+/// la couche fs). Interne au daemon : jamais sérialisé (le tri-état wire/persisté
+/// est [`crate::event_log::SandboxMode`]) — d'où l'absence de derive serde.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Mode {
-    Copy,
-    Pure,
+    /// Réplique de l'hôte : allowlist de `~/.claude` + `~/.claude.json` verbatim.
+    Full,
+    /// Rien en propre — `minimal` **est** le plancher ([`enforce_staging_floor`]).
+    Minimal,
 }
 
-/// Fichiers de config top-level de `~/.claude` recopiés en mode `copy` (en plus
+/// Fichiers de config top-level de `~/.claude` recopiés en mode `full` (en plus
 /// des `*.md` captés par glob). `.credentials.json` préserve son mode 0600 via
 /// [`std::fs::copy`].
-const COPY_ALLOWLIST_FILES: &[&str] =
+///
+/// N.B. [`REMOTE_SETTINGS_FILE`] n'y est **pas** : le plancher en est le writer
+/// unique, dans les deux modes (#426). L'y ajouter donnerait, à la slice
+/// « profils », une entrée décochable que le plancher réinjecterait aussitôt.
+const FULL_ALLOWLIST_FILES: &[&str] =
     &["settings.json", "settings.local.json", ".credentials.json"];
 
-/// Dossiers de `~/.claude` recopiés en mode `copy` (walk préservant symlinks +
+/// Dossiers de `~/.claude` recopiés en mode `full` (walk préservant symlinks +
 /// bits exécutables). `projects/` est délibérément absent : jamais copié.
-const COPY_ALLOWLIST_DIRS: &[&str] = &["skills", "plugins", "agents", "commands", "output-styles"];
+const FULL_ALLOWLIST_DIRS: &[&str] = &["skills", "plugins", "agents", "commands", "output-styles"];
+
+/// Baseline de managed settings poussée par l'organisation, cachée par Claude Code
+/// dans `~/.claude/`. Garantie G2 : recopiée dans les **deux** modes, jamais via
+/// [`FULL_ALLOWLIST_FILES`]. Sans elle, la session bute sur le dialogue
+/// « managed settings require approval » (le consentement est comparé au contenu
+/// de ce fichier) et un Run autonome reste planté.
+const REMOTE_SETTINGS_FILE: &str = "remote-settings.json";
+
+/// Le `settings.json` du home stagé — porteur de la garantie G3.
+const SETTINGS_FILE: &str = "settings.json";
+
+/// Clé top-level qui désarme le prompt de confirmation du
+/// `--dangerously-skip-permissions`. Garantie G3 : un agent non surveillé s'y
+/// bloque. Résolue par un **OU monotone** sur les tiers de settings, donc un
+/// `true` dans le `settings.json` stagé suffit — et un `false` hôte doit être
+/// **écrasé** (d'où `insert` et non `entry().or_insert()`).
+const BYPASS_PERMISSIONS_KEY: &str = "skipDangerousModePermissionPrompt";
 
 // -- path math (pur, sans IO) ------------------------------------------------
 
@@ -92,12 +120,24 @@ pub(crate) fn staged_claude_json(sandbox_root: &Path, run_id: &str) -> PathBuf {
 
 /// Seede le *staged Claude home* et renvoie sa racine (`<sandbox_root>/<run_id>`).
 ///
-/// Idempotent (`create_dir_all` ; copy-or-overwrite). `trusted_root` : racine à
-/// pré-approuver dans le `.claude.json`. En mode `pure`, `None` = objet nu. En
-/// mode `copy` (#409), une racine fournie est **mergée** dans le `.claude.json`
-/// hôte copié (les autres clés/projets préservés, 0600 réappliqué) — le repo du
-/// Run est ainsi trusté même si l'hôte ne l'avait jamais ouvert (sinon un Run
-/// autonome se bloquerait sur le dialogue « trust this folder ? »).
+/// **Deux phases** (#426, ADR-0031 §1) :
+/// 1. *matérialisation du profil* — ce que `full` apporte **en plus** ; `minimal`
+///    n'apporte rien en propre ;
+/// 2. *[`enforce_staging_floor`]* — mode-agnostique, tient les **cinq garanties**
+///    (credentials, managed settings de l'org, bypass permissions, confiance sur
+///    `trusted_root` + onboarding, `projects/` vide).
+///
+/// La phase 2 tourne **après** le match, jamais dedans : le plancher est un
+/// *check-then-repair* sur ce qui est effectivement posé sur disque (« satisfaite
+/// soit par une copie de l'hôte, soit par une synthèse de repli » n'est décidable
+/// qu'à ce moment-là). Le double write sur `settings.json` en `full` (copié par le
+/// profil, puis mergé par le plancher) est **voulu** : le plancher est merge-aware,
+/// il ne doit pas être mode-aware.
+///
+/// Idempotent (`create_dir_all` ; copy-or-overwrite ; merges non destructifs) et
+/// **additif** — jamais de suppression (ADR-0031 §6). `trusted_root` : racine à
+/// pré-approuver dans le `.claude.json` stagé ; `None` = pas de bloc `projects`
+/// (le reste du plancher est tenu quand même).
 pub(crate) fn prepare(
     home_root: &Path,
     sandbox_root: &Path,
@@ -111,58 +151,132 @@ pub(crate) fn prepare(
         .with_context(|| format!("create staged claude home {}", home.display()))?;
 
     let src = home_root.join(".claude");
+    let staged_json = staged_claude_json(sandbox_root, run_id);
 
+    // -- PHASE 1 : matérialisation du profil ---------------------------------
     match mode {
-        Mode::Copy => {
-            // Allowlist top-level : `*.md` (capte CLAUDE.md + imports siblings type
-            // RTK.md) + les fichiers de config nommés (0600 des creds préservé).
-            copy_top_level_md(&src, &home)?;
-            for name in COPY_ALLOWLIST_FILES {
-                copy_file_if_present(&src.join(name), &home.join(name))?;
-            }
-            // Allowlist dirs : walk préservant les symlinks intra-arbre + mode,
-            // déréférençant les liens échappants (#409). `projects/` EXCLU.
-            // `copy_root` = la racine canonique `~/.claude` : tout symlink dont la
-            // cible sort de cet arbre est copié déréférencé (sa cible réelle n'est
-            // ni copiée ni montée → danglerait). Best-effort par entrée.
-            let copy_root = std::fs::canonicalize(&src).unwrap_or_else(|_| src.clone());
-            for name in COPY_ALLOWLIST_DIRS {
-                let dir_src = src.join(name);
-                if dir_src.is_dir() {
-                    copy_tree_preserving(&dir_src, &home.join(name), &copy_root, 0);
-                }
-            }
-            // `.claude.json` sibling, verbatim (mode préservé). Chemin explicite :
-            // c'est un dotfile, un glob `*` sans dotglob le raterait.
-            copy_file_if_present(
-                &home_root.join(".claude.json"),
-                &staged_claude_json(sandbox_root, run_id),
-            )?;
-            // D5 (#409) : garantir que le repo du Run est trusté. `copy` s'appuie
-            // sur le `.claude.json` hôte, qui peut n'avoir jamais ouvert ce repo →
-            // Run autonome bloqué sur le dialogue de confiance. Merge non-destructif.
-            if let Some(root) = trusted_root {
-                seed_trust_in_claude_json(&staged_claude_json(sandbox_root, run_id), root)?;
-            }
-        }
-        Mode::Pure => {
-            // Auth = `.credentials.json` seul (`oauthAccount`/`userID` de
-            // `.claude.json` sont du cache profil PII inutile).
-            copy_file_if_present(
-                &src.join(".credentials.json"),
-                &home.join(".credentials.json"),
-            )?;
-            write_pure_claude_json(&staged_claude_json(sandbox_root, run_id), trusted_root)?;
-        }
+        Mode::Full => materialise_full(&src, home_root, &home, &staged_json)?,
+        // `minimal` EST le plancher : rien en propre, par construction.
+        Mode::Minimal => {}
     }
 
-    // Les deux modes : `projects/` créé VIDE (puits de transcripts runtime). Ni
+    // -- PHASE 2 : plancher, mode-agnostique --------------------------------
+    enforce_staging_floor(&src, &home, &staged_json, trusted_root)?;
+
+    Ok(staging)
+}
+
+/// Phase 1 du mode `full` : réplique de l'hôte (allowlist `~/.claude` +
+/// `~/.claude.json` verbatim). N'inclut **aucune** garantie du plancher — celui-ci
+/// tourne juste après, dans les deux modes.
+fn materialise_full(src: &Path, home_root: &Path, home: &Path, staged_json: &Path) -> Result<()> {
+    // Allowlist top-level : `*.md` (capte CLAUDE.md + imports siblings type
+    // RTK.md) + les fichiers de config nommés (0600 des creds préservé).
+    copy_top_level_md(src, home)?;
+    for name in FULL_ALLOWLIST_FILES {
+        copy_file_if_present(&src.join(name), &home.join(name))?;
+    }
+    // Allowlist dirs : walk préservant les symlinks intra-arbre + mode,
+    // déréférençant les liens échappants (#409). `projects/` EXCLU.
+    // `copy_root` = la racine canonique `~/.claude` : tout symlink dont la
+    // cible sort de cet arbre est copié déréférencé (sa cible réelle n'est
+    // ni copiée ni montée → danglerait). Best-effort par entrée.
+    let copy_root = std::fs::canonicalize(src).unwrap_or_else(|_| src.to_path_buf());
+    for name in FULL_ALLOWLIST_DIRS {
+        let dir_src = src.join(name);
+        if dir_src.is_dir() {
+            copy_tree_preserving(&dir_src, &home.join(name), &copy_root, 0);
+        }
+    }
+    // `.claude.json` sibling, verbatim (mode préservé). Chemin explicite :
+    // c'est un dotfile, un glob `*` sans dotglob le raterait. La confiance et
+    // l'onboarding y sont mergés ensuite par le plancher (G4).
+    copy_file_if_present(&home_root.join(".claude.json"), staged_json)?;
+    Ok(())
+}
+
+/// **Le plancher de staging** (#426, ADR-0031 §1) : les garanties que `prepare`
+/// tient dans les **deux** modes — et demain quel que soit le profil. Chacune est
+/// satisfaite soit par une **copie de l'hôte** (phase 1 ou ici), soit par une
+/// **synthèse de repli**. Écrit exclusivement dans le staging ; ne touche jamais
+/// l'hôte.
+///
+/// - **G1 credentials** — `.credentials.json` copié (0600 préservé par
+///   [`std::fs::copy`]). Absent hôte → no-op (l'auth échouera plus loin, ce n'est
+///   pas à `prepare` d'en juger).
+/// - **G2 managed settings de l'org** — [`REMOTE_SETTINGS_FILE`] copié verbatim.
+///   Absent hôte → `info!` + no-op (cas majoritaire : install sans org ; un `warn!`
+///   par Run entraînerait à ignorer les warnings). Présent mais copie en échec →
+///   erreur **dure** : c'est une surprise de conformité, pas un détail.
+/// - **G3 bypass permissions** — [`BYPASS_PERMISSIONS_KEY`] à `true` dans le
+///   `settings.json` stagé : **mergé** dans la copie hôte en `full`, **synthétisé**
+///   en `minimal`. Fichier corrompu/non-objet → `warn!` + remplacé (symétrie avec
+///   G4 : durcir ferait qu'un seul caractère malformé dans `~/.claude/settings.json`
+///   empêcherait **tout** Run sandboxé).
+/// - **G4 baseline `.claude.json`** — `hasCompletedOnboarding` (défaut défensif,
+///   `or_insert`) + confiance sur `trusted_root` si fournie, 0600 réappliqué.
+///   Inconditionnelle : `sandbox_container` monte ce chemin **toujours**, donc ne
+///   rien écrire laisserait Docker créer un *répertoire* par-dessus
+///   `$HOME/.claude.json`.
+/// - **G5 puits de transcripts** — `projects/` créé **vide**.
+///
+/// Politique d'écriture : **fail-fast**. `prepare` tourne avant l'existence du
+/// conteneur ; une garantie intenable doit échouer là, pas produire un Run qui pend
+/// sur un dialogue sans personne devant. Ni le best-effort de
+/// [`copy_tree_preserving`] (arbre de 1 Go volatil) ni l'avalage de
+/// [`copy_jsonl_tree`] (transition terminale, ADR-0023) ne s'appliquent ici.
+fn enforce_staging_floor(
+    src: &Path,
+    home: &Path,
+    staged_json: &Path,
+    trusted_root: Option<&Path>,
+) -> Result<()> {
+    // G1 — auth. En `minimal`, c'est la seule chose copiée de `~/.claude`
+    // (`oauthAccount`/`userID` de `.claude.json` sont du cache profil PII inutile).
+    copy_file_if_present(
+        &src.join(".credentials.json"),
+        &home.join(".credentials.json"),
+    )?;
+
+    // G2 — baseline de managed settings de l'org, writer UNIQUE (jamais l'allowlist).
+    let remote_src = src.join(REMOTE_SETTINGS_FILE);
+    if remote_src.exists() {
+        let remote_dst = home.join(REMOTE_SETTINGS_FILE);
+        std::fs::copy(&remote_src, &remote_dst).with_context(|| {
+            format!(
+                "stage org managed settings {} -> {}",
+                remote_src.display(),
+                remote_dst.display()
+            )
+        })?;
+    } else {
+        // Cas majoritaire (install sans organisation). `info!` et non `debug!` : le
+        // filtre par défaut du daemon est `pdo_daemon=info,info` (`main.rs`).
+        info!(
+            "sandbox staging: no {REMOTE_SETTINGS_FILE} at {} — nothing to consent to (no-op)",
+            remote_src.display()
+        );
+    }
+
+    // G3 — bypass permissions. `insert` (pas `entry().or_insert()`) : un `false`
+    // hôte doit être écrasé, sinon l'agent se bloque sur le prompt. Pas de `chmod`
+    // (ce n'est pas un secret ; `fs::write` tronque en place et préserve donc le
+    // mode hôte en `full`) et pas de tmp+rename : aucun lecteur concurrent n'existe
+    // avant le conteneur — contrairement à `merge_back`/`atomic_copy_into`.
+    edit_json_object(&home.join(SETTINGS_FILE), "staged settings.json", |obj| {
+        obj.insert(BYPASS_PERMISSIONS_KEY.to_string(), serde_json::json!(true));
+    })?;
+
+    // G4 — baseline du `.claude.json` stagé (onboarding + confiance).
+    ensure_claude_json_baseline(staged_json, trusted_root)?;
+
+    // G5 — `projects/` créé VIDE (puits de transcripts runtime). Ni
     // `~/.claude/projects/` ni le sous-dir encodé n'existent pour un run frais.
     let projects = home.join("projects");
     std::fs::create_dir_all(&projects)
         .with_context(|| format!("create staged projects sink {}", projects.display()))?;
 
-    Ok(staging)
+    Ok(())
 }
 
 /// Récupère les transcripts (`projects/**/*.jsonl`) du staging vers
@@ -175,12 +289,12 @@ pub(crate) fn prepare(
 ///
 /// **Best-effort** : tolère tout échec `read_dir`/`copy` sans jamais faire échouer
 /// l'appelant (la transition terminale du Run ne doit pas dépendre de ce merge).
-/// `projects/` staging absent (mode `pure`, run sans session) = no-op propre.
+/// `projects/` staging absent (run sans session) = no-op propre.
 pub(crate) fn merge_back(home_root: &Path, sandbox_root: &Path, run_id: &str) -> Result<()> {
     let src = staged_claude_home(sandbox_root, run_id).join("projects");
     let dest = home_root.join(".claude").join("projects");
     if !src.is_dir() {
-        return Ok(()); // pure / rien écrit
+        return Ok(()); // rien écrit
     }
     let Ok(entries) = std::fs::read_dir(&src) else {
         return Ok(());
@@ -254,34 +368,90 @@ fn copy_file_if_present(src: &Path, dst: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Écrit le `.claude.json` du mode `pure` (chmod 0600). `Some(root)` seede la
-/// confiance de la racine (héritée par les descendants → couvre les worktrees de
-/// nodes) ; `None` → objet nu `{"hasCompletedOnboarding":true}`.
-fn write_pure_claude_json(dst: &Path, trusted_root: Option<&Path>) -> Result<()> {
-    let value = match trusted_root {
-        Some(root) => {
-            let key = root.to_string_lossy().into_owned();
-            serde_json::json!({
-                "hasCompletedOnboarding": true,
-                "projects": {
-                    key: {
-                        "hasTrustDialogAccepted": true,
-                        "hasCompletedProjectOnboarding": true,
-                    }
-                }
-            })
-        }
-        None => serde_json::json!({ "hasCompletedOnboarding": true }),
+/// *Lire-comme-objet-ou-dégrader → muter → écrire pretty.* La **politique de
+/// dégradation unique** du module (#426) : fichier absent ou illisible → objet vide
+/// (synthèse) ; objet → merge ; JSON valide mais **pas** un objet, ou corrompu →
+/// `warn!` + objet vide. `what` nomme le fichier dans les logs et les erreurs.
+///
+/// Volontairement sans paramètre de mode de fichier : la confidentialité reste au
+/// callsite (0600 pour le `.claude.json`, rien pour le `settings.json`), là où
+/// l'asymétrie est décidée.
+fn edit_json_object(
+    path: &Path,
+    what: &str,
+    mutate: impl FnOnce(&mut serde_json::Map<String, serde_json::Value>),
+) -> Result<()> {
+    let mut value = match std::fs::read_to_string(path) {
+        Ok(body) => serde_json::from_str(&body).unwrap_or_else(|e| {
+            warn!(
+                "sandbox staging: {what} at {} is not valid JSON ({e}); replacing with a synthesised object",
+                path.display()
+            );
+            serde_json::json!({})
+        }),
+        Err(_) => serde_json::json!({}),
     };
-    let body = serde_json::to_string_pretty(&value).context("serialize pure .claude.json")?;
-    if let Some(parent) = dst.parent() {
+    if !value.is_object() {
+        warn!(
+            "sandbox staging: {what} at {} is not a JSON object; replacing with a synthesised object",
+            path.display()
+        );
+        value = serde_json::json!({});
+    }
+    let obj = value.as_object_mut().expect("value forced to object above");
+    mutate(obj);
+
+    let body = serde_json::to_string_pretty(&value).with_context(|| format!("serialize {what}"))?;
+    if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)
             .with_context(|| format!("create parent {}", parent.display()))?;
     }
-    std::fs::write(dst, body)
-        .with_context(|| format!("write pure .claude.json {}", dst.display()))?;
-    set_mode_0600(dst)?;
+    std::fs::write(path, body).with_context(|| format!("write {what} {}", path.display()))?;
     Ok(())
+}
+
+/// Garantie **G4** du plancher : le `.claude.json` stagé porte
+/// `hasCompletedOnboarding` et, si `trusted_root` est fournie, la confiance de cette
+/// racine (héritée par les descendants → couvre les worktrees de nodes). Merge non
+/// destructif dans le fichier hôte copié en `full` (profil `oauthAccount`, autres
+/// repos trustés… préservés) ; synthèse en `minimal`. 0600 réappliqué (le fichier
+/// peut porter un token).
+///
+/// `hasCompletedOnboarding` en `or_insert` (**défaut défensif** : une valeur hôte
+/// existante est respectée) mais les deux drapeaux de confiance en `insert` (ce sont
+/// des **garanties** : un `false` bloquerait un Run autonome).
+fn ensure_claude_json_baseline(path: &Path, trusted_root: Option<&Path>) -> Result<()> {
+    edit_json_object(path, "staged .claude.json", |obj| {
+        obj.entry("hasCompletedOnboarding")
+            .or_insert_with(|| serde_json::json!(true));
+        let Some(root) = trusted_root else {
+            return; // pas de bloc `projects` — objet nu (hors `full`, où l'hôte le porte)
+        };
+        let projects = obj
+            .entry("projects")
+            .or_insert_with(|| serde_json::json!({}));
+        if !projects.is_object() {
+            *projects = serde_json::json!({});
+        }
+        let projects = projects.as_object_mut().expect("projects forced to object");
+        let key = root.to_string_lossy().into_owned();
+        let entry = projects.entry(key).or_insert_with(|| serde_json::json!({}));
+        if !entry.is_object() {
+            *entry = serde_json::json!({});
+        }
+        let entry = entry
+            .as_object_mut()
+            .expect("project entry forced to object");
+        entry.insert(
+            "hasTrustDialogAccepted".to_string(),
+            serde_json::json!(true),
+        );
+        entry.insert(
+            "hasCompletedProjectOnboarding".to_string(),
+            serde_json::json!(true),
+        );
+    })?;
+    set_mode_0600(path)
 }
 
 /// `chmod 0600` (le `.claude.json` généré contient un token potentiel côté
@@ -426,59 +596,6 @@ fn stage_symlink(from: &Path, to: &Path, copy_root: &Path, depth: u32) {
     // else : échappant non-régulier (socket/fifo) → skip.
 }
 
-/// Merge non-destructif d'une confiance pour `trusted_root` dans le `.claude.json`
-/// (existant ou frais) du staging `copy` (#409, D5). Préserve toutes les autres
-/// clés/projets (profil `oauthAccount`, autres repos trustés…) et réapplique 0600
-/// (le fichier peut porter un token). Un `.claude.json` illisible/corrompu est
-/// remplacé par un objet nu + la confiance (dégradation gracieuse, pas d'échec dur).
-fn seed_trust_in_claude_json(path: &Path, trusted_root: &Path) -> Result<()> {
-    let mut value = match std::fs::read_to_string(path) {
-        Ok(body) => serde_json::from_str(&body).unwrap_or_else(|_| serde_json::json!({})),
-        Err(_) => serde_json::json!({}),
-    };
-    if !value.is_object() {
-        value = serde_json::json!({});
-    }
-    let obj = value.as_object_mut().expect("value forced to object above");
-    // Onboarding : défensif, aligne `copy` sur la garantie `pure` sans écraser une
-    // valeur hôte existante.
-    obj.entry("hasCompletedOnboarding")
-        .or_insert_with(|| serde_json::json!(true));
-    let projects = obj
-        .entry("projects")
-        .or_insert_with(|| serde_json::json!({}));
-    if !projects.is_object() {
-        *projects = serde_json::json!({});
-    }
-    let projects = projects.as_object_mut().expect("projects forced to object");
-    let key = trusted_root.to_string_lossy().into_owned();
-    let entry = projects.entry(key).or_insert_with(|| serde_json::json!({}));
-    if !entry.is_object() {
-        *entry = serde_json::json!({});
-    }
-    let entry = entry
-        .as_object_mut()
-        .expect("project entry forced to object");
-    entry.insert(
-        "hasTrustDialogAccepted".to_string(),
-        serde_json::json!(true),
-    );
-    entry.insert(
-        "hasCompletedProjectOnboarding".to_string(),
-        serde_json::json!(true),
-    );
-
-    let body = serde_json::to_string_pretty(&value).context("serialize copy .claude.json")?;
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)
-            .with_context(|| format!("create parent {}", parent.display()))?;
-    }
-    std::fs::write(path, body)
-        .with_context(|| format!("write copy .claude.json {}", path.display()))?;
-    set_mode_0600(path)?;
-    Ok(())
-}
-
 /// Recopie récursivement les `*.jsonl` de `src_dir` vers `dest_dir`, copy-if-
 /// absent-or-larger, atomiquement. Miroir de
 /// [`crate::run_cost`]'s `collect_jsonl_recursive` (même prédicat `is_dir` +
@@ -568,6 +685,15 @@ mod tests {
         std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode)).unwrap();
     }
 
+    fn read_json(path: &Path) -> serde_json::Value {
+        serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap()
+    }
+
+    /// Contenu de la baseline org fabriquée par [`fabricate_home`]. Un *stand-in*
+    /// : le vrai `~/.claude/remote-settings.json` porte un bearer OTEL de l'org et
+    /// ne doit jamais apparaître dans un test, un log ou un artefact (#426).
+    const ORG_BASELINE: &str = r#"{"org":"baseline"}"#;
+
     /// Construit un faux `~/.claude` réaliste sous `<home>/.claude` + le sibling
     /// `<home>/.claude.json`, couvrant l'allowlist, un symlink, un exécutable,
     /// des creds 0600, ET de l'état hôte volumineux qui doit rester EXCLU.
@@ -596,6 +722,11 @@ mod tests {
         // Allowlist files.
         write(&claude.join("settings.json"), r#"{"hooks":{"Stop":[]}}"#);
         write(&claude.join("settings.local.json"), r#"{"local":true}"#);
+        // Baseline de managed settings de l'org — hors allowlist, stagée par le
+        // plancher (G2) dans les DEUX modes. Miroir de la fixture couche 3
+        // (`sandbox_tracer::fabricate_host_claude`) : les deux doivent dériver
+        // ensemble.
+        write(&claude.join(REMOTE_SETTINGS_FILE), ORG_BASELINE);
         write_mode(
             &claude.join(".credentials.json"),
             r#"{"token":"secret"}"#,
@@ -638,10 +769,10 @@ mod tests {
         );
     }
 
-    // -- prepare (copy) ------------------------------------------------------
+    // -- prepare (full) ------------------------------------------------------
 
     #[test]
-    fn prepare_copy_reproduces_allowlist_and_excludes_projects() {
+    fn prepare_full_reproduces_allowlist_and_excludes_projects() {
         let home_dir = tempfile::tempdir().unwrap();
         let sandbox_dir = tempfile::tempdir().unwrap();
         fabricate_home(home_dir.path());
@@ -649,7 +780,7 @@ mod tests {
         let staging = prepare(
             home_dir.path(),
             sandbox_dir.path(),
-            Mode::Copy,
+            Mode::Full,
             "run1",
             None,
         )
@@ -677,12 +808,19 @@ mod tests {
             "*.md siblings captés par glob"
         );
 
-        // `.claude.json` sibling copié verbatim (hors claude-home/).
+        // `.claude.json` sibling copié depuis l'hôte (hors claude-home/), puis
+        // repris par G4 : les clés hôte survivent, l'onboarding est ajouté. Le
+        // fichier n'est PLUS byte-identique à l'hôte depuis #426 (G4 est
+        // inconditionnelle) — mais rien de l'hôte n'est perdu.
         let staged_json = staged_claude_json(sandbox_dir.path(), "run1");
         assert!(staged_json.is_file());
-        assert_eq!(
-            std::fs::read_to_string(&staged_json).unwrap(),
-            r#"{"host":"profile","oauthAccount":{"x":1}}"#
+        let json = read_json(&staged_json);
+        assert_eq!(json["host"], serde_json::json!("profile"));
+        assert_eq!(json["oauthAccount"]["x"], serde_json::json!(1));
+        assert_eq!(json["hasCompletedOnboarding"], serde_json::json!(true));
+        assert!(
+            json.get("projects").is_none(),
+            "trusted_root None → aucun bloc projects ajouté"
         );
         assert!(
             !home.join(".claude.json").exists(),
@@ -701,7 +839,7 @@ mod tests {
     }
 
     #[test]
-    fn prepare_copy_preserves_symlinks_and_exec_bit() {
+    fn prepare_full_preserves_symlinks_and_exec_bit() {
         let home_dir = tempfile::tempdir().unwrap();
         let sandbox_dir = tempfile::tempdir().unwrap();
         fabricate_home(home_dir.path());
@@ -709,7 +847,7 @@ mod tests {
         prepare(
             home_dir.path(),
             sandbox_dir.path(),
-            Mode::Copy,
+            Mode::Full,
             "run1",
             None,
         )
@@ -735,7 +873,7 @@ mod tests {
     }
 
     #[test]
-    fn prepare_copy_ignores_missing_entries() {
+    fn prepare_full_ignores_missing_entries() {
         let home_dir = tempfile::tempdir().unwrap();
         let sandbox_dir = tempfile::tempdir().unwrap();
         // Home minimal : uniquement settings.json, aucun autre membre de l'allowlist.
@@ -745,7 +883,7 @@ mod tests {
         prepare(
             home_dir.path(),
             sandbox_dir.path(),
-            Mode::Copy,
+            Mode::Full,
             "run1",
             None,
         )
@@ -754,12 +892,26 @@ mod tests {
         assert!(home.join("settings.json").is_file());
         assert!(!home.join("skills").exists());
         assert!(!home.join(".credentials.json").exists());
-        assert!(!staged_claude_json(sandbox_dir.path(), "run1").exists());
         assert!(home.join("projects").is_dir());
+        // G3 : le `settings.json` hôte était `{}` → la clé de bypass y est ajoutée.
+        assert_eq!(
+            read_json(&home.join(SETTINGS_FILE)),
+            serde_json::json!({ BYPASS_PERMISSIONS_KEY: true })
+        );
+        // G4 est INCONDITIONNELLE depuis #426 : sans elle, l'hôte n'ayant pas de
+        // `~/.claude.json`, rien n'était stagé — et `sandbox_container` monte ce
+        // chemin toujours, donc Docker créait un *répertoire* par-dessus
+        // `$HOME/.claude.json`. Le plancher ferme ce footgun.
+        let staged_json = staged_claude_json(sandbox_dir.path(), "run1");
+        assert_eq!(
+            read_json(&staged_json),
+            serde_json::json!({ "hasCompletedOnboarding": true })
+        );
+        assert_eq!(mode_of(&staged_json), 0o600);
     }
 
     #[test]
-    fn prepare_copy_dereferences_escaping_symlink() {
+    fn prepare_full_dereferences_escaping_symlink() {
         let home_dir = tempfile::tempdir().unwrap();
         let sandbox_dir = tempfile::tempdir().unwrap();
         fabricate_home(home_dir.path());
@@ -767,7 +919,7 @@ mod tests {
         prepare(
             home_dir.path(),
             sandbox_dir.path(),
-            Mode::Copy,
+            Mode::Full,
             "run1",
             None,
         )
@@ -808,7 +960,7 @@ mod tests {
     }
 
     #[test]
-    fn prepare_copy_is_best_effort_on_unreadable_entry() {
+    fn prepare_full_is_best_effort_on_unreadable_entry() {
         let home_dir = tempfile::tempdir().unwrap();
         let sandbox_dir = tempfile::tempdir().unwrap();
         let claude = home_dir.path().join(".claude");
@@ -821,7 +973,7 @@ mod tests {
         prepare(
             home_dir.path(),
             sandbox_dir.path(),
-            Mode::Copy,
+            Mode::Full,
             "run1",
             None,
         )
@@ -837,7 +989,7 @@ mod tests {
     }
 
     #[test]
-    fn prepare_copy_seeds_trust_for_repo_root() {
+    fn prepare_full_seeds_trust_for_repo_root() {
         let home_dir = tempfile::tempdir().unwrap();
         let sandbox_dir = tempfile::tempdir().unwrap();
         fabricate_home(home_dir.path()); // `.claude.json` hôte porte `oauthAccount`
@@ -846,7 +998,7 @@ mod tests {
         prepare(
             home_dir.path(),
             sandbox_dir.path(),
-            Mode::Copy,
+            Mode::Full,
             "run1",
             Some(trusted),
         )
@@ -869,10 +1021,13 @@ mod tests {
         assert_eq!(mode_of(&staged), 0o600);
     }
 
-    // -- prepare (pure) ------------------------------------------------------
+    // -- prepare (minimal) ---------------------------------------------------
 
+    /// *L'*assertion que `minimal` == le plancher, ni plus ni moins (#426) : le
+    /// contenu exact de `claude-home/` est le plancher, alors que l'hôte porte tout
+    /// l'appareil `full` (skills, plugins, settings riches…).
     #[test]
-    fn prepare_pure_only_credentials_and_onboarding() {
+    fn prepare_minimal_stages_only_the_floor() {
         let home_dir = tempfile::tempdir().unwrap();
         let sandbox_dir = tempfile::tempdir().unwrap();
         fabricate_home(home_dir.path()); // skills/settings existent → prouvent l'exclusion
@@ -880,14 +1035,14 @@ mod tests {
         prepare(
             home_dir.path(),
             sandbox_dir.path(),
-            Mode::Pure,
+            Mode::Minimal,
             "run1",
             None,
         )
         .unwrap();
         let home = staged_claude_home(sandbox_dir.path(), "run1");
 
-        // claude-home ne contient QUE `.credentials.json` + `projects/` (vide).
+        // Ensemble EXACT (trié ASCII) = les fichiers du plancher, rien d'autre.
         let mut names: Vec<String> = std::fs::read_dir(&home)
             .unwrap()
             .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
@@ -895,28 +1050,33 @@ mod tests {
         names.sort();
         assert_eq!(
             names,
-            vec![".credentials.json".to_string(), "projects".to_string()]
+            vec![
+                ".credentials.json".to_string(),
+                "projects".to_string(),
+                REMOTE_SETTINGS_FILE.to_string(),
+                SETTINGS_FILE.to_string(),
+            ]
         );
         assert_eq!(std::fs::read_dir(home.join("projects")).unwrap().count(), 0);
         assert!(!home.join("skills").exists());
-        assert!(!home.join("settings.json").exists());
         assert_eq!(mode_of(&home.join(".credentials.json")), 0o600);
+        // G3 : `settings.json` est la SYNTHÈSE à une clé, pas celui de l'hôte (qui
+        // porte des `hooks`) — c'est la fourche synthèse-vs-copie du plancher.
+        assert_eq!(
+            read_json(&home.join(SETTINGS_FILE)),
+            serde_json::json!({ BYPASS_PERMISSIONS_KEY: true })
+        );
 
         // `.claude.json` minimal : onboarding seul, pas de bloc projects.
-        let json: serde_json::Value = serde_json::from_str(
-            &std::fs::read_to_string(staged_claude_json(sandbox_dir.path(), "run1")).unwrap(),
-        )
-        .unwrap();
+        let staged_json = staged_claude_json(sandbox_dir.path(), "run1");
+        let json = read_json(&staged_json);
         assert_eq!(json["hasCompletedOnboarding"], serde_json::json!(true));
         assert!(json.get("projects").is_none(), "None → objet nu");
-        assert_eq!(
-            mode_of(&staged_claude_json(sandbox_dir.path(), "run1")),
-            0o600
-        );
+        assert_eq!(mode_of(&staged_json), 0o600);
     }
 
     #[test]
-    fn prepare_pure_seeds_trust_when_root_given() {
+    fn prepare_minimal_seeds_trust_when_root_given() {
         let home_dir = tempfile::tempdir().unwrap();
         let sandbox_dir = tempfile::tempdir().unwrap();
         write_mode(
@@ -929,7 +1089,7 @@ mod tests {
         prepare(
             home_dir.path(),
             sandbox_dir.path(),
-            Mode::Pure,
+            Mode::Minimal,
             "run1",
             Some(trusted),
         )
@@ -949,14 +1109,14 @@ mod tests {
     }
 
     #[test]
-    fn prepare_pure_bare_object_when_no_root() {
+    fn prepare_minimal_bare_object_when_no_root() {
         let home_dir = tempfile::tempdir().unwrap();
         let sandbox_dir = tempfile::tempdir().unwrap();
 
         prepare(
             home_dir.path(),
             sandbox_dir.path(),
-            Mode::Pure,
+            Mode::Minimal,
             "run1",
             None,
         )
@@ -968,6 +1128,392 @@ mod tests {
         .unwrap();
         // Exactement une clé : hasCompletedOnboarding.
         assert_eq!(json, serde_json::json!({ "hasCompletedOnboarding": true }));
+    }
+
+    // -- plancher de staging, G2 : managed settings de l'org (#426) -----------
+
+    /// Home fabriqué à la main SANS baseline org — le cas majoritaire (install sans
+    /// organisation). Porte des credentials pour que G1 ait quelque chose à faire.
+    fn fabricate_home_without_org(home: &Path) {
+        write_mode(&home.join(".claude/.credentials.json"), "{}", 0o600);
+    }
+
+    #[test]
+    fn prepare_full_stages_remote_settings() {
+        let home_dir = tempfile::tempdir().unwrap();
+        let sandbox_dir = tempfile::tempdir().unwrap();
+        fabricate_home(home_dir.path());
+
+        prepare(
+            home_dir.path(),
+            sandbox_dir.path(),
+            Mode::Full,
+            "run1",
+            None,
+        )
+        .unwrap();
+
+        let staged = staged_claude_home(sandbox_dir.path(), "run1").join(REMOTE_SETTINGS_FILE);
+        // Copie VERBATIM : la baseline est comparée au contenu côté Claude Code, une
+        // ré-sérialisation ne serait pas forcément reconnue.
+        assert_eq!(std::fs::read_to_string(&staged).unwrap(), ORG_BASELINE);
+    }
+
+    #[test]
+    fn prepare_minimal_stages_remote_settings() {
+        let home_dir = tempfile::tempdir().unwrap();
+        let sandbox_dir = tempfile::tempdir().unwrap();
+        fabricate_home(home_dir.path());
+
+        prepare(
+            home_dir.path(),
+            sandbox_dir.path(),
+            Mode::Minimal,
+            "run1",
+            None,
+        )
+        .unwrap();
+
+        let home = staged_claude_home(sandbox_dir.path(), "run1");
+        assert_eq!(
+            std::fs::read_to_string(home.join(REMOTE_SETTINGS_FILE)).unwrap(),
+            ORG_BASELINE
+        );
+        // Preuve que c'est le PLANCHER et non l'allowlist `full` : rien du profil.
+        assert!(!home.join("skills").exists());
+    }
+
+    #[test]
+    fn prepare_full_without_remote_settings_is_a_logged_noop() {
+        let home_dir = tempfile::tempdir().unwrap();
+        let sandbox_dir = tempfile::tempdir().unwrap();
+        fabricate_home_without_org(home_dir.path());
+
+        // Aucune erreur : l'absence est le cas majoritaire (`info!` + no-op).
+        prepare(
+            home_dir.path(),
+            sandbox_dir.path(),
+            Mode::Full,
+            "run1",
+            None,
+        )
+        .unwrap();
+
+        let home = staged_claude_home(sandbox_dir.path(), "run1");
+        assert!(!home.join(REMOTE_SETTINGS_FILE).exists());
+        // …et le plancher n'a PAS avorté en cours de route.
+        assert!(home.join(SETTINGS_FILE).is_file());
+        assert!(home.join("projects").is_dir());
+    }
+
+    #[test]
+    fn prepare_minimal_without_remote_settings_is_a_logged_noop() {
+        let home_dir = tempfile::tempdir().unwrap();
+        let sandbox_dir = tempfile::tempdir().unwrap();
+        fabricate_home_without_org(home_dir.path());
+
+        prepare(
+            home_dir.path(),
+            sandbox_dir.path(),
+            Mode::Minimal,
+            "run1",
+            None,
+        )
+        .unwrap();
+
+        let home = staged_claude_home(sandbox_dir.path(), "run1");
+        assert!(!home.join(REMOTE_SETTINGS_FILE).exists());
+        assert!(home.join(SETTINGS_FILE).is_file());
+        assert!(home.join("projects").is_dir());
+        // G1 tenue malgré le no-op de G2.
+        assert_eq!(mode_of(&home.join(".credentials.json")), 0o600);
+    }
+
+    // -- plancher de staging, G3 : bypass permissions (#426) ------------------
+
+    fn staged_settings(sandbox: &Path, run_id: &str) -> PathBuf {
+        staged_claude_home(sandbox, run_id).join(SETTINGS_FILE)
+    }
+
+    #[test]
+    fn prepare_full_merges_bypass_into_host_settings() {
+        let home_dir = tempfile::tempdir().unwrap();
+        let sandbox_dir = tempfile::tempdir().unwrap();
+        let host_settings = home_dir.path().join(".claude").join(SETTINGS_FILE);
+        write(&host_settings, r#"{"hooks":{"Stop":[]},"model":"opus"}"#);
+
+        prepare(
+            home_dir.path(),
+            sandbox_dir.path(),
+            Mode::Full,
+            "run1",
+            None,
+        )
+        .unwrap();
+
+        let staged = staged_settings(sandbox_dir.path(), "run1");
+        let json = read_json(&staged);
+        assert_eq!(json[BYPASS_PERMISSIONS_KEY], serde_json::json!(true));
+        // Merge NON destructif : les clés hôte survivent.
+        assert_eq!(json["model"], serde_json::json!("opus"));
+        assert!(json["hooks"]["Stop"].is_array());
+        // Pas de chmod, pas d'élargissement : le mode hôte est conservé (`fs::write`
+        // tronque en place). Comparé au mode hôte, donc indépendant de l'umask.
+        assert_eq!(mode_of(&staged), mode_of(&host_settings));
+    }
+
+    #[test]
+    fn prepare_full_keeps_bypass_already_set_by_host() {
+        let home_dir = tempfile::tempdir().unwrap();
+        let sandbox_dir = tempfile::tempdir().unwrap();
+        write(
+            &home_dir.path().join(".claude").join(SETTINGS_FILE),
+            &format!(r#"{{"{BYPASS_PERMISSIONS_KEY}":true,"model":"opus"}}"#),
+        );
+
+        prepare(
+            home_dir.path(),
+            sandbox_dir.path(),
+            Mode::Full,
+            "run1",
+            None,
+        )
+        .unwrap();
+
+        let json = read_json(&staged_settings(sandbox_dir.path(), "run1"));
+        assert_eq!(json[BYPASS_PERMISSIONS_KEY], serde_json::json!(true));
+        // Aucun artefact de duplication : toujours 2 clés.
+        assert_eq!(json.as_object().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn prepare_full_overrides_host_bypass_false() {
+        let home_dir = tempfile::tempdir().unwrap();
+        let sandbox_dir = tempfile::tempdir().unwrap();
+        write(
+            &home_dir.path().join(".claude").join(SETTINGS_FILE),
+            &format!(r#"{{"{BYPASS_PERMISSIONS_KEY}":false}}"#),
+        );
+
+        prepare(
+            home_dir.path(),
+            sandbox_dir.path(),
+            Mode::Full,
+            "run1",
+            None,
+        )
+        .unwrap();
+
+        // C'est une GARANTIE, pas un défaut : `insert`, jamais `entry().or_insert()`
+        // (contrairement à `hasCompletedOnboarding` juste à côté). Un `false` hôte
+        // bloquerait l'agent sur le prompt de bypass.
+        let json = read_json(&staged_settings(sandbox_dir.path(), "run1"));
+        assert_eq!(json[BYPASS_PERMISSIONS_KEY], serde_json::json!(true));
+    }
+
+    #[test]
+    fn prepare_full_synthesises_settings_when_host_has_none() {
+        let home_dir = tempfile::tempdir().unwrap();
+        let sandbox_dir = tempfile::tempdir().unwrap();
+        fabricate_home_without_org(home_dir.path()); // aucun settings.json hôte
+
+        prepare(
+            home_dir.path(),
+            sandbox_dir.path(),
+            Mode::Full,
+            "run1",
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(
+            read_json(&staged_settings(sandbox_dir.path(), "run1")),
+            serde_json::json!({ BYPASS_PERMISSIONS_KEY: true })
+        );
+    }
+
+    #[test]
+    fn prepare_minimal_synthesises_settings_ignoring_host() {
+        let home_dir = tempfile::tempdir().unwrap();
+        let sandbox_dir = tempfile::tempdir().unwrap();
+        fabricate_home(home_dir.path()); // settings hôte riches (hooks)
+
+        prepare(
+            home_dir.path(),
+            sandbox_dir.path(),
+            Mode::Minimal,
+            "run1",
+            None,
+        )
+        .unwrap();
+
+        // La phrase d'ADR-0031 §1 sous forme de test : la même garantie, satisfaite
+        // par une synthèse ici et par un merge en `full`.
+        assert_eq!(
+            read_json(&staged_settings(sandbox_dir.path(), "run1")),
+            serde_json::json!({ BYPASS_PERMISSIONS_KEY: true })
+        );
+    }
+
+    #[test]
+    fn prepare_full_replaces_corrupt_host_settings() {
+        let home_dir = tempfile::tempdir().unwrap();
+        let sandbox_dir = tempfile::tempdir().unwrap();
+        write(
+            &home_dir.path().join(".claude").join(SETTINGS_FILE),
+            "{ not json,",
+        );
+
+        // Dégradation GRACIEUSE (miroir du seed de trust) : en dur, un seul
+        // caractère malformé dans `~/.claude/settings.json` empêcherait TOUT Run
+        // sandboxé de démarrer.
+        prepare(
+            home_dir.path(),
+            sandbox_dir.path(),
+            Mode::Full,
+            "run1",
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(
+            read_json(&staged_settings(sandbox_dir.path(), "run1")),
+            serde_json::json!({ BYPASS_PERMISSIONS_KEY: true })
+        );
+    }
+
+    #[test]
+    fn prepare_full_replaces_non_object_host_settings() {
+        let home_dir = tempfile::tempdir().unwrap();
+        let sandbox_dir = tempfile::tempdir().unwrap();
+        // JSON valide, mais pas un objet → chemin de code distinct (garde `is_object`).
+        write(
+            &home_dir.path().join(".claude").join(SETTINGS_FILE),
+            "[1,2]",
+        );
+
+        prepare(
+            home_dir.path(),
+            sandbox_dir.path(),
+            Mode::Full,
+            "run1",
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(
+            read_json(&staged_settings(sandbox_dir.path(), "run1")),
+            serde_json::json!({ BYPASS_PERMISSIONS_KEY: true })
+        );
+    }
+
+    // -- plancher de staging, les CINQ garanties en un point (#426) -----------
+
+    /// La forme exécutable d'ADR-0031 §1, et le test qu'un relecteur lit pour
+    /// répondre « le plancher est-il tenu ? ». La slice « profils » l'étendra
+    /// (même corps, plus « … même avec l'entrée décochée »).
+    #[test]
+    fn prepare_floor_holds_in_both_modes() {
+        for mode in [Mode::Full, Mode::Minimal] {
+            let home_dir = tempfile::tempdir().unwrap();
+            let sandbox_dir = tempfile::tempdir().unwrap();
+            fabricate_home(home_dir.path());
+            let trusted = Path::new("/repo/root");
+
+            prepare(
+                home_dir.path(),
+                sandbox_dir.path(),
+                mode,
+                "run1",
+                Some(trusted),
+            )
+            .unwrap();
+            let home = staged_claude_home(sandbox_dir.path(), "run1");
+
+            // G1 — credentials valides, 0600 préservé.
+            assert_eq!(
+                mode_of(&home.join(".credentials.json")),
+                0o600,
+                "G1 en {mode:?}"
+            );
+            // G2 — baseline de managed settings de l'org.
+            assert_eq!(
+                std::fs::read_to_string(home.join(REMOTE_SETTINGS_FILE)).unwrap(),
+                ORG_BASELINE,
+                "G2 en {mode:?}"
+            );
+            // G3 — bypass permissions accepté.
+            assert_eq!(
+                read_json(&home.join(SETTINGS_FILE))[BYPASS_PERMISSIONS_KEY],
+                serde_json::json!(true),
+                "G3 en {mode:?}"
+            );
+            // G4 — confiance pré-accordée à la racine du Run + onboarding.
+            let json = read_json(&staged_claude_json(sandbox_dir.path(), "run1"));
+            assert_eq!(
+                json["projects"]["/repo/root"]["hasTrustDialogAccepted"],
+                serde_json::json!(true),
+                "G4 (trust) en {mode:?}"
+            );
+            assert_eq!(
+                json["hasCompletedOnboarding"],
+                serde_json::json!(true),
+                "G4 (onboarding) en {mode:?}"
+            );
+            // G5 — puits de transcripts créé VIDE.
+            let projects = home.join("projects");
+            assert!(projects.is_dir(), "G5 en {mode:?}");
+            assert_eq!(
+                std::fs::read_dir(&projects).unwrap().count(),
+                0,
+                "G5 vide en {mode:?}"
+            );
+        }
+    }
+
+    /// Fige ADR-0031 §6 (« `prepare` est additif : il copie ou écrase, il ne
+    /// supprime jamais ») et répond à la question du double write sur
+    /// `settings.json` en `full` : le second merge n'écrase ni ne duplique rien.
+    #[test]
+    fn prepare_twice_keeps_the_floor_and_is_additive() {
+        let home_dir = tempfile::tempdir().unwrap();
+        let sandbox_dir = tempfile::tempdir().unwrap();
+        fabricate_home(home_dir.path());
+        let trusted = Path::new("/repo/root");
+        let (home_p, sandbox_p) = (home_dir.path(), sandbox_dir.path());
+
+        prepare(home_p, sandbox_p, Mode::Full, "run1", Some(trusted)).unwrap();
+        // Le conteneur (simulé) a écrit un transcript dans le puits.
+        stage_transcript(sandbox_p, "run1", &format!("{ENC}/s.jsonl"), "line\n");
+
+        prepare(home_p, sandbox_p, Mode::Full, "run1", Some(trusted)).unwrap();
+
+        let home = staged_claude_home(sandbox_p, "run1");
+        let settings = read_json(&home.join(SETTINGS_FILE));
+        assert_eq!(settings[BYPASS_PERMISSIONS_KEY], serde_json::json!(true));
+        assert!(
+            settings["hooks"]["Stop"].is_array(),
+            "le 2e merge n'a pas écrasé les clés hôte"
+        );
+        assert_eq!(
+            settings.as_object().unwrap().len(),
+            2,
+            "ni dupliqué la clé de bypass"
+        );
+        assert_eq!(
+            std::fs::read_to_string(home.join(REMOTE_SETTINGS_FILE)).unwrap(),
+            ORG_BASELINE
+        );
+        assert_eq!(
+            read_json(&staged_claude_json(sandbox_p, "run1"))["projects"]["/repo/root"]
+                ["hasTrustDialogAccepted"],
+            serde_json::json!(true)
+        );
+        // ADDITIF : le transcript écrit entre les deux `prepare` survit.
+        assert_eq!(
+            std::fs::read_to_string(home.join(format!("projects/{ENC}/s.jsonl"))).unwrap(),
+            "line\n"
+        );
     }
 
     // -- merge_back ----------------------------------------------------------
@@ -1120,7 +1666,7 @@ mod tests {
         let sandbox_dir = tempfile::tempdir().unwrap();
         let (home, sandbox) = (home_dir.path(), sandbox_dir.path());
 
-        // Staging pure : claude-home existe mais sans projects/.
+        // Staging minimal : claude-home existe mais sans projects/.
         std::fs::create_dir_all(staged_claude_home(sandbox, "run1")).unwrap();
 
         merge_back(home, sandbox, "run1").unwrap(); // Ok, aucune écriture hôte.
@@ -1187,12 +1733,12 @@ mod tests {
     // -- round-trip prepare → (write) → merge_back → teardown ----------------
 
     #[test]
-    fn prepare_pure_then_merge_and_teardown_roundtrip() {
+    fn prepare_minimal_then_merge_and_teardown_roundtrip() {
         let home_dir = tempfile::tempdir().unwrap();
         let sandbox_dir = tempfile::tempdir().unwrap();
         let (home, sandbox) = (home_dir.path(), sandbox_dir.path());
 
-        prepare(home, sandbox, Mode::Pure, "run1", None).unwrap();
+        prepare(home, sandbox, Mode::Minimal, "run1", None).unwrap();
         // Le conteneur (simulé) écrit un transcript dans le puits projects/.
         stage_transcript(sandbox, "run1", &format!("{ENC}/sess.jsonl"), "hello\n");
 

--- a/crates/pdo-daemon/src/trigger_store.rs
+++ b/crates/pdo-daemon/src/trigger_store.rs
@@ -43,7 +43,7 @@ pub struct Trigger {
     /// `None` = unbounded (also the effective value under the `skip` policy).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_concurrent: Option<i64>,
-    /// Per-Trigger sandbox mode (`"off"` | `"copy"` | `"pure"`), or `None` to inherit
+    /// Per-Trigger sandbox mode (`"off"` | `"full"` | `"minimal"`), or `None` to inherit
     /// the instance default (#410). Read at fire time and folded into the create
     /// request's explicit tier; the create chokepoint then resolves precedence
     /// (run → trigger → instance default). Clearable back to `None` via the
@@ -1266,9 +1266,9 @@ mod tests {
         let db = test_db().await;
 
         let mut sandboxed = sample("sandboxed", "0 9 * * *");
-        sandboxed.sandbox = Some("pure".to_string());
+        sandboxed.sandbox = Some("minimal".to_string());
         let created = create(&db, sandboxed).await.unwrap();
-        assert_eq!(created.sandbox.as_deref(), Some("pure"));
+        assert_eq!(created.sandbox.as_deref(), Some("minimal"));
         assert_eq!(
             get(&db, &created.id)
                 .await
@@ -1276,7 +1276,7 @@ mod tests {
                 .unwrap()
                 .sandbox
                 .as_deref(),
-            Some("pure")
+            Some("minimal")
         );
 
         // The default (inherit instance) round-trips as NULL.
@@ -1296,7 +1296,7 @@ mod tests {
             &db,
             &t.id,
             UpdateTrigger {
-                sandbox: Some(Some("copy".to_string())),
+                sandbox: Some(Some("full".to_string())),
                 ..Default::default()
             },
         )
@@ -1304,7 +1304,7 @@ mod tests {
         .unwrap();
         assert_eq!(
             get(&db, &t.id).await.unwrap().unwrap().sandbox.as_deref(),
-            Some("copy")
+            Some("full")
         );
 
         // An unrelated edit (None) leaves it untouched.
@@ -1320,7 +1320,7 @@ mod tests {
         .unwrap();
         assert_eq!(
             get(&db, &t.id).await.unwrap().unwrap().sandbox.as_deref(),
-            Some("copy")
+            Some("full")
         );
 
         // Some(None) clears it back to NULL (inherit the instance default).

--- a/crates/pdo-daemon/tests/sandbox_observability.rs
+++ b/crates/pdo-daemon/tests/sandbox_observability.rs
@@ -331,7 +331,7 @@ fn plant_transcript(
 // -- Test 1: cost reads the staged home while a sandboxed run is live ----------
 
 #[tokio::test]
-async fn cost_reads_staging_during_pure_run() {
+async fn cost_reads_staging_during_minimal_run() {
     if !tmux_available() {
         eprintln!("tmux not on PATH — skipping");
         return;
@@ -346,7 +346,7 @@ async fn cost_reads_staging_during_pure_run() {
     .await
     .unwrap();
 
-    let run_id = start_run(&daemon, Some("pure")).await;
+    let run_id = start_run(&daemon, Some("minimal")).await;
     // The worker reaches Running with a live (sleeping) session; its staging is
     // seeded by the eager prep.
     wait_node_status(&daemon, &run_id, "running").await;
@@ -389,7 +389,7 @@ async fn cost_reads_staging_during_pure_run() {
 // -- Test 2: stale-detection reads the staged home while live ------------------
 
 #[tokio::test]
-async fn stale_detection_reads_staging_during_pure_run() {
+async fn stale_detection_reads_staging_during_minimal_run() {
     if !tmux_available() {
         eprintln!("tmux not on PATH — skipping");
         return;
@@ -404,7 +404,7 @@ async fn stale_detection_reads_staging_during_pure_run() {
     .await
     .unwrap();
 
-    let run_id = start_run(&daemon, Some("pure")).await;
+    let run_id = start_run(&daemon, Some("minimal")).await;
     wait_node_status(&daemon, &run_id, "running").await;
     assert!(
         wait_until(|| staging_projects(&daemon, &run_id)
@@ -453,7 +453,7 @@ async fn terminal_merges_staging_into_host_claude_projects() {
     .await
     .unwrap();
 
-    let run_id = start_run(&daemon, Some("pure")).await;
+    let run_id = start_run(&daemon, Some("minimal")).await;
     wait_node_status(&daemon, &run_id, "running").await;
     assert!(
         wait_until(|| staging_projects(&daemon, &run_id)
@@ -517,7 +517,7 @@ async fn double_merge_terminal_then_cleanup_is_identical() {
     .await
     .unwrap();
 
-    let run_id = start_run(&daemon, Some("pure")).await;
+    let run_id = start_run(&daemon, Some("minimal")).await;
     wait_node_status(&daemon, &run_id, "running").await;
     assert!(
         wait_until(|| staging_projects(&daemon, &run_id)
@@ -604,7 +604,7 @@ async fn resume_reengages_seam_and_ensures_container() {
     .await
     .unwrap();
 
-    let run_id = start_run(&daemon, Some("pure")).await;
+    let run_id = start_run(&daemon, Some("minimal")).await;
     wait_node_status(&daemon, &run_id, "running").await;
     write_node_output(&daemon, &run_id, "done\n");
     simulate_node_done(&daemon, &run_id).await;
@@ -649,7 +649,7 @@ async fn resume_fails_loud_when_docker_unavailable() {
     .await
     .unwrap();
 
-    let run_id = start_run(&daemon, Some("pure")).await;
+    let run_id = start_run(&daemon, Some("minimal")).await;
     wait_run_status(&daemon, &run_id, "failed").await;
 
     let resp = post_command(

--- a/crates/pdo-daemon/tests/sandbox_tracer.rs
+++ b/crates/pdo-daemon/tests/sandbox_tracer.rs
@@ -4,7 +4,7 @@
 //! `docker_cmd_override`) and a tempdir-scoped sandbox home (via
 //! `sandbox_home_override`), so no test needs Docker, touches the real `$HOME`,
 //! or launches real claude. Asserts the run-advance wiring:
-//!   1. a `pure` run projects `sandbox=pure`, prep runs (`create`+`start`), the
+//!   1. a `minimal` run projects `sandbox=minimal`, prep runs (`create`+`start`), the
 //!      node tail is wrapped (`docker exec … pdo-sbx-<run>`), and the run completes;
 //!   2. Docker unavailable → `RunFailed`, ZERO host spawn (no `NodeStarted`);
 //!   3. an `off` run invokes docker NOT AT ALL (argv log empty) and completes on
@@ -248,10 +248,10 @@ async fn simulate_node_done(daemon: &TestDaemon, run_id: &str) {
     );
 }
 
-// -- Test 1: pure run wires end-to-end ---------------------------------------
+// -- Test 1: minimal run wires end-to-end ------------------------------------
 
 #[tokio::test]
-async fn pure_run_prepares_wraps_and_completes() {
+async fn minimal_run_prepares_wraps_and_completes() {
     ensure_pdo_on_path();
     let (_fake_dir, docker, log) = write_fake_docker();
     let daemon =
@@ -259,13 +259,13 @@ async fn pure_run_prepares_wraps_and_completes() {
             .await
             .unwrap();
 
-    let run_id = start_run(&daemon, Some("pure")).await;
+    let run_id = start_run(&daemon, Some("minimal")).await;
 
     // (a) The mode is projected onto the Run from RunStarted.
     let run = get_run(&daemon, &run_id).await;
     assert_eq!(
-        run["sandbox"], "pure",
-        "run must project sandbox=pure: {run}"
+        run["sandbox"], "minimal",
+        "run must project sandbox=minimal: {run}"
     );
 
     // (b) Eager prep created + started the container (ensure_ready).
@@ -296,10 +296,27 @@ async fn pure_run_prepares_wraps_and_completes() {
     // POST node-done) and assert the whole run reaches `completed`.
     let run = wait_node_status(&daemon, &run_id, "running").await;
     assert_eq!(run["nodes"][NODE_ID]["status"], "running", "run: {run}");
+
+    // (d-bis) #426 G3: with no host `~/.claude` at all, the floor SYNTHESISES the
+    // staged `settings.json` down to the single bypass key — otherwise the session
+    // would stall on the bypass-permissions prompt with nobody watching.
+    let home = staged_home(&daemon, &run_id);
+    let settings: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(home.join("settings.json")).unwrap())
+            .unwrap();
+    assert_eq!(
+        settings,
+        serde_json::json!({ BYPASS_PERMISSIONS_KEY: true }),
+        "minimal must synthesise settings.json to the floor's single key"
+    );
+
     write_node_output(&daemon, &run_id, "hello from the sandbox\n");
     simulate_node_done(&daemon, &run_id).await;
     let run = wait_run_status(&daemon, &run_id, "completed").await;
-    assert_eq!(run["status"], "completed", "pure run must complete: {run}");
+    assert_eq!(
+        run["status"], "completed",
+        "minimal run must complete: {run}"
+    );
 }
 
 // -- Test 2: Docker unavailable → RunFailed, no host spawn -------------------
@@ -315,7 +332,7 @@ async fn docker_unavailable_fails_run_with_no_host_spawn() {
     .await
     .unwrap();
 
-    let run_id = start_run(&daemon, Some("pure")).await;
+    let run_id = start_run(&daemon, Some("minimal")).await;
 
     let run = wait_run_status(&daemon, &run_id, "failed").await;
     assert_eq!(
@@ -378,7 +395,7 @@ async fn cleanup_run_removes_container_and_staging() {
             .await
             .unwrap();
 
-    let run_id = start_run(&daemon, Some("pure")).await;
+    let run_id = start_run(&daemon, Some("minimal")).await;
     wait_node_status(&daemon, &run_id, "running").await;
     write_node_output(&daemon, &run_id, "done\n");
     simulate_node_done(&daemon, &run_id).await;
@@ -423,7 +440,7 @@ async fn boot_recovery_reensures_sandbox_container() {
             .await
             .unwrap();
 
-    let run_id = start_run(&daemon, Some("pure")).await;
+    let run_id = start_run(&daemon, Some("minimal")).await;
     let count_creates = |log: &Path| log_text(log).lines().filter(|l| *l == "create").count();
 
     // Wait for the first prep to create+start (so the run is live), targeting
@@ -460,7 +477,7 @@ async fn kill_node_targets_the_container() {
             .await
             .unwrap();
 
-    let run_id = start_run(&daemon, Some("pure")).await;
+    let run_id = start_run(&daemon, Some("minimal")).await;
     wait_node_status(&daemon, &run_id, "running").await;
 
     let resp = post_command(
@@ -480,15 +497,25 @@ async fn kill_node_targets_the_container() {
     );
 }
 
-// -- #409: mode `copy` de bout en bout ---------------------------------------
+// -- #409: mode `full` de bout en bout ---------------------------------------
 //
 // The harness collocates `home_root == host_home == repo_root == tempdir`
 // (`sandbox_home_override`), so the fake host `~/.claude` lives at
 // `<repo>/.claude`. It is fabricated AFTER spawn (untracked, out of the seed
 // commit) and BEFORE `start_run` (eager prep reads it). The fake `docker exec`
-// cannot run the container body, so a real end-to-end `copy` run (skills actually
+// cannot run the container body, so a real end-to-end `full` run (skills actually
 // loaded, kernel isolation, real auth) is the Layer-5 job (FP-409). Layer-3 proves
 // what PDO **stages** and the **argv/mounts** it hands `docker create`.
+
+/// Org managed-settings baseline cached by Claude Code in `~/.claude/` — the
+/// guarantee G2 of the staging floor (#426).
+const ORG_BASELINE_FILE: &str = "remote-settings.json";
+/// Stand-in content for [`ORG_BASELINE_FILE`]. The real host file carries an org
+/// OTEL bearer: assertions here compare against this fixture, never the real one.
+const ORG_BASELINE: &str = r#"{"org":"baseline"}"#;
+/// The top-level key that disarms the `--dangerously-skip-permissions` prompt —
+/// guarantee G3 of the staging floor (#426).
+const BYPASS_PERMISSIONS_KEY: &str = "skipDangerousModePermissionPrompt";
 
 /// Fabricate a realistic host `~/.claude` (+ sibling `.claude.json`) under `home`.
 /// Mirrors the unit `sandbox_staging::fabricate_home`: allowlist dirs/files, an
@@ -529,6 +556,11 @@ fn fabricate_host_claude(home: &Path) {
     // Allowlist files (hooks live inside settings.json).
     write(claude.join("settings.json"), r#"{"hooks":{"Stop":[]}}"#);
     write(claude.join("settings.local.json"), r#"{"local":true}"#);
+    // Org managed-settings baseline (#426): OUTSIDE the `full` allowlist — the
+    // staging floor is its single writer, in BOTH modes. Deliberate mirror of the
+    // unit fixture `sandbox_staging::tests::fabricate_home`; keep them in step.
+    // Stand-in content: the real file carries an org OTEL bearer.
+    write(claude.join(ORG_BASELINE_FILE), ORG_BASELINE);
     write_mode(
         claude.join(".credentials.json"),
         r#"{"token":"secret"}"#,
@@ -545,7 +577,8 @@ fn fabricate_host_claude(home: &Path) {
         claude.join("projects/-enc-host/old.jsonl"),
         "{\"host\":1}\n",
     );
-    // Sibling profile `.claude.json` (PII-bearing; copy stages it verbatim + trust).
+    // Sibling profile `.claude.json` (PII-bearing; `full` stages it, the floor
+    // then merges onboarding + trust into it).
     write(
         home.join(".claude.json"),
         r#"{"host":"profile","oauthAccount":{"x":1}}"#,
@@ -586,10 +619,10 @@ fn mount_specs(log: &Path) -> Vec<String> {
     specs
 }
 
-// -- Test 7: copy stages the allowlist (deref + trust) and completes ---------
+// -- Test 7: full stages the allowlist (deref + trust) and completes ---------
 
 #[tokio::test]
-async fn copy_run_stages_allowlist_and_completes() {
+async fn full_run_stages_allowlist_and_completes() {
     ensure_pdo_on_path();
     let (_fake_dir, docker, _log) = write_fake_docker();
     let daemon =
@@ -598,14 +631,14 @@ async fn copy_run_stages_allowlist_and_completes() {
             .unwrap();
     fabricate_host_claude(daemon.repo_root());
 
-    let run_id = start_run(&daemon, Some("copy")).await;
+    let run_id = start_run(&daemon, Some("full")).await;
     let run = get_run(&daemon, &run_id).await;
     assert_eq!(
-        run["sandbox"], "copy",
-        "run must project sandbox=copy: {run}"
+        run["sandbox"], "full",
+        "run must project sandbox=full: {run}"
     );
 
-    // Node reaches Running ⇒ eager prep (incl. the copy walk + trust seed) is done.
+    // Node reaches Running ⇒ eager prep (incl. the full walk + the floor) is done.
     let run = wait_node_status(&daemon, &run_id, "running").await;
     assert_eq!(run["nodes"][NODE_ID]["status"], "running", "run: {run}");
 
@@ -636,6 +669,28 @@ async fn copy_run_stages_allowlist_and_completes() {
     assert!(std::fs::read_to_string(home.join("settings.json"))
         .unwrap()
         .contains("hooks"));
+    // #426 G2: the org managed-settings baseline is staged VERBATIM — through the
+    // daemon's real prep path, not just the unit. It lives OUTSIDE the `full`
+    // allowlist: the floor is its single writer.
+    assert_eq!(
+        std::fs::read_to_string(home.join(ORG_BASELINE_FILE)).unwrap(),
+        ORG_BASELINE,
+        "the org managed-settings baseline must be staged byte-for-byte"
+    );
+    // #426 G3: the bypass key is MERGED into the copied host settings — the hooks
+    // survive (a naive overwrite would drop them).
+    let staged_settings: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(home.join("settings.json")).unwrap())
+            .unwrap();
+    assert_eq!(
+        staged_settings[BYPASS_PERMISSIONS_KEY],
+        serde_json::json!(true),
+        "staged settings.json must carry the bypass key: {staged_settings}"
+    );
+    assert!(
+        staged_settings["hooks"]["Stop"].is_array(),
+        "the merge must be non-destructive: {staged_settings}"
+    );
     assert!(home.join("settings.local.json").is_file());
     assert!(home.join(".credentials.json").is_file());
     assert!(home.join("CLAUDE.md").is_file());
@@ -655,7 +710,7 @@ async fn copy_run_stages_allowlist_and_completes() {
     assert_eq!(
         json["projects"][&repo_key]["hasTrustDialogAccepted"],
         serde_json::json!(true),
-        "copy seeds trust for the Run's repo_root: {json}"
+        "the floor seeds trust for the Run's repo_root: {json}"
     );
     assert!(
         !home.join(".claude.json").exists(),
@@ -667,16 +722,22 @@ async fn copy_run_stages_allowlist_and_completes() {
     assert_eq!(std::fs::read_dir(home.join("projects")).unwrap().count(), 0);
 
     // Drive the run terminal (simulate the container's output + `pdo complete`).
-    write_node_output(&daemon, &run_id, "copy output\n");
+    write_node_output(&daemon, &run_id, "full output\n");
     simulate_node_done(&daemon, &run_id).await;
     let run = wait_run_status(&daemon, &run_id, "completed").await;
-    assert_eq!(run["status"], "completed", "copy run must complete: {run}");
+    assert_eq!(run["status"], "completed", "full run must complete: {run}");
 }
 
-// -- Test 8: copy excludes projects/ and bulky host state --------------------
+// -- Test 7-bis (#426): minimal against a FABRICATED host — the floor's fork ---
+//
+// The only layer-3 test that drives `minimal` with a real host `~/.claude` present.
+// That is exactly where the floor's copy-vs-synthesis fork lives: `remote-settings`
+// is COPIED in both modes (G2), while `settings.json` is SYNTHESISED in `minimal`
+// even though a rich host file sits right there (G3). Without a fabricated host, G2
+// would take its no-op branch in every layer-3 test.
 
 #[tokio::test]
-async fn copy_excludes_projects_and_bulky_host_state() {
+async fn minimal_run_stages_the_floor_against_a_fabricated_host() {
     ensure_pdo_on_path();
     let (_fake_dir, docker, _log) = write_fake_docker();
     let daemon =
@@ -685,7 +746,68 @@ async fn copy_excludes_projects_and_bulky_host_state() {
             .unwrap();
     fabricate_host_claude(daemon.repo_root());
 
-    let run_id = start_run(&daemon, Some("copy")).await;
+    let run_id = start_run(&daemon, Some("minimal")).await;
+    wait_node_status(&daemon, &run_id, "running").await;
+
+    let home = staged_home(&daemon, &run_id);
+    assert!(
+        wait_until(|| home.join("settings.json").is_file()).await,
+        "staging should be seeded once the node is running"
+    );
+
+    // (a) G2 — COPY branch: the org baseline is staged even in `minimal`.
+    assert_eq!(
+        std::fs::read_to_string(home.join(ORG_BASELINE_FILE)).unwrap(),
+        ORG_BASELINE,
+        "the floor stages the org baseline in `minimal` too"
+    );
+
+    // (b) G3 — SYNTHESIS branch: the host `settings.json` carries `hooks`, the staged
+    // one carries the bypass key and NOTHING of the host.
+    let settings: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(home.join("settings.json")).unwrap())
+            .unwrap();
+    assert_eq!(
+        settings,
+        serde_json::json!({ BYPASS_PERMISSIONS_KEY: true }),
+        "`minimal` synthesises settings.json — it never copies the host's: {settings}"
+    );
+
+    // (c) `minimal` really is minimal: nothing from the `full` profile leaked in.
+    assert!(!home.join("skills").exists());
+    assert!(!home.join("plugins").exists());
+    assert!(!home.join("CLAUDE.md").exists());
+
+    // (d) The host `.claude` is untouched (no write-back through the floor).
+    let host_settings = daemon.repo_root().join(".claude/settings.json");
+    assert_eq!(
+        std::fs::read_to_string(&host_settings).unwrap(),
+        r#"{"hooks":{"Stop":[]}}"#,
+        "the floor must never write to the host `~/.claude`"
+    );
+
+    write_node_output(&daemon, &run_id, "minimal output\n");
+    simulate_node_done(&daemon, &run_id).await;
+    let run = wait_run_status(&daemon, &run_id, "completed").await;
+    assert_eq!(
+        run["status"], "completed",
+        "minimal run must complete: {run}"
+    );
+}
+
+// -- Test 8: full excludes projects/ and bulky host state --------------------
+
+#[tokio::test]
+async fn full_excludes_projects_and_bulky_host_state() {
+    ensure_pdo_on_path();
+    let (_fake_dir, docker, _log) = write_fake_docker();
+    let daemon =
+        TestDaemon::spawn_with_docker_override(seed("#!/usr/bin/env bash\ntrue\n"), docker)
+            .await
+            .unwrap();
+    fabricate_host_claude(daemon.repo_root());
+
+    let run_id = start_run(&daemon, Some("full")).await;
     wait_node_status(&daemon, &run_id, "running").await;
 
     let home = staged_home(&daemon, &run_id);
@@ -707,7 +829,7 @@ async fn copy_excludes_projects_and_bulky_host_state() {
 // -- Test 9: the real host ~/.claude is never a mount SOURCE -----------------
 
 #[tokio::test]
-async fn copy_never_mounts_the_real_host_claude() {
+async fn full_never_mounts_the_real_host_claude() {
     ensure_pdo_on_path();
     let (_fake_dir, docker, log) = write_fake_docker();
     let daemon =
@@ -716,7 +838,7 @@ async fn copy_never_mounts_the_real_host_claude() {
             .unwrap();
     fabricate_host_claude(daemon.repo_root());
 
-    let run_id = start_run(&daemon, Some("copy")).await;
+    let run_id = start_run(&daemon, Some("full")).await;
     // `container inspect` → ABSENT → ensure_running does `create` (mounts logged).
     assert!(
         wait_until(|| log_text(&log).contains("create")).await,
@@ -761,7 +883,7 @@ async fn copy_never_mounts_the_real_host_claude() {
 // -- Test 10: no host config write-back; transcripts DO flow back ------------
 
 #[tokio::test]
-async fn copy_completes_without_host_config_writeback() {
+async fn full_completes_without_host_config_writeback() {
     ensure_pdo_on_path();
     let (_fake_dir, docker, _log) = write_fake_docker();
     let daemon =
@@ -776,7 +898,7 @@ async fn copy_completes_without_host_config_writeback() {
     let settings_before = std::fs::read(host_claude.join("settings.json")).unwrap();
     let json_before = std::fs::read(&host_json).unwrap();
 
-    let run_id = start_run(&daemon, Some("copy")).await;
+    let run_id = start_run(&daemon, Some("full")).await;
     wait_node_status(&daemon, &run_id, "running").await;
     write_node_output(&daemon, &run_id, "done\n");
     simulate_node_done(&daemon, &run_id).await;
@@ -888,7 +1010,7 @@ async fn registry_mode_pulls_the_sandbox_image() {
 
     // Store registry mode BEFORE starting the run — eager prep reads it fresh.
     put_image_source(&daemon, "registry").await;
-    let _run_id = start_run(&daemon, Some("pure")).await;
+    let _run_id = start_run(&daemon, Some("minimal")).await;
 
     // ensure_image (image absent) attempts a pull before any build.
     assert!(
@@ -916,7 +1038,7 @@ async fn dockerfile_mode_builds_never_pulls() {
             .unwrap();
 
     put_image_source(&daemon, "dockerfile").await;
-    let _run_id = start_run(&daemon, Some("pure")).await;
+    let _run_id = start_run(&daemon, Some("minimal")).await;
 
     assert!(
         wait_until(|| log_has_subcommand(&log, "build")).await,
@@ -1054,7 +1176,7 @@ async fn get_settings_reports_docker_unavailable_when_binary_absent() {
 // -- Test 14: a per-Trigger sandbox mode fires sandboxed Runs -----------------
 
 #[tokio::test]
-async fn trigger_with_sandbox_pure_fires_pure_run() {
+async fn trigger_with_sandbox_minimal_fires_minimal_run() {
     ensure_pdo_on_path();
     let (_fake_dir, docker, _log) = write_fake_docker();
     let daemon =
@@ -1062,13 +1184,13 @@ async fn trigger_with_sandbox_pure_fires_pure_run() {
             .await
             .unwrap();
 
-    let trigger_id = create_trigger(&daemon, Some("pure")).await;
+    let trigger_id = create_trigger(&daemon, Some("minimal")).await;
     let run_id = fire_trigger_and_get_run(&daemon, &trigger_id).await;
 
     let run = get_run(&daemon, &run_id).await;
     assert_eq!(
-        run["sandbox"], "pure",
-        "a trigger with sandbox=pure must fire a pure Run: {run}"
+        run["sandbox"], "minimal",
+        "a trigger with sandbox=minimal must fire a minimal Run: {run}"
     );
 }
 
@@ -1083,14 +1205,14 @@ async fn trigger_without_sandbox_defers_to_instance_default() {
             .await
             .unwrap();
 
-    // Instance default = copy; the Trigger carries no sandbox → it inherits.
-    put_default_sandbox(&daemon, "copy").await;
+    // Instance default = full; the Trigger carries no sandbox → it inherits.
+    put_default_sandbox(&daemon, "full").await;
     let trigger_id = create_trigger(&daemon, None).await;
     let run_id = fire_trigger_and_get_run(&daemon, &trigger_id).await;
 
     let run = get_run(&daemon, &run_id).await;
     assert_eq!(
-        run["sandbox"], "copy",
-        "a null-sandbox Trigger must defer to the instance default (copy): {run}"
+        run["sandbox"], "full",
+        "a null-sandbox Trigger must defer to the instance default (full): {run}"
     );
 }

--- a/docs/adr/0030-sandbox-execution-model.md
+++ b/docs/adr/0030-sandbox-execution-model.md
@@ -153,10 +153,15 @@ Quatre points de cette ADR sont amendés à l'issue de la validation manuelle du
 merge vers `main`. Le détail du modèle de contenu vit dans **ADR-0031** ; ici, ce qui change du
 modèle d'*exécution*.
 
-1. **Vocabulaire.** Le tri-état devient `off` | `minimal` | `full` (ex-`pure`/`copy`). Aucun alias
-   de compatibilité : les seules valeurs persistées vivaient dans la base de l'instance de test,
-   nettoyée avant le renommage. `minimal` est plus juste que `pure` depuis que le plancher de
-   garanties (ADR-0031 §1) y seede des consentements — le mode n'est pas *pur*, il est *minimal*.
+1. **Vocabulaire (réalisé en #426).** Le tri-état devient `off` | `minimal` | `full`
+   (ex-`pure`/`copy`). Aucun alias de compatibilité : aucune valeur persistée n'existe dans
+   l'instance prod ni dans l'instance dev (0/399 et 0/103 `run_started` ; ni l'une ni l'autre n'a même
+   les colonnes `default_sandbox` / `triggers.sandbox`), un alias n'aurait donc servi que des
+   instances de validation jetables. Corollaire assumé : un token pré-renommage retrouvé dans un log
+   d'événements se dégrade en `off`, donc vers **moins** d'isolation — les trois décodeurs le
+   **loggent** (#426), le point 4 interdisant tout fallback hôte silencieux. `minimal` est plus juste
+   que `pure` depuis que le plancher de garanties (ADR-0031 §1) y seede des consentements — le mode
+   n'est pas *pur*, il est *minimal*.
 
 2. **Les identity mounts ne sont plus une liste fermée.** Aux quatre mounts du point 1 (repo,
    `.claude` stagé, `.claude.json` stagé, binaire `pdo`) s'ajoutent les **exceptions déclarées** par
@@ -188,10 +193,14 @@ modèle d'*exécution*.
    installé, auto-updater off, `$HOME` inscriptible au chemin hôte) et rouvrirait une question
    d'auth que le pull anonyme évite.
 
+Le corps de cette ADR (points 1-10) est laissé **tel quel**, dans le vocabulaire d'avant #426 : y
+lire `full` partout où il dit `copy`, et `minimal` partout où il dit `pure`.
+
 ## Relations
 
 - **ADR-0031** (profils de staging) : *ce que* le home stagé contient, là où cette ADR fixe *où* et
-  *comment* le Run s'exécute.
+  *comment* le Run s'exécute. §1 (le plancher de garanties) est **réalisé en #426**, avec le point 1
+  de l'amendement ci-dessus.
 - **ADR-0004** (stratégie de test) : golden des tails wrappées (unit) + layer-3 (Docker indispo →
   RunFailed, off inchangé, cleanup/boot/kill) via les seams `docker_cmd_override` +
   `sandbox_home_override` (per-daemon, #181) — jamais d'`std::env` global ni de vrai Docker en CI.

--- a/docs/adr/0031-sandbox-staging-profiles.md
+++ b/docs/adr/0031-sandbox-staging-profiles.md
@@ -2,14 +2,15 @@
 
 > Statut : accepted (grilling du 2026-07-24, PRD #403). Vocabulaire : CONTEXT.md § « Sandbox ».
 > Complète ADR-0030 (modèle d'exécution) : ADR-0030 dit *où* tourne un Run sandboxé, celle-ci dit
-> *avec quel contenu de home*. Implémentée par les slices « plancher » puis « profils ».
+> *avec quel contenu de home*. Implémentée par les slices « plancher » puis « profils » : §1 est
+> **réalisé en #426** (avec l'amendement §1 d'ADR-0030) ; §2-§7 restent à livrer.
 
 Le contenu du *staged Claude home* cesse d'être une constante Rust invisible. Il devient un
 **profil de staging** : une liste nommée, éditable, sélectionnable par Run et par Trigger.
 
 ## Ce qu'on décide
 
-1. **Le plancher est une liste de garanties, pas de fichiers verrouillés.** Quel que soit le
+1. **Le plancher est une liste de garanties, pas de fichiers verrouillés** *(réalisé en #426)*. Quel que soit le
    profil, `prepare` garantit qu'au démarrage la session dispose de : credentials valides, managed
    settings de l'org **consentis**, bypass permissions accepté, confiance pré-accordée à la racine
    du Run, `projects/` vide. Chaque garantie est satisfaite **soit** par une entrée du profil,
@@ -69,7 +70,7 @@ Le contenu du *staged Claude home* cesse d'être une constante Rust invisible. I
 
 Le mode est un interrupteur à deux positions qui décide de *tout* d'un coup — skills, plugins,
 agents, commands, settings, `.md` globaux. Or le poste de coût est **un seul** de ces éléments :
-`copy`/`full` pèse ~1 Go par Run, « dominé par `plugins/*/node_modules` », et le staging n'est purgé
+`full` pèse ~1 Go par Run, « dominé par `plugins/*/node_modules` », et le staging n'est purgé
 qu'au `cleanup_run`. Un pipeline qui a besoin des skills mais pas des serveurs MCP n'avait aucune
 option : il payait 1 Go ou il perdait tout. Sur une instance à Triggers horaires, ce choix
 binaire alimente directement la récurrence disque connue.
@@ -106,4 +107,5 @@ un Run sandboxé pour faire le travail réel est ailleurs dans `$HOME` : l'ident
 - **ADR-0015** — précédence `stored → env → default` des réglages d'instance ; les défauts virtuels
   `minimal`/`full` en sont l'application à une valeur non scalaire.
 - **ADR-0001** — outil tranchant, pas outil sûr : fonde le choix « autoriser + avertir » (§3).
-- **#403** — PRD Sandbox ; ces décisions sont livrées par les slices post-validation du PRD.
+- **#403** — PRD Sandbox ; ces décisions sont livrées par les slices post-validation du PRD. §1 est
+  livré par **#426**, §2-§7 par les slices « profils ».

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -344,7 +344,7 @@ export interface CreateRunRequest {
   target_repo?: string;
   source_branch?: string;
   name?: string;
-  /** Explicit sandbox mode (#410): `"off"` | `"copy"` | `"pure"`. Omitted → the
+  /** Explicit sandbox mode (#410): `"off"` | `"full"` | `"minimal"`. Omitted → the
    *  server defers to the trigger/instance default at the create chokepoint. */
   sandbox?: string;
   images?: File[];
@@ -395,7 +395,7 @@ export interface CreateTriggerRequest {
   overlap_policy?: string;
   /** Bounded-`allow` ceiling (#239): max simultaneous live Runs; omit/undefined = unbounded. */
   max_concurrent?: number | null;
-  /** Per-Trigger sandbox mode (#410): `"off"` | `"copy"` | `"pure"`, or null/omit to
+  /** Per-Trigger sandbox mode (#410): `"off"` | `"full"` | `"minimal"`, or null/omit to
    *  inherit the instance default. */
   sandbox?: string | null;
 }

--- a/frontend/src/components/NewRunModal.test.tsx
+++ b/frontend/src/components/NewRunModal.test.tsx
@@ -1331,21 +1331,21 @@ describe("NewRunModal — sandbox selector (#410)", () => {
   it("prefills the run selector from the instance default", async () => {
     vi.mocked(fetchSettings).mockResolvedValue(
       settingsFixture({
-        default_sandbox: { effective: "copy", source: "stored", stored: "copy", env: null, default: "off" },
+        default_sandbox: { effective: "full", source: "stored", stored: "full", env: null, default: "off" },
       }),
     );
     vi.mocked(fetchPipelines).mockResolvedValue([makePipeline({ id: "p1", name: "P", scope: "repo" })]);
     renderModal();
     await waitFor(() => {
-      expect((screen.getByTestId("sandbox-select") as HTMLSelectElement).value).toBe("copy");
+      expect((screen.getByTestId("sandbox-select") as HTMLSelectElement).value).toBe("full");
     });
   });
 
-  it("disables copy/pure and clamps to off when Docker is unavailable (availability wins over prefill)", async () => {
+  it("disables full/minimal and clamps to off when Docker is unavailable (availability wins over prefill)", async () => {
     vi.mocked(fetchSettings).mockResolvedValue(
       settingsFixture({
-        // The instance default is `pure`, but Docker is down: greying wins.
-        default_sandbox: { effective: "pure", source: "stored", stored: "pure", env: null, default: "off" },
+        // The instance default is `minimal`, but Docker is down: greying wins.
+        default_sandbox: { effective: "minimal", source: "stored", stored: "minimal", env: null, default: "off" },
         sandbox_docker: { available: false, reason: "Docker daemon unreachable", checked_at: "x" },
       }),
     );
@@ -1355,17 +1355,17 @@ describe("NewRunModal — sandbox selector (#410)", () => {
     const select = (await screen.findByTestId("sandbox-select")) as HTMLSelectElement;
     // Clamped to off (never mints a Run doomed to RunFailed).
     await waitFor(() => expect(select.value).toBe("off"));
-    // copy/pure options are disabled; the reason is surfaced.
+    // full/minimal options are disabled; the reason is surfaced.
     const options = Array.from(select.options);
-    expect(options.find((o) => o.value === "copy")?.disabled).toBe(true);
-    expect(options.find((o) => o.value === "pure")?.disabled).toBe(true);
+    expect(options.find((o) => o.value === "full")?.disabled).toBe(true);
+    expect(options.find((o) => o.value === "minimal")?.disabled).toBe(true);
     expect(screen.getByTestId("sandbox-docker-warning")).toHaveTextContent(/unreachable/i);
   });
 
   it("passes the chosen sandbox mode to createRun", async () => {
     vi.mocked(fetchSettings).mockResolvedValue(
       settingsFixture({
-        default_sandbox: { effective: "copy", source: "stored", stored: "copy", env: null, default: "off" },
+        default_sandbox: { effective: "full", source: "stored", stored: "full", env: null, default: "off" },
       }),
     );
     vi.mocked(fetchPipelines).mockResolvedValue([
@@ -1373,9 +1373,9 @@ describe("NewRunModal — sandbox selector (#410)", () => {
     ]);
     renderModal();
     await enterValidRepo();
-    // The prefill lands "copy".
+    // The prefill lands "full".
     await waitFor(() => {
-      expect((screen.getByTestId("sandbox-select") as HTMLSelectElement).value).toBe("copy");
+      expect((screen.getByTestId("sandbox-select") as HTMLSelectElement).value).toBe("full");
     });
 
     vi.useRealTimers();
@@ -1383,7 +1383,7 @@ describe("NewRunModal — sandbox selector (#410)", () => {
     fireEvent.click(screen.getByRole("button", { name: /launch/i }));
 
     await waitFor(() => {
-      expect(createRun).toHaveBeenCalledWith(expect.objectContaining({ sandbox: "copy" }));
+      expect(createRun).toHaveBeenCalledWith(expect.objectContaining({ sandbox: "full" }));
     });
   });
 
@@ -1391,7 +1391,7 @@ describe("NewRunModal — sandbox selector (#410)", () => {
     vi.mocked(fetchPipelines).mockResolvedValue([
       makePipeline({ id: "p1", name: "Auditor", scope: "repo", prompt_required: false }),
     ]);
-    // A trigger whose sandbox is set to `pure` — prefills the select to `pure`.
+    // A trigger whose sandbox is set to `minimal` — prefills the select to `minimal`.
     const trigger = {
       id: "trg-sbx",
       name: "Nightly",
@@ -1404,7 +1404,7 @@ describe("NewRunModal — sandbox selector (#410)", () => {
       cron: "0 9 * * *",
       guard_command: null,
       overlap_policy: "skip",
-      sandbox: "pure",
+      sandbox: "minimal",
       enabled: true,
       next_fire_at: null,
       last_fired_at: null,
@@ -1416,7 +1416,7 @@ describe("NewRunModal — sandbox selector (#410)", () => {
     );
 
     const select = (await screen.findByTestId("sandbox-select")) as HTMLSelectElement;
-    await waitFor(() => expect(select.value).toBe("pure"));
+    await waitFor(() => expect(select.value).toBe("minimal"));
     // Trigger mode exposes the inherit option.
     expect(Array.from(select.options).some((o) => o.value === "")).toBe(true);
 

--- a/frontend/src/components/NewRunModal.tsx
+++ b/frontend/src/components/NewRunModal.tsx
@@ -93,7 +93,7 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
 
   // Sandbox (#410). `settings` carries the instance `default_sandbox` (prefill) and
   // the advisory `sandbox_docker` probe (greying). `sandbox` is the selector value:
-  // a concrete `off`/`copy`/`pure` in run mode; also `""` in trigger mode, meaning
+  // a concrete `off`/`full`/`minimal` in run mode; also `""` in trigger mode, meaning
   // "inherit the instance default".
   const [settings, setSettings] = useState<InstanceSettings | null>(null);
   const [sandbox, setSandbox] = useState<string>("off");
@@ -307,7 +307,7 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
   // #410: seed the sandbox selector once per open, matched to the intent. Edit/new
   // trigger seed synchronously (from the trigger / the "inherit" sentinel); a plain
   // run waits for the settings fetch to prefill the instance default, CLAMPED to
-  // `off` when Docker is unavailable (availability wins over a `copy`/`pure` prefill
+  // `off` when Docker is unavailable (availability wins over a `full`/`minimal` prefill
   // so we never mint a Run doomed to a RunFailed the UI could have prevented).
   useEffect(() => {
     if (!open) {
@@ -472,7 +472,7 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
         source_branch: sourceBranch || undefined,
         name: autoName ? undefined : runName.trim() || undefined,
         // #410: the explicit run-level mode. Always concrete in run mode
-        // (off/copy/pure); sent explicitly so it wins the create-chokepoint
+        // (off/full/minimal); sent explicitly so it wins the create-chokepoint
         // precedence over any instance/trigger default.
         sandbox: sandbox || undefined,
         images: images.length > 0 ? images : undefined,
@@ -494,7 +494,7 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
 
   const canLaunch = repoValid && selectedPipeline && hasRequiredPrompt;
 
-  // #410: advisory Docker greying. Only gate `copy`/`pure` once we KNOW Docker is
+  // #410: advisory Docker greying. Only gate `full`/`minimal` once we KNOW Docker is
   // unavailable (settings loaded && probe false); while settings load, stay
   // optimistic. `sandboxReason` explains the greying (title + help text).
   const dockerUnavailable = settings != null && !settings.sandbox_docker.available;
@@ -909,8 +909,8 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
             </div>
 
             {/* Sandbox (#410): the isolation mode. Run mode offers a concrete
-                off/copy/pure (prefilled from the instance default); Trigger mode adds
-                a leading "Use instance default" option. `copy`/`pure` are disabled
+                off/full/minimal (prefilled from the instance default); Trigger mode adds
+                a leading "Use instance default" option. `full`/`minimal` are disabled
                 when the daemon reports Docker unavailable (advisory greying — the
                 run-advance fail-fast remains authoritative). */}
             <div className="flex flex-col gap-1.5">
@@ -934,11 +934,13 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
                   <option value="">Use instance default</option>
                 )}
                 <option value="off">off (run on the host)</option>
-                <option value="copy" disabled={dockerUnavailable}>
-                  {dockerUnavailable ? "copy (Docker unavailable)" : "copy (Docker sandbox)"}
+                <option value="full" disabled={dockerUnavailable}>
+                  {dockerUnavailable ? "full (Docker unavailable)" : "full (Docker sandbox)"}
                 </option>
-                <option value="pure" disabled={dockerUnavailable}>
-                  {dockerUnavailable ? "pure (Docker unavailable)" : "pure (Docker sandbox)"}
+                <option value="minimal" disabled={dockerUnavailable}>
+                  {dockerUnavailable
+                    ? "minimal (Docker unavailable)"
+                    : "minimal (Docker sandbox)"}
                 </option>
               </select>
               {dockerUnavailable && (

--- a/frontend/src/components/PipelineInfoPanel.test.tsx
+++ b/frontend/src/components/PipelineInfoPanel.test.tsx
@@ -42,15 +42,15 @@ function renderPanel(run: RunState | null) {
 }
 
 describe("PipelineInfoPanel — sandbox surface (#410)", () => {
-  it("shows the sandbox badge for a sandboxed run (pure)", () => {
-    renderPanel(makeRun({ sandbox: "pure" }));
+  it("shows the sandbox badge for a sandboxed run (minimal)", () => {
+    renderPanel(makeRun({ sandbox: "minimal" }));
     const badge = screen.getByTestId("sandbox-badge");
-    expect(badge).toHaveTextContent(/sandbox:\s*pure/i);
+    expect(badge).toHaveTextContent(/sandbox:\s*minimal/i);
   });
 
-  it("shows the sandbox badge for a copy run", () => {
-    renderPanel(makeRun({ sandbox: "copy" }));
-    expect(screen.getByTestId("sandbox-badge")).toHaveTextContent(/sandbox:\s*copy/i);
+  it("shows the sandbox badge for a full run", () => {
+    renderPanel(makeRun({ sandbox: "full" }));
+    expect(screen.getByTestId("sandbox-badge")).toHaveTextContent(/sandbox:\s*full/i);
   });
 
   it("omits the badge for an off/host run", () => {
@@ -64,12 +64,12 @@ describe("PipelineInfoPanel — sandbox surface (#410)", () => {
   });
 
   it("shows the preparation banner while sandbox_prep is pending", () => {
-    renderPanel(makeRun({ sandbox: "pure", sandbox_prep: "pending" }));
+    renderPanel(makeRun({ sandbox: "minimal", sandbox_prep: "pending" }));
     expect(screen.getByTestId("sandbox-prep-banner")).toHaveTextContent(/preparing the sandbox/i);
   });
 
   it("hides the preparation banner once sandbox_prep is ready", () => {
-    renderPanel(makeRun({ sandbox: "pure", sandbox_prep: "ready" }));
+    renderPanel(makeRun({ sandbox: "minimal", sandbox_prep: "ready" }));
     expect(screen.queryByTestId("sandbox-prep-banner")).not.toBeInTheDocument();
     // The badge stays visible after prep completes.
     expect(screen.getByTestId("sandbox-badge")).toBeInTheDocument();

--- a/frontend/src/components/PipelineInfoPanel.tsx
+++ b/frontend/src/components/PipelineInfoPanel.tsx
@@ -196,7 +196,7 @@ function InfoTab({
               {run ? `run ${run.run_id.slice(-8)} · ${pipeline?.version ?? "v1"}` : `template · ${pipeline?.version ?? "v1"}`}
             </div>
           </div>
-          {/* Sandbox badge (#410): shown for any sandboxed Run (copy/pure). An
+          {/* Sandbox badge (#410): shown for any sandboxed Run (full/minimal). An
               `off`/host Run renders nothing — the field is absent on those. */}
           {run?.sandbox && run.sandbox !== "off" && (
             <span

--- a/frontend/src/components/SettingsModal.test.tsx
+++ b/frontend/src/components/SettingsModal.test.tsx
@@ -254,9 +254,9 @@ describe("SettingsModal", () => {
     fetchSettingsMock.mockResolvedValue(
       sample({
         default_sandbox: {
-          effective: "pure",
+          effective: "minimal",
           source: "stored",
-          stored: "pure",
+          stored: "minimal",
           env: null,
           default: "off",
         },
@@ -264,7 +264,7 @@ describe("SettingsModal", () => {
     );
     render(<SettingsModal open onClose={() => {}} />);
     const select = (await screen.findByTestId("setting-default-sandbox")) as HTMLSelectElement;
-    expect(select.value).toBe("pure");
+    expect(select.value).toBe("minimal");
   });
 
   it("saves the picked default sandbox (#410)", async () => {
@@ -272,9 +272,9 @@ describe("SettingsModal", () => {
     updateSettingsMock.mockResolvedValue(
       sample({
         default_sandbox: {
-          effective: "copy",
+          effective: "full",
           source: "stored",
-          stored: "copy",
+          stored: "full",
           env: null,
           default: "off",
         },
@@ -284,11 +284,11 @@ describe("SettingsModal", () => {
     render(<SettingsModal open onClose={onClose} />);
 
     const select = await screen.findByTestId("setting-default-sandbox");
-    fireEvent.change(select, { target: { value: "copy" } });
+    fireEvent.change(select, { target: { value: "full" } });
     fireEvent.click(screen.getByTestId("settings-save"));
 
     await waitFor(() => expect(updateSettingsMock).toHaveBeenCalledTimes(1));
-    expect(updateSettingsMock).toHaveBeenCalledWith({ default_sandbox: "copy" });
+    expect(updateSettingsMock).toHaveBeenCalledWith({ default_sandbox: "full" });
     await waitFor(() => expect(onClose).toHaveBeenCalled());
   });
 
@@ -306,17 +306,17 @@ describe("SettingsModal", () => {
     fetchSettingsMock.mockResolvedValue(
       sample({
         default_sandbox: {
-          effective: "pure",
+          effective: "minimal",
           source: "stored",
-          stored: "pure",
-          env: "copy",
+          stored: "minimal",
+          env: "full",
           default: "off",
         },
       }),
     );
     render(<SettingsModal open onClose={() => {}} />);
     const note = await screen.findByTestId("setting-source-default-sandbox");
-    expect(note).toHaveTextContent("PDO_DEFAULT_SANDBOX=copy");
+    expect(note).toHaveTextContent("PDO_DEFAULT_SANDBOX=full");
     expect(note).toHaveTextContent(/overridden/i);
   });
 });

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -389,13 +389,13 @@ function SettingsForm({ settings, liveSessions, save, onClose, onSaved }: FormPr
             style={{ fontSize: "12px" }}
           >
             <option value="off">off (run on the host)</option>
-            <option value="copy">copy (Docker, copy your Claude home)</option>
-            <option value="pure">pure (Docker, credentials + trust only)</option>
+            <option value="full">full (Docker, replica of your Claude home)</option>
+            <option value="minimal">minimal (Docker, staging floor only)</option>
           </select>
           <div className="text-fg-4" style={{ fontSize: "10.5px" }}>
             The isolation mode a Run uses when neither the launch dialog nor a firing
             Trigger picks one. <span className="font-mono">off</span> runs on the host;{" "}
-            <span className="font-mono">copy</span> and <span className="font-mono">pure</span>{" "}
+            <span className="font-mono">full</span> and <span className="font-mono">minimal</span>{" "}
             run inside a Docker sandbox (require Docker).
           </div>
           <div

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -91,8 +91,8 @@ export interface InstanceSettings {
    */
   image_source: StringSettingField;
   /**
-   * Instance-wide default sandbox mode (#410): `"off"` (host, default), `"copy"`,
-   * or `"pure"`. A closed enum with a built-in `off` default, so every tier is a
+   * Instance-wide default sandbox mode (#410): `"off"` (host, default), `"full"`,
+   * or `"minimal"`. A closed enum with a built-in `off` default, so every tier is a
    * present string — reuses {@link StringSettingField} (a superset) though it is
    * never null. The create-run chokepoint resolves precedence run → trigger → this.
    */
@@ -100,7 +100,7 @@ export interface InstanceSettings {
   /**
    * Advisory Docker availability probe (#410), folded into `GET /settings` so the
    * NewRunModal learns the default AND whether Docker can run a sandbox in one fetch.
-   * `available: false` grays out `copy`/`pure` (`reason` explains why); the
+   * `available: false` grays out `full`/`minimal` (`reason` explains why); the
    * run-advance fail-fast stays the authoritative gate.
    */
   sandbox_docker: {
@@ -126,7 +126,7 @@ export interface UpdateSettingsRequest {
   /** Sandbox image source (#411): `"registry"` | `"dockerfile"`. The `<select>` only
    *  ever sends a concrete variant — the `""` clear sentinel is backend-only. */
   image_source?: string;
-  /** Default sandbox mode (#410): `"off"` | `"copy"` | `"pure"`, or `""` to clear
+  /** Default sandbox mode (#410): `"off"` | `"full"` | `"minimal"`, or `""` to clear
    *  back to the built-in default (`off`). Same `""`-sentinel discipline as
    *  `default_model`/`image_source`. */
   default_sandbox?: string;
@@ -184,7 +184,7 @@ export interface Trigger {
   overlap_policy: string;
   /** Bounded-`allow` ceiling (#239): max simultaneous live Runs; null = unbounded. */
   max_concurrent?: number | null;
-  /** Per-Trigger sandbox mode (#410): `"off"` | `"copy"` | `"pure"`, or null/absent
+  /** Per-Trigger sandbox mode (#410): `"off"` | `"full"` | `"minimal"`, or null/absent
    *  to inherit the instance default. Read at fire time. */
   sandbox?: string | null;
   enabled: boolean;
@@ -342,7 +342,7 @@ export interface RunState {
    * runs (projected as `off` server-side and skipped from the payload when off).
    * Immutable once the Run started.
    */
-  sandbox?: "off" | "copy" | "pure";
+  sandbox?: "off" | "full" | "minimal";
   /**
    * One-time image-prep visibility for a sandboxed Run (#410). `"pending"` while
    * the image is pulled/built at first use; `"ready"` once the container is about


### PR DESCRIPTION
Slice I du PRD #403. Renomme le vocabulaire de sandbox `off|copy|pure` → **`off|minimal|full`**
(sans aucun alias de compatibilité) et garantit un **plancher de staging** : quel que soit le
profil Docker, la baseline de configuration `claude` est posée dans le home stagé *avant* que le
conteneur n'existe, de sorte qu'aucun dialogue interactif ne puisse bloquer une session de nœud.

Décisions documentées dans `docs/adr/0031-sandbox-staging-profiles.md` (profils de staging) et
l'amendement à `docs/adr/0030` (`y lire full partout où il dit copy`).

## Ce que fait la slice

- **Vocabulaire** — `SandboxMode` et le `Mode` du staging sont `Off|Full|Minimal`. Le parse rejette
  `copy` et `pure` (`None`) : `PUT /settings {"default_sandbox":"copy"}` → **400**,
  `POST /runs {"sandbox":"pure"}` → **400**. Trois `warn!` nomment explicitement les tokens morts
  pour rester actionnables. Front aligné : valeurs *et* libellés d'`<option>` (`NewRunModal`,
  `SettingsModal`, `PipelineInfoPanel`, badge de run).
- **Plancher de staging garanti** — `prepare` en deux phases : le plancher est posé
  inconditionnellement (y compris en `minimal`, où le bras de copie est vide).
  - `remote-settings.json` de l'hôte copié **verbatim** (0600) quand il existe — consentement aux
    managed settings ;
  - absent chez l'hôte → **no-op explicitement loggé**, jamais un `RunFailed` ;
  - `skipDangerousModePermissionPrompt: true` — **synthétisé** en `minimal`, **mergé sans rien
    détruire** en `full` (les clés `hooks`/`model` de l'hôte survivent) ;
  - `.claude.json` stagé inconditionnel (`hasCompletedOnboarding`, `projects` trustant la racine du
    repo, 0600) — ferme le trou où Docker créait un *répertoire* par-dessus `$HOME/.claude.json`.

## Preuve AC5 — zéro valeur de mode `copy`/`pure` vivante

```
grep -rnE '"(copy|pure)"|(SandboxMode|[^a-zA-Z_])Mode::(Copy|Pure)\b|`(copy|pure)`|off[|/](copy|pure)|(copy|pure)[|/](copy|pure)|sandbox[ =:]+"?(copy|pure)' \
  --include='*.rs' --include='*.ts' --include='*.tsx' --include='*.md' \
  crates frontend/src CONTEXT.md docs/adr | grep -vE 'library_store\.rs|\(copy\)'
```

**36 lignes** (et non 32 comme annoncé par le rapport d'implémentation — compte recomptable
ci-dessus), toutes justifiées : 13 dans `sandbox_staging.rs` = préfixe de log et doc du **walk de
copie** (`sandbox copy:`), pas une valeur de mode ; 11 dans `event_log.rs` = pierres tombales, texte
des `warn!`, et les tests figeant `parse("copy") == None` / `parse("pure") == None` ; 7 dans
ADR-0030 = corps non retro-édité + sa ligne de lecture ; 3 dans `CONTEXT.md` = vocabulaire mort
nommé comme tel ; 2 dans `lib.rs` = texte de `warn!`.
`grep -rnE 'Mode::(Copy|Pure)\b' crates frontend/src` → **0**.

## Gates

| Gate | Résultat |
|---|---|
| `cargo +stable build -p pdo-daemon` | exit 0 |
| `cargo +stable fmt --all --check` | exit 0, zéro hunk |
| `cargo +stable clippy --all-targets -- -D warnings` | zéro warning |
| `cargo +stable test --workspace` | **1615 passés / 0 échec / 0 ignoré** |
| `npm run lint` / `npm run typecheck` / `npm run test` | PASS / PASS / 1342 tests |

## Validation agentique FP-426 — **Pass** (Docker réel)

Cinq AC vérifiées en conditions réelles (daemons jetables, fixtures d'hôte `with`/`without`,
wrapper `docker` loggant chaque argv horodaté), pas par relecture de code :

- **Contrôle négatif tiré d'abord** : sur fixture `without`, `Managed settings require approval`
  apparaît dans les 20 captures consécutives sur 40 s — c'est ce qui rend l'absence de dialogue
  attribuable ensuite.
- Les deux Runs à baseline stagée (`minimal` et `full`) **complètent**, footer
  `⏵⏵ bypass permissions on`, zéro dialogue sur les 8 chaînes recherchées.
- **Ordonnancement observé littéralement** : `file_mtime 23:34:25.590` < `container .Created
  23:34:25.803` < `first docker exec 23:34:26.167`. Le fichier est écrit **avant l'existence du
  conteneur**, recoupé par `docker inspect -f {{.Created}}`. `sha256(hôte) == sha256(stagé)`, 0600.
- Fourche copie-vs-synthèse réellement exercée (fixture sans la clé) : `minimal` → 1 seule clé ;
  `full` → merge, `hooks` et `model` survivent. Preuve *comportementale* en plus : le Run `full`
  exécute un `Bash(…)` **sans prompt d'approbation**.
- Hôte sans `remote-settings.json` → no-op loggé nommant le fichier, `settings.json` stagé quand
  même, **0 `run_failed`** dans les deux modes.

Hygiène : aucun contenu de `remote-settings.json` / `.credentials.json` lu ni versé dans un
artefact (assertions par `stat` et `sha256sum` uniquement). Le vrai `~/.claude` n'a jamais été
écrit — ce que corrobore la sentinelle `full_completes_without_host_config_writeback`.

## Findings non bloquants (pré-existants, hors périmètre #426)

- **Course `prepare` vs `pipeline_watcher`** (#406/#407) : a tiré sur un Run, avec preuve littérale
  (`exec 23:32:16.935` **précède** `start 23:32:17.438` → session morte, Run resté `running`).
  Nuance utile : la fenêtre n'est pas gouvernée par la durée de `prepare` (≈ 2 ms) mais par tout
  `ensure_ready`, dominé par un `docker create` mesuré à **52-55 s** sous load average ≈ 18,6
  contre 3,4 s à vide.
- **`.claude.json` stagé déchiré par deux `claude` concurrents** (2/2 Runs, les deux modes) : le
  fichier est bind-monté `rw` sur un seul chemin et deux sessions y `exec` en parallèle
  (`pdo-<run>-w1-iter-1` et `pdo-mgr-<run>`). `claude` s'en remet (sauvegarde + reconstruction) et
  le seed de confiance survit, mais le risque est latent puisque G4 vit dans ce fichier. À
  rattacher au modèle conteneur/sessions (#406).

Non exercé ici : le volume réel du mode `full` (~1 Go / ~42 s sur un `~/.claude` de 2,2 Go), le
déréférencement des symlinks échappants et `MAX_COPY_DEPTH` — la fixture mince est justement ce qui
rend le test rapide. Parité `claude` conteneur 2.1.218 / hôte 2.1.219.

Issue #426 (fermée à la main : les mots-clés de fermeture ne portent que sur la branche par défaut).
