### PR TITLE
fix(ci): remet main au vert — 4 tests rouges, 2 causes (env global muté entre tests, fixtures périmées par #473)

### DIFF
--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -2118,6 +2118,36 @@ pub struct DaemonConfig {
     /// Same charter as `price_refresh_at_boot`: true in prod, false in the
     /// `tests/common/mod.rs` literals — never a process-global env read (#181).
     pub run_trigger_scheduler_loop: bool,
+    /// **Nested (no-cleanup) mode**: suppress the boot orphan sweep, the periodic
+    /// reaper, boot recovery and the stale detector, leaving the daemon completely
+    /// passive on tmux state. `false` in production unless the env says otherwise
+    /// (`PDO_NODE_ID` — a sub-claude context — or `PDO_DAEMON_NO_CLEANUP`), which
+    /// [`DaemonConfig::from_env`] resolves once at boot via [`nested_daemon_from`].
+    ///
+    /// It is a config field and not an env read at boot precisely because the
+    /// alternative was a **cross-test race** (#181 charter, same as
+    /// `tmux_cmd_override`): a test binary holds several daemons, and the two
+    /// `pty_bridge` tests each wrapped their `spawn` in
+    /// `set_var`/`remove_var("PDO_DAEMON_NO_CLEANUP")`. A sibling's `remove_var`
+    /// landing inside the other's in-flight `serve_with_config` booted that daemon
+    /// with cleanup ARMED; its reaper then killed the out-of-band `pdo-pty-test-*`
+    /// session as an unrecognised name (no TTL on that arm), and the attached
+    /// client printed `[exited]` instead of the echo. Per-daemon config cannot
+    /// interleave.
+    pub nested_daemon: bool,
+}
+
+/// Resolve the daemon's cleanup posture from the two env signals production
+/// carries it on — **pure**, so the truth table is testable without touching
+/// process-global env.
+///
+/// - `PDO_NODE_ID` present at all ⇒ nested. A sub-claude context exports it via
+///   `wrap_with_env`, and its mere presence is the signal (an empty value still
+///   means "we are inside a NodeRun").
+/// - `PDO_DAEMON_NO_CLEANUP` ⇒ nested when set to anything but `""` or `"0"`, the
+///   same truthiness the `PDO_DEBUG_PANIC_*` knobs use.
+pub(crate) fn nested_daemon_from(node_id: Option<&str>, no_cleanup: Option<&str>) -> bool {
+    node_id.is_some() || no_cleanup.is_some_and(|v| !v.is_empty() && v != "0")
 }
 
 impl DaemonConfig {
@@ -2170,6 +2200,13 @@ impl DaemonConfig {
             // No env seam — the loop is core daemon behaviour, only the layer-3
             // test literals opt out (deterministic tick seam).
             run_trigger_scheduler_loop: true,
+            // The ONE place either env var is read. `serve_with_config` consumes
+            // the resolved boolean, so a test can pick the posture per daemon
+            // instead of racing every sibling on a process-global (#181).
+            nested_daemon: nested_daemon_from(
+                std::env::var("PDO_NODE_ID").ok().as_deref(),
+                std::env::var("PDO_DAEMON_NO_CLEANUP").ok().as_deref(),
+            ),
         }
     }
 }
@@ -2259,6 +2296,10 @@ pub async fn serve_with_config(
     // (see `DaemonConfig::run_trigger_scheduler_loop`).
     let run_trigger_scheduler_loop = config.run_trigger_scheduler_loop;
 
+    // Same capture, same reason (see `DaemonConfig::nested_daemon`): the cleanup
+    // posture is decided by the caller, not re-read from process-global env here.
+    let nested_daemon = config.nested_daemon;
+
     let state = Arc::new(AppState {
         db,
         event_tx,
@@ -2297,22 +2338,15 @@ pub async fn serve_with_config(
     // is scoped to its own private socket (`pdo-<port>`) so we can
     // never reach into another daemon's tmux state on the same host.
     //
-    // If we detect that we were spawned from inside a PDO pipeline
-    // (sub-claude context exports `PDO_NODE_ID` via wrap_with_env),
-    // or the operator set `PDO_DAEMON_NO_CLEANUP=1`, suppress every
-    // cleanup pathway. A Tester or Implementer that accidentally runs
-    // `pdo daemon` then can't trigger reaper-based kills, even on
-    // its own socket. The daemon still serves HTTP and accepts
-    // explicit `cleanup_run` calls — only the *automatic* sweeps go away.
-    let nested_daemon = std::env::var("PDO_NODE_ID").is_ok()
-        || std::env::var("PDO_DAEMON_NO_CLEANUP")
-            .map(|v| !v.is_empty() && v != "0")
-            .unwrap_or(false);
-
+    // A nested daemon suppresses every cleanup pathway: a Tester or
+    // Implementer that accidentally runs `pdo daemon` can't trigger
+    // reaper-based kills, even on its own socket. The daemon still serves
+    // HTTP and accepts explicit `cleanup_run` calls — only the *automatic*
+    // sweeps go away. The decision is `config.nested_daemon`, resolved from
+    // env ONCE in `DaemonConfig::from_env`, never re-read here (#181).
     if nested_daemon {
         warn!(
-            "PDO daemon launched from a sub-claude context \
-             (PDO_NODE_ID or PDO_DAEMON_NO_CLEANUP set) — \
+            "PDO daemon in nested (no-cleanup) mode — \
              skipping boot-time orphan sweep and periodic reaper. \
              This daemon will not auto-reap any tmux sessions."
         );
@@ -14322,6 +14356,42 @@ mod tests {
         use std::sync::atomic::{AtomicU16, Ordering};
         static NEXT: AtomicU16 = AtomicU16::new(20000);
         NEXT.fetch_add(1, Ordering::Relaxed)
+    }
+
+    // --- The nested-daemon (no-cleanup) posture resolver ---
+    //
+    // The truth table used to be inlined in `serve_with_config` as two
+    // `std::env::var` reads, which made it untestable except by mutating
+    // process-global env — the very thing that raced the `pty_bridge` tests into
+    // a red CI. Pure fn, so each case is a plain assertion.
+
+    #[test]
+    fn nested_daemon_is_off_when_neither_signal_is_present() {
+        assert!(!nested_daemon_from(None, None));
+    }
+
+    #[test]
+    fn a_sub_claude_context_is_nested_on_the_mere_presence_of_a_node_id() {
+        // `wrap_with_env` exports PDO_NODE_ID; presence is the signal, so even an
+        // empty value means "inside a NodeRun" (the pre-existing `.is_ok()` shape).
+        assert!(nested_daemon_from(Some("implementer"), None));
+        assert!(nested_daemon_from(Some(""), None));
+    }
+
+    #[test]
+    fn the_operator_knob_is_truthy_but_not_merely_set() {
+        assert!(nested_daemon_from(None, Some("1")));
+        assert!(nested_daemon_from(None, Some("yes")));
+        // Same truthiness as the `PDO_DEBUG_PANIC_*` knobs: "" and "0" are OFF, so
+        // `PDO_DAEMON_NO_CLEANUP=0` disarms rather than arms.
+        assert!(!nested_daemon_from(None, Some("")));
+        assert!(!nested_daemon_from(None, Some("0")));
+    }
+
+    #[test]
+    fn either_signal_alone_is_enough() {
+        assert!(nested_daemon_from(Some("worker"), Some("0")));
+        assert!(nested_daemon_from(None, Some("1")));
     }
 
     // --- POST /nodes/parse (#345): single-node YAML → canvas-instantiable spec.

--- a/crates/pdo-daemon/tests/common/mod.rs
+++ b/crates/pdo-daemon/tests/common/mod.rs
@@ -48,15 +48,38 @@ impl TestDaemon {
     where
         F: FnOnce(&Path) -> Result<()>,
     {
-        // When the test suite itself runs inside a PDO node (e.g. an agent
-        // worktree), `PDO_NODE_ID` is exported in the environment and the
-        // daemon under test would consider itself "nested" — silently disabling
-        // the orphan sweep and reaper, and failing every test that asserts on
-        // them. A TestDaemon must behave like a top-level daemon regardless of
-        // where the tests run; nested-mode tests opt back in explicitly via
-        // `PDO_DAEMON_NO_CLEANUP=1`.
-        std::env::remove_var("PDO_NODE_ID");
+        Self::spawn_inner(setup, tmux_cmd_override, false).await
+    }
 
+    /// Spawn a daemon in **nested (no-cleanup) mode**: no boot orphan sweep, no
+    /// periodic reaper, no boot recovery, no stale detector — completely passive on
+    /// tmux state, exactly as when a sub-claude accidentally runs `pdo daemon`.
+    ///
+    /// Two kinds of test need it: one that asserts the passivity itself, and one
+    /// that creates a tmux session **out of band** (no run in the event log), which
+    /// an armed reaper kills on sight as an unrecognised `pdo-*` name — with no TTL
+    /// grace on that arm.
+    ///
+    /// It is a `DaemonConfig` field and not `set_var("PDO_DAEMON_NO_CLEANUP")`
+    /// because the env var is process-global while a test binary holds several
+    /// daemons: the sibling `remove_var` used to land inside another test's
+    /// in-flight `serve_with_config` and boot *that* daemon with cleanup armed.
+    /// See `DaemonConfig::nested_daemon`.
+    pub async fn spawn_nested<F>(setup: F) -> Result<Self>
+    where
+        F: FnOnce(&Path) -> Result<()>,
+    {
+        Self::spawn_inner(setup, Some("exec sleep 600".to_string()), true).await
+    }
+
+    async fn spawn_inner<F>(
+        setup: F,
+        tmux_cmd_override: Option<String>,
+        nested_daemon: bool,
+    ) -> Result<Self>
+    where
+        F: FnOnce(&Path) -> Result<()>,
+    {
         let tempdir = tempfile::tempdir()?;
         setup(tempdir.path())?;
 
@@ -76,6 +99,11 @@ impl TestDaemon {
                 // #450: layer-3 tests drive firing via `run_trigger_tick`; the
                 // background heartbeat's immediate boot tick would race the seam.
                 run_trigger_scheduler_loop: false,
+                // The caller's choice, defaulting to `false` in every other
+                // constructor: a TestDaemon behaves like a TOP-LEVEL daemon (sweeps
+                // armed) whatever env the suite itself was launched with, and
+                // `spawn_nested` is the only way to opt out.
+                nested_daemon,
             },
         )
         .await?;
@@ -100,8 +128,6 @@ impl TestDaemon {
     where
         F: FnOnce(&Path) -> Result<()>,
     {
-        std::env::remove_var("PDO_NODE_ID");
-
         let tempdir = tempfile::tempdir()?;
         setup(tempdir.path())?;
 
@@ -123,6 +149,10 @@ impl TestDaemon {
                 // #450: layer-3 tests drive firing via `run_trigger_tick`; the
                 // background heartbeat's immediate boot tick would race the seam.
                 run_trigger_scheduler_loop: false,
+                // A TestDaemon behaves like a TOP-LEVEL daemon: sweeps armed,
+                // whatever env the suite itself was launched with. The opt-out is
+                // `TestDaemon::spawn_nested`, per daemon.
+                nested_daemon: false,
             },
         )
         .await?;
@@ -151,8 +181,6 @@ impl TestDaemon {
     where
         F: FnOnce(&Path) -> Result<()>,
     {
-        std::env::remove_var("PDO_NODE_ID");
-
         let tempdir = tempfile::tempdir()?;
         setup(tempdir.path())?;
 
@@ -172,6 +200,10 @@ impl TestDaemon {
                 // #450: layer-3 tests drive firing via `run_trigger_tick`; the
                 // background heartbeat's immediate boot tick would race the seam.
                 run_trigger_scheduler_loop: false,
+                // A TestDaemon behaves like a TOP-LEVEL daemon: sweeps armed,
+                // whatever env the suite itself was launched with. The opt-out is
+                // `TestDaemon::spawn_nested`, per daemon.
+                nested_daemon: false,
             },
         )
         .await?;
@@ -203,8 +235,6 @@ impl TestDaemon {
     where
         F: FnOnce(&Path) -> Result<()>,
     {
-        std::env::remove_var("PDO_NODE_ID");
-
         let tempdir = tempfile::tempdir()?;
         setup(tempdir.path())?;
 
@@ -224,6 +254,10 @@ impl TestDaemon {
                 // #450: layer-3 tests drive firing via `run_trigger_tick`; the
                 // background heartbeat's immediate boot tick would race the seam.
                 run_trigger_scheduler_loop: false,
+                // A TestDaemon behaves like a TOP-LEVEL daemon: sweeps armed,
+                // whatever env the suite itself was launched with. The opt-out is
+                // `TestDaemon::spawn_nested`, per daemon.
+                nested_daemon: false,
             },
         )
         .await?;
@@ -244,8 +278,6 @@ impl TestDaemon {
     where
         F: FnOnce(&Path) -> Result<()>,
     {
-        std::env::remove_var("PDO_NODE_ID");
-
         let tempdir = tempfile::tempdir()?;
         setup(tempdir.path())?;
 
@@ -265,6 +297,10 @@ impl TestDaemon {
                 // #450: layer-3 tests drive firing via `run_trigger_tick`; the
                 // background heartbeat's immediate boot tick would race the seam.
                 run_trigger_scheduler_loop: false,
+                // A TestDaemon behaves like a TOP-LEVEL daemon: sweeps armed,
+                // whatever env the suite itself was launched with. The opt-out is
+                // `TestDaemon::spawn_nested`, per daemon.
+                nested_daemon: false,
             },
         )
         .await?;
@@ -294,8 +330,6 @@ impl TestDaemon {
     where
         F: FnOnce(&Path) -> Result<()>,
     {
-        std::env::remove_var("PDO_NODE_ID");
-
         let tempdir = tempfile::tempdir()?;
         setup(tempdir.path())?;
 
@@ -314,6 +348,8 @@ impl TestDaemon {
                 price_refresh_at_boot: true,
                 // #450: deterministic tick seam — no background heartbeat.
                 run_trigger_scheduler_loop: false,
+                // See the sibling literals: armed sweeps, per-daemon opt-out.
+                nested_daemon: false,
             },
         )
         .await?;

--- a/crates/pdo-daemon/tests/common/mod.rs
+++ b/crates/pdo-daemon/tests/common/mod.rs
@@ -380,6 +380,45 @@ impl TestDaemon {
         self.repo_root().to_string_lossy().into_owned()
     }
 
+    /// The Claude Code session id this daemon pinned for `node_id`'s latest
+    /// iteration, read back from its `node_started` payload (#473).
+    ///
+    /// Mandatory for any test that **plants** a transcript. Since #473 the liveness
+    /// sweep resolves a node's transcript by exact filename — `<session_id>.jsonl`
+    /// under the encoded-cwd project dir — instead of picking the newest `.jsonl`
+    /// in that dir, so a fixture written under any other name resolves to nothing
+    /// and the sweep sees "no signal" rather than the planted turn state. The id is
+    /// a fresh uuid per spawn, so reading it back is the only way to know it.
+    ///
+    /// Panics if the node has no `node_started` yet, or none carrying an id (a
+    /// `script` node legitimately has none — it launches no agent and nothing would
+    /// resolve its transcript anyway).
+    pub async fn pinned_session_id(&self, run_id: &str, node_id: &str) -> String {
+        let events: Vec<serde_json::Value> = reqwest::Client::new()
+            .get(format!("{}/runs/{run_id}/events", self.url()))
+            .send()
+            .await
+            .expect("GET /runs/<id>/events")
+            .json()
+            .await
+            .expect("events decode as JSON");
+
+        // The LAST `node_started` for this node: a `restart_node` of the same
+        // iteration pins a fresh id, and the sweep reads back the latest one.
+        events
+            .iter()
+            .filter(|e| e["kind"] == "node_started" && e["node_id"] == node_id)
+            .filter_map(|e| e["payload"]["session_id"].as_str())
+            .next_back()
+            .unwrap_or_else(|| {
+                panic!(
+                    "no node_started with a pinned session_id for {node_id} in run {run_id} \
+                     — plant the transcript AFTER the node has started"
+                )
+            })
+            .to_string()
+    }
+
     /// Tmux socket scoped to this daemon (`tmux -L <name>`). Tests that
     /// spawn or inspect tmux sessions out-of-band must use this socket so
     /// they hit the same tmux server the daemon talks to.

--- a/crates/pdo-daemon/tests/manager_pty.rs
+++ b/crates/pdo-daemon/tests/manager_pty.rs
@@ -55,10 +55,9 @@ async fn manager_pty_ws_roundtrip() {
     // This test exercises the PTY bridge, not the reaper. The manager session
     // below is created out-of-band (its run is absent from the event log), so
     // the daemon's orphan sweep would race the test and kill it — opt out of
-    // all automatic cleanup for this daemon.
-    std::env::set_var("PDO_DAEMON_NO_CLEANUP", "1");
-    let daemon = TestDaemon::spawn(|_repo| Ok(())).await.unwrap();
-    std::env::remove_var("PDO_DAEMON_NO_CLEANUP");
+    // all automatic cleanup for this daemon, per-daemon rather than through the
+    // process-global env var (cf. `TestDaemon::spawn_nested`).
+    let daemon = TestDaemon::spawn_nested(|_repo| Ok(())).await.unwrap();
     let socket = daemon.tmux_socket();
 
     kill_tmux_session(&socket, &session_name);

--- a/crates/pdo-daemon/tests/pty_bridge.rs
+++ b/crates/pdo-daemon/tests/pty_bridge.rs
@@ -45,12 +45,13 @@ async fn pty_ws_roundtrip_echo() {
     }
 
     // This test exercises the PTY bridge, not the reaper. The session below is
-    // created out-of-band (no run in the event log), so the daemon's orphan
-    // sweep would race the test and kill it as unrecognised — opt out of all
-    // automatic cleanup for this daemon.
-    std::env::set_var("PDO_DAEMON_NO_CLEANUP", "1");
-    let daemon = TestDaemon::spawn(|_repo| Ok(())).await.unwrap();
-    std::env::remove_var("PDO_DAEMON_NO_CLEANUP");
+    // created out-of-band (no run in the event log), so an armed orphan sweep
+    // kills it as an unrecognised `pdo-*` name (no TTL on that arm) and the
+    // attached client prints `[exited]` instead of the echo — opt out of all
+    // automatic cleanup for THIS daemon, per-daemon, never via process-global env
+    // (a sibling's `remove_var` used to land inside this `spawn`, cf.
+    // `TestDaemon::spawn_nested`).
+    let daemon = TestDaemon::spawn_nested(|_repo| Ok(())).await.unwrap();
     let socket = daemon.tmux_socket();
 
     let session_name = "pdo-pty-test-echo";
@@ -221,10 +222,10 @@ async fn pty_ws_reaps_tmux_child_on_close() {
     }
 
     // Out-of-band session (no run in the event log) → opt out of the orphan
-    // sweep so it can't race the test and kill the session/client for us.
-    std::env::set_var("PDO_DAEMON_NO_CLEANUP", "1");
-    let daemon = TestDaemon::spawn(|_repo| Ok(())).await.unwrap();
-    std::env::remove_var("PDO_DAEMON_NO_CLEANUP");
+    // sweep so it can't race the test and kill the session/client for us. A
+    // per-daemon flag, not `set_var`: this test's own `remove_var` is what used to
+    // arm the sibling echo test's reaper (cf. `TestDaemon::spawn_nested`).
+    let daemon = TestDaemon::spawn_nested(|_repo| Ok(())).await.unwrap();
     let socket = daemon.tmux_socket();
 
     let session_name = "pdo-pty-test-reap";

--- a/crates/pdo-daemon/tests/sandbox_observability.rs
+++ b/crates/pdo-daemon/tests/sandbox_observability.rs
@@ -311,17 +311,26 @@ fn priced_line(id: &str, req: &str, input: u64) -> String {
 
 /// Plant a transcript for `run_id`'s worktree cwd under `projects_root`, returning
 /// the `.jsonl` path. Optionally back-date it so the stale sweep sees it idle.
+///
+/// `file_name` matters to exactly one reader. Cost and the terminal merge walk the
+/// project dir, so any name will do (`s.jsonl`, and the merge tests assert on that
+/// literal to prove the copy is verbatim). The **liveness sweep** does not: since
+/// #473 it resolves a node's transcript by exact filename (`<session_id>.jsonl`,
+/// the id PDO pinned at spawn — see `TestDaemon::pinned_session_id`), so a fixture
+/// meant for the sweep MUST carry that name or it resolves to nothing and the
+/// sweep's "no signal" masquerades as its verdict.
 fn plant_transcript(
     projects_root: &Path,
     daemon: &TestDaemon,
     run_id: &str,
+    file_name: &str,
     body: &str,
     age: Option<Duration>,
 ) -> PathBuf {
     let enc = encode_working_dir(&worktree_dir(daemon, run_id));
     let proj = projects_root.join(enc);
     std::fs::create_dir_all(&proj).unwrap();
-    let file = proj.join("s.jsonl");
+    let file = proj.join(file_name);
     std::fs::write(&file, body).unwrap();
     if let Some(age) = age {
         filetime::set_file_mtime(
@@ -370,6 +379,7 @@ async fn cost_reads_staging_during_minimal_run() {
         &staging_projects(&daemon, &run_id),
         &daemon,
         &run_id,
+        "s.jsonl",
         &format!("{}\n", priced_line("m1", "r1", 1_000_000)),
         None,
     );
@@ -377,6 +387,7 @@ async fn cost_reads_staging_during_minimal_run() {
         &host_projects(&daemon),
         &daemon,
         &run_id,
+        "s.jsonl",
         &format!("{}\n", priced_line("m2", "r2", 2_000_000)),
         None,
     );
@@ -451,10 +462,15 @@ async fn liveness_sweep_reads_staging_during_minimal_run() {
         "the control needs a live staging, or the host fallback is legitimate"
     );
     write_node_output(&daemon, &control_run, "# out\n");
+    // Named with the id the daemon pinned for THIS node, so the sweep would resolve
+    // it if it read the host home — without that the control is vacuous (#473: an
+    // unresolvable name yields "no signal", not a verdict).
+    let control_sid = daemon.pinned_session_id(&control_run, NODE_ID).await;
     plant_transcript(
         &host_projects(&daemon),
         &daemon,
         &control_run,
+        &format!("{control_sid}.jsonl"),
         FIXTURE_TURN_ENDED,
         // Settled past the anti-bounce window, so only the ROOT can explain a no-op.
         Some(Duration::from_secs(600)),
@@ -480,10 +496,12 @@ async fn liveness_sweep_reads_staging_during_minimal_run() {
         "the staging home must exist during a live sandboxed run"
     );
     write_node_output(&daemon, &run_id, "# out\n");
+    let sid = daemon.pinned_session_id(&run_id, NODE_ID).await;
     plant_transcript(
         &staging_projects(&daemon, &run_id),
         &daemon,
         &run_id,
+        &format!("{sid}.jsonl"),
         FIXTURE_TURN_ENDED,
         Some(Duration::from_secs(600)),
     );
@@ -531,6 +549,7 @@ async fn terminal_merges_staging_into_host_claude_projects() {
         &staging_projects(&daemon, &run_id),
         &daemon,
         &run_id,
+        "s.jsonl",
         &body,
         None,
     );
@@ -595,6 +614,7 @@ async fn double_merge_terminal_then_cleanup_is_identical() {
         &staging_projects(&daemon, &run_id),
         &daemon,
         &run_id,
+        "s.jsonl",
         &body,
         None,
     );

--- a/crates/pdo-daemon/tests/tmux_lifecycle.rs
+++ b/crates/pdo-daemon/tests/tmux_lifecycle.rs
@@ -13,9 +13,8 @@ use std::time::Duration;
 use common::TestDaemon;
 use pdo_daemon::tmux_session_manager;
 
-/// Tests in this file mutate process-wide env vars
-/// (PDO_REAPER_*_SECS, PDO_DAEMON_NO_CLEANUP) and assert on
-/// timing-sensitive reaper behaviour. They MUST run serially or one test will
+/// Tests in this file mutate process-wide env vars (PDO_REAPER_*_SECS) and assert
+/// on timing-sensitive reaper behaviour. They MUST run serially or one test will
 /// see another's values. (The tmux command override is per-daemon config now —
 /// `TestDaemon::spawn`'s harmless `sleep` default — not a process-global env.)
 static SERIAL: Mutex<()> = Mutex::new(());
@@ -274,12 +273,15 @@ async fn orphan_sweep_at_boot_kills_stale_session() {
     std::env::remove_var(tmux_session_manager::REAPER_INTERVAL_SECS_ENV);
 }
 
-/// Layer 3a: A daemon spawned with `PDO_DAEMON_NO_CLEANUP=1` (mirrors
-/// what happens when a sub-claude accidentally runs `pdo daemon` —
-/// `PDO_NODE_ID` is set in its env by `wrap_with_env`) MUST NOT reap
-/// any orphan session, even one its own socket can see. Pinned by #86
-/// follow-up: the only safe behaviour for a nested daemon is to be
+/// Layer 3a: A daemon in nested mode — what an operator gets from
+/// `PDO_DAEMON_NO_CLEANUP=1`, and what a sub-claude accidentally running
+/// `pdo daemon` gets from the `PDO_NODE_ID` that `wrap_with_env` exported into its
+/// env — MUST NOT reap any orphan session, even one its own socket can see. Pinned
+/// by #86 follow-up: the only safe behaviour for a nested daemon is to be
 /// completely passive on tmux state.
+///
+/// The posture is injected as config here; that either env var *produces* this
+/// posture is the separate, purely-tested claim of `nested_daemon_from`.
 #[tokio::test]
 // Holds the process-wide `serial_guard()` MutexGuard across `.await`s to keep
 // the env-var-sensitive reaper tests from racing each other — intentional, and
@@ -294,9 +296,14 @@ async fn nested_daemon_skips_orphan_sweep_and_reaper() {
 
     std::env::set_var(tmux_session_manager::REAPER_TTL_SECS_ENV, "0");
     std::env::set_var(tmux_session_manager::REAPER_INTERVAL_SECS_ENV, "1");
-    std::env::set_var("PDO_DAEMON_NO_CLEANUP", "1");
 
-    let daemon = TestDaemon::spawn(seed).await.unwrap();
+    // The posture is per-daemon config (`DaemonConfig::nested_daemon`), not the
+    // env var: with the reaper interval forced to 1 s, a sibling test clearing a
+    // process-global `PDO_DAEMON_NO_CLEANUP` mid-`spawn` would arm this daemon's
+    // reaper and delete the very orphan the assertion below expects to survive.
+    // The env → posture mapping is pinned separately and purely by
+    // `pdo_daemon`'s `nested_daemon_from` unit tests.
+    let daemon = TestDaemon::spawn_nested(seed).await.unwrap();
     let socket = daemon.tmux_socket();
 
     let orphan_session = "pdo-20260101-120000-aaaaaaa-orphan-iter-1";
@@ -312,14 +319,13 @@ async fn nested_daemon_skips_orphan_sweep_and_reaper() {
 
     assert!(
         tmux_has_session(&socket, orphan_session),
-        "nested daemon must NOT sweep orphans (PDO_DAEMON_NO_CLEANUP=1)"
+        "nested daemon must NOT sweep orphans"
     );
 
     // Cleanup
     let _ = std::process::Command::new("tmux")
         .args(["-L", &socket, "kill-session", "-t", orphan_session])
         .output();
-    std::env::remove_var("PDO_DAEMON_NO_CLEANUP");
     std::env::remove_var(tmux_session_manager::REAPER_TTL_SECS_ENV);
     std::env::remove_var(tmux_session_manager::REAPER_INTERVAL_SECS_ENV);
 }

--- a/crates/pdo-daemon/tests/turn_end_autocomplete.rs
+++ b/crates/pdo-daemon/tests/turn_end_autocomplete.rs
@@ -256,16 +256,26 @@ async fn set_autocomplete(daemon_url: &str, on: bool) {
 
 /// Plant a Claude Code transcript for `working_dir` under the daemon's (temp)
 /// home, back-dated `quiet` so the sweep sees the write as settled.
+///
+/// `session_id` is the id PDO pinned for the node at spawn
+/// ([`TestDaemon::pinned_session_id`]), and it names the file. That is not a
+/// cosmetic detail: since #473 the sweep resolves a node's transcript by exact
+/// filename (`<session_id>.jsonl`) rather than by picking the newest `.jsonl` in
+/// the encoded-cwd dir, so a fixture planted under any other name resolves to
+/// nothing and every assertion here degrades into "the sweep had no signal" —
+/// which is indistinguishable from "the sweep read it and decided to do nothing".
+/// Naming it as production would is what keeps the no-op assertions falsifiable.
 fn plant_transcript(
     home: &std::path::Path,
     working_dir: &std::path::Path,
+    session_id: &str,
     contents: &str,
     quiet: Duration,
 ) {
     let encoded = stale_detector::encode_working_dir(working_dir);
     let proj = home.join(".claude").join("projects").join(encoded);
     std::fs::create_dir_all(&proj).unwrap();
-    let jsonl = proj.join("session.jsonl");
+    let jsonl = proj.join(format!("{session_id}.jsonl"));
     std::fs::write(&jsonl, contents).unwrap();
     filetime::set_file_mtime(
         &jsonl,
@@ -326,9 +336,11 @@ async fn a_long_silent_tool_call_never_kills_the_run() {
     // Outputs ALREADY valid, so only the turn-state guard stands between this
     // node and a completion it must not get.
     write_valid_outputs(&worktree);
+    let sid = daemon.pinned_session_id(&run_id, NODE_ID).await;
     plant_transcript(
         &home,
         &worktree,
+        &sid,
         FIXTURE_IN_TOOL_CALL,
         Duration::from_secs(300),
     );
@@ -385,7 +397,8 @@ async fn an_idle_transcript_with_incomplete_outputs_is_no_longer_stale() {
 
     let worktree = home.join(".pdo/runs").join(&run_id).join("worktree");
     // No outputs written: incomplete, the old `Detection::Stale` arm.
-    plant_transcript(&home, &worktree, "{}\n", Duration::from_secs(600));
+    let sid = daemon.pinned_session_id(&run_id, NODE_ID).await;
+    plant_transcript(&home, &worktree, &sid, "{}\n", Duration::from_secs(600));
 
     daemon.run_stale_detection_tick().await;
 
@@ -500,7 +513,8 @@ async fn the_setting_gates_completion_and_takes_effect_on_the_next_sweep() {
 
     let worktree = home.join(".pdo/runs").join(&run_id).join("worktree");
     write_valid_outputs(&worktree);
-    plant_transcript(&home, &worktree, FIXTURE_TURN_ENDED, settled());
+    let sid = daemon.pinned_session_id(&run_id, NODE_ID).await;
+    plant_transcript(&home, &worktree, &sid, FIXTURE_TURN_ENDED, settled());
 
     // --- box unchecked: nothing happens (AC8) ---
     daemon.run_stale_detection_tick().await;
@@ -824,7 +838,8 @@ async fn auto_completing_a_code_mutating_node_merges_its_commit() {
     // and forgot to call `pdo complete` leaves behind.
     std::fs::write(sub_worktree.join("IMPLEMENTED.md"), "the work\n").unwrap();
     write_valid_outputs(&worktree);
-    plant_transcript(&home, &sub_worktree, FIXTURE_TURN_ENDED, settled());
+    let sid = daemon.pinned_session_id(&run_id, NODE_ID).await;
+    plant_transcript(&home, &sub_worktree, &sid, FIXTURE_TURN_ENDED, settled());
 
     daemon.run_stale_detection_tick().await;
 


### PR DESCRIPTION
`main` est rouge depuis au moins trois merges (#507, #394, #508) et cela bloquait une release. Cette PR
la remet au vert. **Quatre tests rouges, deux causes indépendantes, aucun défaut produit.**

La CI en fail-fast cachait l'inventaire réel : elle s'arrêtait au premier binaire rouge, donc les
quatre étapes suivantes du job `Rust` (`clippy`, `fmt`, `smoke.sh`) et deux tests de
`turn_end_autocomplete` **n'avaient jamais tourné**. Selon l'ordre des binaires, le log montrait
tantôt `pty_ws_roundtrip_echo`, tantôt `liveness_sweep_...` — deux causes derrière un seul symptôme.

## Cause A — un env var global muté en concurrence entre tests frères

`pty_ws_roundtrip_echo` : `serve_with_config` lisait `PDO_DAEMON_NO_CLEANUP` dans l'env **global du
processus** au boot, alors que les deux tests de `pty_bridge` encadraient chacun leur spawn d'un
`set_var`/`remove_var` sur cette même variable. Le `remove_var` de l'un tombe à l'intérieur du
`serve_with_config` de l'autre, resté en vol sur un `.await` : ce daemon démarre avec le nettoyage
**armé**. Son reaper voit une session créée hors-bande (aucun Run dans le journal) → `UnrecognisedName`
→ **ce bras tue sans TTL ni délai de grâce**, d'où le `[exited]` au lieu de l'écho. Le premier tick de
l'intervalle se déclenchant immédiatement, la fenêtre est systématique : 100 % sur la CI, ~10 % en
local.

Correctif : `DaemonConfig` porte `nested_daemon`, du même statut que `tmux_cmd_override` (#181) — la
charte du type dit déjà que ces décisions sont par-daemon pour que deux daemons du même processus ne se
marchent pas dessus. L'entrelacement **ne peut plus exister structurellement** ; aucun `sleep`, aucune
garde sérielle.

**Seul changement de code de production de la PR, et le contrat opérateur est inchangé.** `from_env()`
reste le seul lecteur des deux variables, et la table de vérité est équivalente
(`env::var().ok().is_some()` ≡ `is_ok()`, `is_some_and(p)` ≡ `.map(p).unwrap_or(false)`). Les gardes de
la liveness et du scheduler de Triggers sont inchangées à l'octet : un daemon qui ne pose pas le
drapeau garde détecteur, scheduler, boot recovery et reaper armés. Vérifié sur le binaire construit
dans les deux directions (avec le drapeau : `reaper.last_sweep_at` = `null` ; sans : horodaté). Bénéfice
de fond : cette table de vérité n'avait **aucun** test, elle en a quatre maintenant.

## Cause B — #473 a périmé les tests qui plantent un transcript

`liveness_sweep_reads_staging_during_minimal_run` + les deux `turn_end_autocomplete` : #473 fait
résoudre le transcript par **nom de fichier exact** `<session_id>.jsonl` au lieu du `.jsonl` le plus
récent du répertoire encodé. `spawn_node` épingle un uuid pour tout nœud non-`script`, y compris sous
le harnais de test qui remplace `claude` par `sleep`. Les fixtures plantaient `session.jsonl` /
`s.jsonl` : plus rien ne résolvait, `transcript_tail()` rendait `None`, le balayage n'avait **aucun**
signal, le nœud restait `running`.

Ce ne sont pas les tests qui avaient raison : en production `claude --session-id <uuid>` écrit bien
`<uuid>.jsonl`. Les fixtures lisent désormais l'id épinglé dans la charge utile `node_started` et
plantent sous **le nom que la production écrirait** — plus fidèles, pas plus permissives.

### Le vrai poisson : trois assertions de non-action étaient devenues VIDES

`a_long_silent_tool_call_never_kills_the_run`,
`an_idle_transcript_with_incomplete_outputs_is_no_longer_stale` et le contrôle négatif « un Run
sandboxé vivant n'est pas jugé sur le transcript hôte » passaient parce que **rien ne résolvait**, pas
parce que le balayage lisait et s'abstenait : un vert indiscernable d'une panne totale. Elles mordent à
nouveau. Corollaire : **#473 a été livré sans aucune couverture couche 3a de la résolution par
identité** ; le test liveness corrigé la fournit.

## Preuves

Contrôles négatifs joués dans les deux sens, pas seulement « ça passe » :

- Cause A : en retirant la garde d'env du seul test échouant, l'échec revient **5/5** avec la signature
  `[exited]` **byte-identique** à celle de la CI.
- Cause B : nom remis à `s.jsonl` → l'échec d'origine se reproduit à l'identique ; fixture du contrôle
  négatif déplacée dans le staging → le nœud **complète** et le contrôle échoue. Les deux assertions
  peuvent donc toujours échouer.

Répétitions : `pty_bridge` 18/20 avant → **75/75** après ; `turn_end_autocomplete` 0/20 → **20/20** ;
`sandbox_observability` déterministe avant → **20/20**. Durées effondrées, signe corroborant :
`sandbox_observability` 30,55 s → 3,63 s, `turn_end_autocomplete` 20,26 s → 0,53 s — c'étaient des
attentes de complétions qui ne venaient jamais.

Les cinq étapes du job `Rust`, toutes lancées : `check`, `test --workspace --no-fail-fast`
(**49 binaires, 2190 passés, 0 échoué, 0 ignored**), `clippy -D warnings`, `fmt --check`, `smoke.sh` —
toutes vertes. `layout-ratchet.sh` vert, aucun fichier frontend touché.

## Divulgations

- **Aucun `#[ignore]`, aucun test supprimé, aucune assertion affaiblie** — le `0 ignored` sur 2190 est
  le reçu.
- `tmux_lifecycle::nested_daemon_skips_orphan_sweep_and_reaper` ne pilote plus la posture par l'env var
  mais par la config : il ne prouve donc plus le câblage env → posture. C'est le seul endroit où une
  couverture diminue, compensé par quatre tests purs sur la fonction de décision (zéro avant) plus la
  sonde live. Re-couvrir ce câblage en couche 3a demanderait de réintroduire une mutation d'env
  globale, ce qui est précisément la cause A.

7 fichiers, tous sous `crates/pdo-daemon/`. Aucun `Cargo.toml`, `Cargo.lock`, `CHANGELOG.md` ni
`package.json` : cette PR ne bouge pas la version.
