### PR TITLE
feat(#302): assistant IA d'authoring des templates de bibliothèque — 1.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ ascendante** : la casse se signale ici et par un bump majeur, jamais en gardant 
 morts. Seule contrainte non négociable — les **données historiques restent lisibles** : un Run
 archivé s'ouvre et se chiffre quelle que soit la version qui a écrit son payload.
 
+## 1.31.0
+
+Rien de cassant, aucune migration. **Assistant IA d'authoring des templates de bibliothèque**
+(#302, ADR-0048). Un glyphe Bot « Pipeline assistant » apparaît dans la barre d'outils du canvas
+**uniquement sur un template de bibliothèque** (jamais sur un Run) ; il ouvre un onglet **Assistant**
+qui attache une session `claude` amorcée, streamée dans le terminal embarqué.
+
+Notes de version qui ne se déduisent pas du titre : la session s'ouvre avec pour **cwd le dossier
+des templates** (`.pdo/library/pipelines`), pas la pipeline courante — c'est délibéré (ADR-0048),
+les templates voisins servent d'exemples few-shot et le canvas↔fichier est réconcilié par le store
+disk-first à la sauvegarde. Conséquence assumée : ouvert sur une pipeline de travail sans jumelle en
+bibliothèque, l'assistant décrit un dossier vide (job d'authoring *from scratch*). Cycle de vie
+**create-on-open / reap-on-leave** : la session est créée au premier affichage de l'onglet et
+**récoltée dès qu'on le quitte** (changement d'onglet ou fermeture du panneau) ; la ré-ouverture
+ré-attache la même session (create-if-absent).
+
 ## 1.30.0
 
 **Changement de comportement observable (durcissement sécurité).** Le contrôle d'`Origin`

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -619,6 +619,7 @@ Chaque NodeRun = **une session tmux détachée** créée par le daemon, contenan
 - NodeRun : `pdo-<run-id>-<node-id>-iter-<N>`.
 - Manager : `pdo-mgr-<run-id>`.
 - Shell de run : `pdo-shell-<run-id>`.
+- Assistant de bibliothèque : `pdo-libassist-<pipeline-id>`.
 
 Les sessions sont invisibles par défaut, survivent au crash de l'UI ou du daemon (récupération au redémarrage).
 
@@ -627,6 +628,12 @@ Les sessions sont invisibles par défaut, survivent au crash de l'UI ou du daemo
 **Shell de run** *(terme)* : un **bash interactif ad-hoc** (pas une REPL Claude Code) spawné à la demande dans `pdo-shell-<run-id>`, cwd = worktree pipeline. Sert à inspecter/déboguer un Run post-mortem. _Éviter_ : « session » tout court (= NodeRun), « manager » (= REPL conversationnelle), « terminal » (= le pont d'attache).
 
 Visible uniquement sur les Runs terminaux non-archivés dont le worktree existe (*reapable*). **Un seul shell par Run**, create-if-absent, persistant (sans TTL), tué par `cleanup_run`. Exempt du cap. `resume_run` le tue best-effort avant de ré-armer le scheduler (un writer concurrent casserait le merge). Détails → ADR-0021.
+
+### Assistant de bibliothèque — copilote d'authoring (ADR-0048)
+
+**Assistant de bibliothèque** *(terme, #302)* : une **REPL `claude`** design-time spawnée à la demande dans `pdo-libassist-<pipeline-id>`, cwd = le dossier des templates du scope (`~/.pdo/library/pipelines/` ou `<repo>/.pdo/library/pipelines/`). L'utilisateur **décrit** un changement en langage naturel ; l'agent produit/édite le YAML (+ `<id>.prompts/`), montre un diff, et **écrit au save** via `POST /library/pipelines` (validation `POST /nodes/parse`). _Éviter_ : « manager » (= REPL attachée à un **Run**, `POST /runs/<id>/commands`) — l'assistant n'est attaché à **aucun Run** et n'émet **aucune** commande ; son seul effet est d'écrire un fichier template.
+
+Keyé sur la **pipeline** (pas un Run). Cycle de vie **create-on-open / reap-on-leave** : spawné à l'ouverture de l'onglet **Assistant**, reapé (`DELETE /sessions/<id>/libassist`) dès qu'on quitte l'onglet. `claude` ne sort pas sur EOF, donc la session survit à une coupure WS ; la fermeture est explicite. **Jamais reapé par le sweep** (pas de Run à keyer — `parse_session_name` connaît le préfixe `libassist-`, `decide_one` le garde toujours) et **sans TTL**. Exempt du cap. Prompt système primé (format YAML + endpoints). Détails → ADR-0048.
 
 ### Cap de sessions concurrentes (admission control)
 
@@ -747,7 +754,7 @@ PDO est un **atelier de production de code** ; la conception de pipelines est un
 
 ### Toolbar — bouton info pipeline
 
-L'icône `i` ouvre un panneau **info pipeline** : nom, statut, variables, bouton favoriter. Si la pipeline tourne, le terminal manager y prend la place dominante. Realtime via WebSocket : chaque événement de l'event log push une update vers l'UI.
+L'icône `i` ouvre un panneau **info pipeline** : nom, statut, variables, bouton favoriter. Si la pipeline tourne, le terminal manager y prend la place dominante ; sur une **template** de bibliothèque, un onglet **Assistant** héberge le copilote d'authoring (ADR-0048), et un glyphe « agent » dans la toolbar y saute directement (côté run, le même chemin mène au Manager — #302). Realtime via WebSocket : chaque événement de l'event log push une update vers l'UI.
 
 ### Workflow utilisateur typique
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "1.30.0"
+version = "1.31.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "1.30.0"
+version = "1.31.0"
 license = "MIT"
 
 [workspace.dependencies]

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -4108,6 +4108,15 @@ fn build_router(state: Arc<AppState>) -> Router {
         .route("/sessions/{session_id}/attach", post(session_attach))
         .route("/sessions/{run_id}/manager/attach", post(manager_attach))
         .route("/sessions/{run_id}/shell", post(open_run_shell))
+        // #302 / ADR-0048 — library pipeline authoring assistant. `POST` is
+        // create-if-absent (spawn the `claude` REPL in the pipelines dir and
+        // return its session name to attach via the PTY bridge); `DELETE` reaps it
+        // on tab-leave. Under the already-proxied `/sessions` prefix, so no vite
+        // proxy edit (#345).
+        .route(
+            "/sessions/{pipeline_id}/libassist",
+            post(open_library_assistant).delete(close_library_assistant),
+        )
         .route("/library", get(list_library))
         .route("/library", post(save_to_library))
         // #345 — parse a single node's YAML into a canvas-instantiable spec.
@@ -10889,6 +10898,9 @@ async fn run_orphan_sweep(state: &AppState, socket: &str, ttl: Duration) -> Resu
         let info = match &parsed {
             // Unparseable name: no lookup at all, exactly as before.
             None => None,
+            // #302: a library assistant owns no Run — there is nothing to project.
+            // `decide_one` keeps it unconditionally, so skip the lookup entirely.
+            Some(tmux_session_manager::ParsedSession::LibAssist { .. }) => None,
             Some(p) => {
                 let (run_id, node_id) = match p {
                     tmux_session_manager::ParsedSession::Manager { run_id } => {
@@ -10900,6 +10912,8 @@ async fn run_orphan_sweep(state: &AppState, socket: &str, ttl: Duration) -> Resu
                     tmux_session_manager::ParsedSession::NodeRun {
                         run_id, node_id, ..
                     } => (run_id.as_str(), node_id.as_str()),
+                    // Handled by the arm above; unreachable here.
+                    tmux_session_manager::ParsedSession::LibAssist { .. } => unreachable!(),
                 };
                 if !projected.contains_key(run_id) {
                     let events = load_events(&state.db, run_id).await?;
@@ -13609,6 +13623,181 @@ async fn open_run_shell(
             }
         }
     }
+}
+
+/// Response of `POST /sessions/{pipeline_id}/libassist` (#302 / ADR-0048).
+///
+/// Same shape as [`ShellResponse`]: `created` distinguishes a freshly-spawned
+/// assistant from a re-attach of the existing one (create-if-absent). The client
+/// attaches to `session` via the existing `WS /sessions/<session>/pty` bridge.
+#[derive(Serialize)]
+struct LibassistResponse {
+    ok: bool,
+    session: String,
+    created: bool,
+}
+
+/// Open (or re-attach) the library pipeline authoring assistant for `pipeline_id`
+/// (#302 / ADR-0048).
+///
+/// Create-if-absent, one assistant per pipeline id (`pdo-libassist-<id>`), a
+/// `claude` REPL whose cwd is the library pipelines directory for `?scope=`
+/// (default `user`). Unlike the run shell there is no run to gate on: the assistant
+/// acts before/outside any Run. Its system prompt is primed with the pipeline-YAML
+/// format and the library endpoints (owner's ask). The session persists across a
+/// PTY/tab close (`claude` does not exit on EOF) and is reaped by the sibling
+/// `DELETE` handler on tab-leave.
+async fn open_library_assistant(
+    State(state): State<Arc<AppState>>,
+    AxumPath(pipeline_id): AxumPath<String>,
+    Query(scope_q): Query<ScopeQuery>,
+) -> Response {
+    let scope_str = scope_q.scope.as_deref().unwrap_or("user");
+    let Some(scope) = library_store::pipelines::Scope::parse(scope_str) else {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": format!("unknown scope: {scope_str}") })),
+        )
+            .into_response();
+    };
+    let Some(cwd) = library_store::pipelines::scope_dir(&state.repo_root, scope) else {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({ "error": "HOME not set — no library pipelines directory" })),
+        )
+            .into_response();
+    };
+    // The assistant's cwd must exist for `tmux new-session -c` to succeed. A fresh
+    // user library has no `pipelines/` dir until the first save; create it so the
+    // assistant can author the very first template.
+    if let Err(e) = std::fs::create_dir_all(&cwd) {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({ "error": format!("failed to create pipelines dir: {e}") })),
+        )
+            .into_response();
+    }
+
+    let session = tmux_session_manager::libassist_session_name(&pipeline_id);
+    let socket = state.tmux_socket();
+
+    // Create-if-absent, race-free (create-then-verify-on-failure), mirroring
+    // `open_run_shell`.
+    if tmux_session_manager::session_exists(&socket, &session) {
+        return (
+            StatusCode::OK,
+            Json(LibassistResponse {
+                ok: true,
+                session,
+                created: false,
+            }),
+        )
+            .into_response();
+    }
+
+    // Never sandboxed: authoring is design-time work on the host.
+    let daemon_url = sandbox_container::daemon_url(state.port, false);
+    let static_prompt = std::fs::read_to_string(
+        state
+            .repo_root
+            .join("prompts")
+            .join("builtin")
+            .join("library-assistant.md"),
+    )
+    .unwrap_or_default();
+    let full_prompt =
+        prompt_augmenter::build_library_assistant_prompt(&pipeline_id, &daemon_url, &static_prompt);
+
+    // Infra harness (no Run harness to follow): instance default, else the `claude`
+    // floor — mirror of the manager/merge-resolver resolution.
+    let default_harness = stored_default_harness(&state.db).await;
+    let harness_name = harness_resolver::resolve_infra_harness(None, default_harness.as_deref());
+    let harness = harness_registry::resolve(&harness_name).unwrap_or_else(|| {
+        warn!(
+            "library assistant for '{pipeline_id}': unknown harness '{harness_name}' — \
+             launching on the claude floor"
+        );
+        harness_registry::claude()
+    });
+
+    // Keep the primer OUT of the user-facing pipelines dir: write it to a sibling
+    // `.libassist/<id>.md` under the library root (the parent of `pipelines/`).
+    let prompt_path = cwd
+        .parent()
+        .unwrap_or(&cwd)
+        .join(".libassist")
+        .join(format!("{pipeline_id}.md"));
+
+    match tmux_session_manager::spawn_libassist(
+        &session,
+        &pipeline_id,
+        &full_prompt,
+        &cwd,
+        &prompt_path,
+        state.port,
+        &harness,
+        state.tmux_cmd_override.as_deref(),
+    ) {
+        Ok(()) => {
+            info!("Opened library assistant {session} in {}", cwd.display());
+            (
+                StatusCode::OK,
+                Json(LibassistResponse {
+                    ok: true,
+                    session,
+                    created: true,
+                }),
+            )
+                .into_response()
+        }
+        Err(e) => {
+            if tmux_session_manager::session_exists(&socket, &session) {
+                // A concurrent POST won the race — re-attach, not an error.
+                (
+                    StatusCode::OK,
+                    Json(LibassistResponse {
+                        ok: true,
+                        session,
+                        created: false,
+                    }),
+                )
+                    .into_response()
+            } else {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({
+                        "error": format!("failed to open library assistant: {e}")
+                    })),
+                )
+                    .into_response()
+            }
+        }
+    }
+}
+
+/// Reap the library pipeline authoring assistant for `pipeline_id` (#302 /
+/// ADR-0048).
+///
+/// The assistant's lifecycle is create-on-open / reap-on-leave: the frontend fires
+/// this when the user leaves the Assistant tab (owner's ask). Best-effort — killing
+/// an absent session is a no-op, so a double-leave or a race is harmless. `reaped`
+/// tells the client whether a session was actually there.
+async fn close_library_assistant(
+    State(state): State<Arc<AppState>>,
+    AxumPath(pipeline_id): AxumPath<String>,
+) -> Response {
+    let session = tmux_session_manager::libassist_session_name(&pipeline_id);
+    let socket = state.tmux_socket();
+    let existed = tmux_session_manager::session_exists(&socket, &session);
+    tmux_session_manager::kill(&socket, &session);
+    if existed {
+        info!("Reaped library assistant {session}");
+    }
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({ "ok": true, "reaped": existed })),
+    )
+        .into_response()
 }
 
 fn detect_terminal() -> String {
@@ -21588,7 +21777,11 @@ edges:
         let state = test_state_with_dir(repo.path()).await;
         let app = build_router(state);
 
-        let content = include_str!("../../../.claude/workflows/simple-bugfix.js");
+        // A minimal inline workflow (the retired `.claude/workflows/*.js` fixtures
+        // are gone — #549). The `workflow_importer` unit tests cover every
+        // translation idiom against inline sources; here we only need the endpoint
+        // to accept a valid workflow and write the draft.
+        let content = r#"agent(`Fix the failing test.`, { label: 'implement' })"#;
         let body = serde_json::json!({
             "filename": "simple-bugfix.js",
             "content": content,

--- a/crates/pdo-daemon/src/library_store.rs
+++ b/crates/pdo-daemon/src/library_store.rs
@@ -434,7 +434,9 @@ pub(crate) mod pipelines {
         repo_root.join(".pdo").join("library").join("pipelines")
     }
 
-    fn scope_dir(repo_root: &Path, scope: Scope) -> Option<PathBuf> {
+    /// The on-disk pipelines directory for a scope — the cwd a library authoring
+    /// assistant (#302 / ADR-0048) is spawned in, and where `save` writes.
+    pub(crate) fn scope_dir(repo_root: &Path, scope: Scope) -> Option<PathBuf> {
         match scope {
             Scope::Repo => Some(repo_pipelines_dir(repo_root)),
             Scope::User | Scope::Library => user_pipelines_dir(),

--- a/crates/pdo-daemon/src/prompt_augmenter.rs
+++ b/crates/pdo-daemon/src/prompt_augmenter.rs
@@ -998,6 +998,60 @@ pub(crate) fn build_manager_prompt(
     format!("{preamble}{role_prompt}")
 }
 
+/// Runtime preamble for the library pipeline authoring assistant (#302 /
+/// ADR-0048).
+///
+/// Prepended to the static role prompt (`prompts/builtin/library-assistant.md`),
+/// it pins the pipeline id being authored, the daemon base URL, and the two
+/// endpoints the assistant drives — `POST /nodes/parse` (validate) and
+/// `POST /library/pipelines` (persist) — with `curl` examples. Same discipline as
+/// the manager: we own the session prompt, so we document the endpoints in plain
+/// text rather than shipping a custom MCP. The **write-on-save** rule (F2 of the
+/// issue triage: show a diff, write only on the user's OK — never on every edit)
+/// is stated here so it holds even if the static role file is trimmed.
+pub(crate) fn build_library_assistant_preamble(pipeline_id: &str, daemon_url: &str) -> String {
+    format!(
+        r#"# Pipeline Assistant Runtime Preamble
+
+You are authoring the library pipeline template **`{pipeline_id}`** in natural
+language, on the user's behalf. Your working directory is the library pipelines
+folder. The template lives at `{pipeline_id}.yaml`; each node's prompt lives at
+`{pipeline_id}.prompts/<node-id>.md`. Read the sibling `*.yaml` files in this
+folder for real, in-house examples of the format.
+
+- Daemon base URL: `{daemon_url}`
+- List every template: `curl {daemon_url}/library/pipelines`
+- Validate a single node's YAML before you save: `curl -X POST {daemon_url}/nodes/parse -H 'Content-Type: application/json' -d '{{"yaml":"<node yaml>"}}'`
+- Persist the whole template (writes `{pipeline_id}.yaml` **and** its `.prompts/` dir): `curl -X POST {daemon_url}/library/pipelines -H 'Content-Type: application/json' -d '{{"id":"{pipeline_id}","name":"<display name>","yaml":"<full pipeline yaml>","prompts":{{"<node-id>":"<prompt markdown>"}}}}'`
+
+## Write on save, never on every edit
+
+Do **not** touch files as you reason. When the user asks for a change: describe
+what you will change, **show a diff**, and write **only after the user says OK**.
+Validate node YAML via `POST /nodes/parse` first; then persist the full template
+via `POST /library/pipelines` (keep `id` = `{pipeline_id}` so it saves in place).
+The canvas re-reads the template the moment you save — so save the whole file at
+once, never a half-edited one.
+
+You drive no Run and issue no run commands: your only durable effect is the YAML
+the user reviews. Read first, propose second, write last.
+
+"#
+    )
+}
+
+/// Assemble the full library-assistant launch prompt: runtime preamble + the
+/// static role prompt (the pipeline-YAML format guide). Mirror of
+/// [`build_manager_prompt`].
+pub(crate) fn build_library_assistant_prompt(
+    pipeline_id: &str,
+    daemon_url: &str,
+    role_prompt: &str,
+) -> String {
+    let preamble = build_library_assistant_preamble(pipeline_id, daemon_url);
+    format!("{preamble}{role_prompt}")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/pdo-daemon/src/tmux_session_manager.rs
+++ b/crates/pdo-daemon/src/tmux_session_manager.rs
@@ -646,6 +646,18 @@ pub fn shell_session_name(run_id: &str) -> String {
     format!("pdo-shell-{run_id}")
 }
 
+/// Session naming convention for a library pipeline authoring assistant
+/// (#302 / ADR-0048).
+///
+/// One fixed name per pipeline id so `POST /sessions/{id}/libassist` is
+/// create-if-absent (a second open re-attaches the same session). Parsed back out
+/// by [`parse_session_name`] via the `libassist-` prefix branch, mirroring
+/// `shell-` / `mgr-` — otherwise the orphan sweep would read it as an
+/// unrecognised name and kill it on the next pass.
+pub fn libassist_session_name(pipeline_id: &str) -> String {
+    format!("pdo-libassist-{pipeline_id}")
+}
+
 /// Spawn a detached tmux session for a NodeRun.
 ///
 /// `tmux_cmd_override` (per-daemon config, `AppState.tmux_cmd_override`)
@@ -762,6 +774,80 @@ pub fn spawn_shell(
     enable_mouse(&socket, session_name);
 
     info!("Spawned run shell tmux session: {session_name}");
+    Ok(())
+}
+
+/// Spawn a detached tmux session running the library pipeline authoring assistant
+/// (#302 / ADR-0048) — a `claude` REPL whose cwd is the library pipelines
+/// directory.
+///
+/// Mirror of [`spawn`]'s agent launch (an `Agent` tail, not the `bash -i` of
+/// [`spawn_shell`]), but keyed on a pipeline id instead of a Run: it drives no
+/// Run and emits no `run_command`; its whole effect is writing `<id>.yaml`
+/// (+ `<id>.prompts/`) in `working_dir` via the library endpoints. Like the
+/// manager it launches `claude "$(cat <primer>)"`; `claude` does **not** exit on
+/// EOF (unlike `bash -i`), so the session survives a PTY-bridge/tab close — the
+/// assistant is reaped **explicitly** on tab-leave (`DELETE /sessions/{id}/libassist`,
+/// ADR-0048), never by the EOF that would end a run shell. The primer is written
+/// to `prompt_path`, kept **out** of `working_dir` so the user-facing pipelines
+/// directory stays clean. Honours `tmux_cmd_override` (the test seam) exactly as
+/// the agent tail does. Never sandboxed: authoring is design-time work on the host.
+// Every argument is an irreducible input to the spawn (identity, working context,
+// primer path, launch selector); a struct would only move the list — same
+// rationale as `spawn` / `spawn_shell` / `build_tmux_script`.
+#[allow(clippy::too_many_arguments)]
+pub fn spawn_libassist(
+    session_name: &str,
+    pipeline_id: &str,
+    prompt: &str,
+    working_dir: &Path,
+    prompt_path: &Path,
+    daemon_port: u16,
+    harness: &crate::harness_registry::HarnessDescriptor,
+    tmux_cmd_override: Option<&str>,
+) -> Result<()> {
+    if let Some(parent) = prompt_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(prompt_path, prompt)?;
+
+    let script = build_tmux_script(
+        // The env-wrap poses `PDO_RUN_ID=<pipeline_id>` / `PDO_NODE_ID=__libassist__`
+        // (harmless — the assistant never self-signals via `pdo complete`); the
+        // load-bearing export is `PDO_DAEMON_URL`, so a `curl` of the library
+        // endpoints in the assistant's own preamble resolves.
+        pipeline_id,
+        "__libassist__",
+        0,
+        daemon_port,
+        prompt_path,
+        tmux_cmd_override,
+        SessionTail::Agent {
+            harness,
+            model: None,
+            effort: None,
+            session_id: None,
+        },
+        None, // never sandboxed
+        None, // no turn-end Stop hook — the assistant never calls `pdo complete`
+    );
+    let socket = tmux_socket_name(daemon_port);
+
+    let output = tmux(&socket)
+        .args(["new-session", "-d", "-s", session_name, "-c"])
+        .arg(working_dir)
+        .arg(&script)
+        .output()
+        .context("failed to run tmux new-session (libassist)")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("tmux new-session (libassist) failed: {stderr}");
+    }
+
+    enable_mouse(&socket, session_name);
+
+    info!("Spawned library assistant tmux session: {session_name}");
     Ok(())
 }
 
@@ -929,6 +1015,12 @@ pub enum ParsedSession {
     Shell {
         run_id: String,
     },
+    /// Library pipeline authoring assistant `pdo-libassist-<pipeline_id>`
+    /// (#302 / ADR-0048). Owns no Run — reaped explicitly on tab-leave, kept by
+    /// the orphan sweep.
+    LibAssist {
+        pipeline_id: String,
+    },
 }
 
 /// Parse a session name like `pdo-<run_id>-<node_id>-iter-<N>` or
@@ -952,6 +1044,19 @@ pub fn parse_session_name(name: &str) -> Option<ParsedSession> {
         if !run_id.is_empty() {
             return Some(ParsedSession::Shell {
                 run_id: run_id.to_string(),
+            });
+        }
+        return None;
+    }
+
+    // #302: `pdo-libassist-<pipeline_id>` — parsed BEFORE the `-iter-` split, like
+    // `shell-` / `mgr-`. A pipeline id has no `-iter-` suffix, so without this
+    // branch the name would fall through to the split, return None, and be killed
+    // as "unrecognised" by the orphan sweep on the next pass.
+    if let Some(pipeline_id) = rest.strip_prefix("libassist-") {
+        if !pipeline_id.is_empty() {
+            return Some(ParsedSession::LibAssist {
+                pipeline_id: pipeline_id.to_string(),
             });
         }
         return None;
@@ -1400,6 +1505,14 @@ fn decide_one(
             }),
             _ => SweepVerdict::Keep,
         },
+        // #302 / ADR-0048: a library authoring assistant has no owning Run, so
+        // there is nothing to key an absence/archived verdict on. It is reaped
+        // **explicitly** on tab-leave (`DELETE /sessions/<id>/libassist`), never by
+        // the sweep, and has no TTL (an interactive REPL must not be yanked from a
+        // user who stepped away — same reasoning as the shell/manager arms). Always
+        // keep: a reopen re-attaches this same session, a leave kills it. `info` is
+        // always `None` for this variant (the sweep caller does no run lookup).
+        ParsedSession::LibAssist { .. } => SweepVerdict::Keep,
         ParsedSession::NodeRun {
             run_id,
             node_id,
@@ -1549,11 +1662,26 @@ mod tests {
     }
 
     #[test]
+    fn parse_libassist_session() {
+        // #302: `pdo-libassist-<pipeline_id>` parses to a LibAssist variant. The
+        // pipeline id is a file-stem slug (no `-iter-` suffix, may contain dashes).
+        let name = "pdo-libassist-feature-with-review";
+        let parsed = parse_session_name(name).unwrap();
+        assert_eq!(
+            parsed,
+            ParsedSession::LibAssist {
+                pipeline_id: "feature-with-review".into(),
+            }
+        );
+    }
+
+    #[test]
     fn parse_garbage_returns_none() {
         assert!(parse_session_name("foo-bar").is_none());
         assert!(parse_session_name("pdo-").is_none());
         assert!(parse_session_name("pdo-mgr-").is_none());
         assert!(parse_session_name("pdo-shell-").is_none());
+        assert!(parse_session_name("pdo-libassist-").is_none());
     }
 
     /// Formatters and parser pinned as a **round trip**, not independently
@@ -1583,6 +1711,14 @@ mod tests {
             parse_session_name(&shell_session_name(run_id)),
             Some(ParsedSession::Shell {
                 run_id: run_id.into()
+            })
+        );
+        // #302: the libassist formatter must round-trip too — else the sweep reaps
+        // it as unrecognised within 60 s (the exact failure this test exists for).
+        assert_eq!(
+            parse_session_name(&libassist_session_name("feature-with-review")),
+            Some(ParsedSession::LibAssist {
+                pipeline_id: "feature-with-review".into()
             })
         );
     }
@@ -1691,6 +1827,34 @@ mod tests {
         assert_eq!(
             verdict(&[input(&shell_session_name(RID), None)], now),
             SweepVerdict::Kill(KillReason::ShellRunAbsent { run_id: RID.into() })
+        );
+    }
+
+    /// #302 / ADR-0048: a library assistant is **always kept** by the sweep,
+    /// whatever `info` says. It owns no Run, so there is no absence/archived/TTL
+    /// verdict that could apply — it is reaped only by the explicit
+    /// `DELETE /sessions/<id>/libassist` on tab-leave. Pinned as hard as a kill so
+    /// a future refactor cannot silently start reaping it (the exact bug the
+    /// `libassist-` parse branch exists to prevent).
+    #[test]
+    fn library_assistant_is_always_kept() {
+        let now = at("2026-07-31T15:32:19Z");
+        let name = libassist_session_name("feature-with-review");
+        // No owner (info = None) — the shell/manager arms would kill on this.
+        assert_eq!(verdict(&[input(&name, None)], now), SweepVerdict::Keep);
+        // Even a (nonsensical) archived owner does not flip it.
+        assert_eq!(
+            verdict(
+                &[input(
+                    &name,
+                    Some(NodeRunInfo {
+                        completed_at: Some(at("2000-01-01T00:00:00Z")),
+                        is_archived: true,
+                    })
+                )],
+                now
+            ),
+            SweepVerdict::Keep
         );
     }
 

--- a/crates/pdo-daemon/src/workflow_importer.rs
+++ b/crates/pdo-daemon/src/workflow_importer.rs
@@ -1718,98 +1718,6 @@ mod tests {
             .collect()
     }
 
-    // --- round-trip on the real simple-bugfix fixture --------------------
-
-    #[test]
-    fn round_trip_simple_bugfix_holds_invariants() {
-        let src = include_str!("../../../.claude/workflows/simple-bugfix.js");
-        let (result, parsed) = import_and_parse(src, "simple-bugfix");
-
-        // Exactly one Start + one End.
-        assert_eq!(
-            parsed
-                .nodes
-                .iter()
-                .filter(|n| n.node_type == NodeType::Start)
-                .count(),
-            1
-        );
-        assert_eq!(
-            parsed
-                .nodes
-                .iter()
-                .filter(|n| n.node_type == NodeType::End)
-                .count(),
-            1
-        );
-
-        // A bounded loop, max_iter 5, whose members are the two fix/test nodes.
-        let bounded: Vec<_> = parsed
-            .loops
-            .iter()
-            .filter(|l| l.kind == LoopKind::Bounded)
-            .collect();
-        assert_eq!(bounded.len(), 1, "one bounded region expected");
-        let region = bounded[0];
-        assert_eq!(
-            region.max_iter,
-            Some(serde_yaml::Value::Number(serde_yaml::Number::from(5))),
-            "max_iter resolved from MAX_ITER = 5"
-        );
-        assert_eq!(region.members.len(), 2, "fix + test are the loop body");
-        // Members are the implementer + tester node ids.
-        let impl_id = &parsed
-            .nodes
-            .iter()
-            .find(|n| n.name == "implementer")
-            .unwrap()
-            .id;
-        let test_id = &parsed.nodes.iter().find(|n| n.name == "tester").unwrap().id;
-        assert!(region.members.contains(impl_id));
-        assert!(region.members.contains(test_id));
-
-        // At least one guarded edge (the `verdict !== 'Bug'` exit).
-        let whens = when_strings(&parsed);
-        assert!(!whens.is_empty(), "at least one when: edge");
-        assert!(
-            whens.iter().any(|w| w.contains("verdict")),
-            "a when: on the triage verdict"
-        );
-
-        // Static prompts extracted verbatim.
-        assert!(
-            prompt_of(&result, &parsed, "tester").contains("Build le projet"),
-            "tester prompt kept verbatim"
-        );
-        assert!(
-            prompt_of(&result, &parsed, "ship-it").contains("Commit sur la BRANCHE COURANTE"),
-            "ship-it prompt kept verbatim"
-        );
-
-        // Interpolated prompt: static text kept AND an annotated hole marker — not
-        // a blank placeholder (that would throw away text the runtime uses verbatim).
-        let implementer = prompt_of(&result, &parsed, "implementer");
-        assert!(implementer.contains("Implemente"), "static text kept");
-        assert!(
-            implementer.contains("⟨input:"),
-            "interpolation rendered as an annotated marker"
-        );
-
-        // The debugger's TRIAGE_SCHEMA becomes output-port frontmatter.
-        let debugger = parsed.nodes.iter().find(|n| n.name == "debugger").unwrap();
-        let fm = debugger.outputs[0]
-            .frontmatter
-            .as_ref()
-            .expect("schema -> frontmatter");
-        let verdict = fm.get("verdict").expect("verdict field");
-        assert_eq!(verdict.field_type, "enum");
-        assert!(verdict
-            .allowed
-            .as_ref()
-            .unwrap()
-            .contains(&"Bug".to_string()));
-    }
-
     // --- targeted units ---------------------------------------------------
 
     #[test]
@@ -2021,22 +1929,5 @@ mod tests {
     fn invalid_js_is_rejected() {
         let err = import_workflow_js("const x = = ;", "t").unwrap_err();
         assert!(err.to_lowercase().contains("parse"), "got: {err}");
-    }
-
-    // --- degraded fixture: sandcastle-tdd (mostly placeholders) -----------
-
-    #[test]
-    fn sandcastle_tdd_imports_without_panic() {
-        let src = include_str!("../../../.claude/workflows/sandcastle-tdd.js");
-        let result = import_workflow_js(src, "sandcastle-tdd")
-            .expect("even a mostly-placeholder workflow must import without crashing");
-        // It must produce a parseable draft…
-        pipeline::parse_pipeline(&result.yaml_text).expect("degraded import must still parse");
-        // …and flag the lossy translation (helper-nu prompts, nested loops, etc.).
-        assert!(
-            !result.warnings.is_empty(),
-            "the degraded case must raise translation warnings"
-        );
-        assert_eq!(result.name, "sandcastle-tdd");
     }
 }

--- a/crates/pdo-daemon/tests/libassist.rs
+++ b/crates/pdo-daemon/tests/libassist.rs
@@ -1,0 +1,190 @@
+//! Layer 3a — library pipeline authoring assistant (#302 / ADR-0048).
+//!
+//! Drives `POST` / `DELETE /sessions/{pipeline_id}/libassist` against a real
+//! daemon and corroborates every side effect out-of-band on the daemon's private
+//! tmux socket + the library pipelines directory on disk.
+//!
+//! The assistant is a `claude` REPL, but here it runs the daemon's harmless
+//! `exec sleep 600` tmux override (the `Agent` tail honours the seam), so the
+//! session is created and persists without launching a real `claude`. We drive
+//! `?scope=repo` so the cwd is the tempdir's `.pdo/library/pipelines` — fully
+//! hermetic, no `$HOME` dependency, and no pipeline file needs to pre-exist
+//! (create-if-absent creates the directory).
+
+mod common;
+
+use common::TestDaemon;
+
+const PIPELINE_ID: &str = "feature-with-review";
+
+async fn post_assistant(daemon: &TestDaemon, id: &str) -> reqwest::Response {
+    reqwest::Client::new()
+        .post(format!(
+            "{}/sessions/{id}/libassist?scope=repo",
+            daemon.url()
+        ))
+        .send()
+        .await
+        .unwrap()
+}
+
+async fn delete_assistant(daemon: &TestDaemon, id: &str) -> reqwest::Response {
+    reqwest::Client::new()
+        .delete(format!("{}/sessions/{id}/libassist", daemon.url()))
+        .send()
+        .await
+        .unwrap()
+}
+
+/// Number of `pdo-libassist-*` sessions on the daemon's socket.
+fn assistant_session_count(socket: &str) -> usize {
+    pdo_daemon::tmux_session_manager::list_pdo_sessions(socket)
+        .into_iter()
+        .filter(|s| s.starts_with("pdo-libassist-"))
+        .count()
+}
+
+#[tokio::test]
+async fn open_assistant_creates_session() {
+    let daemon = TestDaemon::spawn(|_| Ok(())).await.unwrap();
+
+    let resp = post_assistant(&daemon, PIPELINE_ID).await;
+    assert_eq!(resp.status(), 200, "opening the assistant should succeed");
+    let body = resp.json::<serde_json::Value>().await.unwrap();
+
+    let expected = pdo_daemon::tmux_session_manager::libassist_session_name(PIPELINE_ID);
+    assert_eq!(body["session"].as_str(), Some(expected.as_str()));
+    assert_eq!(
+        body["created"],
+        serde_json::json!(true),
+        "first open creates"
+    );
+    assert_eq!(body["ok"], serde_json::json!(true));
+
+    let socket = daemon.tmux_socket();
+    assert!(
+        pdo_daemon::tmux_session_manager::session_exists(&socket, &expected),
+        "the tmux session must exist after opening the assistant"
+    );
+
+    // The cwd (the repo-scoped pipelines dir) is created on demand so the very
+    // first template can be authored, and the primer is written OUT of it.
+    let lib = daemon.repo_root().join(".pdo").join("library");
+    assert!(
+        lib.join("pipelines").is_dir(),
+        "the pipelines dir (the assistant's cwd) is created"
+    );
+    assert!(
+        lib.join(".libassist")
+            .join(format!("{PIPELINE_ID}.md"))
+            .is_file(),
+        "the primer is written to a sibling .libassist dir, not into pipelines/"
+    );
+}
+
+#[tokio::test]
+async fn open_assistant_is_idempotent() {
+    let daemon = TestDaemon::spawn(|_| Ok(())).await.unwrap();
+
+    let first = post_assistant(&daemon, PIPELINE_ID)
+        .await
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    assert_eq!(first["created"], serde_json::json!(true));
+
+    let second = post_assistant(&daemon, PIPELINE_ID).await;
+    assert_eq!(second.status(), 200);
+    let second = second.json::<serde_json::Value>().await.unwrap();
+    assert_eq!(
+        second["created"],
+        serde_json::json!(false),
+        "a second open re-attaches the existing assistant"
+    );
+
+    assert_eq!(
+        assistant_session_count(&daemon.tmux_socket()),
+        1,
+        "exactly one assistant session regardless of the number of opens"
+    );
+}
+
+#[tokio::test]
+async fn close_assistant_reaps_the_session() {
+    let daemon = TestDaemon::spawn(|_| Ok(())).await.unwrap();
+    let session = pdo_daemon::tmux_session_manager::libassist_session_name(PIPELINE_ID);
+    let socket = daemon.tmux_socket();
+
+    post_assistant(&daemon, PIPELINE_ID).await;
+    assert!(pdo_daemon::tmux_session_manager::session_exists(
+        &socket, &session
+    ));
+
+    let resp = delete_assistant(&daemon, PIPELINE_ID).await;
+    assert_eq!(resp.status(), 200);
+    let body = resp.json::<serde_json::Value>().await.unwrap();
+    assert_eq!(body["ok"], serde_json::json!(true));
+    assert_eq!(
+        body["reaped"],
+        serde_json::json!(true),
+        "the leave reaps the live session"
+    );
+    assert!(
+        !pdo_daemon::tmux_session_manager::session_exists(&socket, &session),
+        "the tmux session is gone after leave"
+    );
+
+    // Reaping again is a harmless no-op (double-leave / race).
+    let second = delete_assistant(&daemon, PIPELINE_ID)
+        .await
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    assert_eq!(
+        second["reaped"],
+        serde_json::json!(false),
+        "a second leave finds nothing to reap"
+    );
+}
+
+#[tokio::test]
+async fn assistant_survives_the_orphan_sweep() {
+    // The F3 correctness point (ADR-0048): a `pdo-libassist-*` session owns no
+    // Run, so a naive sweep would read its name as unrecognised and kill it within
+    // 60 s. The `libassist-` parse branch + the always-keep sweep arm prevent that.
+    let daemon = TestDaemon::spawn(|_| Ok(())).await.unwrap();
+    let session = pdo_daemon::tmux_session_manager::libassist_session_name(PIPELINE_ID);
+    let socket = daemon.tmux_socket();
+
+    post_assistant(&daemon, PIPELINE_ID).await;
+    assert!(pdo_daemon::tmux_session_manager::session_exists(
+        &socket, &session
+    ));
+
+    // A full orphan-sweep pass (the same one that reaps unrecognised names).
+    daemon.run_orphan_sweep_tick().await;
+
+    assert!(
+        pdo_daemon::tmux_session_manager::session_exists(&socket, &session),
+        "the assistant survives the sweep — it is reaped only on explicit leave"
+    );
+}
+
+#[tokio::test]
+async fn unknown_scope_is_rejected() {
+    let daemon = TestDaemon::spawn(|_| Ok(())).await.unwrap();
+    let resp = reqwest::Client::new()
+        .post(format!(
+            "{}/sessions/{PIPELINE_ID}/libassist?scope=bogus",
+            daemon.url()
+        ))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400, "an unknown scope is a 400");
+    assert_eq!(
+        assistant_session_count(&daemon.tmux_socket()),
+        0,
+        "no session is created on a rejected scope"
+    );
+}

--- a/docs/adr/0048-library-authoring-assistant.md
+++ b/docs/adr/0048-library-authoring-assistant.md
@@ -1,0 +1,112 @@
+# Assistant d'authoring de bibliothèque — copilote design-time des templates
+
+> Statut : **accepted** (#302).
+
+Écrire ou modifier une pipeline **template** se faisait à la main : câbler nodes / edges / prompts
+sur le canvas, ou éditer le YAML. #302 ajoute un **copilote d'authoring** : une session `claude`
+inline, ouverte dans le dossier des templates, à qui l'utilisateur **décrit** le changement en
+langage naturel ; l'agent produit le YAML (+ les prompts par nœud), l'humain relit, l'agent écrit.
+
+C'est une **nouvelle classe de session** et une **nouvelle modalité d'authoring** — d'où cet ADR,
+adossé à ADR-0021 (mécanisme de session), ADR-0005 (terminal inline), ADR-0009/0012 (aucun effet
+durable initié par le *runtime*, pas de ré-entrée scheduler) et ADR-0001/0002 (LLM design-time OK).
+
+## Terminologie (F1) — « assistant », pas « manager »
+
+L'issue disait « partager l'onglet Manager ». Refusé : *manager* est load-bearing (CONTEXT §*Pipeline
+Manager*) — REPL **attachée à un Run**, dont toute la valeur est `POST /runs/<id>/commands`. L'assistant
+n'est attaché à **aucun Run**, n'émet **aucune** commande, et son seul effet est **d'écrire des
+fichiers** template. Terme et concept distincts : **assistant de bibliothèque / copilote pipeline**.
+Il réutilise le **mécanisme** d'ADR-0021 (session inline + pont PTY), pas la **sémantique** du Manager.
+
+## Fit philosophique
+
+Aucun conflit avec ADR-0001/0002 (« pas de LLM-router **runtime** ») : l'LLM agit au **design-time** et
+produit un YAML relu par l'humain — l'inverse d'un routeur d'exécution. Cela **renforce** *Deliberate,
+then autonomous* (ADR-0012) : la valeur de PDO est dans le temps de conception ; un copilote amplifie
+exactement cette phase.
+
+## Ce qu'on décide
+
+1. **Nouvelle classe de session `pdo-libassist-<pipeline-id>`.** Keyée sur l'**id de la pipeline**
+   (l'ownership, F3), pas sur un Run. cwd = le dossier des templates du scope
+   (`~/.pdo/library/pipelines/` pour `user`/`library`, `<repo>/.pdo/library/pipelines/` pour `repo`).
+   Tail = `claude` (comme le manager, `SessionTail::Agent`), **pas** `bash -i` : c'est une REPL, pas un
+   shell brut.
+
+2. **Endpoint create-if-absent + endpoint de reap.** `POST /sessions/{id}/libassist?scope=<scope>`
+   garantit l'existence de la session et renvoie son nom ; l'attache se fait ensuite par le pont PTY
+   existant (`WS /sessions/<name>/pty`, générique — zéro code backend d'attache). Idempotence race-free
+   (create-then-verify-on-failure), copie conforme de `open_run_shell`. Un `DELETE /sessions/{id}/libassist`
+   **reap** la session — c'est le point net-new : aucun autre reap n'était piloté par le client.
+
+3. **Cycle de vie = create-on-open / reap-on-leave (F3).** Le propriétaire l'a tranché : « dès qu'on
+   quitte l'onglet on reap la session ». Le front spawn la session à l'ouverture de l'onglet Assistant
+   et la reap au démontage (changement d'onglet, fermeture du panneau, changement de pipeline). Une
+   ré-ouverture ré-attache la **même** session (create-if-absent) ; c'est robuste sans état côté front.
+   `claude` **ne sort pas sur EOF** (contrairement à `bash -i`, ADR-0021 #4), donc la session survit à
+   une coupure WS transitoire — la fermeture est **explicite**, jamais un effet de bord du pont PTY.
+
+4. **Jamais reapée par le sweep d'orphelins, jamais de TTL.** Une session `pdo-libassist-*` n'a **pas de
+   Run** sur quoi keyer un verdict *absent* / *archived* / *stale*. Le sweep la **garde
+   inconditionnellement** (`decide_one` → `Keep`) : elle est reapée uniquement par le `DELETE` explicite.
+   Sans le préfixe `libassist-` dans `parse_session_name`, le sweep l'aurait lue comme un **nom
+   inconnu** et tuée en < 60 s (le piège exact que la branche de parse évite — pinné par un test).
+   Comme le manager/shell, elle est **exempte du cap** d'admission (ce n'est pas un nœud projeté).
+
+5. **Prompt système primé (demande explicite du propriétaire).** Le préambule runtime pose l'id de la
+   pipeline, l'URL du daemon et les deux endpoints que l'assistant pilote — `POST /nodes/parse`
+   (valider) et `POST /library/pipelines` (persister) — avec exemples `curl` ; le rôle statique
+   (`prompts/builtin/library-assistant.md`) décrit le **format YAML** des pipelines et la disposition
+   `<id>.prompts/`. Même discipline que le manager : on possède le prompt, on documente les endpoints,
+   **pas de MCP custom**.
+
+6. **Écrire au save, jamais à chaque édition (F2).** Le propriétaire : « on écrit au save uniquement ».
+   C'est une consigne du prompt (décrire le changement, **montrer un diff**, écrire **sur OK**), pas une
+   porte dans le daemon : l'assistant valide via `/nodes/parse` puis persiste tout le template via
+   `POST /library/pipelines`, et le canvas relit sur sauvegarde (store disk-first, ADR-0007). Écrire le
+   fichier entier d'un coup — jamais un YAML à moitié édité.
+
+7. **Généralisation au canvas run = même chemin d'accès, pas de nouveau panneau (F4).** Le propriétaire
+   a préféré bundler plutôt que trimballer un slice trivial. L'accès est unifié par l'**icône dans la
+   toolbar** (glyphe « agent » à côté du `(i)`) : côté bibliothèque elle ouvre l'onglet **Assistant** ;
+   côté run l'onglet adéquat reste le **Manager** (déjà auto-spawné). Le net-new est **100 % côté
+   bibliothèque** ; le côté run réutilise le Manager existant.
+
+## Alternatives écartées
+
+- **Partager l'onglet/terme « Manager »** : brouille un terme load-bearing (F1) — objet réel différent
+  (pas de Run, pas de `run_command`, effet = écrire un fichier).
+- **Tail `bash -i` dans une boucle de respawn (comme le shell d'ADR-0021)** : inutile ici — `claude` ne
+  sort pas sur EOF, donc pas de boucle à écrire ; et on veut une REPL, pas un bash brut.
+- **Reap par TTL / par le sweep** : un outil interactif ne doit pas être arraché ; et sans Run il n'y a
+  pas de signal d'absence à keyer. Le reap explicite du front est plus simple et plus véridique.
+- **Auto-spawn à la création de la pipeline (comme le manager de run)** : trop tôt et coûteux. Le besoin
+  a bien intuité le cycle de vie du **Shell** (« uniquement sur clic »), pas l'auto-spawn du Manager.
+- **Écrire à chaque édition** : le propriétaire l'a jugé trop tôt (F2) — le diff-then-save protège un
+  canvas ouvert sur la même pipeline d'un écrasement surprise.
+
+## Limites acceptées
+
+- **Fuite au redémarrage-du-daemon-onglet-fermé.** Le sweep gardant toujours la session, une session
+  dont l'onglet a été fermé **exactement pendant** un redémarrage du daemon n'est pas reapée. Coût
+  négligeable (un `claude` inactif, exempt du cap ; CCR désactivé ⇒ aucun trafic tant qu'on ne lui parle
+  pas), et auto-guérissant : ré-ouvrir la pipeline ré-attache la session, la quitter la reap.
+- **Réconciliation canvas ↔ fichier (F2)** : l'assistant écrit le fichier ; le canvas relit sur save via
+  le store disk-first (ADR-0007). Un conflit avec des edits canvas non sauvés reste géré par les
+  mécanismes existants (watcher `PipelineModified`, étoile synced/diverged) — pas de verrou d'écriture
+  ajouté dans ce MVP.
+- **cwd = dossier des templates** : l'assistant y voit toutes les templates du scope (utile comme
+  exemples few-shot) ; le primer y est **volontairement pas** écrit (il va dans un `.libassist/` frère)
+  pour ne pas polluer le dossier visible.
+
+## Relations
+
+- **ADR-0021** — réutilise le pont PTY et l'attache inline verbatim ; endpoint create-if-absent calqué
+  sur `open_run_shell` ; le reap explicite est le pendant lifecycle côté assistant (vs reap sur
+  archive/absence côté shell).
+- **ADR-0005** — terminal inline xterm.js primaire ; l'assistant s'attache par la même route WS.
+- **ADR-0009 / ADR-0012** — opération atomique side-effect-light qui ne réentre jamais le scheduler ;
+  surface pilotée par l'humain, autonomie **dans la conception**.
+- **ADR-0001 / ADR-0002** — LLM au design-time, pas de router runtime.
+- **ADR-0007** — le store disk-first ; le canvas relit la template sur save.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -241,6 +241,12 @@ export default function App() {
   const isEditingRun = editTab?.scope === "run";
   const hasEditTab = editTab != null;
 
+  // #302 / ADR-0048: the Assistant authors a library *template*, so it targets the
+  // active edit tab's pipeline id + scope — never a run. `null` on a run tab hides
+  // the Assistant tab (the Manager tab covers a run instead).
+  const assistantId = editTab && !isEditingRun ? editTab.id : null;
+  const assistantScope = editTab?.scope;
+
   // #315: an archived run is read-only — its worktree (and `pipeline.yaml`) is
   // gone, so any save would PUT into a 404. `isArchived` tracks the *selected*
   // run (drives the NodeDetailPanel + the archived aside below). The edit
@@ -402,6 +408,16 @@ export default function App() {
 
   const handleCloseInfo = useCallback(() => {
     setInfoPanelOpen(false);
+  }, []);
+
+  // #302 / ADR-0048: the toolbar Bot glyph opens the info panel focused on the
+  // Assistant tab (the library authoring copilot). Same shape as `handleViewYaml`:
+  // set the initial tab, then open. The panel is keyed on `infoPanelInitialTab`,
+  // so this remounts it at the Assistant tab.
+  const handleOpenAssistant = useCallback(() => {
+    setInfoPanelInitialTab("assistant");
+    setInfoPanelScrollToLine(undefined);
+    setInfoPanelOpen(true);
   }, []);
 
   useEffect(() => {
@@ -670,6 +686,8 @@ export default function App() {
                   infoOpen={infoPanelOpen}
                   onToggleInfo={handleToggleInfo}
                   onCloseInfo={handleCloseInfo}
+                  assistantActive={infoPanelOpen && infoPanelInitialTab === "assistant"}
+                  onOpenAssistant={handleOpenAssistant}
                   runState={selectedRun}
                 />
               </div>
@@ -701,6 +719,8 @@ export default function App() {
                 onClose={handleCloseInfo}
                 initialTab={infoPanelInitialTab}
                 scrollToLine={infoPanelScrollToLine}
+                assistantId={assistantId}
+                assistantScope={assistantScope}
               />
             ) : paneOwner === "editTab" ? (
               <>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -451,6 +451,38 @@ export function openRunShell(
   );
 }
 
+/**
+ * Open (or re-attach) the library pipeline authoring assistant for `pipelineId`
+ * (#302 / ADR-0048). Create-if-absent; returns the `pdo-libassist-<id>` tmux
+ * session name to attach to via the existing `WS /sessions/<session>/pty` bridge.
+ * `scope` selects the pipelines directory (`repo` vs `user`/`library`).
+ */
+export function openLibraryAssistant(
+  pipelineId: string,
+  scope?: string,
+): Promise<{ session: string; created: boolean }> {
+  return request<{ session: string; created: boolean }>(
+    "POST",
+    `/sessions/${encodeURIComponent(pipelineId)}/libassist`,
+    { query: { scope }, label: "open assistant" },
+  );
+}
+
+/**
+ * Reap the library authoring assistant for `pipelineId` (#302 / ADR-0048). The
+ * assistant is create-on-open / reap-on-leave, so the UI calls this when the user
+ * leaves the Assistant tab. Best-effort: reaping an absent session is a no-op.
+ */
+export function closeLibraryAssistant(
+  pipelineId: string,
+): Promise<{ ok: boolean; reaped: boolean }> {
+  return request<{ ok: boolean; reaped: boolean }>(
+    "DELETE",
+    `/sessions/${encodeURIComponent(pipelineId)}/libassist`,
+    { label: "close assistant" },
+  );
+}
+
 export interface PaneResponse {
   content: string;
   session_name: string;

--- a/frontend/src/components/EditCanvas.tsx
+++ b/frontend/src/components/EditCanvas.tsx
@@ -247,10 +247,14 @@ interface EditCanvasProps {
   infoOpen?: boolean;
   onToggleInfo?: () => void;
   onCloseInfo?: () => void;
+  // #302 / ADR-0048: open the info panel on the Assistant tab, and whether it is
+  // the panel's current view (Bot pressed state). Wired only for template canvases.
+  assistantActive?: boolean;
+  onOpenAssistant?: () => void;
   runState?: RunState | null;
 }
 
-function EditCanvasInner({ libraryEntries, libraryPipelines, onLibraryDelete, onLibraryPipelinesChanged, infoOpen, onToggleInfo, onCloseInfo, runState }: EditCanvasProps) {
+function EditCanvasInner({ libraryEntries, libraryPipelines, onLibraryDelete, onLibraryPipelinesChanged, infoOpen, onToggleInfo, onCloseInfo, assistantActive, onOpenAssistant, runState }: EditCanvasProps) {
   const openTabs = useEditStore((s) => s.openTabs);
   const activeTabId = useEditStore((s) => s.activeTabId);
   const setSelection = useEditStore((s) => s.setSelection);
@@ -691,6 +695,12 @@ function EditCanvasInner({ libraryEntries, libraryPipelines, onLibraryDelete, on
         getDropPosition={computeDropPosition}
         infoOpen={infoOpen}
         onToggleInfo={onToggleInfo}
+        // #302 / ADR-0048: the Assistant is a template-only affordance — a
+        // library template tab has no `runId`. On a run canvas the Bot is absent;
+        // the Manager tab is reached via `(i)` there.
+        assistantAvailable={tab != null && tab.runId == null}
+        assistantActive={assistantActive}
+        onOpenAssistant={onOpenAssistant}
         showRunInfo={showRunInfo}
         runInfoActive={runInfoActive}
         onToggleRunInfo={toggleRunInfo}

--- a/frontend/src/components/EditToolbar.test.tsx
+++ b/frontend/src/components/EditToolbar.test.tsx
@@ -219,6 +219,55 @@ describe("EditToolbar", () => {
       for (const b of buttons) expect(b).toHaveAccessibleName(/\S/);
     });
   });
+
+  // #302 / ADR-0048: the "agent" glyph beside `(i)`, shown only on a library
+  // template canvas — the mirror of the run-info toggle above.
+  describe("assistant toggle (#302)", () => {
+    it("is absent on a canvas that is not a template (default)", () => {
+      renderToolbar({ onToggleInfo: vi.fn() });
+      expect(screen.queryByTestId("toolbar-assistant")).toBeNull();
+    });
+
+    it("stays absent when available but no handler is wired", () => {
+      renderToolbar({ assistantAvailable: true });
+      expect(screen.queryByTestId("toolbar-assistant")).toBeNull();
+    });
+
+    it("renders named, unpressed at rest, and opens on click", () => {
+      const onOpenAssistant = vi.fn();
+      renderToolbar({ assistantAvailable: true, onOpenAssistant });
+      const btn = screen.getByTestId("toolbar-assistant");
+      expect(btn).toHaveAccessibleName("Pipeline assistant");
+      expect(btn).toHaveAttribute("aria-pressed", "false");
+      fireEvent.click(btn);
+      expect(onOpenAssistant).toHaveBeenCalledTimes(1);
+    });
+
+    it("reflects the pressed state while the Assistant tab is the panel view", () => {
+      renderToolbar({
+        assistantAvailable: true,
+        onOpenAssistant: vi.fn(),
+        assistantActive: true,
+      });
+      expect(screen.getByTestId("toolbar-assistant")).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      );
+    });
+
+    it("adds exactly one more named button beside Pipeline info", () => {
+      renderToolbar({
+        assistantAvailable: true,
+        onOpenAssistant: vi.fn(),
+        onToggleInfo: vi.fn(),
+      });
+      const buttons = [
+        ...screen.getByTestId("edit-toolbar").querySelectorAll("button"),
+      ];
+      expect(buttons).toHaveLength(8); // 7 core + assistant
+      for (const b of buttons) expect(b).toHaveAccessibleName(/\S/);
+    });
+  });
 });
 
 describe("EditToolbar undo/redo buttons (ADR-0014 / #226)", () => {

--- a/frontend/src/components/EditToolbar.tsx
+++ b/frontend/src/components/EditToolbar.tsx
@@ -1,4 +1,4 @@
-import { Plus, GitMerge, Info, Undo2, Redo2, SquareTerminal, Box, StickyNote, FilePlus, FolderGit2 } from "lucide-react";
+import { Plus, GitMerge, Info, Undo2, Redo2, SquareTerminal, Box, StickyNote, FilePlus, FolderGit2, Bot } from "lucide-react";
 import type { NodeType } from "../types";
 import type { LibraryEntry } from "../api";
 import { Tooltip } from "./ui/tooltip";
@@ -21,6 +21,13 @@ interface Props {
   getDropPosition?: () => { x: number; y: number };
   infoOpen?: boolean;
   onToggleInfo?: () => void;
+  // #302 / ADR-0048: the "agent" glyph beside `(i)`. Opens the Pipeline info
+  // panel focused on the Assistant tab (the library authoring copilot). Only
+  // wired for a library *template* canvas (`assistantAvailable`) — on a run
+  // canvas the same access path leads to the Manager tab instead.
+  assistantAvailable?: boolean;
+  assistantActive?: boolean;
+  onOpenAssistant?: () => void;
   // #465 slice 2 (F1): on a live run the App auto-snaps the selection to the
   // running node, so the Run-info / Repositories sidebar (mounted when nothing
   // is selected) is otherwise unreachable. This toggle opens it explicitly. Only
@@ -34,7 +41,7 @@ interface Props {
   readOnly?: boolean;
 }
 
-export default function EditToolbar({ onAddNode, onAddNote, onAddNodeFromYaml, libraryEntries, onLibraryDelete, getDropPosition, infoOpen, onToggleInfo, showRunInfo = false, runInfoActive = false, onToggleRunInfo, readOnly = false }: Props) {
+export default function EditToolbar({ onAddNode, onAddNote, onAddNodeFromYaml, libraryEntries, onLibraryDelete, getDropPosition, infoOpen, onToggleInfo, assistantAvailable = false, assistantActive = false, onOpenAssistant, showRunInfo = false, runInfoActive = false, onToggleRunInfo, readOnly = false }: Props) {
   // Read undo/redo straight from the store (ADR-0014 / #226): they have no
   // component-local dependency, unlike the prop-drilled add/merge callbacks, so
   // the point-of-use selector idiom is the right fit. `canUndo`/`canRedo` are
@@ -188,24 +195,47 @@ export default function EditToolbar({ onAddNode, onAddNote, onAddNodeFromYaml, l
         </>
       )}
 
-      {onToggleInfo && (
+      {(onToggleInfo || (assistantAvailable && onOpenAssistant)) && (
         <>
-          {/* #315: no leading separator when the info button is the sole control. */}
+          {/* #315: no leading separator when the info group is the sole control. */}
           {!readOnly && !showRunInfo && <span className="mx-0.5 h-4 w-px bg-line" />}
 
-          <Tooltip content="Pipeline info">
-            <button
-              data-testid="toolbar-info"
-              onClick={onToggleInfo}
-              className={`grid h-7 w-7 cursor-pointer place-items-center rounded transition-colors ${
-                infoOpen
-                  ? "bg-acc text-bg-0"
-                  : "text-fg-3 hover:bg-bg-4 hover:text-fg active:bg-acc active:text-bg-0"
-              }`}
-            >
-              <Info size={14} />
-            </button>
-          </Tooltip>
+          {/* #302 / ADR-0048: the "agent" glyph, immediately left of `(i)`, both
+              opening the same Pipeline info panel — the Bot jumps straight to the
+              Assistant tab. Grouped with `(i)`, so no separator between them. */}
+          {assistantAvailable && onOpenAssistant && (
+            <Tooltip content="Pipeline assistant">
+              <button
+                data-testid="toolbar-assistant"
+                aria-label="Pipeline assistant"
+                aria-pressed={assistantActive}
+                onClick={onOpenAssistant}
+                className={`grid h-7 w-7 cursor-pointer place-items-center rounded transition-colors ${
+                  assistantActive
+                    ? "bg-acc text-bg-0"
+                    : "text-fg-3 hover:bg-bg-4 hover:text-fg active:bg-acc active:text-bg-0"
+                }`}
+              >
+                <Bot size={14} />
+              </button>
+            </Tooltip>
+          )}
+
+          {onToggleInfo && (
+            <Tooltip content="Pipeline info">
+              <button
+                data-testid="toolbar-info"
+                onClick={onToggleInfo}
+                className={`grid h-7 w-7 cursor-pointer place-items-center rounded transition-colors ${
+                  infoOpen
+                    ? "bg-acc text-bg-0"
+                    : "text-fg-3 hover:bg-bg-4 hover:text-fg active:bg-acc active:text-bg-0"
+                }`}
+              >
+                <Info size={14} />
+              </button>
+            </Tooltip>
+          )}
         </>
       )}
     </div>

--- a/frontend/src/components/PipelineInfoPanel.test.tsx
+++ b/frontend/src/components/PipelineInfoPanel.test.tsx
@@ -1,7 +1,7 @@
-import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import type { RunState } from "../types";
+import type { RunState, PipelineDef } from "../types";
 
 // The badge/banner live in the InfoTab header, above DiffSection. Mock the heavy
 // children (network-fetching diff, tmux terminal) so the test stays focused on the
@@ -9,7 +9,20 @@ import type { RunState } from "../types";
 vi.mock("./DiffSection", () => ({ default: () => null }));
 vi.mock("./TmuxTerminal", () => ({ default: () => null }));
 
+// #302 / ADR-0048: the Assistant tab drives create-if-absent / reap-on-leave
+// against the daemon. Mock those two api helpers so the tests can assert the
+// lifecycle without a network or a tmux session.
+const { openLibraryAssistant, closeLibraryAssistant } = vi.hoisted(() => ({
+  openLibraryAssistant: vi.fn(),
+  closeLibraryAssistant: vi.fn(),
+}));
+vi.mock("../api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../api")>();
+  return { ...actual, openLibraryAssistant, closeLibraryAssistant };
+});
+
 import PipelineInfoPanel from "./PipelineInfoPanel";
+import type { TabId } from "./PipelineInfoPanel";
 
 function makeRun(overrides: Partial<RunState> = {}): RunState {
   return {
@@ -100,5 +113,107 @@ describe("PipelineInfoPanel — accessible names (#397)", () => {
     );
     await userEvent.click(screen.getByRole("button", { name: "Close pipeline info" }));
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});
+
+// #302 / ADR-0048: the Assistant tab is the mirror of the Manager tab — shown
+// only for a library *template* (no live Run) with a resolvable pipeline id.
+describe("PipelineInfoPanel — Assistant tab (#302)", () => {
+  function makePipeline(overrides: Partial<PipelineDef> = {}): PipelineDef {
+    return {
+      name: "feature-with-review",
+      version: "1.0",
+      variables: {},
+      nodes: [],
+      edges: [],
+      ...overrides,
+    };
+  }
+
+  function renderTemplatePanel(
+    props: {
+      assistantId?: string | null;
+      assistantScope?: string;
+      initialTab?: TabId;
+      run?: RunState | null;
+    } = {},
+  ) {
+    // Honour an explicit `assistantId: null` (a template without a resolvable id)
+    // rather than coalescing it back to the default.
+    const assistantId = "assistantId" in props ? props.assistantId : "feature-with-review";
+    return render(
+      <PipelineInfoPanel
+        run={props.run ?? null}
+        pipeline={makePipeline()}
+        libraryPipelines={[]}
+        onLibraryChanged={() => {}}
+        onClose={() => {}}
+        initialTab={props.initialTab}
+        assistantId={assistantId}
+        assistantScope={props.assistantScope ?? "user"}
+      />,
+    );
+  }
+
+  beforeEach(() => {
+    openLibraryAssistant.mockReset();
+    closeLibraryAssistant.mockReset();
+    openLibraryAssistant.mockResolvedValue({
+      session: "pdo-libassist-feature-with-review",
+      created: true,
+    });
+    closeLibraryAssistant.mockResolvedValue({ ok: true, reaped: true });
+  });
+
+  it("shows the Assistant tab (not Manager) for a library template", () => {
+    renderTemplatePanel();
+    expect(screen.getByTestId("info-tab-assistant")).toBeInTheDocument();
+    // Manager is a run-only tab — absent for a template.
+    expect(screen.queryByTestId("info-tab-manager")).not.toBeInTheDocument();
+  });
+
+  it("hides the Assistant tab on a live run (Manager takes its place)", () => {
+    // Even with an id supplied, the `!run` gate hides the Assistant on a run.
+    renderTemplatePanel({ run: makeRun(), assistantId: "feature-with-review" });
+    expect(screen.queryByTestId("info-tab-assistant")).not.toBeInTheDocument();
+    expect(screen.getByTestId("info-tab-manager")).toBeInTheDocument();
+  });
+
+  it("hides the Assistant tab when no pipeline id is resolvable", () => {
+    renderTemplatePanel({ assistantId: null });
+    expect(screen.queryByTestId("info-tab-assistant")).not.toBeInTheDocument();
+  });
+
+  it("ensures the session on open and reaps it on leave", async () => {
+    const { unmount } = renderTemplatePanel({ initialTab: "assistant" });
+
+    // Create-on-open: mounting the Assistant tab ensures the session.
+    await waitFor(() =>
+      expect(openLibraryAssistant).toHaveBeenCalledWith(
+        "feature-with-review",
+        "user",
+      ),
+    );
+    // The resolved session name surfaces in the tab header.
+    expect(
+      await screen.findByText("pdo-libassist-feature-with-review"),
+    ).toBeInTheDocument();
+
+    // Reap-on-leave: unmounting (tab switch / panel close / pipeline switch all
+    // unmount this subtree) kills the session.
+    unmount();
+    expect(closeLibraryAssistant).toHaveBeenCalledWith("feature-with-review");
+  });
+
+  it("switching to the Assistant tab starts the session", async () => {
+    renderTemplatePanel();
+    expect(openLibraryAssistant).not.toHaveBeenCalled();
+    await userEvent.click(screen.getByTestId("info-tab-assistant"));
+    await waitFor(() =>
+      expect(openLibraryAssistant).toHaveBeenCalledWith(
+        "feature-with-review",
+        "user",
+      ),
+    );
   });
 });

--- a/frontend/src/components/PipelineInfoPanel.tsx
+++ b/frontend/src/components/PipelineInfoPanel.tsx
@@ -1,9 +1,10 @@
 import { useState, useMemo, useRef, useEffect } from "react";
-import { Info, Terminal, X, FileText, Code, Box, Loader } from "lucide-react";
+import { Info, Terminal, X, FileText, Code, Box, Loader, Bot } from "lucide-react";
 import { SectionHead } from "./InspectorPrimitives";
 import TmuxTerminal from "./TmuxTerminal";
 import DiffSection from "./DiffSection";
 import type { LibraryPipelineEntry } from "../api";
+import { openLibraryAssistant, closeLibraryAssistant } from "../api";
 import type { RunState, PipelineDef } from "../types";
 import { isLiveRun } from "../types";
 import { formatDuration, useRunDuration } from "../lib/runDuration";
@@ -11,7 +12,7 @@ import { formatEstCost } from "../lib/costLabel";
 import { serializePipeline } from "../lib/serializePipeline";
 import { highlightYaml } from "./yamlHighlight";
 
-export type TabId = "info" | "manager" | "yaml";
+export type TabId = "info" | "manager" | "yaml" | "assistant";
 
 function StatRow({
   label,
@@ -42,6 +43,13 @@ interface Props {
   onClose: () => void;
   initialTab?: TabId;
   scrollToLine?: number;
+  /** Library pipeline id the Assistant tab authors (#302 / ADR-0048). Present
+   *  only for a library template tab (not a live Run); `null`/absent hides the
+   *  Assistant tab. `PipelineDef` has no id, so it is threaded from the edit tab. */
+  assistantId?: string | null;
+  /** Scope of `assistantId` (`repo` | `user` | `library`) — selects the pipelines
+   *  directory the assistant is spawned in. */
+  assistantScope?: string;
 }
 
 const STATUS_DOT: Record<string, string> = {
@@ -62,6 +70,8 @@ export default function PipelineInfoPanel({
   onClose,
   initialTab,
   scrollToLine,
+  assistantId,
+  assistantScope,
 }: Props) {
   const pipelineName = run?.pipeline_name ?? pipeline?.name ?? "Untitled";
   const variables = pipeline?.variables ?? {};
@@ -69,12 +79,21 @@ export default function PipelineInfoPanel({
   const managerSession = run ? `pdo-mgr-${run.run_id}` : null;
 
   const hasManager = !!managerSession;
+  // #302: the Assistant is the mirror of the Manager — it exists only for a
+  // library *template* (no live Run) with a resolvable pipeline id. Manager and
+  // Assistant are therefore never both shown.
+  const hasAssistant = !run && !!assistantId;
   const [activeTab, setActiveTab] = useState<TabId>(initialTab ?? "info");
-  const resolvedTab = activeTab === "manager" && !hasManager ? "info" : activeTab;
+  const resolvedTab =
+    (activeTab === "manager" && !hasManager) ||
+    (activeTab === "assistant" && !hasAssistant)
+      ? "info"
+      : activeTab;
 
   const tabs: { id: TabId; label: string; icon: typeof Info; show: boolean }[] = [
     { id: "info", label: "Info", icon: FileText, show: true },
     { id: "manager", label: "Manager", icon: Terminal, show: hasManager },
+    { id: "assistant", label: "Assistant", icon: Bot, show: hasAssistant },
     { id: "yaml", label: "YAML", icon: Code, show: true },
   ];
 
@@ -129,6 +148,7 @@ export default function PipelineInfoPanel({
           pipeline={pipeline}
           pipelineName={pipelineName}
           variables={variableEntries}
+          hasAssistant={hasAssistant}
         />
       )}
 
@@ -157,10 +177,98 @@ export default function PipelineInfoPanel({
         </div>
       )}
 
+      {resolvedTab === "assistant" && hasAssistant && assistantId && (
+        // Key on id+scope so switching the authored pipeline remounts with fresh
+        // state (and reaps the old session via the unmount cleanup).
+        <AssistantTab
+          key={`${assistantId}:${assistantScope ?? ""}`}
+          pipelineId={assistantId}
+          scope={assistantScope}
+        />
+      )}
+
       {resolvedTab === "yaml" && (
         <YamlTab pipeline={pipeline} scrollToLine={scrollToLine} />
       )}
     </aside>
+  );
+}
+
+/**
+ * The Assistant tab body (#302 / ADR-0048): an inline `claude` REPL that authors
+ * the library template. Lifecycle = **create on open, reap on leave** (owner's
+ * ask): mounting ensures the `pdo-libassist-<id>` tmux session exists, unmounting
+ * (switching tab, closing the panel, or switching pipeline) reaps it. React
+ * unmounts this component in every one of those cases because it is rendered only
+ * while the Assistant tab is the resolved tab.
+ */
+function AssistantTab({
+  pipelineId,
+  scope,
+}: {
+  pipelineId: string;
+  scope?: string;
+}) {
+  const [session, setSession] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    // This subtree is remounted (keyed on id+scope) whenever the target changes,
+    // so the effect only needs to ensure-on-mount and reap-on-unmount — no
+    // in-effect state reset (which would trip react-hooks/set-state-in-effect).
+    let cancelled = false;
+    openLibraryAssistant(pipelineId, scope)
+      .then((r) => {
+        if (!cancelled) setSession(r.session);
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+      });
+    return () => {
+      cancelled = true;
+      // Reap on leave — best-effort; reaping an absent session is a no-op.
+      void closeLibraryAssistant(pipelineId).catch(() => {});
+    };
+  }, [pipelineId, scope]);
+
+  return (
+    <div
+      className="flex min-h-0 flex-1 flex-col"
+      style={{ fontSize: "11.5px" }}
+      data-testid="assistant-tab"
+    >
+      <div className="flex items-center gap-2 border-b border-line px-3 py-2">
+        <Bot size={14} className="text-fg-3" />
+        <span className="text-fg-2" style={{ fontSize: "11px" }}>
+          Pipeline Assistant
+        </span>
+        {session && (
+          <span className="font-mono text-fg-4" style={{ fontSize: "10px" }}>
+            {session}
+          </span>
+        )}
+      </div>
+      {error ? (
+        <div
+          className="flex flex-1 items-center justify-center px-4 text-center text-st-failed"
+          style={{ fontSize: "11.5px" }}
+          data-testid="assistant-error"
+        >
+          Failed to start the assistant: {error}
+        </div>
+      ) : session ? (
+        <TmuxTerminal session={session} expanded status="running" />
+      ) : (
+        <div
+          className="flex flex-1 items-center justify-center gap-2 text-fg-4"
+          style={{ fontSize: "11.5px" }}
+          data-testid="assistant-loading"
+        >
+          <Loader size={14} className="animate-spin" />
+          Starting the assistant…
+        </div>
+      )}
+    </div>
   );
 }
 
@@ -169,11 +277,13 @@ function InfoTab({
   pipeline,
   pipelineName,
   variables,
+  hasAssistant,
 }: {
   run: RunState | null;
   pipeline: PipelineDef | null;
   pipelineName: string;
   variables: [string, { default: unknown }][];
+  hasAssistant: boolean;
 }) {
   const durationMs = useRunDuration(run?.started_at, run?.completed_at, run?.status);
   const durationLabel = formatDuration(durationMs);
@@ -338,8 +448,9 @@ function InfoTab({
           >
             <Info size={14} className="shrink-0" />
             <span>
-              No active run. The Manager tab becomes available while a Run is in
-              progress.
+              {hasAssistant
+                ? "This is a template. Use the Assistant tab to author it in natural language; the Manager tab becomes available while a Run is in progress."
+                : "No active run. The Manager tab becomes available while a Run is in progress."}
             </span>
           </div>
         )}

--- a/prompts/builtin/library-assistant.md
+++ b/prompts/builtin/library-assistant.md
@@ -1,0 +1,124 @@
+You are the **Pipeline Assistant** for the PDO library — a design-time copilot that
+authors and edits pipeline **templates** in natural language, so the user does not
+have to wire nodes, edges, and prompts by hand on the canvas or hand-edit the YAML.
+
+You act **before/outside any Run**. You never orchestrate execution and never emit
+runtime commands. Your only durable effect is the template YAML (and its per-node
+prompts) that the user reviews and approves.
+
+## How you work
+
+1. **Understand the ask.** Read the current `<id>.yaml` and its `<id>.prompts/`.
+   Read sibling `*.yaml` in this folder for real examples of every construct.
+2. **Propose, with a diff.** Describe the change and show a unified diff of the
+   YAML (and any prompt files). Do not write anything yet.
+3. **Validate.** Run each changed node's YAML through `POST /nodes/parse` and fix
+   whatever it rejects before offering to save.
+4. **Save only on the user's OK.** Persist the whole template via
+   `POST /library/pipelines` with the same `id`. The canvas re-reads on save.
+
+Confirm before destructive edits (deleting nodes, dropping ports that downstream
+nodes consume). When in doubt, ask.
+
+## Pipeline YAML format
+
+A template is one YAML document:
+
+```yaml
+name: feature-with-review        # display name
+version: "1.0"
+variables:                        # optional; $name references, resolved at run start
+  max_iter: 3
+nodes: [ ... ]
+edges: [ ... ]
+loops: [ ... ]                    # optional; bounded loop regions
+```
+
+### Nodes
+
+```yaml
+nodes:
+  - id: implement                 # stable slug, unique in the pipeline
+    name: implementer             # display label
+    type: code-mutating
+    inputs:                       # emergent for work nodes — usually omit; named by edges
+      - { name: in, side: left }
+    outputs:
+      - name: out
+        side: bottom              # left | right | top | bottom
+        port_type: markdown       # markdown (default) | image | image_list | html
+        frontmatter:              # optional typed frontmatter the node must emit
+          Verdict:
+            type: enum            # enum | bool | string | int | number
+            allowed: [Pass, Fail, Minor_changes]
+    view: { x: 320, y: 173 }      # canvas position
+```
+
+**Node types** (`type:`):
+
+- `start` — the entry; its output carries the user prompt. One per pipeline.
+- `end` — the terminal sink. One per pipeline.
+- `code-mutating` — an agent node that edits the repo (gets a sub-worktree).
+- `doc-only` — an agent node with no repo side effect (analysis, review, design).
+  Add `interactive: true` for a node a human drives and marks done by hand.
+- `script` — deterministic author-written bash instead of an agent (ADR-0017).
+- `merge` — joins parallel branches back together (ADR-0006).
+- `switch` — mechanical fan-out on a typed value.
+
+Work nodes (`code-mutating` / `doc-only` / `script`) have **emergent inputs**: an
+input port is created from each incoming edge and named after the edge's target
+port — you normally don't declare `inputs:` on them. Structural nodes
+(`start`/`end`/`merge`/`switch`) keep declared ports.
+
+Each node's system prompt is a separate file `<id>.prompts/<node-id>.md`, sent in
+the `prompts` map of the save request (key = node id).
+
+### Edges
+
+```yaml
+edges:
+  - source: { node: implement, port: out }
+    target: { node: review, port: in }
+    target_side: top              # optional; which side the arrow lands on
+
+  # Conditional edge — taken only when the upstream frontmatter matches (ADR-0011):
+  - source: { node: review, port: out }
+    target: { node: ship, port: in }
+    when:
+      Verdict: { eq: Pass }       # eq | ne | gte | lte | ...
+
+  # The fallback edge for unmatched conditions:
+  - source: { node: review, port: out }
+    target: { node: implement, port: in }
+    else: true
+
+  # `mode: manual` — a gate a human must click to advance (vs default auto):
+  - source: { node: ship, port: out }
+    target: { node: end, port: result }
+    mode: manual
+    waypoints: [ { x: 368, y: 469 } ]   # optional edge routing points
+```
+
+### Loops (bounded regions)
+
+```yaml
+loops:
+  - id: loop-<hex>
+    kind: bounded
+    members: [implement, review]  # nodes that re-run together
+    max_iter: 3                   # ceiling; the region blocks "exhausted" at the cap
+```
+
+A conditional `else` edge from a member back to the region's head is what closes
+the loop; `max_iter` bounds it. Wire an explicit exhaustion exit (`when:` on the
+region ceiling) if you don't want the region to block at the cap.
+
+## Endpoints (also in your runtime preamble)
+
+- `POST /nodes/parse` — `{"yaml": "<one node's yaml>"}` → `{spec, prompt, warnings}`
+  or `400 {error}`. Validate here before saving.
+- `POST /library/pipelines` — `{"id","name","yaml","prompts":{node:md}}` → saves in
+  place. Omit `id` to create a fresh template.
+- `GET /library/pipelines` — list every template (ids, names, scopes).
+
+Keep the YAML the user's — verbatim, minimal diffs, no gratuitous reformatting.

--- a/scripts/layout-ratchet.sh
+++ b/scripts/layout-ratchet.sh
@@ -8,7 +8,7 @@ cd "$(git rev-parse --show-toplevel)"
 
 # <directory>  <max direct tracked files>
 BASELINES='
-frontend/src/components 143
+frontend/src/components 144
 crates/pdo-daemon/src 63
 '
 


### PR DESCRIPTION
## Assistant IA d'authoring des templates de bibliothèque — Closes #302

Ajoute un assistant `claude` amorcé pour créer/éditer les templates de pipeline de la
bibliothèque, conformément à **ADR-0048** et aux décisions d'owner F1–F5.

### Ce que ça fait
- Glyphe **Bot « Pipeline assistant »** dans la barre d'outils du canvas, **template-only**
  (jamais sur un Run), à côté du `(i)`.
- Onglet **Assistant** (Info · Assistant · YAML) qui attache une session `claude` amorcée,
  streamée dans le terminal PTY embarqué.
- cwd de la session = **dossier des templates** (`.pdo/library/pipelines`) → les templates
  voisins servent d'exemples few-shot (délibéré, ADR-0048).
- Cycle de vie **create-on-open / reap-on-leave** : session créée au 1er affichage de
  l'onglet, récoltée dès qu'on le quitte ; ré-ouverture = ré-attache la même session.

### Validation (nœud de recette) — **Verdict : Pass**
- Gate déterministe complet vert : **2329 tests Rust** (0 fail), **1811 vitest** (0 fail),
  clippy `-D warnings` / fmt / typecheck / lint / build / smoke propres.
- Recette agentique en conditions réelles (daemon isolé port 6172, UI pilotée navigateur) :
  Bot template-only qui toggle, onglet Assistant qui spawn une session `claude` amorcée dans
  le bon dossier, terminal qui stream, reap ~1 s au changement d'onglet — conforme au contrat.
- Le seul rouge CI (`layout-ratchet` 143→144) était **une dérive préexistante sur `main`**
  (fichier ajouté par `fix(#369)` sans bumper le baseline) — #302 n'ajoute aucun fichier sous
  `frontend/src/components` ; corrigé par un bump de baseline documenté.

### Commits inclus
- `feat(#302)` — assistant IA d'authoring des templates de bibliothèque
- `chore(ci)` — baseline ratchet `frontend/src/components` 143 → 144
- `chore(release)` — **1.30.0 → 1.31.0** + entrée CHANGELOG

🤖 Generated with [Claude Code](https://claude.com/claude-code)
