### PR TITLE
feat(#427): la table de prix a trois tiers et une source distante, fetchée hors du chemin de lecture — 1.5.0

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -502,12 +502,29 @@ _Éviter_ : nom final, nom auto, rename automatique.
 
 ### Statistiques de Run
 
-Le panneau d'info d'un Run expose un petit bloc de stats (cf. #100, #272). **Quatre métriques** ; le **coût** est une **estimation** — pas une facture — dérivée des transcripts Claude Code locaux (`~/.claude/projects/<cwd-encodé>/*.jsonl`) : somme des `usage` par message (dédupliqués par `(message.id, requestId)`) × table de prix publics par modèle (cache dérivé 1.25×/2×/0.1× de l'input). Reversé #272 (2026-07-06, ratifié par le propriétaire) : le blocage historique (« aucune télémétrie fiable ») était faux — la télémétrie n'est pas requise, les transcripts portent l'usage. Modèle inconnu → $0 + drapeau « borne basse » ; aucun `costUSD` dans les transcripts (mode *calculate*). Voir ADR-0022.
+Le panneau d'info d'un Run expose un petit bloc de stats (cf. #100, #272). **Quatre métriques** ; le **coût** est une **estimation** — pas une facture — dérivée des transcripts Claude Code locaux (`~/.claude/projects/<cwd-encodé>/*.jsonl`) : somme des `usage` par message (dédupliqués par `(message.id, requestId)`) × table de prix publics par modèle (cache dérivé 1.25×/2×/0.1× de l'input). La table se résout **`manuel → fetché → embarquée`**, **par clé de famille** : `~/.pdo/prices/models.yaml` (édité à la main) gagne sur `~/.pdo/prices/fetched.json` (écrit par le daemon depuis models.dev, hors du chemin de lecture), qui gagne sur la table compilée — laquelle reste le **plancher** et le seul tarificateur de trois familles retirées de toute source distante. Les deux fichiers sont absents par défaut et rien n'est jamais seedé (cf. #427, ADR-0034). Reversé #272 (2026-07-06, ratifié par le propriétaire) : le blocage historique (« aucune télémétrie fiable ») était faux — la télémétrie n'est pas requise, les transcripts portent l'usage. Modèle inconnu → $0 + drapeau « borne basse » ; aucun `costUSD` dans les transcripts (mode *calculate*). Voir ADR-0022.
 
 - **Durée** : temps écoulé entre `started_at` et `completed_at`. **Dérivée à l'affichage** (frontend) à partir des deux timestamps déjà projetés depuis l'event log — pas de `duration_ms` backend (qui figerait un Run vivant). Horloge **live** (tick) tant que le Run est vivant (`Running`/`AwaitingUser`/`Paused`) ; figée à `completed_at` à l'entrée terminale. La durée est du **wall-clock** : un Run `Paused` continue de compter (le temps de pause est inclus).
 - **Sessions de nœud lancées** (*node sessions started*) : **compte cumulatif** des événements `NodeStarted` sur tout le Run. Mesure les sessions tmux NodeRun réellement spawnées — **y compris** les re-spawns au **même** `(node, iter)` (restart/recovery), donc ≥ le nombre de `(node, iter)` distincts (une projection dédupliquée par `(node, iter)` *sous-compterait*). Le **Pipeline Manager** n'émet pas `NodeStarted` → exclu par construction (« exclure le manager » est un no-op). Distinct de la gauge « sessions vivantes » du cap (cf. *Cap de sessions concurrentes*).
 - **LOC** (lignes changées par le Run) : `git diff --numstat` en **trois-points** (`HEAD...pdo/run-<run-id>`) — la base est le **point de fork** (merge-base), donc stable même si `main` avance (un diff deux-points dériverait). **Exclut `.pdo/`** (artefacts/prompts générés ne sont pas du code produit ; protégé par `.gitignore` mais un pathspec `:(exclude).pdo/` défensif couvre les repos cibles externes). **Dérivé du git, live-only** : la branche `pdo/run-<run-id>` est supprimée au cleanup → la stat affiche **« — »** pour un Run archivé/nettoyé (branche absente = `None`), à distinguer de **« 0 »** (diff réellement vide). Même schéma que le snapshot de pane qui survit au reap.
-- **Coût (est.)** : `Some { usd, partial }` **dérivé à la lecture**, jamais persisté (comme LOC), dans `run_cost::compute_run_cost`. Agrège TOUTES les sessions du Run (nœuds, manager, merge-resolver, subagents) via prefix-glob sur `~/.claude/projects/`. `None` → « — » quand aucun transcript n'est trouvé. **Plus durable que LOC** : le cleanup supprime la branche (LOC → « — ») mais **pas** `~/.claude/projects/`, donc un Run archivé garde son coût. `partial: true` (un modèle non tarifé a contribué, donc exclu) → borne basse, signalée par un « † » dans l'UI. Encodeur de chemin **propre** (`cc_project_dirname`), volontairement distinct de `stale_detector::encode_working_dir` (bogué, à corriger séparément — cf. ADR-0022 et le doc-comment).
+- **Coût (est.)** : `Some { usd, partial }` **dérivé à la lecture**, jamais persisté (comme LOC), dans `run_cost::compute_run_cost`. Agrège TOUTES les sessions du Run (nœuds, manager, merge-resolver, subagents) via prefix-glob sur `~/.claude/projects/`. `None` → « — » quand aucun transcript n'est trouvé. **Plus durable que LOC** : le cleanup supprime la branche (LOC → « — ») mais **pas** `~/.claude/projects/`, donc un Run archivé garde son coût. `partial: true` (un modèle non tarifé a contribué, donc exclu) → borne basse, signalée par un « † » dans l'UI. Le chargeur de la table est **tolérant mais pas muet** : fichier absent → silencieux ; ligne rejetée (clé datée, sentinelle, prix négatif ou non fini) → inerte, la clé retombe sur le tier suivant, et le rejet est nommé **une fois** dans le journal et en `reason` sur `GET /settings`. Un `fetched.json` dont le `schema` n'est pas `prices-v1` est **entièrement** inerte. Encodeur de chemin **propre** (`cc_project_dirname`), volontairement distinct de `stale_detector::encode_working_dir` (bogué, à corriger séparément — cf. ADR-0022 et le doc-comment).
+
+**Table de prix embarquée / fetchée / manuelle / résolue** *(termes, #427)* :
+Quatre choses distinctes. L'**embarquée** est le `const` livré dans le binaire — le **plancher**, et
+le seul tarificateur de `claude-opus-4-0`, `claude-sonnet-4-0` et `claude-3-5-haiku`, absentes de
+toute source distante. La **fetchée** est `~/.pdo/prices/fetched.json`, écrite par le daemon **seul**
+depuis `models.dev/api.json` hors du chemin de lecture (`POST /settings/cost-prices/sync`, plus un
+rafraîchissement au démarrage qui ne fetche **que** si le fichier existe déjà et a plus de 24 h —
+aucun egress avant le premier clic). La **manuelle** est `~/.pdo/prices/models.yaml`, écrite par
+l'**humain seul** et jamais touchée par PDO. La **résolue** est celle avec laquelle
+`compute_run_cost` chiffre : précédence **`manuel → fetché → embarquée`**, **par clé de famille**,
+jamais un remplacement. Un écrivain par fichier, et une empreinte de la table résolue entre dans la
+clé du memo de `/stats/cost`.
+_Éviter_ : « surcharge de prix » (dans ce domaine « surcharge » désigne déjà un supplément tarifaire,
+cf. ADR-0022 *Hors-scope* « surcharge input Sonnet-4.5 ») ; « override de prix » (dans PDO un
+override est un **tier de précédence**, pas un contournement) ; « merge » / « fusion des tables » ;
+« prix seedés » (rien n'est copié du binaire vers le disque, et c'est délibéré — cf. ADR-0031 §2) ;
+« prix live » (la lecture est **toujours** locale).
 
 ### Statistiques d'instance (cockpit, #377)
 
@@ -516,7 +533,10 @@ par période, à distinguer des **Statistiques de Run** (par-run, panneau d'info
 **jamais matérialisés** (ADR-0029, préserve ADR-0022) :
 
 - **Deux endpoints** : `GET /stats/overview` (SQL bon marché, index `events(kind,ts)` +
-  `trigger_fires(ts)`) et `GET /stats/cost` (lourd, lazy, memo RAM `(run_id, mtime-max)`).
+  `trigger_fires(ts)`) et `GET /stats/cost` (lourd, lazy, memo RAM `(run_id, mtime-max, empreinte de
+  la table de prix)` — sans le troisième composant, un sync de prix ne serait jamais visible sur un
+  Run terminé, dont les transcripts sont figés, alors que `GET /runs/:id` afficherait le nouveau
+  montant : deux surfaces qui se contredisent, cf. #427).
 - **Runs/erreurs/sessions par période** : `GROUP BY strftime` sur `events` — erreurs = `run_failed`
   (`run_skipped` **exclu**), sessions = `node_started` (démarrages, re-spawns inclus, manager exclu).
 - **Fires par pipeline** : `LEFT JOIN triggers` sur `pipeline_id` — un fire orphelin (trigger
@@ -1570,7 +1590,9 @@ Cf. ADR-0003.
 
 ### Mono-user, local
 
-Le daemon écoute sur `127.0.0.1:<port>` uniquement. Pas d'auth, pas de TLS, pas de multi-user. Single-user local par design. Tout ce qu'il faut pour ça : SQLite locale, FS local, tmux local, git local. Pas de dépendance réseau.
+Le daemon bind **`0.0.0.0:<port>`**, pas `127.0.0.1` — il est donc joignable depuis le LAN, c'est **délibéré** (accès depuis un autre appareil du réseau local) et #260 est **CLOSED**, pas différée (cf. `lib.rs:1902` et le commentaire `lib.rs:1990`). Pas d'auth, pas de TLS, pas de multi-user : single-user local par design, sur un réseau de confiance. Tout ce qu'il faut pour ça : SQLite locale, FS local, tmux local, git local.
+
+Aucun service distant ne détient l'état ni ne conditionne le fonctionnement ; **le chemin de lecture ne dépend jamais d'Internet**. Les egress du produit sont tous **opt-in et tolérants à l'échec** : `docker pull` (ADR-0030), les guards de Trigger shellés (`gh`), et le sync de la table de prix (#427, ADR-0034). Chaque nœud est par ailleurs une session `claude`, donc le produit ne fonctionne pas hors ligne (ADR-0004 l'assume) — « pas de dépendance réseau » n'a jamais été littéral.
 
 ### Persistance et hot-reload
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "1.4.1"
+version = "1.5.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "1.4.1"
+version = "1.5.0"
 license = "MIT"
 
 [workspace.dependencies]

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -28,6 +28,7 @@ mod pipeline;
 pub mod pipeline_migrator;
 mod pipeline_semantics;
 mod pipeline_watcher;
+pub mod price_table;
 mod prompt_augmenter;
 mod pty_bridge;
 mod run_advance;
@@ -309,6 +310,22 @@ struct AppState {
     /// docker round-trip). The refresh runs under `spawn_blocking` + a short
     /// `timeout`, so a cold Docker daemon never hangs the `/settings` response.
     docker_probe_cache: Arc<tokio::sync::Mutex<Option<(Instant, sandbox_image::DockerProbe)>>>,
+    /// Serializes price syncs (#427). Unlike `trigger_tick_lock`, which *serializes*
+    /// because both triggers (cron and manual) are legitimate and must both land, a
+    /// second concurrent price sync brings nothing — so this is taken with
+    /// `try_lock` and a failure answers **409**, the `admission_lock` posture
+    /// (`lib.rs` `admission_lock` + 409). The boot refresh takes the same lock and,
+    /// failing to get it, gives up silently: a manual sync is in flight and does
+    /// strictly better.
+    price_sync_lock: tokio::sync::Mutex<()>,
+    /// Price-source URL override (#427). `None` in production →
+    /// [`price_table::PRICE_SOURCE_URL_DEFAULT`]. Seeded per-daemon via
+    /// [`DaemonConfig`] so a layer-3 test points the fetch at its own fixture
+    /// server, never at models.dev and never through a process-global env.
+    price_source_url: Option<String>,
+    /// Whether the boot pass may refresh the fetched tier (#427). See
+    /// [`DaemonConfig::price_refresh_at_boot`].
+    price_refresh_at_boot: bool,
 }
 
 impl AppState {
@@ -1223,6 +1240,15 @@ impl DaemonHandle {
         boot_recovery::run_boot_recovery(&self.state).await;
     }
 
+    /// Run the boot price-table refresh synchronously (#427). Sibling of
+    /// [`Self::run_boot_recovery_tick`]: production spawns this DETACHED at
+    /// startup, and a test must never race a detached task. Honours all three
+    /// gates (config flag, cache must already exist, 24 h staleness), so a test
+    /// can prove "absent cache → zero request" with the same code production runs.
+    pub async fn run_price_refresh_tick(&self) {
+        refresh_prices_at_boot(&self.state).await;
+    }
+
     /// Run a single orphan-sweep (reaper) pass synchronously. Lets integration
     /// tests drive session reaping deterministically instead of racing the
     /// ~60 s background interval + process-global TTL env (#316). Resolves the
@@ -1541,6 +1567,19 @@ pub struct DaemonConfig {
     /// test stages under its own tempdir and never touches the real home. Read
     /// once at boot from `PDO_SANDBOX_HOME_OVERRIDE`.
     pub sandbox_home_override: Option<PathBuf>,
+    /// Price-source URL (#427, ADR-0034). `None` in production →
+    /// [`price_table::PRICE_SOURCE_URL_DEFAULT`]. `Some(url)` points the fetch at a
+    /// local server: the seam that makes the sync testable at layer 3 and playable
+    /// at layer 5 without depending on models.dev. Read once at boot from
+    /// `PDO_PRICE_SOURCE_URL`. Same charter as `docker_cmd_override` (#407) and
+    /// `PDO_TMUX_CMD_OVERRIDE` (#181) — never a process-global env read.
+    pub price_source_url: Option<String>,
+    /// Refresh the fetched price tier at startup (#427). `true` in production,
+    /// `false` in the five `tests/common/mod.rs` literals. Even armed it fetches
+    /// ONLY if `fetched.json` already exists and is over 24 h old: no egress before
+    /// the user has clicked "Sync costs" once (ADR-0034 — the click IS the consent).
+    /// `PDO_PRICE_SYNC=off|0|""` disarms it.
+    pub price_refresh_at_boot: bool,
 }
 
 impl DaemonConfig {
@@ -1578,6 +1617,17 @@ impl DaemonConfig {
                 .ok()
                 .filter(|s| !s.is_empty())
                 .map(PathBuf::from),
+            // Price-source seam (#427), sibling of PDO_DOCKER_CMD_OVERRIDE.
+            price_source_url: std::env::var("PDO_PRICE_SOURCE_URL")
+                .ok()
+                .filter(|s| !s.is_empty()),
+            // The crate's ONE opt-OUT env, and deliberately so: a feature that must
+            // work out of the box cannot be armed by an env var, and the real opt-in
+            // is the first click (ADR-0034 — the boot pass only ever REFRESHES an
+            // existing cache, it never creates one).
+            price_refresh_at_boot: std::env::var("PDO_PRICE_SYNC")
+                .map(|v| !v.is_empty() && v != "0" && v != "off")
+                .unwrap_or(true),
         }
     }
 }
@@ -1688,6 +1738,9 @@ pub async fn serve_with_config(
         node_done_tail_gate_armed: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         service_health,
         docker_probe_cache: Arc::new(tokio::sync::Mutex::new(None)),
+        price_sync_lock: tokio::sync::Mutex::new(()),
+        price_source_url: config.price_source_url,
+        price_refresh_at_boot: config.price_refresh_at_boot,
     });
 
     // The orphan sweep — and every other tmux call this daemon makes —
@@ -1821,6 +1874,22 @@ pub async fn serve_with_config(
         axum::serve(listener, app).await.context("server error")?;
         Ok(())
     });
+
+    // Price-table refresh (#427, ADR-0034). DETACHED and posted AFTER
+    // `tokio::spawn(axum::serve(...))`, never `.await`ed before `build_router` —
+    // unlike `boot_recovery`. A `.await` here would delay the first `accept()`
+    // behind a DNS timeout, and `tests/smoke.sh` polls `/runs` for up to 30 s so it
+    // would go green while masking exactly that. Wrapped in `run_isolated`, the
+    // shared spine of the daemon's otherwise-unsupervised sweeps.
+    {
+        let price_state = state.clone();
+        tokio::spawn(async move {
+            run_isolated("price refresh", async move {
+                refresh_prices_at_boot(&price_state).await;
+            })
+            .await;
+        });
+    }
 
     Ok(DaemonHandle {
         addr: bound_addr,
@@ -3221,6 +3290,12 @@ fn build_router(state: Arc<AppState>) -> Router {
         // The shared prefix is a **routing** decision, NOT a claim about the schema:
         // profiles are ROWS, not a `{effective, source, stored, env, default}` knob, and
         // they must NOT be folded into `build_settings_view` beyond the name list.
+        // Price sync (#427, ADR-0034). Under `/settings` for exactly the reason
+        // above — the vite proxy key is a prefix, so no proxy edit — and a static
+        // verb segment under a named sub-resource is the router's most frequent
+        // gesture (`/triggers/{id}/fire`, `/triggers/pause`, `/pipelines/{id}/promote`).
+        // The ONLY route in the crate that reaches the network.
+        .route("/settings/cost-prices/sync", post(sync_cost_prices))
         .route("/settings/sandbox-profiles", get(list_sandbox_profiles))
         .route(
             "/settings/sandbox-profiles/{name}",
@@ -6947,9 +7022,50 @@ async fn build_settings_view(state: &AppState) -> Result<serde_json::Value, sqlx
         .iter()
         .map(|(name, is_virtual)| serde_json::json!({ "name": name, "virtual": is_virtual }))
         .collect();
-    let host_home = sandbox_run::sandbox_home_roots(state)
-        .ok()
-        .map(|(home, _)| home.to_string_lossy().into_owned());
+    let host_home_path = sandbox_run::sandbox_home_roots(state).ok().map(|(h, _)| h);
+    let host_home = host_home_path
+        .as_ref()
+        .map(|h| h.to_string_lossy().into_owned());
+
+    // --- price table: an observed STATE, not a settings knob (#427) ---
+    // NOT a `settings_field`: there is no stored / env / default tier here, only
+    // which of the three price tiers won. Shape of `sandbox_docker` (#410) and
+    // motive of #432: a hand-edited file passes through NO validator by
+    // construction, so the only honest place to surface a refused row is here, as
+    // an advisory `reason` beside the facts. `journalctl` alone is this product's
+    // recurring failure mode (#497, #485).
+    //
+    // Both paths are ALWAYS reported, even when neither file exists — nothing is
+    // ever seeded (that would freeze a snapshot, ADR-0031 §2), so naming the paths
+    // IS the entire discoverability story.
+    let price_table_view = match &host_home_path {
+        Some(home) => {
+            let table = price_table::PriceTable::load(home);
+            let (manual_path, fetched_path) = price_table::PriceTable::paths(home);
+            serde_json::json!({
+                "manual_path": manual_path.to_string_lossy(),
+                "fetched_path": fetched_path.to_string_lossy(),
+                "source": table.source(),
+                "fetched_at": table.fetched_at(),
+                "fetched_rows": table.fetched_rows(),
+                "manual_keys": table.manual_keys(),
+                // The SAME string the loader logs — one pure constructor, so the page
+                // and the journal can never disagree.
+                "reason": table.diagnostic(),
+            })
+        }
+        // HOME unset: the paths are unknowable, and saying so beats inventing one.
+        None => serde_json::json!({
+            "manual_path": null,
+            "fetched_path": null,
+            "source": null,
+            "fetched_at": null,
+            "fetched_rows": 0,
+            "manual_keys": [],
+            "reason": "HOME is unset, so the price files have no resolvable path — \
+                       only the prices compiled into the binary apply",
+        }),
+    };
 
     Ok(serde_json::json!({
         "session_cap": settings_field(cap_effective, cap_source, cfg.session_cap, cap_env, cap_default),
@@ -6970,6 +7086,8 @@ async fn build_settings_view(state: &AppState) -> Result<serde_json::Value, sqlx
         // #432: names only (see the note above), and the host `$HOME` as an observed fact.
         "sandbox_profiles": sandbox_profiles,
         "home": host_home,
+        // #427, ADR-0034: which price tiers are in force, and what is inert.
+        "price_table": price_table_view,
         "sandbox_docker": {
             "available": docker_probe.available,
             "reason": docker_probe.reason,
@@ -6984,6 +7102,288 @@ async fn build_settings_view(state: &AppState) -> Result<serde_json::Value, sqlx
         ),
         "updated_at": cfg.updated_at,
     }))
+}
+
+/// Resolve the price-source URL for this daemon: the per-daemon override (the
+/// layer-3/5 seam) else the shipped default.
+fn price_source_url(state: &AppState) -> String {
+    state
+        .price_source_url
+        .clone()
+        .unwrap_or_else(|| price_table::PRICE_SOURCE_URL_DEFAULT.to_string())
+}
+
+/// The host home the price files live under, or a message explaining why there is
+/// none. Prices are an **instance** concept: even for a sandboxed Run this is the
+/// HOST home (the #408 seam moves the transcript root, not this one).
+///
+/// Returns the *message*, not a `Response`: `Result<_, Response>` trips
+/// `clippy::result_large_err` (a `Response` is 128 bytes, exactly the threshold)
+/// and the CI is `-D warnings`. House convention is `Option<Response>`, or a small
+/// error the caller renders — which is what this does.
+fn price_home_root(state: &AppState) -> Result<PathBuf, String> {
+    sandbox_run::sandbox_home_roots(state)
+        .map(|(home, _)| home)
+        .map_err(|e| format!("cannot resolve the home root for the price files: {e}"))
+}
+
+/// Outcome of one price sync, for the report. Split out so the pure diff is
+/// testable without an HTTP round-trip.
+struct PriceSyncOutcome {
+    rows: usize,
+    added: Vec<String>,
+    updated: Vec<String>,
+    unchanged: usize,
+    shadowed_by_manual: Vec<String>,
+    changed: bool,
+}
+
+/// Diff a freshly normalised fetched tier against the table currently in force.
+/// PURE. `changed` is keyed on the RAW fetched rows, not on effective prices: a
+/// shadowed key whose source price moved is a real change to the fetched tier even
+/// though nothing a user sees moves.
+fn diff_price_sync(
+    before: &price_table::PriceTable,
+    fresh: &std::collections::BTreeMap<String, price_table::Price>,
+) -> PriceSyncOutcome {
+    let mut out = PriceSyncOutcome {
+        rows: fresh.len(),
+        added: Vec::new(),
+        updated: Vec::new(),
+        unchanged: 0,
+        shadowed_by_manual: Vec::new(),
+        changed: fresh != before.fetched_prices(),
+    };
+    for (key, fresh_price) in fresh {
+        let shadowed = before.tier_of(key) == Some(price_table::PriceTier::Manual);
+        if shadowed {
+            // Said, never hidden: a sync cannot silently erase a hand correction.
+            out.shadowed_by_manual.push(key.clone());
+        }
+        let effective_before = before.price_for(key);
+        // What this key will resolve to once written: manual still wins.
+        let effective_after = if shadowed {
+            effective_before
+        } else {
+            Some(*fresh_price)
+        };
+        match effective_before {
+            None => out.added.push(key.clone()),
+            Some(_) if effective_before != effective_after => out.updated.push(key.clone()),
+            Some(_) => out.unchanged += 1,
+        }
+    }
+    out
+}
+
+/// `POST /settings/cost-prices/sync` — fetch the remote price source and rewrite
+/// the fetched tier (#427, ADR-0034).
+///
+/// Deliberately UNDER `/settings` rather than a new top-level prefix: the vite
+/// proxy key is a PREFIX, so this needs no `vite.config.ts` edit and avoids the
+/// trap `/nodes` (#345), `/stats` (#377) and `/fs` (#431) each paid. NOT a
+/// `POST /runs/:id/commands` kind — that dispatcher is run-scoped, and a price sync
+/// touches neither the event log nor a Run projection (the `CONTEXT.md:794`
+/// criterion). NOT under `/stats` either: ADR-0029 makes that a read-derivation
+/// surface.
+///
+/// Codes: **409** a sync is already in flight · **502** source unreachable /
+/// timeout / broken JSON / empty harvest, and **nothing is written** · **500** a
+/// disk write failed · **200** otherwise, with `noop: true` + `reason` when the
+/// table did not move (ADR-0025 forbids a blind `{ok:true}`).
+///
+/// The 502 is the crate's first, and on purpose: classing a network cut as a 500
+/// would file it as a daemon defect, contradicting ADR-0022's honest-labelling
+/// posture. ADR-0030:107-112 settles the shape — an explicitly requested effect
+/// that fails is a HARD error that NAMES the source, never a silent fallback.
+async fn sync_cost_prices(State(state): State<Arc<AppState>>) -> Response {
+    let home_root = match price_home_root(&state) {
+        Ok(h) => h,
+        Err(msg) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": msg })),
+            )
+                .into_response();
+        }
+    };
+    // `try_lock`, not `.lock()`: a second click brings nothing, and ADR-0025 wants
+    // us to say so rather than queue silently.
+    let Ok(_guard) = state.price_sync_lock.try_lock() else {
+        return (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({ "error": "a price sync is already in flight" })),
+        )
+            .into_response();
+    };
+
+    let url = price_source_url(&state);
+    // The table BEFORE, so the report can name what actually moves.
+    let before = price_table::PriceTable::load(&home_root);
+
+    let body = match price_table::fetch_source(&url).await {
+        Ok(b) => b,
+        Err(e) => {
+            return (
+                StatusCode::BAD_GATEWAY,
+                Json(serde_json::json!({
+                    "error": format!("price source unreachable: {url}: {e}")
+                })),
+            )
+                .into_response();
+        }
+    };
+    let (fresh, rejected) = match price_table::normalize_models_dev(&body) {
+        Ok(v) => v,
+        Err(e) => {
+            // Includes the empty-harvest guard: an upstream schema drift must NOT be
+            // able to write an empty file over the last known table.
+            return (
+                StatusCode::BAD_GATEWAY,
+                Json(serde_json::json!({
+                    "error": format!("price source unusable: {url}: {e}")
+                })),
+            )
+                .into_response();
+        }
+    };
+
+    let outcome = diff_price_sync(&before, &fresh);
+    let (_, fetched_path) = price_table::PriceTable::paths(&home_root);
+    let rejected_msgs: Vec<String> = rejected
+        .iter()
+        .map(|r| format!("{}: {}", r.key, r.why))
+        .collect();
+
+    if !outcome.changed {
+        // Nothing to write, so nothing is written — which also leaves the table's
+        // fingerprint alone and keeps `COST_MEMO` warm for every Run.
+        return Json(serde_json::json!({
+            "ok": true,
+            "noop": true,
+            "reason": format!(
+                "table already up to date — {} row(s) from the source, none changed",
+                outcome.rows
+            ),
+            "source": url,
+            "fetched_at": before.fetched_at(),
+            "rows": outcome.rows,
+            "added": Vec::<String>::new(),
+            "updated": Vec::<String>::new(),
+            "unchanged": outcome.unchanged,
+            "rejected": rejected_msgs,
+            "shadowed_by_manual": outcome.shadowed_by_manual,
+        }))
+        .into_response();
+    }
+
+    let fetched_at = event_log::now_iso();
+    if let Err(e) = price_table::write_fetched(&fetched_path, &url, &fetched_at, &fresh) {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({
+                "error": format!("cannot write {}: {e}", fetched_path.display())
+            })),
+        )
+            .into_response();
+    }
+
+    // Same shape as `pause_triggers`: tell every connected client the table moved,
+    // so an open Stats modal is not the only thing that knows.
+    let _ = state.pipeline_tx.send(serde_json::json!({
+        "type": "cost_prices_synced",
+        "rows": outcome.rows,
+    }));
+
+    Json(serde_json::json!({
+        "ok": true,
+        "source": url,
+        "fetched_at": fetched_at,
+        "rows": outcome.rows,
+        "added": outcome.added,
+        "updated": outcome.updated,
+        "unchanged": outcome.unchanged,
+        "rejected": rejected_msgs,
+        "shadowed_by_manual": outcome.shadowed_by_manual,
+    }))
+    .into_response()
+}
+
+/// Refresh the fetched price tier if — and only if — it already exists and is
+/// stale (#427, ADR-0034). Driven at boot as a DETACHED task and by the
+/// [`DaemonHandle::run_price_refresh_tick`] test seam, so production and the
+/// synchronous test path are the same code.
+///
+/// Three gates, in this order, and each is load-bearing:
+/// 1. the config flag (`PDO_PRICE_SYNC` in production, `false` in the test literals);
+/// 2. **`fetched.json` must already exist** — the boot pass REFRESHES, it never
+///    seeds, so there is no egress before the user's first explicit click. Happy
+///    side effect: the 240 integration daemons boot from a fresh `HOME`, hence no
+///    cache, hence no network even when the flag is armed;
+/// 3. it must be older than [`price_table::PRICE_REFRESH_MAX_AGE`].
+///
+/// Failure regime is `boot_recovery.rs:161-168`'s: a `warn!`, never fatal. A daemon
+/// restarted by systemd can legitimately come up before the network is ready
+/// (`service_unit.rs` emits `After=network-online.target` but nothing guarantees
+/// DNS), and a boot must not fail on that.
+async fn refresh_prices_at_boot(state: &Arc<AppState>) {
+    if !state.price_refresh_at_boot {
+        return;
+    }
+    let Ok(home_root) = sandbox_run::sandbox_home_roots(state).map(|(h, _)| h) else {
+        return; // no HOME → no path → nothing to refresh, silently
+    };
+    let (_, fetched_path) = price_table::PriceTable::paths(&home_root);
+    if !fetched_path.exists() {
+        // Gate 2. The user has never synced; asking the network now would be an
+        // egress they did not consent to.
+        return;
+    }
+    let table = price_table::PriceTable::load(&home_root);
+    if let Some(fetched_at) = table.fetched_at() {
+        if let Ok(then) = chrono::DateTime::parse_from_rfc3339(fetched_at) {
+            let age = chrono::Utc::now().signed_duration_since(then.with_timezone(&chrono::Utc));
+            if age
+                < chrono::Duration::from_std(price_table::PRICE_REFRESH_MAX_AGE)
+                    .unwrap_or_else(|_| chrono::Duration::hours(24))
+            {
+                return; // fresh → noop
+            }
+        }
+        // An unparseable `fetched_at` falls through and refreshes: a cache whose
+        // vintage we cannot read is exactly one worth re-fetching.
+    }
+
+    // Same lock as the button. Losing the race means a manual sync is running,
+    // which does strictly better — give up without a word.
+    let Ok(_guard) = state.price_sync_lock.try_lock() else {
+        return;
+    };
+    let url = price_source_url(state);
+    let body = match price_table::fetch_source(&url).await {
+        Ok(b) => b,
+        Err(e) => {
+            warn!("price refresh at boot: {url} unreachable ({e}) — keeping the current table");
+            return;
+        }
+    };
+    let fresh = match price_table::normalize_models_dev(&body) {
+        Ok((rows, _)) => rows,
+        Err(e) => {
+            warn!("price refresh at boot: {url} unusable ({e}) — keeping the current table");
+            return;
+        }
+    };
+    if fresh == *table.fetched_prices() {
+        return; // nothing moved: leave the file, and the memo, alone
+    }
+    match price_table::write_fetched(&fetched_path, &url, &event_log::now_iso(), &fresh) {
+        Ok(()) => info!("price refresh at boot: {} row(s) from {url}", fresh.len()),
+        Err(e) => warn!(
+            "price refresh at boot: cannot write {}: {e}",
+            fetched_path.display()
+        ),
+    }
 }
 
 /// `GET /settings` — the instance-wide config, per knob, as
@@ -7951,7 +8351,15 @@ async fn get_run(
                 &home_root,
                 &sandbox_root,
             );
-            augment_run_state_from_disk(&mut run_state, &projects_root, &repo_root);
+            // #427: resolve the three price tiers ONCE, here at the edge, next to
+            // the roots this request already resolved. Two `fs::read` of a few KB —
+            // deliberately not an `AppState` cache and never a `OnceLock`, which
+            // would make a daemon restart mandatory to change a price and so annul
+            // ADR-0034. Note the seam asymmetry: prices come from `home_root` (the
+            // HOST home — prices are an instance concept), while transcripts come
+            // from `projects_root` (the #408 seam, which moves for a sandboxed Run).
+            let prices = price_table::PriceTable::load(&home_root);
+            augment_run_state_from_disk(&mut run_state, &projects_root, &repo_root, &prices);
             Json(run_state).into_response()
         }
         None => (StatusCode::NOT_FOUND, "run not found").into_response(),
@@ -11508,6 +11916,7 @@ fn augment_run_state_from_disk(
     run_state: &mut event_log::RunState,
     projects_root: &std::path::Path,
     repo_root: &std::path::Path,
+    prices: &price_table::PriceTable,
 ) {
     // LOC is independent of the run YAML: the run branch lives in `repo_root`,
     // not the run dir, so a missing/unparseable YAML must not suppress an
@@ -11517,7 +11926,8 @@ fn augment_run_state_from_disk(
     // Claude Code transcripts under `projects_root` (the #408 seam — the staged
     // home while a sandboxed Run is live, `~/.claude/projects/` otherwise), not
     // the run dir. `repo_root` builds the run-id dir prefix, not the read root.
-    run_state.cost = run_cost::compute_run_cost(projects_root, repo_root, &run_state.run_id);
+    run_state.cost =
+        run_cost::compute_run_cost(projects_root, repo_root, &run_state.run_id, prices);
 
     let yaml_path = run_scoped_pipeline_path(repo_root, &run_state.run_id);
     let Ok(yaml) = std::fs::read_to_string(&yaml_path) else {
@@ -12430,6 +12840,9 @@ mod tests {
                 persistent: None,
             }),
             docker_probe_cache: Arc::new(tokio::sync::Mutex::new(None)),
+            price_sync_lock: tokio::sync::Mutex::new(()),
+            price_source_url: None,
+            price_refresh_at_boot: false,
         })
     }
 
@@ -12468,6 +12881,9 @@ mod tests {
             node_done_tail_gate_armed: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             service_health: Arc::new(service_health),
             docker_probe_cache: Arc::new(tokio::sync::Mutex::new(None)),
+            price_sync_lock: tokio::sync::Mutex::new(()),
+            price_source_url: None,
+            price_refresh_at_boot: false,
         })
     }
 
@@ -16275,6 +16691,9 @@ mod tests {
                 persistent: None,
             }),
             docker_probe_cache: Arc::new(tokio::sync::Mutex::new(None)),
+            price_sync_lock: tokio::sync::Mutex::new(()),
+            price_source_url: None,
+            price_refresh_at_boot: false,
         })
     }
 
@@ -21772,6 +22191,9 @@ edges: []
                 persistent: None,
             }),
             docker_probe_cache: Arc::new(tokio::sync::Mutex::new(None)),
+            price_sync_lock: tokio::sync::Mutex::new(()),
+            price_source_url: None,
+            price_refresh_at_boot: false,
         });
         let app = build_router(state);
 
@@ -21962,6 +22384,9 @@ edges: []
                 persistent: None,
             }),
             docker_probe_cache: Arc::new(tokio::sync::Mutex::new(None)),
+            price_sync_lock: tokio::sync::Mutex::new(()),
+            price_source_url: None,
+            price_refresh_at_boot: false,
         });
         let app = build_router(state);
 

--- a/crates/pdo-daemon/src/price_table.rs
+++ b/crates/pdo-daemon/src/price_table.rs
@@ -1,0 +1,1372 @@
+//! The price table in force for ONE cost read: three tiers merged **by family
+//! key** — manual (`~/.pdo/prices/models.yaml`, written by the human alone) →
+//! fetched (`~/.pdo/prices/fetched.json`, written by the daemon alone) →
+//! embedded ([`PRICES`], the compiled floor). See ADR-0034 and ADR-0022's #427
+//! amendment.
+//!
+//! This module never reads `$HOME`: a root goes in, path-math + `std::fs` come
+//! out (the discipline #408 paid a slice to give `run_cost` — `library_store`'s
+//! global `$HOME` read costs a crate-wide test lock, `library_store.rs:967`).
+//!
+//! ## What is load-bearing here
+//! - **Merge by key, never replacement.** A key present in a tier wins; a key
+//!   absent keeps whatever the next tier says. Under global replacement,
+//!   forgetting `claude-opus-4-8` would erase 79 941 of ~116 200 transcript
+//!   lines — a wrong-price bug converted into a total blackout — and would
+//!   freeze the table against future releases.
+//! - **The embedded tier is a FLOOR, not a seed.** `claude-opus-4-0`,
+//!   `claude-sonnet-4-0` and `claude-3-5-haiku` are absent from every remote
+//!   source examined, so the `const` is their ONLY pricer.
+//! - **De-dating is asymmetric on purpose.** A dated key in the *manual* file is
+//!   REFUSED (stripping would silently collapse two rows the author wanted
+//!   distinct, and the refusal teaches); a dated id from the *source* is
+//!   DE-DATED (refusing would throw away `claude-haiku-4-5`, which is the form
+//!   transcripts actually write).
+//! - **Absent is silent; present-but-rejected is said once.** A missing file is
+//!   the normal state of every instance. A rejected row goes inert, its key
+//!   falls through to the next tier, and [`PriceTable::diagnostic`] names it —
+//!   once per distinct fingerprint in the log, and always in `GET /settings`.
+//!
+//! The single egress ([`fetch_source`]) lives here too, but strictly OUTSIDE the
+//! read path: nothing in [`PriceTable::load`] touches the network.
+
+use std::collections::BTreeMap;
+use std::hash::Hasher;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Mutex;
+use std::time::Duration;
+use tracing::warn;
+
+/// The prices PDO ships — the former `run_cost::PRICES`, moved here verbatim.
+///
+/// Source: https://platform.claude.com/docs/en/about-claude/pricing (fetched
+/// 2026-07-06). Per-MTok list prices `(family_key, input, output)`. Cache prices
+/// are DERIVED (write_5m = 1.25×in, write_1h = 2×in, read = 0.1×in) — verified
+/// universal across every current row. Match on the FULL family key: Opus
+/// 4.5–4.8 are $5/$25 but Opus 4.1/4.0 are $15/$75 — never a
+/// `starts_with("opus-4")` shortcut.
+///
+/// Since #427 this is the **floor**, not a seed: a sync never replaces it, and
+/// three of these rows exist in no remote source at all.
+const PRICES: &[(&str, f64, f64)] = &[
+    ("claude-opus-4-8", 5.0, 25.0),
+    ("claude-opus-4-7", 5.0, 25.0),
+    ("claude-opus-4-6", 5.0, 25.0),
+    ("claude-opus-4-5", 5.0, 25.0),
+    ("claude-opus-4-1", 15.0, 75.0),
+    ("claude-opus-4-0", 15.0, 75.0),
+    ("claude-sonnet-4-6", 3.0, 15.0),
+    ("claude-sonnet-4-5", 3.0, 15.0),
+    ("claude-sonnet-4-0", 3.0, 15.0),
+    ("claude-haiku-4-5", 1.0, 5.0),
+    ("claude-3-5-haiku", 0.80, 4.0),
+];
+
+/// Claude Code's local/no-cost sentinel. Priced $0 **above every tier** so it can
+/// never flip `partial` — ORDER IS LOAD-BEARING (see [`PriceTable::price_for`]).
+const SYNTHETIC: &str = "<synthetic>";
+
+/// The only schema marker `fetched.json` is read under. A document carrying
+/// anything else is ENTIRELY inert — never a row read under a schema we do not
+/// recognise (precedent: `hash_algo: "semantic-v1"`, `library_store.rs:259-269`).
+pub const FETCHED_SCHEMA: &str = "prices-v1";
+
+/// Default price source (ADR-0034): models.dev, `anthropic` provider only.
+pub const PRICE_SOURCE_URL_DEFAULT: &str = "https://models.dev/api.json";
+
+/// Hard ceiling on one fetch. 10 s, not the 3 s of `DOCKER_PROBE_TIMEOUT`: the
+/// payload is ~3.3 MB.
+pub const PRICE_FETCH_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Guard against a hostile or aberrant body.
+pub const PRICE_FETCH_MAX_BYTES: usize = 16 * 1024 * 1024;
+
+/// Age past which the boot refresh re-fetches an EXISTING cache. It never
+/// creates one (ADR-0034: no egress before the first explicit click).
+pub const PRICE_REFRESH_MAX_AGE: Duration = Duration::from_secs(24 * 3600);
+
+/// Drop a trailing 8-digit date segment so a dated id resolves to its family
+/// key: `claude-sonnet-4-5-20250929` → `claude-sonnet-4-5`. A version-only id is
+/// returned unchanged. Moved here from `run_cost.rs` — the fetch normaliser uses
+/// it too.
+pub(crate) fn strip_date_suffix(model: &str) -> &str {
+    if let Some((head, tail)) = model.rsplit_once('-') {
+        if tail.len() == 8 && tail.bytes().all(|b| b.is_ascii_digit()) {
+            return head;
+        }
+    }
+    model
+}
+
+/// Per-MTok `(input, output)` list price. `PartialEq` and not `Eq` — these are
+/// `f64` (same reason as `CostStat`).
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct Price {
+    pub input: f64,
+    pub output: f64,
+}
+
+/// Which tier decided a family key. ADR-0015's vocabulary, transposed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PriceTier {
+    Manual,
+    Fetched,
+    Embedded,
+}
+
+/// A refused row and why — the material of BOTH the `warn!` and the
+/// `GET /settings` `reason`, so the two can never drift.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RejectedRow {
+    pub key: String,
+    pub why: String,
+}
+
+/// Where a fetched document came from and when. `None` for the manual tier: the
+/// human's file carries no provenance, by design (PDO never writes it).
+#[derive(Debug, Clone, PartialEq)]
+pub struct Provenance {
+    pub source: String,
+    pub fetched_at: String,
+}
+
+/// The result of parsing one on-disk tier. Pure: text in, rows + refusals out.
+/// An unparseable document yields `unparseable: Some(err)` and NO rows — never an
+/// `Err`, because a bad price file must not be able to fail a cost read.
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct ParsedTier {
+    pub rows: BTreeMap<String, Price>,
+    pub rejected: Vec<RejectedRow>,
+    pub unparseable: Option<String>,
+    pub provenance: Option<Provenance>,
+}
+
+impl ParsedTier {
+    /// A tier built straight from rows — the shape a test or the sync writer
+    /// wants when there is nothing to refuse.
+    #[cfg(test)]
+    fn of(rows: &[(&str, f64, f64)]) -> Self {
+        Self {
+            rows: rows
+                .iter()
+                .map(|(k, i, o)| {
+                    (
+                        (*k).to_string(),
+                        Price {
+                            input: *i,
+                            output: *o,
+                        },
+                    )
+                })
+                .collect(),
+            ..Default::default()
+        }
+    }
+}
+
+/// The table resolved for one read, plus the fingerprint saying WHICH table it
+/// is. That fingerprint is the whole reason this is not a bare map: it is the
+/// third component of `run_cost`'s memo key, without which a sync would stay
+/// invisible on `/stats/cost` until the daemon restarted.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PriceTable {
+    resolved: BTreeMap<String, (Price, PriceTier)>,
+    manual: ParsedTier,
+    fetched: ParsedTier,
+    manual_keys: Vec<String>,
+    fingerprint: u64,
+    /// Set by [`Self::load`] only, so `diagnostic()` can name the real file.
+    /// `None` for a table built by the pure [`Self::resolve`].
+    manual_path: Option<PathBuf>,
+    fetched_path: Option<PathBuf>,
+}
+
+impl Default for PriceTable {
+    fn default() -> Self {
+        Self::builtin()
+    }
+}
+
+impl PriceTable {
+    /// The floor alone. Pure, no IO, no `$HOME`. `fingerprint() == 0`.
+    pub fn builtin() -> Self {
+        Self::resolve(ParsedTier::default(), ParsedTier::default(), 0)
+    }
+
+    /// PURE, TOTAL resolver — tiers injected, zero IO. Mirrors
+    /// `sandbox_profile::resolve_entry_list`: ONE resolver shared by the cost
+    /// computation and by the `GET /settings` view, so what the UI shows can
+    /// never drift from what actually prices (the lesson of #373).
+    pub fn resolve(manual: ParsedTier, fetched: ParsedTier, fingerprint: u64) -> Self {
+        let mut resolved: BTreeMap<String, (Price, PriceTier)> = BTreeMap::new();
+        // Lowest precedence first, so a higher tier simply overwrites.
+        for (k, i, o) in PRICES {
+            resolved.insert(
+                (*k).to_string(),
+                (
+                    Price {
+                        input: *i,
+                        output: *o,
+                    },
+                    PriceTier::Embedded,
+                ),
+            );
+        }
+        for (k, p) in &fetched.rows {
+            resolved.insert(k.clone(), (*p, PriceTier::Fetched));
+        }
+        for (k, p) in &manual.rows {
+            resolved.insert(k.clone(), (*p, PriceTier::Manual));
+        }
+        let manual_keys = manual.rows.keys().cloned().collect();
+        Self {
+            resolved,
+            manual,
+            fetched,
+            manual_keys,
+            fingerprint,
+            manual_path: None,
+            fetched_path: None,
+        }
+    }
+
+    /// `<home_root>/.pdo/prices/{models.yaml, fetched.json}` — path arithmetic
+    /// only, like `sandbox_image::default_dockerfile_path(sandbox_root)`.
+    pub fn paths(home_root: &Path) -> (PathBuf, PathBuf) {
+        let dir = home_root.join(".pdo").join("prices");
+        (dir.join("models.yaml"), dir.join("fetched.json"))
+    }
+
+    /// Load the effective table from an injected root. Absent or unreadable →
+    /// that tier is empty and SILENT (the normal state of every instance).
+    /// Unparseable, or an unknown `schema` → the tier is ENTIRELY inert plus a
+    /// diagnostic. Emits AT MOST ONE `warn!` per distinct fingerprint, so a
+    /// polled `/stats/cost` cannot produce one log line per request.
+    pub fn load(home_root: &Path) -> Self {
+        let (manual_path, fetched_path) = Self::paths(home_root);
+        let manual_bytes = std::fs::read(&manual_path).ok();
+        let fetched_bytes = std::fs::read(&fetched_path).ok();
+        let fingerprint = fingerprint_of(manual_bytes.as_deref(), fetched_bytes.as_deref());
+
+        let manual = manual_bytes
+            .as_deref()
+            .map(|b| parse_manual(&String::from_utf8_lossy(b)))
+            .unwrap_or_default();
+        let fetched = fetched_bytes
+            .as_deref()
+            .map(|b| parse_fetched(&String::from_utf8_lossy(b)))
+            .unwrap_or_default();
+
+        let mut table = Self::resolve(manual, fetched, fingerprint);
+        table.manual_path = Some(manual_path);
+        table.fetched_path = Some(fetched_path);
+        table.warn_once();
+        table
+    }
+
+    /// Per-MTok price, or `None` for a model unknown to all THREE tiers (the
+    /// caller then flips `partial` and the line contributes $0).
+    ///
+    /// `<synthetic>` is priced $0 **above every table** — ORDER IS LOAD-BEARING.
+    /// Moving the lookup first would let a price file turn the sentinel into a
+    /// real cost, and would break the `Some((0,0))` / `None` distinction that
+    /// keeps `partial` honest.
+    pub fn price_for(&self, model: &str) -> Option<Price> {
+        if model == SYNTHETIC {
+            return Some(Price {
+                input: 0.0,
+                output: 0.0,
+            });
+        }
+        self.resolved.get(strip_date_suffix(model)).map(|(p, _)| *p)
+    }
+
+    /// Which tier decides a family key, or `None` if no tier knows it. For the
+    /// view and for the sync report.
+    pub fn tier_of(&self, key: &str) -> Option<PriceTier> {
+        self.resolved.get(key).map(|(_, t)| *t)
+    }
+
+    pub fn fingerprint(&self) -> u64 {
+        self.fingerprint
+    }
+
+    /// The keys the manual tier actually decided — the `GET /settings` signal
+    /// that a hand edit is shadowing a sync.
+    pub fn manual_keys(&self) -> &[String] {
+        &self.manual_keys
+    }
+
+    /// Rows accepted from `fetched.json` (0 when the file is absent or inert).
+    pub fn fetched_rows(&self) -> usize {
+        self.fetched.rows.len()
+    }
+
+    /// The fetched tier's rows, for the sync's added/updated/unchanged diff.
+    pub fn fetched_prices(&self) -> &BTreeMap<String, Price> {
+        &self.fetched.rows
+    }
+
+    /// Vintage of the fetched tier — D14 pt 2: the table's date is readable, not
+    /// guessed.
+    pub fn fetched_at(&self) -> Option<&str> {
+        self.fetched
+            .provenance
+            .as_ref()
+            .map(|p| p.fetched_at.as_str())
+    }
+
+    /// URL of the last successful fetch.
+    pub fn source(&self) -> Option<&str> {
+        self.fetched.provenance.as_ref().map(|p| p.source.as_str())
+    }
+
+    /// ONE message naming every inert file and every refused row, or `None` when
+    /// nothing is wrong. PURE, so a unit test can pin it instead of a terminal
+    /// (modelled on `retired_sandbox_settings_warning`). ADR-0015:44: two lines
+    /// for one problem read as two problems.
+    pub fn diagnostic(&self) -> Option<String> {
+        let mut parts: Vec<String> = Vec::new();
+        for (tier, parsed, path) in [
+            ("manual", &self.manual, self.manual_path.as_ref()),
+            ("fetched", &self.fetched, self.fetched_path.as_ref()),
+        ] {
+            let where_ = match path {
+                Some(p) => format!("{} price tier ({})", tier, p.display()),
+                None => format!("{tier} price tier"),
+            };
+            if let Some(err) = &parsed.unparseable {
+                parts.push(format!("{where_} is entirely inert: {err}"));
+            }
+            if !parsed.rejected.is_empty() {
+                let rows = parsed
+                    .rejected
+                    .iter()
+                    .map(|r| format!("`{}` ({})", r.key, r.why))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                parts.push(format!(
+                    "{where_} refused {} row(s), each falling through to the next tier: {rows}",
+                    parsed.rejected.len()
+                ));
+            }
+        }
+        if parts.is_empty() {
+            None
+        } else {
+            Some(format!("price table (#427) — {}", parts.join(" ; ")))
+        }
+    }
+
+    /// Say a diagnostic at most once per distinct table. A *differently* bad file
+    /// has a different fingerprint and so is said again.
+    ///
+    /// A `static` de-dup is a novation here — the crate's two conventions are
+    /// unique *placement* (`warn_about_retired_sandbox_settings`, called once at
+    /// boot) and de-dup through the *event log* (`stale_detector.rs:653`).
+    /// Neither applies to a loader called once per request.
+    fn warn_once(&self) {
+        static LAST_WARNED: Mutex<Option<u64>> = Mutex::new(None);
+        let Some(msg) = self.diagnostic() else {
+            return;
+        };
+        let mut guard = LAST_WARNED.lock().unwrap_or_else(|e| e.into_inner());
+        if *guard == Some(self.fingerprint) {
+            return;
+        }
+        *guard = Some(self.fingerprint);
+        warn!("{msg}");
+    }
+}
+
+/// Content hash of the bytes actually read. `0` ⇔ both files absent.
+///
+/// Preferred over mtime: no millisecond granularity to reason about and no
+/// copy-preserves-mtime trap. The hasher need NOT be stable across Rust versions
+/// — the only consumer is `run_cost`'s process-local RAM memo.
+fn fingerprint_of(manual: Option<&[u8]>, fetched: Option<&[u8]>) -> u64 {
+    if manual.is_none() && fetched.is_none() {
+        return 0;
+    }
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    for part in [manual, fetched] {
+        match part {
+            // Length-prefixed so `("ab", "c")` and `("a", "bc")` cannot collide.
+            Some(b) => {
+                h.write_u8(1);
+                h.write_usize(b.len());
+                h.write(b);
+            }
+            None => h.write_u8(0),
+        }
+    }
+    // `0` is reserved for "no file at all", so a real table never claims it.
+    match h.finish() {
+        0 => 1,
+        v => v,
+    }
+}
+
+/// Validate one row's `(input, output)` numbers. Applied to BOTH disk tiers: a
+/// `NaN` would poison `usd` *and* serialise to JSON `null` for a frontend that
+/// types it `number`, and a negative price would silently deflate a total.
+/// **Refuse, never clamp** — `CONTEXT.md:813` forbids silent self-repair, and
+/// `PUT /settings` 400s a cap `< 1` rather than clamping it.
+fn validate_price(input: f64, output: f64) -> Result<Price, String> {
+    for (label, v) in [("input", input), ("output", output)] {
+        if !v.is_finite() {
+            return Err(format!("{label} price is not a finite number"));
+        }
+        if v < 0.0 {
+            return Err(format!("{label} price is negative"));
+        }
+    }
+    Ok(Price { input, output })
+}
+
+/// Reject a family key that could never price anything. Shared by both tiers'
+/// key checks that are *not* about de-dating.
+fn reject_sentinel_key(key: &str) -> Option<String> {
+    key.starts_with('<').then(|| {
+        format!(
+            "`{key}` looks like a Claude Code sentinel (`{SYNTHETIC}` is priced $0 above every \
+             tier, so such a row could only ever be inert)"
+        )
+    })
+}
+
+/// Parse the manual tier (`models.yaml`). Applies D4's four refusal rules row by
+/// row. PURE.
+///
+/// Shape — a MAP, not a list of records, so key uniqueness is structural and the
+/// file reads as what it is, a sparse patch:
+///
+/// ```yaml
+/// models:
+///   claude-opus-4-8: { input: 4.5, output: 22.5 }
+/// ```
+///
+/// An unknown *field* stays ignored (no `deny_unknown_fields` anywhere in this
+/// crate; ADR-0015 #471 says an unknown field is simply ignored by serde).
+pub fn parse_manual(text: &str) -> ParsedTier {
+    #[derive(serde::Deserialize)]
+    struct Doc {
+        #[serde(default)]
+        models: BTreeMap<String, serde_yaml::Value>,
+    }
+
+    // A blank/comment-only file deserialises to YAML null, which is not a `Doc`.
+    // That is an empty patch, not a broken one.
+    if text.trim().is_empty() {
+        return ParsedTier::default();
+    }
+    let doc: Doc = match serde_yaml::from_str(text) {
+        Ok(d) => d,
+        Err(e) => {
+            return ParsedTier {
+                unparseable: Some(e.to_string()),
+                ..Default::default()
+            }
+        }
+    };
+
+    let mut tier = ParsedTier::default();
+    for (key, value) in doc.models {
+        // Rule 1 — a dated key would NEVER price anything, and the symptom is
+        // indistinguishable from absence. Refuse, do not normalise: stripping
+        // would silently collapse two rows the author wanted distinct. The
+        // message prints the correct form.
+        let family = strip_date_suffix(&key);
+        if family != key {
+            tier.rejected.push(RejectedRow {
+                key: key.clone(),
+                why: format!(
+                    "keys are FAMILY keys and carry no date suffix — write `{family}` instead"
+                ),
+            });
+            continue;
+        }
+        // Rule 2 — a sentinel-shaped key.
+        if let Some(why) = reject_sentinel_key(&key) {
+            tier.rejected.push(RejectedRow { key, why });
+            continue;
+        }
+        // Rule 3 — the numbers. A missing or wrongly-typed field lands here too.
+        let num = |field: &str| -> Result<f64, String> {
+            value
+                .get(field)
+                .ok_or_else(|| format!("missing `{field}`"))?
+                .as_f64()
+                .ok_or_else(|| format!("`{field}` is not a number"))
+        };
+        match num("input").and_then(|i| num("output").and_then(|o| validate_price(i, o))) {
+            Ok(price) => {
+                tier.rows.insert(key, price);
+            }
+            Err(why) => tier.rejected.push(RejectedRow { key, why }),
+        }
+        // Rule 4 — a duplicate key is structurally impossible: the schema is a map.
+    }
+    tier
+}
+
+/// Parse the fetched tier (`fetched.json`). Requires `schema == "prices-v1"`;
+/// anything else leaves the tier ENTIRELY inert. PURE.
+pub fn parse_fetched(text: &str) -> ParsedTier {
+    #[derive(serde::Deserialize)]
+    struct Doc {
+        schema: Option<String>,
+        source: Option<String>,
+        fetched_at: Option<String>,
+        #[serde(default)]
+        models: BTreeMap<String, Price>,
+    }
+
+    if text.trim().is_empty() {
+        return ParsedTier {
+            unparseable: Some("file is empty".to_string()),
+            ..Default::default()
+        };
+    }
+    let doc: Doc = match serde_json::from_str(text) {
+        Ok(d) => d,
+        Err(e) => {
+            return ParsedTier {
+                unparseable: Some(e.to_string()),
+                ..Default::default()
+            }
+        }
+    };
+    match doc.schema.as_deref() {
+        Some(FETCHED_SCHEMA) => {}
+        other => {
+            return ParsedTier {
+                unparseable: Some(format!(
+                    "unrecognised schema {} — expected `{FETCHED_SCHEMA}`; no row is read under a \
+                     schema this build does not know",
+                    other.map_or("(absent)".to_string(), |s| format!("`{s}`"))
+                )),
+                ..Default::default()
+            }
+        }
+    }
+
+    let mut tier = ParsedTier {
+        provenance: match (doc.source, doc.fetched_at) {
+            (Some(source), Some(fetched_at)) => Some(Provenance { source, fetched_at }),
+            _ => None,
+        },
+        ..Default::default()
+    };
+    // The daemon validated these at write time, so rows are taken as written —
+    // except for the numeric guard, which is free and defends a hand-edited file
+    // (the name says the daemon owns it, but nothing enforces that).
+    for (key, price) in doc.models {
+        if let Some(why) = reject_sentinel_key(&key) {
+            tier.rejected.push(RejectedRow { key, why });
+            continue;
+        }
+        match validate_price(price.input, price.output) {
+            Ok(p) => {
+                tier.rows.insert(key, p);
+            }
+            Err(why) => tier.rejected.push(RejectedRow { key, why }),
+        }
+    }
+    tier
+}
+
+// --- The single egress, strictly outside the read path (ADR-0034) ------------
+
+/// GET the price source. The daemon's ONLY outbound call outside `docker pull`
+/// and the shelled Trigger guards.
+///
+/// **Async, mandatorily**: `reqwest::blocking` panics when invoked from inside
+/// the runtime context, including from a `spawn_blocking` thread (those carry the
+/// context) — `main.rs:18-20` documents this for the CLI paths. This is the
+/// crate's first async reqwest call, so there is no precedent to copy.
+pub async fn fetch_source(url: &str) -> Result<String, String> {
+    let client = reqwest::Client::builder()
+        .timeout(PRICE_FETCH_TIMEOUT)
+        .connect_timeout(PRICE_FETCH_TIMEOUT)
+        .build()
+        .map_err(|e| format!("cannot build the HTTP client: {e}"))?;
+    let resp = client
+        .get(url)
+        .send()
+        .await
+        .map_err(|e| format!("request failed: {e}"))?;
+    let status = resp.status();
+    if !status.is_success() {
+        return Err(format!("source answered HTTP {status}"));
+    }
+    let bytes = resp
+        .bytes()
+        .await
+        .map_err(|e| format!("cannot read the body: {e}"))?;
+    if bytes.len() > PRICE_FETCH_MAX_BYTES {
+        return Err(format!(
+            "body is {} bytes, over the {PRICE_FETCH_MAX_BYTES}-byte ceiling",
+            bytes.len()
+        ));
+    }
+    String::from_utf8(bytes.to_vec()).map_err(|e| format!("body is not UTF-8: {e}"))
+}
+
+/// Normalise a models.dev payload into rows ready to write. PURE.
+///
+/// Reads ONLY `root["anthropic"]["models"]`. The other 174 providers carry
+/// re-prefixed ids (`anthropic.claude-opus-5`, `us.anthropic.…`) and REGIONAL
+/// prices (`eu.anthropic.claude-opus-5` is +10 %) — mixing them would reintroduce
+/// exactly the collisions that disqualified OpenRouter.
+///
+/// - keeps ids matching `claude-`; everything else is ignored WITHOUT error
+///   (noise, not a defect)
+/// - de-dates the key, and never strips `-fast` (stripping creates a
+///   $5/$25-vs-$10/$50 collision; keeping it yields a key no transcript matches,
+///   which costs nothing)
+/// - takes `cost.input` / `cost.output` in **$/MTok as-is** — models.dev is
+///   already in the right unit, which is the other reason to prefer it: there is
+///   no 10⁶ factor to get wrong
+/// - a divergent-price collision after de-dating DROPS THE WHOLE KEY, named
+///   (a source defect, not something to arbitrate by heuristic — the posture of
+///   #395's "never a false `synced` verdict")
+/// - an EMPTY harvest is an `Err`: an upstream schema drift would otherwise write
+///   an empty `fetched.json` and destroy the last known table
+#[allow(clippy::type_complexity)]
+pub fn normalize_models_dev(
+    text: &str,
+) -> Result<(BTreeMap<String, Price>, Vec<RejectedRow>), String> {
+    let root: serde_json::Value =
+        serde_json::from_str(text).map_err(|e| format!("response is not valid JSON: {e}"))?;
+    let models = root
+        .get("anthropic")
+        .and_then(|p| p.get("models"))
+        .and_then(|m| m.as_object())
+        .ok_or_else(|| {
+            "no `anthropic.models` object in the response — the source schema has drifted"
+                .to_string()
+        })?;
+
+    let mut candidates: BTreeMap<String, Vec<Price>> = BTreeMap::new();
+    let mut rejected: Vec<RejectedRow> = Vec::new();
+
+    for (map_key, entry) in models {
+        let id = entry
+            .get("id")
+            .and_then(|v| v.as_str())
+            .unwrap_or(map_key.as_str());
+        if !id.starts_with("claude-") {
+            continue; // noise, not a defect
+        }
+        let key = strip_date_suffix(id).to_string();
+        let cost = entry.get("cost");
+        let num = |field: &str| -> Result<f64, String> {
+            cost.and_then(|c| c.get(field))
+                .ok_or_else(|| format!("missing `cost.{field}`"))?
+                .as_f64()
+                .ok_or_else(|| format!("`cost.{field}` is not a number"))
+        };
+        match num("input").and_then(|i| num("output").and_then(|o| validate_price(i, o))) {
+            Ok(price) => candidates.entry(key).or_default().push(price),
+            Err(why) => rejected.push(RejectedRow { key, why }),
+        }
+    }
+
+    let mut rows: BTreeMap<String, Price> = BTreeMap::new();
+    for (key, prices) in candidates {
+        let first = prices[0];
+        if prices.iter().all(|p| *p == first) {
+            rows.insert(key, first);
+        } else {
+            let seen = prices
+                .iter()
+                .map(|p| format!("${}/${}", p.input, p.output))
+                .collect::<Vec<_>>()
+                .join(" vs ");
+            rejected.push(RejectedRow {
+                key,
+                why: format!(
+                    "de-dating collapses several source ids onto this key at DIVERGENT prices \
+                     ({seen}) — the whole key is dropped rather than arbitrated"
+                ),
+            });
+        }
+    }
+
+    if rows.is_empty() {
+        return Err(
+            "zero usable `claude-*` row in the response — refusing to write, so the last known \
+             table survives (ADR-0034)"
+                .to_string(),
+        );
+    }
+    Ok((rows, rejected))
+}
+
+/// Monotonic counter for unique temp names, like `sandbox_staging`'s `TMP_SEQ`.
+static TMP_SEQ: AtomicU64 = AtomicU64::new(0);
+
+/// Serialise and write `fetched.json` by tmp + `rename` **in the same
+/// directory** (idiom of `sandbox_staging.rs:790`), so a concurrent
+/// `PriceTable::load` can never read a half-written document.
+///
+/// **Never writes an empty table** — the one path by which this feature could
+/// destroy something.
+pub fn write_fetched(
+    path: &Path,
+    source: &str,
+    fetched_at: &str,
+    rows: &BTreeMap<String, Price>,
+) -> std::io::Result<()> {
+    if rows.is_empty() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "refusing to write an empty price table (ADR-0034)",
+        ));
+    }
+    let dir = path.parent().ok_or_else(|| {
+        std::io::Error::new(std::io::ErrorKind::InvalidInput, "path has no parent")
+    })?;
+    std::fs::create_dir_all(dir)?;
+    let doc = serde_json::json!({
+        "schema": FETCHED_SCHEMA,
+        "source": source,
+        "fetched_at": fetched_at,
+        "models": rows,
+    });
+    let body = serde_json::to_vec_pretty(&doc)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    let seq = TMP_SEQ.fetch_add(1, Ordering::Relaxed);
+    let tmp = dir.join(format!("fetched.json.pdo-tmp.{}.{seq}", std::process::id()));
+    std::fs::write(&tmp, &body)?;
+    match std::fs::rename(&tmp, path) {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            let _ = std::fs::remove_file(&tmp); // never leave an orphan
+            Err(e)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn p(input: f64, output: f64) -> Price {
+        Price { input, output }
+    }
+
+    // --- strip_date_suffix (moved from run_cost.rs with its tests) ---
+
+    #[test]
+    fn strips_trailing_8_digit_date() {
+        assert_eq!(
+            strip_date_suffix("claude-sonnet-4-5-20250929"),
+            "claude-sonnet-4-5"
+        );
+        assert_eq!(
+            strip_date_suffix("claude-3-5-haiku-20241022"),
+            "claude-3-5-haiku"
+        );
+    }
+
+    #[test]
+    fn leaves_version_only_id_untouched() {
+        assert_eq!(strip_date_suffix("claude-opus-4-8"), "claude-opus-4-8");
+        assert_eq!(strip_date_suffix("claude-opus-5"), "claude-opus-5");
+    }
+
+    // --- price_for on the builtin floor (the moved run_cost tests) ---
+
+    #[test]
+    fn prices_known_models() {
+        let t = PriceTable::builtin();
+        assert_eq!(t.price_for("claude-opus-4-8"), Some(p(5.0, 25.0)));
+        assert_eq!(t.price_for("claude-sonnet-4-5"), Some(p(3.0, 15.0)));
+        assert_eq!(t.price_for("claude-haiku-4-5"), Some(p(1.0, 5.0)));
+    }
+
+    #[test]
+    fn opus_4_1_and_4_0_are_not_collapsed_with_4_5_plus() {
+        // The single most error-prone row: same "opus-4" prefix, different price.
+        let t = PriceTable::builtin();
+        assert_eq!(t.price_for("claude-opus-4-1"), Some(p(15.0, 75.0)));
+        assert_eq!(t.price_for("claude-opus-4-0"), Some(p(15.0, 75.0)));
+        assert_ne!(
+            t.price_for("claude-opus-4-1"),
+            t.price_for("claude-opus-4-8")
+        );
+    }
+
+    #[test]
+    fn dated_id_resolves_to_family_price() {
+        assert_eq!(
+            PriceTable::builtin().price_for("claude-sonnet-4-5-20250929"),
+            Some(p(3.0, 15.0))
+        );
+    }
+
+    #[test]
+    fn synthetic_is_zero_not_unknown() {
+        assert_eq!(
+            PriceTable::builtin().price_for(SYNTHETIC),
+            Some(p(0.0, 0.0))
+        );
+    }
+
+    #[test]
+    fn unknown_model_is_none() {
+        let t = PriceTable::builtin();
+        assert_eq!(t.price_for("gpt-9"), None);
+        assert_eq!(t.price_for("claude-opus-9-9"), None);
+    }
+
+    #[test]
+    fn builtin_has_a_zero_fingerprint_and_no_diagnostic() {
+        let t = PriceTable::builtin();
+        assert_eq!(t.fingerprint(), 0);
+        assert_eq!(t.diagnostic(), None);
+        assert!(t.manual_keys().is_empty());
+        assert_eq!(t.fetched_rows(), 0);
+        assert_eq!(t.fetched_at(), None);
+        assert_eq!(t.source(), None);
+    }
+
+    // --- parse_manual ---
+
+    #[test]
+    fn parse_manual_accepts_a_valid_map() {
+        let tier = parse_manual(
+            "models:\n  claude-opus-4-8: { input: 4.5, output: 22.5 }\n  claude-mythos-5: { input: 10.0, output: 50.0 }\n",
+        );
+        assert!(tier.unparseable.is_none());
+        assert!(tier.rejected.is_empty());
+        assert_eq!(tier.rows.get("claude-opus-4-8"), Some(&p(4.5, 22.5)));
+        assert_eq!(tier.rows.get("claude-mythos-5"), Some(&p(10.0, 50.0)));
+    }
+
+    #[test]
+    fn parse_manual_refuses_a_dated_key_and_prints_the_correct_form() {
+        let tier =
+            parse_manual("models:\n  claude-opus-5-20260501: { input: 5.0, output: 25.0 }\n");
+        assert!(tier.rows.is_empty(), "a dated key must not price anything");
+        assert_eq!(tier.rejected.len(), 1);
+        assert_eq!(tier.rejected[0].key, "claude-opus-5-20260501");
+        assert!(
+            tier.rejected[0].why.contains("claude-opus-5"),
+            "the refusal must print the correct undated form, got: {}",
+            tier.rejected[0].why
+        );
+        // And it must print the FAMILY form, not merely echo the dated key.
+        assert!(!tier.rejected[0].why.contains("`claude-opus-5-20260501`"));
+    }
+
+    #[test]
+    fn parse_manual_refuses_a_sentinel_key() {
+        let tier = parse_manual("models:\n  \"<synthetic>\": { input: 99.0, output: 99.0 }\n");
+        assert!(tier.rows.is_empty());
+        assert_eq!(tier.rejected.len(), 1);
+        assert_eq!(tier.rejected[0].key, SYNTHETIC);
+    }
+
+    #[test]
+    fn parse_manual_refuses_negative_and_non_finite_prices() {
+        let neg = parse_manual("models:\n  claude-opus-5: { input: -1.0, output: 25.0 }\n");
+        assert!(neg.rows.is_empty());
+        assert!(neg.rejected[0].why.contains("negative"));
+
+        let nan = parse_manual("models:\n  claude-opus-5: { input: 5.0, output: .nan }\n");
+        assert!(
+            nan.rows.is_empty(),
+            "a NaN would poison `usd` and serialise as JSON null"
+        );
+        assert!(nan.rejected[0].why.contains("finite"));
+
+        let inf = parse_manual("models:\n  claude-opus-5: { input: .inf, output: 25.0 }\n");
+        assert!(inf.rows.is_empty());
+    }
+
+    #[test]
+    fn parse_manual_refuses_a_row_with_a_missing_field() {
+        let tier = parse_manual("models:\n  claude-opus-5: { input: 5.0 }\n");
+        assert!(tier.rows.is_empty());
+        assert!(tier.rejected[0].why.contains("output"));
+    }
+
+    #[test]
+    fn parse_manual_ignores_an_unknown_field_rather_than_rejecting() {
+        // No `deny_unknown_fields` anywhere in this crate (ADR-0015 #471).
+        let tier = parse_manual(
+            "models:\n  claude-opus-5: { input: 5.0, output: 25.0, note: \"discount\" }\n",
+        );
+        assert!(tier.rejected.is_empty());
+        assert_eq!(tier.rows.get("claude-opus-5"), Some(&p(5.0, 25.0)));
+    }
+
+    #[test]
+    fn parse_manual_reports_broken_yaml_without_rows() {
+        let tier = parse_manual("models:\n  - this is: [not, a, map\n");
+        assert!(tier.unparseable.is_some());
+        assert!(tier.rows.is_empty());
+    }
+
+    #[test]
+    fn parse_manual_treats_an_empty_or_comment_only_file_as_an_empty_patch() {
+        // A user who creates the file from the path shown in Settings and has not
+        // written a row yet must NOT see a diagnostic: that would read as a defect.
+        for text in ["", "   \n", "# nothing yet\n", "models:\n", "models: {}\n"] {
+            let tier = parse_manual(text);
+            assert!(
+                tier.unparseable.is_none(),
+                "text = {text:?} → {:?}",
+                tier.unparseable
+            );
+            assert!(tier.rows.is_empty());
+            assert!(tier.rejected.is_empty());
+        }
+    }
+
+    #[test]
+    fn parse_manual_keeps_the_good_rows_when_one_is_refused() {
+        let tier = parse_manual(
+            "models:\n  claude-opus-4-8: { input: 4.5, output: 22.5 }\n  claude-opus-5-20260501: { input: 5.0, output: 25.0 }\n",
+        );
+        assert_eq!(tier.rows.len(), 1, "one bad row must not void the file");
+        assert_eq!(tier.rejected.len(), 1);
+    }
+
+    // --- parse_fetched ---
+
+    fn fetched_doc(schema: &str) -> String {
+        format!(
+            r#"{{"schema":"{schema}","source":"https://models.dev/api.json","fetched_at":"2026-07-30T14:12:03Z","models":{{"claude-opus-5":{{"input":5.0,"output":25.0}}}}}}"#
+        )
+    }
+
+    #[test]
+    fn parse_fetched_accepts_the_known_schema_with_its_provenance() {
+        let tier = parse_fetched(&fetched_doc(FETCHED_SCHEMA));
+        assert!(tier.unparseable.is_none());
+        assert_eq!(tier.rows.get("claude-opus-5"), Some(&p(5.0, 25.0)));
+        assert_eq!(
+            tier.provenance.as_ref().map(|x| x.fetched_at.as_str()),
+            Some("2026-07-30T14:12:03Z")
+        );
+    }
+
+    #[test]
+    fn parse_fetched_is_entirely_inert_under_an_unknown_or_absent_schema() {
+        for text in [
+            fetched_doc("prices-v99"),
+            r#"{"models":{"claude-opus-5":{"input":5.0,"output":25.0}}}"#.to_string(),
+        ] {
+            let tier = parse_fetched(&text);
+            assert!(
+                tier.rows.is_empty(),
+                "no row may be read under a schema this build does not know"
+            );
+            assert!(tier.unparseable.is_some());
+        }
+    }
+
+    #[test]
+    fn parse_fetched_is_inert_on_broken_or_empty_json() {
+        for text in ["{not json", ""] {
+            let tier = parse_fetched(text);
+            assert!(tier.rows.is_empty());
+            assert!(tier.unparseable.is_some());
+        }
+    }
+
+    #[test]
+    fn parse_fetched_still_guards_the_numbers_of_a_hand_edited_file() {
+        let text = r#"{"schema":"prices-v1","source":"s","fetched_at":"t","models":{"claude-opus-5":{"input":-5.0,"output":25.0}}}"#;
+        let tier = parse_fetched(text);
+        assert!(tier.rows.is_empty());
+        assert_eq!(tier.rejected.len(), 1);
+    }
+
+    // --- resolve: precedence, by key ---
+
+    #[test]
+    fn manual_wins_over_fetched_which_wins_over_embedded() {
+        let t = PriceTable::resolve(
+            ParsedTier::of(&[("claude-opus-4-8", 1.0, 1.0)]),
+            ParsedTier::of(&[("claude-opus-4-8", 2.0, 2.0), ("claude-opus-4-7", 3.0, 3.0)]),
+            42,
+        );
+        assert_eq!(t.price_for("claude-opus-4-8"), Some(p(1.0, 1.0)));
+        assert_eq!(t.tier_of("claude-opus-4-8"), Some(PriceTier::Manual));
+        assert_eq!(t.price_for("claude-opus-4-7"), Some(p(3.0, 3.0)));
+        assert_eq!(t.tier_of("claude-opus-4-7"), Some(PriceTier::Fetched));
+        // Untouched by either disk tier → still the embedded floor.
+        assert_eq!(t.price_for("claude-opus-4-6"), Some(p(5.0, 25.0)));
+        assert_eq!(t.tier_of("claude-opus-4-6"), Some(PriceTier::Embedded));
+        assert_eq!(t.tier_of("claude-nope"), None);
+        assert_eq!(t.fingerprint(), 42);
+        assert_eq!(t.manual_keys(), ["claude-opus-4-8"]);
+    }
+
+    #[test]
+    fn a_key_only_the_disk_knows_is_priced_and_no_longer_partial() {
+        let t = PriceTable::resolve(
+            ParsedTier::default(),
+            ParsedTier::of(&[("claude-fable-5", 10.0, 50.0)]),
+            7,
+        );
+        assert_eq!(t.price_for("claude-fable-5"), Some(p(10.0, 50.0)));
+        // Merge BY KEY: the rest of the floor survives a partial disk tier.
+        assert_eq!(t.price_for("claude-opus-4-8"), Some(p(5.0, 25.0)));
+    }
+
+    #[test]
+    fn the_embedded_tier_is_a_floor_not_a_seed() {
+        // #427 D2: these three families are in NO remote source, so a full
+        // fetched tier must not be able to un-price them.
+        let full_fetch = ParsedTier::of(&[
+            ("claude-opus-4-8", 5.0, 25.0),
+            ("claude-opus-5", 5.0, 25.0),
+            ("claude-sonnet-5", 2.0, 10.0),
+            ("claude-fable-5", 10.0, 50.0),
+        ]);
+        let t = PriceTable::resolve(ParsedTier::default(), full_fetch, 9);
+        assert_eq!(t.price_for("claude-opus-4-0"), Some(p(15.0, 75.0)));
+        assert_eq!(t.price_for("claude-sonnet-4-0"), Some(p(3.0, 15.0)));
+        assert_eq!(t.price_for("claude-3-5-haiku"), Some(p(0.80, 4.0)));
+        for k in ["claude-opus-4-0", "claude-sonnet-4-0", "claude-3-5-haiku"] {
+            assert_eq!(t.tier_of(k), Some(PriceTier::Embedded), "key = {k}");
+        }
+    }
+
+    #[test]
+    fn a_refused_row_falls_through_to_the_next_tier_instead_of_destroying_it() {
+        // D5: a typo in the manual file must not collapse 79 941 lines.
+        let manual =
+            parse_manual("models:\n  claude-opus-4-8-20260101: { input: 4.5, output: 22.5 }\n");
+        assert_eq!(manual.rejected.len(), 1);
+        let t = PriceTable::resolve(manual, ParsedTier::of(&[("claude-opus-4-8", 2.0, 2.0)]), 3);
+        assert_eq!(t.price_for("claude-opus-4-8"), Some(p(2.0, 2.0)));
+        assert_eq!(t.tier_of("claude-opus-4-8"), Some(PriceTier::Fetched));
+
+        // And with no fetched tier at all, it falls all the way to the floor.
+        let manual =
+            parse_manual("models:\n  claude-opus-4-8-20260101: { input: 4.5, output: 22.5 }\n");
+        let t = PriceTable::resolve(manual, ParsedTier::default(), 3);
+        assert_eq!(t.price_for("claude-opus-4-8"), Some(p(5.0, 25.0)));
+    }
+
+    #[test]
+    fn synthetic_stays_zero_even_when_a_file_prices_it_at_99() {
+        // The test that stops a future refactor from moving the lookup above the
+        // sentinel guard. `parse_manual` refuses such a row, so build the tier
+        // directly — this pins `price_for`'s ORDER, not the parser.
+        let t = PriceTable::resolve(
+            ParsedTier::of(&[(SYNTHETIC, 99.0, 99.0)]),
+            ParsedTier::default(),
+            1,
+        );
+        assert_eq!(t.price_for(SYNTHETIC), Some(p(0.0, 0.0)));
+    }
+
+    // --- diagnostic ---
+
+    #[test]
+    fn diagnostic_is_none_on_a_healthy_table() {
+        let t = PriceTable::resolve(
+            ParsedTier::of(&[("claude-opus-4-8", 1.0, 1.0)]),
+            ParsedTier::of(&[("claude-opus-5", 5.0, 25.0)]),
+            5,
+        );
+        assert_eq!(t.diagnostic(), None);
+    }
+
+    #[test]
+    fn diagnostic_is_one_string_naming_every_inert_file_and_row() {
+        // ADR-0015:44 — two lines for one problem read as two problems.
+        let t = PriceTable::resolve(
+            parse_manual("models:\n  claude-opus-5-20260501: { input: 5.0, output: 25.0 }\n  claude-x: { input: -1.0, output: 2.0 }\n"),
+            parse_fetched(&fetched_doc("prices-v99")),
+            5,
+        );
+        let d = t.diagnostic().expect("a diagnostic was expected");
+        assert_eq!(d.lines().count(), 1, "exactly one message: {d}");
+        assert!(d.contains("claude-opus-5-20260501"));
+        assert!(d.contains("claude-x"));
+        assert!(d.contains("prices-v99"));
+        assert!(d.contains("manual") && d.contains("fetched"));
+    }
+
+    // --- fingerprint ---
+
+    #[test]
+    fn fingerprint_is_zero_only_when_both_files_are_absent() {
+        assert_eq!(fingerprint_of(None, None), 0);
+        assert_ne!(fingerprint_of(Some(b""), None), 0);
+        assert_ne!(fingerprint_of(None, Some(b"")), 0);
+    }
+
+    #[test]
+    fn fingerprint_changes_with_content_and_cannot_be_confused_by_a_shifted_split() {
+        assert_ne!(
+            fingerprint_of(Some(b"a"), None),
+            fingerprint_of(Some(b"b"), None)
+        );
+        // Length-prefixing: ("ab", "c") and ("a", "bc") must not collide.
+        assert_ne!(
+            fingerprint_of(Some(b"ab"), Some(b"c")),
+            fingerprint_of(Some(b"a"), Some(b"bc"))
+        );
+        // Which file the bytes came from matters too.
+        assert_ne!(
+            fingerprint_of(Some(b"x"), None),
+            fingerprint_of(None, Some(b"x"))
+        );
+    }
+
+    // --- load (filesystem, injected root — no $HOME swap) ---
+
+    fn write_manual(home: &Path, body: &str) {
+        let (path, _) = PriceTable::paths(home);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, body).unwrap();
+    }
+
+    fn write_fetched_raw(home: &Path, body: &str) {
+        let (_, path) = PriceTable::paths(home);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, body).unwrap();
+    }
+
+    #[test]
+    fn load_on_a_root_without_a_prices_dir_is_the_builtin_floor_and_silent() {
+        let home = tempfile::tempdir().unwrap();
+        let t = PriceTable::load(home.path());
+        assert_eq!(t.fingerprint(), 0);
+        assert_eq!(t.diagnostic(), None);
+        assert_eq!(t.price_for("claude-opus-4-8"), Some(p(5.0, 25.0)));
+        assert_eq!(t.price_for("claude-opus-5"), None);
+        // Byte-identical to the pre-#427 behaviour.
+        assert_eq!(t.resolved, PriceTable::builtin().resolved);
+    }
+
+    #[test]
+    fn load_applies_the_manual_tier_and_keeps_the_rest_of_the_floor() {
+        let home = tempfile::tempdir().unwrap();
+        write_manual(
+            home.path(),
+            "models:\n  claude-opus-5: { input: 5.0, output: 25.0 }\n",
+        );
+        let t = PriceTable::load(home.path());
+        assert_eq!(t.price_for("claude-opus-5"), Some(p(5.0, 25.0)));
+        assert_eq!(t.price_for("claude-opus-4-8"), Some(p(5.0, 25.0)));
+        assert_ne!(t.fingerprint(), 0);
+        assert_eq!(t.manual_keys(), ["claude-opus-5"]);
+    }
+
+    #[test]
+    fn load_of_a_corrupt_fetched_file_prices_like_absence_but_says_so() {
+        let home = tempfile::tempdir().unwrap();
+        write_fetched_raw(home.path(), "{not json");
+        let t = PriceTable::load(home.path());
+        assert_eq!(t.price_for("claude-opus-4-8"), Some(p(5.0, 25.0)));
+        assert_eq!(t.price_for("claude-opus-5"), None);
+        let d = t.diagnostic().expect("a corrupt file must be said");
+        assert!(d.contains("fetched.json"), "the path must be named: {d}");
+    }
+
+    #[test]
+    fn load_reads_both_tiers_with_manual_winning() {
+        let home = tempfile::tempdir().unwrap();
+        write_manual(
+            home.path(),
+            "models:\n  claude-opus-5: { input: 4.0, output: 20.0 }\n",
+        );
+        write_fetched_raw(home.path(), &fetched_doc(FETCHED_SCHEMA));
+        let t = PriceTable::load(home.path());
+        assert_eq!(t.price_for("claude-opus-5"), Some(p(4.0, 20.0)));
+        assert_eq!(t.tier_of("claude-opus-5"), Some(PriceTier::Manual));
+        assert_eq!(t.fetched_rows(), 1);
+        assert_eq!(t.source(), Some("https://models.dev/api.json"));
+        assert_eq!(t.fetched_at(), Some("2026-07-30T14:12:03Z"));
+    }
+
+    #[test]
+    fn load_names_both_paths_even_when_no_file_exists() {
+        // The whole discoverability story: nothing is seeded, so `GET /settings`
+        // naming the paths is the only way a user learns where to write.
+        let home = tempfile::tempdir().unwrap();
+        let t = PriceTable::load(home.path());
+        let (m, f) = PriceTable::paths(home.path());
+        assert_eq!(t.manual_path.as_deref(), Some(m.as_path()));
+        assert_eq!(t.fetched_path.as_deref(), Some(f.as_path()));
+        assert!(!m.exists() && !f.exists(), "load must never seed a file");
+    }
+
+    // --- normalize_models_dev ---
+
+    /// The real shape of `models.dev/api.json`, trimmed to what we read.
+    const MODELS_DEV: &str = r#"{
+      "anthropic": { "models": {
+        "claude-opus-5":   { "id": "claude-opus-5",   "cost": { "input": 5,  "output": 25, "cache_read": 0.5, "cache_write": 6.25 } },
+        "claude-sonnet-5": { "id": "claude-sonnet-5", "cost": { "input": 2,  "output": 10 } },
+        "claude-fable-5":  { "id": "claude-fable-5",  "cost": { "input": 10, "output": 50 } },
+        "claude-haiku-4-5-20251001": { "id": "claude-haiku-4-5-20251001", "cost": { "input": 1, "output": 5 } },
+        "claude-opus-5-fast": { "id": "claude-opus-5-fast", "cost": { "input": 10, "output": 50 } },
+        "gpt-nope": { "id": "gpt-nope", "cost": { "input": 1, "output": 1 } }
+      } },
+      "eu.anthropic": { "models": {
+        "eu.anthropic.claude-opus-5": { "id": "claude-opus-5", "cost": { "input": 5.5, "output": 27.5 } }
+      } }
+    }"#;
+
+    #[test]
+    fn normalize_reads_the_real_shape_in_dollars_per_mtok() {
+        let (rows, rejected) = normalize_models_dev(MODELS_DEV).unwrap();
+        // The test that fails if anyone multiplies or divides by 10^6.
+        assert_eq!(rows.get("claude-opus-5"), Some(&p(5.0, 25.0)));
+        assert_eq!(rows.get("claude-sonnet-5"), Some(&p(2.0, 10.0)));
+        assert_eq!(rows.get("claude-fable-5"), Some(&p(10.0, 50.0)));
+        assert!(rejected.is_empty(), "rejected = {rejected:?}");
+    }
+
+    #[test]
+    fn normalize_de_dates_the_key() {
+        let (rows, _) = normalize_models_dev(MODELS_DEV).unwrap();
+        assert_eq!(
+            rows.get("claude-haiku-4-5"),
+            Some(&p(1.0, 5.0)),
+            "a dated source id must price the family the transcripts write"
+        );
+        assert!(!rows.contains_key("claude-haiku-4-5-20251001"));
+    }
+
+    #[test]
+    fn normalize_never_strips_fast() {
+        let (rows, _) = normalize_models_dev(MODELS_DEV).unwrap();
+        // Stripping would collide with claude-opus-5 at a different price.
+        assert_eq!(rows.get("claude-opus-5-fast"), Some(&p(10.0, 50.0)));
+        assert_eq!(rows.get("claude-opus-5"), Some(&p(5.0, 25.0)));
+    }
+
+    #[test]
+    fn normalize_ignores_other_providers_and_non_claude_ids() {
+        let (rows, _) = normalize_models_dev(MODELS_DEV).unwrap();
+        // Regional prices (+10 %) would reintroduce OpenRouter's collisions.
+        assert_eq!(rows.get("claude-opus-5"), Some(&p(5.0, 25.0)));
+        assert!(!rows.keys().any(|k| k.contains("eu.")));
+        assert!(!rows.contains_key("gpt-nope"));
+    }
+
+    #[test]
+    fn normalize_drops_a_whole_key_on_a_divergent_collision() {
+        let text = r#"{"anthropic":{"models":{
+            "claude-zed-1-20260101": { "id": "claude-zed-1-20260101", "cost": { "input": 1, "output": 2 } },
+            "claude-zed-1-20260202": { "id": "claude-zed-1-20260202", "cost": { "input": 9, "output": 9 } },
+            "claude-opus-5": { "id": "claude-opus-5", "cost": { "input": 5, "output": 25 } }
+        }}}"#;
+        let (rows, rejected) = normalize_models_dev(text).unwrap();
+        assert!(
+            !rows.contains_key("claude-zed-1"),
+            "a divergent collision drops the whole key rather than arbitrating"
+        );
+        assert!(rejected.iter().any(|r| r.key == "claude-zed-1"));
+        assert!(rows.contains_key("claude-opus-5"), "the other keys survive");
+    }
+
+    #[test]
+    fn normalize_accepts_an_identical_price_collision() {
+        let text = r#"{"anthropic":{"models":{
+            "claude-zed-1-20260101": { "id": "claude-zed-1-20260101", "cost": { "input": 1, "output": 2 } },
+            "claude-zed-1-20260202": { "id": "claude-zed-1-20260202", "cost": { "input": 1, "output": 2 } }
+        }}}"#;
+        let (rows, rejected) = normalize_models_dev(text).unwrap();
+        assert_eq!(rows.get("claude-zed-1"), Some(&p(1.0, 2.0)));
+        assert!(rejected.is_empty());
+    }
+
+    #[test]
+    fn normalize_errors_on_an_empty_harvest_or_a_drifted_schema() {
+        // The guard that stops a schema drift from destroying the last table.
+        assert!(normalize_models_dev("{}").is_err());
+        assert!(normalize_models_dev(r#"{"anthropic":{"models":{}}}"#).is_err());
+        assert!(normalize_models_dev(
+            r#"{"anthropic":{"models":{"gpt-1":{"cost":{"input":1,"output":1}}}}}"#
+        )
+        .is_err());
+        assert!(normalize_models_dev("{not json").is_err());
+    }
+
+    #[test]
+    fn normalize_rejects_a_row_with_a_bad_cost_but_keeps_the_others() {
+        let text = r#"{"anthropic":{"models":{
+            "claude-bad-1": { "id": "claude-bad-1", "cost": { "input": "5", "output": 25 } },
+            "claude-opus-5": { "id": "claude-opus-5", "cost": { "input": 5, "output": 25 } }
+        }}}"#;
+        let (rows, rejected) = normalize_models_dev(text).unwrap();
+        assert!(!rows.contains_key("claude-bad-1"));
+        assert!(rows.contains_key("claude-opus-5"));
+        assert_eq!(rejected.len(), 1);
+    }
+
+    // --- write_fetched ---
+
+    #[test]
+    fn write_fetched_round_trips_through_parse_fetched() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("prices").join("fetched.json");
+        let rows: BTreeMap<String, Price> = [
+            ("claude-fable-5".to_string(), p(10.0, 50.0)),
+            ("claude-opus-5".to_string(), p(5.0, 25.0)),
+        ]
+        .into_iter()
+        .collect();
+        write_fetched(
+            &path,
+            "https://models.dev/api.json",
+            "2026-07-30T14:12:03Z",
+            &rows,
+        )
+        .unwrap();
+
+        let tier = parse_fetched(&std::fs::read_to_string(&path).unwrap());
+        assert!(tier.unparseable.is_none());
+        assert_eq!(tier.rows, rows);
+        assert_eq!(
+            tier.provenance.map(|x| x.source),
+            Some("https://models.dev/api.json".to_string())
+        );
+        // No temp file left behind.
+        let leftovers: Vec<_> = std::fs::read_dir(path.parent().unwrap())
+            .unwrap()
+            .flatten()
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n != "fetched.json")
+            .collect();
+        assert!(leftovers.is_empty(), "leftovers = {leftovers:?}");
+    }
+
+    #[test]
+    fn write_fetched_refuses_an_empty_table() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("fetched.json");
+        let err = write_fetched(&path, "s", "t", &BTreeMap::new()).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+        assert!(!path.exists(), "nothing may be written");
+    }
+
+    #[test]
+    fn write_fetched_leaves_the_previous_table_intact_on_a_refusal() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("fetched.json");
+        let rows: BTreeMap<String, Price> = [("claude-opus-5".to_string(), p(5.0, 25.0))]
+            .into_iter()
+            .collect();
+        write_fetched(&path, "s", "t1", &rows).unwrap();
+        let before = std::fs::read(&path).unwrap();
+        assert!(write_fetched(&path, "s", "t2", &BTreeMap::new()).is_err());
+        assert_eq!(std::fs::read(&path).unwrap(), before, "byte for byte");
+    }
+}

--- a/crates/pdo-daemon/src/run_cost.rs
+++ b/crates/pdo-daemon/src/run_cost.rs
@@ -1,6 +1,12 @@
 //! Estimated USD cost of a Run (#272), derived on read from the per-message
 //! token `usage` recorded in each session's Claude Code transcript
-//! (`<projects_root>/<encoded-cwd>/*.jsonl`) × a hardcoded public price table.
+//! (`<projects_root>/<encoded-cwd>/*.jsonl`) × a public price table.
+//!
+//! Since #427 that table is **injected** too, as a [`crate::price_table::PriceTable`]
+//! resolved by the caller at the request edge (`manual → fetched → embedded`, see
+//! ADR-0034). There is deliberately NO N-1-argument wrapper meaning "the embedded
+//! prices": the next call site added would silently ignore both disk tiers and no
+//! test could catch it.
 //!
 //! The `projects_root` is injected by the caller (the #408 observability seam,
 //! [`crate::sandbox_run::transcripts_root`]): `~/.claude/projects/` for an
@@ -34,59 +40,11 @@
 //!   was observed) are skipped line-by-line, never `?`-propagated.
 
 use crate::event_log::CostStat;
+use crate::price_table::PriceTable;
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::{Mutex, OnceLock};
 use std::time::UNIX_EPOCH;
-
-// Source: https://platform.claude.com/docs/en/about-claude/pricing (fetched 2026-07-06).
-// Per-MTok list prices `(family_key, input, output)`. UPDATE when Anthropic
-// changes pricing or ships a model. Cache prices are DERIVED (write_5m = 1.25×in,
-// write_1h = 2×in, read = 0.1×in) — verified universal across every current row.
-// Match on the FULL family key: Opus 4.5–4.8 are $5/$25 but Opus 4.1/4.0 are
-// $15/$75 — never a `starts_with("opus-4")` shortcut.
-const PRICES: &[(&str, f64, f64)] = &[
-    ("claude-opus-4-8", 5.0, 25.0),
-    ("claude-opus-4-7", 5.0, 25.0),
-    ("claude-opus-4-6", 5.0, 25.0),
-    ("claude-opus-4-5", 5.0, 25.0),
-    ("claude-opus-4-1", 15.0, 75.0),
-    ("claude-opus-4-0", 15.0, 75.0),
-    ("claude-sonnet-4-6", 3.0, 15.0),
-    ("claude-sonnet-4-5", 3.0, 15.0),
-    ("claude-sonnet-4-0", 3.0, 15.0),
-    ("claude-haiku-4-5", 1.0, 5.0),
-    ("claude-3-5-haiku", 0.80, 4.0),
-    // NOTE: `claude-sonnet-5` intro price ($2/$10) expires 2026-08-31 → $3/$15.
-    // PDO runs opus-4-8 today; add sonnet-5 (date-gated) only if it starts appearing.
-];
-
-/// Drop a trailing 8-digit date segment so a dated id resolves to its family
-/// key: `claude-sonnet-4-5-20250929` → `claude-sonnet-4-5`. A version-only id is
-/// returned unchanged.
-fn strip_date_suffix(model: &str) -> &str {
-    if let Some((head, tail)) = model.rsplit_once('-') {
-        if tail.len() == 8 && tail.bytes().all(|b| b.is_ascii_digit()) {
-            return head;
-        }
-    }
-    model
-}
-
-/// Per-MTok `(input, output)` price for a model, or `None` for an unknown real
-/// model (the caller then flags `partial` and the model contributes $0).
-/// `<synthetic>` — CC's local/no-cost sentinel — is priced at $0, NOT treated as
-/// unknown (so it never flips `partial`).
-fn price_for(model: &str) -> Option<(f64, f64)> {
-    if model == "<synthetic>" {
-        return Some((0.0, 0.0));
-    }
-    let key = strip_date_suffix(model);
-    PRICES
-        .iter()
-        .find(|(k, ..)| *k == key)
-        .map(|(_, i, o)| (*i, *o))
-}
 
 /// Token counts from one assistant message's `usage`. The four cache buckets are
 /// disjoint from `input`/`output` (CC's `input_tokens` excludes cache tokens).
@@ -177,10 +135,11 @@ fn parse_line(raw: &str) -> Option<Line> {
     })
 }
 
-/// Dedup by `(message.id, requestId)` (keep first), price each surviving line,
-/// and flag `partial` when any line used a model absent from [`PRICES`]. Lines
-/// without a `message.id` are always counted (no key to dedup on).
-fn aggregate(lines: impl Iterator<Item = Line>) -> CostStat {
+/// Dedup by `(message.id, requestId)` (keep first), price each surviving line
+/// against the resolved `prices` table, and flag `partial` when any line used a
+/// model no tier knows. Lines without a `message.id` are always counted (no key
+/// to dedup on).
+fn aggregate(lines: impl Iterator<Item = Line>, prices: &PriceTable) -> CostStat {
     let mut seen = std::collections::HashSet::new();
     let mut usd = 0.0;
     let mut partial = false;
@@ -190,8 +149,8 @@ fn aggregate(lines: impl Iterator<Item = Line>) -> CostStat {
                 continue; // duplicate: replay on resume/compaction
             }
         }
-        match price_for(&l.model) {
-            Some((i, o)) => usd += line_cost(&l.usage, i, o),
+        match prices.price_for(&l.model) {
+            Some(p) => usd += line_cost(&l.usage, p.input, p.output),
             None => partial = true, // unknown real model → $0 + lower-bound flag
         }
     }
@@ -246,7 +205,14 @@ fn collect_jsonl_recursive(dir: &Path, out: &mut Vec<Line>) {
 /// **effective** repo root (honours `target_repo`) — pass the value the caller
 /// already resolved via `effective_repo_root`; it builds the run-id dir prefix,
 /// NOT the read root.
-pub fn compute_run_cost(projects_root: &Path, repo_root: &Path, run_id: &str) -> Option<CostStat> {
+/// `prices` is the table resolved at the request edge (#427) — mandatory; see the
+/// module header on why there is no defaulting wrapper.
+pub fn compute_run_cost(
+    projects_root: &Path,
+    repo_root: &Path,
+    run_id: &str,
+    prices: &PriceTable,
+) -> Option<CostStat> {
     let run_dir = repo_root.join(".pdo").join("runs").join(run_id);
     // Trailing '-' anchors the run_id: a run whose id is a lexical prefix of
     // another can't leak its sessions in (after run_id comes `-nodes`/`-worktree`).
@@ -263,7 +229,7 @@ pub fn compute_run_cost(projects_root: &Path, repo_root: &Path, run_id: &str) ->
     if !found {
         return None;
     }
-    Some(aggregate(lines.into_iter()))
+    Some(aggregate(lines.into_iter(), prices))
 }
 
 // --- Read-side memo for the aggregate cost path (#377 / ADR-0029) ------------
@@ -271,16 +237,30 @@ pub fn compute_run_cost(projects_root: &Path, repo_root: &Path, run_id: &str) ->
 // The Stats modal's `/stats/cost` endpoint fans [`compute_run_cost`] out over
 // every run in the visible period — the exact anti-fan-out ADR-0022 kept off the
 // `/runs` list handler. This memo is ADR-0022's *sanctioned escape hatch*: a
-// derive-on-read RAM cache keyed on `(run_id, max transcript mtime)`, NEVER
-// persisted (no snapshot table, no metric-freezing event). A transcript change
-// bumps the mtime and so invalidates the entry naturally. It is touched ONLY by
-// [`compute_run_cost_cached`] (the aggregate path); `get_run`'s single-run read
-// keeps calling [`compute_run_cost`] directly, so ADR-0022's per-read contract
-// is byte-identical there.
+// derive-on-read RAM cache keyed on `(run_id, max transcript mtime, price-table
+// fingerprint)`, NEVER persisted (no snapshot table, no metric-freezing event). A
+// transcript change bumps the mtime and so invalidates the entry naturally. It is
+// touched ONLY by [`compute_run_cost_cached`] (the aggregate path); `get_run`'s
+// single-run read keeps calling [`compute_run_cost`] directly, so ADR-0022's
+// per-read contract is byte-identical there.
+//
+// The THIRD key component is load-bearing (#427, ADR-0034). A price sync bumps no
+// transcript mtime, so under the old two-part key `/stats/cost` (memoized) would
+// re-serve pre-sync dollars until the daemon restarted while `GET /runs/:id`
+// (not memoized) told the truth — two surfaces contradicting each other on the
+// same Run, and the affected Runs (finished, transcripts frozen) are exactly the
+// ones a sync is meant to repair. A sync deliberately does NOT clear the memo:
+// under the new key a stale entry is simply unreachable, and clearing would also
+// invalidate Runs whose prices did not move.
 
-/// Memo key: `(run_id, max transcript mtime in epoch millis)`. A transcript
-/// change bumps the mtime, so the key changes and the old entry is bypassed.
-type CostMemoKey = (String, i64);
+/// Memo key: `(run_id, max transcript mtime in epoch millis, price-table
+/// fingerprint)`. A transcript change bumps the mtime and a price change bumps the
+/// fingerprint, so either one changes the key and bypasses the old entry.
+///
+/// Consequence to know: [`COST_MEMO_CAP`] now holds several entries per Run across
+/// a table change. Overflow clears the whole map, which stays
+/// correctness-preserving by construction.
+type CostMemoKey = (String, i64, u64);
 /// The memoized value is exactly what [`compute_run_cost`] returns (`None` = no
 /// transcript dir), so a hit is byte-identical to a recompute.
 type CostMemoMap = HashMap<CostMemoKey, Option<CostStat>>;
@@ -343,20 +323,24 @@ pub fn max_transcript_mtime_millis(projects_root: &Path, repo_root: &Path, run_i
 }
 
 /// Memoized [`compute_run_cost`]: byte-identical result, cached on
-/// `(run_id, max transcript mtime)` (see the module memo above). Used only by
-/// the `/stats/cost` aggregate (period-bounded fan-out); `get_run`'s single-run
-/// path is deliberately left calling [`compute_run_cost`] directly so ADR-0022's
-/// per-read contract is unchanged.
+/// `(run_id, max transcript mtime, price fingerprint)` (see the module memo
+/// above). Used only by the `/stats/cost` aggregate (period-bounded fan-out);
+/// `get_run`'s single-run path is deliberately left calling [`compute_run_cost`]
+/// directly so ADR-0022's per-read contract is unchanged.
 pub fn compute_run_cost_cached(
     projects_root: &Path,
     repo_root: &Path,
     run_id: &str,
+    prices: &PriceTable,
 ) -> Option<CostStat> {
-    // Load-bearing: the SAME `projects_root` feeds the key (mtime) AND the value
-    // (aggregate). A mismatched root would desync the memo silently (#408 P1).
+    // Load-bearing twice over: the SAME `projects_root` feeds the key (mtime) AND
+    // the value (aggregate) — a mismatched root would desync the memo silently
+    // (#408 P1) — and the SAME table feeds the fingerprint AND the pricing, so a
+    // hit can never be a table the caller did not ask for (#427).
     let key = (
         run_id.to_string(),
         max_transcript_mtime_millis(projects_root, repo_root, run_id),
+        prices.fingerprint(),
     );
     {
         let guard = cost_memo().lock().unwrap_or_else(|e| e.into_inner());
@@ -364,7 +348,7 @@ pub fn compute_run_cost_cached(
             return hit.clone();
         }
     }
-    let value = compute_run_cost(projects_root, repo_root, run_id);
+    let value = compute_run_cost(projects_root, repo_root, run_id, prices);
     let mut guard = cost_memo().lock().unwrap_or_else(|e| e.into_inner());
     if guard.len() >= COST_MEMO_CAP {
         guard.clear();
@@ -378,58 +362,13 @@ mod tests {
     use super::*;
     use std::path::Path;
 
-    // --- strip_date_suffix ---
-
-    #[test]
-    fn strips_trailing_8_digit_date() {
-        assert_eq!(
-            strip_date_suffix("claude-sonnet-4-5-20250929"),
-            "claude-sonnet-4-5"
-        );
-        assert_eq!(
-            strip_date_suffix("claude-3-5-haiku-20241022"),
-            "claude-3-5-haiku"
-        );
-    }
-
-    #[test]
-    fn leaves_version_only_id_untouched() {
-        assert_eq!(strip_date_suffix("claude-opus-4-8"), "claude-opus-4-8");
-        // A short numeric tail (not 8 digits) is not a date suffix.
-        assert_eq!(strip_date_suffix("claude-opus-4-8"), "claude-opus-4-8");
-    }
-
-    // --- price_for ---
-
-    #[test]
-    fn prices_known_models() {
-        assert_eq!(price_for("claude-opus-4-8"), Some((5.0, 25.0)));
-        assert_eq!(price_for("claude-sonnet-4-5"), Some((3.0, 15.0)));
-        assert_eq!(price_for("claude-haiku-4-5"), Some((1.0, 5.0)));
-    }
-
-    #[test]
-    fn opus_4_1_and_4_0_are_not_collapsed_with_4_5_plus() {
-        // The single most error-prone row: same "opus-4" prefix, different price.
-        assert_eq!(price_for("claude-opus-4-1"), Some((15.0, 75.0)));
-        assert_eq!(price_for("claude-opus-4-0"), Some((15.0, 75.0)));
-        assert_ne!(price_for("claude-opus-4-1"), price_for("claude-opus-4-8"));
-    }
-
-    #[test]
-    fn dated_id_resolves_to_family_price() {
-        assert_eq!(price_for("claude-sonnet-4-5-20250929"), Some((3.0, 15.0)));
-    }
-
-    #[test]
-    fn synthetic_is_zero_not_unknown() {
-        assert_eq!(price_for("<synthetic>"), Some((0.0, 0.0)));
-    }
-
-    #[test]
-    fn unknown_model_is_none() {
-        assert_eq!(price_for("gpt-9"), None);
-        assert_eq!(price_for("claude-opus-9-9"), None);
+    // `strip_date_suffix` and the whole `price_for` family moved to
+    // `price_table.rs` with #427, and their tests moved with them. What stays here
+    // is everything that is about *transcripts*, not about *prices* — every case
+    // below now pins the EMBEDDED tier explicitly via `PriceTable::builtin()`, so a
+    // stray `~/.pdo/prices/` on a dev machine can never turn this module red.
+    fn builtin() -> PriceTable {
+        PriceTable::builtin()
     }
 
     // --- line_cost ---
@@ -541,7 +480,7 @@ mod tests {
             line(Some("m1"), Some("r1"), "claude-opus-4-8", 1_000_000), // dup
             line(Some("m2"), Some("r2"), "claude-opus-4-8", 1_000_000),
         ];
-        let c = aggregate(lines.into_iter());
+        let c = aggregate(lines.into_iter(), &builtin());
         // 2 distinct × (1M input × $5 / 1M) = $5 + $5 = $10 (dup excluded).
         assert!((c.usd - 10.0).abs() < 1e-9, "usd = {}", c.usd);
         assert!(!c.partial);
@@ -553,7 +492,7 @@ mod tests {
             line(None, None, "claude-opus-4-8", 1_000_000),
             line(None, None, "claude-opus-4-8", 1_000_000),
         ];
-        let c = aggregate(lines.into_iter());
+        let c = aggregate(lines.into_iter(), &builtin());
         assert!((c.usd - 10.0).abs() < 1e-9, "usd = {}", c.usd);
     }
 
@@ -563,7 +502,7 @@ mod tests {
             line(Some("m1"), Some("r1"), "claude-opus-4-8", 1_000_000),
             line(Some("m2"), Some("r2"), "some-future-model", 1_000_000),
         ];
-        let c = aggregate(lines.into_iter());
+        let c = aggregate(lines.into_iter(), &builtin());
         // Only the priced line contributes; the unknown one flags partial + $0.
         assert!((c.usd - 5.0).abs() < 1e-9, "usd = {}", c.usd);
         assert!(c.partial);
@@ -572,7 +511,7 @@ mod tests {
     #[test]
     fn aggregate_synthetic_does_not_flip_partial() {
         let lines = vec![line(Some("m1"), Some("r1"), "<synthetic>", 1_000_000)];
-        let c = aggregate(lines.into_iter());
+        let c = aggregate(lines.into_iter(), &builtin());
         assert_eq!(c.usd, 0.0);
         assert!(!c.partial);
     }
@@ -605,7 +544,7 @@ mod tests {
         // l1 replayed (same msg_1, req_1) → deduped.
         std::fs::write(proj.join("s.jsonl"), format!("{l1}\n{l1}\n{l2}\n")).unwrap();
 
-        let cost = compute_run_cost(&projects, repo.path(), run_id).unwrap();
+        let cost = compute_run_cost(&projects, repo.path(), run_id, &builtin()).unwrap();
         // (1000*5 + 500*25)/1e6 + (2000*5 + 1000*25)/1e6 = 0.0175 + 0.035 = 0.0525
         assert!((cost.usd - 0.0525).abs() < 1e-9, "usd = {}", cost.usd);
         assert!(!cost.partial);
@@ -645,7 +584,7 @@ mod tests {
         )
         .unwrap();
 
-        let cost = compute_run_cost(&projects, repo.path(), run_id).unwrap();
+        let cost = compute_run_cost(&projects, repo.path(), run_id, &builtin()).unwrap();
         // 1M input × $5/MTok, twice (main + subagent) = $10.
         assert!((cost.usd - 10.0).abs() < 1e-9, "usd = {}", cost.usd);
     }
@@ -656,7 +595,7 @@ mod tests {
         let projects = home.path().join(".claude").join("projects");
         std::fs::create_dir_all(&projects).unwrap();
         let repo = tempfile::tempdir().unwrap();
-        assert!(compute_run_cost(&projects, repo.path(), "no-such-run").is_none());
+        assert!(compute_run_cost(&projects, repo.path(), "no-such-run", &builtin()).is_none());
     }
 
     // --- compute_run_cost_cached / memo (#377) ---
@@ -689,8 +628,8 @@ mod tests {
             run_id,
             &assistant("m1", "r1", "claude-opus-4-8", 1_000_000, 0),
         );
-        let direct = compute_run_cost(&projects, repo.path(), run_id);
-        let cached = compute_run_cost_cached(&projects, repo.path(), run_id);
+        let direct = compute_run_cost(&projects, repo.path(), run_id, &builtin());
+        let cached = compute_run_cost_cached(&projects, repo.path(), run_id, &builtin());
         assert_eq!(direct, cached);
         assert!((cached.unwrap().usd - 5.0).abs() < 1e-9);
     }
@@ -711,7 +650,7 @@ mod tests {
             filetime::FileTime::from_last_modification_time(&std::fs::metadata(&file).unwrap());
 
         // First call: memoize $5 under (run_id, mtime).
-        let first = compute_run_cost_cached(&projects, repo.path(), run_id).unwrap();
+        let first = compute_run_cost_cached(&projects, repo.path(), run_id, &builtin()).unwrap();
         assert!((first.usd - 5.0).abs() < 1e-9);
 
         // Rewrite with a DIFFERENT cost ($10) but force the mtime back — the key
@@ -725,12 +664,69 @@ mod tests {
         )
         .unwrap();
         filetime::set_file_mtime(&file, orig).unwrap();
-        let hit = compute_run_cost_cached(&projects, repo.path(), run_id).unwrap();
+        let hit = compute_run_cost_cached(&projects, repo.path(), run_id, &builtin()).unwrap();
         assert!((hit.usd - 5.0).abs() < 1e-9, "memo hit should re-serve $5");
         // But the uncached path sees the new content ($10) — proving the file
         // really changed and the hit above was the cache, not a recompute.
-        let direct = compute_run_cost(&projects, repo.path(), run_id).unwrap();
+        let direct = compute_run_cost(&projects, repo.path(), run_id, &builtin()).unwrap();
         assert!((direct.usd - 10.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn cached_recomputes_when_only_the_price_table_changes() {
+        // THE #427 regression test. A price sync bumps NO transcript mtime, so under
+        // the old two-part key `/stats/cost` would re-serve pre-sync dollars until
+        // the daemon restarted while `GET /runs/:id` showed the new ones — two
+        // surfaces contradicting each other on a finished Run, which is exactly the
+        // Run a sync exists to repair. Delete the third key component and this fails.
+        let home = tempfile::tempdir().unwrap();
+        let projects = home.path().join(".claude").join("projects");
+        let repo = tempfile::tempdir().unwrap();
+        let run_id = "memo-prices";
+        let file = seed_transcript(
+            &projects,
+            repo.path(),
+            run_id,
+            // A model NO tier prices out of the box → $0 + partial, the very symptom.
+            &assistant("m1", "r1", "claude-fable-5", 1_000_000, 0),
+        );
+        let mtime_before =
+            filetime::FileTime::from_last_modification_time(&std::fs::metadata(&file).unwrap());
+
+        let unpriced = compute_run_cost_cached(&projects, repo.path(), run_id, &builtin()).unwrap();
+        assert_eq!(unpriced.usd, 0.0);
+        assert!(unpriced.partial, "an unknown model flags partial");
+
+        // Now price it — a DIFFERENT table (different fingerprint), same transcript.
+        let home2 = tempfile::tempdir().unwrap();
+        let (manual, _) = crate::price_table::PriceTable::paths(home2.path());
+        std::fs::create_dir_all(manual.parent().unwrap()).unwrap();
+        std::fs::write(
+            &manual,
+            "models:\n  claude-fable-5: { input: 10.0, output: 50.0 }\n",
+        )
+        .unwrap();
+        let synced = crate::price_table::PriceTable::load(home2.path());
+        assert_ne!(synced.fingerprint(), builtin().fingerprint());
+
+        // The transcript's mtime is untouched — only the table moved.
+        assert_eq!(
+            filetime::FileTime::from_last_modification_time(&std::fs::metadata(&file).unwrap()),
+            mtime_before
+        );
+
+        let repriced = compute_run_cost_cached(&projects, repo.path(), run_id, &synced).unwrap();
+        assert!(
+            (repriced.usd - 10.0).abs() < 1e-9,
+            "the memo must MISS on a new price fingerprint, got ${}",
+            repriced.usd
+        );
+        assert!(!repriced.partial, "the model is priced now");
+
+        // And the old entry is still reachable under its own key — the sync does not
+        // (and need not) clear the memo.
+        let again = compute_run_cost_cached(&projects, repo.path(), run_id, &builtin()).unwrap();
+        assert_eq!(again.usd, 0.0);
     }
 
     #[test]
@@ -747,7 +743,7 @@ mod tests {
         );
         let orig =
             filetime::FileTime::from_last_modification_time(&std::fs::metadata(&file).unwrap());
-        let first = compute_run_cost_cached(&projects, repo.path(), run_id).unwrap();
+        let first = compute_run_cost_cached(&projects, repo.path(), run_id, &builtin()).unwrap();
         assert!((first.usd - 5.0).abs() < 1e-9);
 
         // New content AND a bumped mtime → new key → recompute picks up $10.
@@ -761,7 +757,8 @@ mod tests {
         .unwrap();
         let bumped = filetime::FileTime::from_unix_time(orig.unix_seconds() + 10, 0);
         filetime::set_file_mtime(&file, bumped).unwrap();
-        let recomputed = compute_run_cost_cached(&projects, repo.path(), run_id).unwrap();
+        let recomputed =
+            compute_run_cost_cached(&projects, repo.path(), run_id, &builtin()).unwrap();
         assert!(
             (recomputed.usd - 10.0).abs() < 1e-9,
             "a bumped mtime must invalidate the memo"
@@ -802,8 +799,9 @@ mod tests {
             &assistant("m2", "r2", "claude-opus-4-8", 2_000_000, 0),
         );
 
-        let host_cost = compute_run_cost_cached(&host, repo.path(), run_id).unwrap();
-        let staging_cost = compute_run_cost_cached(&staging, repo.path(), run_id).unwrap();
+        let host_cost = compute_run_cost_cached(&host, repo.path(), run_id, &builtin()).unwrap();
+        let staging_cost =
+            compute_run_cost_cached(&staging, repo.path(), run_id, &builtin()).unwrap();
         assert!((host_cost.usd - 5.0).abs() < 1e-9, "host root → $5");
         assert!(
             (staging_cost.usd - 10.0).abs() < 1e-9,
@@ -853,6 +851,6 @@ mod tests {
         .unwrap();
 
         // Querying "run-1" must NOT pick up "run-1x"'s transcript.
-        assert!(compute_run_cost(&projects, repo.path(), "run-1").is_none());
+        assert!(compute_run_cost(&projects, repo.path(), "run-1", &builtin()).is_none());
     }
 }

--- a/crates/pdo-daemon/src/stats.rs
+++ b/crates/pdo-daemon/src/stats.rs
@@ -409,6 +409,13 @@ pub async fn stats_cost(
             (home, sandbox)
         });
 
+    // #427: the three price tiers, resolved ONCE for the whole fold — never inside
+    // the per-Run loop. `home_root` is the HOST home even for a sandboxed Run:
+    // prices are an instance concept, and the #408 seam moves the TRANSCRIPT root,
+    // not this one. The table's fingerprint is the memo's third key component, so a
+    // sync is visible here without a daemon restart.
+    let prices = crate::price_table::PriceTable::load(&home_root);
+
     let mut cost_rows: Vec<CostRow> = Vec::with_capacity(rows.len());
     for (run_id, bucket, payload) in rows {
         let payload: serde_json::Value = payload
@@ -447,7 +454,8 @@ pub async fn stats_cost(
         let projects_root =
             crate::sandbox_run::transcripts_root(sandboxed, &run_id, &home_root, &sandbox_root);
 
-        let cost = crate::run_cost::compute_run_cost_cached(&projects_root, &repo_root, &run_id);
+        let cost =
+            crate::run_cost::compute_run_cost_cached(&projects_root, &repo_root, &run_id, &prices);
         cost_rows.push(CostRow {
             bucket,
             pipeline,

--- a/crates/pdo-daemon/tests/common/mod.rs
+++ b/crates/pdo-daemon/tests/common/mod.rs
@@ -71,6 +71,8 @@ impl TestDaemon {
                 service_health_override: None,
                 docker_cmd_override: None,
                 sandbox_home_override: None,
+                price_source_url: None,
+                price_refresh_at_boot: false,
             },
         )
         .await?;
@@ -113,6 +115,8 @@ impl TestDaemon {
                 // #407: stage the sandbox home UNDER the tempdir so the test never
                 // touches the real `$HOME` (`~/.pdo/sandbox`, `~/.claude`).
                 sandbox_home_override: Some(tempdir.path().to_path_buf()),
+                price_source_url: None,
+                price_refresh_at_boot: false,
             },
         )
         .await?;
@@ -157,6 +161,8 @@ impl TestDaemon {
                 service_health_override: None,
                 docker_cmd_override: None,
                 sandbox_home_override: Some(tempdir.path().to_path_buf()),
+                price_source_url: None,
+                price_refresh_at_boot: false,
             },
         )
         .await?;
@@ -204,6 +210,8 @@ impl TestDaemon {
                 service_health_override: None,
                 docker_cmd_override: Some(docker_cmd),
                 sandbox_home_override: Some(tempdir.path().to_path_buf()),
+                price_source_url: None,
+                price_refresh_at_boot: false,
             },
         )
         .await?;
@@ -240,6 +248,55 @@ impl TestDaemon {
                 service_health_override: None,
                 docker_cmd_override: None,
                 sandbox_home_override: None,
+                price_source_url: None,
+                price_refresh_at_boot: false,
+            },
+        )
+        .await?;
+
+        Ok(Self {
+            addr: handle.addr,
+            tempdir,
+            handle: Some(handle),
+        })
+    }
+
+    /// Spawn a daemon whose price source is `price_source_url` and whose boot
+    /// refresh is ARMED (#427).
+    ///
+    /// `sandbox_home_override` is the tempdir, so `~/.pdo/prices/` resolves under
+    /// the test's own dir — the price files are read from the HOST home root, so
+    /// without this the test would read (and the sync would WRITE) the real
+    /// `~/.pdo/prices/`.
+    ///
+    /// `price_refresh_at_boot: true` is deliberate and safe: the boot pass only
+    /// refreshes an EXISTING `fetched.json`, and a fresh tempdir has none — so a
+    /// test that plants no cache proves "zero request" against production's own
+    /// gate, and one that plants a stale cache drives the refresh through
+    /// [`pdo_daemon::DaemonHandle::run_price_refresh_tick`] rather than racing the
+    /// detached boot task.
+    pub async fn spawn_with_price_source<F>(setup: F, price_source_url: String) -> Result<Self>
+    where
+        F: FnOnce(&Path) -> Result<()>,
+    {
+        std::env::remove_var("PDO_NODE_ID");
+
+        let tempdir = tempfile::tempdir()?;
+        setup(tempdir.path())?;
+
+        let handle = serve_with_config(
+            SocketAddr::from(([127, 0, 0, 1], 0)),
+            tempdir.path().to_path_buf(),
+            DaemonConfig {
+                tmux_cmd_override: Some("exec true".to_string()),
+                panic_on_trigger_name: None,
+                panic_on_stale_sweep: false,
+                panic_on_spawn: false,
+                service_health_override: None,
+                docker_cmd_override: None,
+                sandbox_home_override: Some(tempdir.path().to_path_buf()),
+                price_source_url: Some(price_source_url),
+                price_refresh_at_boot: true,
             },
         )
         .await?;
@@ -295,6 +352,14 @@ impl TestDaemon {
     pub async fn run_boot_recovery_tick(&self) {
         if let Some(handle) = self.handle.as_ref() {
             handle.run_boot_recovery_tick().await;
+        }
+    }
+
+    /// Run the boot price-table refresh synchronously (test seam, #427). Production
+    /// spawns this DETACHED at startup; a test must drive it rather than race it.
+    pub async fn run_price_refresh_tick(&self) {
+        if let Some(handle) = self.handle.as_ref() {
+            handle.run_price_refresh_tick().await;
         }
     }
 

--- a/crates/pdo-daemon/tests/cost_prices.rs
+++ b/crates/pdo-daemon/tests/cost_prices.rs
@@ -1,0 +1,660 @@
+//! Layer 3 — the three-tier price table and its out-of-band fetch (#427, ADR-0034).
+//!
+//! Drives a **real daemon** whose price source is a **local fixture server**, so no
+//! test reaches models.dev, and whose sandbox home override puts `~/.pdo/prices/`
+//! under the test's own tempdir — without that, a sync would write the developer's
+//! real `~/.pdo/prices/fetched.json`.
+//!
+//! What is proven here rather than in unit tests (ADR-0004's règle d'or — an AC is
+//! closed at layer ≥ 3):
+//!   1. the route is REGISTERED (the anti-SPA gate: content-type, not just status);
+//!   2. a sync repairs a `$0` and `GET /runs/:id` shows it **in the same process**,
+//!      with no daemon restart;
+//!   3. an unreachable source, a drifted schema and an empty harvest each answer
+//!      502 and leave `fetched.json` **byte for byte** intact;
+//!   4. a second sync with nothing to change answers `noop: true` + `reason`;
+//!   5. two concurrent syncs → one 200, one 409;
+//!   6. the manual tier wins over the fetched one, and the report **says so**;
+//!   7. `GET /settings` names both paths even when neither file exists;
+//!   8. the boot refresh never CREATES a cache — no egress before the first click —
+//!      refreshes a stale one, and survives an unreachable source.
+
+mod common;
+
+use common::TestDaemon;
+use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+const PIPELINE_YAML: &str = r#"name: prices
+version: "1.0"
+prompt_required: false
+nodes:
+  - id: start
+    name: Start
+    type: start
+    outputs:
+      - { name: user_prompt, side: bottom }
+  - id: worker
+    name: Worker
+    type: doc-only
+    inputs:
+      - { name: in, side: top }
+    outputs:
+      - { name: out, side: bottom }
+  - id: end
+    name: End
+    type: end
+    inputs:
+      - { name: result, side: top }
+edges:
+  - source: { node: start, port: user_prompt }
+    target: { node: worker, port: in }
+  - source: { node: worker, port: out }
+    target: { node: end, port: result }
+"#;
+
+/// The real shape of `models.dev/api.json`, trimmed to what the normaliser reads.
+/// Three of these rows are the models #427 measured as unpriced ($0 on ~30 % of
+/// the corpus); `eu.anthropic` is here to prove regional prices are ignored.
+const MODELS_DEV: &str = r#"{
+  "anthropic": { "models": {
+    "claude-opus-4-8":   { "id": "claude-opus-4-8",   "cost": { "input": 5,  "output": 25 } },
+    "claude-opus-5":     { "id": "claude-opus-5",     "cost": { "input": 5,  "output": 25 } },
+    "claude-sonnet-5":   { "id": "claude-sonnet-5",   "cost": { "input": 2,  "output": 10 } },
+    "claude-fable-5":    { "id": "claude-fable-5",    "cost": { "input": 10, "output": 50 } },
+    "claude-haiku-4-5-20251001": { "id": "claude-haiku-4-5-20251001", "cost": { "input": 1, "output": 5 } }
+  } },
+  "eu.anthropic": { "models": {
+    "eu.anthropic.claude-opus-5": { "id": "claude-opus-5", "cost": { "input": 5.5, "output": 27.5 } }
+  } }
+}"#;
+
+/// The same payload with one price moved, so a second sync has something to write.
+const MODELS_DEV_BUMPED: &str = r#"{
+  "anthropic": { "models": {
+    "claude-opus-5": { "id": "claude-opus-5", "cost": { "input": 6, "output": 30 } }
+  } }
+}"#;
+
+// --- the fixture source ------------------------------------------------------
+
+/// A local price source. Counts its hits, so a test can assert **zero requests**
+/// — the only honest way to prove "no egress before the first click".
+struct Fixture {
+    addr: SocketAddr,
+    hits: Arc<AtomicUsize>,
+    _task: tokio::task::JoinHandle<()>,
+}
+
+impl Fixture {
+    fn url(&self) -> String {
+        format!("http://{}/api.json", self.addr)
+    }
+    fn hits(&self) -> usize {
+        self.hits.load(Ordering::SeqCst)
+    }
+}
+
+/// Serve `body` at `/api.json` on an ephemeral loopback port. Uses axum directly
+/// (already a dependency; the crate has neither wiremock nor httpmock).
+async fn spawn_fixture(body: &'static str) -> Fixture {
+    let hits = Arc::new(AtomicUsize::new(0));
+    let counter = hits.clone();
+    let app = axum::Router::new().route(
+        "/api.json",
+        axum::routing::get(move || {
+            let counter = counter.clone();
+            async move {
+                counter.fetch_add(1, Ordering::SeqCst);
+                ([("content-type", "application/json")], body)
+            }
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let task = tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    Fixture {
+        addr,
+        hits,
+        _task: task,
+    }
+}
+
+// --- repo / run helpers ------------------------------------------------------
+
+fn tmux_available() -> bool {
+    Command::new("tmux")
+        .arg("-V")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn seed(repo: &Path) -> anyhow::Result<()> {
+    let pipelines = repo.join(".pdo").join("pipelines");
+    std::fs::create_dir_all(&pipelines)?;
+    std::fs::write(pipelines.join("prices.yaml"), PIPELINE_YAML)?;
+    let run = |args: &[&str]| -> anyhow::Result<()> {
+        let out = Command::new("git").args(args).current_dir(repo).output()?;
+        anyhow::ensure!(out.status.success(), "git {args:?} failed");
+        Ok(())
+    };
+    run(&["init", "-q", "-b", "main"])?;
+    run(&["config", "user.email", "t@example.com"])?;
+    run(&["config", "user.name", "Test"])?;
+    run(&["config", "commit.gpgsign", "false"])?;
+    std::fs::write(repo.join(".gitignore"), ".pdo/runs/\n")?;
+    run(&["add", "."])?;
+    run(&["commit", "-q", "-m", "init"])?;
+    Ok(())
+}
+
+/// `<home>/.pdo/prices/{models.yaml, fetched.json}` — the same path arithmetic
+/// `price_table::paths` does, restated here so the test pins the CONTRACT rather
+/// than calling the code under test.
+fn manual_path(daemon: &TestDaemon) -> PathBuf {
+    daemon.repo_root().join(".pdo/prices/models.yaml")
+}
+fn fetched_path(daemon: &TestDaemon) -> PathBuf {
+    daemon.repo_root().join(".pdo/prices/fetched.json")
+}
+
+async fn sync(daemon: &TestDaemon) -> reqwest::Response {
+    reqwest::Client::new()
+        .post(format!("{}/settings/cost-prices/sync", daemon.url()))
+        .send()
+        .await
+        .unwrap()
+}
+
+fn content_type(resp: &reqwest::Response) -> String {
+    resp.headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+        .to_string()
+}
+
+async fn settings(daemon: &TestDaemon) -> serde_json::Value {
+    reqwest::get(format!("{}/settings", daemon.url()))
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap()
+}
+
+async fn get_run(daemon: &TestDaemon, run_id: &str) -> serde_json::Value {
+    reqwest::get(format!("{}/runs/{run_id}", daemon.url()))
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap()
+}
+
+async fn start_run(daemon: &TestDaemon) -> String {
+    let resp = reqwest::Client::new()
+        .post(format!("{}/runs", daemon.url()))
+        .json(&serde_json::json!({
+            "pipeline": "prices",
+            "input": "hello",
+            // #470: the target repo is required at the create boundary (ADR-0033).
+            "target_repo": daemon.target_repo(),
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 201, "POST /runs should create the run");
+    resp.json::<serde_json::Value>().await.unwrap()["run_id"]
+        .as_str()
+        .unwrap()
+        .to_string()
+}
+
+/// Plant a transcript for `run_id`'s worktree cwd under the host `~/.claude`
+/// (the tempdir home override), priced against `model`.
+fn plant_transcript(daemon: &TestDaemon, run_id: &str, model: &str, input: u64) {
+    let worktree = daemon
+        .repo_root()
+        .join(".pdo/runs")
+        .join(run_id)
+        .join("worktree");
+    let enc = pdo_daemon::stale_detector::encode_working_dir(&worktree);
+    let proj = daemon.repo_root().join(".claude/projects").join(enc);
+    std::fs::create_dir_all(&proj).unwrap();
+    std::fs::write(
+        proj.join("s.jsonl"),
+        format!(
+            "{{\"type\":\"assistant\",\"requestId\":\"r1\",\"message\":{{\"id\":\"m1\",\
+             \"model\":\"{model}\",\"usage\":{{\"input_tokens\":{input},\"output_tokens\":0}}}}}}\n"
+        ),
+    )
+    .unwrap();
+}
+
+/// Back-date a `fetched.json`'s `fetched_at` by `hours`, leaving the rest intact.
+fn age_fetched_at(path: &Path, hours: i64) {
+    let mut doc: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap();
+    let then = chrono::Utc::now() - chrono::Duration::hours(hours);
+    doc["fetched_at"] = serde_json::json!(then.to_rfc3339_opts(chrono::SecondsFormat::Secs, true));
+    std::fs::write(path, serde_json::to_vec_pretty(&doc).unwrap()).unwrap();
+}
+
+// --- 1. the route exists, and the anti-SPA gate ------------------------------
+
+#[tokio::test]
+async fn sync_is_registered_and_answers_json() {
+    // THE ANTI-SPA GATE (`tests/fs_browse.rs:234-249`). `static_handler` serves
+    // index.html for every unmatched path AND every method, so a forgotten
+    // `.route(...)` answers 200 + text/html and a status-only assertion goes green.
+    let fixture = spawn_fixture(MODELS_DEV).await;
+    let daemon = TestDaemon::spawn_with_price_source(seed, fixture.url())
+        .await
+        .unwrap();
+
+    let resp = sync(&daemon).await;
+    assert_eq!(resp.status(), 200);
+    let ct = content_type(&resp);
+    assert!(
+        ct.starts_with("application/json"),
+        "route must be registered — the SPA fallback would answer text/html, got {ct}"
+    );
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["ok"], true);
+    assert_eq!(body["source"], fixture.url());
+
+    // The three models #427 measured as unpriced are now priced.
+    let added: Vec<String> = serde_json::from_value(body["added"].clone()).unwrap();
+    for k in ["claude-opus-5", "claude-sonnet-5", "claude-fable-5"] {
+        assert!(added.contains(&k.to_string()), "added = {added:?}");
+    }
+    // `claude-opus-4-8` was ALREADY priced by the embedded floor at the same price →
+    // unchanged, not added. Merge by key, never replacement.
+    assert!(!added.contains(&"claude-opus-4-8".to_string()));
+    // The dated source id landed de-dated.
+    assert!(
+        added.contains(&"claude-haiku-4-5".to_string()) || body["unchanged"].as_u64() > Some(0)
+    );
+
+    assert!(
+        fetched_path(&daemon).exists(),
+        "fetched.json must be written"
+    );
+    let doc: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(fetched_path(&daemon)).unwrap()).unwrap();
+    assert_eq!(doc["schema"], "prices-v1");
+    assert_eq!(doc["models"]["claude-fable-5"]["input"], 10.0);
+    // Regional prices must not have leaked in (+10 % on eu.anthropic).
+    assert_eq!(doc["models"]["claude-opus-5"]["input"], 5.0);
+    assert_eq!(fixture.hits(), 1);
+}
+
+// --- 2. the repair is visible in the SAME process ----------------------------
+
+#[tokio::test]
+async fn a_sync_reprices_a_live_run_without_restarting_the_daemon() {
+    if !tmux_available() {
+        eprintln!("tmux not on PATH — skipping");
+        return;
+    }
+    let fixture = spawn_fixture(MODELS_DEV).await;
+    let daemon = TestDaemon::spawn_with_price_source(seed, fixture.url())
+        .await
+        .unwrap();
+    let run_id = start_run(&daemon).await;
+
+    // A transcript on a model NO tier prices out of the box: 1 MTok of fable-5.
+    plant_transcript(&daemon, &run_id, "claude-fable-5", 1_000_000);
+
+    let before = get_run(&daemon, &run_id).await;
+    assert_eq!(
+        before["cost"]["usd"].as_f64(),
+        Some(0.0),
+        "an unpriced model contributes $0: {}",
+        before["cost"]
+    );
+    assert_eq!(
+        before["cost"]["partial"], true,
+        "and flips the lower-bound flag"
+    );
+
+    assert_eq!(sync(&daemon).await.status(), 200);
+
+    // Same process, same PID, no restart — just the next read.
+    let after = get_run(&daemon, &run_id).await;
+    let usd = after["cost"]["usd"].as_f64().unwrap_or(-1.0);
+    assert!(
+        (usd - 10.0).abs() < 1e-9,
+        "1 MTok of claude-fable-5 at $10/MTok = $10 after the sync, got {usd} ({})",
+        after["cost"]
+    );
+    assert_eq!(
+        after["cost"]["partial"], false,
+        "nothing is unpriced any more"
+    );
+}
+
+// --- 3. every failure mode leaves the last known table intact ----------------
+
+#[tokio::test]
+async fn a_dead_port_answers_502_naming_the_url() {
+    // 127.0.0.1:9 (discard) is reserved and never bound in this environment: a
+    // refused connection, so the assertion is fast and not a timeout.
+    let dead = "http://127.0.0.1:9/api.json".to_string();
+    let daemon = TestDaemon::spawn_with_price_source(seed, dead.clone())
+        .await
+        .unwrap();
+
+    let resp = sync(&daemon).await;
+    assert_eq!(resp.status(), 502, "a network cut is not a daemon defect");
+    let body: serde_json::Value = resp.json().await.unwrap();
+    let err = body["error"].as_str().unwrap_or_default();
+    assert!(err.contains(&dead), "the error must NAME the source: {err}");
+    assert!(
+        !fetched_path(&daemon).exists(),
+        "a failed fetch must write nothing at all"
+    );
+}
+
+#[tokio::test]
+async fn an_empty_harvest_answers_502_and_leaves_the_table_byte_identical() {
+    // The one path by which this feature could DESTROY something: an upstream
+    // schema drift writing an empty file over the last known table.
+    let good = spawn_fixture(MODELS_DEV).await;
+    let daemon = TestDaemon::spawn_with_price_source(seed, good.url())
+        .await
+        .unwrap();
+    assert_eq!(sync(&daemon).await.status(), 200);
+    let before = std::fs::read(fetched_path(&daemon)).unwrap();
+
+    // Now stand up a DRIFTED source and point a second daemon at it, sharing
+    // nothing but the file we hand-copy in — the cleanest way to prove the guard
+    // without mutating a live daemon's config.
+    let drifted = spawn_fixture("{}").await;
+    let daemon2 = TestDaemon::spawn_with_price_source(seed, drifted.url())
+        .await
+        .unwrap();
+    std::fs::create_dir_all(fetched_path(&daemon2).parent().unwrap()).unwrap();
+    std::fs::write(fetched_path(&daemon2), &before).unwrap();
+
+    let resp = sync(&daemon2).await;
+    assert_eq!(resp.status(), 502);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert!(
+        body["error"]
+            .as_str()
+            .unwrap_or_default()
+            .contains(&drifted.url()),
+        "the error must name the source: {body}"
+    );
+    assert_eq!(
+        std::fs::read(fetched_path(&daemon2)).unwrap(),
+        before,
+        "byte for byte — an empty harvest must never destroy the last known table"
+    );
+    // And the table still prices what it used to.
+    let s = settings(&daemon2).await;
+    assert_eq!(s["price_table"]["fetched_rows"].as_u64(), Some(5));
+}
+
+// --- 4. a second sync with nothing to change ---------------------------------
+
+#[tokio::test]
+async fn a_second_sync_with_nothing_to_change_is_an_explicit_noop() {
+    // ADR-0025: never a blind `{ok:true}`.
+    let fixture = spawn_fixture(MODELS_DEV).await;
+    let daemon = TestDaemon::spawn_with_price_source(seed, fixture.url())
+        .await
+        .unwrap();
+    assert_eq!(sync(&daemon).await.status(), 200);
+    let first = std::fs::read(fetched_path(&daemon)).unwrap();
+
+    let resp = sync(&daemon).await;
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["noop"], true);
+    assert!(
+        body["reason"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("up to date"),
+        "a noop must SAY why: {body}"
+    );
+    assert_eq!(
+        std::fs::read(fetched_path(&daemon)).unwrap(),
+        first,
+        "a noop rewrites nothing — which also keeps the cost memo warm"
+    );
+    assert_eq!(
+        fixture.hits(),
+        2,
+        "it did ask; it just had nothing to write"
+    );
+}
+
+// --- 5. concurrency ----------------------------------------------------------
+
+#[tokio::test]
+async fn two_concurrent_syncs_yield_one_200_and_one_409() {
+    let fixture = spawn_fixture(MODELS_DEV).await;
+    let daemon = TestDaemon::spawn_with_price_source(seed, fixture.url())
+        .await
+        .unwrap();
+
+    let (a, b) = tokio::join!(sync(&daemon), sync(&daemon));
+    let mut codes = [a.status().as_u16(), b.status().as_u16()];
+    codes.sort_unstable();
+    assert_eq!(
+        codes,
+        [200, 409],
+        "a second click brings nothing, and ADR-0025 wants us to say so"
+    );
+}
+
+// --- 6. the manual tier wins, and the report says so ------------------------
+
+#[tokio::test]
+async fn the_manual_tier_shadows_the_fetched_one_and_the_report_names_it() {
+    let fixture = spawn_fixture(MODELS_DEV).await;
+    let daemon = TestDaemon::spawn_with_price_source(seed, fixture.url())
+        .await
+        .unwrap();
+    // An enterprise discount, written by hand.
+    std::fs::create_dir_all(manual_path(&daemon).parent().unwrap()).unwrap();
+    std::fs::write(
+        manual_path(&daemon),
+        "models:\n  claude-opus-5: { input: 1.0, output: 2.0 }\n",
+    )
+    .unwrap();
+
+    let resp = sync(&daemon).await;
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    let shadowed: Vec<String> = serde_json::from_value(body["shadowed_by_manual"].clone()).unwrap();
+    assert!(
+        shadowed.contains(&"claude-opus-5".to_string()),
+        "a sync must never silently erase a hand correction: {body}"
+    );
+
+    // And the hand price is what actually applies.
+    let s = settings(&daemon).await;
+    let manual_keys: Vec<String> =
+        serde_json::from_value(s["price_table"]["manual_keys"].clone()).unwrap();
+    assert_eq!(manual_keys, ["claude-opus-5"]);
+
+    // PDO never writes the manual file — one writer per file (ADR-0034).
+    assert_eq!(
+        std::fs::read_to_string(manual_path(&daemon)).unwrap(),
+        "models:\n  claude-opus-5: { input: 1.0, output: 2.0 }\n",
+        "the sync must leave the human's file byte for byte"
+    );
+}
+
+// --- 7. discoverability: the paths are named even when absent ----------------
+
+#[tokio::test]
+async fn settings_names_both_price_paths_even_when_no_file_exists() {
+    // Nothing is ever seeded (that would freeze a snapshot, ADR-0031 §2), so
+    // naming the paths IS the entire discoverability story.
+    let fixture = spawn_fixture(MODELS_DEV).await;
+    let daemon = TestDaemon::spawn_with_price_source(seed, fixture.url())
+        .await
+        .unwrap();
+
+    let s = settings(&daemon).await;
+    let pt = &s["price_table"];
+    assert_eq!(
+        pt["manual_path"].as_str(),
+        Some(manual_path(&daemon).to_string_lossy().as_ref())
+    );
+    assert_eq!(
+        pt["fetched_path"].as_str(),
+        Some(fetched_path(&daemon).to_string_lossy().as_ref())
+    );
+    assert!(!manual_path(&daemon).exists() && !fetched_path(&daemon).exists());
+    // Absent is SILENT: no reason, no vintage, no rows.
+    assert_eq!(pt["reason"], serde_json::Value::Null);
+    assert_eq!(pt["fetched_at"], serde_json::Value::Null);
+    assert_eq!(pt["fetched_rows"].as_u64(), Some(0));
+    assert_eq!(fixture.hits(), 0, "reading settings must not egress");
+}
+
+#[tokio::test]
+async fn a_refused_row_is_inert_and_reported_but_never_fails_a_read() {
+    let fixture = spawn_fixture(MODELS_DEV).await;
+    let daemon = TestDaemon::spawn_with_price_source(seed, fixture.url())
+        .await
+        .unwrap();
+    std::fs::create_dir_all(manual_path(&daemon).parent().unwrap()).unwrap();
+    // A dated key: the single most likely mistake, since both natural sources (the
+    // pricing page and the transcripts) give the dated form.
+    std::fs::write(
+        manual_path(&daemon),
+        "models:\n  claude-opus-5-20260501: { input: 5.0, output: 25.0 }\n",
+    )
+    .unwrap();
+
+    let s = settings(&daemon).await;
+    let reason = s["price_table"]["reason"].as_str().unwrap_or_default();
+    assert!(
+        reason.contains("claude-opus-5"),
+        "the refusal must be readable in the UI, and print the correct form: {reason}"
+    );
+    assert_eq!(
+        s["price_table"]["manual_keys"].as_array().map(Vec::len),
+        Some(0),
+        "a refused row prices nothing"
+    );
+
+    // And a cost read still answers 200 — a bad price file can never fail one.
+    let resp = reqwest::get(format!(
+        "{}/stats/cost?from=1970-01-01T00:00:00Z&to=2100-01-01T00:00:00Z&bucket=day",
+        daemon.url()
+    ))
+    .await
+    .unwrap();
+    assert_eq!(resp.status(), 200);
+}
+
+// --- 8. the boot refresh: refreshes, never seeds -----------------------------
+
+#[tokio::test]
+async fn the_boot_refresh_never_creates_a_cache() {
+    // ADR-0034: no egress before the user has clicked once. The click IS the
+    // consent, so an instance that has never synced must never reach the network —
+    // even with the flag armed, which `spawn_with_price_source` sets to `true`.
+    let fixture = spawn_fixture(MODELS_DEV).await;
+    let daemon = TestDaemon::spawn_with_price_source(seed, fixture.url())
+        .await
+        .unwrap();
+    assert!(!fetched_path(&daemon).exists());
+
+    daemon.run_price_refresh_tick().await;
+
+    assert_eq!(
+        fixture.hits(),
+        0,
+        "an absent cache must produce ZERO requests"
+    );
+    assert!(!fetched_path(&daemon).exists(), "and seed nothing");
+}
+
+#[tokio::test]
+async fn the_boot_refresh_is_a_noop_on_a_fresh_cache() {
+    let fixture = spawn_fixture(MODELS_DEV).await;
+    let daemon = TestDaemon::spawn_with_price_source(seed, fixture.url())
+        .await
+        .unwrap();
+    assert_eq!(sync(&daemon).await.status(), 200);
+    assert_eq!(fixture.hits(), 1);
+
+    daemon.run_price_refresh_tick().await;
+    assert_eq!(fixture.hits(), 1, "a cache under 24 h old is left alone");
+}
+
+#[tokio::test]
+async fn the_boot_refresh_refetches_a_stale_cache_and_rewrites_it() {
+    let fixture = spawn_fixture(MODELS_DEV_BUMPED).await;
+    let daemon = TestDaemon::spawn_with_price_source(seed, fixture.url())
+        .await
+        .unwrap();
+    assert_eq!(sync(&daemon).await.status(), 200);
+    assert_eq!(fixture.hits(), 1);
+
+    // Hand-write a table the refresh will have to replace, and age it past 24 h.
+    let path = fetched_path(&daemon);
+    let mut doc: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+    doc["models"]["claude-opus-5"]["input"] = serde_json::json!(1.0);
+    std::fs::write(&path, serde_json::to_vec_pretty(&doc).unwrap()).unwrap();
+    age_fetched_at(&path, 25);
+
+    daemon.run_price_refresh_tick().await;
+
+    assert_eq!(fixture.hits(), 2, "a cache over 24 h old is refreshed");
+    let after: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+    assert_eq!(
+        after["models"]["claude-opus-5"]["input"], 6.0,
+        "the refreshed table must be the source's: {after}"
+    );
+}
+
+#[tokio::test]
+async fn an_unreachable_source_at_boot_leaves_the_table_and_the_daemon_alive() {
+    // `boot_recovery.rs:161-168`'s regime: a warn, never fatal. A daemon restarted
+    // by systemd can legitimately come up before DNS is ready.
+    let good = spawn_fixture(MODELS_DEV).await;
+    let daemon = TestDaemon::spawn_with_price_source(seed, good.url())
+        .await
+        .unwrap();
+    assert_eq!(sync(&daemon).await.status(), 200);
+    let before = std::fs::read(fetched_path(&daemon)).unwrap();
+
+    // A second daemon whose source is dead, carrying the same stale cache.
+    let daemon2 = TestDaemon::spawn_with_price_source(seed, "http://127.0.0.1:9/api.json".into())
+        .await
+        .unwrap();
+    std::fs::create_dir_all(fetched_path(&daemon2).parent().unwrap()).unwrap();
+    std::fs::write(fetched_path(&daemon2), &before).unwrap();
+    age_fetched_at(&fetched_path(&daemon2), 25);
+    let stale = std::fs::read(fetched_path(&daemon2)).unwrap();
+
+    daemon2.run_price_refresh_tick().await;
+
+    assert_eq!(
+        std::fs::read(fetched_path(&daemon2)).unwrap(),
+        stale,
+        "the table survives an unreachable source, byte for byte"
+    );
+    // The daemon is still serving.
+    let s = settings(&daemon2).await;
+    assert_eq!(s["price_table"]["fetched_rows"].as_u64(), Some(5));
+}

--- a/crates/pdo-daemon/tests/log_level_default.rs
+++ b/crates/pdo-daemon/tests/log_level_default.rs
@@ -24,6 +24,12 @@ fn info_logs_emitted_when_rust_log_is_unset() {
         .args(["daemon", "--port", "0"])
         .env_remove("RUST_LOG")
         .env_remove("PDO_TMUX_CMD_OVERRIDE")
+        // #427: this harness runs the REAL binary, so it goes through
+        // `DaemonConfig::from_env()` where the boot price refresh defaults to armed.
+        // It would still make no request (a fresh tempdir has no `fetched.json`, and
+        // the boot pass refreshes rather than seeds), but a test must not depend on
+        // the network being irrelevant — it must not reach for it at all.
+        .env("PDO_PRICE_SYNC", "off")
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::piped())
         .spawn()

--- a/docs/adr/0022-estimated-cost-from-local-transcripts.md
+++ b/docs/adr/0022-estimated-cost-from-local-transcripts.md
@@ -71,7 +71,9 @@ persisté, et l'UI l'étiquette explicitement « est. ».
 
 ## Conséquences
 
-- **Positif.** Le coût est visible sans dépendance réseau ni binaire, byte-identique quand aucun
+- **Positif.** Le coût est visible sans dépendance binaire, et **son chemin de lecture est sans
+  dépendance réseau** (amendement #427 : le *remplissage* de la table peut sortir sur Internet, la
+  lecture jamais) ; byte-identique quand aucun
   transcript n'est trouvé (`None` → « — »). Il est **plus durable que LOC** : le cleanup supprime
   la branche (LOC → « — ») mais **pas** `~/.claude/projects/`, donc un Run **archivé** garde son
   coût — cohérent avec l'esprit d'ADR-0020.
@@ -97,11 +99,59 @@ redevient le défaut hôte. Un Run `off` lit **toujours** `~/.claude/projects/` 
 Le memo garde la **même** racine pour la clé (`max mtime`) et la valeur (agrégat), donc pas de désync.
 La dédup `(message.id, requestId)` reste la garantie anti-double-comptage, quelle que soit la racine.
 
+## Amendement — La table de prix a trois tiers et une source distante ; le `const` devient le plancher (#427)
+
+Voir **ADR-0034** pour le contrat d'egress complet et le recensement des sources. Ce qui est amendé
+ici, c'est la **puce 1** : « table de prix codée en dur (Rust `const`), pas de réseau » n'est plus
+la description du système. Ce qui **survit** intact : le coût reste une **estimation** (prix de
+liste, pas de facture), il reste **dérivé à la lecture**, et « à maintenir à la main » devient le
+**tier manuel** — plus littéralement maintenu à la main qu'un `const`, puisqu'il ne demande plus
+d'éditer du Rust, de bumper, de releaser et de lancer `make update`.
+
+- **Trois tiers, résolus par clé de famille** : `manuel → fetché → embarquée`.
+  `~/.pdo/prices/models.yaml` (écrit par l'humain seul) gagne sur `~/.pdo/prices/fetched.json`
+  (écrit par le daemon seul depuis `models.dev/api.json`, **hors du chemin de lecture**), qui gagne
+  sur `PRICES`. Les deux fichiers sont **absents par défaut** et rien n'est jamais seedé.
+- **Fusion par clé, jamais remplacement.** Une clé absente d'un tier garde ce que le tier suivant en
+  dit. Sous remplacement global, oublier `claude-opus-4-8` effacerait **79 941** lignes de
+  transcript sur ~116 200 — un bug de prix faux converti en blackout — et **gèlerait** la table
+  contre les releases futures.
+- **Le `const` est un plancher, pas une amorce.** `claude-opus-4-0`, `claude-sonnet-4-0` et
+  `claude-3-5-haiku` sont absentes de **toute** source distante examinée : le `const` en est le
+  **seul** tarificateur. Un test l'épingle.
+- **La clé du memo gagne un troisième composant** : `(run_id, mtime-max, empreinte de la table)`.
+  Sans lui, un sync ne bougeant aucun mtime de transcript, `GET /stats/cost` (mémoïsé) servirait
+  les anciens dollars **jusqu'au redémarrage** pendant que `GET /runs/:id` (non mémoïsé) dirait
+  vrai — deux surfaces qui se contredisent sur les Runs terminés, c'est-à-dire précisément ceux
+  qu'un sync existe pour réparer.
+- **Absent : silencieux ; présent mais rejeté : dit une fois.** Un fichier absent est l'état normal
+  de toute instance. Un fichier illisible, ou une ligne refusée (clé datée, sentinelle, prix négatif
+  ou non fini), devient **inerte** — la clé retombe sur le tier suivant, elle ne détruit pas
+  l'estimation — et le rejet est nommé **une fois** dans le journal et en `reason` sur
+  `GET /settings`. Un `fetched.json` dont le `schema` n'est pas `prices-v1` est **entièrement**
+  inerte.
+- **Le seam #408 déplace la racine des transcripts, pas celle des prix.** Les prix sont un concept
+  d'**instance** : même pour un Run sandboxé, la table se lit sous le home **hôte**.
+- **Deux limites assumées.** (1) Le **mode fast** est invisible : `claude-opus-5` et
+  `claude-opus-5-fast` s'écrivent du même id dans `message.model`, donc un nœud en mode fast est
+  sous-facturé ×2 et aucune normalisation ne peut le rattraper. (2) Éditer la table **retarife tous
+  les Runs historiques, archivés inclus** — conséquence directe du « dérivé à la lecture » ci-dessus.
+  Cela satisfait la contrainte « un Run archivé s'ouvre et se chiffre », mais le chiffre d'un Run
+  clos devient fonction d'un fichier modifiable, à assumer au titre de l'« Étiquetage honnête
+  (load-bearing) » ci-dessus.
+
 ## Alternatives rejetées
 
 - **Embarquer / shell-out `ccusage`** — dépendance binaire/Node + réseau ; daemon network-free.
+  *(re-motivé par #427 — le rejet **tient**, mais « réseau » n'y est plus discriminant. Le motif
+  survivant est la dépendance **binaire + Node**, et le fait que ccusage imposerait **sa** table
+  plutôt que la nôtre.)*
 - **Fetcher LiteLLM `model_prices_and_context_window.json`** (ce que fait ccusage) — réseau au
   build + retard amont sur les ids récents.
+  *(toujours rejeté après #427, et la distinction est load-bearing : fetcher **au build** fige la
+  table dans le binaire et **ramène** le couplage à la release qu'ADR-0034 supprime ; fetcher
+  **out-of-band vers un cache disque** ne le fait pas. LiteLLM reste l'adaptateur de repli
+  documenté si models.dev disparaît.)*
 - **Snapshot à la complétion (Shape B)** — aucun précédent, fige un Run vivant, sous-compte au
   `resume_run`.
 - **Figure autoritative / facture** — non atteignable localement (pas de `costUSD`, prix de liste
@@ -114,4 +164,12 @@ La dédup `(message.id, requestId)` reste la garantie anti-double-comptage, quel
   seulement sur une requête isolée > 200K input ; PDO tourne opus-4-8 (pas de surcharge).
 - **Prix d'intro daté de `claude-sonnet-5`** ($2/$10 jusqu'au 2026-08-31) — seulement si
   sonnet-5 commence à apparaître.
+  *(depuis #427, c'est **l'édition d'une ligne** dans `~/.pdo/prices/models.yaml` au 2026-08-31 —
+  ou rien du tout si un sync a tourné d'ici là. Aucune source ne porte de date d'effet, et la
+  dimension de date par ligne reste hors-scope : voir ADR-0034.)*
 - **Rafraîchissement de prix live (LiteLLM / models.dev)** — rejeté (daemon network-free).
+  *(levé par #427 — voir **ADR-0034** : le fetch est **out-of-band** et le chemin de lecture reste
+  strictement local. Le motif « daemon network-free » était déjà faux à l'écriture :
+  `service_unit.rs:49-50` déclare `After=network-online.target`, le daemon shelle les guards de
+  Trigger — `gh issue list` à chaque tick — et ADR-0030 fait un `docker pull`. Ce qui est vrai et
+  reste protégé est plus étroit : **un `GET /runs/:id` ne dépend pas d'Internet**.)*

--- a/docs/adr/0029-aggregated-stats-derive-and-index.md
+++ b/docs/adr/0029-aggregated-stats-derive-and-index.md
@@ -33,10 +33,15 @@ runs » est exactement ce fan-out interdit : mesuré à 2 502 transcripts / 1,1 
 
 ## Conséquences
 
-- **Positif.** Réactif (SQL indexé + memo), zéro dépendance réseau, aucune divergence possible avec
-  l'event log (source de vérité unique), le coût reste consultable pour un run archivé.
-- **Négatif / assumé.** Le memo vit en RAM (perdu au restart, reconstruit à la demande). La table de
-  prix reste à maintenir à la main (ADR-0022). « Sessions/période » compte les *démarrages* de
+- **Positif.** Réactif (SQL indexé + memo), **zéro dépendance réseau sur le chemin de lecture**
+  (#427 : le remplissage de la table de prix est out-of-band, la lecture reste deux `fs::read` et un
+  `const`), aucune divergence possible avec l'event log (source de vérité unique), le coût reste
+  consultable pour un run archivé.
+- **Négatif / assumé.** Le memo vit en RAM (perdu au restart, reconstruit à la demande) et sa clé est
+  `(run_id, mtime-max, empreinte de la table de prix)` — le troisième composant est arrivé avec #427,
+  sans lui un sync resterait invisible ici jusqu'au redémarrage alors que `GET /runs/:id` dirait vrai.
+  La table de prix se résout **`manuel → fetché → embarquée`**, le tier fetché étant alimenté hors du
+  chemin de lecture (ADR-0022 amendement #427, ADR-0034). « Sessions/période » compte les *démarrages* de
   session (`node_started`), re-spawns et laps de boucle inclus (cohérent avec la stat par-run).
 
 ## Alternatives rejetées

--- a/docs/adr/0034-out-of-band-price-fetch.md
+++ b/docs/adr/0034-out-of-band-price-fetch.md
@@ -1,0 +1,317 @@
+# La table de prix a une source distante, fetchée hors du chemin de lecture
+
+## Contexte
+
+ADR-0022 estime le coût d'un Run en multipliant les compteurs de tokens des transcripts locaux par une
+**table de prix codée en dur** (`run_cost.rs:48`, 11 lignes, source « page de prix Anthropic, fetched
+2026-07-06 »). Son premier point de décision motive ce choix par « pas de réseau », et son hors-scope
+rejette explicitement le « rafraîchissement de prix live (LiteLLM / models.dev) — rejeté (daemon
+network-free) ».
+
+Le motif ne tient plus, pour deux raisons distinctes.
+
+**1. La table dérive plus vite qu'elle ne se corrige.** Recensement du 2026-07-30 sur les
+2 189 transcripts de la machine de référence, champ `message.model` :
+
+| modèle | lignes | tarifé par le `const` ? |
+|---|---:|---|
+| `claude-opus-4-8` | 79 941 | oui |
+| **`claude-opus-5`** | **28 427** | **non → $0** |
+| **`claude-fable-5`** | **6 587** | **non → $0** |
+| `claude-haiku-4-5-20251001` | 591 | oui (dé-datage) |
+| **`claude-sonnet-5`** | **607** | **non → $0** |
+| `claude-opus-4-6` | 2 | oui |
+| `<synthetic>` | 86 | tarifé $0 exprès |
+
+**35 621 lignes sur ~116 200, soit ~30 %, ne sont pas tarifées** — le coût affiché est une borne basse
+sur près d'un tiers de la dépense, et les graphes de #377 s'en trouvent faux. Le modèle le plus **cher**
+de la liste, `claude-fable-5` à $10/$50, est celui que personne n'avait identifié : il n'est nommé dans
+aucune issue, parce que le produit ne le dit nulle part. Corriger la table exige aujourd'hui d'éditer du
+Rust, de bumper, de releaser, et de lancer `make update` sur le daemon de production — un chemin qui,
+de fait, n'est pas pris (le retard de version du daemon de production est structurel et récidivant, et
+`make update` ne peut pas être lancé depuis un nœud puisque sa dernière ligne redémarre le daemon qui
+porte le Run).
+
+**2. « Network-free » n'a jamais été littéral.** Trois egress préexistent, tous ratifiés :
+`service_unit.rs:49-50` déclare `After=network-online.target` / `Wants=network-online.target` sur
+l'unité du daemon ; le daemon shelle les guards de Trigger sous son propre environnement d'auth, et
+l'exemple canonique documenté est `gh issue list` (`CONTEXT.md:593,597`) — un appel à
+`api.github.com` avec credentials, à chaque tick cron ; et `sandbox_image.rs:320-332` fait un
+`docker pull` vers GHCR. Au-dessus de tout ça, chaque nœud est une session `claude` : le produit ne
+fonctionne pas hors ligne, et ADR-0004:16 l'assume.
+
+Ce qui était vrai et qui doit rester vrai est plus étroit que « pas de réseau » : **un `GET /runs/:id`
+ne doit pas dépendre d'Internet**.
+
+Le propriétaire a ratifié la réouverture sur l'issue #427 (2026-07-30) : « Je veux que la table soit
+remplie depuis le remote. L'idée étant que si demain il y a un nouveau modèle, alors la table l'embarque.
+Pour la remplir, soit appel au démarrage, soit bouton "sync coûts" depuis les stats. Il faut regarder
+les sources disponibles, si possible utiliser OpenRouter. »
+
+## Décision
+
+Le daemon peut sortir sur Internet, **hors du chemin de lecture uniquement**, pour remplir un cache de
+prix sur disque. La table de prix devient un empilement à trois tiers résolu **par clé de famille** :
+`manuel → fetché → embarquée`. La lecture reste strictement locale : deux `fs::read` et un `const`.
+
+```
+fetch out-of-band (bouton, ou rafraîchissement au démarrage)
+   → écrit ~/.pdo/prices/fetched.json
+       → le calcul de coût lit le disque   (manuel → fetché → embarquée, FUSION PAR CLÉ)
+```
+
+### Ce qu'on décide
+
+- **Trois tiers, deux fichiers, un seul écrivain par fichier.**
+  `~/.pdo/prices/models.yaml` est le tier **manuel** : l'humain l'écrit, PDO n'y touche **jamais** et
+  ne le seed jamais. `~/.pdo/prices/fetched.json` est le tier **fetché** : le daemon le réécrit
+  **intégralement** (tmp + `rename` dans le même répertoire, idiome de `sandbox_staging.rs:790`), et
+  personne d'autre. `const PRICES` reste le tier **embarqué**.
+  Deux formes ont été écartées. Un fichier unique réécrit par le sync **rejoue le défaut que l'issue
+  combat** — il effacerait une correction à la main. Un fichier à deux sections condamnerait le daemon
+  à réécrire partiellement le fichier que l'humain édite, alors que ce codebase a **zéro** précédent de
+  réécriture partielle sûre et deux précédents qui disent pourquoi : le `duplicate` de pipeline
+  réécrit le YAML « verbatim sauf la ligne `name:` de colonne 0, jamais re-sérialisé, pour préserver
+  clés top-level inconnues, commentaires et ordre des champs » (`CONTEXT.md:1611`), et
+  `sandbox_staging.rs:411` érige le **writer unique** en règle, rattachée par ADR-0031:282 à #447
+  « un fait, un propriétaire ». Deux fichiers font **disparaître** le problème au lieu de le résoudre.
+  C'est aussi la forme homomorphe à ADR-0015, où chaque tier a son propre stockage (SQLite / env du
+  process / `const`) : ajouter un tier, c'est ajouter un stockage, pas cohabiter dans celui d'un autre.
+
+- **La table embarquée est un plancher, jamais une amorce.** `claude-opus-4-0` ($15/$75),
+  `claude-sonnet-4-0` ($3/$15) et `claude-3-5-haiku` ($0.80/$4) sont dans le `const` et **absentes des
+  trois sources distantes examinées** — models.dev et LiteLLM les ont purgées de leur namespace
+  `anthropic`, OpenRouter a délisté 3.5-haiku tout court. Le `const` est donc le **seul tarificateur**
+  de ces familles, pas un jeu de données jetable qu'un sync remplacerait.
+
+- **Fusion par clé, jamais remplacement.** Une clé présente dans un tier gagne ; une clé absente garde
+  ce que le tier suivant en dit. Sous remplacement global, oublier `claude-opus-4-8` effacerait
+  **79 941** lignes sur ~116 200 : un bug de prix faux converti en blackout total. Et le fichier
+  **gèlerait** la table — une release ajoutant une ligne deviendrait invisible. Analogie maison :
+  ADR-0031 §2, « un profil est un **diff**, jamais un instantané ».
+
+- **models.dev est la source, et OpenRouter est rejeté.** `GET https://models.dev/api.json`, en ne
+  lisant que `root["anthropic"]["models"]`. Le critère décisif n'est ni la fraîcheur (les trois sources
+  ont publié `claude-opus-5` dans l'heure de sa sortie) ni la licence : c'est que **les clés de
+  models.dev sont déjà le vocabulaire de PDO** — l'id de l'API Anthropic, tirets compris — donc la
+  normalisation se réduit à un dé-datage, et le risque de *mauvais mapping* (bien pire qu'une ligne
+  manquante : il produit un nombre plausible et faux) tombe à zéro. Les prix y sont déjà en **$/MTok**
+  et en `number`, ce qui supprime la classe d'erreur du facteur 10⁶.
+  OpenRouter, suggéré par le propriétaire, a été mesuré et écarté : normaliser ses ids vers une clé de
+  famille produit **9 collisions à prix divergents** (`claude-opus-4-8` sort à la fois $2.5/$12.5,
+  $5/$25 et $10/$50 selon la variante `:batch` / `-fast` / alias), son `canonical_slug` est
+  inutilisable (l'ordre des mots s'inverse selon la génération — `claude-4.8-opus-20260528` mais
+  `claude-opus-5-20260723`), et il expose un SKU fantôme `anthropic/claude-opus-4.7-fast` à
+  **$30/$150** pour un mode que la doc Anthropic déclare indisponible sur ce modèle — un normalisateur
+  *last-wins* gonflerait opus-4-7 **×6**. models.dev et LiteLLM produisent **zéro** collision. En prime,
+  les CGU §7 d'OpenRouter interdisent de « scrape or copy any information on the Site or the Services »,
+  ce que fait littéralement un daemon qui persiste puis réaffiche des prix ; models.dev et LiteLLM sont
+  **MIT**.
+  **Anthropic n'expose pas ses prix** : `GET /v1/models` rend `id`, `capabilities`, `created_at`,
+  `display_name`, `max_input_tokens`, `max_tokens`, `type` — aucun champ tarifaire, et 401 sans clé. La
+  page de pricing reste le **juge d'appel**, pas une source machine.
+  **Une seule source, un seul parseur en v1.** L'URL est surchargeable, mais le parseur est de forme
+  models.dev : pointer l'URL sur LiteLLM produit une moisson vide, donc un refus explicite, pas un
+  silence.
+
+- **Le dé-datage est asymétrique, et c'est voulu.** Sur le tier **manuel**, une clé datée est
+  **refusée** en imprimant la forme correcte : stripper collapserait silencieusement deux lignes que
+  l'auteur voulait distinctes, et le refus enseigne. Sur le chemin **fetché**, l'identifiant est
+  **dé-daté** : la source expose des ids datés (`claude-opus-4-5-20251101`,
+  `claude-haiku-4-5-20251001`), les refuser jetterait `claude-haiku-4-5` — 591 lignes, et c'est
+  justement la forme que les transcripts écrivent. On contrôle la transformation, et l'invariant est
+  vérifié : **0 collision** après dé-datage sur `models.dev/anthropic`. Une collision à prix divergents
+  fait **tomber la clé entière** du tier fetché, nommée — c'est un défaut de source, pas un cas à
+  arbitrer par heuristique (posture de #395 : « jamais de faux verdict `synced` »,
+  `library_store.rs:397-399`). Le suffixe `-fast` n'est **jamais** stripé : le stripper créerait la
+  collision, le garder produit une clé qui ne matche aucun transcript — coût nul, aucune fausse
+  déflation.
+
+- **Une moisson vide est un échec, pas un résultat.** Une dérive de schéma chez models.dev écrirait
+  sinon un `fetched.json` vide qui **détruirait la dernière table connue**. Le garde « zéro ligne
+  Anthropic → on n'écrit rien » est principiel ; tout autre plancher serait un nombre magique. C'est le
+  seul chemin par lequel cette feature pourrait *détruire* quelque chose.
+
+- **Deux déclencheurs, deux postures d'échec.** Le contrat d'egress d'ADR-0030 se transpose en trois
+  clauses : (1) le local précède toujours le réseau — `image inspect` avant `docker pull`
+  (`sandbox_image.rs:491`, « FAST PATH — précède TOUT réseau … offline-safe ») devient *table sur
+  disque avant fetch* ; (2) un échec réseau retombe sur un chemin qui produit la même chose —
+  `fallback build` (ADR-0030:72-74) devient *les tiers déjà présents* ; (3) **sauf** quand l'effet a
+  été explicitement demandé, et là c'est une erreur **dure qui nomme** la source (ADR-0030:107-112,
+  « un `docker pull` en échec est une erreur DURE qui NOMME le ref, jamais un build silencieux »).
+  D'où : le **bouton** échoue en **502 nommant l'URL** ; le **rafraîchissement au démarrage** échoue en
+  un `warn!`, jamais fatal — régime de `boot_recovery.rs:161-168`, dont le commentaire justifie
+  exactement ce choix par les courses d'ordonnancement du boot (`service_unit.rs` émet
+  `After=network-online.target` sans `After=docker.service`).
+
+- **Le démarrage rafraîchit, il n'amorce pas.** Même armé, le fetch de boot ne se déclenche **que** si
+  `fetched.json` existe déjà et a plus de 24 heures. **Aucun egress avant que l'utilisateur ait cliqué
+  « Sync coûts » une première fois** — le clic **est** le consentement. Motif : ADR-0001:11, « défaut
+  Z, réversible et additif — relâcher vers Y/X plus tard ne surprend personne, l'inverse oui », et
+  ADR-0012 (l'autonomie se gagne), dont le seul précédent de polarité,
+  `AUTOCOMPLETE_TURN_END_DEFAULT = false` (`stale_detector.rs:74`), est un opt-in. La tâche est
+  **détachée** et posée **après** `tokio::spawn(axum::serve(...))` (`lib.rs:1815`), enveloppée dans
+  `run_isolated` (`lib.rs:3702`) : elle ne retarde jamais le premier `accept()`. Contrairement à
+  `boot_recovery`, elle n'est **pas** `await`ée avant `build_router`.
+
+- **La lecture reste locale, par requête, sans `OnceLock`.** La table se charge une fois par requête au
+  **bord** — là où `(home_root, sandbox_root)` est déjà résolu (`lib.rs:7943`, `stats.rs:406`) — jamais
+  dans la boucle par Run. Un `OnceLock` figerait l'empreinte au boot et rendrait le redémarrage
+  obligatoire pour changer un prix, ce qui annule l'objet de la décision. Un champ d'`AppState` avec
+  TTL n'a pour précédent que `docker_probe_cache` (`lib.rs:311`), motivé par un aller-retour Docker :
+  deux `fs::read` de quelques Ko ne l'achètent pas.
+
+- **L'empreinte de la table entre dans la clé du memo.** `CostMemoKey` passe de `(run_id, mtime)` à
+  `(run_id, mtime, empreinte)`. Sans ce troisième composant, un sync ne bougerait **aucun** mtime de
+  transcript, donc `GET /stats/cost` (mémoïsé, `stats.rs:450`) servirait les anciens dollars **jusqu'au
+  redémarrage** pendant que `GET /runs/:id` (non mémoïsé, `lib.rs:11520`) dirait vrai. Deux surfaces qui
+  se contredisent est pire que l'une des deux fausse — et les Runs concernés, terminés et aux
+  transcripts figés, sont exactement ceux qu'on veut réparer. Le sync **ne vide pas** le memo : sous la
+  nouvelle clé une entrée périmée devient inatteignable, et vider invaliderait aussi les Runs dont les
+  prix n'ont pas bougé.
+
+- **Absent : silencieux. Présent mais rejeté : dit une fois, et lisible dans l'UI.** Un fichier absent
+  est l'état normal de toute instance — pas même une ligne de log. Un fichier présent mais illisible ou
+  non parsable, ou une ligne refusée, produit **un** `warn!` et un `reason` consultatif sur
+  `GET /settings`. ADR-0015 amendement #471 : « une valeur que l'utilisateur a posée ne doit jamais
+  cesser de compter en silence » ; ADR-0001:11 classe la perte de config silencieuse dans les
+  diagnostics **toujours visibles**. Le précédent exact est #432 : `PDO_DEFAULT_SANDBOX` « passe par
+  aucun validateur par construction, donc le seul endroit honnête pour le remonter est ici, en `reason`
+  consultatif à côté de la valeur » (`lib.rs:6894-6898`). Et `journalctl` seul est le motif de panne
+  récurrent de ce produit (#497, #485). Le chargeur mémorise la dernière empreinte avertie pour ne pas
+  émettre une ligne par requête de `/stats/cost`.
+  **Un `fetched.json` dont le `schema` n'est pas `prices-v1` est entièrement inerte.** Jamais de lignes
+  lues sous un schéma non reconnu — précédent `hash_algo: "semantic-v1"` (`library_store.rs:259-269`),
+  dont le commentaire dit que « changer l'algorithme sans ce marqueur aurait fait passer **tous** les
+  pipelines promus en ⚠, exactement le symptôme qu'on corrige ».
+
+- **Une ligne rejetée retombe sur le tier suivant, elle ne détruit pas l'estimation.** Un typo sur
+  `claude-opus-4-8` ne doit pas effondrer 79 941 lignes. La clé garde ce que le tier suivant en dit, et
+  l'inertie **se dit**. Si aucun tier ne connaît la clé, le modèle reste non tarifé — `$0` + `partial`,
+  comportement actuel, rien de neuf.
+
+- **Aucun des deux fichiers n'est seedé.** Seeder les 11 lignes embarquées créerait un **instantané**
+  (ADR-0031 §2) : le jour où une release ajoute une ligne au `const`, un fichier seedé la masquerait.
+  « Ne rien poser est un état de première classe, et le défaut » (ADR-0031 §9). La découvrabilité passe
+  donc **entièrement** par le bloc `GET /settings`, qui nomme les deux chemins **même quand les
+  fichiers sont absents**, et affiche le millésime du dernier fetch.
+
+- **Le chemin est injecté, jamais `$HOME` lu.** `price_table::paths(home_root)` est de l'arithmétique
+  de chemin, à l'image de `sandbox_image::default_dockerfile_path(sandbox_root)`. `library_store.rs:49`
+  lit `$HOME` globalement, et le coût de ce régime est chiffré : un `HOME_TEST_LOCK`
+  (`library_store.rs:967`) pris par 34 tests de `lib.rs` avec 36 `allow(clippy::await_holding_lock)`.
+  #408 a payé une slice pour en sortir `run_cost`. Corollaire : le seam #408 déplace la racine des
+  **transcripts**, pas celle des **prix** — les prix sont un concept d'**instance**, l'hôte les porte
+  même pour un Run sandboxé.
+
+- **Le fetch est testable sans réseau.** L'URL est un seam par variable d'environnement
+  (`PDO_PRICE_SOURCE_URL`), lu une fois au boot et porté dans `DaemonConfig` — l'idiome de
+  `PDO_TMUX_CMD_OVERRIDE` (#181) et `PDO_DOCKER_CMD_OVERRIDE` (#407), dont le commentaire est la charte
+  (`lib.rs:1531`) : « so no test needs a real daemon or a global `std::env::set_var` race ». Le
+  rafraîchissement de boot est un second champ de `DaemonConfig`. C'est le **seul** point qui sépare
+  production et tests : `from_env()` (`lib.rs:1552`) n'est appelé que par `serve` (`:1586`), tandis que
+  les 240 `TestDaemon` construisent `DaemonConfig` par littéral exhaustif — ajouter un champ **casse la
+  compilation** des cinq constructeurs de `tests/common/mod.rs`, ce qui force une décision explicite
+  au lieu d'une convention oubliable. Gater sur `nested_daemon` ne protégerait rien :
+  `tests/common/mod.rs:58` retire `PDO_NODE_ID` exprès.
+
+- **Aucune dépendance nouvelle.** `reqwest` est déjà une dépendance du daemon avec `rustls-tls`,
+  `json`, `http2` et `system-proxy` (`crates/pdo-daemon/Cargo.toml:45`), et `webpki-roots` est dans le
+  lock : les trust anchors sont compilés. Contrainte à préserver — la rationale de rustls
+  (`Cargo.toml:42-44`) est que `openssl-sys` ne cross-compile pas vers `aarch64-unknown-linux-gnu` ;
+  une dépendance qui le ramènerait casserait la release sur cette cible **seulement**, invisible de la
+  CI. Le client doit être **async** : `reqwest::blocking` panique depuis le contexte du runtime, y
+  compris dans un `spawn_blocking` (les threads du pool bloquant portent ce contexte), ce que
+  `main.rs:18-20` documente déjà pour les chemins CLI.
+
+## Conséquences
+
+- **Positif.** Un nouveau modèle se tarife **sans intervention** dès qu'un sync a tourné, et la fenêtre
+  d'ops passe d'un cycle de release à un clic. Le chemin de lecture ne change pas de nature : il reste
+  deux `fs::read` et un `const`, donc `GET /runs/:id` et `GET /stats/cost` répondent à l'identique,
+  hors ligne comme en ligne. Une remise entreprise, ou un modèle qu'aucune source ne publie
+  (`claude-mythos-5`), reste réparable par le tier manuel — et cette correction **survit** au sync, ce
+  qui est visible dans le compte-rendu.
+
+- **Négatif / assumé.** Le daemon a désormais un egress **de plus**, et une source tierce devient une
+  dépendance de **correctitude des chiffres affichés**. La doctrine applicable est celle d'ADR-0013:26
+  — « la version fait partie de la frontière de sécurité, pas un détail de dépendance » — sauf qu'ici ce
+  sont les **valeurs** qui sont load-bearing, non la version. D'où le `fetched_at` visible : le
+  millésime de la table est lisible, pas deviné. models.dev est communautaire (PR + CI de schéma) et a
+  changé d'organisation GitHub (`sst` → `anomalyco`) sans promesse de versioning du schéma ; c'est le
+  prix de la propreté de ses clés, et la raison pour laquelle le repli LiteLLM n'est pas décoratif.
+  Le coût étant dérivé à la lecture, un sync **retarife tous les Runs historiques, archivés inclus** :
+  cela satisfait la contrainte du CHANGELOG (« un Run archivé s'ouvre et se chiffre »), mais le chiffre
+  d'un Run clos devient fonction d'un fichier modifiable — à assumer au titre de l'« étiquetage
+  honnête (load-bearing) » d'ADR-0022:66-70.
+  `COST_MEMO_CAP` (`run_cost.rs:293`) porte maintenant plusieurs entrées par Run à travers un
+  changement de table ; l'overflow vide toute la map, ce qui reste correctness-preserving par
+  construction.
+
+- **Limites connues, à ne pas confondre avec des bugs.**
+  **Le mode fast est invisible** : `claude-opus-5` et `claude-opus-5-fast` s'écrivent du **même id**
+  dans `message.model`, donc un nœud en mode fast est sous-facturé ×2 et **aucune** normalisation ne
+  peut le rattraper. models.dev expose la grille dans `experimental.modes.fast` (10/50), inutilisable
+  faute de signal côté transcript.
+  **Le prix d'intro de `claude-sonnet-5`** (2/10) expire le 2026-08-31 → 3/15, et **aucune** des trois
+  sources ne porte de date d'effet. Sans dimension de date — délibérément absente, voir hors-scope — la
+  remontée surestimera de 50 % les 607 lignes sonnet-5 antérieures, soit **0,5 %** d'un nombre déjà
+  préfixé `~`.
+  **Les prix de cache restent dérivés** (1.25× / 2× / 0.1× de l'input). models.dev les **confirme**
+  ligne par ligne et n'a **pas** de split 5m/1h : le bucket 1 heure n'est dérivable d'aucun de ses
+  champs, et la doc Anthropic confirme le facteur 2.
+
+## Alternatives rejetées
+
+- **OpenRouter comme source.** 9 collisions à prix divergents après normalisation, un `canonical_slug`
+  à l'ordre des mots instable, un SKU fantôme à $30/$150, et des CGU qui interdisent la copie des
+  informations du service. Suggéré par le propriétaire, mesuré, écarté — avec les preuves ci-dessus.
+- **LiteLLM comme source primaire.** Zéro collision aussi, MIT aussi, et l'argument propre que
+  `ccusage` lit exactement ce fichier (donc PDO se réconcilierait avec l'outil de recoupement de
+  l'équipe). Écarté en v1 pour une seule raison : ses clés ne sont pas le vocabulaire de PDO (alias à
+  ordre inversé — `claude-4-opus-20250514` **et** `claude-opus-4-20250514`), et 273 clés `claude-*`
+  d'autres providers doivent être filtrées. **Reste le repli documenté** si models.dev disparaît : un
+  adaptateur, pas une refonte.
+- **Fetcher au build** (ce que rejetait déjà ADR-0022, et qui reste rejeté). La distinction est
+  load-bearing et sera confondue : fetcher **au build** fige la table dans le binaire et **ramène** le
+  couplage à la release qu'on supprime ; fetcher **out-of-band vers un cache disque** ne le fait pas.
+- **Fetcher sur le chemin de lecture** (paresseusement, à la première lecture de coût). Interdit :
+  ADR-0030:119-121 pose déjà la règle en refusant un aller-retour réseau dans un handler `PUT`. Un
+  `GET /runs/:id` qui dépend d'Internet est exactement ce que le motif d'ADR-0022 protégeait, sous sa
+  forme forte.
+- **Un fichier unique réécrit par le sync**, ou **un fichier à deux sections**. Voir la première puce
+  de décision : la première efface les corrections manuelles, la seconde exige une réécriture partielle
+  sûre d'un fichier humain, dont ce codebase n'a aucun précédent.
+- **Remplacement global au lieu d'une fusion par clé.** Chiffré : oublier `claude-opus-4-8` effacerait
+  79 941 lignes sur ~116 200, et gèlerait la table contre les releases futures.
+- **Inférer le prix du nom du modèle.** Faux, pas seulement fragile : `claude-opus-4-1` et
+  `claude-opus-4-0` sont à $15/$75, `claude-opus-4-5` à `4-8` à $5/$25 — même famille, 3× l'écart. Le
+  commentaire de `run_cost.rs:46-47` l'interdit déjà noir sur blanc (« never a `starts_with("opus-4")`
+  shortcut »). Il n'y a **rien à calculer**, seulement quelque chose à *savoir*.
+- **Embarquer / shell-out `ccusage`.** Toujours rejeté, mais le motif change : « réseau » n'est plus
+  discriminant. Ce qui subsiste est la dépendance **binaire + Node**, et le fait que ccusage imposerait
+  *sa* table plutôt que la nôtre.
+- **Vider `COST_MEMO` au sync** au lieu de mettre l'empreinte dans sa clé. Redondant sous la nouvelle
+  clé, et strictement moins bon : cela invaliderait aussi les Runs dont les prix n'ont pas bougé.
+- **`etag` / `If-None-Match`.** ADR-0015 amendement #471 interdit les champs morts. Le payload fait
+  3,3 Mo mais le fetch est manuel ou une fois par 24 heures : conditionner n'achète rien en v1.
+
+## Hors-scope (suivis à filer)
+
+- **Nommer le modèle non tarifé** dans l'UI (`unpriced_models`, rendre `—` au lieu de `~$0.00`) :
+  **#425**, AC #4. Sans elle, l'utilisateur reste incapable d'apprendre **quel** modèle manque quand
+  aucun tier ne le connaît — et c'est ainsi que `claude-fable-5` est resté invisible.
+- **Un `GET /prices` exposant le tier gagnant par modèle.** C'est de la découvrabilité de modèles, donc
+  le territoire de #425. `manual_keys` et `fetched_rows` sur `GET /settings` suffisent à rendre visible
+  qu'un tier masque un autre.
+- **Un adaptateur LiteLLM** — le repli nommé ci-dessus.
+- **Le mode fast** et le **palier long-contexte > 200K** : ce sont des **paliers**, pas des prix de
+  famille ; ni un multiplicateur ni une ligne de plus ne les exprime, et le premier n'a de toute façon
+  aucun signal côté transcript.
+- **Une dimension de date par ligne.** La bonne horloge n'est pas `now()` : `price_for` et `line_cost`
+  ne prennent pas le temps, `parse_line` ne lit jamais le `timestamp`. Gater sur `now()` **retariferait
+  l'histoire** — le coût d'un Run terminé changerait sans que ses transcripts changent — et serait
+  invisible de la clé du memo. Purement additif plus tard.
+- **Transcrire dans `docs/agents/run-scenario.md` la recette de pile isolée et de teardown** que le
+  Feature Path de #427 a dû porter lui-même : ce playbook ne dit nulle part comment démarrer ni démonter
+  une pile, ce qui est la cause racine documentée de #422, et il omet le socket tmux dérivé du port.

--- a/docs/adr/0034-out-of-band-price-fetch.md
+++ b/docs/adr/0034-out-of-band-price-fetch.md
@@ -127,6 +127,21 @@ fetch out-of-band (bouton, ou rafraîchissement au démarrage)
   collision, le garder produit une clé qui ne matche aucun transcript — coût nul, aucune fausse
   déflation.
 
+- **Un sync qui ne change rien n'écrit rien.** Si les lignes normalisées sont identiques à celles déjà
+  dans `fetched.json`, le fichier n'est pas réécrit : la réponse est un `noop: true` + `reason`
+  (ADR-0025) et l'**empreinte de la table ne bouge pas**, donc `COST_MEMO` reste chaud pour tous les
+  Runs. Le prix payé est que `fetched_at` n'avance pas sur un noop, donc le rafraîchissement au
+  démarrage re-demandera la source après 24 h pour ne rien écrire — un `GET` par démarrage au pire,
+  contre une invalidation complète du memo à chaque sync. L'arbitrage penche du côté du memo :
+  l'égalité des lignes est la preuve que rien n'avait à changer.
+
+- **Le garde numérique s'applique aux DEUX tiers disque.** Le tier fetché est écrit par le daemon, qui
+  a validé à l'écriture — mais le nom du fichier est la seule chose qui en interdit l'édition à la
+  main. Un prix négatif ou non fini y est donc refusé exactement comme dans le tier manuel (ligne
+  inerte, clé retombant sur le tier suivant), parce qu'un `NaN` empoisonne `usd` **et** sérialise en
+  JSON `null` vers un frontend qui le type `number`. Les règles de **clé** (dé-datage, sentinelle),
+  elles, restent asymétriques comme décrit ci-dessus.
+
 - **Une moisson vide est un échec, pas un résultat.** Une dérive de schéma chez models.dev écrirait
   sinon un `fetched.json` vide qui **détruirait la dernière table connue**. Le garde « zéro ligne
   Anthropic → on n'écrit rien » est principiel ; tout autre plancher serait un nombre magique. C'est le
@@ -208,7 +223,12 @@ fetch out-of-band (bouton, ou rafraîchissement au démarrage)
   (`PDO_PRICE_SOURCE_URL`), lu une fois au boot et porté dans `DaemonConfig` — l'idiome de
   `PDO_TMUX_CMD_OVERRIDE` (#181) et `PDO_DOCKER_CMD_OVERRIDE` (#407), dont le commentaire est la charte
   (`lib.rs:1531`) : « so no test needs a real daemon or a global `std::env::set_var` race ». Le
-  rafraîchissement de boot est un second champ de `DaemonConfig`. C'est le **seul** point qui sépare
+  rafraîchissement de boot est un second champ de `DaemonConfig`, désarmable par
+  **`PDO_PRICE_SYNC=off|0|""`** — le seul env d'**opt-out** du crate, et assumé comme tel : une feature
+  qui doit marcher d'emblée ne peut pas être armée par variable d'environnement, et l'opt-in réel est
+  le premier clic. Les trois harnais qui lancent le **vrai binaire** le posent
+  (`tests/log_level_default.rs`, `frontend/playwright.config.ts`, `tests/smoke.sh`).
+  C'est le **seul** point qui sépare
   production et tests : `from_env()` (`lib.rs:1552`) n'est appelé que par `serve` (`:1586`), tandis que
   les 240 `TestDaemon` construisent `DaemonConfig` par littéral exhaustif — ajouter un champ **casse la
   compilation** des cinq constructeurs de `tests/common/mod.rs`, ce qui force une décision explicite

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -70,6 +70,10 @@ export default defineConfig({
       // handful of runs a single spec holds open at once without lifting the
       // tmux-protecting cap so high that a missed cleanup could pile up.
       PDO_SESSION_CAP: "64",
+      // #427: the e2e daemon is the REAL binary, so it reads `PDO_PRICE_SYNC` from
+      // the environment (armed by default). Disarm it: the suite must never depend
+      // on models.dev being reachable, and CI must never egress for a UI test.
+      PDO_PRICE_SYNC: "off",
       PDO_TMUX_CMD_OVERRIDE:
         'case "$PDO_NODE_ID" in ' +
         "scroller) " +

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,4 +1,4 @@
-import type { PipelineListEntry, PipelineDetail, PipelineDef, RunListEntry, RunState, PortDef, PortSide, PortType, FrontmatterFieldDecl, Trigger, TriggerFire, DaemonStatus, InstanceSettings, UpdateSettingsRequest, StatsOverview, StatsCost, SandboxProfile, SandboxProfileImage, SandboxProfileReferents } from "./types";
+import type { PipelineListEntry, PipelineDetail, PipelineDef, RunListEntry, RunState, PortDef, PortSide, PortType, FrontmatterFieldDecl, Trigger, TriggerFire, DaemonStatus, InstanceSettings, UpdateSettingsRequest, StatsOverview, StatsCost, SandboxProfile, SandboxProfileImage, SandboxProfileReferents, SyncCostPricesReport } from "./types";
 
 const BASE = "";
 
@@ -226,6 +226,25 @@ export function fetchSandboxProfileReferents(
     "GET",
     `/settings/sandbox-profiles/${encodeURIComponent(name)}/referents`,
   );
+}
+
+/**
+ * Fetch the remote price source and rewrite the fetched price tier (#427,
+ * ADR-0034). The daemon's only outbound call from a user gesture.
+ *
+ * Under `/settings/…` deliberately: the vite dev proxy keys on a PREFIX, so this
+ * needs no `vite.config.ts` line — the trap `/nodes` (#345), `/stats` (#377) and
+ * `/fs` (#431) each paid, where a missing proxy entry makes a dev-mode request
+ * answer 200 with the SPA.
+ *
+ * Throws on 409 (a sync is already in flight) and on 502 (source unreachable, or
+ * an empty harvest — in which case nothing was written and the last known table
+ * survives). A run with nothing to change resolves with `noop: true`.
+ */
+export function syncCostPrices(): Promise<SyncCostPricesReport> {
+  return request<SyncCostPricesReport>("POST", "/settings/cost-prices/sync", {
+    label: "POST /settings/cost-prices/sync",
+  });
 }
 
 /**

--- a/frontend/src/components/NewRunModal.test.tsx
+++ b/frontend/src/components/NewRunModal.test.tsx
@@ -34,6 +34,8 @@ vi.mock("../api", () => ({
     home: "/home/user",
     // #469: required on InstanceSettings; this modal does not read it.
     autocomplete_turn_end: { effective: false, source: "default", stored: null, env: null, default: false },
+    // #427: required on InstanceSettings; this modal does not read it.
+    price_table: { manual_path: "/home/user/.pdo/prices/models.yaml", fetched_path: "/home/user/.pdo/prices/fetched.json", source: null, fetched_at: null, fetched_rows: 0, manual_keys: [], reason: null },
     updated_at: "2026-07-01T10:00:00.000Z",
   }),
   // #431 prophylaxis: this file renders `RepoCombobox`, which mounts `FsExplorerModal`
@@ -1439,6 +1441,8 @@ describe("NewRunModal — sandbox selector (#410)", () => {
       home: "/home/user",
       // #469: required on InstanceSettings; this modal does not read it.
       autocomplete_turn_end: { effective: false, source: "default", stored: null, env: null, default: false },
+      // #427: required on InstanceSettings; this modal does not read it.
+      price_table: { manual_path: "/home/user/.pdo/prices/models.yaml", fetched_path: "/home/user/.pdo/prices/fetched.json", source: null, fetched_at: null, fetched_rows: 0, manual_keys: [], reason: null },
       updated_at: "2026-07-01T10:00:00.000Z",
       ...overrides,
     };
@@ -1715,6 +1719,8 @@ describe("NewRunModal — the launch dialog can defer to default_sandbox (#452)"
       home: "/home/user",
       // #469: required on InstanceSettings; this modal does not read it.
       autocomplete_turn_end: { effective: false, source: "default", stored: null, env: null, default: false },
+      // #427: required on InstanceSettings; this modal does not read it.
+      price_table: { manual_path: "/home/user/.pdo/prices/models.yaml", fetched_path: "/home/user/.pdo/prices/fetched.json", source: null, fetched_at: null, fetched_rows: 0, manual_keys: [], reason: null },
       updated_at: "2026-07-01T10:00:00.000Z",
       ...overrides,
     };
@@ -1921,6 +1927,8 @@ describe("NewRunModal — the target repo is required at the boundary (#470)", (
       ],
       home: "/home/user",
       autocomplete_turn_end: { effective: false, source: "default", stored: null, env: null, default: false },
+      // #427: required on InstanceSettings; this modal does not read it.
+      price_table: { manual_path: "/home/user/.pdo/prices/models.yaml", fetched_path: "/home/user/.pdo/prices/fetched.json", source: null, fetched_at: null, fetched_rows: 0, manual_keys: [], reason: null },
       updated_at: "2026-07-01T10:00:00.000Z",
     });
   });

--- a/frontend/src/components/SettingsModal.test.tsx
+++ b/frontend/src/components/SettingsModal.test.tsx
@@ -67,6 +67,17 @@ function sample(overrides: Partial<InstanceSettings> = {}): InstanceSettings {
       env: null,
       default: false,
     },
+    // Price table (#427): the default state of every instance — neither file exists,
+    // never synced, nothing inert. The paths are reported all the same.
+    price_table: {
+      manual_path: "/home/user/.pdo/prices/models.yaml",
+      fetched_path: "/home/user/.pdo/prices/fetched.json",
+      source: null,
+      fetched_at: null,
+      fetched_rows: 0,
+      manual_keys: [],
+      reason: null,
+    },
     updated_at: "2026-07-01T10:00:00.000Z",
     ...overrides,
   };
@@ -221,6 +232,59 @@ describe("SettingsModal", () => {
     expect(cap.value).toBe("9");
     expect((screen.getByTestId("setting-reaper-ttl") as HTMLInputElement).value).toBe("3600");
     expect((screen.getByTestId("setting-guard-timeout") as HTMLInputElement).value).toBe("60");
+  });
+
+  // --- price table (#427, ADR-0034) ---
+
+  it("names both price paths even though neither file exists", async () => {
+    // Nothing is ever seeded (that would freeze a snapshot, ADR-0031 §2), so naming
+    // the paths IS the whole discoverability story.
+    fetchSettingsMock.mockResolvedValue(sample());
+    render(<SettingsModal open onClose={() => {}} />);
+    expect(await screen.findByTestId("setting-price-table")).toBeInTheDocument();
+    expect(screen.getByTestId("setting-price-table-manual-path")).toHaveTextContent(
+      "/home/user/.pdo/prices/models.yaml",
+    );
+    expect(screen.getByTestId("setting-price-table-fetched-path")).toHaveTextContent(
+      "/home/user/.pdo/prices/fetched.json",
+    );
+    expect(screen.getByTestId("setting-price-table-fetched-at")).toHaveTextContent(
+      /never synced/i,
+    );
+    // Absent is SILENT: no advisory when nothing is wrong.
+    expect(screen.queryByTestId("setting-price-table-reason")).not.toBeInTheDocument();
+  });
+
+  it("surfaces the daemon's reason when a price row went inert", async () => {
+    // A hand-edited file passes through NO validator, so this is the only place a
+    // refused row is visible (the #432 argument). journalctl alone is this product's
+    // recurring blind spot.
+    fetchSettingsMock.mockResolvedValue(
+      sample({
+        price_table: {
+          manual_path: "/home/user/.pdo/prices/models.yaml",
+          fetched_path: "/home/user/.pdo/prices/fetched.json",
+          source: "https://models.dev/api.json",
+          fetched_at: "2026-07-30T14:12:03Z",
+          fetched_rows: 15,
+          manual_keys: ["claude-opus-4-8"],
+          reason:
+            "price table (#427) — manual price tier refused 1 row(s): `claude-opus-5-20260501` (write `claude-opus-5` instead)",
+        },
+      }),
+    );
+    render(<SettingsModal open onClose={() => {}} />);
+    const reason = await screen.findByTestId("setting-price-table-reason");
+    expect(reason).toHaveTextContent("claude-opus-5");
+    // The vintage is readable, not guessed — a third-party source is now a
+    // correctness dependency of the numbers shown.
+    expect(screen.getByTestId("setting-price-table-fetched-at")).toHaveTextContent(
+      "2026-07-30T14:12:03Z",
+    );
+    // And what the manual tier shadows is visible.
+    expect(screen.getByTestId("setting-price-table-manual-path")).toHaveTextContent(
+      "claude-opus-4-8",
+    );
   });
 
   it("discloses a shadowed env source for the cap", async () => {

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -540,6 +540,74 @@ function SettingsForm({
           </div>
         </div>
 
+        {/* Price table (#427, ADR-0034) — READ ONLY. Not a knob: this is which of
+            the three price tiers is in force, so there is nothing to PUT. The paths
+            are shown even when the files are absent, because nothing is ever seeded
+            and naming them is the only way a user learns where to write.
+
+            The presence check is not dead code despite the non-optional type: in the
+            `vite dev` workflow the SPA is served from source against a separately
+            built daemon, which may predate this field. In production the SPA is
+            embedded in the binary, so the two can never disagree. */}
+        {settings.price_table && (
+          <div className="flex flex-col gap-1.5" data-testid="setting-price-table">
+            <label className="font-medium text-fg-2" style={{ fontSize: "11.5px" }}>
+              Cost price table
+            </label>
+            <div className="text-fg-4" style={{ fontSize: "10.5px" }}>
+              Costs resolve <span className="font-mono">manual → fetched → built-in</span>,
+              per model family. Neither file exists until you create one (or press
+              “Sync costs” in Stats); the built-in table is the floor.
+            </div>
+            <div
+              className="text-fg-3"
+              style={{ fontSize: "10.5px" }}
+              data-testid="setting-price-table-manual-path"
+            >
+              Yours (wins):{" "}
+              <span className="font-mono">
+                {settings.price_table.manual_path ?? "— (HOME unset)"}
+              </span>
+              {settings.price_table.manual_keys.length > 0 &&
+                ` — ${settings.price_table.manual_keys.length} model(s): ${settings.price_table.manual_keys.join(", ")}`}
+            </div>
+            <div
+              className="text-fg-3"
+              style={{ fontSize: "10.5px" }}
+              data-testid="setting-price-table-fetched-path"
+            >
+              Synced (PDO writes this):{" "}
+              <span className="font-mono">
+                {settings.price_table.fetched_path ?? "— (HOME unset)"}
+              </span>
+              {` — ${settings.price_table.fetched_rows} model(s)`}
+            </div>
+            {/* The table's vintage, readable rather than guessed: a third-party
+                source is now a correctness dependency of the numbers shown. */}
+            <div
+              className="text-fg-4"
+              style={{ fontSize: "10.5px" }}
+              data-testid="setting-price-table-fetched-at"
+            >
+              {settings.price_table.fetched_at
+                ? `Last synced ${settings.price_table.fetched_at}${settings.price_table.source ? ` from ${settings.price_table.source}` : ""}`
+                : "Never synced — only the built-in prices apply."}
+            </div>
+            {/* Server-supplied, because a hand-edited file passes through no
+                validator at all: an inert file or refused row is only visible here
+                (and in journalctl, which is this product's recurring blind spot). */}
+            {settings.price_table.reason && (
+              <div
+                className="text-st-failed"
+                style={{ fontSize: "10.5px" }}
+                data-testid="setting-price-table-reason"
+              >
+                {settings.price_table.reason}
+              </div>
+            )}
+          </div>
+        )}
+
         {error && (
           <div
             className="rounded-md border border-st-failed/30 bg-st-failed-bg px-3 py-2 text-st-failed"

--- a/frontend/src/components/StatsModal.test.tsx
+++ b/frontend/src/components/StatsModal.test.tsx
@@ -1,0 +1,176 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const fetchStatsOverviewMock = vi.fn();
+const fetchStatsCostMock = vi.fn();
+const syncCostPricesMock = vi.fn();
+
+// Every api function StatsModal (or anything it renders) touches MUST be in this
+// factory: Vitest 4 wraps the return in a Proxy whose `get` trap throws, and the SSR
+// transform rewrites calls into member accesses — so a missing key does not break at
+// import, it throws at FIRST ACCESS with `No "<name>" export is defined`.
+vi.mock("../api", () => ({
+  fetchStatsOverview: (...args: unknown[]) => fetchStatsOverviewMock(...args),
+  fetchStatsCost: (...args: unknown[]) => fetchStatsCostMock(...args),
+  syncCostPrices: (...args: unknown[]) => syncCostPricesMock(...args),
+}));
+
+// recharts is heavy and code-split behind `React.lazy`; the charts are strictly
+// presentational and irrelevant to what this file asserts (the sync button lives in
+// StatsModal precisely because StatsCharts has no access to the refetch).
+vi.mock("./StatsCharts", () => ({
+  default: () => <div data-testid="stats-charts-stub" />,
+}));
+
+import StatsModal from "./StatsModal";
+import type { StatsCost, StatsOverview, SyncCostPricesReport } from "../types";
+
+const OVERVIEW: StatsOverview = {
+  buckets: ["2026-07-30"],
+  runs: [{ bucket: "2026-07-30", count: 1 }],
+  errors: [],
+  sessions: [],
+  fires_by_pipeline: [],
+  triggers_created_runs: { fired: 0, distinct_triggers: 0, enabled_triggers: 0 },
+};
+
+const COST: StatsCost = { by_period: [], by_pipeline: [], by_project: [] };
+
+function report(overrides: Partial<SyncCostPricesReport> = {}): SyncCostPricesReport {
+  return {
+    ok: true,
+    source: "https://models.dev/api.json",
+    fetched_at: "2026-07-30T14:12:03Z",
+    rows: 15,
+    added: ["claude-fable-5", "claude-opus-5"],
+    updated: ["claude-sonnet-5"],
+    unchanged: 12,
+    rejected: [],
+    shadowed_by_manual: [],
+    ...overrides,
+  };
+}
+
+/** Open the modal and switch to the Cost tab, where the sync button lives. */
+async function openCostTab() {
+  const user = userEvent.setup();
+  render(<StatsModal open onClose={() => {}} />);
+  await user.click(await screen.findByTestId("stats-tab-cost"));
+  return user;
+}
+
+beforeEach(() => {
+  fetchStatsOverviewMock.mockReset().mockResolvedValue(OVERVIEW);
+  fetchStatsCostMock.mockReset().mockResolvedValue(COST);
+  syncCostPricesMock.mockReset().mockResolvedValue(report());
+});
+
+describe("StatsModal — price sync (#427, ADR-0034)", () => {
+  it("shows the Sync costs button only on the Cost tab", async () => {
+    const user = userEvent.setup();
+    render(<StatsModal open onClose={() => {}} />);
+    // Default tab is Runs: the table's staleness is not visible there, so neither is
+    // the button.
+    expect(await screen.findByTestId("stats-tab-runs")).toBeInTheDocument();
+    expect(screen.queryByTestId("stats-sync-prices")).not.toBeInTheDocument();
+
+    await user.click(screen.getByTestId("stats-tab-cost"));
+    expect(screen.getByTestId("stats-sync-prices")).toBeInTheDocument();
+  });
+
+  it("renders a readable report on success, naming what was repaired", async () => {
+    const user = await openCostTab();
+    await user.click(screen.getByTestId("stats-sync-prices"));
+
+    const box = await screen.findByTestId("stats-sync-report");
+    expect(box).toHaveTextContent("claude-fable-5");
+    expect(box).toHaveTextContent("claude-opus-5");
+    expect(box).toHaveTextContent("claude-sonnet-5");
+    expect(box).toHaveTextContent("15 price row(s)");
+    expect(screen.queryByTestId("stats-sync-noop")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("stats-sync-error")).not.toBeInTheDocument();
+  });
+
+  it("says when the manual tier shadows a fetched price", async () => {
+    // A sync must never silently erase a hand correction — it is REPORTED.
+    syncCostPricesMock.mockResolvedValue(
+      report({ shadowed_by_manual: ["claude-opus-4-8"] }),
+    );
+    const user = await openCostTab();
+    await user.click(screen.getByTestId("stats-sync-prices"));
+
+    const box = await screen.findByTestId("stats-sync-report");
+    expect(box).toHaveTextContent("claude-opus-4-8");
+    expect(box).toHaveTextContent(/models\.yaml/);
+  });
+
+  it("renders a noop as its reason, not as a success box", async () => {
+    // ADR-0025: never a blind `{ok:true}`.
+    syncCostPricesMock.mockResolvedValue(
+      report({
+        noop: true,
+        reason: "table already up to date — 15 row(s) from the source, none changed",
+      }),
+    );
+    const user = await openCostTab();
+    await user.click(screen.getByTestId("stats-sync-prices"));
+
+    expect(await screen.findByTestId("stats-sync-noop")).toHaveTextContent(
+      /already up to date/,
+    );
+    expect(screen.queryByTestId("stats-sync-report")).not.toBeInTheDocument();
+  });
+
+  it("surfaces a failure naming the source, and keeps the tab usable", async () => {
+    // The daemon answers 502 with the URL (ADR-0030: an explicitly requested effect
+    // that fails is a hard error that NAMES the source, never a silent fallback).
+    syncCostPricesMock.mockRejectedValue(
+      new Error("price source unreachable: https://models.dev/api.json: request failed"),
+    );
+    const user = await openCostTab();
+    await user.click(screen.getByTestId("stats-sync-prices"));
+
+    const err = await screen.findByTestId("stats-sync-error");
+    expect(err).toHaveTextContent("https://models.dev/api.json");
+    expect(screen.queryByTestId("stats-sync-report")).not.toBeInTheDocument();
+    // The button is usable again — a failure is not a dead end.
+    expect(screen.getByTestId("stats-sync-prices")).not.toBeDisabled();
+  });
+
+  it("disables the button while a sync is in flight", async () => {
+    // Client-side guard on top of the daemon's 409 (precedent: `guardTesting`).
+    let release: (r: SyncCostPricesReport) => void = () => {};
+    syncCostPricesMock.mockReturnValue(
+      new Promise<SyncCostPricesReport>((resolve) => {
+        release = resolve;
+      }),
+    );
+    const user = await openCostTab();
+    const button = screen.getByTestId("stats-sync-prices");
+    await user.click(button);
+
+    expect(button).toBeDisabled();
+    expect(button).toHaveTextContent(/syncing/i);
+
+    release(report());
+    await waitFor(() => expect(button).not.toBeDisabled());
+  });
+
+  it("refetches /stats/cost after a successful sync (the bumped reloadKey)", async () => {
+    // Without this the button would repair the table and lie about it: there is no
+    // polling of `/stats/cost`, so nothing else would move the number.
+    const user = await openCostTab();
+    await waitFor(() => expect(fetchStatsCostMock).toHaveBeenCalledTimes(1));
+
+    await user.click(screen.getByTestId("stats-sync-prices"));
+    await waitFor(() => expect(fetchStatsCostMock).toHaveBeenCalledTimes(2));
+
+    // And the reload key never reaches the API: the call keeps its 3-arg shape, which
+    // `useStats.test.ts` asserts exactly (Vitest compares arity strictly). The modal
+    // owns the period, so assert the SHAPE, not literal dates.
+    const args = fetchStatsCostMock.mock.calls.at(-1)!;
+    expect(args).toHaveLength(3);
+    expect(args[2]).toBe("day"); // the 30d default preset's bucket
+  });
+});

--- a/frontend/src/components/StatsModal.tsx
+++ b/frontend/src/components/StatsModal.tsx
@@ -1,6 +1,8 @@
 import { Suspense, lazy, useEffect, useMemo, useState } from "react";
 import { X } from "lucide-react";
 import { useStats } from "../hooks/useStats";
+import { syncCostPrices } from "../api";
+import type { SyncCostPricesReport } from "../types";
 import type { StatsTab } from "./StatsCharts";
 
 // First `React.lazy` in the repo (#377): recharts is heavy, so StatsCharts (its
@@ -81,13 +83,43 @@ export default function StatsModal({ open, onClose }: Props) {
   const [tab, setTab] = useState<StatsTab>("runs");
   const period = useMemo(() => presetPeriod(preset), [preset]);
 
+  // Price sync (#427, ADR-0034). The triplet mirrors
+  // `guardTest`/`guardTesting`/`guardTestError` in TriggerDetailPanel — there is no
+  // global toast system in this app (the one mention of the word is a "no toast"
+  // comment), so every component renders its own message inline.
+  const [syncReport, setSyncReport] = useState<SyncCostPricesReport | null>(null);
+  const [syncing, setSyncing] = useState(false);
+  const [syncError, setSyncError] = useState<string | null>(null);
+  // Bumped after a successful sync so `useStats` refetches `/stats/cost`. Without
+  // it the numbers would not move until the period changed: the button would have
+  // repaired the table and lied about it.
+  const [reloadKey, setReloadKey] = useState(0);
+
   const { overview, cost, error, costError } = useStats(
     open,
     period.from,
     period.to,
     period.bucket,
     tab === "cost",
+    reloadKey,
   );
+
+  const onSyncPrices = async () => {
+    setSyncing(true);
+    setSyncError(null);
+    setSyncReport(null);
+    try {
+      const report = await syncCostPrices();
+      setSyncReport(report);
+      // Even a noop bumps: the user asked, and a refetch is the honest confirmation
+      // that what they see is current.
+      setReloadKey((k) => k + 1);
+    } catch (e) {
+      setSyncError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSyncing(false);
+    }
+  };
 
   // Escape-to-close (grafted from MarkdownArtifactModal — SettingsModal lacks it).
   useEffect(() => {
@@ -163,6 +195,24 @@ export default function StatsModal({ open, onClose }: Props) {
                 {t.label}
               </button>
             ))}
+            {/* Price sync (#427). Only on the Cost tab — the one place the table's
+                staleness is visible — and pushed right with `ml-auto`. It lives here
+                rather than in StatsCharts because that component is lazy and strictly
+                presentational, with no access to the refetch; StatsModal owns
+                `useStats`. Style copied from TriggerDetailPanel's "Test guard". */}
+            {tab === "cost" && (
+              <button
+                type="button"
+                onClick={onSyncPrices}
+                disabled={syncing}
+                data-testid="stats-sync-prices"
+                title="Fetch public model prices and refresh the local price table"
+                className="ml-auto flex items-center gap-1.5 rounded-md border border-line-strong bg-bg-3 px-2 py-1 font-medium text-fg-2 transition-colors hover:bg-bg-4 disabled:opacity-40"
+                style={{ fontSize: "10.5px" }}
+              >
+                {syncing ? "Syncing…" : "Sync costs"}
+              </button>
+            )}
           </div>
         </div>
 
@@ -175,6 +225,59 @@ export default function StatsModal({ open, onClose }: Props) {
               data-testid="stats-error"
             >
               {error}
+            </div>
+          )}
+          {/* #427: a failed sync NAMES the source (the daemon answers 502 with the
+              URL) — ADR-0030's rule that an explicitly requested effect which fails
+              is a hard error, never a silent fallback. */}
+          {syncError && (
+            <div
+              className="mb-3 rounded-md border border-st-failed/30 bg-st-failed-bg px-3 py-2 text-st-failed"
+              style={{ fontSize: "11.5px" }}
+              data-testid="stats-sync-error"
+            >
+              {syncError}
+            </div>
+          )}
+          {syncReport?.noop && (
+            <div
+              className="mb-3 text-fg-4"
+              style={{ fontSize: "10.5px" }}
+              data-testid="stats-sync-noop"
+            >
+              {syncReport.reason ?? "Price table already up to date."}
+            </div>
+          )}
+          {syncReport && !syncReport.noop && (
+            <div
+              className="mb-3 rounded-md border border-st-await/40 bg-st-await/10 px-3 py-2 text-fg-2"
+              style={{ fontSize: "10.5px" }}
+              data-testid="stats-sync-report"
+            >
+              <div>
+                {syncReport.rows} price row(s) from{" "}
+                <span className="font-mono">{syncReport.source}</span>
+                {syncReport.fetched_at ? ` at ${syncReport.fetched_at}` : ""}.
+              </div>
+              <ul className="list-disc pl-4">
+                {syncReport.added.length > 0 && (
+                  <li>Newly priced: {syncReport.added.join(", ")}</li>
+                )}
+                {syncReport.updated.length > 0 && (
+                  <li>Price changed: {syncReport.updated.join(", ")}</li>
+                )}
+                {/* Said, never hidden: a sync cannot silently erase a hand edit. */}
+                {syncReport.shadowed_by_manual.length > 0 && (
+                  <li>
+                    Kept from your <span className="font-mono">models.yaml</span>{" "}
+                    (overrides the fetched price):{" "}
+                    {syncReport.shadowed_by_manual.join(", ")}
+                  </li>
+                )}
+                {syncReport.rejected.length > 0 && (
+                  <li>Refused by the source: {syncReport.rejected.join("; ")}</li>
+                )}
+              </ul>
             </div>
           )}
           <Suspense

--- a/frontend/src/hooks/useStats.ts
+++ b/frontend/src/hooks/useStats.ts
@@ -16,6 +16,11 @@ import type { StatsOverview, StatsCost } from "../types";
  * from the async callbacks, and — unlike `useSettings` — it *surfaces* an
  * `error`/`costError` rather than swallowing it, so a failed fetch (or a failed
  * lazy chunk on the cost tab) is visible, not a blank tab.
+ *
+ * `reloadKey` (#427) is a **dependency only** — bumping it refetches, and it is
+ * never passed to an API call. Threading it into `fetchStatsCost` would change
+ * that function's arity, which the tests below assert exactly (Vitest compares
+ * arity strictly). Precedent: `refreshKey` in `TriggerDetailPanel`.
  */
 export function useStats(
   open: boolean,
@@ -23,6 +28,7 @@ export function useStats(
   to: string,
   bucket: string,
   costActive: boolean,
+  reloadKey: number = 0,
 ) {
   const [overview, setOverview] = useState<StatsOverview | null>(null);
   const [cost, setCost] = useState<StatsCost | null>(null);
@@ -46,7 +52,7 @@ export function useStats(
     return () => {
       cancelled = true;
     };
-  }, [open, from, to, bucket]);
+  }, [open, from, to, bucket, reloadKey]);
 
   // Cost: lazy — only once the cost tab is active, then on period change too.
   useEffect(() => {
@@ -65,7 +71,7 @@ export function useStats(
     return () => {
       cancelled = true;
     };
-  }, [open, costActive, from, to, bucket]);
+  }, [open, costActive, from, to, bucket, reloadKey]);
 
   return { overview, cost, error, costError };
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -276,7 +276,61 @@ export interface InstanceSettings {
    * #469 removed.
    */
   autocomplete_turn_end: BoolSettingField;
+  /**
+   * Which price tiers are in force (#427, ADR-0034) — an observed STATE, not a
+   * settings knob, hence no `{effective, source, stored, env, default}` shape.
+   *
+   * Both paths are always reported, **even when neither file exists**: nothing is
+   * ever seeded, so naming them is the whole discoverability story. `reason` is the
+   * same string the daemon logs, and is non-null exactly when a file or a row went
+   * inert — a hand-edited file passes through no validator, so this is the only
+   * honest place to surface it (the #432 argument).
+   */
+  price_table: PriceTableView;
   updated_at: string;
+}
+
+/** `GET /settings` → `price_table` (#427). */
+export interface PriceTableView {
+  /** `~/.pdo/prices/models.yaml` — the human's file. PDO never writes it.
+   *  `null` only when `HOME` is unset. */
+  manual_path: string | null;
+  /** `~/.pdo/prices/fetched.json` — the daemon's file. Rewritten whole. */
+  fetched_path: string | null;
+  /** URL of the last successful fetch, or `null` if none ever ran. */
+  source: string | null;
+  /** The fetched table's vintage — readable, not guessed. */
+  fetched_at: string | null;
+  fetched_rows: number;
+  /** Family keys the manual tier actually decides — i.e. what shadows a sync. */
+  manual_keys: string[];
+  /** Advisory: an inert file or refused row, named. `null` when all is well. */
+  reason: string | null;
+}
+
+/**
+ * Response of `POST /settings/cost-prices/sync` (#427, ADR-0034).
+ *
+ * A noop is an honest 200 carrying `noop: true` + `reason` (ADR-0025 forbids a
+ * blind `{ok:true}`); a network cut is a thrown 502 naming the source.
+ */
+export interface SyncCostPricesReport {
+  ok: boolean;
+  noop?: boolean;
+  reason?: string | null;
+  source: string;
+  fetched_at: string | null;
+  /** Rows retained in the fetched tier. */
+  rows: number;
+  /** Keys no tier priced before — the repair. */
+  added: string[];
+  /** Keys whose effective price changes. */
+  updated: string[];
+  unchanged: number;
+  /** Source rows refused, with the motive. */
+  rejected: string[];
+  /** Fetched, but the manual tier still wins — said, never hidden. */
+  shadowed_by_manual: string[];
 }
 
 /**

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -37,7 +37,9 @@ LOG="$TMPDIR/daemon.log"
 echo "[smoke] Using port $PORT, working dir $TMPDIR"
 
 # Run daemon from the tempdir so its .pdo lives there, not in the repo.
-( cd "$TMPDIR" && "$BIN" daemon --port "$PORT" >"$LOG" 2>&1 ) &
+# PDO_PRICE_SYNC=off (#427): the smoke test polls /runs for up to 30 s, so a boot
+# price fetch waiting on a DNS timeout would pass anyway while masking exactly that.
+( cd "$TMPDIR" && PDO_PRICE_SYNC=off "$BIN" daemon --port "$PORT" >"$LOG" 2>&1 ) &
 DAEMON_PID=$!
 
 cleanup() {


### PR DESCRIPTION
## Ce que ça change

L'estimation de coût reposait sur un mapping de prix statique dans le binaire : chaque nouveau
modèle Claude sortait non tarifé, silencieusement compté à `$0`. Trois modèles l'étaient encore au
recensement du 2026-07-30, dont `claude-fable-5`.

La table de prix devient une résolution à **trois tiers**, fusionnée **par clé** (jamais un
remplacement en bloc) :

1. `~/.pdo/prices/models.yaml` — correction manuelle, prioritaire, jamais écrasée par un sync ;
2. le cache fetché — rempli par un **clic explicite** (« Sync costs ») ou par un rafraîchissement
   au boot **uniquement si le cache est périmé**, toujours **hors du chemin de lecture** ;
3. la table embarquée — plancher qui survit à tout.

Un modèle inconnu des trois tiers n'est plus compté `$0` en silence : le montant porte une dague `†`
et le tooltip dit `Lower bound: an unpriced model was excluded.` Les trois états — **absent** (`—`),
**zéro réel**, **borne basse** (`†`) — sont enfin distincts.

`Settings > Cost price table` nomme les deux chemins résolus, la provenance, l'horodatage du dernier
sync, et rend les diagnostics en clair (fichier nommé, forme correcte suggérée).

Voir `docs/adr/0034-out-of-band-price-fetch.md`.

## Garanties tenues, mesurées

- **L'empreinte de la table est dans la clé du memo** : deux `GET /stats/cost` d'URL byte-identique,
  séparés par un changement de prix qui n'a bougé aucun mtime de `.jsonl`, rendent `$20.20` puis
  `$60.20`. Le bug « pire que celui qu'on corrige » n'existe pas.
- **Une source dégradée ne détruit rien** : port fermé, schéma dérivé, JSON corrompu → `502` nommant
  l'URL, cache **byte-identique** dans les trois cas.
- **Le fetch est hors du chemin de lecture** : pendant une pendaison de 10 s, les deux surfaces de
  lecture répondent en ~22 ms au même chiffre.
- **Le boot ne fetche pas à l'aveugle** : 0 requête sans cache, 0 sur cache frais, 1 sur cache
  vieux — et un boot à 0,14 s même source morte (tâche détachée).
- **Une correction manuelle survit à un sync qui écrit réellement**, et le rapport nomme le modèle
  masqué.
- Normalisation vérifiée au niveau octet : ids datés dé-datés, `-fast` jamais replié sur la famille
  de base, providers régionaux ignorés, ids non-claude ignorés.

## Validation

Portes CI toutes vertes : `cargo check` / `clippy -D warnings` / `fmt --check` / **1961 tests Rust**,
`tsc -b` / eslint / `npm run build` / **1501 vitest**, `tests/smoke.sh` (couche 4).

Feature Path `FP-427-REMOTE` joué en conditions réelles (daemon debug isolé, home factice,
navigateur) — **dix actes, verdict Pass, aucun finding bloquant**. Les quatre findings restants sont
non bloquants et deux d'entre eux ne portent pas sur ce diff (le trou de documentation de harnais de
test, et la fuite de daemon pré-existante de `smoke.sh`).

Version : **1.5.0** (mineur, non cassant).

Closes #427

🤖 Generated with [Claude Code](https://claude.com/claude-code)
