### PR TITLE
fix(#447): un résolveur unique pour l'URL du daemon — le préambule manager suit le côté d'exécution

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -740,7 +740,7 @@ GET    /fs/browse?path=&files=&hidden=     — listing filesystem à un niveau (
 
 ### Conséquence pour la prompt augmentation
 
-Le préambule runtime injecté dans chaque NodeRun (cf. section *Prompt augmentation*) inclut, en plus des chemins d'inputs/outputs, **l'URL de base du daemon** (`http://localhost:<port>`) pour les nœuds qui en ont besoin (typiquement le manager, mais aussi un nœud "Shipper" qui voudrait poster un commentaire sur l'issue source via les endpoints, etc.).
+Le préambule runtime injecté dans chaque NodeRun (cf. section *Prompt augmentation*) inclut, en plus des chemins d'inputs/outputs, **l'URL de base du daemon** pour les nœuds qui en ont besoin (typiquement le manager, mais aussi un nœud "Shipper" qui voudrait poster un commentaire sur l'issue source via les endpoints, etc.). Cette URL **n'est pas une constante** : elle dépend du côté où l'agent s'exécute (`http://localhost:<port>` sur l'hôte, la gateway du conteneur en sandbox) et passe donc par le **résolveur d'URL du daemon** — cf. section *Sandbox*.
 
 ---
 
@@ -1082,6 +1082,18 @@ La séquence d'arguments préposée à la tail d'un nœud pour la faire tourner 
 l'hôte. En mode `off` le préfixe est **vide** (exécution hôte). Pur : construction d'argv, sans
 effet de bord. Ne re-passe jamais `PDO_DAEMON_URL` (posé au create vers `host.docker.internal`).
 _Éviter_ : « wrapper », « shim ».
+
+**Résolveur d'URL du daemon (`daemon_url(port, sandboxed)`)** :
+La fonction **pure et unique** qui rend l'URL du daemon **telle qu'elle est joignable depuis le côté
+où l'agent s'exécute** : `http://localhost:<port>` côté hôte, `http://host.docker.internal:<port>`
+depuis l'intérieur du conteneur. Vit dans `sandbox_container` parce que c'est le module qui possède
+le `--add-host` créant cette gateway : le hostname n'a donc **qu'une** occurrence. Ses deux
+consommateurs sont le `-e PDO_DAEMON_URL` du `docker create` **et** le **texte** du préambule
+manager — c'est ce qui interdit la dérive #447 (l'env résolu, la prose codée en dur sur `localhost`,
+un manager sandboxé qui déclare le daemon mort). Son booléen nomme le **côté d'exécution**, pas le
+mode du Run : les exports d'env côté hôte du wrapper passent `false` même pour un Run sandboxé,
+puisqu'ils ne traversent pas le `docker exec`. _Éviter_ : « URL du daemon » tout court (ambigu entre
+l'env et le texte), « unifier les occurrences de localhost » (deux d'entre elles sont légitimes).
 
 **Marqueur de session (`PDO_SBX_SESSION`)** :
 La **variable d'environnement** (`PDO_SBX_SESSION=<nom-de-session>`) posée sur **chaque** `docker

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -6424,7 +6424,12 @@ fn spawn_manager_session(
     name_hint: prompt_augmenter::RunNameHint,
     sandboxed: bool,
 ) {
-    let daemon_url = format!("http://localhost:{}", state.port);
+    // #447: the URL must be the one reachable from the side this manager will run
+    // on. A sandboxed manager execs into the Run's container, where `localhost` is
+    // the container — every `curl` of its own preamble hit nothing, and the manager
+    // reported the daemon dead (falsely, and with confidence) instead of issuing its
+    // commands. `sandboxed` is already in hand two lines below for the `SandboxWrap`.
+    let daemon_url = sandbox_container::daemon_url(state.port, sandboxed);
 
     let static_prompt = std::fs::read_to_string(
         state

--- a/crates/pdo-daemon/src/node_primitives.rs
+++ b/crates/pdo-daemon/src/node_primitives.rs
@@ -131,6 +131,14 @@ pub fn start_node(params: &StartNodeParams<'_>) -> StartNodeResult {
         }
     };
 
+    // #447: same single resolver as the manager preamble and `PDO_DAEMON_URL`. A
+    // sandboxed node's session execs into the container, where `localhost` is the
+    // container. NOTE: `AugmentContext.daemon_url` currently has no consumer — no
+    // node preamble prints it — so this is defensive, not the fix for the observed
+    // symptom (that one is the manager, `lib.rs`). Resolving it here means a future
+    // node preamble that does print it inherits the correct URL instead of the bug.
+    let sandboxed = !params.run_state.sandbox.is_off();
+
     let aug_ctx = crate::prompt_augmenter::AugmentContext {
         pipeline: params.pipeline,
         node,
@@ -138,7 +146,7 @@ pub fn start_node(params: &StartNodeParams<'_>) -> StartNodeResult {
         iter: params.iter,
         artifacts_dir: params.artifacts_dir,
         variables: params.resolved_vars,
-        daemon_url: &format!("http://localhost:{}", params.daemon_port),
+        daemon_url: &crate::sandbox_container::daemon_url(params.daemon_port, sandboxed),
         foreach_context: None,
         source_worktree_dir: has_sub_worktree.then_some(working_dir.as_path()),
         input_images: Vec::new(),
@@ -221,14 +229,13 @@ pub fn start_node(params: &StartNodeParams<'_>) -> StartNodeResult {
         tmux_session_manager::node_session_name(params.run_id, params.node_id, params.iter);
     // #407: wrap the tail into the Run's container when sandboxed (manual
     // force-spawn / restart door, #204). Marker = the session name (kill target).
-    let sandbox_wrap =
-        (!params.run_state.sandbox.is_off()).then(|| tmux_session_manager::SandboxWrap {
-            docker_bin: params.docker_cmd_override.unwrap_or("docker"),
-            uid: crate::sandbox_container::host_uid(),
-            gid: crate::sandbox_container::host_gid(),
-            marker: &session_name,
-            workdir: &working_dir,
-        });
+    let sandbox_wrap = sandboxed.then(|| tmux_session_manager::SandboxWrap {
+        docker_bin: params.docker_cmd_override.unwrap_or("docker"),
+        uid: crate::sandbox_container::host_uid(),
+        gid: crate::sandbox_container::host_gid(),
+        marker: &session_name,
+        workdir: &working_dir,
+    });
     if let Err(e) = tmux_session_manager::spawn(
         &session_name,
         spawn_prompt,

--- a/crates/pdo-daemon/src/node_spawn.rs
+++ b/crates/pdo-daemon/src/node_spawn.rs
@@ -384,7 +384,11 @@ pub(crate) async fn spawn_node(
             iter,
             artifacts_dir: spawn_ctx.artifacts_dir,
             variables: spawn_ctx.resolved_vars,
-            daemon_url: &format!("http://localhost:{}", deps.port),
+            // #447: same single resolver as the manager preamble and
+            // `PDO_DAEMON_URL` — `run_sandboxed` is already projected above for the
+            // spawn precondition. Defensive here: no node preamble consumes
+            // `daemon_url` yet (see the note in `node_primitives::start_node`).
+            daemon_url: &crate::sandbox_container::daemon_url(deps.port, run_sandboxed),
             foreach_context,
             source_worktree_dir: has_sub_worktree.then_some(working_dir.as_path()),
             input_images,

--- a/crates/pdo-daemon/src/prompt_augmenter.rs
+++ b/crates/pdo-daemon/src/prompt_augmenter.rs
@@ -1613,6 +1613,40 @@ mod tests {
         assert!(preamble.contains("Content-Type: application/json"));
     }
 
+    // #447: the preamble takes the URL as a *parameter* — these tests pin the
+    // composition with the shared resolver, i.e. what the daemon actually hands it
+    // on each path. Asserting the ABSENCE of the wrong host is the load-bearing
+    // half: the bug was not a missing URL, it was a plausible wrong one that the
+    // manager obeyed and then reported the daemon dead.
+
+    #[test]
+    fn manager_preamble_sandboxed_carries_the_container_side_url_only() {
+        let url = crate::sandbox_container::daemon_url(6193, true);
+        let preamble = build_manager_preamble("run-1", &url, RunNameHint::DeriveFromInput);
+        assert!(
+            preamble.contains("Daemon base URL: `http://host.docker.internal:6193`"),
+            "a sandboxed manager must be told the gateway URL: {preamble}"
+        );
+        assert!(
+            !preamble.contains("localhost:6193"),
+            "no `curl` line may keep the host-only URL — inside the container it \
+             resolves to the container itself and every command silently fails"
+        );
+        // The very command the bug swallowed: the first-action rename.
+        assert!(preamble.contains("http://host.docker.internal:6193/runs/run-1/commands"));
+    }
+
+    #[test]
+    fn manager_preamble_host_path_is_unchanged() {
+        let url = crate::sandbox_container::daemon_url(6193, false);
+        let preamble = build_manager_preamble("run-1", &url, RunNameHint::DeriveFromInput);
+        assert!(preamble.contains("Daemon base URL: `http://localhost:6193`"));
+        assert!(
+            !preamble.contains("host.docker.internal"),
+            "non-regression: an `off` Run's manager must never see the gateway host"
+        );
+    }
+
     #[test]
     fn manager_prompt_combines_preamble_and_role() {
         let prompt = build_manager_prompt(

--- a/crates/pdo-daemon/src/sandbox_container.rs
+++ b/crates/pdo-daemon/src/sandbox_container.rs
@@ -44,6 +44,11 @@
 //!   donc `-e PDO_DAEMON_URL=http://host.docker.internal:<port>` (couplé à `--add-host`), et
 //!   [`exec_prefix`] ne re-passe JAMAIS cette var (un `-e PDO_DAEMON_URL` nu clobbererait la
 //!   gateway par le `localhost` hôte). L'exec ne forwarde que les vars PAR-NŒUD.
+//! - **[`daemon_url`] est le résolveur UNIQUE de cette URL (#447).** Ce module possède le
+//!   hostname de la gateway parce qu'il possède le `--add-host` qui la crée : le littéral
+//!   n'apparaît donc qu'ici. Le `-e PDO_DAEMON_URL` du create **et** le texte des préambules
+//!   (manager, ADR-0030 §8) passent par le même appel — c'est ce qui interdit qu'un chemin
+//!   résolve pendant que l'autre reste sur `localhost`.
 
 #![allow(dead_code)] // Tracer bullet : consommé/câblé par #407, non câblé dans cette slice.
 
@@ -57,6 +62,42 @@ use crate::sandbox_image::DOCKER_NOT_FOUND_MSG;
 /// Env var portée par CHAQUE `docker exec`, héritée par `claude` et toute sa descendance ;
 /// clé du kill ciblé (scan `/proc/*/environ`). N'est PAS un label Docker.
 pub(crate) const SESSION_MARKER_ENV: &str = "PDO_SBX_SESSION";
+
+// -- résolveur d'URL du daemon (#447) ----------------------------------------
+
+/// Hostname du daemon **vu depuis le côté hôte** : le conteneur exclu, `localhost`
+/// désigne bien la machine qui écoute.
+const HOST_SIDE_HOST: &str = "localhost";
+
+/// Hostname de la gateway hôte **vu depuis l'intérieur du conteneur**, matérialisée
+/// par le `--add-host host.docker.internal:host-gateway` de [`create_args`]. Dans le
+/// conteneur, `localhost` désigne le conteneur : c'est ce hostname-là, et lui seul,
+/// qui joint le daemon.
+const CONTAINER_SIDE_HOST: &str = "host.docker.internal";
+
+/// Résolveur PUR de l'URL du daemon **telle qu'elle est joignable depuis le côté où
+/// l'agent s'exécute** (#447).
+///
+/// Le bug qu'il ferme : l'URL existait sous DEUX représentations du même fait —
+/// l'env `PDO_DAEMON_URL` (résolue, donc correcte dans le conteneur) et le **texte**
+/// du préambule (codé en dur sur `localhost`). Un agent sandboxé qui obéissait aux
+/// `curl` de son propre préambule tapait dans le vide et en concluait, de bonne foi,
+/// que le daemon était mort — panne silencieuse, intermittente et *affirmative*.
+/// Un seul résolveur, consommé par les deux, rend la dérive impossible (leçon #373).
+///
+/// **Ce résolveur ne s'applique PAS aux exports d'env côté hôte du wrapper
+/// `docker exec`** (`tmux_session_manager::wrap_with_env`) : ceux-là tournent AVANT
+/// le `docker exec`, ne traversent pas dans le conteneur, et doivent donc rester
+/// `localhost` (ADR-0030 §5). Ils appellent avec `sandboxed = false` — l'argument
+/// nomme le côté d'exécution, pas le mode du Run.
+pub(crate) fn daemon_url(port: u16, sandboxed: bool) -> String {
+    let host = if sandboxed {
+        CONTAINER_SIDE_HOST
+    } else {
+        HOST_SIDE_HOST
+    };
+    format!("http://{host}:{port}")
+}
 
 // -- type valeur (assemblé par les résolveurs, nourrit les builders purs) ----
 
@@ -130,7 +171,7 @@ pub(crate) fn create_args(run_id: &str, spec: &ContainerSpec) -> Vec<String> {
         format!("{}:{}", spec.uid, spec.gid),
         // --add-host : la gateway que `-e PDO_DAEMON_URL` ci-dessous pointe.
         "--add-host".to_string(),
-        "host.docker.internal:host-gateway".to_string(),
+        format!("{CONTAINER_SIDE_HOST}:host-gateway"),
         // -w au create (cosmétique, satisfait l'AC ; load-bearing = par-exec).
         "-w".to_string(),
         spec.run_worktree.display().to_string(),
@@ -138,10 +179,9 @@ pub(crate) fn create_args(run_id: &str, spec: &ContainerSpec) -> Vec<String> {
         "-e".to_string(),
         format!("HOME={}", spec.host_home.display()),
         "-e".to_string(),
-        format!(
-            "PDO_DAEMON_URL=http://host.docker.internal:{}",
-            spec.daemon_port
-        ),
+        // #447 : la MÊME résolution que celle du texte des préambules. L'env et la
+        // prose ne peuvent plus diverger.
+        format!("PDO_DAEMON_URL={}", daemon_url(spec.daemon_port, true)),
         "-e".to_string(),
         format!("PDO_RUN_ID={run_id}"),
         "-e".to_string(),
@@ -713,6 +753,54 @@ mod tests {
                 .and_then(std::io::Error::raw_os_error)
                 == Some(26)
         })
+    }
+
+    // -- 0. résolveur d'URL du daemon (#447) ----------------------------------
+
+    /// Les deux côtés d'exécution rendent des hostnames DIFFÉRENTS, et le port suit.
+    /// C'est la propriété que le bug violait : une seule des deux formes existait.
+    #[test]
+    fn daemon_url_resolves_per_execution_side() {
+        assert_eq!(daemon_url(6193, false), "http://localhost:6193");
+        assert_eq!(
+            daemon_url(6193, true),
+            "http://host.docker.internal:6193",
+            "un agent dans le conteneur ne joint le daemon que par la gateway"
+        );
+        assert_ne!(daemon_url(6193, true), daemon_url(6193, false));
+    }
+
+    /// L'anti-dérive : la valeur de `-e PDO_DAEMON_URL` posée au create N'EST PAS un
+    /// littéral parallèle, c'est **le même appel** que celui du texte des préambules.
+    /// Si ce test tombe, l'env et la prose ont recommencé à diverger — le bug #447.
+    #[test]
+    fn create_env_daemon_url_comes_from_the_shared_resolver() {
+        let fx = Fixtures::sample();
+        let args = create_args("r1", &fx.spec());
+        let posed = args
+            .iter()
+            .find_map(|a| a.strip_prefix("PDO_DAEMON_URL="))
+            .expect("le create pose PDO_DAEMON_URL");
+        assert_eq!(posed, daemon_url(6172, true));
+    }
+
+    /// Le hostname de la gateway que le create **crée** (`--add-host`) est le même que
+    /// celui que le résolveur **rend**. Deux littéraux désynchronisés donneraient un
+    /// `PDO_DAEMON_URL` pointant vers un nom que le conteneur ne résout pas.
+    #[test]
+    fn add_host_and_resolver_name_the_same_gateway() {
+        let fx = Fixtures::sample();
+        let args = create_args("r1", &fx.spec());
+        let mapping = args
+            .iter()
+            .find(|a| a.ends_with(":host-gateway"))
+            .expect("le create pose --add-host");
+        let host = mapping.trim_end_matches(":host-gateway");
+        assert!(
+            daemon_url(6172, true).contains(host),
+            "--add-host {host} n'est pas le hostname du résolveur ({})",
+            daemon_url(6172, true)
+        );
     }
 
     // -- 1. create_args golden (AC#1, éclaté en trois en #432) ----------------

--- a/crates/pdo-daemon/src/tmux_session_manager.rs
+++ b/crates/pdo-daemon/src/tmux_session_manager.rs
@@ -246,7 +246,16 @@ fn wrap_with_env(
         run_id_q = sh_single_quote(run_id),
         node_id_q = sh_single_quote(node_id),
         iter_q = sh_single_quote(&iter.to_string()),
-        daemon_url_q = sh_single_quote(&format!("http://localhost:{daemon_port}")),
+        // #447: `sandboxed = false` is NOT an oversight — these exports run on the
+        // HOST side of the `docker exec` wrapper (see `build_tmux_script`: the
+        // wrapped tail is the *argument* of `wrap_with_env`, so the exports execute
+        // before the exec and never cross into the container). Resolving to the
+        // gateway here would hand the host path a hostname it can't resolve, and
+        // would be dead bytes on the sandbox path — the `docker create` already
+        // posted the container-side value, which the exec deliberately never
+        // clobbers (ADR-0030 §5). Routed through the resolver anyway so the literal
+        // lives in exactly one module.
+        daemon_url_q = sh_single_quote(&crate::sandbox_container::daemon_url(daemon_port, false)),
     );
 
     format!("exec bash -c {}", sh_single_quote(&inner))

--- a/crates/pdo-daemon/tests/sandbox_tracer.rs
+++ b/crates/pdo-daemon/tests/sandbox_tracer.rs
@@ -12,7 +12,11 @@
 //!   4. `cleanup_run` removes the container (`rm -f pdo-sbx-<run>`) + purges staging;
 //!   5. `boot_recovery` re-ensures a live sandboxed run's container;
 //!   6. killing a sandboxed node issues a targeted in-container `docker exec` kill
-//!      carrying the session marker.
+//!      carrying the session marker;
+//!   7. the **manager preamble text** names the daemon by the hostname reachable from
+//!      the side it will run on — the gateway when sandboxed, `localhost` when `off`
+//!      (#447). The preamble file is written before tmux is invoked, so this is
+//!      assertable without a real claude.
 //!
 //! The real end-to-end run (a live container, `pdo complete` from inside it) is
 //! the Layer-5 job — a fake `docker exec` cannot run the node's body, so tests
@@ -1604,5 +1608,106 @@ async fn watcher_advance_mid_prep_never_spawns_and_is_replayed() {
     assert!(
         t.contains("exec") && t.contains(&format!("pdo-sbx-{run_id}")),
         "the replayed tail must run inside the Run's container; log:\n{t}"
+    );
+}
+
+// -- Test 12: the manager preamble carries the URL of the side it runs on (#447)
+
+/// The manager's runtime preamble as written to disk by `tmux_session_manager::spawn`
+/// (`<worktree>/.pdo/prompts/__manager__-iter-0.md`). Written *before* tmux is
+/// invoked, so it exists whether or not the harmless tail actually started.
+fn manager_preamble_path(daemon: &TestDaemon, run_id: &str) -> PathBuf {
+    daemon
+        .repo_root()
+        .join(".pdo/runs")
+        .join(run_id)
+        .join("worktree/.pdo/prompts/__manager__-iter-0.md")
+}
+
+async fn read_manager_preamble(daemon: &TestDaemon, run_id: &str) -> String {
+    let path = manager_preamble_path(daemon, run_id);
+    assert!(
+        wait_until(|| path.exists()).await,
+        "the manager preamble must be written at {}",
+        path.display()
+    );
+    std::fs::read_to_string(&path).unwrap()
+}
+
+/// #447: a sandboxed manager execs into the Run's container, where `localhost` is
+/// the container — so the `curl` lines of its own preamble must name the host
+/// gateway. Before the fix the text said `localhost:<port>`, the manager obeyed it,
+/// got connection-refused on every call, and reported "the daemon is down" on a
+/// perfectly healthy daemon — losing its whole command surface (starting with the
+/// `rename_run` its preamble demands as a first action).
+///
+/// The assertion that matters is the ABSENCE of `localhost:<port>`: a preamble that
+/// merely *mentions* the gateway somewhere while still printing host-only `curl`
+/// commands reproduces the bug exactly.
+#[tokio::test]
+async fn sandboxed_manager_preamble_uses_the_container_side_url() {
+    ensure_pdo_on_path();
+    let (_fake_dir, docker, _log) = write_fake_docker();
+    let daemon =
+        TestDaemon::spawn_with_docker_override(seed("#!/usr/bin/env bash\ntrue\n"), docker)
+            .await
+            .unwrap();
+
+    let run_id = start_run(&daemon, Some("minimal")).await;
+    // The manager is spawned by the prep task, right after `sandbox_prep_ready`.
+    wait_node_status(&daemon, &run_id, "running").await;
+
+    let port = daemon.addr.port();
+    let preamble = read_manager_preamble(&daemon, &run_id).await;
+
+    assert!(
+        preamble.contains(&format!(
+            "Daemon base URL: `http://host.docker.internal:{port}`"
+        )),
+        "preamble:\n{preamble}"
+    );
+    assert!(
+        !preamble.contains(&format!("localhost:{port}")),
+        "no line may keep the host-only URL — from inside the container it resolves \
+         to the container itself, so every command fails and the manager concludes \
+         the daemon is dead:\n{preamble}"
+    );
+    // The command endpoint specifically: this is the surface the bug removed.
+    assert!(
+        preamble.contains(&format!(
+            "POST http://host.docker.internal:{port}/runs/{run_id}/commands"
+        )),
+        "preamble:\n{preamble}"
+    );
+}
+
+/// Non-regression twin: an `off` Run's manager runs on the host, so its preamble
+/// must stay exactly as it was — `localhost`, and no gateway hostname anywhere.
+#[tokio::test]
+async fn off_run_manager_preamble_stays_on_localhost() {
+    ensure_pdo_on_path();
+    let (_fake_dir, docker, log) = write_fake_docker();
+    let daemon =
+        TestDaemon::spawn_with_docker_override(seed("#!/usr/bin/env bash\ntrue\n"), docker)
+            .await
+            .unwrap();
+
+    let run_id = start_run(&daemon, None).await;
+    let port = daemon.addr.port();
+    let preamble = read_manager_preamble(&daemon, &run_id).await;
+
+    assert!(
+        preamble.contains(&format!("Daemon base URL: `http://localhost:{port}`")),
+        "preamble:\n{preamble}"
+    );
+    assert!(
+        !preamble.contains("host.docker.internal"),
+        "the host path must never be handed the container-only hostname:\n{preamble}"
+    );
+    // And the `off` parcours still never touches docker.
+    assert_eq!(
+        log_text(&log),
+        "",
+        "the `off` path must not invoke docker at all"
     );
 }

--- a/docs/adr/0030-sandbox-execution-model.md
+++ b/docs/adr/0030-sandbox-execution-model.md
@@ -303,6 +303,52 @@ n'aurait rien corrigé, puisque la précondition doit tenir quel que soit **qui*
 Le corps de cette ADR (points 1-10) est laissé **tel quel**, dans le vocabulaire d'avant #426 : y
 lire `full` partout où il dit `copy`, et `minimal` partout où il dit `pure`.
 
+## Amendement — L'URL du daemon a un résolveur unique ; le préambule en est un consommateur (#447)
+
+Le point 3 ne parlait que de **l'env** `PDO_DAEMON_URL`. Le **texte** des préambules construisait la
+sienne, codée en dur sur `localhost:<port>`, indépendamment du mode du Run. Un préambule de manager
+sandboxé listait donc des `curl` que le conteneur ne peut pas joindre : `localhost` y désigne le
+conteneur. Le manager obéissait, récoltait des refus de connexion sur **tous** ses appels, et en
+concluait — de bonne foi et avec assurance — que le daemon était mort, pendant que le pied de page de
+la même fenêtre affichait « Daemon: connected ». Reproduit 3 fois sur 3 sur stack isolée, avec
+contrôle négatif `off`.
+
+Ce n'était pas de la prose fausse mais une **perte de fonctionnalité** : toute la surface de commande
+du manager (`rename_run`, `restart_node`, `kill_node`, `mark_node_done`, `extend_cycle`,
+`cleanup_run`…) devenait inatteignable sur un Run sandboxé, en commençant par le `rename_run` que le
+préambule impose comme première action — d'où des Runs sandboxés restés sans nom. Et la panne est
+**intermittente** : sur deux Runs mesurés, un manager s'en est sorti en inspectant `$PDO_DAEMON_URL`
+de sa propre initiative, l'autre a refusé d'émettre quoi que ce soit. Le pire profil de panne :
+silencieuse, non déterministe, et affirmative.
+
+1. **Un résolveur pur unique, `sandbox_container::daemon_url(port, sandboxed)`.** Il vit dans le
+   module qui possède le `--add-host host.docker.internal:host-gateway`, parce que le hostname de la
+   gateway et la gateway elle-même sont **le même fait** : le littéral n'apparaît donc qu'une fois.
+   Le `-e PDO_DAEMON_URL` du create et le texte du préambule manager sont désormais deux
+   **consommateurs** du même appel — l'env et la prose ne peuvent plus diverger (leçon #373 : un seul
+   résolveur, zéro drift).
+
+2. **L'argument nomme le côté d'exécution, pas le mode du Run.** Nuance load-bearing : les exports
+   d'env côté hôte du wrapper (`wrap_with_env`, point 5) appellent avec `sandboxed = false` **même
+   pour un Run sandboxé**, parce qu'ils s'exécutent avant le `docker exec` et ne traversent pas. Y
+   plaquer le résolveur « selon le mode du Run » aurait inversé la logique, ou produit des octets
+   morts sur le chemin sandbox tout en cassant l'identité-octet du chemin `off`. Un résolveur partagé
+   n'autorise pas à unifier les sites sans distinguer les côtés.
+
+3. **Le préambule de nœud n'était pas le symptôme, et le reste.** `AugmentContext.daemon_url` n'a
+   **aucun consommateur** : aucun préambule de nœud n'imprime d'URL ni de `curl` (vérifié en
+   exécution, 489 octets sans URL). Les deux sites de nœud sont donc des valeurs mortes ; ils passent
+   quand même par le résolveur, pour qu'un futur préambule de nœud n'hérite pas du bug — mais la
+   preuve d'acceptation ne peut passer que par le manager, seul préambule qui imprime l'URL.
+
+4. **La preuve est un test de couche 3, pas un unit test.** `build_manager_preamble` prend l'URL en
+   paramètre : un unit test ne prouve que la composition, jamais que `spawn_manager_session` passe le
+   bon booléen — exactement ce que le bug ratait. Le test lit donc le **fichier de préambule écrit sur
+   disque** (`<worktree>/.pdo/prompts/__manager__-iter-0.md`, écrit avant l'appel à tmux, donc
+   assertable sans vrai claude) pour un Run `minimal` et pour son jumeau `off`. L'assertion portante
+   est l'**absence** de `localhost:<port>` : un préambule qui mentionne la gateway quelque part tout
+   en gardant des `curl` hôte reproduit le bug à l'identique.
+
 ## Relations
 
 - **ADR-0031** (profils de staging) : *ce que* le home stagé contient, là où cette ADR fixe *où* et


### PR DESCRIPTION
Refs #447. PR vers la branche d'intégration `integration/prd-403-sandbox` (pas `main`).

## Le défaut

Le point 3 d'ADR-0030 ne couvrait que l'env `PDO_DAEMON_URL`. Le **texte** des préambules
construisait la sienne, codée en dur sur `localhost:<port>`, quel que soit le mode du Run. Dans le
conteneur, `localhost` désigne le conteneur : un manager sandboxé récoltait des refus de connexion
sur tous les `curl` de son propre préambule et en concluait que le daemon était mort — pendant que
l'UI affichait « Daemon: connected ». Perte de fonctionnalité, pas juste de la prose fausse : toute
la surface de commande du manager devenait inatteignable, à commencer par le `rename_run` que le
préambule impose comme première action (d'où les Runs sandboxés restés sans nom).

## Le correctif

- `sandbox_container::daemon_url(port, sandboxed)` : résolveur pur unique, placé dans le module qui
  possède le `--add-host` créant la gateway, donc une seule occurrence du hostname. Consommé par le
  `-e PDO_DAEMON_URL` du `docker create` **et** par le texte du préambule manager : l'env et la prose
  ne peuvent plus diverger (leçon #373).
- Son booléen nomme le **côté d'exécution**, pas le mode du Run : les exports d'env côté hôte du
  wrapper (`wrap_with_env`) passent `false` même pour un Run sandboxé, puisqu'ils tournent avant le
  `docker exec` et ne traversent pas (ADR-0030 §5). Unifier naïvement les 4 littéraux aurait cassé ça.
- Les deux sites de préambule de nœud passent aussi par le résolveur, mais `AugmentContext.daemon_url`
  n'a **aucun consommateur** : c'est défensif, pas le correctif du symptôme observé.

## Preuve

Test de couche 3 sur le **fichier de préambule écrit sur disque** (`__manager__-iter-0.md`) pour un
Run `minimal` et son jumeau `off`. L'assertion portante est l'ABSENCE de `localhost:<port>`. Rouge
sans le correctif, vert avec.

Validation agentique en **docker réel** (4 runs, verdict Pass) :

| Preuve | `minimal` | `off` |
|---|---|---|
| hôte dans le préambule manager (19 URLs) | `host.docker.internal:6194` | `localhost:6194` |
| occurrences de l'URL de l'autre côté | 0 | 0 |
| `curl localhost` depuis le conteneur | `000` | — |
| `curl host.docker.internal` depuis le conteneur | `200` | — |
| `rename_run` émis sans détour | oui | oui |

`diff` des deux préambules après normalisation du run id et de l'hôte : **identiques**. Le résolveur
est la seule chose qui varie avec le côté d'exécution.

**Contrôle négatif au niveau du binaire** : même binaire reconstruit avec la seule ligne forcée à
`daemon_url(port, false)` → le bug revient tel quel, le manager affirme « The daemon process isn't
running » alors que le daemon écoute sans interruption. Causalité établie, pas inférée.

Réserve honnête du validateur : « le run est nommé » n'est **pas** un signal discriminant dans ce
harnais (un LLM peut se rattraper sur `$PDO_DAEMON_URL` si le pipeline l'imprime). Le texte du
préambule et la matrice `curl` le sont, et eux basculent de façon déterministe.

## Docs

Amendement ADR-0030 + entrée de vocabulaire CONTEXT.md (et correction de la section « Conséquence
pour la prompt augmentation », qui présentait l'URL comme une constante).

Pas de bump de version : la branche d'intégration porte le bump une seule fois, au merge vers `main`.