### PR TITLE
refactor(#359): extract orchestration hooks from giant components — 1.17.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "1.16.1"
+version = "1.17.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "1.16.1"
+version = "1.17.0"
 license = "MIT"
 
 [workspace.dependencies]

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,11 +7,8 @@ import { useLibrary } from "./hooks/useLibrary";
 import { useLibraryPipelines } from "./hooks/useLibraryPipelines";
 import { fetchRuns, fetchRun, fetchTriggers, fetchSessions, fetchTriggersHealth, pauseTriggers } from "./api";
 import { pickLatestLiveNode } from "./lib/pickLatestLiveNode";
-import { rightPaneOwner } from "./lib/rightPaneOwner";
-import { shouldClearTriggerOnCanvasFocus } from "./lib/triggerCanvasReconcile";
-import { shouldCloseInfoOnTabChange } from "./lib/infoPanelReconcile";
-import type { RunListEntry, RunState, NodeState, Trigger, DaemonStatus } from "./types";
-import { isLiveRun } from "./types";
+import { useRightPaneRouter } from "./hooks/useRightPaneRouter";
+import type { RunListEntry, RunState, Trigger, DaemonStatus } from "./types";
 import SessionCounter from "./components/SessionCounter";
 import ServiceHealthIndicator from "./components/ServiceHealthIndicator";
 import UnifiedLeftPanel from "./components/UnifiedLeftPanel";
@@ -241,98 +238,26 @@ export default function App() {
   const isActiveRunArchived =
     isEditingRun && editTab?.runId === selectedRun?.run_id && isArchived;
 
-  // The Trigger backing the right-panel detail view (#162), shown whenever a
-  // Trigger is selected and the info overlay is closed — even while a run-edit
-  // tab owns the canvas (#247).
-  //
-  // A Trigger detail and a canvas selection compete for the right pane (#247).
-  // The Trigger now wins over a *persistent* run-edit tab (see rightPaneOwner),
-  // so we need an explicit way for the canvas to reclaim the pane — otherwise a
-  // once-selected Trigger would shadow every later node/edge/region inspector.
-  // Selecting a Trigger touches neither `selection` nor the active tab, so the
-  // canvas-focus signal below never fires on a fresh Trigger selection; any
-  // later canvas focus (a node/edge/region selection, or a tab switch/open —
-  // all of which change `selection` or `editActiveTabId`) clears it. Adjusting
-  // state during render (React's recommended reset-on-change pattern) rather
-  // than in an effect avoids painting one stale frame of the Trigger detail.
-  const [lastCanvasFocus, setLastCanvasFocus] = useState({
-    selection,
-    tabId: editActiveTabId,
-  });
-  if (
-    lastCanvasFocus.selection !== selection ||
-    lastCanvasFocus.tabId !== editActiveTabId
-  ) {
-    // setLastCanvasFocus MUST stay unconditional — gating it would make this
-    // block re-fire every render (infinite loop).
-    setLastCanvasFocus({ selection, tabId: editActiveTabId });
-    // #320: skip clearing the Trigger when this focus change is the Trigger's
-    // OWN openPipeline landing — i.e. the tab it opened is now active with
-    // nothing selected. A genuine canvas reclaim differs and STILL clears
-    // (preserving #247): a node/edge/region select makes selection.kind !==
-    // "none", and switching to another tab makes editActiveTabId !==
-    // triggerOpenedTabId.
-    if (
-      shouldClearTriggerOnCanvasFocus({
-        selectedTriggerId,
-        editActiveTabId,
-        selectionKind: selection.kind,
-        triggerOpenedTabId,
-      })
-    ) {
-      setSelectedTriggerId(null);
-    }
-  }
-
-  // #385: the Pipeline Info peek overlay is tab-scoped and shadows the right
-  // pane while open (rightPaneOwner gives it top precedence). Close it when the
-  // active tab changes — selecting a different run/library-pipeline (left
-  // panel), a Trigger opening its pipeline, or a TabBar switch all move
-  // `editActiveTabId`. Canvas node/edge/note clicks already close it via
-  // EditCanvas.onCloseInfo.
-  //
-  // Same render-time reset-on-change idiom as the #320 block above (adjust
-  // state during render, not in an effect, to avoid painting one stale frame).
-  // CRITICAL: advance `lastInfoTabId` UNCONDITIONALLY — if the advance were
-  // gated on `infoPanelOpen`, the tracker would go stale while the overlay is
-  // closed and spuriously close the NEXT overlay one frame after it opens on a
-  // new tab (and gating would also re-fire this block every render). `useState`
-  // (not a ref): the value is read during render, which react-hooks/refs
-  // forbids — the same reason `triggerOpenedTabId` above is state.
-  const [lastInfoTabId, setLastInfoTabId] = useState<string | null>(editActiveTabId);
-  if (lastInfoTabId !== editActiveTabId) {
-    const closeInfo = shouldCloseInfoOnTabChange({
-      prevTabId: lastInfoTabId,
-      nextTabId: editActiveTabId,
-      infoOpen: infoPanelOpen,
+  // The Trigger backing the right-panel detail view (#162), the pane-owner
+  // precedence (#247), the two render-time reconciliations (#320 canvas-reclaim,
+  // #385 info auto-close), and the synthesized pending run-pane node all live in
+  // useRightPaneRouter (#359). It runs the setState-during-render reconciliations
+  // in-body here (App owns `selectedTriggerId`/`infoPanelOpen`, passed in with
+  // their setters) so no stale frame of a shadowed panel is painted.
+  const { paneOwner, selectedTrigger, triggerPromptRequired, runNode } =
+    useRightPaneRouter({
+      selection,
+      editActiveTabId,
+      hasEditTab,
+      selectedTriggerId,
+      setSelectedTriggerId,
+      triggerOpenedTabId,
+      infoPanelOpen,
+      setInfoPanelOpen,
+      triggers,
+      pipelines,
+      selectedRun,
     });
-    setLastInfoTabId(editActiveTabId); // UNCONDITIONAL — mirrors the #320 block
-    if (closeInfo) setInfoPanelOpen(false);
-  }
-
-  const selectedTrigger =
-    selectedTriggerId != null
-      ? triggers.find((t) => t.id === selectedTriggerId) ?? null
-      : null;
-
-  // Prompt-required (#351): default true when the flag is absent (matches the
-  // daemon default); false when the pipeline can't be found, so a dangling
-  // reference shows no false "would be empty" caveat.
-  const triggerPromptRequired = selectedTrigger
-    ? (() => {
-        const p = pipelines.find((pl) => pl.id === selectedTrigger.pipeline_id);
-        return p ? p.prompt_required !== false : false;
-      })()
-    : false;
-
-  // Which view owns the right-hand detail pane (#247). A selected Trigger now
-  // wins over a persistent run-edit tab; the canvas-focus reconciliation above
-  // clears `selectedTriggerId` the moment the canvas is touched again.
-  const paneOwner = rightPaneOwner({
-    triggerSelected: selectedTrigger != null,
-    infoPanelOpen,
-    hasEditTab,
-  });
 
   const openNewRunModal = useCallback((intent: OpenIntent) => {
     setOpenIntent(intent);
@@ -411,32 +336,6 @@ export default function App() {
 
   const { activeTab: inspectorTab, setActiveTab: setInspectorTab } =
     useInspectorTab(editActiveTabId, isEditingRun);
-
-  // The Run-pane node. A node present in the pipeline (canvas) but absent from the
-  // run's node map is genuinely pending: the event-sourced projection only lists a
-  // node once it has been scheduled (NodeStarted / NodeWaiting / …), so a
-  // not-yet-reached downstream node has no entry. On a live run, synthesize a
-  // pending NodeState so the inspector renders NodeDetailPanel (with its force-start
-  // Start button, #204) instead of the passive RunTabPlaceholder — the daemon's
-  // force_spawn_node already accepts a node absent from run state. Terminal runs and
-  // start/end pseudo-nodes stay null.
-  const runNode: NodeState | null = (() => {
-    if (selection.kind !== "node" || !selection.id || !selectedRun) return null;
-    const existing = selectedRun.nodes[selection.id];
-    if (existing) return existing;
-    if (!isLiveRun(selectedRun.status)) return null;
-    const def = selectedRun.node_defs?.find((d) => d.id === selection.id);
-    if (!def || def.node_type === "start" || def.node_type === "end") return null;
-    return {
-      node_id: selection.id,
-      status: "pending",
-      iter: 0,
-      started_at: null,
-      completed_at: null,
-      failure_reason: null,
-      iterations: [],
-    };
-  })();
 
   // Both inspector panes are always rendered (with the inactive one hidden
   // via the `hidden` attribute) so that switching tabs does not unmount the

--- a/frontend/src/components/LibraryRow.test.tsx
+++ b/frontend/src/components/LibraryRow.test.tsx
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import LibraryRow from "./LibraryRow";
+import type { PipelineScope } from "../types";
+
+function renderRow(
+  over: {
+    name?: string;
+    scope?: PipelineScope;
+    nodeCount?: number;
+    starred?: boolean;
+    selected?: boolean;
+    showDuplicate?: boolean;
+    onOpen?: () => void;
+    onDuplicate?: () => void;
+    onDelete?: () => void;
+    deleteTitle?: string;
+  } = {},
+) {
+  const props = {
+    name: "fixture",
+    scope: "repo" as PipelineScope,
+    nodeCount: 3,
+    starred: false,
+    showDuplicate: false,
+    onDelete: () => {},
+    deleteTitle: "Delete pipeline",
+    ...over,
+  };
+  return render(<LibraryRow {...props} testId="row" />);
+}
+
+describe("LibraryRow openable vs passive", () => {
+  it("renders a <button> when onOpen is given, and clicking it opens", () => {
+    const onOpen = vi.fn();
+    renderRow({ onOpen });
+
+    const row = screen.getByTestId("row");
+    expect(row.tagName).toBe("BUTTON");
+    fireEvent.click(row);
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders a passive <div> when onOpen is absent", () => {
+    renderRow();
+
+    const row = screen.getByTestId("row");
+    expect(row.tagName).toBe("DIV");
+    // Not a button by role either — there is nothing behind it to open.
+    expect(row.getAttribute("role")).toBeNull();
+  });
+
+  it("shows the name and node count in both shapes", () => {
+    const { unmount } = renderRow({ name: "planner", nodeCount: 7 });
+    expect(screen.getByText("planner")).toBeInTheDocument();
+    expect(screen.getByText("7 nodes")).toBeInTheDocument();
+    unmount();
+
+    renderRow({ name: "planner", nodeCount: 7, onOpen: () => {} });
+    expect(screen.getByText("planner")).toBeInTheDocument();
+    expect(screen.getByText("7 nodes")).toBeInTheDocument();
+  });
+
+  it("renders no data-testid attribute at all when testId is omitted", () => {
+    // The /pipelines rows pass none; an empty `data-testid=""` would make them
+    // matchable by an accidental query.
+    const { container } = render(
+      <LibraryRow
+        name="fixture"
+        scope="repo"
+        nodeCount={3}
+        starred={false}
+        showDuplicate={false}
+        onDelete={() => {}}
+        deleteTitle="Delete pipeline"
+      />,
+    );
+    expect(container.firstElementChild!.hasAttribute("data-testid")).toBe(false);
+  });
+});
+
+describe("LibraryRow star", () => {
+  it("shows the star when starred", () => {
+    renderRow({ starred: true });
+    expect(screen.getByTestId("left-panel-star")).toBeInTheDocument();
+  });
+
+  it("hides the star when not starred", () => {
+    renderRow({ starred: false });
+    expect(screen.queryByTestId("left-panel-star")).not.toBeInTheDocument();
+  });
+});
+
+describe("LibraryRow scope badge", () => {
+  it.each<PipelineScope>(["repo", "user", "library"])("labels a %s row", (scope) => {
+    renderRow({ scope });
+    expect(screen.getByText(scope)).toBeInTheDocument();
+  });
+});
+
+describe("LibraryRow delete", () => {
+  it("calls onDelete on the trash affordance, addressed by its title", () => {
+    const onDelete = vi.fn();
+    renderRow({ onDelete, deleteTitle: "Remove from library" });
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove from library" }));
+    expect(onDelete).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not also open the row: the trash stops propagation", () => {
+    const onOpen = vi.fn();
+    const onDelete = vi.fn();
+    renderRow({ onOpen, onDelete });
+
+    // The affordance is a span nested inside the row <button>; without
+    // stopPropagation the click would open the pipeline it is deleting.
+    fireEvent.click(screen.getByRole("button", { name: "Delete pipeline" }));
+    expect(onDelete).toHaveBeenCalledTimes(1);
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+});
+
+describe("LibraryRow duplicate", () => {
+  it("hides the duplicate affordance when showDuplicate is false", () => {
+    renderRow({ showDuplicate: false, onDuplicate: () => {} });
+    expect(screen.queryByTestId("library-duplicate-button")).not.toBeInTheDocument();
+  });
+
+  it("calls onDuplicate without opening the row", () => {
+    const onOpen = vi.fn();
+    const onDuplicate = vi.fn();
+    renderRow({ showDuplicate: true, onDuplicate, onOpen });
+
+    fireEvent.click(screen.getByTestId("library-duplicate-button"));
+    expect(onDuplicate).toHaveBeenCalledTimes(1);
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+
+  it("survives a shown duplicate affordance with no handler wired", () => {
+    renderRow({ showDuplicate: true });
+    expect(() =>
+      fireEvent.click(screen.getByTestId("library-duplicate-button")),
+    ).not.toThrow();
+  });
+});
+
+describe("LibraryRow selection", () => {
+  it("marks the open editor tab with the selected background", () => {
+    renderRow({ onOpen: () => {}, selected: true });
+    const cls = screen.getByTestId("row").className;
+    expect(cls).toContain("bg-bg-3 text-fg");
+    // Not the unselected pair (whose `hover:bg-bg-3/50` also contains "bg-bg-3").
+    expect(cls).not.toContain("hover:bg-bg-3/50");
+  });
+
+  it("leaves an unselected row on the hover-only background", () => {
+    renderRow({ onOpen: () => {}, selected: false });
+    const cls = screen.getByTestId("row").className;
+    expect(cls).toContain("text-fg-2 hover:bg-bg-3/50");
+  });
+
+  it("defaults to unselected when `selected` is omitted", () => {
+    renderRow({ onOpen: () => {} });
+    expect(screen.getByTestId("row").className).toContain("hover:bg-bg-3/50");
+  });
+});

--- a/frontend/src/components/LibraryRow.tsx
+++ b/frontend/src/components/LibraryRow.tsx
@@ -1,0 +1,141 @@
+import { Copy, Star, Trash2 } from "lucide-react";
+import type { PipelineScope } from "../types";
+
+const SCOPE_BADGE: Record<PipelineScope, { label: string; cls: string }> = {
+  repo: { label: "repo", cls: "border-acc text-acc" },
+  user: { label: "user", cls: "border-st-await text-st-await" },
+  library: { label: "library", cls: "border-st-await text-st-await" },
+};
+
+interface Props {
+  name: string;
+  scope: PipelineScope;
+  nodeCount: number;
+  /** Star badge — the visible "this name is in your Library" link (#227). */
+  starred: boolean;
+  /** Highlighted as the open editor tab. Only meaningful on an openable row. */
+  selected?: boolean;
+  showDuplicate: boolean;
+  /**
+   * Present ⇒ the row is an openable `<button>`; absent ⇒ a passive `<div>`.
+   * That is the real axis between the two library lists: a row backed by a
+   * /pipelines entry can be opened in the editor, a library-only row cannot.
+   */
+  onOpen?: () => void;
+  onDuplicate?: () => void;
+  /**
+   * Fired on the trash affordance. A plain callback on purpose: the parent owns
+   * *how* the delete happens (confirm modal + optional #227 cascade for a
+   * working pipeline, direct `deleteLibraryPipeline` for a library-only row), so
+   * this component never needs to know which mode it is in.
+   */
+  onDelete: () => void;
+  deleteTitle: string;
+  testId?: string;
+}
+
+/**
+ * One row of the Library tab. Both lists in `UnifiedLeftPanel` render through
+ * this: the /pipelines rows (openable, star when a Library twin exists, Copy on
+ * scope:"library" only) and the library-only rows (passive, always starred,
+ * always copyable). They were two near-identical renderers that drifted apart
+ * twice — #273 (Copy missing on a scope:"library" row) and #371 (a fresh
+ * duplicate stuck in the degraded passive row).
+ */
+export default function LibraryRow({
+  name,
+  scope,
+  nodeCount,
+  starred,
+  selected = false,
+  showDuplicate,
+  onOpen,
+  onDuplicate,
+  onDelete,
+  deleteTitle,
+  testId,
+}: Props) {
+  const badge = SCOPE_BADGE[scope];
+
+  const body = (
+    <>
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-1.5">
+          {starred && (
+            <Star
+              size={10}
+              className="shrink-0 fill-acc text-acc"
+              data-testid="left-panel-star"
+            />
+          )}
+          <span className="truncate font-medium">{name}</span>
+        </div>
+        <div
+          className="mt-0.5 flex items-center gap-1.5 text-fg-4"
+          style={{ fontSize: "10px" }}
+        >
+          <span>{nodeCount} nodes</span>
+        </div>
+      </div>
+      <span
+        className={`shrink-0 rounded border px-1 py-px group-hover:hidden ${badge.cls}`}
+        style={{ fontSize: "9px", fontWeight: 500 }}
+      >
+        {badge.label}
+      </span>
+      {showDuplicate && (
+        <span
+          className="hidden shrink-0 group-hover:inline-flex"
+          data-testid="library-duplicate-button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onDuplicate?.();
+          }}
+          role="button"
+          title="Duplicate pipeline"
+        >
+          <Copy size={14} className="text-fg-4 transition-colors hover:text-acc" />
+        </span>
+      )}
+      <span
+        className="hidden shrink-0 group-hover:inline-flex"
+        onClick={(e) => {
+          e.stopPropagation();
+          onDelete();
+        }}
+        role="button"
+        title={deleteTitle}
+      >
+        <Trash2
+          size={14}
+          className="text-fg-4 transition-colors hover:text-st-failed"
+        />
+      </span>
+    </>
+  );
+
+  if (onOpen) {
+    return (
+      <button
+        onClick={onOpen}
+        className={`group flex w-full cursor-pointer items-center gap-2 border-b border-line-soft px-3 py-2 text-left transition-colors ${
+          selected ? "bg-bg-3 text-fg" : "text-fg-2 hover:bg-bg-3/50"
+        }`}
+        style={{ fontSize: "11.5px" }}
+        data-testid={testId}
+      >
+        {body}
+      </button>
+    );
+  }
+
+  return (
+    <div
+      className="group flex w-full items-center gap-2 border-b border-line-soft px-3 py-2 text-left text-fg-2 transition-colors hover:bg-bg-3/50"
+      style={{ fontSize: "11.5px" }}
+      data-testid={testId}
+    >
+      {body}
+    </div>
+  );
+}

--- a/frontend/src/components/NewRunModal.tsx
+++ b/frontend/src/components/NewRunModal.tsx
@@ -1,13 +1,16 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ChevronDown, Clock, FolderGit2, GitBranch, ImagePlus, Save, Sparkles, Star, X } from "lucide-react";
-import type { InstanceSettings, PipelineListEntry, Trigger } from "../types";
+import type { InstanceSettings, Trigger } from "../types";
 import type { TestGuardResponse } from "../api";
-import { createRun, createTrigger, updateTrigger, fetchPipelines, fetchSettings, promotePipeline, validateRepo, listBranches, testGuard } from "../api";
+import { createRun, createTrigger, updateTrigger, fetchSettings, promotePipeline, testGuard } from "../api";
 import { useEditStore } from "../stores/editStore";
 import { useRecentReposStore } from "../stores/recentReposStore";
 import RepoCombobox from "./RepoCombobox";
 import GuardTestResult from "./GuardTestResult";
-import { CRON_PRESETS, presetToCron, cronToPreset, parseDailyTime, type CronPresetId } from "../cronPresets";
+import { CRON_PRESETS, cronToPreset, parseDailyTime, type CronPresetId } from "../cronPresets";
+import { useLaunchTargets } from "../hooks/useLaunchTargets";
+import { useRepoValidation } from "../hooks/useRepoValidation";
+import * as newRunForm from "../lib/newRunForm";
 
 const ACCEPTED_IMAGE_TYPES = ["image/png", "image/jpeg", "image/gif", "image/webp", "image/svg+xml", "image/bmp"];
 
@@ -47,8 +50,37 @@ interface Props {
 }
 
 export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN_INTENT, onTriggerSaved }: Props) {
-  const [pipelines, setPipelines] = useState<PipelineListEntry[]>([]);
-  const [selectedPipelineId, setSelectedPipelineId] = useState("");
+  // What this Run/Trigger can be launched against: the instance's pipelines and the
+  // target repo's branches, both served by the daemon (#359).
+  const {
+    pipelines,
+    repoPipelines,
+    libraryPipelines,
+    userPipelines,
+    selectedPipeline,
+    selectedPipelineId,
+    setSelectedPipelineId,
+    loadPipelines,
+    branches,
+    branchesLoading,
+    sourceBranch,
+    setSourceBranch,
+    loadBranches,
+    clearBranches,
+  } = useLaunchTargets(open);
+
+  // Multi-repo state: the target repo field, its debounced verdict, and the border it
+  // paints. Hands a validated path over to the branch loader above (#359).
+  const {
+    targetRepo,
+    repoValid,
+    repoError,
+    repoValidating,
+    repoBorderClass,
+    handleRepoChange,
+    resetRepo,
+  } = useRepoValidation({ open, loadBranches, clearBranches });
+
   const [runName, setRunName] = useState("");
   const [autoName, setAutoName] = useState(true);
   const [input, setInput] = useState("");
@@ -80,15 +112,6 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Multi-repo state
-  const [targetRepo, setTargetRepo] = useState("");
-  const [repoValid, setRepoValid] = useState<boolean | null>(null);
-  const [repoError, setRepoError] = useState<string | null>(null);
-  const [repoValidating, setRepoValidating] = useState(false);
-  const [branches, setBranches] = useState<string[]>([]);
-  const [sourceBranch, setSourceBranch] = useState("");
-  const [branchesLoading, setBranchesLoading] = useState(false);
-
   const [images, setImages] = useState<File[]>([]);
 
   // Sandbox (#410/#432/#452). `settings` carries the instance `default_sandbox` (it
@@ -114,20 +137,9 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
   const recentRepos = useRecentReposStore((s) => s.recentRepos);
   const refreshRecentRepos = useRecentReposStore((s) => s.refresh);
 
-  const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const prefillDone = useRef(false);
   const openPrefillDone = useRef(false);
-
-  const handleRepoChange = useCallback((value: string) => {
-    setTargetRepo(value);
-    if (!value.trim()) {
-      setRepoValid(null);
-      setRepoError(null);
-      setBranches([]);
-      setSourceBranch("");
-    }
-  }, []);
 
   // #386: the modal is always-mounted (`if (!open) return null` below), so its
   // useState survives a close. This one-shot, ref-gated effect resets the
@@ -179,11 +191,8 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
       setSelectedPipelineId("");
       setInput("");
       setOverrides({});
-      setTargetRepo("");
-      setRepoValid(null);
-      setRepoError(null);
-      setBranches([]);
-      setSourceBranch("");
+      resetRepo("");
+      clearBranches();
     };
 
     switch (openIntent.kind) {
@@ -206,15 +215,13 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
         setMode("trigger");
         setEditingTriggerId(trigger.id);
         setSelectedPipelineId(trigger.pipeline_id);
-        setTargetRepo(trigger.target_repo ?? "");
         // #470: reset the validity verdict with the field. The modal stays
         // mounted (#386), so a `repoValid === true` left over from a previous
         // open would survive next to an EMPTY repo field — reachable by opening
         // New Run with a valid repo, closing it, then editing a legacy Trigger
         // whose target repo is null. `canLaunch` would then be true with no
         // repo, which is exactly the case the daemon now 400s.
-        setRepoValid(null);
-        setRepoError(null);
+        resetRepo(trigger.target_repo ?? "");
         setSourceBranch(trigger.source_branch ?? "");
         setInput(trigger.input_template ?? "");
         setOverrides(
@@ -258,69 +265,6 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
       prefillDone.current = false;
     }
   }, [open, recentRepos, targetRepo, handleRepoChange, openIntent]);
-
-  useEffect(() => {
-    if (!open || !targetRepo.trim()) return;
-
-    clearTimeout(debounceRef.current);
-    debounceRef.current = setTimeout(async () => {
-      setRepoValidating(true);
-      setRepoError(null);
-      try {
-        const result = await validateRepo(targetRepo.trim());
-        setRepoValid(result.valid);
-        if (!result.valid) {
-          setRepoError(result.error ?? "Not a valid git repository");
-          setBranches([]);
-          setSourceBranch("");
-        } else {
-          setBranchesLoading(true);
-          try {
-            const branchList = await listBranches(targetRepo.trim());
-            setBranches(branchList);
-            // #454: re-select whenever the held branch is not one THIS repo has.
-            // The old `!sourceBranch` guard only ever seeded an empty field, so
-            // switching repos kept a branch the new one lacks — and a `<select>`
-            // whose value matches no option renders its FIRST option, so the field
-            // DISPLAYED `master` while the state still held `main`. The launch then
-            // failed with `branch 'main' does not exist`, blaming the daemon for a
-            // value the UI never showed. Testing membership instead subsumes the
-            // empty case and still preserves a deliberate choice the new repo honours.
-            if (branchList.length > 0 && !branchList.includes(sourceBranch)) {
-              const main = branchList.find((b) => b === "main")
-                ?? branchList.find((b) => b === "master")
-                ?? branchList[0];
-              setSourceBranch(main);
-            }
-          } catch {
-            setBranches([]);
-          } finally {
-            setBranchesLoading(false);
-          }
-        }
-      } catch {
-        setRepoValid(false);
-        setRepoError("Failed to validate repository");
-        setBranches([]);
-        setSourceBranch("");
-      } finally {
-        setRepoValidating(false);
-      }
-    }, 400);
-
-    return () => clearTimeout(debounceRef.current);
-  }, [targetRepo, open]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  const loadPipelines = useCallback(() => {
-    if (!open) return;
-    fetchPipelines()
-      .then((list) => setPipelines(list))
-      .catch(() => {});
-  }, [open]);
-
-  useEffect(() => {
-    loadPipelines();
-  }, [loadPipelines]);
 
   // #410: fetch instance settings on open — the `default_sandbox` label AND the
   // `sandbox_docker` availability probe arrive in one round-trip (the modal did not
@@ -398,24 +342,6 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
     setAutoName(isEdit ? openIntent.trigger.auto_name : settings!.default_auto_name.effective);
   }, [open, openIntent, settings]);
 
-  const repoPipelines = useMemo(
-    () => pipelines.filter((p) => p.scope === "repo"),
-    [pipelines],
-  );
-  const libraryPipelines = useMemo(
-    () => pipelines.filter((p) => p.scope === "library"),
-    [pipelines],
-  );
-  const userPipelines = useMemo(
-    () => pipelines.filter((p) => p.scope === "user"),
-    [pipelines],
-  );
-
-  const selectedPipeline = useMemo(
-    () => pipelines.find((p) => p.id === selectedPipelineId),
-    [pipelines, selectedPipelineId],
-  );
-
   // Auto-select first repo pipeline when available
   const shouldAutoSelect = open && repoValid && pipelines.length > 0 && !selectedPipelineId;
   if (shouldAutoSelect) {
@@ -430,14 +356,10 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
     );
   }, [selectedPipeline]);
 
-  const overrideCount = useMemo(() => {
-    if (!selectedPipeline) return 0;
-    return Object.entries(overrides).filter(([key, val]) => {
-      const decl = selectedPipeline.variables[key];
-      if (!decl) return false;
-      return val !== String(decl.default);
-    }).length;
-  }, [overrides, selectedPipeline]);
+  const overrideCount = useMemo(
+    () => newRunForm.overrideCount(overrides, selectedPipeline),
+    [overrides, selectedPipeline],
+  );
 
   const handlePipelineChange = useCallback(
     (value: string) => {
@@ -445,7 +367,7 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
       setOverrides({});
       setVarsOpen(false);
     },
-    [],
+    [setSelectedPipelineId],
   );
 
   const flushPendingSaves = useEditStore((s) => s.flushPendingSaves);
@@ -503,104 +425,52 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
     }
   }, [loadPipelines]);
 
-  // A prompt-optional pipeline (#158) may launch with an empty prompt; the
-  // entry node sources its own work. Prompt-required (the default) still demands
-  // non-empty input.
-  const promptOptional = selectedPipeline?.prompt_required === false;
-  const hasRequiredPrompt = promptOptional || Boolean(input.trim());
+  // Whether this pipeline may launch with an empty prompt (#158) — see `newRunForm`.
+  const promptOptional = newRunForm.promptOptional(selectedPipeline);
+  const hasRequiredPrompt = newRunForm.hasRequiredPrompt(promptOptional, input);
 
-  // #410: advisory Docker greying. Only gate the sandboxed options once we KNOW Docker is
-  // unavailable (settings loaded && probe false); while settings load, stay
-  // optimistic. `sandboxReason` explains the greying (title + help text).
-  const dockerUnavailable = settings != null && !settings.sandbox_docker.available;
-  const sandboxReason = settings?.sandbox_docker.reason ?? undefined;
-
-  // #432: the options come from the daemon's profile list. Sorted server-side.
-  const sandboxProfiles = settings?.sandbox_profiles ?? [];
-
-  /**
-   * THE PHANTOM-PROFILE RULE. A seeded value is **never** silently rewritten: a
-   * non-empty, non-`off` value that is absent from the list gets a tombstone option and
-   * blocks Save/Launch.
-   *
-   * Without the tombstone React sets `selectedIndex = -1`, the field renders blank, and
-   * saving would PATCH `sandbox: null` — a **silent fallback to the instance default**,
-   * exactly what ADR-0031 §7 forbids. Deliberately separate from the Docker clamp above:
-   * clamping to `off` is legitimate for an unavailable Docker, and would be a silent
-   * fallback for a missing profile.
-   */
-  const missingProfile = Boolean(
-    settings &&
-      sandbox &&
-      sandbox !== "off" &&
-      !sandboxProfiles.some((p) => p.name === sandbox),
+  // The sandbox selector's whole derived state (#410/#432/#452) — the Docker greying, the
+  // phantom-profile tombstone, the inherited default and the doomed-launch refusal.
+  // Memoized so its destructured fields (`missingProfile`, `sandboxDoomed`, …)
+  // are stable deps for the trigger memos below — a fresh object every render
+  // would otherwise trip `react-hooks/preserve-manual-memoization`. Pure over
+  // (settings, sandbox, mode), so the value is unchanged between recomputes.
+  const {
+    dockerUnavailable,
+    sandboxReason,
+    sandboxProfiles,
+    missingProfile,
+    instanceDefaultSandbox,
+    effectiveSandbox,
+    sandboxDoomed,
+    inheritedDefaultReason,
+  } = useMemo(
+    () => newRunForm.sandboxState({ settings, sandbox, mode }),
+    [settings, sandbox, mode],
   );
-
-  // #452: the instance default, used to LABEL the inherit option — never to seed the value.
-  // `null` while settings are unknown, which is the honest rendering: we do not know yet.
-  const instanceDefaultSandbox = settings ? (settings.default_sandbox.effective ?? "off") : null;
-
-  // #452: what will actually apply to the Run being created. `""` is not a value — it means
-  // the key is omitted and the instance default decides — so the checks below have to
-  // resolve it to say anything true about the Run.
-  const effectiveSandbox = sandbox === "" ? instanceDefaultSandbox : sandbox;
-
-  /**
-   * #452, the Docker clamp, relocated. A Run whose effective sandbox is a profile while the
-   * daemon reports Docker unavailable is born condemned, so #410 clamped the SELECTOR to
-   * `off`. That protection was right and is kept; the way it was applied was not — it wrote
-   * a business verdict into the field, indistinguishable from a user picking `off`, and
-   * posted it explicitly.
-   *
-   * So refuse the launch and say why, instead of quietly substituting an answer. Same rule
-   * as the phantom-profile tombstone above, for the same reason: the app never demotes a
-   * sandbox behind the user's back (ADR-0031 §7).
-   *
-   * Run mode only. A Trigger resolves its sandbox when it FIRES, and today's Docker probe
-   * says nothing about that moment.
-   */
-  const sandboxDoomed = Boolean(
-    mode === "run" && dockerUnavailable && effectiveSandbox && effectiveSandbox !== "off",
-  );
-
-  // #452: `default_sandbox` carries a `reason` when the winning tier names a profile that
-  // does not resolve. Inheriting is now the default path in run mode, so that dangling name
-  // is worth showing here — the create chokepoint 400s on it rather than falling back.
-  const inheritedDefaultReason = sandbox === "" ? (settings?.default_sandbox.reason ?? null) : null;
 
   const handleLaunch = useCallback(async () => {
     if (!repoValid || !selectedPipeline || !hasRequiredPrompt) return;
     setSubmitting(true);
     setError(null);
 
-    const variables: Record<string, unknown> = {};
-    for (const [key, val] of Object.entries(overrides)) {
-      const decl = selectedPipeline.variables[key];
-      if (!decl) continue;
-      if (val === String(decl.default)) continue;
-      variables[key] = parseVariableValue(val, decl.var_type);
-    }
+    const variables = newRunForm.buildVariables(overrides, selectedPipeline);
 
     try {
       await flushPendingSaves();
-      const resp = await createRun({
-        pipeline: selectedPipeline.name,
-        input: input.trim(),
-        variables,
-        pipeline_id: selectedPipeline.id,
-        target_repo: targetRepo.trim() || undefined,
-        source_branch: sourceBranch || undefined,
-        name: autoName ? undefined : runName.trim() || undefined,
-        // #338: always send the explicit choice so it wins the create-chokepoint
-        // resolution (the daemon never has to guess from `name` presence for a UI create).
-        auto_name: autoName,
-        // #410/#452: the explicit run-level choice — `off` or a staging profile name — sent
-        // so it wins the create-chokepoint precedence. `""` means the user did not choose,
-        // and OMITS the key: only an absent `sandbox` lets the daemon apply
-        // `default_sandbox`, because it reads a present `off` as final.
-        sandbox: sandbox || undefined,
-        images: images.length > 0 ? images : undefined,
-      });
+      const resp = await createRun(
+        newRunForm.buildRunPayload({
+          selectedPipeline,
+          input,
+          variables,
+          targetRepo,
+          sourceBranch,
+          autoName,
+          runName,
+          sandbox,
+          images,
+        }),
+      );
       onCreated(resp.run_id);
       refreshRecentRepos();
       setRunName("");
@@ -618,40 +488,57 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
     }
   }, [selectedPipeline, input, hasRequiredPrompt, overrides, onCreated, onClose, flushPendingSaves, repoValid, targetRepo, sourceBranch, autoName, runName, images, sandbox, settings, refreshRecentRepos]);
 
-  const canLaunch =
-    repoValid && selectedPipeline && hasRequiredPrompt && !missingProfile && !sandboxDoomed;
+  const canLaunch = newRunForm.canLaunch({
+    repoValid,
+    selectedPipeline,
+    hasRequiredPrompt,
+    missingProfile,
+    sandboxDoomed,
+  });
 
-  // The cron expression the Trigger will be created with: a compiled preset or
-  // the raw escape-hatch expression.
-  const resolvedCron =
-    cronPresetId === "custom"
-      ? rawCron.trim()
-      : presetToCron(cronPresetId, { hour: dailyHour, minute: dailyMinute });
+  // The cron the Trigger will be created with: a compiled preset, or the raw escape hatch.
+  // Memoized (like `selectedPipeline`/`overrideCount` above) so the compiler can
+  // keep it as a stable dep of `handleCreateTrigger` — an object-literal call
+  // result is otherwise a fresh value each render, which trips
+  // `react-hooks/preserve-manual-memoization`. Value is byte-identical to the
+  // former inline expression.
+  const resolvedCron = useMemo(
+    () => newRunForm.resolvedCron({ cronPresetId, rawCron, dailyHour, dailyMinute }),
+    [cronPresetId, rawCron, dailyHour, dailyMinute],
+  );
 
-  // The fire_decision reject rule, mirrored client-side: a prompt-required
-  // pipeline whose resolved input would be empty (no guard, no input template)
-  // is a misconfiguration. We pre-block Create and explain why, in addition to
-  // the authoritative server-side reject (CONTEXT.md → Trigger; #161).
-  const triggerInputRejectReason =
-    mode === "trigger" &&
-    selectedPipeline &&
-    !promptOptional &&
-    guardCommand.trim().length === 0 &&
-    input.trim().length === 0
-      ? "This pipeline requires a prompt. Add a guard command, an input template, or mark the pipeline prompt-not-required."
-      : null;
+  // The fire_decision reject rule, mirrored client-side (#161) — see `newRunForm`.
+  const triggerInputRejectReason = useMemo(
+    () =>
+      newRunForm.triggerInputRejectReason({
+        mode,
+        selectedPipeline,
+        promptOptional,
+        guardCommand,
+        input,
+      }),
+    [mode, selectedPipeline, promptOptional, guardCommand, input],
+  );
 
-  // Trigger creation needs a name, a pipeline, a valid repo and a cron, and a
-  // resolvable input when the pipeline requires a prompt.
-  const canCreateTrigger = Boolean(
-    repoValid &&
-      selectedPipeline &&
-      triggerName.trim().length > 0 &&
-      resolvedCron.length > 0 &&
-      !triggerInputRejectReason &&
-      // #432: a Trigger pointing at a vanished profile must not be re-saved as-is; the
-      // user picks a real one (or `off`) first.
-      !missingProfile,
+  // Name + pipeline + valid repo + cron + a resolvable input — see `newRunForm`.
+  const canCreateTrigger = useMemo(
+    () =>
+      newRunForm.canCreateTrigger({
+        repoValid,
+        selectedPipeline,
+        triggerName,
+        resolvedCron,
+        triggerInputRejectReason,
+        missingProfile,
+      }),
+    [
+      repoValid,
+      selectedPipeline,
+      triggerName,
+      resolvedCron,
+      triggerInputRejectReason,
+      missingProfile,
+    ],
   );
 
   const handleCreateTrigger = useCallback(async () => {
@@ -659,59 +546,28 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
     setSubmitting(true);
     setError(null);
 
-    const variables: Record<string, unknown> = {};
-    for (const [key, val] of Object.entries(overrides)) {
-      const decl = selectedPipeline.variables[key];
-      if (!decl) continue;
-      if (val === String(decl.default)) continue;
-      variables[key] = parseVariableValue(val, decl.var_type);
-    }
+    const variables = newRunForm.buildVariables(overrides, selectedPipeline);
+    const fields = {
+      selectedPipeline,
+      triggerName,
+      resolvedCron,
+      input,
+      guardCommand,
+      targetRepo,
+      sourceBranch,
+      allowOverlap,
+      maxConcurrent,
+      sandbox,
+      autoName,
+      variables,
+    };
 
     try {
       await flushPendingSaves();
       if (editingTriggerId) {
-        // Edit (#162): PATCH the existing Trigger's editable fields. `Some(None)`
-        // semantics: an emptied guard clears it. `pipeline_id` repoints the
-        // trigger to a different pipeline (#230) — previously the editable
-        // dropdown was a phantom control whose change was silently dropped.
-        await updateTrigger(editingTriggerId, {
-          name: triggerName.trim(),
-          pipeline_id: selectedPipeline.id,
-          cron: resolvedCron,
-          input_template: input.trim(),
-          guard_command: guardCommand.trim() || null,
-          target_repo: targetRepo.trim() || null,
-          source_branch: sourceBranch || null,
-          // Round-trip the real overlap policy (#239). Previously hard-coded to
-          // `undefined`, which silently reset every edited trigger toward skip.
-          // `null` clears a stale cap when overlap is off or the input is blank.
-          overlap_policy: allowOverlap ? "allow" : "skip",
-          max_concurrent: allowOverlap && maxConcurrent.trim() ? Number(maxConcurrent) : null,
-          // #410: `""` (Use instance default) clears back to inheriting (`null`);
-          // `off` or a staging profile name sets it.
-          sandbox: sandbox || null,
-          // #338: round-trip the auto-naming choice (flat bool, mirror of `enabled`).
-          auto_name: autoName,
-          variables,
-        });
+        await updateTrigger(editingTriggerId, newRunForm.buildTriggerUpdatePayload(fields));
       } else {
-        await createTrigger({
-          name: triggerName.trim(),
-          pipeline_id: selectedPipeline.id,
-          cron: resolvedCron,
-          input_template: input.trim() || undefined,
-          guard_command: guardCommand.trim() || undefined,
-          target_repo: targetRepo.trim() || undefined,
-          source_branch: sourceBranch || undefined,
-          overlap_policy: allowOverlap ? "allow" : "skip",
-          max_concurrent: allowOverlap && maxConcurrent.trim() ? Number(maxConcurrent) : undefined,
-          // #410: `""` (Use instance default) → `null` (inherit); `off` or a profile sets it.
-          sandbox: sandbox || null,
-          // #338: freeze the auto-naming choice on the new Trigger (seeded from the
-          // instance default when the modal opened).
-          auto_name: autoName,
-          variables,
-        });
+        await createTrigger(newRunForm.buildTriggerCreatePayload(fields));
       }
       onTriggerSaved?.();
       setTriggerName("");
@@ -768,10 +624,6 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
       setGuardTesting(false);
     }
   }, [guardCommand, targetRepo]);
-
-  let repoBorderClass = "border-line-strong focus:border-acc";
-  if (repoValid === true) repoBorderClass = "border-acc focus:border-acc";
-  else if (repoValid === false) repoBorderClass = "border-st-failed focus:border-st-failed";
 
   if (!open) return null;
 
@@ -1622,26 +1474,4 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
       </div>
     </div>
   );
-}
-
-function parseVariableValue(raw: string, varType: string): unknown {
-  switch (varType) {
-    case "int":
-      return parseInt(raw, 10) || 0;
-    case "float":
-      return parseFloat(raw) || 0;
-    case "bool":
-      return raw === "true";
-    case "list":
-      try {
-        return JSON.parse(raw);
-      } catch {
-        return raw
-          .replace(/^\[|\]$/g, "")
-          .split(",")
-          .map((s) => s.trim());
-      }
-    default:
-      return raw;
-  }
 }

--- a/frontend/src/components/NodeDetailPanel.tsx
+++ b/frontend/src/components/NodeDetailPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import {
   CheckCircle,
   AlertCircle,
@@ -10,20 +10,11 @@ import {
   Maximize2,
 } from "lucide-react";
 import type { IterationInfo, NodeState, NodeStatus } from "../types";
-import {
-  markNodeDone,
-  killNode,
-  restartNode,
-  startNode,
-  stopNode,
-  retryNode,
-  retryNodePreview,
-  fetchPrompt,
-  fetchNodeIO,
-  artifactUrl,
-} from "../api";
-import type { PortIO, FileInfo, MarkNodeDoneOutcome } from "../api";
+import { artifactUrl } from "../api";
+import type { PortIO, FileInfo } from "../api";
 import type { PortType } from "../types";
+import { useNodeRun } from "../hooks/useNodeRun";
+import type { MarkVerdict } from "../hooks/useNodeRun";
 import {
   ResizablePanelGroup,
   ResizablePanel,
@@ -50,21 +41,6 @@ const STATUS_LABELS: Record<NodeStatus, string> = {
   stale: "Stale",
 };
 
-function pollInterval(status: NodeStatus): number | null {
-  switch (status) {
-    case "running":
-    case "awaiting_user":
-    case "stale":
-      return 1000;
-    case "completed":
-    case "failed":
-    case "stopped":
-      return 5000;
-    case "pending":
-      return null;
-  }
-}
-
 interface Props {
   node: NodeState;
   runId: string;
@@ -81,19 +57,6 @@ interface Props {
 // An enum (not two orthogonal booleans) makes the illegal
 // `{minimized + expanded}` state unrepresentable.
 type TerminalView = "minimized" | "split" | "expanded";
-
-/**
- * What the last *Mark complete* click produced (#490, ADR-0035).
- *
- * `pending` exists so the verdict region always has a tenant: the handler no longer
- * clears before awaiting, so there is no window in which a previous verdict has been
- * erased and no new one written. `error` is the transport breakdown, which the
- * pre-#490 code swallowed into `console.error` and rendered as nothing.
- */
-type MarkVerdict =
-  | { kind: "pending" }
-  | MarkNodeDoneOutcome
-  | { kind: "error"; message: string };
 
 /**
  * Three tones, because the three answers demand three different reactions:
@@ -241,21 +204,7 @@ export default function NodeDetailPanel({
   nodeName,
   initialTerminalExpanded,
 }: Props) {
-  const [promptText, setPromptText] = useState<string | null>(null);
-  const [inputs, setInputs] = useState<PortIO[]>([]);
-  const [outputs, setOutputs] = useState<PortIO[]>([]);
   const [modal, setModal] = useState<ModalState | null>(null);
-  // #490: a VERDICT object, not `string[] | null`. The old shape was
-  // *structurally incapable* of expressing "refused for a reason that has no port
-  // list" — which is the bug: the transition guard's refusal ("resume the run
-  // first") arrived with an empty list and the banner was gated on `length > 0`, so
-  // the most frequent refusal of all rendered nothing.
-  //
-  // Scoped by `iter` on the `userSelectedIter` idiom of this file, which also kills
-  // a latent second bug: a verdict from iter 3 surviving a switch back to iter 1.
-  const [markVerdict, setMarkVerdict] = useState<
-    ({ iter: number } & MarkVerdict) | null
-  >(null);
   // Seed at mount only (no reactive effect on status): the issue trigger is
   // "clicking the node" (= selection / mount), not a live transition. A node
   // is `key`-ed by node_id at both mount sites, so selecting another terminated
@@ -270,9 +219,6 @@ export default function NodeDetailPanel({
     nodeId: string;
     iter: number;
   } | null>(null);
-  const [retryConfirm, setRetryConfirm] = useState<{
-    affectedCount: number;
-  } | null>(null);
 
   const selectedIter =
     userSelectedIter?.nodeId === node.node_id
@@ -286,9 +232,35 @@ export default function NodeDetailPanel({
     [node.node_id],
   );
 
+  // The retry handlers used to call `setTerminalView("split")` inline. The mode
+  // stays presentational state here; it travels into `useNodeRun` as a *stable*
+  // callback (`useCallback` with no deps, exactly as stable as the `setTerminalView`
+  // setter it replaces), so the retry callbacks keep the identity they had.
+  const showTerminalSplit = useCallback(() => setTerminalView("split"), []);
+
+  // Every read and command of this panel is iter-scoped, so the resolved
+  // `selectedIter` is an argument: the panel owns the IterSelector's state and the
+  // hook owns the orchestration. One owner, no second copy to keep in sync.
+  const {
+    promptText,
+    inputs,
+    outputs,
+    markVerdict,
+    retryConfirm,
+    stop,
+    retry,
+    confirmRetry,
+    cancelRetry,
+    start,
+    markComplete,
+    killStale,
+    restartStale,
+  } = useNodeRun(runId, node, selectedIter, {
+    isArchived,
+    onRetryStarted: showTerminalSplit,
+  });
+
   const sessionName = `pdo-${runId}-${node.node_id}-iter-${selectedIter}`;
-  const interval = pollInterval(node.status);
-  const isStaleIter = selectedIter !== node.iter;
   const hasMultipleIters = (node.iterations?.length ?? 0) > 1;
   const showTerminal = node.status !== "pending";
 
@@ -313,138 +285,6 @@ export default function NodeDetailPanel({
         }
       : { kind: "static", files: modal.files };
   }, [modal, node.iterations, node.node_id, selectedIter]);
-
-  // #315: the per-iter *rendered* prompt lives in the node's working dir, which
-  // is destroyed on archive and is not among the preserved set (ADR-0020 keeps
-  // artifacts + pipeline.yaml + pipeline.prompts/). So the fetch would always
-  // 404 for an archived run — skip it and show an honest note instead of a
-  // stuck "Loading prompt..." spinner.
-  const shouldFetchPrompt =
-    !isArchived && (node.status !== "pending" || isStaleIter);
-
-  useEffect(() => {
-    if (!shouldFetchPrompt) return;
-
-    let cancelled = false;
-
-    fetchPrompt(runId, node.node_id, selectedIter)
-      .then((text) => {
-        if (!cancelled) setPromptText(text);
-      })
-      .catch(() => {});
-
-    return () => {
-      cancelled = true;
-    };
-  }, [runId, node.node_id, selectedIter, shouldFetchPrompt]);
-
-  useEffect(() => {
-    const oneShot = isStaleIter || (interval === null && node.status === "pending");
-
-    if (oneShot) {
-      let cancelled = false;
-      fetchNodeIO(runId, node.node_id, selectedIter)
-        .then((io) => {
-          if (!cancelled) {
-            setInputs(io.inputs);
-            setOutputs(io.outputs);
-          }
-        })
-        .catch(() => {});
-      return () => {
-        cancelled = true;
-      };
-    }
-
-    if (interval === null) return;
-
-    let cancelled = false;
-
-    async function pollIO() {
-      try {
-        const io = await fetchNodeIO(runId, node.node_id, selectedIter);
-        if (!cancelled) {
-          setInputs(io.inputs);
-          setOutputs(io.outputs);
-        }
-      } catch {
-        // ignore
-      }
-    }
-
-    pollIO();
-    const timer = setInterval(pollIO, interval);
-    return () => {
-      cancelled = true;
-      clearInterval(timer);
-    };
-  }, [interval, node.node_id, selectedIter, runId, isStaleIter, node.status]);
-
-  const handleStop = useCallback(async () => {
-    try {
-      await stopNode(runId, node.node_id);
-    } catch {
-      // best-effort
-    }
-  }, [runId, node.node_id]);
-
-  const handleRetry = useCallback(async () => {
-    try {
-      const preview = await retryNodePreview(runId, node.node_id);
-      if (preview.affected_count > 0) {
-        setRetryConfirm({ affectedCount: preview.affected_count });
-        return; // not retried yet → leave terminalView untouched
-      }
-      await retryNode(runId, node.node_id);
-      // Session revives (status → running once refreshRun lands the NodeStarted
-      // event); re-show the terminal beside the details rather than full-frame.
-      setTerminalView("split");
-    } catch {
-      // best-effort
-    }
-  }, [runId, node.node_id]);
-
-  const handleRetryConfirmed = useCallback(async () => {
-    setRetryConfirm(null);
-    try {
-      await retryNode(runId, node.node_id);
-      setTerminalView("split");
-    } catch {
-      // best-effort
-    }
-  }, [runId, node.node_id]);
-
-  // #204: force-spawn a pending node out of dependency order. The daemon owns
-  // the run-status gate (a non-spawnable run returns 409), so a click on a
-  // pending node in a terminal run just no-ops with a caught error.
-  const handleStart = useCallback(async () => {
-    try {
-      await startNode(runId, node.node_id);
-    } catch {
-      // best-effort
-    }
-  }, [runId, node.node_id]);
-
-  const handleMarkComplete = useCallback(async () => {
-    // #490: NO `setMarkVerdict(null)` preamble. Clearing before awaiting is what
-    // made the banner flicker — on a lying `200` nothing was written back, so a
-    // verdict from a previous click vanished and never returned. The region always
-    // has a tenant: `pending` occupies it, and every exit writes a verdict.
-    const iter = selectedIter;
-    setMarkVerdict({ iter, kind: "pending" });
-    try {
-      const outcome: MarkNodeDoneOutcome = await markNodeDone(runId, node.node_id, iter);
-      setMarkVerdict({ iter, ...outcome });
-    } catch (e) {
-      // No longer swallowed into `console.error`: a POST that never lands must not
-      // look like a success.
-      setMarkVerdict({
-        iter,
-        kind: "error",
-        message: e instanceof Error ? e.message : String(e),
-      });
-    }
-  }, [runId, node.node_id, selectedIter]);
 
   return (
     <aside className="flex h-full flex-col bg-bg-2">
@@ -494,7 +334,7 @@ export default function NodeDetailPanel({
           <button
             data-testid="stop-btn"
             disabled={node.status !== "running"}
-            onClick={node.status === "running" ? handleStop : undefined}
+            onClick={node.status === "running" ? stop : undefined}
             className={
               node.status === "running"
                 ? "flex cursor-pointer items-center gap-1 rounded border border-st-failed/40 bg-st-failed/10 px-2 py-0.5 text-st-failed transition-colors hover:bg-st-failed/20"
@@ -508,7 +348,7 @@ export default function NodeDetailPanel({
           {node.status === "pending" && (
             <button
               data-testid="start-btn"
-              onClick={handleStart}
+              onClick={start}
               className={RETRY_BUTTON_CLASS}
               style={RETRY_BUTTON_STYLE}
             >
@@ -516,7 +356,7 @@ export default function NodeDetailPanel({
               Start
             </button>
           )}
-          <RetryPlayButton status={node.status} onClick={handleRetry} />
+          <RetryPlayButton status={node.status} onClick={retry} />
         </div>
       )}
 
@@ -560,9 +400,7 @@ export default function NodeDetailPanel({
             <div className="flex items-center gap-1">
               <button
                 data-testid="stale-stop-btn"
-                onClick={async () => {
-                  try { await killNode(runId, node.node_id, selectedIter); } catch { /* best-effort */ }
-                }}
+                onClick={killStale}
                 className="flex cursor-pointer items-center gap-1 rounded border border-st-stale/40 bg-st-stale/10 px-1.5 py-0.5 text-st-stale transition-colors hover:bg-st-stale/20"
                 style={{ fontSize: "10.5px", fontWeight: 500 }}
               >
@@ -571,9 +409,7 @@ export default function NodeDetailPanel({
               </button>
               <button
                 data-testid="stale-retry-btn"
-                onClick={async () => {
-                  try { await restartNode(runId, node.node_id, selectedIter); } catch { /* best-effort */ }
-                }}
+                onClick={restartStale}
                 className="flex cursor-pointer items-center gap-1 rounded border border-st-stale/40 bg-st-stale/10 px-1.5 py-0.5 text-st-stale transition-colors hover:bg-st-stale/20"
                 style={{ fontSize: "10.5px", fontWeight: 500 }}
               >
@@ -722,7 +558,7 @@ export default function NodeDetailPanel({
               {(node.status === "awaiting_user" || node.status === "running" || node.status === "failed" || node.status === "stale") && !isArchived && (
                 <>
                   <button
-                    onClick={handleMarkComplete}
+                    onClick={markComplete}
                     data-testid="mark-complete-btn"
                     className="flex w-full cursor-pointer items-center justify-center gap-1.5 rounded-md border border-st-done/40 bg-st-done-bg px-3 py-1.5 text-st-done transition-colors hover:border-st-done/60 hover:bg-st-done/20"
                     style={{ fontSize: "11.5px", fontWeight: 500 }}
@@ -859,7 +695,7 @@ export default function NodeDetailPanel({
         <div
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
           data-testid="retry-confirm-backdrop"
-          onClick={() => setRetryConfirm(null)}
+          onClick={cancelRetry}
         >
           <div
             className="w-[360px] rounded-lg border border-line bg-bg-2 p-4 shadow-lg"
@@ -877,7 +713,7 @@ export default function NodeDetailPanel({
             <div className="mt-4 flex justify-end gap-2">
               <button
                 data-testid="retry-confirm-cancel"
-                onClick={() => setRetryConfirm(null)}
+                onClick={cancelRetry}
                 className="rounded-md border border-line-strong bg-bg-3 px-3 py-1.5 text-fg-2 transition-colors hover:bg-bg-4"
                 style={{ fontSize: "11.5px" }}
               >
@@ -885,7 +721,7 @@ export default function NodeDetailPanel({
               </button>
               <button
                 data-testid="retry-confirm-ok"
-                onClick={handleRetryConfirmed}
+                onClick={confirmRetry}
                 className="rounded-md bg-accent px-3 py-1.5 text-white transition-colors hover:bg-accent/80"
                 style={{ fontSize: "11.5px" }}
               >

--- a/frontend/src/components/UnifiedLeftPanel.tsx
+++ b/frontend/src/components/UnifiedLeftPanel.tsx
@@ -1,13 +1,15 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { ChevronDown, ChevronRight, Copy, FileUp, Pause, Pencil, Play, Plus, RotateCcw, SquareTerminal, Star, Trash2, Zap } from "lucide-react";
+import { ChevronDown, ChevronRight, FileUp, Pause, Pencil, Play, Plus, RotateCcw, SquareTerminal, Trash2, Zap } from "lucide-react";
 import { isLiveRun, isTerminalRun, type RunListEntry, type RunStatus, type PipelineListEntry, type PipelineScope, type Trigger } from "../types";
 import type { LibraryPipelineEntry } from "../api";
 import { cleanupRun, createPipeline, deleteLibraryPipeline, duplicateLibraryPipeline, forgetRun, importWorkflow, openRunShell, pauseRun, renameRun, resumeRun, retryAll } from "../api";
 import { useEditStore } from "../stores/editStore";
 import { groupByRepo } from "../lib/groupByRepo";
+import { cascadableTwin, isStarred, libraryOnly } from "../lib/libraryTwins";
 import CleanupConfirmModal from "./CleanupConfirmModal";
 import ConfirmDeleteModal from "./ConfirmDeleteModal";
 import ForgetRunModal from "./ForgetRunModal";
+import LibraryRow from "./LibraryRow";
 import RunFilters from "./RunFilters";
 import { EMPTY_RUN_FILTER, runMatchesFilter } from "./runFilter";
 import RunShellModal from "./RunShellModal";
@@ -24,12 +26,6 @@ const STATUS_STYLES: Record<RunStatus, { dot: string }> = {
   halted: { dot: "bg-st-blocked" },
   paused: { dot: "bg-st-paused" },
   archived: { dot: "bg-st-archived" },
-};
-
-const SCOPE_BADGE: Record<PipelineScope, { label: string; cls: string }> = {
-  repo: { label: "repo", cls: "border-acc text-acc" },
-  user: { label: "user", cls: "border-st-await text-st-await" },
-  library: { label: "library", cls: "border-st-await text-st-await" },
 };
 
 interface Props {
@@ -175,19 +171,18 @@ export default function UnifiedLeftPanel({
 
   async function handleConfirmDelete(cascade: boolean) {
     if (!deleteTarget) return;
-    // Match on `name`, never id: the Library copy's id is an independently
-    // derived slug that can diverge from the repo pipeline's file-stem id, and
-    // the whole star/twin model is name-keyed (#227).
-    const twins = libraryPipelines.filter((lp) => lp.name === deleteTarget.name);
-    const cascadable = deleteTarget.scope !== "library" && twins.length === 1;
+    // The twin rule (name-keyed, unique-only) lives in `lib/libraryTwins` — the
+    // same call the checkbox's visibility uses, so what the user was offered and
+    // what runs here cannot drift (#227).
+    const twin = cascadableTwin(deleteTarget, libraryPipelines);
     try {
       // Forward scope so a `library` entry deletes from the library store, not
       // the same-named repo pipeline file (#216).
       await removePipeline(deleteTarget.id, deleteTarget.scope);
-      if (cascade && cascadable) {
+      if (cascade && twin) {
         // #227: also remove the durable Library copy the star created.
         try {
-          await deleteLibraryPipeline(twins[0].id);
+          await deleteLibraryPipeline(twin.id);
         } catch {
           /* non-fatal: the working pipeline is already gone */
         }
@@ -649,157 +644,61 @@ export default function UnifiedLeftPanel({
               No pipelines found
             </div>
           )}
-          {pipelines.map((p) => {
-            const badge = SCOPE_BADGE[p.scope];
-            const isSelected = p.id === activeTabId;
-            // A pipeline counts as "starred" when a library entry exists with
-            // the same name. This is the visible link the user expects when
-            // they click the canvas star: their pipeline gets a star badge
-            // here, confirming the action had effect.
-            const starred = libraryPipelines.some((lp) => lp.name === p.name);
-            return (
-              <button
-                key={`${p.scope}-${p.id}`}
-                onClick={() => openPipeline(p.id, p.scope)}
-                className={`group flex w-full cursor-pointer items-center gap-2 border-b border-line-soft px-3 py-2 text-left transition-colors ${
-                  isSelected ? "bg-bg-3 text-fg" : "text-fg-2 hover:bg-bg-3/50"
-                }`}
-                style={{ fontSize: "11.5px" }}
-              >
-                <div className="min-w-0 flex-1">
-                  <div className="flex items-center gap-1.5">
-                    {starred && (
-                      <Star
-                        size={10}
-                        className="shrink-0 fill-acc text-acc"
-                        data-testid="left-panel-star"
-                      />
-                    )}
-                    <span className="truncate font-medium">{p.name}</span>
-                  </div>
-                  <div
-                    className="mt-0.5 flex items-center gap-1.5 text-fg-4"
-                    style={{ fontSize: "10px" }}
-                  >
-                    <span>{p.node_count} nodes</span>
-                  </div>
-                </div>
-                <span
-                  className={`shrink-0 rounded border px-1 py-px group-hover:hidden ${badge.cls}`}
-                  style={{ fontSize: "9px", fontWeight: 500 }}
-                >
-                  {badge.label}
-                </span>
-                {/* #273: scope:"library" rows now appear here in block 1 (the
-                    /pipelines scope-merge from #216 means they no longer fall
-                    through to the library-only block below). Surface the same
-                    Copy affordance #224 shipped, gated on identity (scope), not
-                    the name-absence filter that block 2 uses. `p.id` is the HOME
-                    library file-stem — duplicateLibraryPipeline resolves it. */}
-                {p.scope === "library" && (
-                  <span
-                    className="hidden shrink-0 group-hover:inline-flex"
-                    data-testid="library-duplicate-button"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      handleDuplicate(p.id);
-                    }}
-                    role="button"
-                    title="Duplicate pipeline"
-                  >
-                    <Copy
-                      size={14}
-                      className="text-fg-4 transition-colors hover:text-acc"
-                    />
-                  </span>
-                )}
-                <span
-                  className="hidden shrink-0 group-hover:inline-flex"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    setDeleteTarget(p);
-                  }}
-                  role="button"
-                  title="Delete pipeline"
-                >
-                  <Trash2
-                    size={14}
-                    className="text-fg-4 transition-colors hover:text-st-failed"
-                  />
-                </span>
-              </button>
-            );
-          })}
+          {pipelines.map((p) => (
+            <LibraryRow
+              key={`${p.scope}-${p.id}`}
+              name={p.name}
+              scope={p.scope}
+              nodeCount={p.node_count}
+              // A pipeline counts as "starred" when a library entry exists with
+              // the same name. This is the visible link the user expects when
+              // they click the canvas star: their pipeline gets a star badge
+              // here, confirming the action had effect.
+              starred={isStarred(p, libraryPipelines)}
+              selected={p.id === activeTabId}
+              // #273: scope:"library" rows now appear here in block 1 (the
+              // /pipelines scope-merge from #216 means they no longer fall
+              // through to the library-only block below). Surface the same Copy
+              // affordance #224 shipped, gated on identity (scope), not the
+              // name-absence filter that block 2 uses. `p.id` is the HOME
+              // library file-stem — duplicateLibraryPipeline resolves it.
+              showDuplicate={p.scope === "library"}
+              onOpen={() => openPipeline(p.id, p.scope)}
+              onDuplicate={() => handleDuplicate(p.id)}
+              // Confirm-gated, because this row is a working pipeline file and
+              // the delete may cascade to its Library twin (#227).
+              onDelete={() => setDeleteTarget(p)}
+              deleteTitle="Delete pipeline"
+            />
+          ))}
           {/* Library-only entries (no matching name in /pipelines). These
               previously only showed up in the New Run dropdown — surfacing
               them here means starring a brand-new pipeline yields a visible
               entry in the sidebar, matching the user's mental model that
-              starred == in the library. */}
-          {libraryPipelines
-            .filter((lp) => !pipelines.some((p) => p.name === lp.name))
-            .map((lp) => (
-              <div
-                key={`lib-only-${lp.scope}-${lp.id}`}
-                className="group flex w-full items-center gap-2 border-b border-line-soft px-3 py-2 text-left text-fg-2 transition-colors hover:bg-bg-3/50"
-                style={{ fontSize: "11.5px" }}
-                data-testid="library-only-entry"
-              >
-                <div className="min-w-0 flex-1">
-                  <div className="flex items-center gap-1.5">
-                    <Star
-                      size={10}
-                      className="shrink-0 fill-acc text-acc"
-                      data-testid="left-panel-star"
-                    />
-                    <span className="truncate font-medium">{lp.name}</span>
-                  </div>
-                  <div
-                    className="mt-0.5 flex items-center gap-1.5 text-fg-4"
-                    style={{ fontSize: "10px" }}
-                  >
-                    <span>{lp.node_count} nodes</span>
-                  </div>
-                </div>
-                <span
-                  className={`shrink-0 rounded border px-1 py-px group-hover:hidden ${SCOPE_BADGE[lp.scope].cls}`}
-                  style={{ fontSize: "9px", fontWeight: 500 }}
-                >
-                  {SCOPE_BADGE[lp.scope].label}
-                </span>
-                <span
-                  className="hidden shrink-0 group-hover:inline-flex"
-                  data-testid="library-duplicate-button"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    handleDuplicate(lp.id);
-                  }}
-                  role="button"
-                  title="Duplicate pipeline"
-                >
-                  <Copy
-                    size={14}
-                    className="text-fg-4 transition-colors hover:text-acc"
-                  />
-                </span>
-                <span
-                  className="hidden shrink-0 group-hover:inline-flex"
-                  onClick={async (e) => {
-                    e.stopPropagation();
-                    try {
-                      await deleteLibraryPipeline(lp.id);
-                      onLibraryPipelinesChanged();
-                    } catch { /* ignore */ }
-                  }}
-                  role="button"
-                  title="Remove from library"
-                >
-                  <Trash2
-                    size={14}
-                    className="text-fg-4 transition-colors hover:text-st-failed"
-                  />
-                </span>
-              </div>
-            ))}
+              starred == in the library. No `onOpen`: there is no working
+              pipeline behind them to open. */}
+          {libraryOnly(libraryPipelines, pipelines).map((lp) => (
+            <LibraryRow
+              key={`lib-only-${lp.scope}-${lp.id}`}
+              name={lp.name}
+              scope={lp.scope}
+              nodeCount={lp.node_count}
+              // Unconditional: these rows come straight out of the library.
+              starred
+              showDuplicate
+              onDuplicate={() => handleDuplicate(lp.id)}
+              // Direct, no confirm modal: nothing cascades from a row that only
+              // exists in the library (#227 d).
+              onDelete={async () => {
+                try {
+                  await deleteLibraryPipeline(lp.id);
+                  onLibraryPipelinesChanged();
+                } catch { /* ignore */ }
+              }}
+              deleteTitle="Remove from library"
+              testId="library-only-entry"
+            />
+          ))}
         </div>
         </div>
       )}
@@ -836,28 +735,23 @@ export default function UnifiedLeftPanel({
         />
       )}
 
-      {(() => {
-        // Show the cascade checkbox only when the target has exactly one
-        // same-name Library copy and isn't itself the library row (#227).
-        const twins = deleteTarget
-          ? libraryPipelines.filter((lp) => lp.name === deleteTarget.name)
-          : [];
-        const cascadable =
-          deleteTarget != null &&
-          deleteTarget.scope !== "library" &&
-          twins.length === 1;
-        return (
-          <ConfirmDeleteModal
-            // Remount per target so the checkbox resets to OFF each open (#227).
-            key={deleteTarget?.id ?? "none"}
-            open={deleteTarget !== null}
-            onClose={() => setDeleteTarget(null)}
-            onConfirm={handleConfirmDelete}
-            name={deleteTarget?.name ?? ""}
-            cascadeLabel={cascadable ? "Also remove the Library copy" : undefined}
-          />
-        );
-      })()}
+      {/* Show the cascade checkbox only when the target has exactly one same-name
+          Library copy and isn't itself the library row (#227) — the SAME
+          `cascadableTwin` call `handleConfirmDelete` acts on, so the offer and
+          the deed can never disagree. */}
+      <ConfirmDeleteModal
+        // Remount per target so the checkbox resets to OFF each open (#227).
+        key={deleteTarget?.id ?? "none"}
+        open={deleteTarget !== null}
+        onClose={() => setDeleteTarget(null)}
+        onConfirm={handleConfirmDelete}
+        name={deleteTarget?.name ?? ""}
+        cascadeLabel={
+          cascadableTwin(deleteTarget, libraryPipelines)
+            ? "Also remove the Library copy"
+            : undefined
+        }
+      />
 
       {showNewModal && (
         <NewPipelineModal onClose={() => setShowNewModal(false)} />

--- a/frontend/src/hooks/useLaunchTargets.test.ts
+++ b/frontend/src/hooks/useLaunchTargets.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useLaunchTargets } from "./useLaunchTargets";
+import * as api from "../api";
+import type { PipelineListEntry } from "../types";
+
+vi.mock("../api", () => ({
+  fetchPipelines: vi.fn(),
+  listBranches: vi.fn(),
+}));
+
+function pipeline(over: Partial<PipelineListEntry> = {}): PipelineListEntry {
+  return {
+    id: "p1",
+    name: "Auditor",
+    scope: "repo",
+    path: "/repo/.pdo/pipelines/auditor.yaml",
+    node_count: 3,
+    modified: null,
+    variables: {},
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  vi.mocked(api.fetchPipelines).mockReset().mockResolvedValue([]);
+  vi.mocked(api.listBranches).mockReset().mockResolvedValue(["main", "dev", "feature-x"]);
+});
+
+function setup(open = true) {
+  return renderHook(({ open }: { open: boolean }) => useLaunchTargets(open), {
+    initialProps: { open },
+  });
+}
+
+describe("useLaunchTargets — the pipelines", () => {
+  it("fetches the list on open", async () => {
+    vi.mocked(api.fetchPipelines).mockResolvedValue([pipeline()]);
+    const { result } = setup();
+    await waitFor(() => expect(result.current.pipelines).toHaveLength(1));
+    expect(api.fetchPipelines).toHaveBeenCalledTimes(1);
+  });
+
+  it("fetches nothing while the dialog is closed", async () => {
+    const { result } = setup(false);
+    await act(async () => {});
+    expect(api.fetchPipelines).not.toHaveBeenCalled();
+    expect(result.current.pipelines).toEqual([]);
+  });
+
+  // The modal is always-mounted (#386), so a reopen has to re-read the list: a pipeline may
+  // have been added, promoted or edited while it was closed.
+  it("re-reads the list on every reopen", async () => {
+    const { rerender } = setup();
+    await waitFor(() => expect(api.fetchPipelines).toHaveBeenCalledTimes(1));
+    rerender({ open: false });
+    rerender({ open: true });
+    await waitFor(() => expect(api.fetchPipelines).toHaveBeenCalledTimes(2));
+  });
+
+  it("groups the list by scope, repo pipelines first", async () => {
+    vi.mocked(api.fetchPipelines).mockResolvedValue([
+      pipeline({ id: "lib", name: "Lib", scope: "library" }),
+      pipeline({ id: "repo", name: "Repo", scope: "repo" }),
+      pipeline({ id: "user", name: "User", scope: "user" }),
+    ]);
+    const { result } = setup();
+    await waitFor(() => expect(result.current.pipelines).toHaveLength(3));
+    expect(result.current.repoPipelines.map((p) => p.id)).toEqual(["repo"]);
+    expect(result.current.libraryPipelines.map((p) => p.id)).toEqual(["lib"]);
+    expect(result.current.userPipelines.map((p) => p.id)).toEqual(["user"]);
+  });
+
+  it("resolves the selected pipeline by id, and nothing while the id is unknown", async () => {
+    vi.mocked(api.fetchPipelines).mockResolvedValue([pipeline({ id: "p1" }), pipeline({ id: "p2" })]);
+    const { result } = setup();
+    await waitFor(() => expect(result.current.pipelines).toHaveLength(2));
+    expect(result.current.selectedPipeline).toBeUndefined();
+
+    act(() => result.current.setSelectedPipelineId("p2"));
+    expect(result.current.selectedPipeline?.id).toBe("p2");
+
+    // A pipeline that vanished from the list leaves no selection behind.
+    act(() => result.current.setSelectedPipelineId("gone"));
+    expect(result.current.selectedPipeline).toBeUndefined();
+  });
+
+  // A failed listing is not worth a dialog: the picker simply stays empty, which the modal
+  // already renders as "No pipelines found".
+  it("swallows a failed listing and leaves the picker empty", async () => {
+    vi.mocked(api.fetchPipelines).mockRejectedValue(new Error("daemon unreachable"));
+    const { result } = setup();
+    await act(async () => {});
+    expect(result.current.pipelines).toEqual([]);
+  });
+
+  // What the promote button calls: the star moves from "repo" to "library" server-side, so
+  // the list has to be re-read for it to show.
+  it("re-reads the list on demand", async () => {
+    const { result } = setup();
+    await waitFor(() => expect(api.fetchPipelines).toHaveBeenCalledTimes(1));
+    vi.mocked(api.fetchPipelines).mockResolvedValue([pipeline({ scope: "library" })]);
+    await act(async () => {
+      result.current.loadPipelines();
+    });
+    await waitFor(() => expect(result.current.libraryPipelines).toHaveLength(1));
+  });
+});
+
+describe("useLaunchTargets — the branches", () => {
+  async function load(
+    result: { current: ReturnType<typeof useLaunchTargets> },
+    repoPath: string,
+  ) {
+    await act(async () => {
+      await result.current.loadBranches(repoPath);
+    });
+  }
+
+  it("lists the target repo's branches", async () => {
+    const { result } = setup();
+    await load(result, "/home/user/project");
+    expect(api.listBranches).toHaveBeenCalledWith("/home/user/project");
+    expect(result.current.branches).toEqual(["main", "dev", "feature-x"]);
+    expect(result.current.branchesLoading).toBe(false);
+  });
+
+  it("flags the load while it is in flight", async () => {
+    let release!: (branches: string[]) => void;
+    vi.mocked(api.listBranches).mockReturnValue(
+      new Promise<string[]>((resolve) => {
+        release = resolve;
+      }),
+    );
+    const { result } = setup();
+    let pending!: Promise<void>;
+    act(() => {
+      pending = result.current.loadBranches("/home/user/project");
+    });
+    expect(result.current.branchesLoading).toBe(true);
+
+    await act(async () => {
+      release(["main"]);
+      await pending;
+    });
+    expect(result.current.branchesLoading).toBe(false);
+    expect(result.current.branches).toEqual(["main"]);
+  });
+
+  /**
+   * #454: the selection is re-made whenever the held branch is not one THIS repo has. The
+   * old `!sourceBranch` guard only ever seeded an empty field, so switching repos kept a
+   * branch the new one lacks — and a `<select>` whose value matches no option renders its
+   * FIRST option, so the field DISPLAYED `master` while the state still held `main`, and the
+   * launch failed with `branch 'main' does not exist`.
+   */
+  it("re-selects when the held branch is not one this repo has (#454)", async () => {
+    const { result } = setup();
+    await load(result, "/home/user/project-a");
+    expect(result.current.sourceBranch).toBe("main");
+
+    vi.mocked(api.listBranches).mockResolvedValue(["master"]);
+    await load(result, "/home/user/project-b");
+    expect(result.current.sourceBranch).toBe("master");
+  });
+
+  // The other half of #454: testing membership subsumes the empty case WITHOUT throwing
+  // away a deliberate choice the new repo honours.
+  it("keeps a deliberate choice the new repo still offers (#454)", async () => {
+    const { result } = setup();
+    await load(result, "/home/user/project-a");
+    act(() => result.current.setSourceBranch("feature-x"));
+
+    vi.mocked(api.listBranches).mockResolvedValue(["main", "feature-x"]);
+    await load(result, "/home/user/project-b");
+    expect(result.current.sourceBranch).toBe("feature-x");
+  });
+
+  it("prefers main, then master, then whatever comes first", async () => {
+    const { result } = setup();
+
+    vi.mocked(api.listBranches).mockResolvedValue(["dev", "master", "main"]);
+    await load(result, "/a");
+    expect(result.current.sourceBranch).toBe("main");
+
+    vi.mocked(api.listBranches).mockResolvedValue(["dev", "master"]);
+    await load(result, "/b");
+    expect(result.current.sourceBranch).toBe("master");
+
+    vi.mocked(api.listBranches).mockResolvedValue(["topic", "other"]);
+    await load(result, "/c");
+    expect(result.current.sourceBranch).toBe("topic");
+  });
+
+  it("re-selects nothing for a repo that lists no branch at all", async () => {
+    const { result } = setup();
+    await load(result, "/a");
+    expect(result.current.sourceBranch).toBe("main");
+
+    vi.mocked(api.listBranches).mockResolvedValue([]);
+    await load(result, "/b");
+    expect(result.current.branches).toEqual([]);
+    expect(result.current.sourceBranch).toBe("main");
+  });
+
+  it("empties the list when the listing fails", async () => {
+    const { result } = setup();
+    await load(result, "/a");
+    vi.mocked(api.listBranches).mockRejectedValue(new Error("not a git repository"));
+    await load(result, "/b");
+    expect(result.current.branches).toEqual([]);
+    expect(result.current.branchesLoading).toBe(false);
+  });
+
+  it("clearBranches drops the list and the selection together", async () => {
+    const { result } = setup();
+    await load(result, "/a");
+    expect(result.current.sourceBranch).toBe("main");
+
+    act(() => result.current.clearBranches());
+    expect(result.current.branches).toEqual([]);
+    expect(result.current.sourceBranch).toBe("");
+  });
+});

--- a/frontend/src/hooks/useLaunchTargets.ts
+++ b/frontend/src/hooks/useLaunchTargets.ts
@@ -1,0 +1,102 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { fetchPipelines, listBranches } from "../api";
+import type { PipelineListEntry } from "../types";
+
+/**
+ * What a Run/Trigger can be launched AGAINST (#359): the target repo's branches and the
+ * pipelines the instance serves. Both are lists the daemon owns, so both live here,
+ * behind the same hook the New Run modal drives.
+ *
+ * Branch loading is *called*, not reactive: `useRepoValidation` owns the debounce and the
+ * verdict, and hands the validated path over once — `loadBranches` on a valid repo,
+ * `clearBranches` on an invalid one. Keeping the two as callbacks (rather than an effect
+ * keyed on the verdict) preserves the single async chain the modal has always had: the
+ * repo is still "validating" while its branches load.
+ */
+export function useLaunchTargets(open: boolean) {
+  const [pipelines, setPipelines] = useState<PipelineListEntry[]>([]);
+  const [selectedPipelineId, setSelectedPipelineId] = useState("");
+  const [branches, setBranches] = useState<string[]>([]);
+  const [sourceBranch, setSourceBranch] = useState("");
+  const [branchesLoading, setBranchesLoading] = useState(false);
+
+  const clearBranches = useCallback(() => {
+    setBranches([]);
+    setSourceBranch("");
+  }, []);
+
+  const loadBranches = useCallback(
+    async (repoPath: string) => {
+      setBranchesLoading(true);
+      try {
+        const branchList = await listBranches(repoPath);
+        setBranches(branchList);
+        // #454: re-select whenever the held branch is not one THIS repo has.
+        // The old `!sourceBranch` guard only ever seeded an empty field, so
+        // switching repos kept a branch the new one lacks — and a `<select>`
+        // whose value matches no option renders its FIRST option, so the field
+        // DISPLAYED `master` while the state still held `main`. The launch then
+        // failed with `branch 'main' does not exist`, blaming the daemon for a
+        // value the UI never showed. Testing membership instead subsumes the
+        // empty case and still preserves a deliberate choice the new repo honours.
+        if (branchList.length > 0 && !branchList.includes(sourceBranch)) {
+          const main = branchList.find((b) => b === "main")
+            ?? branchList.find((b) => b === "master")
+            ?? branchList[0];
+          setSourceBranch(main);
+        }
+      } catch {
+        setBranches([]);
+      } finally {
+        setBranchesLoading(false);
+      }
+    },
+    [sourceBranch],
+  );
+
+  const loadPipelines = useCallback(() => {
+    if (!open) return;
+    fetchPipelines()
+      .then((list) => setPipelines(list))
+      .catch(() => {});
+  }, [open]);
+
+  useEffect(() => {
+    loadPipelines();
+  }, [loadPipelines]);
+
+  const repoPipelines = useMemo(
+    () => pipelines.filter((p) => p.scope === "repo"),
+    [pipelines],
+  );
+  const libraryPipelines = useMemo(
+    () => pipelines.filter((p) => p.scope === "library"),
+    [pipelines],
+  );
+  const userPipelines = useMemo(
+    () => pipelines.filter((p) => p.scope === "user"),
+    [pipelines],
+  );
+
+  const selectedPipeline = useMemo(
+    () => pipelines.find((p) => p.id === selectedPipelineId),
+    [pipelines, selectedPipelineId],
+  );
+
+  return {
+    pipelines,
+    repoPipelines,
+    libraryPipelines,
+    userPipelines,
+    selectedPipeline,
+    selectedPipelineId,
+    setSelectedPipelineId,
+    loadPipelines,
+    branches,
+    branchesLoading,
+    sourceBranch,
+    setSourceBranch,
+    loadBranches,
+    clearBranches,
+  };
+}

--- a/frontend/src/hooks/useNodeRun.test.ts
+++ b/frontend/src/hooks/useNodeRun.test.ts
@@ -1,0 +1,382 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useNodeRun } from "./useNodeRun";
+import * as api from "../api";
+import type { NodeIO } from "../api";
+import type { NodeState } from "../types";
+
+vi.mock("../api", () => ({
+  fetchPrompt: vi.fn(),
+  fetchNodeIO: vi.fn(),
+  markNodeDone: vi.fn(),
+  killNode: vi.fn(),
+  restartNode: vi.fn(),
+  startNode: vi.fn(),
+  stopNode: vi.fn(),
+  retryNode: vi.fn(),
+  retryNodePreview: vi.fn(),
+}));
+
+const IO: NodeIO = {
+  inputs: [{ port: "brief", repeated: false, files: [] }],
+  outputs: [{ port: "plan", repeated: false, files: [] }],
+};
+
+function makeNode(overrides?: Partial<NodeState>): NodeState {
+  return {
+    node_id: "n1",
+    status: "running",
+    iter: 1,
+    started_at: null,
+    completed_at: null,
+    failure_reason: null,
+    iterations: [],
+    ...overrides,
+  };
+}
+
+// `waitFor` needs a real clock, and every cadence assertion below needs a fake
+// one — so the promise queue is drained explicitly instead. Two turns: the API
+// promise resolves on the first, the state write lands on the second.
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+async function advance(ms: number) {
+  await act(async () => {
+    vi.advanceTimersByTime(ms);
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.mocked(api.fetchPrompt).mockReset().mockResolvedValue("PROMPT");
+  vi.mocked(api.fetchNodeIO).mockReset().mockResolvedValue(IO);
+  vi.mocked(api.markNodeDone).mockReset().mockResolvedValue({ kind: "completed" });
+  vi.mocked(api.retryNodePreview)
+    .mockReset()
+    .mockResolvedValue({ downstream: [], affected_count: 0, with_artifacts: [] });
+  vi.mocked(api.retryNode).mockReset().mockResolvedValue({ ok: true, iter: 2, invalidated: [] });
+  vi.mocked(api.stopNode).mockReset().mockResolvedValue(undefined);
+  vi.mocked(api.startNode).mockReset().mockResolvedValue({ ok: true, iter: 1 });
+  vi.mocked(api.killNode).mockReset().mockResolvedValue(undefined);
+  vi.mocked(api.restartNode).mockReset().mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("useNodeRun — prompt fetch (#315 archive guard)", () => {
+  it("fetches the prompt once for a live node", async () => {
+    const { result } = renderHook(() =>
+      useNodeRun("run-1", makeNode({ status: "running" }), 1, {}),
+    );
+    await flush();
+    expect(api.fetchPrompt).toHaveBeenCalledTimes(1);
+    expect(api.fetchPrompt).toHaveBeenCalledWith("run-1", "n1", 1);
+    expect(result.current.promptText).toBe("PROMPT");
+  });
+
+  it("never fetches the prompt for an archived run", async () => {
+    const { result } = renderHook(() =>
+      useNodeRun("run-1", makeNode({ status: "completed" }), 1, { isArchived: true }),
+    );
+    await flush();
+    expect(api.fetchPrompt).not.toHaveBeenCalled();
+    expect(result.current.promptText).toBeNull();
+  });
+
+  it("never fetches the prompt for a pending node, archived or not", async () => {
+    renderHook(() => useNodeRun("run-1", makeNode({ status: "pending" }), 1, {}));
+    await flush();
+    expect(api.fetchPrompt).not.toHaveBeenCalled();
+  });
+
+  it("does fetch the prompt of a past iteration of a pending node", async () => {
+    // A pending node with a stale iter selected: the iteration on screen HAS run,
+    // so its rendered prompt exists on disk.
+    renderHook(() => useNodeRun("run-1", makeNode({ status: "pending", iter: 3 }), 1, {}));
+    await flush();
+    expect(api.fetchPrompt).toHaveBeenCalledWith("run-1", "n1", 1);
+  });
+});
+
+describe("useNodeRun — IO reads", () => {
+  it("emits exactly ONE IO fetch and never polls for an archived pending node", async () => {
+    const { result } = renderHook(() =>
+      useNodeRun("run-1", makeNode({ status: "pending" }), 1, { isArchived: true }),
+    );
+    await flush();
+    expect(api.fetchNodeIO).toHaveBeenCalledTimes(1);
+    expect(result.current.inputs).toEqual(IO.inputs);
+    expect(result.current.outputs).toEqual(IO.outputs);
+
+    await advance(60_000);
+    expect(api.fetchNodeIO).toHaveBeenCalledTimes(1);
+  });
+
+  it("reads the IO of an archived non-pending node on the settled cadence (the guard is prompt-only)", async () => {
+    renderHook(() =>
+      useNodeRun("run-1", makeNode({ status: "completed" }), 1, { isArchived: true }),
+    );
+    await flush();
+    expect(api.fetchNodeIO).toHaveBeenCalledTimes(1);
+    await advance(5000);
+    expect(api.fetchNodeIO).toHaveBeenCalledTimes(2);
+  });
+
+  it("polls IO every 1000ms for a running node", async () => {
+    renderHook(() => useNodeRun("run-1", makeNode({ status: "running" }), 1, {}));
+    await flush();
+    expect(api.fetchNodeIO).toHaveBeenCalledTimes(1);
+
+    await advance(999);
+    expect(api.fetchNodeIO).toHaveBeenCalledTimes(1);
+    await advance(1);
+    expect(api.fetchNodeIO).toHaveBeenCalledTimes(2);
+    await advance(2000);
+    expect(api.fetchNodeIO).toHaveBeenCalledTimes(4);
+  });
+
+  it("polls IO every 1000ms for awaiting_user and stale too", async () => {
+    for (const status of ["awaiting_user", "stale"] as const) {
+      vi.mocked(api.fetchNodeIO).mockClear();
+      const { unmount } = renderHook(() =>
+        useNodeRun("run-1", makeNode({ status }), 1, {}),
+      );
+      await flush();
+      await advance(1000);
+      expect(api.fetchNodeIO, status).toHaveBeenCalledTimes(2);
+      unmount();
+    }
+  });
+
+  it("polls IO every 5000ms for a terminal node", async () => {
+    renderHook(() => useNodeRun("run-1", makeNode({ status: "completed" }), 1, {}));
+    await flush();
+    expect(api.fetchNodeIO).toHaveBeenCalledTimes(1);
+
+    await advance(4999);
+    expect(api.fetchNodeIO).toHaveBeenCalledTimes(1);
+    await advance(1);
+    expect(api.fetchNodeIO).toHaveBeenCalledTimes(2);
+  });
+
+  it("stops polling on unmount", async () => {
+    const { unmount } = renderHook(() =>
+      useNodeRun("run-1", makeNode({ status: "running" }), 1, {}),
+    );
+    await flush();
+    unmount();
+    await advance(5000);
+    expect(api.fetchNodeIO).toHaveBeenCalledTimes(1);
+  });
+
+  it("reads a past iteration once, without polling, even while the node runs", async () => {
+    renderHook(() => useNodeRun("run-1", makeNode({ status: "running", iter: 4 }), 2, {}));
+    await flush();
+    expect(api.fetchNodeIO).toHaveBeenCalledTimes(1);
+    expect(api.fetchNodeIO).toHaveBeenCalledWith("run-1", "n1", 2);
+
+    await advance(10_000);
+    expect(api.fetchNodeIO).toHaveBeenCalledTimes(1);
+  });
+
+  it("refetches when the selected iteration changes", async () => {
+    const { rerender } = renderHook(
+      ({ iter }) => useNodeRun("run-1", makeNode({ status: "running", iter: 3 }), iter, {}),
+      { initialProps: { iter: 3 } },
+    );
+    await flush();
+    expect(api.fetchNodeIO).toHaveBeenLastCalledWith("run-1", "n1", 3);
+
+    rerender({ iter: 1 });
+    await flush();
+    expect(api.fetchNodeIO).toHaveBeenLastCalledWith("run-1", "n1", 1);
+  });
+});
+
+describe("useNodeRun — mark complete (#490)", () => {
+  it("occupies the verdict region with `pending` while the call is in flight", async () => {
+    // Never settles: the point is that the region has a tenant DURING the call,
+    // which is what killed the pre-#490 flicker.
+    vi.mocked(api.markNodeDone).mockReturnValue(new Promise<never>(() => {}));
+    const { result } = renderHook(() =>
+      useNodeRun("run-1", makeNode({ status: "awaiting_user", iter: 3 }), 3, {}),
+    );
+    await flush();
+
+    await act(async () => {
+      result.current.markComplete();
+    });
+    expect(result.current.markVerdict).toEqual({ iter: 3, kind: "pending" });
+  });
+
+  it("stamps the verdict with the SELECTED iter, not node.iter", async () => {
+    const { result } = renderHook(() =>
+      useNodeRun("run-1", makeNode({ status: "awaiting_user", iter: 4 }), 2, {}),
+    );
+    await flush();
+
+    await act(async () => {
+      await result.current.markComplete();
+    });
+    expect(api.markNodeDone).toHaveBeenCalledWith("run-1", "n1", 2);
+    expect(result.current.markVerdict).toEqual({ iter: 2, kind: "completed" });
+  });
+
+  it("carries a refusal verdict through verbatim", async () => {
+    vi.mocked(api.markNodeDone).mockResolvedValue({
+      kind: "refused",
+      slug: "missing_outputs",
+      recoverable: true,
+      message: "outputs missing",
+      missing: ["plan"],
+      violations: [],
+      body: null,
+    });
+    const { result } = renderHook(() =>
+      useNodeRun("run-1", makeNode({ status: "awaiting_user" }), 1, {}),
+    );
+    await flush();
+
+    await act(async () => {
+      await result.current.markComplete();
+    });
+    expect(result.current.markVerdict).toMatchObject({
+      iter: 1,
+      kind: "refused",
+      slug: "missing_outputs",
+      recoverable: true,
+      missing: ["plan"],
+    });
+  });
+
+  it("turns a transport breakdown into an `error` verdict instead of swallowing it", async () => {
+    vi.mocked(api.markNodeDone).mockRejectedValue(new Error("boom"));
+    const { result } = renderHook(() =>
+      useNodeRun("run-1", makeNode({ status: "awaiting_user" }), 1, {}),
+    );
+    await flush();
+
+    await act(async () => {
+      await result.current.markComplete();
+    });
+    expect(result.current.markVerdict).toEqual({ iter: 1, kind: "error", message: "boom" });
+  });
+});
+
+describe("useNodeRun — commands", () => {
+  it("stops and starts the node by id", async () => {
+    const { result } = renderHook(() =>
+      useNodeRun("run-1", makeNode({ status: "running" }), 1, {}),
+    );
+    await flush();
+
+    await act(async () => {
+      await result.current.stop();
+      await result.current.start();
+    });
+    expect(api.stopNode).toHaveBeenCalledWith("run-1", "n1");
+    expect(api.startNode).toHaveBeenCalledWith("run-1", "n1");
+  });
+
+  it("swallows a command failure (best-effort)", async () => {
+    vi.mocked(api.stopNode).mockRejectedValue(new Error("409"));
+    const { result } = renderHook(() =>
+      useNodeRun("run-1", makeNode({ status: "running" }), 1, {}),
+    );
+    await flush();
+
+    await act(async () => {
+      await expect(result.current.stop()).resolves.toBeUndefined();
+    });
+  });
+
+  it("sends the stale-banner actions scoped to the SELECTED iter", async () => {
+    const { result } = renderHook(() =>
+      useNodeRun("run-1", makeNode({ status: "stale", iter: 5 }), 2, {}),
+    );
+    await flush();
+
+    await act(async () => {
+      await result.current.killStale();
+      await result.current.restartStale();
+    });
+    expect(api.killNode).toHaveBeenCalledWith("run-1", "n1", 2);
+    expect(api.restartNode).toHaveBeenCalledWith("run-1", "n1", 2);
+  });
+});
+
+describe("useNodeRun — retry", () => {
+  it("retries straight away when nothing downstream is affected, and signals the retry", async () => {
+    const onRetryStarted = vi.fn();
+    const { result } = renderHook(() =>
+      useNodeRun("run-1", makeNode({ status: "running" }), 1, { onRetryStarted }),
+    );
+    await flush();
+
+    await act(async () => {
+      await result.current.retry();
+    });
+    expect(api.retryNode).toHaveBeenCalledWith("run-1", "n1");
+    expect(result.current.retryConfirm).toBeNull();
+    expect(onRetryStarted).toHaveBeenCalledTimes(1);
+  });
+
+  it("asks for confirmation instead, and does NOT signal a retry that has not happened", async () => {
+    vi.mocked(api.retryNodePreview).mockResolvedValue({
+      downstream: ["b", "c"],
+      affected_count: 2,
+      with_artifacts: ["b"],
+    });
+    const onRetryStarted = vi.fn();
+    const { result } = renderHook(() =>
+      useNodeRun("run-1", makeNode({ status: "running" }), 1, { onRetryStarted }),
+    );
+    await flush();
+
+    await act(async () => {
+      await result.current.retry();
+    });
+    expect(result.current.retryConfirm).toEqual({ affectedCount: 2 });
+    expect(api.retryNode).not.toHaveBeenCalled();
+    expect(onRetryStarted).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await result.current.confirmRetry();
+    });
+    expect(result.current.retryConfirm).toBeNull();
+    expect(api.retryNode).toHaveBeenCalledWith("run-1", "n1");
+    expect(onRetryStarted).toHaveBeenCalledTimes(1);
+  });
+
+  it("drops the confirmation without retrying on cancel", async () => {
+    vi.mocked(api.retryNodePreview).mockResolvedValue({
+      downstream: ["b"],
+      affected_count: 1,
+      with_artifacts: [],
+    });
+    const { result } = renderHook(() =>
+      useNodeRun("run-1", makeNode({ status: "running" }), 1, {}),
+    );
+    await flush();
+
+    await act(async () => {
+      await result.current.retry();
+    });
+    expect(result.current.retryConfirm).toEqual({ affectedCount: 1 });
+
+    await act(async () => {
+      result.current.cancelRetry();
+    });
+    expect(result.current.retryConfirm).toBeNull();
+    expect(api.retryNode).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/useNodeRun.ts
+++ b/frontend/src/hooks/useNodeRun.ts
@@ -1,0 +1,263 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  markNodeDone,
+  killNode,
+  restartNode,
+  startNode,
+  stopNode,
+  retryNode,
+  retryNodePreview,
+  fetchPrompt,
+  fetchNodeIO,
+} from "../api";
+import type { PortIO, MarkNodeDoneOutcome } from "../api";
+import type { NodeState, NodeStatus } from "../types";
+
+function pollInterval(status: NodeStatus): number | null {
+  switch (status) {
+    case "running":
+    case "awaiting_user":
+    case "stale":
+      return 1000;
+    case "completed":
+    case "failed":
+    case "stopped":
+      return 5000;
+    case "pending":
+      return null;
+  }
+}
+
+/**
+ * What the last *Mark complete* click produced (#490, ADR-0035).
+ *
+ * `pending` exists so the verdict region always has a tenant: the handler no longer
+ * clears before awaiting, so there is no window in which a previous verdict has been
+ * erased and no new one written. `error` is the transport breakdown, which the
+ * pre-#490 code swallowed into `console.error` and rendered as nothing.
+ */
+export type MarkVerdict =
+  | { kind: "pending" }
+  | MarkNodeDoneOutcome
+  | { kind: "error"; message: string };
+
+export interface UseNodeRunOptions {
+  isArchived?: boolean;
+  /**
+   * Fired once a retry has actually been sent (#346 seam). The terminal inset's
+   * display mode stays presentational state in `NodeDetailPanel`, but a retry
+   * revives the session and must re-show the terminal beside the details — so
+   * the flip travels back out as a callback instead of dragging `terminalView`
+   * into this hook. NOT called on the confirm-dialog path, where nothing has
+   * been retried yet.
+   */
+  onRetryStarted?: () => void;
+}
+
+/**
+ * Run-command orchestration for one node of one run: the per-iter prompt and IO
+ * reads, plus every command the node detail panel can send (stop / retry /
+ * start / mark complete, and the two stale-banner actions).
+ *
+ * `selectedIter` is an **argument, not state**. It is both an orchestration
+ * input (every read and `mark_node_done` is iter-scoped) and the IterSelector's
+ * UI state; the panel owns the selector (`userSelectedIter`, which falls back to
+ * `node.iter` when the selection belongs to another node) and passes the
+ * resolved iter down, so there is exactly one owner and no second copy to keep
+ * in sync.
+ *
+ * The archive guard gates the **prompt fetch only** (#315): the IO effect never
+ * looks at `isArchived`, so an archived node still reports its preserved
+ * artifacts — one-shot for a pending one, on the `pollInterval` cadence
+ * otherwise.
+ */
+export function useNodeRun(
+  runId: string,
+  node: NodeState,
+  selectedIter: number,
+  { isArchived, onRetryStarted }: UseNodeRunOptions,
+) {
+  const [promptText, setPromptText] = useState<string | null>(null);
+  const [inputs, setInputs] = useState<PortIO[]>([]);
+  const [outputs, setOutputs] = useState<PortIO[]>([]);
+  // #490: a VERDICT object, not `string[] | null`. The old shape was
+  // *structurally incapable* of expressing "refused for a reason that has no port
+  // list" — which is the bug: the transition guard's refusal ("resume the run
+  // first") arrived with an empty list and the banner was gated on `length > 0`, so
+  // the most frequent refusal of all rendered nothing.
+  //
+  // Scoped by `iter` on the `userSelectedIter` idiom of the detail panel, which also
+  // kills a latent second bug: a verdict from iter 3 surviving a switch back to iter 1.
+  const [markVerdict, setMarkVerdict] = useState<
+    ({ iter: number } & MarkVerdict) | null
+  >(null);
+  const [retryConfirm, setRetryConfirm] = useState<{
+    affectedCount: number;
+  } | null>(null);
+
+  const interval = pollInterval(node.status);
+  const isStaleIter = selectedIter !== node.iter;
+
+  // #315: the per-iter *rendered* prompt lives in the node's working dir, which
+  // is destroyed on archive and is not among the preserved set (ADR-0020 keeps
+  // artifacts + pipeline.yaml + pipeline.prompts/). So the fetch would always
+  // 404 for an archived run — skip it and show an honest note instead of a
+  // stuck "Loading prompt..." spinner.
+  const shouldFetchPrompt =
+    !isArchived && (node.status !== "pending" || isStaleIter);
+
+  useEffect(() => {
+    if (!shouldFetchPrompt) return;
+
+    let cancelled = false;
+
+    fetchPrompt(runId, node.node_id, selectedIter)
+      .then((text) => {
+        if (!cancelled) setPromptText(text);
+      })
+      .catch(() => {});
+
+    return () => {
+      cancelled = true;
+    };
+  }, [runId, node.node_id, selectedIter, shouldFetchPrompt]);
+
+  useEffect(() => {
+    const oneShot = isStaleIter || (interval === null && node.status === "pending");
+
+    if (oneShot) {
+      let cancelled = false;
+      fetchNodeIO(runId, node.node_id, selectedIter)
+        .then((io) => {
+          if (!cancelled) {
+            setInputs(io.inputs);
+            setOutputs(io.outputs);
+          }
+        })
+        .catch(() => {});
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    if (interval === null) return;
+
+    let cancelled = false;
+
+    async function pollIO() {
+      try {
+        const io = await fetchNodeIO(runId, node.node_id, selectedIter);
+        if (!cancelled) {
+          setInputs(io.inputs);
+          setOutputs(io.outputs);
+        }
+      } catch {
+        // ignore
+      }
+    }
+
+    pollIO();
+    const timer = setInterval(pollIO, interval);
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+    };
+  }, [interval, node.node_id, selectedIter, runId, isStaleIter, node.status]);
+
+  const stop = useCallback(async () => {
+    try {
+      await stopNode(runId, node.node_id);
+    } catch {
+      // best-effort
+    }
+  }, [runId, node.node_id]);
+
+  const retry = useCallback(async () => {
+    try {
+      const preview = await retryNodePreview(runId, node.node_id);
+      if (preview.affected_count > 0) {
+        setRetryConfirm({ affectedCount: preview.affected_count });
+        return; // not retried yet → leave terminalView untouched
+      }
+      await retryNode(runId, node.node_id);
+      // Session revives (status → running once refreshRun lands the NodeStarted
+      // event); re-show the terminal beside the details rather than full-frame.
+      onRetryStarted?.();
+    } catch {
+      // best-effort
+    }
+  }, [runId, node.node_id, onRetryStarted]);
+
+  const confirmRetry = useCallback(async () => {
+    setRetryConfirm(null);
+    try {
+      await retryNode(runId, node.node_id);
+      onRetryStarted?.();
+    } catch {
+      // best-effort
+    }
+  }, [runId, node.node_id, onRetryStarted]);
+
+  const cancelRetry = useCallback(() => {
+    setRetryConfirm(null);
+  }, []);
+
+  // #204: force-spawn a pending node out of dependency order. The daemon owns
+  // the run-status gate (a non-spawnable run returns 409), so a click on a
+  // pending node in a terminal run just no-ops with a caught error.
+  const start = useCallback(async () => {
+    try {
+      await startNode(runId, node.node_id);
+    } catch {
+      // best-effort
+    }
+  }, [runId, node.node_id]);
+
+  const markComplete = useCallback(async () => {
+    // #490: NO `setMarkVerdict(null)` preamble. Clearing before awaiting is what
+    // made the banner flicker — on a lying `200` nothing was written back, so a
+    // verdict from a previous click vanished and never returned. The region always
+    // has a tenant: `pending` occupies it, and every exit writes a verdict.
+    const iter = selectedIter;
+    setMarkVerdict({ iter, kind: "pending" });
+    try {
+      const outcome: MarkNodeDoneOutcome = await markNodeDone(runId, node.node_id, iter);
+      setMarkVerdict({ iter, ...outcome });
+    } catch (e) {
+      // No longer swallowed into `console.error`: a POST that never lands must not
+      // look like a success.
+      setMarkVerdict({
+        iter,
+        kind: "error",
+        message: e instanceof Error ? e.message : String(e),
+      });
+    }
+  }, [runId, node.node_id, selectedIter]);
+
+  // The two stale-banner actions (ADR-0032 §1: historical runs only). Iter-scoped
+  // like the reads — the banner acts on the iteration on screen, not on
+  // `node.iter`.
+  const killStale = useCallback(async () => {
+    try { await killNode(runId, node.node_id, selectedIter); } catch { /* best-effort */ }
+  }, [runId, node.node_id, selectedIter]);
+
+  const restartStale = useCallback(async () => {
+    try { await restartNode(runId, node.node_id, selectedIter); } catch { /* best-effort */ }
+  }, [runId, node.node_id, selectedIter]);
+
+  return {
+    promptText,
+    inputs,
+    outputs,
+    markVerdict,
+    retryConfirm,
+    stop,
+    retry,
+    confirmRetry,
+    cancelRetry,
+    start,
+    markComplete,
+    killStale,
+    restartStale,
+  };
+}

--- a/frontend/src/hooks/useRepoValidation.test.ts
+++ b/frontend/src/hooks/useRepoValidation.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useRepoValidation } from "./useRepoValidation";
+import * as api from "../api";
+
+vi.mock("../api", () => ({
+  validateRepo: vi.fn(),
+}));
+
+const REPO = "/home/user/project";
+/** The debounce the field has always used. */
+const DEBOUNCE_MS = 400;
+
+beforeEach(() => {
+  vi.mocked(api.validateRepo).mockReset().mockResolvedValue({ valid: true });
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+function setup(
+  open = true,
+  loadBranches = vi.fn<(repoPath: string) => Promise<void>>(async () => {}),
+) {
+  const clearBranches = vi.fn<() => void>();
+  const rendered = renderHook(
+    ({ open }: { open: boolean }) => useRepoValidation({ open, loadBranches, clearBranches }),
+    { initialProps: { open } },
+  );
+  return { ...rendered, loadBranches, clearBranches };
+}
+
+/** Let the debounce fire and its whole async chain settle. */
+async function settle(ms = DEBOUNCE_MS) {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms);
+  });
+}
+
+describe("useRepoValidation — the debounced verdict", () => {
+  it("does not validate anything while the dialog is closed", async () => {
+    const { result } = setup(false);
+    act(() => result.current.handleRepoChange(REPO));
+    await settle();
+    expect(api.validateRepo).not.toHaveBeenCalled();
+  });
+
+  it("does not validate a blank path", async () => {
+    const { result } = setup();
+    act(() => result.current.handleRepoChange("   "));
+    await settle();
+    expect(api.validateRepo).not.toHaveBeenCalled();
+  });
+
+  it("waits out the debounce before asking the daemon", async () => {
+    const { result } = setup();
+    act(() => result.current.handleRepoChange(REPO));
+    await settle(DEBOUNCE_MS - 1);
+    expect(api.validateRepo).not.toHaveBeenCalled();
+    await settle(1);
+    expect(api.validateRepo).toHaveBeenCalledTimes(1);
+  });
+
+  // Typing is a stream of values; only the one the user stopped on is worth a round-trip.
+  it("collapses a burst of keystrokes into one request for the settled value", async () => {
+    const { result } = setup();
+    act(() => result.current.handleRepoChange("/home"));
+    await settle(100);
+    act(() => result.current.handleRepoChange("/home/user"));
+    await settle(100);
+    act(() => result.current.handleRepoChange(REPO));
+    await settle();
+    expect(api.validateRepo).toHaveBeenCalledTimes(1);
+    expect(api.validateRepo).toHaveBeenCalledWith(REPO);
+  });
+
+  it("validates the trimmed path", async () => {
+    const { result } = setup();
+    act(() => result.current.handleRepoChange(`  ${REPO}  `));
+    await settle();
+    expect(api.validateRepo).toHaveBeenCalledWith(REPO);
+  });
+
+  it("drops a pending request when the dialog closes", async () => {
+    const { result, rerender } = setup();
+    act(() => result.current.handleRepoChange(REPO));
+    await settle(100);
+    rerender({ open: false });
+    await settle();
+    expect(api.validateRepo).not.toHaveBeenCalled();
+  });
+});
+
+describe("useRepoValidation — handing over to the branch loader", () => {
+  it("hands a valid repo, trimmed, to the branch loader", async () => {
+    const { result, loadBranches, clearBranches } = setup();
+    act(() => result.current.handleRepoChange(`  ${REPO}  `));
+    await settle();
+    expect(result.current.repoValid).toBe(true);
+    expect(result.current.repoError).toBeNull();
+    expect(loadBranches).toHaveBeenCalledWith(REPO);
+    expect(clearBranches).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The single async chain the modal has always had: branches load INSIDE the validation,
+   * so the field stays busy until the list it gates has landed. A branch list arriving
+   * after the spinner stopped would let the user launch against a stale branch — the #454
+   * family.
+   */
+  it("keeps the field validating until the branches have landed", async () => {
+    let release!: () => void;
+    const pending = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const { result } = setup(true, vi.fn<(repoPath: string) => Promise<void>>(() => pending));
+    act(() => result.current.handleRepoChange(REPO));
+    await settle();
+
+    expect(result.current.repoValid).toBe(true);
+    expect(result.current.repoValidating).toBe(true);
+
+    await act(async () => {
+      release();
+      // Flush the microtask queue so the loader's continuation — and its `finally` — run.
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(result.current.repoValidating).toBe(false);
+  });
+
+  it("rejects an invalid repo with the daemon's reason and drops the branches", async () => {
+    vi.mocked(api.validateRepo).mockResolvedValue({ valid: false, error: "not a git repository" });
+    const { result, loadBranches, clearBranches } = setup();
+    act(() => result.current.handleRepoChange(REPO));
+    await settle();
+    expect(result.current.repoValid).toBe(false);
+    expect(result.current.repoError).toBe("not a git repository");
+    expect(clearBranches).toHaveBeenCalled();
+    expect(loadBranches).not.toHaveBeenCalled();
+  });
+
+  it("falls back to a generic reason when the daemon names none", async () => {
+    vi.mocked(api.validateRepo).mockResolvedValue({ valid: false });
+    const { result } = setup();
+    act(() => result.current.handleRepoChange(REPO));
+    await settle();
+    expect(result.current.repoError).toBe("Not a valid git repository");
+  });
+
+  it("reads a failed request as an invalid repo rather than leaving the verdict open", async () => {
+    vi.mocked(api.validateRepo).mockRejectedValue(new Error("daemon unreachable"));
+    const { result, clearBranches } = setup();
+    act(() => result.current.handleRepoChange(REPO));
+    await settle();
+    expect(result.current.repoValid).toBe(false);
+    expect(result.current.repoError).toBe("Failed to validate repository");
+    expect(result.current.repoValidating).toBe(false);
+    expect(clearBranches).toHaveBeenCalled();
+  });
+});
+
+describe("useRepoValidation — clearing the verdict", () => {
+  it("clears the verdict and the branches when the field is emptied", async () => {
+    const { result, clearBranches } = setup();
+    act(() => result.current.handleRepoChange(REPO));
+    await settle();
+    expect(result.current.repoValid).toBe(true);
+
+    act(() => result.current.handleRepoChange(""));
+    expect(result.current.targetRepo).toBe("");
+    expect(result.current.repoValid).toBeNull();
+    expect(result.current.repoError).toBeNull();
+    expect(clearBranches).toHaveBeenCalled();
+  });
+
+  // Retyping over a valid path keeps the old verdict until the new one resolves; only an
+  // EMPTY field is an immediate "nothing chosen".
+  it("keeps the standing verdict while a non-empty path is being retyped", async () => {
+    const { result } = setup();
+    act(() => result.current.handleRepoChange(REPO));
+    await settle();
+    act(() => result.current.handleRepoChange(`${REPO}-b`));
+    expect(result.current.repoValid).toBe(true);
+  });
+
+  /**
+   * #470: `resetRepo` points the field somewhere new AND throws the verdict away. The
+   * modal is always-mounted (#386), so a `repoValid === true` surviving a close would
+   * otherwise sit next to a repo nobody validated — and `canLaunch` would say yes to the
+   * request the daemon answers 400 to.
+   */
+  it("resetRepo re-points the field and drops the verdict (#470)", async () => {
+    const { result } = setup();
+    act(() => result.current.handleRepoChange(REPO));
+    await settle();
+    expect(result.current.repoValid).toBe(true);
+
+    act(() => result.current.resetRepo(""));
+    expect(result.current.targetRepo).toBe("");
+    expect(result.current.repoValid).toBeNull();
+    expect(result.current.repoError).toBeNull();
+  });
+
+  it("resetRepo can seed a repo without claiming it is valid", () => {
+    const { result } = setup();
+    act(() => result.current.resetRepo("/from/a/trigger"));
+    expect(result.current.targetRepo).toBe("/from/a/trigger");
+    expect(result.current.repoValid).toBeNull();
+  });
+});
+
+describe("useRepoValidation — the field's border", () => {
+  it("stays neutral until there is a verdict", () => {
+    const { result } = setup();
+    expect(result.current.repoBorderClass).toBe("border-line-strong focus:border-acc");
+  });
+
+  it("goes accent on a valid repo and failed on an invalid one", async () => {
+    const { result } = setup();
+    act(() => result.current.handleRepoChange(REPO));
+    await settle();
+    expect(result.current.repoBorderClass).toBe("border-acc focus:border-acc");
+
+    vi.mocked(api.validateRepo).mockResolvedValue({ valid: false, error: "nope" });
+    act(() => result.current.handleRepoChange("/tmp/not-a-repo"));
+    await settle();
+    expect(result.current.repoBorderClass).toBe("border-st-failed focus:border-st-failed");
+  });
+});

--- a/frontend/src/hooks/useRepoValidation.ts
+++ b/frontend/src/hooks/useRepoValidation.ts
@@ -1,0 +1,96 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { validateRepo } from "../api";
+
+/**
+ * The target-repo field and its verdict (#359), lifted out of `NewRunModal.tsx`.
+ *
+ * Typing debounces a `GET /repos/validate`; a valid path then hands over to the branch
+ * loader, and an invalid one (or a failed request) clears the branch list, because a
+ * branch belonging to the previous repo is worse than none — see #454.
+ *
+ * `loadBranches` / `clearBranches` come from `useLaunchTargets`, which owns that list.
+ * They are called from inside the debounced chain rather than reacted to, so a repo stays
+ * "validating" until its branches have landed, exactly as before.
+ */
+export function useRepoValidation({
+  open,
+  loadBranches,
+  clearBranches,
+}: {
+  open: boolean;
+  loadBranches: (repoPath: string) => Promise<void>;
+  clearBranches: () => void;
+}) {
+  const [targetRepo, setTargetRepo] = useState("");
+  const [repoValid, setRepoValid] = useState<boolean | null>(null);
+  const [repoError, setRepoError] = useState<string | null>(null);
+  const [repoValidating, setRepoValidating] = useState(false);
+
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  const handleRepoChange = useCallback((value: string) => {
+    setTargetRepo(value);
+    if (!value.trim()) {
+      setRepoValid(null);
+      setRepoError(null);
+      clearBranches();
+    }
+  }, [clearBranches]);
+
+  /**
+   * Point the field at `value` and throw the verdict away with it (#470). The modal stays
+   * mounted (#386), so a `repoValid === true` left over from a previous open would
+   * otherwise survive next to a repo the user never validated.
+   */
+  const resetRepo = useCallback((value: string) => {
+    setTargetRepo(value);
+    setRepoValid(null);
+    setRepoError(null);
+  }, []);
+
+  useEffect(() => {
+    if (!open || !targetRepo.trim()) return;
+
+    clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(async () => {
+      setRepoValidating(true);
+      setRepoError(null);
+      try {
+        const result = await validateRepo(targetRepo.trim());
+        setRepoValid(result.valid);
+        if (!result.valid) {
+          setRepoError(result.error ?? "Not a valid git repository");
+          clearBranches();
+        } else {
+          await loadBranches(targetRepo.trim());
+        }
+      } catch {
+        setRepoValid(false);
+        setRepoError("Failed to validate repository");
+        clearBranches();
+      } finally {
+        setRepoValidating(false);
+      }
+    }, 400);
+
+    return () => clearTimeout(debounceRef.current);
+    // `loadBranches` closes over the CURRENT source branch (the #454 membership test), so
+    // listing it here would re-debounce — and re-validate — on every branch pick. The
+    // closure captured when `targetRepo` last changed already holds the value the user had
+    // then, which is the one the re-selection must judge against.
+  }, [targetRepo, open]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  let repoBorderClass = "border-line-strong focus:border-acc";
+  if (repoValid === true) repoBorderClass = "border-acc focus:border-acc";
+  else if (repoValid === false) repoBorderClass = "border-st-failed focus:border-st-failed";
+
+  return {
+    targetRepo,
+    repoValid,
+    repoError,
+    repoValidating,
+    repoBorderClass,
+    handleRepoChange,
+    resetRepo,
+  };
+}

--- a/frontend/src/hooks/useRightPaneRouter.test.ts
+++ b/frontend/src/hooks/useRightPaneRouter.test.ts
@@ -1,0 +1,314 @@
+import { renderHook } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { useRightPaneRouter } from "./useRightPaneRouter";
+import type { RightPaneRouterArgs } from "./useRightPaneRouter";
+import type { Selection } from "../stores/editStore";
+import type { Trigger, PipelineListEntry, RunState } from "../types";
+
+const NO_SEL: Selection = { kind: "none", id: null };
+const nodeSel = (id: string): Selection => ({ kind: "node", id });
+
+function trigger(id: string, pipeline_id: string): Trigger {
+  return { id, pipeline_id } as unknown as Trigger;
+}
+
+function pipeline(
+  id: string,
+  prompt_required?: boolean,
+): PipelineListEntry {
+  return { id, prompt_required } as unknown as PipelineListEntry;
+}
+
+function makeRun(over: Partial<RunState>): RunState {
+  return {
+    run_id: "r1",
+    status: "running",
+    nodes: {},
+    node_defs: [],
+    ...over,
+  } as unknown as RunState;
+}
+
+function baseArgs(over: Partial<RightPaneRouterArgs> = {}): RightPaneRouterArgs {
+  return {
+    selection: NO_SEL,
+    editActiveTabId: null,
+    hasEditTab: false,
+    selectedTriggerId: null,
+    setSelectedTriggerId: vi.fn(),
+    triggerOpenedTabId: null,
+    infoPanelOpen: false,
+    setInfoPanelOpen: vi.fn(),
+    triggers: [],
+    pipelines: [],
+    selectedRun: null,
+    ...over,
+  };
+}
+
+describe("useRightPaneRouter — pane-owner precedence (#247)", () => {
+  it("info wins over everything", () => {
+    const { result } = renderHook(() =>
+      useRightPaneRouter(
+        baseArgs({
+          infoPanelOpen: true,
+          selectedTriggerId: "t1",
+          triggers: [trigger("t1", "p1")],
+          hasEditTab: true,
+        }),
+      ),
+    );
+    expect(result.current.paneOwner).toBe("info");
+  });
+
+  it("a selected Trigger wins over a persistent edit tab (#247)", () => {
+    const { result } = renderHook(() =>
+      useRightPaneRouter(
+        baseArgs({
+          selectedTriggerId: "t1",
+          triggers: [trigger("t1", "p1")],
+          hasEditTab: true,
+        }),
+      ),
+    );
+    expect(result.current.paneOwner).toBe("trigger");
+    expect(result.current.selectedTrigger?.id).toBe("t1");
+  });
+
+  it("editTab when an edit tab is open and no trigger/info", () => {
+    const { result } = renderHook(() =>
+      useRightPaneRouter(baseArgs({ hasEditTab: true })),
+    );
+    expect(result.current.paneOwner).toBe("editTab");
+  });
+
+  it("selectedNode is the legacy fallback", () => {
+    const { result } = renderHook(() => useRightPaneRouter(baseArgs()));
+    expect(result.current.paneOwner).toBe("selectedNode");
+  });
+
+  it("a deleted Trigger resolves to null and yields no phantom trigger pane", () => {
+    const { result } = renderHook(() =>
+      useRightPaneRouter(
+        baseArgs({ selectedTriggerId: "gone", triggers: [], hasEditTab: true }),
+      ),
+    );
+    expect(result.current.selectedTrigger).toBeNull();
+    expect(result.current.paneOwner).toBe("editTab");
+  });
+});
+
+describe("useRightPaneRouter — #320 canvas-reclaim reconciliation", () => {
+  it("a genuine canvas selection clears the selected Trigger", () => {
+    const setSelectedTriggerId = vi.fn();
+    const { rerender } = renderHook(
+      (args: RightPaneRouterArgs) => useRightPaneRouter(args),
+      {
+        initialProps: baseArgs({
+          selectedTriggerId: "t1",
+          triggers: [trigger("t1", "p1")],
+          selection: NO_SEL,
+          editActiveTabId: "p1",
+          triggerOpenedTabId: "p1",
+          setSelectedTriggerId,
+        }),
+      },
+    );
+    // Focus a node on the trigger's own tab: selectionKind !== "none" ⇒ reclaim.
+    rerender(
+      baseArgs({
+        selectedTriggerId: "t1",
+        triggers: [trigger("t1", "p1")],
+        selection: nodeSel("n1"),
+        editActiveTabId: "p1",
+        triggerOpenedTabId: "p1",
+        setSelectedTriggerId,
+      }),
+    );
+    expect(setSelectedTriggerId).toHaveBeenCalledTimes(1);
+    expect(setSelectedTriggerId).toHaveBeenCalledWith(null);
+  });
+
+  it("the Trigger's OWN openPipeline landing does NOT clear it (#320)", () => {
+    const setSelectedTriggerId = vi.fn();
+    const { rerender } = renderHook(
+      (args: RightPaneRouterArgs) => useRightPaneRouter(args),
+      {
+        initialProps: baseArgs({
+          selectedTriggerId: "t1",
+          triggers: [trigger("t1", "p1")],
+          selection: NO_SEL,
+          editActiveTabId: null,
+          triggerOpenedTabId: null,
+          setSelectedTriggerId,
+        }),
+      },
+    );
+    // The trigger opens its pipeline: active tab becomes p1, nothing selected.
+    rerender(
+      baseArgs({
+        selectedTriggerId: "t1",
+        triggers: [trigger("t1", "p1")],
+        selection: NO_SEL,
+        editActiveTabId: "p1",
+        triggerOpenedTabId: "p1",
+        setSelectedTriggerId,
+      }),
+    );
+    expect(setSelectedTriggerId).not.toHaveBeenCalled();
+  });
+});
+
+describe("useRightPaneRouter — #385 info auto-close reconciliation", () => {
+  it("closes the info overlay when the active tab changes", () => {
+    const setInfoPanelOpen = vi.fn();
+    const { rerender } = renderHook(
+      (args: RightPaneRouterArgs) => useRightPaneRouter(args),
+      {
+        initialProps: baseArgs({
+          infoPanelOpen: true,
+          editActiveTabId: "p1",
+          setInfoPanelOpen,
+        }),
+      },
+    );
+    rerender(
+      baseArgs({
+        infoPanelOpen: true,
+        editActiveTabId: "p2",
+        setInfoPanelOpen,
+      }),
+    );
+    expect(setInfoPanelOpen).toHaveBeenCalledTimes(1);
+    expect(setInfoPanelOpen).toHaveBeenCalledWith(false);
+  });
+
+  it("keeps the info overlay open while the active tab is unchanged", () => {
+    const setInfoPanelOpen = vi.fn();
+    const { rerender } = renderHook(
+      (args: RightPaneRouterArgs) => useRightPaneRouter(args),
+      {
+        initialProps: baseArgs({
+          infoPanelOpen: true,
+          editActiveTabId: "p1",
+          setInfoPanelOpen,
+        }),
+      },
+    );
+    rerender(
+      baseArgs({
+        infoPanelOpen: true,
+        editActiveTabId: "p1",
+        setInfoPanelOpen,
+      }),
+    );
+    expect(setInfoPanelOpen).not.toHaveBeenCalled();
+  });
+});
+
+describe("useRightPaneRouter — triggerPromptRequired (#351)", () => {
+  it("defaults to true when the flag is absent", () => {
+    const { result } = renderHook(() =>
+      useRightPaneRouter(
+        baseArgs({
+          selectedTriggerId: "t1",
+          triggers: [trigger("t1", "p1")],
+          pipelines: [pipeline("p1")],
+        }),
+      ),
+    );
+    expect(result.current.triggerPromptRequired).toBe(true);
+  });
+
+  it("is false when the pipeline sets prompt_required = false", () => {
+    const { result } = renderHook(() =>
+      useRightPaneRouter(
+        baseArgs({
+          selectedTriggerId: "t1",
+          triggers: [trigger("t1", "p1")],
+          pipelines: [pipeline("p1", false)],
+        }),
+      ),
+    );
+    expect(result.current.triggerPromptRequired).toBe(false);
+  });
+
+  it("is false when the pipeline can't be found (dangling reference)", () => {
+    const { result } = renderHook(() =>
+      useRightPaneRouter(
+        baseArgs({
+          selectedTriggerId: "t1",
+          triggers: [trigger("t1", "p1")],
+          pipelines: [],
+        }),
+      ),
+    );
+    expect(result.current.triggerPromptRequired).toBe(false);
+  });
+});
+
+describe("useRightPaneRouter — runNode synthesis (#204)", () => {
+  it("returns the existing NodeState when the run already tracks the node", () => {
+    const existing = { node_id: "n1", status: "running" } as never;
+    const { result } = renderHook(() =>
+      useRightPaneRouter(
+        baseArgs({
+          selection: nodeSel("n1"),
+          selectedRun: makeRun({ nodes: { n1: existing } }),
+        }),
+      ),
+    );
+    expect(result.current.runNode).toBe(existing);
+  });
+
+  it("synthesizes a pending node on a live run for an unscheduled node", () => {
+    const { result } = renderHook(() =>
+      useRightPaneRouter(
+        baseArgs({
+          selection: nodeSel("n2"),
+          selectedRun: makeRun({
+            status: "running",
+            nodes: {},
+            node_defs: [{ id: "n2", node_type: "code-mutating" }] as never,
+          }),
+        }),
+      ),
+    );
+    expect(result.current.runNode).toMatchObject({
+      node_id: "n2",
+      status: "pending",
+    });
+  });
+
+  it("returns null on a terminal run", () => {
+    const { result } = renderHook(() =>
+      useRightPaneRouter(
+        baseArgs({
+          selection: nodeSel("n2"),
+          selectedRun: makeRun({
+            status: "completed",
+            nodes: {},
+            node_defs: [{ id: "n2", node_type: "code-mutating" }] as never,
+          }),
+        }),
+      ),
+    );
+    expect(result.current.runNode).toBeNull();
+  });
+
+  it("returns null for start/end pseudo-nodes", () => {
+    const { result } = renderHook(() =>
+      useRightPaneRouter(
+        baseArgs({
+          selection: nodeSel("start"),
+          selectedRun: makeRun({
+            status: "running",
+            nodes: {},
+            node_defs: [{ id: "start", node_type: "start" }] as never,
+          }),
+        }),
+      ),
+    );
+    expect(result.current.runNode).toBeNull();
+  });
+});

--- a/frontend/src/hooks/useRightPaneRouter.ts
+++ b/frontend/src/hooks/useRightPaneRouter.ts
@@ -1,0 +1,203 @@
+import { useState } from "react";
+import { rightPaneOwner } from "../lib/rightPaneOwner";
+import type { RightPaneOwner } from "../lib/rightPaneOwner";
+import { shouldClearTriggerOnCanvasFocus } from "../lib/triggerCanvasReconcile";
+import { shouldCloseInfoOnTabChange } from "../lib/infoPanelReconcile";
+import type { Selection } from "../stores/editStore";
+import type {
+  Trigger,
+  PipelineListEntry,
+  RunState,
+  NodeState,
+} from "../types";
+import { isLiveRun } from "../types";
+
+export interface RightPaneRouterArgs {
+  /** The current canvas selection (`editStore.selection`). */
+  selection: Selection;
+  /** The active edit-tab id (`editStore.activeTabId`). */
+  editActiveTabId: string | null;
+  /** Whether an edit tab owns the centre canvas. */
+  hasEditTab: boolean;
+  /** The currently-selected Trigger id (App-owned state). */
+  selectedTriggerId: string | null;
+  /** Setter for `selectedTriggerId` — the #320 reconciliation clears it. */
+  setSelectedTriggerId: (id: string | null) => void;
+  /** The tab id that selecting a Trigger opened in the canvas (#320). */
+  triggerOpenedTabId: string | null;
+  /** Whether the Pipeline Info peek overlay is open (App-owned state). */
+  infoPanelOpen: boolean;
+  /** Setter for `infoPanelOpen` — the #385 reconciliation closes it. */
+  setInfoPanelOpen: (open: boolean) => void;
+  /** The Triggers list — used to resolve `selectedTrigger`. */
+  triggers: Trigger[];
+  /** The merged /pipelines list — used for the guard dry-run caveat (#351). */
+  pipelines: PipelineListEntry[];
+  /** The selected run — used to synthesize a pending run-pane node. */
+  selectedRun: RunState | null;
+}
+
+export interface RightPaneRouterResult {
+  /** Which view owns the right-hand detail pane (#247). */
+  paneOwner: RightPaneOwner;
+  /** The Trigger backing the right-panel detail view, or null. */
+  selectedTrigger: Trigger | null;
+  /** Whether the selected Trigger's pipeline requires a prompt (#351). */
+  triggerPromptRequired: boolean;
+  /** A synthesized pending NodeState for the Run pane, or null. */
+  runNode: NodeState | null;
+}
+
+/**
+ * The right-pane router (#359, extracted from App.tsx).
+ *
+ * Composes the two render-time reconciliations (#320 canvas-reclaim, #385 info
+ * auto-close), the pane-owner precedence (#247, `rightPaneOwner`), and the
+ * derived detail-view state (`selectedTrigger`, its prompt-required signal, and
+ * the synthesized pending run-pane node) that together decide what the
+ * right-hand pane shows.
+ *
+ * Both reconciliations run as setState-DURING-render (React's recommended
+ * reset-on-change idiom, NOT `useEffect`) so no stale frame of the shadowed
+ * panel is ever painted (#247/#385). This hook is called at the top of App's
+ * render, so those setState calls happen during App's render exactly as before:
+ * `selectedTriggerId`/`infoPanelOpen` are App-owned (passed in with their
+ * setters); the two order-trackers (`lastCanvasFocus`, `lastInfoTabId`) are
+ * owned here. LOAD-BEARING: reconcile BEFORE compute-owner, in the SAME render
+ * pass; advance each tracker UNCONDITIONALLY (gating it would re-fire the block
+ * every render — infinite loop); never move the clears into an effect.
+ */
+export function useRightPaneRouter(
+  args: RightPaneRouterArgs,
+): RightPaneRouterResult {
+  const {
+    selection,
+    editActiveTabId,
+    hasEditTab,
+    selectedTriggerId,
+    setSelectedTriggerId,
+    triggerOpenedTabId,
+    infoPanelOpen,
+    setInfoPanelOpen,
+    triggers,
+    pipelines,
+    selectedRun,
+  } = args;
+
+  // #320 canvas-reclaim. A Trigger detail and a canvas selection compete for the
+  // right pane (#247). The Trigger wins over a *persistent* run-edit tab (see
+  // rightPaneOwner), so the canvas needs an explicit way to reclaim the pane —
+  // otherwise a once-selected Trigger would shadow every later node/edge/region
+  // inspector. Selecting a Trigger touches neither `selection` nor the active
+  // tab, so the canvas-focus signal below never fires on a fresh Trigger
+  // selection; any later canvas focus (a node/edge/region selection, or a tab
+  // switch/open) clears it. Adjusting state during render rather than in an
+  // effect avoids painting one stale frame of the Trigger detail.
+  const [lastCanvasFocus, setLastCanvasFocus] = useState({
+    selection,
+    tabId: editActiveTabId,
+  });
+  if (
+    lastCanvasFocus.selection !== selection ||
+    lastCanvasFocus.tabId !== editActiveTabId
+  ) {
+    // setLastCanvasFocus MUST stay unconditional — gating it would make this
+    // block re-fire every render (infinite loop).
+    setLastCanvasFocus({ selection, tabId: editActiveTabId });
+    // #320: skip clearing the Trigger when this focus change is the Trigger's
+    // OWN openPipeline landing — i.e. the tab it opened is now active with
+    // nothing selected. A genuine canvas reclaim differs and STILL clears
+    // (preserving #247): a node/edge/region select makes selection.kind !==
+    // "none", and switching to another tab makes editActiveTabId !==
+    // triggerOpenedTabId.
+    if (
+      shouldClearTriggerOnCanvasFocus({
+        selectedTriggerId,
+        editActiveTabId,
+        selectionKind: selection.kind,
+        triggerOpenedTabId,
+      })
+    ) {
+      setSelectedTriggerId(null);
+    }
+  }
+
+  // #385: the Pipeline Info peek overlay is tab-scoped and shadows the right
+  // pane while open (rightPaneOwner gives it top precedence). Close it when the
+  // active tab changes — selecting a different run/library-pipeline (left
+  // panel), a Trigger opening its pipeline, or a TabBar switch all move
+  // `editActiveTabId`. Canvas node/edge/note clicks already close it via
+  // EditCanvas.onCloseInfo.
+  //
+  // Same render-time reset-on-change idiom as the #320 block above (adjust
+  // state during render, not in an effect, to avoid painting one stale frame).
+  // CRITICAL: advance `lastInfoTabId` UNCONDITIONALLY — if the advance were
+  // gated on `infoPanelOpen`, the tracker would go stale while the overlay is
+  // closed and spuriously close the NEXT overlay one frame after it opens on a
+  // new tab (and gating would also re-fire this block every render).
+  const [lastInfoTabId, setLastInfoTabId] = useState<string | null>(
+    editActiveTabId,
+  );
+  if (lastInfoTabId !== editActiveTabId) {
+    const closeInfo = shouldCloseInfoOnTabChange({
+      prevTabId: lastInfoTabId,
+      nextTabId: editActiveTabId,
+      infoOpen: infoPanelOpen,
+    });
+    setLastInfoTabId(editActiveTabId); // UNCONDITIONAL — mirrors the #320 block
+    if (closeInfo) setInfoPanelOpen(false);
+  }
+
+  const selectedTrigger =
+    selectedTriggerId != null
+      ? triggers.find((t) => t.id === selectedTriggerId) ?? null
+      : null;
+
+  // Prompt-required (#351): default true when the flag is absent (matches the
+  // daemon default); false when the pipeline can't be found, so a dangling
+  // reference shows no false "would be empty" caveat.
+  const triggerPromptRequired = selectedTrigger
+    ? (() => {
+        const p = pipelines.find((pl) => pl.id === selectedTrigger.pipeline_id);
+        return p ? p.prompt_required !== false : false;
+      })()
+    : false;
+
+  // Which view owns the right-hand detail pane (#247). A selected Trigger now
+  // wins over a persistent run-edit tab; the canvas-focus reconciliation above
+  // clears `selectedTriggerId` the moment the canvas is touched again.
+  const paneOwner = rightPaneOwner({
+    triggerSelected: selectedTrigger != null,
+    infoPanelOpen,
+    hasEditTab,
+  });
+
+  // The Run-pane node. A node present in the pipeline (canvas) but absent from
+  // the run's node map is genuinely pending: the event-sourced projection only
+  // lists a node once it has been scheduled (NodeStarted / NodeWaiting / …), so
+  // a not-yet-reached downstream node has no entry. On a live run, synthesize a
+  // pending NodeState so the inspector renders NodeDetailPanel (with its
+  // force-start Start button, #204) instead of the passive RunTabPlaceholder —
+  // the daemon's force_spawn_node already accepts a node absent from run state.
+  // Terminal runs and start/end pseudo-nodes stay null.
+  const runNode: NodeState | null = (() => {
+    if (selection.kind !== "node" || !selection.id || !selectedRun) return null;
+    const existing = selectedRun.nodes[selection.id];
+    if (existing) return existing;
+    if (!isLiveRun(selectedRun.status)) return null;
+    const def = selectedRun.node_defs?.find((d) => d.id === selection.id);
+    if (!def || def.node_type === "start" || def.node_type === "end")
+      return null;
+    return {
+      node_id: selection.id,
+      status: "pending",
+      iter: 0,
+      started_at: null,
+      completed_at: null,
+      failure_reason: null,
+      iterations: [],
+    };
+  })();
+
+  return { paneOwner, selectedTrigger, triggerPromptRequired, runNode };
+}

--- a/frontend/src/lib/libraryTwins.test.ts
+++ b/frontend/src/lib/libraryTwins.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from "vitest";
+import { cascadableTwin, isStarred, libraryOnly, libraryTwins } from "./libraryTwins";
+import type { LibraryPipelineEntry, LibraryPipelineScope } from "../api";
+import type { PipelineListEntry, PipelineScope } from "../types";
+
+function lib(
+  id: string,
+  name: string,
+  scope: LibraryPipelineScope = "user",
+): LibraryPipelineEntry {
+  return {
+    id,
+    name,
+    scope,
+    node_count: 3,
+    modified: null,
+    yaml: `name: ${name}\n`,
+    pipeline: { name, version: "1.0", variables: {}, nodes: [], edges: [] },
+    prompts: {},
+  };
+}
+
+function working(
+  id: string,
+  name: string,
+  scope: PipelineScope = "repo",
+): PipelineListEntry {
+  return {
+    id,
+    name,
+    scope,
+    path: `/repo/.pdo/pipelines/${id}.yaml`,
+    node_count: 3,
+    modified: null,
+    variables: {},
+  };
+}
+
+describe("libraryTwins", () => {
+  it("finds no twin in an empty library", () => {
+    expect(libraryTwins(working("fixture-repo-id", "fixture"), [])).toEqual([]);
+  });
+
+  it("finds the twin by NAME even when the ids diverge (#227)", () => {
+    // The Library copy's id is an independently derived slug: matching on id
+    // would find nothing here, which is the whole bug the name key prevents.
+    const twin = lib("fixture-lib-slug", "fixture");
+    const found = libraryTwins(working("fixture-repo-id", "fixture"), [twin]);
+    expect(found).toEqual([twin]);
+  });
+
+  it("never joins on id: a same-id, different-name entry is not a twin", () => {
+    const sameIdOtherName = lib("fixture", "something-else");
+    expect(libraryTwins(working("fixture", "fixture"), [sameIdOtherName])).toEqual([]);
+  });
+
+  it("returns both copies of a double-star (same name in repo and user scope)", () => {
+    const repoCopy = lib("fixture-repo-copy", "fixture", "repo");
+    const userCopy = lib("fixture-user-copy", "fixture", "user");
+    expect(
+      libraryTwins(working("fixture-repo-id", "fixture"), [
+        repoCopy,
+        lib("other", "other"),
+        userCopy,
+      ]),
+    ).toEqual([repoCopy, userCopy]);
+  });
+});
+
+describe("cascadableTwin", () => {
+  const twin = lib("fixture-lib-slug", "fixture");
+
+  it("offers nothing when no row is targeted (the pre-open modal state)", () => {
+    expect(cascadableTwin(null, [twin])).toBeNull();
+  });
+
+  it("offers the unique same-name twin, so the caller deletes it by ITS id", () => {
+    const got = cascadableTwin(working("fixture-repo-id", "fixture"), [twin]);
+    expect(got).toBe(twin);
+    expect(got!.id).toBe("fixture-lib-slug");
+  });
+
+  it("offers nothing when the library has no same-name copy", () => {
+    expect(cascadableTwin(working("fixture-repo-id", "fixture"), [])).toBeNull();
+    expect(
+      cascadableTwin(working("fixture-repo-id", "fixture"), [lib("other", "other")]),
+    ).toBeNull();
+  });
+
+  it("refuses an ambiguous double-star — never guesses which copy to destroy", () => {
+    expect(
+      cascadableTwin(working("fixture-repo-id", "fixture"), [
+        lib("fixture-repo-copy", "fixture", "repo"),
+        lib("fixture-user-copy", "fixture", "user"),
+      ]),
+    ).toBeNull();
+  });
+
+  it("refuses a scope:'library' target: the row IS the copy, nothing to cascade to", () => {
+    // Same name, exactly one twin — only the scope guard stops the cascade (#216).
+    expect(cascadableTwin(working("fixture", "fixture", "library"), [twin])).toBeNull();
+  });
+
+  it("offers the cascade for a user-scoped working pipeline too, not just repo", () => {
+    expect(cascadableTwin(working("fixture-user-id", "fixture", "user"), [twin])).toBe(twin);
+  });
+});
+
+describe("libraryOnly", () => {
+  it("keeps every entry when /pipelines is empty", () => {
+    const entries = [lib("a", "alpha"), lib("b", "beta")];
+    expect(libraryOnly(entries, [])).toEqual(entries);
+  });
+
+  it("drops the entries whose name already sits in /pipelines", () => {
+    const alpha = lib("alpha-lib-slug", "alpha");
+    const beta = lib("beta-lib-slug", "beta");
+    expect(libraryOnly([alpha, beta], [working("alpha-repo-id", "alpha")])).toEqual([beta]);
+  });
+
+  it("drops on name, not id: a divergent-id same-name row still hides the entry", () => {
+    // The mirror of the #227 join: matching on id would leave a phantom
+    // library-only row next to the working pipeline it belongs to.
+    const alpha = lib("alpha-lib-slug", "alpha");
+    expect(libraryOnly([alpha], [working("alpha-repo-id", "alpha")])).toEqual([]);
+  });
+
+  it("keeps an entry whose id collides with a /pipelines row of another name", () => {
+    const entry = lib("shared-id", "alpha");
+    expect(libraryOnly([entry], [working("shared-id", "beta")])).toEqual([entry]);
+  });
+
+  it("preserves library order", () => {
+    const a = lib("a", "alpha");
+    const b = lib("b", "beta");
+    const c = lib("c", "gamma");
+    expect(libraryOnly([a, b, c], [working("beta-id", "beta")])).toEqual([a, c]);
+  });
+});
+
+describe("isStarred", () => {
+  it("is false against an empty library", () => {
+    expect(isStarred(working("fixture-repo-id", "fixture"), [])).toBe(false);
+  });
+
+  it("is true on a name match with a divergent id", () => {
+    expect(
+      isStarred(working("fixture-repo-id", "fixture"), [lib("fixture-lib-slug", "fixture")]),
+    ).toBe(true);
+  });
+
+  it("is false when only the id matches", () => {
+    expect(isStarred(working("fixture", "fixture"), [lib("fixture", "other")])).toBe(false);
+  });
+
+  it("stays true on a double-star (the star shows even when no cascade is offered)", () => {
+    const library = [
+      lib("fixture-repo-copy", "fixture", "repo"),
+      lib("fixture-user-copy", "fixture", "user"),
+    ];
+    const row = working("fixture-repo-id", "fixture");
+    expect(isStarred(row, library)).toBe(true);
+    // …and the cascade is still refused: the two predicates are independent.
+    expect(cascadableTwin(row, library)).toBeNull();
+  });
+});

--- a/frontend/src/lib/libraryTwins.ts
+++ b/frontend/src/lib/libraryTwins.ts
@@ -1,0 +1,83 @@
+/**
+ * The Library "twin" rule (#227) — one source of truth.
+ *
+ * A working pipeline and its durable Library copy are linked by NAME, never by
+ * id: the Library copy's id is an independently derived slug that can diverge
+ * from the working pipeline's file-stem id (#227, commit 51b5ee1). Every star,
+ * cascade and library-only decision in the left panel joins on that one key.
+ *
+ * These predicates back a SAFETY decision — a cascade delete destroys a second
+ * file the user never pointed at — so they live here instead of inline at each
+ * call site. The delete's EXECUTION path (`handleConfirmDelete`) and the
+ * checkbox's VISIBILITY path (the `ConfirmDeleteModal` render) used to compute
+ * the rule separately; they now agree by construction rather than by two copies
+ * staying in step.
+ */
+import type { LibraryPipelineEntry } from "../api";
+import type { PipelineListEntry } from "../types";
+
+/**
+ * The one join key: same display name. Never `id` — see the module note. Every
+ * predicate below routes through this, so the key exists in exactly one place.
+ */
+function sameName(a: { name: string }, b: { name: string }): boolean {
+  return a.name === b.name;
+}
+
+/**
+ * Every Library entry twinned with `entry`. Usually 0 or 1; a "double-star" (the
+ * same name saved in both the repo-scoped and user-scoped library) yields 2+,
+ * which is the ambiguous case {@link cascadableTwin} refuses to act on.
+ */
+export function libraryTwins(
+  entry: { name: string },
+  library: LibraryPipelineEntry[],
+): LibraryPipelineEntry[] {
+  return library.filter((lp) => sameName(lp, entry));
+}
+
+/**
+ * The Library copy a delete of `target` may cascade to, or `null` when no
+ * cascade is on offer. Null-safe on `target` so the checkbox-visibility site can
+ * ask before any row is picked (`deleteTarget === null` ⇒ no cascade label).
+ *
+ * Two guards, both load-bearing:
+ *   - `scope !== "library"`: the row already IS the library entry, so there is
+ *     no separate copy left to remove — the plain delete covers it (#216).
+ *   - exactly one twin: a double-star is ambiguous, and guessing which copy to
+ *     destroy is exactly the mistake a cascade must never make.
+ */
+export function cascadableTwin(
+  target: Pick<PipelineListEntry, "name" | "scope"> | null,
+  library: LibraryPipelineEntry[],
+): LibraryPipelineEntry | null {
+  if (target == null) return null;
+  if (target.scope === "library") return null;
+  const twins = libraryTwins(target, library);
+  return twins.length === 1 ? twins[0] : null;
+}
+
+/**
+ * Library entries with no same-name row in `pipelines`. These are the ones the
+ * merged /pipelines list doesn't already surface, so the panel renders them as
+ * their own passive rows — starring a brand-new pipeline yields a visible
+ * sidebar entry, matching "starred == in the library".
+ */
+export function libraryOnly(
+  library: LibraryPipelineEntry[],
+  pipelines: { name: string }[],
+): LibraryPipelineEntry[] {
+  return library.filter((lp) => !pipelines.some((p) => sameName(p, lp)));
+}
+
+/**
+ * Whether `pipeline` shows the star badge: a Library entry exists under the same
+ * name. This is the visible confirmation the user expects after clicking the
+ * canvas star.
+ */
+export function isStarred(
+  pipeline: { name: string },
+  library: LibraryPipelineEntry[],
+): boolean {
+  return libraryTwins(pipeline, library).length > 0;
+}

--- a/frontend/src/lib/newRunForm.test.ts
+++ b/frontend/src/lib/newRunForm.test.ts
@@ -1,0 +1,609 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildRunPayload,
+  buildTriggerCreatePayload,
+  buildTriggerUpdatePayload,
+  buildVariables,
+  canCreateTrigger,
+  canLaunch,
+  hasRequiredPrompt,
+  overrideCount,
+  parseVariableValue,
+  promptOptional,
+  resolvedCron,
+  sandboxState,
+  triggerInputRejectReason,
+} from "./newRunForm";
+import type { InstanceSettings, PipelineListEntry } from "../types";
+
+function pipeline(over: Partial<PipelineListEntry> = {}): PipelineListEntry {
+  return {
+    id: "p1",
+    name: "Auditor",
+    scope: "repo",
+    path: "/repo/.pdo/pipelines/auditor.yaml",
+    node_count: 3,
+    modified: null,
+    variables: {},
+    ...over,
+  };
+}
+
+function settings(over: Partial<InstanceSettings> = {}): InstanceSettings {
+  return {
+    session_cap: { effective: 20, source: "default", stored: null, env: null, default: 20 },
+    reaper_ttl_secs: { effective: 3600, source: "default", stored: null, env: null, default: 3600 },
+    guard_timeout_secs: { effective: 60, source: "default", stored: null, env: null, default: 60 },
+    default_model: { effective: null, source: "default", stored: null, env: null, default: null },
+    default_sandbox: { effective: "off", source: "default", stored: null, env: null, default: "off", reason: null },
+    sandbox_docker: { available: true, reason: null, checked_at: "2026-07-01T10:00:00.000Z" },
+    sandbox_profiles: [
+      { name: "full", virtual: true },
+      { name: "minimal", virtual: true },
+    ],
+    home: "/home/user",
+    autocomplete_turn_end: { effective: false, source: "default", stored: null, env: null, default: false },
+    default_auto_name: { effective: true, source: "default", stored: null, env: null, default: true },
+    price_table: { manual_path: null, fetched_path: null, source: null, fetched_at: null, fetched_rows: 0, manual_keys: [], reason: null },
+    updated_at: "2026-07-01T10:00:00.000Z",
+    ...over,
+  };
+}
+
+/** The default_sandbox tier resolving to `name` (the #452 fixture). */
+const defaultIs = (name: string, reason: string | null = null): Partial<InstanceSettings> => ({
+  default_sandbox: { effective: name, source: "stored", stored: name, env: null, default: "off", reason },
+});
+
+describe("parseVariableValue", () => {
+  it("parses int, falling back to 0 on garbage", () => {
+    expect(parseVariableValue("42", "int")).toBe(42);
+    expect(parseVariableValue("nope", "int")).toBe(0);
+  });
+
+  it("parses float, falling back to 0 on garbage", () => {
+    expect(parseVariableValue("2.5", "float")).toBe(2.5);
+    expect(parseVariableValue("", "float")).toBe(0);
+  });
+
+  // Only the exact string `true` is true — a checkbox never reaches here, so a typo
+  // must read as false rather than as "any non-empty string".
+  it("parses bool from the literal string true only", () => {
+    expect(parseVariableValue("true", "bool")).toBe(true);
+    expect(parseVariableValue("True", "bool")).toBe(false);
+    expect(parseVariableValue("1", "bool")).toBe(false);
+  });
+
+  it("parses a list from JSON", () => {
+    expect(parseVariableValue('["a", "b"]', "list")).toEqual(["a", "b"]);
+  });
+
+  it("falls back to a trimmed comma split for a non-JSON list", () => {
+    expect(parseVariableValue("[a, b , c]", "list")).toEqual(["a", "b", "c"]);
+    expect(parseVariableValue("a,b", "list")).toEqual(["a", "b"]);
+  });
+
+  it("passes an unknown type through as the raw string", () => {
+    expect(parseVariableValue("  spaced  ", "string")).toBe("  spaced  ");
+  });
+});
+
+/**
+ * Run mode and Trigger mode each carried a byte-identical copy of this loop before #359.
+ * The rules it encodes are the ones a single copy must keep whole.
+ */
+describe("buildVariables", () => {
+  const declared = pipeline({
+    variables: {
+      max_iter: { var_type: "int", default: 3 },
+      label: { var_type: "string", default: "ready" },
+    },
+  });
+
+  it("keeps only overrides the pipeline declares", () => {
+    expect(buildVariables({ max_iter: "5", ghost: "x" }, declared)).toEqual({ max_iter: 5 });
+  });
+
+  it("drops an override equal to the declared default (not an override)", () => {
+    expect(buildVariables({ max_iter: "3" }, declared)).toEqual({});
+  });
+
+  it("parses each value by its declared type", () => {
+    expect(buildVariables({ max_iter: "5", label: "rfa" }, declared)).toEqual({
+      max_iter: 5,
+      label: "rfa",
+    });
+  });
+
+  it("returns an empty map when nothing was typed", () => {
+    expect(buildVariables({}, declared)).toEqual({});
+  });
+
+  /**
+   * The dedup, asserted where it can actually be observed: the payload builders CARRY the
+   * map they are handed — they do not recompute it — so the single `buildVariables` call is
+   * the only place the rules above live. `toBe` (identity), not `toEqual`: a builder that
+   * rebuilt an equal map would pass an equality check and re-open the drift.
+   */
+  it("is computed once and carried into every payload, run and trigger alike", () => {
+    const variables = buildVariables({ max_iter: "5" }, declared);
+    const runFields = {
+      selectedPipeline: declared,
+      input: "audit",
+      variables,
+      targetRepo: "/repo",
+      sourceBranch: "main",
+      autoName: true,
+      runName: "",
+      sandbox: "",
+      images: [],
+    };
+    const triggerFields = {
+      selectedPipeline: declared,
+      triggerName: "Nightly",
+      resolvedCron: "0 * * * *",
+      input: "audit",
+      guardCommand: "",
+      targetRepo: "/repo",
+      sourceBranch: "main",
+      allowOverlap: false,
+      maxConcurrent: "",
+      sandbox: "",
+      autoName: true,
+      variables,
+    };
+    expect(buildRunPayload(runFields).variables).toBe(variables);
+    expect(buildTriggerCreatePayload(triggerFields).variables).toBe(variables);
+    expect(buildTriggerUpdatePayload(triggerFields).variables).toBe(variables);
+  });
+});
+
+describe("overrideCount", () => {
+  const declared = pipeline({
+    variables: { max_iter: { var_type: "int", default: 3 } },
+  });
+
+  it("counts nothing without a selected pipeline", () => {
+    expect(overrideCount({ max_iter: "5" }, undefined)).toBe(0);
+  });
+
+  it("ignores undeclared keys and values equal to the default", () => {
+    expect(overrideCount({ max_iter: "3", ghost: "x" }, declared)).toBe(0);
+  });
+
+  it("counts a real override", () => {
+    expect(overrideCount({ max_iter: "5" }, declared)).toBe(1);
+  });
+});
+
+describe("resolvedCron", () => {
+  const daily = { rawCron: "", dailyHour: 9, dailyMinute: 0 };
+
+  it("compiles the preset schedules", () => {
+    expect(resolvedCron({ ...daily, cronPresetId: "every_15_min" })).toBe("*/15 * * * *");
+    expect(resolvedCron({ ...daily, cronPresetId: "hourly" })).toBe("0 * * * *");
+  });
+
+  it("compiles the daily preset with its time of day", () => {
+    expect(
+      resolvedCron({ cronPresetId: "daily", rawCron: "", dailyHour: 7, dailyMinute: 30 }),
+    ).toBe("30 7 * * *");
+  });
+
+  it("takes the raw expression, trimmed, for the custom escape hatch", () => {
+    expect(
+      resolvedCron({ cronPresetId: "custom", rawCron: "  */5 * * * *  ", dailyHour: 9, dailyMinute: 0 }),
+    ).toBe("*/5 * * * *");
+  });
+
+  // Drives the "cron: —" placeholder and blocks Create: a blank custom expression is not
+  // a schedule.
+  it("resolves an empty custom expression to the empty string", () => {
+    expect(resolvedCron({ ...daily, cronPresetId: "custom" })).toBe("");
+  });
+});
+
+describe("promptOptional / hasRequiredPrompt", () => {
+  it("treats an absent prompt_required as required (#158 default)", () => {
+    expect(promptOptional(pipeline())).toBe(false);
+    expect(promptOptional(undefined)).toBe(false);
+  });
+
+  it("is optional only for an explicit prompt_required: false", () => {
+    expect(promptOptional(pipeline({ prompt_required: false }))).toBe(true);
+    expect(promptOptional(pipeline({ prompt_required: true }))).toBe(false);
+  });
+
+  it("demands non-blank input when the prompt is required", () => {
+    expect(hasRequiredPrompt(false, "")).toBe(false);
+    expect(hasRequiredPrompt(false, "   ")).toBe(false);
+    expect(hasRequiredPrompt(false, "do the thing")).toBe(true);
+  });
+
+  it("needs no input at all when the pipeline sources its own work", () => {
+    expect(hasRequiredPrompt(true, "")).toBe(true);
+  });
+});
+
+describe("triggerInputRejectReason (#161)", () => {
+  const base = {
+    mode: "trigger" as const,
+    selectedPipeline: pipeline(),
+    promptOptional: false,
+    guardCommand: "",
+    input: "",
+  };
+
+  it("mirrors the server reject for a prompt-required pipeline with no guard and no template", () => {
+    expect(triggerInputRejectReason(base)).toMatch(/requires a prompt/);
+  });
+
+  it("says nothing in run mode", () => {
+    expect(triggerInputRejectReason({ ...base, mode: "run" })).toBeNull();
+  });
+
+  it("says nothing before a pipeline is chosen", () => {
+    expect(triggerInputRejectReason({ ...base, selectedPipeline: undefined })).toBeNull();
+  });
+
+  it("is resolved by a guard command, whose stdout becomes the input", () => {
+    expect(triggerInputRejectReason({ ...base, guardCommand: "gh issue list" })).toBeNull();
+  });
+
+  it("is resolved by an input template", () => {
+    expect(triggerInputRejectReason({ ...base, input: "audit the codebase" })).toBeNull();
+  });
+
+  it("is resolved by a prompt-not-required pipeline", () => {
+    expect(triggerInputRejectReason({ ...base, promptOptional: true })).toBeNull();
+  });
+
+  // Blanks are not input: the server resolves the same way, so the modal must not
+  // pre-approve a fire it would reject.
+  it("treats a whitespace-only guard and template as absent", () => {
+    expect(triggerInputRejectReason({ ...base, guardCommand: "  ", input: " \n " })).toMatch(
+      /requires a prompt/,
+    );
+  });
+});
+
+describe("canLaunch", () => {
+  const ok = {
+    repoValid: true,
+    selectedPipeline: pipeline(),
+    hasRequiredPrompt: true,
+    missingProfile: false,
+    sandboxDoomed: false,
+  };
+
+  it("allows a launch once repo, pipeline and prompt are settled", () => {
+    expect(canLaunch(ok)).toBe(true);
+  });
+
+  it("refuses an unvalidated repo (#470: `null` is not a verdict)", () => {
+    expect(canLaunch({ ...ok, repoValid: null })).toBe(false);
+    expect(canLaunch({ ...ok, repoValid: false })).toBe(false);
+  });
+
+  it("refuses without a pipeline or without the required prompt", () => {
+    expect(canLaunch({ ...ok, selectedPipeline: undefined })).toBe(false);
+    expect(canLaunch({ ...ok, hasRequiredPrompt: false })).toBe(false);
+  });
+
+  // ADR-0031 §7: neither a vanished profile nor an unavailable Docker is silently
+  // demoted — both refuse the launch instead.
+  it("refuses a vanished profile and a Docker-doomed sandbox", () => {
+    expect(canLaunch({ ...ok, missingProfile: true })).toBe(false);
+    expect(canLaunch({ ...ok, sandboxDoomed: true })).toBe(false);
+  });
+});
+
+describe("canCreateTrigger", () => {
+  const ok = {
+    repoValid: true,
+    selectedPipeline: pipeline(),
+    triggerName: "Nightly",
+    resolvedCron: "0 * * * *",
+    triggerInputRejectReason: null,
+    missingProfile: false,
+  };
+
+  it("allows a create once name, pipeline, repo and cron are settled", () => {
+    expect(canCreateTrigger(ok)).toBe(true);
+  });
+
+  it("refuses a blank name", () => {
+    expect(canCreateTrigger({ ...ok, triggerName: "   " })).toBe(false);
+  });
+
+  it("refuses an unresolvable schedule", () => {
+    expect(canCreateTrigger({ ...ok, resolvedCron: "" })).toBe(false);
+  });
+
+  it("refuses an unvalidated repo or a missing pipeline", () => {
+    expect(canCreateTrigger({ ...ok, repoValid: null })).toBe(false);
+    expect(canCreateTrigger({ ...ok, selectedPipeline: undefined })).toBe(false);
+  });
+
+  it("refuses the fire the server would reject", () => {
+    expect(canCreateTrigger({ ...ok, triggerInputRejectReason: "…" })).toBe(false);
+  });
+
+  // #432: re-saving a Trigger whose profile vanished would PATCH `sandbox: null` — a
+  // silent fallback to the instance default.
+  it("refuses to re-save a trigger pointing at a vanished profile", () => {
+    expect(canCreateTrigger({ ...ok, missingProfile: true })).toBe(false);
+  });
+});
+
+describe("sandboxState (#410/#432/#452)", () => {
+  it("asserts nothing while settings are unknown", () => {
+    const state = sandboxState({ settings: null, sandbox: "", mode: "run" });
+    expect(state).toMatchObject({
+      dockerUnavailable: false,
+      sandboxProfiles: [],
+      missingProfile: false,
+      instanceDefaultSandbox: null,
+      effectiveSandbox: null,
+      sandboxDoomed: false,
+      inheritedDefaultReason: null,
+    });
+  });
+
+  it("serves the daemon's profile list as the options", () => {
+    const state = sandboxState({ settings: settings(), sandbox: "", mode: "run" });
+    expect(state.sandboxProfiles.map((p) => p.name)).toEqual(["full", "minimal"]);
+  });
+
+  it("resolves the inherit sentinel to the instance default, and a pick to itself", () => {
+    expect(
+      sandboxState({ settings: settings(defaultIs("full")), sandbox: "", mode: "run" })
+        .effectiveSandbox,
+    ).toBe("full");
+    expect(
+      sandboxState({ settings: settings(defaultIs("full")), sandbox: "off", mode: "run" })
+        .effectiveSandbox,
+    ).toBe("off");
+  });
+
+  it("reads a null default tier as off", () => {
+    const state = sandboxState({
+      settings: settings({
+        default_sandbox: { effective: null, source: "default", stored: null, env: null, default: null, reason: null },
+      }),
+      sandbox: "",
+      mode: "run",
+    });
+    expect(state.instanceDefaultSandbox).toBe("off");
+  });
+
+  it("greys the profiles and names why once Docker is known unavailable", () => {
+    const state = sandboxState({
+      settings: settings({
+        sandbox_docker: { available: false, reason: "Docker daemon unreachable", checked_at: "x" },
+      }),
+      sandbox: "",
+      mode: "run",
+    });
+    expect(state.dockerUnavailable).toBe(true);
+    expect(state.sandboxReason).toBe("Docker daemon unreachable");
+  });
+
+  /**
+   * #452: the Docker clamp says NO instead of answering `off` on the user's behalf — the
+   * inherited default counts, because that is what the Run will actually get.
+   */
+  it("dooms a run whose inherited default needs an unavailable Docker", () => {
+    const dockerDown = settings({
+      ...defaultIs("minimal"),
+      sandbox_docker: { available: false, reason: "Docker daemon unreachable", checked_at: "x" },
+    });
+    expect(sandboxState({ settings: dockerDown, sandbox: "", mode: "run" }).sandboxDoomed).toBe(true);
+    // Demoting to `off` is the user's call, and it unblocks.
+    expect(sandboxState({ settings: dockerDown, sandbox: "off", mode: "run" }).sandboxDoomed).toBe(
+      false,
+    );
+    // A Trigger resolves its sandbox when it FIRES: today's probe says nothing about it.
+    expect(sandboxState({ settings: dockerDown, sandbox: "", mode: "trigger" }).sandboxDoomed).toBe(
+      false,
+    );
+  });
+
+  it("does not doom a run when Docker is available", () => {
+    expect(
+      sandboxState({ settings: settings(defaultIs("full")), sandbox: "full", mode: "run" })
+        .sandboxDoomed,
+    ).toBe(false);
+  });
+
+  // THE PHANTOM-PROFILE RULE: a dangling name is tombstoned, never rewritten.
+  it("flags a value that names no served profile", () => {
+    expect(
+      sandboxState({ settings: settings(), sandbox: "full-no-mcp", mode: "trigger" })
+        .missingProfile,
+    ).toBe(true);
+  });
+
+  it("never tombstones off or the inherit sentinel", () => {
+    expect(sandboxState({ settings: settings(), sandbox: "off", mode: "run" }).missingProfile).toBe(
+      false,
+    );
+    expect(sandboxState({ settings: settings(), sandbox: "", mode: "run" }).missingProfile).toBe(
+      false,
+    );
+  });
+
+  it("cannot tombstone before the profile list has landed", () => {
+    expect(
+      sandboxState({ settings: null, sandbox: "full-no-mcp", mode: "run" }).missingProfile,
+    ).toBe(false);
+  });
+
+  it("surfaces a dangling instance default only while inheriting it", () => {
+    const dangling = settings(defaultIs("deleted-profile", "No staging profile named `deleted-profile`"));
+    expect(
+      sandboxState({ settings: dangling, sandbox: "", mode: "run" }).inheritedDefaultReason,
+    ).toMatch(/deleted-profile/);
+    // An explicit pick does not inherit, so the default's problem is not the user's.
+    expect(
+      sandboxState({ settings: dangling, sandbox: "off", mode: "run" }).inheritedDefaultReason,
+    ).toBeNull();
+  });
+});
+
+describe("buildRunPayload", () => {
+  const fields = {
+    selectedPipeline: pipeline({ id: "p1", name: "Auditor" }),
+    input: "  implement feature X  ",
+    variables: { max_iter: 5 },
+    targetRepo: "  /home/user/project  ",
+    sourceBranch: "dev",
+    autoName: false,
+    runName: "  Fix bug  ",
+    sandbox: "full",
+    images: [new File(["png"], "design.png", { type: "image/png" })],
+  };
+
+  it("posts the trimmed form values", () => {
+    expect(buildRunPayload(fields)).toMatchObject({
+      pipeline: "Auditor",
+      pipeline_id: "p1",
+      input: "implement feature X",
+      variables: { max_iter: 5 },
+      target_repo: "/home/user/project",
+      source_branch: "dev",
+      name: "Fix bug",
+      auto_name: false,
+      sandbox: "full",
+    });
+    expect(buildRunPayload(fields).images).toHaveLength(1);
+  });
+
+  // #338: the box wins over whatever is left in the name field — the daemon never has to
+  // guess from `name` presence.
+  it("sends no name at all when the manager auto-names the Run", () => {
+    expect(buildRunPayload({ ...fields, autoName: true })).toMatchObject({
+      name: undefined,
+      auto_name: true,
+    });
+  });
+
+  it("omits a blank name, repo, branch and image list", () => {
+    const payload = buildRunPayload({
+      ...fields,
+      runName: "   ",
+      targetRepo: "  ",
+      sourceBranch: "",
+      images: [],
+    });
+    expect(payload.name).toBeUndefined();
+    expect(payload.target_repo).toBeUndefined();
+    expect(payload.source_branch).toBeUndefined();
+    expect(payload.images).toBeUndefined();
+  });
+
+  /**
+   * #452, the whole issue in one assertion: `""` means "the user did not choose", and only
+   * an ABSENT `sandbox` lets the daemon apply `default_sandbox` — it reads a present `off`
+   * as final.
+   */
+  it("omits the sandbox key for the inherit sentinel, and sends an explicit off", () => {
+    expect(buildRunPayload({ ...fields, sandbox: "" }).sandbox).toBeUndefined();
+    expect(buildRunPayload({ ...fields, sandbox: "off" }).sandbox).toBe("off");
+  });
+});
+
+describe("buildTriggerCreatePayload / buildTriggerUpdatePayload", () => {
+  const fields = {
+    selectedPipeline: pipeline({ id: "p2", name: "Bugfixer" }),
+    triggerName: "  Nightly audit  ",
+    resolvedCron: "*/15 * * * *",
+    input: "  audit the codebase  ",
+    guardCommand: "  gh issue list  ",
+    targetRepo: "  /home/user/project  ",
+    sourceBranch: "dev",
+    allowOverlap: true,
+    maxConcurrent: " 2 ",
+    sandbox: "minimal",
+    autoName: true,
+    variables: { max_iter: 5 },
+  };
+
+  it("creates with the trimmed form values", () => {
+    expect(buildTriggerCreatePayload(fields)).toEqual({
+      name: "Nightly audit",
+      // #230: the current pipeline is always sent, so an unchanged edit is a no-op repoint.
+      pipeline_id: "p2",
+      cron: "*/15 * * * *",
+      input_template: "audit the codebase",
+      guard_command: "gh issue list",
+      target_repo: "/home/user/project",
+      source_branch: "dev",
+      overlap_policy: "allow",
+      max_concurrent: 2,
+      sandbox: "minimal",
+      auto_name: true,
+      variables: { max_iter: 5 },
+    });
+  });
+
+  it("patches the same values, with `null` where a create simply omits", () => {
+    expect(buildTriggerUpdatePayload(fields)).toEqual({
+      name: "Nightly audit",
+      pipeline_id: "p2",
+      cron: "*/15 * * * *",
+      input_template: "audit the codebase",
+      guard_command: "gh issue list",
+      target_repo: "/home/user/project",
+      source_branch: "dev",
+      overlap_policy: "allow",
+      max_concurrent: 2,
+      sandbox: "minimal",
+      auto_name: true,
+      variables: { max_iter: 5 },
+    });
+  });
+
+  /**
+   * The create/update asymmetry, which is the reason these are two functions: on a PATCH
+   * `undefined` means "leave unchanged", so clearing a field has to be an explicit `null`.
+   * An emptied guard CLEARS it (#162 `Some(None)`); a blank one is simply absent on create.
+   */
+  it("clears an emptied guard, repo, branch and cap on a patch, and omits them on a create", () => {
+    const blanked = { ...fields, guardCommand: "  ", targetRepo: "  ", sourceBranch: "", allowOverlap: false };
+    expect(buildTriggerUpdatePayload(blanked)).toMatchObject({
+      guard_command: null,
+      target_repo: null,
+      source_branch: null,
+      max_concurrent: null,
+      overlap_policy: "skip",
+    });
+    expect(buildTriggerCreatePayload(blanked)).toMatchObject({
+      guard_command: undefined,
+      target_repo: undefined,
+      source_branch: undefined,
+      max_concurrent: undefined,
+      overlap_policy: "skip",
+    });
+  });
+
+  // #239: the cap only means something with overlap allowed, and a blank cap is unbounded.
+  it("drops the cap when overlap is off or the field is blank", () => {
+    expect(buildTriggerCreatePayload({ ...fields, allowOverlap: false }).max_concurrent).toBeUndefined();
+    expect(buildTriggerCreatePayload({ ...fields, maxConcurrent: "  " }).max_concurrent).toBeUndefined();
+    expect(buildTriggerUpdatePayload({ ...fields, maxConcurrent: "" }).max_concurrent).toBeNull();
+  });
+
+  // #410: unlike a Run, a Trigger has a real "inherit" state — so `""` is `null` here,
+  // not an omission.
+  it("sends null for the inherit sentinel on both paths", () => {
+    expect(buildTriggerCreatePayload({ ...fields, sandbox: "" }).sandbox).toBeNull();
+    expect(buildTriggerUpdatePayload({ ...fields, sandbox: "" }).sandbox).toBeNull();
+  });
+
+  // A create sends no input_template at all when blank; a patch clears it to "".
+  it("differs on a blank input template: absent on create, emptied on patch", () => {
+    expect(buildTriggerCreatePayload({ ...fields, input: "   " }).input_template).toBeUndefined();
+    expect(buildTriggerUpdatePayload({ ...fields, input: "   " }).input_template).toBe("");
+  });
+});

--- a/frontend/src/lib/newRunForm.ts
+++ b/frontend/src/lib/newRunForm.ts
@@ -1,0 +1,416 @@
+import type { CreateRunRequest, CreateTriggerRequest, UpdateTriggerRequest } from "../api";
+import type { InstanceSettings, PipelineListEntry, SandboxProfileRef } from "../types";
+import { presetToCron, type CronPresetId } from "../cronPresets";
+
+/**
+ * The New Run / Trigger form's pure logic (#359), lifted out of `NewRunModal.tsx`.
+ *
+ * Everything here is a function of the form's values — no state, no fetch, no React — so
+ * the decisions the dialog makes can be read and tested without rendering it: what a
+ * variable override parses to, what the sandbox selector actually resolves to, whether
+ * Launch / Create is allowed, and the exact request bodies that get posted.
+ *
+ * The modal keeps the JSX shell, the `mode` toggle and the wiring.
+ */
+
+/** What the override inputs hold: the raw typed text, keyed by variable name. */
+type VariableOverrides = Record<string, string>;
+
+export function parseVariableValue(raw: string, varType: string): unknown {
+  switch (varType) {
+    case "int":
+      return parseInt(raw, 10) || 0;
+    case "float":
+      return parseFloat(raw) || 0;
+    case "bool":
+      return raw === "true";
+    case "list":
+      try {
+        return JSON.parse(raw);
+      } catch {
+        return raw
+          .replace(/^\[|\]$/g, "")
+          .split(",")
+          .map((s) => s.trim());
+      }
+    default:
+      return raw;
+  }
+}
+
+/**
+ * The variables a submit sends: only the overrides the selected pipeline actually
+ * DECLARES, and only those that differ from the declared default — an override equal to
+ * the default is not an override, so it stays out of the payload rather than pinning a
+ * value the pipeline may later change.
+ *
+ * Run mode and Trigger mode had a byte-identical copy of this loop each (#359); they now
+ * share this one, so the two can no longer drift apart.
+ */
+export function buildVariables(
+  overrides: VariableOverrides,
+  pipeline: PipelineListEntry,
+): Record<string, unknown> {
+  const variables: Record<string, unknown> = {};
+  for (const [key, val] of Object.entries(overrides)) {
+    const decl = pipeline.variables[key];
+    if (!decl) continue;
+    if (val === String(decl.default)) continue;
+    variables[key] = parseVariableValue(val, decl.var_type);
+  }
+  return variables;
+}
+
+/** How many of the typed overrides are real overrides — the accordion's badge. */
+export function overrideCount(
+  overrides: VariableOverrides,
+  pipeline: PipelineListEntry | undefined,
+): number {
+  if (!pipeline) return 0;
+  return Object.entries(overrides).filter(([key, val]) => {
+    const decl = pipeline.variables[key];
+    if (!decl) return false;
+    return val !== String(decl.default);
+  }).length;
+}
+
+/**
+ * The cron expression the Trigger will be created with: a compiled preset or the raw
+ * escape-hatch expression.
+ */
+export function resolvedCron({
+  cronPresetId,
+  rawCron,
+  dailyHour,
+  dailyMinute,
+}: {
+  cronPresetId: CronPresetId;
+  rawCron: string;
+  dailyHour: number;
+  dailyMinute: number;
+}): string {
+  return cronPresetId === "custom"
+    ? rawCron.trim()
+    : presetToCron(cronPresetId, { hour: dailyHour, minute: dailyMinute });
+}
+
+/**
+ * A prompt-optional pipeline (#158) may launch with an empty prompt; the entry node
+ * sources its own work. Prompt-required (the default) still demands non-empty input.
+ */
+export function promptOptional(pipeline: PipelineListEntry | undefined): boolean {
+  return pipeline?.prompt_required === false;
+}
+
+/** @see promptOptional */
+export function hasRequiredPrompt(promptOptional: boolean, input: string): boolean {
+  return promptOptional || Boolean(input.trim());
+}
+
+/**
+ * The fire_decision reject rule, mirrored client-side: a prompt-required pipeline whose
+ * resolved input would be empty (no guard, no input template) is a misconfiguration. We
+ * pre-block Create and explain why, in addition to the authoritative server-side reject
+ * (CONTEXT.md → Trigger; #161).
+ */
+export function triggerInputRejectReason({
+  mode,
+  selectedPipeline,
+  promptOptional,
+  guardCommand,
+  input,
+}: {
+  mode: "run" | "trigger";
+  selectedPipeline: PipelineListEntry | undefined;
+  promptOptional: boolean;
+  guardCommand: string;
+  input: string;
+}): string | null {
+  return mode === "trigger" &&
+    selectedPipeline &&
+    !promptOptional &&
+    guardCommand.trim().length === 0 &&
+    input.trim().length === 0
+    ? "This pipeline requires a prompt. Add a guard command, an input template, or mark the pipeline prompt-not-required."
+    : null;
+}
+
+export function canLaunch({
+  repoValid,
+  selectedPipeline,
+  hasRequiredPrompt,
+  missingProfile,
+  sandboxDoomed,
+}: {
+  repoValid: boolean | null;
+  selectedPipeline: PipelineListEntry | undefined;
+  hasRequiredPrompt: boolean;
+  missingProfile: boolean;
+  sandboxDoomed: boolean;
+}): boolean {
+  return Boolean(
+    repoValid && selectedPipeline && hasRequiredPrompt && !missingProfile && !sandboxDoomed,
+  );
+}
+
+/**
+ * Trigger creation needs a name, a pipeline, a valid repo and a cron, and a resolvable
+ * input when the pipeline requires a prompt.
+ */
+export function canCreateTrigger({
+  repoValid,
+  selectedPipeline,
+  triggerName,
+  resolvedCron,
+  triggerInputRejectReason,
+  missingProfile,
+}: {
+  repoValid: boolean | null;
+  selectedPipeline: PipelineListEntry | undefined;
+  triggerName: string;
+  resolvedCron: string;
+  triggerInputRejectReason: string | null;
+  missingProfile: boolean;
+}): boolean {
+  return Boolean(
+    repoValid &&
+      selectedPipeline &&
+      triggerName.trim().length > 0 &&
+      resolvedCron.length > 0 &&
+      !triggerInputRejectReason &&
+      // #432: a Trigger pointing at a vanished profile must not be re-saved as-is; the
+      // user picks a real one (or `off`) first.
+      !missingProfile,
+  );
+}
+
+/** Everything the sandbox selector derives from `settings` + the selected value (ADR-0031). */
+export interface SandboxState {
+  dockerUnavailable: boolean;
+  sandboxReason: string | undefined;
+  sandboxProfiles: SandboxProfileRef[];
+  missingProfile: boolean;
+  instanceDefaultSandbox: string | null;
+  effectiveSandbox: string | null;
+  sandboxDoomed: boolean;
+  inheritedDefaultReason: string | null;
+}
+
+/**
+ * The sandbox cluster (#410/#432/#452, ADR-0031 §7). `sandbox` is the selector value in
+ * BOTH modes: `""` = "the user did not choose", `off`, or a staging profile name.
+ */
+export function sandboxState({
+  settings,
+  sandbox,
+  mode,
+}: {
+  settings: InstanceSettings | null;
+  sandbox: string;
+  mode: "run" | "trigger";
+}): SandboxState {
+  // #410: advisory Docker greying. Only gate the sandboxed options once we KNOW Docker is
+  // unavailable (settings loaded && probe false); while settings load, stay
+  // optimistic. `sandboxReason` explains the greying (title + help text).
+  const dockerUnavailable = settings != null && !settings.sandbox_docker.available;
+  const sandboxReason = settings?.sandbox_docker.reason ?? undefined;
+
+  // #432: the options come from the daemon's profile list. Sorted server-side.
+  const sandboxProfiles = settings?.sandbox_profiles ?? [];
+
+  /**
+   * THE PHANTOM-PROFILE RULE. A seeded value is **never** silently rewritten: a
+   * non-empty, non-`off` value that is absent from the list gets a tombstone option and
+   * blocks Save/Launch.
+   *
+   * Without the tombstone React sets `selectedIndex = -1`, the field renders blank, and
+   * saving would PATCH `sandbox: null` — a **silent fallback to the instance default**,
+   * exactly what ADR-0031 §7 forbids. Deliberately separate from the Docker clamp above:
+   * clamping to `off` is legitimate for an unavailable Docker, and would be a silent
+   * fallback for a missing profile.
+   */
+  const missingProfile = Boolean(
+    settings &&
+      sandbox &&
+      sandbox !== "off" &&
+      !sandboxProfiles.some((p) => p.name === sandbox),
+  );
+
+  // #452: the instance default, used to LABEL the inherit option — never to seed the value.
+  // `null` while settings are unknown, which is the honest rendering: we do not know yet.
+  const instanceDefaultSandbox = settings ? (settings.default_sandbox.effective ?? "off") : null;
+
+  // #452: what will actually apply to the Run being created. `""` is not a value — it means
+  // the key is omitted and the instance default decides — so the checks below have to
+  // resolve it to say anything true about the Run.
+  const effectiveSandbox = sandbox === "" ? instanceDefaultSandbox : sandbox;
+
+  /**
+   * #452, the Docker clamp, relocated. A Run whose effective sandbox is a profile while the
+   * daemon reports Docker unavailable is born condemned, so #410 clamped the SELECTOR to
+   * `off`. That protection was right and is kept; the way it was applied was not — it wrote
+   * a business verdict into the field, indistinguishable from a user picking `off`, and
+   * posted it explicitly.
+   *
+   * So refuse the launch and say why, instead of quietly substituting an answer. Same rule
+   * as the phantom-profile tombstone above, for the same reason: the app never demotes a
+   * sandbox behind the user's back (ADR-0031 §7).
+   *
+   * Run mode only. A Trigger resolves its sandbox when it FIRES, and today's Docker probe
+   * says nothing about that moment.
+   */
+  const sandboxDoomed = Boolean(
+    mode === "run" && dockerUnavailable && effectiveSandbox && effectiveSandbox !== "off",
+  );
+
+  // #452: `default_sandbox` carries a `reason` when the winning tier names a profile that
+  // does not resolve. Inheriting is now the default path in run mode, so that dangling name
+  // is worth showing here — the create chokepoint 400s on it rather than falling back.
+  const inheritedDefaultReason = sandbox === "" ? (settings?.default_sandbox.reason ?? null) : null;
+
+  return {
+    dockerUnavailable,
+    sandboxReason,
+    sandboxProfiles,
+    missingProfile,
+    instanceDefaultSandbox,
+    effectiveSandbox,
+    sandboxDoomed,
+    inheritedDefaultReason,
+  };
+}
+
+/** The form values `POST /runs` reads. */
+export interface RunPayloadInput {
+  selectedPipeline: PipelineListEntry;
+  input: string;
+  variables: Record<string, unknown>;
+  targetRepo: string;
+  sourceBranch: string;
+  autoName: boolean;
+  runName: string;
+  sandbox: string;
+  images: File[];
+}
+
+export function buildRunPayload({
+  selectedPipeline,
+  input,
+  variables,
+  targetRepo,
+  sourceBranch,
+  autoName,
+  runName,
+  sandbox,
+  images,
+}: RunPayloadInput): CreateRunRequest {
+  return {
+    pipeline: selectedPipeline.name,
+    input: input.trim(),
+    variables,
+    pipeline_id: selectedPipeline.id,
+    target_repo: targetRepo.trim() || undefined,
+    source_branch: sourceBranch || undefined,
+    name: autoName ? undefined : runName.trim() || undefined,
+    // #338: always send the explicit choice so it wins the create-chokepoint
+    // resolution (the daemon never has to guess from `name` presence for a UI create).
+    auto_name: autoName,
+    // #410/#452: the explicit run-level choice — `off` or a staging profile name — sent
+    // so it wins the create-chokepoint precedence. `""` means the user did not choose,
+    // and OMITS the key: only an absent `sandbox` lets the daemon apply
+    // `default_sandbox`, because it reads a present `off` as final.
+    sandbox: sandbox || undefined,
+    images: images.length > 0 ? images : undefined,
+  };
+}
+
+/** The form values a Trigger create / edit reads. */
+export interface TriggerPayloadInput {
+  selectedPipeline: PipelineListEntry;
+  triggerName: string;
+  resolvedCron: string;
+  input: string;
+  guardCommand: string;
+  targetRepo: string;
+  sourceBranch: string;
+  allowOverlap: boolean;
+  maxConcurrent: string;
+  sandbox: string;
+  autoName: boolean;
+  variables: Record<string, unknown>;
+}
+
+/**
+ * Edit (#162): PATCH the existing Trigger's editable fields. `Some(None)`
+ * semantics: an emptied guard clears it. `pipeline_id` repoints the
+ * trigger to a different pipeline (#230) — previously the editable
+ * dropdown was a phantom control whose change was silently dropped.
+ */
+export function buildTriggerUpdatePayload({
+  selectedPipeline,
+  triggerName,
+  resolvedCron,
+  input,
+  guardCommand,
+  targetRepo,
+  sourceBranch,
+  allowOverlap,
+  maxConcurrent,
+  sandbox,
+  autoName,
+  variables,
+}: TriggerPayloadInput): UpdateTriggerRequest {
+  return {
+    name: triggerName.trim(),
+    pipeline_id: selectedPipeline.id,
+    cron: resolvedCron,
+    input_template: input.trim(),
+    guard_command: guardCommand.trim() || null,
+    target_repo: targetRepo.trim() || null,
+    source_branch: sourceBranch || null,
+    // Round-trip the real overlap policy (#239). Previously hard-coded to
+    // `undefined`, which silently reset every edited trigger toward skip.
+    // `null` clears a stale cap when overlap is off or the input is blank.
+    overlap_policy: allowOverlap ? "allow" : "skip",
+    max_concurrent: allowOverlap && maxConcurrent.trim() ? Number(maxConcurrent) : null,
+    // #410: `""` (Use instance default) clears back to inheriting (`null`);
+    // `off` or a staging profile name sets it.
+    sandbox: sandbox || null,
+    // #338: round-trip the auto-naming choice (flat bool, mirror of `enabled`).
+    auto_name: autoName,
+    variables,
+  };
+}
+
+export function buildTriggerCreatePayload({
+  selectedPipeline,
+  triggerName,
+  resolvedCron,
+  input,
+  guardCommand,
+  targetRepo,
+  sourceBranch,
+  allowOverlap,
+  maxConcurrent,
+  sandbox,
+  autoName,
+  variables,
+}: TriggerPayloadInput): CreateTriggerRequest {
+  return {
+    name: triggerName.trim(),
+    pipeline_id: selectedPipeline.id,
+    cron: resolvedCron,
+    input_template: input.trim() || undefined,
+    guard_command: guardCommand.trim() || undefined,
+    target_repo: targetRepo.trim() || undefined,
+    source_branch: sourceBranch || undefined,
+    overlap_policy: allowOverlap ? "allow" : "skip",
+    max_concurrent: allowOverlap && maxConcurrent.trim() ? Number(maxConcurrent) : undefined,
+    // #410: `""` (Use instance default) → `null` (inherit); `off` or a profile sets it.
+    sandbox: sandbox || null,
+    // #338: freeze the auto-naming choice on the new Trigger (seeded from the
+    // instance default when the modal opened).
+    auto_name: autoName,
+    variables,
+  };
+}

--- a/scripts/layout-ratchet.sh
+++ b/scripts/layout-ratchet.sh
@@ -8,7 +8,7 @@ cd "$(git rev-parse --show-toplevel)"
 
 # <directory>  <max direct tracked files>
 BASELINES='
-frontend/src/components 137
+frontend/src/components 139
 crates/pdo-daemon/src 55
 '
 


### PR DESCRIPTION
Closes #359.

Behavior-preserving frontend refactor: extracts orchestration logic from the four
giant components into testable hooks/lib modules.

## What changed
- **`useRightPaneRouter`** — right-pane routing (node ⇄ Run ⇄ Trigger ⇄ Pipeline-info) extracted from `App.tsx`. Edit↔Run flip keeps the terminal mounted (hidden, not remounted).
- **`useNodeRun`** — node run-command lifecycle (IO poll, prompt fetch, mark-complete #490, retry/start, stale-iter guards) extracted from `NodeDetailPanel.tsx`.
- **`libraryTwins` + `LibraryRow`** — cascade-delete twin logic (scope guards, name join, ambiguity refusal) extracted from `UnifiedLeftPanel.tsx`.
- **`newRunForm` + `useRepoValidation`/`useLaunchTargets`** — New Run/Trigger single-shell form state extracted from `NewRunModal.tsx`.

## Validation
- Layout ratchet: `frontend/src/components` **139/139**, `crates/pdo-daemon/src` 55/55. The `137 → 139` bump is only `LibraryRow.tsx` + its colocated test (other extractions land in `hooks/`/`lib/`, not ratcheted).
- `tsc -b` clean · `eslint .` 0 problems · `vite build` ✓ · **vitest 1701/1701** (107 files).
- No Rust source changed (diff = frontend + 1-line ratchet bump + version).
- FP-359 agentic test (L5) drove all four surfaces live against the real embedded SPA, each UI observation paired with a backing-store probe — **PASS**.

## Rebase note
Rebased onto current `main` (1.16.1). The only overlap was `NodeDetailPanel.tsx`, where #369's mermaid-flicker fix (the `modalSource` `useMemo`) was re-applied on top of the hook extraction; the moved effects/handlers now live in `useNodeRun`.

Version bumped 1.16.1 → 1.17.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)