### PR TITLE
fix(#445): la précondition sandbox est portée par le spawn, plus par ses appelants

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1146,12 +1146,30 @@ mode), confondre avec `ensure_image`/`probe_state` (provisionnement/liveness par
 **Préparation du sandbox (`sandbox_prep`)** :
 État **additif** projeté sur le Run (`pending`|`ready`) qui rend visible la fenêtre de prep eager
 (ADR-0030 pt 4/10) : `SandboxPrepStarted` (avant `ensure_ready`) → `pending`, `SandboxPrepReady`
-(avant le 1er spawn) → `ready`. Événements **informationnels** (même grain que `NodeBlockedOnLimit` /
-`NodeAutoCompleteObserved`), émis au chokepoint `append_event`, **jamais** pour un Run `off`. N'altère
-**pas** `status` (reste `running`). Échec → `RunFailed` (pas d'événement de prep dédié). L'UI du Run
-affiche une **bannière** « préparation du sandbox » tant que `pending`, plus un **badge** `sandbox :
-minimal|full` persistant. _Éviter_ : « statut preparing » (écarté, pas un état de la machine à statut) ;
-l'inférence client (écartée : faux positifs advance-détaché/#159).
+(avant le 1er spawn) → `ready`. Émis au chokepoint `append_event`, **jamais** pour un Run `off`.
+N'altère **pas** `status` (reste `running`). Échec → `RunFailed` (pas d'événement de prep dédié).
+L'UI du Run affiche une **bannière** « préparation du sandbox » tant que `pending`, plus un **badge**
+`sandbox : minimal|full` persistant. Depuis #445 la paire n'est plus **seulement informationnelle** :
+elle porte la **précondition de spawn** ci-dessous, donc `SandboxPrepReady` est aussi émis par
+`resume_run` et la boot recovery quand elles ré-arment le conteneur d'un Run resté `pending`
+(amendement ADR-0030 §3 ; `open_run_shell` reste non émetteur — Run terminal). _Éviter_ : « statut
+preparing » (écarté, pas un état de la machine à statut) ; l'inférence client (écartée : faux positifs
+advance-détaché/#159) ; « événement purement informationnel » (plus vrai depuis #445).
+
+**Précondition de spawn du sandbox** (`RunState::sandbox_spawn_block`) :
+Règle « **un Run sandboxé dont la prep n'est pas `ready` n'est pas schedulable** », portée par
+`spawn_node` lui-même (après le garde de transition, avant l'admission et tout sous-worktree) et
+répétée en `409` par `force_spawn_node`, qui ne passe pas par le spawn. Décision **pure** sur la
+projection : `off` jamais bloqué, `ready` jamais bloqué, `pending` **et** `absent` bloqués. Le refus
+n'écrit **rien** — ni `NodeStarted` ni `NodeWaiting` — parce qu'un nœud sans état reste dans
+`compute_ready_to_spawn` : c'est ce qui permet le **rejeu** par l'`advance_run` qui suit
+`SandboxPrepReady`. Issue de spawn dédiée `SpawnOutcome::Deferred`, distincte de `Refused` (rien à
+reprendre) et de `Throttled` (réservation posée). Sans elle, un avancement déclenché par le watcher de
+pipeline ou par `retry_waiting_nodes` pendant la prep lançait un `docker exec` sur un conteneur
+inexistant → exit 1 en ~30 ms → `session_died` 25 s plus tard (#445, profil `full` inutilisable).
+_Éviter_ : « garde du watcher » (le défaut était l'absence de précondition au spawn, corriger le site
+d'appel laisse le suivant la réintroduire) ; confondre avec l'**admission** (cap de sessions
+concurrentes) ni avec le **garde de transition** (#212, légalité d'un `NodeStarted`).
 
 ### Relations
 - Une **Sandbox** `minimal`/`full` possède un **staging dir** (`~/.pdo/sandbox/<run-id>/`) contenant un
@@ -1229,6 +1247,27 @@ l'inférence client (écartée : faux positifs advance-détaché/#159).
   content-type, forme additive, les 2 drapeaux, liens cassés et spéciaux invisibles ; `sandbox_tracer` :
   build depuis le chemin custom **sans pull**, et chemin disparu → `RunFailed` nommant chemin + tier)
   + FE (vitest) + FP-431 (L5, Docker réel).
+- **Réalisé (#445, amendement ADR-0030 « précondition du spawn »)** : la garantie du point 4 (« conteneur
+  prêt avant le premier spawn ») était rejouée par le **seul** parcours de création ; le watcher de
+  pipeline et `retry_waiting_nodes` atteignaient le spawn pendant la prep → `docker exec` sur un
+  conteneur inexistant → `session_died` (profil `full` mort 7 fois sur 7 en reproduction, et
+  **systématiquement dès qu'un onglet du Run était ouvert**, la lecture de `pipeline.yaml` réveillant le
+  watcher). La règle devient une **précondition portée par `spawn_node`** (voir le lexique ci-dessus),
+  répétée en `409` par `force_spawn_node` ; le refus n'écrit rien, donc le spawn est **rejoué** par
+  l'`advance_run` qui suit `SandboxPrepReady` — d'où l'extension des émetteurs de cet event
+  (`resume_run`, boot recovery) sans laquelle un Run ayant échoué *pendant* sa prep serait bloqué à vie.
+  `run_stall_reason` gagne une **grâce sandbox** de 15 min (une prep de 2 Go dure 83-87 s, davantage sur
+  un build froid : la fenêtre #279 de 120 s tuait précisément les Runs lents que la précondition sauve),
+  et une prep dont le Run est devenu terminal est **abandonnée** (ni event, ni spawn, `docker rm -f` du
+  conteneur ; le staging reste pour `merge_back`/`cleanup_run`). Couvert layer-1 (décision pure, table
+  complète) + unit (spawn différé sans event, `off` jamais bloqué, rejeu de bout en bout sur
+  `advance_run`, `409` du force-spawn, les deux bornes de la grâce sandbox) + FP-445 (L5, Docker réel,
+  recette `full-heavy`).
+- **Non traité, à ficher** : le réveil parasite du watcher. La première **lecture** de
+  `<run>/pipeline.yaml` produit un `pipeline_modified` mensonger (masque inotify `OPEN`, debouncer sans
+  filtre d'`EventKind`, `content_actually_changed` sans baseline pour un Run neuf —`seed_run_mtimes` ne
+  tourne qu'au boot ; `copy_pipeline_to_run` est en outre le seul écrivain de l'arbre qui n'appelle
+  jamais `mark_self_write`). Indépendant de #445 : la précondition tient quel que soit qui avance le Run.
 - **Différé** : injection `/etc/passwd`+`/etc/group` pour uid hôte ≠ 1000 (sudo +
   Node `os.userInfo()`) (issue de suivi) ; auto-flip de la visibilité publique du package GHCR
   (non supporté par l'API → manuel one-time après la 1ʳᵉ release, #411).

--- a/crates/pdo-daemon/src/boot_recovery.rs
+++ b/crates/pdo-daemon/src/boot_recovery.rs
@@ -144,7 +144,20 @@ pub(crate) async fn run_boot_recovery(state: &AppState) {
                     match tokio::task::spawn_blocking(move || crate::sandbox_run::ensure_ready(&ctx))
                         .await
                     {
-                        Ok(Ok(())) => {}
+                        // #445: record the container as ready, or the spawn precondition
+                        // would refuse every node of a Run whose prep task died with the
+                        // previous daemon (its projection is frozen at `pending`, and
+                        // nothing else would ever lift it). Only on the success arm: the
+                        // two `warn!` arms below leave the projection `pending` on
+                        // purpose, so the run is deferred rather than spawned into a
+                        // container that is not there. Gated on the Run actually being
+                        // blocked so the common case — every live sandboxed Run, already
+                        // `ready` — does not append one no-op event per Run per boot.
+                        Ok(Ok(())) => {
+                            if run_state.sandbox_spawn_block().is_some() {
+                                crate::mark_sandbox_prep_ready(state, run_id).await;
+                            }
+                        }
                         // KEPT as a `warn!`, deliberately. `ensure_ready` touches the
                         // Docker socket, and `service_unit.rs` emits
                         // `After=network-online.target` WITHOUT `After=docker.service` —

--- a/crates/pdo-daemon/src/event_log.rs
+++ b/crates/pdo-daemon/src/event_log.rs
@@ -738,6 +738,50 @@ impl RunState {
                 .iter()
                 .all(|id| self.node_status(id) == Some(&NodeStatus::Completed))
     }
+
+    /// Why this Run is **not schedulable yet** because its sandbox is still being
+    /// prepared (#445) — `None` when a session may be launched.
+    ///
+    /// A sandboxed node's tmux window runs `docker exec … pdo-sbx-<run_id> …`. On a
+    /// container that does not exist yet, `docker exec` exits 1 in ~30 ms, the window's
+    /// command ends, the tmux session disappears, and ~25 s later the stale detector
+    /// renders `session_died` — a failure that names tmux while the real fault is the
+    /// ordering. The precondition therefore belongs to the *spawn*, not to the callers
+    /// that reach it: `create_run` gated correctly while the pipeline watcher
+    /// (`handle_run_pipeline_modifications`) and `retry_waiting_nodes` did not.
+    ///
+    /// | `sandbox` | `sandbox_prep` | verdict |
+    /// |---|---|---|
+    /// | `off` | (any) | `None` — the host path never grew a precondition |
+    /// | profile | `Ready` | `None` — image + container + staging are guaranteed |
+    /// | profile | `Pending` | blocked — the prep task is between its two events |
+    /// | profile | `None` | blocked — the prep task has not reached its head event |
+    ///
+    /// The `None` arm blocks deliberately: `RunStarted` and `SandboxPrepStarted` are
+    /// ~100 ms apart, and a read of `<run>/pipeline.yaml` inside that window wakes the
+    /// watcher (inotify reports the *first read* of a fresh run dir as a modification).
+    /// Blocking is also the fail-safe direction — the cost of a wrong `Some` is one
+    /// deferred spawn replayed on `SandboxPrepReady`, the cost of a wrong `None` is a
+    /// dead node.
+    ///
+    /// Pure: projected state in, decision out. The reason is the operator-facing
+    /// sentence, so it names the profile (the *why this Run and not that one*).
+    pub fn sandbox_spawn_block(&self) -> Option<String> {
+        let profile = self.sandbox.profile()?;
+        match self.sandbox_prep {
+            Some(SandboxPrepState::Ready) => None,
+            Some(SandboxPrepState::Pending) => Some(format!(
+                "sandbox prep for run {} (profile `{profile}`) is still in progress: \
+                 its container is not up, so no session can be launched yet",
+                self.run_id
+            )),
+            None => Some(format!(
+                "sandbox prep for run {} (profile `{profile}`) has not started yet: \
+                 its container does not exist, so no session can be launched yet",
+                self.run_id
+            )),
+        }
+    }
 }
 
 fn entry_node_ids(edges: &[EdgeInfo], node_defs: &[NodeDefInfo]) -> Vec<String> {
@@ -2062,6 +2106,56 @@ mod tests {
         assert_eq!(state.sandbox_prep, None);
         let value = serde_json::to_value(&state).unwrap();
         assert!(value.get("sandbox_prep").is_none());
+    }
+
+    // -- #445: the sandbox spawn precondition, decided on the projection alone ----
+
+    #[test]
+    fn sandbox_spawn_block_gates_on_the_projected_prep_state() {
+        // The whole decision table of `sandbox_spawn_block`, which is what stands
+        // between the pipeline watcher and a `docker exec` into a container that does
+        // not exist yet.
+        let sandboxed = |prep: Option<SandboxPrepState>| {
+            let mut s = RunState::new("r1".into(), "p".into());
+            s.sandbox = SandboxMode::Profile("full".into());
+            s.sandbox_prep = prep;
+            s
+        };
+
+        // Prep finished: the container is up, spawning is legal.
+        assert!(sandboxed(Some(SandboxPrepState::Ready))
+            .sandbox_spawn_block()
+            .is_none());
+
+        // Prep in flight — the reported failure window.
+        let pending = sandboxed(Some(SandboxPrepState::Pending))
+            .sandbox_spawn_block()
+            .expect("a pending prep must block the spawn");
+        assert!(
+            pending.contains("full") && pending.contains("r1"),
+            "the reason must name the profile and the run, got {pending:?}"
+        );
+
+        // No prep event yet: RunStarted and SandboxPrepStarted are ~100 ms apart, and
+        // a read of the fresh run dir inside that window wakes the watcher. Blocking
+        // is the fail-safe direction — a wrong block costs one replayed spawn, a wrong
+        // pass costs a dead node.
+        assert!(
+            sandboxed(None).sandbox_spawn_block().is_some(),
+            "a sandboxed Run whose prep has not even started must block"
+        );
+    }
+
+    #[test]
+    fn sandbox_spawn_block_never_gates_the_host_path() {
+        // An `off` Run has no prep events at all, so `sandbox_prep` is permanently
+        // `None`. Reading that as "not ready" would deadlock every non-sandboxed Run
+        // in the instance — the `off` parcours must stay byte-identical.
+        let mut s = RunState::new("r1".into(), "p".into());
+        assert!(s.sandbox_spawn_block().is_none());
+        // …and stays unblocked whatever the prep field says (defensive: `off` wins).
+        s.sandbox_prep = Some(SandboxPrepState::Pending);
+        assert!(s.sandbox_spawn_block().is_none());
     }
 
     #[test]

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -5271,6 +5271,18 @@ pub(crate) async fn retry_waiting_nodes(state: &AppState) {
 /// so the daemon's two "idle past N" notions agree.
 const SPAWN_STALL_GRACE_SECS: i64 = 120;
 
+/// Idle window (#445) after which a sandboxed Run stuck at `sandbox_prep = pending` is
+/// treated as a lost preparation rather than one still working.
+///
+/// Deliberately an order of magnitude above [`SPAWN_STALL_GRACE_SECS`], because the two
+/// measure different things: 120 s bounds an *event-driven spawn*, which is milliseconds
+/// of work, while this bounds staging up to a couple of gigabytes of `~/.claude` plus a
+/// cold `docker build` — measured at 83-87 s for a 2 GB profile with a warm image, and
+/// legitimately minutes on the first build of a machine. 15 minutes is comfortably past
+/// any healthy prep and still short enough that a Run whose prep task died with a
+/// previous daemon is reported the same hour rather than sitting `Running` for ever.
+const SANDBOX_PREP_STALL_GRACE_SECS: i64 = 900;
+
 /// Seconds elapsed since the run's most recent event, or `None` when no event
 /// carries a parseable RFC3339 timestamp. The most recent event has the
 /// *smallest* age, so this is the `min` over ages — i.e. "how long since the run
@@ -5390,6 +5402,33 @@ fn run_stall_reason(
         .as_ref()
         .is_some_and(|mr| mr.status == event_log::NodeStatus::Running);
     if has_live_node || resolver_active {
+        return None;
+    }
+
+    // (#445) A sandboxed Run between `SandboxPrepStarted` and `SandboxPrepReady` looks
+    // EXACTLY like a #279 silent spawn-abort: a ready node, no live node, and — since
+    // the prep emits no event of its own while it works — an idle clock that ticks up
+    // for the whole prep. It is not one: `spawn_node` is deliberately deferring, and
+    // `SandboxPrepReady` will replay it. Staging ~2 GB of `~/.claude` plus a cold
+    // `docker build` overruns the 120 s spawn-stall window comfortably, so without this
+    // arm the reconciler would kill precisely the slow Runs the precondition just saved.
+    //
+    // Deferring for ever would only trade a false failure for a silent stall, which
+    // ADR-0004 forbids just as strongly — so this is a LONGER grace, not an exemption:
+    // past it, the prep task is genuinely gone (killed with a previous daemon, panicked
+    // outside its catch) and the Run is failed with a cause that names the sandbox
+    // rather than blaming tmux. Placed before the `ready` / `loop_seed` arms because it
+    // explains the whole class: while the prep is pending NOTHING in this Run can start,
+    // whatever the scheduler proposes.
+    if let Some(block) = run_state.sandbox_spawn_block() {
+        if idle_secs.is_some_and(|s| s >= SANDBOX_PREP_STALL_GRACE_SECS) {
+            return Some(format!(
+                "run_stalled: {block}; idle {}s past the {SANDBOX_PREP_STALL_GRACE_SECS}s \
+                 sandbox-prep grace — the preparation task is gone and nothing will \
+                 re-drive this run (#445)",
+                idle_secs.unwrap_or_default()
+            ));
+        }
         return None;
     }
 
@@ -6232,17 +6271,25 @@ async fn create_run_inner(
             // `spawn_blocking`, which also isolates its panic into a `JoinError`.
             match tokio::task::spawn_blocking(move || sandbox_run::ensure_ready(&ctx)).await {
                 Ok(Ok(())) => {
+                    // #445: the Run may have gone terminal WHILE the prep ran (a stop /
+                    // kill, or — before the spawn precondition existed — the very
+                    // `session_died` this prep caused). Emitting `SandboxPrepReady` and
+                    // spawning into a dead Run leaves a container nobody will ever exec
+                    // into, so abandon instead: no event, no node, no manager, and the
+                    // container is removed. Idempotent — a later `resume_run` re-runs
+                    // `ensure_ready` and recreates it.
+                    if abandon_prep_if_run_is_terminal(&task_state, &task_run_id).await {
+                        return;
+                    }
                     // #410: image ready, container about to receive the first session.
                     // Emitted just before the spawn so the prep banner clears exactly
                     // when work can start. A failed prep emits `RunFailed` instead (no
                     // dedicated failed-prep event).
-                    emit_run_event(
-                        &task_state,
-                        &task_run_id,
-                        event_log::EventKind::SandboxPrepReady,
-                        None,
-                    )
-                    .await;
+                    //
+                    // #445: this pair — the event, then the advance — is now the single
+                    // REPLAY point for every spawn `spawn_node` deferred while the prep
+                    // was in flight, which is why `mark_sandbox_prep_ready` owns it.
+                    mark_sandbox_prep_ready(&task_state, &task_run_id).await;
                     spawn_ready_after_event(&task_state, &task_run_id).await;
                     spawn_manager_session(
                         &task_state,
@@ -6275,6 +6322,79 @@ async fn create_run_inner(
     info!("Run {run_id} started for pipeline {}", pipeline.name);
 
     Ok(run_id)
+}
+
+/// Record that a sandboxed Run's container is up (#410 `SandboxPrepReady`), which
+/// since #445 is also the moment the spawns deferred by
+/// [`event_log::RunState::sandbox_spawn_block`] become legal.
+///
+/// The event is the ONLY thing that lifts the spawn precondition, so every path that
+/// makes the container real must go through here: the create-time prep task, `resume_run`
+/// re-arming a terminal Run, and boot recovery reconciling a live one. Without this a Run
+/// whose prep completed outside the create path (daemon restart mid-prep, resume of a
+/// Run that failed *during* its prep) would keep a `pending` projection for ever and
+/// every spawn would be deferred for ever — the deadlock the precondition must not
+/// create.
+///
+/// Idempotent: the projection assigns `Ready`, so a second call is a no-op in effect.
+/// It deliberately does NOT advance the Run — the create path pairs it with
+/// `spawn_ready_after_event`, `resume_run` with `re_evaluate_after_command`, and boot
+/// recovery with its own reconciliation, and folding an advance in here would make this
+/// a scheduling entry point (ADR-0009).
+pub(crate) async fn mark_sandbox_prep_ready(state: &AppState, run_id: &str) {
+    emit_run_event(state, run_id, event_log::EventKind::SandboxPrepReady, None).await;
+}
+
+/// Abandon a just-finished sandbox prep whose Run went terminal while it ran (#445),
+/// returning whether it abandoned.
+///
+/// The observed damage this closes: on a Run killed by the spawn race, `container
+/// Created` landed 27-35 s *after* `run_failed`, then `sandbox_prep_ready` was emitted
+/// on a terminal Run — a container nobody can ever exec into, plus a prep-ready banner
+/// on a corpse. The spawn precondition removes the cause; this removes the residue for
+/// the cases that remain legitimate (the user stops or kills a Run mid-prep).
+///
+/// Removes the container (`docker rm -f`, idempotent and best-effort) but deliberately
+/// KEEPS the staging: staging is purged by `cleanup_run` at archive, and destroying it
+/// here would also destroy the transcripts `merge_back` harvests. The in-flight
+/// filesystem walk itself is not interrupted — `sandbox_staging::prepare` is a sync walk
+/// in a pure module with no cancellation seam — so a Run stopped mid-staging still pays
+/// for the copy already under way. Bounded and inert: no container, no event, no spawn.
+async fn abandon_prep_if_run_is_terminal(state: &AppState, run_id: &str) -> bool {
+    let Some((_, run_state)) = reload_run_state(state, run_id).await else {
+        // No projection at all: the Run was forgotten (#328) under the prep. Same
+        // verdict — nothing may be spawned, and the container must not linger.
+        warn!("Run {run_id}: sandbox prep finished for a run with no projected state — abandoning");
+        remove_sandbox_container_best_effort(state, run_id);
+        return true;
+    };
+    if !run_state.status.is_terminal() {
+        return false;
+    }
+    warn!(
+        "Run {run_id}: sandbox prep finished but the run is already {:?} — abandoning \
+         (no prep-ready event, no spawn); removing its container",
+        run_state.status
+    );
+    remove_sandbox_container_best_effort(state, run_id);
+    true
+}
+
+/// `docker rm -f pdo-sbx-<run_id>` on a blocking thread, best-effort (#445). Split out
+/// so the abandonment path reads as one line and never blocks the executor.
+fn remove_sandbox_container_best_effort(state: &AppState, run_id: &str) {
+    let docker_bin = state
+        .docker_cmd_override
+        .clone()
+        .unwrap_or_else(|| "docker".to_string());
+    let rid = run_id.to_string();
+    tokio::task::spawn_blocking(move || {
+        if let Err(e) = sandbox_container::remove(&docker_bin, &rid) {
+            warn!(
+                "Run {rid}: failed to remove the abandoned sandbox container (best-effort): {e:#}"
+            );
+        }
+    });
 }
 
 /// Fail a sandboxed Run *loud* when its eager prep can't complete (#407 D4).
@@ -9446,6 +9566,20 @@ async fn force_spawn_node(state: &Arc<AppState>, run_id: &str, node_id: &str) ->
         .map(|ns| ns.iter + 1)
         .unwrap_or(1);
 
+    // #445: the SECOND spawn path. This one does not route through `spawn_node` (it
+    // drives `node_primitives::start_node`), so it needs the sandbox precondition
+    // stated again — the same `docker exec` on a container that does not exist yet
+    // would die the same way. 409 rather than a silent defer: "start now" must not
+    // queue, and the operator who pressed the button deserves to read why (mirrors the
+    // session-cap arm below, which fails fast for exactly that reason).
+    if let Some(reason) = run_state.sandbox_spawn_block() {
+        return (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({ "error": reason })),
+        )
+            .into_response();
+    }
+
     // D4 (#204): pre-validate the start against the SAME transition guard that
     // backstops `append_event`, BEFORE the primitive spawns a tmux session — so
     // a start refused by the backstop never leaves an orphan session behind.
@@ -10355,6 +10489,16 @@ async fn run_command(
                     )
                         .into_response();
                 }
+                // #445: the container is up again — say so in the log, or the spawn
+                // precondition would refuse every node the re-evaluation below proposes.
+                // Load-bearing for the Run that failed *during* its own prep: its
+                // projection is still `pending`, and resuming it is the operator's only
+                // recovery path. Emitted only after `ensure_ready` returned `Ok` (so the
+                // event never claims a container that isn't there) and only when the Run
+                // is actually blocked (so a routine resume adds no no-op event).
+                if run_state.sandbox_spawn_block().is_some() {
+                    mark_sandbox_prep_ready(&state, &run_id).await;
+                }
             }
 
             let summary = re_evaluate_after_command(&state, &run_id).await;
@@ -10812,9 +10956,12 @@ impl ReEvalSummary {
             SpawnOutcome::Throttled => self.skipped.push(format!(
                 "node '{node_id}' iter {iter} throttled into waiting (session cap)"
             )),
-            SpawnOutcome::Refused { reason } | SpawnOutcome::Failed { reason } => {
-                self.skipped.push(reason)
-            }
+            // #445: `Deferred` joins the two here rather than getting its own arm —
+            // its reason already reads as the operator sentence, and every consumer of
+            // `skipped` is a "why did nothing start" message.
+            SpawnOutcome::Refused { reason }
+            | SpawnOutcome::Deferred { reason }
+            | SpawnOutcome::Failed { reason } => self.skipped.push(reason),
         }
     }
 
@@ -16115,6 +16262,76 @@ mod tests {
             )
             .is_none(),
             "a ready node within the grace window is about to be driven — never fail it"
+        );
+    }
+
+    /// A sandboxed Run mid-prep with a `full` staging profile — the projection the
+    /// reconciler sees while the spawn is legitimately deferred (#445).
+    fn run_state_sandbox_mid_prep(run_id: &str) -> event_log::RunState {
+        let mut rs = event_log::RunState::new(run_id.into(), "linear".into());
+        rs.sandbox = event_log::SandboxMode::Profile("full".into());
+        rs.sandbox_prep = Some(event_log::SandboxPrepState::Pending);
+        rs
+    }
+
+    #[test]
+    fn run_stall_reason_defers_a_sandboxed_run_still_preparing_past_the_spawn_grace() {
+        // #445, the false-positive half. A sandboxed Run between SandboxPrepStarted
+        // and SandboxPrepReady has an entry node the scheduler reports ready, no live
+        // node, and — because the prep emits nothing while it works — an idle clock
+        // that keeps ticking. That is the #279 orphan signature exactly, so without a
+        // sandbox arm the reconciler would fail every prep slower than 120 s: measured
+        // 83-87 s for a 2 GB profile, and minutes on a cold `docker build`. Failing
+        // those Runs would defeat the precondition that just saved them.
+        let pipeline = linear_two_node_pipeline();
+        let run_state = run_state_sandbox_mid_prep("20260725-sbx-preparing");
+
+        let ready = scheduler_dispatcher::compute_ready_to_spawn(&pipeline, &run_state);
+        let loop_seed = scheduler::seed_pending_loops(&pipeline, &run_state, &HashMap::new());
+        assert!(
+            !ready.is_empty(),
+            "precondition: the deferred entry node is still in the ready set"
+        );
+
+        assert!(
+            run_stall_reason(
+                &pipeline,
+                &run_state,
+                &ready,
+                &loop_seed,
+                Some(SPAWN_STALL_GRACE_SECS * 2),
+            )
+            .is_none(),
+            "a Run whose container is still being built is preparing, not stalled — \
+             it must survive well past the 120s spawn-stall window"
+        );
+    }
+
+    #[test]
+    fn run_stall_reason_flags_a_sandbox_prep_lost_past_its_own_grace() {
+        // The other half: deferring for ever would trade a false failure for a silent
+        // stall, which ADR-0004 forbids just as strongly. Past the sandbox-prep grace
+        // the preparation task is genuinely gone (killed with a previous daemon,
+        // panicked outside its catch) and nothing will ever emit SandboxPrepReady, so
+        // the Run is failed with a cause that names the sandbox instead of blaming
+        // tmux — the diagnosability complaint in the report.
+        let pipeline = linear_two_node_pipeline();
+        let run_state = run_state_sandbox_mid_prep("20260725-sbx-lost");
+
+        let ready = scheduler_dispatcher::compute_ready_to_spawn(&pipeline, &run_state);
+        let loop_seed = scheduler::seed_pending_loops(&pipeline, &run_state, &HashMap::new());
+
+        let reason = run_stall_reason(
+            &pipeline,
+            &run_state,
+            &ready,
+            &loop_seed,
+            Some(SANDBOX_PREP_STALL_GRACE_SECS),
+        )
+        .expect("a prep pending past its grace window is a lost preparation, not work in flight");
+        assert!(
+            reason.contains("sandbox prep") && reason.contains("#445"),
+            "cause {reason:?} must name the sandbox preparation rather than tmux"
         );
     }
 
@@ -22641,6 +22858,252 @@ edges: []
         assert_eq!(
             iter1_starts, 1,
             "the live iter-1 NodeStarted must be untouched by the refused iter-2 spawn"
+        );
+    }
+
+    // --- #445: the sandbox spawn precondition (block + replay) ------------------
+    //
+    // The defect: a sandboxed Run's node session runs `docker exec … pdo-sbx-<run>`,
+    // and `create_run`'s detached prep task was the ONLY thing that waited for the
+    // container. The pipeline watcher (woken by the first *read* of the fresh run
+    // dir's `pipeline.yaml`) called the same advance path with no such wait, so the
+    // exec hit a container that did not exist → exit 1 in ~30 ms → the tmux window's
+    // command ended → `session_died` ~25 s later. The precondition now lives in
+    // `spawn_node`, which is why these tests drive the spawn and the advance rather
+    // than the watcher's mpsc plumbing: `handle_run_pipeline_modifications` calls
+    // `spawn_ready_after_event` == `advance_run`, the exact entry point exercised in
+    // `sandbox_pending_run_is_not_schedulable_until_prep_ready`.
+
+    /// Seed a sandboxed Run whose prep has STARTED but not finished — the projection
+    /// the watcher used to spawn into (`sandbox_prep = pending`).
+    async fn seed_sandboxed_run_mid_prep(state: &Arc<AppState>, run_id: &str, pipeline_name: &str) {
+        let started = event_log::Event {
+            id: None,
+            run_id: run_id.into(),
+            ts: event_log::now_iso(),
+            kind: event_log::EventKind::RunStarted,
+            node_id: None,
+            iter: None,
+            payload: Some(serde_json::json!({
+                "pipeline_name": pipeline_name,
+                "sandbox": "full",
+                "sandbox_entries": [".claude/plugins"],
+            })),
+        };
+        append_event(state, &started).await.unwrap();
+        emit_run_event(
+            state,
+            run_id,
+            event_log::EventKind::SandboxPrepStarted,
+            None,
+        )
+        .await;
+    }
+
+    /// AC "blocage", at the chokepoint: a sandboxed Run mid-prep defers the spawn
+    /// before ANY side effect — no `NodeStarted` (which would be the lie the stale
+    /// detector later reports as `session_died`) and, just as important, no
+    /// `NodeWaiting` either: a `Waiting` node leaves `compute_ready_to_spawn`, so the
+    /// reservation would move the replay onto the cross-run admission sweep and a Run
+    /// whose only trigger was the watcher could wedge for ever.
+    #[tokio::test]
+    async fn spawn_node_defers_while_sandbox_prep_is_pending() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = test_state_with_dir(tmp.path()).await;
+
+        let run_id = "spawn-unit-sbx-pending";
+        seed_sandboxed_run_mid_prep(&state, run_id, "spawn-unit").await;
+
+        let (pipeline, node, pipeline_path) =
+            spawn_test_fixture(tmp.path(), "worker", pipeline::NodeType::DocOnly);
+        let artifacts_dir = tmp.path().join("artifacts");
+        let resolved_vars = HashMap::new();
+        let ctx = SpawnContext {
+            pipeline: &pipeline,
+            run_id,
+            pipeline_path: &pipeline_path,
+            worktree_dir: tmp.path(),
+            artifacts_dir: &artifacts_dir,
+            resolved_vars: &resolved_vars,
+            repo_root: tmp.path(),
+        };
+
+        let outcome = spawn_node(SpawnDeps::from_state(&state), &ctx, &node, 1).await;
+        let SpawnOutcome::Deferred { reason } = outcome else {
+            panic!(
+                "a spawn into a Run whose container is not up must be Deferred, got {outcome:?}"
+            );
+        };
+        assert!(
+            reason.contains("sandbox prep") && reason.contains("full"),
+            "the deferral must name the sandbox prep and the profile, got {reason:?}"
+        );
+
+        let events = load_events(&state.db, run_id).await.unwrap();
+        assert!(
+            !events
+                .iter()
+                .any(|e| e.kind == event_log::EventKind::NodeStarted),
+            "a deferred spawn must append NO NodeStarted — that event is what makes the \
+             stale detector report session_died 25s later"
+        );
+        assert!(
+            !events
+                .iter()
+                .any(|e| e.kind == event_log::EventKind::NodeWaiting),
+            "a deferred spawn must reserve NOTHING: a Waiting node leaves \
+             compute_ready_to_spawn and would never be replayed by advance_run"
+        );
+    }
+
+    /// The precondition must not leak onto the host path: an `off` Run has no prep
+    /// events at all, and `sandbox_prep = None` must not be read as "not ready" for
+    /// it — that would deadlock every non-sandboxed Run in the instance.
+    #[tokio::test]
+    async fn spawn_node_never_defers_a_host_run() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = test_state_with_dir(tmp.path()).await;
+
+        let run_id = "spawn-unit-host";
+        // RunStarted with no `sandbox` key at all → SandboxMode::Off, prep = None.
+        seed_run_for_node_control(&state, run_id, "spawn-unit").await;
+
+        let (pipeline, node, pipeline_path) =
+            spawn_test_fixture(tmp.path(), "worker", pipeline::NodeType::DocOnly);
+        let artifacts_dir = tmp.path().join("artifacts");
+        let resolved_vars = HashMap::new();
+        let ctx = SpawnContext {
+            pipeline: &pipeline,
+            run_id,
+            pipeline_path: &pipeline_path,
+            worktree_dir: tmp.path(),
+            artifacts_dir: &artifacts_dir,
+            resolved_vars: &resolved_vars,
+            repo_root: tmp.path(),
+        };
+
+        let outcome = spawn_node(SpawnDeps::from_state(&state), &ctx, &node, 1).await;
+        assert!(
+            matches!(outcome, SpawnOutcome::Spawned),
+            "an `off` Run must spawn exactly as before the precondition, got {outcome:?}"
+        );
+    }
+
+    /// Both ACs on the real advance path, in order — this is the regression test for
+    /// the reported failure and for the deadlock a naive fix would introduce.
+    ///
+    /// 1. **Blocage**: `advance_run` (what the pipeline watcher calls, via
+    ///    `spawn_ready_after_event`) starts nothing while the prep is pending.
+    /// 2. **Rejeu**: `mark_sandbox_prep_ready` + the following `advance_run` — the
+    ///    exact pair the create-time prep task runs — starts the node that was
+    ///    deferred. Without this half, a Run whose only trigger was the watcher would
+    ///    stay `Running` with nothing live for ever, which is strictly worse than the
+    ///    bug being fixed.
+    #[tokio::test]
+    async fn sandbox_pending_run_is_not_schedulable_until_prep_ready() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_root = tmp.path();
+        let state = test_state_with_dir(repo_root).await;
+
+        let run_id = "sbx-advance-replay";
+        // The default `prompt_required: true` keeps the spawn off the `_input`
+        // artifact read; `worker` has no incoming edge, so it is a root the readiness
+        // sweep reports ready from the very first tick.
+        let yaml = format!(
+            "name: sbx-advance\nversion: \"1.0\"\nnodes:\n{START_END_YAML}  - id: worker\n    name: worker\n    type: doc-only\n    inputs:\n      - name: task\n    outputs:\n      - name: result\n"
+        );
+        let yaml = yaml.as_str();
+        let run_dir = repo_root.join(".pdo").join("runs").join(run_id);
+        std::fs::create_dir_all(&run_dir).unwrap();
+        std::fs::write(run_dir.join("pipeline.yaml"), yaml).unwrap();
+
+        seed_sandboxed_run_mid_prep(&state, run_id, "sbx-advance").await;
+
+        // (1) The watcher's tick, mid-prep: nothing may start.
+        spawn_ready_after_event(&state, run_id).await;
+        let events = load_events(&state.db, run_id).await.unwrap();
+        assert!(
+            !events
+                .iter()
+                .any(|e| e.kind == event_log::EventKind::NodeStarted),
+            "the watcher-driven advance must start no node while the container is \
+             still being prepared"
+        );
+
+        // The node kept NO state, so the scheduler still sees it as ready — that is
+        // what makes the replay below possible at all.
+        let run_state = event_log::project(&events).unwrap();
+        let parsed = pipeline::parse_pipeline(yaml).unwrap().pipeline;
+        assert_eq!(
+            scheduler_dispatcher::compute_ready_to_spawn(&parsed, &run_state)
+                .into_iter()
+                .map(|r| r.node_id)
+                .collect::<Vec<_>>(),
+            vec!["worker".to_string()],
+            "a deferred node must stay in the ready set, or nothing could replay it"
+        );
+
+        // (2) Prep finishes: the create-time pair replays the deferred spawn.
+        mark_sandbox_prep_ready(&state, run_id).await;
+        spawn_ready_after_event(&state, run_id).await;
+
+        let events = load_events(&state.db, run_id).await.unwrap();
+        assert!(
+            events
+                .iter()
+                .any(|e| e.kind == event_log::EventKind::NodeStarted
+                    && e.node_id.as_deref() == Some("worker")),
+            "the spawn deferred during the prep MUST be replayed once \
+             sandbox_prep_ready lands — otherwise the run wedges for ever"
+        );
+    }
+
+    /// The force-spawn path (`POST …/nodes/<id>/start`, and the manager's
+    /// `start_node`) does not route through `spawn_node`: it drives
+    /// `node_primitives::start_node`, so it states the precondition itself. 409 with a
+    /// reason, not a silent queue — "start now" must not defer, and the operator who
+    /// pressed the button gets told why.
+    #[tokio::test]
+    async fn force_spawn_is_refused_while_sandbox_prep_is_pending() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_root = tmp.path();
+        write_test_pipeline(repo_root, "sbx-force");
+        let state = test_state_with_dir(repo_root).await;
+
+        let run_id = "sbx-force-spawn";
+        seed_sandboxed_run_mid_prep(&state, run_id, "sbx-force").await;
+
+        let app = build_router(state.clone());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/runs/{run_id}/nodes/worker/start"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(
+            json["error"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("sandbox prep"),
+            "the 409 must explain that the sandbox is still being prepared, got {json}"
+        );
+
+        let events = load_events(&state.db, run_id).await.unwrap();
+        assert!(
+            !events
+                .iter()
+                .any(|e| e.kind == event_log::EventKind::NodeStarted),
+            "a refused force-spawn must start nothing"
         );
     }
 

--- a/crates/pdo-daemon/src/node_spawn.rs
+++ b/crates/pdo-daemon/src/node_spawn.rs
@@ -124,6 +124,15 @@ pub(crate) enum SpawnOutcome {
     /// The transition guard refused the spawn before any side effect
     /// (already live / already completed iteration).
     Refused { reason: String },
+    /// The Run is sandboxed and its container is not up yet (#445): the spawn was
+    /// declined before any side effect and **no event was appended**, so the node
+    /// keeps no state and the scheduler still reports it ready. It is replayed when
+    /// `SandboxPrepReady` drives the next `advance_run`.
+    ///
+    /// Distinct from [`SpawnOutcome::Refused`] (nothing to retry — the work is
+    /// already live or done) and from [`SpawnOutcome::Throttled`] (a `NodeWaiting`
+    /// reservation *was* appended and the cross-run admission sweep owns the retry).
+    Deferred { reason: String },
     /// The spawn aborted (empty script body, worktree creation failure,
     /// panic/error in the isolated span) — a failure was recorded.
     Failed { reason: String },
@@ -165,6 +174,32 @@ pub(crate) async fn spawn_node(
     // guard projection — `sandbox` never changes over a Run's life. A `bool` and not
     // the mode (#432): the profile name is owned, and only the off-ness matters here.
     let run_sandboxed = projected.as_ref().is_some_and(|s| !s.sandbox.is_off());
+
+    // #445: SANDBOX PRECONDITION — "a sandboxed Run whose prep is not `ready` is not
+    // schedulable". Carried by the spawn itself, deliberately NOT by its callers: the
+    // create path gated correctly (`lib.rs`, the detached prep task) while the pipeline
+    // watcher and `retry_waiting_nodes` reached the spawn with no idea a container was
+    // still being built, so the tail below `docker exec`ed into a name that did not
+    // exist yet → exit 1 in ~30 ms → the tmux window's command ended → `session_died`.
+    // Enforced HERE (after the transition guard, before admission and before any
+    // sub-worktree is created) so the invariant holds for every present and future
+    // caller, exactly as the transition guard does for illegal starts.
+    //
+    // Appends NOTHING and reserves nothing. That is load-bearing for the replay: a
+    // node with no state stays in `compute_ready_to_spawn`, so the `advance_run` that
+    // follows `SandboxPrepReady` starts it. A `NodeWaiting` reservation would flip it
+    // to `Waiting`, which `compute_ready_to_spawn` skips — the deferred spawn would
+    // then depend on the *cross-run* admission sweep and a Run whose only trigger was
+    // the watcher could wedge for ever. `run_stall_reason` knows about this window and
+    // will not read it as a silent spawn-abort (it fails loud only past its own
+    // sandbox-prep grace).
+    if let Some(reason) = projected.as_ref().and_then(|s| s.sandbox_spawn_block()) {
+        info!(
+            "spawn_node deferred for {} iter {iter}: {reason} (replayed on sandbox_prep_ready)",
+            node.id
+        );
+        return SpawnOutcome::Deferred { reason };
+    }
 
     // #248 / ADR-0017: refuse to spawn a `script` node with an empty body — it
     // would `bash <empty>` → exit 0 → a silent no-op masquerading as success.

--- a/crates/pdo-daemon/tests/sandbox_tracer.rs
+++ b/crates/pdo-daemon/tests/sandbox_tracer.rs
@@ -1446,3 +1446,163 @@ async fn trigger_without_sandbox_defers_to_instance_default() {
         "a null-sandbox Trigger must defer to the instance default (full): {run}"
     );
 }
+
+// -- Test 16 (#445): the watcher may not spawn into a container that isn't up --
+//
+// The reported failure, reproduced through the production trigger. `create_run`'s
+// detached prep task waits for `ensure_ready` before advancing the Run, but the
+// pipeline watcher did not: the FIRST read of a fresh `<run>/pipeline.yaml` is
+// reported by inotify as an external modification, so merely opening the Run in the
+// UI woke `handle_run_pipeline_modifications` mid-prep, which called the same
+// advance path with no precondition. The node's tail `docker exec`ed into a
+// container that did not exist yet — exit 1 in ~30 ms, the tmux window's command
+// ended, and ~25 s later the stale detector rendered `session_died`.
+//
+// A fake `docker` whose `create` SLEEPS gives a deterministic prep window (the real
+// trigger is ~1 GB of `~/.claude` staging, measured at 83-87 s for a 2 GB profile).
+// Under the same fixture the pre-#445 daemon appends `node_started` while
+// `sandbox_prep` is still `pending`, which is exactly what this asserts against.
+
+/// Like [`write_fake_docker`] but `create` sleeps `secs` first, holding the Run in
+/// `sandbox_prep = pending` long enough to fire a watcher event inside the window.
+fn write_slow_create_docker(secs: u64) -> (TempDir, String, PathBuf) {
+    let dir = tempfile::tempdir().unwrap();
+    let bin = dir.path().join("fake-docker");
+    let log = dir.path().join("argv.log");
+    let sq = |s: &str| format!("'{}'", s.replace('\'', "'\\''"));
+    let script = format!(
+        "#!/usr/bin/env bash\n\
+         printf '%s\\n' \"$@\" >> {log}\n\
+         case \"$1\" in\n\
+         image) exit 0 ;;\n\
+         container) printf '%s' 'Error: No such container' >&2; exit 1 ;;\n\
+         create) sleep {secs}; exit 0 ;;\n\
+         *) exit 0 ;;\n\
+         esac\n",
+        log = sq(&log.display().to_string()),
+    );
+    std::fs::write(&bin, script).unwrap();
+    std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
+    (dir, bin.to_str().unwrap().to_string(), log)
+}
+
+async fn wait_for_event_kind(
+    daemon: &TestDaemon,
+    run_id: &str,
+    kind: &str,
+    within: Duration,
+) -> bool {
+    let deadline = Instant::now() + within;
+    while Instant::now() < deadline {
+        if run_events(daemon, run_id)
+            .await
+            .iter()
+            .any(|e| e["kind"] == kind)
+        {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    false
+}
+
+#[tokio::test]
+async fn watcher_advance_mid_prep_never_spawns_and_is_replayed() {
+    ensure_pdo_on_path();
+    // 6s: comfortably longer than the watcher's ~1s debounce plus the round trips
+    // below, so the `pipeline_modified` advance provably lands inside the window.
+    let (_fake_dir, docker, log) = write_slow_create_docker(6);
+    let daemon =
+        TestDaemon::spawn_with_docker_override(seed("#!/usr/bin/env bash\ntrue\n"), docker)
+            .await
+            .unwrap();
+
+    let run_id = start_run(&daemon, Some("full")).await;
+
+    // The prep has started and is blocked in `docker create`.
+    assert!(
+        wait_for_event_kind(
+            &daemon,
+            &run_id,
+            "sandbox_prep_started",
+            Duration::from_secs(10)
+        )
+        .await,
+        "the detached prep task must announce itself before we probe the window"
+    );
+    let run = get_run(&daemon, &run_id).await;
+    assert_eq!(
+        run["sandbox_prep"], "pending",
+        "precondition: the Run must be mid-prep for this test to mean anything: {run}"
+    );
+
+    // Wake the watcher exactly as the UI does — an external touch of the run-scoped
+    // YAML. In production this is a *read*; a write is the same event to the daemon
+    // and is what a test can trigger deterministically.
+    let yaml_path = daemon
+        .repo_root()
+        .join(".pdo")
+        .join("runs")
+        .join(&run_id)
+        .join("pipeline.yaml");
+    let bumped = std::fs::read_to_string(&yaml_path)
+        .unwrap()
+        .replace("version: \"1.0\"", "version: \"1.1\"");
+    std::fs::write(&yaml_path, bumped).unwrap();
+
+    assert!(
+        wait_for_event_kind(
+            &daemon,
+            &run_id,
+            "pipeline_modified",
+            Duration::from_secs(5)
+        )
+        .await,
+        "the external write must reach the watcher — without this event the test \
+         proves nothing about the spawn path it drives"
+    );
+
+    // THE ASSERTION. The watcher-driven advance ran; the container is still absent.
+    let events = run_events(&daemon, &run_id).await;
+    let prep_ready_seen = events.iter().any(|e| e["kind"] == "sandbox_prep_ready");
+    assert!(
+        !prep_ready_seen,
+        "precondition: the prep must still be in flight at this point"
+    );
+    assert!(
+        !events.iter().any(|e| e["kind"] == "node_started"),
+        "the watcher-driven advance must NOT start a node while the container is \
+         still being created — that spawn is what dies as session_died: {events:#?}"
+    );
+    assert_eq!(
+        get_run(&daemon, &run_id).await["status"],
+        "running",
+        "and the Run must still be alive, not failed"
+    );
+
+    // THE OTHER HALF: the deferred spawn is replayed once the container is up.
+    assert!(
+        wait_for_event_kind(
+            &daemon,
+            &run_id,
+            "sandbox_prep_ready",
+            Duration::from_secs(20)
+        )
+        .await,
+        "the prep must finish"
+    );
+    let run = wait_node_status(&daemon, &run_id, "running").await;
+    assert_eq!(
+        run["nodes"][NODE_ID]["status"], "running",
+        "the spawn deferred during the prep must be replayed after \
+         sandbox_prep_ready — a Run whose only trigger was the watcher would \
+         otherwise wedge for ever: {run}"
+    );
+
+    // And it entered the container, not the host.
+    let t = log_text(&log);
+    assert!(
+        t.contains("exec") && t.contains(&format!("pdo-sbx-{run_id}")),
+        "the replayed tail must run inside the Run's container; log:\n{t}"
+    );
+}

--- a/docs/adr/0030-sandbox-execution-model.md
+++ b/docs/adr/0030-sandbox-execution-model.md
@@ -224,6 +224,82 @@ modèle d'*exécution*.
    installé, auto-updater off, `$HOME` inscriptible au chemin hôte) et rouvrirait une question
    d'auth que le pull anonyme évite.
 
+## Amendement — La garantie du point 4 devient une précondition du spawn (#445)
+
+Le point 4 promet « image + conteneur + staging garantis prêts **avant le premier spawn** ». Cette
+garantie n'était **pas** portée par le spawn : elle était rejouée par le seul parcours de création,
+qui attend `ensure_ready` avant `spawn_ready_after_event`. Les autres déclencheurs d'avancement
+n'en savaient rien — le watcher de pipeline (`handle_run_pipeline_modifications`) et le balayage
+d'admission cross-Run (`retry_waiting_nodes`) atteignaient le spawn pendant la prep. La tail
+`docker exec … pdo-sbx-<run>` tombait alors sur un conteneur inexistant : **exit 1 en ~30 ms**, la
+commande de la fenêtre tmux se terminait, et ~25 s plus tard le détecteur de sessions mortes rendait
+`session_died`. Reproduit 7 fois sur stack isolée ; le profil `full` était **inutilisable dès qu'on
+regardait son Run** (l'onglet ouvert lit `<run>/pipeline.yaml`, ce que le watcher rapporte comme une
+modification externe la première fois — inotify `OPEN`, pas d'édition).
+
+1. **La précondition est portée par `spawn_node`, pas par ses appelants** : « un Run sandboxé dont la
+   prep n'est pas `ready` n'est pas schedulable ». Décision pure
+   (`event_log::RunState::sandbox_spawn_block`) évaluée sur la projection déjà chargée pour le garde
+   de transition, **après** lui et **avant** l'admission comme avant toute création de sous-worktree.
+   Corriger le site d'appel du watcher aurait laissé le prochain appelant réintroduire le défaut ;
+   c'est le même argument qui a mis le garde de transition (#212) dans le spawn. Un `off` n'est
+   **jamais** bloqué (invariant byte-identique). Une prep *absente* bloque comme une prep *pendante* :
+   `RunStarted` et `SandboxPrepStarted` sont à ~100 ms l'un de l'autre et la course y tient déjà ;
+   bloquer est en outre le sens fail-safe (un blocage à tort coûte un spawn rejoué, un passage à tort
+   coûte un nœud mort).
+
+2. **Le refus n'écrit RIEN — et c'est ce qui rend le rejeu possible.** Pas de `NodeStarted` (l'event
+   qui, seul, fait rendre `session_died` 25 s plus tard), et pas de `NodeWaiting` non plus : un nœud
+   `Waiting` sort de `compute_ready_to_spawn`, donc la réservation déplacerait le rejeu sur le
+   balayage d'admission cross-Run et un Run dont le seul déclencheur était le watcher pourrait rester
+   coincé pour toujours. Sans état, le nœud reste dans l'ensemble prêt et le premier `advance_run`
+   suivant `SandboxPrepReady` le démarre. Nouvelle issue de `SpawnOutcome` (`Deferred`), distincte de
+   `Refused` (rien à reprendre) et de `Throttled` (réservation posée, retry cross-Run).
+
+3. **Le point 10 est amendé : `SandboxPrepReady` n'est plus seulement informationnel.** Il devient
+   le fait qui lève la précondition, donc **tout** parcours qui rend le conteneur réel doit l'émettre
+   — ce qui **renverse** le « non émis au ré-armement » du point 10 pour `resume_run` et la boot
+   recovery. Sans ça, un Run qui a échoué *pendant* sa prep garde une projection `pending` pour
+   toujours et chaque spawn est différé pour toujours : l'interblocage que la précondition ne doit
+   pas créer. Émis seulement après un `ensure_ready` en `Ok` (l'event ne prétend jamais qu'un
+   conteneur est là), et seulement si le Run était effectivement bloqué (un resume ou un boot de
+   routine n'ajoute pas d'event no-op). `open_run_shell` reste **non émetteur** : il ressuscite un Run
+   terminal, où rien ne sera spawné — un resume ultérieur repasse par `ensure_ready` de toute façon.
+
+4. **La réconciliation de stall devient sandbox-consciente.** Un Run en prep présente *exactement* la
+   signature #279 d'un spawn silencieusement avorté (nœud prêt, aucun nœud vivant, horloge d'inactivité
+   qui monte — la prep n'émet rien pendant qu'elle travaille). Sans arme dédiée, `run_stall_reason`
+   tuait donc précisément les Runs lents que la précondition venait de sauver (83-87 s mesurés pour un
+   profil de 2 Go, davantage sur un `docker build` froid, contre une fenêtre de 120 s). D'où une
+   **grâce plus longue et non une exemption** (`SANDBOX_PREP_STALL_GRACE_SECS`, 15 min) : au-delà, la
+   tâche de prep est réellement perdue (morte avec un daemon précédent) et le Run échoue avec une
+   cause qui **nomme la sandbox** au lieu d'accuser tmux. Différer indéfiniment aurait échangé un faux
+   échec contre un stall silencieux, qu'ADR-0004 interdit tout autant.
+
+5. **Le chemin force-spawn répète la précondition, en `409`.** `force_spawn_node` (bouton Start de
+   l'UI, `start_node` du manager) ne passe pas par `spawn_node` : il pilote
+   `node_primitives::start_node`. Il refuse donc explicitement plutôt que de différer — « démarrer
+   maintenant » ne doit pas se mettre en file — en miroir du fail-fast au cap de sessions.
+
+6. **Une prep dont le Run est devenu terminal est abandonnée.** Observé : `container Created` +27 à
+   +35 s **après** `run_failed`, puis un `sandbox_prep_ready` sur un cadavre — un conteneur que
+   personne n'exécutera jamais. Le point 1 supprime la cause ; il reste les cas légitimes (l'humain
+   stoppe ou tue un Run en cours de prep). À la fin d'`ensure_ready`, si le Run est terminal : aucun
+   event, aucun spawn, aucun manager, et `docker rm -f` du conteneur (idempotent, best-effort — un
+   `resume_run` le recrée). Le staging est **conservé** : c'est `cleanup_run` qui le purge, et le
+   détruire ici détruirait les transcripts que `merge_back` moissonne. **Résidu assumé** : la marche
+   filesystem déjà lancée n'est pas interrompue — `sandbox_staging::prepare` est un module pur sans
+   seam d'annulation, et y ajouter un jeton de cancellation pour ce seul cas coûterait plus que le
+   gigaoctet qu'il économise. Le gaspillage est borné à une copie, sans conteneur ni event derrière.
+
+Non traité ici, et **volontairement** : le réveil parasite du watcher lui-même. La première *lecture*
+de `<run>/pipeline.yaml` est rapportée comme une modification externe (masque inotify `OPEN` armé par
+`notify`, aucun filtrage d'`EventKind` par le debouncer, et `content_actually_changed` renvoie `true`
+faute de baseline pour un Run neuf — `seed_run_mtimes` ne tourne qu'au boot ; `copy_pipeline_to_run`
+est par ailleurs le seul écrivain de l'arbre qui n'appelle jamais `mark_self_write`). C'est un
+`pipeline_modified` mensonger, une fois par Run, à traiter pour lui-même : supprimer ce déclencheur
+n'aurait rien corrigé, puisque la précondition doit tenir quel que soit **qui** avance le Run.
+
 Le corps de cette ADR (points 1-10) est laissé **tel quel**, dans le vocabulaire d'avant #426 : y
 lire `full` partout où il dit `copy`, et `minimal` partout où il dit `pure`.
 


### PR DESCRIPTION
## Contexte

ADR-0030 (point 4) promet « conteneur prêt avant le premier spawn ». En pratique seul le **parcours
de création** l'honorait : il attend `ensure_ready` avant d'avancer le Run. Le **watcher de pipeline**
et `retry_waiting_nodes` atteignaient `spawn_node` *pendant* la prep. La tail
`docker exec … pdo-sbx-<run>` tombait alors sur un conteneur inexistant → exit 1 en ~30 ms → la
commande de la fenêtre tmux se terminait → `session_died` ~25 s plus tard.

Profil `full` mort **7 fois sur 7**, et systématiquement dès qu'un onglet du Run était ouvert dans
l'UI : la simple **lecture** de `<run>/pipeline.yaml` (inotify `OPEN`) réveille le watcher. C'est le
déclencheur — une lecture, pas une écriture.

## Le correctif

La précondition change de porteur : elle passe des appelants au **spawn lui-même**.

- `RunState::sandbox_spawn_block()` — décision **pure** (`off` jamais bloqué, `ready` jamais bloqué,
  `pending` et `absent` bloqués).
- Appliquée dans `spawn_node`, après le garde de transition et avant l'admission comme avant tout
  sous-worktree : couvre donc **tous** les appelants, présents et futurs.
- Le refus n'écrit **rien** (ni `NodeStarted` ni `NodeWaiting`). Un nœud sans état reste dans
  `compute_ready_to_spawn`, ce qui rend le **rejeu** possible par l'`advance_run` qui suit
  `SandboxPrepReady`. `SpawnOutcome::Deferred` est le retour dédié.
- `SandboxPrepReady` cesse d'être purement informationnel : il **lève** la précondition. `resume_run`
  et la boot recovery l'émettent donc aussi quand elles ré-arment le conteneur d'un Run resté
  `pending` — sans quoi un Run ayant échoué *pendant* sa prep serait bloqué à vie (l'interblocage à
  éviter, et le risque principal du correctif).
- `run_stall_reason` gagne une **grâce sandbox de 15 min** : une prep de 2 Go dure 83-87 s, davantage
  sur un build froid, et la fenêtre #279 de 120 s tuait précisément les Runs lents que la
  précondition sauve. Grâce plus longue, pas exemption : au-delà, échec avec une cause qui nomme la
  sandbox, pas tmux.
- `force_spawn_node` (2ᵉ chemin de spawn, hors `spawn_node`) refuse en **409**.
- Une prep dont le Run est devenu terminal est **abandonnée** : ni event, ni spawn, ni manager, et
  `docker rm -f` du conteneur (le staging reste pour `merge_back`).

## Tests

- **layer-1** : table complète de la décision pure.
- **unit** : spawn différé sans event, `off` jamais bloqué, rejeu de bout en bout sur `advance_run`,
  409 du force-spawn, les deux bornes de la grâce.
- **layer-3** `sandbox_tracer` : fake docker dont `create` dort, réveil réel du watcher mid-prep →
  aucun `node_started`, puis nœud démarré dans le conteneur après `sandbox_prep_ready`.

Chaque test a été vérifié rouge sans le correctif.

## Validation en conditions réelles — verdict **Pass**

11 Runs sur une **stack isolée** (port 6455, faux `$HOME`, clone dédié), **docker réel**, profil
`full-heavy` (~2 Go de staging, preps de 16 à 50 s), avec un **contrôle négatif** compilé depuis le
commit parent `a2c227d` et exécuté sur la même stack, la même base, le même pipeline.

| | commit parent `a2c227d` | correctif |
|---|---|---|
| Runs via l'**UI** (onglet ouvert) | **panne 3/3** — écarts de -15,2 s, -26,1 s, -25,5 s ; session tmux disparue, sortie vide, Run bloqué sur `running` | **0 panne sur 3** — conteneur créé 7,5 s *avant* le nœud ; nœud rejoué 14-27 ms après `sandbox_prep_ready` ; Runs complétés |
| Run `sandbox=off` | — | intact : `node_started` immédiat, aucun event de prep, zéro deferral, complété en < 4 s sur l'hôte |

Corroborations relevées **hors event-log** : ordre de création du conteneur (docker), vie de la
session tmux sur le socket, exécution réellement *dans* le conteneur (`hostname 27687fb0ac5b`,
`whoami ubuntu`, `/.dockerenv`, extra `heavy` de 986 Mo monté), contenu réellement écrit.

Le journal daemon montre le refus, deux fois (un par réveil du watcher) :

```
spawn_node deferred for PROBE001 iter 1: sandbox prep for run 20260725-095859-30e0958
(profile `full-heavy`) is still in progress: its container is not up, so no session
can be launched yet (replayed on sandbox_prep_ready)
```

### Enseignement pour la non-régression

Les deux premiers Runs de contrôle lancés **par l'API, sans onglet ouvert**, ont **réussi** sur le
binaire cassé. Sans lecteur du répertoire du Run, le watcher ne se réveille pas et le garde du
parcours de création — déjà correct — suffit. **Toute recette de non-régression sur #445 doit donc
passer par l'UI ; une recette API est structurellement aveugle au défaut.**

### Réserves portées au dossier (n'affectent pas le verdict)

1. `cargo test` / `cargo nextest` n'ont pas pu être exécutés par le nœud de validation (leurs
   `TestDaemon` balaient les orphelins et interfèrent avec le daemon parent). Le signal de validation
   est **comportemental** (11 Runs, docker réel), pas le vert de la suite — le contrôle négatif joue
   le rôle du « rouge sans le correctif », mais au niveau du système entier. La suite reste gatée par
   la CI de cette PR.
2. La grâce anti-stall n'a pas été **exercée** : les preps ont culminé à 50 s, sous l'ancienne fenêtre
   de 120 s. Elle reste couverte uniquement par ses tests unitaires.

## Docs

Amendement ADR-0030 (précondition, émetteurs, grâce, abandon) + CONTEXT.md.

---

Livre #445. PR ouverte sur la branche d'intégration `integration/prd-403-sandbox`, pas sur `main` :
l'issue est fermée à la main puisque GitHub n'honore les mots-clés de fermeture que sur la branche
par défaut. Pas de bump de version — il aura lieu une fois, au merge de l'intégration vers `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
