### PR TITLE
feat(#507): journal d'audit hors-Run (audit_log) + GET /audit — 1.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ ascendante** : la casse se signale ici et par un bump majeur, jamais en gardant 
 morts. Seule contrainte non négociable — les **données historiques restent lisibles** : un Run
 archivé s'ouvre et se chiffre quelle que soit la version qui a écrit son payload.
 
+## 1.25.0
+
+Rien de cassant, aucune migration (`CREATE TABLE IF NOT EXISTS`, aucun backfill). PDO gagne un
+**troisième journal** : `audit_log`, le foyer des **mutations de configuration hors-Run** —
+create/patch/delete de Trigger et pause globale — jusqu'ici invisibles à l'`event_log` (dont
+l'`Event.run_id` est obligatoire). Table dédiée sans `run_id` dans `pdo.db`, écrite au **handler
+HTTP** après commit (best-effort : sous-rapport possible, sur-rapport jamais), lue par `GET /audit`
+(feed global décroissant, filtrable par cible et fenêtre `[from, to)`). L'origine est un indice
+**déclaratif et falsifiable** (`actor_hint` via l'en-tête `X-PDO-Actor`, jamais un gate — bind
+0.0.0.0 sans auth). Referme la cause de la fausse #505 : un Trigger coupé à la main laisse désormais
+une trace. AC5 (signal *vivant* `overdue`) différé hors v1 (#507, ADR-0044).
+
 ## 1.24.0
 
 Rien de cassant, aucune migration. La **complétion sur fin de tour gagne un substrat primaire,

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -498,6 +498,9 @@ Les Triggers vivent dans une table SQLite (`~/.pdo/pdo.db`), pas en YAML : un Tr
 
 **Table `trigger_fires`** (audit) : un enregistrement horodaté par tick significatif (`fired` / `skipped-overlap` / `guard-exit-nonzero` / `guard-error`), keyé par Trigger. Répond à la question #1 du debug : « pourquoi mon Trigger n'a pas firé cette nuit ? ». Sur un skip de guard, PDO conserve stdout/stderr/exit code (plafonnés, queue conservée — l'erreur s'imprime en dernier) : purement diagnostiques, ils n'altèrent pas le contrat d'input. La provenance (`manual` vs `cron`) est une dimension orthogonale à l'outcome (#341).
 
+**Trois journaux, trois questions.** PDO tient trois journaux disjoints, chacun pour une question de debug distincte : l'**event log** (« qu'est-il arrivé *dans ce Run* ? » — vérité event-sourced du Run, `run_id` obligatoire) ; **`trigger_fires`** (« pourquoi mon Trigger a-t-il firé, ou pas ? » — les évaluations de scheduling) ; et l'**`audit_log`** (« qui a changé la config de l'app, et quand ? » — les mutations *hors-Run* : create/patch/delete de Trigger et pause globale). L'audit log est le seul sans `run_id` : un geste de config n'appartient à aucun Run. Origine best-effort (`actor_hint`, falsifiable, jamais un gate — bind 0.0.0.0 sans auth). Contrat : ADR-0044.
+_Éviter_ : « le log » sans qualifier lequel des trois.
+
 ### UI — onglet Triggers
 
 - **Ligne** : status dot, nom, pipeline, badge repo, planning lisible, toggle enable/disable, next/last fire. **Panneau détail** : config + historique des fires avec raison.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "1.24.0"
+version = "1.25.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "1.24.0"
+version = "1.25.0"
 license = "MIT"
 
 [workspace.dependencies]

--- a/crates/pdo-daemon/src/audit_log.rs
+++ b/crates/pdo-daemon/src/audit_log.rs
@@ -1,0 +1,437 @@
+//! Journal d'audit hors-Run (#507, ADR-0044). Le troisième journal de PDO,
+//! frère de [`crate::trigger_store`] / [`crate::instance_config`] : il consigne
+//! les mutations de configuration faites *hors Run* — désactiver un Trigger à la
+//! main, éditer son cron, mettre les Triggers en pause — invisibles à
+//! l'`event_log` (dont l'`Event.run_id` est obligatoire, la projection refusant
+//! tout fragment sans `RunStarted`). Append-only, sans `run_id`, sur le pool
+//! `pdo.db` partagé.
+//!
+//! **Invariant (ADR-0044) :** l'audit peut *sous-rapporter* (mutation réussie,
+//! ligne manquante sur disque plein / base verrouillée) mais **jamais**
+//! *sur-rapporter* (une ligne pour une mutation non commitée). D'où l'ordre au
+//! seam : lire l'avant → muter → écrire l'audit **après le commit**, en
+//! best-effort ([`record_best_effort`]). Un échec d'écriture se logue en
+//! `error!` et n'échoue jamais la mutation appelante.
+//!
+//! **Origine best-effort :** [`Actor`] lit un en-tête `X-PDO-Actor` déclaratif
+//! (`ui` / `cli` / `unknown`) stocké en colonne `actor_hint` — jamais `actor`.
+//! Le daemon bind 0.0.0.0 sans auth : l'origine est un indice falsifiable,
+//! jamais un gate de comportement.
+
+use serde::Serialize;
+use sqlx::{Row, SqlitePool};
+
+/// Une ligne d'audit relue pour le feed `GET /audit` (décroissant, newest-first).
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct AuditEntry {
+    pub id: i64,
+    pub ts: String,
+    pub actor_hint: String,
+    pub action: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target_kind: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub before: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub after: Option<serde_json::Value>,
+}
+
+/// Une écriture d'audit en attente, remise à [`record`] / [`record_best_effort`].
+/// Deux colonnes explicites `before`/`after` (pas un `detail` fourre-tout) : AC2
+/// demande *avant → après*.
+#[derive(Debug, Clone)]
+pub(crate) struct NewAuditEntry {
+    pub actor_hint: String,
+    pub action: String,
+    pub target_kind: Option<String>,
+    pub target_id: Option<String>,
+    pub before: Option<serde_json::Value>,
+    pub after: Option<serde_json::Value>,
+}
+
+/// Crée la table (et son index temporel) si absente. `CREATE TABLE IF NOT
+/// EXISTS`, aucune `ALTER`, aucun backfill → zéro risque sur un `pdo.db` prod.
+pub(crate) async fn init(db: &SqlitePool) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS audit_log (
+            id          INTEGER PRIMARY KEY AUTOINCREMENT,
+            ts          TEXT NOT NULL,
+            actor_hint  TEXT NOT NULL,
+            action      TEXT NOT NULL,
+            target_kind TEXT,
+            target_id   TEXT,
+            before      TEXT,
+            after       TEXT
+        )",
+    )
+    .execute(db)
+    .await?;
+    sqlx::query("CREATE INDEX IF NOT EXISTS idx_audit_log_ts ON audit_log(ts)")
+        .execute(db)
+        .await?;
+    Ok(())
+}
+
+/// Écrit une entrée. Renvoie l'erreur au caller (les tests s'en servent) ;
+/// `before`/`after` sont sérialisés en TEXT JSON (SQLite n'a pas de type JSON
+/// réel — comme `Event.payload`).
+pub(crate) async fn record(db: &SqlitePool, e: NewAuditEntry) -> Result<(), sqlx::Error> {
+    let before = e.before.as_ref().map(|v| v.to_string());
+    let after = e.after.as_ref().map(|v| v.to_string());
+    sqlx::query(
+        "INSERT INTO audit_log (ts, actor_hint, action, target_kind, target_id, before, after)
+         VALUES (?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(crate::event_log::now_iso())
+    .bind(&e.actor_hint)
+    .bind(&e.action)
+    .bind(&e.target_kind)
+    .bind(&e.target_id)
+    .bind(before)
+    .bind(after)
+    .execute(db)
+    .await?;
+    Ok(())
+}
+
+/// Best-effort (ADR-0044) : ne fait **jamais** échouer la mutation appelante ;
+/// un échec d'écriture se logue en `error!` (jamais `warn!` — une entrée d'audit
+/// manquante est un vrai trou d'observabilité, pas un avertissement mineur).
+pub(crate) async fn record_best_effort(db: &SqlitePool, e: NewAuditEntry) {
+    let (action, target) = (e.action.clone(), e.target_id.clone());
+    if let Err(err) = record(db, e).await {
+        tracing::error!(action = %action, target_id = ?target, "audit_log: écriture échouée: {err}");
+    }
+}
+
+/// Lecture filtrée, newest-first. `id DESC` seul suffit (`INTEGER PRIMARY KEY
+/// AUTOINCREMENT` est déjà un ordre total — pas de tiebreak sur `ts`). Les
+/// quatre filtres sont optionnels : un feed global décroissant par défaut, la
+/// posture #505 (on découvre *quelle* cible dans le flux). `[from, to)` :
+/// borne basse incluse, borne haute exclue.
+pub(crate) async fn list(
+    db: &SqlitePool,
+    from: Option<&str>,
+    to: Option<&str>,
+    target_kind: Option<&str>,
+    target_id: Option<&str>,
+    limit: i64,
+) -> Result<Vec<AuditEntry>, sqlx::Error> {
+    let rows = sqlx::query(
+        "SELECT id, ts, actor_hint, action, target_kind, target_id, before, after
+         FROM audit_log
+         WHERE (?1 IS NULL OR ts >= ?1)
+           AND (?2 IS NULL OR ts < ?2)
+           AND (?3 IS NULL OR target_kind = ?3)
+           AND (?4 IS NULL OR target_id = ?4)
+         ORDER BY id DESC
+         LIMIT ?5",
+    )
+    .bind(from)
+    .bind(to)
+    .bind(target_kind)
+    .bind(target_id)
+    .bind(limit)
+    .fetch_all(db)
+    .await?;
+    rows.iter().map(row_to_entry).collect()
+}
+
+/// `row.get` pour les colonnes NOT NULL, `try_get` pour les nullables. Les blobs
+/// `before`/`after` sont du TEXT JSON qu'on reparse en `Value` ; un TEXT
+/// malformé (jamais écrit par [`record`], mais on ne panique pas dessus)
+/// dégrade en `None`.
+fn row_to_entry(row: &sqlx::sqlite::SqliteRow) -> Result<AuditEntry, sqlx::Error> {
+    let before: Option<String> = row.try_get("before")?;
+    let after: Option<String> = row.try_get("after")?;
+    Ok(AuditEntry {
+        id: row.get("id"),
+        ts: row.get("ts"),
+        actor_hint: row.get("actor_hint"),
+        action: row.get("action"),
+        target_kind: row.try_get("target_kind")?,
+        target_id: row.try_get("target_id")?,
+        before: before.and_then(|s| serde_json::from_str(&s).ok()),
+        after: after.and_then(|s| serde_json::from_str(&s).ok()),
+    })
+}
+
+/// Origine déclarative d'une mutation de config, lue de l'en-tête `X-PDO-Actor`.
+/// **Falsifiable** (bind 0.0.0.0, aucune auth) : c'est un indice de traçabilité
+/// stocké en `actor_hint`, jamais un gate de comportement. `Cli` est reconnu par
+/// forward-proofing bien qu'aucune sous-commande CLI ne mute de Trigger en v1.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Actor {
+    Ui,
+    Cli,
+    Unknown,
+}
+
+impl Actor {
+    pub(crate) fn as_hint(self) -> &'static str {
+        match self {
+            Actor::Ui => "ui",
+            Actor::Cli => "cli",
+            Actor::Unknown => "unknown",
+        }
+    }
+}
+
+/// Le premier extracteur `FromRequestParts` du crate. Ne rejette **jamais**
+/// (`Infallible`) : un en-tête absent ou inconnu vaut [`Actor::Unknown`], pas un
+/// 4xx — « origine inconnue » est acceptable, « aucune entrée » ne l'est pas.
+/// À placer avant le consommateur de corps (`Json<T>`) dans les signatures de
+/// handler (axum exige le body-extractor en dernier).
+impl<S> axum::extract::FromRequestParts<S> for Actor
+where
+    S: Send + Sync,
+{
+    type Rejection = std::convert::Infallible;
+
+    async fn from_request_parts(
+        parts: &mut axum::http::request::Parts,
+        _state: &S,
+    ) -> Result<Self, Self::Rejection> {
+        Ok(
+            match parts
+                .headers
+                .get("X-PDO-Actor")
+                .and_then(|v| v.to_str().ok())
+            {
+                Some("ui") => Actor::Ui,
+                Some("cli") => Actor::Cli,
+                _ => Actor::Unknown,
+            },
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::extract::FromRequestParts;
+
+    async fn test_db() -> SqlitePool {
+        let db = sqlx::sqlite::SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .unwrap();
+        init(&db).await.unwrap();
+        db
+    }
+
+    fn trigger_entry(action: &str, id: &str) -> NewAuditEntry {
+        NewAuditEntry {
+            actor_hint: "ui".to_string(),
+            action: action.to_string(),
+            target_kind: Some("trigger".to_string()),
+            target_id: Some(id.to_string()),
+            before: None,
+            after: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn record_then_list_roundtrips_before_and_after_json() {
+        // A patch-shaped entry carries both snapshots; `list` must give them back
+        // byte-for-byte as JSON, not as re-escaped strings.
+        let db = test_db().await;
+        record(
+            &db,
+            NewAuditEntry {
+                actor_hint: "ui".to_string(),
+                action: "trigger.updated".to_string(),
+                target_kind: Some("trigger".to_string()),
+                target_id: Some("t-1".to_string()),
+                before: Some(serde_json::json!({"enabled": true, "name": "nightly"})),
+                after: Some(serde_json::json!({"enabled": false, "name": "nightly"})),
+            },
+        )
+        .await
+        .unwrap();
+
+        let rows = list(&db, None, None, None, None, 200).await.unwrap();
+        assert_eq!(rows.len(), 1);
+        let e = &rows[0];
+        assert_eq!(e.actor_hint, "ui");
+        assert_eq!(e.action, "trigger.updated");
+        assert_eq!(e.target_kind.as_deref(), Some("trigger"));
+        assert_eq!(e.target_id.as_deref(), Some("t-1"));
+        assert_eq!(
+            e.before.as_ref().unwrap()["enabled"],
+            serde_json::json!(true)
+        );
+        assert_eq!(
+            e.after.as_ref().unwrap()["enabled"],
+            serde_json::json!(false)
+        );
+        assert!(!e.ts.is_empty(), "ts is stamped by now_iso()");
+    }
+
+    #[tokio::test]
+    async fn create_and_delete_null_snapshots_survive() {
+        // create → before NULL, after set; delete → before set, after NULL. Both
+        // NULLs must round-trip as `None`, not as a JSON `null` Value.
+        let db = test_db().await;
+        record(
+            &db,
+            NewAuditEntry {
+                after: Some(serde_json::json!({"id": "t-1"})),
+                ..trigger_entry("trigger.created", "t-1")
+            },
+        )
+        .await
+        .unwrap();
+        record(
+            &db,
+            NewAuditEntry {
+                before: Some(serde_json::json!({"id": "t-1"})),
+                ..trigger_entry("trigger.deleted", "t-1")
+            },
+        )
+        .await
+        .unwrap();
+
+        let rows = list(&db, None, None, None, None, 200).await.unwrap();
+        // newest-first: delete then create.
+        assert_eq!(rows[0].action, "trigger.deleted");
+        assert!(rows[0].before.is_some());
+        assert!(rows[0].after.is_none());
+        assert_eq!(rows[1].action, "trigger.created");
+        assert!(rows[1].before.is_none());
+        assert!(rows[1].after.is_some());
+    }
+
+    #[tokio::test]
+    async fn list_is_newest_first_by_id() {
+        let db = test_db().await;
+        for i in 0..5 {
+            record(&db, trigger_entry("trigger.updated", &format!("t-{i}")))
+                .await
+                .unwrap();
+        }
+        let rows = list(&db, None, None, None, None, 200).await.unwrap();
+        let ids: Vec<i64> = rows.iter().map(|e| e.id).collect();
+        let mut sorted = ids.clone();
+        sorted.sort_unstable();
+        sorted.reverse();
+        assert_eq!(ids, sorted, "id DESC is a total order, newest first");
+    }
+
+    #[tokio::test]
+    async fn limit_caps_the_read() {
+        let db = test_db().await;
+        for i in 0..10 {
+            record(&db, trigger_entry("trigger.updated", &format!("t-{i}")))
+                .await
+                .unwrap();
+        }
+        let rows = list(&db, None, None, None, None, 3).await.unwrap();
+        assert_eq!(rows.len(), 3, "LIMIT bounds the feed");
+    }
+
+    #[tokio::test]
+    async fn target_filters_narrow_to_one_trigger() {
+        let db = test_db().await;
+        record(&db, trigger_entry("trigger.updated", "t-1"))
+            .await
+            .unwrap();
+        record(&db, trigger_entry("trigger.updated", "t-2"))
+            .await
+            .unwrap();
+        record(
+            &db,
+            NewAuditEntry {
+                target_kind: Some("instance".to_string()),
+                target_id: None,
+                ..trigger_entry("triggers.pause_changed", "ignored")
+            },
+        )
+        .await
+        .unwrap();
+
+        let only_t1 = list(&db, None, None, Some("trigger"), Some("t-1"), 200)
+            .await
+            .unwrap();
+        assert_eq!(only_t1.len(), 1);
+        assert_eq!(only_t1[0].target_id.as_deref(), Some("t-1"));
+
+        let only_instance = list(&db, None, None, Some("instance"), None, 200)
+            .await
+            .unwrap();
+        assert_eq!(only_instance.len(), 1);
+        assert_eq!(only_instance[0].action, "triggers.pause_changed");
+    }
+
+    #[tokio::test]
+    async fn from_to_window_is_half_open() {
+        // `[from, to)`: `from` inclusive, `to` exclusive. Bind the rows' own
+        // timestamps as bounds to assert the boundary semantics precisely.
+        let db = test_db().await;
+        for i in 0..3 {
+            record(&db, trigger_entry("trigger.updated", &format!("t-{i}")))
+                .await
+                .unwrap();
+        }
+        let all = list(&db, None, None, None, None, 200).await.unwrap();
+        assert_eq!(all.len(), 3);
+        // ascending by ts to pick boundaries
+        let mut ts: Vec<String> = all.iter().map(|e| e.ts.clone()).collect();
+        ts.sort();
+
+        // from = middle ts (inclusive) → drops nothing strictly older.
+        let from_mid = list(&db, Some(ts[1].as_str()), None, None, None, 200)
+            .await
+            .unwrap();
+        assert!(
+            from_mid.iter().all(|e| e.ts >= ts[1]),
+            "from is an inclusive lower bound"
+        );
+
+        // to = max ts (exclusive) → the newest row is excluded.
+        let to_max = list(&db, None, Some(ts[2].as_str()), None, None, 200)
+            .await
+            .unwrap();
+        assert!(
+            to_max.iter().all(|e| e.ts < ts[2]),
+            "to is an exclusive upper bound"
+        );
+    }
+
+    #[tokio::test]
+    async fn record_best_effort_swallows_a_write_error() {
+        // §2·B: a failed audit write must NEVER propagate. Close the pool, then a
+        // best-effort record must log-and-return, not panic or block.
+        let db = test_db().await;
+        db.close().await;
+        // Would-be error is swallowed; the mutation (imagined upstream) stands.
+        record_best_effort(&db, trigger_entry("trigger.updated", "t-1")).await;
+    }
+
+    async fn actor_from_header(value: Option<&str>) -> Actor {
+        let mut builder = axum::http::Request::builder();
+        if let Some(v) = value {
+            builder = builder.header("X-PDO-Actor", v);
+        }
+        let req = builder.body(axum::body::Body::empty()).unwrap();
+        let (mut parts, _) = req.into_parts();
+        Actor::from_request_parts(&mut parts, &())
+            .await
+            .expect("Actor extraction is Infallible")
+    }
+
+    #[tokio::test]
+    async fn actor_extractor_maps_header_and_never_rejects() {
+        assert_eq!(actor_from_header(Some("ui")).await, Actor::Ui);
+        assert_eq!(actor_from_header(Some("cli")).await, Actor::Cli);
+        assert_eq!(actor_from_header(Some("bogus")).await, Actor::Unknown);
+        assert_eq!(actor_from_header(None).await, Actor::Unknown);
+        // as_hint is the byte-exact column value.
+        assert_eq!(Actor::Ui.as_hint(), "ui");
+        assert_eq!(Actor::Cli.as_hint(), "cli");
+        assert_eq!(Actor::Unknown.as_hint(), "unknown");
+    }
+}

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -4,6 +4,7 @@
 #![warn(unreachable_pub)]
 
 pub mod admission;
+mod audit_log;
 mod blackboard;
 mod boot_recovery;
 pub(crate) mod completion_refusal;
@@ -3071,6 +3072,7 @@ async fn guard_test(
 
 async fn create_trigger(
     State(state): State<Arc<AppState>>,
+    actor: audit_log::Actor,
     Json(req): Json<CreateTriggerRequest>,
 ) -> Response {
     if req.name.trim().is_empty() {
@@ -3223,6 +3225,19 @@ async fn create_trigger(
                 "type": "trigger_created",
                 "trigger_id": trigger.id,
             }));
+            // #507: audit AFTER the row committed (§2·B — never over-report).
+            audit_log::record_best_effort(
+                &state.db,
+                audit_log::NewAuditEntry {
+                    actor_hint: actor.as_hint().to_string(),
+                    action: "trigger.created".to_string(),
+                    target_kind: Some("trigger".to_string()),
+                    target_id: Some(trigger.id.clone()),
+                    before: None,
+                    after: serde_json::to_value(&trigger).ok(),
+                },
+            )
+            .await;
             (StatusCode::CREATED, Json(trigger)).into_response()
         }
         Err(e) => {
@@ -3275,13 +3290,33 @@ async fn list_triggers(State(state): State<Arc<AppState>>) -> Response {
 async fn delete_trigger(
     State(state): State<Arc<AppState>>,
     AxumPath(trigger_id): AxumPath<String>,
+    actor: audit_log::Actor,
 ) -> Response {
+    // #507: `trigger_store::delete` returns `bool`, never the row — so read the
+    // "before" snapshot HERE, before it is gone, or the audit of a delete
+    // degrades to a dead UUID. Best-effort (a read miss → `None`).
+    let before = trigger_store::get(&state.db, &trigger_id)
+        .await
+        .ok()
+        .flatten();
     match trigger_store::delete(&state.db, &trigger_id).await {
         Ok(true) => {
             let _ = state.pipeline_tx.send(serde_json::json!({
                 "type": "trigger_deleted",
                 "trigger_id": trigger_id,
             }));
+            audit_log::record_best_effort(
+                &state.db,
+                audit_log::NewAuditEntry {
+                    actor_hint: actor.as_hint().to_string(),
+                    action: "trigger.deleted".to_string(),
+                    target_kind: Some("trigger".to_string()),
+                    target_id: Some(trigger_id.clone()),
+                    before: before.as_ref().and_then(|t| serde_json::to_value(t).ok()),
+                    after: None,
+                },
+            )
+            .await;
             StatusCode::NO_CONTENT.into_response()
         }
         Ok(false) => (
@@ -3385,6 +3420,7 @@ struct PatchTriggerRequest {
 async fn patch_trigger(
     State(state): State<Arc<AppState>>,
     AxumPath(trigger_id): AxumPath<String>,
+    actor: audit_log::Actor,
     Json(req): Json<PatchTriggerRequest>,
 ) -> Response {
     // The Trigger must exist.
@@ -3649,6 +3685,21 @@ async fn patch_trigger(
                 "type": "trigger_updated",
                 "trigger_id": trigger_id,
             }));
+            // #507: persist BOTH snapshots (§2·D) — "a patch happened" cannot tell
+            // a manual `enabled:false` (the #505 gesture) from a cron edit unless
+            // before→after is on the row. `existing` (:3391) is still borrowed-only.
+            audit_log::record_best_effort(
+                &state.db,
+                audit_log::NewAuditEntry {
+                    actor_hint: actor.as_hint().to_string(),
+                    action: "trigger.updated".to_string(),
+                    target_kind: Some("trigger".to_string()),
+                    target_id: Some(trigger_id.clone()),
+                    before: serde_json::to_value(&existing).ok(),
+                    after: serde_json::to_value(&updated).ok(),
+                },
+            )
+            .await;
             Json(updated).into_response()
         }
         _ => (
@@ -3673,6 +3724,51 @@ async fn list_trigger_fires(
             )
                 .into_response()
         }
+    }
+}
+
+/// `GET /audit` — the out-of-Run audit feed (#507, ADR-0044). All filters are
+/// OPTIONAL: with none, a global newest-first feed (the #505 posture — you
+/// discover *which* target in the flow, you do not know it up front). `from`/`to`
+/// bound a half-open `[from, to)` ISO-8601 window; `target_kind`/`target_id`
+/// narrow to one target; `limit` defaults to 200. `house` param style mirrors
+/// `stats.rs`.
+#[derive(Debug, Deserialize)]
+struct AuditQuery {
+    #[serde(default)]
+    from: Option<String>,
+    #[serde(default)]
+    to: Option<String>,
+    #[serde(default)]
+    target_kind: Option<String>,
+    #[serde(default)]
+    target_id: Option<String>,
+    #[serde(default = "default_audit_limit")]
+    limit: i64,
+}
+
+fn default_audit_limit() -> i64 {
+    200
+}
+
+async fn get_audit(State(state): State<Arc<AppState>>, Query(q): Query<AuditQuery>) -> Response {
+    match audit_log::list(
+        &state.db,
+        q.from.as_deref(),
+        q.to.as_deref(),
+        q.target_kind.as_deref(),
+        q.target_id.as_deref(),
+        q.limit,
+    )
+    .await
+    {
+        // Bare JSON array, newest-first — same shape as `list_trigger_fires`.
+        Ok(rows) => Json(rows).into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({ "error": format!("audit list: {e}") })),
+        )
+            .into_response(),
     }
 }
 
@@ -3918,6 +4014,11 @@ fn build_router(state: Arc<AppState>) -> Router {
         // fetched only when the cost tab is shown).
         .route("/stats/overview", get(stats::stats_overview))
         .route("/stats/cost", get(stats::stats_cost))
+        // Out-of-Run audit feed (#507, ADR-0044). NEW top-level `/audit` prefix
+        // → added to the vite dev proxy whitelist (frontend/vite.config.ts) so a
+        // dev-mode GET hits the daemon instead of the SPA fallback (same trap as
+        // `/nodes` #345, `/stats` #377, `/fs` #431).
+        .route("/audit", get(get_audit))
         .route(
             "/triggers/{trigger_id}",
             get(get_trigger).patch(patch_trigger).delete(delete_trigger),
@@ -3982,6 +4083,13 @@ async fn init_db(db: &sqlx::SqlitePool) -> Result<()> {
     sandbox_profile::init(db)
         .await
         .context("failed to create sandbox_profiles table")?;
+
+    // #507 / ADR-0044: the third journal — out-of-Run config mutations. Sibling
+    // store, its own `audit_log` table, no `run_id`. `CREATE TABLE IF NOT
+    // EXISTS`, no ALTER, no backfill.
+    audit_log::init(db)
+        .await
+        .context("failed to create audit_log table")?;
 
     Ok(())
 }
@@ -8945,14 +9053,31 @@ struct PauseTriggersRequest {
 /// Contract: `200 { ok, paused }`; `500 { error }` on a DB write failure.
 async fn pause_triggers(
     State(state): State<Arc<AppState>>,
+    actor: audit_log::Actor,
     Json(req): Json<PauseTriggersRequest>,
 ) -> Response {
+    // #507: this endpoint writes blind (no prior read) — capture the "before" flag
+    // first, or the audit entry cannot show the direction of the flip. The single
+    // `POST /triggers/pause` handles pause AND resume; `req.paused` captures both.
+    let before = instance_config::triggers_paused(&state.db).await.ok();
     match instance_config::set_triggers_paused(&state.db, req.paused).await {
         Ok(()) => {
             let _ = state.pipeline_tx.send(serde_json::json!({
                 "type": "triggers_paused",
                 "paused": req.paused,
             }));
+            audit_log::record_best_effort(
+                &state.db,
+                audit_log::NewAuditEntry {
+                    actor_hint: actor.as_hint().to_string(),
+                    action: "triggers.pause_changed".to_string(),
+                    target_kind: Some("instance".to_string()),
+                    target_id: None,
+                    before: Some(serde_json::json!({ "paused": before })),
+                    after: Some(serde_json::json!({ "paused": req.paused })),
+                },
+            )
+            .await;
             Json(serde_json::json!({ "ok": true, "paused": req.paused })).into_response()
         }
         Err(e) => (
@@ -18943,6 +19068,173 @@ mod tests {
         // The trigger is left exactly as it was.
         let after = trigger_store::get(&state.db, &id).await.unwrap().unwrap();
         assert_eq!(after.pipeline_id, "watch-pipe");
+    }
+
+    // --- #507: out-of-Run audit seams (create / patch / delete / pause) ---
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn create_trigger_writes_one_audit_row() {
+        // A successful create leaves exactly one `trigger.created` row whose
+        // `after` is the FULL trigger (not a bare id) and whose `before` is empty.
+        let _home = FakeHome::new();
+        let tmp = tempfile::tempdir().unwrap();
+        write_optional_pipeline(tmp.path(), "watch-pipe");
+        init_test_repo(tmp.path());
+        let state = test_state_with_dir(tmp.path()).await;
+        let id = create_trigger_ok(&state, tmp.path()).await;
+
+        let rows = audit_log::list(&state.db, None, None, None, None, 200)
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 1, "create leaves exactly one audit row");
+        let e = &rows[0];
+        assert_eq!(e.action, "trigger.created");
+        assert_eq!(e.target_kind.as_deref(), Some("trigger"));
+        assert_eq!(e.target_id.as_deref(), Some(id.as_str()));
+        // No header on `create_trigger_ok`'s request → the honest default.
+        assert_eq!(e.actor_hint, "unknown");
+        assert!(e.before.is_none(), "create has no before");
+        let after = e.after.as_ref().expect("create carries an after snapshot");
+        assert_eq!(after["id"], serde_json::json!(id));
+        assert_eq!(after["name"], serde_json::json!("T"));
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn delete_trigger_audits_the_full_before_snapshot() {
+        // Load-bearing (#507 §6): `trigger_store::delete` returns `bool`, so the
+        // handler must `get()` the row BEFORE deleting or the audit degrades to a
+        // dead UUID. Assert the `before` is the WHOLE row, `after` empty.
+        let _home = FakeHome::new();
+        let tmp = tempfile::tempdir().unwrap();
+        write_optional_pipeline(tmp.path(), "watch-pipe");
+        init_test_repo(tmp.path());
+        let state = test_state_with_dir(tmp.path()).await;
+        let id = create_trigger_ok(&state, tmp.path()).await;
+
+        let app = build_router(state.clone());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri(format!("/triggers/{id}"))
+                    .header("X-PDO-Actor", "ui")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+
+        let rows = audit_log::list(&state.db, None, None, Some("trigger"), Some(&id), 200)
+            .await
+            .unwrap();
+        let del = rows
+            .iter()
+            .find(|e| e.action == "trigger.deleted")
+            .expect("a delete row");
+        assert_eq!(del.actor_hint, "ui", "X-PDO-Actor header plumbed through");
+        assert!(del.after.is_none(), "delete has no after");
+        let before = del
+            .before
+            .as_ref()
+            .expect("delete carries the pre-image, NOT a bare UUID");
+        assert_eq!(before["id"], serde_json::json!(id));
+        assert_eq!(before["name"], serde_json::json!("T"));
+        assert_eq!(before["cron"], serde_json::json!("0 4 * * 1"));
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn patch_disable_audits_before_true_after_false() {
+        // The #505 discriminator: a manual disable must leave a row where
+        // before.enabled=true and after.enabled=false — that is what tells a
+        // "disabled by a gesture" apart from "no longer scheduled".
+        let _home = FakeHome::new();
+        let tmp = tempfile::tempdir().unwrap();
+        write_optional_pipeline(tmp.path(), "watch-pipe");
+        init_test_repo(tmp.path());
+        let state = test_state_with_dir(tmp.path()).await;
+        let id = create_trigger_ok(&state, tmp.path()).await;
+
+        let app = build_router(state.clone());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("PATCH")
+                    .uri(format!("/triggers/{id}"))
+                    .header("content-type", "application/json")
+                    .header("X-PDO-Actor", "ui")
+                    .body(Body::from(
+                        serde_json::json!({ "enabled": false }).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let rows = audit_log::list(&state.db, None, None, Some("trigger"), Some(&id), 200)
+            .await
+            .unwrap();
+        let upd = rows
+            .iter()
+            .find(|e| e.action == "trigger.updated")
+            .expect("an update row");
+        assert_eq!(upd.actor_hint, "ui");
+        assert_eq!(
+            upd.before.as_ref().unwrap()["enabled"],
+            serde_json::json!(true)
+        );
+        assert_eq!(
+            upd.after.as_ref().unwrap()["enabled"],
+            serde_json::json!(false)
+        );
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn pause_triggers_audits_the_flag_flip() {
+        // Pause is the instance-scoped seam: target_kind=instance, no target_id,
+        // and both directions of the flip are captured from `req.paused`.
+        let _home = FakeHome::new();
+        let tmp = tempfile::tempdir().unwrap();
+        init_test_repo(tmp.path());
+        let state = test_state_with_dir(tmp.path()).await;
+
+        let app = build_router(state.clone());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/triggers/pause")
+                    .header("content-type", "application/json")
+                    .header("X-PDO-Actor", "ui")
+                    .body(Body::from(
+                        serde_json::json!({ "paused": true }).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let rows = audit_log::list(&state.db, None, None, Some("instance"), None, 200)
+            .await
+            .unwrap();
+        let p = rows
+            .iter()
+            .find(|e| e.action == "triggers.pause_changed")
+            .expect("a pause row");
+        assert_eq!(p.actor_hint, "ui");
+        assert_eq!(p.target_kind.as_deref(), Some("instance"));
+        assert!(p.target_id.is_none(), "instance-global has no target_id");
+        assert_eq!(
+            p.before.as_ref().unwrap()["paused"],
+            serde_json::json!(false)
+        );
+        assert_eq!(p.after.as_ref().unwrap()["paused"], serde_json::json!(true));
     }
 
     // --- A Trigger is a Run template: no target repo, no Trigger (#470) ---

--- a/docs/adr/0044-out-of-run-audit-log.md
+++ b/docs/adr/0044-out-of-run-audit-log.md
@@ -1,0 +1,49 @@
+# ADR-0044 — Un troisième journal : `audit_log` pour les mutations de config hors-Run
+
+> Statut : accepted (grilling #507). Vocabulaire : CONTEXT.md § « Trigger / Persistence »
+> (« trois journaux, trois questions »). Version 1.25.0 (provisoire — renuméroter au rebase ;
+> numéro d'ADR provisoire, next-free au-dessus de `origin/main` au rebase).
+
+## Contexte
+
+PDO a deux journaux, tous deux liés à un Run : l'`event_log` (vérité du Run ; `Event.run_id`
+**obligatoire**, la projection refuse tout fragment sans `RunStarted`) et `trigger_fires` (les
+évaluations de scheduling, keyées par Trigger). Une mutation de configuration faite **hors Run** —
+désactiver un Trigger à la main, éditer son cron, mettre les Triggers en pause — n'a de place dans
+aucun des deux. Conséquence mesurée : un Trigger coupé manuellement a été diagnostiqué à tort comme
+une panne de scheduler (fausse issue #505), parce que rien ne prouvait le geste.
+
+## Décision
+
+Une **troisième table**, `audit_log` (module frère `audit_log.rs`), sans `run_id`, append-only,
+partageant le pool `pdo.db`. v1 journalise les **mutations de Trigger** (create / patch / delete) et
+la **pause globale**, instrumentées au **handler HTTP** (pas au store : seul le handler a l'origine et
+l'avant→après ; le store ne voit que le delta). Lue par `GET /audit` (feed global décroissant,
+filtrable par cible et fenêtre de temps).
+
+L'origine est **best-effort et déclarative** : un en-tête `X-PDO-Actor` (`ui`/`cli`/`unknown`) stocké
+dans une colonne nommée **`actor_hint`** — jamais `actor`. Le daemon bind 0.0.0.0 sans auth :
+l'origine est un indice falsifiable, **jamais un gate de comportement**. « Origine inconnue » est
+acceptable ; « aucune entrée » ne l'est pas.
+
+Invariant : l'audit peut **sous-rapporter**, jamais **sur-rapporter**. On lit l'avant, on mute, on
+écrit l'audit **après le commit** ; un échec d'écriture se logue en `error!` et **n'échoue pas** la
+mutation. Best-effort exclut le transactionnel (une transaction laisserait un audit verrouillé annuler
+la mutation).
+
+## Alternatives écartées
+
+- **Rendre `Event.run_id` optionnel** : `run_id` est la clé de sharding de l'event log
+  (`load_all_run_ids`, projection lisant `RunStarted`) ; le relâcher fabrique des Runs fantômes et
+  casse un invariant load-bearing. Rejeté.
+- **Étendre `trigger_fires`** : erreur de catégorie — `trigger_id NOT NULL`, colonnes de scheduling,
+  JOIN de stats. Un audit hétérogène (Triggers + pause d'instance) n'y entre pas. Rejeté.
+
+## Conséquences
+
+- L'invariant « toute mutation de config est auditée » est tenu par **discipline au seam handler**,
+  pas par le type-système : un futur appelant non-handler de `trigger_store::update` échapperait
+  silencieusement à l'audit. Le seam est load-bearing — à garder à l'esprit avant d'ajouter un chemin
+  de mutation bulk/programmatique.
+- Rétention non bornée assumée (débit minuscule ; un cap serait une suppression non auditée).
+- `PUT /settings` et le signal *vivant* `overdue` (AC5 de #507) restent hors v1 (suivi côté #222).

--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -216,7 +216,18 @@ describe("request core", () => {
     await request("POST", "/upload", { body: form });
     const [, init] = fetchMock.mock.calls[0];
     expect(init?.body).toBeInstanceOf(FormData);
-    expect(init?.headers).toBeUndefined();
+    // #507: the origin hint rides on every request, but Content-Type must stay
+    // absent so the browser sets the multipart boundary itself.
+    expect(init?.headers).toEqual({ "X-PDO-Actor": "ui" });
+  });
+
+  it("declares X-PDO-Actor: ui on every request, even a body-less GET (#507)", async () => {
+    const fetchMock = captureFetch(200, { id: "x" });
+    await request("GET", "/things");
+    const [, init] = fetchMock.mock.calls[0];
+    expect((init?.headers as Record<string, string>)["X-PDO-Actor"]).toBe("ui");
+    // No body → no Content-Type.
+    expect((init?.headers as Record<string, string>)["Content-Type"]).toBeUndefined();
   });
 
   it("appends query params, encoding values and dropping undefined", async () => {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -100,12 +100,17 @@ export async function request<T = unknown>(
   }
 
   const init: RequestInit = { method };
+  // #507: declare the request's origin on EVERY call (falsifiable hint read
+  // into `audit_log.actor_hint`, never a gate). Set unconditionally — the JSON
+  // branch alone would miss FormData and body-less GET/DELETE.
+  const headers: Record<string, string> = { "X-PDO-Actor": "ui" };
   if (body instanceof FormData) {
     init.body = body; // browser sets the multipart boundary — no Content-Type
   } else if (body !== undefined) {
-    init.headers = { "Content-Type": "application/json" };
+    headers["Content-Type"] = "application/json";
     init.body = JSON.stringify(body);
   }
+  init.headers = headers;
 
   const resp = await fetch(url, init);
   if (responseMode === "raw") return resp as unknown as T; // caller owns status

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -36,6 +36,10 @@ export default defineConfig({
       // (#345) and `/stats` (#377): without it a dev GET /fs/browse answers 200
       // with the SPA and any smoke test would lie.
       '/fs': daemonTarget,
+      // #507: out-of-Run audit feed. New top-level `/audit` prefix — same trap
+      // as `/nodes`/`/stats`/`/fs`: without it a dev GET /audit answers 200 with
+      // the SPA.
+      '/audit': daemonTarget,
     },
   },
   test: {

--- a/scripts/layout-ratchet.sh
+++ b/scripts/layout-ratchet.sh
@@ -9,7 +9,7 @@ cd "$(git rev-parse --show-toplevel)"
 # <directory>  <max direct tracked files>
 BASELINES='
 frontend/src/components 141
-crates/pdo-daemon/src 56
+crates/pdo-daemon/src 57
 '
 
 fail=0


### PR DESCRIPTION
## #507 — Journal d'audit hors-Run (`audit_log`) + `GET /audit`

Troisième journal, distinct de l'event-log (par-Run) et de `trigger_fires` (scheduling) :
il répond à « qui a changé la config de l'app, et quand ? ». Chaque mutation de config
**hors-Run** (create/patch/delete d'un Trigger, pause globale) laisse une trace durable,
interrogeable, avant→après, avec une origine best-effort falsifiable (`actor_hint`). Referme
la cause de la fausse #505 : un agent pouvait constater qu'un Trigger « n'était plus
ordonnancé » sans savoir si un humain l'avait **désactivé**.

### Contenu
- `crates/pdo-daemon/src/audit_log.rs` — table `audit_log` (append-only, sans `run_id`), écritures best-effort.
- `GET /audit` — lecture filtrable (`target_kind`, `target_id`, fenêtre half-open `[from, to)`), tri décroissant.
- Instrumentation des mutations Trigger + pause globale (before/after complets ; garde `get()`-avant-`delete`).
- ADR-0044 + glossaire CONTEXT.md « trois journaux, trois questions ».
- Front : `frontend/src/api.ts` (+ `api.test.ts`), whitelist proxy vite `/audit`.

### Validation L5 — Pass
5 scénarios P0 (append-only + survie restart, non-régression #505, cycle create→update→delete,
pause/reprise symétrique, contrat `GET /audit`) et 2 P1 (origine best-effort jamais un gate,
pas de sur-rapport sur mutation échouée) **verts**, valeurs JSON observées à l'appui, sur pile
isolée. Invariant ADR-0044 tenu : sous-rapport possible, sur-rapport jamais. Portes CI pertinentes
au diff vertes localement (`fmt --check`, `layout-ratchet`, clippy `-D warnings`, typecheck/lint/build,
vitest). Les 3 tests rouges de la suite sont des flakes d'environnement pré-existants (sweep de
complétion #433 + Docker), prouvés identiques sur `main` par contrôle négatif ; delta CI introduit = nul.

Version : 1.24.0 → **1.25.0** (MINOR, feature additive).

Closes #507
