### PR TITLE
fix(#598): reprise UI d'une node interrupted — 1.35.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "1.35.0"
+version = "1.35.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "1.35.0"
+version = "1.35.1"
 license = "MIT"
 description = "Prompt-Driven Orchestrator — a local daemon that runs and supervises agentic coding pipelines"
 repository = "https://github.com/Loulen/prompt-driven-orchestrator"

--- a/frontend/e2e/interrupted-node-fp.spec.ts
+++ b/frontend/e2e/interrupted-node-fp.spec.ts
@@ -1,0 +1,282 @@
+import { test, expect } from "@playwright/test";
+import type { Page } from "@playwright/test";
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { cleanupRuns, runMultipart } from "./helpers";
+
+// FP validation — #598 / ADR-0049: an interactive node whose tmux session dies
+// parks `interrupted` (recoverable) and the panel must now offer a way out:
+// Play + Reopen banner + Mark complete + a minimized (no "can't find session")
+// terminal; a Reopen revives the session; and an archived run shows none of it.
+//
+// This drives the REAL system end to end: a real daemon (webServer), a real
+// tmux session per node, killed for real, and the real stale-detector sweep
+// producing `interrupted`. Screenshots are annotated and written to the PDO
+// feature-screens artifact directory for the run report.
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const WORKSPACE_ROOT = path.resolve(__dirname, "..", "..");
+const PORT = Number(process.env.PDO_E2E_PORT ?? 5273);
+const SOCKET = `pdo-${PORT}`;
+const SHOTS = process.env.PDO_FP_SHOTS_DIR ?? path.join(WORKSPACE_ROOT, "fp-shots");
+
+const PIPELINE_NAME = `e2e-interrupted-fp-${process.pid}-${Date.now()}`;
+const PIPELINE_DIR = path.join(WORKSPACE_ROOT, ".pdo", "pipelines");
+const PIPELINE_PATH = path.join(PIPELINE_DIR, `${PIPELINE_NAME}.yaml`);
+
+// A single worker node with a live session. The stale detector only probes
+// nodes in `Running` state (`running_nodes`), so this worker must be running
+// when its session dies — the reproduce doc's "running" branch. The panel's
+// recovery affordances key on `status === "interrupted"` alone (not node type),
+// so a running worker turned interrupted exercises the exact fixed code path.
+const SEED_YAML = `name: ${PIPELINE_NAME}
+version: "1.0"
+nodes:
+  - id: start
+    name: Start
+    type: start
+    outputs:
+      - { name: user_prompt, side: bottom }
+    view: { x: 100, y: 0 }
+  - id: worker
+    name: worker
+    type: doc-only
+    inputs:
+      - { name: task, side: top }
+    outputs:
+      - { name: summary, side: bottom }
+    view: { x: 100, y: 150 }
+  - id: end
+    name: End
+    type: end
+    inputs:
+      - { name: result, side: top }
+    view: { x: 100, y: 300 }
+edges:
+  - source: { node: start, port: user_prompt }
+    target: { node: worker, port: task }
+  - source: { node: worker, port: summary }
+    target: { node: end, port: result }
+`;
+
+const createdRunIds: string[] = [];
+
+// Wide viewport so the right-hand Run inspector (where every affordance lives)
+// is fully on screen and the annotation callouts aren't clipped at the edge.
+test.use({ viewport: { width: 1600, height: 900 } });
+
+test.beforeAll(async () => {
+  await fs.mkdir(PIPELINE_DIR, { recursive: true });
+  await fs.writeFile(PIPELINE_PATH, SEED_YAML);
+  await fs.mkdir(SHOTS, { recursive: true });
+});
+
+test.afterAll(async () => {
+  await fs.rm(PIPELINE_PATH, { force: true });
+  await cleanupRuns(...createdRunIds);
+});
+
+async function waitWorkerStatus(
+  page: Page,
+  baseURL: string,
+  runId: string,
+  status: string,
+  timeout = 45_000,
+) {
+  await expect(async () => {
+    const resp = await page.request.get(`${baseURL}/runs/${runId}`);
+    expect(resp.status()).toBe(200);
+    const json = await resp.json();
+    expect(json.nodes?.worker?.status).toBe(status);
+  }).toPass({ timeout });
+}
+
+// An interactive node parks `awaiting_user` (a live, attachable tmux session)
+// rather than `running` — that live session is precisely what the stale
+// detector later finds dead and turns into `interrupted`.
+async function waitWorkerLive(page: Page, baseURL: string, runId: string) {
+  await expect(async () => {
+    const resp = await page.request.get(`${baseURL}/runs/${runId}`);
+    expect(resp.status()).toBe(200);
+    const json = await resp.json();
+    expect(["running", "awaiting_user"]).toContain(json.nodes?.worker?.status);
+  }).toPass({ timeout: 45_000 });
+}
+
+async function createRun(page: Page, baseURL: string): Promise<string> {
+  const resp = await page.request.post(`${baseURL}/runs`, {
+    multipart: runMultipart({ pipeline: PIPELINE_NAME, input: "e2e interrupted-node FP" }),
+  });
+  expect(resp.status()).toBe(201);
+  const { run_id } = await resp.json();
+  createdRunIds.push(run_id);
+  await waitWorkerLive(page, baseURL, run_id);
+  return run_id;
+}
+
+// Select a run in the left panel, its worker node, and switch to the Run tab.
+async function openWorker(page: Page, runId: string) {
+  await page
+    .getByText(runId.slice(0, 20))
+    .first()
+    .click({ timeout: 5_000, position: { x: 5, y: 5 } });
+  await page.waitForTimeout(400);
+  const node = page.getByText("worker", { exact: true }).first();
+  await expect(node).toBeVisible({ timeout: 5_000 });
+  await node.click();
+  const runTab = page.getByTestId("inspector-tab-run");
+  if (await runTab.count()) await runTab.click({ timeout: 5_000 });
+}
+
+// Draw a caption banner + numbered callouts over the live page, then screenshot.
+// Annotations are pure DOM overlays removed right after the capture.
+async function annotateAndShoot(
+  page: Page,
+  file: string,
+  title: string,
+  callouts: { testid: string; label: string }[],
+) {
+  await page.evaluate(
+    ({ title, callouts }) => {
+      const root = document.createElement("div");
+      root.id = "__fp_annot__";
+      const cap = document.createElement("div");
+      cap.textContent = title;
+      Object.assign(cap.style, {
+        position: "fixed", top: "0", left: "0", right: "0", zIndex: "2147483647",
+        background: "#0b1021", color: "#fff", font: "600 14px/1.5 system-ui, sans-serif",
+        padding: "8px 14px", borderBottom: "2px solid #f59e0b", whiteSpace: "pre-wrap",
+      } as CSSStyleDeclaration);
+      root.appendChild(cap);
+      callouts.forEach((c, i) => {
+        const el = document.querySelector(`[data-testid="${c.testid}"]`) as HTMLElement | null;
+        if (!el) return;
+        const r = el.getBoundingClientRect();
+        const box = document.createElement("div");
+        Object.assign(box.style, {
+          position: "fixed", left: `${r.left - 3}px`, top: `${r.top - 3}px`,
+          width: `${r.width + 6}px`, height: `${r.height + 6}px`, zIndex: "2147483646",
+          border: "2px solid #f59e0b", borderRadius: "6px", boxShadow: "0 0 0 2px rgba(0,0,0,.35)",
+          pointerEvents: "none",
+        } as CSSStyleDeclaration);
+        const tag = document.createElement("div");
+        tag.textContent = `${i + 1}. ${c.label}`;
+        // Flip the label to open leftward when the element sits in the right
+        // third of the viewport, so the caption never runs off-screen.
+        const flip = r.left > window.innerWidth * 0.6;
+        Object.assign(tag.style, {
+          position: "fixed", top: `${r.top - 24}px`, zIndex: "2147483647",
+          background: "#f59e0b", color: "#0b1021", font: "700 11px/1.4 system-ui, sans-serif",
+          padding: "1px 6px", borderRadius: "4px", whiteSpace: "nowrap",
+          ...(flip
+            ? { right: `${Math.max(4, window.innerWidth - r.right - 3)}px` }
+            : { left: `${r.left - 3}px` }),
+        } as CSSStyleDeclaration);
+        root.appendChild(box);
+        root.appendChild(tag);
+      });
+      document.body.appendChild(root);
+    },
+    { title, callouts },
+  );
+  await page.waitForTimeout(150);
+  await page.screenshot({ path: path.join(SHOTS, file), fullPage: false });
+  await page.evaluate(() => document.getElementById("__fp_annot__")?.remove());
+}
+
+test("interrupted node offers Play + Reopen + Mark complete, revives on Reopen, and hides all of it when archived", async ({
+  page,
+  baseURL,
+}) => {
+  test.setTimeout(150_000);
+  await page.goto("/");
+  await expect(page.getByText("Daemon: connected")).toBeVisible({ timeout: 15_000 });
+
+  // Two runs: one to exercise the recovery affordances (+ Reopen), one to leave
+  // archived-while-interrupted for the archived variant. Kill both sessions,
+  // then a single stale-detector sweep turns both `interrupted`.
+  const recoverRun = await createRun(page, baseURL!);
+  const archiveRun = await createRun(page, baseURL!);
+
+  for (const runId of [recoverRun, archiveRun]) {
+    execFileSync("tmux", ["-L", SOCKET, "kill-session", "-t", `pdo-${runId}-worker-iter-1`]);
+  }
+
+  // The background sweep (30s cadence) detects the dead sessions → interrupted.
+  await waitWorkerStatus(page, baseURL!, recoverRun, "interrupted");
+  await waitWorkerStatus(page, baseURL!, archiveRun, "interrupted");
+
+  // ---- Step 1: the interrupted panel shows every recovery affordance --------
+  await openWorker(page, recoverRun);
+  const banner = page.getByTestId("interrupted-banner");
+  await expect(banner).toBeVisible({ timeout: 8_000 });
+  await expect(banner).toContainText("Session died");
+  await expect(banner).toContainText("the work is presumed intact");
+  await expect(page.getByTestId("interrupted-reopen-btn")).toBeVisible();
+  await expect(page.getByTestId("play-retry-btn")).toBeVisible();
+  await expect(page.getByTestId("play-retry-btn")).toContainText("Play");
+  await expect(page.getByTestId("mark-complete-btn")).toBeVisible();
+  await expect(page.getByTestId("terminal-minimized")).toBeVisible();
+  await expect(page.getByTestId("tmux-terminal")).toHaveCount(0);
+  await expect(page.getByText(/can't find session/i)).toHaveCount(0);
+
+  await annotateAndShoot(page, "1-interrupted-affordances.png", [
+    "Etape 1 — Node Interrupted : session tmux tuee, detectee par la sweep stale-detector (meme etat NodeInterrupted qu'au redemarrage daemon).",
+    "Le volet offre desormais une sortie : banniere Reopen, bouton Play, Mark complete ; terminal minimise (plus de \"can't find session\").",
+  ].join("\n"), [
+    { testid: "interrupted-banner", label: "Banniere: Session died - the work is presumed intact" },
+    { testid: "interrupted-reopen-btn", label: "Bouton Reopen (geste retry)" },
+    { testid: "play-retry-btn", label: "Bouton Play dans node-controls" },
+    { testid: "mark-complete-btn", label: "Mark complete de nouveau atteignable" },
+    { testid: "terminal-minimized", label: "Terminal minimise (session definitivement morte)" },
+  ]);
+
+  // ---- Step 2: Reopen revives the session, terminal flips back to split -----
+  await page.getByTestId("interrupted-reopen-btn").click();
+  await waitWorkerLive(page, baseURL!, recoverRun);
+  await expect(page.getByTestId("tmux-terminal")).toBeVisible({ timeout: 10_000 });
+  await expect(page.getByTestId("interrupted-banner")).toHaveCount(0);
+
+  await annotateAndShoot(page, "2-reopened-live.png", [
+    "Etape 2 — Apres clic sur Reopen : la node se relance (running), la session tmux ranime,",
+    "le terminal repasse en vue split (live). La banniere Interrupted a disparu.",
+  ].join("\n"), [
+    { testid: "tmux-terminal", label: "Terminal live re-attache (vue split)" },
+    { testid: "node-controls", label: "Controles de la node presents (node relancee, live)" },
+  ]);
+
+  // ---- Step 3: archived run shows none of the affordances -------------------
+  await page.request.post(`${baseURL}/runs/${archiveRun}/commands`, {
+    data: { kind: "cleanup_run" },
+    headers: { "Content-Type": "application/json" },
+  });
+  // Reload so the canvas starts empty: otherwise the previous (live) run's
+  // `worker` node lingers on the canvas and `getByText("worker")` can select it
+  // before the canvas switches to the archived run — a stale-selection race.
+  await page.reload();
+  await expect(page.getByText("Daemon: connected")).toBeVisible({ timeout: 15_000 });
+  // Archived runs live in a collapsed "Archived" section — expand it if the run
+  // row isn't already on screen, then select the archived run's worker node.
+  const archivedToggle = page.getByTestId("run-archived-toggle");
+  await expect(archivedToggle).toBeVisible({ timeout: 8_000 });
+  const archivedRow = page.getByText(archiveRun.slice(0, 20)).first();
+  if (!(await archivedRow.isVisible().catch(() => false))) {
+    await archivedToggle.click();
+    await expect(archivedRow).toBeVisible({ timeout: 5_000 });
+  }
+  await openWorker(page, archiveRun);
+  await expect(page.getByTestId("terminal-minimized")).toBeVisible({ timeout: 8_000 });
+  await expect(page.getByTestId("node-controls")).toHaveCount(0);
+  await expect(page.getByTestId("interrupted-reopen-btn")).toHaveCount(0);
+  await expect(page.getByTestId("play-retry-btn")).toHaveCount(0);
+  await expect(page.getByTestId("mark-complete-btn")).toHaveCount(0);
+
+  await annotateAndShoot(page, "3-archived-no-affordances.png", [
+    "Etape 3 — Variante archivee : sur un run archive (worktree + session detruits),",
+    "aucune affordance de reprise n'apparait (ni controles, ni Reopen, ni Mark complete). Terminal minimise.",
+  ].join("\n"), [
+    { testid: "terminal-minimized", label: "Terminal minimise ; aucun bouton de reprise" },
+  ]);
+});

--- a/frontend/src/components/NodeDetailPanel.test.tsx
+++ b/frontend/src/components/NodeDetailPanel.test.tsx
@@ -731,6 +731,88 @@ describe("NodeDetailPanel", () => {
     });
   });
 
+  // #598 / ADR-0049: an interrupted node (session died on an infra incident) must
+  // offer a way back — before this it was a dead end (no Play, no Reopen, no Mark
+  // complete), the exact bug reported for an interactive node with a lost session.
+  describe("Interrupted node recovery (#598)", () => {
+    const interrupted = () =>
+      makeNode({ status: "interrupted", failure_reason: "session died — reopen or retry" });
+
+    it("renders the Interrupted label and banner", () => {
+      render(
+        <TooltipProvider>
+          <NodeDetailPanel node={interrupted()} runId="run-1" />
+        </TooltipProvider>,
+      );
+      expect(screen.getByText("Interrupted")).toBeInTheDocument();
+      expect(screen.getByTestId("interrupted-banner")).toBeInTheDocument();
+      expect(screen.getByText(/session died/i)).toBeInTheDocument();
+    });
+
+    it("offers a Play button in the node controls", () => {
+      render(
+        <TooltipProvider>
+          <NodeDetailPanel node={interrupted()} runId="run-1" />
+        </TooltipProvider>,
+      );
+      expect(screen.getByTestId("play-retry-btn")).toHaveTextContent("Play");
+    });
+
+    it("Play re-drives the node via retryNode (daemon embeds the reopen)", async () => {
+      render(
+        <TooltipProvider>
+          <NodeDetailPanel node={interrupted()} runId="run-1" />
+        </TooltipProvider>,
+      );
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("play-retry-btn"));
+      });
+      expect(retryNodeMock).toHaveBeenCalledWith("run-1", "test-node");
+    });
+
+    it("the banner Reopen button also re-drives the node", async () => {
+      render(
+        <TooltipProvider>
+          <NodeDetailPanel node={interrupted()} runId="run-1" />
+        </TooltipProvider>,
+      );
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("interrupted-reopen-btn"));
+      });
+      expect(retryNodeMock).toHaveBeenCalledWith("run-1", "test-node");
+    });
+
+    it("keeps Mark complete reachable (accept the artifacts as they are)", () => {
+      render(
+        <TooltipProvider>
+          <NodeDetailPanel node={interrupted()} runId="run-1" />
+        </TooltipProvider>,
+      );
+      expect(screen.getByTestId("mark-complete-btn")).toBeInTheDocument();
+    });
+
+    it("opens minimized — the dead session is never attached", () => {
+      render(
+        <TooltipProvider>
+          <NodeDetailPanel node={interrupted()} runId="run-1" />
+        </TooltipProvider>,
+      );
+      expect(screen.getByTestId("terminal-minimized")).toBeInTheDocument();
+      expect(screen.queryByTestId("tmux-terminal")).not.toBeInTheDocument();
+    });
+
+    it("hides the recovery affordances for an archived run", () => {
+      render(
+        <TooltipProvider>
+          <NodeDetailPanel node={interrupted()} runId="run-1" isArchived />
+        </TooltipProvider>,
+      );
+      expect(screen.queryByTestId("node-controls")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("interrupted-reopen-btn")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("mark-complete-btn")).not.toBeInTheDocument();
+    });
+  });
+
   describe("Terminated-node default layout (#346)", () => {
     it("defaults a completed node to a minimized terminal with Outputs visible", () => {
       render(

--- a/frontend/src/components/NodeDetailPanel.tsx
+++ b/frontend/src/components/NodeDetailPanel.tsx
@@ -178,16 +178,23 @@ function MarkCompleteVerdict({ verdict }: { verdict: MarkVerdict }) {
 }
 
 // The session is settled — the tmux session is gone, so the terminal WebSocket
-// would attach to a dead session. `{completed, failed, stopped}` is exactly the
-// "settled" tier of `pollInterval` (5s). `stale` is EXCLUDED unless archived:
-// its tmux session is typically still alive and recovery happens *inside* the
-// terminal (nudge / Stop / Retry). An archived run overrides everything (its
-// worktree + session are torn down). An unknown future status falls on the
-// non-terminated (live) side.
+// would attach to a dead session. `{completed, failed, stopped, interrupted}` is
+// exactly the "settled" tier of `pollInterval` (5s). `interrupted` belongs here
+// (#598 / ADR-0049): its tmux session is *definitively* dead (that death is what
+// produced the status), so attaching would only spam "can't find session" — open
+// minimized and prioritise the Outputs, exactly like the other settled states.
+// A Retry revives the session and flips back to split (`onRetryStarted`). `stale`
+// is EXCLUDED unless archived: its tmux session is typically still alive and
+// recovery happens *inside* the terminal (nudge / Stop / Retry). An archived run
+// overrides everything (its worktree + session are torn down). An unknown future
+// status falls on the non-terminated (live) side.
 function nodeSessionEnded(status: NodeStatus, isArchived?: boolean): boolean {
   if (isArchived) return true;
   return (
-    status === "completed" || status === "failed" || status === "stopped"
+    status === "completed" ||
+    status === "failed" ||
+    status === "stopped" ||
+    status === "interrupted"
   );
 }
 
@@ -460,6 +467,42 @@ export default function NodeDetailPanel({
         </div>
       )}
 
+      {/* Interrupted banner — #598 / ADR-0049. An infra incident killed the
+          session (tmux gone, daemon restart, spawn-abort); the work on disk is
+          presumed intact and the run is parked, not failed. The one action that
+          matters here is Reopen: it re-drives the interrupted node (the daemon
+          reopens the run atomically on the node retry). Before this the state
+          was a dead end — the placeholder promised "reopen or retry" but no
+          button delivered it. Mirrors the `stale` banner's shape; the Reopen
+          button shares the toolbar Play's `retry` handler (revives the session,
+          flips the terminal back to split). */}
+      {node.status === "interrupted" && (
+        <div
+          className="flex items-center gap-2 border-b border-st-interrupted/30 bg-st-interrupted-bg px-3 py-2"
+          data-testid="interrupted-banner"
+        >
+          <AlertCircle size={14} className="shrink-0 text-st-interrupted" />
+          <span
+            className="flex-1 text-st-interrupted"
+            style={{ fontSize: "11.5px", fontWeight: 500 }}
+          >
+            Session died{node.failure_reason ? ` — ${node.failure_reason}` : ""} — the
+            work is presumed intact
+          </span>
+          {!isArchived && (
+            <button
+              data-testid="interrupted-reopen-btn"
+              onClick={retry}
+              className="flex cursor-pointer items-center gap-1 rounded border border-st-interrupted/40 bg-st-interrupted/10 px-1.5 py-0.5 text-st-interrupted transition-colors hover:bg-st-interrupted/20"
+              style={{ fontSize: "10.5px", fontWeight: 500 }}
+            >
+              <RotateCcw size={10} />
+              Reopen
+            </button>
+          )}
+        </div>
+      )}
+
       {/* Frontmatter retry pending banner (amber) */}
       {node.status === "running" && (node.frontmatter_retries ?? 0) > 0 && (
         <div
@@ -581,7 +624,13 @@ export default function NodeDetailPanel({
           >
             {/* Actions */}
             <div className="flex flex-col gap-1.5 px-3 py-2">
-              {(node.status === "awaiting_user" || node.status === "running" || node.status === "failed" || node.status === "stale") && !isArchived && (
+              {/* `interrupted` is included (#598 / ADR-0049): an interrupted
+                  interactive node parks the run `awaiting_user`, so the "take the
+                  artifacts as they are" escape must stay reachable — the daemon
+                  embeds the run reopen on `mark_node_done` too, and the output
+                  guard rejects gracefully (rendered at the gesture) if the work
+                  is genuinely incomplete. */}
+              {(node.status === "awaiting_user" || node.status === "running" || node.status === "failed" || node.status === "stale" || node.status === "interrupted") && !isArchived && (
                 <>
                   <button
                     onClick={markComplete}
@@ -800,7 +849,18 @@ function RetryPlayButton({
     );
   }
 
-  if (status === "failed" || status === "stopped" || status === "stale") {
+  // #598 / ADR-0049: `interrupted` joins the "Play" set. The node-level retry
+  // re-drives the interrupted work — the daemon embeds the run reopen atomically
+  // (`node_retry` → `embed_reopen_for_targeted_command`), so the click that used
+  // to hit "resume the run first" now just works. Without this the panel offered
+  // no way out of an interrupted node (issue: an interactive node with a dead
+  // session had no resume affordance).
+  if (
+    status === "failed" ||
+    status === "stopped" ||
+    status === "stale" ||
+    status === "interrupted"
+  ) {
     return (
       <button
         data-testid="play-retry-btn"

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "failed",
+  "failedTests": []
+}


### PR DESCRIPTION
Une node interactive dont la session tmux meurt passe `interrupted` (état récupérable, ADR-0049). Le volet ne proposait aucune sortie : ni Play, ni Reopen, ni Mark complete, juste un Stop désactivé. Le placeholder promettait « reopen or retry » sans bouton pour le tenir.

Le levier daemon existait déjà : un `node_retry` sur un run parqué embarque le reopen atomiquement et re-drive le travail. Il manquait le déclencheur UI. Dans `NodeDetailPanel` :

- `interrupted` rejoint l'ensemble « Play » de `RetryPlayButton`.
- Bannière `interrupted` (modèle stale/stopped) avec un bouton Reopen câblé sur le même geste retry.
- `interrupted` rejoint la garde de Mark complete (échappatoire « artefacts en l'état »).
- `interrupted` rejoint `nodeSessionEnded` : terminal minimisé, plus de « can't find session » ; un Reopen ranime la session et rebascule en split.

## Validation

- Suite frontend verte (1878 tests) ; 7 tests ajoutés dans `NodeDetailPanel.test.tsx`. Aucun changement Rust.
- Feature Path agentique **Pass** contre le système réel (daemon + tmux + navigateur) : incident provoqué (session tuée → sweep `stale_detector` → `interrupted`), reprise via Reopen (retour `running`, session ré-attachée en iter-2), variante archivée sans affordance de reprise.

## Tickets

- Closes #598

🤖 Generated with [Claude Code](https://claude.com/claude-code)