### PR TITLE
fix(#454,#455,#456,#457): les quatre findings non bloquants du gate HP

### DIFF
--- a/frontend/src/components/EdgeDetailPanel.test.tsx
+++ b/frontend/src/components/EdgeDetailPanel.test.tsx
@@ -131,6 +131,55 @@ describe("EdgeDetailPanel", () => {
     expect(typeof (edge.when!.is_blocking as Record<string, unknown>).eq).toBe("boolean");
   });
 
+  // #456: the operator dropdown is typed. A bool has no useful ordering, so
+  // offering `<`/`≤`/`>`/`≥` (and the list operators) let `is_blocking >= true`
+  // be authored and saved.
+  describe("operator set is typed (#456)", () => {
+    it("offers only = and ≠ for a boolean field", () => {
+      seedEdge({ ...baseEdge, when: { is_blocking: { eq: true } } });
+      render(<EdgeDetailPanel />);
+      const opSel = screen.getByTestId("op-dropdown") as HTMLSelectElement;
+      expect(Array.from(opSel.options).map((o) => o.value)).toEqual(["eq", "neq"]);
+    });
+
+    it("keeps the full operator set for iter and for an enum field", () => {
+      seedEdge({ ...baseEdge, when: { iter: { gte: 3 } } });
+      render(<EdgeDetailPanel />);
+      const opSel = screen.getByTestId("op-dropdown") as HTMLSelectElement;
+      expect(Array.from(opSel.options).map((o) => o.value)).toEqual([
+        "eq", "neq", "lt", "lte", "gt", "gte", "in", "not_in",
+      ]);
+    });
+
+    it("clamps the operator to eq when the field is switched to a bool", () => {
+      seedEdge({ ...baseEdge, when: { iter: { gte: 3 } } });
+      render(<EdgeDetailPanel />);
+
+      fireEvent.change(screen.getByTestId("field-dropdown"), {
+        target: { value: "is_blocking" },
+      });
+
+      const edge = useEditStore.getState().openTabs[0].pipeline.edges[0];
+      // `gte` would have survived the field change and written `is_blocking >= true`.
+      expect(edge.when).toEqual({ is_blocking: { eq: true } });
+    });
+
+    /**
+     * A pipeline authored before the fix (or by hand) can carry `is_blocking:
+     * {gte: true}`. Dropping `gte` from the options would leave the `<select>`
+     * DISPLAYING `=` while the row still holds `gte` — the same
+     * shows-one-thing-sends-another trap as #454. The panel already keeps that
+     * escape hatch for an unknown field; the operator needs it too.
+     */
+    it("still renders an out-of-range operator already present on the edge", () => {
+      seedEdge({ ...baseEdge, when: { is_blocking: { gte: true } } });
+      render(<EdgeDetailPanel />);
+      const opSel = screen.getByTestId("op-dropdown") as HTMLSelectElement;
+      expect(opSel.value).toBe("gte");
+      expect(Array.from(opSel.options).map((o) => o.value)).toContain("gte");
+    });
+  });
+
   it("offers iter as a selectable condition field", () => {
     seedEdge(baseEdge);
     render(<EdgeDetailPanel />);

--- a/frontend/src/components/EdgeDetailPanel.tsx
+++ b/frontend/src/components/EdgeDetailPanel.tsx
@@ -3,13 +3,18 @@ import { ArrowRight, Plus, X, Activity, RefreshCw, CornerDownRight } from "lucid
 import { useEditStore } from "../stores/editStore";
 import type { EdgeDef, EdgeTriggerStatus } from "../types";
 import {
-  OPERATORS,
   whenToRows,
   rowsToWhen,
   type ConditionRow,
   type Operator,
 } from "../lib/whenClause";
-import { edgeConditionFields, isBoolField, type EdgeConditionField } from "../lib/edgeFields";
+import {
+  edgeConditionFields,
+  isBoolField,
+  operatorsForField,
+  clampOperator,
+  type EdgeConditionField,
+} from "../lib/edgeFields";
 import { SectionHead } from "./InspectorPrimitives";
 
 interface Props {
@@ -96,9 +101,20 @@ export default function EdgeDetailPanel({ trigger = null }: Props) {
   const handleUpdateRow = (i: number, updates: Partial<ConditionRow>) => {
     const next = rows.map((r, idx) => {
       if (idx !== i) return r;
-      // A field change resets the value and recomputes the bool type hint.
+      // A field change resets the value, recomputes the bool type hint, and
+      // clamps the operator to what the new field admits (#456) — otherwise a
+      // `gte` carried over from `iter` would land on a bool.
       const merged = { ...r, ...updates };
-      return withTypeHint(updates.field !== undefined ? { ...merged, value: defaultValueFor(merged.field, fields) } : merged, fields);
+      return withTypeHint(
+        updates.field !== undefined
+          ? {
+              ...merged,
+              op: clampOperator(fields, merged.field, merged.op),
+              value: defaultValueFor(merged.field, fields),
+            }
+          : merged,
+        fields,
+      );
     });
     commitRows(next);
   };
@@ -271,6 +287,7 @@ function ConditionRowEditor({
   const isEnum = selectedField?.decl?.type === "enum" && selectedField.decl.allowed;
   const isBool = isBoolField(fields, row.field);
   const isList = row.op === "in" || row.op === "not_in";
+  const allowedOps = operatorsForField(fields, row.field);
 
   return (
     <div className="flex items-center gap-1" data-testid="condition-row">
@@ -299,7 +316,15 @@ function ConditionRowEditor({
         style={{ fontSize: "10.5px" }}
         data-testid="op-dropdown"
       >
-        {OPERATORS.map((op) => (
+        {/* An operator the field no longer admits can still sit in a hand-written
+            or pre-#456 YAML. Keep it selectable, exactly as the field dropdown
+            above keeps an unknown field: dropping it would leave the `<select>`
+            DISPLAYING `=` while the row still holds `gte` — the
+            shows-one-sends-another trap of #454. */}
+        {!allowedOps.includes(row.op) && (
+          <option value={row.op}>{OP_SYMBOLS[row.op]}</option>
+        )}
+        {allowedOps.map((op) => (
           <option key={op} value={op}>
             {OP_SYMBOLS[op]}
           </option>

--- a/frontend/src/components/EditCanvas.test.ts
+++ b/frontend/src/components/EditCanvas.test.ts
@@ -601,7 +601,7 @@ describe("deriveLoopRegions — bounded region rendering (ADR-0011 / #148)", () 
   });
 });
 
-describe("buildLoopRegionNodes — region box must not intercept edge clicks (issue #167)", () => {
+describe("buildLoopRegionNodes — box behind, chrome above (#167 / #455)", () => {
   function regionPipeline(): PipelineDef {
     return {
       name: "loop-region-review-loop",
@@ -632,10 +632,15 @@ describe("buildLoopRegionNodes — region box must not intercept edge clicks (is
     };
   }
 
+  function layer(nodes: ReturnType<typeof buildLoopRegionNodes>, want: string) {
+    const found = nodes.filter((n) => (n.data as { layer?: string }).layer === want);
+    expect(found).toHaveLength(1);
+    return found[0];
+  }
+
   it("renders the box region as a `loopRegion` node positioned at the box origin", () => {
     const nodes = buildLoopRegionNodes(regionPipeline(), null);
-    expect(nodes).toHaveLength(1);
-    const region = nodes[0];
+    const region = layer(nodes, "box");
     expect(region.id).toBe("region-review_loop");
     expect(region.type).toBe("loopRegion");
     expect(region.position.x).toBeLessThan(280);
@@ -648,12 +653,12 @@ describe("buildLoopRegionNodes — region box must not intercept edge clicks (is
     // clicks meant for the edges it overlaps. The node spec must override that
     // back to `none`. xyflow spreads `node.style` after its own pointerEvents,
     // so this is the override that wins.
-    const region = buildLoopRegionNodes(regionPipeline(), null)[0];
+    const region = layer(buildLoopRegionNodes(regionPipeline(), null), "box");
     expect((region.style as { pointerEvents?: string }).pointerEvents).toBe("none");
   });
 
   it("keeps the region non-selectable, non-draggable, and non-focusable (decorative only)", () => {
-    const region = buildLoopRegionNodes(regionPipeline(), null)[0];
+    const region = layer(buildLoopRegionNodes(regionPipeline(), null), "box");
     expect(region.selectable).toBe(false);
     expect(region.draggable).toBe(false);
     expect(region.focusable).toBe(false);
@@ -663,6 +668,50 @@ describe("buildLoopRegionNodes — region box must not intercept edge clicks (is
     const p = regionPipeline();
     p.loops = [{ id: "solo", kind: "bounded", members: ["impl"], max_iter: 3 }];
     expect(buildLoopRegionNodes(p, null)).toHaveLength(0);
+  });
+
+  /**
+   * #455: the header (and the exhausted badge, which carries the #152 "route
+   * from manager" BUTTON) used to live INSIDE the box node. A positioned wrapper
+   * with `z-index: 0` is a stacking context, so no descendant of it can paint
+   * above a sibling card — a node overlapping the header band stole every click,
+   * and the RegionInspector became unreachable. The two requirements are
+   * genuinely opposed (fill behind the cards, chrome above them), so they need
+   * two stacking layers: two nodes.
+   */
+  describe("interactive chrome sits above the member cards (#455)", () => {
+    it("emits a chrome node per boxed region, geometrically on top of the box", () => {
+      const nodes = buildLoopRegionNodes(regionPipeline(), null);
+      expect(nodes).toHaveLength(2);
+      const box = layer(nodes, "box");
+      const chrome = layer(nodes, "chrome");
+      expect(chrome.id).toBe("region-chrome-review_loop");
+      expect(chrome.type).toBe("loopRegion");
+      expect(chrome.position).toEqual(box.position);
+      expect(chrome.data.width).toBe(box.data.width);
+      expect(chrome.data.height).toBe(box.data.height);
+    });
+
+    it("outranks even a SELECTED card", () => {
+      // Cards carry no explicit zIndex (→ 0), but xyflow's `elevateNodesOnSelect`
+      // adds SELECTED_NODE_Z = 1000 to whichever one is selected. Anything at or
+      // below 1000 leaves the header unreachable while a card is selected, which
+      // is exactly when a user is most likely to reach for the region.
+      const chrome = layer(buildLoopRegionNodes(regionPipeline(), null), "chrome");
+      expect(chrome.zIndex).toBeGreaterThan(1000);
+      expect((chrome.style as { zIndex?: number }).zIndex).toBeGreaterThan(1000);
+    });
+
+    it("still lets clicks through everywhere except its own chips", () => {
+      // The chrome node spans the whole box, so its WRAPPER must stay
+      // pass-through or it would re-break #167 the other way round — and
+      // swallow every click on the member cards it now covers.
+      const chrome = layer(buildLoopRegionNodes(regionPipeline(), null), "chrome");
+      expect((chrome.style as { pointerEvents?: string }).pointerEvents).toBe("none");
+      expect(chrome.selectable).toBe(false);
+      expect(chrome.draggable).toBe(false);
+      expect(chrome.focusable).toBe(false);
+    });
   });
 });
 

--- a/frontend/src/components/LoopRegionNode.test.tsx
+++ b/frontend/src/components/LoopRegionNode.test.tsx
@@ -64,6 +64,9 @@ function props(data: Partial<LoopRegionNodeData>): NodeProps<Node<LoopRegionNode
     runId: null,
     width: 400,
     height: 200,
+    // Every test below drives the header or the exhausted badge, which live on
+    // the chrome layer (#455). The box layer is covered by its own describe.
+    layer: "chrome",
   };
   return {
     id: "region-review_loop",
@@ -219,5 +222,66 @@ describe("LoopRegionNode — route from manager (#152)", () => {
     expect(
       screen.queryByTestId("loop-region-route-from-manager"),
     ).toBeNull();
+  });
+});
+
+/**
+ * #455: the two layers are exclusive. The box draws the grouping rectangle and
+ * nothing interactive; the chrome draws the chips and no rectangle. If either
+ * leaked into the other, the fix would be undone — chrome under a card again, or
+ * a filled rectangle painted over the cards it is supposed to sit behind.
+ */
+describe("LoopRegionNode — box / chrome layer split (#455)", () => {
+  beforeEach(() => {
+    useEditStore.setState({
+      openTabs: [],
+      activeTabId: null,
+      selection: { kind: "none", id: null },
+    });
+  });
+
+  it("the box layer draws the rectangle and NO interactive chrome", () => {
+    seedStore([reviewLoop]);
+    render(
+      <Wrapper>
+        <LoopRegionNode {...props({ layer: "box", exhausted: true, runId: "run-1" })} />
+      </Wrapper>,
+    );
+    const box = screen.getByTestId("loop-region");
+    expect(box.style.border).toContain("dashed");
+    expect(box.style.background).not.toBe("");
+    expect(screen.queryByTestId("loop-region-header")).toBeNull();
+    expect(screen.queryByTestId("loop-region-block")).toBeNull();
+    expect(screen.queryByTestId("loop-region-route-from-manager")).toBeNull();
+  });
+
+  it("the chrome layer draws the chips and NO rectangle over the cards", () => {
+    seedStore([reviewLoop]);
+    render(
+      <Wrapper>
+        <LoopRegionNode {...props({ layer: "chrome", exhausted: true, runId: "run-1" })} />
+      </Wrapper>,
+    );
+    expect(screen.getByTestId("loop-region-header")).toBeTruthy();
+    expect(screen.getByTestId("loop-region-block")).toBeTruthy();
+    // No `loop-region` box: the chrome covers the member cards, so a border or a
+    // fill here would hide them.
+    expect(screen.queryByTestId("loop-region")).toBeNull();
+    const chrome = screen.getByTestId("loop-region-chrome");
+    expect(chrome.style.border).toBe("");
+    expect(chrome.style.background).toBe("");
+  });
+
+  it("keeps the chrome container itself pass-through, only the chips clickable", () => {
+    seedStore([reviewLoop]);
+    render(
+      <Wrapper>
+        <LoopRegionNode {...props({ layer: "chrome" })} />
+      </Wrapper>,
+    );
+    // The container spans the whole box and now sits ABOVE the member cards, so
+    // it must not swallow their clicks (#167, the other way round).
+    expect(screen.getByTestId("loop-region-chrome").className).toContain("pointer-events-none");
+    expect(screen.getByTestId("loop-region-header").className).toContain("pointer-events-auto");
   });
 });

--- a/frontend/src/components/LoopRegionNode.tsx
+++ b/frontend/src/components/LoopRegionNode.tsx
@@ -14,6 +14,9 @@ import { endRegion } from "../api";
  * the *sole* place `max_iter` is edited and where the region id is shown. The
  * canvas header carries neither an inline control nor the id, per the slim-card
  * rule (#149): the inline header editor #150 originally added was removed.
+ *
+ * Each region is backed by TWO such nodes, distinguished by {@link layer} —
+ * see `buildLoopRegionNodes` for why one cannot do both jobs (#455).
  */
 export interface LoopRegionNodeData {
   regionId: string;
@@ -33,6 +36,18 @@ export interface LoopRegionNodeData {
   runId: string | null;
   width: number;
   height: number;
+  /**
+   * Which half of the region this node draws (#455).
+   *
+   * `"box"` — the dashed, translucent rectangle, pinned BEHIND the member cards.
+   * `"chrome"` — the same rectangle, transparent, ABOVE the cards, carrying the
+   * clickable header and the exhausted badge.
+   *
+   * They cannot be one node: a positioned wrapper with a numeric `z-index` is a
+   * stacking context, so chrome nested in the `zIndex: 0` box could never paint
+   * above a card, and a card overlapping the header band swallowed its clicks.
+   */
+  layer: "box" | "chrome";
   [key: string]: unknown;
 }
 
@@ -48,22 +63,38 @@ export function LoopRegionNode({ data }: NodeProps<Node<LoopRegionNodeData>>) {
   const openInspector = () =>
     setSelection({ kind: "region", id: null, regionId: data.regionId });
 
+  // The grouping layer: border + faint fill, nothing interactive. Sits behind
+  // the member cards and lets every click through (#167).
+  if (data.layer === "box") {
+    return (
+      <div
+        data-testid="loop-region"
+        data-region-id={data.regionId}
+        className="loop-region pointer-events-none relative"
+        style={{
+          width: data.width,
+          height: data.height,
+          borderRadius: 12,
+          border: `1px dashed ${accent}`,
+          // Faint translucent fill so the box reads as a grouping layer behind
+          // the member cards without obscuring them.
+          background: data.exhausted
+            ? "var(--color-st-blocked-bg)"
+            : "var(--color-acc-bg)",
+        }}
+      />
+    );
+  }
+
+  // The chrome layer: same rectangle, no border and no fill (it covers the
+  // cards, so anything painted here would hide them), `pointer-events: none`
+  // throughout except on the two chips below.
   return (
     <div
-      data-testid="loop-region"
+      data-testid="loop-region-chrome"
       data-region-id={data.regionId}
-      className="loop-region pointer-events-none relative"
-      style={{
-        width: data.width,
-        height: data.height,
-        borderRadius: 12,
-        border: `1px dashed ${accent}`,
-        // Faint translucent fill so the box reads as a grouping layer behind
-        // the member cards without obscuring them.
-        background: data.exhausted
-          ? "var(--color-st-blocked-bg)"
-          : "var(--color-acc-bg)",
-      }}
+      className="pointer-events-none relative"
+      style={{ width: data.width, height: data.height }}
     >
       <div
         data-testid="loop-region-header"

--- a/frontend/src/components/NewRunModal.test.tsx
+++ b/frontend/src/components/NewRunModal.test.tsx
@@ -75,6 +75,11 @@ const noop = () => {};
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // `clearAllMocks` wipes recorded calls but KEEPS implementations, so a
+  // `mockResolvedValue` set inside one test leaks into every later one. The
+  // repo-switch tests (#454) re-point this mock per repo, so restore the
+  // documented default here rather than trusting each test to clean up.
+  vi.mocked(listBranches).mockResolvedValue(["main", "dev", "feature-x"]);
   vi.useFakeTimers({ shouldAdvanceTime: true });
   useEditStore.setState({
     openTabs: [],
@@ -302,6 +307,90 @@ describe("NewRunModal — multi-repo form flow", () => {
       expect(options).toContain("main");
       expect(options).toContain("dev");
       expect(options).toContain("feature-x");
+    });
+  });
+
+  /**
+   * #454: the `!sourceBranch` guard blocked re-selection when the repo changed.
+   * The `<select>` then DISPLAYED the new repo's only option while the state
+   * still held a branch that repo does not have → launch refused with
+   * `branch 'main' does not exist`. Same shows-one-sends-another family as #452.
+   */
+  describe("changing the target repo re-selects the source branch (#454)", () => {
+    /**
+     * Asserting `branchSelect.value` CANNOT catch this bug, and that is the whole
+     * point of it: a `<select>` whose React value matches none of its options
+     * reports the FIRST option's value. So the DOM read `master` even while the
+     * state held `main` — the read that looks like a check and passes either way.
+     * Only what the form actually submits distinguishes the two.
+     */
+    it("launches against the re-selected branch, not the stale one", async () => {
+      vi.mocked(fetchPipelines).mockResolvedValue([
+        makePipeline({ id: "p1", name: "P1", scope: "repo" }),
+      ]);
+      vi.mocked(listBranches).mockResolvedValue(["main", "dev", "feature-x"]);
+      renderModal();
+      await enterValidRepo("/home/user/project-a"); // → main
+
+      vi.mocked(listBranches).mockResolvedValue(["master"]);
+      await enterValidRepo("/home/user/project-b");
+
+      const branchSelect = screen.getByLabelText(/source branch/i) as HTMLSelectElement;
+      await waitFor(() => {
+        expect(Array.from(branchSelect.options).map((o) => o.value)).toEqual(["master"]);
+      });
+
+      fireEvent.change(screen.getByTestId("pipeline-select"), { target: { value: "p1" } });
+      fireEvent.change(screen.getByPlaceholderText(/free-text prompt/i), {
+        target: { value: "do the thing" },
+      });
+
+      vi.useRealTimers();
+      fireEvent.click(screen.getByRole("button", { name: /launch/i }));
+
+      await waitFor(() => {
+        // Pre-fix this was `main`, a branch project-b does not have → the daemon
+        // refused the launch with `branch 'main' does not exist`.
+        expect(createRun).toHaveBeenCalledWith(
+          expect.objectContaining({ source_branch: "master" }),
+        );
+      });
+    });
+
+    /**
+     * Guard against over-correcting: resetting unconditionally on every repo
+     * change would throw away a deliberate choice that the new repo still honours.
+     * This one passes before the fix too — it is here to keep the fix honest, not
+     * to prove the bug.
+     */
+    it("keeps the user's branch when the new repo still has it", async () => {
+      vi.mocked(fetchPipelines).mockResolvedValue([
+        makePipeline({ id: "p1", name: "P1", scope: "repo" }),
+      ]);
+      vi.mocked(listBranches).mockResolvedValue(["main", "dev", "feature-x"]);
+      renderModal();
+      await enterValidRepo("/home/user/project-a");
+
+      const branchSelect = screen.getByLabelText(/source branch/i) as HTMLSelectElement;
+      fireEvent.change(branchSelect, { target: { value: "feature-x" } });
+      expect(branchSelect.value).toBe("feature-x");
+
+      vi.mocked(listBranches).mockResolvedValue(["main", "feature-x"]);
+      await enterValidRepo("/home/user/project-b");
+
+      fireEvent.change(screen.getByTestId("pipeline-select"), { target: { value: "p1" } });
+      fireEvent.change(screen.getByPlaceholderText(/free-text prompt/i), {
+        target: { value: "do the thing" },
+      });
+
+      vi.useRealTimers();
+      fireEvent.click(screen.getByRole("button", { name: /launch/i }));
+
+      await waitFor(() => {
+        expect(createRun).toHaveBeenCalledWith(
+          expect.objectContaining({ source_branch: "feature-x" }),
+        );
+      });
     });
   });
 

--- a/frontend/src/components/NewRunModal.tsx
+++ b/frontend/src/components/NewRunModal.tsx
@@ -269,7 +269,15 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
           try {
             const branchList = await listBranches(targetRepo.trim());
             setBranches(branchList);
-            if (branchList.length > 0 && !sourceBranch) {
+            // #454: re-select whenever the held branch is not one THIS repo has.
+            // The old `!sourceBranch` guard only ever seeded an empty field, so
+            // switching repos kept a branch the new one lacks — and a `<select>`
+            // whose value matches no option renders its FIRST option, so the field
+            // DISPLAYED `master` while the state still held `main`. The launch then
+            // failed with `branch 'main' does not exist`, blaming the daemon for a
+            // value the UI never showed. Testing membership instead subsumes the
+            // empty case and still preserves a deliberate choice the new repo honours.
+            if (branchList.length > 0 && !branchList.includes(sourceBranch)) {
               const main = branchList.find((b) => b === "main")
                 ?? branchList.find((b) => b === "master")
                 ?? branchList[0];

--- a/frontend/src/components/editNodeDerivation.ts
+++ b/frontend/src/components/editNodeDerivation.ts
@@ -241,20 +241,41 @@ export function deriveLoopRegions(
 }
 
 /**
+ * xyflow's `elevateNodesOnSelect` (on by default) adds `SELECTED_NODE_Z = 1000`
+ * to whichever node is selected. Region chrome has to outrank even that: a
+ * selected card overlapping the header is precisely when a user reaches for the
+ * region, and anything ≤ 1000 would leave the header unreachable right then.
+ */
+const REGION_CHROME_Z = 1001;
+
+/**
  * Builds the decorative xyflow `loopRegion` nodes that back each box-form
- * bounded region (ADR-0011 / #148). One node per `>= 2`-member region; single-
- * member regions render as a badge on the member card (no box) and produce no
- * node here.
+ * bounded region (ADR-0011 / #148). TWO nodes per `>= 2`-member region; single-
+ * member regions render as a badge on the member card (no box) and produce
+ * neither.
  *
- * The region box sits BEHIND the member cards and must never intercept pointer
- * events: an edge whose path crosses the box has to stay clickable/selectable
- * (#167). xyflow gives every node wrapper `pointer-events: all` whenever the
- * canvas registers node mouse handlers (it does, for the drag-highlight), so
- * pinning the inner div to `pointer-events: none` is not enough — the wrapper
- * still swallows the click. We override the wrapper's pointer-events to `none`
- * via the node's own `style` (xyflow spreads `node.style` AFTER its own
- * `pointerEvents`, so this wins without `!important`). The region header keeps
- * its own `pointer-events: auto` and stays clickable as a descendant.
+ * Neither node may intercept pointer events at the wrapper level: an edge whose
+ * path crosses the box has to stay clickable/selectable (#167). xyflow gives
+ * every node wrapper `pointer-events: all` whenever the canvas registers node
+ * mouse handlers (it does, for the drag-highlight), so pinning the inner div to
+ * `pointer-events: none` is not enough — the wrapper still swallows the click.
+ * Both specs override the wrapper back to `none` via the node's own `style`
+ * (xyflow spreads `node.style` AFTER its own `pointerEvents`, so this wins
+ * without `!important`), and the individual chips opt back in.
+ *
+ * WHY TWO NODES (#455). The box must paint BEHIND the member cards; the header
+ * and the exhausted badge — which carries the #152 "route from manager" button —
+ * must sit ABOVE them. Those are opposed, and one node cannot do both: a
+ * positioned wrapper with a numeric `z-index` IS a stacking context, so no
+ * descendant of the `zIndex: 0` box can ever paint above a sibling card. With
+ * the chrome inside the box, any node overlapping the header band stole its
+ * clicks and the RegionInspector became unreachable. So: a `box` layer at
+ * `zIndex: 0`, and a `chrome` layer at {@link REGION_CHROME_Z} covering the same
+ * rectangle. `LoopRegionNode` renders one or the other on `data.layer`.
+ *
+ * Both keep `type: "loopRegion"` on purpose — every `n.type === "loopRegion"`
+ * guard in `EditCanvas` (drag-stop, context menu, node click) then covers the
+ * chrome for free instead of needing a parallel set of guards for a 5th type.
  */
 export function buildLoopRegionNodes(
   pipeline: PipelineDef,
@@ -262,11 +283,9 @@ export function buildLoopRegionNodes(
 ): Node[] {
   return deriveLoopRegions(pipeline, runState)
     .filter((r) => r.box != null)
-    .map((r) => ({
-      id: `region-${r.id}`,
-      type: "loopRegion",
-      position: { x: r.box!.x, y: r.box!.y },
-      data: {
+    .flatMap((r) => {
+      const position = { x: r.box!.x, y: r.box!.y };
+      const data = {
         regionId: r.id,
         kind: r.kind,
         counterText: r.counterText,
@@ -276,17 +295,32 @@ export function buildLoopRegionNodes(
         runId: runState?.run_id ?? null,
         width: r.box!.width,
         height: r.box!.height,
-      },
-      draggable: false,
-      selectable: false,
-      connectable: false,
-      focusable: false,
-      zIndex: 0,
-      // `pointerEvents: "none"` defeats xyflow's wrapper-level `all` so edges
-      // under the box remain clickable (#167); `zIndex: 0` keeps the box behind
-      // the member cards.
-      style: { zIndex: 0, pointerEvents: "none" },
-    }));
+      };
+      const inert = {
+        type: "loopRegion",
+        position,
+        draggable: false,
+        selectable: false,
+        connectable: false,
+        focusable: false,
+      } as const;
+      return [
+        {
+          ...inert,
+          id: `region-${r.id}`,
+          data: { ...data, layer: "box" as const },
+          zIndex: 0,
+          style: { zIndex: 0, pointerEvents: "none" },
+        },
+        {
+          ...inert,
+          id: `region-chrome-${r.id}`,
+          data: { ...data, layer: "chrome" as const },
+          zIndex: REGION_CHROME_Z,
+          style: { zIndex: REGION_CHROME_Z, pointerEvents: "none" },
+        },
+      ];
+    });
 }
 
 /**

--- a/frontend/src/lib/edgeFields.test.ts
+++ b/frontend/src/lib/edgeFields.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { edgeConditionFields } from "./edgeFields";
+import { edgeConditionFields, operatorsForField, clampOperator } from "./edgeFields";
+import { OPERATORS } from "./whenClause";
 import type { PipelineDef, EdgeDef } from "../types";
 
 function pipeline(): PipelineDef {
@@ -88,5 +89,41 @@ describe("isBoolField helper", () => {
     expect(isBoolField(fields, "is_blocking")).toBe(true);
     expect(isBoolField(fields, "verdict")).toBe(false);
     expect(isBoolField(fields, "iter")).toBe(false);
+  });
+});
+
+// #456: the operator set is a function of the field's type. A bool admits only
+// equality — `approved >= true` was authorable before this, and the engine has no
+// useful ordering to apply to it.
+describe("operatorsForField", () => {
+  it("restricts a bool field to equality", () => {
+    const fields = edgeConditionFields(pipeline(), guardedEdge);
+    expect(operatorsForField(fields, "is_blocking")).toEqual(["eq", "neq"]);
+  });
+
+  it("leaves every other field with the full operator set", () => {
+    const fields = edgeConditionFields(pipeline(), guardedEdge);
+    expect(operatorsForField(fields, "iter")).toEqual(OPERATORS);
+    expect(operatorsForField(fields, "verdict")).toEqual(OPERATORS);
+    expect(operatorsForField(fields, "$threshold")).toEqual(OPERATORS);
+  });
+
+  it("falls back to the full set for a field it does not know", () => {
+    const fields = edgeConditionFields(pipeline(), guardedEdge);
+    expect(operatorsForField(fields, "not_declared_anywhere")).toEqual(OPERATORS);
+  });
+});
+
+describe("clampOperator", () => {
+  it("rewrites an order operator to eq when the field is a bool", () => {
+    const fields = edgeConditionFields(pipeline(), guardedEdge);
+    expect(clampOperator(fields, "is_blocking", "gte")).toBe("eq");
+    expect(clampOperator(fields, "is_blocking", "in")).toBe("eq");
+  });
+
+  it("keeps an operator the field already admits", () => {
+    const fields = edgeConditionFields(pipeline(), guardedEdge);
+    expect(clampOperator(fields, "is_blocking", "neq")).toBe("neq");
+    expect(clampOperator(fields, "iter", "gte")).toBe("gte");
   });
 });

--- a/frontend/src/lib/edgeFields.ts
+++ b/frontend/src/lib/edgeFields.ts
@@ -1,3 +1,4 @@
+import { OPERATORS, type Operator } from "./whenClause";
 import type { PipelineDef, EdgeDef, FrontmatterFieldDecl } from "../types";
 
 /**
@@ -45,4 +46,39 @@ export function edgeConditionFields(
 /** Whether the named field is declared as a boolean (drives the true/false toggle). */
 export function isBoolField(fields: EdgeConditionField[], name: string): boolean {
   return fields.find((f) => f.name === name)?.decl?.type === "bool";
+}
+
+/** Equality only — a boolean has no ordering the predicate grammar can use (#456). */
+const BOOL_OPERATORS: readonly Operator[] = ["eq", "neq"];
+
+/**
+ * The operators admissible on a given field (#456). A `bool` takes equality
+ * only: `approved >= true` was authorable and savable before this, and ADR-0002
+ * gives the engine no ordering to apply to it.
+ *
+ * Every other field keeps the full set — including a field this resolver does
+ * not know (a stale `when:` referencing a since-renamed port). Narrowing an
+ * unknown field would be guessing, and the panel's job is to stop nonsense, not
+ * to hide what the YAML already says.
+ */
+export function operatorsForField(
+  fields: EdgeConditionField[],
+  name: string,
+): readonly Operator[] {
+  return isBoolField(fields, name) ? BOOL_OPERATORS : OPERATORS;
+}
+
+/**
+ * Coerces `op` into what `name` admits, defaulting to `eq`. Called when the
+ * field of a condition row changes: without it, switching an `iter >= 3` row
+ * over to a bool field would leave `gte` in place and write the very clause
+ * this restriction exists to prevent.
+ */
+export function clampOperator(
+  fields: EdgeConditionField[],
+  name: string,
+  op: Operator,
+): Operator {
+  const allowed = operatorsForField(fields, name);
+  return allowed.includes(op) ? op : "eq";
 }

--- a/frontend/src/lib/serializePipeline.test.ts
+++ b/frontend/src/lib/serializePipeline.test.ts
@@ -558,4 +558,74 @@ describe("exportNodeAsYaml (#345)", () => {
   it("is library-entry-shaped: name + type at the root", () => {
     expect(exportNodeAsYaml(node(), "p").startsWith("name: Reviewer\ntype: doc-only")).toBe(true);
   });
+
+  // #457: the third frontmatter emit site — same null-stripping rule.
+  it("drops a null allowed from a node-library entry too", () => {
+    const yaml = exportNodeAsYaml(
+      node({
+        outputs: [{
+          name: "review", repeated: false, side: "right",
+          frontmatter: { approved: { type: "bool", allowed: null } },
+        }],
+      }),
+      "p",
+    );
+    expect(yaml).toContain("type: bool");
+    expect(yaml).not.toContain("allowed:");
+  });
+});
+
+/**
+ * #457: `allowed` is `Option<Vec<String>>` on the daemon, so `GET /pipelines/...`
+ * ships `allowed: null` for every non-enum field. The emitters copied the
+ * declaration verbatim, so the FIRST save after a page load rewrote
+ * `{type: bool}` as `{allowed: null, type: bool}` — then stayed put, because the
+ * reloaded pipeline already carried the null. A parasitic diff on a
+ * git-versioned pipeline, and the Library stores YAML byte-for-byte, so it also
+ * reads as twin drift.
+ */
+describe("serializePipeline strips null frontmatter keys (#457)", () => {
+  function withFrontmatter(frontmatter: NodeDef["outputs"][number]["frontmatter"]): PipelineDef {
+    return {
+      name: "fm-test", version: "1.0", variables: {},
+      nodes: [{
+        id: "reviewer", name: "reviewer", type: "doc-only",
+        inputs: [{ name: "code", repeated: false, side: "left", frontmatter }],
+        outputs: [{ name: "review", repeated: false, side: "right", frontmatter }],
+        interactive: false, view: { x: 0, y: 0 },
+      }],
+      edges: [],
+    };
+  }
+
+  it("omits allowed when it is null", () => {
+    const yaml = serializePipeline(withFrontmatter({ approved: { type: "bool", allowed: null } }));
+    expect(yaml).toContain("type: bool");
+    expect(yaml).not.toContain("allowed:");
+  });
+
+  it("keeps allowed on an enum", () => {
+    const yaml = serializePipeline(
+      withFrontmatter({ verdict: { type: "enum", allowed: ["PASS", "FAIL"] } }),
+    );
+    expect(yaml).toContain("allowed:");
+    expect(yaml).toContain("PASS");
+  });
+
+  it("keeps an explicitly empty allowed — [] is not null", () => {
+    const yaml = serializePipeline(withFrontmatter({ verdict: { type: "enum", allowed: [] } }));
+    expect(yaml).toContain("allowed:");
+  });
+
+  /**
+   * The actual defect, stated as the invariant: what the daemon hands back
+   * (`allowed: null`) and what the user authored (key absent) must serialize to
+   * the same bytes. Both emit sites are covered — the inline one in
+   * `pipelineToYamlObject` (inputs AND outputs) and `portToYamlObject`.
+   */
+  it("emits the same bytes for a null allowed and an absent one", () => {
+    const fromDaemon = serializePipeline(withFrontmatter({ approved: { type: "bool", allowed: null } }));
+    const fromAuthor = serializePipeline(withFrontmatter({ approved: { type: "bool" } }));
+    expect(fromDaemon).toBe(fromAuthor);
+  });
 });

--- a/frontend/src/lib/serializePipeline.ts
+++ b/frontend/src/lib/serializePipeline.ts
@@ -22,7 +22,45 @@
  * The two per-port emitters are DELIBERATELY divergent — do not unify them, see
  * the comment on `portToYamlObject`.
  */
-import type { PipelineDef, NodeDef, PortDef, PortSide } from "../types";
+import type {
+  PipelineDef,
+  NodeDef,
+  PortDef,
+  PortSide,
+  FrontmatterFieldDecl,
+} from "../types";
+
+/**
+ * Drops the null-valued keys of every frontmatter declaration (#457).
+ *
+ * The daemon's `FrontmatterFieldDecl.allowed` is an `Option<Vec<String>>` with no
+ * `skip_serializing_if`, so `GET /pipelines/...` ships `allowed: null` on every
+ * non-enum field. Copying the declaration verbatim carried that null into the
+ * YAML, so the FIRST save after a page load rewrote `{type: bool}` as
+ * `{allowed: null, type: bool}` — stable afterwards, since the reloaded pipeline
+ * then already held the null. A parasitic diff on a git-versioned pipeline, and
+ * twin drift for the Library (which stores YAML byte-for-byte).
+ *
+ * Absent and null must produce the same bytes, so this normalises toward absent:
+ * on the reader side serde maps both to `None`. `[]` is NOT null and survives —
+ * an enum with an empty allow-list is a statement, not a default.
+ *
+ * Every one of the three frontmatter emit sites goes through here. Add a fourth
+ * and it must too.
+ */
+function frontmatterToYamlObject(
+  frontmatter: Record<string, FrontmatterFieldDecl>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [field, decl] of Object.entries(frontmatter)) {
+    const cleaned: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(decl)) {
+      if (value !== null && value !== undefined) cleaned[key] = value;
+    }
+    out[field] = cleaned;
+  }
+  return out;
+}
 
 // Canonical plain-object form of a pipeline — the exact structure that gets
 // YAML-serialized on save. Also used for semantic comparison against library
@@ -75,7 +113,7 @@ export function pipelineToYamlObject(p: PipelineDef): Record<string, unknown> {
         if (port.side) p.side = port.side;
         if (port.port_type && port.port_type !== "markdown")
           p.port_type = port.port_type;
-        if (port.frontmatter) p.frontmatter = port.frontmatter;
+        if (port.frontmatter) p.frontmatter = frontmatterToYamlObject(port.frontmatter);
         return p;
       });
     if (n.outputs.length > 0)
@@ -85,7 +123,7 @@ export function pipelineToYamlObject(p: PipelineDef): Record<string, unknown> {
         if (port.side) p.side = port.side;
         if (port.port_type && port.port_type !== "markdown")
           p.port_type = port.port_type;
-        if (port.frontmatter) p.frontmatter = port.frontmatter;
+        if (port.frontmatter) p.frontmatter = frontmatterToYamlObject(port.frontmatter);
         if (port.when) p.when = port.when;
         return p;
       });
@@ -173,7 +211,7 @@ function portToYamlObject(port: PortDef, defaultSide: PortSide): Record<string, 
   if (port.repeated) p.repeated = true;
   if (port.side && port.side !== defaultSide) p.side = port.side;
   if (port.port_type && port.port_type !== "markdown") p.port_type = port.port_type;
-  if (port.frontmatter) p.frontmatter = port.frontmatter;
+  if (port.frontmatter) p.frontmatter = frontmatterToYamlObject(port.frontmatter);
   if (port.when) p.when = port.when;
   return p;
 }


### PR DESCRIPTION
Les quatre findings **non bloquants** du gate HP du 2026-07-25, corrigés à la main sur décision de
périmètre : le budget de la semaine ne tenait pas six runs de bugfix orchestrés **plus** la reprise du
gate, et ces quatre-là sont des fix mono-fichier dont l'issue spécifiait déjà le filet de régression.
Les deux bloquants gardent l'orchestration : #452 est livré (PR #459), #453 tourne.

## Issues

- Closes #454 — changer de dépôt cible ne réinitialisait pas la branche source
- Closes #455 — header de loop region incliquable sous une carte de nœud
- Closes #456 — opérateurs d'ordre proposés sur un champ `bool`
- Closes #457 — sérialisation non idempotente (`allowed: null` réinjecté au 1er save)

⚠️ Cette PR cible une branche d'intégration : GitHub **n'appliquera pas** les `Closes` ci-dessus. Les
quatre issues sont à fermer à la main après le merge.

## Un fil rouge entre trois des quatre

#454, #455 et #456 sont la même faute sous trois formes : **l'UI affiche une chose et en porte une
autre**.

- #454 — un `<select>` dont la valeur React ne correspond à aucune option rend sa **première** option.
  Le champ montrait `master` pendant que l'état gardait `main`, et le lancement échouait sur
  « branch 'main' does not exist » en imputant au daemon une valeur jamais affichée.
- #456 — même piège en germe : retirer un opérateur de la liste sans traiter les clauses existantes
  aurait fait afficher `=` à une ligne portant `gte`. D'où l'option de repli sur un opérateur hors gamme
  déjà présent.
- #455 — le header *paraissait* cliquable et ne l'était pas.

C'est aussi la famille de #452, corrigé en amont dans cette même salve.

## Conséquence de méthode, qui a failli coûter un faux vert

**Une assertion sur `select.value` ne peut pas attraper #454** : le DOM lisait déjà `master`, c'est
exactement la tromperie. Le premier test écrit pour ce fix **passait avant le fix**. Le filet passe donc
par ce que le formulaire soumet (`createRun`), pas par ce que le DOM affiche.

Deuxième piège rencontré : `vi.clearAllMocks()` efface les appels enregistrés mais **conserve** les
implémentations, donc un `mockResolvedValue` posé dans un test fuit dans tous les suivants — il a fait
échouer un test préexistant de `NewRunModal`. Le défaut de `listBranches` est maintenant rétabli dans le
`beforeEach`.

## Le seul fix non trivial : #455

Le header et le badge « exhausted » (qui porte le bouton *route from manager* de #152) vivaient **dans**
le nœud de la boîte. Un wrapper positionné avec un `z-index` numérique est un contexte d'empilement :
aucun descendant du `zIndex: 0` de la boîte ne peut peindre au-dessus d'une carte sœur.

Les deux exigences sont réellement opposées — le fond **derrière** les cartes, le chrome **devant** —
donc il faut deux couches d'empilement, donc deux nœuds : `region-<id>` (`layer: "box"`, zIndex 0) et
`region-chrome-<id>` (`layer: "chrome"`, zIndex **1001**), sur le même rectangle.

1001 et pas 1, parce qu'`elevateNodesOnSelect` de xyflow ajoute `SELECTED_NODE_Z = 1000` au nœud
sélectionné : tout ce qui est ≤ 1000 laisserait le header inatteignable pendant qu'une carte est
sélectionnée, précisément le moment où l'on tend la main vers la région.

Les deux nœuds gardent `type: "loopRegion"`, si bien que les gardes `n.type === "loopRegion"` d'`EditCanvas`
(drag-stop, menu contextuel, clic) couvrent le chrome gratuitement au lieu d'exiger un jeu parallèle pour
un 5e type. Et les deux wrappers restent `pointer-events: none` : le chrome couvre maintenant les cartes,
il ne doit pas avaler leurs clics — #167 dans l'autre sens.

## Vérification

- **+30 tests**, tous vus **rouges avant** leur fix, sauf deux garde-fous explicitement étiquetés comme
  tels (le cas enum de #457, et l'anti-sur-correction de #454 : une réinitialisation inconditionnelle
  jetterait un choix délibéré encore valide).
- Suite frontend complète : **1434 tests verts**, 0 échec (1404 avant).
- `npm run lint` : propre. `tsc --noEmit` : propre.
- La suite Rust n'est pas touchée par ce diff ; la CI de cette PR est le seul endroit où
  `cargo test --workspace` tourne, et elle sert de gate.

## Ce que ce diff ne prouve pas

Aucune de ces quatre corrections n'a été validée dans l'application réelle. #455 en particulier est un
défaut de superposition : jsdom ne le reproduit pas, le filet assère le `zIndex` calculé, pas le
hit-testing. **La preuve visuelle vient du rejeu de la suite HP**, prévu après le merge de #453 et le
rebuild de l'instance de test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
