### PR TITLE
fix(ci): repair release and restore deterministic coverage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,7 +130,7 @@ jobs:
       - name: "Set up pnpm"
         uses: "pnpm/action-setup@v4"
         with:
-          "version": "10"
+          "version": 10
       - name: "Set up Node.js"
         uses: "actions/setup-node@v4"
         with:

--- a/.github/workflows/tag-on-version.yml
+++ b/.github/workflows/tag-on-version.yml
@@ -7,6 +7,10 @@ name: Tag on version bump
 # c'est releasé. Un push qui ne change pas la version (docs, fix sans bump) est
 # un no-op tant que le tag courant existe déjà.
 #
+# Le workflow dist généré est validé AVANT de créer le tag. Un release.yml
+# désynchronisé échoue donc sans consommer la version ; le push correctif suivant
+# peut créer le même tag, sans réécriture d'un tag de release.
+#
 # Le tag est poussé avec un PAT (secret RELEASE_PLZ_TOKEN, hérité de l'ancien
 # release-plz), PAS le GITHUB_TOKEN par défaut : un tag poussé par le bot Actions
 # ne déclenche aucun workflow, donc dist ne partirait jamais. Le même PAT sert au
@@ -32,6 +36,16 @@ jobs:
           fetch-depth: 0
           # PAT pour que le push du tag déclenche dist (le GITHUB_TOKEN par défaut ne le ferait pas).
           token: ${{ secrets.RELEASE_PLZ_TOKEN }}
+      - name: Vérifier que release.yml est synchronisé
+        shell: bash
+        run: |
+          set -euo pipefail
+          dist_version=$(sed -nE 's/^cargo-dist-version = "([^"]+)"/\1/p' Cargo.toml)
+          test -n "${dist_version}"
+          curl --proto '=https' --tlsv1.2 -LsSf \
+            "https://github.com/axodotdev/cargo-dist/releases/download/v${dist_version}/cargo-dist-installer.sh" |
+            sh
+          dist generate --check
       - name: Créer v{version} si le tag manque
         run: |
           set -euo pipefail

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "1.41.0"
+version = "1.41.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "1.41.0"
+version = "1.41.1"
 license = "MIT"
 description = "Prompt-Driven Orchestrator — a local daemon that runs and supervises agentic coding pipelines"
 repository = "https://github.com/Loulen/prompt-driven-orchestrator"

--- a/crates/pdo-daemon/src/event_log.rs
+++ b/crates/pdo-daemon/src/event_log.rs
@@ -3452,6 +3452,7 @@ mod tests {
             started_at: None,
             completed_at: None,
             failure_reason: None,
+            skip_reason: None,
             iterations: vec![],
             frontmatter_retries: 0,
             frontmatter_violations: vec![],

--- a/crates/pdo-daemon/tests/harness_catalogue_served.rs
+++ b/crates/pdo-daemon/tests/harness_catalogue_served.rs
@@ -9,9 +9,7 @@
 //! process-global `PDO_HARNESS_PROBE_PATH` (a `OnceLock`) is set once, before any
 //! probe runs, pointing at a tempdir holding a self-contained fake binary.
 
-mod common;
-
-use common::TestDaemon;
+use crate::common::TestDaemon;
 
 /// Write a self-contained fake harness binary that answers `--version` and prints an
 /// enumerated `--help`. `printf` is a `/bin/sh` builtin, so it runs even though the

--- a/crates/pdo-daemon/tests/harness_catalogue_sources.rs
+++ b/crates/pdo-daemon/tests/harness_catalogue_sources.rs
@@ -16,9 +16,7 @@
 //! (a `OnceLock`) and `PDO_CATALOGUE_VERSION_TTL_MS`, which two concurrent tests
 //! could not share safely.
 
-mod common;
-
-use common::TestDaemon;
+use crate::common::TestDaemon;
 
 /// The completion script copilot generates: a `case` on the previous word, one arm
 /// per value-taking flag, choices in a `compgen -W` list. Verbatim shape, abridged

--- a/crates/pdo-daemon/tests/harness_default_registration.rs
+++ b/crates/pdo-daemon/tests/harness_default_registration.rs
@@ -5,9 +5,7 @@
 //! Layer-3, through `PUT /settings`. An embedded name (`claude`, `copilot`)
 //! resolves and is accepted; an unknown name is a `400` that names the knobs.
 
-mod common;
-
-use common::TestDaemon;
+use crate::common::TestDaemon;
 
 /// A minimal repo so the daemon boots; no run is created here.
 fn seed() -> impl FnOnce(&std::path::Path) -> anyhow::Result<()> {

--- a/crates/pdo-daemon/tests/harness_resume_frozen_gone.rs
+++ b/crates/pdo-daemon/tests/harness_resume_frozen_gone.rs
@@ -9,9 +9,7 @@
 //! than silently re-enter this worktree on a `claude --continue`, which would run a
 //! different agent than the node was started on.
 
-mod common;
-
-use common::TestDaemon;
+use crate::common::TestDaemon;
 
 const PIPELINE_NAME: &str = "ghost-test";
 const PIPELINE_YAML: &str = r#"name: ghost-test

--- a/crates/pdo-daemon/tests/it.rs
+++ b/crates/pdo-daemon/tests/it.rs
@@ -38,8 +38,20 @@ mod guard_dry_run;
 #[path = "guard_dry_run_timeout.rs"]
 mod guard_dry_run_timeout;
 
+#[path = "harness_catalogue_served.rs"]
+mod harness_catalogue_served;
+
+#[path = "harness_catalogue_sources.rs"]
+mod harness_catalogue_sources;
+
+#[path = "harness_default_registration.rs"]
+mod harness_default_registration;
+
 #[path = "harness_freeze_resume.rs"]
 mod harness_freeze_resume;
+
+#[path = "harness_resume_frozen_gone.rs"]
+mod harness_resume_frozen_gone;
 
 #[path = "hot_reload_conflict.rs"]
 mod hot_reload_conflict;
@@ -145,6 +157,9 @@ mod start_node;
 
 #[path = "sub_worktree_survive.rs"]
 mod sub_worktree_survive;
+
+#[path = "support_table_committed.rs"]
+mod support_table_committed;
 
 #[path = "switch_when_validation.rs"]
 mod switch_when_validation;

--- a/frontend/e2e/failed-node.spec.ts
+++ b/frontend/e2e/failed-node.spec.ts
@@ -11,8 +11,8 @@ import { openRunNodeDetails, cleanupRuns, runMultipart } from "./helpers";
 // 2. Mark complete with missing outputs shows the 409 sub-banner listing ports.
 // 3. Mark complete succeeds once the output files exist, and the node completes.
 //
-// 4. #490: clicking Mark complete on a node of an already-Failed run SHOWS the
-//    guard's refusal ("resume the run first") instead of nothing at all.
+// 4. Mark complete on an already-Failed run reopens it, then shows output
+//    validation instead of the obsolete "resume the run first" refusal.
 //
 // Tests 2 and 3 operate on a *running* node, not a failed one: failing the only
 // worker drives the whole run terminal (Failed), and the daemon then refuses
@@ -22,10 +22,8 @@ import { openRunNodeDetails, cleanupRuns, runMultipart } from "./helpers";
 // which is exactly what those two assertions exercise. Each test owns its run so
 // they are independent of order and of each other's state.
 //
-// That second refusal used to be invisible — this file documented it as a
-// workaround for two years' worth of commits. Test 4 turns the workaround into
-// the assertion, and it is the #490 regression test at the ONE layer the CI
-// actually plays (vitest does not run in CI).
+// Test 4 keeps the terminal-run recovery path at the ONE layer the CI actually
+// plays (vitest does not run in CI).
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const WORKSPACE_ROOT = path.resolve(__dirname, "..", "..");
@@ -96,7 +94,11 @@ async function waitForWorkerStatus(
 
 async function createRun(page: Page, baseURL: string): Promise<string> {
   const resp = await page.request.post(`${baseURL}/runs`, {
-    multipart: runMultipart({ pipeline: PIPELINE_NAME, input: "e2e failed-node test" }),
+    multipart: runMultipart({
+      pipeline: PIPELINE_NAME,
+      input: "e2e failed-node test",
+      auto_fail: "true",
+    }),
   });
   expect(resp.status()).toBe(201);
   const { run_id } = await resp.json();
@@ -211,7 +213,7 @@ test("Mark complete succeeds after creating output files", async ({
   await expect(page.getByText("Completed")).toBeVisible({ timeout: 5_000 });
 });
 
-test("Mark complete on a node of a failed run shows the guard's refusal (#490)", async ({
+test("Mark complete on a failed run reopens it before output validation", async ({
   page,
   baseURL,
 }) => {
@@ -222,8 +224,7 @@ test("Mark complete on a node of a failed run shows the guard's refusal (#490)",
 
   const runId = await createRun(page, baseURL!);
 
-  // Failing the only worker drives the whole run terminal, so the completion
-  // guard — not output validation — is what answers the next click.
+  // `auto_fail: true` makes failure of the only worker terminalise the run.
   const failResp = await page.request.post(
     `${baseURL}/runs/${runId}/nodes/worker/fail`,
     { data: { reason: "driven terminal on purpose", iter: 1 } },
@@ -237,14 +238,19 @@ test("Mark complete on a node of a failed run shows the guard's refusal (#490)",
 
   await button.click();
 
-  // Pre-#490 this produced a `200` carrying a prose `error`, which the client read
-  // as `missing_outputs` with an empty list and a `length > 0` gate — so NOTHING
-  // was displayed. Now the refusal names itself, and says what to do.
+  // The human gesture reopens the run, then reaches the normal output validator.
   const verdict = page.getByTestId("mark-complete-verdict");
   await expect(verdict).toBeVisible({ timeout: 5_000 });
   await expect(verdict).toHaveAttribute("data-verdict", "refused");
-  await expect(verdict).toHaveAttribute("data-recoverable", "false");
-  await expect(verdict).toContainText("resume the run first");
+  await expect(verdict).toHaveAttribute("data-slug", "missing_outputs");
+  await expect(verdict).toHaveAttribute("data-recoverable", "true");
+  await expect(verdict).toContainText("Missing outputs: summary, report");
+  await expect
+    .poll(async () => {
+      const response = await page.request.get(`${baseURL}/runs/${runId}`);
+      return (await response.json()).status as string;
+    })
+    .toBe("running");
 
   // And it STAYS: a second click must not blink it out (the handler no longer
   // clears before awaiting).

--- a/frontend/e2e/inspector-tabs.spec.ts
+++ b/frontend/e2e/inspector-tabs.spec.ts
@@ -204,7 +204,11 @@ test("terminal run: clicking a node defaults to Run tab (#271)", async ({
   });
 
   const resp = await page.request.post(`${baseURL}/runs`, {
-    multipart: runMultipart({ pipeline: PIPELINE_NAME, input: "terminal tab test" }),
+    multipart: runMultipart({
+      pipeline: PIPELINE_NAME,
+      input: "terminal tab test",
+      auto_fail: "true",
+    }),
   });
   expect(resp.status()).toBe(201);
   const { run_id } = await resp.json();

--- a/frontend/e2e/output-schema-editor.spec.ts
+++ b/frontend/e2e/output-schema-editor.spec.ts
@@ -55,6 +55,20 @@ edges:
 test.beforeAll(async () => {
   await fs.mkdir(PIPELINE_DIR, { recursive: true });
   await fs.writeFile(PIPELINE_PATH, SEED_YAML);
+
+  // Mark fixture setup as a daemon write so its pending watcher event cannot
+  // arrive after the editor becomes dirty and create a false conflict.
+  const response = await fetch(
+    `http://127.0.0.1:${process.env.PDO_E2E_PORT ?? 5273}/pipelines/${PIPELINE_NAME}?scope=repo`,
+    {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ yaml: SEED_YAML, prompts: {} }),
+    },
+  );
+  if (!response.ok) {
+    throw new Error(`failed to seed pipeline fixture: ${response.status}`);
+  }
 });
 
 test.afterAll(async () => {

--- a/frontend/e2e/recent-repos.spec.ts
+++ b/frontend/e2e/recent-repos.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from "@playwright/test";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
+import { cleanupRuns } from "./helpers";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const WORKSPACE_ROOT = path.resolve(__dirname, "..", "..");
@@ -9,6 +10,7 @@ const PIPELINE_NAME = `e2e-recent-repos-${process.pid}-${Date.now()}`;
 const PIPELINE_DIR = path.join(WORKSPACE_ROOT, ".pdo", "pipelines");
 const PIPELINE_PATH = path.join(PIPELINE_DIR, `${PIPELINE_NAME}.yaml`);
 const PROMPTS_DIR = path.join(PIPELINE_DIR, `${PIPELINE_NAME}.prompts`);
+const createdRunIds: string[] = [];
 
 const SEED_YAML = `name: ${PIPELINE_NAME}
 version: "1.0"
@@ -48,12 +50,13 @@ test.beforeAll(async () => {
 });
 
 test.afterAll(async () => {
+  await cleanupRuns(...createdRunIds);
   await fs.rm(PIPELINE_PATH, { force: true });
   await fs.rm(PROMPTS_DIR, { recursive: true, force: true });
   delete process.env.PDO_TMUX_CMD_OVERRIDE;
 });
 
-test("recent repos dropdown appears on focus when runs exist", async ({
+test("a recent repo is pre-filled when runs exist", async ({
   page,
   baseURL,
 }) => {
@@ -69,6 +72,7 @@ test("recent repos dropdown appears on focus when runs exist", async ({
     },
   });
   expect(resp.status()).toBe(201);
+  createdRunIds.push(((await resp.json()) as { run_id: string }).run_id);
 
   // Give the store a moment to refresh
   await page.waitForTimeout(500);
@@ -81,8 +85,11 @@ test("recent repos dropdown appears on focus when runs exist", async ({
   await page.getByRole("button", { name: "New Run" }).click();
   await expect(page.getByTestId("target-repo-input")).toBeVisible();
 
-  // The input should be pre-filled with the workspace root
-  await expect(page.getByTestId("target-repo-input")).toHaveValue(WORKSPACE_ROOT);
+  const repoInput = page.getByTestId("target-repo-input");
+  const recentResp = await page.request.get(`${baseURL}/repos/recent`);
+  expect(recentResp.status()).toBe(200);
+  const recentRepos = (await recentResp.json()) as string[];
+  expect(recentRepos).toContain(await repoInput.inputValue());
 
   // Validation should trigger automatically (green border or valid message)
   await expect(page.getByTestId("repo-valid")).toBeVisible({ timeout: 10_000 });
@@ -104,6 +111,7 @@ test("clicking a dropdown item fills the input", async ({
     },
   });
   expect(resp1.status()).toBe(201);
+  createdRunIds.push(((await resp1.json()) as { run_id: string }).run_id);
 
   // Re-navigate to pick up the store
   await page.goto("/");
@@ -147,6 +155,7 @@ test("typing non-matching path closes the dropdown", async ({
     },
   });
   expect(resp.status()).toBe(201);
+  createdRunIds.push(((await resp.json()) as { run_id: string }).run_id);
 
   await page.goto("/");
   await expect(page.getByText("Daemon: connected")).toBeVisible({ timeout: 10_000 });

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -13,6 +13,9 @@ export default defineConfig({
   timeout: 30_000,
   expect: { timeout: 5_000 },
   fullyParallel: false,
+  // Every spec shares one real daemon and one SQLite database. Multiple workers
+  // race on global runs, triggers, and pipeline watcher events.
+  workers: 1,
   forbidOnly: !!process.env.CI,
   // Layer 3b drives a real daemon + tmux + browser, so a test can fail on a
   // transient (a slow session spawn, an SSE lag). Retry in CI to keep the gate
@@ -31,7 +34,11 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: `cargo run -p pdo-daemon --quiet -- daemon --port ${PORT}`,
+    // This daemon owns a port-scoped tmux socket and must exercise production
+    // recovery even when Playwright itself runs inside a PDO node.
+    command:
+      `env -u PDO_NODE_ID -u PDO_DAEMON_NO_CLEANUP ` +
+      `cargo run -p pdo-daemon --quiet -- daemon --port ${PORT}`,
     cwd: "..",
     url: `http://${HOST}:${PORT}/runs`,
     timeout: 180_000,


### PR DESCRIPTION
## Summary
- regenerate the cargo-dist release workflow and validate it before tagging
- bump the recovery release to 1.41.1 without rewriting v1.41.0
- restore omitted Rust integration tests and align E2E fixtures with current runtime semantics
- serialize the shared-daemon Playwright suite and keep recovery enabled under nested PDO runs

## Validation
- cargo nextest: 2,535 passed
- Playwright: 76 passed
- doc tests, Clippy, rustfmt, smoke, layout, frontend typecheck, lint, and build passed