### PR TITLE
feat(#553): capacités = code par harnais, absence dite, + tier disque des descripteurs

### DIFF
--- a/crates/pdo-daemon/src/event_log.rs
+++ b/crates/pdo-daemon/src/event_log.rs
@@ -598,6 +598,17 @@ pub struct CostStat {
     /// — stayed invisible on `/stats/cost` for weeks. Empty ⟺ `partial == false`.
     #[serde(default)]
     pub unpriced_models: Vec<String>,
+    /// The harnesses this Run launched a node on that have **no cost source**
+    /// capability (#553, ADR-0045). Non-empty ⇒ the Run's cost is not honestly
+    /// summable — a harness like `opencode` writes its cost where PDO does not read
+    /// (its own SQLite), so adding `claude`'s real dollars to that harness's
+    /// invisible $0 would be a silent under-count. So the surface shows **"—" with
+    /// a reason naming these harnesses**, never a `$0`, never a mute `partial`
+    /// (same "name what is missing" vein as `unpriced_models`). Sorted, deduped.
+    /// Empty on every all-`claude` Run, so `usd`/`partial` mean exactly what they
+    /// meant before this field existed.
+    #[serde(default)]
+    pub uncosted_harnesses: Vec<String>,
 }
 
 /// A secondary repository pinned to a Run (#465, ADR-0042).

--- a/crates/pdo-daemon/src/harness_probes.rs
+++ b/crates/pdo-daemon/src/harness_probes.rs
@@ -1,0 +1,325 @@
+//! The capability factory for agentic harnesses (#553, ADR-0045).
+//!
+//! Everything PDO knows how to do **beyond launching** a harness is a
+//! **capability**, written harness by harness: estimate a cost, resolve a
+//! transcript, constate an end of turn, spot a usage-limit menu, hold a staging
+//! floor. This module is the factory for those capabilities — and its whole
+//! point is to make their **absence legible**: never supplied, never silent.
+//!
+//! The shape is deliberate and was settled at the grilling (do not redraw it):
+//!
+//! - a trait ([`HarnessProbes`]) whose **every method defaults to "absent"**;
+//! - one implementation per harness that **overrides only what it can do**
+//!   ([`ClaudeProbes`] overrides all five);
+//! - a factory ([`probes_for`]) that returns `Option<&'static dyn …>`, so a
+//!   harness **declared in data** (an `opencode`, or a user's disk descriptor)
+//!   gets `None` — "no capability" — for free and un-forgettably.
+//!
+//! A closed `enum Harness` with compiled exhaustiveness was **explicitly
+//! rejected**: a data-declared harness has no variant, so every `match` would
+//! carry a catch-all arm. Here it costs nothing — an unknown name simply does not
+//! match, and the caller reads "absent" off the `None`.
+//!
+//! ## What "absent is said, never supplied" buys each caller
+//! - **cost** ([`crate::run_cost`]): a harness with no [`HarnessProbes::cost_source`]
+//!   contributes "—" **and a reason naming it**, never `$0`, never a silent
+//!   `partial` — the same vein as `unpriced_models` (#425).
+//! - **turn-end / usage-limit** ([`crate::stale_detector`]): the two sweep probes
+//!   are **gated** on [`HarnessProbes::turn_end_substrate`] /
+//!   [`HarnessProbes::usage_limit_anchor`]. Absent ⇒ the probe does not run, and
+//!   no node is ever auto-completed on an invented heuristic.
+//! - **sandbox** ([`crate::node_spawn`]): a sandboxed Run on a harness with no
+//!   [`HarnessProbes::staging_floor`] is **said once, visibly** — it holds only by
+//!   the user's image and the profile's `$HOME` exceptions, without the plancher's
+//!   guarantees (ADR-0031).
+//!
+//! This module is narrow on purpose: it fabricates **capabilities, never a
+//! launch** (a launch is data — the argv template of [`crate::harness_registry`]).
+
+use crate::harness_registry;
+
+/// A harness's cost source — how PDO turns a live Run into a dollar figure.
+///
+/// A marker, present or absent. Absent ⇒ the Run's cost is "—" with a reason.
+/// `claude`'s is the only source today; a second harness's would be a distinct
+/// variant (measured: `opencode` writes its own per-message cost into a SQLite
+/// its HTTP API exposes, four buckets that do not map onto `claude`'s — so cost
+/// stays code, never a declared mini-language, ADR-0045).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CostSource {
+    /// PDO derives the cost itself: per-message token usage in the harness's
+    /// transcript × the resolved price table (ADR-0034), as [`crate::run_cost`]
+    /// already does for `claude`.
+    DerivedFromTranscript,
+}
+
+/// How PDO resolves a harness's transcript on disk.
+///
+/// A cost or a turn-end read needs to find the right file first; a harness whose
+/// store PDO cannot map has neither. (Measured: `opencode` migrated its sessions
+/// into a SQLite and left months of dead JSON on disk — a store is not a contract,
+/// ADR-0045 — so PDO declares no resolution for it rather than reading zeros.)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TranscriptResolution {
+    /// Claude Code's `<projects_root>/<encoded-cwd>/<session-id>.jsonl` (#473),
+    /// newest-mtime for a pre-#473 row.
+    ClaudeJsonl,
+}
+
+/// The substrate PDO reads to constate an end of turn (#469 §2, ADR-0043).
+///
+/// Absent ⇒ the turn-end auto-completion probe never runs for this harness, so no
+/// node is auto-completed on an invented heuristic.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TurnEndSubstrate {
+    /// The Claude Code JSONL transcript tail, classified by
+    /// [`crate::stale_detector::parse_turn_state`].
+    ClaudeTranscript,
+}
+
+/// A harness's on-screen usage-limit menu — the anchor PDO matches in a pane
+/// capture (#290). **Proper to a harness**: the wording is claude's, so the probe
+/// is gated on this capability being present.
+///
+/// A marker, not a carrier of the substrings: those live next to their matcher in
+/// [`crate::stale_detector`] (they drift with Claude Code and are updated there).
+/// Absent ⇒ the usage-limit probe never runs for this harness.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum UsageLimitAnchor {
+    /// Claude Code's interactive "stop and wait for limit to reset" menu, matched
+    /// by [`crate::stale_detector::detect_usage_limit`].
+    ClaudePaneMenu,
+}
+
+/// The sandbox staging floor a harness guarantees (ADR-0031).
+///
+/// Absent ⇒ a sandboxed Run on this harness holds only by the user's image and
+/// the profile's `$HOME` exceptions, without the plancher's guarantees — and PDO
+/// says so once (see [`staging_floor_absence_note`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum StagingFloor {
+    /// The `.claude` staged home: valid credentials, org managed settings, bypass
+    /// permissions accepted, trust pre-granted to the Run root, empty `projects/`.
+    ClaudeDotClaude,
+}
+
+/// The capabilities of one harness. **Every method defaults to "absent"**
+/// (`None`); an implementation overrides only what its harness can do.
+///
+/// `Sync` so a single `&'static` instance can be handed out from [`probes_for`]
+/// across the daemon's threads (each impl is a stateless zero-sized type).
+pub(crate) trait HarnessProbes: Sync {
+    /// Cost source, or `None` (contribute "—" + a reason, never `$0`).
+    fn cost_source(&self) -> Option<CostSource> {
+        None
+    }
+    /// How PDO finds this harness's transcript, or `None`.
+    fn transcript_resolution(&self) -> Option<TranscriptResolution> {
+        None
+    }
+    /// The end-of-turn substrate, or `None` (the sweep's turn-end probe is gated
+    /// on this).
+    fn turn_end_substrate(&self) -> Option<TurnEndSubstrate> {
+        None
+    }
+    /// The usage-limit menu anchor, or `None` (the sweep's usage-limit probe is
+    /// gated on this).
+    fn usage_limit_anchor(&self) -> Option<UsageLimitAnchor> {
+        None
+    }
+    /// The sandbox staging floor, or `None` (a sandboxed Run says its absence
+    /// once).
+    fn staging_floor(&self) -> Option<StagingFloor> {
+        None
+    }
+}
+
+/// The `claude` capabilities — all five, exactly as they are today. This slice is
+/// a **dispatch refactor**, not a behaviour change: every method returns the
+/// mechanism `claude` has always used.
+struct ClaudeProbes;
+
+impl HarnessProbes for ClaudeProbes {
+    fn cost_source(&self) -> Option<CostSource> {
+        Some(CostSource::DerivedFromTranscript)
+    }
+    fn transcript_resolution(&self) -> Option<TranscriptResolution> {
+        Some(TranscriptResolution::ClaudeJsonl)
+    }
+    fn turn_end_substrate(&self) -> Option<TurnEndSubstrate> {
+        Some(TurnEndSubstrate::ClaudeTranscript)
+    }
+    fn usage_limit_anchor(&self) -> Option<UsageLimitAnchor> {
+        Some(UsageLimitAnchor::ClaudePaneMenu)
+    }
+    fn staging_floor(&self) -> Option<StagingFloor> {
+        Some(StagingFloor::ClaudeDotClaude)
+    }
+}
+
+/// The single `claude` instance handed out by [`probes_for`]. Zero-sized, so this
+/// `static` costs nothing and needs no lazy init.
+static CLAUDE_PROBES: ClaudeProbes = ClaudeProbes;
+
+/// The capabilities of `harness`, or `None` for a harness PDO carries no code for.
+///
+/// `claude` is the only harness with any capability today; `opencode` and every
+/// **data-declared** harness (a user's disk descriptor) get `None` — "no
+/// capability" — which is exactly what makes the absence free and un-forgettable.
+/// A caller that wants per-capability booleans uses [`capabilities`], which reads
+/// the same `None` as "all absent".
+pub(crate) fn probes_for(harness: &str) -> Option<&'static dyn HarnessProbes> {
+    match harness {
+        harness_registry::CLAUDE => Some(&CLAUDE_PROBES),
+        // `opencode` (resident but un-instrumented in v1) and every data-declared
+        // harness: no capability. A launch is data; a capability is code (ADR-0045).
+        _ => None,
+    }
+}
+
+/// The five capabilities of a harness as plain booleans — the read-friendly view
+/// the gates consult. A harness with no probes (`None` from [`probes_for`]) is
+/// absent on all five, so a data-declared harness resolves to
+/// [`Capabilities::NONE`] without any per-harness code.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct Capabilities {
+    pub cost: bool,
+    pub transcript: bool,
+    pub turn_end: bool,
+    pub usage_limit: bool,
+    pub staging: bool,
+}
+
+impl Capabilities {
+    /// Every capability absent — a data-declared harness, un-instrumented and
+    /// blind, but still launchable/attachable/completable (ADR-0045).
+    pub(crate) const NONE: Capabilities = Capabilities {
+        cost: false,
+        transcript: false,
+        turn_end: false,
+        usage_limit: false,
+        staging: false,
+    };
+}
+
+/// Resolve `harness` to its five capability booleans. `None` from the factory ⇒
+/// [`Capabilities::NONE`], so an unknown or data-declared harness is absent on all
+/// five — the property the whole slice rests on.
+pub(crate) fn capabilities(harness: &str) -> Capabilities {
+    match probes_for(harness) {
+        None => Capabilities::NONE,
+        Some(p) => Capabilities {
+            cost: p.cost_source().is_some(),
+            transcript: p.transcript_resolution().is_some(),
+            turn_end: p.turn_end_substrate().is_some(),
+            usage_limit: p.usage_limit_anchor().is_some(),
+            staging: p.staging_floor().is_some(),
+        },
+    }
+}
+
+/// Whether PDO can derive a Run's cost for `harness`: it needs both a cost source
+/// and a way to find the transcript that source reads. A data-declared harness has
+/// neither, so its Run's cost is "—" with a reason rather than a silent `$0`.
+pub(crate) fn can_cost(harness: &str) -> bool {
+    let c = capabilities(harness);
+    c.cost && c.transcript
+}
+
+/// The one-time note for a sandboxed Run whose node runs on a harness with no
+/// staging floor (ADR-0031). `Some(msg)` when `harness` lacks the floor,
+/// `None` when it has it (`claude`). Pure and testable, modelled on
+/// `price_table::diagnostic`.
+pub(crate) fn staging_floor_absence_note(harness: &str) -> Option<String> {
+    if capabilities(harness).staging {
+        return None;
+    }
+    Some(format!(
+        "sandbox: harness `{harness}` has no staging floor (#553, ADR-0031) — this Run's session \
+         holds only by the profile's image and its `$HOME` exceptions, without the plancher's \
+         guarantees (credentials, org managed settings, pre-granted trust, empty projects/)"
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::harness_registry::{CLAUDE, OPENCODE};
+
+    /// A struct that overrides nothing: the demonstration that **every trait
+    /// method defaults to "absent"**. This is the shape of a harness declared in
+    /// data — it has no code, so it inherits every default.
+    struct BareHarness;
+    impl HarnessProbes for BareHarness {}
+
+    #[test]
+    fn every_default_is_absent() {
+        let bare = BareHarness;
+        assert!(bare.cost_source().is_none());
+        assert!(bare.transcript_resolution().is_none());
+        assert!(bare.turn_end_substrate().is_none());
+        assert!(bare.usage_limit_anchor().is_none());
+        assert!(bare.staging_floor().is_none());
+    }
+
+    #[test]
+    fn claude_keeps_its_five_capabilities() {
+        // The control: `claude`'s five capabilities are intact — this slice is a
+        // dispatch refactor, not a behaviour change.
+        let p = probes_for(CLAUDE).expect("claude has probes");
+        assert_eq!(p.cost_source(), Some(CostSource::DerivedFromTranscript));
+        assert_eq!(
+            p.transcript_resolution(),
+            Some(TranscriptResolution::ClaudeJsonl)
+        );
+        assert_eq!(
+            p.turn_end_substrate(),
+            Some(TurnEndSubstrate::ClaudeTranscript)
+        );
+        assert_eq!(
+            p.usage_limit_anchor(),
+            Some(UsageLimitAnchor::ClaudePaneMenu)
+        );
+        assert_eq!(p.staging_floor(), Some(StagingFloor::ClaudeDotClaude));
+    }
+
+    #[test]
+    fn claude_capabilities_are_all_present() {
+        let c = capabilities(CLAUDE);
+        assert_eq!(
+            c,
+            Capabilities {
+                cost: true,
+                transcript: true,
+                turn_end: true,
+                usage_limit: true,
+                staging: true,
+            }
+        );
+        assert!(can_cost(CLAUDE));
+    }
+
+    #[test]
+    fn a_data_declared_harness_is_absent_on_all_five() {
+        // AC: a harness declared in data returns "absent" on the five. `opencode`
+        // (embedded but un-instrumented in v1) and any never-seen name both take
+        // the factory's `None`.
+        for name in [OPENCODE, "my-custom-harness", "not-a-harness"] {
+            assert!(probes_for(name).is_none(), "{name} must have no probes");
+            assert_eq!(capabilities(name), Capabilities::NONE, "{name}");
+            assert!(!can_cost(name), "{name} cannot be costed");
+        }
+    }
+
+    #[test]
+    fn staging_floor_absence_note_fires_only_for_a_harness_without_the_floor() {
+        // `claude` has the floor → no note.
+        assert_eq!(staging_floor_absence_note(CLAUDE), None);
+        // A data-declared harness has none → one visible note that names it and
+        // says what is NOT guaranteed.
+        let note = staging_floor_absence_note("my-custom-harness").expect("a note");
+        assert!(note.contains("`my-custom-harness`"));
+        assert!(note.contains("no staging floor"));
+        assert!(note.contains("$HOME"));
+    }
+}

--- a/crates/pdo-daemon/src/harness_registry.rs
+++ b/crates/pdo-daemon/src/harness_registry.rs
@@ -13,6 +13,22 @@
 //! #553; [`merge_by_name`] is that seam, present and tested now so the disk tier
 //! layers on without rewriting [`resolve`]'s callers — but no caller passes a disk
 //! tier in this slice, so the floor is the whole registry.
+//!
+//! **#553 lands that disk tier.** [`HarnessRegistry::load`] reads a user-declared
+//! descriptor file under an **injected root** (never `$HOME` — the discipline this
+//! module already keeps), parses it, and merges it over the embedded floor **by
+//! name** ([`merge_by_name`]). Nothing is ever written or seeded. A descriptor that
+//! is unreadable or refused is **inert and diagnosed**: its key falls through to
+//! the next tier (the floor), it is never partially applied, and it is named —
+//! once per distinct diagnostic in the log, and always in `GET /settings` — the
+//! exact idiom of `price_table` (ADR-0034).
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use serde::Deserialize;
+use tracing::warn;
 
 /// A harness, as PDO launches / resumes / attaches it (ADR-0045).
 ///
@@ -181,6 +197,262 @@ pub fn resolve(name: &str) -> Option<HarnessDescriptor> {
     embedded_floor().into_iter().find(|d| d.name == name)
 }
 
+// --- The disk tier (#553) -----------------------------------------------------
+
+/// A refused disk descriptor and why — the material of BOTH the `warn!` and the
+/// `GET /settings` `reason`, so the two can never drift (idiom of
+/// `price_table::RejectedRow`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RejectedDescriptor {
+    pub name: String,
+    pub why: String,
+}
+
+/// The result of parsing the on-disk descriptor tier. Pure: text in; the parsed
+/// descriptors and any refusals out. An unparseable document yields
+/// `unparseable: Some(err)` and NO descriptors — never an `Err`, because a bad
+/// descriptor file must not be able to fail a spawn (it degrades to the floor).
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct ParsedDescriptors {
+    pub descriptors: Vec<HarnessDescriptor>,
+    pub rejected: Vec<RejectedDescriptor>,
+    pub unparseable: Option<String>,
+}
+
+/// One row of the descriptor file. The harness **name is the map key**, so it is
+/// not a field here (key uniqueness is structural, like `price_table`'s manual
+/// map). No `deny_unknown_fields` (ADR-0015 #471: an unknown field is ignored).
+#[derive(Debug, Deserialize)]
+struct DescriptorRow {
+    binary: Option<String>,
+    #[serde(default)]
+    launch: Vec<String>,
+    #[serde(default)]
+    resume: Vec<String>,
+    #[serde(default)]
+    env: BTreeMap<String, String>,
+}
+
+/// Parse the descriptor file (`descriptors.yaml`). PURE.
+///
+/// Shape — a MAP keyed by harness name, mirroring `price_table`'s `models.yaml`:
+///
+/// ```yaml
+/// harnesses:
+///   my-harness:
+///     binary: my-harness
+///     launch: ["exec", "my-harness", "--auto", "--prompt {prompt}"]
+///     resume: ["exec", "my-harness", "--auto", "--continue"]   # optional
+///     env: { FOO: bar }                                        # optional
+/// ```
+///
+/// A row is **refused whole** (never partially applied) when it lacks the two
+/// things PDO needs to *launch* it: a `binary` to probe and a non-empty `launch`
+/// argv template (ADR-0045). A refused row's key falls through to the next tier —
+/// so a broken `claude:` override leaves the embedded `claude` untouched. PDO does
+/// **not** validate what the argv *means* (ADR-0001): a descriptor without an
+/// autonomy flag simply yields a node stalled on a permission dialog, which is
+/// said in the descriptor's documentation, not guarded here.
+pub fn parse_descriptors(text: &str) -> ParsedDescriptors {
+    #[derive(Deserialize)]
+    struct Doc {
+        #[serde(default)]
+        harnesses: BTreeMap<String, DescriptorRow>,
+    }
+
+    // A blank/comment-only file is an empty tier, not a broken one — the normal
+    // state of an instance that has the dir but no descriptor yet.
+    if text.trim().is_empty() {
+        return ParsedDescriptors::default();
+    }
+    let doc: Doc = match serde_yaml::from_str(text) {
+        Ok(d) => d,
+        Err(e) => {
+            return ParsedDescriptors {
+                unparseable: Some(e.to_string()),
+                ..Default::default()
+            }
+        }
+    };
+
+    let mut parsed = ParsedDescriptors::default();
+    for (name, row) in doc.harnesses {
+        if name.trim().is_empty() {
+            parsed.rejected.push(RejectedDescriptor {
+                name,
+                why: "a harness name must not be blank".to_string(),
+            });
+            continue;
+        }
+        let binary = row.binary.unwrap_or_default();
+        if binary.trim().is_empty() {
+            parsed.rejected.push(RejectedDescriptor {
+                name,
+                why: "missing `binary` — PDO probes a program at spawn; a descriptor with none \
+                      could only ever fail-fast"
+                    .to_string(),
+            });
+            continue;
+        }
+        // An empty string among the launch tokens is not a hole to fill — it would
+        // render to a stray token. Refuse the row rather than launch something odd.
+        if row.launch.is_empty() {
+            parsed.rejected.push(RejectedDescriptor {
+                name,
+                why: "missing `launch` — a harness declares itself by an argv template (ADR-0045)"
+                    .to_string(),
+            });
+            continue;
+        }
+        parsed.descriptors.push(HarnessDescriptor {
+            name,
+            binary,
+            launch: row.launch,
+            resume: row.resume,
+            env: row.env.into_iter().collect(),
+        });
+    }
+    parsed
+}
+
+/// The registry resolved for one read: the embedded floor merged with the disk
+/// tier **by name**, plus the diagnostics for whatever the disk tier refused. The
+/// analogue of `price_table::PriceTable` — one resolver shared by the spawn/resume
+/// seams and the `GET /settings` view, so what the UI lists can never drift from
+/// what actually resolves.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HarnessRegistry {
+    /// Floor ∪ disk, merged by name (a disk descriptor replaces the floor entry of
+    /// its name; a floor name absent from disk survives).
+    descriptors: Vec<HarnessDescriptor>,
+    disk_rejected: Vec<RejectedDescriptor>,
+    disk_unparseable: Option<String>,
+    /// Set by [`Self::load`] only, so [`Self::diagnostic`] can name the real file.
+    disk_path: Option<PathBuf>,
+}
+
+impl Default for HarnessRegistry {
+    fn default() -> Self {
+        Self::builtin()
+    }
+}
+
+impl HarnessRegistry {
+    /// The floor alone — no IO, no `$HOME`. What every non-root caller (infra
+    /// sessions, the golden tests) resolves against.
+    pub fn builtin() -> Self {
+        Self {
+            descriptors: embedded_floor(),
+            disk_rejected: Vec::new(),
+            disk_unparseable: None,
+            disk_path: None,
+        }
+    }
+
+    /// `<home_root>/.pdo/harnesses/descriptors.yaml` — path arithmetic only, the
+    /// idiom of `price_table::PriceTable::paths`.
+    pub fn descriptors_path(home_root: &Path) -> PathBuf {
+        home_root
+            .join(".pdo")
+            .join("harnesses")
+            .join("descriptors.yaml")
+    }
+
+    /// Load the effective registry from an injected root. Absent or unreadable →
+    /// the floor, SILENT (the normal state of an instance). Unparseable, or a
+    /// refused row → the floor for that key plus a diagnostic. Never reads `$HOME`,
+    /// never writes, never seeds. Emits AT MOST ONE `warn!` per distinct
+    /// diagnostic, so a polled spawn/settings path cannot flood the log.
+    pub fn load(home_root: &Path) -> Self {
+        let path = Self::descriptors_path(home_root);
+        let parsed = std::fs::read(&path)
+            .ok()
+            .map(|b| parse_descriptors(&String::from_utf8_lossy(&b)))
+            .unwrap_or_default();
+        let registry = Self {
+            descriptors: merge_by_name(embedded_floor(), parsed.descriptors),
+            disk_rejected: parsed.rejected,
+            disk_unparseable: parsed.unparseable,
+            disk_path: Some(path),
+        };
+        registry.warn_once();
+        registry
+    }
+
+    /// Resolve a name against the merged registry. `None` ⇒ no tier carries that
+    /// name (the spawn seam turns this into a fail-fast that names it).
+    pub fn resolve(&self, name: &str) -> Option<HarnessDescriptor> {
+        self.descriptors.iter().find(|d| d.name == name).cloned()
+    }
+
+    /// The names the registry resolves, in declaration order (floor first, then
+    /// any novel disk harness). The `GET /settings` "which harnesses exist" view.
+    pub fn names(&self) -> Vec<String> {
+        self.descriptors.iter().map(|d| d.name.clone()).collect()
+    }
+
+    /// The disk descriptors the registry refused — each inert, its key on the
+    /// floor. For the settings surface.
+    pub fn rejected(&self) -> &[RejectedDescriptor] {
+        &self.disk_rejected
+    }
+
+    /// ONE message naming an inert descriptor file and every refused row, or
+    /// `None` when the disk tier is clean/absent. PURE, so a unit test can pin it
+    /// instead of a terminal (modelled on `price_table::PriceTable::diagnostic`).
+    pub fn diagnostic(&self) -> Option<String> {
+        let where_ = match &self.disk_path {
+            Some(p) => format!("harness descriptor tier ({})", p.display()),
+            None => "harness descriptor tier".to_string(),
+        };
+        let mut parts: Vec<String> = Vec::new();
+        if let Some(err) = &self.disk_unparseable {
+            parts.push(format!("{where_} is entirely inert: {err}"));
+        }
+        if !self.disk_rejected.is_empty() {
+            let rows = self
+                .disk_rejected
+                .iter()
+                .map(|r| format!("`{}` ({})", r.name, r.why))
+                .collect::<Vec<_>>()
+                .join(", ");
+            parts.push(format!(
+                "{where_} refused {} descriptor(s), each key falling through to the next tier: \
+                 {rows}",
+                self.disk_rejected.len()
+            ));
+        }
+        if parts.is_empty() {
+            None
+        } else {
+            Some(format!(
+                "harness descriptors (#553) — {}",
+                parts.join(" ; ")
+            ))
+        }
+    }
+
+    /// Say the diagnostic at most once per distinct message — a *differently* bad
+    /// file hashes differently and is said again. Same posture as
+    /// `price_table::PriceTable::warn_once` (a loader called once per request must
+    /// not log per request).
+    fn warn_once(&self) {
+        static LAST_WARNED: Mutex<Option<u64>> = Mutex::new(None);
+        let Some(msg) = self.diagnostic() else {
+            return;
+        };
+        let mut h = std::collections::hash_map::DefaultHasher::new();
+        std::hash::Hash::hash(&msg, &mut h);
+        let fingerprint = std::hash::Hasher::finish(&h);
+        let mut guard = LAST_WARNED.lock().unwrap_or_else(|e| e.into_inner());
+        if *guard == Some(fingerprint) {
+            return;
+        }
+        *guard = Some(fingerprint);
+        warn!("{msg}");
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -244,5 +516,197 @@ mod tests {
         let merged = merge_by_name(embedded_floor(), vec![novel]);
         assert!(merged.iter().any(|d| d.name == "novel"));
         assert_eq!(merged.len(), 3);
+    }
+
+    // --- the disk tier (#553) ------------------------------------------------
+
+    #[test]
+    fn parse_descriptors_accepts_a_valid_custom_harness() {
+        let parsed = parse_descriptors(
+            "harnesses:\n  my-harness:\n    binary: my-harness\n    launch: [\"exec\", \"my-harness\", \"--auto\", \"--prompt {prompt}\"]\n    resume: [\"exec\", \"my-harness\", \"--auto\", \"--continue\"]\n    env: { FOO: bar }\n",
+        );
+        assert!(parsed.unparseable.is_none());
+        assert!(parsed.rejected.is_empty());
+        assert_eq!(parsed.descriptors.len(), 1);
+        let d = &parsed.descriptors[0];
+        assert_eq!(d.name, "my-harness");
+        assert_eq!(d.binary, "my-harness");
+        assert_eq!(d.launch.last().unwrap(), "--prompt {prompt}");
+        assert_eq!(d.resume, vec!["exec", "my-harness", "--auto", "--continue"]);
+        assert_eq!(d.env, vec![("FOO".to_string(), "bar".to_string())]);
+    }
+
+    #[test]
+    fn parse_descriptors_treats_an_empty_or_comment_only_file_as_an_empty_tier() {
+        for text in [
+            "",
+            "   \n",
+            "# nothing yet\n",
+            "harnesses:\n",
+            "harnesses: {}\n",
+        ] {
+            let parsed = parse_descriptors(text);
+            assert!(parsed.unparseable.is_none(), "text = {text:?}");
+            assert!(parsed.descriptors.is_empty());
+            assert!(parsed.rejected.is_empty());
+        }
+    }
+
+    #[test]
+    fn parse_descriptors_refuses_a_row_missing_binary_or_launch_whole() {
+        // A row without a binary or a launch template is refused ENTIRELY, never
+        // partially applied — its key falls through to the next tier.
+        let no_binary = parse_descriptors("harnesses:\n  x:\n    launch: [\"exec\", \"x\"]\n");
+        assert!(no_binary.descriptors.is_empty());
+        assert_eq!(no_binary.rejected.len(), 1);
+        assert!(no_binary.rejected[0].why.contains("binary"));
+
+        let no_launch = parse_descriptors("harnesses:\n  x:\n    binary: x\n");
+        assert!(no_launch.descriptors.is_empty());
+        assert_eq!(no_launch.rejected.len(), 1);
+        assert!(no_launch.rejected[0].why.contains("launch"));
+    }
+
+    #[test]
+    fn parse_descriptors_keeps_the_good_rows_when_one_is_refused() {
+        let parsed = parse_descriptors(
+            "harnesses:\n  good:\n    binary: good\n    launch: [\"exec\", \"good\"]\n  bad:\n    launch: [\"exec\", \"bad\"]\n",
+        );
+        assert_eq!(
+            parsed.descriptors.len(),
+            1,
+            "one bad row must not void the file"
+        );
+        assert_eq!(parsed.descriptors[0].name, "good");
+        assert_eq!(parsed.rejected.len(), 1);
+        assert_eq!(parsed.rejected[0].name, "bad");
+    }
+
+    #[test]
+    fn parse_descriptors_reports_broken_yaml_without_descriptors() {
+        let parsed = parse_descriptors("harnesses:\n  - this is: [not, a, map\n");
+        assert!(parsed.unparseable.is_some());
+        assert!(parsed.descriptors.is_empty());
+    }
+
+    #[test]
+    fn builtin_registry_resolves_the_floor() {
+        let reg = HarnessRegistry::builtin();
+        assert!(reg.resolve(CLAUDE).is_some());
+        assert!(reg.resolve(OPENCODE).is_some());
+        assert!(reg.resolve("nope").is_none());
+        assert!(reg.diagnostic().is_none());
+        assert_eq!(reg.names(), vec![CLAUDE.to_string(), OPENCODE.to_string()]);
+    }
+
+    #[test]
+    fn load_on_a_root_without_a_descriptor_file_is_the_floor_and_silent() {
+        let home = tempfile::tempdir().unwrap();
+        let reg = HarnessRegistry::load(home.path());
+        assert!(reg.resolve(CLAUDE).is_some());
+        assert!(reg.resolve(OPENCODE).is_some());
+        assert!(reg.diagnostic().is_none());
+        // Nothing is ever seeded on disk.
+        assert!(!HarnessRegistry::descriptors_path(home.path()).exists());
+    }
+
+    #[test]
+    fn load_merges_a_custom_harness_by_name_over_the_floor() {
+        // FP: declare a harness PDO does not know, and it resolves.
+        let home = tempfile::tempdir().unwrap();
+        let path = HarnessRegistry::descriptors_path(home.path());
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &path,
+            "harnesses:\n  my-harness:\n    binary: my-harness\n    launch: [\"exec\", \"my-harness\", \"--auto\"]\n",
+        )
+        .unwrap();
+
+        let reg = HarnessRegistry::load(home.path());
+        let d = reg
+            .resolve("my-harness")
+            .expect("the custom harness resolves");
+        assert_eq!(d.binary, "my-harness");
+        // …and the floor survives alongside it (merge by name).
+        assert!(reg.resolve(CLAUDE).is_some());
+        assert!(reg.resolve(OPENCODE).is_some());
+        assert!(reg.names().contains(&"my-harness".to_string()));
+    }
+
+    #[test]
+    fn a_broken_descriptor_file_leaves_claude_untouched_and_is_diagnosed() {
+        // FP: corrupt the file → it becomes inert and diagnosed; `claude` and
+        // `opencode` keep working (the whole disk tier falls through to the floor).
+        let home = tempfile::tempdir().unwrap();
+        let path = HarnessRegistry::descriptors_path(home.path());
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, "harnesses:\n  - not: [a, map\n").unwrap();
+
+        let reg = HarnessRegistry::load(home.path());
+        // Floor intact, byte-identical to the embedded claude.
+        assert_eq!(reg.resolve(CLAUDE), Some(claude()));
+        assert_eq!(reg.resolve(OPENCODE), Some(opencode()));
+        // …and the corruption is named, pointing at the real file.
+        let d = reg.diagnostic().expect("a broken file must be said");
+        assert!(
+            d.contains("descriptors.yaml"),
+            "the path must be named: {d}"
+        );
+        assert!(d.contains("inert"));
+    }
+
+    #[test]
+    fn a_refused_row_falls_through_to_the_floor_and_is_named() {
+        // A malformed `claude:` override must not un-define claude: the row is
+        // refused, its key falls to the embedded floor, and the refusal is named.
+        let home = tempfile::tempdir().unwrap();
+        let path = HarnessRegistry::descriptors_path(home.path());
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &path,
+            // No `binary` → refused whole.
+            "harnesses:\n  claude:\n    launch: [\"exec\", \"totally-wrong\"]\n",
+        )
+        .unwrap();
+
+        let reg = HarnessRegistry::load(home.path());
+        assert_eq!(
+            reg.resolve(CLAUDE),
+            Some(claude()),
+            "claude stays the floor"
+        );
+        assert_eq!(reg.rejected().len(), 1);
+        assert_eq!(reg.rejected()[0].name, "claude");
+        let d = reg.diagnostic().unwrap();
+        assert!(d.contains("`claude`") && d.contains("falling through"));
+    }
+
+    #[test]
+    fn load_never_writes_to_disk() {
+        // The read is pure: loading, even with a healthy file, seeds nothing beyond
+        // the file the user already wrote (no fetched.json analogue, no baseline).
+        let home = tempfile::tempdir().unwrap();
+        let dir = HarnessRegistry::descriptors_path(home.path())
+            .parent()
+            .unwrap()
+            .to_path_buf();
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            HarnessRegistry::descriptors_path(home.path()),
+            "harnesses:\n  x:\n    binary: x\n    launch: [\"exec\", \"x\"]\n",
+        )
+        .unwrap();
+        let before: Vec<_> = std::fs::read_dir(&dir)
+            .unwrap()
+            .flatten()
+            .map(|e| e.file_name())
+            .collect();
+        let _ = HarnessRegistry::load(home.path());
+        let after: Vec<_> = std::fs::read_dir(&dir)
+            .unwrap()
+            .flatten()
+            .map(|e| e.file_name())
+            .collect();
+        assert_eq!(before, after, "load must not write any file");
     }
 }

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -20,6 +20,7 @@ mod frontmatter_parser;
 mod graph_resolver;
 mod guard_runner;
 mod harness_argv;
+mod harness_probes;
 pub mod harness_registry;
 mod harness_resolver;
 mod input_resolution;
@@ -8155,6 +8156,36 @@ async fn build_settings_view(state: &AppState) -> Result<serde_json::Value, sqlx
         }),
     };
 
+    // --- harness descriptors: the disk tier, surfaced (#553, ADR-0045) ---
+    // Same posture as `price_table` above: a hand-edited descriptor file passes
+    // through NO validator (ADR-0001), so the only honest place to say a descriptor
+    // is inert or refused is here, beside the facts. `names` lists what actually
+    // resolves (floor merged with disk), so a user learns their declared harness
+    // "appeared"; `reason` carries the SAME string the loader logs. The path is
+    // ALWAYS reported so the user knows where to write — nothing is ever seeded.
+    let harness_descriptors_view = match &host_home_path {
+        Some(home) => {
+            let registry = harness_registry::HarnessRegistry::load(home);
+            serde_json::json!({
+                "path": harness_registry::HarnessRegistry::descriptors_path(home).to_string_lossy(),
+                "names": registry.names(),
+                "rejected": registry
+                    .rejected()
+                    .iter()
+                    .map(|r| serde_json::json!({ "name": r.name, "why": r.why }))
+                    .collect::<Vec<_>>(),
+                "reason": registry.diagnostic(),
+            })
+        }
+        None => serde_json::json!({
+            "path": null,
+            "names": harness_registry::HarnessRegistry::builtin().names(),
+            "rejected": [],
+            "reason": "HOME is unset, so the descriptor file has no resolvable path — \
+                       only the harnesses compiled into the binary apply",
+        }),
+    };
+
     Ok(serde_json::json!({
         "session_cap": settings_field(cap_effective, cap_source, cfg.session_cap, cap_env, cap_default),
         "reaper_ttl_secs": settings_field(ttl_effective, ttl_source, cfg.reaper_ttl_secs, ttl_env, ttl_default),
@@ -8169,6 +8200,10 @@ async fn build_settings_view(state: &AppState) -> Result<serde_json::Value, sqlx
             "effective": dhm_effective,
             "stored": dhm_stored,
         },
+        // #553/ADR-0045: the disk descriptor tier — which harnesses resolve (floor
+        // ∪ disk), the file path, and any inert/refused descriptor named. The
+        // settings surface is where a broken descriptor is ALWAYS said.
+        "harness_descriptors": harness_descriptors_view,
         "default_sandbox": {
             "effective": sbx_effective.as_str(),
             "source": sbx_source,
@@ -9481,7 +9516,13 @@ async fn get_run(
             // HOST home — prices are an instance concept), while transcripts come
             // from `projects_root` (the #408 seam, which moves for a sandboxed Run).
             let prices = price_table::PriceTable::load(&home_root);
-            augment_run_state_from_disk(&mut run_state, &projects_root, &repo_root, &prices);
+            augment_run_state_from_disk(
+                &mut run_state,
+                &events,
+                &projects_root,
+                &repo_root,
+                &prices,
+            );
             Json(run_state).into_response()
         }
         None => (StatusCode::NOT_FOUND, "run not found").into_response(),
@@ -10110,6 +10151,20 @@ async fn run_stale_detection(state: &Arc<AppState>) {
                 running: &running,
             };
 
+            // #553: gate the turn-end and usage-limit probes on the node's
+            // FROZEN-at-spawn harness (ADR-0046), never the current YAML. `None`
+            // (a script node, a pre-#550 row) is the `claude` floor, which has both
+            // capabilities — so the sweep is byte-identical to pre-#553 there. A
+            // node on a harness without them runs neither probe: no auto-completion
+            // on an invented heuristic, no capture for another harness's menu.
+            let node_harness = find_launch_harness(&events, node_id, *iter)
+                .unwrap_or_else(|| harness_registry::CLAUDE.to_string());
+            let hc = harness_probes::capabilities(&node_harness);
+            let caps = stale_detector::HarnessCapabilities {
+                turn_end: hc.turn_end,
+                usage_limit: hc.usage_limit,
+            };
+
             let assessment = stale_detector::assess_node(
                 &probes,
                 &events,
@@ -10118,6 +10173,7 @@ async fn run_stale_detection(state: &Arc<AppState>) {
                 *iter,
                 now,
                 autocomplete_turn_end,
+                caps,
             );
 
             if assessment.blocked_on_limit {
@@ -10551,9 +10607,20 @@ async fn node_pane(
             // now. A pre-#550 row (no key) or an unknown harness falls back to the
             // `claude` floor, byte-identical to the legacy resume.
             let launch_harness = find_launch_harness(&events, &node_id, iter);
+            // #553: resolve the frozen harness against the embedded floor MERGED
+            // with the disk descriptor tier, so a user-declared harness resumes
+            // like the built-in ones. The registry reads a root we hand it (never
+            // `$HOME`); a resolution failure, a pre-#550 row, or an unresolved home
+            // all fall back to the `claude` floor — byte-identical to the legacy
+            // resume.
+            let harness_home_root = sandbox_run::sandbox_home_roots(&state)
+                .map(|(home, _)| home)
+                .unwrap_or_default();
             let descriptor = launch_harness
                 .as_deref()
-                .and_then(harness_registry::resolve)
+                .and_then(|name| {
+                    harness_registry::HarnessRegistry::load(&harness_home_root).resolve(name)
+                })
                 .unwrap_or_else(harness_registry::claude);
             // AC #9: a harness with no resume mechanism serves its last pane
             // snapshot (the same branch as a `script` node), never a resume error.
@@ -13966,6 +14033,7 @@ fn compute_run_loc(repo_root: &std::path::Path, run_id: &str) -> Option<event_lo
 
 fn augment_run_state_from_disk(
     run_state: &mut event_log::RunState,
+    events: &[event_log::Event],
     projects_root: &std::path::Path,
     repo_root: &std::path::Path,
     prices: &price_table::PriceTable,
@@ -13978,8 +14046,13 @@ fn augment_run_state_from_disk(
     // Claude Code transcripts under `projects_root` (the #408 seam — the staged
     // home while a sandboxed Run is live, `~/.claude/projects/` otherwise), not
     // the run dir. `repo_root` builds the run-id dir prefix, not the read root.
+    // #553/ADR-0045: honest about a harness with no cost source. If a node ran on
+    // such a harness the aggregate is not summable, so this yields a "—"-with-reason
+    // `CostStat` (never `$0`); otherwise it is exactly `compute_run_cost`. Needs the
+    // raw events for the frozen-at-spawn harnesses (`RunState` alone does not carry
+    // them per node).
     run_state.cost =
-        run_cost::compute_run_cost(projects_root, repo_root, &run_state.run_id, prices);
+        run_cost::run_cost_or_absence(events, projects_root, repo_root, &run_state.run_id, prices);
 
     let yaml_path = run_scoped_pipeline_path(repo_root, &run_state.run_id);
     let Ok(yaml) = std::fs::read_to_string(&yaml_path) else {

--- a/crates/pdo-daemon/src/node_spawn.rs
+++ b/crates/pdo-daemon/src/node_spawn.rs
@@ -59,6 +59,12 @@ pub(crate) struct SpawnDeps<'a> {
     /// Per-daemon `docker` binary override for the sandbox wiring (#407), `Copy`
     /// like the rest of the bundle. `None` in production (real `docker`).
     pub(crate) docker_cmd_override: Option<&'a str>,
+    /// The host home root override (#407 seam), borrowed so the bundle stays
+    /// `Copy`. `None` in production ⇒ the real `$HOME`. #553 uses it as the root
+    /// under which the **disk descriptor tier** (`~/.pdo/harnesses/`) is read, so a
+    /// user-declared harness resolves at spawn — and so a layer-3 test that sets
+    /// the override reads descriptors from its own tempdir, never the real home.
+    pub(crate) home_override: Option<&'a std::path::Path>,
 }
 
 impl<'a> SpawnDeps<'a> {
@@ -72,7 +78,41 @@ impl<'a> SpawnDeps<'a> {
             port: state.port,
             tmux_cmd_override: state.tmux_cmd_override.as_deref(),
             docker_cmd_override: state.docker_cmd_override.as_deref(),
+            home_override: state.sandbox_home_override.as_deref(),
         }
+    }
+}
+
+/// The host home root the disk descriptor tier (#553) is read under: the per-daemon
+/// override when set (the layer-3 seam), else the real `$HOME`. Mirrors
+/// `sandbox_run::sandbox_home_roots` exactly, but reachable from the narrow
+/// [`SpawnDeps`] bundle (which carries no `AppState`). An unresolved `$HOME`
+/// degrades to an empty root, i.e. the embedded floor — never a spawn failure.
+fn spawn_home_root(deps: &SpawnDeps<'_>) -> PathBuf {
+    deps.home_override
+        .map(PathBuf::from)
+        .or_else(|| crate::sandbox_staging::default_roots_from_env().map(|(home, _)| home))
+        .unwrap_or_default()
+}
+
+/// #553 / ADR-0031: say ONCE per `(run, harness)` that a sandboxed Run's node runs
+/// on a harness with no staging floor. The message is the pure
+/// [`crate::harness_probes::staging_floor_absence_note`] (so it is unit-tested
+/// there, not against a terminal); the process-static dedup keeps a busy scheduler
+/// from repeating it on every retry or collection lap. A no-op for `claude`, which
+/// has the floor.
+fn warn_missing_staging_floor_once(run_id: &str, harness: &str) {
+    use std::collections::HashSet;
+    use std::sync::Mutex;
+    static SAID: Mutex<Option<HashSet<(String, String)>>> = Mutex::new(None);
+
+    let Some(note) = crate::harness_probes::staging_floor_absence_note(harness) else {
+        return; // the harness has a staging floor (claude) — nothing to say
+    };
+    let mut guard = SAID.lock().unwrap_or_else(|e| e.into_inner());
+    let said = guard.get_or_insert_with(HashSet::new);
+    if said.insert((run_id.to_string(), harness.to_string())) {
+        warn!("run {run_id}: {note}");
     }
 }
 
@@ -343,15 +383,31 @@ pub(crate) async fn spawn_node(
     };
     let harness_descriptor = match &resolved_harness {
         None => None,
-        Some(r) => match harness_registry::resolve(&r.harness) {
-            Some(d) => Some(d),
-            None => {
-                // Unknown harness — a spawn that cannot happen. Fail fast, naming it.
-                return SpawnOutcome::Failed {
-                    reason: format!("node {}: unknown harness '{}'", node.id, r.harness),
-                };
+        Some(r) => {
+            // #553: resolve against the embedded floor MERGED with the user's disk
+            // descriptor tier (`~/.pdo/harnesses/`), so a harness declared in data
+            // launches without a rebuild. The registry reads a root we hand it — it
+            // never touches `$HOME` itself.
+            let registry = harness_registry::HarnessRegistry::load(&spawn_home_root(&deps));
+            match registry.resolve(&r.harness) {
+                Some(d) => {
+                    // #553 / ADR-0031: a sandboxed Run whose node runs on a harness
+                    // with no staging floor holds only by the profile's image and
+                    // its `$HOME` exceptions — say it once, visibly (the plancher is
+                    // claude-specific and built per-Run regardless of the harness).
+                    if run_sandboxed {
+                        warn_missing_staging_floor_once(run_id, &r.harness);
+                    }
+                    Some(d)
+                }
+                None => {
+                    // Unknown harness — a spawn that cannot happen. Fail fast, naming it.
+                    return SpawnOutcome::Failed {
+                        reason: format!("node {}: unknown harness '{}'", node.id, r.harness),
+                    };
+                }
             }
-        },
+        }
     };
     if let Some(d) = &harness_descriptor {
         if deps.tmux_cmd_override.is_none() && !tmux_session_manager::binary_available(&d.binary) {

--- a/crates/pdo-daemon/src/run_cost.rs
+++ b/crates/pdo-daemon/src/run_cost.rs
@@ -172,7 +172,74 @@ fn aggregate(lines: impl Iterator<Item = Line>, prices: &PriceTable) -> CostStat
         usd,
         partial: !unpriced_models.is_empty(),
         unpriced_models,
+        // The aggregate is transcript-derived — i.e. it already ran because the
+        // Run's harness HAS a cost source. Absent-cost-source harnesses never reach
+        // this fold; they are handled one layer up in [`run_cost_or_absence`], which
+        // returns a "—"-with-reason `CostStat` before any transcript is read.
+        uncosted_harnesses: Vec::new(),
     }
+}
+
+/// The distinct harnesses this Run launched a node on that have **no cost source**
+/// capability (#553) — sorted, deduplicated. Read off the `NodeStarted` payloads
+/// (the frozen-at-spawn harness, ADR-0046), never the current YAML. A `null`
+/// harness (a `script` node, or any pre-#550 row) is the `claude` floor, which HAS
+/// a cost source, so it never lands here — only an explicit `opencode` or a
+/// data-declared harness does.
+pub(crate) fn uncosted_harnesses(events: &[crate::event_log::Event]) -> Vec<String> {
+    let mut names: BTreeSet<String> = BTreeSet::new();
+    for e in events {
+        if e.kind != crate::event_log::EventKind::NodeStarted {
+            continue;
+        }
+        let Some(harness) = e
+            .payload
+            .as_ref()
+            .and_then(|p| p.get("harness"))
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+        else {
+            continue; // null harness ⇒ the claude floor ⇒ has a cost source
+        };
+        if !crate::harness_probes::can_cost(harness) {
+            names.insert(harness.to_string());
+        }
+    }
+    names.into_iter().collect()
+}
+
+/// The Run's cost, made **honest about harnesses without a cost source** (#553).
+///
+/// If any node ran on a harness PDO cannot cost, the Run's aggregate is not
+/// honestly summable — adding `claude`'s real dollars to that harness's invisible
+/// $0 would be a silent under-count — so this returns `Some(CostStat)` carrying
+/// **`uncosted_harnesses`** and no dollars, which the surfaces render as "—" with a
+/// reason (never `$0`, never a mute `partial`). Otherwise it is exactly
+/// [`compute_run_cost`].
+///
+/// `events` is the Run's event-log snapshot (for the frozen harnesses); the rest
+/// is [`compute_run_cost`]'s signature verbatim.
+pub(crate) fn run_cost_or_absence(
+    events: &[crate::event_log::Event],
+    projects_root: &Path,
+    repo_root: &Path,
+    run_id: &str,
+    prices: &PriceTable,
+) -> Option<CostStat> {
+    let uncosted = uncosted_harnesses(events);
+    if !uncosted.is_empty() {
+        return Some(CostStat {
+            usd: 0.0,
+            // NOT `partial`: `partial` means "priced, but a lower bound" and still
+            // shows a dollar figure. This is a categorically different state — the
+            // aggregate is unavailable, not merely incomplete — so it stays out of
+            // the `partial ⟺ !unpriced_models.is_empty()` invariant (both empty).
+            partial: false,
+            unpriced_models: Vec::new(),
+            uncosted_harnesses: uncosted,
+        });
+    }
+    compute_run_cost(projects_root, repo_root, run_id, prices)
 }
 
 /// Encode an absolute path exactly as Claude Code names its `~/.claude/projects`
@@ -917,5 +984,83 @@ mod tests {
 
         // Querying "run-1" must NOT pick up "run-1x"'s transcript.
         assert!(compute_run_cost(&projects, repo.path(), "run-1", &builtin()).is_none());
+    }
+
+    // --- run_cost_or_absence / uncosted_harnesses (#553) ---
+    //
+    // The test that guarantees "absence is said": a Run on a harness with no cost
+    // source shows "—" and a reason, never `0`.
+
+    use crate::event_log::{Event, EventKind};
+
+    fn node_started(node: &str, harness: Option<&str>) -> Event {
+        Event {
+            id: None,
+            run_id: "r".into(),
+            ts: crate::event_log::now_iso(),
+            kind: EventKind::NodeStarted,
+            node_id: Some(node.into()),
+            iter: Some(1),
+            payload: Some(serde_json::json!({ "harness": harness })),
+        }
+    }
+
+    #[test]
+    fn uncosted_harnesses_names_only_the_harnesses_without_a_cost_source() {
+        let events = vec![
+            node_started("a", Some("claude")),   // has a cost source
+            node_started("b", Some("opencode")), // none
+            node_started("c", None),             // script/legacy ⇒ claude floor ⇒ costed
+            node_started("d", Some("opencode")), // duplicate ⇒ deduped
+        ];
+        assert_eq!(uncosted_harnesses(&events), vec!["opencode".to_string()]);
+    }
+
+    #[test]
+    fn run_cost_or_absence_is_dash_with_reason_not_zero_for_an_uncosted_harness() {
+        // A Run with an `opencode` node: no transcript need even be read — the
+        // aggregate is not honestly summable, so cost is "—" (usd 0, NOT partial)
+        // and names the harness.
+        let home = tempfile::tempdir().unwrap();
+        let projects = home.path().join(".claude").join("projects");
+        std::fs::create_dir_all(&projects).unwrap();
+        let repo = tempfile::tempdir().unwrap();
+        let events = vec![node_started("n", Some("opencode"))];
+
+        let cost = run_cost_or_absence(&events, &projects, repo.path(), "run-x", &builtin())
+            .expect("an uncosted harness yields Some(—), not a bare None");
+        assert_eq!(cost.usd, 0.0);
+        assert!(!cost.partial, "not a lower bound — it is unavailable");
+        assert!(cost.unpriced_models.is_empty());
+        // The offender is NAMED (the frontend builds the "— because opencode has no
+        // cost source" sentence from this, the same way it names `unpriced_models`).
+        assert_eq!(cost.uncosted_harnesses, vec!["opencode".to_string()]);
+    }
+
+    #[test]
+    fn run_cost_or_absence_is_plain_compute_run_cost_for_an_all_claude_run() {
+        // The negative control: a claude Run (and a script node) costs exactly as
+        // before — no `uncosted_harnesses`, real dollars.
+        let home = tempfile::tempdir().unwrap();
+        let projects = home.path().join(".claude").join("projects");
+        let repo = tempfile::tempdir().unwrap();
+        let run_id = "claude-run";
+        seed_transcript(
+            &projects,
+            repo.path(),
+            run_id,
+            &assistant("m1", "r1", "claude-opus-4-8", 1_000_000, 0),
+        );
+        let events = vec![node_started("n", Some("claude")), node_started("s", None)];
+
+        let honest =
+            run_cost_or_absence(&events, &projects, repo.path(), run_id, &builtin()).unwrap();
+        let plain = compute_run_cost(&projects, repo.path(), run_id, &builtin()).unwrap();
+        assert_eq!(
+            honest, plain,
+            "an all-claude Run is byte-identical to before"
+        );
+        assert!(honest.uncosted_harnesses.is_empty());
+        assert!((honest.usd - 5.0).abs() < 1e-9);
     }
 }

--- a/crates/pdo-daemon/src/stale_detector.rs
+++ b/crates/pdo-daemon/src/stale_detector.rs
@@ -178,6 +178,37 @@ pub enum Detection {
     Ok,
 }
 
+/// The two harness capabilities the sweep gates its probes on (#553, ADR-0045).
+///
+/// Absent ⇒ the probe **does not run**: no turn-end auto-completion on an invented
+/// heuristic (the substrate is claude's JSONL transcript), and no pane capture for
+/// a usage-limit menu whose wording is proper to another harness. The sweep
+/// ([`crate::lib`]) fills this from [`crate::harness_probes`] for the node's
+/// frozen-at-spawn harness; keeping it a plain two-bool struct here keeps
+/// [`assess_node`] pure and injected, exactly like `autocomplete_turn_end`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HarnessCapabilities {
+    /// The harness has an end-of-turn substrate PDO can read
+    /// ([`crate::harness_probes::HarnessProbes::turn_end_substrate`]).
+    pub turn_end: bool,
+    /// The harness has a usage-limit menu anchor PDO can match
+    /// ([`crate::harness_probes::HarnessProbes::usage_limit_anchor`]).
+    pub usage_limit: bool,
+}
+
+impl HarnessCapabilities {
+    /// Both present — `claude`, and the shape the pre-#553 sweep always assumed.
+    pub const CLAUDE: HarnessCapabilities = HarnessCapabilities {
+        turn_end: true,
+        usage_limit: true,
+    };
+    /// Both absent — a data-declared harness: neither probe runs.
+    pub const NONE: HarnessCapabilities = HarnessCapabilities {
+        turn_end: false,
+        usage_limit: false,
+    };
+}
+
 /// Pure liveness decision: session alive or not (#469 §1).
 ///
 /// This *is* the whole of it now. `session_alive == false` is the single
@@ -665,6 +696,9 @@ fn informational_event(
 ///
 /// `prior_events` is the run's event-log snapshot, used purely for the
 /// rising-edge de-dup of `NodeBlockedOnLimit` (see [`episode_has_event`]).
+// The probe set + policy toggles are all distinct facts a sweep tick needs; the
+// same posture as the four `tmux_session_manager` builders that allow this lint.
+#[allow(clippy::too_many_arguments)]
 pub fn assess_node(
     probes: &impl NodeProbes,
     prior_events: &[event_log::Event],
@@ -673,6 +707,7 @@ pub fn assess_node(
     iter: i64,
     now: SystemTime,
     autocomplete_turn_end: bool,
+    caps: HarnessCapabilities,
 ) -> Assessment {
     let detection = decide(probes.session_alive());
 
@@ -691,9 +726,14 @@ pub fn assess_node(
     // Alive, but maybe wedged on Claude Code's usage-limit menu (#290):
     // observability only — the node keeps running. The gauge counts every sweep
     // the menu is visible; the event is emitted once per (node, iter) episode.
-    let blocked_on_limit = probes
-        .capture_pane()
-        .is_some_and(|pane| detect_usage_limit(&pane));
+    //
+    // #553: the menu anchor is proper to a harness. Gate the probe on the
+    // capability — a harness without it never has its pane captured for a menu
+    // whose wording belongs to another harness (ANDed first, so no pane I/O runs).
+    let blocked_on_limit = caps.usage_limit
+        && probes
+            .capture_pane()
+            .is_some_and(|pane| detect_usage_limit(&pane));
     let events = if blocked_on_limit
         && !episode_has_event(prior_events, &EventKind::NodeBlockedOnLimit, node_id, iter)
     {
@@ -713,7 +753,13 @@ pub fn assess_node(
     // "<prompt>"` does not exit at the end of a turn — it stays in the REPL — so
     // an agent that finished without calling `pdo complete` is alive and
     // motionless, and this is its positive signature.
+    //
+    // #553: the turn-end substrate is a capability. Gate the probe on it — a
+    // harness without it is never auto-completed on an invented heuristic (its
+    // store is not the claude JSONL `parse_turn_state` reads). ANDed BEFORE the
+    // transcript read, so an un-instrumented harness pays no transcript I/O.
     let turn_ended = autocomplete_turn_end
+        && caps.turn_end
         && probes.transcript_tail().is_some_and(|tail| {
             quiet_long_enough(tail.mtime, now)
                 && parse_turn_state(&tail.text) == TurnState::TurnEnded
@@ -1669,6 +1715,9 @@ SwapFree:         204800 kB
     }
 
     fn assess(probes: &FakeProbes, autocomplete: bool) -> Assessment {
+        // The existing suite is about the `claude` sweep, which has both
+        // capabilities; #553's capability gating is exercised by the dedicated
+        // tests below with `HarnessCapabilities::NONE`.
         assess_node(
             probes,
             &[],
@@ -1677,6 +1726,7 @@ SwapFree:         204800 kB
             1,
             SystemTime::now(),
             autocomplete,
+            HarnessCapabilities::CLAUDE,
         )
     }
 
@@ -1884,6 +1934,7 @@ SwapFree:         204800 kB
             1,
             SystemTime::now(),
             true,
+            HarnessCapabilities::CLAUDE,
         );
         assert!(
             a.blocked_on_limit,
@@ -1908,5 +1959,70 @@ SwapFree:         204800 kB
         assert!(a.blocked_on_limit);
         assert_eq!(a.events.len(), 1);
         assert_eq!(a.events[0].kind, EventKind::NodeBlockedOnLimit);
+    }
+
+    // --- #553: capability gating — a data-declared harness runs no probe ---
+
+    fn assess_caps(
+        probes: &FakeProbes,
+        autocomplete: bool,
+        caps: HarnessCapabilities,
+    ) -> Assessment {
+        assess_node(
+            probes,
+            &[],
+            "run1",
+            "worker",
+            1,
+            SystemTime::now(),
+            autocomplete,
+            caps,
+        )
+    }
+
+    #[test]
+    fn a_harness_without_the_turn_end_capability_is_never_auto_completed() {
+        // The node HAS finished its turn with valid outputs and the setting is ON —
+        // but its harness has no turn-end substrate, so the sweep must not complete
+        // it, and must not even read a transcript (the substrate is not claude's).
+        let probes = FakeProbes::finished_turn();
+        let a = assess_caps(&probes, true, HarnessCapabilities::NONE);
+        assert_eq!(
+            a.detection,
+            Detection::Ok,
+            "no auto-completion without the capability"
+        );
+        assert_eq!(
+            probes.tail_calls.get(),
+            0,
+            "no transcript read for an un-instrumented harness"
+        );
+        assert_eq!(probes.validate_calls.get(), 0);
+    }
+
+    #[test]
+    fn a_harness_with_the_turn_end_capability_still_auto_completes() {
+        // The control: with the capability present (and the setting on) the same
+        // finished turn IS completed — the gate is the capability, nothing else.
+        let probes = FakeProbes::finished_turn();
+        let a = assess_caps(&probes, true, HarnessCapabilities::CLAUDE);
+        assert_eq!(a.detection, Detection::TurnEnded);
+    }
+
+    #[test]
+    fn a_harness_without_the_usage_limit_capability_is_never_flagged_blocked() {
+        // The pane shows what WOULD be a usage-limit menu, but this harness has no
+        // such anchor — so the probe short-circuits and the node is not flagged.
+        let probes = FakeProbes {
+            pane: Some("❯ 1. Stop and wait for limit to reset".to_string()),
+            ..FakeProbes::alive()
+        };
+        let a = assess_caps(&probes, true, HarnessCapabilities::NONE);
+        assert_eq!(a.detection, Detection::Ok);
+        assert!(
+            !a.blocked_on_limit,
+            "no menu probe runs without the usage-limit capability"
+        );
+        assert!(a.events.is_empty());
     }
 }

--- a/crates/pdo-daemon/src/stats.rs
+++ b/crates/pdo-daemon/src/stats.rs
@@ -776,6 +776,7 @@ mod tests {
                     usd: 1.0,
                     partial: false,
                     unpriced_models: vec![],
+                    uncosted_harnesses: vec![],
                 }),
             },
             CostRow {
@@ -786,6 +787,7 @@ mod tests {
                     usd: 2.0,
                     partial: true,
                     unpriced_models: vec!["claude-sonnet-5".into()],
+                    uncosted_harnesses: vec![],
                 }),
             },
             CostRow {
@@ -861,6 +863,7 @@ mod tests {
                     usd: 0.0,
                     partial: true,
                     unpriced_models: vec!["claude-sonnet-5".into(), "claude-fable-5".into()],
+                    uncosted_harnesses: vec![],
                 }),
             },
             CostRow {
@@ -871,6 +874,7 @@ mod tests {
                     usd: 0.0,
                     partial: true,
                     unpriced_models: vec!["claude-fable-5".into(), "claude-opus-5".into()],
+                    uncosted_harnesses: vec![],
                 }),
             },
         ];

--- a/frontend/src/components/PipelineInfoPanel.stats.test.tsx
+++ b/frontend/src/components/PipelineInfoPanel.stats.test.tsx
@@ -203,4 +203,26 @@ describe("PipelineInfoPanel — Stats block (#100)", () => {
     expect(cost).toHaveTextContent("—");
     expect(cost).not.toHaveTextContent("$");
   });
+
+  it("renders '—' with a reason (never $0, no dagger) when a harness has no cost source (#553)", () => {
+    // A Run with an opencode node: cost is present but not summable → "—" naming
+    // the harness in the tooltip, never a misleading $0.
+    renderPanel(
+      makeRun({
+        cost: {
+          usd: 0,
+          partial: false,
+          unpriced_models: [],
+          uncosted_harnesses: ["opencode"],
+        },
+      }),
+    );
+    const cost = screen.getByTestId("stat-cost");
+    expect(cost).toHaveTextContent("—");
+    expect(cost).not.toHaveTextContent("$");
+    expect(cost).not.toHaveTextContent("†");
+    const title = cost.querySelector("[title]")?.getAttribute("title") ?? "";
+    expect(title).toMatch(/cost unavailable/i);
+    expect(title).toContain("opencode");
+  });
 });

--- a/frontend/src/components/PipelineInfoPanel.tsx
+++ b/frontend/src/components/PipelineInfoPanel.tsx
@@ -300,6 +300,9 @@ function InfoTab({
                     run.cost.usd,
                     run.cost.partial,
                     run.cost.unpriced_models,
+                    // #553: "—" + reason when a node ran on a harness with no cost
+                    // source (e.g. opencode) — never a misleading $0.
+                    run.cost.uncosted_harnesses ?? [],
                   );
                   return (
                     <span className="flex items-center gap-1" title={c.title}>

--- a/frontend/src/components/SettingsModal.test.tsx
+++ b/frontend/src/components/SettingsModal.test.tsx
@@ -88,6 +88,14 @@ function sample(overrides: Partial<InstanceSettings> = {}): InstanceSettings {
       manual_keys: [],
       reason: null,
     },
+    // Harness descriptors (#553): the default clean state — only the built-in
+    // floor resolves, nothing inert. The path is reported all the same.
+    harness_descriptors: {
+      path: "/home/user/.pdo/harnesses/descriptors.yaml",
+      names: ["claude", "opencode"],
+      rejected: [],
+      reason: null,
+    },
     updated_at: "2026-07-01T10:00:00.000Z",
     ...overrides,
   };
@@ -294,6 +302,49 @@ describe("SettingsModal", () => {
     // And what the manual tier shadows is visible.
     expect(screen.getByTestId("setting-price-table-manual-path")).toHaveTextContent(
       "claude-opus-4-8",
+    );
+  });
+
+  it("lists the resolved harnesses and stays silent when no descriptor is inert (#553)", async () => {
+    fetchSettingsMock.mockResolvedValue(sample());
+    render(<SettingsModal open onClose={() => {}} />);
+    const names = await screen.findByTestId("setting-harness-descriptors-names");
+    // A declared harness "appears" here (floor ∪ disk); the clean fixture shows the floor.
+    expect(names).toHaveTextContent("claude");
+    expect(names).toHaveTextContent("opencode");
+    expect(screen.getByTestId("setting-harness-descriptors-path")).toHaveTextContent(
+      "/home/user/.pdo/harnesses/descriptors.yaml",
+    );
+    // Absent is SILENT: no advisory when nothing is wrong.
+    expect(
+      screen.queryByTestId("setting-harness-descriptors-reason"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("surfaces the daemon's reason and merged names when a descriptor went inert (#553)", async () => {
+    // Corrupting the file makes it inert and diagnosed; the built-in floor keeps
+    // resolving — the only honest place to say so, since a descriptor passes
+    // through no validator (ADR-0001).
+    fetchSettingsMock.mockResolvedValue(
+      sample({
+        harness_descriptors: {
+          path: "/home/user/.pdo/harnesses/descriptors.yaml",
+          names: ["claude", "opencode"],
+          rejected: [
+            { name: "claude", why: "missing `binary`" },
+          ],
+          reason:
+            "harness descriptors (#553) — harness descriptor tier (/home/user/.pdo/harnesses/descriptors.yaml) refused 1 descriptor(s), each key falling through to the next tier: `claude` (missing `binary`)",
+        },
+      }),
+    );
+    render(<SettingsModal open onClose={() => {}} />);
+    const reason = await screen.findByTestId("setting-harness-descriptors-reason");
+    expect(reason).toHaveTextContent("claude");
+    expect(reason).toHaveTextContent(/falling through/);
+    // …and the floor still resolves alongside the diagnostic.
+    expect(screen.getByTestId("setting-harness-descriptors-names")).toHaveTextContent(
+      "opencode",
     );
   });
 

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -755,6 +755,52 @@ function SettingsForm({
           </div>
         )}
 
+        {/* #553/ADR-0045: the harness descriptor disk tier — declare a harness PDO
+            does not ship by writing this file; it merges over the built-in floor by
+            name. Same posture as the price table above: the path is always shown
+            (nothing is seeded), and a broken/refused descriptor is named here (the
+            only place, since a hand-edited descriptor passes through no validator).
+            Guarded so a daemon predating #553 renders nothing. */}
+        {settings.harness_descriptors && (
+          <div className="flex flex-col gap-1.5" data-testid="setting-harness-descriptors">
+            <label className="font-medium text-fg-2" style={{ fontSize: "11.5px" }}>
+              Harness descriptors
+            </label>
+            <div className="text-fg-4" style={{ fontSize: "10.5px" }}>
+              Declare a harness PDO does not ship by writing this file; it merges over
+              the built-in <span className="font-mono">claude</span> /{" "}
+              <span className="font-mono">opencode</span> by name. Nothing is ever
+              seeded — the built-in harnesses are the floor.
+            </div>
+            <div
+              className="text-fg-3"
+              style={{ fontSize: "10.5px" }}
+              data-testid="setting-harness-descriptors-path"
+            >
+              File:{" "}
+              <span className="font-mono">
+                {settings.harness_descriptors.path ?? "— (HOME unset)"}
+              </span>
+            </div>
+            <div
+              className="text-fg-3"
+              style={{ fontSize: "10.5px" }}
+              data-testid="setting-harness-descriptors-names"
+            >
+              Harnesses: {settings.harness_descriptors.names.join(", ")}
+            </div>
+            {settings.harness_descriptors.reason && (
+              <div
+                className="text-st-failed"
+                style={{ fontSize: "10.5px" }}
+                data-testid="setting-harness-descriptors-reason"
+              >
+                {settings.harness_descriptors.reason}
+              </div>
+            )}
+          </div>
+        )}
+
         {error && (
           <div
             className="rounded-md border border-st-failed/30 bg-st-failed-bg px-3 py-2 text-st-failed"

--- a/frontend/src/lib/costLabel.test.ts
+++ b/frontend/src/lib/costLabel.test.ts
@@ -51,6 +51,30 @@ describe("formatEstCost (single run, #272)", () => {
     const c = formatEstCost(2.5, true, []);
     expect(c.title).toMatch(/an unpriced model was excluded/);
   });
+
+  it("renders — (never $0, no dagger) and names the harness for an uncosted harness (#553)", () => {
+    // A Run with a node on a harness with no cost source: "—" with a reason
+    // naming the harness — categorically different from a lower bound.
+    const c = formatEstCost(0, false, [], ["opencode"]);
+    expect(c.text).toBe("—");
+    expect(c.text).not.toContain("$");
+    expect(c.dagger).toBe(false);
+    expect(c.title).toMatch(/cost unavailable/i);
+    expect(c.title).toContain("opencode");
+    expect(c.title).toMatch(/no cost source/);
+  });
+
+  it("takes the uncosted branch even when partial/priced data is present (#553)", () => {
+    // "Unavailable" is a stronger statement than "lower bound": it wins.
+    const c = formatEstCost(4.2, true, ["claude-fable-5"], ["opencode", "codex"]);
+    expect(c.text).toBe("—");
+    expect(c.dagger).toBe(false);
+    expect(c.title).toContain("opencode");
+    expect(c.title).toContain("codex");
+    expect(c.title).toMatch(/harnesses .* have no cost source/);
+    // Not framed as a lower bound — there is no figure at all.
+    expect(c.title).not.toContain("claude-fable-5");
+  });
 });
 
 describe("formatBucketCost (aggregate, #377)", () => {

--- a/frontend/src/lib/costLabel.ts
+++ b/frontend/src/lib/costLabel.ts
@@ -37,6 +37,21 @@ function lowerBoundClause(unpricedModels: string[], runSuffix = ""): string {
   return body + runSuffix;
 }
 
+/**
+ * The clause for a Run whose cost is **unavailable** because one or more harnesses
+ * has no cost source (#553, ADR-0045). Names the harness(es) — the same "name what
+ * is missing" discipline as {@link lowerBoundClause} for unpriced models — so the
+ * user never reads an anonymous blank, and never a `$0` standing in for "unknown".
+ * A categorically different state from a lower bound: there is no figure at all.
+ */
+export function uncostedClause(uncostedHarnesses: string[]): string {
+  return ` Cost unavailable: ${
+    uncostedHarnesses.length === 1 ? "harness" : "harnesses"
+  } ${uncostedHarnesses.join(", ")} ${
+    uncostedHarnesses.length === 1 ? "has" : "have"
+  } no cost source, so this Run's cost cannot be estimated.`;
+}
+
 export interface CostLabel {
   /** Display text, e.g. `~$1.2345`. */
   text: string;
@@ -55,7 +70,20 @@ export function formatEstCost(
   usd: number,
   partial: boolean,
   unpricedModels: string[] = [],
+  uncostedHarnesses: string[] = [],
 ): CostLabel {
+  // #553: a harness with no cost source makes the Run's cost not honestly
+  // summable — show "—" with a reason naming the harness, never a $ figure and
+  // never a mute dagger (that would read as "priced, lower bound", which this is
+  // not). This branch takes precedence over `partial`, since "unavailable" is a
+  // stronger statement than "incomplete".
+  if (uncostedHarnesses.length > 0) {
+    return {
+      text: "—",
+      dagger: false,
+      title: COST_ESTIMATE_NOTE + uncostedClause(uncostedHarnesses),
+    };
+  }
   return {
     text: `~$${usd.toFixed(costPrecision(usd))}`,
     dagger: partial,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -318,7 +318,33 @@ export interface InstanceSettings {
    * honest place to surface it (the #432 argument).
    */
   price_table: PriceTableView;
+  /**
+   * The harness descriptor disk tier (#553, ADR-0045) — an observed STATE, like
+   * `price_table`. `names` lists the harnesses that actually resolve (embedded
+   * floor merged with the user's disk file), so a declared harness "appears";
+   * `path` is always reported (nothing is seeded) so the user knows where to
+   * write; `reason` is the same string the daemon logs, non-null exactly when a
+   * descriptor went inert or was refused — the only honest place to say so, since
+   * a hand-edited descriptor passes through no validator (ADR-0001).
+   *
+   * Optional in the type (the SettingsModal guards on it) so a UI built against a
+   * daemon that predates #553 still typechecks — same defensive posture the modal
+   * takes for `price_table`. In production the SPA is embedded, so they agree.
+   */
+  harness_descriptors?: HarnessDescriptorsView;
   updated_at: string;
+}
+
+/** `GET /settings` → `harness_descriptors` (#553). */
+export interface HarnessDescriptorsView {
+  /** `~/.pdo/harnesses/descriptors.yaml`. `null` only when `HOME` is unset. */
+  path: string | null;
+  /** The harnesses the registry resolves (floor ∪ disk), in resolution order. */
+  names: string[];
+  /** Descriptors the disk tier refused — each inert, its key on the floor. */
+  rejected: { name: string; why: string }[];
+  /** Advisory: an inert file or refused descriptor, named. `null` when all is well. */
+  reason: string | null;
 }
 
 /** `GET /settings` → `price_table` (#427). */
@@ -723,11 +749,18 @@ export interface RunState {
    * lower bound; `unpriced_models` names which family keys were excluded (#425),
    * so the UI can say *which* model rather than an anonymous "an unpriced model".
    * Invariant: `partial ⟺ unpriced_models.length > 0`.
+   *
+   * `uncosted_harnesses` (#553): the harnesses a node ran on that have **no cost
+   * source** (e.g. `opencode`). Non-empty ⇒ the Run's cost is not honestly
+   * summable, so the UI shows "—" with a reason naming them, never a `$0` and
+   * never a mute lower-bound — a categorically different state from `partial`
+   * (which still shows a figure). Empty on every all-`claude` Run.
    */
   cost?: {
     usd: number;
     partial: boolean;
     unpriced_models: string[];
+    uncosted_harnesses?: string[];
   } | null;
 }
 


### PR DESCRIPTION
Slice #553 du PRD #549 (harnais agentique, ADR-0045). Tout ce que PDO sait faire au-delà de lancer un harnais est une capacité écrite harnais par harnais, dispatchée derrière une factory dont l'absence est *lisible* (jamais suppléée, jamais silencieuse). Plus le tier disque des descripteurs (`~/.pdo/harnesses/descriptors.yaml`) : déclarer un harnais que PDO ne connaît pas, sans recompiler.

## Contenu
- `harness_probes` (factory) : un trait dont les cinq méthodes ont un défaut « absent » ; `ClaudeProbes` surcharge les cinq à l'identique (refactor de dispatch) ; `probes_for` rend `Option<&'static dyn …>`, donc un harnais déclaré en donnée obtient `None` sur les cinq, gratuitement.
- Coût honnête : un Run dont un nœud tourne sur un harnais sans source de coût affiche « — » + une raison nommant le harnais (`uncosted_harnesses`), jamais $0, jamais un partial muet (même veine que `unpriced_models`, #425).
- Sondes stale gatées : fin de tour et menu de limite ne tournent pas sur un harnais sans la capacité.
- Sandbox : un Run sandboxé sur un harnais sans plancher de staging le dit une fois (warn dédupliqué au spawn).
- Tier disque `harness_registry` : fusion par nom sur le plancher, jamais seedé, ne lit jamais `$HOME` ; un descripteur illisible est inerte + diagnostiqué (sa clé retombe sur le tier suivant). Résolu au spawn et au resume, surfacé dans `GET /settings`.

## Validation
Verdict **Pass** du nœud de validation : build propre, matrice de tests verte (`cargo test -p pdo-daemon --lib` 1938 ✓, `harness_freeze_resume` 2 ✓, fmt/clippy clean, eslint clean, vitest 1757 ✓), et les quatre Feature-Path drivés dans l'UI réelle.

## Notes d'intégration
- Base = `integration/549-multi-harnais` (**jamais** `main` ; la PR intégration → main est #554).
- **Pas de bump de version** : #551 / #552 / #553 atterrissent en parallèle sur cette branche ; un seul bump coordonné par la session d'orchestration quand les trois sont là.
- Conflits attendus avec #551 (déjà mergé) sur `lib.rs`, `node_spawn.rs`, `types.ts` — la résolution correcte **garde les deux côtés** (chaque slice remplit un champ différent du littéral `HarnessTiers`).

Closes #553

🤖 Generated with [Claude Code](https://claude.com/claude-code)
