### PR TITLE
chore(#586): picker de harnais custom fidèle au design — 1.31.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "1.31.1"
+version = "1.31.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "1.31.1"
+version = "1.31.2"
 license = "MIT"
 
 [workspace.dependencies]

--- a/frontend/src/components/HarnessSelect.test.tsx
+++ b/frontend/src/components/HarnessSelect.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import HarnessSelect from "./HarnessSelect";
 import type { HarnessCatalog } from "../lib/harness";
 
@@ -14,68 +15,119 @@ const catalog: HarnessCatalog = {
   ],
 };
 
-function optionByText(select: HTMLSelectElement, text: string): HTMLOptionElement {
-  const opt = Array.from(select.options).find((o) => o.textContent === text);
-  if (!opt) throw new Error(`no option "${text}"`);
-  return opt;
+function renderPicker(props: Partial<React.ComponentProps<typeof HarnessSelect>> = {}) {
+  const onChange = props.onChange ?? vi.fn();
+  render(
+    <HarnessSelect
+      value=""
+      onChange={onChange}
+      catalog={catalog}
+      inheritLabel="Use instance default"
+      data-testid="hs"
+      {...props}
+    />,
+  );
+  return { onChange };
 }
 
 describe("HarnessSelect (#586)", () => {
-  it("leads with the inherit sentinel, then the two named sections", () => {
-    render(
-      <HarnessSelect
-        value=""
-        onChange={() => {}}
-        catalog={catalog}
-        inheritLabel="Use instance default (claude)"
-        data-testid="hs"
-      />,
-    );
-    const select = screen.getByTestId("hs") as HTMLSelectElement;
-    // The inherit option is first and carries the empty value.
-    expect(select.options[0].value).toBe("");
-    expect(select.options[0].textContent).toBe("Use instance default (claude)");
-    // Two <optgroup> sections, Built-in before From descriptors.
-    const groups = select.querySelectorAll("optgroup");
-    expect(Array.from(groups).map((g) => g.getAttribute("label"))).toEqual([
-      "Built-in",
+  it("shows the inherit label on the trigger when unset", () => {
+    renderPicker({ value: "" });
+    expect(screen.getByTestId("hs")).toHaveTextContent("Use instance default");
+  });
+
+  it("shows the pinned harness name on the trigger", () => {
+    renderPicker({ value: "pi" });
+    expect(screen.getByTestId("hs")).toHaveTextContent("pi");
+  });
+
+  it("opens a panel with the inherit row, then the two named sections", async () => {
+    const user = userEvent.setup();
+    renderPicker({ inheritLabel: "Use instance default", inheritHint: "claude" });
+
+    await user.click(screen.getByTestId("hs"));
+
+    // The inherit sentinel leads, and names what it resolves to (the hint).
+    const inherit = await screen.findByTestId("hs-option-inherit");
+    expect(inherit).toHaveTextContent("Use instance default");
+    expect(inherit).toHaveTextContent("claude");
+
+    // Both section headers, Built-in before From descriptors.
+    expect(screen.getByTestId("hs-section-builtin")).toHaveTextContent("Built-in");
+    expect(screen.getByTestId("hs-section-descriptors")).toHaveTextContent(
       "From descriptors",
-    ]);
+    );
+
+    // Every catalog harness is offered, in both sections.
+    for (const name of ["claude", "opencode", "pi", "aider"]) {
+      expect(screen.getByTestId(`hs-option-${name}`)).toBeInTheDocument();
+    }
+
+    // The legend explains the two sections and names the descriptor file.
+    expect(
+      screen.getByText(/~\/\.pdo\/harnesses\/descriptors\.yaml/),
+    ).toBeInTheDocument();
   });
 
-  it("greys and disables a harness whose binary is not installed", () => {
-    render(
-      <HarnessSelect value="" onChange={() => {}} catalog={catalog} inheritLabel="x" data-testid="hs" />,
+  it("greys and disables a harness whose binary is not installed", async () => {
+    const user = userEvent.setup();
+    const { onChange } = renderPicker();
+    await user.click(screen.getByTestId("hs"));
+
+    const opencode = await screen.findByTestId("hs-option-opencode");
+    const aider = screen.getByTestId("hs-option-aider");
+    // Non-selectable in BOTH sections, each with the discreet note.
+    for (const el of [opencode, aider]) {
+      expect(el).toHaveAttribute("data-disabled");
+      expect(el).toHaveTextContent("not installed");
+    }
+
+    // Clicking a disabled row selects nothing.
+    await user.click(opencode).catch(() => {});
+    expect(onChange).not.toHaveBeenCalled();
+
+    // …while installed rows carry no note.
+    expect(screen.getByTestId("hs-option-claude")).not.toHaveTextContent(
+      "not installed",
     );
-    const select = screen.getByTestId("hs") as HTMLSelectElement;
-    // Installed → plain name, selectable.
-    expect(optionByText(select, "claude").disabled).toBe(false);
-    expect(optionByText(select, "pi").disabled).toBe(false);
-    // Uninstalled → "not installed" note and non-selectable, in BOTH sections.
-    expect(optionByText(select, "opencode — not installed").disabled).toBe(true);
-    expect(optionByText(select, "aider — not installed").disabled).toBe(true);
   });
 
-  it("reports the chosen harness by name", () => {
-    const onChange = vi.fn();
-    render(
-      <HarnessSelect value="" onChange={onChange} catalog={catalog} inheritLabel="x" data-testid="hs" />,
-    );
-    fireEvent.change(screen.getByTestId("hs"), { target: { value: "pi" } });
+  it("reports the chosen harness by name", async () => {
+    const user = userEvent.setup();
+    const { onChange } = renderPicker();
+    await user.click(screen.getByTestId("hs"));
+    await user.click(await screen.findByTestId("hs-option-pi"));
     expect(onChange).toHaveBeenCalledWith("pi");
   });
 
-  it("omits an empty section rather than rendering a blank group", () => {
-    render(
-      <HarnessSelect
-        value=""
-        onChange={() => {}}
-        catalog={{ builtin: [{ name: "claude", installed: true }], descriptors: [] }}
-        inheritLabel="x"
-        data-testid="hs"
-      />,
-    );
-    const groups = (screen.getByTestId("hs") as HTMLSelectElement).querySelectorAll("optgroup");
-    expect(Array.from(groups).map((g) => g.getAttribute("label"))).toEqual(["Built-in"]);
+  it("reports the inherit sentinel (empty string) when the inherit row is picked", async () => {
+    const user = userEvent.setup();
+    const { onChange } = renderPicker({ value: "pi" });
+    await user.click(screen.getByTestId("hs"));
+    await user.click(await screen.findByTestId("hs-option-inherit"));
+    expect(onChange).toHaveBeenCalledWith("");
+  });
+
+  it("marks the selected row with a check", async () => {
+    const user = userEvent.setup();
+    renderPicker({ value: "claude" });
+    await user.click(screen.getByTestId("hs"));
+    const claude = await screen.findByTestId("hs-option-claude");
+    // The accent check is an SVG rendered only on the selected row.
+    expect(claude.querySelector("svg")).not.toBeNull();
+    expect(
+      screen.getByTestId("hs-option-pi").querySelector("svg"),
+    ).toBeNull();
+  });
+
+  it("omits an empty section rather than rendering a blank header", async () => {
+    const user = userEvent.setup();
+    renderPicker({
+      catalog: { builtin: [{ name: "claude", installed: true }], descriptors: [] },
+    });
+    await user.click(screen.getByTestId("hs"));
+    await screen.findByTestId("hs-option-claude");
+    expect(screen.getByTestId("hs-section-builtin")).toBeInTheDocument();
+    expect(screen.queryByTestId("hs-section-descriptors")).toBeNull();
   });
 });

--- a/frontend/src/components/HarnessSelect.tsx
+++ b/frontend/src/components/HarnessSelect.tsx
@@ -1,26 +1,61 @@
 import type { CSSProperties } from "react";
+import { Check, ChevronDown } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuLabel,
+  DropdownMenuItem,
+} from "./ui/dropdown-menu";
+import { cn } from "@/lib/utils";
 import type { HarnessCatalog, HarnessOption } from "../lib/harness";
+
+/** The resolved row's marker: an accent bar flush left and a check, both in the
+ *  accent colour — the design's "this is what runs" cue (picker-simple.png). */
+function SelectedMarker() {
+  return (
+    <>
+      <span
+        aria-hidden
+        className="absolute inset-y-1 left-0 w-[3px] rounded-full bg-acc"
+      />
+      <Check
+        size={13}
+        className="absolute left-1.5 top-1/2 -translate-y-1/2 text-acc"
+      />
+    </>
+  );
+}
 
 /**
  * The dynamic harness picker (#586, ADR-0045/0046).
  *
- * One native `<select>` split into two `<optgroup>` sections — **Built-in** and
- * **From descriptors** — listing harness NAMES only (no capability pills; the
- * "simple" direction). A harness whose binary is not installed (absent from the
- * daemon's `$PATH`) renders **greyed and non-selectable** with a discreet
- * "not installed" note, because spawning it would fail fast (ADR-0037). The first
- * option is always the inherit sentinel (value `""`), whose label the caller
- * supplies — each surface names what `""` resolves to differently.
+ * A custom dropdown — NOT a native `<select>` — because the design (the "simple"
+ * direction, `frontend/design/harness-picker/picker-simple.png`) styles what a
+ * native control cannot: a check + accent bar on the resolved row, letter-spaced
+ * **BUILT-IN** / **FROM DESCRIPTORS** section headers, a right-aligned muted
+ * "not installed" note, a muted resolved-default hint on the inherit row, and a
+ * legend. It is built on the same `@base-ui` menu the model picker uses, so it
+ * inherits the app's dropdown behaviour (portal, keyboard nav, click-away).
+ *
+ * The panel lists harness NAMES only (no capability pills — directions B/C/D were
+ * dropped) split into two sections on provenance. A harness whose binary is not
+ * installed (absent from the daemon's `$PATH`) renders **greyed, non-selectable
+ * and keyboard-skipped** with a discreet "not installed" note, because spawning it
+ * would fail fast (ADR-0037). The first row is always the inherit sentinel (value
+ * `""`), whose label each surface supplies — `""` resolves differently per surface.
  *
  * Shared by all four harness surfaces (node inspector, New Run, Projet, Settings
- * default) so the sectioning, greying, and "not installed" rendering live in one
- * place and can never drift between them.
+ * default) so the sectioning, greying, check and legend live in one place and can
+ * never drift between them.
  */
 export default function HarnessSelect({
   value,
   onChange,
   catalog,
   inheritLabel,
+  inheritHint,
   id,
   className,
   style,
@@ -31,38 +66,121 @@ export default function HarnessSelect({
   value: string;
   onChange: (value: string) => void;
   catalog: HarnessCatalog;
-  /** Label for the inherit option (value `""`), e.g. "Use instance default (claude)". */
+  /** Main label for the inherit row (value `""`), e.g. "Use instance default". */
   inheritLabel: string;
+  /** Optional muted hint shown right-aligned on the inherit row — the name `""`
+   *  resolves to (e.g. the instance default `claude`). A pure label; never seeded. */
+  inheritHint?: string;
   id?: string;
   className?: string;
   style?: CSSProperties;
   disabled?: boolean;
   "data-testid"?: string;
 }) {
-  const renderOption = (o: HarnessOption) => (
-    <option key={o.name} value={o.name} disabled={!o.installed}>
-      {o.installed ? o.name : `${o.name} — not installed`}
-    </option>
-  );
+  const optionTestId = (name: string) =>
+    testId ? `${testId}-option-${name}` : undefined;
+
+  // The selected row (inherit or a concrete name) carries the check + accent.
+  const rowClass = (selected: boolean, installed: boolean) =>
+    cn(
+      "relative pl-6 font-mono",
+      selected && "bg-acc-bg text-acc",
+      !installed && "text-fg-4",
+    );
+
+  const renderOption = (o: HarnessOption) => {
+    const selected = value === o.name;
+    return (
+      <DropdownMenuItem
+        key={o.name}
+        data-testid={optionTestId(o.name)}
+        disabled={!o.installed}
+        className={rowClass(selected, o.installed)}
+        onClick={() => onChange(o.name)}
+      >
+        {selected && <SelectedMarker />}
+        <span className="truncate">{o.name}</span>
+        {!o.installed && (
+          <span className="ml-auto pl-3 text-[0.9em] text-fg-4">
+            not installed
+          </span>
+        )}
+      </DropdownMenuItem>
+    );
+  };
+
+  const inheritSelected = value === "";
+
   return (
-    <select
-      id={id}
-      data-testid={testId}
-      value={value}
-      onChange={(e) => onChange(e.target.value)}
-      disabled={disabled}
-      className={className}
-      style={style}
-    >
-      <option value="">{inheritLabel}</option>
-      {catalog.builtin.length > 0 && (
-        <optgroup label="Built-in">{catalog.builtin.map(renderOption)}</optgroup>
-      )}
-      {catalog.descriptors.length > 0 && (
-        <optgroup label="From descriptors">
-          {catalog.descriptors.map(renderOption)}
-        </optgroup>
-      )}
-    </select>
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        id={id}
+        data-testid={testId}
+        disabled={disabled}
+        className={cn(
+          "flex cursor-pointer items-center justify-between gap-2 text-left outline-none transition-colors focus:border-acc data-[popup-open]:border-acc disabled:cursor-not-allowed disabled:opacity-40",
+          className,
+        )}
+        style={style}
+      >
+        <span className={cn("truncate", value ? "font-mono" : "text-fg-3")}>
+          {value || inheritLabel}
+        </span>
+        <ChevronDown size={12} className="shrink-0 text-fg-4" />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        data-testid={testId ? `${testId}-menu` : undefined}
+        className="text-fg"
+        style={style}
+        side="bottom"
+        align="start"
+      >
+        <DropdownMenuItem
+          data-testid={testId ? `${testId}-option-inherit` : undefined}
+          className={rowClass(inheritSelected, true)}
+          onClick={() => onChange("")}
+        >
+          {inheritSelected && <SelectedMarker />}
+          <span className="truncate font-sans">{inheritLabel}</span>
+          {inheritHint && (
+            <span className="ml-auto pl-3 font-mono text-fg-4">
+              {inheritHint}
+            </span>
+          )}
+        </DropdownMenuItem>
+
+        {catalog.builtin.length > 0 && (
+          <DropdownMenuGroup>
+            <DropdownMenuLabel
+              data-testid={testId ? `${testId}-section-builtin` : undefined}
+              className="uppercase tracking-wider text-fg-4"
+            >
+              Built-in
+            </DropdownMenuLabel>
+            {catalog.builtin.map(renderOption)}
+          </DropdownMenuGroup>
+        )}
+        {catalog.descriptors.length > 0 && (
+          <DropdownMenuGroup>
+            <DropdownMenuLabel
+              data-testid={testId ? `${testId}-section-descriptors` : undefined}
+              className="uppercase tracking-wider text-fg-4"
+            >
+              From descriptors
+            </DropdownMenuLabel>
+            {catalog.descriptors.map(renderOption)}
+          </DropdownMenuGroup>
+        )}
+
+        <div
+          className="mt-1 border-t border-line px-1.5 pt-1.5 pb-0.5 leading-snug text-fg-4"
+          style={{ fontSize: "10px" }}
+        >
+          <span className="font-medium">Built-in</span> = embedded harnesses.{" "}
+          <span className="font-medium">From descriptors</span> ={" "}
+          <span className="font-mono">~/.pdo/harnesses/descriptors.yaml</span>.
+        </div>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }

--- a/frontend/src/components/NewRunModal.test.tsx
+++ b/frontend/src/components/NewRunModal.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import NewRunModal from "./NewRunModal";
 import { useEditStore } from "../stores/editStore";
 import type { BranchRef, InstanceSettings, PipelineListEntry, Trigger } from "../types";
@@ -2475,9 +2476,9 @@ describe("NewRunModal — harness selector (#551)", () => {
   }
 
   /** #452 for the harness axis: the run selector NAMES the instance default on the inherit
-   *  option; it never copies it into the field. Assert on the OPTION TEXT and the presence
-   *  of the concrete options — never on `select.value` for the "names it" claim (a value
-   *  assertion cannot fail here — the memory of #347/#452). */
+   *  option; it never copies it into the field. Assert on the OPTION TEXT (the muted hint)
+   *  and the presence of the concrete options — never that a concrete value was seeded (the
+   *  memory of #347/#452). #586: the picker is a custom sectioned dropdown, so open it. */
   it("names the instance default on the inherit option without seeding the field", async () => {
     vi.mocked(fetchSettings).mockResolvedValue(
       harnessSettings({
@@ -2485,31 +2486,30 @@ describe("NewRunModal — harness selector (#551)", () => {
       }),
     );
     vi.mocked(fetchPipelines).mockResolvedValue([makePipeline({ id: "p1", name: "P", scope: "repo" })]);
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
     renderModal();
-    const select = (await screen.findByTestId("harness-select")) as HTMLSelectElement;
-    await waitFor(() => {
-      expect(Array.from(select.options).find((o) => o.value === "")).toHaveTextContent(
-        "Use instance default (opencode)",
-      );
-    });
-    // The field asserts nothing of its own — the inherit sentinel, not the copied value.
-    expect(select.value).toBe("");
-    // The embedded harnesses are offered as concrete options.
-    const values = Array.from(select.options).map((o) => o.value);
-    expect(values).toContain("claude");
-    expect(values).toContain("opencode");
+    // The closed trigger shows the inherit label — never the copied default value.
+    const trigger = await screen.findByTestId("harness-select");
+    expect(trigger).toHaveTextContent("Use instance default");
+    // Open it: the inherit row names what "" resolves to (the muted hint), and the
+    // embedded harnesses are offered as concrete options.
+    await user.click(trigger);
+    const inherit = await screen.findByTestId("harness-select-option-inherit");
+    await waitFor(() => expect(inherit).toHaveTextContent("opencode"));
+    expect(inherit).toHaveTextContent("Use instance default");
+    expect(screen.getByTestId("harness-select-option-claude")).toBeInTheDocument();
+    expect(screen.getByTestId("harness-select-option-opencode")).toBeInTheDocument();
   });
 
   it("names the claude floor when the instance sets no default", async () => {
     vi.mocked(fetchSettings).mockResolvedValue(harnessSettings());
     vi.mocked(fetchPipelines).mockResolvedValue([makePipeline({ id: "p1", name: "P", scope: "repo" })]);
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
     renderModal();
-    const select = (await screen.findByTestId("harness-select")) as HTMLSelectElement;
-    await waitFor(() => {
-      expect(Array.from(select.options).find((o) => o.value === "")).toHaveTextContent(
-        "Use instance default (claude)",
-      );
-    });
+    await user.click(await screen.findByTestId("harness-select"));
+    const inherit = await screen.findByTestId("harness-select-option-inherit");
+    await waitFor(() => expect(inherit).toHaveTextContent("claude"));
+    expect(inherit).toHaveTextContent("Use instance default");
   });
 
   it("passes the chosen harness to createRun", async () => {
@@ -2520,11 +2520,13 @@ describe("NewRunModal — harness selector (#551)", () => {
     renderModal();
     await enterValidRepo();
 
-    const select = (await screen.findByTestId("harness-select")) as HTMLSelectElement;
-    await waitFor(() => expect(Array.from(select.options).some((o) => o.value === "opencode")).toBe(true));
-    fireEvent.change(select, { target: { value: "opencode" } });
-
+    // #586: open the custom dropdown and pick opencode (real timers keep userEvent
+    // simple; repo validation above already ran under fake timers).
     vi.useRealTimers();
+    const user = userEvent.setup();
+    await user.click(await screen.findByTestId("harness-select"));
+    await user.click(await screen.findByTestId("harness-select-option-opencode"));
+
     await waitFor(() => expect(screen.getByRole("button", { name: /launch/i })).toBeEnabled());
     fireEvent.click(screen.getByRole("button", { name: /launch/i }));
 
@@ -2540,7 +2542,7 @@ describe("NewRunModal — harness selector (#551)", () => {
     ]);
     renderModal();
     await enterValidRepo();
-    // Leave the harness selector on "" (inherit).
+    // Leave the harness selector on "" (inherit) — never open it.
     await screen.findByTestId("harness-select");
 
     vi.useRealTimers();
@@ -2581,18 +2583,20 @@ describe("NewRunModal — harness selector (#551)", () => {
         openIntent={{ kind: "edit-trigger", trigger }} />,
     );
 
-    const select = (await screen.findByTestId("harness-select")) as HTMLSelectElement;
-    await waitFor(() => expect(select.value).toBe("opencode"));
-    // Trigger mode exposes the inherit option.
-    expect(Array.from(select.options).some((o) => o.value === "")).toBe(true);
+    // #586: the closed trigger shows the Trigger's pinned harness by name.
+    const harnessTrigger = await screen.findByTestId("harness-select");
+    await waitFor(() => expect(harnessTrigger).toHaveTextContent("opencode"));
 
     // Repo validation must resolve so Save is enabled.
     await vi.advanceTimersByTimeAsync(500);
     await waitFor(() => expect(validateRepo).toHaveBeenCalledWith("/home/user/project"));
 
-    // Reset to "use instance default" → the PATCH must clear it (null).
-    fireEvent.change(select, { target: { value: "" } });
+    // Reset to "use instance default" → the PATCH must clear it (null). Trigger mode
+    // exposes the inherit option; open the dropdown and pick it.
     vi.useRealTimers();
+    const user = userEvent.setup();
+    await user.click(harnessTrigger);
+    await user.click(await screen.findByTestId("harness-select-option-inherit"));
     await waitFor(() => expect(screen.getByTestId("save-trigger-button")).toBeEnabled());
     fireEvent.click(screen.getByTestId("save-trigger-button"));
 

--- a/frontend/src/components/NewRunModal.tsx
+++ b/frontend/src/components/NewRunModal.tsx
@@ -1220,10 +1220,11 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
                 value={harness}
                 onChange={setHarness}
                 catalog={harnessCatalog}
-                inheritLabel={
+                inheritLabel="Use instance default"
+                inheritHint={
                   mode === "run" && instanceDefaultHarness
-                    ? `Use instance default (${instanceDefaultHarness})`
-                    : "Use instance default"
+                    ? instanceDefaultHarness
+                    : undefined
                 }
                 className="w-full rounded-md border border-line-strong bg-bg-3 px-2.5 py-1.5 font-mono text-fg transition-colors focus:border-acc focus:outline-none disabled:opacity-40"
                 style={{ fontSize: "12px" }}

--- a/frontend/src/components/NodeInspector.test.tsx
+++ b/frontend/src/components/NodeInspector.test.tsx
@@ -562,13 +562,13 @@ describe("NodeInspector — harness axis (#550, ADR-0046)", () => {
   });
 
   it("pinning a harness writes pin_harness onto the node", async () => {
+    const user = userEvent.setup();
     seedNode({});
     renderInspector({ libraryEntries: [], onLibraryChanged: () => {} });
-    // #586: the pin is now a single sectioned <select>; opencode is offered even
-    // before /settings answers (the embedded-floor fallback), so no wait is needed.
-    fireEvent.change(screen.getByTestId("node-harness-select"), {
-      target: { value: "opencode" },
-    });
+    // #586: the pin is a custom sectioned dropdown; opencode is offered even before
+    // /settings answers (the embedded-floor fallback). Open it and pick opencode.
+    await user.click(screen.getByTestId("node-harness-select"));
+    await user.click(await screen.findByTestId("node-harness-select-option-opencode"));
     const node = useEditStore.getState().openTabs[0].pipeline.nodes[0];
     expect(node.pin_harness).toBe("opencode");
     // A green fetch settles the dynamic catalog; flush it inside act so the

--- a/frontend/src/components/ProjectEditModal.test.tsx
+++ b/frontend/src/components/ProjectEditModal.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import ProjectEditModal from "./ProjectEditModal";
 import { ApiError } from "../api";
 import type { Project } from "../types";
@@ -99,18 +100,21 @@ describe("ProjectEditModal", () => {
   });
 
   it("creates a project, sets its harness, and attaches the checked members on save", async () => {
+    const user = userEvent.setup();
     createProject.mockResolvedValue({ id: "p9", name: "front", harness: null, members: [] });
     updateProject.mockResolvedValue({});
     addProjectMember.mockResolvedValue({});
     const { onSaved, onClose } = renderModal();
 
-    // Attach the second repo too, and pose a harness on the Projet.
+    // Attach the second repo too, and pose a harness on the Projet (#586: a custom
+    // sectioned dropdown — open it and pick opencode).
     fireEvent.click(
       within(memberRow("/repos/back")).getByTestId("project-member-checkbox"),
     );
-    fireEvent.change(screen.getByTestId("project-harness-select"), {
-      target: { value: "opencode" },
-    });
+    await user.click(screen.getByTestId("project-harness-select"));
+    await user.click(
+      await screen.findByTestId("project-harness-select-option-opencode"),
+    );
     fireEvent.click(screen.getByTestId("project-edit-save"));
 
     await waitFor(() => expect(onSaved).toHaveBeenCalled());


### PR DESCRIPTION
## Quoi

Le picker de harnais passe d'un `<select>` natif à un **dropdown custom fidèle au design** :
sections *Built-in* / *From descriptors*, ligne d'héritage « Use instance default » nommant le
défaut résolu, harnais non installé grisé + « not installed » (non sélectionnable), coche/liseré
vert sur la ligne active. Diff **100 % front** (`frontend/src/components/*`) ; back inchangé.

Suite de #586 (picker dynamique, déjà livré en 1.31.1) — pass de fidélité au design.

## Validation (verdict : **Pass**)

| Chaîne | Résultat |
|--------|----------|
| Front — `tsc -b`, `eslint`, `vitest` (1820), `vite build` | vert |
| Back — `cargo build/test` (2008), `clippy -D warnings`, `fmt --check` | vert |
| Visual ID (app réelle, Playwright) | les 6 points du Feature Path OK |

App réelle : panneau custom (pas natif), deux sections, hint d'héritage nommant `claude`,
`gemini-cli` grisé/« not installed »/clic sans effet, sélection de `pi` → trigger `pi`.

## Version

`1.31.1 → 1.31.2` (patch — refinement UI d'une feature déjà livrée).

Ref #586
