### PR TITLE
fix(#369): stopper le clignotement des diagrammes mermaid — 1.16.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "1.16.0"
+version = "1.16.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "1.16.0"
+version = "1.16.1"
 license = "MIT"
 
 [workspace.dependencies]

--- a/frontend/src/components/MarkdownArtifactModal.test.tsx
+++ b/frontend/src/components/MarkdownArtifactModal.test.tsx
@@ -163,6 +163,59 @@ describe("MarkdownArtifactModal", () => {
       expect(screen.getByTestId("iter-next")).toBeDisabled();
     });
 
+    // #369: NodeDetailPanel polls node I/O and re-renders every tick. Before the
+    // fix it rebuilt an equivalent-but-fresh `source` object each time, and the
+    // modal keyed its fetch effect on that reference — so it re-fetched (and reset
+    // file pagination + blanked the body, remounting the mermaid diagram) every
+    // tick. The effect must instead key on the primitive nav fields, so a parent
+    // re-render with an equivalent source triggers no new fetch.
+    it("does not re-fetch when the parent re-renders with an equivalent source", async () => {
+      fetchArtifactMock.mockResolvedValue("# content");
+      fetchNodeIOMock.mockResolvedValue({
+        inputs: [],
+        outputs: [
+          { port: "out", repeated: false, files: [makeFile("/iter-2/out.md")] },
+        ],
+      });
+
+      // A fresh source object (new reference, incl. a new iterations array) with
+      // identical field values — exactly what a poll-driven re-render produces.
+      const makeSource = () =>
+        ({
+          kind: "iter-nav",
+          nodeId: "node-1",
+          portKind: "output",
+          iterations: makeIters(3),
+          initialIter: 2,
+        }) as const;
+
+      const { rerender } = render(
+        <MarkdownArtifactModal
+          runId="run-1"
+          portName="out"
+          source={makeSource()}
+          onClose={() => {}}
+        />,
+      );
+      await act(async () => {});
+      expect(fetchNodeIOMock).toHaveBeenCalledTimes(1);
+
+      fetchNodeIOMock.mockClear();
+      rerender(
+        <MarkdownArtifactModal
+          runId="run-1"
+          portName="out"
+          source={makeSource()}
+          onClose={() => {}}
+        />,
+      );
+      await act(async () => {});
+
+      expect(fetchNodeIOMock).not.toHaveBeenCalled();
+      // The iter nav is still fully functional after the churn-free re-render.
+      expect(screen.getByText("iter 2 of 3")).toBeInTheDocument();
+    });
+
     it("does not show iter nav when only one iteration", async () => {
       fetchArtifactMock.mockResolvedValue("");
       fetchNodeIOMock.mockResolvedValue({

--- a/frontend/src/components/MarkdownArtifactModal.tsx
+++ b/frontend/src/components/MarkdownArtifactModal.tsx
@@ -55,13 +55,25 @@ export default function MarkdownArtifactModal({
     setIter(newIter);
   }, []);
 
+  // #369: key the fetch effect on the primitive fields it actually reads, NOT
+  // on the `source` object reference. The parent (NodeDetailPanel) polls node
+  // I/O and re-renders on every tick; if it hands us a fresh-but-equivalent
+  // `source` object, depending on its identity would re-run this effect each
+  // tick — re-fetching and calling `setFiles(new array)` + `setFileIndex(0)`,
+  // which momentarily blanks the body and remounts the mermaid diagram (the
+  // reported flicker). These primitives only change when the iter-nav target
+  // genuinely does, so the effect (and file pagination) stays put under polling.
+  const isIterNav = source.kind === "iter-nav";
+  const navNodeId = source.kind === "iter-nav" ? source.nodeId : null;
+  const navPortKind = source.kind === "iter-nav" ? source.portKind : null;
+
   useEffect(() => {
-    if (source.kind !== "iter-nav") return;
+    if (!isIterNav || navNodeId == null || navPortKind == null) return;
     let cancelled = false;
-    fetchNodeIO(runId, source.nodeId, iter)
+    fetchNodeIO(runId, navNodeId, iter)
       .then((io) => {
         if (cancelled) return;
-        const ports = source.portKind === "input" ? io.inputs : io.outputs;
+        const ports = navPortKind === "input" ? io.inputs : io.outputs;
         const port = ports.find((p) => p.port === portName);
         setFiles(port?.files ?? []);
         setFileIndex(0);
@@ -76,7 +88,7 @@ export default function MarkdownArtifactModal({
     return () => {
       cancelled = true;
     };
-  }, [source, runId, iter, portName]);
+  }, [isIterNav, navNodeId, navPortKind, runId, iter, portName]);
 
   const file = files[fileIndex];
   const total = files.length;

--- a/frontend/src/components/NodeDetailPanel.tsx
+++ b/frontend/src/components/NodeDetailPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   CheckCircle,
   AlertCircle,
@@ -36,6 +36,7 @@ import {
   DropdownMenuItem,
 } from "./ui/dropdown-menu";
 import MarkdownArtifactModal from "./MarkdownArtifactModal";
+import type { ArtifactSource } from "./MarkdownArtifactModal";
 import ImageLightbox from "./ImageLightbox";
 import TmuxTerminal from "./TmuxTerminal";
 
@@ -290,6 +291,28 @@ export default function NodeDetailPanel({
   const isStaleIter = selectedIter !== node.iter;
   const hasMultipleIters = (node.iterations?.length ?? 0) > 1;
   const showTerminal = node.status !== "pending";
+
+  // #369: the I/O poll (`setInputs`/`setOutputs`) re-renders this panel every
+  // tick (1s live, 5s settled). Building the modal's `source` prop as an inline
+  // object literal handed the child a fresh reference on every one of those
+  // re-renders; the modal keyed a fetch effect on that reference, so it re-ran
+  // `fetchNodeIO` + `setFiles(new array)` + `setFileIndex(0)` on every tick,
+  // which momentarily emptied the body and unmounted/remounted the rendered
+  // markdown (mermaid diagram → back to its empty `aria-busy` state → flicker).
+  // Memoize on the structural keys so the reference stays stable across ticks
+  // and only changes when the underlying identity actually does.
+  const modalSource = useMemo<ArtifactSource | null>(() => {
+    if (!modal) return null;
+    return node.iterations && node.iterations.length > 1
+      ? {
+          kind: "iter-nav",
+          nodeId: node.node_id,
+          portKind: modal.portKind,
+          iterations: node.iterations,
+          initialIter: selectedIter,
+        }
+      : { kind: "static", files: modal.files };
+  }, [modal, node.iterations, node.node_id, selectedIter]);
 
   // #315: the per-iter *rendered* prompt lives in the node's working dir, which
   // is destroyed on archive and is not among the preserved set (ADR-0020 keeps
@@ -822,22 +845,12 @@ export default function NodeDetailPanel({
         );
       })()}
 
-      {modal && (
+      {modal && modalSource && (
         <MarkdownArtifactModal
           runId={runId}
           portName={modal.portName}
           portType={modal.portType}
-          source={
-            node.iterations && node.iterations.length > 1
-              ? {
-                  kind: "iter-nav",
-                  nodeId: node.node_id,
-                  portKind: modal.portKind,
-                  iterations: node.iterations,
-                  initialIter: selectedIter,
-                }
-              : { kind: "static", files: modal.files }
-          }
+          source={modalSource}
           onClose={() => setModal(null)}
         />
       )}


### PR DESCRIPTION
## Contexte

Closes #369.

Les diagrammes mermaid clignotaient dans le modal d'artefact : la prop `source` était un littéral objet inline (nouvelle référence à chaque re-render), et le modal keyait son effet de fetch iter-nav sur cette identité d'objet. Sous le poll d'I/O de `NodeDetailPanel`, le sous-arbre `<Markdown>`/`<MermaidDiagram>` était démonté/remonté à chaque tick → mermaid repassait par son état vide `aria-busy` → le flash.

## Correctif (100 % frontend)

- `NodeDetailPanel` : mémoïser `source` sur des clés structurelles/primitives.
- `MarkdownArtifactModal` : keyer l'effet de fetch sur les champs primitifs (`nodeId`, `portKind`, `kind`) plutôt que sur l'identité de l'objet `source` ; corrige aussi la pagination fichiers qui sautait à zéro sous poll.
- Test de régression : un re-render parent avec un `source` équivalent ne déclenche plus de fetch.

ADR-0013 respecté (`securityLevel` strict, mermaid pinné, pas de DOMPurify app).

## Validation

- `npm run typecheck` (tsc -b) : vert (sur la base 1.16.0 rebasée).
- `npx vitest run MarkdownArtifactModal` : **19/19 verts**, dont la régression #369.
- Reproduction navigateur sur le vrai chemin de code : **0 clignotement** côté corrigé contre **9 en 4 s** côté pré-fix ; `fetchNodeIO` figé à 2 appels au lieu de croître sans borne.

Version bump 1.16.0 → **1.16.1** (patch, non cassant). Rebasé sur `origin/main` (le Run était parti d'une base 1.12.0 périmée).

🤖 Generated with [Claude Code](https://claude.com/claude-code)