### PR TITLE
fix(#452): le dialogue de lancement peut ne rien choisir — `default_sandbox` redevient atteignable

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1136,7 +1136,14 @@ Défaut du mode sandbox **par-daemon** : colonne **nullable** `instance_config` 
 `""` = sentinelle clear → NULL). Résolveur `default_sandbox_with` (`stored → env(`PDO_DEFAULT_SANDBOX`)
 → default(`off`)`, ADR-0015), lu **frais** au bord et partagé par `create_run_inner` **et** `GET
 /settings` (0 drift #373, miroir exact d'`image_source`). Éditable dans la Settings UI (`<select>`).
-_Éviter_ : confondre avec `image_source` (provisionnement d'image, orthogonal) ; « mode d'instance ».
+**Atteignable depuis le dialogue de lancement** (#452) : le sélecteur du NewRunModal mène, dans les
+**deux** modes, sur « Use instance default » — la sentinelle `""` qui **omet** la clé `sandbox` de la
+requête. C'est la seule façon de déférer, `Some(Off)` étant final ; en mode run l'option **nomme** le
+défaut résolu au lieu de le **recopier** dans le champ (un prefill async best-effort ratait sa fenêtre
+sur un fetch lent, en échec, ou en cache d'une ouverture précédente, et atterrissait sur un `off`
+explicite que l'utilisateur n'avait pas choisi).
+_Éviter_ : confondre avec `image_source` (provisionnement d'image, orthogonal) ; « mode d'instance » ;
+dire que le dialogue de lancement « choisit toujours » un mode (c'était le défaut #452).
 
 **Défaut par-Trigger (`Trigger.sandbox`)** :
 Mode par défaut d'un **Trigger** : colonne **nullable** `sandbox` sur `triggers`. `None` = **déférer**
@@ -1150,10 +1157,12 @@ Check de disponibilité host (`docker version`, exit 0 = disponible ; binaire ab
 `DOCKER_NOT_FOUND_MSG` ; daemon injoignable → message dédié). **TTL-cachée** (~10 s) par-daemon,
 surfacée sur `GET /settings` comme `sandbox_docker {available, reason, checked_at}` (pas un
 `settings_field` : aucun tier stored/env/default) à côté du knob `default_sandbox`, pour un **seul**
-fetch du modal. Affordance **advisory** : grise les options `minimal`/`full` du sélecteur tri-état et
-clamp sur `off` ; le fail-fast du run-advance (ADR-0030 pt 4) reste le gate **autoritaire**. Passe par
-le seam `docker_cmd_override`. _Éviter_ : « Docker health », « sandbox available » (ambigu avec le
-mode), confondre avec `ensure_image`/`probe_state` (provisionnement/liveness par-Run).
+fetch du modal. Affordance **advisory** : grise les options de profil du sélecteur et **refuse le
+Launch** quand le mode effectif en est un (#452 — elle ne **clampe plus** sur `off` : écrire un verdict
+métier dans le champ le rendait indistinguable d'un choix utilisateur) ; le fail-fast du run-advance
+(ADR-0030 pt 4) reste le gate **autoritaire**. Passe par le seam `docker_cmd_override`.
+_Éviter_ : « Docker health », « sandbox available » (ambigu avec le mode), confondre avec
+`ensure_image`/`probe_state` (provisionnement/liveness par-Run).
 
 **Préparation du sandbox (`sandbox_prep`)** :
 État **additif** projeté sur le Run (`pending`|`ready`) qui rend visible la fenêtre de prep eager

--- a/docs/test-scenarios/HP-01-author-and-save.md
+++ b/docs/test-scenarios/HP-01-author-and-save.md
@@ -36,8 +36,10 @@ Features validated while crossing the editing screens (grafted from retired per-
 ## Journey
 
 1. Open the app → the **Library** lists the available pipelines.
-2. **Duplicate** a library-only pipeline → an unlinked copy appears, name suffixed `(copy)`, opened on
-   the canvas. (Duplicate is offered only on library-only rows, never on starred working rows.)
+2. **Duplicate** a library-only pipeline → an unlinked copy appears **in the Library list**, name
+   suffixed `(copy)`, as a clickable row correctly badged `library` scope. The copy is **not** opened
+   on the canvas — that is deliberate (#371); **open it explicitly** to continue the journey.
+   (Duplicate is offered only on library-only rows, never on starred working rows.)
 3. **Add a node** from the edit toolbar → a new slim card appears (type icon + name + code/doc marker,
    no id text, no `interactive` badge).
 4. **Draw an edge**: drag from a node's green **output dot** and drop on another node's **card body**

--- a/docs/test-scenarios/HP-02-run-to-completion.md
+++ b/docs/test-scenarios/HP-02-run-to-completion.md
@@ -65,8 +65,9 @@ Features validated while crossing the run screens (grafted from retired per-issu
    changed / LOC, and an **estimated cost** ("Est. cost", labelled as an estimate — "—" when uncomputable).
 9. Find the run in the **Runs list** (grouped by repo when ≥ 2 repos exist).
 10. **Sandboxed twin.** Seed (or reuse) a **one-node pipeline** whose node asks for a single line of
-    output and then completes. Open **New Run** on it → the sandbox field offers `off`, `minimal`,
-    `full` and any named **staging profile**; pick **`full`** → **Launch**.
+    output and then completes. Open **New Run** on it → the sandbox field sits on **Use instance
+    default**, and offers `off`, `minimal`, `full` and any named **staging profile**; pick **`full`**
+    → **Launch**.
 11. **Stay on the Run** and watch the **preparation** phase: the Run announces that its sandbox is
     being prepared and **no node starts while it lasts** (tens of seconds on a real `~/.claude`).
     When preparation clears, the node starts, its terminal preview shows a live `claude` session
@@ -96,6 +97,12 @@ Features validated while crossing the run screens (grafted from retired per-issu
 
 - The sandbox field lists `off`, `minimal`, `full` **and** any named staging profile; `full` and
   `minimal` are selectable with no prior configuration (they are virtual defaults).
+- The field **leads with "Use instance default"** and that is where a freshly opened dialog sits.
+  Set `default_sandbox` to a profile in **Settings**, **reopen** New Run *without reloading the page*
+  (the reopen is the part that used to fail), launch **without touching the field**, and read the
+  **`POST /runs` body**: it must carry **no** `sandbox` key. A `"sandbox":"off"` there is the #452
+  regression — `off` is final for the daemon, so it makes `default_sandbox` unreachable, and nothing
+  in the UI shows it. Only the request body does.
 - While the `full` Run prepares, **no node is running**. A node running while preparation is still
   announced is a **blocking finding** — that inversion is the #445 regression.
 - The sandboxed node's terminal preview shows a live `claude` session **with no interactive dialog**:

--- a/frontend/src/components/NewRunModal.test.tsx
+++ b/frontend/src/components/NewRunModal.test.tsx
@@ -1369,7 +1369,12 @@ describe("NewRunModal — sandbox selector (#410)", () => {
     };
   }
 
-  it("prefills the run selector from the instance default", async () => {
+  /**
+   * #452 replaces #410's prefill. The run selector NAMES the instance default instead of
+   * copying it into the field: the value stays the `""` sentinel, so the key is omitted and
+   * the daemon resolves. See the `#452` describe below for why copying it was unsound.
+   */
+  it("names the instance default on the inherit option without seeding the field", async () => {
     vi.mocked(fetchSettings).mockResolvedValue(
       settingsFixture({
         default_sandbox: { effective: "full", source: "stored", stored: "full", env: null, default: "off", reason: null },
@@ -1377,36 +1382,57 @@ describe("NewRunModal — sandbox selector (#410)", () => {
     );
     vi.mocked(fetchPipelines).mockResolvedValue([makePipeline({ id: "p1", name: "P", scope: "repo" })]);
     renderModal();
+    const select = (await screen.findByTestId("sandbox-select")) as HTMLSelectElement;
     await waitFor(() => {
-      expect((screen.getByTestId("sandbox-select") as HTMLSelectElement).value).toBe("full");
+      expect(Array.from(select.options).find((o) => o.value === "")).toHaveTextContent(
+        "Use instance default (full)",
+      );
     });
+    // The field asserts nothing of its own.
+    expect(select.value).toBe("");
   });
 
-  it("disables full/minimal and clamps to off when Docker is unavailable (availability wins over prefill)", async () => {
+  it("disables full/minimal and BLOCKS the launch when Docker is unavailable (no silent clamp to off)", async () => {
     vi.mocked(fetchSettings).mockResolvedValue(
       settingsFixture({
-        // The instance default is `minimal`, but Docker is down: greying wins.
+        // The instance default is `minimal`, but Docker is down.
         default_sandbox: { effective: "minimal", source: "stored", stored: "minimal", env: null, default: "off", reason: null },
         sandbox_docker: { available: false, reason: "Docker daemon unreachable", checked_at: "x" },
       }),
     );
-    vi.mocked(fetchPipelines).mockResolvedValue([makePipeline({ id: "p1", name: "P", scope: "repo" })]);
+    vi.mocked(fetchPipelines).mockResolvedValue([
+      makePipeline({ id: "p1", name: "P", scope: "repo", prompt_required: false }),
+    ]);
     renderModal();
+    await enterValidRepo();
 
     const select = (await screen.findByTestId("sandbox-select")) as HTMLSelectElement;
-    // Clamped to off (never mints a Run doomed to RunFailed).
-    await waitFor(() => expect(select.value).toBe("off"));
+    // #452: NOT clamped to `off` — the field still says "I did not choose".
+    await waitFor(() => expect(screen.getByTestId("sandbox-doomed-warning")).toBeInTheDocument());
+    expect(select.value).toBe("");
     // full/minimal options are disabled; the reason is surfaced.
     const options = Array.from(select.options);
     expect(options.find((o) => o.value === "full")?.disabled).toBe(true);
     expect(options.find((o) => o.value === "minimal")?.disabled).toBe(true);
     expect(screen.getByTestId("sandbox-docker-warning")).toHaveTextContent(/unreachable/i);
+
+    // The Run doomed to a RunFailed is still prevented — by refusing it, not by
+    // answering `off` on the user's behalf.
+    vi.useRealTimers();
+    await waitFor(() => expect(screen.getByTestId("launch-button")).toBeDisabled());
+    fireEvent.click(screen.getByTestId("launch-button"));
+    expect(createRun).not.toHaveBeenCalled();
+
+    // Demoting to `off` is the user's call, and it unblocks.
+    fireEvent.change(select, { target: { value: "off" } });
+    await waitFor(() => expect(screen.getByTestId("launch-button")).toBeEnabled());
+    expect(screen.queryByTestId("sandbox-doomed-warning")).not.toBeInTheDocument();
   });
 
   it("passes the chosen sandbox mode to createRun", async () => {
     vi.mocked(fetchSettings).mockResolvedValue(
       settingsFixture({
-        default_sandbox: { effective: "full", source: "stored", stored: "full", env: null, default: "off", reason: null },
+        default_sandbox: { effective: "off", source: "default", stored: null, env: null, default: "off", reason: null },
       }),
     );
     vi.mocked(fetchPipelines).mockResolvedValue([
@@ -1414,10 +1440,12 @@ describe("NewRunModal — sandbox selector (#410)", () => {
     ]);
     renderModal();
     await enterValidRepo();
-    // The prefill lands "full".
-    await waitFor(() => {
-      expect((screen.getByTestId("sandbox-select") as HTMLSelectElement).value).toBe("full");
-    });
+
+    // An explicit pick — the case this test is named for. It must survive as-is, even
+    // though it disagrees with the instance default (`off`).
+    const select = (await screen.findByTestId("sandbox-select")) as HTMLSelectElement;
+    await waitFor(() => expect(Array.from(select.options).some((o) => o.value === "full")).toBe(true));
+    fireEvent.change(select, { target: { value: "full" } });
 
     vi.useRealTimers();
     await waitFor(() => expect(screen.getByRole("button", { name: /launch/i })).toBeEnabled());
@@ -1495,7 +1523,9 @@ describe("NewRunModal — sandbox selector (#410)", () => {
     renderModal();
     const select = (await screen.findByTestId("sandbox-select")) as HTMLSelectElement;
     await waitFor(() =>
+      // #452: the inherit sentinel leads the list in run mode too.
       expect(Array.from(select.options).map((o) => o.value)).toEqual([
+        "",
         "off",
         "full",
         "full-no-mcp",
@@ -1562,7 +1592,243 @@ describe("NewRunModal — sandbox selector (#410)", () => {
     vi.mocked(fetchPipelines).mockResolvedValue([makePipeline({ id: "p1", name: "P", scope: "repo" })]);
     renderModal();
     const select = (await screen.findByTestId("sandbox-select")) as HTMLSelectElement;
-    await waitFor(() => expect(select.value).toBe("off"));
+    await waitFor(() => expect(Array.from(select.options).length).toBeGreaterThan(1));
+    fireEvent.change(select, { target: { value: "off" } });
+    expect(select.value).toBe("off");
     expect(screen.queryByTestId("sandbox-missing-profile")).not.toBeInTheDocument();
+  });
+
+  it("does not tombstone the inherit sentinel either", async () => {
+    vi.mocked(fetchSettings).mockResolvedValue(settingsFixture());
+    vi.mocked(fetchPipelines).mockResolvedValue([makePipeline({ id: "p1", name: "P", scope: "repo" })]);
+    renderModal();
+    const select = (await screen.findByTestId("sandbox-select")) as HTMLSelectElement;
+    await waitFor(() => expect(Array.from(select.options).length).toBeGreaterThan(1));
+    expect(select.value).toBe("");
+    expect(screen.queryByTestId("sandbox-missing-profile")).not.toBeInTheDocument();
+  });
+});
+
+/**
+ * #452 — `default_sandbox` must be REACHABLE from the launch dialog.
+ *
+ * The daemon's contract is `Option<SandboxMode>`: `None` = "defer to the instance default",
+ * `Some(Off)` = "run on the host, and nothing may override that upward". #410 seeded the run
+ * selector by copying the resolved default into the field, asynchronously and best-effort, and
+ * `sandbox: sandbox || undefined` omits the key only for `""` — which run mode never held. So
+ * the key was structurally always present, and every way the prefill could miss its window
+ * landed on an explicit `off`: a choice the user never made, in the least protective direction,
+ * that nothing downstream could undo.
+ *
+ * The tests below pin the three ways it missed. Each one FAILS on the pre-fix component (it
+ * posts `sandbox: "off"`), which is the point: the happy path at
+ * "names the instance default…" passed throughout and hid all three.
+ */
+describe("NewRunModal — the launch dialog can defer to default_sandbox (#452)", () => {
+  function settingsFixture(overrides: Partial<InstanceSettings> = {}): InstanceSettings {
+    return {
+      session_cap: { effective: 20, source: "default", stored: null, env: null, default: 20 },
+      reaper_ttl_secs: { effective: 3600, source: "default", stored: null, env: null, default: 3600 },
+      guard_timeout_secs: { effective: 60, source: "default", stored: null, env: null, default: 60 },
+      default_model: { effective: null, source: "default", stored: null, env: null, default: null },
+      image_source: { effective: "registry", source: "default", stored: null, env: null, default: "registry" },
+      default_sandbox: { effective: "off", source: "default", stored: null, env: null, default: "off", reason: null },
+      dockerfile_path: {
+        effective: "/home/user/.pdo/sandbox/Dockerfile",
+        source: "default",
+        stored: null,
+        env: null,
+        default: "/home/user/.pdo/sandbox/Dockerfile",
+      },
+      sandbox_image: { tag: "pdo-sandbox:h-9a67637571a4", reason: null },
+      sandbox_docker: { available: true, reason: null, checked_at: "2026-07-01T10:00:00.000Z" },
+      sandbox_profiles: [
+        { name: "full", virtual: true },
+        { name: "minimal", virtual: true },
+      ],
+      home: "/home/user",
+      updated_at: "2026-07-01T10:00:00.000Z",
+      ...overrides,
+    };
+  }
+
+  const defaultIs = (name: string): Partial<InstanceSettings> => ({
+    default_sandbox: { effective: name, source: "stored", stored: name, env: null, default: "off", reason: null },
+  });
+
+  /**
+   * "Omitted" is read at the `createRun` boundary rather than on the wire: `api.ts` skips a
+   * falsy `sandbox` on BOTH transports (`JSON.stringify` drops `undefined`; the multipart path
+   * guards with `if (req.sandbox)`), so `undefined` here IS an absent key there. Asserted as a
+   * property lookup, not with `toHaveBeenCalledWith`, because `objectContaining` cannot express
+   * absence — and because vitest compares arity strictly, so a spurious trailing argument would
+   * fail the assertion for the wrong reason.
+   */
+  function sandboxSentTo(mock: typeof createRun) {
+    const calls = vi.mocked(mock).mock.calls;
+    expect(calls).toHaveLength(1);
+    return calls[0][0].sandbox;
+  }
+
+  async function launchWithoutTouchingSandbox() {
+    await enterValidRepo();
+    vi.useRealTimers();
+    await waitFor(() => expect(screen.getByTestId("launch-button")).toBeEnabled());
+    fireEvent.click(screen.getByTestId("launch-button"));
+    await waitFor(() => expect(createRun).toHaveBeenCalled());
+  }
+
+  beforeEach(() => {
+    vi.mocked(fetchPipelines).mockResolvedValue([
+      makePipeline({ id: "p1", name: "Optional Pipeline", scope: "repo", prompt_required: false }),
+    ]);
+  });
+
+  it("omits the sandbox key when the user never touches the selector", async () => {
+    vi.mocked(fetchSettings).mockResolvedValue(settingsFixture(defaultIs("full")));
+    renderModal();
+    // Wait for the settings to land, so this is not accidentally the in-flight case below.
+    await screen.findByTestId("sandbox-select");
+    await waitFor(() => expect(fetchSettings).toHaveBeenCalled());
+
+    await launchWithoutTouchingSandbox();
+
+    // The whole issue in one line: never `off`, and never anything at all.
+    expect(sandboxSentTo(createRun)).toBeUndefined();
+  });
+
+  /**
+   * Mode B of the repro, and the only one that needs no fault injection. The modal is
+   * always-mounted, so `settings` survives a close; the old seeding effect therefore ran
+   * synchronously against the STALE value on reopen and latched its one-shot ref before the
+   * fresh fetch could land. A user who changes `default_sandbox` in Settings and reopens New
+   * Run — without reloading the page — got the previous default posted explicitly.
+   */
+  it("does not seed a reopened dialog from settings cached before the default changed", async () => {
+    vi.mocked(fetchSettings).mockResolvedValue(settingsFixture(defaultIs("off")));
+    const { rerender } = render(
+      <NewRunModal open={true} onClose={noop} onCreated={noop} openIntent={{ kind: "run" }} />,
+    );
+    await screen.findByTestId("sandbox-select");
+    await waitFor(() => expect(fetchSettings).toHaveBeenCalledTimes(1));
+
+    // Close. The component stays mounted, so `settings` stays in state.
+    rerender(<NewRunModal open={false} onClose={noop} onCreated={noop} openIntent={{ kind: "run" }} />);
+
+    // The operator switches the instance default to `full` in Settings.
+    vi.mocked(fetchSettings).mockResolvedValue(settingsFixture(defaultIs("full")));
+
+    rerender(<NewRunModal open={true} onClose={noop} onCreated={noop} openIntent={{ kind: "run" }} />);
+    const select = (await screen.findByTestId("sandbox-select")) as HTMLSelectElement;
+    expect(select.value).toBe("");
+    // And the label catches up with the new default once the refetch lands.
+    await waitFor(() =>
+      expect(Array.from(select.options).find((o) => o.value === "")).toHaveTextContent(
+        "Use instance default (full)",
+      ),
+    );
+
+    await launchWithoutTouchingSandbox();
+    expect(sandboxSentTo(createRun)).toBeUndefined();
+  });
+
+  /**
+   * Mode C. `GET /settings` failing used to be swallowed whole: the option list silently
+   * degraded to `off` alone — indistinguishable from an instance without Docker — and the
+   * submission went ahead with an explicit `off`. Deferring is the right answer when we know
+   * nothing: the daemon has the default, we do not.
+   */
+  it("still defers, and says so, when GET /settings fails", async () => {
+    vi.mocked(fetchSettings).mockRejectedValue(new Error("daemon unreachable"));
+    renderModal();
+    const select = (await screen.findByTestId("sandbox-select")) as HTMLSelectElement;
+    await waitFor(() => expect(screen.getByTestId("sandbox-settings-error")).toBeInTheDocument());
+    expect(select.value).toBe("");
+
+    await launchWithoutTouchingSandbox();
+    expect(sandboxSentTo(createRun)).toBeUndefined();
+  });
+
+  /**
+   * The prefill also lost its race whenever the fetch was merely SLOW — a Run launched
+   * before it resolved was posted with the `off` initial state. Nothing waits on the fetch
+   * any more, so there is no race left to lose.
+   */
+  it("defers when the launch beats the settings fetch", async () => {
+    let resolveSettings!: (s: InstanceSettings) => void;
+    vi.mocked(fetchSettings).mockReturnValue(
+      new Promise<InstanceSettings>((resolve) => {
+        resolveSettings = resolve;
+      }),
+    );
+    renderModal();
+    await screen.findByTestId("sandbox-select");
+
+    await launchWithoutTouchingSandbox();
+    expect(sandboxSentTo(createRun)).toBeUndefined();
+
+    resolveSettings(settingsFixture(defaultIs("full")));
+  });
+
+  it("sends an explicit off when the user actually picks it", async () => {
+    vi.mocked(fetchSettings).mockResolvedValue(settingsFixture(defaultIs("full")));
+    renderModal();
+    const select = (await screen.findByTestId("sandbox-select")) as HTMLSelectElement;
+    await waitFor(() => expect(Array.from(select.options).length).toBeGreaterThan(1));
+    fireEvent.change(select, { target: { value: "off" } });
+
+    await enterValidRepo();
+    vi.useRealTimers();
+    await waitFor(() => expect(screen.getByTestId("launch-button")).toBeEnabled());
+    fireEvent.click(screen.getByTestId("launch-button"));
+    await waitFor(() => expect(createRun).toHaveBeenCalled());
+
+    // The sentinel must not swallow a real choice: `off` on purpose stays `off`, explicitly,
+    // so it keeps winning over the instance default.
+    expect(sandboxSentTo(createRun)).toBe("off");
+  });
+
+  it("surfaces a dangling instance default instead of letting the launch 400 unexplained", async () => {
+    vi.mocked(fetchSettings).mockResolvedValue(
+      settingsFixture({
+        default_sandbox: {
+          effective: "deleted-profile",
+          source: "stored",
+          stored: "deleted-profile",
+          env: null,
+          default: "off",
+          reason: "No staging profile named `deleted-profile`",
+        },
+      }),
+    );
+    renderModal();
+    await screen.findByTestId("sandbox-select");
+    await waitFor(() =>
+      expect(screen.getByTestId("sandbox-default-reason")).toHaveTextContent(/deleted-profile/),
+    );
+  });
+
+  /**
+   * Trigger mode is untouched by all of this: a Trigger resolves its sandbox when it FIRES,
+   * so today's Docker probe cannot condemn it and the inherit option stays unqualified.
+   */
+  it("leaves trigger mode's inherit option unqualified and unblocked", async () => {
+    vi.mocked(fetchSettings).mockResolvedValue(
+      settingsFixture({
+        ...defaultIs("full"),
+        sandbox_docker: { available: false, reason: "Docker daemon unreachable", checked_at: "x" },
+      }),
+    );
+    render(
+      <NewRunModal open={true} onClose={noop} onCreated={noop} openIntent={{ kind: "new-trigger" }} />,
+    );
+    const select = (await screen.findByTestId("sandbox-select")) as HTMLSelectElement;
+    await waitFor(() => expect(screen.getByTestId("sandbox-docker-warning")).toBeInTheDocument());
+    expect(select.value).toBe("");
+    expect(Array.from(select.options).find((o) => o.value === "")).toHaveTextContent(
+      "Use instance default",
+    );
+    expect(Array.from(select.options).find((o) => o.value === "")).not.toHaveTextContent("(full)");
+    expect(screen.queryByTestId("sandbox-doomed-warning")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/NewRunModal.tsx
+++ b/frontend/src/components/NewRunModal.tsx
@@ -91,14 +91,23 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
 
   const [images, setImages] = useState<File[]>([]);
 
-  // Sandbox (#410/#432). `settings` carries the instance `default_sandbox` (prefill), the
-  // advisory `sandbox_docker` probe (greying) and — since #432 — `sandbox_profiles`, the
-  // NAME list that drives the options. `sandbox` is the selector value: `off` or a staging
-  // profile name in run mode; also `""` in trigger mode, meaning "inherit the instance
-  // default". No second fetch: the modal already fetches settings on open (the
-  // `sandbox_docker` precedent from #410).
+  // Sandbox (#410/#432/#452). `settings` carries the instance `default_sandbox` (it
+  // LABELS the inherit option — it no longer seeds the value), the advisory
+  // `sandbox_docker` probe (greying) and — since #432 — `sandbox_profiles`, the NAME list
+  // that drives the options. No second fetch: the modal already fetches settings on open
+  // (the `sandbox_docker` precedent from #410).
+  //
+  // `sandbox` is the selector value, in BOTH modes: `""` = "the user did not choose", `off`,
+  // or a staging profile name. `""` omits the key from the request, which is the only way to
+  // reach `default_sandbox` — `None` is the daemon's "defer" and `Some(Off)` is final.
+  //
+  // #452: the initial value is `""`, not `off`. `off` is a verdict ("run on the host"), so an
+  // un-seeded `off` did not *lose* the user's intent, it FABRICATED one, in the least
+  // protective direction, and nothing downstream could override it upward. `""` is the only
+  // value that asserts nothing.
   const [settings, setSettings] = useState<InstanceSettings | null>(null);
-  const [sandbox, setSandbox] = useState<string>("off");
+  const [settingsFailed, setSettingsFailed] = useState(false);
+  const [sandbox, setSandbox] = useState<string>("");
   const sandboxSeeded = useRef(false);
 
   const recentRepos = useRecentReposStore((s) => s.recentRepos);
@@ -296,48 +305,55 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
     loadPipelines();
   }, [loadPipelines]);
 
-  // #410: fetch instance settings on open — the `default_sandbox` prefill AND the
+  // #410: fetch instance settings on open — the `default_sandbox` label AND the
   // `sandbox_docker` availability probe arrive in one round-trip (the modal did not
   // fetch settings before this slice).
+  //
+  // #452: the failure is no longer swallowed. It cannot corrupt what we send any more (the
+  // sandbox value is seeded synchronously, below), but it silently shrinks the option list
+  // to `off` alone, which looks exactly like an instance without Docker. `settingsFailed`
+  // makes the difference visible instead of leaving the user to misread it.
   useEffect(() => {
     if (!open) return;
+    let cancelled = false;
     fetchSettings()
-      .then(setSettings)
-      .catch(() => {});
+      .then((s) => {
+        if (cancelled) return;
+        setSettings(s);
+        setSettingsFailed(false);
+      })
+      .catch(() => {
+        if (!cancelled) setSettingsFailed(true);
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [open]);
 
-  // #410: seed the sandbox selector once per open, matched to the intent. Edit/new
-  // trigger seed synchronously (from the trigger / the "inherit" sentinel); a plain
-  // run waits for the settings fetch to prefill the instance default, CLAMPED to
-  // `off` when Docker is unavailable (availability wins over a `full`/`minimal` prefill
-  // so we never mint a Run doomed to a RunFailed the UI could have prevented).
+  // #410/#452: seed the sandbox selector once per open, matched to the intent. Every intent
+  // now seeds SYNCHRONOUSLY, to a value that carries no assertion of its own: `""` for a
+  // plain run and a new trigger, the trigger's own stored choice for an edit (whose `null`
+  // already means the same thing).
+  //
+  // #452: this used to wait on `settings` for the run intent and prefill the resolved
+  // default. That bridge to `default_sandbox` was a best-effort async prefill, and it broke
+  // three ways — a failed fetch, a fetch still in flight, and a `settings` state that
+  // survives a close and re-seeds a REOPEN from the stale value — each landing on an
+  // explicit `off` the user never picked. Nothing that gets sent may depend on a fetch that
+  // is allowed to be late, wrong, or absent: the daemon already owns the resolution, so the
+  // modal defers to it by omission rather than racing to guess it. The instance default is
+  // now shown as the inherit option's LABEL, where being stale for one round-trip is
+  // cosmetic. The Docker clamp moved out of here too — see `sandboxDoomed`.
   useEffect(() => {
     if (!open) {
       sandboxSeeded.current = false;
       return;
     }
     if (sandboxSeeded.current) return;
-    // One-shot seeding gated by the ref (bounded, does not re-fire) — the same
-    // pattern as the intent reset above, so the rule is opted out here too.
-    /* eslint-disable react-hooks/set-state-in-effect */
-    if (openIntent.kind === "edit-trigger") {
-      setSandbox(openIntent.trigger.sandbox ?? "");
-      sandboxSeeded.current = true;
-      return;
-    }
-    if (openIntent.kind === "new-trigger") {
-      setSandbox(""); // "" = inherit the instance default
-      sandboxSeeded.current = true;
-      return;
-    }
-    // run: prefill from the instance default once settings are loaded.
-    if (!settings) return;
-    const def = settings.default_sandbox.effective ?? "off";
-    const dockerOk = settings.sandbox_docker.available;
-    setSandbox(!dockerOk && def !== "off" ? "off" : def);
+    // One-shot seeding gated by the ref: bounded, does not re-fire.
     sandboxSeeded.current = true;
-    /* eslint-enable react-hooks/set-state-in-effect */
-  }, [open, openIntent, settings]);
+    setSandbox(openIntent.kind === "edit-trigger" ? (openIntent.trigger.sandbox ?? "") : "");
+  }, [open, openIntent]);
 
   const repoPipelines = useMemo(
     () => pipelines.filter((p) => p.scope === "repo"),
@@ -477,6 +493,38 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
       !sandboxProfiles.some((p) => p.name === sandbox),
   );
 
+  // #452: the instance default, used to LABEL the inherit option — never to seed the value.
+  // `null` while settings are unknown, which is the honest rendering: we do not know yet.
+  const instanceDefaultSandbox = settings ? (settings.default_sandbox.effective ?? "off") : null;
+
+  // #452: what will actually apply to the Run being created. `""` is not a value — it means
+  // the key is omitted and the instance default decides — so the checks below have to
+  // resolve it to say anything true about the Run.
+  const effectiveSandbox = sandbox === "" ? instanceDefaultSandbox : sandbox;
+
+  /**
+   * #452, the Docker clamp, relocated. A Run whose effective sandbox is a profile while the
+   * daemon reports Docker unavailable is born condemned, so #410 clamped the SELECTOR to
+   * `off`. That protection was right and is kept; the way it was applied was not — it wrote
+   * a business verdict into the field, indistinguishable from a user picking `off`, and
+   * posted it explicitly.
+   *
+   * So refuse the launch and say why, instead of quietly substituting an answer. Same rule
+   * as the phantom-profile tombstone above, for the same reason: the app never demotes a
+   * sandbox behind the user's back (ADR-0031 §7).
+   *
+   * Run mode only. A Trigger resolves its sandbox when it FIRES, and today's Docker probe
+   * says nothing about that moment.
+   */
+  const sandboxDoomed = Boolean(
+    mode === "run" && dockerUnavailable && effectiveSandbox && effectiveSandbox !== "off",
+  );
+
+  // #452: `default_sandbox` carries a `reason` when the winning tier names a profile that
+  // does not resolve. Inheriting is now the default path in run mode, so that dangling name
+  // is worth showing here — the create chokepoint 400s on it rather than falling back.
+  const inheritedDefaultReason = sandbox === "" ? (settings?.default_sandbox.reason ?? null) : null;
+
   const handleLaunch = useCallback(async () => {
     if (!repoValid || !selectedPipeline || !hasRequiredPrompt) return;
     setSubmitting(true);
@@ -500,9 +548,10 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
         target_repo: targetRepo.trim() || undefined,
         source_branch: sourceBranch || undefined,
         name: autoName ? undefined : runName.trim() || undefined,
-        // #410: the explicit run-level choice. Always concrete in run mode (`off` or a
-        // staging profile name); sent explicitly so it wins the create-chokepoint
-        // precedence over any instance/trigger default.
+        // #410/#452: the explicit run-level choice — `off` or a staging profile name — sent
+        // so it wins the create-chokepoint precedence. `""` means the user did not choose,
+        // and OMITS the key: only an absent `sandbox` lets the daemon apply
+        // `default_sandbox`, because it reads a present `off` as final.
         sandbox: sandbox || undefined,
         images: images.length > 0 ? images : undefined,
       });
@@ -521,7 +570,8 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
     }
   }, [selectedPipeline, input, hasRequiredPrompt, overrides, onCreated, onClose, flushPendingSaves, repoValid, targetRepo, sourceBranch, autoName, runName, images, sandbox, refreshRecentRepos]);
 
-  const canLaunch = repoValid && selectedPipeline && hasRequiredPrompt && !missingProfile;
+  const canLaunch =
+    repoValid && selectedPipeline && hasRequiredPrompt && !missingProfile && !sandboxDoomed;
 
   // The cron expression the Trigger will be created with: a compiled preset or
   // the raw escape-hatch expression.
@@ -934,13 +984,14 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
               )}
             </div>
 
-            {/* Sandbox (#410/#432): `off`, or one of the instance's STAGING PROFILES —
-                the options are data, served by `GET /settings` (names only). Run mode
-                prefills from the instance default; Trigger mode adds a leading "Use
-                instance default" option. Profiles are disabled when the daemon reports
-                Docker unavailable (advisory greying — the run-advance fail-fast remains
-                authoritative), and a seeded name that no longer exists gets a tombstone
-                that blocks the action instead of being silently rewritten. */}
+            {/* Sandbox (#410/#432/#452): "Use instance default", `off`, or one of the
+                instance's STAGING PROFILES — the options are data, served by `GET /settings`
+                (names only). #452: BOTH modes lead with the inherit option, so "I am not
+                choosing" is expressible in run mode too; it is the seeded value, and run mode
+                names what it currently resolves to. Profiles are disabled when the daemon
+                reports Docker unavailable (advisory greying — the run-advance fail-fast
+                remains authoritative), and neither an unavailable Docker nor a vanished
+                profile rewrites the field: both block the action and say so. */}
             <div className="flex flex-col gap-1.5">
               <label
                 htmlFor="sandbox-select"
@@ -958,9 +1009,15 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
                 className="w-full rounded-md border border-line-strong bg-bg-3 px-2.5 py-1.5 font-mono text-fg transition-colors focus:border-acc focus:outline-none disabled:opacity-40"
                 style={{ fontSize: "12px" }}
               >
-                {mode === "trigger" && (
-                  <option value="">Use instance default</option>
-                )}
+                {/* #452: run mode names the resolved default, because the choice is made
+                    NOW and the user is entitled to know what they are inheriting. A Trigger
+                    resolves when it fires, so naming today's value there would be a
+                    promise the modal cannot keep. */}
+                <option value="">
+                  {mode === "run" && instanceDefaultSandbox
+                    ? `Use instance default (${instanceDefaultSandbox})`
+                    : "Use instance default"}
+                </option>
                 <option value="off">off (run on the host)</option>
                 {sandboxProfiles.map((p) => (
                   <option key={p.name} value={p.name} disabled={dockerUnavailable}>
@@ -989,6 +1046,40 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
                   on a missing profile fails at launch, it does not fall back to a default.
                 </span>
               )}
+              {/* #452: what #410 used to do silently — clamp to `off` — stated instead of
+                  performed. Launch is blocked; the user demotes to `off` themselves or
+                  fixes Docker. */}
+              {sandboxDoomed && (
+                <span
+                  className="text-st-failed"
+                  style={{ fontSize: "10.5px" }}
+                  data-testid="sandbox-doomed-warning"
+                >
+                  {sandbox === "" ? (
+                    <>
+                      The instance default is{" "}
+                      <span className="font-mono">{effectiveSandbox}</span>, which needs
+                      Docker
+                    </>
+                  ) : (
+                    <>
+                      <span className="font-mono">{effectiveSandbox}</span> needs Docker
+                    </>
+                  )}
+                  {" "}— the daemon reports it unavailable. Pick{" "}
+                  <span className="font-mono">off</span> to run on the host; this Run is not
+                  silently downgraded to it.
+                </span>
+              )}
+              {inheritedDefaultReason && (
+                <span
+                  className="text-st-failed"
+                  style={{ fontSize: "10.5px" }}
+                  data-testid="sandbox-default-reason"
+                >
+                  {inheritedDefaultReason}
+                </span>
+              )}
               {dockerUnavailable && (
                 <span
                   className="text-fg-4"
@@ -996,6 +1087,19 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
                   data-testid="sandbox-docker-warning"
                 >
                   {sandboxReason}
+                </span>
+              )}
+              {/* #452: a failed `GET /settings` leaves a one-entry list that reads like an
+                  instance without Docker. Say which one it is. Not blocking: inheriting is
+                  the safe answer here — the daemon resolves its own default. */}
+              {settingsFailed && !settings && (
+                <span
+                  className="text-fg-4"
+                  style={{ fontSize: "10.5px" }}
+                  data-testid="sandbox-settings-error"
+                >
+                  Could not load instance settings, so the sandbox options are unavailable.
+                  This Run will use the instance default.
                 </span>
               )}
             </div>


### PR DESCRIPTION
Closes #452 — *(la fermeture est faite à la main : les mots-clés GitHub ne s'appliquent que sur la branche par défaut, or cette PR cible `integration/prd-403-sandbox`.)*

## Cause racine

Le sélecteur Sandbox du `NewRunModal` n'offrait, en mode run, **aucune option d'héritage** : il était
pré-rempli de façon asynchrone en **recopiant** le `default_sandbox` résolu dans le champ. Ce prefill
best-effort ratait sa fenêtre sur un fetch lent, un fetch en échec, ou — le repro réel — sur des
settings **mis en cache lors d'une ouverture précédente du dialogue**. Le champ retombait alors sur
un `off` explicite que personne n'avait choisi, et comme `Some(Off)` est final côté daemon,
`default_sandbox` devenait littéralement inatteignable depuis l'UI, sans rien qui le signale à
l'écran. Second contributeur : quand Docker était indisponible, l'affordance *advisory* **clampait**
le champ sur `off`, écrivant un verdict métier là où seule l'intention utilisateur a sa place.

Le fix rend la sentinelle `""` (« Use instance default ») atteignable dans les **deux** modes — elle
**omet** la clé `sandbox` de la requête au lieu d'en fabriquer une — fait **nommer** le défaut résolu
par l'option plutôt que le recopier dans le champ, et remplace le clamp Docker par un **refus de
Launch** motivé.

## Preuve visuelle (nœud Visual tester, verdict **Pass**)

Artefacts du run `20260725-154645-194dfce`, nœud `7V3Hf41X` (`.pdo/artifacts/7V3Hf41X/iter-1/screens-fixed/`) :

| Capture | Ce qu'on y voit |
|---|---|
| `01-BEFORE-prefix-bundle-fabricates-off.png` | **Contrôle négatif** : bundle pré-fix servi, `default_sandbox = full`, champ affiché `off (run on the host)`, aucune option d'héritage. |
| `02-AFTER-fixed-defers-to-default.png` | Corrigé, même script : le champ affiche `Use instance default (minimal)`. |
| `03-AFTER-run-really-sandboxed.png` | Badge `sandbox: full` sur le Run créé sans toucher au sélecteur — la déférence est appliquée par le daemon, pas seulement affichée. |
| `04-AFTER-explicit-off-still-sent.png` | Un `off` choisi explicitement part toujours explicitement : la sentinelle n'avale pas l'intention. |
| `00-ab-toggle.gif` | Comparateur clignotant AVANT / APRÈS sur la ligne Sandbox. |

La paire A/B a été jouée sur **la même instance isolée** (`PDO_PORT=6191`, `HOME` factice, dépôt
jetable), seul le bundle servi changeant — indispensable ici, le faux négatif connu de #452 étant
qu'un **chargement frais** est déjà sain : le repro passe par la **réouverture** du dialogue sans
recharger la page.

Corps du `POST /runs` observé, Launch sans jamais toucher le sélecteur (`default_sandbox = full`) :

```json
{"pipeline":"probe","input":"…","variables":{},"pipeline_id":"probe",
 "target_repo":"/tmp/pdo452/repo","source_branch":"main"}
```

**Aucune clé `sandbox`** → Run `20260725-162517-19a9fef` enregistré `sandbox: "full"`,
`sandbox_prep: "ready"`, exécuté dans le conteneur. Avec le bundle pré-fix, le même script produisait
`"sandbox":"off"` et un Run exécuté sur l'hôte.

## Filet de régression

`frontend/src/components/NewRunModal.test.tsx` — **80 tests passent**, dont 7 nouveaux contrats
`(#452)` et 4 contrats `(#410)` réécrits :

- `omits the sandbox key when the user never touches the selector` ;
- `does not seed a reopened dialog from settings cached before the default changed` (le repro exact) ;
- `still defers, and says so, when GET /settings fails` ;
- `defers when the launch beats the settings fetch` ;
- `sends an explicit off when the user actually picks it` ;
- `surfaces a dangling instance default instead of letting the launch 400 unexplained` ;
- `leaves trigger mode's inherit option unqualified and unblocked` ;
- réécrits : `names the instance default on the inherit option without seeding the field`,
  `disables full/minimal and BLOCKS the launch when Docker is unavailable (no silent clamp to off)`,
  `does not tombstone the inherit sentinel either`.

**Pourquoi ils échouaient avant** : le code d'avant recopiait le défaut résolu dans l'état du champ,
donc `POST /runs` portait **toujours** une clé `sandbox` — les cinq premiers contrats, qui assertent
l'**absence** de cette clé (ou sa valeur héritée), échouaient sur `"sandbox":"off"`. Le contrat Docker
échouait symétriquement : l'ancien code clampait silencieusement sur `off` et **laissait le Launch
passer**, là où le test exige désormais un refus motivé.

## Documentation

`CONTEXT.md` (vocabulaire *Défaut sandbox par-daemon* et *Disponibilité Docker*) et
`docs/test-scenarios/HP-02-run-to-completion.md` (le HP lit désormais le corps du `POST /runs` :
un `"sandbox":"off"` non sollicité y est un finding bloquant) enregistrent la décision.

## Note de périmètre

La branche porte un second commit, `a897bd4 docs(#403): HP-01 étape 2 — la copie n'est PAS ouverte sur
le canvas`, hérité de la base de ce run et non encore présent sur la branche d'intégration. Il est
purement documentaire (correction du scénario HP-01) et sans rapport avec le code de #452.

## Vérifications locales

`npx tsc --noEmit` 0 erreur · `npm run lint` 0 issue · `npx vitest run NewRunModal.test.tsx` 80/80 ·
`cargo +stable build --bin pdo` OK. Pas de `cargo test --workspace` en local (interférence des
`TestDaemon` avec le daemon parent) : la suite complète tourne dans la CI de cette PR.
