### PR TITLE
fix(release): filtrer les artefacts sur `pdo-*` — le build record du job image faisait échouer la release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,9 +83,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # `pattern` est LOAD-BEARING : sans filtre, cette étape télécharge TOUS les artefacts du run,
+      # y compris le build record `*.dockerbuild` publié par docker/build-push-action dans le job
+      # `image`. Ce n'est pas un zip exploitable par l'action → « Unable to download and extract
+      # artifact » après 5 retries, et la release entière échoue (v1.0.0, run 30272375005). Le job
+      # `image` se croit isolé parce qu'il n'a pas de `needs:`, mais le couplage passe par le
+      # magasin d'artefacts, et il est INTERMITTENT : si le job `image` finit après cette étape,
+      # l'artefact n'existe pas encore et la release passe.
       - uses: actions/download-artifact@v4
         with:
           path: artifacts
+          pattern: pdo-*
           merge-multiple: true
 
       - name: Generate checksums


### PR DESCRIPTION
Découvert en publiant **v1.0.0** : le tag a bien déclenché `release.yml`, les **4 binaires ont été
construits** (aarch64-linux inclus — la landmine rustls est intacte) et l'image GHCR publiée, mais le
job `Release` a échoué et **aucune Release n'a été créée**.

## Cause

`actions/download-artifact@v4` était appelé **sans `pattern`**, donc il téléchargeait *tous* les
artefacts du run. Depuis que #411 a ajouté le job `image`, `docker/build-push-action` publie en plus
un **build record `*.dockerbuild`** — pas un zip exploitable par l'action :

```
- pdo-macos-aarch64 (ID: 8655504717) ... Artifact download completed successfully.
- pdo-linux-aarch64 (ID: 8655495292) ... Artifact download completed successfully.
- pdo-macos-x86_64  (ID: 8655488354) ... Artifact download completed successfully.
- pdo-linux-x86_64  (ID: 8655484822) ... Artifact download completed successfully.
- Loulen~prompt-driven-orchestrator~DUNHBZ.dockerbuild (ID: 8655454419)
##[error]Unable to download artifact(s): Unable to download and extract artifact:
         Artifact download failed after 5 retries.
```

Ce qui rend le défaut intéressant : le job `image` porte un commentaire affirmant son indépendance
« PAS de `needs:` — un hoquet registry ne doit jamais faire échouer/retarder la release binaire ».
L'isolement a été raisonné en termes de `needs:` et de steps partagés ; le couplage est arrivé par
le **magasin d'artefacts**, qui n'est ni l'un ni l'autre.

Il est aussi **intermittent**, ce qui est pire qu'un échec franc : le job `image` n'a pas de `needs`,
donc il court en parallèle. S'il finit *après* l'étape de download, l'artefact n'existe pas encore et
la release passe. C'est un piège qui ne se reproduira pas de façon fiable.

## Fix

`pattern: pdo-*` sur l'étape de download. Matche les quatre `pdo-<platform>` produits par la matrice
`build` et exclut tout artefact futur qu'un autre job viendrait ajouter — la protection vaut au-delà
du seul `.dockerbuild`.

## Vérification

Le tag `v1.0.0` sera repointé sur le commit de ce fix et repoussé : rien n'a été publié sous ce tag
(`gh release view v1.0.0` → *release not found*, seule `v0.1.63` existe), donc aucun consommateur
externe ne le voit bouger. La preuve que le fix marche est la Release v1.0.0 effectivement créée avec
ses 4 tarballs + `SHA256SUMS.txt` + `install.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)