### PR TITLE
feat(harnais): dispatch des cinq capacités (#613) — 1.36.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "1.35.0"
+version = "1.36.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "1.35.0"
+version = "1.36.0"
 license = "MIT"
 description = "Prompt-Driven Orchestrator — a local daemon that runs and supervises agentic coding pipelines"
 repository = "https://github.com/Loulen/prompt-driven-orchestrator"

--- a/crates/pdo-daemon/src/harness_probes.rs
+++ b/crates/pdo-daemon/src/harness_probes.rs
@@ -20,14 +20,37 @@
 //! carry a catch-all arm. Here it costs nothing — an unknown name simply does not
 //! match, and the caller reads "absent" off the `None`.
 //!
+//! ## A capability is a **dispatch point**, not a presence guard (ADR-0051)
+//!
+//! Each capability is the site where the **implementation of the resolved harness
+//! is chosen** — not a boolean the caller reads before running `claude`'s function
+//! anyway. So the trait carries **behaviour**, not only markers: the sweep asks
+//! [`HarnessProbes::classify_turn_ended`] / [`HarnessProbes::detect_usage_limit`] /
+//! [`HarnessProbes::resolve_transcript`], and gets *this harness's* answer. The
+//! claude-proper functions (transcript resolution, the turn-state parser, the
+//! usage-limit anchors) are `claude`'s implementation of these methods — no longer
+//! reachable from a generic consumer, which holds a `&dyn HarnessProbes` and never
+//! names them. A harness that declares an implementation gets **its** behaviour;
+//! the regression ADR-0051 exists to kill (declare a variant, silently read
+//! claude's paths) is now impossible.
+//!
+//! [`resolved`] is **total** — every name resolves to a `&'static dyn HarnessProbes`
+//! ([`ClaudeProbes`] for `claude`, [`NullProbes`] for a data-declared harness) — so
+//! there is always a dispatch, and "absent" is a **method returning `None`/`false`**,
+//! distinguishable from a missing dispatch (ADR-0051 §2).
+//!
 //! ## What "absent is said, never supplied" buys each caller
 //! - **cost** ([`crate::run_cost`]): a harness with no [`HarnessProbes::cost_source`]
 //!   contributes "—" **and a reason naming it**, never `$0`, never a silent
 //!   `partial` — the same vein as `unpriced_models` (#425).
 //! - **turn-end / usage-limit** ([`crate::stale_detector`]): the two sweep probes
-//!   are **gated** on [`HarnessProbes::turn_end_substrate`] /
-//!   [`HarnessProbes::usage_limit_anchor`]. Absent ⇒ the probe does not run, and
-//!   no node is ever auto-completed on an invented heuristic.
+//!   dispatch through [`turn_ended`] / [`usage_limit_shown`], gated on
+//!   [`HarnessProbes::turn_end_substrate`] / [`HarnessProbes::usage_limit_anchor`].
+//!   Absent ⇒ the probe does not run, and no node is ever auto-completed on an
+//!   invented heuristic, nor its pane matched against another harness's menu.
+//! - **turn-end setting** ([`crate::node_spawn`]): enabling turn-end completion on a
+//!   harness with no substrate is **said once** ([`turn_end_absence_note`]) rather
+//!   than being a silent no-op.
 //! - **sandbox** ([`crate::node_spawn`]): a sandboxed Run on a harness with no
 //!   [`HarnessProbes::staging_floor`] is **said once, visibly** — it holds only by
 //!   the user's image and the profile's `$HOME` exceptions, without the plancher's
@@ -37,6 +60,7 @@
 //! launch** (a launch is data — the argv template of [`crate::harness_registry`]).
 
 use crate::harness_registry;
+use std::path::{Path, PathBuf};
 
 /// A harness's cost source — how PDO turns a live Run into a dollar figure.
 ///
@@ -132,6 +156,47 @@ pub(crate) trait HarnessProbes: Sync {
     fn staging_floor(&self) -> Option<StagingFloor> {
         None
     }
+
+    // --- the behaviour behind the markers (ADR-0051 dispatch points) ---------
+    //
+    // These are the methods a generic consumer actually calls. The default is
+    // "absent" — a data-declared harness ([`NullProbes`]) resolves no transcript,
+    // never constates an end of turn, never matches a usage-limit menu — so a
+    // caller that dispatches through [`resolved`] can never reach `claude`'s
+    // implementation for a harness that did not declare it.
+
+    /// Resolve this node's transcript file on disk, or `None`.
+    ///
+    /// Gated by [`Self::transcript_resolution`] being present; the default (a
+    /// harness whose store PDO cannot map) returns `None`, so a cost or turn-end
+    /// read finds no file and the consumer treats it as "no signal". `claude`
+    /// resolves by pinned session id (`<uuid>.jsonl`), else newest-mtime.
+    fn resolve_transcript(
+        &self,
+        _projects_root: &Path,
+        _working_dir: &Path,
+        _session_id: Option<&str>,
+    ) -> Option<PathBuf> {
+        None
+    }
+
+    /// Whether the transcript `tail` shows this harness's end-of-turn signature.
+    ///
+    /// The default is `false` (no substrate ⇒ never a constated end of turn). This
+    /// is the parser that must be **this harness's own**: reading `claude`'s JSONL
+    /// turn-state on another harness's store is exactly the ADR-0051 regression.
+    fn classify_turn_ended(&self, _tail: &str) -> bool {
+        false
+    }
+
+    /// Whether the captured `pane` shows this harness's usage-limit menu.
+    ///
+    /// The default is `false` (no anchor ⇒ the wording is proper to another
+    /// harness, so a generic consumer never matches it). `claude` matches its
+    /// interactive "stop and wait for limit to reset" menu.
+    fn detect_usage_limit(&self, _pane: &str) -> bool {
+        false
+    }
 }
 
 /// The `claude` capabilities — all five, exactly as they are today. This slice is
@@ -155,11 +220,107 @@ impl HarnessProbes for ClaudeProbes {
     fn staging_floor(&self) -> Option<StagingFloor> {
         Some(StagingFloor::ClaudeDotClaude)
     }
+
+    /// `claude`'s transcript resolution: by the pinned session id when the node
+    /// recorded one (`<uuid>.jsonl` — this node's own transcript, #473), else the
+    /// legacy newest-mtime pick for a pre-#473 row. This is the sole reachable
+    /// caller of [`crate::stale_detector::session_jsonl_by_id`] /
+    /// [`crate::stale_detector::find_session_jsonl`] from outside the sweep — they
+    /// are `claude`'s implementation now, not a generic transcript resolver.
+    fn resolve_transcript(
+        &self,
+        projects_root: &Path,
+        working_dir: &Path,
+        session_id: Option<&str>,
+    ) -> Option<PathBuf> {
+        match session_id {
+            Some(sid) => {
+                crate::stale_detector::session_jsonl_by_id(projects_root, working_dir, sid)
+            }
+            None => crate::stale_detector::find_session_jsonl(projects_root, working_dir),
+        }
+    }
+
+    /// `claude`'s end-of-turn parser: the JSONL turn-state tail classifier
+    /// ([`crate::stale_detector::parse_turn_state`]) answering `TurnEnded`.
+    fn classify_turn_ended(&self, tail: &str) -> bool {
+        crate::stale_detector::parse_turn_state(tail) == crate::stale_detector::TurnState::TurnEnded
+    }
+
+    /// `claude`'s usage-limit matcher over a pane capture
+    /// ([`crate::stale_detector::detect_usage_limit`]).
+    fn detect_usage_limit(&self, pane: &str) -> bool {
+        crate::stale_detector::detect_usage_limit(pane)
+    }
 }
 
 /// The single `claude` instance handed out by [`probes_for`]. Zero-sized, so this
 /// `static` costs nothing and needs no lazy init.
 static CLAUDE_PROBES: ClaudeProbes = ClaudeProbes;
+
+/// The capabilities of a **data-declared** harness (a user's disk descriptor, or
+/// `opencode` in v1): every method inherits the trait's "absent" default. This is
+/// the dispatch target that makes ADR-0051 §2 hold — a harness PDO carries no code
+/// for still resolves to *something*, and that something answers "absent" on every
+/// capability rather than routing to `claude`'s implementation.
+struct NullProbes;
+impl HarnessProbes for NullProbes {}
+
+/// The single all-absent instance handed out by [`resolved`] for any harness with
+/// no code. Zero-sized, like [`CLAUDE_PROBES`].
+static NULL_PROBES: NullProbes = NullProbes;
+
+/// The dispatch target for `harness` — **total**: `claude` gets [`ClaudeProbes`],
+/// every other name (a data-declared harness) gets [`NullProbes`]. Never `None`:
+/// there is always a dispatch, and absence is a method answering `None`/`false`,
+/// not a missing implementation (ADR-0051 §2). This is what a generic consumer
+/// holds instead of naming a claude-proper function.
+pub(crate) fn resolved(harness: &str) -> &'static dyn HarnessProbes {
+    match probes_for(harness) {
+        Some(p) => p,
+        None => &NULL_PROBES,
+    }
+}
+
+/// Resolve `harness`'s transcript file, dispatched to its implementation (ADR-0051).
+/// A data-declared harness resolves `None` — never `claude`'s `<uuid>.jsonl` path.
+pub(crate) fn resolve_transcript(
+    harness: &str,
+    projects_root: &Path,
+    working_dir: &Path,
+    session_id: Option<&str>,
+) -> Option<PathBuf> {
+    resolved(harness).resolve_transcript(projects_root, working_dir, session_id)
+}
+
+/// Whether `harness` constates an end of turn from this transcript `tail`,
+/// dispatched to its implementation (ADR-0051). A harness with no substrate
+/// answers `false` — never `claude`'s JSONL parser on a foreign store.
+pub(crate) fn turn_ended(harness: &str, tail: &str) -> bool {
+    resolved(harness).classify_turn_ended(tail)
+}
+
+/// Whether `harness`'s usage-limit menu is showing in this `pane`, dispatched to
+/// its implementation (ADR-0051). A harness with no anchor answers `false`.
+pub(crate) fn usage_limit_shown(harness: &str, pane: &str) -> bool {
+    resolved(harness).detect_usage_limit(pane)
+}
+
+/// The one-time note for a node whose harness has **no turn-end substrate** while
+/// turn-end auto-completion is enabled (ADR-0051 / correctif AC #7). `Some(msg)`
+/// when the setting cannot be honoured for `harness`, `None` for a harness that
+/// has the substrate (`claude`). Pure and testable, the twin of
+/// [`staging_floor_absence_note`]: the setting stops being a silent no-op.
+pub(crate) fn turn_end_absence_note(harness: &str) -> Option<String> {
+    if capabilities(harness).turn_end {
+        return None;
+    }
+    Some(format!(
+        "turn-end auto-completion is enabled but harness `{harness}` has no end-of-turn substrate \
+         (#613, ADR-0051) — this node will not be auto-completed on turn end; complete it by \
+         signalling `pdo complete` or leave it attached"
+    ))
+}
 
 /// The capabilities of `harness`, or `None` for a harness PDO carries no code for.
 ///
@@ -309,6 +470,129 @@ mod tests {
             assert_eq!(capabilities(name), Capabilities::NONE, "{name}");
             assert!(!can_cost(name), "{name} cannot be costed");
         }
+    }
+
+    // --- ADR-0051: a capability is a dispatch point ------------------------------
+
+    /// A fictional harness that **declares its own implementation** of three
+    /// capabilities. It is the negative image of `claude`: it resolves a transcript
+    /// to a fixed sentinel path, calls a turn ended on a marker `claude` would never
+    /// emit, and matches its own usage-limit wording. If dispatch ever fell back to
+    /// `claude` for a declared harness, every assertion below would flip.
+    struct TestProbes;
+    impl HarnessProbes for TestProbes {
+        fn transcript_resolution(&self) -> Option<TranscriptResolution> {
+            Some(TranscriptResolution::ClaudeJsonl) // marker present ⇒ capability declared
+        }
+        fn turn_end_substrate(&self) -> Option<TurnEndSubstrate> {
+            Some(TurnEndSubstrate::ClaudeTranscript)
+        }
+        fn resolve_transcript(
+            &self,
+            _projects_root: &Path,
+            _working_dir: &Path,
+            _session_id: Option<&str>,
+        ) -> Option<PathBuf> {
+            Some(PathBuf::from("/test-harness/own-transcript.log"))
+        }
+        fn classify_turn_ended(&self, tail: &str) -> bool {
+            tail == "TEST-HARNESS-DONE"
+        }
+        fn detect_usage_limit(&self, pane: &str) -> bool {
+            pane.contains("test-harness rate limit")
+        }
+    }
+
+    #[test]
+    fn a_declared_implementation_gets_its_own_behaviour_not_claudes() {
+        // AC #4, the regression this ticket makes impossible: a harness that
+        // declares an implementation is dispatched to ITS behaviour, never claude's.
+        let t = TestProbes;
+
+        // Its turn-end parser fires on ITS marker and rejects what claude would
+        // accept (a real `assistant`-terminated JSONL tail).
+        assert!(t.classify_turn_ended("TEST-HARNESS-DONE"));
+        let claude = probes_for(CLAUDE).unwrap();
+        // The claude parser would NOT call this tail ended (not valid JSONL), and
+        // the test harness's own parser is what runs — the two disagree, which is
+        // the whole point.
+        assert!(!claude.classify_turn_ended("TEST-HARNESS-DONE"));
+
+        // Its transcript resolves to its own path, not a `<uuid>.jsonl` under the
+        // claude projects root.
+        let p = t
+            .resolve_transcript(Path::new("/proj"), Path::new("/wd"), Some("abc"))
+            .unwrap();
+        assert_eq!(p, PathBuf::from("/test-harness/own-transcript.log"));
+
+        // Its usage-limit anchor is its own wording; claude's menu text does not
+        // match it and vice-versa.
+        assert!(t.detect_usage_limit("test-harness rate limit reached"));
+        assert!(!t.detect_usage_limit("Stop and wait for limit to reset"));
+    }
+
+    #[test]
+    fn a_data_declared_harness_dispatches_to_absent_never_to_claude() {
+        // AC #1/#4: the generic by-name dispatch for a harness PDO carries no code
+        // for resolves to "absent" on every behaviour — it must NOT reach claude's
+        // implementation. This is the path a liveness sweep takes.
+        for name in [OPENCODE, "pi", "not-a-harness"] {
+            assert!(
+                resolve_transcript(name, Path::new("/proj"), Path::new("/wd"), Some("abc")).is_none(),
+                "{name}: no transcript resolution leaks from claude"
+            );
+            // A tail claude WOULD call ended is not enough — a data-declared harness
+            // answers `false`, so no node on it is ever auto-completed.
+            assert!(
+                !turn_ended(name, FIXTURE_CLAUDE_TURN_ENDED),
+                "{name}: no turn-end via claude's parser"
+            );
+            assert!(
+                !usage_limit_shown(name, "Stop and wait for limit to reset"),
+                "{name}: no usage-limit match via claude's anchor"
+            );
+        }
+    }
+
+    #[test]
+    fn claude_dispatches_to_its_own_behaviour() {
+        // The control: `claude`'s by-name dispatch DOES run its parser/anchor — this
+        // slice is a dispatch refactor, not a behaviour change (AC #5).
+        assert!(turn_ended(CLAUDE, FIXTURE_CLAUDE_TURN_ENDED));
+        assert!(usage_limit_shown(
+            CLAUDE,
+            "❯ 1. Stop and wait for limit to reset"
+        ));
+    }
+
+    #[test]
+    fn resolved_is_total_and_absence_is_a_value_not_a_missing_dispatch() {
+        // ADR-0051 §2: every name resolves to *some* dispatch; "absent" is a method
+        // answering None/false on that dispatch, distinguishable from claude's.
+        assert!(resolved(CLAUDE).cost_source().is_some());
+        assert!(resolved(OPENCODE).cost_source().is_none());
+        assert!(resolved("never-seen").turn_end_substrate().is_none());
+    }
+
+    /// A minimal, valid claude JSONL tail whose last substantial record is an
+    /// `assistant` message with no pending `tool_use` — the one shape
+    /// [`crate::stale_detector::parse_turn_state`] calls `TurnEnded`.
+    const FIXTURE_CLAUDE_TURN_ENDED: &str = concat!(
+        r#"{"type":"user","message":{"role":"user","content":"hi"}}"#,
+        "\n",
+        r#"{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"done"}]}}"#,
+        "\n"
+    );
+
+    #[test]
+    fn turn_end_absence_note_fires_only_for_a_harness_without_the_substrate() {
+        // AC #7: enabling turn-end completion on a substrate-less harness is said,
+        // not a silent no-op. `claude` has the substrate → no note.
+        assert_eq!(turn_end_absence_note(CLAUDE), None);
+        let note = turn_end_absence_note("pi").expect("a note for a substrate-less harness");
+        assert!(note.contains("`pi`"));
+        assert!(note.contains("no end-of-turn substrate"));
+        assert!(note.contains("not be auto-completed"));
     }
 
     #[test]

--- a/crates/pdo-daemon/src/harness_probes.rs
+++ b/crates/pdo-daemon/src/harness_probes.rs
@@ -538,7 +538,8 @@ mod tests {
         // implementation. This is the path a liveness sweep takes.
         for name in [OPENCODE, "pi", "not-a-harness"] {
             assert!(
-                resolve_transcript(name, Path::new("/proj"), Path::new("/wd"), Some("abc")).is_none(),
+                resolve_transcript(name, Path::new("/proj"), Path::new("/wd"), Some("abc"))
+                    .is_none(),
                 "{name}: no transcript resolution leaks from claude"
             );
             // A tail claude WOULD call ended is not enough — a data-declared harness

--- a/crates/pdo-daemon/src/harness_registry.rs
+++ b/crates/pdo-daemon/src/harness_registry.rs
@@ -72,6 +72,22 @@ impl HarnessDescriptor {
         !self.resume.is_empty()
     }
 
+    /// Whether the templates carry a `{settings}` hole — i.e. this harness accepts
+    /// an injected settings file (the turn-end `Stop` hook substrate, #433/ADR-0043).
+    ///
+    /// #613/ADR-0051 (correctif 8): PDO writes the claude-format settings file
+    /// **only** for a harness that has this hole. `opencode` has none (its template
+    /// carries no `{settings}` token), so a node on it gets no stray settings file
+    /// beside its prompt — "the absence is said, never supplied". Checks both
+    /// templates so a harness that resumes but does not launch with settings (or the
+    /// reverse) is still handled at the matching seam.
+    pub fn has_settings_hole(&self) -> bool {
+        self.launch
+            .iter()
+            .chain(self.resume.iter())
+            .any(|t| t.contains("{settings}"))
+    }
+
     /// Whether the LAUNCH template pins a session identity (`{session_id}`).
     ///
     /// `opencode` cannot (measured: launching with a fresh id answers "Session not
@@ -529,6 +545,10 @@ mod tests {
         assert!(d.pins_session_id(), "claude pins --session-id");
         assert!(d.has_effort_hole(), "claude has an effort axis");
         assert!(d.can_resume(), "claude resumes by --resume/--continue");
+        assert!(
+            d.has_settings_hole(),
+            "claude accepts an injected settings file (the Stop-hook substrate)"
+        );
     }
 
     #[test]
@@ -544,6 +564,10 @@ mod tests {
         );
         assert!(d.can_resume(), "opencode blind-continues");
         assert!(d.env.is_empty(), "opencode carries no CCR env");
+        assert!(
+            !d.has_settings_hole(),
+            "opencode has no settings hole — PDO writes it no settings file (#613)"
+        );
     }
 
     #[test]

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -10786,6 +10786,11 @@ struct SweepNodeProbes<'a> {
     /// transcript by identity (`<uuid>.jsonl`); `None` (a pre-#473 row / a script
     /// node) ⇒ the legacy newest-mtime fallback.
     session_id: Option<&'a str>,
+    /// #613/ADR-0051: the node's frozen-at-spawn harness. Transcript resolution
+    /// dispatches on it — `claude`'s `<uuid>.jsonl` / newest-mtime for `claude`,
+    /// nothing for a harness whose store PDO cannot map — so this adapter never
+    /// hardcodes claude's resolution for a foreign harness.
+    harness: &'a str,
     pipeline_path: &'a Path,
     artifacts_dir: &'a Path,
     run_id: &'a str,
@@ -10800,19 +10805,19 @@ impl stale_detector::NodeProbes for SweepNodeProbes<'_> {
     }
 
     fn transcript_tail(&self) -> Option<stale_detector::TranscriptTail> {
-        // #473: resolve by pinned session identity when we have one — this node's
-        // own `<uuid>.jsonl`, never the newest `.jsonl` in a cwd shared with the
-        // manager / sibling non-CM nodes. A pre-#473 node (no recorded id) falls
-        // back to the legacy newest-mtime resolution.
-        let resolved = match self.session_id {
-            Some(sid) => {
-                stale_detector::session_jsonl_by_id(self.projects_root, self.working_dir, sid)
-            }
-            None => stale_detector::find_session_jsonl(self.projects_root, self.working_dir),
-        };
-        resolved
-            .as_deref()
-            .and_then(stale_detector::read_transcript_tail)
+        // #613/ADR-0051: dispatch transcript resolution to the resolved harness's
+        // implementation. `claude` resolves by pinned session identity (this node's
+        // own `<uuid>.jsonl`, #473) or the legacy newest-mtime fallback; a
+        // data-declared harness resolves `None` and no tail is read. The byte-read
+        // of the resolved path is generic (`read_transcript_tail`).
+        harness_probes::resolve_transcript(
+            self.harness,
+            self.projects_root,
+            self.working_dir,
+            self.session_id,
+        )
+        .as_deref()
+        .and_then(stale_detector::read_transcript_tail)
     }
 
     fn outputs_valid(&self) -> bool {
@@ -10964,32 +10969,28 @@ async fn run_stale_detection(state: &Arc<AppState>) {
             // usage-limit-dedup pipeline lives in `assess_node`, with all tmux +
             // filesystem I/O injected via this adapter. The sweep only appends
             // the returned events and runs the reap/spawn side effects below.
+            // #553/#613: the node's FROZEN-at-spawn harness (ADR-0046), never the
+            // current YAML. `None` (a script node, a pre-#550 row) is the `claude`
+            // floor. Every capability — transcript resolution, turn-end, usage-limit
+            // — dispatches on this name (ADR-0051): `claude`'s implementation for
+            // `claude`, a data-declared harness's own (or nothing) otherwise. So the
+            // sweep never reads another harness's store with claude's parser.
+            let node_harness = find_launch_harness(&events, node_id, *iter)
+                .unwrap_or_else(|| harness_registry::CLAUDE.to_string());
+
             let probes = SweepNodeProbes {
                 socket: &socket,
                 session_name: &session_name,
                 working_dir: &working_dir,
                 projects_root: &projects_root,
                 session_id: launch_session_id.as_deref(),
+                harness: &node_harness,
                 pipeline_path: &pipeline_path,
                 artifacts_dir: &artifacts_dir,
                 run_id,
                 node_id,
                 iter: *iter,
                 running: &running,
-            };
-
-            // #553: gate the turn-end and usage-limit probes on the node's
-            // FROZEN-at-spawn harness (ADR-0046), never the current YAML. `None`
-            // (a script node, a pre-#550 row) is the `claude` floor, which has both
-            // capabilities — so the sweep is byte-identical to pre-#553 there. A
-            // node on a harness without them runs neither probe: no auto-completion
-            // on an invented heuristic, no capture for another harness's menu.
-            let node_harness = find_launch_harness(&events, node_id, *iter)
-                .unwrap_or_else(|| harness_registry::CLAUDE.to_string());
-            let hc = harness_probes::capabilities(&node_harness);
-            let caps = stale_detector::HarnessCapabilities {
-                turn_end: hc.turn_end,
-                usage_limit: hc.usage_limit,
             };
 
             let assessment = stale_detector::assess_node(
@@ -11000,7 +11001,7 @@ async fn run_stale_detection(state: &Arc<AppState>) {
                 *iter,
                 now,
                 autocomplete_turn_end,
-                caps,
+                &node_harness,
             );
 
             if assessment.blocked_on_limit {

--- a/crates/pdo-daemon/src/node_spawn.rs
+++ b/crates/pdo-daemon/src/node_spawn.rs
@@ -116,6 +116,29 @@ fn warn_missing_staging_floor_once(run_id: &str, harness: &str) {
     }
 }
 
+/// #613 / ADR-0051 (AC #7): say ONCE per `(run, harness)` that turn-end
+/// auto-completion is enabled but the node's harness has no end-of-turn substrate,
+/// so the setting cannot be honoured for it. The message is the pure
+/// [`crate::harness_probes::turn_end_absence_note`] (unit-tested there); the
+/// process-static dedup keeps a busy scheduler from repeating it. A no-op for
+/// `claude` (which has the substrate) and whenever the setting is off. Without this
+/// the setting was a **silent** no-op on a substrate-less harness — the very thing
+/// this ticket removes.
+fn warn_turn_end_unsupported_once(run_id: &str, harness: &str) {
+    use std::collections::HashSet;
+    use std::sync::Mutex;
+    static SAID: Mutex<Option<HashSet<(String, String)>>> = Mutex::new(None);
+
+    let Some(note) = crate::harness_probes::turn_end_absence_note(harness) else {
+        return; // the harness has a turn-end substrate (claude) — nothing to say
+    };
+    let mut guard = SAID.lock().unwrap_or_else(|e| e.into_inner());
+    let said = guard.get_or_insert_with(HashSet::new);
+    if said.insert((run_id.to_string(), harness.to_string())) {
+        warn!("run {run_id}: {note}");
+    }
+}
+
 /// A collection-region member (ADR-0011 / #269) reads its OWN deposited item:
 /// the fan-out deposits `_item.md` under the entry's artifact dir, one per
 /// lap — there is no separate driver node like the retired ForEach.
@@ -856,6 +879,15 @@ pub(crate) async fn spawn_node(
     // tail, no `claude`). Resolved here, at the spawn edge, so a `PUT /settings`
     // takes effect on the next node with no daemon restart.
     let inject_hook = !is_script && stored_autocomplete_turn_end(deps.db).await;
+    // #613/ADR-0051 (AC #7): the setting is on but this harness has no end-of-turn
+    // substrate ⇒ it will not auto-complete. Say the absence once rather than let
+    // the setting be a silent no-op. `claude` (and a `script` node, which never
+    // arms the hook) say nothing.
+    if inject_hook {
+        if let Some(r) = &resolved_harness {
+            warn_turn_end_unsupported_once(run_id, &r.harness);
+        }
+    }
     if let Err(e) = tmux_session_manager::spawn(
         &session_name,
         spawn_prompt,

--- a/crates/pdo-daemon/src/stale_detector.rs
+++ b/crates/pdo-daemon/src/stale_detector.rs
@@ -148,7 +148,12 @@ fn strip_ansi(s: &str) -> String {
 /// True if the captured pane shows Claude Code's usage-limit interactive menu.
 /// `pane` is raw tmux capture (may contain ANSI). Observability-only (#290): the
 /// caller flags the node but never changes its fate.
-pub fn detect_usage_limit(pane: &str) -> bool {
+///
+/// `pub(crate)` since #613/ADR-0051: this is **`claude`'s** usage-limit
+/// implementation ([`crate::harness_probes::HarnessProbes::detect_usage_limit`]),
+/// not a generic matcher — a consumer dispatches through
+/// [`crate::harness_probes::usage_limit_shown`], never calling this directly.
+pub(crate) fn detect_usage_limit(pane: &str) -> bool {
     // Normalise: strip ANSI, lowercase (anchors are ASCII), collapse whitespace so
     // line-wrap / padding can't split an anchor.
     let stripped = strip_ansi(pane).to_ascii_lowercase();
@@ -176,37 +181,6 @@ pub enum Detection {
     /// Nothing to do. Includes every "alive but not progressing" shape —
     /// mid-tool-call, wedged on an interactive prompt, API retries exhausted.
     Ok,
-}
-
-/// The two harness capabilities the sweep gates its probes on (#553, ADR-0045).
-///
-/// Absent ⇒ the probe **does not run**: no turn-end auto-completion on an invented
-/// heuristic (the substrate is claude's JSONL transcript), and no pane capture for
-/// a usage-limit menu whose wording is proper to another harness. The sweep
-/// ([`crate::lib`]) fills this from [`crate::harness_probes`] for the node's
-/// frozen-at-spawn harness; keeping it a plain two-bool struct here keeps
-/// [`assess_node`] pure and injected, exactly like `autocomplete_turn_end`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct HarnessCapabilities {
-    /// The harness has an end-of-turn substrate PDO can read
-    /// ([`crate::harness_probes::HarnessProbes::turn_end_substrate`]).
-    pub turn_end: bool,
-    /// The harness has a usage-limit menu anchor PDO can match
-    /// ([`crate::harness_probes::HarnessProbes::usage_limit_anchor`]).
-    pub usage_limit: bool,
-}
-
-impl HarnessCapabilities {
-    /// Both present — `claude`, and the shape the pre-#553 sweep always assumed.
-    pub const CLAUDE: HarnessCapabilities = HarnessCapabilities {
-        turn_end: true,
-        usage_limit: true,
-    };
-    /// Both absent — a data-declared harness: neither probe runs.
-    pub const NONE: HarnessCapabilities = HarnessCapabilities {
-        turn_end: false,
-        usage_limit: false,
-    };
 }
 
 /// Pure liveness decision: session alive or not (#469 §1).
@@ -282,7 +256,12 @@ enum RecordRole {
 /// The JSONL layout is not a documented contract — same caution as the #290 pane
 /// anchors — though `tool_use` / `tool_result` blocks and their `id`s are its
 /// most stable part, far ahead of a menu's wording.
-pub fn parse_turn_state(tail: &str) -> TurnState {
+///
+/// `pub(crate)` since #613/ADR-0051: this is **`claude`'s** end-of-turn parser
+/// ([`crate::harness_probes::HarnessProbes::classify_turn_ended`]) — a consumer
+/// dispatches through [`crate::harness_probes::turn_ended`], never reading another
+/// harness's store with it.
+pub(crate) fn parse_turn_state(tail: &str) -> TurnState {
     let mut open_tool_uses: std::collections::HashSet<String> = std::collections::HashSet::new();
     let mut last_role: Option<RecordRole> = None;
 
@@ -383,7 +362,10 @@ pub fn encode_working_dir(dir: &Path) -> String {
 /// stays the single source of truth (#373). Returns `None` when the file does not
 /// exist yet (a session that has not written its transcript), which the sweep
 /// treats as "no signal".
-pub fn session_jsonl_by_id(
+/// `pub(crate)` since #613/ADR-0051: part of **`claude`'s** transcript resolution
+/// ([`crate::harness_probes::HarnessProbes::resolve_transcript`]); a consumer
+/// dispatches through [`crate::harness_probes::resolve_transcript`].
+pub(crate) fn session_jsonl_by_id(
     projects_root: &Path,
     working_dir: &Path,
     session_id: &str,
@@ -410,7 +392,7 @@ pub fn session_jsonl_by_id(
 /// [`crate::sandbox_run::transcripts_root`] (staging for a live sandboxed Run,
 /// `~/.claude/projects/` otherwise). The cwd encoding stays here, the single
 /// source of truth (#373) — the seam only swaps the base root.
-pub fn find_session_jsonl(projects_root: &Path, working_dir: &Path) -> Option<PathBuf> {
+pub(crate) fn find_session_jsonl(projects_root: &Path, working_dir: &Path) -> Option<PathBuf> {
     let encoded = encode_working_dir(working_dir);
     newest_jsonl_in(&projects_root.join(encoded))
 }
@@ -710,8 +692,13 @@ pub fn assess_node(
     iter: i64,
     now: SystemTime,
     autocomplete_turn_end: bool,
-    caps: HarnessCapabilities,
+    harness: &str,
 ) -> Assessment {
+    // #613/ADR-0051: the two probes are dispatch points, not presence guards. The
+    // gate reads the resolved harness's declared capabilities, and the detection
+    // itself is dispatched to that harness's implementation — `claude`'s JSONL
+    // parser / pane anchor for `claude`, a data-declared harness's own (or nothing).
+    let caps = crate::harness_probes::capabilities(harness);
     let detection = decide(probes.session_alive());
 
     if detection == Detection::SessionDied {
@@ -736,7 +723,7 @@ pub fn assess_node(
     let blocked_on_limit = caps.usage_limit
         && probes
             .capture_pane()
-            .is_some_and(|pane| detect_usage_limit(&pane));
+            .is_some_and(|pane| crate::harness_probes::usage_limit_shown(harness, &pane));
     let events = if blocked_on_limit
         && !episode_has_event(prior_events, &EventKind::NodeBlockedOnLimit, node_id, iter)
     {
@@ -765,7 +752,7 @@ pub fn assess_node(
         && caps.turn_end
         && probes.transcript_tail().is_some_and(|tail| {
             quiet_long_enough(tail.mtime, now)
-                && parse_turn_state(&tail.text) == TurnState::TurnEnded
+                && crate::harness_probes::turn_ended(harness, &tail.text)
         })
         && probes.outputs_valid();
 
@@ -1721,8 +1708,9 @@ SwapFree:         204800 kB
 
     fn assess(probes: &FakeProbes, autocomplete: bool) -> Assessment {
         // The existing suite is about the `claude` sweep, which has both
-        // capabilities; #553's capability gating is exercised by the dedicated
-        // tests below with `HarnessCapabilities::NONE`.
+        // capabilities and whose JSONL parser the `FakeProbes` fixtures feed;
+        // #613's capability gating is exercised by the dedicated tests below on a
+        // data-declared harness (`opencode`, which has neither capability).
         assess_node(
             probes,
             &[],
@@ -1731,7 +1719,7 @@ SwapFree:         204800 kB
             1,
             SystemTime::now(),
             autocomplete,
-            HarnessCapabilities::CLAUDE,
+            crate::harness_registry::CLAUDE,
         )
     }
 
@@ -1940,7 +1928,7 @@ SwapFree:         204800 kB
             1,
             SystemTime::now(),
             true,
-            HarnessCapabilities::CLAUDE,
+            crate::harness_registry::CLAUDE,
         );
         assert!(
             a.blocked_on_limit,
@@ -1967,13 +1955,9 @@ SwapFree:         204800 kB
         assert_eq!(a.events[0].kind, EventKind::NodeBlockedOnLimit);
     }
 
-    // --- #553: capability gating — a data-declared harness runs no probe ---
+    // --- #553/#613: capability gating — a data-declared harness runs no probe ---
 
-    fn assess_caps(
-        probes: &FakeProbes,
-        autocomplete: bool,
-        caps: HarnessCapabilities,
-    ) -> Assessment {
+    fn assess_harness(probes: &FakeProbes, autocomplete: bool, harness: &str) -> Assessment {
         assess_node(
             probes,
             &[],
@@ -1982,9 +1966,13 @@ SwapFree:         204800 kB
             1,
             SystemTime::now(),
             autocomplete,
-            caps,
+            harness,
         )
     }
+
+    /// A data-declared harness the sweep carries no code for: neither capability,
+    /// no transcript resolution, no pane anchor. `opencode` is the embedded example.
+    const DATA_DECLARED: &str = crate::harness_registry::OPENCODE;
 
     #[test]
     fn a_harness_without_the_turn_end_capability_is_never_auto_completed() {
@@ -1992,7 +1980,7 @@ SwapFree:         204800 kB
         // but its harness has no turn-end substrate, so the sweep must not complete
         // it, and must not even read a transcript (the substrate is not claude's).
         let probes = FakeProbes::finished_turn();
-        let a = assess_caps(&probes, true, HarnessCapabilities::NONE);
+        let a = assess_harness(&probes, true, DATA_DECLARED);
         assert_eq!(
             a.detection,
             Detection::Ok,
@@ -2011,7 +1999,7 @@ SwapFree:         204800 kB
         // The control: with the capability present (and the setting on) the same
         // finished turn IS completed — the gate is the capability, nothing else.
         let probes = FakeProbes::finished_turn();
-        let a = assess_caps(&probes, true, HarnessCapabilities::CLAUDE);
+        let a = assess_harness(&probes, true, crate::harness_registry::CLAUDE);
         assert_eq!(a.detection, Detection::TurnEnded);
     }
 
@@ -2023,7 +2011,7 @@ SwapFree:         204800 kB
             pane: Some("❯ 1. Stop and wait for limit to reset".to_string()),
             ..FakeProbes::alive()
         };
-        let a = assess_caps(&probes, true, HarnessCapabilities::NONE);
+        let a = assess_harness(&probes, true, DATA_DECLARED);
         assert_eq!(a.detection, Detection::Ok);
         assert!(
             !a.blocked_on_limit,

--- a/crates/pdo-daemon/src/tmux_session_manager.rs
+++ b/crates/pdo-daemon/src/tmux_session_manager.rs
@@ -691,7 +691,15 @@ pub fn spawn(
     // prompt (gitignored under `.pdo/`, resolves identically host and container).
     // Callers pass `false` for `script`/manager/merge-resolver sessions; the tail
     // selector in `build_tmux_script` is the belt-and-suspenders guard.
-    let settings_path = if inject_hook {
+    //
+    // #613/ADR-0051 (correctif 8): write the claude-format settings file ONLY for a
+    // harness that actually has a `{settings}` hole to fill. A node on a harness
+    // with none (`opencode`) would never reference the file — writing it beside the
+    // prompt was the one place "absence is supplied, not said" leaked. Now the
+    // absence is honoured: no hole, no file.
+    let harness_takes_settings =
+        matches!(&tail, SessionTail::Agent { harness, .. } if harness.has_settings_hole());
+    let settings_path = if inject_hook && harness_takes_settings {
         let p = prompt_dir.join(format!("{node_id}-iter-{iter}.settings.json"));
         std::fs::write(&p, STOP_HOOK_SETTINGS_JSON)?;
         Some(p)
@@ -882,7 +890,10 @@ pub fn resume(
     // reference it. `create_dir_all` covers the rare case where the prompt dir was
     // pruned since spawn. `false` (setting off, or a `script` node) ⇒ no file, and
     // `build_resume_script` emits a byte-identical `--continue` tail.
-    let settings_path = if inject_hook {
+    //
+    // #613/ADR-0051 (correctif 8): as at spawn, only a harness with a `{settings}`
+    // hole gets the file — a resumed `opencode` node writes none.
+    let settings_path = if inject_hook && descriptor.has_settings_hole() {
         let prompt_dir = working_dir.join(".pdo").join("prompts");
         std::fs::create_dir_all(&prompt_dir)?;
         let p = prompt_dir.join(format!("{node_id}-iter-{iter}.settings.json"));
@@ -2411,6 +2422,71 @@ mod tests {
         assert_eq!(
             v["hooks"]["Stop"][0]["hooks"][0]["type"].as_str(),
             Some("command")
+        );
+    }
+
+    /// Drive the real `spawn` with a benign tail and report whether it dropped the
+    /// turn-end settings file beside the prompt. Kills the ephemeral tmux server on
+    /// its own socket afterwards. `port` isolates the socket from sibling tests.
+    fn spawn_and_check_settings_file(
+        port: u16,
+        harness: &crate::harness_registry::HarnessDescriptor,
+    ) -> bool {
+        let wd = tempfile::tempdir().unwrap();
+        let session = node_session_name("run-c8", "n", 1);
+        // The tail runs `true` (exits at once); we only assert on the file the write
+        // gate controls, which is written before tmux is ever touched.
+        let _ = spawn(
+            &session,
+            "prompt body",
+            wd.path(),
+            "run-c8",
+            "n",
+            1,
+            port,
+            Some("true"),
+            SessionTail::Agent {
+                harness,
+                model: None,
+                effort: None,
+                session_id: None,
+            },
+            None,
+            true, // inject_hook ON — the setting is enabled
+        );
+        let settings = wd
+            .path()
+            .join(".pdo")
+            .join("prompts")
+            .join("n-iter-1.settings.json");
+        let present = settings.is_file();
+        // Tear down the ephemeral server (ignore errors — the `true` tail may have
+        // already ended the only session, leaving no server to kill).
+        let _ = std::process::Command::new("tmux")
+            .args(["-L", &tmux_socket_name(port), "kill-server"])
+            .output();
+        present
+    }
+
+    #[test]
+    fn spawn_writes_the_settings_file_for_a_harness_with_a_settings_hole() {
+        // #613 (correctif 8) control: `claude` HAS a `{settings}` hole, so with the
+        // setting on PDO writes the Stop-hook file beside the prompt, as always.
+        assert!(
+            spawn_and_check_settings_file(58231, &crate::harness_registry::claude()),
+            "claude must still get its turn-end settings file"
+        );
+    }
+
+    #[test]
+    fn spawn_writes_no_settings_file_for_a_harness_without_a_settings_hole() {
+        // #613 (correctif 8): `opencode` has NO `{settings}` hole, so even with
+        // turn-end auto-completion enabled PDO writes it no claude-format settings
+        // file — the absence is honoured, not supplied. This was the one place the
+        // discipline was broken.
+        assert!(
+            !spawn_and_check_settings_file(58232, &crate::harness_registry::opencode()),
+            "opencode must get no settings file — it has no settings hole"
         );
     }
 

--- a/crates/pdo-daemon/tests/run_shell.rs
+++ b/crates/pdo-daemon/tests/run_shell.rs
@@ -218,10 +218,25 @@ async fn run_status(daemon: &TestDaemon, run_id: &str) -> Option<String> {
 ///
 /// Returns on timeout rather than panicking, so the caller's assertion still
 /// produces its own (more specific) message.
-async fn wait_for_marker(path: &std::path::Path, needle: &str) -> String {
+///
+/// Beyond the empty-file race above, there is a *second* one on the write side:
+/// `send-keys` fires the `echo` into the pane, but a freshly opened (or just
+/// respawned) interactive bash may not have reached its input read loop yet. On a
+/// loaded machine the keystrokes are dropped before bash consumes them — the
+/// command never runs, and polling content forever reads nothing. So re-send the
+/// command each iteration: it is `echo … > file`, idempotent, so a later send
+/// lands the instant bash is ready, and the marker's final content is unchanged.
+async fn wait_for_marker(
+    socket: &str,
+    session: &str,
+    command: &str,
+    path: &std::path::Path,
+    needle: &str,
+) -> String {
     let deadline = std::time::Instant::now() + Duration::from_secs(10);
     let mut last = String::new();
     while std::time::Instant::now() < deadline {
+        pdo_daemon::tmux_session_manager::send_keys(socket, session, command);
         last = std::fs::read_to_string(path).unwrap_or_default();
         if last.contains(needle) {
             break;
@@ -362,30 +377,34 @@ async fn shell_runs_real_bash_in_pipeline_worktree() {
 
     // A real bash — not the `sleep 600` test override — in the pipeline worktree.
     // Prove cwd + writability, and that the env-safety export is inherited.
-    pdo_daemon::tmux_session_manager::send_keys(
-        &socket,
-        &session,
-        "echo PDO_OK > fp316-marker.txt",
-    );
-    pdo_daemon::tmux_session_manager::send_keys(
-        &socket,
-        &session,
-        "echo \"$CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC\" > env-marker.txt",
-    );
-
     let worktree = worktree_path(&daemon, &run_id);
     let marker = worktree.join("fp316-marker.txt");
     let env_marker = worktree.join("env-marker.txt");
 
     // Poll for the side effect (interactive bash + send-keys is async), on the
-    // CONTENT rather than on the file existing — see `wait_for_marker`.
-    let got = wait_for_marker(&marker, "PDO_OK").await;
+    // CONTENT rather than on the file existing, re-sending the (idempotent) echo
+    // until bash is ready to run it — see `wait_for_marker`.
+    let got = wait_for_marker(
+        &socket,
+        &session,
+        "echo PDO_OK > fp316-marker.txt",
+        &marker,
+        "PDO_OK",
+    )
+    .await;
     assert!(
         got.contains("PDO_OK"),
         "marker at {} must hold PDO_OK — proves cwd = worktree and real bash; got {got:?}",
         marker.display()
     );
-    let env_got = wait_for_marker(&env_marker, "1").await;
+    let env_got = wait_for_marker(
+        &socket,
+        &session,
+        "echo \"$CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC\" > env-marker.txt",
+        &env_marker,
+        "1",
+    )
+    .await;
     assert_eq!(
         env_got.trim(),
         "1",
@@ -744,14 +763,17 @@ async fn shell_survives_eof_and_exit() {
     );
 
     // ...and a fresh, usable bash must have taken its place: prove it by writing
-    // a marker from the respawned shell into the pipeline worktree.
-    pdo_daemon::tmux_session_manager::send_keys(
+    // a marker from the respawned shell into the pipeline worktree. Re-send the
+    // (idempotent) echo until the respawned bash is ready — see `wait_for_marker`.
+    let marker = worktree_path(&daemon, &run_id).join("respawn-marker.txt");
+    let got = wait_for_marker(
         &socket,
         &session,
         "echo RESPAWN_OK > respawn-marker.txt",
-    );
-    let marker = worktree_path(&daemon, &run_id).join("respawn-marker.txt");
-    let got = wait_for_marker(&marker, "RESPAWN_OK").await;
+        &marker,
+        "RESPAWN_OK",
+    )
+    .await;
     assert!(
         got.contains("RESPAWN_OK"),
         "respawned shell must be usable — marker at {} never held RESPAWN_OK; got {got:?}",

--- a/crates/pdo-daemon/tests/session_cap_admission.rs
+++ b/crates/pdo-daemon/tests/session_cap_admission.rs
@@ -116,8 +116,13 @@ async fn node_status(daemon: &TestDaemon, run_id: &str) -> Option<String> {
 
 /// Poll the projected status of `run_id`'s solo node until it equals `want` or
 /// the deadline elapses. Returns the last observed status for diagnostics.
+///
+/// The deadline is generous (15s): status is projected from the event log, and on
+/// a machine loaded enough that the projection lags — e.g. the full `--tests` run
+/// under a concurrent orchestrator — a tight 5s budget reads a stale status and
+/// fails a transition that is merely slow, not wrong.
 async fn wait_for_status(daemon: &TestDaemon, run_id: &str, want: &str) -> Option<String> {
-    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    let deadline = std::time::Instant::now() + Duration::from_secs(15);
     let mut last = None;
     while std::time::Instant::now() < deadline {
         last = node_status(daemon, run_id).await;


### PR DESCRIPTION
Livre le prefactor #613 sur la branche d'intégration `integration/copilot-first-party`.

## Contenu
Les cinq capacités du harnais deviennent des points de dispatch (`resolved`), le
comportement de `claude` reste inchangé. Absence de réglage traitée via `NullProbes`,
`has_settings_hole` vérifié au spawn comme à la reprise, note de fin de tour.

Commits inclus :
- `06e2b4c` feat(harnais): les cinq capacités deviennent des points de dispatch (#613)
- `689b6d5` fix(daemon): format harness_probes assert; harden two load-flaky shell tests
- `1cd5f29` chore(#613): bump version — 1.36.0

## Validation
Verdict du testeur agentique : **Pass**.

Vérification déterministe (équivalent CI) sur le binaire de la branche :
- `cargo build -p pdo-daemon` : exit 0
- `cargo clippy -p pdo-daemon --all-targets -- -D warnings` : 0 warning
- `cargo fmt --all --check` : propre (le gate rouge de l'itération 1 est corrigé)
- `cargo test -p pdo-daemon --tests` : 2405 passés, 0 échec, sur deux runs consécutifs
- `bash tests/smoke.sh` : exit 0

Visual ID : daemon démarré en isolation, UI servie, surface de dispatch conforme
(`harness_descriptors.names = ["claude", "opencode"]`, claude reste le plancher).

Version : 1.35.0 -> 1.36.0 (feat, prefactor sans changement de comportement).

Closes #613

🤖 Generated with [Claude Code](https://claude.com/claude-code)
