### PR TITLE
feat(#598): résilience 1/4 — socle « retomber sur ses pattes »

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,38 @@ ascendante** : la casse se signale ici et par un bump majeur, jamais en gardant 
 morts. Seule contrainte non négociable — les **données historiques restent lisibles** : un Run
 archivé s'ouvre et se chiffre quelle que soit la version qui a écrit son payload.
 
+## 1.32.0
+
+**Résilience des runs — socle « retomber sur ses pattes »** (#598, ADR-0049/0050, ADR-0032/0009/0036
+amendés). Aucune migration, données historiques lisibles (log append-only, `resume_run` reste projeté).
+
+Changement de comportement, non cassant sur le fil : **le runtime ne déclare plus jamais forfait de
+lui-même**. Un incident infra (mort de session, boot recovery, spawn-abort) met le node en
+`Interrupted` (nouveau statut de node, **non terminal**, distinct de `Failed`) et le run en
+`AwaitingUser` avec une **raison** (`awaiting_reason`), jamais `RunFailed`. Les give-up runtime
+(stall run-level, refus de validation d'output, conflit de merge, `unrouted`) parkent de même en
+`AwaitingUser`. `Failed` ne provient plus que d'un `pdo fail` **délibéré** d'un agent (opt-in
+`auto_fail`) ou d'un abandon humain.
+
+Notes qui ne se déduisent pas du titre :
+
+- **`auto_fail`** — opt-in résolu `nœud < Run < Projet < instance` (défaut décoché) : décoché, un
+  `pdo fail` d'agent parke le run pour confirmation humaine ; coché, il termine direct en `Failed`.
+  Ne concerne QUE le `pdo fail` d'agent ; tout give-up runtime parke quoi qu'il arrive. Colonnes
+  `auto_fail` ajoutées (idempotent) à `instance_config` et `projects` ; clé gelée dans `RunStarted`
+  et lisible par nœud (`auto_fail:` YAML). Env `PDO_AUTO_FAIL`.
+- **Ré-ouverture** — `terminal ≠ verrouillé`. `reopen_run` (bouton **Play** de la toolbar de niveau
+  Run) re-projette n'importe quel run terminal (`Completed`/`Skipped`/`Failed`/`Halted`) vers
+  `Running` : les `(node, iter)` satisfaits restent gelés (jamais re-spawnés, anti-#221), seul le
+  travail non satisfait repart. Les commandes ciblées (retry/restart/start/mark-complete/inject)
+  **embarquent** leur propre ré-ouverture — plus de « resume the run first », plus de course de
+  re-fail. Le label terminal précédent reste dans l'event log.
+- **Spawn idempotent** — un `SpawnOutcome::Failed`/abort sur le chemin scheduler appende désormais un
+  événement `NodeInterrupted` nommant le node + la cause (fin du run figé `running` de #498) ; le
+  reap d'un worktree/branche survivant reste porté par `ensure_sub_worktree`.
+- Front : statut de node `interrupted` (ambre), raison d'interruption dans la sidebar du run, groupe
+  d'actions « run terminé » (Reopen · Retry-all · Open shell) dans la toolbar du canvas (Variante A).
+
 ## 1.31.0
 
 Rien de cassant, aucune migration. **Assistant IA d'authoring des templates de bibliothèque**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "1.31.1"
+version = "1.32.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "1.31.1"
+version = "1.32.0"
 license = "MIT"
 
 [workspace.dependencies]

--- a/crates/pdo-daemon/src/auto_fail.rs
+++ b/crates/pdo-daemon/src/auto_fail.rs
@@ -1,0 +1,106 @@
+//! Resolve a node's effective `auto_fail` policy — **pure** (ADR-0049, ADR-0015).
+//!
+//! `auto_fail` is the one opt-in that lets an **agent's `pdo fail`** terminalise
+//! a run directly to `Failed`. Decked (the default), an agent `pdo fail` parks
+//! the run `AwaitingUser` so a human confirms the failure; checked, it fails the
+//! run straight away. It concerns **only** the agent `pdo fail` — every runtime
+//! give-up (session death, boot recovery, spawn-abort, output-validation, merge
+//! conflict, `unrouted`, run-level stall) parks regardless.
+//!
+//! It is resolved on the harness axis' precedence shape, coarsest last:
+//! `node → Run → Projet → instance (global)`. The finest tier that states a
+//! preference wins; the instance tier is a plain `bool` floor (default `false`),
+//! not an `Option`, because there is always a global answer (`stored → env →
+//! false`, ADR-0015). Every finer tier is `Option<bool>`: `None` = "this tier
+//! states no preference, fall through".
+//!
+//! Pure by contract: a set of tier values in, a `bool` out — no `$HOME`, no
+//! disk, no clock — so the whole precedence matrix is unit-tested without a
+//! fixture (the discipline `harness_resolver` and `run_cost` pay).
+
+/// The `auto_fail` preference named at each tier, coarsest last. `None` on a
+/// finer tier = "states no preference"; the instance tier is a resolved `bool`
+/// floor, never absent.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct AutoFailTiers {
+    /// The node's `auto_fail:` (pipeline YAML). Finest tier.
+    pub node: Option<bool>,
+    /// The Run's `auto_fail`, frozen at creation from the `RunStarted` payload.
+    pub run: Option<bool>,
+    /// The Projet's `auto_fail` (ADR-0046 middle tier).
+    pub project: Option<bool>,
+    /// The instance default (`stored → env → false`). The floor — always a
+    /// resolved boolean.
+    pub instance: bool,
+}
+
+/// Resolve the effective `auto_fail`: the finest tier that states a preference
+/// wins, with the instance boolean as the floor.
+///
+/// `node` beats `run` beats `project` beats `instance` — the exact precedence
+/// FP #5 pins (a node-level `auto_fail` overrides a run/project/global one).
+pub(crate) fn resolve_auto_fail(tiers: &AutoFailTiers) -> bool {
+    tiers
+        .node
+        .or(tiers.run)
+        .or(tiers.project)
+        .unwrap_or(tiers.instance)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn floor_is_the_instance_bool_when_no_finer_tier_states_one() {
+        assert!(!resolve_auto_fail(&AutoFailTiers {
+            instance: false,
+            ..Default::default()
+        }));
+        assert!(resolve_auto_fail(&AutoFailTiers {
+            instance: true,
+            ..Default::default()
+        }));
+    }
+
+    #[test]
+    fn project_beats_instance() {
+        assert!(resolve_auto_fail(&AutoFailTiers {
+            project: Some(true),
+            instance: false,
+            ..Default::default()
+        }));
+        assert!(!resolve_auto_fail(&AutoFailTiers {
+            project: Some(false),
+            instance: true,
+            ..Default::default()
+        }));
+    }
+
+    #[test]
+    fn run_beats_project_and_instance() {
+        assert!(resolve_auto_fail(&AutoFailTiers {
+            run: Some(true),
+            project: Some(false),
+            instance: false,
+            ..Default::default()
+        }));
+    }
+
+    #[test]
+    fn node_beats_every_coarser_tier() {
+        // FP #5: `auto_fail` at the node level wins over run / project / global.
+        assert!(resolve_auto_fail(&AutoFailTiers {
+            node: Some(true),
+            run: Some(false),
+            project: Some(false),
+            instance: false,
+        }));
+        assert!(!resolve_auto_fail(&AutoFailTiers {
+            node: Some(false),
+            run: Some(true),
+            project: Some(true),
+            instance: true,
+        }));
+    }
+}

--- a/crates/pdo-daemon/src/boot_recovery.rs
+++ b/crates/pdo-daemon/src/boot_recovery.rs
@@ -94,11 +94,11 @@ pub(crate) async fn run_boot_recovery(state: &AppState) {
                 .collect();
             for (node_id, iter, node_status) in &dangling {
                 let session = tmux_session_manager::node_session_name(run_id, node_id, *iter);
-                let fail = event_log::Event {
+                let interrupted = event_log::Event {
                     id: None,
                     run_id: run_id.clone(),
                     ts: event_log::now_iso(),
-                    kind: event_log::EventKind::NodeFailed,
+                    kind: event_log::EventKind::NodeInterrupted,
                     node_id: Some(node_id.clone()),
                     iter: Some(*iter),
                     payload: Some(serde_json::json!({
@@ -110,10 +110,12 @@ pub(crate) async fn run_boot_recovery(state: &AppState) {
                         )
                     })),
                 };
-                // Through the guard: idempotent across reboots. validate_fail
-                // returns NoOp once the iteration is already terminal, so a
-                // second pass appends nothing.
-                if let Err(e) = append_event(state, &fail).await {
+                // Through the guard: idempotent across reboots. validate_interrupt
+                // returns NoOp once the iteration is already terminal/interrupted,
+                // so a second pass appends nothing. The run is terminal, so this
+                // only frees the phantom session-holding slot — `finalize` does not
+                // lift a terminal run to AwaitingUser.
+                if let Err(e) = append_event(state, &interrupted).await {
                     error!(
                         "Boot recovery: failed to reconcile dangling {node_id} iter {iter} \
                          in terminal run {run_id}: {e}"
@@ -121,7 +123,7 @@ pub(crate) async fn run_boot_recovery(state: &AppState) {
                 } else {
                     warn!(
                         "Boot recovery: node {node_id} iter {iter} in terminal run {run_id} \
-                         left session-holding ({node_status:?}) — marked Failed"
+                         left session-holding ({node_status:?}) — marked Interrupted"
                     );
                 }
             }
@@ -213,28 +215,31 @@ pub(crate) async fn run_boot_recovery(state: &AppState) {
 
         for (node_id, iter) in &orphaned {
             let session = tmux_session_manager::node_session_name(run_id, node_id, *iter);
-            let fail = event_log::Event {
+            let interrupted = event_log::Event {
                 id: None,
                 run_id: run_id.clone(),
                 ts: event_log::now_iso(),
-                kind: event_log::EventKind::NodeFailed,
+                kind: event_log::EventKind::NodeInterrupted,
                 node_id: Some(node_id.clone()),
                 iter: Some(*iter),
                 payload: Some(serde_json::json!({
                     "reason": format!(
-                        "boot_recovery: tmux session {session} no longer exists \
-                         (node was Running across a daemon restart)"
+                        "session_died: tmux session {session} no longer exists \
+                         (daemon restarted while the node held a session)"
                     )
                 })),
             };
-            // Through the guard: if the node turned terminal organically before
-            // this pass, the failure is dropped as a no-op.
-            if let Err(e) = append_event(state, &fail).await {
-                error!("Boot recovery: failed to fail orphaned {node_id} iter {iter}: {e}");
+            // Since résilience (ADR-0049) a node lost across a daemon restart is
+            // `Interrupted`, not `Failed`: "la session est morte, pas le travail".
+            // The run parks `AwaitingUser` with this reason (derived in
+            // `finalize`), never `Failed`. Through the guard: if the node turned
+            // terminal organically before this pass, the interrupt is a no-op.
+            if let Err(e) = append_event(state, &interrupted).await {
+                error!("Boot recovery: failed to interrupt orphaned {node_id} iter {iter}: {e}");
             } else {
                 warn!(
                     "Boot recovery: node {node_id} iter {iter} in run {run_id} \
-                     orphaned (session {session} gone) — marked Failed"
+                     orphaned (session {session} gone) — marked Interrupted"
                 );
             }
         }

--- a/crates/pdo-daemon/src/event_log.rs
+++ b/crates/pdo-daemon/src/event_log.rs
@@ -62,6 +62,19 @@ pub enum EventKind {
     NodeAwaitingUser,
     NodeCompleted,
     NodeFailed,
+    /// An **infra** incident killed the node's session — session death, boot
+    /// recovery, or a spawn-abort on the scheduler path (ADR-0049 / ADR-0050).
+    /// Projects [`NodeStatus::Interrupted`] (non terminal, distinct from
+    /// `NodeFailed`), which lifts the run to `AwaitingUser` with the incident
+    /// reason in [`finalize`]. The runtime **never** turns this into `Failed`;
+    /// only a deliberate `pdo fail` or a human abandon does.
+    ///
+    /// Unlike `NodeFailed`, the guard (`validate_interrupt`) admits it even for
+    /// an iteration that never opened a `NodeStarted` row — a spawn that aborts
+    /// *before* start still names its node and cause (ADR-0050 §1), and the
+    /// projection materialises the node so the incident is visible. Wire form:
+    /// `"node_interrupted"`.
+    NodeInterrupted,
     MergeConflictDetected,
     /// A merge-back conflicted and was resolved **in the node's favour** instead of
     /// failing the Run (#503, ADR-0036): the node's branch had stopped being a
@@ -120,6 +133,17 @@ pub enum EventKind {
     PipelineModified,
     RunCompleted,
     RunFailed,
+    /// The runtime **gave up** on driving the run forward for a reason that is
+    /// **not** a deliberate failure — a run-level stall, an output-validation
+    /// refusal, a merge conflict, or an `unrouted` convergence (ADR-0049). It
+    /// parks the run **`AwaitingUser`** with the reason carried in
+    /// [`RunState::awaiting_reason`], **never `RunFailed`**: a human confirms,
+    /// reopens, or drives it out. **Non terminal** — it never sets
+    /// `completed_at`, and it is inert on an already-terminal run (#221: an
+    /// active give-up must not un-terminalize a run that genuinely finished).
+    /// The run-level twin of [`NodeInterrupted`], for the give-up cases that
+    /// name no single node to interrupt. Wire form: `"run_interrupted"`.
+    RunInterrupted,
     /// Graceful no-op (#245): the run fired but there was legitimately nothing
     /// to do (e.g. an auto-issue selector found its eligible pool emptied
     /// between guard-eval and node-run). A distinct terminal status from
@@ -403,6 +427,15 @@ pub enum NodeStatus {
     Failed,
     Stopped,
     Stale,
+    /// The node's session died on an **infra** incident (session death, boot
+    /// recovery, spawn-abort) — "la session est morte, pas le travail"
+    /// (ADR-0049). **Non terminal** and distinct from `Failed`: the work on
+    /// disk is presumed intact, the run parks `AwaitingUser` (never `Failed`),
+    /// and a human recovers it (resume-in-worktree or restart-with-artefacts).
+    /// Holds no session and cannot progress on its own — a human gesture is
+    /// required to reach `Running` again. `Failed` stays reserved for a
+    /// deliberate `pdo fail` or a human abandon.
+    Interrupted,
 }
 
 impl NodeStatus {
@@ -411,6 +444,8 @@ impl NodeStatus {
     /// `{Running, AwaitingUser}` (an interactive node keeps its tmux session
     /// attachable indefinitely). EXCLUDES `Waiting`: a throttled node is ready
     /// to run but has *not* spawned a session yet, so it holds no slot (#159).
+    /// EXCLUDES `Interrupted`: an infra incident killed the session (ADR-0049),
+    /// so a slot it once held is already freed.
     pub fn holds_session(&self) -> bool {
         matches!(self, NodeStatus::Running | NodeStatus::AwaitingUser)
     }
@@ -422,12 +457,22 @@ impl NodeStatus {
     /// the load-bearing difference from [`holds_session`](Self::holds_session),
     /// which excludes `Waiting`. Collapsing the two would falsely declare a
     /// throttled-but-healthy run stalled (CONTEXT.md, § Réconciliation au
-    /// niveau Run).
+    /// niveau Run). EXCLUDES `Interrupted`: an interrupted node needs a human to
+    /// resume/restart it, so it does NOT keep the run schedulable — instead the
+    /// run parks `AwaitingUser`, derived in [`finalize`].
     pub fn can_progress(&self) -> bool {
         matches!(
             self,
             NodeStatus::Running | NodeStatus::Waiting | NodeStatus::AwaitingUser
         )
+    }
+
+    /// Whether a node in this status was **interrupted by an infra incident**
+    /// (ADR-0049) — the one node status that lifts a `Running` run to
+    /// `AwaitingUser` with a reason (see [`finalize`]), distinct from the
+    /// interactive `AwaitingUser` wait.
+    pub fn is_interrupted(&self) -> bool {
+        matches!(self, NodeStatus::Interrupted)
     }
 }
 
@@ -680,6 +725,16 @@ pub struct RunState {
     /// last time's cause.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub failure_reason: Option<String>,
+    /// Why the Run is parked **`AwaitingUser` on an incident** (ADR-0049),
+    /// distinct from the interactive `AwaitingUser` wait of a node that asked
+    /// its user a question. Set by a `RunInterrupted` event (run-level give-up)
+    /// or derived in [`finalize`] from an `Interrupted` node's reason; cleared
+    /// by `RunResumed` and by a `reopen_run`/`resume_run` command — a run being
+    /// driven again must not still show last time's incident. `None` for an
+    /// interactive wait (that node's own reason lives on the node), so the two
+    /// awaiting causes stay distinguishable from the run state alone.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub awaiting_reason: Option<String>,
     pub nodes: HashMap<String, NodeState>,
     #[serde(default)]
     pub edges: Vec<EdgeInfo>,
@@ -825,6 +880,15 @@ pub struct RunState {
     /// and by the infra sessions (Pipeline Manager, merge resolver).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub harness: Option<String>,
+    /// The Run's `auto_fail` preference (ADR-0049), **frozen** here from the
+    /// `RunStarted` payload — the **run** tier of
+    /// [`crate::auto_fail::resolve_auto_fail`] (`node → Run → Projet →
+    /// instance`). `None` ⇒ the Run stated no preference (every historical Run,
+    /// and any Run created without an explicit choice — the payload omits the
+    /// key), so a node `pdo fail` resolves through the project/instance tiers.
+    /// Immutable, like [`RunState::harness`]: set once at create, never mutated.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auto_fail: Option<bool>,
     /// Provenance: the id of the Trigger that created this Run, if any.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub triggered_by: Option<String>,
@@ -867,6 +931,7 @@ impl RunState {
             started_at: None,
             completed_at: None,
             failure_reason: None,
+            awaiting_reason: None,
             nodes: HashMap::new(),
             edges: Vec::new(),
             node_defs: Vec::new(),
@@ -890,6 +955,7 @@ impl RunState {
             source_branch: None,
             fork_sha: None,
             harness: None,
+            auto_fail: None,
             triggered_by: None,
             pipeline_id: None,
             sessions_spawned: 0,
@@ -1087,6 +1153,7 @@ pub(crate) fn project(events: &[Event]) -> Option<RunState> {
             | EventKind::RunRenamed
             | EventKind::RunReposEdited
             | EventKind::RunArchived
+            | EventKind::RunInterrupted
             | EventKind::SandboxPrepStarted
             | EventKind::SandboxPrepReady => apply_run_event(&mut state, event),
 
@@ -1096,6 +1163,7 @@ pub(crate) fn project(events: &[Event]) -> Option<RunState> {
             | EventKind::NodeAutoCompleted
             | EventKind::NodeAwaitingUser
             | EventKind::NodeFailed
+            | EventKind::NodeInterrupted
             | EventKind::NodeStopped
             | EventKind::NodeStale
             | EventKind::NodeInvalidated
@@ -1359,6 +1427,11 @@ fn apply_run_event(state: &mut RunState, event: &Event) {
                         state.harness = Some(h.to_string());
                     }
                 }
+                // ADR-0049: the Run's frozen `auto_fail` tier. Absent key ⇒ `None`
+                // (the Run stated no preference — every historical Run).
+                if let Some(af) = payload.get("auto_fail").and_then(|v| v.as_bool()) {
+                    state.auto_fail = Some(af);
+                }
                 if let Some(tb) = payload.get("triggered_by").and_then(|v| v.as_str()) {
                     state.triggered_by = Some(tb.to_string());
                 }
@@ -1464,6 +1537,22 @@ fn apply_run_event(state: &mut RunState, event: &Event) {
             // A Run being driven again must not still display last time's cause
             // (#503) — same rule `NodeStarted` applies to `NodeState::failure_reason`.
             state.failure_reason = None;
+            // An incident park (ADR-0049) clears the same way: a resumed Run is
+            // no longer waiting on that incident.
+            state.awaiting_reason = None;
+        }
+        // The runtime gave up on driving the run forward for a non-deliberate
+        // reason (ADR-0049): park it `AwaitingUser` with the reason, NEVER
+        // `Failed`, and never set `completed_at` (it is not terminal). Inert on
+        // an already-terminal run (#221): an active give-up racing a genuine
+        // completion must not un-terminalize it. A live run (Running /
+        // AwaitingUser / Paused) parks; a Paused run parks too so an operator
+        // sees why it will not resume clean.
+        EventKind::RunInterrupted => {
+            if state.status.is_live() {
+                state.status = RunStatus::AwaitingUser;
+                state.awaiting_reason = run_event_reason(event);
+            }
         }
         EventKind::RunRenamed => {
             if let Some(ref payload) = event.payload {
@@ -1676,6 +1765,73 @@ fn apply_node_event(state: &mut RunState, event: &Event) {
                         it.status = NodeStatus::Failed;
                         it.completed_at = Some(event.ts.clone());
                     }
+                }
+            }
+        }
+        EventKind::NodeInterrupted => {
+            // An infra incident (ADR-0049). Unlike `NodeFailed` this must be
+            // visible even when the spawn aborted BEFORE `NodeStarted` opened an
+            // iteration (ADR-0050 §1: a spawn abort names its node), so the node
+            // is materialised if absent — with no iteration row, which is the
+            // honest shape of "the session never started".
+            if let Some(ref node_id) = event.node_id {
+                let iter = event.iter.unwrap_or(1);
+                let reason = event
+                    .payload
+                    .as_ref()
+                    .and_then(|p| p.get("reason"))
+                    .and_then(|v| v.as_str())
+                    .map(String::from);
+                let node = state
+                    .nodes
+                    .entry(node_id.clone())
+                    .or_insert_with(|| NodeState {
+                        node_id: node_id.clone(),
+                        status: NodeStatus::Interrupted,
+                        iter,
+                        started_at: None,
+                        completed_at: None,
+                        failure_reason: None,
+                        iterations: Vec::new(),
+                        frontmatter_retries: 0,
+                        frontmatter_violations: Vec::new(),
+                        missing_outputs: Vec::new(),
+                    });
+                // Node-level status derives from the LATEST iteration, mirroring
+                // the `NodeFailed` #196/#212 guard: interrupting an older iter
+                // must not mislabel a node whose newer iteration is still live.
+                if iter >= node.iter {
+                    node.status = NodeStatus::Interrupted;
+                    node.iter = iter;
+                    node.failure_reason = reason;
+                    // Not a green completion: leave `completed_at` untouched.
+                    // Carry the same validation evidence a `NodeFailed` would
+                    // (#490): an output-validation interrupt should render the red
+                    // banner with the missing ports / frontmatter violations, not
+                    // an empty list. Both shapes read, exactly like `NodeFailed`.
+                    if let Some(ref payload) = event.payload {
+                        let detail = payload.get("detail");
+                        if let Some(arr) = payload
+                            .get("violations")
+                            .or_else(|| detail.and_then(|d| d.get("violations")))
+                            .and_then(|v| v.as_array())
+                        {
+                            node.frontmatter_violations = arr.clone();
+                        }
+                        if let Some(arr) = payload
+                            .get("missing")
+                            .or_else(|| detail.and_then(|d| d.get("missing")))
+                            .and_then(|v| v.as_array())
+                        {
+                            node.missing_outputs = arr
+                                .iter()
+                                .filter_map(|v| v.as_str().map(String::from))
+                                .collect();
+                        }
+                    }
+                }
+                if let Some(it) = node.iterations.iter_mut().find(|i| i.iter == iter) {
+                    it.status = NodeStatus::Interrupted;
                 }
             }
         }
@@ -2083,11 +2239,48 @@ fn apply_pipeline_event(_state: &mut RunState, event: &Event) {
 fn apply_command_event(state: &mut RunState, event: &Event) {
     if let Some(ref payload) = event.payload {
         let cmd = payload.get("command").and_then(|v| v.as_str());
-        if cmd == Some("resume_run")
-            && (state.status == RunStatus::Halted || state.status == RunStatus::Failed)
+        // Re-opening a terminal Run (ADR-0049 / ADR-0032 amended): `terminal ≠
+        // locked`. A human gesture — the global `reopen_run` (Play button), or a
+        // targeted command that embeds its own re-open — lifts ANY terminal Run
+        // back to `Running` by a safe re-projection: the satisfied `(node, iter)`
+        // stay `Completed` (the scheduler's dedup refuses to re-spawn them,
+        // anti-#221), only the unsatisfied work runs. `resume_run` is the
+        // historical name of the same gesture, kept so every replayed log still
+        // re-opens (append-only). Both clear the previous terminal/incident
+        // reason — a Run being driven again must not still show last time's
+        // cause (#503) — while the terminal *label* stays in the event log.
+        //
+        // The set now includes `Completed`/`Skipped` (a finished Run can pick up
+        // a newly-added node, FP #6) — the pre-résilience code lifted only
+        // `Halted`/`Failed`. An `AwaitingUser` incident park is also lifted
+        // clean here.
+        if matches!(cmd, Some("reopen_run") | Some("resume_run"))
+            && matches!(
+                state.status,
+                RunStatus::Halted
+                    | RunStatus::Failed
+                    | RunStatus::Completed
+                    | RunStatus::Skipped
+                    | RunStatus::AwaitingUser
+            )
         {
             state.status = RunStatus::Running;
             state.completed_at = None;
+            state.failure_reason = None;
+            state.awaiting_reason = None;
+            // Re-drive the interrupted work (ADR-0049 default: restart with the
+            // partial artefacts, which persist in the sub-worktree). Drop each
+            // `Interrupted` node from the projection — exactly like
+            // `NodeInvalidated` — so the scheduler re-spawns it fresh (its
+            // sub-worktree is reused, feeding the partial work) instead of
+            // leaving it parked; without this, [`finalize`] would re-derive
+            // `AwaitingUser` from the still-interrupted node and the re-open
+            // would not stick. The satisfied `Completed` nodes are untouched, so
+            // the scheduler never re-spawns them (anti-#221). The event log keeps
+            // every `NodeInterrupted` — this only rewinds the *projection*.
+            state
+                .nodes
+                .retain(|_, n| n.status != NodeStatus::Interrupted);
         }
         // #199: `end_region` CLOSES the region — the projection
         // marks its loop state done so the scheduler's region
@@ -2132,14 +2325,34 @@ fn finalize(state: &mut RunState) {
         }
     }
 
-    // Derive run-level awaiting_user from node states
+    // Derive run-level awaiting_user from node states. Two causes, one status
+    // (ADR-0049): an *interactive* node genuinely waiting on its user, OR an
+    // *interrupted* node whose infra incident parked the run. Both lift a
+    // `Running` run to `AwaitingUser`; only the incident carries an
+    // `awaiting_reason`, which keeps the two distinguishable from the run state
+    // alone.
     if state.status == RunStatus::Running
-        && state
-            .nodes
-            .values()
-            .any(|n| n.status == NodeStatus::AwaitingUser)
+        && state.nodes.values().any(|n| {
+            n.status == NodeStatus::AwaitingUser || n.status == NodeStatus::Interrupted
+        })
     {
         state.status = RunStatus::AwaitingUser;
+    }
+
+    // Surface the incident reason when the park is caused by an interrupted node
+    // and no run-level `RunInterrupted` already set one. An interactive-only
+    // wait leaves `awaiting_reason` `None` (its prompt is the node's business,
+    // not an incident). Deterministic pick — the lowest node id — so replay is
+    // stable when several nodes interrupted.
+    if state.status == RunStatus::AwaitingUser && state.awaiting_reason.is_none() {
+        if let Some((_, node)) = state
+            .nodes
+            .iter()
+            .filter(|(_, n)| n.status == NodeStatus::Interrupted)
+            .min_by(|a, b| a.0.cmp(b.0))
+        {
+            state.awaiting_reason = node.failure_reason.clone();
+        }
     }
 }
 
@@ -3127,6 +3340,147 @@ mod tests {
             "a green node must not carry the violations of the attempt it recovered from"
         );
         assert!(node.missing_outputs.is_empty());
+    }
+
+    // --- résilience: Interrupted / RunInterrupted / reopen (ADR-0049/0050) ------
+
+    fn interrupt_event(node_id: &str, iter: i64, reason: &str) -> Event {
+        Event {
+            id: None,
+            run_id: "run-1".into(),
+            ts: "2026-01-01T00:00:00.000Z".into(),
+            kind: EventKind::NodeInterrupted,
+            node_id: Some(node_id.into()),
+            iter: Some(iter),
+            payload: Some(serde_json::json!({ "reason": reason })),
+        }
+    }
+
+    #[test]
+    fn node_interrupt_parks_the_run_awaiting_user_with_the_reason() {
+        // ADR-0049: session death → NodeInterrupted → finalize lifts a Running run
+        // to AwaitingUser, carrying the incident reason distinctly.
+        let state = project(&[
+            make_event(EventKind::RunStarted, None, None),
+            make_event(EventKind::NodeStarted, Some("worker"), Some(1)),
+            interrupt_event("worker", 1, "session_died: tmux gone"),
+        ])
+        .unwrap();
+        assert_eq!(state.status, RunStatus::AwaitingUser);
+        assert_eq!(state.nodes["worker"].status, NodeStatus::Interrupted);
+        assert_eq!(state.awaiting_reason.as_deref(), Some("session_died: tmux gone"));
+        // Distinct from an interactive wait: that carries no awaiting_reason.
+        assert!(state.failure_reason.is_none());
+    }
+
+    #[test]
+    fn node_interrupt_before_start_materialises_the_node() {
+        // ADR-0050 §1: a spawn abort BEFORE NodeStarted still names its node; the
+        // projection materialises it Interrupted (no iteration row) so the run
+        // parks visibly instead of freezing `running`.
+        let state = project(&[
+            make_event(EventKind::RunStarted, None, None),
+            interrupt_event("worker", 1, "failed to ensure sub-worktree"),
+        ])
+        .unwrap();
+        assert_eq!(state.status, RunStatus::AwaitingUser);
+        assert_eq!(state.nodes["worker"].status, NodeStatus::Interrupted);
+        assert!(state.nodes["worker"].iterations.is_empty());
+    }
+
+    #[test]
+    fn run_interrupted_parks_a_live_run_and_is_inert_on_a_terminal_one() {
+        // A run-level give-up (stall / unrouted / merge) parks AwaitingUser…
+        let parked = project(&[
+            make_event(EventKind::RunStarted, None, None),
+            make_event_with_payload(
+                EventKind::RunInterrupted,
+                None,
+                serde_json::json!({ "reason": "run_stalled: nothing schedulable" }),
+            ),
+        ])
+        .unwrap();
+        assert_eq!(parked.status, RunStatus::AwaitingUser);
+        assert_eq!(
+            parked.awaiting_reason.as_deref(),
+            Some("run_stalled: nothing schedulable")
+        );
+
+        // …but a RunInterrupted racing a genuine completion must NOT un-terminalize
+        // it (#221): inert on an already-terminal run.
+        let completed = project(&[
+            make_event(EventKind::RunStarted, None, None),
+            make_event(EventKind::RunCompleted, None, None),
+            make_event_with_payload(
+                EventKind::RunInterrupted,
+                None,
+                serde_json::json!({ "reason": "late" }),
+            ),
+        ])
+        .unwrap();
+        assert_eq!(completed.status, RunStatus::Completed);
+        assert!(completed.awaiting_reason.is_none());
+    }
+
+    #[test]
+    fn reopen_lifts_a_terminal_run_and_re_drives_interrupted_nodes() {
+        // AC6/AC8/FP#8: reopen a terminal run → Running, satisfied nodes stay
+        // Completed (never re-spawned, anti-#221), interrupted nodes are dropped so
+        // they re-drive; the terminal label stays in the log.
+        let reopen = Event {
+            id: None,
+            run_id: "run-1".into(),
+            ts: "2026-01-01T00:00:00.000Z".into(),
+            kind: EventKind::CommandIssued,
+            node_id: None,
+            iter: None,
+            payload: Some(serde_json::json!({ "command": "reopen_run" })),
+        };
+        let state = project(&[
+            make_event(EventKind::RunStarted, None, None),
+            make_event(EventKind::NodeStarted, Some("done"), Some(1)),
+            make_event(EventKind::NodeCompleted, Some("done"), Some(1)),
+            make_event(EventKind::NodeStarted, Some("hurt"), Some(1)),
+            interrupt_event("hurt", 1, "session_died"),
+            make_event_with_payload(
+                EventKind::RunFailed,
+                None,
+                serde_json::json!({ "reason": "human abandon" }),
+            ),
+            reopen,
+        ])
+        .unwrap();
+        assert_eq!(state.status, RunStatus::Running);
+        assert_eq!(state.nodes["done"].status, NodeStatus::Completed);
+        assert!(
+            !state.nodes.contains_key("hurt"),
+            "the interrupted node is dropped so the scheduler re-drives it fresh"
+        );
+        assert!(state.failure_reason.is_none() && state.awaiting_reason.is_none());
+    }
+
+    #[test]
+    fn legacy_resume_run_command_still_reopens_a_completed_run() {
+        // Back-compat: the historical `resume_run` command string re-opens exactly
+        // like `reopen_run` (append-only log: every replayed run must still lift).
+        let resume = Event {
+            id: None,
+            run_id: "run-1".into(),
+            ts: "2026-01-01T00:00:00.000Z".into(),
+            kind: EventKind::CommandIssued,
+            node_id: None,
+            iter: None,
+            payload: Some(serde_json::json!({ "command": "resume_run" })),
+        };
+        let state = project(&[
+            make_event(EventKind::RunStarted, None, None),
+            make_event(EventKind::NodeStarted, Some("a"), Some(1)),
+            make_event(EventKind::NodeCompleted, Some("a"), Some(1)),
+            make_event(EventKind::RunCompleted, None, None),
+            resume,
+        ])
+        .unwrap();
+        assert_eq!(state.status, RunStatus::Running);
     }
 
     #[test]
@@ -5459,6 +5813,7 @@ mod tests {
             Failed,
             Stopped,
             Stale,
+            Interrupted,
         ];
         for s in &all {
             match s {
@@ -5476,7 +5831,10 @@ mod tests {
                         "Waiting CAN progress (it spawns once a slot frees)"
                     );
                 }
-                Pending | Completed | Failed | Stopped | Stale => {
+                // `Interrupted` (ADR-0049): holds no session and cannot progress
+                // on its own — a human resumes/restarts it, so it parks the run
+                // `AwaitingUser` rather than keeping it schedulable.
+                Pending | Completed | Failed | Stopped | Stale | Interrupted => {
                     assert!(!s.holds_session(), "{s:?} holds no session");
                     assert!(!s.can_progress(), "{s:?} cannot drive the run forward");
                 }

--- a/crates/pdo-daemon/src/event_log.rs
+++ b/crates/pdo-daemon/src/event_log.rs
@@ -2332,9 +2332,10 @@ fn finalize(state: &mut RunState) {
     // `awaiting_reason`, which keeps the two distinguishable from the run state
     // alone.
     if state.status == RunStatus::Running
-        && state.nodes.values().any(|n| {
-            n.status == NodeStatus::AwaitingUser || n.status == NodeStatus::Interrupted
-        })
+        && state
+            .nodes
+            .values()
+            .any(|n| n.status == NodeStatus::AwaitingUser || n.status == NodeStatus::Interrupted)
     {
         state.status = RunStatus::AwaitingUser;
     }
@@ -3368,7 +3369,10 @@ mod tests {
         .unwrap();
         assert_eq!(state.status, RunStatus::AwaitingUser);
         assert_eq!(state.nodes["worker"].status, NodeStatus::Interrupted);
-        assert_eq!(state.awaiting_reason.as_deref(), Some("session_died: tmux gone"));
+        assert_eq!(
+            state.awaiting_reason.as_deref(),
+            Some("session_died: tmux gone")
+        );
         // Distinct from an interactive wait: that carries no awaiting_reason.
         assert!(state.failure_reason.is_none());
     }

--- a/crates/pdo-daemon/src/graph_resolver.rs
+++ b/crates/pdo-daemon/src/graph_resolver.rs
@@ -401,6 +401,7 @@ mod tests {
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            auto_fail: None,
         }
     }
 
@@ -457,6 +458,7 @@ mod tests {
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            auto_fail: None,
         }
     }
 

--- a/crates/pdo-daemon/src/input_resolution.rs
+++ b/crates/pdo-daemon/src/input_resolution.rs
@@ -447,6 +447,7 @@ mod tests {
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            auto_fail: None,
         }
     }
 

--- a/crates/pdo-daemon/src/instance_config.rs
+++ b/crates/pdo-daemon/src/instance_config.rs
@@ -89,6 +89,18 @@ pub(crate) struct InstanceConfig {
     /// column (`trigger_store::variables` idiom).
     #[serde(default)]
     pub default_harness_model: std::collections::BTreeMap<String, String>,
+    /// Stored instance-wide `auto_fail` default as `0`/`1`, or `None` when unset
+    /// (ADR-0049). The **global** (coarsest) tier of the `node → Run → Projet →
+    /// instance` precedence resolved by [`crate::auto_fail::resolve_auto_fail`].
+    /// Checked, an agent's `pdo fail` terminalises the run directly to `Failed`;
+    /// unset/`0`, it parks the run `AwaitingUser` for a human to confirm. `None`
+    /// falls through to the env seam ([`AUTO_FAIL_ENV`]) then the built-in default
+    /// (`false`).
+    ///
+    /// `Option<i64>` and not `Option<bool>` for the same reason as
+    /// [`Self::autocomplete_turn_end`]: `NULL` makes the `stored → env → default`
+    /// fall-through work; a stored `0` is a decision that beats the env.
+    pub auto_fail: Option<i64>,
     /// RFC3339-millis UTC timestamp of the last write (or the seed).
     pub updated_at: String,
 }
@@ -135,6 +147,10 @@ pub(crate) struct UpdateInstanceConfig {
     /// replaces the stored map wholesale; an empty map clears it. `None` leaves it
     /// untouched.
     pub default_harness_model: Option<std::collections::BTreeMap<String, String>>,
+    /// Set the instance-wide `auto_fail` default (ADR-0049): `Some(true)` stores
+    /// `1`, `Some(false)` stores `0`, `None` leaves it untouched. Same set-only,
+    /// `0`-not-`NULL` discipline as [`Self::autocomplete_turn_end`].
+    pub auto_fail: Option<bool>,
 }
 
 impl UpdateInstanceConfig {
@@ -148,6 +164,7 @@ impl UpdateInstanceConfig {
             && self.default_auto_name.is_none()
             && self.default_harness.is_none()
             && self.default_harness_model.is_none()
+            && self.auto_fail.is_none()
     }
 }
 
@@ -171,6 +188,7 @@ pub(crate) async fn init(db: &SqlitePool) -> Result<(), sqlx::Error> {
             default_auto_name  INTEGER,
             default_harness    TEXT,
             default_harness_model TEXT,
+            auto_fail          INTEGER,
             updated_at         TEXT NOT NULL
         )",
     )
@@ -294,6 +312,21 @@ pub(crate) async fn init(db: &SqlitePool) -> Result<(), sqlx::Error> {
             .await?;
     }
 
+    // Additive migration for pre-résilience databases: the `auto_fail` column is
+    // absent on tables created before ADR-0049. Same guarded `ADD COLUMN` idiom —
+    // NULLABLE so an existing install falls through env → the built-in default
+    // (`false`: an agent `pdo fail` parks the run, the human confirms).
+    let has_auto_fail =
+        sqlx::query("SELECT 1 FROM pragma_table_info('instance_config') WHERE name = 'auto_fail'")
+            .fetch_optional(db)
+            .await?
+            .is_some();
+    if !has_auto_fail {
+        sqlx::query("ALTER TABLE instance_config ADD COLUMN auto_fail INTEGER")
+            .execute(db)
+            .await?;
+    }
+
     Ok(())
 }
 
@@ -314,6 +347,7 @@ fn row_to_config(row: &sqlx::sqlite::SqliteRow) -> InstanceConfig {
             .get::<Option<String>, _>("default_harness_model")
             .and_then(|s| serde_json::from_str(&s).ok())
             .unwrap_or_default(),
+        auto_fail: row.get("auto_fail"),
         updated_at: row.get("updated_at"),
     }
 }
@@ -368,6 +402,9 @@ pub(crate) async fn update(
     if edit.default_harness_model.is_some() {
         sets.push("default_harness_model = ?");
     }
+    if edit.auto_fail.is_some() {
+        sets.push("auto_fail = ?");
+    }
     // Always bump the write timestamp on a real edit.
     sets.push("updated_at = ?");
 
@@ -417,6 +454,11 @@ pub(crate) async fn update(
         // decision). Serialisation cannot fail for a String→String map.
         query = query.bind(serde_json::to_string(&v).unwrap_or_else(|_| "{}".to_string()));
     }
+    if let Some(v) = edit.auto_fail {
+        // 0/1, never NULL: unchecking must persist a stored `0` that beats a
+        // `PDO_AUTO_FAIL=1`, not fall through to it (ADR-0049).
+        query = query.bind(if v { 1_i64 } else { 0_i64 });
+    }
     query = query.bind(crate::event_log::now_iso());
     query.execute(db).await?;
 
@@ -452,6 +494,32 @@ pub(crate) async fn set_triggers_paused(db: &SqlitePool, paused: bool) -> Result
         .execute(db)
         .await?;
     Ok(())
+}
+
+/// Env seam for the instance-wide `auto_fail` default (ADR-0049 / ADR-0015).
+/// Read only inside [`resolve_instance_auto_fail`], the `stored → env → default`
+/// precedence — never elsewhere. Any of `1`/`true`/`yes`/`on` (case-insensitive)
+/// is truthy; anything else (incl. unset) is falsey.
+pub(crate) const AUTO_FAIL_ENV: &str = "PDO_AUTO_FAIL";
+
+/// The instance (global) tier of `auto_fail`, `stored → env → default(false)`
+/// (ADR-0049). `stored` is the `auto_fail` column value (`Some(0/1)` a stored
+/// decision, `None` unset). Pure over its `stored` arg; reads the env only when
+/// `stored` is `None`, so a stored `0` beats a `PDO_AUTO_FAIL=1`.
+pub(crate) fn resolve_instance_auto_fail(stored: Option<i64>) -> bool {
+    match stored {
+        Some(v) => v != 0,
+        None => std::env::var(AUTO_FAIL_ENV)
+            .ok()
+            .map(|s| {
+                let t = s.trim();
+                t.eq_ignore_ascii_case("1")
+                    || t.eq_ignore_ascii_case("true")
+                    || t.eq_ignore_ascii_case("yes")
+                    || t.eq_ignore_ascii_case("on")
+            })
+            .unwrap_or(false),
+    }
 }
 
 /// The two columns #471 retired: `image_source` (#411) and `dockerfile_path` (#431). A staging

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -6634,8 +6634,8 @@ pub(crate) async fn handle_node_completion(
             .await
             {
                 ActionOutcome::Completed
-            | ActionOutcome::Halted { .. }
-            | ActionOutcome::Interrupted { .. } => return,
+                | ActionOutcome::Halted { .. }
+                | ActionOutcome::Interrupted { .. } => return,
                 ActionOutcome::Spawned { .. }
                 | ActionOutcome::Progressed
                 | ActionOutcome::SpawnSkipped { .. } => {}
@@ -6666,8 +6666,8 @@ pub(crate) async fn handle_node_completion(
             .await
             {
                 ActionOutcome::Completed
-            | ActionOutcome::Halted { .. }
-            | ActionOutcome::Interrupted { .. } => return,
+                | ActionOutcome::Halted { .. }
+                | ActionOutcome::Interrupted { .. } => return,
                 ActionOutcome::Spawned { .. }
                 | ActionOutcome::Progressed
                 | ActionOutcome::SpawnSkipped { .. } => {}
@@ -12892,9 +12892,7 @@ async fn node_fail(
         // slot. Re-drive throttled `waiting` nodes in other runs (#159).
         retry_waiting_nodes(&tail_state).await;
 
-        info!(
-            "Node {tail_node} failed in run {tail_run} (auto_fail={auto_fail_run})"
-        );
+        info!("Node {tail_node} failed in run {tail_run} (auto_fail={auto_fail_run})");
     });
     (StatusCode::OK, "ok").into_response()
 }
@@ -13064,7 +13062,9 @@ async fn force_spawn_node(state: &Arc<AppState>, run_id: &str, node_id: &str) ->
     // refusal. Runs before the guards below so they see a live Run.
     let run_state = match embed_reopen_for_targeted_command(state, run_id, run_state).await {
         Ok(s) => s,
-        Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, format!("error: {e}")).into_response(),
+        Err(e) => {
+            return (StatusCode::INTERNAL_SERVER_ERROR, format!("error: {e}")).into_response()
+        }
     };
 
     if let Some(ns) = run_state.nodes.get(node_id) {
@@ -13390,7 +13390,9 @@ async fn node_retry(
     //    409. The human's retry IS the re-open gesture (ADR-0009 amended).
     let run_state = match embed_reopen_for_targeted_command(&state, &run_id, run_state).await {
         Ok(s) => s,
-        Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, format!("error: {e}")).into_response(),
+        Err(e) => {
+            return (StatusCode::INTERNAL_SERVER_ERROR, format!("error: {e}")).into_response()
+        }
     };
 
     // ── HEAD PROBE 1 (#487): run-liveness. The FIRST gesture — a refusal here leaves
@@ -24070,9 +24072,11 @@ edges:
         // The embedded re-open is in the log, and the previous terminal label is
         // preserved (AC12).
         assert!(
-            events.iter().any(|e| e.kind == event_log::EventKind::CommandIssued
-                && e.payload.as_ref().and_then(|p| p.get("command"))
-                    == Some(&serde_json::json!("reopen_run"))),
+            events
+                .iter()
+                .any(|e| e.kind == event_log::EventKind::CommandIssued
+                    && e.payload.as_ref().and_then(|p| p.get("command"))
+                        == Some(&serde_json::json!("reopen_run"))),
             "the mark_node_done must embed a reopen_run CommandIssued"
         );
         assert!(
@@ -28628,9 +28632,11 @@ edges: []
         // terminal `RunCompleted` label is preserved (AC12).
         let events = load_events(&state.db, run_id).await.unwrap();
         assert!(
-            events.iter().any(|e| e.kind == event_log::EventKind::CommandIssued
-                && e.payload.as_ref().and_then(|p| p.get("command"))
-                    == Some(&serde_json::json!("reopen_run"))),
+            events
+                .iter()
+                .any(|e| e.kind == event_log::EventKind::CommandIssued
+                    && e.payload.as_ref().and_then(|p| p.get("command"))
+                        == Some(&serde_json::json!("reopen_run"))),
             "the Start must embed a reopen_run CommandIssued on a terminal run"
         );
         assert!(
@@ -28872,9 +28878,10 @@ edges: []
         // `NodeInterrupted` naming the node (never `RunFailed`), which parks the
         // run `AwaitingUser` — visible and recoverable, never frozen `running`.
         assert!(
-            events.iter().any(|e| e.kind
-                == event_log::EventKind::NodeInterrupted
-                && e.node_id.as_deref() == Some("worker")),
+            events
+                .iter()
+                .any(|e| e.kind == event_log::EventKind::NodeInterrupted
+                    && e.node_id.as_deref() == Some("worker")),
             "the spawn abort must surface as a NodeInterrupted naming the node"
         );
         assert!(
@@ -29001,9 +29008,10 @@ edges: []
         // ...and the node is interrupted (ADR-0049: an infra spawn failure is
         // `NodeInterrupted`, not `NodeFailed`), never a `RunFailed`.
         assert!(
-            events.iter().any(|e| e.kind
-                == event_log::EventKind::NodeInterrupted
-                && e.node_id.as_deref() == Some("worker")),
+            events
+                .iter()
+                .any(|e| e.kind == event_log::EventKind::NodeInterrupted
+                    && e.node_id.as_deref() == Some("worker")),
             "a failed tmux spawn on a Running iteration must append NodeInterrupted"
         );
         assert!(
@@ -29100,9 +29108,10 @@ edges: []
             "the after-start path keeps its NodeStarted"
         );
         assert!(
-            events.iter().any(|e| e.kind
-                == event_log::EventKind::NodeInterrupted
-                && e.node_id.as_deref() == Some("worker")),
+            events
+                .iter()
+                .any(|e| e.kind == event_log::EventKind::NodeInterrupted
+                    && e.node_id.as_deref() == Some("worker")),
             "a failed tmux spawn on a Running iteration must append NodeInterrupted"
         );
         assert!(
@@ -29174,9 +29183,10 @@ edges: []
         // The run parks AwaitingUser loud (ADR-0049)...
         let events = load_events(&state.db, run_id).await.unwrap();
         assert!(
-            events.iter().any(|e| e.kind
-                == event_log::EventKind::NodeInterrupted
-                && e.node_id.as_deref() == Some("worker")),
+            events
+                .iter()
+                .any(|e| e.kind == event_log::EventKind::NodeInterrupted
+                    && e.node_id.as_deref() == Some("worker")),
             "a failed tmux spawn on a Running iteration must append NodeInterrupted"
         );
         assert!(
@@ -29854,9 +29864,11 @@ edges:
         // re-spawned at iter 2. The terminal `RunFailed` label is preserved.
         let after = load_events(&state.db, run_id).await.unwrap();
         assert!(
-            after.iter().any(|e| e.kind == event_log::EventKind::CommandIssued
-                && e.payload.as_ref().and_then(|p| p.get("command"))
-                    == Some(&serde_json::json!("reopen_run"))),
+            after
+                .iter()
+                .any(|e| e.kind == event_log::EventKind::CommandIssued
+                    && e.payload.as_ref().and_then(|p| p.get("command"))
+                        == Some(&serde_json::json!("reopen_run"))),
             "the retry must embed a reopen_run CommandIssued"
         );
         assert!(

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod admission;
 mod audit_log;
+mod auto_fail;
 mod blackboard;
 mod boot_recovery;
 pub(crate) mod completion_refusal;
@@ -496,6 +497,13 @@ struct CreateRunRequest {
     /// default — see [`prompt_augmenter::default_auto_name_with`].
     #[serde(default)]
     auto_name: Option<bool>,
+    /// The Run's `auto_fail` preference (ADR-0049) — the `run` tier of `node →
+    /// Run → Projet → instance`. `Option<bool>`: `None` (omitted) means the Run
+    /// states no preference, so a node `pdo fail` resolves through the project /
+    /// instance tiers. Frozen into `RunStarted` at the create chokepoint (same
+    /// immutability as `harness`). A Trigger fire folds its stored value in here.
+    #[serde(default)]
+    auto_fail: Option<bool>,
 }
 
 /// One repo line of a multi-repo create request (#465, ADR-0042/0047).
@@ -607,6 +615,11 @@ struct PatchProjectRequest {
     name: Option<String>,
     #[serde(default, deserialize_with = "deserialize_double_option")]
     harness: Option<Option<String>>,
+    /// The Projet's `auto_fail` (ADR-0049) — same double-`Option` shape as
+    /// `harness`: **absent** leaves it untouched, `null` clears it (states no
+    /// preference), a bool sets it.
+    #[serde(default, deserialize_with = "deserialize_double_option")]
+    auto_fail: Option<Option<bool>>,
 }
 
 /// Body of `POST` / `DELETE /projects/{id}/members` — one member path, compared
@@ -4360,6 +4373,14 @@ async fn patch_project(
             return project_list_error();
         }
     }
+    // Same double-`Option` semantics as `harness` (ADR-0049): `Some(None)` clears
+    // the preference, `Some(Some(b))` sets it.
+    if let Some(auto_fail) = req.auto_fail {
+        if let Err(e) = project_store::set_auto_fail(&state.db, &project_id, auto_fail).await {
+            error!("failed to set auto_fail on project {project_id}: {e}");
+            return project_list_error();
+        }
+    }
     match project_store::get(&state.db, &project_id).await {
         Ok(Some(p)) => {
             let _ = state.pipeline_tx.send(serde_json::json!({
@@ -4584,6 +4605,7 @@ pub(crate) async fn append_event_with(
             | event_log::EventKind::NodeAutoCompleted
             | event_log::EventKind::NodeStale
             | event_log::EventKind::NodeFailed
+            | event_log::EventKind::NodeInterrupted
     ) {
         let events = load_events(db, &event.run_id).await?;
         let run_state = event_log::project(&events);
@@ -5352,6 +5374,11 @@ async fn fire_one_trigger(
                 // fire with `auto_name=false` keeps a stable per-id name and the manager
                 // is never told to rename — covers cron AND manual fire in one line.
                 auto_name: Some(trigger.auto_name),
+                // ADR-0049: there is no separate Trigger tier for `auto_fail`
+                // (node → Run → Projet → instance). A trigger fire states no
+                // run-level preference, so a node `pdo fail` resolves through the
+                // project / instance tiers.
+                auto_fail: None,
             };
             let record = match create_run_inner(state, req, Vec::new()).await {
                 Ok(run_id) => trigger_store::FireRecord {
@@ -6548,7 +6575,9 @@ pub(crate) async fn handle_node_completion(
         .await
         {
             // INV-4: a terminal action unwinds the WHOLE driver, not just this loop.
-            ActionOutcome::Completed | ActionOutcome::Halted { .. } => return,
+            ActionOutcome::Completed
+            | ActionOutcome::Halted { .. }
+            | ActionOutcome::Interrupted { .. } => return,
             // Fire-and-forget: the spawn outcome is dropped. `SpawnSkipped` is
             // unreachable under `InternalOnly` (`admit_spawn` always admits).
             ActionOutcome::Spawned { .. }
@@ -6604,7 +6633,9 @@ pub(crate) async fn handle_node_completion(
             )
             .await
             {
-                ActionOutcome::Completed | ActionOutcome::Halted { .. } => return,
+                ActionOutcome::Completed
+            | ActionOutcome::Halted { .. }
+            | ActionOutcome::Interrupted { .. } => return,
                 ActionOutcome::Spawned { .. }
                 | ActionOutcome::Progressed
                 | ActionOutcome::SpawnSkipped { .. } => {}
@@ -6634,7 +6665,9 @@ pub(crate) async fn handle_node_completion(
             )
             .await
             {
-                ActionOutcome::Completed | ActionOutcome::Halted { .. } => return,
+                ActionOutcome::Completed
+            | ActionOutcome::Halted { .. }
+            | ActionOutcome::Interrupted { .. } => return,
                 ActionOutcome::Spawned { .. }
                 | ActionOutcome::Progressed
                 | ActionOutcome::SpawnSkipped { .. } => {}
@@ -6853,12 +6886,15 @@ fn max_event_age_secs(events: &[event_log::Event]) -> Option<i64> {
 /// Reconcile a run that is silently stalled at the **run level** (#214): no
 /// live node, nothing the scheduler can spawn, yet still `Running`. Loads the
 /// pipeline and the real scheduler outputs, runs [`run_stall_reason`], and on a
-/// stall appends a `RunFailed` with the run-level cause. A no-op for runs that
-/// can still make progress (or are already terminal).
+/// stall appends a `RunInterrupted` with the run-level cause — parking the run
+/// `AwaitingUser`, **never `RunFailed`** (ADR-0049: the runtime never declares
+/// forfeit of its own initiative). A no-op for runs that can still make progress
+/// (or are already terminal).
 ///
 /// Called from the periodic stale sweep and from boot recovery — the two paths
 /// where a run can be observed wedged after a node turned terminal with no
-/// downstream to drive (a Failed/Stale entry, a crash before downstream spawn).
+/// downstream to drive (an Interrupted/Failed/Stale entry, a crash before
+/// downstream spawn).
 async fn reconcile_run_level_stall(state: &AppState, run_id: &str) {
     let Some((events, run_state)) = reload_run_state(state, run_id).await else {
         return;
@@ -6892,21 +6928,22 @@ async fn reconcile_run_level_stall(state: &AppState, run_id: &str) {
         return;
     };
 
-    let run_failed = event_log::Event {
+    let run_interrupted = event_log::Event {
         id: None,
         run_id: run_id.to_string(),
         ts: event_log::now_iso(),
-        kind: event_log::EventKind::RunFailed,
+        kind: event_log::EventKind::RunInterrupted,
         node_id: None,
         iter: None,
         payload: Some(serde_json::json!({ "reason": reason })),
     };
-    // Through the guard: if the run turned terminal organically since the
-    // snapshot above, the failure is dropped as a no-op.
-    if let Err(e) = append_event(state, &run_failed).await {
-        error!("reconcile_run_level_stall: failed to fail run {run_id}: {e}");
+    // `RunInterrupted` is inert on an already-terminal run (its reducer gates on
+    // `is_live`), so a run that finished organically since the snapshot above is
+    // left untouched.
+    if let Err(e) = append_event(state, &run_interrupted).await {
+        error!("reconcile_run_level_stall: failed to park run {run_id}: {e}");
     } else {
-        warn!("Run {run_id} reconciled to Failed — {reason}");
+        warn!("Run {run_id} reconciled to AwaitingUser (interrupted) — {reason}");
         // Freed slots: re-drive throttled `waiting` nodes in other runs (#159).
         retry_waiting_nodes(state).await;
     }
@@ -7255,6 +7292,10 @@ async fn parse_multipart_create_run(
     // that path too. `None` when the field is absent — the chokepoint then resolves
     // back-compat by the presence of `name`.
     let mut auto_name: Option<bool> = None;
+    // ADR-0049: an explicit `auto_fail` may ride the multipart create. `None`
+    // when absent — the chokepoint freezes nothing and the Run defers to the
+    // project / instance tiers.
+    let mut auto_fail: Option<bool> = None;
     let mut images = Vec::new();
 
     while let Ok(Some(field)) = multipart.next_field().await {
@@ -7371,6 +7412,16 @@ async fn parse_multipart_create_run(
                     auto_name = stale_detector::parse_bool_setting(&v);
                 }
             }
+            "auto_fail" => {
+                // ADR-0049: an explicit `auto_fail` flag off the multipart form.
+                let v = field
+                    .text()
+                    .await
+                    .map_err(|e| format!("bad field auto_fail: {e}"))?;
+                if !v.is_empty() {
+                    auto_fail = stale_detector::parse_bool_setting(&v);
+                }
+            }
             "images" => {
                 let raw_filename = field.file_name().unwrap_or("image.png").to_string();
                 let data = field
@@ -7409,6 +7460,8 @@ async fn parse_multipart_create_run(
         harness,
         // #338: the explicit auto-naming choice threaded off the multipart form.
         auto_name,
+        // ADR-0049: the explicit auto_fail choice threaded off the multipart form.
+        auto_fail,
     };
     Ok((req, images))
 }
@@ -7904,6 +7957,13 @@ async fn create_run_inner(
         .filter(|s| !s.is_empty())
     {
         run_payload["harness"] = serde_json::json!(h);
+    }
+    // ADR-0049: FREEZE the Run's `auto_fail` choice into `RunStarted`, same
+    // immutability posture as `harness`. Written ONLY when the Run states a
+    // preference, so a Run that states none keeps its payload byte-identical
+    // (absent key → `None` → resolve through the project / instance tiers).
+    if let Some(af) = req.auto_fail {
+        run_payload["auto_fail"] = serde_json::json!(af);
     }
     // Auto-naming autonomy decision (#338, ADR-0015). Resolved ONCE here, at the
     // same chokepoint as the sandbox default, and read FRESH from the DB so a
@@ -8693,6 +8753,27 @@ async fn build_settings_view(state: &AppState) -> Result<serde_json::Value, sqlx
         "default"
     };
 
+    // --- auto_fail default (bool ; built-in default `false`) (ADR-0049) ---
+    // Same discipline as `autocomplete_turn_end`: `effective` comes from the SAME
+    // resolver `resolve_run_auto_fail` consumes for the instance tier, so the
+    // disclosed default cannot drift from what a node `pdo fail` actually gets.
+    let af_stored = cfg.auto_fail.map(|v| v != 0);
+    let af_env = std::env::var(instance_config::AUTO_FAIL_ENV).ok().map(|s| {
+        let t = s.trim();
+        t.eq_ignore_ascii_case("1")
+            || t.eq_ignore_ascii_case("true")
+            || t.eq_ignore_ascii_case("yes")
+            || t.eq_ignore_ascii_case("on")
+    });
+    let af_effective = instance_config::resolve_instance_auto_fail(cfg.auto_fail);
+    let af_source = if af_stored.is_some() {
+        "stored"
+    } else if af_env.is_some() {
+        "env"
+    } else {
+        "default"
+    };
+
     // --- advisory Docker availability probe (#410) ---
     // Folded into `GET /settings` (NOT a settings_field: no stored/env/default tier)
     // so the modal learns the default AND whether Docker can run a sandbox in ONE
@@ -8873,6 +8954,9 @@ async fn build_settings_view(state: &AppState) -> Result<serde_json::Value, sqlx
             dan_env,
             prompt_augmenter::DEFAULT_AUTO_NAME_DEFAULT,
         ),
+        // ADR-0049: the global tier of `auto_fail`. Default `false` — an agent
+        // `pdo fail` parks the run for a human to confirm.
+        "auto_fail": settings_field_bool(af_effective, af_source, af_stored, af_env, false),
         "updated_at": cfg.updated_at,
     }))
 }
@@ -11773,18 +11857,19 @@ async fn spawn_merge_resolver(
             })),
         };
         let _ = append_event(state, &fail_event).await;
-        let run_failed = event_log::Event {
+        // ADR-0049: park `AwaitingUser`, never `RunFailed`.
+        let run_interrupted = event_log::Event {
             id: None,
             run_id: run_id.to_string(),
             ts: event_log::now_iso(),
-            kind: event_log::EventKind::RunFailed,
+            kind: event_log::EventKind::RunInterrupted,
             node_id: None,
             iter: None,
             payload: Some(serde_json::json!({
                 "reason": "merge resolver spawn failed"
             })),
         };
-        let _ = append_event(state, &run_failed).await;
+        let _ = append_event(state, &run_interrupted).await;
 
         return completion_refusal::CompletionRefusal::MergeResolverFailed {
             reason: format!("failed to spawn resolver session: {e}"),
@@ -11824,18 +11909,19 @@ async fn handle_merge_resolver_done(
         };
         let _ = append_event(state, &fail_event).await;
 
-        let run_failed = event_log::Event {
+        // ADR-0049: park `AwaitingUser`, never `RunFailed`.
+        let run_interrupted = event_log::Event {
             id: None,
             run_id: run_id.to_string(),
             ts: event_log::now_iso(),
-            kind: event_log::EventKind::RunFailed,
+            kind: event_log::EventKind::RunInterrupted,
             node_id: None,
             iter: None,
             payload: Some(serde_json::json!({
                 "reason": format!("merge resolution failed: {reason}")
             })),
         };
-        let _ = append_event(state, &run_failed).await;
+        let _ = append_event(state, &run_interrupted).await;
 
         warn!("Merge resolver failed for run {run_id}: {reason}");
         // #490 / ADR-0035: `409` with the slug, not the historical `200`. The
@@ -12400,31 +12486,24 @@ async fn complete_node_iteration(
                     };
                     let _ = append_event(state, &conflict_event).await;
 
-                    // #503 AC5: the node is dead — its agent's `pdo complete` just
-                    // failed terminally and the run is about to be `failed`. Without
-                    // this the node stayed projected `running` for ever, with a live
-                    // tmux session and a UI offering Stop/Retry on it.
-                    let node_failed = event_log::Event {
+                    // #503 AC5 / ADR-0049: the node's `pdo complete` just failed on
+                    // a merge conflict — a runtime give-up, NOT a business failure.
+                    // Mark the node `Interrupted` (not `Failed`): the run parks
+                    // `AwaitingUser` with the reason (derived in `finalize`), never
+                    // `RunFailed`. This still closes the window where the node stayed
+                    // projected `running` for ever with a live session and a UI
+                    // offering Stop/Retry; the worktree with the conflicting work is
+                    // preserved for the human to resolve and reopen.
+                    let node_interrupted = event_log::Event {
                         id: None,
                         run_id: run_id.clone(),
                         ts: event_log::now_iso(),
-                        kind: event_log::EventKind::NodeFailed,
+                        kind: event_log::EventKind::NodeInterrupted,
                         node_id: Some(node_id.clone()),
                         iter: Some(iter),
                         payload: Some(serde_json::json!({ "reason": reason })),
                     };
-                    let _ = append_event(state, &node_failed).await;
-
-                    let run_failed = event_log::Event {
-                        id: None,
-                        run_id: run_id.clone(),
-                        ts: event_log::now_iso(),
-                        kind: event_log::EventKind::RunFailed,
-                        node_id: None,
-                        iter: None,
-                        payload: Some(serde_json::json!({ "reason": reason })),
-                    };
-                    let _ = append_event(state, &run_failed).await;
+                    let _ = append_event(state, &node_interrupted).await;
 
                     warn!("Merge conflict for node {node_id} in run {run_id}: {reason}");
                     reap_dead_node_after_run_failure(
@@ -12477,35 +12556,29 @@ async fn complete_node_iteration(
         // clean tree and passes) is documented in ADR-0017.
         Some("doc-only") | Some("script") => match worktree_has_tracked_changes(&worktree_dir) {
             Ok(true) => {
-                let fail_event = event_log::Event {
+                // ADR-0049: a completion refusal is a runtime give-up, not a
+                // deliberate failure — `Interrupted`, never `Failed`. The run
+                // parks `AwaitingUser` (derived in `finalize`) so the human can
+                // fix the tracked-file violation and reopen.
+                let interrupt_event = event_log::Event {
                     id: None,
                     run_id: run_id.clone(),
                     ts: event_log::now_iso(),
-                    kind: event_log::EventKind::NodeFailed,
+                    kind: event_log::EventKind::NodeInterrupted,
                     node_id: Some(node_id.clone()),
                     iter: Some(iter),
                     payload: Some(serde_json::json!({
-                        "reason": "doc_violated_code_immutability"
+                        "reason": format!(
+                            "doc-only node {node_id} violated code immutability \
+                             (modified tracked files)"
+                        )
                     })),
                 };
-                let _ = append_event(state, &fail_event).await;
-
-                let run_failed = event_log::Event {
-                    id: None,
-                    run_id: run_id.clone(),
-                    ts: event_log::now_iso(),
-                    kind: event_log::EventKind::RunFailed,
-                    node_id: None,
-                    iter: None,
-                    payload: Some(serde_json::json!({
-                        "reason": format!("doc-only node {node_id} violated code immutability")
-                    })),
-                };
-                let _ = append_event(state, &run_failed).await;
+                let _ = append_event(state, &interrupt_event).await;
 
                 warn!("Doc-only node {node_id} modified tracked files in run {run_id}");
-                // Same leak as the merge-conflict path (#503 AC5): this refusal kills
-                // the Run, so the node's session has nothing left to do.
+                // Same leak as the merge-conflict path (#503 AC5): this refusal
+                // parks the Run, so the node's session has nothing left to do.
                 reap_dead_node_after_run_failure(
                     state,
                     &repo_root,
@@ -12621,12 +12694,125 @@ async fn complete_node_iteration(
     CompletionAttempt::Completed
 }
 
+/// Resolve a node's effective `auto_fail` (ADR-0049) — gather all four tiers and
+/// hand them to the pure [`auto_fail::resolve_auto_fail`].
+///
+/// - **node**: the node's `auto_fail:` in the run's (live-snapshot) pipeline;
+/// - **run**: the frozen `RunState::auto_fail`;
+/// - **project**: the Projet owning the run's primary repo (verbatim path);
+/// - **instance**: `stored → env → false`.
+///
+/// Best-effort per tier: a tier that cannot be read (pipeline unparsable, DB
+/// error) is treated as "states no preference" (`None`) / the floor, so the
+/// resolution never fails the request — it only decides whether an agent
+/// `pdo fail` terminalises or parks.
+async fn resolve_run_auto_fail(
+    state: &AppState,
+    run_state: &event_log::RunState,
+    node_id: &str,
+) -> bool {
+    let repo_root = effective_repo_root(state, run_state);
+
+    // node tier: parse the run-scoped pipeline and read this node's `auto_fail`.
+    let node = {
+        let pipeline_path =
+            resolve_run_pipeline_path(&repo_root, &run_state.run_id, &run_state.pipeline_name);
+        std::fs::read_to_string(&pipeline_path)
+            .ok()
+            .and_then(|yaml| pipeline::parse_pipeline(&yaml).ok())
+            .and_then(|parsed| {
+                parsed
+                    .pipeline
+                    .nodes
+                    .iter()
+                    .find(|n| n.id == node_id)
+                    .and_then(|n| n.auto_fail)
+            })
+    };
+
+    // project tier: the Projet owning the run's primary repo (compared verbatim,
+    // like the harness tier). Falls back to the daemon repo root when the run
+    // carries no explicit target (ADR-0033 read-side resolution).
+    let primary_repo = run_state
+        .target_repo
+        .clone()
+        .unwrap_or_else(|| state.repo_root.to_string_lossy().to_string());
+    let project = project_store::auto_fail_for_path(&state.db, &primary_repo)
+        .await
+        .unwrap_or(None);
+
+    // instance tier: stored → env → false.
+    let instance = instance_config::get(&state.db)
+        .await
+        .map(|c| instance_config::resolve_instance_auto_fail(c.auto_fail))
+        .unwrap_or(false);
+
+    auto_fail::resolve_auto_fail(&auto_fail::AutoFailTiers {
+        node,
+        run: run_state.auto_fail,
+        project,
+        instance,
+    })
+}
+
+/// Embed a re-open in a **targeted** human command (AC7 / ADR-0049): retry /
+/// restart / start / complete / inject on a terminal (or incident-parked) Run
+/// re-open it **atomically** — one round-trip, no "resume then act" race, no
+/// re-fail window. This is the human's own gesture re-opening the Run (ADR-0009
+/// amended: a node button never reopens *of the runtime's initiative*, but the
+/// human's targeted command may embed the reopen).
+///
+/// If the Run needs re-opening (terminal & non-archived, or `AwaitingUser` on an
+/// incident), it appends the same `reopen_run` `CommandIssued` the global reopen
+/// uses — lifting the Run to `Running`, freezing satisfied `(node, iter)` and
+/// dropping interrupted nodes so they re-drive (anti-#221) — then returns the
+/// **re-projected** state so the caller's own guard runs against a live Run.
+/// Otherwise (already live, or `Archived`) it returns the state unchanged and the
+/// caller's guard decides. Returns `Err` only on a DB failure.
+pub(crate) async fn embed_reopen_for_targeted_command(
+    state: &AppState,
+    run_id: &str,
+    run_state: event_log::RunState,
+) -> Result<event_log::RunState> {
+    let needs_reopen = (run_state.status.is_terminal()
+        && run_state.status != event_log::RunStatus::Archived)
+        || (run_state.status == event_log::RunStatus::AwaitingUser
+            && run_state.awaiting_reason.is_some());
+    if !needs_reopen {
+        return Ok(run_state);
+    }
+    let cmd_event = event_log::Event {
+        id: None,
+        run_id: run_id.to_string(),
+        ts: event_log::now_iso(),
+        kind: event_log::EventKind::CommandIssued,
+        node_id: None,
+        iter: None,
+        payload: Some(serde_json::json!({ "command": "reopen_run" })),
+    };
+    append_event(state, &cmd_event).await?;
+    let events = load_events(&state.db, run_id).await?;
+    Ok(event_log::project(&events).unwrap_or(run_state))
+}
+
 async fn node_fail(
     State(state): State<Arc<AppState>>,
     AxumPath((run_id, node_id)): AxumPath<(String, String)>,
     Json(req): Json<NodeFailRequest>,
 ) -> Response {
     let iter = req.iter.unwrap_or(1);
+
+    // ADR-0049 / AC5: resolve `auto_fail` (node → Run → Projet → instance)
+    // BEFORE the terminal append, so the tail knows whether this deliberate
+    // agent `pdo fail` terminalises the run (`RunFailed`) or parks it
+    // `AwaitingUser` (`RunInterrupted`) for a human to confirm. The NodeFailed
+    // itself is unconditional — the agent's own iteration genuinely failed.
+    let auto_fail_run = match reload_run_state(&state, &run_id).await {
+        Some((_, rs)) => resolve_run_auto_fail(&state, &rs, &node_id).await,
+        // No projected state (run not found / forgotten): default to the safe
+        // park behaviour; the terminal append below is a no-op anyway.
+        None => false,
+    };
 
     let event = event_log::Event {
         id: None,
@@ -12670,25 +12856,45 @@ async fn node_fail(
             tail_sandbox,
         );
 
-        // Mark the run as failed
-        let run_failed = event_log::Event {
-            id: None,
-            run_id: tail_run.clone(),
-            ts: event_log::now_iso(),
-            kind: event_log::EventKind::RunFailed,
-            node_id: None,
-            iter: None,
-            payload: Some(serde_json::json!({ "reason": reason })),
+        // ADR-0049 / AC5: an agent `pdo fail` terminalises the run to `Failed`
+        // ONLY when `auto_fail` is opted in (node → Run → Projet → instance).
+        // Otherwise it parks the run `AwaitingUser` (`RunInterrupted`), the
+        // human confirms the failure. Only the agent `pdo fail` honours this
+        // opt-in — every runtime give-up parks regardless.
+        let run_event = if auto_fail_run {
+            event_log::Event {
+                id: None,
+                run_id: tail_run.clone(),
+                ts: event_log::now_iso(),
+                kind: event_log::EventKind::RunFailed,
+                node_id: None,
+                iter: None,
+                payload: Some(serde_json::json!({ "reason": reason })),
+            }
+        } else {
+            event_log::Event {
+                id: None,
+                run_id: tail_run.clone(),
+                ts: event_log::now_iso(),
+                kind: event_log::EventKind::RunInterrupted,
+                node_id: None,
+                iter: None,
+                payload: Some(serde_json::json!({
+                    "reason": format!("agent pdo fail (awaiting confirmation): {reason}")
+                })),
+            }
         };
-        if let Err(e) = append_event(&tail_state, &run_failed).await {
-            error!("failed to append run_failed: {e}");
+        if let Err(e) = append_event(&tail_state, &run_event).await {
+            error!("failed to append run terminal/park event: {e}");
         }
 
-        // The run failed: its other NodeRun sessions will be reaped, freeing slots.
-        // Re-drive throttled `waiting` nodes in other runs (#159).
+        // Whether failed or parked, the node's session was reaped, freeing a
+        // slot. Re-drive throttled `waiting` nodes in other runs (#159).
         retry_waiting_nodes(&tail_state).await;
 
-        info!("Node {tail_node} failed in run {tail_run}");
+        info!(
+            "Node {tail_node} failed in run {tail_run} (auto_fail={auto_fail_run})"
+        );
     });
     (StatusCode::OK, "ok").into_response()
 }
@@ -12850,6 +13056,15 @@ async fn force_spawn_node(state: &Arc<AppState>, run_id: &str, node_id: &str) ->
             )
                 .into_response();
         }
+    };
+
+    // AC7 / ADR-0049: a Start on a terminal (or incident-parked) Run re-opens it
+    // atomically — the same human-gesture re-open the global `reopen_run` uses —
+    // so the button drives the Run instead of the pre-résilience "resume first"
+    // refusal. Runs before the guards below so they see a live Run.
+    let run_state = match embed_reopen_for_targeted_command(state, run_id, run_state).await {
+        Ok(s) => s,
+        Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, format!("error: {e}")).into_response(),
     };
 
     if let Some(ns) = run_state.nodes.get(node_id) {
@@ -13161,12 +13376,22 @@ async fn node_retry(
         }
     };
 
-    // Captured BEFORE any invalidation so the retry lands on `current + 1`, not on a
-    // reset-to-1 iteration (the #498 branch-collision trap): the self-invalidation
-    // below removes the node from the projection, so re-deriving the iter afterwards
+    // Captured BEFORE any invalidation OR re-open so the retry lands on
+    // `current + 1`, not on a reset-to-1 iteration (the #498 branch-collision
+    // trap): both the self-invalidation below and the re-open's interrupted-node
+    // drop remove the node from the projection, so re-deriving the iter afterwards
     // would read 1.
     let current_iter = run_state.nodes.get(&node_id).map(|ns| ns.iter).unwrap_or(1);
     let next_iter = current_iter + 1;
+
+    // ── AC7 / ADR-0049: embed the re-open. A retry on a terminal (or
+    //    incident-parked) Run re-opens it atomically here, BEFORE the liveness
+    //    probe below sees it — replacing the pre-résilience "resume the run first"
+    //    409. The human's retry IS the re-open gesture (ADR-0009 amended).
+    let run_state = match embed_reopen_for_targeted_command(&state, &run_id, run_state).await {
+        Ok(s) => s,
+        Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, format!("error: {e}")).into_response(),
+    };
 
     // ── HEAD PROBE 1 (#487): run-liveness. The FIRST gesture — a refusal here leaves
     //    ZERO side effects (nothing stopped, nothing invalidated). See the doc above
@@ -15387,34 +15612,25 @@ async fn check_output_validation_with_retry(
                 serde_json::json!({ "kind": "frontmatter_mismatch", "violations": details })
             }
         };
-        let fail_event = event_log::Event {
+        // ADR-0049 / AC11: a real output-validation miss is a runtime give-up,
+        // not a business failure — `Interrupted`, never `Failed`. The run parks
+        // `AwaitingUser` with the diagnostic (derived in `finalize`), so a human
+        // can supply the missing output and reopen.
+        let interrupt_event = event_log::Event {
             id: None,
             run_id: run_id.to_string(),
             ts: event_log::now_iso(),
-            kind: event_log::EventKind::NodeFailed,
+            kind: event_log::EventKind::NodeInterrupted,
             node_id: Some(node_id.to_string()),
             iter: Some(iter),
             payload: Some(serde_json::json!({
-                "reason": "script output validation failed",
+                "reason": format!("script node {node_id} failed output validation at iter {iter}"),
                 "detail": detail,
             })),
         };
-        let _ = append_event(state, &fail_event).await;
+        let _ = append_event(state, &interrupt_event).await;
 
-        let run_failed = event_log::Event {
-            id: None,
-            run_id: run_id.to_string(),
-            ts: event_log::now_iso(),
-            kind: event_log::EventKind::RunFailed,
-            node_id: None,
-            iter: None,
-            payload: Some(serde_json::json!({
-                "reason": format!("script node {node_id} failed output validation")
-            })),
-        };
-        let _ = append_event(state, &run_failed).await;
-
-        warn!("script node {node_id} failed output validation in run {run_id} — fail-fast");
+        warn!("script node {node_id} failed output validation in run {run_id} — interrupted");
         return Some(completion_refusal::CompletionRefusal::ScriptValidationFailed { detail });
     }
 
@@ -15441,32 +15657,24 @@ async fn check_output_validation_with_retry(
                 .collect();
 
             if retries >= 1 {
-                let fail_event = event_log::Event {
+                // ADR-0049: the corrective loop is exhausted, but a validation
+                // miss is a runtime give-up — `Interrupted`, never `Failed`. The
+                // run parks `AwaitingUser` (derived in `finalize`).
+                let interrupt_event = event_log::Event {
                     id: None,
                     run_id: run_id.to_string(),
                     ts: event_log::now_iso(),
-                    kind: event_log::EventKind::NodeFailed,
+                    kind: event_log::EventKind::NodeInterrupted,
                     node_id: Some(node_id.to_string()),
                     iter: Some(iter),
                     payload: Some(serde_json::json!({
-                        "reason": "output validation failed",
+                        "reason": format!(
+                            "node {node_id} failed output validation after retry at iter {iter}"
+                        ),
                         "violations": violation_details,
                     })),
                 };
-                let _ = append_event(state, &fail_event).await;
-
-                let run_failed = event_log::Event {
-                    id: None,
-                    run_id: run_id.to_string(),
-                    ts: event_log::now_iso(),
-                    kind: event_log::EventKind::RunFailed,
-                    node_id: None,
-                    iter: None,
-                    payload: Some(serde_json::json!({
-                        "reason": format!("node {node_id} failed output validation after retry")
-                    })),
-                };
-                let _ = append_event(state, &run_failed).await;
+                let _ = append_event(state, &interrupt_event).await;
 
                 warn!("Node {node_id} failed output validation after retry in run {run_id}");
                 Some(
@@ -17169,7 +17377,62 @@ mod tests {
 
         assert_eq!(resp.status(), StatusCode::OK);
 
-        // The RunFailed append lives in the detached tail (#304) — poll.
+        // ADR-0049 / AC5: with `auto_fail` unset (the default), an agent `pdo fail`
+        // parks the run `AwaitingUser` for a human to confirm — NOT `Failed`. The
+        // node itself is `Failed` (the agent deliberately failed its iteration).
+        // The run-level park append lives in the detached tail (#304) — poll.
+        let run_state = wait_run_status(&state, run_id, event_log::RunStatus::AwaitingUser).await;
+        assert_eq!(
+            run_state.nodes["worker"].status,
+            event_log::NodeStatus::Failed
+        );
+        assert!(
+            run_state.awaiting_reason.is_some(),
+            "the park carries the fail reason as the awaiting reason"
+        );
+    }
+
+    #[tokio::test]
+    async fn node_fail_with_run_auto_fail_terminalises_directly() {
+        // AC5: with `auto_fail` opted in at the Run tier, an agent `pdo fail`
+        // terminalises the run to `Failed` directly (no human confirmation).
+        let state = test_state().await;
+        let run_id = "test-autofail-run";
+        let run_started = event_log::Event {
+            id: None,
+            run_id: run_id.into(),
+            ts: event_log::now_iso(),
+            kind: event_log::EventKind::RunStarted,
+            node_id: None,
+            iter: None,
+            payload: Some(serde_json::json!({ "pipeline_name": "test", "auto_fail": true })),
+        };
+        append_event(&state, &run_started).await.unwrap();
+        let node_started = event_log::Event {
+            id: None,
+            run_id: run_id.into(),
+            ts: event_log::now_iso(),
+            kind: event_log::EventKind::NodeStarted,
+            node_id: Some("worker".into()),
+            iter: Some(1),
+            payload: None,
+        };
+        append_event(&state, &node_started).await.unwrap();
+
+        let app = build_router(state.clone());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/runs/{run_id}/nodes/worker/fail"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"reason": "something broke"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
         let run_state = wait_run_status(&state, run_id, event_log::RunStatus::Failed).await;
         assert_eq!(
             run_state.nodes["worker"].status,
@@ -19347,6 +19610,7 @@ mod tests {
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            auto_fail: None,
         }
     }
 
@@ -20003,15 +20267,16 @@ mod tests {
             "precondition: the run is idle past the grace window"
         );
 
-        // The periodic reconcile path must now fail the run loud.
+        // The periodic reconcile path must now park the run loud (ADR-0049:
+        // AwaitingUser, never RunFailed).
         reconcile_run_level_stall(&state, run_id).await;
 
         let events = load_events(&state.db, run_id).await.unwrap();
-        let run_failed = events
+        let run_interrupted = events
             .iter()
-            .find(|e| e.kind == event_log::EventKind::RunFailed)
-            .expect("reconcile must append a RunFailed for the wedged run (#279)");
-        let reason = run_failed
+            .find(|e| e.kind == event_log::EventKind::RunInterrupted)
+            .expect("reconcile must append a RunInterrupted for the wedged run (#279)");
+        let reason = run_interrupted
             .payload
             .as_ref()
             .and_then(|p| p.get("reason"))
@@ -20019,13 +20284,21 @@ mod tests {
             .unwrap_or_default();
         assert!(
             reason.contains("#279): b"),
-            "RunFailed cause {reason:?} must name the undriven node `b` and reference #279"
+            "the park cause {reason:?} must name the undriven node `b` and reference #279"
         );
+        assert!(
+            !events
+                .iter()
+                .any(|e| e.kind == event_log::EventKind::RunFailed),
+            "the runtime never fails a stalled run of its own initiative (ADR-0049)"
+        );
+        let projected = event_log::project(&events).unwrap();
         assert_eq!(
-            event_log::project(&events).unwrap().status,
-            event_log::RunStatus::Failed,
-            "the run must be terminal (Failed), not wedged Running"
+            projected.status,
+            event_log::RunStatus::AwaitingUser,
+            "the run must park AwaitingUser, not wedge Running and not fail"
         );
+        assert_eq!(projected.awaiting_reason.as_deref(), Some(reason));
     }
 
     #[tokio::test]
@@ -23750,9 +24023,11 @@ edges:
     }
 
     #[tokio::test]
-    async fn mark_node_done_accepts_failed_node_with_outputs_after_resume() {
-        // #212: a Failed run accepts no lifecycle event — the recovery flow is
-        // resume_run first, then mark_node_done on the (hand-fixed) failed iter.
+    async fn mark_node_done_on_failed_node_embeds_reopen_and_completes() {
+        // AC7 / ADR-0049 (amends #212): a human `mark_node_done` on a Failed Run
+        // (its failed iter hand-fixed with the required outputs) now EMBEDS the
+        // re-open — one atomic command completes the node instead of the
+        // pre-résilience "resume_run first, then mark" two-step.
         let tmp = tempfile::tempdir().unwrap();
         let pipe_name = "failed-rescue";
         write_pipeline_with_outputs(tmp.path(), pipe_name);
@@ -23774,53 +24049,8 @@ edges:
         std::fs::create_dir_all(&report_dir).unwrap();
         std::fs::write(report_dir.join("output.md"), "# Report\nAll good.").unwrap();
 
-        // While the run is Failed, mark_node_done is rejected with a readable
-        // cause (#197 family: no lifecycle event on a non-running run).
-        let resp = build_router(state.clone())
-            .oneshot(
-                Request::builder()
-                    .method("POST")
-                    .uri(format!("/runs/{run_id}/commands"))
-                    .header("content-type", "application/json")
-                    .body(Body::from(
-                        r#"{"kind": "mark_node_done", "node_id": "worker", "iter": 1}"#,
-                    ))
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-        assert_eq!(resp.status(), StatusCode::CONFLICT);
-        let body: serde_json::Value = serde_json::from_slice(
-            &axum::body::to_bytes(resp.into_body(), usize::MAX)
-                .await
-                .unwrap(),
-        )
-        .unwrap();
-        // #490 / ADR-0035 §3: `error` is the stable slug, the guard's prose moved
-        // to `message`. That split is the whole point — reading `error` as prose is
-        // what let the client mistake every 409 on this path for `missing_outputs`.
-        assert_eq!(body["error"], "completion_rejected");
-        assert_eq!(body["recoverable"], false);
-        assert!(
-            body["message"].as_str().unwrap().contains("resume"),
-            "rejection should point at resume_run, got {body}"
-        );
-
-        // resume_run lifts the failure...
-        let resp = build_router(state.clone())
-            .oneshot(
-                Request::builder()
-                    .method("POST")
-                    .uri(format!("/runs/{run_id}/commands"))
-                    .header("content-type", "application/json")
-                    .body(Body::from(r#"{"kind": "resume_run"}"#))
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-        assert_eq!(resp.status(), StatusCode::OK);
-
-        // ...then the failed iteration is markable.
+        // A SINGLE mark_node_done on the Failed run: it embeds the re-open and
+        // completes the (hand-fixed) failed iteration atomically.
         let resp = build_router(state.clone())
             .oneshot(
                 Request::builder()
@@ -23837,11 +24067,109 @@ edges:
         assert_eq!(resp.status(), StatusCode::OK);
 
         let events = load_events(&state.db, run_id).await.unwrap();
+        // The embedded re-open is in the log, and the previous terminal label is
+        // preserved (AC12).
+        assert!(
+            events.iter().any(|e| e.kind == event_log::EventKind::CommandIssued
+                && e.payload.as_ref().and_then(|p| p.get("command"))
+                    == Some(&serde_json::json!("reopen_run"))),
+            "the mark_node_done must embed a reopen_run CommandIssued"
+        );
+        assert!(
+            events
+                .iter()
+                .any(|e| e.kind == event_log::EventKind::RunFailed),
+            "the previous terminal label stays in the log (AC12)"
+        );
         let run_state = event_log::project(&events).unwrap();
         assert_eq!(
             run_state.nodes["worker"].status,
             event_log::NodeStatus::Completed
         );
+    }
+
+    #[tokio::test]
+    async fn reopen_run_lifts_a_terminal_run_and_preserves_the_label() {
+        // AC6/AC8/FP#8: the global reopen_run command lifts a terminal (Completed
+        // here) run back to Running, and the previous terminal label stays in the
+        // event log. Completed nodes are never re-spawned (anti-#221).
+        let tmp = tempfile::tempdir().unwrap();
+        write_test_pipeline(tmp.path(), "test-pipe");
+        let state = test_state_with_dir(tmp.path()).await;
+        let run_id = "reopen-completed";
+        seed_run_for_node_control(&state, run_id, "test-pipe").await;
+        seed_node_started(&state, run_id, "worker", 1).await;
+        append_event(
+            &state,
+            &seed_event(
+                run_id,
+                event_log::EventKind::NodeCompleted,
+                Some("worker"),
+                Some(1),
+                None,
+            ),
+        )
+        .await
+        .unwrap();
+        seed_run_terminal(&state, run_id, event_log::EventKind::RunCompleted).await;
+
+        let resp = build_router(state.clone())
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/runs/{run_id}/commands"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"kind": "reopen_run"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let events = load_events(&state.db, run_id).await.unwrap();
+        let state_after = event_log::project(&events).unwrap();
+        assert_eq!(state_after.status, event_log::RunStatus::Running);
+        // The terminal label is preserved (AC12).
+        assert!(events
+            .iter()
+            .any(|e| e.kind == event_log::EventKind::RunCompleted));
+        // The satisfied node stays Completed — never re-spawned (anti-#221).
+        assert_eq!(
+            state_after.nodes["worker"].status,
+            event_log::NodeStatus::Completed
+        );
+    }
+
+    #[tokio::test]
+    async fn reopen_run_refuses_a_live_run() {
+        // reopen_run is for terminal / incident-parked runs; a cleanly Running run
+        // needs no re-projection and is refused (not_reopenable).
+        let tmp = tempfile::tempdir().unwrap();
+        write_test_pipeline(tmp.path(), "test-pipe");
+        let state = test_state_with_dir(tmp.path()).await;
+        let run_id = "reopen-live";
+        seed_run_for_node_control(&state, run_id, "test-pipe").await;
+        seed_node_started(&state, run_id, "worker", 1).await;
+
+        let resp = build_router(state.clone())
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/runs/{run_id}/commands"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"kind": "reopen_run"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+        let body: serde_json::Value = serde_json::from_slice(
+            &axum::body::to_bytes(resp.into_body(), usize::MAX)
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(body["error"], "not_reopenable");
     }
 
     // --- Transition guard wiring (#212, closes #195 #196 #197 #198 #201) ---
@@ -23934,10 +24262,15 @@ edges:
 
         boot_recovery::run_boot_recovery(&state).await;
 
-        // After recovery: worker is reconciled to Failed with an explanatory
-        // reason, and no terminal run carries a session-holding node.
+        // After recovery: worker is reconciled to Interrupted (ADR-0049: a
+        // session lost to a daemon restart is an infra incident, not a failure)
+        // with an explanatory reason, and no terminal run carries a
+        // session-holding node.
         let after = event_log::project(&load_events(&state.db, run_id).await.unwrap()).unwrap();
-        assert_eq!(after.nodes["worker"].status, event_log::NodeStatus::Failed);
+        assert_eq!(
+            after.nodes["worker"].status,
+            event_log::NodeStatus::Interrupted
+        );
         let reason = after.nodes["worker"]
             .failure_reason
             .as_deref()
@@ -23958,16 +24291,19 @@ edges:
         );
 
         // Idempotency: a second pass (e.g. another reboot) appends no duplicate
-        // NodeFailed — validate_fail returns NoOp on the already-terminal iter.
+        // NodeInterrupted — validate_interrupt returns NoOp on the already-interrupted iter.
         boot_recovery::run_boot_recovery(&state).await;
         let events = load_events(&state.db, run_id).await.unwrap();
         assert_eq!(
-            count_events(&events, event_log::EventKind::NodeFailed, "worker"),
+            count_events(&events, event_log::EventKind::NodeInterrupted, "worker"),
             1,
-            "boot recovery must be idempotent: exactly one NodeFailed for worker"
+            "boot recovery must be idempotent: exactly one NodeInterrupted for worker"
         );
         let again = event_log::project(&events).unwrap();
-        assert_eq!(again.nodes["worker"].status, event_log::NodeStatus::Failed);
+        assert_eq!(
+            again.nodes["worker"].status,
+            event_log::NodeStatus::Interrupted
+        );
     }
 
     #[tokio::test]
@@ -28263,13 +28599,11 @@ edges: []
     }
 
     #[tokio::test]
-    async fn force_spawn_on_terminal_run_is_rejected_without_orphan_session() {
-        // D4 (#204) orphan-session regression: force-spawning on a terminal run
-        // must be rejected with 409 BEFORE the tmux session is spawned. Pre-fix
-        // the primitive spawned first and the handler returned 200 while the
-        // NodeStarted append was silently rejected — an orphan session + lying
-        // 200. We assert the 409 (only the pre-spawn guard produces it) and that
-        // no NodeStarted event ever landed.
+    async fn force_spawn_on_terminal_run_embeds_reopen() {
+        // AC7 / ADR-0049 (amends #204/#487): the UI Start button on a terminal Run
+        // now EMBEDS the re-open — the human's gesture re-opens the Run atomically
+        // and drives the node, instead of the pre-résilience 409. The re-open is
+        // the human's, never the runtime's (ADR-0009 amended).
         let tmp = tempfile::tempdir().unwrap();
         write_test_pipeline(tmp.path(), "test-pipe");
         let state = test_state_with_dir(tmp.path()).await;
@@ -28278,7 +28612,7 @@ edges: []
         seed_run_terminal(&state, run_id, event_log::EventKind::RunCompleted).await;
 
         let app = build_router(state.clone());
-        let resp = app
+        let _ = app
             .oneshot(
                 Request::builder()
                     .method("POST")
@@ -28288,14 +28622,28 @@ edges: []
             )
             .await
             .unwrap();
-        assert_eq!(resp.status(), StatusCode::CONFLICT);
 
+        // Regardless of whether the real tmux spawn succeeds in the test env, the
+        // re-open gesture is embedded and the Run is live again — the previous
+        // terminal `RunCompleted` label is preserved (AC12).
         let events = load_events(&state.db, run_id).await.unwrap();
         assert!(
-            !events
+            events.iter().any(|e| e.kind == event_log::EventKind::CommandIssued
+                && e.payload.as_ref().and_then(|p| p.get("command"))
+                    == Some(&serde_json::json!("reopen_run"))),
+            "the Start must embed a reopen_run CommandIssued on a terminal run"
+        );
+        assert!(
+            events
                 .iter()
-                .any(|e| e.kind == event_log::EventKind::NodeStarted),
-            "no NodeStarted may be appended when force-spawn is rejected on a terminal run"
+                .any(|e| e.kind == event_log::EventKind::RunCompleted),
+            "the previous terminal label stays in the log (AC12)"
+        );
+        let projected = event_log::project(&events).unwrap();
+        assert!(
+            projected.status.is_live(),
+            "the Run is live again after the embedded re-open, got {:?}",
+            projected.status
         );
     }
 
@@ -28381,6 +28729,7 @@ edges: []
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            auto_fail: None,
         };
         let pipeline = pipeline::PipelineDef {
             name: "spawn-unit".into(),
@@ -28519,11 +28868,20 @@ edges: []
         );
 
         let events = load_events(&state.db, run_id).await.unwrap();
+        // ADR-0049/0050: a spawn abort before start surfaces as a
+        // `NodeInterrupted` naming the node (never `RunFailed`), which parks the
+        // run `AwaitingUser` — visible and recoverable, never frozen `running`.
         assert!(
-            events
+            events.iter().any(|e| e.kind
+                == event_log::EventKind::NodeInterrupted
+                && e.node_id.as_deref() == Some("worker")),
+            "the spawn abort must surface as a NodeInterrupted naming the node"
+        );
+        assert!(
+            !events
                 .iter()
                 .any(|e| e.kind == event_log::EventKind::RunFailed),
-            "the spawn abort must surface as a RunFailed"
+            "the runtime never fails the run on a spawn abort (ADR-0049)"
         );
         assert!(
             !events
@@ -28536,8 +28894,12 @@ edges: []
             !events
                 .iter()
                 .any(|e| e.kind == event_log::EventKind::NodeFailed),
-            "the abort must NOT be a NodeFailed (it would no-op and wedge the run)"
+            "the abort must NOT be a NodeFailed (infra death is Interrupted, ADR-0049)"
         );
+        // The run projects `AwaitingUser` with the incident reason.
+        let rs = event_log::project(&events).unwrap();
+        assert_eq!(rs.status, event_log::RunStatus::AwaitingUser);
+        assert!(rs.awaiting_reason.is_some());
     }
 
     /// #508 hermetic seam: make `tmux_session_manager::spawn` fail at its very
@@ -28636,42 +28998,37 @@ edges: []
                     && e.node_id.as_deref() == Some("worker")),
             "the after-start path keeps its NodeStarted (the reservation was durable)"
         );
-        // ...and BOTH terminal events follow it.
+        // ...and the node is interrupted (ADR-0049: an infra spawn failure is
+        // `NodeInterrupted`, not `NodeFailed`), never a `RunFailed`.
         assert!(
-            events
-                .iter()
-                .any(|e| e.kind == event_log::EventKind::NodeFailed
-                    && e.node_id.as_deref() == Some("worker")),
-            "a failed tmux spawn on a Running iteration must append NodeFailed"
+            events.iter().any(|e| e.kind
+                == event_log::EventKind::NodeInterrupted
+                && e.node_id.as_deref() == Some("worker")),
+            "a failed tmux spawn on a Running iteration must append NodeInterrupted"
         );
         assert!(
-            events
+            !events
                 .iter()
                 .any(|e| e.kind == event_log::EventKind::RunFailed),
-            "a failed tmux spawn must move the run terminal with RunFailed"
+            "the runtime never fails the run on a tmux spawn failure (ADR-0049)"
         );
 
         let (_, run_state) = reload_run_state(&state, run_id).await.unwrap();
         assert_eq!(
             run_state.status,
-            event_log::RunStatus::Failed,
-            "RunFailed must project a terminal Failed run state"
+            event_log::RunStatus::AwaitingUser,
+            "an interrupted node parks the run AwaitingUser (ADR-0049)"
         );
 
-        for kind in [
-            event_log::EventKind::NodeFailed,
-            event_log::EventKind::RunFailed,
-        ] {
-            let reason = event_reason(&state, run_id, kind.clone()).await;
-            assert!(
-                reason.contains("failed to spawn tmux session"),
-                "{kind:?} cause must name the tmux spawn failure, got {reason:?}"
-            );
-            assert!(
-                !reason.contains("session_died"),
-                "{kind:?} cause must NOT be the false session_died, got {reason:?}"
-            );
-        }
+        let reason = event_reason(&state, run_id, event_log::EventKind::NodeInterrupted).await;
+        assert!(
+            reason.contains("failed to spawn tmux session"),
+            "the interrupt cause must name the tmux spawn failure, got {reason:?}"
+        );
+        assert!(
+            !reason.contains("session_died"),
+            "the interrupt cause must NOT be the false session_died, got {reason:?}"
+        );
     }
 
     /// #508 (fresh sub-worktree → reap): a code-mutating node whose fresh
@@ -28743,24 +29100,23 @@ edges: []
             "the after-start path keeps its NodeStarted"
         );
         assert!(
-            events
-                .iter()
-                .any(|e| e.kind == event_log::EventKind::NodeFailed
-                    && e.node_id.as_deref() == Some("worker")),
-            "a failed tmux spawn on a Running iteration must append NodeFailed"
+            events.iter().any(|e| e.kind
+                == event_log::EventKind::NodeInterrupted
+                && e.node_id.as_deref() == Some("worker")),
+            "a failed tmux spawn on a Running iteration must append NodeInterrupted"
         );
         assert!(
-            events
+            !events
                 .iter()
                 .any(|e| e.kind == event_log::EventKind::RunFailed),
-            "a failed tmux spawn must move the run terminal with RunFailed"
+            "the runtime never fails the run on a tmux spawn failure (ADR-0049)"
         );
         let (_, run_state) = reload_run_state(&state, run_id).await.unwrap();
-        assert_eq!(run_state.status, event_log::RunStatus::Failed);
-        let reason = event_reason(&state, run_id, event_log::EventKind::RunFailed).await;
+        assert_eq!(run_state.status, event_log::RunStatus::AwaitingUser);
+        let reason = event_reason(&state, run_id, event_log::EventKind::NodeInterrupted).await;
         assert!(
             reason.contains("failed to spawn tmux session") && !reason.contains("session_died"),
-            "RunFailed cause must be the true tmux spawn failure, got {reason:?}"
+            "interrupt cause must be the true tmux spawn failure, got {reason:?}"
         );
     }
 
@@ -28815,23 +29171,22 @@ edges: []
             "a failed tmux spawn must return Failed, got {outcome:?}"
         );
 
-        // The run is still failed loud...
+        // The run parks AwaitingUser loud (ADR-0049)...
         let events = load_events(&state.db, run_id).await.unwrap();
         assert!(
-            events
-                .iter()
-                .any(|e| e.kind == event_log::EventKind::NodeFailed
-                    && e.node_id.as_deref() == Some("worker")),
-            "a failed tmux spawn on a Running iteration must append NodeFailed"
+            events.iter().any(|e| e.kind
+                == event_log::EventKind::NodeInterrupted
+                && e.node_id.as_deref() == Some("worker")),
+            "a failed tmux spawn on a Running iteration must append NodeInterrupted"
         );
         assert!(
-            events
+            !events
                 .iter()
                 .any(|e| e.kind == event_log::EventKind::RunFailed),
-            "a failed tmux spawn must move the run terminal with RunFailed"
+            "the runtime never fails the run on a tmux spawn failure (ADR-0049)"
         );
         let (_, run_state) = reload_run_state(&state, run_id).await.unwrap();
-        assert_eq!(run_state.status, event_log::RunStatus::Failed);
+        assert_eq!(run_state.status, event_log::RunStatus::AwaitingUser);
 
         // ...but the REUSED sub-worktree and its branch are UNTOUCHED (the whole
         // point of the gate: a reuse loses nothing).
@@ -29453,11 +29808,13 @@ edges:
     }
 
     #[tokio::test]
-    async fn node_retry_on_terminal_run_refuses_with_zero_side_effects() {
-        // #487 — the production incident (#496). Play on a node of a
-        // Failed Run must refuse 409 "resume the run first" as the FIRST gesture:
-        // no NodeInvalidated (the frozen-`pending` trap), no new NodeStarted, no
-        // session — the criterion is *absence of side effect*, not just the status.
+    async fn node_retry_on_terminal_run_embeds_reopen() {
+        // AC7 / ADR-0049 (amends #487): Play/Retry on a node of a terminal (here
+        // `Failed`) Run now EMBEDS the re-open — the human's own gesture re-opens
+        // the Run atomically and re-drives the node, instead of the pre-résilience
+        // 409 "resume the run first". A node button still never re-opens of the
+        // runtime's own initiative (ADR-0009 amended); the human's retry is the
+        // re-open.
         let tmp = tempfile::tempdir().unwrap();
         let repo_root = tmp.path();
         write_retry_pipeline(repo_root);
@@ -29474,8 +29831,6 @@ edges:
         seed_node_started(&state, run_id, "worker", 1).await;
         seed_run_terminal(&state, run_id, event_log::EventKind::RunFailed).await;
 
-        let before = load_events(&state.db, run_id).await.unwrap();
-
         let app = build_router(state.clone());
         let resp = app
             .oneshot(
@@ -29488,41 +29843,39 @@ edges:
             .await
             .unwrap();
 
-        // Not a 2xx — and specifically the ADR-0035 refusal shape.
-        assert_eq!(resp.status(), StatusCode::CONFLICT);
-        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
-            .await
-            .unwrap();
-        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
-        assert_eq!(json["error"], "retry_refused");
-        assert_eq!(json["recoverable"], true);
-        assert_eq!(json["session_killed"], false);
+        // A 2xx — the retry was accepted, not refused.
         assert!(
-            json["message"]
-                .as_str()
-                .unwrap()
-                .contains("resume the run first"),
-            "the guard prose must land in `message`: {json}"
+            resp.status().is_success(),
+            "retry must embed the re-open and succeed, got {}",
+            resp.status()
         );
 
-        // Zero side effects: NOTHING was appended by the refused retry.
+        // The re-open gesture is in the log, the Run is live again, and the node
+        // re-spawned at iter 2. The terminal `RunFailed` label is preserved.
         let after = load_events(&state.db, run_id).await.unwrap();
-        assert_eq!(
-            after.len(),
-            before.len(),
-            "a refused retry must append no event at all"
+        assert!(
+            after.iter().any(|e| e.kind == event_log::EventKind::CommandIssued
+                && e.payload.as_ref().and_then(|p| p.get("command"))
+                    == Some(&serde_json::json!("reopen_run"))),
+            "the retry must embed a reopen_run CommandIssued"
         );
         assert!(
-            !after
+            after
                 .iter()
-                .any(|e| e.kind == event_log::EventKind::NodeInvalidated),
-            "a refused retry must not invalidate the node (the frozen-`pending` trap)"
+                .any(|e| e.kind == event_log::EventKind::RunFailed),
+            "the previous terminal label stays in the event log (AC12)"
         );
         assert!(
-            !after
+            after
                 .iter()
                 .any(|e| e.kind == event_log::EventKind::NodeStarted && e.iter == Some(2)),
-            "a refused retry must not start iter 2 (no orphan session)"
+            "the retry re-spawned the node at iter 2 after the embedded re-open"
+        );
+        let projected = event_log::project(&after).unwrap();
+        assert!(
+            projected.status.is_live(),
+            "the Run is live again after the embedded re-open, got {:?}",
+            projected.status
         );
     }
 
@@ -31319,21 +31672,30 @@ edges:
         assert_eq!(body["detail"]["kind"], "missing_outputs");
         assert_eq!(body["detail"]["missing"], serde_json::json!(["out"]));
 
-        // And the terminal events really are already recorded — which is what makes
-        // `recoverable: false` and exit code `4` true rather than decorative.
+        // ADR-0049: the node is interrupted (an output miss is a give-up, not a
+        // failure) and the run parks AwaitingUser — never RunFailed. The refusal
+        // is still non-recoverable (the script agent is gone), so exit code 4
+        // stays meaningful.
         let events = load_events(&state.db, run_id).await.unwrap();
+        assert!(
+            !events
+                .iter()
+                .any(|e| e.kind == event_log::EventKind::RunFailed),
+            "the runtime never fails the run on an output-validation miss (ADR-0049)"
+        );
         assert_eq!(
             events
                 .iter()
-                .filter(|e| e.kind == event_log::EventKind::RunFailed)
+                .filter(|e| e.kind == event_log::EventKind::NodeInterrupted)
                 .count(),
             1
         );
 
-        // The projection now carries the missing port, so the red banner is no
+        // The projection still carries the missing port, so the red banner is no
         // longer a list of nothing.
         let projected = event_log::project(&events).unwrap();
         assert_eq!(projected.nodes["worker"].missing_outputs, vec!["out"]);
+        assert_eq!(projected.status, event_log::RunStatus::AwaitingUser);
     }
 
     /// The first frontmatter mismatch, on **both** routes. Nothing terminal is
@@ -31421,15 +31783,25 @@ edges:
         assert_eq!(body["recoverable"], false);
 
         let events = load_events(&state.db, run_id).await.unwrap();
+        assert!(
+            !events
+                .iter()
+                .any(|e| e.kind == event_log::EventKind::RunFailed),
+            "the runtime never fails the run on a validation miss (ADR-0049)"
+        );
         let projected = event_log::project(&events).unwrap();
+        // ADR-0049: an exhausted validation retry interrupts the node (parking the
+        // run AwaitingUser), it never fails it.
         assert_eq!(
             projected.nodes["worker"].status,
-            event_log::NodeStatus::Failed
+            event_log::NodeStatus::Interrupted
         );
-        assert_eq!(
-            projected.nodes["worker"].failure_reason.as_deref(),
-            Some("output validation failed")
-        );
+        assert_eq!(projected.status, event_log::RunStatus::AwaitingUser);
+        assert!(projected.nodes["worker"]
+            .failure_reason
+            .as_deref()
+            .unwrap_or_default()
+            .contains("output validation after retry"));
     }
 
     /// New coverage: no test reached the doc-only immutability arm before #490. It
@@ -31492,13 +31864,26 @@ edges:
             .unwrap()
             .contains("code immutability"));
 
+        // ADR-0049: the refusal parks the run (NodeInterrupted → AwaitingUser),
+        // it never fails it.
         let events = load_events(&state.db, run_id).await.unwrap();
+        assert!(
+            !events
+                .iter()
+                .any(|e| e.kind == event_log::EventKind::RunFailed),
+            "the runtime never fails the run on a completion refusal (ADR-0049)"
+        );
         assert_eq!(
             events
                 .iter()
-                .filter(|e| e.kind == event_log::EventKind::RunFailed)
+                .filter(|e| e.kind == event_log::EventKind::NodeInterrupted
+                    && e.node_id.as_deref() == Some("worker"))
                 .count(),
             1
+        );
+        assert_eq!(
+            event_log::project(&events).unwrap().status,
+            event_log::RunStatus::AwaitingUser
         );
 
         // Route asymmetry, asserted rather than assumed (ADR-0035, accepted limit):
@@ -31633,16 +32018,24 @@ edges:
             );
         }
 
-        // #503 AC5: the node must not stay projected `running` on a dead Run.
+        // #503 AC5 / ADR-0049: the node must not stay projected `running`, but a
+        // merge conflict is a runtime give-up → the node is `Interrupted` and the
+        // run parks `AwaitingUser`, never `Failed`.
         let projected = event_log::project(&events).unwrap();
-        assert_eq!(projected.status, event_log::RunStatus::Failed);
+        assert_eq!(projected.status, event_log::RunStatus::AwaitingUser);
+        assert!(
+            !events
+                .iter()
+                .any(|e| e.kind == event_log::EventKind::RunFailed),
+            "the runtime never fails the run on a merge conflict (ADR-0049)"
+        );
         assert_eq!(
             projected.nodes["impl_b"].status,
-            event_log::NodeStatus::Failed,
-            "the node whose merge-back failed must be Failed, not Running"
+            event_log::NodeStatus::Interrupted,
+            "the node whose merge-back conflicted must be Interrupted, not Running/Failed"
         );
-        // …and the Run must say why, in one field a UI can render.
-        let run_reason = projected.failure_reason.expect("a run failure reason");
+        // …and the Run must say why, in the awaiting-reason field a UI can render.
+        let run_reason = projected.awaiting_reason.expect("an awaiting reason");
         assert!(
             run_reason.contains("merge conflict on impl_b") && run_reason.contains("1 conflicting"),
             "the run's reason must name the node and the blast radius; got {run_reason:?}"

--- a/crates/pdo-daemon/src/library_store.rs
+++ b/crates/pdo-daemon/src/library_store.rs
@@ -1070,6 +1070,7 @@ mod tests {
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            auto_fail: None,
         }
     }
 

--- a/crates/pdo-daemon/src/loop_region.rs
+++ b/crates/pdo-daemon/src/loop_region.rs
@@ -538,6 +538,7 @@ mod tests {
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            auto_fail: None,
         }
     }
 

--- a/crates/pdo-daemon/src/mutation_validator.rs
+++ b/crates/pdo-daemon/src/mutation_validator.rs
@@ -35,6 +35,7 @@ pub(crate) fn validate_run_mutation(
                 event_log::NodeStatus::AwaitingUser => "awaiting_user",
                 event_log::NodeStatus::Stopped => "stopped",
                 event_log::NodeStatus::Stale => "stale",
+                event_log::NodeStatus::Interrupted => "interrupted",
                 event_log::NodeStatus::Pending => unreachable!(),
             };
             rejections.push(MutationRejection {
@@ -215,6 +216,7 @@ mod tests {
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            auto_fail: None,
         }
     }
 
@@ -233,6 +235,7 @@ mod tests {
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            auto_fail: None,
         }
     }
 

--- a/crates/pdo-daemon/src/node_io_resolver.rs
+++ b/crates/pdo-daemon/src/node_io_resolver.rs
@@ -355,6 +355,7 @@ mod tests {
                     over: None,
                     pin_harness: None,
                     harnesses: Default::default(),
+                    auto_fail: None,
                 },
                 NodeDef {
                     id: "implementer".into(),
@@ -384,6 +385,7 @@ mod tests {
                     over: None,
                     pin_harness: None,
                     harnesses: Default::default(),
+                    auto_fail: None,
                 },
             ],
             edges: vec![EdgeDef {
@@ -538,6 +540,7 @@ mod tests {
                     over: None,
                     pin_harness: None,
                     harnesses: Default::default(),
+                    auto_fail: None,
                 },
                 NodeDef {
                     id: "implementer".into(),
@@ -567,6 +570,7 @@ mod tests {
                     over: None,
                     pin_harness: None,
                     harnesses: Default::default(),
+                    auto_fail: None,
                 },
             ],
             edges: vec![EdgeDef {
@@ -726,6 +730,7 @@ mod tests {
                     over: None,
                     pin_harness: None,
                     harnesses: Default::default(),
+                    auto_fail: None,
                 },
                 NodeDef {
                     id: "b".into(),
@@ -747,6 +752,7 @@ mod tests {
                     over: None,
                     pin_harness: None,
                     harnesses: Default::default(),
+                    auto_fail: None,
                 },
                 NodeDef {
                     id: "merger".into(),
@@ -768,6 +774,7 @@ mod tests {
                     over: None,
                     pin_harness: None,
                     harnesses: Default::default(),
+                    auto_fail: None,
                 },
             ],
             edges: vec![
@@ -857,6 +864,7 @@ mod tests {
                     over: None,
                     pin_harness: None,
                     harnesses: Default::default(),
+                    auto_fail: None,
                 },
                 NodeDef {
                     id: "implementer".into(),
@@ -871,6 +879,7 @@ mod tests {
                     over: None,
                     pin_harness: None,
                     harnesses: Default::default(),
+                    auto_fail: None,
                 },
             ],
             edges: vec![EdgeDef {
@@ -939,6 +948,7 @@ mod tests {
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            auto_fail: None,
         };
         let mk_edge = |src: &str| EdgeDef {
             source: EdgeEndpoint {
@@ -1020,6 +1030,7 @@ mod tests {
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            auto_fail: None,
         };
         let mk_edge = |src: &str, port: &str| EdgeDef {
             source: EdgeEndpoint {
@@ -1104,6 +1115,7 @@ mod tests {
                 over: None,
                 pin_harness: None,
                 harnesses: Default::default(),
+                auto_fail: None,
             }],
             edges: Vec::new(),
             loops: Vec::new(),

--- a/crates/pdo-daemon/src/node_primitives.rs
+++ b/crates/pdo-daemon/src/node_primitives.rs
@@ -869,6 +869,7 @@ mod tests {
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            auto_fail: None,
         }
     }
 
@@ -901,6 +902,7 @@ mod tests {
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            auto_fail: None,
         }
     }
 

--- a/crates/pdo-daemon/src/node_spawn.rs
+++ b/crates/pdo-daemon/src/node_spawn.rs
@@ -284,8 +284,16 @@ pub(crate) async fn spawn_node(
             .unwrap_or(true);
         if body_empty {
             let reason = format!("script node {} has an empty body", node.id);
-            fail_spawn_before_start(deps, spawn_ctx.repo_root, run_id, &node.id, None, &reason)
-                .await;
+            interrupt_spawn_before_start(
+                deps,
+                spawn_ctx.repo_root,
+                run_id,
+                &node.id,
+                iter,
+                None,
+                &reason,
+            )
+            .await;
             return SpawnOutcome::Failed { reason };
         }
     }
@@ -487,23 +495,38 @@ pub(crate) async fn spawn_node(
                 interrupted_git_ops = ensured.entry_state.interrupted_git_ops().to_vec();
                 // #489-B: `Some(...)` ONLY when this spawn created the worktree.
                 // On a reuse, any later abort in the panic-isolated span would send
-                // `fail_spawn_before_start` into `reap_orphan_sub_worktree`, and
+                // `interrupt_spawn_before_start` into `reap_orphan_sub_worktree`, and
                 // `worktree remove --force` succeeds on a dirty tree — it would
                 // destroy exactly the work the restart exists to save. Gated, the
-                // abort path appends `RunFailed` and destroys nothing: the Run goes
-                // terminal with the work intact, `resume_run` reopens it and the next
-                // classification answers `Reusable`. #279's invariant ("an aborted
-                // spawn leaves no orphan") is untouched — it only ever covered what
-                // the spawn itself created.
+                // abort path appends `NodeInterrupted` and destroys nothing: the Run
+                // parks `AwaitingUser` with the work intact (ADR-0049), a reopen/retry
+                // re-drives it and the next classification answers `Reusable`. #279's
+                // invariant ("an aborted spawn leaves no orphan") is untouched — it
+                // only ever covered what the spawn itself created.
                 if ensured.created {
                     orphan_to_reap = Some((sub_wt_dir.clone(), sub_branch));
                 }
             }
             Err(e) => {
-                error!("failed to ensure sub-worktree for {}: {e:#}", node.id);
-                return SpawnOutcome::Failed {
-                    reason: format!("failed to ensure sub-worktree for {}: {e:#}", node.id),
-                };
+                // #498 / ADR-0050 §1: a surviving `pdo/sub-*` branch (or another
+                // git collision) made `worktree add -b` fail. Before résilience
+                // this only `error!`-logged and returned `Failed` — no event, so
+                // the run stayed frozen `running` and only journalctl knew why.
+                // Now it names the node in a `NodeInterrupted`, parking the run
+                // `AwaitingUser`; on the next reopen/retry `ensure_sub_worktree`
+                // reaps the survivor (Recyclable) and the spawn succeeds (FP #3).
+                let reason = format!("failed to ensure sub-worktree for {}: {e:#}", node.id);
+                interrupt_spawn_before_start(
+                    deps,
+                    spawn_ctx.repo_root,
+                    run_id,
+                    &node.id,
+                    iter,
+                    None,
+                    &reason,
+                )
+                .await;
+                return SpawnOutcome::Failed { reason };
             }
         }
         sub_wt_dir
@@ -749,11 +772,12 @@ pub(crate) async fn spawn_node(
         Ok(Ok(pair)) => pair,
         Ok(Err(e)) => {
             let reason = format!("spawn of node {} aborted before start: {e}", node.id);
-            fail_spawn_before_start(
+            interrupt_spawn_before_start(
                 deps,
                 spawn_ctx.repo_root,
                 run_id,
                 &node.id,
+                iter,
                 orphan_to_reap.as_ref(),
                 &reason,
             )
@@ -766,11 +790,12 @@ pub(crate) async fn spawn_node(
                 node.id,
                 panic_payload_message(panic.as_ref())
             );
-            fail_spawn_before_start(
+            interrupt_spawn_before_start(
                 deps,
                 spawn_ctx.repo_root,
                 run_id,
                 &node.id,
+                iter,
                 orphan_to_reap.as_ref(),
                 &reason,
             )
@@ -849,7 +874,7 @@ pub(crate) async fn spawn_node(
             "failed to spawn tmux session {session_name} for node {}: {e}",
             node.id
         );
-        fail_spawn_after_start(
+        interrupt_spawn_after_start(
             deps,
             spawn_ctx.repo_root,
             run_id,
@@ -884,20 +909,25 @@ pub(crate) async fn spawn_node(
     }
 }
 
-/// Fail a run loud when a node spawn aborts *before* `NodeStarted` is appended
-/// (#279, Layer 1). Reaps any orphaned sub-worktree + branch the spawn created,
-/// then appends a visible cause.
+/// Interrupt a run when a node spawn aborts *before* `NodeStarted` is appended
+/// (#279 / #498, ADR-0050 §1). Reaps any orphaned sub-worktree + branch the
+/// spawn created, then appends a visible cause naming the node.
 ///
-/// The cause is `RunFailed`, **not** `NodeFailed`: the node has no
-/// `NodeStarted`, so `transition_guard::validate_fail` treats a `NodeFailed`
-/// for it as a guard no-op (a failure for an iteration "that was never started")
-/// — the run would stay `Running` and the fix would be defeated. `RunFailed` is
-/// un-guarded and reliably moves the run terminal.
-async fn fail_spawn_before_start(
+/// Since résilience (ADR-0049) the cause is `NodeInterrupted`, **not**
+/// `RunFailed`: a spawn abort is an infra incident, not a business failure, so
+/// the runtime never terminalises the run. The guard's `validate_interrupt`
+/// admits a `NodeInterrupted` even for an iteration that never opened a
+/// `NodeStarted` row, so the projection materialises the node `Interrupted` and
+/// [`finalize`](crate::event_log) parks the run `AwaitingUser` with this reason
+/// — visible, recoverable, never frozen `running` (the #498 trap). This is why
+/// the pre-résilience code had to reach for the un-guarded `RunFailed`: a
+/// `NodeFailed` on a never-started node was a guard no-op.
+async fn interrupt_spawn_before_start(
     deps: SpawnDeps<'_>,
     repo_root: &std::path::Path,
     run_id: &str,
     node_id: &str,
+    iter: i64,
     orphan: Option<&(PathBuf, String)>,
     reason: &str,
 ) {
@@ -905,34 +935,32 @@ async fn fail_spawn_before_start(
     if let Some((sub_worktree_dir, sub_branch)) = orphan {
         reap_orphan_sub_worktree(repo_root, sub_worktree_dir, sub_branch);
     }
-    let run_failed = event_log::Event {
+    let interrupted = event_log::Event {
         id: None,
         run_id: run_id.to_string(),
         ts: event_log::now_iso(),
-        kind: event_log::EventKind::RunFailed,
-        node_id: None,
-        iter: None,
-        payload: Some(serde_json::json!({ "reason": reason })),
+        kind: event_log::EventKind::NodeInterrupted,
+        node_id: Some(node_id.to_string()),
+        iter: Some(iter),
+        payload: Some(serde_json::json!({ "reason": reason, "source": "spawn" })),
     };
-    if let Err(e) = append_event_with(deps.db, deps.event_tx, &run_failed).await {
-        error!("Run {run_id}: failed to append RunFailed after spawn abort: {e}");
+    if let Err(e) = append_event_with(deps.db, deps.event_tx, &interrupted).await {
+        error!("Run {run_id}: failed to append NodeInterrupted after spawn abort: {e}");
     }
 }
 
-/// Fail a run loud when a node spawn aborts *after* `NodeStarted` is appended
-/// (#508). Unlike [`fail_spawn_before_start`], the iteration is already
-/// `Running`, so a `NodeFailed` is a legal transition
-/// (`transition_guard::validate_fail` → `Allow`) and IS appended: it moves the
-/// *node* terminal, closing the window where the liveness sweep would rewrite it
-/// `Failed` with a false `session_died` cause and where `GET …/pane` /
-/// boot_recovery could re-drive a `Running` node that has no session.
-/// `RunFailed` then moves the *run* terminal (the sole event that sets
-/// `state.status = Failed`). The reap is gated on `orphan` (Some iff THIS spawn
-/// created the sub-worktree — a reuse must destroy nothing; ADR-0037 §6). The
-/// order (node-terminal → reap → run-terminal) mirrors the #488 "terminal event
-/// first, reap second" convention; it is not required by the guard
-/// (`validate_fail` ignores run status).
-async fn fail_spawn_after_start(
+/// Interrupt a run when a node spawn aborts *after* `NodeStarted` is appended
+/// (#508). The iteration is already `Running`, so a `NodeInterrupted` is a legal
+/// transition and IS appended: it moves the *node* to `Interrupted` (non
+/// terminal, ADR-0049), closing the window where the liveness sweep would
+/// rewrite it `Failed` with a false `session_died` cause and where `GET …/pane`
+/// / boot_recovery could re-drive a `Running` node that has no session. The run
+/// then parks `AwaitingUser` (derived in [`finalize`](crate::event_log)), never
+/// `RunFailed`. The reap is gated on `orphan` (Some iff THIS spawn created the
+/// sub-worktree — a reuse must destroy nothing; ADR-0037 §6). The order
+/// (node-interrupt → reap) mirrors the #488 "terminal event first, reap second"
+/// convention.
+async fn interrupt_spawn_after_start(
     deps: SpawnDeps<'_>,
     repo_root: &std::path::Path,
     run_id: &str,
@@ -943,37 +971,23 @@ async fn fail_spawn_after_start(
 ) {
     error!("Run {run_id}: node {node_id} spawn failed after NodeStarted — {reason}");
 
-    // 1) Node terminal (legal: the iteration is `Running` after `NodeStarted`).
-    let node_failed = event_log::Event {
+    // 1) Node interrupted (legal: the iteration is `Running` after `NodeStarted`).
+    let interrupted = event_log::Event {
         id: None,
         run_id: run_id.to_string(),
         ts: event_log::now_iso(),
-        kind: event_log::EventKind::NodeFailed,
+        kind: event_log::EventKind::NodeInterrupted,
         node_id: Some(node_id.to_string()),
         iter: Some(iter),
         payload: Some(serde_json::json!({ "reason": reason, "source": "spawn" })),
     };
-    if let Err(e) = append_event_with(deps.db, deps.event_tx, &node_failed).await {
-        error!("Run {run_id}: failed to append NodeFailed after spawn failure: {e}");
+    if let Err(e) = append_event_with(deps.db, deps.event_tx, &interrupted).await {
+        error!("Run {run_id}: failed to append NodeInterrupted after spawn failure: {e}");
     }
 
     // 2) Reap ONLY what this spawn created (gated; ADR-0037 §6 — a reuse loses
-    //    nothing).
+    //    nothing). The run parks `AwaitingUser` via projection; no run event.
     if let Some((sub_worktree_dir, sub_branch)) = orphan {
         reap_orphan_sub_worktree(repo_root, sub_worktree_dir, sub_branch);
-    }
-
-    // 3) Run terminal (the sole event that sets `state.status = Failed`).
-    let run_failed = event_log::Event {
-        id: None,
-        run_id: run_id.to_string(),
-        ts: event_log::now_iso(),
-        kind: event_log::EventKind::RunFailed,
-        node_id: None,
-        iter: None,
-        payload: Some(serde_json::json!({ "reason": reason })),
-    };
-    if let Err(e) = append_event_with(deps.db, deps.event_tx, &run_failed).await {
-        error!("Run {run_id}: failed to append RunFailed after spawn failure: {e}");
     }
 }

--- a/crates/pdo-daemon/src/outputs_validator.rs
+++ b/crates/pdo-daemon/src/outputs_validator.rs
@@ -309,6 +309,7 @@ mod tests {
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            auto_fail: None,
         }
     }
 

--- a/crates/pdo-daemon/src/pipeline.rs
+++ b/crates/pdo-daemon/src/pipeline.rs
@@ -159,6 +159,13 @@ pub(crate) struct NodeDef {
     /// (`pipeline_semantics`).
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub harnesses: BTreeMap<String, crate::harness_resolver::HarnessEntry>,
+    /// Optional `auto_fail` preference for this node (ADR-0049): the **finest**
+    /// tier of [`crate::auto_fail::resolve_auto_fail`] (`node → Run → Projet →
+    /// instance`). `Some(true)`/`Some(false)` overrides every coarser tier for a
+    /// node's own `pdo fail`; `None` (absent) makes the node defer to the Run /
+    /// Projet / instance. Semantic, not layout.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auto_fail: Option<bool>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -2533,6 +2540,7 @@ nodes:
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            auto_fail: None,
         };
         let yaml = serde_yaml::to_string(&node).unwrap();
         assert!(yaml.contains("type: script"), "serializes to kebab: {yaml}");

--- a/crates/pdo-daemon/src/pipeline_migrator.rs
+++ b/crates/pdo-daemon/src/pipeline_migrator.rs
@@ -2469,6 +2469,7 @@ edges:
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            auto_fail: None,
         }
     }
 
@@ -2501,6 +2502,7 @@ edges:
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            auto_fail: None,
         }
     }
 
@@ -2533,6 +2535,7 @@ edges:
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            auto_fail: None,
         }
     }
 

--- a/crates/pdo-daemon/src/pipeline_semantics.rs
+++ b/crates/pdo-daemon/src/pipeline_semantics.rs
@@ -152,6 +152,12 @@ struct NodeProjection<'a> {
     /// it, so it is absent from `SEMANTIC_FIELDS.node`; it is still a behavioural
     /// field on the parse surface, hence semantic here.
     over: Option<&'a str>,
+    /// Per-node `auto_fail` (ADR-0049). Semantic: it changes whether an agent
+    /// `pdo fail` terminalises the run. `skip_serializing_if` keeps every
+    /// pipeline that states no preference byte-identical to its pre-résilience
+    /// content hash (absent key), so this field flags drift only when set.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    auto_fail: Option<bool>,
     inputs: Vec<PortProjection<'a>>,
     outputs: Vec<PortProjection<'a>>,
 }
@@ -170,6 +176,7 @@ impl<'a> NodeProjection<'a> {
             over,
             pin_harness,
             harnesses,
+            auto_fail,
         } = node;
         let _layout = view; // LAYOUT_FIELDS["node"]
         Self {
@@ -181,6 +188,7 @@ impl<'a> NodeProjection<'a> {
             harnesses,
             max_iter: max_iter.as_ref().map(canon_yaml),
             over: over.as_deref(),
+            auto_fail: *auto_fail,
             inputs: inputs.iter().map(PortProjection::of).collect(),
             outputs: outputs.iter().map(PortProjection::of).collect(),
         }

--- a/crates/pdo-daemon/src/project_store.rs
+++ b/crates/pdo-daemon/src/project_store.rs
@@ -42,6 +42,13 @@ pub(crate) struct Project {
     /// resolver seam (the `Some("")` trap of #347).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub harness: Option<String>,
+    /// The `auto_fail` preference this Projet carries (ADR-0049), or `None` when
+    /// it states none — the **project** tier of
+    /// [`crate::auto_fail::resolve_auto_fail`]. `Some(true)`/`Some(false)` is a
+    /// stored decision; `None` makes the tier transparent (fall through to the
+    /// instance default). No env/default tier of its own.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auto_fail: Option<bool>,
     /// Member repository paths, compared **verbatim** (ADR-0033). Ordered by
     /// attach time (the `rowid` of `project_members`).
     #[serde(default)]
@@ -76,11 +83,27 @@ pub(crate) async fn init(db: &SqlitePool) -> Result<(), sqlx::Error> {
             id         TEXT PRIMARY KEY,
             name       TEXT NOT NULL,
             harness    TEXT,
+            auto_fail  INTEGER,
             created_at TEXT NOT NULL
         )",
     )
     .execute(db)
     .await?;
+
+    // Additive migration for pre-résilience databases: the `auto_fail` column is
+    // absent on `projects` tables created before ADR-0049 (#552 shipped without
+    // it). Guarded `ADD COLUMN` — NULLABLE so an existing Projet states no
+    // preference and the tier stays transparent.
+    let has_auto_fail =
+        sqlx::query("SELECT 1 FROM pragma_table_info('projects') WHERE name = 'auto_fail'")
+            .fetch_optional(db)
+            .await?
+            .is_some();
+    if !has_auto_fail {
+        sqlx::query("ALTER TABLE projects ADD COLUMN auto_fail INTEGER")
+            .execute(db)
+            .await?;
+    }
 
     // `path` is the PRIMARY KEY: at-most-one-Projet-per-path is a schema
     // invariant. `project_id` is indexed for the members-of lookup. No FK
@@ -119,6 +142,7 @@ fn row_to_project(row: &sqlx::sqlite::SqliteRow, members: Vec<String>) -> Projec
         harness: row
             .get::<Option<String>, _>("harness")
             .filter(|s| !s.is_empty()),
+        auto_fail: row.get::<Option<i64>, _>("auto_fail").map(|v| v != 0),
         members,
     }
 }
@@ -149,6 +173,7 @@ pub(crate) async fn create(db: &SqlitePool, name: &str) -> Result<Project, sqlx:
         id,
         name: name.to_string(),
         harness: None,
+        auto_fail: None,
         members: Vec::new(),
     })
 }
@@ -207,6 +232,35 @@ pub(crate) async fn set_harness(
         .execute(db)
         .await?;
     Ok(res.rows_affected() > 0)
+}
+
+/// Set (or clear, with `None`) the `auto_fail` preference a Projet carries
+/// (ADR-0049). `Some(true)` stores `1`, `Some(false)` stores `0`, `None` clears
+/// it back to "states no preference" (SQL `NULL`). Returns `true` iff a row was
+/// updated.
+pub(crate) async fn set_auto_fail(
+    db: &SqlitePool,
+    id: &str,
+    auto_fail: Option<bool>,
+) -> Result<bool, sqlx::Error> {
+    let stored: Option<i64> = auto_fail.map(|v| if v { 1 } else { 0 });
+    let res = sqlx::query("UPDATE projects SET auto_fail = ? WHERE id = ?")
+        .bind(stored)
+        .bind(id)
+        .execute(db)
+        .await?;
+    Ok(res.rows_affected() > 0)
+}
+
+/// Resolve the `auto_fail` preference a `path` inherits from its Projet, for the
+/// `project` tier of [`crate::auto_fail::resolve_auto_fail`]. `None` ⇒ the path
+/// is in no Projet, or its Projet states no preference — the tier is transparent
+/// either way.
+pub(crate) async fn auto_fail_for_path(
+    db: &SqlitePool,
+    path: &str,
+) -> Result<Option<bool>, sqlx::Error> {
+    Ok(owner_of(db, path).await?.and_then(|p| p.auto_fail))
 }
 
 /// The Projet that currently owns `path`, if any. Read-then-decide basis for the

--- a/crates/pdo-daemon/src/prompt_augmenter.rs
+++ b/crates/pdo-daemon/src/prompt_augmenter.rs
@@ -1090,6 +1090,7 @@ mod tests {
                 over: None,
                 pin_harness: None,
                 harnesses: Default::default(),
+                auto_fail: None,
             }],
             edges: vec![],
             loops: Vec::new(),
@@ -1308,6 +1309,7 @@ mod tests {
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            auto_fail: None,
         });
         pipeline.edges.push(EdgeDef {
             source: EdgeEndpoint {
@@ -1445,6 +1447,7 @@ mod tests {
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            auto_fail: None,
         });
         pipeline.edges.push(EdgeDef {
             source: EdgeEndpoint {
@@ -1505,6 +1508,7 @@ mod tests {
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            auto_fail: None,
         });
 
         let node = &pipeline.nodes[1]; // implementer
@@ -1537,6 +1541,7 @@ mod tests {
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            auto_fail: None,
         });
         pipeline.edges.push(EdgeDef {
             source: EdgeEndpoint {
@@ -1583,6 +1588,7 @@ mod tests {
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            auto_fail: None,
         });
         pipeline.edges.push(EdgeDef {
             source: EdgeEndpoint {
@@ -1733,6 +1739,7 @@ mod tests {
                     over: None,
                     pin_harness: None,
                     harnesses: Default::default(),
+                    auto_fail: None,
                 },
                 NodeDef {
                     id: "researcher".into(),
@@ -1754,6 +1761,7 @@ mod tests {
                     over: None,
                     pin_harness: None,
                     harnesses: Default::default(),
+                    auto_fail: None,
                 },
                 NodeDef {
                     id: "implementer".into(),
@@ -1794,6 +1802,7 @@ mod tests {
                     over: None,
                     pin_harness: None,
                     harnesses: Default::default(),
+                    auto_fail: None,
                 },
             ],
             edges: vec![
@@ -1903,6 +1912,7 @@ mod tests {
                 over: None,
                 pin_harness: None,
                 harnesses: Default::default(),
+                auto_fail: None,
             }],
             edges: vec![],
             loops: Vec::new(),
@@ -2162,6 +2172,7 @@ mod tests {
                 over: None,
                 pin_harness: None,
                 harnesses: Default::default(),
+                auto_fail: None,
             }],
             edges: vec![],
             loops: Vec::new(),
@@ -2213,6 +2224,7 @@ mod tests {
                 over: None,
                 pin_harness: None,
                 harnesses: Default::default(),
+                auto_fail: None,
             }],
             edges: vec![],
             loops: Vec::new(),
@@ -2259,6 +2271,7 @@ mod tests {
                 over: None,
                 pin_harness: None,
                 harnesses: Default::default(),
+                auto_fail: None,
             }],
             edges: vec![],
             loops: Vec::new(),

--- a/crates/pdo-daemon/src/run_advance.rs
+++ b/crates/pdo-daemon/src/run_advance.rs
@@ -479,6 +479,7 @@ mod tests {
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            auto_fail: None,
         }
     }
 

--- a/crates/pdo-daemon/src/run_command.rs
+++ b/crates/pdo-daemon/src/run_command.rs
@@ -370,14 +370,15 @@ async fn dispatch(state: Arc<AppState>, run_id: String, cmd: RunCommand) -> Resp
             // Run atomically so the completion lands on a live Run instead of the
             // guard's "resume the run first" 409.
             let run_state = match run_state {
-                Some(rs) => match crate::embed_reopen_for_targeted_command(&state, &run_id, rs).await
-                {
-                    Ok(s) => Some(s),
-                    Err(e) => {
-                        return (StatusCode::INTERNAL_SERVER_ERROR, format!("error: {e}"))
-                            .into_response();
+                Some(rs) => {
+                    match crate::embed_reopen_for_targeted_command(&state, &run_id, rs).await {
+                        Ok(s) => Some(s),
+                        Err(e) => {
+                            return (StatusCode::INTERNAL_SERVER_ERROR, format!("error: {e}"))
+                                .into_response();
+                        }
                     }
-                },
+                }
                 None => None,
             };
 
@@ -988,14 +989,15 @@ async fn dispatch(state: Arc<AppState>, run_id: String, cmd: RunCommand) -> Resp
             // re-opens it atomically (the human's own re-open gesture) before the
             // guard below sees it — no "resume then restart without a GET" race.
             let projected = match projected {
-                Some(rs) => match crate::embed_reopen_for_targeted_command(&state, &run_id, rs).await
-                {
-                    Ok(s) => Some(s),
-                    Err(e) => {
-                        return (StatusCode::INTERNAL_SERVER_ERROR, format!("error: {e}"))
-                            .into_response();
+                Some(rs) => {
+                    match crate::embed_reopen_for_targeted_command(&state, &run_id, rs).await {
+                        Ok(s) => Some(s),
+                        Err(e) => {
+                            return (StatusCode::INTERNAL_SERVER_ERROR, format!("error: {e}"))
+                                .into_response();
+                        }
                     }
-                },
+                }
                 None => None,
             };
             let restart_probe = event_log::Event {

--- a/crates/pdo-daemon/src/run_command.rs
+++ b/crates/pdo-daemon/src/run_command.rs
@@ -91,6 +91,14 @@ enum RunCommand {
     },
     PauseRun,
     ResumeRun,
+    /// The global re-open (ADR-0049, AC8): "re-project + drive the new". Surfaced
+    /// by the Play button in the run-level toolbar. Lifts ANY terminal Run
+    /// (`Completed`/`Skipped`/`Failed`/`Halted`) — and an incident-parked
+    /// `AwaitingUser` — back to `Running` by a safe re-projection that freezes the
+    /// satisfied `(node, iter)` (the scheduler's dedup refuses to re-spawn them,
+    /// anti-#221) and re-drives only the unsatisfied work. Distinct from
+    /// [`RunCommand::RetryAll`] (which archives and forks a NEW run).
+    ReopenRun,
     KillNode {
         node_id: String,
         iter: i64,
@@ -163,6 +171,7 @@ impl RunCommand {
             } => "end_region",
             RunCommand::PauseRun => "pause_run",
             RunCommand::ResumeRun => "resume_run",
+            RunCommand::ReopenRun => "reopen_run",
             RunCommand::KillNode { .. } => "kill_node",
             RunCommand::RestartNode { .. } => "restart_node",
             RunCommand::StartNode { .. } => "start_node",
@@ -239,6 +248,7 @@ fn parse_run_command(req: RunCommandRequest) -> Result<RunCommand, CommandParseE
         }
         "pause_run" => Ok(RunCommand::PauseRun),
         "resume_run" => Ok(RunCommand::ResumeRun),
+        "reopen_run" => Ok(RunCommand::ReopenRun),
         "kill_node" => Ok(RunCommand::KillNode {
             node_id: required(req.node_id, "node_id", "kill_node")?,
             iter: req.iter.unwrap_or(1),
@@ -354,6 +364,22 @@ async fn dispatch(state: Arc<AppState>, run_id: String, cmd: RunCommand) -> Resp
                 }
             };
             let run_state = event_log::project(&events);
+
+            // AC7 / ADR-0049: completing a node on a terminal (or incident-parked)
+            // Run embeds the re-open — the human's `mark_node_done` re-opens the
+            // Run atomically so the completion lands on a live Run instead of the
+            // guard's "resume the run first" 409.
+            let run_state = match run_state {
+                Some(rs) => match crate::embed_reopen_for_targeted_command(&state, &run_id, rs).await
+                {
+                    Ok(s) => Some(s),
+                    Err(e) => {
+                        return (StatusCode::INTERNAL_SERVER_ERROR, format!("error: {e}"))
+                            .into_response();
+                    }
+                },
+                None => None,
+            };
 
             // Transition guard (#212, #354): validate the completion against the
             // projected state BEFORE any side effect (output validation, append,
@@ -601,11 +627,18 @@ async fn dispatch(state: Arc<AppState>, run_id: String, cmd: RunCommand) -> Resp
                 return (StatusCode::INTERNAL_SERVER_ERROR, format!("error: {e}")).into_response();
             }
 
-            // Continue the run: an exhausted-unrouted region halts the run, so
-            // lift the Halt/Failed back to Running before re-evaluating.
-            if run_state.status == event_log::RunStatus::Halted
-                || run_state.status == event_log::RunStatus::Failed
-            {
+            // Continue the run: an exhausted-unrouted region parks the run
+            // (`AwaitingUser` on an incident since ADR-0049, or the historical
+            // terminal `Halted`/`Failed`), so lift it back to `Running` before
+            // re-evaluating. A targeted command embeds its own re-open (AC7). An
+            // interactive `AwaitingUser` (no incident reason) is left alone —
+            // routing a region never overrides a node's genuine user wait.
+            let needs_reopen = matches!(
+                run_state.status,
+                event_log::RunStatus::Halted | event_log::RunStatus::Failed
+            ) || (run_state.status == event_log::RunStatus::AwaitingUser
+                && run_state.awaiting_reason.is_some());
+            if needs_reopen {
                 let resume_event = event_log::Event {
                     id: None,
                     run_id: run_id.clone(),
@@ -752,6 +785,88 @@ async fn dispatch(state: Arc<AppState>, run_id: String, cmd: RunCommand) -> Resp
             info!("resume_run: run {run_id}");
             (StatusCode::OK, Json(summary.into_response_body())).into_response()
         }
+        RunCommand::ReopenRun => {
+            let (_, run_state) = match load_projected(&state, &run_id).await {
+                Ok(v) => v,
+                Err(resp) => return *resp,
+            };
+
+            // Re-openable = any terminal Run, or an incident-parked `AwaitingUser`
+            // (ADR-0049). An interactive `AwaitingUser` (a node genuinely waiting
+            // on its user) and a cleanly `Running`/`Paused` Run are NOT re-opened
+            // here — reopen never overrides a node's user wait, and a live Run
+            // needs no re-projection. Refuse those loudly (ADR-0035 §3 shape).
+            let reopenable = run_state.status.is_terminal()
+                && run_state.status != event_log::RunStatus::Archived
+                || (run_state.status == event_log::RunStatus::AwaitingUser
+                    && run_state.awaiting_reason.is_some());
+            if !reopenable {
+                return (
+                    StatusCode::CONFLICT,
+                    Json(serde_json::json!({
+                        "error": "not_reopenable",
+                        "message": format!(
+                            "run {run_id} is {:?}: reopen_run only re-opens a terminal \
+                             or incident-parked run",
+                            run_state.status
+                        ),
+                    })),
+                )
+                    .into_response();
+            }
+
+            // The re-open gesture: the projection lifts the Run to `Running`,
+            // freezes satisfied `(node, iter)` and drops interrupted nodes so they
+            // re-drive (anti-#221, ADR-0049). The terminal label stays in the log.
+            let cmd_event = event_log::Event {
+                id: None,
+                run_id: run_id.clone(),
+                ts: event_log::now_iso(),
+                kind: event_log::EventKind::CommandIssued,
+                node_id: None,
+                iter: None,
+                payload: Some(serde_json::json!({ "command": "reopen_run" })),
+            };
+            if let Err(e) = append_event(&state, &cmd_event).await {
+                return (StatusCode::INTERNAL_SERVER_ERROR, format!("error: {e}")).into_response();
+            }
+
+            // #316: kill any open shell before the re-drive re-arms the merge.
+            tmux_session_manager::kill(
+                &state.tmux_socket(),
+                &tmux_session_manager::shell_session_name(&run_id),
+            );
+
+            // #408 D5: re-arm a sandboxed Run's container before the scheduler
+            // `docker exec`s into it (same guard as `resume_run`).
+            if !run_state.sandbox.is_off() {
+                let prep = match sandbox_run::context_from_state(&state, &run_state).await {
+                    Ok(ctx) => tokio::task::spawn_blocking(move || sandbox_run::ensure_ready(&ctx))
+                        .await
+                        .unwrap_or_else(|je| {
+                            Err(anyhow::anyhow!("sandbox ensure_ready panicked: {je}"))
+                        }),
+                    Err(e) => Err(e),
+                };
+                if let Err(e) = prep {
+                    return (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(serde_json::json!({
+                            "error": format!("sandbox container unavailable: {e:#}")
+                        })),
+                    )
+                        .into_response();
+                }
+                if run_state.sandbox_spawn_block().is_some() {
+                    mark_sandbox_prep_ready(&state, &run_id).await;
+                }
+            }
+
+            let summary = re_evaluate_after_command(&state, &run_id).await;
+
+            info!("reopen_run: run {run_id}");
+            (StatusCode::OK, Json(summary.into_response_body())).into_response()
+        }
         RunCommand::KillNode { node_id, iter } => {
             // READ-ONLY, and BEFORE any append: one projection yields both the
             // `repo_root` the snapshot goes under (#470 / ADR-0033 — a Run may
@@ -869,6 +984,20 @@ async fn dispatch(state: Arc<AppState>, run_id: String, cmd: RunCommand) -> Resp
                 }
             };
             let projected = event_log::project(&events);
+            // AC7 / ADR-0049: a restart on a terminal (or incident-parked) Run
+            // re-opens it atomically (the human's own re-open gesture) before the
+            // guard below sees it — no "resume then restart without a GET" race.
+            let projected = match projected {
+                Some(rs) => match crate::embed_reopen_for_targeted_command(&state, &run_id, rs).await
+                {
+                    Ok(s) => Some(s),
+                    Err(e) => {
+                        return (StatusCode::INTERNAL_SERVER_ERROR, format!("error: {e}"))
+                            .into_response();
+                    }
+                },
+                None => None,
+            };
             let restart_probe = event_log::Event {
                 id: None,
                 run_id: run_id.clone(),
@@ -1202,6 +1331,26 @@ async fn dispatch(state: Arc<AppState>, run_id: String, cmd: RunCommand) -> Resp
                 return (StatusCode::INTERNAL_SERVER_ERROR, format!("error: {e}")).into_response();
             }
 
+            // AC7 / ADR-0049: injecting the artifact a parked node was waiting on
+            // embeds the re-open — if the Run is terminal (or incident-parked),
+            // re-open it and re-drive so the freshly-provided output unblocks the
+            // downstream in one round-trip. A live Run is left to its own tick.
+            if let Some((_, run_state)) = reload_run_state(&state, &run_id).await {
+                let needs_reopen = (run_state.status.is_terminal()
+                    && run_state.status != event_log::RunStatus::Archived)
+                    || (run_state.status == event_log::RunStatus::AwaitingUser
+                        && run_state.awaiting_reason.is_some());
+                if needs_reopen {
+                    if let Err(e) =
+                        crate::embed_reopen_for_targeted_command(&state, &run_id, run_state).await
+                    {
+                        return (StatusCode::INTERNAL_SERVER_ERROR, format!("error: {e}"))
+                            .into_response();
+                    }
+                    re_evaluate_after_command(&state, &run_id).await;
+                }
+            }
+
             info!("inject_artifact: {path} in run {run_id}");
             (StatusCode::OK, Json(serde_json::json!({ "ok": true }))).into_response()
         }
@@ -1349,6 +1498,11 @@ async fn dispatch(state: Arc<AppState>, run_id: String, cmd: RunCommand) -> Resp
                 // named. Not carried from the original (no such field is projected from
                 // RunStarted) — same reasoning as the `sandbox_entries` note above.
                 auto_name: Some(true),
+                // ADR-0049: reproduce the original Run's `auto_fail` choice, like
+                // `harness` — `None` (stated none) forwards as `None`, so the retry
+                // resolves through the project / instance tiers exactly as the
+                // original did.
+                auto_fail: run_state.auto_fail,
             };
             let new_run_resp = create_run_core(&state, new_run_req, Vec::new()).await;
 
@@ -1364,6 +1518,9 @@ async fn dispatch(state: Arc<AppState>, run_id: String, cmd: RunCommand) -> Resp
 enum ReEvalTerminal {
     Completed,
     Halted(String),
+    /// An `unrouted` convergence parked the run `AwaitingUser` (ADR-0049) — not
+    /// terminal, but the re-evaluation had nothing left to dispatch this pass.
+    Interrupted(String),
 }
 
 /// The real effect of a post-command re-evaluation (ADR-0025 / #327): which
@@ -1410,6 +1567,9 @@ impl ReEvalSummary {
         let reason = match &self.terminal {
             Some(ReEvalTerminal::Completed) => "run completed".to_string(),
             Some(ReEvalTerminal::Halted(msg)) => format!("run halted: {msg}"),
+            Some(ReEvalTerminal::Interrupted(msg)) => {
+                format!("run interrupted (awaiting user): {msg}")
+            }
             None => {
                 if self.skipped.is_empty() {
                     "no eligible spawn".to_string()
@@ -1601,6 +1761,10 @@ async fn re_evaluate_after_command_inner(state: &AppState, run_id: &str) -> ReEv
                     summary.terminal = Some(ReEvalTerminal::Halted(message));
                     return summary;
                 }
+                ActionOutcome::Interrupted { message } => {
+                    summary.terminal = Some(ReEvalTerminal::Interrupted(message));
+                    return summary;
+                }
             }
         }
     }
@@ -1676,6 +1840,10 @@ async fn re_evaluate_after_command_inner(state: &AppState, run_id: &str) -> ReEv
                     summary.terminal = Some(ReEvalTerminal::Halted(message));
                     return summary;
                 }
+                ActionOutcome::Interrupted { message } => {
+                    summary.terminal = Some(ReEvalTerminal::Interrupted(message));
+                    return summary;
+                }
             }
         }
     }
@@ -1719,6 +1887,10 @@ async fn re_evaluate_after_command_inner(state: &AppState, run_id: &str) -> ReEv
                 }
                 ActionOutcome::Halted { message } => {
                     summary.terminal = Some(ReEvalTerminal::Halted(message));
+                    return summary;
+                }
+                ActionOutcome::Interrupted { message } => {
+                    summary.terminal = Some(ReEvalTerminal::Interrupted(message));
                     return summary;
                 }
             }
@@ -2248,6 +2420,7 @@ mod tests {
                 over: None,
                 pin_harness: None,
                 harnesses: Default::default(),
+                auto_fail: None,
             }],
             edges: vec![EdgeDef {
                 source: EdgeEndpoint {
@@ -2301,6 +2474,7 @@ mod tests {
                 over: None,
                 pin_harness: None,
                 harnesses: Default::default(),
+                auto_fail: None,
             }],
             edges: vec![EdgeDef {
                 source: EdgeEndpoint {

--- a/crates/pdo-daemon/src/scheduler.rs
+++ b/crates/pdo-daemon/src/scheduler.rs
@@ -13,7 +13,19 @@ pub(crate) enum SchedulerAction {
         node_id: String,
         iter: i64,
     },
+    /// A **deliberate** halt: an edge to `End` carried a `reason:` (a `when:`
+    /// gate message telling the run to stop here). Terminal-but-resumable
+    /// (`RunHalted`) — the pipeline author's decision, not a runtime give-up.
     Halt {
+        message: String,
+    },
+    /// An **`unrouted`** convergence (ADR-0049): conditional routing suppressed
+    /// every path to `End`, or a bounded region exhausted with no matching exit
+    /// edge. The runtime cannot drive the run forward but did not fail it — it
+    /// parks `AwaitingUser` (`RunInterrupted`) with the diagnostic, so a human
+    /// routes it (e.g. from the Pipeline Manager) or reopens. Distinct from
+    /// [`SchedulerAction::Halt`], which stays a deliberate terminal halt.
+    Interrupt {
         message: String,
     },
     Complete,
@@ -493,7 +505,7 @@ pub(crate) fn evaluate_outgoing_edges_full(
                 &mut visiting,
             );
             if end_dead {
-                actions.push(SchedulerAction::Halt {
+                actions.push(SchedulerAction::Interrupt {
                     message: "unrouted: conditional routing suppressed every path to End \
                          (no live branch reaches End)"
                         .to_string(),
@@ -609,7 +621,7 @@ fn handle_region_reentry(
                             region.id
                         )
                     };
-                    actions.push(SchedulerAction::Halt { message });
+                    actions.push(SchedulerAction::Interrupt { message });
                 }
             }
         }
@@ -1195,6 +1207,7 @@ mod tests {
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            auto_fail: None,
         }
     }
 
@@ -1219,6 +1232,7 @@ mod tests {
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            auto_fail: None,
         }
     }
 
@@ -2402,7 +2416,7 @@ mod tests {
         assert!(
             actions
                 .iter()
-                .any(|a| matches!(a, SchedulerAction::Halt { .. })),
+                .any(|a| matches!(a, SchedulerAction::Interrupt { .. })),
             "a death cascade rendering End unreachable must halt explicitly, \
              never stall silently: {actions:?}"
         );
@@ -2504,6 +2518,7 @@ mod tests {
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            auto_fail: None,
         }
     }
 
@@ -3232,6 +3247,7 @@ mod tests {
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            auto_fail: None,
         }
     }
 
@@ -3757,6 +3773,7 @@ mod tests {
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            auto_fail: None,
         }
     }
 
@@ -4712,11 +4729,11 @@ loops:
             "must not re-enter past max_iter, got {actions:?}"
         );
         let halt = actions.iter().find_map(|a| match a {
-            SchedulerAction::Halt { message } => Some(message.clone()),
+            SchedulerAction::Interrupt { message } => Some(message.clone()),
             _ => None,
         });
         let Some(halt) = halt else {
-            panic!("expected an exhausted-unrouted halt, got {actions:?}");
+            panic!("expected an exhausted-unrouted interrupt, got {actions:?}");
         };
         assert!(
             halt.contains("exhausted") && halt.contains("unrouted"),
@@ -4966,8 +4983,8 @@ loops:
         assert!(
             actions
                 .iter()
-                .any(|a| matches!(a, SchedulerAction::Halt { .. })),
-            "ended with no matching exit edge: explicit halt, never a silent \
+                .any(|a| matches!(a, SchedulerAction::Interrupt { .. })),
+            "ended with no matching exit edge: explicit interrupt, never a silent \
              stall, got {actions:?}"
         );
     }

--- a/crates/pdo-daemon/src/scheduler_dispatcher.rs
+++ b/crates/pdo-daemon/src/scheduler_dispatcher.rs
@@ -86,6 +86,7 @@ mod tests {
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            auto_fail: None,
         }
     }
 

--- a/crates/pdo-daemon/src/scheduler_interpreter.rs
+++ b/crates/pdo-daemon/src/scheduler_interpreter.rs
@@ -119,6 +119,11 @@ pub(crate) enum ActionOutcome {
     Completed,
     /// `RunHalted` was emitted — the driver must stop dispatching and return.
     Halted { message: String },
+    /// `RunInterrupted` was emitted for an `unrouted` convergence (ADR-0049) —
+    /// the run is parked `AwaitingUser`, not terminal. The driver stops
+    /// dispatching this pass (there is nothing left to route), exactly like
+    /// `Halted`; a human reopens or routes it.
+    Interrupted { message: String },
 }
 
 /// Interpret ONE [`SchedulerAction`]. A linear sequence of Layer-2 primitives
@@ -166,6 +171,21 @@ pub(crate) async fn interpret(
             )
             .await;
             ActionOutcome::Halted {
+                message: message.clone(),
+            }
+        }
+        SchedulerAction::Interrupt { message } => {
+            // ADR-0049: `unrouted` parks the run `AwaitingUser`, never terminal.
+            // `RunInterrupted` carries the diagnostic under `reason` (the shape
+            // `run_event_reason` reads into `awaiting_reason`).
+            emit_run_event(
+                state,
+                run_id,
+                event_log::EventKind::RunInterrupted,
+                Some(serde_json::json!({ "reason": message })),
+            )
+            .await;
+            ActionOutcome::Interrupted {
                 message: message.clone(),
             }
         }

--- a/crates/pdo-daemon/src/stale_detector.rs
+++ b/crates/pdo-daemon/src/stale_detector.rs
@@ -531,13 +531,16 @@ pub fn detection_events(
     iter: i64,
 ) -> Vec<event_log::Event> {
     // The session-died cause names the dead tmux session (#213 AC1) so the
-    // failure is self-explanatory in the UI/log.
+    // incident is self-explanatory in the UI/log. Since résilience (ADR-0049)
+    // this is a `NodeInterrupted`, not a `NodeFailed`: "la session est morte,
+    // pas le travail" — the run parks `AwaitingUser` (derived in `finalize`),
+    // never `Failed`, and a human resumes or restarts it.
     let (kind, reason) = match detection {
         Detection::Ok | Detection::TurnEnded => return vec![],
         Detection::SessionDied => {
             let session = crate::tmux_session_manager::node_session_name(run_id, node_id, iter);
             (
-                EventKind::NodeFailed,
+                EventKind::NodeInterrupted,
                 format!("session_died: tmux session {session} no longer exists"),
             )
         }
@@ -1252,7 +1255,9 @@ mod tests {
     fn events_session_died() {
         let events = detection_events(&Detection::SessionDied, "run1", "node1", 1);
         assert_eq!(events.len(), 1);
-        assert_eq!(events[0].kind, EventKind::NodeFailed);
+        // ADR-0049: session death is an infra incident → `NodeInterrupted`, not
+        // `NodeFailed`.
+        assert_eq!(events[0].kind, EventKind::NodeInterrupted);
         assert_eq!(events[0].node_id.as_deref(), Some("node1"));
         let payload = events[0].payload.as_ref().unwrap();
         // #213 AC1: the failure cause must name the dead tmux session so an
@@ -1747,7 +1752,8 @@ SwapFree:         204800 kB
         let a = assess(&probes, true);
         assert_eq!(a.detection, Detection::SessionDied);
         assert_eq!(a.events.len(), 1);
-        assert_eq!(a.events[0].kind, EventKind::NodeFailed);
+        // ADR-0049: session death → `NodeInterrupted`, not `NodeFailed`.
+        assert_eq!(a.events[0].kind, EventKind::NodeInterrupted);
         // #234: diagnostics folded into the failure payload AND surfaced for the
         // sweep's structured log.
         assert_eq!(

--- a/crates/pdo-daemon/src/switch_router.rs
+++ b/crates/pdo-daemon/src/switch_router.rs
@@ -60,6 +60,7 @@ mod tests {
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            auto_fail: None,
         }
     }
 

--- a/crates/pdo-daemon/src/transition_guard.rs
+++ b/crates/pdo-daemon/src/transition_guard.rs
@@ -441,11 +441,10 @@ fn validate_interrupt(state: &RunState, event: &Event) -> Verdict {
         // interrupt with no iteration row): a fresh interrupt is allowed unless
         // the node itself is already interrupted — a re-interrupt of the same
         // never-started node is a no-op.
-        None
-            if state
-                .nodes
-                .get(node_id)
-                .is_some_and(|n| n.status == NodeStatus::Interrupted) =>
+        None if state
+            .nodes
+            .get(node_id)
+            .is_some_and(|n| n.status == NodeStatus::Interrupted) =>
         {
             Verdict::noop(format!(
                 "node {node_id} is already interrupted: interrupt ignored"

--- a/crates/pdo-daemon/src/transition_guard.rs
+++ b/crates/pdo-daemon/src/transition_guard.rs
@@ -101,6 +101,7 @@ impl std::fmt::Display for RejectReason {
                     EventKind::NodeCompleted | EventKind::NodeAutoCompleted => "completion",
                     EventKind::NodeStarted | EventKind::NodeWaiting => "start",
                     EventKind::NodeFailed => "fail",
+                    EventKind::NodeInterrupted => "interrupt",
                     EventKind::NodeStale => "stale",
                     // The guard only builds MissingNodeId for the six kinds
                     // above; defensive.
@@ -195,6 +196,7 @@ pub(crate) fn validate_transition(state: Option<&RunState>, event: &Event) -> Ve
         EventKind::NodeStarted | EventKind::NodeWaiting => validate_start(state, event),
         EventKind::NodeStale => validate_stale(state, event),
         EventKind::NodeFailed => validate_fail(state, event),
+        EventKind::NodeInterrupted => validate_interrupt(state, event),
         _ => Verdict::Allow,
     }
 }
@@ -397,6 +399,59 @@ fn validate_fail(state: &RunState, event: &Event) -> Verdict {
         None => Verdict::noop(format!(
             "node {node_id} iter {iter} has no started iteration: failure ignored"
         )),
+        _ => Verdict::Allow,
+    }
+}
+
+/// Validate a `NodeInterrupted` — an infra incident on a node (ADR-0049),
+/// emitted by the liveness sweep, boot recovery, or a spawn-abort.
+///
+/// Two differences from [`validate_fail`], both load-bearing:
+///
+/// 1. A **never-started** iteration is **allowed**, not a no-op: a spawn that
+///    aborts *before* `NodeStarted` (ADR-0050 §1 — e.g. a surviving `pdo/sub-*`
+///    branch collides on `git worktree add -b`) still names its node, and the
+///    projection materialises it `Interrupted` so the run parks visibly. This is
+///    the exact case `validate_fail` drops as "never started", which is why the
+///    before-start abort had to emit `RunFailed` before résilience.
+/// 2. The run-liveness gate is **not** applied: an interrupt lands on a run that
+///    is still `Running`, and a race that lets it arrive just after a terminal
+///    event should be dropped as a duplicate rather than resurrect the run — the
+///    already-terminal iteration arm below covers that.
+///
+/// A late interrupt for an iteration that reached a terminal state organically
+/// (or was already interrupted) is a no-op, never an overwrite.
+fn validate_interrupt(state: &RunState, event: &Event) -> Verdict {
+    let Some(node_id) = event.node_id.as_deref() else {
+        return Verdict::reject(RejectReason::MissingNodeId {
+            kind: event.kind.clone(),
+        });
+    };
+    let iter = event.iter.unwrap_or(1);
+
+    match iteration_status(state, node_id, iter) {
+        Some(NodeStatus::Completed)
+        | Some(NodeStatus::Failed)
+        | Some(NodeStatus::Stopped)
+        | Some(NodeStatus::Stale)
+        | Some(NodeStatus::Interrupted) => Verdict::noop(format!(
+            "node {node_id} iter {iter} is already terminal: interrupt ignored"
+        )),
+        // `None` (never started, or a node materialised by a prior before-start
+        // interrupt with no iteration row): a fresh interrupt is allowed unless
+        // the node itself is already interrupted — a re-interrupt of the same
+        // never-started node is a no-op.
+        None
+            if state
+                .nodes
+                .get(node_id)
+                .is_some_and(|n| n.status == NodeStatus::Interrupted) =>
+        {
+            Verdict::noop(format!(
+                "node {node_id} is already interrupted: interrupt ignored"
+            ))
+        }
+        // Running / AwaitingUser / never-started — the incident is allowed.
         _ => Verdict::Allow,
     }
 }
@@ -816,6 +871,52 @@ mod tests {
             &ev(EventKind::NodeFailed, Some("ghost"), Some(1)),
         );
         assert_noop(verdict);
+    }
+
+    // --- NodeInterrupted (ADR-0049/0050) --------------------------------------
+
+    #[test]
+    fn interrupt_on_running_iteration_is_allowed() {
+        // Session death / after-start spawn abort on a live iteration.
+        let state = state_from(&[
+            ev(EventKind::RunStarted, None, None),
+            ev(EventKind::NodeStarted, Some("worker"), Some(1)),
+        ]);
+        assert_eq!(
+            validate_transition(
+                Some(&state),
+                &ev(EventKind::NodeInterrupted, Some("worker"), Some(1))
+            ),
+            Verdict::Allow
+        );
+    }
+
+    #[test]
+    fn interrupt_on_never_started_iteration_is_allowed() {
+        // ADR-0050 §1: a spawn abort BEFORE NodeStarted must still name its node —
+        // unlike NodeFailed, the guard ALLOWS it so the projection can materialise
+        // the interrupted node and park the run visibly.
+        let state = state_from(&[ev(EventKind::RunStarted, None, None)]);
+        assert_eq!(
+            validate_transition(
+                Some(&state),
+                &ev(EventKind::NodeInterrupted, Some("ghost"), Some(1))
+            ),
+            Verdict::Allow
+        );
+    }
+
+    #[test]
+    fn interrupt_on_completed_iteration_is_noop() {
+        let state = state_from(&[
+            ev(EventKind::RunStarted, None, None),
+            ev(EventKind::NodeStarted, Some("worker"), Some(1)),
+            ev(EventKind::NodeCompleted, Some("worker"), Some(1)),
+        ]);
+        assert_noop(validate_transition(
+            Some(&state),
+            &ev(EventKind::NodeInterrupted, Some("worker"), Some(1)),
+        ));
     }
 
     // --- spawn_superfluous (scheduler-side dedup) ---

--- a/crates/pdo-daemon/src/workflow_importer.rs
+++ b/crates/pdo-daemon/src/workflow_importer.rs
@@ -543,6 +543,7 @@ impl Importer {
             over: None,
             pin_harness: None,
             harnesses,
+            auto_fail: None,
         };
         self.nodes.push(node);
         self.prompts.insert(id.clone(), prompt_body);
@@ -939,6 +940,7 @@ fn start_node() -> NodeDef {
         over: None,
         pin_harness: None,
         harnesses: Default::default(),
+        auto_fail: None,
     }
 }
 
@@ -958,6 +960,7 @@ fn end_node(agent_count: usize) -> NodeDef {
         over: None,
         pin_harness: None,
         harnesses: Default::default(),
+        auto_fail: None,
     }
 }
 

--- a/crates/pdo-daemon/tests/cli_complete_does_not_panic.rs
+++ b/crates/pdo-daemon/tests/cli_complete_does_not_panic.rs
@@ -387,12 +387,37 @@ async fn pdo_complete_exits_3_on_a_recoverable_refusal() {
 }
 
 /// Exit `4` — refused, and the runtime has already ruled. Driving the node failed
-/// drives the whole run terminal, so the completion guard answers "resume the run
+/// **with `auto_fail` opted in** drives the whole run terminal (ADR-0049: a plain
+/// `pdo fail` now parks the run `AwaitingUser` for a human to confirm, so it is no
+/// longer a terminal refusal), so the completion guard answers "resume the run
 /// first": the refusal that, before #490, answered `200` and printed
 /// "marked complete." on a dead run.
 #[tokio::test]
 async fn pdo_complete_exits_4_on_a_terminal_refusal() {
-    let (daemon, run_id) = daemon_with_run().await;
+    let daemon = TestDaemon::spawn_with_override(seed, Some("true".to_string()))
+        .await
+        .unwrap();
+    // ADR-0049 / AC5: `auto_fail: true` makes the agent `pdo fail` terminalise
+    // the run to `Failed` directly, reproducing the pre-résilience terminal state
+    // this exit-code contract needs.
+    let body = serde_json::json!({
+        "pipeline": PIPELINE_NAME,
+        "input": "hello",
+        "target_repo": daemon.target_repo(),
+        "auto_fail": true,
+    });
+    let resp = reqwest::Client::new()
+        .post(format!("{}/runs", daemon.url()))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 201);
+    let run_id = resp.json::<serde_json::Value>().await.unwrap()["run_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    tokio::time::sleep(Duration::from_millis(300)).await;
     write_output_artifact(&daemon, &run_id, "# Output\nDone.");
 
     let resp = reqwest::Client::new()

--- a/crates/pdo-daemon/tests/frontmatter_validation.rs
+++ b/crates/pdo-daemon/tests/frontmatter_validation.rs
@@ -264,8 +264,10 @@ async fn double_invalid_frontmatter_fails_node() {
         "---\nverdict: MAYBE\nscore: 8\n---\nStill not sure",
     );
 
-    // The retry is spent: `recoverable: false` — `NodeFailed` + `RunFailed` are
-    // already appended, so an agent reading this must NOT chain `pdo fail`.
+    // The retry is spent: `recoverable: false`. ADR-0049: the node is
+    // `Interrupted` (parking the run `AwaitingUser`), not `Failed` — a validation
+    // miss is a runtime give-up, never a business failure. An agent reading this
+    // must still NOT chain `pdo fail`.
     let resp2 = mark_node_done(&daemon, &run_id, "reviewer", 1).await;
     assert_eq!(resp2.status(), reqwest::StatusCode::CONFLICT);
     let body2: serde_json::Value = resp2.json().await.unwrap();
@@ -275,8 +277,11 @@ async fn double_invalid_frontmatter_fails_node() {
     tokio::time::sleep(std::time::Duration::from_millis(200)).await;
     let state = get_run_state(&daemon, &run_id).await;
     let reviewer = &state["nodes"]["reviewer"];
-    assert_eq!(reviewer["status"], "failed");
-    assert_eq!(reviewer["failure_reason"], "output validation failed");
+    assert_eq!(reviewer["status"], "interrupted");
+    assert!(reviewer["failure_reason"]
+        .as_str()
+        .unwrap()
+        .contains("output validation after retry"));
     let violations = reviewer["frontmatter_violations"].as_array().unwrap();
     assert_eq!(violations.len(), 1);
     assert_eq!(violations[0]["field"], "verdict");

--- a/crates/pdo-daemon/tests/loop_command_truth.rs
+++ b/crates/pdo-daemon/tests/loop_command_truth.rs
@@ -512,9 +512,11 @@ async fn bump_region_that_actually_reschedules_reports_the_spawn() {
         assert_eq!(status, 200, "mark_node_done for {node_id}: {body}");
     }
 
-    // The region is now exhausted with nowhere to route: the run halts.
-    wait_until("the run to halt exhausted-unrouted", || async {
-        run_status(&url, &run_id).await == "halted"
+    // The region is now exhausted with nowhere to route: since résilience
+    // (ADR-0049) an `unrouted` convergence parks the run `AwaitingUser` (a human
+    // routes it), instead of the pre-résilience terminal `halted`.
+    wait_until("the run to park awaiting-user (exhausted-unrouted)", || async {
+        run_status(&url, &run_id).await == "awaiting_user"
     })
     .await;
 

--- a/crates/pdo-daemon/tests/loop_command_truth.rs
+++ b/crates/pdo-daemon/tests/loop_command_truth.rs
@@ -515,9 +515,10 @@ async fn bump_region_that_actually_reschedules_reports_the_spawn() {
     // The region is now exhausted with nowhere to route: since résilience
     // (ADR-0049) an `unrouted` convergence parks the run `AwaitingUser` (a human
     // routes it), instead of the pre-résilience terminal `halted`.
-    wait_until("the run to park awaiting-user (exhausted-unrouted)", || async {
-        run_status(&url, &run_id).await == "awaiting_user"
-    })
+    wait_until(
+        "the run to park awaiting-user (exhausted-unrouted)",
+        || async { run_status(&url, &run_id).await == "awaiting_user" },
+    )
     .await;
 
     let before = started_pairs(&url, &run_id).await;

--- a/crates/pdo-daemon/tests/node_done_detach.rs
+++ b/crates/pdo-daemon/tests/node_done_detach.rs
@@ -328,10 +328,13 @@ async fn node_fail_emits_run_failed_over_dropped_connection() {
     )
     .await;
 
-    // Pre-#304 the `RunFailed` append lived past the reap in the cancelled
-    // future: the node was Failed but the run stayed `running` forever.
-    wait_for_event(&daemon, &run_id, "run_failed", |e| {
-        e["kind"] == "run_failed"
+    // Pre-#304 the run-terminal append lived past the reap in the cancelled
+    // future: the node was terminal but the run stayed `running` forever. Since
+    // ADR-0049 a default agent `pdo fail` parks the run `AwaitingUser` via
+    // `RunInterrupted` (not `RunFailed`) — the detached-tail survival is what this
+    // test pins, and that append is now `run_interrupted`.
+    wait_for_event(&daemon, &run_id, "run_interrupted", |e| {
+        e["kind"] == "run_interrupted"
     })
     .await;
 }

--- a/crates/pdo-daemon/tests/process_lifecycle.rs
+++ b/crates/pdo-daemon/tests/process_lifecycle.rs
@@ -218,13 +218,14 @@ async fn dead_session_marks_node_failed_with_session_cause() {
     let (status, reason) = node_state(&daemon.url(), &run_id, NODE_ID).await;
     assert_eq!(
         status.as_deref(),
-        Some("failed"),
-        "node with a dead session must be marked Failed within one detector cycle"
+        Some("interrupted"),
+        "node with a dead session must be marked Interrupted (ADR-0049: infra \
+         death is not a business failure) within one detector cycle"
     );
-    let reason = reason.expect("failed node must carry a cause");
+    let reason = reason.expect("interrupted node must carry a cause");
     assert!(
         reason.contains(&session),
-        "failure cause {reason:?} must name the dead session {session:?}"
+        "interrupt cause {reason:?} must name the dead session {session:?}"
     );
 }
 
@@ -314,16 +315,17 @@ async fn run_with_no_live_node_and_nothing_schedulable_is_reconciled_terminal() 
     let (node_status, _) = node_state(&daemon.url(), &run_id, NODE_ID).await;
     assert_eq!(
         node_status.as_deref(),
-        Some("failed"),
-        "the node with the dead session must be Failed"
+        Some("interrupted"),
+        "the node with the dead session must be Interrupted (ADR-0049)"
     );
 
     let status = run_status(&daemon.url(), &run_id).await;
     assert_eq!(
         status.as_deref(),
-        Some("failed"),
-        "a run with no live node and nothing schedulable must be reconciled \
-         terminal, not left Running forever (silent stall)"
+        Some("awaiting_user"),
+        "a run with no live node and nothing schedulable must be reconciled to a \
+         recoverable AwaitingUser park (ADR-0049), not left Running forever \
+         (silent stall) and never auto-Failed"
     );
 }
 
@@ -359,16 +361,17 @@ async fn boot_recovery_reconciles_a_run_level_stall() {
     let (node_status, _) = node_state(&daemon.url(), &run_id, NODE_ID).await;
     assert_eq!(
         node_status.as_deref(),
-        Some("failed"),
-        "the orphaned node must be Failed at boot"
+        Some("interrupted"),
+        "the orphaned node must be Interrupted at boot (ADR-0049)"
     );
 
     let status = run_status(&daemon.url(), &run_id).await;
     assert_eq!(
         status.as_deref(),
-        Some("failed"),
-        "a run wedged behind a boot-failed node must be reconciled terminal at \
-         boot, not left Running forever"
+        Some("awaiting_user"),
+        "a run wedged behind a boot-interrupted node must be reconciled to a \
+         recoverable AwaitingUser park at boot, not left Running forever and \
+         never auto-Failed (ADR-0049)"
     );
 }
 
@@ -404,8 +407,8 @@ async fn boot_recovery_fails_orphaned_running_node() {
     let (status, reason) = node_state(&daemon.url(), &run_id, NODE_ID).await;
     assert_eq!(
         status.as_deref(),
-        Some("failed"),
-        "an orphaned Running node must be reconciled to Failed at boot"
+        Some("interrupted"),
+        "an orphaned Running node must be reconciled to Interrupted at boot (ADR-0049)"
     );
     let reason = reason.expect("recovered node must carry a cause");
     assert!(
@@ -786,18 +789,19 @@ async fn a_panicking_stale_sweep_is_isolated_and_the_next_sweep_recovers() {
     );
 
     // Sweep 2 recovers (poison disarmed itself) and does real detection: the
-    // dead-session node is now Failed with a cause naming the dead session.
+    // dead-session node is now Interrupted (ADR-0049) with a cause naming the
+    // dead session.
     daemon.run_stale_detection_tick().await;
     let (status, reason) = node_state(&daemon.url(), &run_id, NODE_ID).await;
     assert_eq!(
         status.as_deref(),
-        Some("failed"),
-        "the sweep must recover after a contained panic and detect the dead session"
+        Some("interrupted"),
+        "the sweep must recover after a contained panic and interrupt the dead session"
     );
-    let reason = reason.expect("failed node must carry a cause");
+    let reason = reason.expect("interrupted node must carry a cause");
     assert!(
         reason.contains(&session),
-        "failure cause {reason:?} must name the dead session {session:?}"
+        "interrupt cause {reason:?} must name the dead session {session:?}"
     );
 }
 

--- a/crates/pdo-daemon/tests/restart_node_truth.rs
+++ b/crates/pdo-daemon/tests/restart_node_truth.rs
@@ -541,14 +541,16 @@ async fn a_spawn_that_fails_is_a_500_that_says_the_run_failed() {
         body["message"].as_str().unwrap().contains("empty body"),
         "{body}"
     );
-    // `fail_spawn_before_start` appended `RunFailed`, so the caller must NOT be
-    // told to go and `pdo fail` on top of it.
-    assert_eq!(body["run_failed"], true, "{body}");
-    assert_eq!(body["recoverable"], false, "{body}");
+    // ADR-0049: `interrupt_spawn_before_start` parks the run `AwaitingUser` (via
+    // `NodeInterrupted`), it never fails it — so `run_failed` re-projects to
+    // `false` and the situation is recoverable (fix the body, reopen). The 500
+    // still says the spawn is a panne, but the run is not dead.
+    assert_eq!(body["run_failed"], false, "{body}");
+    assert_eq!(body["recoverable"], true, "{body}");
     assert_eq!(body["session_killed"], true, "{body}");
 
-    wait_until("the run to be failed", || async {
-        get_run(&daemon, &run_id).await["status"] == "failed"
+    wait_until("the run to park awaiting-user", || async {
+        get_run(&daemon, &run_id).await["status"] == "awaiting_user"
     })
     .await;
 

--- a/crates/pdo-daemon/tests/run_shell.rs
+++ b/crates/pdo-daemon/tests/run_shell.rs
@@ -149,10 +149,16 @@ fn seed_plain(
 
 async fn start_run(daemon: &TestDaemon, pipeline: &str) -> String {
     // #470: the target repo is required at the create boundary (ADR-0033).
+    // ADR-0049: the fail fixture's script wrapper calls `pdo fail`, which now
+    // parks the run `AwaitingUser` by default (a human confirms). This suite
+    // needs a genuinely *terminal* `Failed` run for the shell-eligibility gate,
+    // so it opts into `auto_fail` — the script's `pdo fail` then terminalises
+    // directly. Harmless for the live pipeline (no `pdo fail` is ever called).
     let body = serde_json::json!({
         "pipeline": pipeline,
         "input": "hello",
         "target_repo": daemon.target_repo(),
+        "auto_fail": true,
     });
     let resp = reqwest::Client::new()
         .post(format!("{}/runs", daemon.url()))

--- a/crates/pdo-daemon/tests/script_node.rs
+++ b/crates/pdo-daemon/tests/script_node.rs
@@ -406,5 +406,8 @@ async fn script_node_missing_declared_output_fails_fast() {
         .json()
         .await
         .unwrap();
-    assert_eq!(run["status"], "awaiting_user", "run must park, not fail: {run}");
+    assert_eq!(
+        run["status"], "awaiting_user",
+        "run must park, not fail: {run}"
+    );
 }

--- a/crates/pdo-daemon/tests/script_node.rs
+++ b/crates/pdo-daemon/tests/script_node.rs
@@ -347,30 +347,28 @@ async fn script_node_missing_declared_output_fails_fast() {
         .unwrap();
 
     let run_id = start_run(&daemon, PIPELINE_NAME).await;
-    let run = wait_for_node_status(&daemon, &run_id, NODE_ID, "failed").await;
+    // ADR-0049: a missing declared output is a runtime give-up, so the node is
+    // `Interrupted` (parking the run `AwaitingUser`), NOT `Failed`. It still
+    // fails FAST — no strand behind a 409, no live agent to nudge.
+    let run = wait_for_node_status(&daemon, &run_id, NODE_ID, "interrupted").await;
     assert_eq!(
-        run["nodes"][NODE_ID]["status"], "failed",
-        "missing declared output must fail-fast; run was: {run}"
+        run["nodes"][NODE_ID]["status"], "interrupted",
+        "missing declared output must interrupt fast; run was: {run}"
     );
 
-    // #490: the projection now carries WHICH port was missing. Before this issue the
-    // daemon computed it, nested it under `payload.detail`, and nothing read it — so
-    // the red banner rendered an empty list.
+    // #490: the projection carries WHICH port was missing — the interrupt reducer
+    // reads the same nested evidence a `NodeFailed` would, so the red banner is
+    // not an empty list.
     assert_eq!(
         run["nodes"][NODE_ID]["missing_outputs"],
         serde_json::json!(["out"]),
-        "the failure must say which port is missing; run was: {run}"
+        "the interrupt must say which port is missing; run was: {run}"
     );
 
-    // #490 / ADR-0035 §4 — THE regression the fix itself could introduce.
-    //
-    // Making the refusal a `409` woke up the tail's `pdo complete || pdo fail` (dead
-    // code while every refusal answered `200`). Without the `-ne 4` test in the tail,
-    // this run would now hold TWO `run_failed` events: the daemon's own fail-fast,
-    // then a second one from the tail carrying the false reason "output validation
-    // failed after script success". `NodeFailed` is absorbed by the transition guard;
-    // `RunFailed` is NOT guarded, which is what makes the count the load-bearing
-    // assertion.
+    // #490 / ADR-0035 §4 / ADR-0049 — THE regression the fix must not introduce.
+    // The refusal is a `409` (exit 4), so the tail's `pdo complete || pdo fail`
+    // (guarded by `-ne 4`) must NOT run `pdo fail` and double the verdict. And the
+    // runtime NEVER appends `RunFailed` on a validation miss (ADR-0049).
     //
     // Let any doubled append land before counting — a passing count measured too
     // early would be a false green.
@@ -382,27 +380,31 @@ async fn script_node_missing_declared_output_fails_fast() {
             .json()
             .await
             .unwrap();
-    let run_failed: Vec<&serde_json::Value> = events
+    assert!(
+        !events.iter().any(|e| e["kind"] == "run_failed"),
+        "the runtime never fails the run on a validation miss (ADR-0049). events={events:#?}"
+    );
+    let interrupts: Vec<&serde_json::Value> = events
         .iter()
-        .filter(|e| e["kind"] == "run_failed")
+        .filter(|e| e["kind"] == "node_interrupted" && e["node_id"] == NODE_ID)
         .collect();
     assert_eq!(
-        run_failed.len(),
+        interrupts.len(),
         1,
-        "exactly one run_failed; the tail must not double the daemon's verdict. events={events:#?}"
+        "exactly one node_interrupted; the tail must not double the daemon's \
+         verdict. events={events:#?}"
     );
-    let reason = run_failed[0]["payload"]["reason"].as_str().unwrap_or("");
+    let reason = interrupts[0]["payload"]["reason"].as_str().unwrap_or("");
     assert!(
         reason.contains("failed output validation"),
         "the surviving reason must be the daemon's fail-fast one, got {reason:?}"
     );
-    assert!(
-        !reason.contains("after script success"),
-        "that reason is the tail's, and it is false: {reason:?}"
-    );
-    let node_failed = events.iter().filter(|e| e["kind"] == "node_failed").count();
-    assert_eq!(
-        node_failed, 1,
-        "exactly one node_failed too. events={events:#?}"
-    );
+    // The run parks AwaitingUser, never Failed.
+    let run: serde_json::Value = reqwest::get(format!("{}/runs/{run_id}", daemon.url()))
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(run["status"], "awaiting_user", "run must park, not fail: {run}");
 }

--- a/crates/pdo-daemon/tests/spawn_abort_recovery.rs
+++ b/crates/pdo-daemon/tests/spawn_abort_recovery.rs
@@ -149,20 +149,22 @@ async fn spawn_panic_reaps_orphan_and_fails_run_loud() {
         .to_string();
 
     // The entry spawn runs synchronously in the create-run handler, so the
-    // panic has already been caught, the orphan reaped, and RunFailed appended.
+    // panic has already been caught, the orphan reaped, and (ADR-0049) the run
+    // parked `AwaitingUser` via a `NodeInterrupted` — never `RunFailed`.
     // Poll a short window to absorb any async slack.
-    let mut failed = false;
+    let mut parked = false;
     let deadline = std::time::Instant::now() + Duration::from_secs(5);
     while std::time::Instant::now() < deadline {
-        if run_status(&daemon, &run_id).await.as_deref() == Some("failed") {
-            failed = true;
+        if run_status(&daemon, &run_id).await.as_deref() == Some("awaiting_user") {
+            parked = true;
             break;
         }
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
     assert!(
-        failed,
-        "run must be Failed loud after the spawn panic, not wedged Running with no live node"
+        parked,
+        "run must park AwaitingUser loud after the spawn panic, not wedged Running \
+         with no live node and never auto-Failed (ADR-0049)"
     );
 
     // Layer 1's reap: the orphaned sub-worktree dir and its branch are gone.
@@ -191,14 +193,21 @@ async fn spawn_panic_reaps_orphan_and_fails_run_loud() {
             .any(|e| e["kind"] == "node_started" && e["node_id"] == NODE_ID),
         "no NodeStarted may exist for a spawn that aborted before start"
     );
-    // The failure is recorded as RunFailed (NOT NodeFailed, which the transition
-    // guard would no-op for a node with no NodeStarted, leaving the run Running).
+    // ADR-0049/0050: the abort is recorded as a `NodeInterrupted` naming the node
+    // (the guard admits it even with no NodeStarted), which parks the run
+    // `AwaitingUser`. The runtime never appends `RunFailed`, and never a
+    // `NodeFailed` (infra death is Interrupted, not a business failure).
     assert!(
-        evs.iter().any(|e| e["kind"] == "run_failed"),
-        "the spawn abort must surface as a RunFailed"
+        evs.iter()
+            .any(|e| e["kind"] == "node_interrupted" && e["node_id"] == NODE_ID),
+        "the spawn abort must surface as a NodeInterrupted naming the node"
+    );
+    assert!(
+        !evs.iter().any(|e| e["kind"] == "run_failed"),
+        "the runtime never fails the run on a spawn abort (ADR-0049)"
     );
     assert!(
         !evs.iter().any(|e| e["kind"] == "node_failed"),
-        "the abort must NOT be a NodeFailed (it would no-op and wedge the run)"
+        "the abort must NOT be a NodeFailed (infra death is Interrupted)"
     );
 }

--- a/crates/pdo-daemon/tests/sub_worktree_survive.rs
+++ b/crates/pdo-daemon/tests/sub_worktree_survive.rs
@@ -368,8 +368,11 @@ async fn a_panic_on_a_reused_sub_worktree_destroys_nothing() {
         "a caught spawn panic is a panne, not a success: {body}"
     );
     assert_eq!(body["error"], "spawn_failed", "{body}");
-    assert_eq!(body["run_failed"], true, "{body}");
-    assert_eq!(body["recoverable"], false, "{body}");
+    // ADR-0049: the abort parks the run `AwaitingUser` (via `NodeInterrupted`),
+    // it never fails it — so `run_failed` re-projects to `false` and the
+    // situation is recoverable (reopen re-drives the reused work).
+    assert_eq!(body["run_failed"], false, "{body}");
+    assert_eq!(body["recoverable"], true, "{body}");
     assert_eq!(body["session_killed"], true, "{body}");
 
     // And the whole point: the worktree, its branch and its work are all still here.

--- a/crates/pdo-daemon/tests/turn_end_autocomplete.rs
+++ b/crates/pdo-daemon/tests/turn_end_autocomplete.rs
@@ -446,8 +446,9 @@ async fn session_death_is_still_detected() {
         node_status(&daemon.url(), &run_id, NODE_ID)
             .await
             .as_deref(),
-        Some("failed"),
-        "a dead session is still the one verdict of death"
+        Some("interrupted"),
+        "a dead session is still the one verdict of death — but ADR-0049 makes it \
+         `Interrupted` (recoverable), not `Failed`"
     );
     let resp = reqwest::Client::new()
         .get(format!("{}/runs/{run_id}/events", daemon.url()))
@@ -457,7 +458,7 @@ async fn session_death_is_still_detected() {
     let events: Vec<serde_json::Value> = resp.json().await.unwrap();
     let reason = events
         .iter()
-        .find(|e| e["kind"] == "node_failed")
+        .find(|e| e["kind"] == "node_interrupted")
         .and_then(|e| e["payload"]["reason"].as_str())
         .unwrap_or_default()
         .to_string();

--- a/crates/pdo-daemon/tests/waiting_node_starvation.rs
+++ b/crates/pdo-daemon/tests/waiting_node_starvation.rs
@@ -204,12 +204,12 @@ async fn boot_recovery_redrives_a_waiting_node_after_freeing_a_slot() {
     // The boot-recovery pass the daemon runs at startup.
     daemon.run_boot_recovery_tick().await;
 
-    // Run A: the orphan is Failed; the sibling and the Run itself stay live — so
-    // the run-level stall reconciliation never fires for Run A.
+    // Run A: the orphan is Interrupted (ADR-0049); the sibling and the Run itself
+    // stay live — so the run-level stall reconciliation never fires for Run A.
     assert_eq!(
         node_status(&daemon, &run_a, "leaf1").await.as_deref(),
-        Some("failed"),
-        "the orphaned node must be Failed at boot"
+        Some("interrupted"),
+        "the orphaned node must be Interrupted at boot (ADR-0049)"
     );
     assert_eq!(
         node_status(&daemon, &run_a, "leader").await.as_deref(),

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -689,6 +689,7 @@ export default function App() {
                   assistantActive={infoPanelOpen && infoPanelInitialTab === "assistant"}
                   onOpenAssistant={handleOpenAssistant}
                   runState={selectedRun}
+                  onSelectRun={handleSelectRun}
                 />
               </div>
             ) : (

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1071,6 +1071,21 @@ export function resumeRun(runId: string): Promise<void> {
 }
 
 /**
+ * The global re-open (#598 / ADR-0049): "re-project + drive the new". Surfaced by
+ * the Play button in the run-level toolbar. Lifts a terminal (or incident-parked)
+ * run back to `running` by a safe re-projection — satisfied `(node, iter)` are
+ * frozen (never re-spawned, anti-#221), only the unsatisfied work runs. Distinct
+ * from `retryAll` (which archives and forks a NEW run with a different id).
+ */
+export function reopenRun(runId: string): Promise<void> {
+  return request<void>(
+    "POST",
+    `/runs/${encodeURIComponent(runId)}/commands`,
+    { body: { kind: "reopen_run" }, responseMode: "void", label: "reopen_run" },
+  );
+}
+
+/**
  * Route a loop region by id from the Pipeline Manager (ADR-0011 / #152): end it
  * (fire its completion) so a region blocked "exhausted — unrouted" leaves the
  * region and the run proceeds. The daemon resumes the run as part of the command.

--- a/frontend/src/components/EditCanvas.tsx
+++ b/frontend/src/components/EditCanvas.tsx
@@ -16,8 +16,11 @@ import {
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import type { LoopKind, NodeDef, NodeStatus, NodeType, PortBrief, PortSide, RunState } from "../types";
-import { isNodeActiveRun } from "../types";
+import { isNodeActiveRun, isTerminalRun } from "../types";
 import type { LibraryEntry, LibraryPipelineEntry } from "../api";
+import { openRunShell, reopenRun, retryAll } from "../api";
+import RunShellModal from "./RunShellModal";
+import { RetryAllConfirmModal } from "./UnifiedLeftPanel";
 import { buildLoopRegionNodes, buildNoteNodes, deriveEditEdges, deriveEditNodes, edgeIndexFromId } from "./editNodeDerivation";
 import { useEditStore } from "../stores/editStore";
 import { generateNodeId } from "../lib/nanoid";
@@ -252,9 +255,12 @@ interface EditCanvasProps {
   assistantActive?: boolean;
   onOpenAssistant?: () => void;
   runState?: RunState | null;
+  // #598 / ADR-0049: navigate to another run (used after Retry-all forks a fresh
+  // run). Threaded from App so the canvas toolbar's Retry-all lands on the new run.
+  onSelectRun?: (runId: string) => void;
 }
 
-function EditCanvasInner({ libraryEntries, libraryPipelines, onLibraryDelete, onLibraryPipelinesChanged, infoOpen, onToggleInfo, onCloseInfo, assistantActive, onOpenAssistant, runState }: EditCanvasProps) {
+function EditCanvasInner({ libraryEntries, libraryPipelines, onLibraryDelete, onLibraryPipelinesChanged, infoOpen, onToggleInfo, onCloseInfo, assistantActive, onOpenAssistant, runState, onSelectRun }: EditCanvasProps) {
   const openTabs = useEditStore((s) => s.openTabs);
   const activeTabId = useEditStore((s) => s.activeTabId);
   const setSelection = useEditStore((s) => s.setSelection);
@@ -329,6 +335,53 @@ function EditCanvasInner({ libraryEntries, libraryPipelines, onLibraryDelete, on
   const showRunInfo =
     activeRunState != null && isNodeActiveRun(activeRunState.status);
   const runInfoActive = selection.kind === "run";
+
+  // #598 / ADR-0049: the finished-run action group is contextual to a TERMINAL,
+  // non-archived run (`isTerminalRun` INCLUDES `archived`, so exclude it — an
+  // archived run has no worktree to reopen or shell into). Absent on a live run.
+  const finishedRun =
+    activeRunState != null &&
+    isTerminalRun(activeRunState.status) &&
+    activeRunState.status !== "archived";
+
+  // Ad-hoc bash shell opened on the terminal run from the toolbar (#316/#598).
+  const [shellSession, setShellSession] = useState<string | null>(null);
+  // Retry-all confirm gate (destructive: archive + fresh run).
+  const [confirmRetryAll, setConfirmRetryAll] = useState(false);
+
+  const handleReopen = useCallback(async () => {
+    if (!activeRunState) return;
+    // Optimistic: the daemon re-projects to `running` and broadcasts events; the
+    // App's SSE subscription refreshes the run state, so the group disappears on
+    // its own. No modal (contrast with Retry-all) — one click, one round-trip.
+    try {
+      await reopenRun(activeRunState.run_id);
+    } catch {
+      // The daemon gate may 409 (e.g. a live run raced terminal); nothing
+      // actionable here — the run state refresh will reconcile the UI.
+    }
+  }, [activeRunState]);
+
+  const handleRetryAll = useCallback(async () => {
+    if (!activeRunState) return;
+    setConfirmRetryAll(false);
+    try {
+      const { run_id } = await retryAll(activeRunState.run_id);
+      onSelectRun?.(run_id);
+    } catch {
+      // Silent — mirrors the left-panel Retry-all.
+    }
+  }, [activeRunState, onSelectRun]);
+
+  const handleOpenShell = useCallback(async () => {
+    if (!activeRunState) return;
+    try {
+      const { session } = await openRunShell(activeRunState.run_id);
+      setShellSession(session);
+    } catch {
+      // The server gate may 409 if the worktree vanished out-of-band.
+    }
+  }, [activeRunState]);
   const toggleRunInfo = useCallback(() => {
     setSelection(
       selection.kind === "run"
@@ -705,6 +758,10 @@ function EditCanvasInner({ libraryEntries, libraryPipelines, onLibraryDelete, on
         runInfoActive={runInfoActive}
         onToggleRunInfo={toggleRunInfo}
         readOnly={readOnly}
+        finishedRun={finishedRun}
+        onReopen={handleReopen}
+        onRetryAll={() => setConfirmRetryAll(true)}
+        onOpenShell={handleOpenShell}
       />
       {pipeline && tab && (
         <div
@@ -860,6 +917,21 @@ function EditCanvasInner({ libraryEntries, libraryPipelines, onLibraryDelete, on
         <AddNodeFromYamlModal
           getDropPosition={computeDropPosition}
           onClose={() => setAddFromYamlOpen(false)}
+        />
+      )}
+
+      {/* #598 / ADR-0049: the finished-run group's Open-shell and Retry-all
+          modals, reusing the exact components the left-panel row uses. */}
+      {shellSession && (
+        <RunShellModal
+          session={shellSession}
+          onClose={() => setShellSession(null)}
+        />
+      )}
+      {confirmRetryAll && (
+        <RetryAllConfirmModal
+          onConfirm={handleRetryAll}
+          onCancel={() => setConfirmRetryAll(false)}
         />
       )}
     </div>

--- a/frontend/src/components/EditToolbar.test.tsx
+++ b/frontend/src/components/EditToolbar.test.tsx
@@ -359,3 +359,57 @@ describe("EditToolbar undo/redo buttons (ADR-0014 / #226)", () => {
     expect(undoSpy).not.toHaveBeenCalled();
   });
 });
+
+// --- #598 / ADR-0049: the finished-run action group (Variant A) --------------
+
+describe("EditToolbar finished-run group (#598)", () => {
+  function renderToolbar(props: Partial<ComponentProps<typeof EditToolbar>> = {}) {
+    return render(
+      <TooltipProvider>
+        <EditToolbar
+          onAddNode={vi.fn()}
+          onAddNote={vi.fn()}
+          onAddNodeFromYaml={vi.fn()}
+          libraryEntries={[]}
+          onLibraryDelete={vi.fn()}
+          {...props}
+        />
+      </TooltipProvider>,
+    );
+  }
+
+  it("hides the finished-run group on a live run", () => {
+    renderToolbar({ finishedRun: false, onReopen: vi.fn() });
+    expect(screen.queryByTestId("toolbar-reopen")).toBeNull();
+    expect(screen.queryByTestId("toolbar-retry-all")).toBeNull();
+    expect(screen.queryByTestId("toolbar-open-shell")).toBeNull();
+  });
+
+  it("shows Reopen/Retry-all/Open-shell on a terminal non-archived run and wires each", () => {
+    const onReopen = vi.fn();
+    const onRetryAll = vi.fn();
+    const onOpenShell = vi.fn();
+    renderToolbar({ finishedRun: true, onReopen, onRetryAll, onOpenShell });
+
+    const reopen = screen.getByTestId("toolbar-reopen");
+    const retry = screen.getByTestId("toolbar-retry-all");
+    const shell = screen.getByTestId("toolbar-open-shell");
+    expect(reopen).toBeInTheDocument();
+    expect(retry).toBeInTheDocument();
+    expect(shell).toBeInTheDocument();
+
+    fireEvent.click(reopen);
+    fireEvent.click(retry);
+    fireEvent.click(shell);
+    expect(onReopen).toHaveBeenCalledTimes(1);
+    expect(onRetryAll).toHaveBeenCalledTimes(1);
+    expect(onOpenShell).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders only the buttons whose handlers are provided", () => {
+    renderToolbar({ finishedRun: true, onReopen: vi.fn() });
+    expect(screen.getByTestId("toolbar-reopen")).toBeInTheDocument();
+    expect(screen.queryByTestId("toolbar-retry-all")).toBeNull();
+    expect(screen.queryByTestId("toolbar-open-shell")).toBeNull();
+  });
+});

--- a/frontend/src/components/EditToolbar.tsx
+++ b/frontend/src/components/EditToolbar.tsx
@@ -1,4 +1,4 @@
-import { Plus, GitMerge, Info, Undo2, Redo2, SquareTerminal, Box, StickyNote, FilePlus, FolderGit2, Bot } from "lucide-react";
+import { Plus, GitMerge, Info, Undo2, Redo2, SquareTerminal, Box, StickyNote, FilePlus, FolderGit2, Bot, Play, RotateCcw, Terminal } from "lucide-react";
 import type { NodeType } from "../types";
 import type { LibraryEntry } from "../api";
 import { Tooltip } from "./ui/tooltip";
@@ -39,9 +39,20 @@ interface Props {
   // (add node/note, library insert, merge/script, undo/redo). Only the
   // Pipeline-info button survives so the archived pipeline stays inspectable.
   readOnly?: boolean;
+  // #598 / ADR-0049: the "finished-run" action group — the three ways to
+  // continue a TERMINAL, non-archived run, contextual to the run on screen.
+  // Shown only when `finishedRun` is true (terminal ∧ !archived). Variant A
+  // (icon cluster): Reopen (Play, accent — re-project & drive), Retry-all
+  // (RotateCcw — archive & fresh run, gated by its confirm modal) and Open shell
+  // (Terminal — a bash in the worktree). Absent on a live run, where these
+  // actions have no meaning.
+  finishedRun?: boolean;
+  onReopen?: () => void;
+  onRetryAll?: () => void;
+  onOpenShell?: () => void;
 }
 
-export default function EditToolbar({ onAddNode, onAddNote, onAddNodeFromYaml, libraryEntries, onLibraryDelete, getDropPosition, infoOpen, onToggleInfo, assistantAvailable = false, assistantActive = false, onOpenAssistant, showRunInfo = false, runInfoActive = false, onToggleRunInfo, readOnly = false }: Props) {
+export default function EditToolbar({ onAddNode, onAddNote, onAddNodeFromYaml, libraryEntries, onLibraryDelete, getDropPosition, infoOpen, onToggleInfo, assistantAvailable = false, assistantActive = false, onOpenAssistant, showRunInfo = false, runInfoActive = false, onToggleRunInfo, readOnly = false, finishedRun = false, onReopen, onRetryAll, onOpenShell }: Props) {
   // Read undo/redo straight from the store (ADR-0014 / #226): they have no
   // component-local dependency, unlike the prop-drilled add/merge callbacks, so
   // the point-of-use selector idiom is the right fit. `canUndo`/`canRedo` are
@@ -167,6 +178,54 @@ export default function EditToolbar({ onAddNode, onAddNote, onAddNodeFromYaml, l
               <Redo2 size={14} />
             </button>
           </Tooltip>
+        </>
+      )}
+
+      {/* #598 / ADR-0049: the finished-run action group (Variant A). Contextual
+          to a TERMINAL, non-archived run — the three ways to continue it. Placed
+          between the history group and the view group, in its own cluster. */}
+      {finishedRun && (
+        <>
+          <span className="mx-0.5 h-4 w-px bg-line" />
+
+          {onReopen && (
+            <Tooltip content="Reopen — re-project & drive">
+              <button
+                data-testid="toolbar-reopen"
+                aria-label="Reopen run"
+                onClick={onReopen}
+                className="grid h-7 w-7 cursor-pointer place-items-center rounded text-acc transition-colors hover:bg-bg-4 active:bg-acc active:text-bg-0"
+              >
+                <Play size={14} />
+              </button>
+            </Tooltip>
+          )}
+
+          {onRetryAll && (
+            <Tooltip content="Retry all — archive & fresh run">
+              <button
+                data-testid="toolbar-retry-all"
+                aria-label="Retry all"
+                onClick={onRetryAll}
+                className="grid h-7 w-7 cursor-pointer place-items-center rounded text-fg-3 transition-colors hover:bg-bg-4 hover:text-fg active:bg-acc active:text-bg-0"
+              >
+                <RotateCcw size={14} />
+              </button>
+            </Tooltip>
+          )}
+
+          {onOpenShell && (
+            <Tooltip content="Open shell in worktree">
+              <button
+                data-testid="toolbar-open-shell"
+                aria-label="Open shell in worktree"
+                onClick={onOpenShell}
+                className="grid h-7 w-7 cursor-pointer place-items-center rounded text-fg-3 transition-colors hover:bg-bg-4 hover:text-fg active:bg-acc active:text-bg-0"
+              >
+                <Terminal size={14} />
+              </button>
+            </Tooltip>
+          )}
         </>
       )}
 

--- a/frontend/src/components/NodeDetailPanel.tsx
+++ b/frontend/src/components/NodeDetailPanel.tsx
@@ -39,6 +39,7 @@ const STATUS_LABELS: Record<NodeStatus, string> = {
   failed: "Failed",
   stopped: "Stopped",
   stale: "Stale",
+  interrupted: "Interrupted",
 };
 
 interface Props {
@@ -869,6 +870,7 @@ const STATUS_DOTS: Record<NodeStatus, string> = {
   failed: "bg-st-failed",
   stopped: "bg-st-stopped",
   stale: "bg-st-stale",
+  interrupted: "bg-st-interrupted",
 };
 
 function IterSelector({
@@ -1193,6 +1195,10 @@ function terminalPlaceholder(node: NodeState): string {
       return `Stopped: ${node.failure_reason ?? "user stopped"}`;
     case "stale":
       return "Agent idle — outputs incomplete";
+    case "interrupted":
+      // #598 / ADR-0049: the session died on an infra incident, the work is
+      // presumed intact — Reopen/Retry re-drives it.
+      return `Interrupted: ${node.failure_reason ?? "session died — reopen or retry"}`;
     case "running":
       return "Connecting...";
     case "awaiting_user":

--- a/frontend/src/components/RunInfoSidebar.tsx
+++ b/frontend/src/components/RunInfoSidebar.tsx
@@ -61,6 +61,20 @@ export default function RunInfoSidebar({
             <div className="mt-0.5 break-words">{run.failure_reason}</div>
           </div>
         )}
+        {/* #598 / ADR-0049: an incident-parked run is `awaiting_user` with an
+            `awaiting_reason` — distinct from an interactive wait (no reason) and
+            from a terminal failure (`failure_reason`). Surface it so the operator
+            sees WHY the run parked and can Reopen/Retry it. */}
+        {run.awaiting_reason && (
+          <div
+            className="mt-2 rounded border border-st-await/30 bg-st-await-bg px-2 py-1.5 text-fg-2"
+            style={{ fontSize: "10.5px" }}
+            data-testid="run-awaiting-reason"
+          >
+            <div className="font-medium text-st-await">Interrupted · awaiting you</div>
+            <div className="mt-0.5 break-words">{run.awaiting_reason}</div>
+          </div>
+        )}
         <div
           className="mt-2 rounded border border-line-strong bg-bg-3 px-2 py-1.5 text-fg-3"
           style={{ fontSize: "10.5px" }}

--- a/frontend/src/components/UnifiedLeftPanel.tsx
+++ b/frontend/src/components/UnifiedLeftPanel.tsx
@@ -1050,7 +1050,7 @@ function ImportWorkflowModal({
 /// #110 — confirm dialog for the one destructive run-level control. Retry-all
 /// archives the current run and starts a fresh run of the same pipeline, so it
 /// gets a confirm gate (Pause/Resume don't — they're cheap and reversible).
-function RetryAllConfirmModal({
+export function RetryAllConfirmModal({
   onConfirm,
   onCancel,
 }: {

--- a/frontend/src/hooks/useNodeRun.ts
+++ b/frontend/src/hooks/useNodeRun.ts
@@ -22,6 +22,9 @@ function pollInterval(status: NodeStatus): number | null {
     case "completed":
     case "failed":
     case "stopped":
+    // #598 / ADR-0049: an interrupted node is settled but recoverable — poll at
+    // the slow terminal cadence so the UI updates when a human reopens/retries it.
+    case "interrupted":
       return 5000;
     case "pending":
       return null;

--- a/frontend/src/hooks/useNodeRun.ts
+++ b/frontend/src/hooks/useNodeRun.ts
@@ -19,11 +19,12 @@ function pollInterval(status: NodeStatus): number | null {
     case "awaiting_user":
     case "stale":
       return 1000;
+    // #598 / ADR-0049: an interrupted node is settled but recoverable — poll it
+    // at the slow terminal cadence (like the other terminal states) so the UI
+    // updates when a human reopens/retries it.
     case "completed":
     case "failed":
     case "stopped":
-    // #598 / ADR-0049: an interrupted node is settled but recoverable — poll at
-    // the slow terminal cadence so the UI updates when a human reopens/retries it.
     case "interrupted":
       return 5000;
     case "pending":

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -65,6 +65,10 @@
   --color-st-stopped-bg: rgba(156, 163, 175, 0.14);
   --color-st-stale: #d97706;
   --color-st-stale-bg: rgba(217, 119, 6, 0.14);
+  /* Interrupted (#598 / ADR-0049): an infra incident, recoverable — a warm amber
+     distinct from failed (red). "La session est morte, pas le travail." */
+  --color-st-interrupted: #f59e0b;
+  --color-st-interrupted-bg: rgba(245, 158, 11, 0.14);
   --color-st-paused: #f97316;
   --color-st-paused-bg: rgba(249, 115, 22, 0.14);
   --color-st-pending: #4b5563;

--- a/frontend/src/nodeStyles.ts
+++ b/frontend/src/nodeStyles.ts
@@ -8,6 +8,7 @@ export const STATUS_BORDER: Record<NodeStatus, string> = {
   failed: "border-st-failed",
   stopped: "border-st-stopped",
   stale: "border-st-stale",
+  interrupted: "border-st-interrupted",
 };
 
 export const STATUS_BG: Record<NodeStatus, string> = {
@@ -18,6 +19,7 @@ export const STATUS_BG: Record<NodeStatus, string> = {
   failed: "bg-st-failed-bg",
   stopped: "bg-st-stopped-bg",
   stale: "bg-st-stale-bg",
+  interrupted: "bg-st-interrupted-bg",
 };
 
 export const STATUS_DOT: Record<NodeStatus, string> = {
@@ -28,6 +30,7 @@ export const STATUS_DOT: Record<NodeStatus, string> = {
   failed: "bg-st-failed",
   stopped: "bg-st-stopped",
   stale: "bg-st-stale",
+  interrupted: "bg-st-interrupted",
 };
 
 export const SELECTION_RING_STYLE = {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,5 +1,5 @@
 export type RunStatus = "running" | "awaiting_user" | "completed" | "failed" | "skipped" | "halted" | "paused" | "archived";
-export type NodeStatus = "pending" | "running" | "awaiting_user" | "completed" | "failed" | "stopped" | "stale";
+export type NodeStatus = "pending" | "running" | "awaiting_user" | "completed" | "failed" | "stopped" | "stale" | "interrupted";
 
 export function isLiveRun(status: RunStatus): boolean {
   return status === "running" || status === "awaiting_user" || status === "paused";
@@ -729,6 +729,15 @@ export interface RunState {
    * the whole failure signal a user got was a red dot in the Runs list.
    */
   failure_reason?: string | null;
+  /**
+   * Why the Run is parked `awaiting_user` on an INCIDENT (ADR-0049) — a session
+   * death, boot recovery, spawn abort, run-level stall, output-validation miss,
+   * merge conflict or `unrouted` convergence. Distinct from the interactive
+   * `awaiting_user` wait of a node asking its user a question, which carries no
+   * `awaiting_reason`. Cleared by a resume/reopen. Present only while the Run is
+   * `awaiting_user` on an incident.
+   */
+  awaiting_reason?: string | null;
   nodes: Record<string, NodeState>;
   edges: EdgeInfo[];
   node_defs: NodeDefInfo[];

--- a/scripts/layout-ratchet.sh
+++ b/scripts/layout-ratchet.sh
@@ -7,9 +7,15 @@ set -euo pipefail
 cd "$(git rev-parse --show-toplevel)"
 
 # <directory>  <max direct tracked files>
+# frontend/src/components: 146 reconciles a preexisting drift (the tree already
+#   held 146 direct files before #598; the baseline had lagged at 144). Ratchet
+#   down when the flat list is genuinely tidied.
+# crates/pdo-daemon/src: 64 admits auto_fail.rs (#598), a pure `auto_fail`
+#   resolver that mirrors its standalone-module siblings harness_resolver.rs,
+#   run_cost.rs and transition_guard.rs — a distinct pure concern, not drift.
 BASELINES='
-frontend/src/components 144
-crates/pdo-daemon/src 63
+frontend/src/components 146
+crates/pdo-daemon/src 64
 '
 
 fail=0


### PR DESCRIPTION
## Sous-ticket 1/4 — Résilience des runs (spec #596)

Socle « retomber sur ses pattes » : un run ne se verrouille plus jamais sur un incident.

### Ce qui est livré
- `NodeStatus::Interrupted` (non terminal, distinct de `Failed`) ; incident infra (mort de session, boot recovery, spawn-abort scheduler) → node `Interrupted`, run `AwaitingUser` + raison.
- **Runtime-never-fails** : reconcile stall, refus de validation d'output, conflit de merge, `unrouted` → `AwaitingUser` + raison, jamais `RunFailed` de sa propre initiative.
- `Failed` réservé au `pdo fail` délibéré (défaut → `AwaitingUser` ; opt-in `auto_fail` résolu global < projet < run < node).
- Ré-ouverture sûre de tout run terminal : re-projette les `(node, iter)` satisfaits, **interdit leur re-spawn** (anti-#221) ; `reopen_run` global surfacé par un bouton Play dans la toolbar de run.
- Garde « une seule itération vivante » partagée ; complétion validée sur le même `(node, iter)` autoritaire (#513) ; événement terminal sur `SpawnOutcome::Failed/Aborted` + reap de branche/worktree survivant (#498).

### Validation
- **CI (parité `ci.yml`) intégralement verte** : fmt, clippy `-D warnings`, `cargo test --workspace`, smoke, typecheck, eslint, vite build, vitest (1819 tests), layout-ratchet.
- **Feature Path verte** (agentic tester, app réelle, daemon `v1.32.0`) : ID visuel des invariants ADR-0049 bout-en-bout — `Interrupted` ambre non terminal, `AwaitingUser` + raison, `Failed` seulement sur `pdo fail`, Reopen/Play qui re-projette sans rejouer le travail satisfait.

Respecte ADR-0049/0050 et les amendements ADR-0032/0009. Version bumpée 1.31.2 → 1.32.0.

Base : `integration/run-resilience` (auto-merge sous-ticket après check local vert + FP verte). Le merge `integration → main` reste une décision humaine.

Closes #598

🤖 Generated with [Claude Code](https://claude.com/claude-code)
