### PR TITLE
fix(#437): FsExplorerModal accessible — role=dialog, focus trap, focus restoration — 1.22.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "1.22.0"
+version = "1.22.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "1.22.0"
+version = "1.22.1"
 license = "MIT"
 
 [workspace.dependencies]

--- a/frontend/src/components/FsExplorerModal.test.tsx
+++ b/frontend/src/components/FsExplorerModal.test.tsx
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
 import FsExplorerModal from "./FsExplorerModal";
 import type { BrowseResponse } from "../api";
 import { browseFs } from "../api";
@@ -245,5 +247,122 @@ describe("FsExplorerModal — testids, layering, errors", () => {
     expect(await screen.findByTestId("fs-browse-error")).toHaveTextContent(
       "path must be an absolute path",
     );
+  });
+});
+
+// A11y (#437). Renders a focusable element OUTSIDE the modal: without it the Tab would
+// loop through the card anyway and the trap test would be a false positive.
+function renderWithOutside(overrides: Partial<Parameters<typeof FsExplorerModal>[0]> = {}) {
+  const props = {
+    onPick: vi.fn(),
+    onClose: vi.fn(),
+    ...overrides,
+  };
+  render(
+    <>
+      <button data-testid="outside">outside</button>
+      <FsExplorerModal {...props} />
+    </>,
+  );
+  return props;
+}
+
+// Harness for focus restoration: a trigger button that mounts the modal on click, so
+// `document.activeElement` at mount is the trigger (what the restoration effect captures).
+function FocusHarness() {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <button data-testid="trigger" onClick={() => setOpen(true)}>
+        open
+      </button>
+      {open && <FsExplorerModal onPick={vi.fn()} onClose={() => setOpen(false)} />}
+    </>
+  );
+}
+
+describe("FsExplorerModal — accessibility (#437)", () => {
+  it("marks the card as an aria-modal dialog", async () => {
+    renderModal();
+    const modal = await screen.findByTestId("fs-browse-modal");
+    expect(modal).toHaveAttribute("role", "dialog");
+    expect(modal).toHaveAttribute("aria-modal", "true");
+  });
+
+  it("names the dialog from the title row when a title is given", async () => {
+    renderModal({ mode: "file", title: "Choose a Dockerfile" });
+    await screen.findByTestId("fs-browse-modal");
+    expect(screen.getByRole("dialog")).toHaveAccessibleName("Choose a Dockerfile");
+  });
+
+  it("derives the name from mode when no title — dir mode says 'Choose a folder'", async () => {
+    renderModal();
+    await screen.findByTestId("fs-browse-modal");
+    expect(screen.getByRole("dialog")).toHaveAccessibleName("Choose a folder");
+  });
+
+  it("derives the name from mode when no title — file mode says 'Choose a file'", async () => {
+    renderModal({ mode: "file" });
+    await screen.findByTestId("fs-browse-modal");
+    expect(screen.getByRole("dialog")).toHaveAccessibleName("Choose a file");
+  });
+
+  it("moves initial focus to the dialog card", async () => {
+    renderModal();
+    await screen.findByTestId("fs-browse-modal");
+    await waitFor(() => expect(screen.getByTestId("fs-browse-modal")).toHaveFocus());
+  });
+
+  it("traps Tab: from the last focusable it wraps to the first, never escaping", async () => {
+    const user = userEvent.setup();
+    renderWithOutside();
+    await screen.findByTestId("fs-browse-select");
+    // Wait for the load so 'Up' is enabled (parent "/") — it is the first focusable.
+    await waitFor(() => expect(screen.getByTestId("fs-browse-up")).toBeEnabled());
+    screen.getByTestId("fs-browse-select").focus(); // last focusable
+    await user.tab();
+    expect(screen.getByTestId("fs-browse-up")).toHaveFocus();
+    expect(screen.getByTestId("outside")).not.toHaveFocus();
+  });
+
+  it("traps Shift+Tab: from the first focusable it wraps to the last, never escaping", async () => {
+    const user = userEvent.setup();
+    renderWithOutside();
+    await screen.findByTestId("fs-browse-select");
+    await waitFor(() => expect(screen.getByTestId("fs-browse-up")).toBeEnabled());
+    screen.getByTestId("fs-browse-up").focus(); // first focusable
+    await user.tab({ shift: true });
+    expect(screen.getByTestId("fs-browse-select")).toHaveFocus();
+    expect(screen.getByTestId("outside")).not.toHaveFocus();
+  });
+
+  it.each(["cancel", "escape", "confirm"] as const)(
+    "restores focus to the opener on close via %s",
+    async (closeVia) => {
+      const user = userEvent.setup();
+      render(<FocusHarness />);
+      const trigger = screen.getByTestId("trigger");
+      await user.click(trigger);
+      // Open: the card holds focus; the confirm button is enabled once the load lands.
+      await waitFor(() => expect(screen.getByTestId("fs-browse-modal")).toHaveFocus());
+      await waitFor(() => expect(screen.getByTestId("fs-browse-select")).toBeEnabled());
+
+      if (closeVia === "cancel") {
+        await user.click(screen.getByRole("button", { name: "Cancel" }));
+      } else if (closeVia === "escape") {
+        fireEvent.keyDown(document, { key: "Escape" });
+      } else {
+        await user.click(screen.getByTestId("fs-browse-select"));
+      }
+
+      await waitFor(() => expect(trigger).toHaveFocus());
+    },
+  );
+
+  it("does not swallow Escape — the trap effect ignores non-Tab keys", async () => {
+    const props = renderModal();
+    await screen.findByTestId("fs-browse-modal");
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(props.onClose).toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/FsExplorerModal.tsx
+++ b/frontend/src/components/FsExplorerModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 // `File` is aliased: the bare name would shadow the DOM `File` global in this module.
 import { ArrowUp, File as FileIcon, Folder, FolderGit2, Link2 } from "lucide-react";
 import { browseFs } from "../api";
@@ -52,9 +52,12 @@ interface Props {
  * unchanged to the pixel) and the settings Dockerfile picker (`mode="file"`,
  * `showHidden`).
  *
- * `role="dialog"` / a focus trap are deliberately out of scope: they are absent since
- * #131, and adding them here would change observable behaviour under an extraction
- * that is meant to change none.
+ * Accessible dialog (#437): `role="dialog"` + `aria-modal`, a name via
+ * `aria-labelledby` (the title row) or an `aria-label` derived from `mode`, a
+ * Tab/Shift+Tab focus trap, initial focus on the card, and focus restored to the
+ * opener on close. First focus trap in the app; if a PARENT modal ever gains its
+ * own trap, the two `document` Tab listeners must be coordinated so only the
+ * topmost is active (mark the background `inert`, or a shared trap stack).
  */
 export default function FsExplorerModal({
   mode = "dir",
@@ -75,6 +78,7 @@ export default function FsExplorerModal({
   const [truncated, setTruncated] = useState(false);
   /** File mode only: the selected file, `null` until one is clicked. */
   const [picked, setPicked] = useState<string | null>(null);
+  const dialogRef = useRef<HTMLDivElement>(null);
 
   // Navigate to `path` (omit → backend default root). Always lands on a 200 shape: an
   // in-body `error` (e.g. permission denied) is surfaced inline while the breadcrumb is
@@ -138,6 +142,57 @@ export default function FsExplorerModal({
     return () => document.removeEventListener("keydown", handleKeyDown);
   }, [onClose]);
 
+  // Focus initial + restitution (#437). Montage == ouverture (cf. l'effet de fetch
+  // ci-dessus). On capture l'opener (la loupe déclencheuse) AVANT de bouger le focus,
+  // on pose le focus sur la carte pour que le lecteur d'écran annonce le dialogue par
+  // son nom accessible, et on rend le focus à l'opener au démontage. `[]` volontaire :
+  // mêmes sémantiques "ouvrir une fois" que l'effet de fetch. StrictMode double-invoque
+  // de façon idempotente (capture -> restore -> capture lit le même opener).
+  useEffect(() => {
+    const opener = document.activeElement as HTMLElement | null;
+    dialogRef.current?.focus();
+    return () => {
+      if (opener?.isConnected) opener.focus?.();
+    };
+  }, []);
+
+  // Piège de focus (#437) : garde Tab / Shift+Tab dans la carte. Effet distinct de
+  // l'Escape pour ne pas perturber son stopPropagation / ordre d'écouteurs. document +
+  // phase bubble, comme l'Escape de ce fichier. Interception AUX BORDS seulement : on ne
+  // redirige qu'au premier/dernier focusable, le Tab au milieu reste natif (pas de calcul
+  // sur les ~1000 lignes, le scroll-suit-focus marche tout seul). Re-query à chaque Tab
+  // pour suivre le churn asynchrone des lignes (navigateTo).
+  useEffect(() => {
+    function handleTab(e: KeyboardEvent) {
+      if (e.key !== "Tab") return;
+      const card = dialogRef.current;
+      if (!card) return;
+      const items = card.querySelectorAll<HTMLElement>(
+        'a[href], button:not([disabled]), input:not([disabled]), ' +
+          'select:not([disabled]), textarea:not([disabled]), ' +
+          '[tabindex]:not([tabindex="-1"])',
+      );
+      if (items.length === 0) return;
+      const first = items[0];
+      const last = items[items.length - 1];
+      const active = document.activeElement;
+      const inside = card.contains(active);
+      if (e.shiftKey) {
+        if (active === first || !inside) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (active === last || !inside) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    }
+    document.addEventListener("keydown", handleTab);
+    return () => document.removeEventListener("keydown", handleTab);
+  }, []);
+
   const handleRow = (entry: BrowseEntry) => {
     // Dir mode: the listing is directories-only by contract, so a row is ALWAYS a
     // navigation and `is_dir` is never consulted — which keeps the frozen
@@ -172,13 +227,23 @@ export default function FsExplorerModal({
       }}
     >
       <div
-        className="flex max-h-[70vh] w-[460px] flex-col rounded-lg border border-line bg-bg-4 shadow-xl"
+        ref={dialogRef}
+        tabIndex={-1}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={title ? `${modalId}-title` : undefined}
+        aria-label={title ? undefined : mode === "file" ? "Choose a file" : "Choose a folder"}
+        className="flex max-h-[70vh] w-[460px] flex-col rounded-lg border border-line bg-bg-4 shadow-xl focus:outline-none"
         data-testid={modalId}
         onClick={(e) => e.stopPropagation()}
       >
         {title && (
           <div className="border-b border-line px-3 py-2">
-            <span className="font-semibold text-fg" style={{ fontSize: "12.5px" }}>
+            <span
+              id={`${modalId}-title`}
+              className="font-semibold text-fg"
+              style={{ fontSize: "12.5px" }}
+            >
               {title}
             </span>
           </div>


### PR DESCRIPTION
Corrige la dette d'accessibilité de `FsExplorerModal` (partagé par le sélecteur de repo *New Run* et le sélecteur de Dockerfile *Settings*), présente depuis #131 et rendue visible par l'extraction de #431.

## Changements
- `role="dialog"` + `aria-modal="true"` sur la carte ; nom accessible via `aria-labelledby` quand `title` est fourni, sinon `aria-label` dérivé du `mode` (« Choose a folder » / « Choose a Dockerfile … »).
- Focus initial posé dans le modal à l'ouverture.
- Focus trap sur Tab / Shift+Tab aux deux bords (Confirm désactivé exclu du set focusable).
- Restitution du focus au déclencheur (la loupe) à la fermeture — pour les deux consommateurs.

Additif : testids historiques (`repo-browser-modal`, `fs-browse-*`) intacts, arité `browseFs` inchangée, Escape reste mono-couche.

## Validation
- Tests front `FsExplorerModal.test.tsx` : **33 verts** (dont les nouveaux `accessibility (#437)`).
- Build front (tsc + vite) vert.
- Test agentique L5 en navigateur réel : rôle/nom, focus initial, piège Tab/Shift+Tab et restitution vérifiés au clavier sur les **deux** consommateurs (repo `dir` sans titre, Dockerfile `file` avec titre). Verdict **Pass**.

Bump PATCH **1.22.1** (fix non cassant).

Closes #437

🤖 Generated with [Claude Code](https://claude.com/claude-code)