### PR TITLE
fix(#414): l'identité de l'uid hôte se pose sur le conteneur, pas dans les mounts — 1.2.1

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1142,8 +1142,26 @@ Les bind-mounts qui **répliquent l'identité de l'hôte** pour que le chemin de
 des deux côtés : repo cible monté rw à son **chemin absolu hôte** (couvre tous les worktrees de
 nœuds, sous `.pdo/runs/`), *staged Claude home* → `$HOME/.claude`, `.claude.json` sibling →
 `$HOME/.claude.json`, binaire `pdo` hôte monté ro dans le PATH, **uid/gid hôte** adoptés par le
-process (`--user`). C'est ce qui garantit le **même dirname encodé** que `merge_back`. _Éviter_ :
-« volumes » seul, « partage de fichiers ».
+process (`--user`). C'est ce qui garantit le **même dirname encodé** que `merge_back`. La liste
+reste à **quatre** — c'est la propriété : donner un *nom* à l'uid hôte n'en ajoute pas un cinquième,
+c'est l'**injection d'identité** (ci-dessous), qui n'est pas un mount. _Éviter_ : « volumes » seul,
+« partage de fichiers ».
+
+**Injection d'identité (`ensure_identity`)** :
+Le `docker exec --user 0:0` que `ensure_running` lance **juste après le `start`**, sur ses **trois**
+branches, pour donner à l'uid/gid hôte une **identité nommée** (`pdo`) dans le conteneur : il
+**ajoute** deux lignes aux `/etc/passwd` et `/etc/group` **réels de l'image**, derrière une garde
+`getent`. Le défaut qu'il ferme : le conteneur tourne en `--user` **numérique**, et `ubuntu:24.04` ne
+connaît de nom que pour l'uid 1000 — pour tout autre uid, `sudo` appelle `getpwuid()` avant
+d'appliquer NOPASSWD et abandonne (« you do not exist in the passwd database »), donc l'agent perd
+`apt install`, et `whoami` échoue. La garde **est** la conditionnalité, et elle est exacte : elle
+interroge l'image réelle au lieu de supposer laquelle c'est, donc en uid 1000 rien n'est écrit
+(fichiers byte-identiques) et le script est **idempotent**. Champ mot de passe `*` et non `x` (avec
+`x`, PAM cherche `/etc/shadow` et `sudo` rend « account validation failure »), **append** et jamais
+`replace` (`sudo` résout `root` par nom avant tout le reste), **best-effort** (`warn!`, jamais un Run
+cassé : la majorité des Runs n'invoquent pas `sudo`). _Éviter_ : « créer un utilisateur » (rien n'est
+créé, le conteneur tourne toujours en `--user` numérique), « identity mount » (ce n'est pas un
+mount), « nss_wrapper » (écarté, ADR-0030).
 
 **Préfixe `docker exec` (`exec_prefix`)** :
 La séquence d'arguments préposée à la tail d'un nœud pour la faire tourner **dans** le conteneur
@@ -1375,14 +1393,27 @@ concurrentes) ni avec le **garde de transition** (#212, légalité d'un `NodeSta
   complète) + unit (spawn différé sans event, `off` jamais bloqué, rejeu de bout en bout sur
   `advance_run`, `409` du force-spawn, les deux bornes de la grâce sandbox) + FP-445 (L5, Docker réel,
   recette `full-heavy`).
+- **Réalisé (#414, ADR-0030 pt 1)** : un conteneur tourne en `--user <uid>:<gid>` **numérique**, et
+  `ubuntu:24.04` ne connaît de nom que pour l'uid 1000 — sur toute machine dont l'uid ≠ 1000, `sudo`
+  refusait de démarrer (« you do not exist in the passwd database ») et `whoami` échouait, donc
+  l'agent perdait `apt install`, la raison même pour laquelle l'image embarque `sudo` NOPASSWD.
+  L'issue prescrivait de générer `/etc/passwd`+`/etc/group` au `prepare`-time et de les bind-monter :
+  **mesuré, ce mécanisme casse `useradd`/`apt` en `:ro` comme en `:rw`** (`rename()` par-dessus un
+  mount de fichier), soit une régression sur le chemin uid 1000. La livraison est donc une
+  **injection d'identité** (voir le lexique) : un `docker exec --user 0:0` **après le `start`**, sur
+  les trois branches d'`ensure_running`, qui **ajoute** les lignes manquantes derrière une garde
+  `getent` — la liste des mounts ne bouge pas et l'argv du `create` reste byte-identique. La prémisse
+  `claude`/`ERR_SYSTEM_ERROR` de l'issue était **fausse** : le `claude` de l'image est un binaire
+  **Bun**, qui ignore la base passwd. Couvert par unit (`identity_script` golden + `*` vs `x` +
+  append-jamais-truncate + quoting hostile + `identity_exec_args` + les trois branches + best-effort)
+  + layer-3 (`sandbox_tracer` : l'exec suit le `start`, `off` n'exec rien) + FP-414 (L5, Docker réel).
 - **Non traité, à ficher** : le réveil parasite du watcher. La première **lecture** de
   `<run>/pipeline.yaml` produit un `pipeline_modified` mensonger (masque inotify `OPEN`, debouncer sans
   filtre d'`EventKind`, `content_actually_changed` sans baseline pour un Run neuf —`seed_run_mtimes` ne
   tourne qu'au boot ; `copy_pipeline_to_run` est en outre le seul écrivain de l'arbre qui n'appelle
   jamais `mark_self_write`). Indépendant de #445 : la précondition tient quel que soit qui avance le Run.
-- **Différé** : injection `/etc/passwd`+`/etc/group` pour uid hôte ≠ 1000 (sudo +
-  Node `os.userInfo()`) (issue de suivi) ; auto-flip de la visibilité publique du package GHCR
-  (non supporté par l'API → manuel one-time après la 1ʳᵉ release, #411).
+- **Différé** : auto-flip de la visibilité publique du package GHCR (non supporté par l'API → manuel
+  one-time après la 1ʳᵉ release, #411).
 
 ### Ambiguïté signalée
 « sandbox » désigne deux choses : (1) cette feature (exécution conteneurisée d'un Run, #403) ;

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "1.2.0"
+version = "1.2.1"
 license = "MIT"
 
 [workspace.dependencies]

--- a/crates/pdo-daemon/src/sandbox_container.rs
+++ b/crates/pdo-daemon/src/sandbox_container.rs
@@ -33,12 +33,17 @@
 //! - **`--user` toujours NUMÉRIQUE `uid:gid`.** `--user 1000` seul ferait résoudre le gid
 //!   primaire via `/etc/passwd` (absent pour un uid arbitraire) → gid 0, bug silencieux de
 //!   propriété. `-e HOME=` suffit aux écritures `~/.claude` de Claude Code.
-//! - **GAP DOCUMENTÉ (uid hôte ≠ 1000).** L'image `ubuntu:24.04` livre `ubuntu`=uid/gid 1000,
-//!   donc le cas laptop courant résout ENTIÈREMENT (passwd présent). Pour un uid hôte ≠ 1000 :
-//!   `sudo` casse (getpwuid avant NOPASSWD) et `claude` peut casser (`os.userInfo()`). L'injection
-//!   `/etc/passwd`+`/etc/group` (générer les lignes au `prepare`-time, bind-monter — pattern PDO)
-//!   est **différée à une issue de suivi** (cf. `assets/sandbox/Dockerfile:33`). NE PAS éditer le
-//!   Dockerfile ici : il est content-hashé (#405), toute édition périme l'image buildée.
+//! - **L'identité de l'uid hôte est posée sur le conteneur, pas dans l'image (#414).** L'image
+//!   `ubuntu:24.04` ne connaît que l'uid 1000 (`ubuntu`) ; pour tout autre uid hôte, `sudo`
+//!   appelle `getpwuid()` avant NOPASSWD et abandonne (« you do not exist in the passwd
+//!   database »), et `whoami` échoue. [`ensure_running`] lance donc, juste après le `start`, un
+//!   `docker exec --user 0:0` qui **ajoute** les lignes manquantes aux `/etc/passwd` et
+//!   `/etc/group` RÉELS de l'image, derrière une garde `getent` ([`identity_script`]).
+//!   **Pas un bind-mount** (le mécanisme initialement prescrit) : mesuré, un `/etc/passwd`
+//!   bind-monté casse `useradd`/`apt` en `:ro` **comme** en `:rw` (`rename()` par-dessus un
+//!   mount de fichier), et exigerait de dupliquer la baseline d'une image que l'utilisateur peut
+//!   éditer. NE PAS éditer le Dockerfile : il est content-hashé (#405), toute édition périme
+//!   l'image buildée — et son commentaire ligne 33 décrit désormais le comportement livré.
 //! - **L'env par profil de staging est posé au CREATE (#468).** Ce sont des constantes de Run,
 //!   pas des variables de nœud : le chemin `docker exec` a sa propre liste par-nœud
 //!   ([`exec_prefix_with_env`]) et n'est pas concerné. Ce module possède
@@ -63,6 +68,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use anyhow::{Context, Result};
+use tracing::warn;
 
 use crate::sandbox_image::DOCKER_NOT_FOUND_MSG;
 
@@ -75,6 +81,14 @@ pub(crate) const SESSION_MARKER_ENV: &str = "PDO_SBX_SESSION";
 /// une raison légitime de le faire, et la fusion de [`create_args`] remplace alors la
 /// valeur **en place** (un seul `-e`, à la même position) au lieu d'en ajouter un second.
 const CLAUDE_TRAFFIC_ENV: &str = "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC";
+
+/// Nom d'utilisateur **et** de groupe synthétisés dans le conteneur pour l'uid/gid hôte
+/// ([`ensure_identity`]). Constante, jamais `$USER` : aucun chemin load-bearing ne lit ce
+/// nom (le `claude` de l'image est un binaire **Bun**, qui lit `$HOME`/`$USER` et ignore la
+/// base passwd ; `git` échoue sur le domaine `(none)`, pas sur le nom), donc lire
+/// l'environnement ajouterait le premier résolveur de nom d'utilisateur du dépôt pour un
+/// gain nul. `ubuntu:24.04` ne livre aucun `pdo` — pas de collision de nom.
+const IDENTITY_NAME: &str = "pdo";
 
 /// Les trois vars run-constantes qu'un profil de staging ne peut **pas** redéfinir (#468).
 ///
@@ -316,6 +330,72 @@ pub(crate) fn create_args(run_id: &str, spec: &ContainerSpec) -> Vec<String> {
     args
 }
 
+/// Script `sh -c` qui donne une **identité nommée** à l'uid/gid hôte dans le conteneur, en
+/// **ajoutant** au `/etc/passwd` et `/etc/group` réels de l'image — jamais en les remplaçant.
+///
+/// Le défaut qu'il ferme : un conteneur tourne en `--user <uid>:<gid>` numérique, et l'image
+/// `ubuntu:24.04` ne connaît que l'uid 1000 (`ubuntu`). Pour tout autre uid, `sudo` appelle
+/// `getpwuid()` avant d'appliquer NOPASSWD et abandonne sur « you do not exist in the passwd
+/// database » — l'agent perd `apt install`, la raison même pour laquelle l'image embarque `sudo`.
+///
+/// Trois détails sont load-bearing, chacun mesuré :
+/// - **`append`, pas `replace`** — `sudo` résout `root` PAR NOM avant tout le reste ; un passwd
+///   réduit à notre ligne rend `sudo: unknown user root`. Un `/etc/group` amputé fait en plus
+///   perdre à apt son bac à sable `_apt`.
+/// - **champ mot de passe `*`, pas `x`** — avec `x`, la phase *account* de `pam_unix` va chercher
+///   `/etc/shadow`, n'y trouve rien, et `sudo` rend « account validation failure ». `*` court-
+///   circuite la recherche. C'est ce qui évite un TROISIÈME fichier à injecter.
+/// - **garde `getent`** — c'est la conditionnalité, et elle est exacte : elle interroge l'image
+///   réelle au lieu de supposer laquelle c'est. En uid 1000 elle résout (`ubuntu`) et rien n'est
+///   écrit (fichiers byte-identiques) ; le chemin laptop courant est donc inchangé sans qu'aucun
+///   `if uid != 1000` n'existe en Rust — pas de branche morte, un seul chemin testé. Elle rend
+///   aussi le script **idempotent**, ce qu'exige un appel sur les trois branches d'
+///   [`ensure_running`] et à chaque `ensure_ready` du Run.
+///
+/// Home = le `$HOME` hôte, celui du `-e HOME=` du create : `getent`, `~` et l'environnement
+/// doivent désigner le même répertoire (et c'est de là que Node lirait `userInfo().homedir` si
+/// Claude Code repassait un jour sur une distribution Node).
+pub(crate) fn identity_script(uid: u32, gid: u32, host_home: &Path) -> String {
+    let passwd_line = format!(
+        "{IDENTITY_NAME}:*:{uid}:{gid}:PDO sandbox:{}:/bin/bash",
+        host_home.display()
+    );
+    let group_line = format!("{IDENTITY_NAME}:x:{gid}:");
+    format!(
+        "getent passwd {uid} >/dev/null 2>&1 || printf '%s\\n' {p} >> /etc/passwd; \
+         getent group {gid} >/dev/null 2>&1 || printf '%s\\n' {g} >> /etc/group",
+        p = sh_single_quote(&passwd_line),
+        g = sh_single_quote(&group_line),
+    )
+}
+
+/// Argv `docker exec` de l'injection d'identité (après le binaire `docker`). Ordre canonique
+/// FIGÉ par le golden test.
+///
+/// **`--user 0:0`** : écrire dans `/etc/passwd` demande root, et le `--user` d'un `exec` écrase
+/// celui du `create`. Le sandbox n'est pas une frontière de sécurité (ADR-0030) — le daemon
+/// possède déjà le conteneur, il ne s'accorde rien de neuf.
+///
+/// **Aucun `-e`, aucun `-i`/`-t`, aucun `-w`** : ce n'est pas une session de nœud. En
+/// particulier pas de [`SESSION_MARKER_ENV`], sinon le kill ciblé de la première session tuerait
+/// aussi cet exec (même raison que pour [`kill_session_in_container`]).
+pub(crate) fn identity_exec_args(
+    run_id: &str,
+    uid: u32,
+    gid: u32,
+    host_home: &Path,
+) -> Vec<String> {
+    vec![
+        "exec".to_string(),
+        "--user".to_string(),
+        "0:0".to_string(),
+        container_name(run_id),
+        "sh".to_string(),
+        "-c".to_string(),
+        identity_script(uid, gid, host_home),
+    ]
+}
+
 /// Préfixe `docker exec` d'une session de nœud (après le binaire `docker` ; #407 y ajoute la
 /// tail `claude`). Ordre canonique FIGÉ par le golden test.
 ///
@@ -459,13 +539,17 @@ fn probe_state(docker_bin: &str, name: &str) -> Result<ContainerState> {
 pub(crate) fn ensure_running(docker_bin: &str, run_id: &str, spec: &ContainerSpec) -> Result<()> {
     let name = container_name(run_id);
     match probe_state(docker_bin, &name)? {
-        ContainerState::Running => Ok(()),
-        ContainerState::Stopped => start_container(docker_bin, &name),
+        ContainerState::Running => {}
+        ContainerState::Stopped => start_container(docker_bin, &name)?,
         ContainerState::Absent => {
             create_container(docker_bin, run_id, spec)?;
-            start_container(docker_bin, &name)
+            start_container(docker_bin, &name)?;
         }
     }
+    // #414 : l'identité se pose sur le conteneur DÉMARRÉ, pas dans l'argv du create — voir
+    // `identity_script`. Sur les trois branches : un conteneur d'un daemon antérieur rattrape.
+    ensure_identity(docker_bin, run_id, spec.uid, spec.gid, spec.host_home);
+    Ok(())
 }
 
 /// `docker` + [`create_args`]. `create` et `start` sont DEUX primitives (pas `run -d`) : la
@@ -518,6 +602,42 @@ fn start_container(docker_bin: &str, name: &str) -> Result<()> {
             "failed to start the sandbox container `{name}` — `docker start` exited with {}: {stderr}",
             output.status
         )
+    }
+}
+
+/// Pose l'identité de l'uid/gid hôte dans le conteneur ([`identity_script`]). Appelée par
+/// [`ensure_running`] sur les **trois** branches, après le `start`.
+///
+/// **Best-effort, par choix** : la grande majorité des Runs n'invoquent jamais `sudo`. Faire
+/// échouer un Run parce qu'une commodité n'a pas pu être posée serait pire que le défaut
+/// corrigé — donc `warn!` et on continue, jamais de `?` vers l'appelant (miroir de
+/// `sandbox_run::kill_session_best_effort`). C'est l'exact opposé de la politique du plancher de
+/// staging, et pour une raison nette : le plancher désarme des dialogues qui **bloquent** un
+/// agent non surveillé, ici l'agent voit juste une commande échouer.
+///
+/// Sur les trois branches et pas seulement `Absent` : un conteneur créé par un daemon antérieur
+/// et toujours vivant doit rattraper son identité. La garde `getent` rend les appels répétés
+/// gratuits.
+fn ensure_identity(docker_bin: &str, run_id: &str, uid: u32, gid: u32, host_home: &Path) {
+    let name = container_name(run_id);
+    let args = identity_exec_args(run_id, uid, gid, host_home);
+    match Command::new(docker_bin).args(&args).output() {
+        Ok(output) if output.status.success() => {}
+        Ok(output) => {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            if is_absent_stderr(&stderr) {
+                return; // le conteneur a disparu entre le start et ici — rien à identifier.
+            }
+            warn!(
+                "sandbox: could not give uid {uid} a passwd entry in `{name}` \
+                 (`docker exec` exited with {}: {stderr}) — `sudo` will refuse to start inside \
+                 the container",
+                output.status
+            );
+        }
+        Err(e) => {
+            warn!("sandbox: could not run `docker exec` to identify uid {uid} in `{name}`: {e:#}");
+        }
     }
 }
 
@@ -1244,7 +1364,156 @@ mod tests {
         );
     }
 
+    // -- 2c. identité du conteneur (#414) ------------------------------------
+    //
+    // Le script est le seul endroit du dépôt où vivent les subtilités mesurées pendant le
+    // grilling (`*` vs `x`, `>>` vs `>`, la garde). Chacune a son test NOMMÉ, pour qu'une
+    // simplification bien intentionnée tombe sur un refus qui porte sa raison.
+
+    /// Le golden : la chaîne EXACTE pour un uid hôte ≠ 1000. C'est ce texte que l'humain de
+    /// la HP recopie pour reproduire à la main (§3.5 du plan #414).
+    #[test]
+    fn identity_script_golden() {
+        assert_eq!(
+            identity_script(1234, 1234, Path::new("/home/u")),
+            "getent passwd 1234 >/dev/null 2>&1 || printf '%s\\n' \
+             'pdo:*:1234:1234:PDO sandbox:/home/u:/bin/bash' >> /etc/passwd; \
+             getent group 1234 >/dev/null 2>&1 || printf '%s\\n' 'pdo:x:1234:' >> /etc/group"
+        );
+    }
+
+    /// D4 — le champ mot de passe de la ligne passwd est `*`, JAMAIS `x`. Avec `x`, la phase
+    /// *account* de `pam_unix` cherche la ligne dans `/etc/shadow`, ne la trouve pas, et `sudo`
+    /// rend « account validation failure, is your account locked? » : il faudrait alors injecter
+    /// un TROISIÈME fichier. La ligne `group`, elle, porte bien `x` (c'est son champ mot de passe
+    /// de groupe, sans rapport avec shadow) — d'où la tentation d'« harmoniser », que ce test
+    /// refuse en nommant la raison.
+    #[test]
+    fn identity_script_password_field_is_star_not_x() {
+        let script = identity_script(1234, 5678, Path::new("/home/u"));
+        assert!(
+            script.contains("'pdo:*:1234:5678:"),
+            "la ligne passwd doit porter `*` comme champ mot de passe: {script}"
+        );
+        assert!(
+            !script.contains("'pdo:x:1234:"),
+            "un `x` en passwd renverrait PAM vers /etc/shadow (account validation failure): {script}"
+        );
+        // Contrepartie : la ligne de groupe garde son `x`, c'est sa forme canonique.
+        assert!(script.contains("'pdo:x:5678:'"), "ligne group: {script}");
+    }
+
+    /// D5 — on AJOUTE, on ne tronque jamais. Un `/etc/passwd` réduit à notre ligne rend
+    /// `sudo: unknown user root` (sudo résout `root` PAR NOM avant tout le reste), et un
+    /// `/etc/group` amputé fait perdre à apt son bac à sable `_apt`. Les seuls `>` tolérés
+    /// sont les deux `>>` et les redirections `>/dev/null` de la garde.
+    #[test]
+    fn identity_script_appends_and_never_truncates() {
+        let script = identity_script(1234, 1234, Path::new("/home/u"));
+        assert_eq!(
+            script.matches(">>").count(),
+            2,
+            "exactement deux appends (passwd + group): {script}"
+        );
+        let stripped = script
+            .replace(">> /etc/passwd", "")
+            .replace(">> /etc/group", "");
+        // Les redirections de la GARDE sont légitimes : elles muselent `getent`, elles
+        // n'écrivent aucun fichier.
+        let stripped = stripped.replace(">/dev/null 2>&1", "");
+        assert!(
+            !stripped.contains('>'),
+            "aucune redirection tronquante ne doit exister: {script}"
+        );
+        for verb in ["tee", "sed -i", "truncate", "cat >"] {
+            assert!(
+                !script.contains(verb),
+                "`{verb}` réécrirait le fichier au lieu de l'étendre: {script}"
+            );
+        }
+    }
+
+    /// Un `$HOME` hôte hostile (apostrophe + espace) reste UN seul argument `sh` correctement
+    /// quoté. Prouvé en faisant round-tripper le littéral par un vrai `sh`, pas en relisant le
+    /// quoting à l'œil.
+    #[test]
+    fn identity_script_quotes_a_hostile_home() {
+        let home = Path::new("/home/o'brien x");
+        let script = identity_script(1234, 1234, home);
+        let line = "pdo:*:1234:1234:PDO sandbox:/home/o'brien x:/bin/bash";
+        let quoted = sh_single_quote(line);
+        assert!(
+            script.contains(&quoted),
+            "la ligne passwd doit être single-quotée en entier: {script}"
+        );
+        let out = Command::new("sh")
+            .arg("-c")
+            .arg(format!("printf '%s' {quoted}"))
+            .output()
+            .unwrap();
+        assert_eq!(
+            String::from_utf8_lossy(&out.stdout),
+            line,
+            "le quoting doit round-tripper par un vrai `sh`"
+        );
+    }
+
+    /// Golden argv de l'injection : root (`--user 0:0`, écrire `/etc/passwd` l'exige) et
+    /// **aucun** marqueur de session — sinon le kill ciblé de la première session emporterait
+    /// aussi cet exec (même raison que pour le kill exec lui-même).
+    #[test]
+    fn identity_exec_runs_as_root_without_a_session_marker() {
+        let args = identity_exec_args("r1", 1234, 1234, Path::new("/home/u"));
+        let mut expected = strings(&["exec", "--user", "0:0", "pdo-sbx-r1", "sh", "-c"]);
+        expected.push(identity_script(1234, 1234, Path::new("/home/u")));
+        assert_eq!(args, expected);
+        assert!(
+            !args.iter().any(|a| a.contains(SESSION_MARKER_ENV)),
+            "pas de marqueur de session sur l'exec d'identité: {args:?}"
+        );
+        // Ce n'est pas une session de nœud : ni tty, ni forwarding d'env, ni cwd.
+        for flag in ["-i", "-t", "-e", "-w"] {
+            assert!(
+                !args.iter().any(|a| a == flag),
+                "`{flag}` n'a rien à faire sur l'exec d'identité: {args:?}"
+            );
+        }
+    }
+
+    /// D1 — l'identité n'est PAS un mount : l'argv du `create` ne porte ni `/etc/passwd` ni
+    /// `/etc/group`. Les goldens de `create_args` le prouvent déjà par égalité ; celui-ci
+    /// **nomme** la propriété, parce que le mécanisme prescrit par l'issue était précisément
+    /// un bind-mount et qu'il casse `useradd`/`apt` (en `:ro` comme en `:rw`).
+    #[test]
+    fn create_args_is_untouched_by_identity_injection() {
+        let fx = Fixtures::sample();
+        let args = create_args("r1", &fx.spec());
+        for forbidden in ["/etc/passwd", "/etc/group", "/etc/shadow"] {
+            assert!(
+                !args.iter().any(|a| a.contains(forbidden)),
+                "`{forbidden}` ne doit jamais être monté: {args:?}"
+            );
+        }
+        // Le `--user` du create reste NUMÉRIQUE même une fois passwd peuplé : `--user <nom>`
+        // ferait résoudre le gid primaire via passwd → gid 0 (le bug que #406 ferme).
+        let user_at = args.iter().position(|a| a == "--user").unwrap();
+        assert_eq!(args[user_at + 1], "1000:1000");
+    }
+
     // -- 3-8. ensure_running / probe (AC#2) ----------------------------------
+
+    /// Position de l'`exec` d'identité (#414) dans l'`argv.log` du fake docker : la ligne
+    /// `0:0` en est le témoin UNIQUE (aucune autre invocation ne porte ce `--user`).
+    fn identity_exec_at(lines: &[String]) -> Option<usize> {
+        let user_at = lines.iter().position(|l| l == "0:0")?;
+        Some(user_at - 2) // `exec`, `--user`, `0:0`
+    }
+
+    /// L'argv complet de l'`exec` d'identité tel que le fake docker l'a vu.
+    fn identity_exec_argv(lines: &[String]) -> Vec<String> {
+        let at = identity_exec_at(lines).expect("l'exec d'identité doit avoir tourné");
+        lines[at..(at + 7).min(lines.len())].to_vec()
+    }
 
     #[test]
     fn running_reuses() {
@@ -1267,6 +1536,13 @@ mod tests {
             !lines.contains(&"start".to_string()),
             "running → pas de start"
         );
+        // #414 : un conteneur déjà up d'un daemon ANTÉRIEUR rattrape son identité — c'est
+        // pour ça que l'injection vit après le `match`, pas dans le bras `Absent`.
+        assert_eq!(
+            identity_exec_argv(&lines),
+            identity_exec_args("r1", 1000, 1000, Path::new("/home/u")),
+            "running → l'identité est tout de même posée"
+        );
     }
 
     #[test]
@@ -1286,6 +1562,12 @@ mod tests {
         assert!(
             !lines.contains(&"create".to_string()),
             "stopped → pas de create"
+        );
+        // #414 : l'identité se pose sur un conteneur DÉMARRÉ — donc après le `start`.
+        let start_pos = lines.iter().position(|l| l == "start").unwrap();
+        assert!(
+            identity_exec_at(&lines).unwrap() > start_pos,
+            "l'exec d'identité doit suivre le start: {lines:?}"
         );
     }
 
@@ -1317,6 +1599,81 @@ mod tests {
         assert!(
             lines.contains(&"sleep".to_string()) && lines.contains(&"infinity".to_string()),
             "create doit poser `sleep infinity`"
+        );
+        // #414 : create → start → identité, dans cet ordre. L'inverser exec-erait dans un
+        // conteneur pas encore démarré.
+        assert!(
+            identity_exec_at(&lines).unwrap() > start_pos,
+            "l'exec d'identité doit suivre le start: {lines:?}"
+        );
+    }
+
+    /// #414 — l'identité est posée sur les **trois** branches de la machine à états, jamais
+    /// sur la seule `Absent`. Un conteneur créé par un daemon antérieur à #414 et toujours
+    /// vivant (branche `Running`) doit rattraper : c'est exactement le cas qu'une injection
+    /// posée au `create` aurait laissé sans identité pour toute la durée du Run.
+    #[test]
+    fn identity_is_ensured_on_all_three_branches() {
+        let branches = [
+            ("running", FakeSpec::default()),
+            (
+                "stopped",
+                FakeSpec {
+                    inspect_stdout: "false".to_string(),
+                    ..Default::default()
+                },
+            ),
+            (
+                "absent",
+                FakeSpec {
+                    inspect_exit: 1,
+                    inspect_stdout: String::new(),
+                    inspect_stderr: "Error: No such container: pdo-sbx-r1".to_string(),
+                    ..Default::default()
+                },
+            ),
+        ];
+        for (label, spec) in branches {
+            let tmp = tempfile::tempdir().unwrap();
+            let (docker, log) = write_fake_docker(tmp.path(), &spec);
+            let fx = Fixtures::sample();
+
+            retry_etxtbsy(|| ensure_running(&docker, "r1", &fx.spec())).unwrap();
+
+            let lines = log_lines(&log);
+            assert_eq!(
+                identity_exec_argv(&lines),
+                identity_exec_args("r1", 1000, 1000, Path::new("/home/u")),
+                "branche `{label}` : l'identité doit être posée"
+            );
+        }
+    }
+
+    /// D8 — best-effort : un `docker exec` d'identité en échec `warn!` et laisse le Run
+    /// continuer. La majorité des Runs n'invoquent jamais `sudo` ; faire échouer un Run parce
+    /// qu'une commodité n'a pas pu être posée serait pire que le défaut corrigé.
+    #[test]
+    fn ensure_identity_never_fails_the_run() {
+        let tmp = tempfile::tempdir().unwrap();
+        let spec = FakeSpec {
+            inspect_exit: 1,
+            inspect_stdout: String::new(),
+            inspect_stderr: "Error: No such container: pdo-sbx-r1".to_string(),
+            exec_exit: 1,
+            exec_stderr: "boom".to_string(),
+            ..Default::default()
+        };
+        let (docker, log) = write_fake_docker(tmp.path(), &spec);
+        let fx = Fixtures::sample();
+
+        // Le conteneur est bien créé et démarré ; seule l'identité a échoué.
+        retry_etxtbsy(|| ensure_running(&docker, "r1", &fx.spec())).unwrap();
+
+        let lines = log_lines(&log);
+        assert!(lines.contains(&"create".to_string()));
+        assert!(
+            identity_exec_at(&lines).is_some(),
+            "l'exec a bien été tenté"
         );
     }
 

--- a/crates/pdo-daemon/tests/sandbox_tracer.rs
+++ b/crates/pdo-daemon/tests/sandbox_tracer.rs
@@ -1698,3 +1698,124 @@ async fn off_run_manager_preamble_stays_on_localhost() {
         "the `off` path must not invoke docker at all"
     );
 }
+
+// -- Test 13: the host uid gets a named identity inside the container (#414) ---
+
+/// The `argv.log` window of the identity `docker exec` (#414). The `0:0` line is its
+/// UNIQUE witness: every other invocation of the fake docker either carries no `--user`
+/// at all or carries the host `<uid>:<gid>`, never root.
+fn identity_exec_argv(log: &Path) -> Option<Vec<String>> {
+    let content = log_text(log);
+    let lines: Vec<String> = content.lines().map(str::to_string).collect();
+    let user_at = lines.iter().position(|l| l == "0:0")?;
+    let at = user_at.checked_sub(2)?; // `exec`, `--user`, `0:0`
+    Some(lines[at..(at + 7).min(lines.len())].to_vec())
+}
+
+/// #414: a container runs as `--user <uid>:<gid>` NUMERIC, and `ubuntu:24.04` only knows
+/// uid 1000. On any other host uid, `sudo` calls `getpwuid()` before applying NOPASSWD and
+/// gives up ("you do not exist in the passwd database") — the agent loses `apt install`,
+/// which is the entire reason the image ships `sudo`. So the prep runs one
+/// `docker exec --user 0:0` right after the `start` that APPENDS the missing lines to the
+/// image's REAL `/etc/passwd` and `/etc/group`, behind a `getent` guard.
+///
+/// The daemon here runs under the live host uid, so this asserts the SHAPE, never a uid
+/// value: the argv, the guard, the two appends, the `*` password field, and the home field
+/// — which must be the harness's `sandbox_home_override`, i.e. the very path the create
+/// posed as `-e HOME=`. `getent`, `~` and the environment naming three different
+/// directories is precisely the class of bug this pins.
+///
+/// Includes its own negative control (an `off` Run adds no such exec), stronger than
+/// re-reading `off_run_never_invokes_docker`: it proves the injection is gated by the mode
+/// on a daemon that HAS just performed one.
+#[tokio::test]
+async fn sandbox_prep_identifies_the_host_uid_in_the_container() {
+    ensure_pdo_on_path();
+    let (_fake_dir, docker, log) = write_fake_docker();
+    // A body that writes its declared output on the host, so the `off` half of this test
+    // (the negative control) completes for real instead of failing output validation.
+    let daemon = TestDaemon::spawn_with_docker_override(
+        seed(
+            "#!/usr/bin/env bash\nset -euo pipefail\n\
+             printf 'ok\\n' > \"$PDO_OUTPUT_OUT\"\n",
+        ),
+        docker,
+    )
+    .await
+    .unwrap();
+
+    let run_id = start_run(&daemon, Some("minimal")).await;
+    assert!(
+        wait_until(|| identity_exec_argv(&log).is_some()).await,
+        "the prep must run the identity `docker exec`; log:\n{}",
+        log_text(&log)
+    );
+    let argv = identity_exec_argv(&log).unwrap();
+
+    // (a) The argv: root, this Run's container, `sh -c <script>`. No `-e` (a session
+    // marker here would make the first targeted kill take this exec down too), no tty.
+    assert_eq!(
+        &argv[..6],
+        &[
+            "exec".to_string(),
+            "--user".to_string(),
+            "0:0".to_string(),
+            format!("pdo-sbx-{run_id}"),
+            "sh".to_string(),
+            "-c".to_string(),
+        ][..],
+        "identity exec argv; log:\n{}",
+        log_text(&log)
+    );
+
+    // (b) The script: guarded, appending, `*` in the password field.
+    let script = &argv[6];
+    for needle in [
+        "getent passwd ",
+        "getent group ",
+        ">> /etc/passwd",
+        ">> /etc/group",
+        ":*:",
+    ] {
+        assert!(
+            script.contains(needle),
+            "the identity script must contain `{needle}`: {script}"
+        );
+    }
+    // The home field IS the `-e HOME=` of the create (the harness collocates
+    // host_home == repo_root via `sandbox_home_override`).
+    let home = daemon.repo_root().display().to_string();
+    assert!(
+        script.contains(&format!("PDO sandbox:{home}:/bin/bash")),
+        "the injected home must be the container's `$HOME` ({home}): {script}"
+    );
+
+    // (c) It runs AFTER the start — an exec into a container that is not up yet fails.
+    let content = log_text(&log);
+    let lines: Vec<&str> = content.lines().collect();
+    let start_at = lines
+        .iter()
+        .position(|l| *l == "start")
+        .expect("the prep must start the container");
+    let identity_at = lines
+        .iter()
+        .position(|l| *l == "0:0")
+        .expect("the identity exec must be logged");
+    assert!(
+        start_at < identity_at,
+        "the identity exec must follow `docker start`; log:\n{content}"
+    );
+
+    // (d) Negative control on the SAME daemon: an `off` Run adds no identity exec.
+    let identity_execs = |log: &Path| log_text(log).lines().filter(|l| *l == "0:0").count();
+    let before = identity_execs(&log);
+    let off_id = start_run(&daemon, None).await;
+    let off = wait_run_status(&daemon, &off_id, "completed").await;
+    assert_eq!(off["status"], "completed", "off run must complete: {off}");
+    assert_eq!(
+        identity_execs(&log),
+        before,
+        "an `off` Run must not identify anything — it never touches docker; log:\n{}",
+        log_text(&log)
+    );
+}

--- a/docs/adr/0030-sandbox-execution-model.md
+++ b/docs/adr/0030-sandbox-execution-model.md
@@ -16,6 +16,23 @@ PID 1 = tini). Les guards de Trigger restent hôte (décision de fiançailles, p
    le chemin de travail est identique des deux côtés → le dirname encodé des transcripts matche
    (pré-requis du merge-back, câblé en #408).
 
+   **Amendement #414 — l'identité de l'uid hôte se pose sur le conteneur démarré, pas dans la liste
+   des mounts.** La liste des mounts **ne bouge pas** (elle reste celle ci-dessus + la queue
+   d'exception `$HOME` d'ADR-0031 §4), et l'argv du `docker create` reste **byte-identique** : le
+   `--user` numérique donne au process l'uid/gid hôte, mais l'image ne connaît de *nom* que pour
+   l'uid 1000. `ensure_running` lance donc, juste après le `start` et **sur ses trois branches**, un
+   `docker exec --user 0:0` qui **ajoute** les deux lignes manquantes aux `/etc/passwd` et
+   `/etc/group` réels de l'image, derrière une garde `getent` — no-op exact en uid 1000 (fichiers
+   byte-identiques), best-effort partout (`warn!`, jamais un Run cassé). Voir « Injection
+   d'identité » dans le lexique, et les alternatives écartées ci-dessous pour pourquoi ce n'est
+   **pas** un bind-mount.
+
+   Le **Dockerfile n'est pas modifié** — pas même un commentaire : il est hashé octet par octet
+   (`sha256`, sans normalisation) pour dériver le tag `pdo-sandbox:h-<hash>`, donc toute édition
+   périmerait l'image buildée et publiée. Son commentaire de la règle sudoers (« pour tout autre uid
+   hôte, le RUNTIME doit injecter une entrée passwd — hors périmètre de l'image ») **devient vrai**
+   avec cette livraison ; seul son pointeur `(#406)` est daté, et se lit désormais `(#414)`.
+
 2. **Staging par Run.** `~/.pdo/sandbox/<run-id>/` (jamais le vrai `~/.claude`), seedé par `prepare`
    selon le mode, purgé par `teardown` au `cleanup_run`. En `pure`, la confiance (`hasTrustDialogAccepted`)
    est pré-accordée à la **racine du repo** — l'ancêtre commun du worktree de pipeline ET de tous les
@@ -206,6 +223,25 @@ l'hôte qu'un Run hôte.
   conteneurs que PDO croit finis.
 - **Envelopper `wrap_with_env` entier dans le `docker exec`** (au lieu d'`-e` explicites) : rejeté —
   ré-exporterait `PDO_DAEMON_URL=localhost` dans le conteneur et casserait la gateway.
+- **Bind-monter un `/etc/passwd` + `/etc/group` générés au `prepare`-time** (le mécanisme que #414
+  prescrivait) : rejeté **sur mesure**. Un `/etc/passwd` bind-monté casse `sudo apt-get install` de
+  tout paquet créant un utilisateur système — `groupadd: cannot open /etc/group`, dpkg laissé en
+  `iU` — en `:ro` **comme** en `:rw` : `useradd` fait un `rename()` par-dessus le point de montage,
+  ce qui échoue toujours. C'est une **régression sur le chemin uid 1000 actuel**. S'y ajoutent deux
+  coûts de conception : construire le fichier exige de connaître la **baseline de l'image**, or le
+  Dockerfile est éditable par l'utilisateur et un profil peut pointer une image de registry
+  arbitraire (il faudrait donc lire la baseline via Docker, ce que `sandbox_staging` s'interdit par
+  contrat) ; et un mount dont la source manque rend le staging de ~1 Go **indélébile** par le
+  daemon. L'`exec` gardé ne paie aucun des trois.
+- **`nss_wrapper`** (`LD_PRELOAD` + un passwd de substitution) : rejeté — la lib doit être *dans*
+  l'image, donc le problème devient circulaire (c'est justement le Dockerfile qu'on ne touche pas),
+  et un `LD_PRELOAD` est sans effet sur un binaire statique.
+- **`--user <nom>` au lieu du numérique**, une fois passwd peuplé : rejeté — cela rouvrirait le bug
+  que le `--user` numérique existe pour fermer. `--user <nom>` (ou `--user <uid>` seul) fait
+  résoudre le **gid primaire** via `/etc/passwd` ; pour un uid que l'image ne connaît pas, Docker
+  retombe sur **gid 0** — bug silencieux de propriété de fichiers. Écrit séparément parce qu'un
+  nettoyage bien intentionné (« maintenant que passwd est peuplé, autant nommer l'utilisateur »)
+  est exactement la forme que prendrait la régression.
 
 ## Limites acceptées
 
@@ -213,6 +249,10 @@ l'hôte qu'un Run hôte.
   faute d'entrée `/etc/passwd` ; ubuntu:24.04 livre `ubuntu`=1000 → le cas laptop courant résout.
   Injection `/etc/passwd`+`/etc/group` différée à une issue de suivi (ne PAS éditer le Dockerfile,
   content-hashé).
+  *(levé par #414 — voir l'amendement du point 1 ; la prémisse `os.userInfo()` était fausse, le
+  `claude` de l'image est un binaire Bun, qui lit `$HOME`/`$USER` et ignore la base passwd :
+  `claude --version` et `claude -p` se comportent à l'identique en uid 1234 et 1000. Seuls `sudo`
+  et `whoami` cassaient réellement.)*
 - **run-shell in-container** peut être *moins* fidèle pour l'inspection statique (les mounts identité
   donnent déjà la parité fichiers) et perd les outils `sudo`-installés éphémères. On garde le
   wrapping pour l'uniformité + zéro divergence hôte silencieuse (`ensure_running`-or-fail).

--- a/docs/test-scenarios/HP-02-run-to-completion.md
+++ b/docs/test-scenarios/HP-02-run-to-completion.md
@@ -173,6 +173,7 @@ Sandbox A/B, read-only probes:
   stall detector. Only a Run still preparing past that grace is a finding.
 - On a machine that does not yet have the sandbox image, the first sandboxed Run **builds** it
   (minutes). Expected once per image change, not a finding.
-- **Do not assert a writable `$HOME` inside the container, nor a host uid ≠ 1000.** Both are known,
-  filed gaps (#443, #414). Asserting them here would report a documented backlog item as a
-  regression on every execution.
+- **Do not assert a writable `$HOME` inside the container.** That is a known, filed gap (#443).
+  Asserting it here would report a documented backlog item as a regression on every execution. The
+  host-uid half of this note is **gone**: since #414 a named identity is injected into the container,
+  so `whoami` and `sudo -n true` DO work under any host uid — a failure there is a finding.


### PR DESCRIPTION
## Le défaut

Un conteneur sandbox tourne en `--user <uid>:<gid>` **numérique** et `ubuntu:24.04` ne connaît de nom que pour l'uid 1000. Sur toute machine dont l'uid hôte ≠ 1000, `sudo` refusait de démarrer (« you do not exist in the passwd database ») et `whoami` échouait — l'agent perdait `apt install`, la raison même pour laquelle l'image embarque `sudo` NOPASSWD.

## Le correctif

`ensure_running` lance, juste après le `start` et sur ses **trois** branches (un conteneur d'un daemon antérieur rattrape), un `docker exec --user 0:0` qui **ajoute** les deux lignes manquantes aux `/etc/passwd` et `/etc/group` réels de l'image, derrière une garde `getent`. La garde **est** la conditionnalité : aucun `if uid != 1000` en Rust, donc aucune branche morte, un seul chemin testé. En uid 1000, `getent` résout déjà (`ubuntu`) → no-op, fichiers byte-identiques.

**Déviation assumée** par rapport à l'issue, qui prescrivait de générer les fichiers au `prepare`-time et de les **bind-monter**. Mesuré : un `/etc/passwd` bind-monté casse `sudo apt-get install` de tout paquet créant un utilisateur système, en `:ro` **comme** en `:rw` (`useradd` fait un `rename()` par-dessus le point de montage, qui échoue toujours) — régression sur le chemin uid 1000, donc violation frontale de l'AC3. La liste des mounts ne bouge pas et l'argv du `docker create` reste byte-identique.

Trois détails load-bearing, chacun mesuré : champ mot de passe `*` et non `x` ; `append` et jamais `replace` (`sudo` résout `root` par nom avant tout le reste) ; best-effort (`warn!`, jamais un Run cassé).

La prémisse `claude`/`ERR_SYSTEM_ERROR` de l'issue était **fausse** : le `claude` de l'image est un binaire Bun, qui lit `$HOME`/`$USER` et ignore la base passwd. Seuls `sudo` et `whoami` cassaient. Le Dockerfile n'est pas modifié (il est content-hashé) et son commentaire décrivant l'injection runtime devient vrai.

## Validation

Tous les gates déterministes que la CI exécute, verts :

| Gate | Résultat |
|---|---|
| `cargo +stable build --workspace` | ✅ 0 warning |
| `cargo +stable test --workspace` | ✅ 1825 passed, 0 failed |
| `cargo +stable clippy --workspace --all-targets -- -D warnings` | ✅ |
| `cargo +stable fmt --all -- --check` | ✅ |
| frontend `lint` / `typecheck` / `vitest` / `build` | ✅ 1438/1438 vitest |
| `tests/smoke.sh` | ✅ |
| Playwright e2e (`CI=true`) | ✅ 73 passed, 0 flaky |

Test agentique FP-414 joué en **Docker réel** sur une pile isolée (`PDO_PORT=6183`, HOME factice), pas simulé :

- **Acte 1** — Run sandboxé `minimal` depuis l'UI, Completed en 3.9 s, `POST /runs` portant bien `"sandbox":"minimal"` (contrôle de non-régression #452), zéro erreur console.
- **Acte 2** — uid 1000 intact : `/etc/passwd` et `/etc/group` **byte-identiques** à l'image vierge, `grep -c '^pdo:'` = 0, `.Config.User` = `1000:1000`, la liste des mounts toujours les mêmes quatre `-v` sans `/etc/passwd` en vue, aucun `warn!`.
- **Témoin** — `docker events` du daemon Docker capture le script verbatim en `exec_create` après le `start`, portant l'uid/gid hôte vivants et le `$HOME` réel du conteneur : la substitution est prouvée, pas inférée.
- **Acte 3** — le défaut lui-même à uid 4242 : contrôle négatif rouge comme requis (`you do not exist in the passwd database`), puis après application `whoami` → `pdo`, `id` → `uid=4242(pdo)`, `sudo -n whoami` → `root`, idempotent (`grep -c` = 1 après deux applications), survit à `stop`/`start`, et **`sudo apt-get install rsync` fonctionne** — exactement ce que le design bind-mount aurait cassé.

Findings non bloquants relevés par le testeur : le bouton `Cleanup run` n'est révélé que par un vrai hover CSS (nuisance d'automatisation UI, préexistante) ; un daemon fuit du `cargo test` sur un port éphémère (famille #422) ; `playwright install --with-deps` exige un sudo interactif sur cette machine.

Closes #414

🤖 Generated with [Claude Code](https://claude.com/claude-code)
