### PR TITLE
test(ci): attendre le contenu du marqueur, pas l'existence du fichier

### DIFF
--- a/crates/pdo-daemon/tests/run_shell.rs
+++ b/crates/pdo-daemon/tests/run_shell.rs
@@ -195,6 +195,31 @@ async fn run_status(daemon: &TestDaemon, run_id: &str) -> Option<String> {
         .map(String::from)
 }
 
+/// Polls until `path` holds `needle`, returning whatever it last read.
+///
+/// `path.exists()` is NOT a usable readiness signal for `echo X > file`: the
+/// redirect creates and truncates the file *before* the shell writes a byte into
+/// it. A poll that stops at `exists()` therefore reads an EMPTY file whenever the
+/// machine is loaded enough to interleave there — which is how
+/// `shell_survives_eof_and_exit` failed CI on 2026-07-27, panicking with
+/// `marker bytes: ` and nothing after the colon. Wait for the CONTENT, which is
+/// what these assertions are about in the first place.
+///
+/// Returns on timeout rather than panicking, so the caller's assertion still
+/// produces its own (more specific) message.
+async fn wait_for_marker(path: &std::path::Path, needle: &str) -> String {
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    let mut last = String::new();
+    while std::time::Instant::now() < deadline {
+        last = std::fs::read_to_string(path).unwrap_or_default();
+        if last.contains(needle) {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(150)).await;
+    }
+    last
+}
+
 async fn post_shell(daemon: &TestDaemon, run_id: &str) -> reqwest::Response {
     reqwest::Client::new()
         .post(format!("{}/sessions/{run_id}/shell", daemon.url()))
@@ -341,22 +366,15 @@ async fn shell_runs_real_bash_in_pipeline_worktree() {
     let marker = worktree.join("fp316-marker.txt");
     let env_marker = worktree.join("env-marker.txt");
 
-    // Poll for the side effect (interactive bash + send-keys is async).
-    let deadline = std::time::Instant::now() + Duration::from_secs(10);
-    while std::time::Instant::now() < deadline {
-        if marker.exists() && env_marker.exists() {
-            break;
-        }
-        tokio::time::sleep(Duration::from_millis(150)).await;
-    }
-    let got = std::fs::read_to_string(&marker).unwrap_or_else(|_| {
-        panic!(
-            "marker must exist at {} — proves cwd = worktree and real bash",
-            marker.display()
-        )
-    });
-    assert!(got.contains("PDO_OK"), "marker bytes: {got}");
-    let env_got = std::fs::read_to_string(&env_marker).unwrap_or_default();
+    // Poll for the side effect (interactive bash + send-keys is async), on the
+    // CONTENT rather than on the file existing — see `wait_for_marker`.
+    let got = wait_for_marker(&marker, "PDO_OK").await;
+    assert!(
+        got.contains("PDO_OK"),
+        "marker at {} must hold PDO_OK — proves cwd = worktree and real bash; got {got:?}",
+        marker.display()
+    );
+    let env_got = wait_for_marker(&env_marker, "1").await;
     assert_eq!(
         env_got.trim(),
         "1",
@@ -722,18 +740,10 @@ async fn shell_survives_eof_and_exit() {
         "echo RESPAWN_OK > respawn-marker.txt",
     );
     let marker = worktree_path(&daemon, &run_id).join("respawn-marker.txt");
-    let deadline = std::time::Instant::now() + Duration::from_secs(10);
-    while std::time::Instant::now() < deadline {
-        if marker.exists() {
-            break;
-        }
-        tokio::time::sleep(Duration::from_millis(150)).await;
-    }
-    let got = std::fs::read_to_string(&marker).unwrap_or_else(|_| {
-        panic!(
-            "respawned shell must be usable — marker missing at {}",
-            marker.display()
-        )
-    });
-    assert!(got.contains("RESPAWN_OK"), "marker bytes: {got}");
+    let got = wait_for_marker(&marker, "RESPAWN_OK").await;
+    assert!(
+        got.contains("RESPAWN_OK"),
+        "respawned shell must be usable — marker at {} never held RESPAWN_OK; got {got:?}",
+        marker.display()
+    );
 }


### PR DESCRIPTION
La CI Rust de la PR #461 (fix #453) est sortie **rouge** en pleine salve #403, sur un test qui n'a
aucun rapport avec le diff. Comme la PR ciblait une branche d'intégration, `--auto` ne gate rien et
elle a été mergée quand même : la branche d'intégration porte donc un rouge, sur le chemin du merge
1.0.0.

## Ce n'était pas un aléa

```
thread 'shell_survives_eof_and_exit' panicked at run_shell.rs:738:
marker bytes:
```

Rien après les deux-points. Le fichier **existait** — sans quoi le `unwrap_or_else` « marker
missing » aurait tiré à la place — mais il était **vide**.

`path.exists()` n'est pas une condition de réveil valable pour `echo X > file` : la redirection crée
et tronque le fichier **avant** que le shell n'y écrive un octet. Une boucle qui s'arrête sur
`exists()` lit donc un fichier vide dès que la machine est assez chargée pour s'intercaler là. Le
test attendait la mauvaise chose.

## Le fix

`wait_for_marker` attend le **contenu**, ce que ces assertions vérifient en réalité, et rend la main
sur timeout au lieu de paniquer — l'assertion de l'appelant produit alors son propre message, plus
précis, avec les octets réellement lus.

Les **deux** sites concernés y passent : `shell_survives_eof_and_exit` (celui qui a cassé) et
`shell_runs_real_bash_in_pipeline_worktree`, qui portait le même défaut, latent.

## Attribution

`shell_survives_eof_and_exit` et son assertion sont **intacts depuis `main`** — la salve #403 n'a
touché `run_shell.rs` que pour ajouter un argument `None` à deux *autres* tests. Ce flake est donc
**préexistant**, pas une régression de la salve. Il est corrigé ici parce qu'il est sur le chemin du
gate 1.0.0 et qu'il reflakera au merge sinon.

## Vérification, et ce qu'elle vaut

- `cargo test -p pdo-daemon --test run_shell` : **13/13**.
- `cargo clippy --workspace --all-targets` : propre.

Passer en local ne prouve évidemment **rien** sur une course — le test passait déjà en local avant.
Ce qui vaut ici, c'est que la condition attendue est désormais celle que le test assère.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
