### PR TITLE
feat(#549): le harnais agentique est un axe à quatre tiers — claude + opencode, descripteur par argv, capacités dispatchées (1.27.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,29 @@ ascendante** : la casse se signale ici et par un bump majeur, jamais en gardant 
 morts. Seule contrainte non négociable — les **données historiques restent lisibles** : un Run
 archivé s'ouvre et se chiffre quelle que soit la version qui a écrit son payload.
 
+## 1.26.0
+
+**Cassant, migration automatique.** Première tranche du **harnais agentique** (#550, PRD #549) :
+le programme qui fait tourner l'agent d'un nœud (`claude`, `opencode`) devient un axe à quatre
+tiers (`node → Run → Projet → instance → plancher claude`), résolu **une fois au spawn** et **gelé**
+dans l'événement de démarrage — la reprise re-pose ce qui a été lancé, jamais ce que le YAML dit
+maintenant (ADR-0007). Cette tranche livre `node → instance → plancher` ; les tiers Run et Projet
+suivent (#551, #552).
+
+Le tail n'est plus composé de flags en dur : un **descripteur** (ADR-0045) porte deux templates
+d'argv (lancement, reprise) et un bloc d'env, et un module **pur** (`harness_argv`) rend la chaîne
+avec une seule règle — *un token dont un trou est vide disparaît en entier*. Le tail `claude` reste
+**identique au byte** quand rien de neuf n'est posé (goldens). `claude` et `opencode` sont dans le
+**plancher embarqué** ; rien n'est écrit sur disque.
+
+**Migration du schéma de nœud** : les champs plats `model:` / `effort:` deviennent une carte par
+harnais `harnesses.<nom>.{model, effort}` (le modèle et l'effort se lisent dans l'entrée du harnais
+gagnant, pas d'axe propre — ADR-0046). Le migrateur de pipelines les replie sous `harnesses.claude`
+au démarrage ; un `pin_harness:` scalaire épingle le harnais d'un nœud. La carte est **sémantique**
+(diff + `content_hash`). Un défaut de harnais **et** un défaut de modèle **par harnais** rejoignent
+la Configuration d'instance (`stored → env → default`, ADR-0015 amendée). Un binaire de harnais
+introuvable au spawn échoue **fort** (jamais un 2xx, ADR-0037) en nommant le harnais.
+
 ## 1.25.0
 
 Rien de cassant, aucune migration (`CREATE TABLE IF NOT EXISTS`, aucun backfill). PDO gagne un

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,13 +44,19 @@ qu'un A/B sur un harnais neuf met donc aussi à l'épreuve (ADR-0046).
 
 **Le Projet est une entité** (#552) : un regroupement **nommé** de dépôts qui se travaillent
 ensemble, et le tier du milieu de la précédence. **Rien n'est seedé** — tant que personne n'a nommé
-un groupe, il n'existe aucune ligne de Projet et les listes se groupent exactement comme avant
-(dérivé du chemin, côté client) ; c'est le crayon sur un en-tête de groupe qui **crée** l'entité,
+un groupe, il n'existe aucune ligne de Projet et les listes se groupent **par les mêmes chemins
+qu'avant**, dérivés côté client ; c'est le crayon sur un en-tête de groupe qui **crée** l'entité,
 même posture que la table de prix (ADR-0034). Un chemin appartient à **au plus un** Projet, comparé
 **verbatim** (aucune canonicalisation — ADR-0033), et un ajout conflictuel est un **refus nommant**
 le Projet propriétaire. Le Projet d'un Run est celui de son **dépôt primaire** : ajouter ou retirer
 un secondaire ne change ni le Projet ni le harnais résolu (ADR-0042). Le seuil « ne grouper qu'à
 partir de 2 » porte désormais sur les **projets**.
+
+**Changement visible : l'ordre des en-têtes de groupe.** Les groupes se trient désormais sur le
+**libellé affiché** (départagé par la clé), là où #258 triait sur le **chemin complet** du dépôt.
+C'est ce qui permet à un Projet — dont le nom n'a aucun chemin — de prendre sa place dans le même
+ordre que les groupes-chemins. Conséquence à connaître : à contenu identique, une liste peut
+apparaître dans un ordre différent de la version précédente, sans qu'aucun Projet ait été créé.
 
 **Les capacités sont du code par harnais, et leur absence est dite** (#553). Les cinq — source de
 coût, résolution du transcript, substrat de fin de tour, ancre de menu de limite, plancher de

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,13 @@ archivé s'ouvre et se chiffre quelle que soit la version qui a écrit son paylo
 
 ## 1.26.0
 
-**Cassant, migration automatique.** Première tranche du **harnais agentique** (#550, PRD #549) :
-le programme qui fait tourner l'agent d'un nœud (`claude`, `opencode`) devient un axe à quatre
-tiers (`node → Run → Projet → instance → plancher claude`), résolu **une fois au spawn** et **gelé**
-dans l'événement de démarrage — la reprise re-pose ce qui a été lancé, jamais ce que le YAML dit
-maintenant (ADR-0007). Cette tranche livre `node → instance → plancher` ; les tiers Run et Projet
-suivent (#551, #552).
+**Cassant, migration automatique.** Le **harnais agentique** (PRD #549, quatre tranches — #550,
+#551, #552, #553) : le programme qui fait tourner l'agent d'un nœud (`claude`, `opencode`) devient
+un axe à quatre tiers (`node → Run → Projet → instance → plancher claude`), résolu **une fois au
+spawn** et **gelé** dans l'événement de démarrage — la reprise re-pose ce qui a été lancé, jamais ce
+que le YAML dit maintenant (ADR-0007). L'axe entier est livré ici : le nœud épingle (#550), le Run
+choisit (#551), le Projet porte le tier du milieu (#552), et les capacités sont dispatchées par
+harnais (#553).
 
 Le tail n'est plus composé de flags en dur : un **descripteur** (ADR-0045) porte deux templates
 d'argv (lancement, reprise) et un bloc d'env, et un module **pur** (`harness_argv`) rend la chaîne
@@ -32,6 +33,42 @@ au démarrage ; un `pin_harness:` scalaire épingle le harnais d'un nœud. La ca
 (diff + `content_hash`). Un défaut de harnais **et** un défaut de modèle **par harnais** rejoignent
 la Configuration d'instance (`stored → env → default`, ADR-0015 amendée). Un binaire de harnais
 introuvable au spawn échoue **fort** (jamais un 2xx, ADR-0037) en nommant le harnais.
+
+**Le Run est un tier** (#551) : le harnais choisi à la création est **gelé dans l'événement de
+création** — même posture d'immuabilité que le mode de sandbox — proposé par le dialogue de
+lancement, et porté par un Trigger **par construction** (le template d'un Trigger *est* la charge
+utile d'une création de Run, donc aucun tier Trigger séparé). Un nœud qui a **épinglé** résiste au
+choix du Run. Les **sessions d'infra** (Pipeline Manager, résolveur de merge) suivent le harnais du
+Run : « ce Run tourne sur X » devient vrai sans exception — y compris pour l'outil de déblocage, ce
+qu'un A/B sur un harnais neuf met donc aussi à l'épreuve (ADR-0046).
+
+**Le Projet est une entité** (#552) : un regroupement **nommé** de dépôts qui se travaillent
+ensemble, et le tier du milieu de la précédence. **Rien n'est seedé** — tant que personne n'a nommé
+un groupe, il n'existe aucune ligne de Projet et les listes se groupent exactement comme avant
+(dérivé du chemin, côté client) ; c'est le crayon sur un en-tête de groupe qui **crée** l'entité,
+même posture que la table de prix (ADR-0034). Un chemin appartient à **au plus un** Projet, comparé
+**verbatim** (aucune canonicalisation — ADR-0033), et un ajout conflictuel est un **refus nommant**
+le Projet propriétaire. Le Projet d'un Run est celui de son **dépôt primaire** : ajouter ou retirer
+un secondaire ne change ni le Projet ni le harnais résolu (ADR-0042). Le seuil « ne grouper qu'à
+partir de 2 » porte désormais sur les **projets**.
+
+**Les capacités sont du code par harnais, et leur absence est dite** (#553). Les cinq — source de
+coût, résolution du transcript, substrat de fin de tour, ancre de menu de limite, plancher de
+staging — passent derrière une fabrique (`harness_probes`) dont **toutes les méthodes ont un défaut
+« absent »** : un harnais déclaré en donnée n'obtient aucune capacité sans qu'on puisse l'oublier.
+`claude` garde les cinq à l'identique. Conséquences visibles : un Run dont le harnais n'a pas de
+source de coût affiche **« — » et une raison**, jamais `$0` ni un `partial` muet (même veine que
+`unpriced_models`, #425) ; les sondes de fin de tour et de menu de limite **ne tournent pas** sans la
+capacité, donc aucun nœud n'est auto-complété sur une heuristique inventée ; un Run sandboxé sur un
+harnais sans plancher de staging **le dit une fois** (ADR-0031). Cette tranche livre aussi le **tier
+disque** des descripteurs : on déclare un harnais inconnu et on le lance sans recompiler, par fusion
+**par nom** avec le plancher embarqué, et un descripteur illisible reste **inerte et diagnostiqué** —
+sa clé retombe sur le tier suivant, jamais partiellement appliquée.
+
+**Hors périmètre, assumé** : la sandbox (le plancher de staging reste propre à `claude`), les
+capacités d'`opencode` (il se lance, s'attache, se reprend et se complète par `pdo complete` — aucun
+coût, aucune fin de tour automatique), l'effort sur `opencode` (aucun axe d'effort au lancement), et
+le catalogue de modèles (le modèle reste du texte libre).
 
 ## 1.25.0
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -22,7 +22,7 @@ Contrairement à : Liza (pipelines YAML), Langgraph (conditional edges + LLM-rou
 
 ## Node
 
-Unité atomique d'un Pipeline. Un **Node** représente un rôle. La plupart des nodes lancent une instance de Claude Code à laquelle on confie un prompt système qui définit sa mission (Implementer, Planner, Reviewer, etc.). Un node **`script`** fait exception : il exécute du **bash déterministe fourni par l'auteur**, sans LLM (ADR-0017).
+Unité atomique d'un Pipeline. Un **Node** représente un rôle. La plupart des nodes lancent un **harnais agentique** (cf. §*Harnais agentique*) à qui on confie un prompt système qui définit sa mission (Implementer, Planner, Reviewer, etc.). Un node **`script`** fait exception : il exécute du **bash déterministe fourni par l'auteur**, sans LLM (ADR-0017).
 
 Un Node se définit par :
 
@@ -35,26 +35,31 @@ Asymétrie assumée : le Node *connaît* ses sorties, *découvre* ses entrées a
 
 Distinct de :
 
-- **NodeRun** — l'exécution d'un Node au sein d'un Pipeline Run précis. Un NodeRun = une session tmux Claude Code dans un sous-worktree dédié, avec un statut (pending/running/done/failed).
+- **NodeRun** — l'exécution d'un Node au sein d'un Pipeline Run précis. Un NodeRun = une session tmux d'un harnais agentique dans un sous-worktree dédié, avec un statut (pending/running/done/failed).
 
-### Modèle (par node)
+### Harnais agentique
 
-Chaque Node peut porter un **modèle** optionnel : l'identifiant du modèle Claude avec lequel sa session est lancée. Permet de payer un modèle capable là où le raisonnement est dur et un modèle économique sur les nodes mécaniques.
+Le **harnais agentique** est le programme qui fait tourner l'agent d'un NodeRun (`claude`, `opencode`, …). PDO le lance, l'attache, le tue ; il n'en embarque et n'en fournit aucun.
+_Éviter_ : « CLI » comme terme — réservé au binaire `pdo` (cf. *Prompt augmentation*, « capacités CLI ») ; « modèle » (le harnais est le programme, le modèle est ce qu'il appelle) ; « provider ».
 
-- **Texte libre, pass-through, aucune validation** : alias ou id complet, transmis verbatim à `claude`. Un id invalide fait échouer `claude` au démarrage — *sharp tool* (ADR-0001). Pas d'enum fermé qui périmerait à chaque sortie de modèle.
-- **Sémantique, pas layout** : le modèle change *quel agent* tourne ; il entre dans le **diff sémantique**, contrairement au layout.
-- **S'applique aux nodes qui lancent un agent** (`doc-only`, `code-mutating`, `merge`). Le manager et le résolveur de merge (sessions d'infra) restent au défaut du compte.
-- **Resume** : une session reprise conserve son modèle d'origine (garanti par Claude Code) — la garantie ne s'étend pas à l'effort (ci-dessous).
-- **Défaut d'instance** (#347) : un `default_model` daemon-wide (Configuration d'instance, ADR-0015) s'applique à tout node de travail sans `model:` propre. Précédence : `node.model` → défaut d'instance → défaut du compte. _Éviter_ : « modèle global », « modèle du run » (le modèle est *par node* ou *par instance*, jamais par run).
+- **Résident, jamais one-shot** : un harnais éligible reste vivant après la fin de son tour, dans une session attachable où l'utilisateur peut reprendre la main — c'est le principe même de PDO (ADR-0012). Un harnais qui sort en fin de travail est **inéligible** : sa mort de session serait indiscernable d'un échec (ADR-0032). Contrat d'éligibilité et forme du descripteur → ADR-0045.
+- **Précédence à quatre tiers** : `node` → Run → Projet → Configuration d'instance → plancher (`claude`). Résolue une fois **au spawn** et gelée dans l'événement de démarrage du nœud : une édition de YAML ou de Projet n'atteint jamais une itération vivante (ADR-0007). Contrat → ADR-0044.
+- **Épinglage ≠ paramétrage** : épingler un harnais sur un node dit « ce rôle exige ce harnais » et le soustrait à un changement de tier supérieur ; la carte des réglages par harnais dit seulement *comment* le node tourne sur chacun.
+- **Instrumentation inégale, jamais silencieuse** : coût, complétion sur fin de tour, détection de menu de limite, plancher de staging sont des **capacités** écrites harnais par harnais. Absente, la capacité rend la feature absente et le **dit** (« — », jamais `$0`) — ADR-0045.
+- **Sessions d'infra** (Pipeline Manager, résolveur de merge) : elles suivent le harnais **du Run**, sans modèle ni effort propres.
 
-### Niveau d'effort (par node)
+### Modèle et effort (par node, conditionnés par le harnais)
 
-Chaque Node peut porter un **niveau d'effort** optionnel : le budget de raisonnement de sa session. Axe **orthogonal au modèle** : le modèle dit *quel agent* tourne, l'effort dit *combien il réfléchit*. Aucun défaut d'instance (#424).
+Le **modèle** dit *quel agent* tourne, le **niveau d'effort** *combien il réfléchit* : orthogonaux entre eux, mais **aucun des deux n'a de sens hors d'un harnais** — un slug Anthropic ne veut rien dire pour `opencode`. Ils vivent donc dans une carte du node, une entrée par harnais, et se lisent dans l'entrée du **harnais gagnant** ; ils n'ont pas de précédence propre (ADR-0044).
 
-- **Texte libre côté wire, jeu curaté côté UI** : la valeur est transmise verbatim (comme `model`), mais l'UI propose un picker fermé + l'état « Default ». Raison de l'asymétrie : un id de modèle invalide fait échouer `claude` (le designer le voit) ; un niveau d'effort inconnu ne produit qu'un warning et la session démarre au défaut — le node tourne *vert* avec un budget qui n'est pas celui demandé. Le picker ferme le seul mode d'échec que le designer ne peut pas constater (#268).
-- **Sémantique, pas layout** : entre dans le diff sémantique et le `content_hash` de la bibliothèque.
-- **Re-posé au resume** (#424) : contrairement au modèle, l'effort est perdu par `claude --continue` ; PDO re-pose le flag depuis ce qui a été enregistré au spawn — pas depuis le YAML courant, qui a pu être édité entre-temps (ADR-0007). Le YAML est la source de vérité au *spawn*, l'event log l'est au *resume*.
-- **Effort demandé ≠ effort obtenu** : le flag exprime une **intention** — un niveau non supporté retombe en silence, un plafond d'organisation peut clamper, un skill/sous-agent peut surclasser le niveau de session. À lire comme un levier de déterminisme et de latence, pas un cadran de coût. _Éviter_ : « effort garanti », « effort du run », « mode économique ».
+- **Texte libre, pass-through, aucune validation** : alias ou id complet, transmis verbatim. Pas d'enum fermé qui périmerait à chaque sortie de modèle — *sharp tool* (ADR-0001).
+- **Le mode d'échec d'un modèle appartient au harnais, pas à PDO** : `claude` sort non-zéro sur un id invalide, donc le designer le voit ; `opencode` **retombe en silence sur son défaut** quand le modèle demandé est injoignable, et le nœud tourne *vert* avec un autre modèle que celui écrit. L'asymétrie « le modèle échoue fort, l'effort échoue en silence » (#268) n'est donc pas une propriété du produit — elle se vérifie harnais par harnais (ADR-0045).
+- **Un harnais peut n'avoir aucun axe d'effort** — `opencode` ne l'expose pas au lancement. L'UI grise alors le picker : c'est une absence déclarée, pas un défaut.
+- **Effort demandé ≠ effort obtenu** : le flag exprime une **intention** — un niveau non supporté retombe en silence, un plafond d'organisation peut clamper, un skill/sous-agent peut surclasser le niveau de session. À lire comme un levier de déterminisme et de latence, pas un cadran de coût. _Éviter_ : « effort garanti », « effort du run », « mode économique », « modèle global », « modèle du run ».
+- **Sémantique, pas layout** : la carte entre dans le **diff sémantique** et le `content_hash` de la bibliothèque.
+- **S'applique aux nodes qui lancent un agent** (`doc-only`, `code-mutating`, `merge`), jamais à un node `script`.
+- **Ce que la reprise conserve dépend du harnais** : sur `claude`, le modèle survit, l'effort non — PDO le re-pose depuis l'événement de démarrage, jamais depuis le YAML courant, qui a pu être édité entre-temps (#424, ADR-0007). Le YAML est la vérité au *spawn*, l'event log au *resume*.
+- **Défaut d'instance** (#347) : un modèle par harnais peut être posé daemon-wide (Configuration d'instance, ADR-0015).
 
 ### Node `script` — exécution déterministe (ADR-0017)
 
@@ -273,9 +278,9 @@ Le préambule contient au minimum : les **inputs disponibles** (nom du port + ch
 
 Conséquence : le designer n'a pas à se soucier dans son prompt de « où écrire / quoi mettre en frontmatter / comment signaler la fin » — c'est imposé par le runtime. Il se concentre sur le *rôle*.
 
-### Skills Claude Code — délégué
+### Skills et extensions — délégués au harnais
 
-PDO **ne gère pas** les skills. Les skills disponibles dans une session NodeRun sont ceux que Claude Code charge naturellement (`~/.claude/skills/`, repo cible, sous-worktree). Pas d'attachement par-Node, pas de mécanisme custom.
+PDO **ne gère pas** les skills, sous-agents, plugins ou MCP d'un harnais. Ce qui est disponible dans une session NodeRun est ce que le harnais charge naturellement depuis son propre home et le repo cible. Pas d'attachement par-Node, pas de mécanisme custom.
 
 ---
 
@@ -455,6 +460,18 @@ La brique **unique** de sélection de chemin à la souris : un listing à **un n
 
 ---
 
+## Projet
+
+Un **Projet** est un regroupement **nommé** de dépôts qui se travaillent ensemble (un front et un back, par exemple). Il porte un nom éditable et une liste de chemins **membres**, comparés verbatim comme partout ailleurs (cf. *Repo cible*).
+
+- **Un chemin appartient à au plus un Projet**, et le Projet d'un Run est celui qui possède son **dépôt primaire**. Un secondaire membre d'un autre Projet n'y change rien : c'est un contexte read-only, pas une appartenance (ADR-0042).
+- **Matérialisé à la demande, jamais seedé** : tant qu'aucun nom n'est donné ni aucun réglage attaché, il n'existe pas de Projet — les listes se groupent sur le libellé dérivé du chemin. Nommer un en-tête de groupe est ce qui crée l'entité.
+- **Premier réglage porté** : le harnais agentique, dont il est le tier intermédiaire (ADR-0044).
+
+_Éviter_ : « projet » pour un dépôt seul (c'est le *repo cible*) ou pour le `projects/` d'un home stagé.
+
+---
+
 ## Trigger
 
 Un **Trigger** est une liaison nommée et persistée entre une **condition de déclenchement** et un **template de Run**. Quand la condition se réalise, PDO crée un Pipeline Run *ordinaire*.
@@ -523,7 +540,7 @@ Agent conversationnel attaché à un Pipeline Run. Permet de **lire l'état** et
 
 ### Implémentation
 
-Le manager **est** une instance Claude Code standard, prompt augmenté par le runtime (identité du Run, endpoints HTTP documentés en clair + exemples curl). **Pas de MCP custom** : on possède le prompt de la session, autant documenter les endpoints. Pour la lecture brute, bash complet — tout l'état du Run est sur disque.
+Le manager **est** une instance standard du harnais du Run, prompt augmenté par le runtime (identité du Run, endpoints HTTP documentés en clair + exemples curl). **Pas de MCP custom** : on possède le prompt de la session, autant documenter les endpoints. Pour la lecture brute, bash complet — tout l'état du Run est sur disque.
 
 ### Commandes disponibles (v1)
 
@@ -588,7 +605,7 @@ Réglages **daemon-wide** (ADR-0015), à distinguer d'une variable *pipeline* ou
 
 ### Modèle d'exécution
 
-Chaque NodeRun = **une session tmux détachée** créée par le daemon, contenant Claude Code en mode interactif avec le prompt augmenté. Nommage :
+Chaque NodeRun = **une session tmux détachée** créée par le daemon, contenant le harnais du nœud en mode interactif avec le prompt augmenté. Nommage :
 
 - NodeRun : `pdo-<run-id>-<node-id>-iter-<N>`.
 - Manager : `pdo-mgr-<run-id>`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -43,14 +43,14 @@ Le **harnais agentique** est le programme qui fait tourner l'agent d'un NodeRun 
 _Éviter_ : « CLI » comme terme — réservé au binaire `pdo` (cf. *Prompt augmentation*, « capacités CLI ») ; « modèle » (le harnais est le programme, le modèle est ce qu'il appelle) ; « provider ».
 
 - **Résident, jamais one-shot** : un harnais éligible reste vivant après la fin de son tour, dans une session attachable où l'utilisateur peut reprendre la main — c'est le principe même de PDO (ADR-0012). Un harnais qui sort en fin de travail est **inéligible** : sa mort de session serait indiscernable d'un échec (ADR-0032). Contrat d'éligibilité et forme du descripteur → ADR-0045.
-- **Précédence à quatre tiers** : `node` → Run → Projet → Configuration d'instance → plancher (`claude`). Résolue une fois **au spawn** et gelée dans l'événement de démarrage du nœud : une édition de YAML ou de Projet n'atteint jamais une itération vivante (ADR-0007). Contrat → ADR-0044.
+- **Précédence à quatre tiers** : `node` → Run → Projet → Configuration d'instance → plancher (`claude`). Résolue une fois **au spawn** et gelée dans l'événement de démarrage du nœud : une édition de YAML ou de Projet n'atteint jamais une itération vivante (ADR-0007). Contrat → ADR-0046.
 - **Épinglage ≠ paramétrage** : épingler un harnais sur un node dit « ce rôle exige ce harnais » et le soustrait à un changement de tier supérieur ; la carte des réglages par harnais dit seulement *comment* le node tourne sur chacun.
 - **Instrumentation inégale, jamais silencieuse** : coût, complétion sur fin de tour, détection de menu de limite, plancher de staging sont des **capacités** écrites harnais par harnais. Absente, la capacité rend la feature absente et le **dit** (« — », jamais `$0`) — ADR-0045.
 - **Sessions d'infra** (Pipeline Manager, résolveur de merge) : elles suivent le harnais **du Run**, sans modèle ni effort propres.
 
 ### Modèle et effort (par node, conditionnés par le harnais)
 
-Le **modèle** dit *quel agent* tourne, le **niveau d'effort** *combien il réfléchit* : orthogonaux entre eux, mais **aucun des deux n'a de sens hors d'un harnais** — un slug Anthropic ne veut rien dire pour `opencode`. Ils vivent donc dans une carte du node, une entrée par harnais, et se lisent dans l'entrée du **harnais gagnant** ; ils n'ont pas de précédence propre (ADR-0044).
+Le **modèle** dit *quel agent* tourne, le **niveau d'effort** *combien il réfléchit* : orthogonaux entre eux, mais **aucun des deux n'a de sens hors d'un harnais** — un slug Anthropic ne veut rien dire pour `opencode`. Ils vivent donc dans une carte du node, une entrée par harnais, et se lisent dans l'entrée du **harnais gagnant** ; ils n'ont pas de précédence propre (ADR-0046).
 
 - **Texte libre, pass-through, aucune validation** : alias ou id complet, transmis verbatim. Pas d'enum fermé qui périmerait à chaque sortie de modèle — *sharp tool* (ADR-0001).
 - **Le mode d'échec d'un modèle appartient au harnais, pas à PDO** : `claude` sort non-zéro sur un id invalide, donc le designer le voit ; `opencode` **retombe en silence sur son défaut** quand le modèle demandé est injoignable, et le nœud tourne *vert* avec un autre modèle que celui écrit. L'asymétrie « le modèle échoue fort, l'effort échoue en silence » (#268) n'est donc pas une propriété du produit — elle se vérifie harnais par harnais (ADR-0045).
@@ -466,7 +466,7 @@ Un **Projet** est un regroupement **nommé** de dépôts qui se travaillent ense
 
 - **Un chemin appartient à au plus un Projet**, et le Projet d'un Run est celui qui possède son **dépôt primaire**. Un secondaire membre d'un autre Projet n'y change rien : c'est un contexte read-only, pas une appartenance (ADR-0042).
 - **Matérialisé à la demande, jamais seedé** : tant qu'aucun nom n'est donné ni aucun réglage attaché, il n'existe pas de Projet — les listes se groupent sur le libellé dérivé du chemin. Nommer un en-tête de groupe est ce qui crée l'entité.
-- **Premier réglage porté** : le harnais agentique, dont il est le tier intermédiaire (ADR-0044).
+- **Premier réglage porté** : le harnais agentique, dont il est le tier intermédiaire (ADR-0046).
 
 _Éviter_ : « projet » pour un dépôt seul (c'est le *repo cible*) ou pour le `projects/` d'un home stagé.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "1.25.1"
+version = "1.26.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "1.25.1"
+version = "1.26.0"
 license = "MIT"
 
 [workspace.dependencies]

--- a/crates/pdo-daemon/src/event_log.rs
+++ b/crates/pdo-daemon/src/event_log.rs
@@ -773,6 +773,21 @@ pub struct RunState {
     pub sandbox_prep: Option<SandboxPrepState>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_branch: Option<String>,
+    /// The harness chosen at Run creation (#551, ADR-0046), **frozen** here from the
+    /// `RunStarted` payload — the middle tier of the precedence chain
+    /// `nœud → Run → Projet → instance → plancher (claude)`. Immutable, exactly like
+    /// [`RunState::sandbox`]: set once from the create event, never mutated, so a
+    /// pipeline edit or a changed instance default cannot re-decide a Run in flight.
+    ///
+    /// `None` ⇒ the Run named no harness, so each free node resolves through the
+    /// instance default and the floor as before (every historical Run, and any Run
+    /// created without an explicit choice — the payload omits the key, keeping it
+    /// byte-identical to the pre-#551 shape). A blank/empty stored value collapses to
+    /// `None` at the freeze (`Some("")` never persists), so it can never win a tier
+    /// (#347). Read at every spawn seam as the `run` tier of [`crate::harness_resolver`]
+    /// and by the infra sessions (Pipeline Manager, merge resolver).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub harness: Option<String>,
     /// Provenance: the id of the Trigger that created this Run, if any.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub triggered_by: Option<String>,
@@ -836,6 +851,7 @@ impl RunState {
             sandbox_image_raw_error: None,
             sandbox_prep: None,
             source_branch: None,
+            harness: None,
             triggered_by: None,
             pipeline_id: None,
             sessions_spawned: 0,
@@ -1285,6 +1301,18 @@ fn apply_run_event(state: &mut RunState, event: &Event) {
                 }
                 if let Some(sb) = payload.get("source_branch").and_then(|v| v.as_str()) {
                     state.source_branch = Some(sb.to_string());
+                }
+                // #551 (ADR-0046): the FROZEN Run harness, projected the same way as
+                // `source_branch`. The create chokepoint only writes this key for a
+                // non-empty choice, so an absent key (every historical Run, every Run
+                // with no explicit harness) leaves `None` — the free nodes then resolve
+                // through the instance default and the `claude` floor. A blank string
+                // never reaches here (normalised away at the freeze), so it cannot win a
+                // tier (#347).
+                if let Some(h) = payload.get("harness").and_then(|v| v.as_str()) {
+                    if !h.is_empty() {
+                        state.harness = Some(h.to_string());
+                    }
                 }
                 if let Some(tb) = payload.get("triggered_by").and_then(|v| v.as_str()) {
                     state.triggered_by = Some(tb.to_string());
@@ -4702,6 +4730,36 @@ mod tests {
             serde_json::json!({ "pipeline_name": "p", "target_repos": "not-an-array" }),
         )];
         assert!(project(&malformed).unwrap().target_repos.is_empty());
+    }
+
+    /// #551 (ADR-0046): the `RunStarted.harness` freeze projects into
+    /// `RunState.harness`; an absent key (every historical Run, every Run with no
+    /// explicit choice) stays `None`; an empty string never wins a tier (#347).
+    #[test]
+    fn harness_projects_and_defaults_to_none() {
+        // Present + non-empty → frozen verbatim.
+        let with = vec![make_event_with_payload(
+            EventKind::RunStarted,
+            None,
+            serde_json::json!({ "pipeline_name": "p", "harness": "opencode" }),
+        )];
+        assert_eq!(project(&with).unwrap().harness.as_deref(), Some("opencode"));
+
+        // Absent key → None (resolve through the instance default and the floor).
+        let legacy = vec![make_event_with_payload(
+            EventKind::RunStarted,
+            None,
+            serde_json::json!({ "pipeline_name": "p" }),
+        )];
+        assert_eq!(project(&legacy).unwrap().harness, None);
+
+        // Empty string → None: a blank freeze can never win a precedence tier (#347).
+        let blank = vec![make_event_with_payload(
+            EventKind::RunStarted,
+            None,
+            serde_json::json!({ "pipeline_name": "p", "harness": "" }),
+        )];
+        assert_eq!(project(&blank).unwrap().harness, None);
     }
 
     /// #465 slice 2 (ADR-0042): `RunReposEdited` overwrites `target_repos`

--- a/crates/pdo-daemon/src/event_log.rs
+++ b/crates/pdo-daemon/src/event_log.rs
@@ -598,6 +598,17 @@ pub struct CostStat {
     /// — stayed invisible on `/stats/cost` for weeks. Empty ⟺ `partial == false`.
     #[serde(default)]
     pub unpriced_models: Vec<String>,
+    /// The harnesses this Run launched a node on that have **no cost source**
+    /// capability (#553, ADR-0045). Non-empty ⇒ the Run's cost is not honestly
+    /// summable — a harness like `opencode` writes its cost where PDO does not read
+    /// (its own SQLite), so adding `claude`'s real dollars to that harness's
+    /// invisible $0 would be a silent under-count. So the surface shows **"—" with
+    /// a reason naming these harnesses**, never a `$0`, never a mute `partial`
+    /// (same "name what is missing" vein as `unpriced_models`). Sorted, deduped.
+    /// Empty on every all-`claude` Run, so `usd`/`partial` mean exactly what they
+    /// meant before this field existed.
+    #[serde(default)]
+    pub uncosted_harnesses: Vec<String>,
 }
 
 /// A secondary repository pinned to a Run (#465, ADR-0042).

--- a/crates/pdo-daemon/src/graph_resolver.rs
+++ b/crates/pdo-daemon/src/graph_resolver.rs
@@ -399,8 +399,8 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         }
     }
 
@@ -455,8 +455,8 @@ mod tests {
                 max_iter,
             ))),
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         }
     }
 

--- a/crates/pdo-daemon/src/harness_argv.rs
+++ b/crates/pdo-daemon/src/harness_argv.rs
@@ -1,0 +1,275 @@
+//! Pure argv-template renderer for agentic harnesses (ADR-0045).
+//!
+//! A harness declares its launch and resume tails as a **template of argv
+//! tokens**. This module turns such a template plus a set of hole values into the
+//! single tail string a tmux session runs — with ONE rule: **a token that
+//! references a hole whose value is empty is dropped in its entirety**. That rule
+//! is the whole reason the `claude` tail stays byte-identical to the legacy launch
+//! when no model / effort / settings / session identity is posed (the #550 gate).
+//!
+//! **Pure by contract — an AC, not advice.** No `$HOME`, no disk, no clock. The
+//! caller shell-quotes each hole value before handing it in (`'opus'`, or
+//! `"$(cat '/path')"` for the prompt), so the shell-quoting discipline stays in
+//! [`crate::tmux_session_manager`] where the shell semantics already live. This
+//! module only substitutes placeholders and joins the survivors, which is exactly
+//! what makes it testable without a fixture.
+
+/// The values substituted into a descriptor's argv holes.
+///
+/// Each field is **already shell-quoted by the caller**. An EMPTY string means
+/// "no value": every token that references that hole is dropped, so the rendered
+/// tail collapses to exactly what it would be if the hole did not appear in the
+/// template at all.
+///
+/// `prompt`, `model`, `effort`, `session_id` and `settings` are the five holes of
+/// ADR-0045. `resume` is a sixth, and it is deliberately NOT one of them: it is
+/// the resume *selector* (`--resume '<id>'` by identity, or a blind `--continue`),
+/// which ADR-0045 keeps in **code** because the identity-or-blind choice reads the
+/// node's event-log row, not the harness. The pure hole-drop rule cannot express
+/// "emit X *when* the hole is empty", so the selector is computed by the caller
+/// and handed in here as one opaque, never-empty value.
+#[derive(Debug, Default, Clone)]
+pub(crate) struct Holes {
+    pub prompt: String,
+    pub model: String,
+    pub effort: String,
+    pub session_id: String,
+    pub settings: String,
+    pub resume: String,
+}
+
+impl Holes {
+    /// Resolve a placeholder name to its (already-quoted) value.
+    ///
+    /// An unknown placeholder resolves to the empty string, so its token drops —
+    /// the same "absent" behaviour as an empty known hole. Every embedded
+    /// descriptor is pinned by a byte-for-byte golden, which turns a typo'd
+    /// placeholder into a red test rather than a silent drop.
+    fn resolve(&self, name: &str) -> &str {
+        match name {
+            "prompt" => &self.prompt,
+            "model" => &self.model,
+            "effort" => &self.effort,
+            "session_id" => &self.session_id,
+            "settings" => &self.settings,
+            "resume" => &self.resume,
+            _ => "",
+        }
+    }
+}
+
+/// Render a descriptor's argv-token template into a single tail string.
+///
+/// Each token may contain zero or more `{hole}` placeholders. A token is dropped
+/// **entirely** if any placeholder it contains resolves to an empty value;
+/// otherwise every placeholder is substituted and the token is kept. The
+/// survivors are joined by a single space — so an absent optional flag leaves no
+/// double space and no trailing space, which is precisely what keeps the no-op
+/// `claude` tail byte-identical to the hand-written legacy literal.
+pub(crate) fn render(tokens: &[String], holes: &Holes) -> String {
+    tokens
+        .iter()
+        .filter_map(|tok| render_token(tok, holes))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Render one token, or `None` when it references an empty hole (⇒ the token is
+/// dropped by [`render`]).
+fn render_token(token: &str, holes: &Holes) -> Option<String> {
+    let mut out = String::with_capacity(token.len());
+    let mut rest = token;
+    loop {
+        let open = match rest.find('{') {
+            None => {
+                out.push_str(rest);
+                return Some(out);
+            }
+            Some(i) => i,
+        };
+        // A `{` with no closing `}` is literal text, not a placeholder — keep it
+        // and stop scanning (none of our descriptors do this, but be lenient).
+        let rel_close = match rest[open + 1..].find('}') {
+            None => {
+                out.push_str(rest);
+                return Some(out);
+            }
+            Some(i) => i,
+        };
+        let close = open + 1 + rel_close;
+        out.push_str(&rest[..open]);
+        let value = holes.resolve(&rest[open + 1..close]);
+        if value.is_empty() {
+            return None; // one empty hole drops the whole token
+        }
+        out.push_str(value);
+        rest = &rest[close + 1..];
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::harness_registry;
+
+    /// The prompt hole as the caller builds it: `"$(cat '<path>')"`.
+    fn prompt_hole(path: &str) -> String {
+        format!("\"$(cat '{path}')\"")
+    }
+
+    // -----------------------------------------------------------------------
+    // THE GATE (#550): the `claude` launch/resume tails, byte for byte.
+    //
+    // These goldens were captured from the pre-refactor `build_agent_tail` /
+    // `build_resume_script` literals (single space before the prompt cat, leading
+    // space on `--effort` etc.) and then the tail builders were rewritten to route
+    // through this renderer. A golden written *after* the refactor would prove
+    // nothing — so it is the literal here that is authoritative.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn claude_launch_no_holes_is_byte_identical_to_the_legacy_tail() {
+        let d = harness_registry::resolve("claude").unwrap();
+        let holes = Holes {
+            prompt: prompt_hole("/tmp/test-prompt.md"),
+            ..Default::default()
+        };
+        assert_eq!(
+            render(&d.launch, &holes),
+            "exec claude --dangerously-skip-permissions \"$(cat '/tmp/test-prompt.md')\""
+        );
+    }
+
+    #[test]
+    fn claude_resume_no_holes_is_byte_identical_to_the_legacy_tail() {
+        let d = harness_registry::resolve("claude").unwrap();
+        // The blind-continue selector, as the resume seam computes it when the row
+        // carries no pinned id (pre-#473 / opencode).
+        let holes = Holes {
+            resume: "--continue".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(
+            render(&d.resume, &holes),
+            "exec claude --dangerously-skip-permissions --continue"
+        );
+    }
+
+    #[test]
+    fn claude_launch_fills_every_hole_in_order() {
+        let d = harness_registry::resolve("claude").unwrap();
+        let holes = Holes {
+            prompt: prompt_hole("/tmp/p.md"),
+            model: "'opus'".to_string(),
+            effort: "'low'".to_string(),
+            settings: "'/tmp/s.json'".to_string(),
+            session_id: "'abc-123'".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(
+            render(&d.launch, &holes),
+            "exec claude --dangerously-skip-permissions --model 'opus' --effort 'low' \
+             --settings '/tmp/s.json' --session-id 'abc-123' \"$(cat '/tmp/p.md')\""
+        );
+    }
+
+    #[test]
+    fn claude_launch_model_only_hugs_the_base_flag() {
+        // #296/#424: an absent optional flag leaves no double space and no gap.
+        let d = harness_registry::resolve("claude").unwrap();
+        let holes = Holes {
+            prompt: prompt_hole("/tmp/p.md"),
+            model: "'opus'".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(
+            render(&d.launch, &holes),
+            "exec claude --dangerously-skip-permissions --model 'opus' \"$(cat '/tmp/p.md')\""
+        );
+    }
+
+    #[test]
+    fn claude_launch_effort_only_leaves_no_gap_where_the_model_would_be() {
+        let d = harness_registry::resolve("claude").unwrap();
+        let holes = Holes {
+            prompt: prompt_hole("/tmp/p.md"),
+            effort: "'xhigh'".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(
+            render(&d.launch, &holes),
+            "exec claude --dangerously-skip-permissions --effort 'xhigh' \"$(cat '/tmp/p.md')\""
+        );
+    }
+
+    #[test]
+    fn claude_resume_by_identity() {
+        let d = harness_registry::resolve("claude").unwrap();
+        let holes = Holes {
+            resume: "--resume 'abc-123'".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(
+            render(&d.resume, &holes),
+            "exec claude --dangerously-skip-permissions --resume 'abc-123'"
+        );
+    }
+
+    #[test]
+    fn claude_resume_carries_effort_and_settings() {
+        let d = harness_registry::resolve("claude").unwrap();
+        let holes = Holes {
+            resume: "--continue".to_string(),
+            effort: "'low'".to_string(),
+            settings: "'/tmp/s.json'".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(
+            render(&d.resume, &holes),
+            "exec claude --dangerously-skip-permissions --continue --effort 'low' \
+             --settings '/tmp/s.json'"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // The rendering rule itself, independent of any descriptor.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn a_token_with_one_empty_hole_is_dropped_whole() {
+        let tokens = vec!["--model {model}".to_string()];
+        assert_eq!(render(&tokens, &Holes::default()), "");
+    }
+
+    #[test]
+    fn a_token_with_a_filled_hole_survives() {
+        let tokens = vec!["--model {model}".to_string()];
+        let holes = Holes {
+            model: "'opus'".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(render(&tokens, &holes), "--model 'opus'");
+    }
+
+    #[test]
+    fn a_literal_token_with_no_hole_always_survives() {
+        let tokens = vec!["--auto".to_string()];
+        assert_eq!(render(&tokens, &Holes::default()), "--auto");
+    }
+
+    #[test]
+    fn survivors_are_joined_by_a_single_space_only() {
+        let tokens = vec![
+            "a".to_string(),
+            "--x {model}".to_string(), // dropped
+            "b".to_string(),
+        ];
+        assert_eq!(render(&tokens, &Holes::default()), "a b");
+    }
+
+    #[test]
+    fn an_unknown_placeholder_drops_its_token() {
+        let tokens = vec!["--x {nope}".to_string(), "keep".to_string()];
+        assert_eq!(render(&tokens, &Holes::default()), "keep");
+    }
+}

--- a/crates/pdo-daemon/src/harness_probes.rs
+++ b/crates/pdo-daemon/src/harness_probes.rs
@@ -1,0 +1,325 @@
+//! The capability factory for agentic harnesses (#553, ADR-0045).
+//!
+//! Everything PDO knows how to do **beyond launching** a harness is a
+//! **capability**, written harness by harness: estimate a cost, resolve a
+//! transcript, constate an end of turn, spot a usage-limit menu, hold a staging
+//! floor. This module is the factory for those capabilities — and its whole
+//! point is to make their **absence legible**: never supplied, never silent.
+//!
+//! The shape is deliberate and was settled at the grilling (do not redraw it):
+//!
+//! - a trait ([`HarnessProbes`]) whose **every method defaults to "absent"**;
+//! - one implementation per harness that **overrides only what it can do**
+//!   ([`ClaudeProbes`] overrides all five);
+//! - a factory ([`probes_for`]) that returns `Option<&'static dyn …>`, so a
+//!   harness **declared in data** (an `opencode`, or a user's disk descriptor)
+//!   gets `None` — "no capability" — for free and un-forgettably.
+//!
+//! A closed `enum Harness` with compiled exhaustiveness was **explicitly
+//! rejected**: a data-declared harness has no variant, so every `match` would
+//! carry a catch-all arm. Here it costs nothing — an unknown name simply does not
+//! match, and the caller reads "absent" off the `None`.
+//!
+//! ## What "absent is said, never supplied" buys each caller
+//! - **cost** ([`crate::run_cost`]): a harness with no [`HarnessProbes::cost_source`]
+//!   contributes "—" **and a reason naming it**, never `$0`, never a silent
+//!   `partial` — the same vein as `unpriced_models` (#425).
+//! - **turn-end / usage-limit** ([`crate::stale_detector`]): the two sweep probes
+//!   are **gated** on [`HarnessProbes::turn_end_substrate`] /
+//!   [`HarnessProbes::usage_limit_anchor`]. Absent ⇒ the probe does not run, and
+//!   no node is ever auto-completed on an invented heuristic.
+//! - **sandbox** ([`crate::node_spawn`]): a sandboxed Run on a harness with no
+//!   [`HarnessProbes::staging_floor`] is **said once, visibly** — it holds only by
+//!   the user's image and the profile's `$HOME` exceptions, without the plancher's
+//!   guarantees (ADR-0031).
+//!
+//! This module is narrow on purpose: it fabricates **capabilities, never a
+//! launch** (a launch is data — the argv template of [`crate::harness_registry`]).
+
+use crate::harness_registry;
+
+/// A harness's cost source — how PDO turns a live Run into a dollar figure.
+///
+/// A marker, present or absent. Absent ⇒ the Run's cost is "—" with a reason.
+/// `claude`'s is the only source today; a second harness's would be a distinct
+/// variant (measured: `opencode` writes its own per-message cost into a SQLite
+/// its HTTP API exposes, four buckets that do not map onto `claude`'s — so cost
+/// stays code, never a declared mini-language, ADR-0045).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CostSource {
+    /// PDO derives the cost itself: per-message token usage in the harness's
+    /// transcript × the resolved price table (ADR-0034), as [`crate::run_cost`]
+    /// already does for `claude`.
+    DerivedFromTranscript,
+}
+
+/// How PDO resolves a harness's transcript on disk.
+///
+/// A cost or a turn-end read needs to find the right file first; a harness whose
+/// store PDO cannot map has neither. (Measured: `opencode` migrated its sessions
+/// into a SQLite and left months of dead JSON on disk — a store is not a contract,
+/// ADR-0045 — so PDO declares no resolution for it rather than reading zeros.)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TranscriptResolution {
+    /// Claude Code's `<projects_root>/<encoded-cwd>/<session-id>.jsonl` (#473),
+    /// newest-mtime for a pre-#473 row.
+    ClaudeJsonl,
+}
+
+/// The substrate PDO reads to constate an end of turn (#469 §2, ADR-0043).
+///
+/// Absent ⇒ the turn-end auto-completion probe never runs for this harness, so no
+/// node is auto-completed on an invented heuristic.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TurnEndSubstrate {
+    /// The Claude Code JSONL transcript tail, classified by
+    /// [`crate::stale_detector::parse_turn_state`].
+    ClaudeTranscript,
+}
+
+/// A harness's on-screen usage-limit menu — the anchor PDO matches in a pane
+/// capture (#290). **Proper to a harness**: the wording is claude's, so the probe
+/// is gated on this capability being present.
+///
+/// A marker, not a carrier of the substrings: those live next to their matcher in
+/// [`crate::stale_detector`] (they drift with Claude Code and are updated there).
+/// Absent ⇒ the usage-limit probe never runs for this harness.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum UsageLimitAnchor {
+    /// Claude Code's interactive "stop and wait for limit to reset" menu, matched
+    /// by [`crate::stale_detector::detect_usage_limit`].
+    ClaudePaneMenu,
+}
+
+/// The sandbox staging floor a harness guarantees (ADR-0031).
+///
+/// Absent ⇒ a sandboxed Run on this harness holds only by the user's image and
+/// the profile's `$HOME` exceptions, without the plancher's guarantees — and PDO
+/// says so once (see [`staging_floor_absence_note`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum StagingFloor {
+    /// The `.claude` staged home: valid credentials, org managed settings, bypass
+    /// permissions accepted, trust pre-granted to the Run root, empty `projects/`.
+    ClaudeDotClaude,
+}
+
+/// The capabilities of one harness. **Every method defaults to "absent"**
+/// (`None`); an implementation overrides only what its harness can do.
+///
+/// `Sync` so a single `&'static` instance can be handed out from [`probes_for`]
+/// across the daemon's threads (each impl is a stateless zero-sized type).
+pub(crate) trait HarnessProbes: Sync {
+    /// Cost source, or `None` (contribute "—" + a reason, never `$0`).
+    fn cost_source(&self) -> Option<CostSource> {
+        None
+    }
+    /// How PDO finds this harness's transcript, or `None`.
+    fn transcript_resolution(&self) -> Option<TranscriptResolution> {
+        None
+    }
+    /// The end-of-turn substrate, or `None` (the sweep's turn-end probe is gated
+    /// on this).
+    fn turn_end_substrate(&self) -> Option<TurnEndSubstrate> {
+        None
+    }
+    /// The usage-limit menu anchor, or `None` (the sweep's usage-limit probe is
+    /// gated on this).
+    fn usage_limit_anchor(&self) -> Option<UsageLimitAnchor> {
+        None
+    }
+    /// The sandbox staging floor, or `None` (a sandboxed Run says its absence
+    /// once).
+    fn staging_floor(&self) -> Option<StagingFloor> {
+        None
+    }
+}
+
+/// The `claude` capabilities — all five, exactly as they are today. This slice is
+/// a **dispatch refactor**, not a behaviour change: every method returns the
+/// mechanism `claude` has always used.
+struct ClaudeProbes;
+
+impl HarnessProbes for ClaudeProbes {
+    fn cost_source(&self) -> Option<CostSource> {
+        Some(CostSource::DerivedFromTranscript)
+    }
+    fn transcript_resolution(&self) -> Option<TranscriptResolution> {
+        Some(TranscriptResolution::ClaudeJsonl)
+    }
+    fn turn_end_substrate(&self) -> Option<TurnEndSubstrate> {
+        Some(TurnEndSubstrate::ClaudeTranscript)
+    }
+    fn usage_limit_anchor(&self) -> Option<UsageLimitAnchor> {
+        Some(UsageLimitAnchor::ClaudePaneMenu)
+    }
+    fn staging_floor(&self) -> Option<StagingFloor> {
+        Some(StagingFloor::ClaudeDotClaude)
+    }
+}
+
+/// The single `claude` instance handed out by [`probes_for`]. Zero-sized, so this
+/// `static` costs nothing and needs no lazy init.
+static CLAUDE_PROBES: ClaudeProbes = ClaudeProbes;
+
+/// The capabilities of `harness`, or `None` for a harness PDO carries no code for.
+///
+/// `claude` is the only harness with any capability today; `opencode` and every
+/// **data-declared** harness (a user's disk descriptor) get `None` — "no
+/// capability" — which is exactly what makes the absence free and un-forgettable.
+/// A caller that wants per-capability booleans uses [`capabilities`], which reads
+/// the same `None` as "all absent".
+pub(crate) fn probes_for(harness: &str) -> Option<&'static dyn HarnessProbes> {
+    match harness {
+        harness_registry::CLAUDE => Some(&CLAUDE_PROBES),
+        // `opencode` (resident but un-instrumented in v1) and every data-declared
+        // harness: no capability. A launch is data; a capability is code (ADR-0045).
+        _ => None,
+    }
+}
+
+/// The five capabilities of a harness as plain booleans — the read-friendly view
+/// the gates consult. A harness with no probes (`None` from [`probes_for`]) is
+/// absent on all five, so a data-declared harness resolves to
+/// [`Capabilities::NONE`] without any per-harness code.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct Capabilities {
+    pub cost: bool,
+    pub transcript: bool,
+    pub turn_end: bool,
+    pub usage_limit: bool,
+    pub staging: bool,
+}
+
+impl Capabilities {
+    /// Every capability absent — a data-declared harness, un-instrumented and
+    /// blind, but still launchable/attachable/completable (ADR-0045).
+    pub(crate) const NONE: Capabilities = Capabilities {
+        cost: false,
+        transcript: false,
+        turn_end: false,
+        usage_limit: false,
+        staging: false,
+    };
+}
+
+/// Resolve `harness` to its five capability booleans. `None` from the factory ⇒
+/// [`Capabilities::NONE`], so an unknown or data-declared harness is absent on all
+/// five — the property the whole slice rests on.
+pub(crate) fn capabilities(harness: &str) -> Capabilities {
+    match probes_for(harness) {
+        None => Capabilities::NONE,
+        Some(p) => Capabilities {
+            cost: p.cost_source().is_some(),
+            transcript: p.transcript_resolution().is_some(),
+            turn_end: p.turn_end_substrate().is_some(),
+            usage_limit: p.usage_limit_anchor().is_some(),
+            staging: p.staging_floor().is_some(),
+        },
+    }
+}
+
+/// Whether PDO can derive a Run's cost for `harness`: it needs both a cost source
+/// and a way to find the transcript that source reads. A data-declared harness has
+/// neither, so its Run's cost is "—" with a reason rather than a silent `$0`.
+pub(crate) fn can_cost(harness: &str) -> bool {
+    let c = capabilities(harness);
+    c.cost && c.transcript
+}
+
+/// The one-time note for a sandboxed Run whose node runs on a harness with no
+/// staging floor (ADR-0031). `Some(msg)` when `harness` lacks the floor,
+/// `None` when it has it (`claude`). Pure and testable, modelled on
+/// `price_table::diagnostic`.
+pub(crate) fn staging_floor_absence_note(harness: &str) -> Option<String> {
+    if capabilities(harness).staging {
+        return None;
+    }
+    Some(format!(
+        "sandbox: harness `{harness}` has no staging floor (#553, ADR-0031) — this Run's session \
+         holds only by the profile's image and its `$HOME` exceptions, without the plancher's \
+         guarantees (credentials, org managed settings, pre-granted trust, empty projects/)"
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::harness_registry::{CLAUDE, OPENCODE};
+
+    /// A struct that overrides nothing: the demonstration that **every trait
+    /// method defaults to "absent"**. This is the shape of a harness declared in
+    /// data — it has no code, so it inherits every default.
+    struct BareHarness;
+    impl HarnessProbes for BareHarness {}
+
+    #[test]
+    fn every_default_is_absent() {
+        let bare = BareHarness;
+        assert!(bare.cost_source().is_none());
+        assert!(bare.transcript_resolution().is_none());
+        assert!(bare.turn_end_substrate().is_none());
+        assert!(bare.usage_limit_anchor().is_none());
+        assert!(bare.staging_floor().is_none());
+    }
+
+    #[test]
+    fn claude_keeps_its_five_capabilities() {
+        // The control: `claude`'s five capabilities are intact — this slice is a
+        // dispatch refactor, not a behaviour change.
+        let p = probes_for(CLAUDE).expect("claude has probes");
+        assert_eq!(p.cost_source(), Some(CostSource::DerivedFromTranscript));
+        assert_eq!(
+            p.transcript_resolution(),
+            Some(TranscriptResolution::ClaudeJsonl)
+        );
+        assert_eq!(
+            p.turn_end_substrate(),
+            Some(TurnEndSubstrate::ClaudeTranscript)
+        );
+        assert_eq!(
+            p.usage_limit_anchor(),
+            Some(UsageLimitAnchor::ClaudePaneMenu)
+        );
+        assert_eq!(p.staging_floor(), Some(StagingFloor::ClaudeDotClaude));
+    }
+
+    #[test]
+    fn claude_capabilities_are_all_present() {
+        let c = capabilities(CLAUDE);
+        assert_eq!(
+            c,
+            Capabilities {
+                cost: true,
+                transcript: true,
+                turn_end: true,
+                usage_limit: true,
+                staging: true,
+            }
+        );
+        assert!(can_cost(CLAUDE));
+    }
+
+    #[test]
+    fn a_data_declared_harness_is_absent_on_all_five() {
+        // AC: a harness declared in data returns "absent" on the five. `opencode`
+        // (embedded but un-instrumented in v1) and any never-seen name both take
+        // the factory's `None`.
+        for name in [OPENCODE, "my-custom-harness", "not-a-harness"] {
+            assert!(probes_for(name).is_none(), "{name} must have no probes");
+            assert_eq!(capabilities(name), Capabilities::NONE, "{name}");
+            assert!(!can_cost(name), "{name} cannot be costed");
+        }
+    }
+
+    #[test]
+    fn staging_floor_absence_note_fires_only_for_a_harness_without_the_floor() {
+        // `claude` has the floor → no note.
+        assert_eq!(staging_floor_absence_note(CLAUDE), None);
+        // A data-declared harness has none → one visible note that names it and
+        // says what is NOT guaranteed.
+        let note = staging_floor_absence_note("my-custom-harness").expect("a note");
+        assert!(note.contains("`my-custom-harness`"));
+        assert!(note.contains("no staging floor"));
+        assert!(note.contains("$HOME"));
+    }
+}

--- a/crates/pdo-daemon/src/harness_registry.rs
+++ b/crates/pdo-daemon/src/harness_registry.rs
@@ -1,0 +1,248 @@
+//! Resolve an agentic-harness name to its descriptor (ADR-0045).
+//!
+//! A **harness** is the program that runs a NodeRun's agent (`claude`,
+//! `opencode`, …). It declares itself with two argv-token templates (launch,
+//! resume), an env block, and the binary PDO probes at spawn — never with named
+//! per-feature fields (a named field per case becomes a spelling per case; the
+//! template covers them without naming, ADR-0045).
+//!
+//! **This slice is the embedded floor only.** `claude` and `opencode` are compiled
+//! in; nothing is seeded on disk and this module never reads `$HOME` (the
+//! discipline `run_cost` paid for in #408 — a root goes in, a descriptor comes
+//! out). A user-declared *disk tier* that merges over the floor **by name** is
+//! #553; [`merge_by_name`] is that seam, present and tested now so the disk tier
+//! layers on without rewriting [`resolve`]'s callers — but no caller passes a disk
+//! tier in this slice, so the floor is the whole registry.
+
+/// A harness, as PDO launches / resumes / attaches it (ADR-0045).
+///
+/// The two templates are rendered by [`crate::harness_argv`]; the caller fills
+/// the holes (`{prompt}`, `{model}`, `{effort}`, `{session_id}`, `{settings}`,
+/// and the resume-only `{resume}` selector). The env block is exported before an
+/// **agent** tail — that is where `claude`'s `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1`
+/// now comes from (AC #4); `script` / `shell` tails get it forced by the wrapper.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HarnessDescriptor {
+    /// The harness name (`claude`, `opencode`) — the registry key.
+    pub name: String,
+    /// The program that runs the agent — probed on `PATH` at spawn. Not found ⇒
+    /// the spawn fails **fast**, naming the harness, and writes no start event
+    /// (ADR-0037).
+    pub binary: String,
+    /// The launch tail as an argv-token template.
+    pub launch: Vec<String>,
+    /// The resume tail as an argv-token template. **Empty** ⇒ the harness has no
+    /// resume mechanism, so a resume serves the last pane snapshot rather than an
+    /// error (AC #9, same branch as a `script` node).
+    pub resume: Vec<String>,
+    /// Env exported before an agent tail (`K=V`). Rendered by the wrapper.
+    pub env: Vec<(String, String)>,
+}
+
+impl HarnessDescriptor {
+    /// Whether the LAUNCH template carries an `{effort}` hole.
+    ///
+    /// `opencode` has no effort axis at launch (measured on 1.18.18: the effort
+    /// variant is an in-session command, not a flag), so the UI greys its effort
+    /// picker off this fact alone — an absence declared by the descriptor's shape,
+    /// no extra flag needed (AC #13, ADR-0045).
+    pub fn has_effort_hole(&self) -> bool {
+        self.launch.iter().any(|t| t.contains("{effort}"))
+    }
+
+    /// Whether the harness can re-enter a saved conversation. `false` ⇒ a resume
+    /// serves the pane snapshot (AC #9).
+    pub fn can_resume(&self) -> bool {
+        !self.resume.is_empty()
+    }
+
+    /// Whether the LAUNCH template pins a session identity (`{session_id}`).
+    ///
+    /// `opencode` cannot (measured: launching with a fresh id answers "Session not
+    /// found" and exits 1 — its selector *continues* a session, never creates
+    /// one), so PDO never pins one for it and attributes by working dir alone.
+    pub fn pins_session_id(&self) -> bool {
+        self.launch.iter().any(|t| t.contains("{session_id}"))
+    }
+}
+
+/// The `claude` harness name — the floor of the precedence chain (ADR-0046).
+pub const CLAUDE: &str = "claude";
+/// The `opencode` harness name (ADR-0045, measured on 1.18.18).
+pub const OPENCODE: &str = "opencode";
+
+/// The `claude` descriptor: the legacy launch, expressed as data.
+///
+/// The launch template reproduces the pre-#550 `build_agent_tail` **byte for
+/// byte** once its holes are empty — that is the #550 gate, pinned by the goldens
+/// in [`crate::harness_argv`]. The resume template reproduces the pre-#550
+/// `build_resume_script` tail; its `{resume}` hole is the identity-or-blind
+/// selector the resume seam computes (ADR-0045 keeps that choice in code).
+pub fn claude() -> HarnessDescriptor {
+    HarnessDescriptor {
+        name: CLAUDE.to_string(),
+        binary: "claude".to_string(),
+        launch: [
+            "exec",
+            "claude",
+            "--dangerously-skip-permissions",
+            "--model {model}",
+            "--effort {effort}",
+            "--settings {settings}",
+            "--session-id {session_id}",
+            "{prompt}",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect(),
+        resume: [
+            "exec",
+            "claude",
+            "--dangerously-skip-permissions",
+            "{resume}",
+            "--effort {effort}",
+            "--settings {settings}",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect(),
+        // AC #4: the CCR suppression now comes from the descriptor for an agent
+        // tail (byte-identical to the wrapper's old hard-coded export — see the
+        // `harness_env` handling in `tmux_session_manager::wrap_with_env`).
+        env: vec![(
+            "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC".to_string(),
+            "1".to_string(),
+        )],
+    }
+}
+
+/// The `opencode` descriptor (measured on 1.18.18).
+///
+/// `--auto` is its `--dangerously-skip-permissions`; the prompt is a `--prompt`
+/// argument; the model is `--model provider/model`. There is **no** effort hole
+/// (no launch-time effort axis) and **no** session-id hole (identity can't be
+/// pinned), so the effort picker greys and attribution falls back to the working
+/// dir. Resume is a blind `--continue` (opencode is resident and continues the
+/// cwd's latest session); it carries no env block.
+pub fn opencode() -> HarnessDescriptor {
+    HarnessDescriptor {
+        name: OPENCODE.to_string(),
+        binary: "opencode".to_string(),
+        launch: [
+            "exec",
+            "opencode",
+            "--auto",
+            "--model {model}",
+            "--prompt {prompt}",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect(),
+        resume: ["exec", "opencode", "--auto", "--continue"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect(),
+        env: vec![],
+    }
+}
+
+/// The embedded floor: the harnesses PDO ships compiled in, in precedence-neutral
+/// declaration order.
+pub fn embedded_floor() -> Vec<HarnessDescriptor> {
+    vec![claude(), opencode()]
+}
+
+/// Merge a user-declared disk tier over the embedded floor, **by name**: a disk
+/// descriptor replaces the floor's entry of the same name; a floor name absent
+/// from disk survives. Pure — the caller (a future slice, #553) reads and parses
+/// the disk tier and hands the descriptors in. No caller passes a disk tier in
+/// this slice, so `merge_by_name(embedded_floor(), vec![])` is the whole registry.
+pub fn merge_by_name(
+    floor: Vec<HarnessDescriptor>,
+    disk: Vec<HarnessDescriptor>,
+) -> Vec<HarnessDescriptor> {
+    let mut merged = floor;
+    for d in disk {
+        match merged.iter_mut().find(|f| f.name == d.name) {
+            Some(slot) => *slot = d,
+            None => merged.push(d),
+        }
+    }
+    merged
+}
+
+/// Resolve a harness name to its descriptor. `None` ⇒ no harness carries that
+/// name (an unknown harness — the spawn seam turns this into a fail-fast that
+/// names it, never a silent fallback).
+///
+/// The disk tier (#553) layers on by making this `merge_by_name(embedded_floor(),
+/// disk).into_iter().find(...)`; callers don't change.
+pub fn resolve(name: &str) -> Option<HarnessDescriptor> {
+    embedded_floor().into_iter().find(|d| d.name == name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn floor_carries_claude_and_opencode() {
+        assert!(resolve(CLAUDE).is_some());
+        assert!(resolve(OPENCODE).is_some());
+        assert!(resolve("nope").is_none());
+    }
+
+    #[test]
+    fn claude_pins_identity_has_effort_and_can_resume() {
+        let d = claude();
+        assert!(d.pins_session_id(), "claude pins --session-id");
+        assert!(d.has_effort_hole(), "claude has an effort axis");
+        assert!(d.can_resume(), "claude resumes by --resume/--continue");
+    }
+
+    #[test]
+    fn opencode_has_no_effort_axis_and_no_identity_pin() {
+        let d = opencode();
+        assert!(
+            !d.has_effort_hole(),
+            "opencode has no launch-time effort axis (greys the picker)"
+        );
+        assert!(
+            !d.pins_session_id(),
+            "opencode cannot pin a session identity"
+        );
+        assert!(d.can_resume(), "opencode blind-continues");
+        assert!(d.env.is_empty(), "opencode carries no CCR env");
+    }
+
+    #[test]
+    fn merge_by_name_replaces_a_floor_entry_and_keeps_the_rest() {
+        let custom_claude = HarnessDescriptor {
+            name: CLAUDE.to_string(),
+            binary: "my-claude".to_string(),
+            launch: vec!["exec".to_string(), "my-claude".to_string()],
+            resume: vec![],
+            env: vec![],
+        };
+        let merged = merge_by_name(embedded_floor(), vec![custom_claude.clone()]);
+        // claude is replaced by the disk entry…
+        let c = merged.iter().find(|d| d.name == CLAUDE).unwrap();
+        assert_eq!(c.binary, "my-claude");
+        // …and opencode, absent from the disk tier, survives from the floor.
+        assert!(merged.iter().any(|d| d.name == OPENCODE));
+    }
+
+    #[test]
+    fn merge_by_name_appends_an_unknown_disk_harness() {
+        let novel = HarnessDescriptor {
+            name: "novel".to_string(),
+            binary: "novel".to_string(),
+            launch: vec!["exec".to_string(), "novel".to_string()],
+            resume: vec![],
+            env: vec![],
+        };
+        let merged = merge_by_name(embedded_floor(), vec![novel]);
+        assert!(merged.iter().any(|d| d.name == "novel"));
+        assert_eq!(merged.len(), 3);
+    }
+}

--- a/crates/pdo-daemon/src/harness_registry.rs
+++ b/crates/pdo-daemon/src/harness_registry.rs
@@ -13,6 +13,22 @@
 //! #553; [`merge_by_name`] is that seam, present and tested now so the disk tier
 //! layers on without rewriting [`resolve`]'s callers — but no caller passes a disk
 //! tier in this slice, so the floor is the whole registry.
+//!
+//! **#553 lands that disk tier.** [`HarnessRegistry::load`] reads a user-declared
+//! descriptor file under an **injected root** (never `$HOME` — the discipline this
+//! module already keeps), parses it, and merges it over the embedded floor **by
+//! name** ([`merge_by_name`]). Nothing is ever written or seeded. A descriptor that
+//! is unreadable or refused is **inert and diagnosed**: its key falls through to
+//! the next tier (the floor), it is never partially applied, and it is named —
+//! once per distinct diagnostic in the log, and always in `GET /settings` — the
+//! exact idiom of `price_table` (ADR-0034).
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use serde::Deserialize;
+use tracing::warn;
 
 /// A harness, as PDO launches / resumes / attaches it (ADR-0045).
 ///
@@ -181,6 +197,262 @@ pub fn resolve(name: &str) -> Option<HarnessDescriptor> {
     embedded_floor().into_iter().find(|d| d.name == name)
 }
 
+// --- The disk tier (#553) -----------------------------------------------------
+
+/// A refused disk descriptor and why — the material of BOTH the `warn!` and the
+/// `GET /settings` `reason`, so the two can never drift (idiom of
+/// `price_table::RejectedRow`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RejectedDescriptor {
+    pub name: String,
+    pub why: String,
+}
+
+/// The result of parsing the on-disk descriptor tier. Pure: text in; the parsed
+/// descriptors and any refusals out. An unparseable document yields
+/// `unparseable: Some(err)` and NO descriptors — never an `Err`, because a bad
+/// descriptor file must not be able to fail a spawn (it degrades to the floor).
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct ParsedDescriptors {
+    pub descriptors: Vec<HarnessDescriptor>,
+    pub rejected: Vec<RejectedDescriptor>,
+    pub unparseable: Option<String>,
+}
+
+/// One row of the descriptor file. The harness **name is the map key**, so it is
+/// not a field here (key uniqueness is structural, like `price_table`'s manual
+/// map). No `deny_unknown_fields` (ADR-0015 #471: an unknown field is ignored).
+#[derive(Debug, Deserialize)]
+struct DescriptorRow {
+    binary: Option<String>,
+    #[serde(default)]
+    launch: Vec<String>,
+    #[serde(default)]
+    resume: Vec<String>,
+    #[serde(default)]
+    env: BTreeMap<String, String>,
+}
+
+/// Parse the descriptor file (`descriptors.yaml`). PURE.
+///
+/// Shape — a MAP keyed by harness name, mirroring `price_table`'s `models.yaml`:
+///
+/// ```yaml
+/// harnesses:
+///   my-harness:
+///     binary: my-harness
+///     launch: ["exec", "my-harness", "--auto", "--prompt {prompt}"]
+///     resume: ["exec", "my-harness", "--auto", "--continue"]   # optional
+///     env: { FOO: bar }                                        # optional
+/// ```
+///
+/// A row is **refused whole** (never partially applied) when it lacks the two
+/// things PDO needs to *launch* it: a `binary` to probe and a non-empty `launch`
+/// argv template (ADR-0045). A refused row's key falls through to the next tier —
+/// so a broken `claude:` override leaves the embedded `claude` untouched. PDO does
+/// **not** validate what the argv *means* (ADR-0001): a descriptor without an
+/// autonomy flag simply yields a node stalled on a permission dialog, which is
+/// said in the descriptor's documentation, not guarded here.
+pub fn parse_descriptors(text: &str) -> ParsedDescriptors {
+    #[derive(Deserialize)]
+    struct Doc {
+        #[serde(default)]
+        harnesses: BTreeMap<String, DescriptorRow>,
+    }
+
+    // A blank/comment-only file is an empty tier, not a broken one — the normal
+    // state of an instance that has the dir but no descriptor yet.
+    if text.trim().is_empty() {
+        return ParsedDescriptors::default();
+    }
+    let doc: Doc = match serde_yaml::from_str(text) {
+        Ok(d) => d,
+        Err(e) => {
+            return ParsedDescriptors {
+                unparseable: Some(e.to_string()),
+                ..Default::default()
+            }
+        }
+    };
+
+    let mut parsed = ParsedDescriptors::default();
+    for (name, row) in doc.harnesses {
+        if name.trim().is_empty() {
+            parsed.rejected.push(RejectedDescriptor {
+                name,
+                why: "a harness name must not be blank".to_string(),
+            });
+            continue;
+        }
+        let binary = row.binary.unwrap_or_default();
+        if binary.trim().is_empty() {
+            parsed.rejected.push(RejectedDescriptor {
+                name,
+                why: "missing `binary` — PDO probes a program at spawn; a descriptor with none \
+                      could only ever fail-fast"
+                    .to_string(),
+            });
+            continue;
+        }
+        // An empty string among the launch tokens is not a hole to fill — it would
+        // render to a stray token. Refuse the row rather than launch something odd.
+        if row.launch.is_empty() {
+            parsed.rejected.push(RejectedDescriptor {
+                name,
+                why: "missing `launch` — a harness declares itself by an argv template (ADR-0045)"
+                    .to_string(),
+            });
+            continue;
+        }
+        parsed.descriptors.push(HarnessDescriptor {
+            name,
+            binary,
+            launch: row.launch,
+            resume: row.resume,
+            env: row.env.into_iter().collect(),
+        });
+    }
+    parsed
+}
+
+/// The registry resolved for one read: the embedded floor merged with the disk
+/// tier **by name**, plus the diagnostics for whatever the disk tier refused. The
+/// analogue of `price_table::PriceTable` — one resolver shared by the spawn/resume
+/// seams and the `GET /settings` view, so what the UI lists can never drift from
+/// what actually resolves.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HarnessRegistry {
+    /// Floor ∪ disk, merged by name (a disk descriptor replaces the floor entry of
+    /// its name; a floor name absent from disk survives).
+    descriptors: Vec<HarnessDescriptor>,
+    disk_rejected: Vec<RejectedDescriptor>,
+    disk_unparseable: Option<String>,
+    /// Set by [`Self::load`] only, so [`Self::diagnostic`] can name the real file.
+    disk_path: Option<PathBuf>,
+}
+
+impl Default for HarnessRegistry {
+    fn default() -> Self {
+        Self::builtin()
+    }
+}
+
+impl HarnessRegistry {
+    /// The floor alone — no IO, no `$HOME`. What every non-root caller (infra
+    /// sessions, the golden tests) resolves against.
+    pub fn builtin() -> Self {
+        Self {
+            descriptors: embedded_floor(),
+            disk_rejected: Vec::new(),
+            disk_unparseable: None,
+            disk_path: None,
+        }
+    }
+
+    /// `<home_root>/.pdo/harnesses/descriptors.yaml` — path arithmetic only, the
+    /// idiom of `price_table::PriceTable::paths`.
+    pub fn descriptors_path(home_root: &Path) -> PathBuf {
+        home_root
+            .join(".pdo")
+            .join("harnesses")
+            .join("descriptors.yaml")
+    }
+
+    /// Load the effective registry from an injected root. Absent or unreadable →
+    /// the floor, SILENT (the normal state of an instance). Unparseable, or a
+    /// refused row → the floor for that key plus a diagnostic. Never reads `$HOME`,
+    /// never writes, never seeds. Emits AT MOST ONE `warn!` per distinct
+    /// diagnostic, so a polled spawn/settings path cannot flood the log.
+    pub fn load(home_root: &Path) -> Self {
+        let path = Self::descriptors_path(home_root);
+        let parsed = std::fs::read(&path)
+            .ok()
+            .map(|b| parse_descriptors(&String::from_utf8_lossy(&b)))
+            .unwrap_or_default();
+        let registry = Self {
+            descriptors: merge_by_name(embedded_floor(), parsed.descriptors),
+            disk_rejected: parsed.rejected,
+            disk_unparseable: parsed.unparseable,
+            disk_path: Some(path),
+        };
+        registry.warn_once();
+        registry
+    }
+
+    /// Resolve a name against the merged registry. `None` ⇒ no tier carries that
+    /// name (the spawn seam turns this into a fail-fast that names it).
+    pub fn resolve(&self, name: &str) -> Option<HarnessDescriptor> {
+        self.descriptors.iter().find(|d| d.name == name).cloned()
+    }
+
+    /// The names the registry resolves, in declaration order (floor first, then
+    /// any novel disk harness). The `GET /settings` "which harnesses exist" view.
+    pub fn names(&self) -> Vec<String> {
+        self.descriptors.iter().map(|d| d.name.clone()).collect()
+    }
+
+    /// The disk descriptors the registry refused — each inert, its key on the
+    /// floor. For the settings surface.
+    pub fn rejected(&self) -> &[RejectedDescriptor] {
+        &self.disk_rejected
+    }
+
+    /// ONE message naming an inert descriptor file and every refused row, or
+    /// `None` when the disk tier is clean/absent. PURE, so a unit test can pin it
+    /// instead of a terminal (modelled on `price_table::PriceTable::diagnostic`).
+    pub fn diagnostic(&self) -> Option<String> {
+        let where_ = match &self.disk_path {
+            Some(p) => format!("harness descriptor tier ({})", p.display()),
+            None => "harness descriptor tier".to_string(),
+        };
+        let mut parts: Vec<String> = Vec::new();
+        if let Some(err) = &self.disk_unparseable {
+            parts.push(format!("{where_} is entirely inert: {err}"));
+        }
+        if !self.disk_rejected.is_empty() {
+            let rows = self
+                .disk_rejected
+                .iter()
+                .map(|r| format!("`{}` ({})", r.name, r.why))
+                .collect::<Vec<_>>()
+                .join(", ");
+            parts.push(format!(
+                "{where_} refused {} descriptor(s), each key falling through to the next tier: \
+                 {rows}",
+                self.disk_rejected.len()
+            ));
+        }
+        if parts.is_empty() {
+            None
+        } else {
+            Some(format!(
+                "harness descriptors (#553) — {}",
+                parts.join(" ; ")
+            ))
+        }
+    }
+
+    /// Say the diagnostic at most once per distinct message — a *differently* bad
+    /// file hashes differently and is said again. Same posture as
+    /// `price_table::PriceTable::warn_once` (a loader called once per request must
+    /// not log per request).
+    fn warn_once(&self) {
+        static LAST_WARNED: Mutex<Option<u64>> = Mutex::new(None);
+        let Some(msg) = self.diagnostic() else {
+            return;
+        };
+        let mut h = std::collections::hash_map::DefaultHasher::new();
+        std::hash::Hash::hash(&msg, &mut h);
+        let fingerprint = std::hash::Hasher::finish(&h);
+        let mut guard = LAST_WARNED.lock().unwrap_or_else(|e| e.into_inner());
+        if *guard == Some(fingerprint) {
+            return;
+        }
+        *guard = Some(fingerprint);
+        warn!("{msg}");
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -244,5 +516,197 @@ mod tests {
         let merged = merge_by_name(embedded_floor(), vec![novel]);
         assert!(merged.iter().any(|d| d.name == "novel"));
         assert_eq!(merged.len(), 3);
+    }
+
+    // --- the disk tier (#553) ------------------------------------------------
+
+    #[test]
+    fn parse_descriptors_accepts_a_valid_custom_harness() {
+        let parsed = parse_descriptors(
+            "harnesses:\n  my-harness:\n    binary: my-harness\n    launch: [\"exec\", \"my-harness\", \"--auto\", \"--prompt {prompt}\"]\n    resume: [\"exec\", \"my-harness\", \"--auto\", \"--continue\"]\n    env: { FOO: bar }\n",
+        );
+        assert!(parsed.unparseable.is_none());
+        assert!(parsed.rejected.is_empty());
+        assert_eq!(parsed.descriptors.len(), 1);
+        let d = &parsed.descriptors[0];
+        assert_eq!(d.name, "my-harness");
+        assert_eq!(d.binary, "my-harness");
+        assert_eq!(d.launch.last().unwrap(), "--prompt {prompt}");
+        assert_eq!(d.resume, vec!["exec", "my-harness", "--auto", "--continue"]);
+        assert_eq!(d.env, vec![("FOO".to_string(), "bar".to_string())]);
+    }
+
+    #[test]
+    fn parse_descriptors_treats_an_empty_or_comment_only_file_as_an_empty_tier() {
+        for text in [
+            "",
+            "   \n",
+            "# nothing yet\n",
+            "harnesses:\n",
+            "harnesses: {}\n",
+        ] {
+            let parsed = parse_descriptors(text);
+            assert!(parsed.unparseable.is_none(), "text = {text:?}");
+            assert!(parsed.descriptors.is_empty());
+            assert!(parsed.rejected.is_empty());
+        }
+    }
+
+    #[test]
+    fn parse_descriptors_refuses_a_row_missing_binary_or_launch_whole() {
+        // A row without a binary or a launch template is refused ENTIRELY, never
+        // partially applied — its key falls through to the next tier.
+        let no_binary = parse_descriptors("harnesses:\n  x:\n    launch: [\"exec\", \"x\"]\n");
+        assert!(no_binary.descriptors.is_empty());
+        assert_eq!(no_binary.rejected.len(), 1);
+        assert!(no_binary.rejected[0].why.contains("binary"));
+
+        let no_launch = parse_descriptors("harnesses:\n  x:\n    binary: x\n");
+        assert!(no_launch.descriptors.is_empty());
+        assert_eq!(no_launch.rejected.len(), 1);
+        assert!(no_launch.rejected[0].why.contains("launch"));
+    }
+
+    #[test]
+    fn parse_descriptors_keeps_the_good_rows_when_one_is_refused() {
+        let parsed = parse_descriptors(
+            "harnesses:\n  good:\n    binary: good\n    launch: [\"exec\", \"good\"]\n  bad:\n    launch: [\"exec\", \"bad\"]\n",
+        );
+        assert_eq!(
+            parsed.descriptors.len(),
+            1,
+            "one bad row must not void the file"
+        );
+        assert_eq!(parsed.descriptors[0].name, "good");
+        assert_eq!(parsed.rejected.len(), 1);
+        assert_eq!(parsed.rejected[0].name, "bad");
+    }
+
+    #[test]
+    fn parse_descriptors_reports_broken_yaml_without_descriptors() {
+        let parsed = parse_descriptors("harnesses:\n  - this is: [not, a, map\n");
+        assert!(parsed.unparseable.is_some());
+        assert!(parsed.descriptors.is_empty());
+    }
+
+    #[test]
+    fn builtin_registry_resolves_the_floor() {
+        let reg = HarnessRegistry::builtin();
+        assert!(reg.resolve(CLAUDE).is_some());
+        assert!(reg.resolve(OPENCODE).is_some());
+        assert!(reg.resolve("nope").is_none());
+        assert!(reg.diagnostic().is_none());
+        assert_eq!(reg.names(), vec![CLAUDE.to_string(), OPENCODE.to_string()]);
+    }
+
+    #[test]
+    fn load_on_a_root_without_a_descriptor_file_is_the_floor_and_silent() {
+        let home = tempfile::tempdir().unwrap();
+        let reg = HarnessRegistry::load(home.path());
+        assert!(reg.resolve(CLAUDE).is_some());
+        assert!(reg.resolve(OPENCODE).is_some());
+        assert!(reg.diagnostic().is_none());
+        // Nothing is ever seeded on disk.
+        assert!(!HarnessRegistry::descriptors_path(home.path()).exists());
+    }
+
+    #[test]
+    fn load_merges_a_custom_harness_by_name_over_the_floor() {
+        // FP: declare a harness PDO does not know, and it resolves.
+        let home = tempfile::tempdir().unwrap();
+        let path = HarnessRegistry::descriptors_path(home.path());
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &path,
+            "harnesses:\n  my-harness:\n    binary: my-harness\n    launch: [\"exec\", \"my-harness\", \"--auto\"]\n",
+        )
+        .unwrap();
+
+        let reg = HarnessRegistry::load(home.path());
+        let d = reg
+            .resolve("my-harness")
+            .expect("the custom harness resolves");
+        assert_eq!(d.binary, "my-harness");
+        // …and the floor survives alongside it (merge by name).
+        assert!(reg.resolve(CLAUDE).is_some());
+        assert!(reg.resolve(OPENCODE).is_some());
+        assert!(reg.names().contains(&"my-harness".to_string()));
+    }
+
+    #[test]
+    fn a_broken_descriptor_file_leaves_claude_untouched_and_is_diagnosed() {
+        // FP: corrupt the file → it becomes inert and diagnosed; `claude` and
+        // `opencode` keep working (the whole disk tier falls through to the floor).
+        let home = tempfile::tempdir().unwrap();
+        let path = HarnessRegistry::descriptors_path(home.path());
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, "harnesses:\n  - not: [a, map\n").unwrap();
+
+        let reg = HarnessRegistry::load(home.path());
+        // Floor intact, byte-identical to the embedded claude.
+        assert_eq!(reg.resolve(CLAUDE), Some(claude()));
+        assert_eq!(reg.resolve(OPENCODE), Some(opencode()));
+        // …and the corruption is named, pointing at the real file.
+        let d = reg.diagnostic().expect("a broken file must be said");
+        assert!(
+            d.contains("descriptors.yaml"),
+            "the path must be named: {d}"
+        );
+        assert!(d.contains("inert"));
+    }
+
+    #[test]
+    fn a_refused_row_falls_through_to_the_floor_and_is_named() {
+        // A malformed `claude:` override must not un-define claude: the row is
+        // refused, its key falls to the embedded floor, and the refusal is named.
+        let home = tempfile::tempdir().unwrap();
+        let path = HarnessRegistry::descriptors_path(home.path());
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &path,
+            // No `binary` → refused whole.
+            "harnesses:\n  claude:\n    launch: [\"exec\", \"totally-wrong\"]\n",
+        )
+        .unwrap();
+
+        let reg = HarnessRegistry::load(home.path());
+        assert_eq!(
+            reg.resolve(CLAUDE),
+            Some(claude()),
+            "claude stays the floor"
+        );
+        assert_eq!(reg.rejected().len(), 1);
+        assert_eq!(reg.rejected()[0].name, "claude");
+        let d = reg.diagnostic().unwrap();
+        assert!(d.contains("`claude`") && d.contains("falling through"));
+    }
+
+    #[test]
+    fn load_never_writes_to_disk() {
+        // The read is pure: loading, even with a healthy file, seeds nothing beyond
+        // the file the user already wrote (no fetched.json analogue, no baseline).
+        let home = tempfile::tempdir().unwrap();
+        let dir = HarnessRegistry::descriptors_path(home.path())
+            .parent()
+            .unwrap()
+            .to_path_buf();
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            HarnessRegistry::descriptors_path(home.path()),
+            "harnesses:\n  x:\n    binary: x\n    launch: [\"exec\", \"x\"]\n",
+        )
+        .unwrap();
+        let before: Vec<_> = std::fs::read_dir(&dir)
+            .unwrap()
+            .flatten()
+            .map(|e| e.file_name())
+            .collect();
+        let _ = HarnessRegistry::load(home.path());
+        let after: Vec<_> = std::fs::read_dir(&dir)
+            .unwrap()
+            .flatten()
+            .map(|e| e.file_name())
+            .collect();
+        assert_eq!(before, after, "load must not write any file");
     }
 }

--- a/crates/pdo-daemon/src/harness_resolver.rs
+++ b/crates/pdo-daemon/src/harness_resolver.rs
@@ -103,6 +103,22 @@ pub(crate) fn resolve_effort(node_entry_effort: Option<&str>) -> Option<String> 
         .map(str::to_string)
 }
 
+/// The harness an **infra** session (Pipeline Manager, merge resolver) runs on
+/// (#551, ADR-0046). Infra sessions have no NodeDef, so no `node` tier and no
+/// model/effort of their own: they follow the Run's frozen harness, then the
+/// instance default, then the `claude` floor — `Run → instance → plancher`. This
+/// is what makes "ce Run tourne sur X" true with no exception to remember (the
+/// A/B on a new harness also exercises the unblocking tool). Same empty-string
+/// collapse as [`resolve_harness`] (the `Some("")` trap of #347).
+pub(crate) fn resolve_infra_harness(run: Option<&str>, instance_default: Option<&str>) -> String {
+    resolve_harness(&HarnessTiers {
+        node_pin: None,
+        run,
+        project: None,
+        instance_default,
+    })
+}
+
 /// The single precedence point both spawn seams call (like `effective_sandbox`):
 /// resolve the harness, then read the model and effort from the **winning
 /// harness's** entry. Shaped so #551/#552 fill `tiers.run`/`tiers.project`
@@ -209,6 +225,31 @@ mod tests {
         assert_eq!(resolve_harness(&tiers), CLAUDE);
     }
 
+    // ---- infra sessions follow the Run's harness (#551) ---------------------
+
+    #[test]
+    fn infra_harness_follows_the_run_then_instance_then_floor() {
+        // AC: the Pipeline Manager and merge resolver run on the harness OF THE RUN,
+        // no node tier, no model/effort. Run wins over the instance default…
+        assert_eq!(
+            resolve_infra_harness(Some(OPENCODE), Some(CLAUDE)),
+            OPENCODE
+        );
+        // …the instance default backs an unset Run…
+        assert_eq!(resolve_infra_harness(None, Some(OPENCODE)), OPENCODE);
+        // …and with neither set, the manager stays on the `claude` floor — the
+        // byte-identical legacy manager launch (the control).
+        assert_eq!(resolve_infra_harness(None, None), CLAUDE);
+    }
+
+    #[test]
+    fn infra_harness_ignores_a_blank_run_choice() {
+        // A blank Run harness (`Some("")`) is "unset", not a harness named "" — it
+        // must fall through to the instance default, never to an unknown harness.
+        assert_eq!(resolve_infra_harness(Some(""), Some(OPENCODE)), OPENCODE);
+        assert_eq!(resolve_infra_harness(Some(""), Some("")), CLAUDE);
+    }
+
     // ---- model / effort read from the WINNING harness's entry ---------------
 
     #[test]
@@ -226,6 +267,33 @@ mod tests {
         // opencode's entry wins — NOT claude's, even though claude has richer settings.
         assert_eq!(r.model.as_deref(), Some("openrouter/foo"));
         assert_eq!(r.effort, None);
+    }
+
+    #[test]
+    fn a_run_switched_to_another_harness_reads_the_new_harness_entry_not_the_old() {
+        // AC (#551): a Run basculé sur un autre harnais n'hérite jamais du slug écrit pour
+        // le précédent — the model/effort come from the WINNING (Run-tier) harness entry.
+        // Same node, two Runs: no Run harness → claude wins → claude's slug; Run picks
+        // opencode → opencode wins → opencode's slug, never claude's.
+        let node_entries = entries(&[
+            (CLAUDE, Some("opus"), Some("high")),
+            (OPENCODE, Some("openrouter/foo"), None),
+        ]);
+
+        let on_claude = resolve(&HarnessTiers::default(), &node_entries, &no_defaults());
+        assert_eq!(on_claude.harness, CLAUDE);
+        assert_eq!(on_claude.model.as_deref(), Some("opus"));
+        assert_eq!(on_claude.effort.as_deref(), Some("high"));
+
+        let run_opencode = HarnessTiers {
+            run: Some(OPENCODE),
+            ..Default::default()
+        };
+        let on_opencode = resolve(&run_opencode, &node_entries, &no_defaults());
+        assert_eq!(on_opencode.harness, OPENCODE);
+        // opencode's entry wins — claude's `opus`/`high` never leak onto the switched Run.
+        assert_eq!(on_opencode.model.as_deref(), Some("openrouter/foo"));
+        assert_eq!(on_opencode.effort, None);
     }
 
     #[test]

--- a/crates/pdo-daemon/src/harness_resolver.rs
+++ b/crates/pdo-daemon/src/harness_resolver.rs
@@ -1,0 +1,290 @@
+//! Resolve a node's effective harness, model and effort — **pure** (ADR-0046).
+//!
+//! The harness is an axis with four tiers, coarsest last:
+//! `node → Run → Projet → Configuration d'instance → plancher (claude)`. The
+//! finest tier that names a harness wins, and a **pinned** node harness shields
+//! that choice from every coarser tier. The model and effort are **not** axes:
+//! they carry no precedence of their own — they are read from the winning
+//! harness's entry in the node's per-harness map (a slug means nothing outside
+//! the harness that accepts it, ADR-0046).
+//!
+//! **This slice populates only `node` and `instance`.** [`HarnessTiers`] already
+//! carries `run` and `project` slots so the two follow-up slices (#551 Run tier,
+//! #552 Projet tier) fill them without rewriting this signature or its callers.
+//!
+//! Pure by contract (an AC): a set of tier values goes in, a [`ResolvedHarness`]
+//! comes out — no `$HOME`, no disk, no clock — so the whole precedence matrix is
+//! unit-tested without a fixture (the discipline `run_cost` paid for in #408).
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+/// A node's settings for one harness (`harnesses.<name>` in the YAML): the model
+/// and effort to use when the node runs on that harness. Both are free-text
+/// pass-through (ADR-0001: no closed enum that would perish at every model
+/// release). `BTreeMap`-keyed by harness name on the node, so a node stays
+/// executable on either harness instead of launching every node with a slug the
+/// other harness rejects (ADR-0046).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct HarnessEntry {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effort: Option<String>,
+}
+
+/// The harness named at each tier, coarsest last. `None` = that tier names no
+/// harness. `run` and `project` are always `None` in this slice (#551, #552).
+#[derive(Debug, Default, Clone)]
+pub(crate) struct HarnessTiers<'a> {
+    /// The node's pinned harness (`pin_harness`). A pin both **selects** the
+    /// harness and shields it from every coarser tier (ADR-0046: épinglage ≠
+    /// paramétrage).
+    pub node_pin: Option<&'a str>,
+    /// The Run's harness (#551) — the tier that re-runs the same pipeline on
+    /// another harness. `None` in this slice.
+    pub run: Option<&'a str>,
+    /// The Projet's harness (#552). `None` in this slice.
+    pub project: Option<&'a str>,
+    /// The instance default harness (ADR-0015, amended by ADR-0046).
+    pub instance_default: Option<&'a str>,
+}
+
+/// What the spawn seam launches with, frozen into the node's start event.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ResolvedHarness {
+    pub harness: String,
+    pub model: Option<String>,
+    pub effort: Option<String>,
+}
+
+/// Resolve the effective harness name: the finest tier that names a non-empty
+/// harness wins, with `claude` as the floor.
+///
+/// An empty string never wins a tier — `""` means "unset" everywhere, so a
+/// blank `pin_harness:` in YAML or a blank instance default falls through to the
+/// floor instead of resolving to an unknown harness (the `Some("")` trap of
+/// #347).
+pub(crate) fn resolve_harness(tiers: &HarnessTiers<'_>) -> String {
+    [
+        tiers.node_pin,
+        tiers.run,
+        tiers.project,
+        tiers.instance_default,
+    ]
+    .into_iter()
+    .flatten()
+    .find(|s| !s.is_empty())
+    .unwrap_or(crate::harness_registry::CLAUDE)
+    .to_string()
+}
+
+/// Resolve the model a node launches with on the winning harness: the node's
+/// entry for that harness wins, else the instance per-harness default, else
+/// `None` (the harness account default — no `--model`, byte-identical to the
+/// legacy launch for `claude`). An empty string on either side collapses to the
+/// next tier (#347).
+pub(crate) fn resolve_model(
+    node_entry_model: Option<&str>,
+    instance_default_model: Option<&str>,
+) -> Option<String> {
+    node_entry_model
+        .filter(|s| !s.is_empty())
+        .or(instance_default_model.filter(|s| !s.is_empty()))
+        .map(str::to_string)
+}
+
+/// Resolve the effort: the node's entry for the winning harness, empty → `None`
+/// (#424). One tier — effort has no instance default in this slice.
+pub(crate) fn resolve_effort(node_entry_effort: Option<&str>) -> Option<String> {
+    node_entry_effort
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+}
+
+/// The single precedence point both spawn seams call (like `effective_sandbox`):
+/// resolve the harness, then read the model and effort from the **winning
+/// harness's** entry. Shaped so #551/#552 fill `tiers.run`/`tiers.project`
+/// without touching this body.
+pub(crate) fn resolve(
+    tiers: &HarnessTiers<'_>,
+    node_entries: &BTreeMap<String, HarnessEntry>,
+    instance_default_models: &BTreeMap<String, String>,
+) -> ResolvedHarness {
+    let harness = resolve_harness(tiers);
+    let entry = node_entries.get(&harness);
+    let node_model = entry.and_then(|e| e.model.as_deref());
+    let node_effort = entry.and_then(|e| e.effort.as_deref());
+    let default_model = instance_default_models.get(&harness).map(String::as_str);
+    ResolvedHarness {
+        model: resolve_model(node_model, default_model),
+        effort: resolve_effort(node_effort),
+        harness,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::harness_registry::{CLAUDE, OPENCODE};
+
+    fn entries(pairs: &[(&str, Option<&str>, Option<&str>)]) -> BTreeMap<String, HarnessEntry> {
+        pairs
+            .iter()
+            .map(|(name, model, effort)| {
+                (
+                    name.to_string(),
+                    HarnessEntry {
+                        model: model.map(str::to_string),
+                        effort: effort.map(str::to_string),
+                    },
+                )
+            })
+            .collect()
+    }
+
+    fn no_defaults() -> BTreeMap<String, String> {
+        BTreeMap::new()
+    }
+
+    // ---- harness precedence matrix (each tier wins in turn) -----------------
+
+    #[test]
+    fn floor_is_claude_when_no_tier_names_one() {
+        assert_eq!(resolve_harness(&HarnessTiers::default()), CLAUDE);
+    }
+
+    #[test]
+    fn instance_default_beats_the_floor() {
+        let tiers = HarnessTiers {
+            instance_default: Some(OPENCODE),
+            ..Default::default()
+        };
+        assert_eq!(resolve_harness(&tiers), OPENCODE);
+    }
+
+    #[test]
+    fn node_pin_beats_every_coarser_tier() {
+        // The pin resists an instance (and, once they land, Run/Projet) change —
+        // "this role requires this harness" (ADR-0046).
+        let tiers = HarnessTiers {
+            node_pin: Some(CLAUDE),
+            run: Some(OPENCODE),
+            project: Some(OPENCODE),
+            instance_default: Some(OPENCODE),
+        };
+        assert_eq!(resolve_harness(&tiers), CLAUDE);
+    }
+
+    #[test]
+    fn run_beats_project_and_instance() {
+        let tiers = HarnessTiers {
+            node_pin: None,
+            run: Some("run-harness"),
+            project: Some("project-harness"),
+            instance_default: Some(OPENCODE),
+        };
+        assert_eq!(resolve_harness(&tiers), "run-harness");
+    }
+
+    #[test]
+    fn project_beats_instance() {
+        let tiers = HarnessTiers {
+            project: Some("project-harness"),
+            instance_default: Some(OPENCODE),
+            ..Default::default()
+        };
+        assert_eq!(resolve_harness(&tiers), "project-harness");
+    }
+
+    #[test]
+    fn empty_string_never_wins_a_tier() {
+        // The `Some("")` trap of #347: a blank pin falls through to the floor.
+        let tiers = HarnessTiers {
+            node_pin: Some(""),
+            instance_default: Some(""),
+            ..Default::default()
+        };
+        assert_eq!(resolve_harness(&tiers), CLAUDE);
+    }
+
+    // ---- model / effort read from the WINNING harness's entry ---------------
+
+    #[test]
+    fn model_and_effort_come_from_the_winning_harness_entry() {
+        let tiers = HarnessTiers {
+            node_pin: Some(OPENCODE),
+            ..Default::default()
+        };
+        let node_entries = entries(&[
+            (CLAUDE, Some("opus"), Some("high")),
+            (OPENCODE, Some("openrouter/foo"), None),
+        ]);
+        let r = resolve(&tiers, &node_entries, &no_defaults());
+        assert_eq!(r.harness, OPENCODE);
+        // opencode's entry wins — NOT claude's, even though claude has richer settings.
+        assert_eq!(r.model.as_deref(), Some("openrouter/foo"));
+        assert_eq!(r.effort, None);
+    }
+
+    #[test]
+    fn a_node_without_an_entry_for_the_winning_harness_runs_without_a_model() {
+        // AC: no entry ⇒ no `--model`, the harness account default.
+        let tiers = HarnessTiers {
+            node_pin: Some(OPENCODE),
+            ..Default::default()
+        };
+        let node_entries = entries(&[(CLAUDE, Some("opus"), Some("high"))]);
+        let r = resolve(&tiers, &node_entries, &no_defaults());
+        assert_eq!(r.harness, OPENCODE);
+        assert_eq!(r.model, None, "no claude slug leaks onto opencode");
+        assert_eq!(r.effort, None);
+    }
+
+    #[test]
+    fn instance_per_harness_default_model_backs_a_missing_node_model() {
+        let tiers = HarnessTiers {
+            instance_default: Some(OPENCODE),
+            ..Default::default()
+        };
+        let defaults: BTreeMap<String, String> =
+            [(OPENCODE.to_string(), "openrouter/def".to_string())]
+                .into_iter()
+                .collect();
+        let r = resolve(&tiers, &BTreeMap::new(), &defaults);
+        assert_eq!(r.harness, OPENCODE);
+        assert_eq!(r.model.as_deref(), Some("openrouter/def"));
+    }
+
+    #[test]
+    fn node_entry_model_beats_the_instance_default() {
+        let defaults: BTreeMap<String, String> = [(CLAUDE.to_string(), "sonnet".to_string())]
+            .into_iter()
+            .collect();
+        let node_entries = entries(&[(CLAUDE, Some("opus"), None)]);
+        let r = resolve(&HarnessTiers::default(), &node_entries, &defaults);
+        assert_eq!(r.model.as_deref(), Some("opus"));
+    }
+
+    #[test]
+    fn empty_node_model_falls_through_to_the_instance_default() {
+        let defaults: BTreeMap<String, String> = [(CLAUDE.to_string(), "sonnet".to_string())]
+            .into_iter()
+            .collect();
+        let node_entries = entries(&[(CLAUDE, Some(""), Some(""))]);
+        let r = resolve(&HarnessTiers::default(), &node_entries, &defaults);
+        assert_eq!(r.model.as_deref(), Some("sonnet"), "\"\" is unset");
+        assert_eq!(r.effort, None, "empty effort collapses to None");
+    }
+
+    #[test]
+    fn claude_node_with_no_settings_resolves_to_the_byte_identical_launch() {
+        // The control: a plain claude node yields no model, no effort — the state
+        // the legacy launch reproduces byte for byte.
+        let r = resolve(&HarnessTiers::default(), &BTreeMap::new(), &no_defaults());
+        assert_eq!(r.harness, CLAUDE);
+        assert_eq!(r.model, None);
+        assert_eq!(r.effort, None);
+    }
+}

--- a/crates/pdo-daemon/src/input_resolution.rs
+++ b/crates/pdo-daemon/src/input_resolution.rs
@@ -445,8 +445,8 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         }
     }
 

--- a/crates/pdo-daemon/src/instance_config.rs
+++ b/crates/pdo-daemon/src/instance_config.rs
@@ -74,6 +74,21 @@ pub(crate) struct InstanceConfig {
     /// [`Self::autocomplete_turn_end`]: `NULL` is what makes the `stored → env → default`
     /// fall-through work; a stored `0` is a decision that beats the env.
     pub default_auto_name: Option<i64>,
+    /// Stored instance-wide default **harness** (`claude`, `opencode`), or `None`
+    /// when unset (#550, ADR-0046 amending ADR-0015). `None` falls through to the
+    /// env seam ([`crate::tmux_session_manager::DEFAULT_HARNESS_ENV`]) then the
+    /// `claude` floor. Free-text pass-through, no enum (ADR-0001). `Some("")` is
+    /// the clear sentinel — [`update`] normalises it to SQL `NULL`.
+    pub default_harness: Option<String>,
+    /// Stored instance-wide default **model per harness** (#550, ADR-0046): a map
+    /// `harness → model`, e.g. `{"claude":"opus"}`. The single `default_model`
+    /// became per-harness because a model slug means nothing outside its harness.
+    /// Empty map ⇒ no per-harness default (for `claude` the legacy
+    /// [`crate::tmux_session_manager::DEFAULT_MODEL_ENV`] still contributes at the
+    /// spawn seam). Persisted as a JSON object in the `default_harness_model`
+    /// column (`trigger_store::variables` idiom).
+    #[serde(default)]
+    pub default_harness_model: std::collections::BTreeMap<String, String>,
     /// RFC3339-millis UTC timestamp of the last write (or the seed).
     pub updated_at: String,
 }
@@ -113,6 +128,13 @@ pub(crate) struct UpdateInstanceConfig {
     /// storing `0` for "off" is what lets unticking the box override a
     /// `PDO_DEFAULT_AUTO_NAME=1`, which a `NULL` fall-through would not.
     pub default_auto_name: Option<bool>,
+    /// Set the instance-wide default harness (#550). `Some("")` clears it back to
+    /// unset (same `""`-sentinel as `default_model`); `None` leaves it untouched.
+    pub default_harness: Option<String>,
+    /// Set the instance-wide per-harness default model map (#550). `Some(map)`
+    /// replaces the stored map wholesale; an empty map clears it. `None` leaves it
+    /// untouched.
+    pub default_harness_model: Option<std::collections::BTreeMap<String, String>>,
 }
 
 impl UpdateInstanceConfig {
@@ -124,6 +146,8 @@ impl UpdateInstanceConfig {
             && self.default_sandbox.is_none()
             && self.autocomplete_turn_end.is_none()
             && self.default_auto_name.is_none()
+            && self.default_harness.is_none()
+            && self.default_harness_model.is_none()
     }
 }
 
@@ -145,6 +169,8 @@ pub(crate) async fn init(db: &SqlitePool) -> Result<(), sqlx::Error> {
             default_sandbox    TEXT,
             autocomplete_turn_end INTEGER,
             default_auto_name  INTEGER,
+            default_harness    TEXT,
+            default_harness_model TEXT,
             updated_at         TEXT NOT NULL
         )",
     )
@@ -241,6 +267,33 @@ pub(crate) async fn init(db: &SqlitePool) -> Result<(), sqlx::Error> {
             .await?;
     }
 
+    // Additive migration for pre-#550 databases: the `default_harness` and
+    // `default_harness_model` columns are absent on tables created before the
+    // multi-harness axis. Same guarded `ADD COLUMN` idiom — NULLABLE so an
+    // existing install falls through env → the `claude` floor unchanged.
+    let has_default_harness = sqlx::query(
+        "SELECT 1 FROM pragma_table_info('instance_config') WHERE name = 'default_harness'",
+    )
+    .fetch_optional(db)
+    .await?
+    .is_some();
+    if !has_default_harness {
+        sqlx::query("ALTER TABLE instance_config ADD COLUMN default_harness TEXT")
+            .execute(db)
+            .await?;
+    }
+    let has_default_harness_model = sqlx::query(
+        "SELECT 1 FROM pragma_table_info('instance_config') WHERE name = 'default_harness_model'",
+    )
+    .fetch_optional(db)
+    .await?
+    .is_some();
+    if !has_default_harness_model {
+        sqlx::query("ALTER TABLE instance_config ADD COLUMN default_harness_model TEXT")
+            .execute(db)
+            .await?;
+    }
+
     Ok(())
 }
 
@@ -253,6 +306,14 @@ fn row_to_config(row: &sqlx::sqlite::SqliteRow) -> InstanceConfig {
         default_sandbox: row.get("default_sandbox"),
         autocomplete_turn_end: row.get("autocomplete_turn_end"),
         default_auto_name: row.get("default_auto_name"),
+        default_harness: row.get("default_harness"),
+        // Stored as a JSON object in a TEXT column (trigger_store::variables
+        // idiom). NULL / empty / unparseable ⇒ an empty map, so a fresh row and a
+        // corrupt one both fall through to env → floor rather than erroring.
+        default_harness_model: row
+            .get::<Option<String>, _>("default_harness_model")
+            .and_then(|s| serde_json::from_str(&s).ok())
+            .unwrap_or_default(),
         updated_at: row.get("updated_at"),
     }
 }
@@ -301,6 +362,12 @@ pub(crate) async fn update(
     if edit.default_auto_name.is_some() {
         sets.push("default_auto_name = ?");
     }
+    if edit.default_harness.is_some() {
+        sets.push("default_harness = ?");
+    }
+    if edit.default_harness_model.is_some() {
+        sets.push("default_harness_model = ?");
+    }
     // Always bump the write timestamp on a real edit.
     sets.push("updated_at = ?");
 
@@ -339,6 +406,16 @@ pub(crate) async fn update(
         // 0/1, never NULL: unticking must persist a stored `0` that beats a
         // `PDO_DEFAULT_AUTO_NAME=1`, not fall through to it (#338).
         query = query.bind(if v { 1_i64 } else { 0_i64 });
+    }
+    if let Some(v) = edit.default_harness {
+        // "" = clear sentinel → SQL NULL (#550, mirrors default_model): a stored
+        // "" would win precedence and shadow env/floor. NULL restores fall-through.
+        query = query.bind(if v.is_empty() { None } else { Some(v) });
+    }
+    if let Some(v) = edit.default_harness_model {
+        // Persist the map as JSON; an empty map stores `{}` (a real "no defaults"
+        // decision). Serialisation cannot fail for a String→String map.
+        query = query.bind(serde_json::to_string(&v).unwrap_or_else(|_| "{}".to_string()));
     }
     query = query.bind(crate::event_log::now_iso());
     query.execute(db).await?;
@@ -458,7 +535,122 @@ mod tests {
         assert_eq!(cfg.default_sandbox, None);
         assert_eq!(cfg.autocomplete_turn_end, None);
         assert_eq!(cfg.default_auto_name, None);
+        assert_eq!(cfg.default_harness, None);
+        assert!(cfg.default_harness_model.is_empty());
         assert!(!cfg.updated_at.is_empty(), "seed must stamp updated_at");
+    }
+
+    #[tokio::test]
+    async fn update_sets_and_reads_back_default_harness() {
+        // #550/ADR-0046: the scalar default harness round-trips like `default_model`.
+        let db = test_db().await;
+        let updated = update(
+            &db,
+            UpdateInstanceConfig {
+                default_harness: Some("opencode".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(updated.default_harness.as_deref(), Some("opencode"));
+        assert_eq!(
+            get(&db).await.unwrap().default_harness.as_deref(),
+            Some("opencode")
+        );
+        // "" clears it back to unset (the resolver's floor then applies).
+        update(
+            &db,
+            UpdateInstanceConfig {
+                default_harness: Some(String::new()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(get(&db).await.unwrap().default_harness, None);
+    }
+
+    #[tokio::test]
+    async fn update_sets_and_reads_back_per_harness_default_model() {
+        // #550/ADR-0046: the per-harness default model map persists as JSON and
+        // round-trips through a re-read.
+        let db = test_db().await;
+        let map: std::collections::BTreeMap<String, String> = [
+            ("claude".to_string(), "opus".to_string()),
+            ("opencode".to_string(), "openrouter/foo".to_string()),
+        ]
+        .into_iter()
+        .collect();
+        update(
+            &db,
+            UpdateInstanceConfig {
+                default_harness_model: Some(map.clone()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(get(&db).await.unwrap().default_harness_model, map);
+    }
+
+    #[tokio::test]
+    async fn init_migrates_pre_harness_schema() {
+        // #550: a table created before the harness columns gains them on init,
+        // idempotently, without clobbering a pre-existing knob.
+        let db = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        // The full pre-#550 schema (everything except the two harness columns).
+        sqlx::query(
+            "CREATE TABLE instance_config (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                session_cap INTEGER,
+                reaper_ttl_secs INTEGER,
+                guard_timeout_secs INTEGER,
+                default_model TEXT,
+                triggers_paused INTEGER,
+                default_sandbox TEXT,
+                autocomplete_turn_end INTEGER,
+                default_auto_name INTEGER,
+                updated_at TEXT NOT NULL
+            )",
+        )
+        .execute(&db)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO instance_config (id, session_cap, updated_at) VALUES (1, 7, 'seed')",
+        )
+        .execute(&db)
+        .await
+        .unwrap();
+
+        // First init adds the columns; a second is a no-op (PRAGMA guard holds).
+        init(&db).await.unwrap();
+        init(&db).await.unwrap();
+
+        let cfg = get(&db).await.unwrap();
+        assert_eq!(cfg.session_cap, Some(7), "pre-existing knob survives");
+        assert_eq!(cfg.default_harness, None, "new column defaults to NULL");
+        assert!(cfg.default_harness_model.is_empty());
+
+        // …and both new columns are writable afterward.
+        let map: std::collections::BTreeMap<String, String> =
+            [("claude".to_string(), "opus".to_string())]
+                .into_iter()
+                .collect();
+        update(
+            &db,
+            UpdateInstanceConfig {
+                default_harness: Some("opencode".to_string()),
+                default_harness_model: Some(map.clone()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        let cfg = get(&db).await.unwrap();
+        assert_eq!(cfg.default_harness.as_deref(), Some("opencode"));
+        assert_eq!(cfg.default_harness_model, map);
     }
 
     #[tokio::test]

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -20,6 +20,7 @@ mod frontmatter_parser;
 mod graph_resolver;
 mod guard_runner;
 mod harness_argv;
+mod harness_probes;
 pub mod harness_registry;
 mod harness_resolver;
 mod input_resolution;
@@ -8155,6 +8156,36 @@ async fn build_settings_view(state: &AppState) -> Result<serde_json::Value, sqlx
         }),
     };
 
+    // --- harness descriptors: the disk tier, surfaced (#553, ADR-0045) ---
+    // Same posture as `price_table` above: a hand-edited descriptor file passes
+    // through NO validator (ADR-0001), so the only honest place to say a descriptor
+    // is inert or refused is here, beside the facts. `names` lists what actually
+    // resolves (floor merged with disk), so a user learns their declared harness
+    // "appeared"; `reason` carries the SAME string the loader logs. The path is
+    // ALWAYS reported so the user knows where to write — nothing is ever seeded.
+    let harness_descriptors_view = match &host_home_path {
+        Some(home) => {
+            let registry = harness_registry::HarnessRegistry::load(home);
+            serde_json::json!({
+                "path": harness_registry::HarnessRegistry::descriptors_path(home).to_string_lossy(),
+                "names": registry.names(),
+                "rejected": registry
+                    .rejected()
+                    .iter()
+                    .map(|r| serde_json::json!({ "name": r.name, "why": r.why }))
+                    .collect::<Vec<_>>(),
+                "reason": registry.diagnostic(),
+            })
+        }
+        None => serde_json::json!({
+            "path": null,
+            "names": harness_registry::HarnessRegistry::builtin().names(),
+            "rejected": [],
+            "reason": "HOME is unset, so the descriptor file has no resolvable path — \
+                       only the harnesses compiled into the binary apply",
+        }),
+    };
+
     Ok(serde_json::json!({
         "session_cap": settings_field(cap_effective, cap_source, cfg.session_cap, cap_env, cap_default),
         "reaper_ttl_secs": settings_field(ttl_effective, ttl_source, cfg.reaper_ttl_secs, ttl_env, ttl_default),
@@ -8169,6 +8200,10 @@ async fn build_settings_view(state: &AppState) -> Result<serde_json::Value, sqlx
             "effective": dhm_effective,
             "stored": dhm_stored,
         },
+        // #553/ADR-0045: the disk descriptor tier — which harnesses resolve (floor
+        // ∪ disk), the file path, and any inert/refused descriptor named. The
+        // settings surface is where a broken descriptor is ALWAYS said.
+        "harness_descriptors": harness_descriptors_view,
         "default_sandbox": {
             "effective": sbx_effective.as_str(),
             "source": sbx_source,
@@ -9481,7 +9516,13 @@ async fn get_run(
             // HOST home — prices are an instance concept), while transcripts come
             // from `projects_root` (the #408 seam, which moves for a sandboxed Run).
             let prices = price_table::PriceTable::load(&home_root);
-            augment_run_state_from_disk(&mut run_state, &projects_root, &repo_root, &prices);
+            augment_run_state_from_disk(
+                &mut run_state,
+                &events,
+                &projects_root,
+                &repo_root,
+                &prices,
+            );
             Json(run_state).into_response()
         }
         None => (StatusCode::NOT_FOUND, "run not found").into_response(),
@@ -10110,6 +10151,20 @@ async fn run_stale_detection(state: &Arc<AppState>) {
                 running: &running,
             };
 
+            // #553: gate the turn-end and usage-limit probes on the node's
+            // FROZEN-at-spawn harness (ADR-0046), never the current YAML. `None`
+            // (a script node, a pre-#550 row) is the `claude` floor, which has both
+            // capabilities — so the sweep is byte-identical to pre-#553 there. A
+            // node on a harness without them runs neither probe: no auto-completion
+            // on an invented heuristic, no capture for another harness's menu.
+            let node_harness = find_launch_harness(&events, node_id, *iter)
+                .unwrap_or_else(|| harness_registry::CLAUDE.to_string());
+            let hc = harness_probes::capabilities(&node_harness);
+            let caps = stale_detector::HarnessCapabilities {
+                turn_end: hc.turn_end,
+                usage_limit: hc.usage_limit,
+            };
+
             let assessment = stale_detector::assess_node(
                 &probes,
                 &events,
@@ -10118,6 +10173,7 @@ async fn run_stale_detection(state: &Arc<AppState>) {
                 *iter,
                 now,
                 autocomplete_turn_end,
+                caps,
             );
 
             if assessment.blocked_on_limit {
@@ -10551,9 +10607,20 @@ async fn node_pane(
             // now. A pre-#550 row (no key) or an unknown harness falls back to the
             // `claude` floor, byte-identical to the legacy resume.
             let launch_harness = find_launch_harness(&events, &node_id, iter);
+            // #553: resolve the frozen harness against the embedded floor MERGED
+            // with the disk descriptor tier, so a user-declared harness resumes
+            // like the built-in ones. The registry reads a root we hand it (never
+            // `$HOME`); a resolution failure, a pre-#550 row, or an unresolved home
+            // all fall back to the `claude` floor — byte-identical to the legacy
+            // resume.
+            let harness_home_root = sandbox_run::sandbox_home_roots(&state)
+                .map(|(home, _)| home)
+                .unwrap_or_default();
             let descriptor = launch_harness
                 .as_deref()
-                .and_then(harness_registry::resolve)
+                .and_then(|name| {
+                    harness_registry::HarnessRegistry::load(&harness_home_root).resolve(name)
+                })
                 .unwrap_or_else(harness_registry::claude);
             // AC #9: a harness with no resume mechanism serves its last pane
             // snapshot (the same branch as a `script` node), never a resume error.
@@ -13966,6 +14033,7 @@ fn compute_run_loc(repo_root: &std::path::Path, run_id: &str) -> Option<event_lo
 
 fn augment_run_state_from_disk(
     run_state: &mut event_log::RunState,
+    events: &[event_log::Event],
     projects_root: &std::path::Path,
     repo_root: &std::path::Path,
     prices: &price_table::PriceTable,
@@ -13978,8 +14046,13 @@ fn augment_run_state_from_disk(
     // Claude Code transcripts under `projects_root` (the #408 seam — the staged
     // home while a sandboxed Run is live, `~/.claude/projects/` otherwise), not
     // the run dir. `repo_root` builds the run-id dir prefix, not the read root.
+    // #553/ADR-0045: honest about a harness with no cost source. If a node ran on
+    // such a harness the aggregate is not summable, so this yields a "—"-with-reason
+    // `CostStat` (never `$0`); otherwise it is exactly `compute_run_cost`. Needs the
+    // raw events for the frozen-at-spawn harnesses (`RunState` alone does not carry
+    // them per node).
     run_state.cost =
-        run_cost::compute_run_cost(projects_root, repo_root, &run_state.run_id, prices);
+        run_cost::run_cost_or_absence(events, projects_root, repo_root, &run_state.run_id, prices);
 
     let yaml_path = run_scoped_pipeline_path(repo_root, &run_state.run_id);
     let Ok(yaml) = std::fs::read_to_string(&yaml_path) else {

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -40,6 +40,7 @@ mod pipeline_migrator;
 mod pipeline_semantics;
 mod pipeline_watcher;
 mod price_table;
+mod project_store;
 mod prompt_augmenter;
 mod pty_bridge;
 mod reap_policy;
@@ -567,6 +568,34 @@ struct TriggerListEntry {
     #[serde(flatten)]
     trigger: trigger_store::Trigger,
     effective_repo: String,
+}
+
+/// Body of `POST /projects` — materialise a Projet from a bare name (#552). The
+/// only path that creates a `projects` row from a name; membership and the
+/// harness are attached afterwards, so a Projet begins empty and harness-less.
+#[derive(Deserialize)]
+struct CreateProjectRequest {
+    name: String,
+}
+
+/// Body of `PATCH /projects/{id}` — rename the Projet and/or (re)set the harness
+/// it carries (#552). `harness` is a double-`Option` (mirror of
+/// `UpdateTrigger.sandbox`): **absent** leaves it untouched, `null` clears it,
+/// a string sets it. An empty string clears it too (the `Some("")` trap of #347).
+#[derive(Deserialize)]
+struct PatchProjectRequest {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_double_option")]
+    harness: Option<Option<String>>,
+}
+
+/// Body of `POST` / `DELETE /projects/{id}/members` — one member path, compared
+/// **verbatim** (ADR-0033). The attach enforces at-most-one membership before any
+/// write; a path owned by another Projet is a 409 naming the owner (#552).
+#[derive(Deserialize)]
+struct ProjectMemberRequest {
+    path: String,
 }
 
 #[derive(Serialize)]
@@ -4055,6 +4084,21 @@ fn build_router(state: Arc<AppState>) -> Router {
         // dev-mode GET hits the daemon instead of the SPA fallback (same trap as
         // `/nodes` #345, `/stats` #377, `/fs` #431).
         .route("/audit", get(get_audit))
+        // Projets (#552, ADR-0046) — the group-header pencil's CRUD and the middle
+        // tier of the harness axis. NEW top-level `/projects` prefix → added to the
+        // vite dev proxy whitelist (frontend/vite.config.ts) so a dev-mode GET hits
+        // the daemon, not the SPA fallback (same trap as `/audit` #507). The
+        // members sub-resource is a static segment under the param — axum 0.8
+        // allows it (cf. `/triggers/{id}/fires`).
+        .route("/projects", get(list_projects).post(create_project))
+        .route(
+            "/projects/{project_id}",
+            get(get_project).patch(patch_project).delete(delete_project),
+        )
+        .route(
+            "/projects/{project_id}/members",
+            post(add_project_member).delete(remove_project_member),
+        )
         .route(
             "/triggers/{trigger_id}",
             get(get_trigger).patch(patch_trigger).delete(delete_trigger),
@@ -4065,6 +4109,245 @@ fn build_router(state: Arc<AppState>) -> Router {
         .route("/triggers/{trigger_id}/fire", post(fire_trigger_now))
         .fallback(static_handler)
         .with_state(state)
+}
+
+// --- Projets (#552, ADR-0046) ---
+//
+// A Projet is the middle tier of the harness axis and a named grouping of member
+// repo paths. Nothing is seeded: a row exists only once a human names a group or
+// attaches a setting (ADR-0046). The lists group by Projet client-side; these
+// endpoints are the CRUD behind the group-header pencil. `/projects` is a NEW
+// top-level prefix → it has its own entry in the vite dev proxy whitelist
+// (`frontend/vite.config.ts`), same trap as `/nodes` (#345) / `/stats` (#377) /
+// `/audit` (#507).
+
+fn project_list_error() -> Response {
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(serde_json::json!({ "error": "project store unavailable" })),
+    )
+        .into_response()
+}
+
+async fn list_projects(State(state): State<Arc<AppState>>) -> Response {
+    match project_store::list(&state.db).await {
+        Ok(projects) => Json(projects).into_response(),
+        Err(e) => {
+            error!("failed to list projects: {e}");
+            project_list_error()
+        }
+    }
+}
+
+async fn get_project(
+    State(state): State<Arc<AppState>>,
+    AxumPath(project_id): AxumPath<String>,
+) -> Response {
+    match project_store::get(&state.db, &project_id).await {
+        Ok(Some(p)) => Json(p).into_response(),
+        Ok(None) => (StatusCode::NOT_FOUND, "no such project").into_response(),
+        Err(e) => {
+            error!("failed to load project {project_id}: {e}");
+            project_list_error()
+        }
+    }
+}
+
+async fn create_project(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<CreateProjectRequest>,
+) -> Response {
+    let name = req.name.trim();
+    if name.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": "project name is required" })),
+        )
+            .into_response();
+    }
+    match project_store::create(&state.db, name).await {
+        Ok(project) => {
+            let _ = state.pipeline_tx.send(serde_json::json!({
+                "type": "project_changed",
+                "project_id": project.id,
+            }));
+            (StatusCode::CREATED, Json(project)).into_response()
+        }
+        Err(e) => {
+            error!("failed to create project: {e}");
+            project_list_error()
+        }
+    }
+}
+
+async fn patch_project(
+    State(state): State<Arc<AppState>>,
+    AxumPath(project_id): AxumPath<String>,
+    Json(req): Json<PatchProjectRequest>,
+) -> Response {
+    // The Projet must exist first — a PATCH never materialises one (only the
+    // pencil's create does, via POST /projects).
+    match project_store::get(&state.db, &project_id).await {
+        Ok(Some(_)) => {}
+        Ok(None) => return (StatusCode::NOT_FOUND, "no such project").into_response(),
+        Err(e) => {
+            error!("failed to load project {project_id}: {e}");
+            return project_list_error();
+        }
+    }
+    if let Some(name) = req.name.as_deref() {
+        let name = name.trim();
+        if name.is_empty() {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({ "error": "project name cannot be blank" })),
+            )
+                .into_response();
+        }
+        if let Err(e) = project_store::rename(&state.db, &project_id, name).await {
+            error!("failed to rename project {project_id}: {e}");
+            return project_list_error();
+        }
+    }
+    // Double-`Option`: `Some(_)` means the field was present. `Some(None)` and
+    // `Some(Some(""))` both clear; `Some(Some(h))` sets. `set_harness` normalises
+    // the empty string to NULL itself (#347).
+    if let Some(harness) = req.harness {
+        let harness = harness.as_deref();
+        if let Err(e) = project_store::set_harness(&state.db, &project_id, harness).await {
+            error!("failed to set harness on project {project_id}: {e}");
+            return project_list_error();
+        }
+    }
+    match project_store::get(&state.db, &project_id).await {
+        Ok(Some(p)) => {
+            let _ = state.pipeline_tx.send(serde_json::json!({
+                "type": "project_changed",
+                "project_id": project_id,
+            }));
+            Json(p).into_response()
+        }
+        Ok(None) => (StatusCode::NOT_FOUND, "no such project").into_response(),
+        Err(e) => {
+            error!("failed to reload project {project_id}: {e}");
+            project_list_error()
+        }
+    }
+}
+
+async fn delete_project(
+    State(state): State<Arc<AppState>>,
+    AxumPath(project_id): AxumPath<String>,
+) -> Response {
+    match project_store::delete(&state.db, &project_id).await {
+        Ok(true) => {
+            let _ = state.pipeline_tx.send(serde_json::json!({
+                "type": "project_changed",
+                "project_id": project_id,
+            }));
+            StatusCode::NO_CONTENT.into_response()
+        }
+        Ok(false) => (StatusCode::NOT_FOUND, "no such project").into_response(),
+        Err(e) => {
+            error!("failed to delete project {project_id}: {e}");
+            project_list_error()
+        }
+    }
+}
+
+async fn add_project_member(
+    State(state): State<Arc<AppState>>,
+    AxumPath(project_id): AxumPath<String>,
+    Json(req): Json<ProjectMemberRequest>,
+) -> Response {
+    let path = req.path.trim();
+    if path.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": "member path is required" })),
+        )
+            .into_response();
+    }
+    // The target Projet must exist (materialised by the pencil's create).
+    match project_store::get(&state.db, &project_id).await {
+        Ok(Some(_)) => {}
+        Ok(None) => return (StatusCode::NOT_FOUND, "no such project").into_response(),
+        Err(e) => {
+            error!("failed to load project {project_id}: {e}");
+            return project_list_error();
+        }
+    }
+    match project_store::add_member(&state.db, &project_id, path).await {
+        Ok(project_store::AddMember::Added) | Ok(project_store::AddMember::AlreadyMember) => {
+            let _ = state.pipeline_tx.send(serde_json::json!({
+                "type": "project_changed",
+                "project_id": project_id,
+            }));
+            match project_store::get(&state.db, &project_id).await {
+                Ok(Some(p)) => Json(p).into_response(),
+                _ => StatusCode::NO_CONTENT.into_response(),
+            }
+        }
+        // AC: a path already owned by another Projet is refused BEFORE any effect,
+        // and the refusal NAMES the owner (409, so the pencil can say which one).
+        Ok(project_store::AddMember::Refused {
+            owner_id,
+            owner_name,
+        }) => (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({
+                "error": format!("path already belongs to project '{owner_name}'"),
+                "owner_id": owner_id,
+                "owner_name": owner_name,
+            })),
+        )
+            .into_response(),
+        Err(e) => {
+            error!("failed to add member to project {project_id}: {e}");
+            project_list_error()
+        }
+    }
+}
+
+async fn remove_project_member(
+    State(state): State<Arc<AppState>>,
+    AxumPath(project_id): AxumPath<String>,
+    Json(req): Json<ProjectMemberRequest>,
+) -> Response {
+    let path = req.path.trim();
+    // Scope the detach to the named Projet: a path owned by a *different* Projet
+    // is left alone (idempotent no-op), so a stale client can't strip another
+    // Projet's member.
+    match project_store::owner_of(&state.db, path).await {
+        Ok(Some(owner)) if owner.id == project_id => {}
+        Ok(_) => {
+            // Not a member of this Projet (or of any) — nothing to do.
+            return match project_store::get(&state.db, &project_id).await {
+                Ok(Some(p)) => Json(p).into_response(),
+                Ok(None) => (StatusCode::NOT_FOUND, "no such project").into_response(),
+                Err(e) => {
+                    error!("failed to load project {project_id}: {e}");
+                    project_list_error()
+                }
+            };
+        }
+        Err(e) => {
+            error!("failed to resolve owner of {path}: {e}");
+            return project_list_error();
+        }
+    }
+    if let Err(e) = project_store::remove_member(&state.db, path).await {
+        error!("failed to remove member from project {project_id}: {e}");
+        return project_list_error();
+    }
+    let _ = state.pipeline_tx.send(serde_json::json!({
+        "type": "project_changed",
+        "project_id": project_id,
+    }));
+    match project_store::get(&state.db, &project_id).await {
+        Ok(Some(p)) => Json(p).into_response(),
+        _ => StatusCode::NO_CONTENT.into_response(),
+    }
 }
 
 async fn init_db(db: &sqlx::SqlitePool) -> Result<()> {
@@ -4126,6 +4409,13 @@ async fn init_db(db: &sqlx::SqlitePool) -> Result<()> {
     audit_log::init(db)
         .await
         .context("failed to create audit_log table")?;
+
+    // #552 / ADR-0046: Projets — the middle tier of the harness axis. Brand-new
+    // tables, materialised on demand (nothing seeded), same `CREATE TABLE IF NOT
+    // EXISTS` idiom as `sandbox_profiles` / `audit_log`.
+    project_store::init(db)
+        .await
+        .context("failed to create project tables")?;
 
     Ok(())
 }
@@ -12345,6 +12635,14 @@ async fn force_spawn_node(state: &Arc<AppState>, run_id: &str, node_id: &str) ->
         // #550/ADR-0046: same fresh-resolution discipline for the harness axis.
         default_harness: stored_default_harness(&state.db).await,
         default_harness_models: stored_default_harness_models(&state.db).await,
+        // #552/ADR-0046: the Projet tier — the harness carried by the Projet that
+        // owns this Run's primary (effective) repo. Resolved fresh here so a manual
+        // force-spawn honours a Projet setting attached mid-Run, like the model /
+        // harness defaults above. A DB error degrades to a transparent tier.
+        project_harness: project_store::harness_for_path(&state.db, &repo_root.to_string_lossy())
+            .await
+            .ok()
+            .flatten(),
         // #433 / ADR-0043: same reasoning as `default_model` — resolve turn-end
         // auto-completion fresh so a force-spawned node arms the `Stop` hook when
         // the setting is on, instead of silently missing it on this seam alone.
@@ -12621,6 +12919,12 @@ async fn node_retry(
         // #550/ADR-0046: retry resolves the harness axis fresh, like model.
         default_harness: stored_default_harness(&state.db).await,
         default_harness_models: stored_default_harness_models(&state.db).await,
+        // #552/ADR-0046: retry resolves the Projet tier fresh too, from the Run's
+        // primary (effective) repo — a secondary never sways it (ADR-0042).
+        project_harness: project_store::harness_for_path(&state.db, &repo_root.to_string_lossy())
+            .await
+            .ok()
+            .flatten(),
         // #433 / ADR-0043: retry re-arms the `Stop` hook per the current setting,
         // like the live scheduler path — not the value at the original spawn.
         inject_hook: stored_autocomplete_turn_end(&state.db).await,

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -467,6 +467,17 @@ struct CreateRunRequest {
     /// (`create_run_inner`) resolves it once against the fresh instance default.
     #[serde(default)]
     sandbox: Option<event_log::SandboxMode>,
+    /// The agentic harness this Run chooses (#551, ADR-0046) — the `run` tier of the
+    /// precedence chain `nœud → Run → Projet → instance → plancher (claude)`. Free
+    /// text (ADR-0045: PDO does not validate a harness name; an unknown one fails fast
+    /// at spawn, naming it). `#[serde(default)]` → an omitted/`null`/blank field means
+    /// "the Run names no harness", so each free node resolves through the instance
+    /// default and the floor — byte-identical to the pre-#551 shape. Frozen into
+    /// `RunStarted` at the create chokepoint (same immutability as `sandbox`); a
+    /// pinned node still ignores it. A Trigger fire folds its stored harness in here
+    /// (a Run has a single origin), so "Run now" and a cron tick produce the same one.
+    #[serde(default)]
+    harness: Option<String>,
     /// Whether the manager auto-names this Run (#338). `Option`, NOT `bool`:
     /// `#[serde(default)]` → `None` is an **omitted** field, which resolves
     /// back-compatibly by the presence of `name` (a supplied `name` with no flag
@@ -1877,6 +1888,7 @@ impl DaemonHandle {
                 overlap_policy: "skip".to_string(),
                 max_concurrent: None,
                 sandbox: None,
+                harness: None,
                 auto_name: true,
                 next_fire_at: Some("2030-01-01T00:00:00.000Z".to_string()),
             },
@@ -2882,6 +2894,11 @@ struct CreateTriggerRequest {
     /// request's explicit tier.
     #[serde(default)]
     sandbox: Option<String>,
+    /// Per-Trigger harness (#551, ADR-0046): a harness name, or absent/`null`/blank to
+    /// inherit the instance default. Read at fire time and folded into the fired Run's
+    /// harness (there is no separate Trigger tier). Free text — no validation (ADR-0045).
+    #[serde(default)]
+    harness: Option<String>,
     /// Whether Runs this Trigger fires are auto-named (#338). Seeded from the instance
     /// default in the create modal and frozen on the row; `#[serde(default)]` → `true`
     /// so an older client that omits the field keeps the pre-#338 auto-naming behaviour.
@@ -3215,6 +3232,9 @@ async fn create_trigger(
         // #410: normalise `Some("")` to `None` (inherit the instance default), so an
         // empty selector value never persists as a bogus stored mode.
         sandbox: req.sandbox.filter(|s| !s.trim().is_empty()),
+        // #551: same normalisation for the harness — a blank selector value inherits the
+        // instance default at fire time rather than persisting as a harness named "".
+        harness: req.harness.filter(|s| !s.trim().is_empty()),
         // #338: freeze the auto-naming choice on the row (seeded from the instance
         // default in the modal). No re-resolution at fire time — the runtime never
         // decides autonomy (ADR-0012 frontier).
@@ -3412,6 +3432,12 @@ struct PatchTriggerRequest {
     /// from JSON — that is what lets the UI reset a Trigger to "use the instance default".
     #[serde(default, deserialize_with = "deserialize_double_option")]
     sandbox: Option<Option<String>>,
+    /// Per-Trigger harness (#551), double-wrapped like `sandbox`: absent = leave, present
+    /// `null` = clear back to inheriting the instance default, `"name"` = set. The custom
+    /// deserializer makes present-`null` → `Some(None)` reachable from JSON — what lets the
+    /// UI reset a Trigger to "use the instance default".
+    #[serde(default, deserialize_with = "deserialize_double_option")]
+    harness: Option<Option<String>>,
     /// Auto-naming toggle (#338), a FLAT `Option<bool>` like `enabled` — NOT
     /// double-wrapped like `sandbox`/`max_concurrent`. There is no "inherit" state to
     /// clear back to: a Trigger's autonomy is a plain on/off. `None` leaves it,
@@ -3663,6 +3689,12 @@ async fn patch_trigger(
         // instance default, `None` leaves it. The FE maps the "use instance default"
         // option to `null`, so an empty string never reaches here.
         sandbox: req.sandbox,
+        // #551: `Some(Some(name))` sets, `Some(None)` clears to inherit, `None` leaves it.
+        // Normalise a stray `Some(Some(""))` to a clean clear (`Some(None)`) so a blank
+        // never persists as a harness named "" (defence in depth; the FE sends `null`).
+        harness: req
+            .harness
+            .map(|inner| inner.filter(|s| !s.trim().is_empty())),
         // #338: flat toggle — `Some(v)` sets, `None` leaves. No clear state.
         auto_name: req.auto_name,
         next_fire_at,
@@ -4877,6 +4909,12 @@ async fn fire_one_trigger(
                     .sandbox
                     .as_deref()
                     .and_then(event_log::SandboxMode::parse),
+                // #551 (ADR-0046): the Trigger carries the harness IN its Run template —
+                // there is no separate Trigger tier. Fold the stored harness into the
+                // create request's `run` choice, so a cron tick and a "Run now" (both
+                // route through here) freeze the SAME harness. A blank/absent stored
+                // value defers to the instance default. No validation (ADR-0045).
+                harness: trigger.harness.clone(),
                 // #338: pass the Trigger's frozen auto-naming choice as the explicit
                 // tier. `Some(b)` wins the chokepoint resolution unconditionally, so a
                 // fire with `auto_name=false` keeps a stable per-id name and the manager
@@ -6711,6 +6749,11 @@ async fn parse_multipart_create_run(
     // defers to the trigger/instance default at the chokepoint. An unknown token is
     // treated as unset (defensive; the FE only ever sends valid variants).
     let mut sandbox: Option<event_log::SandboxMode> = None;
+    // #551: an explicit harness may ride the multipart (browser) create when images
+    // are attached, so a harness choice is honoured on that path too. `None` when the
+    // field is absent/blank — the chokepoint then freezes nothing and the Run resolves
+    // through the instance default and the floor.
+    let mut harness: Option<String> = None;
     // #338: an explicit auto-naming choice may ride the multipart (browser) create
     // when images are attached, so an unchecked "Auto-generated" box is honoured on
     // that path too. `None` when the field is absent — the chokepoint then resolves
@@ -6809,6 +6852,17 @@ async fn parse_multipart_create_run(
                     sandbox = event_log::SandboxMode::parse(&v);
                 }
             }
+            "harness" => {
+                // #551: the explicit harness threaded off the multipart form. Empty →
+                // leave `None` (the Run names no harness). No validation (ADR-0045).
+                let v = field
+                    .text()
+                    .await
+                    .map_err(|e| format!("bad field harness: {e}"))?;
+                if !v.trim().is_empty() {
+                    harness = Some(v);
+                }
+            }
             "auto_name" => {
                 // #338: an explicit flag off the multipart form. Reuses the shared
                 // boolean parser; an unrecognised token leaves `None` (defer to the
@@ -6855,6 +6909,8 @@ async fn parse_multipart_create_run(
         // create with attached images). `None` when the field is absent — the
         // chokepoint then defers to the trigger/instance default.
         sandbox,
+        // #551: the explicit harness threaded off the multipart form.
+        harness,
         // #338: the explicit auto-naming choice threaded off the multipart form.
         auto_name,
     };
@@ -7312,6 +7368,24 @@ async fn create_run_inner(
     if let Some(ref branch) = effective_source_branch {
         run_payload["source_branch"] = serde_json::json!(branch);
     }
+    // #551 (ADR-0046): FREEZE the Run's harness choice into `RunStarted`, the same
+    // immutability posture as `sandbox` above — editing the pipeline or the instance
+    // default afterwards can never re-decide a Run in flight. Written ONLY for a
+    // non-blank choice, so a Run that names no harness keeps its payload byte-identical
+    // to the pre-#551 shape (absent key → `None` → resolve through the instance default
+    // and the floor). A blank/whitespace value is normalised to absent here, so the
+    // `Some("")` trap of #347 can never persist. `req.harness` already carries the Run's
+    // single-origin choice: a manual create's field, or a Trigger fire's folded harness.
+    // No validation (ADR-0045): an unknown name fails fast at the first node spawn,
+    // naming it — never here, never silently.
+    if let Some(h) = req
+        .harness
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        run_payload["harness"] = serde_json::json!(h);
+    }
     // Auto-naming autonomy decision (#338, ADR-0015). Resolved ONCE here, at the
     // same chokepoint as the sandbox default, and read FRESH from the DB so a
     // `PUT /settings` bites on the very next create with no restart (never cached at
@@ -7465,7 +7539,7 @@ async fn create_run_inner(
     if sandbox.is_off() {
         // Historical host path — inline, byte-identical to pre-#407. NO docker.
         spawn_ready_after_event(state, &run_id).await;
-        spawn_manager_session(state, &run_id, &worktree_dir, name_hint, false);
+        spawn_manager_session(state, &run_id, &worktree_dir, name_hint, false).await;
     } else {
         // #407 D3/D4: eager fail-fast prep on a detached, panic-isolated task
         // (mirror ADR-0023 — the 201 must not block on a first-run `docker
@@ -7544,7 +7618,8 @@ async fn create_run_inner(
                         &task_worktree,
                         name_hint,
                         true,
-                    );
+                    )
+                    .await;
                 }
                 Ok(Err(e)) => {
                     fail_run_sandbox_prep(
@@ -7673,7 +7748,7 @@ pub(crate) async fn fail_run_sandbox_prep(state: &AppState, run_id: &str, reason
 /// today: `create_run` appends `RunStarted` and `return Err`s on failure, well
 /// before either spawn site here (host, or the detached sandbox task). Keep it
 /// that way.
-fn spawn_manager_session(
+async fn spawn_manager_session(
     state: &AppState,
     run_id: &str,
     worktree_dir: &std::path::Path,
@@ -7709,10 +7784,28 @@ fn spawn_manager_session(
         marker: &session_name,
         workdir: worktree_dir,
     });
-    // #550/ADR-0046: infra sessions follow the Run's harness; the Run tier is #551,
-    // so in this slice the manager runs on the `claude` floor — byte-identical to
-    // the legacy manager launch (no model, no effort, no session id).
-    let manager_harness = harness_registry::claude();
+    // #551/ADR-0046: the manager follows the harness OF THE RUN — `Run → instance →
+    // floor`, no node tier and (deliberately) no model/effort. So "ce Run tourne sur
+    // X" holds with no exception to remember: an A/B on a new harness exercises the
+    // manager too. When the Run named no harness AND the instance default is unset,
+    // this resolves to the `claude` floor — byte-identical to the legacy manager
+    // launch. An unknown name (only reachable via an unvalidated Run choice, ADR-0045)
+    // falls back to `claude` with a warning rather than failing the whole Run here:
+    // the first NODE spawn is where an unknown harness fails fast (ADR-0037), and the
+    // manager is a best-effort assist that must not itself wedge the Run.
+    let run_harness = reload_run_state(state, run_id)
+        .await
+        .and_then(|(_, s)| s.harness);
+    let default_harness = stored_default_harness(&state.db).await;
+    let manager_harness_name =
+        harness_resolver::resolve_infra_harness(run_harness.as_deref(), default_harness.as_deref());
+    let manager_harness = harness_registry::resolve(&manager_harness_name).unwrap_or_else(|| {
+        warn!(
+            "manager for run {run_id}: unknown harness '{manager_harness_name}' — \
+             launching the manager on the claude floor (the first node spawn fails fast)"
+        );
+        harness_registry::claude()
+    });
     if let Err(e) = tmux_session_manager::spawn(
         &session_name,
         &full_prompt,
@@ -10918,11 +11011,13 @@ async fn spawn_merge_resolver(
     let prompt = load_merge_resolver_prompt(&state.repo_root);
     let session_name = tmux_session_manager::node_session_name(run_id, MERGE_RESOLVER_NODE_ID, 1);
 
-    // #407: the merge resolver runs inside the Run's container when sandboxed.
-    // Project the (immutable) mode; default `off` if the state can't be reloaded.
-    let sandbox_mode = reload_run_state(state, run_id)
+    // #407/#551: the merge resolver runs inside the Run's container when sandboxed
+    // AND on the harness OF THE RUN. Project both from the SAME (immutable) reload —
+    // the mode defaults to `off`, the harness to `None`, if the state can't be
+    // reloaded.
+    let (sandbox_mode, run_harness) = reload_run_state(state, run_id)
         .await
-        .map(|(_, s)| s.sandbox)
+        .map(|(_, s)| (s.sandbox, s.harness))
         .unwrap_or_default();
 
     let resolver_started = event_log::Event {
@@ -10947,9 +11042,20 @@ async fn spawn_merge_resolver(
         marker: &session_name,
         workdir: worktree_dir,
     });
-    // #550/ADR-0046: infra sessions follow the Run's harness (Run tier = #551), so
-    // the merge resolver runs on the `claude` floor in this slice — byte-identical.
-    let resolver_harness = harness_registry::claude();
+    // #551/ADR-0046: the merge resolver follows the harness OF THE RUN, exactly like
+    // the manager — `Run → instance → floor`, no node tier, no model/effort. Unknown
+    // name (unvalidated Run choice, ADR-0045) falls back to `claude` with a warning:
+    // the resolver is dead in production since ADR-0006, so this is defence in depth.
+    let default_harness = stored_default_harness(&state.db).await;
+    let resolver_harness_name =
+        harness_resolver::resolve_infra_harness(run_harness.as_deref(), default_harness.as_deref());
+    let resolver_harness = harness_registry::resolve(&resolver_harness_name).unwrap_or_else(|| {
+        warn!(
+            "merge resolver for run {run_id}: unknown harness '{resolver_harness_name}' — \
+             launching on the claude floor"
+        );
+        harness_registry::claude()
+    });
     if let Err(e) = tmux_session_manager::spawn(
         &session_name,
         &prompt,

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -19,6 +19,9 @@ mod fire_decision;
 mod frontmatter_parser;
 mod graph_resolver;
 mod guard_runner;
+mod harness_argv;
+pub mod harness_registry;
+mod harness_resolver;
 mod input_resolution;
 mod instance_config;
 mod library_store;
@@ -4409,6 +4412,41 @@ async fn stored_default_model(db: &sqlx::SqlitePool) -> Option<String> {
     tmux_session_manager::default_model_with(stored)
 }
 
+/// The instance-wide default **harness**, resolved `stored → env → None` from a
+/// *fresh* read of `instance_config` (#550, ADR-0046). Feeds the `instance` tier
+/// of [`harness_resolver`] at every spawn seam so a `PUT /settings` takes effect
+/// on the next node with no restart. `None` ⇒ the resolver's `claude` floor.
+async fn stored_default_harness(db: &sqlx::SqlitePool) -> Option<String> {
+    let stored = instance_config::get(db)
+        .await
+        .ok()
+        .and_then(|c| c.default_harness);
+    tmux_session_manager::default_harness_with(stored)
+}
+
+/// The per-harness default model map for the resolver (#550, ADR-0046), from a
+/// *fresh* read of `instance_config`. The stored `default_harness_model` map, with
+/// the legacy single instance default (`default_model` stored/env) folded under
+/// `claude` when the map is silent for it — so a pre-#550 setup keeps working
+/// unchanged. A DB read error yields an empty map (fall through to no default).
+async fn stored_default_harness_models(
+    db: &sqlx::SqlitePool,
+) -> std::collections::BTreeMap<String, String> {
+    let cfg = instance_config::get(db).await.ok();
+    let mut map = cfg
+        .as_ref()
+        .map(|c| c.default_harness_model.clone())
+        .unwrap_or_default();
+    if !map.contains_key(harness_registry::CLAUDE) {
+        if let Some(legacy) =
+            tmux_session_manager::default_model_with(cfg.and_then(|c| c.default_model))
+        {
+            map.insert(harness_registry::CLAUDE.to_string(), legacy);
+        }
+    }
+    map
+}
+
 /// Resolve turn-end auto-completion the way the liveness sweep does, from a
 /// *fresh* read of `instance_config` (#433, ADR-0043). Consulted at every agent
 /// spawn/resume seam so injecting the `Stop` hook tracks a `PUT /settings` with
@@ -5388,6 +5426,10 @@ const KNOWN_NODE_KEYS: &[&str] = &[
     "max_iter",
     "branches",
     "prompt",
+    // #550/ADR-0046: the harness axis. `model`/`effort` above stay accepted (a
+    // pasted flat pair is folded into `harnesses.claude` by `normalize_node_value`).
+    "pin_harness",
+    "harnesses",
     // Accepted-and-dropped, not a semantic loss → no warning.
     "id",
     "view",
@@ -5468,7 +5510,32 @@ fn parse_node_spec(yaml: &str) -> Result<serde_json::Value, String> {
         }
     }
 
-    // 7. Deserialize the (normalized) map into a LibraryEntry. `prompt` defaults
+    // 7. #550/ADR-0046: read the harness axis off the (folded) value before it is
+    //    consumed. `normalize_node_value` above folded any flat `model:`/`effort:`
+    //    into `harnesses.claude`, so the claude entry is the source for the
+    //    (claude-aware) `spec.model`/`spec.effort` the node library shows — and the
+    //    full `harnesses` map + `pin_harness` ride through for the harness UI.
+    let claude = value
+        .get("harnesses")
+        .and_then(|h| h.get(harness_registry::CLAUDE));
+    let claude_model = claude
+        .and_then(|c| c.get("model"))
+        .and_then(|v| v.as_str())
+        .map(String::from);
+    let claude_effort = claude
+        .and_then(|c| c.get("effort"))
+        .and_then(|v| v.as_str())
+        .map(String::from);
+    let pin_harness = value
+        .get("pin_harness")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+    let harnesses = value
+        .get("harnesses")
+        .map(yaml_value_to_json)
+        .unwrap_or(serde_json::Value::Null);
+
+    // 8. Deserialize the (normalized) map into a LibraryEntry. `prompt` defaults
     //    to empty (a structural node carries none); unknown fields are ignored.
     let entry: library_store::LibraryEntry =
         serde_yaml::from_value(value).map_err(|e| format!("{e}"))?;
@@ -5480,8 +5547,12 @@ fn parse_node_spec(yaml: &str) -> Result<serde_json::Value, String> {
             "inputs": entry.inputs,
             "outputs": entry.outputs,
             "interactive": entry.interactive,
-            "model": entry.model,
-            "effort": entry.effort,
+            // Claude-aware view (#345) — derived from the folded harnesses map.
+            "model": claude_model,
+            "effort": claude_effort,
+            // #550: the harness axis, for the pin selector + per-harness UI.
+            "pin_harness": pin_harness,
+            "harnesses": harnesses,
             "max_iter": entry.max_iter,
             "branches": entry.branches,
         },
@@ -7638,6 +7709,10 @@ fn spawn_manager_session(
         marker: &session_name,
         workdir: worktree_dir,
     });
+    // #550/ADR-0046: infra sessions follow the Run's harness; the Run tier is #551,
+    // so in this slice the manager runs on the `claude` floor — byte-identical to
+    // the legacy manager launch (no model, no effort, no session id).
+    let manager_harness = harness_registry::claude();
     if let Err(e) = tmux_session_manager::spawn(
         &session_name,
         &full_prompt,
@@ -7654,6 +7729,7 @@ fn spawn_manager_session(
         // and resolving nodes by their own id is precisely what stops the manager's
         // transcript, which shares this cwd, from being read as a node's.
         tmux_session_manager::SessionTail::Agent {
+            harness: &manager_harness,
             model: None,
             effort: None,
             session_id: None,
@@ -7914,6 +7990,29 @@ async fn build_settings_view(state: &AppState) -> Result<serde_json::Value, sqlx
         "default"
     };
 
+    // --- default harness (#550, ADR-0046) — same `stored → env → floor` shape as
+    // `default_model`. `effective`=null ⇒ the `claude` floor applies at resolve. ---
+    let dh_stored = cfg.default_harness.as_deref().filter(|s| !s.is_empty());
+    let dh_env = tmux_session_manager::env_default_harness();
+    let dh_effective = tmux_session_manager::default_harness_with(cfg.default_harness.clone());
+    let dh_source = if dh_stored.is_some() {
+        "stored"
+    } else if dh_env.is_some() {
+        "env"
+    } else {
+        "default"
+    };
+    // The per-harness default model map (#550): disclosed verbatim (the stored map)
+    // plus the legacy `PDO_DEFAULT_MODEL` env folded under `claude`, so the screen
+    // shows exactly what the resolver's `instance` tier will read.
+    let dhm_stored = cfg.default_harness_model.clone();
+    let mut dhm_effective = dhm_stored.clone();
+    if !dhm_effective.contains_key(harness_registry::CLAUDE) {
+        if let Some(m) = dm_effective.clone() {
+            dhm_effective.insert(harness_registry::CLAUDE.to_string(), m);
+        }
+    }
+
     // --- default sandbox mode (enum ; built-in default `off`) (#410) ---
     // The empty-string filter treats a stored `""` as unset, and `effective` is computed by
     // the SAME resolver the create-run chokepoint consumes, so the disclosed value can never
@@ -8061,6 +8160,15 @@ async fn build_settings_view(state: &AppState) -> Result<serde_json::Value, sqlx
         "reaper_ttl_secs": settings_field(ttl_effective, ttl_source, cfg.reaper_ttl_secs, ttl_env, ttl_default),
         "guard_timeout_secs": settings_field(guard_effective, guard_source, cfg.guard_timeout_secs, guard_env_ms, guard_default),
         "default_model": settings_field_str(dm_effective.as_deref(), dm_source, dm_stored, dm_env.as_deref()),
+        // #550/ADR-0046: the harness axis. `default_harness` is a plain
+        // stored→env→floor string field; `default_harness_model` is a per-harness
+        // map, disclosed as {effective, stored} so the screen shows both what is
+        // set and what the resolver will read (env fold under claude included).
+        "default_harness": settings_field_str(dh_effective.as_deref(), dh_source, dh_stored, dh_env.as_deref()),
+        "default_harness_model": {
+            "effective": dhm_effective,
+            "stored": dhm_stored,
+        },
         "default_sandbox": {
             "effective": sbx_effective.as_str(),
             "source": sbx_source,
@@ -10439,6 +10547,31 @@ async fn node_pane(
             // own transcript. A pre-#473 row (no id) falls back to a bare
             // `--continue`, which is the very collision this issue fixes.
             let launch_session_id = find_launch_session_id(&events, &node_id, iter);
+            // #550/ADR-0046: re-pose the harness FROZEN at spawn — never the YAML's
+            // now. A pre-#550 row (no key) or an unknown harness falls back to the
+            // `claude` floor, byte-identical to the legacy resume.
+            let launch_harness = find_launch_harness(&events, &node_id, iter);
+            let descriptor = launch_harness
+                .as_deref()
+                .and_then(harness_registry::resolve)
+                .unwrap_or_else(harness_registry::claude);
+            // AC #9: a harness with no resume mechanism serves its last pane
+            // snapshot (the same branch as a `script` node), never a resume error.
+            if !descriptor.can_resume() {
+                let snapshot_path = pane_snapshot_path(&repo_root, &run_id, &node_id, iter);
+                let (content, source) = match std::fs::read_to_string(&snapshot_path) {
+                    Ok(c) => (c, "snapshot"),
+                    Err(_) => ("Session no longer available".to_string(), "unavailable"),
+                };
+                return Json(PaneResponse {
+                    content,
+                    session_name,
+                    resumed: false,
+                    stale: false,
+                    source,
+                })
+                .into_response();
+            }
             // #433 / ADR-0043 (D7): re-resolve turn-end auto-completion FRESH — it
             // may have toggled since spawn — so a resurrected session re-carries
             // the `Stop` hook. A `script` node returned early above, so this tail is
@@ -10451,6 +10584,7 @@ async fn node_pane(
                 &node_id,
                 iter,
                 state.port,
+                &descriptor,
                 launch_effort.as_deref(),
                 launch_session_id.as_deref(),
                 state.tmux_cmd_override.as_deref(),
@@ -10543,6 +10677,27 @@ fn find_launch_session_id(events: &[event_log::Event], node_id: &str, iter: i64)
         })
         .and_then(|e| e.payload.as_ref())
         .and_then(|p| p.get("session_id"))
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+}
+
+/// The harness a node's iteration was **launched** with (#550, ADR-0046), read
+/// back from its `NodeStarted` payload — never re-resolved from the current YAML
+/// or the tiers above (ADR-0007: a live iteration is immutable to edits). A
+/// missing key (every pre-#550 row, every infra session) yields `None`, which the
+/// resume seam treats as the `claude` floor — byte-identical to the legacy tail.
+fn find_launch_harness(events: &[event_log::Event], node_id: &str, iter: i64) -> Option<String> {
+    events
+        .iter()
+        .rev()
+        .find(|e| {
+            e.kind == event_log::EventKind::NodeStarted
+                && e.node_id.as_deref() == Some(node_id)
+                && e.iter == Some(iter)
+        })
+        .and_then(|e| e.payload.as_ref())
+        .and_then(|p| p.get("harness"))
         .and_then(|v| v.as_str())
         .filter(|s| !s.is_empty())
         .map(|s| s.to_string())
@@ -10792,6 +10947,9 @@ async fn spawn_merge_resolver(
         marker: &session_name,
         workdir: worktree_dir,
     });
+    // #550/ADR-0046: infra sessions follow the Run's harness (Run tier = #551), so
+    // the merge resolver runs on the `claude` floor in this slice — byte-identical.
+    let resolver_harness = harness_registry::claude();
     if let Err(e) = tmux_session_manager::spawn(
         &session_name,
         &prompt,
@@ -10807,6 +10965,7 @@ async fn spawn_merge_resolver(
         // confused with a `merge` NODE, which is a regular NodeDef routed through
         // `spawn_node` and DOES carry an effort and a pinned id.
         tmux_session_manager::SessionTail::Agent {
+            harness: &resolver_harness,
             model: None,
             effort: None,
             session_id: None,
@@ -12010,6 +12169,9 @@ async fn force_spawn_node(state: &Arc<AppState>, run_id: &str, node_id: &str) ->
         // (wiring only one seam would leave this path at the account default —
         // a silent bug visible only on a manual force-spawn).
         default_model: stored_default_model(&state.db).await,
+        // #550/ADR-0046: same fresh-resolution discipline for the harness axis.
+        default_harness: stored_default_harness(&state.db).await,
+        default_harness_models: stored_default_harness_models(&state.db).await,
         // #433 / ADR-0043: same reasoning as `default_model` — resolve turn-end
         // auto-completion fresh so a force-spawned node arms the `Stop` hook when
         // the setting is on, instead of silently missing it on this seam alone.
@@ -12283,6 +12445,9 @@ async fn node_retry(
         docker_cmd_override: state.docker_cmd_override.as_deref(),
         // #347: retry honours the instance default like the live scheduler path.
         default_model: stored_default_model(&state.db).await,
+        // #550/ADR-0046: retry resolves the harness axis fresh, like model.
+        default_harness: stored_default_harness(&state.db).await,
+        default_harness_models: stored_default_harness_models(&state.db).await,
         // #433 / ADR-0043: retry re-arms the `Stop` hook per the current setting,
         // like the live scheduler path — not the value at the original spawn.
         inject_hook: stored_autocomplete_turn_end(&state.db).await,
@@ -17803,8 +17968,8 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         }
     }
 
@@ -26437,8 +26602,8 @@ edges: []
             view: None,
             max_iter: None,
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         };
         let pipeline = pipeline::PipelineDef {
             name: "spawn-unit".into(),

--- a/crates/pdo-daemon/src/library_store.rs
+++ b/crates/pdo-daemon/src/library_store.rs
@@ -200,10 +200,18 @@ pub(crate) fn entry_from_node(node: &pipeline::NodeDef, prompt: &str) -> Library
         outputs: node.outputs.clone(),
         interactive: node.interactive,
         // #345/#296: carry the per-node model so a starred node stays synced
-        // instead of flipping to `diverged` the moment it has an override.
-        model: node.model.clone(),
+        // instead of flipping to `diverged` the moment it has an override. Since
+        // #550 the model/effort live under `harnesses.claude`; the node library
+        // stays claude-aware (its pre-#550 contract), so project that entry.
+        model: node
+            .harnesses
+            .get(crate::harness_registry::CLAUDE)
+            .and_then(|e| e.model.clone()),
         // #424: same reasoning for the effort level.
-        effort: node.effort.clone(),
+        effort: node
+            .harnesses
+            .get(crate::harness_registry::CLAUDE)
+            .and_then(|e| e.effort.clone()),
         max_iter: None,
         branches: None,
         prompt: prompt.to_string(),
@@ -1011,6 +1019,18 @@ mod tests {
         });
     }
 
+    /// #550: set a node's `harnesses.claude` entry — the source `entry_from_node`
+    /// now projects into a `LibraryEntry`'s `model`/`effort`.
+    fn set_claude_entry(node: &mut pipeline::NodeDef, model: Option<&str>, effort: Option<&str>) {
+        node.harnesses.insert(
+            crate::harness_registry::CLAUDE.to_string(),
+            crate::harness_resolver::HarnessEntry {
+                model: model.map(str::to_string),
+                effort: effort.map(str::to_string),
+            },
+        );
+    }
+
     fn make_node(name: &str) -> pipeline::NodeDef {
         pipeline::NodeDef {
             id: "test-id".to_string(),
@@ -1038,8 +1058,8 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         }
     }
 
@@ -1242,7 +1262,7 @@ mod tests {
         // #345/#296: a node with a per-node model must produce a model-aware
         // library entry (previously the model was silently dropped).
         let mut node = make_node("Modelled");
-        node.model = Some("sonnet".to_string());
+        set_claude_entry(&mut node, Some("sonnet"), None);
         let entry = entry_from_node(&node, "prompt");
         assert_eq!(entry.model, Some("sonnet".to_string()));
     }
@@ -1280,8 +1300,7 @@ mod tests {
         // #424: a node with a per-node effort must produce an effort-aware library
         // entry, and the two axes must not interfere.
         let mut node = make_node("Effortful");
-        node.model = Some("sonnet".to_string());
-        node.effort = Some("xhigh".to_string());
+        set_claude_entry(&mut node, Some("sonnet"), Some("xhigh"));
         let entry = entry_from_node(&node, "prompt");
         assert_eq!(entry.effort, Some("xhigh".to_string()));
         assert_eq!(entry.model, Some("sonnet".to_string()));
@@ -1294,14 +1313,14 @@ mod tests {
         // bug #345, one field later.
         with_temp_home(|| {
             let mut node = make_node("Effortful");
-            node.effort = Some("low".to_string());
+            set_claude_entry(&mut node, None, Some("low"));
             save(&entry_from_node(&node, "prompt")).unwrap();
             assert_eq!(sync_state(&node, "prompt"), SyncState::Synced);
 
-            node.effort = Some("high".to_string());
+            set_claude_entry(&mut node, None, Some("high"));
             assert_eq!(sync_state(&node, "prompt"), SyncState::Diverged);
 
-            node.effort = None;
+            set_claude_entry(&mut node, None, None);
             assert_eq!(sync_state(&node, "prompt"), SyncState::Diverged);
         });
     }

--- a/crates/pdo-daemon/src/loop_region.rs
+++ b/crates/pdo-daemon/src/loop_region.rs
@@ -536,8 +536,8 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         }
     }
 

--- a/crates/pdo-daemon/src/mutation_validator.rs
+++ b/crates/pdo-daemon/src/mutation_validator.rs
@@ -213,8 +213,8 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         }
     }
 
@@ -231,8 +231,8 @@ mod tests {
                 max_iter,
             ))),
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         }
     }
 

--- a/crates/pdo-daemon/src/node_io_resolver.rs
+++ b/crates/pdo-daemon/src/node_io_resolver.rs
@@ -353,8 +353,8 @@ mod tests {
                     view: None,
                     max_iter: None,
                     over: None,
-                    model: None,
-                    effort: None,
+                    pin_harness: None,
+                    harnesses: Default::default(),
                 },
                 NodeDef {
                     id: "implementer".into(),
@@ -382,8 +382,8 @@ mod tests {
                     view: None,
                     max_iter: None,
                     over: None,
-                    model: None,
-                    effort: None,
+                    pin_harness: None,
+                    harnesses: Default::default(),
                 },
             ],
             edges: vec![EdgeDef {
@@ -536,8 +536,8 @@ mod tests {
                     view: None,
                     max_iter: None,
                     over: None,
-                    model: None,
-                    effort: None,
+                    pin_harness: None,
+                    harnesses: Default::default(),
                 },
                 NodeDef {
                     id: "implementer".into(),
@@ -565,8 +565,8 @@ mod tests {
                     view: None,
                     max_iter: None,
                     over: None,
-                    model: None,
-                    effort: None,
+                    pin_harness: None,
+                    harnesses: Default::default(),
                 },
             ],
             edges: vec![EdgeDef {
@@ -724,8 +724,8 @@ mod tests {
                     view: None,
                     max_iter: None,
                     over: None,
-                    model: None,
-                    effort: None,
+                    pin_harness: None,
+                    harnesses: Default::default(),
                 },
                 NodeDef {
                     id: "b".into(),
@@ -745,8 +745,8 @@ mod tests {
                     view: None,
                     max_iter: None,
                     over: None,
-                    model: None,
-                    effort: None,
+                    pin_harness: None,
+                    harnesses: Default::default(),
                 },
                 NodeDef {
                     id: "merger".into(),
@@ -766,8 +766,8 @@ mod tests {
                     view: None,
                     max_iter: None,
                     over: None,
-                    model: None,
-                    effort: None,
+                    pin_harness: None,
+                    harnesses: Default::default(),
                 },
             ],
             edges: vec![
@@ -855,8 +855,8 @@ mod tests {
                     view: None,
                     max_iter: None,
                     over: None,
-                    model: None,
-                    effort: None,
+                    pin_harness: None,
+                    harnesses: Default::default(),
                 },
                 NodeDef {
                     id: "implementer".into(),
@@ -869,8 +869,8 @@ mod tests {
                     view: None,
                     max_iter: None,
                     over: None,
-                    model: None,
-                    effort: None,
+                    pin_harness: None,
+                    harnesses: Default::default(),
                 },
             ],
             edges: vec![EdgeDef {
@@ -937,8 +937,8 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         };
         let mk_edge = |src: &str| EdgeDef {
             source: EdgeEndpoint {
@@ -1018,8 +1018,8 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         };
         let mk_edge = |src: &str, port: &str| EdgeDef {
             source: EdgeEndpoint {
@@ -1102,8 +1102,8 @@ mod tests {
                 view: None,
                 max_iter: None,
                 over: None,
-                model: None,
-                effort: None,
+                pin_harness: None,
+                harnesses: Default::default(),
             }],
             edges: Vec::new(),
             loops: Vec::new(),

--- a/crates/pdo-daemon/src/node_primitives.rs
+++ b/crates/pdo-daemon/src/node_primitives.rs
@@ -57,6 +57,15 @@ pub(crate) struct StartNodeParams<'a> {
     /// Instance per-harness default model map, resolved fresh by the caller (#550).
     /// Feeds the fallback tier of the model resolution for the winning harness.
     pub default_harness_models: std::collections::BTreeMap<String, String>,
+    /// The harness carried by the **Projet** of this Run's primary repo, resolved
+    /// by the caller (#552, ADR-0046). Same DB-less contract as
+    /// [`Self::default_harness`]: `start_node` is sync, so the async caller looks
+    /// up `project_store::harness_for_path` on the Run's effective repo and passes
+    /// the result in. Feeds the `project` tier of [`harness_resolver`], between the
+    /// Run and the instance default. `None` ⇒ the primary is in no Projet (or its
+    /// Projet carries no harness), so the tier is transparent. Resolved from the
+    /// **primary** repo only, so a secondary (ADR-0042) never sways it.
+    pub project_harness: Option<String>,
     /// Turn-end auto-completion, already resolved `stored → env → default` by the
     /// caller (#433, ADR-0043). Same DB-less contract as [`Self::default_model`]:
     /// the async caller reads [`crate::stored_autocomplete_turn_end`] and passes
@@ -393,7 +402,10 @@ pub(crate) fn start_node(params: &StartNodeParams<'_>) -> StartNodeResult {
             // from the projected state the caller already holds. A pinned node ignores
             // it; a free node follows it (ADR-0046). Mirrors `node_spawn`.
             run: params.run_state.harness.as_deref(),
-            project: None, // #552
+            // #552: the Projet of the Run's primary repo, resolved DB-lessly by
+            // the caller (an empty string never wins a tier — the `Some("")` trap
+            // of #347).
+            project: params.project_harness.as_deref().filter(|s| !s.is_empty()),
             instance_default: params.default_harness.as_deref(),
         };
         Some(harness_resolver::resolve(
@@ -1013,6 +1025,7 @@ mod tests {
             default_model: None,
             default_harness: None,
             default_harness_models: Default::default(),
+            project_harness: None,
             inject_hook: false,
         };
 
@@ -1055,6 +1068,7 @@ mod tests {
             default_model: None,
             default_harness: None,
             default_harness_models: Default::default(),
+            project_harness: None,
             inject_hook: false,
         };
 
@@ -1103,6 +1117,7 @@ mod tests {
             default_model: None,
             default_harness: None,
             default_harness_models: Default::default(),
+            project_harness: None,
             inject_hook: true,
         };
         let result = start_node(&params);
@@ -1156,6 +1171,7 @@ mod tests {
             default_model: None,
             default_harness: None,
             default_harness_models: Default::default(),
+            project_harness: None,
             inject_hook: true,
         };
         let result = start_node(&params);
@@ -1221,6 +1237,7 @@ mod tests {
             default_model: None,
             default_harness: None,
             default_harness_models: Default::default(),
+            project_harness: None,
             inject_hook: false,
         };
 
@@ -1282,6 +1299,7 @@ mod tests {
             default_model: None,
             default_harness: None,
             default_harness_models: Default::default(),
+            project_harness: None,
             inject_hook: false,
         };
 
@@ -1329,6 +1347,7 @@ mod tests {
             default_model: None,
             default_harness: None,
             default_harness_models: Default::default(),
+            project_harness: None,
             inject_hook: false,
         };
 
@@ -1400,6 +1419,7 @@ mod tests {
             default_model: None,
             default_harness: None,
             default_harness_models: Default::default(),
+            project_harness: None,
             inject_hook: false,
         };
 
@@ -1494,6 +1514,7 @@ mod tests {
             default_model: None,
             default_harness: None,
             default_harness_models: Default::default(),
+            project_harness: None,
             inject_hook: false,
         };
 
@@ -1561,6 +1582,7 @@ mod tests {
             default_model: None,
             default_harness: None,
             default_harness_models: Default::default(),
+            project_harness: None,
             inject_hook: false,
         };
 
@@ -1628,6 +1650,7 @@ mod tests {
             default_model: None,
             default_harness: None,
             default_harness_models: Default::default(),
+            project_harness: None,
             inject_hook: false,
         };
 
@@ -1891,6 +1914,7 @@ mod tests {
             default_model: None,
             default_harness: None,
             default_harness_models: Default::default(),
+            project_harness: None,
             inject_hook: false,
         };
 

--- a/crates/pdo-daemon/src/node_primitives.rs
+++ b/crates/pdo-daemon/src/node_primitives.rs
@@ -6,7 +6,7 @@ use serde::Serialize;
 use crate::event_log::{self, EventKind, NodeStatus};
 use crate::pipeline::{self, PipelineDef};
 use crate::worktree_ops::{ensure_sub_worktree, sub_worktree_branch, sub_worktree_path};
-use crate::{blackboard, tmux_session_manager};
+use crate::{blackboard, harness_registry, harness_resolver, tmux_session_manager};
 
 // ---------------------------------------------------------------------------
 // Result types
@@ -49,6 +49,14 @@ pub(crate) struct StartNodeParams<'a> {
     /// / retry callers resolve it and pass it in; the node's own `model:` still
     /// wins over it via [`tmux_session_manager::resolve_node_model`].
     pub default_model: Option<String>,
+    /// Instance default **harness**, already resolved `stored → env → None` by the
+    /// caller (#550, ADR-0046). Same DB-less contract as [`Self::default_model`]:
+    /// feeds the `instance` tier of [`harness_resolver`]; the node's `pin_harness`
+    /// still wins over it.
+    pub default_harness: Option<String>,
+    /// Instance per-harness default model map, resolved fresh by the caller (#550).
+    /// Feeds the fallback tier of the model resolution for the winning harness.
+    pub default_harness_models: std::collections::BTreeMap<String, String>,
     /// Turn-end auto-completion, already resolved `stored → env → default` by the
     /// caller (#433, ADR-0043). Same DB-less contract as [`Self::default_model`]:
     /// the async caller reads [`crate::stored_autocomplete_turn_end`] and passes
@@ -97,6 +105,9 @@ pub(crate) struct StartNodeSpawn {
 /// cannot be carried across the append.
 enum StartNodeTail {
     Agent {
+        /// #550: the resolved harness descriptor (owned; `execute` borrows it into
+        /// [`tmux_session_manager::SessionTail::Agent`]).
+        harness: harness_registry::HarnessDescriptor,
         model: Option<String>,
         effort: Option<String>,
         /// #473: the pinned Claude Code session id (owned mirror of
@@ -130,10 +141,12 @@ impl StartNodeSpawn {
     pub(crate) fn execute(&self) -> anyhow::Result<()> {
         let tail = match &self.tail {
             StartNodeTail::Agent {
+                harness,
                 model,
                 effort,
                 session_id,
             } => tmux_session_manager::SessionTail::Agent {
+                harness,
                 model: model.as_deref(),
                 effort: effort.as_deref(),
                 session_id: session_id.as_deref(),
@@ -358,21 +371,79 @@ pub(crate) fn start_node(params: &StartNodeParams<'_>) -> StartNodeResult {
     } else {
         Vec::new()
     };
-    // #347/#424: resolved once, then used by both the tail and the `NodeStarted`
-    // payload — the payload must record what the flags actually carried, because
-    // that is what the resume path reads back to re-pose `--effort`. Unlike
-    // `spawn_node`, this primitive is synchronous and already holds
-    // `params.default_model`, so nothing has to be hoisted.
-    let resolved_model = tmux_session_manager::resolve_node_model(
-        node.model.as_deref(),
-        params.default_model.as_deref(),
-    );
-    let resolved_effort = tmux_session_manager::resolve_node_effort(node.effort.as_deref());
-    // #473: pin a Claude Code session id for an agent node so the sweep resolves
-    // its transcript by identity and the resume path re-enters it. `None` for a
-    // script node (no claude) — mirrors `node_spawn`. Recorded on `NodeStarted`
-    // below and threaded into the tail.
-    let session_id: Option<String> = (!is_script).then(|| uuid::Uuid::new_v4().to_string());
+    // #550/ADR-0046: resolve the harness (mirrors `node_spawn`), reading model +
+    // effort from the winning harness's entry. `params.default_harness` /
+    // `default_harness_models` are the instance tier, resolved DB-lessly by the
+    // caller. A `script` node resolves no harness.
+    let resolved_harness = if is_script {
+        None
+    } else {
+        // Fold the legacy single `default_model` under `claude` when the per-harness
+        // map is silent for it — the same back-compat fold `stored_default_harness_models`
+        // does, kept here so this DB-less primitive is self-contained given its inputs.
+        let mut default_models = params.default_harness_models.clone();
+        if !default_models.contains_key(harness_registry::CLAUDE) {
+            if let Some(m) = params.default_model.as_deref().filter(|s| !s.is_empty()) {
+                default_models.insert(harness_registry::CLAUDE.to_string(), m.to_string());
+            }
+        }
+        let tiers = harness_resolver::HarnessTiers {
+            node_pin: node.pin_harness.as_deref(),
+            run: None,     // #551
+            project: None, // #552
+            instance_default: params.default_harness.as_deref(),
+        };
+        Some(harness_resolver::resolve(
+            &tiers,
+            &node.harnesses,
+            &default_models,
+        ))
+    };
+    let harness_descriptor = match &resolved_harness {
+        None => None,
+        Some(r) => match harness_registry::resolve(&r.harness) {
+            Some(d) => Some(d),
+            None => {
+                return StartNodeResult {
+                    outcome: PrimitiveOutcome::Rejected {
+                        reason: format!(
+                            "node '{}': unknown harness '{}'",
+                            params.node_id, r.harness
+                        ),
+                    },
+                    events: vec![],
+                    spawn: None,
+                };
+            }
+        },
+    };
+    // AC #10: a missing harness binary is a spawn that cannot happen — reject
+    // (never a 2xx), naming the harness. Skipped under the test seam.
+    if let Some(d) = &harness_descriptor {
+        if params.tmux_cmd_override.is_none() && !tmux_session_manager::binary_available(&d.binary)
+        {
+            return StartNodeResult {
+                outcome: PrimitiveOutcome::Rejected {
+                    reason: format!(
+                        "node '{}': harness '{}' binary '{}' not found on PATH",
+                        params.node_id, d.name, d.binary
+                    ),
+                },
+                events: vec![],
+                spawn: None,
+            };
+        }
+    }
+    // #347/#424/#550: model + effort come from the resolved harness's entry, used
+    // by both the tail and the `NodeStarted` payload (which records what the flags
+    // carried — what the resume path reads back to re-pose `--effort`).
+    let resolved_model = resolved_harness.as_ref().and_then(|r| r.model.clone());
+    let resolved_effort = resolved_harness.as_ref().and_then(|r| r.effort.clone());
+    // #473/#550: pin a session id only for a harness that can honour it (`claude`).
+    let session_id: Option<String> = harness_descriptor
+        .as_ref()
+        .filter(|d| d.pins_session_id())
+        .map(|_| uuid::Uuid::new_v4().to_string());
     let tail = if is_script {
         StartNodeTail::Script {
             timeout_secs: tmux_session_manager::SCRIPT_TIMEOUT_SECS,
@@ -380,8 +451,11 @@ pub(crate) fn start_node(params: &StartNodeParams<'_>) -> StartNodeResult {
         }
     } else {
         StartNodeTail::Agent {
-            model: resolved_model.map(str::to_string),
-            effort: resolved_effort.map(str::to_string),
+            harness: harness_descriptor
+                .clone()
+                .expect("a non-script node resolved a harness descriptor"),
+            model: resolved_model.clone(),
+            effort: resolved_effort.clone(),
             session_id: session_id.clone(),
         }
     };
@@ -400,8 +474,11 @@ pub(crate) fn start_node(params: &StartNodeParams<'_>) -> StartNodeResult {
             // #424: launch-time model + effort, **resolved**. Mirrors the
             // `spawn_node` payload; see the comment there for why the model is
             // recorded even though nothing reads it back yet.
-            "model": resolved_model,
-            "effort": resolved_effort,
+            "model": resolved_model.as_deref(),
+            "effort": resolved_effort.as_deref(),
+            // #550/ADR-0046: the harness resolved at spawn, FROZEN so the resume
+            // path re-poses what was launched (ADR-0007). Mirrors `spawn_node`.
+            "harness": resolved_harness.as_ref().map(|r| r.harness.as_str()),
             // #473: the pinned Claude Code session id — read back by the sweep
             // (transcript resolution) and the resume path. `null` for a script node
             // and every pre-#473 row. Mirrors the `spawn_node` payload.
@@ -775,8 +852,8 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         }
     }
 
@@ -807,8 +884,8 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         }
     }
 
@@ -931,6 +1008,8 @@ mod tests {
             tmux_cmd_override: Some("exec true"),
             docker_cmd_override: None,
             default_model: None,
+            default_harness: None,
+            default_harness_models: Default::default(),
             inject_hook: false,
         };
 
@@ -971,6 +1050,8 @@ mod tests {
             tmux_cmd_override: Some("exec true"),
             docker_cmd_override: None,
             default_model: None,
+            default_harness: None,
+            default_harness_models: Default::default(),
             inject_hook: false,
         };
 
@@ -1017,6 +1098,8 @@ mod tests {
             tmux_cmd_override: Some("exec true"),
             docker_cmd_override: None,
             default_model: None,
+            default_harness: None,
+            default_harness_models: Default::default(),
             inject_hook: true,
         };
         let result = start_node(&params);
@@ -1068,6 +1151,8 @@ mod tests {
             tmux_cmd_override: Some("exec true"),
             docker_cmd_override: None,
             default_model: None,
+            default_harness: None,
+            default_harness_models: Default::default(),
             inject_hook: true,
         };
         let result = start_node(&params);
@@ -1131,6 +1216,8 @@ mod tests {
             tmux_cmd_override: Some("exec true"),
             docker_cmd_override: None,
             default_model: None,
+            default_harness: None,
+            default_harness_models: Default::default(),
             inject_hook: false,
         };
 
@@ -1190,6 +1277,8 @@ mod tests {
             tmux_cmd_override: Some("exec true"),
             docker_cmd_override: None,
             default_model: None,
+            default_harness: None,
+            default_harness_models: Default::default(),
             inject_hook: false,
         };
 
@@ -1235,6 +1324,8 @@ mod tests {
             tmux_cmd_override: Some("exec true"),
             docker_cmd_override: None,
             default_model: None,
+            default_harness: None,
+            default_harness_models: Default::default(),
             inject_hook: false,
         };
 
@@ -1304,6 +1395,8 @@ mod tests {
             tmux_cmd_override: Some("exec true"),
             docker_cmd_override: None,
             default_model: None,
+            default_harness: None,
+            default_harness_models: Default::default(),
             inject_hook: false,
         };
 
@@ -1396,6 +1489,8 @@ mod tests {
             tmux_cmd_override: Some("exec true"),
             docker_cmd_override: None,
             default_model: None,
+            default_harness: None,
+            default_harness_models: Default::default(),
             inject_hook: false,
         };
 
@@ -1461,6 +1556,8 @@ mod tests {
             tmux_cmd_override: Some("exec true"),
             docker_cmd_override: None,
             default_model: None,
+            default_harness: None,
+            default_harness_models: Default::default(),
             inject_hook: false,
         };
 
@@ -1526,6 +1623,8 @@ mod tests {
             tmux_cmd_override: Some("exec true"),
             docker_cmd_override: None,
             default_model: None,
+            default_harness: None,
+            default_harness_models: Default::default(),
             inject_hook: false,
         };
 
@@ -1787,6 +1886,8 @@ mod tests {
             tmux_cmd_override: Some("exec true"),
             docker_cmd_override: None,
             default_model: None,
+            default_harness: None,
+            default_harness_models: Default::default(),
             inject_hook: false,
         };
 

--- a/crates/pdo-daemon/src/node_primitives.rs
+++ b/crates/pdo-daemon/src/node_primitives.rs
@@ -389,7 +389,10 @@ pub(crate) fn start_node(params: &StartNodeParams<'_>) -> StartNodeResult {
         }
         let tiers = harness_resolver::HarnessTiers {
             node_pin: node.pin_harness.as_deref(),
-            run: None,     // #551
+            // #551: the Run tier — the harness frozen in this Run's `RunStarted`, read
+            // from the projected state the caller already holds. A pinned node ignores
+            // it; a free node follows it (ADR-0046). Mirrors `node_spawn`.
+            run: params.run_state.harness.as_deref(),
             project: None, // #552
             instance_default: params.default_harness.as_deref(),
         };

--- a/crates/pdo-daemon/src/node_spawn.rs
+++ b/crates/pdo-daemon/src/node_spawn.rs
@@ -22,8 +22,9 @@ use crate::worktree_ops::{
 };
 use crate::{
     admission, append_event_with, count_global_live_sessions_excluding, event_log,
-    input_resolution, merge_action, panic_payload_message, pipeline, prompt_augmenter,
-    reload_run_state_with, stored_autocomplete_turn_end, stored_default_model, stored_session_cap,
+    harness_registry, harness_resolver, input_resolution, merge_action, panic_payload_message,
+    pipeline, prompt_augmenter, reload_run_state_with, stored_autocomplete_turn_end,
+    stored_default_harness, stored_default_harness_models, stored_session_cap,
     tmux_session_manager, transition_guard, AppState,
 };
 
@@ -315,6 +316,54 @@ pub(crate) async fn spawn_node(
 
     let foreach_context = find_collection_context(spawn_ctx, &node.id, iter);
 
+    // #550/ADR-0046: resolve the harness ONCE, here — before any side effect — so
+    // its result freezes into `NodeStarted` and is re-posed at resume (ADR-0007).
+    // A `script` node launches no agent (ADR-0017), so it resolves no harness. The
+    // binary fail-fast runs BEFORE the sub-worktree is created and BEFORE the
+    // reservation span, so a missing harness leaves no orphan and writes no spawn
+    // event (AC #10 / ADR-0037: never a 2xx for a spawn that did not happen).
+    // Skipped under the tmux command override — the test seam launches a stand-in,
+    // not the real binary.
+    let resolved_harness = if node.node_type == pipeline::NodeType::Script {
+        None
+    } else {
+        let default_harness = stored_default_harness(deps.db).await;
+        let default_models = stored_default_harness_models(deps.db).await;
+        let tiers = harness_resolver::HarnessTiers {
+            node_pin: node.pin_harness.as_deref(),
+            run: None,     // #551
+            project: None, // #552
+            instance_default: default_harness.as_deref(),
+        };
+        Some(harness_resolver::resolve(
+            &tiers,
+            &node.harnesses,
+            &default_models,
+        ))
+    };
+    let harness_descriptor = match &resolved_harness {
+        None => None,
+        Some(r) => match harness_registry::resolve(&r.harness) {
+            Some(d) => Some(d),
+            None => {
+                // Unknown harness — a spawn that cannot happen. Fail fast, naming it.
+                return SpawnOutcome::Failed {
+                    reason: format!("node {}: unknown harness '{}'", node.id, r.harness),
+                };
+            }
+        },
+    };
+    if let Some(d) = &harness_descriptor {
+        if deps.tmux_cmd_override.is_none() && !tmux_session_manager::binary_available(&d.binary) {
+            return SpawnOutcome::Failed {
+                reason: format!(
+                    "node {}: harness '{}' binary '{}' not found on PATH",
+                    node.id, d.name, d.binary
+                ),
+            };
+        }
+    }
+
     let has_sub_worktree = node.node_type == pipeline::NodeType::CodeMutating
         || node.node_type == pipeline::NodeType::Merge;
 
@@ -383,29 +432,24 @@ pub(crate) async fn spawn_node(
         spawn_ctx.worktree_dir.to_path_buf()
     };
 
-    // #347/#424: resolve what the session will actually launch with, BEFORE the
-    // span below. The `NodeStarted` payload appended *inside* the span records the
-    // **resolved** values (what the flags really carried, which is what the resume
-    // path reads back), and `stored_default_model` is async — it cannot be awaited
-    // from the spawn seam further down and still be visible to the append. This is
-    // a move, not an extra read: the same single DB read, earlier.
-    // `__manager__` / `__merge_resolver__` are infra sessions with no NodeDef and
-    // stay at the account default — they don't route through `spawn_node` (#296).
-    let default_effective = stored_default_model(deps.db).await;
-    let resolved_model = tmux_session_manager::resolve_node_model(
-        node.model.as_deref(),
-        default_effective.as_deref(),
-    );
-    let resolved_effort = tmux_session_manager::resolve_node_effort(node.effort.as_deref());
-    // #473: pin a Claude Code session id for an AGENT node so its transcript is
-    // `<uuid>.jsonl` and the liveness sweep resolves it by identity — never by the
-    // newest `.jsonl` in a cwd it shares with the manager and sibling non-CM nodes.
-    // Recorded on `NodeStarted` (below) so the resume path and the sweep read it
-    // back; a fresh id per spawn means a `restart_node` of the same iteration gets
-    // its own transcript. A `script` node launches no `claude`, so it gets no id
-    // (`null` in the payload) — nothing would resolve it and nothing resumes it.
-    let session_id: Option<String> =
-        (node.node_type != pipeline::NodeType::Script).then(|| uuid::Uuid::new_v4().to_string());
+    // #550/#347/#424: the model and effort come from the harness resolved above
+    // (post node → instance precedence, post empty-string collapse), read from the
+    // winning harness's entry — NOT the raw NodeDef. The `NodeStarted` payload
+    // records these resolved values (what the flags really carried, which the
+    // resume path reads back). `__manager__` / `__merge_resolver__` are infra
+    // sessions with no NodeDef and stay at the account default — they don't route
+    // through `spawn_node`.
+    let resolved_model = resolved_harness.as_ref().and_then(|r| r.model.clone());
+    let resolved_effort = resolved_harness.as_ref().and_then(|r| r.effort.clone());
+    // #473/#550: pin a session id only for a harness that can honour it
+    // (`claude`); a harness that cannot (`opencode`: a fresh id errors) gets
+    // `None` and is attributed by working dir. Recorded on `NodeStarted` so the
+    // resume path and the sweep read it back; a fresh id per spawn means a
+    // `restart_node` of the same iteration gets its own transcript.
+    let session_id: Option<String> = harness_descriptor
+        .as_ref()
+        .filter(|d| d.pins_session_id())
+        .map(|_| uuid::Uuid::new_v4().to_string());
 
     // Panic/cancellation-isolated spawn window (#279). Everything from here to
     // the `NodeStarted` append can panic (`build_full_prompt`, image discovery,
@@ -577,8 +621,12 @@ pub(crate) async fn spawn_node(
                 // reads it yet: the meaning of an effort level depends on the
                 // model (supported levels and the default both vary per model),
                 // so storing the effort alone would store half a fact.
-                "model": resolved_model,
-                "effort": resolved_effort,
+                "model": resolved_model.as_deref(),
+                "effort": resolved_effort.as_deref(),
+                // #550/ADR-0046: the harness resolved at spawn, FROZEN here so the
+                // resume path re-poses what was launched, never what the YAML or a
+                // tier says now (ADR-0007). `null` for a `script` node (no agent).
+                "harness": resolved_harness.as_ref().map(|r| r.harness.as_str()),
                 // #473: the pinned Claude Code session id the agent launches with
                 // (`claude --session-id <uuid>`). The sweep resolves this node's
                 // transcript by it (`<uuid>.jsonl`), and the resume path re-enters
@@ -661,10 +709,15 @@ pub(crate) async fn spawn_node(
         }
     } else {
         // Resolved above the panic span so the `NodeStarted` payload could record
-        // the same values the flags carry (#347/#424/#473).
+        // the same values the flags carry (#347/#424/#473/#550). A non-`script`
+        // node always has a resolved descriptor (the fail-fast returned otherwise).
+        let descriptor = harness_descriptor
+            .as_ref()
+            .expect("a non-script node resolved a harness descriptor");
         tmux_session_manager::SessionTail::Agent {
-            model: resolved_model,
-            effort: resolved_effort,
+            harness: descriptor,
+            model: resolved_model.as_deref(),
+            effort: resolved_effort.as_deref(),
             session_id: session_id.as_deref(),
         }
     };

--- a/crates/pdo-daemon/src/node_spawn.rs
+++ b/crates/pdo-daemon/src/node_spawn.rs
@@ -331,7 +331,10 @@ pub(crate) async fn spawn_node(
         let default_models = stored_default_harness_models(deps.db).await;
         let tiers = harness_resolver::HarnessTiers {
             node_pin: node.pin_harness.as_deref(),
-            run: None,     // #551
+            // #551: the Run tier — the harness frozen in this Run's `RunStarted`
+            // (`projected` is the fresh projection loaded at the head of this spawn).
+            // A pinned node still ignores it; a free node follows it (ADR-0046).
+            run: projected.and_then(|s| s.harness.as_deref()),
             project: None, // #552
             instance_default: default_harness.as_deref(),
         };

--- a/crates/pdo-daemon/src/node_spawn.rs
+++ b/crates/pdo-daemon/src/node_spawn.rs
@@ -59,6 +59,12 @@ pub(crate) struct SpawnDeps<'a> {
     /// Per-daemon `docker` binary override for the sandbox wiring (#407), `Copy`
     /// like the rest of the bundle. `None` in production (real `docker`).
     pub(crate) docker_cmd_override: Option<&'a str>,
+    /// The host home root override (#407 seam), borrowed so the bundle stays
+    /// `Copy`. `None` in production ⇒ the real `$HOME`. #553 uses it as the root
+    /// under which the **disk descriptor tier** (`~/.pdo/harnesses/`) is read, so a
+    /// user-declared harness resolves at spawn — and so a layer-3 test that sets
+    /// the override reads descriptors from its own tempdir, never the real home.
+    pub(crate) home_override: Option<&'a std::path::Path>,
 }
 
 impl<'a> SpawnDeps<'a> {
@@ -72,7 +78,41 @@ impl<'a> SpawnDeps<'a> {
             port: state.port,
             tmux_cmd_override: state.tmux_cmd_override.as_deref(),
             docker_cmd_override: state.docker_cmd_override.as_deref(),
+            home_override: state.sandbox_home_override.as_deref(),
         }
+    }
+}
+
+/// The host home root the disk descriptor tier (#553) is read under: the per-daemon
+/// override when set (the layer-3 seam), else the real `$HOME`. Mirrors
+/// `sandbox_run::sandbox_home_roots` exactly, but reachable from the narrow
+/// [`SpawnDeps`] bundle (which carries no `AppState`). An unresolved `$HOME`
+/// degrades to an empty root, i.e. the embedded floor — never a spawn failure.
+fn spawn_home_root(deps: &SpawnDeps<'_>) -> PathBuf {
+    deps.home_override
+        .map(PathBuf::from)
+        .or_else(|| crate::sandbox_staging::default_roots_from_env().map(|(home, _)| home))
+        .unwrap_or_default()
+}
+
+/// #553 / ADR-0031: say ONCE per `(run, harness)` that a sandboxed Run's node runs
+/// on a harness with no staging floor. The message is the pure
+/// [`crate::harness_probes::staging_floor_absence_note`] (so it is unit-tested
+/// there, not against a terminal); the process-static dedup keeps a busy scheduler
+/// from repeating it on every retry or collection lap. A no-op for `claude`, which
+/// has the floor.
+fn warn_missing_staging_floor_once(run_id: &str, harness: &str) {
+    use std::collections::HashSet;
+    use std::sync::Mutex;
+    static SAID: Mutex<Option<HashSet<(String, String)>>> = Mutex::new(None);
+
+    let Some(note) = crate::harness_probes::staging_floor_absence_note(harness) else {
+        return; // the harness has a staging floor (claude) — nothing to say
+    };
+    let mut guard = SAID.lock().unwrap_or_else(|e| e.into_inner());
+    let said = guard.get_or_insert_with(HashSet::new);
+    if said.insert((run_id.to_string(), harness.to_string())) {
+        warn!("run {run_id}: {note}");
     }
 }
 
@@ -343,15 +383,31 @@ pub(crate) async fn spawn_node(
     };
     let harness_descriptor = match &resolved_harness {
         None => None,
-        Some(r) => match harness_registry::resolve(&r.harness) {
-            Some(d) => Some(d),
-            None => {
-                // Unknown harness — a spawn that cannot happen. Fail fast, naming it.
-                return SpawnOutcome::Failed {
-                    reason: format!("node {}: unknown harness '{}'", node.id, r.harness),
-                };
+        Some(r) => {
+            // #553: resolve against the embedded floor MERGED with the user's disk
+            // descriptor tier (`~/.pdo/harnesses/`), so a harness declared in data
+            // launches without a rebuild. The registry reads a root we hand it — it
+            // never touches `$HOME` itself.
+            let registry = harness_registry::HarnessRegistry::load(&spawn_home_root(&deps));
+            match registry.resolve(&r.harness) {
+                Some(d) => {
+                    // #553 / ADR-0031: a sandboxed Run whose node runs on a harness
+                    // with no staging floor holds only by the profile's image and
+                    // its `$HOME` exceptions — say it once, visibly (the plancher is
+                    // claude-specific and built per-Run regardless of the harness).
+                    if run_sandboxed {
+                        warn_missing_staging_floor_once(run_id, &r.harness);
+                    }
+                    Some(d)
+                }
+                None => {
+                    // Unknown harness — a spawn that cannot happen. Fail fast, naming it.
+                    return SpawnOutcome::Failed {
+                        reason: format!("node {}: unknown harness '{}'", node.id, r.harness),
+                    };
+                }
             }
-        },
+        }
     };
     if let Some(d) = &harness_descriptor {
         if deps.tmux_cmd_override.is_none() && !tmux_session_manager::binary_available(&d.binary) {

--- a/crates/pdo-daemon/src/node_spawn.rs
+++ b/crates/pdo-daemon/src/node_spawn.rs
@@ -369,13 +369,33 @@ pub(crate) async fn spawn_node(
     } else {
         let default_harness = stored_default_harness(deps.db).await;
         let default_models = stored_default_harness_models(deps.db).await;
+        // #552/ADR-0046: the Projet tier — the harness carried by the Projet that
+        // owns this Run's **primary** repo. The primary is `target_repo` (else the
+        // daemon repo root — the same `effective_repo` key the lists group and
+        // attach by). A secondary repo (ADR-0042) lives in `target_repos` and is
+        // never consulted, so adding or removing one changes neither the Projet nor
+        // the resolved harness. A DB error degrades the tier to transparent — a
+        // Projet lookup never fails a spawn.
+        let primary_repo = projected
+            .and_then(|s| s.target_repo.clone())
+            .unwrap_or_else(|| spawn_ctx.repo_root.to_string_lossy().into_owned());
+        let project_harness =
+            match crate::project_store::harness_for_path(deps.db, &primary_repo).await {
+                Ok(h) => h,
+                Err(e) => {
+                    warn!("project harness lookup failed for {primary_repo}: {e}");
+                    None
+                }
+            };
         let tiers = harness_resolver::HarnessTiers {
             node_pin: node.pin_harness.as_deref(),
             // #551: the Run tier — the harness frozen in this Run's `RunStarted`
             // (`projected` is the fresh projection loaded at the head of this spawn).
             // A pinned node still ignores it; a free node follows it (ADR-0046).
             run: projected.and_then(|s| s.harness.as_deref()),
-            project: None, // #552
+            // #552: the Projet tier — resolved just above from this Run's primary
+            // repo. Sits below the Run and above the instance default (ADR-0046).
+            project: project_harness.as_deref(),
             instance_default: default_harness.as_deref(),
         };
         Some(harness_resolver::resolve(

--- a/crates/pdo-daemon/src/outputs_validator.rs
+++ b/crates/pdo-daemon/src/outputs_validator.rs
@@ -307,8 +307,8 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         }
     }
 

--- a/crates/pdo-daemon/src/pipeline.rs
+++ b/crates/pdo-daemon/src/pipeline.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::Path;
 
 use serde::{Deserialize, Serialize};
@@ -139,27 +139,26 @@ pub(crate) struct NodeDef {
     pub max_iter: Option<serde_yaml::Value>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub over: Option<String>,
-    /// Optional per-node model override (#296): free-text pass-through to
-    /// `claude --model <x>` when the node spawns. Absent ⇒ account default
-    /// (no flag emitted, launch command byte-identical to the legacy path).
-    /// Semantic, not layout — included in the pipeline diff (ADR-0001).
+    /// Optional pinned harness (#550, ADR-0046): the harness this node **requires**
+    /// (`claude`, `opencode`). A pin both selects the harness and shields it from
+    /// every coarser tier (Run / Projet / instance). Absent ⇒ the node follows the
+    /// tier above (in this slice: instance default, else the `claude` floor).
+    /// Free-text pass-through (ADR-0001: no closed enum). Semantic, not layout.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub model: Option<String>,
-    /// Optional per-node reasoning-effort override (#424): free-text pass-through
-    /// to `claude --effort <level>` when the node spawns. Absent ⇒ no flag emitted,
-    /// launch command byte-identical to the legacy path.
+    pub pin_harness: Option<String>,
+    /// Per-harness settings map (#550, ADR-0046): `harnesses.<name> = {model,
+    /// effort}`. The model and effort are **not** axes with their own precedence —
+    /// they are read from the entry of the *winning* harness, so the same node
+    /// stays executable on `claude` and `opencode` instead of launching every node
+    /// with a slug the other harness rejects. This replaces the flat `model:` /
+    /// `effort:` of #296/#424, which the pipeline migrator folds into
+    /// `harnesses.claude.*`.
     ///
-    /// Orthogonal to `model`: the model says *which* agent runs, the effort says
-    /// *how long it thinks*. Unlike `--model` (an invalid id makes `claude` exit
-    /// non-zero), an invalid `--effort` is only a stderr warning and the session
-    /// starts at the default — a silent wrong value. That is why the UI proposes a
-    /// closed set while the wire stays open (ADR-0001: sharp tool, no closed enum
-    /// that would perish at every model release).
-    ///
-    /// Semantic, not layout — included in the pipeline diff and in the library
-    /// content hash (`pipeline_semantics`).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub effort: Option<String>,
+    /// `BTreeMap` for a deterministic serialization + canonical form. Semantic, not
+    /// layout — included in the pipeline diff and the library content hash
+    /// (`pipeline_semantics`).
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub harnesses: BTreeMap<String, crate::harness_resolver::HarnessEntry>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -487,7 +486,88 @@ pub(crate) fn normalize_node_value(
         }
         _ => {}
     }
+
+    // #550: fold a legacy flat `model:` / `effort:` into `harnesses.claude.*` so
+    // that a parse is lossless even before the on-disk migrator has rewritten the
+    // file. The migrator persists the same fold; this is the in-memory safety net
+    // that keeps `harnesses` the single source the resolver reads.
+    fold_flat_model_effort_into_harnesses(node_map);
+
     Ok(diagnostics)
+}
+
+/// Fold a node's legacy flat `model:` / `effort:` keys (#296/#424) into
+/// `harnesses.claude.{model, effort}` (#550, ADR-0046), removing the flat keys.
+///
+/// Shared by [`normalize_node_value`] (lossless in-memory parse) and the pipeline
+/// migrator (persisted rewrite), so both fold identically. Returns `true` iff it
+/// removed a flat key — i.e. the raw YAML changed — which is what the migrator's
+/// `needs_migration` guard keys off.
+///
+/// An explicit `harnesses.claude` entry is authoritative: a flat value fills a
+/// slot only when the map has none, so a second run is a no-op (idempotent).
+pub(crate) fn fold_flat_model_effort_into_harnesses(node_map: &mut serde_yaml::Mapping) -> bool {
+    let removed_model = node_map.remove(serde_yaml::Value::String("model".into()));
+    let removed_effort = node_map.remove(serde_yaml::Value::String("effort".into()));
+    let changed = removed_model.is_some() || removed_effort.is_some();
+
+    let flat_model = removed_model
+        .as_ref()
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+    let flat_effort = removed_effort
+        .as_ref()
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+    if flat_model.is_none() && flat_effort.is_none() {
+        return changed; // the flat keys were absent or empty — nothing to carry
+    }
+
+    let harnesses_key = serde_yaml::Value::String("harnesses".into());
+    if !node_map
+        .get(&harnesses_key)
+        .map(serde_yaml::Value::is_mapping)
+        .unwrap_or(false)
+    {
+        node_map.insert(
+            harnesses_key.clone(),
+            serde_yaml::Value::Mapping(serde_yaml::Mapping::new()),
+        );
+    }
+    let harnesses = node_map
+        .get_mut(&harnesses_key)
+        .and_then(serde_yaml::Value::as_mapping_mut)
+        .expect("harnesses just ensured to be a mapping");
+
+    let claude_key = serde_yaml::Value::String(crate::harness_registry::CLAUDE.into());
+    if !harnesses
+        .get(&claude_key)
+        .map(serde_yaml::Value::is_mapping)
+        .unwrap_or(false)
+    {
+        harnesses.insert(
+            claude_key.clone(),
+            serde_yaml::Value::Mapping(serde_yaml::Mapping::new()),
+        );
+    }
+    let claude = harnesses
+        .get_mut(&claude_key)
+        .and_then(serde_yaml::Value::as_mapping_mut)
+        .expect("harnesses.claude just ensured to be a mapping");
+
+    if let Some(m) = flat_model {
+        claude
+            .entry(serde_yaml::Value::String("model".into()))
+            .or_insert(serde_yaml::Value::String(m));
+    }
+    if let Some(e) = flat_effort {
+        claude
+            .entry(serde_yaml::Value::String("effort".into()))
+            .or_insert(serde_yaml::Value::String(e));
+    }
+    changed
 }
 
 pub(crate) fn parse_pipeline(yaml: &str) -> Result<ParseResult, ParseError> {
@@ -2451,8 +2531,8 @@ nodes:
             view: None,
             max_iter: None,
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         };
         let yaml = serde_yaml::to_string(&node).unwrap();
         assert!(yaml.contains("type: script"), "serializes to kebab: {yaml}");
@@ -3614,9 +3694,15 @@ nodes:
             .iter()
             .find(|n| n.id == "ab000001")
             .unwrap();
-        assert_eq!(node.model.as_deref(), Some("opus"));
+        // #550: a flat `model:` is folded into `harnesses.claude.model` on parse.
+        assert_eq!(
+            node.harnesses
+                .get("claude")
+                .and_then(|e| e.model.as_deref()),
+            Some("opus")
+        );
 
-        // Round-trips: re-serialize, re-parse — the model survives.
+        // Round-trips: re-serialize, re-parse — the model survives (now under the map).
         let serialized = serde_yaml::to_string(&result.pipeline).unwrap();
         let result2 = parse_pipeline(&serialized).unwrap();
         let node2 = result2
@@ -3625,7 +3711,13 @@ nodes:
             .iter()
             .find(|n| n.id == "ab000001")
             .unwrap();
-        assert_eq!(node2.model.as_deref(), Some("opus"));
+        assert_eq!(
+            node2
+                .harnesses
+                .get("claude")
+                .and_then(|e| e.model.as_deref()),
+            Some("opus")
+        );
     }
 
     #[test]
@@ -3651,10 +3743,11 @@ nodes:
             .iter()
             .find(|n| n.id == "ab000001")
             .unwrap();
-        assert!(node.model.is_none());
+        assert!(node.harnesses.is_empty());
         // Absent ⇒ never serialized (clean file, round-trips by absence).
         let serialized = serde_yaml::to_string(&result.pipeline).unwrap();
         assert!(!serialized.contains("model:"));
+        assert!(!serialized.contains("harnesses:"));
     }
 
     #[test]
@@ -3683,12 +3776,12 @@ nodes:
 "#,
         );
         let result = parse_pipeline(&yaml).unwrap();
+        // #550: flat `effort:` is folded into `harnesses.claude.effort` on parse.
         let find = |p: &PipelineDef, id: &str| {
             p.nodes
                 .iter()
                 .find(|n| n.id == id)
-                .map(|n| n.effort.clone())
-                .unwrap()
+                .and_then(|n| n.harnesses.get("claude").and_then(|e| e.effort.clone()))
         };
         assert_eq!(find(&result.pipeline, "ab000001").as_deref(), Some("low"));
         // Orthogonal to the model — both land, neither clobbers the other.
@@ -3699,8 +3792,9 @@ nodes:
                 .iter()
                 .find(|n| n.id == "ab000001")
                 .unwrap()
-                .model
-                .as_deref(),
+                .harnesses
+                .get("claude")
+                .and_then(|e| e.model.as_deref()),
             Some("opus")
         );
         // An unknown level parses fine (pass-through, no closed enum).
@@ -3740,7 +3834,7 @@ nodes:
             .iter()
             .find(|n| n.id == "ab000001")
             .unwrap();
-        assert!(node.effort.is_none());
+        assert!(node.harnesses.is_empty());
         // Absent ⇒ never serialized (clean file, round-trips by absence).
         let serialized = serde_yaml::to_string(&result.pipeline).unwrap();
         assert!(!serialized.contains("effort:"));

--- a/crates/pdo-daemon/src/pipeline_migrator.rs
+++ b/crates/pdo-daemon/src/pipeline_migrator.rs
@@ -87,6 +87,13 @@ fn needs_migration(yaml_value: &serde_yaml::Value) -> bool {
         return true;
     }
     for node in nodes {
+        // #550/ADR-0046: a flat `model:` / `effort:` on ANY node (including a
+        // `merge` node, which spawns an agent) migrates under `harnesses.claude.*`.
+        // Checked before the structural-node `continue` below so a `merge` node's
+        // flat fields are not skipped.
+        if node.get("model").is_some() || node.get("effort").is_some() {
+            return true;
+        }
         let node_type = node.get("type").and_then(|v| v.as_str()).unwrap_or("");
         if matches!(node_type, "start" | "end" | "switch" | "loop" | "merge") {
             continue;
@@ -338,6 +345,20 @@ pub(crate) fn migrate_pipeline_yaml(
     }
 
     inject_start_end_nodes(&mut doc);
+
+    // #550/ADR-0046: fold every node's flat `model:` / `effort:` into
+    // `harnesses.claude.*`, removing the flat keys. Reuses the exact fold
+    // `pipeline::normalize_node_value` runs, so a persisted rewrite and an
+    // in-memory parse agree — and it is idempotent (an already-folded node is a
+    // no-op). Runs after `inject_start_end_nodes` so injected Start/End nodes
+    // (which carry neither) are harmlessly visited too.
+    if let Some(nodes) = doc.get_mut("nodes").and_then(|n| n.as_sequence_mut()) {
+        for node in nodes.iter_mut() {
+            if let Some(mapping) = node.as_mapping_mut() {
+                pipeline::fold_flat_model_effort_into_harnesses(mapping);
+            }
+        }
+    }
 
     let yaml_text =
         serde_yaml::to_string(&doc).map_err(|e| format!("YAML serialize error: {e}"))?;
@@ -1692,6 +1713,105 @@ edges: []
     }
 
     #[test]
+    fn migrates_flat_model_effort_into_harnesses_claude() {
+        // #550/ADR-0046: a pipeline whose only legacy trait is a flat model/effort
+        // must fold them under `harnesses.claude` and drop the flat keys — then a
+        // second run is a no-op (idempotent).
+        let yaml = r#"
+name: test
+version: "1.0"
+nodes:
+  - id: start
+    name: Start
+    type: start
+    outputs:
+      - name: user_prompt
+  - id: aBcD1234
+    name: implementer
+    type: code-mutating
+    model: opus
+    effort: low
+    outputs:
+      - name: code
+        side: right
+    view: { x: 100, y: 160 }
+  - id: end
+    name: End
+    type: end
+    inputs:
+      - name: result
+edges: []
+"#;
+        let result = migrate_pipeline_yaml(yaml, Path::new("/tmp/test.yaml")).unwrap();
+        assert!(
+            result.migrated,
+            "a flat model/effort must trigger migration"
+        );
+        let parsed: serde_yaml::Value = serde_yaml::from_str(&result.yaml_text).unwrap();
+        let node = parsed["nodes"]
+            .as_sequence()
+            .unwrap()
+            .iter()
+            .find(|n| n["name"].as_str() == Some("implementer"))
+            .unwrap();
+        assert!(node.get("model").is_none(), "flat model removed");
+        assert!(node.get("effort").is_none(), "flat effort removed");
+        assert_eq!(node["harnesses"]["claude"]["model"].as_str(), Some("opus"));
+        assert_eq!(node["harnesses"]["claude"]["effort"].as_str(), Some("low"));
+
+        // Idempotent: re-running the migrated YAML is a no-op.
+        let again = migrate_pipeline_yaml(&result.yaml_text, Path::new("/tmp/test.yaml")).unwrap();
+        assert!(
+            !again.migrated,
+            "an already-folded pipeline must not migrate again"
+        );
+    }
+
+    #[test]
+    fn migrates_flat_model_effort_on_a_merge_node() {
+        // #550: a `merge` node spawns an agent, so its flat model/effort migrate too
+        // — the `needs_migration` clause runs before the structural-node `continue`.
+        let yaml = r#"
+name: test
+version: "1.0"
+nodes:
+  - id: start
+    name: Start
+    type: start
+    outputs:
+      - name: user_prompt
+  - id: aBcD1234
+    name: merger
+    type: merge
+    model: sonnet
+    outputs:
+      - name: merged
+        side: right
+    view: { x: 100, y: 160 }
+  - id: end
+    name: End
+    type: end
+    inputs:
+      - name: result
+edges: []
+"#;
+        let result = migrate_pipeline_yaml(yaml, Path::new("/tmp/test.yaml")).unwrap();
+        assert!(result.migrated, "a merge node's flat model must migrate");
+        let parsed: serde_yaml::Value = serde_yaml::from_str(&result.yaml_text).unwrap();
+        let node = parsed["nodes"]
+            .as_sequence()
+            .unwrap()
+            .iter()
+            .find(|n| n["name"].as_str() == Some("merger"))
+            .unwrap();
+        assert!(node.get("model").is_none());
+        assert_eq!(
+            node["harnesses"]["claude"]["model"].as_str(),
+            Some("sonnet")
+        );
+    }
+
+    #[test]
     fn drops_declared_inputs_on_regular_nodes() {
         // #149: inputs are emergent (derived from edges). The migrator strips the
         // now-redundant declared `inputs` from doc-only / code-mutating nodes.
@@ -2347,8 +2467,8 @@ edges:
             view: None,
             max_iter: None,
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         }
     }
 
@@ -2379,8 +2499,8 @@ edges:
             view: None,
             max_iter: None,
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         }
     }
 
@@ -2411,8 +2531,8 @@ edges:
             view: None,
             max_iter: None,
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         }
     }
 

--- a/crates/pdo-daemon/src/pipeline_semantics.rs
+++ b/crates/pdo-daemon/src/pipeline_semantics.rs
@@ -137,12 +137,16 @@ struct NodeProjection<'a> {
     name: &'a str,
     node_type: &'a NodeType,
     interactive: bool,
-    model: Option<&'a str>,
-    /// Per-node reasoning-effort override (#424). Semantic for the same reason as
-    /// `model`: it changes how the agent behaves, so a pipeline that differs only
-    /// by an effort level is *not* the same pipeline — the library drift badge and
-    /// the pipeline diff must both see it.
-    effort: Option<&'a str>,
+    /// Pinned harness (#550, ADR-0046). Semantic: pinning a node to `opencode`
+    /// changes what runs it, so a pipeline that differs only by a pin is *not* the
+    /// same pipeline.
+    pin_harness: Option<&'a str>,
+    /// Per-harness `{model, effort}` map (#550, ADR-0046) — replaces the flat
+    /// `model:`/`effort:` of #296/#424. Semantic for the same reason: it changes
+    /// how the agent behaves, so the library drift badge and the pipeline diff must
+    /// both see it. A `BTreeMap` so the canonical form is key-ordered; empty ⇒
+    /// serialized as `{}` (a plain claude node with no settings).
+    harnesses: &'a std::collections::BTreeMap<String, crate::harness_resolver::HarnessEntry>,
     max_iter: Option<serde_json::Value>,
     /// Legacy per-node collection driver. The frontend serializer no longer emits
     /// it, so it is absent from `SEMANTIC_FIELDS.node`; it is still a behavioural
@@ -164,8 +168,8 @@ impl<'a> NodeProjection<'a> {
             view,
             max_iter,
             over,
-            model,
-            effort,
+            pin_harness,
+            harnesses,
         } = node;
         let _layout = view; // LAYOUT_FIELDS["node"]
         Self {
@@ -173,8 +177,8 @@ impl<'a> NodeProjection<'a> {
             name,
             node_type,
             interactive: *interactive,
-            model: model.as_deref(),
-            effort: effort.as_deref(),
+            pin_harness: pin_harness.as_deref(),
+            harnesses,
             max_iter: max_iter.as_ref().map(canon_yaml),
             over: over.as_deref(),
             inputs: inputs.iter().map(PortProjection::of).collect(),
@@ -462,6 +466,26 @@ mod tests {
                 // launch a stale copy believing it current.
                 "per-node effort",
                 base.replace("  type: doc-only", "  type: doc-only\n  effort: low"),
+            ),
+            (
+                // #550/ADR-0046: a pinned harness changes what runs the node, so it
+                // is a semantic change — the library drift badge and the diff see it.
+                "pin_harness",
+                base.replace(
+                    "  type: doc-only",
+                    "  type: doc-only\n  pin_harness: opencode",
+                ),
+            ),
+            (
+                // #550/ADR-0046: the per-harness `{model, effort}` map is semantic
+                // (it replaces the flat model/effort). Authored directly under
+                // `harnesses.claude` here (not folded from a flat key) to pin the map
+                // projection itself.
+                "harnesses map",
+                base.replace(
+                    "  type: doc-only",
+                    "  type: doc-only\n  harnesses:\n    claude:\n      model: opus",
+                ),
             ),
             (
                 "edge condition",

--- a/crates/pdo-daemon/src/project_store.rs
+++ b/crates/pdo-daemon/src/project_store.rs
@@ -1,0 +1,456 @@
+//! Persistence for **Projets** — a named grouping of member repository paths,
+//! and the middle tier of the harness precedence axis (ADR-0046, #552).
+//!
+//! A Projet is materialised **on demand**: no row exists until a human names a
+//! group or attaches a setting (ADR-0046, same posture as the price table of
+//! ADR-0034 — nothing is ever seeded). Membership is a **verbatim** path
+//! comparison — a repo path is never canonicalised (ADR-0033), so two spellings
+//! of the same path are two paths and nothing reconciles them silently. A path
+//! belongs to **at most one** Projet; a second attach is a **refusal that names
+//! the owning Projet**, rendered before any write.
+//!
+//! Idiom of `trigger_store` / `instance_config`: SQLite, nullable columns for
+//! what the Projet carries (its optional `harness`). Two tables:
+//!
+//! - `projects` — identity (`id`, `name`) plus the optional `harness` it carries
+//!   (the first per-Projet setting, ADR-0046).
+//! - `project_members` — `path` → `project_id`, with `path` as the PRIMARY KEY so
+//!   "at most one Projet per path" is a **schema invariant**, not merely a code
+//!   check. The named refusal is still computed in code (a bare PK conflict could
+//!   not name the owner).
+//!
+//! The Projet of a Run is the one that owns its **primary** repo path; a
+//! secondary repo (ADR-0042) is never consulted here, so adding or removing one
+//! can change neither the Projet nor the resolved harness. That property lives at
+//! the spawn seam (which passes the primary path only) — this store just answers
+//! "who owns this exact path".
+
+use serde::{Deserialize, Serialize};
+use sqlx::{Row, SqlitePool};
+
+/// A persisted Projet: a named group of member paths and the optional harness it
+/// carries. `harness` is `None` when the Projet names no harness (the tier is
+/// then transparent to resolution). `members` is the verbatim member-path list,
+/// ordered by attach time.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct Project {
+    pub id: String,
+    pub name: String,
+    /// The harness this Projet carries (ADR-0046), or `None`. Stored nullable;
+    /// there is no env/default tier for a per-Projet harness, so this is the
+    /// degenerate `stored → None`. An empty string is treated as "unset" by the
+    /// resolver seam (the `Some("")` trap of #347).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub harness: Option<String>,
+    /// Member repository paths, compared **verbatim** (ADR-0033). Ordered by
+    /// attach time (the `rowid` of `project_members`).
+    #[serde(default)]
+    pub members: Vec<String>,
+}
+
+/// The outcome of attaching a path to a Projet — the "at most one Projet per
+/// path" invariant expressed as data so the API can render the named refusal.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum AddMember {
+    /// The path was newly attached to the Projet.
+    Added,
+    /// The path was already a member of **this** Projet — an idempotent no-op.
+    AlreadyMember,
+    /// The path is already a member of **another** Projet. No write happened; the
+    /// owning Projet is named so the caller can say which one (AC: "refus nommant
+    /// le Projet propriétaire, avant tout effet").
+    Refused {
+        owner_id: String,
+        owner_name: String,
+    },
+}
+
+/// Create the `projects` and `project_members` tables if they do not exist.
+///
+/// Both are brand-new tables (like `sandbox_profiles` / `audit_log`), so a plain
+/// `CREATE TABLE IF NOT EXISTS` is the whole migration — natively idempotent,
+/// needing no PRAGMA-guarded `ALTER` (there is no earlier shape to migrate from).
+pub(crate) async fn init(db: &SqlitePool) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS projects (
+            id         TEXT PRIMARY KEY,
+            name       TEXT NOT NULL,
+            harness    TEXT,
+            created_at TEXT NOT NULL
+        )",
+    )
+    .execute(db)
+    .await?;
+
+    // `path` is the PRIMARY KEY: at-most-one-Projet-per-path is a schema
+    // invariant. `project_id` is indexed for the members-of lookup. No FK
+    // ON DELETE cascade — deletes clear members explicitly (portable, and the
+    // daemon never enables `PRAGMA foreign_keys`).
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS project_members (
+            path       TEXT PRIMARY KEY,
+            project_id TEXT NOT NULL,
+            created_at TEXT NOT NULL
+        )",
+    )
+    .execute(db)
+    .await?;
+
+    sqlx::query(
+        "CREATE INDEX IF NOT EXISTS idx_project_members_project ON project_members(project_id)",
+    )
+    .execute(db)
+    .await?;
+
+    Ok(())
+}
+
+/// Generate a Projet id (`prj-<ts>-<short uuid>`), mirroring `trigger_store`.
+pub(crate) fn generate_project_id() -> String {
+    let ts = chrono::Utc::now().format("%Y%m%d-%H%M%S");
+    let short = &uuid::Uuid::new_v4().to_string()[..7];
+    format!("prj-{ts}-{short}")
+}
+
+fn row_to_project(row: &sqlx::sqlite::SqliteRow, members: Vec<String>) -> Project {
+    Project {
+        id: row.get("id"),
+        name: row.get("name"),
+        harness: row
+            .get::<Option<String>, _>("harness")
+            .filter(|s| !s.is_empty()),
+        members,
+    }
+}
+
+/// Load the member paths of one Projet, ordered by attach time.
+async fn members_of(db: &SqlitePool, project_id: &str) -> Result<Vec<String>, sqlx::Error> {
+    let rows =
+        sqlx::query("SELECT path FROM project_members WHERE project_id = ? ORDER BY rowid ASC")
+            .bind(project_id)
+            .fetch_all(db)
+            .await?;
+    Ok(rows.iter().map(|r| r.get::<String, _>("path")).collect())
+}
+
+/// Insert a new (empty, harness-less) Projet with the given name, returning the
+/// stored row. Materialisation on naming (ADR-0046): this is the only path that
+/// creates a `projects` row from a bare name.
+pub(crate) async fn create(db: &SqlitePool, name: &str) -> Result<Project, sqlx::Error> {
+    let id = generate_project_id();
+    let now = crate::event_log::now_iso();
+    sqlx::query("INSERT INTO projects (id, name, harness, created_at) VALUES (?, ?, NULL, ?)")
+        .bind(&id)
+        .bind(name)
+        .bind(&now)
+        .execute(db)
+        .await?;
+    Ok(Project {
+        id,
+        name: name.to_string(),
+        harness: None,
+        members: Vec::new(),
+    })
+}
+
+/// All Projets with their member lists, newest first.
+pub(crate) async fn list(db: &SqlitePool) -> Result<Vec<Project>, sqlx::Error> {
+    let rows = sqlx::query("SELECT * FROM projects ORDER BY created_at DESC")
+        .fetch_all(db)
+        .await?;
+    let mut projects = Vec::with_capacity(rows.len());
+    for row in &rows {
+        let id: String = row.get("id");
+        let members = members_of(db, &id).await?;
+        projects.push(row_to_project(row, members));
+    }
+    Ok(projects)
+}
+
+/// One Projet by id, with its members. `None` ⇒ no such Projet.
+pub(crate) async fn get(db: &SqlitePool, id: &str) -> Result<Option<Project>, sqlx::Error> {
+    let row = sqlx::query("SELECT * FROM projects WHERE id = ?")
+        .bind(id)
+        .fetch_optional(db)
+        .await?;
+    match row {
+        Some(row) => {
+            let members = members_of(db, id).await?;
+            Ok(Some(row_to_project(&row, members)))
+        }
+        None => Ok(None),
+    }
+}
+
+/// Rename a Projet. Returns `true` iff a row was updated.
+pub(crate) async fn rename(db: &SqlitePool, id: &str, name: &str) -> Result<bool, sqlx::Error> {
+    let res = sqlx::query("UPDATE projects SET name = ? WHERE id = ?")
+        .bind(name)
+        .bind(id)
+        .execute(db)
+        .await?;
+    Ok(res.rows_affected() > 0)
+}
+
+/// Set (or clear, with `None`) the harness a Projet carries. Returns `true` iff a
+/// row was updated. An empty string is stored as `NULL` — a blank never carries a
+/// harness (the `Some("")` trap of #347), matching the resolver's floor-through.
+pub(crate) async fn set_harness(
+    db: &SqlitePool,
+    id: &str,
+    harness: Option<&str>,
+) -> Result<bool, sqlx::Error> {
+    let stored = harness.filter(|s| !s.is_empty());
+    let res = sqlx::query("UPDATE projects SET harness = ? WHERE id = ?")
+        .bind(stored)
+        .bind(id)
+        .execute(db)
+        .await?;
+    Ok(res.rows_affected() > 0)
+}
+
+/// The Projet that currently owns `path`, if any. Read-then-decide basis for the
+/// named refusal, and re-usable as a plain lookup. Compared **verbatim**.
+pub(crate) async fn owner_of(db: &SqlitePool, path: &str) -> Result<Option<Project>, sqlx::Error> {
+    let row = sqlx::query("SELECT project_id FROM project_members WHERE path = ?")
+        .bind(path)
+        .fetch_optional(db)
+        .await?;
+    match row {
+        Some(row) => get(db, &row.get::<String, _>("project_id")).await,
+        None => Ok(None),
+    }
+}
+
+/// Attach a member path to a Projet, enforcing at-most-one membership **before
+/// any write**. A path already owned by a *different* Projet is refused, naming
+/// the owner; a re-attach to the same Projet is an idempotent no-op.
+pub(crate) async fn add_member(
+    db: &SqlitePool,
+    project_id: &str,
+    path: &str,
+) -> Result<AddMember, sqlx::Error> {
+    if let Some(owner) = owner_of(db, path).await? {
+        if owner.id == project_id {
+            return Ok(AddMember::AlreadyMember);
+        }
+        return Ok(AddMember::Refused {
+            owner_id: owner.id,
+            owner_name: owner.name,
+        });
+    }
+    let now = crate::event_log::now_iso();
+    sqlx::query("INSERT INTO project_members (path, project_id, created_at) VALUES (?, ?, ?)")
+        .bind(path)
+        .bind(project_id)
+        .bind(&now)
+        .execute(db)
+        .await?;
+    Ok(AddMember::Added)
+}
+
+/// Detach a member path from **any** Projet (the path is globally unique). Returns
+/// `true` iff a membership row was removed.
+pub(crate) async fn remove_member(db: &SqlitePool, path: &str) -> Result<bool, sqlx::Error> {
+    let res = sqlx::query("DELETE FROM project_members WHERE path = ?")
+        .bind(path)
+        .execute(db)
+        .await?;
+    Ok(res.rows_affected() > 0)
+}
+
+/// Delete a Projet and all its memberships. Returns `true` iff a Projet row was
+/// removed. Used when a group is un-named back to its derived label.
+pub(crate) async fn delete(db: &SqlitePool, id: &str) -> Result<bool, sqlx::Error> {
+    sqlx::query("DELETE FROM project_members WHERE project_id = ?")
+        .bind(id)
+        .execute(db)
+        .await?;
+    let res = sqlx::query("DELETE FROM projects WHERE id = ?")
+        .bind(id)
+        .execute(db)
+        .await?;
+    Ok(res.rows_affected() > 0)
+}
+
+/// Resolve the harness a `path` inherits from its Projet, for the `project` tier
+/// of [`crate::harness_resolver`]. `None` ⇒ the path is in no Projet, or its
+/// Projet carries no harness — the tier is transparent either way. An empty
+/// stored harness is already normalised to `None` by [`owner_of`] → [`get`].
+pub(crate) async fn harness_for_path(
+    db: &SqlitePool,
+    path: &str,
+) -> Result<Option<String>, sqlx::Error> {
+    Ok(owner_of(db, path).await?.and_then(|p| p.harness))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn mem_db() -> SqlitePool {
+        let db = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        init(&db).await.unwrap();
+        db
+    }
+
+    #[tokio::test]
+    async fn init_is_idempotent() {
+        // The "migration de table idempotente" AC: running init twice on the same
+        // pool is a no-op, never an error (mirror of trigger_store's guarantee).
+        let db = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        init(&db).await.unwrap();
+        init(&db).await.unwrap();
+        // And a project created before the second init survives it.
+        let p = create(&db, "P").await.unwrap();
+        init(&db).await.unwrap();
+        assert!(get(&db, &p.id).await.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn no_row_exists_before_naming() {
+        // AC: aucune ligne de Projet tant qu'un humain n'a pas nommé un groupe.
+        // A fresh store has zero rows and no path is owned.
+        let db = mem_db().await;
+        assert!(list(&db).await.unwrap().is_empty());
+        assert!(owner_of(&db, "/repos/front").await.unwrap().is_none());
+        assert!(harness_for_path(&db, "/repos/front")
+            .await
+            .unwrap()
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn a_path_cannot_belong_to_two_projects_refusal_names_the_owner() {
+        // AC: un chemin déjà membre ne peut pas être ajouté à un second — refus
+        // nommant le propriétaire, avant tout effet.
+        let db = mem_db().await;
+        let a = create(&db, "Alpha").await.unwrap();
+        let b = create(&db, "Bravo").await.unwrap();
+
+        assert_eq!(
+            add_member(&db, &a.id, "/repos/front").await.unwrap(),
+            AddMember::Added
+        );
+        // Second attach to a DIFFERENT project: refused, naming Alpha.
+        match add_member(&db, &b.id, "/repos/front").await.unwrap() {
+            AddMember::Refused {
+                owner_id,
+                owner_name,
+            } => {
+                assert_eq!(owner_id, a.id);
+                assert_eq!(owner_name, "Alpha");
+            }
+            other => panic!("expected refusal naming the owner, got {other:?}"),
+        }
+        // …and BEFORE any effect: Bravo gained no member.
+        assert!(get(&db, &b.id).await.unwrap().unwrap().members.is_empty());
+        // The path still belongs to Alpha only.
+        assert_eq!(
+            owner_of(&db, "/repos/front").await.unwrap().unwrap().id,
+            a.id
+        );
+    }
+
+    #[tokio::test]
+    async fn re_attaching_to_the_same_project_is_an_idempotent_noop() {
+        let db = mem_db().await;
+        let a = create(&db, "Alpha").await.unwrap();
+        assert_eq!(
+            add_member(&db, &a.id, "/repos/front").await.unwrap(),
+            AddMember::Added
+        );
+        assert_eq!(
+            add_member(&db, &a.id, "/repos/front").await.unwrap(),
+            AddMember::AlreadyMember
+        );
+        assert_eq!(
+            get(&db, &a.id).await.unwrap().unwrap().members,
+            vec!["/repos/front".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn membership_comparison_is_verbatim() {
+        // ADR-0033: two spellings of the same path are two paths — nothing
+        // reconciles them. A trailing slash makes a distinct, unowned key.
+        let db = mem_db().await;
+        let a = create(&db, "Alpha").await.unwrap();
+        add_member(&db, &a.id, "/repos/front").await.unwrap();
+        assert!(owner_of(&db, "/repos/front").await.unwrap().is_some());
+        assert!(owner_of(&db, "/repos/front/").await.unwrap().is_none());
+        assert!(owner_of(&db, "/repos/FRONT").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn harness_for_path_reads_the_owning_projects_harness() {
+        // The `project` tier the spawn seam reads: a member path inherits its
+        // Projet's harness; a blank harness collapses to None (#347).
+        let db = mem_db().await;
+        let a = create(&db, "Alpha").await.unwrap();
+        add_member(&db, &a.id, "/repos/front").await.unwrap();
+        add_member(&db, &a.id, "/repos/back").await.unwrap();
+
+        assert!(harness_for_path(&db, "/repos/front")
+            .await
+            .unwrap()
+            .is_none());
+        assert!(set_harness(&db, &a.id, Some("opencode")).await.unwrap());
+        assert_eq!(
+            harness_for_path(&db, "/repos/front")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("opencode")
+        );
+        // Both members inherit it — a Projet setting is posed once for its repos.
+        assert_eq!(
+            harness_for_path(&db, "/repos/back")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("opencode")
+        );
+        // A non-member path inherits nothing.
+        assert!(harness_for_path(&db, "/repos/other")
+            .await
+            .unwrap()
+            .is_none());
+        // Clearing the harness (empty string → NULL) makes the tier transparent.
+        assert!(set_harness(&db, &a.id, Some("")).await.unwrap());
+        assert!(harness_for_path(&db, "/repos/front")
+            .await
+            .unwrap()
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn rename_and_delete() {
+        let db = mem_db().await;
+        let a = create(&db, "Alpha").await.unwrap();
+        add_member(&db, &a.id, "/repos/front").await.unwrap();
+
+        assert!(rename(&db, &a.id, "Renamed").await.unwrap());
+        assert_eq!(get(&db, &a.id).await.unwrap().unwrap().name, "Renamed");
+
+        // Deleting a Projet frees its member paths for another Projet.
+        assert!(delete(&db, &a.id).await.unwrap());
+        assert!(get(&db, &a.id).await.unwrap().is_none());
+        assert!(owner_of(&db, "/repos/front").await.unwrap().is_none());
+        let b = create(&db, "Bravo").await.unwrap();
+        assert_eq!(
+            add_member(&db, &b.id, "/repos/front").await.unwrap(),
+            AddMember::Added
+        );
+    }
+
+    #[tokio::test]
+    async fn remove_member_frees_the_path() {
+        let db = mem_db().await;
+        let a = create(&db, "Alpha").await.unwrap();
+        add_member(&db, &a.id, "/repos/front").await.unwrap();
+        assert!(remove_member(&db, "/repos/front").await.unwrap());
+        assert!(owner_of(&db, "/repos/front").await.unwrap().is_none());
+        assert!(!remove_member(&db, "/repos/front").await.unwrap());
+    }
+}

--- a/crates/pdo-daemon/src/prompt_augmenter.rs
+++ b/crates/pdo-daemon/src/prompt_augmenter.rs
@@ -978,8 +978,8 @@ mod tests {
                 view: None,
                 max_iter: None,
                 over: None,
-                model: None,
-                effort: None,
+                pin_harness: None,
+                harnesses: Default::default(),
             }],
             edges: vec![],
             loops: Vec::new(),
@@ -1121,8 +1121,8 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         });
         pipeline.edges.push(EdgeDef {
             source: EdgeEndpoint {
@@ -1258,8 +1258,8 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         });
         pipeline.edges.push(EdgeDef {
             source: EdgeEndpoint {
@@ -1318,8 +1318,8 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         });
 
         let node = &pipeline.nodes[1]; // implementer
@@ -1350,8 +1350,8 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         });
         pipeline.edges.push(EdgeDef {
             source: EdgeEndpoint {
@@ -1396,8 +1396,8 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         });
         pipeline.edges.push(EdgeDef {
             source: EdgeEndpoint {
@@ -1546,8 +1546,8 @@ mod tests {
                     view: None,
                     max_iter: None,
                     over: None,
-                    model: None,
-                    effort: None,
+                    pin_harness: None,
+                    harnesses: Default::default(),
                 },
                 NodeDef {
                     id: "researcher".into(),
@@ -1567,8 +1567,8 @@ mod tests {
                     view: None,
                     max_iter: None,
                     over: None,
-                    model: None,
-                    effort: None,
+                    pin_harness: None,
+                    harnesses: Default::default(),
                 },
                 NodeDef {
                     id: "implementer".into(),
@@ -1607,8 +1607,8 @@ mod tests {
                     view: None,
                     max_iter: None,
                     over: None,
-                    model: None,
-                    effort: None,
+                    pin_harness: None,
+                    harnesses: Default::default(),
                 },
             ],
             edges: vec![
@@ -1716,8 +1716,8 @@ mod tests {
                 view: None,
                 max_iter: None,
                 over: None,
-                model: None,
-                effort: None,
+                pin_harness: None,
+                harnesses: Default::default(),
             }],
             edges: vec![],
             loops: Vec::new(),
@@ -1975,8 +1975,8 @@ mod tests {
                 view: None,
                 max_iter: None,
                 over: None,
-                model: None,
-                effort: None,
+                pin_harness: None,
+                harnesses: Default::default(),
             }],
             edges: vec![],
             loops: Vec::new(),
@@ -2026,8 +2026,8 @@ mod tests {
                 view: None,
                 max_iter: None,
                 over: None,
-                model: None,
-                effort: None,
+                pin_harness: None,
+                harnesses: Default::default(),
             }],
             edges: vec![],
             loops: Vec::new(),
@@ -2072,8 +2072,8 @@ mod tests {
                 view: None,
                 max_iter: None,
                 over: None,
-                model: None,
-                effort: None,
+                pin_harness: None,
+                harnesses: Default::default(),
             }],
             edges: vec![],
             loops: Vec::new(),

--- a/crates/pdo-daemon/src/run_advance.rs
+++ b/crates/pdo-daemon/src/run_advance.rs
@@ -477,8 +477,8 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         }
     }
 

--- a/crates/pdo-daemon/src/run_command.rs
+++ b/crates/pdo-daemon/src/run_command.rs
@@ -2285,8 +2285,8 @@ mod tests {
                 view: None,
                 max_iter: None,
                 over: None,
-                model: None,
-                effort: None,
+                pin_harness: None,
+                harnesses: Default::default(),
             }],
             edges: vec![EdgeDef {
                 source: EdgeEndpoint {
@@ -2338,8 +2338,8 @@ mod tests {
                 view: None,
                 max_iter: None,
                 over: None,
-                model: None,
-                effort: None,
+                pin_harness: None,
+                harnesses: Default::default(),
             }],
             edges: vec![EdgeDef {
                 source: EdgeEndpoint {

--- a/crates/pdo-daemon/src/run_command.rs
+++ b/crates/pdo-daemon/src/run_command.rs
@@ -1381,6 +1381,15 @@ async fn dispatch(state: Arc<AppState>, run_id: String, cmd: RunCommand) -> Resp
                 // Side effect, intended: a profile deleted since makes the retry 400,
                 // loudly, instead of quietly running something else.
                 sandbox: Some(run_state.sandbox.clone()),
+                // #551 (ADR-0046): a retry is a new Run, but it must reproduce the
+                // original's harness — an A/B comparison that silently reverted to the
+                // instance default on retry would be worthless. The frozen harness is
+                // projected from the original's `RunStarted`; `None` (the Run named no
+                // harness) forwards as `None`, so the retry resolves through the instance
+                // default exactly as the original did. Unlike `sandbox` this needs no
+                // `Some`-wrapping-for-explicit dance: the create chokepoint freezes
+                // `req.harness` verbatim, with no precedence resolution of its own.
+                harness: run_state.harness.clone(),
                 // #338: pin the historical retry behaviour exactly. A retry has always
                 // set `name: None` and re-derived the name (placeholder or from input);
                 // `Some(true)` reproduces that regardless of the instance default, so a

--- a/crates/pdo-daemon/src/run_cost.rs
+++ b/crates/pdo-daemon/src/run_cost.rs
@@ -172,7 +172,74 @@ fn aggregate(lines: impl Iterator<Item = Line>, prices: &PriceTable) -> CostStat
         usd,
         partial: !unpriced_models.is_empty(),
         unpriced_models,
+        // The aggregate is transcript-derived — i.e. it already ran because the
+        // Run's harness HAS a cost source. Absent-cost-source harnesses never reach
+        // this fold; they are handled one layer up in [`run_cost_or_absence`], which
+        // returns a "—"-with-reason `CostStat` before any transcript is read.
+        uncosted_harnesses: Vec::new(),
     }
+}
+
+/// The distinct harnesses this Run launched a node on that have **no cost source**
+/// capability (#553) — sorted, deduplicated. Read off the `NodeStarted` payloads
+/// (the frozen-at-spawn harness, ADR-0046), never the current YAML. A `null`
+/// harness (a `script` node, or any pre-#550 row) is the `claude` floor, which HAS
+/// a cost source, so it never lands here — only an explicit `opencode` or a
+/// data-declared harness does.
+pub(crate) fn uncosted_harnesses(events: &[crate::event_log::Event]) -> Vec<String> {
+    let mut names: BTreeSet<String> = BTreeSet::new();
+    for e in events {
+        if e.kind != crate::event_log::EventKind::NodeStarted {
+            continue;
+        }
+        let Some(harness) = e
+            .payload
+            .as_ref()
+            .and_then(|p| p.get("harness"))
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+        else {
+            continue; // null harness ⇒ the claude floor ⇒ has a cost source
+        };
+        if !crate::harness_probes::can_cost(harness) {
+            names.insert(harness.to_string());
+        }
+    }
+    names.into_iter().collect()
+}
+
+/// The Run's cost, made **honest about harnesses without a cost source** (#553).
+///
+/// If any node ran on a harness PDO cannot cost, the Run's aggregate is not
+/// honestly summable — adding `claude`'s real dollars to that harness's invisible
+/// $0 would be a silent under-count — so this returns `Some(CostStat)` carrying
+/// **`uncosted_harnesses`** and no dollars, which the surfaces render as "—" with a
+/// reason (never `$0`, never a mute `partial`). Otherwise it is exactly
+/// [`compute_run_cost`].
+///
+/// `events` is the Run's event-log snapshot (for the frozen harnesses); the rest
+/// is [`compute_run_cost`]'s signature verbatim.
+pub(crate) fn run_cost_or_absence(
+    events: &[crate::event_log::Event],
+    projects_root: &Path,
+    repo_root: &Path,
+    run_id: &str,
+    prices: &PriceTable,
+) -> Option<CostStat> {
+    let uncosted = uncosted_harnesses(events);
+    if !uncosted.is_empty() {
+        return Some(CostStat {
+            usd: 0.0,
+            // NOT `partial`: `partial` means "priced, but a lower bound" and still
+            // shows a dollar figure. This is a categorically different state — the
+            // aggregate is unavailable, not merely incomplete — so it stays out of
+            // the `partial ⟺ !unpriced_models.is_empty()` invariant (both empty).
+            partial: false,
+            unpriced_models: Vec::new(),
+            uncosted_harnesses: uncosted,
+        });
+    }
+    compute_run_cost(projects_root, repo_root, run_id, prices)
 }
 
 /// Encode an absolute path exactly as Claude Code names its `~/.claude/projects`
@@ -917,5 +984,83 @@ mod tests {
 
         // Querying "run-1" must NOT pick up "run-1x"'s transcript.
         assert!(compute_run_cost(&projects, repo.path(), "run-1", &builtin()).is_none());
+    }
+
+    // --- run_cost_or_absence / uncosted_harnesses (#553) ---
+    //
+    // The test that guarantees "absence is said": a Run on a harness with no cost
+    // source shows "—" and a reason, never `0`.
+
+    use crate::event_log::{Event, EventKind};
+
+    fn node_started(node: &str, harness: Option<&str>) -> Event {
+        Event {
+            id: None,
+            run_id: "r".into(),
+            ts: crate::event_log::now_iso(),
+            kind: EventKind::NodeStarted,
+            node_id: Some(node.into()),
+            iter: Some(1),
+            payload: Some(serde_json::json!({ "harness": harness })),
+        }
+    }
+
+    #[test]
+    fn uncosted_harnesses_names_only_the_harnesses_without_a_cost_source() {
+        let events = vec![
+            node_started("a", Some("claude")),   // has a cost source
+            node_started("b", Some("opencode")), // none
+            node_started("c", None),             // script/legacy ⇒ claude floor ⇒ costed
+            node_started("d", Some("opencode")), // duplicate ⇒ deduped
+        ];
+        assert_eq!(uncosted_harnesses(&events), vec!["opencode".to_string()]);
+    }
+
+    #[test]
+    fn run_cost_or_absence_is_dash_with_reason_not_zero_for_an_uncosted_harness() {
+        // A Run with an `opencode` node: no transcript need even be read — the
+        // aggregate is not honestly summable, so cost is "—" (usd 0, NOT partial)
+        // and names the harness.
+        let home = tempfile::tempdir().unwrap();
+        let projects = home.path().join(".claude").join("projects");
+        std::fs::create_dir_all(&projects).unwrap();
+        let repo = tempfile::tempdir().unwrap();
+        let events = vec![node_started("n", Some("opencode"))];
+
+        let cost = run_cost_or_absence(&events, &projects, repo.path(), "run-x", &builtin())
+            .expect("an uncosted harness yields Some(—), not a bare None");
+        assert_eq!(cost.usd, 0.0);
+        assert!(!cost.partial, "not a lower bound — it is unavailable");
+        assert!(cost.unpriced_models.is_empty());
+        // The offender is NAMED (the frontend builds the "— because opencode has no
+        // cost source" sentence from this, the same way it names `unpriced_models`).
+        assert_eq!(cost.uncosted_harnesses, vec!["opencode".to_string()]);
+    }
+
+    #[test]
+    fn run_cost_or_absence_is_plain_compute_run_cost_for_an_all_claude_run() {
+        // The negative control: a claude Run (and a script node) costs exactly as
+        // before — no `uncosted_harnesses`, real dollars.
+        let home = tempfile::tempdir().unwrap();
+        let projects = home.path().join(".claude").join("projects");
+        let repo = tempfile::tempdir().unwrap();
+        let run_id = "claude-run";
+        seed_transcript(
+            &projects,
+            repo.path(),
+            run_id,
+            &assistant("m1", "r1", "claude-opus-4-8", 1_000_000, 0),
+        );
+        let events = vec![node_started("n", Some("claude")), node_started("s", None)];
+
+        let honest =
+            run_cost_or_absence(&events, &projects, repo.path(), run_id, &builtin()).unwrap();
+        let plain = compute_run_cost(&projects, repo.path(), run_id, &builtin()).unwrap();
+        assert_eq!(
+            honest, plain,
+            "an all-claude Run is byte-identical to before"
+        );
+        assert!(honest.uncosted_harnesses.is_empty());
+        assert!((honest.usd - 5.0).abs() < 1e-9);
     }
 }

--- a/crates/pdo-daemon/src/scheduler.rs
+++ b/crates/pdo-daemon/src/scheduler.rs
@@ -1193,8 +1193,8 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         }
     }
 
@@ -1217,8 +1217,8 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         }
     }
 
@@ -2502,8 +2502,8 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         }
     }
 
@@ -3230,8 +3230,8 @@ mod tests {
                 max_iter,
             ))),
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         }
     }
 
@@ -3755,8 +3755,8 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         }
     }
 

--- a/crates/pdo-daemon/src/scheduler_dispatcher.rs
+++ b/crates/pdo-daemon/src/scheduler_dispatcher.rs
@@ -84,8 +84,8 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         }
     }
 

--- a/crates/pdo-daemon/src/stale_detector.rs
+++ b/crates/pdo-daemon/src/stale_detector.rs
@@ -178,6 +178,37 @@ pub enum Detection {
     Ok,
 }
 
+/// The two harness capabilities the sweep gates its probes on (#553, ADR-0045).
+///
+/// Absent ⇒ the probe **does not run**: no turn-end auto-completion on an invented
+/// heuristic (the substrate is claude's JSONL transcript), and no pane capture for
+/// a usage-limit menu whose wording is proper to another harness. The sweep
+/// ([`crate::lib`]) fills this from [`crate::harness_probes`] for the node's
+/// frozen-at-spawn harness; keeping it a plain two-bool struct here keeps
+/// [`assess_node`] pure and injected, exactly like `autocomplete_turn_end`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HarnessCapabilities {
+    /// The harness has an end-of-turn substrate PDO can read
+    /// ([`crate::harness_probes::HarnessProbes::turn_end_substrate`]).
+    pub turn_end: bool,
+    /// The harness has a usage-limit menu anchor PDO can match
+    /// ([`crate::harness_probes::HarnessProbes::usage_limit_anchor`]).
+    pub usage_limit: bool,
+}
+
+impl HarnessCapabilities {
+    /// Both present — `claude`, and the shape the pre-#553 sweep always assumed.
+    pub const CLAUDE: HarnessCapabilities = HarnessCapabilities {
+        turn_end: true,
+        usage_limit: true,
+    };
+    /// Both absent — a data-declared harness: neither probe runs.
+    pub const NONE: HarnessCapabilities = HarnessCapabilities {
+        turn_end: false,
+        usage_limit: false,
+    };
+}
+
 /// Pure liveness decision: session alive or not (#469 §1).
 ///
 /// This *is* the whole of it now. `session_alive == false` is the single
@@ -665,6 +696,9 @@ fn informational_event(
 ///
 /// `prior_events` is the run's event-log snapshot, used purely for the
 /// rising-edge de-dup of `NodeBlockedOnLimit` (see [`episode_has_event`]).
+// The probe set + policy toggles are all distinct facts a sweep tick needs; the
+// same posture as the four `tmux_session_manager` builders that allow this lint.
+#[allow(clippy::too_many_arguments)]
 pub fn assess_node(
     probes: &impl NodeProbes,
     prior_events: &[event_log::Event],
@@ -673,6 +707,7 @@ pub fn assess_node(
     iter: i64,
     now: SystemTime,
     autocomplete_turn_end: bool,
+    caps: HarnessCapabilities,
 ) -> Assessment {
     let detection = decide(probes.session_alive());
 
@@ -691,9 +726,14 @@ pub fn assess_node(
     // Alive, but maybe wedged on Claude Code's usage-limit menu (#290):
     // observability only — the node keeps running. The gauge counts every sweep
     // the menu is visible; the event is emitted once per (node, iter) episode.
-    let blocked_on_limit = probes
-        .capture_pane()
-        .is_some_and(|pane| detect_usage_limit(&pane));
+    //
+    // #553: the menu anchor is proper to a harness. Gate the probe on the
+    // capability — a harness without it never has its pane captured for a menu
+    // whose wording belongs to another harness (ANDed first, so no pane I/O runs).
+    let blocked_on_limit = caps.usage_limit
+        && probes
+            .capture_pane()
+            .is_some_and(|pane| detect_usage_limit(&pane));
     let events = if blocked_on_limit
         && !episode_has_event(prior_events, &EventKind::NodeBlockedOnLimit, node_id, iter)
     {
@@ -713,7 +753,13 @@ pub fn assess_node(
     // "<prompt>"` does not exit at the end of a turn — it stays in the REPL — so
     // an agent that finished without calling `pdo complete` is alive and
     // motionless, and this is its positive signature.
+    //
+    // #553: the turn-end substrate is a capability. Gate the probe on it — a
+    // harness without it is never auto-completed on an invented heuristic (its
+    // store is not the claude JSONL `parse_turn_state` reads). ANDed BEFORE the
+    // transcript read, so an un-instrumented harness pays no transcript I/O.
     let turn_ended = autocomplete_turn_end
+        && caps.turn_end
         && probes.transcript_tail().is_some_and(|tail| {
             quiet_long_enough(tail.mtime, now)
                 && parse_turn_state(&tail.text) == TurnState::TurnEnded
@@ -1669,6 +1715,9 @@ SwapFree:         204800 kB
     }
 
     fn assess(probes: &FakeProbes, autocomplete: bool) -> Assessment {
+        // The existing suite is about the `claude` sweep, which has both
+        // capabilities; #553's capability gating is exercised by the dedicated
+        // tests below with `HarnessCapabilities::NONE`.
         assess_node(
             probes,
             &[],
@@ -1677,6 +1726,7 @@ SwapFree:         204800 kB
             1,
             SystemTime::now(),
             autocomplete,
+            HarnessCapabilities::CLAUDE,
         )
     }
 
@@ -1884,6 +1934,7 @@ SwapFree:         204800 kB
             1,
             SystemTime::now(),
             true,
+            HarnessCapabilities::CLAUDE,
         );
         assert!(
             a.blocked_on_limit,
@@ -1908,5 +1959,70 @@ SwapFree:         204800 kB
         assert!(a.blocked_on_limit);
         assert_eq!(a.events.len(), 1);
         assert_eq!(a.events[0].kind, EventKind::NodeBlockedOnLimit);
+    }
+
+    // --- #553: capability gating — a data-declared harness runs no probe ---
+
+    fn assess_caps(
+        probes: &FakeProbes,
+        autocomplete: bool,
+        caps: HarnessCapabilities,
+    ) -> Assessment {
+        assess_node(
+            probes,
+            &[],
+            "run1",
+            "worker",
+            1,
+            SystemTime::now(),
+            autocomplete,
+            caps,
+        )
+    }
+
+    #[test]
+    fn a_harness_without_the_turn_end_capability_is_never_auto_completed() {
+        // The node HAS finished its turn with valid outputs and the setting is ON —
+        // but its harness has no turn-end substrate, so the sweep must not complete
+        // it, and must not even read a transcript (the substrate is not claude's).
+        let probes = FakeProbes::finished_turn();
+        let a = assess_caps(&probes, true, HarnessCapabilities::NONE);
+        assert_eq!(
+            a.detection,
+            Detection::Ok,
+            "no auto-completion without the capability"
+        );
+        assert_eq!(
+            probes.tail_calls.get(),
+            0,
+            "no transcript read for an un-instrumented harness"
+        );
+        assert_eq!(probes.validate_calls.get(), 0);
+    }
+
+    #[test]
+    fn a_harness_with_the_turn_end_capability_still_auto_completes() {
+        // The control: with the capability present (and the setting on) the same
+        // finished turn IS completed — the gate is the capability, nothing else.
+        let probes = FakeProbes::finished_turn();
+        let a = assess_caps(&probes, true, HarnessCapabilities::CLAUDE);
+        assert_eq!(a.detection, Detection::TurnEnded);
+    }
+
+    #[test]
+    fn a_harness_without_the_usage_limit_capability_is_never_flagged_blocked() {
+        // The pane shows what WOULD be a usage-limit menu, but this harness has no
+        // such anchor — so the probe short-circuits and the node is not flagged.
+        let probes = FakeProbes {
+            pane: Some("❯ 1. Stop and wait for limit to reset".to_string()),
+            ..FakeProbes::alive()
+        };
+        let a = assess_caps(&probes, true, HarnessCapabilities::NONE);
+        assert_eq!(a.detection, Detection::Ok);
+        assert!(
+            !a.blocked_on_limit,
+            "no menu probe runs without the usage-limit capability"
+        );
+        assert!(a.events.is_empty());
     }
 }

--- a/crates/pdo-daemon/src/stats.rs
+++ b/crates/pdo-daemon/src/stats.rs
@@ -776,6 +776,7 @@ mod tests {
                     usd: 1.0,
                     partial: false,
                     unpriced_models: vec![],
+                    uncosted_harnesses: vec![],
                 }),
             },
             CostRow {
@@ -786,6 +787,7 @@ mod tests {
                     usd: 2.0,
                     partial: true,
                     unpriced_models: vec!["claude-sonnet-5".into()],
+                    uncosted_harnesses: vec![],
                 }),
             },
             CostRow {
@@ -861,6 +863,7 @@ mod tests {
                     usd: 0.0,
                     partial: true,
                     unpriced_models: vec!["claude-sonnet-5".into(), "claude-fable-5".into()],
+                    uncosted_harnesses: vec![],
                 }),
             },
             CostRow {
@@ -871,6 +874,7 @@ mod tests {
                     usd: 0.0,
                     partial: true,
                     unpriced_models: vec!["claude-fable-5".into(), "claude-opus-5".into()],
+                    uncosted_harnesses: vec![],
                 }),
             },
         ];

--- a/crates/pdo-daemon/src/switch_router.rs
+++ b/crates/pdo-daemon/src/switch_router.rs
@@ -58,8 +58,8 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         }
     }
 

--- a/crates/pdo-daemon/src/tmux_session_manager.rs
+++ b/crates/pdo-daemon/src/tmux_session_manager.rs
@@ -70,6 +70,13 @@ pub enum SessionTail<'a> {
     /// Agent node / manager / merge-resolver. `model` is the per-node model
     /// override (#296); `None` ⇒ account default (byte-identical legacy launch).
     Agent {
+        /// The resolved harness descriptor (#550, ADR-0045). Its `launch`
+        /// template renders the tail via [`crate::harness_argv`]; its `env` block
+        /// is exported before the tail (that is where `claude`'s CCR suppression
+        /// now comes from — AC #4). For infra sessions and the byte-identity gate
+        /// this is the `claude` descriptor, whose template reproduces the legacy
+        /// tail exactly once its holes are empty.
+        harness: &'a crate::harness_registry::HarnessDescriptor,
         model: Option<&'a str>,
         /// Per-node reasoning-effort override (#424). `None` *or* an empty string
         /// ⇒ no `--effort`, byte-identical tail. A `Script` tail carries no such
@@ -233,19 +240,35 @@ fn wrap_tail_in_docker_exec(
 /// tmux pane), writes `~/.claude.json`, and force-exits via `kill(getpid(),
 /// SIGKILL)`. That's the "Tester dies silently 20–60 s in" bug.
 ///
-/// `extra_env` are additional `export K=V` pairs injected *after* the base four
-/// and the CCR suppression, before the tail. Agents pass `&[]`, so the emitted
-/// bytes are identical to the legacy command (the #296 byte-identity discipline)
-/// — only `script` nodes populate it with the `PDO_INPUT_*`/`PDO_OUTPUT_*`/…
-/// catalogue.
+/// `harness_env` are the harness descriptor's env pairs (`claude`'s CCR
+/// suppression — AC #4), exported *after* the base four and *before* `extra_env`.
+/// For the `claude` descriptor this is exactly `[(CCR, "1")]`, so the emitted
+/// bytes match the legacy hard-coded `export CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1`
+/// — the value is rendered by [`sh_quote_arg`] (bare-if-safe), which leaves `1`
+/// unquoted, preserving byte-identity. `script` / `shell` tails pass the same
+/// forced `[(CCR, "1")]` (the wrapper still poses it — a hand-typed `claude` in a
+/// run shell depends on it, CONTEXT.md §*Shell de run*).
+///
+/// `extra_env` are additional `export K=V` pairs injected after `harness_env`,
+/// before the tail. Agents pass `&[]`, so the emitted bytes are identical to the
+/// legacy command (the #296 byte-identity discipline) — only `script` nodes
+/// populate it with the `PDO_INPUT_*`/`PDO_OUTPUT_*`/… catalogue.
 fn wrap_with_env(
     run_id: &str,
     node_id: &str,
     iter: i64,
     daemon_port: u16,
+    harness_env: &[(String, String)],
     extra_env: &[(String, String)],
     tail_cmd: &str,
 ) -> String {
+    // #550/AC #4: the harness env (CCR for `claude`) — `sh_quote_arg` keeps a safe
+    // value like `1` bare, so `export CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1`
+    // is byte-identical to the legacy hard-coded export.
+    let harness_exports: String = harness_env
+        .iter()
+        .map(|(k, v)| format!("export {k}={} && ", sh_quote_arg(v)))
+        .collect();
     let extra_exports: String = extra_env
         .iter()
         .map(|(k, v)| format!("export {k}={} && ", sh_single_quote(v)))
@@ -256,8 +279,7 @@ fn wrap_with_env(
          export PDO_NODE_ID={node_id_q} && \
          export PDO_NODE_ITER={iter_q} && \
          export PDO_DAEMON_URL={daemon_url_q} && \
-         export CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1 && \
-         {extra_exports}{tail_cmd}",
+         {harness_exports}{extra_exports}{tail_cmd}",
         run_id_q = sh_single_quote(run_id),
         node_id_q = sh_single_quote(node_id),
         iter_q = sh_single_quote(&iter.to_string()),
@@ -288,64 +310,56 @@ fn wrap_with_env(
 /// exports `wrap_with_env` set, so no env has to be threaded into the JSON.
 pub(crate) const STOP_HOOK_SETTINGS_JSON: &str = r#"{"hooks":{"Stop":[{"matcher":"","hooks":[{"type":"command","command":"pdo complete --auto; exit 0"}]}]}}"#;
 
-/// Build the `exec claude …` tail for an agent node. A non-empty `model`
-/// inserts `--model '<m>'`, a non-empty `effort` inserts `--effort '<lvl>'`
-/// after it, then a `Some` `settings_path` inserts `--settings '<file>'` (#433),
-/// and a non-empty `session_id` inserts `--session-id '<uuid>'` last (#473);
-/// `None` *or* an empty string on all of them reproduces the legacy command
-/// byte-for-byte (the state infra sessions launch in).
+/// Build the agent tail by rendering the harness descriptor's launch template
+/// through [`crate::harness_argv`] (#550, ADR-0045). The caller shell-quotes each
+/// hole value here — where the shell semantics live — and the renderer only
+/// substitutes and drops empty-hole tokens. For the `claude` descriptor with all
+/// holes empty this reproduces the legacy `build_agent_tail` **byte for byte**
+/// (the #550 gate, pinned by the goldens in `harness_argv`): a non-empty `model`
+/// inserts `--model '<m>'`, `effort` inserts `--effort '<lvl>'` after it, a `Some`
+/// `settings_path` inserts `--settings '<file>'` (#433), and a non-empty
+/// `session_id` inserts `--session-id '<uuid>'` last (#473). `None` *or* an empty
+/// string on any of them drops its token (the `Some("")` last-resort guard of
+/// #347: a stray `""` never reaches the tail as `--model ''`).
 fn build_agent_tail(
+    descriptor: &crate::harness_registry::HarnessDescriptor,
     prompt_path: &Path,
     model: Option<&str>,
     effort: Option<&str>,
     settings_path: Option<&Path>,
     session_id: Option<&str>,
 ) -> String {
-    // A non-empty `Some` ⇒ a single-quoted `--model '<m>' ` with a trailing
-    // space; `None` OR `Some("")` ⇒ empty string, so the command collapses to
-    // the exact legacy literal (one space before the `"$(cat …)"`). The
-    // empty-string arm is the last-resort guard (#347): every upstream tier
-    // already filters "", but a missed source would otherwise emit `--model ''`
-    // and crash `claude` — keeping the guard here covers them all at once.
-    let model_flag = match model {
-        Some(m) if !m.is_empty() => format!("--model {} ", sh_single_quote(m)),
-        _ => String::new(),
+    let quote_opt = |v: Option<&str>| {
+        v.filter(|s| !s.is_empty())
+            .map(sh_single_quote)
+            .unwrap_or_default()
     };
-    // #424: same shape as the model flag, and deliberately placed *after* it —
-    // the tail test pins the substring `--dangerously-skip-permissions --model
-    // '<m>' `, so inserting before would break it for nothing. `None` OR
-    // `Some("")` ⇒ empty fragment, so the no-effort command collapses to the exact
-    // legacy literal (one space before the `"$(cat …)"`).
-    let effort_flag = match effort {
-        Some(e) if !e.is_empty() => format!("--effort {} ", sh_single_quote(e)),
-        _ => String::new(),
+    let holes = crate::harness_argv::Holes {
+        prompt: format!(
+            "\"$(cat {})\"",
+            sh_single_quote(&prompt_path.to_string_lossy())
+        ),
+        model: quote_opt(model),
+        effort: quote_opt(effort),
+        settings: settings_path
+            .map(|p| sh_single_quote(&p.to_string_lossy()))
+            .unwrap_or_default(),
+        session_id: quote_opt(session_id),
+        // The launch template carries no `{resume}` hole.
+        resume: String::new(),
     };
-    // #433: `--settings '<file>'` arms the turn-end `Stop` hook. Placed AFTER
-    // `--effort` — the position that leaves every model/effort substring test
-    // untouched. `None` ⇒ empty fragment, so the hook-off tail stays
-    // byte-identical to the legacy launch.
-    let settings_flag = match settings_path {
-        Some(p) => format!("--settings {} ", sh_single_quote(&p.to_string_lossy())),
-        None => String::new(),
-    };
-    // #473: pin the Claude Code session id so its transcript is `<uuid>.jsonl` and
-    // the liveness sweep resolves it by identity, never by newest-mtime in a shared
-    // cwd. Placed LAST (after model/effort/settings) so the model/effort byte-identity
-    // substrings the #296/#424 tests pin stay contiguous. `None` OR `Some("")` ⇒
-    // empty fragment (infra sessions): the tail then reproduces the legacy launch
-    // byte-for-byte, so the pre-#473 "no id" behaviour is what `None` still means.
-    let session_flag = match session_id {
-        Some(s) if !s.is_empty() => format!("--session-id {} ", sh_single_quote(s)),
-        _ => String::new(),
-    };
-    format!(
-        "exec claude --dangerously-skip-permissions {}{}{}{}\"$(cat {})\"",
-        model_flag,
-        effort_flag,
-        settings_flag,
-        session_flag,
-        sh_single_quote(&prompt_path.to_string_lossy())
-    )
+    crate::harness_argv::render(&descriptor.launch, &holes)
+}
+
+/// The `claude` CCR suppression, forced by the wrapper for `script` / `shell`
+/// tails (AC #4): those run bash, not an agent, so they carry no descriptor — but
+/// a hand-typed `claude` in a run shell still depends on it (CONTEXT.md §*Shell de
+/// run*). An **agent** tail gets this from its descriptor's `env` instead.
+fn forced_ccr_env() -> Vec<(String, String)> {
+    vec![(
+        "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC".to_string(),
+        "1".to_string(),
+    )]
 }
 
 /// Build the bash tail for a `script` node (#248 / ADR-0017).
@@ -406,10 +420,16 @@ pub fn build_tmux_script(
     settings_path: Option<&Path>,
 ) -> String {
     const NO_ENV: &[(String, String)] = &[];
-    let (tail_cmd, extra_env): (String, &[(String, String)]) = match tail {
-        SessionTail::Script { timeout_secs, env } => {
-            (build_script_tail(prompt_path, timeout_secs), env)
-        }
+    // #550/AC #4: `harness_env` sources the CCR export — from the harness
+    // descriptor for an agent tail, forced by the wrapper for `script` / `shell`.
+    // (Type inferred, not annotated: an explicit 3-tuple type trips clippy's
+    // `type_complexity`, which CI denies.)
+    let (tail_cmd, extra_env, harness_env) = match tail {
+        SessionTail::Script { timeout_secs, env } => (
+            build_script_tail(prompt_path, timeout_secs),
+            env,
+            forced_ccr_env(),
+        ),
         SessionTail::Shell => {
             // #316: a deterministic interactive bash. Like `Script`, the test
             // seam must not clobber it (`sleep 600` instead of a real shell is
@@ -433,9 +453,11 @@ pub fn build_tmux_script(
             (
                 "while true; do bash -i; sleep 0.2; done".to_string(),
                 NO_ENV,
+                forced_ccr_env(),
             )
         }
         SessionTail::Agent {
+            harness,
             model,
             effort,
             session_id,
@@ -443,12 +465,21 @@ pub fn build_tmux_script(
             // #433: `settings_path` (the turn-end `Stop` hook) is honoured ONLY on
             // the agent tail — a `Script`/`Shell` tail runs bash, never `claude`,
             // so it structurally cannot carry `--settings`. #473: `session_id` pins
-            // the transcript identity, threaded through the enum variant.
+            // the transcript identity, threaded through the enum variant. #550: the
+            // harness descriptor's `launch` template renders the tail and its `env`
+            // block carries the CCR suppression (AC #4).
             let cmd = match tmux_cmd_override {
                 Some(cmd) => cmd.to_string(),
-                None => build_agent_tail(prompt_path, model, effort, settings_path, session_id),
+                None => build_agent_tail(
+                    harness,
+                    prompt_path,
+                    model,
+                    effort,
+                    settings_path,
+                    session_id,
+                ),
             };
-            (cmd, NO_ENV)
+            (cmd, NO_ENV, harness.env.clone())
         }
     };
 
@@ -461,9 +492,25 @@ pub fn build_tmux_script(
     match sandbox {
         Some(wrap) => {
             let docker_tail = wrap_tail_in_docker_exec(run_id, wrap, extra_env, &tail_cmd);
-            wrap_with_env(run_id, node_id, iter, daemon_port, NO_ENV, &docker_tail)
+            wrap_with_env(
+                run_id,
+                node_id,
+                iter,
+                daemon_port,
+                &harness_env,
+                NO_ENV,
+                &docker_tail,
+            )
         }
-        None => wrap_with_env(run_id, node_id, iter, daemon_port, extra_env, &tail_cmd),
+        None => wrap_with_env(
+            run_id,
+            node_id,
+            iter,
+            daemon_port,
+            &harness_env,
+            extra_env,
+            &tail_cmd,
+        ),
     }
 }
 
@@ -508,47 +555,71 @@ fn build_resume_script(
     node_id: &str,
     iter: i64,
     daemon_port: u16,
+    descriptor: &crate::harness_registry::HarnessDescriptor,
     effort: Option<&str>,
     session_id: Option<&str>,
     tmux_cmd_override: Option<&str>,
     sandbox: Option<&SandboxWrap<'_>>,
     settings_path: Option<&Path>,
 ) -> String {
-    let effort_flag = match effort {
-        Some(e) if !e.is_empty() => format!(" --effort {}", sh_single_quote(e)),
-        _ => String::new(),
-    };
-    // #473: `--resume <uuid>` targets THIS node's transcript by identity; a
-    // pre-#473 row with no recorded id falls back to positional `--continue`.
-    let resume_flag = match session_id {
+    // #473/ADR-0045: the resume *selector* is the one thing the pure hole-drop
+    // rule cannot express (emit `--continue` precisely *when* the id is empty), so
+    // it is computed here — "reprendre par identité ou en aveugle" stays in code.
+    // `--resume <uuid>` targets THIS node's transcript by identity; a row with no
+    // recorded id (pre-#473, or a harness like `opencode` that can't pin one)
+    // falls back to blind `--continue`. Both delivered harnesses blind-continue
+    // with `--continue`.
+    let resume_selector = match session_id {
         Some(s) if !s.is_empty() => format!("--resume {}", sh_single_quote(s)),
         _ => "--continue".to_string(),
     };
-    // #433 / ADR-0043 (D7): re-arm the `Stop` hook on resume, or a resurrected
-    // session silently loses it — the daemon sweep still covers the node, but the
-    // PRIMARY substrate must survive resurrection. Leading space matches this
-    // function's local `effort_flag` convention; `None` ⇒ byte-identical tail.
-    let settings_flag = match settings_path {
-        Some(p) => format!(" --settings {}", sh_single_quote(&p.to_string_lossy())),
-        None => String::new(),
+    let quote_opt = |v: Option<&str>| {
+        v.filter(|s| !s.is_empty())
+            .map(sh_single_quote)
+            .unwrap_or_default()
+    };
+    let holes = crate::harness_argv::Holes {
+        resume: resume_selector,
+        // #424: a resume restores the model but loses the effort, so re-pose it.
+        effort: quote_opt(effort),
+        // #433 / ADR-0043 (D7): re-arm the `Stop` hook on resume.
+        settings: settings_path
+            .map(|p| sh_single_quote(&p.to_string_lossy()))
+            .unwrap_or_default(),
+        ..Default::default()
     };
     let tail_cmd = match tmux_cmd_override {
         Some(cmd) => cmd.to_string(),
-        None => format!(
-            "exec claude --dangerously-skip-permissions {resume_flag}{effort_flag}{settings_flag}"
-        ),
+        None => crate::harness_argv::render(&descriptor.resume, &holes),
     };
 
-    // #407: the 6th tail path (`claude --continue`) is wrapped identically — a
-    // resumed sandboxed session re-enters the same container. `--continue` matches
-    // its transcript by working-dir path; the container mounts the repo at the
-    // same host path, so the path (hence the transcript) still matches.
+    // #407: the resume tail is wrapped identically — a resumed sandboxed session
+    // re-enters the same container. `--continue` matches its transcript by
+    // working-dir path; the container mounts the repo at the same host path, so
+    // the path (hence the transcript) still matches.
+    let harness_env = descriptor.env.clone();
     match sandbox {
         Some(wrap) => {
             let docker_tail = wrap_tail_in_docker_exec(run_id, wrap, &[], &tail_cmd);
-            wrap_with_env(run_id, node_id, iter, daemon_port, &[], &docker_tail)
+            wrap_with_env(
+                run_id,
+                node_id,
+                iter,
+                daemon_port,
+                &harness_env,
+                &[],
+                &docker_tail,
+            )
         }
-        None => wrap_with_env(run_id, node_id, iter, daemon_port, &[], &tail_cmd),
+        None => wrap_with_env(
+            run_id,
+            node_id,
+            iter,
+            daemon_port,
+            &harness_env,
+            &[],
+            &tail_cmd,
+        ),
     }
 }
 
@@ -713,6 +784,7 @@ pub fn resume(
     node_id: &str,
     iter: i64,
     daemon_port: u16,
+    descriptor: &crate::harness_registry::HarnessDescriptor,
     effort: Option<&str>,
     session_id: Option<&str>,
     tmux_cmd_override: Option<&str>,
@@ -738,6 +810,7 @@ pub fn resume(
         node_id,
         iter,
         daemon_port,
+        descriptor,
         effort,
         session_id,
         tmux_cmd_override,
@@ -999,6 +1072,48 @@ pub fn env_default_model() -> Option<String> {
 /// without a daemon restart.
 pub fn default_model_with(stored: Option<String>) -> Option<String> {
     stored.filter(|s| !s.is_empty()).or_else(env_default_model)
+}
+
+/// Env var supplying the instance-wide default **harness** (#550, ADR-0046).
+/// `None`/empty ⇒ fall through to the `claude` floor, byte-identical launch.
+pub const DEFAULT_HARNESS_ENV: &str = "PDO_DEFAULT_HARNESS";
+
+/// The default harness contributed by [`DEFAULT_HARNESS_ENV`] alone, or `None`
+/// when unset or empty. Exposed so `GET /settings` can disclose a shadowed env
+/// var and compute the winning tier identically to [`default_harness_with`].
+pub fn env_default_harness() -> Option<String> {
+    std::env::var(DEFAULT_HARNESS_ENV)
+        .ok()
+        .filter(|s| !s.is_empty())
+}
+
+/// Resolve the instance-wide default harness, `stored → env → None` (#550,
+/// ADR-0046, mirroring [`default_model_with`]). `None` ⇒ the resolver's `claude`
+/// floor applies. Read FRESH at every spawn seam so a `PUT /settings` takes
+/// effect on the next node without a daemon restart (ADR-0015).
+pub fn default_harness_with(stored: Option<String>) -> Option<String> {
+    stored
+        .filter(|s| !s.is_empty())
+        .or_else(env_default_harness)
+}
+
+/// Whether `binary` resolves on the current `PATH` — the fail-fast spawn check
+/// (#550, AC #10). A name with a `/` is checked directly; a bare name is searched
+/// across `$PATH`. **Never executes** the binary (a probe run could hang a
+/// resident harness), and lives here (not in the pure `harness_registry`) because
+/// it reads `$PATH`. A missing binary makes the spawn fail *before* any session
+/// or start event exists (ADR-0037).
+pub fn binary_available(binary: &str) -> bool {
+    if binary.is_empty() {
+        return false;
+    }
+    if binary.contains('/') {
+        return Path::new(binary).is_file();
+    }
+    match std::env::var_os("PATH") {
+        Some(path) => std::env::split_paths(&path).any(|dir| dir.join(binary).is_file()),
+        None => false,
+    }
 }
 
 /// Resolve the model a work node launches with: the node's own `model:`
@@ -1803,6 +1918,26 @@ mod tests {
         assert_eq!(decisions[2].verdict, SweepVerdict::Keep);
     }
 
+    /// #550/AC #10: the fail-fast PATH probe. A bare name absent from `$PATH` is
+    /// unavailable; an empty name is never available; a slash-path is checked as a
+    /// file directly. `sh` is on every CI box, so it stands in for "installed".
+    #[test]
+    fn binary_available_probes_path_without_executing() {
+        assert!(!binary_available(""), "empty name is never available");
+        assert!(
+            !binary_available("pdo-definitely-not-a-real-binary-xyz"),
+            "a name absent from PATH is unavailable"
+        );
+        assert!(
+            binary_available("sh"),
+            "a ubiquitous binary resolves on PATH"
+        );
+        assert!(
+            !binary_available("/no/such/absolute/path/binary"),
+            "a missing slash-path is unavailable"
+        );
+    }
+
     #[test]
     fn build_script_default_and_override() {
         let prompt_path = Path::new("/tmp/test-prompt.md");
@@ -1816,6 +1951,7 @@ mod tests {
             prompt_path,
             None,
             SessionTail::Agent {
+                harness: &crate::harness_registry::claude(),
                 model: None,
                 effort: None,
                 session_id: None,
@@ -1838,6 +1974,7 @@ mod tests {
             prompt_path,
             Some("exec sleep 60"),
             SessionTail::Agent {
+                harness: &crate::harness_registry::claude(),
                 model: None,
                 effort: None,
                 session_id: None,
@@ -1864,6 +2001,7 @@ mod tests {
             prompt_path,
             None,
             SessionTail::Agent {
+                harness: &crate::harness_registry::claude(),
                 model: None,
                 effort: None,
                 session_id: None,
@@ -1900,6 +2038,7 @@ mod tests {
             prompt_path,
             None,
             SessionTail::Agent {
+                harness: &crate::harness_registry::claude(),
                 model: Some("opus"),
                 effort: None,
                 session_id: None,
@@ -1940,6 +2079,7 @@ mod tests {
             prompt_path,
             None,
             SessionTail::Agent {
+                harness: &crate::harness_registry::claude(),
                 model: Some(""),
                 effort: None,
                 session_id: None,
@@ -1969,6 +2109,7 @@ mod tests {
             Path::new("/tmp/test-prompt.md"),
             None,
             SessionTail::Agent {
+                harness: &crate::harness_registry::claude(),
                 model,
                 effort,
                 session_id: None,
@@ -2057,6 +2198,7 @@ mod tests {
             Path::new("/tmp/test-prompt.md"),
             None,
             SessionTail::Agent {
+                harness: &crate::harness_registry::claude(),
                 model: None,
                 effort: None,
                 session_id: None,
@@ -2080,6 +2222,7 @@ mod tests {
             Path::new("/tmp/test-prompt.md"),
             None,
             SessionTail::Agent {
+                harness: &crate::harness_registry::claude(),
                 model,
                 effort,
                 session_id,
@@ -2135,6 +2278,7 @@ mod tests {
             Path::new("/tmp/test-prompt.md"),
             None,
             SessionTail::Agent {
+                harness: &crate::harness_registry::claude(),
                 model: Some("opus"),
                 effort: Some("low"),
                 session_id: None,
@@ -2236,6 +2380,7 @@ mod tests {
             Path::new("/tmp/test-prompt.md"),
             None,
             SessionTail::Agent {
+                harness: &crate::harness_registry::claude(),
                 model: None,
                 effort: None,
                 session_id: None,
@@ -2284,7 +2429,18 @@ mod tests {
     fn build_resume_script_omits_settings_when_none() {
         // D7 off path: a resume with no hook is byte-identical to the legacy
         // `--continue` tail.
-        let script = build_resume_script("r1", "solo", 1, 6172, None, None, None, None, None);
+        let script = build_resume_script(
+            "r1",
+            "solo",
+            1,
+            6172,
+            &crate::harness_registry::claude(),
+            None,
+            None,
+            None,
+            None,
+            None,
+        );
         assert!(!script.contains("--settings"), "{script}");
         assert!(
             script.contains("exec claude --dangerously-skip-permissions --continue"),
@@ -2301,6 +2457,7 @@ mod tests {
             "solo",
             1,
             6172,
+            &crate::harness_registry::claude(),
             Some("low"),
             None,
             None,
@@ -2741,6 +2898,7 @@ mod tests {
             prompt_path,
             None,
             SessionTail::Agent {
+                harness: &crate::harness_registry::claude(),
                 model: None,
                 effort: None,
                 session_id: None,
@@ -2871,6 +3029,7 @@ mod tests {
             prompt_path,
             None,
             SessionTail::Agent {
+                harness: &crate::harness_registry::claude(),
                 model: None,
                 effort: None,
                 session_id: None,
@@ -2895,8 +3054,18 @@ mod tests {
         // here (#473) ⇒ the legacy `--continue` fallback.
         let wt = Path::new("/repo/.pdo/runs/r1/nodes/solo/iter-1");
         let wrap = sample_wrap("pdo-r1-solo-iter-1", wt);
-        let wrapped =
-            build_resume_script("r1", "solo", 1, 6172, None, None, None, Some(&wrap), None);
+        let wrapped = build_resume_script(
+            "r1",
+            "solo",
+            1,
+            6172,
+            &crate::harness_registry::claude(),
+            None,
+            None,
+            None,
+            Some(&wrap),
+            None,
+        );
         assert!(
             wrapped.contains("docker exec -i -t -e PDO_SBX_SESSION=pdo-r1-solo-iter-1"),
             "{wrapped}"
@@ -2904,7 +3073,18 @@ mod tests {
         assert!(wrapped.contains("pdo-sbx-r1 bash -lc"), "{wrapped}");
         assert!(wrapped.contains("--continue"), "{wrapped}");
         // off path unchanged.
-        let off = build_resume_script("r1", "solo", 1, 6172, None, None, None, None, None);
+        let off = build_resume_script(
+            "r1",
+            "solo",
+            1,
+            6172,
+            &crate::harness_registry::claude(),
+            None,
+            None,
+            None,
+            None,
+            None,
+        );
         assert!(!off.contains("docker"), "{off}");
         assert!(
             off.contains("exec claude --dangerously-skip-permissions --continue"),
@@ -2920,7 +3100,18 @@ mod tests {
         // cwd is the shared Run worktree). The uuid is single-quoted, hence `'\''`
         // once `wrap_with_env` re-wraps the tail in `bash -c '…'`.
         let sid = "11111111-2222-3333-4444-555555555555";
-        let off = build_resume_script("r1", "solo", 1, 6172, None, Some(sid), None, None, None);
+        let off = build_resume_script(
+            "r1",
+            "solo",
+            1,
+            6172,
+            &crate::harness_registry::claude(),
+            None,
+            Some(sid),
+            None,
+            None,
+            None,
+        );
         assert!(
             off.contains(&format!(r"--resume '\''{sid}'\''")),
             "resume must target the pinned session id: {off}"
@@ -2940,6 +3131,7 @@ mod tests {
             "solo",
             1,
             6172,
+            &crate::harness_registry::claude(),
             Some("low"),
             Some(sid),
             None,
@@ -2960,7 +3152,18 @@ mod tests {
     fn build_resume_script_falls_back_to_continue_for_empty_session_id() {
         // #473: an empty pinned id behaves exactly like `None` (a pre-#473 row) —
         // the legacy positional `--continue`, byte-identical.
-        let script = build_resume_script("r1", "solo", 1, 6172, None, Some(""), None, None, None);
+        let script = build_resume_script(
+            "r1",
+            "solo",
+            1,
+            6172,
+            &crate::harness_registry::claude(),
+            None,
+            Some(""),
+            None,
+            None,
+            None,
+        );
         assert!(!script.contains("--resume"), "{script}");
         assert!(
             script.contains(r"exec claude --dangerously-skip-permissions --continue'"),
@@ -2974,7 +3177,18 @@ mod tests {
         // byte-identical to the legacy tail. `Some("")` behaves like `None` — the
         // same last-resort guard as the spawn tail.
         for effort in [None, Some("")] {
-            let script = build_resume_script("r1", "solo", 1, 6172, effort, None, None, None, None);
+            let script = build_resume_script(
+                "r1",
+                "solo",
+                1,
+                6172,
+                &crate::harness_registry::claude(),
+                effort,
+                None,
+                None,
+                None,
+                None,
+            );
             assert!(
                 !script.contains("--effort"),
                 "no effort flag when unset ({effort:?}): {script}"
@@ -2996,8 +3210,18 @@ mod tests {
         // the transcript stores no effort field to read back. So the level is
         // re-posed here, from the `NodeStarted` payload. Still no `--model`: that
         // one really is restored.
-        let script =
-            build_resume_script("r1", "solo", 1, 6172, Some("low"), None, None, None, None);
+        let script = build_resume_script(
+            "r1",
+            "solo",
+            1,
+            6172,
+            &crate::harness_registry::claude(),
+            Some("low"),
+            None,
+            None,
+            None,
+            None,
+        );
         assert!(
             script.contains(r"--continue --effort '\''low'\''"),
             "effort must be re-posed right after --continue: {script}"
@@ -3019,6 +3243,7 @@ mod tests {
             "solo",
             1,
             6172,
+            &crate::harness_registry::claude(),
             Some("low"),
             Some("11111111-2222-3333-4444-555555555555"),
             Some("exec sleep 60"),

--- a/crates/pdo-daemon/src/trigger_scheduler.rs
+++ b/crates/pdo-daemon/src/trigger_scheduler.rs
@@ -311,6 +311,7 @@ mod tests {
             overlap_policy: "skip".to_string(),
             max_concurrent: None,
             sandbox: None,
+            harness: None,
             auto_name: true,
             enabled: true,
             next_fire_at: next_fire_at.map(str::to_string),

--- a/crates/pdo-daemon/src/trigger_store.rs
+++ b/crates/pdo-daemon/src/trigger_store.rs
@@ -65,6 +65,16 @@ pub(crate) struct Trigger {
     /// double-`Option` `UpdateTrigger.sandbox` (mirror of `max_concurrent`, #239).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub sandbox: Option<String>,
+    /// The agentic harness fired Runs launch on (#551, ADR-0046), or `None` to inherit
+    /// the instance default. There is NO separate Trigger tier in the precedence chain:
+    /// a Trigger *is* a Run template, so its harness is read at fire time and folded
+    /// into the create request's `run` choice (`nœud → Run → Projet → instance`). A
+    /// cron tick and a "Run now" both route through `fire_one_trigger`, so they freeze
+    /// the SAME harness. Free text — no validation (ADR-0045); an unknown name fails
+    /// fast at the fired Run's first node spawn. Clearable back to `None` via the
+    /// double-`Option` [`UpdateTrigger::harness`] (mirror of `sandbox`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub harness: Option<String>,
     /// Whether Runs fired from this Trigger are auto-named by the manager (#338). A
     /// flat bool (mirror of [`Self::enabled`]), NOT a nullable inherit: the choice is
     /// frozen at creation from the instance default and read at fire time. `true`
@@ -105,6 +115,8 @@ pub(crate) struct NewTrigger {
     pub max_concurrent: Option<i64>,
     /// Per-Trigger sandbox mode (#410); `None` inherits the instance default.
     pub sandbox: Option<String>,
+    /// Per-Trigger harness (#551); `None` inherits the instance default at fire time.
+    pub harness: Option<String>,
     /// Whether Runs this Trigger fires are auto-named (#338). Seeded from the instance
     /// default in the create modal and frozen here; `true` is the pre-#338 behaviour.
     pub auto_name: bool,
@@ -171,6 +183,7 @@ pub(crate) async fn init(db: &SqlitePool) -> Result<(), sqlx::Error> {
             overlap_policy TEXT NOT NULL DEFAULT 'skip',
             max_concurrent INTEGER,
             sandbox TEXT,
+            harness TEXT,
             auto_name INTEGER NOT NULL DEFAULT 1,
             enabled INTEGER NOT NULL DEFAULT 1,
             next_fire_at TEXT,
@@ -228,6 +241,21 @@ pub(crate) async fn init(db: &SqlitePool) -> Result<(), sqlx::Error> {
             .is_some();
     if !has_sandbox {
         sqlx::query("ALTER TABLE triggers ADD COLUMN sandbox TEXT")
+            .execute(db)
+            .await?;
+    }
+
+    // Additive migration (#551): per-Trigger `harness`. Same PRAGMA-guarded `ALTER`
+    // precedent as `sandbox` above — a pre-#551 `~/.pdo/pdo.db` got the table via
+    // `CREATE TABLE IF NOT EXISTS`, a no-op there, so the column must be added
+    // out-of-band. NULLABLE: a NULL row inherits the instance default at fire time.
+    let has_harness =
+        sqlx::query("SELECT 1 FROM pragma_table_info('triggers') WHERE name = 'harness'")
+            .fetch_optional(db)
+            .await?
+            .is_some();
+    if !has_harness {
+        sqlx::query("ALTER TABLE triggers ADD COLUMN harness TEXT")
             .execute(db)
             .await?;
     }
@@ -327,8 +355,8 @@ pub(crate) async fn create(db: &SqlitePool, new: NewTrigger) -> Result<Trigger, 
         "INSERT INTO triggers
             (id, name, pipeline_id, pipeline_name, target_repo, target_repos, source_branch,
              input_template, variables, cron, guard_command, overlap_policy,
-             max_concurrent, sandbox, auto_name, enabled, next_fire_at, last_fired_at, last_outcome, created_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, NULL, NULL, ?)",
+             max_concurrent, sandbox, harness, auto_name, enabled, next_fire_at, last_fired_at, last_outcome, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, NULL, NULL, ?)",
     )
     .bind(&id)
     .bind(&new.name)
@@ -344,6 +372,7 @@ pub(crate) async fn create(db: &SqlitePool, new: NewTrigger) -> Result<Trigger, 
     .bind(&new.overlap_policy)
     .bind(new.max_concurrent)
     .bind(&new.sandbox)
+    .bind(&new.harness)
     .bind(if new.auto_name { 1_i64 } else { 0_i64 })
     .bind(&new.next_fire_at)
     .bind(&now)
@@ -372,6 +401,9 @@ fn row_to_trigger(row: &sqlx::sqlite::SqliteRow) -> Trigger {
         overlap_policy: row.get("overlap_policy"),
         max_concurrent: row.get("max_concurrent"),
         sandbox: row.get("sandbox"),
+        // #551: tolerant of a legacy-NULL / pre-migration read (mirror of `target_repos`) —
+        // absence inherits the instance default at fire time.
+        harness: row.try_get("harness").unwrap_or(None),
         // #338: tolerant of a legacy NULL (a pre-migration row read mid-upgrade) —
         // absence reads as auto-name ON, the pre-#338 behaviour.
         auto_name: row.try_get::<i64, _>("auto_name").unwrap_or(1) != 0,
@@ -555,6 +587,12 @@ pub(crate) struct UpdateTrigger {
     /// `serde(default)` would make present-`null` indistinguishable from omitted, so
     /// the UI could never reset a Trigger back to inheriting.
     pub sandbox: Option<Option<String>>,
+    /// Per-Trigger harness (#551), double-wrapped like `sandbox`: `None` leaves it,
+    /// `Some(None)` clears to NULL (= "inherit the instance default"), `Some(Some(name))`
+    /// sets it. The double-`Option` is load-bearing for the same reason as `sandbox` — a
+    /// plain `serde(default)` would make present-`null` indistinguishable from omitted, so
+    /// the UI could never reset a Trigger back to inheriting.
+    pub harness: Option<Option<String>>,
     /// Auto-naming toggle (#338): `None` leaves the flag, `Some(v)` sets it. A FLAT
     /// `Option<bool>` (mirror of [`Self::enabled`]), NOT double-wrapped like `sandbox`
     /// — there is no "inherit" state to clear back to; the choice is a plain on/off.
@@ -581,6 +619,7 @@ impl UpdateTrigger {
             && self.overlap_policy.is_none()
             && self.max_concurrent.is_none()
             && self.sandbox.is_none()
+            && self.harness.is_none()
             && self.auto_name.is_none()
             && self.next_fire_at.is_none()
             && self.enabled.is_none()
@@ -639,6 +678,9 @@ pub(crate) async fn update(
     if edit.sandbox.is_some() {
         sets.push("sandbox = ?");
     }
+    if edit.harness.is_some() {
+        sets.push("harness = ?");
+    }
     if edit.auto_name.is_some() {
         sets.push("auto_name = ?");
     }
@@ -693,6 +735,11 @@ pub(crate) async fn update(
         // `Some(Some(mode))` → binds the mode string. Mirror of `target_repo`.
         query = query.bind(v.clone());
     }
+    if let Some(v) = &edit.harness {
+        // #551: `Some(None)` → SQL NULL (inherit the instance default);
+        // `Some(Some(name))` → the harness name. Mirror of `sandbox`.
+        query = query.bind(v.clone());
+    }
     if let Some(v) = &edit.auto_name {
         // Flat bool → 0/1 (mirror of `enabled`), never NULL: the column is
         // `NOT NULL DEFAULT 1` and the choice is a plain on/off (#338).
@@ -738,6 +785,7 @@ mod tests {
             overlap_policy: "skip".to_string(),
             max_concurrent: None,
             sandbox: None,
+            harness: None,
             auto_name: true,
             next_fire_at: Some("2026-06-06T10:00:00.000Z".to_string()),
         }
@@ -1493,6 +1541,136 @@ mod tests {
         .await
         .unwrap();
         assert!(get(&db, &t.id).await.unwrap().unwrap().auto_name);
+    }
+
+    /// #551 (ADR-0046): the per-Trigger harness round-trips through create, is set and
+    /// cleared through the double-`Option` update, and an unrelated edit leaves it. Mirror
+    /// of the `sandbox` double-`Option` semantics.
+    #[tokio::test]
+    async fn harness_round_trips_and_clears() {
+        let db = test_db().await;
+        let mut new = sample("t", "0 9 * * *");
+        new.harness = Some("opencode".to_string());
+        let t = create(&db, new).await.unwrap();
+        assert_eq!(t.harness.as_deref(), Some("opencode"));
+
+        // Some(Some(name)) sets it to another harness.
+        update(
+            &db,
+            &t.id,
+            UpdateTrigger {
+                harness: Some(Some("claude".to_string())),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            get(&db, &t.id).await.unwrap().unwrap().harness.as_deref(),
+            Some("claude")
+        );
+
+        // An unrelated edit (harness = None) leaves it untouched.
+        update(
+            &db,
+            &t.id,
+            UpdateTrigger {
+                input_template: Some("changed".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            get(&db, &t.id).await.unwrap().unwrap().harness.as_deref(),
+            Some("claude")
+        );
+
+        // Some(None) clears it back to inheriting the instance default.
+        update(
+            &db,
+            &t.id,
+            UpdateTrigger {
+                harness: Some(None),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(get(&db, &t.id).await.unwrap().unwrap().harness, None);
+    }
+
+    /// #551 migration: a `~/.pdo/pdo.db` created before `harness` existed must pick up the
+    /// column on the next `init`, and a legacy row must read back with `harness = None`
+    /// (inherit the instance default) — the pre-#551 behaviour.
+    #[tokio::test]
+    async fn init_adds_harness_to_legacy_table() {
+        let db = sqlx::sqlite::SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .unwrap();
+
+        // Pre-#551 schema: `triggers` WITHOUT `harness` (but WITH the earlier
+        // sandbox/auto_name columns, so this exercises the tail ALTER).
+        sqlx::query(
+            "CREATE TABLE triggers (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                pipeline_id TEXT NOT NULL,
+                pipeline_name TEXT NOT NULL DEFAULT '',
+                target_repo TEXT,
+                target_repos TEXT,
+                source_branch TEXT,
+                input_template TEXT NOT NULL DEFAULT '',
+                variables JSON NOT NULL DEFAULT '{}',
+                cron TEXT NOT NULL,
+                guard_command TEXT,
+                overlap_policy TEXT NOT NULL DEFAULT 'skip',
+                max_concurrent INTEGER,
+                sandbox TEXT,
+                auto_name INTEGER NOT NULL DEFAULT 1,
+                enabled INTEGER NOT NULL DEFAULT 1,
+                next_fire_at TEXT,
+                last_fired_at TEXT,
+                last_outcome TEXT,
+                created_at TEXT NOT NULL
+            )",
+        )
+        .execute(&db)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO triggers (id, name, pipeline_id, cron, created_at)
+             VALUES ('trg-legacy', 'legacy', 'lib-pipe', '0 9 * * *', '2026-01-01T00:00:00.000Z')",
+        )
+        .execute(&db)
+        .await
+        .unwrap();
+
+        let before =
+            sqlx::query("SELECT 1 FROM pragma_table_info('triggers') WHERE name = 'harness'")
+                .fetch_optional(&db)
+                .await
+                .unwrap();
+        assert!(
+            before.is_none(),
+            "precondition: legacy table lacks the column"
+        );
+
+        init(&db).await.unwrap();
+        init(&db).await.unwrap(); // idempotent
+
+        let after =
+            sqlx::query("SELECT 1 FROM pragma_table_info('triggers') WHERE name = 'harness'")
+                .fetch_optional(&db)
+                .await
+                .unwrap();
+        assert!(after.is_some(), "init must add the harness column");
+
+        // The legacy row reads back inheriting (None), the pre-#551 behaviour.
+        let migrated = get(&db, "trg-legacy").await.unwrap().unwrap();
+        assert_eq!(migrated.harness, None);
     }
 
     /// #338 migration: a `~/.pdo/pdo.db` created before `auto_name` existed must pick up

--- a/crates/pdo-daemon/src/workflow_importer.rs
+++ b/crates/pdo-daemon/src/workflow_importer.rs
@@ -517,6 +517,17 @@ impl Importer {
         };
         out_port.frontmatter = frontmatter;
 
+        // #550: the imported `model` / `effort` land under `harnesses.claude`
+        // (workflow import stays claude-only, ADR-0016). Only materialise an entry
+        // when at least one is present, so a plain node keeps an empty map.
+        let mut harnesses = std::collections::BTreeMap::new();
+        if model.is_some() || effort.is_some() {
+            harnesses.insert(
+                crate::harness_registry::CLAUDE.to_string(),
+                crate::harness_resolver::HarnessEntry { model, effort },
+            );
+        }
+
         let node = NodeDef {
             id: id.clone(),
             name: display_name,
@@ -530,8 +541,8 @@ impl Importer {
             }),
             max_iter: None,
             over: None,
-            model,
-            effort,
+            pin_harness: None,
+            harnesses,
         };
         self.nodes.push(node);
         self.prompts.insert(id.clone(), prompt_body);
@@ -926,8 +937,8 @@ fn start_node() -> NodeDef {
         view: Some(ViewPosition { x: 320.0, y: 0.0 }),
         max_iter: None,
         over: None,
-        model: None,
-        effort: None,
+        pin_harness: None,
+        harnesses: Default::default(),
     }
 }
 
@@ -945,8 +956,8 @@ fn end_node(agent_count: usize) -> NodeDef {
         }),
         max_iter: None,
         over: None,
-        model: None,
-        effort: None,
+        pin_harness: None,
+        harnesses: Default::default(),
     }
 }
 
@@ -1842,10 +1853,12 @@ mod tests {
         let src = r#"agent(`work`, { label: 'w', model: 'opus', effort: 'low' }); agent(`plain`, { label: 'p' })"#;
         let (result, parsed) = import_and_parse(src, "t");
         let node = |name: &str| parsed.nodes.iter().find(|n| n.name == name).unwrap();
-        assert_eq!(node("w").effort.as_deref(), Some("low"));
-        assert_eq!(node("w").model.as_deref(), Some("opus"));
-        // An agent with no effort stays unset — no key, no flag.
-        assert_eq!(node("p").effort, None);
+        // #550: imported model/effort land under `harnesses.claude` (claude-only import).
+        let claude = |name: &str| node(name).harnesses.get("claude").cloned();
+        assert_eq!(claude("w").and_then(|e| e.effort).as_deref(), Some("low"));
+        assert_eq!(claude("w").and_then(|e| e.model).as_deref(), Some("opus"));
+        // An agent with no effort/model stays unset — no claude entry at all.
+        assert_eq!(claude("p"), None);
         assert!(
             result
                 .warnings
@@ -1855,15 +1868,13 @@ mod tests {
             result.warnings
         );
         // Structural nodes never carry one.
-        assert_eq!(
-            parsed
-                .nodes
-                .iter()
-                .find(|n| n.node_type == NodeType::Start)
-                .unwrap()
-                .effort,
-            None
-        );
+        assert!(parsed
+            .nodes
+            .iter()
+            .find(|n| n.node_type == NodeType::Start)
+            .unwrap()
+            .harnesses
+            .is_empty());
     }
 
     #[test]
@@ -1873,10 +1884,14 @@ mod tests {
         // dropping it in silence.
         let src = r#"const lvl = 'low'; agent(`work`, { label: 'w', effort: lvl })"#;
         let (result, parsed) = import_and_parse(src, "t");
-        assert_eq!(
-            parsed.nodes.iter().find(|n| n.name == "w").unwrap().effort,
-            None
-        );
+        // A computed (non-literal) effort is lost, so the node carries no claude entry.
+        assert!(parsed
+            .nodes
+            .iter()
+            .find(|n| n.name == "w")
+            .unwrap()
+            .harnesses
+            .is_empty());
         assert!(
             result.warnings.iter().any(|w| w.message.contains("effort")),
             "a computed effort must raise a warning: {:?}",

--- a/crates/pdo-daemon/tests/harness_freeze_resume.rs
+++ b/crates/pdo-daemon/tests/harness_freeze_resume.rs
@@ -91,11 +91,19 @@ fn git_init_with_commit(repo: &std::path::Path) -> anyhow::Result<()> {
 }
 
 async fn create_run(daemon: &TestDaemon) -> String {
-    let body = serde_json::json!({
+    create_run_with_harness(daemon, None).await
+}
+
+/// Create a Run, optionally choosing a **Run-level harness** (#551) — the `run` tier.
+async fn create_run_with_harness(daemon: &TestDaemon, harness: Option<&str>) -> String {
+    let mut body = serde_json::json!({
         "pipeline": PIPELINE_NAME,
         "input": "go",
         "target_repo": daemon.target_repo(),
     });
+    if let Some(h) = harness {
+        body["harness"] = serde_json::json!(h);
+    }
     let resp = reqwest::Client::new()
         .post(format!("{}/runs", daemon.url()))
         .json(&body)
@@ -105,6 +113,17 @@ async fn create_run(daemon: &TestDaemon) -> String {
     assert_eq!(resp.status(), 201, "POST /runs should return 201");
     let json: serde_json::Value = resp.json().await.unwrap();
     json["run_id"].as_str().unwrap().to_string()
+}
+
+/// The Run's projected state (`GET /runs/<id>`), which serializes `RunState` — so its
+/// `harness` key is the frozen Run harness the panel shows (#551).
+async fn get_run(daemon: &TestDaemon, run_id: &str) -> serde_json::Value {
+    reqwest::get(format!("{}/runs/{run_id}", daemon.url()))
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap()
 }
 
 async fn events(daemon: &TestDaemon, run_id: &str) -> Vec<serde_json::Value> {
@@ -184,5 +203,106 @@ async fn resume_reposes_the_frozen_harness() {
         pane["source"].as_str(),
         Some("unavailable"),
         "a resumable pinned node must re-pose, not report unavailable: {pane}"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// #551 — the Run tier (`nœud → Run → instance → plancher`), end to end.
+// -----------------------------------------------------------------------------
+
+/// Poll for the manager session (`pdo-mgr-<run>`) to come up on the daemon's own tmux
+/// socket, proving the manager spawned on the resolved harness without failing fast.
+async fn wait_for_manager_session(daemon: &TestDaemon, run_id: &str) -> bool {
+    let socket = daemon.tmux_socket();
+    let session = format!("pdo-mgr-{run_id}");
+    for _ in 0..50 {
+        let up = std::process::Command::new("tmux")
+            .args(["-L", &socket, "has-session", "-t", &session])
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false);
+        if up {
+            return true;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+    false
+}
+
+/// The Run tier moves a **free** node off the floor: a Run created on `opencode` freezes
+/// `opencode` into the unpinned node's `NodeStarted` (it followed the Run), while the
+/// Run's own frozen harness is visible in `GET /runs/<id>` (the Run panel, AC), and the
+/// Pipeline Manager comes up on that harness (the infra session follows the Run — AC).
+#[tokio::test]
+async fn run_harness_moves_the_free_node_and_manager() {
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+    let run_id = create_run_with_harness(&daemon, Some("opencode")).await;
+    let evs = wait_for_both_started(&daemon, &run_id).await;
+
+    // The unpinned node followed the Run tier off the `claude` floor to `opencode`…
+    assert_eq!(
+        started_harness(&evs, "aaaaaaaa").as_deref(),
+        Some("opencode"),
+        "a free node must follow the Run's harness"
+    );
+    // …and the pinned node stays `opencode` too (its pin agrees with the Run here).
+    assert_eq!(
+        started_harness(&evs, "bbbbbbbb").as_deref(),
+        Some("opencode")
+    );
+
+    // The frozen Run harness is visible in the Run panel (AC): `GET /runs/<id>`.
+    let run = get_run(&daemon, &run_id).await;
+    assert_eq!(
+        run["harness"].as_str(),
+        Some("opencode"),
+        "the Run panel must show the frozen Run harness: {run}"
+    );
+
+    // The Pipeline Manager followed the Run's harness (AC): its session came up, so the
+    // manager spawn resolved `opencode` and did not fail fast. (The exact harness the
+    // manager launches is proven purely by `harness_resolver::resolve_infra_harness`;
+    // the tmux command override erases the tail, so an L3 asserts the spawn, not bytes.)
+    assert!(
+        wait_for_manager_session(&daemon, &run_id).await,
+        "the manager session must come up on the Run's harness"
+    );
+}
+
+/// A **pinned** node resists the Run tier: a Run created on `claude` cannot pull the
+/// `opencode`-pinned node off its pin (ADR-0046, épinglage ≠ paramétrage), while the free
+/// node follows the Run down to `claude`.
+#[tokio::test]
+async fn pinned_node_resists_the_run_harness() {
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+    let run_id = create_run_with_harness(&daemon, Some("claude")).await;
+    let evs = wait_for_both_started(&daemon, &run_id).await;
+
+    // The pinned node ignores the Run's `claude` choice and stays on its `opencode` pin.
+    assert_eq!(
+        started_harness(&evs, "bbbbbbbb").as_deref(),
+        Some("opencode"),
+        "a pinned node must resist the Run harness"
+    );
+    // The free node follows the Run to `claude`.
+    assert_eq!(started_harness(&evs, "aaaaaaaa").as_deref(), Some("claude"));
+
+    // And the Run panel shows the Run's own frozen choice.
+    let run = get_run(&daemon, &run_id).await;
+    assert_eq!(run["harness"].as_str(), Some("claude"), "{run}");
+}
+
+/// A Run created with **no** harness names none: the free node stays on the floor and the
+/// Run panel omits the key (byte-identical to the pre-#551 shape).
+#[tokio::test]
+async fn a_run_without_a_harness_freezes_none() {
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+    let run_id = create_run(&daemon).await;
+    wait_for_both_started(&daemon, &run_id).await;
+
+    let run = get_run(&daemon, &run_id).await;
+    assert!(
+        run.get("harness").is_none() || run["harness"].is_null(),
+        "a Run that named no harness must not carry the key: {run}"
     );
 }

--- a/crates/pdo-daemon/tests/harness_freeze_resume.rs
+++ b/crates/pdo-daemon/tests/harness_freeze_resume.rs
@@ -1,0 +1,188 @@
+//! Layer 3a (#550, ADR-0046) — the harness axis, end to end through the daemon.
+//!
+//! A two-node `doc-only` pipeline: one node with no pin (⇒ the `claude` floor),
+//! one `pin_harness: opencode`. Spawned through the **tmux command seam** (a
+//! harmless `sleep`, never a real agent), the test proves:
+//!   1. the resolved harness is **frozen** in each node's `NodeStarted` event, and
+//!   2. a resume of the pinned node **re-poses** that frozen harness (ADR-0007).
+//!
+//! The binary fail-fast (AC #10) is deliberately not exercised here: it is
+//! skipped under the command override (an override means the real binary never
+//! runs), and it is unit-tested in `node_spawn` / `node_primitives`.
+
+mod common;
+
+use common::TestDaemon;
+
+const PIPELINE_NAME: &str = "harness-test";
+const PIPELINE_YAML: &str = r#"name: harness-test
+version: "1.0"
+nodes:
+  - id: start
+    name: Start
+    type: start
+    outputs:
+      - name: user_prompt
+  - id: aaaaaaaa
+    name: on-claude
+    type: doc-only
+    outputs:
+      - name: out
+    view: { x: 200, y: 60 }
+  - id: bbbbbbbb
+    name: on-opencode
+    type: doc-only
+    pin_harness: opencode
+    outputs:
+      - name: out
+    view: { x: 200, y: 200 }
+  - id: end
+    name: End
+    type: end
+    inputs:
+      - name: result
+edges:
+  - source: { node: start, port: user_prompt }
+    target: { node: aaaaaaaa, port: task }
+  - source: { node: start, port: user_prompt }
+    target: { node: bbbbbbbb, port: task }
+  - source: { node: aaaaaaaa, port: out }
+    target: { node: end, port: result }
+"#;
+
+fn seed(repo: &std::path::Path) -> anyhow::Result<()> {
+    let pipelines_dir = repo.join(".pdo").join("pipelines");
+    std::fs::create_dir_all(&pipelines_dir)?;
+    std::fs::write(
+        pipelines_dir.join(format!("{PIPELINE_NAME}.yaml")),
+        PIPELINE_YAML,
+    )?;
+    let prompts_dir = pipelines_dir.join(format!("{PIPELINE_NAME}.prompts"));
+    std::fs::create_dir_all(&prompts_dir)?;
+    std::fs::write(prompts_dir.join("aaaaaaaa.md"), "You are on claude.\n")?;
+    std::fs::write(prompts_dir.join("bbbbbbbb.md"), "You are on opencode.\n")?;
+    git_init_with_commit(repo)?;
+    Ok(())
+}
+
+fn git_init_with_commit(repo: &std::path::Path) -> anyhow::Result<()> {
+    let run = |args: &[&str]| -> anyhow::Result<()> {
+        let out = std::process::Command::new("git")
+            .args(args)
+            .current_dir(repo)
+            .output()?;
+        if !out.status.success() {
+            anyhow::bail!(
+                "git {:?} failed: {}",
+                args,
+                String::from_utf8_lossy(&out.stderr)
+            );
+        }
+        Ok(())
+    };
+    run(&["init", "-q", "-b", "main"])?;
+    run(&["config", "user.email", "test@example.com"])?;
+    run(&["config", "user.name", "Test"])?;
+    run(&["config", "commit.gpgsign", "false"])?;
+    std::fs::write(repo.join(".gitignore"), ".pdo/runs/\n")?;
+    run(&["add", "."])?;
+    run(&["commit", "-q", "-m", "init"])?;
+    Ok(())
+}
+
+async fn create_run(daemon: &TestDaemon) -> String {
+    let body = serde_json::json!({
+        "pipeline": PIPELINE_NAME,
+        "input": "go",
+        "target_repo": daemon.target_repo(),
+    });
+    let resp = reqwest::Client::new()
+        .post(format!("{}/runs", daemon.url()))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 201, "POST /runs should return 201");
+    let json: serde_json::Value = resp.json().await.unwrap();
+    json["run_id"].as_str().unwrap().to_string()
+}
+
+async fn events(daemon: &TestDaemon, run_id: &str) -> Vec<serde_json::Value> {
+    let v: serde_json::Value = reqwest::get(format!("{}/runs/{run_id}/events", daemon.url()))
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    v.as_array().cloned().unwrap_or_default()
+}
+
+/// The `harness` frozen on a node's latest `NodeStarted`, or `None` until it lands.
+fn started_harness(evs: &[serde_json::Value], node_id: &str) -> Option<String> {
+    evs.iter()
+        .rev()
+        .find(|e| e["kind"] == "node_started" && e["node_id"] == node_id)
+        .and_then(|e| e["payload"]["harness"].as_str())
+        .map(String::from)
+}
+
+/// Poll the event log until both entry nodes have a `NodeStarted`, or time out.
+async fn wait_for_both_started(daemon: &TestDaemon, run_id: &str) -> Vec<serde_json::Value> {
+    for _ in 0..50 {
+        let evs = events(daemon, run_id).await;
+        if started_harness(&evs, "aaaaaaaa").is_some()
+            && started_harness(&evs, "bbbbbbbb").is_some()
+        {
+            return evs;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+    panic!("both entry nodes should have started within the timeout");
+}
+
+#[tokio::test]
+async fn resolved_harness_is_frozen_on_node_started() {
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+    let run_id = create_run(&daemon).await;
+    let evs = wait_for_both_started(&daemon, &run_id).await;
+
+    // The unpinned node froze the `claude` floor; the pinned node froze `opencode`
+    // — the resolved harness, not what any tier says now (ADR-0046, gel au spawn).
+    assert_eq!(started_harness(&evs, "aaaaaaaa").as_deref(), Some("claude"));
+    assert_eq!(
+        started_harness(&evs, "bbbbbbbb").as_deref(),
+        Some("opencode")
+    );
+}
+
+#[tokio::test]
+async fn resume_reposes_the_frozen_harness() {
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+    let run_id = create_run(&daemon).await;
+    wait_for_both_started(&daemon, &run_id).await;
+
+    // Kill the pinned node's live session out-of-band (on the daemon's own tmux
+    // socket) so the pane endpoint has to RESUME rather than merely capture.
+    let socket = daemon.tmux_socket();
+    let session = format!("pdo-{run_id}-bbbbbbbb-iter-1");
+    let _ = std::process::Command::new("tmux")
+        .args(["-L", &socket, "kill-session", "-t", &session])
+        .output();
+
+    // The pane endpoint reads the frozen `opencode` harness back from `NodeStarted`,
+    // finds it can resume, and re-poses it (via the command seam). It must not
+    // answer a bare "session no longer available".
+    let resp = reqwest::get(format!(
+        "{}/runs/{run_id}/nodes/bbbbbbbb/pane",
+        daemon.url()
+    ))
+    .await
+    .unwrap();
+    assert_eq!(resp.status(), 200);
+    let pane: serde_json::Value = resp.json().await.unwrap();
+    assert_ne!(
+        pane["source"].as_str(),
+        Some("unavailable"),
+        "a resumable pinned node must re-pose, not report unavailable: {pane}"
+    );
+}

--- a/crates/pdo-daemon/tests/project_harness_resolution.rs
+++ b/crates/pdo-daemon/tests/project_harness_resolution.rs
@@ -1,0 +1,265 @@
+//! Layer 3 (#552, ADR-0046) — the **Projet** tier of the harness axis, end to end
+//! through the daemon.
+//!
+//! A single unpinned `doc-only` node, spawned through the **tmux command seam** (a
+//! harmless `sleep`, never a real agent). With no node pin and no instance
+//! default, the only tier that can name a harness is the **Projet** of the Run's
+//! primary repo. The tests prove:
+//!   1. a Projet posed on the primary repo resolves the node's harness (and is
+//!      **frozen** on `NodeStarted`), while a Projet on a *secondary* repo is
+//!      ignored — the Run follows its **primary** (ADR-0042);
+//!   2. with no Projet, resolution falls through to the `claude` floor; and
+//!   3. attaching a path already owned by another Projet is refused, **naming**
+//!      the owner (AC), before any effect.
+//!
+//! Nothing is seeded: every Projet here is materialised via `POST /projects`.
+
+mod common;
+
+use common::TestDaemon;
+
+const PIPELINE_NAME: &str = "proj-harness-test";
+const PIPELINE_YAML: &str = r#"name: proj-harness-test
+version: "1.0"
+nodes:
+  - id: start
+    name: Start
+    type: start
+    outputs:
+      - name: user_prompt
+  - id: aaaaaaaa
+    name: worker
+    type: doc-only
+    outputs:
+      - name: out
+    view: { x: 200, y: 60 }
+  - id: end
+    name: End
+    type: end
+    inputs:
+      - name: result
+edges:
+  - source: { node: start, port: user_prompt }
+    target: { node: aaaaaaaa, port: task }
+  - source: { node: aaaaaaaa, port: out }
+    target: { node: end, port: result }
+"#;
+
+fn seed(repo: &std::path::Path) -> anyhow::Result<()> {
+    let pipelines_dir = repo.join(".pdo").join("pipelines");
+    std::fs::create_dir_all(&pipelines_dir)?;
+    std::fs::write(
+        pipelines_dir.join(format!("{PIPELINE_NAME}.yaml")),
+        PIPELINE_YAML,
+    )?;
+    let prompts_dir = pipelines_dir.join(format!("{PIPELINE_NAME}.prompts"));
+    std::fs::create_dir_all(&prompts_dir)?;
+    std::fs::write(prompts_dir.join("aaaaaaaa.md"), "You are the worker.\n")?;
+    git_init_with_commit(repo)?;
+    Ok(())
+}
+
+fn git_init_with_commit(repo: &std::path::Path) -> anyhow::Result<()> {
+    let run = |args: &[&str]| -> anyhow::Result<()> {
+        let out = std::process::Command::new("git")
+            .args(args)
+            .current_dir(repo)
+            .output()?;
+        if !out.status.success() {
+            anyhow::bail!(
+                "git {:?} failed: {}",
+                args,
+                String::from_utf8_lossy(&out.stderr)
+            );
+        }
+        Ok(())
+    };
+    run(&["init", "-q", "-b", "main"])?;
+    run(&["config", "user.email", "test@example.com"])?;
+    run(&["config", "user.name", "Test"])?;
+    run(&["config", "commit.gpgsign", "false"])?;
+    std::fs::write(repo.join(".gitignore"), ".pdo/runs/\n")?;
+    run(&["add", "."])?;
+    run(&["commit", "-q", "-m", "init"])?;
+    Ok(())
+}
+
+/// A fresh git repo (one commit) at `dir`, ready to be pinned as a secondary.
+fn make_secondary_repo(dir: &std::path::Path) {
+    std::fs::write(dir.join("README.md"), "secondary\n").unwrap();
+    git_init_with_commit(dir).unwrap();
+}
+
+// --- HTTP helpers over the Projet endpoints ----------------------------------
+
+async fn create_project(daemon: &TestDaemon, name: &str) -> String {
+    let resp = reqwest::Client::new()
+        .post(format!("{}/projects", daemon.url()))
+        .json(&serde_json::json!({ "name": name }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 201, "POST /projects should return 201");
+    let json: serde_json::Value = resp.json().await.unwrap();
+    json["id"].as_str().unwrap().to_string()
+}
+
+async fn add_member(daemon: &TestDaemon, project_id: &str, path: &str) -> reqwest::Response {
+    reqwest::Client::new()
+        .post(format!("{}/projects/{project_id}/members", daemon.url()))
+        .json(&serde_json::json!({ "path": path }))
+        .send()
+        .await
+        .unwrap()
+}
+
+async fn set_harness(daemon: &TestDaemon, project_id: &str, harness: &str) {
+    let resp = reqwest::Client::new()
+        .patch(format!("{}/projects/{project_id}", daemon.url()))
+        .json(&serde_json::json!({ "harness": harness }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200, "PATCH /projects should return 200");
+}
+
+async fn create_run(daemon: &TestDaemon, body: serde_json::Value) -> String {
+    let resp = reqwest::Client::new()
+        .post(format!("{}/runs", daemon.url()))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 201, "POST /runs should return 201");
+    let json: serde_json::Value = resp.json().await.unwrap();
+    json["run_id"].as_str().unwrap().to_string()
+}
+
+async fn events(daemon: &TestDaemon, run_id: &str) -> Vec<serde_json::Value> {
+    let v: serde_json::Value = reqwest::get(format!("{}/runs/{run_id}/events", daemon.url()))
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    v.as_array().cloned().unwrap_or_default()
+}
+
+/// The `harness` frozen on the worker node's latest `NodeStarted`, or `None`.
+fn started_harness(evs: &[serde_json::Value]) -> Option<String> {
+    evs.iter()
+        .rev()
+        .find(|e| e["kind"] == "node_started" && e["node_id"] == "aaaaaaaa")
+        .and_then(|e| e["payload"]["harness"].as_str())
+        .map(String::from)
+}
+
+async fn wait_for_started(daemon: &TestDaemon, run_id: &str) -> String {
+    for _ in 0..50 {
+        let evs = events(daemon, run_id).await;
+        if let Some(h) = started_harness(&evs) {
+            return h;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+    panic!("worker node should have started within the timeout");
+}
+
+#[tokio::test]
+async fn projet_of_primary_repo_resolves_the_node_harness_secondary_ignored() {
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+    let primary = daemon.target_repo();
+
+    // A secondary git repo, owned by a DIFFERENT Projet carrying `claude`. If the
+    // resolver ever consulted a secondary, this would drag the node onto claude.
+    let secondary = tempfile::tempdir().unwrap();
+    make_secondary_repo(secondary.path());
+    let secondary_path = secondary.path().to_str().unwrap().to_string();
+
+    // Materialise the Projets via the API (nothing is seeded) and pose harnesses.
+    let product = create_project(&daemon, "Product").await;
+    assert_eq!(
+        add_member(&daemon, &product, &primary).await.status(),
+        200,
+        "primary attaches cleanly"
+    );
+    set_harness(&daemon, &product, "opencode").await;
+
+    let legacy = create_project(&daemon, "Legacy").await;
+    assert_eq!(
+        add_member(&daemon, &legacy, &secondary_path).await.status(),
+        200
+    );
+    set_harness(&daemon, &legacy, "claude").await;
+
+    // A Run on the primary, carrying the secondary read-only. The unpinned node
+    // has no node/Run/instance harness — only the Projet tier can name one.
+    let run_id = create_run(
+        &daemon,
+        serde_json::json!({
+            "pipeline": PIPELINE_NAME,
+            "input": "go",
+            "target_repo": primary,
+            "target_repos": [ { "repo": primary }, { "repo": secondary_path } ],
+        }),
+    )
+    .await;
+
+    // The node froze `opencode` — the primary's Projet — NOT `claude` from the
+    // secondary's Projet, and NOT the bare `claude` floor.
+    assert_eq!(
+        wait_for_started(&daemon, &run_id).await,
+        "opencode",
+        "the Run follows its primary repo's Projet; the secondary's Projet is ignored"
+    );
+}
+
+#[tokio::test]
+async fn no_projet_falls_through_to_the_claude_floor() {
+    // Control: with no Projet naming a harness, an unpinned node resolves the
+    // `claude` floor — the pre-#552 behaviour, unchanged.
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+    let run_id = create_run(
+        &daemon,
+        serde_json::json!({
+            "pipeline": PIPELINE_NAME,
+            "input": "go",
+            "target_repo": daemon.target_repo(),
+        }),
+    )
+    .await;
+    assert_eq!(wait_for_started(&daemon, &run_id).await, "claude");
+}
+
+#[tokio::test]
+async fn attaching_a_path_to_a_second_projet_is_refused_naming_the_owner() {
+    // AC end to end: a path already owned by a Projet cannot join a second — the
+    // refusal is a 409 that NAMES the owner, before any effect.
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+    let primary = daemon.target_repo();
+
+    let alpha = create_project(&daemon, "Alpha").await;
+    assert_eq!(add_member(&daemon, &alpha, &primary).await.status(), 200);
+
+    let bravo = create_project(&daemon, "Bravo").await;
+    let refused = add_member(&daemon, &bravo, &primary).await;
+    assert_eq!(refused.status(), 409, "a second attach is refused");
+    let body: serde_json::Value = refused.json().await.unwrap();
+    assert_eq!(body["owner_name"].as_str(), Some("Alpha"));
+    assert!(
+        body["error"].as_str().unwrap_or_default().contains("Alpha"),
+        "the refusal message names the owning Projet: {body}"
+    );
+
+    // Before any effect: Bravo gained no member.
+    let bravo_state: serde_json::Value = reqwest::get(format!("{}/projects/{bravo}", daemon.url()))
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert!(
+        bravo_state["members"].as_array().unwrap().is_empty(),
+        "the refused Projet must gain no member"
+    );
+}

--- a/crates/pdo-daemon/tests/tmux_run_spawn.rs
+++ b/crates/pdo-daemon/tests/tmux_run_spawn.rs
@@ -86,6 +86,9 @@ fn build_tmux_script_uses_exec_bash_and_invokes_claude() {
     // `claude --dangerously-skip-permissions` and the `exec bash -c` shape.
     // `None` override → production claude tail.
     let prompt_path = std::path::Path::new("/tmp/pdo-test/solo-iter-1.md");
+    // #550: the `claude` descriptor — its launch template reproduces the legacy
+    // tail byte for byte once the holes are empty (the state this test asserts).
+    let claude = pdo_daemon::harness_registry::claude();
     let script = build_tmux_script(
         "run-abc",
         "solo",
@@ -94,6 +97,7 @@ fn build_tmux_script_uses_exec_bash_and_invokes_claude() {
         prompt_path,
         None,
         SessionTail::Agent {
+            harness: &claude,
             model: None,
             effort: None,
             session_id: None,

--- a/crates/pdo-daemon/tests/trigger_scheduler.rs
+++ b/crates/pdo-daemon/tests/trigger_scheduler.rs
@@ -1646,6 +1646,88 @@ async fn trigger_auto_name_true_fires_an_unnamed_run_for_manager_to_derive() {
     cleanup_runs(&daemon).await;
 }
 
+/// The Run's projected state (`GET /runs/<id>`), which serializes `RunState` — the only
+/// place the frozen Run `harness` is observable (the list entry does not carry it).
+async fn get_run(daemon: &TestDaemon, run_id: &str) -> serde_json::Value {
+    reqwest::get(format!("{}/runs/{run_id}", daemon.url()))
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap()
+}
+
+/// #551 (ADR-0046): a Trigger carries the harness IN its Run template, and both a cron
+/// tick and a "Run now" manual fire produce a Run FROZEN on that harness — the AC's
+/// "« Run now » et un tir cron produisent le même harnais", proven because both routes
+/// share `fire_one_trigger`. Overlap `allow`, so the two fires both create a Run.
+#[tokio::test]
+async fn trigger_fire_freezes_the_declared_harness_cron_and_run_now() {
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+
+    let body = serde_json::json!({
+        "name": "on opencode",
+        "pipeline_id": PIPELINE_NAME,
+        "cron": "* * * * *",
+        "target_repo": daemon.target_repo(),
+        "harness": "opencode",
+        "overlap_policy": "allow",
+    });
+    let trigger: serde_json::Value = reqwest::Client::new()
+        .post(format!("{}/triggers", daemon.url()))
+        .json(&body)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let trigger_id = trigger["id"].as_str().unwrap().to_string();
+    // The stored Trigger carries the harness in its Run template.
+    assert_eq!(
+        get_trigger(&daemon, &trigger_id).await["harness"].as_str(),
+        Some("opencode"),
+        "the Trigger must store the harness in its Run template"
+    );
+
+    // "Run now" (manual fire) → a Run frozen on opencode.
+    let now_fire: serde_json::Value = reqwest::Client::new()
+        .post(format!("{}/triggers/{}/fire", daemon.url(), trigger_id))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(now_fire["fired"].as_bool(), Some(true), "{now_fire}");
+    let run_now_id = now_fire["run_id"].as_str().unwrap().to_string();
+    assert_eq!(
+        get_run(&daemon, &run_now_id).await["harness"].as_str(),
+        Some("opencode"),
+        "a \"Run now\" fire must freeze the Trigger's harness"
+    );
+
+    // A cron tick → a Run frozen on the SAME harness.
+    daemon.force_trigger_due(&trigger_id).await;
+    daemon.run_trigger_tick().await;
+    let cron_run = list_runs(&daemon)
+        .await
+        .into_iter()
+        .find(|r| {
+            r["triggered_by"].as_str() == Some(trigger_id.as_str())
+                && r["run_id"].as_str() != Some(run_now_id.as_str())
+        })
+        .expect("the cron tick must have fired a second run");
+    let cron_run_id = cron_run["run_id"].as_str().unwrap();
+    assert_eq!(
+        get_run(&daemon, cron_run_id).await["harness"].as_str(),
+        Some("opencode"),
+        "a cron tick must freeze the same harness as \"Run now\""
+    );
+
+    cleanup_runs(&daemon).await;
+}
+
 /// Best-effort: kill any tmux sessions the runs spawned so a `sleep 60` doesn't
 /// leak past the test.
 async fn cleanup_runs(daemon: &TestDaemon) {

--- a/docs/adr/0015-instance-config-store-and-precedence.md
+++ b/docs/adr/0015-instance-config-store-and-precedence.md
@@ -1,6 +1,6 @@
 # Configuration d'instance : store SQLite singleton + précédence `stored → env → default`
 
-> **Amendé par ADR-0044** : l'instance n'est plus le tier le plus haut pour tout réglage — le harnais
+> **Amendé par ADR-0046** : l'instance n'est plus le tier le plus haut pour tout réglage — le harnais
 > agentique en compte deux au-dessous d'elle (Run, Projet) — et son défaut de modèle devient un défaut
 > **par harnais**. La précédence `stored → env → default` de chaque réglage est inchangée.
 

--- a/docs/adr/0015-instance-config-store-and-precedence.md
+++ b/docs/adr/0015-instance-config-store-and-precedence.md
@@ -1,5 +1,9 @@
 # Configuration d'instance : store SQLite singleton + précédence `stored → env → default`
 
+> **Amendé par ADR-0044** : l'instance n'est plus le tier le plus haut pour tout réglage — le harnais
+> agentique en compte deux au-dessous d'elle (Run, Projet) — et son défaut de modèle devient un défaut
+> **par harnais**. La précédence `stored → env → default` de chaque réglage est inchangée.
+
 Trois réglages runtime daemon-wide n'existaient qu'en variable d'environnement (shell + redémarrage) : le **cap de sessions** (`PDO_SESSION_CAP`, défaut 20), le **reaper TTL** (`PDO_REAPER_TTL_SECS`, défaut 3600 s) et le **timeout du guard de Trigger** (`PDO_GUARD_TIMEOUT_MS`, défaut 60 s). CONTEXT.md promettait de longue date une page de réglages instance-wide qui les expose (#129 ; cf. *Cap de sessions*, *Trigger*, *terminal inline*). C'est la mauvaise ergonomie pour l'arc d'autonomie non-attendue (ADR-0012 nomme le cap comme *la* primitive de sécurité contre l'effondrement tmux #77/#78).
 
 **Décision.** On introduit une **Configuration d'instance** : une table SQLite **singleton** `instance_config` (une seule ligne) dans `pdo.db`, calquée sur le store des Triggers (config + état mutable, pas un artefact canvas-backed → mauvais fit YAML, cf. CONTEXT.md *Persistence — table SQLite*) ; des routes daemon `GET`/`PUT /settings` ; un écran de réglages frontend. La résolution de chaque réglage suit l'ordre **`stored → env → default`** : la valeur stockée (UI) **gagne**, la variable d'environnement devient un *bootstrap* consulté seulement quand le stored est `NULL`, le défaut est le plancher. `GET /settings` renvoie par champ `{ effective, source, stored, env, default }` (`source ∈ {stored, env, default}`) pour que l'UI **révèle** un env masqué plutôt que de l'ignorer en silence.

--- a/docs/adr/0022-estimated-cost-from-local-transcripts.md
+++ b/docs/adr/0022-estimated-cost-from-local-transcripts.md
@@ -1,5 +1,10 @@
 # Coût estimé d'un Run à partir des transcripts Claude Code locaux
 
+> **Amendé par ADR-0045** : le coût **dérivé** décrit ici (tokens des transcripts × table de prix) n'est
+> plus la seule forme. Un harnais qui calcule lui-même le coût de chaque message en fournit un
+> **rapporté**, qu'on somme tel quel — mesuré indispensable : ses buckets de cache ne se mappent pas sur
+> les quatre d'ici, donc un recalcul uniforme est impossible. Un harnais sans capacité de coût rend « — ».
+>
 > **Amendé par ADR-0034 (#427)** : la table de prix n'est plus un `const` seul — elle a trois tiers
 > (`manuel → fetché → embarquée`, fusion par clé) remplis par un fetch hors du chemin de lecture.
 > Ce qui survit intact ici : le coût reste une **estimation**, **dérivée à la lecture**, jamais

--- a/docs/adr/0032-liveness-death-and-turn-end-completion.md
+++ b/docs/adr/0032-liveness-death-and-turn-end-completion.md
@@ -10,6 +10,10 @@
 > observait ensuite fidèlement, sous un `session_died` parfaitement crédible. Le verdict terminal
 > reste le bon ; ce qu'il faut lire avec lui, c'est **qui** a tué la session.
 >
+> **Amendé par ADR-0045.** « La mort de session est le seul verdict terminal » cesse d'être un constat
+> sur Claude Code pour devenir un **critère d'éligibilité** d'un harnais agentique : un harnais qui sort
+> en fin de travail rendrait ce verdict indiscernable d'un succès, donc il est refusé.
+>
 > **Amendé par ADR-0043 (#433).** La complétion sur fin de tour (§2) gagne un substrat de livraison
 > **primaire, event-driven, côté agent** : un hook `Stop` de Claude Code, injecté par le runtime, qui
 > exécute `pdo complete --auto` à chaque fin de tour. Le balayage daemon décrit ci-dessous en devient

--- a/docs/adr/0044-le-harnais-est-un-axe-a-quatre-tiers-modele-et-effort-sont-conditionnes-par-lui.md
+++ b/docs/adr/0044-le-harnais-est-un-axe-a-quatre-tiers-modele-et-effort-sont-conditionnes-par-lui.md
@@ -1,0 +1,69 @@
+# ADR-0044 — Le harnais agentique est un axe à quatre tiers ; le modèle et l'effort sont conditionnés par lui, jamais résolus à part
+
+> Statut : accepted (grilling du 2026-08-14). Vocabulaire : CONTEXT.md §*Harnais agentique*, §*Modèle
+> et effort*, §*Projet*. **Amende ADR-0015** (la Configuration d'instance gagne un tier au-dessus
+> d'elle, et son défaut de modèle devient un défaut *par harnais*). Forme du descripteur et contrat
+> d'éligibilité d'un harnais → **ADR-0045**.
+
+## Contexte
+
+PDO n'a jamais lancé qu'un seul harnais, `claude`. Le modèle est donc un axe autonome à deux tiers
+(`node` → instance → défaut du compte, #296/#347) et l'effort un troisième axe sans défaut (#424).
+Ouvrir le produit à plusieurs harnais casse ce découpage : un identifiant de modèle n'a pas
+d'existence hors du harnais qui l'accepte.
+
+## Ce qu'on décide
+
+1. **Le harnais est un axe à quatre tiers** : `node` → Run → Projet → Configuration d'instance →
+   plancher (`claude`). Il se résout **une fois, au spawn**, et se gèle dans l'événement de démarrage
+   du nœud.
+2. **Le modèle et l'effort ne sont pas des axes.** Un node porte une **carte par harnais** ; les
+   valeurs se lisent dans l'entrée du **harnais gagnant**. Aucune précédence propre, aucun merge de
+   champs entre tiers de harnais différents.
+3. **Le tier intermédiaire est un Projet** — un regroupement nommé de dépôts membres — et non le
+   repo cible nu.
+4. **Les sessions d'infra** (Pipeline Manager, résolveur de merge) suivent le harnais **du Run**.
+
+## Pourquoi, et ce qui a tué les alternatives
+
+**Garder le modèle comme axe séparé est réfuté par le tier Run.** Ce tier existe pour relancer le
+*même* pipeline sur un autre harnais. Un node qui porte un modèle est plus fin que le Run, donc il
+gagne : le Run bascule sur `opencode` et chaque nœud est lancé avec un slug Anthropic, donc **tous**
+échouent au démarrage. Aucun réaménagement de précédence ne sauve ce cas — ce n'est pas un conflit de
+tiers, c'est une valeur qui n'a pas de sens dans l'autre harnais. La carte est la seule forme où un
+changement de harnais à un tier grossier reste exécutable.
+
+**Le triple atomique par tier** (le tier gagnant fournit harnais + modèle + effort d'un bloc) est
+écarté par ses effets de bord : passer un node en modèle capable forcerait à re-nommer son harnais, et
+un réglage posé sur un Projet écraserait l'effort de tous ses nœuds.
+
+**Le tier intermédiaire ne peut pas être le repo cible.** Le repo cible est stocké **verbatim, jamais
+canonicalisé** (ADR-0033) et les listes le comparent verbatim : un store keyé dessus donnerait deux
+configurations pour deux orthographes du même chemin, sans réconciliation possible. Et depuis
+ADR-0042 un Run porte plusieurs dépôts — « le dépôt » n'est plus une clé. Le Projet nomme le
+regroupement une fois ; l'appartenance, elle, reste une comparaison verbatim.
+
+**L'identité d'un Projet n'est pas l'ensemble des dépôts d'un Run.** Le multi-repo étant un axe
+par-Run (ADR-0042), cet ensemble varie d'un Run au suivant : en faire l'identité ferait disparaître le
+nom donné *et* le réglage attaché dès qu'un Run ajoute un dépôt secondaire.
+
+**Un Projet est matérialisé à la demande, jamais seedé.** Le groupement des listes est déjà dérivé du
+chemin ; une ligne n'existe que si un humain nomme le groupe ou y attache un réglage. Même posture que
+la table de prix (ADR-0034 : rien n'est seedé) et que les agrégats (ADR-0029 : dérivé à la lecture).
+
+**Le gel au spawn** reprend la leçon de #424 : la reprise doit re-poser ce qui a été **lancé**, pas ce
+que le YAML ou le Projet disent maintenant — une édition n'atteint jamais l'itération vivante d'un
+nœud (ADR-0007).
+
+## Limites acceptées
+
+- **Un node sans entrée pour le harnais gagnant tourne sans modèle**, donc au défaut du compte de ce
+  harnais. C'est exactement ce que « pas de modèle posé » veut déjà dire ; on n'invente pas un refus.
+- **Les sessions d'infra suivant le Run**, un A/B sur un harnais neuf met aussi le manager à
+  l'épreuve : l'outil de déblocage est celui qu'on teste. Choisi en connaissance de cause, pour que
+  « tout ce Run tourne sur X » reste vrai sans exception à retenir.
+- **Le YAML change de forme** : le champ de modèle plat devient une entrée de carte sous `claude`.
+  Breaking, annoncé en semver, migré par le migrateur de pipelines.
+- **Quatre tiers, c'est un de plus que le sandbox** (`Run → Trigger → instance → off`). Le tier
+  Trigger n'est pas dupliqué ici : le template d'un Trigger *est* la charge utile d'un `POST /runs`,
+  donc un Trigger pose son harnais par construction.

--- a/docs/adr/0045-un-harnais-se-declare-par-un-template-d-argv-les-capacites-remplissent-les-trous.md
+++ b/docs/adr/0045-un-harnais-se-declare-par-un-template-d-argv-les-capacites-remplissent-les-trous.md
@@ -1,0 +1,90 @@
+# ADR-0045 — Un harnais se déclare par un template d'argv ; les capacités remplissent les trous ; l'absence est dite, jamais suppléée
+
+> Statut : accepted (grilling du 2026-08-14, mesures sur `claude` 2.x et `opencode` 1.18.18).
+> Vocabulaire : CONTEXT.md §*Harnais agentique*. Précédence et conditionnement du modèle → **ADR-0044**.
+> **Amende ADR-0032** : « la mort de session est le seul verdict de mort » devient un **critère
+> d'éligibilité** d'un harnais, pas seulement un constat sur `claude`.
+
+## Contexte
+
+Le lancement d'un nœud porte aujourd'hui cinq flags propres à Claude Code, un fichier de réglages
+injecté (ADR-0043), une identité de session épinglée (#473), un parse de transcript JSONL et une ancre
+de texte dans le pane. Accueillir un second harnais demande de trancher ce qui se **déclare** et ce qui
+s'**écrit**.
+
+## Ce qu'on décide
+
+1. **Un harnais se déclare par deux templates d'argv** (lancement, reprise) et un bloc d'env. Règle
+   unique : **un token contenant un trou vide est supprimé en entier**. Les trous sont le prompt, le
+   modèle, l'effort, l'identité de session et le fichier de réglages.
+2. **Les capacités remplissent les trous.** Une capacité est du **code** écrit harnais par harnais :
+   coût, résolution du transcript, complétion sur fin de tour, détection de menu de limite, plancher de
+   staging, épinglage d'identité. Sans capacité, le trou reste vide, le token disparaît, et la feature
+   est **absente et nommée absente** (un coût illisible s'affiche « — », jamais `$0`).
+3. **Éligibilité : résident.** Un harnais qui sort en fin de travail est refusé.
+4. **PDO ne valide pas un descripteur.**
+
+## Pourquoi, et ce qui a tué les alternatives
+
+**Des champs nommés n'achètent rien — deux harnais suffisent à le montrer.** `--model X` contre
+`-m X` ; prompt en argument positionnel contre `--prompt` ; et un harnais **sans aucun axe d'effort au
+lancement** (mesuré : sur `opencode` 1.18.18, l'effort se règle par une commande *dans* la session,
+pas par un flag). Un champ nommé par cas devient une épellation par cas, alors que le template les
+couvre sans les nommer — et l'absence d'un trou est elle-même le signal exploitable par l'UI, qui
+grise le picker sans réglage supplémentaire.
+
+**Déclarer les sondes dans un mini-langage est réfuté par la mesure.** Le fold de coût de Claude Code
+dédupe sur deux clés et somme quatre buckets de cache avec des multiplicateurs distincts ; `opencode`
+écrit lui-même un coût par message et n'expose que deux buckets (read/write). Non seulement aucun
+langage déclaratif raisonnable n'exprime les deux, mais **un recalcul uniforme est impossible** : les
+buckets ne se mappent pas l'un sur l'autre. Le coût reste donc du code, avec deux formes légitimes —
+**rapporté** par le harnais, ou **dérivé** par PDO (tokens × table de prix, ADR-0034).
+
+**Un trait fermé à N implémentations est écarté** pour deux raisons : il interdit d'ajouter un harnais
+sans recompiler, et il ferait remonter les particularités de Claude Code (le sibling `.claude.json`,
+l'appariement de transcript par répertoire de travail) dans l'interface que tous les autres doivent
+implémenter.
+
+**Le résident est obligatoire, et le one-shot est refusé malgré son avantage.** En one-shot la fin de
+tour serait **gratuite** — la sortie du process *est* le signal — là où `claude` a demandé ADR-0032 §2
+puis ADR-0043 pour l'obtenir. On refuse quand même : un nœud doit rester attachable et conversationnel
+jusqu'à son reap, c'est le principe même du produit (ADR-0012), et en one-shot la mort de session
+cesse d'être un verdict d'échec (ADR-0032). Deux invariants ne s'échangent pas contre un confort
+d'implémentation.
+
+**Pas de validation du descripteur** (ADR-0001) : PDO ne sait pas ce que le template *veut dire*. La
+conséquence est réelle et connue — un descripteur sans flag d'autonomie donne un nœud arrêté sur un
+dialogue de permission, vivant et immobile, que **rien** ne détecte depuis la suppression du filet de
+staleness (#469). Le premier nœud lancé le dit ; PDO ne le devine pas.
+
+## Limites acceptées
+
+- **Un harnais qui ne laisse pas imposer l'identité de session** ne peut être attribué que par
+  répertoire de travail — précisément le trou que #473 vient de fermer pour `claude`. Mesuré sur
+  `opencode` : lancer avec un id de session neuf répond « Session not found » et sort en 1 — le
+  sélecteur *continue* une session, il ne la crée pas. Deux nœuds `doc-only` concurrents partagent le
+  worktree du Run, donc leurs sessions se confondent : coût attribué au mauvais nœud, fin de tour lue
+  sur la mauvaise session. Accepté en v1.
+  Le levier mesuré n'est pas de relocaliser le store : c'est que ce harnais **sert une API HTTP locale**
+  et accepte un **port au lancement**. PDO attribuant déjà un port par nœud, il peut créer la session
+  lui-même puis s'y attacher, et lire messages, coût et arrêt par cette API — sans coupler PDO au
+  schéma d'une base étrangère. À vérifier avant de s'engager : le listing de sessions de cette API est
+  **global**, pas scopé au port, donc seule la création-puis-attache ferme réellement le trou.
+- **Le store d'un harnais n'est pas un contrat.** Mesuré : `opencode` 1.18.18 écrit ses sessions et ses
+  messages dans un SQLite, et son ancien store de fichiers JSON — encore présent sur disque, avec des
+  mois de données — n'est plus écrit du tout. Une capacité de coût branchée sur la forme *observée* du
+  store lit de l'historique mort et rapporte zéro sur chaque Run : la lecture passe par l'API du harnais
+  quand il en a une.
+- **Un modèle qu'un harnais ne peut pas honorer ne fait pas forcément échouer le lancement.** Mesuré :
+  `opencode` avec un modèle valide mais injoignable (fournisseur non authentifié) **retombe en silence**
+  sur son défaut et rend un tour vert sous un autre modèle ; avec un modèle joignable, le flag est bien
+  honoré. PDO ne peut donc pas compter sur un échec bruyant pour révéler un réglage non tenu — le mode
+  d'échec appartient au harnais.
+- **Le choix « reprendre par identité ou en aveugle » reste en code** : il parle des lignes d'event log
+  antérieures à #473, pas du harnais.
+- **Le sandbox est hors périmètre** : le plancher de staging reste propre à `claude` (ADR-0031). Un
+  autre harnais dans un Run sandboxé ne tient que par le Dockerfile de l'utilisateur et les exceptions
+  `$HOME` de son profil, sans aucune garantie du plancher — et PDO le dit une fois, visiblement.
+- **Un harnais déclaré sans capacité est utilisable mais aveugle** : il tourne, on l'attache, il
+  complète ; il ne rapporte ni coût ni fin de tour. C'est la contrepartie assumée de « on peut ajouter
+  un harnais à la volée ».

--- a/docs/adr/0045-un-harnais-se-declare-par-un-template-d-argv-les-capacites-remplissent-les-trous.md
+++ b/docs/adr/0045-un-harnais-se-declare-par-un-template-d-argv-les-capacites-remplissent-les-trous.md
@@ -1,7 +1,7 @@
 # ADR-0045 — Un harnais se déclare par un template d'argv ; les capacités remplissent les trous ; l'absence est dite, jamais suppléée
 
 > Statut : accepted (grilling du 2026-08-14, mesures sur `claude` 2.x et `opencode` 1.18.18).
-> Vocabulaire : CONTEXT.md §*Harnais agentique*. Précédence et conditionnement du modèle → **ADR-0044**.
+> Vocabulaire : CONTEXT.md §*Harnais agentique*. Précédence et conditionnement du modèle → **ADR-0046**.
 > **Amende ADR-0032** : « la mort de session est le seul verdict de mort » devient un **critère
 > d'éligibilité** d'un harnais, pas seulement un constat sur `claude`.
 

--- a/docs/adr/0046-le-harnais-est-un-axe-a-quatre-tiers-modele-et-effort-sont-conditionnes-par-lui.md
+++ b/docs/adr/0046-le-harnais-est-un-axe-a-quatre-tiers-modele-et-effort-sont-conditionnes-par-lui.md
@@ -1,4 +1,4 @@
-# ADR-0044 — Le harnais agentique est un axe à quatre tiers ; le modèle et l'effort sont conditionnés par lui, jamais résolus à part
+# ADR-0046 — Le harnais agentique est un axe à quatre tiers ; le modèle et l'effort sont conditionnés par lui, jamais résolus à part
 
 > Statut : accepted (grilling du 2026-08-14). Vocabulaire : CONTEXT.md §*Harnais agentique*, §*Modèle
 > et effort*, §*Projet*. **Amende ADR-0015** (la Configuration d'instance gagne un tier au-dessus

--- a/docs/test-scenarios/HP-02-run-to-completion.md
+++ b/docs/test-scenarios/HP-02-run-to-completion.md
@@ -1,6 +1,6 @@
 ---
 id: HP-02
-covers: [run, start-node, tmux-session, dataflow, conditional-routing, loop-region, collection, merge, artifact, run-stats, sandbox, staging-profile, staging-floor, sandbox-prep]
+covers: [run, start-node, tmux-session, dataflow, conditional-routing, loop-region, collection, merge, artifact, run-stats, sandbox, staging-profile, staging-floor, sandbox-prep, harness, harness-pin, harness-capability]
 ---
 
 # HP-02 — Launch a run to completion
@@ -8,9 +8,10 @@ covers: [run, start-node, tmux-session, dataflow, conditional-routing, loop-regi
 ## Goal
 
 A user launches a **Run** on a pipeline: picks a target repo, enters a prompt (optionally images),
-and watches nodes spawn real **tmux sessions** running `claude`, data route through edges / a loop
-region / a collection fan-out into a **Merge**, until the Run reaches a clean **Completed** state with
-inspectable artifacts and live stats — the core "drive an orchestration to its end" loop.
+and watches nodes spawn real **tmux sessions** running each node's resolved **harness** (`claude` is
+the floor, not the only one), data route through edges / a loop region / a collection fan-out into a
+**Merge**, until the Run reaches a clean **Completed** state with inspectable artifacts and live
+stats — the core "drive an orchestration to its end" loop.
 
 ## Drive-by
 
@@ -38,11 +39,18 @@ Features validated while crossing the run screens (grafted from retired per-issu
   business outcome by two visibly different routes. The `off` twin is the **control**: without it, a
   green sandboxed Run proves nothing (a Run that silently fell back to the host path also looks
   green). See the journey's §10-12 and the dedicated checks below.
+- **Agentic harness, as an A/B pair** (PRD #549, ADR-0045, ADR-0046): a **two-node** pipeline runs one
+  node pinned to **`claude`** and one pinned to **`opencode`** in the **same Run**. The pair is the
+  control, exactly as for the sandbox: a single-harness Run that silently resolved to the `claude`
+  floor is indistinguishable from a correctly resolved one, so the second harness is what makes the
+  four-tier resolution observable at all. See the journey's §14-15.
 
 ## Preconditions
 
 - The app is running locally and reachable in a browser; status bar shows the daemon **connected**.
 - `claude` is on `PATH` (the daemon shells out to it for each node session).
+- `opencode` is on `PATH` too: the second harness of the embedded floor (ADR-0045), and the harness
+  A/B needs both binaries resident.
 - A valid pipeline and a target git repo are available. No hard-coded ports/ids in the journey — see
   `docs/agents/run-scenario.md` for how to drive PDO and probe side-effects.
 
@@ -81,6 +89,12 @@ Features validated while crossing the run screens (grafted from retired per-issu
     Open the profile editor → it lists the floor entry by entry, and its **Image** control offers
     `default` / `dockerfile` / `registry`, the `default` option saying in one sentence that the tag is
     the SHA-256 of the seeded Dockerfile's bytes.
+14. **Harness A/B.** Seed a **two-node** pipeline: two parallel nodes, each asked for a single line of
+    output. In the **node inspector**, pin the first node's harness to **`claude`** and the second's to
+    **`opencode`**; each node's inspector reads back which harness it **resolves** to. Launch it once,
+    sandbox **`off`** (the two axes are deliberately not crossed — see the notes).
+15. Both nodes start, both reach **completed**, and the Run reaches **Completed** with the End
+    `result` port **received**: one Run, two harnesses, one outcome.
 
 ## Checks
 
@@ -118,6 +132,20 @@ Features validated while crossing the run screens (grafted from retired per-issu
   floor entry by entry, offers the three-way **Image** control, warns on credential-bearing entries,
   and lists a profile's referents before confirming its deletion.
 
+#### Harness A/B (steps 14-15)
+
+- The node inspector offers **Default / claude / opencode** and reads back the **resolved** harness,
+  saying whether that is a **pin** or the **floor**.
+- The **effort picker is greyed on the `opencode` node** and live on the `claude` one. That is the
+  descriptor's missing `{effort}` hole surfacing on screen (ADR-0045): an absence *declared*, not a
+  defect, and the cheapest visible proof that the resolved harness reached the UI at all.
+- **Est. cost reads "—" and names `opencode`** — never `$0`, and never the `claude` node's dollars on
+  their own. A Run that launched a node on a harness with no cost source is not honestly summable, so
+  the whole amount goes (#553, the `unpriced_models` vein of #425). A number reappearing there is the
+  regression, and it is the one that would otherwise pass for a plausible total.
+- Neither pane sits on an interactive dialog: `--auto` is `opencode`'s bypass flag, so a permission
+  prompt on that pane is a finding.
+
 ### Backing store
 
 - A tmux session named for the run/node/iter is alive while the node runs and shows `claude` (not a
@@ -137,6 +165,17 @@ Sandbox A/B, read-only probes:
   baseline when the host has one, and a settings file bearing the bypass-permissions key.
 - The `off` twin creates **no** container and **no** staging directory.
 
+Harness A/B, read-only probes:
+
+- The `claude` node's session really runs `claude`, the `opencode` node's really runs `opencode`, **and
+  each agrees with the harness frozen in that node's start event** (#550). The event is the contract —
+  the harness is resolved once, at spawn, and never re-read from the YAML — so a pane that contradicts
+  it is the finding, and this is the only place the disagreement is visible.
+- **Do not assert the `opencode` node's model.** Measured on 1.18.18: an unreachable model id falls
+  back **silently** to another provider and the turn still goes green, so a model assertion there is a
+  false pass either way. Same for any transcript-based probe: `opencode` cannot pin a session identity,
+  so PDO attributes by working directory alone.
+
 ## Cleanup (best-effort)
 
 - Archive the Run (`cleanup_run`): it reaps sessions and the worktree. Delete any pipeline the agent
@@ -145,6 +184,9 @@ Sandbox A/B, read-only probes:
   container named for either Run survives, and the `full` Run's staging directory is gone. Its ~1 GB
   is reclaimed **only** here — a missed purge is the known disk-fill recurrence, and a silent leak
   is a finding.
+- Archive the **harness A/B** Run and delete its two-node pipeline. Leave `opencode`'s own store
+  (`~/.local/share/opencode/`) **alone**: the run legitimately writes a session there, that is the
+  harness's business, and deleting a user's harness database is not cleanup.
 
 ## Notes
 
@@ -154,7 +196,8 @@ Sandbox A/B, read-only probes:
 - **Select data by characteristics, not hard-coded ids** (HP mode): if no data satisfies a condition,
   that is a legitimate finding, not an excuse to bypass the UI.
 - A first `claude` launch in a fresh worktree lands on the trust dialog — confirm it (see the driving
-  playbook) before expecting chat output.
+  playbook) before expecting chat output. That one is **`claude`'s**, not the product's: `opencode
+  --auto` shows no such dialog, so a dialog on an `opencode` pane is a finding rather than a step.
 - A node with no output yet returns **409 `missing_outputs`** on "Mark complete" — that guard is
   expected, not a bug.
 
@@ -177,3 +220,24 @@ Sandbox A/B, read-only probes:
   Asserting it here would report a documented backlog item as a regression on every execution. The
   host-uid half of this note is **gone**: since #414 a named identity is injected into the container,
   so `whoami` and `sudo -n true` DO work under any host uid — a failure there is a finding.
+
+### Harness A/B — why it is built this way
+
+- **Its own two-node pipeline, not a pin on the main journey's nodes.** Those nodes carry the dataflow
+  (conditional routing, loop region, collection, merge); a node that fails to complete among them costs
+  six steps of assertions downstream. Isolating the newest axis is the same call the sandbox twin makes
+  by getting its own one-node pipeline.
+- **The two axes are not crossed, on purpose.** HP-02 already pays ~1 GB of staging for the sandbox
+  pair; harness × sandbox would be four combinations for no extra information. The harness pair rides
+  the `off` side, where it costs two panes.
+- **`opencode` completes because the agent runs `pdo complete` itself, and for now that IS the
+  contract.** It has neither of PDO's automatic substrates: no turn-end `Stop` hook (its argv template
+  carries no `{settings}` hole, so the hook file is written and never referenced) and no turn-end sweep
+  probe (no `turn_end_substrate` capability, #553). That instrumentation is deliberately later work and
+  **is not a defect to raise here** — what this journey asserts is the outcome, that the node reaches
+  completed.
+- **Bound the wait on the `opencode` node.** Because the harness is *resident* (ADR-0045: it stays
+  alive after its turn), a node that never self-completes stays `running`, **alive and mute rather than
+  dead** — there is no session death to notice and nothing times it out. Give it a finite wait and
+  raise a finding on the harness's obedience; do not sit on it, and do not read the silence as the
+  missing auto-completion above.

--- a/docs/test-scenarios/HP-02-run-to-completion.md
+++ b/docs/test-scenarios/HP-02-run-to-completion.md
@@ -91,10 +91,15 @@ Features validated while crossing the run screens (grafted from retired per-issu
     the SHA-256 of the seeded Dockerfile's bytes.
 14. **Harness A/B.** Seed a **two-node** pipeline: two parallel nodes, each asked for a single line of
     output. In the **node inspector**, pin the first node's harness to **`claude`** and the second's to
-    **`opencode`**; each node's inspector reads back which harness it **resolves** to. Launch it once,
-    sandbox **`off`** (the two axes are deliberately not crossed — see the notes).
-15. Both nodes start, both reach **completed**, and the Run reaches **Completed** with the End
-    `result` port **received**: one Run, two harnesses, one outcome.
+    **`opencode`**; each node's inspector reads back which harness it **resolves** to. On the
+    `opencode` node, also set a **model** through the picker's `Custom…` escape hatch — a
+    `provider/model` slug that supports tool use (e.g. `openrouter/anthropic/claude-haiku-4.5`).
+    **This is not optional**, and the notes say why.
+15. Open **New Run** on it. Set the Run's **Harness** field to **`claude`** and sandbox to **`off`**,
+    then Launch. Setting the Run tier to `claude` is what turns the second node's pin into a real
+    proof: it must still run `opencode` *against* the tier above it. Both nodes start, both reach
+    **completed**, and the Run reaches **Completed** with the End `result` port **received**: one Run,
+    two harnesses, one outcome.
 
 ## Checks
 
@@ -135,7 +140,11 @@ Features validated while crossing the run screens (grafted from retired per-issu
 #### Harness A/B (steps 14-15)
 
 - The node inspector offers **Default / claude / opencode** and reads back the **resolved** harness,
-  saying whether that is a **pin** or the **floor**.
+  saying whether that is a **pin** or the **floor** ("Resolved: opencode (pinned)" vs "Resolved:
+  claude (floor — no pin)").
+- Saving writes the pin as the node's own `pin_harness`, and the custom model under the **resolved
+  harness's key** (`harnesses: { opencode: { model: … } }`), not as a flat `model:` — the per-harness
+  map of #550, since a model means nothing outside a harness.
 - The **effort picker is greyed on the `opencode` node** and live on the `claude` one. That is the
   descriptor's missing `{effort}` hole surfacing on screen (ADR-0045): an absence *declared*, not a
   defect, and the cheapest visible proof that the resolved harness reached the UI at all.
@@ -171,6 +180,12 @@ Harness A/B, read-only probes:
   each agrees with the harness frozen in that node's start event** (#550). The event is the contract —
   the harness is resolved once, at spawn, and never re-read from the YAML — so a pane that contradicts
   it is the finding, and this is the only place the disagreement is visible.
+- Each pane's **real argv** matches its descriptor's template: the `claude` one carries
+  `--dangerously-skip-permissions` and a `--session-id`, the `opencode` one carries `--auto --prompt`
+  and **neither** `--session-id` (it cannot pin an identity) **nor** `--settings` (its template has no
+  such hole). Those two absences are the descriptor's shape showing through to the process table.
+- Both output artifacts carry the expected line. A `completed` status is not evidence on its own
+  (#490): read the artifact.
 - **Do not assert the `opencode` node's model.** Measured on 1.18.18: an unreachable model id falls
   back **silently** to another provider and the turn still goes green, so a model assertion there is a
   false pass either way. Same for any transcript-based probe: `opencode` cannot pin a session identity,
@@ -241,3 +256,20 @@ Harness A/B, read-only probes:
   dead** — there is no session death to notice and nothing times it out. Give it a finite wait and
   raise a finding on the harness's obedience; do not sit on it, and do not read the silence as the
   missing auto-completion above.
+- **The `opencode` node MUST carry a model, and this is the trap that sinks a first run.** PDO passes
+  no `--model` when a node declares none, and `opencode` then resolves its **own** default from the
+  operator's config — whatever they last selected. Measured here: it landed on an *image* model and the
+  turn died on `No endpoints found that support tool use`, so the node could neither write its artifact
+  nor complete, and simply sat there resident. Nothing in PDO is at fault and nothing warns: a model id
+  is meaningless outside its harness, so `opencode` needs an explicit `provider/model`.
+- **The model picker still speaks `claude` on an `opencode` node.** It offers `sonnet` / `opus` /
+  `haiku` / `opusplan` / `fable` — Anthropic aliases that mean nothing to `opencode` — so `Custom…` is
+  the only usable path. The effort picker greys correctly off the descriptor; the model *list* does not
+  follow the resolved harness. Do not pick `haiku` here and assume it took.
+- **`opencode`'s residency is conditional, and its exit reads as a session death.** It is resident
+  after a *completed* turn (that is its ADR-0045 eligibility), but after the hard provider error above
+  it exited on its own a couple of minutes later, which surfaced as `session_died` and reconciled the
+  Run to `failed` with `run_stalled: … blocked behind: <node>`. Two things it is **not**: the PTY
+  bridge (it kills its own `tmux attach` client on socket close, never the session — verified by
+  opening and closing a bridge on a live session, which survived), and memory pressure (the detector's
+  own diagnostics carry `mem_available_kb` / `swap_free_kb`, so read them before blaming the machine).

--- a/docs/test-scenarios/README.md
+++ b/docs/test-scenarios/README.md
@@ -27,7 +27,7 @@ Two levels:
 | ID | Title | Covers | Status |
 |---|---|---|---|
 | [HP-01](HP-01-author-and-save.md) | Author & save a pipeline | pipeline authoring, library, unified canvas | active |
-| [HP-02](HP-02-run-to-completion.md) | Launch a run to completion | run lifecycle, dataflow, artifacts, stats, **sandbox A/B (`full` vs `off`)** | active |
+| [HP-02](HP-02-run-to-completion.md) | Launch a run to completion | run lifecycle, dataflow, artifacts, stats, **sandbox A/B (`full` vs `off`)**, **harness A/B (`claude` vs `opencode`)** | active |
 | HP-03 | *(reserved — free slot)* | candidate: Triggers, once it is core | — |
 
 The 3rd slot is intentionally free. To add it: allocate `HP-03`, follow `SCENARIO-FORMAT.md`, update
@@ -42,3 +42,10 @@ before running the suite: each execution copies ~1 GB of staging and spends tens
 preparing, and the journey must **stay on the Run** during preparation (see HP-02's notes for why
 that is load-bearing). The day the instance default stops being `off` — a VPS deployment, where
 most Runs will be sandboxed — this drive-by is the natural candidate to be promoted to `HP-03`.
+
+**The agentic-harness axis (PRD #549) is grafted onto HP-02 for the same reason, at a far lower
+price.** The pair `claude` + `opencode` is what makes it meaningful: a single-harness Run that
+silently resolved to the `claude` floor is indistinguishable from a correctly resolved one, so the
+second harness is the control that makes the four-tier resolution observable. Unlike the sandbox pair
+it costs almost nothing — two panes inside one Run, no staging, no image — which is why it rides
+HP-02's `off` side rather than claiming the free slot. `HP-03` stays reserved for Triggers.

--- a/frontend/e2e/runs-triggers-by-repo.spec.ts
+++ b/frontend/e2e/runs-triggers-by-repo.spec.ts
@@ -163,14 +163,18 @@ test("Triggers list groups by repo across ≥2 repos, including the daemon's own
   expect(labels).toContain(path.basename(WORKSPACE_ROOT));
   expect(labels.join(" ")).not.toMatch(/unassigned/i);
 
-  // Groups are ordered by full PATH (groupByRepo), not by the basename label.
-  // Assert the displayed label order equals sorting the three repos by full path,
-  // so the check is robust to the workspace's absolute path — which differs
-  // between local (…/Maestro) and CI (…/prompt-driven-orchestrator) and would
-  // otherwise flip basename order relative to full-path order.
+  // Groups are ordered by the DISPLAYED LABEL (groupByProject, #552), tie-broken
+  // by group key — no longer by full path as #258's groupByRepo did. Sorting on
+  // what the user actually reads is why a Projet, whose name has no path at all,
+  // can take its place in the same ordering.
+  //
+  // This also removes the local/CI trap the previous assertion had to work around:
+  // the expectation now sorts the same strings the UI sorts, so it no longer
+  // depends on the workspace's absolute path (…/Maestro locally,
+  // …/prompt-driven-orchestrator in CI) landing on the same side as its basename.
   const expectedLabelOrder = [repoA, repoB, WORKSPACE_ROOT]
-    .sort((a, b) => (a < b ? -1 : a > b ? 1 : 0))
-    .map((p) => path.basename(p));
+    .map((p) => path.basename(p))
+    .sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
   expect(labels).toEqual(expectedLabelOrder);
 
   // Full path on hover: the repoA group header carries title=repoA.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,10 +5,10 @@ import type { ConnectionStatus } from "./hooks/useDaemonSocket";
 import { useResizableLayout } from "./hooks/useResizableLayout";
 import { useLibrary } from "./hooks/useLibrary";
 import { useLibraryPipelines } from "./hooks/useLibraryPipelines";
-import { fetchRuns, fetchRun, fetchTriggers, fetchSessions, fetchTriggersHealth, pauseTriggers } from "./api";
+import { fetchRuns, fetchRun, fetchTriggers, fetchProjects, fetchSessions, fetchTriggersHealth, pauseTriggers } from "./api";
 import { pickLatestLiveNode } from "./lib/pickLatestLiveNode";
 import { useRightPaneRouter } from "./hooks/useRightPaneRouter";
-import type { RunListEntry, RunState, Trigger, DaemonStatus } from "./types";
+import type { RunListEntry, RunState, Trigger, Project, DaemonStatus } from "./types";
 import { shouldAutoSnapToLiveNode } from "./lib/autoSnap";
 import SessionCounter from "./components/SessionCounter";
 import ServiceHealthIndicator from "./components/ServiceHealthIndicator";
@@ -95,6 +95,22 @@ function useTriggers() {
   return { triggers, refresh };
 }
 
+// #552 — Projets, hydrated on mount and refreshed on a `project_changed` WS push
+// (the daemon broadcasts one on every project mutation). Mirror of useTriggers.
+function useProjects() {
+  const [projects, setProjects] = useState<Project[]>([]);
+
+  const refresh = useCallback(async () => {
+    try {
+      setProjects(await fetchProjects());
+    } catch {
+      // ignore
+    }
+  }, []);
+
+  return { projects, refresh };
+}
+
 function useSelectedRun() {
   const [run, setRun] = useState<RunState | null>(null);
   const currentIdRef = useRef<string | null>(null);
@@ -136,6 +152,7 @@ export default function App() {
   const { runs, refresh: refreshRuns } = useRuns();
   const { sessions, refresh: refreshSessions } = useSessions();
   const { triggers, refresh: refreshTriggers } = useTriggers();
+  const { projects, refresh: refreshProjects } = useProjects();
   // #348: global Trigger pause. Lifted here (not in a per-panel hook) so the WS
   // dispatcher can flip it live and every consumer stays in sync; hydrated on
   // mount from GET /triggers/health since there is no trigger polling.
@@ -393,6 +410,7 @@ export default function App() {
       refreshRuns();
       refreshSessions();
       refreshTriggers();
+      refreshProjects();
       // #348: hydrate the global pause flag once — no trigger polling carries it,
       // so without this a page reload would show the banner off while paused.
       fetchTriggersHealth()
@@ -400,7 +418,7 @@ export default function App() {
         .catch(() => {});
       useRecentReposStore.getState().refresh();
     }
-  }, [refreshRuns, refreshSessions, refreshTriggers]);
+  }, [refreshRuns, refreshSessions, refreshTriggers, refreshProjects]);
 
   // A WS reconnect usually means the daemon restarted — possibly as a different
   // binary, so the /sessions payload (version included, #139) may be stale. An
@@ -493,6 +511,13 @@ export default function App() {
         setTriggersPaused(!!msg.paused);
         return;
       }
+      // #552: a Projet mutation (name/harness/members) — refresh the Projet list
+      // so the Runs and Triggers regrouping is live across clients. The Runs /
+      // Triggers rows themselves are unchanged, so only the Projet list refetches.
+      if (msg.type === "project_changed") {
+        refreshProjects();
+        return;
+      }
       // Trigger lifecycle (#160/#162): create/update/delete refreshes the
       // Triggers list; a fire also creates a Run, so refresh both.
       if (
@@ -525,7 +550,7 @@ export default function App() {
       // count (#159) — keep the status-bar counter current.
       refreshSessions();
     });
-  }, [subscribe, refreshRuns, refreshRun, refreshSessions, refreshTriggers, reloadPipeline, loadPipelines]);
+  }, [subscribe, refreshRuns, refreshRun, refreshSessions, refreshTriggers, refreshProjects, reloadPipeline, loadPipelines]);
 
   // Detect: active tab is a run whose library twin (matched by id, then name)
   // diverges from the run snapshot — pipeline or prompts, the same comparison
@@ -622,6 +647,8 @@ export default function App() {
               onEditTrigger={(t) => openNewRunModal({ kind: "edit-trigger", trigger: t })}
               triggersPaused={triggersPaused}
               onTogglePause={handleTogglePause}
+              projects={projects}
+              onProjectsChanged={refreshProjects}
             />
           </ResizablePanel>
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -563,6 +563,10 @@ export interface CreateRunRequest {
   /** Explicit sandbox (#410/#432): `"off"` or a staging-profile name. Omitted → the
    *  server defers to the trigger/instance default at the create chokepoint. */
   sandbox?: string;
+  /** Explicit harness (#551, ADR-0046): the `run` tier of the precedence chain. Omitted/
+   *  blank → the Run names no harness and each free node resolves through the instance
+   *  default and the `claude` floor. Frozen into `RunStarted` at the create chokepoint. */
+  harness?: string;
   /** Whether the manager auto-names this Run (#338). The modal always sends it; omit and
    *  the server resolves back-compat by the presence of `name`, then the instance default. */
   auto_name?: boolean;
@@ -593,6 +597,10 @@ export function createRun(req: CreateRunRequest): Promise<CreateRunResponse> {
     // sandboxed Run created WITH attached images keeps its mode (the daemon's
     // multipart parser reads this field).
     if (req.sandbox) form.append("sandbox", req.sandbox);
+    // #551: thread the explicit harness through the multipart path too, so a Run created
+    // WITH attached images keeps its harness choice (the daemon's multipart parser reads
+    // this field). Omitted when blank — the Run then names no harness.
+    if (req.harness) form.append("harness", req.harness);
     // #338: thread the explicit auto-naming choice through the multipart path too, so an
     // unchecked "Auto-generated" box is honoured on a create WITH attached images. Sent as
     // a stringified bool; only when the caller made a choice (it always does from the modal).
@@ -680,6 +688,9 @@ export interface CreateTriggerRequest {
   /** Per-Trigger sandbox (#410/#432): `"off"` or a staging-profile name, or null/omit to
    *  inherit the instance default. */
   sandbox?: string | null;
+  /** Per-Trigger harness (#551): a harness name, or null/omit to inherit the instance
+   *  default. Folded into the fired Run's harness (no separate Trigger tier). */
+  harness?: string | null;
   /** Whether Runs this Trigger fires are auto-named (#338). Seeded from the instance
    *  default in the modal; omit → the server defaults to `true` (pre-#338 behaviour). */
   auto_name?: boolean;
@@ -722,6 +733,9 @@ export interface UpdateTriggerRequest {
   /** Per-Trigger sandbox (#410/#432): a value sets it, `null` clears back to
    *  inheriting the instance default, `undefined` leaves it unchanged. */
   sandbox?: string | null;
+  /** Per-Trigger harness (#551): a value sets it, `null` clears back to inheriting the
+   *  instance default, `undefined` leaves it unchanged. */
+  harness?: string | null;
   /** Auto-naming toggle (#338): a bool sets it, `undefined` leaves it unchanged. A flat
    *  bool (no clear state) — mirror of `enabled`. */
   auto_name?: boolean;

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,4 +1,4 @@
-import type { PipelineListEntry, PipelineDetail, PipelineDef, RunListEntry, RunState, PortDef, PortSide, PortType, FrontmatterFieldDecl, FrontmatterViolation, Trigger, TriggerFire, DaemonStatus, InstanceSettings, UpdateSettingsRequest, StatsOverview, StatsCost, SandboxProfile, SandboxProfileImage, SandboxProfileReferents, SyncCostPricesReport } from "./types";
+import type { PipelineListEntry, PipelineDetail, PipelineDef, RunListEntry, RunState, PortDef, PortSide, PortType, FrontmatterFieldDecl, FrontmatterViolation, Trigger, TriggerFire, DaemonStatus, InstanceSettings, UpdateSettingsRequest, StatsOverview, StatsCost, SandboxProfile, SandboxProfileImage, SandboxProfileReferents, SyncCostPricesReport, Project } from "./types";
 import { foldHarnessOntoNode } from "./lib/harness";
 
 const BASE = "";
@@ -750,6 +750,71 @@ export function updateTrigger(
     `/triggers/${encodeURIComponent(triggerId)}`,
     { body: req, label: `PATCH /triggers/${triggerId}` },
   );
+}
+
+// --- Projets (#552, ADR-0046) ---
+
+/** All Projets with their members (`GET /projects`). */
+export function fetchProjects(): Promise<Project[]> {
+  return request<Project[]>("GET", "/projects");
+}
+
+/** Materialise a Projet from a bare name (`POST /projects`). */
+export function createProject(name: string): Promise<Project> {
+  return request<Project>("POST", "/projects", {
+    body: { name },
+    label: "POST /projects",
+  });
+}
+
+/**
+ * Rename a Projet and/or (re)set the harness it carries (`PATCH /projects/{id}`).
+ * `harness`: a string sets it, `null` clears it, `undefined` leaves it unchanged
+ * (double-`Option` on the wire). `name` omitted leaves it unchanged.
+ */
+export interface UpdateProjectRequest {
+  name?: string;
+  harness?: string | null;
+}
+
+export function updateProject(
+  projectId: string,
+  req: UpdateProjectRequest,
+): Promise<Project> {
+  return request<Project>("PATCH", `/projects/${encodeURIComponent(projectId)}`, {
+    body: req,
+    label: `PATCH /projects/${projectId}`,
+  });
+}
+
+/**
+ * Attach a member path to a Projet (`POST /projects/{id}/members`). Throws an
+ * {@link ApiError} with `status: 409` whose message names the owning Projet when
+ * the path already belongs to a different one (AC: refus nommant le propriétaire).
+ */
+export function addProjectMember(projectId: string, path: string): Promise<Project> {
+  return request<Project>(
+    "POST",
+    `/projects/${encodeURIComponent(projectId)}/members`,
+    { body: { path }, label: `POST /projects/${projectId}/members` },
+  );
+}
+
+/** Detach a member path from a Projet (`DELETE /projects/{id}/members`). */
+export function removeProjectMember(projectId: string, path: string): Promise<Project> {
+  return request<Project>(
+    "DELETE",
+    `/projects/${encodeURIComponent(projectId)}/members`,
+    { body: { path }, label: `DELETE /projects/${projectId}/members` },
+  );
+}
+
+/** Delete a Projet and its memberships (`DELETE /projects/{id}`). */
+export function deleteProject(projectId: string): Promise<void> {
+  return request<void>("DELETE", `/projects/${encodeURIComponent(projectId)}`, {
+    responseMode: "void",
+    label: `DELETE /projects/${projectId}`,
+  });
 }
 
 export async function deleteTrigger(triggerId: string): Promise<void> {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,4 +1,5 @@
 import type { PipelineListEntry, PipelineDetail, PipelineDef, RunListEntry, RunState, PortDef, PortSide, PortType, FrontmatterFieldDecl, FrontmatterViolation, Trigger, TriggerFire, DaemonStatus, InstanceSettings, UpdateSettingsRequest, StatsOverview, StatsCost, SandboxProfile, SandboxProfileImage, SandboxProfileReferents, SyncCostPricesReport } from "./types";
+import { foldHarnessOntoNode } from "./lib/harness";
 
 const BASE = "";
 
@@ -1085,12 +1086,27 @@ export function forgetRun(runId: string): Promise<void> {
 
 // --- Run-scoped pipeline ---
 
+// #550/ADR-0046: the daemon returns each node's per-harness `harnesses` map; the
+// editor's pickers edit a flat `model`/`effort` view of the RESOLVED harness. Fold
+// on the way in so the existing UI + library sync keep working; `serializePipeline`
+// folds back on save. Applied at every pipeline-load boundary.
+function foldPipelineDetail(detail: PipelineDetail): PipelineDetail {
+  if (!detail?.pipeline?.nodes) return detail;
+  return {
+    ...detail,
+    pipeline: {
+      ...detail.pipeline,
+      nodes: detail.pipeline.nodes.map(foldHarnessOntoNode),
+    },
+  };
+}
+
 export function fetchRunPipeline(runId: string): Promise<PipelineDetail> {
   return request<PipelineDetail>(
     "GET",
     `/runs/${encodeURIComponent(runId)}/pipeline`,
     { label: `GET /runs/${runId}/pipeline` },
-  );
+  ).then(foldPipelineDetail);
 }
 
 export function saveRunPipeline(
@@ -1120,7 +1136,7 @@ export function fetchPipeline(id: string, scope?: string): Promise<PipelineDetai
     "GET",
     `/pipelines/${encodeURIComponent(id)}${scopeQuery(scope)}`,
     { label: `GET /pipelines/${id}` },
-  );
+  ).then(foldPipelineDetail);
 }
 
 export function savePipeline(

--- a/frontend/src/components/EffortPicker.test.tsx
+++ b/frontend/src/components/EffortPicker.test.tsx
@@ -119,4 +119,34 @@ describe("EffortPicker (#424)", () => {
     expect(screen.getByTestId("merge-effort-option-low")).toBeInTheDocument();
     expect(screen.queryByTestId("node-effort-option-low")).toBeNull();
   });
+
+  // #550/AC #13: greyed when the resolved harness has no launch-time effort axis.
+  it("is greyed when disabled — every option carries the `disabled` attribute", () => {
+    render(<EffortPicker value={null} onChange={() => {}} testid="node-effort" disabled />);
+    // Assert the DISABLED attribute, never `.value`: a `.value` assertion on a
+    // control cannot fail (the known trap this AC calls out).
+    for (const radio of screen.getAllByRole("radio")) {
+      expect(radio).toBeDisabled();
+    }
+    expect(screen.getByRole("radiogroup", { name: "Effort" })).toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
+  });
+
+  it("does not fire onChange while disabled", async () => {
+    const onChange = vi.fn();
+    render(<EffortPicker value={null} onChange={onChange} testid="node-effort" disabled />);
+    await userEvent.click(screen.getByTestId("node-effort-option-high"));
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("is enabled and fires onChange by default (no `disabled` prop)", async () => {
+    const onChange = vi.fn();
+    render(<EffortPicker value={null} onChange={onChange} testid="node-effort" />);
+    const high = screen.getByTestId("node-effort-option-high");
+    expect(high).not.toBeDisabled();
+    await userEvent.click(high);
+    expect(onChange).toHaveBeenCalledWith("high");
+  });
 });

--- a/frontend/src/components/EffortPicker.tsx
+++ b/frontend/src/components/EffortPicker.tsx
@@ -30,10 +30,16 @@ export default function EffortPicker({
   value,
   onChange,
   testid,
+  disabled = false,
 }: {
   value: string | null;
   onChange: (v: string | null) => void;
   testid: string; // "node-effort" | "merge-effort"
+  /* #550/ADR-0046: greyed when the resolved harness has no launch-time effort
+     axis (`opencode`). An absence DECLARED by the descriptor's shape, not a
+     default — so the control is disabled, not hidden. Assert on the `disabled`
+     attribute, never `.value` (a `.value` assertion cannot fail — a known trap). */
+  disabled?: boolean;
 }) {
   const set = value != null && value !== "";
   const known = set && (EFFORT_LEVELS as readonly string[]).includes(value);
@@ -46,7 +52,12 @@ export default function EffortPicker({
   ];
 
   return (
-    <div role="radiogroup" aria-label="Effort" className="flex gap-1">
+    <div
+      role="radiogroup"
+      aria-label="Effort"
+      aria-disabled={disabled}
+      className={`flex gap-1 ${disabled ? "opacity-50" : ""}`}
+    >
       {options.map((o) => {
         // `""` is normalised to unset, so an empty-string value selects Default.
         const selected = (set ? value : null) === o.id;
@@ -56,9 +67,14 @@ export default function EffortPicker({
             type="button"
             role="radio"
             aria-checked={selected}
+            disabled={disabled}
             data-testid={`${testid}-option-${o.slug}`}
-            onClick={() => onChange(o.id)}
-            className={`flex-1 cursor-pointer rounded border px-2 py-1 font-medium transition-colors ${
+            onClick={() => {
+              if (!disabled) onChange(o.id);
+            }}
+            className={`flex-1 rounded border px-2 py-1 font-medium transition-colors ${
+              disabled ? "cursor-not-allowed" : "cursor-pointer"
+            } ${
               selected
                 ? o.id == null
                   ? "border-fg-4 bg-bg-3 text-fg"

--- a/frontend/src/components/NewRunModal.test.tsx
+++ b/frontend/src/components/NewRunModal.test.tsx
@@ -24,6 +24,8 @@ vi.mock("../api", () => ({
     reaper_ttl_secs: { effective: 3600, source: "default", stored: null, env: null, default: 3600 },
     guard_timeout_secs: { effective: 60, source: "default", stored: null, env: null, default: 60 },
     default_model: { effective: null, source: "default", stored: null, env: null, default: null },
+    default_harness: { effective: null, source: "default", stored: null, env: null, default: null },
+    default_harness_model: { effective: {}, stored: {} },
     default_sandbox: { effective: "off", source: "default", stored: null, env: null, default: "off", reason: null },
     sandbox_docker: { available: true, reason: null, checked_at: "2026-07-01T10:00:00.000Z" },
     // #432: the sandbox `<select>` options are DATA now — the two virtual defaults.
@@ -794,6 +796,8 @@ describe("NewRunModal — auto-naming default (#338)", () => {
       reaper_ttl_secs: { effective: 3600, source: "default", stored: null, env: null, default: 3600 },
       guard_timeout_secs: { effective: 60, source: "default", stored: null, env: null, default: 60 },
       default_model: { effective: null, source: "default", stored: null, env: null, default: null },
+      default_harness: { effective: null, source: "default", stored: null, env: null, default: null },
+      default_harness_model: { effective: {}, stored: {} },
       default_sandbox: { effective: "off", source: "default", stored: null, env: null, default: "off", reason: null },
       sandbox_docker: { available: true, reason: null, checked_at: "2026-07-01T10:00:00.000Z" },
       sandbox_profiles: [{ name: "full", virtual: true }, { name: "minimal", virtual: true }],
@@ -1538,6 +1542,8 @@ describe("NewRunModal — sandbox selector (#410)", () => {
       reaper_ttl_secs: { effective: 3600, source: "default", stored: null, env: null, default: 3600 },
       guard_timeout_secs: { effective: 60, source: "default", stored: null, env: null, default: 60 },
       default_model: { effective: null, source: "default", stored: null, env: null, default: null },
+      default_harness: { effective: null, source: "default", stored: null, env: null, default: null },
+      default_harness_model: { effective: {}, stored: {} },
       default_sandbox: { effective: "off", source: "default", stored: null, env: null, default: "off", reason: null },
       // #431: required fields on InstanceSettings; this modal reads neither, they are
       // here to satisfy the typed fixture.
@@ -1823,6 +1829,8 @@ describe("NewRunModal — the launch dialog can defer to default_sandbox (#452)"
       reaper_ttl_secs: { effective: 3600, source: "default", stored: null, env: null, default: 3600 },
       guard_timeout_secs: { effective: 60, source: "default", stored: null, env: null, default: 60 },
       default_model: { effective: null, source: "default", stored: null, env: null, default: null },
+      default_harness: { effective: null, source: "default", stored: null, env: null, default: null },
+      default_harness_model: { effective: {}, stored: {} },
       default_sandbox: { effective: "off", source: "default", stored: null, env: null, default: "off", reason: null },
       sandbox_docker: { available: true, reason: null, checked_at: "2026-07-01T10:00:00.000Z" },
       sandbox_profiles: [
@@ -2034,6 +2042,8 @@ describe("NewRunModal — the target repo is required at the boundary (#470)", (
       reaper_ttl_secs: { effective: 3600, source: "default", stored: null, env: null, default: 3600 },
       guard_timeout_secs: { effective: 60, source: "default", stored: null, env: null, default: 60 },
       default_model: { effective: null, source: "default", stored: null, env: null, default: null },
+      default_harness: { effective: null, source: "default", stored: null, env: null, default: null },
+      default_harness_model: { effective: {}, stored: {} },
       default_sandbox: { effective: "off", source: "default", stored: null, env: null, default: "off", reason: null },
       sandbox_docker: { available: true, reason: null, checked_at: "2026-07-01T10:00:00.000Z" },
       sandbox_profiles: [

--- a/frontend/src/components/NewRunModal.test.tsx
+++ b/frontend/src/components/NewRunModal.test.tsx
@@ -2255,3 +2255,155 @@ describe("NewRunModal — multi-repo (#465)", () => {
     expect(screen.getByTestId("launch-button")).toBeDisabled();
   });
 });
+
+describe("NewRunModal — harness selector (#551)", () => {
+  function harnessSettings(overrides: Partial<InstanceSettings> = {}): InstanceSettings {
+    return {
+      session_cap: { effective: 20, source: "default", stored: null, env: null, default: 20 },
+      reaper_ttl_secs: { effective: 3600, source: "default", stored: null, env: null, default: 3600 },
+      guard_timeout_secs: { effective: 60, source: "default", stored: null, env: null, default: 60 },
+      default_model: { effective: null, source: "default", stored: null, env: null, default: null },
+      default_harness: { effective: null, source: "default", stored: null, env: null, default: null },
+      default_harness_model: { effective: {}, stored: {} },
+      default_sandbox: { effective: "off", source: "default", stored: null, env: null, default: "off", reason: null },
+      sandbox_docker: { available: true, reason: null, checked_at: "2026-07-01T10:00:00.000Z" },
+      sandbox_profiles: [],
+      home: "/home/user",
+      autocomplete_turn_end: { effective: false, source: "default", stored: null, env: null, default: false },
+      default_auto_name: { effective: true, source: "default", stored: null, env: null, default: true },
+      price_table: { manual_path: null, fetched_path: null, source: null, fetched_at: null, fetched_rows: 0, manual_keys: [], reason: null },
+      updated_at: "2026-07-01T10:00:00.000Z",
+      ...overrides,
+    };
+  }
+
+  /** #452 for the harness axis: the run selector NAMES the instance default on the inherit
+   *  option; it never copies it into the field. Assert on the OPTION TEXT and the presence
+   *  of the concrete options — never on `select.value` for the "names it" claim (a value
+   *  assertion cannot fail here — the memory of #347/#452). */
+  it("names the instance default on the inherit option without seeding the field", async () => {
+    vi.mocked(fetchSettings).mockResolvedValue(
+      harnessSettings({
+        default_harness: { effective: "opencode", source: "stored", stored: "opencode", env: null, default: null },
+      }),
+    );
+    vi.mocked(fetchPipelines).mockResolvedValue([makePipeline({ id: "p1", name: "P", scope: "repo" })]);
+    renderModal();
+    const select = (await screen.findByTestId("harness-select")) as HTMLSelectElement;
+    await waitFor(() => {
+      expect(Array.from(select.options).find((o) => o.value === "")).toHaveTextContent(
+        "Use instance default (opencode)",
+      );
+    });
+    // The field asserts nothing of its own — the inherit sentinel, not the copied value.
+    expect(select.value).toBe("");
+    // The embedded harnesses are offered as concrete options.
+    const values = Array.from(select.options).map((o) => o.value);
+    expect(values).toContain("claude");
+    expect(values).toContain("opencode");
+  });
+
+  it("names the claude floor when the instance sets no default", async () => {
+    vi.mocked(fetchSettings).mockResolvedValue(harnessSettings());
+    vi.mocked(fetchPipelines).mockResolvedValue([makePipeline({ id: "p1", name: "P", scope: "repo" })]);
+    renderModal();
+    const select = (await screen.findByTestId("harness-select")) as HTMLSelectElement;
+    await waitFor(() => {
+      expect(Array.from(select.options).find((o) => o.value === "")).toHaveTextContent(
+        "Use instance default (claude)",
+      );
+    });
+  });
+
+  it("passes the chosen harness to createRun", async () => {
+    vi.mocked(fetchSettings).mockResolvedValue(harnessSettings());
+    vi.mocked(fetchPipelines).mockResolvedValue([
+      makePipeline({ id: "p1", name: "Optional Pipeline", scope: "repo", prompt_required: false }),
+    ]);
+    renderModal();
+    await enterValidRepo();
+
+    const select = (await screen.findByTestId("harness-select")) as HTMLSelectElement;
+    await waitFor(() => expect(Array.from(select.options).some((o) => o.value === "opencode")).toBe(true));
+    fireEvent.change(select, { target: { value: "opencode" } });
+
+    vi.useRealTimers();
+    await waitFor(() => expect(screen.getByRole("button", { name: /launch/i })).toBeEnabled());
+    fireEvent.click(screen.getByRole("button", { name: /launch/i }));
+
+    await waitFor(() => {
+      expect(createRun).toHaveBeenCalledWith(expect.objectContaining({ harness: "opencode" }));
+    });
+  });
+
+  it("omits the harness key when left on the inherit default", async () => {
+    vi.mocked(fetchSettings).mockResolvedValue(harnessSettings());
+    vi.mocked(fetchPipelines).mockResolvedValue([
+      makePipeline({ id: "p1", name: "Optional Pipeline", scope: "repo", prompt_required: false }),
+    ]);
+    renderModal();
+    await enterValidRepo();
+    // Leave the harness selector on "" (inherit).
+    await screen.findByTestId("harness-select");
+
+    vi.useRealTimers();
+    await waitFor(() => expect(screen.getByRole("button", { name: /launch/i })).toBeEnabled());
+    fireEvent.click(screen.getByRole("button", { name: /launch/i }));
+
+    await waitFor(() => expect(createRun).toHaveBeenCalled());
+    // The Run names no harness — the daemon resolves through the instance default.
+    expect(vi.mocked(createRun).mock.calls[0][0].harness).toBeUndefined();
+  });
+
+  it("round-trips a Trigger's harness and clears it to null on reset", async () => {
+    vi.mocked(fetchSettings).mockResolvedValue(harnessSettings());
+    vi.mocked(fetchPipelines).mockResolvedValue([
+      makePipeline({ id: "p1", name: "Auditor", scope: "repo", prompt_required: false }),
+    ]);
+    const trigger: Trigger = {
+      id: "trg-hns",
+      name: "Nightly",
+      pipeline_id: "p1",
+      pipeline_name: "Auditor",
+      target_repo: "/home/user/project",
+      source_branch: "dev",
+      input_template: "audit",
+      variables: {},
+      cron: "0 9 * * *",
+      guard_command: null,
+      overlap_policy: "skip",
+      harness: "opencode",
+      auto_name: true,
+      enabled: true,
+      next_fire_at: null,
+      last_fired_at: null,
+      last_outcome: null,
+    };
+    render(
+      <NewRunModal open={true} onClose={noop} onCreated={noop}
+        openIntent={{ kind: "edit-trigger", trigger }} />,
+    );
+
+    const select = (await screen.findByTestId("harness-select")) as HTMLSelectElement;
+    await waitFor(() => expect(select.value).toBe("opencode"));
+    // Trigger mode exposes the inherit option.
+    expect(Array.from(select.options).some((o) => o.value === "")).toBe(true);
+
+    // Repo validation must resolve so Save is enabled.
+    await vi.advanceTimersByTimeAsync(500);
+    await waitFor(() => expect(validateRepo).toHaveBeenCalledWith("/home/user/project"));
+
+    // Reset to "use instance default" → the PATCH must clear it (null).
+    fireEvent.change(select, { target: { value: "" } });
+    vi.useRealTimers();
+    await waitFor(() => expect(screen.getByTestId("save-trigger-button")).toBeEnabled());
+    fireEvent.click(screen.getByTestId("save-trigger-button"));
+
+    await waitFor(() => {
+      expect(updateTrigger).toHaveBeenCalledWith(
+        "trg-hns",
+        expect.objectContaining({ harness: null }),
+      );
+    });
+  });
+});

--- a/frontend/src/components/NewRunModal.tsx
+++ b/frontend/src/components/NewRunModal.tsx
@@ -141,6 +141,13 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
   const [settingsFailed, setSettingsFailed] = useState(false);
   const [sandbox, setSandbox] = useState<string>("");
   const sandboxSeeded = useRef(false);
+  // Harness (#551/#452). `harness` is the selector value in BOTH modes: `""` = "the user
+  // did not choose" (inherit), or a concrete harness name. Seeded to `""` (asserts
+  // nothing) synchronously — the inherited default is only ever the inherit option's
+  // LABEL, never copied into the field (the #452 prefill trap). `""` omits the key from
+  // the request, the only value that lets the daemon resolve its own default.
+  const [harness, setHarness] = useState<string>("");
+  const harnessSeeded = useRef(false);
   const autoNameSeeded = useRef(false);
 
   const recentRepos = useRecentReposStore((s) => s.recentRepos);
@@ -365,6 +372,22 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
     setSandbox(openIntent.kind === "edit-trigger" ? (openIntent.trigger.sandbox ?? "") : "");
   }, [open, openIntent]);
 
+  // #551/#452: seed the harness selector once per open, matched to the intent — the same
+  // ref-gated, synchronous, assertion-free seed as the sandbox selector above. An
+  // `edit-trigger` round-trips the Trigger's own stored harness (whose `null` already
+  // means "inherit"); a run / new-trigger seeds `""`, so the field asserts nothing and the
+  // inherited default stays a LABEL. Never waits on `settings` (the #452 trap).
+  useEffect(() => {
+    if (!open) {
+      harnessSeeded.current = false;
+      return;
+    }
+    if (harnessSeeded.current) return;
+    // One-shot seeding gated by the ref: bounded, does not re-fire.
+    harnessSeeded.current = true;
+    setHarness(openIntent.kind === "edit-trigger" ? (openIntent.trigger.harness ?? "") : "");
+  }, [open, openIntent]);
+
   // #338: seed the "Auto-generated" box once per open, ref-gated (same anti-reseed guard as
   // the sandbox selector, so a `settings` state surviving a close cannot re-seed a REOPEN
   // from a stale value — the #452 trap). An `edit-trigger` seeds SYNCHRONOUSLY from the
@@ -498,6 +521,14 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
     [settings, sandbox, mode],
   );
 
+  // #551/#452: the harness selector's derived state — the known harnesses and the
+  // inherited default's NAME (a label, never a seed). Memoized like `sandboxState` so its
+  // destructured fields are stable. Pure over (settings, harness).
+  const { knownHarnesses, instanceDefaultHarness } = useMemo(
+    () => newRunForm.harnessState({ settings, harness }),
+    [settings, harness],
+  );
+
   // #465: every non-empty secondary row must have resolved to a valid repo before a
   // launch (mirror of the primary `repoValid` gate). An empty row is incomplete.
   const secondariesReady = secondaryRepos.every(
@@ -536,6 +567,7 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
           autoName,
           runName,
           sandbox,
+          harness,
           images,
           // #465: full list ([0] = primary, [1..] = secondaries), or undefined
           // for a mono-repo Run (keeps the request byte-identical).
@@ -557,7 +589,7 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
     } finally {
       setSubmitting(false);
     }
-  }, [selectedPipeline, input, hasRequiredPrompt, overrides, onCreated, onClose, flushPendingSaves, repoValid, targetRepo, sourceBranch, buildTargetRepos, autoName, runName, images, sandbox, settings, refreshRecentRepos]);
+  }, [selectedPipeline, input, hasRequiredPrompt, overrides, onCreated, onClose, flushPendingSaves, repoValid, targetRepo, sourceBranch, buildTargetRepos, autoName, runName, images, sandbox, harness, settings, refreshRecentRepos]);
 
   const canLaunch = newRunForm.canLaunch({
     repoValid,
@@ -631,6 +663,7 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
       allowOverlap,
       maxConcurrent,
       sandbox,
+      harness,
       autoName,
       variables,
       // #465: full list ([0] = primary, [1..] = secondaries), or undefined for
@@ -682,6 +715,7 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
     sourceBranch,
     buildTargetRepos,
     sandbox,
+    harness,
     autoName,
     flushPendingSaves,
     onTriggerSaved,
@@ -1132,6 +1166,49 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
                   This Run will use the instance default.
                 </span>
               )}
+            </div>
+
+            {/* Harness (#551/#452, ADR-0046): "Use instance default", or one of the
+                embedded harnesses. The inherit option is the SEEDED value and NAMES what
+                it resolves to in run mode ("the choice is made now, the user is entitled
+                to know what they inherit"); a Trigger resolves when it fires, so naming
+                today's value there would be a promise the modal cannot keep. Unlike the
+                sandbox selector there is nothing to grey and nothing to block — a harness
+                name is free text with no availability probe (ADR-0045); an unknown one
+                fails fast at the node spawn, not here. A node that PINS its harness
+                (NodeInspector) ignores this Run-level choice (ADR-0046). */}
+            <div className="flex flex-col gap-1.5">
+              <label
+                htmlFor="harness-select"
+                className="font-medium text-fg-2"
+                style={{ fontSize: "11.5px" }}
+              >
+                Harness
+              </label>
+              <select
+                id="harness-select"
+                data-testid="harness-select"
+                value={harness}
+                onChange={(e) => setHarness(e.target.value)}
+                className="w-full rounded-md border border-line-strong bg-bg-3 px-2.5 py-1.5 font-mono text-fg transition-colors focus:border-acc focus:outline-none disabled:opacity-40"
+                style={{ fontSize: "12px" }}
+              >
+                <option value="">
+                  {mode === "run" && instanceDefaultHarness
+                    ? `Use instance default (${instanceDefaultHarness})`
+                    : "Use instance default"}
+                </option>
+                {knownHarnesses.map((h) => (
+                  <option key={h} value={h}>
+                    {h}
+                  </option>
+                ))}
+              </select>
+              <span className="text-fg-4" style={{ fontSize: "10.5px" }}>
+                {mode === "trigger"
+                  ? "Every fired Run launches on this harness. Nodes that pin their own harness ignore it."
+                  : "The harness every free node runs on for this Run. Nodes that pin their own harness ignore it."}
+              </span>
             </div>
           </div>
 

--- a/frontend/src/components/NodeInspector.test.tsx
+++ b/frontend/src/components/NodeInspector.test.tsx
@@ -488,3 +488,76 @@ describe("NodeInspector StarButton — library save is independent of pipeline s
     expect(mockDelete).not.toHaveBeenCalled();
   });
 });
+
+// #550/ADR-0046: the harness axis in the node inspector.
+function seedNode(node: Record<string, unknown>) {
+  useEditStore.setState({
+    openTabs: [
+      {
+        id: "p1",
+        scope: "repo",
+        pipeline: {
+          name: "p1",
+          version: "1.0",
+          variables: {},
+          nodes: [
+            {
+              id: "n1",
+              name: "worker",
+              type: "doc-only",
+              interactive: false,
+              inputs: [{ name: "in", repeated: false, side: "left" }],
+              outputs: [{ name: "out", repeated: false, side: "right" }],
+              view: { x: 0, y: 0 },
+              ...node,
+            },
+          ],
+          edges: [],
+        },
+        prompts: { n1: "do the thing" },
+        diagnostics: [],
+        dirty: false,
+        externalDirty: false,
+      },
+    ],
+    activeTabId: "p1",
+    selection: { kind: "node", id: "n1" },
+  });
+}
+
+describe("NodeInspector — harness axis (#550, ADR-0046)", () => {
+  beforeEach(() => {
+    seedNode({});
+  });
+
+  it("resolves to the claude floor when the node has no pin", () => {
+    seedNode({});
+    renderInspector({ libraryEntries: [], onLibraryChanged: () => {} });
+    expect(screen.getByTestId("node-harness-resolved")).toHaveTextContent("claude");
+    // The effort picker is ENABLED on claude (it has an effort axis).
+    expect(screen.getByTestId("node-effort-option-high")).not.toBeDisabled();
+  });
+
+  it("shows the pinned harness as resolved and greys the effort picker on opencode", () => {
+    seedNode({ pin_harness: "opencode" });
+    renderInspector({ libraryEntries: [], onLibraryChanged: () => {} });
+    expect(screen.getByTestId("node-harness-resolved")).toHaveTextContent("opencode");
+    // AC #13: opencode has no launch-time effort axis → the picker is greyed.
+    // Assert the `disabled` attribute, never `.value`.
+    expect(screen.getByTestId("node-effort-option-high")).toBeDisabled();
+  });
+
+  it("pinning a harness writes pin_harness onto the node", async () => {
+    seedNode({});
+    renderInspector({ libraryEntries: [], onLibraryChanged: () => {} });
+    await userEvent.click(screen.getByTestId("node-harness-option-opencode"));
+    const node = useEditStore.getState().openTabs[0].pipeline.nodes[0];
+    expect(node.pin_harness).toBe("opencode");
+  });
+
+  it("hides the harness selector for a script node", () => {
+    seedNode({ type: "script" });
+    renderInspector({ libraryEntries: [], onLibraryChanged: () => {} });
+    expect(screen.queryByTestId("node-harness")).toBeNull();
+  });
+});

--- a/frontend/src/components/NodeInspector.tsx
+++ b/frontend/src/components/NodeInspector.tsx
@@ -7,6 +7,7 @@ import OutputPortCard from "./OutputPortCard";
 import PooledInputRow from "./PooledInputRow";
 import ModelPicker from "./ModelPicker";
 import EffortPicker from "./EffortPicker";
+import { KNOWN_HARNESSES, harnessHasEffort, resolveEditorHarness } from "../lib/harness";
 import DestroyLoopModal from "./DestroyLoopModal";
 import { derivePooledInputs } from "../lib/derivePooledInputs";
 import { regionsDestroyedByEdgeRemoval } from "../lib/loopRegions";
@@ -82,6 +83,12 @@ export default function NodeInspector({
   // fixed (no doc-only↔code-mutating toggle), it has no model, and its "prompt"
   // is a bash body whose I/O arrives as PDO_* env vars, not a prose preamble.
   const isScript = node.type === "script";
+
+  // #550/ADR-0046: the harness this node resolves to in the editor — its pin,
+  // else the `claude` floor. Drives the model/effort meaning and the effort
+  // greying. (The daemon re-resolves authoritatively at spawn, with the instance
+  // tier the editor does not fetch per-node.)
+  const resolvedHarness = resolveEditorHarness(node);
 
   // #339: delete one contributing edge of a pooled input — the canonical
   // "delete an input" since inputs are emergent (#149/ADR-0011). Last-cycle
@@ -215,9 +222,57 @@ export default function NodeInspector({
           </div>
         </Tooltip>
 
+        {/* Harness (#550/ADR-0046): the program that runs this node's agent. The
+            pin both selects the harness and shields it from coarser tiers; the
+            RESOLVED harness (pin, else the `claude` floor here in the editor) is
+            what the model/effort below apply to and what greys the effort picker.
+            Hidden for a script node — it launches no agent (ADR-0017). */}
+        {!isScript && (
+          <Field label="Harness">
+            <div
+              role="radiogroup"
+              aria-label="Harness"
+              className="flex gap-1"
+              data-testid="node-harness"
+              data-resolved={resolvedHarness}
+            >
+              {[
+                { id: null as string | null, label: "Default", slug: "default" },
+                ...KNOWN_HARNESSES.map((h) => ({ id: h as string, label: h, slug: h })),
+              ].map((o) => {
+                const selected = (node.pin_harness ?? null) === o.id;
+                return (
+                  <button
+                    key={o.slug}
+                    type="button"
+                    role="radio"
+                    aria-checked={selected}
+                    data-testid={`node-harness-option-${o.slug}`}
+                    onClick={() => handleField("pin_harness", o.id)}
+                    className={`flex-1 cursor-pointer rounded border px-2 py-1 font-medium transition-colors ${
+                      selected
+                        ? o.id == null
+                          ? "border-fg-4 bg-bg-3 text-fg"
+                          : "border-acc bg-acc-bg text-acc"
+                        : "border-line-strong bg-bg-3 text-fg-4 hover:text-fg-3"
+                    }`}
+                    style={{ fontSize: "10px" }}
+                  >
+                    {o.label}
+                  </button>
+                );
+              })}
+            </div>
+            <p className="mt-1 text-fg-4" style={{ fontSize: "9.5px" }}>
+              Resolved: <span data-testid="node-harness-resolved">{resolvedHarness}</span>
+              {node.pin_harness ? " (pinned)" : " (floor — no pin)"}
+            </p>
+          </Field>
+        )}
+
         {/* Model (#296/#324): dropdown + Custom… escape hatch (see ModelPicker).
-            Hidden for a script node (#248): it launches no agent, so it has no
-            model. */}
+            Since #550 it edits the RESOLVED harness's model. Hidden for a script
+            node (#248): it launches no agent, so it has no model. */}
         {!isScript && (
           <Field label="Model">
             <ModelPicker
@@ -239,6 +294,9 @@ export default function NodeInspector({
               value={node.effort ?? null}
               onChange={(v) => handleField("effort", v)}
               testid="node-effort"
+              /* #550/AC #13: greyed when the resolved harness has no launch-time
+                 effort axis (measured: `opencode` has none). */
+              disabled={!harnessHasEffort(resolvedHarness)}
             />
           </Field>
         )}

--- a/frontend/src/components/PipelineInfoPanel.stats.test.tsx
+++ b/frontend/src/components/PipelineInfoPanel.stats.test.tsx
@@ -203,4 +203,26 @@ describe("PipelineInfoPanel — Stats block (#100)", () => {
     expect(cost).toHaveTextContent("—");
     expect(cost).not.toHaveTextContent("$");
   });
+
+  it("renders '—' with a reason (never $0, no dagger) when a harness has no cost source (#553)", () => {
+    // A Run with an opencode node: cost is present but not summable → "—" naming
+    // the harness in the tooltip, never a misleading $0.
+    renderPanel(
+      makeRun({
+        cost: {
+          usd: 0,
+          partial: false,
+          unpriced_models: [],
+          uncosted_harnesses: ["opencode"],
+        },
+      }),
+    );
+    const cost = screen.getByTestId("stat-cost");
+    expect(cost).toHaveTextContent("—");
+    expect(cost).not.toHaveTextContent("$");
+    expect(cost).not.toHaveTextContent("†");
+    const title = cost.querySelector("[title]")?.getAttribute("title") ?? "";
+    expect(title).toMatch(/cost unavailable/i);
+    expect(title).toContain("opencode");
+  });
 });

--- a/frontend/src/components/PipelineInfoPanel.tsx
+++ b/frontend/src/components/PipelineInfoPanel.tsx
@@ -300,6 +300,9 @@ function InfoTab({
                     run.cost.usd,
                     run.cost.partial,
                     run.cost.unpriced_models,
+                    // #553: "—" + reason when a node ran on a harness with no cost
+                    // source (e.g. opencode) — never a misleading $0.
+                    run.cost.uncosted_harnesses ?? [],
                   );
                   return (
                     <span className="flex items-center gap-1" title={c.title}>

--- a/frontend/src/components/ProjectEditModal.test.tsx
+++ b/frontend/src/components/ProjectEditModal.test.tsx
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+import ProjectEditModal from "./ProjectEditModal";
+import { ApiError } from "../api";
+import type { Project } from "../types";
+
+const createProject = vi.fn();
+const updateProject = vi.fn();
+const addProjectMember = vi.fn();
+const removeProjectMember = vi.fn();
+
+vi.mock("../api", () => {
+  // Defined INSIDE the factory: `vi.mock` is hoisted above module top-level, so a
+  // class declared outside would be in its TDZ here.
+  class ApiError extends Error {}
+  return {
+    ApiError,
+    createProject: (name: string) => createProject(name),
+    updateProject: (id: string, req: unknown) => updateProject(id, req),
+    addProjectMember: (id: string, path: string) => addProjectMember(id, path),
+    removeProjectMember: (id: string, path: string) => removeProjectMember(id, path),
+  };
+});
+
+beforeEach(() => {
+  createProject.mockReset();
+  updateProject.mockReset();
+  addProjectMember.mockReset();
+  removeProjectMember.mockReset();
+});
+
+function renderModal(overrides: Partial<React.ComponentProps<typeof ProjectEditModal>> = {}) {
+  const onClose = vi.fn();
+  const onSaved = vi.fn();
+  render(
+    <ProjectEditModal
+      initialProject={null}
+      initialName="front"
+      initialMemberPaths={["/repos/front"]}
+      availableRepos={["/repos/front", "/repos/back"]}
+      projects={[]}
+      onClose={onClose}
+      onSaved={onSaved}
+      {...overrides}
+    />,
+  );
+  return { onClose, onSaved };
+}
+
+/** The member row whose `data-path` matches, from `project-member-row`. */
+function memberRow(path: string): HTMLElement {
+  const rows = screen.getAllByTestId("project-member-row");
+  const row = rows.find((r) => r.getAttribute("data-path") === path);
+  if (!row) throw new Error(`no member row for ${path}`);
+  return row;
+}
+
+describe("ProjectEditModal", () => {
+  it("disables the checkbox of a repo owned by another project, naming the owner", () => {
+    const other: Project = {
+      id: "p2",
+      name: "Other",
+      harness: null,
+      members: ["/repos/back"],
+    };
+    renderModal({ projects: [other] });
+
+    // Assert on the DISABLED attribute + rendered owner text — never on `.value`,
+    // which cannot fail a desync assertion (the #347 frontend guidance).
+    const backCheckbox = within(memberRow("/repos/back")).getByTestId(
+      "project-member-checkbox",
+    ) as HTMLInputElement;
+    expect(backCheckbox).toBeDisabled();
+    expect(memberRow("/repos/back").getAttribute("data-disabled")).toBe("true");
+    expect(within(memberRow("/repos/back")).getByTestId("project-member-owner").textContent).toContain(
+      "Other",
+    );
+
+    // The unowned repo stays enabled.
+    const frontCheckbox = within(memberRow("/repos/front")).getByTestId(
+      "project-member-checkbox",
+    ) as HTMLInputElement;
+    expect(frontCheckbox).not.toBeDisabled();
+  });
+
+  it("creates a project, sets its harness, and attaches the checked members on save", async () => {
+    createProject.mockResolvedValue({ id: "p9", name: "front", harness: null, members: [] });
+    updateProject.mockResolvedValue({});
+    addProjectMember.mockResolvedValue({});
+    const { onSaved, onClose } = renderModal();
+
+    // Attach the second repo too, and pose a harness on the Projet.
+    fireEvent.click(
+      within(memberRow("/repos/back")).getByTestId("project-member-checkbox"),
+    );
+    fireEvent.change(screen.getByTestId("project-harness-select"), {
+      target: { value: "opencode" },
+    });
+    fireEvent.click(screen.getByTestId("project-edit-save"));
+
+    await waitFor(() => expect(onSaved).toHaveBeenCalled());
+    expect(createProject).toHaveBeenCalledWith("front");
+    expect(updateProject).toHaveBeenCalledWith("p9", { harness: "opencode" });
+    expect(addProjectMember).toHaveBeenCalledWith("p9", "/repos/front");
+    expect(addProjectMember).toHaveBeenCalledWith("p9", "/repos/back");
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("renames and diffs members for an existing project (adds new, removes dropped)", async () => {
+    const existing: Project = {
+      id: "p1",
+      name: "Product",
+      harness: "claude",
+      members: ["/repos/front"],
+    };
+    updateProject.mockResolvedValue({});
+    addProjectMember.mockResolvedValue({});
+    removeProjectMember.mockResolvedValue({});
+    const { onSaved } = renderModal({
+      initialProject: existing,
+      initialName: "Product",
+      initialMemberPaths: ["/repos/front"],
+    });
+
+    // Drop /repos/front, add /repos/back, rename.
+    fireEvent.click(
+      within(memberRow("/repos/front")).getByTestId("project-member-checkbox"),
+    );
+    fireEvent.click(
+      within(memberRow("/repos/back")).getByTestId("project-member-checkbox"),
+    );
+    fireEvent.change(screen.getByTestId("project-name-input"), {
+      target: { value: "Renamed" },
+    });
+    fireEvent.click(screen.getByTestId("project-edit-save"));
+
+    await waitFor(() => expect(onSaved).toHaveBeenCalled());
+    expect(updateProject).toHaveBeenCalledWith("p1", { name: "Renamed", harness: "claude" });
+    expect(addProjectMember).toHaveBeenCalledWith("p1", "/repos/back");
+    expect(removeProjectMember).toHaveBeenCalledWith("p1", "/repos/front");
+    // The existing project is NOT re-created.
+    expect(createProject).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a refusal that names the owning project and keeps the modal open", async () => {
+    createProject.mockResolvedValue({ id: "p9", name: "front", harness: null, members: [] });
+    addProjectMember.mockRejectedValue(
+      new ApiError("path already belongs to project 'Other'"),
+    );
+    const { onSaved, onClose } = renderModal();
+
+    fireEvent.click(screen.getByTestId("project-edit-save"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("project-edit-error").textContent).toContain("Other"),
+    );
+    expect(onSaved).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("disables Save when the name is blank", () => {
+    renderModal({ initialName: "  " });
+    expect(screen.getByTestId("project-edit-save")).toBeDisabled();
+  });
+});

--- a/frontend/src/components/ProjectEditModal.tsx
+++ b/frontend/src/components/ProjectEditModal.tsx
@@ -1,0 +1,271 @@
+import { useMemo, useState } from "react";
+import type { Project } from "../types";
+import {
+  addProjectMember,
+  ApiError,
+  createProject,
+  removeProjectMember,
+  updateProject,
+} from "../api";
+
+/**
+ * The group-header pencil (#552, ADR-0046): name a Projet (or rename an existing
+ * one), pick which repo paths are its members, and optionally pose the harness it
+ * carries. Naming a group is what **materialises** the Projet — nothing is seeded
+ * until this saves (ADR-0046).
+ *
+ * A candidate repo already owned by **another** Projet is shown disabled with the
+ * owner's name (the "refus nommant le propriétaire" surfaced up front); the daemon
+ * refuses it too (409), which we also catch defensively.
+ *
+ * Membership is compared **verbatim** (ADR-0033): the candidate list is the exact
+ * effective-repo paths the surrounding list groups by, never canonicalised.
+ */
+
+/** The harnesses PDO ships (ADR-0045). A disk-declared tier is #553; until then
+ *  the picker offers the embedded floor plus "no harness". */
+const HARNESS_OPTIONS = ["claude", "opencode"] as const;
+
+export default function ProjectEditModal({
+  initialProject,
+  initialName,
+  initialMemberPaths,
+  availableRepos,
+  projects,
+  onClose,
+  onSaved,
+}: {
+  /** The Projet being edited, or `null` when the pencil creates a fresh one. */
+  initialProject: Project | null;
+  /** Pre-filled name: the Projet's name, or the group's derived label. */
+  initialName: string;
+  /** Pre-checked member paths: the Projet's members, or the group's own path. */
+  initialMemberPaths: string[];
+  /** Candidate repo paths to attach (the surrounding list's distinct repos). */
+  availableRepos: string[];
+  /** All Projets, to mark a candidate owned by another Projet as disabled. */
+  projects: Project[];
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const [name, setName] = useState(initialName);
+  const [harness, setHarness] = useState<string>(initialProject?.harness ?? "");
+  const [checked, setChecked] = useState<Set<string>>(
+    () => new Set(initialMemberPaths),
+  );
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // path → name of the Projet that OWNS it, excluding the one being edited. A
+  // candidate owned elsewhere cannot be attached here (AC: at most one Projet).
+  const ownerElsewhere = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const p of projects) {
+      if (initialProject && p.id === initialProject.id) continue;
+      for (const path of p.members) map.set(path, p.name);
+    }
+    return map;
+  }, [projects, initialProject]);
+
+  // The candidate universe: the surrounding list's repos, plus any existing
+  // members (so a member currently filtered out of the list can still be unchecked).
+  const candidates = useMemo(() => {
+    const set = new Set<string>(availableRepos);
+    for (const m of initialMemberPaths) set.add(m);
+    return [...set].sort();
+  }, [availableRepos, initialMemberPaths]);
+
+  const trimmedName = name.trim();
+  const canSave = trimmedName.length > 0 && !submitting;
+
+  function toggle(path: string) {
+    setChecked((prev) => {
+      const next = new Set(prev);
+      if (next.has(path)) next.delete(path);
+      else next.add(path);
+      return next;
+    });
+  }
+
+  async function handleSave() {
+    if (!canSave) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      // Materialise (or reuse) the Projet, then reconcile its name, harness and
+      // members. Create first so a fresh Projet has an id to attach against.
+      let projectId: string;
+      if (initialProject) {
+        projectId = initialProject.id;
+        await updateProject(projectId, {
+          name: trimmedName,
+          // Empty select → clear the harness (null); a value sets it.
+          harness: harness ? harness : null,
+        });
+      } else {
+        const created = await createProject(trimmedName);
+        projectId = created.id;
+        if (harness) await updateProject(projectId, { harness });
+      }
+
+      const current = new Set(initialProject?.members ?? []);
+      const desired = checked;
+      // Attach newly-checked paths; a path owned elsewhere is skipped by the
+      // disabled checkbox, but the daemon refuses it too (409 naming the owner).
+      for (const path of desired) {
+        if (!current.has(path)) await addProjectMember(projectId, path);
+      }
+      // Detach paths that were members but are now unchecked.
+      for (const path of current) {
+        if (!desired.has(path)) await removeProjectMember(projectId, path);
+      }
+      onSaved();
+      onClose();
+    } catch (e) {
+      const msg =
+        e instanceof ApiError
+          ? e.message
+          : e instanceof Error
+            ? e.message
+            : "failed to save project";
+      setError(msg);
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      data-testid="project-edit-backdrop"
+      onClick={onClose}
+    >
+      <div
+        className="w-[440px] max-w-[90vw] rounded-lg border border-line bg-bg-4 p-4"
+        style={{ fontSize: "12px" }}
+        role="dialog"
+        aria-label="Edit project"
+        data-testid="project-edit-modal"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="mb-1 font-medium text-fg">
+          {initialProject ? "Edit project" : "Name project"}
+        </div>
+        <p className="mb-3 text-fg-4" style={{ fontSize: "11px" }}>
+          Group repositories that work together under one name. A repo belongs to
+          at most one project; the harness set here applies to every Run whose
+          primary repo is a member.
+        </p>
+
+        <label className="mb-1 block text-fg-3" style={{ fontSize: "11px" }}>
+          Name
+        </label>
+        <input
+          value={name}
+          onChange={(e) => {
+            setName(e.target.value);
+            setError(null);
+          }}
+          data-testid="project-name-input"
+          className="mb-3 w-full rounded border border-line-strong bg-bg-3 px-2 py-1.5 text-fg outline-none focus:border-acc"
+          style={{ fontSize: "11px" }}
+        />
+
+        <label className="mb-1 block text-fg-3" style={{ fontSize: "11px" }}>
+          Harness
+        </label>
+        <select
+          value={harness}
+          onChange={(e) => setHarness(e.target.value)}
+          data-testid="project-harness-select"
+          className="mb-3 w-full rounded border border-line-strong bg-bg-3 px-2 py-1.5 text-fg outline-none focus:border-acc"
+          style={{ fontSize: "11px" }}
+        >
+          <option value="">No harness (inherit)</option>
+          {HARNESS_OPTIONS.map((h) => (
+            <option key={h} value={h}>
+              {h}
+            </option>
+          ))}
+        </select>
+
+        <label className="mb-1 block text-fg-3" style={{ fontSize: "11px" }}>
+          Member repositories
+        </label>
+        <div
+          className="mb-3 max-h-48 overflow-y-auto rounded border border-line-strong bg-bg-3"
+          data-testid="project-members-list"
+        >
+          {candidates.length === 0 && (
+            <div className="px-2 py-2 text-fg-4" style={{ fontSize: "11px" }}>
+              No repositories to attach.
+            </div>
+          )}
+          {candidates.map((path) => {
+            const owner = ownerElsewhere.get(path);
+            const disabled = owner != null;
+            return (
+              <label
+                key={path}
+                className={`flex items-center gap-2 border-b border-line-soft px-2 py-1.5 last:border-b-0 ${
+                  disabled ? "opacity-50" : "cursor-pointer hover:bg-bg-4"
+                }`}
+                style={{ fontSize: "11px" }}
+                title={owner ? `Already in project "${owner}"` : path}
+                data-testid="project-member-row"
+                data-path={path}
+                data-disabled={disabled ? "true" : "false"}
+              >
+                <input
+                  type="checkbox"
+                  checked={checked.has(path)}
+                  disabled={disabled}
+                  onChange={() => toggle(path)}
+                  data-testid="project-member-checkbox"
+                />
+                <span className="truncate text-fg">{path}</span>
+                {owner && (
+                  <span
+                    className="ml-auto shrink-0 text-fg-4"
+                    data-testid="project-member-owner"
+                  >
+                    in {owner}
+                  </span>
+                )}
+              </label>
+            );
+          })}
+        </div>
+
+        {error && (
+          <div
+            className="mb-3 rounded border border-st-failed/40 bg-st-failed/10 px-2 py-1.5 text-st-failed"
+            style={{ fontSize: "11px" }}
+            data-testid="project-edit-error"
+          >
+            {error}
+          </div>
+        )}
+
+        <div className="flex justify-end gap-2">
+          <button
+            onClick={onClose}
+            className="cursor-pointer rounded border border-line-strong px-3 py-1 text-fg-3 transition-colors hover:bg-bg-3"
+            style={{ fontSize: "11px" }}
+            data-testid="project-edit-cancel"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={!canSave}
+            className="cursor-pointer rounded bg-acc px-3 py-1 font-medium text-[#04140d] transition-colors hover:bg-acc-dim disabled:cursor-not-allowed disabled:opacity-50"
+            style={{ fontSize: "11px" }}
+            data-testid="project-edit-save"
+          >
+            {submitting ? "Saving…" : "Save"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/RunInfoSidebar.test.tsx
+++ b/frontend/src/components/RunInfoSidebar.test.tsx
@@ -89,6 +89,23 @@ describe("RunInfoSidebar", () => {
     expect(screen.queryByTestId("run-failure-reason")).toBeNull();
   });
 
+  // #551 (ADR-0046): the frozen Run harness is visible in the panel.
+  it("shows the Run's frozen harness when it named one", () => {
+    render(
+      <RunInfoSidebar run={{ ...makeRun("running"), harness: "opencode" } as unknown as RunState} />,
+    );
+    const chip = screen.getByTestId("run-harness");
+    expect(chip.textContent).toContain("Harness");
+    expect(chip.textContent).toContain("opencode");
+  });
+
+  it("shows no harness chip when the Run inherited the default", () => {
+    // Absent harness = inherited the instance default (and the floor) — the panel does
+    // not spell that out per-Run.
+    render(<RunInfoSidebar run={makeRun("running")} />);
+    expect(screen.queryByTestId("run-harness")).toBeNull();
+  });
+
   // #465 slice 2 — the Repositories section.
   it("shows no Repositories section for a mono-repo run (no target_repo)", () => {
     render(<RunInfoSidebar run={makeRun("running")} />);

--- a/frontend/src/components/RunInfoSidebar.tsx
+++ b/frontend/src/components/RunInfoSidebar.tsx
@@ -70,6 +70,22 @@ export default function RunInfoSidebar({
             ? "Archived run · read-only · outputs preserved"
             : "Editing run-scoped pipeline · changes sync to template"}
         </div>
+        {/* #551 (ADR-0046): the harness this Run was FROZEN on — the `run` tier that
+            made it an A/B of the same pipeline on another harness. Shown only when the
+            Run named one; absence means it inherited the instance default (and the
+            `claude` floor), which the panel does not need to spell out per-Run. */}
+        {run.harness && (
+          <div
+            className="mt-2 flex items-center gap-1.5 text-fg-3"
+            style={{ fontSize: "10.5px" }}
+            data-testid="run-harness"
+          >
+            <span className="text-fg-4">Harness</span>
+            <span className="rounded bg-bg-3 px-1.5 py-0.5 font-mono text-fg-2">
+              {run.harness}
+            </span>
+          </div>
+        )}
       </div>
 
       {run.target_repo && (

--- a/frontend/src/components/SettingsModal.test.tsx
+++ b/frontend/src/components/SettingsModal.test.tsx
@@ -88,6 +88,14 @@ function sample(overrides: Partial<InstanceSettings> = {}): InstanceSettings {
       manual_keys: [],
       reason: null,
     },
+    // Harness descriptors (#553): the default clean state — only the built-in
+    // floor resolves, nothing inert. The path is reported all the same.
+    harness_descriptors: {
+      path: "/home/user/.pdo/harnesses/descriptors.yaml",
+      names: ["claude", "opencode"],
+      rejected: [],
+      reason: null,
+    },
     updated_at: "2026-07-01T10:00:00.000Z",
     ...overrides,
   };
@@ -294,6 +302,49 @@ describe("SettingsModal", () => {
     // And what the manual tier shadows is visible.
     expect(screen.getByTestId("setting-price-table-manual-path")).toHaveTextContent(
       "claude-opus-4-8",
+    );
+  });
+
+  it("lists the resolved harnesses and stays silent when no descriptor is inert (#553)", async () => {
+    fetchSettingsMock.mockResolvedValue(sample());
+    render(<SettingsModal open onClose={() => {}} />);
+    const names = await screen.findByTestId("setting-harness-descriptors-names");
+    // A declared harness "appears" here (floor ∪ disk); the clean fixture shows the floor.
+    expect(names).toHaveTextContent("claude");
+    expect(names).toHaveTextContent("opencode");
+    expect(screen.getByTestId("setting-harness-descriptors-path")).toHaveTextContent(
+      "/home/user/.pdo/harnesses/descriptors.yaml",
+    );
+    // Absent is SILENT: no advisory when nothing is wrong.
+    expect(
+      screen.queryByTestId("setting-harness-descriptors-reason"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("surfaces the daemon's reason and merged names when a descriptor went inert (#553)", async () => {
+    // Corrupting the file makes it inert and diagnosed; the built-in floor keeps
+    // resolving — the only honest place to say so, since a descriptor passes
+    // through no validator (ADR-0001).
+    fetchSettingsMock.mockResolvedValue(
+      sample({
+        harness_descriptors: {
+          path: "/home/user/.pdo/harnesses/descriptors.yaml",
+          names: ["claude", "opencode"],
+          rejected: [
+            { name: "claude", why: "missing `binary`" },
+          ],
+          reason:
+            "harness descriptors (#553) — harness descriptor tier (/home/user/.pdo/harnesses/descriptors.yaml) refused 1 descriptor(s), each key falling through to the next tier: `claude` (missing `binary`)",
+        },
+      }),
+    );
+    render(<SettingsModal open onClose={() => {}} />);
+    const reason = await screen.findByTestId("setting-harness-descriptors-reason");
+    expect(reason).toHaveTextContent("claude");
+    expect(reason).toHaveTextContent(/falling through/);
+    // …and the floor still resolves alongside the diagnostic.
+    expect(screen.getByTestId("setting-harness-descriptors-names")).toHaveTextContent(
+      "opencode",
     );
   });
 

--- a/frontend/src/components/SettingsModal.test.tsx
+++ b/frontend/src/components/SettingsModal.test.tsx
@@ -46,6 +46,8 @@ function sample(overrides: Partial<InstanceSettings> = {}): InstanceSettings {
     guard_timeout_secs: { effective: 60, source: "default", stored: null, env: null, default: 60 },
     // Unset by default (account default): effective/stored/env/default all null.
     default_model: { effective: null, source: "default", stored: null, env: null, default: null },
+    default_harness: { effective: null, source: "default", stored: null, env: null, default: null },
+    default_harness_model: { effective: {}, stored: {} },
     // Default sandbox (#410): built-in default `off`, nothing stored/env. The ONLY sandbox
     // knob on this screen since #471 — image and Dockerfile belong to a staging profile.
     default_sandbox: { effective: "off", source: "default", stored: null, env: null, default: "off", reason: null },
@@ -381,6 +383,8 @@ describe("SettingsModal", () => {
     updateSettingsMock.mockResolvedValue(
       sample({
         default_model: { effective: "opus", source: "stored", stored: "opus", env: null, default: null },
+        default_harness: { effective: null, source: "default", stored: null, env: null, default: null },
+        default_harness_model: { effective: {}, stored: {} },
       }),
     );
     const onClose = vi.fn();
@@ -401,6 +405,8 @@ describe("SettingsModal", () => {
     fetchSettingsMock.mockResolvedValue(
       sample({
         default_model: { effective: "opus", source: "stored", stored: "opus", env: null, default: null },
+        default_harness: { effective: null, source: "default", stored: null, env: null, default: null },
+        default_harness_model: { effective: {}, stored: {} },
       }),
     );
     updateSettingsMock.mockResolvedValue(sample());
@@ -422,6 +428,8 @@ describe("SettingsModal", () => {
     fetchSettingsMock.mockResolvedValue(
       sample({
         default_model: { effective: "opus", source: "stored", stored: "opus", env: "sonnet", default: null },
+        default_harness: { effective: null, source: "default", stored: null, env: null, default: null },
+        default_harness_model: { effective: {}, stored: {} },
       }),
     );
     render(<SettingsModal open onClose={() => {}} />);

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -248,6 +248,18 @@ function SettingsForm({
   // Model is `null` when unset (account default); ModelPicker speaks the same
   // `string | null` contract as the per-node inspector (#296/#324/#347).
   const [model, setModel] = useState<string | null>(() => settings.default_model.effective);
+  // #550/ADR-0046: the harness axis. `defaultHarness` is `""` when unset (the
+  // `claude` floor applies); the two per-harness default models are edited as
+  // free text, empty = that harness's account default.
+  const [defaultHarness, setDefaultHarness] = useState<string>(
+    () => settings.default_harness.effective ?? "",
+  );
+  const [claudeDefaultModel, setClaudeDefaultModel] = useState<string>(
+    () => settings.default_harness_model.stored["claude"] ?? "",
+  );
+  const [opencodeDefaultModel, setOpencodeDefaultModel] = useState<string>(
+    () => settings.default_harness_model.stored["opencode"] ?? "",
+  );
   // Default sandbox (#410/#432): `off` or a staging-profile name. `effective` is always
   // a present string (the `?? "off"` is belt-and-braces).
   const [defaultSandbox, setDefaultSandbox] = useState<string>(
@@ -322,6 +334,24 @@ function SettingsForm({
     // sent when it actually changed (avoids a needless clear/no-op PUT).
     if (model !== settings.default_model.effective) {
       patch.default_model = model ?? "";
+    }
+    // #550: the harness axis. `""` clears the default harness (same sentinel as
+    // the model). The per-harness default model map is sent whole when either
+    // known entry changed; a trimmed-empty value drops that harness's entry.
+    if (defaultHarness !== (settings.default_harness.effective ?? "")) {
+      patch.default_harness = defaultHarness;
+    }
+    const storedModels = settings.default_harness_model.stored;
+    const claudeM = claudeDefaultModel.trim();
+    const opencodeM = opencodeDefaultModel.trim();
+    if (
+      (claudeM || undefined) !== (storedModels["claude"] || undefined) ||
+      (opencodeM || undefined) !== (storedModels["opencode"] || undefined)
+    ) {
+      const map: Record<string, string> = {};
+      if (claudeM) map["claude"] = claudeM;
+      if (opencodeM) map["opencode"] = opencodeM;
+      patch.default_harness_model = map;
     }
 
     // Default sandbox mode (#410): a concrete enum variant, only sent when it changed. The
@@ -515,6 +545,71 @@ function SettingsForm({
             data-testid="setting-source-default-model"
           >
             {modelSourceNote(settings.default_model)}
+          </div>
+        </div>
+
+        {/* Default harness (#550/ADR-0046): the harness a new node runs on unless
+            it pins its own or a coarser tier sets one. Precedence at spawn:
+            node → Run → Projet → instance (this) → claude floor. */}
+        <div className="flex flex-col gap-1.5" data-testid="setting-default-harness">
+          <label className="font-medium text-fg-2" style={{ fontSize: "11.5px" }}>
+            Default harness
+          </label>
+          <select
+            value={defaultHarness}
+            onChange={(e) => setDefaultHarness(e.target.value)}
+            data-testid="setting-default-harness-select"
+            className="rounded border border-line-strong bg-bg-3 px-2 py-1 text-fg"
+            style={{ fontSize: "11px" }}
+          >
+            <option value="">Default (claude floor)</option>
+            <option value="claude">claude</option>
+            <option value="opencode">opencode</option>
+          </select>
+          <div className="text-fg-4" style={{ fontSize: "10.5px" }}>
+            Every new node runs on this harness unless it pins its own. "Default"
+            leaves it to the <span className="font-mono">claude</span> floor.
+          </div>
+          <div
+            className="text-fg-3"
+            style={{ fontSize: "10.5px" }}
+            data-testid="setting-source-default-harness"
+          >
+            {modelSourceNote(settings.default_harness)}
+          </div>
+        </div>
+
+        {/* Default model per harness (#550/ADR-0046): a slug means nothing outside
+            its harness, so the instance default model is per-harness. Free text. */}
+        <div className="flex flex-col gap-1.5" data-testid="setting-default-harness-model">
+          <label className="font-medium text-fg-2" style={{ fontSize: "11.5px" }}>
+            Default model per harness
+          </label>
+          <label className="flex items-center gap-2 text-fg-3" style={{ fontSize: "11px" }}>
+            <span className="w-16 font-mono">claude</span>
+            <input
+              type="text"
+              value={claudeDefaultModel}
+              onChange={(e) => setClaudeDefaultModel(e.target.value)}
+              placeholder="account default"
+              data-testid="setting-default-model-claude"
+              className="flex-1 rounded border border-line-strong bg-bg-3 px-2 py-1 text-fg"
+            />
+          </label>
+          <label className="flex items-center gap-2 text-fg-3" style={{ fontSize: "11px" }}>
+            <span className="w-16 font-mono">opencode</span>
+            <input
+              type="text"
+              value={opencodeDefaultModel}
+              onChange={(e) => setOpencodeDefaultModel(e.target.value)}
+              placeholder="account default"
+              data-testid="setting-default-model-opencode"
+              className="flex-1 rounded border border-line-strong bg-bg-3 px-2 py-1 text-fg"
+            />
+          </label>
+          <div className="text-fg-4" style={{ fontSize: "10.5px" }}>
+            The model a node runs with on that harness when it sets none. Empty = the
+            harness account default.
           </div>
         </div>
 

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -755,6 +755,52 @@ function SettingsForm({
           </div>
         )}
 
+        {/* #553/ADR-0045: the harness descriptor disk tier — declare a harness PDO
+            does not ship by writing this file; it merges over the built-in floor by
+            name. Same posture as the price table above: the path is always shown
+            (nothing is seeded), and a broken/refused descriptor is named here (the
+            only place, since a hand-edited descriptor passes through no validator).
+            Guarded so a daemon predating #553 renders nothing. */}
+        {settings.harness_descriptors && (
+          <div className="flex flex-col gap-1.5" data-testid="setting-harness-descriptors">
+            <label className="font-medium text-fg-2" style={{ fontSize: "11.5px" }}>
+              Harness descriptors
+            </label>
+            <div className="text-fg-4" style={{ fontSize: "10.5px" }}>
+              Declare a harness PDO does not ship by writing this file; it merges over
+              the built-in <span className="font-mono">claude</span> /{" "}
+              <span className="font-mono">opencode</span> by name. Nothing is ever
+              seeded — the built-in harnesses are the floor.
+            </div>
+            <div
+              className="text-fg-3"
+              style={{ fontSize: "10.5px" }}
+              data-testid="setting-harness-descriptors-path"
+            >
+              File:{" "}
+              <span className="font-mono">
+                {settings.harness_descriptors.path ?? "— (HOME unset)"}
+              </span>
+            </div>
+            <div
+              className="text-fg-3"
+              style={{ fontSize: "10.5px" }}
+              data-testid="setting-harness-descriptors-names"
+            >
+              Harnesses: {settings.harness_descriptors.names.join(", ")}
+            </div>
+            {settings.harness_descriptors.reason && (
+              <div
+                className="text-st-failed"
+                style={{ fontSize: "10.5px" }}
+                data-testid="setting-harness-descriptors-reason"
+              >
+                {settings.harness_descriptors.reason}
+              </div>
+            )}
+          </div>
+        )}
+
         {error && (
           <div
             className="rounded-md border border-st-failed/30 bg-st-failed-bg px-3 py-2 text-st-failed"

--- a/frontend/src/components/TriggersListPanel.tsx
+++ b/frontend/src/components/TriggersListPanel.tsx
@@ -1,8 +1,11 @@
+import { useMemo, useState } from "react";
 import { AlertCircle, PauseCircle, Pencil, Play, Plus, Power, Trash2, Zap } from "lucide-react";
-import type { Trigger } from "../types";
+import type { Trigger, Project } from "../types";
 import { deleteTrigger, updateTrigger } from "../api";
 import { humanizeCron } from "../cronPresets";
-import { groupByRepo, repoGroupLabel } from "../lib/groupByRepo";
+import { groupByProject, repoGroupLabel, type ProjectRef } from "../lib/groupByRepo";
+import { projectLookup } from "../lib/projectLookup";
+import ProjectEditModal from "./ProjectEditModal";
 
 interface Props {
   triggers: Trigger[];
@@ -18,6 +21,10 @@ interface Props {
   paused?: boolean;
   /** #348: flip the global pause flag. */
   onTogglePause?: () => void;
+  /** Projets (#552) — the group-by-Projet layer and the pencil. Optional so
+   *  existing callers/tests keep working. */
+  projects?: Project[];
+  onProjectsChanged?: () => void;
 }
 
 /**
@@ -56,7 +63,16 @@ export default function TriggersListPanel({
   onEditTrigger,
   paused = false,
   onTogglePause,
+  projects = [],
+  onProjectsChanged,
 }: Props) {
+  // #552 — the group-header pencil editor (see UnifiedLeftPanel for the shape).
+  const [projectEditor, setProjectEditor] = useState<{
+    project: Project | null;
+    name: string;
+    memberPaths: string[];
+  } | null>(null);
+
   async function handleDelete(triggerId: string) {
     try {
       await deleteTrigger(triggerId);
@@ -191,9 +207,44 @@ export default function TriggersListPanel({
     );
   }
 
-  // Group the Triggers list by project (#258) only when ≥ 2 distinct repos are
-  // present; otherwise `null` ⇒ the flat list, byte-identical to before.
-  const triggerGroups = groupByRepo(triggers, (t) => t.effective_repo);
+  // #552 — verbatim `path → Projet` lookup and the candidate repos the pencil can
+  // attach (the distinct effective repos across the Triggers list).
+  const projectOf = useMemo<(path: string) => ProjectRef | null>(
+    () => projectLookup(projects),
+    [projects],
+  );
+  const availableRepos = useMemo(() => {
+    const set = new Set<string>();
+    for (const t of triggers) if (t.effective_repo) set.add(t.effective_repo);
+    return [...set];
+  }, [triggers]);
+
+  // Group the Triggers list by Projet (#552), falling back to the #258 per-path
+  // grouping when nothing is named; `null` ⇒ the flat list.
+  const triggerGroups = groupByProject(triggers, (t) => t.effective_repo, projectOf);
+
+  const openProjectEditor = (group: {
+    kind: "project" | "path";
+    key: string;
+    repoPath: string;
+    label: string;
+  }) => {
+    if (group.kind === "project") {
+      const id = group.key.slice("project:".length);
+      const project = projects.find((p) => p.id === id) ?? null;
+      setProjectEditor({
+        project,
+        name: project?.name ?? group.label,
+        memberPaths: project?.members ?? [],
+      });
+    } else {
+      setProjectEditor({
+        project: null,
+        name: group.label,
+        memberPaths: group.repoPath ? [group.repoPath] : [],
+      });
+    }
+  };
 
   return (
     <div className="flex h-full flex-col" data-testid="triggers-list-panel">
@@ -280,20 +331,46 @@ export default function TriggersListPanel({
           {triggerGroups === null
             ? triggers.map(renderTriggerRow)
             : triggerGroups.map((group) => (
-                <div key={group.repoPath} data-testid="trigger-repo-group">
+                <div
+                  key={group.key}
+                  data-testid="trigger-repo-group"
+                  data-project={group.kind === "project" ? "true" : "false"}
+                >
                   <div
-                    className="flex h-[22px] shrink-0 items-center border-b border-line-soft bg-bg-3/40 px-3 font-medium text-fg-3"
+                    className="group/hdr flex h-[22px] shrink-0 items-center gap-1 border-b border-line-soft bg-bg-3/40 px-3 font-medium text-fg-3"
                     style={{ fontSize: "10px" }}
-                    title={group.repoPath}
+                    title={group.title}
                   >
                     <span className="truncate" data-testid="trigger-repo-label">
                       {group.label}
                     </span>
+                    {/* #552 — the pencil that names / renames the Projet. */}
+                    <button
+                      onClick={() => openProjectEditor(group)}
+                      className="ml-auto hidden shrink-0 cursor-pointer rounded p-0.5 text-fg-4 transition-colors hover:bg-bg-4 hover:text-fg-2 group-hover/hdr:inline-flex"
+                      title={group.kind === "project" ? "Edit project" : "Name project"}
+                      aria-label={group.kind === "project" ? "Edit project" : "Name project"}
+                      data-testid="trigger-group-pencil"
+                    >
+                      <Pencil size={10} />
+                    </button>
                   </div>
                   {group.items.map(renderTriggerRow)}
                 </div>
               ))}
         </div>
+      )}
+
+      {projectEditor && (
+        <ProjectEditModal
+          initialProject={projectEditor.project}
+          initialName={projectEditor.name}
+          initialMemberPaths={projectEditor.memberPaths}
+          availableRepos={availableRepos}
+          projects={projects}
+          onClose={() => setProjectEditor(null)}
+          onSaved={() => onProjectsChanged?.()}
+        />
       )}
     </div>
   );

--- a/frontend/src/components/UnifiedLeftPanel.tsx
+++ b/frontend/src/components/UnifiedLeftPanel.tsx
@@ -1,15 +1,17 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { ChevronDown, ChevronRight, FileUp, Pause, Pencil, Play, Plus, RotateCcw, SquareTerminal, Trash2, Zap } from "lucide-react";
-import { isLiveRun, isTerminalRun, type RunListEntry, type RunStatus, type PipelineListEntry, type PipelineScope, type Trigger } from "../types";
+import { isLiveRun, isTerminalRun, type RunListEntry, type RunStatus, type PipelineListEntry, type PipelineScope, type Trigger, type Project } from "../types";
 import type { LibraryPipelineEntry } from "../api";
 import { cleanupRun, createPipeline, deleteLibraryPipeline, duplicateLibraryPipeline, forgetRun, importWorkflow, openRunShell, pauseRun, renameRun, resumeRun, retryAll } from "../api";
 import { useEditStore } from "../stores/editStore";
-import { groupByRepo } from "../lib/groupByRepo";
+import { groupByProject, type ProjectRef } from "../lib/groupByRepo";
+import { projectLookup } from "../lib/projectLookup";
 import { cascadableTwin, isStarred, libraryOnly } from "../lib/libraryTwins";
 import CleanupConfirmModal from "./CleanupConfirmModal";
 import ConfirmDeleteModal from "./ConfirmDeleteModal";
 import ForgetRunModal from "./ForgetRunModal";
 import LibraryRow from "./LibraryRow";
+import ProjectEditModal from "./ProjectEditModal";
 import RunFilters from "./RunFilters";
 import { EMPTY_RUN_FILTER, runMatchesFilter } from "./runFilter";
 import RunShellModal from "./RunShellModal";
@@ -48,6 +50,11 @@ interface Props {
    * callers/tests keep working (defaults to not-paused, no-op toggle). */
   triggersPaused?: boolean;
   onTogglePause?: () => void;
+  /** Projets (#552) — the group-by-Projet layer and the pencil's source of
+   *  truth. Optional so existing callers/tests keep working (no Projet → the
+   *  #258 per-path grouping, unchanged). */
+  projects?: Project[];
+  onProjectsChanged?: () => void;
 }
 
 export default function UnifiedLeftPanel({
@@ -66,6 +73,8 @@ export default function UnifiedLeftPanel({
   onEditTrigger,
   triggersPaused = false,
   onTogglePause,
+  projects = [],
+  onProjectsChanged,
 }: Props) {
   const [activeTab, setActiveTab] = useState<LeftTab>("runs");
   const [confirmCleanup, setConfirmCleanup] = useState<
@@ -80,6 +89,13 @@ export default function UnifiedLeftPanel({
   const [renamingRunId, setRenamingRunId] = useState<string | null>(null);
   const [renameValue, setRenameValue] = useState("");
   const renameInputRef = useRef<HTMLInputElement>(null);
+  // #552 — the group-header pencil. Holds the Projet being edited (or `null` for
+  // a fresh one, when the header is a derived path group) plus the pre-fill.
+  const [projectEditor, setProjectEditor] = useState<{
+    project: Project | null;
+    name: string;
+    memberPaths: string[];
+  } | null>(null);
 
   const pipelines = useEditStore((s) => s.pipelines);
   const loadPipelines = useEditStore((s) => s.loadPipelines);
@@ -470,9 +486,47 @@ export default function UnifiedLeftPanel({
     if (selectedArchivedId !== null) setArchivedOpen(true);
   }
 
-  // Group the active Runs list by project (#258) only when ≥ 2 distinct repos are
-  // present; otherwise `null` ⇒ the flat list, byte-identical to before.
-  const runGroups = groupByRepo(activeRuns, (r) => r.effective_repo);
+  // #552 — verbatim `path → Projet` lookup, and the candidate repos the pencil
+  // can attach (the distinct effective repos across ALL runs, so a filtered view
+  // never hides an attachable repo).
+  const projectOf = useMemo<(path: string) => ProjectRef | null>(
+    () => projectLookup(projects),
+    [projects],
+  );
+  const availableRepos = useMemo(() => {
+    const set = new Set<string>();
+    for (const r of runs) if (r.effective_repo) set.add(r.effective_repo);
+    return [...set];
+  }, [runs]);
+
+  // Group the active Runs list by Projet (#552), falling back to the #258
+  // per-path grouping when nothing is named; `null` ⇒ the flat list.
+  const runGroups = groupByProject(activeRuns, (r) => r.effective_repo, projectOf);
+
+  // Open the pencil on a group header: an existing Projet pre-fills its record;
+  // a derived path group pre-fills the label + its own path as the sole member.
+  const openProjectEditor = (group: {
+    kind: "project" | "path";
+    key: string;
+    repoPath: string;
+    label: string;
+  }) => {
+    if (group.kind === "project") {
+      const id = group.key.slice("project:".length);
+      const project = projects.find((p) => p.id === id) ?? null;
+      setProjectEditor({
+        project,
+        name: project?.name ?? group.label,
+        memberPaths: project?.members ?? [],
+      });
+    } else {
+      setProjectEditor({
+        project: null,
+        name: group.label,
+        memberPaths: group.repoPath ? [group.repoPath] : [],
+      });
+    }
+  };
 
   const tabs: { id: LeftTab; label: string }[] = [
     { id: "runs", label: "Runs" },
@@ -555,15 +609,29 @@ export default function UnifiedLeftPanel({
           {runGroups === null
             ? activeRuns.map(renderRunRow)
             : runGroups.map((group) => (
-                <div key={group.repoPath} data-testid="run-repo-group">
+                <div
+                  key={group.key}
+                  data-testid="run-repo-group"
+                  data-project={group.kind === "project" ? "true" : "false"}
+                >
                   <div
-                    className="flex h-[22px] shrink-0 items-center border-b border-line-soft bg-bg-3/40 px-3 font-medium text-fg-3"
+                    className="group/hdr flex h-[22px] shrink-0 items-center gap-1 border-b border-line-soft bg-bg-3/40 px-3 font-medium text-fg-3"
                     style={{ fontSize: "10px" }}
-                    title={group.repoPath}
+                    title={group.title}
                   >
                     <span className="truncate" data-testid="run-repo-label">
                       {group.label}
                     </span>
+                    {/* #552 — the pencil that names / renames the Projet. */}
+                    <button
+                      onClick={() => openProjectEditor(group)}
+                      className="ml-auto hidden shrink-0 cursor-pointer rounded p-0.5 text-fg-4 transition-colors hover:bg-bg-4 hover:text-fg-2 group-hover/hdr:inline-flex"
+                      title={group.kind === "project" ? "Edit project" : "Name project"}
+                      aria-label={group.kind === "project" ? "Edit project" : "Name project"}
+                      data-testid="run-group-pencil"
+                    >
+                      <Pencil size={10} />
+                    </button>
                   </div>
                   {group.items.map(renderRunRow)}
                 </div>
@@ -606,6 +674,8 @@ export default function UnifiedLeftPanel({
             onEditTrigger={onEditTrigger}
             paused={triggersPaused}
             onTogglePause={onTogglePause ?? (() => {})}
+            projects={projects}
+            onProjectsChanged={onProjectsChanged}
           />
         </div>
       )}
@@ -725,6 +795,18 @@ export default function UnifiedLeftPanel({
         <RunShellModal
           session={shellRun.session}
           onClose={() => setShellRun(null)}
+        />
+      )}
+
+      {projectEditor && (
+        <ProjectEditModal
+          initialProject={projectEditor.project}
+          initialName={projectEditor.name}
+          initialMemberPaths={projectEditor.memberPaths}
+          availableRepos={availableRepos}
+          projects={projects}
+          onClose={() => setProjectEditor(null)}
+          onSaved={() => onProjectsChanged?.()}
         />
       )}
 

--- a/frontend/src/lib/costLabel.test.ts
+++ b/frontend/src/lib/costLabel.test.ts
@@ -51,6 +51,30 @@ describe("formatEstCost (single run, #272)", () => {
     const c = formatEstCost(2.5, true, []);
     expect(c.title).toMatch(/an unpriced model was excluded/);
   });
+
+  it("renders — (never $0, no dagger) and names the harness for an uncosted harness (#553)", () => {
+    // A Run with a node on a harness with no cost source: "—" with a reason
+    // naming the harness — categorically different from a lower bound.
+    const c = formatEstCost(0, false, [], ["opencode"]);
+    expect(c.text).toBe("—");
+    expect(c.text).not.toContain("$");
+    expect(c.dagger).toBe(false);
+    expect(c.title).toMatch(/cost unavailable/i);
+    expect(c.title).toContain("opencode");
+    expect(c.title).toMatch(/no cost source/);
+  });
+
+  it("takes the uncosted branch even when partial/priced data is present (#553)", () => {
+    // "Unavailable" is a stronger statement than "lower bound": it wins.
+    const c = formatEstCost(4.2, true, ["claude-fable-5"], ["opencode", "codex"]);
+    expect(c.text).toBe("—");
+    expect(c.dagger).toBe(false);
+    expect(c.title).toContain("opencode");
+    expect(c.title).toContain("codex");
+    expect(c.title).toMatch(/harnesses .* have no cost source/);
+    // Not framed as a lower bound — there is no figure at all.
+    expect(c.title).not.toContain("claude-fable-5");
+  });
 });
 
 describe("formatBucketCost (aggregate, #377)", () => {

--- a/frontend/src/lib/costLabel.ts
+++ b/frontend/src/lib/costLabel.ts
@@ -37,6 +37,21 @@ function lowerBoundClause(unpricedModels: string[], runSuffix = ""): string {
   return body + runSuffix;
 }
 
+/**
+ * The clause for a Run whose cost is **unavailable** because one or more harnesses
+ * has no cost source (#553, ADR-0045). Names the harness(es) — the same "name what
+ * is missing" discipline as {@link lowerBoundClause} for unpriced models — so the
+ * user never reads an anonymous blank, and never a `$0` standing in for "unknown".
+ * A categorically different state from a lower bound: there is no figure at all.
+ */
+export function uncostedClause(uncostedHarnesses: string[]): string {
+  return ` Cost unavailable: ${
+    uncostedHarnesses.length === 1 ? "harness" : "harnesses"
+  } ${uncostedHarnesses.join(", ")} ${
+    uncostedHarnesses.length === 1 ? "has" : "have"
+  } no cost source, so this Run's cost cannot be estimated.`;
+}
+
 export interface CostLabel {
   /** Display text, e.g. `~$1.2345`. */
   text: string;
@@ -55,7 +70,20 @@ export function formatEstCost(
   usd: number,
   partial: boolean,
   unpricedModels: string[] = [],
+  uncostedHarnesses: string[] = [],
 ): CostLabel {
+  // #553: a harness with no cost source makes the Run's cost not honestly
+  // summable — show "—" with a reason naming the harness, never a $ figure and
+  // never a mute dagger (that would read as "priced, lower bound", which this is
+  // not). This branch takes precedence over `partial`, since "unavailable" is a
+  // stronger statement than "incomplete".
+  if (uncostedHarnesses.length > 0) {
+    return {
+      text: "—",
+      dagger: false,
+      title: COST_ESTIMATE_NOTE + uncostedClause(uncostedHarnesses),
+    };
+  }
   return {
     text: `~$${usd.toFixed(costPrecision(usd))}`,
     dagger: partial,

--- a/frontend/src/lib/groupByProject.test.ts
+++ b/frontend/src/lib/groupByProject.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from "vitest";
+import { groupByProject, type ProjectRef } from "./groupByRepo";
+
+interface Row {
+  id: string;
+  repo: string | null;
+}
+
+const repoOf = (r: Row) => r.repo;
+
+/** Build a verbatim `path → ProjectRef | null` lookup from a members map. */
+function projectOfFrom(
+  members: Record<string, ProjectRef>,
+): (path: string) => ProjectRef | null {
+  return (path) => members[path] ?? null;
+}
+
+const NO_PROJECTS = projectOfFrom({});
+
+describe("groupByProject", () => {
+  it("returns null for an empty list", () => {
+    expect(groupByProject([] as Row[], repoOf, NO_PROJECTS)).toBeNull();
+  });
+
+  it("without any Projet, behaves exactly like the #258 per-path grouping", () => {
+    // AC: sans Projet, les listes se groupent exactement comme aujourd'hui.
+    const rows: Row[] = [
+      { id: "a", repo: "/repos/foo" },
+      { id: "b", repo: "/repos/foo" },
+    ];
+    // One distinct path, no Projet → flat.
+    expect(groupByProject(rows, repoOf, NO_PROJECTS)).toBeNull();
+  });
+
+  it("groups ≥2 distinct paths (no Projet), derived basename labels", () => {
+    // AC vitest: libellé dérivé quand il n'y a pas de Projet.
+    const rows: Row[] = [
+      { id: "z1", repo: "/repos/zebra" },
+      { id: "a1", repo: "/repos/alpha" },
+      { id: "z2", repo: "/repos/zebra" },
+    ];
+    const groups = groupByProject(rows, repoOf, NO_PROJECTS);
+    expect(groups).not.toBeNull();
+    expect(groups!.map((g) => g.label)).toEqual(["alpha", "zebra"]);
+    expect(groups!.every((g) => g.kind === "path")).toBe(true);
+    // Items preserved in input order within each group.
+    expect(groups!.find((g) => g.label === "zebra")!.items.map((i) => i.id)).toEqual([
+      "z1",
+      "z2",
+    ]);
+  });
+
+  it("disambiguates colliding basenames on path groups (minimal suffix)", () => {
+    const rows: Row[] = [
+      { id: "1", repo: "/a/app" },
+      { id: "2", repo: "/b/app" },
+    ];
+    const groups = groupByProject(rows, repoOf, NO_PROJECTS)!;
+    expect(groups.map((g) => g.label).sort()).toEqual(["a/app", "b/app"]);
+  });
+
+  it("collapses a Projet's member paths under its name (single Projet still shows)", () => {
+    // FP: nommer un Projet et y rattacher les deux dépôts → les deux se rangent
+    // sous ce nom. A single Projet over the only two repos still renders (the
+    // "any group is a Projet" clause), it does not flatten.
+    const front = "/repos/front";
+    const back = "/repos/back";
+    const projectOf = projectOfFrom({
+      [front]: { id: "p1", name: "MyProduct" },
+      [back]: { id: "p1", name: "MyProduct" },
+    });
+    const rows: Row[] = [
+      { id: "f", repo: front },
+      { id: "b", repo: back },
+    ];
+    const groups = groupByProject(rows, repoOf, projectOf);
+    expect(groups).not.toBeNull();
+    expect(groups!).toHaveLength(1);
+    expect(groups![0].kind).toBe("project");
+    expect(groups![0].label).toBe("MyProduct");
+    // Both repos' rows are under the one name.
+    expect(groups![0].items.map((i) => i.id)).toEqual(["f", "b"]);
+    // The hover title exposes the member paths.
+    expect(groups![0].title).toBe([back, front].sort().join(", "));
+  });
+
+  it("counts a Projet as one unit — the threshold moved onto projects, not paths", () => {
+    // A Projet grouping two repos + one loose repo = 2 groups → grouped, with the
+    // Projet collapsing its two member paths into a single header.
+    const front = "/repos/front";
+    const back = "/repos/back";
+    const other = "/repos/other";
+    const projectOf = projectOfFrom({
+      [front]: { id: "p1", name: "Product" },
+      [back]: { id: "p1", name: "Product" },
+    });
+    const rows: Row[] = [
+      { id: "f", repo: front },
+      { id: "b", repo: back },
+      { id: "o", repo: other },
+    ];
+    const groups = groupByProject(rows, repoOf, projectOf)!;
+    expect(groups).toHaveLength(2);
+    const project = groups.find((g) => g.kind === "project")!;
+    expect(project.label).toBe("Product");
+    expect(project.items.map((i) => i.id)).toEqual(["f", "b"]);
+    const path = groups.find((g) => g.kind === "path")!;
+    expect(path.label).toBe("other");
+    expect(path.items.map((i) => i.id)).toEqual(["o"]);
+  });
+
+  it("a Projet whose members are absent from the list does not force grouping", () => {
+    // projectOf returns a ref only for member paths actually present. A single
+    // loose repo whose path is in no Projet stays flat.
+    const rows: Row[] = [{ id: "x", repo: "/repos/solo" }];
+    const projectOf = projectOfFrom({
+      "/repos/elsewhere": { id: "p9", name: "Elsewhere" },
+    });
+    expect(groupByProject(rows, repoOf, projectOf)).toBeNull();
+  });
+
+  it("compares membership verbatim — a trailing slash is a different, unowned path", () => {
+    // ADR-0033: two spellings are two paths. `/repos/front/` is not the member
+    // `/repos/front`, so it falls back to a path group.
+    const projectOf = projectOfFrom({
+      "/repos/front": { id: "p1", name: "Product" },
+    });
+    const rows: Row[] = [
+      { id: "a", repo: "/repos/front" },
+      { id: "b", repo: "/repos/front/" },
+    ];
+    const groups = groupByProject(rows, repoOf, projectOf)!;
+    expect(groups).toHaveLength(2);
+    expect(groups.some((g) => g.kind === "project" && g.label === "Product")).toBe(true);
+    expect(groups.some((g) => g.kind === "path")).toBe(true);
+  });
+
+  it("orders groups by label, tie-broken by key; items keep input order", () => {
+    const projectOf = projectOfFrom({
+      "/repos/aaa": { id: "pz", name: "Zeta" },
+    });
+    const rows: Row[] = [
+      { id: "1", repo: "/repos/aaa" }, // Projet "Zeta"
+      { id: "2", repo: "/repos/mmm" }, // path "mmm"
+    ];
+    const groups = groupByProject(rows, repoOf, projectOf)!;
+    // "Zeta" > "mmm"? Code-unit: 'Z'(90) < 'm'(109), so "Zeta" sorts first.
+    expect(groups.map((g) => g.label)).toEqual(["Zeta", "mmm"]);
+  });
+});

--- a/frontend/src/lib/groupByRepo.ts
+++ b/frontend/src/lib/groupByRepo.ts
@@ -105,3 +105,116 @@ export function groupByRepo<T>(
     items: buckets.get(key)!,
   }));
 }
+
+/** A Projet reference: the identity the daemon returns, minimal for grouping. */
+export interface ProjectRef {
+  id: string;
+  name: string;
+}
+
+/**
+ * A group in the "group by Projet" view (#552). Either a **Projet** (several
+ * member repo paths collapse under the human-given name) or a derived **path**
+ * group (an effective repo in no Projet, labelled by basename as before, #258).
+ */
+export interface ProjectGroup<T> {
+  /** Stable identity: `project:<id>` for a Projet, else the raw effective path. */
+  key: string;
+  kind: "project" | "path";
+  /** The effective-repo path for a path group; empty for a Projet group. */
+  repoPath: string;
+  /** Display label: the Projet name, or the derived basename for a path group. */
+  label: string;
+  /** Hover title: the path (path group) or the joined member paths (Projet). */
+  title: string;
+  items: T[];
+}
+
+interface Bucket<T> {
+  key: string;
+  kind: "project" | "path";
+  ref: ProjectRef | null;
+  paths: Set<string>;
+  items: T[];
+}
+
+/**
+ * Group `items` by their **Projet** (#552, ADR-0046), falling back to the #258
+ * per-path grouping for any repo in no Projet. The Projet of a path is resolved
+ * **verbatim** by `projectOf` (a `path → ProjectRef | null` lookup the caller
+ * builds from `GET /projects`); ADR-0033 forbids canonicalising, so two spellings
+ * are two paths.
+ *
+ * Returns `null` — the flat list, byte-identical to no grouping — unless grouping
+ * is warranted. Grouping shows when **there are ≥ 2 distinct groups**, OR **any
+ * group is a named Projet**. The second clause is what makes a single Projet over
+ * all of a list's repos still render under its name (the FP's "se rangent sous ce
+ * nom"); the ≥ 2 clause preserves #258 exactly when no Projet exists — the "seuil
+ * porte désormais sur les projets" of the AC, a Projet counting as one unit that
+ * collapses its member paths.
+ *
+ * Groups are ordered by label (locale-independent code-unit compare), tie-broken
+ * by key, so they never reshuffle as rows arrive. An item whose `repoOf` is
+ * null/empty drops into a single nameless bucket that does not count toward the
+ * threshold (defensive: real daemon data always resolves a concrete path).
+ */
+export function groupByProject<T>(
+  items: T[],
+  repoOf: (item: T) => string | null | undefined,
+  projectOf: (path: string) => ProjectRef | null,
+): ProjectGroup<T>[] | null {
+  const buckets = new Map<string, Bucket<T>>();
+  for (const item of items) {
+    const raw = repoOf(item);
+    const path = raw == null || raw.length === 0 ? "" : raw;
+    const proj = path.length ? projectOf(path) : null;
+    const key = proj ? `project:${proj.id}` : path;
+    let bucket = buckets.get(key);
+    if (!bucket) {
+      bucket = {
+        key,
+        kind: proj ? "project" : "path",
+        ref: proj,
+        paths: new Set(),
+        items: [],
+      };
+      buckets.set(key, bucket);
+    }
+    if (path.length) bucket.paths.add(path);
+    bucket.items.push(item);
+  }
+
+  // Real buckets exclude the defensive nameless one (empty key).
+  const real = [...buckets.values()].filter((b) => b.key.length > 0);
+  const hasProject = real.some((b) => b.kind === "project");
+  if (real.length < 2 && !hasProject) return null;
+
+  // Path-group labels disambiguate among the path groups only (a Projet's paths
+  // are hidden behind its name, so they never force a suffix on a path group).
+  const pathKeys = real.filter((b) => b.kind === "path").map((b) => b.key);
+
+  const groups: ProjectGroup<T>[] = [...buckets.values()].map((b) => {
+    if (b.kind === "project") {
+      return {
+        key: b.key,
+        kind: "project" as const,
+        repoPath: "",
+        label: b.ref ? b.ref.name : "",
+        title: [...b.paths].sort().join(", "),
+        items: b.items,
+      };
+    }
+    return {
+      key: b.key,
+      kind: "path" as const,
+      repoPath: b.key,
+      label: b.key.length > 0 ? repoGroupLabel(b.key, pathKeys) : "",
+      title: b.key,
+      items: b.items,
+    };
+  });
+
+  const cmp = (a: string, b: string) => (a < b ? -1 : a > b ? 1 : 0);
+  groups.sort((a, b) => cmp(a.label, b.label) || cmp(a.key, b.key));
+  return groups;
+}

--- a/frontend/src/lib/harness.ts
+++ b/frontend/src/lib/harness.ts
@@ -1,0 +1,78 @@
+// The agentic-harness axis, client side (#550, ADR-0046).
+//
+// The daemon owns the truth (descriptor + resolver); this module is the thin
+// client mirror the editor needs: which harnesses exist, which one an editor node
+// resolves to, whether a harness exposes an effort axis (to grey the picker), and
+// the fold between the node's per-harness `harnesses` map and the single
+// `model`/`effort` view the existing pickers edit.
+
+import type { NodeDef } from "../types";
+
+/** The floor of the precedence chain — a node with no pin runs on `claude`. */
+export const HARNESS_FLOOR = "claude";
+
+/** The harnesses PDO ships embedded (ADR-0045). The pin selector offers these
+ *  plus "Default" (follow the tier above). A user-declared disk harness (#553)
+ *  would extend this; not in this slice. */
+export const KNOWN_HARNESSES = ["claude", "opencode"] as const;
+
+/** Client mirror of the descriptor's `{effort}` hole (ADR-0045): `opencode` has
+ *  no launch-time effort axis, so its effort picker is greyed. An unknown harness
+ *  defaults to "has effort" — the conservative choice (don't grey what we can't
+ *  see; the daemon still ignores an effort a harness can't honour). */
+const HARNESS_HAS_EFFORT: Record<string, boolean> = {
+  claude: true,
+  opencode: false,
+};
+
+export function harnessHasEffort(name: string): boolean {
+  return HARNESS_HAS_EFFORT[name] ?? true;
+}
+
+/** The harness an editor node resolves to, with only the tiers a client knows:
+ *  the node's pin, else the `claude` floor. (The instance default is a coarser
+ *  tier the editor does not fetch per-node; the floor is the safe editor default,
+ *  and the daemon re-resolves authoritatively at spawn.) An empty pin is "unset". */
+export function resolveEditorHarness(node: Pick<NodeDef, "pin_harness">): string {
+  const pin = node.pin_harness;
+  return pin && pin !== "" ? pin : HARNESS_FLOOR;
+}
+
+/** Load fold: project the RESOLVED harness's `{model, effort}` out of the node's
+ *  `harnesses` map onto the flat `model`/`effort` the pickers edit. Returns a new
+ *  node; the `harnesses` map is preserved so non-resolved entries survive a
+ *  round-trip. Idempotent. */
+export function foldHarnessOntoNode(node: NodeDef): NodeDef {
+  const resolved = resolveEditorHarness(node);
+  const entry = node.harnesses?.[resolved];
+  return {
+    ...node,
+    model: entry?.model ?? null,
+    effort: entry?.effort ?? null,
+  };
+}
+
+/** Save fold: merge the flat `model`/`effort` back into `harnesses[resolved]`,
+ *  preserving every other harness's entry, and dropping an entry that carries
+ *  neither. Returns the harnesses map to emit (or `undefined` when empty). */
+export function foldNodeIntoHarnesses(
+  node: NodeDef,
+): Record<string, { model?: string; effort?: string }> | undefined {
+  const resolved = resolveEditorHarness(node);
+  const out: Record<string, { model?: string; effort?: string }> = {};
+  // Carry over existing entries (non-resolved harnesses keep their settings).
+  for (const [name, entry] of Object.entries(node.harnesses ?? {})) {
+    const model = entry?.model || undefined;
+    const effort = entry?.effort || undefined;
+    if (model || effort) out[name] = { ...(model ? { model } : {}), ...(effort ? { effort } : {}) };
+  }
+  // Overlay the flat view onto the resolved harness.
+  const model = node.model || undefined;
+  const effort = node.effort || undefined;
+  if (model || effort) {
+    out[resolved] = { ...(model ? { model } : {}), ...(effort ? { effort } : {}) };
+  } else {
+    delete out[resolved];
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}

--- a/frontend/src/lib/layoutFields.test.ts
+++ b/frontend/src/lib/layoutFields.test.ts
@@ -67,6 +67,10 @@ const NODE: Complete<NodeDef> = {
   // `serializePipeline.test.ts` (the key lands in the YAML object) and in
   // `editStore.test.ts` (edit → spread → serializer → save payload).
   effort: "low",
+  // #550/ADR-0046: `Complete<NodeDef>` forces these two; same caveat as above —
+  // naming them proves nothing about emission (the serializer tests do that).
+  pin_harness: "claude",
+  harnesses: { claude: { model: "opus", effort: "low" } },
 };
 const EDGE: Complete<EdgeDef> = {
   source: { node: "n1", port: "out" },

--- a/frontend/src/lib/layoutFields.ts
+++ b/frontend/src/lib/layoutFields.ts
@@ -43,11 +43,13 @@ export type SerializerScope =
 
 export const SEMANTIC_FIELDS: Record<SerializerScope, readonly string[]> = {
   pipeline: ["name", "version", "prompt_required", "variables", "nodes", "edges", "loops"] satisfies (keyof PipelineDef)[],
-  // #424: `effort` is SEMANTIC, like `model` — it changes how the agent behaves,
-  // so it belongs in the pipeline diff and in the library content hash. What is
-  // load-bearing is its ABSENCE from LAYOUT_FIELDS.node: that is what keeps
-  // `stripLayout` from dropping it.
-  node: ["id", "name", "type", "interactive", "model", "effort", "max_iter", "inputs", "outputs"] satisfies (keyof NodeDef)[],
+  // #550/ADR-0046: the harness axis replaces the flat `model`/`effort` (#296/#424)
+  // the serializer used to emit. `pin_harness` and the per-harness `harnesses` map
+  // are SEMANTIC — they change what runs the node and how — so they belong in the
+  // pipeline diff and the library content hash. What is load-bearing is their
+  // ABSENCE from LAYOUT_FIELDS.node: that is what keeps `stripLayout` from dropping
+  // them.
+  node: ["id", "name", "type", "interactive", "pin_harness", "harnesses", "max_iter", "inputs", "outputs"] satisfies (keyof NodeDef)[],
   // `side` is SEMANTIC today (emitted, not stripped) — deliberate, see #355 D5:
   // the node-library star already treats port side as identity, so the pipeline
   // diff must agree or the two stars contradict each other on the same edit.

--- a/frontend/src/lib/newRunForm.test.ts
+++ b/frontend/src/lib/newRunForm.test.ts
@@ -6,6 +6,7 @@ import {
   buildVariables,
   canCreateTrigger,
   canLaunch,
+  harnessState,
   hasRequiredPrompt,
   overrideCount,
   parseVariableValue,
@@ -138,6 +139,7 @@ describe("buildVariables", () => {
       autoName: true,
       runName: "",
       sandbox: "",
+      harness: "",
       images: [],
     };
     const triggerFields = {
@@ -151,6 +153,7 @@ describe("buildVariables", () => {
       allowOverlap: false,
       maxConcurrent: "",
       sandbox: "",
+      harness: "",
       autoName: true,
       variables,
     };
@@ -453,6 +456,48 @@ describe("sandboxState (#410/#432/#452)", () => {
   });
 });
 
+/** The default_harness tier resolving to `name` (#551). */
+const defaultHarnessIs = (name: string): Partial<InstanceSettings> => ({
+  default_harness: { effective: name, source: "stored", stored: name, env: null, default: null },
+});
+
+describe("harnessState (#551/#452)", () => {
+  it("does not know the default until settings arrive", () => {
+    // The honest render: `null`, not a guess. The selector shows a bare "Use instance
+    // default" until it knows what that is — it never seeds a value from a late fetch.
+    const state = harnessState({ settings: null, harness: "" });
+    expect(state.instanceDefaultHarness).toBeNull();
+    expect(state.effectiveHarness).toBeNull();
+  });
+
+  it("names the instance default through the claude floor when none is set", () => {
+    // #452: the inherit option is LABELLED with what it resolves to — the floor when the
+    // instance names no harness — but the value stays `""` (asserts nothing).
+    const state = harnessState({ settings: settings(), harness: "" });
+    expect(state.instanceDefaultHarness).toBe("claude");
+    expect(state.effectiveHarness).toBe("claude");
+  });
+
+  it("names a stored instance default", () => {
+    const state = harnessState({ settings: settings(defaultHarnessIs("opencode")), harness: "" });
+    expect(state.instanceDefaultHarness).toBe("opencode");
+    // The inherit sentinel resolves to the instance default…
+    expect(state.effectiveHarness).toBe("opencode");
+  });
+
+  it("resolves a concrete selection to itself, not the default", () => {
+    const state = harnessState({ settings: settings(defaultHarnessIs("claude")), harness: "opencode" });
+    expect(state.effectiveHarness).toBe("opencode");
+  });
+
+  it("offers the embedded harnesses", () => {
+    expect(harnessState({ settings: settings(), harness: "" }).knownHarnesses).toEqual([
+      "claude",
+      "opencode",
+    ]);
+  });
+});
+
 describe("buildRunPayload", () => {
   const fields = {
     selectedPipeline: pipeline({ id: "p1", name: "Auditor" }),
@@ -463,8 +508,19 @@ describe("buildRunPayload", () => {
     autoName: false,
     runName: "  Fix bug  ",
     sandbox: "full",
+    harness: "",
     images: [new File(["png"], "design.png", { type: "image/png" })],
   };
+
+  /**
+   * #551/#452, the harness twin of the sandbox assertion: `""` means "the user did not
+   * choose", and only an ABSENT `harness` lets the daemon resolve through the instance
+   * default and the floor. A concrete choice is sent verbatim.
+   */
+  it("omits the harness key for the inherit sentinel, and sends an explicit choice", () => {
+    expect(buildRunPayload({ ...fields, harness: "" }).harness).toBeUndefined();
+    expect(buildRunPayload({ ...fields, harness: "opencode" }).harness).toBe("opencode");
+  });
 
   it("posts the trimmed form values", () => {
     expect(buildRunPayload(fields)).toMatchObject({
@@ -527,6 +583,7 @@ describe("buildTriggerCreatePayload / buildTriggerUpdatePayload", () => {
     allowOverlap: true,
     maxConcurrent: " 2 ",
     sandbox: "minimal",
+    harness: "",
     autoName: true,
     variables: { max_iter: 5 },
   };
@@ -544,6 +601,9 @@ describe("buildTriggerCreatePayload / buildTriggerUpdatePayload", () => {
       overlap_policy: "allow",
       max_concurrent: 2,
       sandbox: "minimal",
+      // #551: the inherit sentinel `""` maps to `null` on a Trigger (a real inherit
+      // state), exactly like `sandbox`.
+      harness: null,
       auto_name: true,
       variables: { max_iter: 5 },
     });
@@ -564,6 +624,7 @@ describe("buildTriggerCreatePayload / buildTriggerUpdatePayload", () => {
       overlap_policy: "allow",
       max_concurrent: 2,
       sandbox: "minimal",
+      harness: null,
       auto_name: true,
       variables: { max_iter: 5 },
     });
@@ -604,6 +665,15 @@ describe("buildTriggerCreatePayload / buildTriggerUpdatePayload", () => {
   it("sends null for the inherit sentinel on both paths", () => {
     expect(buildTriggerCreatePayload({ ...fields, sandbox: "" }).sandbox).toBeNull();
     expect(buildTriggerUpdatePayload({ ...fields, sandbox: "" }).sandbox).toBeNull();
+  });
+
+  // #551: the harness has the same real "inherit" state — `""` → `null` on both paths,
+  // a concrete name is sent verbatim.
+  it("maps the harness inherit sentinel to null, and sends a concrete choice", () => {
+    expect(buildTriggerCreatePayload({ ...fields, harness: "" }).harness).toBeNull();
+    expect(buildTriggerUpdatePayload({ ...fields, harness: "" }).harness).toBeNull();
+    expect(buildTriggerCreatePayload({ ...fields, harness: "opencode" }).harness).toBe("opencode");
+    expect(buildTriggerUpdatePayload({ ...fields, harness: "opencode" }).harness).toBe("opencode");
   });
 
   // A create sends no input_template at all when blank; a patch clears it to "".

--- a/frontend/src/lib/newRunForm.test.ts
+++ b/frontend/src/lib/newRunForm.test.ts
@@ -35,6 +35,8 @@ function settings(over: Partial<InstanceSettings> = {}): InstanceSettings {
     reaper_ttl_secs: { effective: 3600, source: "default", stored: null, env: null, default: 3600 },
     guard_timeout_secs: { effective: 60, source: "default", stored: null, env: null, default: 60 },
     default_model: { effective: null, source: "default", stored: null, env: null, default: null },
+    default_harness: { effective: null, source: "default", stored: null, env: null, default: null },
+    default_harness_model: { effective: {}, stored: {} },
     default_sandbox: { effective: "off", source: "default", stored: null, env: null, default: "off", reason: null },
     sandbox_docker: { available: true, reason: null, checked_at: "2026-07-01T10:00:00.000Z" },
     sandbox_profiles: [

--- a/frontend/src/lib/newRunForm.ts
+++ b/frontend/src/lib/newRunForm.ts
@@ -6,6 +6,7 @@ import type {
 } from "../api";
 import type { InstanceSettings, PipelineListEntry, SandboxProfileRef } from "../types";
 import { presetToCron, type CronPresetId } from "../cronPresets";
+import { HARNESS_FLOOR, KNOWN_HARNESSES } from "./harness";
 
 /**
  * The New Run / Trigger form's pure logic (#359), lifted out of `NewRunModal.tsx`.
@@ -295,6 +296,54 @@ export function sandboxState({
   };
 }
 
+/** Everything the harness selector derives from `settings` + the selected value (#551, ADR-0046). */
+export interface HarnessState {
+  /** The harnesses the pin selector offers (the embedded floor, ADR-0045). */
+  knownHarnesses: readonly string[];
+  /**
+   * The instance default harness, used to **label** the inherit option — never to seed
+   * the value (the #452 trap: a prefilled field freezes a stale value the user never
+   * chose). `null` while `settings` are unknown (the honest "we don't know yet" render).
+   * Resolves through the floor when the instance names none, so run mode always has a
+   * concrete name to show.
+   */
+  instanceDefaultHarness: string | null;
+  /**
+   * What will actually apply to the Run being created. `""` is not a value — it means the
+   * key is omitted and the instance default (then the floor) decides — so it resolves to
+   * `instanceDefaultHarness`. A concrete selection is itself.
+   */
+  effectiveHarness: string | null;
+}
+
+/**
+ * The harness cluster (#551, ADR-0046). `harness` is the selector value in BOTH modes:
+ * `""` = "the user did not choose" (inherit), or a concrete harness name. Mirror of
+ * {@link sandboxState}, minus the Docker/profile machinery — a harness name is free text
+ * with no availability probe (ADR-0045: PDO does not validate it; an unknown one fails
+ * fast at spawn), so there is nothing to grey and nothing to block.
+ */
+export function harnessState({
+  settings,
+  harness,
+}: {
+  settings: InstanceSettings | null;
+  harness: string;
+}): HarnessState {
+  // #452: the instance default LABELS the inherit option, never seeds the value. `null`
+  // while settings are unknown; resolves through the `claude` floor once known, so run
+  // mode always names a concrete harness the Run would inherit.
+  const instanceDefaultHarness = settings
+    ? (settings.default_harness.effective || HARNESS_FLOOR)
+    : null;
+  const effectiveHarness = harness === "" ? instanceDefaultHarness : harness;
+  return {
+    knownHarnesses: KNOWN_HARNESSES,
+    instanceDefaultHarness,
+    effectiveHarness,
+  };
+}
+
 /** The form values `POST /runs` reads. */
 export interface RunPayloadInput {
   selectedPipeline: PipelineListEntry;
@@ -305,6 +354,8 @@ export interface RunPayloadInput {
   autoName: boolean;
   runName: string;
   sandbox: string;
+  /** #551: the harness selector value — `""` (inherit) or a concrete name. */
+  harness: string;
   images: File[];
   /** #465: `[0]` = primary, `[1..]` = secondaries. Omit / `undefined` for a mono-repo Run. */
   targetRepos?: TargetRepoInput[];
@@ -319,6 +370,7 @@ export function buildRunPayload({
   autoName,
   runName,
   sandbox,
+  harness,
   images,
   targetRepos,
 }: RunPayloadInput): CreateRunRequest {
@@ -341,6 +393,10 @@ export function buildRunPayload({
     // and OMITS the key: only an absent `sandbox` lets the daemon apply
     // `default_sandbox`, because it reads a present `off` as final.
     sandbox: sandbox || undefined,
+    // #551: the explicit harness choice. `""` (inherit) OMITS the key, so the Run names
+    // no harness and each free node resolves through the instance default and the floor —
+    // exactly the "name the default, don't copy it" contract of the selector (#452).
+    harness: harness || undefined,
     images: images.length > 0 ? images : undefined,
   };
 }
@@ -357,6 +413,8 @@ export interface TriggerPayloadInput {
   allowOverlap: boolean;
   maxConcurrent: string;
   sandbox: string;
+  /** #551: the harness selector value — `""` (inherit) or a concrete name. */
+  harness: string;
   autoName: boolean;
   variables: Record<string, unknown>;
   /** #465: `[0]` = primary, `[1..]` = secondaries. Omit / `undefined` for a mono-repo Trigger. */
@@ -380,6 +438,7 @@ export function buildTriggerUpdatePayload({
   allowOverlap,
   maxConcurrent,
   sandbox,
+  harness,
   autoName,
   variables,
   targetRepos,
@@ -402,6 +461,9 @@ export function buildTriggerUpdatePayload({
     // #410: `""` (Use instance default) clears back to inheriting (`null`);
     // `off` or a staging profile name sets it.
     sandbox: sandbox || null,
+    // #551: `""` (Use instance default) clears back to inheriting (`null`); a concrete
+    // harness name sets it. Mirror of `sandbox`.
+    harness: harness || null,
     // #338: round-trip the auto-naming choice (flat bool, mirror of `enabled`).
     auto_name: autoName,
     variables,
@@ -419,6 +481,7 @@ export function buildTriggerCreatePayload({
   allowOverlap,
   maxConcurrent,
   sandbox,
+  harness,
   autoName,
   variables,
   targetRepos,
@@ -437,6 +500,8 @@ export function buildTriggerCreatePayload({
     max_concurrent: allowOverlap && maxConcurrent.trim() ? Number(maxConcurrent) : undefined,
     // #410: `""` (Use instance default) → `null` (inherit); `off` or a profile sets it.
     sandbox: sandbox || null,
+    // #551: `""` (Use instance default) → `null` (inherit); a concrete harness sets it.
+    harness: harness || null,
     // #338: freeze the auto-naming choice on the new Trigger (seeded from the
     // instance default when the modal opened).
     auto_name: autoName,

--- a/frontend/src/lib/projectLookup.ts
+++ b/frontend/src/lib/projectLookup.ts
@@ -1,0 +1,18 @@
+import type { Project } from "../types";
+import type { ProjectRef } from "./groupByRepo";
+
+/**
+ * Build a **verbatim** `path → ProjectRef | null` lookup from the Projets list
+ * (#552). ADR-0033: paths are matched by exact string equality, never
+ * canonicalised — two spellings of a path are two paths. Shared by the Runs and
+ * Triggers panels so both group identically.
+ */
+export function projectLookup(
+  projects: Project[],
+): (path: string) => ProjectRef | null {
+  const byPath = new Map<string, ProjectRef>();
+  for (const p of projects) {
+    for (const path of p.members) byPath.set(path, { id: p.id, name: p.name });
+  }
+  return (path) => byPath.get(path) ?? null;
+}

--- a/frontend/src/lib/serializePipeline.test.ts
+++ b/frontend/src/lib/serializePipeline.test.ts
@@ -133,6 +133,60 @@ describe("serializePipeline round-trip: YAML structural correctness", () => {
     expect(serializePipeline(makeFullPipeline([impl]))).toContain("effort: turbo");
   });
 
+  // #550/ADR-0046: the flat model/effort view is folded under `harnesses.<resolved>`
+  // — the substring assertions above pass by coincidence (the block CONTAINS
+  // "model: opus"); these pin the STRUCTURE and the pin.
+  it("folds model/effort under harnesses.claude for an unpinned node (#550)", () => {
+    const impl: NodeDef = {
+      id: "impl", name: "implementer", type: "code-mutating",
+      inputs: [], outputs: [{ name: "code", repeated: false, side: "right" }],
+      interactive: false, view: { x: 200, y: 0 }, model: "opus", effort: "low",
+    };
+    const yaml = serializePipeline(makeFullPipeline([impl]));
+    expect(yaml).toContain("harnesses:");
+    // The dumper emits a small map in flow style.
+    expect(yaml).toContain("claude: { model: opus, effort: low }");
+    // No pin when the node relies on the floor.
+    expect(yaml).not.toContain("pin_harness:");
+  });
+
+  it("emits pin_harness and folds model under the PINNED harness (#550)", () => {
+    const impl: NodeDef = {
+      id: "impl", name: "implementer", type: "code-mutating",
+      inputs: [], outputs: [{ name: "code", repeated: false, side: "right" }],
+      interactive: false, view: { x: 200, y: 0 },
+      pin_harness: "opencode", model: "openrouter/foo",
+    };
+    const yaml = serializePipeline(makeFullPipeline([impl]));
+    expect(yaml).toContain("pin_harness: opencode");
+    expect(yaml).toContain("opencode: { model: openrouter/foo }");
+  });
+
+  it("preserves a non-resolved harness's entry across a round-trip (#550)", () => {
+    // Editing on the resolved harness (claude) must not clobber opencode's entry.
+    const impl: NodeDef = {
+      id: "impl", name: "implementer", type: "code-mutating",
+      inputs: [], outputs: [{ name: "code", repeated: false, side: "right" }],
+      interactive: false, view: { x: 200, y: 0 },
+      model: "opus", // resolved = claude (no pin)
+      harnesses: { opencode: { model: "openrouter/bar" } },
+    };
+    const yaml = serializePipeline(makeFullPipeline([impl]));
+    expect(yaml).toContain("openrouter/bar"); // opencode entry survived
+    expect(yaml).toContain("opus"); // claude entry from the flat view
+  });
+
+  it("omits harnesses entirely for a plain node (#550, no-diverge default)", () => {
+    const impl: NodeDef = {
+      id: "impl", name: "implementer", type: "code-mutating",
+      inputs: [], outputs: [{ name: "code", repeated: false, side: "right" }],
+      interactive: false, view: { x: 200, y: 0 },
+    };
+    const yaml = serializePipeline(makeFullPipeline([impl]));
+    expect(yaml).not.toContain("harnesses:");
+    expect(yaml).not.toContain("pin_harness:");
+  });
+
   it("omits effort when unset/null/empty — the byte-identical default (#424)", () => {
     // `undefined`, `null` and `""` must all serialize as an ABSENT key: an
     // `effort: ""` in the file would reach the tail as an empty `--effort`, which

--- a/frontend/src/lib/serializePipeline.ts
+++ b/frontend/src/lib/serializePipeline.ts
@@ -29,6 +29,8 @@ import type {
   PortSide,
   FrontmatterFieldDecl,
 } from "../types";
+// #550: the per-harness fold (pure, `../types`-only) — keeps this module pure.
+import { foldNodeIntoHarnesses } from "./harness";
 
 /**
  * Drops the null-valued keys of every frontmatter declaration (#457).
@@ -90,18 +92,16 @@ export function pipelineToYamlObject(p: PipelineDef): Record<string, unknown> {
       type: n.type,
     };
     if (n.interactive) node.interactive = true;
-    // Per-node model override (#296): semantic (compared in the pipeline diff),
-    // emitted only when set so an unset node and a library twin with no model
-    // both produce objects without the key and stay `synced`, not `diverged`.
-    if (n.model) node.model = n.model;
-    // Per-node effort override (#424): semantic (compared in the pipeline diff),
-    // emitted only when set — the truthiness guard folds `undefined`, `null` AND
-    // `""` into "absent", which is what keeps an unset node byte-identical to a
-    // library twin with no effort (`synced`, not `diverged`) and what holds the
-    // launch-command byte-identity gate. This emitter and `exportNodeAsYaml` are
-    // deliberately NOT unified (see the note further down) — a field added here
-    // must be added there too.
-    if (n.effort) node.effort = n.effort;
+    // #550/ADR-0046: the harness axis replaces flat `model:`/`effort:`. The pin is
+    // emitted when set; the flat model/effort view is folded back into the
+    // resolved harness's entry in the per-harness `harnesses` map, emitted only
+    // when non-empty — so an unset node and a library twin with no settings both
+    // produce objects without the keys and stay `synced`, not `diverged`. This
+    // emitter and `exportNodeAsYaml` are deliberately NOT unified (see the note
+    // further down) — a field added here must be added there too.
+    if (n.pin_harness) node.pin_harness = n.pin_harness;
+    const harnesses = foldNodeIntoHarnesses(n);
+    if (harnesses) node.harnesses = harnesses;
     // Legacy `type: loop` nodes (pre-region model, ADR-0011) carry a node-level
     // `max_iter` that the daemon still requires and validates
     // (`pipeline.rs` `NodeType::Loop`). The current model emits `max_iter` on the

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -248,6 +248,16 @@ export interface InstanceSettings {
   reaper_ttl_secs: SettingField;
   guard_timeout_secs: SettingField;
   default_model: StringSettingField;
+  /** #550/ADR-0046: instance-wide default harness (`stored → env → floor claude`).
+   *  `effective: null` ⇒ the `claude` floor applies at resolve. */
+  default_harness: StringSettingField;
+  /** #550/ADR-0046: instance-wide default model **per harness**. `effective` is
+   *  the resolved map (the stored map plus the legacy `PDO_DEFAULT_MODEL` folded
+   *  under `claude`); `stored` is the raw stored map. */
+  default_harness_model: {
+    effective: Record<string, string>;
+    stored: Record<string, string>;
+  };
   /**
    * Instance-wide default sandbox (#410/#432): `"off"` (host, default) or the name of a
    * **staging profile**. No longer a closed enum — its value space is the user's profile
@@ -366,6 +376,11 @@ export interface UpdateSettingsRequest {
   reaper_ttl_secs?: number;
   guard_timeout_secs?: number;
   default_model?: string;
+  /** #550: instance default harness; `""` clears it (same sentinel as
+   *  `default_model`). */
+  default_harness?: string;
+  /** #550: per-harness default model map; replaces the stored map wholesale. */
+  default_harness_model?: Record<string, string>;
   /** Default sandbox (#410/#432): `"off"` or a staging-profile name, or `""` to clear
    *  back to the built-in default (`off`). Same `""`-sentinel discipline as
    *  `default_model`. The daemon 400s a name that does not resolve.
@@ -816,7 +831,25 @@ export interface NodeDef {
   /** Optional per-node reasoning-effort override (#424): free-text pass-through
    *  to `claude --effort <level>`. Absent/null ⇒ no flag (account default).
    *  Orthogonal to `model`, and semantic — it enters the pipeline diff and the
-   *  node-library content hash. */
+   *  node-library content hash.
+   *
+   *  Since #550 this is the **resolved harness's** effort: folded out of
+   *  `harnesses[resolved].effort` on load, folded back on save. */
+  effort?: string | null;
+  /** #550/ADR-0046: the pinned harness (`claude`, `opencode`), or null/absent to
+   *  follow the tier above (instance default, else the `claude` floor). A pin both
+   *  selects the harness and shields it from every coarser tier. */
+  pin_harness?: string | null;
+  /** #550/ADR-0046: per-harness `{model, effort}` settings. `model`/`effort` above
+   *  are the RESOLVED harness's view (folded from this map on load, back into it on
+   *  save); the map preserves entries for the non-resolved harnesses. */
+  harnesses?: Record<string, HarnessSettings>;
+}
+
+/** #550/ADR-0046: a node's `{model, effort}` for one harness. Free-text
+ *  pass-through — a slug means nothing outside the harness that accepts it. */
+export interface HarnessSettings {
+  model?: string | null;
   effort?: string | null;
 }
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -318,7 +318,33 @@ export interface InstanceSettings {
    * honest place to surface it (the #432 argument).
    */
   price_table: PriceTableView;
+  /**
+   * The harness descriptor disk tier (#553, ADR-0045) — an observed STATE, like
+   * `price_table`. `names` lists the harnesses that actually resolve (embedded
+   * floor merged with the user's disk file), so a declared harness "appears";
+   * `path` is always reported (nothing is seeded) so the user knows where to
+   * write; `reason` is the same string the daemon logs, non-null exactly when a
+   * descriptor went inert or was refused — the only honest place to say so, since
+   * a hand-edited descriptor passes through no validator (ADR-0001).
+   *
+   * Optional in the type (the SettingsModal guards on it) so a UI built against a
+   * daemon that predates #553 still typechecks — same defensive posture the modal
+   * takes for `price_table`. In production the SPA is embedded, so they agree.
+   */
+  harness_descriptors?: HarnessDescriptorsView;
   updated_at: string;
+}
+
+/** `GET /settings` → `harness_descriptors` (#553). */
+export interface HarnessDescriptorsView {
+  /** `~/.pdo/harnesses/descriptors.yaml`. `null` only when `HOME` is unset. */
+  path: string | null;
+  /** The harnesses the registry resolves (floor ∪ disk), in resolution order. */
+  names: string[];
+  /** Descriptors the disk tier refused — each inert, its key on the floor. */
+  rejected: { name: string; why: string }[];
+  /** Advisory: an inert file or refused descriptor, named. `null` when all is well. */
+  reason: string | null;
 }
 
 /** `GET /settings` → `price_table` (#427). */
@@ -723,11 +749,18 @@ export interface RunState {
    * lower bound; `unpriced_models` names which family keys were excluded (#425),
    * so the UI can say *which* model rather than an anonymous "an unpriced model".
    * Invariant: `partial ⟺ unpriced_models.length > 0`.
+   *
+   * `uncosted_harnesses` (#553): the harnesses a node ran on that have **no cost
+   * source** (e.g. `opencode`). Non-empty ⇒ the Run's cost is not honestly
+   * summable, so the UI shows "—" with a reason naming them, never a `$0` and
+   * never a mute lower-bound — a categorically different state from `partial`
+   * (which still shows a figure). Empty on every all-`claude` Run.
    */
   cost?: {
     usd: number;
     partial: boolean;
     unpriced_models: string[];
+    uncosted_harnesses?: string[];
   } | null;
 }
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -459,6 +459,22 @@ export interface RunListEntry {
 }
 
 /**
+ * A **Projet** (#552, ADR-0046): a named grouping of member repo paths, and the
+ * middle tier of the harness precedence axis. Materialised on demand — a Projet
+ * exists only once a human names a group header or attaches a setting; until then
+ * the lists group by the derived path label (#258). Membership is compared
+ * verbatim (ADR-0033).
+ */
+export interface Project {
+  id: string;
+  name: string;
+  /** The harness this Projet carries, or absent/null when it carries none. */
+  harness?: string | null;
+  /** Member repository paths (the effective-repo keys the lists group by). */
+  members: string[];
+}
+
+/**
  * A persisted Trigger (#160 / ADR-0012): a cron schedule bound to a run
  * template. Cron-only in this slice — `guard_command` is reserved for #161.
  */
@@ -796,7 +812,8 @@ export interface WsMessage {
     | "trigger_fired"
     | "trigger_updated"
     | "trigger_deleted"
-    | "triggers_paused";
+    | "triggers_paused"
+    | "project_changed";
   event?: DaemonEvent;
   pipeline_id?: string;
   path?: string;
@@ -807,6 +824,8 @@ export interface WsMessage {
   run_id?: string | null;
   /** Set on `triggers_paused` messages (#348): the new global pause state. */
   paused?: boolean;
+  /** Set on `project_changed` messages (#552): the mutated Projet's id. */
+  project_id?: string;
 }
 
 export type EditScope = null | "run";

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -465,6 +465,10 @@ export interface Trigger {
   /** Per-Trigger sandbox (#410/#432): `"off"` or a staging-profile name, or null/absent
    *  to inherit the instance default. Read at fire time. */
   sandbox?: string | null;
+  /** Per-Trigger harness (#551, ADR-0046): a harness name, or null/absent to inherit the
+   *  instance default. Read at fire time and folded into the fired Run's harness (no
+   *  separate Trigger tier — a cron tick and a "Run now" produce the same one). */
+  harness?: string | null;
   /** Whether Runs this Trigger fires are auto-named (#338). Frozen at creation from the
    *  instance default; `true` is the pre-#338 behaviour. A flat bool (no inherit state). */
   auto_name: boolean;
@@ -704,6 +708,14 @@ export interface RunState {
    * throughout, so this drives a banner only.
    */
   sandbox_prep?: "pending" | "ready";
+  /**
+   * The agentic harness this Run was created on (#551, ADR-0046) — the `run` tier of
+   * the precedence chain, **frozen** at creation like {@link RunState.sandbox}. Absent
+   * when the Run named no harness (every historical Run, and any Run that inherited the
+   * instance default): each free node then resolved through the instance default and
+   * the `claude` floor. Shown in the Run panel; a pinned node ignored it.
+   */
+  harness?: string;
   /**
    * Cumulative count of NodeRun sessions this run spawned — raw `NodeStarted`
    * count, not distinct `(node, iter)`; manager excluded (#100). Defaults to 0

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -40,6 +40,11 @@ export default defineConfig({
       // as `/nodes`/`/stats`/`/fs`: without it a dev GET /audit answers 200 with
       // the SPA.
       '/audit': daemonTarget,
+      // #552: Projets (harness middle tier + group-header pencil). New top-level
+      // `/projects` prefix — same trap as `/audit`: without it a dev
+      // GET/POST /projects answers 200 with the SPA and the pencil would silently
+      // no-op.
+      '/projects': daemonTarget,
     },
   },
   test: {

--- a/scripts/layout-ratchet.sh
+++ b/scripts/layout-ratchet.sh
@@ -9,7 +9,7 @@ cd "$(git rev-parse --show-toplevel)"
 # <directory>  <max direct tracked files>
 BASELINES='
 frontend/src/components 141
-crates/pdo-daemon/src 57
+crates/pdo-daemon/src 60
 '
 
 fail=0

--- a/scripts/layout-ratchet.sh
+++ b/scripts/layout-ratchet.sh
@@ -8,8 +8,8 @@ cd "$(git rev-parse --show-toplevel)"
 
 # <directory>  <max direct tracked files>
 BASELINES='
-frontend/src/components 141
-crates/pdo-daemon/src 61
+frontend/src/components 143
+crates/pdo-daemon/src 62
 '
 
 fail=0

--- a/scripts/layout-ratchet.sh
+++ b/scripts/layout-ratchet.sh
@@ -9,7 +9,7 @@ cd "$(git rev-parse --show-toplevel)"
 # <directory>  <max direct tracked files>
 BASELINES='
 frontend/src/components 141
-crates/pdo-daemon/src 60
+crates/pdo-daemon/src 61
 '
 
 fail=0


### PR DESCRIPTION
Branche d'intégration du **PRD #549 — multi-harnais agentique**. Les quatre tranches sont livrées.

Le **harnais agentique** est le programme qui fait tourner l'agent d'un NodeRun (`claude`, `opencode`).
Il devient un **axe à quatre tiers** — `nœud → Run → Projet → instance → plancher claude` — résolu
**une fois au spawn** et **gelé** dans l'événement de démarrage : la reprise re-pose ce qui a été lancé,
jamais ce que le YAML dit maintenant (ADR-0007).

## Issues incluses

| Issue | Tranche | État |
|---|---|---|
| #550 | Le nœud épingle son harnais — descripteur, template d'argv, résolution au spawn, reprise | closed |
| #551 | Le Run choisit son harnais — tier de précédence, New Run, Trigger, sessions d'infra | closed |
| #552 | Le Projet est une entité nommée de dépôts, et le tier du milieu | **ouverte** (voir plus bas) |
| #553 | Les capacités sont du code par harnais, et leur absence est dite + tier disque des descripteurs | closed |

ADR : **0045** (un harnais se déclare par un template d'argv), **0046** (l'axe à quatre tiers), plus des
amendements à 0015 (config d'instance) et 0031 (sandbox). `CONTEXT.md` gagne §*Harnais agentique* et
§*Projet*.

## Version : 1.27.0, et pourquoi pas 1.26.0

`main` avait bumpé **1.26.0** pour le cassant #508 pendant que cette branche bumpait le **même** 1.26.0
pour l'axe harnais. Collision de numéro. La fusion de `main` (`4d39a94`) tranche : l'axe harnais prend
**1.27.0** et 1.26.0 **reste** à #508, telle que `main` l'a écrite — sinon son CHANGELOG devient faux.

Cette fusion méritait une relecture manuelle : le seul conflit textuel était le CHANGELOG, mais
`node_spawn.rs` s'est **auto-fusionné** alors que `main` y réécrit le bras `Err` de
`tmux_session_manager::spawn` (#508) et que cette branche y écrit le littéral `HarnessTiers` juste à
côté. Une résolution qui aurait perdu un tier **compilerait et passerait les tests** en désactivant
silencieusement un cran de précédence. Vérifié à la main : les quatre tiers sont remplis et le nouveau
`fail_spawn_after_start` est bien appelé.

## Validation agentique

**L'A/B de harnais a été joué en conditions réelles** (pile isolée, socket tmux dédié, `HOME` factice
avec les credentials des deux harnais, dépôt cible jetable), et greffé en **drive-by sur HP-02** plutôt
que de consommer le slot HP-03 libre — la paire `claude` + `opencode` est le contrôle, exactement comme
la paire sandbox : un Run mono-harnais qui a silencieusement résolu le plancher est indiscernable d'un
Run correctement résolu.

Un seul Run, deux nœuds épinglés, **tier Run posé sur `claude`** pour que l'épinglage `opencode` du
second nœud soit une vraie preuve de précédence et non un défaut suivi. Résultats :

- les deux nœuds atteignent `completed` (14 s et 19 s), **artefacts relus** — un statut ne prouve rien
  seul (#490) ;
- readout `Resolved: opencode (pinned)` vs `claude (floor — no pin)` ;
- picker d'effort **grisé 6/6** sur opencode, **0/6** sur claude : l'absence de trou `{effort}` du
  descripteur qui remonte jusqu'à l'écran ;
- **Est. cost = « — »** avec la raison nommant `opencode`, jamais `$0` ni le seul montant de l'autre
  nœud ;
- argv réels conformes aux descripteurs, y compris les deux **absences** côté opencode (`--session-id`,
  `--settings`) ;
- harnais **gelé** dans les événements de démarrage, en accord avec ce que tourne chaque pane ;
- modèle écrit sous la clé du harnais résolu (`harnesses: { opencode: { model } }`), pas en `model:` à
  plat.

Le scénario **aurait échoué tel qu'il était écrit** : un nœud `opencode` sans modèle est un cul-de-sac
muet (PDO ne passe aucun `--model`, opencode résout son propre défaut — ici un modèle d'image, tour mort
sur `No endpoints found that support tool use`, nœud ni complété ni mort). Corrigé dans HP-02, et fiché
(#561).

**Ce qui n'a pas été joué, dit franchement :** la suite HP complète (HP-01, et le reste de HP-02 dont
l'A/B sandbox à ~1 Go de staging) n'a pas été rejouée pour cette branche. Seule la greffe harnais l'a
été.

## #552 reste ouverte

Son code est mergé et couvert par les tests, mais son **Feature Path agentique n'a jamais été joué** :
le nœud de validation est mort deux fois (OOM machine, puis quota). Trois vérifications d'écran restent
donc à faire, et l'issue les porte :

- avec aucun Projet nommé, les listes se groupent sur les mêmes **chemins** qu'avant (« rien n'est
  seedé » — vérifié côté API : `GET /projects` rend `[]`). Attention : l'**ordre**, lui, a changé — voir
  ci-dessous ;
- le crayon sur un en-tête de groupe crée puis renomme le Projet, et le seuil « ≥ 2 » porte alors sur
  les projets ;
- un chemin déjà membre d'un Projet **refuse** d'être ajouté à un second, en **nommant** le propriétaire.

## Un changement de comportement trouvé par la CI, et assumé

L'e2e `runs-triggers-by-repo` a été rouge sur cette PR, **déterministe et non aléatoire** : #552 trie
les en-têtes de groupe sur le **libellé affiché**, là où #258 triait sur le **chemin complet**. En local
`…/Maestro` tombe du même côté dans les deux tris, donc rien ne se voyait ; en CI
`pdo258-alpha` passe avant `prompt-driven-orchestrator` par libellé mais après par chemin. Le
commentaire du spec documentait exactement ce piège — pour l'ancien contrat.

Le tri par libellé est **gardé** : c'est ce qui permet à un Projet, dont le nom n'a aucun chemin, de
prendre sa place dans le même ordre que les groupes-chemins. Conséquence assumée et **signalée dans le
CHANGELOG**, dont la phrase « les listes se groupent exactement comme avant » était vraie du *seuil* et
fausse de l'*ordre* : à contenu identique, une liste peut désormais apparaître dans un ordre différent
sans qu'aucun Projet ait été créé.

C'est exactement la vérification que le Feature Path non joué de #552 aurait dû attraper. Elle a été
attrapée par la couche 3b à la place.

## Portes

Ratchet 143/143 et 62/62 · `fmt --all --check` · `clippy --workspace --all-targets -D warnings` ·
`cargo test --workspace --no-fail-fast` · frontend `typecheck` + `lint` + `build` + vitest.

Note : `main` était **rouge depuis trois merges** au moment d'ouvrir cette PR (deux causes de test
indépendantes qu'un log fail-fast masquait). Réparé séparément par #562, mergé avant celle-ci — sinon la
CI de cette branche aurait été rouge pour des raisons qui ne lui appartiennent pas.

## Hors périmètre, assumé

La sandbox (le plancher de staging reste propre à `claude`), les capacités d'`opencode` au-delà du
lancement (#561), le catalogue de modèles par harnais (#560), et faire du descripteur un mini-langage
(refusé par ADR-0045).
