### PR TITLE
fix(#369): stop mermaid flicker — stabilise markdown render props so poll ticks don't remount the diagram (1.28.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "1.28.0"
+version = "1.28.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "1.28.0"
+version = "1.28.1"
 license = "MIT"
 
 [workspace.dependencies]

--- a/frontend/src/components/MarkdownArtifactModal.mermaidRemount.test.tsx
+++ b/frontend/src/components/MarkdownArtifactModal.mermaidRemount.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useEffect } from "react";
+
+// #369 (residual flicker, after #532): a poll-driven parent re-render must NOT
+// remount the mermaid diagram. NodeDetailPanel polls node I/O and re-renders the
+// modal on every tick (passing a brand-new `onClose` each time). Before the fix,
+// MarkdownArtifactModal rebuilt its `components` / `remarkPlugins` INLINE on every
+// render, so react-markdown saw a fresh `components.pre` identity and remounted the
+// routed <MermaidDiagram>. A freshly mounted diagram starts at `svg === null`,
+// flashing its empty `aria-busy` frame before re-rendering the SVG — that blank
+// frame IS the reported blink.
+//
+// This suite uses the REAL react-markdown (so the `components.pre` routing runs end
+// to end) but mocks <MermaidDiagram> to a bare mount counter. jsdom cannot execute
+// mermaid's render path, so counting the mock's mounts is the deterministic,
+// white-box measurement of the bug the reproduce doc (section B) prescribes.
+
+let mountCount = 0;
+vi.mock("./MermaidDiagram", () => {
+  function MermaidDiagramStub({ source }: { source: string }) {
+    useEffect(() => {
+      mountCount++;
+    }, []);
+    return <div data-testid="mermaid-stub">{source}</div>;
+  }
+  return { default: MermaidDiagramStub };
+});
+
+const fetchArtifactMock = vi.fn();
+const fetchNodeIOMock = vi.fn();
+
+vi.mock("../api", () => ({
+  fetchArtifact: (...args: unknown[]) => fetchArtifactMock(...args),
+  fetchNodeIO: (...args: unknown[]) => fetchNodeIOMock(...args),
+  artifactUrl: (runId: string, path: string) =>
+    `/runs/${runId}/artifact?path=${encodeURIComponent(path)}`,
+}));
+
+import MarkdownArtifactModal from "./MarkdownArtifactModal";
+import type { ArtifactSource } from "./MarkdownArtifactModal";
+import type { FileInfo } from "../api";
+
+function makeFile(path: string, exists = true): FileInfo {
+  return { path, exists, size: 0, frontmatter: null };
+}
+
+const SOURCE: ArtifactSource = {
+  kind: "static",
+  files: [makeFile("artifacts/node/iter-1/out/output.md")],
+};
+
+describe("MarkdownArtifactModal mermaid remount (#369)", () => {
+  beforeEach(() => {
+    mountCount = 0;
+    fetchArtifactMock.mockReset();
+    fetchNodeIOMock.mockReset();
+    fetchArtifactMock.mockResolvedValue(
+      "# Diagram\n\n```mermaid\nflowchart TD\n  A --> B\n```\n",
+    );
+  });
+
+  it("mounts the diagram once and keeps it mounted across poll-driven re-renders", async () => {
+    const { rerender } = render(
+      <MarkdownArtifactModal
+        runId="run-1"
+        portName="out"
+        source={SOURCE}
+        onClose={() => {}}
+      />,
+    );
+
+    // The fenced block is routed to <MermaidDiagram> once the artifact resolves.
+    await screen.findByTestId("mermaid-stub");
+    expect(mountCount).toBe(1);
+
+    // Simulate several poll ticks: NodeDetailPanel re-renders the modal with a
+    // fresh `onClose` (`() => setModal(null)`) on every tick.
+    for (let i = 0; i < 5; i++) {
+      rerender(
+        <MarkdownArtifactModal
+          runId="run-1"
+          portName="out"
+          source={SOURCE}
+          onClose={() => {}}
+        />,
+      );
+      await act(async () => {});
+    }
+
+    // The diagram was never unmounted+remounted → no blank frame → no flicker.
+    expect(mountCount).toBe(1);
+    expect(screen.getByTestId("mermaid-stub")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/MarkdownArtifactModal.tsx
+++ b/frontend/src/components/MarkdownArtifactModal.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { X, ChevronLeft, ChevronRight } from "lucide-react";
 import Markdown from "react-markdown";
+import type { Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { fetchArtifact, fetchNodeIO, artifactUrl } from "../api";
 import type { FileInfo } from "../api";
@@ -8,6 +9,16 @@ import type { IterationInfo, PortType } from "../types";
 import type { Element } from "hast";
 import ImageLightbox from "./ImageLightbox";
 import MermaidDiagram from "./MermaidDiagram";
+
+// #369 (residual flicker): react-markdown remounts a custom component whenever the
+// `components` entry at its position changes IDENTITY. NodeDetailPanel polls node
+// I/O and re-renders the modal on every tick; rebuilding `remarkPlugins`/`components`
+// inline handed react-markdown a fresh `components.pre` each time, remounting the
+// routed <MermaidDiagram> — which resets to its empty `aria-busy` frame before
+// re-rendering the SVG (the blink). Hoisting `remarkPlugins` to module scope (and
+// memoising `components` per instance below) keeps those identities stable, so a
+// poll-driven re-render no longer remounts the diagram.
+const REMARK_PLUGINS = [remarkGfm];
 
 export type ArtifactSource =
   | { kind: "static"; files: FileInfo[] }
@@ -177,6 +188,56 @@ export default function MarkdownArtifactModal({
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [handleKeyDown]);
 
+  // #369: memoise the markdown component overrides so their identities survive a
+  // poll-driven re-render (see the module-scope note on REMARK_PLUGINS). `setLightbox`
+  // is a stable useState setter, so an empty dep array is correct and keeps the
+  // `pre`/`img` references constant for the modal's whole lifetime — no remount of
+  // the routed <MermaidDiagram>, hence no flicker.
+  const markdownComponents = useMemo<Components>(
+    () => ({
+      img: ({ src, alt }) => {
+        const url = typeof src === "string" ? src : undefined;
+        return (
+          <img
+            src={url}
+            alt={alt ?? ""}
+            className="cursor-zoom-in rounded transition-opacity hover:opacity-90"
+            onClick={() => {
+              // A markdown-embedded <img> is rendered in isolation by
+              // react-markdown — there is no collected list to page through, so it
+              // is an honest single-image set.
+              if (url) setLightbox({ images: [url], index: 0 });
+            }}
+          />
+        );
+      },
+      // A ```mermaid fenced block parses to
+      // <pre><code class="language-mermaid">src</code></pre>. Detect it on the
+      // child <code> and unwrap to a rendered SVG diagram; every other block falls
+      // through to a plain <pre>. We override `pre` (not `code`) to avoid emitting a
+      // <div> inside a <pre> (invalid nesting). Regular ```ts / ```bash fences are
+      // untouched. (#240)
+      pre: ({ node, children, ...rest }) => {
+        const child = node?.children?.[0];
+        const isMermaid =
+          child?.type === "element" &&
+          child.tagName === "code" &&
+          ((child.properties?.className as string[]) ?? []).includes(
+            "language-mermaid",
+          );
+        if (isMermaid) {
+          const codeEl = child as Element;
+          const text = codeEl.children?.[0];
+          const source =
+            text && text.type === "text" ? text.value.replace(/\n$/, "") : "";
+          return <MermaidDiagram source={source} />;
+        }
+        return <pre {...rest}>{children}</pre>;
+      },
+    }),
+    [],
+  );
+
   const frontmatter = file?.frontmatter;
   const bodyContent = content ? stripFrontmatter(content) : null;
 
@@ -341,52 +402,8 @@ export default function MarkdownArtifactModal({
               ) : bodyContent ? (
                 <div className="artifact-markdown prose-sm">
                   <Markdown
-                    remarkPlugins={[remarkGfm]}
-                    components={{
-                      img: ({ src, alt }) => {
-                        const url = typeof src === "string" ? src : undefined;
-                        return (
-                          <img
-                            src={url}
-                            alt={alt ?? ""}
-                            className="cursor-zoom-in rounded transition-opacity hover:opacity-90"
-                            onClick={() => {
-                              // A markdown-embedded <img> is rendered in
-                              // isolation by react-markdown — there is no
-                              // collected list to page through, so it is an
-                              // honest single-image set.
-                              if (url) setLightbox({ images: [url], index: 0 });
-                            }}
-                          />
-                        );
-                      },
-                      // A ```mermaid fenced block parses to
-                      // <pre><code class="language-mermaid">src</code></pre>.
-                      // Detect it on the child <code> and unwrap to a rendered
-                      // SVG diagram; every other block falls through to a plain
-                      // <pre>. We override `pre` (not `code`) to avoid emitting a
-                      // <div> inside a <pre> (invalid nesting). Regular ```ts /
-                      // ```bash fences are untouched. (#240)
-                      pre: ({ node, children, ...rest }) => {
-                        const child = node?.children?.[0];
-                        const isMermaid =
-                          child?.type === "element" &&
-                          child.tagName === "code" &&
-                          (
-                            (child.properties?.className as string[]) ?? []
-                          ).includes("language-mermaid");
-                        if (isMermaid) {
-                          const codeEl = child as Element;
-                          const text = codeEl.children?.[0];
-                          const source =
-                            text && text.type === "text"
-                              ? text.value.replace(/\n$/, "")
-                              : "";
-                          return <MermaidDiagram source={source} />;
-                        }
-                        return <pre {...rest}>{children}</pre>;
-                      },
-                    }}
+                    remarkPlugins={REMARK_PLUGINS}
+                    components={markdownComponents}
                   >
                     {bodyContent}
                   </Markdown>

--- a/frontend/src/components/NodeDetailPanel.tsx
+++ b/frontend/src/components/NodeDetailPanel.tsx
@@ -286,6 +286,13 @@ export default function NodeDetailPanel({
       : { kind: "static", files: modal.files };
   }, [modal, node.iterations, node.node_id, selectedIter]);
 
+  // #369: a stable `onClose` (setModal is a stable useState setter, so no deps).
+  // The panel re-renders on every I/O poll tick; an inline `() => setModal(null)`
+  // handed the modal a fresh prop each tick, re-rendering it needlessly. A constant
+  // identity lets the modal's memoised markdown props do their job (no diagram
+  // remount, no flicker).
+  const closeModal = useCallback(() => setModal(null), []);
+
   return (
     <aside className="flex h-full flex-col bg-bg-2">
       {/* Header */}
@@ -687,7 +694,7 @@ export default function NodeDetailPanel({
           portName={modal.portName}
           portType={modal.portType}
           source={modalSource}
-          onClose={() => setModal(null)}
+          onClose={closeModal}
         />
       )}
 


### PR DESCRIPTION
## Problème (#369)

Les diagrammes **mermaid** clignotent dans les outputs et gênent la lecture. Reliquat après #532 : `NodeDetailPanel` poll les I/O du nœud et re-render `MarkdownArtifactModal` à chaque tick (5 s sur un nœud terminal). Le modal reconstruisait ses `components`/`remarkPlugins` react-markdown **inline** à chaque render → react-markdown voyait une nouvelle identité de `components.pre` et **remontait** le `<MermaidDiagram>` routé. Un diagramme fraîchement monté démarre à `svg===null` et affiche sa trame vide `aria-busy` avant de repeindre le SVG — c'est ce **blanc** qui clignote.

## Correctif

- `remarkPlugins` hissé en constante module-scope + `components` mémoïsé (`useMemo`, deps stables) → les deux identités survivent aux re-renders de poll.
- `onClose` stabilisé dans `NodeDetailPanel` via `useCallback` pour ne pas re-render le modal inutilement.
- Test de régression : `<MermaidDiagram>` mocké en compteur de montage, modal piloté sur 5 re-renders façon poll → assert **1 seul montage** (6 avant le fix). Le vrai react-markdown exerce le routage `pre` de bout en bout.

## Validation

- `npm run build` (tsc -b + vite build) → OK. `vitest run …mermaidRemount.test.tsx` → 1 passed.
- Repro navigateur réel (Playwright/chromium, vrai `MarkdownArtifactModal` + vrai `MermaidDiagram`, mermaid exécuté dans le navigateur) : **0 remount** sur 6 ticks côté patché contre **6** sur le motif pré-fix, sans `pageerror`. Diagramme intact après polling.

Patch 1.28.0 → **1.28.1** (bugfix, aucune casse ; ADR-0013 `strict` et la dégradation gracieuse ne sont pas touchés).

Closes #369

🤖 Generated with [Claude Code](https://claude.com/claude-code)