### PR TITLE
feat(harnais): copilot, deuxième harnais first-party (#614) — 1.37.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "1.35.0"
+version = "1.36.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "1.35.0"
+version = "1.36.0"
 license = "MIT"
 description = "Prompt-Driven Orchestrator — a local daemon that runs and supervises agentic coding pipelines"
 repository = "https://github.com/Loulen/prompt-driven-orchestrator"

--- a/crates/pdo-daemon/src/harness_argv.rs
+++ b/crates/pdo-daemon/src/harness_argv.rs
@@ -232,6 +232,103 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // #614: the `copilot` launch/resume tails, byte for byte — every hole full
+    // and every hole empty (AC "tous trous pleins et tous trous vides"). The tail
+    // is what a resident tmux pane runs; goldens pin it so a flag typo is a red
+    // test, never a broken launch discovered only against a live binary.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn copilot_launch_no_holes_uses_the_automatic_selector_and_no_session_pin() {
+        // A node with no model / session id: `--model` and `--session-id` drop, so
+        // copilot launches on its automatic model selector (AC), fully autonomous,
+        // question tool off, resident after the turn.
+        let d = harness_registry::resolve("copilot").unwrap();
+        let holes = Holes {
+            prompt: prompt_hole("/tmp/p.md"),
+            ..Default::default()
+        };
+        assert_eq!(
+            render(&d.launch, &holes),
+            "exec copilot --allow-all --no-ask-user \"$(cat '/tmp/p.md')\""
+        );
+    }
+
+    #[test]
+    fn copilot_launch_fills_every_hole() {
+        // Every hole present: model pins the selector, session id pins identity.
+        // `--effort` has no place in copilot's template, so an effort value never
+        // leaks a token (copilot has no launch-time effort axis).
+        let d = harness_registry::resolve("copilot").unwrap();
+        let holes = Holes {
+            prompt: prompt_hole("/tmp/p.md"),
+            model: "'gpt-5.2'".to_string(),
+            session_id: "'abc-123'".to_string(),
+            effort: "'high'".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(
+            render(&d.launch, &holes),
+            "exec copilot --allow-all --no-ask-user --model 'gpt-5.2' --session-id 'abc-123' \
+             \"$(cat '/tmp/p.md')\""
+        );
+    }
+
+    #[test]
+    fn copilot_launch_model_only_still_pins_no_session() {
+        let d = harness_registry::resolve("copilot").unwrap();
+        let holes = Holes {
+            prompt: prompt_hole("/tmp/p.md"),
+            model: "'gpt-5.2'".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(
+            render(&d.launch, &holes),
+            "exec copilot --allow-all --no-ask-user --model 'gpt-5.2' \"$(cat '/tmp/p.md')\""
+        );
+    }
+
+    #[test]
+    fn copilot_resume_by_identity() {
+        // The resume seam fills `{resume}` with `--resume '<id>'` (its verb is the
+        // descriptor's `resume_by_id`), so copilot re-enters THIS node's session.
+        let d = harness_registry::resolve("copilot").unwrap();
+        let holes = Holes {
+            resume: "--resume 'abc-123'".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(
+            render(&d.resume, &holes),
+            "exec copilot --allow-all --no-ask-user --resume 'abc-123'"
+        );
+    }
+
+    #[test]
+    fn copilot_resume_with_no_identity_renders_no_resume_flag() {
+        // copilot's `resume_blind` is empty, so a resume with no recorded id leaves
+        // the `{resume}` hole empty and the token drops — never a blind `--continue`
+        // (AC "jamais par un continue aveugle").
+        let d = harness_registry::resolve("copilot").unwrap();
+        assert_eq!(
+            render(&d.resume, &Holes::default()),
+            "exec copilot --allow-all --no-ask-user"
+        );
+    }
+
+    #[test]
+    fn opencode_resume_stays_a_blind_continue_byte_for_byte() {
+        // The #614 verb-as-property refactor keeps opencode's resume byte-identical:
+        // `resume_blind` fills `{resume}` with `--continue` (opencode cannot pin an
+        // identity, so it only ever blind-continues).
+        let d = harness_registry::resolve("opencode").unwrap();
+        let holes = Holes {
+            resume: "--continue".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(render(&d.resume, &holes), "exec opencode --auto --continue");
+    }
+
+    // -----------------------------------------------------------------------
     // The rendering rule itself, independent of any descriptor.
     // -----------------------------------------------------------------------
 

--- a/crates/pdo-daemon/src/harness_registry.rs
+++ b/crates/pdo-daemon/src/harness_registry.rs
@@ -227,10 +227,16 @@ pub fn copilot() -> HarnessDescriptor {
         .iter()
         .map(|s| s.to_string())
         .collect(),
-        resume: ["exec", "copilot", "--allow-all", "--no-ask-user", "{resume}"]
-            .iter()
-            .map(|s| s.to_string())
-            .collect(),
+        resume: [
+            "exec",
+            "copilot",
+            "--allow-all",
+            "--no-ask-user",
+            "{resume}",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect(),
         // Resume is by identity (`--resume '<id>'`) or not at all: `resume_blind`
         // is empty, so a resume with no recorded id renders no resume flag rather
         // than a blind continue (AC "jamais par un continue aveugle").

--- a/crates/pdo-daemon/src/harness_registry.rs
+++ b/crates/pdo-daemon/src/harness_registry.rs
@@ -51,6 +51,19 @@ pub struct HarnessDescriptor {
     /// resume mechanism, so a resume serves the last pane snapshot rather than an
     /// error (AC #9, same branch as a `script` node).
     pub resume: Vec<String>,
+    /// The flag that fills the resume template's `{resume}` hole to re-enter a
+    /// conversation **by session identity** — `claude`/`copilot`'s `--resume`. The
+    /// resume seam prepends it to the node's recorded session id (`--resume '<id>'`).
+    /// **Empty** ⇒ the harness cannot resume by identity, so the seam falls back to
+    /// [`Self::resume_blind`]. This is the #614 move: the resume *verb* is a property
+    /// of the harness, not a constant hard-coded in the resume seam.
+    pub resume_by_id: String,
+    /// The flag that fills `{resume}` when the node has **no** recorded identity —
+    /// `claude`/`opencode`'s blind `--continue` (re-enter the cwd's latest session).
+    /// **Empty** ⇒ the harness never blind-continues, so a resume with no identity
+    /// renders no resume flag at all (`copilot`: resume is by identity or not at
+    /// all — never a blind continue).
+    pub resume_blind: String,
     /// Env exported before an agent tail (`K=V`). Rendered by the wrapper.
     pub env: Vec<(String, String)>,
 }
@@ -86,6 +99,8 @@ impl HarnessDescriptor {
 pub const CLAUDE: &str = "claude";
 /// The `opencode` harness name (ADR-0045, measured on 1.18.18).
 pub const OPENCODE: &str = "opencode";
+/// The `copilot` harness name — PDO's second first-party harness (#614).
+pub const COPILOT: &str = "copilot";
 
 /// The `claude` descriptor: the legacy launch, expressed as data.
 ///
@@ -122,6 +137,11 @@ pub fn claude() -> HarnessDescriptor {
         .iter()
         .map(|s| s.to_string())
         .collect(),
+        // #614: the resume verbs, now a property of the descriptor rather than
+        // constants in the resume seam. `--resume '<id>'` re-enters by identity
+        // (#473); `--continue` blind-continues a pre-#473 row or the manager.
+        resume_by_id: "--resume".to_string(),
+        resume_blind: "--continue".to_string(),
         // AC #4: the CCR suppression now comes from the descriptor for an agent
         // tail (byte-identical to the wrapper's old hard-coded export — see the
         // `harness_env` handling in `tmux_session_manager::wrap_with_env`).
@@ -154,18 +174,78 @@ pub fn opencode() -> HarnessDescriptor {
         .iter()
         .map(|s| s.to_string())
         .collect(),
-        resume: ["exec", "opencode", "--auto", "--continue"]
+        resume: ["exec", "opencode", "--auto", "{resume}"]
             .iter()
             .map(|s| s.to_string())
             .collect(),
+        // opencode cannot pin a session identity, so it only ever blind-continues
+        // — `resume_by_id` is empty and `{resume}` always renders `--continue`
+        // (byte-identical to the pre-#614 literal tail).
+        resume_by_id: String::new(),
+        resume_blind: "--continue".to_string(),
         env: vec![],
+    }
+}
+
+/// The `copilot` descriptor — GitHub Copilot CLI as PDO's second first-party
+/// harness (#614, ADR-0045). Embedded (the third arm of the floor), not a disk
+/// descriptor: the picker's provenance is decided by name, so a `copilot` declared
+/// on disk would read "From descriptors" and contradict the support table.
+///
+/// **This slice makes copilot launchable / attachable / resumable — no
+/// capability** (cost, turn-end, transcript land later, ADR-0051). So, like
+/// `opencode`, it is embedded but returns `None` from [`crate::harness_probes`].
+///
+/// The launch uses copilot's **interactive** mode (resident after the turn —
+/// ADR-0045 §3, the non-interactive `-p` exits at turn end and is ineligible):
+/// - `--allow-all` grants full autonomy — no tool, path or URL permission dialog
+///   (AC "aucun dialogue de permission d'outil, de chemin ou d'URL");
+/// - `--no-ask-user` disables the question tool, so the node never stalls asking;
+/// - the model hole is **absent when unset**, so a node with no explicit model
+///   launches on copilot's own automatic model selector (AC), the class of
+///   dead-end #561 measured on `opencode` never arises;
+/// - `--session-id {session_id}` pins the session identity at launch (measured on
+///   the installed binary — the caller-provided id the SDK documents, requested
+///   for the CLI in github/copilot-cli#167), so resume re-enters **this** node's
+///   session by identity, never a blind `--continue` (AC).
+///
+/// `COPILOT_AUTO_UPDATE=false` freezes the binary: PDO decides when the target
+/// moves, not the provider (AC).
+pub fn copilot() -> HarnessDescriptor {
+    HarnessDescriptor {
+        name: COPILOT.to_string(),
+        binary: "copilot".to_string(),
+        launch: [
+            "exec",
+            "copilot",
+            "--allow-all",
+            "--no-ask-user",
+            "--model {model}",
+            "--session-id {session_id}",
+            "{prompt}",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect(),
+        resume: ["exec", "copilot", "--allow-all", "--no-ask-user", "{resume}"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect(),
+        // Resume is by identity (`--resume '<id>'`) or not at all: `resume_blind`
+        // is empty, so a resume with no recorded id renders no resume flag rather
+        // than a blind continue (AC "jamais par un continue aveugle").
+        resume_by_id: "--resume".to_string(),
+        resume_blind: String::new(),
+        // PDO owns when the harness moves (AC): disable copilot's start-of-session
+        // plugin auto-update.
+        env: vec![("COPILOT_AUTO_UPDATE".to_string(), "false".to_string())],
     }
 }
 
 /// The embedded floor: the harnesses PDO ships compiled in, in precedence-neutral
 /// declaration order.
 pub fn embedded_floor() -> Vec<HarnessDescriptor> {
-    vec![claude(), opencode()]
+    vec![claude(), opencode(), copilot()]
 }
 
 /// Merge a user-declared disk tier over the embedded floor, **by name**: a disk
@@ -263,8 +343,33 @@ struct DescriptorRow {
     launch: Vec<String>,
     #[serde(default)]
     resume: Vec<String>,
+    /// The resume-by-identity verb (`--resume`) that fills the resume template's
+    /// `{resume}` hole (#614). Optional — a disk descriptor whose resume tail bakes
+    /// its verb literally (the shape the pre-#614 examples used) leaves it empty.
+    #[serde(default)]
+    resume_by_id: String,
+    /// The blind-resume verb (`--continue`) for a node with no recorded identity
+    /// (#614). Optional, same default as [`Self::resume_by_id`].
+    #[serde(default)]
+    resume_blind: String,
     #[serde(default)]
     env: BTreeMap<String, String>,
+}
+
+/// Whether the launch template makes the **declared binary the leader of the
+/// pane** — the one thing PDO validates about a descriptor (ADR-0054).
+///
+/// The check is syntactic (a proxy, ADR-0054 §"Limites"): the template must begin
+/// with the token `exec` immediately followed by the declared `binary`. `exec`
+/// replaces the pane's shell with the harness, so the harness — not a surviving
+/// shell — is the pane leader, which is the precondition of PDO's only terminal
+/// liveness verdict (ADR-0032): the harness dies ⇒ the session dies ⇒ the node
+/// fails visibly. A template that wraps the binary in a shell, or omits `exec`,
+/// leaves the shell leader: the harness can die while the session lives on, and
+/// the node stays `Running` forever, mute. That descriptor is refused.
+pub fn launch_makes_binary_leader(launch: &[String], binary: &str) -> bool {
+    launch.first().map(String::as_str) == Some("exec")
+        && launch.get(1).map(String::as_str) == Some(binary)
 }
 
 /// Parse the descriptor file (`descriptors.yaml`). PURE.
@@ -338,11 +443,31 @@ pub fn parse_descriptors(text: &str) -> ParsedDescriptors {
             });
             continue;
         }
+        // ADR-0054: the ONLY thing PDO validates about a descriptor — the launch
+        // must make the declared binary the pane leader (`exec <binary> …`).
+        // Otherwise the harness can die behind a surviving shell without the
+        // session dying, and the node stays `Running` forever, mute — PDO's only
+        // terminal liveness verdict (ADR-0032) becomes silently false. Same refusal
+        // shape as a missing `binary`/`launch`: the row is inert, its key falls
+        // through to the next tier.
+        if !launch_makes_binary_leader(&row.launch, &binary) {
+            parsed.rejected.push(RejectedDescriptor {
+                name,
+                why: format!(
+                    "launch does not make the binary `{binary}` the pane leader — it must begin \
+                     `exec {binary} …` (ADR-0054); otherwise the harness can die without the \
+                     session dying and the node hangs `Running` forever"
+                ),
+            });
+            continue;
+        }
         parsed.descriptors.push(HarnessDescriptor {
             name,
             binary,
             launch: row.launch,
             resume: row.resume,
+            resume_by_id: row.resume_by_id,
+            resume_blind: row.resume_blind,
             env: row.env.into_iter().collect(),
         });
     }
@@ -547,12 +672,103 @@ mod tests {
     }
 
     #[test]
+    fn copilot_is_on_the_floor_pins_identity_and_resumes_by_identity_only() {
+        // #614: copilot is the third arm of the embedded floor, launchable and
+        // resumable before any capability.
+        assert!(resolve(COPILOT).is_some());
+        let d = copilot();
+        assert_eq!(d.binary, "copilot");
+        // Full autonomy + question tool off, so a node runs unattended.
+        assert!(d.launch.iter().any(|t| t == "--allow-all"));
+        assert!(d.launch.iter().any(|t| t == "--no-ask-user"));
+        // A model hole that drops when unset ⇒ copilot's automatic selector.
+        assert!(d.launch.iter().any(|t| t.contains("{model}")));
+        // Identity is pinned at launch, so resume re-enters THIS session.
+        assert!(d.pins_session_id(), "copilot pins --session-id");
+        assert!(d.can_resume());
+        // Resume is by identity or not at all — never a blind continue (AC).
+        assert_eq!(d.resume_by_id, "--resume");
+        assert!(
+            d.resume_blind.is_empty(),
+            "copilot never blind-continues (AC)"
+        );
+        // Auto-update frozen: PDO owns when the target moves.
+        assert_eq!(
+            d.env,
+            vec![("COPILOT_AUTO_UPDATE".to_string(), "false".to_string())]
+        );
+    }
+
+    #[test]
+    fn the_whole_floor_makes_its_binary_the_pane_leader() {
+        // ADR-0054: PDO's one descriptor invariant holds for every embedded harness
+        // — each launch begins `exec <binary> …`, so the harness leads the pane.
+        for d in embedded_floor() {
+            assert!(
+                launch_makes_binary_leader(&d.launch, &d.binary),
+                "{} must make its binary the pane leader",
+                d.name
+            );
+        }
+    }
+
+    #[test]
+    fn resume_verbs_are_the_floor_harnesses_own_property() {
+        // #614: the resume verb is a descriptor property, not a resume-seam constant.
+        assert_eq!(claude().resume_by_id, "--resume");
+        assert_eq!(claude().resume_blind, "--continue");
+        // opencode cannot pin identity → blind-continue only.
+        assert!(opencode().resume_by_id.is_empty());
+        assert_eq!(opencode().resume_blind, "--continue");
+    }
+
+    #[test]
+    fn parse_descriptors_refuses_a_launch_that_does_not_lead_the_pane() {
+        // ADR-0054: a launch that wraps the binary in a shell (or omits `exec`) is
+        // refused whole, same shape as a missing `binary`/`launch`; its key falls
+        // through to the next tier.
+        let wrapped = parse_descriptors(
+            "harnesses:\n  x:\n    binary: x\n    launch: [\"bash\", \"-lc\", \"exec x\"]\n",
+        );
+        assert!(wrapped.descriptors.is_empty());
+        assert_eq!(wrapped.rejected.len(), 1);
+        assert_eq!(wrapped.rejected[0].name, "x");
+        assert!(wrapped.rejected[0].why.contains("pane leader"));
+
+        // Missing `exec` — the binary is launched but the shell stays leader.
+        let no_exec =
+            parse_descriptors("harnesses:\n  x:\n    binary: x\n    launch: [\"x\", \"--auto\"]\n");
+        assert_eq!(no_exec.rejected.len(), 1);
+        assert!(no_exec.rejected[0].why.contains("pane leader"));
+
+        // `exec` present but leading a DIFFERENT binary than declared.
+        let wrong_leader = parse_descriptors(
+            "harnesses:\n  x:\n    binary: x\n    launch: [\"exec\", \"y\", \"--auto\"]\n",
+        );
+        assert_eq!(wrong_leader.rejected.len(), 1);
+        assert!(wrong_leader.rejected[0].why.contains("pane leader"));
+    }
+
+    #[test]
+    fn parse_descriptors_carries_the_resume_verbs() {
+        // A disk descriptor may declare its resume verbs (#614), filling `{resume}`.
+        let parsed = parse_descriptors(
+            "harnesses:\n  h:\n    binary: h\n    launch: [\"exec\", \"h\", \"{prompt}\"]\n    resume: [\"exec\", \"h\", \"{resume}\"]\n    resume_by_id: \"--resume\"\n    resume_blind: \"--continue\"\n",
+        );
+        assert_eq!(parsed.descriptors.len(), 1);
+        assert_eq!(parsed.descriptors[0].resume_by_id, "--resume");
+        assert_eq!(parsed.descriptors[0].resume_blind, "--continue");
+    }
+
+    #[test]
     fn merge_by_name_replaces_a_floor_entry_and_keeps_the_rest() {
         let custom_claude = HarnessDescriptor {
             name: CLAUDE.to_string(),
             binary: "my-claude".to_string(),
             launch: vec!["exec".to_string(), "my-claude".to_string()],
             resume: vec![],
+            resume_by_id: String::new(),
+            resume_blind: String::new(),
             env: vec![],
         };
         let merged = merge_by_name(embedded_floor(), vec![custom_claude.clone()]);
@@ -570,11 +786,15 @@ mod tests {
             binary: "novel".to_string(),
             launch: vec!["exec".to_string(), "novel".to_string()],
             resume: vec![],
+            resume_by_id: String::new(),
+            resume_blind: String::new(),
             env: vec![],
         };
         let merged = merge_by_name(embedded_floor(), vec![novel]);
         assert!(merged.iter().any(|d| d.name == "novel"));
-        assert_eq!(merged.len(), 3);
+        // The three-harness floor (claude, opencode, copilot) plus the novel disk
+        // harness.
+        assert_eq!(merged.len(), 4);
     }
 
     // --- the disk tier (#553) ------------------------------------------------
@@ -655,7 +875,14 @@ mod tests {
         assert!(reg.resolve(OPENCODE).is_some());
         assert!(reg.resolve("nope").is_none());
         assert!(reg.diagnostic().is_none());
-        assert_eq!(reg.names(), vec![CLAUDE.to_string(), OPENCODE.to_string()]);
+        assert_eq!(
+            reg.names(),
+            vec![
+                CLAUDE.to_string(),
+                OPENCODE.to_string(),
+                COPILOT.to_string()
+            ]
+        );
     }
 
     #[test]
@@ -805,10 +1032,11 @@ mod tests {
     #[test]
     fn builtin_listing_is_the_floor_as_builtin() {
         let listing = HarnessRegistry::builtin().listing();
-        assert_eq!(listing.len(), 2);
+        assert_eq!(listing.len(), 3);
         assert!(listing.iter().all(|h| h.source == HarnessSource::Builtin));
         assert_eq!(listing[0].name, CLAUDE);
         assert_eq!(listing[1].name, OPENCODE);
+        assert_eq!(listing[2].name, COPILOT);
     }
 
     #[test]

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -8488,13 +8488,21 @@ async fn spawn_manager_session(
     let default_harness = stored_default_harness(&state.db).await;
     let manager_harness_name =
         harness_resolver::resolve_infra_harness(run_harness.as_deref(), default_harness.as_deref());
-    let manager_harness = harness_registry::resolve(&manager_harness_name).unwrap_or_else(|| {
-        warn!(
-            "manager for run {run_id}: unknown harness '{manager_harness_name}' — \
-             launching the manager on the claude floor (the first node spawn fails fast)"
-        );
-        harness_registry::claude()
-    });
+    // #614 (correctif 3): resolve against the DISK TIER, so "this Run runs on X" is
+    // true even when X is a user-declared harness — the manager follows the Run's
+    // frozen harness through the same registry the node spawns resolve against.
+    let harness_home_root = sandbox_run::sandbox_home_roots(state)
+        .map(|(home, _)| home)
+        .unwrap_or_default();
+    let manager_harness = harness_registry::HarnessRegistry::load(&harness_home_root)
+        .resolve(&manager_harness_name)
+        .unwrap_or_else(|| {
+            warn!(
+                "manager for run {run_id}: unknown harness '{manager_harness_name}' — \
+                 launching the manager on the claude floor (the first node spawn fails fast)"
+            );
+            harness_registry::claude()
+        });
     if let Err(e) = tmux_session_manager::spawn(
         &session_name,
         &full_prompt,
@@ -9498,6 +9506,27 @@ async fn put_settings(
         // no silent default) (#410/#432). Same shared gate as the Trigger surfaces.
         if let Err(msg) = validate_sandbox_ref(&state.db, s).await {
             return bad(&msg);
+        }
+    }
+    if let Some(h) = req.default_harness.as_deref() {
+        // #614 (correctif 10): "" = clear sentinel (accepted); anything else must
+        // RESOLVE against the registry (embedded floor merged with the disk tier),
+        // exactly as the default sandbox must above. A default harness that resolves
+        // to nothing would break EVERY subsequent spawn that falls through to it —
+        // so it is refused at registration, fail-fast, never a silent broken default.
+        if !h.is_empty() {
+            let home_root = sandbox_run::sandbox_home_roots(&state)
+                .map(|(home, _)| home)
+                .unwrap_or_default();
+            let registry = harness_registry::HarnessRegistry::load(&home_root);
+            if registry.resolve(h).is_none() {
+                return bad(&format!(
+                    "unknown default harness `{h}`: it resolves to no embedded or declared \
+                     harness — a default that does not resolve would break every spawn that \
+                     falls through to it. Known harnesses: {}",
+                    registry.names().join(", ")
+                ));
+            }
         }
     }
 
@@ -11327,6 +11356,13 @@ pub(crate) enum ReattachOutcome {
     /// ADR-0045). The optimal path is unavailable — the caller falls back
     /// (`recover_node` → restart-with-artifacts, AC #9 / `node_pane` → snapshot).
     CannotResume,
+    /// The harness FROZEN at spawn no longer resolves — its embedded name was
+    /// dropped, or its disk descriptor was removed/renamed (#614, correctif 2).
+    /// PDO **refuses** rather than relaunch `claude` in this node's worktree: a
+    /// silent fallback would run a different agent than the one the node was
+    /// started on, corrupting its transcript and its cost attribution. The caller
+    /// surfaces the refusal, naming the missing harness.
+    FrozenHarnessGone { harness: String },
     /// The session cap refused the re-attach (a re-attach IS a (re)spawn, #487 §3).
     CapReached { live: usize, cap: usize },
     /// The `NodeStarted` resurrection trace was refused (e.g. a terminal Run) — do
@@ -11382,16 +11418,28 @@ pub(crate) async fn reattach_node_session(
     let launch_effort = find_launch_effort(events, node_id, iter);
     let launch_session_id = find_launch_session_id(events, node_id, iter);
     // #550/#553/ADR-0046: re-pose the harness FROZEN at spawn, resolved against the
-    // embedded floor MERGED with the disk descriptor tier; any failure falls back
-    // to the `claude` floor, byte-identical to the legacy resume.
+    // embedded floor MERGED with the disk descriptor tier. #614 (correctif 2): a
+    // name that WAS frozen but no longer resolves REFUSES — never a silent `claude`
+    // relaunch, which would run a different agent in this node's worktree. A row
+    // with NO frozen harness (pre-#550, a legacy resume) keeps the `claude` floor,
+    // byte-identical to the legacy resume.
     let launch_harness = find_launch_harness(events, node_id, iter);
     let harness_home_root = sandbox_run::sandbox_home_roots(state)
         .map(|(home, _)| home)
         .unwrap_or_default();
-    let descriptor = launch_harness
-        .as_deref()
-        .and_then(|name| harness_registry::HarnessRegistry::load(&harness_home_root).resolve(name))
-        .unwrap_or_else(harness_registry::claude);
+    let descriptor = match launch_harness.as_deref() {
+        Some(name) => {
+            match harness_registry::HarnessRegistry::load(&harness_home_root).resolve(name) {
+                Some(d) => d,
+                None => {
+                    return ReattachOutcome::FrozenHarnessGone {
+                        harness: name.to_string(),
+                    }
+                }
+            }
+        }
+        None => harness_registry::claude(),
+    };
     // AC #9 / ADR-0045: a harness with no resume tail cannot be re-attached.
     if !descriptor.can_resume() {
         return ReattachOutcome::CannotResume;
@@ -11570,6 +11618,26 @@ async fn node_pane(
                     resumed: false,
                     stale: false,
                     source,
+                })
+                .into_response();
+            }
+            // #614 (correctif 2): the frozen harness no longer resolves — refuse,
+            // naming it, rather than relaunch `claude` in this node's worktree.
+            ReattachOutcome::FrozenHarnessGone { harness } => {
+                warn!(
+                    "node_pane: refusing to resurrect {node_id} iter {iter} in {run_id} — its \
+                     frozen harness '{harness}' no longer resolves (embedded name dropped or disk \
+                     descriptor removed); not relaunching claude in its place"
+                );
+                return Json(PaneResponse {
+                    content: format!(
+                        "Session cannot be resumed: this node's harness '{harness}' no longer \
+                         resolves. Restore its descriptor, or retry the node to start fresh."
+                    ),
+                    session_name,
+                    resumed: false,
+                    stale: false,
+                    source: "unavailable",
                 })
                 .into_response();
             }
@@ -11966,13 +12034,19 @@ async fn spawn_merge_resolver(
     let default_harness = stored_default_harness(&state.db).await;
     let resolver_harness_name =
         harness_resolver::resolve_infra_harness(run_harness.as_deref(), default_harness.as_deref());
-    let resolver_harness = harness_registry::resolve(&resolver_harness_name).unwrap_or_else(|| {
-        warn!(
-            "merge resolver for run {run_id}: unknown harness '{resolver_harness_name}' — \
-             launching on the claude floor"
-        );
-        harness_registry::claude()
-    });
+    // #614 (correctif 3): resolve against the DISK TIER, like the manager.
+    let resolver_home_root = sandbox_run::sandbox_home_roots(state)
+        .map(|(home, _)| home)
+        .unwrap_or_default();
+    let resolver_harness = harness_registry::HarnessRegistry::load(&resolver_home_root)
+        .resolve(&resolver_harness_name)
+        .unwrap_or_else(|| {
+            warn!(
+                "merge resolver for run {run_id}: unknown harness '{resolver_harness_name}' — \
+                 launching on the claude floor"
+            );
+            harness_registry::claude()
+        });
     if let Err(e) = tmux_session_manager::spawn(
         &session_name,
         &prompt,
@@ -13369,6 +13443,17 @@ async fn force_spawn_node(
         .map(|ov| materialize_override_inputs(&artifacts_dir, node_id, iter, ov))
         .filter(|m| !m.is_empty());
 
+    // #614 (correctif 4): resolve the winning harness against the DISK TIER, so a
+    // manual force-spawn / Start reaches a user-declared harness exactly like the
+    // scheduler's `spawn_node` does — these commands stop being reserved to
+    // embedded harnesses. Bound before `params` so the borrow outlives `start_node`.
+    // Absent HOME degrades to the embedded floor (`load` returns the floor when the
+    // file is unreadable).
+    let harness_home_root = sandbox_run::sandbox_home_roots(state)
+        .map(|(home, _)| home)
+        .unwrap_or_default();
+    let harness_registry = harness_registry::HarnessRegistry::load(&harness_home_root);
+
     let params = node_primitives::StartNodeParams {
         run_id,
         node_id,
@@ -13403,6 +13488,8 @@ async fn force_spawn_node(
         // auto-completion fresh so a force-spawned node arms the `Stop` hook when
         // the setting is on, instead of silently missing it on this seam alone.
         inject_hook: stored_autocomplete_turn_end(&state.db).await,
+        // #614 (correctif 4): honour the disk tier on this manual seam too.
+        harness_registry: Some(&harness_registry),
     };
 
     // D5 (#204): admission cap as an atomic check-and-reserve. Hold the lock
@@ -14202,13 +14289,19 @@ async fn open_library_assistant(
     // floor — mirror of the manager/merge-resolver resolution.
     let default_harness = stored_default_harness(&state.db).await;
     let harness_name = harness_resolver::resolve_infra_harness(None, default_harness.as_deref());
-    let harness = harness_registry::resolve(&harness_name).unwrap_or_else(|| {
-        warn!(
-            "library assistant for '{pipeline_id}': unknown harness '{harness_name}' — \
-             launching on the claude floor"
-        );
-        harness_registry::claude()
-    });
+    // #614 (correctif 3): resolve against the DISK TIER, like the manager/resolver.
+    let libassist_home_root = sandbox_run::sandbox_home_roots(&state)
+        .map(|(home, _)| home)
+        .unwrap_or_default();
+    let harness = harness_registry::HarnessRegistry::load(&libassist_home_root)
+        .resolve(&harness_name)
+        .unwrap_or_else(|| {
+            warn!(
+                "library assistant for '{pipeline_id}': unknown harness '{harness_name}' — \
+                 launching on the claude floor"
+            );
+            harness_registry::claude()
+        });
 
     // Keep the primer OUT of the user-facing pipelines dir: write it to a sibling
     // `.libassist/<id>.md` under the library root (the parent of `pipelines/`).
@@ -31601,8 +31694,9 @@ edges:
             assert!(h["installed"].is_boolean(), "installed is a bool: {h}");
         }
 
-        // The embedded floor always resolves, always as `builtin`.
-        for floor in ["claude", "opencode"] {
+        // The embedded floor always resolves, always as `builtin` — copilot is the
+        // third arm (#614), listed under "Built-in" like the other two.
+        for floor in ["claude", "opencode", "copilot"] {
             let entry = harnesses
                 .iter()
                 .find(|h| h["name"] == floor)

--- a/crates/pdo-daemon/src/node_primitives.rs
+++ b/crates/pdo-daemon/src/node_primitives.rs
@@ -123,8 +123,10 @@ pub(crate) struct StartNodeSpawn {
 enum StartNodeTail {
     Agent {
         /// #550: the resolved harness descriptor (owned; `execute` borrows it into
-        /// [`tmux_session_manager::SessionTail::Agent`]).
-        harness: harness_registry::HarnessDescriptor,
+        /// [`tmux_session_manager::SessionTail::Agent`]). Boxed (#614) so the wide
+        /// descriptor — grown by the resume fields — does not bloat every
+        /// `StartNodeTail` (`clippy::large_enum_variant`).
+        harness: Box<harness_registry::HarnessDescriptor>,
         model: Option<String>,
         effort: Option<String>,
         /// #473: the pinned Claude Code session id (owned mirror of
@@ -163,7 +165,7 @@ impl StartNodeSpawn {
                 effort,
                 session_id,
             } => tmux_session_manager::SessionTail::Agent {
-                harness,
+                harness: harness.as_ref(),
                 model: model.as_deref(),
                 effort: effort.as_deref(),
                 session_id: session_id.as_deref(),
@@ -495,9 +497,11 @@ pub(crate) fn start_node(params: &StartNodeParams<'_>) -> StartNodeResult {
         }
     } else {
         StartNodeTail::Agent {
-            harness: harness_descriptor
-                .clone()
-                .expect("a non-script node resolved a harness descriptor"),
+            harness: Box::new(
+                harness_descriptor
+                    .clone()
+                    .expect("a non-script node resolved a harness descriptor"),
+            ),
             model: resolved_model.clone(),
             effort: resolved_effort.clone(),
             session_id: session_id.clone(),

--- a/crates/pdo-daemon/src/node_primitives.rs
+++ b/crates/pdo-daemon/src/node_primitives.rs
@@ -74,6 +74,14 @@ pub(crate) struct StartNodeParams<'a> {
     /// keeps a manual force-spawn honouring the instance default — the same
     /// silent-bug class the `default_model` comment warns about (#347).
     pub inject_hook: bool,
+    /// The harness registry to resolve the winning harness name against (#614,
+    /// correctif 4). `Some` ⇒ the **disk tier** is honoured (embedded floor merged
+    /// with `~/.pdo/harnesses/descriptors.yaml`), so a force-spawn / Start-button
+    /// relaunch reaches a user-declared harness exactly like the scheduler's
+    /// `spawn_node` does — these commands stop being reserved to embedded harnesses.
+    /// `None` ⇒ the embedded floor only (the DB-less test default, and the pre-#614
+    /// behaviour). Borrowed: the async caller loads it once and passes a ref.
+    pub harness_registry: Option<&'a harness_registry::HarnessRegistry>,
 }
 
 /// Everything needed to launch the node's tmux session, once its reservation has
@@ -421,21 +429,31 @@ pub(crate) fn start_node(params: &StartNodeParams<'_>) -> StartNodeResult {
     };
     let harness_descriptor = match &resolved_harness {
         None => None,
-        Some(r) => match harness_registry::resolve(&r.harness) {
-            Some(d) => Some(d),
-            None => {
-                return StartNodeResult {
-                    outcome: PrimitiveOutcome::Rejected {
-                        reason: format!(
-                            "node '{}': unknown harness '{}'",
-                            params.node_id, r.harness
-                        ),
-                    },
-                    events: vec![],
-                    spawn: None,
-                };
+        // #614 (correctif 4): resolve the name against the disk tier when the
+        // caller supplied a loaded registry (force-spawn / Start), else the
+        // embedded floor (the DB-less default). Either way, an unresolvable name is
+        // a rejection that names it — never a silent claude fallback.
+        Some(r) => {
+            let resolved = match params.harness_registry {
+                Some(reg) => reg.resolve(&r.harness),
+                None => harness_registry::resolve(&r.harness),
+            };
+            match resolved {
+                Some(d) => Some(d),
+                None => {
+                    return StartNodeResult {
+                        outcome: PrimitiveOutcome::Rejected {
+                            reason: format!(
+                                "node '{}': unknown harness '{}'",
+                                params.node_id, r.harness
+                            ),
+                        },
+                        events: vec![],
+                        spawn: None,
+                    };
+                }
             }
-        },
+        }
     };
     // AC #10: a missing harness binary is a spawn that cannot happen — reject
     // (never a 2xx), naming the harness. Skipped under the test seam.
@@ -445,8 +463,14 @@ pub(crate) fn start_node(params: &StartNodeParams<'_>) -> StartNodeResult {
             return StartNodeResult {
                 outcome: PrimitiveOutcome::Rejected {
                     reason: format!(
-                        "node '{}': harness '{}' binary '{}' not found on PATH",
-                        params.node_id, d.name, d.binary
+                        "node '{}': harness '{}' binary '{}' not found in PATH {} \
+                         (ADR-0055: the user's interactive PATH, not the service's) — \
+                         install it or check the name; this is not \"not installed\" unless \
+                         the binary is truly absent from that PATH",
+                        params.node_id,
+                        d.name,
+                        d.binary,
+                        tmux_session_manager::harness_probe_path()
                     ),
                 },
                 events: vec![],
@@ -1102,6 +1126,7 @@ mod tests {
             default_harness_models: Default::default(),
             project_harness: None,
             inject_hook: false,
+            harness_registry: None,
         };
 
         let result = start_node(&params);
@@ -1145,6 +1170,7 @@ mod tests {
             default_harness_models: Default::default(),
             project_harness: None,
             inject_hook: false,
+            harness_registry: None,
         };
 
         let result = start_node(&params);
@@ -1194,6 +1220,7 @@ mod tests {
             default_harness_models: Default::default(),
             project_harness: None,
             inject_hook: true,
+            harness_registry: None,
         };
         let result = start_node(&params);
         assert_eq!(result.outcome, PrimitiveOutcome::Executed);
@@ -1248,6 +1275,7 @@ mod tests {
             default_harness_models: Default::default(),
             project_harness: None,
             inject_hook: true,
+            harness_registry: None,
         };
         let result = start_node(&params);
         assert_eq!(result.outcome, PrimitiveOutcome::Executed);
@@ -1314,6 +1342,7 @@ mod tests {
             default_harness_models: Default::default(),
             project_harness: None,
             inject_hook: false,
+            harness_registry: None,
         };
 
         let input_paths = resolve_inputs(&params, node);
@@ -1376,6 +1405,7 @@ mod tests {
             default_harness_models: Default::default(),
             project_harness: None,
             inject_hook: false,
+            harness_registry: None,
         };
 
         let input_paths = resolve_inputs(&params, node);
@@ -1435,6 +1465,7 @@ mod tests {
             default_harness_models: Default::default(),
             project_harness: None,
             inject_hook: false,
+            harness_registry: None,
         };
         let input_paths = resolve_inputs(&params, node);
         assert_eq!(
@@ -1544,6 +1575,7 @@ mod tests {
             default_harness_models: Default::default(),
             project_harness: None,
             inject_hook: false,
+            harness_registry: None,
         };
 
         let input_paths = resolve_inputs(&params, node);
@@ -1616,6 +1648,7 @@ mod tests {
             default_harness_models: Default::default(),
             project_harness: None,
             inject_hook: false,
+            harness_registry: None,
         };
 
         let input_paths = resolve_inputs(&params, node);
@@ -1711,6 +1744,7 @@ mod tests {
             default_harness_models: Default::default(),
             project_harness: None,
             inject_hook: false,
+            harness_registry: None,
         };
 
         let input_paths = resolve_inputs(&params, node);
@@ -1779,6 +1813,7 @@ mod tests {
             default_harness_models: Default::default(),
             project_harness: None,
             inject_hook: false,
+            harness_registry: None,
         };
 
         let input_paths = resolve_inputs(&params, node);
@@ -1847,6 +1882,7 @@ mod tests {
             default_harness_models: Default::default(),
             project_harness: None,
             inject_hook: false,
+            harness_registry: None,
         };
 
         let input_paths = resolve_inputs(&params, node);
@@ -2111,6 +2147,7 @@ mod tests {
             default_harness_models: Default::default(),
             project_harness: None,
             inject_hook: false,
+            harness_registry: None,
         };
 
         let result = start_node(&params);

--- a/crates/pdo-daemon/src/node_spawn.rs
+++ b/crates/pdo-daemon/src/node_spawn.rs
@@ -444,8 +444,12 @@ pub(crate) async fn spawn_node(
         if deps.tmux_cmd_override.is_none() && !tmux_session_manager::binary_available(&d.binary) {
             return SpawnOutcome::Failed {
                 reason: format!(
-                    "node {}: harness '{}' binary '{}' not found on PATH",
-                    node.id, d.name, d.binary
+                    "node {}: harness '{}' binary '{}' not found in PATH {} \
+                     (ADR-0055: the user's interactive PATH, not the service's)",
+                    node.id,
+                    d.name,
+                    d.binary,
+                    tmux_session_manager::harness_probe_path()
                 ),
             };
         }

--- a/crates/pdo-daemon/src/run_command.rs
+++ b/crates/pdo-daemon/src/run_command.rs
@@ -463,6 +463,17 @@ fn recover_response(
             "harness_cannot_resume",
             "the frozen harness declares no resume tail (ADR-0045)",
         ),
+        // #614 (correctif 2): the mechanism-choice above already refuses a gone
+        // frozen harness early, so this is normally unreachable — mapped for
+        // exhaustiveness, and honest if `reattach_node_session` reaches it.
+        ReattachOutcome::FrozenHarnessGone { harness } => recover_conflict(
+            mechanism,
+            "frozen_harness_gone",
+            &format!(
+                "this node's frozen harness '{harness}' no longer resolves; PDO will not \
+                 relaunch claude in its place"
+            ),
+        ),
         ReattachOutcome::TraceRefused { error } => {
             recover_conflict(mechanism, "reattach_refused", &error)
         }
@@ -1839,17 +1850,35 @@ async fn dispatch(state: Arc<AppState>, run_id: String, cmd: RunCommand) -> Resp
                 return (StatusCode::NOT_FOUND, "run not found").into_response();
             };
             // Resolve the frozen harness against the embedded floor merged with the
-            // disk descriptor tier; any failure (pre-#550 row, unknown name,
-            // unresolved home) falls back to the `claude` floor — which `can_resume`.
+            // disk descriptor tier. #614 (correctif 2): a name that WAS frozen but no
+            // longer resolves REFUSES — never a silent `claude` relaunch in this
+            // node's worktree. A row with NO frozen harness (pre-#550) keeps the
+            // `claude` floor, which `can_resume`.
             let harness_home_root = sandbox_run::sandbox_home_roots(&state)
                 .map(|(home, _)| home)
                 .unwrap_or_default();
-            let descriptor = crate::find_launch_harness(&events, &node_id, iter)
-                .as_deref()
-                .and_then(|name| {
-                    crate::harness_registry::HarnessRegistry::load(&harness_home_root).resolve(name)
-                })
-                .unwrap_or_else(crate::harness_registry::claude);
+            let descriptor = match crate::find_launch_harness(&events, &node_id, iter).as_deref() {
+                Some(name) => {
+                    match crate::harness_registry::HarnessRegistry::load(&harness_home_root)
+                        .resolve(name)
+                    {
+                        Some(d) => d,
+                        None => {
+                            return recover_conflict(
+                                crate::recovery::RecoveryMechanism::Reattach,
+                                "frozen_harness_gone",
+                                &format!(
+                                    "this node's frozen harness '{name}' no longer resolves \
+                                     (embedded name dropped or disk descriptor removed); PDO will \
+                                     not relaunch claude in its place — restore its descriptor, or \
+                                     retry the node to start fresh"
+                                ),
+                            );
+                        }
+                    }
+                }
+                None => crate::harness_registry::claude(),
+            };
             let mechanism = crate::recovery::choose_recovery(descriptor.can_resume());
 
             // Audit the intent, naming the mechanism so the automatic fallback is

--- a/crates/pdo-daemon/src/tmux_session_manager.rs
+++ b/crates/pdo-daemon/src/tmux_session_manager.rs
@@ -5,6 +5,7 @@
 
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
@@ -562,16 +563,20 @@ fn build_resume_script(
     sandbox: Option<&SandboxWrap<'_>>,
     settings_path: Option<&Path>,
 ) -> String {
-    // #473/ADR-0045: the resume *selector* is the one thing the pure hole-drop
-    // rule cannot express (emit `--continue` precisely *when* the id is empty), so
-    // it is computed here — "reprendre par identité ou en aveugle" stays in code.
-    // `--resume <uuid>` targets THIS node's transcript by identity; a row with no
-    // recorded id (pre-#473, or a harness like `opencode` that can't pin one)
-    // falls back to blind `--continue`. Both delivered harnesses blind-continue
-    // with `--continue`.
+    // #473/#614: the resume *selector* is the one thing the pure hole-drop rule
+    // cannot express (emit the blind verb precisely *when* the id is empty), so it
+    // is computed here — but the VERBS are now the descriptor's property, not
+    // constants (#614). `<resume_by_id> '<uuid>'` targets THIS node's transcript by
+    // identity; a row with no recorded id (pre-#473, or a harness like `opencode`
+    // that can't pin one) falls back to the harness's blind verb. A harness that
+    // declares neither (an empty `resume_by_id`/`resume_blind` for the case at
+    // hand) renders no resume flag: `copilot` resumes by identity or not at all,
+    // never a blind continue (AC).
     let resume_selector = match session_id {
-        Some(s) if !s.is_empty() => format!("--resume {}", sh_single_quote(s)),
-        _ => "--continue".to_string(),
+        Some(s) if !s.is_empty() && !descriptor.resume_by_id.is_empty() => {
+            format!("{} {}", descriptor.resume_by_id, sh_single_quote(s))
+        }
+        _ => descriptor.resume_blind.clone(),
     };
     let quote_opt = |v: Option<&str>| {
         v.filter(|s| !s.is_empty())
@@ -1202,12 +1207,93 @@ pub fn default_harness_with(stored: Option<String>) -> Option<String> {
         .or_else(env_default_harness)
 }
 
-/// Whether `binary` resolves on the current `PATH` — the fail-fast spawn check
-/// (#550, AC #10). A name with a `/` is checked directly; a bare name is searched
-/// across `$PATH`. **Never executes** the binary (a probe run could hang a
-/// resident harness), and lives here (not in the pure `harness_registry`) because
-/// it reads `$PATH`. A missing binary makes the spawn fail *before* any session
-/// or start event exists (ADR-0037).
+/// The `PATH` the daemon searches for harness binaries (ADR-0055).
+///
+/// A daemon launched as a service inherits the **unit's** `PATH`, which misses the
+/// entries a package manager (Homebrew, nvm, a user prefix) adds only to an
+/// **interactive** shell — so a harness the user installed and can run by hand is
+/// invisible to the service, and the spawn fails saying an installed binary does
+/// not exist. This resolves the binary in the `PATH` the user has *when they type
+/// the command*: the interactive shell's `PATH`, unioned with the process `PATH`
+/// so nothing the service already saw is lost. Measured (ADR-0055): a *login*
+/// shell does not suffice — package managers add their paths from the
+/// **interactive** rc files — so the probe sources an interactive shell (`-i`).
+///
+/// Resolved **once** and cached for the daemon's lifetime: the cost of sourcing
+/// the user's shell config is paid at the first probe, not per spawn, and a `PATH`
+/// the user changes afterwards is seen only on the next daemon start (ADR-0055
+/// limits, same freshness contract as the model catalogue, ADR-0053). The env
+/// override `PDO_HARNESS_PROBE_PATH` short-circuits the shell probe (ops / tests).
+pub fn harness_probe_path() -> String {
+    static PROBE_PATH: OnceLock<String> = OnceLock::new();
+    PROBE_PATH.get_or_init(resolve_harness_probe_path).clone()
+}
+
+/// Compute the probe `PATH` (uncached): the interactive shell's `PATH` unioned
+/// with the process `PATH`. See [`harness_probe_path`].
+fn resolve_harness_probe_path() -> String {
+    // An explicit override wins outright — the deterministic seam a test or an
+    // operator uses instead of the ambient shell.
+    if let Some(p) = std::env::var_os("PDO_HARNESS_PROBE_PATH") {
+        if !p.is_empty() {
+            return p.to_string_lossy().into_owned();
+        }
+    }
+    let process_path = std::env::var_os("PATH")
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    match interactive_path_via_shell() {
+        Some(interactive) => union_paths(&interactive, &process_path),
+        None => process_path,
+    }
+}
+
+/// The user's `PATH` as an **interactive** shell reports it, or `None` when the
+/// probe fails (no `$SHELL`, the shell errors, empty output). Runs `$SHELL -i -c`
+/// so the interactive rc files — where version and package managers add their
+/// paths — are sourced (a *login* shell, `-l`, is not enough; ADR-0055).
+fn interactive_path_via_shell() -> Option<String> {
+    let shell = std::env::var_os("SHELL").filter(|s| !s.is_empty())?;
+    // `printf` with no trailing newline, stdout only — job-control chatter an
+    // interactive shell may emit goes to stderr and is ignored.
+    let output = std::process::Command::new(&shell)
+        .arg("-i")
+        .arg("-c")
+        .arg(r#"printf '%s' "$PATH""#)
+        .output()
+        .ok()?;
+    let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!path.is_empty()).then_some(path)
+}
+
+/// Union two `PATH` strings, `first` taking precedence, dropping duplicates and
+/// empty entries while preserving order. Pure — the testable core of the ADR-0055
+/// merge.
+fn union_paths(first: &str, second: &str) -> String {
+    let mut seen = std::collections::HashSet::new();
+    let joined: Vec<String> = std::env::split_paths(first)
+        .chain(std::env::split_paths(second))
+        .filter(|p| !p.as_os_str().is_empty())
+        .filter(|p| seen.insert(p.clone()))
+        .map(|p| p.to_string_lossy().into_owned())
+        .collect();
+    joined.join(":")
+}
+
+/// Whether `binary` resolves in `path`. Pure — the testable core of the probe.
+fn path_contains_binary(path: &str, binary: &str) -> bool {
+    std::env::split_paths(path).any(|dir| dir.join(binary).is_file())
+}
+
+/// Whether `binary` resolves on the harness probe `PATH` — the fail-fast spawn
+/// check (#550, AC #10). A name with a `/` is checked directly; a bare name is
+/// searched across [`harness_probe_path`] (the user's interactive `PATH`, ADR-0055
+/// — **not** the service's inherited one). **Never executes** the binary (a probe
+/// run could hang a resident harness), and lives here (not in the pure
+/// `harness_registry`) because it reads the environment. A missing binary makes
+/// the spawn fail *before* any session or start event exists (ADR-0037); the
+/// caller's diagnostic names [`harness_probe_path`] so "not found" cannot read as
+/// "not installed".
 pub fn binary_available(binary: &str) -> bool {
     if binary.is_empty() {
         return false;
@@ -1215,10 +1301,7 @@ pub fn binary_available(binary: &str) -> bool {
     if binary.contains('/') {
         return Path::new(binary).is_file();
     }
-    match std::env::var_os("PATH") {
-        Some(path) => std::env::split_paths(&path).any(|dir| dir.join(binary).is_file()),
-        None => false,
-    }
+    path_contains_binary(&harness_probe_path(), binary)
 }
 
 /// Resolve the model a work node launches with: the node's own `model:`
@@ -2082,9 +2165,10 @@ mod tests {
         assert_eq!(decisions[2].verdict, SweepVerdict::Keep);
     }
 
-    /// #550/AC #10: the fail-fast PATH probe. A bare name absent from `$PATH` is
-    /// unavailable; an empty name is never available; a slash-path is checked as a
-    /// file directly. `sh` is on every CI box, so it stands in for "installed".
+    /// #550/AC #10: the fail-fast PATH probe. A bare name absent from the probe
+    /// `PATH` is unavailable; an empty name is never available; a slash-path is
+    /// checked as a file directly. `sh` is on every CI box (and the process `PATH`
+    /// is unioned into the probe path, ADR-0055), so it stands in for "installed".
     #[test]
     fn binary_available_probes_path_without_executing() {
         assert!(!binary_available(""), "empty name is never available");
@@ -2100,6 +2184,40 @@ mod tests {
             !binary_available("/no/such/absolute/path/binary"),
             "a missing slash-path is unavailable"
         );
+    }
+
+    /// ADR-0055: the pure core of the probe `PATH` search — a directory that holds
+    /// the binary makes it resolvable; one that does not, does not.
+    #[test]
+    fn path_contains_binary_searches_each_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        let bin = dir.path().join("my-harness");
+        std::fs::write(&bin, b"#!/bin/sh\n").unwrap();
+        let path = format!("/nonexistent-a:{}:/nonexistent-b", dir.path().display());
+        assert!(path_contains_binary(&path, "my-harness"));
+        assert!(!path_contains_binary(&path, "absent-harness"));
+        assert!(
+            !path_contains_binary("/nonexistent-a:/nonexistent-b", "my-harness"),
+            "no entry holds it"
+        );
+    }
+
+    /// ADR-0055: the user's interactive `PATH` is unioned with the process one,
+    /// first wins, duplicates and empty entries dropped, order preserved — so the
+    /// package-manager prefix the service never inherited becomes searchable
+    /// without losing any entry the service already had.
+    #[test]
+    fn union_paths_merges_first_precedence_dedup_order_preserved() {
+        assert_eq!(
+            union_paths("/opt/homebrew/bin:/usr/bin", "/usr/bin:/bin"),
+            "/opt/homebrew/bin:/usr/bin:/bin"
+        );
+        // Empty operands collapse cleanly.
+        assert_eq!(union_paths("", "/usr/bin:/bin"), "/usr/bin:/bin");
+        assert_eq!(union_paths("/usr/bin", ""), "/usr/bin");
+        assert_eq!(union_paths("", ""), "");
+        // A stray empty entry ("::") never becomes a "search the cwd" hole.
+        assert_eq!(union_paths("/a::/b", "/b"), "/a:/b");
     }
 
     #[test]
@@ -3310,6 +3428,52 @@ mod tests {
         );
         // Effort is still re-posed after the resume flag (#424).
         assert!(wrapped.contains("--effort"), "{wrapped}");
+    }
+
+    #[test]
+    fn build_resume_script_takes_the_resume_verb_from_the_descriptor() {
+        // #614: the resume verb is the descriptor's property, not a seam constant.
+        // copilot resumes by identity with ITS `--resume`, and — because its
+        // `resume_blind` is empty — a resume with no id renders NO resume flag,
+        // never a blind `--continue`.
+        let sid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let by_id = build_resume_script(
+            "r1",
+            "solo",
+            1,
+            6172,
+            &crate::harness_registry::copilot(),
+            None,
+            Some(sid),
+            None,
+            None,
+            None,
+        );
+        assert!(
+            by_id.contains(&format!(r"--resume '\''{sid}'\''")),
+            "copilot resumes by identity with its own --resume verb: {by_id}"
+        );
+        assert!(
+            !by_id.contains("--continue"),
+            "copilot never blind-continues: {by_id}"
+        );
+
+        let no_id = build_resume_script(
+            "r1",
+            "solo",
+            1,
+            6172,
+            &crate::harness_registry::copilot(),
+            None,
+            None,
+            None,
+            None,
+            None,
+        );
+        assert!(
+            !no_id.contains("--resume") && !no_id.contains("--continue"),
+            "with no identity copilot renders no resume flag at all (AC): {no_id}"
+        );
     }
 
     #[test]

--- a/crates/pdo-daemon/tests/harness_default_registration.rs
+++ b/crates/pdo-daemon/tests/harness_default_registration.rs
@@ -1,0 +1,79 @@
+//! #614 (correctif 10): a default harness that does not resolve is **refused at
+//! registration**, exactly as the default sandbox already is — never accepted and
+//! then breaking every spawn that falls through to it.
+//!
+//! Layer-3, through `PUT /settings`. An embedded name (`claude`, `copilot`)
+//! resolves and is accepted; an unknown name is a `400` that names the knobs.
+
+mod common;
+
+use common::TestDaemon;
+
+/// A minimal repo so the daemon boots; no run is created here.
+fn seed() -> impl FnOnce(&std::path::Path) -> anyhow::Result<()> {
+    |dir: &std::path::Path| {
+        let run = |args: &[&str]| -> anyhow::Result<()> {
+            let out = std::process::Command::new("git")
+                .args(args)
+                .current_dir(dir)
+                .output()?;
+            anyhow::ensure!(out.status.success(), "git {args:?} failed");
+            Ok(())
+        };
+        run(&["init", "-q"])?;
+        run(&["config", "user.email", "t@e.st"])?;
+        run(&["config", "user.name", "t"])?;
+        std::fs::write(dir.join("README.md"), "x\n")?;
+        std::fs::write(dir.join(".gitignore"), ".pdo/runs/\n")?;
+        run(&["add", "."])?;
+        run(&["commit", "-q", "-m", "init"])?;
+        Ok(())
+    }
+}
+
+async fn put_default_harness(daemon: &TestDaemon, name: &str) -> reqwest::Response {
+    reqwest::Client::new()
+        .put(format!("{}/settings", daemon.url()))
+        .json(&serde_json::json!({ "default_harness": name }))
+        .send()
+        .await
+        .unwrap()
+}
+
+#[tokio::test]
+async fn an_embedded_default_harness_is_accepted() {
+    let daemon = TestDaemon::spawn(seed()).await.unwrap();
+    for name in ["claude", "opencode", "copilot"] {
+        let resp = put_default_harness(&daemon, name).await;
+        assert_eq!(
+            resp.status(),
+            200,
+            "an embedded harness `{name}` must be an accepted default"
+        );
+    }
+}
+
+#[tokio::test]
+async fn a_default_harness_that_does_not_resolve_is_refused() {
+    let daemon = TestDaemon::spawn(seed()).await.unwrap();
+    let resp = put_default_harness(&daemon, "totally-unknown-harness-xyz").await;
+    assert_eq!(
+        resp.status(),
+        400,
+        "an unresolvable default harness must be refused at registration (correctif 10)"
+    );
+    let body: serde_json::Value = resp.json().await.unwrap();
+    let err = body["error"].as_str().unwrap_or_default();
+    assert!(
+        err.contains("totally-unknown-harness-xyz") && err.contains("default harness"),
+        "the refusal must name the bad harness: {err}"
+    );
+}
+
+#[tokio::test]
+async fn clearing_the_default_harness_is_accepted() {
+    // "" is the clear sentinel — accepted, so a user can reset to the floor.
+    let daemon = TestDaemon::spawn(seed()).await.unwrap();
+    let resp = put_default_harness(&daemon, "").await;
+    assert_eq!(resp.status(), 200, "the empty clear sentinel is accepted");
+}

--- a/crates/pdo-daemon/tests/harness_resume_frozen_gone.rs
+++ b/crates/pdo-daemon/tests/harness_resume_frozen_gone.rs
@@ -1,0 +1,176 @@
+//! #614 (correctif 2): resuming a node whose **frozen descriptor is gone**
+//! REFUSES — it never relaunches `claude` in the node's worktree.
+//!
+//! Layer 3, through the daemon. A node is pinned to a disk-declared harness
+//! (`ghost`), spawned through the tmux command seam (a harmless `sleep`, so the
+//! ghost binary need never exist), and freezes `ghost` on `NodeStarted`. The disk
+//! descriptor is then removed and the live session killed. `GET …/pane` must read
+//! the frozen `ghost`, fail to resolve it, and refuse — naming the harness — rather
+//! than silently re-enter this worktree on a `claude --continue`, which would run a
+//! different agent than the node was started on.
+
+mod common;
+
+use common::TestDaemon;
+
+const PIPELINE_NAME: &str = "ghost-test";
+const PIPELINE_YAML: &str = r#"name: ghost-test
+version: "1.0"
+nodes:
+  - id: start
+    name: Start
+    type: start
+    outputs:
+      - name: user_prompt
+  - id: cccccccc
+    name: on-ghost
+    type: doc-only
+    pin_harness: ghost
+    outputs:
+      - name: out
+    view: { x: 200, y: 120 }
+  - id: end
+    name: End
+    type: end
+    inputs:
+      - name: result
+edges:
+  - source: { node: start, port: user_prompt }
+    target: { node: cccccccc, port: task }
+  - source: { node: cccccccc, port: out }
+    target: { node: end, port: result }
+"#;
+
+/// A disk descriptor declaring `ghost` — leader-correct (`exec ghost …`), so it
+/// loads, and resumable by identity (`--resume` fills `{resume}`).
+const GHOST_DESCRIPTOR: &str = r#"harnesses:
+  ghost:
+    binary: ghost
+    launch: ["exec", "ghost", "--auto", "--model {model}", "--session-id {session_id}", "{prompt}"]
+    resume: ["exec", "ghost", "--auto", "{resume}"]
+    resume_by_id: "--resume"
+"#;
+
+fn descriptors_path(home: &std::path::Path) -> std::path::PathBuf {
+    home.join(".pdo").join("harnesses").join("descriptors.yaml")
+}
+
+fn seed(repo: &std::path::Path) -> anyhow::Result<()> {
+    let pipelines_dir = repo.join(".pdo").join("pipelines");
+    std::fs::create_dir_all(&pipelines_dir)?;
+    std::fs::write(
+        pipelines_dir.join(format!("{PIPELINE_NAME}.yaml")),
+        PIPELINE_YAML,
+    )?;
+    let prompts_dir = pipelines_dir.join(format!("{PIPELINE_NAME}.prompts"));
+    std::fs::create_dir_all(&prompts_dir)?;
+    std::fs::write(prompts_dir.join("cccccccc.md"), "You are on ghost.\n")?;
+
+    // Declare `ghost` on disk (home root == repo root under the home override).
+    let dpath = descriptors_path(repo);
+    std::fs::create_dir_all(dpath.parent().unwrap())?;
+    std::fs::write(&dpath, GHOST_DESCRIPTOR)?;
+
+    let run = |args: &[&str]| -> anyhow::Result<()> {
+        let out = std::process::Command::new("git")
+            .args(args)
+            .current_dir(repo)
+            .output()?;
+        anyhow::ensure!(
+            out.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        Ok(())
+    };
+    run(&["init", "-q", "-b", "main"])?;
+    run(&["config", "user.email", "test@example.com"])?;
+    run(&["config", "user.name", "Test"])?;
+    run(&["config", "commit.gpgsign", "false"])?;
+    std::fs::write(repo.join(".gitignore"), ".pdo/runs/\n")?;
+    run(&["add", "."])?;
+    run(&["commit", "-q", "-m", "init"])?;
+    Ok(())
+}
+
+async fn create_run(daemon: &TestDaemon) -> String {
+    let resp = reqwest::Client::new()
+        .post(format!("{}/runs", daemon.url()))
+        .json(&serde_json::json!({
+            "pipeline": PIPELINE_NAME,
+            "input": "go",
+            "target_repo": daemon.target_repo(),
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 201, "POST /runs should return 201");
+    let json: serde_json::Value = resp.json().await.unwrap();
+    json["run_id"].as_str().unwrap().to_string()
+}
+
+async fn started_harness(daemon: &TestDaemon, run_id: &str, node: &str) -> Option<String> {
+    let v: serde_json::Value = reqwest::get(format!("{}/runs/{run_id}/events", daemon.url()))
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    v.as_array()?
+        .iter()
+        .rev()
+        .find(|e| e["kind"] == "node_started" && e["node_id"] == node)
+        .and_then(|e| e["payload"]["harness"].as_str())
+        .map(String::from)
+}
+
+async fn wait_for_ghost_started(daemon: &TestDaemon, run_id: &str) {
+    for _ in 0..50 {
+        if started_harness(daemon, run_id, "cccccccc").await.as_deref() == Some("ghost") {
+            return;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+    panic!("the ghost-pinned node should have started within the timeout");
+}
+
+#[tokio::test]
+async fn resume_of_a_gone_frozen_harness_refuses_never_relaunches_claude() {
+    let daemon = TestDaemon::spawn_with_home_override(seed, Some("exec sleep 600".to_string()))
+        .await
+        .unwrap();
+    let run_id = create_run(&daemon).await;
+    wait_for_ghost_started(&daemon, &run_id).await;
+
+    // Kill the node's live session so `/pane` must RESUME rather than capture.
+    let socket = daemon.tmux_socket();
+    let session = format!("pdo-{run_id}-cccccccc-iter-1");
+    let _ = std::process::Command::new("tmux")
+        .args(["-L", &socket, "kill-session", "-t", &session])
+        .output();
+
+    // Remove the disk descriptor: `ghost` no longer resolves in any tier.
+    std::fs::remove_file(descriptors_path(daemon.repo_root())).unwrap();
+
+    // The pane endpoint reads the frozen `ghost`, cannot resolve it, and REFUSES —
+    // naming the harness — instead of relaunching claude in this worktree.
+    let resp = reqwest::get(format!(
+        "{}/runs/{run_id}/nodes/cccccccc/pane",
+        daemon.url()
+    ))
+    .await
+    .unwrap();
+    assert_eq!(resp.status(), 200);
+    let pane: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(
+        pane["source"].as_str(),
+        Some("unavailable"),
+        "a gone frozen harness must refuse, not resume: {pane}"
+    );
+    assert_eq!(pane["resumed"].as_bool(), Some(false), "{pane}");
+    let content = pane["content"].as_str().unwrap_or_default();
+    assert!(
+        content.contains("ghost") && content.contains("no longer resolves"),
+        "the refusal must name the missing harness: {content}"
+    );
+}


### PR DESCRIPTION
Livre l'issue #614 sur la branche d'intégration `integration/copilot-first-party` :
`copilot` devient le **deuxième harnais first-party** — lançable, attachable, reprenable.

## Contenu
- Descripteur `copilot()` embarqué comme troisième builtin du plancher, aux côtés de
  `claude` et `opencode`. Binaire `copilot` résolu dans le PATH interactif de l'utilisateur.
- Lancement en mode interactif (résident après le tour), attache et reprise par identité de session.
- Posé **par-dessus le prefactor #613** (les cinq capacités deviennent des points de dispatch) :
  la branche d'intégration avait déjà mergé #613 (PR #618) et consommé 1.36.0 ; ce lot a été
  mergé sur cet état, sans conflit sémantique.

## Validation (check local vert)
- Verdict du testeur agentique : **Pass** (ID visuel confirmé — `copilot` en section BUILT-IN,
  installé et sélectionnable, aux côtés de `claude`/`opencode`).
- `cargo build --workspace` : exit 0 sur l'arbre mergé.
- `cargo test --workspace` : **2423 passés, 0 échec**.

## Version
1.36.0 -> **1.37.0** (feat : nouveau harnais first-party ; 1.36.0 était déjà pris par #613).

Closes #614
