### PR TITLE
style(#338): cargo fmt --all — débloque le gate CI fmt (suivi #523)

### DIFF
--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -21533,13 +21533,19 @@ edges:
             .await
             .unwrap();
             let view = build_settings_view(&state).await.unwrap();
-            assert_eq!(view["default_auto_name"]["effective"], serde_json::json!(on));
+            assert_eq!(
+                view["default_auto_name"]["effective"],
+                serde_json::json!(on)
+            );
             assert_eq!(
                 view["default_auto_name"]["stored"],
                 serde_json::json!(on),
                 "the stored tier is disclosed as a bool, not as 0/1"
             );
-            assert_eq!(view["default_auto_name"]["source"], serde_json::json!("stored"));
+            assert_eq!(
+                view["default_auto_name"]["source"],
+                serde_json::json!("stored")
+            );
         }
     }
 
@@ -26682,7 +26688,10 @@ edges:
         // With auto-naming ON the pre-#338 behaviour holds, gated on input only.
         // No (meaningful) input → deterministic placeholder, renamed best-effort later.
         assert_eq!(run_name_hint(true, None, ""), RunNameHint::Placeholder);
-        assert_eq!(run_name_hint(true, None, "   \n\t "), RunNameHint::Placeholder);
+        assert_eq!(
+            run_name_hint(true, None, "   \n\t "),
+            RunNameHint::Placeholder
+        );
         assert_eq!(run_name_hint(true, Some(""), ""), RunNameHint::Placeholder);
         // Real input → manager derives the name from `_input` immediately.
         assert_eq!(

--- a/crates/pdo-daemon/src/trigger_store.rs
+++ b/crates/pdo-daemon/src/trigger_store.rs
@@ -1505,7 +1505,10 @@ mod tests {
                 .fetch_optional(&db)
                 .await
                 .unwrap();
-        assert!(before.is_none(), "precondition: legacy table lacks the column");
+        assert!(
+            before.is_none(),
+            "precondition: legacy table lacks the column"
+        );
 
         init(&db).await.unwrap();
         init(&db).await.unwrap(); // idempotent

--- a/crates/pdo-daemon/tests/run_naming.rs
+++ b/crates/pdo-daemon/tests/run_naming.rs
@@ -195,7 +195,11 @@ async fn put_settings(daemon: &TestDaemon, body: serde_json::Value) {
         .send()
         .await
         .unwrap();
-    assert_eq!(resp.status(), 200, "PUT /settings should succeed for {body}");
+    assert_eq!(
+        resp.status(),
+        200,
+        "PUT /settings should succeed for {body}"
+    );
 }
 
 /// #338: an explicit `auto_name:false` with a name keeps that name — the same as


### PR DESCRIPTION
La CI Rust de `main` est rouge depuis #523 : `cargo fmt --all --check` échoue sur du code #338 jamais formaté au rustfmt stable (recette de validation amont sans `cargo fmt --check`).

Branche basée directement sur `main` — diff = **reformatage pur** des 3 fichiers #338, rien d'autre. rustfmt **1.9.0-stable** (version CI). Aucun changement sémantique (`git diff -w` ne montre que des `assert!`/`assert_eq!` longs éclatés en multi-lignes).

Les étapes CI 1–3 sur `stable` (`cargo check`, `cargo test --workspace`, `cargo clippy -- -D warnings`) passaient déjà avant le step fmt. Pas de bump de version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)