### PR TITLE
fix(#508)!: un spawn tmux échoué fait échouer le nœud et le Run, plus jamais Spawned — 1.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ ascendante** : la casse se signale ici et par un bump majeur, jamais en gardant 
 morts. Seule contrainte non négociable — les **données historiques restent lisibles** : un Run
 archivé s'ouvre et se chiffre quelle que soit la version qui a écrit son payload.
 
+## 1.26.0
+
+### Cassant — un spawn tmux échoué fait échouer le nœud et le Run, plus jamais `Spawned` (#508, ADR-0037)
+
+`spawn_node` avalait l'`Err` de `tmux_session_manager::spawn` et rendait `Spawned` alors que
+`NodeStarted` était déjà durable : le nœud se projetait `Running` **sans session**, puis la veille de
+vivacité le réécrivait `Failed` ~30 s plus tard avec une **cause fausse** (`session_died`), et
+`restart_node` répondait un `200 {"spawned":[…]}` menteur. Désormais le bras `Err` appende `NodeFailed`
+(légal : l'itération est `Running`) **puis** un reap gaté (le seul sous-worktree que *ce* spawn a créé,
+jamais un réutilisé) **puis** `RunFailed`, et rend `SpawnOutcome::Failed`. Effets filaires (véracité,
+ADR-0037 §1/§3) : `restart_node` répond **`500 {"error":"spawn_failed","recoverable":false,"run_failed":true}`**
+au lieu de `200 {"spawned":[…]}` ; les routes `resume`/`pause` comptent le nœud en **`noop`** (avec sa
+raison) au lieu de le déclarer `spawned`. Ferme la « Limite acceptée » homonyme d'ADR-0037.
+
 ## 1.25.0
 
 Rien de cassant, aucune migration (`CREATE TABLE IF NOT EXISTS`, aucun backfill). PDO gagne un

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "1.25.1"
+version = "1.26.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "1.25.1"
+version = "1.26.0"
 license = "MIT"
 
 [workspace.dependencies]

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -26598,6 +26598,319 @@ edges: []
         );
     }
 
+    /// #508 hermetic seam: make `tmux_session_manager::spawn` fail at its very
+    /// first statement (`create_dir_all(working_dir/.pdo/prompts)`) by planting a
+    /// *file* named `.pdo/prompts` where a directory is expected. `create_dir_all`
+    /// returns `AlreadyExists` (os error 17) BEFORE tmux is ever invoked, for
+    /// every node type — no real tmux, no debug poison. `commit` decides whether
+    /// the file is only on disk (a doc-only node runs straight in `worktree_dir`)
+    /// or committed onto HEAD (a code-mutating node's sub-worktree is a fresh
+    /// checkout of the pipeline branch that must carry the collision file).
+    fn plant_pdo_prompts_file(dir: &std::path::Path, commit: bool) {
+        let pdo = dir.join(".pdo");
+        std::fs::create_dir_all(&pdo).unwrap();
+        std::fs::write(pdo.join("prompts"), "collision\n").unwrap();
+        if commit {
+            let run = |args: &[&str]| {
+                std::process::Command::new("git")
+                    .args(args)
+                    .current_dir(dir)
+                    .output()
+                    .unwrap()
+            };
+            run(&["add", "-f", ".pdo/prompts"]);
+            run(&[
+                "commit",
+                "-m",
+                "seed .pdo/prompts collision file (#508 test)",
+            ]);
+        }
+    }
+
+    /// The `reason` prose carried by the first event of `kind` for `run_id`.
+    async fn event_reason(
+        state: &Arc<AppState>,
+        run_id: &str,
+        kind: event_log::EventKind,
+    ) -> String {
+        let events = load_events(&state.db, run_id).await.unwrap();
+        events
+            .iter()
+            .find(|e| e.kind == kind)
+            .and_then(|e| e.payload.as_ref())
+            .and_then(|p| p.get("reason"))
+            .and_then(|r| r.as_str())
+            .unwrap_or_default()
+            .to_string()
+    }
+
+    /// #508 (core, no sub-worktree): when the tmux spawn itself fails *after*
+    /// `NodeStarted` is durable, `spawn_node` no longer swallows the `Err` and
+    /// returns a lying `Spawned`. It appends `NodeFailed` (legal — the iteration
+    /// is `Running`) THEN `RunFailed`, moving both node and run terminal with the
+    /// TRUE cause (a tmux spawn failure), never the false `session_died` the
+    /// liveness sweep would have written ~30s later. A doc-only node owns no
+    /// sub-worktree, so nothing is reaped.
+    #[tokio::test]
+    async fn spawn_node_tmux_err_fails_run_loud_no_worktree() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path();
+        init_test_repo(repo);
+        let state = test_state_with_dir(repo).await;
+
+        let run_id = "spawn-unit-tmuxerr-noworktree";
+        seed_run_for_node_control(&state, run_id, "spawn-unit").await;
+
+        // Plant the collision file directly in the doc-only node's working dir
+        // (= `worktree_dir`); no commit needed since it runs there in place.
+        plant_pdo_prompts_file(repo, false);
+
+        let (pipeline, node, pipeline_path) =
+            spawn_test_fixture(repo, "worker", pipeline::NodeType::DocOnly);
+        let artifacts_dir = repo.join(".pdo").join("artifacts");
+        let resolved_vars = HashMap::new();
+        let ctx = SpawnContext {
+            pipeline: &pipeline,
+            run_id,
+            pipeline_path: &pipeline_path,
+            worktree_dir: repo,
+            artifacts_dir: &artifacts_dir,
+            resolved_vars: &resolved_vars,
+            repo_root: repo,
+        };
+
+        let outcome = spawn_node(SpawnDeps::from_state(&state), &ctx, &node, 1).await;
+        assert!(
+            matches!(outcome, SpawnOutcome::Failed { .. }),
+            "a failed tmux spawn must return Failed, not a lying Spawned, got {outcome:?}"
+        );
+
+        let events = load_events(&state.db, run_id).await.unwrap();
+        // The reservation was durably recorded (this is the *after-start* path)...
+        assert!(
+            events
+                .iter()
+                .any(|e| e.kind == event_log::EventKind::NodeStarted
+                    && e.node_id.as_deref() == Some("worker")),
+            "the after-start path keeps its NodeStarted (the reservation was durable)"
+        );
+        // ...and BOTH terminal events follow it.
+        assert!(
+            events
+                .iter()
+                .any(|e| e.kind == event_log::EventKind::NodeFailed
+                    && e.node_id.as_deref() == Some("worker")),
+            "a failed tmux spawn on a Running iteration must append NodeFailed"
+        );
+        assert!(
+            events
+                .iter()
+                .any(|e| e.kind == event_log::EventKind::RunFailed),
+            "a failed tmux spawn must move the run terminal with RunFailed"
+        );
+
+        let (_, run_state) = reload_run_state(&state, run_id).await.unwrap();
+        assert_eq!(
+            run_state.status,
+            event_log::RunStatus::Failed,
+            "RunFailed must project a terminal Failed run state"
+        );
+
+        for kind in [
+            event_log::EventKind::NodeFailed,
+            event_log::EventKind::RunFailed,
+        ] {
+            let reason = event_reason(&state, run_id, kind.clone()).await;
+            assert!(
+                reason.contains("failed to spawn tmux session"),
+                "{kind:?} cause must name the tmux spawn failure, got {reason:?}"
+            );
+            assert!(
+                !reason.contains("session_died"),
+                "{kind:?} cause must NOT be the false session_died, got {reason:?}"
+            );
+        }
+    }
+
+    /// #508 (fresh sub-worktree → reap): a code-mutating node whose fresh
+    /// sub-worktree this spawn created reaps that orphan (dir + branch) on a tmux
+    /// spawn failure, exactly as the pre-start abort does — the run goes terminal
+    /// with no leaked worktree.
+    #[tokio::test]
+    async fn spawn_node_tmux_err_reaps_fresh_sub_worktree() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path();
+        init_test_repo(repo);
+        // Commit the collision file so the sub-worktree checkout carries it.
+        plant_pdo_prompts_file(repo, true);
+        let state = test_state_with_dir(repo).await;
+
+        let run_id = "spawn-unit-tmuxerr-reap";
+        seed_run_for_node_control(&state, run_id, "spawn-unit").await;
+
+        let wt_dir = repo.join(".pdo/runs").join(run_id).join("worktree");
+        let pipeline_branch = format!("pdo/run-{run_id}");
+        create_worktree(repo, &wt_dir, &pipeline_branch, "HEAD").unwrap();
+
+        let (pipeline, node, pipeline_path) =
+            spawn_test_fixture(repo, "worker", pipeline::NodeType::CodeMutating);
+        let artifacts_dir = wt_dir.join(".pdo").join("artifacts");
+        let resolved_vars = HashMap::new();
+        let ctx = SpawnContext {
+            pipeline: &pipeline,
+            run_id,
+            pipeline_path: &pipeline_path,
+            worktree_dir: &wt_dir,
+            artifacts_dir: &artifacts_dir,
+            resolved_vars: &resolved_vars,
+            repo_root: repo,
+        };
+
+        let outcome = spawn_node(SpawnDeps::from_state(&state), &ctx, &node, 1).await;
+        assert!(
+            matches!(outcome, SpawnOutcome::Failed { .. }),
+            "a failed tmux spawn must return Failed, got {outcome:?}"
+        );
+
+        // The orphaned sub-worktree dir + branch this spawn created are reaped.
+        let sub_wt = sub_worktree_path(repo, run_id, "worker", 1);
+        assert!(
+            !sub_wt.exists(),
+            "the fresh sub-worktree {} this spawn created must be reaped",
+            sub_wt.display()
+        );
+        let sub_branch = sub_worktree_branch(run_id, "worker", 1);
+        let branch_list = std::process::Command::new("git")
+            .args(["branch", "--list", &sub_branch])
+            .current_dir(repo)
+            .output()
+            .unwrap();
+        assert!(
+            String::from_utf8_lossy(&branch_list.stdout)
+                .trim()
+                .is_empty(),
+            "the fresh sub-worktree branch {sub_branch} must be deleted after the reap"
+        );
+
+        let events = load_events(&state.db, run_id).await.unwrap();
+        assert!(
+            events
+                .iter()
+                .any(|e| e.kind == event_log::EventKind::NodeStarted
+                    && e.node_id.as_deref() == Some("worker")),
+            "the after-start path keeps its NodeStarted"
+        );
+        assert!(
+            events
+                .iter()
+                .any(|e| e.kind == event_log::EventKind::NodeFailed
+                    && e.node_id.as_deref() == Some("worker")),
+            "a failed tmux spawn on a Running iteration must append NodeFailed"
+        );
+        assert!(
+            events
+                .iter()
+                .any(|e| e.kind == event_log::EventKind::RunFailed),
+            "a failed tmux spawn must move the run terminal with RunFailed"
+        );
+        let (_, run_state) = reload_run_state(&state, run_id).await.unwrap();
+        assert_eq!(run_state.status, event_log::RunStatus::Failed);
+        let reason = event_reason(&state, run_id, event_log::EventKind::RunFailed).await;
+        assert!(
+            reason.contains("failed to spawn tmux session") && !reason.contains("session_died"),
+            "RunFailed cause must be the true tmux spawn failure, got {reason:?}"
+        );
+    }
+
+    /// #508 (reused sub-worktree → NO reap): the critical leg. When the
+    /// sub-worktree already existed (classified `Reusable`, `created=false`), a
+    /// tmux spawn failure must destroy NOTHING — the reused work is preserved.
+    /// `orphan_to_reap` is `None`, so the after-start failure appends
+    /// `NodeFailed` + `RunFailed` but leaves the sub-worktree and its branch
+    /// intact (ADR-0037 §6). Inverse of the fresh-worktree case.
+    #[tokio::test]
+    async fn spawn_node_tmux_err_preserves_reused_sub_worktree() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path();
+        init_test_repo(repo);
+        plant_pdo_prompts_file(repo, true);
+        let state = test_state_with_dir(repo).await;
+
+        let run_id = "spawn-unit-tmuxerr-reuse";
+        seed_run_for_node_control(&state, run_id, "spawn-unit").await;
+
+        let wt_dir = repo.join(".pdo/runs").join(run_id).join("worktree");
+        let pipeline_branch = format!("pdo/run-{run_id}");
+        create_worktree(repo, &wt_dir, &pipeline_branch, "HEAD").unwrap();
+
+        // Pre-create the sub-worktree so `ensure_sub_worktree` classifies it
+        // `Reusable` → `created=false` → `orphan_to_reap = None`.
+        let sub_wt = sub_worktree_path(repo, run_id, "worker", 1);
+        let sub_branch = sub_worktree_branch(run_id, "worker", 1);
+        create_sub_worktree(repo, &sub_wt, &sub_branch, &pipeline_branch).unwrap();
+        assert!(
+            sub_wt.exists(),
+            "precondition: the reused sub-worktree exists"
+        );
+
+        let (pipeline, node, pipeline_path) =
+            spawn_test_fixture(repo, "worker", pipeline::NodeType::CodeMutating);
+        let artifacts_dir = wt_dir.join(".pdo").join("artifacts");
+        let resolved_vars = HashMap::new();
+        let ctx = SpawnContext {
+            pipeline: &pipeline,
+            run_id,
+            pipeline_path: &pipeline_path,
+            worktree_dir: &wt_dir,
+            artifacts_dir: &artifacts_dir,
+            resolved_vars: &resolved_vars,
+            repo_root: repo,
+        };
+
+        let outcome = spawn_node(SpawnDeps::from_state(&state), &ctx, &node, 1).await;
+        assert!(
+            matches!(outcome, SpawnOutcome::Failed { .. }),
+            "a failed tmux spawn must return Failed, got {outcome:?}"
+        );
+
+        // The run is still failed loud...
+        let events = load_events(&state.db, run_id).await.unwrap();
+        assert!(
+            events
+                .iter()
+                .any(|e| e.kind == event_log::EventKind::NodeFailed
+                    && e.node_id.as_deref() == Some("worker")),
+            "a failed tmux spawn on a Running iteration must append NodeFailed"
+        );
+        assert!(
+            events
+                .iter()
+                .any(|e| e.kind == event_log::EventKind::RunFailed),
+            "a failed tmux spawn must move the run terminal with RunFailed"
+        );
+        let (_, run_state) = reload_run_state(&state, run_id).await.unwrap();
+        assert_eq!(run_state.status, event_log::RunStatus::Failed);
+
+        // ...but the REUSED sub-worktree and its branch are UNTOUCHED (the whole
+        // point of the gate: a reuse loses nothing).
+        assert!(
+            sub_wt.exists(),
+            "the reused sub-worktree {} must NOT be reaped — a reuse loses nothing",
+            sub_wt.display()
+        );
+        let branch_list = std::process::Command::new("git")
+            .args(["branch", "--list", &sub_branch])
+            .current_dir(repo)
+            .output()
+            .unwrap();
+        assert!(
+            !String::from_utf8_lossy(&branch_list.stdout)
+                .trim()
+                .is_empty(),
+            "the reused sub-worktree branch {sub_branch} must still be listed"
+        );
+    }
+
     /// INV-1 (#212): the transition guard refuses an illegal NodeStarted BEFORE
     /// any side effect. Spawning iter-2 of a node whose iter-1 is still live is
     /// rejected — `Refused`, and no NodeStarted for iter-2 is appended.

--- a/crates/pdo-daemon/src/node_spawn.rs
+++ b/crates/pdo-daemon/src/node_spawn.rs
@@ -704,7 +704,30 @@ pub(crate) async fn spawn_node(
         sandbox_wrap.as_ref(),
         inject_hook,
     ) {
-        error!("failed to spawn tmux session: {e}");
+        // #508: the tmux spawn itself failed *after* `NodeStarted` is durable. It
+        // used to be swallowed (`error!` + fall through), leaving the node
+        // projected `Running` with NO session — the liveness sweep then rewrote it
+        // `Failed` ~30s later with a false `session_died` cause, and `restart_node`
+        // answered a lying `200 {spawned}`. Fail loud right here instead: append
+        // `NodeFailed` (legal now that the iteration is `Running`) → reap only what
+        // this spawn created → `RunFailed`, then return `Failed`. This lands BEFORE
+        // the `NodeAwaitingUser` block below, so a session that never launched can
+        // never collect a phantom `NodeAwaitingUser`. (ADR-0037 §1/§3.)
+        let reason = format!(
+            "failed to spawn tmux session {session_name} for node {}: {e}",
+            node.id
+        );
+        fail_spawn_after_start(
+            deps,
+            spawn_ctx.repo_root,
+            run_id,
+            &node.id,
+            iter,
+            orphan_to_reap.as_ref(),
+            &reason,
+        )
+        .await;
+        return SpawnOutcome::Failed { reason };
     }
 
     if node.interactive {
@@ -761,5 +784,64 @@ async fn fail_spawn_before_start(
     };
     if let Err(e) = append_event_with(deps.db, deps.event_tx, &run_failed).await {
         error!("Run {run_id}: failed to append RunFailed after spawn abort: {e}");
+    }
+}
+
+/// Fail a run loud when a node spawn aborts *after* `NodeStarted` is appended
+/// (#508). Unlike [`fail_spawn_before_start`], the iteration is already
+/// `Running`, so a `NodeFailed` is a legal transition
+/// (`transition_guard::validate_fail` → `Allow`) and IS appended: it moves the
+/// *node* terminal, closing the window where the liveness sweep would rewrite it
+/// `Failed` with a false `session_died` cause and where `GET …/pane` /
+/// boot_recovery could re-drive a `Running` node that has no session.
+/// `RunFailed` then moves the *run* terminal (the sole event that sets
+/// `state.status = Failed`). The reap is gated on `orphan` (Some iff THIS spawn
+/// created the sub-worktree — a reuse must destroy nothing; ADR-0037 §6). The
+/// order (node-terminal → reap → run-terminal) mirrors the #488 "terminal event
+/// first, reap second" convention; it is not required by the guard
+/// (`validate_fail` ignores run status).
+async fn fail_spawn_after_start(
+    deps: SpawnDeps<'_>,
+    repo_root: &std::path::Path,
+    run_id: &str,
+    node_id: &str,
+    iter: i64,
+    orphan: Option<&(PathBuf, String)>,
+    reason: &str,
+) {
+    error!("Run {run_id}: node {node_id} spawn failed after NodeStarted — {reason}");
+
+    // 1) Node terminal (legal: the iteration is `Running` after `NodeStarted`).
+    let node_failed = event_log::Event {
+        id: None,
+        run_id: run_id.to_string(),
+        ts: event_log::now_iso(),
+        kind: event_log::EventKind::NodeFailed,
+        node_id: Some(node_id.to_string()),
+        iter: Some(iter),
+        payload: Some(serde_json::json!({ "reason": reason, "source": "spawn" })),
+    };
+    if let Err(e) = append_event_with(deps.db, deps.event_tx, &node_failed).await {
+        error!("Run {run_id}: failed to append NodeFailed after spawn failure: {e}");
+    }
+
+    // 2) Reap ONLY what this spawn created (gated; ADR-0037 §6 — a reuse loses
+    //    nothing).
+    if let Some((sub_worktree_dir, sub_branch)) = orphan {
+        reap_orphan_sub_worktree(repo_root, sub_worktree_dir, sub_branch);
+    }
+
+    // 3) Run terminal (the sole event that sets `state.status = Failed`).
+    let run_failed = event_log::Event {
+        id: None,
+        run_id: run_id.to_string(),
+        ts: event_log::now_iso(),
+        kind: event_log::EventKind::RunFailed,
+        node_id: None,
+        iter: None,
+        payload: Some(serde_json::json!({ "reason": reason })),
+    };
+    if let Err(e) = append_event_with(deps.db, deps.event_tx, &run_failed).await {
+        error!("Run {run_id}: failed to append RunFailed after spawn failure: {e}");
     }
 }

--- a/crates/pdo-daemon/src/run_command.rs
+++ b/crates/pdo-daemon/src/run_command.rs
@@ -1154,11 +1154,11 @@ async fn dispatch(state: Arc<AppState>, run_id: String, cmd: RunCommand) -> Resp
                     },
                 ),
                 // A panne, not a verdict → `500`. `run_failed` is re-PROJECTED, never
-                // guessed: the four producers of `Failed` disagree (three append
-                // `RunFailed`, the sub-worktree branch appended nothing at all), and a
-                // `500` routes the CLI toward `pdo fail` — catastrophic advice if
-                // `RunFailed` is already on the log. Homogenising the producers is
-                // #498-B.
+                // guessed: the five producers of `Failed` disagree (three append
+                // `RunFailed`, #508's tmux-spawn arm appends `NodeFailed` + `RunFailed`,
+                // the sub-worktree branch appended nothing at all), and a `500` routes
+                // the CLI toward `pdo fail` — catastrophic advice if `RunFailed` is
+                // already on the log. Homogenising the producers is #498-B.
                 SpawnOutcome::Failed { reason } => {
                     let run_failed = reload_run_state(&state, &run_id)
                         .await

--- a/docs/adr/0037-a-spawn-that-did-not-happen-is-never-a-2xx.md
+++ b/docs/adr/0037-a-spawn-that-did-not-happen-is-never-a-2xx.md
@@ -220,9 +220,13 @@ libérer le slot qu'un restart throttlé attend, et le retry des nœuds en atten
   corps et l'erreur, et le seul bouton câblé vit dans une bannière que plus rien ne produit depuis
   #469. Trou connu, propriété de **#492**, énoncé pour qu'un prochain grilling ne le fiche pas en
   régression. Zéro travail frontend dans ce lot.
-- **`Spawned` est rendu même quand le spawn tmux lui-même a échoué** — l'erreur est loguée et le
-  flux continue. Le `200 {spawned}` de cette ADR est donc lui-même non véridique dans ce cas. Bug
-  distinct, à ficher, cité ici pour ne pas créditer la décision d'un cas qu'elle ne couvre pas.
+- ~~**`Spawned` est rendu même quand le spawn tmux lui-même a échoué** — l'erreur est loguée et le
+  flux continue. Le `200 {spawned}` de cette ADR est donc lui-même non véridique dans ce cas.~~
+  **Fermé par #508** : le bras `Err` de `tmux_session_manager::spawn` appende désormais `NodeFailed`
+  **puis** un reap gaté (seul le sous-worktree que *ce* spawn a créé) **puis** `RunFailed`
+  (`return SpawnOutcome::Failed`), via le helper `fail_spawn_after_start`. Un spawn qui n'a pas eu
+  lieu retombe donc sous l'invariant §1 (jamais `2xx` — `restart_node` répond `500 spawn_failed`) et
+  sous l'ordre §3 (la cause connaissable se pose avant l'effet), au lieu d'y échapper.
 - **`restart_node` n'invalide jamais les artefacts** : les sorties partielles de la tentative
   avortée survivent au même `iter`, et une complétion ultérieure peut valider l'**ancien** output.
   Vrai avant comme après.
@@ -255,4 +259,8 @@ libérer le slot qu'un restart throttlé attend, et le retry des nœuds en atten
 - **#498** — sa slice A doit consommer la classification posée ici via le bras `Recyclable`, pas la
   réimplémenter. Son levier 3 (un spawn échoué du scheduler doit appender un événement) reste chez
   elle : le chemin du scheduler n'a aucune réponse HTTP, l'événement y est le seul canal.
+- **#508** — ferme la limite acceptée du `Spawned` sur échec tmux : le chemin de spawn appende
+  `NodeFailed` + `RunFailed` (reap gaté du seul sous-worktree que ce spawn a créé) sur `Err`, si bien
+  que la panne tmux honore §1 (jamais `2xx`) et §3 (cause avant effet). Effet filaire annexe : les
+  routes `resume`/`pause` comptent le nœud en `noop` (avec sa raison) au lieu de le déclarer `spawned`.
 - **#491** vient après (corps texte brut vs JSON). **#492** possède le trou côté UI.


### PR DESCRIPTION
## Contexte

Ferme #508. `spawn_node` avalait l'`Err` de `tmux_session_manager::spawn` et rendait `SpawnOutcome::Spawned` alors que `NodeStarted` était déjà durable : le nœud se projetait `Running` **sans session**, puis la veille de vivacité le réécrivait `Failed` ~30 s plus tard avec une **cause fausse** (`session_died`), et `restart_node` répondait un `200 {"spawned":[…]}` menteur.

## Correctif

Le bras `Err` appelle désormais le helper `fail_spawn_after_start` (sibling de `fail_spawn_before_start`) : `NodeFailed` (légal, l'itération est `Running`) → **reap gaté** (seul le sous-worktree que *ce* spawn a créé ; une réutilisation ne détruit rien, ADR-0037 §6) → `RunFailed`, puis `return SpawnOutcome::Failed`. Le `return` atterrit **avant** le bloc `NodeAwaitingUser` (pas de fantôme).

Effets filaires (ADR-0037 §1/§3) : `restart_node` répond `500 {"error":"spawn_failed","recoverable":false,"run_failed":true}` ; `resume`/`pause` comptent le nœud en `noop`.

## Validation

- **Tests** : 3 tests hermétiques couche 3 (cœur no-worktree, reap d'un sous-worktree frais, préservation d'un sous-worktree réutilisé) verts ; `1882 passed`.
- **Portes CI** : `cargo check --workspace --all-targets`, `clippy -D warnings`, `fmt --check`, smoke L4 — verts.
- **Agentique (FP-508, app réelle)** : collision de nom tmux forcée → `node_started(target)` puis `node_failed(target)` avec la **cause vraie** (`duplicate session`), puis `run_failed` ; **`session_died` = 0** sur tout le Run ; persistance vérifiée au-delà d'un tick de veille (pas de résurrection `Running`). Verdict **Pass**.

## Versionnement

`fix!` cassant sur une 1.x sans bump majeur → **1.26.0** (1.25.0 consommée par #507, 1.25.1 par #394). CHANGELOG + `Cargo.toml`/`Cargo.lock` à 1.26.0. Rebasé proprement sur `main` (1.25.1).

Closes #508

🤖 Generated with [Claude Code](https://claude.com/claude-code)