### PR TITLE
feat(#550)!: harnais agentique — descripteur, résolution+gel au spawn, reprise, migration (slice 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,29 @@ ascendante** : la casse se signale ici et par un bump majeur, jamais en gardant 
 morts. Seule contrainte non négociable — les **données historiques restent lisibles** : un Run
 archivé s'ouvre et se chiffre quelle que soit la version qui a écrit son payload.
 
+## 1.26.0
+
+**Cassant, migration automatique.** Première tranche du **harnais agentique** (#550, PRD #549) :
+le programme qui fait tourner l'agent d'un nœud (`claude`, `opencode`) devient un axe à quatre
+tiers (`node → Run → Projet → instance → plancher claude`), résolu **une fois au spawn** et **gelé**
+dans l'événement de démarrage — la reprise re-pose ce qui a été lancé, jamais ce que le YAML dit
+maintenant (ADR-0007). Cette tranche livre `node → instance → plancher` ; les tiers Run et Projet
+suivent (#551, #552).
+
+Le tail n'est plus composé de flags en dur : un **descripteur** (ADR-0045) porte deux templates
+d'argv (lancement, reprise) et un bloc d'env, et un module **pur** (`harness_argv`) rend la chaîne
+avec une seule règle — *un token dont un trou est vide disparaît en entier*. Le tail `claude` reste
+**identique au byte** quand rien de neuf n'est posé (goldens). `claude` et `opencode` sont dans le
+**plancher embarqué** ; rien n'est écrit sur disque.
+
+**Migration du schéma de nœud** : les champs plats `model:` / `effort:` deviennent une carte par
+harnais `harnesses.<nom>.{model, effort}` (le modèle et l'effort se lisent dans l'entrée du harnais
+gagnant, pas d'axe propre — ADR-0046). Le migrateur de pipelines les replie sous `harnesses.claude`
+au démarrage ; un `pin_harness:` scalaire épingle le harnais d'un nœud. La carte est **sémantique**
+(diff + `content_hash`). Un défaut de harnais **et** un défaut de modèle **par harnais** rejoignent
+la Configuration d'instance (`stored → env → default`, ADR-0015 amendée). Un binaire de harnais
+introuvable au spawn échoue **fort** (jamais un 2xx, ADR-0037) en nommant le harnais.
+
 ## 1.25.0
 
 Rien de cassant, aucune migration (`CREATE TABLE IF NOT EXISTS`, aucun backfill). PDO gagne un

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "1.25.1"
+version = "1.26.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "1.25.1"
+version = "1.26.0"
 license = "MIT"
 
 [workspace.dependencies]

--- a/crates/pdo-daemon/src/graph_resolver.rs
+++ b/crates/pdo-daemon/src/graph_resolver.rs
@@ -399,8 +399,8 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         }
     }
 
@@ -455,8 +455,8 @@ mod tests {
                 max_iter,
             ))),
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         }
     }
 

--- a/crates/pdo-daemon/src/harness_argv.rs
+++ b/crates/pdo-daemon/src/harness_argv.rs
@@ -1,0 +1,275 @@
+//! Pure argv-template renderer for agentic harnesses (ADR-0045).
+//!
+//! A harness declares its launch and resume tails as a **template of argv
+//! tokens**. This module turns such a template plus a set of hole values into the
+//! single tail string a tmux session runs — with ONE rule: **a token that
+//! references a hole whose value is empty is dropped in its entirety**. That rule
+//! is the whole reason the `claude` tail stays byte-identical to the legacy launch
+//! when no model / effort / settings / session identity is posed (the #550 gate).
+//!
+//! **Pure by contract — an AC, not advice.** No `$HOME`, no disk, no clock. The
+//! caller shell-quotes each hole value before handing it in (`'opus'`, or
+//! `"$(cat '/path')"` for the prompt), so the shell-quoting discipline stays in
+//! [`crate::tmux_session_manager`] where the shell semantics already live. This
+//! module only substitutes placeholders and joins the survivors, which is exactly
+//! what makes it testable without a fixture.
+
+/// The values substituted into a descriptor's argv holes.
+///
+/// Each field is **already shell-quoted by the caller**. An EMPTY string means
+/// "no value": every token that references that hole is dropped, so the rendered
+/// tail collapses to exactly what it would be if the hole did not appear in the
+/// template at all.
+///
+/// `prompt`, `model`, `effort`, `session_id` and `settings` are the five holes of
+/// ADR-0045. `resume` is a sixth, and it is deliberately NOT one of them: it is
+/// the resume *selector* (`--resume '<id>'` by identity, or a blind `--continue`),
+/// which ADR-0045 keeps in **code** because the identity-or-blind choice reads the
+/// node's event-log row, not the harness. The pure hole-drop rule cannot express
+/// "emit X *when* the hole is empty", so the selector is computed by the caller
+/// and handed in here as one opaque, never-empty value.
+#[derive(Debug, Default, Clone)]
+pub(crate) struct Holes {
+    pub prompt: String,
+    pub model: String,
+    pub effort: String,
+    pub session_id: String,
+    pub settings: String,
+    pub resume: String,
+}
+
+impl Holes {
+    /// Resolve a placeholder name to its (already-quoted) value.
+    ///
+    /// An unknown placeholder resolves to the empty string, so its token drops —
+    /// the same "absent" behaviour as an empty known hole. Every embedded
+    /// descriptor is pinned by a byte-for-byte golden, which turns a typo'd
+    /// placeholder into a red test rather than a silent drop.
+    fn resolve(&self, name: &str) -> &str {
+        match name {
+            "prompt" => &self.prompt,
+            "model" => &self.model,
+            "effort" => &self.effort,
+            "session_id" => &self.session_id,
+            "settings" => &self.settings,
+            "resume" => &self.resume,
+            _ => "",
+        }
+    }
+}
+
+/// Render a descriptor's argv-token template into a single tail string.
+///
+/// Each token may contain zero or more `{hole}` placeholders. A token is dropped
+/// **entirely** if any placeholder it contains resolves to an empty value;
+/// otherwise every placeholder is substituted and the token is kept. The
+/// survivors are joined by a single space — so an absent optional flag leaves no
+/// double space and no trailing space, which is precisely what keeps the no-op
+/// `claude` tail byte-identical to the hand-written legacy literal.
+pub(crate) fn render(tokens: &[String], holes: &Holes) -> String {
+    tokens
+        .iter()
+        .filter_map(|tok| render_token(tok, holes))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Render one token, or `None` when it references an empty hole (⇒ the token is
+/// dropped by [`render`]).
+fn render_token(token: &str, holes: &Holes) -> Option<String> {
+    let mut out = String::with_capacity(token.len());
+    let mut rest = token;
+    loop {
+        let open = match rest.find('{') {
+            None => {
+                out.push_str(rest);
+                return Some(out);
+            }
+            Some(i) => i,
+        };
+        // A `{` with no closing `}` is literal text, not a placeholder — keep it
+        // and stop scanning (none of our descriptors do this, but be lenient).
+        let rel_close = match rest[open + 1..].find('}') {
+            None => {
+                out.push_str(rest);
+                return Some(out);
+            }
+            Some(i) => i,
+        };
+        let close = open + 1 + rel_close;
+        out.push_str(&rest[..open]);
+        let value = holes.resolve(&rest[open + 1..close]);
+        if value.is_empty() {
+            return None; // one empty hole drops the whole token
+        }
+        out.push_str(value);
+        rest = &rest[close + 1..];
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::harness_registry;
+
+    /// The prompt hole as the caller builds it: `"$(cat '<path>')"`.
+    fn prompt_hole(path: &str) -> String {
+        format!("\"$(cat '{path}')\"")
+    }
+
+    // -----------------------------------------------------------------------
+    // THE GATE (#550): the `claude` launch/resume tails, byte for byte.
+    //
+    // These goldens were captured from the pre-refactor `build_agent_tail` /
+    // `build_resume_script` literals (single space before the prompt cat, leading
+    // space on `--effort` etc.) and then the tail builders were rewritten to route
+    // through this renderer. A golden written *after* the refactor would prove
+    // nothing — so it is the literal here that is authoritative.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn claude_launch_no_holes_is_byte_identical_to_the_legacy_tail() {
+        let d = harness_registry::resolve("claude").unwrap();
+        let holes = Holes {
+            prompt: prompt_hole("/tmp/test-prompt.md"),
+            ..Default::default()
+        };
+        assert_eq!(
+            render(&d.launch, &holes),
+            "exec claude --dangerously-skip-permissions \"$(cat '/tmp/test-prompt.md')\""
+        );
+    }
+
+    #[test]
+    fn claude_resume_no_holes_is_byte_identical_to_the_legacy_tail() {
+        let d = harness_registry::resolve("claude").unwrap();
+        // The blind-continue selector, as the resume seam computes it when the row
+        // carries no pinned id (pre-#473 / opencode).
+        let holes = Holes {
+            resume: "--continue".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(
+            render(&d.resume, &holes),
+            "exec claude --dangerously-skip-permissions --continue"
+        );
+    }
+
+    #[test]
+    fn claude_launch_fills_every_hole_in_order() {
+        let d = harness_registry::resolve("claude").unwrap();
+        let holes = Holes {
+            prompt: prompt_hole("/tmp/p.md"),
+            model: "'opus'".to_string(),
+            effort: "'low'".to_string(),
+            settings: "'/tmp/s.json'".to_string(),
+            session_id: "'abc-123'".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(
+            render(&d.launch, &holes),
+            "exec claude --dangerously-skip-permissions --model 'opus' --effort 'low' \
+             --settings '/tmp/s.json' --session-id 'abc-123' \"$(cat '/tmp/p.md')\""
+        );
+    }
+
+    #[test]
+    fn claude_launch_model_only_hugs_the_base_flag() {
+        // #296/#424: an absent optional flag leaves no double space and no gap.
+        let d = harness_registry::resolve("claude").unwrap();
+        let holes = Holes {
+            prompt: prompt_hole("/tmp/p.md"),
+            model: "'opus'".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(
+            render(&d.launch, &holes),
+            "exec claude --dangerously-skip-permissions --model 'opus' \"$(cat '/tmp/p.md')\""
+        );
+    }
+
+    #[test]
+    fn claude_launch_effort_only_leaves_no_gap_where_the_model_would_be() {
+        let d = harness_registry::resolve("claude").unwrap();
+        let holes = Holes {
+            prompt: prompt_hole("/tmp/p.md"),
+            effort: "'xhigh'".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(
+            render(&d.launch, &holes),
+            "exec claude --dangerously-skip-permissions --effort 'xhigh' \"$(cat '/tmp/p.md')\""
+        );
+    }
+
+    #[test]
+    fn claude_resume_by_identity() {
+        let d = harness_registry::resolve("claude").unwrap();
+        let holes = Holes {
+            resume: "--resume 'abc-123'".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(
+            render(&d.resume, &holes),
+            "exec claude --dangerously-skip-permissions --resume 'abc-123'"
+        );
+    }
+
+    #[test]
+    fn claude_resume_carries_effort_and_settings() {
+        let d = harness_registry::resolve("claude").unwrap();
+        let holes = Holes {
+            resume: "--continue".to_string(),
+            effort: "'low'".to_string(),
+            settings: "'/tmp/s.json'".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(
+            render(&d.resume, &holes),
+            "exec claude --dangerously-skip-permissions --continue --effort 'low' \
+             --settings '/tmp/s.json'"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // The rendering rule itself, independent of any descriptor.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn a_token_with_one_empty_hole_is_dropped_whole() {
+        let tokens = vec!["--model {model}".to_string()];
+        assert_eq!(render(&tokens, &Holes::default()), "");
+    }
+
+    #[test]
+    fn a_token_with_a_filled_hole_survives() {
+        let tokens = vec!["--model {model}".to_string()];
+        let holes = Holes {
+            model: "'opus'".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(render(&tokens, &holes), "--model 'opus'");
+    }
+
+    #[test]
+    fn a_literal_token_with_no_hole_always_survives() {
+        let tokens = vec!["--auto".to_string()];
+        assert_eq!(render(&tokens, &Holes::default()), "--auto");
+    }
+
+    #[test]
+    fn survivors_are_joined_by_a_single_space_only() {
+        let tokens = vec![
+            "a".to_string(),
+            "--x {model}".to_string(), // dropped
+            "b".to_string(),
+        ];
+        assert_eq!(render(&tokens, &Holes::default()), "a b");
+    }
+
+    #[test]
+    fn an_unknown_placeholder_drops_its_token() {
+        let tokens = vec!["--x {nope}".to_string(), "keep".to_string()];
+        assert_eq!(render(&tokens, &Holes::default()), "keep");
+    }
+}

--- a/crates/pdo-daemon/src/harness_registry.rs
+++ b/crates/pdo-daemon/src/harness_registry.rs
@@ -1,0 +1,248 @@
+//! Resolve an agentic-harness name to its descriptor (ADR-0045).
+//!
+//! A **harness** is the program that runs a NodeRun's agent (`claude`,
+//! `opencode`, …). It declares itself with two argv-token templates (launch,
+//! resume), an env block, and the binary PDO probes at spawn — never with named
+//! per-feature fields (a named field per case becomes a spelling per case; the
+//! template covers them without naming, ADR-0045).
+//!
+//! **This slice is the embedded floor only.** `claude` and `opencode` are compiled
+//! in; nothing is seeded on disk and this module never reads `$HOME` (the
+//! discipline `run_cost` paid for in #408 — a root goes in, a descriptor comes
+//! out). A user-declared *disk tier* that merges over the floor **by name** is
+//! #553; [`merge_by_name`] is that seam, present and tested now so the disk tier
+//! layers on without rewriting [`resolve`]'s callers — but no caller passes a disk
+//! tier in this slice, so the floor is the whole registry.
+
+/// A harness, as PDO launches / resumes / attaches it (ADR-0045).
+///
+/// The two templates are rendered by [`crate::harness_argv`]; the caller fills
+/// the holes (`{prompt}`, `{model}`, `{effort}`, `{session_id}`, `{settings}`,
+/// and the resume-only `{resume}` selector). The env block is exported before an
+/// **agent** tail — that is where `claude`'s `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1`
+/// now comes from (AC #4); `script` / `shell` tails get it forced by the wrapper.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HarnessDescriptor {
+    /// The harness name (`claude`, `opencode`) — the registry key.
+    pub name: String,
+    /// The program that runs the agent — probed on `PATH` at spawn. Not found ⇒
+    /// the spawn fails **fast**, naming the harness, and writes no start event
+    /// (ADR-0037).
+    pub binary: String,
+    /// The launch tail as an argv-token template.
+    pub launch: Vec<String>,
+    /// The resume tail as an argv-token template. **Empty** ⇒ the harness has no
+    /// resume mechanism, so a resume serves the last pane snapshot rather than an
+    /// error (AC #9, same branch as a `script` node).
+    pub resume: Vec<String>,
+    /// Env exported before an agent tail (`K=V`). Rendered by the wrapper.
+    pub env: Vec<(String, String)>,
+}
+
+impl HarnessDescriptor {
+    /// Whether the LAUNCH template carries an `{effort}` hole.
+    ///
+    /// `opencode` has no effort axis at launch (measured on 1.18.18: the effort
+    /// variant is an in-session command, not a flag), so the UI greys its effort
+    /// picker off this fact alone — an absence declared by the descriptor's shape,
+    /// no extra flag needed (AC #13, ADR-0045).
+    pub fn has_effort_hole(&self) -> bool {
+        self.launch.iter().any(|t| t.contains("{effort}"))
+    }
+
+    /// Whether the harness can re-enter a saved conversation. `false` ⇒ a resume
+    /// serves the pane snapshot (AC #9).
+    pub fn can_resume(&self) -> bool {
+        !self.resume.is_empty()
+    }
+
+    /// Whether the LAUNCH template pins a session identity (`{session_id}`).
+    ///
+    /// `opencode` cannot (measured: launching with a fresh id answers "Session not
+    /// found" and exits 1 — its selector *continues* a session, never creates
+    /// one), so PDO never pins one for it and attributes by working dir alone.
+    pub fn pins_session_id(&self) -> bool {
+        self.launch.iter().any(|t| t.contains("{session_id}"))
+    }
+}
+
+/// The `claude` harness name — the floor of the precedence chain (ADR-0046).
+pub const CLAUDE: &str = "claude";
+/// The `opencode` harness name (ADR-0045, measured on 1.18.18).
+pub const OPENCODE: &str = "opencode";
+
+/// The `claude` descriptor: the legacy launch, expressed as data.
+///
+/// The launch template reproduces the pre-#550 `build_agent_tail` **byte for
+/// byte** once its holes are empty — that is the #550 gate, pinned by the goldens
+/// in [`crate::harness_argv`]. The resume template reproduces the pre-#550
+/// `build_resume_script` tail; its `{resume}` hole is the identity-or-blind
+/// selector the resume seam computes (ADR-0045 keeps that choice in code).
+pub fn claude() -> HarnessDescriptor {
+    HarnessDescriptor {
+        name: CLAUDE.to_string(),
+        binary: "claude".to_string(),
+        launch: [
+            "exec",
+            "claude",
+            "--dangerously-skip-permissions",
+            "--model {model}",
+            "--effort {effort}",
+            "--settings {settings}",
+            "--session-id {session_id}",
+            "{prompt}",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect(),
+        resume: [
+            "exec",
+            "claude",
+            "--dangerously-skip-permissions",
+            "{resume}",
+            "--effort {effort}",
+            "--settings {settings}",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect(),
+        // AC #4: the CCR suppression now comes from the descriptor for an agent
+        // tail (byte-identical to the wrapper's old hard-coded export — see the
+        // `harness_env` handling in `tmux_session_manager::wrap_with_env`).
+        env: vec![(
+            "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC".to_string(),
+            "1".to_string(),
+        )],
+    }
+}
+
+/// The `opencode` descriptor (measured on 1.18.18).
+///
+/// `--auto` is its `--dangerously-skip-permissions`; the prompt is a `--prompt`
+/// argument; the model is `--model provider/model`. There is **no** effort hole
+/// (no launch-time effort axis) and **no** session-id hole (identity can't be
+/// pinned), so the effort picker greys and attribution falls back to the working
+/// dir. Resume is a blind `--continue` (opencode is resident and continues the
+/// cwd's latest session); it carries no env block.
+pub fn opencode() -> HarnessDescriptor {
+    HarnessDescriptor {
+        name: OPENCODE.to_string(),
+        binary: "opencode".to_string(),
+        launch: [
+            "exec",
+            "opencode",
+            "--auto",
+            "--model {model}",
+            "--prompt {prompt}",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect(),
+        resume: ["exec", "opencode", "--auto", "--continue"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect(),
+        env: vec![],
+    }
+}
+
+/// The embedded floor: the harnesses PDO ships compiled in, in precedence-neutral
+/// declaration order.
+pub fn embedded_floor() -> Vec<HarnessDescriptor> {
+    vec![claude(), opencode()]
+}
+
+/// Merge a user-declared disk tier over the embedded floor, **by name**: a disk
+/// descriptor replaces the floor's entry of the same name; a floor name absent
+/// from disk survives. Pure — the caller (a future slice, #553) reads and parses
+/// the disk tier and hands the descriptors in. No caller passes a disk tier in
+/// this slice, so `merge_by_name(embedded_floor(), vec![])` is the whole registry.
+pub fn merge_by_name(
+    floor: Vec<HarnessDescriptor>,
+    disk: Vec<HarnessDescriptor>,
+) -> Vec<HarnessDescriptor> {
+    let mut merged = floor;
+    for d in disk {
+        match merged.iter_mut().find(|f| f.name == d.name) {
+            Some(slot) => *slot = d,
+            None => merged.push(d),
+        }
+    }
+    merged
+}
+
+/// Resolve a harness name to its descriptor. `None` ⇒ no harness carries that
+/// name (an unknown harness — the spawn seam turns this into a fail-fast that
+/// names it, never a silent fallback).
+///
+/// The disk tier (#553) layers on by making this `merge_by_name(embedded_floor(),
+/// disk).into_iter().find(...)`; callers don't change.
+pub fn resolve(name: &str) -> Option<HarnessDescriptor> {
+    embedded_floor().into_iter().find(|d| d.name == name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn floor_carries_claude_and_opencode() {
+        assert!(resolve(CLAUDE).is_some());
+        assert!(resolve(OPENCODE).is_some());
+        assert!(resolve("nope").is_none());
+    }
+
+    #[test]
+    fn claude_pins_identity_has_effort_and_can_resume() {
+        let d = claude();
+        assert!(d.pins_session_id(), "claude pins --session-id");
+        assert!(d.has_effort_hole(), "claude has an effort axis");
+        assert!(d.can_resume(), "claude resumes by --resume/--continue");
+    }
+
+    #[test]
+    fn opencode_has_no_effort_axis_and_no_identity_pin() {
+        let d = opencode();
+        assert!(
+            !d.has_effort_hole(),
+            "opencode has no launch-time effort axis (greys the picker)"
+        );
+        assert!(
+            !d.pins_session_id(),
+            "opencode cannot pin a session identity"
+        );
+        assert!(d.can_resume(), "opencode blind-continues");
+        assert!(d.env.is_empty(), "opencode carries no CCR env");
+    }
+
+    #[test]
+    fn merge_by_name_replaces_a_floor_entry_and_keeps_the_rest() {
+        let custom_claude = HarnessDescriptor {
+            name: CLAUDE.to_string(),
+            binary: "my-claude".to_string(),
+            launch: vec!["exec".to_string(), "my-claude".to_string()],
+            resume: vec![],
+            env: vec![],
+        };
+        let merged = merge_by_name(embedded_floor(), vec![custom_claude.clone()]);
+        // claude is replaced by the disk entry…
+        let c = merged.iter().find(|d| d.name == CLAUDE).unwrap();
+        assert_eq!(c.binary, "my-claude");
+        // …and opencode, absent from the disk tier, survives from the floor.
+        assert!(merged.iter().any(|d| d.name == OPENCODE));
+    }
+
+    #[test]
+    fn merge_by_name_appends_an_unknown_disk_harness() {
+        let novel = HarnessDescriptor {
+            name: "novel".to_string(),
+            binary: "novel".to_string(),
+            launch: vec!["exec".to_string(), "novel".to_string()],
+            resume: vec![],
+            env: vec![],
+        };
+        let merged = merge_by_name(embedded_floor(), vec![novel]);
+        assert!(merged.iter().any(|d| d.name == "novel"));
+        assert_eq!(merged.len(), 3);
+    }
+}

--- a/crates/pdo-daemon/src/harness_resolver.rs
+++ b/crates/pdo-daemon/src/harness_resolver.rs
@@ -1,0 +1,290 @@
+//! Resolve a node's effective harness, model and effort — **pure** (ADR-0046).
+//!
+//! The harness is an axis with four tiers, coarsest last:
+//! `node → Run → Projet → Configuration d'instance → plancher (claude)`. The
+//! finest tier that names a harness wins, and a **pinned** node harness shields
+//! that choice from every coarser tier. The model and effort are **not** axes:
+//! they carry no precedence of their own — they are read from the winning
+//! harness's entry in the node's per-harness map (a slug means nothing outside
+//! the harness that accepts it, ADR-0046).
+//!
+//! **This slice populates only `node` and `instance`.** [`HarnessTiers`] already
+//! carries `run` and `project` slots so the two follow-up slices (#551 Run tier,
+//! #552 Projet tier) fill them without rewriting this signature or its callers.
+//!
+//! Pure by contract (an AC): a set of tier values goes in, a [`ResolvedHarness`]
+//! comes out — no `$HOME`, no disk, no clock — so the whole precedence matrix is
+//! unit-tested without a fixture (the discipline `run_cost` paid for in #408).
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+/// A node's settings for one harness (`harnesses.<name>` in the YAML): the model
+/// and effort to use when the node runs on that harness. Both are free-text
+/// pass-through (ADR-0001: no closed enum that would perish at every model
+/// release). `BTreeMap`-keyed by harness name on the node, so a node stays
+/// executable on either harness instead of launching every node with a slug the
+/// other harness rejects (ADR-0046).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct HarnessEntry {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effort: Option<String>,
+}
+
+/// The harness named at each tier, coarsest last. `None` = that tier names no
+/// harness. `run` and `project` are always `None` in this slice (#551, #552).
+#[derive(Debug, Default, Clone)]
+pub(crate) struct HarnessTiers<'a> {
+    /// The node's pinned harness (`pin_harness`). A pin both **selects** the
+    /// harness and shields it from every coarser tier (ADR-0046: épinglage ≠
+    /// paramétrage).
+    pub node_pin: Option<&'a str>,
+    /// The Run's harness (#551) — the tier that re-runs the same pipeline on
+    /// another harness. `None` in this slice.
+    pub run: Option<&'a str>,
+    /// The Projet's harness (#552). `None` in this slice.
+    pub project: Option<&'a str>,
+    /// The instance default harness (ADR-0015, amended by ADR-0046).
+    pub instance_default: Option<&'a str>,
+}
+
+/// What the spawn seam launches with, frozen into the node's start event.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ResolvedHarness {
+    pub harness: String,
+    pub model: Option<String>,
+    pub effort: Option<String>,
+}
+
+/// Resolve the effective harness name: the finest tier that names a non-empty
+/// harness wins, with `claude` as the floor.
+///
+/// An empty string never wins a tier — `""` means "unset" everywhere, so a
+/// blank `pin_harness:` in YAML or a blank instance default falls through to the
+/// floor instead of resolving to an unknown harness (the `Some("")` trap of
+/// #347).
+pub(crate) fn resolve_harness(tiers: &HarnessTiers<'_>) -> String {
+    [
+        tiers.node_pin,
+        tiers.run,
+        tiers.project,
+        tiers.instance_default,
+    ]
+    .into_iter()
+    .flatten()
+    .find(|s| !s.is_empty())
+    .unwrap_or(crate::harness_registry::CLAUDE)
+    .to_string()
+}
+
+/// Resolve the model a node launches with on the winning harness: the node's
+/// entry for that harness wins, else the instance per-harness default, else
+/// `None` (the harness account default — no `--model`, byte-identical to the
+/// legacy launch for `claude`). An empty string on either side collapses to the
+/// next tier (#347).
+pub(crate) fn resolve_model(
+    node_entry_model: Option<&str>,
+    instance_default_model: Option<&str>,
+) -> Option<String> {
+    node_entry_model
+        .filter(|s| !s.is_empty())
+        .or(instance_default_model.filter(|s| !s.is_empty()))
+        .map(str::to_string)
+}
+
+/// Resolve the effort: the node's entry for the winning harness, empty → `None`
+/// (#424). One tier — effort has no instance default in this slice.
+pub(crate) fn resolve_effort(node_entry_effort: Option<&str>) -> Option<String> {
+    node_entry_effort
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+}
+
+/// The single precedence point both spawn seams call (like `effective_sandbox`):
+/// resolve the harness, then read the model and effort from the **winning
+/// harness's** entry. Shaped so #551/#552 fill `tiers.run`/`tiers.project`
+/// without touching this body.
+pub(crate) fn resolve(
+    tiers: &HarnessTiers<'_>,
+    node_entries: &BTreeMap<String, HarnessEntry>,
+    instance_default_models: &BTreeMap<String, String>,
+) -> ResolvedHarness {
+    let harness = resolve_harness(tiers);
+    let entry = node_entries.get(&harness);
+    let node_model = entry.and_then(|e| e.model.as_deref());
+    let node_effort = entry.and_then(|e| e.effort.as_deref());
+    let default_model = instance_default_models.get(&harness).map(String::as_str);
+    ResolvedHarness {
+        model: resolve_model(node_model, default_model),
+        effort: resolve_effort(node_effort),
+        harness,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::harness_registry::{CLAUDE, OPENCODE};
+
+    fn entries(pairs: &[(&str, Option<&str>, Option<&str>)]) -> BTreeMap<String, HarnessEntry> {
+        pairs
+            .iter()
+            .map(|(name, model, effort)| {
+                (
+                    name.to_string(),
+                    HarnessEntry {
+                        model: model.map(str::to_string),
+                        effort: effort.map(str::to_string),
+                    },
+                )
+            })
+            .collect()
+    }
+
+    fn no_defaults() -> BTreeMap<String, String> {
+        BTreeMap::new()
+    }
+
+    // ---- harness precedence matrix (each tier wins in turn) -----------------
+
+    #[test]
+    fn floor_is_claude_when_no_tier_names_one() {
+        assert_eq!(resolve_harness(&HarnessTiers::default()), CLAUDE);
+    }
+
+    #[test]
+    fn instance_default_beats_the_floor() {
+        let tiers = HarnessTiers {
+            instance_default: Some(OPENCODE),
+            ..Default::default()
+        };
+        assert_eq!(resolve_harness(&tiers), OPENCODE);
+    }
+
+    #[test]
+    fn node_pin_beats_every_coarser_tier() {
+        // The pin resists an instance (and, once they land, Run/Projet) change —
+        // "this role requires this harness" (ADR-0046).
+        let tiers = HarnessTiers {
+            node_pin: Some(CLAUDE),
+            run: Some(OPENCODE),
+            project: Some(OPENCODE),
+            instance_default: Some(OPENCODE),
+        };
+        assert_eq!(resolve_harness(&tiers), CLAUDE);
+    }
+
+    #[test]
+    fn run_beats_project_and_instance() {
+        let tiers = HarnessTiers {
+            node_pin: None,
+            run: Some("run-harness"),
+            project: Some("project-harness"),
+            instance_default: Some(OPENCODE),
+        };
+        assert_eq!(resolve_harness(&tiers), "run-harness");
+    }
+
+    #[test]
+    fn project_beats_instance() {
+        let tiers = HarnessTiers {
+            project: Some("project-harness"),
+            instance_default: Some(OPENCODE),
+            ..Default::default()
+        };
+        assert_eq!(resolve_harness(&tiers), "project-harness");
+    }
+
+    #[test]
+    fn empty_string_never_wins_a_tier() {
+        // The `Some("")` trap of #347: a blank pin falls through to the floor.
+        let tiers = HarnessTiers {
+            node_pin: Some(""),
+            instance_default: Some(""),
+            ..Default::default()
+        };
+        assert_eq!(resolve_harness(&tiers), CLAUDE);
+    }
+
+    // ---- model / effort read from the WINNING harness's entry ---------------
+
+    #[test]
+    fn model_and_effort_come_from_the_winning_harness_entry() {
+        let tiers = HarnessTiers {
+            node_pin: Some(OPENCODE),
+            ..Default::default()
+        };
+        let node_entries = entries(&[
+            (CLAUDE, Some("opus"), Some("high")),
+            (OPENCODE, Some("openrouter/foo"), None),
+        ]);
+        let r = resolve(&tiers, &node_entries, &no_defaults());
+        assert_eq!(r.harness, OPENCODE);
+        // opencode's entry wins — NOT claude's, even though claude has richer settings.
+        assert_eq!(r.model.as_deref(), Some("openrouter/foo"));
+        assert_eq!(r.effort, None);
+    }
+
+    #[test]
+    fn a_node_without_an_entry_for_the_winning_harness_runs_without_a_model() {
+        // AC: no entry ⇒ no `--model`, the harness account default.
+        let tiers = HarnessTiers {
+            node_pin: Some(OPENCODE),
+            ..Default::default()
+        };
+        let node_entries = entries(&[(CLAUDE, Some("opus"), Some("high"))]);
+        let r = resolve(&tiers, &node_entries, &no_defaults());
+        assert_eq!(r.harness, OPENCODE);
+        assert_eq!(r.model, None, "no claude slug leaks onto opencode");
+        assert_eq!(r.effort, None);
+    }
+
+    #[test]
+    fn instance_per_harness_default_model_backs_a_missing_node_model() {
+        let tiers = HarnessTiers {
+            instance_default: Some(OPENCODE),
+            ..Default::default()
+        };
+        let defaults: BTreeMap<String, String> =
+            [(OPENCODE.to_string(), "openrouter/def".to_string())]
+                .into_iter()
+                .collect();
+        let r = resolve(&tiers, &BTreeMap::new(), &defaults);
+        assert_eq!(r.harness, OPENCODE);
+        assert_eq!(r.model.as_deref(), Some("openrouter/def"));
+    }
+
+    #[test]
+    fn node_entry_model_beats_the_instance_default() {
+        let defaults: BTreeMap<String, String> = [(CLAUDE.to_string(), "sonnet".to_string())]
+            .into_iter()
+            .collect();
+        let node_entries = entries(&[(CLAUDE, Some("opus"), None)]);
+        let r = resolve(&HarnessTiers::default(), &node_entries, &defaults);
+        assert_eq!(r.model.as_deref(), Some("opus"));
+    }
+
+    #[test]
+    fn empty_node_model_falls_through_to_the_instance_default() {
+        let defaults: BTreeMap<String, String> = [(CLAUDE.to_string(), "sonnet".to_string())]
+            .into_iter()
+            .collect();
+        let node_entries = entries(&[(CLAUDE, Some(""), Some(""))]);
+        let r = resolve(&HarnessTiers::default(), &node_entries, &defaults);
+        assert_eq!(r.model.as_deref(), Some("sonnet"), "\"\" is unset");
+        assert_eq!(r.effort, None, "empty effort collapses to None");
+    }
+
+    #[test]
+    fn claude_node_with_no_settings_resolves_to_the_byte_identical_launch() {
+        // The control: a plain claude node yields no model, no effort — the state
+        // the legacy launch reproduces byte for byte.
+        let r = resolve(&HarnessTiers::default(), &BTreeMap::new(), &no_defaults());
+        assert_eq!(r.harness, CLAUDE);
+        assert_eq!(r.model, None);
+        assert_eq!(r.effort, None);
+    }
+}

--- a/crates/pdo-daemon/src/input_resolution.rs
+++ b/crates/pdo-daemon/src/input_resolution.rs
@@ -445,8 +445,8 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         }
     }
 

--- a/crates/pdo-daemon/src/instance_config.rs
+++ b/crates/pdo-daemon/src/instance_config.rs
@@ -74,6 +74,21 @@ pub(crate) struct InstanceConfig {
     /// [`Self::autocomplete_turn_end`]: `NULL` is what makes the `stored → env → default`
     /// fall-through work; a stored `0` is a decision that beats the env.
     pub default_auto_name: Option<i64>,
+    /// Stored instance-wide default **harness** (`claude`, `opencode`), or `None`
+    /// when unset (#550, ADR-0046 amending ADR-0015). `None` falls through to the
+    /// env seam ([`crate::tmux_session_manager::DEFAULT_HARNESS_ENV`]) then the
+    /// `claude` floor. Free-text pass-through, no enum (ADR-0001). `Some("")` is
+    /// the clear sentinel — [`update`] normalises it to SQL `NULL`.
+    pub default_harness: Option<String>,
+    /// Stored instance-wide default **model per harness** (#550, ADR-0046): a map
+    /// `harness → model`, e.g. `{"claude":"opus"}`. The single `default_model`
+    /// became per-harness because a model slug means nothing outside its harness.
+    /// Empty map ⇒ no per-harness default (for `claude` the legacy
+    /// [`crate::tmux_session_manager::DEFAULT_MODEL_ENV`] still contributes at the
+    /// spawn seam). Persisted as a JSON object in the `default_harness_model`
+    /// column (`trigger_store::variables` idiom).
+    #[serde(default)]
+    pub default_harness_model: std::collections::BTreeMap<String, String>,
     /// RFC3339-millis UTC timestamp of the last write (or the seed).
     pub updated_at: String,
 }
@@ -113,6 +128,13 @@ pub(crate) struct UpdateInstanceConfig {
     /// storing `0` for "off" is what lets unticking the box override a
     /// `PDO_DEFAULT_AUTO_NAME=1`, which a `NULL` fall-through would not.
     pub default_auto_name: Option<bool>,
+    /// Set the instance-wide default harness (#550). `Some("")` clears it back to
+    /// unset (same `""`-sentinel as `default_model`); `None` leaves it untouched.
+    pub default_harness: Option<String>,
+    /// Set the instance-wide per-harness default model map (#550). `Some(map)`
+    /// replaces the stored map wholesale; an empty map clears it. `None` leaves it
+    /// untouched.
+    pub default_harness_model: Option<std::collections::BTreeMap<String, String>>,
 }
 
 impl UpdateInstanceConfig {
@@ -124,6 +146,8 @@ impl UpdateInstanceConfig {
             && self.default_sandbox.is_none()
             && self.autocomplete_turn_end.is_none()
             && self.default_auto_name.is_none()
+            && self.default_harness.is_none()
+            && self.default_harness_model.is_none()
     }
 }
 
@@ -145,6 +169,8 @@ pub(crate) async fn init(db: &SqlitePool) -> Result<(), sqlx::Error> {
             default_sandbox    TEXT,
             autocomplete_turn_end INTEGER,
             default_auto_name  INTEGER,
+            default_harness    TEXT,
+            default_harness_model TEXT,
             updated_at         TEXT NOT NULL
         )",
     )
@@ -241,6 +267,33 @@ pub(crate) async fn init(db: &SqlitePool) -> Result<(), sqlx::Error> {
             .await?;
     }
 
+    // Additive migration for pre-#550 databases: the `default_harness` and
+    // `default_harness_model` columns are absent on tables created before the
+    // multi-harness axis. Same guarded `ADD COLUMN` idiom — NULLABLE so an
+    // existing install falls through env → the `claude` floor unchanged.
+    let has_default_harness = sqlx::query(
+        "SELECT 1 FROM pragma_table_info('instance_config') WHERE name = 'default_harness'",
+    )
+    .fetch_optional(db)
+    .await?
+    .is_some();
+    if !has_default_harness {
+        sqlx::query("ALTER TABLE instance_config ADD COLUMN default_harness TEXT")
+            .execute(db)
+            .await?;
+    }
+    let has_default_harness_model = sqlx::query(
+        "SELECT 1 FROM pragma_table_info('instance_config') WHERE name = 'default_harness_model'",
+    )
+    .fetch_optional(db)
+    .await?
+    .is_some();
+    if !has_default_harness_model {
+        sqlx::query("ALTER TABLE instance_config ADD COLUMN default_harness_model TEXT")
+            .execute(db)
+            .await?;
+    }
+
     Ok(())
 }
 
@@ -253,6 +306,14 @@ fn row_to_config(row: &sqlx::sqlite::SqliteRow) -> InstanceConfig {
         default_sandbox: row.get("default_sandbox"),
         autocomplete_turn_end: row.get("autocomplete_turn_end"),
         default_auto_name: row.get("default_auto_name"),
+        default_harness: row.get("default_harness"),
+        // Stored as a JSON object in a TEXT column (trigger_store::variables
+        // idiom). NULL / empty / unparseable ⇒ an empty map, so a fresh row and a
+        // corrupt one both fall through to env → floor rather than erroring.
+        default_harness_model: row
+            .get::<Option<String>, _>("default_harness_model")
+            .and_then(|s| serde_json::from_str(&s).ok())
+            .unwrap_or_default(),
         updated_at: row.get("updated_at"),
     }
 }
@@ -301,6 +362,12 @@ pub(crate) async fn update(
     if edit.default_auto_name.is_some() {
         sets.push("default_auto_name = ?");
     }
+    if edit.default_harness.is_some() {
+        sets.push("default_harness = ?");
+    }
+    if edit.default_harness_model.is_some() {
+        sets.push("default_harness_model = ?");
+    }
     // Always bump the write timestamp on a real edit.
     sets.push("updated_at = ?");
 
@@ -339,6 +406,16 @@ pub(crate) async fn update(
         // 0/1, never NULL: unticking must persist a stored `0` that beats a
         // `PDO_DEFAULT_AUTO_NAME=1`, not fall through to it (#338).
         query = query.bind(if v { 1_i64 } else { 0_i64 });
+    }
+    if let Some(v) = edit.default_harness {
+        // "" = clear sentinel → SQL NULL (#550, mirrors default_model): a stored
+        // "" would win precedence and shadow env/floor. NULL restores fall-through.
+        query = query.bind(if v.is_empty() { None } else { Some(v) });
+    }
+    if let Some(v) = edit.default_harness_model {
+        // Persist the map as JSON; an empty map stores `{}` (a real "no defaults"
+        // decision). Serialisation cannot fail for a String→String map.
+        query = query.bind(serde_json::to_string(&v).unwrap_or_else(|_| "{}".to_string()));
     }
     query = query.bind(crate::event_log::now_iso());
     query.execute(db).await?;
@@ -458,7 +535,122 @@ mod tests {
         assert_eq!(cfg.default_sandbox, None);
         assert_eq!(cfg.autocomplete_turn_end, None);
         assert_eq!(cfg.default_auto_name, None);
+        assert_eq!(cfg.default_harness, None);
+        assert!(cfg.default_harness_model.is_empty());
         assert!(!cfg.updated_at.is_empty(), "seed must stamp updated_at");
+    }
+
+    #[tokio::test]
+    async fn update_sets_and_reads_back_default_harness() {
+        // #550/ADR-0046: the scalar default harness round-trips like `default_model`.
+        let db = test_db().await;
+        let updated = update(
+            &db,
+            UpdateInstanceConfig {
+                default_harness: Some("opencode".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(updated.default_harness.as_deref(), Some("opencode"));
+        assert_eq!(
+            get(&db).await.unwrap().default_harness.as_deref(),
+            Some("opencode")
+        );
+        // "" clears it back to unset (the resolver's floor then applies).
+        update(
+            &db,
+            UpdateInstanceConfig {
+                default_harness: Some(String::new()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(get(&db).await.unwrap().default_harness, None);
+    }
+
+    #[tokio::test]
+    async fn update_sets_and_reads_back_per_harness_default_model() {
+        // #550/ADR-0046: the per-harness default model map persists as JSON and
+        // round-trips through a re-read.
+        let db = test_db().await;
+        let map: std::collections::BTreeMap<String, String> = [
+            ("claude".to_string(), "opus".to_string()),
+            ("opencode".to_string(), "openrouter/foo".to_string()),
+        ]
+        .into_iter()
+        .collect();
+        update(
+            &db,
+            UpdateInstanceConfig {
+                default_harness_model: Some(map.clone()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(get(&db).await.unwrap().default_harness_model, map);
+    }
+
+    #[tokio::test]
+    async fn init_migrates_pre_harness_schema() {
+        // #550: a table created before the harness columns gains them on init,
+        // idempotently, without clobbering a pre-existing knob.
+        let db = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        // The full pre-#550 schema (everything except the two harness columns).
+        sqlx::query(
+            "CREATE TABLE instance_config (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                session_cap INTEGER,
+                reaper_ttl_secs INTEGER,
+                guard_timeout_secs INTEGER,
+                default_model TEXT,
+                triggers_paused INTEGER,
+                default_sandbox TEXT,
+                autocomplete_turn_end INTEGER,
+                default_auto_name INTEGER,
+                updated_at TEXT NOT NULL
+            )",
+        )
+        .execute(&db)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO instance_config (id, session_cap, updated_at) VALUES (1, 7, 'seed')",
+        )
+        .execute(&db)
+        .await
+        .unwrap();
+
+        // First init adds the columns; a second is a no-op (PRAGMA guard holds).
+        init(&db).await.unwrap();
+        init(&db).await.unwrap();
+
+        let cfg = get(&db).await.unwrap();
+        assert_eq!(cfg.session_cap, Some(7), "pre-existing knob survives");
+        assert_eq!(cfg.default_harness, None, "new column defaults to NULL");
+        assert!(cfg.default_harness_model.is_empty());
+
+        // …and both new columns are writable afterward.
+        let map: std::collections::BTreeMap<String, String> =
+            [("claude".to_string(), "opus".to_string())]
+                .into_iter()
+                .collect();
+        update(
+            &db,
+            UpdateInstanceConfig {
+                default_harness: Some("opencode".to_string()),
+                default_harness_model: Some(map.clone()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        let cfg = get(&db).await.unwrap();
+        assert_eq!(cfg.default_harness.as_deref(), Some("opencode"));
+        assert_eq!(cfg.default_harness_model, map);
     }
 
     #[tokio::test]

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -19,6 +19,9 @@ mod fire_decision;
 mod frontmatter_parser;
 mod graph_resolver;
 mod guard_runner;
+mod harness_argv;
+pub mod harness_registry;
+mod harness_resolver;
 mod input_resolution;
 mod instance_config;
 mod library_store;
@@ -4409,6 +4412,41 @@ async fn stored_default_model(db: &sqlx::SqlitePool) -> Option<String> {
     tmux_session_manager::default_model_with(stored)
 }
 
+/// The instance-wide default **harness**, resolved `stored → env → None` from a
+/// *fresh* read of `instance_config` (#550, ADR-0046). Feeds the `instance` tier
+/// of [`harness_resolver`] at every spawn seam so a `PUT /settings` takes effect
+/// on the next node with no restart. `None` ⇒ the resolver's `claude` floor.
+async fn stored_default_harness(db: &sqlx::SqlitePool) -> Option<String> {
+    let stored = instance_config::get(db)
+        .await
+        .ok()
+        .and_then(|c| c.default_harness);
+    tmux_session_manager::default_harness_with(stored)
+}
+
+/// The per-harness default model map for the resolver (#550, ADR-0046), from a
+/// *fresh* read of `instance_config`. The stored `default_harness_model` map, with
+/// the legacy single instance default (`default_model` stored/env) folded under
+/// `claude` when the map is silent for it — so a pre-#550 setup keeps working
+/// unchanged. A DB read error yields an empty map (fall through to no default).
+async fn stored_default_harness_models(
+    db: &sqlx::SqlitePool,
+) -> std::collections::BTreeMap<String, String> {
+    let cfg = instance_config::get(db).await.ok();
+    let mut map = cfg
+        .as_ref()
+        .map(|c| c.default_harness_model.clone())
+        .unwrap_or_default();
+    if !map.contains_key(harness_registry::CLAUDE) {
+        if let Some(legacy) =
+            tmux_session_manager::default_model_with(cfg.and_then(|c| c.default_model))
+        {
+            map.insert(harness_registry::CLAUDE.to_string(), legacy);
+        }
+    }
+    map
+}
+
 /// Resolve turn-end auto-completion the way the liveness sweep does, from a
 /// *fresh* read of `instance_config` (#433, ADR-0043). Consulted at every agent
 /// spawn/resume seam so injecting the `Stop` hook tracks a `PUT /settings` with
@@ -5388,6 +5426,10 @@ const KNOWN_NODE_KEYS: &[&str] = &[
     "max_iter",
     "branches",
     "prompt",
+    // #550/ADR-0046: the harness axis. `model`/`effort` above stay accepted (a
+    // pasted flat pair is folded into `harnesses.claude` by `normalize_node_value`).
+    "pin_harness",
+    "harnesses",
     // Accepted-and-dropped, not a semantic loss → no warning.
     "id",
     "view",
@@ -5468,7 +5510,32 @@ fn parse_node_spec(yaml: &str) -> Result<serde_json::Value, String> {
         }
     }
 
-    // 7. Deserialize the (normalized) map into a LibraryEntry. `prompt` defaults
+    // 7. #550/ADR-0046: read the harness axis off the (folded) value before it is
+    //    consumed. `normalize_node_value` above folded any flat `model:`/`effort:`
+    //    into `harnesses.claude`, so the claude entry is the source for the
+    //    (claude-aware) `spec.model`/`spec.effort` the node library shows — and the
+    //    full `harnesses` map + `pin_harness` ride through for the harness UI.
+    let claude = value
+        .get("harnesses")
+        .and_then(|h| h.get(harness_registry::CLAUDE));
+    let claude_model = claude
+        .and_then(|c| c.get("model"))
+        .and_then(|v| v.as_str())
+        .map(String::from);
+    let claude_effort = claude
+        .and_then(|c| c.get("effort"))
+        .and_then(|v| v.as_str())
+        .map(String::from);
+    let pin_harness = value
+        .get("pin_harness")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+    let harnesses = value
+        .get("harnesses")
+        .map(yaml_value_to_json)
+        .unwrap_or(serde_json::Value::Null);
+
+    // 8. Deserialize the (normalized) map into a LibraryEntry. `prompt` defaults
     //    to empty (a structural node carries none); unknown fields are ignored.
     let entry: library_store::LibraryEntry =
         serde_yaml::from_value(value).map_err(|e| format!("{e}"))?;
@@ -5480,8 +5547,12 @@ fn parse_node_spec(yaml: &str) -> Result<serde_json::Value, String> {
             "inputs": entry.inputs,
             "outputs": entry.outputs,
             "interactive": entry.interactive,
-            "model": entry.model,
-            "effort": entry.effort,
+            // Claude-aware view (#345) — derived from the folded harnesses map.
+            "model": claude_model,
+            "effort": claude_effort,
+            // #550: the harness axis, for the pin selector + per-harness UI.
+            "pin_harness": pin_harness,
+            "harnesses": harnesses,
             "max_iter": entry.max_iter,
             "branches": entry.branches,
         },
@@ -7638,6 +7709,10 @@ fn spawn_manager_session(
         marker: &session_name,
         workdir: worktree_dir,
     });
+    // #550/ADR-0046: infra sessions follow the Run's harness; the Run tier is #551,
+    // so in this slice the manager runs on the `claude` floor — byte-identical to
+    // the legacy manager launch (no model, no effort, no session id).
+    let manager_harness = harness_registry::claude();
     if let Err(e) = tmux_session_manager::spawn(
         &session_name,
         &full_prompt,
@@ -7654,6 +7729,7 @@ fn spawn_manager_session(
         // and resolving nodes by their own id is precisely what stops the manager's
         // transcript, which shares this cwd, from being read as a node's.
         tmux_session_manager::SessionTail::Agent {
+            harness: &manager_harness,
             model: None,
             effort: None,
             session_id: None,
@@ -7914,6 +7990,29 @@ async fn build_settings_view(state: &AppState) -> Result<serde_json::Value, sqlx
         "default"
     };
 
+    // --- default harness (#550, ADR-0046) — same `stored → env → floor` shape as
+    // `default_model`. `effective`=null ⇒ the `claude` floor applies at resolve. ---
+    let dh_stored = cfg.default_harness.as_deref().filter(|s| !s.is_empty());
+    let dh_env = tmux_session_manager::env_default_harness();
+    let dh_effective = tmux_session_manager::default_harness_with(cfg.default_harness.clone());
+    let dh_source = if dh_stored.is_some() {
+        "stored"
+    } else if dh_env.is_some() {
+        "env"
+    } else {
+        "default"
+    };
+    // The per-harness default model map (#550): disclosed verbatim (the stored map)
+    // plus the legacy `PDO_DEFAULT_MODEL` env folded under `claude`, so the screen
+    // shows exactly what the resolver's `instance` tier will read.
+    let dhm_stored = cfg.default_harness_model.clone();
+    let mut dhm_effective = dhm_stored.clone();
+    if !dhm_effective.contains_key(harness_registry::CLAUDE) {
+        if let Some(m) = dm_effective.clone() {
+            dhm_effective.insert(harness_registry::CLAUDE.to_string(), m);
+        }
+    }
+
     // --- default sandbox mode (enum ; built-in default `off`) (#410) ---
     // The empty-string filter treats a stored `""` as unset, and `effective` is computed by
     // the SAME resolver the create-run chokepoint consumes, so the disclosed value can never
@@ -8061,6 +8160,15 @@ async fn build_settings_view(state: &AppState) -> Result<serde_json::Value, sqlx
         "reaper_ttl_secs": settings_field(ttl_effective, ttl_source, cfg.reaper_ttl_secs, ttl_env, ttl_default),
         "guard_timeout_secs": settings_field(guard_effective, guard_source, cfg.guard_timeout_secs, guard_env_ms, guard_default),
         "default_model": settings_field_str(dm_effective.as_deref(), dm_source, dm_stored, dm_env.as_deref()),
+        // #550/ADR-0046: the harness axis. `default_harness` is a plain
+        // stored→env→floor string field; `default_harness_model` is a per-harness
+        // map, disclosed as {effective, stored} so the screen shows both what is
+        // set and what the resolver will read (env fold under claude included).
+        "default_harness": settings_field_str(dh_effective.as_deref(), dh_source, dh_stored, dh_env.as_deref()),
+        "default_harness_model": {
+            "effective": dhm_effective,
+            "stored": dhm_stored,
+        },
         "default_sandbox": {
             "effective": sbx_effective.as_str(),
             "source": sbx_source,
@@ -10439,6 +10547,31 @@ async fn node_pane(
             // own transcript. A pre-#473 row (no id) falls back to a bare
             // `--continue`, which is the very collision this issue fixes.
             let launch_session_id = find_launch_session_id(&events, &node_id, iter);
+            // #550/ADR-0046: re-pose the harness FROZEN at spawn — never the YAML's
+            // now. A pre-#550 row (no key) or an unknown harness falls back to the
+            // `claude` floor, byte-identical to the legacy resume.
+            let launch_harness = find_launch_harness(&events, &node_id, iter);
+            let descriptor = launch_harness
+                .as_deref()
+                .and_then(harness_registry::resolve)
+                .unwrap_or_else(harness_registry::claude);
+            // AC #9: a harness with no resume mechanism serves its last pane
+            // snapshot (the same branch as a `script` node), never a resume error.
+            if !descriptor.can_resume() {
+                let snapshot_path = pane_snapshot_path(&repo_root, &run_id, &node_id, iter);
+                let (content, source) = match std::fs::read_to_string(&snapshot_path) {
+                    Ok(c) => (c, "snapshot"),
+                    Err(_) => ("Session no longer available".to_string(), "unavailable"),
+                };
+                return Json(PaneResponse {
+                    content,
+                    session_name,
+                    resumed: false,
+                    stale: false,
+                    source,
+                })
+                .into_response();
+            }
             // #433 / ADR-0043 (D7): re-resolve turn-end auto-completion FRESH — it
             // may have toggled since spawn — so a resurrected session re-carries
             // the `Stop` hook. A `script` node returned early above, so this tail is
@@ -10451,6 +10584,7 @@ async fn node_pane(
                 &node_id,
                 iter,
                 state.port,
+                &descriptor,
                 launch_effort.as_deref(),
                 launch_session_id.as_deref(),
                 state.tmux_cmd_override.as_deref(),
@@ -10543,6 +10677,27 @@ fn find_launch_session_id(events: &[event_log::Event], node_id: &str, iter: i64)
         })
         .and_then(|e| e.payload.as_ref())
         .and_then(|p| p.get("session_id"))
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+}
+
+/// The harness a node's iteration was **launched** with (#550, ADR-0046), read
+/// back from its `NodeStarted` payload — never re-resolved from the current YAML
+/// or the tiers above (ADR-0007: a live iteration is immutable to edits). A
+/// missing key (every pre-#550 row, every infra session) yields `None`, which the
+/// resume seam treats as the `claude` floor — byte-identical to the legacy tail.
+fn find_launch_harness(events: &[event_log::Event], node_id: &str, iter: i64) -> Option<String> {
+    events
+        .iter()
+        .rev()
+        .find(|e| {
+            e.kind == event_log::EventKind::NodeStarted
+                && e.node_id.as_deref() == Some(node_id)
+                && e.iter == Some(iter)
+        })
+        .and_then(|e| e.payload.as_ref())
+        .and_then(|p| p.get("harness"))
         .and_then(|v| v.as_str())
         .filter(|s| !s.is_empty())
         .map(|s| s.to_string())
@@ -10792,6 +10947,9 @@ async fn spawn_merge_resolver(
         marker: &session_name,
         workdir: worktree_dir,
     });
+    // #550/ADR-0046: infra sessions follow the Run's harness (Run tier = #551), so
+    // the merge resolver runs on the `claude` floor in this slice — byte-identical.
+    let resolver_harness = harness_registry::claude();
     if let Err(e) = tmux_session_manager::spawn(
         &session_name,
         &prompt,
@@ -10807,6 +10965,7 @@ async fn spawn_merge_resolver(
         // confused with a `merge` NODE, which is a regular NodeDef routed through
         // `spawn_node` and DOES carry an effort and a pinned id.
         tmux_session_manager::SessionTail::Agent {
+            harness: &resolver_harness,
             model: None,
             effort: None,
             session_id: None,
@@ -12010,6 +12169,9 @@ async fn force_spawn_node(state: &Arc<AppState>, run_id: &str, node_id: &str) ->
         // (wiring only one seam would leave this path at the account default —
         // a silent bug visible only on a manual force-spawn).
         default_model: stored_default_model(&state.db).await,
+        // #550/ADR-0046: same fresh-resolution discipline for the harness axis.
+        default_harness: stored_default_harness(&state.db).await,
+        default_harness_models: stored_default_harness_models(&state.db).await,
         // #433 / ADR-0043: same reasoning as `default_model` — resolve turn-end
         // auto-completion fresh so a force-spawned node arms the `Stop` hook when
         // the setting is on, instead of silently missing it on this seam alone.
@@ -12283,6 +12445,9 @@ async fn node_retry(
         docker_cmd_override: state.docker_cmd_override.as_deref(),
         // #347: retry honours the instance default like the live scheduler path.
         default_model: stored_default_model(&state.db).await,
+        // #550/ADR-0046: retry resolves the harness axis fresh, like model.
+        default_harness: stored_default_harness(&state.db).await,
+        default_harness_models: stored_default_harness_models(&state.db).await,
         // #433 / ADR-0043: retry re-arms the `Stop` hook per the current setting,
         // like the live scheduler path — not the value at the original spawn.
         inject_hook: stored_autocomplete_turn_end(&state.db).await,
@@ -17803,8 +17968,8 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         }
     }
 
@@ -26437,8 +26602,8 @@ edges: []
             view: None,
             max_iter: None,
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         };
         let pipeline = pipeline::PipelineDef {
             name: "spawn-unit".into(),

--- a/crates/pdo-daemon/src/library_store.rs
+++ b/crates/pdo-daemon/src/library_store.rs
@@ -200,10 +200,18 @@ pub(crate) fn entry_from_node(node: &pipeline::NodeDef, prompt: &str) -> Library
         outputs: node.outputs.clone(),
         interactive: node.interactive,
         // #345/#296: carry the per-node model so a starred node stays synced
-        // instead of flipping to `diverged` the moment it has an override.
-        model: node.model.clone(),
+        // instead of flipping to `diverged` the moment it has an override. Since
+        // #550 the model/effort live under `harnesses.claude`; the node library
+        // stays claude-aware (its pre-#550 contract), so project that entry.
+        model: node
+            .harnesses
+            .get(crate::harness_registry::CLAUDE)
+            .and_then(|e| e.model.clone()),
         // #424: same reasoning for the effort level.
-        effort: node.effort.clone(),
+        effort: node
+            .harnesses
+            .get(crate::harness_registry::CLAUDE)
+            .and_then(|e| e.effort.clone()),
         max_iter: None,
         branches: None,
         prompt: prompt.to_string(),
@@ -1011,6 +1019,18 @@ mod tests {
         });
     }
 
+    /// #550: set a node's `harnesses.claude` entry — the source `entry_from_node`
+    /// now projects into a `LibraryEntry`'s `model`/`effort`.
+    fn set_claude_entry(node: &mut pipeline::NodeDef, model: Option<&str>, effort: Option<&str>) {
+        node.harnesses.insert(
+            crate::harness_registry::CLAUDE.to_string(),
+            crate::harness_resolver::HarnessEntry {
+                model: model.map(str::to_string),
+                effort: effort.map(str::to_string),
+            },
+        );
+    }
+
     fn make_node(name: &str) -> pipeline::NodeDef {
         pipeline::NodeDef {
             id: "test-id".to_string(),
@@ -1038,8 +1058,8 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         }
     }
 
@@ -1242,7 +1262,7 @@ mod tests {
         // #345/#296: a node with a per-node model must produce a model-aware
         // library entry (previously the model was silently dropped).
         let mut node = make_node("Modelled");
-        node.model = Some("sonnet".to_string());
+        set_claude_entry(&mut node, Some("sonnet"), None);
         let entry = entry_from_node(&node, "prompt");
         assert_eq!(entry.model, Some("sonnet".to_string()));
     }
@@ -1280,8 +1300,7 @@ mod tests {
         // #424: a node with a per-node effort must produce an effort-aware library
         // entry, and the two axes must not interfere.
         let mut node = make_node("Effortful");
-        node.model = Some("sonnet".to_string());
-        node.effort = Some("xhigh".to_string());
+        set_claude_entry(&mut node, Some("sonnet"), Some("xhigh"));
         let entry = entry_from_node(&node, "prompt");
         assert_eq!(entry.effort, Some("xhigh".to_string()));
         assert_eq!(entry.model, Some("sonnet".to_string()));
@@ -1294,14 +1313,14 @@ mod tests {
         // bug #345, one field later.
         with_temp_home(|| {
             let mut node = make_node("Effortful");
-            node.effort = Some("low".to_string());
+            set_claude_entry(&mut node, None, Some("low"));
             save(&entry_from_node(&node, "prompt")).unwrap();
             assert_eq!(sync_state(&node, "prompt"), SyncState::Synced);
 
-            node.effort = Some("high".to_string());
+            set_claude_entry(&mut node, None, Some("high"));
             assert_eq!(sync_state(&node, "prompt"), SyncState::Diverged);
 
-            node.effort = None;
+            set_claude_entry(&mut node, None, None);
             assert_eq!(sync_state(&node, "prompt"), SyncState::Diverged);
         });
     }

--- a/crates/pdo-daemon/src/loop_region.rs
+++ b/crates/pdo-daemon/src/loop_region.rs
@@ -536,8 +536,8 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         }
     }
 

--- a/crates/pdo-daemon/src/mutation_validator.rs
+++ b/crates/pdo-daemon/src/mutation_validator.rs
@@ -213,8 +213,8 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         }
     }
 
@@ -231,8 +231,8 @@ mod tests {
                 max_iter,
             ))),
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         }
     }
 

--- a/crates/pdo-daemon/src/node_io_resolver.rs
+++ b/crates/pdo-daemon/src/node_io_resolver.rs
@@ -353,8 +353,8 @@ mod tests {
                     view: None,
                     max_iter: None,
                     over: None,
-                    model: None,
-                    effort: None,
+                    pin_harness: None,
+                    harnesses: Default::default(),
                 },
                 NodeDef {
                     id: "implementer".into(),
@@ -382,8 +382,8 @@ mod tests {
                     view: None,
                     max_iter: None,
                     over: None,
-                    model: None,
-                    effort: None,
+                    pin_harness: None,
+                    harnesses: Default::default(),
                 },
             ],
             edges: vec![EdgeDef {
@@ -536,8 +536,8 @@ mod tests {
                     view: None,
                     max_iter: None,
                     over: None,
-                    model: None,
-                    effort: None,
+                    pin_harness: None,
+                    harnesses: Default::default(),
                 },
                 NodeDef {
                     id: "implementer".into(),
@@ -565,8 +565,8 @@ mod tests {
                     view: None,
                     max_iter: None,
                     over: None,
-                    model: None,
-                    effort: None,
+                    pin_harness: None,
+                    harnesses: Default::default(),
                 },
             ],
             edges: vec![EdgeDef {
@@ -724,8 +724,8 @@ mod tests {
                     view: None,
                     max_iter: None,
                     over: None,
-                    model: None,
-                    effort: None,
+                    pin_harness: None,
+                    harnesses: Default::default(),
                 },
                 NodeDef {
                     id: "b".into(),
@@ -745,8 +745,8 @@ mod tests {
                     view: None,
                     max_iter: None,
                     over: None,
-                    model: None,
-                    effort: None,
+                    pin_harness: None,
+                    harnesses: Default::default(),
                 },
                 NodeDef {
                     id: "merger".into(),
@@ -766,8 +766,8 @@ mod tests {
                     view: None,
                     max_iter: None,
                     over: None,
-                    model: None,
-                    effort: None,
+                    pin_harness: None,
+                    harnesses: Default::default(),
                 },
             ],
             edges: vec![
@@ -855,8 +855,8 @@ mod tests {
                     view: None,
                     max_iter: None,
                     over: None,
-                    model: None,
-                    effort: None,
+                    pin_harness: None,
+                    harnesses: Default::default(),
                 },
                 NodeDef {
                     id: "implementer".into(),
@@ -869,8 +869,8 @@ mod tests {
                     view: None,
                     max_iter: None,
                     over: None,
-                    model: None,
-                    effort: None,
+                    pin_harness: None,
+                    harnesses: Default::default(),
                 },
             ],
             edges: vec![EdgeDef {
@@ -937,8 +937,8 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         };
         let mk_edge = |src: &str| EdgeDef {
             source: EdgeEndpoint {
@@ -1018,8 +1018,8 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         };
         let mk_edge = |src: &str, port: &str| EdgeDef {
             source: EdgeEndpoint {
@@ -1102,8 +1102,8 @@ mod tests {
                 view: None,
                 max_iter: None,
                 over: None,
-                model: None,
-                effort: None,
+                pin_harness: None,
+                harnesses: Default::default(),
             }],
             edges: Vec::new(),
             loops: Vec::new(),

--- a/crates/pdo-daemon/src/node_primitives.rs
+++ b/crates/pdo-daemon/src/node_primitives.rs
@@ -6,7 +6,7 @@ use serde::Serialize;
 use crate::event_log::{self, EventKind, NodeStatus};
 use crate::pipeline::{self, PipelineDef};
 use crate::worktree_ops::{ensure_sub_worktree, sub_worktree_branch, sub_worktree_path};
-use crate::{blackboard, tmux_session_manager};
+use crate::{blackboard, harness_registry, harness_resolver, tmux_session_manager};
 
 // ---------------------------------------------------------------------------
 // Result types
@@ -49,6 +49,14 @@ pub(crate) struct StartNodeParams<'a> {
     /// / retry callers resolve it and pass it in; the node's own `model:` still
     /// wins over it via [`tmux_session_manager::resolve_node_model`].
     pub default_model: Option<String>,
+    /// Instance default **harness**, already resolved `stored → env → None` by the
+    /// caller (#550, ADR-0046). Same DB-less contract as [`Self::default_model`]:
+    /// feeds the `instance` tier of [`harness_resolver`]; the node's `pin_harness`
+    /// still wins over it.
+    pub default_harness: Option<String>,
+    /// Instance per-harness default model map, resolved fresh by the caller (#550).
+    /// Feeds the fallback tier of the model resolution for the winning harness.
+    pub default_harness_models: std::collections::BTreeMap<String, String>,
     /// Turn-end auto-completion, already resolved `stored → env → default` by the
     /// caller (#433, ADR-0043). Same DB-less contract as [`Self::default_model`]:
     /// the async caller reads [`crate::stored_autocomplete_turn_end`] and passes
@@ -97,6 +105,9 @@ pub(crate) struct StartNodeSpawn {
 /// cannot be carried across the append.
 enum StartNodeTail {
     Agent {
+        /// #550: the resolved harness descriptor (owned; `execute` borrows it into
+        /// [`tmux_session_manager::SessionTail::Agent`]).
+        harness: harness_registry::HarnessDescriptor,
         model: Option<String>,
         effort: Option<String>,
         /// #473: the pinned Claude Code session id (owned mirror of
@@ -130,10 +141,12 @@ impl StartNodeSpawn {
     pub(crate) fn execute(&self) -> anyhow::Result<()> {
         let tail = match &self.tail {
             StartNodeTail::Agent {
+                harness,
                 model,
                 effort,
                 session_id,
             } => tmux_session_manager::SessionTail::Agent {
+                harness,
                 model: model.as_deref(),
                 effort: effort.as_deref(),
                 session_id: session_id.as_deref(),
@@ -358,21 +371,79 @@ pub(crate) fn start_node(params: &StartNodeParams<'_>) -> StartNodeResult {
     } else {
         Vec::new()
     };
-    // #347/#424: resolved once, then used by both the tail and the `NodeStarted`
-    // payload — the payload must record what the flags actually carried, because
-    // that is what the resume path reads back to re-pose `--effort`. Unlike
-    // `spawn_node`, this primitive is synchronous and already holds
-    // `params.default_model`, so nothing has to be hoisted.
-    let resolved_model = tmux_session_manager::resolve_node_model(
-        node.model.as_deref(),
-        params.default_model.as_deref(),
-    );
-    let resolved_effort = tmux_session_manager::resolve_node_effort(node.effort.as_deref());
-    // #473: pin a Claude Code session id for an agent node so the sweep resolves
-    // its transcript by identity and the resume path re-enters it. `None` for a
-    // script node (no claude) — mirrors `node_spawn`. Recorded on `NodeStarted`
-    // below and threaded into the tail.
-    let session_id: Option<String> = (!is_script).then(|| uuid::Uuid::new_v4().to_string());
+    // #550/ADR-0046: resolve the harness (mirrors `node_spawn`), reading model +
+    // effort from the winning harness's entry. `params.default_harness` /
+    // `default_harness_models` are the instance tier, resolved DB-lessly by the
+    // caller. A `script` node resolves no harness.
+    let resolved_harness = if is_script {
+        None
+    } else {
+        // Fold the legacy single `default_model` under `claude` when the per-harness
+        // map is silent for it — the same back-compat fold `stored_default_harness_models`
+        // does, kept here so this DB-less primitive is self-contained given its inputs.
+        let mut default_models = params.default_harness_models.clone();
+        if !default_models.contains_key(harness_registry::CLAUDE) {
+            if let Some(m) = params.default_model.as_deref().filter(|s| !s.is_empty()) {
+                default_models.insert(harness_registry::CLAUDE.to_string(), m.to_string());
+            }
+        }
+        let tiers = harness_resolver::HarnessTiers {
+            node_pin: node.pin_harness.as_deref(),
+            run: None,     // #551
+            project: None, // #552
+            instance_default: params.default_harness.as_deref(),
+        };
+        Some(harness_resolver::resolve(
+            &tiers,
+            &node.harnesses,
+            &default_models,
+        ))
+    };
+    let harness_descriptor = match &resolved_harness {
+        None => None,
+        Some(r) => match harness_registry::resolve(&r.harness) {
+            Some(d) => Some(d),
+            None => {
+                return StartNodeResult {
+                    outcome: PrimitiveOutcome::Rejected {
+                        reason: format!(
+                            "node '{}': unknown harness '{}'",
+                            params.node_id, r.harness
+                        ),
+                    },
+                    events: vec![],
+                    spawn: None,
+                };
+            }
+        },
+    };
+    // AC #10: a missing harness binary is a spawn that cannot happen — reject
+    // (never a 2xx), naming the harness. Skipped under the test seam.
+    if let Some(d) = &harness_descriptor {
+        if params.tmux_cmd_override.is_none() && !tmux_session_manager::binary_available(&d.binary)
+        {
+            return StartNodeResult {
+                outcome: PrimitiveOutcome::Rejected {
+                    reason: format!(
+                        "node '{}': harness '{}' binary '{}' not found on PATH",
+                        params.node_id, d.name, d.binary
+                    ),
+                },
+                events: vec![],
+                spawn: None,
+            };
+        }
+    }
+    // #347/#424/#550: model + effort come from the resolved harness's entry, used
+    // by both the tail and the `NodeStarted` payload (which records what the flags
+    // carried — what the resume path reads back to re-pose `--effort`).
+    let resolved_model = resolved_harness.as_ref().and_then(|r| r.model.clone());
+    let resolved_effort = resolved_harness.as_ref().and_then(|r| r.effort.clone());
+    // #473/#550: pin a session id only for a harness that can honour it (`claude`).
+    let session_id: Option<String> = harness_descriptor
+        .as_ref()
+        .filter(|d| d.pins_session_id())
+        .map(|_| uuid::Uuid::new_v4().to_string());
     let tail = if is_script {
         StartNodeTail::Script {
             timeout_secs: tmux_session_manager::SCRIPT_TIMEOUT_SECS,
@@ -380,8 +451,11 @@ pub(crate) fn start_node(params: &StartNodeParams<'_>) -> StartNodeResult {
         }
     } else {
         StartNodeTail::Agent {
-            model: resolved_model.map(str::to_string),
-            effort: resolved_effort.map(str::to_string),
+            harness: harness_descriptor
+                .clone()
+                .expect("a non-script node resolved a harness descriptor"),
+            model: resolved_model.clone(),
+            effort: resolved_effort.clone(),
             session_id: session_id.clone(),
         }
     };
@@ -400,8 +474,11 @@ pub(crate) fn start_node(params: &StartNodeParams<'_>) -> StartNodeResult {
             // #424: launch-time model + effort, **resolved**. Mirrors the
             // `spawn_node` payload; see the comment there for why the model is
             // recorded even though nothing reads it back yet.
-            "model": resolved_model,
-            "effort": resolved_effort,
+            "model": resolved_model.as_deref(),
+            "effort": resolved_effort.as_deref(),
+            // #550/ADR-0046: the harness resolved at spawn, FROZEN so the resume
+            // path re-poses what was launched (ADR-0007). Mirrors `spawn_node`.
+            "harness": resolved_harness.as_ref().map(|r| r.harness.as_str()),
             // #473: the pinned Claude Code session id — read back by the sweep
             // (transcript resolution) and the resume path. `null` for a script node
             // and every pre-#473 row. Mirrors the `spawn_node` payload.
@@ -775,8 +852,8 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         }
     }
 
@@ -807,8 +884,8 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         }
     }
 
@@ -931,6 +1008,8 @@ mod tests {
             tmux_cmd_override: Some("exec true"),
             docker_cmd_override: None,
             default_model: None,
+            default_harness: None,
+            default_harness_models: Default::default(),
             inject_hook: false,
         };
 
@@ -971,6 +1050,8 @@ mod tests {
             tmux_cmd_override: Some("exec true"),
             docker_cmd_override: None,
             default_model: None,
+            default_harness: None,
+            default_harness_models: Default::default(),
             inject_hook: false,
         };
 
@@ -1017,6 +1098,8 @@ mod tests {
             tmux_cmd_override: Some("exec true"),
             docker_cmd_override: None,
             default_model: None,
+            default_harness: None,
+            default_harness_models: Default::default(),
             inject_hook: true,
         };
         let result = start_node(&params);
@@ -1068,6 +1151,8 @@ mod tests {
             tmux_cmd_override: Some("exec true"),
             docker_cmd_override: None,
             default_model: None,
+            default_harness: None,
+            default_harness_models: Default::default(),
             inject_hook: true,
         };
         let result = start_node(&params);
@@ -1131,6 +1216,8 @@ mod tests {
             tmux_cmd_override: Some("exec true"),
             docker_cmd_override: None,
             default_model: None,
+            default_harness: None,
+            default_harness_models: Default::default(),
             inject_hook: false,
         };
 
@@ -1190,6 +1277,8 @@ mod tests {
             tmux_cmd_override: Some("exec true"),
             docker_cmd_override: None,
             default_model: None,
+            default_harness: None,
+            default_harness_models: Default::default(),
             inject_hook: false,
         };
 
@@ -1235,6 +1324,8 @@ mod tests {
             tmux_cmd_override: Some("exec true"),
             docker_cmd_override: None,
             default_model: None,
+            default_harness: None,
+            default_harness_models: Default::default(),
             inject_hook: false,
         };
 
@@ -1304,6 +1395,8 @@ mod tests {
             tmux_cmd_override: Some("exec true"),
             docker_cmd_override: None,
             default_model: None,
+            default_harness: None,
+            default_harness_models: Default::default(),
             inject_hook: false,
         };
 
@@ -1396,6 +1489,8 @@ mod tests {
             tmux_cmd_override: Some("exec true"),
             docker_cmd_override: None,
             default_model: None,
+            default_harness: None,
+            default_harness_models: Default::default(),
             inject_hook: false,
         };
 
@@ -1461,6 +1556,8 @@ mod tests {
             tmux_cmd_override: Some("exec true"),
             docker_cmd_override: None,
             default_model: None,
+            default_harness: None,
+            default_harness_models: Default::default(),
             inject_hook: false,
         };
 
@@ -1526,6 +1623,8 @@ mod tests {
             tmux_cmd_override: Some("exec true"),
             docker_cmd_override: None,
             default_model: None,
+            default_harness: None,
+            default_harness_models: Default::default(),
             inject_hook: false,
         };
 
@@ -1787,6 +1886,8 @@ mod tests {
             tmux_cmd_override: Some("exec true"),
             docker_cmd_override: None,
             default_model: None,
+            default_harness: None,
+            default_harness_models: Default::default(),
             inject_hook: false,
         };
 

--- a/crates/pdo-daemon/src/node_spawn.rs
+++ b/crates/pdo-daemon/src/node_spawn.rs
@@ -22,8 +22,9 @@ use crate::worktree_ops::{
 };
 use crate::{
     admission, append_event_with, count_global_live_sessions_excluding, event_log,
-    input_resolution, merge_action, panic_payload_message, pipeline, prompt_augmenter,
-    reload_run_state_with, stored_autocomplete_turn_end, stored_default_model, stored_session_cap,
+    harness_registry, harness_resolver, input_resolution, merge_action, panic_payload_message,
+    pipeline, prompt_augmenter, reload_run_state_with, stored_autocomplete_turn_end,
+    stored_default_harness, stored_default_harness_models, stored_session_cap,
     tmux_session_manager, transition_guard, AppState,
 };
 
@@ -315,6 +316,54 @@ pub(crate) async fn spawn_node(
 
     let foreach_context = find_collection_context(spawn_ctx, &node.id, iter);
 
+    // #550/ADR-0046: resolve the harness ONCE, here — before any side effect — so
+    // its result freezes into `NodeStarted` and is re-posed at resume (ADR-0007).
+    // A `script` node launches no agent (ADR-0017), so it resolves no harness. The
+    // binary fail-fast runs BEFORE the sub-worktree is created and BEFORE the
+    // reservation span, so a missing harness leaves no orphan and writes no spawn
+    // event (AC #10 / ADR-0037: never a 2xx for a spawn that did not happen).
+    // Skipped under the tmux command override — the test seam launches a stand-in,
+    // not the real binary.
+    let resolved_harness = if node.node_type == pipeline::NodeType::Script {
+        None
+    } else {
+        let default_harness = stored_default_harness(deps.db).await;
+        let default_models = stored_default_harness_models(deps.db).await;
+        let tiers = harness_resolver::HarnessTiers {
+            node_pin: node.pin_harness.as_deref(),
+            run: None,     // #551
+            project: None, // #552
+            instance_default: default_harness.as_deref(),
+        };
+        Some(harness_resolver::resolve(
+            &tiers,
+            &node.harnesses,
+            &default_models,
+        ))
+    };
+    let harness_descriptor = match &resolved_harness {
+        None => None,
+        Some(r) => match harness_registry::resolve(&r.harness) {
+            Some(d) => Some(d),
+            None => {
+                // Unknown harness — a spawn that cannot happen. Fail fast, naming it.
+                return SpawnOutcome::Failed {
+                    reason: format!("node {}: unknown harness '{}'", node.id, r.harness),
+                };
+            }
+        },
+    };
+    if let Some(d) = &harness_descriptor {
+        if deps.tmux_cmd_override.is_none() && !tmux_session_manager::binary_available(&d.binary) {
+            return SpawnOutcome::Failed {
+                reason: format!(
+                    "node {}: harness '{}' binary '{}' not found on PATH",
+                    node.id, d.name, d.binary
+                ),
+            };
+        }
+    }
+
     let has_sub_worktree = node.node_type == pipeline::NodeType::CodeMutating
         || node.node_type == pipeline::NodeType::Merge;
 
@@ -383,29 +432,24 @@ pub(crate) async fn spawn_node(
         spawn_ctx.worktree_dir.to_path_buf()
     };
 
-    // #347/#424: resolve what the session will actually launch with, BEFORE the
-    // span below. The `NodeStarted` payload appended *inside* the span records the
-    // **resolved** values (what the flags really carried, which is what the resume
-    // path reads back), and `stored_default_model` is async — it cannot be awaited
-    // from the spawn seam further down and still be visible to the append. This is
-    // a move, not an extra read: the same single DB read, earlier.
-    // `__manager__` / `__merge_resolver__` are infra sessions with no NodeDef and
-    // stay at the account default — they don't route through `spawn_node` (#296).
-    let default_effective = stored_default_model(deps.db).await;
-    let resolved_model = tmux_session_manager::resolve_node_model(
-        node.model.as_deref(),
-        default_effective.as_deref(),
-    );
-    let resolved_effort = tmux_session_manager::resolve_node_effort(node.effort.as_deref());
-    // #473: pin a Claude Code session id for an AGENT node so its transcript is
-    // `<uuid>.jsonl` and the liveness sweep resolves it by identity — never by the
-    // newest `.jsonl` in a cwd it shares with the manager and sibling non-CM nodes.
-    // Recorded on `NodeStarted` (below) so the resume path and the sweep read it
-    // back; a fresh id per spawn means a `restart_node` of the same iteration gets
-    // its own transcript. A `script` node launches no `claude`, so it gets no id
-    // (`null` in the payload) — nothing would resolve it and nothing resumes it.
-    let session_id: Option<String> =
-        (node.node_type != pipeline::NodeType::Script).then(|| uuid::Uuid::new_v4().to_string());
+    // #550/#347/#424: the model and effort come from the harness resolved above
+    // (post node → instance precedence, post empty-string collapse), read from the
+    // winning harness's entry — NOT the raw NodeDef. The `NodeStarted` payload
+    // records these resolved values (what the flags really carried, which the
+    // resume path reads back). `__manager__` / `__merge_resolver__` are infra
+    // sessions with no NodeDef and stay at the account default — they don't route
+    // through `spawn_node`.
+    let resolved_model = resolved_harness.as_ref().and_then(|r| r.model.clone());
+    let resolved_effort = resolved_harness.as_ref().and_then(|r| r.effort.clone());
+    // #473/#550: pin a session id only for a harness that can honour it
+    // (`claude`); a harness that cannot (`opencode`: a fresh id errors) gets
+    // `None` and is attributed by working dir. Recorded on `NodeStarted` so the
+    // resume path and the sweep read it back; a fresh id per spawn means a
+    // `restart_node` of the same iteration gets its own transcript.
+    let session_id: Option<String> = harness_descriptor
+        .as_ref()
+        .filter(|d| d.pins_session_id())
+        .map(|_| uuid::Uuid::new_v4().to_string());
 
     // Panic/cancellation-isolated spawn window (#279). Everything from here to
     // the `NodeStarted` append can panic (`build_full_prompt`, image discovery,
@@ -577,8 +621,12 @@ pub(crate) async fn spawn_node(
                 // reads it yet: the meaning of an effort level depends on the
                 // model (supported levels and the default both vary per model),
                 // so storing the effort alone would store half a fact.
-                "model": resolved_model,
-                "effort": resolved_effort,
+                "model": resolved_model.as_deref(),
+                "effort": resolved_effort.as_deref(),
+                // #550/ADR-0046: the harness resolved at spawn, FROZEN here so the
+                // resume path re-poses what was launched, never what the YAML or a
+                // tier says now (ADR-0007). `null` for a `script` node (no agent).
+                "harness": resolved_harness.as_ref().map(|r| r.harness.as_str()),
                 // #473: the pinned Claude Code session id the agent launches with
                 // (`claude --session-id <uuid>`). The sweep resolves this node's
                 // transcript by it (`<uuid>.jsonl`), and the resume path re-enters
@@ -661,10 +709,15 @@ pub(crate) async fn spawn_node(
         }
     } else {
         // Resolved above the panic span so the `NodeStarted` payload could record
-        // the same values the flags carry (#347/#424/#473).
+        // the same values the flags carry (#347/#424/#473/#550). A non-`script`
+        // node always has a resolved descriptor (the fail-fast returned otherwise).
+        let descriptor = harness_descriptor
+            .as_ref()
+            .expect("a non-script node resolved a harness descriptor");
         tmux_session_manager::SessionTail::Agent {
-            model: resolved_model,
-            effort: resolved_effort,
+            harness: descriptor,
+            model: resolved_model.as_deref(),
+            effort: resolved_effort.as_deref(),
             session_id: session_id.as_deref(),
         }
     };

--- a/crates/pdo-daemon/src/outputs_validator.rs
+++ b/crates/pdo-daemon/src/outputs_validator.rs
@@ -307,8 +307,8 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         }
     }
 

--- a/crates/pdo-daemon/src/pipeline.rs
+++ b/crates/pdo-daemon/src/pipeline.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::Path;
 
 use serde::{Deserialize, Serialize};
@@ -139,27 +139,26 @@ pub(crate) struct NodeDef {
     pub max_iter: Option<serde_yaml::Value>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub over: Option<String>,
-    /// Optional per-node model override (#296): free-text pass-through to
-    /// `claude --model <x>` when the node spawns. Absent ⇒ account default
-    /// (no flag emitted, launch command byte-identical to the legacy path).
-    /// Semantic, not layout — included in the pipeline diff (ADR-0001).
+    /// Optional pinned harness (#550, ADR-0046): the harness this node **requires**
+    /// (`claude`, `opencode`). A pin both selects the harness and shields it from
+    /// every coarser tier (Run / Projet / instance). Absent ⇒ the node follows the
+    /// tier above (in this slice: instance default, else the `claude` floor).
+    /// Free-text pass-through (ADR-0001: no closed enum). Semantic, not layout.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub model: Option<String>,
-    /// Optional per-node reasoning-effort override (#424): free-text pass-through
-    /// to `claude --effort <level>` when the node spawns. Absent ⇒ no flag emitted,
-    /// launch command byte-identical to the legacy path.
+    pub pin_harness: Option<String>,
+    /// Per-harness settings map (#550, ADR-0046): `harnesses.<name> = {model,
+    /// effort}`. The model and effort are **not** axes with their own precedence —
+    /// they are read from the entry of the *winning* harness, so the same node
+    /// stays executable on `claude` and `opencode` instead of launching every node
+    /// with a slug the other harness rejects. This replaces the flat `model:` /
+    /// `effort:` of #296/#424, which the pipeline migrator folds into
+    /// `harnesses.claude.*`.
     ///
-    /// Orthogonal to `model`: the model says *which* agent runs, the effort says
-    /// *how long it thinks*. Unlike `--model` (an invalid id makes `claude` exit
-    /// non-zero), an invalid `--effort` is only a stderr warning and the session
-    /// starts at the default — a silent wrong value. That is why the UI proposes a
-    /// closed set while the wire stays open (ADR-0001: sharp tool, no closed enum
-    /// that would perish at every model release).
-    ///
-    /// Semantic, not layout — included in the pipeline diff and in the library
-    /// content hash (`pipeline_semantics`).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub effort: Option<String>,
+    /// `BTreeMap` for a deterministic serialization + canonical form. Semantic, not
+    /// layout — included in the pipeline diff and the library content hash
+    /// (`pipeline_semantics`).
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub harnesses: BTreeMap<String, crate::harness_resolver::HarnessEntry>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -487,7 +486,88 @@ pub(crate) fn normalize_node_value(
         }
         _ => {}
     }
+
+    // #550: fold a legacy flat `model:` / `effort:` into `harnesses.claude.*` so
+    // that a parse is lossless even before the on-disk migrator has rewritten the
+    // file. The migrator persists the same fold; this is the in-memory safety net
+    // that keeps `harnesses` the single source the resolver reads.
+    fold_flat_model_effort_into_harnesses(node_map);
+
     Ok(diagnostics)
+}
+
+/// Fold a node's legacy flat `model:` / `effort:` keys (#296/#424) into
+/// `harnesses.claude.{model, effort}` (#550, ADR-0046), removing the flat keys.
+///
+/// Shared by [`normalize_node_value`] (lossless in-memory parse) and the pipeline
+/// migrator (persisted rewrite), so both fold identically. Returns `true` iff it
+/// removed a flat key — i.e. the raw YAML changed — which is what the migrator's
+/// `needs_migration` guard keys off.
+///
+/// An explicit `harnesses.claude` entry is authoritative: a flat value fills a
+/// slot only when the map has none, so a second run is a no-op (idempotent).
+pub(crate) fn fold_flat_model_effort_into_harnesses(node_map: &mut serde_yaml::Mapping) -> bool {
+    let removed_model = node_map.remove(serde_yaml::Value::String("model".into()));
+    let removed_effort = node_map.remove(serde_yaml::Value::String("effort".into()));
+    let changed = removed_model.is_some() || removed_effort.is_some();
+
+    let flat_model = removed_model
+        .as_ref()
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+    let flat_effort = removed_effort
+        .as_ref()
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+    if flat_model.is_none() && flat_effort.is_none() {
+        return changed; // the flat keys were absent or empty — nothing to carry
+    }
+
+    let harnesses_key = serde_yaml::Value::String("harnesses".into());
+    if !node_map
+        .get(&harnesses_key)
+        .map(serde_yaml::Value::is_mapping)
+        .unwrap_or(false)
+    {
+        node_map.insert(
+            harnesses_key.clone(),
+            serde_yaml::Value::Mapping(serde_yaml::Mapping::new()),
+        );
+    }
+    let harnesses = node_map
+        .get_mut(&harnesses_key)
+        .and_then(serde_yaml::Value::as_mapping_mut)
+        .expect("harnesses just ensured to be a mapping");
+
+    let claude_key = serde_yaml::Value::String(crate::harness_registry::CLAUDE.into());
+    if !harnesses
+        .get(&claude_key)
+        .map(serde_yaml::Value::is_mapping)
+        .unwrap_or(false)
+    {
+        harnesses.insert(
+            claude_key.clone(),
+            serde_yaml::Value::Mapping(serde_yaml::Mapping::new()),
+        );
+    }
+    let claude = harnesses
+        .get_mut(&claude_key)
+        .and_then(serde_yaml::Value::as_mapping_mut)
+        .expect("harnesses.claude just ensured to be a mapping");
+
+    if let Some(m) = flat_model {
+        claude
+            .entry(serde_yaml::Value::String("model".into()))
+            .or_insert(serde_yaml::Value::String(m));
+    }
+    if let Some(e) = flat_effort {
+        claude
+            .entry(serde_yaml::Value::String("effort".into()))
+            .or_insert(serde_yaml::Value::String(e));
+    }
+    changed
 }
 
 pub(crate) fn parse_pipeline(yaml: &str) -> Result<ParseResult, ParseError> {
@@ -2451,8 +2531,8 @@ nodes:
             view: None,
             max_iter: None,
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         };
         let yaml = serde_yaml::to_string(&node).unwrap();
         assert!(yaml.contains("type: script"), "serializes to kebab: {yaml}");
@@ -3614,9 +3694,15 @@ nodes:
             .iter()
             .find(|n| n.id == "ab000001")
             .unwrap();
-        assert_eq!(node.model.as_deref(), Some("opus"));
+        // #550: a flat `model:` is folded into `harnesses.claude.model` on parse.
+        assert_eq!(
+            node.harnesses
+                .get("claude")
+                .and_then(|e| e.model.as_deref()),
+            Some("opus")
+        );
 
-        // Round-trips: re-serialize, re-parse — the model survives.
+        // Round-trips: re-serialize, re-parse — the model survives (now under the map).
         let serialized = serde_yaml::to_string(&result.pipeline).unwrap();
         let result2 = parse_pipeline(&serialized).unwrap();
         let node2 = result2
@@ -3625,7 +3711,13 @@ nodes:
             .iter()
             .find(|n| n.id == "ab000001")
             .unwrap();
-        assert_eq!(node2.model.as_deref(), Some("opus"));
+        assert_eq!(
+            node2
+                .harnesses
+                .get("claude")
+                .and_then(|e| e.model.as_deref()),
+            Some("opus")
+        );
     }
 
     #[test]
@@ -3651,10 +3743,11 @@ nodes:
             .iter()
             .find(|n| n.id == "ab000001")
             .unwrap();
-        assert!(node.model.is_none());
+        assert!(node.harnesses.is_empty());
         // Absent ⇒ never serialized (clean file, round-trips by absence).
         let serialized = serde_yaml::to_string(&result.pipeline).unwrap();
         assert!(!serialized.contains("model:"));
+        assert!(!serialized.contains("harnesses:"));
     }
 
     #[test]
@@ -3683,12 +3776,12 @@ nodes:
 "#,
         );
         let result = parse_pipeline(&yaml).unwrap();
+        // #550: flat `effort:` is folded into `harnesses.claude.effort` on parse.
         let find = |p: &PipelineDef, id: &str| {
             p.nodes
                 .iter()
                 .find(|n| n.id == id)
-                .map(|n| n.effort.clone())
-                .unwrap()
+                .and_then(|n| n.harnesses.get("claude").and_then(|e| e.effort.clone()))
         };
         assert_eq!(find(&result.pipeline, "ab000001").as_deref(), Some("low"));
         // Orthogonal to the model — both land, neither clobbers the other.
@@ -3699,8 +3792,9 @@ nodes:
                 .iter()
                 .find(|n| n.id == "ab000001")
                 .unwrap()
-                .model
-                .as_deref(),
+                .harnesses
+                .get("claude")
+                .and_then(|e| e.model.as_deref()),
             Some("opus")
         );
         // An unknown level parses fine (pass-through, no closed enum).
@@ -3740,7 +3834,7 @@ nodes:
             .iter()
             .find(|n| n.id == "ab000001")
             .unwrap();
-        assert!(node.effort.is_none());
+        assert!(node.harnesses.is_empty());
         // Absent ⇒ never serialized (clean file, round-trips by absence).
         let serialized = serde_yaml::to_string(&result.pipeline).unwrap();
         assert!(!serialized.contains("effort:"));

--- a/crates/pdo-daemon/src/pipeline_migrator.rs
+++ b/crates/pdo-daemon/src/pipeline_migrator.rs
@@ -87,6 +87,13 @@ fn needs_migration(yaml_value: &serde_yaml::Value) -> bool {
         return true;
     }
     for node in nodes {
+        // #550/ADR-0046: a flat `model:` / `effort:` on ANY node (including a
+        // `merge` node, which spawns an agent) migrates under `harnesses.claude.*`.
+        // Checked before the structural-node `continue` below so a `merge` node's
+        // flat fields are not skipped.
+        if node.get("model").is_some() || node.get("effort").is_some() {
+            return true;
+        }
         let node_type = node.get("type").and_then(|v| v.as_str()).unwrap_or("");
         if matches!(node_type, "start" | "end" | "switch" | "loop" | "merge") {
             continue;
@@ -338,6 +345,20 @@ pub(crate) fn migrate_pipeline_yaml(
     }
 
     inject_start_end_nodes(&mut doc);
+
+    // #550/ADR-0046: fold every node's flat `model:` / `effort:` into
+    // `harnesses.claude.*`, removing the flat keys. Reuses the exact fold
+    // `pipeline::normalize_node_value` runs, so a persisted rewrite and an
+    // in-memory parse agree — and it is idempotent (an already-folded node is a
+    // no-op). Runs after `inject_start_end_nodes` so injected Start/End nodes
+    // (which carry neither) are harmlessly visited too.
+    if let Some(nodes) = doc.get_mut("nodes").and_then(|n| n.as_sequence_mut()) {
+        for node in nodes.iter_mut() {
+            if let Some(mapping) = node.as_mapping_mut() {
+                pipeline::fold_flat_model_effort_into_harnesses(mapping);
+            }
+        }
+    }
 
     let yaml_text =
         serde_yaml::to_string(&doc).map_err(|e| format!("YAML serialize error: {e}"))?;
@@ -1692,6 +1713,105 @@ edges: []
     }
 
     #[test]
+    fn migrates_flat_model_effort_into_harnesses_claude() {
+        // #550/ADR-0046: a pipeline whose only legacy trait is a flat model/effort
+        // must fold them under `harnesses.claude` and drop the flat keys — then a
+        // second run is a no-op (idempotent).
+        let yaml = r#"
+name: test
+version: "1.0"
+nodes:
+  - id: start
+    name: Start
+    type: start
+    outputs:
+      - name: user_prompt
+  - id: aBcD1234
+    name: implementer
+    type: code-mutating
+    model: opus
+    effort: low
+    outputs:
+      - name: code
+        side: right
+    view: { x: 100, y: 160 }
+  - id: end
+    name: End
+    type: end
+    inputs:
+      - name: result
+edges: []
+"#;
+        let result = migrate_pipeline_yaml(yaml, Path::new("/tmp/test.yaml")).unwrap();
+        assert!(
+            result.migrated,
+            "a flat model/effort must trigger migration"
+        );
+        let parsed: serde_yaml::Value = serde_yaml::from_str(&result.yaml_text).unwrap();
+        let node = parsed["nodes"]
+            .as_sequence()
+            .unwrap()
+            .iter()
+            .find(|n| n["name"].as_str() == Some("implementer"))
+            .unwrap();
+        assert!(node.get("model").is_none(), "flat model removed");
+        assert!(node.get("effort").is_none(), "flat effort removed");
+        assert_eq!(node["harnesses"]["claude"]["model"].as_str(), Some("opus"));
+        assert_eq!(node["harnesses"]["claude"]["effort"].as_str(), Some("low"));
+
+        // Idempotent: re-running the migrated YAML is a no-op.
+        let again = migrate_pipeline_yaml(&result.yaml_text, Path::new("/tmp/test.yaml")).unwrap();
+        assert!(
+            !again.migrated,
+            "an already-folded pipeline must not migrate again"
+        );
+    }
+
+    #[test]
+    fn migrates_flat_model_effort_on_a_merge_node() {
+        // #550: a `merge` node spawns an agent, so its flat model/effort migrate too
+        // — the `needs_migration` clause runs before the structural-node `continue`.
+        let yaml = r#"
+name: test
+version: "1.0"
+nodes:
+  - id: start
+    name: Start
+    type: start
+    outputs:
+      - name: user_prompt
+  - id: aBcD1234
+    name: merger
+    type: merge
+    model: sonnet
+    outputs:
+      - name: merged
+        side: right
+    view: { x: 100, y: 160 }
+  - id: end
+    name: End
+    type: end
+    inputs:
+      - name: result
+edges: []
+"#;
+        let result = migrate_pipeline_yaml(yaml, Path::new("/tmp/test.yaml")).unwrap();
+        assert!(result.migrated, "a merge node's flat model must migrate");
+        let parsed: serde_yaml::Value = serde_yaml::from_str(&result.yaml_text).unwrap();
+        let node = parsed["nodes"]
+            .as_sequence()
+            .unwrap()
+            .iter()
+            .find(|n| n["name"].as_str() == Some("merger"))
+            .unwrap();
+        assert!(node.get("model").is_none());
+        assert_eq!(
+            node["harnesses"]["claude"]["model"].as_str(),
+            Some("sonnet")
+        );
+    }
+
+    #[test]
     fn drops_declared_inputs_on_regular_nodes() {
         // #149: inputs are emergent (derived from edges). The migrator strips the
         // now-redundant declared `inputs` from doc-only / code-mutating nodes.
@@ -2347,8 +2467,8 @@ edges:
             view: None,
             max_iter: None,
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         }
     }
 
@@ -2379,8 +2499,8 @@ edges:
             view: None,
             max_iter: None,
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         }
     }
 
@@ -2411,8 +2531,8 @@ edges:
             view: None,
             max_iter: None,
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         }
     }
 

--- a/crates/pdo-daemon/src/pipeline_semantics.rs
+++ b/crates/pdo-daemon/src/pipeline_semantics.rs
@@ -137,12 +137,16 @@ struct NodeProjection<'a> {
     name: &'a str,
     node_type: &'a NodeType,
     interactive: bool,
-    model: Option<&'a str>,
-    /// Per-node reasoning-effort override (#424). Semantic for the same reason as
-    /// `model`: it changes how the agent behaves, so a pipeline that differs only
-    /// by an effort level is *not* the same pipeline — the library drift badge and
-    /// the pipeline diff must both see it.
-    effort: Option<&'a str>,
+    /// Pinned harness (#550, ADR-0046). Semantic: pinning a node to `opencode`
+    /// changes what runs it, so a pipeline that differs only by a pin is *not* the
+    /// same pipeline.
+    pin_harness: Option<&'a str>,
+    /// Per-harness `{model, effort}` map (#550, ADR-0046) — replaces the flat
+    /// `model:`/`effort:` of #296/#424. Semantic for the same reason: it changes
+    /// how the agent behaves, so the library drift badge and the pipeline diff must
+    /// both see it. A `BTreeMap` so the canonical form is key-ordered; empty ⇒
+    /// serialized as `{}` (a plain claude node with no settings).
+    harnesses: &'a std::collections::BTreeMap<String, crate::harness_resolver::HarnessEntry>,
     max_iter: Option<serde_json::Value>,
     /// Legacy per-node collection driver. The frontend serializer no longer emits
     /// it, so it is absent from `SEMANTIC_FIELDS.node`; it is still a behavioural
@@ -164,8 +168,8 @@ impl<'a> NodeProjection<'a> {
             view,
             max_iter,
             over,
-            model,
-            effort,
+            pin_harness,
+            harnesses,
         } = node;
         let _layout = view; // LAYOUT_FIELDS["node"]
         Self {
@@ -173,8 +177,8 @@ impl<'a> NodeProjection<'a> {
             name,
             node_type,
             interactive: *interactive,
-            model: model.as_deref(),
-            effort: effort.as_deref(),
+            pin_harness: pin_harness.as_deref(),
+            harnesses,
             max_iter: max_iter.as_ref().map(canon_yaml),
             over: over.as_deref(),
             inputs: inputs.iter().map(PortProjection::of).collect(),
@@ -462,6 +466,26 @@ mod tests {
                 // launch a stale copy believing it current.
                 "per-node effort",
                 base.replace("  type: doc-only", "  type: doc-only\n  effort: low"),
+            ),
+            (
+                // #550/ADR-0046: a pinned harness changes what runs the node, so it
+                // is a semantic change — the library drift badge and the diff see it.
+                "pin_harness",
+                base.replace(
+                    "  type: doc-only",
+                    "  type: doc-only\n  pin_harness: opencode",
+                ),
+            ),
+            (
+                // #550/ADR-0046: the per-harness `{model, effort}` map is semantic
+                // (it replaces the flat model/effort). Authored directly under
+                // `harnesses.claude` here (not folded from a flat key) to pin the map
+                // projection itself.
+                "harnesses map",
+                base.replace(
+                    "  type: doc-only",
+                    "  type: doc-only\n  harnesses:\n    claude:\n      model: opus",
+                ),
             ),
             (
                 "edge condition",

--- a/crates/pdo-daemon/src/prompt_augmenter.rs
+++ b/crates/pdo-daemon/src/prompt_augmenter.rs
@@ -978,8 +978,8 @@ mod tests {
                 view: None,
                 max_iter: None,
                 over: None,
-                model: None,
-                effort: None,
+                pin_harness: None,
+                harnesses: Default::default(),
             }],
             edges: vec![],
             loops: Vec::new(),
@@ -1121,8 +1121,8 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         });
         pipeline.edges.push(EdgeDef {
             source: EdgeEndpoint {
@@ -1258,8 +1258,8 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         });
         pipeline.edges.push(EdgeDef {
             source: EdgeEndpoint {
@@ -1318,8 +1318,8 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         });
 
         let node = &pipeline.nodes[1]; // implementer
@@ -1350,8 +1350,8 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         });
         pipeline.edges.push(EdgeDef {
             source: EdgeEndpoint {
@@ -1396,8 +1396,8 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         });
         pipeline.edges.push(EdgeDef {
             source: EdgeEndpoint {
@@ -1546,8 +1546,8 @@ mod tests {
                     view: None,
                     max_iter: None,
                     over: None,
-                    model: None,
-                    effort: None,
+                    pin_harness: None,
+                    harnesses: Default::default(),
                 },
                 NodeDef {
                     id: "researcher".into(),
@@ -1567,8 +1567,8 @@ mod tests {
                     view: None,
                     max_iter: None,
                     over: None,
-                    model: None,
-                    effort: None,
+                    pin_harness: None,
+                    harnesses: Default::default(),
                 },
                 NodeDef {
                     id: "implementer".into(),
@@ -1607,8 +1607,8 @@ mod tests {
                     view: None,
                     max_iter: None,
                     over: None,
-                    model: None,
-                    effort: None,
+                    pin_harness: None,
+                    harnesses: Default::default(),
                 },
             ],
             edges: vec![
@@ -1716,8 +1716,8 @@ mod tests {
                 view: None,
                 max_iter: None,
                 over: None,
-                model: None,
-                effort: None,
+                pin_harness: None,
+                harnesses: Default::default(),
             }],
             edges: vec![],
             loops: Vec::new(),
@@ -1975,8 +1975,8 @@ mod tests {
                 view: None,
                 max_iter: None,
                 over: None,
-                model: None,
-                effort: None,
+                pin_harness: None,
+                harnesses: Default::default(),
             }],
             edges: vec![],
             loops: Vec::new(),
@@ -2026,8 +2026,8 @@ mod tests {
                 view: None,
                 max_iter: None,
                 over: None,
-                model: None,
-                effort: None,
+                pin_harness: None,
+                harnesses: Default::default(),
             }],
             edges: vec![],
             loops: Vec::new(),
@@ -2072,8 +2072,8 @@ mod tests {
                 view: None,
                 max_iter: None,
                 over: None,
-                model: None,
-                effort: None,
+                pin_harness: None,
+                harnesses: Default::default(),
             }],
             edges: vec![],
             loops: Vec::new(),

--- a/crates/pdo-daemon/src/run_advance.rs
+++ b/crates/pdo-daemon/src/run_advance.rs
@@ -477,8 +477,8 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         }
     }
 

--- a/crates/pdo-daemon/src/run_command.rs
+++ b/crates/pdo-daemon/src/run_command.rs
@@ -2285,8 +2285,8 @@ mod tests {
                 view: None,
                 max_iter: None,
                 over: None,
-                model: None,
-                effort: None,
+                pin_harness: None,
+                harnesses: Default::default(),
             }],
             edges: vec![EdgeDef {
                 source: EdgeEndpoint {
@@ -2338,8 +2338,8 @@ mod tests {
                 view: None,
                 max_iter: None,
                 over: None,
-                model: None,
-                effort: None,
+                pin_harness: None,
+                harnesses: Default::default(),
             }],
             edges: vec![EdgeDef {
                 source: EdgeEndpoint {

--- a/crates/pdo-daemon/src/scheduler.rs
+++ b/crates/pdo-daemon/src/scheduler.rs
@@ -1193,8 +1193,8 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         }
     }
 
@@ -1217,8 +1217,8 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         }
     }
 
@@ -2502,8 +2502,8 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         }
     }
 
@@ -3230,8 +3230,8 @@ mod tests {
                 max_iter,
             ))),
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         }
     }
 
@@ -3755,8 +3755,8 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         }
     }
 

--- a/crates/pdo-daemon/src/scheduler_dispatcher.rs
+++ b/crates/pdo-daemon/src/scheduler_dispatcher.rs
@@ -84,8 +84,8 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         }
     }
 

--- a/crates/pdo-daemon/src/switch_router.rs
+++ b/crates/pdo-daemon/src/switch_router.rs
@@ -58,8 +58,8 @@ mod tests {
             view: None,
             max_iter: None,
             over: None,
-            model: None,
-            effort: None,
+            pin_harness: None,
+            harnesses: Default::default(),
         }
     }
 

--- a/crates/pdo-daemon/src/tmux_session_manager.rs
+++ b/crates/pdo-daemon/src/tmux_session_manager.rs
@@ -70,6 +70,13 @@ pub enum SessionTail<'a> {
     /// Agent node / manager / merge-resolver. `model` is the per-node model
     /// override (#296); `None` ⇒ account default (byte-identical legacy launch).
     Agent {
+        /// The resolved harness descriptor (#550, ADR-0045). Its `launch`
+        /// template renders the tail via [`crate::harness_argv`]; its `env` block
+        /// is exported before the tail (that is where `claude`'s CCR suppression
+        /// now comes from — AC #4). For infra sessions and the byte-identity gate
+        /// this is the `claude` descriptor, whose template reproduces the legacy
+        /// tail exactly once its holes are empty.
+        harness: &'a crate::harness_registry::HarnessDescriptor,
         model: Option<&'a str>,
         /// Per-node reasoning-effort override (#424). `None` *or* an empty string
         /// ⇒ no `--effort`, byte-identical tail. A `Script` tail carries no such
@@ -233,19 +240,35 @@ fn wrap_tail_in_docker_exec(
 /// tmux pane), writes `~/.claude.json`, and force-exits via `kill(getpid(),
 /// SIGKILL)`. That's the "Tester dies silently 20–60 s in" bug.
 ///
-/// `extra_env` are additional `export K=V` pairs injected *after* the base four
-/// and the CCR suppression, before the tail. Agents pass `&[]`, so the emitted
-/// bytes are identical to the legacy command (the #296 byte-identity discipline)
-/// — only `script` nodes populate it with the `PDO_INPUT_*`/`PDO_OUTPUT_*`/…
-/// catalogue.
+/// `harness_env` are the harness descriptor's env pairs (`claude`'s CCR
+/// suppression — AC #4), exported *after* the base four and *before* `extra_env`.
+/// For the `claude` descriptor this is exactly `[(CCR, "1")]`, so the emitted
+/// bytes match the legacy hard-coded `export CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1`
+/// — the value is rendered by [`sh_quote_arg`] (bare-if-safe), which leaves `1`
+/// unquoted, preserving byte-identity. `script` / `shell` tails pass the same
+/// forced `[(CCR, "1")]` (the wrapper still poses it — a hand-typed `claude` in a
+/// run shell depends on it, CONTEXT.md §*Shell de run*).
+///
+/// `extra_env` are additional `export K=V` pairs injected after `harness_env`,
+/// before the tail. Agents pass `&[]`, so the emitted bytes are identical to the
+/// legacy command (the #296 byte-identity discipline) — only `script` nodes
+/// populate it with the `PDO_INPUT_*`/`PDO_OUTPUT_*`/… catalogue.
 fn wrap_with_env(
     run_id: &str,
     node_id: &str,
     iter: i64,
     daemon_port: u16,
+    harness_env: &[(String, String)],
     extra_env: &[(String, String)],
     tail_cmd: &str,
 ) -> String {
+    // #550/AC #4: the harness env (CCR for `claude`) — `sh_quote_arg` keeps a safe
+    // value like `1` bare, so `export CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1`
+    // is byte-identical to the legacy hard-coded export.
+    let harness_exports: String = harness_env
+        .iter()
+        .map(|(k, v)| format!("export {k}={} && ", sh_quote_arg(v)))
+        .collect();
     let extra_exports: String = extra_env
         .iter()
         .map(|(k, v)| format!("export {k}={} && ", sh_single_quote(v)))
@@ -256,8 +279,7 @@ fn wrap_with_env(
          export PDO_NODE_ID={node_id_q} && \
          export PDO_NODE_ITER={iter_q} && \
          export PDO_DAEMON_URL={daemon_url_q} && \
-         export CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1 && \
-         {extra_exports}{tail_cmd}",
+         {harness_exports}{extra_exports}{tail_cmd}",
         run_id_q = sh_single_quote(run_id),
         node_id_q = sh_single_quote(node_id),
         iter_q = sh_single_quote(&iter.to_string()),
@@ -288,64 +310,56 @@ fn wrap_with_env(
 /// exports `wrap_with_env` set, so no env has to be threaded into the JSON.
 pub(crate) const STOP_HOOK_SETTINGS_JSON: &str = r#"{"hooks":{"Stop":[{"matcher":"","hooks":[{"type":"command","command":"pdo complete --auto; exit 0"}]}]}}"#;
 
-/// Build the `exec claude …` tail for an agent node. A non-empty `model`
-/// inserts `--model '<m>'`, a non-empty `effort` inserts `--effort '<lvl>'`
-/// after it, then a `Some` `settings_path` inserts `--settings '<file>'` (#433),
-/// and a non-empty `session_id` inserts `--session-id '<uuid>'` last (#473);
-/// `None` *or* an empty string on all of them reproduces the legacy command
-/// byte-for-byte (the state infra sessions launch in).
+/// Build the agent tail by rendering the harness descriptor's launch template
+/// through [`crate::harness_argv`] (#550, ADR-0045). The caller shell-quotes each
+/// hole value here — where the shell semantics live — and the renderer only
+/// substitutes and drops empty-hole tokens. For the `claude` descriptor with all
+/// holes empty this reproduces the legacy `build_agent_tail` **byte for byte**
+/// (the #550 gate, pinned by the goldens in `harness_argv`): a non-empty `model`
+/// inserts `--model '<m>'`, `effort` inserts `--effort '<lvl>'` after it, a `Some`
+/// `settings_path` inserts `--settings '<file>'` (#433), and a non-empty
+/// `session_id` inserts `--session-id '<uuid>'` last (#473). `None` *or* an empty
+/// string on any of them drops its token (the `Some("")` last-resort guard of
+/// #347: a stray `""` never reaches the tail as `--model ''`).
 fn build_agent_tail(
+    descriptor: &crate::harness_registry::HarnessDescriptor,
     prompt_path: &Path,
     model: Option<&str>,
     effort: Option<&str>,
     settings_path: Option<&Path>,
     session_id: Option<&str>,
 ) -> String {
-    // A non-empty `Some` ⇒ a single-quoted `--model '<m>' ` with a trailing
-    // space; `None` OR `Some("")` ⇒ empty string, so the command collapses to
-    // the exact legacy literal (one space before the `"$(cat …)"`). The
-    // empty-string arm is the last-resort guard (#347): every upstream tier
-    // already filters "", but a missed source would otherwise emit `--model ''`
-    // and crash `claude` — keeping the guard here covers them all at once.
-    let model_flag = match model {
-        Some(m) if !m.is_empty() => format!("--model {} ", sh_single_quote(m)),
-        _ => String::new(),
+    let quote_opt = |v: Option<&str>| {
+        v.filter(|s| !s.is_empty())
+            .map(sh_single_quote)
+            .unwrap_or_default()
     };
-    // #424: same shape as the model flag, and deliberately placed *after* it —
-    // the tail test pins the substring `--dangerously-skip-permissions --model
-    // '<m>' `, so inserting before would break it for nothing. `None` OR
-    // `Some("")` ⇒ empty fragment, so the no-effort command collapses to the exact
-    // legacy literal (one space before the `"$(cat …)"`).
-    let effort_flag = match effort {
-        Some(e) if !e.is_empty() => format!("--effort {} ", sh_single_quote(e)),
-        _ => String::new(),
+    let holes = crate::harness_argv::Holes {
+        prompt: format!(
+            "\"$(cat {})\"",
+            sh_single_quote(&prompt_path.to_string_lossy())
+        ),
+        model: quote_opt(model),
+        effort: quote_opt(effort),
+        settings: settings_path
+            .map(|p| sh_single_quote(&p.to_string_lossy()))
+            .unwrap_or_default(),
+        session_id: quote_opt(session_id),
+        // The launch template carries no `{resume}` hole.
+        resume: String::new(),
     };
-    // #433: `--settings '<file>'` arms the turn-end `Stop` hook. Placed AFTER
-    // `--effort` — the position that leaves every model/effort substring test
-    // untouched. `None` ⇒ empty fragment, so the hook-off tail stays
-    // byte-identical to the legacy launch.
-    let settings_flag = match settings_path {
-        Some(p) => format!("--settings {} ", sh_single_quote(&p.to_string_lossy())),
-        None => String::new(),
-    };
-    // #473: pin the Claude Code session id so its transcript is `<uuid>.jsonl` and
-    // the liveness sweep resolves it by identity, never by newest-mtime in a shared
-    // cwd. Placed LAST (after model/effort/settings) so the model/effort byte-identity
-    // substrings the #296/#424 tests pin stay contiguous. `None` OR `Some("")` ⇒
-    // empty fragment (infra sessions): the tail then reproduces the legacy launch
-    // byte-for-byte, so the pre-#473 "no id" behaviour is what `None` still means.
-    let session_flag = match session_id {
-        Some(s) if !s.is_empty() => format!("--session-id {} ", sh_single_quote(s)),
-        _ => String::new(),
-    };
-    format!(
-        "exec claude --dangerously-skip-permissions {}{}{}{}\"$(cat {})\"",
-        model_flag,
-        effort_flag,
-        settings_flag,
-        session_flag,
-        sh_single_quote(&prompt_path.to_string_lossy())
-    )
+    crate::harness_argv::render(&descriptor.launch, &holes)
+}
+
+/// The `claude` CCR suppression, forced by the wrapper for `script` / `shell`
+/// tails (AC #4): those run bash, not an agent, so they carry no descriptor — but
+/// a hand-typed `claude` in a run shell still depends on it (CONTEXT.md §*Shell de
+/// run*). An **agent** tail gets this from its descriptor's `env` instead.
+fn forced_ccr_env() -> Vec<(String, String)> {
+    vec![(
+        "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC".to_string(),
+        "1".to_string(),
+    )]
 }
 
 /// Build the bash tail for a `script` node (#248 / ADR-0017).
@@ -406,10 +420,16 @@ pub fn build_tmux_script(
     settings_path: Option<&Path>,
 ) -> String {
     const NO_ENV: &[(String, String)] = &[];
-    let (tail_cmd, extra_env): (String, &[(String, String)]) = match tail {
-        SessionTail::Script { timeout_secs, env } => {
-            (build_script_tail(prompt_path, timeout_secs), env)
-        }
+    // #550/AC #4: `harness_env` sources the CCR export — from the harness
+    // descriptor for an agent tail, forced by the wrapper for `script` / `shell`.
+    // (Type inferred, not annotated: an explicit 3-tuple type trips clippy's
+    // `type_complexity`, which CI denies.)
+    let (tail_cmd, extra_env, harness_env) = match tail {
+        SessionTail::Script { timeout_secs, env } => (
+            build_script_tail(prompt_path, timeout_secs),
+            env,
+            forced_ccr_env(),
+        ),
         SessionTail::Shell => {
             // #316: a deterministic interactive bash. Like `Script`, the test
             // seam must not clobber it (`sleep 600` instead of a real shell is
@@ -433,9 +453,11 @@ pub fn build_tmux_script(
             (
                 "while true; do bash -i; sleep 0.2; done".to_string(),
                 NO_ENV,
+                forced_ccr_env(),
             )
         }
         SessionTail::Agent {
+            harness,
             model,
             effort,
             session_id,
@@ -443,12 +465,21 @@ pub fn build_tmux_script(
             // #433: `settings_path` (the turn-end `Stop` hook) is honoured ONLY on
             // the agent tail — a `Script`/`Shell` tail runs bash, never `claude`,
             // so it structurally cannot carry `--settings`. #473: `session_id` pins
-            // the transcript identity, threaded through the enum variant.
+            // the transcript identity, threaded through the enum variant. #550: the
+            // harness descriptor's `launch` template renders the tail and its `env`
+            // block carries the CCR suppression (AC #4).
             let cmd = match tmux_cmd_override {
                 Some(cmd) => cmd.to_string(),
-                None => build_agent_tail(prompt_path, model, effort, settings_path, session_id),
+                None => build_agent_tail(
+                    harness,
+                    prompt_path,
+                    model,
+                    effort,
+                    settings_path,
+                    session_id,
+                ),
             };
-            (cmd, NO_ENV)
+            (cmd, NO_ENV, harness.env.clone())
         }
     };
 
@@ -461,9 +492,25 @@ pub fn build_tmux_script(
     match sandbox {
         Some(wrap) => {
             let docker_tail = wrap_tail_in_docker_exec(run_id, wrap, extra_env, &tail_cmd);
-            wrap_with_env(run_id, node_id, iter, daemon_port, NO_ENV, &docker_tail)
+            wrap_with_env(
+                run_id,
+                node_id,
+                iter,
+                daemon_port,
+                &harness_env,
+                NO_ENV,
+                &docker_tail,
+            )
         }
-        None => wrap_with_env(run_id, node_id, iter, daemon_port, extra_env, &tail_cmd),
+        None => wrap_with_env(
+            run_id,
+            node_id,
+            iter,
+            daemon_port,
+            &harness_env,
+            extra_env,
+            &tail_cmd,
+        ),
     }
 }
 
@@ -508,47 +555,71 @@ fn build_resume_script(
     node_id: &str,
     iter: i64,
     daemon_port: u16,
+    descriptor: &crate::harness_registry::HarnessDescriptor,
     effort: Option<&str>,
     session_id: Option<&str>,
     tmux_cmd_override: Option<&str>,
     sandbox: Option<&SandboxWrap<'_>>,
     settings_path: Option<&Path>,
 ) -> String {
-    let effort_flag = match effort {
-        Some(e) if !e.is_empty() => format!(" --effort {}", sh_single_quote(e)),
-        _ => String::new(),
-    };
-    // #473: `--resume <uuid>` targets THIS node's transcript by identity; a
-    // pre-#473 row with no recorded id falls back to positional `--continue`.
-    let resume_flag = match session_id {
+    // #473/ADR-0045: the resume *selector* is the one thing the pure hole-drop
+    // rule cannot express (emit `--continue` precisely *when* the id is empty), so
+    // it is computed here — "reprendre par identité ou en aveugle" stays in code.
+    // `--resume <uuid>` targets THIS node's transcript by identity; a row with no
+    // recorded id (pre-#473, or a harness like `opencode` that can't pin one)
+    // falls back to blind `--continue`. Both delivered harnesses blind-continue
+    // with `--continue`.
+    let resume_selector = match session_id {
         Some(s) if !s.is_empty() => format!("--resume {}", sh_single_quote(s)),
         _ => "--continue".to_string(),
     };
-    // #433 / ADR-0043 (D7): re-arm the `Stop` hook on resume, or a resurrected
-    // session silently loses it — the daemon sweep still covers the node, but the
-    // PRIMARY substrate must survive resurrection. Leading space matches this
-    // function's local `effort_flag` convention; `None` ⇒ byte-identical tail.
-    let settings_flag = match settings_path {
-        Some(p) => format!(" --settings {}", sh_single_quote(&p.to_string_lossy())),
-        None => String::new(),
+    let quote_opt = |v: Option<&str>| {
+        v.filter(|s| !s.is_empty())
+            .map(sh_single_quote)
+            .unwrap_or_default()
+    };
+    let holes = crate::harness_argv::Holes {
+        resume: resume_selector,
+        // #424: a resume restores the model but loses the effort, so re-pose it.
+        effort: quote_opt(effort),
+        // #433 / ADR-0043 (D7): re-arm the `Stop` hook on resume.
+        settings: settings_path
+            .map(|p| sh_single_quote(&p.to_string_lossy()))
+            .unwrap_or_default(),
+        ..Default::default()
     };
     let tail_cmd = match tmux_cmd_override {
         Some(cmd) => cmd.to_string(),
-        None => format!(
-            "exec claude --dangerously-skip-permissions {resume_flag}{effort_flag}{settings_flag}"
-        ),
+        None => crate::harness_argv::render(&descriptor.resume, &holes),
     };
 
-    // #407: the 6th tail path (`claude --continue`) is wrapped identically — a
-    // resumed sandboxed session re-enters the same container. `--continue` matches
-    // its transcript by working-dir path; the container mounts the repo at the
-    // same host path, so the path (hence the transcript) still matches.
+    // #407: the resume tail is wrapped identically — a resumed sandboxed session
+    // re-enters the same container. `--continue` matches its transcript by
+    // working-dir path; the container mounts the repo at the same host path, so
+    // the path (hence the transcript) still matches.
+    let harness_env = descriptor.env.clone();
     match sandbox {
         Some(wrap) => {
             let docker_tail = wrap_tail_in_docker_exec(run_id, wrap, &[], &tail_cmd);
-            wrap_with_env(run_id, node_id, iter, daemon_port, &[], &docker_tail)
+            wrap_with_env(
+                run_id,
+                node_id,
+                iter,
+                daemon_port,
+                &harness_env,
+                &[],
+                &docker_tail,
+            )
         }
-        None => wrap_with_env(run_id, node_id, iter, daemon_port, &[], &tail_cmd),
+        None => wrap_with_env(
+            run_id,
+            node_id,
+            iter,
+            daemon_port,
+            &harness_env,
+            &[],
+            &tail_cmd,
+        ),
     }
 }
 
@@ -713,6 +784,7 @@ pub fn resume(
     node_id: &str,
     iter: i64,
     daemon_port: u16,
+    descriptor: &crate::harness_registry::HarnessDescriptor,
     effort: Option<&str>,
     session_id: Option<&str>,
     tmux_cmd_override: Option<&str>,
@@ -738,6 +810,7 @@ pub fn resume(
         node_id,
         iter,
         daemon_port,
+        descriptor,
         effort,
         session_id,
         tmux_cmd_override,
@@ -999,6 +1072,48 @@ pub fn env_default_model() -> Option<String> {
 /// without a daemon restart.
 pub fn default_model_with(stored: Option<String>) -> Option<String> {
     stored.filter(|s| !s.is_empty()).or_else(env_default_model)
+}
+
+/// Env var supplying the instance-wide default **harness** (#550, ADR-0046).
+/// `None`/empty ⇒ fall through to the `claude` floor, byte-identical launch.
+pub const DEFAULT_HARNESS_ENV: &str = "PDO_DEFAULT_HARNESS";
+
+/// The default harness contributed by [`DEFAULT_HARNESS_ENV`] alone, or `None`
+/// when unset or empty. Exposed so `GET /settings` can disclose a shadowed env
+/// var and compute the winning tier identically to [`default_harness_with`].
+pub fn env_default_harness() -> Option<String> {
+    std::env::var(DEFAULT_HARNESS_ENV)
+        .ok()
+        .filter(|s| !s.is_empty())
+}
+
+/// Resolve the instance-wide default harness, `stored → env → None` (#550,
+/// ADR-0046, mirroring [`default_model_with`]). `None` ⇒ the resolver's `claude`
+/// floor applies. Read FRESH at every spawn seam so a `PUT /settings` takes
+/// effect on the next node without a daemon restart (ADR-0015).
+pub fn default_harness_with(stored: Option<String>) -> Option<String> {
+    stored
+        .filter(|s| !s.is_empty())
+        .or_else(env_default_harness)
+}
+
+/// Whether `binary` resolves on the current `PATH` — the fail-fast spawn check
+/// (#550, AC #10). A name with a `/` is checked directly; a bare name is searched
+/// across `$PATH`. **Never executes** the binary (a probe run could hang a
+/// resident harness), and lives here (not in the pure `harness_registry`) because
+/// it reads `$PATH`. A missing binary makes the spawn fail *before* any session
+/// or start event exists (ADR-0037).
+pub fn binary_available(binary: &str) -> bool {
+    if binary.is_empty() {
+        return false;
+    }
+    if binary.contains('/') {
+        return Path::new(binary).is_file();
+    }
+    match std::env::var_os("PATH") {
+        Some(path) => std::env::split_paths(&path).any(|dir| dir.join(binary).is_file()),
+        None => false,
+    }
 }
 
 /// Resolve the model a work node launches with: the node's own `model:`
@@ -1803,6 +1918,26 @@ mod tests {
         assert_eq!(decisions[2].verdict, SweepVerdict::Keep);
     }
 
+    /// #550/AC #10: the fail-fast PATH probe. A bare name absent from `$PATH` is
+    /// unavailable; an empty name is never available; a slash-path is checked as a
+    /// file directly. `sh` is on every CI box, so it stands in for "installed".
+    #[test]
+    fn binary_available_probes_path_without_executing() {
+        assert!(!binary_available(""), "empty name is never available");
+        assert!(
+            !binary_available("pdo-definitely-not-a-real-binary-xyz"),
+            "a name absent from PATH is unavailable"
+        );
+        assert!(
+            binary_available("sh"),
+            "a ubiquitous binary resolves on PATH"
+        );
+        assert!(
+            !binary_available("/no/such/absolute/path/binary"),
+            "a missing slash-path is unavailable"
+        );
+    }
+
     #[test]
     fn build_script_default_and_override() {
         let prompt_path = Path::new("/tmp/test-prompt.md");
@@ -1816,6 +1951,7 @@ mod tests {
             prompt_path,
             None,
             SessionTail::Agent {
+                harness: &crate::harness_registry::claude(),
                 model: None,
                 effort: None,
                 session_id: None,
@@ -1838,6 +1974,7 @@ mod tests {
             prompt_path,
             Some("exec sleep 60"),
             SessionTail::Agent {
+                harness: &crate::harness_registry::claude(),
                 model: None,
                 effort: None,
                 session_id: None,
@@ -1864,6 +2001,7 @@ mod tests {
             prompt_path,
             None,
             SessionTail::Agent {
+                harness: &crate::harness_registry::claude(),
                 model: None,
                 effort: None,
                 session_id: None,
@@ -1900,6 +2038,7 @@ mod tests {
             prompt_path,
             None,
             SessionTail::Agent {
+                harness: &crate::harness_registry::claude(),
                 model: Some("opus"),
                 effort: None,
                 session_id: None,
@@ -1940,6 +2079,7 @@ mod tests {
             prompt_path,
             None,
             SessionTail::Agent {
+                harness: &crate::harness_registry::claude(),
                 model: Some(""),
                 effort: None,
                 session_id: None,
@@ -1969,6 +2109,7 @@ mod tests {
             Path::new("/tmp/test-prompt.md"),
             None,
             SessionTail::Agent {
+                harness: &crate::harness_registry::claude(),
                 model,
                 effort,
                 session_id: None,
@@ -2057,6 +2198,7 @@ mod tests {
             Path::new("/tmp/test-prompt.md"),
             None,
             SessionTail::Agent {
+                harness: &crate::harness_registry::claude(),
                 model: None,
                 effort: None,
                 session_id: None,
@@ -2080,6 +2222,7 @@ mod tests {
             Path::new("/tmp/test-prompt.md"),
             None,
             SessionTail::Agent {
+                harness: &crate::harness_registry::claude(),
                 model,
                 effort,
                 session_id,
@@ -2135,6 +2278,7 @@ mod tests {
             Path::new("/tmp/test-prompt.md"),
             None,
             SessionTail::Agent {
+                harness: &crate::harness_registry::claude(),
                 model: Some("opus"),
                 effort: Some("low"),
                 session_id: None,
@@ -2236,6 +2380,7 @@ mod tests {
             Path::new("/tmp/test-prompt.md"),
             None,
             SessionTail::Agent {
+                harness: &crate::harness_registry::claude(),
                 model: None,
                 effort: None,
                 session_id: None,
@@ -2284,7 +2429,18 @@ mod tests {
     fn build_resume_script_omits_settings_when_none() {
         // D7 off path: a resume with no hook is byte-identical to the legacy
         // `--continue` tail.
-        let script = build_resume_script("r1", "solo", 1, 6172, None, None, None, None, None);
+        let script = build_resume_script(
+            "r1",
+            "solo",
+            1,
+            6172,
+            &crate::harness_registry::claude(),
+            None,
+            None,
+            None,
+            None,
+            None,
+        );
         assert!(!script.contains("--settings"), "{script}");
         assert!(
             script.contains("exec claude --dangerously-skip-permissions --continue"),
@@ -2301,6 +2457,7 @@ mod tests {
             "solo",
             1,
             6172,
+            &crate::harness_registry::claude(),
             Some("low"),
             None,
             None,
@@ -2741,6 +2898,7 @@ mod tests {
             prompt_path,
             None,
             SessionTail::Agent {
+                harness: &crate::harness_registry::claude(),
                 model: None,
                 effort: None,
                 session_id: None,
@@ -2871,6 +3029,7 @@ mod tests {
             prompt_path,
             None,
             SessionTail::Agent {
+                harness: &crate::harness_registry::claude(),
                 model: None,
                 effort: None,
                 session_id: None,
@@ -2895,8 +3054,18 @@ mod tests {
         // here (#473) ⇒ the legacy `--continue` fallback.
         let wt = Path::new("/repo/.pdo/runs/r1/nodes/solo/iter-1");
         let wrap = sample_wrap("pdo-r1-solo-iter-1", wt);
-        let wrapped =
-            build_resume_script("r1", "solo", 1, 6172, None, None, None, Some(&wrap), None);
+        let wrapped = build_resume_script(
+            "r1",
+            "solo",
+            1,
+            6172,
+            &crate::harness_registry::claude(),
+            None,
+            None,
+            None,
+            Some(&wrap),
+            None,
+        );
         assert!(
             wrapped.contains("docker exec -i -t -e PDO_SBX_SESSION=pdo-r1-solo-iter-1"),
             "{wrapped}"
@@ -2904,7 +3073,18 @@ mod tests {
         assert!(wrapped.contains("pdo-sbx-r1 bash -lc"), "{wrapped}");
         assert!(wrapped.contains("--continue"), "{wrapped}");
         // off path unchanged.
-        let off = build_resume_script("r1", "solo", 1, 6172, None, None, None, None, None);
+        let off = build_resume_script(
+            "r1",
+            "solo",
+            1,
+            6172,
+            &crate::harness_registry::claude(),
+            None,
+            None,
+            None,
+            None,
+            None,
+        );
         assert!(!off.contains("docker"), "{off}");
         assert!(
             off.contains("exec claude --dangerously-skip-permissions --continue"),
@@ -2920,7 +3100,18 @@ mod tests {
         // cwd is the shared Run worktree). The uuid is single-quoted, hence `'\''`
         // once `wrap_with_env` re-wraps the tail in `bash -c '…'`.
         let sid = "11111111-2222-3333-4444-555555555555";
-        let off = build_resume_script("r1", "solo", 1, 6172, None, Some(sid), None, None, None);
+        let off = build_resume_script(
+            "r1",
+            "solo",
+            1,
+            6172,
+            &crate::harness_registry::claude(),
+            None,
+            Some(sid),
+            None,
+            None,
+            None,
+        );
         assert!(
             off.contains(&format!(r"--resume '\''{sid}'\''")),
             "resume must target the pinned session id: {off}"
@@ -2940,6 +3131,7 @@ mod tests {
             "solo",
             1,
             6172,
+            &crate::harness_registry::claude(),
             Some("low"),
             Some(sid),
             None,
@@ -2960,7 +3152,18 @@ mod tests {
     fn build_resume_script_falls_back_to_continue_for_empty_session_id() {
         // #473: an empty pinned id behaves exactly like `None` (a pre-#473 row) —
         // the legacy positional `--continue`, byte-identical.
-        let script = build_resume_script("r1", "solo", 1, 6172, None, Some(""), None, None, None);
+        let script = build_resume_script(
+            "r1",
+            "solo",
+            1,
+            6172,
+            &crate::harness_registry::claude(),
+            None,
+            Some(""),
+            None,
+            None,
+            None,
+        );
         assert!(!script.contains("--resume"), "{script}");
         assert!(
             script.contains(r"exec claude --dangerously-skip-permissions --continue'"),
@@ -2974,7 +3177,18 @@ mod tests {
         // byte-identical to the legacy tail. `Some("")` behaves like `None` — the
         // same last-resort guard as the spawn tail.
         for effort in [None, Some("")] {
-            let script = build_resume_script("r1", "solo", 1, 6172, effort, None, None, None, None);
+            let script = build_resume_script(
+                "r1",
+                "solo",
+                1,
+                6172,
+                &crate::harness_registry::claude(),
+                effort,
+                None,
+                None,
+                None,
+                None,
+            );
             assert!(
                 !script.contains("--effort"),
                 "no effort flag when unset ({effort:?}): {script}"
@@ -2996,8 +3210,18 @@ mod tests {
         // the transcript stores no effort field to read back. So the level is
         // re-posed here, from the `NodeStarted` payload. Still no `--model`: that
         // one really is restored.
-        let script =
-            build_resume_script("r1", "solo", 1, 6172, Some("low"), None, None, None, None);
+        let script = build_resume_script(
+            "r1",
+            "solo",
+            1,
+            6172,
+            &crate::harness_registry::claude(),
+            Some("low"),
+            None,
+            None,
+            None,
+            None,
+        );
         assert!(
             script.contains(r"--continue --effort '\''low'\''"),
             "effort must be re-posed right after --continue: {script}"
@@ -3019,6 +3243,7 @@ mod tests {
             "solo",
             1,
             6172,
+            &crate::harness_registry::claude(),
             Some("low"),
             Some("11111111-2222-3333-4444-555555555555"),
             Some("exec sleep 60"),

--- a/crates/pdo-daemon/src/workflow_importer.rs
+++ b/crates/pdo-daemon/src/workflow_importer.rs
@@ -517,6 +517,17 @@ impl Importer {
         };
         out_port.frontmatter = frontmatter;
 
+        // #550: the imported `model` / `effort` land under `harnesses.claude`
+        // (workflow import stays claude-only, ADR-0016). Only materialise an entry
+        // when at least one is present, so a plain node keeps an empty map.
+        let mut harnesses = std::collections::BTreeMap::new();
+        if model.is_some() || effort.is_some() {
+            harnesses.insert(
+                crate::harness_registry::CLAUDE.to_string(),
+                crate::harness_resolver::HarnessEntry { model, effort },
+            );
+        }
+
         let node = NodeDef {
             id: id.clone(),
             name: display_name,
@@ -530,8 +541,8 @@ impl Importer {
             }),
             max_iter: None,
             over: None,
-            model,
-            effort,
+            pin_harness: None,
+            harnesses,
         };
         self.nodes.push(node);
         self.prompts.insert(id.clone(), prompt_body);
@@ -926,8 +937,8 @@ fn start_node() -> NodeDef {
         view: Some(ViewPosition { x: 320.0, y: 0.0 }),
         max_iter: None,
         over: None,
-        model: None,
-        effort: None,
+        pin_harness: None,
+        harnesses: Default::default(),
     }
 }
 
@@ -945,8 +956,8 @@ fn end_node(agent_count: usize) -> NodeDef {
         }),
         max_iter: None,
         over: None,
-        model: None,
-        effort: None,
+        pin_harness: None,
+        harnesses: Default::default(),
     }
 }
 
@@ -1842,10 +1853,12 @@ mod tests {
         let src = r#"agent(`work`, { label: 'w', model: 'opus', effort: 'low' }); agent(`plain`, { label: 'p' })"#;
         let (result, parsed) = import_and_parse(src, "t");
         let node = |name: &str| parsed.nodes.iter().find(|n| n.name == name).unwrap();
-        assert_eq!(node("w").effort.as_deref(), Some("low"));
-        assert_eq!(node("w").model.as_deref(), Some("opus"));
-        // An agent with no effort stays unset — no key, no flag.
-        assert_eq!(node("p").effort, None);
+        // #550: imported model/effort land under `harnesses.claude` (claude-only import).
+        let claude = |name: &str| node(name).harnesses.get("claude").cloned();
+        assert_eq!(claude("w").and_then(|e| e.effort).as_deref(), Some("low"));
+        assert_eq!(claude("w").and_then(|e| e.model).as_deref(), Some("opus"));
+        // An agent with no effort/model stays unset — no claude entry at all.
+        assert_eq!(claude("p"), None);
         assert!(
             result
                 .warnings
@@ -1855,15 +1868,13 @@ mod tests {
             result.warnings
         );
         // Structural nodes never carry one.
-        assert_eq!(
-            parsed
-                .nodes
-                .iter()
-                .find(|n| n.node_type == NodeType::Start)
-                .unwrap()
-                .effort,
-            None
-        );
+        assert!(parsed
+            .nodes
+            .iter()
+            .find(|n| n.node_type == NodeType::Start)
+            .unwrap()
+            .harnesses
+            .is_empty());
     }
 
     #[test]
@@ -1873,10 +1884,14 @@ mod tests {
         // dropping it in silence.
         let src = r#"const lvl = 'low'; agent(`work`, { label: 'w', effort: lvl })"#;
         let (result, parsed) = import_and_parse(src, "t");
-        assert_eq!(
-            parsed.nodes.iter().find(|n| n.name == "w").unwrap().effort,
-            None
-        );
+        // A computed (non-literal) effort is lost, so the node carries no claude entry.
+        assert!(parsed
+            .nodes
+            .iter()
+            .find(|n| n.name == "w")
+            .unwrap()
+            .harnesses
+            .is_empty());
         assert!(
             result.warnings.iter().any(|w| w.message.contains("effort")),
             "a computed effort must raise a warning: {:?}",

--- a/crates/pdo-daemon/tests/harness_freeze_resume.rs
+++ b/crates/pdo-daemon/tests/harness_freeze_resume.rs
@@ -1,0 +1,188 @@
+//! Layer 3a (#550, ADR-0046) — the harness axis, end to end through the daemon.
+//!
+//! A two-node `doc-only` pipeline: one node with no pin (⇒ the `claude` floor),
+//! one `pin_harness: opencode`. Spawned through the **tmux command seam** (a
+//! harmless `sleep`, never a real agent), the test proves:
+//!   1. the resolved harness is **frozen** in each node's `NodeStarted` event, and
+//!   2. a resume of the pinned node **re-poses** that frozen harness (ADR-0007).
+//!
+//! The binary fail-fast (AC #10) is deliberately not exercised here: it is
+//! skipped under the command override (an override means the real binary never
+//! runs), and it is unit-tested in `node_spawn` / `node_primitives`.
+
+mod common;
+
+use common::TestDaemon;
+
+const PIPELINE_NAME: &str = "harness-test";
+const PIPELINE_YAML: &str = r#"name: harness-test
+version: "1.0"
+nodes:
+  - id: start
+    name: Start
+    type: start
+    outputs:
+      - name: user_prompt
+  - id: aaaaaaaa
+    name: on-claude
+    type: doc-only
+    outputs:
+      - name: out
+    view: { x: 200, y: 60 }
+  - id: bbbbbbbb
+    name: on-opencode
+    type: doc-only
+    pin_harness: opencode
+    outputs:
+      - name: out
+    view: { x: 200, y: 200 }
+  - id: end
+    name: End
+    type: end
+    inputs:
+      - name: result
+edges:
+  - source: { node: start, port: user_prompt }
+    target: { node: aaaaaaaa, port: task }
+  - source: { node: start, port: user_prompt }
+    target: { node: bbbbbbbb, port: task }
+  - source: { node: aaaaaaaa, port: out }
+    target: { node: end, port: result }
+"#;
+
+fn seed(repo: &std::path::Path) -> anyhow::Result<()> {
+    let pipelines_dir = repo.join(".pdo").join("pipelines");
+    std::fs::create_dir_all(&pipelines_dir)?;
+    std::fs::write(
+        pipelines_dir.join(format!("{PIPELINE_NAME}.yaml")),
+        PIPELINE_YAML,
+    )?;
+    let prompts_dir = pipelines_dir.join(format!("{PIPELINE_NAME}.prompts"));
+    std::fs::create_dir_all(&prompts_dir)?;
+    std::fs::write(prompts_dir.join("aaaaaaaa.md"), "You are on claude.\n")?;
+    std::fs::write(prompts_dir.join("bbbbbbbb.md"), "You are on opencode.\n")?;
+    git_init_with_commit(repo)?;
+    Ok(())
+}
+
+fn git_init_with_commit(repo: &std::path::Path) -> anyhow::Result<()> {
+    let run = |args: &[&str]| -> anyhow::Result<()> {
+        let out = std::process::Command::new("git")
+            .args(args)
+            .current_dir(repo)
+            .output()?;
+        if !out.status.success() {
+            anyhow::bail!(
+                "git {:?} failed: {}",
+                args,
+                String::from_utf8_lossy(&out.stderr)
+            );
+        }
+        Ok(())
+    };
+    run(&["init", "-q", "-b", "main"])?;
+    run(&["config", "user.email", "test@example.com"])?;
+    run(&["config", "user.name", "Test"])?;
+    run(&["config", "commit.gpgsign", "false"])?;
+    std::fs::write(repo.join(".gitignore"), ".pdo/runs/\n")?;
+    run(&["add", "."])?;
+    run(&["commit", "-q", "-m", "init"])?;
+    Ok(())
+}
+
+async fn create_run(daemon: &TestDaemon) -> String {
+    let body = serde_json::json!({
+        "pipeline": PIPELINE_NAME,
+        "input": "go",
+        "target_repo": daemon.target_repo(),
+    });
+    let resp = reqwest::Client::new()
+        .post(format!("{}/runs", daemon.url()))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 201, "POST /runs should return 201");
+    let json: serde_json::Value = resp.json().await.unwrap();
+    json["run_id"].as_str().unwrap().to_string()
+}
+
+async fn events(daemon: &TestDaemon, run_id: &str) -> Vec<serde_json::Value> {
+    let v: serde_json::Value = reqwest::get(format!("{}/runs/{run_id}/events", daemon.url()))
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    v.as_array().cloned().unwrap_or_default()
+}
+
+/// The `harness` frozen on a node's latest `NodeStarted`, or `None` until it lands.
+fn started_harness(evs: &[serde_json::Value], node_id: &str) -> Option<String> {
+    evs.iter()
+        .rev()
+        .find(|e| e["kind"] == "node_started" && e["node_id"] == node_id)
+        .and_then(|e| e["payload"]["harness"].as_str())
+        .map(String::from)
+}
+
+/// Poll the event log until both entry nodes have a `NodeStarted`, or time out.
+async fn wait_for_both_started(daemon: &TestDaemon, run_id: &str) -> Vec<serde_json::Value> {
+    for _ in 0..50 {
+        let evs = events(daemon, run_id).await;
+        if started_harness(&evs, "aaaaaaaa").is_some()
+            && started_harness(&evs, "bbbbbbbb").is_some()
+        {
+            return evs;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+    panic!("both entry nodes should have started within the timeout");
+}
+
+#[tokio::test]
+async fn resolved_harness_is_frozen_on_node_started() {
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+    let run_id = create_run(&daemon).await;
+    let evs = wait_for_both_started(&daemon, &run_id).await;
+
+    // The unpinned node froze the `claude` floor; the pinned node froze `opencode`
+    // — the resolved harness, not what any tier says now (ADR-0046, gel au spawn).
+    assert_eq!(started_harness(&evs, "aaaaaaaa").as_deref(), Some("claude"));
+    assert_eq!(
+        started_harness(&evs, "bbbbbbbb").as_deref(),
+        Some("opencode")
+    );
+}
+
+#[tokio::test]
+async fn resume_reposes_the_frozen_harness() {
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+    let run_id = create_run(&daemon).await;
+    wait_for_both_started(&daemon, &run_id).await;
+
+    // Kill the pinned node's live session out-of-band (on the daemon's own tmux
+    // socket) so the pane endpoint has to RESUME rather than merely capture.
+    let socket = daemon.tmux_socket();
+    let session = format!("pdo-{run_id}-bbbbbbbb-iter-1");
+    let _ = std::process::Command::new("tmux")
+        .args(["-L", &socket, "kill-session", "-t", &session])
+        .output();
+
+    // The pane endpoint reads the frozen `opencode` harness back from `NodeStarted`,
+    // finds it can resume, and re-poses it (via the command seam). It must not
+    // answer a bare "session no longer available".
+    let resp = reqwest::get(format!(
+        "{}/runs/{run_id}/nodes/bbbbbbbb/pane",
+        daemon.url()
+    ))
+    .await
+    .unwrap();
+    assert_eq!(resp.status(), 200);
+    let pane: serde_json::Value = resp.json().await.unwrap();
+    assert_ne!(
+        pane["source"].as_str(),
+        Some("unavailable"),
+        "a resumable pinned node must re-pose, not report unavailable: {pane}"
+    );
+}

--- a/crates/pdo-daemon/tests/tmux_run_spawn.rs
+++ b/crates/pdo-daemon/tests/tmux_run_spawn.rs
@@ -86,6 +86,9 @@ fn build_tmux_script_uses_exec_bash_and_invokes_claude() {
     // `claude --dangerously-skip-permissions` and the `exec bash -c` shape.
     // `None` override → production claude tail.
     let prompt_path = std::path::Path::new("/tmp/pdo-test/solo-iter-1.md");
+    // #550: the `claude` descriptor — its launch template reproduces the legacy
+    // tail byte for byte once the holes are empty (the state this test asserts).
+    let claude = pdo_daemon::harness_registry::claude();
     let script = build_tmux_script(
         "run-abc",
         "solo",
@@ -94,6 +97,7 @@ fn build_tmux_script_uses_exec_bash_and_invokes_claude() {
         prompt_path,
         None,
         SessionTail::Agent {
+            harness: &claude,
             model: None,
             effort: None,
             session_id: None,

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,4 +1,5 @@
 import type { PipelineListEntry, PipelineDetail, PipelineDef, RunListEntry, RunState, PortDef, PortSide, PortType, FrontmatterFieldDecl, FrontmatterViolation, Trigger, TriggerFire, DaemonStatus, InstanceSettings, UpdateSettingsRequest, StatsOverview, StatsCost, SandboxProfile, SandboxProfileImage, SandboxProfileReferents, SyncCostPricesReport } from "./types";
+import { foldHarnessOntoNode } from "./lib/harness";
 
 const BASE = "";
 
@@ -1085,12 +1086,27 @@ export function forgetRun(runId: string): Promise<void> {
 
 // --- Run-scoped pipeline ---
 
+// #550/ADR-0046: the daemon returns each node's per-harness `harnesses` map; the
+// editor's pickers edit a flat `model`/`effort` view of the RESOLVED harness. Fold
+// on the way in so the existing UI + library sync keep working; `serializePipeline`
+// folds back on save. Applied at every pipeline-load boundary.
+function foldPipelineDetail(detail: PipelineDetail): PipelineDetail {
+  if (!detail?.pipeline?.nodes) return detail;
+  return {
+    ...detail,
+    pipeline: {
+      ...detail.pipeline,
+      nodes: detail.pipeline.nodes.map(foldHarnessOntoNode),
+    },
+  };
+}
+
 export function fetchRunPipeline(runId: string): Promise<PipelineDetail> {
   return request<PipelineDetail>(
     "GET",
     `/runs/${encodeURIComponent(runId)}/pipeline`,
     { label: `GET /runs/${runId}/pipeline` },
-  );
+  ).then(foldPipelineDetail);
 }
 
 export function saveRunPipeline(
@@ -1120,7 +1136,7 @@ export function fetchPipeline(id: string, scope?: string): Promise<PipelineDetai
     "GET",
     `/pipelines/${encodeURIComponent(id)}${scopeQuery(scope)}`,
     { label: `GET /pipelines/${id}` },
-  );
+  ).then(foldPipelineDetail);
 }
 
 export function savePipeline(

--- a/frontend/src/components/EffortPicker.test.tsx
+++ b/frontend/src/components/EffortPicker.test.tsx
@@ -119,4 +119,34 @@ describe("EffortPicker (#424)", () => {
     expect(screen.getByTestId("merge-effort-option-low")).toBeInTheDocument();
     expect(screen.queryByTestId("node-effort-option-low")).toBeNull();
   });
+
+  // #550/AC #13: greyed when the resolved harness has no launch-time effort axis.
+  it("is greyed when disabled — every option carries the `disabled` attribute", () => {
+    render(<EffortPicker value={null} onChange={() => {}} testid="node-effort" disabled />);
+    // Assert the DISABLED attribute, never `.value`: a `.value` assertion on a
+    // control cannot fail (the known trap this AC calls out).
+    for (const radio of screen.getAllByRole("radio")) {
+      expect(radio).toBeDisabled();
+    }
+    expect(screen.getByRole("radiogroup", { name: "Effort" })).toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
+  });
+
+  it("does not fire onChange while disabled", async () => {
+    const onChange = vi.fn();
+    render(<EffortPicker value={null} onChange={onChange} testid="node-effort" disabled />);
+    await userEvent.click(screen.getByTestId("node-effort-option-high"));
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("is enabled and fires onChange by default (no `disabled` prop)", async () => {
+    const onChange = vi.fn();
+    render(<EffortPicker value={null} onChange={onChange} testid="node-effort" />);
+    const high = screen.getByTestId("node-effort-option-high");
+    expect(high).not.toBeDisabled();
+    await userEvent.click(high);
+    expect(onChange).toHaveBeenCalledWith("high");
+  });
 });

--- a/frontend/src/components/EffortPicker.tsx
+++ b/frontend/src/components/EffortPicker.tsx
@@ -30,10 +30,16 @@ export default function EffortPicker({
   value,
   onChange,
   testid,
+  disabled = false,
 }: {
   value: string | null;
   onChange: (v: string | null) => void;
   testid: string; // "node-effort" | "merge-effort"
+  /* #550/ADR-0046: greyed when the resolved harness has no launch-time effort
+     axis (`opencode`). An absence DECLARED by the descriptor's shape, not a
+     default — so the control is disabled, not hidden. Assert on the `disabled`
+     attribute, never `.value` (a `.value` assertion cannot fail — a known trap). */
+  disabled?: boolean;
 }) {
   const set = value != null && value !== "";
   const known = set && (EFFORT_LEVELS as readonly string[]).includes(value);
@@ -46,7 +52,12 @@ export default function EffortPicker({
   ];
 
   return (
-    <div role="radiogroup" aria-label="Effort" className="flex gap-1">
+    <div
+      role="radiogroup"
+      aria-label="Effort"
+      aria-disabled={disabled}
+      className={`flex gap-1 ${disabled ? "opacity-50" : ""}`}
+    >
       {options.map((o) => {
         // `""` is normalised to unset, so an empty-string value selects Default.
         const selected = (set ? value : null) === o.id;
@@ -56,9 +67,14 @@ export default function EffortPicker({
             type="button"
             role="radio"
             aria-checked={selected}
+            disabled={disabled}
             data-testid={`${testid}-option-${o.slug}`}
-            onClick={() => onChange(o.id)}
-            className={`flex-1 cursor-pointer rounded border px-2 py-1 font-medium transition-colors ${
+            onClick={() => {
+              if (!disabled) onChange(o.id);
+            }}
+            className={`flex-1 rounded border px-2 py-1 font-medium transition-colors ${
+              disabled ? "cursor-not-allowed" : "cursor-pointer"
+            } ${
               selected
                 ? o.id == null
                   ? "border-fg-4 bg-bg-3 text-fg"

--- a/frontend/src/components/NewRunModal.test.tsx
+++ b/frontend/src/components/NewRunModal.test.tsx
@@ -24,6 +24,8 @@ vi.mock("../api", () => ({
     reaper_ttl_secs: { effective: 3600, source: "default", stored: null, env: null, default: 3600 },
     guard_timeout_secs: { effective: 60, source: "default", stored: null, env: null, default: 60 },
     default_model: { effective: null, source: "default", stored: null, env: null, default: null },
+    default_harness: { effective: null, source: "default", stored: null, env: null, default: null },
+    default_harness_model: { effective: {}, stored: {} },
     default_sandbox: { effective: "off", source: "default", stored: null, env: null, default: "off", reason: null },
     sandbox_docker: { available: true, reason: null, checked_at: "2026-07-01T10:00:00.000Z" },
     // #432: the sandbox `<select>` options are DATA now — the two virtual defaults.
@@ -794,6 +796,8 @@ describe("NewRunModal — auto-naming default (#338)", () => {
       reaper_ttl_secs: { effective: 3600, source: "default", stored: null, env: null, default: 3600 },
       guard_timeout_secs: { effective: 60, source: "default", stored: null, env: null, default: 60 },
       default_model: { effective: null, source: "default", stored: null, env: null, default: null },
+      default_harness: { effective: null, source: "default", stored: null, env: null, default: null },
+      default_harness_model: { effective: {}, stored: {} },
       default_sandbox: { effective: "off", source: "default", stored: null, env: null, default: "off", reason: null },
       sandbox_docker: { available: true, reason: null, checked_at: "2026-07-01T10:00:00.000Z" },
       sandbox_profiles: [{ name: "full", virtual: true }, { name: "minimal", virtual: true }],
@@ -1538,6 +1542,8 @@ describe("NewRunModal — sandbox selector (#410)", () => {
       reaper_ttl_secs: { effective: 3600, source: "default", stored: null, env: null, default: 3600 },
       guard_timeout_secs: { effective: 60, source: "default", stored: null, env: null, default: 60 },
       default_model: { effective: null, source: "default", stored: null, env: null, default: null },
+      default_harness: { effective: null, source: "default", stored: null, env: null, default: null },
+      default_harness_model: { effective: {}, stored: {} },
       default_sandbox: { effective: "off", source: "default", stored: null, env: null, default: "off", reason: null },
       // #431: required fields on InstanceSettings; this modal reads neither, they are
       // here to satisfy the typed fixture.
@@ -1823,6 +1829,8 @@ describe("NewRunModal — the launch dialog can defer to default_sandbox (#452)"
       reaper_ttl_secs: { effective: 3600, source: "default", stored: null, env: null, default: 3600 },
       guard_timeout_secs: { effective: 60, source: "default", stored: null, env: null, default: 60 },
       default_model: { effective: null, source: "default", stored: null, env: null, default: null },
+      default_harness: { effective: null, source: "default", stored: null, env: null, default: null },
+      default_harness_model: { effective: {}, stored: {} },
       default_sandbox: { effective: "off", source: "default", stored: null, env: null, default: "off", reason: null },
       sandbox_docker: { available: true, reason: null, checked_at: "2026-07-01T10:00:00.000Z" },
       sandbox_profiles: [
@@ -2034,6 +2042,8 @@ describe("NewRunModal — the target repo is required at the boundary (#470)", (
       reaper_ttl_secs: { effective: 3600, source: "default", stored: null, env: null, default: 3600 },
       guard_timeout_secs: { effective: 60, source: "default", stored: null, env: null, default: 60 },
       default_model: { effective: null, source: "default", stored: null, env: null, default: null },
+      default_harness: { effective: null, source: "default", stored: null, env: null, default: null },
+      default_harness_model: { effective: {}, stored: {} },
       default_sandbox: { effective: "off", source: "default", stored: null, env: null, default: "off", reason: null },
       sandbox_docker: { available: true, reason: null, checked_at: "2026-07-01T10:00:00.000Z" },
       sandbox_profiles: [

--- a/frontend/src/components/NodeInspector.test.tsx
+++ b/frontend/src/components/NodeInspector.test.tsx
@@ -488,3 +488,76 @@ describe("NodeInspector StarButton — library save is independent of pipeline s
     expect(mockDelete).not.toHaveBeenCalled();
   });
 });
+
+// #550/ADR-0046: the harness axis in the node inspector.
+function seedNode(node: Record<string, unknown>) {
+  useEditStore.setState({
+    openTabs: [
+      {
+        id: "p1",
+        scope: "repo",
+        pipeline: {
+          name: "p1",
+          version: "1.0",
+          variables: {},
+          nodes: [
+            {
+              id: "n1",
+              name: "worker",
+              type: "doc-only",
+              interactive: false,
+              inputs: [{ name: "in", repeated: false, side: "left" }],
+              outputs: [{ name: "out", repeated: false, side: "right" }],
+              view: { x: 0, y: 0 },
+              ...node,
+            },
+          ],
+          edges: [],
+        },
+        prompts: { n1: "do the thing" },
+        diagnostics: [],
+        dirty: false,
+        externalDirty: false,
+      },
+    ],
+    activeTabId: "p1",
+    selection: { kind: "node", id: "n1" },
+  });
+}
+
+describe("NodeInspector — harness axis (#550, ADR-0046)", () => {
+  beforeEach(() => {
+    seedNode({});
+  });
+
+  it("resolves to the claude floor when the node has no pin", () => {
+    seedNode({});
+    renderInspector({ libraryEntries: [], onLibraryChanged: () => {} });
+    expect(screen.getByTestId("node-harness-resolved")).toHaveTextContent("claude");
+    // The effort picker is ENABLED on claude (it has an effort axis).
+    expect(screen.getByTestId("node-effort-option-high")).not.toBeDisabled();
+  });
+
+  it("shows the pinned harness as resolved and greys the effort picker on opencode", () => {
+    seedNode({ pin_harness: "opencode" });
+    renderInspector({ libraryEntries: [], onLibraryChanged: () => {} });
+    expect(screen.getByTestId("node-harness-resolved")).toHaveTextContent("opencode");
+    // AC #13: opencode has no launch-time effort axis → the picker is greyed.
+    // Assert the `disabled` attribute, never `.value`.
+    expect(screen.getByTestId("node-effort-option-high")).toBeDisabled();
+  });
+
+  it("pinning a harness writes pin_harness onto the node", async () => {
+    seedNode({});
+    renderInspector({ libraryEntries: [], onLibraryChanged: () => {} });
+    await userEvent.click(screen.getByTestId("node-harness-option-opencode"));
+    const node = useEditStore.getState().openTabs[0].pipeline.nodes[0];
+    expect(node.pin_harness).toBe("opencode");
+  });
+
+  it("hides the harness selector for a script node", () => {
+    seedNode({ type: "script" });
+    renderInspector({ libraryEntries: [], onLibraryChanged: () => {} });
+    expect(screen.queryByTestId("node-harness")).toBeNull();
+  });
+});

--- a/frontend/src/components/NodeInspector.tsx
+++ b/frontend/src/components/NodeInspector.tsx
@@ -7,6 +7,7 @@ import OutputPortCard from "./OutputPortCard";
 import PooledInputRow from "./PooledInputRow";
 import ModelPicker from "./ModelPicker";
 import EffortPicker from "./EffortPicker";
+import { KNOWN_HARNESSES, harnessHasEffort, resolveEditorHarness } from "../lib/harness";
 import DestroyLoopModal from "./DestroyLoopModal";
 import { derivePooledInputs } from "../lib/derivePooledInputs";
 import { regionsDestroyedByEdgeRemoval } from "../lib/loopRegions";
@@ -82,6 +83,12 @@ export default function NodeInspector({
   // fixed (no doc-only↔code-mutating toggle), it has no model, and its "prompt"
   // is a bash body whose I/O arrives as PDO_* env vars, not a prose preamble.
   const isScript = node.type === "script";
+
+  // #550/ADR-0046: the harness this node resolves to in the editor — its pin,
+  // else the `claude` floor. Drives the model/effort meaning and the effort
+  // greying. (The daemon re-resolves authoritatively at spawn, with the instance
+  // tier the editor does not fetch per-node.)
+  const resolvedHarness = resolveEditorHarness(node);
 
   // #339: delete one contributing edge of a pooled input — the canonical
   // "delete an input" since inputs are emergent (#149/ADR-0011). Last-cycle
@@ -215,9 +222,57 @@ export default function NodeInspector({
           </div>
         </Tooltip>
 
+        {/* Harness (#550/ADR-0046): the program that runs this node's agent. The
+            pin both selects the harness and shields it from coarser tiers; the
+            RESOLVED harness (pin, else the `claude` floor here in the editor) is
+            what the model/effort below apply to and what greys the effort picker.
+            Hidden for a script node — it launches no agent (ADR-0017). */}
+        {!isScript && (
+          <Field label="Harness">
+            <div
+              role="radiogroup"
+              aria-label="Harness"
+              className="flex gap-1"
+              data-testid="node-harness"
+              data-resolved={resolvedHarness}
+            >
+              {[
+                { id: null as string | null, label: "Default", slug: "default" },
+                ...KNOWN_HARNESSES.map((h) => ({ id: h as string, label: h, slug: h })),
+              ].map((o) => {
+                const selected = (node.pin_harness ?? null) === o.id;
+                return (
+                  <button
+                    key={o.slug}
+                    type="button"
+                    role="radio"
+                    aria-checked={selected}
+                    data-testid={`node-harness-option-${o.slug}`}
+                    onClick={() => handleField("pin_harness", o.id)}
+                    className={`flex-1 cursor-pointer rounded border px-2 py-1 font-medium transition-colors ${
+                      selected
+                        ? o.id == null
+                          ? "border-fg-4 bg-bg-3 text-fg"
+                          : "border-acc bg-acc-bg text-acc"
+                        : "border-line-strong bg-bg-3 text-fg-4 hover:text-fg-3"
+                    }`}
+                    style={{ fontSize: "10px" }}
+                  >
+                    {o.label}
+                  </button>
+                );
+              })}
+            </div>
+            <p className="mt-1 text-fg-4" style={{ fontSize: "9.5px" }}>
+              Resolved: <span data-testid="node-harness-resolved">{resolvedHarness}</span>
+              {node.pin_harness ? " (pinned)" : " (floor — no pin)"}
+            </p>
+          </Field>
+        )}
+
         {/* Model (#296/#324): dropdown + Custom… escape hatch (see ModelPicker).
-            Hidden for a script node (#248): it launches no agent, so it has no
-            model. */}
+            Since #550 it edits the RESOLVED harness's model. Hidden for a script
+            node (#248): it launches no agent, so it has no model. */}
         {!isScript && (
           <Field label="Model">
             <ModelPicker
@@ -239,6 +294,9 @@ export default function NodeInspector({
               value={node.effort ?? null}
               onChange={(v) => handleField("effort", v)}
               testid="node-effort"
+              /* #550/AC #13: greyed when the resolved harness has no launch-time
+                 effort axis (measured: `opencode` has none). */
+              disabled={!harnessHasEffort(resolvedHarness)}
             />
           </Field>
         )}

--- a/frontend/src/components/SettingsModal.test.tsx
+++ b/frontend/src/components/SettingsModal.test.tsx
@@ -46,6 +46,8 @@ function sample(overrides: Partial<InstanceSettings> = {}): InstanceSettings {
     guard_timeout_secs: { effective: 60, source: "default", stored: null, env: null, default: 60 },
     // Unset by default (account default): effective/stored/env/default all null.
     default_model: { effective: null, source: "default", stored: null, env: null, default: null },
+    default_harness: { effective: null, source: "default", stored: null, env: null, default: null },
+    default_harness_model: { effective: {}, stored: {} },
     // Default sandbox (#410): built-in default `off`, nothing stored/env. The ONLY sandbox
     // knob on this screen since #471 — image and Dockerfile belong to a staging profile.
     default_sandbox: { effective: "off", source: "default", stored: null, env: null, default: "off", reason: null },
@@ -381,6 +383,8 @@ describe("SettingsModal", () => {
     updateSettingsMock.mockResolvedValue(
       sample({
         default_model: { effective: "opus", source: "stored", stored: "opus", env: null, default: null },
+        default_harness: { effective: null, source: "default", stored: null, env: null, default: null },
+        default_harness_model: { effective: {}, stored: {} },
       }),
     );
     const onClose = vi.fn();
@@ -401,6 +405,8 @@ describe("SettingsModal", () => {
     fetchSettingsMock.mockResolvedValue(
       sample({
         default_model: { effective: "opus", source: "stored", stored: "opus", env: null, default: null },
+        default_harness: { effective: null, source: "default", stored: null, env: null, default: null },
+        default_harness_model: { effective: {}, stored: {} },
       }),
     );
     updateSettingsMock.mockResolvedValue(sample());
@@ -422,6 +428,8 @@ describe("SettingsModal", () => {
     fetchSettingsMock.mockResolvedValue(
       sample({
         default_model: { effective: "opus", source: "stored", stored: "opus", env: "sonnet", default: null },
+        default_harness: { effective: null, source: "default", stored: null, env: null, default: null },
+        default_harness_model: { effective: {}, stored: {} },
       }),
     );
     render(<SettingsModal open onClose={() => {}} />);

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -248,6 +248,18 @@ function SettingsForm({
   // Model is `null` when unset (account default); ModelPicker speaks the same
   // `string | null` contract as the per-node inspector (#296/#324/#347).
   const [model, setModel] = useState<string | null>(() => settings.default_model.effective);
+  // #550/ADR-0046: the harness axis. `defaultHarness` is `""` when unset (the
+  // `claude` floor applies); the two per-harness default models are edited as
+  // free text, empty = that harness's account default.
+  const [defaultHarness, setDefaultHarness] = useState<string>(
+    () => settings.default_harness.effective ?? "",
+  );
+  const [claudeDefaultModel, setClaudeDefaultModel] = useState<string>(
+    () => settings.default_harness_model.stored["claude"] ?? "",
+  );
+  const [opencodeDefaultModel, setOpencodeDefaultModel] = useState<string>(
+    () => settings.default_harness_model.stored["opencode"] ?? "",
+  );
   // Default sandbox (#410/#432): `off` or a staging-profile name. `effective` is always
   // a present string (the `?? "off"` is belt-and-braces).
   const [defaultSandbox, setDefaultSandbox] = useState<string>(
@@ -322,6 +334,24 @@ function SettingsForm({
     // sent when it actually changed (avoids a needless clear/no-op PUT).
     if (model !== settings.default_model.effective) {
       patch.default_model = model ?? "";
+    }
+    // #550: the harness axis. `""` clears the default harness (same sentinel as
+    // the model). The per-harness default model map is sent whole when either
+    // known entry changed; a trimmed-empty value drops that harness's entry.
+    if (defaultHarness !== (settings.default_harness.effective ?? "")) {
+      patch.default_harness = defaultHarness;
+    }
+    const storedModels = settings.default_harness_model.stored;
+    const claudeM = claudeDefaultModel.trim();
+    const opencodeM = opencodeDefaultModel.trim();
+    if (
+      (claudeM || undefined) !== (storedModels["claude"] || undefined) ||
+      (opencodeM || undefined) !== (storedModels["opencode"] || undefined)
+    ) {
+      const map: Record<string, string> = {};
+      if (claudeM) map["claude"] = claudeM;
+      if (opencodeM) map["opencode"] = opencodeM;
+      patch.default_harness_model = map;
     }
 
     // Default sandbox mode (#410): a concrete enum variant, only sent when it changed. The
@@ -515,6 +545,71 @@ function SettingsForm({
             data-testid="setting-source-default-model"
           >
             {modelSourceNote(settings.default_model)}
+          </div>
+        </div>
+
+        {/* Default harness (#550/ADR-0046): the harness a new node runs on unless
+            it pins its own or a coarser tier sets one. Precedence at spawn:
+            node → Run → Projet → instance (this) → claude floor. */}
+        <div className="flex flex-col gap-1.5" data-testid="setting-default-harness">
+          <label className="font-medium text-fg-2" style={{ fontSize: "11.5px" }}>
+            Default harness
+          </label>
+          <select
+            value={defaultHarness}
+            onChange={(e) => setDefaultHarness(e.target.value)}
+            data-testid="setting-default-harness-select"
+            className="rounded border border-line-strong bg-bg-3 px-2 py-1 text-fg"
+            style={{ fontSize: "11px" }}
+          >
+            <option value="">Default (claude floor)</option>
+            <option value="claude">claude</option>
+            <option value="opencode">opencode</option>
+          </select>
+          <div className="text-fg-4" style={{ fontSize: "10.5px" }}>
+            Every new node runs on this harness unless it pins its own. "Default"
+            leaves it to the <span className="font-mono">claude</span> floor.
+          </div>
+          <div
+            className="text-fg-3"
+            style={{ fontSize: "10.5px" }}
+            data-testid="setting-source-default-harness"
+          >
+            {modelSourceNote(settings.default_harness)}
+          </div>
+        </div>
+
+        {/* Default model per harness (#550/ADR-0046): a slug means nothing outside
+            its harness, so the instance default model is per-harness. Free text. */}
+        <div className="flex flex-col gap-1.5" data-testid="setting-default-harness-model">
+          <label className="font-medium text-fg-2" style={{ fontSize: "11.5px" }}>
+            Default model per harness
+          </label>
+          <label className="flex items-center gap-2 text-fg-3" style={{ fontSize: "11px" }}>
+            <span className="w-16 font-mono">claude</span>
+            <input
+              type="text"
+              value={claudeDefaultModel}
+              onChange={(e) => setClaudeDefaultModel(e.target.value)}
+              placeholder="account default"
+              data-testid="setting-default-model-claude"
+              className="flex-1 rounded border border-line-strong bg-bg-3 px-2 py-1 text-fg"
+            />
+          </label>
+          <label className="flex items-center gap-2 text-fg-3" style={{ fontSize: "11px" }}>
+            <span className="w-16 font-mono">opencode</span>
+            <input
+              type="text"
+              value={opencodeDefaultModel}
+              onChange={(e) => setOpencodeDefaultModel(e.target.value)}
+              placeholder="account default"
+              data-testid="setting-default-model-opencode"
+              className="flex-1 rounded border border-line-strong bg-bg-3 px-2 py-1 text-fg"
+            />
+          </label>
+          <div className="text-fg-4" style={{ fontSize: "10.5px" }}>
+            The model a node runs with on that harness when it sets none. Empty = the
+            harness account default.
           </div>
         </div>
 

--- a/frontend/src/lib/harness.ts
+++ b/frontend/src/lib/harness.ts
@@ -1,0 +1,78 @@
+// The agentic-harness axis, client side (#550, ADR-0046).
+//
+// The daemon owns the truth (descriptor + resolver); this module is the thin
+// client mirror the editor needs: which harnesses exist, which one an editor node
+// resolves to, whether a harness exposes an effort axis (to grey the picker), and
+// the fold between the node's per-harness `harnesses` map and the single
+// `model`/`effort` view the existing pickers edit.
+
+import type { NodeDef } from "../types";
+
+/** The floor of the precedence chain — a node with no pin runs on `claude`. */
+export const HARNESS_FLOOR = "claude";
+
+/** The harnesses PDO ships embedded (ADR-0045). The pin selector offers these
+ *  plus "Default" (follow the tier above). A user-declared disk harness (#553)
+ *  would extend this; not in this slice. */
+export const KNOWN_HARNESSES = ["claude", "opencode"] as const;
+
+/** Client mirror of the descriptor's `{effort}` hole (ADR-0045): `opencode` has
+ *  no launch-time effort axis, so its effort picker is greyed. An unknown harness
+ *  defaults to "has effort" — the conservative choice (don't grey what we can't
+ *  see; the daemon still ignores an effort a harness can't honour). */
+const HARNESS_HAS_EFFORT: Record<string, boolean> = {
+  claude: true,
+  opencode: false,
+};
+
+export function harnessHasEffort(name: string): boolean {
+  return HARNESS_HAS_EFFORT[name] ?? true;
+}
+
+/** The harness an editor node resolves to, with only the tiers a client knows:
+ *  the node's pin, else the `claude` floor. (The instance default is a coarser
+ *  tier the editor does not fetch per-node; the floor is the safe editor default,
+ *  and the daemon re-resolves authoritatively at spawn.) An empty pin is "unset". */
+export function resolveEditorHarness(node: Pick<NodeDef, "pin_harness">): string {
+  const pin = node.pin_harness;
+  return pin && pin !== "" ? pin : HARNESS_FLOOR;
+}
+
+/** Load fold: project the RESOLVED harness's `{model, effort}` out of the node's
+ *  `harnesses` map onto the flat `model`/`effort` the pickers edit. Returns a new
+ *  node; the `harnesses` map is preserved so non-resolved entries survive a
+ *  round-trip. Idempotent. */
+export function foldHarnessOntoNode(node: NodeDef): NodeDef {
+  const resolved = resolveEditorHarness(node);
+  const entry = node.harnesses?.[resolved];
+  return {
+    ...node,
+    model: entry?.model ?? null,
+    effort: entry?.effort ?? null,
+  };
+}
+
+/** Save fold: merge the flat `model`/`effort` back into `harnesses[resolved]`,
+ *  preserving every other harness's entry, and dropping an entry that carries
+ *  neither. Returns the harnesses map to emit (or `undefined` when empty). */
+export function foldNodeIntoHarnesses(
+  node: NodeDef,
+): Record<string, { model?: string; effort?: string }> | undefined {
+  const resolved = resolveEditorHarness(node);
+  const out: Record<string, { model?: string; effort?: string }> = {};
+  // Carry over existing entries (non-resolved harnesses keep their settings).
+  for (const [name, entry] of Object.entries(node.harnesses ?? {})) {
+    const model = entry?.model || undefined;
+    const effort = entry?.effort || undefined;
+    if (model || effort) out[name] = { ...(model ? { model } : {}), ...(effort ? { effort } : {}) };
+  }
+  // Overlay the flat view onto the resolved harness.
+  const model = node.model || undefined;
+  const effort = node.effort || undefined;
+  if (model || effort) {
+    out[resolved] = { ...(model ? { model } : {}), ...(effort ? { effort } : {}) };
+  } else {
+    delete out[resolved];
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}

--- a/frontend/src/lib/layoutFields.test.ts
+++ b/frontend/src/lib/layoutFields.test.ts
@@ -67,6 +67,10 @@ const NODE: Complete<NodeDef> = {
   // `serializePipeline.test.ts` (the key lands in the YAML object) and in
   // `editStore.test.ts` (edit → spread → serializer → save payload).
   effort: "low",
+  // #550/ADR-0046: `Complete<NodeDef>` forces these two; same caveat as above —
+  // naming them proves nothing about emission (the serializer tests do that).
+  pin_harness: "claude",
+  harnesses: { claude: { model: "opus", effort: "low" } },
 };
 const EDGE: Complete<EdgeDef> = {
   source: { node: "n1", port: "out" },

--- a/frontend/src/lib/layoutFields.ts
+++ b/frontend/src/lib/layoutFields.ts
@@ -43,11 +43,13 @@ export type SerializerScope =
 
 export const SEMANTIC_FIELDS: Record<SerializerScope, readonly string[]> = {
   pipeline: ["name", "version", "prompt_required", "variables", "nodes", "edges", "loops"] satisfies (keyof PipelineDef)[],
-  // #424: `effort` is SEMANTIC, like `model` — it changes how the agent behaves,
-  // so it belongs in the pipeline diff and in the library content hash. What is
-  // load-bearing is its ABSENCE from LAYOUT_FIELDS.node: that is what keeps
-  // `stripLayout` from dropping it.
-  node: ["id", "name", "type", "interactive", "model", "effort", "max_iter", "inputs", "outputs"] satisfies (keyof NodeDef)[],
+  // #550/ADR-0046: the harness axis replaces the flat `model`/`effort` (#296/#424)
+  // the serializer used to emit. `pin_harness` and the per-harness `harnesses` map
+  // are SEMANTIC — they change what runs the node and how — so they belong in the
+  // pipeline diff and the library content hash. What is load-bearing is their
+  // ABSENCE from LAYOUT_FIELDS.node: that is what keeps `stripLayout` from dropping
+  // them.
+  node: ["id", "name", "type", "interactive", "pin_harness", "harnesses", "max_iter", "inputs", "outputs"] satisfies (keyof NodeDef)[],
   // `side` is SEMANTIC today (emitted, not stripped) — deliberate, see #355 D5:
   // the node-library star already treats port side as identity, so the pipeline
   // diff must agree or the two stars contradict each other on the same edit.

--- a/frontend/src/lib/newRunForm.test.ts
+++ b/frontend/src/lib/newRunForm.test.ts
@@ -35,6 +35,8 @@ function settings(over: Partial<InstanceSettings> = {}): InstanceSettings {
     reaper_ttl_secs: { effective: 3600, source: "default", stored: null, env: null, default: 3600 },
     guard_timeout_secs: { effective: 60, source: "default", stored: null, env: null, default: 60 },
     default_model: { effective: null, source: "default", stored: null, env: null, default: null },
+    default_harness: { effective: null, source: "default", stored: null, env: null, default: null },
+    default_harness_model: { effective: {}, stored: {} },
     default_sandbox: { effective: "off", source: "default", stored: null, env: null, default: "off", reason: null },
     sandbox_docker: { available: true, reason: null, checked_at: "2026-07-01T10:00:00.000Z" },
     sandbox_profiles: [

--- a/frontend/src/lib/serializePipeline.test.ts
+++ b/frontend/src/lib/serializePipeline.test.ts
@@ -133,6 +133,60 @@ describe("serializePipeline round-trip: YAML structural correctness", () => {
     expect(serializePipeline(makeFullPipeline([impl]))).toContain("effort: turbo");
   });
 
+  // #550/ADR-0046: the flat model/effort view is folded under `harnesses.<resolved>`
+  // — the substring assertions above pass by coincidence (the block CONTAINS
+  // "model: opus"); these pin the STRUCTURE and the pin.
+  it("folds model/effort under harnesses.claude for an unpinned node (#550)", () => {
+    const impl: NodeDef = {
+      id: "impl", name: "implementer", type: "code-mutating",
+      inputs: [], outputs: [{ name: "code", repeated: false, side: "right" }],
+      interactive: false, view: { x: 200, y: 0 }, model: "opus", effort: "low",
+    };
+    const yaml = serializePipeline(makeFullPipeline([impl]));
+    expect(yaml).toContain("harnesses:");
+    // The dumper emits a small map in flow style.
+    expect(yaml).toContain("claude: { model: opus, effort: low }");
+    // No pin when the node relies on the floor.
+    expect(yaml).not.toContain("pin_harness:");
+  });
+
+  it("emits pin_harness and folds model under the PINNED harness (#550)", () => {
+    const impl: NodeDef = {
+      id: "impl", name: "implementer", type: "code-mutating",
+      inputs: [], outputs: [{ name: "code", repeated: false, side: "right" }],
+      interactive: false, view: { x: 200, y: 0 },
+      pin_harness: "opencode", model: "openrouter/foo",
+    };
+    const yaml = serializePipeline(makeFullPipeline([impl]));
+    expect(yaml).toContain("pin_harness: opencode");
+    expect(yaml).toContain("opencode: { model: openrouter/foo }");
+  });
+
+  it("preserves a non-resolved harness's entry across a round-trip (#550)", () => {
+    // Editing on the resolved harness (claude) must not clobber opencode's entry.
+    const impl: NodeDef = {
+      id: "impl", name: "implementer", type: "code-mutating",
+      inputs: [], outputs: [{ name: "code", repeated: false, side: "right" }],
+      interactive: false, view: { x: 200, y: 0 },
+      model: "opus", // resolved = claude (no pin)
+      harnesses: { opencode: { model: "openrouter/bar" } },
+    };
+    const yaml = serializePipeline(makeFullPipeline([impl]));
+    expect(yaml).toContain("openrouter/bar"); // opencode entry survived
+    expect(yaml).toContain("opus"); // claude entry from the flat view
+  });
+
+  it("omits harnesses entirely for a plain node (#550, no-diverge default)", () => {
+    const impl: NodeDef = {
+      id: "impl", name: "implementer", type: "code-mutating",
+      inputs: [], outputs: [{ name: "code", repeated: false, side: "right" }],
+      interactive: false, view: { x: 200, y: 0 },
+    };
+    const yaml = serializePipeline(makeFullPipeline([impl]));
+    expect(yaml).not.toContain("harnesses:");
+    expect(yaml).not.toContain("pin_harness:");
+  });
+
   it("omits effort when unset/null/empty — the byte-identical default (#424)", () => {
     // `undefined`, `null` and `""` must all serialize as an ABSENT key: an
     // `effort: ""` in the file would reach the tail as an empty `--effort`, which

--- a/frontend/src/lib/serializePipeline.ts
+++ b/frontend/src/lib/serializePipeline.ts
@@ -29,6 +29,8 @@ import type {
   PortSide,
   FrontmatterFieldDecl,
 } from "../types";
+// #550: the per-harness fold (pure, `../types`-only) — keeps this module pure.
+import { foldNodeIntoHarnesses } from "./harness";
 
 /**
  * Drops the null-valued keys of every frontmatter declaration (#457).
@@ -90,18 +92,16 @@ export function pipelineToYamlObject(p: PipelineDef): Record<string, unknown> {
       type: n.type,
     };
     if (n.interactive) node.interactive = true;
-    // Per-node model override (#296): semantic (compared in the pipeline diff),
-    // emitted only when set so an unset node and a library twin with no model
-    // both produce objects without the key and stay `synced`, not `diverged`.
-    if (n.model) node.model = n.model;
-    // Per-node effort override (#424): semantic (compared in the pipeline diff),
-    // emitted only when set — the truthiness guard folds `undefined`, `null` AND
-    // `""` into "absent", which is what keeps an unset node byte-identical to a
-    // library twin with no effort (`synced`, not `diverged`) and what holds the
-    // launch-command byte-identity gate. This emitter and `exportNodeAsYaml` are
-    // deliberately NOT unified (see the note further down) — a field added here
-    // must be added there too.
-    if (n.effort) node.effort = n.effort;
+    // #550/ADR-0046: the harness axis replaces flat `model:`/`effort:`. The pin is
+    // emitted when set; the flat model/effort view is folded back into the
+    // resolved harness's entry in the per-harness `harnesses` map, emitted only
+    // when non-empty — so an unset node and a library twin with no settings both
+    // produce objects without the keys and stay `synced`, not `diverged`. This
+    // emitter and `exportNodeAsYaml` are deliberately NOT unified (see the note
+    // further down) — a field added here must be added there too.
+    if (n.pin_harness) node.pin_harness = n.pin_harness;
+    const harnesses = foldNodeIntoHarnesses(n);
+    if (harnesses) node.harnesses = harnesses;
     // Legacy `type: loop` nodes (pre-region model, ADR-0011) carry a node-level
     // `max_iter` that the daemon still requires and validates
     // (`pipeline.rs` `NodeType::Loop`). The current model emits `max_iter` on the

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -248,6 +248,16 @@ export interface InstanceSettings {
   reaper_ttl_secs: SettingField;
   guard_timeout_secs: SettingField;
   default_model: StringSettingField;
+  /** #550/ADR-0046: instance-wide default harness (`stored → env → floor claude`).
+   *  `effective: null` ⇒ the `claude` floor applies at resolve. */
+  default_harness: StringSettingField;
+  /** #550/ADR-0046: instance-wide default model **per harness**. `effective` is
+   *  the resolved map (the stored map plus the legacy `PDO_DEFAULT_MODEL` folded
+   *  under `claude`); `stored` is the raw stored map. */
+  default_harness_model: {
+    effective: Record<string, string>;
+    stored: Record<string, string>;
+  };
   /**
    * Instance-wide default sandbox (#410/#432): `"off"` (host, default) or the name of a
    * **staging profile**. No longer a closed enum — its value space is the user's profile
@@ -366,6 +376,11 @@ export interface UpdateSettingsRequest {
   reaper_ttl_secs?: number;
   guard_timeout_secs?: number;
   default_model?: string;
+  /** #550: instance default harness; `""` clears it (same sentinel as
+   *  `default_model`). */
+  default_harness?: string;
+  /** #550: per-harness default model map; replaces the stored map wholesale. */
+  default_harness_model?: Record<string, string>;
   /** Default sandbox (#410/#432): `"off"` or a staging-profile name, or `""` to clear
    *  back to the built-in default (`off`). Same `""`-sentinel discipline as
    *  `default_model`. The daemon 400s a name that does not resolve.
@@ -816,7 +831,25 @@ export interface NodeDef {
   /** Optional per-node reasoning-effort override (#424): free-text pass-through
    *  to `claude --effort <level>`. Absent/null ⇒ no flag (account default).
    *  Orthogonal to `model`, and semantic — it enters the pipeline diff and the
-   *  node-library content hash. */
+   *  node-library content hash.
+   *
+   *  Since #550 this is the **resolved harness's** effort: folded out of
+   *  `harnesses[resolved].effort` on load, folded back on save. */
+  effort?: string | null;
+  /** #550/ADR-0046: the pinned harness (`claude`, `opencode`), or null/absent to
+   *  follow the tier above (instance default, else the `claude` floor). A pin both
+   *  selects the harness and shields it from every coarser tier. */
+  pin_harness?: string | null;
+  /** #550/ADR-0046: per-harness `{model, effort}` settings. `model`/`effort` above
+   *  are the RESOLVED harness's view (folded from this map on load, back into it on
+   *  save); the map preserves entries for the non-resolved harnesses. */
+  harnesses?: Record<string, HarnessSettings>;
+}
+
+/** #550/ADR-0046: a node's `{model, effort}` for one harness. Free-text
+ *  pass-through — a slug means nothing outside the harness that accepts it. */
+export interface HarnessSettings {
+  model?: string | null;
   effort?: string | null;
 }
 


### PR DESCRIPTION
Première tranche du **harnais agentique** (#550, PRD #549), livrée sur la branche
d'intégration de l'axe. La PR intégration → `main` est #554.

## Portée (slice 1 : `node → instance → plancher claude`)

- **Descripteur de harnais** (ADR-0045) : deux templates d'argv (lancement, reprise) + bloc
  d'env, rendus par un module **pur** `harness_argv` — règle unique « un token dont un trou est
  vide disparaît en entier ». Tail `claude` **identique au byte** quand rien de neuf n'est posé
  (goldens). `claude` et `opencode` dans le **plancher embarqué**, rien sur disque.
- **Résolution + gel au spawn** : l'axe `node → Run → Projet → instance → plancher claude` est
  résolu **une fois au spawn** et **gelé** dans l'événement de démarrage ; la reprise re-pose ce
  qui a été lancé, jamais le YAML courant (ADR-0007). Cette tranche câble `node → instance →
  plancher` ; les tiers Run et Projet suivent (#551, #552).
- **Migration du schéma de nœud** : `model:` / `effort:` plats → carte par harnais
  `harnesses.<nom>.{model, effort}` (ADR-0046) ; migrateur automatique, données historiques
  restent lisibles.
- **UI** : sélecteur de harnais + harnais résolu dans l'inspecteur ; `EffortPicker` **désactivé**
  (pas masqué) sur `opencode` — l'absence d'axe d'effort est déclarée par la forme du descripteur
  (AC #13) ; tier instance dans les Réglages.

## Validation (nœud agentique, verdict **Pass**)

- Gates CI verts : `cargo check` / `clippy -D warnings` / `fmt --check`, `tsc -b`, `eslint`,
  `npm run build`, **vitest 1752/0**.
- `cargo test` : 3 rouges **préexistants** (identiques sur `main` par contrôle négatif) — flake
  docker-env + tests de timing sweep de l'hôte headless, **pas** des régressions de #550.
- Test agentique UI (Playwright, pile isolée sur port dédié, prod :6160 intouchée) : sélecteur
  de harnais, « Resolved: claude (floor) » → « opencode (pinned) », grisage d'effort mesuré
  (`aria-disabled`, boutons `disabled`), réglages d'instance. Captures à l'appui.

Cassant, migration automatique — voir CHANGELOG 1.26.0.

Closes #550
