### PR TITLE
fix(#417): la stat LOC et le diff de Run s'ancrent sur le point de fork gelé, plus sur le HEAD errant (1.28.2)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -299,6 +299,8 @@ Parallélisation : les `doc-only` sont gratis-parallèles ; les `code-mutating` 
 
 Le merge-back suppose que le tip de la branche pipeline reste un **ancêtre** de la branche du nœud (fast-forward). Un nœud qui **se rebase** casse l'invariant. Le garde est **structurel**, keyé sur la **base de spawn** (`base_sha`) : si la divergence est l'histoire du Run réécrite par le nœud lui-même, le merge-back se **résout en faveur du nœud** (commit de merge, rien ne devient inatteignable, événement nommé — jamais silencieux) ; si la base est périmée ou inconnue, conflit + échec comme avant (résoudre perdrait du travail arrivé entre-temps). Aucun garde de **contenu** ne marche — mesuré : blobs, chemins et tree-sémantique refusent tous les trois l'occurrence qu'ils devaient sauver (ADR-0036 §3).
 
+**À ne pas confondre** : cette **base de spawn (`base_sha`)** est le fork *sous-worktree ← branche pipeline*, et elle **avance** au fil des merge-backs des nœuds sœurs. C'est un axe distinct du **point de fork du Run (`fork_sha`)** (§*Parallélisation entre Runs*), qui est le fork *branche du Run ← branche source*, **figé** à la création et jamais avancé — la base de la stat LOC / du diff de Run (#417). Réutiliser `base_sha` pour la stat surchargerait silencieusement un terme critique au merge-back : ce sont deux forks, deux durées de vie.
+
 ---
 
 ## Merge — nœud first-class
@@ -407,6 +409,8 @@ Plusieurs Runs peuvent tourner simultanément sur le même repo. Conventions ant
 - Sous-worktrees : `<repo>/.pdo/runs/<run-id>/nodes/<node-id>/iter-<N>/`.
 - `<run-id>` = slug `<timestamp>-<short-uuid>`, lisible et unique.
 
+**Point de fork du Run (`fork_sha`)** *(terme, #417)* : le commit d'où `pdo/run-<run-id>` est **coupé** à la création, **gelé** dans l'événement `RunStarted` (résolu contre le ref local, sans fetch — même posture d'immuabilité que `source_branch`, le harnais gelé et `RepoPin.sha`, ADR-0042/0030). C'est la **base stable en trois-points** de la stat LOC et du diff de Run : figé à la création, il ne peut plus être déplacé par un `HEAD` du checkout partagé qui erre ensuite (le bug #417). Absent (Run d'avant #417) ⇒ repli sur `source_branch`, puis `HEAD`. _Éviter_ : le confondre avec **`base_sha`** (la base de spawn *sous-worktree ← branche pipeline*, ADR-0036 — un autre fork, qui **avance** au fil des merge-backs) ; « HEAD » comme base (c'est précisément l'ancre errante que #417 supprime) ; « checkout partagé » comme référence de diff ; le `source_branch` **vivant** comme cible de diff (même classe d'instabilité que le bug — l'opérateur peut le rebaser/supprimer).
+
 **Nom placeholder** *(terme)* : nom lisible posé par le daemon au spawn, déterministe et immédiat, garanti présent même pour un Run prompt-less. _Éviter_ : nom temporaire, titre par défaut.
 
 **Nom descriptif** *(terme)* : nom posé best-effort par le Pipeline Manager dans son propre tour, une fois qu'il sait ce que fait le Run ; remplace le placeholder s'il aboutit, sans jamais le supprimer (un Run a toujours un nom). **Désactivable par-Run et par-Trigger** (défaut d'instance `default_auto_name`, résolu `stored → env PDO_DEFAULT_AUTO_NAME → true`, ADR-0015, #338) : désactivé, le Run garde son nom placeholder et le manager n'est pas instruit de renommer. _Éviter_ : nom final, rename automatique.
@@ -417,7 +421,7 @@ Quatre métriques dans le panneau d'info (#100, #272) :
 
 - **Durée** : wall-clock entre `started_at` et `completed_at`, dérivée à l'affichage (jamais persistée), live tant que le Run est vivant. Un Run `Paused` continue de compter.
 - **Sessions de nœud lancées** : compte **cumulatif** des démarrages de session, re-spawns inclus, manager exclu. À distinguer de la gauge « sessions vivantes » du cap.
-- **LOC** : `git diff --numstat` en **trois-points** depuis le point de fork (stable même si `main` avance), **exclut `.pdo/`**. Live-only : « — » pour un Run archivé (branche supprimée), à distinguer de « 0 » (diff vide).
+- **LOC** : `git diff --numstat` en **trois-points** depuis le **point de fork du Run (`fork_sha`)** — jamais depuis le `HEAD` du checkout partagé (#417) —, stable même si `main` avance **et** si le checkout est garé sur une branche divergente, **exclut `.pdo/`**. Live-only : « — » pour un Run archivé (branche supprimée), à distinguer de « 0 » (diff vide).
 - **Coût (est.)** : **estimation** — pas une facture — dérivée à la lecture des transcripts Claude Code locaux, jamais persistée. Agrège toutes les sessions du Run. Un modèle non tarifé ⇒ borne basse signalée « † » (`partial`), et `unpriced_models` (#425) nomme les familles concernées — champ rendu dans le tooltip du † et présent sur `GET /runs/:id` comme, unioné par bucket, sur `GET /stats/cost`. Survit à l'archivage (les transcripts restent). Modèle de calcul et dédup → ADR-0022 ; table de prix → ADR-0034.
 **Table de prix embarquée / fetchée / manuelle / résolue** *(termes, ADR-0034)* : l'**embarquée** est le plancher compilé dans le binaire ; la **fetchée** est écrite par le daemon seul depuis models.dev, hors du chemin de lecture ; la **manuelle** est écrite par l'humain seul ; la **résolue** est la fusion **par clé de famille** avec précédence `manuel → fetché → embarquée`. Un écrivain par fichier ; rien n'est jamais seedé. Depuis #528, la **résolue** est aussi **exposée en lecture** sur `GET /stats/cost` (tableau `resolved` : tier gagnant + `$/MTok` par famille, rendu dans l'onglet Stats → Cost à côté de « Sync costs ») — additif, lecture seule, même `PriceTable` que le fold de coût, donc jamais divergente du tarificateur (#373). _Éviter_ : « surcharge de prix », « merge des tables », « prix seedés », « prix live » (la lecture est toujours locale).
 
@@ -427,7 +431,7 @@ Modale **Stats** : agrégats **transverses** filtrables par période (runs/erreu
 
 ### Diff de Run (surface de relecture)
 
-Section **Diff** repliable du panneau d'info (#116, #376) — distincte de la stat LOC et du diff sémantique. Trois portées : **diff de Run** (trois-points depuis le fork, exclut `.pdo/`, mêmes bornes que LOC pour que « compté » et « montré » coïncident), **diff de nœud** (deux-points, connu-imparfait — la base fidèle par nœud est différée), **Run archivé** (« Diff not preserved for archived runs », à distinguer de « No changes »).
+Section **Diff** repliable du panneau d'info (#116, #376) — distincte de la stat LOC et du diff sémantique. Trois portées : **diff de Run** (trois-points depuis le **point de fork du Run (`fork_sha`)**, jamais depuis le `HEAD` du checkout partagé — #417 —, exclut `.pdo/`, mêmes bornes que LOC pour que « compté » et « montré » coïncident), **diff de nœud** (deux-points, connu-imparfait — la base fidèle par nœud est différée), **Run archivé** (« Diff not preserved for archived runs », à distinguer de « No changes »).
 
 ### Contrôles de Run (niveau Run)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "1.28.1"
+version = "1.28.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "1.28.1"
+version = "1.28.2"
 license = "MIT"
 
 [workspace.dependencies]

--- a/crates/pdo-daemon/src/event_log.rs
+++ b/crates/pdo-daemon/src/event_log.rs
@@ -801,6 +801,15 @@ pub struct RunState {
     pub sandbox_prep: Option<SandboxPrepState>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_branch: Option<String>,
+    /// The commit `pdo/run-<id>` was cut from at Run start — the run's fork point,
+    /// FROZEN here from the `RunStarted` payload (#417), same immutability posture as
+    /// `source_branch`/`harness`/`RepoPin.sha`. The stable 3-dot base for the LOC stat
+    /// and the Run diff, so a shared checkout whose HEAD later wanders can no longer
+    /// displace the merge-base and inflate the count. `None` ⇒ a pre-#417 Run (payload
+    /// omits the key) → fall back to `source_branch`, then `HEAD`. NB: distinct from the
+    /// per-node `NodeStarted.base_sha` (sub-worktree ← pipeline branch, ADR-0036).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fork_sha: Option<String>,
     /// The harness chosen at Run creation (#551, ADR-0046), **frozen** here from the
     /// `RunStarted` payload — the middle tier of the precedence chain
     /// `nœud → Run → Projet → instance → plancher (claude)`. Immutable, exactly like
@@ -879,6 +888,7 @@ impl RunState {
             sandbox_image_raw_error: None,
             sandbox_prep: None,
             source_branch: None,
+            fork_sha: None,
             harness: None,
             triggered_by: None,
             pipeline_id: None,
@@ -1329,6 +1339,13 @@ fn apply_run_event(state: &mut RunState, event: &Event) {
                 }
                 if let Some(sb) = payload.get("source_branch").and_then(|v| v.as_str()) {
                     state.source_branch = Some(sb.to_string());
+                }
+                // #417: the FROZEN fork point, projected the same way as `source_branch`.
+                // The create chokepoint writes this key for every new Run (a resolvable
+                // `source_ref`); an absent key (every pre-#417 Run) leaves `None`, and the
+                // LOC/diff base then falls back to `source_branch`, then `HEAD`.
+                if let Some(fs) = payload.get("fork_sha").and_then(|v| v.as_str()) {
+                    state.fork_sha = Some(fs.to_string());
                 }
                 // #551 (ADR-0046): the FROZEN Run harness, projected the same way as
                 // `source_branch`. The create chokepoint only writes this key for a

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -7547,6 +7547,22 @@ async fn create_run_inner(
 
     let run_id = event_log::generate_run_id();
 
+    // #417: freeze the run's fork point NOW, from the same local `source_ref` that
+    // `create_worktree` will cut the run branch from below, so a later HEAD move in the
+    // shared checkout can never displace the LOC/diff base and sweep in phantom line
+    // counts. `rev_parse_verified` resolves the LOCAL ref (no fetch, `^{commit}`-verified),
+    // mirroring `resolve_secondary_pins` — and, like it, resolving BEFORE `append_event`
+    // keeps the current event ordering (no reorder around `create_worktree`). A resolve
+    // failure is non-fatal: it degrades to the `source_branch`/`HEAD` fallback ladder at
+    // read time (`run_diff_base`) and must never block run creation.
+    let fork_sha = match crate::worktree_ops::rev_parse_verified(&run_repo_root, source_ref) {
+        Ok(sha) => Some(sha),
+        Err(e) => {
+            warn!("could not resolve fork_sha for run {run_id} from {source_ref}: {e}");
+            None
+        }
+    };
+
     // #410 CHOKEPOINT: resolve the effective sandbox mode ONCE, here, where the JSON,
     // multipart, and trigger-fire create paths converge — just before the mode is
     // frozen into `RunStarted`. `req.sandbox` already carries either the explicit
@@ -7704,6 +7720,13 @@ async fn create_run_inner(
     }
     if let Some(ref branch) = effective_source_branch {
         run_payload["source_branch"] = serde_json::json!(branch);
+    }
+    // #417: FREEZE the resolved fork point into `RunStarted`, next to `source_branch`.
+    // Written whenever the local ref resolved (every new Run in practice); a resolve
+    // failure leaves it absent → the read-side `run_diff_base` ladder recovers via
+    // `source_branch`, then `HEAD`. Absent key on replay → `None` (back-compat).
+    if let Some(ref fs) = fork_sha {
+        run_payload["fork_sha"] = serde_json::json!(fs);
     }
     // #551 (ADR-0046): FREEZE the Run's harness choice into `RunStarted`, the same
     // immutability posture as `sandbox` above — editing the pipeline or the instance
@@ -9985,15 +10008,19 @@ async fn run_diff(
         }
     };
 
-    if event_log::project(&events).is_none() {
-        return (StatusCode::NOT_FOUND, "run not found").into_response();
-    }
+    let run_state = match event_log::project(&events) {
+        Some(s) => s,
+        None => return (StatusCode::NOT_FOUND, "run not found").into_response(),
+    };
 
     let pipeline_branch = format!("pdo/run-{run_id}");
-    // Three-dot (merge-base = fork point) so main's advance after the fork does
-    // not surface as phantom deletions; `:(exclude).pdo/` drops the blackboard
-    // artefacts. Mirrors compute_run_loc (see lib.rs ~10985). #376.
-    let range = format!("HEAD...{pipeline_branch}");
+    // #417: base on the Run's frozen fork point (`run_diff_base`: `fork_sha` → recorded
+    // `source_branch` → `HEAD`), NOT the shared checkout's wandering HEAD — otherwise a
+    // checkout parked on a divergent branch sweeps in phantom files. Three-dot (merge-base
+    // = fork point) so main's advance after the fork does not surface as phantom deletions;
+    // `:(exclude).pdo/` drops the blackboard artefacts. Mirrors compute_run_loc. #376/#417.
+    let base = run_diff_base(&run_state);
+    let range = format!("{base}...{pipeline_branch}");
     let output = match std::process::Command::new("git")
         .args(["diff", &range, "--", ".", ":(exclude).pdo/"])
         .current_dir(&state.repo_root)
@@ -14472,16 +14499,38 @@ fn parse_numstat(stdout: &str) -> event_log::LocStat {
     }
 }
 
-/// Lines changed for a Run, from `git diff --numstat HEAD...pdo/run-<id>` with
+/// The base ref for a Run's "what changed" diff (#417): the frozen fork SHA, else the
+/// recorded source branch (legacy runs — the 3-dot merge-base still recovers the fork
+/// point), else `HEAD` (baseless legacy runs — today's behaviour, kept byte-identical).
+/// Uniform 3-dot at the call sites: because `pdo/run-<id>` is cut from `fork_sha` and only
+/// gains commits on top, `merge-base(fork_sha, run) == fork_sha`, so the same range form is
+/// correct for all three tiers and never re-introduces the wandering-HEAD defect for a run
+/// that recorded a base. NB: this is the Run's fork point, NOT the per-node
+/// `NodeStarted.base_sha` (sub-worktree ← pipeline branch, ADR-0036).
+fn run_diff_base(run_state: &event_log::RunState) -> &str {
+    run_state
+        .fork_sha
+        .as_deref()
+        .or(run_state.source_branch.as_deref())
+        .unwrap_or("HEAD")
+}
+
+/// Lines changed for a Run, from `git diff --numstat <base>...pdo/run-<id>` with
 /// `.pdo/` excluded (issue #100). Returns `None` when the diff is uncomputable
 /// (git missing, not a repo, run branch gone after cleanup) so the UI renders
 /// "—"; a successful but empty diff returns `Some({0, 0, 0})` → UI "0".
 ///
-/// Uses a **three-dot** range so the base is the merge-base (the run's fork
-/// point): the count stays correct even as `main` advances past the fork
-/// (two-dot would drift and report later main commits as deletions).
-fn compute_run_loc(repo_root: &std::path::Path, run_id: &str) -> Option<event_log::LocStat> {
-    let range = format!("HEAD...pdo/run-{run_id}");
+/// `base_ref` is the Run's stable fork point (`run_diff_base`, #417), not the shared
+/// checkout's `HEAD`. Uses a **three-dot** range so the base is the merge-base (the
+/// run's fork point): the count stays correct even as `main` advances past the fork
+/// (two-dot would drift and report later main commits as deletions), AND a checkout
+/// parked on a divergent branch can no longer displace it (#417).
+fn compute_run_loc(
+    repo_root: &std::path::Path,
+    run_id: &str,
+    base_ref: &str,
+) -> Option<event_log::LocStat> {
+    let range = format!("{base_ref}...pdo/run-{run_id}");
     let output = std::process::Command::new("git")
         // `:(exclude).pdo/` is a literal pathspec argv element (no shell). `.pdo/`
         // is gitignored here, but the exclusion is defensive for external target
@@ -14510,7 +14559,11 @@ fn augment_run_state_from_disk(
     // LOC is independent of the run YAML: the run branch lives in `repo_root`,
     // not the run dir, so a missing/unparseable YAML must not suppress an
     // otherwise-valid LOC. Compute it before the YAML early-return below.
-    run_state.loc = compute_run_loc(repo_root, &run_state.run_id);
+    // #417: base the diff on the Run's frozen fork point (`run_diff_base`), not the
+    // shared checkout's wandering HEAD. Resolve the base into an owned `String` first so
+    // the immutable borrow of `run_state` ends before the mutable assignment to `.loc`.
+    let base = run_diff_base(run_state).to_string();
+    run_state.loc = compute_run_loc(repo_root, &run_state.run_id, &base);
     // Estimated cost (#272), likewise independent of the run YAML: it reads the
     // Claude Code transcripts under `projects_root` (the #408 seam — the staged
     // home while a sandboxed Run is live, `~/.claude/projects/` otherwise), not
@@ -19443,7 +19496,9 @@ mod tests {
         git(&["commit", "-m", "run changes"]);
         git(&["checkout", &default_branch]);
 
-        let loc = compute_run_loc(repo, run_id).expect("branch present -> Some");
+        // Tier-3 legacy path: no fork_sha/source_branch recorded, so the base is "HEAD".
+        // This test never parks HEAD off the fork line, so the behaviour is unchanged (#417).
+        let loc = compute_run_loc(repo, run_id, "HEAD").expect("branch present -> Some");
         assert_eq!(
             loc,
             event_log::LocStat {
@@ -19459,7 +19514,7 @@ mod tests {
         std::fs::write(repo.join("other.txt"), "x\ny\n").unwrap();
         git(&["add", "other.txt"]);
         git(&["commit", "-m", "advance main"]);
-        let loc_after = compute_run_loc(repo, run_id).expect("still Some");
+        let loc_after = compute_run_loc(repo, run_id, "HEAD").expect("still Some");
         assert_eq!(
             loc_after, loc,
             "three-dot base stays at the fork point as HEAD advances"
@@ -19468,7 +19523,7 @@ mod tests {
         // Branch gone (cleanup) -> None -> UI renders "—" (not "0").
         git(&["branch", "-D", &branch]);
         assert!(
-            compute_run_loc(repo, run_id).is_none(),
+            compute_run_loc(repo, run_id, "HEAD").is_none(),
             "missing run branch -> None"
         );
     }
@@ -19488,12 +19543,98 @@ mod tests {
             .unwrap();
         assert!(out.status.success());
         assert_eq!(
-            compute_run_loc(repo, run_id).expect("branch present -> Some"),
+            compute_run_loc(repo, run_id, "HEAD").expect("branch present -> Some"),
             event_log::LocStat {
                 insertions: 0,
                 deletions: 0,
                 files_changed: 0,
             }
+        );
+    }
+
+    #[test]
+    fn compute_run_loc_ignores_parked_checkout_and_uses_run_source_branch() {
+        // #417 regression: the shared checkout is parked on a divergent branch that
+        // forks BEFORE the run's fork point. The pre-fix `HEAD...` range collapsed the
+        // merge-base onto the common ancestor and swept in every commit the fork branch
+        // gained since (the phantom). Basing the diff on the Run's own fork point
+        // (`default_branch`, standing in for the frozen `fork_sha`) must report ONLY the
+        // run's own 1-line change, regardless of where HEAD is parked.
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path();
+        init_test_repo(repo); // c0 = "initial" (README.md) on the default branch
+        let git = |args: &[&str]| {
+            let out = std::process::Command::new("git")
+                .args(args)
+                .current_dir(repo)
+                .output()
+                .unwrap();
+            assert!(
+                out.status.success(),
+                "git {args:?} failed: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+            out
+        };
+
+        // `init_test_repo` is a bare `git init` → recover the default branch name.
+        let default_branch =
+            String::from_utf8_lossy(&git(&["rev-parse", "--abbrev-ref", "HEAD"]).stdout)
+                .trim()
+                .to_string();
+
+        // A divergent branch off c0 with its own commit — the head the operator parks on.
+        git(&["checkout", "-b", "integration/prd-403-sandbox"]);
+        std::fs::write(repo.join("sandbox.txt"), "sandbox\n").unwrap();
+        git(&["add", "sandbox.txt"]);
+        git(&["commit", "-m", "parked: unrelated work"]);
+
+        // Advance the default branch two commits PAST the fork — this is the phantom
+        // payload the buggy merge-base would sweep in.
+        git(&["checkout", &default_branch]);
+        std::fs::write(repo.join("file_a.txt"), "a1\na2\na3\n").unwrap();
+        git(&["add", "file_a.txt"]);
+        git(&["commit", "-m", "main: +3 in file_a"]);
+        std::fs::write(repo.join("file_b.txt"), "b1\nb2\n").unwrap();
+        git(&["add", "file_b.txt"]);
+        git(&["commit", "-m", "main: +2 in file_b"]); // <- the run's fork point
+
+        // Cut the run branch from the default-branch tip and add ONE real line.
+        let run_id = "loc-parked-fork";
+        let branch = format!("pdo/run-{run_id}");
+        git(&["checkout", "-b", &branch]);
+        std::fs::write(repo.join("run_only.txt"), "the only real change\n").unwrap();
+        git(&["add", "run_only.txt"]);
+        git(&["commit", "-m", "run change"]);
+
+        // PARK the checkout on the divergent branch (the exact #417 / #451 condition).
+        git(&["checkout", "integration/prd-403-sandbox"]);
+
+        // Based on the run's fork point, ONLY run_only.txt counts — never file_a/file_b.
+        // Under the pre-fix `HEAD...` the parked checkout would inflate this to {6,0,3}.
+        assert_eq!(
+            compute_run_loc(repo, run_id, &default_branch).expect("branch present -> Some"),
+            event_log::LocStat {
+                insertions: 1,
+                deletions: 0,
+                files_changed: 1,
+            },
+            "parked divergent HEAD must not displace the fork-point base"
+        );
+
+        // Doc-only variant: a run cut at the fork tip with NO commit changed nothing.
+        // With HEAD still parked on the divergent branch, the honest answer is {0,0,0}
+        // (the triage's "even doc-only, zero files" case), not the phantom.
+        let doc_run = "loc-parked-doc-only";
+        git(&["branch", &format!("pdo/run-{doc_run}"), &default_branch]);
+        assert_eq!(
+            compute_run_loc(repo, doc_run, &default_branch).expect("branch present -> Some"),
+            event_log::LocStat {
+                insertions: 0,
+                deletions: 0,
+                files_changed: 0,
+            },
+            "a doc-only run reads 0, not the parked-checkout phantom"
         );
     }
 
@@ -26196,6 +26337,122 @@ edges: []
         assert!(
             !body.contains("advanced_on_main"),
             "diff must not contain main's post-fork content as a removed line: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_diff_ignores_parked_checkout_via_frozen_fork_sha() {
+        // #417 (layer-2 mirror of the layer-3a `run_diff_range` test): with a `fork_sha`
+        // frozen in `RunStarted`, `GET /runs/<id>/diff` must base on the fork point even
+        // when the shared checkout's HEAD is parked on a divergent branch that forks
+        // BEFORE it. RED under the old `HEAD...` range (the divergent branch's pre-fork
+        // files render as a phantom); GREEN with `run_diff_base`.
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path();
+        init_test_repo(repo);
+
+        let git = |dir: &std::path::Path, args: &[&str]| {
+            let out = std::process::Command::new("git")
+                .args(args)
+                .current_dir(dir)
+                .output()
+                .unwrap();
+            assert!(
+                out.status.success(),
+                "git {args:?} failed: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+            out
+        };
+        let default_branch =
+            String::from_utf8_lossy(&git(repo, &["rev-parse", "--abbrev-ref", "HEAD"]).stdout)
+                .trim()
+                .to_string();
+
+        // Divergent branch off c0 with a phantom-carrying commit; then advance the
+        // default branch past the fork.
+        git(repo, &["checkout", "-b", "wip/parked"]);
+        std::fs::write(repo.join("phantom.rs"), "fn phantom() {}\n").unwrap();
+        git(repo, &["add", "phantom.rs"]);
+        git(repo, &["commit", "-m", "parked: unrelated work"]);
+        git(repo, &["checkout", &default_branch]);
+        std::fs::write(repo.join("main_advance.rs"), "fn advanced_on_main() {}\n").unwrap();
+        git(repo, &["add", "main_advance.rs"]);
+        git(repo, &["commit", "-m", "advance main after divergence"]);
+
+        // Freeze the fork point = current default-branch tip.
+        let fork_sha =
+            String::from_utf8_lossy(&git(repo, &["rev-parse", "HEAD"]).stdout)
+                .trim()
+                .to_string();
+
+        let run_id = "diff-parked-fork";
+        let state = test_state_with_dir(repo).await;
+        // Seed a RunStarted carrying the frozen `fork_sha` (the fix's mechanism), plus a
+        // node so the projection is realistic.
+        let run_started = event_log::Event {
+            id: None,
+            run_id: run_id.into(),
+            ts: event_log::now_iso(),
+            kind: event_log::EventKind::RunStarted,
+            node_id: None,
+            iter: None,
+            payload: Some(serde_json::json!({
+                "pipeline_name": "test-pipe",
+                "input": "test",
+                "fork_sha": fork_sha,
+                "node_defs": [
+                    { "id": "impl-1", "node_type": "code-mutating", "inputs": [], "outputs": [] }
+                ],
+                "edges": []
+            })),
+        };
+        append_event(&state, &run_started).await.unwrap();
+
+        // Cut the run branch/worktree from the fork point.
+        let wt_dir = repo.join(".pdo/runs").join(run_id).join("worktree");
+        let pipeline_branch = format!("pdo/run-{run_id}");
+        create_worktree(repo, &wt_dir, &pipeline_branch, &default_branch).unwrap();
+
+        // The run's only real change.
+        std::fs::write(wt_dir.join("run_file.rs"), "fn run_work() {}\n").unwrap();
+        git(&wt_dir, &["add", "run_file.rs"]);
+        git(&wt_dir, &["commit", "-m", "run work"]);
+
+        // PARK the shared checkout on the divergent branch (the #417 / #451 condition).
+        git(repo, &["checkout", "wip/parked"]);
+
+        let app = build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/runs/{run_id}/diff"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = String::from_utf8(
+            axum::body::to_bytes(resp.into_body(), usize::MAX)
+                .await
+                .unwrap()
+                .to_vec(),
+        )
+        .unwrap();
+
+        assert!(
+            body.contains("run_file.rs") && body.contains("fn run_work()"),
+            "diff must contain the run's own change: {body}"
+        );
+        // The phantom: the parked branch's pre-fork file. RED under `HEAD...`.
+        assert!(
+            !body.contains("phantom.rs"),
+            "parked divergent HEAD must not add a phantom file to the diff: {body}"
+        );
+        assert!(
+            !body.contains("main_advance.rs"),
+            "main's post-fork file must not appear either (three-dot base): {body}"
         );
     }
 

--- a/crates/pdo-daemon/tests/run_diff_range.rs
+++ b/crates/pdo-daemon/tests/run_diff_range.rs
@@ -81,12 +81,25 @@ fn git_init_with_commit(repo: &std::path::Path) -> anyhow::Result<()> {
 }
 
 async fn create_run(daemon_url: String, target_repo: String) -> Option<String> {
+    create_run_on_branch(daemon_url, target_repo, None).await
+}
+
+async fn create_run_on_branch(
+    daemon_url: String,
+    target_repo: String,
+    source_branch: Option<&str>,
+) -> Option<String> {
     // #470: the target repo is required at the create boundary (ADR-0033).
-    let body = serde_json::json!({
+    let mut body = serde_json::json!({
         "pipeline": PIPELINE_NAME,
         "input": "go",
         "target_repo": target_repo,
     });
+    // #417: naming the source branch makes the daemon freeze `fork_sha` from that exact
+    // local ref at creation — the fork point the diff base must anchor on.
+    if let Some(branch) = source_branch {
+        body["source_branch"] = serde_json::json!(branch);
+    }
     let resp = reqwest::Client::new()
         .post(format!("{daemon_url}/runs"))
         .json(&body)
@@ -159,5 +172,89 @@ async fn run_diff_uses_three_dot_and_excludes_pdo_over_real_daemon() {
     assert!(
         !body.contains("artifact.txt"),
         "blackboard excluded: {body}"
+    );
+}
+
+#[tokio::test]
+async fn run_diff_ignores_parked_checkout_over_real_daemon() {
+    // #417 (layer-3a): the whole bug, end-to-end. The shared checkout is parked on a
+    // branch that diverges BEFORE the Run's fork point, so the pre-fix `HEAD...` range
+    // collapses the merge-base onto the common ancestor and sweeps in every commit `main`
+    // gained since. With `fork_sha` frozen at creation, `GET /runs/<id>/diff` anchors on
+    // the fork point and shows ONLY the Run's own change. RED under the old code.
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+    let repo = daemon.repo_root().to_path_buf();
+
+    let git = |dir: &std::path::Path, args: &[&str]| {
+        let out = std::process::Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .output()
+            .unwrap();
+        assert!(
+            out.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        out
+    };
+
+    // c0 (the seed "init" commit) is the common ancestor. Branch the operator's parked
+    // head off it BEFORE advancing main, so its merge-base with the Run is c0.
+    let c0 = String::from_utf8_lossy(&git(&repo, &["rev-parse", "HEAD"]).stdout)
+        .trim()
+        .to_string();
+    git(&repo, &["branch", "wip/parked", &c0]);
+
+    // Advance main two commits PAST c0 — the phantom payload the buggy merge-base sweeps in.
+    std::fs::write(repo.join("file_a.rs"), "fn a() {}\n").unwrap();
+    git(&repo, &["add", "file_a.rs"]);
+    git(&repo, &["commit", "-m", "main: +file_a"]);
+    std::fs::write(repo.join("file_b.rs"), "fn b() {}\n").unwrap();
+    git(&repo, &["add", "file_b.rs"]);
+    git(&repo, &["commit", "-m", "main: +file_b"]); // main tip = the Run's fork point
+
+    // Create the Run forked from `main` (freezes fork_sha = current main tip).
+    let run_id = create_run_on_branch(daemon.url(), daemon.target_repo(), Some("main"))
+        .await
+        .expect("run created");
+
+    let wt_dir = repo.join(".pdo/runs").join(&run_id).join("worktree");
+    for _ in 0..100 {
+        if wt_dir.exists() {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+    assert!(
+        wt_dir.exists(),
+        "pipeline worktree should exist for {run_id}"
+    );
+
+    // The Run's only real change, on the run branch (via the daemon-created worktree).
+    std::fs::write(wt_dir.join("run_file.rs"), "fn run_work() {}\n").unwrap();
+    git(&wt_dir, &["add", "run_file.rs"]);
+    git(&wt_dir, &["commit", "-m", "run work"]);
+
+    // PARK the shared checkout on the divergent branch — the exact #417 / #451 condition.
+    git(&repo, &["checkout", "wip/parked"]);
+
+    let body = reqwest::Client::new()
+        .get(format!("{}/runs/{run_id}/diff", daemon.url()))
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+
+    assert!(
+        body.contains("run_file.rs") && body.contains("fn run_work()"),
+        "diff must contain the Run's own change: {body}"
+    );
+    // The phantom under `HEAD...`: main's commits since c0, swept in by the parked HEAD.
+    assert!(
+        !body.contains("file_a.rs") && !body.contains("file_b.rs"),
+        "parked divergent HEAD must not sweep in main's pre-fork files: {body}"
     );
 }


### PR DESCRIPTION
## Contexte

`Closes #417`

La stat « Lines changed » et le diff de Run diffaient en `HEAD...pdo/run-<id>`, où `HEAD` est le working head du **checkout partagé** que l'opérateur déplace librement. Checkout garé sur une branche divergente → la merge-base 3-points s'effondre sur un vieil ancêtre commun et le diff aspire tout ce que la branche source a gagné depuis (comptes fantômes, même pour un Run doc-only qui n'a rien écrit).

## Correctif

Geler le **point de fork** du Run à la création et diffuser depuis lui.

- `event_log.rs` : champ additif `RunState.fork_sha` (serde skip-if-none → payloads legacy inchangés), initialisé dans `new`, projeté dans l'arm `RunStarted` juste après `source_branch`.
- `lib.rs` (`create_run`) : résolution de `fork_sha` via `rev_parse_verified` sur le même `source_ref` local que `create_worktree`, avant `append_event`. Échec de résolution non-fatal (`warn!` → `None`), jamais bloquant.
- `lib.rs` : sélecteur partagé `run_diff_base` (`fork_sha → source_branch → HEAD`) ; `compute_run_loc` prend la base résolue en argument, `run_diff` réutilise le `RunState` projeté.
- `CONTEXT.md` : terme de glossaire « Point de fork du Run (`fork_sha`) », garde « À ne pas confondre » `base_sha` ⇄ `fork_sha`.

## Tests (ADR-0004)

- Layer 1 : `compute_run_loc_ignores_parked_checkout_and_uses_run_source_branch` (+ variante doc-only `{0,0,0}`).
- Layer 2 : `run_diff_ignores_parked_checkout_via_frozen_fork_sha`.
- Layer 3a : `run_diff_ignores_parked_checkout_over_real_daemon`.
- Suite daemon complète : **2273 passed / 0 failed**, clippy `-D warnings` clean.

## Validation agentique (FP-417, niveau 5)

Dans l'UI réelle, checkout garé sur `wip/parked` : la stat lit `+0 −0 0 files` (Run frais) et `+1 −0 1 file` (un vrai commit), jamais le fantôme `+200`. Contre-factuel vérifié : l'ancienne formule `HEAD...` imprime encore le fantôme → le scénario reproduit bien le bug.

## Hors périmètre

`node_diff` (défaut sœur) et le fait que `run_diff` tourne dans `state.repo_root` (pré-existant) → tickets de suivi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)