### PR TITLE
feat(ui): picker de harnais dynamique (depuis les descriptors), grisé si binaire non installé (#586)

### DIFF
--- a/crates/pdo-daemon/src/harness_registry.rs
+++ b/crates/pdo-daemon/src/harness_registry.rs
@@ -208,6 +208,40 @@ pub struct RejectedDescriptor {
     pub why: String,
 }
 
+/// Where a resolved harness came from — the embedded floor, or the disk tier
+/// (#586). The picker splits its two sections on this fact; it is a name-based
+/// judgement (`claude`/`opencode` are the floor), so a disk *override* of a floor
+/// name stays `Builtin` — the picker still lists it under "Built-in", which is
+/// what the design shows.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HarnessSource {
+    Builtin,
+    Descriptor,
+}
+
+impl HarnessSource {
+    /// The wire token `GET /settings` surfaces (`builtin` | `descriptor`).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            HarnessSource::Builtin => "builtin",
+            HarnessSource::Descriptor => "descriptor",
+        }
+    }
+}
+
+/// One resolved harness as the picker needs it (#586): its name, its provenance,
+/// and the binary PDO probes at spawn. The binary is exposed — not an `installed`
+/// bool — because whether it resolves on `$PATH` is decided by the caller
+/// (`tmux_session_manager::binary_available`, which alone reads the environment);
+/// this pure module never touches `$PATH`, the same discipline it keeps for
+/// `$HOME`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HarnessListing {
+    pub name: String,
+    pub source: HarnessSource,
+    pub binary: String,
+}
+
 /// The result of parsing the on-disk descriptor tier. Pure: text in; the parsed
 /// descriptors and any refusals out. An unparseable document yields
 /// `unparseable: Some(err)` and NO descriptors — never an `Err`, because a bad
@@ -389,6 +423,31 @@ impl HarnessRegistry {
     /// any novel disk harness). The `GET /settings` "which harnesses exist" view.
     pub fn names(&self) -> Vec<String> {
         self.descriptors.iter().map(|d| d.name.clone()).collect()
+    }
+
+    /// Each resolved harness with its provenance and probe binary, in resolution
+    /// order (#586). `source` is `Builtin` for the embedded floor names
+    /// (`claude`/`opencode`), `Descriptor` for a disk-declared harness — the split
+    /// the picker renders as two sections. `installed` is NOT decided here: the
+    /// caller pairs each `binary` with `tmux_session_manager::binary_available`, so
+    /// this module stays pure (no `$PATH`). Refused rows never enter
+    /// `self.descriptors`, so they are already absent — a refused key resolves to
+    /// the floor, which is what appears.
+    pub fn listing(&self) -> Vec<HarnessListing> {
+        let builtin: std::collections::HashSet<String> =
+            embedded_floor().into_iter().map(|d| d.name).collect();
+        self.descriptors
+            .iter()
+            .map(|d| HarnessListing {
+                name: d.name.clone(),
+                source: if builtin.contains(&d.name) {
+                    HarnessSource::Builtin
+                } else {
+                    HarnessSource::Descriptor
+                },
+                binary: d.binary.clone(),
+            })
+            .collect()
     }
 
     /// The disk descriptors the registry refused — each inert, its key on the
@@ -679,6 +738,77 @@ mod tests {
         assert_eq!(reg.rejected()[0].name, "claude");
         let d = reg.diagnostic().unwrap();
         assert!(d.contains("`claude`") && d.contains("falling through"));
+    }
+
+    #[test]
+    fn listing_tags_the_floor_builtin_and_a_disk_harness_descriptor() {
+        // #586: the picker's two sections. A novel disk harness is `Descriptor`;
+        // the embedded floor stays `Builtin`. The probe binary rides along so the
+        // caller can decide `installed` without this module reading `$PATH`.
+        let home = tempfile::tempdir().unwrap();
+        let path = HarnessRegistry::descriptors_path(home.path());
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &path,
+            "harnesses:\n  pi:\n    binary: pi-runner\n    launch: [\"exec\", \"pi-runner\"]\n",
+        )
+        .unwrap();
+
+        let reg = HarnessRegistry::load(home.path());
+        let listing = reg.listing();
+
+        let claude = listing.iter().find(|h| h.name == CLAUDE).unwrap();
+        assert_eq!(claude.source, HarnessSource::Builtin);
+        assert_eq!(claude.binary, "claude");
+
+        let opencode = listing.iter().find(|h| h.name == OPENCODE).unwrap();
+        assert_eq!(opencode.source, HarnessSource::Builtin);
+
+        let pi = listing.iter().find(|h| h.name == "pi").unwrap();
+        assert_eq!(pi.source, HarnessSource::Descriptor);
+        assert_eq!(
+            pi.binary, "pi-runner",
+            "the probe binary is exposed by name"
+        );
+
+        assert_eq!(HarnessSource::Builtin.as_str(), "builtin");
+        assert_eq!(HarnessSource::Descriptor.as_str(), "descriptor");
+    }
+
+    #[test]
+    fn listing_keeps_a_disk_override_of_a_floor_name_builtin() {
+        // A disk `claude:` override still lists under "Built-in" (name-based), so
+        // the picker's Built-in section always carries claude/opencode — what the
+        // design shows — while the override's own binary is what is probed.
+        let home = tempfile::tempdir().unwrap();
+        let path = HarnessRegistry::descriptors_path(home.path());
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &path,
+            "harnesses:\n  claude:\n    binary: my-claude\n    launch: [\"exec\", \"my-claude\"]\n",
+        )
+        .unwrap();
+
+        let reg = HarnessRegistry::load(home.path());
+        let claude = reg
+            .listing()
+            .into_iter()
+            .find(|h| h.name == CLAUDE)
+            .unwrap();
+        assert_eq!(claude.source, HarnessSource::Builtin);
+        assert_eq!(
+            claude.binary, "my-claude",
+            "the override's binary is probed"
+        );
+    }
+
+    #[test]
+    fn builtin_listing_is_the_floor_as_builtin() {
+        let listing = HarnessRegistry::builtin().listing();
+        assert_eq!(listing.len(), 2);
+        assert!(listing.iter().all(|h| h.source == HarnessSource::Builtin));
+        assert_eq!(listing[0].name, CLAUDE);
+        assert_eq!(listing[1].name, OPENCODE);
     }
 
     #[test]

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -8701,12 +8701,31 @@ async fn build_settings_view(state: &AppState) -> Result<serde_json::Value, sqlx
     // resolves (floor merged with disk), so a user learns their declared harness
     // "appeared"; `reason` carries the SAME string the loader logs. The path is
     // ALWAYS reported so the user knows where to write — nothing is ever seeded.
+    // #586: each resolved harness carries its provenance (`source`) and whether its
+    // binary resolves on `$PATH` (`installed`). The registry is pure — it yields the
+    // name/source/binary; `binary_available` (the same probe the spawn seam runs)
+    // decides `installed` here, beside the environment, so the picker greys a
+    // harness that would only fail-fast at launch.
+    let harness_list_json = |registry: &harness_registry::HarnessRegistry| {
+        registry
+            .listing()
+            .iter()
+            .map(|h| {
+                serde_json::json!({
+                    "name": h.name,
+                    "source": h.source.as_str(),
+                    "installed": tmux_session_manager::binary_available(&h.binary),
+                })
+            })
+            .collect::<Vec<_>>()
+    };
     let harness_descriptors_view = match &host_home_path {
         Some(home) => {
             let registry = harness_registry::HarnessRegistry::load(home);
             serde_json::json!({
                 "path": harness_registry::HarnessRegistry::descriptors_path(home).to_string_lossy(),
                 "names": registry.names(),
+                "harnesses": harness_list_json(&registry),
                 "rejected": registry
                     .rejected()
                     .iter()
@@ -8715,13 +8734,17 @@ async fn build_settings_view(state: &AppState) -> Result<serde_json::Value, sqlx
                 "reason": registry.diagnostic(),
             })
         }
-        None => serde_json::json!({
-            "path": null,
-            "names": harness_registry::HarnessRegistry::builtin().names(),
-            "rejected": [],
-            "reason": "HOME is unset, so the descriptor file has no resolvable path — \
-                       only the harnesses compiled into the binary apply",
-        }),
+        None => {
+            let registry = harness_registry::HarnessRegistry::builtin();
+            serde_json::json!({
+                "path": null,
+                "names": registry.names(),
+                "harnesses": harness_list_json(&registry),
+                "rejected": [],
+                "reason": "HOME is unset, so the descriptor file has no resolvable path — \
+                           only the harnesses compiled into the binary apply",
+            })
+        }
     };
 
     Ok(serde_json::json!({
@@ -21588,7 +21611,7 @@ edges:
         let state = test_state_with_dir(repo.path()).await;
         let app = build_router(state);
 
-        let content = include_str!("../../../.claude/workflows/simple-bugfix.js");
+        let content = include_str!("testdata/workflows/simple-bugfix.js");
         let body = serde_json::json!({
             "filename": "simple-bugfix.js",
             "content": content,
@@ -30505,6 +30528,51 @@ edges:
         for kept in ["default_sandbox", "sandbox_profiles", "sandbox_docker"] {
             assert!(view.get(kept).is_some(), "`{kept}` must stay: {view}");
         }
+    }
+
+    #[tokio::test]
+    async fn settings_view_lists_harnesses_with_source_and_installed() {
+        // #586 AC#1: `GET /settings → harness_descriptors` carries, per resolved
+        // harness, `name` + `source` (builtin|descriptor) + `installed` (bool) — the
+        // shape the two-section, grey-if-uninstalled picker reads. The embedded floor
+        // (claude/opencode) always resolves as `builtin`; disk-declared harnesses (if
+        // any on this host) ride as `descriptor`. `installed` reads the real `$PATH`,
+        // so we assert its TYPE, never a value — the picker only greys on it. `rejected`
+        // is preserved alongside (AC: kept for an eventual display).
+        let state = test_state().await;
+        let view = get_settings_json(&state).await;
+
+        let harnesses = view["harness_descriptors"]["harnesses"]
+            .as_array()
+            .expect("harness_descriptors.harnesses must be an array");
+        assert!(
+            !harnesses.is_empty(),
+            "the floor alone makes this non-empty"
+        );
+
+        for h in harnesses {
+            assert!(h["name"].is_string(), "each harness carries a name: {h}");
+            let source = h["source"].as_str().expect("source is a string");
+            assert!(
+                source == "builtin" || source == "descriptor",
+                "source is builtin|descriptor, got {source:?}"
+            );
+            assert!(h["installed"].is_boolean(), "installed is a bool: {h}");
+        }
+
+        // The embedded floor always resolves, always as `builtin`.
+        for floor in ["claude", "opencode"] {
+            let entry = harnesses
+                .iter()
+                .find(|h| h["name"] == floor)
+                .unwrap_or_else(|| panic!("floor harness `{floor}` must appear: {view}"));
+            assert_eq!(entry["source"], "builtin", "`{floor}` is built-in");
+        }
+
+        assert!(
+            view["harness_descriptors"]["rejected"].is_array(),
+            "rejected stays an array: {view}"
+        );
     }
 
     #[tokio::test]

--- a/crates/pdo-daemon/src/testdata/workflows/sandcastle-tdd.js
+++ b/crates/pdo-daemon/src/testdata/workflows/sandcastle-tdd.js
@@ -1,0 +1,546 @@
+export const meta = {
+  name: 'sandcastle-tdd',
+  description:
+    "Mimique sandcastle en workflow dynamique : vagues plan -> implement(/tdd) + review -> merge -> tester niveau 5 -> promote. Implementer pilote par la skill /tdd ; un tester agentique joue les scenarios couche 5 (docs/testing/scenarios) a la fin de CHAQUE vague. UNE SEULE branche de consolidation FIXE reutilisee a travers les runs (defaut sandcastle/integration, surchargeable args.target) — plus de wf/<tag>/integration jetable par run. Apres une vague VERTE (build+tests+L5), le workflow fait avancer main en fast-forward (args.promote=false pour ne livrer que sur la branche de consolidation). Cleanup garanti (try/finally).",
+  phases: [
+    { title: 'Bootstrap',        detail: "Reutilise (ou cree) la branche de consolidation FIXE + son worktree stable ; empile sur son tip" },
+    { title: 'Plan',             detail: 'Agent lit les issues ready-for-agent, sort les non-bloquees (lecture seule)' },
+    { title: 'Prepare',          detail: 'Cree en SERIE un worktree par issue depuis le tip integration (zero race)' },
+    { title: 'Implement+Review', detail: 'Par issue (parallele) : implementer /tdd dans son worktree, puis reviewer dans le meme' },
+    { title: 'Merge',            detail: 'Merge des branches completees DANS la branche de consolidation (worktree dedie) + build' },
+    { title: 'Test L5',          detail: 'Tester agentique : scenarios couche 5 sur le worktree integration (best-effort, app live + navigateur MCP)' },
+    { title: 'Fix L5',           detail: 'Sur FAIL L5 : fix-loop borne (cap L5_FIX_TRIES) qui corrige le CODE PRODUIT (jamais le scenario) + re-test ; fallback surface-humaine' },
+    { title: 'Promote',          detail: 'Vague verte : avance main (FF-only) jusqu\'au tip de consolidation ; note le SHA d\'avant pour reset trivial. Jamais de fusion divergente, jamais de push' },
+    { title: 'Cleanup',          detail: 'Garanti : seul proprietaire des worktrees feature ; supprime branches feature mergees sur succes, garde tout sur echec ; CONSERVE la branche de consolidation + son worktree (durables)' },
+  ],
+}
+
+// ---------------------------------------------------------------------------
+// Options (args). Defauts surs : rien de sortant (pas de push, pas de PR, pas
+// de fermeture d'issue). On ne touche jamais la branche/checkout de l'utilisateur.
+// ---------------------------------------------------------------------------
+// `args` peut arriver soit comme objet JSON, soit comme CHAINE (le tool Workflow
+// delivre parfois un objet sous forme de chaine JSON). On parse si c'est une chaine ;
+// une chaine non-JSON (p.ex. "issues en ready-for-agent") retombe sur les defauts.
+// Le harness peut DOUBLE-encoder args (chaine-JSON d'une chaine-JSON) : on deballe
+// en boucle jusqu'a obtenir un objet (ou une chaine non-JSON => defauts).
+let _rawArgs = args
+let _g = 0
+while (typeof _rawArgs === 'string' && _g++ < 5) {
+  try { _rawArgs = JSON.parse(_rawArgs) } catch (e) { break }
+}
+const opt           = (_rawArgs && typeof _rawArgs === 'object') ? _rawArgs : {}
+const LABEL         = opt.label             || 'ready-for-agent' // label des issues a prendre
+const MAX_WAVES     = opt.max_waves         || 3                 // garde-fou : nb max de vagues
+const WT_ROOT       = opt.worktree_root     || '.pdo/wf'     // racine des worktrees jetables
+const TARGET        = opt.target            || 'sandcastle/integration' // branche de consolidation FIXE, reutilisee + empilee a travers les runs (jamais une branche neuve par run)
+const INTEG_WT      = opt.integration_worktree || `${WT_ROOT}/integration` // worktree STABLE de la branche de consolidation (un seul, pas par run_tag)
+const SOURCE        = opt.source            || ''               // base a la PREMIERE creation de TARGET seulement (defaut: main). Sans effet si TARGET existe deja (on empile sur son tip).
+const PROMOTE       = opt.promote !== false                     // avancer PROMOTE_INTO (FF-only) apres une vague VERTE (defaut: true)
+const PROMOTE_INTO  = opt.promote_into      || 'main'           // branche locale a faire avancer en fast-forward (defaut: main)
+const SKIP_TEST     = opt.skip_test         || false             // sauter la couche 5
+const STOP_ON_FAIL  = opt.stop_on_fail !== false                 // stopper les vagues si L5 FAIL (defaut: true)
+const CLOSE_ISSUES  = opt.close_issues      || false             // SORTANT : fermer les issues au merge
+const REPO_HINT     = opt.repo              || 'Loulen/prompt-driven-orchestrator'  // repo gh (cf CLAUDE.local.md)
+const WAVE_FLOOR    = opt.wave_floor        || 80_000            // marge tokens avant de lancer une vague
+const PRIORITY      = Array.isArray(opt.priority) ? opt.priority.map(Number) : []  // numeros d'issues a traiter en priorite (ordre)
+const NOTES         = (opt.notes && typeof opt.notes === 'object') ? opt.notes : {} // {"<num>": "consigne supplementaire pour l'implementer de cette issue"}
+const L5_FIX_TRIES  = Number.isInteger(opt.l5_fix_tries) ? opt.l5_fix_tries : 2     // fix-loop borne apres un FAIL couche 5 (0 = desactive)
+
+// ---------------------------------------------------------------------------
+// Schemas (sortie structuree, validee au tool-call -> pas de parsing)
+// ---------------------------------------------------------------------------
+const BOOTSTRAP_SCHEMA = {
+  type: 'object', required: ['run_tag', 'source_branch', 'integration_branch', 'integration_worktree', 'tip_sha'],
+  properties: {
+    run_tag:              { type: 'string', description: 'Tag de run unique (genere via shell, p.ex. $(date +%s)-$RANDOM) — namespace les worktrees feature ephemeres' },
+    source_branch:        { type: 'string', description: 'Branche actuellement checkout (lecture seule, jamais modifiee)' },
+    source_sha:           { type: 'string' },
+    integration_branch:   { type: 'string', description: "Branche de consolidation FIXE reutilisee (= TARGET, defaut sandcastle/integration)" },
+    integration_worktree: { type: 'string', description: "Worktree (stable) de la branche de consolidation, tel qu'effectivement utilise" },
+    tip_sha:              { type: 'string', description: "Tip actuel de la branche de consolidation (apres reutilisation/creation)" },
+    reused:               { type: 'boolean', description: 'true si TARGET existait deja et a ete reutilisee ; false si creee ce run' },
+  },
+}
+const PLAN_SCHEMA = {
+  type: 'object', required: ['issues'],
+  properties: {
+    issues: {
+      type: 'array',
+      description: 'Issues NON bloquees, travaillables en parallele cette vague. Vide si rien a faire.',
+      items: {
+        type: 'object', required: ['number', 'title', 'branch', 'slug'],
+        properties: {
+          number: { type: 'number' },
+          title:  { type: 'string' },
+          branch: { type: 'string', description: 'sandcastle/<run_tag>/issue-<number>-<slug>' },
+          slug:   { type: 'string', description: 'slug court sans slash (chemin de worktree)' },
+        },
+      },
+    },
+  },
+}
+const PREPARE_SCHEMA = {
+  type: 'object', required: ['wave_base_sha', 'prepared'],
+  properties: {
+    wave_base_sha: { type: 'string', description: 'Tip integration AVANT cette vague (pour le diff du tester)' },
+    prepared: {
+      type: 'array',
+      items: {
+        type: 'object', required: ['number', 'branch', 'worktree', 'ready'],
+        properties: {
+          number:   { type: 'number' },
+          title:    { type: 'string' },
+          branch:   { type: 'string' },
+          worktree: { type: 'string' },
+          ready:    { type: 'boolean', description: 'worktree cree et utilisable' },
+        },
+      },
+    },
+  },
+}
+const IMPL_SCHEMA = {
+  type: 'object', required: ['branch', 'worktree', 'committed'],
+  properties: {
+    branch:    { type: 'string' },
+    worktree:  { type: 'string' },
+    committed: { type: 'boolean', description: 'true SEULEMENT si au moins un commit existe vs le tip integration' },
+    summary:   { type: 'string' },
+    blockers:  { type: 'string' },
+  },
+}
+const REVIEW_SCHEMA = {
+  type: 'object', required: ['branch', 'changed'],
+  properties: {
+    branch:  { type: 'string' },
+    changed: { type: 'boolean', description: 'true si le reviewer a commit des ameliorations' },
+    notes:   { type: 'string' },
+  },
+}
+const MERGE_SCHEMA = {
+  type: 'object', required: ['merged_branches', 'build_ok', 'integration_head_sha'],
+  properties: {
+    merged_branches:      { type: 'array', items: { type: 'string' } },
+    conflicts:            { type: 'boolean' },
+    build_ok:             { type: 'boolean', description: 'build + tests verts apres merge' },
+    integration_head_sha: { type: 'string' },
+    summary:              { type: 'string' },
+  },
+}
+const TEST_SCHEMA = {
+  type: 'object', required: ['verdict', 'setup_ok', 'scenarios'],
+  properties: {
+    verdict:  { type: 'string', enum: ['PASS', 'FAIL', 'SKIPPED'] },
+    setup_ok: { type: 'boolean', description: 'app couche 5 demarree et pilotable' },
+    port:     { type: 'number', description: 'port non-defaut effectivement utilise' },
+    scenarios: {
+      type: 'array',
+      items: {
+        type: 'object', required: ['name', 'verdict'],
+        properties: {
+          name:     { type: 'string' },
+          verdict:  { type: 'string', enum: ['PASS', 'FAIL', 'SKIPPED'] },
+          evidence: { type: 'array', items: { type: 'string' } },
+        },
+      },
+    },
+    anomalies: { type: 'array', items: { type: 'string' } },
+  },
+}
+const FIX_SCHEMA = {
+  type: 'object', required: ['kind', 'committed'],
+  properties: {
+    kind:                 { type: 'string', enum: ['fixed', 'unfixable-scope', 'gave-up'], description: 'fixed=code produit corrige ; unfixable-scope=la regression exige une decision hors-perimetre (humain/autre issue) ; gave-up=cause non trouvee' },
+    committed:            { type: 'boolean', description: 'true SEULEMENT si un commit de fix (code produit, jamais le scenario) a ete cree dans le worktree integration' },
+    integration_head_sha: { type: 'string', description: 'nouveau HEAD integration apres le fix' },
+    touched:              { type: 'array', items: { type: 'string' }, description: 'fichiers modifies (DOIT exclure docs/testing/scenarios/**)' },
+    summary:              { type: 'string' },
+  },
+}
+const PROMOTE_SCHEMA = {
+  type: 'object', required: ['advanced', 'method'],
+  properties: {
+    advanced:       { type: 'boolean', description: 'true si la branche promue a effectivement avance' },
+    method:         { type: 'string', enum: ['ff-ref', 'ff-worktree', 'skipped-not-ff', 'skipped-blocked', 'skipped-error'], description: 'ff-ref=ref avancee (branche non checkout) ; ff-worktree=FF dans le worktree qui la porte (checkout principal inclus) ; skipped-not-ff=divergence (pas un FF) ; skipped-blocked=FF refuse par git (arbre sale en conflit) ; skipped-error=autre' },
+    target_old_sha: { type: 'string', description: 'SHA de la branche promue AVANT — point de revert (git reset --hard <ce sha>)' },
+    target_new_sha: { type: 'string', description: 'SHA apres (= tip de consolidation si avance)' },
+    manual_cmd:     { type: 'string', description: 'commande FF a lancer manuellement si non avance (sinon vide)' },
+    summary:        { type: 'string' },
+  },
+}
+const CLEANUP_SCHEMA = {
+  type: 'object', required: ['removed', 'kept'],
+  properties: {
+    removed: { type: 'array', items: { type: 'string' }, description: 'worktrees/branches reellement supprimes' },
+    kept:    { type: 'array', items: { type: 'string' }, description: 'worktrees/branches conserves (echec ou integration)' },
+    failed:  { type: 'array', items: { type: 'string' }, description: 'suppressions qui ont echoue (a nettoyer a la main)' },
+  },
+}
+
+// ---------------------------------------------------------------------------
+// Prompts (inline, self-contained). Les agents font TOUT le git/shell :
+// le script lui-meme n'a ni fs ni shell.
+// ---------------------------------------------------------------------------
+const bootstrapPrompt = () =>
+  `NE PAS ECRIRE DE CODE APPLICATIF. Tu prepares l'environnement de consolidation du run.\n` +
+  `Le checkout principal de l'utilisateur (branche courante + d'eventuels changements non commites) est INTOUCHABLE : ne le checkout pas, ne le stash pas, ne le modifie pas. Lis juste sa branche courante pour info : \`git rev-parse --abbrev-ref HEAD\` et son SHA (source_branch, source_sha).\n\n` +
+  `1. Genere un tag de run UNIQUE (namespace les worktrees feature ephemeres, pas la branche) : run_tag="$(date +%s)-$RANDOM".\n` +
+  `2. \`git worktree prune\` (nettoie les refs de worktrees disparus).\n` +
+  `3. Branche de consolidation FIXE et REUTILISEE = \`${TARGET}\`. NE CREE JAMAIS une branche neuve par run (pas de wf/<tag>/...). Determine son etat :\n` +
+  `   a. Existe-t-elle ? \`git rev-parse --verify --quiet refs/heads/${TARGET}\`.\n` +
+  `   b. Est-elle deja attachee a un worktree ? \`git worktree list --porcelain\` (cherche une ligne \`branch refs/heads/${TARGET}\`).\n` +
+  `4. Choisis le worktree de consolidation (renvoie le chemin REEL dans integration_worktree) :\n` +
+  `   - Si \`${TARGET}\` est DEJA attachee a un worktree W : REUTILISE W tel quel. Verifie qu'il est propre (\`git -C W status --porcelain\` vide) ; s'il reste des modifs non commitees d'un run anterieur interrompu, c'est anormal — renvoie-le dans summary mais n'efface rien d'office.\n` +
+  `   - Sinon, si \`${TARGET}\` existe mais sans worktree : attache-la au chemin stable \`${INTEG_WT}\` : \`git worktree add ${INTEG_WT} ${TARGET}\` (si le chemin existe deja en doublon casse, \`git worktree prune\` puis reessaie).\n` +
+  `   - Sinon (\`${TARGET}\` n'existe pas) : cree-la a partir de la base ` + (SOURCE ? `\`${SOURCE}\` (fournie explicitement)` : `\`${PROMOTE_INTO}\` (la branche promue par defaut)`) + ` : \`git rev-parse <base>\` puis \`git worktree add -b ${TARGET} ${INTEG_WT} <base_sha>\`.\n` +
+  `   ATTENTION : si \`${TARGET}\` etait par erreur la branche du checkout principal, git refuserait un 2e worktree — ce n'est pas censé arriver (TARGET est dediee) ; si ça arrive, renvoie l'erreur dans summary sans toucher au checkout.\n` +
+  `5. Dans le worktree de consolidation, assure les pre-requis (cf memoire projet) : si \`.pdo/pipelines\` manque, copie-le depuis le checkout principal ; le frontend sera builde plus tard par les agents qui en ont besoin.\n` +
+  `Renvoie run_tag, source_branch, source_sha, integration_branch=\`${TARGET}\`, integration_worktree (chemin REEL utilise), tip_sha (= \`git -C <worktree> rev-parse HEAD\`), et reused (true si ${TARGET} preexistait).`
+
+const planPrompt = (exclude) =>
+  `NE PAS ECRIRE DE CODE. Tu es le PLANNER (role sandcastle), en LECTURE SEULE.\n` +
+  `1. Lis les issues ouvertes labellisees "${LABEL}" : \`gh issue list --repo ${REPO_HINT} --state open --label ${LABEL} --json number,title,body,labels,comments\`.\n` +
+  `2. Graphe de dependances : B est BLOQUEE par A si B requiert du code/infra que A introduit, si A et B touchent des fichiers/modules qui se chevauchent (conflit probable), ou si B depend d'une decision/API que A va etablir.\n` +
+  `3. NON bloquee = aucune dependance bloquante sur une autre issue ouverte. Une issue qui ressemble a un PRD avec des sous-issues d'implementation ne peut pas etre travaillee.\n` +
+  (exclude && exclude.length
+    ? `   IGNORE les issues DEJA TRAITEES ce run (deja integrees, ne les re-propose pas) : ${exclude.map((n) => '#' + n).join(', ')}.\n`
+    : '') +
+  `4. Pour chaque issue non bloquee : branche \`sandcastle/<run_tag>/issue-<number>-<slug>\` (utilise EXACTEMENT le run_tag fourni) et un slug court sans slash.\n` +
+  `   run_tag de ce run : "{{RUN_TAG}}".\n` +
+  (PRIORITY.length
+    ? `5. MODE PRIORITE (ordre IMPOSE : ${PRIORITY.map((n) => '#' + n).join(' > ')}). Le demandeur a DEJA valide cet ordre et l'absence de dependance bloquante entre ces issues. Donc TANT QUE ces issues ne sont pas toutes traitees :\n` +
+      `   - IGNORE COMPLETEMENT ta propre analyse de blocage POUR ces issues (traite-les comme non bloquees, meme si elles chevauchent d'autres fichiers).\n` +
+      `   - Renvoie EXACTEMENT UNE issue cette vague = la PREMIERE de la liste ci-dessus qui n'est ni deja traitee ni fermee, et RIEN d'autre (n'ajoute AUCUNE issue hors-liste tant que la liste n'est pas epuisee).\n` +
+      `   - Ce n'est qu'une fois TOUTES les issues de la liste traitees que tu reprends l'analyse normale (multi-issues non bloquees).\n`
+    : '') +
+  `Si tout est bloque, ne renvoie que la candidate la plus prioritaire (non deja traitee). Si rien de nouveau n'est travaillable, renvoie issues=[].`
+
+const preparePrompt = (issues, integrationBranch, integrationWorktree) =>
+  `NE PAS ECRIRE DE CODE. Tu prepares les worktrees de la vague, EN SERIE (un par un, jamais en parallele — evite toute race sur .git/worktrees).\n` +
+  `Base = le TIP ACTUEL de la branche d'integration \`${integrationBranch}\` (worktree ${integrationWorktree}). ` +
+  `Recupere ce SHA d'abord : \`git -C ${integrationWorktree} rev-parse HEAD\` -> c'est \`wave_base_sha\` (a renvoyer, le tester en aura besoin).\n\n` +
+  `Pour CHAQUE issue ci-dessous, dans l'ordre, cree un worktree base sur wave_base_sha avec EXACTEMENT le chemin et la branche indiques :\n` +
+  issues.map((i) => `  - #${i.number} (${i.title}) : git worktree add -b ${i.branch} ${i.worktree} <wave_base_sha>`).join('\n') + `\n\n` +
+  `Dans chaque worktree, assure les pre-requis : si \`.pdo/pipelines\` manque, copie-le depuis le checkout principal. ` +
+  `Si un \`git worktree add\` echoue (branche deja existante d'un run anterieur, etc.), marque \`ready:false\` pour cette issue et continue les autres.\n` +
+  `Renvoie wave_base_sha et la liste \`prepared\` (number, title, branch, worktree, ready).`
+
+const implPrompt = (p, integrationBranch) =>
+  `Tu es l'IMPLEMENTER. Issue #${p.number} UNIQUEMENT : ${p.title}.\n\n` +
+  `## Worktree (deja cree)\n` +
+  `Travaille EXCLUSIVEMENT dans \`${p.worktree}\` (branche ${p.branch}). \`cd ${p.worktree}\` (ou \`git -C ${p.worktree}\`). ` +
+  `Ne cree pas de worktree, ne change pas de branche, ne touche a aucun autre worktree ni au checkout principal.\n\n` +
+  `## Skill obligatoire : /tdd\n` +
+  `Pilote ton travail avec la skill **/tdd**. Si elle n'est pas chargeable, lis \`~/.agents/skills/tdd/SKILL.md\` (+ annexes). ` +
+  `Si NI la skill NI le fichier ne sont accessibles, applique quand meme ce contrat : red-green-refactor en SLICES VERTICALES — UN test -> l'implem minimale -> repeter ; jamais tous les tests d'abord ; tests sur le comportement via l'interface publique, pas l'implementation ; refactor seulement a vert.\n\n` +
+  `## Contexte (source de verite, depuis ton worktree)\n` +
+  `\`gh issue view ${p.number} --repo ${REPO_HINT} --comments\` (+ PRD parent si lie). Lis \`./CONTEXT.md\`, \`./.sandcastle/CODING_STANDARDS.md\` (conventions + commandes build/test), et les ADR pertinents de \`./docs/adr/\`. Les criteres d'acceptation definissent "done".\n\n` +
+  `## Feedback loops\n` +
+  `Avant de commit, lance les commandes pertinentes de CODING_STANDARDS (Rust si tu touches du Rust, frontend si frontend, les deux si les deux). Aucun test en echec tolere.\n\n` +
+  `## Scenarios couche 5 (synchro UNIQUEMENT si TON changement les invalide)\n` +
+  `Les scenarios \`docs/testing/scenarios/*.md\` sont des tests d'acceptation joues a la fin de la vague. Si ton implementation modifie DELIBEREMENT (acceptance criteria de CETTE issue) un comportement/une UI qu'un scenario existant asserte — p.ex. tu retires un bouton de toolbar, renommes/supprimes un selecteur ou data-testid, changes un flux d'interaction — METS A JOUR l'assertion CONCERNEE pour refleter le nouveau comportement voulu (cite l'issue/ADR dans le message de commit). C'est dans le perimetre de ton issue : un scenario qui asserte l'ancien comportement provoquerait un FAIL L5 faux-positif qui bloque la vague.\n` +
+  `INTERDIT (anti-triche, la review + le tester L5 le rejettent) : affaiblir/supprimer une assertion SANS rapport avec ton changement, ou vider un scenario pour le faire passer. Tu ne touches la mesure QUE quand c'est TON changement deliberé qui rend l'ancienne assertion obsolete, et tu la remplaces par l'assertion du NOUVEAU comportement (pas par rien).\n\n` +
+  `## Commit\n` +
+  `Commit dans ton worktree, message prefixe \`RALPH:\`, \`refs #${p.number}\`, ce qui a ete fait + decisions + fichiers + blocages. NE FERME PAS l'issue. Si incomplet, commente l'issue.\n\n` +
+  `## Sortie\n` +
+  `committed=true SEULEMENT si \`git -C ${p.worktree} log ${integrationBranch}..HEAD --oneline\` est non vide. Sinon committed=false + blockers explicites.\n` +
+  `PERIMETRE STRICT : QUE cette issue (sharp-tool), aucun refactor opportuniste.` +
+  (NOTES[String(p.number)]
+    ? `\n\n## Consigne specifique a cette issue (OVERRIDE — prime sur le body de l'issue en cas de conflit)\n${NOTES[String(p.number)]}`
+    : '')
+
+const reviewPrompt = (impl, integrationBranch) =>
+  `Tu es le REVIEWER. Worktree EXISTANT : ${impl.worktree} (branche ${impl.branch}). \`cd ${impl.worktree}\`. Ne cree pas de worktree, ne change pas de branche.\n\n` +
+  `## Diff a relire\n` +
+  `\`git -C ${impl.worktree} diff ${integrationBranch}...${impl.branch}\` et \`git -C ${impl.worktree} log ${integrationBranch}..${impl.branch} --oneline\`.\n\n` +
+  `## Process\n` +
+  `1. Comprendre l'intention (diff + commits + criteres de l'issue).\n` +
+  `2. Correctness : implem conforme a l'intention ? edge cases ? comportements nouveaux couverts par des tests ? casts douteux / any / hypotheses non verifiees ? injection / fuite de secret ?\n` +
+  `3. Clarte/maintenabilite : moins de complexite et d'imbrication, pas de redondance, bons noms, pas de ternaires imbriques. PRESERVE le comportement exact (seul le "comment" change).\n` +
+  `4. Standards : ./.sandcastle/CODING_STANDARDS.md.\n\n` +
+  `## Execution\n` +
+  `Si ameliorations : applique-les dans le worktree, relance build+tests pertinents, commit \`RALPH: Review - ...\`. Sinon ne fais rien. changed=true seulement si tu as commit.`
+
+const mergePrompt = (completed, integrationBranch, integrationWorktree) =>
+  `Tu es le MERGER. Tu opere UNIQUEMENT dans le worktree d'integration \`${integrationWorktree}\` (branche ${integrationBranch}). ` +
+  `Tu ne touches NI le checkout principal NI la branche de l'utilisateur. Pas de push, pas de PR.\n\n` +
+  `## Branches a merger (DANS CET ORDRE — ne reordonne pas)\n` +
+  completed.map((c) => `- ${c.branch}  — issue #${c.number}: ${c.title}`).join('\n') + `\n\n` +
+  `## Procedure\n` +
+  `1. Assure-toi d'etre sur ${integrationBranch} dans ${integrationWorktree} (\`git -C ${integrationWorktree} status\`).\n` +
+  `2. Pour chaque branche, dans l'ordre : \`git -C ${integrationWorktree} merge <branche> --no-edit\`. Conflit -> lis les deux cotes, resous intelligemment.\n` +
+  `3. Apres CHAQUE merge : build + tests pertinents (cf CODING_STANDARDS). Rouge -> corrige avant la branche suivante.\n` +
+  `4. Un commit de synthese a la fin si necessaire.\n` +
+  `5. NE supprime PAS les worktrees ni les branches (le cleanup final en est le SEUL proprietaire).\n` +
+  (CLOSE_ISSUES
+    ? `6. SORTANT — ferme les issues mergees : \`gh issue close <n> --repo ${REPO_HINT}\` (+ PRD parent si complete).\n`
+    : `6. NE FERME PAS les issues (gate humaine).\n`) +
+  `\nRenvoie merged_branches (celles reellement mergees), conflicts (bool), build_ok (bool), integration_head_sha (= \`git -C ${integrationWorktree} rev-parse HEAD\`), et un resume.`
+
+const testPrompt = (waveBaseSha, merge, completed, integrationWorktree) =>
+  `Tu es le TESTER COUCHE 5 (scenarios agentiques). Cible : le worktree d'integration \`${integrationWorktree}\` APRES merge de la vague (head ${merge.integration_head_sha || '?'}).\n` +
+  `Protocole de reference a suivre A LA LETTRE : \`docs/agents/run-scenario.md\` (setup -> piloter le navigateur -> valider les effets de bord -> verdict JSON). Couche definie dans \`docs/adr/0004-testing-strategy.md\`.\n\n` +
+  `## Selection des scenarios (deterministe)\n` +
+  `Diff de la vague = \`git -C ${integrationWorktree} diff ${waveBaseSha}..${merge.integration_head_sha || 'HEAD'} --stat\` (SHAs explicites, n'utilise PAS de reflog @{1}).\n` +
+  `Liste TOUS les scenarios : \`ls ${integrationWorktree}/docs/testing/scenarios/*.md\`, lis chacun, et choisis ceux dont la portee CHEVAUCHE le diff. Au minimum, joue \`run-minimal\` (smoke du parcours principal). Le set evolue — DECOUVRE-le via le \`ls\` (ne te fie pas a une liste figee).\n\n` +
+  `## Setup (best-effort, NON DESTRUCTIF)\n` +
+  `La couche 5 a besoin de l'app qui TOURNE (depuis ${integrationWorktree}) : build frontend (\`frontend/dist\`), build daemon (\`cargo build -p pdo-daemon\`), demarrage du daemon, navigateur via MCP chrome-devtools (sinon playwright MCP), tmux + \`claude\` pour run-minimal.\n` +
+  `PORT — ne casse JAMAIS l'environnement de l'utilisateur :\n` +
+  `  - N'utilise PAS le port par defaut 5172. D'abord verifie que le daemon supporte un port custom : \`pdo --help\` / \`pdo daemon --help\` (flag \`--port\` ou env \`PDO_PORT\`). Si tu ne peux pas confirmer le support, verdict SKIPPED.\n` +
+  `  - Choisis un port LIBRE (verifie avec \`ss -ltn\` / un curl qui echoue) hors 5172, demarre le daemon dessus, et CONFIRME : \`curl -fs http://127.0.0.1:<port>/runs\` renvoie du JSON. Adapte TOUTES les URLs/ports des scenarios (5172/5173) a ton port.\n` +
+  `  - Si 5172 est occupe, ne tue rien : c'est probablement le daemon de l'utilisateur.\n` +
+  `  - GARDE le PID du daemon que TU demarres ; a la fin, archive les Run que tu as lances (\`POST /runs/<id>/commands {"kind":"cleanup_run"}\`) PUIS tue CE PID (et lui seul). Ne touche a aucun process que tu n'as pas demarre.\n` +
+  `  - Toolchain manquant (pas de cargo/tmux) ou build qui echoue -> verdict SKIPPED (pas FAIL), explique dans evidence.\n` +
+  `  - MEME si setup_ok=false ou verdict SKIPPED : avant de rendre la main, tue tout daemon que TU aurais demarre (ne laisse aucun process orphelin). Le cleanup final ne gere PAS les process, seulement les worktrees/branches.\n\n` +
+  `## Verdict\n` +
+  `Pour chaque scenario lance, mappe son format de verdict declare vers {name, verdict, evidence}. Une assertion en echec = ce scenario FAIL (pas de demi-PASS). ` +
+  `verdict global = PASS si tous les scenarios lances passent ; FAIL si >=1 FAIL (vraie regression) ; SKIPPED si l'app n'a pas pu etre pilotee. Renvoie aussi le port utilise.`
+
+const l5FixPrompt = (test, integrationBranch, integrationWorktree, attempt, maxAttempts) =>
+  `Tu es le FIXER COUCHE 5 (tentative ${attempt}/${maxAttempts}). La couche 5 a trouve une REGRESSION apres merge dans l'integration. ` +
+  `Tu corriges le CODE PRODUIT pour que le(s) scenario(s) passent HONNETEMENT. Tu opere UNIQUEMENT dans le worktree d'integration \`${integrationWorktree}\` (branche ${integrationBranch}). Pas de push, pas de PR, pas de fermeture d'issue.\n\n` +
+  `## Ce que la couche 5 reproche (source de verite du QUOI corriger)\n` +
+  `Scenarios FAIL : ${((test && test.scenarios) || []).filter((s) => s.verdict === 'FAIL').map((s) => s.name).join(', ') || '(voir anomalies)'}.\n` +
+  '```json\n' + JSON.stringify({ scenarios: ((test && test.scenarios) || []).filter((s) => s.verdict === 'FAIL'), anomalies: (test && test.anomalies) || [] }, null, 2).slice(0, 4500) + '\n```\n\n' +
+  `## Regles ABSOLUES (anti-triche)\n` +
+  `- INTERDIT d'editer, affaiblir ou supprimer un fichier de scenario \`docs/testing/scenarios/**\`, ni d'affaiblir/supprimer une assertion de test pour forcer le vert. Tu corriges le PRODUIT, jamais la mesure. (Le champ touched[] que tu renvoies DOIT exclure docs/testing/scenarios/**.)\n` +
+  `- Si la regression n'est PAS corrigible dans le perimetre de la vague (elle exige une decision d'architecture, une autre issue, un reordonnancement, un choix produit), NE bricole RIEN : renvoie kind="unfixable-scope" + un summary expliquant la decision a prendre. Surface au gate humain > fix incoherent.\n` +
+  `- Perimetre minimal : juste de quoi lever cette regression. Aucun refactor opportuniste.\n\n` +
+  `## Procedure\n` +
+  `1. Comprends l'echec depuis l'evidence ci-dessus ; localise la cause dans le code PRODUIT (pas le test).\n` +
+  `2. Corrige, puis relance les feedback loops pertinents (cf ./.sandcastle/CODING_STANDARDS.md : build + tests Rust et/ou frontend selon les fichiers touches). Aucun test en echec tolere.\n` +
+  `3. Commit dans le worktree integration, message \`RALPH: L5-fix - <quoi>\` (ce commit court-circuite la review per-issue ; le gate humain le relira).\n` +
+  `4. NE supprime PAS de worktree/branche.\n\n` +
+  `## Sortie\n` +
+  `kind, committed (true seulement si commit cree), integration_head_sha (= \`git -C ${integrationWorktree} rev-parse HEAD\`), touched[] (hors scenarios), summary.`
+
+const promotePrompt = (integrationBranch, integrationHeadSha, into) =>
+  `Tu es le PROMOTER. La vague est VERTE (build + tests + couche 5 OK). Objectif : faire avancer la branche locale \`${into}\` jusqu'au tip de \`${integrationBranch}\` (${integrationHeadSha}) en FAST-FORWARD UNIQUEMENT. ` +
+  `JAMAIS de fusion divergente, jamais de resolution de conflit, jamais de push, jamais de --force/-f sur une ref divergente.\n\n` +
+  `## Procedure\n` +
+  `1. Note le SHA actuel de \`${into}\` -> \`target_old_sha\` (point de revert : \`git reset --hard <ce sha>\`).\n` +
+  `2. Verifie que c'est bien un fast-forward : \`git merge-base --is-ancestor ${into} ${integrationBranch}\` (exit 0 = FF possible). Si NON (\`${into}\` a des commits absents de la consolidation -> divergence) : N'AVANCE RIEN, method="skipped-not-ff", \`manual_cmd\` = la commande de merge a decider a la main, explique la divergence dans summary. STOP.\n` +
+  `3. Localise ou \`${into}\` est checkout : \`git worktree list --porcelain\` (ligne \`branch refs/heads/${into}\`).\n` +
+  `   - \`${into}\` checkout NULLE PART -> avance la ref directement : \`git branch -f ${into} ${integrationBranch}\`. method="ff-ref".\n` +
+  `   - \`${into}\` checkout dans un worktree W (le checkout principal de l'utilisateur en fait partie — et c'est OK d'y faire un FF) -> \`git -C W merge --ff-only ${integrationBranch}\`. method="ff-worktree". ` +
+  `Un FF met juste a jour l'arbre ; d'eventuels changements non commites qui n'entrent pas en conflit sont preserves par git. Si (et seulement si) git REFUSE le FF (arbre sale en conflit avec les fichiers avances) : N'INSISTE PAS, ne stash pas, ne commit pas a la place de l'utilisateur — method="skipped-blocked", \`manual_cmd\`=\`git -C W merge --ff-only ${integrationBranch}\` (a relancer une fois l'arbre propre), explique dans summary.\n` +
+  `4. Ne touche a RIEN d'autre (pas d'autre branche, pas de remote).\n\n` +
+  `## Sortie\n` +
+  `advanced (bool), method, target_old_sha, target_new_sha (= \`git rev-parse ${into}\` apres), manual_cmd (vide si avance), summary.`
+
+const cleanupPrompt = (runTag, integrationBranch, integrationWorktree, success, mergedBranches) =>
+  `Tu es le CLEANUP (garanti, SEUL proprietaire des worktrees ; ne build pas, ne merge pas, ne push pas).\n` +
+  `1. Inventaire d'abord : \`git worktree list\` et \`git branch --list 'sandcastle/${runTag}/*'\`. N'agis QUE sur les worktrees FEATURE de ce run (sous \`${WT_ROOT}/${runTag}/\`) et les branches feature \`sandcastle/${runTag}/*\`. La branche de consolidation \`${integrationBranch}\` et son worktree \`${integrationWorktree}\` sont DURABLES et PROTEGES : ne les supprime JAMAIS. Ne touche JAMAIS au checkout principal, ni a un worktree/branche hors du prefixe de ce run, ni a une branche promue (ex. main), ni a une branche distante.\n` +
+  (success
+    ? `2. SUCCES : pour chaque worktree FEATURE sous \`${WT_ROOT}/${runTag}/\` (jamais le worktree de consolidation \`${integrationWorktree}\`) qui existe -> \`git worktree remove <path>\` (--force seulement si refus attendu). Puis \`git worktree prune\`.\n` +
+      `3. Supprime UNIQUEMENT les branches feature CONFIRMEES MERGEES : ${mergedBranches.map((b) => '`' + b + '`').join(', ') || '(aucune)'} -> \`git branch -D <b>\`. ` +
+      `Toute autre branche \`sandcastle/${runTag}/*\` NON listee ici (merge non abouti, conflit) est a CONSERVER (elle peut porter du travail non integre).\n` +
+      `4. CONSERVE la branche de consolidation \`${integrationBranch}\` ET son worktree \`${integrationWorktree}\` (durables, reutilises au prochain run — ne les retire pas).\n`
+    : `2. ECHEC/incomplet : NE supprime AUCUNE branche ni worktree. Conserve tout (worktrees feature \`${WT_ROOT}/${runTag}/\`, branches \`sandcastle/${runTag}/*\`, consolidation \`${integrationBranch}\` + worktree) pour inspection humaine.\n`) +
+  `Renvoie removed[], kept[], failed[] (suppressions qui ont echoue, a nettoyer a la main).`
+
+// ---------------------------------------------------------------------------
+// Orchestration : bootstrap -> vagues (plan -> prepare -> implement+review ->
+// merge -> test L5) -> cleanup garanti (try/finally).
+// ---------------------------------------------------------------------------
+const waves = []
+const allMergedBranches = []    // branches feature CONFIRMEES mergees (seules supprimables au cleanup)
+const handled = []              // numeros d'issues deja traitees ce run (exclues des plans suivants)
+let runOk = true
+let boot = null
+
+try {
+  // ---- Bootstrap (une fois) ----
+  phase('Bootstrap')
+  boot = await agent(bootstrapPrompt(), { label: 'bootstrap', phase: 'Bootstrap', schema: BOOTSTRAP_SCHEMA })
+  if (!boot || !boot.run_tag || !boot.integration_worktree) {
+    log('Bootstrap a echoue (pas de worktree d\'integration) — abandon.')
+    runOk = false
+    return { ok: false, reason: 'bootstrap-failed', boot }
+  }
+  const { run_tag, integration_branch, integration_worktree } = boot
+  log(`Run tag ${run_tag} — consolidation \`${integration_branch}\` ${boot.reused ? 'REUTILISEE' : 'creee'} @ ${(boot.tip_sha || '').slice(0, 9)} (checkout \`${boot.source_branch}\` jamais modifie). ${PROMOTE ? `Vagues vertes -> FF \`${PROMOTE_INTO}\`.` : 'Promote desactive (livraison sur la branche de consolidation).'}`)
+
+  let stop = false
+  for (let wave = 1; wave <= MAX_WAVES && !stop; wave++) {
+    if (budget.total && budget.remaining() < WAVE_FLOOR) {
+      log(`Budget bas (${Math.round(budget.remaining() / 1000)}k restants) — arret avant la vague ${wave}.`)
+      break
+    }
+
+    // ---- Plan (lecture seule) ----
+    phase(`Vague ${wave} · Plan`)
+    // Function replacer : run_tag est insere litteralement (pas d'interpretation de $&/$1).
+    const plan = await agent(planPrompt(handled).replace('{{RUN_TAG}}', () => run_tag), {
+      label: `planner·v${wave}`, phase: `Vague ${wave} · Plan`, schema: PLAN_SCHEMA,
+    })
+    if (!plan || !plan.issues || plan.issues.length === 0) {
+      log(`Vague ${wave} : aucune issue travaillable — fin des vagues.`)
+      break
+    }
+    // Chemins de worktree calcules par le script (uniques par run/vague/issue).
+    const planned = plan.issues.map((i) => ({
+      ...i, worktree: `${WT_ROOT}/${run_tag}/w${wave}-${i.slug}`,
+    }))
+    log(`Vague ${wave} : ${planned.length} issue(s) -> ` + planned.map((i) => `#${i.number}`).join(', '))
+
+    // ---- Prepare (SERIE, zero race) ----
+    phase(`Vague ${wave} · Prepare`)
+    const prep = await agent(preparePrompt(planned, integration_branch, integration_worktree), {
+      label: `prepare·v${wave}`, phase: `Vague ${wave} · Prepare`, schema: PREPARE_SCHEMA,
+    })
+    const ready = ((prep && prep.prepared) || []).filter((p) => p && p.ready)
+    if (ready.length === 0) {
+      log(`Vague ${wave} : aucun worktree pret — arret.`)
+      break
+    }
+    const waveBaseSha = (prep && prep.wave_base_sha) || boot.tip_sha
+
+    // ---- Implement (/tdd) + Review, par issue, en parallele (worktrees pre-crees) ----
+    // pipeline : implement PUIS review pour la MEME issue, sans barriere entre issues.
+    const results = await pipeline(
+      ready,
+      (prevResult, p) => agent(implPrompt(p, integration_branch), {
+        label: `impl·#${p.number}`, phase: `Vague ${wave} · Implement+Review`, schema: IMPL_SCHEMA,
+      }).then((r) => ({ ...p, ...(r || {}), committed: !!(r && r.committed) })),
+      (impl) => {
+        if (!impl || !impl.committed) return impl   // rien a relire
+        return agent(reviewPrompt(impl, integration_branch), {
+          label: `review·#${impl.number}`, phase: `Vague ${wave} · Implement+Review`, schema: REVIEW_SCHEMA,
+        }).then((rev) => ({ ...impl, review: rev || null }))
+      },
+    )
+
+    const completed = results.filter((r) => r && r.committed)
+    log(`Vague ${wave} : ${completed.length}/${ready.length} issue(s) avec commits.`)
+    if (completed.length === 0) {
+      log(`Vague ${wave} : aucun commit — arret (rien a merger).`)
+      waves.push({ wave, planned: planned.length, completed: 0, merge: null, test: null })
+      break
+    }
+    // Ordre de merge deterministe : numero d'issue croissant.
+    completed.sort((a, b) => a.number - b.number)
+
+    // ---- Merge (dans la branche integration) ----
+    phase(`Vague ${wave} · Merge`)
+    let merge = await agent(mergePrompt(completed, integration_branch, integration_worktree), {
+      label: `merger·v${wave}`, phase: `Vague ${wave} · Merge`, schema: MERGE_SCHEMA,
+    })
+    if (merge && merge.build_ok === false) runOk = false
+    // Seules les branches CONFIRMEES mergees sont supprimables au cleanup.
+    if (merge && Array.isArray(merge.merged_branches)) allMergedBranches.push(...merge.merged_branches)
+    // Les issues effectivement traitees ne seront pas re-proposees aux vagues suivantes.
+    handled.push(...completed.map((c) => c.number))
+
+    // ---- Test couche 5 (best-effort) + fix-loop borne ----
+    let test = null
+    if (!SKIP_TEST) {
+      phase(`Vague ${wave} · Test L5`)
+      test = await agent(testPrompt(waveBaseSha, merge || {}, completed, integration_worktree), {
+        label: `tester-L5·v${wave}`, phase: `Vague ${wave} · Test L5`, schema: TEST_SCHEMA,
+      })
+
+      // Sur FAIL : tenter jusqu'a L5_FIX_TRIES corrections du CODE PRODUIT (jamais le scenario),
+      // re-tester apres chaque fix. Fallback garanti : si toujours rouge apres N (ou fix non
+      // aboutie / hors-perimetre), on retombe sur le comportement historique (surface au gate humain).
+      let fixTry = 0
+      while (
+        test && test.verdict === 'FAIL' &&
+        fixTry < L5_FIX_TRIES &&
+        (!budget.total || budget.remaining() > WAVE_FLOOR)
+      ) {
+        fixTry++
+        const fp = `Vague ${wave} · Fix L5 ${fixTry}/${L5_FIX_TRIES}`
+        phase(fp)
+        const fix = await agent(l5FixPrompt(test, integration_branch, integration_worktree, fixTry, L5_FIX_TRIES), {
+          label: `fix-L5·v${wave}·${fixTry}`, phase: fp, schema: FIX_SCHEMA,
+        })
+        if (!fix || !fix.committed || fix.kind !== 'fixed') {
+          log(`Vague ${wave} : fix L5 ${fixTry}/${L5_FIX_TRIES} non aboutie (${(fix && fix.kind) || 'pas de fix'}) — arret du fix-loop, surface au gate.`)
+          break
+        }
+        if (fix.integration_head_sha) merge = { ...(merge || {}), integration_head_sha: fix.integration_head_sha }
+        log(`Vague ${wave} : fix L5 ${fixTry}/${L5_FIX_TRIES} appliquee (${(fix.touched || []).length} fichier(s)) — re-test.`)
+        const rp = `Vague ${wave} · Re-test L5 ${fixTry}/${L5_FIX_TRIES}`
+        phase(rp)
+        test = await agent(testPrompt(waveBaseSha, merge || {}, completed, integration_worktree), {
+          label: `tester-L5·v${wave}·retry${fixTry}`, phase: rp, schema: TEST_SCHEMA,
+        })
+      }
+
+      if (test && test.verdict === 'FAIL') {
+        runOk = false
+        log(`Vague ${wave} : couche 5 = FAIL` + (fixTry ? ` apres ${fixTry} fix(s)` : '') + ` — regression.` + (STOP_ON_FAIL ? ' Arret des vagues.' : ' (poursuite, stop_on_fail=false)'))
+        if (STOP_ON_FAIL) stop = true
+      } else {
+        log(`Vague ${wave} : couche 5 = ${(test && test.verdict) || 'aucun'}` + (fixTry ? ` (vert apres ${fixTry} fix L5).` : '.'))
+      }
+    }
+
+    // ---- Promote (vague VERTE -> avance main en FF-only) ----
+    // Verte = build OK apres merge ET (tests sautes OU couche 5 non-FAIL). On ne
+    // promeut jamais une vague rouge : main ne contient que du vert. FF-only +
+    // garde-fous : jamais de fusion divergente, jamais de push (cf promotePrompt).
+    let promote = null
+    const waveGreen = merge && merge.build_ok !== false && (SKIP_TEST || (test && test.verdict !== 'FAIL'))
+    if (PROMOTE && waveGreen) {
+      phase(`Vague ${wave} · Promote`)
+      promote = await agent(
+        promotePrompt(integration_branch, (merge && merge.integration_head_sha) || 'HEAD', PROMOTE_INTO),
+        { label: `promote·v${wave}`, phase: `Vague ${wave} · Promote`, schema: PROMOTE_SCHEMA },
+      )
+      if (promote && promote.advanced) {
+        log(`Vague ${wave} : ${PROMOTE_INTO} avance ${(promote.target_old_sha || '').slice(0, 9)} -> ${(promote.target_new_sha || '').slice(0, 9)} (${promote.method}).`)
+      } else {
+        log(`Vague ${wave} : ${PROMOTE_INTO} NON avance (${(promote && promote.method) || '?'})` + ((promote && promote.manual_cmd) ? ` — FF manuel : ${promote.manual_cmd}` : '') + '.')
+      }
+    } else if (PROMOTE && !waveGreen) {
+      log(`Vague ${wave} : vague non verte -> ${PROMOTE_INTO} non avance (travail garde sur ${integration_branch}).`)
+    }
+
+    waves.push({
+      wave,
+      planned: planned.length,
+      completed: completed.length,
+      issues: completed.map((c) => ({ number: c.number, title: c.title, branch: c.branch })),
+      merge, test, promote,
+    })
+  }
+} finally {
+  // ---- Cleanup garanti (seul proprietaire des worktrees) ----
+  phase('Cleanup')
+  if (boot && boot.run_tag) {
+    await agent(
+      cleanupPrompt(boot.run_tag, boot.integration_branch, boot.integration_worktree, runOk, allMergedBranches),
+      { label: 'cleanup', phase: 'Cleanup', schema: CLEANUP_SCHEMA },
+    )
+  } else {
+    log('Pas de bootstrap reussi — rien a nettoyer.')
+  }
+}
+
+// Resume de promotion (la derniere vague verte qui a avance la branche promue donne le point de revert)
+const promotedWaves = waves.filter((w) => w.promote && w.promote.advanced)
+const lastPromote = promotedWaves.length ? promotedWaves[promotedWaves.length - 1].promote : null
+
+return {
+  ok: runOk,
+  run_tag: boot && boot.run_tag,
+  integration_branch: boot && boot.integration_branch,
+  integration_reused: boot && boot.reused,
+  source_branch: boot && boot.source_branch,
+  promote_into: PROMOTE ? PROMOTE_INTO : null,
+  promoted_waves: promotedWaves.length,
+  // point de revert = SHA de la branche promue AVANT la 1re promotion de ce run
+  revert_point: promotedWaves.length ? promotedWaves[0].promote.target_old_sha : null,
+  promoted_head: lastPromote ? lastPromote.target_new_sha : null,
+  waves_run: waves.length,
+  waves,
+  note:
+    `Checkout utilisateur jamais modifie (hors FF de \`${PROMOTE_INTO}\` si c'est la branche checkout et propre). ` +
+    `Consolidation sur la branche FIXE \`${TARGET}\` (reutilisee a travers les runs). ` +
+    (PROMOTE
+      ? `Vagues vertes promues en FF vers \`${PROMOTE_INTO}\`${promotedWaves.length ? ` (revert : git reset --hard ${(promotedWaves[0].promote.target_old_sha || '').slice(0, 9)})` : ''}. `
+      : `Promote desactive : tout reste sur \`${TARGET}\` pour relecture/merge humain. `) +
+    (SKIP_TEST ? 'Couche 5 sautee.' : 'Couche 5 best-effort par vague.'),
+}

--- a/crates/pdo-daemon/src/testdata/workflows/simple-bugfix.js
+++ b/crates/pdo-daemon/src/testdata/workflows/simple-bugfix.js
@@ -1,0 +1,92 @@
+export const meta = {
+  name: 'simple-bugfix',
+  description: "Port du pipeline PDO simple-bugfix : triage d'un bug, boucle fix<->test bornee, puis commit",
+  phases: [
+    { title: 'Triage',   detail: 'Debugger reproduit et tranche bug vs pas-bug' },
+    { title: 'Fix loop', detail: 'Implementer corrige, Tester verifie ; jusqu a 5 tours' },
+    { title: 'Ship',     detail: 'Commit du correctif sur la branche courante' },
+  ],
+}
+
+const bugReport = typeof args === 'string' ? args : (args && args.bug) || ''
+if (!bugReport) log('Aucun bug passe en args.')
+
+const TRIAGE_SCHEMA = {
+  type: 'object', required: ['verdict', 'how_to_reproduce'],
+  properties: {
+    verdict: { type: 'string', enum: ['Bug', 'Feature', 'Unsure', 'Not Reproduced'] },
+    how_to_reproduce: { type: 'string', description: 'Etapes de repro precises (agent ou humain)' },
+    root_cause: { type: 'string', description: 'Ou se situe le bug, fichiers/fonctions suspects' },
+  },
+}
+const TEST_SCHEMA = {
+  type: 'object', required: ['verdict', 'evidence'],
+  properties: {
+    verdict: { type: 'string', enum: ['Pass', 'Fail', 'Minor_changes'] },
+    evidence: { type: 'string', description: 'Ce que tu as fait, observe, et justification du verdict' },
+  },
+}
+
+// ---- Phase 1 : Triage (Debugger) ----
+phase('Triage')
+const triage = await agent(
+  `NE PAS ECRIRE DE CODE. Reproduis et trie ce probleme signale :\n\n${bugReport}\n\n` +
+  `C'est le codebase PDO lui-meme. Reproduis le bug : tu peux soit piloter le frontend via les outils MCP chrome-devtools si l'app web tourne, ` +
+  `soit reproduire au niveau code/donnees (inspecter le YAML library sauvegarde et le code de (de)serialisation des Port/PortType). ` +
+  `Tranche : Bug, Feature, Unsure ou Not Reproduced. Si c'est un bug, dis precisement d'ou il vient (fichiers, structs, champs serde) et ecris des etapes de repro reproductibles.`,
+  { label: 'debugger', phase: 'Triage', schema: TRIAGE_SCHEMA }
+)
+
+if (!triage || triage.verdict !== 'Bug') {
+  log(`Verdict triage : ${triage && triage.verdict || 'aucun'} -- pas un bug, sortie avant la boucle (= edge switch->End).`)
+  return { triage, fixed: false, reason: 'not-a-bug' }
+}
+
+// ---- Phase 2 : boucle fix<->test bornee a 5 ----
+phase('Fix loop')
+const MAX_ITER = 5
+let lastFailure = null, shipped = false, rounds = 0
+
+for (let iter = 1; iter <= MAX_ITER; iter++) {
+  rounds = iter
+  await agent(
+    `Implemente l'INTEGRALITE du correctif pour ce bug. Ne differe aucun travail, le perimetre a ete decide en amont.\n\n` +
+    `Bug :\n${bugReport}\n\nEtapes de repro :\n${triage.how_to_reproduce}` +
+    (triage.root_cause ? `\n\nCause racine suspectee :\n${triage.root_cause}` : '') +
+    (lastFailure ? `\n\nLa tentative precedente a ECHOUE. Retour du Tester a corriger :\n${lastFailure}` : '') +
+    `\n\nCorrige a la racine (la persistance du port_type), pas un contournement. ` +
+    `Aucun test unitaire en echec ne doit etre tolere, meme preexistant.`,
+    { label: `implementer#${iter}`, phase: 'Fix loop' }
+  )
+
+  const test = await agent(
+    `Valide l'implementation pour ce bug.\n` +
+    `1. Build le projet (cargo build -p pdo-daemon, et le frontend si touche) ; toute erreur de compilation = Fail.\n` +
+    `2. Verifie que le bug est corrige. Pour ce bug de persistance, la verification naturelle est un test de round-trip serde : ` +
+    `un Port avec port_type=ImageList serialise en YAML puis deserialise doit rester ImageList, et le snapshot de run doit preserver le type.\n` +
+    `   AJUSTEMENT ASSUME (hors contexte PDO) : tu PEUX lancer un test cible "cargo test -p pdo-daemon <nom_du_test>" s'il porte sur de la logique isolee (round-trip serde) et ne construit PAS de daemon.\n` +
+    `   INTERDIT quand meme : "cargo test"/"cargo test --workspace"/"cargo nextest" en entier, demarrer un "pdo daemon", tout process long en arriere-plan.\n` +
+    `3. Si l'app frontend tourne deja, tu peux confirmer visuellement via chrome-devtools MCP (optionnel ici).\n\n` +
+    `Verdict Pass uniquement si le bug est corrige ET le build propre.`,
+    { label: `tester#${iter}`, phase: 'Fix loop', schema: TEST_SCHEMA }
+  )
+
+  log(`Tour ${iter} : verdict tester = ${test && test.verdict || 'aucun'}`)
+  if (test && test.verdict === 'Pass') { shipped = true; break }
+  lastFailure = (test && test.evidence) || 'Aucune evidence retournee.'
+}
+
+// ---- Phase 3 : Ship (commit-only, branche courante) ----
+phase('Ship')
+if (!shipped) {
+  log(`${MAX_ITER} tours sans Pass -- JE NE COMMIT PAS (deviation assumee vs PDO qui irait quand meme a Ship It).`)
+  return { triage, fixed: false, rounds, reason: 'max-iter-no-pass' }
+}
+const ship = await agent(
+  `Le correctif a passe la verification. Commit sur la BRANCHE COURANTE (ne change pas de branche, ne merge PAS sur main, ne rebuild pas, ne supprime rien).\n\n` +
+  `IMPORTANT : "git add" UNIQUEMENT les fichiers que tu as modifies pour ce correctif. ` +
+  `Ne stage SURTOUT PAS les fichiers deja modifies sans rapport (frontend/vite.config.ts, package.json, package-lock.json, Makefile) -- laisse-les tels quels.\n\n` +
+  `Message de commit clair (bug + correctif). Rends la branche + le hash du commit, le diff resume, et explique comment build/relancer l'app pour tester.`,
+  { label: 'ship-it', phase: 'Ship' }
+)
+return { triage, fixed: true, rounds, ship }

--- a/crates/pdo-daemon/src/workflow_importer.rs
+++ b/crates/pdo-daemon/src/workflow_importer.rs
@@ -1722,7 +1722,7 @@ mod tests {
 
     #[test]
     fn round_trip_simple_bugfix_holds_invariants() {
-        let src = include_str!("../../../.claude/workflows/simple-bugfix.js");
+        let src = include_str!("testdata/workflows/simple-bugfix.js");
         let (result, parsed) = import_and_parse(src, "simple-bugfix");
 
         // Exactly one Start + one End.
@@ -2027,7 +2027,7 @@ mod tests {
 
     #[test]
     fn sandcastle_tdd_imports_without_panic() {
-        let src = include_str!("../../../.claude/workflows/sandcastle-tdd.js");
+        let src = include_str!("testdata/workflows/sandcastle-tdd.js");
         let result = import_workflow_js(src, "sandcastle-tdd")
             .expect("even a mostly-placeholder workflow must import without crashing");
         // It must produce a parseable draft…

--- a/frontend/src/components/HarnessSelect.test.tsx
+++ b/frontend/src/components/HarnessSelect.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import HarnessSelect from "./HarnessSelect";
+import type { HarnessCatalog } from "../lib/harness";
+
+const catalog: HarnessCatalog = {
+  builtin: [
+    { name: "claude", installed: true },
+    { name: "opencode", installed: false },
+  ],
+  descriptors: [
+    { name: "pi", installed: true },
+    { name: "aider", installed: false },
+  ],
+};
+
+function optionByText(select: HTMLSelectElement, text: string): HTMLOptionElement {
+  const opt = Array.from(select.options).find((o) => o.textContent === text);
+  if (!opt) throw new Error(`no option "${text}"`);
+  return opt;
+}
+
+describe("HarnessSelect (#586)", () => {
+  it("leads with the inherit sentinel, then the two named sections", () => {
+    render(
+      <HarnessSelect
+        value=""
+        onChange={() => {}}
+        catalog={catalog}
+        inheritLabel="Use instance default (claude)"
+        data-testid="hs"
+      />,
+    );
+    const select = screen.getByTestId("hs") as HTMLSelectElement;
+    // The inherit option is first and carries the empty value.
+    expect(select.options[0].value).toBe("");
+    expect(select.options[0].textContent).toBe("Use instance default (claude)");
+    // Two <optgroup> sections, Built-in before From descriptors.
+    const groups = select.querySelectorAll("optgroup");
+    expect(Array.from(groups).map((g) => g.getAttribute("label"))).toEqual([
+      "Built-in",
+      "From descriptors",
+    ]);
+  });
+
+  it("greys and disables a harness whose binary is not installed", () => {
+    render(
+      <HarnessSelect value="" onChange={() => {}} catalog={catalog} inheritLabel="x" data-testid="hs" />,
+    );
+    const select = screen.getByTestId("hs") as HTMLSelectElement;
+    // Installed → plain name, selectable.
+    expect(optionByText(select, "claude").disabled).toBe(false);
+    expect(optionByText(select, "pi").disabled).toBe(false);
+    // Uninstalled → "not installed" note and non-selectable, in BOTH sections.
+    expect(optionByText(select, "opencode — not installed").disabled).toBe(true);
+    expect(optionByText(select, "aider — not installed").disabled).toBe(true);
+  });
+
+  it("reports the chosen harness by name", () => {
+    const onChange = vi.fn();
+    render(
+      <HarnessSelect value="" onChange={onChange} catalog={catalog} inheritLabel="x" data-testid="hs" />,
+    );
+    fireEvent.change(screen.getByTestId("hs"), { target: { value: "pi" } });
+    expect(onChange).toHaveBeenCalledWith("pi");
+  });
+
+  it("omits an empty section rather than rendering a blank group", () => {
+    render(
+      <HarnessSelect
+        value=""
+        onChange={() => {}}
+        catalog={{ builtin: [{ name: "claude", installed: true }], descriptors: [] }}
+        inheritLabel="x"
+        data-testid="hs"
+      />,
+    );
+    const groups = (screen.getByTestId("hs") as HTMLSelectElement).querySelectorAll("optgroup");
+    expect(Array.from(groups).map((g) => g.getAttribute("label"))).toEqual(["Built-in"]);
+  });
+});

--- a/frontend/src/components/HarnessSelect.tsx
+++ b/frontend/src/components/HarnessSelect.tsx
@@ -1,0 +1,68 @@
+import type { CSSProperties } from "react";
+import type { HarnessCatalog, HarnessOption } from "../lib/harness";
+
+/**
+ * The dynamic harness picker (#586, ADR-0045/0046).
+ *
+ * One native `<select>` split into two `<optgroup>` sections — **Built-in** and
+ * **From descriptors** — listing harness NAMES only (no capability pills; the
+ * "simple" direction). A harness whose binary is not installed (absent from the
+ * daemon's `$PATH`) renders **greyed and non-selectable** with a discreet
+ * "not installed" note, because spawning it would fail fast (ADR-0037). The first
+ * option is always the inherit sentinel (value `""`), whose label the caller
+ * supplies — each surface names what `""` resolves to differently.
+ *
+ * Shared by all four harness surfaces (node inspector, New Run, Projet, Settings
+ * default) so the sectioning, greying, and "not installed" rendering live in one
+ * place and can never drift between them.
+ */
+export default function HarnessSelect({
+  value,
+  onChange,
+  catalog,
+  inheritLabel,
+  id,
+  className,
+  style,
+  disabled,
+  "data-testid": testId,
+}: {
+  /** The selected harness name, or `""` for the inherit sentinel. */
+  value: string;
+  onChange: (value: string) => void;
+  catalog: HarnessCatalog;
+  /** Label for the inherit option (value `""`), e.g. "Use instance default (claude)". */
+  inheritLabel: string;
+  id?: string;
+  className?: string;
+  style?: CSSProperties;
+  disabled?: boolean;
+  "data-testid"?: string;
+}) {
+  const renderOption = (o: HarnessOption) => (
+    <option key={o.name} value={o.name} disabled={!o.installed}>
+      {o.installed ? o.name : `${o.name} — not installed`}
+    </option>
+  );
+  return (
+    <select
+      id={id}
+      data-testid={testId}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      disabled={disabled}
+      className={className}
+      style={style}
+    >
+      <option value="">{inheritLabel}</option>
+      {catalog.builtin.length > 0 && (
+        <optgroup label="Built-in">{catalog.builtin.map(renderOption)}</optgroup>
+      )}
+      {catalog.descriptors.length > 0 && (
+        <optgroup label="From descriptors">
+          {catalog.descriptors.map(renderOption)}
+        </optgroup>
+      )}
+    </select>
+  );
+}

--- a/frontend/src/components/NewRunModal.tsx
+++ b/frontend/src/components/NewRunModal.tsx
@@ -11,6 +11,7 @@ import SecondaryRepoRow, {
   type SecondaryRepo,
 } from "./SecondaryRepoRow";
 import GuardTestResult from "./GuardTestResult";
+import HarnessSelect from "./HarnessSelect";
 import { CRON_PRESETS, cronToPreset, parseDailyTime, type CronPresetId } from "../cronPresets";
 import { useLaunchTargets } from "../hooks/useLaunchTargets";
 import { useRepoValidation } from "../hooks/useRepoValidation";
@@ -526,10 +527,11 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
     [settings, sandbox, mode],
   );
 
-  // #551/#452: the harness selector's derived state — the known harnesses and the
-  // inherited default's NAME (a label, never a seed). Memoized like `sandboxState` so its
-  // destructured fields are stable. Pure over (settings, harness).
-  const { knownHarnesses, instanceDefaultHarness } = useMemo(
+  // #551/#452/#586: the harness selector's derived state — the dynamic catalog
+  // (floor ∪ descriptors, each installed/not) and the inherited default's NAME (a
+  // label, never a seed). Memoized like `sandboxState` so its destructured fields
+  // are stable. Pure over (settings, harness).
+  const { catalog: harnessCatalog, instanceDefaultHarness } = useMemo(
     () => newRunForm.harnessState({ settings, harness }),
     [settings, harness],
   );
@@ -1212,25 +1214,20 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
               >
                 Harness
               </label>
-              <select
+              <HarnessSelect
                 id="harness-select"
                 data-testid="harness-select"
                 value={harness}
-                onChange={(e) => setHarness(e.target.value)}
+                onChange={setHarness}
+                catalog={harnessCatalog}
+                inheritLabel={
+                  mode === "run" && instanceDefaultHarness
+                    ? `Use instance default (${instanceDefaultHarness})`
+                    : "Use instance default"
+                }
                 className="w-full rounded-md border border-line-strong bg-bg-3 px-2.5 py-1.5 font-mono text-fg transition-colors focus:border-acc focus:outline-none disabled:opacity-40"
                 style={{ fontSize: "12px" }}
-              >
-                <option value="">
-                  {mode === "run" && instanceDefaultHarness
-                    ? `Use instance default (${instanceDefaultHarness})`
-                    : "Use instance default"}
-                </option>
-                {knownHarnesses.map((h) => (
-                  <option key={h} value={h}>
-                    {h}
-                  </option>
-                ))}
-              </select>
+              />
               <span className="text-fg-4" style={{ fontSize: "10.5px" }}>
                 {mode === "trigger"
                   ? "Every fired Run launches on this harness. Nodes that pin their own harness ignore it."

--- a/frontend/src/components/NodeInspector.test.tsx
+++ b/frontend/src/components/NodeInspector.test.tsx
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import NodeInspector from "./NodeInspector";
 import type { LibraryEntry } from "../api";
-import { saveToLibrary, deleteFromLibrary } from "../api";
+import { saveToLibrary, deleteFromLibrary, fetchSettings } from "../api";
 import { useEditStore } from "../stores/editStore";
 import { TooltipProvider } from "./ui/tooltip";
 
@@ -17,6 +17,20 @@ function renderInspector(props: Parameters<typeof NodeInspector>[0]) {
 
 vi.mock("../api", () => ({
   fetchLibrary: vi.fn().mockResolvedValue([]),
+  // #586: the harness pin picker now fetches /settings for its dynamic option
+  // list. Resolve it with the embedded floor so the picker offers claude/opencode.
+  fetchSettings: vi.fn().mockResolvedValue({
+    harness_descriptors: {
+      path: null,
+      names: ["claude", "opencode"],
+      harnesses: [
+        { name: "claude", source: "builtin", installed: true },
+        { name: "opencode", source: "builtin", installed: true },
+      ],
+      rejected: [],
+      reason: null,
+    },
+  }),
   saveToLibrary: vi.fn().mockResolvedValue({}),
   deleteFromLibrary: vi.fn().mockResolvedValue(undefined),
   instantiateFromLibrary: vi.fn().mockResolvedValue({
@@ -550,9 +564,18 @@ describe("NodeInspector — harness axis (#550, ADR-0046)", () => {
   it("pinning a harness writes pin_harness onto the node", async () => {
     seedNode({});
     renderInspector({ libraryEntries: [], onLibraryChanged: () => {} });
-    await userEvent.click(screen.getByTestId("node-harness-option-opencode"));
+    // #586: the pin is now a single sectioned <select>; opencode is offered even
+    // before /settings answers (the embedded-floor fallback), so no wait is needed.
+    fireEvent.change(screen.getByTestId("node-harness-select"), {
+      target: { value: "opencode" },
+    });
     const node = useEditStore.getState().openTabs[0].pipeline.nodes[0];
     expect(node.pin_harness).toBe("opencode");
+    // A green fetch settles the dynamic catalog; flush it inside act so the
+    // trailing setState doesn't leak past the test.
+    await waitFor(() =>
+      expect(vi.mocked(fetchSettings)).toHaveBeenCalled(),
+    );
   });
 
   it("hides the harness selector for a script node", () => {

--- a/frontend/src/components/NodeInspector.tsx
+++ b/frontend/src/components/NodeInspector.tsx
@@ -7,7 +7,9 @@ import OutputPortCard from "./OutputPortCard";
 import PooledInputRow from "./PooledInputRow";
 import ModelPicker from "./ModelPicker";
 import EffortPicker from "./EffortPicker";
-import { KNOWN_HARNESSES, harnessHasEffort, resolveEditorHarness } from "../lib/harness";
+import { harnessHasEffort, resolveEditorHarness } from "../lib/harness";
+import HarnessSelect from "./HarnessSelect";
+import { useHarnessCatalog } from "../hooks/useHarnessCatalog";
 import DestroyLoopModal from "./DestroyLoopModal";
 import { derivePooledInputs } from "../lib/derivePooledInputs";
 import { regionsDestroyedByEdgeRemoval } from "../lib/loopRegions";
@@ -72,6 +74,9 @@ export default function NodeInspector({
     : null;
   const promptContent = node ? (tab!.prompts[node.id] ?? "") : "";
   const syncState = useLibraryState(node, promptContent, libraryEntries);
+  // #586: the harness pin's options, dynamic from `/settings` (floor ∪ descriptors,
+  // each installed/not). Called before the early return so the hook order is stable.
+  const harnessCatalog = useHarnessCatalog();
 
   if (!tab || !node) return null;
 
@@ -222,46 +227,26 @@ export default function NodeInspector({
           </div>
         </Tooltip>
 
-        {/* Harness (#550/ADR-0046): the program that runs this node's agent. The
-            pin both selects the harness and shields it from coarser tiers; the
+        {/* Harness (#550/#586, ADR-0046): the program that runs this node's agent.
+            The pin both selects the harness and shields it from coarser tiers; the
             RESOLVED harness (pin, else the `claude` floor here in the editor) is
             what the model/effort below apply to and what greys the effort picker.
-            Hidden for a script node — it launches no agent (ADR-0017). */}
+            The options are dynamic (#586): the floor ∪ the disk descriptor tier,
+            each greyed if its binary is not installed. `""` = "Default" (no pin);
+            a concrete name pins it. Hidden for a script node — it launches no
+            agent (ADR-0017). */}
         {!isScript && (
           <Field label="Harness">
-            <div
-              role="radiogroup"
-              aria-label="Harness"
-              className="flex gap-1"
-              data-testid="node-harness"
-              data-resolved={resolvedHarness}
-            >
-              {[
-                { id: null as string | null, label: "Default", slug: "default" },
-                ...KNOWN_HARNESSES.map((h) => ({ id: h as string, label: h, slug: h })),
-              ].map((o) => {
-                const selected = (node.pin_harness ?? null) === o.id;
-                return (
-                  <button
-                    key={o.slug}
-                    type="button"
-                    role="radio"
-                    aria-checked={selected}
-                    data-testid={`node-harness-option-${o.slug}`}
-                    onClick={() => handleField("pin_harness", o.id)}
-                    className={`flex-1 cursor-pointer rounded border px-2 py-1 font-medium transition-colors ${
-                      selected
-                        ? o.id == null
-                          ? "border-fg-4 bg-bg-3 text-fg"
-                          : "border-acc bg-acc-bg text-acc"
-                        : "border-line-strong bg-bg-3 text-fg-4 hover:text-fg-3"
-                    }`}
-                    style={{ fontSize: "10px" }}
-                  >
-                    {o.label}
-                  </button>
-                );
-              })}
+            <div data-testid="node-harness" data-resolved={resolvedHarness}>
+              <HarnessSelect
+                data-testid="node-harness-select"
+                value={node.pin_harness ?? ""}
+                onChange={(v) => handleField("pin_harness", v === "" ? null : v)}
+                catalog={harnessCatalog}
+                inheritLabel="Default (claude floor)"
+                className="w-full cursor-pointer rounded border border-line-strong bg-bg-3 px-2 py-1 font-medium text-fg outline-none focus:border-acc"
+                style={{ fontSize: "10px" }}
+              />
             </div>
             <p className="mt-1 text-fg-4" style={{ fontSize: "9.5px" }}>
               Resolved: <span data-testid="node-harness-resolved">{resolvedHarness}</span>

--- a/frontend/src/components/ProjectEditModal.test.tsx
+++ b/frontend/src/components/ProjectEditModal.test.tsx
@@ -19,6 +19,21 @@ vi.mock("../api", () => {
     updateProject: (id: string, req: unknown) => updateProject(id, req),
     addProjectMember: (id: string, path: string) => addProjectMember(id, path),
     removeProjectMember: (id: string, path: string) => removeProjectMember(id, path),
+    // #586: the harness select fetches /settings for its dynamic options. Resolve
+    // it with the embedded floor so claude/opencode are offered.
+    fetchSettings: () =>
+      Promise.resolve({
+        harness_descriptors: {
+          path: null,
+          names: ["claude", "opencode"],
+          harnesses: [
+            { name: "claude", source: "builtin", installed: true },
+            { name: "opencode", source: "builtin", installed: true },
+          ],
+          rejected: [],
+          reason: null,
+        },
+      }),
   };
 });
 

--- a/frontend/src/components/ProjectEditModal.tsx
+++ b/frontend/src/components/ProjectEditModal.tsx
@@ -7,6 +7,8 @@ import {
   removeProjectMember,
   updateProject,
 } from "../api";
+import HarnessSelect from "./HarnessSelect";
+import { useHarnessCatalog } from "../hooks/useHarnessCatalog";
 
 /**
  * The group-header pencil (#552, ADR-0046): name a Projet (or rename an existing
@@ -21,10 +23,6 @@ import {
  * Membership is compared **verbatim** (ADR-0033): the candidate list is the exact
  * effective-repo paths the surrounding list groups by, never canonicalised.
  */
-
-/** The harnesses PDO ships (ADR-0045). A disk-declared tier is #553; until then
- *  the picker offers the embedded floor plus "no harness". */
-const HARNESS_OPTIONS = ["claude", "opencode"] as const;
 
 export default function ProjectEditModal({
   initialProject,
@@ -55,6 +53,9 @@ export default function ProjectEditModal({
   );
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // #586: the harness options, dynamic from `/settings` (floor ∪ descriptors,
+  // each installed/not). The modal holds no settings of its own, so it fetches.
+  const harnessCatalog = useHarnessCatalog();
 
   // path → name of the Projet that OWNS it, excluding the one being edited. A
   // candidate owned elsewhere cannot be attached here (AC: at most one Projet).
@@ -173,20 +174,15 @@ export default function ProjectEditModal({
         <label className="mb-1 block text-fg-3" style={{ fontSize: "11px" }}>
           Harness
         </label>
-        <select
+        <HarnessSelect
           value={harness}
-          onChange={(e) => setHarness(e.target.value)}
+          onChange={setHarness}
+          catalog={harnessCatalog}
+          inheritLabel="No harness (inherit)"
           data-testid="project-harness-select"
           className="mb-3 w-full rounded border border-line-strong bg-bg-3 px-2 py-1.5 text-fg outline-none focus:border-acc"
           style={{ fontSize: "11px" }}
-        >
-          <option value="">No harness (inherit)</option>
-          {HARNESS_OPTIONS.map((h) => (
-            <option key={h} value={h}>
-              {h}
-            </option>
-          ))}
-        </select>
+        />
 
         <label className="mb-1 block text-fg-3" style={{ fontSize: "11px" }}>
           Member repositories

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -23,6 +23,8 @@ import type {
 } from "../types";
 import ModelPicker from "./ModelPicker";
 import SessionCounter from "./SessionCounter";
+import HarnessSelect from "./HarnessSelect";
+import { harnessCatalog } from "../lib/harness";
 
 interface Props {
   open: boolean;
@@ -555,17 +557,15 @@ function SettingsForm({
           <label className="font-medium text-fg-2" style={{ fontSize: "11.5px" }}>
             Default harness
           </label>
-          <select
+          <HarnessSelect
             value={defaultHarness}
-            onChange={(e) => setDefaultHarness(e.target.value)}
+            onChange={setDefaultHarness}
+            catalog={harnessCatalog(settings.harness_descriptors)}
+            inheritLabel="Default (claude floor)"
             data-testid="setting-default-harness-select"
             className="rounded border border-line-strong bg-bg-3 px-2 py-1 text-fg"
             style={{ fontSize: "11px" }}
-          >
-            <option value="">Default (claude floor)</option>
-            <option value="claude">claude</option>
-            <option value="opencode">opencode</option>
-          </select>
+          />
           <div className="text-fg-4" style={{ fontSize: "10.5px" }}>
             Every new node runs on this harness unless it pins its own. "Default"
             leaves it to the <span className="font-mono">claude</span> floor.

--- a/frontend/src/components/SidePicker.test.tsx
+++ b/frontend/src/components/SidePicker.test.tsx
@@ -10,6 +10,8 @@ vi.mock("../api", () => ({
   saveToLibrary: vi.fn(),
   deleteFromLibrary: vi.fn(),
   instantiateFromLibrary: vi.fn(),
+  // #586: NodeInspector's harness picker fetches /settings for its options.
+  fetchSettings: vi.fn().mockResolvedValue({ harness_descriptors: null }),
 }));
 
 describe("SidePicker", () => {

--- a/frontend/src/hooks/useHarnessCatalog.ts
+++ b/frontend/src/hooks/useHarnessCatalog.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from "react";
+import { fetchSettings } from "../api";
+import { harnessCatalog } from "../lib/harness";
+import type { HarnessCatalog } from "../lib/harness";
+
+/**
+ * The harness catalog for surfaces that don't already hold `GET /settings` — the
+ * node inspector and the Projet modal (#586). One fetch per mount: the embedded
+ * floor shows until it resolves, and a failed fetch keeps that fallback (the
+ * daemon re-resolves authoritatively at spawn, so a stale picker never
+ * mis-launches a node).
+ *
+ * Surfaces that already fetch settings (New Run, Settings) derive the catalog
+ * with {@link harnessCatalog} directly rather than fetching twice.
+ */
+export function useHarnessCatalog(): HarnessCatalog {
+  const [catalog, setCatalog] = useState<HarnessCatalog>(() => harnessCatalog(null));
+  useEffect(() => {
+    let cancelled = false;
+    fetchSettings()
+      .then((s) => {
+        if (!cancelled) setCatalog(harnessCatalog(s.harness_descriptors));
+      })
+      .catch(() => {
+        /* keep the floor fallback — the picker is never empty */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+  return catalog;
+}

--- a/frontend/src/lib/harness.ts
+++ b/frontend/src/lib/harness.ts
@@ -6,15 +6,53 @@
 // the fold between the node's per-harness `harnesses` map and the single
 // `model`/`effort` view the existing pickers edit.
 
-import type { NodeDef } from "../types";
+import type { HarnessDescriptorsView, NodeDef } from "../types";
 
 /** The floor of the precedence chain — a node with no pin runs on `claude`. */
 export const HARNESS_FLOOR = "claude";
 
-/** The harnesses PDO ships embedded (ADR-0045). The pin selector offers these
- *  plus "Default" (follow the tier above). A user-declared disk harness (#553)
- *  would extend this; not in this slice. */
-export const KNOWN_HARNESSES = ["claude", "opencode"] as const;
+/** One harness as the picker offers it (#586): its name and whether its binary is
+ *  installed (an uninstalled harness renders greyed and non-selectable). */
+export interface HarnessOption {
+  name: string;
+  installed: boolean;
+}
+
+/** The picker's two sections (#586): the embedded floor, and the disk-declared
+ *  tier. Names only — no capability pills (ADR of #586: directions B/C/D dropped). */
+export interface HarnessCatalog {
+  builtin: HarnessOption[];
+  descriptors: HarnessOption[];
+}
+
+/** The floor the picker shows before `GET /settings` answers, or against a daemon
+ *  that predates #586: the embedded harnesses, assumed installed. This is NOT the
+ *  picker's source of truth (that is `view.harnesses`) — it is the transient
+ *  fallback so the control is never empty while settings load. */
+const FLOOR_CATALOG: HarnessCatalog = {
+  builtin: [
+    { name: "claude", installed: true },
+    { name: "opencode", installed: true },
+  ],
+  descriptors: [],
+};
+
+/** Split `GET /settings → harness_descriptors` into the picker's two sections
+ *  (#586). `source` decides the section; refused descriptors never resolve, so
+ *  they are already absent from `harnesses`. Falls back to the embedded floor when
+ *  the view (or its `harnesses` field) is missing — a still-loading fetch or a
+ *  daemon predating #586. */
+export function harnessCatalog(
+  view: HarnessDescriptorsView | null | undefined,
+): HarnessCatalog {
+  if (!view?.harnesses) return FLOOR_CATALOG;
+  const catalog: HarnessCatalog = { builtin: [], descriptors: [] };
+  for (const h of view.harnesses) {
+    const section = h.source === "descriptor" ? catalog.descriptors : catalog.builtin;
+    section.push({ name: h.name, installed: h.installed });
+  }
+  return catalog;
+}
 
 /** Client mirror of the descriptor's `{effort}` hole (ADR-0045): `opencode` has
  *  no launch-time effort axis, so its effort picker is greyed. An unknown harness

--- a/frontend/src/lib/newRunForm.test.ts
+++ b/frontend/src/lib/newRunForm.test.ts
@@ -490,10 +490,40 @@ describe("harnessState (#551/#452)", () => {
     expect(state.effectiveHarness).toBe("opencode");
   });
 
-  it("offers the embedded harnesses", () => {
-    expect(harnessState({ settings: settings(), harness: "" }).knownHarnesses).toEqual([
-      "claude",
-      "opencode",
+  it("offers the embedded floor when settings carry no descriptor view", () => {
+    // No harness_descriptors on the fixture → the floor fallback: claude/opencode,
+    // both built-in, both assumed installed. The picker is never empty.
+    const { catalog } = harnessState({ settings: settings(), harness: "" });
+    expect(catalog.builtin.map((h) => h.name)).toEqual(["claude", "opencode"]);
+    expect(catalog.descriptors).toEqual([]);
+  });
+
+  it("splits the dynamic harness list into built-in and descriptor sections (#586)", () => {
+    // The picker's two sections come from `source`; `installed` greys a row.
+    const { catalog } = harnessState({
+      settings: settings({
+        harness_descriptors: {
+          path: "/home/user/.pdo/harnesses/descriptors.yaml",
+          names: ["claude", "opencode", "pi", "aider"],
+          harnesses: [
+            { name: "claude", source: "builtin", installed: true },
+            { name: "opencode", source: "builtin", installed: false },
+            { name: "pi", source: "descriptor", installed: true },
+            { name: "aider", source: "descriptor", installed: false },
+          ],
+          rejected: [],
+          reason: null,
+        },
+      }),
+      harness: "",
+    });
+    expect(catalog.builtin).toEqual([
+      { name: "claude", installed: true },
+      { name: "opencode", installed: false },
+    ]);
+    expect(catalog.descriptors).toEqual([
+      { name: "pi", installed: true },
+      { name: "aider", installed: false },
     ]);
   });
 });

--- a/frontend/src/lib/newRunForm.ts
+++ b/frontend/src/lib/newRunForm.ts
@@ -6,7 +6,7 @@ import type {
 } from "../api";
 import type { InstanceSettings, PipelineListEntry, SandboxProfileRef } from "../types";
 import { presetToCron, type CronPresetId } from "../cronPresets";
-import { HARNESS_FLOOR, KNOWN_HARNESSES } from "./harness";
+import { HARNESS_FLOOR, harnessCatalog, type HarnessCatalog } from "./harness";
 
 /**
  * The New Run / Trigger form's pure logic (#359), lifted out of `NewRunModal.tsx`.
@@ -298,8 +298,9 @@ export function sandboxState({
 
 /** Everything the harness selector derives from `settings` + the selected value (#551, ADR-0046). */
 export interface HarnessState {
-  /** The harnesses the pin selector offers (the embedded floor, ADR-0045). */
-  knownHarnesses: readonly string[];
+  /** The harnesses the selector offers, split into Built-in / From-descriptors
+   *  sections with per-harness install state (#586, dynamic from `/settings`). */
+  catalog: HarnessCatalog;
   /**
    * The instance default harness, used to **label** the inherit option — never to seed
    * the value (the #452 trap: a prefilled field freezes a stale value the user never
@@ -338,7 +339,10 @@ export function harnessState({
     : null;
   const effectiveHarness = harness === "" ? instanceDefaultHarness : harness;
   return {
-    knownHarnesses: KNOWN_HARNESSES,
+    // #586: the picker's options are now dynamic — the floor merged with the disk
+    // descriptor tier, each tagged installed/not. `harnessCatalog` falls back to
+    // the embedded floor while settings are unknown, so the control is never empty.
+    catalog: harnessCatalog(settings?.harness_descriptors ?? null),
     instanceDefaultHarness,
     effectiveHarness,
   };

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -341,10 +341,29 @@ export interface HarnessDescriptorsView {
   path: string | null;
   /** The harnesses the registry resolves (floor ∪ disk), in resolution order. */
   names: string[];
+  /**
+   * Each resolved harness enriched for the picker (#586): its provenance and
+   * whether its binary resolves on the daemon's `$PATH`. Drives the two-section,
+   * grey-if-uninstalled picker. Optional so a daemon predating #586 still
+   * typechecks (the picker then falls back to the embedded floor); in production
+   * the SPA is embedded, so it is always present.
+   */
+  harnesses?: HarnessListItem[];
   /** Descriptors the disk tier refused — each inert, its key on the floor. */
   rejected: { name: string; why: string }[];
   /** Advisory: an inert file or refused descriptor, named. `null` when all is well. */
   reason: string | null;
+}
+
+/** One resolved harness, as `GET /settings → harness_descriptors.harnesses`
+ *  discloses it (#586). */
+export interface HarnessListItem {
+  name: string;
+  /** `builtin` = the embedded floor (claude/opencode); `descriptor` = the disk tier. */
+  source: "builtin" | "descriptor";
+  /** Whether the harness's binary resolves on the daemon's `$PATH`. `false` greys
+   *  the row and blocks selection — a spawn would fail fast (ADR-0037). */
+  installed: boolean;
 }
 
 /** `GET /settings` → `price_table` (#427). */


### PR DESCRIPTION
Closes #586.

## Ce que ça livre

Le sélecteur de harnais consomme désormais la liste **dynamique** exposée par le daemon
(`GET /settings → harness_descriptors`) au lieu des listes hardcodées. Deux sections
**Built-in** / **From descriptors**, noms seuls, ligne **grisée + « not installed »** si le
binaire n'est pas sur le `$PATH`, sentinelle d'héritage **« Use instance default »** (`value=""`) en tête.

### Backend (`crates/pdo-daemon`)
- `harness_registry.rs` : `HarnessSource` (`Builtin`/`Descriptor`), `HarnessListing { name, source, binary }`, `HarnessRegistry::listing()` — module **pur** (ne lit jamais `$PATH`, expose le `binary` à sonder). +3 tests.
- `lib.rs` (`build_settings_view`) : chaque harnais porte `name`+`source`+`installed` (`installed` via `binary_available`, la même sonde que le spawn), aux deux branches HOME set/unset ; `names`/`rejected` conservés. +1 test HTTP.

### Frontend (`frontend/src`)
- **Nouveau** `components/HarnessSelect.tsx` (+test) : `<select>` sectionné en 2 `<optgroup>`, grise/désactive les non-installés, sentinelle `""` en tête.
- **Nouveau** `hooks/useHarnessCatalog.ts` : fetch `/settings` pour les surfaces qui ne le tiennent pas déjà, fallback floor.
- `lib/harness.ts` : `KNOWN_HARNESSES` **supprimé** ; `harnessCatalog(view)` (split floor/descriptors sur `source`). `types.ts` mis à jour.
- **4 surfaces** basculées sur `HarnessSelect` : `NodeInspector`, `NewRunModal`, `ProjectEditModal`, `SettingsModal` (`HARNESS_OPTIONS` supprimé).

### Dette de build réparée (hors #586, nécessaire à la compil)
Les `.claude/workflows/{simple-bugfix,sandcastle-tdd}.js` supprimés étaient `include_str!`'d par 3 tests → recopiés dans `crates/pdo-daemon/src/testdata/workflows/`.

## Tests

- **Unitaires/intégration — verts** : frontend `tsc` + **1806** vitest + eslint ; daemon build + **2007** tests (dont 3 `listing_*` + 1 settings-view) + clippy `-D warnings` + `cargo fmt --check`.
- **Feature Path agentique — PASS** : les 7 critères d'acceptation drivés en conditions réelles (stack isolée buildée depuis `81ce0de`, Playwright). `/settings` renvoie bien `{name, source, installed}` (`claude/builtin/true`, `opencode/builtin/false`, `pi/descriptor/true`) ; sections + grisé non-sélectionnable + sentinelle `""` vérifiés sur SettingsModal/NewRunModal/NodeInspector ; descriptor cassé injecté à chaud → `rejected`, absent du picker.

### Findings non-bloquants
1. `SettingsModal` garde des lignes hardcodées `claude`/`opencode` dans la matrice **default-*model*** — c'est du **#550, hors scope #586**.
2. Warning WebSocket dev-only sous le proxy Vite, sans rapport.

### Non validé en conditions réelles
- `ProjectEditModal` drivé via l'UI (bloqué par un prérequis de données DB, pas par le code) — chemin identique au `NodeInspector` validé live (même `useHarnessCatalog` + `HarnessSelect`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
