### PR TITLE
build(release): définir [profile.dist] (déblocage release dist)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,3 +78,11 @@ github-build-setup = "../build-setup.yml"
 install-path = "~/.local/bin"
 # Les PR ne construisent que le plan ; rien ne publie hors tag `v*`.
 pr-run-mode = "plan"
+
+# Profil de build utilisé par `dist build` (`cargo build --profile dist`). Requis :
+# sans lui, la release échoue avec « error: profile `dist` is not defined ». Normalement
+# posé par `dist init` ; ici la config a été écrite à la main. Standard dist : hérite de
+# `release` (ce que l'ancien install.sh shippait) + thin LTO.
+[profile.dist]
+inherits = "release"
+lto = "thin"


### PR DESCRIPTION
La première release dist (`v1.31.2`) a échoué sur les 4 cibles :

```
error: profile `dist` is not defined
```

`dist build` compile avec `cargo build --profile dist`. Ce profil est normalement ajouté à `Cargo.toml` par `dist init` ; la config de #605 ayant été écrite à la main puis générée via `dist generate`, le profil manquait.

Fix : `[profile.dist]` standard (`inherits = "release"` + `lto = "thin"`). Validé localement — cargo reconnaît le profil et compile.

Après merge : re-tag `v1.31.2` sur le HEAD corrigé pour relancer dist → release GitHub + formule Homebrew.

🤖 Generated with [Claude Code](https://claude.com/claude-code)