### PR TITLE
fix(#490)!: un refus de complétion n'est jamais un 200 — 409 nommé, exit 0/3/4/1 — 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,101 @@ ascendante** : la casse se signale ici et par un bump majeur, jamais en gardant 
 morts. Seule contrainte non négociable — les **données historiques restent lisibles** : un Run
 archivé s'ouvre et se chiffre quelle que soit la version qui a écrit son payload.
 
+## 1.6.0
+
+Un changement cassant livré sous un bump **mineur**, dans la ligne des précédents posés en 1.2.0 et
+1.3.0 : la surface quotidienne est identique (le bouton *Mark complete* et `pdo complete` sont au même
+endroit et prennent les mêmes arguments), et le comportement retiré était un **mensonge** — huit sorties
+qui décrivaient un refus répondaient `200`, dont quatre après avoir déjà tué le Run. Aucune
+configuration vivante ne peut en dépendre sans être déjà cassée : un client qui lisait « succès » sur
+ces réponses se trompait par construction. **Si le mainteneur préfère la lettre du préambule ci-dessus
+(« la casse se signale ici et par un bump majeur »), c'est `2.0.0` : un mot à changer dans
+`Cargo.toml`.**
+
+### Cassant — un refus de complétion n'est plus jamais un `200` (#490)
+
+Le chemin par lequel **tout** node se termine — `pdo complete` (`POST …/nodes/<id>/done`) et *Mark
+complete* (`POST …/commands` `kind=mark_node_done`) — répondait `200` sur huit corps qui décrivaient un
+refus. Un agent lisait `Node <id> marked complete.`, sortait en `0`, et croyait avoir livré un Run que
+le daemon venait de tuer. Voir **ADR-0035**.
+
+Les sorties qui passent de `200` à **`409`**, avec leur nouveau slug :
+
+| Slug (`error`) | `recoverable` | Événements déjà appendés |
+|---|---|---|
+| `frontmatter_retry_pending` | `true` | `FrontmatterRetryPending` |
+| `frontmatter_retry_exhausted` | `false` | `NodeFailed` + `RunFailed` |
+| `script_validation_failed` | `false` | `NodeFailed` + `RunFailed` |
+| `doc_violated_code_immutability` | `false` | `NodeFailed` + `RunFailed` |
+| `merge_conflict` | `false` | `MergeConflictDetected` + `RunFailed` |
+| `merge_resolution_failed` | `false` | `MergeResolverFailed` + `RunFailed` |
+| `merge_resolver_spawned` / `merge_resolver_failed` | `false` | branches mortes depuis ADR-0006 |
+
+Deux refus **changent de corps sans changer de statut** : `completion_rejected` (le garde de transition,
+déjà en `409`) voit sa prose passer de `error` à **`message`**, `error` portant désormais le slug ; et
+`missing_outputs` gagne simplement `recoverable: true`.
+
+- **Les clients discriminent sur `error`, jamais sur le statut.** Un statut n'a pas assez de bits pour
+  neuf causes, et le client de l'UI en était la démonstration : il relisait *tout* `409` de ce chemin
+  comme `missing_outputs` avec une liste vide, gatée sur `length > 0`, donc le refus le plus fréquent de
+  tous — tout clic sur un node d'un Run déjà en échec — n'affichait **rien**. Un slug inconnu se rend
+  tel quel (ADR-0001).
+- **`recoverable` répond à une seule question** : *est-ce encore ton tour ?* `true` ⇒ le node est
+  toujours `running`, rien de terminal n'est enregistré. `false` ⇒ le daemon a **déjà** enregistré
+  l'issue terminale ; ne jamais enchaîner sur `pdo fail`.
+- **Le détail est verbatim celui d'avant** (`missing`, `violations`, `detail`, `reason`) : ce lot déplace
+  un statut et ajoute deux clés, il ne renomme aucun champ de détail. Le `detail` du fail-fast d'un node
+  `script` reste **imbriqué** — l'aplatir rendrait sa trace d'audit indistinguable d'un échec après
+  retry, et c'est le **projecteur** qui apprend à lire les deux formes.
+
+### Cassant — `pdo complete` a un contrat de codes de sortie
+
+| Code | Sens | Geste attendu |
+|---|---|---|
+| `0` | accordée, ou **doublon légal** (`noop`) | rien |
+| `3` | refusée, **encore ton tour** | corriger, rappeler `pdo complete`. **Pas** `pdo fail` |
+| `4` | refusée, **le runtime a déjà tranché** | s'arrêter et rapporter. **Pas** `pdo fail` |
+| `1` | panne, transport, corps illisible, `5xx` | ici **seulement**, `pdo fail` est le bon conseil |
+
+**Pourquoi un `4` distinct du `1`.** Le tail bash d'un node `script` fait `pdo complete || pdo fail`.
+Ce `||` était du **code mort** tant que son déclencheur répondait `200` ; le passage au `409` le
+réveille. Sans discrimination du `4`, chaque refus terminal d'un node `script` produirait **deux**
+`NodeFailed` et **deux** `RunFailed`, le second avec une raison fausse (`NodeFailed` est absorbé par le
+garde, `RunFailed` ne l'est pas). Le tail teste donc le `4`, et un test de couche 3 en vrai tmux + vrai
+bash compte exactement un `run_failed`.
+
+**Le `0` sur un doublon légal est non négociable** : un agent perplexe qui rappelle `pdo complete` ne
+doit pas lire « refusé » puis enchaîner `pdo fail` — il tuerait un Run qui vient de réussir, et sur un
+node `script` le tail le ferait sans demander.
+
+### Ce qui ne change pas
+
+- **La sémantique du `2xx`** (ADR-0023) : « ton événement terminal est durablement enregistré et
+  l'avance est planifiée ». Elle gagne seulement un corollaire — « et ta complétion n'a pas été
+  refusée ».
+- **La queue d'avance détachée** (#304) et le **fail-fast** d'un node `script` (ADR-0017) : intacts.
+- **`410`, `404`, `500`** : « jamais `2xx` » n'est **pas** « toujours `409` ». Le tombstone d'un Run
+  oublié garde son `410` (ADR-0024), une cible inconnue son `404`, une panne son `500`. Sur la route
+  `POST …/nodes/<id>/done`, ces trois-là portent désormais le corps JSON du contrat
+  (`{error, recoverable, message}`) au lieu d'un texte brut ; leur statut est inchangé.
+- **Le corps de succès de `POST …/done` reste le texte brut `ok`**, asymétrique avec le
+  `{"ok":true}` de `POST …/commands`. Symétriser appartient à **#491**.
+- **La veille de vivacité** (#469 / ADR-0032) : indemne par construction — elle lit la variante du
+  résultat, jamais le statut HTTP.
+
+### Migration
+
+- **Appelants directs** (`curl`, scripts, harnais de test) : remplacer tout test de la forme
+  `if resp.ok` ou `if body.status == "..."` sur ce chemin par une lecture de `body.error` +
+  `body.recoverable`. Un `409` n'est plus une anomalie de transport, c'est un **verdict**.
+- **Bash d'un node `script` écrit à la main** : si le corps enchaîne `pdo complete || pdo fail`, ajouter
+  la garde sur le code `4` — sinon chaque refus terminal produit un second `RunFailed` à raison fausse.
+  Le tail généré par PDO le fait déjà.
+- **Rien à faire côté données** : aucun payload d'événement ne change, `NodeState` gagne un
+  `missing_outputs` omis quand vide, et les Runs archivés se projettent à l'identique à l'octet — à une
+  correction près, un bug préexistant : un node redevenu vert ne traîne plus les violations de la
+  tentative dont il s'est remis.
+
 ## 1.3.0
 
 Un changement cassant livré sous un bump **mineur**, dans la ligne du précédent posé en 1.2.0 : la

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -59,7 +59,8 @@ Chaque Node peut porter un **niveau d'effort** optionnel (`effort: Option<String
 
 Un node **`script`** exécute le bash de l'auteur au lieu de lancer Claude. Il tourne dans une **session tmux** (attachable comme tout NodeRun, ADR-0005) dont le tail est `timeout N bash <corps>` : **exit 0 ⇒ node `completed`**, non-zéro ou timeout ⇒ `failed`. En v1 il est d'**effet doc-only** (pas de sous-worktree ; tourne dans le worktree du Run ; doit le laisser propre).
 
-- **I/O par variables d'environnement** (un script ne lit pas le préambule prose) : `PDO_INPUT_<PORT>`, `PDO_OUTPUT_<PORT>`, `PDO_ARTIFACTS_DIR`, `PDO_VAR_<NAME>`, plus les `PDO_RUN_ID/NODE_ID/NODE_ITER/DAEMON_URL` habituels. Le script écrit lui-même `output.md` à `$PDO_OUTPUT_<port>` ; pour piloter une edge `when:`, il y écrit sa propre frontmatter YAML. `outputs_validator` s'applique en **fail-fast** (pas de retry interactif — la session a quitté).
+- **I/O par variables d'environnement** (un script ne lit pas le préambule prose) : `PDO_INPUT_<PORT>`, `PDO_OUTPUT_<PORT>`, `PDO_ARTIFACTS_DIR`, `PDO_VAR_<NAME>`, plus les `PDO_RUN_ID/NODE_ID/NODE_ITER/DAEMON_URL` habituels. Le script écrit lui-même `output.md` à `$PDO_OUTPUT_<port>` ; pour piloter une edge `when:`, il y écrit sa propre frontmatter YAML. `outputs_validator` s'applique en **fail-fast** (pas de retry interactif — la session a quitté) : raison **`"script output validation failed"`**, détail **imbriqué sous `detail`** (`{kind, missing|violations}`) et volontairement distinct de la forme plate d'un échec après retry — deux causes, deux remèdes, deux empreintes d'audit. Réponse : `409 {"error":"script_validation_failed","recoverable":false,"detail":{…}}` (#490, ADR-0035).
+- **Le tail du node teste le code de sortie `4`** de `pdo complete` : un refus terminal n'y déclenche donc **pas** le `pdo fail` de repli, qui doublerait `NodeFailed` **et** `RunFailed` (ce dernier n'est pas gardé) avec une raison fausse. Le tail ne signale l'échec que sur un code de sortie qui n'est **ni** `0` **ni** `4`.
 - **Corps** stocké dans le slot prompt du node (`<pipeline>.prompts/<node>.md`). Un corps vide fait échouer le lancement (fail-loud, pas de no-op silencieux).
 - **Ni `model` ni `effort`** (aucun agent lancé). Le seam de test `tmux_cmd_override` ne s'applique pas à un script (le bash *est* déterministe, donc testable sans stub).
 - **Sécurité** : équivalent au guard de Trigger et au bash d'un agent — le bash de l'auteur dans son propre pipeline, aucune nouvelle frontière de confiance (#260 reste le contrôle réel).
@@ -287,15 +288,47 @@ outputs:
 
 Quand un NodeRun signale `pdo complete`, le runtime parse la frontmatter de chaque output produit et la matche contre le schéma déclaré. Si **mismatch** :
 
-1. **Fallback** : le runtime envoie un message dans la session tmux du NodeRun (*"Ton frontmatter ne respecte pas le schéma : <champ X manquant / valeur Y hors enum>. Corrige et retry."*). Le NodeRun reste en status `running` (pas marqué failed).
+1. **Fallback** : le runtime envoie un message dans la session tmux du NodeRun (*"Ton frontmatter ne respecte pas le schéma : <champ X manquant / valeur Y hors enum>. Corrige et retry."*). Le NodeRun reste en status `running` (pas marqué failed). La 1re tentative répond `409` `{"error":"frontmatter_retry_pending","recoverable":true,"violations":[…]}` : le refus dit « c'est encore ton tour », pas « c'est raté » — et c'est bien un **refus**, la complétion n'a pas été accordée (#490, ADR-0035 §2).
 2. L'agent corrige et appelle à nouveau `pdo complete`. Le runtime re-valide.
-3. Si la 2e tentative échoue (limite : **1 retry max**, 2 tentatives au total), le NodeRun est marqué `failed` avec raison *"output frontmatter mismatch après retry"*.
+3. Si la 2e tentative échoue (limite : **1 retry max**, 2 tentatives au total), le NodeRun est marqué `failed` avec raison **`"output validation failed"`**. Cette chaîne est **exacte et load-bearing** : la bannière rouge du panneau de nœud s'allume sur l'égalité `failure_reason.includes("output validation failed")`, et le fail-fast d'un node `script` la préfixe (`"script output validation failed"`) pour rester distinguable. Réponse : `409` `{"error":"frontmatter_retry_exhausted","recoverable":false,"violations":[…]}` — `NodeFailed` + `RunFailed` sont **déjà** appendés.
+   _Éviter_ : « output frontmatter mismatch après retry » (ancienne formulation, jamais présente dans le code ; écrire la chaîne exacte).
 
 Ce mécanisme évite de fail loud sur une erreur que l'agent peut typiquement corriger seul, tout en bornant la dérive (un agent qui boucle dans le mismatch finit failé en deux tours).
 
+### Contrat de refus de la complétion (#490, ADR-0035)
+
+Une tentative de complétion — `pdo complete` (`POST …/nodes/<node-id>/done`) ou *Mark complete*
+(`POST …/commands` `kind=mark_node_done`) — a **quatre** issues, et une seule non-succès peut porter un `2xx` :
+
+| Issue | Statut | Événement terminal | Exit `pdo complete` |
+|---|---|---|---|
+| **Completed** | `2xx` | appendé, avance planifiée (ADR-0023) | `0` |
+| **NoOp** — doublon légal sur un nœud déjà terminal | `2xx` `{"ok":true,"noop":true,"reason":…}` | **aucun** | `0` |
+| **Refused** | **jamais `2xx`** | selon `recoverable` | `3` ou `4` |
+| panne / cible inconnue | `404`/`500` | — | `1` |
+
+Forme **unique** de tout refus, sur les deux routes : `{"error":"<slug>","recoverable":<bool>, …détail}`.
+
+- **`error`** — slug `snake_case` stable, **le** point de discrimination. Brancher sur le statut est une faute : un statut n'a pas assez de bits pour neuf causes. Un slug inconnu se rend tel quel (ADR-0001).
+- **`recoverable`** — *est-ce encore ton tour ?* `true` ⇒ le nœud est toujours `running`, **rien de terminal n'est enregistré** ; `false` ⇒ le daemon a **déjà** enregistré l'issue terminale.
+- **Le détail est verbatim celui d'avant #490** (`missing`, `violations`, `detail`, `reason`, `message`).
+- Slugs : `missing_outputs` et `frontmatter_retry_pending` (récupérables) ; `frontmatter_retry_exhausted`, `script_validation_failed`, `doc_violated_code_immutability`, `merge_conflict`, `merge_resolution_failed`, `completion_rejected` (terminaux, `409`) ; `run_forgotten` (**`410`**, ADR-0024, inchangé).
+- « Jamais `2xx` » **≠** « toujours `409` » : le `410` du Run oublié, le `404` d'une cible inconnue et le `500` d'une panne ne bougent pas.
+
+Codes de sortie de `pdo complete` — contrat **public** (ils vivent dans le bash d'auteurs de pipelines) :
+
+| Code | Sens | Geste attendu |
+|---|---|---|
+| `0` | succès, ou doublon légal | rien |
+| `3` | refus **récupérable** | corriger, rappeler `pdo complete`. **Pas** `pdo fail` |
+| `4` | refus **terminal** | s'arrêter et rapporter. **Pas** `pdo fail` (déjà enregistré) ; `resume_run` est le seul levier |
+| `1` | panne, transport, corps illisible | ici **seulement**, `pdo fail` est le bon conseil |
+
+_Éviter_ : « erreur de complétion » pour un refus récupérable (rien n'est cassé, c'est encore le tour de l'agent) ; « échec de `pdo complete` » pour un `noop` (c'est un succès).
+
 ### Avance détachée après transition terminale (#304, ADR-0023)
 
-Le 2xx de `pdo complete` (et `fail`/`skip`) signifie « ton événement terminal est durablement enregistré et l'avance est planifiée », **pas** « le run a avancé ». Après l'append de l'événement terminal (`NodeCompleted`/`NodeFailed`/marqueur skip), la queue du handler — reap de la session tmux + avance du run (spawn du successeur, finalisation du port `end`, `RunFailed`/`RunSkipped`, `retry_waiting_nodes`) — s'exécute sur une tâche `tokio::spawn` **détachée** de la requête HTTP. Raison : le reap tue la session tmux du client `pdo` lui-même ; inline, hyper annulait la future de la requête à la fermeture de la socket et l'avance était silencieusement perdue (run coincé `running`). Les erreurs de validation (guard, merge conflict, outputs) restent renvoyées in-request ; les erreurs d'avance surfacent via `RunFailed` + logs, jamais via la réponse HTTP. Un panic dans la queue détachée est isolé (`catch_unwind`) et émet un `RunFailed` explicite.
+Le 2xx de `pdo complete` (et `fail`/`skip`) signifie « ton événement terminal est durablement enregistré et l'avance est planifiée », **pas** « le run a avancé » — et, depuis #490/ADR-0035, aussi « **ta complétion n'a pas été refusée** ». Après l'append de l'événement terminal (`NodeCompleted`/`NodeFailed`/marqueur skip), la queue du handler — reap de la session tmux + avance du run (spawn du successeur, finalisation du port `end`, `RunFailed`/`RunSkipped`, `retry_waiting_nodes`) — s'exécute sur une tâche `tokio::spawn` **détachée** de la requête HTTP. Raison : le reap tue la session tmux du client `pdo` lui-même ; inline, hyper annulait la future de la requête à la fermeture de la socket et l'avance était silencieusement perdue (run coincé `running`). Les erreurs de validation (guard, merge conflict, outputs) restent renvoyées **in-request**, et y sont en **`409`** (cf. *Contrat de refus de la complétion*) ; les erreurs d'avance surfacent via `RunFailed` + logs, jamais via la réponse HTTP. Un panic dans la queue détachée est isolé (`catch_unwind`) et émet un `RunFailed` explicite.
 
 ---
 
@@ -332,7 +365,7 @@ Le préambule contient au minimum :
   - Pour chaque port de sortie : chemin où écrire + schéma de frontmatter requis.
   - Ex. *"Tu dois produire à `<artifacts>/reviewer-1/iter-2/review.md` un fichier markdown avec frontmatter YAML contenant le champ `verdict: PASS | FAIL`. Le contenu détaillé (blocking issues, justifications) va dans le corps."*
 - **Capacités PDO-specific (CLI)** :
-  - `pdo complete` — à appeler via Bash quand le NodeRun est terminé (cf. signal de complétion, Q10).
+  - `pdo complete` — à appeler via Bash quand le NodeRun est terminé (cf. signal de complétion, Q10). Peut être **refusé** : exit `3` ⇒ corriger et rappeler, exit `4` ⇒ ne **pas** enchaîner sur `pdo fail` (l'échec est déjà enregistré). Cf. *Contrat de refus de la complétion*.
   - `pdo fail --reason "..."` — à appeler en cas d'incapacité à finir.
   - Ces commandes ne sont **pas** packagées comme skills Claude Code — elles sont 100% systématiques, sans bénéfice de progressive disclosure.
 - **Itération courante** : *"Tu es à l'itération {iter} de ce nœud."* Permet à l'agent d'adapter son comportement au tour de boucle (par exemple : Implementer en iter 1 implémente from scratch ; en iter 2+ il itère sur les reviews).
@@ -700,7 +733,7 @@ Toutes exposées comme endpoints `POST /runs/<id>/commands` du daemon :
 | `resume_run` | Relance le Run depuis l'état actuel (utile post-conflit résolu manuellement) |
 | `kill_node` | Tue un NodeRun en cours |
 | `restart_node` | Re-spawn un NodeRun (perd l'état tmux courant) |
-| `mark_node_done` | Force la complétion d'un NodeRun (cas typique : nœud `interactive: true` que l'utilisateur signale fini) |
+| `mark_node_done` | Force la complétion d'un NodeRun (cas typique : nœud `interactive: true` que l'utilisateur signale fini). Passe par le **même corps partagé** que `pdo complete` : refusé en `409` nommant la cause (cf. *Contrat de refus de la complétion*) |
 | `inject_artifact` | Pose un artefact à la main dans le Blackboard |
 | `cleanup_run` | Supprime branches, worktrees, artefacts, événements |
 | `rename_run` | Donne au Run un nom descriptif (remplace le nom placeholder posé au spawn) |
@@ -714,7 +747,7 @@ Les commandes de pilotage de boucle (`extend_cycle`, `bump_region`, `end_region`
 
 - **Cible inconnue** (`node_id` ou `region_id` absent du pipeline du Run — snapshot du Run, pas la bibliothèque) → `400` `{"error":"node '<id>' not found in pipeline"}` (resp. `region '<id>'`). La validation précède l'append du `CommandIssued` **et** la levée du `Halted` : une commande rejetée ne modifie pas l'event log.
 - **Mauvais mécanisme** (`extend_cycle` sur un membre de région bornée) → `409` `{"error":"node '<id>' is a member of loop region '<region>'; use bump_region with region_id '<region>'"}`.
-- **Valide mais sans effet immédiat** (itération encore vivante, région déjà complétée, throttle d'admission) → `200` `{"ok":true,"noop":true,"reason":"..."}` (même convention que `mark_node_done`).
+- **Valide mais sans effet immédiat** (itération encore vivante, région déjà complétée, throttle d'admission) → `200` `{"ok":true,"noop":true,"reason":"..."}` (même convention que `mark_node_done`). La convention noop ne s'étend **qu'au** sans-effet : sur le chemin de complétion, un **refus** n'est jamais un `2xx` (#490, ADR-0035 — qui amende cette section).
 - **Effet réel** → `200` `{"ok":true,"spawned":[{"node_id":...,"iter":...}]}`.
 
 ### Ce que le manager ne peut **pas** faire
@@ -866,6 +899,8 @@ Multi-client par session (deux onglets browser sur la même session tmux) : grat
 Un Node marqué `interactive: true` spawn une session tmux normale, et **n'auto-complète jamais**. La session reste attachable indéfiniment ; l'utilisateur peut détach/réattacher autant de fois que nécessaire et continuer à interagir.
 
 La complétion est signalée **depuis l'UI**, par un bouton "Mark complete" sur le nœud. Click → `POST /runs/<id>/commands { kind: "mark_node_done", node_id, iter }`. Pas de slash-command in-session (un slash-command suppose qu'on est attaché ; le bouton UI reste toujours accessible).
+
+Le bouton **n'est pas une garantie** : il est gaté sur le seul `status` du nœud (`awaiting_user`/`running`/`failed`/`stale`) et `NodeState` ne porte pas `node_type` — il s'affiche donc aussi sur un nœud `script` `failed`. C'est **voulu** : le garde de transition autorise explicitement « mark_node_done sur un nœud failed dont les outputs ont été corrigés à la main » comme chemin de récupération. Le clic peut donc être **refusé** (`409` nommant la cause), et le refus s'affiche au niveau du bouton — cf. *Contrat de refus de la complétion*. Ne pas confondre avec la phrase *« aucun bouton affiché ne peut produire un 409 »* de § *Contrôles de Run*, qui est scopée aux trois actions de **Run** (`pause_run`/`resume_run`/`retry_all`).
 
 À ce moment-là, les artefacts présents sur disque dans `<artifacts>/<node-id>/iter-<N>/` sont considérés comme finaux. Le préambule du nœud le dit explicitement à l'agent et au user : *"écris tes outputs aux chemins X, Y, Z ; quand tu cliques 'Mark complete' dans l'UI, ces fichiers seront pris tels quels"*.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "1.5.0"
+version = "1.6.0"
 license = "MIT"
 
 [workspace.dependencies]

--- a/crates/pdo-daemon/src/admission.rs
+++ b/crates/pdo-daemon/src/admission.rs
@@ -135,6 +135,7 @@ mod tests {
                     iterations: Vec::new(),
                     frontmatter_retries: 0,
                     frontmatter_violations: Vec::new(),
+                    missing_outputs: Vec::new(),
                 },
             );
         }

--- a/crates/pdo-daemon/src/boot_recovery.rs
+++ b/crates/pdo-daemon/src/boot_recovery.rs
@@ -352,6 +352,7 @@ mod tests {
                 iterations: Vec::new(),
                 frontmatter_retries: 0,
                 frontmatter_violations: Vec::new(),
+                missing_outputs: Vec::new(),
             },
         );
         rs

--- a/crates/pdo-daemon/src/completion_refusal.rs
+++ b/crates/pdo-daemon/src/completion_refusal.rs
@@ -1,0 +1,464 @@
+//! Pourquoi une complétion a été refusée, et comment ce refus se projette sur le
+//! wire (#490, ADR-0035).
+//!
+//! Le type ne porte **aucun statut** : la projection ([`refusal_response`]) en est
+//! la seule propriétaire, donc « un refus qui répond 2xx » est inexprimable. C'est
+//! l'invariant du ticket, posé comme propriété du type et non comme liste de bras
+//! à relire — huit des dix-neuf sorties du chemin de complétion répondaient `200`
+//! sur un refus, dont quatre après avoir appendé `RunFailed`.
+//!
+//! Les **deux** appelants du corps de complétion (`POST …/nodes/:id/done` et
+//! `POST /runs/:id/commands` `kind=mark_node_done`) passent par la même
+//! projection : c'est ce qui fait que l'invariant couvre les deux surfaces, là où
+//! un garde posé sur `CompletionAttempt` n'aurait couvert que la première (le bras
+//! `mark_node_done` n'en construit jamais).
+
+use axum::{http::StatusCode, response::IntoResponse, response::Response, Json};
+
+/// La cause d'un refus de complétion, avec son détail verbatim d'avant #490.
+///
+/// `Clone` parce que le corps partagé rend la variante à ses deux appelants et que
+/// l'un d'eux la loge avant de la projeter.
+#[derive(Debug, Clone)]
+pub(crate) enum CompletionRefusal {
+    /// Run tombstoné (#328 / ADR-0024). Garde son `410` : « jamais 2xx » ne veut
+    /// pas dire « toujours 409 ».
+    RunForgotten { run_id: String },
+    /// La projection ne rend aucun Run pour cet id — cible inconnue, `404`.
+    RunNotFound,
+    /// Panne interne **avant** tout verdict (lecture du log, contrôle de tombstone).
+    /// `500` : ce n'est pas un refus argumenté, c'est un daemon qui n'a pas pu
+    /// décider — et c'est le seul cas où `pdo fail` reste le bon conseil.
+    Internal { error: String },
+    /// Garde de transition (#212 / #354). La prose part dans `message`, `error`
+    /// porte le slug : c'est ce qui rend le refus lisible côté client, qui relisait
+    /// jusqu'ici *tout* `409` comme `missing_outputs`.
+    CompletionRejected { message: String },
+    /// Commit/merge du sous-worktree en échec — panne, pas verdict, donc `500`.
+    MergeFailed { error: String },
+    /// Conflit de merge ; `MergeConflictDetected` + `RunFailed` déjà appendés.
+    MergeConflict { node_id: String },
+    /// Node `doc-only`/`script` ayant sali des fichiers suivis ; `NodeFailed` +
+    /// `RunFailed` déjà appendés.
+    DocImmutabilityViolated { node_id: String },
+    /// Ports de sortie déclarés sans artefact. Le node reste vivant.
+    MissingOutputs { missing: Vec<String> },
+    /// Fail-fast d'un node `script` (ADR-0017) ; `NodeFailed` + `RunFailed`
+    /// appendés. Le `detail` reste **imbriqué** : aplatir rendrait la trace
+    /// d'audit indistinguable d'un échec après retry (ADR-0035 §5).
+    ScriptValidationFailed { detail: serde_json::Value },
+    /// Mismatch de frontmatter, message correctif envoyé, node toujours `running`.
+    FrontmatterRetryPending { violations: Vec<serde_json::Value> },
+    /// Mismatch après l'unique retry ; `NodeFailed` + `RunFailed` appendés.
+    FrontmatterRetryExhausted { violations: Vec<serde_json::Value> },
+    /// L'événement terminal n'a pas pu être appendé — panne, `500`.
+    AppendFailed { error: String },
+    /// Résolveur de merge : la résolution n'est pas valide ; `MergeResolverFailed`
+    /// + `RunFailed` appendés.
+    MergeResolutionFailed { reason: String },
+    /// Résolveur de merge spawné. **INATTEIGNABLE** en production :
+    /// `MergeResult::ConflictPendingResolution` n'est construit que sous
+    /// `keep_conflict == true`, qu'aucun appelant de production ne passe, et
+    /// ADR-0006 a retiré le résolveur automatique. Conservé sous le type le temps
+    /// de la retombée d'ADR-0006, qui supprimera le sous-système entier — coût de
+    /// test nul ici, et le supprimer sous un fix de bug mélangerait deux
+    /// intentions (ADR-0035 §6).
+    MergeResolverSpawned { node_id: String },
+    /// Résolveur de merge : le spawn a échoué. **INATTEIGNABLE**, cf. ci-dessus.
+    MergeResolverFailed { reason: String },
+}
+
+impl CompletionRefusal {
+    /// Le slug stable sur lequel les clients discriminent. **Jamais** le statut :
+    /// un statut n'a pas assez de bits pour neuf causes.
+    pub(crate) fn slug(&self) -> &'static str {
+        match self {
+            Self::RunForgotten { .. } => "run_forgotten",
+            Self::RunNotFound => "run_not_found",
+            Self::Internal { .. } => "internal_error",
+            Self::CompletionRejected { .. } => "completion_rejected",
+            Self::MergeFailed { .. } => "merge_failed",
+            Self::MergeConflict { .. } => "merge_conflict",
+            Self::DocImmutabilityViolated { .. } => "doc_violated_code_immutability",
+            Self::MissingOutputs { .. } => "missing_outputs",
+            Self::ScriptValidationFailed { .. } => "script_validation_failed",
+            Self::FrontmatterRetryPending { .. } => "frontmatter_retry_pending",
+            Self::FrontmatterRetryExhausted { .. } => "frontmatter_retry_exhausted",
+            Self::AppendFailed { .. } => "append_failed",
+            Self::MergeResolutionFailed { .. } => "merge_resolution_failed",
+            Self::MergeResolverSpawned { .. } => "merge_resolver_spawned",
+            Self::MergeResolverFailed { .. } => "merge_resolver_failed",
+        }
+    }
+
+    /// Est-ce encore le tour de l'appelant ? `false` ⇒ le daemon a déjà enregistré
+    /// une issue terminale : l'appelant ne doit **rien** appender de plus, et
+    /// surtout pas enchaîner `pdo fail`.
+    ///
+    /// Deux variantes seulement laissent le node vivant, et ce sont les deux bras
+    /// du même `match` sur `ValidationError` qui n'appendent aucun événement
+    /// d'échec.
+    pub(crate) fn recoverable(&self) -> bool {
+        matches!(
+            self,
+            Self::MissingOutputs { .. } | Self::FrontmatterRetryPending { .. }
+        )
+    }
+
+    /// Statut HTTP. Énumération fermée, **jamais** `2xx` — c'est ici que
+    /// l'invariant se tient, et `a_refusal_never_projects_to_a_2xx` le prouve
+    /// variante par variante.
+    ///
+    /// Volontairement **sans joker** : ajouter une variante ne compile plus tant
+    /// qu'on n'a pas décidé de son statut (patron du dispatch d'`event_log`).
+    fn status(&self) -> StatusCode {
+        match self {
+            // ADR-0024 §3 : le tombstone garde son 410.
+            Self::RunForgotten { .. } => StatusCode::GONE,
+            Self::RunNotFound => StatusCode::NOT_FOUND,
+            // Pannes, pas verdicts.
+            Self::Internal { .. } | Self::MergeFailed { .. } | Self::AppendFailed { .. } => {
+                StatusCode::INTERNAL_SERVER_ERROR
+            }
+            Self::CompletionRejected { .. }
+            | Self::MergeConflict { .. }
+            | Self::DocImmutabilityViolated { .. }
+            | Self::MissingOutputs { .. }
+            | Self::ScriptValidationFailed { .. }
+            | Self::FrontmatterRetryPending { .. }
+            | Self::FrontmatterRetryExhausted { .. }
+            | Self::MergeResolutionFailed { .. }
+            | Self::MergeResolverSpawned { .. }
+            | Self::MergeResolverFailed { .. } => StatusCode::CONFLICT,
+        }
+    }
+
+    /// Le détail spécifique, **verbatim celui d'avant #490** : aucun champ renommé,
+    /// aucun champ aplati. Fusionné à plat dans le corps par [`refusal_response`].
+    fn detail(&self) -> serde_json::Value {
+        match self {
+            Self::RunForgotten { run_id } => {
+                serde_json::json!({ "message": format!("run {run_id} has been forgotten") })
+            }
+            Self::RunNotFound => serde_json::json!({ "message": "run not found" }),
+            Self::Internal { error } => serde_json::json!({ "message": error }),
+            Self::CompletionRejected { message } => serde_json::json!({ "message": message }),
+            Self::MergeFailed { error } | Self::AppendFailed { error } => {
+                serde_json::json!({ "message": error })
+            }
+            Self::MergeConflict { node_id } => {
+                serde_json::json!({ "message": format!("merge conflict on {node_id}") })
+            }
+            Self::DocImmutabilityViolated { node_id } => serde_json::json!({
+                "message": format!("doc-only node {node_id} violated code immutability")
+            }),
+            Self::MissingOutputs { missing } => serde_json::json!({ "missing": missing }),
+            Self::ScriptValidationFailed { detail } => serde_json::json!({ "detail": detail }),
+            Self::FrontmatterRetryPending { violations }
+            | Self::FrontmatterRetryExhausted { violations } => {
+                serde_json::json!({ "violations": violations })
+            }
+            Self::MergeResolutionFailed { reason } | Self::MergeResolverFailed { reason } => {
+                serde_json::json!({ "reason": reason })
+            }
+            Self::MergeResolverSpawned { node_id } => serde_json::json!({
+                "message": format!("merge conflict on {node_id}: resolver spawned")
+            }),
+        }
+    }
+
+    /// Raison lisible pour le log et pour la veille de vivacité, qui lit la
+    /// variante et jamais le statut (#469 / ADR-0032 — c'est pourquoi elle est
+    /// indemne de ce lot).
+    pub(crate) fn reason(&self) -> String {
+        match self {
+            Self::RunForgotten { run_id } => format!("run {run_id} has been forgotten"),
+            Self::RunNotFound => "run not found".into(),
+            Self::Internal { error } => error.clone(),
+            Self::CompletionRejected { message } => message.clone(),
+            Self::MergeFailed { error } => {
+                format!("commit/merge of the sub-worktree failed: {error}")
+            }
+            Self::MergeConflict { node_id } => format!("merge conflict on {node_id}"),
+            Self::DocImmutabilityViolated { node_id } => {
+                format!("doc-only node {node_id} violated code immutability")
+            }
+            Self::MissingOutputs { missing } => {
+                format!("missing declared outputs: {}", missing.join(", "))
+            }
+            Self::ScriptValidationFailed { .. } => {
+                "script node failed output validation — fail-fast".into()
+            }
+            Self::FrontmatterRetryPending { .. } => {
+                "output frontmatter mismatch — corrective message sent, awaiting retry".into()
+            }
+            Self::FrontmatterRetryExhausted { .. } => "output validation failed after retry".into(),
+            Self::AppendFailed { error } => {
+                format!("failed to append the terminal event: {error}")
+            }
+            Self::MergeResolutionFailed { reason } => format!("merge resolution failed: {reason}"),
+            Self::MergeResolverSpawned { node_id } => {
+                format!("merge conflict on {node_id}: resolver spawned")
+            }
+            Self::MergeResolverFailed { reason } => {
+                format!("merge resolver spawn failed: {reason}")
+            }
+        }
+    }
+}
+
+/// L'**unique** projection d'un refus vers HTTP.
+///
+/// Les deux appelants du chemin de complétion passent par elle — c'est ce qui fait
+/// que l'invariant couvre `POST …/done` *et* `POST /runs/:id/commands`.
+///
+/// Prend une **référence** : le refus est aussi logué par son appelant, et
+/// `Response` (128 octets) rendu par valeur dans un `Result::Err` déclencherait
+/// `clippy::result_large_err`, que la CI traite en `-D warnings`. Toute la chaîne
+/// en amont circule donc en `Option<CompletionRefusal>` (~40 octets pour la plus
+/// grosse variante), jamais en `Result<_, Response>`.
+pub(crate) fn refusal_response(r: &CompletionRefusal) -> Response {
+    let mut body = serde_json::json!({
+        "error": r.slug(),
+        "recoverable": r.recoverable(),
+    });
+    if let (Some(obj), Some(extra)) = (body.as_object_mut(), r.detail().as_object()) {
+        for (k, v) in extra {
+            obj.insert(k.clone(), v.clone());
+        }
+    }
+    (r.status(), Json(body)).into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn violation() -> serde_json::Value {
+        serde_json::json!({ "port": "review", "field": "verdict", "reason": "not in enum" })
+    }
+
+    /// Un échantillon par variante, produit derrière un `match` **exhaustif sans
+    /// joker** : ajouter une variante à `CompletionRefusal` sans l'échantillonner
+    /// ici ne compile plus. Même garde-fou que le dispatch d'`event_log`.
+    fn every_refusal() -> Vec<CompletionRefusal> {
+        let all = vec![
+            CompletionRefusal::RunForgotten {
+                run_id: "r1".into(),
+            },
+            CompletionRefusal::RunNotFound,
+            CompletionRefusal::Internal {
+                error: "failed to load events: db is locked".into(),
+            },
+            CompletionRefusal::CompletionRejected {
+                message: "resume the run first".into(),
+            },
+            CompletionRefusal::MergeFailed {
+                error: "boom".into(),
+            },
+            CompletionRefusal::MergeConflict {
+                node_id: "impl".into(),
+            },
+            CompletionRefusal::DocImmutabilityViolated {
+                node_id: "scribe".into(),
+            },
+            CompletionRefusal::MissingOutputs {
+                missing: vec!["review".into()],
+            },
+            CompletionRefusal::ScriptValidationFailed {
+                detail: serde_json::json!({ "kind": "missing_outputs", "missing": ["out"] }),
+            },
+            CompletionRefusal::FrontmatterRetryPending {
+                violations: vec![violation()],
+            },
+            CompletionRefusal::FrontmatterRetryExhausted {
+                violations: vec![violation()],
+            },
+            CompletionRefusal::AppendFailed {
+                error: "disk full".into(),
+            },
+            CompletionRefusal::MergeResolutionFailed {
+                reason: "still conflicted".into(),
+            },
+            CompletionRefusal::MergeResolverSpawned {
+                node_id: "impl".into(),
+            },
+            CompletionRefusal::MergeResolverFailed {
+                reason: "spawn failed".into(),
+            },
+        ];
+
+        // Plancher de couverture : le `match` sans joker force à nommer chaque
+        // variante, et le compte force l'échantillon à exister vraiment.
+        let mut seen = std::collections::BTreeSet::new();
+        for r in &all {
+            let key = match r {
+                CompletionRefusal::RunForgotten { .. } => "RunForgotten",
+                CompletionRefusal::RunNotFound => "RunNotFound",
+                CompletionRefusal::Internal { .. } => "Internal",
+                CompletionRefusal::CompletionRejected { .. } => "CompletionRejected",
+                CompletionRefusal::MergeFailed { .. } => "MergeFailed",
+                CompletionRefusal::MergeConflict { .. } => "MergeConflict",
+                CompletionRefusal::DocImmutabilityViolated { .. } => "DocImmutabilityViolated",
+                CompletionRefusal::MissingOutputs { .. } => "MissingOutputs",
+                CompletionRefusal::ScriptValidationFailed { .. } => "ScriptValidationFailed",
+                CompletionRefusal::FrontmatterRetryPending { .. } => "FrontmatterRetryPending",
+                CompletionRefusal::FrontmatterRetryExhausted { .. } => "FrontmatterRetryExhausted",
+                CompletionRefusal::AppendFailed { .. } => "AppendFailed",
+                CompletionRefusal::MergeResolutionFailed { .. } => "MergeResolutionFailed",
+                CompletionRefusal::MergeResolverSpawned { .. } => "MergeResolverSpawned",
+                CompletionRefusal::MergeResolverFailed { .. } => "MergeResolverFailed",
+            };
+            seen.insert(key);
+        }
+        assert_eq!(
+            seen.len(),
+            all.len(),
+            "every_refusal() must hold exactly one sample per variant"
+        );
+        all
+    }
+
+    /// **L'invariant du ticket, en une boucle.** Et il couvre les deux surfaces,
+    /// puisque les deux appelants passent par `refusal_response`.
+    #[test]
+    fn a_refusal_never_projects_to_a_2xx() {
+        for r in every_refusal() {
+            let status = refusal_response(&r).status();
+            assert!(
+                !status.is_success(),
+                "{} projected to a 2xx ({status})",
+                r.slug()
+            );
+            assert!(
+                status.is_client_error() || status.is_server_error(),
+                "{} projected to a non-error status ({status})",
+                r.slug()
+            );
+        }
+    }
+
+    /// Une variante qui oublierait `recoverable` ferait sortir `pdo complete` en
+    /// `1` au lieu de `3`/`4`, **silencieusement** — d'où l'assertion de type.
+    #[tokio::test]
+    async fn every_refusal_body_carries_error_and_recoverable() {
+        for r in every_refusal() {
+            let resp = refusal_response(&r);
+            let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+                .await
+                .expect("refusal body");
+            let body: serde_json::Value =
+                serde_json::from_slice(&bytes).expect("refusal body is JSON");
+            assert!(
+                body["error"].is_string(),
+                "{} has no string `error`: {body}",
+                r.slug()
+            );
+            assert_eq!(body["error"].as_str(), Some(r.slug()));
+            assert!(
+                body["recoverable"].is_boolean(),
+                "{} has no boolean `recoverable`: {body}",
+                r.slug()
+            );
+        }
+    }
+
+    /// `recoverable: true` veut dire « rien de terminal n'a été enregistré ». Les
+    /// deux seules variantes qui laissent le node vivant sont épinglées ici, parce
+    /// que c'est la valeur dont dépend le choix entre exit `3` et exit `4`.
+    #[test]
+    fn only_the_two_still_your_turn_refusals_are_recoverable() {
+        for r in every_refusal() {
+            let expected = matches!(
+                r,
+                CompletionRefusal::MissingOutputs { .. }
+                    | CompletionRefusal::FrontmatterRetryPending { .. }
+            );
+            assert_eq!(r.recoverable(), expected, "{} recoverable()", r.slug());
+        }
+    }
+
+    /// « Jamais `2xx` » **≠** « toujours `409` » : le tombstone d'ADR-0024, la
+    /// cible inconnue et les deux pannes gardent leur statut historique.
+    #[test]
+    fn non_conflict_statuses_are_preserved() {
+        let cases = [
+            (
+                CompletionRefusal::RunForgotten { run_id: "r".into() },
+                StatusCode::GONE,
+            ),
+            (CompletionRefusal::RunNotFound, StatusCode::NOT_FOUND),
+            (
+                CompletionRefusal::Internal { error: "e".into() },
+                StatusCode::INTERNAL_SERVER_ERROR,
+            ),
+            (
+                CompletionRefusal::MergeFailed { error: "e".into() },
+                StatusCode::INTERNAL_SERVER_ERROR,
+            ),
+            (
+                CompletionRefusal::AppendFailed { error: "e".into() },
+                StatusCode::INTERNAL_SERVER_ERROR,
+            ),
+        ];
+        for (r, want) in cases {
+            assert_eq!(refusal_response(&r).status(), want, "{}", r.slug());
+        }
+    }
+
+    /// Le détail est **verbatim celui d'avant #490** : `missing` reste une liste
+    /// plate, `detail` reste imbriqué (ADR-0035 §5), `violations` garde sa forme.
+    #[tokio::test]
+    async fn detail_fields_keep_their_pre_490_shape() {
+        async fn body_of(r: CompletionRefusal) -> serde_json::Value {
+            let bytes = axum::body::to_bytes(refusal_response(&r).into_body(), usize::MAX)
+                .await
+                .unwrap();
+            serde_json::from_slice(&bytes).unwrap()
+        }
+
+        let missing = body_of(CompletionRefusal::MissingOutputs {
+            missing: vec!["review".into()],
+        })
+        .await;
+        assert_eq!(missing["missing"], serde_json::json!(["review"]));
+
+        let script = body_of(CompletionRefusal::ScriptValidationFailed {
+            detail: serde_json::json!({ "kind": "missing_outputs", "missing": ["out"] }),
+        })
+        .await;
+        assert_eq!(script["detail"]["kind"], "missing_outputs");
+        assert_eq!(script["detail"]["missing"], serde_json::json!(["out"]));
+        // Pas aplati : une trace d'audit de fail-fast reste distinguable d'un
+        // échec après retry.
+        assert!(script.get("missing").is_none());
+
+        let exhausted = body_of(CompletionRefusal::FrontmatterRetryExhausted {
+            violations: vec![violation()],
+        })
+        .await;
+        assert_eq!(exhausted["violations"][0]["field"], "verdict");
+    }
+
+    /// La prose du garde de transition part dans `message`, jamais dans `error` :
+    /// c'est ce qui laissait le client relire *tout* `409` comme `missing_outputs`
+    /// avec une liste vide, donc n'afficher **rien**.
+    #[tokio::test]
+    async fn the_transition_guard_prose_lands_in_message() {
+        let r = CompletionRefusal::CompletionRejected {
+            message: "run r1 is failed; resume the run first".into(),
+        };
+        let resp = refusal_response(&r);
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(body["error"], "completion_rejected");
+        assert_eq!(body["recoverable"], false);
+        assert!(body["message"]
+            .as_str()
+            .unwrap()
+            .contains("resume the run first"));
+    }
+}

--- a/crates/pdo-daemon/src/event_log.rs
+++ b/crates/pdo-daemon/src/event_log.rs
@@ -430,6 +430,18 @@ pub struct NodeState {
     pub frontmatter_retries: i64,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub frontmatter_violations: Vec<serde_json::Value>,
+    /// #490: declared output ports the validator found empty, from a `script`
+    /// node's fail-fast branch (`ValidationError::MissingOutputs`). Mutually
+    /// exclusive with `frontmatter_violations` by construction — `ValidationError`
+    /// is an exclusive-or, so no discriminator field is needed.
+    ///
+    /// Without a home, a `script` node that failed on a *missing output* rendered
+    /// the red banner with an empty list: the daemon computed the evidence and the
+    /// projector threw it away. `skip_serializing_if` mirrors its neighbour, so the
+    /// field is **absent** from every pre-#490 response and the wire shape is
+    /// byte-identical for any non-`script` failure.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub missing_outputs: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1299,6 +1311,7 @@ fn apply_node_event(state: &mut RunState, event: &Event) {
                         iterations: Vec::new(),
                         frontmatter_retries: 0,
                         frontmatter_violations: Vec::new(),
+                        missing_outputs: Vec::new(),
                     });
                 node.status = NodeStatus::Waiting;
                 node.iter = iter;
@@ -1331,12 +1344,21 @@ fn apply_node_event(state: &mut RunState, event: &Event) {
                         iterations: Vec::new(),
                         frontmatter_retries: 0,
                         frontmatter_violations: Vec::new(),
+                        missing_outputs: Vec::new(),
                     });
                 node.status = NodeStatus::Running;
                 node.iter = iter;
                 node.started_at = Some(event.ts.clone());
                 node.completed_at = None;
                 node.failure_reason = None;
+                // #490, pre-existing bug: this arm reset `completed_at` and
+                // `failure_reason` but not the evidence vectors, so a *successful*
+                // retry left stale violations on a green node — visible in the
+                // projection golden itself, where a `completed` node still carried
+                // its `frontmatter_violations`. A new attempt starts with no
+                // evidence against it.
+                node.frontmatter_violations = Vec::new();
+                node.missing_outputs = Vec::new();
                 upsert_iteration(&mut node.iterations, iteration);
             }
         }
@@ -1380,9 +1402,35 @@ fn apply_node_event(state: &mut RunState, event: &Event) {
                                 .get("reason")
                                 .and_then(|v| v.as_str())
                                 .map(String::from);
-                            if let Some(arr) = payload.get("violations").and_then(|v| v.as_array())
+                            // #490: read BOTH shapes of the validation evidence. The
+                            // after-retry branch puts `violations` at the top level;
+                            // the `script` fail-fast branch nests everything under
+                            // `detail` (`{kind, violations|missing}`), and nothing
+                            // used to read that — the field was computed and dropped.
+                            // Fixed at the consumer, not by flattening the producer:
+                            // the nesting is what keeps a fail-fast audit trail
+                            // distinguishable from an after-retry one (ADR-0035 §5).
+                            //
+                            // Collision-checked: the only other payload carrying
+                            // `detail` is `MergeConflictDetected`, which routes to
+                            // `apply_merge_event` and never reaches this arm.
+                            let detail = payload.get("detail");
+                            if let Some(arr) = payload
+                                .get("violations")
+                                .or_else(|| detail.and_then(|d| d.get("violations")))
+                                .and_then(|v| v.as_array())
                             {
                                 node.frontmatter_violations = arr.clone();
+                            }
+                            if let Some(arr) = payload
+                                .get("missing")
+                                .or_else(|| detail.and_then(|d| d.get("missing")))
+                                .and_then(|v| v.as_array())
+                            {
+                                node.missing_outputs = arr
+                                    .iter()
+                                    .filter_map(|v| v.as_str().map(String::from))
+                                    .collect();
                             }
                         }
                     }
@@ -1476,6 +1524,7 @@ fn apply_switch_event(state: &mut RunState, event: &Event) {
                     iterations: Vec::new(),
                     frontmatter_retries: 0,
                     frontmatter_violations: Vec::new(),
+                    missing_outputs: Vec::new(),
                 });
             node.status = NodeStatus::Completed;
             node.completed_at = Some(event.ts.clone());
@@ -2723,6 +2772,117 @@ mod tests {
         assert_eq!(node.frontmatter_violations.len(), 2);
         assert_eq!(node.frontmatter_violations[0]["field"], "verdict");
         assert_eq!(node.frontmatter_violations[1]["field"], "score");
+    }
+
+    /// #490 — the twin of the test above, for the `script` fail-fast shape, which
+    /// nests everything under `detail`. Nothing read `payload.detail` before this
+    /// issue: the daemon computed the evidence and the projector dropped it, so the
+    /// red banner rendered a list of nothing.
+    #[test]
+    fn projects_nested_detail_violations_of_a_script_fail_fast() {
+        let events = vec![
+            make_event(EventKind::RunStarted, None, None),
+            make_event(EventKind::NodeStarted, Some("silent"), Some(1)),
+            make_event_with_payload(
+                EventKind::NodeFailed,
+                Some("silent"),
+                serde_json::json!({
+                    "reason": "script output validation failed",
+                    "detail": {
+                        "kind": "frontmatter_mismatch",
+                        "violations": [
+                            { "port": "out", "field": "verdict", "reason": "not in allowed" },
+                        ],
+                    },
+                }),
+            ),
+            make_event(EventKind::RunFailed, None, None),
+        ];
+
+        let node = &project(&events).unwrap().nodes["silent"];
+        assert_eq!(node.frontmatter_violations.len(), 1);
+        assert_eq!(node.frontmatter_violations[0]["field"], "verdict");
+        assert!(
+            node.missing_outputs.is_empty(),
+            "exclusive-or by construction"
+        );
+    }
+
+    /// The other half of the same nesting: a `script` node that never wrote its
+    /// declared output. `missing_outputs` had NO home at all — Rust or TS — before
+    /// #490, which is why the banner listed nothing.
+    #[test]
+    fn projects_nested_detail_missing_outputs_of_a_script_fail_fast() {
+        let events = vec![
+            make_event(EventKind::RunStarted, None, None),
+            make_event(EventKind::NodeStarted, Some("silent"), Some(1)),
+            make_event_with_payload(
+                EventKind::NodeFailed,
+                Some("silent"),
+                serde_json::json!({
+                    "reason": "script output validation failed",
+                    "detail": { "kind": "missing_outputs", "missing": ["out", "log"] },
+                }),
+            ),
+        ];
+
+        let node = &project(&events).unwrap().nodes["silent"];
+        assert_eq!(node.missing_outputs, vec!["out", "log"]);
+        assert!(node.frontmatter_violations.is_empty());
+    }
+
+    /// A `MergeConflictDetected` also carries a `detail`, but it routes to
+    /// `apply_merge_event` and never reaches the `NodeFailed` arm. Pinned so the
+    /// `detail` lookup added by #490 cannot be read as a collision waiting to happen.
+    #[test]
+    fn a_merge_conflict_detail_never_lands_in_the_node_evidence() {
+        let events = vec![
+            make_event(EventKind::RunStarted, None, None),
+            make_event(EventKind::NodeStarted, Some("impl"), Some(1)),
+            make_event_with_payload(
+                EventKind::MergeConflictDetected,
+                Some("impl"),
+                serde_json::json!({
+                    "reason": "conflict merging impl into pipeline branch",
+                    "detail": "CONFLICT (content): Merge conflict in shared.txt",
+                }),
+            ),
+        ];
+
+        let node = &project(&events).unwrap().nodes["impl"];
+        assert!(node.frontmatter_violations.is_empty());
+        assert!(node.missing_outputs.is_empty());
+    }
+
+    /// #490, pre-existing bug: a *successful* retry used to leave stale violations on
+    /// a green node — `NodeStarted` reset `completed_at` and `failure_reason` but not
+    /// the evidence vectors. Visible in the projection golden itself, where a
+    /// `completed` node still carried them.
+    #[test]
+    fn a_new_attempt_purges_the_evidence_of_the_previous_one() {
+        let events = vec![
+            make_event(EventKind::RunStarted, None, None),
+            make_event(EventKind::NodeStarted, Some("reviewer"), Some(1)),
+            make_event_with_payload(
+                EventKind::NodeFailed,
+                Some("reviewer"),
+                serde_json::json!({
+                    "reason": "output validation failed",
+                    "violations": [{ "port": "review", "field": "verdict", "reason": "nope" }],
+                    "missing": ["review"],
+                }),
+            ),
+            make_event(EventKind::NodeStarted, Some("reviewer"), Some(2)),
+            make_event(EventKind::NodeCompleted, Some("reviewer"), Some(2)),
+        ];
+
+        let node = &project(&events).unwrap().nodes["reviewer"];
+        assert_eq!(node.status, NodeStatus::Completed);
+        assert!(
+            node.frontmatter_violations.is_empty(),
+            "a green node must not carry the violations of the attempt it recovered from"
+        );
+        assert!(node.missing_outputs.is_empty());
     }
 
     #[test]
@@ -4646,6 +4806,7 @@ mod tests {
                 .collect(),
             frontmatter_retries: 0,
             frontmatter_violations: Vec::new(),
+            missing_outputs: Vec::new(),
         }
     }
 
@@ -5550,9 +5711,15 @@ mod tests {
                     "iterations": [ { "completed_at": "2026-02-01T00:05:00.000Z", "iter": 1, "started_at": "2026-02-01T00:05:00.000Z", "status": "completed" } ],
                     "node_id": "sw", "started_at": "2026-02-01T00:05:00.000Z", "status": "completed"
                 },
+                // #490: `worker` failed iter 1 on a frontmatter mismatch, then
+                // succeeded on iter 2. It carries NO `frontmatter_violations` any
+                // more — `NodeStarted` purges the evidence vectors, so a green node
+                // no longer shows the violations of the attempt it recovered from.
+                // This is the ONE justified edit to this golden: `missing_outputs`
+                // is `skip_serializing_if`-empty everywhere, so every other byte is
+                // unchanged — which is the wire-compatibility proof.
                 "worker": {
                     "completed_at": "2026-02-01T00:02:03.000Z", "failure_reason": null, "frontmatter_retries": 0,
-                    "frontmatter_violations": [ { "field": "verdict", "port": "out", "reason": "not allowed" } ],
                     "iter": 2,
                     "iterations": [
                         { "completed_at": "2026-02-01T00:02:01.000Z", "iter": 1, "started_at": "2026-02-01T00:02:00.000Z", "status": "failed" },

--- a/crates/pdo-daemon/src/graph_resolver.rs
+++ b/crates/pdo-daemon/src/graph_resolver.rs
@@ -529,6 +529,7 @@ mod tests {
             iterations: Vec::new(),
             frontmatter_retries: 0,
             frontmatter_violations: Vec::new(),
+            missing_outputs: Vec::new(),
         }
     }
 
@@ -543,6 +544,7 @@ mod tests {
             iterations: Vec::new(),
             frontmatter_retries: 0,
             frontmatter_violations: Vec::new(),
+            missing_outputs: Vec::new(),
         }
     }
 

--- a/crates/pdo-daemon/src/input_resolution.rs
+++ b/crates/pdo-daemon/src/input_resolution.rs
@@ -220,6 +220,7 @@ mod tests {
                 .collect(),
             frontmatter_retries: 0,
             frontmatter_violations: Vec::new(),
+            missing_outputs: Vec::new(),
         }
     }
 

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod admission;
 mod blackboard;
 mod boot_recovery;
+pub(crate) mod completion_refusal;
 #[allow(dead_code)]
 mod condition;
 #[allow(dead_code)]
@@ -495,28 +496,232 @@ fn cli_node_iter() -> i64 {
         .unwrap_or(1)
 }
 
-pub fn run_complete() -> Result<()> {
+/// Exit code of `pdo complete` when the completion was **refused and the node is
+/// still yours** (#490, ADR-0035 §4): fix the artefacts and call it again. Nothing
+/// terminal is recorded, so `pdo fail` would be wrong.
+pub const EXIT_REFUSED_RECOVERABLE: u8 = 3;
+/// Exit code of `pdo complete` when the completion was **refused and the runtime has
+/// already ruled** (#490, ADR-0035 §4). The daemon appended the terminal event
+/// itself; `pdo fail` would double it — and `RunFailed` is not guarded, so the
+/// second one lands with a false reason.
+///
+/// This code exists for a `||` in a `script` node's bash tail (see
+/// `tmux_session_manager::build_script_tail`), which was dead code while every
+/// refusal answered `200`. The code is only worth anything because the tail tests
+/// it.
+pub const EXIT_REFUSED_TERMINAL: u8 = 4;
+
+/// `pdo complete` — signal that this node iteration is done.
+///
+/// Returns an [`ExitCode`](std::process::ExitCode) rather than a `Result` because it
+/// is the one subcommand with a **public exit-code contract** (#490, ADR-0035 §4):
+/// `0` granted or legal duplicate · `3` refused, still your turn · `4` refused, the
+/// runtime already ruled · `1` breakdown. Those codes live in pipeline authors' bash
+/// (ADR-0001, sharp tool), so they are as much an API as the wire shape.
+///
+/// Deliberately **not** `std::process::exit`: that skips the `reqwest` client's
+/// destructors and breaks the symmetry with the other subcommands. Returning the
+/// code lets `main` stay a dispatcher.
+pub fn run_complete() -> std::process::ExitCode {
+    let rid = match cli_run_id() {
+        Ok(v) => v,
+        Err(e) => return complete_breakdown(&format!("{e:#}")),
+    };
+    let nid = match cli_node_id() {
+        Ok(v) => v,
+        Err(e) => return complete_breakdown(&format!("{e:#}")),
+    };
     let url = cli_daemon_url();
-    let rid = cli_run_id()?;
-    let nid = cli_node_id()?;
     let iter = cli_node_iter();
 
     let endpoint = format!("{url}/runs/{rid}/nodes/{nid}/done");
     let client = reqwest::blocking::Client::new();
-    let resp = client
+    let resp = match client
         .post(&endpoint)
         .json(&serde_json::json!({ "iter": iter }))
         .send()
-        .context("failed to reach daemon")?;
+    {
+        Ok(r) => r,
+        Err(e) => return complete_breakdown(&format!("failed to reach daemon: {e}")),
+    };
 
-    if resp.status().is_success() {
-        eprintln!("Node {nid} marked complete.");
-    } else {
-        let status = resp.status();
-        let body = resp.text().unwrap_or_default();
-        anyhow::bail!("daemon returned {status}: {body}");
+    let status = resp.status();
+    let raw = resp.text().unwrap_or_default();
+    // The success body of `POST …/done` is the bare text `ok`, so a parse failure is
+    // expected there and must not be treated as a breakdown (#491 owns the
+    // asymmetry). `Value::Null` stands in for "no readable body".
+    let body: serde_json::Value = serde_json::from_str(&raw).unwrap_or(serde_json::Value::Null);
+
+    if status.is_success() {
+        if body.get("noop").and_then(|v| v.as_bool()) == Some(true) {
+            let reason = body
+                .get("reason")
+                .and_then(|v| v.as_str())
+                .unwrap_or("the node iteration was already terminal");
+            eprintln!(
+                "Node {nid} was already complete — nothing to do ({reason}).\n\
+                 This is a legal duplicate, not a failure. Do NOT run `pdo fail`."
+            );
+        } else {
+            eprintln!("Node {nid} marked complete.");
+        }
+        return std::process::ExitCode::SUCCESS;
     }
-    Ok(())
+
+    // A 5xx is a breakdown, not a verdict: the daemon could not decide, so nothing
+    // was ruled and `pdo fail` is the right escalation.
+    if status.is_server_error() {
+        return complete_breakdown(&format!("daemon returned {status}: {raw}"));
+    }
+    // A body we cannot read cannot be discriminated, so it is a breakdown too —
+    // never a silent success.
+    let Some(slug) = body.get("error").and_then(|v| v.as_str()) else {
+        return complete_breakdown(&format!(
+            "daemon returned {status} with an unreadable body: {raw}"
+        ));
+    };
+    let recoverable = body.get("recoverable").and_then(|v| v.as_bool());
+
+    let mut out = String::new();
+    match recoverable {
+        Some(true) => out.push_str(&format!(
+            "pdo complete REFUSED — {}. The node is still running; it is still your turn.\n",
+            refusal_headline(slug, &body)
+        )),
+        Some(false) => out.push_str(&format!(
+            "pdo complete REFUSED and the node is now FAILED — {}.\n\
+             The daemon has already recorded the terminal event. `resume_run` is the only lever.\n",
+            refusal_headline(slug, &body)
+        )),
+        // No `recoverable` key: an older daemon, or a refusal that predates the
+        // contract. Say so instead of guessing which side of the fence we are on.
+        None => out.push_str(&format!(
+            "pdo complete REFUSED — {} (daemon returned {status} without a `recoverable` \
+             flag, so whether the node is still yours is unknown).\n",
+            refusal_headline(slug, &body)
+        )),
+    }
+    out.push_str(&refusal_detail_lines(slug, &body));
+    out.push_str(match recoverable {
+        Some(true) => {
+            "Fix what is listed above, then run `pdo complete` again.\nDo NOT run `pdo fail`."
+        }
+        Some(false) => {
+            "Do NOT run `pdo fail` — the failure is already recorded. Stop here and report it."
+        }
+        None => "Re-read the run state before acting. Do NOT run `pdo fail` blindly.",
+    });
+    eprintln!("{out}");
+
+    match recoverable {
+        Some(true) => std::process::ExitCode::from(EXIT_REFUSED_RECOVERABLE),
+        // Unknown recoverability is treated as terminal: the expensive mistake is
+        // appending a second failure, not skipping a retry.
+        Some(false) | None => std::process::ExitCode::from(EXIT_REFUSED_TERMINAL),
+    }
+}
+
+/// The `1` arm of `pdo complete`: transport, missing env, unreadable body, `5xx`.
+/// The **only** arm where `pdo fail` is the right advice.
+fn complete_breakdown(detail: &str) -> std::process::ExitCode {
+    eprintln!(
+        "pdo complete FAILED to get a verdict — {detail}\n\
+         Nothing was decided about this node. Retry, or signal the problem with \
+         `pdo fail --reason \"…\"`."
+    );
+    std::process::ExitCode::FAILURE
+}
+
+/// One human sentence per refusal slug. An unknown slug is rendered **verbatim**
+/// (ADR-0001): a client that does not recognise a cause must not hide it.
+fn refusal_headline(slug: &str, body: &serde_json::Value) -> String {
+    match slug {
+        "missing_outputs" => "your declared outputs are incomplete".into(),
+        "frontmatter_retry_pending" => {
+            "your output frontmatter does not match the declared schema (this was the ONE retry \
+             you get)"
+                .into()
+        }
+        "frontmatter_retry_exhausted" => {
+            "your output frontmatter still did not match after the retry".into()
+        }
+        "script_validation_failed" => "this script node's declared outputs did not validate".into(),
+        "doc_violated_code_immutability" => {
+            "this node may not modify tracked files, and the worktree is dirty".into()
+        }
+        "merge_conflict" => "merging your sub-worktree into the pipeline branch conflicted".into(),
+        "merge_resolution_failed" | "merge_resolver_failed" | "merge_resolver_spawned" => {
+            "the merge resolver did not settle the conflict".into()
+        }
+        "completion_rejected" => body
+            .get("message")
+            .and_then(|v| v.as_str())
+            .unwrap_or("the run does not accept this completion")
+            .to_string(),
+        "run_forgotten" => "this run has been forgotten (archived); it accepts nothing".into(),
+        // Unknown slug: hand it over as-is, plus whatever prose came with it.
+        other => match body.get("message").and_then(|v| v.as_str()) {
+            Some(m) => format!("{other}: {m}"),
+            None => other.to_string(),
+        },
+    }
+}
+
+/// The actionable middle of the message: what exactly is wrong, one item per line.
+/// Reads both shapes of the validation detail — flat (`violations`/`missing`) and
+/// the `script` fail-fast's nested `detail` (ADR-0035 §5) — so the agent gets the
+/// list either way.
+fn refusal_detail_lines(slug: &str, body: &serde_json::Value) -> String {
+    let mut out = String::new();
+
+    let nested = body.get("detail");
+    let missing = body
+        .get("missing")
+        .or_else(|| nested.and_then(|d| d.get("missing")))
+        .and_then(|v| v.as_array());
+    if let Some(missing) = missing {
+        if !missing.is_empty() {
+            out.push_str("Missing declared outputs:\n");
+            for m in missing {
+                if let Some(m) = m.as_str() {
+                    out.push_str(&format!("  - {m}\n"));
+                }
+            }
+            out.push_str(
+                "Write each missing artefact to the path listed in your prompt preamble.\n",
+            );
+        }
+    }
+
+    let violations = body
+        .get("violations")
+        .or_else(|| nested.and_then(|d| d.get("violations")))
+        .and_then(|v| v.as_array());
+    if let Some(violations) = violations {
+        if !violations.is_empty() {
+            out.push_str("Frontmatter violations:\n");
+            for v in violations {
+                let port = v.get("port").and_then(|x| x.as_str()).unwrap_or("?");
+                let field = v.get("field").and_then(|x| x.as_str()).unwrap_or("?");
+                let reason = v.get("reason").and_then(|x| x.as_str()).unwrap_or("?");
+                out.push_str(&format!("  - {port}.{field}: {reason}\n"));
+            }
+        }
+    }
+
+    if let Some(reason) = body.get("reason").and_then(|v| v.as_str()) {
+        out.push_str(&format!("Reason: {reason}\n"));
+    }
+    // The guard's prose is already the headline; anything else's `message` is extra
+    // context worth printing once.
+    if slug != "completion_rejected" {
+        if let Some(msg) = body.get("message").and_then(|v| v.as_str()) {
+            if !msg.is_empty() && !slug.starts_with("run_") {
+                out.push_str(&format!("Detail: {msg}\n"));
+            }
+        }
+    }
+    out
 }
 
 pub fn run_fail(reason: String) -> Result<()> {
@@ -9034,13 +9239,22 @@ async fn run_stale_detection(state: &Arc<AppState>) {
                     )
                     .await
                     {
+                        // Reads the VARIANT, never the status — which is exactly
+                        // why #469 is indemn to #490's status change. The response
+                        // is still dropped; only the log line differs.
                         CompletionAttempt::Completed => info!(
                             "Stale detector: node {node_id} in run {run_id} — agent finished its \
                              turn without signalling; auto-completed (#469)"
                         ),
-                        CompletionAttempt::Aborted { reason, .. } => info!(
+                        noop @ CompletionAttempt::NoOp { .. } => info!(
                             "Stale detector: node {node_id} in run {run_id} — turn ended but \
-                             auto-completion did not apply: {reason}"
+                             auto-completion was a legal no-op: {}",
+                            noop.reason()
+                        ),
+                        refused @ CompletionAttempt::Refused { .. } => warn!(
+                            "Stale detector: node {node_id} in run {run_id} — turn ended but \
+                             auto-completion was refused: {}",
+                            refused.reason()
                         ),
                     }
                 }
@@ -9544,13 +9758,20 @@ async fn artifact(
     }
 }
 
+/// Spawn the automatic merge resolver. **DEAD in production** since ADR-0006:
+/// reached only from `MergeResult::ConflictPendingResolution`, which is built only
+/// under `keep_conflict == true`, which no production caller passes.
+///
+/// Returns a typed refusal rather than a `Response` (#490, ADR-0035 §6): both its
+/// outcomes — spawned, and spawn-failed — describe a completion that was **not**
+/// granted, and both used to answer `200`.
 async fn spawn_merge_resolver(
     state: &AppState,
     run_id: &str,
     conflicting_node_id: &str,
     conflicting_iter: i64,
     worktree_dir: &std::path::Path,
-) -> Response {
+) -> completion_refusal::CompletionRefusal {
     let prompt = load_merge_resolver_prompt(&state.repo_root);
     let session_name = tmux_session_manager::node_session_name(run_id, MERGE_RESOLVER_NODE_ID, 1);
 
@@ -9628,19 +9849,15 @@ async fn spawn_merge_resolver(
         };
         let _ = append_event(state, &run_failed).await;
 
-        return (
-            StatusCode::OK,
-            Json(serde_json::json!({ "status": "merge_resolver_failed" })),
-        )
-            .into_response();
+        return completion_refusal::CompletionRefusal::MergeResolverFailed {
+            reason: format!("failed to spawn resolver session: {e}"),
+        };
     }
 
     info!("Spawned merge resolver for run {run_id} (conflict on {conflicting_node_id})");
-    (
-        StatusCode::OK,
-        Json(serde_json::json!({ "status": "merge_resolver_spawned" })),
-    )
-        .into_response()
+    completion_refusal::CompletionRefusal::MergeResolverSpawned {
+        node_id: conflicting_node_id.to_string(),
+    }
 }
 
 async fn handle_merge_resolver_done(
@@ -9684,11 +9901,11 @@ async fn handle_merge_resolver_done(
         let _ = append_event(state, &run_failed).await;
 
         warn!("Merge resolver failed for run {run_id}: {reason}");
-        return (
-            StatusCode::OK,
-            Json(serde_json::json!({ "status": "merge_resolution_failed", "reason": reason })),
-        )
-            .into_response();
+        // #490 / ADR-0035: `409` with the slug, not the historical `200`. The
+        // resolution was refused and `RunFailed` is already appended.
+        return completion_refusal::refusal_response(
+            &completion_refusal::CompletionRefusal::MergeResolutionFailed { reason },
+        );
     }
 
     let completed_event = event_log::Event {
@@ -9740,40 +9957,68 @@ async fn handle_merge_resolver_done(
     (StatusCode::OK, "ok").into_response()
 }
 
-/// Map a completion-head verdict to an early HTTP response, or `None` to
-/// proceed. Shared by the three completion handlers (`node_done`,
-/// `mark_node_done`, `node_skip`) so the 409/200 shape + log line live once.
+/// What the shared completion head decided, in the two shapes an HTTP caller has
+/// to answer differently (#490, ADR-0035).
 ///
-/// Returns `Option<Response>` (not `Result`) to match the sibling
-/// `check_output_validation_with_retry` early-return convention and dodge
-/// `clippy::result_large_err` on the large `Response` type.
+/// The split matters: a **no-op is a legal duplicate and stays a `2xx`**
+/// (`transition_guard`: "do not surface an error"), a **reject is a refusal and is
+/// never a `2xx`**. Collapsing them — which the pre-#490 `Option<Response>` did,
+/// by handing back a pre-projected response the caller could not tell apart — is
+/// exactly what made the invariant inexpressible.
+pub(crate) enum CompletionHeadStop {
+    /// Valid but nothing to do. `200 {"ok":true,"noop":true,"reason":…}`, exit `0`.
+    NoOp { reason: String },
+    /// The completion is not granted. Projected by `refusal_response`, so it
+    /// cannot be a `2xx` by construction.
+    Refused {
+        refusal: completion_refusal::CompletionRefusal,
+    },
+}
+
+impl CompletionHeadStop {
+    /// The HTTP shape. `NoOp` keeps its pre-#490 body byte for byte.
+    fn into_response(self) -> Response {
+        match self {
+            CompletionHeadStop::NoOp { reason } => (
+                StatusCode::OK,
+                Json(serde_json::json!({ "ok": true, "noop": true, "reason": reason })),
+            )
+                .into_response(),
+            CompletionHeadStop::Refused { refusal } => {
+                completion_refusal::refusal_response(&refusal)
+            }
+        }
+    }
+}
+
+/// Map a completion-head verdict to an early stop, or `None` to proceed. Shared by
+/// the three completion handlers (`node_done`, `mark_node_done`, `node_skip`) so
+/// the wire shape + log line live once.
+///
+/// Returns the **typed** stop rather than a `Response`: the reject arm's prose now
+/// travels in `message` under the `completion_rejected` slug (ADR-0035 §3), which
+/// is what lets a client tell "resume the run first" apart from "your outputs are
+/// missing" — it used to read *every* `409` on this path as `missing_outputs` with
+/// an empty list, and therefore displayed nothing at all.
 fn completion_head_gate(
     head: run_advance::CompletionHead,
     caller: &str,
     run_id: &str,
     node_id: &str,
     iter: i64,
-) -> Option<Response> {
+) -> Option<CompletionHeadStop> {
     match head {
         run_advance::CompletionHead::Reject { reason } => {
             warn!("{caller} rejected for {node_id} iter {iter} in run {run_id}: {reason}");
-            Some(
-                (
-                    StatusCode::CONFLICT,
-                    Json(serde_json::json!({ "error": reason })),
-                )
-                    .into_response(),
-            )
+            Some(CompletionHeadStop::Refused {
+                refusal: completion_refusal::CompletionRefusal::CompletionRejected {
+                    message: reason,
+                },
+            })
         }
         run_advance::CompletionHead::NoOp { reason } => {
             info!("{caller} no-op for {node_id} iter {iter} in run {run_id}: {reason}");
-            Some(
-                (
-                    StatusCode::OK,
-                    Json(serde_json::json!({ "ok": true, "noop": true, "reason": reason })),
-                )
-                    .into_response(),
-            )
+            Some(CompletionHeadStop::NoOp { reason })
         }
         run_advance::CompletionHead::Allow => None,
     }
@@ -9815,30 +10060,45 @@ impl CompletionSource {
     }
 }
 
-/// What one pass through [`complete_node_iteration`] did (#469 §3).
+/// What one pass through [`complete_node_iteration`] did (#469 §3, #490 §1).
 ///
-/// Two variants only, deliberately: either the terminal event landed and the
-/// detached tail is scheduled, or the attempt stopped short. Every early return
-/// of the shared body funnels into [`Self::Aborted`], so the HTTP handler and the
-/// sweep cannot disagree about *which* branches abort — the handler returns the
-/// carried `response`, the sweep logs the carried `reason` and drops it.
+/// **Three** variants since #490, and the third one is the point: `Aborted` used to
+/// conflate three different things — a refusal, a legal no-op, and (at the merge
+/// resolver site) an outright *success* wrapped in the failure variant. That
+/// conflation is why "an aborted attempt is never a 2xx" was false by construction.
+/// With `Refused` carrying a [`completion_refusal::CompletionRefusal`] — a type
+/// that owns no status — the invariant is total and enforced by the compiler.
 pub(crate) enum CompletionAttempt {
     /// The terminal event is appended (durable) and the tail is scheduled. The
     /// `2xx` an HTTP caller gets means exactly that, not "advanced" (ADR-0023).
     Completed,
-    /// Nothing was completed. `reason` is the log-friendly cause; `response` is
-    /// the verbatim HTTP shape `POST …/done` has always returned for it.
-    Aborted {
-        reason: String,
-        response: Box<Response>,
+    /// Valid, but nothing to do: a legal duplicate on an already-terminal node.
+    /// The **only** non-`Completed` variant allowed a `2xx` — cf. ADR-0025 §3 and
+    /// `transition_guard`: "legal duplicate […] do not surface an error". A
+    /// puzzled agent that re-runs `pdo complete` must not read "refused" and then
+    /// chain `pdo fail`; on a `script` node its tail would do it unprompted.
+    NoOp { reason: String },
+    /// The completion is not granted. `Refused ⇒ never 2xx`, by construction: the
+    /// carried refusal has no status of its own, and `refusal_response` is the only
+    /// thing that gives it one.
+    Refused {
+        refusal: completion_refusal::CompletionRefusal,
     },
 }
 
 impl CompletionAttempt {
-    fn aborted(reason: impl Into<String>, response: Response) -> Self {
-        CompletionAttempt::Aborted {
-            reason: reason.into(),
-            response: Box::new(response),
+    /// Sugar for the many early returns of the shared body.
+    fn refused(refusal: completion_refusal::CompletionRefusal) -> Self {
+        CompletionAttempt::Refused { refusal }
+    }
+
+    /// The log-friendly cause, for the liveness sweep — which reads the *variant*,
+    /// never the status, and is therefore indemn to #490 (#469 / ADR-0032).
+    fn reason(&self) -> String {
+        match self {
+            CompletionAttempt::Completed => "completed".into(),
+            CompletionAttempt::NoOp { reason } => reason.clone(),
+            CompletionAttempt::Refused { refusal } => refusal.reason(),
         }
     }
 
@@ -9846,7 +10106,14 @@ impl CompletionAttempt {
     fn into_response(self) -> Response {
         match self {
             CompletionAttempt::Completed => (StatusCode::OK, "ok").into_response(),
-            CompletionAttempt::Aborted { response, .. } => *response,
+            CompletionAttempt::NoOp { reason } => (
+                StatusCode::OK,
+                Json(serde_json::json!({ "ok": true, "noop": true, "reason": reason })),
+            )
+                .into_response(),
+            CompletionAttempt::Refused { refusal } => {
+                completion_refusal::refusal_response(&refusal)
+            }
         }
     }
 }
@@ -9865,25 +10132,76 @@ async fn node_done(
     body: Option<Json<NodeDoneRequest>>,
 ) -> Response {
     let iter = body.and_then(|b| b.iter).unwrap_or(1);
+
+    // #490 / ADR-0035 §6: `__merge_resolver__` is handled HERE, hoisted out of the
+    // shared body. It was the one site where the shared body's failure variant
+    // wrapped a complete *success* — the resolver handler appends `NodeCompleted`
+    // and calls `run_advance::complete_node`, and its `200 "ok"` is pinned by
+    // `merge_resolver_done_records_original_node_and_completes_once`. That is what
+    // kept "a stopped-short attempt is never a 2xx" from being a total invariant.
+    // Hoisting also removes the transition-guard bypass the branch performed by
+    // sitting *before* the guard.
+    //
+    // Safe: the liveness sweep is the other caller of the shared body and can never
+    // reach this id — no resolver session is ever spawned, since `keep_conflict` is
+    // never `true` in production and ADR-0006 removed the automatic resolver.
+    if node_id == MERGE_RESOLVER_NODE_ID {
+        return merge_resolver_done(&state, &run_id).await;
+    }
+
     complete_node_iteration(&state, run_id, node_id, iter, CompletionSource::Explicit)
         .await
         .into_response()
+}
+
+/// The `__merge_resolver__` half of `POST …/nodes/:id/done` (#490, ADR-0035 §6).
+///
+/// Keeps the pre-hoist preamble in its original order — forgotten-run tombstone
+/// (#328 / ADR-0024) **before** any side effect, then load + project — and hands off
+/// to [`handle_merge_resolver_done`], whose wire shape (including `200 "ok"` on
+/// success) is preserved verbatim.
+async fn merge_resolver_done(state: &Arc<AppState>, run_id: &str) -> Response {
+    match run_is_forgotten(&state.db, run_id).await {
+        Ok(true) => {
+            return completion_refusal::refusal_response(
+                &completion_refusal::CompletionRefusal::RunForgotten {
+                    run_id: run_id.to_string(),
+                },
+            );
+        }
+        Ok(false) => {}
+        Err(e) => {
+            return completion_refusal::refusal_response(
+                &completion_refusal::CompletionRefusal::MergeFailed {
+                    error: format!("forgotten-run check failed: {e}"),
+                },
+            );
+        }
+    }
+
+    let Some((_, pre_run_state)) = reload_run_state(state, run_id).await else {
+        return completion_refusal::refusal_response(
+            &completion_refusal::CompletionRefusal::RunNotFound,
+        );
+    };
+    let repo_root = effective_repo_root(state, &pre_run_state);
+    let worktree_dir = worktree_dir_for_run(&repo_root, run_id);
+    handle_merge_resolver_done(state, run_id, &worktree_dir, &pre_run_state).await
 }
 
 /// The shared node-completion body: everything `POST …/done` does, for either
 /// caller (#469 §3).
 ///
 /// Returns [`CompletionAttempt`] rather than a `Response` so the sweep is not
-/// forced to read HTTP status codes to know what happened — while the response
-/// each abort would have produced is carried verbatim, so the handler stays a
-/// two-line adapter and no branch can be answered differently by the two
-/// callers.
+/// forced to read HTTP status codes to know what happened — and, since #490, so
+/// that no branch *can* answer a refusal with a `2xx`: the variant carries a
+/// [`completion_refusal::CompletionRefusal`], which owns no status, and the single
+/// projection gives it one. The handler stays a thin adapter and the two callers
+/// still cannot disagree about which branches stop short.
 ///
-/// `MERGE_RESOLVER_NODE_ID` keeps its own handler
-/// (`handle_merge_resolver_done`): it has no transition-guard head and no
-/// iteration of its own. The sweep never reaches it (a resolver is not a
-/// projected node in `running_nodes`), so the branch is preserved here purely for
-/// the HTTP caller.
+/// `MERGE_RESOLVER_NODE_ID` is **not** handled here any more: #490 (ADR-0035 §6)
+/// hoisted it into [`node_done`], because it was the one branch whose "stopped
+/// short" was in fact a complete success. The sweep never reaches it either way.
 async fn complete_node_iteration(
     state: &Arc<AppState>,
     run_id: String,
@@ -9897,22 +10215,20 @@ async fn complete_node_iteration(
     // effect (sub-worktree merge in particular).
     match run_is_forgotten(&state.db, &run_id).await {
         Ok(true) => {
-            return CompletionAttempt::aborted(
-                format!("run {run_id} has been forgotten"),
-                (
-                    StatusCode::GONE,
-                    Json(
-                        serde_json::json!({ "error": format!("run {run_id} has been forgotten") }),
-                    ),
-                )
-                    .into_response(),
+            // ADR-0024 §3 keeps its `410`: "never a 2xx" does not mean "always a
+            // 409".
+            return CompletionAttempt::refused(
+                completion_refusal::CompletionRefusal::RunForgotten {
+                    run_id: run_id.clone(),
+                },
             );
         }
         Ok(false) => {}
         Err(e) => {
-            return CompletionAttempt::aborted(
-                format!("forgotten-run check failed: {e}"),
-                (StatusCode::INTERNAL_SERVER_ERROR, format!("error: {e}")).into_response(),
+            return CompletionAttempt::refused(
+                completion_refusal::CompletionRefusal::MergeFailed {
+                    error: format!("forgotten-run check failed: {e}"),
+                },
             );
         }
     }
@@ -9927,34 +10243,21 @@ async fn complete_node_iteration(
     let events = match load_events(&state.db, &run_id).await {
         Ok(e) => e,
         Err(e) => {
-            return CompletionAttempt::aborted(
-                format!("failed to load events: {e}"),
-                (StatusCode::INTERNAL_SERVER_ERROR, format!("error: {e}")).into_response(),
-            );
+            return CompletionAttempt::refused(completion_refusal::CompletionRefusal::Internal {
+                error: format!("failed to load events: {e}"),
+            });
         }
     };
 
     let pre_run_state = match event_log::project(&events) {
         Some(s) => s,
         None => {
-            return CompletionAttempt::aborted(
-                "run not found",
-                (StatusCode::NOT_FOUND, "run not found").into_response(),
-            );
+            return CompletionAttempt::refused(completion_refusal::CompletionRefusal::RunNotFound);
         }
     };
 
     let repo_root = effective_repo_root(state, &pre_run_state);
     let worktree_dir = worktree_dir_for_run(&repo_root, &run_id);
-
-    if node_id == MERGE_RESOLVER_NODE_ID {
-        // Not a projected node, so not a `CompletionAttempt`: its handler owns
-        // its own response shape end to end.
-        return CompletionAttempt::aborted(
-            "merge resolver: handled by its own path",
-            handle_merge_resolver_done(state, &run_id, &worktree_dir, &pre_run_state).await,
-        );
-    }
 
     // Transition guard (#212, #354): validate the completion against the
     // projected state BEFORE any side effect (sub-worktree merge, doc-only
@@ -9968,13 +10271,15 @@ async fn complete_node_iteration(
     // marks a live node `Stale` any more, so the agent of a long tool call is
     // still `Running` here and its late completion is accepted.
     let head = run_advance::evaluate_completion_head(Some(&pre_run_state), &run_id, &node_id, iter);
-    let head_reason = match &head {
-        run_advance::CompletionHead::Reject { reason }
-        | run_advance::CompletionHead::NoOp { reason } => reason.clone(),
-        run_advance::CompletionHead::Allow => String::new(),
-    };
-    if let Some(resp) = completion_head_gate(head, caller, &run_id, &node_id, iter) {
-        return CompletionAttempt::aborted(head_reason, resp);
+    // The head's two stops map to the two *different* variants #490 split apart: a
+    // legal duplicate stays a `2xx` no-op, a reject is a refusal. Carrying the typed
+    // stop instead of a pre-projected `Response` also removes the double projection
+    // the pre-#490 code performed here.
+    if let Some(stop) = completion_head_gate(head, caller, &run_id, &node_id, iter) {
+        return match stop {
+            CompletionHeadStop::NoOp { reason } => CompletionAttempt::NoOp { reason },
+            CompletionHeadStop::Refused { refusal } => CompletionAttempt::refused(refusal),
+        };
     }
 
     match find_node_type(&pre_run_state, &node_id) {
@@ -9994,9 +10299,10 @@ async fn complete_node_iteration(
                 Ok(r) => r,
                 Err(e) => {
                     error!("failed to commit/merge sub-worktree for {node_id}: {e}");
-                    return CompletionAttempt::aborted(
-                        format!("commit/merge of the sub-worktree failed: {e}"),
-                        (StatusCode::INTERNAL_SERVER_ERROR, format!("error: {e}")).into_response(),
+                    return CompletionAttempt::refused(
+                        completion_refusal::CompletionRefusal::MergeFailed {
+                            error: e.to_string(),
+                        },
                     );
                 }
             };
@@ -10031,13 +10337,10 @@ async fn complete_node_iteration(
                     let _ = append_event(state, &run_failed).await;
 
                     warn!("Merge conflict for node {node_id} in run {run_id}");
-                    return CompletionAttempt::aborted(
-                        format!("merge conflict on {node_id}"),
-                        (
-                            StatusCode::OK,
-                            Json(serde_json::json!({ "status": "merge_conflict" })),
-                        )
-                            .into_response(),
+                    return CompletionAttempt::refused(
+                        completion_refusal::CompletionRefusal::MergeConflict {
+                            node_id: node_id.clone(),
+                        },
                     );
                 }
                 MergeResult::ConflictPendingResolution(detail) => {
@@ -10055,8 +10358,12 @@ async fn complete_node_iteration(
                     };
                     let _ = append_event(state, &conflict_event).await;
 
-                    return CompletionAttempt::aborted(
-                        format!("merge conflict on {node_id}: resolver spawned"),
+                    // DEAD in production (ADR-0035 §6): `keep_conflict` is never
+                    // `true`, so `ConflictPendingResolution` is never built. The two
+                    // resolver arms ride the new type at zero test cost; removing
+                    // the whole vestigial subsystem is ADR-0006 fallout, not this
+                    // bug fix.
+                    return CompletionAttempt::refused(
                         spawn_merge_resolver(state, &run_id, &node_id, iter, &worktree_dir).await,
                     );
                 }
@@ -10096,13 +10403,10 @@ async fn complete_node_iteration(
                 let _ = append_event(state, &run_failed).await;
 
                 warn!("Doc-only node {node_id} modified tracked files in run {run_id}");
-                return CompletionAttempt::aborted(
-                    format!("doc-only node {node_id} violated code immutability"),
-                    (
-                        StatusCode::OK,
-                        Json(serde_json::json!({ "status": "doc_violated_code_immutability" })),
-                    )
-                        .into_response(),
+                return CompletionAttempt::refused(
+                    completion_refusal::CompletionRefusal::DocImmutabilityViolated {
+                        node_id: node_id.clone(),
+                    },
                 );
             }
             Ok(false) => {}
@@ -10122,7 +10426,7 @@ async fn complete_node_iteration(
     // it passes — the sweep only proposes `TurnEnded` when validation already
     // succeeded — but if the two ever disagree the answer is `node_done`'s, not a
     // second opinion.
-    if let Some(resp) = check_output_validation_with_retry(
+    if let Some(refusal) = check_output_validation_with_retry(
         state,
         &pipeline_path,
         &node_id,
@@ -10133,7 +10437,7 @@ async fn complete_node_iteration(
     )
     .await
     {
-        return CompletionAttempt::aborted("output validation refused the completion", resp);
+        return CompletionAttempt::refused(refusal);
     }
 
     let event = event_log::Event {
@@ -10151,10 +10455,9 @@ async fn complete_node_iteration(
     };
 
     if let Err(e) = append_event(state, &event).await {
-        return CompletionAttempt::aborted(
-            format!("failed to append the terminal event: {e}"),
-            (StatusCode::INTERNAL_SERVER_ERROR, format!("error: {e}")).into_response(),
-        );
+        return CompletionAttempt::refused(completion_refusal::CompletionRefusal::AppendFailed {
+            error: e.to_string(),
+        });
     }
 
     // Detached tail (#304, ADR-0023): the reap below kills the very tmux
@@ -10310,15 +10613,17 @@ async fn node_skip(
     // Same guard as a completion (#212, #354): the skip terminalizes the node as
     // Completed, so a duplicate skip / a skip on a terminal run must be
     // rejected/no-op'd exactly like `node_done`, never double-appended. Shared
-    // head — same pure decision as `node_done` and `mark_node_done`.
-    if let Some(resp) = completion_head_gate(
+    // head — same pure decision as `node_done` and `mark_node_done`, and therefore
+    // the same body shape since #490: a skip refused by the guard now names itself
+    // `completion_rejected` too, which is coherent — it is the same verdict.
+    if let Some(stop) = completion_head_gate(
         run_advance::evaluate_completion_head(Some(&pre_run_state), &run_id, &node_id, iter),
         "node_skip",
         &run_id,
         &node_id,
         iter,
     ) {
-        return resp;
+        return stop.into_response();
     }
 
     // Terminalize the node as Completed with a no-op marker. A graceful no-op
@@ -12058,6 +12363,16 @@ fn resolve_run_pipeline_path(
     }
 }
 
+/// The **shared chokepoint** of the completion path (#490, ADR-0035): the one
+/// function both `POST …/nodes/:id/done` and the `mark_node_done` command arm
+/// reach. It owns the side effects (`append_event`, `send_keys`) and returns a
+/// **typed refusal**, never a pre-projected `Response` — projection belongs to
+/// `completion_refusal::refusal_response` alone, which is what makes "a refusal is
+/// never a 2xx" a property of the type rather than a list of arms to re-read.
+///
+/// `Option<CompletionRefusal>` (not `Result<_, Response>`): `Response` is 128
+/// bytes, exactly the `clippy::result_large_err` threshold the CI treats as an
+/// error, and the largest refusal variant is ~40 bytes.
 async fn check_output_validation_with_retry(
     state: &AppState,
     pipeline_path: &std::path::Path,
@@ -12066,7 +12381,7 @@ async fn check_output_validation_with_retry(
     artifacts_dir: &std::path::Path,
     run_id: &str,
     run_state: &event_log::RunState,
-) -> Option<Response> {
+) -> Option<completion_refusal::CompletionRefusal> {
     let yaml = std::fs::read_to_string(pipeline_path).ok()?;
     let parse_result = pipeline::parse_pipeline(&yaml).ok()?;
     let Err(validation_error) =
@@ -12128,29 +12443,13 @@ async fn check_output_validation_with_retry(
         let _ = append_event(state, &run_failed).await;
 
         warn!("script node {node_id} failed output validation in run {run_id} — fail-fast");
-        return Some(
-            (
-                StatusCode::OK,
-                Json(serde_json::json!({
-                    "status": "script_validation_failed",
-                    "detail": detail,
-                })),
-            )
-                .into_response(),
-        );
+        return Some(completion_refusal::CompletionRefusal::ScriptValidationFailed { detail });
     }
 
     match validation_error {
-        outputs_validator::ValidationError::MissingOutputs(missing) => Some(
-            (
-                StatusCode::CONFLICT,
-                Json(serde_json::json!({
-                    "error": "missing_outputs",
-                    "missing": missing,
-                })),
-            )
-                .into_response(),
-        ),
+        outputs_validator::ValidationError::MissingOutputs(missing) => {
+            Some(completion_refusal::CompletionRefusal::MissingOutputs { missing })
+        }
         outputs_validator::ValidationError::FrontmatterMismatch(violations) => {
             let retries = run_state
                 .nodes
@@ -12199,14 +12498,9 @@ async fn check_output_validation_with_retry(
 
                 warn!("Node {node_id} failed output validation after retry in run {run_id}");
                 Some(
-                    (
-                        StatusCode::OK,
-                        Json(serde_json::json!({
-                            "status": "frontmatter_retry_exhausted",
-                            "violations": violation_details,
-                        })),
-                    )
-                        .into_response(),
+                    completion_refusal::CompletionRefusal::FrontmatterRetryExhausted {
+                        violations: violation_details,
+                    },
                 )
             } else {
                 let msg = outputs_validator::corrective_message(&violations);
@@ -12228,14 +12522,9 @@ async fn check_output_validation_with_retry(
 
                 info!("Frontmatter mismatch for node {node_id} in run {run_id} — corrective message sent, awaiting retry");
                 Some(
-                    (
-                        StatusCode::OK,
-                        Json(serde_json::json!({
-                            "status": "frontmatter_retry_pending",
-                            "violations": violation_details,
-                        })),
-                    )
-                        .into_response(),
+                    completion_refusal::CompletionRefusal::FrontmatterRetryPending {
+                        violations: violation_details,
+                    },
                 )
             }
         }
@@ -15710,6 +15999,7 @@ mod tests {
                 iterations: Vec::new(),
                 frontmatter_retries: 0,
                 frontmatter_violations: Vec::new(),
+                missing_outputs: Vec::new(),
             },
         );
         rs
@@ -15921,6 +16211,7 @@ mod tests {
                 iterations: Vec::new(),
                 frontmatter_retries: 0,
                 frontmatter_violations: Vec::new(),
+                missing_outputs: Vec::new(),
             },
         );
         // An open loop region (exhausted at max_iter, not done) awaiting a route.
@@ -15973,6 +16264,7 @@ mod tests {
                 iterations: Vec::new(),
                 frontmatter_retries: 0,
                 frontmatter_violations: Vec::new(),
+                missing_outputs: Vec::new(),
             },
         );
         // Node `b` is throttled `Waiting`: ready but no admission slot yet. No
@@ -15990,6 +16282,7 @@ mod tests {
                 iterations: Vec::new(),
                 frontmatter_retries: 0,
                 frontmatter_violations: Vec::new(),
+                missing_outputs: Vec::new(),
             },
         );
 
@@ -16221,6 +16514,7 @@ mod tests {
                         .collect(),
                     frontmatter_retries: 0,
                     frontmatter_violations: Vec::new(),
+                    missing_outputs: Vec::new(),
                 },
             );
         }
@@ -19761,8 +20055,13 @@ edges:
                 .unwrap(),
         )
         .unwrap();
+        // #490 / ADR-0035 §3: `error` is the stable slug, the guard's prose moved
+        // to `message`. That split is the whole point — reading `error` as prose is
+        // what let the client mistake every 409 on this path for `missing_outputs`.
+        assert_eq!(body["error"], "completion_rejected");
+        assert_eq!(body["recoverable"], false);
         assert!(
-            body["error"].as_str().unwrap().contains("resume"),
+            body["message"].as_str().unwrap().contains("resume"),
             "rejection should point at resume_run, got {body}"
         );
 
@@ -20060,8 +20359,10 @@ edges:
                 .unwrap(),
         )
         .unwrap();
+        assert_eq!(body["error"], "completion_rejected");
+        assert_eq!(body["recoverable"], false);
         assert!(
-            body["error"].as_str().unwrap().contains("never started"),
+            body["message"].as_str().unwrap().contains("never started"),
             "got {body}"
         );
 
@@ -26000,5 +26301,520 @@ edges:
             sd["checked_at"].is_string(),
             "checked_at must be a string: {sd}"
         );
+    }
+
+    // ======================================================================
+    // #490 / ADR-0035 — a completion refusal is never a 2xx
+    //
+    // The structural invariant lives in `completion_refusal.rs` (the type owns no
+    // status, so a 2xx refusal is unrepresentable). What follows pins the WIRE, on
+    // BOTH surfaces, because the seam is shared and the test has to prove it: the
+    // pre-#490 bug survived precisely because `POST …/done` and
+    // `POST /runs/:id/commands` were only ever tested one at a time.
+    // ======================================================================
+
+    /// `command_triplet`'s sibling for `POST …/nodes/:id/done` (#490). Status **and**
+    /// content-type, so the two surfaces are pinned by the same shape of assertion
+    /// (net of #236).
+    async fn done_triplet(
+        state: &Arc<AppState>,
+        run_id: &str,
+        node_id: &str,
+        body: &str,
+    ) -> (StatusCode, String, String) {
+        let resp = build_router(state.clone())
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/runs/{run_id}/nodes/{node_id}/done"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = resp.status();
+        let content_type = resp
+            .headers()
+            .get(axum::http::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("")
+            .to_string();
+        let body = String::from_utf8_lossy(
+            &axum::body::to_bytes(resp.into_body(), usize::MAX)
+                .await
+                .unwrap(),
+        )
+        .into_owned();
+        (status, content_type, body)
+    }
+
+    /// `mark_node_done` through the command surface, as a triplet.
+    async fn mark_done_triplet(
+        state: &Arc<AppState>,
+        run_id: &str,
+        node_id: &str,
+    ) -> (StatusCode, String, String) {
+        command_triplet(
+            state,
+            run_id,
+            &serde_json::json!({ "kind": "mark_node_done", "node_id": node_id, "iter": 1 })
+                .to_string(),
+        )
+        .await
+    }
+
+    /// The three `CompletionAttempt` variants, behind a `match` with **no wildcard**:
+    /// a fourth variant does not compile until its status side is decided.
+    ///
+    /// This is the half of the invariant that lives outside `completion_refusal.rs`:
+    /// `NoOp` is the ONE non-`Completed` outcome allowed a `2xx`, because a legal
+    /// duplicate grants nothing and must not read as an error (ADR-0025 §3).
+    #[test]
+    fn noop_is_the_only_2xx_that_grants_nothing() {
+        for attempt in [
+            CompletionAttempt::Completed,
+            CompletionAttempt::NoOp {
+                reason: "already terminal".into(),
+            },
+            CompletionAttempt::refused(completion_refusal::CompletionRefusal::MissingOutputs {
+                missing: vec!["review".into()],
+            }),
+        ] {
+            let expect_2xx = match &attempt {
+                CompletionAttempt::Completed | CompletionAttempt::NoOp { .. } => true,
+                CompletionAttempt::Refused { .. } => false,
+            };
+            let status = attempt.into_response().status();
+            assert_eq!(
+                status.is_success(),
+                expect_2xx,
+                "wrong status class: {status}"
+            );
+        }
+    }
+
+    fn write_script_pipeline_with_outputs(dir: &std::path::Path, name: &str) {
+        let pipelines_dir = dir.join(".pdo").join("pipelines");
+        std::fs::create_dir_all(&pipelines_dir).unwrap();
+        let yaml = format!(
+            "name: {name}\nversion: \"1.0\"\nnodes:\n{START_END_YAML}  - id: worker\n    name: worker\n    type: script\n    inputs:\n      - name: task\n    outputs:\n      - name: out\n"
+        );
+        std::fs::write(pipelines_dir.join(format!("{name}.yaml")), yaml).unwrap();
+    }
+
+    fn write_pipeline_with_frontmatter(dir: &std::path::Path, name: &str) {
+        let pipelines_dir = dir.join(".pdo").join("pipelines");
+        std::fs::create_dir_all(&pipelines_dir).unwrap();
+        let yaml = format!(
+            "name: {name}\nversion: \"1.0\"\nnodes:\n{START_END_YAML}  - id: worker\n    name: worker\n    type: doc-only\n    inputs:\n      - name: task\n    outputs:\n      - name: review\n        frontmatter:\n          verdict:\n            type: enum\n            allowed: [PASS, FAIL]\n"
+        );
+        std::fs::write(pipelines_dir.join(format!("{name}.yaml")), yaml).unwrap();
+    }
+
+    fn write_artifact_for(
+        repo_root: &std::path::Path,
+        run_id: &str,
+        node_id: &str,
+        port: &str,
+        content: &str,
+    ) {
+        let dir = worktree_dir_for_run(repo_root, run_id)
+            .join(".pdo")
+            .join("artifacts")
+            .join(node_id)
+            .join("iter-1")
+            .join(port);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("output.md"), content).unwrap();
+    }
+
+    /// A `script` node whose declared output never landed. The whole point of #490:
+    /// this used to answer `200` **after** appending `NodeFailed` + `RunFailed`, so
+    /// `pdo complete` printed "marked complete." and exited `0` on a dead run.
+    #[tokio::test]
+    async fn script_validation_failed_is_409_not_200() {
+        let tmp = tempfile::tempdir().unwrap();
+        let pipe = "script-refusal";
+        write_script_pipeline_with_outputs(tmp.path(), pipe);
+        let state = test_state_with_dir(tmp.path()).await;
+        let run_id = "script-refusal-run";
+        seed_awaiting_run(&state, run_id, pipe).await;
+
+        let (status, ct, body) = done_triplet(&state, run_id, "worker", "{}").await;
+        assert_eq!((status, ct.as_str()), (StatusCode::CONFLICT, JSON_CT));
+        let body: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(body["error"], "script_validation_failed");
+        assert_eq!(body["recoverable"], false);
+        // The detail stays NESTED (ADR-0035 §5) so a fail-fast audit trail is
+        // distinguishable from an after-retry one.
+        assert_eq!(body["detail"]["kind"], "missing_outputs");
+        assert_eq!(body["detail"]["missing"], serde_json::json!(["out"]));
+
+        // And the terminal events really are already recorded — which is what makes
+        // `recoverable: false` and exit code `4` true rather than decorative.
+        let events = load_events(&state.db, run_id).await.unwrap();
+        assert_eq!(
+            events
+                .iter()
+                .filter(|e| e.kind == event_log::EventKind::RunFailed)
+                .count(),
+            1
+        );
+
+        // The projection now carries the missing port, so the red banner is no
+        // longer a list of nothing.
+        let projected = event_log::project(&events).unwrap();
+        assert_eq!(projected.nodes["worker"].missing_outputs, vec!["out"]);
+    }
+
+    /// The first frontmatter mismatch, on **both** routes. Nothing terminal is
+    /// appended, the node stays `running`, and `recoverable: true` is what tells the
+    /// caller to fix and retry rather than to signal a failure.
+    #[tokio::test]
+    async fn frontmatter_retry_pending_is_409_and_recoverable_on_both_routes() {
+        for (label, use_done_route) in [("done", true), ("commands", false)] {
+            let tmp = tempfile::tempdir().unwrap();
+            let pipe = "fm-pending";
+            write_pipeline_with_frontmatter(tmp.path(), pipe);
+            let state = test_state_with_dir(tmp.path()).await;
+            let run_id = "fm-pending-run";
+            seed_awaiting_run(&state, run_id, pipe).await;
+            write_artifact_for(
+                tmp.path(),
+                run_id,
+                "worker",
+                "review",
+                "---\nverdict: MAYBE\n---\nnope\n",
+            );
+
+            let (status, ct, raw) = if use_done_route {
+                done_triplet(&state, run_id, "worker", "{}").await
+            } else {
+                mark_done_triplet(&state, run_id, "worker").await
+            };
+            assert_eq!(
+                (status, ct.as_str()),
+                (StatusCode::CONFLICT, JSON_CT),
+                "{label}"
+            );
+            let body: serde_json::Value = serde_json::from_str(&raw).unwrap();
+            assert_eq!(body["error"], "frontmatter_retry_pending", "{label}");
+            assert_eq!(body["recoverable"], true, "{label}");
+            assert_eq!(body["violations"][0]["field"], "verdict", "{label}");
+
+            let events = load_events(&state.db, run_id).await.unwrap();
+            assert!(
+                !events.iter().any(|e| matches!(
+                    e.kind,
+                    event_log::EventKind::NodeFailed | event_log::EventKind::RunFailed
+                )),
+                "{label}: a recoverable refusal must append nothing terminal"
+            );
+            // Still alive — `awaiting_user` here because the seed parks the node
+            // there; what matters is that it is not terminal.
+            let projected = event_log::project(&events).unwrap();
+            assert!(
+                !matches!(
+                    projected.nodes["worker"].status,
+                    event_log::NodeStatus::Failed | event_log::NodeStatus::Completed
+                ),
+                "{label}: a recoverable refusal must leave the node alive"
+            );
+        }
+    }
+
+    /// The retry is spent: `recoverable: false`, and `NodeFailed` + `RunFailed` are
+    /// already in the log. This is the arm that answered `200` on a dead run.
+    #[tokio::test]
+    async fn frontmatter_retry_exhausted_is_409_and_not_recoverable() {
+        let tmp = tempfile::tempdir().unwrap();
+        let pipe = "fm-exhausted";
+        write_pipeline_with_frontmatter(tmp.path(), pipe);
+        let state = test_state_with_dir(tmp.path()).await;
+        let run_id = "fm-exhausted-run";
+        seed_awaiting_run(&state, run_id, pipe).await;
+        write_artifact_for(
+            tmp.path(),
+            run_id,
+            "worker",
+            "review",
+            "---\nverdict: MAYBE\n---\nnope\n",
+        );
+
+        // First attempt spends the retry (`FrontmatterRetryPending`).
+        let (first, _, _) = mark_done_triplet(&state, run_id, "worker").await;
+        assert_eq!(first, StatusCode::CONFLICT);
+
+        let (status, ct, raw) = mark_done_triplet(&state, run_id, "worker").await;
+        assert_eq!((status, ct.as_str()), (StatusCode::CONFLICT, JSON_CT));
+        let body: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(body["error"], "frontmatter_retry_exhausted");
+        assert_eq!(body["recoverable"], false);
+
+        let events = load_events(&state.db, run_id).await.unwrap();
+        let projected = event_log::project(&events).unwrap();
+        assert_eq!(
+            projected.nodes["worker"].status,
+            event_log::NodeStatus::Failed
+        );
+        assert_eq!(
+            projected.nodes["worker"].failure_reason.as_deref(),
+            Some("output validation failed")
+        );
+    }
+
+    /// New coverage: no test reached the doc-only immutability arm before #490. It
+    /// needs a real git worktree with a dirty **tracked** file (an untracked artefact
+    /// is ignored by the guard).
+    #[tokio::test]
+    async fn doc_only_immutability_violation_is_409_not_200() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path();
+        init_git_repo_for_refusal_tests(repo);
+        let pipe = "doc-immutability";
+        write_pipeline_with_outputs(repo, pipe);
+
+        let state = test_state_with_dir(repo).await;
+        let run_id = "doc-immutability-run";
+        let wt_dir = worktree_dir_for_run(repo, run_id);
+        create_worktree(repo, &wt_dir, &format!("pdo/run-{run_id}"), "HEAD").unwrap();
+        // Dirty a TRACKED file from inside the run's worktree.
+        std::fs::write(wt_dir.join("tracked.txt"), "mutated by a doc-only node\n").unwrap();
+        assert!(worktree_has_tracked_changes(&wt_dir).unwrap());
+
+        // `find_node_type` reads the PROJECTED node defs, not the YAML on disk, so
+        // the cleanliness arm is only reached when `RunStarted` carries them.
+        for event in [
+            event_log::Event {
+                id: None,
+                run_id: run_id.into(),
+                ts: event_log::now_iso(),
+                kind: event_log::EventKind::RunStarted,
+                node_id: None,
+                iter: None,
+                payload: Some(serde_json::json!({
+                    "pipeline_name": pipe,
+                    "node_defs": [
+                        { "id": "worker", "node_type": "doc-only", "inputs": [], "outputs": [] }
+                    ],
+                    "edges": [],
+                })),
+            },
+            event_log::Event {
+                id: None,
+                run_id: run_id.into(),
+                ts: event_log::now_iso(),
+                kind: event_log::EventKind::NodeStarted,
+                node_id: Some("worker".into()),
+                iter: Some(1),
+                payload: None,
+            },
+        ] {
+            append_event(&state, &event).await.unwrap();
+        }
+
+        let (status, ct, raw) = done_triplet(&state, run_id, "worker", "{}").await;
+        assert_eq!((status, ct.as_str()), (StatusCode::CONFLICT, JSON_CT));
+        let body: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(body["error"], "doc_violated_code_immutability");
+        assert_eq!(body["recoverable"], false);
+        assert!(body["message"]
+            .as_str()
+            .unwrap()
+            .contains("code immutability"));
+
+        let events = load_events(&state.db, run_id).await.unwrap();
+        assert_eq!(
+            events
+                .iter()
+                .filter(|e| e.kind == event_log::EventKind::RunFailed)
+                .count(),
+            1
+        );
+
+        // Route asymmetry, asserted rather than assumed (ADR-0035, accepted limit):
+        // the command arm runs neither the merge nor the cleanliness check, so it
+        // cannot reach this refusal — it falls straight through to output validation.
+        let (cmd_status, _, cmd_raw) = mark_done_triplet(&state, run_id, "worker").await;
+        let cmd_body: serde_json::Value = serde_json::from_str(&cmd_raw).unwrap();
+        assert_eq!(cmd_status, StatusCode::CONFLICT);
+        assert_ne!(cmd_body["error"], "doc_violated_code_immutability");
+    }
+
+    /// New coverage: no test reached the merge-conflict arm before #490 either. Two
+    /// sub-worktrees touching the same file, merged in order — the second conflicts.
+    #[tokio::test]
+    async fn merge_conflict_is_409_not_200() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path();
+        init_git_repo_for_refusal_tests(repo);
+        let pipe = "merge-conflict-refusal";
+        let pipelines_dir = repo.join(".pdo").join("pipelines");
+        std::fs::create_dir_all(&pipelines_dir).unwrap();
+        std::fs::write(
+            pipelines_dir.join(format!("{pipe}.yaml")),
+            format!(
+                "name: {pipe}\nversion: \"1.0\"\nnodes:\n{START_END_YAML}  - id: impl_a\n    name: impl_a\n    type: code-mutating\n    inputs:\n      - name: task\n    outputs:\n      - name: patch\n  - id: impl_b\n    name: impl_b\n    type: code-mutating\n    inputs:\n      - name: task\n    outputs:\n      - name: patch\n"
+            ),
+        )
+        .unwrap();
+
+        let state = test_state_with_dir(repo).await;
+        let run_id = "merge-conflict-run";
+        let wt_dir = worktree_dir_for_run(repo, run_id);
+        let pipeline_branch = format!("pdo/run-{run_id}");
+        create_worktree(repo, &wt_dir, &pipeline_branch, "HEAD").unwrap();
+
+        for node in ["impl_a", "impl_b"] {
+            let sub_dir = sub_worktree_path(repo, run_id, node, 1);
+            let sub_branch = sub_worktree_branch(run_id, node, 1);
+            create_sub_worktree(repo, &sub_dir, &sub_branch, &pipeline_branch).unwrap();
+            std::fs::write(sub_dir.join("shared.txt"), format!("from {node}\n")).unwrap();
+            // Both nodes declare a `patch` output; write it so validation is not
+            // what refuses.
+            write_artifact_for(repo, run_id, node, "patch", "done\n");
+        }
+
+        for event in [
+            event_log::Event {
+                id: None,
+                run_id: run_id.into(),
+                ts: event_log::now_iso(),
+                kind: event_log::EventKind::RunStarted,
+                node_id: None,
+                iter: None,
+                payload: Some(serde_json::json!({
+                    "pipeline_name": pipe,
+                    "node_defs": [
+                        { "id": "impl_a", "node_type": "code-mutating", "inputs": [], "outputs": [] },
+                        { "id": "impl_b", "node_type": "code-mutating", "inputs": [], "outputs": [] },
+                    ],
+                    "edges": [],
+                })),
+            },
+            event_log::Event {
+                id: None,
+                run_id: run_id.into(),
+                ts: event_log::now_iso(),
+                kind: event_log::EventKind::NodeStarted,
+                node_id: Some("impl_a".into()),
+                iter: Some(1),
+                payload: None,
+            },
+            event_log::Event {
+                id: None,
+                run_id: run_id.into(),
+                ts: event_log::now_iso(),
+                kind: event_log::EventKind::NodeStarted,
+                node_id: Some("impl_b".into()),
+                iter: Some(1),
+                payload: None,
+            },
+        ] {
+            append_event(&state, &event).await.unwrap();
+        }
+
+        // First merge lands.
+        let (first, _, _) = done_triplet(&state, run_id, "impl_a", "{}").await;
+        assert!(first.is_success(), "first merge should land, got {first}");
+
+        // Second conflicts — and this is the refusal that used to answer `200`
+        // *after* appending `MergeConflictDetected` + `RunFailed`.
+        let (status, ct, raw) = done_triplet(&state, run_id, "impl_b", "{}").await;
+        assert_eq!((status, ct.as_str()), (StatusCode::CONFLICT, JSON_CT));
+        let body: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(body["error"], "merge_conflict");
+        assert_eq!(body["recoverable"], false);
+
+        let events = load_events(&state.db, run_id).await.unwrap();
+        assert!(events
+            .iter()
+            .any(|e| e.kind == event_log::EventKind::MergeConflictDetected));
+    }
+
+    /// ADR-0024's tombstone keeps its `410` on this route: "never a 2xx" is not
+    /// "always a 409", and flattening these would be the wrong reading of #490.
+    #[tokio::test]
+    async fn a_forgotten_run_still_answers_410_on_the_done_route() {
+        let state = test_state().await;
+        let run_id = "done-forgotten";
+        seed_completed_run(&state, run_id).await;
+        post_cleanup_run(&state, run_id).await;
+        let resp = build_router(state.clone())
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri(format!("/runs/{run_id}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let (status, ct, raw) = done_triplet(&state, run_id, "worker", "{}").await;
+        assert_eq!((status, ct.as_str()), (StatusCode::GONE, JSON_CT));
+        let body: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(body["error"], "run_forgotten");
+        assert_eq!(body["recoverable"], false);
+    }
+
+    /// A legal duplicate is a **success**: `200`, `noop: true`, exit `0`. Guarded on
+    /// both surfaces because an agent that read "refused" here and chained
+    /// `pdo fail` would kill a run that had just succeeded — and a `script` node's
+    /// tail would do it unprompted.
+    #[tokio::test]
+    async fn a_legal_duplicate_completion_is_still_a_200_noop() {
+        let tmp = tempfile::tempdir().unwrap();
+        let pipe = "noop-dup";
+        write_test_pipeline(tmp.path(), pipe);
+        let state = test_state_with_dir(tmp.path()).await;
+        let run_id = "noop-dup-run";
+        seed_awaiting_run(&state, run_id, pipe).await;
+        write_artifact_for(tmp.path(), run_id, "worker", "result", "done\n");
+
+        let (first, _, _) = done_triplet(&state, run_id, "worker", "{}").await;
+        assert!(first.is_success(), "first completion should land: {first}");
+
+        for (label, raw) in [
+            ("done", done_triplet(&state, run_id, "worker", "{}").await),
+            (
+                "commands",
+                mark_done_triplet(&state, run_id, "worker").await,
+            ),
+        ] {
+            let (status, ct, raw) = raw;
+            assert_eq!(
+                (status, ct.as_str()),
+                (StatusCode::OK, JSON_CT),
+                "{label}: a legal duplicate must stay a 2xx"
+            );
+            let body: serde_json::Value = serde_json::from_str(&raw).unwrap();
+            assert_eq!(body["noop"], true, "{label}");
+            assert!(body["reason"].is_string(), "{label}");
+        }
+    }
+
+    /// A throwaway git repo with one tracked file, for the two refusals that need a
+    /// real worktree. Same shape as `worktree_ops`' own `init_test_repo`, which is
+    /// private to that module's test tree.
+    fn init_git_repo_for_refusal_tests(repo: &std::path::Path) {
+        let git = |args: &[&str]| {
+            let out = std::process::Command::new("git")
+                .args(args)
+                .current_dir(repo)
+                .output()
+                .expect("git");
+            assert!(out.status.success(), "git {args:?}: {out:?}");
+        };
+        git(&["init", "-q", "-b", "main"]);
+        git(&["config", "user.email", "refusal@test.local"]);
+        git(&["config", "user.name", "Refusal Test"]);
+        git(&["config", "commit.gpgsign", "false"]);
+        std::fs::write(repo.join(".gitignore"), ".pdo/runs/\n").unwrap();
+        std::fs::write(repo.join("tracked.txt"), "immutable\n").unwrap();
+        git(&["add", "-A"]);
+        git(&["commit", "-q", "-m", "init"]);
     }
 }

--- a/crates/pdo-daemon/src/main.rs
+++ b/crates/pdo-daemon/src/main.rs
@@ -3,10 +3,23 @@ use clap::Parser;
 use pdo_daemon::{
     run_complete, run_daemon, run_fail, run_migrate, run_service, run_skip, Cli, Commands,
 };
+use std::process::ExitCode;
 
-fn main() -> Result<()> {
+fn main() -> ExitCode {
     let cli = Cli::parse();
-    match cli.command {
+
+    // `complete` is the one subcommand with an exit-code contract (#490,
+    // ADR-0035 §4): `0` granted / legal duplicate, `3` refused-still-your-turn,
+    // `4` refused-already-ruled, `1` breakdown. Those codes live in pipeline
+    // authors' bash — a `script` node's tail branches on the `4` to avoid doubling
+    // a failure the daemon already recorded — so they are as much a public API as
+    // the wire shape. It therefore owns its own return, and the other arms keep the
+    // plain `Result` → `0`/`1` mapping they have always had.
+    if let Commands::Complete = cli.command {
+        return run_complete();
+    }
+
+    let res: Result<()> = match cli.command {
         Commands::Daemon { port } => {
             tracing_subscriber::fmt()
                 .with_env_filter(
@@ -21,15 +34,22 @@ fn main() -> Result<()> {
             tokio::runtime::Builder::new_multi_thread()
                 .enable_all()
                 .build()
-                .context("failed to build tokio runtime")?
-                .block_on(run_daemon(port))
+                .context("failed to build tokio runtime")
+                .and_then(|rt| rt.block_on(run_daemon(port)))
         }
-        Commands::Complete => run_complete(),
+        // Unreachable: intercepted above so it can return its own exit code.
+        Commands::Complete => unreachable!("`complete` returns its own ExitCode"),
         Commands::Fail { reason } => run_fail(reason),
         Commands::Skip { reason } => run_skip(reason),
         // A blocking one-shot like Complete/Fail/Skip — no tokio runtime (#156).
         Commands::Service { action } => run_service(action),
         // Blocking one-shot as well (#269): pure fs + YAML rewriting.
         Commands::Migrate { dir, dry_run } => run_migrate(dir, dry_run),
+    };
+
+    if let Err(e) = res {
+        eprintln!("Error: {e:?}");
+        return ExitCode::FAILURE;
     }
+    ExitCode::SUCCESS
 }

--- a/crates/pdo-daemon/src/mutation_validator.rs
+++ b/crates/pdo-daemon/src/mutation_validator.rs
@@ -264,6 +264,7 @@ mod tests {
                     iterations: vec![],
                     frontmatter_retries: 0,
                     frontmatter_violations: vec![],
+                    missing_outputs: vec![],
                 },
             );
         }

--- a/crates/pdo-daemon/src/node_io_resolver.rs
+++ b/crates/pdo-daemon/src/node_io_resolver.rs
@@ -314,6 +314,7 @@ mod tests {
                 .collect(),
             frontmatter_retries: 0,
             frontmatter_violations: Vec::new(),
+            missing_outputs: Vec::new(),
         };
         let mut s = RunState::new("run-1".into(), "test".into());
         s.nodes.insert(node_id.to_string(), node);

--- a/crates/pdo-daemon/src/node_primitives.rs
+++ b/crates/pdo-daemon/src/node_primitives.rs
@@ -662,6 +662,7 @@ mod tests {
             }],
             frontmatter_retries: 0,
             frontmatter_violations: Vec::new(),
+            missing_outputs: Vec::new(),
         }
     }
 
@@ -681,6 +682,7 @@ mod tests {
             }],
             frontmatter_retries: 0,
             frontmatter_violations: Vec::new(),
+            missing_outputs: Vec::new(),
         }
     }
 
@@ -695,6 +697,7 @@ mod tests {
             iterations: Vec::new(),
             frontmatter_retries: 0,
             frontmatter_violations: Vec::new(),
+            missing_outputs: Vec::new(),
         }
     }
 
@@ -1035,6 +1038,7 @@ mod tests {
                 .collect(),
             frontmatter_retries: 0,
             frontmatter_violations: Vec::new(),
+            missing_outputs: Vec::new(),
         }
     }
 

--- a/crates/pdo-daemon/src/outputs_validator.rs
+++ b/crates/pdo-daemon/src/outputs_validator.rs
@@ -249,9 +249,19 @@ fn yaml_value_to_string(v: &serde_yaml::Value) -> String {
     }
 }
 
+/// The corrective nudge sent into the node's tmux session on the first frontmatter
+/// mismatch.
+///
+/// Says **this is the one retry** on purpose (#490): the limit is 1 retry / 2
+/// attempts total, and the previous wording ("please fix and retry") let an agent
+/// believe it could iterate. It also aligns with the `recoverable` vocabulary of the
+/// refusal contract (ADR-0035 §3): the completion was refused, the node is still
+/// running, it is still the agent's turn — which is exactly what `pdo complete`'s
+/// exit code `3` says, so nudge and exit code agree instead of contradicting.
 pub fn corrective_message(violations: &[FieldViolation]) -> String {
     let mut msg = String::from(
-        "Your output frontmatter does not match the declared schema. Please fix the following and retry:\n",
+        "Your output frontmatter does not match the declared schema, so your completion was REFUSED. \
+         The node is still running and nothing has failed: it is still your turn. Fix the following:\n",
     );
     for v in violations {
         msg.push_str(&format!(
@@ -259,7 +269,10 @@ pub fn corrective_message(violations: &[FieldViolation]) -> String {
             v.port, v.field, v.reason
         ));
     }
-    msg.push_str("After correcting, call `pdo complete` again.");
+    msg.push_str(
+        "This is your ONE retry (limit: 1 retry, 2 attempts total) — the next mismatch fails the node. \
+         After correcting, call pdo complete again. Do NOT call pdo fail.",
+    );
     msg
 }
 

--- a/crates/pdo-daemon/src/prompt_augmenter.rs
+++ b/crates/pdo-daemon/src/prompt_augmenter.rs
@@ -529,6 +529,19 @@ pub fn build_preamble(ctx: &AugmentContext<'_>) -> String {
              ```\n\
              pdo complete\n\
              ```\n\n\
+             **`pdo complete` can be REFUSED**, and its exit code tells you what to do \
+             next (#490):\n\
+             - **0** — granted, or a legal duplicate. Nothing more to do.\n\
+             - **3** — refused, *and it is still your turn*: your outputs are missing or \
+             their frontmatter does not match the declared schema. The node is still \
+             running and nothing has failed. Fix what stderr lists, then run \
+             `pdo complete` again. **Do NOT run `pdo fail`.**\n\
+             - **4** — refused, *and the runtime has already ruled*: the failure is \
+             already recorded in the run log. **Do NOT run `pdo fail`** — you would \
+             record it a second time, with a wrong reason. Stop and report what \
+             happened.\n\
+             - **1** — the daemon could not be reached or gave no verdict. This is the \
+             only case where signalling failure yourself is right.\n\n\
              If you cannot complete the task, signal failure:\n\
              ```\n\
              pdo fail --reason \"<description of the problem>\"\n\
@@ -673,6 +686,8 @@ curl -X POST {daemon_url}/runs/{run_id}/commands \
   -H 'Content-Type: application/json' \
   -d '{{"kind":"mark_node_done","node_id":"<node-id>","iter":<N>}}'
 ```
+
+This goes through the same shared completion body as `pdo complete`, so it answers truthfully (#490): `200 {{"ok":true}}` when the node completed, `200 {{"ok":true,"noop":true,"reason":"…"}}` on a legal duplicate, and **`409 {{"error":"<slug>","recoverable":<bool>, …}}`** when the completion is refused — `missing_outputs`, `frontmatter_retry_pending`, `frontmatter_retry_exhausted`, `script_validation_failed`, `completion_rejected`, … Discriminate on `error`, never on the status. `recoverable:false` means the runtime already recorded the terminal event: do not try to record it again.
 
 ### 7. inject_artifact
 

--- a/crates/pdo-daemon/src/run_advance.rs
+++ b/crates/pdo-daemon/src/run_advance.rs
@@ -516,6 +516,7 @@ mod tests {
             iterations: Vec::new(),
             frontmatter_retries: 0,
             frontmatter_violations: Vec::new(),
+            missing_outputs: Vec::new(),
         }
     }
 
@@ -530,6 +531,7 @@ mod tests {
             iterations: Vec::new(),
             frontmatter_retries: 0,
             frontmatter_violations: Vec::new(),
+            missing_outputs: Vec::new(),
         }
     }
 
@@ -689,6 +691,7 @@ mod tests {
             }],
             frontmatter_retries: 0,
             frontmatter_violations: Vec::new(),
+            missing_outputs: Vec::new(),
         }
     }
 

--- a/crates/pdo-daemon/src/run_command.rs
+++ b/crates/pdo-daemon/src/run_command.rs
@@ -29,12 +29,12 @@ use crate::scheduler_interpreter::{ActionOutcome, SpawnDedup};
 use crate::worktree_ops::worktree_dir_for_run;
 use crate::{
     append_event, check_output_validation_with_retry, cleanup_run, completion_head_gate,
-    create_run_core, effective_repo_root, event_log, force_spawn_node, load_events, loop_region,
-    mark_sandbox_prep_ready, pipeline, reload_run_state, resolve_completed_frontmatter,
-    resolve_pipeline_path, resolve_run_pipeline_path, resolve_run_variables,
-    resolve_source_frontmatter, run_advance, run_is_forgotten, run_scoped_pipeline_path,
-    sandbox_run, scheduler, scheduler_interpreter, tmux_session_manager, transition_guard,
-    AppState, CreateRunRequest,
+    completion_refusal, create_run_core, effective_repo_root, event_log, force_spawn_node,
+    load_events, loop_region, mark_sandbox_prep_ready, pipeline, reload_run_state,
+    resolve_completed_frontmatter, resolve_pipeline_path, resolve_run_pipeline_path,
+    resolve_run_variables, resolve_source_frontmatter, run_advance, run_is_forgotten,
+    run_scoped_pipeline_path, sandbox_run, scheduler, scheduler_interpreter, tmux_session_manager,
+    transition_guard, AppState, CreateRunRequest,
 };
 
 /// The wire shape of a command. `pub(crate)` only because `run_command` is —
@@ -411,14 +411,18 @@ async fn dispatch(state: Arc<AppState>, run_id: String, cmd: RunCommand) -> Resp
             // downstream dispatch). Shared head — same pure decision as
             // `node_done` and `node_skip`. `run_state.as_ref()` may be `None`
             // (unstarted run); the guard maps `None -> Allow`, forwarded verbatim.
-            if let Some(resp) = completion_head_gate(
+            // #490 / ADR-0035: the typed stop keeps the legal-duplicate no-op a
+            // `200` while a reject becomes `409 {"error":"completion_rejected",…}`.
+            // This arm is why the invariant could not live on `CompletionAttempt`:
+            // it never builds one, and it is the whole UI path.
+            if let Some(stop) = completion_head_gate(
                 run_advance::evaluate_completion_head(run_state.as_ref(), &run_id, &node_id, iter),
                 "mark_node_done",
                 &run_id,
                 &node_id,
                 iter,
             ) {
-                return resp;
+                return stop.into_response();
             }
 
             let empty_run_state = event_log::RunState::new(run_id.clone(), String::new());
@@ -431,7 +435,10 @@ async fn dispatch(state: Arc<AppState>, run_id: String, cmd: RunCommand) -> Resp
             let pipeline_path = resolve_run_pipeline_path(&repo_root, &run_id, pipeline_name);
             let worktree_dir = worktree_dir_for_run(&repo_root, &run_id);
             let artifacts_dir = worktree_dir.join(".pdo").join("artifacts");
-            if let Some(resp) = check_output_validation_with_retry(
+            // The shared chokepoint (#490). Both surfaces project the refusal
+            // through the same single function, which is what makes "a refusal is
+            // never a 2xx" cover `POST /commands` too.
+            if let Some(refusal) = check_output_validation_with_retry(
                 &state,
                 &pipeline_path,
                 &node_id,
@@ -442,7 +449,7 @@ async fn dispatch(state: Arc<AppState>, run_id: String, cmd: RunCommand) -> Resp
             )
             .await
             {
-                return resp;
+                return completion_refusal::refusal_response(&refusal);
             }
 
             let event = event_log::Event {

--- a/crates/pdo-daemon/src/scheduler.rs
+++ b/crates/pdo-daemon/src/scheduler.rs
@@ -1267,6 +1267,7 @@ mod tests {
             iterations: Vec::new(),
             frontmatter_retries: 0,
             frontmatter_violations: Vec::new(),
+            missing_outputs: Vec::new(),
         }
     }
 
@@ -1281,6 +1282,7 @@ mod tests {
             iterations: Vec::new(),
             frontmatter_retries: 0,
             frontmatter_violations: Vec::new(),
+            missing_outputs: Vec::new(),
         }
     }
 
@@ -1295,6 +1297,7 @@ mod tests {
             iterations: Vec::new(),
             frontmatter_retries: 0,
             frontmatter_violations: Vec::new(),
+            missing_outputs: Vec::new(),
         }
     }
 

--- a/crates/pdo-daemon/src/scheduler_dispatcher.rs
+++ b/crates/pdo-daemon/src/scheduler_dispatcher.rs
@@ -119,6 +119,7 @@ mod tests {
             iterations: Vec::new(),
             frontmatter_retries: 0,
             frontmatter_violations: Vec::new(),
+            missing_outputs: Vec::new(),
         }
     }
 
@@ -133,6 +134,7 @@ mod tests {
             iterations: Vec::new(),
             frontmatter_retries: 0,
             frontmatter_violations: Vec::new(),
+            missing_outputs: Vec::new(),
         }
     }
 
@@ -172,6 +174,7 @@ mod tests {
             iterations: Vec::new(),
             frontmatter_retries: 0,
             frontmatter_violations: Vec::new(),
+            missing_outputs: Vec::new(),
         }
     }
 

--- a/crates/pdo-daemon/src/tmux_session_manager.rs
+++ b/crates/pdo-daemon/src/tmux_session_manager.rs
@@ -302,17 +302,29 @@ fn build_agent_tail(prompt_path: &Path, model: Option<&str>, effort: Option<&str
 /// Build the bash tail for a `script` node (#248 / ADR-0017).
 ///
 /// Runs the author's body under `timeout` then self-signals: exit 0 ⇒
-/// `pdo complete` (with a `pdo fail` fallback so a post-success output-validation
-/// rejection still terminates the node); exit 124 (timeout) or any non-zero ⇒
-/// `pdo fail` with a diagnostic reason. **Not** `exec`-ed: unlike the agent tail
-/// (`exec claude`), the wrapper must run the bash *and then* run `pdo`, so it is
-/// a plain sequence. Ordering `pdo complete` before shell exit makes the node
-/// terminal before the session dies (#304).
+/// `pdo complete`; exit 124 (timeout) or any non-zero ⇒ `pdo fail` with a
+/// diagnostic reason. **Not** `exec`-ed: unlike the agent tail (`exec claude`), the
+/// wrapper must run the bash *and then* run `pdo`, so it is a plain sequence.
+/// Ordering `pdo complete` before shell exit makes the node terminal before the
+/// session dies (#304).
+///
+/// **The `pdo complete` arm branches on exit code `4`** (#490, ADR-0035 §4). Before
+/// #490 it was a bare `pdo complete || pdo fail --reason "…"`, and that `||` was
+/// dead code: every completion refusal answered `200`, so `pdo complete` exited `0`
+/// and the fallback never fired. Making refusals non-2xx woke it up — and a
+/// terminal refusal (`4`) would then append a **second** `NodeFailed` **and** a
+/// second `RunFailed`, the latter unguarded and carrying a false reason ("after
+/// script success", on a script whose output validation had just failed). So the
+/// fallback fires only on a code that is neither `0` (granted or legal duplicate)
+/// nor `4` (already ruled — the daemon recorded the failure itself). A `3`
+/// (refused, still your turn) cannot reach a script node: the fail-fast branch
+/// intercepts before the interactive retry loop.
 fn build_script_tail(prompt_path: &Path, timeout_secs: u64) -> String {
     let body = sh_single_quote(&prompt_path.to_string_lossy());
     format!(
         "timeout {timeout_secs}s bash {body} ; ec=$? ; \
-         if [ $ec -eq 0 ]; then pdo complete || pdo fail --reason \"output validation failed after script success\" ; \
+         if [ $ec -eq 0 ]; then pdo complete ; cc=$? ; \
+         if [ $cc -ne 0 ] && [ $cc -ne 4 ]; then pdo fail --reason \"pdo complete refused with exit $cc after script success\" ; fi ; \
          elif [ $ec -eq 124 ]; then pdo fail --reason \"script timed out after {timeout_secs}s\" ; \
          else pdo fail --reason \"script exited $ec\" ; fi"
     )
@@ -1439,6 +1451,58 @@ mod tests {
         // Base env is still exported.
         assert!(script.contains("PDO_RUN_ID"));
         assert!(script.contains("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1"));
+    }
+
+    /// #490 / ADR-0035 §4 — the tail must NOT double a failure the daemon already
+    /// recorded.
+    ///
+    /// The pre-#490 tail was `pdo complete || pdo fail --reason "…"`. That `||` was
+    /// dead code (every refusal answered `200`, so `pdo complete` exited `0`) and
+    /// waking it up would have appended a second `NodeFailed` **and** a second
+    /// `RunFailed` — the latter unguarded, carrying "after script success" as the
+    /// reason for a script whose output validation had just failed.
+    ///
+    /// Asserted by SUBSTRING because the sibling test is too: it passes whatever the
+    /// tail does, so it is blind to the very bug it looks like it covers.
+    #[test]
+    fn build_script_tail_does_not_double_fail_on_a_refused_completion() {
+        let script = build_script_tail(Path::new("/tmp/body.md"), 60);
+        assert!(
+            !script.contains("pdo complete || pdo fail"),
+            "the bare `||` doubles a failure the daemon already recorded: {script}"
+        );
+        assert!(
+            script.contains("-ne 4"),
+            "the tail must discriminate exit code 4 (refused, already ruled): {script}"
+        );
+        assert!(
+            !script.contains("output validation failed after script success"),
+            "that reason was false — the daemon's own reason is the truthful one: {script}"
+        );
+    }
+
+    /// The full arm matrix of the tail, so a future edit cannot quietly drop one.
+    /// `ec` is the author's bash exit code, `cc` is `pdo complete`'s.
+    #[test]
+    fn build_script_tail_covers_every_arm() {
+        let script = build_script_tail(Path::new("/tmp/body.md"), 60);
+        for needle in [
+            // ec = 0 → try to complete
+            "if [ $ec -eq 0 ]; then pdo complete",
+            // cc = 0 (granted or legal duplicate) and cc = 4 (already ruled) → do
+            // nothing. Anything else → signal the failure ourselves.
+            "if [ $cc -ne 0 ] && [ $cc -ne 4 ]",
+            "pdo complete refused with exit $cc after script success",
+            // ec = 124 → the `timeout` verdict
+            "elif [ $ec -eq 124 ]; then pdo fail --reason \"script timed out after 60s\"",
+            // any other ec → the author's own failure
+            "else pdo fail --reason \"script exited $ec\"",
+        ] {
+            assert!(
+                script.contains(needle),
+                "missing arm {needle:?} in: {script}"
+            );
+        }
     }
 
     #[test]

--- a/crates/pdo-daemon/tests/cli_complete_does_not_panic.rs
+++ b/crates/pdo-daemon/tests/cli_complete_does_not_panic.rs
@@ -1,6 +1,13 @@
-//! Layer 3a — proves the `pdo complete` / `pdo fail` CLI commands
-//! exit cleanly instead of panicking on tokio runtime shutdown when invoked
-//! from inside a tmux NodeRun session.
+//! Layer 3a — the `pdo complete` CLI contract: it exits cleanly instead of
+//! panicking, **and** its exit code tells the truth (#490, ADR-0035 §4).
+//!
+//! `0` granted or legal duplicate · `3` refused, still your turn · `4` refused, the
+//! runtime already ruled · `1` breakdown. Those codes are a **public** contract:
+//! they live in pipeline authors' bash, and a `script` node's tail branches on the
+//! `4` so it does not double a failure the daemon already recorded.
+//!
+//! Originally this file only proved "does not panic", which is why it is still
+//! named that way in git history. The panic regression it was written for:
 //!
 //! Surfaced while running the run-minimal scenario for #18: the spawn primitive
 //! worked, claude wrote the artifact, but `pdo complete` panicked with
@@ -169,6 +176,194 @@ async fn pdo_complete_does_not_panic_and_marks_node_done() {
         run["nodes"][NODE_ID]["status"], "completed",
         "node should be marked completed; run state was: {run}"
     );
+}
+
+/// Boot a daemon + a run, and hand back everything the CLI needs. The tmux override
+/// is `true`, so the node session exits instantly and neither claude nor a live tmux
+/// is required — the trick that makes the whole exit-code matrix testable in CI.
+async fn daemon_with_run() -> (TestDaemon, String) {
+    let daemon = TestDaemon::spawn_with_override(seed, Some("true".to_string()))
+        .await
+        .unwrap();
+    let body = serde_json::json!({
+        "pipeline": PIPELINE_NAME,
+        "input": "hello",
+        // #470 / ADR-0033: required at the create boundary.
+        "target_repo": daemon.target_repo(),
+    });
+    let resp = reqwest::Client::new()
+        .post(format!("{}/runs", daemon.url()))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 201);
+    let run_id = resp.json::<serde_json::Value>().await.unwrap()["run_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    (daemon, run_id)
+}
+
+/// Run the real binary against `url`. On a **blocking** task so the host runtime
+/// stays free to serve the request `pdo complete` is blocking on.
+async fn run_pdo_complete(url: &str, run_id: &str) -> (Option<i32>, String) {
+    let url = url.to_string();
+    let run_id = run_id.to_string();
+    let bin = env!("CARGO_BIN_EXE_pdo");
+    let output = tokio::task::spawn_blocking(move || {
+        Command::new(bin)
+            .arg("complete")
+            .env("PDO_RUN_ID", &run_id)
+            .env("PDO_NODE_ID", NODE_ID)
+            .env("PDO_NODE_ITER", "1")
+            .env("PDO_DAEMON_URL", &url)
+            .output()
+            .expect("failed to spawn pdo complete")
+    })
+    .await
+    .expect("blocking task panicked");
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    // The refusal goes to stderr, never stdout — a property `run_complete` already
+    // had and must keep.
+    assert!(
+        String::from_utf8_lossy(&output.stdout).trim().is_empty(),
+        "pdo complete must write nothing to stdout, got: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert!(
+        !stderr.contains("panicked"),
+        "pdo complete panicked: {stderr}"
+    );
+    (output.status.code(), stderr)
+}
+
+fn write_output_artifact(daemon: &TestDaemon, run_id: &str, body: &str) {
+    let port_dir = daemon
+        .repo_root()
+        .join(".pdo/runs")
+        .join(run_id)
+        .join("worktree/.pdo/artifacts/solo/iter-1/out");
+    std::fs::create_dir_all(&port_dir).unwrap();
+    std::fs::write(port_dir.join("output.md"), body).unwrap();
+}
+
+/// Exit `3` — refused, and the node is still yours. Nothing terminal is recorded, so
+/// the right next move is to write the artefact and call again; `pdo fail` would be
+/// wrong. The stderr has to say so, because the agent reading it is the consumer this
+/// whole issue is about.
+#[tokio::test]
+async fn pdo_complete_exits_3_on_a_recoverable_refusal() {
+    let (daemon, run_id) = daemon_with_run().await;
+    // No artefact written: `missing_outputs`.
+    let (code, stderr) = run_pdo_complete(&daemon.url(), &run_id).await;
+    assert_eq!(code, Some(3), "stderr=\n{stderr}");
+    assert!(stderr.contains("REFUSED"), "stderr=\n{stderr}");
+    assert!(
+        stderr.contains("out"),
+        "must name the missing port: {stderr}"
+    );
+    assert!(
+        stderr.contains("still your turn"),
+        "must say the node is still the caller's: {stderr}"
+    );
+    assert!(
+        stderr.contains("Do NOT run `pdo fail`"),
+        "must warn against doubling: {stderr}"
+    );
+
+    // And it really is still alive — which is what makes `3` rather than `4` correct.
+    let run = reqwest::get(format!("{}/runs/{run_id}", daemon.url()))
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    assert_ne!(run["nodes"][NODE_ID]["status"], "failed", "{run}");
+}
+
+/// Exit `4` — refused, and the runtime has already ruled. Driving the node failed
+/// drives the whole run terminal, so the completion guard answers "resume the run
+/// first": the refusal that, before #490, answered `200` and printed
+/// "marked complete." on a dead run.
+#[tokio::test]
+async fn pdo_complete_exits_4_on_a_terminal_refusal() {
+    let (daemon, run_id) = daemon_with_run().await;
+    write_output_artifact(&daemon, &run_id, "# Output\nDone.");
+
+    let resp = reqwest::Client::new()
+        .post(format!(
+            "{}/runs/{run_id}/nodes/{NODE_ID}/fail",
+            daemon.url()
+        ))
+        .json(&serde_json::json!({ "reason": "driven terminal on purpose", "iter": 1 }))
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.status().is_success());
+    tokio::time::sleep(Duration::from_millis(400)).await;
+
+    let (code, stderr) = run_pdo_complete(&daemon.url(), &run_id).await;
+    assert_eq!(code, Some(4), "stderr=\n{stderr}");
+    assert!(stderr.contains("REFUSED"), "stderr=\n{stderr}");
+    assert!(
+        stderr.contains("Do NOT run `pdo fail`"),
+        "the whole point of the 4: {stderr}"
+    );
+    assert!(
+        stderr.contains("already recorded"),
+        "must say the runtime already ruled: {stderr}"
+    );
+}
+
+/// Exit `0` on a **legal duplicate**. Non-negotiable: a puzzled agent that re-runs
+/// `pdo complete` must not read "refused" and then chain `pdo fail` — it would kill a
+/// run that had just succeeded, and on a `script` node the tail would do it
+/// unprompted.
+#[tokio::test]
+async fn pdo_complete_exits_0_on_a_legal_duplicate() {
+    let (daemon, run_id) = daemon_with_run().await;
+    write_output_artifact(&daemon, &run_id, "# Output\nDone.");
+
+    let (first, stderr) = run_pdo_complete(&daemon.url(), &run_id).await;
+    assert_eq!(first, Some(0), "first call should be granted: {stderr}");
+    tokio::time::sleep(Duration::from_millis(400)).await;
+
+    let (second, stderr) = run_pdo_complete(&daemon.url(), &run_id).await;
+    assert_eq!(second, Some(0), "a legal duplicate is a success: {stderr}");
+    assert!(
+        stderr.contains("already complete") || stderr.contains("nothing to do"),
+        "must say so truthfully rather than claim a fresh completion: {stderr}"
+    );
+    assert!(!stderr.contains("REFUSED"), "{stderr}");
+}
+
+/// Exit `1` — no verdict at all. The **only** arm where `pdo fail` is the right
+/// escalation, and the stderr is the only place that says so.
+#[tokio::test]
+async fn pdo_complete_exits_1_when_the_daemon_is_unreachable() {
+    // A port nothing listens on. No daemon involved, so no run either.
+    let (code, stderr) = run_pdo_complete("http://127.0.0.1:1", "no-such-run").await;
+    assert_eq!(code, Some(1), "stderr=\n{stderr}");
+    assert!(stderr.contains("failed to reach daemon"), "{stderr}");
+    assert!(
+        stderr.contains("pdo fail"),
+        "the one case where signalling failure is right: {stderr}"
+    );
+}
+
+/// Three lines that kill the laziest possible implementation: returning the HTTP
+/// status as the process exit code. `409 % 256 == 153`, and a `u8` exit code cannot
+/// express `409` at all — so a status passthrough would collide with nothing
+/// meaningful and silently break the tail's `-ne 4` test.
+#[tokio::test]
+async fn pdo_complete_exit_code_is_not_the_http_status() {
+    let (daemon, run_id) = daemon_with_run().await;
+    let (code, stderr) = run_pdo_complete(&daemon.url(), &run_id).await;
+    assert_eq!(code, Some(3), "stderr=\n{stderr}");
+    assert_ne!(code, Some(409 % 256), "the exit code is not the status");
+    assert_ne!(code, Some(409), "an exit code cannot even hold 409");
 }
 
 #[tokio::test]

--- a/crates/pdo-daemon/tests/frontmatter_validation.rs
+++ b/crates/pdo-daemon/tests/frontmatter_validation.rs
@@ -2,10 +2,16 @@
 //!
 //! Spawns a real TestDaemon, creates a run with a node that has a frontmatter
 //! schema on its output port. Tests:
-//!   1. Valid frontmatter → NodeCompleted
-//!   2. Invalid frontmatter (1st attempt) → frontmatter_retry_pending, node stays Running
-//!   3. Invalid frontmatter (2nd attempt) → NodeFailed with "output validation failed"
+//!   1. Valid frontmatter → NodeCompleted, `200`
+//!   2. Invalid frontmatter (1st attempt) → `409 frontmatter_retry_pending`
+//!      `recoverable: true`, node stays Running
+//!   3. Invalid frontmatter (2nd attempt) → `409 frontmatter_retry_exhausted`
+//!      `recoverable: false`, NodeFailed with "output validation failed"
 //!   4. Invalid then valid → NodeCompleted on retry
+//!
+//! The two `409`s are #490 / ADR-0035: a refusal is never a `2xx`. Both used to
+//! answer `200`, and the second one did so *after* appending `NodeFailed` +
+//! `RunFailed`. The `200` arms below are the deliberate negative control.
 
 mod common;
 
@@ -190,10 +196,16 @@ async fn invalid_frontmatter_triggers_retry_then_valid_succeeds() {
         "---\nverdict: MAYBE\nscore: 8\n---\nNot sure",
     );
 
+    // #490 / ADR-0035: the completion was NOT granted, so this is a refusal — 409,
+    // not the 200 it used to answer. `recoverable: true` says the node is still
+    // running and it is still the agent's turn, which is exactly what the corrective
+    // nudge in its pane says too.
     let resp = mark_node_done(&daemon, &run_id, "reviewer", 1).await;
-    assert!(resp.status().is_success());
+    assert_eq!(resp.status(), reqwest::StatusCode::CONFLICT);
     let body: serde_json::Value = resp.json().await.unwrap();
-    assert_eq!(body["status"], "frontmatter_retry_pending");
+    assert_eq!(body["error"], "frontmatter_retry_pending");
+    assert_eq!(body["recoverable"], true);
+    assert_eq!(body["violations"][0]["field"], "verdict");
 
     // Check node is still running with retries > 0
     let state = get_run_state(&daemon, &run_id).await;
@@ -237,8 +249,10 @@ async fn double_invalid_frontmatter_fails_node() {
     );
 
     let resp1 = mark_node_done(&daemon, &run_id, "reviewer", 1).await;
+    assert_eq!(resp1.status(), reqwest::StatusCode::CONFLICT);
     let body1: serde_json::Value = resp1.json().await.unwrap();
-    assert_eq!(body1["status"], "frontmatter_retry_pending");
+    assert_eq!(body1["error"], "frontmatter_retry_pending");
+    assert_eq!(body1["recoverable"], true);
 
     // Second attempt: still invalid
     write_artifact(
@@ -250,10 +264,13 @@ async fn double_invalid_frontmatter_fails_node() {
         "---\nverdict: MAYBE\nscore: 8\n---\nStill not sure",
     );
 
+    // The retry is spent: `recoverable: false` — `NodeFailed` + `RunFailed` are
+    // already appended, so an agent reading this must NOT chain `pdo fail`.
     let resp2 = mark_node_done(&daemon, &run_id, "reviewer", 1).await;
-    assert!(resp2.status().is_success());
+    assert_eq!(resp2.status(), reqwest::StatusCode::CONFLICT);
     let body2: serde_json::Value = resp2.json().await.unwrap();
-    assert_eq!(body2["status"], "frontmatter_retry_exhausted");
+    assert_eq!(body2["error"], "frontmatter_retry_exhausted");
+    assert_eq!(body2["recoverable"], false);
 
     tokio::time::sleep(std::time::Duration::from_millis(200)).await;
     let state = get_run_state(&daemon, &run_id).await;

--- a/crates/pdo-daemon/tests/script_node.rs
+++ b/crates/pdo-daemon/tests/script_node.rs
@@ -352,4 +352,57 @@ async fn script_node_missing_declared_output_fails_fast() {
         run["nodes"][NODE_ID]["status"], "failed",
         "missing declared output must fail-fast; run was: {run}"
     );
+
+    // #490: the projection now carries WHICH port was missing. Before this issue the
+    // daemon computed it, nested it under `payload.detail`, and nothing read it — so
+    // the red banner rendered an empty list.
+    assert_eq!(
+        run["nodes"][NODE_ID]["missing_outputs"],
+        serde_json::json!(["out"]),
+        "the failure must say which port is missing; run was: {run}"
+    );
+
+    // #490 / ADR-0035 §4 — THE regression the fix itself could introduce.
+    //
+    // Making the refusal a `409` woke up the tail's `pdo complete || pdo fail` (dead
+    // code while every refusal answered `200`). Without the `-ne 4` test in the tail,
+    // this run would now hold TWO `run_failed` events: the daemon's own fail-fast,
+    // then a second one from the tail carrying the false reason "output validation
+    // failed after script success". `NodeFailed` is absorbed by the transition guard;
+    // `RunFailed` is NOT guarded, which is what makes the count the load-bearing
+    // assertion.
+    //
+    // Let any doubled append land before counting — a passing count measured too
+    // early would be a false green.
+    tokio::time::sleep(Duration::from_millis(1_500)).await;
+    let events: Vec<serde_json::Value> =
+        reqwest::get(format!("{}/runs/{run_id}/events", daemon.url()))
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+    let run_failed: Vec<&serde_json::Value> = events
+        .iter()
+        .filter(|e| e["kind"] == "run_failed")
+        .collect();
+    assert_eq!(
+        run_failed.len(),
+        1,
+        "exactly one run_failed; the tail must not double the daemon's verdict. events={events:#?}"
+    );
+    let reason = run_failed[0]["payload"]["reason"].as_str().unwrap_or("");
+    assert!(
+        reason.contains("failed output validation"),
+        "the surviving reason must be the daemon's fail-fast one, got {reason:?}"
+    );
+    assert!(
+        !reason.contains("after script success"),
+        "that reason is the tail's, and it is false: {reason:?}"
+    );
+    let node_failed = events.iter().filter(|e| e["kind"] == "node_failed").count();
+    assert_eq!(
+        node_failed, 1,
+        "exactly one node_failed too. events={events:#?}"
+    );
 }

--- a/docs/adr/0023-detached-run-advance.md
+++ b/docs/adr/0023-detached-run-advance.md
@@ -60,7 +60,11 @@ falls outside the #279 reconciler's coverage.
   durably recorded and the advance is scheduled", not "the run has advanced".
   Advance errors surface via `RunFailed` + daemon logs, never via the HTTP
   response. Validation errors (transition-guard reject/no-op, merge conflicts,
-  output-validation failures, append failures) still return in-request.
+  output-validation failures, append failures) still return in-request — and
+  since ADR-0035 (#490) they return **non-2xx**: a refusal is never a 2xx, so
+  "2xx means recorded and scheduled" is now also "2xx means not refused". The
+  one exception is the legal-duplicate no-op, which grants nothing and stays a
+  `200` on purpose.
 - A client disconnect at any point can no longer cancel the advance — closing
   the whole silent-abort class upstream of #279's guard, including the
   end-port finalization drop.

--- a/docs/adr/0025-truthful-loop-command-responses.md
+++ b/docs/adr/0025-truthful-loop-command-responses.md
@@ -2,6 +2,12 @@
 
 Date : 2026-07-11 · Statut : accepté · Issue : #327
 
+> **Amendé par ADR-0035 (#490).** La convention noop de §3 tient pour les quatre commandes de boucle,
+> mais elle citait `mark_node_done` comme précédent : sur le **corps de complétion partagé**, huit
+> refus répondaient `200`, quatre après avoir appendé `RunFailed`. ADR-0035 y ajoute la classe que
+> cette ADR n'avait pas — **noop ≠ refus** — et pose l'invariant « un refus n'est jamais un `2xx` ».
+> Lire §3 comme « dire l'effet », jamais comme « un `200` suffit à le dire ».
+
 ## Contexte
 
 `extend_cycle` répondait `{ok:true}` inconditionnellement : node_id inconnu, membre d'une
@@ -31,7 +37,8 @@ nœud à double rôle (membre de région portant sa propre arête `$var`) rend l
 3. **Dire l'effet.** `spawn_node` retourne un `SpawnOutcome`
    (Spawned/Throttled/Refused/Failed), `re_evaluate_after_command` agrège un `ReEvalSummary`.
    Les handlers répondent `{"ok":true,"spawned":[...]}` si effet, ou
-   `{"ok":true,"noop":true,"reason":...}` sinon (convention `mark_node_done`). Décision
+   `{"ok":true,"noop":true,"reason":...}` sinon (convention `mark_node_done` — dont le chemin de
+   *complétion* a depuis été corrigé par ADR-0035). Décision
    synchrone : le détachement ADR-0023 ne couvre que la queue de `node_done`, pas ce chemin.
 4. **Documenter le pilotage de région.** Le préambule du manager gagne `bump_region`/`end_region`
    en section 1 (recette de découverte du region_id : clés de `loop_states` dans

--- a/docs/adr/0035-completion-refusal-is-never-2xx.md
+++ b/docs/adr/0035-completion-refusal-is-never-2xx.md
@@ -1,0 +1,252 @@
+# ADR-0035 — Un refus de complétion n'est jamais un `2xx` : le statut dit refusé, le corps dit laquelle
+
+> Statut : accepted (grilling du 2026-07-30, issue #490). Vocabulaire : CONTEXT.md § « Contrat de refus
+> de la complétion ». **Amende ADR-0023** : le `2xx` de `pdo complete` signifie toujours « ton événement
+> terminal est durablement enregistré et l'avance est planifiée », mais ses *Conséquences* laissaient
+> croire qu'une erreur de validation renvoyée « in-request » pouvait l'être en `2xx` — elle ne peut
+> plus. **Amende ADR-0025 §3** : la convention « dire l'effet » tient pour les quatre commandes de
+> boucle, mais son précédent invoqué (`mark_node_done`) était partiellement un mensonge ; cette ADR y
+> ajoute la classe que 0025 n'avait pas — **noop ≠ refus**. Ne touche **ni** au détachement de la queue
+> d'avance (ADR-0023), **ni** au fail-fast d'un node `script` (ADR-0017), **ni** au tombstone d'un Run
+> oublié (ADR-0024, qui garde son `410`). Suit la ligne d'**ADR-0001** (sharp tool : un slug inconnu se
+> rend tel quel) et d'**ADR-0004** (aucun critère fermé sans test de couche ≥ 3).
+
+## Contexte
+
+Le chemin par lequel **tout** node se termine — `pdo complete` côté agent, *Mark complete* côté UI —
+a dix-neuf sorties. Un recensement du 2026-07-30 en a trouvé **huit** qui décrivent un **refus** et
+répondent malgré tout `200`, dont **quatre après avoir déjà appendé `RunFailed`** :
+
+| Sortie | Statut d'alors | Événements déjà appendés |
+|---|---|---|
+| `frontmatter_retry_pending` | `200` | `FrontmatterRetryPending` |
+| `frontmatter_retry_exhausted` | `200` | `NodeFailed` + `RunFailed` |
+| `script_validation_failed` | `200` | `NodeFailed` + `RunFailed` |
+| `doc_violated_code_immutability` | `200` | `NodeFailed` + `RunFailed` |
+| `merge_conflict` | `200` | `MergeConflictDetected` + `RunFailed` |
+| `merge_resolution_failed` | `200` | `MergeResolverFailed` + `RunFailed` |
+| `merge_resolver_spawned` / `merge_resolver_failed` | `200` | (branches mortes, cf. §6) |
+
+**Le consommateur manquant est la CLI, pas l'UI.** `run_complete` ne regarde que
+`resp.status().is_success()` : sur ces huit corps il imprimait `Node <id> marked complete.` et sortait
+en `0`. Un agent lisait donc « livré » sur un Run que le daemon venait de tuer, puis passait à la
+suite — ou, pire, enchaînait `pdo fail` et doublait un échec déjà enregistré.
+
+L'UI, elle, n'était pas muette : elle rend depuis la **projection** poussée par WebSocket, donc elle
+peignait déjà du rouge — mais **en retard**, et jamais au niveau du geste. Le préjudice y est
+l'**effacement** : `handleMarkComplete` remettait sa bannière à `null` *avant* d'attendre la réponse,
+et un `200`-mensonge ne posait ensuite rien. Une bannière issue d'un clic précédent disparaissait pour
+ne jamais revenir. À quoi s'ajoute le refus du garde de transition, seul refus déjà correctement en
+`409`, que le client relisait comme `missing_outputs` avec une liste vide : gaté sur `length > 0`,
+**rien** ne s'affichait. C'est le symptôme le plus fréquent — tout clic sur un node d'un Run
+`RunFailed` — et il était déjà documenté comme contournement de test dans
+`frontend/e2e/failed-node.spec.ts`.
+
+## Ce qu'on décide
+
+### 1. L'invariant remplace l'énumération
+
+Une tentative de complétion a **quatre** issues, et une seule variante non-succès peut porter un
+`2xx` :
+
+| Issue | Statut | Événement terminal | Exit `pdo complete` |
+|---|---|---|---|
+| **`Completed`** | `2xx` | appendé, avance planifiée (ADR-0023) | `0` |
+| **`NoOp`** | `2xx` | **aucun** | `0` |
+| **`Refused`** | **jamais `2xx`** | selon la cause (cf. `recoverable`) | `3` ou `4` |
+| panne / cible inconnue | `4xx`/`5xx` | — | `1` |
+
+`NoOp` est la frontière que cette ADR ajoute au vocabulaire d'ADR-0025 : « rien à faire » reste un
+succès, « ta complétion est refusée » ne l'est plus. Les confondre — ce que faisait la variante
+`CompletionAttempt::Aborted`, qui emballait indistinctement un refus, un no-op légal et une
+délégation réussie — est exactement ce qui rendait l'invariant inexprimable.
+
+L'invariant se pose donc sur une variante **`Refused`** et sur un type dédié,
+`CompletionRefusal`, qui **ne porte aucun statut** : la projection vers HTTP en est la seule
+propriétaire (`refusal_response`), et son énumération de statuts est fermée sur `409`/`410`/`500`.
+« Un refus qui répond `2xx` » devient inexprimable, et
+`a_refusal_never_projects_to_a_2xx` le prouve variante par variante derrière un `match` exhaustif —
+ajouter une variante sans la couvrir **ne compile plus**.
+
+**« Jamais `2xx` » ≠ « toujours `409` ».** Le `410` d'un Run oublié (#328 / ADR-0024), le `404` d'une
+cible inconnue et le `500` d'une panne **ne bougent pas**. Les aplatir dans le `409` serait la
+mauvaise lecture de l'invariant.
+
+Conséquence assumée : sur la route `POST …/nodes/<id>/done`, ces trois-là portent maintenant le corps
+JSON du §3 (`{error, recoverable, message}`) au lieu du texte brut d'avant. Leur **statut** est
+inchangé, et le gain est qu'un appelant unique — la CLI — sait discriminer sans avoir à connaître deux
+langages de réponse sur la même route. Le `410` y voit donc son `error` passer de la prose au slug
+`run_forgotten`, la prose migrant vers `message` comme pour le garde. La route `POST …/commands` garde
+son propre gate de tombstone (ADR-0024 §3 en place exactement deux frontières), dont le corps ne bouge
+pas.
+
+### 2. `409`, ni `422` ni `202`
+
+`missing_outputs` et les deux `frontmatter_*` sont les **bras d'un même `match` sur
+`ValidationError`** : même validateur, même remède, node `running` dans les trois cas — et
+`missing_outputs` était **déjà** un `409`. Les séparer par statut aurait fait porter au statut une
+distinction que le corps porte mieux.
+
+`422` qualifie le **contenu de la requête**. Ici la requête est `{"iter":1}` : parfaitement traitable.
+Ce qui entre en conflit est l'état du disque face au contrat de sortie déclaré — la définition même du
+`409`.
+
+**`202` pour `frontmatter_retry_pending` a été instruit et rejeté.** L'argument pour : ce n'est pas un
+échec, aucun événement d'échec n'est appendé, un message correctif est déjà parti dans la session, et
+l'agent *doit* retenter. Deux raisons de refuser : (i) `202` est un `2xx`, donc il rend l'invariant du
+§1 inexprimable — or la complétion **n'a pas été accordée**, ce qui est la définition opérationnelle
+d'un refus ; (ii) l'objection « la CLI va donc échouer dans la session qui vient de recevoir le
+message correctif » est **annulée par le contrat d'exit du §4** : le code `3` dit « encore ton tour,
+corrige et rappelle », ce qui est *le même message* que le nudge, en accord et non en contradiction.
+
+### 3. Le statut dit refusé, le corps dit laquelle
+
+Forme **unique** de tout refus, sur les deux routes (`POST …/nodes/:id/done` et `POST …/commands`) :
+
+```json
+{ "error": "<slug>", "recoverable": true|false, "…détail spécifique" }
+```
+
+- **`error`** — slug `snake_case` stable, **le** point de discrimination. Un client qui branche sur le
+  statut est en faute : un statut n'a pas assez de bits pour neuf causes, et la branche qui relisait
+  *tout* `409` comme `missing_outputs` est la démonstration du mode d'échec.
+- **`recoverable`** — répond à une seule question : *est-ce encore ton tour ?* `true` ⇒ le node est
+  toujours `running`, **rien de terminal n'a été enregistré**, corrige et rappelle. `false` ⇒ le daemon
+  a **déjà** enregistré l'issue terminale ; **ne jamais** enchaîner sur `pdo fail`.
+- **Le détail reste verbatim celui d'avant** (`missing`, `violations`, `detail`, `reason`) : cette
+  décision déplace un statut et ajoute deux clés, elle ne renomme aucun champ.
+- Un slug **inconnu d'un client** se rend tel quel, jamais masqué (ADR-0001).
+
+La convention est **transversale**, pas locale à ce chemin : c'est la forme à reprendre pour tout refus
+futur. Corollaire immédiat : le refus du garde de transition (#212/#354) rejoint le contrat de corps —
+son statut ne change pas (il était déjà `409`), mais sa prose passe de `error` à `message`, et `error`
+devient le slug `completion_rejected`. `apiErrorMessage` côté frontend lit déjà
+`body.message ?? body.error ?? fallback`, donc la prose reste lisible sans code neuf.
+
+### 4. Le contrat d'exit de `pdo complete` : `0` / `3` / `4` / `1`
+
+| Situation | Code | Ce que l'appelant doit faire |
+|---|---|---|
+| succès, ou **doublon légal** (`noop`) | `0` | rien |
+| refus **récupérable** (`recoverable: true`) | `3` | corriger, rappeler `pdo complete`. **Pas** `pdo fail` |
+| refus **terminal** (`recoverable: false`) | `4` | s'arrêter et rapporter. **Pas** `pdo fail` — c'est déjà enregistré |
+| panne, transport, corps illisible, `5xx` | `1` | ici seulement, `pdo fail` est le bon conseil |
+
+Ces codes sont un contrat **public** : ils vivent dans le bash d'auteurs de pipelines, et
+`pdo complete` est la seule sous-commande à en porter un.
+
+**Le `4` existe pour un `||` situé six mille lignes plus loin.** Le tail bash d'un node `script` fait
+`pdo complete || pdo fail --reason "…"`. Ce `||` était **du code mort** tant que son déclencheur
+répondait `200` — le §1 le réveille. Sans discrimination du `4`, chaque refus terminal d'un node
+`script` produirait **deux** `NodeFailed` et **deux** `RunFailed`, le second avec une raison fausse
+(`NodeFailed` est absorbé par le garde, `RunFailed` ne l'est pas). Le code `4` n'a donc de valeur que
+si **le tail le teste** : les deux changements sont indissociables, et
+`build_script_tail_does_not_double_fail_on_a_refused_completion` les épingle ensemble.
+
+**Le `0` sur un doublon légal est non négociable** : le no-op est documenté « *legal duplicate […] do
+not surface an error* » dans le garde de transition. Un agent perplexe qui rappelle `pdo complete` ne
+doit pas lire « refusé » puis enchaîner `pdo fail` — il tuerait un Run qui vient de réussir. Et sur un
+node `script`, le `||` du tail le ferait **sans demander**.
+
+### 5. Le détail imbriqué se répare chez le consommateur
+
+Le fail-fast d'un node `script` imbrique sa preuve sous `payload.detail.{kind, violations|missing}` là
+où le chemin après-retry la met à plat sous `payload.violations`. Le projecteur ne lisait que la forme
+plate : le détail déjà calculé était **jeté**, et l'UI peignait une bannière rouge avec une liste vide.
+
+C'est **le projecteur** qui apprend à lire les deux formes, pas le producteur qui aplatit. Trois
+raisons :
+
+1. aplatir rendrait la trace d'audit d'un fail-fast `script` **indistinguable** d'un échec après
+   retry — deux causes, deux remèdes, une seule empreinte ;
+2. cela routerait le cas vers une bannière titrée « after retry », alors qu'un node `script` ne
+   retente **jamais** ;
+3. cela ne répare que **la moitié** du bug : `ValidationError::MissingOutputs` n'a aucun `violations`
+   à aplatir, seulement un `missing` — qui, avant #490, n'avait **aucun** foyer, ni Rust ni TS.
+
+Corollaire : `NodeState` gagne un `missing_outputs`, `#[serde(default, skip_serializing_if)]` comme
+son voisin `frontmatter_violations`, donc **absent** de toute réponse existante — la compatibilité
+filaire est identique à l'octet pour tout échec non-`script`. Et le titre de la bannière rouge devient
+la `failure_reason` **verbatim** au lieu d'une chaîne codée en dur.
+
+### 6. Deux bras morts passent sous le type, sans être supprimés
+
+`merge_resolver_spawned` et `merge_resolver_failed` sont **inatteignables** : ils supposent
+`MergeResult::ConflictPendingResolution`, que seul `keep_conflict == true` construit, et aucun appelant
+de production ne passe `true` (ADR-0006 a retiré le résolveur automatique). Ils suivent les rails du
+nouveau type à coût de test nul.
+
+Leur **suppression** emporterait tout un sous-système vestigial (`MergeResolverStarted/Failed/
+Completed`, `RunState.merge_resolver`, `MergeResolverInfo` côté TS, `prompts/builtin/merge-resolver.md`,
+la route `__merge_resolver__`) : c'est une autre issue, à ouvrir en retombée d'ADR-0006. Supprimer un
+sous-système sous un fix de bug mélangerait deux intentions sous un seul bump.
+
+En revanche la **délégation** au résolveur est hissée : le `if node_id == MERGE_RESOLVER_NODE_ID` quitte
+le corps partagé pour le handler HTTP. Trois bénéfices : la branche emballait un **succès complet**
+(elle a appendé `NodeCompleted` et appelé `complete_node`) dans la variante d'échec, donc le type
+devient `Completed | NoOp | Refused` **sans trou** ; l'invariant devient **total** ; et le contournement
+du garde de transition que cette branche opérait — elle était placée *avant* le garde — disparaît. Le
+hissage est sûr parce que l'autre appelant du corps partagé, la veille de vivacité, ne peut **jamais**
+voir `__merge_resolver__` : aucune session de résolveur n'est jamais spawnée.
+
+## Alternatives écartées
+
+- **Corriger le frontend seul** (option 1 du ticket). Le consommateur lésé est la **CLI** : un agent qui
+  sort en `0` sur un Run mort ne voit aucune UI. Et le mensonge resterait sur le wire pour tout autre
+  client (`curl`, harnais de test, scripts).
+- **Garder le `200` en enrichissant le corps.** C'est l'approche de #489, légitime **là-bas** parce
+  qu'additive sur une surface qui ne mentait pas. Ici le statut *est* le mensonge : un client bien
+  écrit qui teste `resp.ok` a raison de conclure « accordé ».
+- **Énumérer les huit bras** et poser une assertion sur chacun. Le recensement a montré que la liste
+  bouge (deux bras morts, un succès emballé en échec, un bras qui court-circuitait le point de
+  passage) : une liste à relire est un invariant qui dérive. Le type, lui, ne dérive pas.
+- **Poser le garde sur `CompletionAttempt`** (un `debug_assert` dans son constructeur d'échec). Rejeté
+  deux fois : il ne voit pas le bras `mark_node_done`, qui n'a jamais construit de `CompletionAttempt`
+  — c'est-à-dire tout le chemin de l'UI ; et il **tirerait sur du comportement correct** (le no-op, la
+  délégation). Le vrai point de passage partagé est le validateur de sortie.
+- **`422` ou `202`** — cf. §2.
+- **Un seul code de sortie non nul.** « Refusé » et « refusé, et le Run est mort » demandent deux
+  gestes opposés du bash appelant. Un code unique laisserait le tail `script` doubler l'échec.
+
+## Limites acceptées
+
+- **Les corps de succès restent asymétriques** : `POST …/done` répond `200 "ok"` en **texte brut**,
+  `POST …/commands` répond `200 {"ok":true}`. Symétriser appartient à **#491** ; le faire ici
+  mélangerait une rupture et un nettoyage sous un seul bump.
+- **`vitest` ne tourne pas en CI** (le job frontend fait `npm ci` / `typecheck` / `lint` / `build`). La
+  branche client généralisée — le seul endroit où un refus peut *encore* échouer en silence — atterrit
+  donc dans la seule couche qu'aucun gate ne joue. D'où l'assertion Playwright obligatoire, et
+  `make test` déclaré à la main dans la PR.
+- **Le bouton *Mark complete* reste gaté sur le statut seul** (`NodeState` ne porte pas `node_type`),
+  donc il s'affiche aussi sur un node `script` `failed`. Le masquer retirerait un **chemin de
+  récupération supporté** — le garde de transition autorise explicitement « mark_node_done on a failed
+  node (outputs fixed by hand) ». Le clic peut désormais être refusé **visiblement**, ce qui est le
+  bon comportement.
+- **Deux bras morts restent sous le type** (§6).
+- **La branche fail-fast `script` n'est pas idempotente** : un clic refusé sur un node `script` déjà
+  `failed` réentre dedans et appende un **second** `NodeFailed` + `RunFailed` *avant* de répondre — un
+  effet de bord sur un refus. Constaté ici, à ficher séparément : ce n'est pas un statut menteur, c'est
+  une idempotence manquante.
+- **L'asymétrie de route subsiste** : `merge_conflict` et `doc_violated_code_immutability` sont
+  atteignables depuis `POST …/done` (donc depuis chaque `pdo complete`) et **pas** depuis
+  `POST …/commands`, dont le bras ne fait ni le merge ni le contrôle d'immutabilité. Cette ADR ne la
+  crée pas et ne la ferme pas ; elle la nomme.
+
+## Relations
+
+- Issue **#490** (cette décision). **#491** vient **après** (symétrie des corps de succès, filet de
+  content-types). **#489** est séparé et additif.
+- **ADR-0025** (#327) — amendée : la convention noop tient, son précédent était partiellement faux,
+  son vocabulaire gagne **noop ≠ refus**.
+- **ADR-0023** (#304) — amendée : « `2xx` = enregistré + planifié » devient aussi « `2xx` = pas
+  refusé ». Le détachement de la queue est intact.
+- **ADR-0017** (#248) — le fail-fast d'un node `script` est intact ; seul son statut change, et son
+  détail imbriqué est enfin lu.
+- **ADR-0032** (#469) — indemne par construction : la veille lit la **variante**, jamais le statut.
+- **ADR-0024** (#328) — le `410` du Run oublié est conservé tel quel.
+- **ADR-0006** — retombée à ficher : suppression du résolveur de merge automatique (§6).
+- **ADR-0001** — un slug inconnu se rend tel quel.
+- **ADR-0004** — les critères sont fermés par des tests de couche ≥ 3 : invariant structurel, tests
+  filaires sur les **deux** routes, tests de code de sortie sur le vrai binaire, assertion Playwright.
+- **ADR-0009** — le refus est rendu à la couche 3 (l'UI), au niveau du geste.
+- **#212 / #354** — le garde de transition, dont le refus rejoint le contrat de corps.

--- a/frontend/e2e/failed-node.spec.ts
+++ b/frontend/e2e/failed-node.spec.ts
@@ -11,13 +11,21 @@ import { openRunNodeDetails, cleanupRuns, runMultipart } from "./helpers";
 // 2. Mark complete with missing outputs shows the 409 sub-banner listing ports.
 // 3. Mark complete succeeds once the output files exist, and the node completes.
 //
+// 4. #490: clicking Mark complete on a node of an already-Failed run SHOWS the
+//    guard's refusal ("resume the run first") instead of nothing at all.
+//
 // Tests 2 and 3 operate on a *running* node, not a failed one: failing the only
 // worker drives the whole run terminal (Failed), and the daemon then refuses
-// `mark_node_done` with "resume the run first" (a different 409 with no `missing`
+// `mark_node_done` with "resume the run first" (a different 409, no `missing`
 // list) rather than the missing-outputs 409 the sub-banner is built from. A
 // running node in a live run is the state where Mark complete validates outputs,
 // which is exactly what those two assertions exercise. Each test owns its run so
 // they are independent of order and of each other's state.
+//
+// That second refusal used to be invisible — this file documented it as a
+// workaround for two years' worth of commits. Test 4 turns the workaround into
+// the assertion, and it is the #490 regression test at the ONE layer the CI
+// actually plays (vitest does not run in CI).
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const WORKSPACE_ROOT = path.resolve(__dirname, "..", "..");
@@ -201,4 +209,47 @@ test("Mark complete succeeds after creating output files", async ({
 
   // Node status transitions to Completed.
   await expect(page.getByText("Completed")).toBeVisible({ timeout: 5_000 });
+});
+
+test("Mark complete on a node of a failed run shows the guard's refusal (#490)", async ({
+  page,
+  baseURL,
+}) => {
+  await page.goto("/");
+  await expect(page.getByText("Daemon: connected")).toBeVisible({
+    timeout: 10_000,
+  });
+
+  const runId = await createRun(page, baseURL!);
+
+  // Failing the only worker drives the whole run terminal, so the completion
+  // guard — not output validation — is what answers the next click.
+  const failResp = await page.request.post(
+    `${baseURL}/runs/${runId}/nodes/worker/fail`,
+    { data: { reason: "driven terminal on purpose", iter: 1 } },
+  );
+  expect(failResp.status()).toBe(200);
+  await waitForWorkerStatus(page, baseURL!, runId, "failed");
+
+  await selectWorkerRunPane(page, runId);
+  const button = page.getByTestId("mark-complete-btn");
+  await expect(button).toBeVisible({ timeout: 5_000 });
+
+  await button.click();
+
+  // Pre-#490 this produced a `200` carrying a prose `error`, which the client read
+  // as `missing_outputs` with an empty list and a `length > 0` gate — so NOTHING
+  // was displayed. Now the refusal names itself, and says what to do.
+  const verdict = page.getByTestId("mark-complete-verdict");
+  await expect(verdict).toBeVisible({ timeout: 5_000 });
+  await expect(verdict).toHaveAttribute("data-verdict", "refused");
+  await expect(verdict).toHaveAttribute("data-recoverable", "false");
+  await expect(verdict).toContainText("resume the run first");
+
+  // And it STAYS: a second click must not blink it out (the handler no longer
+  // clears before awaiting).
+  await button.click();
+  await expect(verdict).toBeVisible();
+  await page.waitForTimeout(1_500);
+  await expect(page.getByTestId("mark-complete-verdict")).toBeVisible();
 });

--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -10,6 +10,7 @@ import {
   deletePipeline,
   duplicateLibraryPipeline,
   fetchPipeline,
+  markNodeDone,
   request,
   savePipeline,
   saveRunPipeline,
@@ -284,5 +285,145 @@ describe("browseFs wire contract", () => {
     const fetchMock = captureFetch(200, EMPTY);
     await browseFs(undefined, { files: true });
     expect(fetchMock.mock.calls[0][0]).toBe("/fs/browse?files=true");
+  });
+});
+
+// #490 / ADR-0035 — `markNodeDone` had ZERO tests before this issue, and it is the
+// only place a refusal can still fail silently: vitest does not run in CI (the
+// frontend job is `npm ci` / typecheck / lint / build), so this file is guarded by
+// `make test` alone. One case per branch of the outcome union.
+describe("markNodeDone outcome union (#490)", () => {
+  /** A stub whose body is NOT valid JSON — the shape `POST …/done` answers on success. */
+  function stubNonJson(status: number, text: string) {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: status >= 200 && status < 300,
+        status,
+        json: async () => {
+          throw new SyntaxError("Unexpected token");
+        },
+        text: async () => text,
+      })),
+    );
+  }
+
+  it("reads a plain 200 as completed", async () => {
+    stubFetchWith(200, { ok: true });
+    await expect(markNodeDone("r1", "n1", 1)).resolves.toEqual({ kind: "completed" });
+  });
+
+  it("reads a 200 with noop:true as a legal duplicate, not a refusal", async () => {
+    stubFetchWith(200, { ok: true, noop: true, reason: "already completed" });
+    await expect(markNodeDone("r1", "n1", 1)).resolves.toEqual({
+      kind: "noop",
+      reason: "already completed",
+    });
+  });
+
+  it("does not throw a bare SyntaxError on a non-JSON success body", async () => {
+    // Pre-#490 this line was `await resp.json()` unguarded, which violated the
+    // module's single-error-type contract.
+    stubNonJson(200, "ok");
+    await expect(markNodeDone("r1", "n1", 1)).resolves.toEqual({ kind: "completed" });
+  });
+
+  it("reads a 409 missing_outputs as a refusal that is still your turn", async () => {
+    stubFetchWith(409, {
+      error: "missing_outputs",
+      recoverable: true,
+      missing: ["review", "notes"],
+    });
+    const out = await markNodeDone("r1", "n1", 1);
+    expect(out.kind).toBe("refused");
+    if (out.kind !== "refused") throw new Error("unreachable");
+    expect(out.slug).toBe("missing_outputs");
+    expect(out.recoverable).toBe(true);
+    expect(out.missing).toEqual(["review", "notes"]);
+  });
+
+  it("reads a 409 frontmatter_retry_exhausted as a terminal refusal with its violations", async () => {
+    stubFetchWith(409, {
+      error: "frontmatter_retry_exhausted",
+      recoverable: false,
+      violations: [{ port: "review", field: "verdict", reason: "not in enum" }],
+    });
+    const out = await markNodeDone("r1", "n1", 1);
+    if (out.kind !== "refused") throw new Error("expected a refusal");
+    expect(out.slug).toBe("frontmatter_retry_exhausted");
+    expect(out.recoverable).toBe(false);
+    expect(out.violations).toEqual([
+      { port: "review", field: "verdict", reason: "not in enum" },
+    ]);
+  });
+
+  it("surfaces the transition guard's prose instead of an empty missing list", async () => {
+    // THE regression of #490: this refusal used to be read as `missing_outputs` with
+    // `missing: []`, and the banner was gated on `length > 0` — so the most frequent
+    // refusal of all displayed nothing at all.
+    stubFetchWith(409, {
+      error: "completion_rejected",
+      recoverable: false,
+      message: "run r1 is Failed: resume the run first",
+    });
+    const out = await markNodeDone("r1", "n1", 1);
+    if (out.kind !== "refused") throw new Error("expected a refusal");
+    expect(out.slug).toBe("completion_rejected");
+    expect(out.message).toContain("resume the run first");
+    expect(out.missing).toEqual([]);
+  });
+
+  it("reads the nested `detail` of a script fail-fast", async () => {
+    stubFetchWith(409, {
+      error: "script_validation_failed",
+      recoverable: false,
+      detail: { kind: "missing_outputs", missing: ["out"] },
+    });
+    const out = await markNodeDone("r1", "n1", 1);
+    if (out.kind !== "refused") throw new Error("expected a refusal");
+    expect(out.missing).toEqual(["out"]);
+  });
+
+  it("renders an unknown slug verbatim rather than hiding it (ADR-0001)", async () => {
+    stubFetchWith(409, { error: "some_future_cause", recoverable: false, message: "nope" });
+    const out = await markNodeDone("r1", "n1", 1);
+    if (out.kind !== "refused") throw new Error("expected a refusal");
+    expect(out.slug).toBeNull();
+    expect(out.message).toBe("nope");
+  });
+
+  it("leaves `recoverable` null when the daemon sent no flag", async () => {
+    stubFetchWith(409, { error: "missing_outputs", missing: [] });
+    const out = await markNodeDone("r1", "n1", 1);
+    if (out.kind !== "refused") throw new Error("expected a refusal");
+    expect(out.recoverable).toBeNull();
+  });
+
+  it("throws on a 410, a 404 and a 5xx — those are breakdowns, not verdicts", async () => {
+    for (const status of [404, 410, 500]) {
+      stubFetchWith(status, { error: "boom" });
+      await expect(markNodeDone("r1", "n1", 1)).rejects.toBeInstanceOf(ApiError);
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("never renders a 2xx that still carries a `status` key as a completion", async () => {
+    // An older daemon answering a refusal with a success status. Reading that as
+    // "completed" IS the bug.
+    stubFetchWith(200, { status: "script_validation_failed" });
+    const out = await markNodeDone("r1", "n1", 1);
+    expect(out.kind).toBe("refused");
+  });
+
+  it("posts the mark_node_done command with node_id and iter", async () => {
+    const fetchMock = captureFetch(200, { ok: true });
+    await markNodeDone("r1", "n1", 3);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toContain("/runs/r1/commands");
+    expect(JSON.parse(init?.body as string)).toEqual({
+      kind: "mark_node_done",
+      node_id: "n1",
+      iter: 3,
+    });
   });
 });

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,4 +1,4 @@
-import type { PipelineListEntry, PipelineDetail, PipelineDef, RunListEntry, RunState, PortDef, PortSide, PortType, FrontmatterFieldDecl, Trigger, TriggerFire, DaemonStatus, InstanceSettings, UpdateSettingsRequest, StatsOverview, StatsCost, SandboxProfile, SandboxProfileImage, SandboxProfileReferents, SyncCostPricesReport } from "./types";
+import type { PipelineListEntry, PipelineDetail, PipelineDef, RunListEntry, RunState, PortDef, PortSide, PortType, FrontmatterFieldDecl, FrontmatterViolation, Trigger, TriggerFire, DaemonStatus, InstanceSettings, UpdateSettingsRequest, StatsOverview, StatsCost, SandboxProfile, SandboxProfileImage, SandboxProfileReferents, SyncCostPricesReport } from "./types";
 
 const BASE = "";
 
@@ -281,34 +281,136 @@ export function fetchRunEvents(runId: string): Promise<unknown[]> {
   return request<unknown[]>("GET", `/runs/${encodeURIComponent(runId)}/events`);
 }
 
-export interface MissingOutputsError {
-  kind: "missing_outputs";
-  missing: string[];
+/** Refusal slugs this client knows how to phrase (#490, ADR-0035 §3). */
+export type MarkNodeDoneRefusal =
+  | "missing_outputs"
+  | "frontmatter_retry_pending"
+  | "frontmatter_retry_exhausted"
+  | "script_validation_failed"
+  | "doc_violated_code_immutability"
+  | "merge_conflict"
+  | "merge_resolution_failed"
+  | "completion_rejected";
+
+const KNOWN_REFUSALS: readonly string[] = [
+  "missing_outputs",
+  "frontmatter_retry_pending",
+  "frontmatter_retry_exhausted",
+  "script_validation_failed",
+  "doc_violated_code_immutability",
+  "merge_conflict",
+  "merge_resolution_failed",
+  "completion_rejected",
+];
+
+/**
+ * What one *Mark complete* click actually did (#490, ADR-0035).
+ *
+ * A discriminated union on the refusal **slug**, never on the status: a status has
+ * nowhere near enough bits for nine causes, and the pre-#490 code — which read
+ * *every* `409` as `missing_outputs` — is the demonstration. The transition guard's
+ * `409` ("resume the run first") arrived with an empty `missing` list and the banner
+ * was gated on `length > 0`, so the most frequent refusal of all displayed nothing.
+ *
+ * A refusal is a **verdict, not an exception** (same contract as `fireTrigger`): it
+ * resolves. Only a breakdown of the call itself throws.
+ */
+export type MarkNodeDoneOutcome =
+  | { kind: "completed" }
+  | { kind: "noop"; reason: string }
+  | {
+      kind: "refused";
+      /** `null` = a slug this client does not know: render `message` as-is (ADR-0001). */
+      slug: MarkNodeDoneRefusal | null;
+      /** `null` = the daemon sent no `recoverable` flag; do not guess. */
+      recoverable: boolean | null;
+      message: string;
+      missing: string[];
+      violations: FrontmatterViolation[];
+      body: unknown;
+    };
+
+function asStringArray(v: unknown): string[] {
+  return Array.isArray(v) ? v.filter((x): x is string => typeof x === "string") : [];
 }
 
-export interface MarkNodeDoneResult {
-  ok: boolean;
-  missingOutputs?: MissingOutputsError;
+function asViolations(v: unknown): FrontmatterViolation[] {
+  if (!Array.isArray(v)) return [];
+  return v.flatMap((raw) => {
+    const o = raw as { port?: unknown; field?: unknown; reason?: unknown } | null;
+    if (typeof o?.port !== "string" || typeof o?.field !== "string") return [];
+    return [{ port: o.port, field: o.field, reason: String(o.reason ?? "") }];
+  });
 }
 
 export async function markNodeDone(
   runId: string,
   nodeId: string,
   iter: number,
-): Promise<MarkNodeDoneResult> {
-  // Status-inspecting: a 409 is not an error but a "missing outputs" verdict, so
-  // raw mode keeps the bespoke branch (incl. the deliberately UNGUARDED 409 json).
+): Promise<MarkNodeDoneOutcome> {
+  // Status-inspecting: a 409 is a refusal verdict, not a failed call, so raw mode
+  // keeps the bespoke branch.
   const resp = await request<Response>(
     "POST",
     `/runs/${encodeURIComponent(runId)}/commands`,
     { body: { kind: "mark_node_done", node_id: nodeId, iter }, responseMode: "raw" },
   );
+  // GUARDED: the success body of the sibling `POST …/done` route is the bare text
+  // `ok`, and the pre-#490 code threw a naked `SyntaxError` on any non-JSON body —
+  // breaking this module's "one error type" contract.
+  const body: unknown = await resp.json().catch(() => null);
+
+  // 409 and 409 alone is the refusal status. A 410 (forgotten run), a 404 or a 5xx
+  // are a breakdown of the call, so they stay an ApiError.
   if (resp.status === 409) {
-    const body = await resp.json();
-    return { ok: false, missingOutputs: { kind: "missing_outputs", missing: body.missing ?? [] } };
+    const b = body as
+      | { error?: unknown; recoverable?: unknown; missing?: unknown; violations?: unknown; detail?: unknown }
+      | null;
+    const slug = typeof b?.error === "string" ? b.error : null;
+    const detail = b?.detail as { missing?: unknown; violations?: unknown } | undefined;
+    return {
+      kind: "refused",
+      slug: slug !== null && KNOWN_REFUSALS.includes(slug) ? (slug as MarkNodeDoneRefusal) : null,
+      recoverable: typeof b?.recoverable === "boolean" ? b.recoverable : null,
+      // Reuses the module's single message assembler (`body.message ?? body.error ??
+      // fallback`), which is where the guard's prose now lands.
+      message: apiErrorMessage(body, `mark_node_done refused: ${resp.status}`),
+      // Reads both shapes of the evidence — flat, and the `script` fail-fast's
+      // nested `detail` (ADR-0035 §5).
+      missing: asStringArray(b?.missing ?? detail?.missing),
+      violations: asViolations(b?.violations ?? detail?.violations),
+      body,
+    };
   }
-  if (!resp.ok) throw new ApiError(`mark_node_done failed: ${resp.status}`, { status: resp.status });
-  return { ok: true };
+
+  if (!resp.ok) {
+    throw new ApiError(apiErrorMessage(body, `mark_node_done failed: ${resp.status}`), {
+      status: resp.status,
+      body,
+    });
+  }
+
+  const ok = body as { noop?: unknown; reason?: unknown; status?: unknown } | null;
+  if (ok?.noop === true) {
+    return {
+      kind: "noop",
+      reason: typeof ok.reason === "string" ? ok.reason : "the node iteration was already terminal",
+    };
+  }
+  // A `2xx` still carrying a `status` key is a pre-#490 daemon answering a refusal
+  // with a success status. Never render that as a completion — that is the whole bug.
+  if (typeof ok?.status === "string") {
+    return {
+      kind: "refused",
+      slug: KNOWN_REFUSALS.includes(ok.status) ? (ok.status as MarkNodeDoneRefusal) : null,
+      recoverable: null,
+      message: ok.status,
+      missing: [],
+      violations: [],
+      body,
+    };
+  }
+  return { kind: "completed" };
 }
 
 export function attachSession(sessionId: string): Promise<void> {

--- a/frontend/src/components/NodeDetailPanel.test.tsx
+++ b/frontend/src/components/NodeDetailPanel.test.tsx
@@ -25,11 +25,15 @@ const stopNodeMock = vi.fn().mockResolvedValue(undefined);
 const startNodeMock = vi.fn().mockResolvedValue({ ok: true, iter: 1 });
 const retryNodeMock = vi.fn().mockResolvedValue({ ok: true, iter: 2, invalidated: [] });
 const retryNodePreviewMock = vi.fn().mockResolvedValue({ downstream: [], affected_count: 0, with_artifacts: [] });
+// #490: was `markNodeDone: vi.fn()` inline, which resolves `undefined` — so NO test
+// had ever exercised a *Mark complete* click. Made controllable so the verdict
+// branches can be driven. Vitest compares arity strictly, hence the spread.
+const markNodeDoneMock = vi.fn().mockResolvedValue({ kind: "completed" });
 
 vi.mock("../api", () => ({
   fetchPrompt: (...args: unknown[]) => fetchPromptMock(...args),
   fetchNodeIO: (...args: unknown[]) => fetchNodeIOMock(...args),
-  markNodeDone: vi.fn(),
+  markNodeDone: (...args: unknown[]) => markNodeDoneMock(...args),
   killNode: (...args: unknown[]) => killNodeMock(...args),
   restartNode: (...args: unknown[]) => restartNodeMock(...args),
   stopNode: (...args: unknown[]) => stopNodeMock(...args),
@@ -109,6 +113,8 @@ describe("NodeDetailPanel", () => {
     retryNodeMock.mockClear();
     retryNodePreviewMock.mockClear();
     retryNodePreviewMock.mockResolvedValue({ downstream: [], affected_count: 0, with_artifacts: [] });
+    markNodeDoneMock.mockClear();
+    markNodeDoneMock.mockResolvedValue({ kind: "completed" });
     tmuxMountCount.current = 0;
     tmuxUnmountCount.current = 0;
   });
@@ -355,7 +361,7 @@ describe("NodeDetailPanel", () => {
       ).not.toBeInTheDocument();
     });
 
-    it("shows exhausted banner when failed with output validation reason", () => {
+    it("shows the output-validation banner when failed with an output validation reason", () => {
       render(
         <TooltipProvider>
           <NodeDetailPanel
@@ -368,11 +374,53 @@ describe("NodeDetailPanel", () => {
         </TooltipProvider>,
       );
       expect(
-        screen.getByTestId("frontmatter-exhausted-banner"),
+        screen.getByTestId("output-validation-banner"),
       ).toBeInTheDocument();
+      // #490: the reason VERBATIM. The old hard-coded "after retry" title lied for
+      // the `script` fail-fast path, which never retries.
       expect(
-        screen.getByTestId("frontmatter-exhausted-banner"),
-      ).toHaveTextContent("output validation failed after retry");
+        screen.getByTestId("output-validation-banner"),
+      ).toHaveTextContent("Failed — output validation failed");
+    });
+
+    it("titles the banner with the script fail-fast reason, not \"after retry\"", () => {
+      render(
+        <TooltipProvider>
+          <NodeDetailPanel
+            node={makeNode({
+              status: "failed",
+              failure_reason: "script output validation failed",
+            })}
+            runId="run-1"
+          />
+        </TooltipProvider>,
+      );
+      const banner = screen.getByTestId("output-validation-banner");
+      expect(banner).toHaveTextContent("Failed — script output validation failed");
+      expect(banner).not.toHaveTextContent("after retry");
+      // `includes`, not `startsWith`: the script reason does not start with the
+      // after-retry one, so the generic banner must NOT also fire.
+      expect(screen.queryByText(/^Failed — script output validation failed$/)).toBeTruthy();
+    });
+
+    it("lists the missing output ports of a script fail-fast", () => {
+      render(
+        <TooltipProvider>
+          <NodeDetailPanel
+            node={makeNode({
+              status: "failed",
+              failure_reason: "script output validation failed",
+              missing_outputs: ["out"],
+            })}
+            runId="run-1"
+          />
+        </TooltipProvider>,
+      );
+      // Before #490 this list had no home at all in Rust OR TS, so the red banner
+      // showed with nothing in it.
+      expect(screen.getByTestId("missing-output-list")).toHaveTextContent(
+        "Missing outputs: out",
+      );
     });
 
     it("shows offending fields in exhausted banner when violations present", () => {
@@ -428,7 +476,7 @@ describe("NodeDetailPanel", () => {
         </TooltipProvider>,
       );
       expect(
-        screen.queryByTestId("frontmatter-exhausted-banner"),
+        screen.queryByTestId("output-validation-banner"),
       ).not.toBeInTheDocument();
       expect(screen.getAllByText(/some other error/).length).toBeGreaterThan(0);
     });
@@ -905,7 +953,7 @@ describe("NodeDetailPanel", () => {
       );
 
       const staleBanner = staleContainer.querySelector('[data-testid="stale-banner"]');
-      const failedBanner = failedContainer.querySelector('[data-testid="frontmatter-exhausted-banner"]')
+      const failedBanner = failedContainer.querySelector('[data-testid="output-validation-banner"]')
         ?? failedContainer.querySelector('.border-st-failed\\/30');
 
       expect(staleBanner).toBeInTheDocument();
@@ -1246,6 +1294,205 @@ describe("NodeDetailPanel", () => {
 
       expect(screen.queryByTestId("retry-confirm-backdrop")).not.toBeInTheDocument();
       expect(retryNodeMock).not.toHaveBeenCalled();
+    });
+  });
+
+  // #490 / ADR-0035 — the refusal of a *Mark complete* click must be visible AT the
+  // gesture, and must never blink out. Before this issue `markNodeDone` was mocked
+  // as a bare `vi.fn()` resolving `undefined`, so not one of these paths had ever
+  // been exercised.
+  describe("Mark complete verdict (#490)", () => {
+    const awaitingNode = () => makeNode({ status: "awaiting_user" });
+
+    async function clickMarkComplete() {
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("mark-complete-btn"));
+      });
+    }
+
+    it("gives the button a testid so a driver need not match the copy", () => {
+      render(
+        <TooltipProvider>
+          <NodeDetailPanel node={awaitingNode()} runId="run-1" />
+        </TooltipProvider>,
+      );
+      expect(screen.getByTestId("mark-complete-btn")).toBeInTheDocument();
+    });
+
+    it("shows a recoverable refusal as still-your-turn, with the missing ports", async () => {
+      markNodeDoneMock.mockResolvedValue({
+        kind: "refused",
+        slug: "missing_outputs",
+        recoverable: true,
+        message: "outputs are incomplete",
+        missing: ["review"],
+        violations: [],
+        body: {},
+      });
+      render(
+        <TooltipProvider>
+          <NodeDetailPanel node={awaitingNode()} runId="run-1" />
+        </TooltipProvider>,
+      );
+      await clickMarkComplete();
+      const verdict = screen.getByTestId("mark-complete-verdict");
+      expect(verdict).toHaveAttribute("data-verdict", "refused");
+      expect(verdict).toHaveAttribute("data-slug", "missing_outputs");
+      expect(verdict).toHaveAttribute("data-recoverable", "true");
+      // The prefix is load-bearing: the gating e2e spec matches /^Missing outputs:/.
+      expect(screen.getByTestId("verdict-missing-list")).toHaveTextContent(
+        "Missing outputs: review",
+      );
+      expect(verdict).toHaveTextContent("still your turn");
+    });
+
+    it("shows a terminal refusal as the-node-is-now-failed", async () => {
+      markNodeDoneMock.mockResolvedValue({
+        kind: "refused",
+        slug: "frontmatter_retry_exhausted",
+        recoverable: false,
+        message: "still did not match after the retry",
+        missing: [],
+        violations: [{ port: "review", field: "verdict", reason: "not in enum" }],
+        body: {},
+      });
+      render(
+        <TooltipProvider>
+          <NodeDetailPanel node={awaitingNode()} runId="run-1" />
+        </TooltipProvider>,
+      );
+      await clickMarkComplete();
+      const verdict = screen.getByTestId("mark-complete-verdict");
+      expect(verdict).toHaveAttribute("data-recoverable", "false");
+      expect(verdict).toHaveTextContent("now failed");
+      expect(screen.getByTestId("verdict-violation-list")).toHaveTextContent(
+        "review.verdict",
+      );
+    });
+
+    it("shows the transition guard's refusal, which used to display nothing at all", async () => {
+      markNodeDoneMock.mockResolvedValue({
+        kind: "refused",
+        slug: "completion_rejected",
+        recoverable: false,
+        message: "run run-1 is Failed: resume the run first",
+        missing: [],
+        violations: [],
+        body: {},
+      });
+      render(
+        <TooltipProvider>
+          <NodeDetailPanel node={makeNode({ status: "failed", failure_reason: "boom" })} runId="run-1" />
+        </TooltipProvider>,
+      );
+      await clickMarkComplete();
+      // Pre-#490: read as `missing_outputs` with an empty list, gated on
+      // `length > 0`, therefore invisible. This is THE symptom of the issue.
+      expect(screen.getByTestId("mark-complete-verdict")).toHaveTextContent(
+        "resume the run first",
+      );
+    });
+
+    it("does not blink the verdict out between two consecutive clicks", async () => {
+      markNodeDoneMock.mockResolvedValue({
+        kind: "refused",
+        slug: "missing_outputs",
+        recoverable: true,
+        message: "outputs are incomplete",
+        missing: ["review"],
+        violations: [],
+        body: {},
+      });
+      render(
+        <TooltipProvider>
+          <NodeDetailPanel node={awaitingNode()} runId="run-1" />
+        </TooltipProvider>,
+      );
+      await clickMarkComplete();
+      expect(screen.getByTestId("mark-complete-verdict")).toBeInTheDocument();
+
+      // The second click is the one that matters: the first has nothing to erase.
+      // The handler no longer clears before awaiting, so the region always has a
+      // tenant — `pending` occupies it and each outcome overwrites it.
+      let seenEmpty = false;
+      markNodeDoneMock.mockImplementation(async () => {
+        seenEmpty = seenEmpty || screen.queryByTestId("mark-complete-verdict") === null;
+        return {
+          kind: "refused",
+          slug: "missing_outputs",
+          recoverable: true,
+          message: "outputs are incomplete",
+          missing: ["review"],
+          violations: [],
+          body: {},
+        };
+      });
+      await clickMarkComplete();
+      expect(seenEmpty).toBe(false);
+      expect(screen.getByTestId("mark-complete-verdict")).toBeInTheDocument();
+    });
+
+    it("treats a legal duplicate as nothing alarming", async () => {
+      markNodeDoneMock.mockResolvedValue({ kind: "noop", reason: "already completed" });
+      render(
+        <TooltipProvider>
+          <NodeDetailPanel node={awaitingNode()} runId="run-1" />
+        </TooltipProvider>,
+      );
+      await clickMarkComplete();
+      const verdict = screen.getByTestId("mark-complete-verdict");
+      expect(verdict).toHaveAttribute("data-verdict", "noop");
+      expect(verdict).toHaveAttribute("data-recoverable", "");
+    });
+
+    it("surfaces a transport breakdown instead of swallowing it into console.error", async () => {
+      markNodeDoneMock.mockRejectedValue(new Error("Failed to fetch"));
+      render(
+        <TooltipProvider>
+          <NodeDetailPanel node={awaitingNode()} runId="run-1" />
+        </TooltipProvider>,
+      );
+      await clickMarkComplete();
+      const verdict = screen.getByTestId("mark-complete-verdict");
+      expect(verdict).toHaveAttribute("data-verdict", "error");
+      expect(verdict).toHaveTextContent("Failed to fetch");
+    });
+
+    it("scopes the verdict to the iteration it was produced for", async () => {
+      markNodeDoneMock.mockResolvedValue({
+        kind: "refused",
+        slug: "missing_outputs",
+        recoverable: true,
+        message: "outputs are incomplete",
+        missing: ["review"],
+        violations: [],
+        body: {},
+      });
+      render(
+        <TooltipProvider>
+          <NodeDetailPanel
+            node={makeNode({
+              status: "awaiting_user",
+              iter: 2,
+              iterations: [
+                { iter: 1, status: "completed", started_at: null, completed_at: null },
+                { iter: 2, status: "awaiting_user", started_at: null, completed_at: null },
+              ],
+            })}
+            runId="run-1"
+          />
+        </TooltipProvider>,
+      );
+      await clickMarkComplete();
+      expect(screen.getByTestId("mark-complete-verdict")).toBeInTheDocument();
+
+      // Switching iteration must not carry a verdict that belongs to another one.
+      fireEvent.click(screen.getByText(/iter 2/));
+      const option = await screen.findByTestId("iter-option-1");
+      await act(async () => {
+        fireEvent.click(option);
+      });
+      expect(screen.queryByTestId("mark-complete-verdict")).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/components/NodeDetailPanel.tsx
+++ b/frontend/src/components/NodeDetailPanel.tsx
@@ -22,7 +22,7 @@ import {
   fetchNodeIO,
   artifactUrl,
 } from "../api";
-import type { PortIO, FileInfo, MarkNodeDoneResult } from "../api";
+import type { PortIO, FileInfo, MarkNodeDoneOutcome } from "../api";
 import type { PortType } from "../types";
 import {
   ResizablePanelGroup,
@@ -81,6 +81,137 @@ interface Props {
 // `{minimized + expanded}` state unrepresentable.
 type TerminalView = "minimized" | "split" | "expanded";
 
+/**
+ * What the last *Mark complete* click produced (#490, ADR-0035).
+ *
+ * `pending` exists so the verdict region always has a tenant: the handler no longer
+ * clears before awaiting, so there is no window in which a previous verdict has been
+ * erased and no new one written. `error` is the transport breakdown, which the
+ * pre-#490 code swallowed into `console.error` and rendered as nothing.
+ */
+type MarkVerdict =
+  | { kind: "pending" }
+  | MarkNodeDoneOutcome
+  | { kind: "error"; message: string };
+
+/**
+ * Three tones, because the three answers demand three different reactions:
+ * `await` = it is still your turn, `failed` = the node is failed *now*,
+ * `stopped` = refused with no state change, or indeterminable.
+ */
+function verdictTone(v: MarkVerdict): "await" | "failed" | "stopped" | "done" {
+  switch (v.kind) {
+    case "completed":
+      return "done";
+    case "noop":
+      return "stopped";
+    case "pending":
+      return "stopped";
+    case "error":
+      return "failed";
+    case "refused":
+      if (v.recoverable === true) return "await";
+      if (v.recoverable === false) return "failed";
+      return "stopped";
+  }
+}
+
+function verdictHeadline(v: MarkVerdict): string {
+  switch (v.kind) {
+    case "pending":
+      return "Marking complete…";
+    case "completed":
+      return "Marked complete.";
+    case "noop":
+      return `Already complete — nothing to do (${v.reason})`;
+    case "error":
+      return `Could not reach the daemon — ${v.message}`;
+    case "refused":
+      if (v.recoverable === true) return `Refused, still your turn — ${v.message}`;
+      if (v.recoverable === false) return `Refused, the node is now failed — ${v.message}`;
+      return `Refused — ${v.message}`;
+  }
+}
+
+/**
+ * Does this node's failure come from output validation? (#490)
+ *
+ * `includes`, **not** an equality or a `startsWith`: the two reasons are
+ * `"output validation failed"` (after retry) and `"script output validation failed"`
+ * (the `script` fail-fast), and the second neither equals nor starts with the first.
+ * Both banner gates use this one predicate, inverted — two separate tests would let
+ * both fire, or neither.
+ */
+function isOutputValidationFailure(node: NodeState): boolean {
+  return node.failure_reason?.includes("output validation failed") ?? false;
+}
+
+/**
+ * The verdict of a *Mark complete* click, rendered at the gesture (#490).
+ *
+ * `data-*` attributes rather than copy are the assertion surface: a level-5 driver
+ * asserts `data-recoverable="true"` for "still your turn" and `"false"` for "the node
+ * is failed now", so the journey survives a rewording.
+ */
+function MarkCompleteVerdict({ verdict }: { verdict: MarkVerdict }) {
+  const tone = verdictTone(verdict);
+  const toneClass = {
+    done: "border-st-done/30 bg-st-done-bg text-st-done",
+    await: "border-st-await/30 bg-st-await-bg text-st-await",
+    failed: "border-st-failed/30 bg-st-failed-bg text-st-failed",
+    stopped: "border-line-strong bg-bg-3 text-fg-3",
+  }[tone];
+  const refused = verdict.kind === "refused" ? verdict : null;
+
+  return (
+    <div
+      className={`flex flex-col gap-1 rounded-md border px-2.5 py-1.5 ${toneClass}`}
+      style={{ fontSize: "10.5px" }}
+      data-testid="mark-complete-verdict"
+      data-verdict={verdict.kind}
+      data-slug={refused?.slug ?? ""}
+      data-recoverable={refused ? String(refused.recoverable) : ""}
+    >
+      <div className="flex items-start gap-1.5">
+        {tone === "done" ? (
+          <CheckCircle size={12} className="mt-px shrink-0" />
+        ) : (
+          <AlertCircle size={12} className="mt-px shrink-0" />
+        )}
+        <span>{verdictHeadline(verdict)}</span>
+      </div>
+      {refused && refused.missing.length > 0 && (
+        <ul
+          className="flex flex-col gap-0.5 pl-5 font-mono"
+          data-testid="verdict-missing-list"
+        >
+          {/* The `Missing outputs:` prefix is load-bearing — the gating e2e spec
+              matches `/^Missing outputs:/`. */}
+          <li>Missing outputs: {refused.missing.join(", ")}</li>
+        </ul>
+      )}
+      {refused && refused.violations.length > 0 && (
+        <ul
+          className="flex flex-col gap-0.5 pl-5 font-mono"
+          data-testid="verdict-violation-list"
+        >
+          {refused.violations.map((v, i) => (
+            <li key={i}>
+              {v.port}.{v.field}: {v.reason}
+            </li>
+          ))}
+        </ul>
+      )}
+      {refused?.recoverable === true && (
+        <span className="pl-5">Fix the above, then click Mark complete again.</span>
+      )}
+      {refused?.recoverable === false && (
+        <span className="pl-5">Resume the run to try again.</span>
+      )}
+    </div>
+  );
+}
+
 // The session is settled — the tmux session is gone, so the terminal WebSocket
 // would attach to a dead session. `{completed, failed, stopped}` is exactly the
 // "settled" tier of `pollInterval` (5s). `stale` is EXCLUDED unless archived:
@@ -113,7 +244,17 @@ export default function NodeDetailPanel({
   const [inputs, setInputs] = useState<PortIO[]>([]);
   const [outputs, setOutputs] = useState<PortIO[]>([]);
   const [modal, setModal] = useState<ModalState | null>(null);
-  const [missingOutputs, setMissingOutputs] = useState<string[] | null>(null);
+  // #490: a VERDICT object, not `string[] | null`. The old shape was
+  // *structurally incapable* of expressing "refused for a reason that has no port
+  // list" — which is the bug: the transition guard's refusal ("resume the run
+  // first") arrived with an empty list and the banner was gated on `length > 0`, so
+  // the most frequent refusal of all rendered nothing.
+  //
+  // Scoped by `iter` on the `userSelectedIter` idiom of this file, which also kills
+  // a latent second bug: a verdict from iter 3 surviving a switch back to iter 1.
+  const [markVerdict, setMarkVerdict] = useState<
+    ({ iter: number } & MarkVerdict) | null
+  >(null);
   // Seed at mount only (no reactive effect on status): the issue trigger is
   // "clicking the node" (= selection / mount), not a live transition. A node
   // is `key`-ed by node_id at both mount sites, so selecting another terminated
@@ -262,14 +403,23 @@ export default function NodeDetailPanel({
   }, [runId, node.node_id]);
 
   const handleMarkComplete = useCallback(async () => {
-    setMissingOutputs(null);
+    // #490: NO `setMarkVerdict(null)` preamble. Clearing before awaiting is what
+    // made the banner flicker — on a lying `200` nothing was written back, so a
+    // verdict from a previous click vanished and never returned. The region always
+    // has a tenant: `pending` occupies it, and every exit writes a verdict.
+    const iter = selectedIter;
+    setMarkVerdict({ iter, kind: "pending" });
     try {
-      const result: MarkNodeDoneResult = await markNodeDone(runId, node.node_id, selectedIter);
-      if (!result.ok && result.missingOutputs) {
-        setMissingOutputs(result.missingOutputs.missing);
-      }
+      const outcome: MarkNodeDoneOutcome = await markNodeDone(runId, node.node_id, iter);
+      setMarkVerdict({ iter, ...outcome });
     } catch (e) {
-      console.error("Failed to mark node done:", e);
+      // No longer swallowed into `console.error`: a POST that never lands must not
+      // look like a success.
+      setMarkVerdict({
+        iter,
+        kind: "error",
+        message: e instanceof Error ? e.message : String(e),
+      });
     }
   }, [runId, node.node_id, selectedIter]);
 
@@ -441,11 +591,11 @@ export default function NodeDetailPanel({
         </div>
       )}
 
-      {/* Failed banner — validation exhausted variant */}
-      {node.status === "failed" && node.failure_reason === "output validation failed" && (
+      {/* Failed banner — output-validation variant (#490) */}
+      {node.status === "failed" && isOutputValidationFailure(node) && (
         <div
           className="flex flex-col gap-1 border-b border-st-failed/30 bg-st-failed-bg px-3 py-2"
-          data-testid="frontmatter-exhausted-banner"
+          data-testid="output-validation-banner"
         >
           <div className="flex items-center gap-2">
             <AlertCircle size={14} className="shrink-0 text-st-failed" />
@@ -453,7 +603,12 @@ export default function NodeDetailPanel({
               className="text-st-failed"
               style={{ fontSize: "11.5px", fontWeight: 500 }}
             >
-              Failed — output validation failed after retry
+              {/* #490: the reason VERBATIM, not a hard-coded "after retry" — which
+                  lied for the `script` fail-fast path, a path that never retries.
+                  It also makes the landing order safe: if the status arrives before
+                  the evidence, we show the right reason with no list, which is
+                  informationally equal to the pre-#490 behaviour. */}
+              Failed — {node.failure_reason}
             </span>
           </div>
           {node.frontmatter_violations && node.frontmatter_violations.length > 0 && (
@@ -469,11 +624,26 @@ export default function NodeDetailPanel({
               ))}
             </ul>
           )}
+          {/* #490: a `script` node failing on a MISSING output used to paint this
+              banner with an empty list — the daemon computed the evidence and the
+              projector threw it away. */}
+          {node.missing_outputs && node.missing_outputs.length > 0 && (
+            <ul
+              className="mt-0.5 flex flex-col gap-0.5 pl-5 font-mono text-st-failed"
+              style={{ fontSize: "10px" }}
+              data-testid="missing-output-list"
+            >
+              {node.missing_outputs.map((m) => (
+                <li key={m}>Missing outputs: {m}</li>
+              ))}
+            </ul>
+          )}
         </div>
       )}
 
-      {/* Failed banner — generic */}
-      {node.status === "failed" && node.failure_reason !== "output validation failed" && (
+      {/* Failed banner — generic. Same predicate, inverted: two different tests here
+          would let both banners fire (or neither). */}
+      {node.status === "failed" && !isOutputValidationFailure(node) && (
         <div className="flex items-center gap-2 border-b border-st-failed/30 bg-st-failed-bg px-3 py-2">
           <AlertCircle size={14} className="shrink-0 text-st-failed" />
           <span
@@ -530,6 +700,7 @@ export default function NodeDetailPanel({
                 <>
                   <button
                     onClick={handleMarkComplete}
+                    data-testid="mark-complete-btn"
                     className="flex w-full cursor-pointer items-center justify-center gap-1.5 rounded-md border border-st-done/40 bg-st-done-bg px-3 py-1.5 text-st-done transition-colors hover:border-st-done/60 hover:bg-st-done/20"
                     style={{ fontSize: "11.5px", fontWeight: 500 }}
                   >
@@ -537,16 +708,11 @@ export default function NodeDetailPanel({
                     Mark complete
                   </button>
 
-                  {missingOutputs && missingOutputs.length > 0 && (
-                    <div
-                      className="flex items-start gap-1.5 rounded-md border border-st-failed/30 bg-st-failed-bg px-2.5 py-1.5 font-mono text-st-failed"
-                      style={{ fontSize: "10.5px" }}
-                    >
-                      <AlertCircle size={12} className="mt-px shrink-0" />
-                      <span>
-                        Missing outputs: {missingOutputs.join(", ")}
-                      </span>
-                    </div>
+                  {/* #490: the verdict of the click, AT the gesture. Rendered for
+                      every outcome including `pending`, so nothing ever blinks out
+                      without a replacement. */}
+                  {markVerdict && markVerdict.iter === selectedIter && (
+                    <MarkCompleteVerdict verdict={markVerdict} />
                   )}
                 </>
               )}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -449,6 +449,17 @@ export interface IterationInfo {
   completed_at: string | null;
 }
 
+/**
+ * One frontmatter field the validator rejected. Named since #490 because the shape
+ * now travels on two paths: the projection (`NodeState`) *and* the refusal body of
+ * `mark_node_done`.
+ */
+export interface FrontmatterViolation {
+  port: string;
+  field: string;
+  reason: string;
+}
+
 export interface NodeState {
   node_id: string;
   status: NodeStatus;
@@ -458,7 +469,13 @@ export interface NodeState {
   failure_reason: string | null;
   iterations: IterationInfo[];
   frontmatter_retries?: number;
-  frontmatter_violations?: Array<{ port: string; field: string; reason: string }>;
+  frontmatter_violations?: FrontmatterViolation[];
+  /**
+   * #490: declared output ports the validator found empty. Optional because the
+   * daemon omits it when empty (`skip_serializing_if`) — and because a synthetic
+   * `NodeState` literal in `App.tsx` would otherwise stop compiling.
+   */
+  missing_outputs?: string[];
 }
 
 export interface EdgeInfo {


### PR DESCRIPTION
Le chemin par lequel **tout** node se termine — `pdo complete` côté agent, *Mark complete* côté UI —
répondait `200` sur **huit** corps qui décrivaient un refus, dont quatre après avoir déjà appendé
`RunFailed`. Un agent lisait « marked complete. », sortait en `0`, et croyait avoir livré un Run que le
daemon venait de tuer.

L'invariant est désormais porté par le type : `CompletionRefusal` ne porte aucun statut,
`refusal_response` en est la seule projection, et `a_refusal_never_projects_to_a_2xx` le prouve variante
par variante derrière un `match` sans joker. Voir **ADR-0035**.

## Validation (niveau 5, verdict Pass)

Les huit lignes de l'oracle sont **mesurées** sur le vrai binaire, en vrais panes tmux :

| Cas | Filaire | `$?` |
|---|---|---|
| succès / doublon légal | `200` (no-op **byte-pour-byte** identique à avant) | `0` |
| `missing_outputs`, `frontmatter_retry_pending` | `409` `recoverable:true` | `3` |
| `frontmatter_retry_exhausted`, `script_validation_failed`, `doc_violated_code_immutability`, garde Run `Failed` | `409` `recoverable:false` | `4` |
| daemon injoignable | — | `1` |

Le **contrôle négatif** (témoin 1.4.1, mêmes gestes) rend `200` + « marked complete. » + `EXIT=0`
deux fois, dont la fois qui appendait `NodeFailed` + `RunFailed` : le bug du ticket reproduit, donc le
harnais mesure bien la bonne chose. La non-régression du clignotement de bannière est mesurée par
`MutationObserver` sur trois clics consécutifs (zéro transition `présent → absent`), pas déduite d'une
capture.

Sept findings, **aucun bloquant** : cinq préexistants (prouvés tels par diff ou lecture de code), deux
portant sur la recette de test.

## Gates

`cargo fmt` · `cargo clippy --workspace --all-targets -D warnings` (0 diagnostic, re-lint forcé pour
écarter un no-op de cache) · `cargo test --workspace` (**47 suites, 1 986 tests, 0 échec**) ·
`tsc -b` · `eslint .` · `vitest` (**101 fichiers, 1 523 tests, 0 échec**) · `cargo build --release`
zéro warning, `pdo 1.6.0`.

`npx playwright test` **non joué**, délibérément : la suite fuit 18 worktrees + branches dans le `.git`
partagé (#483).

## Deux collisions avec `main`, résolues ici

Rebasé sur `f9f971e` (#427), qui a atterri pendant ce run :

- **Version** — #427 avait déjà pris `1.5.0`, et les deux côtés écrivant la même ligne, **git ne
  produit aucun conflit**. Ce lot part donc en **`1.6.0`** (mineur pour un cassant, comme 1.2.0 et
  1.3.0).
- **Numéro d'ADR** — les deux lots avaient écrit un `0034`. Noms de fichiers différents ⇒ collision
  **silencieuse** elle aussi. #427 ayant mergé le premier garde `0034` ; celui-ci devient
  **ADR-0035**, ses ~40 références réécrites.

Closes #490
