### PR TITLE
feat(#432): sandbox K — profils de staging (nom + diff, gel, mounts $HOME, échec fort)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -857,8 +857,11 @@ La complétion est signalée **depuis l'UI**, par un bouton "Mark complete" sur 
 **Sandbox** :
 Propriété **par Run**, **immuable après création**, portée par l'événement de création (projetée
 dans l'état du Run). Tri-état `off` | `minimal` | `full` (renommé en #426, ex-`pure`/`copy`, **sans
-alias**) : `off` = comportement historique (sessions sur l'hôte, défaut) ; `minimal` / `full` =
-toutes les tails du Run s'exécutent dans un conteneur dédié.
+alias**) : `off` = comportement historique (sessions sur l'hôte, défaut) ; **tout autre nom** est un
+**profil de staging** (#432) — `minimal` / `full` en sont les deux défauts virtuels — et toutes les
+tails du Run s'exécutent alors dans un conteneur dédié. Le champ n'est donc plus un tri-état fermé
+mais `off | <nom de profil>` : `SandboxMode::parse` est **purement syntaxique** (l'existence d'un
+profil est une question de **base**, tranchée au bord), et un nom inconnu échoue fort partout.
 C'est une propriété de l'**environnement d'exécution**, jamais de la sémantique du pipeline (le YAML
 reste intouché — #403 US-5). Modèle d'exécution (conteneur `pdo-sbx-<run-id>`, identity mounts, uid
 hôte, trou réseau/auth) → **ADR-0030 / #407**. La **source** du mode suit la précédence **choix
@@ -870,19 +873,20 @@ _Éviter_ : « mode conteneur », « isolation » seul (ambigu) ; ne pas confond
 
 **Staging dir (répertoire de staging)** :
 Répertoire par Run sous `~/.pdo/sandbox/<run-id>/`, créé au démarrage d'un Run sandboxé et purgé à
-`cleanup_run`. Héberge le *staged Claude home* + un `.claude.json` sibling (+, une fois les
-**profils** livrés, un `home/` portant les **exceptions `$HOME`** déclarées par le profil). Le vrai `~/.claude`
+`cleanup_run`. Héberge le *staged Claude home*, un `.claude.json` sibling et un `home/` portant les
+**exceptions `$HOME`** déclarées par le profil (#432). Le vrai `~/.claude`
 n'est **jamais** monté — et l'invariant s'étend au reste de `$HOME` : ce sont toujours des copies
 qui sont montées. Racines home/staging **injectables** (testabilité temp dirs + compat recette HP
 fake-HOME). _Éviter_ : « home copié », « sandbox dir » (collision avec la racine `~/.pdo/sandbox/`).
 
 **Staged Claude home (`claude-home/`)** :
 Sous-répertoire `~/.pdo/sandbox/<run-id>/claude-home/` qui tient lieu de `.claude` aux sessions du
-Run (monté tel quel : `claude-home/` **est** `$HOME/.claude`). Contenu selon le mode (voir `prepare`).
+Run (monté tel quel : `claude-home/` **est** `$HOME/.claude`). Contenu selon le **profil de staging**
+(voir `prepare`).
 Le `.claude.json` vit à côté (`~/.pdo/sandbox/<run-id>/.claude.json`), monté séparément vers
 `$HOME/.claude.json`. _Éviter_ : « fake home », « home miroir ».
 
-**Profil de staging** _(décidé, pas encore en vigueur — ADR-0031)_ :
+**Profil de staging** :
 Liste **nommée** de ce qu'un Run sandboxé stage dans son home. Le champ sandbox d'un Run, d'un
 Trigger ou de l'instance vaut `off` **ou un nom de profil** — jamais une liste : la précédence
 existante (`effective_sandbox`) et les `<select>` de l'UI restent inchangés. `minimal` et `full`
@@ -891,6 +895,9 @@ sont des **défauts virtuels** (aucune ligne en base) jusqu'à édition. Ce qui 
 plus les évolutions futures du défaut. Le nom **et** la liste résolue sont gelés dans `RunStarted` :
 `prepare` lit l'état du Run, jamais le réglage vivant. Un nom inconnu **échoue fort** (400 à la
 création, tir de Trigger en échec, `RunFailed` en boot recovery), jamais de retombée silencieuse.
+Table `sandbox_profiles` (`name` en clé, `disabled`/`extras` en JSON, `updated_at`) ; **pas de rename
+en v1** — rename = delete + create, car le nom est aussi la valeur stockée par les trois consommateurs
+(Trigger, défaut d'instance, payload `RunStarted`). Réalisé en **#432**.
 _Éviter_ : « allowlist » seul (c'était la constante Rust d'avant), « preset », « template ».
 
 **Plancher de staging** :
@@ -900,42 +907,58 @@ que soit le **profil** : credentials valides (`.credentials.json`), managed sett
 accepté (`skipDangerousModePermissionPrompt: true` **mergé** dans le `settings.json` copié en `full`,
 **synthétisé** en `minimal`), confiance pré-accordée à la racine du Run (dans le `.claude.json`
 stagé, #409), `projects/` **vide**. Chaque garantie est satisfaite soit par une **copie** de l'hôte,
-soit par une **synthèse de repli** — c'est ce qui rendra le décochage d'une entrée de profil sûr sans
+soit par une **synthèse de repli** — c'est ce qui rend le décochage d'une entrée de profil sûr sans
 l'interdire (ADR-0031 §1). Formulé en fichiers verrouillés, le plancher se contredirait dès
-`settings.json` (copié en `full`, synthétisé en `minimal`). Réalisé en **#426**.
+`settings.json` (copié quand l'entrée est cochée, synthétisé sinon). Réalisé en **#426** ; le
+décochage effectif est arrivé avec les profils (**#432**), et trois garanties — credentials,
+managed settings de l'org, `projects/` vide — ne sont **pas** des entrées du tout : elles sont
+affichées en lecture seule et **refusées même en extra**.
 _Éviter_ : « fichiers obligatoires », « liste verrouillée ».
 
-**Entrée de profil / exception `$HOME`** _(décidé, pas encore en vigueur — ADR-0031)_ :
+**Entrée de profil / exception `$HOME`** :
 Une entrée est un chemin **relatif à `$HOME`** (`.claude/skills`, `.gitconfig`, `.config/gh`).
-Refusés : absolu, `..`, sortie de `$HOME`, et `projects/` sous `.claude`. Une entrée **hors
+Refusés à l'écriture (400) : absolu, `..`, `\`, NUL, glob, sortie de `$HOME`, `.claude` nu, `.pdo`,
+et les trois chemins que le plancher possède **en entier** (`.credentials.json`,
+`remote-settings.json`, `projects/` sous `.claude`). Une entrée **hors
 `.claude`** est copiée dans `<staging>/home/<chemin>` puis montée rw à `$HOME/<chemin>` — jamais un
 bind direct du fichier hôte (un agent ferait `git config --global` et réécrirait le `~/.gitconfig`
 de l'utilisateur). Une entrée **sous `.claude/`** ne reçoit **pas** de mount propre : elle est déjà
-servie par le mount `.claude`. _Éviter_ : « fichier monté » (c'est une copie qui est montée),
-« exclusion » pour parler d'un décochage.
+servie par le mount `.claude` — ce n'est pas un cas spécial mais la **conséquence** du
+classificateur unique `landing()`, partagé par la vue *copie* (`prepare`) et la vue *mount*
+(`extra_mounts`), qui ne peuvent donc pas diverger. **Règle M1** : on ne monte que ce qui a été
+réellement stagé — un `-v` dont la source manque fait créer par Docker un répertoire `root:root`,
+ce qui à terme rend le staging indélébile par le daemon. _Éviter_ : « fichier monté » (c'est une
+copie qui est montée), « exclusion » pour parler d'un décochage.
 
-**`prepare(mode, run_id)`** :
-Seede le *staged Claude home* selon le mode, en tenant le **plancher de staging** dans les deux cas.
-**`full`** : recopie une **liste explicite** de `~/.claude` (skills, plugins, agents, commands,
-output-styles, settings[.local].json, credentials, `*.md` global) + `~/.claude.json` verbatim ;
-**exclut `projects/`** et tout état hôte volumineux (`history.jsonl`, `session-env/`, …). Les symlinks
+**`prepare(entries, run_id)`** :
+Seede le *staged Claude home* depuis la **liste d'entrées résolue et gelée** du profil (#432 — le
+paramètre `mode` a disparu avec le tri-état), en tenant le **plancher de staging** dans tous les cas.
+Le défaut `full` porte **9 entrées** : `.claude.json`, `.claude/*.md`, `.claude/settings.json`,
+`.claude/settings.local.json`, `.claude/agents`, `.claude/commands`, `.claude/output-styles`,
+`.claude/plugins`, `.claude/skills` — et **exclut `projects/`** et tout état hôte volumineux
+(`history.jsonl`, `session-env/`, …). Les symlinks
 qui **sortent** de `~/.claude` (skills liés à `~/.agents`) sont **déréférencés** (recréés verbatim ils
 dangleraient dans le conteneur) ; les liens intra-arbre (`node_modules/.bin`) restent des liens. Walk
-**best-effort par entrée** : un `~/.claude` volatil ne fait jamais échouer le Run. **`minimal`** :
-n'apporte **rien** en propre — `minimal` *est* le plancher. Le **plancher**, mode-agnostique, tient
+**best-effort par entrée** : un `~/.claude` volatil ne fait jamais échouer le Run. Une entrée absente
+de l'hôte est **loggée et sautée** (défaut comme extra) : l'échec dur ferait dépendre la politique de
+qui a tapé le chemin, et sur une instance à Triggers horaires désinstaller `gh` tuerait chaque tir.
+**Liste vide** (`minimal`) : n'apporte **rien** en propre — `minimal` *est* le plancher. Le
+**plancher**, profil-agnostique, tient
 ensuite les cinq garanties : `.credentials.json` copié ; `remote-settings.json` copié de `~/.claude/`
 quand il existe (absent → no-op loggé, jamais une erreur) ; `skipDangerousModePermissionPrompt: true`
-dans le `settings.json` stagé (**mergé** non destructivement dans la copie hôte en `full`,
-**synthétisé** en `minimal` — sans quoi la session bute sur le dialogue de bypass permissions) ;
+dans le `settings.json` stagé (**mergé** non destructivement dans la copie hôte quand l'entrée est
+cochée, **synthétisé** sinon — sans quoi la session bute sur le dialogue de bypass permissions) ;
 confiance de la racine du Run mergée dans le `.claude.json` stagé (#409 D5 — sinon un Run autonome se
 bloquerait sur le dialogue « trust this folder ? ») ; `projects/` créé **vide** (puits de transcripts
 runtime). Le plancher est le **writer unique** de `remote-settings.json` et de la clé de bypass : ni
-l'un ni l'autre n'est dans l'allowlist `full`. Bits exécutables préservés. **Volume/PII (#409)** :
+l'un ni l'autre n'est une entrée du défaut. Bits exécutables préservés. **Volume/PII (#409)** :
 `full` pèse **~1 Go/run** (dominé par `plugins/*/node_modules`, requis par les serveurs MCP
 *in-container* — délibérément non strippés) et expose en plus le profil PII
 (`oauthAccount`/`userID`/`emailAddress`) + settings + `.md` globaux que `minimal` retient (choix
-conscient, aligné sur le trou d'auth d'ADR-0030). Dette disque : le staging n'est purgé qu'au
-`cleanup_run` (surveiller vs la récurrence disque connue). _Éviter_ : « init », « seed » seul.
+conscient, aligné sur le trou d'auth d'ADR-0030). Depuis #432 c'est **décochable entrée par entrée** :
+retirer `.claude/plugins` fait tomber le staging d'un ordre de grandeur. Dette disque : le staging
+n'est purgé qu'au `cleanup_run` (surveiller vs la récurrence disque connue).
+_Éviter_ : « init », « seed » seul.
 
 **`merge_back(run_id)`** :
 À la transition terminale du Run **et** à `cleanup_run` : recopie **uniquement** les `*.jsonl` de

--- a/crates/pdo-daemon/src/boot_recovery.rs
+++ b/crates/pdo-daemon/src/boot_recovery.rs
@@ -133,10 +133,11 @@ pub(crate) async fn run_boot_recovery(state: &AppState) {
 
         // #407 D10: a live sandboxed Run needs its container back after a daemon
         // restart — reconcile it here (before the orphan scan). Synchronous effect
-        // via spawn_blocking (ensure_ready may build/probe docker); failure is
-        // logged, not fatal — the orphan/stall handling below still runs, and a
-        // downstream spawn would fail loud on a still-missing container. No-op for
-        // `off`.
+        // via spawn_blocking (ensure_ready may build/probe docker). No-op for `off`.
+        //
+        // #432 (ADR-0031 §7): the two `Err` arms are SPLIT, because they fail for
+        // categorically different reasons. This is the only one of `ensure_ready`'s four
+        // callers that used to swallow both — the other three `RunFailed` or 500.
         if !run_state.sandbox.is_off() {
             match crate::sandbox_run::context_from_state(state, &run_state).await {
                 Ok(ctx) => {
@@ -144,6 +145,14 @@ pub(crate) async fn run_boot_recovery(state: &AppState) {
                         .await
                     {
                         Ok(Ok(())) => {}
+                        // KEPT as a `warn!`, deliberately. `ensure_ready` touches the
+                        // Docker socket, and `service_unit.rs` emits
+                        // `After=network-online.target` WITHOUT `After=docker.service` —
+                        // so a daemon restarted by systemd at boot can reach this before
+                        // `dockerd` accepts connections. Making this arm fatal would
+                        // mass-`RunFailed` every live sandboxed Run on a boot-ordering
+                        // race. (Real fix — add `After=docker.service`, then make this
+                        // fatal — is a follow-up, not this slice.)
                         Ok(Err(e)) => warn!(
                             "Boot recovery: failed to ensure sandbox container for run {run_id}: {e:#}"
                         ),
@@ -152,8 +161,19 @@ pub(crate) async fn run_boot_recovery(state: &AppState) {
                         ),
                     }
                 }
+                // FATAL since #432: this is where an unresolvable FROZEN staging
+                // selection surfaces, and it never touches the Docker socket — so it
+                // cannot fail transiently. Deterministic: the retry at the next boot
+                // would fail identically, for ever. A Run left `Running` with a home
+                // nobody can stage is strictly worse than a Run that says so.
                 Err(e) => {
-                    warn!("Boot recovery: failed to build sandbox context for run {run_id}: {e:#}")
+                    crate::fail_run_sandbox_prep(
+                        state,
+                        run_id,
+                        &format!("sandbox prep failed at boot recovery: {e:#}"),
+                    )
+                    .await;
+                    continue;
                 }
             }
         }

--- a/crates/pdo-daemon/src/event_log.rs
+++ b/crates/pdo-daemon/src/event_log.rs
@@ -189,30 +189,45 @@ impl RunStatus {
     }
 }
 
-/// How a Run is isolated (#403 / #407). A **per-Run, immutable** property carried
-/// on `RunStarted`, projected once into [`RunState::sandbox`], never mutated for
-/// the Run's whole life — a resumed session matches its transcript by working-dir
+/// How a Run is isolated (#403 / #407 / #432). A **per-Run, immutable** property
+/// carried on `RunStarted`, projected once into [`RunState::sandbox`], never mutated
+/// for the Run's whole life — a resumed session matches its transcript by working-dir
 /// path, so flipping the mode mid-life would break `claude --continue`.
 ///
 /// - `Off` — historical host execution (no Docker, byte-identical legacy launch);
-/// - `Full` — sandboxed, staged Claude home seeded by copying an allowlist of the
-///   host `~/.claude` (ex-`copy`, renamed in #426);
-/// - `Minimal` — sandboxed, staged Claude home seeded by the staging floor alone
-///   (ex-`pure`, renamed in #426).
+/// - `Profile(name)` — sandboxed, with the **staging profile** `name` deciding what
+///   the staged home carries (ADR-0031 §5). `full` and `minimal` are the two
+///   *virtual defaults* (no DB row until edited), so `"full"`/`"minimal"` keep
+///   round-tripping byte-identically through every historical payload.
 ///
-/// The wire form is exactly `off`/`full`/`minimal`, with **no compatibility alias**
-/// for the old `copy`/`pure` tokens (ADR-0031 §1 + ADR-0030 amendment §1): an
-/// unknown token keeps yielding `None` from [`SandboxMode::parse`], which the
-/// resolvers treat as unset and now **log** (#426). `Default` is `Off` so an absent
-/// payload field (historical runs, bare-API creates) projects to the host path.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
+/// The wire form is a **bare string**: `off`, or the profile name verbatim. Serde is
+/// hand-written for exactly that reason — `untagged` would emit `null` for the unit
+/// variant, and `#[serde(from = "String")]` would demand an infallible conversion
+/// while a blank token must fail.
+///
+/// [`SandboxMode::parse`] is purely **syntactic** since #432: `None` no longer means
+/// *unknown*, it means *blank*. Whether a profile **exists** is a database question,
+/// answered at the edge (create-run, `PUT /settings`, trigger create/patch) and never
+/// here — this module is pure and its projection runs inside `append_event`.
+/// `Default` is `Off`, so an absent payload field (historical runs, bare-API creates)
+/// projects to the host path.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
 pub enum SandboxMode {
     #[default]
     Off,
-    Full,
-    Minimal,
+    /// Canonicalised by [`SandboxMode::parse`]: trimmed, never empty, never `off`.
+    Profile(String),
 }
+
+/// Wire tokens of the pre-#426 two-position switch. They were dropped **without
+/// alias**, and since #432 `parse` accepts any non-blank token as a profile name —
+/// so a historical payload carrying one would now project to `Profile("copy")`, an
+/// unknown profile, and fail the Run hard. That is a worse answer than the #426
+/// behaviour for a Run created before the rename even existed, so the projection
+/// keeps mapping these two tokens to `Off` + a `warn!`. NOT consulted anywhere the
+/// user can still type a value (a stored `copy` in `instance_config` or on a Trigger
+/// now fails loud at the create chokepoint, which is the point of ADR-0031 §7).
+const LEGACY_SANDBOX_TOKENS: &[&str] = &["copy", "pure"];
 
 impl SandboxMode {
     /// The default tier (never `None`), surfaced by `GET /settings` and used as the
@@ -220,33 +235,73 @@ impl SandboxMode {
     /// legacy host path stays byte-identical (#410). Mirror of [`crate::sandbox_image::ImageSource::DEFAULT`].
     pub const DEFAULT: SandboxMode = SandboxMode::Off;
 
+    /// The wire token of [`SandboxMode::Off`]. A `const &str` rather than
+    /// `DEFAULT.as_str()` because `as_str` now borrows from `self` (the profile name
+    /// is owned), which no `const fn` can do.
+    pub const OFF_WIRE: &'static str = "off";
+
     /// Whether this Run runs on the host (the legacy, no-Docker path). The whole
     /// sandbox wiring is gated on `!is_off()`, so the `off` parcours never touches
     /// a single new line.
-    pub fn is_off(self) -> bool {
+    pub fn is_off(&self) -> bool {
         matches!(self, SandboxMode::Off)
     }
 
-    /// The exact wire form: `off`/`full`/`minimal`. Mirror of `ImageSource::as_str`;
-    /// consumed by `build_settings_view` and the enum validators (#410).
-    pub fn as_str(self) -> &'static str {
+    /// The exact wire form: `off`, or the profile name verbatim. Consumed by
+    /// `build_settings_view` and the enum validators (#410).
+    pub fn as_str(&self) -> &str {
         match self {
-            SandboxMode::Off => "off",
-            SandboxMode::Full => "full",
-            SandboxMode::Minimal => "minimal",
+            SandboxMode::Off => Self::OFF_WIRE,
+            SandboxMode::Profile(name) => name.as_str(),
         }
     }
 
-    /// Parse the wire form; `None` for any unknown token (PUT validators reject
-    /// those, resolvers treat them defensively as unset). Case/whitespace-tolerant,
-    /// mirror of `ImageSource::parse` (#410).
-    pub fn parse(s: &str) -> Option<SandboxMode> {
-        match s.trim().to_ascii_lowercase().as_str() {
-            "off" => Some(SandboxMode::Off),
-            "full" => Some(SandboxMode::Full),
-            "minimal" => Some(SandboxMode::Minimal),
-            _ => None,
+    /// The staging profile this Run uses, or `None` for `off`. The ONE consumer that
+    /// needs the name rather than the off-ness (#432 D2) is the sandbox context
+    /// assembly, which resolves it to a frozen entry list.
+    pub fn profile(&self) -> Option<&str> {
+        match self {
+            SandboxMode::Off => None,
+            SandboxMode::Profile(name) => Some(name.as_str()),
         }
+    }
+
+    /// Parse the wire form. **Purely syntactic** (#432): `off` (case/whitespace
+    /// tolerant, the three closed tokens of the old enum are gone) yields `Off`, a
+    /// blank string yields `None`, and anything else is a profile name — trimmed but
+    /// otherwise **verbatim**, never lowercased.
+    ///
+    /// The asymmetry with [`crate::sandbox_profile::validate_profile_name`] (which
+    /// rejects an uppercase name outright instead of folding it) is deliberate and
+    /// load-bearing: `off` is a closed token whose spelling nobody owns, while a
+    /// profile name is a user namespace where accepting `Foo` and silently storing
+    /// `foo` would make the UI search a list it does not display. Do not "fix" it.
+    pub fn parse(s: &str) -> Option<SandboxMode> {
+        let trimmed = s.trim();
+        if trimmed.is_empty() {
+            return None;
+        }
+        if trimmed.eq_ignore_ascii_case(Self::OFF_WIRE) {
+            return Some(SandboxMode::Off);
+        }
+        Some(SandboxMode::Profile(trimmed.to_string()))
+    }
+}
+
+impl Serialize for SandboxMode {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for SandboxMode {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let raw = String::deserialize(d)?;
+        SandboxMode::parse(&raw).ok_or_else(|| {
+            serde::de::Error::custom(
+                "sandbox must be `off` or the name of a staging profile, not blank",
+            )
+        })
     }
 }
 
@@ -264,22 +319,18 @@ fn env_default_sandbox() -> Option<SandboxMode> {
         .and_then(SandboxMode::parse)
 }
 
-/// Instance default, precedence `stored → env → default(Off)`. A stored empty/invalid
-/// value is treated as unset (mirror of the `""` sentinel + PUT validator). SINGLE
-/// source shared by `create_run_inner` AND `build_settings_view` (0 drift, lesson #373).
+/// Instance default, precedence `stored → env → default(Off)`. A stored empty value is
+/// treated as unset (mirror of the `""` sentinel + PUT validator). SINGLE source shared
+/// by `create_run_inner` AND `build_settings_view` (0 drift, lesson #373).
+///
+/// #432: no `warn!` for an unparseable stored token any more — `parse` is syntactic, so
+/// the only stored value it rejects is blank, which the `""` filter already handles.
+/// A stored name that does not *exist* is no longer demoted to `off` at all: it wins the
+/// tier, and the create-run chokepoint 400s on it by name (ADR-0031 §7 — never a silent
+/// fallback toward less isolation).
 pub fn default_sandbox_with(stored: Option<String>) -> SandboxMode {
-    let stored = stored.filter(|s| !s.is_empty());
-    // #426: a stored token that no longer parses (a pre-rename `copy`/`pure` left in
-    // `instance_config`) silently demotes the whole instance to `off`. Say it out loud.
-    if let Some(raw) = stored.as_deref() {
-        if SandboxMode::parse(raw).is_none() {
-            warn!(
-                "stored default_sandbox `{raw}` is not a valid mode; falling back to the env/`off` \
-                 tier. `copy`/`pure` were renamed to `full`/`minimal` in #426, without alias."
-            );
-        }
-    }
     stored
+        .filter(|s| !s.is_empty())
         .as_deref()
         .and_then(SandboxMode::parse)
         .or_else(env_default_sandbox)
@@ -508,11 +559,29 @@ pub struct RunState {
     pub switch_states: HashMap<String, SwitchState>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub target_repo: Option<String>,
-    /// Isolation mode for this Run (#403 / #407). Immutable: set once from the
+    /// Isolation mode for this Run (#403 / #407 / #432) — `off`, or the name of the
+    /// staging profile it was launched with. Immutable: set once from the
     /// `RunStarted` payload, never mutated. Absent payload field → `Off` (the
     /// legacy host path), so historical runs and bare-API creates stay off.
     #[serde(default)]
     pub sandbox: SandboxMode,
+    /// The staging profile's **resolved entry list, frozen at creation** (#432,
+    /// ADR-0031 §6). Written to `RunStarted` as the sibling key `sandbox_entries`,
+    /// always together with `sandbox` or not at all, so editing (or deleting) a
+    /// profile can never retroactively rewrite what a Run in flight already staged.
+    ///
+    /// The `Option` is **load-bearing**: `Some(vec![])` is a legitimate resolution
+    /// (that IS `minimal`), so a bare `Vec` would confuse "legacy payload, re-resolve"
+    /// with "empty profile, stage the floor only".
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sandbox_entries: Option<Vec<String>>,
+    /// The raw `sandbox_entries` payload value when the key was **present but
+    /// unreadable** (#432). Internal to the projection — `skip`ped on the wire — and
+    /// exists only so the sandbox prep can fail LOUD with the offending value in its
+    /// reason. Silently re-resolving would change what the nodes that already
+    /// launched saw, which is exactly what the freeze protects against.
+    #[serde(skip)]
+    pub sandbox_entries_raw_error: Option<String>,
     /// One-time image-prep visibility for a sandboxed Run (#410). Additive: `None`
     /// for `off`/historical runs; `pending` while the image is pulled/built at first
     /// use; `ready` once the container is about to run. `status` is never touched —
@@ -575,6 +644,8 @@ impl RunState {
             switch_states: HashMap::new(),
             target_repo: None,
             sandbox: SandboxMode::Off,
+            sandbox_entries: None,
+            sandbox_entries_raw_error: None,
             sandbox_prep: None,
             source_branch: None,
             triggered_by: None,
@@ -839,18 +910,55 @@ fn apply_run_event(state: &mut RunState, event: &Event) {
                 // this applier runs before the transition guard.
                 match payload.get("sandbox") {
                     None => {}
+                    // #426/#432: the two pre-rename tokens are mapped to `Off` + a
+                    // `warn!` BEFORE `parse` sees them — `parse` is syntactic now and
+                    // would happily read `copy` as a profile name, turning a Run that
+                    // predates the rename into a hard `RunFailed`. Only the payload
+                    // arm keeps this compatibility; the tiers a user can still type
+                    // (instance default, Trigger) fail loud by design (ADR-0031 §7).
+                    Some(raw)
+                        if raw
+                            .as_str()
+                            .is_some_and(|s| LEGACY_SANDBOX_TOKENS.contains(&s.trim())) =>
+                    {
+                        warn!(
+                            "run_started carries the pre-#426 `sandbox` token ({raw}); \
+                             projecting `off` (host path). `copy`/`pure` were renamed to \
+                             `full`/`minimal` in #426, without alias."
+                        )
+                    }
                     Some(raw) => match serde_json::from_value::<SandboxMode>(raw.clone()) {
                         Ok(sandbox) => state.sandbox = sandbox,
-                        // #426: the rename dropped `copy`/`pure` with no alias, and the
-                        // degradation goes toward LESS isolation (`Off` → host bash in
-                        // `run-shell`, `cleanup_run` skipping `merge_back`/`teardown`,
-                        // cost reading the wrong transcripts root). Silent is not an
-                        // option: ADR-0030 pt 4 forbids an unlogged host fallback.
+                        // A blank / non-string value. The degradation goes toward LESS
+                        // isolation (`Off` → host bash in `run-shell`, `cleanup_run`
+                        // skipping `merge_back`/`teardown`, cost reading the wrong
+                        // transcripts root). Silent is not an option: ADR-0030 pt 4
+                        // forbids an unlogged host fallback.
                         Err(_) => warn!(
                             "run_started carries an unreadable `sandbox` value ({raw}); \
-                             projecting `off` (host path). \
-                             `copy`/`pure` were renamed to `full`/`minimal` in #426, without alias."
+                             projecting `off` (host path)."
                         ),
+                    },
+                }
+                // #432 (ADR-0031 §6): the sibling FROZEN entry list. Written together
+                // with `sandbox` or not at all, so an absent key on a `sandbox` payload
+                // can only mean "created by a pre-profiles daemon" — which the prep
+                // resolves (virtual default) or fails (user profile), per its own
+                // decision table. A present-but-unreadable value is kept verbatim in
+                // `sandbox_entries_raw_error` so the prep can name it: re-resolving
+                // would silently change what the already-spawned nodes saw.
+                match payload.get("sandbox_entries") {
+                    None => {}
+                    Some(raw) => match serde_json::from_value::<Vec<String>>(raw.clone()) {
+                        Ok(entries) => state.sandbox_entries = Some(entries),
+                        Err(_) => {
+                            state.sandbox_entries_raw_error = Some(raw.to_string());
+                            warn!(
+                                "run_started carries an unreadable `sandbox_entries` value \
+                                 ({raw}); the sandbox prep will fail this Run loud rather \
+                                 than re-resolve a different list."
+                            );
+                        }
                     },
                 }
                 if let Some(sb) = payload.get("source_branch").and_then(|v| v.as_str()) {
@@ -1677,13 +1785,24 @@ mod tests {
     }
 
     // -- Slice A (#410): precedence resolver + instance-default helper ---------
+    //
+    // #432 note: the closed `Full`/`Minimal` variants became `Profile("full")` /
+    // `Profile("minimal")`. The precedence rules themselves are UNCHANGED — these tests
+    // are the same assertions written against the new constructor.
+
+    fn full() -> SandboxMode {
+        SandboxMode::Profile("full".into())
+    }
+    fn minimal() -> SandboxMode {
+        SandboxMode::Profile("minimal".into())
+    }
 
     #[test]
     fn explicit_off_beats_full_default() {
         // The bug #410 exists to fix: an explicit `off` must survive a `full`/`minimal`
         // instance default — otherwise the default could never be overridden downward.
         assert_eq!(
-            effective_sandbox(Some(SandboxMode::Off), None, SandboxMode::Full),
+            effective_sandbox(Some(SandboxMode::Off), None, full()),
             SandboxMode::Off
         );
     }
@@ -1691,34 +1810,27 @@ mod tests {
     #[test]
     fn explicit_wins_over_trigger_and_default() {
         assert_eq!(
-            effective_sandbox(
-                Some(SandboxMode::Minimal),
-                Some(SandboxMode::Full),
-                SandboxMode::Off
-            ),
-            SandboxMode::Minimal
+            effective_sandbox(Some(minimal()), Some(full()), SandboxMode::Off),
+            minimal()
         );
     }
 
     #[test]
     fn trigger_used_when_no_explicit() {
         assert_eq!(
-            effective_sandbox(None, Some(SandboxMode::Minimal), SandboxMode::Off),
-            SandboxMode::Minimal
+            effective_sandbox(None, Some(minimal()), SandboxMode::Off),
+            minimal()
         );
         // A trigger's explicit `off` also stands over a `full` instance default.
         assert_eq!(
-            effective_sandbox(None, Some(SandboxMode::Off), SandboxMode::Full),
+            effective_sandbox(None, Some(SandboxMode::Off), full()),
             SandboxMode::Off
         );
     }
 
     #[test]
     fn all_none_falls_to_instance_default() {
-        assert_eq!(
-            effective_sandbox(None, None, SandboxMode::Full),
-            SandboxMode::Full
-        );
+        assert_eq!(effective_sandbox(None, None, full()), full());
         assert_eq!(
             effective_sandbox(None, None, SandboxMode::DEFAULT),
             SandboxMode::Off
@@ -1728,50 +1840,186 @@ mod tests {
     #[test]
     fn default_sandbox_with_precedence() {
         // stored valid wins.
-        assert_eq!(
-            default_sandbox_with(Some("minimal".into())),
-            SandboxMode::Minimal
-        );
-        assert_eq!(default_sandbox_with(Some("full".into())), SandboxMode::Full);
+        assert_eq!(default_sandbox_with(Some("minimal".into())), minimal());
+        assert_eq!(default_sandbox_with(Some("full".into())), full());
         // empty sentinel → unset → default (Off) (env not set in this harness).
         assert_eq!(default_sandbox_with(Some(String::new())), SandboxMode::Off);
-        // garbage → unset → default.
-        assert_eq!(
-            default_sandbox_with(Some("garbage".into())),
-            SandboxMode::Off
-        );
         // absent → default.
         assert_eq!(default_sandbox_with(None), SandboxMode::Off);
     }
 
+    /// #432, the behaviour change worth pinning: an unrecognised stored token is NO
+    /// LONGER demoted to `off`. It is a PROFILE NAME, it wins the tier, and the
+    /// create-run chokepoint 400s on it by name (ADR-0031 §7 — never a silent fallback
+    /// toward less isolation). `default_sandbox_with` is pure and cannot know whether
+    /// the profile exists; that is the edge's job.
+    #[test]
+    fn a_stored_unknown_name_stays_the_winning_tier() {
+        assert_eq!(
+            default_sandbox_with(Some("full-no-mcp".into())),
+            SandboxMode::Profile("full-no-mcp".into())
+        );
+        // Even the two pre-#426 tokens: they are just names now, and they will fail loud
+        // at launch instead of quietly demoting the whole instance to the host path.
+        assert_eq!(
+            default_sandbox_with(Some("copy".into())),
+            SandboxMode::Profile("copy".into())
+        );
+    }
+
     #[test]
     fn sandbox_mode_parse_and_as_str_round_trip() {
-        for mode in [SandboxMode::Off, SandboxMode::Full, SandboxMode::Minimal] {
+        for mode in [SandboxMode::Off, full(), minimal()] {
             assert_eq!(SandboxMode::parse(mode.as_str()), Some(mode));
         }
-        // case / whitespace tolerant, rejects unknown.
-        assert_eq!(SandboxMode::parse("  MINIMAL "), Some(SandboxMode::Minimal));
-        assert_eq!(SandboxMode::parse("nope"), None);
-        // #426: the rename ships with NO compatibility alias — the pre-rename
-        // tokens are plain unknown tokens now.
-        assert_eq!(SandboxMode::parse("copy"), None);
-        assert_eq!(SandboxMode::parse("pure"), None);
+        // `off` is case / whitespace tolerant (a closed token nobody owns the spelling of).
+        assert_eq!(SandboxMode::parse("  OFF "), Some(SandboxMode::Off));
+        // A profile name is trimmed but NEVER lowercased — see the asymmetry documented on
+        // `parse` and on `sandbox_profile::validate_profile_name`.
+        assert_eq!(
+            SandboxMode::parse("  Full-No-MCP "),
+            Some(SandboxMode::Profile("Full-No-MCP".into()))
+        );
+        // Blank is the ONLY `None`: `parse` is syntactic since #432, existence is a
+        // database question answered at the edge.
+        assert_eq!(SandboxMode::parse(""), None);
+        assert_eq!(SandboxMode::parse("   "), None);
+        assert_eq!(
+            SandboxMode::parse("nope"),
+            Some(SandboxMode::Profile("nope".into()))
+        );
+    }
+
+    /// The wire form is a BARE STRING, byte-identical to the pre-#432 enum for the two
+    /// names that existed. Every historical `RunStarted` payload must round-trip
+    /// unchanged, which is what makes this a type change and not a data migration.
+    #[test]
+    fn sandbox_mode_serialises_as_a_bare_string() {
+        for wire in ["off", "full", "minimal", "full-no-mcp"] {
+            let parsed = SandboxMode::parse(wire).unwrap();
+            let json = serde_json::to_value(&parsed).unwrap();
+            assert_eq!(json, serde_json::json!(wire), "{wire} must round-trip");
+            assert_eq!(
+                serde_json::from_value::<SandboxMode>(json).unwrap(),
+                parsed,
+                "{wire} must deserialise back"
+            );
+        }
+        // A blank / non-string value fails deserialisation rather than becoming `Off`.
+        assert!(serde_json::from_value::<SandboxMode>(serde_json::json!("")).is_err());
+        assert!(serde_json::from_value::<SandboxMode>(serde_json::json!(null)).is_err());
+        assert!(serde_json::from_value::<SandboxMode>(serde_json::json!(3)).is_err());
     }
 
     /// #426: a pre-rename `copy`/`pure` in a persisted `RunStarted` degrades to
     /// `Off` — the host path. The degradation is DELIBERATE (no alias, ADR-0031 §1)
     /// but it goes toward LESS isolation, so `apply_run_event` logs it. This test
     /// pins the choice so nobody "fixes" it into an alias by accident.
+    ///
+    /// #432 makes it load-bearing in a NEW way: `parse` would now happily read `copy` as
+    /// a profile name, so without the explicit legacy-token arm a Run that predates the
+    /// rename would `RunFailed` at its next boot recovery instead of running on the host.
     #[test]
     fn run_started_with_a_pre_rename_sandbox_token_projects_off() {
+        for token in ["copy", "pure"] {
+            let events = vec![make_event_with_payload(
+                EventKind::RunStarted,
+                None,
+                serde_json::json!({ "pipeline_name": "p", "sandbox": token }),
+            )];
+            let state = project(&events).unwrap();
+            assert_eq!(state.sandbox, SandboxMode::Off, "token {token}");
+            assert_eq!(state.sandbox_prep, None);
+            assert_eq!(state.sandbox_entries, None);
+        }
+    }
+
+    // -- Slice K (#432): the FROZEN entry list ---------------------------------
+
+    /// The `Option` on `sandbox_entries` is load-bearing: `Some(vec![])` is a legitimate
+    /// resolution — it IS `minimal` — while `None` means "no key, a pre-profiles
+    /// payload". Confusing the two would send `minimal` Runs down the re-resolve arm.
+    #[test]
+    fn an_empty_frozen_list_projects_as_some_not_none() {
         let events = vec![make_event_with_payload(
             EventKind::RunStarted,
             None,
-            serde_json::json!({ "pipeline_name": "p", "sandbox": "copy" }),
+            serde_json::json!({
+                "pipeline_name": "p",
+                "sandbox": "minimal",
+                "sandbox_entries": [],
+            }),
         )];
         let state = project(&events).unwrap();
-        assert_eq!(state.sandbox, SandboxMode::Off);
-        assert_eq!(state.sandbox_prep, None);
+        assert_eq!(state.sandbox, SandboxMode::Profile("minimal".into()));
+        assert_eq!(state.sandbox_entries, Some(Vec::new()));
+        assert_eq!(state.sandbox_entries_raw_error, None);
+    }
+
+    #[test]
+    fn a_frozen_list_projects_verbatim() {
+        let events = vec![make_event_with_payload(
+            EventKind::RunStarted,
+            None,
+            serde_json::json!({
+                "pipeline_name": "p",
+                "sandbox": "full-no-mcp",
+                "sandbox_entries": [".claude/skills", ".gitconfig"],
+            }),
+        )];
+        let state = project(&events).unwrap();
+        assert_eq!(state.sandbox, SandboxMode::Profile("full-no-mcp".into()));
+        assert_eq!(
+            state.sandbox_entries,
+            Some(vec![".claude/skills".to_string(), ".gitconfig".to_string()])
+        );
+    }
+
+    /// A legacy payload: `sandbox` present, no `sandbox_entries`. The prep's decision
+    /// table then re-resolves a virtual default and fails a user profile — but the
+    /// PROJECTION must simply report the absence, never invent a list.
+    #[test]
+    fn a_legacy_sandbox_payload_projects_no_frozen_list() {
+        let events = vec![make_event_with_payload(
+            EventKind::RunStarted,
+            None,
+            serde_json::json!({ "pipeline_name": "p", "sandbox": "full" }),
+        )];
+        let state = project(&events).unwrap();
+        assert_eq!(state.sandbox, SandboxMode::Profile("full".into()));
+        assert_eq!(state.sandbox_entries, None);
+        assert_eq!(state.sandbox_entries_raw_error, None);
+    }
+
+    /// A present-but-unreadable list keeps its RAW value, so the prep can name it in the
+    /// failure reason. Silently re-resolving would change what the already-spawned nodes
+    /// saw — the one thing the freeze exists to prevent.
+    #[test]
+    fn an_unreadable_frozen_list_is_kept_raw_for_the_failure_reason() {
+        let events = vec![make_event_with_payload(
+            EventKind::RunStarted,
+            None,
+            serde_json::json!({
+                "pipeline_name": "p",
+                "sandbox": "full",
+                "sandbox_entries": 42,
+            }),
+        )];
+        let state = project(&events).unwrap();
+        assert_eq!(state.sandbox_entries, None);
+        assert_eq!(state.sandbox_entries_raw_error.as_deref(), Some("42"));
+    }
+
+    /// `sandbox_entries` is INTERNAL to the projection when it is unreadable: the wire
+    /// view of a Run must not grow a field nothing consumes.
+    #[test]
+    fn the_raw_error_is_never_serialised() {
+        let mut state = RunState::new("r1".into(), "p".into());
+        state.sandbox_entries_raw_error = Some("42".into());
+        let value = serde_json::to_value(&state).unwrap();
+        assert!(value.get("sandbox_entries_raw_error").is_none());
+        // …and an absent list is skipped entirely (back-compat of the `off` shape).
+        assert!(value.get("sandbox_entries").is_none());
     }
 
     // -- Slice E (#410): sandbox-prep projection ------------------------------

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -33,6 +33,7 @@ mod run_advance;
 mod run_cost;
 mod sandbox_container;
 mod sandbox_image;
+mod sandbox_profile;
 mod sandbox_run;
 mod sandbox_staging;
 #[allow(dead_code)]
@@ -2195,15 +2196,34 @@ fn default_overlap_policy() -> String {
     "skip".to_string()
 }
 
-/// Validate a per-Trigger `sandbox` mode (#410): `None` (inherit) is always valid;
-/// a present value must be a known variant. Shared by create and patch so the rule
-/// cannot drift. Mirror of the `put_settings` `default_sandbox` validator.
-fn validate_trigger_sandbox(v: Option<&str>) -> Result<(), &'static str> {
-    match v {
-        Some(s) if event_log::SandboxMode::parse(s).is_none() => {
-            Err("sandbox must be `off`, `full`, or `minimal`")
-        }
-        _ => Ok(()),
+/// The SHARED existence gate for any `sandbox` reference a client can store (#432,
+/// ADR-0031 §7): the per-Trigger mode (create + patch) and the instance
+/// `default_sandbox`. `""` is the *clear* sentinel and `off` means "no sandbox", so both
+/// are always valid; anything else must name a profile that resolves — one of the two
+/// virtual defaults, or a materialised row.
+///
+/// A **write-time** gate, deliberately not the authoritative one (the create-run
+/// chokepoint is, and it re-resolves at every fire). It exists so the error lands where
+/// the user can fix it, at the moment they typed it — same posture as #431's
+/// `dockerfile_path` `is_file()` check. The `env` tier (`PDO_DEFAULT_SANDBOX`) never
+/// passes through here at all, which is why `build_settings_view` also discloses a
+/// `reason` on `default_sandbox`.
+async fn validate_sandbox_ref(db: &sqlx::SqlitePool, raw: &str) -> Result<(), String> {
+    let Some(mode) = event_log::SandboxMode::parse(raw) else {
+        return Ok(()); // "" / whitespace = the clear sentinel
+    };
+    let Some(name) = mode.profile() else {
+        return Ok(()); // `off`
+    };
+    match sandbox_profile::exists(db, name).await {
+        Ok(true) => Ok(()),
+        Ok(false) => Err(format!(
+            "unknown sandbox profile `{name}`: use `off`, `{}`, `{}`, or a profile you \
+             created under Settings → Staging profiles",
+            sandbox_profile::MINIMAL_PROFILE,
+            sandbox_profile::FULL_PROFILE,
+        )),
+        Err(e) => Err(format!("sandbox profile store error: {e}")),
     }
 }
 
@@ -2385,13 +2405,15 @@ async fn create_trigger(
             .into_response();
     }
 
-    // A per-Trigger sandbox mode, when present, must be a known variant (#410).
-    if let Err(msg) = validate_trigger_sandbox(req.sandbox.as_deref()) {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({ "error": msg })),
-        )
-            .into_response();
+    // A per-Trigger sandbox reference, when present, must resolve (#410/#432).
+    if let Some(raw) = req.sandbox.as_deref() {
+        if let Err(msg) = validate_sandbox_ref(&state.db, raw).await {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({ "error": msg })),
+            )
+                .into_response();
+        }
     }
 
     // Resolve the target pipeline and its prompt_required flag.
@@ -2787,9 +2809,10 @@ async fn patch_trigger(
         }
     }
 
-    // Validate a sandbox edit (Some(Some(mode)) sets; Some(None) clears to inherit) (#410).
+    // Validate a sandbox edit (Some(Some(mode)) sets; Some(None) clears to inherit)
+    // (#410/#432 — same shared existence gate as create and `PUT /settings`).
     if let Some(Some(ref mode)) = req.sandbox {
-        if let Err(msg) = validate_trigger_sandbox(Some(mode)) {
+        if let Err(msg) = validate_sandbox_ref(&state.db, mode).await {
             return (
                 StatusCode::BAD_REQUEST,
                 Json(serde_json::json!({ "error": msg })),
@@ -3104,6 +3127,28 @@ fn build_router(state: Arc<AppState>) -> Router {
         // {effective, source, stored, env, default} view; `PUT` writes the
         // stored tier (fail-fast validation).
         .route("/settings", get(get_settings).put(put_settings))
+        // Staging profiles (#432, ADR-0031 §2-§7). Deliberately UNDER `/settings`
+        // rather than a new top-level prefix: the vite proxy key is a PREFIX, so
+        // `'/settings': daemonTarget` already covers every sub-path — no proxy edit,
+        // and none of the traps `/nodes` (#345), `/stats` (#377) and `/fs` (#431) each
+        // paid, where a missing proxy line makes a dev GET answer 200 with the SPA.
+        // Static-segment-beside-a-param is fine in axum 0.8 (precedents:
+        // `/triggers/health`, `/library/pipelines/{id}/duplicate`).
+        //
+        // The shared prefix is a **routing** decision, NOT a claim about the schema:
+        // profiles are ROWS, not a `{effective, source, stored, env, default}` knob, and
+        // they must NOT be folded into `build_settings_view` beyond the name list.
+        .route("/settings/sandbox-profiles", get(list_sandbox_profiles))
+        .route(
+            "/settings/sandbox-profiles/{name}",
+            get(get_sandbox_profile)
+                .put(put_sandbox_profile)
+                .delete(delete_sandbox_profile),
+        )
+        .route(
+            "/settings/sandbox-profiles/{name}/referents",
+            get(get_sandbox_profile_referents),
+        )
         // Instance stats cockpit (#377, ADR-0029). New top-level `/stats` prefix
         // → added to the vite dev proxy whitelist so a dev-mode GET hits the
         // daemon instead of the SPA fallback. `overview` is cheap indexed SQL;
@@ -3168,6 +3213,13 @@ async fn init_db(db: &sqlx::SqlitePool) -> Result<()> {
     instance_config::init(db)
         .await
         .context("failed to create instance_config table")?;
+
+    // #432: staging profiles. A brand-new table with NO seed row — `minimal` and
+    // `full` are virtual defaults (ADR-0031 §2), so an untouched install has zero
+    // rows here and still resolves both names.
+    sandbox_profile::init(db)
+        .await
+        .context("failed to create sandbox_profiles table")?;
 
     Ok(())
 }
@@ -3854,22 +3906,18 @@ async fn fire_one_trigger(
                 // tier. A Run has a single origin (a trigger fire is never also a
                 // run-level choice), so this is the sole non-`None` tier here; the
                 // chokepoint's `effective_sandbox(req.sandbox, None, default)` then
-                // resolves it against the instance default. A `None`/unparseable
-                // stored mode defers to the instance default. #426: an unparseable
-                // stored mode is logged — the rename dropped `copy`/`pure` with no
-                // alias, and the degradation goes toward LESS isolation.
-                sandbox: trigger.sandbox.as_deref().and_then(|raw| {
-                    let parsed = event_log::SandboxMode::parse(raw);
-                    if parsed.is_none() {
-                        warn!(
-                            "trigger {} carries an unreadable `sandbox` value ({raw}); deferring to \
-                             the instance default. `copy`/`pure` were renamed to `full`/`minimal` \
-                             in #426, without alias.",
-                            trigger.id
-                        );
-                    }
-                    parsed
-                }),
+                // resolves it against the instance default. A blank/absent stored value
+                // defers to the instance default.
+                //
+                // #432: no unparseable-token `warn!` any more — `parse` is syntactic, so
+                // a stored `copy` now reads as the profile NAME `copy`, and the chokepoint
+                // 400s it by name. That 400's message becomes this fire's `FireRecord`
+                // reason (the `Err` arm below), which is visibly red in the Trigger
+                // history — the fail-hard ADR-0031 §7 asks for, with zero new code.
+                sandbox: trigger
+                    .sandbox
+                    .as_deref()
+                    .and_then(event_log::SandboxMode::parse),
             };
             let record = match create_run_inner(state, req, Vec::new()).await {
                 Ok(run_id) => trigger_store::FireRecord {
@@ -5627,8 +5675,11 @@ async fn parse_multipart_create_run(
                 }
             }
             "sandbox" => {
-                // #410: parse the explicit mode off the multipart form. Empty or
-                // unknown → leave `None` (defer to trigger/instance default).
+                // #410: parse the explicit mode off the multipart form. Empty → leave
+                // `None` (defer to trigger/instance default). #432: `parse` is syntactic
+                // now, so a non-`off` token becomes `Profile(name)` and an unknown NAME
+                // is a hard 400 at the chokepoint — no longer silently demoted to the
+                // instance default (ADR-0031 §7).
                 let v = field
                     .text()
                     .await
@@ -5927,11 +5978,65 @@ async fn create_run_inner(
         .await
         .ok()
         .and_then(|c| c.default_sandbox);
+    let explicit_tier = req.sandbox.is_some();
     let sandbox = event_log::effective_sandbox(
-        req.sandbox,
+        req.sandbox.clone(),
         None,
         event_log::default_sandbox_with(stored_default),
     );
+
+    // #432 (ADR-0031 §6 + §7): resolve the winning tier's staging profile to its entry
+    // list HERE, at the same chokepoint, so the name AND the list are frozen together
+    // into `RunStarted` — editing (or deleting) the profile afterwards can never rewrite
+    // what this Run stages. Only the WINNER is resolved: an unknown name sitting in the
+    // instance default is not an error for a Run that explicitly picks another profile,
+    // because nothing ever consults it.
+    //
+    // An unknown name **fails hard**, never falls back to the instance default or to
+    // `off`. This is before `append_event(run_started)` and before `create_worktree`, so
+    // "no Run is created" holds in the strict sense. A Trigger fire needs ZERO new code:
+    // `fire_one_trigger`'s `Err((_, body))` arm already turns this 400's message into a
+    // `FireRecord { outcome: "error", reason }` that the history renders red — which is
+    // why the wording below is the deliverable, not an afterthought.
+    let sandbox_entries: Option<Vec<String>> = match sandbox.profile() {
+        None => None,
+        Some(name) => match sandbox_profile::resolve(&state.db, name).await {
+            Ok(Some(resolved)) => Some(resolved.resolved.entries),
+            Ok(None) => {
+                let error = if explicit_tier {
+                    if req.triggered_by.is_some() {
+                        format!(
+                            "unknown sandbox profile `{name}`: the Trigger's sandbox setting \
+                             names a staging profile that does not exist. Recreate it under \
+                             Settings → Staging profiles, or point the Trigger at `off`."
+                        )
+                    } else {
+                        format!(
+                            "unknown sandbox profile `{name}`: no such staging profile. \
+                             Create it under Settings → Staging profiles, or use `off`."
+                        )
+                    }
+                } else {
+                    format!(
+                        "unknown sandbox profile `{name}`: the instance default sandbox names \
+                         a staging profile that does not exist. Fix it under \
+                         Settings → Default sandbox."
+                    )
+                };
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    serde_json::json!({ "error": error }),
+                ));
+            }
+            Err(e) => {
+                error!("failed to resolve sandbox profile `{name}`: {e}");
+                return Err((
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    serde_json::json!({ "error": "sandbox profile store error" }),
+                ));
+            }
+        },
+    };
 
     let edge_infos: Vec<event_log::EdgeInfo> =
         pipeline.edges.iter().map(edge_info_from_pipeline).collect();
@@ -5959,8 +6064,17 @@ async fn create_run_inner(
     }
     // #407/#410: carry the RESOLVED isolation mode only when it is NOT `off`, so `off`
     // payloads stay byte-identical to the historical shape (back-compat: absence → Off).
+    // #432: `sandbox_entries` is a SIBLING key, written in the same breath — the two are
+    // written together or not at all, which is the invariant that makes the replay table
+    // decidable (a `sandbox` with no entries can only mean "pre-profiles daemon").
+    // Nesting them (`sandbox: {name, entries}`) is disqualified by permanent
+    // back-compat: every historical payload carries `"sandbox": "full"` as a bare
+    // string, so both readers would have to accept `String | Object` for ever.
     if !sandbox.is_off() {
         run_payload["sandbox"] = serde_json::json!(sandbox);
+        run_payload["sandbox_entries"] = serde_json::json!(sandbox_entries
+            .as_ref()
+            .expect("a non-off sandbox always resolves an entry list at this chokepoint"));
     }
     if let Some(ref branch) = req.source_branch {
         run_payload["source_branch"] = serde_json::json!(branch);
@@ -6065,7 +6179,7 @@ async fn create_run_inner(
     if sandbox.is_off() {
         // Historical host path — inline, byte-identical to pre-#407. NO docker.
         spawn_ready_after_event(state, &run_id).await;
-        spawn_manager_session(state, &run_id, &worktree_dir, name_hint, sandbox);
+        spawn_manager_session(state, &run_id, &worktree_dir, name_hint, false);
     } else {
         // #407 D3/D4: eager fail-fast prep on a detached, panic-isolated task
         // (mirror ADR-0023 — the 201 must not block on a first-run `docker
@@ -6135,7 +6249,7 @@ async fn create_run_inner(
                         &task_run_id,
                         &task_worktree,
                         name_hint,
-                        sandbox,
+                        true,
                     );
                 }
                 Ok(Err(e)) => {
@@ -6167,7 +6281,7 @@ async fn create_run_inner(
 /// `RunFailed` is terminal + unguarded (mirror `fail_spawn_before_start`): a Run
 /// whose container never came up must move terminal, never wedge `Running` with
 /// no live node — and NEVER fall back to a host spawn.
-async fn fail_run_sandbox_prep(state: &AppState, run_id: &str, reason: &str) {
+pub(crate) async fn fail_run_sandbox_prep(state: &AppState, run_id: &str, reason: &str) {
     error!("Run {run_id}: sandbox prep failed — {reason}");
     let run_failed = event_log::Event {
         id: None,
@@ -6188,7 +6302,7 @@ fn spawn_manager_session(
     run_id: &str,
     worktree_dir: &std::path::Path,
     name_hint: prompt_augmenter::RunNameHint,
-    sandbox: event_log::SandboxMode,
+    sandboxed: bool,
 ) {
     let daemon_url = format!("http://localhost:{}", state.port);
 
@@ -6207,7 +6321,7 @@ fn spawn_manager_session(
     let session_name = tmux_session_manager::manager_session_name(run_id);
     // #407: the manager runs inside the Run's container too when sandboxed. Marker
     // = the manager session name; workdir = the pipeline worktree.
-    let sandbox_wrap = (!sandbox.is_off()).then(|| tmux_session_manager::SandboxWrap {
+    let sandbox_wrap = sandboxed.then(|| tmux_session_manager::SandboxWrap {
         docker_bin: state.docker_cmd_override.as_deref().unwrap_or("docker"),
         uid: sandbox_container::host_uid(),
         gid: sandbox_container::host_gid(),
@@ -6510,6 +6624,22 @@ async fn build_settings_view(state: &AppState) -> Result<serde_json::Value, sqlx
     } else {
         "default"
     };
+    // #432: the winning tier may name a staging profile that does not exist, and every
+    // Run it would produce dies with a 400. `put_settings` gates the *stored* tier, but
+    // the **env** tier (`PDO_DEFAULT_SANDBOX`) passes through no validator at all by
+    // construction — so the only honest place to surface it is here, as an advisory
+    // `reason` beside the value (mirror of `sandbox_docker.reason`).
+    let sbx_reason = match sbx_effective.profile() {
+        None => None,
+        Some(name) => match sandbox_profile::exists(db, name).await {
+            Ok(true) => None,
+            Ok(false) => Some(format!(
+                "no staging profile named `{name}` — every Run that falls back to this \
+                 default will fail at launch (tier: {sbx_source})"
+            )),
+            Err(e) => Some(format!("cannot check staging profile `{name}`: {e}")),
+        },
+    };
 
     // --- resolved sandbox Dockerfile (path ; default = <sandbox_root>/Dockerfile) (#431) ---
     // `sandbox_home_roots` honours `sandbox_home_override` (the layer-3 seam, #181), so
@@ -6567,6 +6697,27 @@ async fn build_settings_view(state: &AppState) -> Result<serde_json::Value, sqlx
     // (ADR-0030 pt 4) stays the authoritative gate.
     let docker_probe = docker_probe_cached(state).await;
 
+    // --- staging profiles: NAMES ONLY, plus the host $HOME (#432) ---
+    // NAMES ONLY is part of the contract, not an oversight: this payload is on the hot
+    // path of the launch dialog (which fetches settings on every open). Serving resolved
+    // entry lists here would make a future slice quietly pay a per-profile fold for a
+    // `<select>` that needs three strings. The editor reads
+    // `GET /settings/sandbox-profiles` for the rest.
+    //
+    // `home` is an observed FACT (shape of `sandbox_image`/`sandbox_docker`, no tier):
+    // `onPick` from the filesystem explorer yields an ABSOLUTE path while an entry is
+    // RELATIVE to `$HOME`, and no endpoint exposed `$HOME` before this. It MUST honour
+    // `sandbox_home_override` — otherwise the layer-3 harness and the daemon would
+    // disagree about what "under $HOME" means.
+    let profile_names = sandbox_profile::list_names(db).await?;
+    let sandbox_profiles: Vec<serde_json::Value> = profile_names
+        .iter()
+        .map(|(name, is_virtual)| serde_json::json!({ "name": name, "virtual": is_virtual }))
+        .collect();
+    let host_home = sandbox_run::sandbox_home_roots(state)
+        .ok()
+        .map(|(home, _)| home.to_string_lossy().into_owned());
+
     Ok(serde_json::json!({
         "session_cap": settings_field(cap_effective, cap_source, cfg.session_cap, cap_env, cap_default),
         "reaper_ttl_secs": settings_field(ttl_effective, ttl_source, cfg.reaper_ttl_secs, ttl_env, ttl_default),
@@ -6579,13 +6730,20 @@ async fn build_settings_view(state: &AppState) -> Result<serde_json::Value, sqlx
             img_env.as_deref(),
             sandbox_image::ImageSource::DEFAULT.as_str(),
         ),
-        "default_sandbox": settings_field_enum(
-            sbx_effective.as_str(),
-            sbx_source,
-            sbx_stored,
-            sbx_env_val.as_deref(),
-            event_log::SandboxMode::DEFAULT.as_str(),
-        ),
+        "default_sandbox": {
+            "effective": sbx_effective.as_str(),
+            "source": sbx_source,
+            "stored": sbx_stored,
+            "env": sbx_env_val,
+            "default": event_log::SandboxMode::OFF_WIRE,
+            // #432: additive sixth key, `null` when the winning tier resolves. Only
+            // `default_sandbox` carries it — it is the one enum knob whose value space
+            // is open (a profile name), hence the one that can point at nothing.
+            "reason": sbx_reason,
+        },
+        // #432: names only (see the note above), and the host `$HOME` as an observed fact.
+        "sandbox_profiles": sandbox_profiles,
+        "home": host_home,
         "dockerfile_path": settings_field_path(
             dfp_effective.as_deref(),
             dfp_source,
@@ -6660,10 +6818,11 @@ async fn put_settings(
         }
     }
     if let Some(s) = req.default_sandbox.as_deref() {
-        // "" = clear sentinel (accepted, normalised to NULL by `update`); any other
-        // non-variant → 400 (fail-fast, no silent default) (#410).
-        if !s.is_empty() && event_log::SandboxMode::parse(s).is_none() {
-            return bad("default_sandbox must be `off`, `full`, or `minimal`");
+        // "" = clear sentinel (accepted, normalised to NULL by `update`); anything else
+        // must be `off` or a staging profile that RESOLVES → 400 otherwise (fail-fast,
+        // no silent default) (#410/#432). Same shared gate as the Trigger surfaces.
+        if let Err(msg) = validate_sandbox_ref(&state.db, s).await {
+            return bad(&msg);
         }
     }
     if let Some(p) = req.dockerfile_path.as_deref() {
@@ -6706,6 +6865,396 @@ async fn put_settings(
         )
             .into_response(),
     }
+}
+
+// --- Staging profiles (#432, ADR-0031 §2-§7) --------------------------------
+
+/// Serialise one resolved entry for the editor: the path, what it points at, whether it
+/// comes from the built-in default or the user's extras, whether it is currently on, and
+/// the server-owned advisories.
+///
+/// Advisories are computed **here, server-side** — deliberately. Deriving the ≈1 GB
+/// warning or the sensitivity flag in the client would re-open exactly the drift #373
+/// cost us, and the size figure is a measurement recorded in `sandbox_staging`, not
+/// something a browser can know. `exists` is one `symlink_metadata` per entry (≤ a dozen
+/// per profile) — nothing like the recursive `plugins/**/node_modules` walk the settings
+/// handler explicitly budgets against.
+fn sandbox_entry_view(
+    home_root: Option<&std::path::Path>,
+    path: &str,
+    default_entry: Option<&sandbox_profile::DefaultEntry>,
+    enabled: bool,
+) -> serde_json::Value {
+    let sensitive = sandbox_profile::SENSITIVE_PREFIXES
+        .iter()
+        .any(|p| path == *p || path.starts_with(&format!("{p}/")));
+    // A glob is never stat-ed: the pattern itself is not a path.
+    let is_glob = default_entry.is_some_and(|d| d.kind == sandbox_profile::EntryKind::Glob);
+    let on_disk = match (home_root, is_glob) {
+        (Some(home), false) => Some(home.join(path)),
+        _ => None,
+    };
+    let exists = on_disk
+        .as_ref()
+        .map(|p| std::fs::symlink_metadata(p).is_ok());
+    let kind = match default_entry.map(|d| d.kind) {
+        Some(k) => k,
+        // An extra's kind is an OBSERVED fact — the picker knows it, but the stored diff
+        // does not, and re-deriving it here keeps the row honest after a `rm -rf`.
+        None => match on_disk.as_ref().map(|p| p.is_dir()) {
+            Some(true) => sandbox_profile::EntryKind::Dir,
+            _ => sandbox_profile::EntryKind::File,
+        },
+    };
+    serde_json::json!({
+        "path": path,
+        "kind": kind,
+        "from_default": default_entry.is_some(),
+        "enabled": enabled,
+        "resynthesised": default_entry.is_some_and(|d| d.resynthesised),
+        "note": default_entry.and_then(|d| d.note),
+        "sensitive": sensitive,
+        "exists": exists,
+    })
+}
+
+/// The full editor view of one resolved profile.
+fn sandbox_profile_view(
+    home_root: Option<&std::path::Path>,
+    profile: &sandbox_profile::ResolvedProfile,
+) -> serde_json::Value {
+    let base = sandbox_profile::base_entries(&profile.name);
+    // Default entries first, in the constant's own reading order (NOT sorted): the editor
+    // shows a stable checklist, and reordering it on every edit would be hostile.
+    let mut entries: Vec<serde_json::Value> = sandbox_profile::DEFAULT_FULL_ENTRIES
+        .iter()
+        .filter(|d| base.contains(&d.path))
+        .map(|d| {
+            let enabled = profile.resolved.entries.iter().any(|e| e == d.path);
+            sandbox_entry_view(home_root, d.path, Some(d), enabled)
+        })
+        .collect();
+    // Then the extras, in stored order.
+    for extra in &profile.extras {
+        let enabled = profile.resolved.entries.iter().any(|e| e == extra);
+        entries.push(sandbox_entry_view(home_root, extra, None, enabled));
+    }
+    let floor: Vec<serde_json::Value> = sandbox_profile::FLOOR_GUARANTEES
+        .iter()
+        .map(|g| serde_json::json!({ "id": g.id, "label": g.label, "path": g.path }))
+        .collect();
+    serde_json::json!({
+        "name": profile.name,
+        "virtual": profile.is_virtual,
+        "materialised": profile.materialised,
+        "disabled": profile.disabled,
+        "extras": profile.extras,
+        // The FROZEN-shaped list: exactly what a Run created now would stage.
+        "resolved": profile.resolved.entries,
+        "entries": entries,
+        // Signalled no-ops, never errors (ADR-0031 §2): the default may lose an entry
+        // tomorrow, and a `disabled` for an entry this version does not have yet must be
+        // remembered.
+        "redundant_extras": profile.resolved.redundant_extras,
+        "inactive_disabled": profile.resolved.inactive_disabled,
+        "floor": floor,
+        "sensitive_prefixes": sandbox_profile::SENSITIVE_PREFIXES,
+        "updated_at": profile.updated_at,
+    })
+}
+
+/// `GET /settings/sandbox-profiles` — every profile the instance can serve: the two
+/// virtual defaults ∪ the materialised rows, each fully resolved.
+async fn list_sandbox_profiles(State(state): State<Arc<AppState>>) -> Response {
+    let home_root = sandbox_run::sandbox_home_roots(&state).ok().map(|(h, _)| h);
+    let names = match sandbox_profile::list_names(&state.db).await {
+        Ok(n) => n,
+        Err(e) => {
+            error!("failed to list sandbox profiles: {e}");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": e.to_string() })),
+            )
+                .into_response();
+        }
+    };
+    let mut out = Vec::with_capacity(names.len());
+    for (name, _) in &names {
+        match sandbox_profile::resolve(&state.db, name).await {
+            Ok(Some(p)) => out.push(sandbox_profile_view(home_root.as_deref(), &p)),
+            // Unreachable: the name came from the same store one statement ago.
+            Ok(None) => warn!("sandbox profile `{name}` vanished mid-list"),
+            Err(e) => {
+                error!("failed to resolve sandbox profile `{name}`: {e}");
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({ "error": e.to_string() })),
+                )
+                    .into_response();
+            }
+        }
+    }
+    Json(serde_json::json!({
+        "profiles": out,
+        "home": home_root.map(|h| h.to_string_lossy().into_owned()),
+    }))
+    .into_response()
+}
+
+/// `GET /settings/sandbox-profiles/{name}` — one resolved profile, or 404.
+async fn get_sandbox_profile(
+    State(state): State<Arc<AppState>>,
+    AxumPath(name): AxumPath<String>,
+) -> Response {
+    let home_root = sandbox_run::sandbox_home_roots(&state).ok().map(|(h, _)| h);
+    match sandbox_profile::resolve(&state.db, &name).await {
+        Ok(Some(p)) => Json(sandbox_profile_view(home_root.as_deref(), &p)).into_response(),
+        Ok(None) => (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({ "error": format!("no staging profile named `{name}`") })),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({ "error": e.to_string() })),
+        )
+            .into_response(),
+    }
+}
+
+/// The body of `PUT /settings/sandbox-profiles/{name}` — the **diff**, never a snapshot
+/// (ADR-0031 §2). Both fields default to empty so a bare `{}` means "materialise this
+/// profile exactly as the current default".
+#[derive(Deserialize)]
+struct UpsertSandboxProfileRequest {
+    #[serde(default)]
+    disabled: Vec<String>,
+    #[serde(default)]
+    extras: Vec<String>,
+}
+
+/// `PUT /settings/sandbox-profiles/{name}` — upsert the diff.
+///
+/// `upsert` and not create-then-update: the caller cannot know whether `full` already has
+/// a row, and ADR-0031 §2 says editing it *is* what materialises one.
+///
+/// Validation, all fail-fast before anything is written:
+/// - the name against the grammar (`off` and `""` reserved, no case folding);
+/// - each `extras` path through [`sandbox_profile::validate_entry`] — absolute, `..`,
+///   backslash, NUL, glob, `.claude` bare, `.pdo`, and the three floor-owned paths are
+///   rejected — and it must **exist under `$HOME` right now**, an early UX gate in the
+///   same spirit as #431's `dockerfile_path` (necessary, never sufficient: `prepare`
+///   warns-and-skips, and mount rule M1 handles a path that vanishes later);
+/// - each `disabled` name by **membership in the built-in default**, which is also what
+///   makes the default's `.claude/*.md` glob unauthorable by hand;
+/// - `extras ∩ disabled = ∅`. A contradictory intention resolved silently would freeze
+///   into `RunStarted` a winner the user never picked.
+async fn put_sandbox_profile(
+    State(state): State<Arc<AppState>>,
+    AxumPath(name): AxumPath<String>,
+    Json(req): Json<UpsertSandboxProfileRequest>,
+) -> Response {
+    let bad = |msg: String| -> Response {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": msg })),
+        )
+            .into_response()
+    };
+
+    let name = match sandbox_profile::validate_profile_name(&name) {
+        Ok(n) => n,
+        Err(msg) => return bad(msg),
+    };
+
+    let home_root = sandbox_run::sandbox_home_roots(&state).ok().map(|(h, _)| h);
+
+    // Extras: validate → normalise → (exists under $HOME) → sort → dedup.
+    let mut extras: Vec<String> = Vec::with_capacity(req.extras.len());
+    for raw in &req.extras {
+        let norm = match sandbox_profile::validate_entry(raw) {
+            Ok(n) => n,
+            Err(msg) => return bad(msg),
+        };
+        if let Some(home) = home_root.as_deref() {
+            let abs = home.join(&norm);
+            if std::fs::symlink_metadata(&abs).is_err() {
+                return bad(format!(
+                    "`{norm}`: nothing at {} — pick a file or folder that exists under \
+                     your home directory",
+                    abs.display()
+                ));
+            }
+        }
+        if !extras.contains(&norm) {
+            extras.push(norm);
+        }
+    }
+    extras.sort();
+
+    // Disabled: validated by MEMBERSHIP in the authored default, not by `validate_entry`.
+    // Two consequences, both wanted: the default's `.claude/*.md` glob is uncheckable but
+    // never hand-writable, and an *extra* can only be removed by dropping it from
+    // `extras` — unchecking is for defaults only, which keeps the diff unambiguous.
+    let mut disabled: Vec<String> = Vec::with_capacity(req.disabled.len());
+    for raw in &req.disabled {
+        let candidate = raw.trim().to_string();
+        if candidate.is_empty() {
+            return bad("a `disabled` entry cannot be blank".to_string());
+        }
+        if !sandbox_profile::DEFAULT_FULL_ENTRIES
+            .iter()
+            .any(|d| d.path == candidate)
+        {
+            return bad(format!(
+                "`{candidate}` is not a built-in default entry, so it cannot be unchecked \
+                 — remove it from the extras instead"
+            ));
+        }
+        if !disabled.contains(&candidate) {
+            disabled.push(candidate);
+        }
+    }
+    disabled.sort();
+
+    if let Some(clash) = disabled.iter().find(|d| extras.contains(d)) {
+        return bad(format!(
+            "`{clash}` is both unchecked and added as an extra — pick one"
+        ));
+    }
+
+    match sandbox_profile::upsert(&state.db, &name, &disabled, &extras).await {
+        Ok(_) => match sandbox_profile::resolve(&state.db, &name).await {
+            Ok(Some(p)) => Json(sandbox_profile_view(home_root.as_deref(), &p)).into_response(),
+            Ok(None) | Err(_) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": "profile written but not readable back" })),
+            )
+                .into_response(),
+        },
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({ "error": e.to_string() })),
+        )
+            .into_response(),
+    }
+}
+
+/// `DELETE /settings/sandbox-profiles/{name}` — drop the materialised row.
+///
+/// **Unconditional** (ADR-0031 §7: a *soft* guard-rail, no referential integrity in the
+/// database). Deleting an edited `full`/`minimal` reverts it to its virtual default;
+/// deleting a user profile makes every future Run that references it fail loud. Neither
+/// repoints anything — which is precisely what the referents dialog must say before the
+/// user confirms.
+async fn delete_sandbox_profile(
+    State(state): State<Arc<AppState>>,
+    AxumPath(name): AxumPath<String>,
+) -> Response {
+    match sandbox_profile::delete(&state.db, &name).await {
+        Ok(true) => StatusCode::NO_CONTENT.into_response(),
+        Ok(false) => (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({
+                "error": format!(
+                    "no materialised staging profile named `{name}` \
+                     (an unedited built-in default has no row to delete)"
+                )
+            })),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({ "error": e.to_string() })),
+        )
+            .into_response(),
+    }
+}
+
+/// `GET /settings/sandbox-profiles/{name}/referents` — who still points at this profile.
+///
+/// Server-side because the frontend **cannot** derive the third class: `RunListEntry`
+/// does not carry `sandbox` (only the full `RunState` does), so a client would need N
+/// requests. Three classes, and the distinction between the first two and the third is
+/// the whole point of the dialog:
+/// - `instance_default` / `triggers` — deleting will NOT repoint them, and the next Run
+///   they produce **fails**; it does not fall back to a default;
+/// - `runs` — live Runs that already froze their entry list at start (ADR-0031 §6) and
+///   are therefore **unaffected**.
+async fn get_sandbox_profile_referents(
+    State(state): State<Arc<AppState>>,
+    AxumPath(name): AxumPath<String>,
+) -> Response {
+    // Instance default: the RESOLVED tier, so a stored value shadowed by `PDO_DEFAULT_SANDBOX`
+    // is not reported as a referent when it is not the one that wins.
+    let stored_default = instance_config::get(&state.db)
+        .await
+        .ok()
+        .and_then(|c| c.default_sandbox);
+    let instance_default =
+        event_log::default_sandbox_with(stored_default).profile() == Some(name.as_str());
+
+    let triggers: Vec<serde_json::Value> = match trigger_store::list(&state.db).await {
+        Ok(list) => list
+            .iter()
+            .filter(|t| {
+                t.sandbox
+                    .as_deref()
+                    .and_then(event_log::SandboxMode::parse)
+                    .as_ref()
+                    .and_then(event_log::SandboxMode::profile)
+                    == Some(name.as_str())
+            })
+            .map(|t| serde_json::json!({ "id": t.id, "name": t.name, "enabled": t.enabled }))
+            .collect(),
+        Err(e) => {
+            error!("failed to list triggers for profile referents: {e}");
+            Vec::new()
+        }
+    };
+
+    // Live Runs: one indexed pass over `run_started` payloads, excluding any run that
+    // already emitted a terminal event. Cheaper than projecting each run, and terminality
+    // is exactly "a terminal event exists" for this purpose.
+    let rows: Result<Vec<(String, String)>, _> = sqlx::query_as(
+        "SELECT e.run_id, e.payload FROM events e \
+         WHERE e.kind = 'run_started' AND e.payload IS NOT NULL \
+           AND NOT EXISTS ( \
+             SELECT 1 FROM events t WHERE t.run_id = e.run_id AND t.kind IN \
+               ('run_completed', 'run_failed', 'run_skipped', 'run_halted', 'run_archived') \
+           ) \
+         ORDER BY e.ts DESC",
+    )
+    .fetch_all(&state.db)
+    .await;
+    let runs: Vec<serde_json::Value> = match rows {
+        Ok(rows) => rows
+            .iter()
+            .filter_map(|(run_id, payload)| {
+                let val = serde_json::from_str::<serde_json::Value>(payload).ok()?;
+                if val.get("sandbox")?.as_str()? != name {
+                    return None;
+                }
+                Some(serde_json::json!({
+                    "run_id": run_id,
+                    "pipeline_name": val.get("pipeline_name").and_then(|v| v.as_str()),
+                    "name": val.get("name").and_then(|v| v.as_str()),
+                }))
+            })
+            .collect(),
+        Err(e) => {
+            error!("failed to query runs for profile referents: {e}");
+            Vec::new()
+        }
+    };
+
+    Json(serde_json::json!({
+        "name": name,
+        "instance_default": instance_default,
+        "triggers": triggers,
+        "runs": runs,
+    }))
+    .into_response()
 }
 
 #[derive(Deserialize)]
@@ -7017,7 +7566,7 @@ async fn get_run(
                     (home, sandbox)
                 });
             let projects_root = sandbox_run::transcripts_root(
-                run_state.sandbox,
+                !run_state.sandbox.is_off(),
                 &run_state.run_id,
                 &home_root,
                 &sandbox_root,
@@ -7576,8 +8125,12 @@ async fn run_stale_detection(state: &AppState) {
         // — the staged home while a sandboxed Run is live, `~/.claude/projects/`
         // otherwise. The per-node encoded dirname is still derived from the
         // node's `working_dir` inside the probe; the seam only swaps the base.
-        let projects_root =
-            sandbox_run::transcripts_root(run_state.sandbox, run_id, &home_root, &sandbox_root);
+        let projects_root = sandbox_run::transcripts_root(
+            !run_state.sandbox.is_off(),
+            run_id,
+            &home_root,
+            &sandbox_root,
+        );
 
         let running = stale_detector::running_nodes(&run_state);
         for (node_id, iter) in &running {
@@ -7655,7 +8208,14 @@ async fn run_stale_detection(state: &AppState) {
                     // The session is already gone; reaping captures whatever
                     // remains (usually nothing) and is a no-op otherwise. Its
                     // slot freed. Re-drive throttled `waiting` nodes (#159).
-                    reap_node_session(state, &repo_root, run_id, node_id, *iter, run_state.sandbox);
+                    reap_node_session(
+                        state,
+                        &repo_root,
+                        run_id,
+                        node_id,
+                        *iter,
+                        !run_state.sandbox.is_off(),
+                    );
                     retry_waiting_nodes(state).await;
                 }
                 stale_detector::Detection::AutoComplete => {
@@ -8598,8 +9158,10 @@ async fn node_done(
     let tail_state = state.clone();
     let tail_run = run_id.clone();
     let tail_node = node_id.clone();
-    // #407: the Run's (immutable) sandbox mode for the targeted container kill.
-    let tail_sandbox = pre_run_state.sandbox;
+    // #407/#432: whether this Run is sandboxed, for the targeted container kill. A
+    // `bool`, not the mode: the mode owns a String since profiles landed, and this value
+    // is captured into a detached `async move` where a reference cannot live.
+    let tail_sandbox = !pre_run_state.sandbox.is_off();
     detach_terminal_tail("node_done", state.clone(), run_id, node_id, async move {
         // Reap on terminal state (#205): snapshot the pane then kill the session,
         // so a completed node never holds a live session toward the tmux-collapse
@@ -8669,9 +9231,9 @@ async fn node_fail(
         // projection (the targeted container kill needs the mode).
         let (repo_root, tail_sandbox) = match load_events(&tail_state.db, &tail_run).await {
             Ok(evs) => event_log::project(&evs)
-                .map(|s| (effective_repo_root(&tail_state, &s), s.sandbox))
-                .unwrap_or_else(|| (tail_state.repo_root.clone(), event_log::SandboxMode::Off)),
-            Err(_) => (tail_state.repo_root.clone(), event_log::SandboxMode::Off),
+                .map(|s| (effective_repo_root(&tail_state, &s), !s.sandbox.is_off()))
+                .unwrap_or_else(|| (tail_state.repo_root.clone(), false)),
+            Err(_) => (tail_state.repo_root.clone(), false),
         };
         reap_node_session(
             &tail_state,
@@ -8773,7 +9335,7 @@ async fn node_skip(
     let tail_run = run_id.clone();
     let tail_node = node_id.clone();
     let reason = req.reason.clone();
-    let tail_sandbox = pre_run_state.sandbox;
+    let tail_sandbox = !pre_run_state.sandbox.is_off();
     detach_terminal_tail("node_skip", state.clone(), run_id, node_id, async move {
         // Reap on terminal state (#205): snapshot the pane then kill the session.
         reap_node_session(
@@ -9052,7 +9614,7 @@ async fn node_stop(
         &run_id,
         &node_id,
         iter,
-        run_state.sandbox,
+        !run_state.sandbox.is_off(),
     );
 
     let params = node_primitives::StopNodeParams {
@@ -9817,8 +10379,7 @@ async fn run_command(
             // reparented container process alive.
             let kill_sandbox = reload_run_state(&state, &run_id)
                 .await
-                .map(|(_, s)| s.sandbox)
-                .unwrap_or_default();
+                .is_some_and(|(_, s)| !s.sandbox.is_off());
             sandbox_run::kill_session_best_effort(
                 state.docker_cmd_override.as_deref().unwrap_or("docker"),
                 kill_sandbox,
@@ -9914,8 +10475,7 @@ async fn run_command(
             // process doesn't linger alongside the new one.
             let restart_sandbox = reload_run_state(&state, &run_id)
                 .await
-                .map(|(_, s)| s.sandbox)
-                .unwrap_or_default();
+                .is_some_and(|(_, s)| !s.sandbox.is_off());
             sandbox_run::kill_session_best_effort(
                 state.docker_cmd_override.as_deref().unwrap_or("docker"),
                 restart_sandbox,
@@ -10200,7 +10760,15 @@ async fn run_command(
                 // `Some` so it is treated as EXPLICIT at the chokepoint — the resolver
                 // must honour it exactly, never letting a changed instance default
                 // silently re-sandbox (or un-sandbox) a retried Run.
-                sandbox: Some(run_state.sandbox),
+                //
+                // #432: we HAVE `run_state.sandbox_entries` here and deliberately do NOT
+                // forward it. A retry is a NEW Run — new `run_id`, no node has staged
+                // anything yet — so there is no coherence to protect, and re-resolving is
+                // the only behaviour consistent with ADR-0031 §2 (a profile edited since
+                // must take effect). Do not "fix" this by threading the frozen list.
+                // Side effect, intended: a profile deleted since makes the retry 400,
+                // loudly, instead of quietly running something else.
+                sandbox: Some(run_state.sandbox.clone()),
             };
             let new_run_resp = create_run_core(&state, new_run_req, Vec::new()).await;
 
@@ -11983,7 +12551,7 @@ fn reap_node_session(
     run_id: &str,
     node_id: &str,
     iter: i64,
-    sandbox: event_log::SandboxMode,
+    sandboxed: bool,
 ) {
     let socket = state.tmux_socket();
     let session = tmux_session_manager::node_session_name(run_id, node_id, iter);
@@ -12005,7 +12573,7 @@ fn reap_node_session(
     // no-op for `off`. Marker == the session name (so the /proc scan hits it).
     sandbox_run::kill_session_best_effort(
         state.docker_cmd_override.as_deref().unwrap_or("docker"),
-        sandbox,
+        sandboxed,
         run_id,
         &session,
     );

--- a/crates/pdo-daemon/src/node_spawn.rs
+++ b/crates/pdo-daemon/src/node_spawn.rs
@@ -160,10 +160,11 @@ pub(crate) async fn spawn_node(
         }
     }
 
-    // #407: the Run's isolation mode (immutable, projected from RunStarted). When
-    // not `off`, the tail below is wrapped to run inside `pdo-sbx-<run_id>`. Read
-    // from the guard projection — `sandbox` never changes over a Run's life.
-    let run_sandbox = projected.as_ref().map(|s| s.sandbox).unwrap_or_default();
+    // #407: whether the Run is sandboxed (immutable, projected from RunStarted). When
+    // it is, the tail below is wrapped to run inside `pdo-sbx-<run_id>`. Read from the
+    // guard projection — `sandbox` never changes over a Run's life. A `bool` and not
+    // the mode (#432): the profile name is owned, and only the off-ness matters here.
+    let run_sandboxed = projected.as_ref().is_some_and(|s| !s.sandbox.is_off());
 
     // #248 / ADR-0017: refuse to spawn a `script` node with an empty body — it
     // would `bash <empty>` → exit 0 → a silent no-op masquerading as success.
@@ -472,7 +473,7 @@ pub(crate) async fn spawn_node(
     // #407: wrap the tail in `docker exec … pdo-sbx-<run>` when sandboxed. The
     // marker MUST equal the session name (the kill path scans `/proc` for it), and
     // the workdir is the node's own working dir.
-    let sandbox_wrap = (!run_sandbox.is_off()).then(|| tmux_session_manager::SandboxWrap {
+    let sandbox_wrap = run_sandboxed.then(|| tmux_session_manager::SandboxWrap {
         docker_bin: deps.docker_cmd_override.unwrap_or("docker"),
         uid: crate::sandbox_container::host_uid(),
         gid: crate::sandbox_container::host_gid(),

--- a/crates/pdo-daemon/src/sandbox_container.rs
+++ b/crates/pdo-daemon/src/sandbox_container.rs
@@ -316,6 +316,12 @@ fn probe_state(docker_bin: &str, name: &str) -> Result<ContainerState> {
 /// Provisionneur IDEMPOTENT du conteneur (miroir de [`crate::sandbox_image::ensure_image`]) :
 /// sonde → up → no-op ; arrêté → `start` ; absent → `create` + `start`. Toute erreur de sonde
 /// (transitoire, docker absent) remonte via `?` sans jamais être traitée comme une absence.
+///
+/// **`spec` n'est consulté que sur le bras `Absent`.** `docker start` ne **réévalue jamais** les
+/// mounts d'un conteneur pré-existant : ils sont figés à `docker create`. Cohérent avec le gel
+/// d'ADR-0031 §6 — éditer un profil en cours de Run ne remonte rien, et ne doit rien remonter — mais
+/// jusqu'ici non dit, alors que la queue variable de [`ContainerSpec::extra_mounts`] (#432) rend la
+/// question naturelle.
 pub(crate) fn ensure_running(docker_bin: &str, run_id: &str, spec: &ContainerSpec) -> Result<()> {
     let name = container_name(run_id);
     match probe_state(docker_bin, &name)? {

--- a/crates/pdo-daemon/src/sandbox_container.rs
+++ b/crates/pdo-daemon/src/sandbox_container.rs
@@ -86,6 +86,16 @@ pub(crate) struct ContainerSpec<'a> {
     pub gid: u32,
     /// Port du daemon hôte : `-e PDO_DAEMON_URL=http://host.docker.internal:<port>`.
     pub daemon_port: u16,
+    /// Mounts d'**exception `$HOME`** du profil de staging (#432, ADR-0031 §4) —
+    /// calculés par [`crate::sandbox_staging::extra_mounts`] depuis la liste d'entrées
+    /// GELÉE croisée avec le disque. Queue **variable** : vide pour `minimal`/`full`
+    /// non édités, d'où un argv byte-identique à #406 (propriété que le golden test
+    /// pin explicitement).
+    ///
+    /// Note pour [`ensure_running`] : `docker start` sur un conteneur pré-existant ne
+    /// **réévalue jamais** les mounts. Cohérent avec le gel d'ADR-0031 §6 — un profil
+    /// édité en cours de Run ne remonte rien — mais jusqu'ici non dit.
+    pub extra_mounts: &'a [crate::sandbox_staging::StagedMount],
 }
 
 // -- builders purs (golden-testés) -------------------------------------------
@@ -97,10 +107,17 @@ pub(crate) fn container_name(run_id: &str) -> String {
 }
 
 /// Argv `docker create` (après le binaire `docker`). Ordre canonique FIGÉ par le golden test :
-/// `--init`, `--name`, `--user` numérique, `--add-host`, `-w`, les 4 `-e`, les 4 `-v`, l'image,
-/// puis le trailing `sleep infinity` (le conteneur dort ; les tails entrent par `docker exec`).
+/// `--init`, `--name`, `--user` numérique, `--add-host`, `-w`, les 4 `-e`, les 4 `-v` **fixes**,
+/// puis la **queue variable** des mounts d'exception `$HOME` (#432), l'image, et le trailing
+/// `sleep infinity` (le conteneur dort ; les tails entrent par `docker exec`).
+///
+/// La queue est **entre** les `-v` fixes et l'image — position forcée par Docker : après
+/// l'image, tout argument devient la commande. Elle est triée par chemin relatif
+/// ([`crate::sandbox_staging::extra_mounts`]) : un ordre déterministe rend le golden
+/// lisible, et le tri est ce qui garde le collapse des imbriqués linéaire. Docker lui-même
+/// s'en moque (il applique les mounts par profondeur de destination, pas par ordre d'argv).
 pub(crate) fn create_args(run_id: &str, spec: &ContainerSpec) -> Vec<String> {
-    vec![
+    let mut args = vec![
         "create".to_string(),
         // --init : tini comme PID 1, reape les enfants reparentés après un kill ciblé (sinon
         // zombies permanents, `sleep infinity` ne reape pas). Docker embarque tini >= 1.13.
@@ -147,11 +164,22 @@ pub(crate) fn create_args(run_id: &str, spec: &ContainerSpec) -> Vec<String> {
         ),
         "-v".to_string(),
         format!("{}:/usr/local/bin/pdo:ro", spec.pdo_bin.display()),
-        // Image, puis la commande dormante.
-        spec.image_ref.to_string(),
-        "sleep".to_string(),
-        "infinity".to_string(),
-    ]
+    ];
+    // Queue variable (#432) : un `-v <source>:<target>:rw` par entrée d'exception
+    // `$HOME` réellement stagée. Vide ⇒ l'argv reste byte-identique à #406.
+    for mount in spec.extra_mounts {
+        args.push("-v".to_string());
+        args.push(format!(
+            "{}:{}:rw",
+            mount.source.display(),
+            mount.target.display()
+        ));
+    }
+    // Image, puis la commande dormante.
+    args.push(spec.image_ref.to_string());
+    args.push("sleep".to_string());
+    args.push("infinity".to_string());
+    args
 }
 
 /// Préfixe `docker exec` d'une session de nœud (après le binaire `docker` ; #407 y ajoute la
@@ -604,6 +632,9 @@ mod tests {
         pdo: PathBuf,
         host_home: PathBuf,
         image: String,
+        /// Queue variable (#432). Vide par défaut — c'est ce qui garde l'argv
+        /// byte-identique à #406 pour un profil sans entrée d'exception `$HOME`.
+        extras: Vec<crate::sandbox_staging::StagedMount>,
     }
 
     impl Fixtures {
@@ -616,7 +647,19 @@ mod tests {
                 pdo: PathBuf::from("/host/bin/pdo"),
                 host_home: PathBuf::from("/home/u"),
                 image: "pdo-sandbox:h-abc123".to_string(),
+                extras: Vec::new(),
             }
+        }
+
+        fn with_extras(mut self, rels: &[&str]) -> Self {
+            self.extras = rels
+                .iter()
+                .map(|rel| crate::sandbox_staging::StagedMount {
+                    source: PathBuf::from(format!("/sb/r1/home/{rel}")),
+                    target: PathBuf::from(format!("/home/u/{rel}")),
+                })
+                .collect();
+            self
         }
 
         fn spec(&self) -> ContainerSpec<'_> {
@@ -631,6 +674,7 @@ mod tests {
                 uid: 1000,
                 gid: 1000,
                 daemon_port: 6172,
+                extra_mounts: &self.extras,
             }
         }
     }
@@ -665,13 +709,16 @@ mod tests {
         })
     }
 
-    // -- 1. create_args golden (AC#1) ----------------------------------------
+    // -- 1. create_args golden (AC#1, éclaté en trois en #432) ----------------
+    //
+    // « Accommoder la queue variable, pas la figer » : le préfixe FIXE est gravé UNE
+    // fois, la queue est prouvée séparément, et un troisième test pin la propriété
+    // structurelle (les extras ne peuvent QUE grossir la queue). Le filtre de dédup se
+    // teste là où il vit — `sandbox_staging::extra_mounts` — pas à travers `create_args`.
 
-    #[test]
-    fn create_args_golden() {
-        let fx = Fixtures::sample();
-        let args = create_args("r1", &fx.spec());
-        let expected = strings(&[
+    /// L'argv jusqu'aux 4 `-v` fixes inclus. FIGÉ ICI, et nulle part ailleurs.
+    fn create_argv_fixed() -> Vec<String> {
+        strings(&[
             "create",
             "--init",
             "--name",
@@ -698,11 +745,64 @@ mod tests {
             "/sb/r1/.claude.json:/home/u/.claude.json:rw",
             "-v",
             "/host/bin/pdo:/usr/local/bin/pdo:ro",
-            "pdo-sandbox:h-abc123",
-            "sleep",
-            "infinity",
-        ]);
-        assert_eq!(args, expected);
+        ])
+    }
+
+    /// L'image + la commande dormante.
+    fn create_argv_suffix() -> Vec<String> {
+        strings(&["pdo-sandbox:h-abc123", "sleep", "infinity"])
+    }
+
+    /// Queue vide ⇒ argv **byte-identique** à #406. La propriété qui garantit que #432
+    /// n'a touché aucun Run dont le profil n'a pas d'entrée d'exception `$HOME`.
+    #[test]
+    fn create_args_golden_no_extras() {
+        let fx = Fixtures::sample();
+        let mut expected = create_argv_fixed();
+        expected.extend(create_argv_suffix());
+        assert_eq!(create_args("r1", &fx.spec()), expected);
+    }
+
+    /// Une liste précise → une queue précise, insérée entre les `-v` fixes et l'image.
+    #[test]
+    fn create_args_golden_with_extras() {
+        let fx = Fixtures::sample().with_extras(&[".gitconfig", ".config/gh"]);
+        let mut expected = create_argv_fixed();
+        expected.extend(strings(&[
+            "-v",
+            "/sb/r1/home/.gitconfig:/home/u/.gitconfig:rw",
+            "-v",
+            "/sb/r1/home/.config/gh:/home/u/.config/gh:rw",
+        ]));
+        expected.extend(create_argv_suffix());
+        assert_eq!(create_args("r1", &fx.spec()), expected);
+    }
+
+    /// La propriété STRUCTURELLE, indépendante des chemins : le préfixe est intact, la
+    /// queue est insérée avant l'image, et une entrée coûte exactement deux args.
+    /// Position forcée par Docker — après l'image, tout devient la commande.
+    #[test]
+    fn extras_only_grow_the_tail_between_the_fixed_v_and_the_image() {
+        let fixed = create_argv_fixed();
+        let bare = create_args("r1", &Fixtures::sample().spec());
+        let one = create_args(
+            "r1",
+            &Fixtures::sample().with_extras(&[".gitconfig"]).spec(),
+        );
+
+        assert_eq!(
+            &one[..fixed.len()],
+            &fixed[..],
+            "le préfixe fixe est intact"
+        );
+        assert_eq!(one.len(), bare.len() + 2, "une entrée = exactement 2 args");
+        // La queue précède l'image, qui précède la commande.
+        let image_at = one
+            .iter()
+            .position(|a| a == "pdo-sandbox:h-abc123")
+            .unwrap();
+        assert_eq!(&one[image_at..], &create_argv_suffix()[..]);
+        assert_eq!(one[image_at - 2], "-v");
     }
 
     // -- 2. exec_prefix golden (AC#1) ----------------------------------------

--- a/crates/pdo-daemon/src/sandbox_profile.rs
+++ b/crates/pdo-daemon/src/sandbox_profile.rs
@@ -1,0 +1,895 @@
+//! Staging profiles — the named, editable content of a sandboxed Run's staged home
+//! (#432, slice K of PRD #403; ADR-0031 §2-§7).
+//!
+//! Before this module, what a sandboxed Run carried in its home was an invisible Rust
+//! constant: two arrays at the bottom of [`crate::sandbox_staging`]. You could neither
+//! see it, change it, nor have two versions of it. A *staging profile* replaces that
+//! two-position switch with a **named list**.
+//!
+//! Shape mirrors [`crate::instance_config`]: the **pure** functions first (classes,
+//! defaults, validation, resolution, the [`landing`] classifier), the sqlx CRUD below.
+//! Nothing here reads `$HOME`, shells out, or touches Docker.
+//!
+//! ## The three load-bearing ideas
+//!
+//! 1. **A profile is a *diff*, never a snapshot** (ADR-0031 §2). The row stores the
+//!    user's intention — `disabled` / `extras` — so the day a PDO release adds an entry
+//!    to the default, every existing profile sees it. A snapshot would freeze the
+//!    install forever. Corollary: `full` and `minimal` are **virtual defaults** with no
+//!    row at all until edited, and editing one materialises a row that *also* holds a
+//!    diff.
+//!
+//! 2. **One classifier, two views.** [`landing`] decides, for a single entry, where it
+//!    lands in the staging — and it is called by BOTH the copy view
+//!    ([`crate::sandbox_staging::prepare`]) and the mount view
+//!    ([`crate::sandbox_staging::extra_mounts`]). They therefore cannot drift, and the
+//!    "an entry under `.claude/` produces no extra `-v`" dedup of ADR-0031 §4 is not a
+//!    special case: it is a *consequence*.
+//!
+//! 3. **The floor is not editable, and not an entry either** (ADR-0031 §1). The five
+//!    guarantees [`crate::sandbox_staging`] holds in every profile are satisfied either
+//!    by an entry or by a fallback synthesis. Two of them need *keys* in a file the
+//!    profile may also carry (class **(b)** below) — unchecking those is safe. Three
+//!    need the *whole* file, so they are class **(c)**: shown read-only, never
+//!    checkable, and **refused as extras** too.
+//!
+//! ## No rename in v1
+//!
+//! `name` is the primary key AND the value stored by all three consumers
+//! (`triggers.sandbox`, `instance_config.default_sandbox`, the frozen `RunStarted`
+//! payload). Renaming is therefore *delete + create*. A future rename must be a
+//! **repointing transaction** across those three stores — never an `UPDATE` of this key.
+
+use anyhow::Result;
+use serde::Serialize;
+use sqlx::{Row, SqlitePool};
+
+// -- vocabulary --------------------------------------------------------------
+
+/// The virtual default that carries the full replica of the host `~/.claude`.
+pub(crate) const FULL_PROFILE: &str = "full";
+/// The virtual default that carries **nothing** in its own right: `minimal` *is* the
+/// staging floor, which is exactly the empty entry list.
+pub(crate) const MINIMAL_PROFILE: &str = "minimal";
+
+/// The two names that resolve with no database row (ADR-0031 §2). Creating one *is*
+/// materialising it, which is why [`validate_profile_name`] allows them.
+pub(crate) const VIRTUAL_PROFILES: &[&str] = &[FULL_PROFILE, MINIMAL_PROFILE];
+
+/// Longest accepted profile name. The name is a URL segment, a NOCASE index key, a
+/// `<select>` value and an equality token compared across three stores and one
+/// immutable event — so it stays short, ASCII and boring.
+pub(crate) const MAX_PROFILE_NAME_LEN: usize = 32;
+
+/// `$HOME`-relative prefixes we stage happily but flag in the UI (ADR-0031 §3).
+/// Forbidding them would be theatre while ADR-0030 already assumes the host uid, the
+/// repo mounted rw and real Claude credentials.
+pub(crate) const SENSITIVE_PREFIXES: &[&str] = &[".ssh", ".aws", ".gnupg"];
+
+/// What an entry points at, for the editor's right-hand column.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum EntryKind {
+    Dir,
+    File,
+    /// A one-level filename pattern (only `.claude/*.md` ships as one). Users cannot
+    /// author these — [`validate_entry`] rejects `*` — so the pattern in a resolved
+    /// list can only have come from the default.
+    Glob,
+}
+
+/// One entry of the built-in default (the `full` profile's 9 lines, ADR-0031 §2).
+pub(crate) struct DefaultEntry {
+    /// `$HOME`-relative path or one-level glob.
+    pub path: &'static str,
+    pub kind: EntryKind,
+    /// Class **(b)**: unchecking it does NOT make the file absent — the staging floor
+    /// re-synthesises the keys it needs. Exactly two entries, and the UI must say so,
+    /// or unchecking looks more destructive than it is.
+    pub resynthesised: bool,
+    /// Static, server-owned advisory shown under the entry. Static on purpose: a real
+    /// recursive size walk of `plugins/**/node_modules` is seconds of IO, and the
+    /// settings handler explicitly budgets against that (#373 discipline — the daemon
+    /// owns every derived label, the client computes none).
+    pub note: Option<&'static str>,
+}
+
+/// The `full` profile — the built-in default every profile except `minimal` diffs
+/// against. Order here is the *editor's* reading order; [`resolve_entry_list`] sorts.
+///
+/// `.credentials.json` is deliberately absent: it is a **floor** guarantee (G1), and
+/// having it in both places made the constant lie about being a list of entries.
+pub(crate) const DEFAULT_FULL_ENTRIES: &[DefaultEntry] = &[
+    DefaultEntry {
+        path: ".claude.json",
+        kind: EntryKind::File,
+        resynthesised: true,
+        note: Some(
+            "Unchecked, onboarding and folder trust are synthesised instead — your \
+             oauthAccount / emailAddress never leave the host.",
+        ),
+    },
+    DefaultEntry {
+        path: ".claude/*.md",
+        kind: EntryKind::Glob,
+        resynthesised: false,
+        note: Some("CLAUDE.md and its top-level imports (RTK.md, …)."),
+    },
+    DefaultEntry {
+        path: ".claude/settings.json",
+        kind: EntryKind::File,
+        resynthesised: true,
+        note: Some("Unchecked, a one-key settings.json is synthesised instead — not absent."),
+    },
+    DefaultEntry {
+        path: ".claude/settings.local.json",
+        kind: EntryKind::File,
+        resynthesised: false,
+        note: None,
+    },
+    DefaultEntry {
+        path: ".claude/agents",
+        kind: EntryKind::Dir,
+        resynthesised: false,
+        note: None,
+    },
+    DefaultEntry {
+        path: ".claude/commands",
+        kind: EntryKind::Dir,
+        resynthesised: false,
+        note: None,
+    },
+    DefaultEntry {
+        path: ".claude/output-styles",
+        kind: EntryKind::Dir,
+        resynthesised: false,
+        note: None,
+    },
+    DefaultEntry {
+        path: ".claude/plugins",
+        kind: EntryKind::Dir,
+        resynthesised: false,
+        note: Some("≈1 GB per run, dominated by plugins/*/node_modules."),
+    },
+    DefaultEntry {
+        path: ".claude/skills",
+        kind: EntryKind::Dir,
+        resynthesised: false,
+        note: Some("May pull targets from outside ~/.claude (links into ~/.agents)."),
+    },
+];
+
+/// One class-**(c)** floor guarantee: satisfied by the *whole* file, so it is neither
+/// checkable nor addable. Shown read-only in the editor because without that block a
+/// `minimal` profile's screen looks broken and the user wrongly concludes the container
+/// starts with no credentials.
+pub(crate) struct FloorGuarantee {
+    pub id: &'static str,
+    /// What the container gets, in the user's words.
+    pub label: &'static str,
+    /// The `$HOME`-relative path the floor owns, when there is one.
+    pub path: Option<&'static str>,
+}
+
+/// The staging floor, verbatim from [`crate::sandbox_staging::enforce_staging_floor`].
+/// G3/G4 appear here as guarantees even though their files are class-(b) *entries* —
+/// the difference is the rule that decides the classes: **(b) = the floor needs keys in
+/// the file; (c) = the floor needs the file whole.**
+pub(crate) const FLOOR_GUARANTEES: &[FloorGuarantee] = &[
+    FloorGuarantee {
+        id: "credentials",
+        label: "Valid Claude credentials",
+        path: Some(".claude/.credentials.json"),
+    },
+    FloorGuarantee {
+        id: "org-managed-settings",
+        label: "Your organisation's managed settings, consented",
+        path: Some(".claude/remote-settings.json"),
+    },
+    FloorGuarantee {
+        id: "bypass-permissions",
+        label: "Permissions bypass accepted (no blocking dialog)",
+        path: None,
+    },
+    FloorGuarantee {
+        id: "run-root-trust",
+        label: "Trust pre-granted on the Run's repo root",
+        path: None,
+    },
+    FloorGuarantee {
+        id: "empty-projects",
+        label: "An empty projects/ transcript sink",
+        path: Some(".claude/projects"),
+    },
+];
+
+/// Paths the floor owns **whole** — refused as extras, never checkable.
+const FLOOR_OWNED_PATHS: &[&str] = &[
+    ".claude/.credentials.json",
+    ".claude/remote-settings.json",
+    ".claude/projects",
+];
+
+// -- pure: the classifier ----------------------------------------------------
+
+/// Where an entry lands in the staging. The SINGLE classifier shared by the copy view
+/// and the mount view (see the module header, idea 2).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum Landing<'a> {
+    /// Under `.claude/` → `<staging>/claude-home/<rel>`, already served by the fixed
+    /// `.claude` mount. Produces **no** `-v` of its own (ADR-0031 §4 dedup).
+    ClaudeHome { rel: &'a str, glob: bool },
+    /// `.claude.json` → the `<staging>/.claude.json` **sibling**, served by fixed
+    /// mount #3. It must NOT land under `claude-home/`: there it would appear at
+    /// `$HOME/.claude/.claude.json`, where Claude Code never looks.
+    ClaudeJson,
+    /// Anything else under `$HOME` → copied to `<staging>/home/<rel>` and bind-mounted
+    /// rw at `$HOME/<rel>`. Never a direct bind of the host file (ADR-0031 §4).
+    HomeExtra { rel: &'a str },
+}
+
+/// Classify one `$HOME`-relative entry. Pure path math, no IO.
+pub(crate) fn landing(entry: &str) -> Landing<'_> {
+    if entry == ".claude.json" {
+        return Landing::ClaudeJson;
+    }
+    if let Some(rel) = entry.strip_prefix(".claude/") {
+        return Landing::ClaudeHome {
+            rel,
+            glob: rel.contains('*'),
+        };
+    }
+    Landing::HomeExtra { rel: entry }
+}
+
+// -- pure: names -------------------------------------------------------------
+
+/// Grammar: `^[a-z0-9][a-z0-9-]{0,31}$`, trimmed first then checked **strictly**.
+///
+/// - `off` is **reserved**: it short-circuits resolution before any lookup, so a
+///   profile named `off` would be unreachable for life.
+/// - `""` is **reserved**: it is the *clear* sentinel in `put_settings`, trigger create
+///   and `default_sandbox_with`.
+/// - `full` / `minimal` are **allowed** — creating them *is* materialising them.
+/// - An uppercase name is a **400, never folded**: accepting `Foo` and storing `foo`
+///   would have the UI hunt through a list that displays `foo`. See the deliberate
+///   asymmetry documented on [`crate::event_log::SandboxMode::parse`].
+pub(crate) fn validate_profile_name(raw: &str) -> Result<String, String> {
+    let name = raw.trim();
+    if name.is_empty() {
+        return Err("a profile name cannot be blank".to_string());
+    }
+    if name.eq_ignore_ascii_case(crate::event_log::SandboxMode::OFF_WIRE) {
+        return Err("`off` is reserved: it means \"no sandbox\", not a profile".to_string());
+    }
+    if name.len() > MAX_PROFILE_NAME_LEN {
+        return Err(format!(
+            "profile name `{name}` is longer than {MAX_PROFILE_NAME_LEN} characters"
+        ));
+    }
+    let mut chars = name.chars();
+    let first = chars.next().expect("non-empty checked above");
+    if !first.is_ascii_lowercase() && !first.is_ascii_digit() {
+        return Err(format!(
+            "profile name `{name}` must start with a lowercase letter or a digit"
+        ));
+    }
+    if !chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-') {
+        return Err(format!(
+            "profile name `{name}` may only contain lowercase letters, digits and `-`"
+        ));
+    }
+    Ok(name.to_string())
+}
+
+// -- pure: entries -----------------------------------------------------------
+
+/// Validate and **normalise** one user-authored entry (an *extra*).
+///
+/// Returns the normalised form — `./foo` → `foo`, `foo/` → `foo`, `foo//bar` →
+/// `foo/bar` — which is what makes dedup and the ancestor collapse well defined.
+///
+/// The insight that lets this be pure, with no `$HOME` in scope: once an absolute path
+/// and `..` are refused, a relative path **cannot** leave its root lexically, so
+/// knowing `$HOME` would add nothing. Escaping by **symlink** is not decidable here at
+/// all (the path may not exist yet; the tree mutates between this write and `prepare`),
+/// and the answer already lives where it belongs — the `copy_root` deref of
+/// `copy_tree_preserving`.
+pub(crate) fn validate_entry(raw: &str) -> Result<String, String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err("an entry cannot be blank".to_string());
+    }
+    if trimmed.contains('\0') {
+        return Err("an entry cannot contain a NUL byte".to_string());
+    }
+    // A backslash is a LEGAL filename character under Linux, so `..\..\x` would be ONE
+    // component and would sail straight through the `..` test below.
+    if trimmed.contains('\\') {
+        return Err(format!("`{trimmed}`: an entry cannot contain a backslash"));
+    }
+    if trimmed.contains(['*', '?', '[']) {
+        return Err(format!(
+            "`{trimmed}`: patterns are not accepted — pick the file or folder itself"
+        ));
+    }
+    if trimmed.starts_with('/') {
+        return Err(format!(
+            "`{trimmed}`: an entry is relative to $HOME, not an absolute path"
+        ));
+    }
+    let mut parts: Vec<&str> = Vec::new();
+    for seg in trimmed.split('/') {
+        match seg {
+            "" | "." => continue,
+            ".." => return Err(format!("`{trimmed}`: `..` would escape $HOME")),
+            s => parts.push(s),
+        }
+    }
+    if parts.is_empty() {
+        return Err(format!("`{trimmed}`: that is $HOME itself, not an entry"));
+    }
+    let norm = parts.join("/");
+
+    // Three hard refusals, each of which would otherwise kill EVERY Run of the profile
+    // with an opaque `Error response from daemon: Duplicate mount point`, or leave an
+    // undeletable staging behind.
+    if norm == ".claude" {
+        return Err(
+            "`.claude`: the staged Claude home is already mounted whole — list the \
+             entries you want under it instead"
+                .to_string(),
+        );
+    }
+    if norm == ".pdo" || norm.starts_with(".pdo/") {
+        return Err(format!(
+            "`{norm}`: `.pdo` holds the staging root itself — staging it would copy \
+             every other Run's staging into this one"
+        ));
+    }
+    if FLOOR_OWNED_PATHS.contains(&norm.as_str())
+        || FLOOR_OWNED_PATHS
+            .iter()
+            .any(|p| norm.starts_with(&format!("{p}/")))
+    {
+        return Err(format!(
+            "`{norm}`: the staging floor owns that path in every profile — it is \
+             guaranteed, not selectable"
+        ));
+    }
+    Ok(norm)
+}
+
+/// The built-in default a profile diffs against: **empty** for `minimal` (which *is*
+/// the floor), the `full` list for every other name.
+///
+/// So a brand-new profile starts as a copy of `full` with everything checked — which is
+/// what makes "uncheck `.claude/plugins`" the two-click operation the issue asks for.
+pub(crate) fn base_entries(name: &str) -> Vec<&'static str> {
+    if name == MINIMAL_PROFILE {
+        Vec::new()
+    } else {
+        DEFAULT_FULL_ENTRIES.iter().map(|e| e.path).collect()
+    }
+}
+
+/// Outcome of folding a stored diff over a base list.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ResolvedEntries {
+    /// `base ∪ extras − disabled`, normalised, sorted, deduplicated, ancestor-collapsed.
+    /// This is the list frozen into `RunStarted`.
+    pub entries: Vec<String>,
+    /// Extras that the base already carries. A **signalled no-op**, not an error: the
+    /// default may *lose* the entry tomorrow, and rejecting it would be snapshot
+    /// thinking.
+    pub redundant_extras: Vec<String>,
+    /// `disabled` names absent from the base. Also a signalled no-op — this is
+    /// ADR-0031 §2 verbatim (unchecking `plugins` before your PDO version has it).
+    pub inactive_disabled: Vec<String>,
+}
+
+/// Fold a diff over a base list. **Pure, total, no IO** — the single resolver shared by
+/// the create-run chokepoint, the boot-recovery replay and the editor's read model, so
+/// what the UI shows can never drift from what gets staged (#373).
+pub(crate) fn resolve_entry_list(
+    base: &[&str],
+    disabled: &[String],
+    extras: &[String],
+) -> ResolvedEntries {
+    let inactive_disabled: Vec<String> = disabled
+        .iter()
+        .filter(|d| !base.contains(&d.as_str()))
+        .cloned()
+        .collect();
+    let redundant_extras: Vec<String> = extras
+        .iter()
+        .filter(|e| base.contains(&e.as_str()))
+        .cloned()
+        .collect();
+
+    let mut entries: Vec<String> = base
+        .iter()
+        .filter(|b| !disabled.iter().any(|d| d == *b))
+        .map(|b| b.to_string())
+        .collect();
+    for extra in extras {
+        if !entries.iter().any(|e| e == extra) {
+            entries.push(extra.clone());
+        }
+    }
+    // Sort BEFORE collapsing — not cosmetics. A proper ancestor always sorts before its
+    // descendants, which makes the collapse a single linear pass and removes the whole
+    // "someone reached for a HashSet in the normaliser" error class.
+    entries.sort();
+    entries.dedup();
+    entries = collapse_nested(entries);
+
+    ResolvedEntries {
+        entries,
+        redundant_extras,
+        inactive_disabled,
+    }
+}
+
+/// Drop every entry that has a proper ancestor in the (sorted) list: `.config` +
+/// `.config/gh` → `.config` alone. Without it Docker would refuse the container with
+/// `Duplicate mount point`, or silently resolve the pair by destination depth.
+fn collapse_nested(sorted: Vec<String>) -> Vec<String> {
+    let mut out: Vec<String> = Vec::with_capacity(sorted.len());
+    for entry in sorted {
+        let shadowed = out
+            .iter()
+            .any(|kept| entry.starts_with(&format!("{kept}/")));
+        if !shadowed {
+            out.push(entry);
+        }
+    }
+    out
+}
+
+// -- store: the persisted diff ------------------------------------------------
+
+/// A materialised profile row: the user's **intention**, never the effective list.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct ProfileDiff {
+    pub name: String,
+    pub disabled: Vec<String>,
+    pub extras: Vec<String>,
+    pub updated_at: String,
+}
+
+/// A profile as the API serves it: the stored diff **plus** what it resolves to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ResolvedProfile {
+    pub name: String,
+    /// One of [`VIRTUAL_PROFILES`] — i.e. it resolves with or without a row.
+    pub is_virtual: bool,
+    /// A row exists (the profile has been edited at least once).
+    pub materialised: bool,
+    pub disabled: Vec<String>,
+    pub extras: Vec<String>,
+    pub resolved: ResolvedEntries,
+    pub updated_at: Option<String>,
+}
+
+/// Create the `sandbox_profiles` table if absent. A brand-new table, so
+/// `CREATE TABLE IF NOT EXISTS` **is** the whole migration — there is nothing to
+/// `ALTER`. Future columns go through the idempotent PRAGMA-guarded
+/// `ALTER TABLE … ADD COLUMN` idiom (precedent: `max_concurrent`, #239 in
+/// [`crate::trigger_store`]), **never** a migration runner.
+///
+/// **No seed row**: `minimal` and `full` are virtual (ADR-0031 §2).
+///
+/// `COLLATE NOCASE` is belt-and-braces — [`validate_profile_name`] makes a case
+/// collision unreachable, but if a validator is ever loosened the index refuses the
+/// duplicate instead of creating two profiles that display identically.
+pub(crate) async fn init(db: &SqlitePool) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS sandbox_profiles (
+            name       TEXT PRIMARY KEY COLLATE NOCASE,
+            disabled   JSON NOT NULL DEFAULT '[]',
+            extras     JSON NOT NULL DEFAULT '[]',
+            updated_at TEXT NOT NULL
+        )",
+    )
+    .execute(db)
+    .await?;
+    Ok(())
+}
+
+/// Two columns rather than one `diff` blob: they validate differently, they play
+/// opposite roles at resolution (subtract vs add), and a corrupt one degrades to
+/// `Vec::new()` on its own. Precedent: `variables JSON` in
+/// [`crate::trigger_store`].
+fn row_to_diff(row: &sqlx::sqlite::SqliteRow) -> ProfileDiff {
+    let disabled: String = row.get("disabled");
+    let extras: String = row.get("extras");
+    ProfileDiff {
+        name: row.get("name"),
+        disabled: serde_json::from_str(&disabled).unwrap_or_default(),
+        extras: serde_json::from_str(&extras).unwrap_or_default(),
+        updated_at: row.get("updated_at"),
+    }
+}
+
+/// The stored diff for `name`, or `None` when the profile has never been edited.
+pub(crate) async fn get_diff(
+    db: &SqlitePool,
+    name: &str,
+) -> Result<Option<ProfileDiff>, sqlx::Error> {
+    let row = sqlx::query(
+        "SELECT name, disabled, extras, updated_at FROM sandbox_profiles WHERE name = ?",
+    )
+    .bind(name)
+    .fetch_optional(db)
+    .await?;
+    Ok(row.as_ref().map(row_to_diff))
+}
+
+/// Every materialised diff, by name.
+pub(crate) async fn list_diffs(db: &SqlitePool) -> Result<Vec<ProfileDiff>, sqlx::Error> {
+    let rows = sqlx::query(
+        "SELECT name, disabled, extras, updated_at FROM sandbox_profiles ORDER BY name",
+    )
+    .fetch_all(db)
+    .await?;
+    Ok(rows.iter().map(row_to_diff).collect())
+}
+
+/// `upsert`, not create-then-update: the caller cannot know whether `full` is already
+/// materialised, and ADR-0031 §2 says editing it *is* what materialises it.
+pub(crate) async fn upsert(
+    db: &SqlitePool,
+    name: &str,
+    disabled: &[String],
+    extras: &[String],
+) -> Result<ProfileDiff, sqlx::Error> {
+    let now = crate::event_log::now_iso();
+    let disabled_json = serde_json::to_string(disabled).unwrap_or_else(|_| "[]".to_string());
+    let extras_json = serde_json::to_string(extras).unwrap_or_else(|_| "[]".to_string());
+    sqlx::query(
+        "INSERT INTO sandbox_profiles (name, disabled, extras, updated_at)
+         VALUES (?, ?, ?, ?)
+         ON CONFLICT(name) DO UPDATE SET
+            disabled = excluded.disabled,
+            extras = excluded.extras,
+            updated_at = excluded.updated_at",
+    )
+    .bind(name)
+    .bind(&disabled_json)
+    .bind(&extras_json)
+    .bind(&now)
+    .execute(db)
+    .await?;
+    get_diff(db, name).await?.ok_or(sqlx::Error::RowNotFound)
+}
+
+/// Delete a materialised row. `false` when there was none (a virtual default that was
+/// never edited, or an unknown name) — the caller turns that into a 404.
+///
+/// Unconditional by design (ADR-0031 §7: *soft* guard-rail, no referential integrity in
+/// the database). The referents dialog exists precisely because this does not check.
+pub(crate) async fn delete(db: &SqlitePool, name: &str) -> Result<bool, sqlx::Error> {
+    let res = sqlx::query("DELETE FROM sandbox_profiles WHERE name = ?")
+        .bind(name)
+        .execute(db)
+        .await?;
+    Ok(res.rows_affected() > 0)
+}
+
+/// Resolve `name` to its effective entry list, or `None` when no such profile exists.
+///
+/// This is the ONE existence oracle: `Ok(None)` is what every edge turns into a hard
+/// failure (400 at create, a red Trigger fire record, `RunFailed` at boot recovery) so
+/// an unknown name can never fall back silently to less isolation (ADR-0031 §7).
+pub(crate) async fn resolve(
+    db: &SqlitePool,
+    name: &str,
+) -> Result<Option<ResolvedProfile>, sqlx::Error> {
+    let stored = get_diff(db, name).await?;
+    let is_virtual = VIRTUAL_PROFILES.contains(&name);
+    let Some(diff) = stored else {
+        if !is_virtual {
+            return Ok(None);
+        }
+        let base = base_entries(name);
+        return Ok(Some(ResolvedProfile {
+            name: name.to_string(),
+            is_virtual,
+            materialised: false,
+            disabled: Vec::new(),
+            extras: Vec::new(),
+            resolved: resolve_entry_list(&base, &[], &[]),
+            updated_at: None,
+        }));
+    };
+    // The stored row's own `name` casing wins — it is what the PK holds.
+    let base = base_entries(&diff.name);
+    let resolved = resolve_entry_list(&base, &diff.disabled, &diff.extras);
+    Ok(Some(ResolvedProfile {
+        name: diff.name,
+        is_virtual,
+        materialised: true,
+        disabled: diff.disabled,
+        extras: diff.extras,
+        resolved,
+        updated_at: Some(diff.updated_at),
+    }))
+}
+
+/// Whether `name` names a resolvable profile. Thin wrapper over [`resolve`] so the
+/// existence rule has exactly one implementation.
+pub(crate) async fn exists(db: &SqlitePool, name: &str) -> Result<bool, sqlx::Error> {
+    Ok(resolve(db, name).await?.is_some())
+}
+
+/// Every profile name the instance can serve: the two virtual defaults ∪ the
+/// materialised rows, deduplicated (an edited `full` appears once), sorted.
+pub(crate) async fn list_names(db: &SqlitePool) -> Result<Vec<(String, bool)>, sqlx::Error> {
+    let mut names: Vec<String> = VIRTUAL_PROFILES.iter().map(|s| s.to_string()).collect();
+    for diff in list_diffs(db).await? {
+        if !names.iter().any(|n| n.eq_ignore_ascii_case(&diff.name)) {
+            names.push(diff.name);
+        }
+    }
+    names.sort();
+    Ok(names
+        .into_iter()
+        .map(|n| {
+            let v = VIRTUAL_PROFILES.contains(&n.as_str());
+            (n, v)
+        })
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn v(items: &[&str]) -> Vec<String> {
+        items.iter().map(|s| s.to_string()).collect()
+    }
+
+    // -- the golden that anchors the whole slice -----------------------------
+
+    /// `resolve_entry_list(full, [], [])` must equal what the pre-#432 constant staged,
+    /// entry for entry. This is the one test that proves "profiles" did not silently
+    /// change the default staging.
+    #[test]
+    fn full_default_resolves_to_the_historical_allowlist() {
+        let base = base_entries(FULL_PROFILE);
+        let got = resolve_entry_list(&base, &[], &[]);
+        assert_eq!(
+            got.entries,
+            v(&[
+                ".claude.json",
+                ".claude/*.md",
+                ".claude/agents",
+                ".claude/commands",
+                ".claude/output-styles",
+                ".claude/plugins",
+                ".claude/settings.json",
+                ".claude/settings.local.json",
+                ".claude/skills",
+            ]),
+        );
+        assert!(got.redundant_extras.is_empty());
+        assert!(got.inactive_disabled.is_empty());
+    }
+
+    /// `minimal` IS the floor: the empty list, not an error and not a special case.
+    #[test]
+    fn minimal_default_resolves_to_the_empty_list() {
+        let base = base_entries(MINIMAL_PROFILE);
+        assert!(base.is_empty());
+        assert!(resolve_entry_list(&base, &[], &[]).entries.is_empty());
+    }
+
+    // -- landing(): the single classifier ------------------------------------
+
+    /// GOLDEN, load-bearing: `.claude.json` is the SIBLING, never under `claude-home/`.
+    /// Filed there it would surface at `$HOME/.claude/.claude.json`, where Claude Code
+    /// never looks — see the note on
+    /// [`crate::sandbox_staging::staged_claude_json`]. Do not "tidy" this.
+    #[test]
+    fn landing_routes_claude_json_to_the_sibling() {
+        assert_eq!(landing(".claude.json"), Landing::ClaudeJson);
+    }
+
+    #[test]
+    fn landing_routes_under_claude_to_the_staged_home() {
+        assert_eq!(
+            landing(".claude/skills"),
+            Landing::ClaudeHome {
+                rel: "skills",
+                glob: false
+            }
+        );
+        assert_eq!(
+            landing(".claude/*.md"),
+            Landing::ClaudeHome {
+                rel: "*.md",
+                glob: true
+            }
+        );
+    }
+
+    #[test]
+    fn landing_routes_everything_else_to_a_home_extra() {
+        assert_eq!(
+            landing(".gitconfig"),
+            Landing::HomeExtra { rel: ".gitconfig" }
+        );
+        assert_eq!(
+            landing(".config/gh"),
+            Landing::HomeExtra { rel: ".config/gh" }
+        );
+        // A path that merely *starts with* the same bytes is NOT under `.claude/`.
+        assert_eq!(
+            landing(".claudex/thing"),
+            Landing::HomeExtra {
+                rel: ".claudex/thing"
+            }
+        );
+    }
+
+    // -- resolve_entry_list --------------------------------------------------
+
+    #[test]
+    fn disabling_an_entry_removes_it() {
+        let base = base_entries(FULL_PROFILE);
+        let got = resolve_entry_list(&base, &v(&[".claude/plugins"]), &[]);
+        assert!(!got.entries.iter().any(|e| e == ".claude/plugins"));
+        assert_eq!(got.entries.len(), DEFAULT_FULL_ENTRIES.len() - 1);
+        assert!(got.inactive_disabled.is_empty());
+    }
+
+    #[test]
+    fn extras_are_added_and_sorted_in() {
+        let base = base_entries(FULL_PROFILE);
+        let got = resolve_entry_list(&base, &[], &v(&[".gitconfig", ".config/gh"]));
+        // `.config/gh` sorts before `.gitconfig`, and both after the `.claude*` block.
+        assert_eq!(got.entries[0], ".claude.json");
+        assert!(got.entries.contains(&".config/gh".to_string()));
+        assert!(got.entries.contains(&".gitconfig".to_string()));
+        let sorted = {
+            let mut s = got.entries.clone();
+            s.sort();
+            s
+        };
+        assert_eq!(got.entries, sorted, "the resolved list is sorted");
+    }
+
+    /// An extra already in the default is a SIGNALLED no-op, never an error: the
+    /// default may lose the entry tomorrow. Snapshot thinking is the bug here.
+    #[test]
+    fn a_redundant_extra_is_flagged_not_rejected() {
+        let base = base_entries(FULL_PROFILE);
+        let got = resolve_entry_list(&base, &[], &v(&[".claude/skills"]));
+        assert_eq!(got.redundant_extras, v(&[".claude/skills"]));
+        assert_eq!(got.entries.len(), DEFAULT_FULL_ENTRIES.len());
+    }
+
+    /// ADR-0031 §2 verbatim: unchecking `plugins` on a PDO version whose default does
+    /// not carry it yet must be REMEMBERED, so the day it lands the profile still says
+    /// no.
+    #[test]
+    fn an_inactive_disabled_is_flagged_not_rejected() {
+        let got = resolve_entry_list(&[".claude/skills"], &v(&[".claude/plugins"]), &[]);
+        assert_eq!(got.inactive_disabled, v(&[".claude/plugins"]));
+        assert_eq!(got.entries, v(&[".claude/skills"]));
+    }
+
+    #[test]
+    fn nested_entries_collapse_onto_their_ancestor() {
+        let got = resolve_entry_list(&[], &[], &v(&[".config/gh", ".config", ".configuration"]));
+        // `.config` swallows `.config/gh`; `.configuration` is NOT a descendant (the
+        // check is component-wise, not a bare `starts_with`).
+        assert_eq!(got.entries, v(&[".config", ".configuration"]));
+    }
+
+    #[test]
+    fn duplicate_extras_are_deduplicated() {
+        let got = resolve_entry_list(&[], &[], &v(&[".gitconfig", ".gitconfig"]));
+        assert_eq!(got.entries, v(&[".gitconfig"]));
+    }
+
+    // -- validate_profile_name ----------------------------------------------
+
+    #[test]
+    fn profile_names_accept_the_grammar() {
+        for ok in ["full", "minimal", "full-no-mcp", "a", "0", "x9-y"] {
+            assert_eq!(
+                validate_profile_name(ok).unwrap(),
+                ok,
+                "{ok} should be valid"
+            );
+        }
+        assert_eq!(validate_profile_name("  full  ").unwrap(), "full");
+    }
+
+    #[test]
+    fn profile_names_reject_the_reserved_and_the_malformed() {
+        for bad in [
+            "",
+            "   ",
+            "off",
+            "OFF",
+            "Foo",
+            "-lead",
+            "under_score",
+            "spa ce",
+            "é",
+            "with.dot",
+        ] {
+            assert!(
+                validate_profile_name(bad).is_err(),
+                "{bad:?} should be rejected"
+            );
+        }
+        let too_long = "a".repeat(MAX_PROFILE_NAME_LEN + 1);
+        assert!(validate_profile_name(&too_long).is_err());
+        assert!(validate_profile_name(&"a".repeat(MAX_PROFILE_NAME_LEN)).is_ok());
+    }
+
+    // -- validate_entry ------------------------------------------------------
+
+    #[test]
+    fn entries_normalise_to_a_canonical_relative_path() {
+        assert_eq!(validate_entry("./foo").unwrap(), "foo");
+        assert_eq!(validate_entry("foo/").unwrap(), "foo");
+        assert_eq!(validate_entry("foo//bar").unwrap(), "foo/bar");
+        assert_eq!(validate_entry("  .gitconfig  ").unwrap(), ".gitconfig");
+        assert_eq!(validate_entry(".config/gh").unwrap(), ".config/gh");
+        // Sensitive but ALLOWED (ADR-0031 §3) — warned in the UI, not refused.
+        assert_eq!(validate_entry(".ssh").unwrap(), ".ssh");
+    }
+
+    #[test]
+    fn entries_reject_escapes_and_reserved_paths() {
+        for bad in [
+            "",
+            "   ",
+            ".",
+            "./",
+            "/etc/passwd",
+            "../x",
+            "foo/../../x",
+            // A backslash is a legal Linux filename char, so this would otherwise be
+            // ONE component and pass the `..` test.
+            "..\\..\\x",
+            ".claude/*.md",
+            "foo?",
+            ".claude",
+            ".pdo",
+            ".pdo/sandbox",
+            ".claude/projects",
+            ".claude/projects/-enc/x.jsonl",
+            ".claude/.credentials.json",
+            ".claude/remote-settings.json",
+        ] {
+            assert!(validate_entry(bad).is_err(), "{bad:?} should be rejected");
+        }
+        assert!(validate_entry("a\0b").is_err());
+    }
+
+    /// The default's glob is authored HERE, never by a user — which is why
+    /// `validate_entry` may refuse `*` while the resolved list still carries `*.md`.
+    #[test]
+    fn the_default_glob_is_not_user_authorable() {
+        assert!(base_entries(FULL_PROFILE).contains(&".claude/*.md"));
+        assert!(validate_entry(".claude/*.md").is_err());
+    }
+
+    /// Exactly two class-(b) entries — the floor re-synthesises those two files, so
+    /// unchecking them is safe. The UI copy depends on this count being right.
+    #[test]
+    fn exactly_two_default_entries_are_resynthesised_by_the_floor() {
+        let resynth: Vec<&str> = DEFAULT_FULL_ENTRIES
+            .iter()
+            .filter(|e| e.resynthesised)
+            .map(|e| e.path)
+            .collect();
+        assert_eq!(resynth, vec![".claude.json", ".claude/settings.json"]);
+    }
+}

--- a/crates/pdo-daemon/src/sandbox_run.rs
+++ b/crates/pdo-daemon/src/sandbox_run.rs
@@ -28,7 +28,7 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
-use tracing::warn;
+use tracing::{info, warn};
 
 use crate::event_log::{RunState, SandboxMode};
 use crate::{sandbox_container, sandbox_image, sandbox_staging, AppState};
@@ -40,7 +40,14 @@ pub(crate) struct SandboxContext {
     /// The `docker` binary to invoke (`state.docker_cmd_override` → `"docker"`).
     pub(crate) docker_bin: String,
     pub(crate) run_id: String,
+    /// `off`, or the staging profile this Run was launched with. The ONE place in the
+    /// tree that still needs the profile *name* rather than its off-ness — hence the
+    /// single `.clone()` of [`context_from_state`] (#432 D2).
     pub(crate) mode: SandboxMode,
+    /// The profile's entry list as **frozen at creation** (ADR-0031 §6), resolved at
+    /// the boundary. `None` for `off`. `Some(vec![])` is a legitimate resolution — it
+    /// is `minimal`.
+    pub(crate) entries: Option<Vec<String>>,
     /// Effective repo root — bind-mounted rw at its host path. One mount covers
     /// the repo + every node sub-worktree under `.pdo/runs/` + `.pdo/prompts`.
     pub(crate) repo_root: PathBuf,
@@ -72,15 +79,56 @@ pub(crate) struct SandboxContext {
     pub(crate) dockerfile: sandbox_image::ResolvedDockerfile,
 }
 
-impl SandboxContext {
-    /// [`sandbox_staging::Mode`] for this Run, or `None` for `off` (no staging).
-    fn staging_mode(&self) -> Option<sandbox_staging::Mode> {
-        match self.mode {
-            SandboxMode::Off => None,
-            SandboxMode::Full => Some(sandbox_staging::Mode::Full),
-            SandboxMode::Minimal => Some(sandbox_staging::Mode::Minimal),
-        }
+/// Resolve the entry list a sandboxed Run must stage, from its **frozen** projection
+/// (#432, ADR-0031 §6). The decision table, and why each arm is what it is:
+///
+/// | payload | behaviour | why |
+/// |---|---|---|
+/// | name + valid entries | **entries verbatim**, the name is ignored | the pure form of the freeze. A profile deleted since is *not* an error — surviving that is the point |
+/// | `full`/`minimal`, **no** entries | resolve the virtual default now | a virtual default always resolves; `RunFailed` on a perfectly resolvable Run is indefensible |
+/// | a user profile, **no** entries | **hard error** → `RunFailed` | unreachable by construction (the one chokepoint writes both keys) |
+/// | entries present but unreadable | **hard error**, raw value in the reason | undecidable; any fallback silently changes what the already-spawned nodes saw |
+///
+/// The `full`/`minimal`-without-entries arm does, in effect, read the **live** setting.
+/// Assumed and documented (ADR-0031 §6 note): it only fires for a Run created by a
+/// pre-profiles daemon, cleaned up, then resumed. Both alternatives are worse
+/// (`RunFailed` on something resolvable; or freezing the #426 default into Rust for
+/// ever, which contradicts ADR-0031 §2).
+async fn frozen_entries(
+    db: &sqlx::SqlitePool,
+    run_state: &RunState,
+    name: &str,
+) -> Result<Vec<String>> {
+    if let Some(raw) = &run_state.sandbox_entries_raw_error {
+        anyhow::bail!(
+            "run {} froze an unreadable sandbox entry list ({raw}); refusing to re-resolve \
+             a different list for a Run whose nodes already staged one",
+            run_state.run_id
+        );
     }
+    if let Some(entries) = &run_state.sandbox_entries {
+        // Frozen list wins outright — even if the profile has been edited or deleted.
+        return Ok(entries.clone());
+    }
+    // No frozen list: a pre-#432 payload. Only a virtual default may be re-resolved.
+    if !crate::sandbox_profile::VIRTUAL_PROFILES.contains(&name) {
+        anyhow::bail!(
+            "run {} names the staging profile `{name}` but froze no entry list \
+             (payload predates #432 and `{name}` is not a built-in default); refusing to \
+             guess what it should stage",
+            run_state.run_id
+        );
+    }
+    info!(
+        "run {} predates the frozen sandbox entry list; re-resolving the built-in \
+         default `{name}`",
+        run_state.run_id
+    );
+    let resolved = crate::sandbox_profile::resolve(db, name)
+        .await
+        .with_context(|| format!("resolve the built-in staging profile `{name}`"))?
+        .ok_or_else(|| anyhow::anyhow!("built-in staging profile `{name}` did not resolve"))?;
+    Ok(resolved.resolved.entries)
 }
 
 /// Resolve a [`SandboxContext`] from the daemon state + a projected Run. The one
@@ -91,8 +139,11 @@ impl SandboxContext {
 /// at the next ensure — consistent with the cap/TTL/model seams. A DB read error is
 /// swallowed (falls back env→default), never failing the prep.
 ///
-/// Fails (loud) when `$HOME` is unset or the current exe path can't be resolved —
-/// a sandboxed Run must never fall back to a half-configured container silently.
+/// Fails (loud) when `$HOME` is unset, the current exe path can't be resolved, or the
+/// Run's **frozen** staging-profile selection cannot be resolved (#432) — a sandboxed
+/// Run must never fall back to a half-configured container, or to a *different* home
+/// content, silently. The one caller that used to swallow this error (boot recovery)
+/// now turns it into an explicit `RunFailed`.
 pub(crate) async fn context_from_state(
     state: &AppState,
     run_state: &RunState,
@@ -116,10 +167,19 @@ pub(crate) async fn context_from_state(
         cfg.as_ref().and_then(|c| c.dockerfile_path.clone()),
         &sandbox_root,
     );
+    // #432: the frozen entry list, resolved here (the boundary) so the sync core stays
+    // DB-free. `off` resolves to `None` without touching the DB.
+    let entries = match run_state.sandbox.profile() {
+        None => None,
+        Some(name) => Some(frozen_entries(&state.db, run_state, name).await?),
+    };
     Ok(SandboxContext {
         docker_bin: docker_bin(state),
         run_id: run_state.run_id.clone(),
-        mode: run_state.sandbox,
+        // The ONE clone of the tree (#432 D2): every other consumer only tests
+        // off-ness and takes a `bool`.
+        mode: run_state.sandbox.clone(),
+        entries,
         repo_root,
         run_worktree,
         daemon_port: state.port,
@@ -170,13 +230,17 @@ pub(crate) fn docker_bin(state: &AppState) -> String {
 /// encoding is unchanged — the caller still resolves the encoded dirname from
 /// this base via [`crate::stale_detector::encode_working_dir`], the single source
 /// of truth (#373); the seam only swaps the base `projects/` root.
+/// `sandboxed` is a plain `bool`, not a [`SandboxMode`] (#432 D2): this seam only ever
+/// asked about off-ness, and since the mode owns a `String` a by-value parameter would
+/// force a clone at each of the call sites — several of which capture it into a detached
+/// `async move`, where a reference cannot live.
 pub(crate) fn transcripts_root(
-    mode: SandboxMode,
+    sandboxed: bool,
     run_id: &str,
     home_root: &Path,
     sandbox_root: &Path,
 ) -> PathBuf {
-    if !mode.is_off() && sandbox_staging::staging_dir_for_run(sandbox_root, run_id).exists() {
+    if sandboxed && sandbox_staging::staging_dir_for_run(sandbox_root, run_id).exists() {
         sandbox_staging::staged_claude_home(sandbox_root, run_id).join("projects")
     } else {
         home_root.join(".claude").join("projects")
@@ -227,7 +291,7 @@ pub(crate) async fn merge_back_best_effort(state: &AppState, run_id: &str) {
 /// isn't blocked. `off` is a defensive no-op (callers already gate on
 /// `!sandbox.is_off()`).
 pub(crate) fn ensure_ready(ctx: &SandboxContext) -> Result<()> {
-    let Some(mode) = ctx.staging_mode() else {
+    let Some(entries) = ctx.entries.as_deref() else {
         return Ok(()); // off: gated by callers; no docker touched.
     };
 
@@ -243,16 +307,24 @@ pub(crate) fn ensure_ready(ctx: &SandboxContext) -> Result<()> {
     //    require approval" or bypass-permissions dialogs.
     let staging_dir = sandbox_staging::staging_dir_for_run(&ctx.sandbox_root, &ctx.run_id);
     if !staging_dir.exists() {
-        let trusted_root = match ctx.mode {
-            SandboxMode::Minimal | SandboxMode::Full => Some(ctx.repo_root.as_path()),
-            SandboxMode::Off => None,
-        };
+        // Name the profile AND the list once per staging, so "why does this Run carry
+        // plugins/" is answerable from the log rather than by reading the DB (which may
+        // have been edited since — the list is frozen, the profile is not).
+        info!(
+            "sandbox: staging run {} with profile `{}` ({} entries: {})",
+            ctx.run_id,
+            ctx.mode.as_str(),
+            entries.len(),
+            entries.join(", ")
+        );
+        // `Some(repo_root)` unconditionally: the `off` arm of the old match was DEAD —
+        // the `let Some(entries) = … else { return }` above has already excluded it.
         sandbox_staging::prepare(
             &ctx.home_root,
             &ctx.sandbox_root,
-            mode,
+            entries,
             &ctx.run_id,
-            trusted_root,
+            Some(ctx.repo_root.as_path()),
         )
         .with_context(|| format!("failed to stage the sandbox home for run {}", ctx.run_id))?;
     }
@@ -274,6 +346,11 @@ pub(crate) fn ensure_ready(ctx: &SandboxContext) -> Result<()> {
     // 3. Assemble the container spec + ensure the long-lived container is up.
     let staged_home = sandbox_staging::staged_claude_home(&ctx.sandbox_root, &ctx.run_id);
     let staged_json = sandbox_staging::staged_claude_json(&ctx.sandbox_root, &ctx.run_id);
+    // #432: derived from `frozen list × disk`, NOT returned by `prepare` — `prepare` is
+    // skipped whenever the staging already exists (3 of the 4 `ensure_ready` callers),
+    // and this derivation gives the same answer either way.
+    let extra =
+        sandbox_staging::extra_mounts(&ctx.sandbox_root, &ctx.run_id, &ctx.host_home, entries);
     let spec = sandbox_container::ContainerSpec {
         image_ref: &image_ref,
         repo_root: &ctx.repo_root,
@@ -285,6 +362,7 @@ pub(crate) fn ensure_ready(ctx: &SandboxContext) -> Result<()> {
         uid: ctx.uid,
         gid: ctx.gid,
         daemon_port: ctx.daemon_port,
+        extra_mounts: &extra,
     };
     sandbox_container::ensure_running(&ctx.docker_bin, &ctx.run_id, &spec)
         .context("failed to ensure the sandbox container is running")?;
@@ -319,11 +397,11 @@ pub(crate) fn cleanup(docker_bin: &str, home_root: &Path, sandbox_root: &Path, r
 /// the matching tree — sibling sessions survive.
 pub(crate) fn kill_session_best_effort(
     docker_bin: &str,
-    sandbox: SandboxMode,
+    sandboxed: bool,
     run_id: &str,
     marker: &str,
 ) {
-    if sandbox.is_off() {
+    if !sandboxed {
         return;
     }
     if let Err(e) = sandbox_container::kill_session_in_container(
@@ -415,8 +493,36 @@ mod tests {
         ready()
     }
 
+    fn full() -> SandboxMode {
+        SandboxMode::Profile(crate::sandbox_profile::FULL_PROFILE.into())
+    }
+    fn minimal() -> SandboxMode {
+        SandboxMode::Profile(crate::sandbox_profile::MINIMAL_PROFILE.into())
+    }
+
     /// Build a context rooted under temp dirs (bypasses the env/exe resolvers).
+    ///
+    /// #432: `mode` names the profile and `entries` is the FROZEN list — the two are
+    /// separate parameters here because the point of the freeze is that they *can*
+    /// disagree with whatever the store now says. `Off` carries `None`.
     fn test_ctx(tmp: &Path, docker_bin: String, mode: SandboxMode) -> SandboxContext {
+        let entries = match mode.profile() {
+            None => None,
+            Some(name) => {
+                let base = crate::sandbox_profile::base_entries(name);
+                Some(crate::sandbox_profile::resolve_entry_list(&base, &[], &[]).entries)
+            }
+        };
+        test_ctx_with_entries(tmp, docker_bin, mode, entries)
+    }
+
+    /// Like [`test_ctx`] but with an explicit frozen entry list.
+    fn test_ctx_with_entries(
+        tmp: &Path,
+        docker_bin: String,
+        mode: SandboxMode,
+        entries: Option<Vec<String>>,
+    ) -> SandboxContext {
         let home = tmp.join("home");
         std::fs::create_dir_all(home.join(".claude")).unwrap();
         std::fs::write(home.join(".claude/.credentials.json"), "{}").unwrap();
@@ -425,6 +531,7 @@ mod tests {
             docker_bin,
             run_id: "r1".to_string(),
             mode,
+            entries,
             repo_root: tmp.join("repo"),
             run_worktree: tmp.join("repo/.pdo/runs/r1/worktree"),
             daemon_port: 6172,
@@ -446,7 +553,7 @@ mod tests {
     fn ensure_ready_stages_probes_image_and_container() {
         let tmp = tempfile::tempdir().unwrap();
         let (docker, log) = write_fake_docker(tmp.path());
-        let ctx = test_ctx(tmp.path(), docker, SandboxMode::Minimal);
+        let ctx = test_ctx(tmp.path(), docker, minimal());
 
         retry_etxtbsy(|| ensure_ready(&ctx)).unwrap();
 
@@ -491,7 +598,7 @@ mod tests {
     fn ensure_ready_does_not_restage_when_present() {
         let tmp = tempfile::tempdir().unwrap();
         let (docker, _) = write_fake_docker(tmp.path());
-        let ctx = test_ctx(tmp.path(), docker, SandboxMode::Minimal);
+        let ctx = test_ctx(tmp.path(), docker, minimal());
 
         retry_etxtbsy(|| ensure_ready(&ctx)).unwrap();
         // Drop a sentinel into the staging dir; a second ensure_ready must NOT
@@ -511,7 +618,7 @@ mod tests {
     fn ensure_ready_full_seeds_trust_for_repo_root() {
         let tmp = tempfile::tempdir().unwrap();
         let (docker, _log) = write_fake_docker(tmp.path());
-        let ctx = test_ctx(tmp.path(), docker, SandboxMode::Full);
+        let ctx = test_ctx(tmp.path(), docker, full());
 
         retry_etxtbsy(|| ensure_ready(&ctx)).unwrap();
 
@@ -577,16 +684,16 @@ mod tests {
     fn kill_session_off_is_noop() {
         let tmp = tempfile::tempdir().unwrap();
         let (docker, log) = write_fake_docker(tmp.path());
-        kill_session_best_effort(&docker, SandboxMode::Off, "r1", "pdo-r1-n1-iter-1");
+        kill_session_best_effort(&docker, false, "r1", "pdo-r1-n1-iter-1");
         assert!(!log.exists(), "off must not invoke docker to kill");
     }
 
     #[test]
-    fn kill_session_minimal_execs_marker() {
+    fn kill_session_sandboxed_execs_marker() {
         let tmp = tempfile::tempdir().unwrap();
         let (docker, log) = write_fake_docker(tmp.path());
         let logged = retry_side_effect(
-            || kill_session_best_effort(&docker, SandboxMode::Minimal, "r1", "pdo-r1-n1-iter-1"),
+            || kill_session_best_effort(&docker, true, "r1", "pdo-r1-n1-iter-1"),
             || {
                 let l = log_lines(&log);
                 !l.is_empty()
@@ -650,7 +757,7 @@ mod tests {
         // Even if a staging dir happens to exist, `off` reads the host.
         std::fs::create_dir_all(sandbox_staging::staging_dir_for_run(&sandbox_root, "r1")).unwrap();
         assert_eq!(
-            transcripts_root(SandboxMode::Off, "r1", &home, &sandbox_root),
+            transcripts_root(false, "r1", &home, &sandbox_root),
             home.join(".claude").join("projects")
         );
     }
@@ -663,12 +770,7 @@ mod tests {
         // Staging present → live/reapable Run → read the staged home.
         std::fs::create_dir_all(sandbox_staging::staging_dir_for_run(&sandbox_root, "r1")).unwrap();
         assert_eq!(
-            transcripts_root(SandboxMode::Minimal, "r1", &home, &sandbox_root),
-            sandbox_staging::staged_claude_home(&sandbox_root, "r1").join("projects")
-        );
-        // `full` behaves identically.
-        assert_eq!(
-            transcripts_root(SandboxMode::Full, "r1", &home, &sandbox_root),
+            transcripts_root(true, "r1", &home, &sandbox_root),
             sandbox_staging::staged_claude_home(&sandbox_root, "r1").join("projects")
         );
     }
@@ -682,7 +784,7 @@ mod tests {
         // flushed. Keyed on staging EXISTENCE, not the Run's terminal status.
         assert!(!sandbox_staging::staging_dir_for_run(&sandbox_root, "r1").exists());
         assert_eq!(
-            transcripts_root(SandboxMode::Minimal, "r1", &home, &sandbox_root),
+            transcripts_root(true, "r1", &home, &sandbox_root),
             home.join(".claude").join("projects")
         );
     }
@@ -701,12 +803,12 @@ mod tests {
         let enc = crate::stale_detector::encode_working_dir(cwd);
 
         // Host arm (no staging).
-        let host = transcripts_root(SandboxMode::Minimal, "r1", &home, &sandbox_root);
+        let host = transcripts_root(true, "r1", &home, &sandbox_root);
         assert_eq!(host.join(&enc), home.join(".claude/projects").join(&enc));
 
         // Staging arm (staging materialised) — same encoded segment appended.
         std::fs::create_dir_all(sandbox_staging::staging_dir_for_run(&sandbox_root, "r1")).unwrap();
-        let staged = transcripts_root(SandboxMode::Minimal, "r1", &home, &sandbox_root);
+        let staged = transcripts_root(true, "r1", &home, &sandbox_root);
         assert_eq!(
             staged.join(&enc),
             sandbox_staging::staged_claude_home(&sandbox_root, "r1")

--- a/crates/pdo-daemon/src/sandbox_staging.rs
+++ b/crates/pdo-daemon/src/sandbox_staging.rs
@@ -14,10 +14,13 @@
 //!   stale-detection/coût vers le staging (seam [`crate::sandbox_run::transcripts_root`]).
 //!
 //! ## Décisions de conception (voir la section « Sandbox » de `CONTEXT.md`)
-//! - **`full` = allowlist, jamais denylist.** Copier « tout `~/.claude` sauf
-//!   `projects/` » embarquerait tout l'état hôte transitoire (`history.jsonl`,
-//!   `session-env/`, `file-history/`…) — fuite d'isolation + fragile aux futures
-//!   versions de Claude Code. On copie une liste explicite.
+//! - **Allowlist, jamais denylist.** Copier « tout `~/.claude` sauf `projects/` »
+//!   embarquerait tout l'état hôte transitoire (`history.jsonl`, `session-env/`,
+//!   `file-history/`…) — fuite d'isolation + fragile aux futures versions de Claude
+//!   Code. On copie une liste explicite. Depuis #432 cette liste est **nommée et
+//!   éditable** : c'est le *profil de staging* ([`crate::sandbox_profile`]), résolu et
+//!   **gelé** dans `RunStarted`. Ce module ne connaît plus de « mode » — il reçoit une
+//!   liste d'entrées, et la vide (`minimal`) est un no-op de phase 1.
 //! - **Volume assumé ~1 Go/run** (#409, mesuré ; dominé par `plugins/*/node_modules`,
 //!   requis par les serveurs MCP *dans* le conteneur — délibérément non strippés).
 //!   Dette disque : le staging n'est purgé qu'au `cleanup_run` → à surveiller au
@@ -33,14 +36,19 @@
 //!   `projects/<enc>/<uuid>/subagents/*.jsonl` (profondeur 9). Le copy-set doit
 //!   *égaler* le read-set de [`crate::run_cost`] (`collect_jsonl_recursive`),
 //!   sinon le coût des runs sandboxés est sous-estimé (régression silencieuse).
-//! - **Le plancher de staging est mode-agnostique** (#426, ADR-0031 §1).
-//!   [`prepare`] est en **deux phases** : matérialisation du profil (ce que `full`
-//!   apporte en plus), puis [`enforce_staging_floor`] qui tient **cinq garanties**
-//!   dans les deux modes — chacune satisfaite soit par une copie de l'hôte, soit
-//!   par une synthèse de repli. `minimal` est donc un **bras de `match` vide** :
-//!   `minimal`, c'est exactement le plancher. Les trois garanties qui désarment un
-//!   dialogue bloquant (confiance, managed settings de l'org, bypass permissions)
-//!   ne sont pas cosmétiques : un agent non surveillé se figerait dessus.
+//! - **Le plancher de staging est profil-agnostique** (#426, ADR-0031 §1).
+//!   [`prepare`] est en **deux phases** : matérialisation des entrées du profil, puis
+//!   [`enforce_staging_floor`] qui tient **cinq garanties** quel que soit le profil —
+//!   chacune satisfaite soit par une copie de l'hôte, soit par une synthèse de repli.
+//!   `minimal`, c'est exactement le plancher (liste vide). Les trois garanties qui
+//!   désarment un dialogue bloquant (confiance, managed settings de l'org, bypass
+//!   permissions) ne sont pas cosmétiques : un agent non surveillé se figerait dessus.
+//! - **Une entrée hors `.claude` est copiée puis montée** (#432, ADR-0031 §4) :
+//!   `<staging>/home/<rel>` → `$HOME/<rel>` en rw, **jamais** un bind direct du
+//!   fichier hôte. Un `git config --global` du conteneur touche la copie, pas le
+//!   `~/.gitconfig` de l'utilisateur. Une entrée **sous** `.claude/` ne reçoit aucun
+//!   `-v` propre — conséquence du classificateur unique
+//!   [`crate::sandbox_profile::landing`], partagé par [`prepare`] et [`extra_mounts`].
 
 // #408: `merge_back` is now wired; the rest of the module (path-math + effects)
 // is consumed by #406/#407.
@@ -50,32 +58,6 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use anyhow::{Context, Result};
 use tracing::{info, warn};
-
-/// Comment le *staged Claude home* d'un Run est seedé. `off` (PRD) n'est PAS une
-/// variante : le caller skippe simplement [`prepare`] (pas de branche no-op dans
-/// la couche fs). Interne au daemon : jamais sérialisé (le tri-état wire/persisté
-/// est [`crate::event_log::SandboxMode`]) — d'où l'absence de derive serde.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum Mode {
-    /// Réplique de l'hôte : allowlist de `~/.claude` + `~/.claude.json` verbatim.
-    Full,
-    /// Rien en propre — `minimal` **est** le plancher ([`enforce_staging_floor`]).
-    Minimal,
-}
-
-/// Fichiers de config top-level de `~/.claude` recopiés en mode `full` (en plus
-/// des `*.md` captés par glob). `.credentials.json` préserve son mode 0600 via
-/// [`std::fs::copy`].
-///
-/// N.B. [`REMOTE_SETTINGS_FILE`] n'y est **pas** : le plancher en est le writer
-/// unique, dans les deux modes (#426). L'y ajouter donnerait, à la slice
-/// « profils », une entrée décochable que le plancher réinjecterait aussitôt.
-const FULL_ALLOWLIST_FILES: &[&str] =
-    &["settings.json", "settings.local.json", ".credentials.json"];
-
-/// Dossiers de `~/.claude` recopiés en mode `full` (walk préservant symlinks +
-/// bits exécutables). `projects/` est délibérément absent : jamais copié.
-const FULL_ALLOWLIST_DIRS: &[&str] = &["skills", "plugins", "agents", "commands", "output-styles"];
 
 /// Baseline de managed settings poussée par l'organisation, cachée par Claude Code
 /// dans `~/.claude/`. Garantie G2 : recopiée dans les **deux** modes, jamais via
@@ -116,23 +98,100 @@ pub(crate) fn staged_claude_json(sandbox_root: &Path, run_id: &str) -> PathBuf {
     staging_dir_for_run(sandbox_root, run_id).join(".claude.json")
 }
 
+/// `<staging_dir>/home` — racine des **entrées d'exception `$HOME`** (#432,
+/// ADR-0031 §4). Une entrée hors `.claude` y est *copiée* (`<staging>/home/<rel>`)
+/// puis bind-montée rw à `$HOME/<rel>` : **jamais** un bind direct du fichier hôte,
+/// sinon un agent en `--dangerously-skip-permissions` qui bute sur
+/// `unable to auto-detect email address` réécrirait le `~/.gitconfig` de
+/// l'utilisateur.
+pub(crate) fn staged_home_extras(sandbox_root: &Path, run_id: &str) -> PathBuf {
+    staging_dir_for_run(sandbox_root, run_id).join("home")
+}
+
+/// Un bind-mount d'exception `$HOME` : `source` (dans le staging) → `target` (dans
+/// le conteneur). Calculé par [`extra_mounts`], consommé par
+/// [`crate::sandbox_container::ContainerSpec::extra_mounts`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct StagedMount {
+    pub(crate) source: PathBuf,
+    pub(crate) target: PathBuf,
+}
+
+/// La queue variable de `-v` qu'une liste d'entrées gelée produit (#432).
+///
+/// **Pas** une valeur de retour de [`prepare`] : `ensure_ready` saute `prepare` quand
+/// le staging existe déjà, ce qui est le cas de 3 de ses 4 appelants. Dériver de
+/// `liste gelée × disque` est **total** — même réponse que `prepare` ait tourné ou
+/// non.
+///
+/// Deux filtres, dans cet ordre :
+/// 1. `landing()` == [`crate::sandbox_profile::Landing::HomeExtra`] — une entrée sous
+///    `.claude/` est déjà servie par le mount fixe `.claude` et ne reçoit **aucun**
+///    `-v` propre (dédup obligatoire d'ADR-0031 §4) ;
+/// 2. **règle M1** — la source doit exister sur disque. Un `-v` dont la source hôte
+///    manque fait créer par Docker un répertoire `root:root 0755`, ce qui en escalade
+///    (a) plante `git` quand un mount de *fichier* devient un *répertoire* par-dessus
+///    `$HOME/.gitconfig`, (b) rend le mount inscriptible par personne, et (c) pour un
+///    chemin multi-segment (`.config/gh`) crée `<staging>/home/.config` en root — ce
+///    qui fait échouer le `remove_dir_all` de [`teardown`] en EACCES, erreur avalée
+///    par son `let _ =`, laissant un staging de ~1 Go **définitivement indélébile par
+///    le daemon**. Ça alimente la récurrence disque connue, silencieusement.
+///
+/// Tri par chemin relatif (déterministe pour le golden) ; les imbriqués sont déjà
+/// collapsés à la résolution, la dédup ici est ceinture-bretelles.
+pub(crate) fn extra_mounts(
+    sandbox_root: &Path,
+    run_id: &str,
+    host_home: &Path,
+    entries: &[String],
+) -> Vec<StagedMount> {
+    let extras_root = staged_home_extras(sandbox_root, run_id);
+    let mut rels: Vec<&str> = entries
+        .iter()
+        .filter_map(|entry| match crate::sandbox_profile::landing(entry) {
+            crate::sandbox_profile::Landing::HomeExtra { rel } => Some(rel),
+            _ => None,
+        })
+        .collect();
+    rels.sort_unstable();
+    rels.dedup();
+    rels.into_iter()
+        .filter_map(|rel| {
+            let source = extras_root.join(rel);
+            // M1: only what was REALLY staged gets mounted.
+            if !source.exists() {
+                return None;
+            }
+            Some(StagedMount {
+                source,
+                target: host_home.join(rel),
+            })
+        })
+        .collect()
+}
+
 // -- effets (sync std::fs, anyhow + .context) --------------------------------
 
 /// Seede le *staged Claude home* et renvoie sa racine (`<sandbox_root>/<run_id>`).
 ///
 /// **Deux phases** (#426, ADR-0031 §1) :
-/// 1. *matérialisation du profil* — ce que `full` apporte **en plus** ; `minimal`
-///    n'apporte rien en propre ;
-/// 2. *[`enforce_staging_floor`]* — mode-agnostique, tient les **cinq garanties**
+/// 1. *matérialisation du profil* — une passe sur la liste d'entrées **gelée** ;
+/// 2. *[`enforce_staging_floor`]* — profil-agnostique, tient les **cinq garanties**
 ///    (credentials, managed settings de l'org, bypass permissions, confiance sur
 ///    `trusted_root` + onboarding, `projects/` vide).
 ///
-/// La phase 2 tourne **après** le match, jamais dedans : le plancher est un
+/// La phase 2 tourne **après** la phase 1, jamais dedans : le plancher est un
 /// *check-then-repair* sur ce qui est effectivement posé sur disque (« satisfaite
 /// soit par une copie de l'hôte, soit par une synthèse de repli » n'est décidable
-/// qu'à ce moment-là). Le double write sur `settings.json` en `full` (copié par le
-/// profil, puis mergé par le plancher) est **voulu** : le plancher est merge-aware,
-/// il ne doit pas être mode-aware.
+/// qu'à ce moment-là). Le double write sur `settings.json` quand l'entrée est cochée
+/// (copiée par le profil, puis mergée par le plancher) est **voulu** : le plancher est
+/// merge-aware, il ne doit pas être profil-aware.
+///
+/// `entries` (#432) occupe le slot de l'ancien `mode` : c'est la liste **résolue et
+/// gelée** dans `RunStarted`, jamais le réglage vivant (ADR-0031 §6). `sandbox_staging::Mode`
+/// a disparu — la phase 2 est déjà agnostique depuis #426 et les défauts virtuels sont
+/// des listes nommées, `minimal` étant la vide. Garder un `Mode` à côté d'une liste
+/// recréerait exactement la mode-awareness que le plancher vient de supprimer.
 ///
 /// Idempotent (`create_dir_all` ; copy-or-overwrite ; merges non destructifs) et
 /// **additif** — jamais de suppression (ADR-0031 §6). `trusted_root` : racine à
@@ -141,7 +200,7 @@ pub(crate) fn staged_claude_json(sandbox_root: &Path, run_id: &str) -> PathBuf {
 pub(crate) fn prepare(
     home_root: &Path,
     sandbox_root: &Path,
-    mode: Mode,
+    entries: &[String],
     run_id: &str,
     trusted_root: Option<&Path>,
 ) -> Result<PathBuf> {
@@ -154,44 +213,155 @@ pub(crate) fn prepare(
     let staged_json = staged_claude_json(sandbox_root, run_id);
 
     // -- PHASE 1 : matérialisation du profil ---------------------------------
-    match mode {
-        Mode::Full => materialise_full(&src, home_root, &home, &staged_json)?,
-        // `minimal` EST le plancher : rien en propre, par construction.
-        Mode::Minimal => {}
-    }
+    materialise_entries(home_root, &src, &home, &staged_json, &staging, entries)?;
 
-    // -- PHASE 2 : plancher, mode-agnostique --------------------------------
+    // -- PHASE 2 : plancher, profil-agnostique ------------------------------
     enforce_staging_floor(&src, &home, &staged_json, trusted_root)?;
 
     Ok(staging)
 }
 
-/// Phase 1 du mode `full` : réplique de l'hôte (allowlist `~/.claude` +
-/// `~/.claude.json` verbatim). N'inclut **aucune** garantie du plancher — celui-ci
-/// tourne juste après, dans les deux modes.
-fn materialise_full(src: &Path, home_root: &Path, home: &Path, staged_json: &Path) -> Result<()> {
-    // Allowlist top-level : `*.md` (capte CLAUDE.md + imports siblings type
-    // RTK.md) + les fichiers de config nommés (0600 des creds préservé).
-    copy_top_level_md(src, home)?;
-    for name in FULL_ALLOWLIST_FILES {
-        copy_file_if_present(&src.join(name), &home.join(name))?;
-    }
-    // Allowlist dirs : walk préservant les symlinks intra-arbre + mode,
-    // déréférençant les liens échappants (#409). `projects/` EXCLU.
-    // `copy_root` = la racine canonique `~/.claude` : tout symlink dont la
-    // cible sort de cet arbre est copié déréférencé (sa cible réelle n'est
-    // ni copiée ni montée → danglerait). Best-effort par entrée.
-    let copy_root = std::fs::canonicalize(src).unwrap_or_else(|_| src.to_path_buf());
-    for name in FULL_ALLOWLIST_DIRS {
-        let dir_src = src.join(name);
-        if dir_src.is_dir() {
-            copy_tree_preserving(&dir_src, &home.join(name), &copy_root, 0);
+/// Phase 1 : une passe unique sur la liste gelée, chaque entrée routée par le
+/// classificateur **unique** [`crate::sandbox_profile::landing`] — le même que
+/// [`extra_mounts`] consulte, donc la vue *copie* et la vue *mount* ne peuvent pas
+/// diverger.
+///
+/// N'inclut **aucune** garantie du plancher : celui-ci tourne juste après, quelle que
+/// soit la liste. Une liste vide (`minimal`) est un no-op exact — la traduction
+/// littérale de l'ancien bras `Mode::Minimal => {}`.
+///
+/// Politique manquant-sur-l'hôte : `warn!` + skip, pour les entrées du **défaut**
+/// comme pour les **extras**. L'échec dur a été écarté (plan #432 D5) : il ferait
+/// dépendre la politique de *qui a tapé le chemin* plutôt que de ce dont le conteneur
+/// a besoin — sur une instance à Triggers horaires, désinstaller `gh` tuerait chaque
+/// tir jusqu'à édition d'un profil. Et la règle M1 d'[`extra_mounts`] supprime le
+/// danger réel (le répertoire root-owned), qui était la vraie justification du
+/// fail-fast.
+fn materialise_entries(
+    home_root: &Path,
+    src: &Path,
+    home: &Path,
+    staged_json: &Path,
+    staging: &Path,
+    entries: &[String],
+) -> Result<()> {
+    use crate::sandbox_profile::Landing;
+
+    // `copy_root` du bloc `.claude` : la racine canonique `~/.claude`. Tout symlink
+    // dont la cible sort de CET arbre est copié déréférencé (sa cible réelle n'est ni
+    // copiée ni montée → danglerait, #409). Résolue une fois, partagée par toutes les
+    // entrées `ClaudeHome` — c'est ce qui garde un lien `skills/x → ../agents/y` un
+    // lien.
+    let claude_copy_root = std::fs::canonicalize(src).unwrap_or_else(|_| src.to_path_buf());
+
+    for entry in entries {
+        match crate::sandbox_profile::landing(entry) {
+            // Glob à un niveau (seul `.claude/*.md` en livre un) : capte CLAUDE.md et
+            // ses imports siblings type RTK.md. Le motif est porté **tel quel** dans la
+            // liste gelée, jamais expansé à la résolution — pas d'IO au chokepoint de
+            // création, et la liste gelée reste byte-identique à ce que l'éditeur montre.
+            Landing::ClaudeHome { rel, glob: true } => {
+                copy_glob_one_level(src, home, rel)?;
+            }
+            Landing::ClaudeHome { rel, glob: false } => {
+                let from = src.join(rel);
+                let to = home.join(rel);
+                stage_path(&from, &to, &claude_copy_root, entry)?;
+            }
+            // `.claude.json` sibling, verbatim (mode préservé). La confiance et
+            // l'onboarding y sont mergés ensuite par le plancher (G4).
+            Landing::ClaudeJson => {
+                let from = home_root.join(".claude.json");
+                if !from.exists() {
+                    warn!(
+                        "sandbox staging: profile entry `{entry}` is absent on the host \
+                         ({}) — skipped",
+                        from.display()
+                    );
+                } else {
+                    copy_file_if_present(&from, staged_json)?;
+                }
+            }
+            // Exception `$HOME` : copiée sous `<staging>/home/<rel>`, jamais bind-montée
+            // depuis l'hôte (ADR-0031 §4). `copy_root` = la racine canonique de
+            // **cette** entrée, pas `~/.claude` — sinon tout symlink interne à
+            // `.config/gh` serait classé « échappant » et déréférencé.
+            Landing::HomeExtra { rel } => {
+                let from = home_root.join(rel);
+                let to = staging.join("home").join(rel);
+                let copy_root = std::fs::canonicalize(&from).unwrap_or_else(|_| from.clone());
+                stage_path(&from, &to, &copy_root, entry)?;
+            }
         }
     }
-    // `.claude.json` sibling, verbatim (mode préservé). Chemin explicite :
-    // c'est un dotfile, un glob `*` sans dotglob le raterait. La confiance et
-    // l'onboarding y sont mergés ensuite par le plancher (G4).
-    copy_file_if_present(&home_root.join(".claude.json"), staged_json)?;
+    Ok(())
+}
+
+/// Stage une entrée dont on ne sait pas a priori si c'est un fichier ou un dossier.
+/// Dossier → walk préservant symlinks + bits exécutables ([`copy_tree_preserving`],
+/// best-effort par entrée) ; fichier → [`std::fs::copy`] (mode préservé, dont 0600) ;
+/// absent → `warn!` + skip.
+fn stage_path(from: &Path, to: &Path, copy_root: &Path, entry: &str) -> Result<()> {
+    let Ok(md) = std::fs::symlink_metadata(from) else {
+        warn!(
+            "sandbox staging: profile entry `{entry}` is absent on the host ({}) — skipped",
+            from.display()
+        );
+        return Ok(());
+    };
+    // Un symlink top-level est suivi via `is_dir()`/`copy_file_if_present` : la cible
+    // est ce que l'utilisateur a désigné.
+    if md.file_type().is_symlink() || md.file_type().is_dir() {
+        if from.is_dir() {
+            copy_tree_preserving(from, to, copy_root, 0);
+            return Ok(());
+        }
+        if !from.exists() {
+            warn!(
+                "sandbox staging: profile entry `{entry}` is a broken symlink ({}) — skipped",
+                from.display()
+            );
+            return Ok(());
+        }
+    }
+    copy_file_if_present(from, to)
+}
+
+/// Copie les entrées top-level de `src_dir` dont le nom matche `pattern` (un `*`
+/// unique, ex. `*.md`) vers `dst_dir`. Glob **à un niveau**, sans dotglob implicite —
+/// c'est exactement la sémantique de l'ancien `copy_top_level_md`. Un motif sans `*`
+/// dégrade en égalité de nom. `src_dir` absent = no-op.
+fn copy_glob_one_level(src_dir: &Path, dst_dir: &Path, pattern: &str) -> Result<()> {
+    // Le motif ne porte qu'un segment (les entrées multi-segment à glob n'existent
+    // pas dans le défaut) ; un motif imbriqué serait ignoré plutôt que mal interprété.
+    if pattern.contains('/') {
+        warn!("sandbox staging: nested glob entry `{pattern}` is not supported — skipped");
+        return Ok(());
+    }
+    let (prefix, suffix) = match pattern.split_once('*') {
+        Some((p, s)) => (p, s),
+        None => (pattern, ""),
+    };
+    let Ok(entries) = std::fs::read_dir(src_dir) else {
+        return Ok(());
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if name.len() < prefix.len() + suffix.len()
+            || !name.starts_with(prefix)
+            || !name.ends_with(suffix)
+        {
+            continue;
+        }
+        let from = entry.path();
+        if from.is_file() {
+            let to = dst_dir.join(entry.file_name());
+            std::fs::copy(&from, &to).with_context(|| {
+                format!("copy glob match {} -> {}", from.display(), to.display())
+            })?;
+        }
+    }
     Ok(())
 }
 
@@ -329,28 +499,6 @@ pub(crate) fn default_roots_from_env() -> Option<(PathBuf, PathBuf)> {
 }
 
 // -- helpers (privés) --------------------------------------------------------
-
-/// Copie les `*.md` top-level de `src_dir` vers `dst_dir` (glob à un niveau).
-/// Tolérant : `src_dir` absent = no-op. Capte `CLAUDE.md` et ses imports siblings
-/// (`RTK.md`, …). Le mode est préservé par [`std::fs::copy`].
-fn copy_top_level_md(src_dir: &Path, dst_dir: &Path) -> Result<()> {
-    let Ok(entries) = std::fs::read_dir(src_dir) else {
-        return Ok(());
-    };
-    for entry in entries.flatten() {
-        let name = entry.file_name();
-        if !name.to_string_lossy().ends_with(".md") {
-            continue;
-        }
-        let from = entry.path();
-        if from.is_file() {
-            let to = dst_dir.join(&name);
-            std::fs::copy(&from, &to)
-                .with_context(|| format!("copy md {} -> {}", from.display(), to.display()))?;
-        }
-    }
-    Ok(())
-}
 
 /// Copie `src` → `dst` s'il existe (fichier de l'allowlist absent = no-op).
 /// [`std::fs::copy`] préserve le mode sous Unix (dont 0600 des credentials), même
@@ -697,6 +845,14 @@ mod tests {
     /// Construit un faux `~/.claude` réaliste sous `<home>/.claude` + le sibling
     /// `<home>/.claude.json`, couvrant l'allowlist, un symlink, un exécutable,
     /// des creds 0600, ET de l'état hôte volumineux qui doit rester EXCLU.
+    /// La liste résolue du défaut `full` — le remplaçant mécanique de l'ancien
+    /// `Mode::Full` dans ces tests. Passe par le vrai résolveur (et non par une copie
+    /// de la constante) pour qu'un changement du défaut casse ces tests, pas les mente.
+    fn full_entries() -> Vec<String> {
+        let base = crate::sandbox_profile::base_entries(crate::sandbox_profile::FULL_PROFILE);
+        crate::sandbox_profile::resolve_entry_list(&base, &[], &[]).entries
+    }
+
     fn fabricate_home(home: &Path) {
         let claude = home.join(".claude");
         // Allowlist dirs.
@@ -748,7 +904,22 @@ mod tests {
             &home.join(".claude.json"),
             r#"{"host":"profile","oauthAccount":{"x":1}}"#,
         );
+        // #432 : fichiers hôte HORS `~/.claude` qu'un profil peut déclarer en extra —
+        // `.gitconfig` (fichier) et `.config/gh` (répertoire multi-segment). Présents même
+        // quand le défaut `full` ne les porte pas : c'est ce qui rend testable
+        // « le défaut ne stage rien hors `.claude` ». Miroir des fixtures couche 3
+        // (`sandbox_tracer::fabricate_host_claude`, `sandbox_profiles::fabricate_host_home`) :
+        // les trois doivent dériver ensemble.
+        write(&home.join(".gitconfig"), HOST_GITCONFIG);
+        write(
+            &home.join(".config/gh/hosts.yml"),
+            "github.com:\n  user: me\n",
+        );
     }
+
+    /// Contenu du `~/.gitconfig` fabriqué (comparé octet pour octet par les tests
+    /// « l'hôte n'est jamais muté »).
+    const HOST_GITCONFIG: &str = "[user]\n\tname = Host User\n\temail = host@example.com\n";
 
     // -- path math -----------------------------------------------------------
 
@@ -780,7 +951,7 @@ mod tests {
         let staging = prepare(
             home_dir.path(),
             sandbox_dir.path(),
-            Mode::Full,
+            &full_entries(),
             "run1",
             None,
         )
@@ -847,7 +1018,7 @@ mod tests {
         prepare(
             home_dir.path(),
             sandbox_dir.path(),
-            Mode::Full,
+            &full_entries(),
             "run1",
             None,
         )
@@ -883,7 +1054,7 @@ mod tests {
         prepare(
             home_dir.path(),
             sandbox_dir.path(),
-            Mode::Full,
+            &full_entries(),
             "run1",
             None,
         )
@@ -919,7 +1090,7 @@ mod tests {
         prepare(
             home_dir.path(),
             sandbox_dir.path(),
-            Mode::Full,
+            &full_entries(),
             "run1",
             None,
         )
@@ -973,7 +1144,7 @@ mod tests {
         prepare(
             home_dir.path(),
             sandbox_dir.path(),
-            Mode::Full,
+            &full_entries(),
             "run1",
             None,
         )
@@ -998,7 +1169,7 @@ mod tests {
         prepare(
             home_dir.path(),
             sandbox_dir.path(),
-            Mode::Full,
+            &full_entries(),
             "run1",
             Some(trusted),
         )
@@ -1032,14 +1203,7 @@ mod tests {
         let sandbox_dir = tempfile::tempdir().unwrap();
         fabricate_home(home_dir.path()); // skills/settings existent → prouvent l'exclusion
 
-        prepare(
-            home_dir.path(),
-            sandbox_dir.path(),
-            Mode::Minimal,
-            "run1",
-            None,
-        )
-        .unwrap();
+        prepare(home_dir.path(), sandbox_dir.path(), &[], "run1", None).unwrap();
         let home = staged_claude_home(sandbox_dir.path(), "run1");
 
         // Ensemble EXACT (trié ASCII) = les fichiers du plancher, rien d'autre.
@@ -1089,7 +1253,7 @@ mod tests {
         prepare(
             home_dir.path(),
             sandbox_dir.path(),
-            Mode::Minimal,
+            &[],
             "run1",
             Some(trusted),
         )
@@ -1113,14 +1277,7 @@ mod tests {
         let home_dir = tempfile::tempdir().unwrap();
         let sandbox_dir = tempfile::tempdir().unwrap();
 
-        prepare(
-            home_dir.path(),
-            sandbox_dir.path(),
-            Mode::Minimal,
-            "run1",
-            None,
-        )
-        .unwrap();
+        prepare(home_dir.path(), sandbox_dir.path(), &[], "run1", None).unwrap();
 
         let json: serde_json::Value = serde_json::from_str(
             &std::fs::read_to_string(staged_claude_json(sandbox_dir.path(), "run1")).unwrap(),
@@ -1147,7 +1304,7 @@ mod tests {
         prepare(
             home_dir.path(),
             sandbox_dir.path(),
-            Mode::Full,
+            &full_entries(),
             "run1",
             None,
         )
@@ -1165,14 +1322,7 @@ mod tests {
         let sandbox_dir = tempfile::tempdir().unwrap();
         fabricate_home(home_dir.path());
 
-        prepare(
-            home_dir.path(),
-            sandbox_dir.path(),
-            Mode::Minimal,
-            "run1",
-            None,
-        )
-        .unwrap();
+        prepare(home_dir.path(), sandbox_dir.path(), &[], "run1", None).unwrap();
 
         let home = staged_claude_home(sandbox_dir.path(), "run1");
         assert_eq!(
@@ -1193,7 +1343,7 @@ mod tests {
         prepare(
             home_dir.path(),
             sandbox_dir.path(),
-            Mode::Full,
+            &full_entries(),
             "run1",
             None,
         )
@@ -1212,14 +1362,7 @@ mod tests {
         let sandbox_dir = tempfile::tempdir().unwrap();
         fabricate_home_without_org(home_dir.path());
 
-        prepare(
-            home_dir.path(),
-            sandbox_dir.path(),
-            Mode::Minimal,
-            "run1",
-            None,
-        )
-        .unwrap();
+        prepare(home_dir.path(), sandbox_dir.path(), &[], "run1", None).unwrap();
 
         let home = staged_claude_home(sandbox_dir.path(), "run1");
         assert!(!home.join(REMOTE_SETTINGS_FILE).exists());
@@ -1245,7 +1388,7 @@ mod tests {
         prepare(
             home_dir.path(),
             sandbox_dir.path(),
-            Mode::Full,
+            &full_entries(),
             "run1",
             None,
         )
@@ -1274,7 +1417,7 @@ mod tests {
         prepare(
             home_dir.path(),
             sandbox_dir.path(),
-            Mode::Full,
+            &full_entries(),
             "run1",
             None,
         )
@@ -1298,7 +1441,7 @@ mod tests {
         prepare(
             home_dir.path(),
             sandbox_dir.path(),
-            Mode::Full,
+            &full_entries(),
             "run1",
             None,
         )
@@ -1320,7 +1463,7 @@ mod tests {
         prepare(
             home_dir.path(),
             sandbox_dir.path(),
-            Mode::Full,
+            &full_entries(),
             "run1",
             None,
         )
@@ -1338,14 +1481,7 @@ mod tests {
         let sandbox_dir = tempfile::tempdir().unwrap();
         fabricate_home(home_dir.path()); // settings hôte riches (hooks)
 
-        prepare(
-            home_dir.path(),
-            sandbox_dir.path(),
-            Mode::Minimal,
-            "run1",
-            None,
-        )
-        .unwrap();
+        prepare(home_dir.path(), sandbox_dir.path(), &[], "run1", None).unwrap();
 
         // La phrase d'ADR-0031 §1 sous forme de test : la même garantie, satisfaite
         // par une synthèse ici et par un merge en `full`.
@@ -1370,7 +1506,7 @@ mod tests {
         prepare(
             home_dir.path(),
             sandbox_dir.path(),
-            Mode::Full,
+            &full_entries(),
             "run1",
             None,
         )
@@ -1395,7 +1531,7 @@ mod tests {
         prepare(
             home_dir.path(),
             sandbox_dir.path(),
-            Mode::Full,
+            &full_entries(),
             "run1",
             None,
         )
@@ -1414,7 +1550,21 @@ mod tests {
     /// (même corps, plus « … même avec l'entrée décochée »).
     #[test]
     fn prepare_floor_holds_in_both_modes() {
-        for mode in [Mode::Full, Mode::Minimal] {
+        // #432: "both modes" is now "the two virtual defaults' resolved lists", plus a
+        // THIRD case that only profiles make reachable — `full` with the class-(b) entry
+        // `.claude/settings.json` UNCHECKED. That case is the whole reason ADR-0031 §1
+        // states the floor as guarantees rather than files: G3 must still hold, by
+        // synthesis, on a profile that explicitly refused the host file.
+        let full_no_settings: Vec<String> = full_entries()
+            .into_iter()
+            .filter(|e| e != ".claude/settings.json")
+            .collect();
+        for (mode, entries) in [
+            ("full", full_entries()),
+            ("minimal", Vec::new()),
+            ("full-without-settings", full_no_settings),
+        ] {
+            let entries: &[String] = &entries;
             let home_dir = tempfile::tempdir().unwrap();
             let sandbox_dir = tempfile::tempdir().unwrap();
             fabricate_home(home_dir.path());
@@ -1423,7 +1573,7 @@ mod tests {
             prepare(
                 home_dir.path(),
                 sandbox_dir.path(),
-                mode,
+                entries,
                 "run1",
                 Some(trusted),
             )
@@ -1482,11 +1632,11 @@ mod tests {
         let trusted = Path::new("/repo/root");
         let (home_p, sandbox_p) = (home_dir.path(), sandbox_dir.path());
 
-        prepare(home_p, sandbox_p, Mode::Full, "run1", Some(trusted)).unwrap();
+        prepare(home_p, sandbox_p, &full_entries(), "run1", Some(trusted)).unwrap();
         // Le conteneur (simulé) a écrit un transcript dans le puits.
         stage_transcript(sandbox_p, "run1", &format!("{ENC}/s.jsonl"), "line\n");
 
-        prepare(home_p, sandbox_p, Mode::Full, "run1", Some(trusted)).unwrap();
+        prepare(home_p, sandbox_p, &full_entries(), "run1", Some(trusted)).unwrap();
 
         let home = staged_claude_home(sandbox_p, "run1");
         let settings = read_json(&home.join(SETTINGS_FILE));
@@ -1517,6 +1667,239 @@ mod tests {
     }
 
     // -- merge_back ----------------------------------------------------------
+
+    // -- #432 : entrées d'exception `$HOME` (copie + queue de mounts) ---------
+
+    /// ADR-0031 §4, la moitié *copie* : une entrée hors `.claude` atterrit sous
+    /// `<staging>/home/<rel>`, jamais ailleurs — et surtout jamais dans `claude-home/`,
+    /// où elle finirait à `$HOME/.claude/<rel>` côté conteneur.
+    #[test]
+    fn prepare_copies_a_home_extra_under_staging_home() {
+        let home_dir = tempfile::tempdir().unwrap();
+        let sandbox_dir = tempfile::tempdir().unwrap();
+        fabricate_home(home_dir.path());
+
+        let entries = vec![".gitconfig".to_string(), ".config/gh".to_string()];
+        prepare(home_dir.path(), sandbox_dir.path(), &entries, "run1", None).unwrap();
+
+        let extras = staged_home_extras(sandbox_dir.path(), "run1");
+        assert_eq!(
+            std::fs::read_to_string(extras.join(".gitconfig")).unwrap(),
+            HOST_GITCONFIG,
+            "un fichier extra est copié verbatim"
+        );
+        assert!(
+            extras.join(".config/gh/hosts.yml").is_file(),
+            "un répertoire extra multi-segment est copié en profondeur"
+        );
+        // Rien n'a fui dans le home stagé (le mount `.claude` ne doit PAS les porter).
+        let claude_home = staged_claude_home(sandbox_dir.path(), "run1");
+        assert!(!claude_home.join(".gitconfig").exists());
+        assert!(!claude_home.join(".config").exists());
+        // Et l'hôte n'a pas été touché.
+        assert_eq!(
+            std::fs::read_to_string(home_dir.path().join(".gitconfig")).unwrap(),
+            HOST_GITCONFIG
+        );
+    }
+
+    /// La copie d'une entrée extra utilise `copy_root = canonicalize(l'entrée)`, pas
+    /// `~/.claude`. Avec `~/.claude` comme `copy_root`, tout symlink INTERNE à l'entrée
+    /// serait classé « échappant » et déréférencé — piège explicite du plan #432 D5.
+    #[test]
+    fn a_home_extras_internal_symlink_stays_a_symlink() {
+        let home_dir = tempfile::tempdir().unwrap();
+        let sandbox_dir = tempfile::tempdir().unwrap();
+        fabricate_home(home_dir.path());
+        let gh = home_dir.path().join(".config/gh");
+        std::os::unix::fs::symlink("hosts.yml", gh.join("alias.yml")).unwrap();
+
+        prepare(
+            home_dir.path(),
+            sandbox_dir.path(),
+            &[".config/gh".to_string()],
+            "run1",
+            None,
+        )
+        .unwrap();
+
+        let staged = staged_home_extras(sandbox_dir.path(), "run1").join(".config/gh/alias.yml");
+        assert!(
+            std::fs::symlink_metadata(&staged)
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+            "un lien intra-entrée doit rester un lien, pas être déréférencé"
+        );
+    }
+
+    /// Manquant sur l'hôte = `warn!` + skip, pour un extra COMME pour une entrée du
+    /// défaut. L'échec dur est écarté (plan D5) : il ferait dépendre la politique de qui a
+    /// tapé le chemin, et sur une instance à Triggers horaires désinstaller `gh` tuerait
+    /// chaque tir. La règle M1 ci-dessous supprime le danger réel.
+    #[test]
+    fn prepare_skips_a_home_extra_absent_on_the_host() {
+        let home_dir = tempfile::tempdir().unwrap();
+        let sandbox_dir = tempfile::tempdir().unwrap();
+        fabricate_home(home_dir.path());
+
+        prepare(
+            home_dir.path(),
+            sandbox_dir.path(),
+            &[".not-here".to_string(), ".gitconfig".to_string()],
+            "run1",
+            None,
+        )
+        .expect("une entrée absente ne fait pas échouer le prep");
+
+        let extras = staged_home_extras(sandbox_dir.path(), "run1");
+        assert!(!extras.join(".not-here").exists());
+        assert!(
+            extras.join(".gitconfig").is_file(),
+            "les autres passent quand même"
+        );
+    }
+
+    /// ADR-0031 §4, la moitié *mount* — et la dédup, qui n'est PAS un cas spécial : les
+    /// entrées sous `.claude/` et `.claude.json` sont déjà servies par les mounts fixes,
+    /// donc `landing()` les exclut par construction.
+    #[test]
+    fn extra_mounts_only_covers_home_exceptions() {
+        let sandbox_dir = tempfile::tempdir().unwrap();
+        let host_home = Path::new("/home/u");
+        let extras_root = staged_home_extras(sandbox_dir.path(), "run1");
+        std::fs::create_dir_all(extras_root.join(".config/gh")).unwrap();
+        std::fs::write(extras_root.join(".gitconfig"), "x").unwrap();
+
+        let entries: Vec<String> = [
+            ".claude.json",
+            ".claude/skills",
+            ".claude/*.md",
+            ".gitconfig",
+            ".config/gh",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+
+        let mounts = extra_mounts(sandbox_dir.path(), "run1", host_home, &entries);
+        assert_eq!(
+            mounts,
+            vec![
+                StagedMount {
+                    source: extras_root.join(".config/gh"),
+                    target: host_home.join(".config/gh"),
+                },
+                StagedMount {
+                    source: extras_root.join(".gitconfig"),
+                    target: host_home.join(".gitconfig"),
+                },
+            ],
+            "seules les exceptions `$HOME`, triées par chemin relatif"
+        );
+    }
+
+    /// **Règle M1**, non négociable (sondée en Docker réel 29.2.1) : un `-v` dont la
+    /// source hôte n'existe pas fait créer par Docker un répertoire `root:root 0755`.
+    /// Trois dégâts en escalade — un mount de *fichier* manquant devient un *répertoire*
+    /// par-dessus `$HOME/.gitconfig` (git plante en lecture) ; un mount de *répertoire*
+    /// devient inscriptible par personne (uid 1000 dedans) ; et pour un chemin
+    /// multi-segment (`.config/gh`) Docker crée `<staging>/home/.config` en root aussi,
+    /// ce qui fait échouer le `remove_dir_all` de `teardown` en EACCES — erreur avalée par
+    /// son `let _ =` — laissant un staging de ~1 Go définitivement indélébile par le
+    /// daemon. Ça alimente la récurrence disque connue, silencieusement.
+    #[test]
+    fn extra_mounts_never_mounts_a_source_that_does_not_exist() {
+        let sandbox_dir = tempfile::tempdir().unwrap();
+        // Rien n'a été stagé (l'entrée était absente de l'hôte) → aucun mount.
+        let mounts = extra_mounts(
+            sandbox_dir.path(),
+            "run1",
+            Path::new("/home/u"),
+            &[".gitconfig".to_string()],
+        );
+        assert!(mounts.is_empty(), "M1 : pas de source, pas de `-v`");
+    }
+
+    /// `extra_mounts` dérive de `liste gelée × disque`, PAS d'une valeur de retour de
+    /// `prepare` — `ensure_ready` saute `prepare` quand le staging existe déjà (3 de ses
+    /// 4 appelants). La dérivation doit donc être **totale** : même réponse que `prepare`
+    /// ait tourné ou non.
+    #[test]
+    fn extra_mounts_is_total_whether_prepare_ran_or_not() {
+        let home_dir = tempfile::tempdir().unwrap();
+        let sandbox_dir = tempfile::tempdir().unwrap();
+        fabricate_home(home_dir.path());
+        let host_home = Path::new("/home/u");
+        let entries = vec![".gitconfig".to_string()];
+
+        // Avant `prepare` : rien sur disque → aucun mount (M1).
+        assert!(extra_mounts(sandbox_dir.path(), "run1", host_home, &entries).is_empty());
+
+        prepare(home_dir.path(), sandbox_dir.path(), &entries, "run1", None).unwrap();
+
+        // Après : la même liste gelée donne le mount, sans que `prepare` l'ait renvoyé.
+        let after = extra_mounts(sandbox_dir.path(), "run1", host_home, &entries);
+        assert_eq!(after.len(), 1);
+        assert_eq!(after[0].target, host_home.join(".gitconfig"));
+        // Idempotent : un second appel (le cas « staging déjà présent ») est identique.
+        assert_eq!(
+            extra_mounts(sandbox_dir.path(), "run1", host_home, &entries),
+            after
+        );
+    }
+
+    /// Le glob du défaut reste un glob à UN niveau : il capte les `*.md` top-level de
+    /// `~/.claude` et rien de plus profond.
+    #[test]
+    fn the_md_glob_matches_one_level_only() {
+        let home_dir = tempfile::tempdir().unwrap();
+        let sandbox_dir = tempfile::tempdir().unwrap();
+        fabricate_home(home_dir.path());
+        write(
+            &home_dir.path().join(".claude/deep/nested.md"),
+            "# nested\n",
+        );
+
+        prepare(
+            home_dir.path(),
+            sandbox_dir.path(),
+            &[".claude/*.md".to_string()],
+            "run1",
+            None,
+        )
+        .unwrap();
+
+        let home = staged_claude_home(sandbox_dir.path(), "run1");
+        assert!(home.join("CLAUDE.md").is_file());
+        assert!(home.join("RTK.md").is_file());
+        assert!(!home.join("deep").exists(), "un niveau, pas de récursion");
+        // Et rien d'autre du défaut n'a été stagé : la liste ne portait qu'une entrée.
+        assert!(!home.join("skills").exists());
+    }
+
+    /// Une liste VIDE est le no-op exact de l'ancien bras `Mode::Minimal => {}` : rien en
+    /// propre, tout le plancher.
+    #[test]
+    fn an_empty_entry_list_stages_the_floor_and_nothing_else() {
+        let home_dir = tempfile::tempdir().unwrap();
+        let sandbox_dir = tempfile::tempdir().unwrap();
+        fabricate_home(home_dir.path());
+
+        prepare(home_dir.path(), sandbox_dir.path(), &[], "run1", None).unwrap();
+
+        let home = staged_claude_home(sandbox_dir.path(), "run1");
+        assert!(!home.join("skills").exists());
+        assert!(!home.join("CLAUDE.md").exists());
+        assert!(!staged_home_extras(sandbox_dir.path(), "run1").exists());
+        // Plancher intact.
+        assert!(home.join(".credentials.json").is_file());
+        assert!(home.join("projects").is_dir());
+        assert_eq!(
+            read_json(&home.join(SETTINGS_FILE))[BYPASS_PERMISSIONS_KEY],
+            serde_json::json!(true)
+        );
+    }
 
     /// Écrit un transcript de staging (projects/<ENC>/...).
     fn stage_transcript(sandbox: &Path, run_id: &str, rel: &str, content: &str) {
@@ -1738,7 +2121,7 @@ mod tests {
         let sandbox_dir = tempfile::tempdir().unwrap();
         let (home, sandbox) = (home_dir.path(), sandbox_dir.path());
 
-        prepare(home, sandbox, Mode::Minimal, "run1", None).unwrap();
+        prepare(home, sandbox, &[], "run1", None).unwrap();
         // Le conteneur (simulé) écrit un transcript dans le puits projects/.
         stage_transcript(sandbox, "run1", &format!("{ENC}/sess.jsonl"), "hello\n");
 

--- a/crates/pdo-daemon/src/stats.rs
+++ b/crates/pdo-daemon/src/stats.rs
@@ -413,15 +413,23 @@ pub async fn stats_cost(
         let project = repo_root.to_string_lossy().into_owned();
 
         // #408: read the transcripts from the sandboxed Run's staged home while it
-        // is live (else `~/.claude/projects/`). Parse `sandbox` straight off the
+        // is live (else `~/.claude/projects/`). Read `sandbox` straight off the
         // `run_started` payload (like `target_repo`/`pipeline_id`) — no full
         // RunState projection, so the SQL stays cheap (no fan-out regression).
-        let sandbox = payload
+        //
+        // #432: this stops being a *decoder*. It used to `from_value::<SandboxMode>`,
+        // which silently swallowed any token the closed enum did not know; all this
+        // fold ever needed is the off-ness, and asking the profile store whether the
+        // name resolves would be an N+1 inside a per-row loop of a SQL fan-out.
+        let sandboxed = payload
             .get("sandbox")
-            .and_then(|v| serde_json::from_value::<crate::event_log::SandboxMode>(v.clone()).ok())
-            .unwrap_or_default();
+            .and_then(|v| v.as_str())
+            .is_some_and(|s| {
+                let t = s.trim();
+                !t.is_empty() && !t.eq_ignore_ascii_case(crate::event_log::SandboxMode::OFF_WIRE)
+            });
         let projects_root =
-            crate::sandbox_run::transcripts_root(sandbox, &run_id, &home_root, &sandbox_root);
+            crate::sandbox_run::transcripts_root(sandboxed, &run_id, &home_root, &sandbox_root);
 
         let cost = crate::run_cost::compute_run_cost_cached(&projects_root, &repo_root, &run_id);
         cost_rows.push(CostRow {

--- a/crates/pdo-daemon/tests/sandbox_profiles.rs
+++ b/crates/pdo-daemon/tests/sandbox_profiles.rs
@@ -1,0 +1,1366 @@
+//! Layer 3a — staging profiles (#432, slice K of PRD #403; ADR-0031 §2-§7).
+//!
+//! Same harness as `sandbox_tracer`: a **real daemon**, a **fake `docker`** (via
+//! `docker_cmd_override`) and a tempdir-scoped sandbox home (via
+//! `sandbox_home_override`, which moves the `.claude` SOURCE, the staging ROOT *and* the
+//! container's `HOME` in one go). No test needs Docker, touches the real `$HOME`, or
+//! launches real claude.
+//!
+//! What is pinned here, one acceptance criterion per test:
+//!  1. a profile with `.claude/plugins` unchecked, assigned to a **Trigger**, stages
+//!     without `plugins/` (AC1);
+//!  2. `.gitconfig` as an extra is **copied** into `<staging>/home/` and bind-mounted at
+//!     `$HOME/.gitconfig` (AC2), and the host file is never a mount SOURCE (AC3);
+//!  3. an entry under `.claude/` produces **no** extra `-v` (AC4);
+//!  4. an absolute / `..` / floor-owned / glob entry is a **400 at write** (AC5);
+//!  5. editing a profile after a Run started does not change its staging, and a boot
+//!     recovery replays the **frozen** list identically (AC6);
+//!  6. an unknown profile fails hard at create, at a Trigger fire, and at boot recovery —
+//!     never silently `off` or on another profile (AC7);
+//!  7. unedited `full`/`minimal` have **no row**; editing materialises a **diff**, so a
+//!     default enriched by a later version stays visible (AC8);
+//!  8. unchecking `.claude/settings.json` still starts (the floor re-synthesises it, AC9);
+//!  9. deleting a referenced profile can list its referents first (AC10).
+
+mod common;
+
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::Once;
+use std::time::{Duration, Instant};
+
+use common::TestDaemon;
+use tempfile::TempDir;
+
+const NODE_ID: &str = "notify";
+
+/// `start → notify(script, output `out`) → end` — same shape as the tracer's, so
+/// completing `notify` drives the whole run terminal.
+const PIPELINE_YAML: &str = r#"name: sbx-cycle
+version: "1.0"
+nodes:
+  - id: start
+    name: Start
+    type: start
+    outputs:
+      - name: user_prompt
+  - id: notify
+    name: notify
+    type: script
+    outputs:
+      - name: out
+  - id: end
+    name: End
+    type: end
+    inputs:
+      - name: result
+edges:
+  - source: { node: start, port: user_prompt }
+    target: { node: notify, port: in }
+  - source: { node: notify, port: out }
+    target: { node: end, port: result }
+"#;
+
+fn ensure_pdo_on_path() {
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        let bin = Path::new(env!("CARGO_BIN_EXE_pdo"));
+        let dir = bin.parent().expect("pdo binary has a parent dir");
+        let existing = std::env::var("PATH").unwrap_or_default();
+        std::env::set_var("PATH", format!("{}:{}", dir.display(), existing));
+    });
+}
+
+fn git_init_with_commit(repo: &Path) -> anyhow::Result<()> {
+    let run = |args: &[&str]| -> anyhow::Result<()> {
+        let out = Command::new("git").args(args).current_dir(repo).output()?;
+        if !out.status.success() {
+            anyhow::bail!(
+                "git {args:?} failed: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+        }
+        Ok(())
+    };
+    run(&["init", "-q", "-b", "main"])?;
+    run(&["config", "user.email", "test@example.com"])?;
+    run(&["config", "user.name", "Test"])?;
+    run(&["config", "commit.gpgsign", "false"])?;
+    std::fs::write(repo.join(".gitignore"), ".pdo/runs/\n")?;
+    run(&["add", "."])?;
+    run(&["commit", "-q", "-m", "init"])?;
+    Ok(())
+}
+
+fn seed() -> impl FnOnce(&Path) -> anyhow::Result<()> {
+    move |repo: &Path| {
+        let pipelines_dir = repo.join(".pdo").join("pipelines");
+        std::fs::create_dir_all(&pipelines_dir)?;
+        std::fs::write(pipelines_dir.join("sbx-cycle.yaml"), PIPELINE_YAML)?;
+        let prompts_dir = pipelines_dir.join("sbx-cycle.prompts");
+        std::fs::create_dir_all(&prompts_dir)?;
+        std::fs::write(
+            prompts_dir.join(format!("{NODE_ID}.md")),
+            "#!/usr/bin/env bash\ntrue\n",
+        )?;
+        git_init_with_commit(repo)?;
+        Ok(())
+    }
+}
+
+/// Fake `docker`: logs argv, `image inspect` → present, `container inspect` → ABSENT
+/// (so `ensure_running` does `create` + `start`, which is what makes the mount queue
+/// observable), everything else exit 0.
+fn write_fake_docker() -> (TempDir, String, PathBuf) {
+    let dir = tempfile::tempdir().unwrap();
+    let bin = dir.path().join("fake-docker");
+    let log = dir.path().join("argv.log");
+    let sq = |s: &str| format!("'{}'", s.replace('\'', "'\\''"));
+    let script = format!(
+        "#!/usr/bin/env bash\n\
+         printf '%s\\n' \"$@\" >> {log}\n\
+         case \"$1\" in\n\
+         image) exit 0 ;;\n\
+         container) printf '%s' 'Error: No such container' >&2; exit 1 ;;\n\
+         *) exit 0 ;;\n\
+         esac\n",
+        log = sq(&log.display().to_string()),
+    );
+    std::fs::write(&bin, script).unwrap();
+    std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
+    (dir, bin.to_str().unwrap().to_string(), log)
+}
+
+fn log_text(log: &Path) -> String {
+    std::fs::read_to_string(log).unwrap_or_default()
+}
+
+/// Every `-v` mount spec (the arg following each `-v`) in the fake-docker argv log.
+fn mount_specs(log: &Path) -> Vec<String> {
+    let lines: Vec<String> = log_text(log).lines().map(str::to_string).collect();
+    let mut specs = Vec::new();
+    let mut iter = lines.iter();
+    while let Some(line) = iter.next() {
+        if line == "-v" {
+            if let Some(spec) = iter.next() {
+                specs.push(spec.clone());
+            }
+        }
+    }
+    specs
+}
+
+/// A realistic host `$HOME`: a `~/.claude` with the allowlist content, plus the two
+/// **`$HOME` exception** fixtures this slice exists for — `~/.gitconfig` (the identity a
+/// committing agent needs) and `~/.config/gh` (a multi-segment DIRECTORY entry, which is
+/// the case that proves the `.config` parent is not created root-owned).
+fn fabricate_host_home(home: &Path) {
+    let claude = home.join(".claude");
+    let write = |p: PathBuf, c: &str| {
+        std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+        std::fs::write(&p, c).unwrap();
+    };
+    write(claude.join("skills/foo/skill.md"), "# skill\n");
+    write(claude.join("plugins/bar/plugin.json"), "{}\n");
+    write(
+        claude.join("plugins/bar/node_modules/big/index.js"),
+        "// bulk\n",
+    );
+    write(claude.join("agents/a.md"), "agent\n");
+    write(claude.join("commands/c.md"), "cmd\n");
+    write(claude.join("output-styles/s.md"), "style\n");
+    write(claude.join("settings.json"), r#"{"hooks":{"Stop":[]}}"#);
+    write(claude.join("settings.local.json"), r#"{"local":true}"#);
+    write(claude.join("CLAUDE.md"), "# global\n");
+    std::fs::create_dir_all(claude.join(".credentials.json").parent().unwrap()).unwrap();
+    std::fs::write(claude.join(".credentials.json"), r#"{"token":"secret"}"#).unwrap();
+    std::fs::set_permissions(
+        claude.join(".credentials.json"),
+        std::fs::Permissions::from_mode(0o600),
+    )
+    .unwrap();
+    write(
+        home.join(".claude.json"),
+        r#"{"host":"profile","oauthAccount":{"x":1}}"#,
+    );
+    // -- the `$HOME` exception fixtures (#432) --
+    write(home.join(".gitconfig"), HOST_GITCONFIG);
+    write(
+        home.join(".config/gh/hosts.yml"),
+        "github.com:\n  user: me\n",
+    );
+}
+
+const HOST_GITCONFIG: &str = "[user]\n\tname = Host User\n\temail = host@example.com\n";
+
+fn staging_root(daemon: &TestDaemon, run_id: &str) -> PathBuf {
+    daemon.repo_root().join(".pdo/sandbox").join(run_id)
+}
+
+fn staged_home(daemon: &TestDaemon, run_id: &str) -> PathBuf {
+    staging_root(daemon, run_id).join("claude-home")
+}
+
+/// `<staging>/home` — the `$HOME`-exception copies.
+fn staged_extras(daemon: &TestDaemon, run_id: &str) -> PathBuf {
+    staging_root(daemon, run_id).join("home")
+}
+
+async fn wait_until<F>(mut pred: F) -> bool
+where
+    F: FnMut() -> bool,
+{
+    let deadline = Instant::now() + Duration::from_secs(30);
+    while Instant::now() < deadline {
+        if pred() {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    pred()
+}
+
+async fn get_run(daemon: &TestDaemon, run_id: &str) -> serde_json::Value {
+    reqwest::get(format!("{}/runs/{run_id}", daemon.url()))
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap()
+}
+
+async fn wait_node_status(daemon: &TestDaemon, run_id: &str, expected: &str) -> serde_json::Value {
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let mut last = serde_json::Value::Null;
+    while Instant::now() < deadline {
+        let run = get_run(daemon, run_id).await;
+        if run["nodes"][NODE_ID]["status"] == expected {
+            return run;
+        }
+        last = run;
+        tokio::time::sleep(Duration::from_millis(150)).await;
+    }
+    last
+}
+
+async fn wait_run_status(daemon: &TestDaemon, run_id: &str, expected: &str) -> serde_json::Value {
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let mut last = serde_json::Value::Null;
+    while Instant::now() < deadline {
+        let run = get_run(daemon, run_id).await;
+        if run["status"] == expected {
+            return run;
+        }
+        last = run;
+        tokio::time::sleep(Duration::from_millis(150)).await;
+    }
+    last
+}
+
+/// #431 trap, worth restating: a Run's failure `reason` lives on `GET /runs/<id>/events`,
+/// NOT on `GET /runs/<id>`.
+async fn run_events(daemon: &TestDaemon, run_id: &str) -> Vec<serde_json::Value> {
+    reqwest::get(format!("{}/runs/{run_id}/events", daemon.url()))
+        .await
+        .unwrap()
+        .json::<Vec<serde_json::Value>>()
+        .await
+        .unwrap()
+}
+
+/// Whether any `run_failed` event blames the **sandbox prep**.
+///
+/// Deliberately narrower than "the Run failed": this harness pins the tmux tail to
+/// `exec true`, so the node's session collapses instantly and a boot-recovery tick
+/// legitimately marks the orphaned node Failed. That is the ORPHAN arm doing its job and
+/// has nothing to do with the staging — the question these tests ask is whether the
+/// *sandbox* arm fired.
+async fn sandbox_prep_failure(daemon: &TestDaemon, run_id: &str) -> Option<String> {
+    run_events(daemon, run_id)
+        .await
+        .iter()
+        .filter(|e| e["kind"] == "run_failed")
+        .filter_map(|e| e["payload"]["reason"].as_str().map(str::to_string))
+        .find(|r| r.contains("sandbox prep"))
+}
+
+async fn post_run(daemon: &TestDaemon, sandbox: Option<&str>) -> reqwest::Response {
+    let mut body = serde_json::json!({ "pipeline": "sbx-cycle", "input": "hello" });
+    if let Some(mode) = sandbox {
+        body["sandbox"] = serde_json::json!(mode);
+    }
+    reqwest::Client::new()
+        .post(format!("{}/runs", daemon.url()))
+        .json(&body)
+        .send()
+        .await
+        .unwrap()
+}
+
+async fn start_run(daemon: &TestDaemon, sandbox: Option<&str>) -> String {
+    let resp = post_run(daemon, sandbox).await;
+    assert_eq!(resp.status(), 201, "POST /runs should create the run");
+    resp.json::<serde_json::Value>().await.unwrap()["run_id"]
+        .as_str()
+        .unwrap()
+        .to_string()
+}
+
+/// `PUT /settings/sandbox-profiles/<name>` with an explicit diff.
+async fn put_profile(
+    daemon: &TestDaemon,
+    name: &str,
+    disabled: &[&str],
+    extras: &[&str],
+) -> reqwest::Response {
+    reqwest::Client::new()
+        .put(format!("{}/settings/sandbox-profiles/{name}", daemon.url()))
+        .json(&serde_json::json!({ "disabled": disabled, "extras": extras }))
+        .send()
+        .await
+        .unwrap()
+}
+
+async fn get_profile(daemon: &TestDaemon, name: &str) -> reqwest::Response {
+    reqwest::get(format!("{}/settings/sandbox-profiles/{name}", daemon.url()))
+        .await
+        .unwrap()
+}
+
+async fn get_settings(daemon: &TestDaemon) -> serde_json::Value {
+    reqwest::get(format!("{}/settings", daemon.url()))
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap()
+}
+
+async fn put_default_sandbox(daemon: &TestDaemon, value: &str) -> reqwest::Response {
+    reqwest::Client::new()
+        .put(format!("{}/settings", daemon.url()))
+        .json(&serde_json::json!({ "default_sandbox": value }))
+        .send()
+        .await
+        .unwrap()
+}
+
+/// Create a Trigger with a `sandbox` value, due far in the future (the test forces it).
+async fn create_trigger(daemon: &TestDaemon, name: &str, sandbox: &str) -> reqwest::Response {
+    reqwest::Client::new()
+        .post(format!("{}/triggers", daemon.url()))
+        .json(&serde_json::json!({
+            "name": name,
+            "pipeline_id": "sbx-cycle",
+            "cron": "0 4 * * *",
+            "input_template": "from the trigger",
+            "sandbox": sandbox,
+        }))
+        .send()
+        .await
+        .unwrap()
+}
+
+async fn fire_history(daemon: &TestDaemon, trigger_id: &str) -> Vec<serde_json::Value> {
+    let body: serde_json::Value =
+        reqwest::get(format!("{}/triggers/{trigger_id}/fires", daemon.url()))
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+    body.as_array()
+        .cloned()
+        .or_else(|| body["fires"].as_array().cloned())
+        .unwrap_or_default()
+}
+
+fn write_node_output(daemon: &TestDaemon, run_id: &str, content: &str) {
+    let out = daemon
+        .repo_root()
+        .join(".pdo/runs")
+        .join(run_id)
+        .join("worktree/.pdo/artifacts")
+        .join(NODE_ID)
+        .join("iter-1/out/output.md");
+    std::fs::create_dir_all(out.parent().unwrap()).unwrap();
+    std::fs::write(&out, content).unwrap();
+}
+
+async fn simulate_node_done(daemon: &TestDaemon, run_id: &str) {
+    let resp = reqwest::Client::new()
+        .post(format!(
+            "{}/runs/{run_id}/nodes/{NODE_ID}/done",
+            daemon.url()
+        ))
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .unwrap();
+    assert!(
+        resp.status().is_success(),
+        "simulated pdo complete should succeed: {}",
+        resp.status()
+    );
+}
+
+// -- AC1: a profile with plugins unchecked, on a Trigger -----------------------
+
+/// The headline acceptance criterion. `full-sans-plugins` (diff
+/// `disabled: [".claude/plugins"]`) is assigned to a **Trigger**; firing it stages
+/// everything else and NOT `plugins/` — an order of magnitude less on disk, since
+/// `plugins/*/node_modules` is the measured cost centre.
+#[tokio::test]
+async fn a_profile_with_plugins_unchecked_stages_without_them_through_a_trigger() {
+    ensure_pdo_on_path();
+    let (_fake, docker, _log) = write_fake_docker();
+    let daemon = TestDaemon::spawn_with_docker_override(seed(), docker)
+        .await
+        .unwrap();
+    fabricate_host_home(daemon.repo_root());
+
+    let resp = put_profile(&daemon, "full-sans-plugins", &[".claude/plugins"], &[]).await;
+    assert_eq!(resp.status(), 200, "the profile must be accepted");
+    let view: serde_json::Value = resp.json().await.unwrap();
+    assert!(
+        !view["resolved"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|e| e == ".claude/plugins"),
+        "resolved list must drop the unchecked entry: {view}"
+    );
+
+    let trig = create_trigger(&daemon, "nightly", "full-sans-plugins").await;
+    assert_eq!(trig.status(), 201, "the Trigger must accept the profile");
+    let trigger_id = trig.json::<serde_json::Value>().await.unwrap()["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    daemon.force_trigger_due(&trigger_id).await;
+    daemon.run_trigger_tick().await;
+
+    // The fired Run is the only one; find it through the fire history.
+    let fires = fire_history(&daemon, &trigger_id).await;
+    let run_id = fires
+        .iter()
+        .find_map(|f| f["run_id"].as_str())
+        .unwrap_or_else(|| panic!("the fire must have produced a Run: {fires:?}"))
+        .to_string();
+
+    let run = get_run(&daemon, &run_id).await;
+    assert_eq!(
+        run["sandbox"], "full-sans-plugins",
+        "the Run must carry the profile NAME: {run}"
+    );
+    // The frozen list is on the Run too — that is what makes an edit non-retroactive.
+    let frozen: Vec<String> = run["sandbox_entries"]
+        .as_array()
+        .unwrap_or_else(|| panic!("the Run must freeze its entry list: {run}"))
+        .iter()
+        .map(|v| v.as_str().unwrap().to_string())
+        .collect();
+    assert!(!frozen.iter().any(|e| e == ".claude/plugins"));
+    assert!(frozen.iter().any(|e| e == ".claude/skills"));
+
+    wait_node_status(&daemon, &run_id, "running").await;
+    let home = staged_home(&daemon, &run_id);
+    assert!(
+        wait_until(|| home.join("settings.json").is_file()).await,
+        "staging should be seeded once the node is running"
+    );
+    assert!(
+        !home.join("plugins").exists(),
+        "the unchecked entry must NOT be staged"
+    );
+    // Everything else still is — the diff removed one line, not the profile.
+    assert!(home.join("skills/foo/skill.md").is_file());
+    assert!(home.join("agents/a.md").is_file());
+    assert!(home.join("CLAUDE.md").is_file());
+}
+
+// -- AC2 + AC3: the `$HOME` exception mounts ---------------------------------
+
+/// `.gitconfig` as an extra: the host file is **copied** into `<staging>/home/` and
+/// bind-mounted rw at `$HOME/.gitconfig`, so a `git commit` inside the container runs
+/// under the host identity. The negative half is what ADR-0031 §4 exists for: the host
+/// path is never a mount SOURCE, so no container write can reach it.
+///
+/// A multi-segment DIRECTORY entry (`.config/gh`) rides along, because it is the case
+/// where a missing source would have Docker create `<staging>/home/.config` root-owned
+/// and leave the staging permanently undeletable (mount rule M1).
+#[tokio::test]
+async fn an_extra_is_copied_into_the_staging_and_mounted_never_bound_from_the_host() {
+    ensure_pdo_on_path();
+    let (_fake, docker, log) = write_fake_docker();
+    let daemon = TestDaemon::spawn_with_docker_override(seed(), docker)
+        .await
+        .unwrap();
+    let host = daemon.repo_root();
+    fabricate_host_home(host);
+
+    assert_eq!(
+        put_profile(&daemon, "with-git", &[], &[".gitconfig", ".config/gh"])
+            .await
+            .status(),
+        200
+    );
+
+    let run_id = start_run(&daemon, Some("with-git")).await;
+    assert!(
+        wait_until(|| log_text(&log).contains("create")).await,
+        "prep must `docker create`; log:\n{}",
+        log_text(&log)
+    );
+
+    // (a) COPIED, not referenced: the content matches the host, at the staged path.
+    let staged_git = staged_extras(&daemon, &run_id).join(".gitconfig");
+    assert!(
+        wait_until(|| staged_git.is_file()).await,
+        "the extra must be copied to {}",
+        staged_git.display()
+    );
+    assert_eq!(
+        std::fs::read_to_string(&staged_git).unwrap(),
+        HOST_GITCONFIG
+    );
+    assert!(staged_extras(&daemon, &run_id)
+        .join(".config/gh/hosts.yml")
+        .is_file());
+
+    // (b) MOUNTED rw at the container's `$HOME/<rel>` (host_home == repo_root here).
+    let specs = mount_specs(&log);
+    let expect_git = format!(
+        "{}:{}:rw",
+        staged_git.display(),
+        host.join(".gitconfig").display()
+    );
+    assert!(
+        specs.contains(&expect_git),
+        "the staged extra must be mounted at $HOME/.gitconfig; specs={specs:?}"
+    );
+    let expect_gh = format!(
+        "{}:{}:rw",
+        staged_extras(&daemon, &run_id).join(".config/gh").display(),
+        host.join(".config/gh").display()
+    );
+    assert!(
+        specs.contains(&expect_gh),
+        "the staged directory extra must be mounted too; specs={specs:?}"
+    );
+
+    // (c) THE NEGATIVE, load-bearing: no mount SOURCE is a real host path. Compare the
+    // source SEGMENT, never `contains` — the mount TARGETS legitimately are host paths
+    // (`sandbox_home_override == repo_root` in this harness), so a substring check would
+    // false-positive on every single spec.
+    for spec in &specs {
+        let source = spec.split(':').next().unwrap_or(spec);
+        for forbidden in [
+            host.join(".gitconfig"),
+            host.join(".config/gh"),
+            host.join(".claude"),
+            host.join(".claude.json"),
+        ] {
+            assert_ne!(
+                source,
+                forbidden.display().to_string(),
+                "a real host path must never be a mount source; spec={spec}"
+            );
+        }
+    }
+
+    // (d) And the host file is byte-identical after the Run — nothing wrote back.
+    write_node_output(&daemon, &run_id, "done\n");
+    simulate_node_done(&daemon, &run_id).await;
+    wait_run_status(&daemon, &run_id, "completed").await;
+    assert_eq!(
+        std::fs::read_to_string(host.join(".gitconfig")).unwrap(),
+        HOST_GITCONFIG,
+        "the host ~/.gitconfig must be untouched"
+    );
+}
+
+/// The positive half of "a container write lands in the staged copy": simulate the
+/// container writing THROUGH the mount (host path == staged path from the container's
+/// point of view) and assert the host original is still intact.
+///
+/// Proven on a **directory** entry, deliberately. `git config --global` — the operation
+/// the issue's AC3 named — cannot work here and it is NOT this slice's fault: `$HOME`
+/// does not exist inside the image (`ubuntu:24.04` ships `/home/ubuntu`, not
+/// `/home/<host user>`), so Docker creates it root-owned `0755` as the parent of the
+/// mounts, and `git config` needs a writable `$HOME` for its lock-file-then-rename. That
+/// is a pre-existing condition since #406, already true for `full` today; making `$HOME`
+/// writable touches the ADR-0030 §1 identity mounts and is a follow-up.
+#[tokio::test]
+async fn a_write_under_a_staged_directory_entry_stays_in_the_staging() {
+    ensure_pdo_on_path();
+    let (_fake, docker, _log) = write_fake_docker();
+    let daemon = TestDaemon::spawn_with_docker_override(seed(), docker)
+        .await
+        .unwrap();
+    let host = daemon.repo_root();
+    fabricate_host_home(host);
+    let host_before = std::fs::read(host.join(".config/gh/hosts.yml")).unwrap();
+
+    assert_eq!(
+        put_profile(&daemon, "with-gh", &[], &[".config/gh"])
+            .await
+            .status(),
+        200
+    );
+    let run_id = start_run(&daemon, Some("with-gh")).await;
+    let staged_gh = staged_extras(&daemon, &run_id).join(".config/gh");
+    assert!(wait_until(|| staged_gh.join("hosts.yml").is_file()).await);
+
+    // The container refreshes its `gh` token: it writes into the mount, i.e. the staged
+    // copy. The mount is rw and carries the STAGED source's ownership, so this succeeds.
+    std::fs::write(
+        staged_gh.join("hosts.yml"),
+        "github.com:\n  user: refreshed\n",
+    )
+    .unwrap();
+
+    assert_eq!(
+        std::fs::read(host.join(".config/gh/hosts.yml")).unwrap(),
+        host_before,
+        "the host file must be byte-identical: the container writes to the COPY"
+    );
+}
+
+// -- AC4: an entry under `.claude/` produces no extra `-v` --------------------
+
+/// Not a special case — a consequence of the single `landing()` classifier. `.claude/…`
+/// is already served by the fixed `claude-home` mount, so it must add nothing to the
+/// queue; and with NO `$HOME`-exception entry the argv is byte-identical to #406, which
+/// is exactly the "accommodate, don't freeze" property the golden test pins in-crate.
+#[tokio::test]
+async fn an_entry_under_claude_adds_no_mount() {
+    ensure_pdo_on_path();
+    let (_fake, docker, log) = write_fake_docker();
+    let daemon = TestDaemon::spawn_with_docker_override(seed(), docker)
+        .await
+        .unwrap();
+    fabricate_host_home(daemon.repo_root());
+
+    // A profile whose only edit is under `.claude/` — plus a redundant extra ALSO under
+    // `.claude/`, so both the default and the extra paths are exercised.
+    assert_eq!(
+        put_profile(
+            &daemon,
+            "claude-only",
+            &[".claude/plugins"],
+            &[".claude/skills"]
+        )
+        .await
+        .status(),
+        200
+    );
+    let run_id = start_run(&daemon, Some("claude-only")).await;
+    assert!(wait_until(|| log_text(&log).contains("create")).await);
+
+    let specs = mount_specs(&log);
+    assert_eq!(
+        specs.len(),
+        4,
+        "only the 4 FIXED mounts (repo, claude-home, .claude.json, pdo bin); specs={specs:?}"
+    );
+    assert!(
+        !staged_extras(&daemon, &run_id).exists(),
+        "no `$HOME` exception ⇒ no <staging>/home at all"
+    );
+}
+
+// -- AC5: entry validation at write time --------------------------------------
+
+#[tokio::test]
+async fn a_bad_entry_is_rejected_at_profile_write() {
+    ensure_pdo_on_path();
+    let (_fake, docker, _log) = write_fake_docker();
+    let daemon = TestDaemon::spawn_with_docker_override(seed(), docker)
+        .await
+        .unwrap();
+    fabricate_host_home(daemon.repo_root());
+
+    for bad in [
+        "/etc/passwd",                  // absolute
+        "../outside",                   // escapes $HOME
+        ".config/../../etc/passwd",     // escapes after a normalisation
+        "..\\..\\etc",                  // a backslash is a legal Linux filename char
+        ".claude/projects",             // the runtime transcripts sink (floor-owned)
+        ".claude/projects/-enc",        // …and anything under it
+        ".claude/.credentials.json",    // floor-owned whole
+        ".claude/remote-settings.json", // floor-owned whole
+        ".claude",                      // the staged home is already mounted whole
+        ".pdo",                         // holds the staging root itself
+        ".claude/*.md",                 // a glob: authored by the default, never by hand
+        ".",                            // $HOME itself
+    ] {
+        let resp = put_profile(&daemon, "probe", &[], &[bad]).await;
+        assert_eq!(
+            resp.status(),
+            400,
+            "`{bad}` must be rejected at write; body: {}",
+            resp.text().await.unwrap_or_default()
+        );
+    }
+
+    // …and a path that simply does not exist under $HOME — an early UX gate, with the
+    // picker to hand (necessary, never sufficient: `prepare` warns-and-skips later).
+    let resp = put_profile(&daemon, "probe", &[], &[".nope-not-here"]).await;
+    assert_eq!(resp.status(), 400);
+
+    // Nothing was persisted by any of the refusals.
+    let listed: serde_json::Value =
+        reqwest::get(format!("{}/settings/sandbox-profiles", daemon.url()))
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+    assert!(
+        !listed["profiles"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|p| p["name"] == "probe"),
+        "a rejected write must persist nothing: {listed}"
+    );
+
+    // A contradictory diff is refused too: resolving it silently would freeze into
+    // `RunStarted` a winner the user never picked.
+    let resp = put_profile(&daemon, "probe", &[".claude/skills"], &[".claude/skills"]).await;
+    assert_eq!(resp.status(), 400);
+
+    // A sensitive prefix, by contrast, is ALLOWED (ADR-0031 §3: warn, don't forbid).
+    std::fs::create_dir_all(daemon.repo_root().join(".ssh")).unwrap();
+    std::fs::write(daemon.repo_root().join(".ssh/id_ed25519"), "key\n").unwrap();
+    let resp = put_profile(&daemon, "risky", &[], &[".ssh"]).await;
+    assert_eq!(resp.status(), 200, "`.ssh` is allowed with a warning");
+    let view: serde_json::Value = resp.json().await.unwrap();
+    let ssh = view["entries"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|e| e["path"] == ".ssh")
+        .unwrap()
+        .clone();
+    assert_eq!(ssh["sensitive"], serde_json::json!(true), "{view}");
+}
+
+// -- AC6: the freeze ----------------------------------------------------------
+
+/// Editing a profile after a Run has started must not change that Run's staging, and a
+/// daemon restart must replay the **frozen** list identically (ADR-0031 §6). Without the
+/// freeze, a restarted daemon would produce an incoherent home between two nodes of the
+/// same Run — with `plugins/` physically present despite being unchecked.
+#[tokio::test]
+async fn editing_a_profile_does_not_change_a_running_runs_staging() {
+    ensure_pdo_on_path();
+    let (_fake, docker, _log) = write_fake_docker();
+    let daemon = TestDaemon::spawn_with_docker_override(seed(), docker)
+        .await
+        .unwrap();
+    fabricate_host_home(daemon.repo_root());
+
+    // Start from a profile that DOES carry plugins.
+    assert_eq!(put_profile(&daemon, "frozen", &[], &[]).await.status(), 200);
+    let run_id = start_run(&daemon, Some("frozen")).await;
+    wait_node_status(&daemon, &run_id, "running").await;
+    let home = staged_home(&daemon, &run_id);
+    assert!(wait_until(|| home.join("plugins").is_dir()).await);
+
+    let frozen_before: Vec<String> = get_run(&daemon, &run_id).await["sandbox_entries"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap().to_string())
+        .collect();
+    assert!(frozen_before.iter().any(|e| e == ".claude/plugins"));
+
+    // Now uncheck plugins AND add an extra. The live Run must see neither.
+    assert_eq!(
+        put_profile(&daemon, "frozen", &[".claude/plugins"], &[".gitconfig"])
+            .await
+            .status(),
+        200
+    );
+
+    // Force a SECOND `ensure_ready` for the same Run through boot recovery. `prepare` is
+    // gated on the staging dir existing, so it does not re-run — and `extra_mounts` is
+    // derived from the FROZEN list, so no `.gitconfig` mount appears either.
+    daemon.run_boot_recovery_tick().await;
+
+    let run = get_run(&daemon, &run_id).await;
+    let frozen_after: Vec<String> = run["sandbox_entries"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(
+        frozen_after, frozen_before,
+        "the frozen list is immutable: {run}"
+    );
+    assert_eq!(
+        sandbox_prep_failure(&daemon, &run_id).await,
+        None,
+        "boot recovery must replay the frozen list, not fail the sandbox prep"
+    );
+    assert!(
+        home.join("plugins").is_dir(),
+        "the already-staged entry must not be removed (prepare is additive)"
+    );
+    assert!(
+        !staged_extras(&daemon, &run_id).join(".gitconfig").exists(),
+        "an entry added AFTER the Run started must not appear in its staging"
+    );
+}
+
+/// The other half of the freeze: a Run whose profile has been **deleted** since it
+/// started still replays, because the list — not the name — is what `prepare` consumes.
+/// Surviving that is the whole point.
+#[tokio::test]
+async fn boot_recovery_replays_a_frozen_list_whose_profile_was_deleted() {
+    ensure_pdo_on_path();
+    let (_fake, docker, _log) = write_fake_docker();
+    let daemon = TestDaemon::spawn_with_docker_override(seed(), docker)
+        .await
+        .unwrap();
+    fabricate_host_home(daemon.repo_root());
+
+    assert_eq!(
+        put_profile(&daemon, "doomed", &[".claude/plugins"], &[])
+            .await
+            .status(),
+        200
+    );
+    let run_id = start_run(&daemon, Some("doomed")).await;
+    wait_node_status(&daemon, &run_id, "running").await;
+
+    let resp = reqwest::Client::new()
+        .delete(format!("{}/settings/sandbox-profiles/doomed", daemon.url()))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        204,
+        "delete is unconditional (soft guard-rail)"
+    );
+    assert_eq!(get_profile(&daemon, "doomed").await.status(), 404);
+
+    daemon.run_boot_recovery_tick().await;
+
+    assert_eq!(
+        sandbox_prep_failure(&daemon, &run_id).await,
+        None,
+        "a live Run must survive its profile's deletion — the FROZEN LIST is what \
+         `prepare` consumes, not the name"
+    );
+    assert!(
+        !staged_home(&daemon, &run_id).join("plugins").exists(),
+        "…and still reflect the list it froze"
+    );
+}
+
+// -- AC7: an unknown profile fails hard, everywhere ---------------------------
+
+#[tokio::test]
+async fn an_unknown_profile_is_a_400_at_create() {
+    ensure_pdo_on_path();
+    let (_fake, docker, log) = write_fake_docker();
+    let daemon = TestDaemon::spawn_with_docker_override(seed(), docker)
+        .await
+        .unwrap();
+    fabricate_host_home(daemon.repo_root());
+
+    let resp = post_run(&daemon, Some("does-not-exist")).await;
+    assert_eq!(resp.status(), 400, "no Run may be created");
+    let body: serde_json::Value = resp.json().await.unwrap();
+    let msg = body["error"].as_str().unwrap_or_default();
+    assert!(
+        msg.contains("does-not-exist") && msg.contains("unknown sandbox profile"),
+        "the error must name the profile: {body}"
+    );
+
+    // Strictly nothing happened: no Run, no worktree, no docker call.
+    let runs: serde_json::Value = reqwest::get(format!("{}/runs", daemon.url()))
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let list = runs.as_array().cloned().unwrap_or_default();
+    assert!(list.is_empty(), "no Run may exist: {runs}");
+    assert_eq!(log_text(&log), "", "docker must not be invoked");
+}
+
+/// A Trigger pointing at a vanished profile: the fire is **visibly** in error, and it
+/// produces no Run at all. Zero new code paid for this — `fire_one_trigger`'s existing
+/// `Err` arm turns the 400's message into the history line.
+#[tokio::test]
+async fn an_unknown_profile_makes_a_trigger_fire_visibly_fail() {
+    ensure_pdo_on_path();
+    let (_fake, docker, _log) = write_fake_docker();
+    let daemon = TestDaemon::spawn_with_docker_override(seed(), docker)
+        .await
+        .unwrap();
+    fabricate_host_home(daemon.repo_root());
+
+    // Create the profile, point a Trigger at it, then delete it — the only way to get a
+    // dangling reference, since the write-time gate refuses an unknown name up front.
+    assert_eq!(
+        put_profile(&daemon, "vanishing", &[], &[]).await.status(),
+        200
+    );
+    let trigger_id = create_trigger(&daemon, "nightly", "vanishing")
+        .await
+        .json::<serde_json::Value>()
+        .await
+        .unwrap()["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    assert_eq!(
+        reqwest::Client::new()
+            .delete(format!(
+                "{}/settings/sandbox-profiles/vanishing",
+                daemon.url()
+            ))
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        204
+    );
+
+    daemon.force_trigger_due(&trigger_id).await;
+    daemon.run_trigger_tick().await;
+
+    let fires = fire_history(&daemon, &trigger_id).await;
+    let last = fires
+        .first()
+        .unwrap_or_else(|| panic!("the tick must have recorded a fire: {fires:?}"));
+    assert_eq!(last["outcome"], "error", "the fire must be red: {last}");
+    assert!(
+        last["reason"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("vanishing"),
+        "the reason must name the profile: {last}"
+    );
+    assert!(last["run_id"].is_null(), "no Run may be created: {last}");
+
+    // The Trigger is NOT dangled: `next_fire_at` survives, so recreating the profile
+    // heals it. A `Dangling` transition would have erased the schedule for something the
+    // user can fix in ten seconds.
+    let trig: serde_json::Value = reqwest::get(format!("{}/triggers/{trigger_id}", daemon.url()))
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert!(
+        !trig["next_fire_at"].is_null(),
+        "the schedule must survive: {trig}"
+    );
+}
+
+/// The instance default naming a vanished profile: a Run that falls back to it fails with
+/// a message that names the TIER, and `GET /settings` discloses the dangling reference so
+/// the user can see it before launching anything.
+#[tokio::test]
+async fn an_unknown_instance_default_is_a_distinct_400_and_is_disclosed() {
+    ensure_pdo_on_path();
+    let (_fake, docker, _log) = write_fake_docker();
+    let daemon = TestDaemon::spawn_with_docker_override(seed(), docker)
+        .await
+        .unwrap();
+    fabricate_host_home(daemon.repo_root());
+
+    // The write gate refuses an unknown name, so go through create-then-delete.
+    assert_eq!(put_profile(&daemon, "gone", &[], &[]).await.status(), 200);
+    assert_eq!(put_default_sandbox(&daemon, "gone").await.status(), 200);
+    assert_eq!(
+        reqwest::Client::new()
+            .delete(format!("{}/settings/sandbox-profiles/gone", daemon.url()))
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        204
+    );
+
+    // Disclosed, with a reason (the env tier passes through no validator at all, so this
+    // is the only honest place to say it).
+    let settings = get_settings(&daemon).await;
+    assert_eq!(settings["default_sandbox"]["effective"], "gone");
+    assert!(
+        settings["default_sandbox"]["reason"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("gone"),
+        "the settings view must disclose the dangling default: {}",
+        settings["default_sandbox"]
+    );
+
+    // A Run with no explicit tier falls back to it → 400 naming the tier, NOT a silent
+    // demotion to `off` and NOT another profile.
+    let resp = post_run(&daemon, None).await;
+    assert_eq!(resp.status(), 400);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    let msg = body["error"].as_str().unwrap_or_default();
+    assert!(
+        msg.contains("instance default"),
+        "the message must name the losing tier: {body}"
+    );
+
+    // …and an explicit tier that DOES resolve is unaffected: only the WINNER is resolved.
+    let resp = post_run(&daemon, Some("off")).await;
+    assert_eq!(
+        resp.status(),
+        201,
+        "an unconsulted broken default must not block an explicit `off`"
+    );
+}
+
+/// A `sandbox_entries` payload that cannot be read is a **hard** `RunFailed` at boot
+/// recovery, with the raw value in the reason — never a silent re-resolve, which would
+/// change what the nodes that already launched saw.
+#[tokio::test]
+async fn an_unreadable_frozen_list_fails_the_run_at_boot_recovery() {
+    ensure_pdo_on_path();
+    let (_fake, docker, _log) = write_fake_docker();
+    let daemon = TestDaemon::spawn_with_docker_override(seed(), docker)
+        .await
+        .unwrap();
+    fabricate_host_home(daemon.repo_root());
+
+    let run_id = start_run(&daemon, Some("full")).await;
+    wait_node_status(&daemon, &run_id, "running").await;
+
+    // Corrupt the frozen list in the event log, the way a hand-edited DB or a future
+    // encoder bug would. Straight SQL against the daemon's own SQLite file — no `sqlite3`
+    // CLI, which is not a build dependency of this repo.
+    let db_path = daemon.repo_root().join(".pdo").join("pdo.db");
+    let pool = sqlx::SqlitePool::connect(&format!("sqlite://{}", db_path.display()))
+        .await
+        .unwrap();
+    let updated = sqlx::query(
+        "UPDATE events SET payload = json_set(payload, '$.sandbox_entries', 42) \
+         WHERE run_id = ? AND kind = 'run_started'",
+    )
+    .bind(&run_id)
+    .execute(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        updated.rows_affected(),
+        1,
+        "the run_started row must be patched"
+    );
+    pool.close().await;
+
+    daemon.run_boot_recovery_tick().await;
+
+    let reason = sandbox_prep_failure(&daemon, &run_id)
+        .await
+        .unwrap_or_default();
+    assert!(
+        !reason.is_empty(),
+        "an unreadable frozen list must fail the Run loud, not re-resolve silently"
+    );
+    let run = wait_run_status(&daemon, &run_id, "failed").await;
+    assert_eq!(run["status"], "failed", "{run}");
+    // #431 trap: the reason lives on /events, not on /runs/<id>.
+    assert!(
+        reason.contains("42") && reason.contains("unreadable"),
+        "the reason must carry the offending raw value: {reason}"
+    );
+}
+
+// -- AC8: virtual defaults, and the diff (not a snapshot) ---------------------
+
+#[tokio::test]
+async fn unedited_defaults_have_no_row_and_editing_stores_a_diff() {
+    ensure_pdo_on_path();
+    let (_fake, docker, _log) = write_fake_docker();
+    let daemon = TestDaemon::spawn_with_docker_override(seed(), docker)
+        .await
+        .unwrap();
+    fabricate_host_home(daemon.repo_root());
+
+    // Both virtual defaults resolve with NO row.
+    for name in ["full", "minimal"] {
+        let view: serde_json::Value = get_profile(&daemon, name).await.json().await.unwrap();
+        assert_eq!(view["virtual"], serde_json::json!(true), "{name}: {view}");
+        assert_eq!(
+            view["materialised"],
+            serde_json::json!(false),
+            "{name} must have no DB row until edited: {view}"
+        );
+        assert!(view["updated_at"].is_null(), "{name}: {view}");
+    }
+    // `minimal` IS the floor: an empty entry list, plus the read-only floor block —
+    // without which the screen looks broken and the user wrongly concludes the container
+    // starts with no credentials.
+    let minimal: serde_json::Value = get_profile(&daemon, "minimal").await.json().await.unwrap();
+    assert_eq!(minimal["resolved"], serde_json::json!([]));
+    assert!(
+        minimal["floor"].as_array().unwrap().len() >= 5,
+        "the floor block must be present and read-only: {minimal}"
+    );
+
+    // Editing `full` MATERIALISES it, and stores the DIFF — not a snapshot.
+    let view: serde_json::Value = put_profile(&daemon, "full", &[".claude/plugins"], &[])
+        .await
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(view["materialised"], serde_json::json!(true));
+    assert_eq!(
+        view["virtual"],
+        serde_json::json!(true),
+        "still a default name"
+    );
+    assert_eq!(view["disabled"], serde_json::json!([".claude/plugins"]));
+    assert!(
+        view["extras"].as_array().unwrap().is_empty(),
+        "the row holds the intention, not the effective list: {view}"
+    );
+    // The snapshot test: the resolved list still carries every OTHER default entry, so a
+    // future release that adds one would be seen by this profile too.
+    let resolved: Vec<&str> = view["resolved"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert!(resolved.contains(&".claude/skills"));
+    assert!(resolved.contains(&".claude/*.md"));
+    assert!(!resolved.contains(&".claude/plugins"));
+
+    // Deleting an edited default reverts it to virtual (it does not disappear).
+    assert_eq!(
+        reqwest::Client::new()
+            .delete(format!("{}/settings/sandbox-profiles/full", daemon.url()))
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        204
+    );
+    let view: serde_json::Value = get_profile(&daemon, "full").await.json().await.unwrap();
+    assert_eq!(view["materialised"], serde_json::json!(false));
+    assert!(view["resolved"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|e| e == ".claude/plugins"));
+
+    // A `disabled` naming an entry THIS version does not have is remembered as inactive,
+    // not rejected — ADR-0031 §2's forward-compatibility clause.
+    let view: serde_json::Value = put_profile(&daemon, "minimal", &[".claude/plugins"], &[])
+        .await
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(
+        view["inactive_disabled"],
+        serde_json::json!([".claude/plugins"]),
+        "an inactive `disabled` is a signalled no-op: {view}"
+    );
+    assert_eq!(view["resolved"], serde_json::json!([]));
+}
+
+// -- AC9: the floor holds when a class-(b) entry is unchecked ------------------
+
+/// Unchecking `.claude/settings.json` must NOT block the Run: the floor re-synthesises a
+/// one-key `settings.json` carrying the permissions bypass. This is the case that makes
+/// ADR-0031 §1 state the floor as *guarantees* rather than as *files* — a user whose host
+/// hooks do not exist in the container must get the synthesis, not a refusal.
+#[tokio::test]
+async fn unchecking_settings_json_still_starts_thanks_to_the_floor() {
+    ensure_pdo_on_path();
+    let (_fake, docker, _log) = write_fake_docker();
+    let daemon = TestDaemon::spawn_with_docker_override(seed(), docker)
+        .await
+        .unwrap();
+    fabricate_host_home(daemon.repo_root());
+
+    assert_eq!(
+        put_profile(&daemon, "no-settings", &[".claude/settings.json"], &[])
+            .await
+            .status(),
+        200
+    );
+    let run_id = start_run(&daemon, Some("no-settings")).await;
+    let run = wait_node_status(&daemon, &run_id, "running").await;
+    assert_eq!(
+        run["nodes"][NODE_ID]["status"], "running",
+        "the Run must start with no dialog: {run}"
+    );
+
+    let staged = staged_home(&daemon, &run_id).join("settings.json");
+    assert!(
+        wait_until(|| staged.is_file()).await,
+        "the floor must synthesise settings.json even when unchecked"
+    );
+    let settings: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&staged).unwrap()).unwrap();
+    assert_eq!(
+        settings,
+        serde_json::json!({ "skipDangerousModePermissionPrompt": true }),
+        "SYNTHESISED, not copied: the host's `hooks` must not be there: {settings}"
+    );
+    // The other floor guarantees hold too.
+    assert!(staged_home(&daemon, &run_id)
+        .join(".credentials.json")
+        .is_file());
+    assert!(staged_home(&daemon, &run_id).join("projects").is_dir());
+
+    write_node_output(&daemon, &run_id, "ok\n");
+    simulate_node_done(&daemon, &run_id).await;
+    let run = wait_run_status(&daemon, &run_id, "completed").await;
+    assert_eq!(run["status"], "completed", "{run}");
+}
+
+// -- AC10: referents before deletion ------------------------------------------
+
+/// The dialog cannot be built client-side: `RunListEntry` does not carry `sandbox` (only
+/// the full `RunState` does), so a browser would need N requests. And the third class is
+/// the one that matters most: live Runs already froze their list and are **unaffected**,
+/// while the instance default and Triggers are NOT repointed and their next Run fails.
+#[tokio::test]
+async fn referents_lists_the_three_classes_before_a_delete() {
+    ensure_pdo_on_path();
+    let (_fake, docker, _log) = write_fake_docker();
+    let daemon = TestDaemon::spawn_with_docker_override(seed(), docker)
+        .await
+        .unwrap();
+    fabricate_host_home(daemon.repo_root());
+
+    assert_eq!(put_profile(&daemon, "shared", &[], &[]).await.status(), 200);
+    assert_eq!(put_default_sandbox(&daemon, "shared").await.status(), 200);
+    let trigger_id = create_trigger(&daemon, "nightly audit", "shared")
+        .await
+        .json::<serde_json::Value>()
+        .await
+        .unwrap()["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let run_id = start_run(&daemon, Some("shared")).await;
+    wait_node_status(&daemon, &run_id, "running").await;
+
+    let refs: serde_json::Value = reqwest::get(format!(
+        "{}/settings/sandbox-profiles/shared/referents",
+        daemon.url()
+    ))
+    .await
+    .unwrap()
+    .json()
+    .await
+    .unwrap();
+
+    assert_eq!(refs["instance_default"], serde_json::json!(true), "{refs}");
+    let triggers = refs["triggers"].as_array().unwrap();
+    assert_eq!(triggers.len(), 1, "{refs}");
+    assert_eq!(triggers[0]["id"], serde_json::json!(trigger_id));
+    assert_eq!(triggers[0]["name"], "nightly audit");
+    let runs = refs["runs"].as_array().unwrap();
+    assert!(
+        runs.iter().any(|r| r["run_id"] == run_id.as_str()),
+        "the live Run must be listed (as unaffected): {refs}"
+    );
+
+    // A profile nobody references reports three empties, not a 404 — the dialog must be
+    // able to say "nothing points at this".
+    assert_eq!(put_profile(&daemon, "lonely", &[], &[]).await.status(), 200);
+    let refs: serde_json::Value = reqwest::get(format!(
+        "{}/settings/sandbox-profiles/lonely/referents",
+        daemon.url()
+    ))
+    .await
+    .unwrap()
+    .json()
+    .await
+    .unwrap();
+    assert_eq!(refs["instance_default"], serde_json::json!(false));
+    assert!(refs["triggers"].as_array().unwrap().is_empty());
+    assert!(refs["runs"].as_array().unwrap().is_empty());
+}
+
+// -- the settings surface -----------------------------------------------------
+
+/// `GET /settings` gains exactly two things: the profile NAME list (never entry lists —
+/// this is the launch dialog's hot path) and the host `$HOME`, which the editor needs to
+/// turn the explorer's absolute pick into a `$HOME`-relative entry.
+#[tokio::test]
+async fn get_settings_exposes_profile_names_and_home() {
+    ensure_pdo_on_path();
+    let (_fake, docker, _log) = write_fake_docker();
+    let daemon = TestDaemon::spawn_with_docker_override(seed(), docker)
+        .await
+        .unwrap();
+    fabricate_host_home(daemon.repo_root());
+
+    assert_eq!(put_profile(&daemon, "custom", &[], &[]).await.status(), 200);
+    let settings = get_settings(&daemon).await;
+
+    let names: Vec<(&str, bool)> = settings["sandbox_profiles"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|p| (p["name"].as_str().unwrap(), p["virtual"].as_bool().unwrap()))
+        .collect();
+    assert_eq!(
+        names,
+        vec![("custom", false), ("full", true), ("minimal", true)],
+        "sorted, virtuals ∪ materialised, flagged: {settings}"
+    );
+    // NAMES ONLY — the contract, so a future slice does not start serving entry lists on
+    // the launch dialog's hot path.
+    for p in settings["sandbox_profiles"].as_array().unwrap() {
+        assert!(p.get("entries").is_none(), "names only: {p}");
+        assert!(p.get("resolved").is_none(), "names only: {p}");
+    }
+    // `home` honours `sandbox_home_override` — otherwise the editor and the daemon would
+    // disagree about what "under $HOME" means.
+    assert_eq!(
+        settings["home"].as_str().unwrap(),
+        daemon.repo_root().to_string_lossy(),
+        "{settings}"
+    );
+}
+
+/// The name grammar, at the edge. `off` and a blank name are reserved (they are the
+/// "no sandbox" token and the *clear* sentinel), and an uppercase name is refused rather
+/// than folded — folding would have the UI hunt through a list it displays in lowercase.
+#[tokio::test]
+async fn profile_name_grammar_is_enforced_at_the_edge() {
+    ensure_pdo_on_path();
+    let (_fake, docker, _log) = write_fake_docker();
+    let daemon = TestDaemon::spawn_with_docker_override(seed(), docker)
+        .await
+        .unwrap();
+
+    for bad in ["off", "OFF", "Foo", "under_score", "-lead", "with.dot"] {
+        let resp = put_profile(&daemon, bad, &[], &[]).await;
+        assert_eq!(resp.status(), 400, "`{bad}` must be refused");
+    }
+    // `full` / `minimal` ARE allowed — creating them is what materialises them.
+    for ok in ["full", "minimal", "full-no-mcp", "a9"] {
+        assert_eq!(
+            put_profile(&daemon, ok, &[], &[]).await.status(),
+            200,
+            "{ok}"
+        );
+    }
+    // A `disabled` that is not a built-in default entry is refused: unchecking is for
+    // defaults, dropping is for extras, and conflating them makes the diff ambiguous.
+    let resp = put_profile(&daemon, "full-no-mcp", &[".gitconfig"], &[]).await;
+    assert_eq!(resp.status(), 400);
+}

--- a/crates/pdo-daemon/tests/sandbox_tracer.rs
+++ b/crates/pdo-daemon/tests/sandbox_tracer.rs
@@ -583,6 +583,21 @@ fn fabricate_host_claude(home: &Path) {
         home.join(".claude.json"),
         r#"{"host":"profile","oauthAccount":{"x":1}}"#,
     );
+    // #432: host files OUTSIDE `~/.claude` that a staging profile may declare as
+    // extras. Present here even though the default `full` profile does NOT carry them —
+    // that is the point: `full_never_mounts_the_real_host_claude` and
+    // `full_completes_without_host_config_writeback` assert they are neither mounted nor
+    // written, so a future slice that starts staging them by default trips those tests.
+    // Deliberate mirror of the unit fixture `sandbox_staging::tests::fabricate_home` and
+    // of `sandbox_profiles::fabricate_host_home`; keep the three in step.
+    write(
+        home.join(".gitconfig"),
+        "[user]\n\tname = Host User\n\temail = host@example.com\n",
+    );
+    write(
+        home.join(".config/gh/hosts.yml"),
+        "github.com:\n  user: me\n",
+    );
 }
 
 /// The staged Claude home of a run under the tempdir override
@@ -861,23 +876,33 @@ async fn full_never_mounts_the_real_host_claude() {
         "staged home must mount to <repo>/.claude (source = staging); specs={specs:?}"
     );
 
-    // Negative (load-bearing): NO mount has the real host `.claude`/`.claude.json`
-    // as its SOURCE. Inspect the source SEGMENT (split ':'), never `contains` — the
-    // mount TARGET `<repo>/.claude` coincides on disk with the fake host here
-    // (override home == repo_root), so a substring check would false-positive.
+    // Negative (load-bearing): NO mount has ANY real host config path as its SOURCE.
+    // Widened in #432 from "not the real `.claude`" to "no real host path at all", now
+    // that a profile can name entries outside `~/.claude`: ADR-0031 §4 says such an entry
+    // is COPIED then mounted, never bind-mounted from the host.
+    //
+    // Inspect the source SEGMENT (split ':'), never `contains` — the mount TARGETS
+    // legitimately ARE host paths here (override home == repo_root), so a substring check
+    // would false-positive on every spec.
+    let host_gitconfig = daemon.repo_root().join(".gitconfig");
+    let host_gh = daemon.repo_root().join(".config/gh");
     for spec in &specs {
         let source = spec.split(':').next().unwrap_or(spec);
-        assert_ne!(
-            source,
-            host_claude.display().to_string(),
-            "the real host ~/.claude must never be a mount source; spec={spec}"
-        );
-        assert_ne!(
-            source,
-            host_json.display().to_string(),
-            "the real host ~/.claude.json must never be a mount source; spec={spec}"
-        );
+        for forbidden in [&host_claude, &host_json, &host_gitconfig, &host_gh] {
+            assert_ne!(
+                source,
+                forbidden.display().to_string(),
+                "a real host path must never be a mount source; spec={spec}"
+            );
+        }
     }
+    // And the `full` default declares nothing outside `~/.claude`, so the queue is empty:
+    // exactly the 4 fixed mounts, argv byte-identical to #406.
+    assert_eq!(
+        specs.len(),
+        4,
+        "`full` must add no `$HOME`-exception mount; specs={specs:?}"
+    );
 }
 
 // -- Test 10: no host config write-back; transcripts DO flow back ------------
@@ -894,9 +919,14 @@ async fn full_completes_without_host_config_writeback() {
 
     let host_claude = daemon.repo_root().join(".claude");
     let host_json = daemon.repo_root().join(".claude.json");
+    // #432: `~/.gitconfig` rides along. It is the file ADR-0031 §4 names explicitly — an
+    // agent that hits `unable to auto-detect email address` very naturally reaches for
+    // `git config --global`, and a direct bind would have it rewrite the user's identity.
+    let host_gitconfig = daemon.repo_root().join(".gitconfig");
     // Snapshot the host config BEFORE the run (bytes, load-bearing).
     let settings_before = std::fs::read(host_claude.join("settings.json")).unwrap();
     let json_before = std::fs::read(&host_json).unwrap();
+    let gitconfig_before = std::fs::read(&host_gitconfig).unwrap();
 
     let run_id = start_run(&daemon, Some("full")).await;
     wait_node_status(&daemon, &run_id, "running").await;
@@ -936,6 +966,11 @@ async fn full_completes_without_host_config_writeback() {
         std::fs::read(&host_json).unwrap(),
         json_before,
         "host .claude.json must be byte-identical (trust seeding writes only the staged copy)"
+    );
+    assert_eq!(
+        std::fs::read(&host_gitconfig).unwrap(),
+        gitconfig_before,
+        "host ~/.gitconfig must be byte-identical (ADR-0031 §4: copy, never bind)"
     );
     // Positive counterpart: transcripts DO merge back to the host projects dir.
     assert!(

--- a/docs/adr/0031-sandbox-staging-profiles.md
+++ b/docs/adr/0031-sandbox-staging-profiles.md
@@ -3,7 +3,9 @@
 > Statut : accepted (grilling du 2026-07-24, PRD #403). Vocabulaire : CONTEXT.md § « Sandbox ».
 > Complète ADR-0030 (modèle d'exécution) : ADR-0030 dit *où* tourne un Run sandboxé, celle-ci dit
 > *avec quel contenu de home*. Implémentée par les slices « plancher » puis « profils » : §1 est
-> **réalisé en #426** (avec l'amendement §1 d'ADR-0030) ; §2-§7 restent à livrer.
+> **réalisé en #426** (avec l'amendement §1 d'ADR-0030), **§2-§7 en #432**. Deux amendements en fin
+> de document : un point de §6 relit de fait le réglage vivant dans un cas borné, et l'un des
+> critères d'acceptation de #432 était factuellement faux.
 
 Le contenu du *staged Claude home* cesse d'être une constante Rust invisible. Il devient un
 **profil de staging** : une liste nommée, éditable, sélectionnable par Run et par Trigger.
@@ -108,4 +110,51 @@ un Run sandboxé pour faire le travail réel est ailleurs dans `$HOME` : l'ident
   `minimal`/`full` en sont l'application à une valeur non scalaire.
 - **ADR-0001** — outil tranchant, pas outil sûr : fonde le choix « autoriser + avertir » (§3).
 - **#403** — PRD Sandbox ; ces décisions sont livrées par les slices post-validation du PRD. §1 est
-  livré par **#426**, §2-§7 par les slices « profils ».
+  livré par **#426**, §2-§7 par **#432**.
+
+## Amendements (#432, à la livraison)
+
+### A1 — §6 : un Run d'avant les profils relit le défaut vivant
+
+Le gel dit « `prepare` lit l'état du Run, jamais le réglage vivant ». Une ligne de la table de
+décision au replay y contrevient, **sciemment** : un payload `RunStarted` qui porte
+`sandbox: "full"` (ou `"minimal"`) **sans** `sandbox_entries` fait **re-résoudre le défaut virtuel
+maintenant**. Ce cas n'est atteignable que pour un Run créé par un daemon pré-#432, dont le staging a
+été purgé, puis repris. Les deux alternatives sont pires : `RunFailed` sur un Run parfaitement
+résoluble, ou figer dans le Rust pour toujours le défaut tel qu'il était en #426 — ce qui
+contredirait §2. Toutes les autres lignes de la table respectent le gel à la lettre, et un nom
+d'**utilisateur** sans liste gelée échoue dur (il est injoignable par construction : le chokepoint
+unique écrit les deux clés ou aucune).
+
+### A2 — le critère « `git config --global` modifie la copie stagée » était faux
+
+Le corps de #432 affirmait : « `git config --global` **depuis le conteneur modifie la copie stagée**,
+`~/.gitconfig` reste intact ». La seconde moitié est vraie et **doublement garantie** (copie-puis-mount
+de §4, *et* l'échec net ci-dessous). La première est **fausse**, vérifié en Docker réel
+(`pdo-sandbox:h-9a67637571a4`, `--user 1000:1000`) :
+
+```
+git commit                            -> OK, sous l'identité de l'hôte
+git config --global user.email x@y    -> error: could not lock config file
+                                         /home/probeuser/.gitconfig: Permission denied
+ls -ld $HOME                          -> drwxr-xr-x 2 root root
+```
+
+Cause : `$HOME` **n'existe pas dans l'image** (`ubuntu:24.04` livre `/home/ubuntu`, pas
+`/home/<user hôte>`), donc Docker le crée comme parent des mounts, en `root:root 0755`.
+`git config --global` n'écrit pas en place — il crée `$HOME/.gitconfig.lock` puis renomme, et le
+rename exige un `$HOME` inscriptible. **Condition pré-existante depuis #406**, déjà vraie pour la
+liste `full` : ce n'est pas une régression des profils.
+
+Le critère est donc reformulé en deux affirmations vraies et testées :
+
+1. « `~/.gitconfig` de l'hôte n'est **jamais** muté » — assertion couche 3a (aucun chemin hôte réel
+   en source de mount) + contrôle d'octets avant/après le Run ;
+2. « une écriture du conteneur sous `$HOME` atterrit dans la copie stagée » — prouvée sur une entrée
+   **répertoire** (`.config/gh`), qui est inscriptible (le mount porte l'ownership de la source
+   stagée). Seul le motif *lock-file-puis-rename* est bloqué, et `git config` est exactement ça.
+
+Rendre `$HOME` inscriptible dans le conteneur est un **arbitrage produit** : ça touche les identity
+mounts d'ADR-0030 §1 et casse la propriété « queue de mounts vide ⇒ argv byte-identique à #406 ».
+Hors périmètre de #432, à ficher en suivi. Sans lui, `git config --global`, `gh auth login` et tout
+outil qui crée un dotfile *nouveau* échouent dans le conteneur.

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,4 +1,4 @@
-import type { PipelineListEntry, PipelineDetail, PipelineDef, RunListEntry, RunState, PortDef, PortSide, PortType, FrontmatterFieldDecl, Trigger, TriggerFire, DaemonStatus, InstanceSettings, UpdateSettingsRequest, StatsOverview, StatsCost } from "./types";
+import type { PipelineListEntry, PipelineDetail, PipelineDef, RunListEntry, RunState, PortDef, PortSide, PortType, FrontmatterFieldDecl, Trigger, TriggerFire, DaemonStatus, InstanceSettings, UpdateSettingsRequest, StatsOverview, StatsCost, SandboxProfile, SandboxProfileReferents } from "./types";
 
 const BASE = "";
 
@@ -148,6 +148,72 @@ export function updateSettings(
   patch: UpdateSettingsRequest,
 ): Promise<InstanceSettings> {
   return request<InstanceSettings>("PUT", "/settings", { body: patch });
+}
+
+// --- Staging profiles (#432, ADR-0031 §2-§7) --------------------------------
+//
+// A separate REST resource, NOT part of the grouped `PUT /settings`: a profile is a ROW,
+// not a `{effective, source, stored, env, default}` knob. That is exactly why the editor's
+// footer says "Done" rather than "Save" — nothing is batched behind it.
+//
+// The routes sit under `/settings/…` purely for ROUTING: the vite proxy key is a prefix,
+// so `'/settings'` already covers every sub-path (no proxy edit, none of the "dev GET
+// answers 200 with the SPA" traps that `/nodes`, `/stats` and `/fs` each paid).
+
+/** Every staging profile, each fully resolved (`+ home`, the host `$HOME`). */
+export function fetchSandboxProfiles(): Promise<{
+  profiles: SandboxProfile[];
+  home: string | null;
+}> {
+  return request("GET", "/settings/sandbox-profiles");
+}
+
+/** One resolved profile; throws `ApiError` with status 404 when the name is unknown. */
+export function fetchSandboxProfile(name: string): Promise<SandboxProfile> {
+  return request<SandboxProfile>(
+    "GET",
+    `/settings/sandbox-profiles/${encodeURIComponent(name)}`,
+  );
+}
+
+/**
+ * Upsert a profile's **diff** — `disabled` / `extras`, never a snapshot (ADR-0031 §2).
+ * Upsert, because the caller cannot know whether `full` already has a row, and editing it
+ * IS what materialises one. Returns the recomputed view so the editor needs no refetch.
+ */
+export function saveSandboxProfile(
+  name: string,
+  diff: { disabled: string[]; extras: string[] },
+): Promise<SandboxProfile> {
+  return request<SandboxProfile>(
+    "PUT",
+    `/settings/sandbox-profiles/${encodeURIComponent(name)}`,
+    { body: diff },
+  );
+}
+
+/**
+ * Delete the materialised row. Unconditional (ADR-0031 §7 — a *soft* guard-rail, no
+ * referential integrity in the DB): deleting an edited `full`/`minimal` reverts it to its
+ * virtual default, deleting a user profile makes its referents' next Run fail loud.
+ * Neither repoints anything, which is what {@link fetchSandboxProfileReferents} is for.
+ */
+export function deleteSandboxProfile(name: string): Promise<void> {
+  return request<void>(
+    "DELETE",
+    `/settings/sandbox-profiles/${encodeURIComponent(name)}`,
+    { responseMode: "void" },
+  );
+}
+
+/** Who still points at a profile — server-side, because `RunListEntry` carries no `sandbox`. */
+export function fetchSandboxProfileReferents(
+  name: string,
+): Promise<SandboxProfileReferents> {
+  return request<SandboxProfileReferents>(
+    "GET",
+    `/settings/sandbox-profiles/${encodeURIComponent(name)}/referents`,
+  );
 }
 
 /**
@@ -344,7 +410,7 @@ export interface CreateRunRequest {
   target_repo?: string;
   source_branch?: string;
   name?: string;
-  /** Explicit sandbox mode (#410): `"off"` | `"full"` | `"minimal"`. Omitted → the
+  /** Explicit sandbox (#410/#432): `"off"` or a staging-profile name. Omitted → the
    *  server defers to the trigger/instance default at the create chokepoint. */
   sandbox?: string;
   images?: File[];
@@ -395,7 +461,7 @@ export interface CreateTriggerRequest {
   overlap_policy?: string;
   /** Bounded-`allow` ceiling (#239): max simultaneous live Runs; omit/undefined = unbounded. */
   max_concurrent?: number | null;
-  /** Per-Trigger sandbox mode (#410): `"off"` | `"full"` | `"minimal"`, or null/omit to
+  /** Per-Trigger sandbox (#410/#432): `"off"` or a staging-profile name, or null/omit to
    *  inherit the instance default. */
   sandbox?: string | null;
 }
@@ -431,7 +497,7 @@ export interface UpdateTriggerRequest {
   variables?: Record<string, unknown>;
   /** Bounded-`allow` ceiling (#239): number sets, null clears to unbounded, undefined leaves unchanged. */
   max_concurrent?: number | null;
-  /** Per-Trigger sandbox mode (#410): a mode string sets it, `null` clears back to
+  /** Per-Trigger sandbox (#410/#432): a value sets it, `null` clears back to
    *  inheriting the instance default, `undefined` leaves it unchanged. */
   sandbox?: string | null;
 }

--- a/frontend/src/components/NewRunModal.test.tsx
+++ b/frontend/src/components/NewRunModal.test.tsx
@@ -25,7 +25,7 @@ vi.mock("../api", () => ({
     guard_timeout_secs: { effective: 60, source: "default", stored: null, env: null, default: 60 },
     default_model: { effective: null, source: "default", stored: null, env: null, default: null },
     image_source: { effective: "registry", source: "default", stored: null, env: null, default: "registry" },
-    default_sandbox: { effective: "off", source: "default", stored: null, env: null, default: "off" },
+    default_sandbox: { effective: "off", source: "default", stored: null, env: null, default: "off", reason: null },
     dockerfile_path: {
       effective: "/home/user/.pdo/sandbox/Dockerfile",
       source: "default",
@@ -35,6 +35,12 @@ vi.mock("../api", () => ({
     },
     sandbox_image: { tag: "pdo-sandbox:h-9a67637571a4", reason: null },
     sandbox_docker: { available: true, reason: null, checked_at: "2026-07-01T10:00:00.000Z" },
+    // #432: the sandbox `<select>` options are DATA now — the two virtual defaults.
+    sandbox_profiles: [
+      { name: "full", virtual: true },
+      { name: "minimal", virtual: true },
+    ],
+    home: "/home/user",
     updated_at: "2026-07-01T10:00:00.000Z",
   }),
   // #431 prophylaxis: this file renders `RepoCombobox`, which mounts `FsExplorerModal`
@@ -1340,7 +1346,7 @@ describe("NewRunModal — sandbox selector (#410)", () => {
       guard_timeout_secs: { effective: 60, source: "default", stored: null, env: null, default: 60 },
       default_model: { effective: null, source: "default", stored: null, env: null, default: null },
       image_source: { effective: "registry", source: "default", stored: null, env: null, default: "registry" },
-      default_sandbox: { effective: "off", source: "default", stored: null, env: null, default: "off" },
+      default_sandbox: { effective: "off", source: "default", stored: null, env: null, default: "off", reason: null },
       // #431: required fields on InstanceSettings; this modal reads neither, they are
       // here to satisfy the typed fixture.
       dockerfile_path: {
@@ -1352,6 +1358,12 @@ describe("NewRunModal — sandbox selector (#410)", () => {
       },
       sandbox_image: { tag: "pdo-sandbox:h-9a67637571a4", reason: null },
       sandbox_docker: { available: true, reason: null, checked_at: "2026-07-01T10:00:00.000Z" },
+      // #432: the `<select>` options come from here. Both virtual defaults, no row.
+      sandbox_profiles: [
+        { name: "full", virtual: true },
+        { name: "minimal", virtual: true },
+      ],
+      home: "/home/user",
       updated_at: "2026-07-01T10:00:00.000Z",
       ...overrides,
     };
@@ -1360,7 +1372,7 @@ describe("NewRunModal — sandbox selector (#410)", () => {
   it("prefills the run selector from the instance default", async () => {
     vi.mocked(fetchSettings).mockResolvedValue(
       settingsFixture({
-        default_sandbox: { effective: "full", source: "stored", stored: "full", env: null, default: "off" },
+        default_sandbox: { effective: "full", source: "stored", stored: "full", env: null, default: "off", reason: null },
       }),
     );
     vi.mocked(fetchPipelines).mockResolvedValue([makePipeline({ id: "p1", name: "P", scope: "repo" })]);
@@ -1374,7 +1386,7 @@ describe("NewRunModal — sandbox selector (#410)", () => {
     vi.mocked(fetchSettings).mockResolvedValue(
       settingsFixture({
         // The instance default is `minimal`, but Docker is down: greying wins.
-        default_sandbox: { effective: "minimal", source: "stored", stored: "minimal", env: null, default: "off" },
+        default_sandbox: { effective: "minimal", source: "stored", stored: "minimal", env: null, default: "off", reason: null },
         sandbox_docker: { available: false, reason: "Docker daemon unreachable", checked_at: "x" },
       }),
     );
@@ -1394,7 +1406,7 @@ describe("NewRunModal — sandbox selector (#410)", () => {
   it("passes the chosen sandbox mode to createRun", async () => {
     vi.mocked(fetchSettings).mockResolvedValue(
       settingsFixture({
-        default_sandbox: { effective: "full", source: "stored", stored: "full", env: null, default: "off" },
+        default_sandbox: { effective: "full", source: "stored", stored: "full", env: null, default: "off", reason: null },
       }),
     );
     vi.mocked(fetchPipelines).mockResolvedValue([
@@ -1465,5 +1477,92 @@ describe("NewRunModal — sandbox selector (#410)", () => {
         expect.objectContaining({ sandbox: null }),
       );
     });
+  });
+
+  // -- #432: the options are DATA, and a vanished profile is a tombstone -------
+
+  it("lists off plus every staging profile the daemon serves", async () => {
+    vi.mocked(fetchSettings).mockResolvedValue(
+      settingsFixture({
+        sandbox_profiles: [
+          { name: "full", virtual: true },
+          { name: "full-no-mcp", virtual: false },
+          { name: "minimal", virtual: true },
+        ],
+      }),
+    );
+    vi.mocked(fetchPipelines).mockResolvedValue([makePipeline({ id: "p1", name: "P", scope: "repo" })]);
+    renderModal();
+    const select = (await screen.findByTestId("sandbox-select")) as HTMLSelectElement;
+    await waitFor(() =>
+      expect(Array.from(select.options).map((o) => o.value)).toEqual([
+        "off",
+        "full",
+        "full-no-mcp",
+        "minimal",
+      ]),
+    );
+  });
+
+  /**
+   * THE PHANTOM-PROFILE RULE (#432). A trigger whose stored profile has been deleted keeps
+   * a tombstone option and blocks Save.
+   *
+   * Without it React sets `selectedIndex = -1`, the field renders blank, and saving would
+   * PATCH `sandbox: null` — a SILENT FALLBACK to the instance default, exactly what
+   * ADR-0031 §7 forbids. Deliberately separate from the Docker clamp: clamping to `off` is
+   * legitimate for an unavailable Docker, and would be a silent demotion here.
+   */
+  it("tombstones a trigger's vanished profile and blocks the save", async () => {
+    vi.mocked(fetchSettings).mockResolvedValue(settingsFixture());
+    vi.mocked(fetchPipelines).mockResolvedValue([
+      makePipeline({ id: "p1", name: "Auditor", scope: "repo", prompt_required: false }),
+    ]);
+    const trigger = {
+      id: "trg-gone",
+      name: "Nightly",
+      pipeline_id: "p1",
+      pipeline_name: "Auditor",
+      target_repo: "/home/user/project",
+      source_branch: "dev",
+      input_template: "audit",
+      variables: {},
+      cron: "0 9 * * *",
+      guard_command: null,
+      overlap_policy: "skip",
+      // Materialised once, deleted since — the only way to get a dangling reference.
+      sandbox: "full-no-mcp",
+      enabled: true,
+      next_fire_at: null,
+      last_fired_at: null,
+      last_outcome: null,
+    };
+    render(
+      <NewRunModal open={true} onClose={noop} onCreated={noop}
+        openIntent={{ kind: "edit-trigger", trigger }} />,
+    );
+
+    const select = (await screen.findByTestId("sandbox-select")) as HTMLSelectElement;
+    // The seeded value is NEVER rewritten: still selected, and visibly a tombstone.
+    await waitFor(() => expect(select.value).toBe("full-no-mcp"));
+    expect(screen.getByTestId("sandbox-missing-profile")).toBeInTheDocument();
+    expect(screen.getByTestId("sandbox-missing-profile-warning")).toHaveTextContent(
+      /does not fall back to a default/i,
+    );
+
+    vi.useRealTimers();
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /save trigger/i })).toBeDisabled(),
+    );
+    expect(updateTrigger).not.toHaveBeenCalled();
+  });
+
+  it("does not tombstone `off`, which is never a profile", async () => {
+    vi.mocked(fetchSettings).mockResolvedValue(settingsFixture());
+    vi.mocked(fetchPipelines).mockResolvedValue([makePipeline({ id: "p1", name: "P", scope: "repo" })]);
+    renderModal();
+    const select = (await screen.findByTestId("sandbox-select")) as HTMLSelectElement;
+    await waitFor(() => expect(select.value).toBe("off"));
+    expect(screen.queryByTestId("sandbox-missing-profile")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/NewRunModal.tsx
+++ b/frontend/src/components/NewRunModal.tsx
@@ -91,10 +91,12 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
 
   const [images, setImages] = useState<File[]>([]);
 
-  // Sandbox (#410). `settings` carries the instance `default_sandbox` (prefill) and
-  // the advisory `sandbox_docker` probe (greying). `sandbox` is the selector value:
-  // a concrete `off`/`full`/`minimal` in run mode; also `""` in trigger mode, meaning
-  // "inherit the instance default".
+  // Sandbox (#410/#432). `settings` carries the instance `default_sandbox` (prefill), the
+  // advisory `sandbox_docker` probe (greying) and — since #432 — `sandbox_profiles`, the
+  // NAME list that drives the options. `sandbox` is the selector value: `off` or a staging
+  // profile name in run mode; also `""` in trigger mode, meaning "inherit the instance
+  // default". No second fetch: the modal already fetches settings on open (the
+  // `sandbox_docker` precedent from #410).
   const [settings, setSettings] = useState<InstanceSettings | null>(null);
   const [sandbox, setSandbox] = useState<string>("off");
   const sandboxSeeded = useRef(false);
@@ -448,6 +450,33 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
   const promptOptional = selectedPipeline?.prompt_required === false;
   const hasRequiredPrompt = promptOptional || Boolean(input.trim());
 
+  // #410: advisory Docker greying. Only gate the sandboxed options once we KNOW Docker is
+  // unavailable (settings loaded && probe false); while settings load, stay
+  // optimistic. `sandboxReason` explains the greying (title + help text).
+  const dockerUnavailable = settings != null && !settings.sandbox_docker.available;
+  const sandboxReason = settings?.sandbox_docker.reason ?? undefined;
+
+  // #432: the options come from the daemon's profile list. Sorted server-side.
+  const sandboxProfiles = settings?.sandbox_profiles ?? [];
+
+  /**
+   * THE PHANTOM-PROFILE RULE. A seeded value is **never** silently rewritten: a
+   * non-empty, non-`off` value that is absent from the list gets a tombstone option and
+   * blocks Save/Launch.
+   *
+   * Without the tombstone React sets `selectedIndex = -1`, the field renders blank, and
+   * saving would PATCH `sandbox: null` — a **silent fallback to the instance default**,
+   * exactly what ADR-0031 §7 forbids. Deliberately separate from the Docker clamp above:
+   * clamping to `off` is legitimate for an unavailable Docker, and would be a silent
+   * fallback for a missing profile.
+   */
+  const missingProfile = Boolean(
+    settings &&
+      sandbox &&
+      sandbox !== "off" &&
+      !sandboxProfiles.some((p) => p.name === sandbox),
+  );
+
   const handleLaunch = useCallback(async () => {
     if (!repoValid || !selectedPipeline || !hasRequiredPrompt) return;
     setSubmitting(true);
@@ -471,8 +500,8 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
         target_repo: targetRepo.trim() || undefined,
         source_branch: sourceBranch || undefined,
         name: autoName ? undefined : runName.trim() || undefined,
-        // #410: the explicit run-level mode. Always concrete in run mode
-        // (off/full/minimal); sent explicitly so it wins the create-chokepoint
+        // #410: the explicit run-level choice. Always concrete in run mode (`off` or a
+        // staging profile name); sent explicitly so it wins the create-chokepoint
         // precedence over any instance/trigger default.
         sandbox: sandbox || undefined,
         images: images.length > 0 ? images : undefined,
@@ -492,13 +521,7 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
     }
   }, [selectedPipeline, input, hasRequiredPrompt, overrides, onCreated, onClose, flushPendingSaves, repoValid, targetRepo, sourceBranch, autoName, runName, images, sandbox, refreshRecentRepos]);
 
-  const canLaunch = repoValid && selectedPipeline && hasRequiredPrompt;
-
-  // #410: advisory Docker greying. Only gate `full`/`minimal` once we KNOW Docker is
-  // unavailable (settings loaded && probe false); while settings load, stay
-  // optimistic. `sandboxReason` explains the greying (title + help text).
-  const dockerUnavailable = settings != null && !settings.sandbox_docker.available;
-  const sandboxReason = settings?.sandbox_docker.reason ?? undefined;
+  const canLaunch = repoValid && selectedPipeline && hasRequiredPrompt && !missingProfile;
 
   // The cron expression the Trigger will be created with: a compiled preset or
   // the raw escape-hatch expression.
@@ -527,7 +550,10 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
       selectedPipeline &&
       triggerName.trim().length > 0 &&
       resolvedCron.length > 0 &&
-      !triggerInputRejectReason,
+      !triggerInputRejectReason &&
+      // #432: a Trigger pointing at a vanished profile must not be re-saved as-is; the
+      // user picks a real one (or `off`) first.
+      !missingProfile,
   );
 
   const handleCreateTrigger = useCallback(async () => {
@@ -564,7 +590,7 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
           overlap_policy: allowOverlap ? "allow" : "skip",
           max_concurrent: allowOverlap && maxConcurrent.trim() ? Number(maxConcurrent) : null,
           // #410: `""` (Use instance default) clears back to inheriting (`null`);
-          // a concrete mode sets it.
+          // `off` or a staging profile name sets it.
           sandbox: sandbox || null,
           variables,
         });
@@ -579,7 +605,7 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
           source_branch: sourceBranch || undefined,
           overlap_policy: allowOverlap ? "allow" : "skip",
           max_concurrent: allowOverlap && maxConcurrent.trim() ? Number(maxConcurrent) : undefined,
-          // #410: `""` (Use instance default) → `null` (inherit); a concrete mode sets it.
+          // #410: `""` (Use instance default) → `null` (inherit); `off` or a profile sets it.
           sandbox: sandbox || null,
           variables,
         });
@@ -908,11 +934,13 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
               )}
             </div>
 
-            {/* Sandbox (#410): the isolation mode. Run mode offers a concrete
-                off/full/minimal (prefilled from the instance default); Trigger mode adds
-                a leading "Use instance default" option. `full`/`minimal` are disabled
-                when the daemon reports Docker unavailable (advisory greying — the
-                run-advance fail-fast remains authoritative). */}
+            {/* Sandbox (#410/#432): `off`, or one of the instance's STAGING PROFILES —
+                the options are data, served by `GET /settings` (names only). Run mode
+                prefills from the instance default; Trigger mode adds a leading "Use
+                instance default" option. Profiles are disabled when the daemon reports
+                Docker unavailable (advisory greying — the run-advance fail-fast remains
+                authoritative), and a seeded name that no longer exists gets a tombstone
+                that blocks the action instead of being silently rewritten. */}
             <div className="flex flex-col gap-1.5">
               <label
                 htmlFor="sandbox-select"
@@ -934,15 +962,33 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
                   <option value="">Use instance default</option>
                 )}
                 <option value="off">off (run on the host)</option>
-                <option value="full" disabled={dockerUnavailable}>
-                  {dockerUnavailable ? "full (Docker unavailable)" : "full (Docker sandbox)"}
-                </option>
-                <option value="minimal" disabled={dockerUnavailable}>
-                  {dockerUnavailable
-                    ? "minimal (Docker unavailable)"
-                    : "minimal (Docker sandbox)"}
-                </option>
+                {sandboxProfiles.map((p) => (
+                  <option key={p.name} value={p.name} disabled={dockerUnavailable}>
+                    {dockerUnavailable
+                      ? `${p.name} (Docker unavailable)`
+                      : `${p.name} (Docker sandbox)`}
+                  </option>
+                ))}
+                {/* Tombstone: keeps the seeded value SELECTED (React would otherwise
+                    render the field blank and a save would PATCH `sandbox: null` — a
+                    silent fallback to the instance default). */}
+                {missingProfile && (
+                  <option value={sandbox} data-testid="sandbox-missing-profile">
+                    {sandbox} — missing
+                  </option>
+                )}
               </select>
+              {missingProfile && (
+                <span
+                  className="text-st-failed"
+                  style={{ fontSize: "10.5px" }}
+                  data-testid="sandbox-missing-profile-warning"
+                >
+                  No staging profile named <span className="font-mono">{sandbox}</span> any
+                  more. Pick another one (or <span className="font-mono">off</span>) — a Run
+                  on a missing profile fails at launch, it does not fall back to a default.
+                </span>
+              )}
               {dockerUnavailable && (
                 <span
                   className="text-fg-4"

--- a/frontend/src/components/SettingsModal.test.tsx
+++ b/frontend/src/components/SettingsModal.test.tsx
@@ -5,6 +5,12 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 const fetchSettingsMock = vi.fn();
 const updateSettingsMock = vi.fn();
 const browseFsMock = vi.fn();
+// #432: the staging-profile drill-down. EVERY new api function must be in the factory
+// below — see the Proxy note there.
+const fetchSandboxProfilesMock = vi.fn();
+const saveSandboxProfileMock = vi.fn();
+const deleteSandboxProfileMock = vi.fn();
+const fetchSandboxProfileReferentsMock = vi.fn();
 
 // #431: `browseFs` MUST be in this factory now that the Dockerfile picker renders
 // `FsExplorerModal`. Vitest 4 wraps the factory's return in a Proxy whose `get` trap
@@ -19,11 +25,18 @@ vi.mock("../api", () => ({
   fetchSettings: (...args: unknown[]) => fetchSettingsMock(...args),
   updateSettings: (...args: unknown[]) => updateSettingsMock(...args),
   browseFs: (...args: unknown[]) => browseFsMock(...args),
+  // #432: same Proxy trap as `browseFs` above — a missing key here throws the moment the
+  // staging-profile panel mounts, not at import.
+  fetchSandboxProfiles: (...args: unknown[]) => fetchSandboxProfilesMock(...args),
+  saveSandboxProfile: (...args: unknown[]) => saveSandboxProfileMock(...args),
+  deleteSandboxProfile: (...args: unknown[]) => deleteSandboxProfileMock(...args),
+  fetchSandboxProfileReferents: (...args: unknown[]) =>
+    fetchSandboxProfileReferentsMock(...args),
 }));
 
-import SettingsModal from "./SettingsModal";
+import SettingsModal, { relativiseToHome } from "./SettingsModal";
 import { useEditStore } from "../stores/editStore";
-import type { InstanceSettings } from "../types";
+import type { InstanceSettings, SandboxProfile } from "../types";
 
 function sample(overrides: Partial<InstanceSettings> = {}): InstanceSettings {
   return {
@@ -36,7 +49,7 @@ function sample(overrides: Partial<InstanceSettings> = {}): InstanceSettings {
     // Image source (#411): built-in default `registry`, nothing stored/env.
     image_source: { effective: "registry", source: "default", stored: null, env: null, default: "registry" },
     // Default sandbox (#410): built-in default `off`, nothing stored/env.
-    default_sandbox: { effective: "off", source: "default", stored: null, env: null, default: "off" },
+    default_sandbox: { effective: "off", source: "default", stored: null, env: null, default: "off", reason: null },
     // Dockerfile path (#431): nothing stored/env, so the seeded default wins.
     dockerfile_path: {
       effective: "/home/user/.pdo/sandbox/Dockerfile",
@@ -49,6 +62,14 @@ function sample(overrides: Partial<InstanceSettings> = {}): InstanceSettings {
     sandbox_image: { tag: "pdo-sandbox:h-9a67637571a4", reason: null },
     // Advisory Docker probe (#410): available by default in the fixture.
     sandbox_docker: { available: true, reason: null, checked_at: "2026-07-01T10:00:00.000Z" },
+    // Staging profiles (#432): the two virtual defaults, no materialised row. NAMES ONLY —
+    // the editor reads `GET /settings/sandbox-profiles` for the entry lists.
+    sandbox_profiles: [
+      { name: "full", virtual: true },
+      { name: "minimal", virtual: true },
+    ],
+    // Host `$HOME` (#432): what turns an explorer pick into a `$HOME`-relative entry.
+    home: "/home/user",
     updated_at: "2026-07-01T10:00:00.000Z",
     ...overrides,
   };
@@ -77,12 +98,108 @@ const BROWSE_HOME = {
   error: null,
 };
 
+/**
+ * One staging profile as `GET /settings/sandbox-profiles/{name}` serves it (#432).
+ *
+ * `full` gets three of the nine real default entries — enough to exercise the checkbox,
+ * the class-(b) "re-synthesised" copy and the disk-cost note without pinning the whole
+ * constant, which is the daemon's business (and has its own Rust golden).
+ */
+function profileFixture(
+  name: string,
+  overrides: Partial<SandboxProfile> = {},
+): SandboxProfile {
+  const isMinimal = name === "minimal";
+  return {
+    name,
+    virtual: name === "full" || isMinimal,
+    materialised: false,
+    disabled: [],
+    extras: [],
+    resolved: isMinimal ? [] : [".claude/settings.json", ".claude/plugins", ".claude/skills"],
+    entries: isMinimal
+      ? []
+      : [
+          {
+            path: ".claude/settings.json",
+            kind: "file",
+            from_default: true,
+            enabled: true,
+            resynthesised: true,
+            note: "Unchecked, a one-key settings.json is synthesised instead — not absent.",
+            sensitive: false,
+            exists: true,
+          },
+          {
+            path: ".claude/plugins",
+            kind: "dir",
+            from_default: true,
+            enabled: true,
+            resynthesised: false,
+            note: "≈1 GB per run, dominated by plugins/*/node_modules.",
+            sensitive: false,
+            exists: true,
+          },
+          {
+            path: ".claude/skills",
+            kind: "dir",
+            from_default: true,
+            enabled: true,
+            resynthesised: false,
+            note: null,
+            sensitive: false,
+            exists: true,
+          },
+        ],
+    redundant_extras: [],
+    inactive_disabled: [],
+    floor: [
+      { id: "credentials", label: "Valid Claude credentials", path: ".claude/.credentials.json" },
+      { id: "empty-projects", label: "An empty projects/ transcript sink", path: ".claude/projects" },
+    ],
+    sensitive_prefixes: [".ssh", ".aws", ".gnupg"],
+    updated_at: null,
+    ...overrides,
+  };
+}
+
+/** Reset + default the four profile mocks. Shared by every `beforeEach` in this file. */
+function resetProfileMocks() {
+  fetchSandboxProfilesMock.mockReset();
+  saveSandboxProfileMock.mockReset();
+  deleteSandboxProfileMock.mockReset();
+  fetchSandboxProfileReferentsMock.mockReset();
+  fetchSandboxProfilesMock.mockResolvedValue({
+    profiles: [profileFixture("full"), profileFixture("minimal")],
+    home: "/home/user",
+  });
+  saveSandboxProfileMock.mockImplementation((name: string) =>
+    Promise.resolve(profileFixture(name, { materialised: true })),
+  );
+  deleteSandboxProfileMock.mockResolvedValue(undefined);
+  fetchSandboxProfileReferentsMock.mockResolvedValue({
+    name: "full",
+    instance_default: false,
+    triggers: [],
+    runs: [],
+  });
+}
+
 describe("SettingsModal", () => {
   beforeEach(() => {
     fetchSettingsMock.mockReset();
     updateSettingsMock.mockReset();
     browseFsMock.mockReset();
     browseFsMock.mockResolvedValue(BROWSE_HOME);
+    resetProfileMocks();
+    fetchSandboxProfilesMock.mockReset();
+    saveSandboxProfileMock.mockReset();
+    deleteSandboxProfileMock.mockReset();
+    fetchSandboxProfileReferentsMock.mockReset();
+    fetchSandboxProfilesMock.mockResolvedValue({
+      profiles: [profileFixture("full"), profileFixture("minimal", { virtual: true })],
+      home: "/home/user",
+    });
   });
 
   it("renders nothing when closed", () => {
@@ -305,6 +422,7 @@ describe("SettingsModal", () => {
           stored: "minimal",
           env: null,
           default: "off",
+          reason: null,
         },
       }),
     );
@@ -323,6 +441,7 @@ describe("SettingsModal", () => {
           stored: "full",
           env: null,
           default: "off",
+          reason: null,
         },
       }),
     );
@@ -357,6 +476,7 @@ describe("SettingsModal", () => {
           stored: "minimal",
           env: "full",
           default: "off",
+          reason: null,
         },
       }),
     );
@@ -376,6 +496,7 @@ describe("SettingsModal — sandbox Dockerfile (#431)", () => {
     updateSettingsMock.mockReset();
     browseFsMock.mockReset();
     browseFsMock.mockResolvedValue(BROWSE_HOME);
+    resetProfileMocks();
   });
 
   const stored = (path: string) =>
@@ -604,5 +725,317 @@ describe("SettingsModal — Interface / single-tab toggle (#342)", () => {
     render(<SettingsModal open onClose={() => {}} />);
     const toggle = await screen.findByTestId("setting-tabs-disabled");
     expect(toggle).toHaveAttribute("aria-checked", "true");
+  });
+});
+
+// --- Staging profiles (#432, ADR-0031 §2-§7) ---------------------------------
+
+describe("relativiseToHome (#432)", () => {
+  // The pure half of "an explorer pick becomes an entry": `onPick` yields an ABSOLUTE
+  // path, an entry is RELATIVE to `$HOME`. Returning `null` (instead of guessing) is what
+  // lets the panel say "must live under $HOME" inline rather than firing a doomed PUT.
+  it("relativises a path under $HOME and refuses anything else", () => {
+    expect(relativiseToHome("/home/user/.gitconfig", "/home/user")).toBe(".gitconfig");
+    expect(relativiseToHome("/home/user/.config/gh", "/home/user")).toBe(".config/gh");
+    // A trailing slash on either side must not leak into the entry.
+    expect(relativiseToHome("/home/user/.config/gh/", "/home/user/")).toBe(".config/gh");
+    // Outside $HOME, $HOME itself, and an unknown $HOME are all `null`.
+    expect(relativiseToHome("/etc/passwd", "/home/user")).toBeNull();
+    expect(relativiseToHome("/home/user", "/home/user")).toBeNull();
+    expect(relativiseToHome("/home/user2/.gitconfig", "/home/user")).toBeNull();
+    expect(relativiseToHome("/home/user/.gitconfig", null)).toBeNull();
+  });
+});
+
+describe("SettingsModal — default sandbox is profile-driven (#432)", () => {
+  beforeEach(() => {
+    fetchSettingsMock.mockReset();
+    updateSettingsMock.mockReset();
+    browseFsMock.mockReset();
+    browseFsMock.mockResolvedValue(BROWSE_HOME);
+    resetProfileMocks();
+  });
+
+  it("lists off plus every profile the daemon serves", async () => {
+    fetchSettingsMock.mockResolvedValue(
+      sample({
+        sandbox_profiles: [
+          { name: "full", virtual: true },
+          { name: "full-no-mcp", virtual: false },
+          { name: "minimal", virtual: true },
+        ],
+      }),
+    );
+    render(<SettingsModal open onClose={() => {}} />);
+    const select = (await screen.findByTestId("setting-default-sandbox")) as HTMLSelectElement;
+    expect(Array.from(select.options).map((o) => o.value)).toEqual([
+      "off",
+      "full",
+      "full-no-mcp",
+      "minimal",
+    ]);
+  });
+
+  /**
+   * THE PHANTOM-PROFILE RULE. A stored name absent from the list keeps a tombstone option
+   * and blocks Save. Without it React would set `selectedIndex = -1`, render the field
+   * blank, and the next Save would clear the knob — a **silent fallback to `off`**, which
+   * is exactly the demotion ADR-0031 §7 forbids.
+   */
+  it("keeps a vanished stored profile selected, and blocks Save", async () => {
+    fetchSettingsMock.mockResolvedValue(
+      sample({
+        default_sandbox: {
+          effective: "gone",
+          source: "stored",
+          stored: "gone",
+          env: null,
+          default: "off",
+          reason: "no staging profile named `gone` — every Run that falls back to this default will fail at launch (tier: stored)",
+        },
+      }),
+    );
+    render(<SettingsModal open onClose={() => {}} />);
+    const select = (await screen.findByTestId("setting-default-sandbox")) as HTMLSelectElement;
+    expect(select.value).toBe("gone");
+    expect(screen.getByTestId("setting-default-sandbox-missing")).toBeInTheDocument();
+    // The daemon-supplied reason is rendered (the env tier passes no validator, so this is
+    // the only place a dangling default is visible before a launch 400s).
+    expect(screen.getByTestId("setting-default-sandbox-reason")).toHaveTextContent(/gone/);
+
+    fireEvent.click(screen.getByTestId("settings-save"));
+    await waitFor(() =>
+      expect(screen.getByTestId("settings-error")).toHaveTextContent(/gone/),
+    );
+    expect(updateSettingsMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("SettingsModal — staging profiles panel (#432)", () => {
+  beforeEach(() => {
+    fetchSettingsMock.mockReset();
+    updateSettingsMock.mockReset();
+    browseFsMock.mockReset();
+    browseFsMock.mockResolvedValue(BROWSE_HOME);
+    resetProfileMocks();
+    fetchSettingsMock.mockResolvedValue(sample());
+  });
+
+  async function openPanel() {
+    render(<SettingsModal open onClose={() => {}} />);
+    fireEvent.click(await screen.findByTestId("setting-manage-staging-profiles"));
+    return screen.findByTestId("staging-profiles-panel");
+  }
+
+  /**
+   * The drill-down HIDES the form, it does not unmount it. `SettingsForm` holds UNSAVED
+   * edits seeded on mount, so a conditional render would discard them in silence — the
+   * exact reason the panel is a sibling with a `hidden` class rather than an `? :`.
+   */
+  it("hides the settings form without discarding its unsaved edits", async () => {
+    await openPanel();
+    const cap = screen.getByTestId("setting-session-cap") as HTMLInputElement;
+    // Still mounted (hence still holding state) while the panel is open…
+    expect(cap).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("staging-profiles-back"));
+    await waitFor(() =>
+      expect(screen.queryByTestId("staging-profiles-panel")).not.toBeInTheDocument(),
+    );
+    fireEvent.change(cap, { target: { value: "7" } });
+    fireEvent.click(screen.getByTestId("setting-manage-staging-profiles"));
+    await screen.findByTestId("staging-profiles-panel");
+    fireEvent.click(screen.getByTestId("staging-profiles-back"));
+    await waitFor(() =>
+      expect(
+        (screen.getByTestId("setting-session-cap") as HTMLInputElement).value,
+      ).toBe("7"),
+    );
+  });
+
+  it("unchecking a default entry PUTs the diff, not a snapshot", async () => {
+    await openPanel();
+    const entry = await screen.findByTestId("staging-entry-.claude/plugins");
+    fireEvent.click(entry.querySelector("input[type=checkbox]")!);
+
+    await waitFor(() => expect(saveSandboxProfileMock).toHaveBeenCalledTimes(1));
+    // The DIFF: the one unchecked path, and no `resolved` snapshot. A snapshot would
+    // freeze the install out of every future default entry (ADR-0031 §2).
+    expect(saveSandboxProfileMock).toHaveBeenCalledWith("full", {
+      disabled: [".claude/plugins"],
+      extras: [],
+    });
+  });
+
+  it("shows the read-only floor block, even for minimal (which has no entries)", async () => {
+    await openPanel();
+    fireEvent.click(await screen.findByTestId("staging-profile-row-minimal"));
+    // Without this block the screen looks broken and the user wrongly concludes the
+    // container starts with no credentials.
+    await waitFor(() =>
+      expect(screen.getByTestId("staging-profile-floor")).toHaveTextContent(/credentials/i),
+    );
+    expect(screen.getByTestId("staging-profile-no-default-entries")).toHaveTextContent(
+      /is.*the\s+floor/i,
+    );
+  });
+
+  it("relativises an explorer pick into a $HOME-relative extra", async () => {
+    await openPanel();
+    fireEvent.click(await screen.findByTestId("staging-extra-add-file"));
+    // The generic explorer, consumed UNCHANGED (#431): select-then-confirm in file mode.
+    const rows = await screen.findAllByTestId("fs-browse-entry");
+    fireEvent.click(rows.find((r) => r.textContent?.includes("sbx.Dockerfile"))!);
+    fireEvent.click(screen.getByTestId("fs-browse-select"));
+
+    await waitFor(() => expect(saveSandboxProfileMock).toHaveBeenCalledTimes(1));
+    expect(saveSandboxProfileMock).toHaveBeenCalledWith("full", {
+      disabled: [],
+      extras: ["sbx.Dockerfile"],
+    });
+  });
+
+  it("refuses a pick outside $HOME inline instead of firing a doomed PUT", async () => {
+    browseFsMock.mockResolvedValue({
+      path: "/etc",
+      parent: "/",
+      entries: [
+        { name: "passwd", path: "/etc/passwd", is_git_repo: false, is_symlink: false, is_dir: false },
+      ],
+      truncated: false,
+      error: null,
+    });
+    await openPanel();
+    fireEvent.click(await screen.findByTestId("staging-extra-add-file"));
+    fireEvent.click((await screen.findAllByTestId("fs-browse-entry"))[0]);
+    fireEvent.click(screen.getByTestId("fs-browse-select"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("staging-profiles-error")).toHaveTextContent(
+        /must live under your home directory/i,
+      ),
+    );
+    expect(saveSandboxProfileMock).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The referents dialog is the whole of AC10, and it must say the two things nothing else
+   * in the UI says: deleting does NOT repoint the referents (their next Run fails), while
+   * live Runs already froze their list and are unaffected.
+   */
+  it("lists referents before confirming a delete", async () => {
+    fetchSandboxProfilesMock.mockResolvedValue({
+      profiles: [profileFixture("full", { materialised: true }), profileFixture("minimal")],
+      home: "/home/user",
+    });
+    fetchSandboxProfileReferentsMock.mockResolvedValue({
+      name: "full",
+      instance_default: true,
+      triggers: [{ id: "trg-1", name: "Nightly audit", enabled: true }],
+      runs: [{ run_id: "r1", pipeline_name: "p", name: null }],
+    });
+    await openPanel();
+    fireEvent.click(await screen.findByTestId("staging-profile-delete-full"));
+
+    const dialog = await screen.findByTestId("staging-profile-delete-dialog");
+    expect(dialog).toHaveTextContent(/will\s+not\s+repoint/i);
+    expect(dialog).toHaveTextContent(/fails/i);
+    expect(screen.getByTestId("staging-profile-referents")).toHaveTextContent("Nightly audit");
+    expect(screen.getByTestId("staging-profile-referents")).toHaveTextContent(
+      /Instance default sandbox/i,
+    );
+    expect(screen.getByTestId("staging-profile-referent-runs")).toHaveTextContent(/unaffected/i);
+    // Nothing deleted until the user confirms.
+    expect(deleteSandboxProfileMock).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByTestId("staging-profile-delete-confirm"));
+    await waitFor(() => expect(deleteSandboxProfileMock).toHaveBeenCalledWith("full"));
+  });
+
+  it("offers no delete for an unedited built-in default (there is no row)", async () => {
+    await openPanel();
+    await screen.findByTestId("staging-profile-row-full");
+    expect(screen.queryByTestId("staging-profile-delete-full")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("staging-profile-delete-minimal")).not.toBeInTheDocument();
+  });
+
+  it("creates a profile with a blank diff (a copy of the current default)", async () => {
+    await openPanel();
+    fireEvent.click(await screen.findByTestId("staging-profile-new"));
+    fireEvent.change(screen.getByTestId("staging-profile-new-name"), {
+      target: { value: "full-no-mcp" },
+    });
+    fireEvent.click(screen.getByTestId("staging-profile-create"));
+    await waitFor(() =>
+      expect(saveSandboxProfileMock).toHaveBeenCalledWith("full-no-mcp", {
+        disabled: [],
+        extras: [],
+      }),
+    );
+  });
+
+  it("surfaces the daemon's 400 verbatim", async () => {
+    saveSandboxProfileMock.mockRejectedValue(
+      new Error("`/etc/passwd`: an entry is relative to $HOME, not an absolute path"),
+    );
+    await openPanel();
+    const entry = await screen.findByTestId("staging-entry-.claude/plugins");
+    fireEvent.click(entry.querySelector("input[type=checkbox]")!);
+    await waitFor(() =>
+      expect(screen.getByTestId("staging-profiles-error")).toHaveTextContent(
+        /relative to \$HOME/,
+      ),
+    );
+  });
+
+  it("reports a remembered-but-inactive disabled entry as a no-op, not an error", async () => {
+    fetchSandboxProfilesMock.mockResolvedValue({
+      profiles: [
+        profileFixture("full", {
+          materialised: true,
+          disabled: [".claude/future-thing"],
+          inactive_disabled: [".claude/future-thing"],
+        }),
+        profileFixture("minimal"),
+      ],
+      home: "/home/user",
+    });
+    await openPanel();
+    // ADR-0031 §2: unchecking an entry a FUTURE release will add must be remembered, so
+    // the day it lands the profile still says no.
+    await waitFor(() =>
+      expect(screen.getByTestId("staging-profile-inactive-disabled")).toHaveTextContent(
+        ".claude/future-thing",
+      ),
+    );
+    expect(screen.queryByTestId("staging-profiles-error")).not.toBeInTheDocument();
+  });
+
+  it("marks a sensitive extra without refusing it (ADR-0031 §3)", async () => {
+    fetchSandboxProfilesMock.mockResolvedValue({
+      profiles: [
+        profileFixture("full", {
+          materialised: true,
+          extras: [".ssh"],
+          entries: [
+            ...profileFixture("full").entries,
+            {
+              path: ".ssh",
+              kind: "dir",
+              from_default: false,
+              enabled: true,
+              resynthesised: false,
+              note: null,
+              sensitive: true,
+              exists: true,
+            },
+          ],
+        }),
+      ],
+      home: "/home/user",
+    });
+    await openPanel();
+    expect(await screen.findByTestId("staging-extra-sensitive-.ssh")).toBeInTheDocument();
+    expect(screen.getByTestId("staging-profile-sensitive-warning")).toHaveTextContent(/.ssh/);
   });
 });

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -1,10 +1,20 @@
-import { useState } from "react";
-import { Search, X } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { ChevronLeft, Plus, Search, Trash2, X } from "lucide-react";
 import FsExplorerModal from "./FsExplorerModal";
 import { useSettings } from "../hooks/useSettings";
 import { useEditStore } from "../stores/editStore";
+import {
+  deleteSandboxProfile,
+  fetchSandboxProfileReferents,
+  fetchSandboxProfiles,
+  saveSandboxProfile,
+} from "../api";
 import type {
+  EnumSettingFieldWithReason,
   InstanceSettings,
+  SandboxProfile,
+  SandboxProfileEntry,
+  SandboxProfileReferents,
   SettingField,
   StringSettingField,
   UpdateSettingsRequest,
@@ -41,14 +51,34 @@ interface Props {
  * seeding race).
  */
 export default function SettingsModal({ open, onClose, liveSessions = 0, onSaved }: Props) {
-  const { settings, save } = useSettings(open);
+  const { settings, save, refresh } = useSettings(open);
+  /**
+   * Staging-profile editor (#432): a **drill-down panel** replacing body + footer inside
+   * this same `z-50` shell, not a nested modal.
+   *
+   * Why not a real nested modal: `FsExplorerModal` hardcodes `z-[60]` with no prop, so a
+   * modal-in-modal would force the picker to `z-[70]` (a new prop on a component #431 just
+   * froze) and the delete confirmation to `z-[80]`. Staying in the shell keeps today's
+   * layering exactly: shell `z-50` → picker `z-[60]` (already proven by the Dockerfile
+   * picker below) → confirmation `z-[60]` rendered later in DOM order.
+   */
+  const [profilesOpen, setProfilesOpen] = useState(false);
+
+  // The modal is unmounted-by-render (`if (!open) return null`), so its state SURVIVES a
+  // close. Reset the drill-down here rather than in an effect on `open`: both the backdrop
+  // and the ✕ funnel through this handler, and an effect would be a setState-in-effect
+  // cascade for a transition we already own.
+  const handleClose = () => {
+    setProfilesOpen(false);
+    onClose();
+  };
 
   if (!open) return null;
 
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-      onClick={onClose}
+      onClick={handleClose}
     >
       <div
         className="w-[460px] max-h-[85vh] flex flex-col rounded-lg border border-line bg-bg-4 shadow-xl"
@@ -56,13 +86,25 @@ export default function SettingsModal({ open, onClose, liveSessions = 0, onSaved
         data-testid="settings-modal"
       >
         <div className="flex items-center justify-between border-b border-line px-4 py-3">
-          <h2 className="font-semibold text-fg" style={{ fontSize: "13.5px" }}>
-            Instance settings
-          </h2>
+          <div className="flex min-w-0 items-center gap-2">
+            {profilesOpen && (
+              <button
+                onClick={() => setProfilesOpen(false)}
+                aria-label="Back to settings"
+                data-testid="staging-profiles-back"
+                className="grid h-6 w-6 shrink-0 place-items-center rounded text-fg-3 transition-colors hover:bg-bg-5 hover:text-fg"
+              >
+                <ChevronLeft size={14} />
+              </button>
+            )}
+            <h2 className="truncate font-semibold text-fg" style={{ fontSize: "13.5px" }}>
+              {profilesOpen ? "Staging profiles" : "Instance settings"}
+            </h2>
+          </div>
           <button
-            onClick={onClose}
+            onClick={handleClose}
             aria-label="Close settings"
-            className="grid h-6 w-6 place-items-center rounded text-fg-3 transition-colors hover:bg-bg-5 hover:text-fg"
+            className="grid h-6 w-6 shrink-0 place-items-center rounded text-fg-3 transition-colors hover:bg-bg-5 hover:text-fg"
           >
             <X size={14} />
           </button>
@@ -71,19 +113,36 @@ export default function SettingsModal({ open, onClose, liveSessions = 0, onSaved
         {/* Interface (#342): a per-client UI pref, NOT a daemon knob. It lives in
             the OUTER modal (always rendered when open), so it stays reachable
             even if `GET /settings` fails and the numeric form never mounts
-            (Trap A). */}
-        <InterfaceSection />
+            (Trap A). Hidden — not unmounted — behind the drill-down, same reason
+            as `SettingsForm` below. */}
+        <div className={profilesOpen ? "hidden" : undefined}>
+          <InterfaceSection />
+        </div>
 
         {settings ? (
-          <SettingsForm
-            // Re-seed if the loaded config changes (refetch / restart).
-            key={settings.updated_at}
-            settings={settings}
-            liveSessions={liveSessions}
-            save={save}
-            onClose={onClose}
-            onSaved={onSaved}
-          />
+          // HIDDEN, never unmounted, while the drill-down is open (#432): the form holds
+          // UNSAVED edits (`capStr`, `dockerfilePath`) seeded on mount, and a conditional
+          // render would throw them away in silence.
+          <div
+            className={
+              profilesOpen ? "hidden" : "flex min-h-0 flex-1 flex-col"
+            }
+          >
+            <SettingsForm
+              // Re-seed if the loaded config changes (refetch / restart, or a profile write
+              // that changed the name list).
+              // NOT keyed on the profile list: a profile write must refresh the
+              // `<select>` OPTIONS (a render-time prop) without re-seeding — and thus
+              // discarding — the form's unsaved edits.
+              key={settings.updated_at}
+              settings={settings}
+              liveSessions={liveSessions}
+              save={save}
+              onClose={handleClose}
+              onSaved={onSaved}
+              onManageProfiles={() => setProfilesOpen(true)}
+            />
+          </div>
         ) : (
           <div
             className="px-4 py-6 text-fg-4"
@@ -92,6 +151,19 @@ export default function SettingsModal({ open, onClose, liveSessions = 0, onSaved
           >
             Loading…
           </div>
+        )}
+
+        {profilesOpen && (
+          <StagingProfilesPanel
+            home={settings?.home ?? null}
+            onDone={() => setProfilesOpen(false)}
+            // Refetch `GET /settings` so the Default-sandbox `<select>` sees the new
+            // name list (and a freshly dangling `reason`) without a reopen.
+            onChanged={() => {
+              void refresh();
+              onSaved?.();
+            }}
+          />
         )}
       </div>
     </div>
@@ -155,9 +227,18 @@ interface FormProps {
   save: (patch: UpdateSettingsRequest) => Promise<InstanceSettings>;
   onClose: () => void;
   onSaved?: () => void;
+  /** Open the staging-profile drill-down (#432). */
+  onManageProfiles: () => void;
 }
 
-function SettingsForm({ settings, liveSessions, save, onClose, onSaved }: FormProps) {
+function SettingsForm({
+  settings,
+  liveSessions,
+  save,
+  onClose,
+  onSaved,
+  onManageProfiles,
+}: FormProps) {
   // Seed synchronously from the loaded effective values — correct on first render.
   const [capStr, setCapStr] = useState(() => String(settings.session_cap.effective));
   const [ttlStr, setTtlStr] = useState(() => String(settings.reaper_ttl_secs.effective));
@@ -170,11 +251,18 @@ function SettingsForm({ settings, liveSessions, save, onClose, onSaved }: FormPr
   const [imageSource, setImageSource] = useState<string>(
     () => settings.image_source.effective ?? "registry",
   );
-  // Default sandbox mode (#410): a closed enum with a built-in `off` default, so
-  // `effective` is always present (the `?? "off"` is belt-and-braces).
+  // Default sandbox (#410/#432): `off` or a staging-profile name. `effective` is always
+  // a present string (the `?? "off"` is belt-and-braces).
   const [defaultSandbox, setDefaultSandbox] = useState<string>(
     () => settings.default_sandbox.effective ?? "off",
   );
+  // #432 phantom-profile rule, mirror of the launch dialog's: a seeded value that is not
+  // in the list gets a tombstone option and blocks Save, instead of rendering blank and
+  // clearing the knob on the next Save.
+  const missingDefaultProfile =
+    defaultSandbox !== "off" &&
+    defaultSandbox !== "" &&
+    !settings.sandbox_profiles.some((p) => p.name === defaultSandbox);
   // Sandbox Dockerfile path (#431). DELIBERATE DEVIATION from the `default_model`
   // idiom: seeded from `stored`, not `effective`. This knob's default IS a real
   // non-null path, so seeding from `effective` would show the seeded path in the input
@@ -190,6 +278,14 @@ function SettingsForm({ settings, liveSessions, save, onClose, onSaved }: FormPr
   const handleSave = async () => {
     if (submitting) return;
     setError(null);
+
+    if (missingDefaultProfile) {
+      setError(
+        `No staging profile named \`${defaultSandbox}\` any more. Pick another one (or ` +
+          "`off`) — a Run that falls back to a missing profile fails at launch.",
+      );
+      return;
+    }
 
     const patch: UpdateSettingsRequest = {};
 
@@ -385,10 +481,10 @@ function SettingsForm({ settings, liveSessions, save, onClose, onSaved }: FormPr
           </div>
         </div>
 
-        {/* Default sandbox mode (#410): the isolation mode a Run uses when neither
-            the NewRunModal nor a firing Trigger specifies one. A closed enum →
-            native <select> (mirror of image_source). It only emits a concrete
-            variant; the "" clear sentinel is backend-only. */}
+        {/* Default sandbox (#410/#432): what a Run uses when neither the launch dialog
+            nor a firing Trigger picks one. Since #432 the options are DATA — `off` plus
+            the instance's staging profiles — so this is no longer a closed enum, and a
+            stored name can dangle (see the tombstone and the daemon-supplied `reason`). */}
         <div className="flex flex-col gap-1.5">
           <label
             htmlFor="setting-default-sandbox"
@@ -406,15 +502,47 @@ function SettingsForm({ settings, liveSessions, save, onClose, onSaved }: FormPr
             style={{ fontSize: "12px" }}
           >
             <option value="off">off (run on the host)</option>
-            <option value="full">full (Docker, replica of your Claude home)</option>
-            <option value="minimal">minimal (Docker, staging floor only)</option>
+            {settings.sandbox_profiles.map((p) => (
+              <option key={p.name} value={p.name}>
+                {p.name}
+                {p.virtual ? " (built-in)" : ""}
+              </option>
+            ))}
+            {/* Tombstone (same rule as the launch dialog): a seeded value is NEVER
+                silently rewritten. Without it React would render the field blank and a
+                Save would clear the knob — a silent fallback to `off`. */}
+            {missingDefaultProfile && (
+              <option value={defaultSandbox} data-testid="setting-default-sandbox-missing">
+                {defaultSandbox} — missing
+              </option>
+            )}
           </select>
           <div className="text-fg-4" style={{ fontSize: "10.5px" }}>
-            The isolation mode a Run uses when neither the launch dialog nor a firing
-            Trigger picks one. <span className="font-mono">off</span> runs on the host;{" "}
-            <span className="font-mono">full</span> and <span className="font-mono">minimal</span>{" "}
-            run inside a Docker sandbox (require Docker).
+            What a Run uses when neither the launch dialog nor a firing Trigger picks one.{" "}
+            <span className="font-mono">off</span> runs on the host; a{" "}
+            <span className="font-mono">staging profile</span> runs it inside a Docker
+            sandbox with that profile's home content (requires Docker).
           </div>
+          <button
+            type="button"
+            onClick={onManageProfiles}
+            data-testid="setting-manage-staging-profiles"
+            className="self-start rounded-md border border-line-strong bg-bg-3 px-2.5 py-1 text-fg-2 transition-colors hover:border-acc hover:bg-bg-4"
+            style={{ fontSize: "11px" }}
+          >
+            Manage staging profiles…
+          </button>
+          {/* Server-supplied, because the `env` tier passes through no validator at all:
+              a `PDO_DEFAULT_SANDBOX` naming a vanished profile is only visible here. */}
+          {settings.default_sandbox.reason && (
+            <div
+              className="text-st-failed"
+              style={{ fontSize: "10.5px" }}
+              data-testid="setting-default-sandbox-reason"
+            >
+              {settings.default_sandbox.reason}
+            </div>
+          )}
           <div
             className="text-fg-3"
             style={{ fontSize: "10.5px" }}
@@ -685,8 +813,9 @@ function dockerfilePathSourceNote(field: StringSettingField): string {
 }
 
 /** Which tier the instance default_sandbox comes from (#410). Like image_source there
- *  IS a built-in default (`off`). Discloses a shadowed env var too. */
-function defaultSandboxSourceNote(field: StringSettingField): string {
+ *  IS a built-in default (`off`). Discloses a shadowed env var too. The dangling-profile
+ *  `reason` is rendered separately — it is a health signal, not a precedence note. */
+function defaultSandboxSourceNote(field: EnumSettingFieldWithReason): string {
   const envDisplay = field.env ? `PDO_DEFAULT_SANDBOX=${field.env}` : null;
   if (field.source === "stored") {
     return envDisplay
@@ -697,4 +826,626 @@ function defaultSandboxSourceNote(field: StringSettingField): string {
     return `Source: env ${envDisplay ?? "PDO_DEFAULT_SANDBOX"}.`;
   }
   return `Source: built-in default (${field.default ?? "off"}).`;
+}
+
+// --- Staging profiles (#432, ADR-0031 §2-§7) ---------------------------------
+
+/**
+ * Turn an absolute path from {@link FsExplorerModal} into a `$HOME`-relative profile
+ * entry. `null` when it does not live under `$HOME` (or `$HOME` is unknown), so the caller
+ * can say so inline instead of firing a `PUT` the daemon will 400.
+ *
+ * A pure helper next to {@link dockerfileStartDir}, and the reason `GET /settings` grew a
+ * `home` field: `onPick` yields an ABSOLUTE path, an entry is RELATIVE, and no endpoint
+ * exposed `$HOME` before this. Do NOT string-surgery `dockerfile_path.default` for it —
+ * that value is `null` when `HOME` is absent and it lives behind the
+ * `sandbox_home_override` seam. The daemon revalidates at the edge regardless.
+ */
+// Exported for its own unit test. Precedent: `RUN_INTENT` in `NewRunModal.tsx` — a pure,
+// render-free value whose Fast-Refresh cost is nil, opted out one line at a time rather
+// than moved to a module of its own.
+// eslint-disable-next-line react-refresh/only-export-components
+export function relativiseToHome(abs: string, home: string | null): string | null {
+  if (!home) return null;
+  const h = home.replace(/\/+$/, "");
+  if (abs === h) return null; // `$HOME` itself is not an entry
+  const prefix = `${h}/`;
+  if (!abs.startsWith(prefix)) return null;
+  const rel = abs.slice(prefix.length).replace(/\/+$/, "");
+  return rel.length > 0 ? rel : null;
+}
+
+interface PanelProps {
+  /** Host `$HOME`, from `GET /settings`. `null` disables the pickers' relativisation. */
+  home: string | null;
+  onDone: () => void;
+  /** Called after every successful write so the parent can refetch `GET /settings`. */
+  onChanged: () => void;
+}
+
+/**
+ * The staging-profile editor: a list of profiles on top, the selected one's entries below.
+ *
+ * Two things it deliberately does NOT do:
+ * - it never computes a warning or a size itself. The disk-cost note, the `sensitive` flag
+ *   and the floor block all arrive from the daemon (#373 discipline: a client-side tag
+ *   re-opens exactly the drift that cost us before). A real recursive walk of every
+ *   `node_modules` under `plugins/` is seconds of IO anyway.
+ * - it never batches. Each toggle / add / remove is its own `PUT`, which is why the footer
+ *   says **Done** and not Save — profiles are their own REST resource, not part of the
+ *   grouped `PUT /settings`.
+ */
+function StagingProfilesPanel({ home, onDone, onChanged }: PanelProps) {
+  const [profiles, setProfiles] = useState<SandboxProfile[] | null>(null);
+  const [selected, setSelected] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [newName, setNewName] = useState("");
+  const [pickerMode, setPickerMode] = useState<"file" | "dir" | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState<SandboxProfileReferents | null>(null);
+
+  const load = useCallback(async (keep?: string | null) => {
+    try {
+      const { profiles: list } = await fetchSandboxProfiles();
+      setProfiles(list);
+      setSelected((cur) => {
+        const want = keep ?? cur;
+        if (want && list.some((p) => p.name === want)) return want;
+        return list[0]?.name ?? null;
+      });
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load staging profiles");
+    }
+  }, []);
+
+  // One fetch on mount — the panel is mounted only when the drill-down opens, so mounting
+  // IS "the user opened the editor". `load` sets state after its `await`, which the rule
+  // cannot see through; same trade-off and same disable as `FsExplorerModal`'s initial
+  // navigate.
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- async, see note above.
+    void load();
+  }, [load]);
+
+  const current = profiles?.find((p) => p.name === selected) ?? null;
+
+  /** Write a profile's diff, then refresh both this panel and the parent's settings. */
+  const write = useCallback(
+    async (name: string, diff: { disabled: string[]; extras: string[] }) => {
+      if (busy) return;
+      setBusy(true);
+      setError(null);
+      try {
+        await saveSandboxProfile(name, diff);
+        await load(name);
+        onChanged();
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Failed to save the profile");
+      } finally {
+        setBusy(false);
+      }
+    },
+    [busy, load, onChanged],
+  );
+
+  /**
+   * Toggle one entry. Only a BUILT-IN DEFAULT entry is toggleable: unchecking adds it to
+   * `disabled`, re-checking removes it. An extra is removed by dropping it from `extras`,
+   * never by "unchecking" it — conflating the two would make the stored diff ambiguous
+   * (and the daemon rejects a `disabled` that is not a default entry).
+   */
+  const toggleDefault = (entry: SandboxProfileEntry) => {
+    if (!current || !entry.from_default) return;
+    const disabled = entry.enabled
+      ? [...current.disabled, entry.path]
+      : current.disabled.filter((d) => d !== entry.path);
+    void write(current.name, { disabled, extras: current.extras });
+  };
+
+  const removeExtra = (path: string) => {
+    if (!current) return;
+    void write(current.name, {
+      disabled: current.disabled,
+      extras: current.extras.filter((e) => e !== path),
+    });
+  };
+
+  const addExtra = (abs: string) => {
+    if (!current) return;
+    const rel = relativiseToHome(abs, home);
+    if (!rel) {
+      setError(
+        `\`${abs}\` must live under your home directory${home ? ` (${home})` : ""} — an entry is a path relative to \`$HOME\`.`,
+      );
+      return;
+    }
+    if (current.extras.includes(rel)) return;
+    void write(current.name, {
+      disabled: current.disabled,
+      extras: [...current.extras, rel],
+    });
+  };
+
+  const create = async () => {
+    const name = newName.trim();
+    if (!name || busy) return;
+    setBusy(true);
+    setError(null);
+    try {
+      // A blank diff: "materialise this profile exactly as the current default", which is
+      // the starting point for unchecking something.
+      await saveSandboxProfile(name, { disabled: [], extras: [] });
+      setNewName("");
+      setCreating(false);
+      await load(name);
+      onChanged();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to create the profile");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  /** Ask the daemon who points at the profile BEFORE opening the confirmation. */
+  const askDelete = async (name: string) => {
+    setError(null);
+    try {
+      setConfirmDelete(await fetchSandboxProfileReferents(name));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to look up referents");
+    }
+  };
+
+  const doDelete = async (name: string) => {
+    setBusy(true);
+    setError(null);
+    try {
+      await deleteSandboxProfile(name);
+      setConfirmDelete(null);
+      await load(null);
+      onChanged();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to delete the profile");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <>
+      <div
+        className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-4 py-4"
+        data-testid="staging-profiles-panel"
+      >
+        {/* ── the profile list ── */}
+        <div className="flex flex-col gap-1">
+          {profiles == null ? (
+            <div className="text-fg-4" style={{ fontSize: "12px" }} data-testid="staging-profiles-loading">
+              Loading…
+            </div>
+          ) : (
+            profiles.map((p) => (
+              <div
+                key={p.name}
+                className={`flex items-center gap-2 rounded-md border px-2.5 py-1.5 transition-colors ${
+                  p.name === selected
+                    ? "border-acc bg-bg-3"
+                    : "border-line-strong bg-bg-3 hover:border-line"
+                }`}
+              >
+                <button
+                  type="button"
+                  onClick={() => setSelected(p.name)}
+                  data-testid={`staging-profile-row-${p.name}`}
+                  className="flex min-w-0 flex-1 items-center gap-2 text-left"
+                >
+                  <span className="truncate font-mono text-fg" style={{ fontSize: "12px" }}>
+                    {p.name}
+                  </span>
+                  <span className="shrink-0 text-fg-4" style={{ fontSize: "10px" }}>
+                    {p.materialised ? "edited" : p.virtual ? "built-in" : ""}
+                  </span>
+                </button>
+                {/* Only a MATERIALISED row can be deleted; an unedited built-in default has
+                    no row to delete (the daemon 404s), so the button is not offered. */}
+                {p.materialised && (
+                  <button
+                    type="button"
+                    onClick={() => void askDelete(p.name)}
+                    aria-label={`Delete ${p.name}`}
+                    data-testid={`staging-profile-delete-${p.name}`}
+                    className="shrink-0 rounded p-1 text-fg-4 transition-colors hover:bg-bg-5 hover:text-st-failed"
+                  >
+                    <Trash2 size={13} />
+                  </button>
+                )}
+              </div>
+            ))
+          )}
+
+          {creating ? (
+            <div className="mt-1 flex items-center gap-2">
+              <input
+                autoFocus
+                value={newName}
+                onChange={(e) => setNewName(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") void create();
+                  if (e.key === "Escape") setCreating(false);
+                }}
+                placeholder="full-no-mcp"
+                data-testid="staging-profile-new-name"
+                className="min-w-0 flex-1 rounded-md border border-line-strong bg-bg-3 px-2.5 py-1.5 font-mono text-fg placeholder:text-fg-4 focus:border-acc focus:outline-none"
+                style={{ fontSize: "12px" }}
+              />
+              <button
+                type="button"
+                onClick={() => void create()}
+                disabled={busy || newName.trim().length === 0}
+                data-testid="staging-profile-create"
+                className="shrink-0 rounded-md bg-acc px-2.5 py-1.5 font-medium text-[#04140d] transition-colors hover:bg-acc-dim disabled:opacity-40"
+                style={{ fontSize: "11px" }}
+              >
+                Create
+              </button>
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={() => setCreating(true)}
+              data-testid="staging-profile-new"
+              className="mt-1 flex items-center gap-1.5 self-start rounded-md px-1 py-1 text-fg-3 transition-colors hover:text-fg"
+              style={{ fontSize: "11px" }}
+            >
+              <Plus size={12} /> New profile
+            </button>
+          )}
+          <div className="text-fg-4" style={{ fontSize: "10.5px" }}>
+            Lowercase letters, digits and <span className="font-mono">-</span>. A new profile
+            starts as a copy of the built-in default; unchecking an entry stores the
+            difference, so a later PDO release that adds an entry still shows up here.
+          </div>
+        </div>
+
+        {error && (
+          <div
+            className="rounded-md border border-st-failed/30 bg-st-failed-bg px-3 py-2 text-st-failed"
+            style={{ fontSize: "11.5px" }}
+            data-testid="staging-profiles-error"
+          >
+            {error}
+          </div>
+        )}
+
+        {/* ── the selected profile's entries ── */}
+        {current && (
+          <div className="flex flex-col gap-3 border-t border-line pt-4">
+            <h3 className="font-medium text-fg-2" style={{ fontSize: "12px" }}>
+              <span className="font-mono">{current.name}</span> — entries
+            </h3>
+
+            {/* The FLOOR, read-only. Without this block a `minimal` profile's screen looks
+                broken and the user wrongly concludes the container starts with no
+                credentials. These are guarantees, satisfied by a host copy OR by a
+                fallback synthesis — never selectable, and refused as extras too. */}
+            <div className="flex flex-col gap-1" data-testid="staging-profile-floor">
+              <span className="text-fg-3" style={{ fontSize: "10.5px" }}>
+                Floor (always applied, not editable)
+              </span>
+              <ul className="flex flex-col gap-0.5">
+                {current.floor.map((g) => (
+                  <li key={g.id} className="flex items-baseline gap-2 text-fg-4" style={{ fontSize: "10.5px" }}>
+                    <span>· {g.label}</span>
+                    {g.path && <span className="truncate font-mono">{g.path}</span>}
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            {/* From the default: checkable. `minimal` legitimately has none — say so
+                explicitly, or the empty area reads as a loading failure. */}
+            <div className="flex flex-col gap-1.5">
+              <span className="text-fg-3" style={{ fontSize: "10.5px" }}>
+                From the default
+              </span>
+              {current.entries.filter((e) => e.from_default).length === 0 ? (
+                <span
+                  className="text-fg-4"
+                  style={{ fontSize: "10.5px" }}
+                  data-testid="staging-profile-no-default-entries"
+                >
+                  No entries — <span className="font-mono">{current.name}</span> <em>is</em> the
+                  floor.
+                </span>
+              ) : (
+                current.entries
+                  .filter((e) => e.from_default)
+                  .map((e) => (
+                    <label
+                      key={e.path}
+                      className="flex cursor-pointer items-start gap-2"
+                      data-testid={`staging-entry-${e.path}`}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={e.enabled}
+                        disabled={busy}
+                        onChange={() => toggleDefault(e)}
+                        className="mt-0.5 shrink-0 accent-acc"
+                      />
+                      <span className="flex min-w-0 flex-col">
+                        <span className="flex items-baseline gap-2">
+                          <span className="truncate font-mono text-fg" style={{ fontSize: "11.5px" }}>
+                            {e.path}
+                          </span>
+                          <span className="shrink-0 text-fg-4" style={{ fontSize: "10px" }}>
+                            {e.kind}
+                          </span>
+                          {e.exists === false && (
+                            <span className="shrink-0 text-fg-4" style={{ fontSize: "10px" }}>
+                              not on this host
+                            </span>
+                          )}
+                        </span>
+                        {e.note && (
+                          <span className="text-fg-4" style={{ fontSize: "10px" }}>
+                            {e.note}
+                          </span>
+                        )}
+                      </span>
+                    </label>
+                  ))
+              )}
+            </div>
+
+            {/* Extras: `$HOME` exceptions, added through the generic explorer. */}
+            <div className="flex flex-col gap-1.5">
+              <span className="text-fg-3" style={{ fontSize: "10.5px" }}>
+                Extras
+              </span>
+              {current.entries
+                .filter((e) => !e.from_default)
+                .map((e) => (
+                  <div
+                    key={e.path}
+                    className="flex items-center gap-2"
+                    data-testid={`staging-extra-${e.path}`}
+                  >
+                    <span className="truncate font-mono text-fg" style={{ fontSize: "11.5px" }}>
+                      ~/{e.path}
+                    </span>
+                    <span className="shrink-0 text-fg-4" style={{ fontSize: "10px" }}>
+                      {e.kind}
+                    </span>
+                    {e.sensitive && (
+                      <span
+                        className="shrink-0 text-st-await"
+                        style={{ fontSize: "10px" }}
+                        data-testid={`staging-extra-sensitive-${e.path}`}
+                      >
+                        secrets
+                      </span>
+                    )}
+                    {e.exists === false && (
+                      <span className="shrink-0 text-fg-4" style={{ fontSize: "10px" }}>
+                        missing
+                      </span>
+                    )}
+                    <button
+                      type="button"
+                      onClick={() => removeExtra(e.path)}
+                      disabled={busy}
+                      aria-label={`Remove ${e.path}`}
+                      data-testid={`staging-extra-remove-${e.path}`}
+                      className="ml-auto shrink-0 rounded p-0.5 text-fg-4 transition-colors hover:bg-bg-5 hover:text-fg-2 disabled:opacity-40"
+                    >
+                      <X size={12} />
+                    </button>
+                  </div>
+                ))}
+              <div className="flex gap-2 pt-0.5">
+                {/* `FsExplorerModal` is consumed UNCHANGED (#431): two buttons, two mounts,
+                    `mode="file"` and `mode="dir"`, both `showHidden` — the entries that
+                    matter here are dotfiles. A third `mode` value or a `pickDirs` flag
+                    would have to rewrite `handleRow`, the exact line whose frozen test
+                    keeps `RepoCombobox` and the repo-explorer e2e independent. */}
+                <button
+                  type="button"
+                  onClick={() => setPickerMode("file")}
+                  data-testid="staging-extra-add-file"
+                  className="rounded-md border border-line-strong bg-bg-3 px-2.5 py-1 text-fg-2 transition-colors hover:border-acc"
+                  style={{ fontSize: "11px" }}
+                >
+                  <span className="inline-flex items-center gap-1.5">
+                    <Search size={11} /> Add file…
+                  </span>
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setPickerMode("dir")}
+                  data-testid="staging-extra-add-folder"
+                  className="rounded-md border border-line-strong bg-bg-3 px-2.5 py-1 text-fg-2 transition-colors hover:border-acc"
+                  style={{ fontSize: "11px" }}
+                >
+                  <span className="inline-flex items-center gap-1.5">
+                    <Search size={11} /> Add folder…
+                  </span>
+                </button>
+              </div>
+              <div className="text-fg-4" style={{ fontSize: "10.5px" }}>
+                An extra is <strong>copied</strong> into the run's staging and mounted
+                read-write in the container. The host file is never mutated — and never
+                bind-mounted, so nothing the container writes can reach it.
+              </div>
+              {current.entries.some((e) => !e.from_default && e.sensitive) && (
+                <div
+                  className="text-st-await"
+                  style={{ fontSize: "10.5px" }}
+                  data-testid="staging-profile-sensitive-warning"
+                >
+                  This profile stages secrets ({current.sensitive_prefixes.join(", ")}). They
+                  are copied, not shared — but the container can read them.
+                </div>
+              )}
+            </div>
+
+            {/* Signalled no-ops (ADR-0031 §2). Not errors: the default may LOSE an entry
+                tomorrow, and unchecking one a future release will add must be remembered. */}
+            {current.inactive_disabled.length > 0 && (
+              <div
+                className="text-fg-4"
+                style={{ fontSize: "10.5px" }}
+                data-testid="staging-profile-inactive-disabled"
+              >
+                Remembered but inactive (not in this version's default):{" "}
+                <span className="font-mono">{current.inactive_disabled.join(", ")}</span>
+              </div>
+            )}
+            {current.redundant_extras.length > 0 && (
+              <div
+                className="text-fg-4"
+                style={{ fontSize: "10.5px" }}
+                data-testid="staging-profile-redundant-extras"
+              >
+                Already in the default (kept in case it is removed later):{" "}
+                <span className="font-mono">{current.redundant_extras.join(", ")}</span>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Footer says DONE, not Save: every edit above already went to the daemon. That
+          difference is what makes the drill-down honest — nothing is batched behind it. */}
+      <div className="flex items-center justify-end gap-2 border-t border-line px-4 py-3">
+        <button
+          onClick={onDone}
+          data-testid="staging-profiles-done"
+          className="rounded-md bg-acc px-3 py-1.5 font-medium text-[#04140d] transition-colors hover:bg-acc-dim"
+          style={{ fontSize: "11.5px" }}
+        >
+          Done
+        </button>
+      </div>
+
+      {pickerMode && (
+        <FsExplorerModal
+          mode={pickerMode}
+          showHidden
+          title={pickerMode === "file" ? "Add a file to stage" : "Add a folder to stage"}
+          confirmLabel="Add to the profile"
+          startPath={home ?? undefined}
+          onPick={addExtra}
+          onClose={() => setPickerMode(null)}
+        />
+      )}
+
+      {confirmDelete && (
+        <DeleteProfileDialog
+          referents={confirmDelete}
+          busy={busy}
+          onCancel={() => setConfirmDelete(null)}
+          onConfirm={() => void doDelete(confirmDelete.name)}
+        />
+      )}
+    </>
+  );
+}
+
+/**
+ * Confirmation before deleting a profile — the "soft guard-rail" of ADR-0031 §7 (there is
+ * no referential integrity in the database, and the `DELETE` is unconditional).
+ *
+ * It exists to say the two things nothing else in the UI says: deleting does **not**
+ * repoint the referents, and their next Run **fails** rather than falling back to a
+ * default — while live Runs already froze their entry list and are unaffected.
+ *
+ * `z-[60]`, the same layer as `FsExplorerModal`; they are never open at once.
+ */
+function DeleteProfileDialog({
+  referents,
+  busy,
+  onCancel,
+  onConfirm,
+}: {
+  referents: SandboxProfileReferents;
+  busy: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  const pointing = referents.triggers.length + (referents.instance_default ? 1 : 0);
+  return (
+    <div
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-black/50"
+      onClick={(e) => {
+        e.stopPropagation();
+        onCancel();
+      }}
+    >
+      <div
+        className="w-[420px] rounded-lg border border-line bg-bg-4 p-4 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+        data-testid="staging-profile-delete-dialog"
+      >
+        <h3 className="font-semibold text-fg" style={{ fontSize: "12.5px" }}>
+          Delete profile <span className="font-mono">{referents.name}</span>?
+        </h3>
+        {pointing > 0 ? (
+          <>
+            <p className="mt-2 text-fg-2" style={{ fontSize: "11.5px" }}>
+              {pointing} thing{pointing === 1 ? "" : "s"} still point at it. Deleting will{" "}
+              <strong>not</strong> repoint them — the next Run they produce{" "}
+              <strong>fails</strong>, it does not fall back to a default.
+            </p>
+            <ul className="mt-1.5 flex flex-col gap-0.5" data-testid="staging-profile-referents">
+              {referents.instance_default && (
+                <li className="text-fg-3" style={{ fontSize: "10.5px" }}>
+                  · Instance default sandbox
+                </li>
+              )}
+              {referents.triggers.map((t) => (
+                <li key={t.id} className="text-fg-3" style={{ fontSize: "10.5px" }}>
+                  · Trigger <span className="font-mono">{t.name}</span>
+                  {t.enabled ? "" : " (disabled)"}
+                </li>
+              ))}
+            </ul>
+          </>
+        ) : (
+          <p className="mt-2 text-fg-2" style={{ fontSize: "11.5px" }}>
+            Nothing points at it.
+          </p>
+        )}
+        {referents.runs.length > 0 && (
+          <p
+            className="mt-2 text-fg-4"
+            style={{ fontSize: "10.5px" }}
+            data-testid="staging-profile-referent-runs"
+          >
+            {referents.runs.length} running Run{referents.runs.length === 1 ? "" : "s"} already
+            froze their entry list at start and are unaffected.
+          </p>
+        )}
+        <div className="mt-4 flex items-center justify-end gap-2">
+          <button
+            onClick={onCancel}
+            className="rounded-md border border-line-strong bg-bg-3 px-3 py-1.5 text-fg-2 transition-colors hover:bg-bg-4"
+            style={{ fontSize: "11.5px" }}
+          >
+            Cancel
+          </button>
+          <button
+            onClick={onConfirm}
+            disabled={busy}
+            data-testid="staging-profile-delete-confirm"
+            className="rounded-md bg-st-failed px-3 py-1.5 font-medium text-bg-1 transition-opacity hover:opacity-90 disabled:opacity-40"
+            style={{ fontSize: "11.5px" }}
+          >
+            Delete
+          </button>
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -77,6 +77,100 @@ export interface StringSettingField {
   default: string | null;
 }
 
+/**
+ * String sibling of {@link StringSettingField} carrying an advisory `reason` (#432).
+ *
+ * Only `default_sandbox` needs it: it is the one enum knob whose value space is OPEN (a
+ * staging-profile name), so it is the one that can point at nothing. `PUT /settings` gates
+ * the *stored* tier, but the **env** tier (`PDO_DEFAULT_SANDBOX`) passes through no
+ * validator at all — so the settings view is the only honest place to surface a dangling
+ * reference before the user launches something that will 400.
+ *
+ * `reason` is `null` when the winning tier resolves.
+ */
+export interface EnumSettingFieldWithReason extends StringSettingField {
+  reason: string | null;
+}
+
+/** One staging profile, as `GET /settings` lists it (#432): the NAME only. */
+export interface SandboxProfileRef {
+  name: string;
+  /** `full` / `minimal` — resolves with no DB row until edited (ADR-0031 §2). */
+  virtual: boolean;
+}
+
+/** What a profile entry points at (#432). `glob` is authored by the built-in default only. */
+export type SandboxEntryKind = "dir" | "file" | "glob";
+
+/** One resolved entry of a staging profile, as the editor shows it (#432). */
+export interface SandboxProfileEntry {
+  /** `$HOME`-relative path, or the default's one-level glob pattern. */
+  path: string;
+  kind: SandboxEntryKind;
+  /** From the built-in default (checkable) vs a user extra (removable). */
+  from_default: boolean;
+  enabled: boolean;
+  /**
+   * Class (b): unchecking does NOT make the file absent — the staging floor
+   * re-synthesises the keys it needs. Exactly two entries. The UI must say so, or
+   * unchecking reads as more destructive than it is.
+   */
+  resynthesised: boolean;
+  /** Server-owned advisory (disk cost, behaviour when unchecked). Never derived client-side. */
+  note: string | null;
+  /** Under `.ssh` / `.aws` / `.gnupg` — allowed with a warning (ADR-0031 §3). */
+  sensitive: boolean;
+  /** Present on the host right now; `null` when unknowable (a glob, or no `$HOME`). */
+  exists: boolean | null;
+}
+
+/**
+ * One class-(c) floor guarantee (#432): satisfied by the WHOLE file, so it is neither
+ * checkable nor addable. Rendered read-only — without this block a `minimal` profile's
+ * screen looks broken and the user wrongly concludes the container starts with no
+ * credentials.
+ */
+export interface SandboxFloorGuarantee {
+  id: string;
+  label: string;
+  path: string | null;
+}
+
+/** The full editor view of one staging profile (`GET|PUT /settings/sandbox-profiles/{name}`). */
+export interface SandboxProfile {
+  name: string;
+  virtual: boolean;
+  /** A DB row exists (the profile has been edited at least once). */
+  materialised: boolean;
+  /** The stored DIFF — the user's intention, never the effective list. */
+  disabled: string[];
+  extras: string[];
+  /** What a Run created NOW would freeze into `RunStarted`. */
+  resolved: string[];
+  entries: SandboxProfileEntry[];
+  /** Signalled no-ops, never errors (ADR-0031 §2). */
+  redundant_extras: string[];
+  inactive_disabled: string[];
+  floor: SandboxFloorGuarantee[];
+  sensitive_prefixes: string[];
+  updated_at: string | null;
+}
+
+/**
+ * Who still points at a profile (`GET …/{name}/referents`, #432). Server-side because the
+ * frontend cannot derive the third class: {@link RunListEntry} carries no `sandbox`.
+ *
+ * The distinction is the whole point of the delete dialog: `instance_default` and
+ * `triggers` are NOT repointed and their next Run **fails**, while `runs` already froze
+ * their entry list at start and are **unaffected**.
+ */
+export interface SandboxProfileReferents {
+  name: string;
+  instance_default: boolean;
+  triggers: { id: string; name: string; enabled: boolean }[];
+  runs: { run_id: string; pipeline_name: string | null; name: string | null }[];
+}
+
 /** The full `GET /settings` view (#129, ADR-0015; default_model #347; image_source #411). */
 export interface InstanceSettings {
   session_cap: SettingField;
@@ -91,12 +185,13 @@ export interface InstanceSettings {
    */
   image_source: StringSettingField;
   /**
-   * Instance-wide default sandbox mode (#410): `"off"` (host, default), `"full"`,
-   * or `"minimal"`. A closed enum with a built-in `off` default, so every tier is a
-   * present string — reuses {@link StringSettingField} (a superset) though it is
-   * never null. The create-run chokepoint resolves precedence run → trigger → this.
+   * Instance-wide default sandbox (#410/#432): `"off"` (host, default) or the name of a
+   * **staging profile**. No longer a closed enum — its value space is the user's profile
+   * namespace, which is why it carries a `reason` when the winning tier names a profile
+   * that does not exist. The create-run chokepoint resolves precedence
+   * run → trigger → this, and 400s on a dangling name (never a silent fallback).
    */
-  default_sandbox: StringSettingField;
+  default_sandbox: EnumSettingFieldWithReason;
   /**
    * Path to the sandbox Dockerfile (#431): `stored → env PDO_SANDBOX_DOCKERFILE →
    * the seeded `<sandbox_root>/Dockerfile``. Reuses {@link StringSettingField} as-is:
@@ -128,6 +223,20 @@ export interface InstanceSettings {
     reason: string | null;
     checked_at: string;
   };
+  /**
+   * Every staging profile the instance can serve (#432) — the two virtual defaults ∪ the
+   * materialised rows, sorted. **Names only**, by contract: this payload is on the launch
+   * dialog's hot path (it fetches settings on every open), so entry lists live behind
+   * `GET /settings/sandbox-profiles` instead. Drives the sandbox `<select>`.
+   */
+  sandbox_profiles: SandboxProfileRef[];
+  /**
+   * The host `$HOME` the daemon stages from (#432), honouring `sandbox_home_override`. An
+   * observed FACT, not a settings tier. Needed because the filesystem explorer's `onPick`
+   * yields an ABSOLUTE path while a profile entry is RELATIVE to `$HOME` — and nothing
+   * exposed `$HOME` before this. `null` when `HOME` is unset.
+   */
+  home: string | null;
   updated_at: string;
 }
 
@@ -146,9 +255,9 @@ export interface UpdateSettingsRequest {
   /** Sandbox image source (#411): `"registry"` | `"dockerfile"`. The `<select>` only
    *  ever sends a concrete variant — the `""` clear sentinel is backend-only. */
   image_source?: string;
-  /** Default sandbox mode (#410): `"off"` | `"full"` | `"minimal"`, or `""` to clear
+  /** Default sandbox (#410/#432): `"off"` or a staging-profile name, or `""` to clear
    *  back to the built-in default (`off`). Same `""`-sentinel discipline as
-   *  `default_model`/`image_source`. */
+   *  `default_model`/`image_source`. The daemon 400s a name that does not resolve. */
   default_sandbox?: string;
   /** Sandbox Dockerfile path (#431): an absolute path to an existing regular file
    *  (the daemon 400s otherwise), or `""` to clear back to env → the seeded default.
@@ -208,7 +317,7 @@ export interface Trigger {
   overlap_policy: string;
   /** Bounded-`allow` ceiling (#239): max simultaneous live Runs; null = unbounded. */
   max_concurrent?: number | null;
-  /** Per-Trigger sandbox mode (#410): `"off"` | `"full"` | `"minimal"`, or null/absent
+  /** Per-Trigger sandbox (#410/#432): `"off"` or a staging-profile name, or null/absent
    *  to inherit the instance default. Read at fire time. */
   sandbox?: string | null;
   enabled: boolean;
@@ -362,11 +471,21 @@ export interface RunState {
   target_repo?: string | null;
   source_branch?: string | null;
   /**
-   * Isolation mode for this Run (#403 / #407 / #410). Absent on host/historical
-   * runs (projected as `off` server-side and skipped from the payload when off).
-   * Immutable once the Run started.
+   * Isolation for this Run (#403 / #407 / #410 / #432): `"off"`, or the name of the
+   * **staging profile** it launched with. Absent on host/historical runs (projected as
+   * `off` server-side and skipped from the payload when off). Immutable once the Run
+   * started. Widened from the closed `off|full|minimal` union in #432 — a profile name is
+   * an open value space.
    */
-  sandbox?: "off" | "full" | "minimal";
+  sandbox?: string;
+  /**
+   * The profile's resolved entry list, **frozen at creation** (#432, ADR-0031 §6). Absent
+   * on `off` and on pre-#432 runs. `[]` is a legitimate value — that IS `minimal`.
+   *
+   * This is what `prepare` consumes, which is why editing (or deleting) a profile cannot
+   * retroactively change what a Run in flight staged.
+   */
+  sandbox_entries?: string[];
   /**
    * One-time image-prep visibility for a sandboxed Run (#410). `"pending"` while
    * the image is pulled/built at first use; `"ready"` once the container is about


### PR DESCRIPTION
## Sandbox K — profils de staging (#432)

Dernière slice du PRD sandbox #403 avant merge de l'intégration. Le contenu du `$HOME` stagé
devient un **profil nommé et sélectionnable** au lieu d'une liste figée dans le code.

### Ce que la slice apporte

- **Profil = nom + diff**, pas un instantané. Un profil non édité ne pose **aucune ligne** en
  base (`virtual: true`) ; l'édition ne stocke que les entrées décochées et les extras ajoutés.
- **Plancher de staging en lecture seule.** Cinq garanties non décochables (dont
  `.credentials.json`, `remote-settings.json`, `.claude/projects`) ; `settings.json` est
  *synthétisé* par le plancher, donc le décocher ne casse aucun run.
- **Extras montés depuis `$HOME`**, validés au bord : chemin relatif à `$HOME`, refus de `..`,
  refus de ce que le plancher possède déjà, refus de `.claude` nu (qui aurait fait mourir chaque
  run à `docker create`), refus des noms réservés (`off`). Cinq refus, cinq messages distincts.
- **Gel du profil à la résolution du run.** Éditer un profil pendant qu'un run vit ne le
  rétroagit pas — le gel tient à travers un `prepare` supplémentaire et un redémarrage du daemon.
- **Échec fort, jamais de repli silencieux.** Profil inconnu → 400 aux trois surfaces ; supprimer
  un profil référencé ouvre un dialogue qui **nomme** ses référents et énonce la conséquence ;
  un tir sur profil manquant produit une ligne rouge lisible et **zéro Run**.
- **Le montage `$HOME` passe par des copies** sous `<staging>/home/`, jamais par le fichier hôte :
  contrôle négatif réel, le vrai `~/.gitconfig` de l'utilisateur est resté intact
  (`sha256sum -c` OK).

### Portée

`sandbox_profile.rs` (neuf), staging/container/run adaptés, `SettingsModal` (éditeur de profils +
picker `$HOME`) et `NewRunModal` côté FE. ADR-0031 mise à jour ; commit `08d507b` documente que
`docker start` ne réévalue jamais les mounts.

### Validation

- **Déterministe** : `cargo build`, `fmt`, `clippy -D warnings`, `cargo test --workspace`
  (1703 passés), `npm run lint`, `tsc --noEmit`, `npm test` (1398 passés) — tous verts.
- **Agentique (FP-432)** : verdict **Pass**, en conditions réelles — stack isolée sur `:6191`,
  Docker 29.2.1, vrais conteneurs, pilotage à la souris. Les huit critères d'acceptation
  (A, B, C, E, F, G, H, I) vérifiés, pas déduits du code. Dix captures annotées.
- Deux assertions **littérales** du FP sont tombées, toutes deux sur une prémisse fausse du script
  de test : (a) `claude-home/plugins/` est écrit par le runtime claude dans un répertoire monté
  `rw`, pas par `prepare` (le blob hôte de 12 Mo n'est jamais copié — `BLOB ABSENT` vérifié depuis
  l'intérieur du conteneur) ; (b) le FP pose lui-même `git config --local user.email`, et en git le
  local prime sur le global — l'identité de l'hôte arrive bien, prouvée par un second commit après
  `--unset` local.
- Flake pré-existant hors périmètre : `tests/run_shell.rs` (échéance de polling à 10 s sous
  charge), vert en relance isolée comme en relance complète du workspace.

### Suivi

Follow-ups déjà fichés : #440, #441, #442, #443. Un cinquième mériterait de l'être, appartenant à
#406 et non à cette slice : si le binaire du daemon est remplacé sur disque pendant qu'il tourne
(tout `cargo build` de la boucle de dev), `/proc/self/exe` résout vers `<chemin> (deleted)`, Docker
matérialise un répertoire vide à `/usr/local/bin/pdo`, et les nœuds sandboxés suivants meurent en
`session_died` opaque.

Base : `integration/prd-403-sandbox` (pas `main` — le bump de version se fera au merge de
l'intégration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
