### PR TITLE
feat(#551): le Run choisit son harnais — tier de précédence, New Run, Trigger, sessions d'infra

### DIFF
--- a/crates/pdo-daemon/src/event_log.rs
+++ b/crates/pdo-daemon/src/event_log.rs
@@ -773,6 +773,21 @@ pub struct RunState {
     pub sandbox_prep: Option<SandboxPrepState>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_branch: Option<String>,
+    /// The harness chosen at Run creation (#551, ADR-0046), **frozen** here from the
+    /// `RunStarted` payload — the middle tier of the precedence chain
+    /// `nœud → Run → Projet → instance → plancher (claude)`. Immutable, exactly like
+    /// [`RunState::sandbox`]: set once from the create event, never mutated, so a
+    /// pipeline edit or a changed instance default cannot re-decide a Run in flight.
+    ///
+    /// `None` ⇒ the Run named no harness, so each free node resolves through the
+    /// instance default and the floor as before (every historical Run, and any Run
+    /// created without an explicit choice — the payload omits the key, keeping it
+    /// byte-identical to the pre-#551 shape). A blank/empty stored value collapses to
+    /// `None` at the freeze (`Some("")` never persists), so it can never win a tier
+    /// (#347). Read at every spawn seam as the `run` tier of [`crate::harness_resolver`]
+    /// and by the infra sessions (Pipeline Manager, merge resolver).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub harness: Option<String>,
     /// Provenance: the id of the Trigger that created this Run, if any.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub triggered_by: Option<String>,
@@ -836,6 +851,7 @@ impl RunState {
             sandbox_image_raw_error: None,
             sandbox_prep: None,
             source_branch: None,
+            harness: None,
             triggered_by: None,
             pipeline_id: None,
             sessions_spawned: 0,
@@ -1285,6 +1301,18 @@ fn apply_run_event(state: &mut RunState, event: &Event) {
                 }
                 if let Some(sb) = payload.get("source_branch").and_then(|v| v.as_str()) {
                     state.source_branch = Some(sb.to_string());
+                }
+                // #551 (ADR-0046): the FROZEN Run harness, projected the same way as
+                // `source_branch`. The create chokepoint only writes this key for a
+                // non-empty choice, so an absent key (every historical Run, every Run
+                // with no explicit harness) leaves `None` — the free nodes then resolve
+                // through the instance default and the `claude` floor. A blank string
+                // never reaches here (normalised away at the freeze), so it cannot win a
+                // tier (#347).
+                if let Some(h) = payload.get("harness").and_then(|v| v.as_str()) {
+                    if !h.is_empty() {
+                        state.harness = Some(h.to_string());
+                    }
                 }
                 if let Some(tb) = payload.get("triggered_by").and_then(|v| v.as_str()) {
                     state.triggered_by = Some(tb.to_string());
@@ -4702,6 +4730,36 @@ mod tests {
             serde_json::json!({ "pipeline_name": "p", "target_repos": "not-an-array" }),
         )];
         assert!(project(&malformed).unwrap().target_repos.is_empty());
+    }
+
+    /// #551 (ADR-0046): the `RunStarted.harness` freeze projects into
+    /// `RunState.harness`; an absent key (every historical Run, every Run with no
+    /// explicit choice) stays `None`; an empty string never wins a tier (#347).
+    #[test]
+    fn harness_projects_and_defaults_to_none() {
+        // Present + non-empty → frozen verbatim.
+        let with = vec![make_event_with_payload(
+            EventKind::RunStarted,
+            None,
+            serde_json::json!({ "pipeline_name": "p", "harness": "opencode" }),
+        )];
+        assert_eq!(project(&with).unwrap().harness.as_deref(), Some("opencode"));
+
+        // Absent key → None (resolve through the instance default and the floor).
+        let legacy = vec![make_event_with_payload(
+            EventKind::RunStarted,
+            None,
+            serde_json::json!({ "pipeline_name": "p" }),
+        )];
+        assert_eq!(project(&legacy).unwrap().harness, None);
+
+        // Empty string → None: a blank freeze can never win a precedence tier (#347).
+        let blank = vec![make_event_with_payload(
+            EventKind::RunStarted,
+            None,
+            serde_json::json!({ "pipeline_name": "p", "harness": "" }),
+        )];
+        assert_eq!(project(&blank).unwrap().harness, None);
     }
 
     /// #465 slice 2 (ADR-0042): `RunReposEdited` overwrites `target_repos`

--- a/crates/pdo-daemon/src/harness_resolver.rs
+++ b/crates/pdo-daemon/src/harness_resolver.rs
@@ -103,6 +103,22 @@ pub(crate) fn resolve_effort(node_entry_effort: Option<&str>) -> Option<String> 
         .map(str::to_string)
 }
 
+/// The harness an **infra** session (Pipeline Manager, merge resolver) runs on
+/// (#551, ADR-0046). Infra sessions have no NodeDef, so no `node` tier and no
+/// model/effort of their own: they follow the Run's frozen harness, then the
+/// instance default, then the `claude` floor — `Run → instance → plancher`. This
+/// is what makes "ce Run tourne sur X" true with no exception to remember (the
+/// A/B on a new harness also exercises the unblocking tool). Same empty-string
+/// collapse as [`resolve_harness`] (the `Some("")` trap of #347).
+pub(crate) fn resolve_infra_harness(run: Option<&str>, instance_default: Option<&str>) -> String {
+    resolve_harness(&HarnessTiers {
+        node_pin: None,
+        run,
+        project: None,
+        instance_default,
+    })
+}
+
 /// The single precedence point both spawn seams call (like `effective_sandbox`):
 /// resolve the harness, then read the model and effort from the **winning
 /// harness's** entry. Shaped so #551/#552 fill `tiers.run`/`tiers.project`
@@ -209,6 +225,31 @@ mod tests {
         assert_eq!(resolve_harness(&tiers), CLAUDE);
     }
 
+    // ---- infra sessions follow the Run's harness (#551) ---------------------
+
+    #[test]
+    fn infra_harness_follows_the_run_then_instance_then_floor() {
+        // AC: the Pipeline Manager and merge resolver run on the harness OF THE RUN,
+        // no node tier, no model/effort. Run wins over the instance default…
+        assert_eq!(
+            resolve_infra_harness(Some(OPENCODE), Some(CLAUDE)),
+            OPENCODE
+        );
+        // …the instance default backs an unset Run…
+        assert_eq!(resolve_infra_harness(None, Some(OPENCODE)), OPENCODE);
+        // …and with neither set, the manager stays on the `claude` floor — the
+        // byte-identical legacy manager launch (the control).
+        assert_eq!(resolve_infra_harness(None, None), CLAUDE);
+    }
+
+    #[test]
+    fn infra_harness_ignores_a_blank_run_choice() {
+        // A blank Run harness (`Some("")`) is "unset", not a harness named "" — it
+        // must fall through to the instance default, never to an unknown harness.
+        assert_eq!(resolve_infra_harness(Some(""), Some(OPENCODE)), OPENCODE);
+        assert_eq!(resolve_infra_harness(Some(""), Some("")), CLAUDE);
+    }
+
     // ---- model / effort read from the WINNING harness's entry ---------------
 
     #[test]
@@ -226,6 +267,33 @@ mod tests {
         // opencode's entry wins — NOT claude's, even though claude has richer settings.
         assert_eq!(r.model.as_deref(), Some("openrouter/foo"));
         assert_eq!(r.effort, None);
+    }
+
+    #[test]
+    fn a_run_switched_to_another_harness_reads_the_new_harness_entry_not_the_old() {
+        // AC (#551): a Run basculé sur un autre harnais n'hérite jamais du slug écrit pour
+        // le précédent — the model/effort come from the WINNING (Run-tier) harness entry.
+        // Same node, two Runs: no Run harness → claude wins → claude's slug; Run picks
+        // opencode → opencode wins → opencode's slug, never claude's.
+        let node_entries = entries(&[
+            (CLAUDE, Some("opus"), Some("high")),
+            (OPENCODE, Some("openrouter/foo"), None),
+        ]);
+
+        let on_claude = resolve(&HarnessTiers::default(), &node_entries, &no_defaults());
+        assert_eq!(on_claude.harness, CLAUDE);
+        assert_eq!(on_claude.model.as_deref(), Some("opus"));
+        assert_eq!(on_claude.effort.as_deref(), Some("high"));
+
+        let run_opencode = HarnessTiers {
+            run: Some(OPENCODE),
+            ..Default::default()
+        };
+        let on_opencode = resolve(&run_opencode, &node_entries, &no_defaults());
+        assert_eq!(on_opencode.harness, OPENCODE);
+        // opencode's entry wins — claude's `opus`/`high` never leak onto the switched Run.
+        assert_eq!(on_opencode.model.as_deref(), Some("openrouter/foo"));
+        assert_eq!(on_opencode.effort, None);
     }
 
     #[test]

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -467,6 +467,17 @@ struct CreateRunRequest {
     /// (`create_run_inner`) resolves it once against the fresh instance default.
     #[serde(default)]
     sandbox: Option<event_log::SandboxMode>,
+    /// The agentic harness this Run chooses (#551, ADR-0046) — the `run` tier of the
+    /// precedence chain `nœud → Run → Projet → instance → plancher (claude)`. Free
+    /// text (ADR-0045: PDO does not validate a harness name; an unknown one fails fast
+    /// at spawn, naming it). `#[serde(default)]` → an omitted/`null`/blank field means
+    /// "the Run names no harness", so each free node resolves through the instance
+    /// default and the floor — byte-identical to the pre-#551 shape. Frozen into
+    /// `RunStarted` at the create chokepoint (same immutability as `sandbox`); a
+    /// pinned node still ignores it. A Trigger fire folds its stored harness in here
+    /// (a Run has a single origin), so "Run now" and a cron tick produce the same one.
+    #[serde(default)]
+    harness: Option<String>,
     /// Whether the manager auto-names this Run (#338). `Option`, NOT `bool`:
     /// `#[serde(default)]` → `None` is an **omitted** field, which resolves
     /// back-compatibly by the presence of `name` (a supplied `name` with no flag
@@ -1877,6 +1888,7 @@ impl DaemonHandle {
                 overlap_policy: "skip".to_string(),
                 max_concurrent: None,
                 sandbox: None,
+                harness: None,
                 auto_name: true,
                 next_fire_at: Some("2030-01-01T00:00:00.000Z".to_string()),
             },
@@ -2882,6 +2894,11 @@ struct CreateTriggerRequest {
     /// request's explicit tier.
     #[serde(default)]
     sandbox: Option<String>,
+    /// Per-Trigger harness (#551, ADR-0046): a harness name, or absent/`null`/blank to
+    /// inherit the instance default. Read at fire time and folded into the fired Run's
+    /// harness (there is no separate Trigger tier). Free text — no validation (ADR-0045).
+    #[serde(default)]
+    harness: Option<String>,
     /// Whether Runs this Trigger fires are auto-named (#338). Seeded from the instance
     /// default in the create modal and frozen on the row; `#[serde(default)]` → `true`
     /// so an older client that omits the field keeps the pre-#338 auto-naming behaviour.
@@ -3215,6 +3232,9 @@ async fn create_trigger(
         // #410: normalise `Some("")` to `None` (inherit the instance default), so an
         // empty selector value never persists as a bogus stored mode.
         sandbox: req.sandbox.filter(|s| !s.trim().is_empty()),
+        // #551: same normalisation for the harness — a blank selector value inherits the
+        // instance default at fire time rather than persisting as a harness named "".
+        harness: req.harness.filter(|s| !s.trim().is_empty()),
         // #338: freeze the auto-naming choice on the row (seeded from the instance
         // default in the modal). No re-resolution at fire time — the runtime never
         // decides autonomy (ADR-0012 frontier).
@@ -3412,6 +3432,12 @@ struct PatchTriggerRequest {
     /// from JSON — that is what lets the UI reset a Trigger to "use the instance default".
     #[serde(default, deserialize_with = "deserialize_double_option")]
     sandbox: Option<Option<String>>,
+    /// Per-Trigger harness (#551), double-wrapped like `sandbox`: absent = leave, present
+    /// `null` = clear back to inheriting the instance default, `"name"` = set. The custom
+    /// deserializer makes present-`null` → `Some(None)` reachable from JSON — what lets the
+    /// UI reset a Trigger to "use the instance default".
+    #[serde(default, deserialize_with = "deserialize_double_option")]
+    harness: Option<Option<String>>,
     /// Auto-naming toggle (#338), a FLAT `Option<bool>` like `enabled` — NOT
     /// double-wrapped like `sandbox`/`max_concurrent`. There is no "inherit" state to
     /// clear back to: a Trigger's autonomy is a plain on/off. `None` leaves it,
@@ -3663,6 +3689,12 @@ async fn patch_trigger(
         // instance default, `None` leaves it. The FE maps the "use instance default"
         // option to `null`, so an empty string never reaches here.
         sandbox: req.sandbox,
+        // #551: `Some(Some(name))` sets, `Some(None)` clears to inherit, `None` leaves it.
+        // Normalise a stray `Some(Some(""))` to a clean clear (`Some(None)`) so a blank
+        // never persists as a harness named "" (defence in depth; the FE sends `null`).
+        harness: req
+            .harness
+            .map(|inner| inner.filter(|s| !s.trim().is_empty())),
         // #338: flat toggle — `Some(v)` sets, `None` leaves. No clear state.
         auto_name: req.auto_name,
         next_fire_at,
@@ -4877,6 +4909,12 @@ async fn fire_one_trigger(
                     .sandbox
                     .as_deref()
                     .and_then(event_log::SandboxMode::parse),
+                // #551 (ADR-0046): the Trigger carries the harness IN its Run template —
+                // there is no separate Trigger tier. Fold the stored harness into the
+                // create request's `run` choice, so a cron tick and a "Run now" (both
+                // route through here) freeze the SAME harness. A blank/absent stored
+                // value defers to the instance default. No validation (ADR-0045).
+                harness: trigger.harness.clone(),
                 // #338: pass the Trigger's frozen auto-naming choice as the explicit
                 // tier. `Some(b)` wins the chokepoint resolution unconditionally, so a
                 // fire with `auto_name=false` keeps a stable per-id name and the manager
@@ -6711,6 +6749,11 @@ async fn parse_multipart_create_run(
     // defers to the trigger/instance default at the chokepoint. An unknown token is
     // treated as unset (defensive; the FE only ever sends valid variants).
     let mut sandbox: Option<event_log::SandboxMode> = None;
+    // #551: an explicit harness may ride the multipart (browser) create when images
+    // are attached, so a harness choice is honoured on that path too. `None` when the
+    // field is absent/blank — the chokepoint then freezes nothing and the Run resolves
+    // through the instance default and the floor.
+    let mut harness: Option<String> = None;
     // #338: an explicit auto-naming choice may ride the multipart (browser) create
     // when images are attached, so an unchecked "Auto-generated" box is honoured on
     // that path too. `None` when the field is absent — the chokepoint then resolves
@@ -6809,6 +6852,17 @@ async fn parse_multipart_create_run(
                     sandbox = event_log::SandboxMode::parse(&v);
                 }
             }
+            "harness" => {
+                // #551: the explicit harness threaded off the multipart form. Empty →
+                // leave `None` (the Run names no harness). No validation (ADR-0045).
+                let v = field
+                    .text()
+                    .await
+                    .map_err(|e| format!("bad field harness: {e}"))?;
+                if !v.trim().is_empty() {
+                    harness = Some(v);
+                }
+            }
             "auto_name" => {
                 // #338: an explicit flag off the multipart form. Reuses the shared
                 // boolean parser; an unrecognised token leaves `None` (defer to the
@@ -6855,6 +6909,8 @@ async fn parse_multipart_create_run(
         // create with attached images). `None` when the field is absent — the
         // chokepoint then defers to the trigger/instance default.
         sandbox,
+        // #551: the explicit harness threaded off the multipart form.
+        harness,
         // #338: the explicit auto-naming choice threaded off the multipart form.
         auto_name,
     };
@@ -7312,6 +7368,24 @@ async fn create_run_inner(
     if let Some(ref branch) = effective_source_branch {
         run_payload["source_branch"] = serde_json::json!(branch);
     }
+    // #551 (ADR-0046): FREEZE the Run's harness choice into `RunStarted`, the same
+    // immutability posture as `sandbox` above — editing the pipeline or the instance
+    // default afterwards can never re-decide a Run in flight. Written ONLY for a
+    // non-blank choice, so a Run that names no harness keeps its payload byte-identical
+    // to the pre-#551 shape (absent key → `None` → resolve through the instance default
+    // and the floor). A blank/whitespace value is normalised to absent here, so the
+    // `Some("")` trap of #347 can never persist. `req.harness` already carries the Run's
+    // single-origin choice: a manual create's field, or a Trigger fire's folded harness.
+    // No validation (ADR-0045): an unknown name fails fast at the first node spawn,
+    // naming it — never here, never silently.
+    if let Some(h) = req
+        .harness
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        run_payload["harness"] = serde_json::json!(h);
+    }
     // Auto-naming autonomy decision (#338, ADR-0015). Resolved ONCE here, at the
     // same chokepoint as the sandbox default, and read FRESH from the DB so a
     // `PUT /settings` bites on the very next create with no restart (never cached at
@@ -7465,7 +7539,7 @@ async fn create_run_inner(
     if sandbox.is_off() {
         // Historical host path — inline, byte-identical to pre-#407. NO docker.
         spawn_ready_after_event(state, &run_id).await;
-        spawn_manager_session(state, &run_id, &worktree_dir, name_hint, false);
+        spawn_manager_session(state, &run_id, &worktree_dir, name_hint, false).await;
     } else {
         // #407 D3/D4: eager fail-fast prep on a detached, panic-isolated task
         // (mirror ADR-0023 — the 201 must not block on a first-run `docker
@@ -7544,7 +7618,8 @@ async fn create_run_inner(
                         &task_worktree,
                         name_hint,
                         true,
-                    );
+                    )
+                    .await;
                 }
                 Ok(Err(e)) => {
                     fail_run_sandbox_prep(
@@ -7673,7 +7748,7 @@ pub(crate) async fn fail_run_sandbox_prep(state: &AppState, run_id: &str, reason
 /// today: `create_run` appends `RunStarted` and `return Err`s on failure, well
 /// before either spawn site here (host, or the detached sandbox task). Keep it
 /// that way.
-fn spawn_manager_session(
+async fn spawn_manager_session(
     state: &AppState,
     run_id: &str,
     worktree_dir: &std::path::Path,
@@ -7709,10 +7784,28 @@ fn spawn_manager_session(
         marker: &session_name,
         workdir: worktree_dir,
     });
-    // #550/ADR-0046: infra sessions follow the Run's harness; the Run tier is #551,
-    // so in this slice the manager runs on the `claude` floor — byte-identical to
-    // the legacy manager launch (no model, no effort, no session id).
-    let manager_harness = harness_registry::claude();
+    // #551/ADR-0046: the manager follows the harness OF THE RUN — `Run → instance →
+    // floor`, no node tier and (deliberately) no model/effort. So "ce Run tourne sur
+    // X" holds with no exception to remember: an A/B on a new harness exercises the
+    // manager too. When the Run named no harness AND the instance default is unset,
+    // this resolves to the `claude` floor — byte-identical to the legacy manager
+    // launch. An unknown name (only reachable via an unvalidated Run choice, ADR-0045)
+    // falls back to `claude` with a warning rather than failing the whole Run here:
+    // the first NODE spawn is where an unknown harness fails fast (ADR-0037), and the
+    // manager is a best-effort assist that must not itself wedge the Run.
+    let run_harness = reload_run_state(state, run_id)
+        .await
+        .and_then(|(_, s)| s.harness);
+    let default_harness = stored_default_harness(&state.db).await;
+    let manager_harness_name =
+        harness_resolver::resolve_infra_harness(run_harness.as_deref(), default_harness.as_deref());
+    let manager_harness = harness_registry::resolve(&manager_harness_name).unwrap_or_else(|| {
+        warn!(
+            "manager for run {run_id}: unknown harness '{manager_harness_name}' — \
+             launching the manager on the claude floor (the first node spawn fails fast)"
+        );
+        harness_registry::claude()
+    });
     if let Err(e) = tmux_session_manager::spawn(
         &session_name,
         &full_prompt,
@@ -10918,11 +11011,13 @@ async fn spawn_merge_resolver(
     let prompt = load_merge_resolver_prompt(&state.repo_root);
     let session_name = tmux_session_manager::node_session_name(run_id, MERGE_RESOLVER_NODE_ID, 1);
 
-    // #407: the merge resolver runs inside the Run's container when sandboxed.
-    // Project the (immutable) mode; default `off` if the state can't be reloaded.
-    let sandbox_mode = reload_run_state(state, run_id)
+    // #407/#551: the merge resolver runs inside the Run's container when sandboxed
+    // AND on the harness OF THE RUN. Project both from the SAME (immutable) reload —
+    // the mode defaults to `off`, the harness to `None`, if the state can't be
+    // reloaded.
+    let (sandbox_mode, run_harness) = reload_run_state(state, run_id)
         .await
-        .map(|(_, s)| s.sandbox)
+        .map(|(_, s)| (s.sandbox, s.harness))
         .unwrap_or_default();
 
     let resolver_started = event_log::Event {
@@ -10947,9 +11042,20 @@ async fn spawn_merge_resolver(
         marker: &session_name,
         workdir: worktree_dir,
     });
-    // #550/ADR-0046: infra sessions follow the Run's harness (Run tier = #551), so
-    // the merge resolver runs on the `claude` floor in this slice — byte-identical.
-    let resolver_harness = harness_registry::claude();
+    // #551/ADR-0046: the merge resolver follows the harness OF THE RUN, exactly like
+    // the manager — `Run → instance → floor`, no node tier, no model/effort. Unknown
+    // name (unvalidated Run choice, ADR-0045) falls back to `claude` with a warning:
+    // the resolver is dead in production since ADR-0006, so this is defence in depth.
+    let default_harness = stored_default_harness(&state.db).await;
+    let resolver_harness_name =
+        harness_resolver::resolve_infra_harness(run_harness.as_deref(), default_harness.as_deref());
+    let resolver_harness = harness_registry::resolve(&resolver_harness_name).unwrap_or_else(|| {
+        warn!(
+            "merge resolver for run {run_id}: unknown harness '{resolver_harness_name}' — \
+             launching on the claude floor"
+        );
+        harness_registry::claude()
+    });
     if let Err(e) = tmux_session_manager::spawn(
         &session_name,
         &prompt,

--- a/crates/pdo-daemon/src/node_primitives.rs
+++ b/crates/pdo-daemon/src/node_primitives.rs
@@ -389,7 +389,10 @@ pub(crate) fn start_node(params: &StartNodeParams<'_>) -> StartNodeResult {
         }
         let tiers = harness_resolver::HarnessTiers {
             node_pin: node.pin_harness.as_deref(),
-            run: None,     // #551
+            // #551: the Run tier — the harness frozen in this Run's `RunStarted`, read
+            // from the projected state the caller already holds. A pinned node ignores
+            // it; a free node follows it (ADR-0046). Mirrors `node_spawn`.
+            run: params.run_state.harness.as_deref(),
             project: None, // #552
             instance_default: params.default_harness.as_deref(),
         };

--- a/crates/pdo-daemon/src/node_spawn.rs
+++ b/crates/pdo-daemon/src/node_spawn.rs
@@ -331,7 +331,10 @@ pub(crate) async fn spawn_node(
         let default_models = stored_default_harness_models(deps.db).await;
         let tiers = harness_resolver::HarnessTiers {
             node_pin: node.pin_harness.as_deref(),
-            run: None,     // #551
+            // #551: the Run tier — the harness frozen in this Run's `RunStarted`
+            // (`projected` is the fresh projection loaded at the head of this spawn).
+            // A pinned node still ignores it; a free node follows it (ADR-0046).
+            run: projected.and_then(|s| s.harness.as_deref()),
             project: None, // #552
             instance_default: default_harness.as_deref(),
         };

--- a/crates/pdo-daemon/src/run_command.rs
+++ b/crates/pdo-daemon/src/run_command.rs
@@ -1381,6 +1381,15 @@ async fn dispatch(state: Arc<AppState>, run_id: String, cmd: RunCommand) -> Resp
                 // Side effect, intended: a profile deleted since makes the retry 400,
                 // loudly, instead of quietly running something else.
                 sandbox: Some(run_state.sandbox.clone()),
+                // #551 (ADR-0046): a retry is a new Run, but it must reproduce the
+                // original's harness — an A/B comparison that silently reverted to the
+                // instance default on retry would be worthless. The frozen harness is
+                // projected from the original's `RunStarted`; `None` (the Run named no
+                // harness) forwards as `None`, so the retry resolves through the instance
+                // default exactly as the original did. Unlike `sandbox` this needs no
+                // `Some`-wrapping-for-explicit dance: the create chokepoint freezes
+                // `req.harness` verbatim, with no precedence resolution of its own.
+                harness: run_state.harness.clone(),
                 // #338: pin the historical retry behaviour exactly. A retry has always
                 // set `name: None` and re-derived the name (placeholder or from input);
                 // `Some(true)` reproduces that regardless of the instance default, so a

--- a/crates/pdo-daemon/src/trigger_scheduler.rs
+++ b/crates/pdo-daemon/src/trigger_scheduler.rs
@@ -311,6 +311,7 @@ mod tests {
             overlap_policy: "skip".to_string(),
             max_concurrent: None,
             sandbox: None,
+            harness: None,
             auto_name: true,
             enabled: true,
             next_fire_at: next_fire_at.map(str::to_string),

--- a/crates/pdo-daemon/src/trigger_store.rs
+++ b/crates/pdo-daemon/src/trigger_store.rs
@@ -65,6 +65,16 @@ pub(crate) struct Trigger {
     /// double-`Option` `UpdateTrigger.sandbox` (mirror of `max_concurrent`, #239).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub sandbox: Option<String>,
+    /// The agentic harness fired Runs launch on (#551, ADR-0046), or `None` to inherit
+    /// the instance default. There is NO separate Trigger tier in the precedence chain:
+    /// a Trigger *is* a Run template, so its harness is read at fire time and folded
+    /// into the create request's `run` choice (`nœud → Run → Projet → instance`). A
+    /// cron tick and a "Run now" both route through `fire_one_trigger`, so they freeze
+    /// the SAME harness. Free text — no validation (ADR-0045); an unknown name fails
+    /// fast at the fired Run's first node spawn. Clearable back to `None` via the
+    /// double-`Option` [`UpdateTrigger::harness`] (mirror of `sandbox`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub harness: Option<String>,
     /// Whether Runs fired from this Trigger are auto-named by the manager (#338). A
     /// flat bool (mirror of [`Self::enabled`]), NOT a nullable inherit: the choice is
     /// frozen at creation from the instance default and read at fire time. `true`
@@ -105,6 +115,8 @@ pub(crate) struct NewTrigger {
     pub max_concurrent: Option<i64>,
     /// Per-Trigger sandbox mode (#410); `None` inherits the instance default.
     pub sandbox: Option<String>,
+    /// Per-Trigger harness (#551); `None` inherits the instance default at fire time.
+    pub harness: Option<String>,
     /// Whether Runs this Trigger fires are auto-named (#338). Seeded from the instance
     /// default in the create modal and frozen here; `true` is the pre-#338 behaviour.
     pub auto_name: bool,
@@ -171,6 +183,7 @@ pub(crate) async fn init(db: &SqlitePool) -> Result<(), sqlx::Error> {
             overlap_policy TEXT NOT NULL DEFAULT 'skip',
             max_concurrent INTEGER,
             sandbox TEXT,
+            harness TEXT,
             auto_name INTEGER NOT NULL DEFAULT 1,
             enabled INTEGER NOT NULL DEFAULT 1,
             next_fire_at TEXT,
@@ -228,6 +241,21 @@ pub(crate) async fn init(db: &SqlitePool) -> Result<(), sqlx::Error> {
             .is_some();
     if !has_sandbox {
         sqlx::query("ALTER TABLE triggers ADD COLUMN sandbox TEXT")
+            .execute(db)
+            .await?;
+    }
+
+    // Additive migration (#551): per-Trigger `harness`. Same PRAGMA-guarded `ALTER`
+    // precedent as `sandbox` above — a pre-#551 `~/.pdo/pdo.db` got the table via
+    // `CREATE TABLE IF NOT EXISTS`, a no-op there, so the column must be added
+    // out-of-band. NULLABLE: a NULL row inherits the instance default at fire time.
+    let has_harness =
+        sqlx::query("SELECT 1 FROM pragma_table_info('triggers') WHERE name = 'harness'")
+            .fetch_optional(db)
+            .await?
+            .is_some();
+    if !has_harness {
+        sqlx::query("ALTER TABLE triggers ADD COLUMN harness TEXT")
             .execute(db)
             .await?;
     }
@@ -327,8 +355,8 @@ pub(crate) async fn create(db: &SqlitePool, new: NewTrigger) -> Result<Trigger, 
         "INSERT INTO triggers
             (id, name, pipeline_id, pipeline_name, target_repo, target_repos, source_branch,
              input_template, variables, cron, guard_command, overlap_policy,
-             max_concurrent, sandbox, auto_name, enabled, next_fire_at, last_fired_at, last_outcome, created_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, NULL, NULL, ?)",
+             max_concurrent, sandbox, harness, auto_name, enabled, next_fire_at, last_fired_at, last_outcome, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, NULL, NULL, ?)",
     )
     .bind(&id)
     .bind(&new.name)
@@ -344,6 +372,7 @@ pub(crate) async fn create(db: &SqlitePool, new: NewTrigger) -> Result<Trigger, 
     .bind(&new.overlap_policy)
     .bind(new.max_concurrent)
     .bind(&new.sandbox)
+    .bind(&new.harness)
     .bind(if new.auto_name { 1_i64 } else { 0_i64 })
     .bind(&new.next_fire_at)
     .bind(&now)
@@ -372,6 +401,9 @@ fn row_to_trigger(row: &sqlx::sqlite::SqliteRow) -> Trigger {
         overlap_policy: row.get("overlap_policy"),
         max_concurrent: row.get("max_concurrent"),
         sandbox: row.get("sandbox"),
+        // #551: tolerant of a legacy-NULL / pre-migration read (mirror of `target_repos`) —
+        // absence inherits the instance default at fire time.
+        harness: row.try_get("harness").unwrap_or(None),
         // #338: tolerant of a legacy NULL (a pre-migration row read mid-upgrade) —
         // absence reads as auto-name ON, the pre-#338 behaviour.
         auto_name: row.try_get::<i64, _>("auto_name").unwrap_or(1) != 0,
@@ -555,6 +587,12 @@ pub(crate) struct UpdateTrigger {
     /// `serde(default)` would make present-`null` indistinguishable from omitted, so
     /// the UI could never reset a Trigger back to inheriting.
     pub sandbox: Option<Option<String>>,
+    /// Per-Trigger harness (#551), double-wrapped like `sandbox`: `None` leaves it,
+    /// `Some(None)` clears to NULL (= "inherit the instance default"), `Some(Some(name))`
+    /// sets it. The double-`Option` is load-bearing for the same reason as `sandbox` — a
+    /// plain `serde(default)` would make present-`null` indistinguishable from omitted, so
+    /// the UI could never reset a Trigger back to inheriting.
+    pub harness: Option<Option<String>>,
     /// Auto-naming toggle (#338): `None` leaves the flag, `Some(v)` sets it. A FLAT
     /// `Option<bool>` (mirror of [`Self::enabled`]), NOT double-wrapped like `sandbox`
     /// — there is no "inherit" state to clear back to; the choice is a plain on/off.
@@ -581,6 +619,7 @@ impl UpdateTrigger {
             && self.overlap_policy.is_none()
             && self.max_concurrent.is_none()
             && self.sandbox.is_none()
+            && self.harness.is_none()
             && self.auto_name.is_none()
             && self.next_fire_at.is_none()
             && self.enabled.is_none()
@@ -639,6 +678,9 @@ pub(crate) async fn update(
     if edit.sandbox.is_some() {
         sets.push("sandbox = ?");
     }
+    if edit.harness.is_some() {
+        sets.push("harness = ?");
+    }
     if edit.auto_name.is_some() {
         sets.push("auto_name = ?");
     }
@@ -693,6 +735,11 @@ pub(crate) async fn update(
         // `Some(Some(mode))` → binds the mode string. Mirror of `target_repo`.
         query = query.bind(v.clone());
     }
+    if let Some(v) = &edit.harness {
+        // #551: `Some(None)` → SQL NULL (inherit the instance default);
+        // `Some(Some(name))` → the harness name. Mirror of `sandbox`.
+        query = query.bind(v.clone());
+    }
     if let Some(v) = &edit.auto_name {
         // Flat bool → 0/1 (mirror of `enabled`), never NULL: the column is
         // `NOT NULL DEFAULT 1` and the choice is a plain on/off (#338).
@@ -738,6 +785,7 @@ mod tests {
             overlap_policy: "skip".to_string(),
             max_concurrent: None,
             sandbox: None,
+            harness: None,
             auto_name: true,
             next_fire_at: Some("2026-06-06T10:00:00.000Z".to_string()),
         }
@@ -1493,6 +1541,136 @@ mod tests {
         .await
         .unwrap();
         assert!(get(&db, &t.id).await.unwrap().unwrap().auto_name);
+    }
+
+    /// #551 (ADR-0046): the per-Trigger harness round-trips through create, is set and
+    /// cleared through the double-`Option` update, and an unrelated edit leaves it. Mirror
+    /// of the `sandbox` double-`Option` semantics.
+    #[tokio::test]
+    async fn harness_round_trips_and_clears() {
+        let db = test_db().await;
+        let mut new = sample("t", "0 9 * * *");
+        new.harness = Some("opencode".to_string());
+        let t = create(&db, new).await.unwrap();
+        assert_eq!(t.harness.as_deref(), Some("opencode"));
+
+        // Some(Some(name)) sets it to another harness.
+        update(
+            &db,
+            &t.id,
+            UpdateTrigger {
+                harness: Some(Some("claude".to_string())),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            get(&db, &t.id).await.unwrap().unwrap().harness.as_deref(),
+            Some("claude")
+        );
+
+        // An unrelated edit (harness = None) leaves it untouched.
+        update(
+            &db,
+            &t.id,
+            UpdateTrigger {
+                input_template: Some("changed".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            get(&db, &t.id).await.unwrap().unwrap().harness.as_deref(),
+            Some("claude")
+        );
+
+        // Some(None) clears it back to inheriting the instance default.
+        update(
+            &db,
+            &t.id,
+            UpdateTrigger {
+                harness: Some(None),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(get(&db, &t.id).await.unwrap().unwrap().harness, None);
+    }
+
+    /// #551 migration: a `~/.pdo/pdo.db` created before `harness` existed must pick up the
+    /// column on the next `init`, and a legacy row must read back with `harness = None`
+    /// (inherit the instance default) — the pre-#551 behaviour.
+    #[tokio::test]
+    async fn init_adds_harness_to_legacy_table() {
+        let db = sqlx::sqlite::SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .unwrap();
+
+        // Pre-#551 schema: `triggers` WITHOUT `harness` (but WITH the earlier
+        // sandbox/auto_name columns, so this exercises the tail ALTER).
+        sqlx::query(
+            "CREATE TABLE triggers (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                pipeline_id TEXT NOT NULL,
+                pipeline_name TEXT NOT NULL DEFAULT '',
+                target_repo TEXT,
+                target_repos TEXT,
+                source_branch TEXT,
+                input_template TEXT NOT NULL DEFAULT '',
+                variables JSON NOT NULL DEFAULT '{}',
+                cron TEXT NOT NULL,
+                guard_command TEXT,
+                overlap_policy TEXT NOT NULL DEFAULT 'skip',
+                max_concurrent INTEGER,
+                sandbox TEXT,
+                auto_name INTEGER NOT NULL DEFAULT 1,
+                enabled INTEGER NOT NULL DEFAULT 1,
+                next_fire_at TEXT,
+                last_fired_at TEXT,
+                last_outcome TEXT,
+                created_at TEXT NOT NULL
+            )",
+        )
+        .execute(&db)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO triggers (id, name, pipeline_id, cron, created_at)
+             VALUES ('trg-legacy', 'legacy', 'lib-pipe', '0 9 * * *', '2026-01-01T00:00:00.000Z')",
+        )
+        .execute(&db)
+        .await
+        .unwrap();
+
+        let before =
+            sqlx::query("SELECT 1 FROM pragma_table_info('triggers') WHERE name = 'harness'")
+                .fetch_optional(&db)
+                .await
+                .unwrap();
+        assert!(
+            before.is_none(),
+            "precondition: legacy table lacks the column"
+        );
+
+        init(&db).await.unwrap();
+        init(&db).await.unwrap(); // idempotent
+
+        let after =
+            sqlx::query("SELECT 1 FROM pragma_table_info('triggers') WHERE name = 'harness'")
+                .fetch_optional(&db)
+                .await
+                .unwrap();
+        assert!(after.is_some(), "init must add the harness column");
+
+        // The legacy row reads back inheriting (None), the pre-#551 behaviour.
+        let migrated = get(&db, "trg-legacy").await.unwrap().unwrap();
+        assert_eq!(migrated.harness, None);
     }
 
     /// #338 migration: a `~/.pdo/pdo.db` created before `auto_name` existed must pick up

--- a/crates/pdo-daemon/tests/harness_freeze_resume.rs
+++ b/crates/pdo-daemon/tests/harness_freeze_resume.rs
@@ -91,11 +91,19 @@ fn git_init_with_commit(repo: &std::path::Path) -> anyhow::Result<()> {
 }
 
 async fn create_run(daemon: &TestDaemon) -> String {
-    let body = serde_json::json!({
+    create_run_with_harness(daemon, None).await
+}
+
+/// Create a Run, optionally choosing a **Run-level harness** (#551) — the `run` tier.
+async fn create_run_with_harness(daemon: &TestDaemon, harness: Option<&str>) -> String {
+    let mut body = serde_json::json!({
         "pipeline": PIPELINE_NAME,
         "input": "go",
         "target_repo": daemon.target_repo(),
     });
+    if let Some(h) = harness {
+        body["harness"] = serde_json::json!(h);
+    }
     let resp = reqwest::Client::new()
         .post(format!("{}/runs", daemon.url()))
         .json(&body)
@@ -105,6 +113,17 @@ async fn create_run(daemon: &TestDaemon) -> String {
     assert_eq!(resp.status(), 201, "POST /runs should return 201");
     let json: serde_json::Value = resp.json().await.unwrap();
     json["run_id"].as_str().unwrap().to_string()
+}
+
+/// The Run's projected state (`GET /runs/<id>`), which serializes `RunState` — so its
+/// `harness` key is the frozen Run harness the panel shows (#551).
+async fn get_run(daemon: &TestDaemon, run_id: &str) -> serde_json::Value {
+    reqwest::get(format!("{}/runs/{run_id}", daemon.url()))
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap()
 }
 
 async fn events(daemon: &TestDaemon, run_id: &str) -> Vec<serde_json::Value> {
@@ -184,5 +203,106 @@ async fn resume_reposes_the_frozen_harness() {
         pane["source"].as_str(),
         Some("unavailable"),
         "a resumable pinned node must re-pose, not report unavailable: {pane}"
+    );
+}
+
+// -----------------------------------------------------------------------------
+// #551 — the Run tier (`nœud → Run → instance → plancher`), end to end.
+// -----------------------------------------------------------------------------
+
+/// Poll for the manager session (`pdo-mgr-<run>`) to come up on the daemon's own tmux
+/// socket, proving the manager spawned on the resolved harness without failing fast.
+async fn wait_for_manager_session(daemon: &TestDaemon, run_id: &str) -> bool {
+    let socket = daemon.tmux_socket();
+    let session = format!("pdo-mgr-{run_id}");
+    for _ in 0..50 {
+        let up = std::process::Command::new("tmux")
+            .args(["-L", &socket, "has-session", "-t", &session])
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false);
+        if up {
+            return true;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+    false
+}
+
+/// The Run tier moves a **free** node off the floor: a Run created on `opencode` freezes
+/// `opencode` into the unpinned node's `NodeStarted` (it followed the Run), while the
+/// Run's own frozen harness is visible in `GET /runs/<id>` (the Run panel, AC), and the
+/// Pipeline Manager comes up on that harness (the infra session follows the Run — AC).
+#[tokio::test]
+async fn run_harness_moves_the_free_node_and_manager() {
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+    let run_id = create_run_with_harness(&daemon, Some("opencode")).await;
+    let evs = wait_for_both_started(&daemon, &run_id).await;
+
+    // The unpinned node followed the Run tier off the `claude` floor to `opencode`…
+    assert_eq!(
+        started_harness(&evs, "aaaaaaaa").as_deref(),
+        Some("opencode"),
+        "a free node must follow the Run's harness"
+    );
+    // …and the pinned node stays `opencode` too (its pin agrees with the Run here).
+    assert_eq!(
+        started_harness(&evs, "bbbbbbbb").as_deref(),
+        Some("opencode")
+    );
+
+    // The frozen Run harness is visible in the Run panel (AC): `GET /runs/<id>`.
+    let run = get_run(&daemon, &run_id).await;
+    assert_eq!(
+        run["harness"].as_str(),
+        Some("opencode"),
+        "the Run panel must show the frozen Run harness: {run}"
+    );
+
+    // The Pipeline Manager followed the Run's harness (AC): its session came up, so the
+    // manager spawn resolved `opencode` and did not fail fast. (The exact harness the
+    // manager launches is proven purely by `harness_resolver::resolve_infra_harness`;
+    // the tmux command override erases the tail, so an L3 asserts the spawn, not bytes.)
+    assert!(
+        wait_for_manager_session(&daemon, &run_id).await,
+        "the manager session must come up on the Run's harness"
+    );
+}
+
+/// A **pinned** node resists the Run tier: a Run created on `claude` cannot pull the
+/// `opencode`-pinned node off its pin (ADR-0046, épinglage ≠ paramétrage), while the free
+/// node follows the Run down to `claude`.
+#[tokio::test]
+async fn pinned_node_resists_the_run_harness() {
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+    let run_id = create_run_with_harness(&daemon, Some("claude")).await;
+    let evs = wait_for_both_started(&daemon, &run_id).await;
+
+    // The pinned node ignores the Run's `claude` choice and stays on its `opencode` pin.
+    assert_eq!(
+        started_harness(&evs, "bbbbbbbb").as_deref(),
+        Some("opencode"),
+        "a pinned node must resist the Run harness"
+    );
+    // The free node follows the Run to `claude`.
+    assert_eq!(started_harness(&evs, "aaaaaaaa").as_deref(), Some("claude"));
+
+    // And the Run panel shows the Run's own frozen choice.
+    let run = get_run(&daemon, &run_id).await;
+    assert_eq!(run["harness"].as_str(), Some("claude"), "{run}");
+}
+
+/// A Run created with **no** harness names none: the free node stays on the floor and the
+/// Run panel omits the key (byte-identical to the pre-#551 shape).
+#[tokio::test]
+async fn a_run_without_a_harness_freezes_none() {
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+    let run_id = create_run(&daemon).await;
+    wait_for_both_started(&daemon, &run_id).await;
+
+    let run = get_run(&daemon, &run_id).await;
+    assert!(
+        run.get("harness").is_none() || run["harness"].is_null(),
+        "a Run that named no harness must not carry the key: {run}"
     );
 }

--- a/crates/pdo-daemon/tests/trigger_scheduler.rs
+++ b/crates/pdo-daemon/tests/trigger_scheduler.rs
@@ -1646,6 +1646,88 @@ async fn trigger_auto_name_true_fires_an_unnamed_run_for_manager_to_derive() {
     cleanup_runs(&daemon).await;
 }
 
+/// The Run's projected state (`GET /runs/<id>`), which serializes `RunState` — the only
+/// place the frozen Run `harness` is observable (the list entry does not carry it).
+async fn get_run(daemon: &TestDaemon, run_id: &str) -> serde_json::Value {
+    reqwest::get(format!("{}/runs/{run_id}", daemon.url()))
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap()
+}
+
+/// #551 (ADR-0046): a Trigger carries the harness IN its Run template, and both a cron
+/// tick and a "Run now" manual fire produce a Run FROZEN on that harness — the AC's
+/// "« Run now » et un tir cron produisent le même harnais", proven because both routes
+/// share `fire_one_trigger`. Overlap `allow`, so the two fires both create a Run.
+#[tokio::test]
+async fn trigger_fire_freezes_the_declared_harness_cron_and_run_now() {
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+
+    let body = serde_json::json!({
+        "name": "on opencode",
+        "pipeline_id": PIPELINE_NAME,
+        "cron": "* * * * *",
+        "target_repo": daemon.target_repo(),
+        "harness": "opencode",
+        "overlap_policy": "allow",
+    });
+    let trigger: serde_json::Value = reqwest::Client::new()
+        .post(format!("{}/triggers", daemon.url()))
+        .json(&body)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let trigger_id = trigger["id"].as_str().unwrap().to_string();
+    // The stored Trigger carries the harness in its Run template.
+    assert_eq!(
+        get_trigger(&daemon, &trigger_id).await["harness"].as_str(),
+        Some("opencode"),
+        "the Trigger must store the harness in its Run template"
+    );
+
+    // "Run now" (manual fire) → a Run frozen on opencode.
+    let now_fire: serde_json::Value = reqwest::Client::new()
+        .post(format!("{}/triggers/{}/fire", daemon.url(), trigger_id))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(now_fire["fired"].as_bool(), Some(true), "{now_fire}");
+    let run_now_id = now_fire["run_id"].as_str().unwrap().to_string();
+    assert_eq!(
+        get_run(&daemon, &run_now_id).await["harness"].as_str(),
+        Some("opencode"),
+        "a \"Run now\" fire must freeze the Trigger's harness"
+    );
+
+    // A cron tick → a Run frozen on the SAME harness.
+    daemon.force_trigger_due(&trigger_id).await;
+    daemon.run_trigger_tick().await;
+    let cron_run = list_runs(&daemon)
+        .await
+        .into_iter()
+        .find(|r| {
+            r["triggered_by"].as_str() == Some(trigger_id.as_str())
+                && r["run_id"].as_str() != Some(run_now_id.as_str())
+        })
+        .expect("the cron tick must have fired a second run");
+    let cron_run_id = cron_run["run_id"].as_str().unwrap();
+    assert_eq!(
+        get_run(&daemon, cron_run_id).await["harness"].as_str(),
+        Some("opencode"),
+        "a cron tick must freeze the same harness as \"Run now\""
+    );
+
+    cleanup_runs(&daemon).await;
+}
+
 /// Best-effort: kill any tmux sessions the runs spawned so a `sleep 60` doesn't
 /// leak past the test.
 async fn cleanup_runs(daemon: &TestDaemon) {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -563,6 +563,10 @@ export interface CreateRunRequest {
   /** Explicit sandbox (#410/#432): `"off"` or a staging-profile name. Omitted → the
    *  server defers to the trigger/instance default at the create chokepoint. */
   sandbox?: string;
+  /** Explicit harness (#551, ADR-0046): the `run` tier of the precedence chain. Omitted/
+   *  blank → the Run names no harness and each free node resolves through the instance
+   *  default and the `claude` floor. Frozen into `RunStarted` at the create chokepoint. */
+  harness?: string;
   /** Whether the manager auto-names this Run (#338). The modal always sends it; omit and
    *  the server resolves back-compat by the presence of `name`, then the instance default. */
   auto_name?: boolean;
@@ -593,6 +597,10 @@ export function createRun(req: CreateRunRequest): Promise<CreateRunResponse> {
     // sandboxed Run created WITH attached images keeps its mode (the daemon's
     // multipart parser reads this field).
     if (req.sandbox) form.append("sandbox", req.sandbox);
+    // #551: thread the explicit harness through the multipart path too, so a Run created
+    // WITH attached images keeps its harness choice (the daemon's multipart parser reads
+    // this field). Omitted when blank — the Run then names no harness.
+    if (req.harness) form.append("harness", req.harness);
     // #338: thread the explicit auto-naming choice through the multipart path too, so an
     // unchecked "Auto-generated" box is honoured on a create WITH attached images. Sent as
     // a stringified bool; only when the caller made a choice (it always does from the modal).
@@ -680,6 +688,9 @@ export interface CreateTriggerRequest {
   /** Per-Trigger sandbox (#410/#432): `"off"` or a staging-profile name, or null/omit to
    *  inherit the instance default. */
   sandbox?: string | null;
+  /** Per-Trigger harness (#551): a harness name, or null/omit to inherit the instance
+   *  default. Folded into the fired Run's harness (no separate Trigger tier). */
+  harness?: string | null;
   /** Whether Runs this Trigger fires are auto-named (#338). Seeded from the instance
    *  default in the modal; omit → the server defaults to `true` (pre-#338 behaviour). */
   auto_name?: boolean;
@@ -722,6 +733,9 @@ export interface UpdateTriggerRequest {
   /** Per-Trigger sandbox (#410/#432): a value sets it, `null` clears back to
    *  inheriting the instance default, `undefined` leaves it unchanged. */
   sandbox?: string | null;
+  /** Per-Trigger harness (#551): a value sets it, `null` clears back to inheriting the
+   *  instance default, `undefined` leaves it unchanged. */
+  harness?: string | null;
   /** Auto-naming toggle (#338): a bool sets it, `undefined` leaves it unchanged. A flat
    *  bool (no clear state) — mirror of `enabled`. */
   auto_name?: boolean;

--- a/frontend/src/components/NewRunModal.test.tsx
+++ b/frontend/src/components/NewRunModal.test.tsx
@@ -2255,3 +2255,155 @@ describe("NewRunModal — multi-repo (#465)", () => {
     expect(screen.getByTestId("launch-button")).toBeDisabled();
   });
 });
+
+describe("NewRunModal — harness selector (#551)", () => {
+  function harnessSettings(overrides: Partial<InstanceSettings> = {}): InstanceSettings {
+    return {
+      session_cap: { effective: 20, source: "default", stored: null, env: null, default: 20 },
+      reaper_ttl_secs: { effective: 3600, source: "default", stored: null, env: null, default: 3600 },
+      guard_timeout_secs: { effective: 60, source: "default", stored: null, env: null, default: 60 },
+      default_model: { effective: null, source: "default", stored: null, env: null, default: null },
+      default_harness: { effective: null, source: "default", stored: null, env: null, default: null },
+      default_harness_model: { effective: {}, stored: {} },
+      default_sandbox: { effective: "off", source: "default", stored: null, env: null, default: "off", reason: null },
+      sandbox_docker: { available: true, reason: null, checked_at: "2026-07-01T10:00:00.000Z" },
+      sandbox_profiles: [],
+      home: "/home/user",
+      autocomplete_turn_end: { effective: false, source: "default", stored: null, env: null, default: false },
+      default_auto_name: { effective: true, source: "default", stored: null, env: null, default: true },
+      price_table: { manual_path: null, fetched_path: null, source: null, fetched_at: null, fetched_rows: 0, manual_keys: [], reason: null },
+      updated_at: "2026-07-01T10:00:00.000Z",
+      ...overrides,
+    };
+  }
+
+  /** #452 for the harness axis: the run selector NAMES the instance default on the inherit
+   *  option; it never copies it into the field. Assert on the OPTION TEXT and the presence
+   *  of the concrete options — never on `select.value` for the "names it" claim (a value
+   *  assertion cannot fail here — the memory of #347/#452). */
+  it("names the instance default on the inherit option without seeding the field", async () => {
+    vi.mocked(fetchSettings).mockResolvedValue(
+      harnessSettings({
+        default_harness: { effective: "opencode", source: "stored", stored: "opencode", env: null, default: null },
+      }),
+    );
+    vi.mocked(fetchPipelines).mockResolvedValue([makePipeline({ id: "p1", name: "P", scope: "repo" })]);
+    renderModal();
+    const select = (await screen.findByTestId("harness-select")) as HTMLSelectElement;
+    await waitFor(() => {
+      expect(Array.from(select.options).find((o) => o.value === "")).toHaveTextContent(
+        "Use instance default (opencode)",
+      );
+    });
+    // The field asserts nothing of its own — the inherit sentinel, not the copied value.
+    expect(select.value).toBe("");
+    // The embedded harnesses are offered as concrete options.
+    const values = Array.from(select.options).map((o) => o.value);
+    expect(values).toContain("claude");
+    expect(values).toContain("opencode");
+  });
+
+  it("names the claude floor when the instance sets no default", async () => {
+    vi.mocked(fetchSettings).mockResolvedValue(harnessSettings());
+    vi.mocked(fetchPipelines).mockResolvedValue([makePipeline({ id: "p1", name: "P", scope: "repo" })]);
+    renderModal();
+    const select = (await screen.findByTestId("harness-select")) as HTMLSelectElement;
+    await waitFor(() => {
+      expect(Array.from(select.options).find((o) => o.value === "")).toHaveTextContent(
+        "Use instance default (claude)",
+      );
+    });
+  });
+
+  it("passes the chosen harness to createRun", async () => {
+    vi.mocked(fetchSettings).mockResolvedValue(harnessSettings());
+    vi.mocked(fetchPipelines).mockResolvedValue([
+      makePipeline({ id: "p1", name: "Optional Pipeline", scope: "repo", prompt_required: false }),
+    ]);
+    renderModal();
+    await enterValidRepo();
+
+    const select = (await screen.findByTestId("harness-select")) as HTMLSelectElement;
+    await waitFor(() => expect(Array.from(select.options).some((o) => o.value === "opencode")).toBe(true));
+    fireEvent.change(select, { target: { value: "opencode" } });
+
+    vi.useRealTimers();
+    await waitFor(() => expect(screen.getByRole("button", { name: /launch/i })).toBeEnabled());
+    fireEvent.click(screen.getByRole("button", { name: /launch/i }));
+
+    await waitFor(() => {
+      expect(createRun).toHaveBeenCalledWith(expect.objectContaining({ harness: "opencode" }));
+    });
+  });
+
+  it("omits the harness key when left on the inherit default", async () => {
+    vi.mocked(fetchSettings).mockResolvedValue(harnessSettings());
+    vi.mocked(fetchPipelines).mockResolvedValue([
+      makePipeline({ id: "p1", name: "Optional Pipeline", scope: "repo", prompt_required: false }),
+    ]);
+    renderModal();
+    await enterValidRepo();
+    // Leave the harness selector on "" (inherit).
+    await screen.findByTestId("harness-select");
+
+    vi.useRealTimers();
+    await waitFor(() => expect(screen.getByRole("button", { name: /launch/i })).toBeEnabled());
+    fireEvent.click(screen.getByRole("button", { name: /launch/i }));
+
+    await waitFor(() => expect(createRun).toHaveBeenCalled());
+    // The Run names no harness — the daemon resolves through the instance default.
+    expect(vi.mocked(createRun).mock.calls[0][0].harness).toBeUndefined();
+  });
+
+  it("round-trips a Trigger's harness and clears it to null on reset", async () => {
+    vi.mocked(fetchSettings).mockResolvedValue(harnessSettings());
+    vi.mocked(fetchPipelines).mockResolvedValue([
+      makePipeline({ id: "p1", name: "Auditor", scope: "repo", prompt_required: false }),
+    ]);
+    const trigger: Trigger = {
+      id: "trg-hns",
+      name: "Nightly",
+      pipeline_id: "p1",
+      pipeline_name: "Auditor",
+      target_repo: "/home/user/project",
+      source_branch: "dev",
+      input_template: "audit",
+      variables: {},
+      cron: "0 9 * * *",
+      guard_command: null,
+      overlap_policy: "skip",
+      harness: "opencode",
+      auto_name: true,
+      enabled: true,
+      next_fire_at: null,
+      last_fired_at: null,
+      last_outcome: null,
+    };
+    render(
+      <NewRunModal open={true} onClose={noop} onCreated={noop}
+        openIntent={{ kind: "edit-trigger", trigger }} />,
+    );
+
+    const select = (await screen.findByTestId("harness-select")) as HTMLSelectElement;
+    await waitFor(() => expect(select.value).toBe("opencode"));
+    // Trigger mode exposes the inherit option.
+    expect(Array.from(select.options).some((o) => o.value === "")).toBe(true);
+
+    // Repo validation must resolve so Save is enabled.
+    await vi.advanceTimersByTimeAsync(500);
+    await waitFor(() => expect(validateRepo).toHaveBeenCalledWith("/home/user/project"));
+
+    // Reset to "use instance default" → the PATCH must clear it (null).
+    fireEvent.change(select, { target: { value: "" } });
+    vi.useRealTimers();
+    await waitFor(() => expect(screen.getByTestId("save-trigger-button")).toBeEnabled());
+    fireEvent.click(screen.getByTestId("save-trigger-button"));
+
+    await waitFor(() => {
+      expect(updateTrigger).toHaveBeenCalledWith(
+        "trg-hns",
+        expect.objectContaining({ harness: null }),
+      );
+    });
+  });
+});

--- a/frontend/src/components/NewRunModal.tsx
+++ b/frontend/src/components/NewRunModal.tsx
@@ -141,6 +141,13 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
   const [settingsFailed, setSettingsFailed] = useState(false);
   const [sandbox, setSandbox] = useState<string>("");
   const sandboxSeeded = useRef(false);
+  // Harness (#551/#452). `harness` is the selector value in BOTH modes: `""` = "the user
+  // did not choose" (inherit), or a concrete harness name. Seeded to `""` (asserts
+  // nothing) synchronously — the inherited default is only ever the inherit option's
+  // LABEL, never copied into the field (the #452 prefill trap). `""` omits the key from
+  // the request, the only value that lets the daemon resolve its own default.
+  const [harness, setHarness] = useState<string>("");
+  const harnessSeeded = useRef(false);
   const autoNameSeeded = useRef(false);
 
   const recentRepos = useRecentReposStore((s) => s.recentRepos);
@@ -365,6 +372,22 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
     setSandbox(openIntent.kind === "edit-trigger" ? (openIntent.trigger.sandbox ?? "") : "");
   }, [open, openIntent]);
 
+  // #551/#452: seed the harness selector once per open, matched to the intent — the same
+  // ref-gated, synchronous, assertion-free seed as the sandbox selector above. An
+  // `edit-trigger` round-trips the Trigger's own stored harness (whose `null` already
+  // means "inherit"); a run / new-trigger seeds `""`, so the field asserts nothing and the
+  // inherited default stays a LABEL. Never waits on `settings` (the #452 trap).
+  useEffect(() => {
+    if (!open) {
+      harnessSeeded.current = false;
+      return;
+    }
+    if (harnessSeeded.current) return;
+    // One-shot seeding gated by the ref: bounded, does not re-fire.
+    harnessSeeded.current = true;
+    setHarness(openIntent.kind === "edit-trigger" ? (openIntent.trigger.harness ?? "") : "");
+  }, [open, openIntent]);
+
   // #338: seed the "Auto-generated" box once per open, ref-gated (same anti-reseed guard as
   // the sandbox selector, so a `settings` state surviving a close cannot re-seed a REOPEN
   // from a stale value — the #452 trap). An `edit-trigger` seeds SYNCHRONOUSLY from the
@@ -498,6 +521,14 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
     [settings, sandbox, mode],
   );
 
+  // #551/#452: the harness selector's derived state — the known harnesses and the
+  // inherited default's NAME (a label, never a seed). Memoized like `sandboxState` so its
+  // destructured fields are stable. Pure over (settings, harness).
+  const { knownHarnesses, instanceDefaultHarness } = useMemo(
+    () => newRunForm.harnessState({ settings, harness }),
+    [settings, harness],
+  );
+
   // #465: every non-empty secondary row must have resolved to a valid repo before a
   // launch (mirror of the primary `repoValid` gate). An empty row is incomplete.
   const secondariesReady = secondaryRepos.every(
@@ -536,6 +567,7 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
           autoName,
           runName,
           sandbox,
+          harness,
           images,
           // #465: full list ([0] = primary, [1..] = secondaries), or undefined
           // for a mono-repo Run (keeps the request byte-identical).
@@ -557,7 +589,7 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
     } finally {
       setSubmitting(false);
     }
-  }, [selectedPipeline, input, hasRequiredPrompt, overrides, onCreated, onClose, flushPendingSaves, repoValid, targetRepo, sourceBranch, buildTargetRepos, autoName, runName, images, sandbox, settings, refreshRecentRepos]);
+  }, [selectedPipeline, input, hasRequiredPrompt, overrides, onCreated, onClose, flushPendingSaves, repoValid, targetRepo, sourceBranch, buildTargetRepos, autoName, runName, images, sandbox, harness, settings, refreshRecentRepos]);
 
   const canLaunch = newRunForm.canLaunch({
     repoValid,
@@ -631,6 +663,7 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
       allowOverlap,
       maxConcurrent,
       sandbox,
+      harness,
       autoName,
       variables,
       // #465: full list ([0] = primary, [1..] = secondaries), or undefined for
@@ -682,6 +715,7 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
     sourceBranch,
     buildTargetRepos,
     sandbox,
+    harness,
     autoName,
     flushPendingSaves,
     onTriggerSaved,
@@ -1132,6 +1166,49 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
                   This Run will use the instance default.
                 </span>
               )}
+            </div>
+
+            {/* Harness (#551/#452, ADR-0046): "Use instance default", or one of the
+                embedded harnesses. The inherit option is the SEEDED value and NAMES what
+                it resolves to in run mode ("the choice is made now, the user is entitled
+                to know what they inherit"); a Trigger resolves when it fires, so naming
+                today's value there would be a promise the modal cannot keep. Unlike the
+                sandbox selector there is nothing to grey and nothing to block — a harness
+                name is free text with no availability probe (ADR-0045); an unknown one
+                fails fast at the node spawn, not here. A node that PINS its harness
+                (NodeInspector) ignores this Run-level choice (ADR-0046). */}
+            <div className="flex flex-col gap-1.5">
+              <label
+                htmlFor="harness-select"
+                className="font-medium text-fg-2"
+                style={{ fontSize: "11.5px" }}
+              >
+                Harness
+              </label>
+              <select
+                id="harness-select"
+                data-testid="harness-select"
+                value={harness}
+                onChange={(e) => setHarness(e.target.value)}
+                className="w-full rounded-md border border-line-strong bg-bg-3 px-2.5 py-1.5 font-mono text-fg transition-colors focus:border-acc focus:outline-none disabled:opacity-40"
+                style={{ fontSize: "12px" }}
+              >
+                <option value="">
+                  {mode === "run" && instanceDefaultHarness
+                    ? `Use instance default (${instanceDefaultHarness})`
+                    : "Use instance default"}
+                </option>
+                {knownHarnesses.map((h) => (
+                  <option key={h} value={h}>
+                    {h}
+                  </option>
+                ))}
+              </select>
+              <span className="text-fg-4" style={{ fontSize: "10.5px" }}>
+                {mode === "trigger"
+                  ? "Every fired Run launches on this harness. Nodes that pin their own harness ignore it."
+                  : "The harness every free node runs on for this Run. Nodes that pin their own harness ignore it."}
+              </span>
             </div>
           </div>
 

--- a/frontend/src/components/RunInfoSidebar.test.tsx
+++ b/frontend/src/components/RunInfoSidebar.test.tsx
@@ -89,6 +89,23 @@ describe("RunInfoSidebar", () => {
     expect(screen.queryByTestId("run-failure-reason")).toBeNull();
   });
 
+  // #551 (ADR-0046): the frozen Run harness is visible in the panel.
+  it("shows the Run's frozen harness when it named one", () => {
+    render(
+      <RunInfoSidebar run={{ ...makeRun("running"), harness: "opencode" } as unknown as RunState} />,
+    );
+    const chip = screen.getByTestId("run-harness");
+    expect(chip.textContent).toContain("Harness");
+    expect(chip.textContent).toContain("opencode");
+  });
+
+  it("shows no harness chip when the Run inherited the default", () => {
+    // Absent harness = inherited the instance default (and the floor) — the panel does
+    // not spell that out per-Run.
+    render(<RunInfoSidebar run={makeRun("running")} />);
+    expect(screen.queryByTestId("run-harness")).toBeNull();
+  });
+
   // #465 slice 2 — the Repositories section.
   it("shows no Repositories section for a mono-repo run (no target_repo)", () => {
     render(<RunInfoSidebar run={makeRun("running")} />);

--- a/frontend/src/components/RunInfoSidebar.tsx
+++ b/frontend/src/components/RunInfoSidebar.tsx
@@ -70,6 +70,22 @@ export default function RunInfoSidebar({
             ? "Archived run · read-only · outputs preserved"
             : "Editing run-scoped pipeline · changes sync to template"}
         </div>
+        {/* #551 (ADR-0046): the harness this Run was FROZEN on — the `run` tier that
+            made it an A/B of the same pipeline on another harness. Shown only when the
+            Run named one; absence means it inherited the instance default (and the
+            `claude` floor), which the panel does not need to spell out per-Run. */}
+        {run.harness && (
+          <div
+            className="mt-2 flex items-center gap-1.5 text-fg-3"
+            style={{ fontSize: "10.5px" }}
+            data-testid="run-harness"
+          >
+            <span className="text-fg-4">Harness</span>
+            <span className="rounded bg-bg-3 px-1.5 py-0.5 font-mono text-fg-2">
+              {run.harness}
+            </span>
+          </div>
+        )}
       </div>
 
       {run.target_repo && (

--- a/frontend/src/lib/newRunForm.test.ts
+++ b/frontend/src/lib/newRunForm.test.ts
@@ -6,6 +6,7 @@ import {
   buildVariables,
   canCreateTrigger,
   canLaunch,
+  harnessState,
   hasRequiredPrompt,
   overrideCount,
   parseVariableValue,
@@ -138,6 +139,7 @@ describe("buildVariables", () => {
       autoName: true,
       runName: "",
       sandbox: "",
+      harness: "",
       images: [],
     };
     const triggerFields = {
@@ -151,6 +153,7 @@ describe("buildVariables", () => {
       allowOverlap: false,
       maxConcurrent: "",
       sandbox: "",
+      harness: "",
       autoName: true,
       variables,
     };
@@ -453,6 +456,48 @@ describe("sandboxState (#410/#432/#452)", () => {
   });
 });
 
+/** The default_harness tier resolving to `name` (#551). */
+const defaultHarnessIs = (name: string): Partial<InstanceSettings> => ({
+  default_harness: { effective: name, source: "stored", stored: name, env: null, default: null },
+});
+
+describe("harnessState (#551/#452)", () => {
+  it("does not know the default until settings arrive", () => {
+    // The honest render: `null`, not a guess. The selector shows a bare "Use instance
+    // default" until it knows what that is — it never seeds a value from a late fetch.
+    const state = harnessState({ settings: null, harness: "" });
+    expect(state.instanceDefaultHarness).toBeNull();
+    expect(state.effectiveHarness).toBeNull();
+  });
+
+  it("names the instance default through the claude floor when none is set", () => {
+    // #452: the inherit option is LABELLED with what it resolves to — the floor when the
+    // instance names no harness — but the value stays `""` (asserts nothing).
+    const state = harnessState({ settings: settings(), harness: "" });
+    expect(state.instanceDefaultHarness).toBe("claude");
+    expect(state.effectiveHarness).toBe("claude");
+  });
+
+  it("names a stored instance default", () => {
+    const state = harnessState({ settings: settings(defaultHarnessIs("opencode")), harness: "" });
+    expect(state.instanceDefaultHarness).toBe("opencode");
+    // The inherit sentinel resolves to the instance default…
+    expect(state.effectiveHarness).toBe("opencode");
+  });
+
+  it("resolves a concrete selection to itself, not the default", () => {
+    const state = harnessState({ settings: settings(defaultHarnessIs("claude")), harness: "opencode" });
+    expect(state.effectiveHarness).toBe("opencode");
+  });
+
+  it("offers the embedded harnesses", () => {
+    expect(harnessState({ settings: settings(), harness: "" }).knownHarnesses).toEqual([
+      "claude",
+      "opencode",
+    ]);
+  });
+});
+
 describe("buildRunPayload", () => {
   const fields = {
     selectedPipeline: pipeline({ id: "p1", name: "Auditor" }),
@@ -463,8 +508,19 @@ describe("buildRunPayload", () => {
     autoName: false,
     runName: "  Fix bug  ",
     sandbox: "full",
+    harness: "",
     images: [new File(["png"], "design.png", { type: "image/png" })],
   };
+
+  /**
+   * #551/#452, the harness twin of the sandbox assertion: `""` means "the user did not
+   * choose", and only an ABSENT `harness` lets the daemon resolve through the instance
+   * default and the floor. A concrete choice is sent verbatim.
+   */
+  it("omits the harness key for the inherit sentinel, and sends an explicit choice", () => {
+    expect(buildRunPayload({ ...fields, harness: "" }).harness).toBeUndefined();
+    expect(buildRunPayload({ ...fields, harness: "opencode" }).harness).toBe("opencode");
+  });
 
   it("posts the trimmed form values", () => {
     expect(buildRunPayload(fields)).toMatchObject({
@@ -527,6 +583,7 @@ describe("buildTriggerCreatePayload / buildTriggerUpdatePayload", () => {
     allowOverlap: true,
     maxConcurrent: " 2 ",
     sandbox: "minimal",
+    harness: "",
     autoName: true,
     variables: { max_iter: 5 },
   };
@@ -544,6 +601,9 @@ describe("buildTriggerCreatePayload / buildTriggerUpdatePayload", () => {
       overlap_policy: "allow",
       max_concurrent: 2,
       sandbox: "minimal",
+      // #551: the inherit sentinel `""` maps to `null` on a Trigger (a real inherit
+      // state), exactly like `sandbox`.
+      harness: null,
       auto_name: true,
       variables: { max_iter: 5 },
     });
@@ -564,6 +624,7 @@ describe("buildTriggerCreatePayload / buildTriggerUpdatePayload", () => {
       overlap_policy: "allow",
       max_concurrent: 2,
       sandbox: "minimal",
+      harness: null,
       auto_name: true,
       variables: { max_iter: 5 },
     });
@@ -604,6 +665,15 @@ describe("buildTriggerCreatePayload / buildTriggerUpdatePayload", () => {
   it("sends null for the inherit sentinel on both paths", () => {
     expect(buildTriggerCreatePayload({ ...fields, sandbox: "" }).sandbox).toBeNull();
     expect(buildTriggerUpdatePayload({ ...fields, sandbox: "" }).sandbox).toBeNull();
+  });
+
+  // #551: the harness has the same real "inherit" state — `""` → `null` on both paths,
+  // a concrete name is sent verbatim.
+  it("maps the harness inherit sentinel to null, and sends a concrete choice", () => {
+    expect(buildTriggerCreatePayload({ ...fields, harness: "" }).harness).toBeNull();
+    expect(buildTriggerUpdatePayload({ ...fields, harness: "" }).harness).toBeNull();
+    expect(buildTriggerCreatePayload({ ...fields, harness: "opencode" }).harness).toBe("opencode");
+    expect(buildTriggerUpdatePayload({ ...fields, harness: "opencode" }).harness).toBe("opencode");
   });
 
   // A create sends no input_template at all when blank; a patch clears it to "".

--- a/frontend/src/lib/newRunForm.ts
+++ b/frontend/src/lib/newRunForm.ts
@@ -6,6 +6,7 @@ import type {
 } from "../api";
 import type { InstanceSettings, PipelineListEntry, SandboxProfileRef } from "../types";
 import { presetToCron, type CronPresetId } from "../cronPresets";
+import { HARNESS_FLOOR, KNOWN_HARNESSES } from "./harness";
 
 /**
  * The New Run / Trigger form's pure logic (#359), lifted out of `NewRunModal.tsx`.
@@ -295,6 +296,54 @@ export function sandboxState({
   };
 }
 
+/** Everything the harness selector derives from `settings` + the selected value (#551, ADR-0046). */
+export interface HarnessState {
+  /** The harnesses the pin selector offers (the embedded floor, ADR-0045). */
+  knownHarnesses: readonly string[];
+  /**
+   * The instance default harness, used to **label** the inherit option — never to seed
+   * the value (the #452 trap: a prefilled field freezes a stale value the user never
+   * chose). `null` while `settings` are unknown (the honest "we don't know yet" render).
+   * Resolves through the floor when the instance names none, so run mode always has a
+   * concrete name to show.
+   */
+  instanceDefaultHarness: string | null;
+  /**
+   * What will actually apply to the Run being created. `""` is not a value — it means the
+   * key is omitted and the instance default (then the floor) decides — so it resolves to
+   * `instanceDefaultHarness`. A concrete selection is itself.
+   */
+  effectiveHarness: string | null;
+}
+
+/**
+ * The harness cluster (#551, ADR-0046). `harness` is the selector value in BOTH modes:
+ * `""` = "the user did not choose" (inherit), or a concrete harness name. Mirror of
+ * {@link sandboxState}, minus the Docker/profile machinery — a harness name is free text
+ * with no availability probe (ADR-0045: PDO does not validate it; an unknown one fails
+ * fast at spawn), so there is nothing to grey and nothing to block.
+ */
+export function harnessState({
+  settings,
+  harness,
+}: {
+  settings: InstanceSettings | null;
+  harness: string;
+}): HarnessState {
+  // #452: the instance default LABELS the inherit option, never seeds the value. `null`
+  // while settings are unknown; resolves through the `claude` floor once known, so run
+  // mode always names a concrete harness the Run would inherit.
+  const instanceDefaultHarness = settings
+    ? (settings.default_harness.effective || HARNESS_FLOOR)
+    : null;
+  const effectiveHarness = harness === "" ? instanceDefaultHarness : harness;
+  return {
+    knownHarnesses: KNOWN_HARNESSES,
+    instanceDefaultHarness,
+    effectiveHarness,
+  };
+}
+
 /** The form values `POST /runs` reads. */
 export interface RunPayloadInput {
   selectedPipeline: PipelineListEntry;
@@ -305,6 +354,8 @@ export interface RunPayloadInput {
   autoName: boolean;
   runName: string;
   sandbox: string;
+  /** #551: the harness selector value — `""` (inherit) or a concrete name. */
+  harness: string;
   images: File[];
   /** #465: `[0]` = primary, `[1..]` = secondaries. Omit / `undefined` for a mono-repo Run. */
   targetRepos?: TargetRepoInput[];
@@ -319,6 +370,7 @@ export function buildRunPayload({
   autoName,
   runName,
   sandbox,
+  harness,
   images,
   targetRepos,
 }: RunPayloadInput): CreateRunRequest {
@@ -341,6 +393,10 @@ export function buildRunPayload({
     // and OMITS the key: only an absent `sandbox` lets the daemon apply
     // `default_sandbox`, because it reads a present `off` as final.
     sandbox: sandbox || undefined,
+    // #551: the explicit harness choice. `""` (inherit) OMITS the key, so the Run names
+    // no harness and each free node resolves through the instance default and the floor —
+    // exactly the "name the default, don't copy it" contract of the selector (#452).
+    harness: harness || undefined,
     images: images.length > 0 ? images : undefined,
   };
 }
@@ -357,6 +413,8 @@ export interface TriggerPayloadInput {
   allowOverlap: boolean;
   maxConcurrent: string;
   sandbox: string;
+  /** #551: the harness selector value — `""` (inherit) or a concrete name. */
+  harness: string;
   autoName: boolean;
   variables: Record<string, unknown>;
   /** #465: `[0]` = primary, `[1..]` = secondaries. Omit / `undefined` for a mono-repo Trigger. */
@@ -380,6 +438,7 @@ export function buildTriggerUpdatePayload({
   allowOverlap,
   maxConcurrent,
   sandbox,
+  harness,
   autoName,
   variables,
   targetRepos,
@@ -402,6 +461,9 @@ export function buildTriggerUpdatePayload({
     // #410: `""` (Use instance default) clears back to inheriting (`null`);
     // `off` or a staging profile name sets it.
     sandbox: sandbox || null,
+    // #551: `""` (Use instance default) clears back to inheriting (`null`); a concrete
+    // harness name sets it. Mirror of `sandbox`.
+    harness: harness || null,
     // #338: round-trip the auto-naming choice (flat bool, mirror of `enabled`).
     auto_name: autoName,
     variables,
@@ -419,6 +481,7 @@ export function buildTriggerCreatePayload({
   allowOverlap,
   maxConcurrent,
   sandbox,
+  harness,
   autoName,
   variables,
   targetRepos,
@@ -437,6 +500,8 @@ export function buildTriggerCreatePayload({
     max_concurrent: allowOverlap && maxConcurrent.trim() ? Number(maxConcurrent) : undefined,
     // #410: `""` (Use instance default) → `null` (inherit); `off` or a profile sets it.
     sandbox: sandbox || null,
+    // #551: `""` (Use instance default) → `null` (inherit); a concrete harness sets it.
+    harness: harness || null,
     // #338: freeze the auto-naming choice on the new Trigger (seeded from the
     // instance default when the modal opened).
     auto_name: autoName,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -465,6 +465,10 @@ export interface Trigger {
   /** Per-Trigger sandbox (#410/#432): `"off"` or a staging-profile name, or null/absent
    *  to inherit the instance default. Read at fire time. */
   sandbox?: string | null;
+  /** Per-Trigger harness (#551, ADR-0046): a harness name, or null/absent to inherit the
+   *  instance default. Read at fire time and folded into the fired Run's harness (no
+   *  separate Trigger tier — a cron tick and a "Run now" produce the same one). */
+  harness?: string | null;
   /** Whether Runs this Trigger fires are auto-named (#338). Frozen at creation from the
    *  instance default; `true` is the pre-#338 behaviour. A flat bool (no inherit state). */
   auto_name: boolean;
@@ -704,6 +708,14 @@ export interface RunState {
    * throughout, so this drives a banner only.
    */
   sandbox_prep?: "pending" | "ready";
+  /**
+   * The agentic harness this Run was created on (#551, ADR-0046) — the `run` tier of
+   * the precedence chain, **frozen** at creation like {@link RunState.sandbox}. Absent
+   * when the Run named no harness (every historical Run, and any Run that inherited the
+   * instance default): each free node then resolved through the instance default and
+   * the `claude` floor. Shown in the Run panel; a pinned node ignored it.
+   */
+  harness?: string;
   /**
    * Cumulative count of NodeRun sessions this run spawned — raw `NodeStarted`
    * count, not distinct `(node, iter)`; manager excluded (#100). Defaults to 0


### PR DESCRIPTION
## #551 — Le Run choisit son harnais

Ajoute le tier `run` à la chaîne de précédence du harnais agentique :
`nœud → Run → Projet(None) → instance → plancher (claude)`.

### Portée
- **Résolution** : le Run porte un harnais explicite ou hérite ; `harness_resolver` insère le tier `run` entre nœud et instance.
- **Gel au spawn** : `RunStarted.harness` est gelé au démarrage ; visible via `GET /runs/<id>.harness`. La session manager (infra) monte sur le harnais du Run ; un nœud qui épingle son propre harnais l'emporte.
- **UI New Run** : sélecteur *Harness* mode-aware. L'option d'héritage **nomme** le défaut résolu (`Use instance default (claude)`) sans le recopier ; en mode Trigger l'étiquette perd le nom résolu (un tir résout à son moment).
- **Trigger** : chaque tir lance son Run sur le harnais choisi.

### Validation
- `cargo test --lib` 1922/0 · intégration `harness_freeze_resume` 5/0 · `trigger_scheduler` 40/0 · `tmux_run_spawn` 2/0
- fmt + clippy `-D warnings` propres · vitest 1766/1766 · `npm run lint` + `tsc -b` propres
- ID visuel confirmé sur l'UI réelle (daemon isolé, v1.26.0)

### Notes d'intégration
- **Pas de bump de version** : les slices #551/#552/#553 atterrissent en parallèle sur `integration/549-multi-harnais` ; le bump unique est fait par la session qui orchestre une fois les trois posées.
- Base = `integration/549-multi-harnais` (la PR intégration → main est #554). Aucun merge de `main` dans cette branche.

Refs #551. Fait partie du PRD #549.
