### PR TITLE
fix(#527): amorce le plancher de prix embarqué avec la génération 5 — 1.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ ascendante** : la casse se signale ici et par un bump majeur, jamais en gardant 
 morts. Seule contrainte non négociable — les **données historiques restent lisibles** : un Run
 archivé s'ouvre et se chiffre quelle que soit la version qui a écrit son payload.
 
+## 1.20.0
+
+Rien de cassant. Le **plancher de prix embarqué** amorce désormais la génération courante
+(`claude-opus-5` / `claude-sonnet-5` / `claude-fable-5`), si bien qu'une instance **jamais
+synchronisée, hors ligne** chiffre son modèle par défaut au lieu d'afficher `~$0.00 †` (#527,
+amende ADR-0034). Le plancher reste un **plancher, pas un miroir** : un sync surcharge encore
+chaque clé (p. ex. `sonnet-5` à son intro live). Bump posé contre `origin/main` (1.19.0) ; à
+re-poser au next-free si un autre Run livre entre-temps.
+
 ## 1.18.0
 
 Rien de cassant. Une capacité **purement additive** : un Run peut désormais lire plusieurs dépôts

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "1.19.0"
+version = "1.20.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "1.19.0"
+version = "1.20.0"
 license = "MIT"
 
 [workspace.dependencies]

--- a/crates/pdo-daemon/src/price_table.rs
+++ b/crates/pdo-daemon/src/price_table.rs
@@ -16,7 +16,13 @@
 //!   freeze the table against future releases.
 //! - **The embedded tier is a FLOOR, not a seed.** `claude-opus-4-0`,
 //!   `claude-sonnet-4-0` and `claude-3-5-haiku` are absent from every remote
-//!   source examined, so the `const` is their ONLY pricer.
+//!   source examined, so the `const` is their ONLY pricer. Since #527 the floor
+//!   ALSO carries the current generation (`claude-opus-5`, `claude-sonnet-5`,
+//!   `claude-fable-5`), so a never-synced, offline instance prices its default
+//!   model out of the box instead of reading `~$0.0000 †`. models.dev DOES carry
+//!   these, so a sync still overrides them by key — a floor, not a mirror
+//!   (ADR-0034 §Amendement #527). "Seed" in ADR-0034 means materialising the
+//!   `const` onto a disk file; adding `const` rows is not that.
 //! - **De-dating is asymmetric on purpose.** A dated key in the *manual* file is
 //!   REFUSED (stripping would silently collapse two rows the author wanted
 //!   distinct, and the refusal teaches); a dated id from the *source* is
@@ -41,14 +47,27 @@ use tracing::warn;
 /// The prices PDO ships — the former `run_cost::PRICES`, moved here verbatim.
 ///
 /// Source: https://platform.claude.com/docs/en/about-claude/pricing (fetched
-/// 2026-07-06). Per-MTok list prices `(family_key, input, output)`. Cache prices
-/// are DERIVED (write_5m = 1.25×in, write_1h = 2×in, read = 0.1×in) — verified
-/// universal across every current row. Match on the FULL family key: Opus
-/// 4.5–4.8 are $5/$25 but Opus 4.1/4.0 are $15/$75 — never a
-/// `starts_with("opus-4")` shortcut.
+/// 2026-07-06; gen-5 rows added 2026-08-13, #527). Per-MTok list prices
+/// `(family_key, input, output)`. Cache prices are DERIVED (write_5m = 1.25×in,
+/// write_1h = 2×in, read = 0.1×in) — verified universal across every current
+/// row. Match on the FULL family key: Opus 4.5–4.8 are $5/$25 but Opus 4.1/4.0
+/// are $15/$75 — never a `starts_with("opus-4")` shortcut.
 ///
-/// Since #427 this is the **floor**, not a seed: a sync never replaces it, and
-/// three of these rows exist in no remote source at all.
+/// Since #427 this is the **floor**, not a seed: a sync never replaces it (merge
+/// by key, [`PriceTable::resolve`]), and nothing here is ever written to disk.
+/// Two kinds of row live here, both floored, never frozen:
+///   - families **no remote source carries** (`claude-opus-4-0`,
+///     `claude-sonnet-4-0`, `claude-3-5-haiku`) — the `const` is their ONLY pricer;
+///   - the **current generation** (`claude-opus-5`, `claude-sonnet-5`,
+///     `claude-fable-5`), seeded by #527 so a never-synced instance prices its
+///     default model out of the box instead of reading `~$0.0000 †`. models.dev
+///     DOES carry these, so any sync overrides them the moment it runs — this is
+///     a floor, not a mirror.
+///
+/// `claude-sonnet-5` is graved at its **post-intro** $3/$15, not the dated intro
+/// $2/$10: the `const` cannot be dated, the intro expires 2026-08-31, and a sync
+/// corrects the ~0.5 % pre-cutover drift — ADR-0034's already-ratified posture for
+/// the fetched tier, now shared by the floor.
 const PRICES: &[(&str, f64, f64)] = &[
     ("claude-opus-4-8", 5.0, 25.0),
     ("claude-opus-4-7", 5.0, 25.0),
@@ -61,6 +80,12 @@ const PRICES: &[(&str, f64, f64)] = &[
     ("claude-sonnet-4-0", 3.0, 15.0),
     ("claude-haiku-4-5", 1.0, 5.0),
     ("claude-3-5-haiku", 0.80, 4.0),
+    // Current generation — floored by #527 so an offline, never-synced instance
+    // prices its default model instead of reading `~$0.0000 †`. models.dev carries
+    // these, so any sync overrides them by key. `sonnet-5` is post-intro $3/$15.
+    ("claude-opus-5", 5.0, 25.0),
+    ("claude-sonnet-5", 3.0, 15.0),
+    ("claude-fable-5", 10.0, 50.0),
 ];
 
 /// Claude Code's local/no-cost sentinel. Priced $0 **above every tier** so it can
@@ -790,6 +815,22 @@ mod tests {
     }
 
     #[test]
+    fn gen_5_is_priced_by_the_embedded_floor_out_of_the_box() {
+        // #527: the offline, never-synced default. `sonnet-5` is the post-intro
+        // $3/$15, not the dated intro $2/$10 — the `const` cannot be dated.
+        let t = PriceTable::builtin();
+        assert_eq!(t.price_for("claude-opus-5"), Some(p(5.0, 25.0)));
+        assert_eq!(t.price_for("claude-sonnet-5"), Some(p(3.0, 15.0)));
+        assert_eq!(t.price_for("claude-fable-5"), Some(p(10.0, 50.0)));
+        // A dated gen-5 id resolves to its family price the same way.
+        assert_eq!(
+            t.price_for("claude-opus-5-20260723"),
+            Some(p(5.0, 25.0)),
+            "a dated gen-5 id must strip to its family"
+        );
+    }
+
+    #[test]
     fn opus_4_1_and_4_0_are_not_collapsed_with_4_5_plus() {
         // The single most error-prone row: same "opus-4" prefix, different price.
         let t = PriceTable::builtin();
@@ -1012,12 +1053,15 @@ mod tests {
 
     #[test]
     fn a_key_only_the_disk_knows_is_priced_and_no_longer_partial() {
+        // A model NEWER than the floor knows (`claude-opus-6`): the enduring value
+        // of the fetched tier once #527 floored the current generation.
         let t = PriceTable::resolve(
             ParsedTier::default(),
-            ParsedTier::of(&[("claude-fable-5", 10.0, 50.0)]),
+            ParsedTier::of(&[("claude-opus-6", 10.0, 50.0)]),
             7,
         );
-        assert_eq!(t.price_for("claude-fable-5"), Some(p(10.0, 50.0)));
+        assert_eq!(t.price_for("claude-opus-6"), Some(p(10.0, 50.0)));
+        assert_eq!(t.tier_of("claude-opus-6"), Some(PriceTier::Fetched));
         // Merge BY KEY: the rest of the floor survives a partial disk tier.
         assert_eq!(t.price_for("claude-opus-4-8"), Some(p(5.0, 25.0)));
     }
@@ -1039,6 +1083,11 @@ mod tests {
         for k in ["claude-opus-4-0", "claude-sonnet-4-0", "claude-3-5-haiku"] {
             assert_eq!(t.tier_of(k), Some(PriceTier::Embedded), "key = {k}");
         }
+        // #527: the gen-5 floor is the OPPOSITE case — models.dev carries these, so a
+        // sync overrides them by key. The live intro `sonnet-5` $2/$10 wins over the
+        // floor's post-intro $3/$15. That is what makes it a floor, not a mirror.
+        assert_eq!(t.price_for("claude-sonnet-5"), Some(p(2.0, 10.0)));
+        assert_eq!(t.tier_of("claude-sonnet-5"), Some(PriceTier::Fetched));
     }
 
     #[test]
@@ -1147,8 +1196,13 @@ mod tests {
         assert_eq!(t.fingerprint(), 0);
         assert_eq!(t.diagnostic(), None);
         assert_eq!(t.price_for("claude-opus-4-8"), Some(p(5.0, 25.0)));
-        assert_eq!(t.price_for("claude-opus-5"), None);
-        // Byte-identical to the pre-#427 behaviour.
+        // #527: gen-5 is floored, so a never-synced instance prices its default
+        // model out of the box — the whole point of the amendment.
+        assert_eq!(t.price_for("claude-opus-5"), Some(p(5.0, 25.0)));
+        assert_eq!(t.tier_of("claude-opus-5"), Some(PriceTier::Embedded));
+        // A model the floor cannot know yet is still unpriced until a sync.
+        assert_eq!(t.price_for("claude-opus-6"), None);
+        // The floor is exactly `builtin()` — nothing seeded on disk.
         assert_eq!(t.resolved, PriceTable::builtin().resolved);
     }
 
@@ -1172,7 +1226,10 @@ mod tests {
         write_fetched_raw(home.path(), "{not json");
         let t = PriceTable::load(home.path());
         assert_eq!(t.price_for("claude-opus-4-8"), Some(p(5.0, 25.0)));
-        assert_eq!(t.price_for("claude-opus-5"), None);
+        // #527: gen-5 falls back to the embedded floor when the fetched tier is inert.
+        assert_eq!(t.price_for("claude-opus-5"), Some(p(5.0, 25.0)));
+        // A model beyond the floor stays unpriced.
+        assert_eq!(t.price_for("claude-opus-6"), None);
         let d = t.diagnostic().expect("a corrupt file must be said");
         assert!(d.contains("fetched.json"), "the path must be named: {d}");
     }

--- a/crates/pdo-daemon/src/run_cost.rs
+++ b/crates/pdo-daemon/src/run_cost.rs
@@ -539,16 +539,13 @@ mod tests {
         // #425: several lines, three of them on models no tier prices. The dated
         // and undated forms of the SAME family collapse to one name (the family
         // key a human would add to price it), and the set is sorted + unique.
+        // #527 floored gen-5, so the unpriced exemplars are models BEYOND the
+        // floor (`claude-opus-6`/`claude-opus-7`) — the case a sync still repairs.
         let lines = vec![
             line(Some("m1"), Some("r1"), "claude-opus-4-8", 1_000_000), // priced
-            line(Some("m2"), Some("r2"), "claude-sonnet-5", 1_000_000),
-            line(
-                Some("m3"),
-                Some("r3"),
-                "claude-sonnet-5-20260501",
-                1_000_000,
-            ), // same family
-            line(Some("m4"), Some("r4"), "claude-fable-5", 1_000_000),
+            line(Some("m2"), Some("r2"), "claude-opus-6", 1_000_000),
+            line(Some("m3"), Some("r3"), "claude-opus-6-20260501", 1_000_000), // same family
+            line(Some("m4"), Some("r4"), "claude-opus-7", 1_000_000),
         ];
         let c = aggregate(lines.into_iter(), &builtin());
         // Only the one priced line contributes.
@@ -556,7 +553,7 @@ mod tests {
         assert!(c.partial);
         assert_eq!(
             c.unpriced_models,
-            vec!["claude-fable-5".to_string(), "claude-sonnet-5".to_string()],
+            vec!["claude-opus-6".to_string(), "claude-opus-7".to_string()],
             "de-dated, de-duplicated, sorted"
         );
         // The invariant the whole design rests on.
@@ -745,7 +742,9 @@ mod tests {
             repo.path(),
             run_id,
             // A model NO tier prices out of the box → $0 + partial, the very symptom.
-            &assistant("m1", "r1", "claude-fable-5", 1_000_000, 0),
+            // Since #527 floored gen-5, this must be a model beyond the floor
+            // (`claude-opus-6`) for the $0 to be genuine.
+            &assistant("m1", "r1", "claude-opus-6", 1_000_000, 0),
         );
         let mtime_before =
             filetime::FileTime::from_last_modification_time(&std::fs::metadata(&file).unwrap());
@@ -755,7 +754,7 @@ mod tests {
         assert!(unpriced.partial, "an unknown model flags partial");
         assert_eq!(
             unpriced.unpriced_models,
-            vec!["claude-fable-5".to_string()],
+            vec!["claude-opus-6".to_string()],
             "and the memo carries the offender's name, not just the flag (#425)"
         );
 
@@ -765,7 +764,7 @@ mod tests {
         std::fs::create_dir_all(manual.parent().unwrap()).unwrap();
         std::fs::write(
             &manual,
-            "models:\n  claude-fable-5: { input: 10.0, output: 50.0 }\n",
+            "models:\n  claude-opus-6: { input: 10.0, output: 50.0 }\n",
         )
         .unwrap();
         let synced = crate::price_table::PriceTable::load(home2.path());

--- a/crates/pdo-daemon/tests/cost_prices.rs
+++ b/crates/pdo-daemon/tests/cost_prices.rs
@@ -57,14 +57,19 @@ edges:
 "#;
 
 /// The real shape of `models.dev/api.json`, trimmed to what the normaliser reads.
-/// Three of these rows are the models #427 measured as unpriced ($0 on ~30 % of
-/// the corpus); `eu.anthropic` is here to prove regional prices are ignored.
+/// The gen-5 rows are the models #427 measured as unpriced; since #527 the
+/// embedded floor prices them out of the box, so `claude-opus-6` stands in as the
+/// model the floor cannot know yet — the case a sync still repairs. `sonnet-5`'s
+/// live intro $2/$10 differs from the floor's post-intro $3/$15, exercising the
+/// "floor always overridden by a sync" invariant. `eu.anthropic` proves regional
+/// prices are ignored.
 const MODELS_DEV: &str = r#"{
   "anthropic": { "models": {
     "claude-opus-4-8":   { "id": "claude-opus-4-8",   "cost": { "input": 5,  "output": 25 } },
     "claude-opus-5":     { "id": "claude-opus-5",     "cost": { "input": 5,  "output": 25 } },
     "claude-sonnet-5":   { "id": "claude-sonnet-5",   "cost": { "input": 2,  "output": 10 } },
     "claude-fable-5":    { "id": "claude-fable-5",    "cost": { "input": 10, "output": 50 } },
+    "claude-opus-6":     { "id": "claude-opus-6",     "cost": { "input": 10, "output": 50 } },
     "claude-haiku-4-5-20251001": { "id": "claude-haiku-4-5-20251001", "cost": { "input": 1, "output": 5 } }
   } },
   "eu.anthropic": { "models": {
@@ -270,18 +275,30 @@ async fn sync_is_registered_and_answers_json() {
     assert_eq!(body["ok"], true);
     assert_eq!(body["source"], fixture.url());
 
-    // The three models #427 measured as unpriced are now priced.
+    // #527: gen-5 is now priced by the embedded FLOOR, so a sync no longer "adds"
+    // it out of the box. What a sync still does — the enduring value ADR-0034
+    // promises — is (a) price models the floor cannot know yet (`claude-opus-6`),
+    // and (b) override the floor when the live source moved: `claude-sonnet-5`'s
+    // floor is the post-intro $3/$15, the live source carries the current intro
+    // $2/$10, so it is UPDATED. This proves the floor is a floor, not a mirror.
     let added: Vec<String> = serde_json::from_value(body["added"].clone()).unwrap();
-    for k in ["claude-opus-5", "claude-sonnet-5", "claude-fable-5"] {
-        assert!(added.contains(&k.to_string()), "added = {added:?}");
-    }
-    // `claude-opus-4-8` was ALREADY priced by the embedded floor at the same price →
-    // unchanged, not added. Merge by key, never replacement.
-    assert!(!added.contains(&"claude-opus-4-8".to_string()));
-    // The dated source id landed de-dated.
+    let updated: Vec<String> = serde_json::from_value(body["updated"].clone()).unwrap();
     assert!(
-        added.contains(&"claude-haiku-4-5".to_string()) || body["unchanged"].as_u64() > Some(0)
+        added.contains(&"claude-opus-6".to_string()),
+        "a model newer than the floor must be added: added = {added:?}"
     );
+    assert!(
+        updated.contains(&"claude-sonnet-5".to_string()),
+        "the live source overrides the floor: updated = {updated:?}"
+    );
+    // `claude-opus-5` / `claude-fable-5` / `claude-opus-4-8` were ALREADY priced by
+    // the embedded floor at the same price → unchanged, neither added nor updated.
+    for k in ["claude-opus-5", "claude-fable-5", "claude-opus-4-8"] {
+        assert!(!added.contains(&k.to_string()), "added = {added:?}");
+        assert!(!updated.contains(&k.to_string()), "updated = {updated:?}");
+    }
+    // The dated source id landed de-dated (and is unchanged: the floor prices it).
+    assert!(body["unchanged"].as_u64() > Some(0));
 
     assert!(
         fetched_path(&daemon).exists(),
@@ -310,8 +327,9 @@ async fn a_sync_reprices_a_live_run_without_restarting_the_daemon() {
         .unwrap();
     let run_id = start_run(&daemon).await;
 
-    // A transcript on a model NO tier prices out of the box: 1 MTok of fable-5.
-    plant_transcript(&daemon, &run_id, "claude-fable-5", 1_000_000);
+    // A transcript on a model NO tier prices out of the box: 1 MTok of opus-6.
+    // #527 floored gen-5, so the demonstrator is a model beyond the floor.
+    plant_transcript(&daemon, &run_id, "claude-opus-6", 1_000_000);
 
     let before = get_run(&daemon, &run_id).await;
     assert_eq!(
@@ -330,7 +348,7 @@ async fn a_sync_reprices_a_live_run_without_restarting_the_daemon() {
         serde_json::from_value(before["cost"]["unpriced_models"].clone()).unwrap();
     assert_eq!(
         named,
-        vec!["claude-fable-5".to_string()],
+        vec!["claude-opus-6".to_string()],
         "GET /runs/:id must name the unpriced model, got {}",
         before["cost"]
     );
@@ -342,7 +360,7 @@ async fn a_sync_reprices_a_live_run_without_restarting_the_daemon() {
     let usd = after["cost"]["usd"].as_f64().unwrap_or(-1.0);
     assert!(
         (usd - 10.0).abs() < 1e-9,
-        "1 MTok of claude-fable-5 at $10/MTok = $10 after the sync, got {usd} ({})",
+        "1 MTok of claude-opus-6 at $10/MTok = $10 after the sync, got {usd} ({})",
         after["cost"]
     );
     assert_eq!(
@@ -418,7 +436,7 @@ async fn an_empty_harvest_answers_502_and_leaves_the_table_byte_identical() {
     );
     // And the table still prices what it used to.
     let s = settings(&daemon2).await;
-    assert_eq!(s["price_table"]["fetched_rows"].as_u64(), Some(5));
+    assert_eq!(s["price_table"]["fetched_rows"].as_u64(), Some(6));
 }
 
 // --- 4. a second sync with nothing to change ---------------------------------
@@ -673,5 +691,5 @@ async fn an_unreachable_source_at_boot_leaves_the_table_and_the_daemon_alive() {
     );
     // The daemon is still serving.
     let s = settings(&daemon2).await;
-    assert_eq!(s["price_table"]["fetched_rows"].as_u64(), Some(5));
+    assert_eq!(s["price_table"]["fetched_rows"].as_u64(), Some(6));
 }

--- a/docs/adr/0034-out-of-band-price-fetch.md
+++ b/docs/adr/0034-out-of-band-price-fetch.md
@@ -83,6 +83,10 @@ fetch out-of-band (bouton, ou rafraîchissement au démarrage)
   trois sources distantes examinées** — models.dev et LiteLLM les ont purgées de leur namespace
   `anthropic`, OpenRouter a délisté 3.5-haiku tout court. Le `const` est donc le **seul tarificateur**
   de ces familles, pas un jeu de données jetable qu'un sync remplacerait.
+  **Amendé par #527** (voir l'amendement en fin d'ADR) : le `const` tarife désormais **aussi** les
+  familles de la génération courante (gen-5), en plancher, **toujours surchargées par un sync**. Le
+  *principe de membership* s'élargit ; le mécanisme (fusion par clé, rien de seedé sur disque) ne bouge
+  pas.
 
 - **Fusion par clé, jamais remplacement.** Une clé présente dans un tier gagne ; une clé absente garde
   ce que le tier suivant en dit. Sous remplacement global, oublier `claude-opus-4-8` effacerait
@@ -335,3 +339,44 @@ fetch out-of-band (bouton, ou rafraîchissement au démarrage)
 - **Transcrire dans `docs/agents/run-scenario.md` la recette de pile isolée et de teardown** que le
   Feature Path de #427 a dû porter lui-même : ce playbook ne dit nulle part comment démarrer ni démonter
   une pile, ce qui est la cause racine documentée de #422, et il omet le socket tmux dérivé du port.
+
+## Amendement — La génération courante entre au plancher embarqué (#527, fork de #425)
+
+Le grill de #425 a isolé une question qui **révise le principe de membership de D2** et ne devait pas
+être exécutée en autonome : faut-il **amorcer** `const PRICES` avec la génération 5 (`claude-opus-5`,
+`claude-sonnet-5`, `claude-fable-5`) pour qu'un montant de coût soit **non nul, hors ligne, d'emblée** —
+sans clic « Sync coûts » ni `models.yaml` ? Le propriétaire a tranché le 2026-08-13 : « **On amende** »
+(issue #527).
+
+**Le symptôme corrigé.** Sur une instance jamais synchronisée et sans `models.yaml` — l'état par défaut
+d'un install neuf, et le seul mode strictement hors ligne — un Run sur un modèle de génération 5 (le
+modèle que le produit fait tourner **par défaut**) lisait son coût `~$0.0000 †`. Le recensement de cette
+ADR chiffre ~30 % de la dépense lue à $0 pour cette seule raison ; le tier fetché la corrige, mais
+**seulement après le premier clic**, et le retard de version du daemon de production rend ce clic tardif.
+
+**Ce qui change.** La table embarquée tarife désormais **ce qu'aucun remote ne porte + les familles de
+la génération courante**, en plancher, **toujours surchargées par un sync**. D2 disait « le `const` est
+le **seul** tarificateur des familles qu'aucune source distante ne porte » ; c'est le *principe de
+membership* qui s'élargit — la gen-5 est le cas inverse (models.dev la porte), et on l'ajoute quand même,
+en plancher.
+
+**Ce qui ne change pas — et pourquoi ce n'est pas « amorcer » au sens interdit.** « Amorcer » dans D2 /
+§9 = **matérialiser le `const` sur un fichier disque** (seeder un `.json`), ce qui figerait un instantané
+qu'une release future masquerait. Ajouter des lignes au `const` n'est pas ça : `builtin()` reste pur, la
+fusion par clé est intacte (`resolve()` insère `PRICES` en plus basse précédence, un sync gagne toujours
+par clé), **aucun fichier n'est seedé**, et une release qui ajoute une ligne au `const` reste visible. La
+table est un plancher, pas un miroir des prix fetchables.
+
+**`sonnet-5` = $3/$15, pas $2/$10.** Le `const` ne peut pas être daté (no-date, délibéré). Le prix
+d'intro ($2/$10) expire le **2026-08-31** ; graver $3/$15 (post-intro) n'est faux que pour les lignes
+sonnet-5 **pré-cutover** des instances **jamais synchronisées** (~0,5 % d'un nombre déjà préfixé `~`, la
+dérive **déjà ratifiée** par cette ADR pour le tier fetché) et se **corrige au premier sync**. Graver
+$2/$10 serait faux pour toute la vie post-31-août de chaque release.
+
+**Tests.** `price_table.rs` : `gen_5_is_priced_by_the_embedded_floor_out_of_the_box` (nouveau) épingle
+les trois prix ; `load_..._is_the_builtin_floor_and_silent` et `load_of_a_corrupt_fetched_file_...`
+passent `claude-opus-5` de `None` à `Some` ; `the_embedded_tier_is_a_floor_not_a_seed` documente en plus
+que la gen-5, elle, **est** surchargée par le tier fetché. La démonstration « un sync répare un $0 »
+(unit `a_key_only_the_disk_knows...`, intégration `a_sync_reprices_a_live_run...`,
+`run_cost::cached_recomputes_when_only_the_price_table_changes`) porte désormais sur un modèle **au-delà
+du plancher** (`claude-opus-6`) — la valeur pérenne du sync une fois la gen-5 devenue plancher.


### PR DESCRIPTION
## Quoi

Le plancher de prix embarqué (`const PRICES`) amorce désormais la génération courante — `claude-opus-5` ($5/$25), `claude-sonnet-5` ($3/$15 post-intro), `claude-fable-5` ($10/$50) — **en plancher, toujours surchargée par un sync** (floor, pas mirror). Une instance jamais synchronisée et hors ligne chiffre donc son modèle par défaut au lieu d'afficher `~$0.00 †`.

`resolve()` / `price_for()` inchangés ; aucun fichier seedé sur disque. **Amende ADR-0034** (le principe de membership s'élargit, le mécanisme ne bouge pas).

## Reposé contre `origin/main` (1.19.0)

Le fix initial visait 1.12.0. Entre-temps **#529** (1.13.0) a introduit `unpriced_models` en **nommant gen-5** comme exemplaire non tarifé dans trois assertions pilotées par `builtin()`. Le plancher tarifant maintenant gen-5, ces assertions **cassaient en silence** après un merge textuellement propre. Elles migrent vers des modèles au-delà du plancher (`claude-opus-6` / `claude-opus-7`), en préservant l'intention (de-dating, dedup, tri, offender nommé) :

- `run_cost::aggregate_names_de_dates_and_dedups_unpriced_models`
- `run_cost::cached_recomputes_when_only_the_price_table_changes`
- `cost_prices::a_sync_reprices_a_live_run_without_restarting_the_daemon`

Les fixtures struct-literal (`stats.rs`, tests frontend) gardent leurs libellés gen-5 : opaques, hors table de prix, non affectés.

## Vérification (locale)

- `cargo +stable fmt --all --check` ✅
- `cargo +stable clippy -p pdo-daemon --all-targets -- -D warnings` ✅
- `cargo +stable build -p pdo-daemon` ✅
- 1834 tests lib + 13 `cost_prices` ✅

Closes #527

🤖 Generated with [Claude Code](https://claude.com/claude-code)