### PR TITLE
fix(#473): résout le transcript d'un nœud par identité de session épinglée, plus par cwd — 1.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,17 @@ ascendante** : la casse se signale ici et par un bump majeur, jamais en gardant 
 morts. Seule contrainte non négociable — les **données historiques restent lisibles** : un Run
 archivé s'ouvre et se chiffre quelle que soit la version qui a écrit son payload.
 
-## 1.22.0
+## 1.23.0
+
+Rien de cassant, aucune migration. Le **transcript d'un nœud est résolu par identité de session
+épinglée** (`<uuid>.jsonl`) au lieu du plus récent fichier d'un dossier projet partagé : un nœud
+non code-mutating ne collisionne plus avec le transcript de la session `__manager__` (#473). Le
+spawn d'un nœud agent épingle un `--session-id` UUID v4 (jamais pour un `script`), la veille et le
+resume résolvent par ce nom exact, les sessions infra restent sans id (donc jamais sondées ni
+reprises). ADR-0032 amendé (invariant byte-identité du tail levé pour un nœud agent, conservé pour
+`None`). Bump **re-posé au next-free** (1.23.0 contre `origin/main` 1.22.1) après collision avec
+#437/#465.
+
 
 Rien de cassant. La **liste de dépôts d'un Run devient éditable en cours de Run** — ajout/retrait de
 dépôts secondaires read-only, primaire verrouillé (#465 slice 2, ADR-0042). Bump **re-posé au

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "1.22.1"
+version = "1.23.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "1.22.1"
+version = "1.23.0"
 license = "MIT"
 
 [workspace.dependencies]

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -7512,10 +7512,15 @@ fn spawn_manager_session(
         state.port,
         state.tmux_cmd_override.as_deref(),
         // manager has no NodeDef — always an agent at the account default (#296),
-        // and for the same reason no effort level either (#424)
+        // and for the same reason no effort level either (#424). No pinned session
+        // id either (#473): the manager owns no `NodeStarted`, the sweep never
+        // probes it and it is never resumed, so it keeps the legacy id-less launch —
+        // and resolving nodes by their own id is precisely what stops the manager's
+        // transcript, which shares this cwd, from being read as a node's.
         tmux_session_manager::SessionTail::Agent {
             model: None,
             effort: None,
+            session_id: None,
         },
         sandbox_wrap.as_ref(),
     ) {
@@ -9644,6 +9649,11 @@ struct SweepNodeProbes<'a> {
     /// [`sandbox_run::transcripts_root`]; the encoded cwd segment is still derived
     /// from `working_dir` (the single source of truth), never re-encoded here.
     projects_root: &'a Path,
+    /// #473: the Claude Code session id this node's iteration was launched with,
+    /// read back from its latest `NodeStarted` payload. `Some` ⇒ resolve the
+    /// transcript by identity (`<uuid>.jsonl`); `None` (a pre-#473 row / a script
+    /// node) ⇒ the legacy newest-mtime fallback.
+    session_id: Option<&'a str>,
     pipeline_path: &'a Path,
     artifacts_dir: &'a Path,
     run_id: &'a str,
@@ -9658,7 +9668,17 @@ impl stale_detector::NodeProbes for SweepNodeProbes<'_> {
     }
 
     fn transcript_tail(&self) -> Option<stale_detector::TranscriptTail> {
-        stale_detector::find_session_jsonl(self.projects_root, self.working_dir)
+        // #473: resolve by pinned session identity when we have one — this node's
+        // own `<uuid>.jsonl`, never the newest `.jsonl` in a cwd shared with the
+        // manager / sibling non-CM nodes. A pre-#473 node (no recorded id) falls
+        // back to the legacy newest-mtime resolution.
+        let resolved = match self.session_id {
+            Some(sid) => {
+                stale_detector::session_jsonl_by_id(self.projects_root, self.working_dir, sid)
+            }
+            None => stale_detector::find_session_jsonl(self.projects_root, self.working_dir),
+        };
+        resolved
             .as_deref()
             .and_then(stale_detector::read_transcript_tail)
     }
@@ -9803,6 +9823,11 @@ async fn run_stale_detection(state: &Arc<AppState>) {
 
             let session_name = tmux_session_manager::node_session_name(run_id, node_id, *iter);
 
+            // #473: the session id this iteration was launched with (its latest
+            // `NodeStarted`), so the probe resolves the transcript by identity.
+            // `None` for a script node or a pre-#473 row ⇒ legacy newest-mtime pick.
+            let launch_session_id = find_launch_session_id(&events, node_id, *iter);
+
             // #373: the whole probe → gate → decide → events → diagnostics →
             // usage-limit-dedup pipeline lives in `assess_node`, with all tmux +
             // filesystem I/O injected via this adapter. The sweep only appends
@@ -9812,6 +9837,7 @@ async fn run_stale_detection(state: &Arc<AppState>) {
                 session_name: &session_name,
                 working_dir: &working_dir,
                 projects_root: &projects_root,
+                session_id: launch_session_id.as_deref(),
                 pipeline_path: &pipeline_path,
                 artifacts_dir: &artifacts_dir,
                 run_id,
@@ -10249,10 +10275,14 @@ async fn node_pane(
                     marker: &session_name,
                     workdir: &working_dir,
                 });
-            // #424: `--continue` restores the model but loses the effort level
+            // #424: a resume restores the model but loses the effort level
             // (measured on claude 2.1.220, and the transcript carries nothing to
             // read back), so re-pose the level the node was LAUNCHED with.
             let launch_effort = find_launch_effort(&events, &node_id, iter);
+            // #473: resume by the pinned session id — `--resume <uuid>`, this node's
+            // own transcript. A pre-#473 row (no id) falls back to a bare
+            // `--continue`, which is the very collision this issue fixes.
+            let launch_session_id = find_launch_session_id(&events, &node_id, iter);
             if let Err(e) = tmux_session_manager::resume(
                 &session_name,
                 &working_dir,
@@ -10261,6 +10291,7 @@ async fn node_pane(
                 iter,
                 state.port,
                 launch_effort.as_deref(),
+                launch_session_id.as_deref(),
                 state.tmux_cmd_override.as_deref(),
                 sandbox_wrap.as_ref(),
             ) {
@@ -10324,6 +10355,32 @@ fn find_launch_effort(events: &[event_log::Event], node_id: &str, iter: i64) -> 
         })
         .and_then(|e| e.payload.as_ref())
         .and_then(|p| p.get("effort"))
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+}
+
+/// The Claude Code session id a node's iteration was launched with (#473), read
+/// back from the **latest** `NodeStarted` payload for `(node_id, iter)`.
+///
+/// `.rev().find(...)` takes the most recent `NodeStarted`, so a `restart_node`
+/// that re-spawned the same iteration (a legal same-iter restart) resolves to the
+/// *fresh* id it pinned, not the dead session's. The event log is the source of
+/// truth here for the same reason as [`find_launch_effort`]: ADR-0007 makes a live
+/// iteration immutable to YAML edits. A missing key — every pre-#473 row, every
+/// script node, every infra session — yields `None`, i.e. the legacy newest-mtime
+/// transcript resolution and a bare `--continue` on resume. No migration.
+fn find_launch_session_id(events: &[event_log::Event], node_id: &str, iter: i64) -> Option<String> {
+    events
+        .iter()
+        .rev()
+        .find(|e| {
+            e.kind == event_log::EventKind::NodeStarted
+                && e.node_id.as_deref() == Some(node_id)
+                && e.iter == Some(iter)
+        })
+        .and_then(|e| e.payload.as_ref())
+        .and_then(|p| p.get("session_id"))
         .and_then(|v| v.as_str())
         .filter(|s| !s.is_empty())
         .map(|s| s.to_string())
@@ -10583,12 +10640,14 @@ async fn spawn_merge_resolver(
         state.port,
         state.tmux_cmd_override.as_deref(),
         // __merge_resolver__ has no NodeDef — agent at the account default (#296),
-        // hence no effort level either (#424). NOT to be confused with a `merge`
-        // NODE, which is a regular NodeDef routed through `spawn_node` and DOES
-        // carry an effort.
+        // hence no effort level either (#424), and no pinned session id (#473): it
+        // owns no `NodeStarted` and is neither probed nor resumed. NOT to be
+        // confused with a `merge` NODE, which is a regular NodeDef routed through
+        // `spawn_node` and DOES carry an effort and a pinned id.
         tmux_session_manager::SessionTail::Agent {
             model: None,
             effort: None,
+            session_id: None,
         },
         sandbox_wrap.as_ref(),
     ) {

--- a/crates/pdo-daemon/src/node_primitives.rs
+++ b/crates/pdo-daemon/src/node_primitives.rs
@@ -87,6 +87,10 @@ enum StartNodeTail {
     Agent {
         model: Option<String>,
         effort: Option<String>,
+        /// #473: the pinned Claude Code session id (owned mirror of
+        /// [`tmux_session_manager::SessionTail::Agent::session_id`]). `None` for a
+        /// script node — it launches no `claude`.
+        session_id: Option<String>,
     },
     Script {
         timeout_secs: u64,
@@ -113,9 +117,14 @@ impl StartNodeSpawn {
     /// silent failure is exchanged for a visible one. That is the right way round.
     pub(crate) fn execute(&self) -> anyhow::Result<()> {
         let tail = match &self.tail {
-            StartNodeTail::Agent { model, effort } => tmux_session_manager::SessionTail::Agent {
+            StartNodeTail::Agent {
+                model,
+                effort,
+                session_id,
+            } => tmux_session_manager::SessionTail::Agent {
                 model: model.as_deref(),
                 effort: effort.as_deref(),
+                session_id: session_id.as_deref(),
             },
             StartNodeTail::Script { timeout_secs, env } => {
                 tmux_session_manager::SessionTail::Script {
@@ -346,6 +355,11 @@ pub(crate) fn start_node(params: &StartNodeParams<'_>) -> StartNodeResult {
         params.default_model.as_deref(),
     );
     let resolved_effort = tmux_session_manager::resolve_node_effort(node.effort.as_deref());
+    // #473: pin a Claude Code session id for an agent node so the sweep resolves
+    // its transcript by identity and the resume path re-enters it. `None` for a
+    // script node (no claude) — mirrors `node_spawn`. Recorded on `NodeStarted`
+    // below and threaded into the tail.
+    let session_id: Option<String> = (!is_script).then(|| uuid::Uuid::new_v4().to_string());
     let tail = if is_script {
         StartNodeTail::Script {
             timeout_secs: tmux_session_manager::SCRIPT_TIMEOUT_SECS,
@@ -355,6 +369,7 @@ pub(crate) fn start_node(params: &StartNodeParams<'_>) -> StartNodeResult {
         StartNodeTail::Agent {
             model: resolved_model.map(str::to_string),
             effort: resolved_effort.map(str::to_string),
+            session_id: session_id.clone(),
         }
     };
 
@@ -374,6 +389,10 @@ pub(crate) fn start_node(params: &StartNodeParams<'_>) -> StartNodeResult {
             // recorded even though nothing reads it back yet.
             "model": resolved_model,
             "effort": resolved_effort,
+            // #473: the pinned Claude Code session id — read back by the sweep
+            // (transcript resolution) and the resume path. `null` for a script node
+            // and every pre-#473 row. Mirrors the `spawn_node` payload.
+            "session_id": session_id,
             // #503: the sub-worktree's base commit. Absent for a node with no
             // sub-worktree (`doc-only`/`script`), which never merges back.
             "base_sha": spawn_base_sha,

--- a/crates/pdo-daemon/src/node_spawn.rs
+++ b/crates/pdo-daemon/src/node_spawn.rs
@@ -397,6 +397,15 @@ pub(crate) async fn spawn_node(
         default_effective.as_deref(),
     );
     let resolved_effort = tmux_session_manager::resolve_node_effort(node.effort.as_deref());
+    // #473: pin a Claude Code session id for an AGENT node so its transcript is
+    // `<uuid>.jsonl` and the liveness sweep resolves it by identity — never by the
+    // newest `.jsonl` in a cwd it shares with the manager and sibling non-CM nodes.
+    // Recorded on `NodeStarted` (below) so the resume path and the sweep read it
+    // back; a fresh id per spawn means a `restart_node` of the same iteration gets
+    // its own transcript. A `script` node launches no `claude`, so it gets no id
+    // (`null` in the payload) — nothing would resolve it and nothing resumes it.
+    let session_id: Option<String> =
+        (node.node_type != pipeline::NodeType::Script).then(|| uuid::Uuid::new_v4().to_string());
 
     // Panic/cancellation-isolated spawn window (#279). Everything from here to
     // the `NodeStarted` append can panic (`build_full_prompt`, image discovery,
@@ -570,6 +579,13 @@ pub(crate) async fn spawn_node(
                 // so storing the effort alone would store half a fact.
                 "model": resolved_model,
                 "effort": resolved_effort,
+                // #473: the pinned Claude Code session id the agent launches with
+                // (`claude --session-id <uuid>`). The sweep resolves this node's
+                // transcript by it (`<uuid>.jsonl`), and the resume path re-enters
+                // it (`--resume <uuid>`). `null` for a `script` node (no claude) and
+                // for every pre-#473 row (legacy newest-mtime resolution / bare
+                // `--continue`), so no migration is needed.
+                "session_id": session_id.as_deref(),
                 // #503 / ADR-0036: the sub-worktree's base commit — what the
                 // merge-back compares the pipeline tip against to decide whether a
                 // conflict is the run's own history rewritten by this node. `null`
@@ -645,10 +661,11 @@ pub(crate) async fn spawn_node(
         }
     } else {
         // Resolved above the panic span so the `NodeStarted` payload could record
-        // the same values the flags carry (#347/#424).
+        // the same values the flags carry (#347/#424/#473).
         tmux_session_manager::SessionTail::Agent {
             model: resolved_model,
             effort: resolved_effort,
+            session_id: session_id.as_deref(),
         }
     };
     // A script node executes the RAW bash body (`role_prompt`), never the

--- a/crates/pdo-daemon/src/stale_detector.rs
+++ b/crates/pdo-daemon/src/stale_detector.rs
@@ -335,8 +335,44 @@ pub fn encode_working_dir(dir: &Path) -> String {
         .collect()
 }
 
+/// Resolve a node's transcript by its **pinned session id** (#473): Claude Code
+/// names the transcript file `<session_id>.jsonl` under the encoded-cwd project
+/// dir, so an exact-name lookup returns *this node's own* transcript regardless of
+/// how many other `.jsonl` files share the dir.
+///
+/// This is the fix for the manager-vs-node collision: a non-`code-mutating`/`merge`
+/// node's cwd is the Run worktree, which is also the manager's cwd (and every
+/// sibling non-CM node's), so one CC project dir holds several `.jsonl` and
+/// [`find_session_jsonl`]'s newest-mtime pick returns whichever was touched last —
+/// usually the manager's. Resolving by the id PDO pinned at spawn
+/// (`claude --session-id <uuid>`) is immune to that.
+///
+/// `projects_root` is the same #408 seam as [`find_session_jsonl`] (staging root
+/// for a live sandboxed Run, `~/.claude/projects/` otherwise); the cwd encoding
+/// stays the single source of truth (#373). Returns `None` when the file does not
+/// exist yet (a session that has not written its transcript), which the sweep
+/// treats as "no signal".
+pub fn session_jsonl_by_id(
+    projects_root: &Path,
+    working_dir: &Path,
+    session_id: &str,
+) -> Option<PathBuf> {
+    let encoded = encode_working_dir(working_dir);
+    let path = projects_root
+        .join(encoded)
+        .join(format!("{session_id}.jsonl"));
+    path.is_file().then_some(path)
+}
+
 /// Find the most recently modified `.jsonl` file for `working_dir` under the
 /// given Claude Code `projects/` root.
+///
+/// **Legacy fallback since #473.** The turn-end probe now resolves by pinned
+/// session id ([`session_jsonl_by_id`]) whenever the node recorded one; this
+/// newest-mtime resolution survives only for a node started before #473 (no id in
+/// its `NodeStarted`), where it is exactly the pre-#473 behaviour — including its
+/// known collision with the manager's transcript, which no historical node can now
+/// avoid but every new node does.
 ///
 /// `projects_root` is the seam that lets a sandboxed Run's transcripts be read
 /// from its staged home while it is live (#408): the caller resolves it via
@@ -499,8 +535,16 @@ pub trait NodeProbes {
     /// — see [`decide`].
     fn session_alive(&self) -> bool;
 
-    /// Trailing slice + mtime of the newest Claude Code transcript for this
-    /// node's working dir, or `None` when nothing resolves (#469 §2).
+    /// Trailing slice + mtime of *this node's* Claude Code transcript, or `None`
+    /// when nothing resolves (#469 §2).
+    ///
+    /// #473: the implementation resolves by the session id PDO pinned at spawn
+    /// ([`session_jsonl_by_id`]) — the transcript named `<uuid>.jsonl`, this node's
+    /// own — and only falls back to the newest-mtime pick ([`find_session_jsonl`])
+    /// for a pre-#473 node with no recorded id. Without that, a
+    /// non-`code-mutating`/`merge` node shares its cwd (the Run worktree) with the
+    /// manager's `claude`, so the newest `.jsonl` was usually the manager's and the
+    /// turn-end verdict was read off the wrong conversation.
     ///
     /// Called **only** when turn-end auto-completion is enabled. With the setting
     /// off this is never invoked, which is the whole of "unchecked ⇒ no transcript
@@ -1433,6 +1477,80 @@ SwapFree:         204800 kB
             "find_session_jsonl must resolve a real PDO node transcript after the #373 fix"
         );
         assert_eq!(found.unwrap().file_name().unwrap(), "session.jsonl");
+    }
+
+    // --- session_jsonl_by_id (#473: resolve by pinned identity, not mtime) ---
+
+    #[test]
+    fn session_jsonl_by_id_resolves_the_exact_named_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let projects = tmp.path().join(".claude").join("projects");
+        let wd = Path::new("/home/user/project");
+        let dir = projects.join(encode_working_dir(wd));
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let sid = "11111111-2222-3333-4444-555555555555";
+        std::fs::write(dir.join(format!("{sid}.jsonl")), "{}").unwrap();
+
+        let found = session_jsonl_by_id(&projects, wd, sid).expect("must resolve the pinned id");
+        assert_eq!(found.file_name().unwrap(), format!("{sid}.jsonl").as_str());
+    }
+
+    #[test]
+    fn session_jsonl_by_id_missing_file_is_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let projects = tmp.path().join(".claude").join("projects");
+        // The dir may not even exist yet (session hasn't written a transcript).
+        assert!(
+            session_jsonl_by_id(&projects, Path::new("/home/user/project"), "no-such-id").is_none()
+        );
+    }
+
+    /// **The #473 bug, as a red/green contrast.** A single shared CC project dir
+    /// (the Run worktree, shared by the manager and a non-CM node) holds two
+    /// transcripts: the node's pinned `<uuid>.jsonl` (older) and the manager's
+    /// (newer). `find_session_jsonl` — the pre-#473 resolution — returns the
+    /// manager's (newest mtime); `session_jsonl_by_id` returns the node's own.
+    #[test]
+    fn session_jsonl_by_id_ignores_a_newer_sibling_transcript() {
+        let tmp = tempfile::tempdir().unwrap();
+        let projects = tmp.path().join(".claude").join("projects");
+        // A representative shared worktree cwd.
+        let wd = Path::new("/home/u/.pdo/runs/20260101-120000-abc/worktree");
+        let dir = projects.join(encode_working_dir(wd));
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let node_sid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let node_file = dir.join(format!("{node_sid}.jsonl"));
+        std::fs::write(&node_file, "node").unwrap();
+        filetime::set_file_mtime(
+            &node_file,
+            filetime::FileTime::from_system_time(SystemTime::now() - Duration::from_secs(600)),
+        )
+        .unwrap();
+
+        // The manager's transcript, in the SAME dir, touched more recently.
+        let manager_file = dir.join("00000000-0000-0000-0000-000000000000.jsonl");
+        std::fs::write(&manager_file, "manager").unwrap();
+
+        // Pre-#473: newest-mtime pick returns the MANAGER's file — the bug.
+        assert_eq!(
+            find_session_jsonl(&projects, wd)
+                .unwrap()
+                .file_name()
+                .unwrap(),
+            "00000000-0000-0000-0000-000000000000.jsonl",
+            "the legacy resolution picks the newest sibling (the manager) — this is the bug"
+        );
+        // #473: identity resolution returns the NODE's own transcript.
+        assert_eq!(
+            session_jsonl_by_id(&projects, wd, node_sid)
+                .unwrap()
+                .file_name()
+                .unwrap(),
+            format!("{node_sid}.jsonl").as_str(),
+            "resolving by pinned id must return this node's transcript, not the newest sibling"
+        );
     }
 
     // --- validate_outputs (integration with outputs_validator) ---

--- a/crates/pdo-daemon/src/tmux_session_manager.rs
+++ b/crates/pdo-daemon/src/tmux_session_manager.rs
@@ -75,6 +75,15 @@ pub enum SessionTail<'a> {
         /// ⇒ no `--effort`, byte-identical tail. A `Script` tail carries no such
         /// field, so the type itself guarantees a `script` node never gets one.
         effort: Option<&'a str>,
+        /// #473: the PDO-pinned Claude Code session id (`claude --session-id
+        /// <uuid>`). Claude Code names its transcript `<session_id>.jsonl`, so
+        /// pinning it lets the liveness sweep resolve a node's transcript by
+        /// *identity* instead of by the newest `.jsonl` in a cwd it shares with the
+        /// manager and any sibling non-`code-mutating`/`merge` node. `None` *or* an
+        /// empty string ⇒ no `--session-id`, byte-identical legacy tail — the state
+        /// for infra sessions (`__manager__` / `__merge_resolver__`) that own no
+        /// `NodeStarted`, are never probed by the sweep and are never resumed.
+        session_id: Option<&'a str>,
     },
     /// Script node (#248). Runs `timeout <secs>s bash <body>` then completes on
     /// exit 0 / fails otherwise. `env` is the `PDO_INPUT_*`/`PDO_OUTPUT_*`/… I/O
@@ -269,9 +278,15 @@ fn wrap_with_env(
 
 /// Build the `exec claude …` tail for an agent node. A non-empty `model`
 /// inserts `--model '<m>'`, a non-empty `effort` inserts `--effort '<lvl>'`
-/// after it; `None` *or* an empty string on both reproduces the legacy command
-/// byte-for-byte.
-fn build_agent_tail(prompt_path: &Path, model: Option<&str>, effort: Option<&str>) -> String {
+/// after it, and a non-empty `session_id` inserts `--session-id '<uuid>'` last;
+/// `None` *or* an empty string on all three reproduces the legacy command
+/// byte-for-byte (the state infra sessions launch in).
+fn build_agent_tail(
+    prompt_path: &Path,
+    model: Option<&str>,
+    effort: Option<&str>,
+    session_id: Option<&str>,
+) -> String {
     // A non-empty `Some` ⇒ a single-quoted `--model '<m>' ` with a trailing
     // space; `None` OR `Some("")` ⇒ empty string, so the command collapses to
     // the exact legacy literal (one space before the `"$(cat …)"`). The
@@ -291,10 +306,21 @@ fn build_agent_tail(prompt_path: &Path, model: Option<&str>, effort: Option<&str
         Some(e) if !e.is_empty() => format!("--effort {} ", sh_single_quote(e)),
         _ => String::new(),
     };
+    // #473: pin the Claude Code session id so its transcript is `<uuid>.jsonl` and
+    // the liveness sweep resolves it by identity, never by newest-mtime in a shared
+    // cwd. Placed LAST (after model/effort) so the model/effort byte-identity
+    // substrings the #296/#424 tests pin stay contiguous. `None` OR `Some("")` ⇒
+    // empty fragment (infra sessions): the tail then reproduces the legacy launch
+    // byte-for-byte, so the pre-#473 "no id" behaviour is what `None` still means.
+    let session_flag = match session_id {
+        Some(s) if !s.is_empty() => format!("--session-id {} ", sh_single_quote(s)),
+        _ => String::new(),
+    };
     format!(
-        "exec claude --dangerously-skip-permissions {}{}\"$(cat {})\"",
+        "exec claude --dangerously-skip-permissions {}{}{}\"$(cat {})\"",
         model_flag,
         effort_flag,
+        session_flag,
         sh_single_quote(&prompt_path.to_string_lossy())
     )
 }
@@ -385,10 +411,14 @@ pub fn build_tmux_script(
                 NO_ENV,
             )
         }
-        SessionTail::Agent { model, effort } => {
+        SessionTail::Agent {
+            model,
+            effort,
+            session_id,
+        } => {
             let cmd = match tmux_cmd_override {
                 Some(cmd) => cmd.to_string(),
-                None => build_agent_tail(prompt_path, model, effort),
+                None => build_agent_tail(prompt_path, model, effort, session_id),
             };
             (cmd, NO_ENV)
         }
@@ -409,31 +439,46 @@ pub fn build_tmux_script(
     }
 }
 
-/// Build a resume script that uses `claude --continue` in the same working_dir.
+/// Build a resume script that re-enters the node's saved conversation in the same
+/// working_dir.
 ///
-/// `tmux_cmd_override` replaces the default `claude --continue` tail when
-/// `Some` — the per-daemon test seam.
+/// `tmux_cmd_override` replaces the default resume tail when `Some` — the
+/// per-daemon test seam.
+///
+/// **#473 — resume by session identity.** When `session_id` is a non-empty pinned
+/// id (recorded on `NodeStarted` at spawn), the tail is `claude --resume <uuid>`,
+/// which re-enters *this node's* transcript. The pre-#473 tail was a bare
+/// `--continue`, which re-enters "the most recent conversation of the cwd" — and
+/// for a non-`code-mutating`/`merge` node that cwd is the Run worktree, shared with
+/// the manager's `claude` and any sibling non-CM node, so a resumed node could pick
+/// up the *manager's* (or a sibling's) conversation. `session_id` = `None` or empty
+/// (a pre-#473 row with no recorded id) falls back to that bare `--continue`,
+/// byte-identical to the legacy tail — no migration.
 ///
 /// No `--model` is threaded here (#296): a resumed session keeps the model it
 /// was launched with — "Resumed sessions started with `claude --resume`,
 /// `--continue`, or the `/resume` picker keep the model they were using when
 /// the transcript was saved" (https://code.claude.com/docs/en/model-config).
-/// So `--continue` never silently downgrades the per-node model.
+/// So resuming never silently downgrades the per-node model.
 ///
 /// `--effort` IS threaded here (#424), because that guarantee covers the model
-/// and nothing else. Measured on claude 2.1.220: `--effort xhigh` then
-/// `--continue` reports `auto (currently high)` — the level is lost, and the
-/// transcript stores no `effort` field for anything to read back. So the level
-/// is re-posed from the `NodeStarted` payload (launch-time value, not the
-/// current YAML — ADR-0007: an edit has no effect on a live node's current iter).
-/// `None` or an empty string ⇒ a bare `--continue`, byte-identical to the legacy
-/// tail.
+/// and nothing else. Measured on claude 2.1.220: `--effort xhigh` then a resume
+/// reports `auto (currently high)` — the level is lost, and the transcript stores
+/// no `effort` field for anything to read back. So the level is re-posed from the
+/// `NodeStarted` payload (launch-time value, not the current YAML — ADR-0007: an
+/// edit has no effect on a live node's current iter). `None` or an empty string ⇒
+/// no `--effort`.
+// Every argument is an irreducible input to the resume script (identity, working
+// context, launch selectors, sandbox wrap); bundling them into a struct would only
+// move the list, not shorten it — same rationale as `resume` / `spawn`.
+#[allow(clippy::too_many_arguments)]
 fn build_resume_script(
     run_id: &str,
     node_id: &str,
     iter: i64,
     daemon_port: u16,
     effort: Option<&str>,
+    session_id: Option<&str>,
     tmux_cmd_override: Option<&str>,
     sandbox: Option<&SandboxWrap<'_>>,
 ) -> String {
@@ -441,9 +486,17 @@ fn build_resume_script(
         Some(e) if !e.is_empty() => format!(" --effort {}", sh_single_quote(e)),
         _ => String::new(),
     };
+    // #473: `--resume <uuid>` targets THIS node's transcript by identity; a
+    // pre-#473 row with no recorded id falls back to positional `--continue`.
+    let resume_flag = match session_id {
+        Some(s) if !s.is_empty() => format!("--resume {}", sh_single_quote(s)),
+        _ => "--continue".to_string(),
+    };
     let tail_cmd = match tmux_cmd_override {
         Some(cmd) => cmd.to_string(),
-        None => format!("exec claude --dangerously-skip-permissions --continue{effort_flag}"),
+        None => {
+            format!("exec claude --dangerously-skip-permissions {resume_flag}{effort_flag}")
+        }
     };
 
     // #407: the 6th tail path (`claude --continue`) is wrapped identically — a
@@ -583,13 +636,17 @@ pub fn spawn_shell(
     Ok(())
 }
 
-/// Resume a dead session via `claude --continue` in the original working_dir.
+/// Resume a dead session in the original working_dir.
 ///
 /// `effort` is the level the node was **launched** with, read back from its
-/// `NodeStarted` event (#424) — `--continue` restores the model but not the
-/// effort, so the flag has to be re-posed. Deliberately not re-resolved from the
-/// current YAML: ADR-0007 makes a live node's current iteration immutable to
-/// edits.
+/// `NodeStarted` event (#424) — a resume restores the model but not the effort,
+/// so the flag has to be re-posed. Deliberately not re-resolved from the current
+/// YAML: ADR-0007 makes a live node's current iteration immutable to edits.
+///
+/// `session_id` is the node's pinned Claude Code session id (#473), also read back
+/// from `NodeStarted`. When present the resume is `--resume <uuid>` (this node's
+/// own transcript); when absent (a pre-#473 row) it degrades to a bare
+/// `--continue`.
 #[allow(clippy::too_many_arguments)]
 pub fn resume(
     session_name: &str,
@@ -599,6 +656,7 @@ pub fn resume(
     iter: i64,
     daemon_port: u16,
     effort: Option<&str>,
+    session_id: Option<&str>,
     tmux_cmd_override: Option<&str>,
     sandbox: Option<&SandboxWrap<'_>>,
 ) -> Result<()> {
@@ -608,6 +666,7 @@ pub fn resume(
         iter,
         daemon_port,
         effort,
+        session_id,
         tmux_cmd_override,
         sandbox,
     );
@@ -1685,6 +1744,7 @@ mod tests {
             SessionTail::Agent {
                 model: None,
                 effort: None,
+                session_id: None,
             },
             None,
         );
@@ -1705,6 +1765,7 @@ mod tests {
             SessionTail::Agent {
                 model: None,
                 effort: None,
+                session_id: None,
             },
             None,
         );
@@ -1729,6 +1790,7 @@ mod tests {
             SessionTail::Agent {
                 model: None,
                 effort: None,
+                session_id: None,
             },
             None,
         );
@@ -1763,6 +1825,7 @@ mod tests {
             SessionTail::Agent {
                 model: Some("opus"),
                 effort: None,
+                session_id: None,
             },
             None,
         );
@@ -1801,6 +1864,7 @@ mod tests {
             SessionTail::Agent {
                 model: Some(""),
                 effort: None,
+                session_id: None,
             },
             None,
         );
@@ -1814,7 +1878,9 @@ mod tests {
         );
     }
 
-    /// #424 helper: build an agent tail with an arbitrary model/effort pair.
+    /// #424 helper: build an agent tail with an arbitrary model/effort pair. No
+    /// pinned session id (#473) — the model/effort byte-identity tests below assert
+    /// on the legacy tail, so this helper keeps `session_id: None`.
     fn agent_script(model: Option<&str>, effort: Option<&str>) -> String {
         build_tmux_script(
             "run-abc",
@@ -1823,7 +1889,11 @@ mod tests {
             5172,
             Path::new("/tmp/test-prompt.md"),
             None,
-            SessionTail::Agent { model, effort },
+            SessionTail::Agent {
+                model,
+                effort,
+                session_id: None,
+            },
             None,
         )
     }
@@ -1894,6 +1964,86 @@ mod tests {
             "effort-only tail must leave no gap: {script}"
         );
         assert!(!script.contains("--model"), "{script}");
+    }
+
+    /// #473 helper: build an agent tail with model/effort/session_id.
+    fn agent_script_with_session(
+        model: Option<&str>,
+        effort: Option<&str>,
+        session_id: Option<&str>,
+    ) -> String {
+        build_tmux_script(
+            "run-abc",
+            "solo",
+            1,
+            5172,
+            Path::new("/tmp/test-prompt.md"),
+            None,
+            SessionTail::Agent {
+                model,
+                effort,
+                session_id,
+            },
+            None,
+        )
+    }
+
+    #[test]
+    fn build_script_omits_session_id_when_none_or_empty() {
+        // #473: `None` OR `Some("")` (an infra session — manager / merge resolver)
+        // emits no `--session-id`, byte-identical to the legacy tail. This is what
+        // keeps the pre-#473 launch bytes for the sessions the sweep never probes.
+        for sid in [None, Some("")] {
+            let script = agent_script_with_session(None, None, sid);
+            assert!(
+                !script.contains("--session-id"),
+                "no session-id flag when unset ({sid:?}): {script}"
+            );
+            assert!(
+                script.contains("exec claude --dangerously-skip-permissions \"$(cat "),
+                "legacy tail must be byte-identical without a pinned id ({sid:?}): {script}"
+            );
+        }
+    }
+
+    #[test]
+    fn build_script_inserts_session_id_after_model_and_effort() {
+        // #473: a pinned id emits `--session-id '<uuid>'` LAST — after model/effort,
+        // right before the prompt cat — so Claude Code names its transcript
+        // `<uuid>.jsonl` and the sweep resolves it by identity. Single-quoted, hence
+        // `'\''` once `wrap_with_env` re-wraps the tail in `bash -c '…'`.
+        let sid = "11111111-2222-3333-4444-555555555555";
+        let script = agent_script_with_session(Some("opus"), Some("low"), Some(sid));
+        assert!(
+            script.contains(&format!(
+                r#"--effort '\''low'\'' --session-id '\''{sid}'\'' "$(cat "#
+            )),
+            "session-id must follow model/effort and precede the prompt cat: {script}"
+        );
+        let effort_at = script.find("--effort").unwrap();
+        let session_at = script.find("--session-id").unwrap();
+        let cat_at = script.find("$(cat").unwrap();
+        assert!(
+            effort_at < session_at && session_at < cat_at,
+            "order must be --model, --effort, --session-id, then the prompt cat: {script}"
+        );
+    }
+
+    #[test]
+    fn build_script_session_id_without_model_or_effort_hugs_the_base_flag() {
+        // #473: an id-only node (the common case — no model/effort override) emits
+        // the session-id flag directly after `--dangerously-skip-permissions`, no
+        // gap where the absent model/effort fragments would have been.
+        let sid = "11111111-2222-3333-4444-555555555555";
+        let script = agent_script_with_session(None, None, Some(sid));
+        assert!(
+            script.contains(&format!(
+                r#"--dangerously-skip-permissions --session-id '\''{sid}'\'' "$(cat "#
+            )),
+            "id-only tail must leave no gap: {script}"
+        );
+        assert!(!script.contains("--model"), "{script}");
+        assert!(!script.contains("--effort"), "{script}");
     }
 
     #[test]
@@ -2302,6 +2452,7 @@ mod tests {
             SessionTail::Agent {
                 model: None,
                 effort: None,
+                session_id: None,
             },
             Some(&wrap),
         );
@@ -2428,6 +2579,7 @@ mod tests {
             SessionTail::Agent {
                 model: None,
                 effort: None,
+                session_id: None,
             },
             None,
         );
@@ -2444,10 +2596,11 @@ mod tests {
 
     #[test]
     fn build_resume_script_wraps_continue_in_docker_exec() {
-        // #407: the 6th tail path (`claude --continue`) is wrapped identically.
+        // #407: the 6th tail path (the resume) is wrapped identically. No pinned id
+        // here (#473) ⇒ the legacy `--continue` fallback.
         let wt = Path::new("/repo/.pdo/runs/r1/nodes/solo/iter-1");
         let wrap = sample_wrap("pdo-r1-solo-iter-1", wt);
-        let wrapped = build_resume_script("r1", "solo", 1, 6172, None, None, Some(&wrap));
+        let wrapped = build_resume_script("r1", "solo", 1, 6172, None, None, None, Some(&wrap));
         assert!(
             wrapped.contains("docker exec -i -t -e PDO_SBX_SESSION=pdo-r1-solo-iter-1"),
             "{wrapped}"
@@ -2455,11 +2608,66 @@ mod tests {
         assert!(wrapped.contains("pdo-sbx-r1 bash -lc"), "{wrapped}");
         assert!(wrapped.contains("--continue"), "{wrapped}");
         // off path unchanged.
-        let off = build_resume_script("r1", "solo", 1, 6172, None, None, None);
+        let off = build_resume_script("r1", "solo", 1, 6172, None, None, None, None);
         assert!(!off.contains("docker"), "{off}");
         assert!(
             off.contains("exec claude --dangerously-skip-permissions --continue"),
             "{off}"
+        );
+    }
+
+    #[test]
+    fn build_resume_script_resumes_by_session_id_when_pinned() {
+        // #473: a node with a pinned session id resumes by IDENTITY — `--resume
+        // <uuid>`, which re-enters this node's own transcript, never "the newest
+        // conversation of the cwd" (which is the manager's or a sibling's when the
+        // cwd is the shared Run worktree). The uuid is single-quoted, hence `'\''`
+        // once `wrap_with_env` re-wraps the tail in `bash -c '…'`.
+        let sid = "11111111-2222-3333-4444-555555555555";
+        let off = build_resume_script("r1", "solo", 1, 6172, None, Some(sid), None, None);
+        assert!(
+            off.contains(&format!(r"--resume '\''{sid}'\''")),
+            "resume must target the pinned session id: {off}"
+        );
+        assert!(
+            !off.contains("--continue"),
+            "a pinned id must NOT fall back to positional --continue: {off}"
+        );
+        // Sandboxed: same identity resume, wrapped into the container. The docker
+        // exec re-quotes the tail (`sh_quote_arg` around the outer `bash -c`), so
+        // the single-quote escaping is doubled — assert on the flag + the verbatim
+        // uuid, not on the exact quoting.
+        let wt = Path::new("/repo/.pdo/runs/r1/worktree");
+        let wrap = sample_wrap("pdo-r1-solo-iter-1", wt);
+        let wrapped = build_resume_script(
+            "r1",
+            "solo",
+            1,
+            6172,
+            Some("low"),
+            Some(sid),
+            None,
+            Some(&wrap),
+        );
+        assert!(wrapped.contains("pdo-sbx-r1 bash -lc"), "{wrapped}");
+        assert!(wrapped.contains("--resume"), "{wrapped}");
+        assert!(
+            wrapped.contains(sid),
+            "the resumed uuid must survive the wrap: {wrapped}"
+        );
+        // Effort is still re-posed after the resume flag (#424).
+        assert!(wrapped.contains("--effort"), "{wrapped}");
+    }
+
+    #[test]
+    fn build_resume_script_falls_back_to_continue_for_empty_session_id() {
+        // #473: an empty pinned id behaves exactly like `None` (a pre-#473 row) —
+        // the legacy positional `--continue`, byte-identical.
+        let script = build_resume_script("r1", "solo", 1, 6172, None, Some(""), None, None);
+        assert!(!script.contains("--resume"), "{script}");
+        assert!(
+            script.contains(r"exec claude --dangerously-skip-permissions --continue'"),
+            "empty id must degrade to the legacy --continue tail: {script}"
         );
     }
 
@@ -2469,7 +2677,7 @@ mod tests {
         // byte-identical to the legacy tail. `Some("")` behaves like `None` — the
         // same last-resort guard as the spawn tail.
         for effort in [None, Some("")] {
-            let script = build_resume_script("r1", "solo", 1, 6172, effort, None, None);
+            let script = build_resume_script("r1", "solo", 1, 6172, effort, None, None, None);
             assert!(
                 !script.contains("--effort"),
                 "no effort flag when unset ({effort:?}): {script}"
@@ -2491,7 +2699,7 @@ mod tests {
         // the transcript stores no effort field to read back. So the level is
         // re-posed here, from the `NodeStarted` payload. Still no `--model`: that
         // one really is restored.
-        let script = build_resume_script("r1", "solo", 1, 6172, Some("low"), None, None);
+        let script = build_resume_script("r1", "solo", 1, 6172, Some("low"), None, None, None);
         assert!(
             script.contains(r"--continue --effort '\''low'\''"),
             "effort must be re-posed right after --continue: {script}"
@@ -2514,11 +2722,15 @@ mod tests {
             1,
             6172,
             Some("low"),
+            Some("11111111-2222-3333-4444-555555555555"),
             Some("exec sleep 60"),
             None,
         );
         assert!(script.contains("exec sleep 60"), "{script}");
         assert!(!script.contains("--effort"), "{script}");
+        // The override REPLACES the whole tail — neither the effort nor the #473
+        // session-id resume flag survives it.
+        assert!(!script.contains("--resume"), "{script}");
         assert!(!script.contains("claude"), "{script}");
     }
 }

--- a/crates/pdo-daemon/tests/tmux_run_spawn.rs
+++ b/crates/pdo-daemon/tests/tmux_run_spawn.rs
@@ -96,6 +96,7 @@ fn build_tmux_script_uses_exec_bash_and_invokes_claude() {
         SessionTail::Agent {
             model: None,
             effort: None,
+            session_id: None,
         },
         None,
     );

--- a/docs/adr/0032-liveness-death-and-turn-end-completion.md
+++ b/docs/adr/0032-liveness-death-and-turn-end-completion.md
@@ -9,6 +9,12 @@
 > *détecteur* et était fausse pour le *reaper* : celui-ci **fabriquait** la mort que le détecteur
 > observait ensuite fidèlement, sous un `session_died` parfaitement crédible. Le verdict terminal
 > reste le bon ; ce qu'il faut lire avec lui, c'est **qui** a tué la session.
+>
+> **Amendé par #473 (résolution du transcript par identité de session, 1.22.0).** Le §2 lisait « *son*
+> transcript » ; le code lisait en réalité le `.jsonl` le plus récent du dossier projet CC, résolu par
+> **cwd**. Or un nœud ni `code-mutating` ni `merge` tourne dans le worktree du Run, qui est **aussi** le
+> cwd de la session manager — un seul dossier, plusieurs transcripts, la sonde prenait le dernier touché
+> (souvent celui du manager). Voir « Résolution du transcript » ci-dessous.
 
 Trois décisions durables, arbitrées sur deux réponses du owner : *on veut détecter Mort, pas un seuil
 qui ne serait pas robuste* ; *un faux positif ne doit pas coûter un Run*.
@@ -107,6 +113,24 @@ avec `CompletionSource::TurnEnded`. Sans cela, sur un nœud `code-mutating`/`mer
 `run_advance::complete_node`, dans le handler. L'événement émis est `EventKind::NodeAutoCompleted` (déjà
 projeté comme une complétion, déjà couvert par la même garde) — pour que le log dise que la complétion
 est automatique.
+
+**Résolution du transcript : par identité de session, jamais par cwd (#473).** « *Son* transcript »
+n'est pas ce que le code mesurait : la sonde encodait le **cwd** puis prenait le `.jsonl` de mtime
+maximale du dossier projet CC. Un nœud ni `code-mutating` ni `merge` partage ce cwd (le worktree du
+Run) avec la session manager — donc un dossier, plusieurs `.jsonl`, et le plus récent est **souvent
+celui du manager**. La même racine frappait `claude --continue` au resume (`build_resume_script`),
+toujours actif même case décochée : un nœud non-CM respawné reprenait « la conv. la plus récente du
+cwd » = potentiellement celle du manager ou d'un nœud frère. Correctif : **PDO épingle un `sessionId`
+au spawn** (`claude --session-id <uuid>`, enregistré sur `NodeStarted`) ; CC nomme son transcript
+`<uuid>.jsonl`, donc la sonde résout par **nom exact** (`session_jsonl_by_id`) et le resume cible ce
+transcript-là (`--resume <uuid>`). Les infra sessions (`__manager__` / `__merge_resolver__`) restent
+sans id : elles n'ont pas de `NodeStarted`, ne sont jamais sondées ni reprises — et résoudre chaque
+nœud par *son* id suffit à ignorer leur transcript partagé. Les nœuds `code-mutating`/`merge` étaient
+déjà immunisés (sous-worktree dédié, dossier non partagé) ; ils reçoivent un id quand même, par
+uniformité. Une ligne d'avant #473 (aucun id enregistré) retombe proprement sur l'ancienne résolution
+mtime et le `--continue` positionnel — aucune migration. **L'invariant byte-identité du tail** (#296 /
+#347 / #424) ne vaut donc plus pour un nœud agent : chaque tail porte désormais `--session-id`. Il est
+conservé pour le cas `None` (infra sessions) et la parité host≡sandbox reste entière.
 
 ### 3. #373 Unit B est fermé en won't-do
 


### PR DESCRIPTION
Closes #473

## Problème

Le transcript d'un nœud non code-mutating collisionnait avec celui de la session `__manager__` :
`find_session_jsonl` résolvait le transcript par **cwd** et prenait le fichier `<uuid>.jsonl` le
plus récent du dossier projet Claude Code partagé. La veille lisait alors le mauvais transcript, et
un nœud repris rouvrait la conversation du manager.

## Correctif

Résolution du transcript par **identité de session épinglée** plutôt que par récence :

- Le spawn d'un nœud **agent** épingle un `--session-id` UUID v4 (jamais pour un nœud `script`),
  persisté dans le payload `NodeStarted` (`session_id`) et passé au tail (`build_agent_tail`,
  `--session-id` en dernier ; resume en `--resume <uuid>`, repli `--continue` sur id absent).
- `stale_detector::session_jsonl_by_id` résout par **nom exact** `<uuid>.jsonl` ;
  `find_session_jsonl` (mtime) conservée en repli légataire.
- Sonde de veille et `node_pane` (reprise) résolvent par identité ; helper `find_launch_session_id`
  (`.rev().find`) prend l'id frais après un `restart_node` du même iter.
- Sessions infra (`__manager__`, `__merge_resolver__`) laissées en `session_id: None` — donc jamais
  sondées ni reprises.

ADR-0032 amendé (résolution par identité, invariant byte-identité du tail levé pour un nœud agent,
conservé pour `None`). Rétrocompat sans migration.

## Version

Bump **1.23.0** (MINOR) — re-posé au next-free après collision de bump avec #437/#465 sur
`origin/main` (1.22.1). Frontend non versionné (correctif daemon Rust pur).

## Vérification

- `cargo +stable build -p pdo-daemon` : vert.
- `cargo +stable fmt --all --check` + `clippy -p pdo-daemon --all-targets` : propres.
- `cargo +stable test -p pdo-daemon` : **1854 tests verts** (le test unitaire de contraste
  rouge/vert de `stale_detector` verrouille bug↔fix).
- Verdict du nœud Visual tester : **Pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)