### PR TITLE
fix(#509): un slot d'admission libéré est de nouveau redistribué — 1.16.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "1.15.0"
+version = "1.16.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "1.15.0"
+version = "1.16.0"
 license = "MIT"
 
 [workspace.dependencies]

--- a/crates/pdo-daemon/src/boot_recovery.rs
+++ b/crates/pdo-daemon/src/boot_recovery.rs
@@ -18,7 +18,10 @@
 //! linear sequence of guarded `append_event` calls and must never call the
 //! scheduler or re-enter itself. The shared `reconcile_run_level_stall` (used by
 //! both boot recovery and the stale sweep) stays in `lib.rs`; this module calls
-//! up into it.
+//! up into it. #509: it likewise calls up into `retry_waiting_nodes` **once,
+//! after the whole pass**, to redistribute the admission slots that failing
+//! orphaned `Running` nodes just freed (same "call up into `lib.rs`" pattern as
+//! `reconcile_run_level_stall`, never the scheduler directly).
 
 use tracing::{error, warn};
 
@@ -26,7 +29,7 @@ use crate::worktree_ops::sub_worktree_branch;
 use crate::{admission, event_log, tmux_session_manager};
 use crate::{
     append_event, effective_repo_root, find_node_type, load_all_run_ids, load_events,
-    reconcile_run_level_stall, AppState,
+    reconcile_run_level_stall, retry_waiting_nodes, AppState,
 };
 
 /// Reconcile persisted run state against the live process world at daemon boot.
@@ -249,6 +252,22 @@ pub(crate) async fn run_boot_recovery(state: &AppState) {
         // sees any orphan failure appended in (1).
         reconcile_run_level_stall(state, run_id).await;
     }
+
+    // (4) #509: failing an orphaned `Running` node in (1) frees its admission
+    // slot — a `Failed` node no longer counts in
+    // `admission::count_live_node_sessions`. `reconcile_run_level_stall` above
+    // already re-drives the throttled queue, but ONLY for a Run it reconciles
+    // terminal; a Run whose orphan died while a SIBLING node is still `Running`
+    // never stalls at the run level (`run_stall_reason` returns `None` while any
+    // node is live), so its freed slot was never redistributed. The queued nodes
+    // of OTHER runs would then starve indefinitely across the restart, invisible
+    // to both `run_stall_reason` (the live sibling suppresses it) and
+    // `stale_detector` (it inspects `Running` nodes only). `retry_waiting_nodes`
+    // has no timer of its own — all its callers are event-driven (#159) — so this
+    // one restart-time sweep is what closes the gap. It is a global, idempotent
+    // admission pass (guard-superfluous dedup); running it once after the whole
+    // recovery loop redistributes every slot freed above.
+    retry_waiting_nodes(state).await;
 }
 
 /// Detect sub-worktree branches whose work was merged into the pipeline branch

--- a/crates/pdo-daemon/src/run_command.rs
+++ b/crates/pdo-daemon/src/run_command.rs
@@ -880,8 +880,10 @@ async fn dispatch(state: Arc<AppState>, run_id: String, cmd: RunCommand) -> Resp
             // thing that should have released it. Same posture as `node_stop`, which
             // has called this since #159.
             //
-            // The halt/pause arms and `boot_recovery` (which fails orphaned `Running`
-            // nodes) have the same hole; they are out of #489's scope and filed.
+            // The halt/pause arms (via `re_evaluate_after_command`) and
+            // `boot_recovery` (which fails orphaned `Running` nodes) had the same
+            // hole; #509 closed both — see the re-drive in `re_evaluate_after_command`
+            // and at the tail of `run_boot_recovery`.
             retry_waiting_nodes(&state).await;
 
             info!("kill_node: node {node_id} iter {iter} in run {run_id}");
@@ -1437,12 +1439,34 @@ impl ReEvalSummary {
     }
 }
 
-/// Re-evaluate the scheduler after a command (resume_run, extend_cycle).
-/// Loads the pipeline and run state, resolves variables (including cycle extensions),
-/// then re-evaluates outgoing edges of all completed nodes to find newly ready spawns.
-/// Returns what actually happened so command handlers can tell the truth
-/// (ADR-0025 / #327).
+/// Post-command re-evaluation (ADR-0025 / #327) that also re-drives the
+/// admission queue when the command drove the run to a **terminal** state.
+///
+/// #509: a run going `Halted`/`Completed` here stops counting its
+/// still-session-holding nodes against the global session cap
+/// (`admission::count_live_node_sessions` excludes terminal runs — see
+/// `excludes_halted_run_with_a_running_node`), so a slot frees. But the three
+/// command arms that reach this function (`extend_cycle`, `Region`
+/// bump/end, `resume_run`) never re-drove the nodes throttled into `waiting` in
+/// *other* runs. `retry_waiting_nodes` has no timer of its own — every one of its
+/// callers is event-driven (#159) — so a queued node could starve until an
+/// unrelated event happened to re-drive it. Same posture as the `kill_node` arm
+/// (#489-C): the site that frees a slot re-drives the queue. The sweep is global
+/// and idempotent (guard-superfluous dedup), so a single call after a terminal
+/// re-evaluation is correct.
 async fn re_evaluate_after_command(state: &AppState, run_id: &str) -> ReEvalSummary {
+    let summary = re_evaluate_after_command_inner(state, run_id).await;
+    if summary.terminal.is_some() {
+        retry_waiting_nodes(state).await;
+    }
+    summary
+}
+
+/// The re-evaluation proper. Loads the pipeline and run state, resolves variables
+/// (including cycle extensions), then re-evaluates outgoing edges of all completed
+/// nodes to find newly ready spawns. Returns what actually happened so command
+/// handlers can tell the truth (ADR-0025 / #327).
+async fn re_evaluate_after_command_inner(state: &AppState, run_id: &str) -> ReEvalSummary {
     let mut summary = ReEvalSummary::default();
     let events = match load_events(&state.db, run_id).await {
         Ok(e) => e,

--- a/crates/pdo-daemon/tests/waiting_node_starvation.rs
+++ b/crates/pdo-daemon/tests/waiting_node_starvation.rs
@@ -1,0 +1,255 @@
+//! Layer 3a — #509: a node throttled into `waiting` by the admission cap is
+//! re-driven when a slot frees through a path that does **not** already re-drive
+//! the queue.
+//!
+//! `retry_waiting_nodes` has no timer of its own — every one of its callers is
+//! event-driven (#159) — so a slot-freeing path that forgets to call it strands
+//! the queued node for ever. #489-C closed the `kill_node` path; this file pins
+//! the two that stayed open:
+//!
+//! 1. **Boot recovery.** Failing an orphaned `Running` node at daemon startup
+//!    frees its slot, but a Run whose orphan died while a *sibling* node is still
+//!    `Running` never reaches the run-level stall reconciliation (a live sibling
+//!    suppresses `run_stall_reason`), so nothing redistributed the slot. This is
+//!    the path reproduced empirically on the issue.
+//! 2. **A command that drives a run terminal.** `re_evaluate_after_command`
+//!    (`extend_cycle` / `bump_region` / `end_region` / `resume_run`) can drive a
+//!    run `Halted` while it still projects a session-holding node — a state the
+//!    admission count deliberately excludes (`excludes_halted_run_with_a_running_node`),
+//!    so a slot frees there too.
+//!
+//! The cap is set through the **stored** tier (`PUT /settings`), never
+//! `PDO_SESSION_CAP`: that env var is process-global and would race every sibling
+//! test. Stored beats env, so this is hermetic even under a runner that exports one.
+
+mod common;
+
+use std::time::Duration;
+
+use common::TestDaemon;
+use pdo_daemon::tmux_session_manager;
+
+const PIPELINE_NAME: &str = "starve";
+
+/// `start` fans out to two `doc-only` nodes that both go `Running` the instant a
+/// Run is created — each consuming an admission slot — so a single Run of this
+/// pipeline saturates a cap of 2. `leader` alone feeds `end`; `leaf1` is a leaf,
+/// which is what lets us kill it while `leader` stays alive.
+const PIPELINE_YAML: &str = r#"name: starve
+version: "1.0"
+nodes:
+  - id: start
+    name: Start
+    type: start
+    outputs:
+      - name: user_prompt
+  - id: leaf1
+    name: leaf1
+    type: doc-only
+    inputs:
+      - name: task
+    outputs:
+      - name: plan
+  - id: leader
+    name: leader
+    type: doc-only
+    inputs:
+      - name: task
+    outputs:
+      - name: plan
+  - id: end
+    name: End
+    type: end
+    inputs:
+      - name: result
+edges:
+  - source: { node: start, port: user_prompt }
+    target: { node: leaf1, port: task }
+  - source: { node: start, port: user_prompt }
+    target: { node: leader, port: task }
+  - source: { node: leader, port: plan }
+    target: { node: end, port: result }
+"#;
+
+fn tmux_available() -> bool {
+    std::process::Command::new("tmux")
+        .arg("-V")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn seed(repo: &std::path::Path) -> anyhow::Result<()> {
+    let pipelines_dir = repo.join(".pdo").join("pipelines");
+    std::fs::create_dir_all(&pipelines_dir)?;
+    std::fs::write(
+        pipelines_dir.join(format!("{PIPELINE_NAME}.yaml")),
+        PIPELINE_YAML,
+    )?;
+    git_init_with_commit(repo)?;
+    Ok(())
+}
+
+fn git_init_with_commit(repo: &std::path::Path) -> anyhow::Result<()> {
+    let run = |args: &[&str]| -> anyhow::Result<()> {
+        let out = std::process::Command::new("git")
+            .args(args)
+            .current_dir(repo)
+            .output()?;
+        if !out.status.success() {
+            anyhow::bail!(
+                "git {:?} failed: {}",
+                args,
+                String::from_utf8_lossy(&out.stderr)
+            );
+        }
+        Ok(())
+    };
+    run(&["init", "-q", "-b", "main"])?;
+    run(&["config", "user.email", "test@example.com"])?;
+    run(&["config", "user.name", "Test"])?;
+    run(&["config", "commit.gpgsign", "false"])?;
+    std::fs::write(repo.join(".gitignore"), ".pdo/runs/\n")?;
+    run(&["add", "."])?;
+    run(&["commit", "-q", "-m", "init"])?;
+    Ok(())
+}
+
+async fn set_session_cap(daemon: &TestDaemon, cap: u32) {
+    let resp = reqwest::Client::new()
+        .put(format!("{}/settings", daemon.url()))
+        .json(&serde_json::json!({ "session_cap": cap }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200, "PUT /settings session_cap={cap}");
+}
+
+async fn create_run(daemon: &TestDaemon) -> String {
+    let body = serde_json::json!({
+        "pipeline": PIPELINE_NAME,
+        "input": "test input",
+        "target_repo": daemon.target_repo(),
+    });
+    let resp = reqwest::Client::new()
+        .post(format!("{}/runs", daemon.url()))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 201, "POST /runs should succeed");
+    let json: serde_json::Value = resp.json().await.unwrap();
+    json["run_id"].as_str().unwrap().to_string()
+}
+
+async fn node_status(daemon: &TestDaemon, run_id: &str, node: &str) -> Option<String> {
+    let resp = reqwest::Client::new()
+        .get(format!("{}/runs/{run_id}", daemon.url()))
+        .send()
+        .await
+        .unwrap();
+    let json: serde_json::Value = resp.json().await.unwrap();
+    json["nodes"][node]["status"].as_str().map(String::from)
+}
+
+async fn wait_for_node_status(daemon: &TestDaemon, run_id: &str, node: &str, want: &str) {
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while std::time::Instant::now() < deadline {
+        if node_status(daemon, run_id, node).await.as_deref() == Some(want) {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    panic!(
+        "node {node} of run {run_id} never reached {want:?} (last = {:?})",
+        node_status(daemon, run_id, node).await
+    );
+}
+
+/// #509 — the boot-recovery half, the path reproduced on the issue.
+///
+/// Two Runs of a fan-out pipeline share a cap of 2: Run A takes both slots, Run B
+/// is throttled into `waiting`. An external crash kills ONE of Run A's two node
+/// sessions (`leaf1`) while `leader` stays live. Boot recovery fails the orphan —
+/// freeing its slot — but Run A never stalls at the run level (its `leader` is
+/// still Running), so before the fix nothing re-drove Run B and it starved for
+/// ever. The fix re-drives the queue once, after the whole recovery pass.
+#[tokio::test]
+async fn boot_recovery_redrives_a_waiting_node_after_freeing_a_slot() {
+    if !tmux_available() {
+        eprintln!("tmux not on PATH — skipping");
+        return;
+    }
+
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+    let socket = daemon.tmux_socket();
+    set_session_cap(&daemon, 2).await;
+
+    // Run A saturates the cap: leaf1 + leader both Running (2/2 slots).
+    let run_a = create_run(&daemon).await;
+    wait_for_node_status(&daemon, &run_a, "leaf1", "running").await;
+    wait_for_node_status(&daemon, &run_a, "leader", "running").await;
+
+    // Run B is refused admission on both entry nodes → waiting.
+    let run_b = create_run(&daemon).await;
+    wait_for_node_status(&daemon, &run_b, "leaf1", "waiting").await;
+    wait_for_node_status(&daemon, &run_b, "leader", "waiting").await;
+
+    // Simulate the crash: kill ONLY leaf1's session in Run A, out of band. leader
+    // stays alive and attached.
+    let leaf1_session = tmux_session_manager::node_session_name(&run_a, "leaf1", 1);
+    tmux_session_manager::kill(&socket, &leaf1_session);
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // The boot-recovery pass the daemon runs at startup.
+    daemon.run_boot_recovery_tick().await;
+
+    // Run A: the orphan is Failed; the sibling and the Run itself stay live — so
+    // the run-level stall reconciliation never fires for Run A.
+    assert_eq!(
+        node_status(&daemon, &run_a, "leaf1").await.as_deref(),
+        Some("failed"),
+        "the orphaned node must be Failed at boot"
+    );
+    assert_eq!(
+        node_status(&daemon, &run_a, "leader").await.as_deref(),
+        Some("running"),
+        "the live sibling must stay Running (it suppresses run-level reconciliation)"
+    );
+
+    // The freed slot must be redistributed to Run B. With cap 2 and one live
+    // session left (leader A), exactly one of Run B's two queued nodes wins the
+    // slot; the other stays waiting. Before the fix, BOTH stayed waiting for ever.
+    wait_for_a_redriven_node(&daemon, &run_b).await;
+
+    // Cleanup the sessions this test spawned out of band.
+    tmux_session_manager::kill(
+        &socket,
+        &tmux_session_manager::node_session_name(&run_a, "leader", 1),
+    );
+    for node in ["leaf1", "leader"] {
+        tmux_session_manager::kill(
+            &socket,
+            &tmux_session_manager::node_session_name(&run_b, node, 1),
+        );
+    }
+}
+
+/// Poll until one of Run B's two entry nodes has left `waiting` for `running`.
+async fn wait_for_a_redriven_node(daemon: &TestDaemon, run_b: &str) {
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        let leaf1 = node_status(daemon, run_b, "leaf1").await;
+        let leader = node_status(daemon, run_b, "leader").await;
+        if leaf1.as_deref() == Some("running") || leader.as_deref() == Some("running") {
+            return;
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!(
+                "the freed slot was never redistributed to a waiting node \
+                 (leaf1={leaf1:?}, leader={leader:?}) — #509 starvation"
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}

--- a/docs/adr/0037-a-spawn-that-did-not-happen-is-never-a-2xx.md
+++ b/docs/adr/0037-a-spawn-that-did-not-happen-is-never-a-2xx.md
@@ -285,9 +285,12 @@ slot qu'un restart throttlé attend, et `retry_waiting_nodes` n'a aucun timer.
 - **Les corps d'erreur `text/plain`** (Run absent, pipeline illisible/inparsable) restent tels quels.
   Les normaliser est le périmètre de **#491**, et le faire ici mélangerait une rupture et un nettoyage
   sous un seul bump.
-- **`retry_waiting_nodes` n'a toujours aucun timer**, et deux autres libérateurs de slot ne le
+- ~~**`retry_waiting_nodes` n'a toujours aucun timer**, et deux autres libérateurs de slot ne le
   réveillent pas (les bras halt/pause, et `boot_recovery` qui échoue les `Running` orphelins). #489
-  ferme `kill_node` seul ; le reste est fiché.
+  ferme `kill_node` seul ; le reste est fiché.~~ **Fermé par #509** : `re_evaluate_after_command`
+  re-drive la file d'admission quand une commande rend un Run terminal (`Halted`/`Completed`), et
+  `run_boot_recovery` la re-drive une fois en fin de passe. Toujours pas de timer — le fix reste
+  événementiel, même posture que `kill_node` (#489-C).
 - **Le comptage d'admission reste par nœud, pas par itération** (#453) : N laps parallèles d'un nœud
   consomment **un** slot. Pré-existant ; l'exclusion ne se construit pas sur une hypothèse contraire.
 


### PR DESCRIPTION
## Contexte

Ferme #509 : un nœud throttlé en \`waiting\` mourait de faim quand un slot d'admission se libérait par un chemin qui ne re-drivait pas la file. Bug 100 % headless, invisible à \`run_stall_reason\` (supprimé par un nœud frère vivant) et à \`stale_detector\` (ne regarde que \`Running\`).

## Correctif

Même posture que #489-C (le site qui libère le slot re-drive la file, sans nouveau timer) :

- **boot_recovery** : \`run_boot_recovery\` re-drive la file une fois en fin de passe. Un Run dont un nœud frère reste \`Running\` ne cale jamais au niveau Run, donc le slot n'était jamais redistribué après un redémarrage daemon.
- **run_command** : \`re_evaluate_after_command\` re-drive la file quand une commande (\`extend_cycle\`/\`bump_region\`/\`end_region\`/\`resume_run\`) rend le Run terminal (\`Halted\`/\`Completed\`) — un Run terminal cesse de compter ses nœuds session-holding.
- Commentaire \`kill_node\` et ADR-0037 § « Limites acceptées » mis à jour.

## Test

\`waiting_node_starvation.rs\` reproduit le scénario boot_recovery via le seam \`run_boot_recovery_tick\` (échoue sans le fix : les deux nœuds du Run B restent \`waiting\`). Le scénario **deux nœuds** est requis pour que \`reconcile_run_level_stall\` ne sauve pas accidentellement.

## Validation

- \`cargo build -p pdo-daemon\` : clean
- \`cargo +stable fmt --all --check\` : exit 0
- Verdict Tester : Pass

Version 1.15.0 → **1.16.0** (minor, un bug shippé).

🤖 Generated with [Claude Code](https://claude.com/claude-code)