### PR TITLE
feat(#552): le Projet est une entité nommée de dépôts et le tier du milieu du harnais

### DIFF
--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -40,6 +40,7 @@ mod pipeline_migrator;
 mod pipeline_semantics;
 mod pipeline_watcher;
 mod price_table;
+mod project_store;
 mod prompt_augmenter;
 mod pty_bridge;
 mod reap_policy;
@@ -567,6 +568,34 @@ struct TriggerListEntry {
     #[serde(flatten)]
     trigger: trigger_store::Trigger,
     effective_repo: String,
+}
+
+/// Body of `POST /projects` — materialise a Projet from a bare name (#552). The
+/// only path that creates a `projects` row from a name; membership and the
+/// harness are attached afterwards, so a Projet begins empty and harness-less.
+#[derive(Deserialize)]
+struct CreateProjectRequest {
+    name: String,
+}
+
+/// Body of `PATCH /projects/{id}` — rename the Projet and/or (re)set the harness
+/// it carries (#552). `harness` is a double-`Option` (mirror of
+/// `UpdateTrigger.sandbox`): **absent** leaves it untouched, `null` clears it,
+/// a string sets it. An empty string clears it too (the `Some("")` trap of #347).
+#[derive(Deserialize)]
+struct PatchProjectRequest {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_double_option")]
+    harness: Option<Option<String>>,
+}
+
+/// Body of `POST` / `DELETE /projects/{id}/members` — one member path, compared
+/// **verbatim** (ADR-0033). The attach enforces at-most-one membership before any
+/// write; a path owned by another Projet is a 409 naming the owner (#552).
+#[derive(Deserialize)]
+struct ProjectMemberRequest {
+    path: String,
 }
 
 #[derive(Serialize)]
@@ -4055,6 +4084,21 @@ fn build_router(state: Arc<AppState>) -> Router {
         // dev-mode GET hits the daemon instead of the SPA fallback (same trap as
         // `/nodes` #345, `/stats` #377, `/fs` #431).
         .route("/audit", get(get_audit))
+        // Projets (#552, ADR-0046) — the group-header pencil's CRUD and the middle
+        // tier of the harness axis. NEW top-level `/projects` prefix → added to the
+        // vite dev proxy whitelist (frontend/vite.config.ts) so a dev-mode GET hits
+        // the daemon, not the SPA fallback (same trap as `/audit` #507). The
+        // members sub-resource is a static segment under the param — axum 0.8
+        // allows it (cf. `/triggers/{id}/fires`).
+        .route("/projects", get(list_projects).post(create_project))
+        .route(
+            "/projects/{project_id}",
+            get(get_project).patch(patch_project).delete(delete_project),
+        )
+        .route(
+            "/projects/{project_id}/members",
+            post(add_project_member).delete(remove_project_member),
+        )
         .route(
             "/triggers/{trigger_id}",
             get(get_trigger).patch(patch_trigger).delete(delete_trigger),
@@ -4065,6 +4109,245 @@ fn build_router(state: Arc<AppState>) -> Router {
         .route("/triggers/{trigger_id}/fire", post(fire_trigger_now))
         .fallback(static_handler)
         .with_state(state)
+}
+
+// --- Projets (#552, ADR-0046) ---
+//
+// A Projet is the middle tier of the harness axis and a named grouping of member
+// repo paths. Nothing is seeded: a row exists only once a human names a group or
+// attaches a setting (ADR-0046). The lists group by Projet client-side; these
+// endpoints are the CRUD behind the group-header pencil. `/projects` is a NEW
+// top-level prefix → it has its own entry in the vite dev proxy whitelist
+// (`frontend/vite.config.ts`), same trap as `/nodes` (#345) / `/stats` (#377) /
+// `/audit` (#507).
+
+fn project_list_error() -> Response {
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(serde_json::json!({ "error": "project store unavailable" })),
+    )
+        .into_response()
+}
+
+async fn list_projects(State(state): State<Arc<AppState>>) -> Response {
+    match project_store::list(&state.db).await {
+        Ok(projects) => Json(projects).into_response(),
+        Err(e) => {
+            error!("failed to list projects: {e}");
+            project_list_error()
+        }
+    }
+}
+
+async fn get_project(
+    State(state): State<Arc<AppState>>,
+    AxumPath(project_id): AxumPath<String>,
+) -> Response {
+    match project_store::get(&state.db, &project_id).await {
+        Ok(Some(p)) => Json(p).into_response(),
+        Ok(None) => (StatusCode::NOT_FOUND, "no such project").into_response(),
+        Err(e) => {
+            error!("failed to load project {project_id}: {e}");
+            project_list_error()
+        }
+    }
+}
+
+async fn create_project(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<CreateProjectRequest>,
+) -> Response {
+    let name = req.name.trim();
+    if name.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": "project name is required" })),
+        )
+            .into_response();
+    }
+    match project_store::create(&state.db, name).await {
+        Ok(project) => {
+            let _ = state.pipeline_tx.send(serde_json::json!({
+                "type": "project_changed",
+                "project_id": project.id,
+            }));
+            (StatusCode::CREATED, Json(project)).into_response()
+        }
+        Err(e) => {
+            error!("failed to create project: {e}");
+            project_list_error()
+        }
+    }
+}
+
+async fn patch_project(
+    State(state): State<Arc<AppState>>,
+    AxumPath(project_id): AxumPath<String>,
+    Json(req): Json<PatchProjectRequest>,
+) -> Response {
+    // The Projet must exist first — a PATCH never materialises one (only the
+    // pencil's create does, via POST /projects).
+    match project_store::get(&state.db, &project_id).await {
+        Ok(Some(_)) => {}
+        Ok(None) => return (StatusCode::NOT_FOUND, "no such project").into_response(),
+        Err(e) => {
+            error!("failed to load project {project_id}: {e}");
+            return project_list_error();
+        }
+    }
+    if let Some(name) = req.name.as_deref() {
+        let name = name.trim();
+        if name.is_empty() {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({ "error": "project name cannot be blank" })),
+            )
+                .into_response();
+        }
+        if let Err(e) = project_store::rename(&state.db, &project_id, name).await {
+            error!("failed to rename project {project_id}: {e}");
+            return project_list_error();
+        }
+    }
+    // Double-`Option`: `Some(_)` means the field was present. `Some(None)` and
+    // `Some(Some(""))` both clear; `Some(Some(h))` sets. `set_harness` normalises
+    // the empty string to NULL itself (#347).
+    if let Some(harness) = req.harness {
+        let harness = harness.as_deref();
+        if let Err(e) = project_store::set_harness(&state.db, &project_id, harness).await {
+            error!("failed to set harness on project {project_id}: {e}");
+            return project_list_error();
+        }
+    }
+    match project_store::get(&state.db, &project_id).await {
+        Ok(Some(p)) => {
+            let _ = state.pipeline_tx.send(serde_json::json!({
+                "type": "project_changed",
+                "project_id": project_id,
+            }));
+            Json(p).into_response()
+        }
+        Ok(None) => (StatusCode::NOT_FOUND, "no such project").into_response(),
+        Err(e) => {
+            error!("failed to reload project {project_id}: {e}");
+            project_list_error()
+        }
+    }
+}
+
+async fn delete_project(
+    State(state): State<Arc<AppState>>,
+    AxumPath(project_id): AxumPath<String>,
+) -> Response {
+    match project_store::delete(&state.db, &project_id).await {
+        Ok(true) => {
+            let _ = state.pipeline_tx.send(serde_json::json!({
+                "type": "project_changed",
+                "project_id": project_id,
+            }));
+            StatusCode::NO_CONTENT.into_response()
+        }
+        Ok(false) => (StatusCode::NOT_FOUND, "no such project").into_response(),
+        Err(e) => {
+            error!("failed to delete project {project_id}: {e}");
+            project_list_error()
+        }
+    }
+}
+
+async fn add_project_member(
+    State(state): State<Arc<AppState>>,
+    AxumPath(project_id): AxumPath<String>,
+    Json(req): Json<ProjectMemberRequest>,
+) -> Response {
+    let path = req.path.trim();
+    if path.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": "member path is required" })),
+        )
+            .into_response();
+    }
+    // The target Projet must exist (materialised by the pencil's create).
+    match project_store::get(&state.db, &project_id).await {
+        Ok(Some(_)) => {}
+        Ok(None) => return (StatusCode::NOT_FOUND, "no such project").into_response(),
+        Err(e) => {
+            error!("failed to load project {project_id}: {e}");
+            return project_list_error();
+        }
+    }
+    match project_store::add_member(&state.db, &project_id, path).await {
+        Ok(project_store::AddMember::Added) | Ok(project_store::AddMember::AlreadyMember) => {
+            let _ = state.pipeline_tx.send(serde_json::json!({
+                "type": "project_changed",
+                "project_id": project_id,
+            }));
+            match project_store::get(&state.db, &project_id).await {
+                Ok(Some(p)) => Json(p).into_response(),
+                _ => StatusCode::NO_CONTENT.into_response(),
+            }
+        }
+        // AC: a path already owned by another Projet is refused BEFORE any effect,
+        // and the refusal NAMES the owner (409, so the pencil can say which one).
+        Ok(project_store::AddMember::Refused {
+            owner_id,
+            owner_name,
+        }) => (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({
+                "error": format!("path already belongs to project '{owner_name}'"),
+                "owner_id": owner_id,
+                "owner_name": owner_name,
+            })),
+        )
+            .into_response(),
+        Err(e) => {
+            error!("failed to add member to project {project_id}: {e}");
+            project_list_error()
+        }
+    }
+}
+
+async fn remove_project_member(
+    State(state): State<Arc<AppState>>,
+    AxumPath(project_id): AxumPath<String>,
+    Json(req): Json<ProjectMemberRequest>,
+) -> Response {
+    let path = req.path.trim();
+    // Scope the detach to the named Projet: a path owned by a *different* Projet
+    // is left alone (idempotent no-op), so a stale client can't strip another
+    // Projet's member.
+    match project_store::owner_of(&state.db, path).await {
+        Ok(Some(owner)) if owner.id == project_id => {}
+        Ok(_) => {
+            // Not a member of this Projet (or of any) — nothing to do.
+            return match project_store::get(&state.db, &project_id).await {
+                Ok(Some(p)) => Json(p).into_response(),
+                Ok(None) => (StatusCode::NOT_FOUND, "no such project").into_response(),
+                Err(e) => {
+                    error!("failed to load project {project_id}: {e}");
+                    project_list_error()
+                }
+            };
+        }
+        Err(e) => {
+            error!("failed to resolve owner of {path}: {e}");
+            return project_list_error();
+        }
+    }
+    if let Err(e) = project_store::remove_member(&state.db, path).await {
+        error!("failed to remove member from project {project_id}: {e}");
+        return project_list_error();
+    }
+    let _ = state.pipeline_tx.send(serde_json::json!({
+        "type": "project_changed",
+        "project_id": project_id,
+    }));
+    match project_store::get(&state.db, &project_id).await {
+        Ok(Some(p)) => Json(p).into_response(),
+        _ => StatusCode::NO_CONTENT.into_response(),
+    }
 }
 
 async fn init_db(db: &sqlx::SqlitePool) -> Result<()> {
@@ -4126,6 +4409,13 @@ async fn init_db(db: &sqlx::SqlitePool) -> Result<()> {
     audit_log::init(db)
         .await
         .context("failed to create audit_log table")?;
+
+    // #552 / ADR-0046: Projets — the middle tier of the harness axis. Brand-new
+    // tables, materialised on demand (nothing seeded), same `CREATE TABLE IF NOT
+    // EXISTS` idiom as `sandbox_profiles` / `audit_log`.
+    project_store::init(db)
+        .await
+        .context("failed to create project tables")?;
 
     Ok(())
 }
@@ -12345,6 +12635,14 @@ async fn force_spawn_node(state: &Arc<AppState>, run_id: &str, node_id: &str) ->
         // #550/ADR-0046: same fresh-resolution discipline for the harness axis.
         default_harness: stored_default_harness(&state.db).await,
         default_harness_models: stored_default_harness_models(&state.db).await,
+        // #552/ADR-0046: the Projet tier — the harness carried by the Projet that
+        // owns this Run's primary (effective) repo. Resolved fresh here so a manual
+        // force-spawn honours a Projet setting attached mid-Run, like the model /
+        // harness defaults above. A DB error degrades to a transparent tier.
+        project_harness: project_store::harness_for_path(&state.db, &repo_root.to_string_lossy())
+            .await
+            .ok()
+            .flatten(),
         // #433 / ADR-0043: same reasoning as `default_model` — resolve turn-end
         // auto-completion fresh so a force-spawned node arms the `Stop` hook when
         // the setting is on, instead of silently missing it on this seam alone.
@@ -12621,6 +12919,12 @@ async fn node_retry(
         // #550/ADR-0046: retry resolves the harness axis fresh, like model.
         default_harness: stored_default_harness(&state.db).await,
         default_harness_models: stored_default_harness_models(&state.db).await,
+        // #552/ADR-0046: retry resolves the Projet tier fresh too, from the Run's
+        // primary (effective) repo — a secondary never sways it (ADR-0042).
+        project_harness: project_store::harness_for_path(&state.db, &repo_root.to_string_lossy())
+            .await
+            .ok()
+            .flatten(),
         // #433 / ADR-0043: retry re-arms the `Stop` hook per the current setting,
         // like the live scheduler path — not the value at the original spawn.
         inject_hook: stored_autocomplete_turn_end(&state.db).await,

--- a/crates/pdo-daemon/src/node_primitives.rs
+++ b/crates/pdo-daemon/src/node_primitives.rs
@@ -57,6 +57,15 @@ pub(crate) struct StartNodeParams<'a> {
     /// Instance per-harness default model map, resolved fresh by the caller (#550).
     /// Feeds the fallback tier of the model resolution for the winning harness.
     pub default_harness_models: std::collections::BTreeMap<String, String>,
+    /// The harness carried by the **Projet** of this Run's primary repo, resolved
+    /// by the caller (#552, ADR-0046). Same DB-less contract as
+    /// [`Self::default_harness`]: `start_node` is sync, so the async caller looks
+    /// up `project_store::harness_for_path` on the Run's effective repo and passes
+    /// the result in. Feeds the `project` tier of [`harness_resolver`], between the
+    /// Run and the instance default. `None` ⇒ the primary is in no Projet (or its
+    /// Projet carries no harness), so the tier is transparent. Resolved from the
+    /// **primary** repo only, so a secondary (ADR-0042) never sways it.
+    pub project_harness: Option<String>,
     /// Turn-end auto-completion, already resolved `stored → env → default` by the
     /// caller (#433, ADR-0043). Same DB-less contract as [`Self::default_model`]:
     /// the async caller reads [`crate::stored_autocomplete_turn_end`] and passes
@@ -393,7 +402,10 @@ pub(crate) fn start_node(params: &StartNodeParams<'_>) -> StartNodeResult {
             // from the projected state the caller already holds. A pinned node ignores
             // it; a free node follows it (ADR-0046). Mirrors `node_spawn`.
             run: params.run_state.harness.as_deref(),
-            project: None, // #552
+            // #552: the Projet of the Run's primary repo, resolved DB-lessly by
+            // the caller (an empty string never wins a tier — the `Some("")` trap
+            // of #347).
+            project: params.project_harness.as_deref().filter(|s| !s.is_empty()),
             instance_default: params.default_harness.as_deref(),
         };
         Some(harness_resolver::resolve(
@@ -1013,6 +1025,7 @@ mod tests {
             default_model: None,
             default_harness: None,
             default_harness_models: Default::default(),
+            project_harness: None,
             inject_hook: false,
         };
 
@@ -1055,6 +1068,7 @@ mod tests {
             default_model: None,
             default_harness: None,
             default_harness_models: Default::default(),
+            project_harness: None,
             inject_hook: false,
         };
 
@@ -1103,6 +1117,7 @@ mod tests {
             default_model: None,
             default_harness: None,
             default_harness_models: Default::default(),
+            project_harness: None,
             inject_hook: true,
         };
         let result = start_node(&params);
@@ -1156,6 +1171,7 @@ mod tests {
             default_model: None,
             default_harness: None,
             default_harness_models: Default::default(),
+            project_harness: None,
             inject_hook: true,
         };
         let result = start_node(&params);
@@ -1221,6 +1237,7 @@ mod tests {
             default_model: None,
             default_harness: None,
             default_harness_models: Default::default(),
+            project_harness: None,
             inject_hook: false,
         };
 
@@ -1282,6 +1299,7 @@ mod tests {
             default_model: None,
             default_harness: None,
             default_harness_models: Default::default(),
+            project_harness: None,
             inject_hook: false,
         };
 
@@ -1329,6 +1347,7 @@ mod tests {
             default_model: None,
             default_harness: None,
             default_harness_models: Default::default(),
+            project_harness: None,
             inject_hook: false,
         };
 
@@ -1400,6 +1419,7 @@ mod tests {
             default_model: None,
             default_harness: None,
             default_harness_models: Default::default(),
+            project_harness: None,
             inject_hook: false,
         };
 
@@ -1494,6 +1514,7 @@ mod tests {
             default_model: None,
             default_harness: None,
             default_harness_models: Default::default(),
+            project_harness: None,
             inject_hook: false,
         };
 
@@ -1561,6 +1582,7 @@ mod tests {
             default_model: None,
             default_harness: None,
             default_harness_models: Default::default(),
+            project_harness: None,
             inject_hook: false,
         };
 
@@ -1628,6 +1650,7 @@ mod tests {
             default_model: None,
             default_harness: None,
             default_harness_models: Default::default(),
+            project_harness: None,
             inject_hook: false,
         };
 
@@ -1891,6 +1914,7 @@ mod tests {
             default_model: None,
             default_harness: None,
             default_harness_models: Default::default(),
+            project_harness: None,
             inject_hook: false,
         };
 

--- a/crates/pdo-daemon/src/node_spawn.rs
+++ b/crates/pdo-daemon/src/node_spawn.rs
@@ -369,13 +369,33 @@ pub(crate) async fn spawn_node(
     } else {
         let default_harness = stored_default_harness(deps.db).await;
         let default_models = stored_default_harness_models(deps.db).await;
+        // #552/ADR-0046: the Projet tier — the harness carried by the Projet that
+        // owns this Run's **primary** repo. The primary is `target_repo` (else the
+        // daemon repo root — the same `effective_repo` key the lists group and
+        // attach by). A secondary repo (ADR-0042) lives in `target_repos` and is
+        // never consulted, so adding or removing one changes neither the Projet nor
+        // the resolved harness. A DB error degrades the tier to transparent — a
+        // Projet lookup never fails a spawn.
+        let primary_repo = projected
+            .and_then(|s| s.target_repo.clone())
+            .unwrap_or_else(|| spawn_ctx.repo_root.to_string_lossy().into_owned());
+        let project_harness =
+            match crate::project_store::harness_for_path(deps.db, &primary_repo).await {
+                Ok(h) => h,
+                Err(e) => {
+                    warn!("project harness lookup failed for {primary_repo}: {e}");
+                    None
+                }
+            };
         let tiers = harness_resolver::HarnessTiers {
             node_pin: node.pin_harness.as_deref(),
             // #551: the Run tier — the harness frozen in this Run's `RunStarted`
             // (`projected` is the fresh projection loaded at the head of this spawn).
             // A pinned node still ignores it; a free node follows it (ADR-0046).
             run: projected.and_then(|s| s.harness.as_deref()),
-            project: None, // #552
+            // #552: the Projet tier — resolved just above from this Run's primary
+            // repo. Sits below the Run and above the instance default (ADR-0046).
+            project: project_harness.as_deref(),
             instance_default: default_harness.as_deref(),
         };
         Some(harness_resolver::resolve(

--- a/crates/pdo-daemon/src/project_store.rs
+++ b/crates/pdo-daemon/src/project_store.rs
@@ -1,0 +1,456 @@
+//! Persistence for **Projets** — a named grouping of member repository paths,
+//! and the middle tier of the harness precedence axis (ADR-0046, #552).
+//!
+//! A Projet is materialised **on demand**: no row exists until a human names a
+//! group or attaches a setting (ADR-0046, same posture as the price table of
+//! ADR-0034 — nothing is ever seeded). Membership is a **verbatim** path
+//! comparison — a repo path is never canonicalised (ADR-0033), so two spellings
+//! of the same path are two paths and nothing reconciles them silently. A path
+//! belongs to **at most one** Projet; a second attach is a **refusal that names
+//! the owning Projet**, rendered before any write.
+//!
+//! Idiom of `trigger_store` / `instance_config`: SQLite, nullable columns for
+//! what the Projet carries (its optional `harness`). Two tables:
+//!
+//! - `projects` — identity (`id`, `name`) plus the optional `harness` it carries
+//!   (the first per-Projet setting, ADR-0046).
+//! - `project_members` — `path` → `project_id`, with `path` as the PRIMARY KEY so
+//!   "at most one Projet per path" is a **schema invariant**, not merely a code
+//!   check. The named refusal is still computed in code (a bare PK conflict could
+//!   not name the owner).
+//!
+//! The Projet of a Run is the one that owns its **primary** repo path; a
+//! secondary repo (ADR-0042) is never consulted here, so adding or removing one
+//! can change neither the Projet nor the resolved harness. That property lives at
+//! the spawn seam (which passes the primary path only) — this store just answers
+//! "who owns this exact path".
+
+use serde::{Deserialize, Serialize};
+use sqlx::{Row, SqlitePool};
+
+/// A persisted Projet: a named group of member paths and the optional harness it
+/// carries. `harness` is `None` when the Projet names no harness (the tier is
+/// then transparent to resolution). `members` is the verbatim member-path list,
+/// ordered by attach time.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct Project {
+    pub id: String,
+    pub name: String,
+    /// The harness this Projet carries (ADR-0046), or `None`. Stored nullable;
+    /// there is no env/default tier for a per-Projet harness, so this is the
+    /// degenerate `stored → None`. An empty string is treated as "unset" by the
+    /// resolver seam (the `Some("")` trap of #347).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub harness: Option<String>,
+    /// Member repository paths, compared **verbatim** (ADR-0033). Ordered by
+    /// attach time (the `rowid` of `project_members`).
+    #[serde(default)]
+    pub members: Vec<String>,
+}
+
+/// The outcome of attaching a path to a Projet — the "at most one Projet per
+/// path" invariant expressed as data so the API can render the named refusal.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum AddMember {
+    /// The path was newly attached to the Projet.
+    Added,
+    /// The path was already a member of **this** Projet — an idempotent no-op.
+    AlreadyMember,
+    /// The path is already a member of **another** Projet. No write happened; the
+    /// owning Projet is named so the caller can say which one (AC: "refus nommant
+    /// le Projet propriétaire, avant tout effet").
+    Refused {
+        owner_id: String,
+        owner_name: String,
+    },
+}
+
+/// Create the `projects` and `project_members` tables if they do not exist.
+///
+/// Both are brand-new tables (like `sandbox_profiles` / `audit_log`), so a plain
+/// `CREATE TABLE IF NOT EXISTS` is the whole migration — natively idempotent,
+/// needing no PRAGMA-guarded `ALTER` (there is no earlier shape to migrate from).
+pub(crate) async fn init(db: &SqlitePool) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS projects (
+            id         TEXT PRIMARY KEY,
+            name       TEXT NOT NULL,
+            harness    TEXT,
+            created_at TEXT NOT NULL
+        )",
+    )
+    .execute(db)
+    .await?;
+
+    // `path` is the PRIMARY KEY: at-most-one-Projet-per-path is a schema
+    // invariant. `project_id` is indexed for the members-of lookup. No FK
+    // ON DELETE cascade — deletes clear members explicitly (portable, and the
+    // daemon never enables `PRAGMA foreign_keys`).
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS project_members (
+            path       TEXT PRIMARY KEY,
+            project_id TEXT NOT NULL,
+            created_at TEXT NOT NULL
+        )",
+    )
+    .execute(db)
+    .await?;
+
+    sqlx::query(
+        "CREATE INDEX IF NOT EXISTS idx_project_members_project ON project_members(project_id)",
+    )
+    .execute(db)
+    .await?;
+
+    Ok(())
+}
+
+/// Generate a Projet id (`prj-<ts>-<short uuid>`), mirroring `trigger_store`.
+pub(crate) fn generate_project_id() -> String {
+    let ts = chrono::Utc::now().format("%Y%m%d-%H%M%S");
+    let short = &uuid::Uuid::new_v4().to_string()[..7];
+    format!("prj-{ts}-{short}")
+}
+
+fn row_to_project(row: &sqlx::sqlite::SqliteRow, members: Vec<String>) -> Project {
+    Project {
+        id: row.get("id"),
+        name: row.get("name"),
+        harness: row
+            .get::<Option<String>, _>("harness")
+            .filter(|s| !s.is_empty()),
+        members,
+    }
+}
+
+/// Load the member paths of one Projet, ordered by attach time.
+async fn members_of(db: &SqlitePool, project_id: &str) -> Result<Vec<String>, sqlx::Error> {
+    let rows =
+        sqlx::query("SELECT path FROM project_members WHERE project_id = ? ORDER BY rowid ASC")
+            .bind(project_id)
+            .fetch_all(db)
+            .await?;
+    Ok(rows.iter().map(|r| r.get::<String, _>("path")).collect())
+}
+
+/// Insert a new (empty, harness-less) Projet with the given name, returning the
+/// stored row. Materialisation on naming (ADR-0046): this is the only path that
+/// creates a `projects` row from a bare name.
+pub(crate) async fn create(db: &SqlitePool, name: &str) -> Result<Project, sqlx::Error> {
+    let id = generate_project_id();
+    let now = crate::event_log::now_iso();
+    sqlx::query("INSERT INTO projects (id, name, harness, created_at) VALUES (?, ?, NULL, ?)")
+        .bind(&id)
+        .bind(name)
+        .bind(&now)
+        .execute(db)
+        .await?;
+    Ok(Project {
+        id,
+        name: name.to_string(),
+        harness: None,
+        members: Vec::new(),
+    })
+}
+
+/// All Projets with their member lists, newest first.
+pub(crate) async fn list(db: &SqlitePool) -> Result<Vec<Project>, sqlx::Error> {
+    let rows = sqlx::query("SELECT * FROM projects ORDER BY created_at DESC")
+        .fetch_all(db)
+        .await?;
+    let mut projects = Vec::with_capacity(rows.len());
+    for row in &rows {
+        let id: String = row.get("id");
+        let members = members_of(db, &id).await?;
+        projects.push(row_to_project(row, members));
+    }
+    Ok(projects)
+}
+
+/// One Projet by id, with its members. `None` ⇒ no such Projet.
+pub(crate) async fn get(db: &SqlitePool, id: &str) -> Result<Option<Project>, sqlx::Error> {
+    let row = sqlx::query("SELECT * FROM projects WHERE id = ?")
+        .bind(id)
+        .fetch_optional(db)
+        .await?;
+    match row {
+        Some(row) => {
+            let members = members_of(db, id).await?;
+            Ok(Some(row_to_project(&row, members)))
+        }
+        None => Ok(None),
+    }
+}
+
+/// Rename a Projet. Returns `true` iff a row was updated.
+pub(crate) async fn rename(db: &SqlitePool, id: &str, name: &str) -> Result<bool, sqlx::Error> {
+    let res = sqlx::query("UPDATE projects SET name = ? WHERE id = ?")
+        .bind(name)
+        .bind(id)
+        .execute(db)
+        .await?;
+    Ok(res.rows_affected() > 0)
+}
+
+/// Set (or clear, with `None`) the harness a Projet carries. Returns `true` iff a
+/// row was updated. An empty string is stored as `NULL` — a blank never carries a
+/// harness (the `Some("")` trap of #347), matching the resolver's floor-through.
+pub(crate) async fn set_harness(
+    db: &SqlitePool,
+    id: &str,
+    harness: Option<&str>,
+) -> Result<bool, sqlx::Error> {
+    let stored = harness.filter(|s| !s.is_empty());
+    let res = sqlx::query("UPDATE projects SET harness = ? WHERE id = ?")
+        .bind(stored)
+        .bind(id)
+        .execute(db)
+        .await?;
+    Ok(res.rows_affected() > 0)
+}
+
+/// The Projet that currently owns `path`, if any. Read-then-decide basis for the
+/// named refusal, and re-usable as a plain lookup. Compared **verbatim**.
+pub(crate) async fn owner_of(db: &SqlitePool, path: &str) -> Result<Option<Project>, sqlx::Error> {
+    let row = sqlx::query("SELECT project_id FROM project_members WHERE path = ?")
+        .bind(path)
+        .fetch_optional(db)
+        .await?;
+    match row {
+        Some(row) => get(db, &row.get::<String, _>("project_id")).await,
+        None => Ok(None),
+    }
+}
+
+/// Attach a member path to a Projet, enforcing at-most-one membership **before
+/// any write**. A path already owned by a *different* Projet is refused, naming
+/// the owner; a re-attach to the same Projet is an idempotent no-op.
+pub(crate) async fn add_member(
+    db: &SqlitePool,
+    project_id: &str,
+    path: &str,
+) -> Result<AddMember, sqlx::Error> {
+    if let Some(owner) = owner_of(db, path).await? {
+        if owner.id == project_id {
+            return Ok(AddMember::AlreadyMember);
+        }
+        return Ok(AddMember::Refused {
+            owner_id: owner.id,
+            owner_name: owner.name,
+        });
+    }
+    let now = crate::event_log::now_iso();
+    sqlx::query("INSERT INTO project_members (path, project_id, created_at) VALUES (?, ?, ?)")
+        .bind(path)
+        .bind(project_id)
+        .bind(&now)
+        .execute(db)
+        .await?;
+    Ok(AddMember::Added)
+}
+
+/// Detach a member path from **any** Projet (the path is globally unique). Returns
+/// `true` iff a membership row was removed.
+pub(crate) async fn remove_member(db: &SqlitePool, path: &str) -> Result<bool, sqlx::Error> {
+    let res = sqlx::query("DELETE FROM project_members WHERE path = ?")
+        .bind(path)
+        .execute(db)
+        .await?;
+    Ok(res.rows_affected() > 0)
+}
+
+/// Delete a Projet and all its memberships. Returns `true` iff a Projet row was
+/// removed. Used when a group is un-named back to its derived label.
+pub(crate) async fn delete(db: &SqlitePool, id: &str) -> Result<bool, sqlx::Error> {
+    sqlx::query("DELETE FROM project_members WHERE project_id = ?")
+        .bind(id)
+        .execute(db)
+        .await?;
+    let res = sqlx::query("DELETE FROM projects WHERE id = ?")
+        .bind(id)
+        .execute(db)
+        .await?;
+    Ok(res.rows_affected() > 0)
+}
+
+/// Resolve the harness a `path` inherits from its Projet, for the `project` tier
+/// of [`crate::harness_resolver`]. `None` ⇒ the path is in no Projet, or its
+/// Projet carries no harness — the tier is transparent either way. An empty
+/// stored harness is already normalised to `None` by [`owner_of`] → [`get`].
+pub(crate) async fn harness_for_path(
+    db: &SqlitePool,
+    path: &str,
+) -> Result<Option<String>, sqlx::Error> {
+    Ok(owner_of(db, path).await?.and_then(|p| p.harness))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn mem_db() -> SqlitePool {
+        let db = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        init(&db).await.unwrap();
+        db
+    }
+
+    #[tokio::test]
+    async fn init_is_idempotent() {
+        // The "migration de table idempotente" AC: running init twice on the same
+        // pool is a no-op, never an error (mirror of trigger_store's guarantee).
+        let db = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        init(&db).await.unwrap();
+        init(&db).await.unwrap();
+        // And a project created before the second init survives it.
+        let p = create(&db, "P").await.unwrap();
+        init(&db).await.unwrap();
+        assert!(get(&db, &p.id).await.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn no_row_exists_before_naming() {
+        // AC: aucune ligne de Projet tant qu'un humain n'a pas nommé un groupe.
+        // A fresh store has zero rows and no path is owned.
+        let db = mem_db().await;
+        assert!(list(&db).await.unwrap().is_empty());
+        assert!(owner_of(&db, "/repos/front").await.unwrap().is_none());
+        assert!(harness_for_path(&db, "/repos/front")
+            .await
+            .unwrap()
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn a_path_cannot_belong_to_two_projects_refusal_names_the_owner() {
+        // AC: un chemin déjà membre ne peut pas être ajouté à un second — refus
+        // nommant le propriétaire, avant tout effet.
+        let db = mem_db().await;
+        let a = create(&db, "Alpha").await.unwrap();
+        let b = create(&db, "Bravo").await.unwrap();
+
+        assert_eq!(
+            add_member(&db, &a.id, "/repos/front").await.unwrap(),
+            AddMember::Added
+        );
+        // Second attach to a DIFFERENT project: refused, naming Alpha.
+        match add_member(&db, &b.id, "/repos/front").await.unwrap() {
+            AddMember::Refused {
+                owner_id,
+                owner_name,
+            } => {
+                assert_eq!(owner_id, a.id);
+                assert_eq!(owner_name, "Alpha");
+            }
+            other => panic!("expected refusal naming the owner, got {other:?}"),
+        }
+        // …and BEFORE any effect: Bravo gained no member.
+        assert!(get(&db, &b.id).await.unwrap().unwrap().members.is_empty());
+        // The path still belongs to Alpha only.
+        assert_eq!(
+            owner_of(&db, "/repos/front").await.unwrap().unwrap().id,
+            a.id
+        );
+    }
+
+    #[tokio::test]
+    async fn re_attaching_to_the_same_project_is_an_idempotent_noop() {
+        let db = mem_db().await;
+        let a = create(&db, "Alpha").await.unwrap();
+        assert_eq!(
+            add_member(&db, &a.id, "/repos/front").await.unwrap(),
+            AddMember::Added
+        );
+        assert_eq!(
+            add_member(&db, &a.id, "/repos/front").await.unwrap(),
+            AddMember::AlreadyMember
+        );
+        assert_eq!(
+            get(&db, &a.id).await.unwrap().unwrap().members,
+            vec!["/repos/front".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn membership_comparison_is_verbatim() {
+        // ADR-0033: two spellings of the same path are two paths — nothing
+        // reconciles them. A trailing slash makes a distinct, unowned key.
+        let db = mem_db().await;
+        let a = create(&db, "Alpha").await.unwrap();
+        add_member(&db, &a.id, "/repos/front").await.unwrap();
+        assert!(owner_of(&db, "/repos/front").await.unwrap().is_some());
+        assert!(owner_of(&db, "/repos/front/").await.unwrap().is_none());
+        assert!(owner_of(&db, "/repos/FRONT").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn harness_for_path_reads_the_owning_projects_harness() {
+        // The `project` tier the spawn seam reads: a member path inherits its
+        // Projet's harness; a blank harness collapses to None (#347).
+        let db = mem_db().await;
+        let a = create(&db, "Alpha").await.unwrap();
+        add_member(&db, &a.id, "/repos/front").await.unwrap();
+        add_member(&db, &a.id, "/repos/back").await.unwrap();
+
+        assert!(harness_for_path(&db, "/repos/front")
+            .await
+            .unwrap()
+            .is_none());
+        assert!(set_harness(&db, &a.id, Some("opencode")).await.unwrap());
+        assert_eq!(
+            harness_for_path(&db, "/repos/front")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("opencode")
+        );
+        // Both members inherit it — a Projet setting is posed once for its repos.
+        assert_eq!(
+            harness_for_path(&db, "/repos/back")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("opencode")
+        );
+        // A non-member path inherits nothing.
+        assert!(harness_for_path(&db, "/repos/other")
+            .await
+            .unwrap()
+            .is_none());
+        // Clearing the harness (empty string → NULL) makes the tier transparent.
+        assert!(set_harness(&db, &a.id, Some("")).await.unwrap());
+        assert!(harness_for_path(&db, "/repos/front")
+            .await
+            .unwrap()
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn rename_and_delete() {
+        let db = mem_db().await;
+        let a = create(&db, "Alpha").await.unwrap();
+        add_member(&db, &a.id, "/repos/front").await.unwrap();
+
+        assert!(rename(&db, &a.id, "Renamed").await.unwrap());
+        assert_eq!(get(&db, &a.id).await.unwrap().unwrap().name, "Renamed");
+
+        // Deleting a Projet frees its member paths for another Projet.
+        assert!(delete(&db, &a.id).await.unwrap());
+        assert!(get(&db, &a.id).await.unwrap().is_none());
+        assert!(owner_of(&db, "/repos/front").await.unwrap().is_none());
+        let b = create(&db, "Bravo").await.unwrap();
+        assert_eq!(
+            add_member(&db, &b.id, "/repos/front").await.unwrap(),
+            AddMember::Added
+        );
+    }
+
+    #[tokio::test]
+    async fn remove_member_frees_the_path() {
+        let db = mem_db().await;
+        let a = create(&db, "Alpha").await.unwrap();
+        add_member(&db, &a.id, "/repos/front").await.unwrap();
+        assert!(remove_member(&db, "/repos/front").await.unwrap());
+        assert!(owner_of(&db, "/repos/front").await.unwrap().is_none());
+        assert!(!remove_member(&db, "/repos/front").await.unwrap());
+    }
+}

--- a/crates/pdo-daemon/tests/project_harness_resolution.rs
+++ b/crates/pdo-daemon/tests/project_harness_resolution.rs
@@ -1,0 +1,265 @@
+//! Layer 3 (#552, ADR-0046) — the **Projet** tier of the harness axis, end to end
+//! through the daemon.
+//!
+//! A single unpinned `doc-only` node, spawned through the **tmux command seam** (a
+//! harmless `sleep`, never a real agent). With no node pin and no instance
+//! default, the only tier that can name a harness is the **Projet** of the Run's
+//! primary repo. The tests prove:
+//!   1. a Projet posed on the primary repo resolves the node's harness (and is
+//!      **frozen** on `NodeStarted`), while a Projet on a *secondary* repo is
+//!      ignored — the Run follows its **primary** (ADR-0042);
+//!   2. with no Projet, resolution falls through to the `claude` floor; and
+//!   3. attaching a path already owned by another Projet is refused, **naming**
+//!      the owner (AC), before any effect.
+//!
+//! Nothing is seeded: every Projet here is materialised via `POST /projects`.
+
+mod common;
+
+use common::TestDaemon;
+
+const PIPELINE_NAME: &str = "proj-harness-test";
+const PIPELINE_YAML: &str = r#"name: proj-harness-test
+version: "1.0"
+nodes:
+  - id: start
+    name: Start
+    type: start
+    outputs:
+      - name: user_prompt
+  - id: aaaaaaaa
+    name: worker
+    type: doc-only
+    outputs:
+      - name: out
+    view: { x: 200, y: 60 }
+  - id: end
+    name: End
+    type: end
+    inputs:
+      - name: result
+edges:
+  - source: { node: start, port: user_prompt }
+    target: { node: aaaaaaaa, port: task }
+  - source: { node: aaaaaaaa, port: out }
+    target: { node: end, port: result }
+"#;
+
+fn seed(repo: &std::path::Path) -> anyhow::Result<()> {
+    let pipelines_dir = repo.join(".pdo").join("pipelines");
+    std::fs::create_dir_all(&pipelines_dir)?;
+    std::fs::write(
+        pipelines_dir.join(format!("{PIPELINE_NAME}.yaml")),
+        PIPELINE_YAML,
+    )?;
+    let prompts_dir = pipelines_dir.join(format!("{PIPELINE_NAME}.prompts"));
+    std::fs::create_dir_all(&prompts_dir)?;
+    std::fs::write(prompts_dir.join("aaaaaaaa.md"), "You are the worker.\n")?;
+    git_init_with_commit(repo)?;
+    Ok(())
+}
+
+fn git_init_with_commit(repo: &std::path::Path) -> anyhow::Result<()> {
+    let run = |args: &[&str]| -> anyhow::Result<()> {
+        let out = std::process::Command::new("git")
+            .args(args)
+            .current_dir(repo)
+            .output()?;
+        if !out.status.success() {
+            anyhow::bail!(
+                "git {:?} failed: {}",
+                args,
+                String::from_utf8_lossy(&out.stderr)
+            );
+        }
+        Ok(())
+    };
+    run(&["init", "-q", "-b", "main"])?;
+    run(&["config", "user.email", "test@example.com"])?;
+    run(&["config", "user.name", "Test"])?;
+    run(&["config", "commit.gpgsign", "false"])?;
+    std::fs::write(repo.join(".gitignore"), ".pdo/runs/\n")?;
+    run(&["add", "."])?;
+    run(&["commit", "-q", "-m", "init"])?;
+    Ok(())
+}
+
+/// A fresh git repo (one commit) at `dir`, ready to be pinned as a secondary.
+fn make_secondary_repo(dir: &std::path::Path) {
+    std::fs::write(dir.join("README.md"), "secondary\n").unwrap();
+    git_init_with_commit(dir).unwrap();
+}
+
+// --- HTTP helpers over the Projet endpoints ----------------------------------
+
+async fn create_project(daemon: &TestDaemon, name: &str) -> String {
+    let resp = reqwest::Client::new()
+        .post(format!("{}/projects", daemon.url()))
+        .json(&serde_json::json!({ "name": name }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 201, "POST /projects should return 201");
+    let json: serde_json::Value = resp.json().await.unwrap();
+    json["id"].as_str().unwrap().to_string()
+}
+
+async fn add_member(daemon: &TestDaemon, project_id: &str, path: &str) -> reqwest::Response {
+    reqwest::Client::new()
+        .post(format!("{}/projects/{project_id}/members", daemon.url()))
+        .json(&serde_json::json!({ "path": path }))
+        .send()
+        .await
+        .unwrap()
+}
+
+async fn set_harness(daemon: &TestDaemon, project_id: &str, harness: &str) {
+    let resp = reqwest::Client::new()
+        .patch(format!("{}/projects/{project_id}", daemon.url()))
+        .json(&serde_json::json!({ "harness": harness }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200, "PATCH /projects should return 200");
+}
+
+async fn create_run(daemon: &TestDaemon, body: serde_json::Value) -> String {
+    let resp = reqwest::Client::new()
+        .post(format!("{}/runs", daemon.url()))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 201, "POST /runs should return 201");
+    let json: serde_json::Value = resp.json().await.unwrap();
+    json["run_id"].as_str().unwrap().to_string()
+}
+
+async fn events(daemon: &TestDaemon, run_id: &str) -> Vec<serde_json::Value> {
+    let v: serde_json::Value = reqwest::get(format!("{}/runs/{run_id}/events", daemon.url()))
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    v.as_array().cloned().unwrap_or_default()
+}
+
+/// The `harness` frozen on the worker node's latest `NodeStarted`, or `None`.
+fn started_harness(evs: &[serde_json::Value]) -> Option<String> {
+    evs.iter()
+        .rev()
+        .find(|e| e["kind"] == "node_started" && e["node_id"] == "aaaaaaaa")
+        .and_then(|e| e["payload"]["harness"].as_str())
+        .map(String::from)
+}
+
+async fn wait_for_started(daemon: &TestDaemon, run_id: &str) -> String {
+    for _ in 0..50 {
+        let evs = events(daemon, run_id).await;
+        if let Some(h) = started_harness(&evs) {
+            return h;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+    panic!("worker node should have started within the timeout");
+}
+
+#[tokio::test]
+async fn projet_of_primary_repo_resolves_the_node_harness_secondary_ignored() {
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+    let primary = daemon.target_repo();
+
+    // A secondary git repo, owned by a DIFFERENT Projet carrying `claude`. If the
+    // resolver ever consulted a secondary, this would drag the node onto claude.
+    let secondary = tempfile::tempdir().unwrap();
+    make_secondary_repo(secondary.path());
+    let secondary_path = secondary.path().to_str().unwrap().to_string();
+
+    // Materialise the Projets via the API (nothing is seeded) and pose harnesses.
+    let product = create_project(&daemon, "Product").await;
+    assert_eq!(
+        add_member(&daemon, &product, &primary).await.status(),
+        200,
+        "primary attaches cleanly"
+    );
+    set_harness(&daemon, &product, "opencode").await;
+
+    let legacy = create_project(&daemon, "Legacy").await;
+    assert_eq!(
+        add_member(&daemon, &legacy, &secondary_path).await.status(),
+        200
+    );
+    set_harness(&daemon, &legacy, "claude").await;
+
+    // A Run on the primary, carrying the secondary read-only. The unpinned node
+    // has no node/Run/instance harness — only the Projet tier can name one.
+    let run_id = create_run(
+        &daemon,
+        serde_json::json!({
+            "pipeline": PIPELINE_NAME,
+            "input": "go",
+            "target_repo": primary,
+            "target_repos": [ { "repo": primary }, { "repo": secondary_path } ],
+        }),
+    )
+    .await;
+
+    // The node froze `opencode` — the primary's Projet — NOT `claude` from the
+    // secondary's Projet, and NOT the bare `claude` floor.
+    assert_eq!(
+        wait_for_started(&daemon, &run_id).await,
+        "opencode",
+        "the Run follows its primary repo's Projet; the secondary's Projet is ignored"
+    );
+}
+
+#[tokio::test]
+async fn no_projet_falls_through_to_the_claude_floor() {
+    // Control: with no Projet naming a harness, an unpinned node resolves the
+    // `claude` floor — the pre-#552 behaviour, unchanged.
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+    let run_id = create_run(
+        &daemon,
+        serde_json::json!({
+            "pipeline": PIPELINE_NAME,
+            "input": "go",
+            "target_repo": daemon.target_repo(),
+        }),
+    )
+    .await;
+    assert_eq!(wait_for_started(&daemon, &run_id).await, "claude");
+}
+
+#[tokio::test]
+async fn attaching_a_path_to_a_second_projet_is_refused_naming_the_owner() {
+    // AC end to end: a path already owned by a Projet cannot join a second — the
+    // refusal is a 409 that NAMES the owner, before any effect.
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+    let primary = daemon.target_repo();
+
+    let alpha = create_project(&daemon, "Alpha").await;
+    assert_eq!(add_member(&daemon, &alpha, &primary).await.status(), 200);
+
+    let bravo = create_project(&daemon, "Bravo").await;
+    let refused = add_member(&daemon, &bravo, &primary).await;
+    assert_eq!(refused.status(), 409, "a second attach is refused");
+    let body: serde_json::Value = refused.json().await.unwrap();
+    assert_eq!(body["owner_name"].as_str(), Some("Alpha"));
+    assert!(
+        body["error"].as_str().unwrap_or_default().contains("Alpha"),
+        "the refusal message names the owning Projet: {body}"
+    );
+
+    // Before any effect: Bravo gained no member.
+    let bravo_state: serde_json::Value = reqwest::get(format!("{}/projects/{bravo}", daemon.url()))
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert!(
+        bravo_state["members"].as_array().unwrap().is_empty(),
+        "the refused Projet must gain no member"
+    );
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,10 +5,10 @@ import type { ConnectionStatus } from "./hooks/useDaemonSocket";
 import { useResizableLayout } from "./hooks/useResizableLayout";
 import { useLibrary } from "./hooks/useLibrary";
 import { useLibraryPipelines } from "./hooks/useLibraryPipelines";
-import { fetchRuns, fetchRun, fetchTriggers, fetchSessions, fetchTriggersHealth, pauseTriggers } from "./api";
+import { fetchRuns, fetchRun, fetchTriggers, fetchProjects, fetchSessions, fetchTriggersHealth, pauseTriggers } from "./api";
 import { pickLatestLiveNode } from "./lib/pickLatestLiveNode";
 import { useRightPaneRouter } from "./hooks/useRightPaneRouter";
-import type { RunListEntry, RunState, Trigger, DaemonStatus } from "./types";
+import type { RunListEntry, RunState, Trigger, Project, DaemonStatus } from "./types";
 import { shouldAutoSnapToLiveNode } from "./lib/autoSnap";
 import SessionCounter from "./components/SessionCounter";
 import ServiceHealthIndicator from "./components/ServiceHealthIndicator";
@@ -95,6 +95,22 @@ function useTriggers() {
   return { triggers, refresh };
 }
 
+// #552 — Projets, hydrated on mount and refreshed on a `project_changed` WS push
+// (the daemon broadcasts one on every project mutation). Mirror of useTriggers.
+function useProjects() {
+  const [projects, setProjects] = useState<Project[]>([]);
+
+  const refresh = useCallback(async () => {
+    try {
+      setProjects(await fetchProjects());
+    } catch {
+      // ignore
+    }
+  }, []);
+
+  return { projects, refresh };
+}
+
 function useSelectedRun() {
   const [run, setRun] = useState<RunState | null>(null);
   const currentIdRef = useRef<string | null>(null);
@@ -136,6 +152,7 @@ export default function App() {
   const { runs, refresh: refreshRuns } = useRuns();
   const { sessions, refresh: refreshSessions } = useSessions();
   const { triggers, refresh: refreshTriggers } = useTriggers();
+  const { projects, refresh: refreshProjects } = useProjects();
   // #348: global Trigger pause. Lifted here (not in a per-panel hook) so the WS
   // dispatcher can flip it live and every consumer stays in sync; hydrated on
   // mount from GET /triggers/health since there is no trigger polling.
@@ -393,6 +410,7 @@ export default function App() {
       refreshRuns();
       refreshSessions();
       refreshTriggers();
+      refreshProjects();
       // #348: hydrate the global pause flag once — no trigger polling carries it,
       // so without this a page reload would show the banner off while paused.
       fetchTriggersHealth()
@@ -400,7 +418,7 @@ export default function App() {
         .catch(() => {});
       useRecentReposStore.getState().refresh();
     }
-  }, [refreshRuns, refreshSessions, refreshTriggers]);
+  }, [refreshRuns, refreshSessions, refreshTriggers, refreshProjects]);
 
   // A WS reconnect usually means the daemon restarted — possibly as a different
   // binary, so the /sessions payload (version included, #139) may be stale. An
@@ -493,6 +511,13 @@ export default function App() {
         setTriggersPaused(!!msg.paused);
         return;
       }
+      // #552: a Projet mutation (name/harness/members) — refresh the Projet list
+      // so the Runs and Triggers regrouping is live across clients. The Runs /
+      // Triggers rows themselves are unchanged, so only the Projet list refetches.
+      if (msg.type === "project_changed") {
+        refreshProjects();
+        return;
+      }
       // Trigger lifecycle (#160/#162): create/update/delete refreshes the
       // Triggers list; a fire also creates a Run, so refresh both.
       if (
@@ -525,7 +550,7 @@ export default function App() {
       // count (#159) — keep the status-bar counter current.
       refreshSessions();
     });
-  }, [subscribe, refreshRuns, refreshRun, refreshSessions, refreshTriggers, reloadPipeline, loadPipelines]);
+  }, [subscribe, refreshRuns, refreshRun, refreshSessions, refreshTriggers, refreshProjects, reloadPipeline, loadPipelines]);
 
   // Detect: active tab is a run whose library twin (matched by id, then name)
   // diverges from the run snapshot — pipeline or prompts, the same comparison
@@ -622,6 +647,8 @@ export default function App() {
               onEditTrigger={(t) => openNewRunModal({ kind: "edit-trigger", trigger: t })}
               triggersPaused={triggersPaused}
               onTogglePause={handleTogglePause}
+              projects={projects}
+              onProjectsChanged={refreshProjects}
             />
           </ResizablePanel>
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,4 +1,4 @@
-import type { PipelineListEntry, PipelineDetail, PipelineDef, RunListEntry, RunState, PortDef, PortSide, PortType, FrontmatterFieldDecl, FrontmatterViolation, Trigger, TriggerFire, DaemonStatus, InstanceSettings, UpdateSettingsRequest, StatsOverview, StatsCost, SandboxProfile, SandboxProfileImage, SandboxProfileReferents, SyncCostPricesReport } from "./types";
+import type { PipelineListEntry, PipelineDetail, PipelineDef, RunListEntry, RunState, PortDef, PortSide, PortType, FrontmatterFieldDecl, FrontmatterViolation, Trigger, TriggerFire, DaemonStatus, InstanceSettings, UpdateSettingsRequest, StatsOverview, StatsCost, SandboxProfile, SandboxProfileImage, SandboxProfileReferents, SyncCostPricesReport, Project } from "./types";
 import { foldHarnessOntoNode } from "./lib/harness";
 
 const BASE = "";
@@ -750,6 +750,71 @@ export function updateTrigger(
     `/triggers/${encodeURIComponent(triggerId)}`,
     { body: req, label: `PATCH /triggers/${triggerId}` },
   );
+}
+
+// --- Projets (#552, ADR-0046) ---
+
+/** All Projets with their members (`GET /projects`). */
+export function fetchProjects(): Promise<Project[]> {
+  return request<Project[]>("GET", "/projects");
+}
+
+/** Materialise a Projet from a bare name (`POST /projects`). */
+export function createProject(name: string): Promise<Project> {
+  return request<Project>("POST", "/projects", {
+    body: { name },
+    label: "POST /projects",
+  });
+}
+
+/**
+ * Rename a Projet and/or (re)set the harness it carries (`PATCH /projects/{id}`).
+ * `harness`: a string sets it, `null` clears it, `undefined` leaves it unchanged
+ * (double-`Option` on the wire). `name` omitted leaves it unchanged.
+ */
+export interface UpdateProjectRequest {
+  name?: string;
+  harness?: string | null;
+}
+
+export function updateProject(
+  projectId: string,
+  req: UpdateProjectRequest,
+): Promise<Project> {
+  return request<Project>("PATCH", `/projects/${encodeURIComponent(projectId)}`, {
+    body: req,
+    label: `PATCH /projects/${projectId}`,
+  });
+}
+
+/**
+ * Attach a member path to a Projet (`POST /projects/{id}/members`). Throws an
+ * {@link ApiError} with `status: 409` whose message names the owning Projet when
+ * the path already belongs to a different one (AC: refus nommant le propriétaire).
+ */
+export function addProjectMember(projectId: string, path: string): Promise<Project> {
+  return request<Project>(
+    "POST",
+    `/projects/${encodeURIComponent(projectId)}/members`,
+    { body: { path }, label: `POST /projects/${projectId}/members` },
+  );
+}
+
+/** Detach a member path from a Projet (`DELETE /projects/{id}/members`). */
+export function removeProjectMember(projectId: string, path: string): Promise<Project> {
+  return request<Project>(
+    "DELETE",
+    `/projects/${encodeURIComponent(projectId)}/members`,
+    { body: { path }, label: `DELETE /projects/${projectId}/members` },
+  );
+}
+
+/** Delete a Projet and its memberships (`DELETE /projects/{id}`). */
+export function deleteProject(projectId: string): Promise<void> {
+  return request<void>("DELETE", `/projects/${encodeURIComponent(projectId)}`, {
+    responseMode: "void",
+    label: `DELETE /projects/${projectId}`,
+  });
 }
 
 export async function deleteTrigger(triggerId: string): Promise<void> {

--- a/frontend/src/components/ProjectEditModal.test.tsx
+++ b/frontend/src/components/ProjectEditModal.test.tsx
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+import ProjectEditModal from "./ProjectEditModal";
+import { ApiError } from "../api";
+import type { Project } from "../types";
+
+const createProject = vi.fn();
+const updateProject = vi.fn();
+const addProjectMember = vi.fn();
+const removeProjectMember = vi.fn();
+
+vi.mock("../api", () => {
+  // Defined INSIDE the factory: `vi.mock` is hoisted above module top-level, so a
+  // class declared outside would be in its TDZ here.
+  class ApiError extends Error {}
+  return {
+    ApiError,
+    createProject: (name: string) => createProject(name),
+    updateProject: (id: string, req: unknown) => updateProject(id, req),
+    addProjectMember: (id: string, path: string) => addProjectMember(id, path),
+    removeProjectMember: (id: string, path: string) => removeProjectMember(id, path),
+  };
+});
+
+beforeEach(() => {
+  createProject.mockReset();
+  updateProject.mockReset();
+  addProjectMember.mockReset();
+  removeProjectMember.mockReset();
+});
+
+function renderModal(overrides: Partial<React.ComponentProps<typeof ProjectEditModal>> = {}) {
+  const onClose = vi.fn();
+  const onSaved = vi.fn();
+  render(
+    <ProjectEditModal
+      initialProject={null}
+      initialName="front"
+      initialMemberPaths={["/repos/front"]}
+      availableRepos={["/repos/front", "/repos/back"]}
+      projects={[]}
+      onClose={onClose}
+      onSaved={onSaved}
+      {...overrides}
+    />,
+  );
+  return { onClose, onSaved };
+}
+
+/** The member row whose `data-path` matches, from `project-member-row`. */
+function memberRow(path: string): HTMLElement {
+  const rows = screen.getAllByTestId("project-member-row");
+  const row = rows.find((r) => r.getAttribute("data-path") === path);
+  if (!row) throw new Error(`no member row for ${path}`);
+  return row;
+}
+
+describe("ProjectEditModal", () => {
+  it("disables the checkbox of a repo owned by another project, naming the owner", () => {
+    const other: Project = {
+      id: "p2",
+      name: "Other",
+      harness: null,
+      members: ["/repos/back"],
+    };
+    renderModal({ projects: [other] });
+
+    // Assert on the DISABLED attribute + rendered owner text — never on `.value`,
+    // which cannot fail a desync assertion (the #347 frontend guidance).
+    const backCheckbox = within(memberRow("/repos/back")).getByTestId(
+      "project-member-checkbox",
+    ) as HTMLInputElement;
+    expect(backCheckbox).toBeDisabled();
+    expect(memberRow("/repos/back").getAttribute("data-disabled")).toBe("true");
+    expect(within(memberRow("/repos/back")).getByTestId("project-member-owner").textContent).toContain(
+      "Other",
+    );
+
+    // The unowned repo stays enabled.
+    const frontCheckbox = within(memberRow("/repos/front")).getByTestId(
+      "project-member-checkbox",
+    ) as HTMLInputElement;
+    expect(frontCheckbox).not.toBeDisabled();
+  });
+
+  it("creates a project, sets its harness, and attaches the checked members on save", async () => {
+    createProject.mockResolvedValue({ id: "p9", name: "front", harness: null, members: [] });
+    updateProject.mockResolvedValue({});
+    addProjectMember.mockResolvedValue({});
+    const { onSaved, onClose } = renderModal();
+
+    // Attach the second repo too, and pose a harness on the Projet.
+    fireEvent.click(
+      within(memberRow("/repos/back")).getByTestId("project-member-checkbox"),
+    );
+    fireEvent.change(screen.getByTestId("project-harness-select"), {
+      target: { value: "opencode" },
+    });
+    fireEvent.click(screen.getByTestId("project-edit-save"));
+
+    await waitFor(() => expect(onSaved).toHaveBeenCalled());
+    expect(createProject).toHaveBeenCalledWith("front");
+    expect(updateProject).toHaveBeenCalledWith("p9", { harness: "opencode" });
+    expect(addProjectMember).toHaveBeenCalledWith("p9", "/repos/front");
+    expect(addProjectMember).toHaveBeenCalledWith("p9", "/repos/back");
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("renames and diffs members for an existing project (adds new, removes dropped)", async () => {
+    const existing: Project = {
+      id: "p1",
+      name: "Product",
+      harness: "claude",
+      members: ["/repos/front"],
+    };
+    updateProject.mockResolvedValue({});
+    addProjectMember.mockResolvedValue({});
+    removeProjectMember.mockResolvedValue({});
+    const { onSaved } = renderModal({
+      initialProject: existing,
+      initialName: "Product",
+      initialMemberPaths: ["/repos/front"],
+    });
+
+    // Drop /repos/front, add /repos/back, rename.
+    fireEvent.click(
+      within(memberRow("/repos/front")).getByTestId("project-member-checkbox"),
+    );
+    fireEvent.click(
+      within(memberRow("/repos/back")).getByTestId("project-member-checkbox"),
+    );
+    fireEvent.change(screen.getByTestId("project-name-input"), {
+      target: { value: "Renamed" },
+    });
+    fireEvent.click(screen.getByTestId("project-edit-save"));
+
+    await waitFor(() => expect(onSaved).toHaveBeenCalled());
+    expect(updateProject).toHaveBeenCalledWith("p1", { name: "Renamed", harness: "claude" });
+    expect(addProjectMember).toHaveBeenCalledWith("p1", "/repos/back");
+    expect(removeProjectMember).toHaveBeenCalledWith("p1", "/repos/front");
+    // The existing project is NOT re-created.
+    expect(createProject).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a refusal that names the owning project and keeps the modal open", async () => {
+    createProject.mockResolvedValue({ id: "p9", name: "front", harness: null, members: [] });
+    addProjectMember.mockRejectedValue(
+      new ApiError("path already belongs to project 'Other'"),
+    );
+    const { onSaved, onClose } = renderModal();
+
+    fireEvent.click(screen.getByTestId("project-edit-save"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("project-edit-error").textContent).toContain("Other"),
+    );
+    expect(onSaved).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("disables Save when the name is blank", () => {
+    renderModal({ initialName: "  " });
+    expect(screen.getByTestId("project-edit-save")).toBeDisabled();
+  });
+});

--- a/frontend/src/components/ProjectEditModal.tsx
+++ b/frontend/src/components/ProjectEditModal.tsx
@@ -1,0 +1,271 @@
+import { useMemo, useState } from "react";
+import type { Project } from "../types";
+import {
+  addProjectMember,
+  ApiError,
+  createProject,
+  removeProjectMember,
+  updateProject,
+} from "../api";
+
+/**
+ * The group-header pencil (#552, ADR-0046): name a Projet (or rename an existing
+ * one), pick which repo paths are its members, and optionally pose the harness it
+ * carries. Naming a group is what **materialises** the Projet — nothing is seeded
+ * until this saves (ADR-0046).
+ *
+ * A candidate repo already owned by **another** Projet is shown disabled with the
+ * owner's name (the "refus nommant le propriétaire" surfaced up front); the daemon
+ * refuses it too (409), which we also catch defensively.
+ *
+ * Membership is compared **verbatim** (ADR-0033): the candidate list is the exact
+ * effective-repo paths the surrounding list groups by, never canonicalised.
+ */
+
+/** The harnesses PDO ships (ADR-0045). A disk-declared tier is #553; until then
+ *  the picker offers the embedded floor plus "no harness". */
+const HARNESS_OPTIONS = ["claude", "opencode"] as const;
+
+export default function ProjectEditModal({
+  initialProject,
+  initialName,
+  initialMemberPaths,
+  availableRepos,
+  projects,
+  onClose,
+  onSaved,
+}: {
+  /** The Projet being edited, or `null` when the pencil creates a fresh one. */
+  initialProject: Project | null;
+  /** Pre-filled name: the Projet's name, or the group's derived label. */
+  initialName: string;
+  /** Pre-checked member paths: the Projet's members, or the group's own path. */
+  initialMemberPaths: string[];
+  /** Candidate repo paths to attach (the surrounding list's distinct repos). */
+  availableRepos: string[];
+  /** All Projets, to mark a candidate owned by another Projet as disabled. */
+  projects: Project[];
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const [name, setName] = useState(initialName);
+  const [harness, setHarness] = useState<string>(initialProject?.harness ?? "");
+  const [checked, setChecked] = useState<Set<string>>(
+    () => new Set(initialMemberPaths),
+  );
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // path → name of the Projet that OWNS it, excluding the one being edited. A
+  // candidate owned elsewhere cannot be attached here (AC: at most one Projet).
+  const ownerElsewhere = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const p of projects) {
+      if (initialProject && p.id === initialProject.id) continue;
+      for (const path of p.members) map.set(path, p.name);
+    }
+    return map;
+  }, [projects, initialProject]);
+
+  // The candidate universe: the surrounding list's repos, plus any existing
+  // members (so a member currently filtered out of the list can still be unchecked).
+  const candidates = useMemo(() => {
+    const set = new Set<string>(availableRepos);
+    for (const m of initialMemberPaths) set.add(m);
+    return [...set].sort();
+  }, [availableRepos, initialMemberPaths]);
+
+  const trimmedName = name.trim();
+  const canSave = trimmedName.length > 0 && !submitting;
+
+  function toggle(path: string) {
+    setChecked((prev) => {
+      const next = new Set(prev);
+      if (next.has(path)) next.delete(path);
+      else next.add(path);
+      return next;
+    });
+  }
+
+  async function handleSave() {
+    if (!canSave) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      // Materialise (or reuse) the Projet, then reconcile its name, harness and
+      // members. Create first so a fresh Projet has an id to attach against.
+      let projectId: string;
+      if (initialProject) {
+        projectId = initialProject.id;
+        await updateProject(projectId, {
+          name: trimmedName,
+          // Empty select → clear the harness (null); a value sets it.
+          harness: harness ? harness : null,
+        });
+      } else {
+        const created = await createProject(trimmedName);
+        projectId = created.id;
+        if (harness) await updateProject(projectId, { harness });
+      }
+
+      const current = new Set(initialProject?.members ?? []);
+      const desired = checked;
+      // Attach newly-checked paths; a path owned elsewhere is skipped by the
+      // disabled checkbox, but the daemon refuses it too (409 naming the owner).
+      for (const path of desired) {
+        if (!current.has(path)) await addProjectMember(projectId, path);
+      }
+      // Detach paths that were members but are now unchecked.
+      for (const path of current) {
+        if (!desired.has(path)) await removeProjectMember(projectId, path);
+      }
+      onSaved();
+      onClose();
+    } catch (e) {
+      const msg =
+        e instanceof ApiError
+          ? e.message
+          : e instanceof Error
+            ? e.message
+            : "failed to save project";
+      setError(msg);
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      data-testid="project-edit-backdrop"
+      onClick={onClose}
+    >
+      <div
+        className="w-[440px] max-w-[90vw] rounded-lg border border-line bg-bg-4 p-4"
+        style={{ fontSize: "12px" }}
+        role="dialog"
+        aria-label="Edit project"
+        data-testid="project-edit-modal"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="mb-1 font-medium text-fg">
+          {initialProject ? "Edit project" : "Name project"}
+        </div>
+        <p className="mb-3 text-fg-4" style={{ fontSize: "11px" }}>
+          Group repositories that work together under one name. A repo belongs to
+          at most one project; the harness set here applies to every Run whose
+          primary repo is a member.
+        </p>
+
+        <label className="mb-1 block text-fg-3" style={{ fontSize: "11px" }}>
+          Name
+        </label>
+        <input
+          value={name}
+          onChange={(e) => {
+            setName(e.target.value);
+            setError(null);
+          }}
+          data-testid="project-name-input"
+          className="mb-3 w-full rounded border border-line-strong bg-bg-3 px-2 py-1.5 text-fg outline-none focus:border-acc"
+          style={{ fontSize: "11px" }}
+        />
+
+        <label className="mb-1 block text-fg-3" style={{ fontSize: "11px" }}>
+          Harness
+        </label>
+        <select
+          value={harness}
+          onChange={(e) => setHarness(e.target.value)}
+          data-testid="project-harness-select"
+          className="mb-3 w-full rounded border border-line-strong bg-bg-3 px-2 py-1.5 text-fg outline-none focus:border-acc"
+          style={{ fontSize: "11px" }}
+        >
+          <option value="">No harness (inherit)</option>
+          {HARNESS_OPTIONS.map((h) => (
+            <option key={h} value={h}>
+              {h}
+            </option>
+          ))}
+        </select>
+
+        <label className="mb-1 block text-fg-3" style={{ fontSize: "11px" }}>
+          Member repositories
+        </label>
+        <div
+          className="mb-3 max-h-48 overflow-y-auto rounded border border-line-strong bg-bg-3"
+          data-testid="project-members-list"
+        >
+          {candidates.length === 0 && (
+            <div className="px-2 py-2 text-fg-4" style={{ fontSize: "11px" }}>
+              No repositories to attach.
+            </div>
+          )}
+          {candidates.map((path) => {
+            const owner = ownerElsewhere.get(path);
+            const disabled = owner != null;
+            return (
+              <label
+                key={path}
+                className={`flex items-center gap-2 border-b border-line-soft px-2 py-1.5 last:border-b-0 ${
+                  disabled ? "opacity-50" : "cursor-pointer hover:bg-bg-4"
+                }`}
+                style={{ fontSize: "11px" }}
+                title={owner ? `Already in project "${owner}"` : path}
+                data-testid="project-member-row"
+                data-path={path}
+                data-disabled={disabled ? "true" : "false"}
+              >
+                <input
+                  type="checkbox"
+                  checked={checked.has(path)}
+                  disabled={disabled}
+                  onChange={() => toggle(path)}
+                  data-testid="project-member-checkbox"
+                />
+                <span className="truncate text-fg">{path}</span>
+                {owner && (
+                  <span
+                    className="ml-auto shrink-0 text-fg-4"
+                    data-testid="project-member-owner"
+                  >
+                    in {owner}
+                  </span>
+                )}
+              </label>
+            );
+          })}
+        </div>
+
+        {error && (
+          <div
+            className="mb-3 rounded border border-st-failed/40 bg-st-failed/10 px-2 py-1.5 text-st-failed"
+            style={{ fontSize: "11px" }}
+            data-testid="project-edit-error"
+          >
+            {error}
+          </div>
+        )}
+
+        <div className="flex justify-end gap-2">
+          <button
+            onClick={onClose}
+            className="cursor-pointer rounded border border-line-strong px-3 py-1 text-fg-3 transition-colors hover:bg-bg-3"
+            style={{ fontSize: "11px" }}
+            data-testid="project-edit-cancel"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={!canSave}
+            className="cursor-pointer rounded bg-acc px-3 py-1 font-medium text-[#04140d] transition-colors hover:bg-acc-dim disabled:cursor-not-allowed disabled:opacity-50"
+            style={{ fontSize: "11px" }}
+            data-testid="project-edit-save"
+          >
+            {submitting ? "Saving…" : "Save"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/TriggersListPanel.tsx
+++ b/frontend/src/components/TriggersListPanel.tsx
@@ -1,8 +1,11 @@
+import { useMemo, useState } from "react";
 import { AlertCircle, PauseCircle, Pencil, Play, Plus, Power, Trash2, Zap } from "lucide-react";
-import type { Trigger } from "../types";
+import type { Trigger, Project } from "../types";
 import { deleteTrigger, updateTrigger } from "../api";
 import { humanizeCron } from "../cronPresets";
-import { groupByRepo, repoGroupLabel } from "../lib/groupByRepo";
+import { groupByProject, repoGroupLabel, type ProjectRef } from "../lib/groupByRepo";
+import { projectLookup } from "../lib/projectLookup";
+import ProjectEditModal from "./ProjectEditModal";
 
 interface Props {
   triggers: Trigger[];
@@ -18,6 +21,10 @@ interface Props {
   paused?: boolean;
   /** #348: flip the global pause flag. */
   onTogglePause?: () => void;
+  /** Projets (#552) — the group-by-Projet layer and the pencil. Optional so
+   *  existing callers/tests keep working. */
+  projects?: Project[];
+  onProjectsChanged?: () => void;
 }
 
 /**
@@ -56,7 +63,16 @@ export default function TriggersListPanel({
   onEditTrigger,
   paused = false,
   onTogglePause,
+  projects = [],
+  onProjectsChanged,
 }: Props) {
+  // #552 — the group-header pencil editor (see UnifiedLeftPanel for the shape).
+  const [projectEditor, setProjectEditor] = useState<{
+    project: Project | null;
+    name: string;
+    memberPaths: string[];
+  } | null>(null);
+
   async function handleDelete(triggerId: string) {
     try {
       await deleteTrigger(triggerId);
@@ -191,9 +207,44 @@ export default function TriggersListPanel({
     );
   }
 
-  // Group the Triggers list by project (#258) only when ≥ 2 distinct repos are
-  // present; otherwise `null` ⇒ the flat list, byte-identical to before.
-  const triggerGroups = groupByRepo(triggers, (t) => t.effective_repo);
+  // #552 — verbatim `path → Projet` lookup and the candidate repos the pencil can
+  // attach (the distinct effective repos across the Triggers list).
+  const projectOf = useMemo<(path: string) => ProjectRef | null>(
+    () => projectLookup(projects),
+    [projects],
+  );
+  const availableRepos = useMemo(() => {
+    const set = new Set<string>();
+    for (const t of triggers) if (t.effective_repo) set.add(t.effective_repo);
+    return [...set];
+  }, [triggers]);
+
+  // Group the Triggers list by Projet (#552), falling back to the #258 per-path
+  // grouping when nothing is named; `null` ⇒ the flat list.
+  const triggerGroups = groupByProject(triggers, (t) => t.effective_repo, projectOf);
+
+  const openProjectEditor = (group: {
+    kind: "project" | "path";
+    key: string;
+    repoPath: string;
+    label: string;
+  }) => {
+    if (group.kind === "project") {
+      const id = group.key.slice("project:".length);
+      const project = projects.find((p) => p.id === id) ?? null;
+      setProjectEditor({
+        project,
+        name: project?.name ?? group.label,
+        memberPaths: project?.members ?? [],
+      });
+    } else {
+      setProjectEditor({
+        project: null,
+        name: group.label,
+        memberPaths: group.repoPath ? [group.repoPath] : [],
+      });
+    }
+  };
 
   return (
     <div className="flex h-full flex-col" data-testid="triggers-list-panel">
@@ -280,20 +331,46 @@ export default function TriggersListPanel({
           {triggerGroups === null
             ? triggers.map(renderTriggerRow)
             : triggerGroups.map((group) => (
-                <div key={group.repoPath} data-testid="trigger-repo-group">
+                <div
+                  key={group.key}
+                  data-testid="trigger-repo-group"
+                  data-project={group.kind === "project" ? "true" : "false"}
+                >
                   <div
-                    className="flex h-[22px] shrink-0 items-center border-b border-line-soft bg-bg-3/40 px-3 font-medium text-fg-3"
+                    className="group/hdr flex h-[22px] shrink-0 items-center gap-1 border-b border-line-soft bg-bg-3/40 px-3 font-medium text-fg-3"
                     style={{ fontSize: "10px" }}
-                    title={group.repoPath}
+                    title={group.title}
                   >
                     <span className="truncate" data-testid="trigger-repo-label">
                       {group.label}
                     </span>
+                    {/* #552 — the pencil that names / renames the Projet. */}
+                    <button
+                      onClick={() => openProjectEditor(group)}
+                      className="ml-auto hidden shrink-0 cursor-pointer rounded p-0.5 text-fg-4 transition-colors hover:bg-bg-4 hover:text-fg-2 group-hover/hdr:inline-flex"
+                      title={group.kind === "project" ? "Edit project" : "Name project"}
+                      aria-label={group.kind === "project" ? "Edit project" : "Name project"}
+                      data-testid="trigger-group-pencil"
+                    >
+                      <Pencil size={10} />
+                    </button>
                   </div>
                   {group.items.map(renderTriggerRow)}
                 </div>
               ))}
         </div>
+      )}
+
+      {projectEditor && (
+        <ProjectEditModal
+          initialProject={projectEditor.project}
+          initialName={projectEditor.name}
+          initialMemberPaths={projectEditor.memberPaths}
+          availableRepos={availableRepos}
+          projects={projects}
+          onClose={() => setProjectEditor(null)}
+          onSaved={() => onProjectsChanged?.()}
+        />
       )}
     </div>
   );

--- a/frontend/src/components/UnifiedLeftPanel.tsx
+++ b/frontend/src/components/UnifiedLeftPanel.tsx
@@ -1,15 +1,17 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { ChevronDown, ChevronRight, FileUp, Pause, Pencil, Play, Plus, RotateCcw, SquareTerminal, Trash2, Zap } from "lucide-react";
-import { isLiveRun, isTerminalRun, type RunListEntry, type RunStatus, type PipelineListEntry, type PipelineScope, type Trigger } from "../types";
+import { isLiveRun, isTerminalRun, type RunListEntry, type RunStatus, type PipelineListEntry, type PipelineScope, type Trigger, type Project } from "../types";
 import type { LibraryPipelineEntry } from "../api";
 import { cleanupRun, createPipeline, deleteLibraryPipeline, duplicateLibraryPipeline, forgetRun, importWorkflow, openRunShell, pauseRun, renameRun, resumeRun, retryAll } from "../api";
 import { useEditStore } from "../stores/editStore";
-import { groupByRepo } from "../lib/groupByRepo";
+import { groupByProject, type ProjectRef } from "../lib/groupByRepo";
+import { projectLookup } from "../lib/projectLookup";
 import { cascadableTwin, isStarred, libraryOnly } from "../lib/libraryTwins";
 import CleanupConfirmModal from "./CleanupConfirmModal";
 import ConfirmDeleteModal from "./ConfirmDeleteModal";
 import ForgetRunModal from "./ForgetRunModal";
 import LibraryRow from "./LibraryRow";
+import ProjectEditModal from "./ProjectEditModal";
 import RunFilters from "./RunFilters";
 import { EMPTY_RUN_FILTER, runMatchesFilter } from "./runFilter";
 import RunShellModal from "./RunShellModal";
@@ -48,6 +50,11 @@ interface Props {
    * callers/tests keep working (defaults to not-paused, no-op toggle). */
   triggersPaused?: boolean;
   onTogglePause?: () => void;
+  /** Projets (#552) — the group-by-Projet layer and the pencil's source of
+   *  truth. Optional so existing callers/tests keep working (no Projet → the
+   *  #258 per-path grouping, unchanged). */
+  projects?: Project[];
+  onProjectsChanged?: () => void;
 }
 
 export default function UnifiedLeftPanel({
@@ -66,6 +73,8 @@ export default function UnifiedLeftPanel({
   onEditTrigger,
   triggersPaused = false,
   onTogglePause,
+  projects = [],
+  onProjectsChanged,
 }: Props) {
   const [activeTab, setActiveTab] = useState<LeftTab>("runs");
   const [confirmCleanup, setConfirmCleanup] = useState<
@@ -80,6 +89,13 @@ export default function UnifiedLeftPanel({
   const [renamingRunId, setRenamingRunId] = useState<string | null>(null);
   const [renameValue, setRenameValue] = useState("");
   const renameInputRef = useRef<HTMLInputElement>(null);
+  // #552 — the group-header pencil. Holds the Projet being edited (or `null` for
+  // a fresh one, when the header is a derived path group) plus the pre-fill.
+  const [projectEditor, setProjectEditor] = useState<{
+    project: Project | null;
+    name: string;
+    memberPaths: string[];
+  } | null>(null);
 
   const pipelines = useEditStore((s) => s.pipelines);
   const loadPipelines = useEditStore((s) => s.loadPipelines);
@@ -470,9 +486,47 @@ export default function UnifiedLeftPanel({
     if (selectedArchivedId !== null) setArchivedOpen(true);
   }
 
-  // Group the active Runs list by project (#258) only when ≥ 2 distinct repos are
-  // present; otherwise `null` ⇒ the flat list, byte-identical to before.
-  const runGroups = groupByRepo(activeRuns, (r) => r.effective_repo);
+  // #552 — verbatim `path → Projet` lookup, and the candidate repos the pencil
+  // can attach (the distinct effective repos across ALL runs, so a filtered view
+  // never hides an attachable repo).
+  const projectOf = useMemo<(path: string) => ProjectRef | null>(
+    () => projectLookup(projects),
+    [projects],
+  );
+  const availableRepos = useMemo(() => {
+    const set = new Set<string>();
+    for (const r of runs) if (r.effective_repo) set.add(r.effective_repo);
+    return [...set];
+  }, [runs]);
+
+  // Group the active Runs list by Projet (#552), falling back to the #258
+  // per-path grouping when nothing is named; `null` ⇒ the flat list.
+  const runGroups = groupByProject(activeRuns, (r) => r.effective_repo, projectOf);
+
+  // Open the pencil on a group header: an existing Projet pre-fills its record;
+  // a derived path group pre-fills the label + its own path as the sole member.
+  const openProjectEditor = (group: {
+    kind: "project" | "path";
+    key: string;
+    repoPath: string;
+    label: string;
+  }) => {
+    if (group.kind === "project") {
+      const id = group.key.slice("project:".length);
+      const project = projects.find((p) => p.id === id) ?? null;
+      setProjectEditor({
+        project,
+        name: project?.name ?? group.label,
+        memberPaths: project?.members ?? [],
+      });
+    } else {
+      setProjectEditor({
+        project: null,
+        name: group.label,
+        memberPaths: group.repoPath ? [group.repoPath] : [],
+      });
+    }
+  };
 
   const tabs: { id: LeftTab; label: string }[] = [
     { id: "runs", label: "Runs" },
@@ -555,15 +609,29 @@ export default function UnifiedLeftPanel({
           {runGroups === null
             ? activeRuns.map(renderRunRow)
             : runGroups.map((group) => (
-                <div key={group.repoPath} data-testid="run-repo-group">
+                <div
+                  key={group.key}
+                  data-testid="run-repo-group"
+                  data-project={group.kind === "project" ? "true" : "false"}
+                >
                   <div
-                    className="flex h-[22px] shrink-0 items-center border-b border-line-soft bg-bg-3/40 px-3 font-medium text-fg-3"
+                    className="group/hdr flex h-[22px] shrink-0 items-center gap-1 border-b border-line-soft bg-bg-3/40 px-3 font-medium text-fg-3"
                     style={{ fontSize: "10px" }}
-                    title={group.repoPath}
+                    title={group.title}
                   >
                     <span className="truncate" data-testid="run-repo-label">
                       {group.label}
                     </span>
+                    {/* #552 — the pencil that names / renames the Projet. */}
+                    <button
+                      onClick={() => openProjectEditor(group)}
+                      className="ml-auto hidden shrink-0 cursor-pointer rounded p-0.5 text-fg-4 transition-colors hover:bg-bg-4 hover:text-fg-2 group-hover/hdr:inline-flex"
+                      title={group.kind === "project" ? "Edit project" : "Name project"}
+                      aria-label={group.kind === "project" ? "Edit project" : "Name project"}
+                      data-testid="run-group-pencil"
+                    >
+                      <Pencil size={10} />
+                    </button>
                   </div>
                   {group.items.map(renderRunRow)}
                 </div>
@@ -606,6 +674,8 @@ export default function UnifiedLeftPanel({
             onEditTrigger={onEditTrigger}
             paused={triggersPaused}
             onTogglePause={onTogglePause ?? (() => {})}
+            projects={projects}
+            onProjectsChanged={onProjectsChanged}
           />
         </div>
       )}
@@ -725,6 +795,18 @@ export default function UnifiedLeftPanel({
         <RunShellModal
           session={shellRun.session}
           onClose={() => setShellRun(null)}
+        />
+      )}
+
+      {projectEditor && (
+        <ProjectEditModal
+          initialProject={projectEditor.project}
+          initialName={projectEditor.name}
+          initialMemberPaths={projectEditor.memberPaths}
+          availableRepos={availableRepos}
+          projects={projects}
+          onClose={() => setProjectEditor(null)}
+          onSaved={() => onProjectsChanged?.()}
         />
       )}
 

--- a/frontend/src/lib/groupByProject.test.ts
+++ b/frontend/src/lib/groupByProject.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from "vitest";
+import { groupByProject, type ProjectRef } from "./groupByRepo";
+
+interface Row {
+  id: string;
+  repo: string | null;
+}
+
+const repoOf = (r: Row) => r.repo;
+
+/** Build a verbatim `path → ProjectRef | null` lookup from a members map. */
+function projectOfFrom(
+  members: Record<string, ProjectRef>,
+): (path: string) => ProjectRef | null {
+  return (path) => members[path] ?? null;
+}
+
+const NO_PROJECTS = projectOfFrom({});
+
+describe("groupByProject", () => {
+  it("returns null for an empty list", () => {
+    expect(groupByProject([] as Row[], repoOf, NO_PROJECTS)).toBeNull();
+  });
+
+  it("without any Projet, behaves exactly like the #258 per-path grouping", () => {
+    // AC: sans Projet, les listes se groupent exactement comme aujourd'hui.
+    const rows: Row[] = [
+      { id: "a", repo: "/repos/foo" },
+      { id: "b", repo: "/repos/foo" },
+    ];
+    // One distinct path, no Projet → flat.
+    expect(groupByProject(rows, repoOf, NO_PROJECTS)).toBeNull();
+  });
+
+  it("groups ≥2 distinct paths (no Projet), derived basename labels", () => {
+    // AC vitest: libellé dérivé quand il n'y a pas de Projet.
+    const rows: Row[] = [
+      { id: "z1", repo: "/repos/zebra" },
+      { id: "a1", repo: "/repos/alpha" },
+      { id: "z2", repo: "/repos/zebra" },
+    ];
+    const groups = groupByProject(rows, repoOf, NO_PROJECTS);
+    expect(groups).not.toBeNull();
+    expect(groups!.map((g) => g.label)).toEqual(["alpha", "zebra"]);
+    expect(groups!.every((g) => g.kind === "path")).toBe(true);
+    // Items preserved in input order within each group.
+    expect(groups!.find((g) => g.label === "zebra")!.items.map((i) => i.id)).toEqual([
+      "z1",
+      "z2",
+    ]);
+  });
+
+  it("disambiguates colliding basenames on path groups (minimal suffix)", () => {
+    const rows: Row[] = [
+      { id: "1", repo: "/a/app" },
+      { id: "2", repo: "/b/app" },
+    ];
+    const groups = groupByProject(rows, repoOf, NO_PROJECTS)!;
+    expect(groups.map((g) => g.label).sort()).toEqual(["a/app", "b/app"]);
+  });
+
+  it("collapses a Projet's member paths under its name (single Projet still shows)", () => {
+    // FP: nommer un Projet et y rattacher les deux dépôts → les deux se rangent
+    // sous ce nom. A single Projet over the only two repos still renders (the
+    // "any group is a Projet" clause), it does not flatten.
+    const front = "/repos/front";
+    const back = "/repos/back";
+    const projectOf = projectOfFrom({
+      [front]: { id: "p1", name: "MyProduct" },
+      [back]: { id: "p1", name: "MyProduct" },
+    });
+    const rows: Row[] = [
+      { id: "f", repo: front },
+      { id: "b", repo: back },
+    ];
+    const groups = groupByProject(rows, repoOf, projectOf);
+    expect(groups).not.toBeNull();
+    expect(groups!).toHaveLength(1);
+    expect(groups![0].kind).toBe("project");
+    expect(groups![0].label).toBe("MyProduct");
+    // Both repos' rows are under the one name.
+    expect(groups![0].items.map((i) => i.id)).toEqual(["f", "b"]);
+    // The hover title exposes the member paths.
+    expect(groups![0].title).toBe([back, front].sort().join(", "));
+  });
+
+  it("counts a Projet as one unit — the threshold moved onto projects, not paths", () => {
+    // A Projet grouping two repos + one loose repo = 2 groups → grouped, with the
+    // Projet collapsing its two member paths into a single header.
+    const front = "/repos/front";
+    const back = "/repos/back";
+    const other = "/repos/other";
+    const projectOf = projectOfFrom({
+      [front]: { id: "p1", name: "Product" },
+      [back]: { id: "p1", name: "Product" },
+    });
+    const rows: Row[] = [
+      { id: "f", repo: front },
+      { id: "b", repo: back },
+      { id: "o", repo: other },
+    ];
+    const groups = groupByProject(rows, repoOf, projectOf)!;
+    expect(groups).toHaveLength(2);
+    const project = groups.find((g) => g.kind === "project")!;
+    expect(project.label).toBe("Product");
+    expect(project.items.map((i) => i.id)).toEqual(["f", "b"]);
+    const path = groups.find((g) => g.kind === "path")!;
+    expect(path.label).toBe("other");
+    expect(path.items.map((i) => i.id)).toEqual(["o"]);
+  });
+
+  it("a Projet whose members are absent from the list does not force grouping", () => {
+    // projectOf returns a ref only for member paths actually present. A single
+    // loose repo whose path is in no Projet stays flat.
+    const rows: Row[] = [{ id: "x", repo: "/repos/solo" }];
+    const projectOf = projectOfFrom({
+      "/repos/elsewhere": { id: "p9", name: "Elsewhere" },
+    });
+    expect(groupByProject(rows, repoOf, projectOf)).toBeNull();
+  });
+
+  it("compares membership verbatim — a trailing slash is a different, unowned path", () => {
+    // ADR-0033: two spellings are two paths. `/repos/front/` is not the member
+    // `/repos/front`, so it falls back to a path group.
+    const projectOf = projectOfFrom({
+      "/repos/front": { id: "p1", name: "Product" },
+    });
+    const rows: Row[] = [
+      { id: "a", repo: "/repos/front" },
+      { id: "b", repo: "/repos/front/" },
+    ];
+    const groups = groupByProject(rows, repoOf, projectOf)!;
+    expect(groups).toHaveLength(2);
+    expect(groups.some((g) => g.kind === "project" && g.label === "Product")).toBe(true);
+    expect(groups.some((g) => g.kind === "path")).toBe(true);
+  });
+
+  it("orders groups by label, tie-broken by key; items keep input order", () => {
+    const projectOf = projectOfFrom({
+      "/repos/aaa": { id: "pz", name: "Zeta" },
+    });
+    const rows: Row[] = [
+      { id: "1", repo: "/repos/aaa" }, // Projet "Zeta"
+      { id: "2", repo: "/repos/mmm" }, // path "mmm"
+    ];
+    const groups = groupByProject(rows, repoOf, projectOf)!;
+    // "Zeta" > "mmm"? Code-unit: 'Z'(90) < 'm'(109), so "Zeta" sorts first.
+    expect(groups.map((g) => g.label)).toEqual(["Zeta", "mmm"]);
+  });
+});

--- a/frontend/src/lib/groupByRepo.ts
+++ b/frontend/src/lib/groupByRepo.ts
@@ -105,3 +105,116 @@ export function groupByRepo<T>(
     items: buckets.get(key)!,
   }));
 }
+
+/** A Projet reference: the identity the daemon returns, minimal for grouping. */
+export interface ProjectRef {
+  id: string;
+  name: string;
+}
+
+/**
+ * A group in the "group by Projet" view (#552). Either a **Projet** (several
+ * member repo paths collapse under the human-given name) or a derived **path**
+ * group (an effective repo in no Projet, labelled by basename as before, #258).
+ */
+export interface ProjectGroup<T> {
+  /** Stable identity: `project:<id>` for a Projet, else the raw effective path. */
+  key: string;
+  kind: "project" | "path";
+  /** The effective-repo path for a path group; empty for a Projet group. */
+  repoPath: string;
+  /** Display label: the Projet name, or the derived basename for a path group. */
+  label: string;
+  /** Hover title: the path (path group) or the joined member paths (Projet). */
+  title: string;
+  items: T[];
+}
+
+interface Bucket<T> {
+  key: string;
+  kind: "project" | "path";
+  ref: ProjectRef | null;
+  paths: Set<string>;
+  items: T[];
+}
+
+/**
+ * Group `items` by their **Projet** (#552, ADR-0046), falling back to the #258
+ * per-path grouping for any repo in no Projet. The Projet of a path is resolved
+ * **verbatim** by `projectOf` (a `path → ProjectRef | null` lookup the caller
+ * builds from `GET /projects`); ADR-0033 forbids canonicalising, so two spellings
+ * are two paths.
+ *
+ * Returns `null` — the flat list, byte-identical to no grouping — unless grouping
+ * is warranted. Grouping shows when **there are ≥ 2 distinct groups**, OR **any
+ * group is a named Projet**. The second clause is what makes a single Projet over
+ * all of a list's repos still render under its name (the FP's "se rangent sous ce
+ * nom"); the ≥ 2 clause preserves #258 exactly when no Projet exists — the "seuil
+ * porte désormais sur les projets" of the AC, a Projet counting as one unit that
+ * collapses its member paths.
+ *
+ * Groups are ordered by label (locale-independent code-unit compare), tie-broken
+ * by key, so they never reshuffle as rows arrive. An item whose `repoOf` is
+ * null/empty drops into a single nameless bucket that does not count toward the
+ * threshold (defensive: real daemon data always resolves a concrete path).
+ */
+export function groupByProject<T>(
+  items: T[],
+  repoOf: (item: T) => string | null | undefined,
+  projectOf: (path: string) => ProjectRef | null,
+): ProjectGroup<T>[] | null {
+  const buckets = new Map<string, Bucket<T>>();
+  for (const item of items) {
+    const raw = repoOf(item);
+    const path = raw == null || raw.length === 0 ? "" : raw;
+    const proj = path.length ? projectOf(path) : null;
+    const key = proj ? `project:${proj.id}` : path;
+    let bucket = buckets.get(key);
+    if (!bucket) {
+      bucket = {
+        key,
+        kind: proj ? "project" : "path",
+        ref: proj,
+        paths: new Set(),
+        items: [],
+      };
+      buckets.set(key, bucket);
+    }
+    if (path.length) bucket.paths.add(path);
+    bucket.items.push(item);
+  }
+
+  // Real buckets exclude the defensive nameless one (empty key).
+  const real = [...buckets.values()].filter((b) => b.key.length > 0);
+  const hasProject = real.some((b) => b.kind === "project");
+  if (real.length < 2 && !hasProject) return null;
+
+  // Path-group labels disambiguate among the path groups only (a Projet's paths
+  // are hidden behind its name, so they never force a suffix on a path group).
+  const pathKeys = real.filter((b) => b.kind === "path").map((b) => b.key);
+
+  const groups: ProjectGroup<T>[] = [...buckets.values()].map((b) => {
+    if (b.kind === "project") {
+      return {
+        key: b.key,
+        kind: "project" as const,
+        repoPath: "",
+        label: b.ref ? b.ref.name : "",
+        title: [...b.paths].sort().join(", "),
+        items: b.items,
+      };
+    }
+    return {
+      key: b.key,
+      kind: "path" as const,
+      repoPath: b.key,
+      label: b.key.length > 0 ? repoGroupLabel(b.key, pathKeys) : "",
+      title: b.key,
+      items: b.items,
+    };
+  });
+
+  const cmp = (a: string, b: string) => (a < b ? -1 : a > b ? 1 : 0);
+  groups.sort((a, b) => cmp(a.label, b.label) || cmp(a.key, b.key));
+  return groups;
+}

--- a/frontend/src/lib/projectLookup.ts
+++ b/frontend/src/lib/projectLookup.ts
@@ -1,0 +1,18 @@
+import type { Project } from "../types";
+import type { ProjectRef } from "./groupByRepo";
+
+/**
+ * Build a **verbatim** `path → ProjectRef | null` lookup from the Projets list
+ * (#552). ADR-0033: paths are matched by exact string equality, never
+ * canonicalised — two spellings of a path are two paths. Shared by the Runs and
+ * Triggers panels so both group identically.
+ */
+export function projectLookup(
+  projects: Project[],
+): (path: string) => ProjectRef | null {
+  const byPath = new Map<string, ProjectRef>();
+  for (const p of projects) {
+    for (const path of p.members) byPath.set(path, { id: p.id, name: p.name });
+  }
+  return (path) => byPath.get(path) ?? null;
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -459,6 +459,22 @@ export interface RunListEntry {
 }
 
 /**
+ * A **Projet** (#552, ADR-0046): a named grouping of member repo paths, and the
+ * middle tier of the harness precedence axis. Materialised on demand — a Projet
+ * exists only once a human names a group header or attaches a setting; until then
+ * the lists group by the derived path label (#258). Membership is compared
+ * verbatim (ADR-0033).
+ */
+export interface Project {
+  id: string;
+  name: string;
+  /** The harness this Projet carries, or absent/null when it carries none. */
+  harness?: string | null;
+  /** Member repository paths (the effective-repo keys the lists group by). */
+  members: string[];
+}
+
+/**
  * A persisted Trigger (#160 / ADR-0012): a cron schedule bound to a run
  * template. Cron-only in this slice — `guard_command` is reserved for #161.
  */
@@ -796,7 +812,8 @@ export interface WsMessage {
     | "trigger_fired"
     | "trigger_updated"
     | "trigger_deleted"
-    | "triggers_paused";
+    | "triggers_paused"
+    | "project_changed";
   event?: DaemonEvent;
   pipeline_id?: string;
   path?: string;
@@ -807,6 +824,8 @@ export interface WsMessage {
   run_id?: string | null;
   /** Set on `triggers_paused` messages (#348): the new global pause state. */
   paused?: boolean;
+  /** Set on `project_changed` messages (#552): the mutated Projet's id. */
+  project_id?: string;
 }
 
 export type EditScope = null | "run";

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -40,6 +40,11 @@ export default defineConfig({
       // as `/nodes`/`/stats`/`/fs`: without it a dev GET /audit answers 200 with
       // the SPA.
       '/audit': daemonTarget,
+      // #552: Projets (harness middle tier + group-header pencil). New top-level
+      // `/projects` prefix — same trap as `/audit`: without it a dev
+      // GET/POST /projects answers 200 with the SPA and the pencil would silently
+      // no-op.
+      '/projects': daemonTarget,
     },
   },
   test: {

--- a/scripts/layout-ratchet.sh
+++ b/scripts/layout-ratchet.sh
@@ -8,8 +8,8 @@ cd "$(git rev-parse --show-toplevel)"
 
 # <directory>  <max direct tracked files>
 BASELINES='
-frontend/src/components 141
-crates/pdo-daemon/src 61
+frontend/src/components 143
+crates/pdo-daemon/src 62
 '
 
 fail=0


### PR DESCRIPTION
Récupération + validation de la slice **#552** du PRD #549 (multi-harnais agentique), perdue quand son
Run de validation est mort d'un OOM. Le commit `60fee79` (branche `rescue/552-projet-tier`) a été
cherry-piqué sur `integration/549-multi-harnais` (qui contient déjà #550/#551/#553).

Closes #552.

## Contenu

- **project_store** : SQLite (`projects` + `project_members`, `path` PRIMARY KEY), matérialisé à la
  demande, comparaison **verbatim** (ADR-0033), refus **nommant** le propriétaire avant tout write,
  migration idempotente.
- **harness_resolver** : tier `project` rempli aux **deux** sites de spawn depuis le dépôt **primaire**
  du Run (un secondaire ne le change pas, ADR-0042). Précédence `nœud → Run → Projet → instance →
  plancher claude` (ADR-0046).
- **API `/projects`** (CRUD + membres), refus = **409** nommant le propriétaire ; broadcast
  `project_changed` ; whitelist proxy vite.
- **Frontend** : `groupByProject` (repli #258 dérivé), crayon d'en-tête (`ProjectEditModal`),
  groupement Runs + Triggers par Projet (seuil « ≥ 2 » porté sur les projets), hydratation mount + WS.

## Résolution de conflits (les deux tiers survivent)

Le littéral `HarnessTiers` de `node_spawn.rs` et `node_primitives.rs` : #551 remplit `run`, #552
remplit `project`. La fusion **garde les deux** — un arbitrage qui efface un tier compile mais casse la
précédence en silence. Vérifié aux deux sites + appelants `lib.rs`.

## Ratchet de layout (gate sauté par les validations précédentes)

`scripts/layout-ratchet.sh` : `crates/pdo-daemon/src` **61 → 62** (`project_store.rs`),
`frontend/src/components` **141 → 143** (`ProjectEditModal.tsx` + `.test.tsx`, co-localisation).

## Validation

Tous les gates déterministes verts : `layout-ratchet`, `cargo fmt --check`, `cargo clippy -D warnings`,
`cargo test --workspace` (dont `project_harness_resolution` 3/3, `harness_freeze_resume` 5/5, lib 1952),
et `npm ci && typecheck && lint && build && vitest` (1785).

Trois tests d'intégration Docker restent rouges (`sandbox_observability::liveness_sweep_…`,
`turn_end_autocomplete::{the_setting_gates…, auto_completing_a_code_mutating_node…}`) : **prouvés
environnementaux par contrôle négatif** — ils échouent à l'identique sur la base `36c0107` sans ce
commit, et #552 ne touche aucun code sandbox/liveness.

Trois invariants validés **en pilotant l'UI** (pile isolée démontée) : rien n'est seedé avant nommage ;
le crayon crée/renomme le Projet et regroupe les listes ; un chemin déjà membre est refusé avec le nom
du Projet propriétaire (409 + case désactivée « in <Projet> »).

Pas de touche version/lockfile/CHANGELOG — bump réservé à l'orchestration des quatre slices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)