### PR TITLE
feat(stats): add harness-aware cost drill-down (#638)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "1.37.0"
+version = "1.38.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "1.37.0"
+version = "1.38.0"
 license = "MIT"
 description = "Prompt-Driven Orchestrator — a local daemon that runs and supervises agentic coding pipelines"
 repository = "https://github.com/Loulen/prompt-driven-orchestrator"

--- a/crates/pdo-daemon/src/event_log.rs
+++ b/crates/pdo-daemon/src/event_log.rs
@@ -692,6 +692,27 @@ pub struct CostStat {
     /// meant before this field existed.
     #[serde(default)]
     pub uncosted_harnesses: Vec<String>,
+    /// Readable cost slices grouped by harness.
+    #[serde(default)]
+    pub by_harness: Vec<HarnessCost>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CostForm {
+    Derived,
+    Reported,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct HarnessCost {
+    pub harness: String,
+    pub usd: f64,
+    pub form: CostForm,
+    #[serde(default)]
+    pub partial: bool,
+    #[serde(default)]
+    pub unpriced_models: Vec<String>,
 }
 
 /// A secondary repository pinned to a Run (#465, ADR-0042).

--- a/crates/pdo-daemon/src/harness_registry.rs
+++ b/crates/pdo-daemon/src/harness_registry.rs
@@ -98,6 +98,8 @@ impl HarnessDescriptor {
 pub const CLAUDE: &str = "claude";
 /// The `opencode` harness name (ADR-0045, measured on 1.18.18).
 pub const OPENCODE: &str = "opencode";
+/// The GitHub Copilot CLI harness.
+pub const COPILOT: &str = "copilot";
 
 /// The `claude` descriptor: the legacy launch, expressed as data.
 ///

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -4645,6 +4645,12 @@ async fn init_db(db: &sqlx::SqlitePool) -> Result<()> {
         .execute(db)
         .await
         .context("failed to create idx_events_kind_ts")?;
+    // #638 / ADR-0029: after the indexed `run_started` cohort lookup, Sessions
+    // joins only each selected Run's `node_started` rows in append order.
+    sqlx::query("CREATE INDEX IF NOT EXISTS idx_events_run_kind_id ON events(run_id, kind, id)")
+        .execute(db)
+        .await
+        .context("failed to create idx_events_run_kind_id")?;
 
     // #328 / ADR-0024: tombstones for forgotten runs — a run_id present here
     // can never receive events again (guard in `append_event`).
@@ -9288,7 +9294,7 @@ async fn sync_cost_prices(State(state): State<Arc<AppState>>) -> Response {
 
     if !outcome.changed {
         // Nothing to write, so nothing is written — which also leaves the table's
-        // fingerprint alone and keeps `COST_MEMO` warm for every Run.
+        // fingerprint alone and keeps the cost-breakdown memo warm for every Run.
         return Json(serde_json::json!({
             "ok": true,
             "noop": true,
@@ -10415,10 +10421,12 @@ async fn get_run(
             // HOST home — prices are an instance concept), while transcripts come
             // from `projects_root` (the #408 seam, which moves for a sandboxed Run).
             let prices = price_table::PriceTable::load(&home_root);
+            let copilot_root = sandbox_run::copilot_store_root(&home_root);
             augment_run_state_from_disk(
                 &mut run_state,
                 &events,
                 &projects_root,
+                &copilot_root,
                 &repo_root,
                 &prices,
             );
@@ -16153,6 +16161,7 @@ fn augment_run_state_from_disk(
     run_state: &mut event_log::RunState,
     events: &[event_log::Event],
     projects_root: &std::path::Path,
+    copilot_root: &std::path::Path,
     repo_root: &std::path::Path,
     prices: &price_table::PriceTable,
 ) {
@@ -16173,8 +16182,14 @@ fn augment_run_state_from_disk(
     // `CostStat` (never `$0`); otherwise it is exactly `compute_run_cost`. Needs the
     // raw events for the frozen-at-spawn harnesses (`RunState` alone does not carry
     // them per node).
-    run_state.cost =
-        run_cost::run_cost_or_absence(events, projects_root, repo_root, &run_state.run_id, prices);
+    run_state.cost = run_cost::run_cost_or_absence(
+        events,
+        projects_root,
+        copilot_root,
+        repo_root,
+        &run_state.run_id,
+        prices,
+    );
 
     let yaml_path = run_scoped_pipeline_path(repo_root, &run_state.run_id);
     let Ok(yaml) = std::fs::read_to_string(&yaml_path) else {
@@ -17155,6 +17170,481 @@ mod tests {
             allowed_ws_origins: Vec::new(),
             libassist_focus: Mutex::new(None),
         })
+    }
+
+    #[tokio::test]
+    async fn stats_overview_sessions_use_run_cohorts_and_dynamic_harness_hierarchies() {
+        let state = test_state().await;
+        let insert = |run: &str,
+                      ts: &str,
+                      kind: &str,
+                      node: Option<&str>,
+                      iter: Option<i64>,
+                      payload: Option<serde_json::Value>| {
+            let db = state.db.clone();
+            let run = run.to_string();
+            let ts = ts.to_string();
+            let kind = kind.to_string();
+            let node = node.map(str::to_string);
+            async move {
+                sqlx::query(
+                    "INSERT INTO events (run_id, ts, kind, node_id, iter, payload) \
+                     VALUES (?, ?, ?, ?, ?, ?)",
+                )
+                .bind(run)
+                .bind(ts)
+                .bind(kind)
+                .bind(node)
+                .bind(iter)
+                .bind(payload.map(|value| value.to_string()))
+                .execute(&db)
+                .await
+                .unwrap();
+            }
+        };
+
+        insert(
+            "before",
+            "2026-07-14T09:00:00Z",
+            "run_started",
+            None,
+            None,
+            Some(serde_json::json!({
+                "pipeline_id": "p-out",
+                "pipeline_name": "Outside",
+                "node_defs": [{"id":"worker","name":"Outside worker","node_type":"doc-only"}]
+            })),
+        )
+        .await;
+        insert(
+            "before",
+            "2026-07-15T09:00:00Z",
+            "node_started",
+            Some("worker"),
+            Some(1),
+            Some(serde_json::json!({"node_type":"doc-only","harness":"claude"})),
+        )
+        .await;
+
+        insert(
+            "r1",
+            "2026-07-15T09:00:00Z",
+            "run_started",
+            None,
+            None,
+            Some(serde_json::json!({
+                "pipeline_id": "p1",
+                "pipeline_name": "Pipeline old",
+                "target_repo": "/repos/product",
+                "node_defs": [
+                    {"id":"worker","name":"Worker old","node_type":"doc-only"},
+                    {"id":"build","name":"Build","node_type":"script"}
+                ]
+            })),
+        )
+        .await;
+        for (harness, node_type, session_id) in [
+            (None, "doc-only", None),
+            (Some("copilot"), "doc-only", Some("copilot-resurrected")),
+            (Some("copilot"), "doc-only", Some("copilot-resurrected")),
+            (Some("copilot"), "doc-only", Some("copilot-restart")),
+            (None, "script", None),
+        ] {
+            insert(
+                "r1",
+                "2026-07-20T09:00:00Z",
+                "node_started",
+                Some(if node_type == "script" {
+                    "build"
+                } else {
+                    "worker"
+                }),
+                Some(1),
+                Some(serde_json::json!({
+                    "node_type":node_type,
+                    "harness":harness,
+                    "session_id":session_id
+                })),
+            )
+            .await;
+        }
+
+        insert(
+            "r2",
+            "2026-07-16T09:00:00Z",
+            "run_started",
+            None,
+            None,
+            Some(serde_json::json!({
+                "pipeline_id": "p1",
+                "pipeline_name": "Pipeline latest",
+                "target_repo": "/repos/product",
+                "node_defs": [{"id":"worker","name":"Worker latest","node_type":"doc-only"}]
+            })),
+        )
+        .await;
+        for (iter, session_id) in [(1, "future-loop-1"), (2, "future-loop-2")] {
+            insert(
+                "r2",
+                "2026-07-16T10:00:00Z",
+                "node_started",
+                Some("worker"),
+                Some(iter),
+                Some(serde_json::json!({
+                    "node_type":"doc-only",
+                    "harness":"future-harness",
+                    "session_id":session_id
+                })),
+            )
+            .await;
+        }
+
+        let response = build_router(state)
+            .oneshot(
+                Request::builder()
+                    .uri(
+                        "/stats/overview?from=2026-07-15T00:00:00Z&to=2026-07-17T00:00:00Z&bucket=day",
+                    )
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body: serde_json::Value = serde_json::from_slice(
+            &axum::body::to_bytes(response.into_body(), usize::MAX)
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            body["session_harnesses"],
+            serde_json::json!(["claude", "copilot", "future-harness"])
+        );
+        assert_eq!(
+            body["sessions_by_period"],
+            serde_json::json!([
+                {
+                    "bucket":"2026-07-15",
+                    "harnesses":[
+                        {"harness":"claude","executions":1},
+                        {"harness":"copilot","executions":2}
+                    ]
+                },
+                {
+                    "bucket":"2026-07-16",
+                    "harnesses":[
+                        {"harness":"future-harness","executions":2}
+                    ]
+                }
+            ])
+        );
+        let pipeline = &body["sessions_by_pipeline"][0];
+        assert_eq!(pipeline["id"], "p1");
+        assert_eq!(pipeline["name"], "Pipeline latest");
+        let worker = pipeline["nodes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|node| node["id"] == "worker")
+            .unwrap();
+        assert_eq!(worker["name"], "Worker latest");
+        assert_eq!(worker["executions"], 5);
+        assert_eq!(
+            worker["harnesses"],
+            serde_json::json!([
+                {"harness":"claude","executions":1},
+                {"harness":"copilot","executions":2},
+                {"harness":"future-harness","executions":2}
+            ])
+        );
+        assert!(
+            pipeline["nodes"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .all(|node| node["id"] != "build"),
+            "script starts are excluded"
+        );
+        assert_eq!(pipeline["executions"], 5);
+    }
+
+    #[tokio::test]
+    async fn stats_cost_returns_harness_coverage_and_nested_contribution_hierarchies() {
+        struct Cleanup(std::path::PathBuf);
+        impl Drop for Cleanup {
+            fn drop(&mut self) {
+                let _ = std::fs::remove_dir_all(&self.0);
+            }
+        }
+
+        let mut state = test_state().await;
+        let home = state
+            .repo_root
+            .join(".pdo")
+            .join("test-stats-cost")
+            .join(uuid::Uuid::new_v4().to_string());
+        let _cleanup = Cleanup(home.clone());
+        std::fs::create_dir_all(&home).unwrap();
+        Arc::get_mut(&mut state).unwrap().sandbox_home_override = Some(home.clone());
+        let repo = state.repo_root.to_string_lossy().into_owned();
+        sqlx::query(
+            "INSERT INTO projects (id, name, harness, created_at) VALUES \
+             ('prj-product', 'Product', NULL, '2026-07-01T00:00:00Z')",
+        )
+        .execute(&state.db)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO project_members (path, project_id, created_at) VALUES \
+             (?, 'prj-product', '2026-07-01T00:00:00Z')",
+        )
+        .bind(&repo)
+        .execute(&state.db)
+        .await
+        .unwrap();
+
+        async fn insert_event(
+            db: &sqlx::SqlitePool,
+            run: &str,
+            ts: &str,
+            kind: &str,
+            node: Option<&str>,
+            iter: Option<i64>,
+            payload: serde_json::Value,
+        ) {
+            sqlx::query(
+                "INSERT INTO events (run_id, ts, kind, node_id, iter, payload) \
+                 VALUES (?, ?, ?, ?, ?, ?)",
+            )
+            .bind(run)
+            .bind(ts)
+            .bind(kind)
+            .bind(node)
+            .bind(iter)
+            .bind(payload.to_string())
+            .execute(db)
+            .await
+            .unwrap();
+        }
+
+        let run_ids = ["stats-cost-r1", "stats-cost-r2", "stats-cost-r3"];
+        for (index, run_id) in run_ids.iter().enumerate() {
+            insert_event(
+                &state.db,
+                run_id,
+                &format!("2026-07-{}T09:00:00Z", 15 + index),
+                "run_started",
+                None,
+                None,
+                serde_json::json!({
+                    "pipeline_id":"p1",
+                    "pipeline_name":format!("Pipeline {}", index + 1),
+                    "target_repo":repo,
+                    "harness":"claude",
+                    "node_defs":[{"id":"worker","name":format!("Worker {}", index + 1),"node_type":"code-mutating"}]
+                }),
+            )
+            .await;
+        }
+        insert_event(
+            &state.db,
+            run_ids[0],
+            "2026-07-20T09:00:00Z",
+            "node_started",
+            Some("worker"),
+            Some(1),
+            serde_json::json!({"node_type":"code-mutating","harness":"claude","session_id":"claude-1"}),
+        )
+        .await;
+        insert_event(
+            &state.db,
+            run_ids[0],
+            "2026-07-20T10:00:00Z",
+            "node_started",
+            Some("worker"),
+            Some(1),
+            serde_json::json!({"node_type":"code-mutating","harness":"copilot","session_id":"copilot-1"}),
+        )
+        .await;
+        insert_event(
+            &state.db,
+            run_ids[0],
+            "2026-07-20T11:00:00Z",
+            "node_started",
+            Some("worker"),
+            Some(2),
+            serde_json::json!({"node_type":"code-mutating","harness":"future-harness","session_id":"future-1"}),
+        )
+        .await;
+        insert_event(
+            &state.db,
+            run_ids[1],
+            "2026-07-21T09:00:00Z",
+            "node_started",
+            Some("worker"),
+            Some(1),
+            serde_json::json!({"node_type":"code-mutating","harness":"future-harness","session_id":"future-2"}),
+        )
+        .await;
+        insert_event(
+            &state.db,
+            run_ids[2],
+            "2026-07-22T09:00:00Z",
+            "node_started",
+            Some("worker"),
+            Some(1),
+            serde_json::json!({"node_type":"doc-only"}),
+        )
+        .await;
+
+        let claude_dir =
+            home.join(".claude")
+                .join("projects")
+                .join(stale_detector::encode_working_dir(
+                    &worktree_ops::sub_worktree_path(&state.repo_root, run_ids[0], "worker", 1),
+                ));
+        std::fs::create_dir_all(&claude_dir).unwrap();
+        std::fs::write(
+            claude_dir.join("claude-1.jsonl"),
+            r#"{"type":"assistant","requestId":"r1","message":{"id":"m1","model":"claude-opus-4-8","usage":{"input_tokens":1000000,"output_tokens":0}}}"#,
+        )
+        .unwrap();
+        let legacy_dir =
+            home.join(".claude")
+                .join("projects")
+                .join(stale_detector::encode_working_dir(
+                    &worktree_ops::worktree_dir_for_run(&state.repo_root, run_ids[2]),
+                ));
+        std::fs::create_dir_all(&legacy_dir).unwrap();
+        std::fs::write(
+            legacy_dir.join("legacy.jsonl"),
+            r#"{"type":"assistant","requestId":"r3","message":{"id":"m3","model":"claude-opus-4-8","usage":{"input_tokens":1000000,"output_tokens":0}}}"#,
+        )
+        .unwrap();
+        let copilot_dir = home
+            .join(".copilot")
+            .join("session-state")
+            .join("copilot-1");
+        std::fs::create_dir_all(&copilot_dir).unwrap();
+        std::fs::write(
+            copilot_dir.join("events.jsonl"),
+            r#"{"type":"session.shutdown","data":{"totalNanoAiu":100000000000}}"#,
+        )
+        .unwrap();
+
+        let response = build_router(state)
+            .oneshot(
+                Request::builder()
+                    .uri("/stats/cost?from=2026-07-15T00:00:00Z&to=2026-07-18T00:00:00Z&bucket=day")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body: serde_json::Value = serde_json::from_slice(
+            &axum::body::to_bytes(response.into_body(), usize::MAX)
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            body["harnesses"],
+            serde_json::json!(["claude", "copilot", "future-harness"])
+        );
+        assert_eq!(body["total"]["usd"], 11.0);
+        assert_eq!(body["total"]["executions"], 3);
+        assert_eq!(body["total"]["readable"], 0);
+        assert_eq!(body["total"]["unknown"], 3);
+        assert!(
+            body["total"]["unknown"].as_i64().unwrap()
+                <= body["total"]["executions"].as_i64().unwrap()
+        );
+        let claude = body["total"]["harnesses"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|metric| metric["harness"] == "claude")
+            .unwrap();
+        assert_eq!(claude["usd"], 10.0);
+        assert!(claude["average_usd"].is_null());
+        assert_eq!(claude["estimated"], true);
+        assert_eq!(claude["executions"], 3);
+        assert_eq!(claude["readable"], 0);
+        assert_eq!(claude["unknown"], 3);
+        let future = body["total"]["harnesses"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|metric| metric["harness"] == "future-harness")
+            .unwrap();
+        assert!(future["usd"].is_null());
+        assert_eq!(future["executions"], 2);
+        assert_eq!(future["unknown"], 2);
+        assert!(future["missing_reasons"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|reason| reason == "harness has no cost source"));
+        let copilot = body["total"]["harnesses"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|metric| metric["harness"] == "copilot")
+            .unwrap();
+        assert_eq!(copilot["estimated"], false);
+        assert_eq!(copilot["executions"], 1);
+        assert_eq!(copilot["readable"], 1);
+        assert_eq!(copilot["unknown"], 0);
+        assert_eq!(copilot["average_usd"], 1.0);
+        for metric in body["total"]["harnesses"].as_array().unwrap() {
+            assert!(metric["unknown"].as_i64().unwrap() <= metric["executions"].as_i64().unwrap());
+        }
+
+        assert_eq!(body["by_period"][0]["bucket"], "2026-07-15");
+        assert_eq!(body["by_period"][0]["usd"], 6.0);
+        let pipeline = &body["by_pipeline"][0];
+        assert_eq!(pipeline["id"], "p1");
+        assert_eq!(pipeline["name"], "Pipeline 3");
+        assert_eq!(pipeline["executions"], 3);
+        assert_eq!(pipeline["readable"], 0);
+        assert_eq!(pipeline["unknown"], 3);
+        let worker = pipeline["nodes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|row| row["id"] == "worker")
+            .unwrap();
+        assert_eq!(worker["name"], "Worker 3");
+        assert_eq!(worker["executions"], 5);
+        assert_eq!(worker["readable"], 2);
+        assert_eq!(worker["unknown"], 3);
+        let infrastructure = pipeline["nodes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|row| row["name"] == "Infrastructure")
+            .unwrap();
+        assert_eq!(infrastructure["executions"], 3);
+        assert_eq!(infrastructure["unknown"], 3);
+        let unassigned = pipeline["nodes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|row| row["name"] == "Unassigned")
+            .unwrap();
+        assert_eq!(unassigned["usd"], 5.0);
+        assert_eq!(unassigned["readable"], 0);
+        assert_eq!(body["by_project"][0]["id"], "prj-product");
+        assert_eq!(body["by_project"][0]["name"], "Product");
+        assert_eq!(body["by_project"][0]["executions"], 3);
+        assert_eq!(body["by_project"][0]["readable"], 0);
+        assert_eq!(body["by_project"][0]["unknown"], 3);
+        assert_eq!(body["by_project"][0]["pipelines"][0]["id"], "p1");
+        assert!(!body["resolved"].as_array().unwrap().is_empty());
     }
 
     /// Like [`test_state`], but with an injected [`ServiceHealth`] so the

--- a/crates/pdo-daemon/src/run_cost.rs
+++ b/crates/pdo-daemon/src/run_cost.rs
@@ -1,6 +1,8 @@
-//! Estimated USD cost of a Run (#272), derived on read from the per-message
-//! token `usage` recorded in each session's Claude Code transcript
-//! (`<projects_root>/<encoded-cwd>/*.jsonl`) × a public price table.
+//! Harness-aware USD cost of a Run, derived on read as common contributions.
+//! Claude contributions use per-message token `usage` from each parent session
+//! transcript plus its subagents. Copilot contributions preserve the reported
+//! cumulative cost from its session journal. Unknown harnesses retain their
+//! executions and an absence reason without inventing a zero cost.
 //!
 //! Since #427 that table is **injected** too, as a [`crate::price_table::PriceTable`]
 //! resolved by the caller at the request edge (`manual → fetched → embedded`, see
@@ -13,10 +15,10 @@
 //! `off`/archived run, the staged home while a sandboxed run is live. This
 //! module never reads `$HOME` — one root in, path-math + `std::fs` out.
 //!
-//! This is an **estimate, not an invoice**: it uses public list prices (no
+//! Claude cost is an **estimate, not an invoice**: it uses public list prices (no
 //! enterprise discount), and any model absent from the table contributes $0,
-//! flips the `partial` flag, AND is named in `unpriced_models` (#425 AC#4:
-//! lower-bound signalling that says *which* model, not just *that* one exists).
+//! flips the `partial` flag, and is named in `unpriced_models`. Copilot cost is
+//! reported, not recalculated from tokens.
 //! It mirrors `LocStat`'s
 //! "derived on read, never persisted" contract (see [`crate::event_log::CostStat`]),
 //! and happens to be *more* durable than LOC: archival deletes the run branch
@@ -41,12 +43,437 @@
 //! - **Tolerant parsing.** Torn writes (an interleaved-flush `clauclaude-opus-4-8`
 //!   was observed) are skipped line-by-line, never `?`-propagated.
 
-use crate::event_log::CostStat;
+use crate::event_log::{CostForm, CostStat, HarnessCost};
 use crate::price_table::{strip_date_suffix, PriceTable};
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::hash::{DefaultHasher, Hash, Hasher};
 use std::path::Path;
 use std::sync::{Mutex, OnceLock};
 use std::time::UNIX_EPOCH;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CostScope {
+    Node,
+    Infrastructure,
+    Unassigned,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct CostContribution {
+    pub harness: String,
+    pub scope: CostScope,
+    pub node_id: Option<String>,
+    pub executions: i64,
+    pub readable_executions: i64,
+    pub usd: Option<f64>,
+    pub form: Option<CostForm>,
+    pub partial: bool,
+    pub unpriced_models: Vec<String>,
+    pub unavailable_reasons: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct RunCostBreakdown {
+    pub contributions: Vec<CostContribution>,
+    pub cost: Option<CostStat>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) enum FrozenExecutionIdentity {
+    Session {
+        harness: String,
+        session_id: String,
+    },
+    Legacy {
+        node_id: String,
+        iter: i64,
+        event_id: Option<i64>,
+        order: usize,
+    },
+}
+
+pub(crate) fn frozen_execution_identity(
+    harness: &str,
+    session_id: Option<&str>,
+    node_id: Option<&str>,
+    iter: Option<i64>,
+    event_id: Option<i64>,
+    order: usize,
+) -> FrozenExecutionIdentity {
+    match session_id.filter(|session_id| !session_id.is_empty()) {
+        Some(session_id) => FrozenExecutionIdentity::Session {
+            harness: harness.to_string(),
+            session_id: session_id.to_string(),
+        },
+        None => FrozenExecutionIdentity::Legacy {
+            node_id: node_id.unwrap_or("(unknown)").to_string(),
+            iter: iter.unwrap_or(1),
+            event_id,
+            order,
+        },
+    }
+}
+
+/// GitHub Copilot bills in AI credits (AIU), one AIU worth one US cent. Its
+/// journal reports cumulative spend in nano-AIU, so:
+///
+/// `USD = nanoAiu × 1e-9 AIU/nano-AIU × $0.01/AIU = nanoAiu × 1e-11`.
+///
+/// This is Copilot's published billing conversion, not a token-price estimate.
+const USD_PER_AIU: f64 = 0.01;
+const NANO_PER_AIU: f64 = 1e9;
+
+fn nano_aiu_to_usd(nano_aiu: u64) -> f64 {
+    nano_aiu as f64 / NANO_PER_AIU * USD_PER_AIU
+}
+
+fn reported_cost_usd(journal: &str) -> Option<f64> {
+    let max_nano_aiu = journal
+        .lines()
+        .filter_map(|raw| serde_json::from_str::<serde_json::Value>(raw.trim()).ok())
+        .filter(|value| {
+            matches!(
+                value.get("type").and_then(|kind| kind.as_str()),
+                Some("session.usage_checkpoint") | Some("session.shutdown")
+            )
+        })
+        .filter_map(|value| {
+            value
+                .get("data")
+                .and_then(|data| data.get("totalNanoAiu"))
+                .and_then(|total| total.as_u64())
+        })
+        .max()?;
+    Some(nano_aiu_to_usd(max_nano_aiu))
+}
+
+fn collect_jsonl_file(path: &Path, out: &mut Vec<Line>) {
+    if let Ok(content) = std::fs::read_to_string(path) {
+        out.extend(content.lines().filter_map(parse_line));
+    }
+}
+
+fn claude_execution_cost(
+    claude_root: &Path,
+    working_dir: &Path,
+    session_id: Option<&str>,
+    prices: &PriceTable,
+) -> Option<CostStat> {
+    let project = claude_root.join(cc_project_dirname(working_dir));
+    if !project.is_dir() {
+        return None;
+    }
+    let mut lines = Vec::new();
+    match session_id {
+        Some(sid) => {
+            let main = project.join(format!("{sid}.jsonl"));
+            let subagents = project.join(sid).join("subagents");
+            if !main.is_file() && !subagents.is_dir() {
+                return None;
+            }
+            collect_jsonl_file(&main, &mut lines);
+            collect_jsonl_recursive(&subagents, &mut lines);
+        }
+        None => collect_jsonl_recursive(&project, &mut lines),
+    }
+    Some(aggregate(lines.into_iter(), prices))
+}
+
+pub(crate) fn compute_run_cost_breakdown(
+    events: &[crate::event_log::Event],
+    claude_root: &Path,
+    copilot_root: &Path,
+    repo_root: &Path,
+    run_id: &str,
+    prices: &PriceTable,
+) -> RunCostBreakdown {
+    let node_types: BTreeMap<String, String> = events
+        .iter()
+        .find(|event| event.kind == crate::event_log::EventKind::RunStarted)
+        .and_then(|event| event.payload.as_ref())
+        .and_then(|payload| payload.get("node_defs"))
+        .and_then(|value| value.as_array())
+        .into_iter()
+        .flatten()
+        .filter_map(|node| {
+            Some((
+                node.get("id")?.as_str()?.to_string(),
+                node.get("node_type")?.as_str()?.to_string(),
+            ))
+        })
+        .collect();
+    let node_type = |event: &crate::event_log::Event| {
+        event
+            .payload
+            .as_ref()
+            .and_then(|payload| payload.get("node_type"))
+            .and_then(|value| value.as_str())
+            .map(str::to_string)
+            .or_else(|| {
+                event
+                    .node_id
+                    .as_ref()
+                    .and_then(|id| node_types.get(id))
+                    .cloned()
+            })
+    };
+    let mut contributions = Vec::new();
+    let mut seen_executions = HashSet::new();
+    for (order, event) in events.iter().enumerate() {
+        if event.kind != crate::event_log::EventKind::NodeStarted {
+            continue;
+        }
+        let payload = event.payload.as_ref();
+        if node_type(event).as_deref() == Some("script") {
+            continue;
+        }
+        let harness = payload
+            .and_then(|p| p.get("harness"))
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .unwrap_or(crate::harness_registry::CLAUDE);
+        let session_id = payload
+            .and_then(|p| p.get("session_id"))
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty());
+        let identity = frozen_execution_identity(
+            harness,
+            session_id,
+            event.node_id.as_deref(),
+            event.iter,
+            event.id,
+            order,
+        );
+        if !seen_executions.insert(identity) {
+            continue;
+        }
+        let (cost, form, reason) = match harness {
+            crate::harness_registry::COPILOT => {
+                let usd = session_id.and_then(|sid| {
+                    let journal =
+                        std::fs::read_to_string(copilot_root.join(sid).join("events.jsonl"))
+                            .ok()?;
+                    reported_cost_usd(&journal)
+                });
+                (
+                    usd.map(|usd| CostStat {
+                        usd,
+                        partial: false,
+                        unpriced_models: Vec::new(),
+                        uncosted_harnesses: Vec::new(),
+                        by_harness: Vec::new(),
+                    }),
+                    Some(CostForm::Reported),
+                    if session_id.is_none() {
+                        Some("missing session identity")
+                    } else {
+                        Some("no reported cost reading")
+                    },
+                )
+            }
+            crate::harness_registry::CLAUDE => {
+                let node_type = node_type(event);
+                let working_dir = if node_type.as_deref() == Some("code-mutating") {
+                    crate::worktree_ops::sub_worktree_path(
+                        repo_root,
+                        run_id,
+                        event.node_id.as_deref().unwrap_or(""),
+                        event.iter.unwrap_or(1),
+                    )
+                } else {
+                    crate::worktree_ops::worktree_dir_for_run(repo_root, run_id)
+                };
+                (
+                    if session_id.is_some() || node_type.as_deref() == Some("code-mutating") {
+                        claude_execution_cost(claude_root, &working_dir, session_id, prices)
+                    } else {
+                        None
+                    },
+                    Some(CostForm::Derived),
+                    Some("no attributable Claude transcript"),
+                )
+            }
+            _ => (None, None, Some("harness has no cost source")),
+        };
+        let usd = cost.as_ref().map(|c| c.usd);
+        contributions.push(CostContribution {
+            harness: harness.to_string(),
+            scope: CostScope::Node,
+            node_id: event.node_id.clone(),
+            executions: 1,
+            readable_executions: i64::from(usd.is_some()),
+            usd,
+            form: usd.and(form),
+            partial: cost.as_ref().is_some_and(|c| c.partial),
+            unpriced_models: cost
+                .as_ref()
+                .map(|c| c.unpriced_models.clone())
+                .unwrap_or_default(),
+            unavailable_reasons: if cost.is_none() {
+                reason.map(str::to_string).into_iter().collect()
+            } else {
+                Vec::new()
+            },
+        });
+    }
+
+    let run_harness = events
+        .iter()
+        .find(|event| event.kind == crate::event_log::EventKind::RunStarted)
+        .and_then(|event| event.payload.as_ref())
+        .and_then(|payload| payload.get("harness"))
+        .and_then(|value| value.as_str())
+        .filter(|value| !value.is_empty())
+        .unwrap_or(crate::harness_registry::CLAUDE);
+    let infrastructure_executions = i64::from(
+        events
+            .iter()
+            .any(|event| event.kind == crate::event_log::EventKind::RunStarted),
+    ) + events
+        .iter()
+        .filter(|event| event.kind == crate::event_log::EventKind::MergeResolverStarted)
+        .count() as i64;
+    if infrastructure_executions > 0 {
+        let ambiguous_shared_claude = events.iter().any(|event| {
+            if event.kind != crate::event_log::EventKind::NodeStarted {
+                return false;
+            }
+            let payload = event.payload.as_ref();
+            let node_type = node_type(event);
+            let harness = payload
+                .and_then(|p| p.get("harness"))
+                .and_then(|value| value.as_str())
+                .filter(|value| !value.is_empty())
+                .unwrap_or(crate::harness_registry::CLAUDE);
+            let has_session = payload
+                .and_then(|p| p.get("session_id"))
+                .and_then(|value| value.as_str())
+                .is_some_and(|value| !value.is_empty());
+            node_type.as_deref() != Some("script")
+                && node_type.as_deref() != Some("code-mutating")
+                && harness == crate::harness_registry::CLAUDE
+                && !has_session
+        });
+        let full_claude = (run_harness == crate::harness_registry::CLAUDE)
+            .then(|| compute_run_cost(claude_root, repo_root, run_id, prices))
+            .flatten();
+        let attributed_claude_usd: f64 = contributions
+            .iter()
+            .filter(|c| c.harness == crate::harness_registry::CLAUDE && c.scope == CostScope::Node)
+            .filter_map(|c| c.usd)
+            .sum();
+        let residual = full_claude.map(|cost| CostStat {
+            usd: (cost.usd - attributed_claude_usd).max(0.0),
+            partial: cost.partial,
+            unpriced_models: cost.unpriced_models,
+            uncosted_harnesses: Vec::new(),
+            by_harness: Vec::new(),
+        });
+        let readable = residual
+            .as_ref()
+            .is_some_and(|cost| cost.usd > 0.0 || cost.partial || !cost.unpriced_models.is_empty());
+        contributions.push(CostContribution {
+            harness: run_harness.to_string(),
+            scope: CostScope::Infrastructure,
+            node_id: None,
+            executions: infrastructure_executions,
+            readable_executions: if readable && !ambiguous_shared_claude {
+                infrastructure_executions
+            } else {
+                0
+            },
+            usd: (readable && !ambiguous_shared_claude)
+                .then(|| residual.as_ref().map_or(0.0, |cost| cost.usd)),
+            form: (readable && !ambiguous_shared_claude).then_some(CostForm::Derived),
+            partial: !ambiguous_shared_claude && residual.as_ref().is_some_and(|cost| cost.partial),
+            unpriced_models: if ambiguous_shared_claude {
+                Vec::new()
+            } else {
+                residual
+                    .as_ref()
+                    .map(|cost| cost.unpriced_models.clone())
+                    .unwrap_or_default()
+            },
+            unavailable_reasons: if readable && !ambiguous_shared_claude {
+                Vec::new()
+            } else {
+                vec!["no attributable infrastructure cost".to_string()]
+            },
+        });
+        if readable && ambiguous_shared_claude {
+            let residual = residual.expect("readable residual exists");
+            contributions.push(CostContribution {
+                harness: crate::harness_registry::CLAUDE.to_string(),
+                scope: CostScope::Unassigned,
+                node_id: None,
+                executions: 0,
+                readable_executions: 0,
+                usd: Some(residual.usd),
+                form: Some(CostForm::Derived),
+                partial: residual.partial,
+                unpriced_models: residual.unpriced_models,
+                unavailable_reasons: vec![
+                    "Claude transcript cannot be matched to a legacy node or infrastructure"
+                        .to_string(),
+                ],
+            });
+        }
+    }
+
+    let any_readable = contributions.iter().any(|c| c.usd.is_some());
+    let unpriced_models: Vec<String> = contributions
+        .iter()
+        .flat_map(|c| c.unpriced_models.iter().cloned())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect();
+    let uncosted_harnesses: Vec<String> = contributions
+        .iter()
+        .filter(|contribution| {
+            contribution.usd.is_none()
+                && contribution
+                    .unavailable_reasons
+                    .iter()
+                    .any(|reason| reason == "harness has no cost source")
+        })
+        .map(|contribution| contribution.harness.clone())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect();
+    let mut harnesses: BTreeMap<String, HarnessCost> = BTreeMap::new();
+    for contribution in &contributions {
+        let (Some(usd), Some(form)) = (contribution.usd, contribution.form) else {
+            continue;
+        };
+        let entry = harnesses
+            .entry(contribution.harness.clone())
+            .or_insert_with(|| HarnessCost {
+                harness: contribution.harness.clone(),
+                usd: 0.0,
+                form,
+                partial: false,
+                unpriced_models: Vec::new(),
+            });
+        entry.usd += usd;
+        entry.partial |= contribution.partial;
+        entry
+            .unpriced_models
+            .extend(contribution.unpriced_models.iter().cloned());
+        entry.unpriced_models.sort();
+        entry.unpriced_models.dedup();
+    }
+    let cost = any_readable.then(|| CostStat {
+        usd: contributions.iter().filter_map(|c| c.usd).sum(),
+        partial: !unpriced_models.is_empty(),
+        unpriced_models,
+        uncosted_harnesses,
+        by_harness: harnesses.into_values().collect(),
+    });
+    RunCostBreakdown {
+        contributions,
+        cost,
+    }
+}
 
 /// Token counts from one assistant message's `usage`. The four cache buckets are
 /// disjoint from `input`/`output` (CC's `input_tokens` excludes cache tokens).
@@ -177,6 +604,7 @@ fn aggregate(lines: impl Iterator<Item = Line>, prices: &PriceTable) -> CostStat
         // this fold; they are handled one layer up in [`run_cost_or_absence`], which
         // returns a "—"-with-reason `CostStat` before any transcript is read.
         uncosted_harnesses: Vec::new(),
+        by_harness: Vec::new(),
     }
 }
 
@@ -221,25 +649,28 @@ pub(crate) fn uncosted_harnesses(events: &[crate::event_log::Event]) -> Vec<Stri
 /// is [`compute_run_cost`]'s signature verbatim.
 pub(crate) fn run_cost_or_absence(
     events: &[crate::event_log::Event],
-    projects_root: &Path,
+    claude_root: &Path,
+    copilot_root: &Path,
     repo_root: &Path,
     run_id: &str,
     prices: &PriceTable,
 ) -> Option<CostStat> {
+    let breakdown =
+        compute_run_cost_breakdown(events, claude_root, copilot_root, repo_root, run_id, prices);
+    if breakdown.cost.is_some() {
+        return breakdown.cost;
+    }
     let uncosted = uncosted_harnesses(events);
     if !uncosted.is_empty() {
         return Some(CostStat {
             usd: 0.0,
-            // NOT `partial`: `partial` means "priced, but a lower bound" and still
-            // shows a dollar figure. This is a categorically different state — the
-            // aggregate is unavailable, not merely incomplete — so it stays out of
-            // the `partial ⟺ !unpriced_models.is_empty()` invariant (both empty).
             partial: false,
             unpriced_models: Vec::new(),
             uncosted_harnesses: uncosted,
+            by_harness: Vec::new(),
         });
     }
-    compute_run_cost(projects_root, repo_root, run_id, prices)
+    compute_run_cost(claude_root, repo_root, run_id, prices)
 }
 
 /// Encode an absolute path exactly as Claude Code names its `~/.claude/projects`
@@ -317,51 +748,14 @@ pub(crate) fn compute_run_cost(
     Some(aggregate(lines.into_iter(), prices))
 }
 
-// --- Read-side memo for the aggregate cost path (#377 / ADR-0029) ------------
+// --- Read-side memo for the aggregate contribution path ----------------------
 //
-// The Stats modal's `/stats/cost` endpoint fans [`compute_run_cost`] out over
-// every run in the visible period — the exact anti-fan-out ADR-0022 kept off the
-// `/runs` list handler. This memo is ADR-0022's *sanctioned escape hatch*: a
-// derive-on-read RAM cache keyed on `(run_id, max transcript mtime, price-table
-// fingerprint)`, NEVER persisted (no snapshot table, no metric-freezing event). A
-// transcript change bumps the mtime and so invalidates the entry naturally. It is
-// touched ONLY by [`compute_run_cost_cached`] (the aggregate path); `get_run`'s
-// single-run read keeps calling [`compute_run_cost`] directly, so ADR-0022's
-// per-read contract is byte-identical there.
-//
-// The THIRD key component is load-bearing (#427, ADR-0034). A price sync bumps no
-// transcript mtime, so under the old two-part key `/stats/cost` (memoized) would
-// re-serve pre-sync dollars until the daemon restarted while `GET /runs/:id`
-// (not memoized) told the truth — two surfaces contradicting each other on the
-// same Run, and the affected Runs (finished, transcripts frozen) are exactly the
-// ones a sync is meant to repair. A sync deliberately does NOT clear the memo:
-// under the new key a stale entry is simply unreachable, and clearing would also
-// invalidate Runs whose prices did not move.
+// `/stats/cost` fans over every Run in the selected cohort. The production memo
+// stores the complete harness contribution breakdown, never a superseded scalar.
+// Its key changes with the event snapshot, Claude transcripts, Copilot journals,
+// resolved prices, or storage roots. Nothing is persisted.
 
-/// Memo key: `(run_id, max transcript mtime in epoch millis, price-table
-/// fingerprint)`. A transcript change bumps the mtime and a price change bumps the
-/// fingerprint, so either one changes the key and bypasses the old entry.
-///
-/// Consequence to know: [`COST_MEMO_CAP`] now holds several entries per Run across
-/// a table change. Overflow clears the whole map, which stays
-/// correctness-preserving by construction.
-type CostMemoKey = (String, i64, u64);
-/// The memoized value is exactly what [`compute_run_cost`] returns (`None` = no
-/// transcript dir), so a hit is byte-identical to a recompute.
-type CostMemoMap = HashMap<CostMemoKey, Option<CostStat>>;
-
-static COST_MEMO: OnceLock<Mutex<CostMemoMap>> = OnceLock::new();
-
-/// Soft cap on memo entries. On overflow the whole map is cleared — dropping the
-/// cache is correctness-preserving (a miss just recomputes), so this bounds RAM
-/// without pulling in an `lru` crate. A `CostStat` is a handful of scalars plus a
-/// short `unpriced_models` vec (empty on the overwhelming majority of Runs), so
-/// this cap stays roomy.
-const COST_MEMO_CAP: usize = 4096;
-
-fn cost_memo() -> &'static Mutex<CostMemoMap> {
-    COST_MEMO.get_or_init(|| Mutex::new(HashMap::new()))
-}
+const BREAKDOWN_MEMO_CAP: usize = 4096;
 
 /// Recurse a project dir, folding the max `*.jsonl` mtime (epoch millis) into
 /// `max_ms`. Mirrors [`collect_jsonl_recursive`]'s traversal but `stat`s only —
@@ -413,35 +807,95 @@ pub(crate) fn max_transcript_mtime_millis(
     max_ms
 }
 
-/// Memoized [`compute_run_cost`]: byte-identical result, cached on
-/// `(run_id, max transcript mtime, price fingerprint)` (see the module memo
-/// above). Used only by the `/stats/cost` aggregate (period-bounded fan-out);
-/// `get_run`'s single-run path is deliberately left calling [`compute_run_cost`]
-/// directly so ADR-0022's per-read contract is unchanged.
-pub(crate) fn compute_run_cost_cached(
-    projects_root: &Path,
+type BreakdownMemoKey = (String, i64, i64, u64, u64, u64);
+type BreakdownMemoMap = HashMap<BreakdownMemoKey, RunCostBreakdown>;
+
+static BREAKDOWN_MEMO: OnceLock<Mutex<BreakdownMemoMap>> = OnceLock::new();
+
+fn breakdown_memo() -> &'static Mutex<BreakdownMemoMap> {
+    BREAKDOWN_MEMO.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn copilot_mtime_millis(events: &[crate::event_log::Event], copilot_root: &Path) -> i64 {
+    events
+        .iter()
+        .filter_map(|event| {
+            event
+                .payload
+                .as_ref()
+                .and_then(|payload| payload.get("session_id"))
+                .and_then(|value| value.as_str())
+        })
+        .filter_map(|session_id| {
+            std::fs::metadata(copilot_root.join(session_id).join("events.jsonl"))
+                .and_then(|metadata| metadata.modified())
+                .ok()
+        })
+        .map(|modified| {
+            modified
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_millis() as i64
+        })
+        .max()
+        .unwrap_or(0)
+}
+
+fn event_fingerprint(events: &[crate::event_log::Event]) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    for event in events {
+        event.run_id.hash(&mut hasher);
+        event.ts.hash(&mut hasher);
+        serde_json::to_string(&event.kind)
+            .unwrap_or_default()
+            .hash(&mut hasher);
+        event.node_id.hash(&mut hasher);
+        event.iter.hash(&mut hasher);
+        event
+            .payload
+            .as_ref()
+            .map(serde_json::Value::to_string)
+            .hash(&mut hasher);
+    }
+    hasher.finish()
+}
+
+/// Memoized contribution fold for the lazy Stats cost endpoint. The key covers
+/// the event snapshot, Claude transcripts, Copilot journals, and resolved prices.
+pub(crate) fn compute_run_cost_breakdown_cached(
+    events: &[crate::event_log::Event],
+    claude_root: &Path,
+    copilot_root: &Path,
     repo_root: &Path,
     run_id: &str,
     prices: &PriceTable,
-) -> Option<CostStat> {
-    // Load-bearing twice over: the SAME `projects_root` feeds the key (mtime) AND
-    // the value (aggregate) — a mismatched root would desync the memo silently
-    // (#408 P1) — and the SAME table feeds the fingerprint AND the pricing, so a
-    // hit can never be a table the caller did not ask for (#427).
+) -> RunCostBreakdown {
+    let mut roots = DefaultHasher::new();
+    claude_root.hash(&mut roots);
+    copilot_root.hash(&mut roots);
+    repo_root.hash(&mut roots);
     let key = (
         run_id.to_string(),
-        max_transcript_mtime_millis(projects_root, repo_root, run_id),
+        max_transcript_mtime_millis(claude_root, repo_root, run_id),
+        copilot_mtime_millis(events, copilot_root),
         prices.fingerprint(),
+        event_fingerprint(events),
+        roots.finish(),
     );
     {
-        let guard = cost_memo().lock().unwrap_or_else(|e| e.into_inner());
+        let guard = breakdown_memo()
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
         if let Some(hit) = guard.get(&key) {
             return hit.clone();
         }
     }
-    let value = compute_run_cost(projects_root, repo_root, run_id, prices);
-    let mut guard = cost_memo().lock().unwrap_or_else(|e| e.into_inner());
-    if guard.len() >= COST_MEMO_CAP {
+    let value =
+        compute_run_cost_breakdown(events, claude_root, copilot_root, repo_root, run_id, prices);
+    let mut guard = breakdown_memo()
+        .lock()
+        .unwrap_or_else(|error| error.into_inner());
+    if guard.len() >= BREAKDOWN_MEMO_CAP {
         guard.clear();
     }
     guard.insert(key, value.clone());
@@ -499,6 +953,26 @@ mod tests {
         format!(
             r#"{{"type":"assistant","requestId":"{req}","message":{{"id":"{id}","model":"{model}","usage":{{"input_tokens":{input},"output_tokens":{output}}}}}}}"#
         )
+    }
+
+    #[test]
+    fn copilot_nano_aiu_converts_by_the_published_constant() {
+        assert!((nano_aiu_to_usd(2_823_580_000) - 0.0282358).abs() < 1e-12);
+        assert!((nano_aiu_to_usd(100_000_000_000) - 1.0).abs() < 1e-12);
+        assert_eq!(nano_aiu_to_usd(0), 0.0);
+    }
+
+    #[test]
+    fn copilot_reported_cost_reads_the_max_total_and_is_none_when_absent() {
+        let journal = concat!(
+            "{\"type\":\"session.usage_checkpoint\",\"data\":{\"totalNanoAiu\":2823580000}}\n",
+            "torn json\n",
+            "{\"type\":\"session.shutdown\",\"data\":{\"totalNanoAiu\":2000000000}}\n",
+            "{\"type\":\"session.shutdown\",\"data\":{\"totalNanoAiu\":3000000000}}\n"
+        );
+        assert!((reported_cost_usd(journal).unwrap() - 0.03).abs() < 1e-12);
+        assert!(reported_cost_usd("{\"type\":\"assistant.turn_start\"}\n").is_none());
+        assert!(reported_cost_usd("").is_none());
     }
 
     #[test]
@@ -719,7 +1193,7 @@ mod tests {
         assert!(compute_run_cost(&projects, repo.path(), "no-such-run", &builtin()).is_none());
     }
 
-    // --- compute_run_cost_cached / memo (#377) ---
+    // --- transcript discovery and production breakdown memo ---
 
     /// Write a single-line transcript for `run_id`'s worktree under `projects` and
     /// return the `.jsonl` path so the test can manipulate its mtime.
@@ -735,210 +1209,6 @@ mod tests {
         let file = proj.join("s.jsonl");
         std::fs::write(&file, format!("{line}\n")).unwrap();
         file
-    }
-
-    #[test]
-    fn cached_matches_uncached() {
-        let home = tempfile::tempdir().unwrap();
-        let projects = home.path().join(".claude").join("projects");
-        let repo = tempfile::tempdir().unwrap();
-        let run_id = "memo-eq";
-        seed_transcript(
-            &projects,
-            repo.path(),
-            run_id,
-            &assistant("m1", "r1", "claude-opus-4-8", 1_000_000, 0),
-        );
-        let direct = compute_run_cost(&projects, repo.path(), run_id, &builtin());
-        let cached = compute_run_cost_cached(&projects, repo.path(), run_id, &builtin());
-        assert_eq!(direct, cached);
-        assert!((cached.unwrap().usd - 5.0).abs() < 1e-9);
-    }
-
-    #[test]
-    fn cached_re_serves_from_memo_when_mtime_is_unchanged() {
-        let home = tempfile::tempdir().unwrap();
-        let projects = home.path().join(".claude").join("projects");
-        let repo = tempfile::tempdir().unwrap();
-        let run_id = "memo-hit";
-        let file = seed_transcript(
-            &projects,
-            repo.path(),
-            run_id,
-            &assistant("m1", "r1", "claude-opus-4-8", 1_000_000, 0),
-        );
-        let orig =
-            filetime::FileTime::from_last_modification_time(&std::fs::metadata(&file).unwrap());
-
-        // First call: memoize $5 under (run_id, mtime).
-        let first = compute_run_cost_cached(&projects, repo.path(), run_id, &builtin()).unwrap();
-        assert!((first.usd - 5.0).abs() < 1e-9);
-
-        // Rewrite with a DIFFERENT cost ($10) but force the mtime back — the key
-        // is unchanged, so the memo must re-serve the stale $5.
-        std::fs::write(
-            &file,
-            format!(
-                "{}\n",
-                assistant("m2", "r2", "claude-opus-4-8", 2_000_000, 0)
-            ),
-        )
-        .unwrap();
-        filetime::set_file_mtime(&file, orig).unwrap();
-        let hit = compute_run_cost_cached(&projects, repo.path(), run_id, &builtin()).unwrap();
-        assert!((hit.usd - 5.0).abs() < 1e-9, "memo hit should re-serve $5");
-        // But the uncached path sees the new content ($10) — proving the file
-        // really changed and the hit above was the cache, not a recompute.
-        let direct = compute_run_cost(&projects, repo.path(), run_id, &builtin()).unwrap();
-        assert!((direct.usd - 10.0).abs() < 1e-9);
-    }
-
-    #[test]
-    fn cached_recomputes_when_only_the_price_table_changes() {
-        // THE #427 regression test. A price sync bumps NO transcript mtime, so under
-        // the old two-part key `/stats/cost` would re-serve pre-sync dollars until
-        // the daemon restarted while `GET /runs/:id` showed the new ones — two
-        // surfaces contradicting each other on a finished Run, which is exactly the
-        // Run a sync exists to repair. Delete the third key component and this fails.
-        let home = tempfile::tempdir().unwrap();
-        let projects = home.path().join(".claude").join("projects");
-        let repo = tempfile::tempdir().unwrap();
-        let run_id = "memo-prices";
-        let file = seed_transcript(
-            &projects,
-            repo.path(),
-            run_id,
-            // A model NO tier prices out of the box → $0 + partial, the very symptom.
-            // Since #527 floored gen-5, this must be a model beyond the floor
-            // (`claude-opus-6`) for the $0 to be genuine.
-            &assistant("m1", "r1", "claude-opus-6", 1_000_000, 0),
-        );
-        let mtime_before =
-            filetime::FileTime::from_last_modification_time(&std::fs::metadata(&file).unwrap());
-
-        let unpriced = compute_run_cost_cached(&projects, repo.path(), run_id, &builtin()).unwrap();
-        assert_eq!(unpriced.usd, 0.0);
-        assert!(unpriced.partial, "an unknown model flags partial");
-        assert_eq!(
-            unpriced.unpriced_models,
-            vec!["claude-opus-6".to_string()],
-            "and the memo carries the offender's name, not just the flag (#425)"
-        );
-
-        // Now price it — a DIFFERENT table (different fingerprint), same transcript.
-        let home2 = tempfile::tempdir().unwrap();
-        let (manual, _) = crate::price_table::PriceTable::paths(home2.path());
-        std::fs::create_dir_all(manual.parent().unwrap()).unwrap();
-        std::fs::write(
-            &manual,
-            "models:\n  claude-opus-6: { input: 10.0, output: 50.0 }\n",
-        )
-        .unwrap();
-        let synced = crate::price_table::PriceTable::load(home2.path());
-        assert_ne!(synced.fingerprint(), builtin().fingerprint());
-
-        // The transcript's mtime is untouched — only the table moved.
-        assert_eq!(
-            filetime::FileTime::from_last_modification_time(&std::fs::metadata(&file).unwrap()),
-            mtime_before
-        );
-
-        let repriced = compute_run_cost_cached(&projects, repo.path(), run_id, &synced).unwrap();
-        assert!(
-            (repriced.usd - 10.0).abs() < 1e-9,
-            "the memo must MISS on a new price fingerprint, got ${}",
-            repriced.usd
-        );
-        assert!(!repriced.partial, "the model is priced now");
-        assert!(
-            repriced.unpriced_models.is_empty(),
-            "and no model is named as unpriced any more"
-        );
-
-        // And the old entry is still reachable under its own key — the sync does not
-        // (and need not) clear the memo.
-        let again = compute_run_cost_cached(&projects, repo.path(), run_id, &builtin()).unwrap();
-        assert_eq!(again.usd, 0.0);
-    }
-
-    #[test]
-    fn cached_recomputes_when_mtime_bumps() {
-        let home = tempfile::tempdir().unwrap();
-        let projects = home.path().join(".claude").join("projects");
-        let repo = tempfile::tempdir().unwrap();
-        let run_id = "memo-bump";
-        let file = seed_transcript(
-            &projects,
-            repo.path(),
-            run_id,
-            &assistant("m1", "r1", "claude-opus-4-8", 1_000_000, 0),
-        );
-        let orig =
-            filetime::FileTime::from_last_modification_time(&std::fs::metadata(&file).unwrap());
-        let first = compute_run_cost_cached(&projects, repo.path(), run_id, &builtin()).unwrap();
-        assert!((first.usd - 5.0).abs() < 1e-9);
-
-        // New content AND a bumped mtime → new key → recompute picks up $10.
-        std::fs::write(
-            &file,
-            format!(
-                "{}\n",
-                assistant("m2", "r2", "claude-opus-4-8", 2_000_000, 0)
-            ),
-        )
-        .unwrap();
-        let bumped = filetime::FileTime::from_unix_time(orig.unix_seconds() + 10, 0);
-        filetime::set_file_mtime(&file, bumped).unwrap();
-        let recomputed =
-            compute_run_cost_cached(&projects, repo.path(), run_id, &builtin()).unwrap();
-        assert!(
-            (recomputed.usd - 10.0).abs() < 1e-9,
-            "a bumped mtime must invalidate the memo"
-        );
-    }
-
-    #[test]
-    fn cached_honors_the_injected_projects_root() {
-        // #408 P1: `compute_run_cost_cached` feeds the SAME `projects_root` to
-        // both the mtime key AND the aggregate value — so the cached path honors
-        // whichever root the seam picked (staging while live, host after cleanup).
-        // Mirrors production, where the two roots for a run never share an mtime:
-        // `merge_back` copies with `std::fs::copy` (no mtime preservation), so the
-        // host file lands with a newer mtime than the staging original. We back-
-        // date the host file to guarantee the two keys differ.
-        let home = tempfile::tempdir().unwrap();
-        let host = home.path().join(".claude").join("projects");
-        let staging = home.path().join("staging").join("projects");
-        let repo = tempfile::tempdir().unwrap();
-        let run_id = "memo-root";
-
-        // Host root: $5 (back-dated). Staging root: $10 (fresh). Same run_id.
-        let host_file = seed_transcript(
-            &host,
-            repo.path(),
-            run_id,
-            &assistant("m1", "r1", "claude-opus-4-8", 1_000_000, 0),
-        );
-        filetime::set_file_mtime(
-            &host_file,
-            filetime::FileTime::from_unix_time(1_600_000_000, 0),
-        )
-        .unwrap();
-        seed_transcript(
-            &staging,
-            repo.path(),
-            run_id,
-            &assistant("m2", "r2", "claude-opus-4-8", 2_000_000, 0),
-        );
-
-        let host_cost = compute_run_cost_cached(&host, repo.path(), run_id, &builtin()).unwrap();
-        let staging_cost =
-            compute_run_cost_cached(&staging, repo.path(), run_id, &builtin()).unwrap();
-        assert!((host_cost.usd - 5.0).abs() < 1e-9, "host root → $5");
-        assert!(
-            (staging_cost.usd - 10.0).abs() < 1e-9,
-            "staging root → $10 (its own key/value, not the host's memo)"
-        );
     }
 
     #[test]
@@ -1023,12 +1293,20 @@ mod tests {
         // and names the harness.
         let home = tempfile::tempdir().unwrap();
         let projects = home.path().join(".claude").join("projects");
+        let copilot = home.path().join(".copilot").join("session-state");
         std::fs::create_dir_all(&projects).unwrap();
         let repo = tempfile::tempdir().unwrap();
         let events = vec![node_started("n", Some("opencode"))];
 
-        let cost = run_cost_or_absence(&events, &projects, repo.path(), "run-x", &builtin())
-            .expect("an uncosted harness yields Some(—), not a bare None");
+        let cost = run_cost_or_absence(
+            &events,
+            &projects,
+            &copilot,
+            repo.path(),
+            "run-x",
+            &builtin(),
+        )
+        .expect("an uncosted harness yields Some(—), not a bare None");
         assert_eq!(cost.usd, 0.0);
         assert!(!cost.partial, "not a lower bound — it is unavailable");
         assert!(cost.unpriced_models.is_empty());
@@ -1043,6 +1321,7 @@ mod tests {
         // before — no `uncosted_harnesses`, real dollars.
         let home = tempfile::tempdir().unwrap();
         let projects = home.path().join(".claude").join("projects");
+        let copilot = home.path().join(".copilot").join("session-state");
         let repo = tempfile::tempdir().unwrap();
         let run_id = "claude-run";
         seed_transcript(
@@ -1053,8 +1332,15 @@ mod tests {
         );
         let events = vec![node_started("n", Some("claude")), node_started("s", None)];
 
-        let honest =
-            run_cost_or_absence(&events, &projects, repo.path(), run_id, &builtin()).unwrap();
+        let honest = run_cost_or_absence(
+            &events,
+            &projects,
+            &copilot,
+            repo.path(),
+            run_id,
+            &builtin(),
+        )
+        .unwrap();
         let plain = compute_run_cost(&projects, repo.path(), run_id, &builtin()).unwrap();
         assert_eq!(
             honest, plain,
@@ -1062,5 +1348,501 @@ mod tests {
         );
         assert!(honest.uncosted_harnesses.is_empty());
         assert!((honest.usd - 5.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn copilot_adapter_keeps_each_restart_as_a_separate_reported_execution() {
+        let home = tempfile::tempdir().unwrap();
+        let claude = home.path().join(".claude").join("projects");
+        let copilot = home.path().join(".copilot").join("session-state");
+        let repo = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(&claude).unwrap();
+
+        for (sid, nano_aiu) in [
+            ("sid-first", 100_000_000_000_u64),
+            ("sid-restart", 200_000_000_000_u64),
+        ] {
+            let dir = copilot.join(sid);
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(
+                dir.join("events.jsonl"),
+                format!(
+                    "{{\"type\":\"session.usage_checkpoint\",\"data\":{{\"totalNanoAiu\":{nano_aiu}}}}}\n"
+                ),
+            )
+            .unwrap();
+        }
+
+        let started = |sid: &str| Event {
+            id: None,
+            run_id: "r".into(),
+            ts: crate::event_log::now_iso(),
+            kind: EventKind::NodeStarted,
+            node_id: Some("worker".into()),
+            iter: Some(1),
+            payload: Some(serde_json::json!({
+                "node_type": "doc-only",
+                "harness": "copilot",
+                "session_id": sid
+            })),
+        };
+        let events = vec![started("sid-first"), started("sid-restart")];
+
+        let breakdown =
+            compute_run_cost_breakdown(&events, &claude, &copilot, repo.path(), "r", &builtin());
+        let node: Vec<&CostContribution> = breakdown
+            .contributions
+            .iter()
+            .filter(|c| c.scope == CostScope::Node)
+            .collect();
+
+        assert_eq!(node.len(), 2, "a restart is another execution");
+        assert!(node.iter().all(|c| c.harness == "copilot"));
+        assert!(node.iter().all(|c| c.form == Some(CostForm::Reported)));
+        let usd: Vec<f64> = node.iter().map(|c| c.usd.unwrap()).collect();
+        assert!((usd[0] - 1.0).abs() < 1e-9);
+        assert!((usd[1] - 2.0).abs() < 1e-9);
+        assert!((breakdown.cost.unwrap().usd - 3.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn pane_resurrection_does_not_bill_the_same_frozen_session_twice() {
+        let home = tempfile::tempdir().unwrap();
+        let claude = home.path().join(".claude").join("projects");
+        let copilot = home.path().join(".copilot").join("session-state");
+        let repo = tempfile::tempdir().unwrap();
+        let run_id = "resurrected-pane";
+
+        let node_dir = crate::worktree_ops::sub_worktree_path(repo.path(), run_id, "claude", 1);
+        let project = claude.join(cc_project_dirname(&node_dir));
+        std::fs::create_dir_all(&project).unwrap();
+        std::fs::write(
+            project.join("claude-session.jsonl"),
+            format!(
+                "{}\n",
+                assistant("c", "req-c", "claude-opus-4-8", 1_000_000, 0)
+            ),
+        )
+        .unwrap();
+        let journal = copilot.join("copilot-session").join("events.jsonl");
+        std::fs::create_dir_all(journal.parent().unwrap()).unwrap();
+        std::fs::write(
+            journal,
+            "{\"type\":\"session.shutdown\",\"data\":{\"totalNanoAiu\":100000000000}}\n",
+        )
+        .unwrap();
+
+        let started = |node: &str, harness: &str, session_id: &str| Event {
+            id: None,
+            run_id: run_id.into(),
+            ts: crate::event_log::now_iso(),
+            kind: EventKind::NodeStarted,
+            node_id: Some(node.into()),
+            iter: Some(1),
+            payload: Some(serde_json::json!({
+                "node_type":"code-mutating",
+                "harness":harness,
+                "session_id":session_id
+            })),
+        };
+        let claude_start = started("claude", "claude", "claude-session");
+        let copilot_start = started("copilot", "copilot", "copilot-session");
+        let events = vec![
+            claude_start.clone(),
+            claude_start,
+            copilot_start.clone(),
+            copilot_start,
+        ];
+
+        let breakdown =
+            compute_run_cost_breakdown(&events, &claude, &copilot, repo.path(), run_id, &builtin());
+        let nodes: Vec<_> = breakdown
+            .contributions
+            .iter()
+            .filter(|contribution| contribution.scope == CostScope::Node)
+            .collect();
+        assert_eq!(nodes.len(), 2);
+        assert_eq!(nodes.iter().map(|node| node.executions).sum::<i64>(), 2);
+        assert!((breakdown.cost.unwrap().usd - 6.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn legacy_starts_without_session_identity_remain_distinct() {
+        let home = tempfile::tempdir().unwrap();
+        let claude = home.path().join(".claude").join("projects");
+        let copilot = home.path().join(".copilot").join("session-state");
+        let repo = tempfile::tempdir().unwrap();
+        let start = Event {
+            id: None,
+            run_id: "legacy-restarts".into(),
+            ts: crate::event_log::now_iso(),
+            kind: EventKind::NodeStarted,
+            node_id: Some("worker".into()),
+            iter: Some(1),
+            payload: Some(serde_json::json!({ "node_type":"doc-only" })),
+        };
+
+        let breakdown = compute_run_cost_breakdown(
+            &[start.clone(), start],
+            &claude,
+            &copilot,
+            repo.path(),
+            "legacy-restarts",
+            &builtin(),
+        );
+        assert_eq!(
+            breakdown
+                .contributions
+                .iter()
+                .filter(|contribution| contribution.scope == CostScope::Node)
+                .count(),
+            2
+        );
+    }
+
+    #[test]
+    fn claude_adapter_attaches_subagent_cost_to_its_parent_execution() {
+        let home = tempfile::tempdir().unwrap();
+        let claude = home.path().join(".claude").join("projects");
+        let copilot = home.path().join(".copilot").join("session-state");
+        let repo = tempfile::tempdir().unwrap();
+        let run_id = "r";
+        let working_dir = repo
+            .path()
+            .join(".pdo/runs")
+            .join(run_id)
+            .join("nodes/worker/iter-1");
+        let project = claude.join(cc_project_dirname(&working_dir));
+        std::fs::create_dir_all(project.join("sid/subagents")).unwrap();
+        std::fs::write(
+            project.join("sid.jsonl"),
+            format!(
+                "{}\n",
+                assistant("main", "req-main", "claude-opus-4-8", 1_000_000, 0)
+            ),
+        )
+        .unwrap();
+        std::fs::write(
+            project.join("sid/subagents/side.jsonl"),
+            format!(
+                "{}\n",
+                assistant("sub", "req-sub", "claude-opus-4-8", 1_000_000, 0)
+            ),
+        )
+        .unwrap();
+        let events = vec![Event {
+            id: None,
+            run_id: run_id.into(),
+            ts: crate::event_log::now_iso(),
+            kind: EventKind::NodeStarted,
+            node_id: Some("worker".into()),
+            iter: Some(1),
+            payload: Some(serde_json::json!({
+                "node_type": "code-mutating",
+                "harness": "claude",
+                "session_id": "sid"
+            })),
+        }];
+
+        let breakdown =
+            compute_run_cost_breakdown(&events, &claude, &copilot, repo.path(), run_id, &builtin());
+
+        assert_eq!(breakdown.contributions.len(), 1);
+        let contribution = &breakdown.contributions[0];
+        assert_eq!(contribution.scope, CostScope::Node);
+        assert_eq!(contribution.node_id.as_deref(), Some("worker"));
+        assert_eq!(contribution.executions, 1, "a subagent is not an execution");
+        assert_eq!(contribution.readable_executions, 1);
+        assert_eq!(contribution.form, Some(CostForm::Derived));
+        assert!((contribution.usd.unwrap() - 10.0).abs() < 1e-9);
+        assert!(
+            (breakdown.cost.unwrap().usd - contribution.usd.unwrap()).abs() < 1e-9,
+            "the Run total uses the same contribution source"
+        );
+    }
+
+    #[test]
+    fn claude_cost_outside_node_sessions_is_infrastructure() {
+        let home = tempfile::tempdir().unwrap();
+        let claude = home.path().join(".claude").join("projects");
+        let copilot = home.path().join(".copilot").join("session-state");
+        let repo = tempfile::tempdir().unwrap();
+        let run_id = "infra-run";
+        let worktree = repo.path().join(".pdo/runs").join(run_id).join("worktree");
+        let project = claude.join(cc_project_dirname(&worktree));
+        std::fs::create_dir_all(&project).unwrap();
+        std::fs::write(
+            project.join("manager.jsonl"),
+            format!(
+                "{}\n",
+                assistant("manager", "req-manager", "claude-opus-4-8", 400_000, 0)
+            ),
+        )
+        .unwrap();
+        let events = vec![
+            Event {
+                id: None,
+                run_id: run_id.into(),
+                ts: crate::event_log::now_iso(),
+                kind: EventKind::RunStarted,
+                node_id: None,
+                iter: None,
+                payload: Some(serde_json::json!({ "harness": "claude" })),
+            },
+            Event {
+                id: None,
+                run_id: run_id.into(),
+                ts: crate::event_log::now_iso(),
+                kind: EventKind::MergeResolverStarted,
+                node_id: None,
+                iter: None,
+                payload: None,
+            },
+        ];
+
+        let breakdown =
+            compute_run_cost_breakdown(&events, &claude, &copilot, repo.path(), run_id, &builtin());
+
+        assert_eq!(breakdown.contributions.len(), 1);
+        let infra = &breakdown.contributions[0];
+        assert_eq!(infra.scope, CostScope::Infrastructure);
+        assert_eq!(infra.harness, "claude");
+        assert_eq!(infra.executions, 2);
+        assert_eq!(infra.readable_executions, 2);
+        assert!((infra.usd.unwrap() - 2.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn non_claude_infrastructure_keeps_run_harness_and_unknown_session_cost() {
+        let home = tempfile::tempdir().unwrap();
+        let claude = home.path().join(".claude").join("projects");
+        let copilot = home.path().join(".copilot").join("session-state");
+        let repo = tempfile::tempdir().unwrap();
+        let event = |kind| Event {
+            id: None,
+            run_id: "copilot-infra".into(),
+            ts: crate::event_log::now_iso(),
+            kind,
+            node_id: None,
+            iter: None,
+            payload: Some(serde_json::json!({ "harness": "copilot" })),
+        };
+        let events = vec![
+            event(EventKind::RunStarted),
+            event(EventKind::MergeResolverStarted),
+        ];
+
+        let breakdown = compute_run_cost_breakdown(
+            &events,
+            &claude,
+            &copilot,
+            repo.path(),
+            "copilot-infra",
+            &builtin(),
+        );
+        let infrastructure = breakdown
+            .contributions
+            .iter()
+            .find(|contribution| contribution.scope == CostScope::Infrastructure)
+            .unwrap();
+        assert_eq!(infrastructure.harness, "copilot");
+        assert_eq!(infrastructure.executions, 2);
+        assert_eq!(infrastructure.readable_executions, 0);
+        assert_eq!(infrastructure.usd, None);
+        assert_eq!(
+            infrastructure.unavailable_reasons,
+            vec!["no attributable infrastructure cost"]
+        );
+    }
+
+    #[test]
+    fn legacy_agent_is_claude_script_is_excluded_and_ambiguous_cost_is_unassigned() {
+        let home = tempfile::tempdir().unwrap();
+        let claude = home.path().join(".claude").join("projects");
+        let copilot = home.path().join(".copilot").join("session-state");
+        let repo = tempfile::tempdir().unwrap();
+        let run_id = "legacy-run";
+        let worktree = repo.path().join(".pdo/runs").join(run_id).join("worktree");
+        let project = claude.join(cc_project_dirname(&worktree));
+        std::fs::create_dir_all(&project).unwrap();
+        std::fs::write(
+            project.join("unknown-session.jsonl"),
+            format!(
+                "{}\n",
+                assistant("legacy", "req-legacy", "claude-opus-4-8", 1_000_000, 0)
+            ),
+        )
+        .unwrap();
+        let event = |node: Option<&str>, node_type: Option<&str>| Event {
+            id: None,
+            run_id: run_id.into(),
+            ts: crate::event_log::now_iso(),
+            kind: if node.is_some() {
+                EventKind::NodeStarted
+            } else {
+                EventKind::RunStarted
+            },
+            node_id: node.map(str::to_string),
+            iter: node.map(|_| 1),
+            payload: node_type.map(|kind| serde_json::json!({ "node_type": kind })),
+        };
+        let mut started = event(None, None);
+        started.payload = Some(serde_json::json!({
+            "node_defs": [
+                {"id":"legacy-agent","node_type":"doc-only"},
+                {"id":"deterministic","node_type":"script"}
+            ]
+        }));
+        let events = vec![
+            started,
+            event(Some("legacy-agent"), Some("doc-only")),
+            event(Some("deterministic"), None),
+        ];
+
+        let breakdown =
+            compute_run_cost_breakdown(&events, &claude, &copilot, repo.path(), run_id, &builtin());
+
+        let node: Vec<_> = breakdown
+            .contributions
+            .iter()
+            .filter(|c| c.scope == CostScope::Node)
+            .collect();
+        assert_eq!(node.len(), 1, "the script start is not agentic");
+        assert_eq!(node[0].node_id.as_deref(), Some("legacy-agent"));
+        assert_eq!(node[0].harness, "claude");
+        assert!(node[0].usd.is_none());
+
+        let infra = breakdown
+            .contributions
+            .iter()
+            .find(|c| c.scope == CostScope::Infrastructure)
+            .unwrap();
+        assert!(
+            infra.usd.is_none(),
+            "do not guess that the residual is infra"
+        );
+        let unassigned = breakdown
+            .contributions
+            .iter()
+            .find(|c| c.scope == CostScope::Unassigned)
+            .unwrap();
+        assert_eq!(
+            unassigned.executions, 0,
+            "Unassigned invents no denominator"
+        );
+        assert!((unassigned.usd.unwrap() - 5.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn run_cost_projects_the_same_mixed_harness_contributions_as_stats() {
+        let home = tempfile::tempdir().unwrap();
+        let claude = home.path().join(".claude").join("projects");
+        let copilot = home.path().join(".copilot").join("session-state");
+        let repo = tempfile::tempdir().unwrap();
+        let run_id = "mixed";
+
+        let node_dir = repo
+            .path()
+            .join(".pdo/runs")
+            .join(run_id)
+            .join("nodes/claude-node/iter-1");
+        let claude_project = claude.join(cc_project_dirname(&node_dir));
+        std::fs::create_dir_all(&claude_project).unwrap();
+        std::fs::write(
+            claude_project.join("sid-claude.jsonl"),
+            format!(
+                "{}\n",
+                assistant("c", "req-c", "claude-opus-4-8", 1_000_000, 0)
+            ),
+        )
+        .unwrap();
+        let copilot_dir = copilot.join("sid-copilot");
+        std::fs::create_dir_all(&copilot_dir).unwrap();
+        std::fs::write(
+            copilot_dir.join("events.jsonl"),
+            "{\"type\":\"session.usage_checkpoint\",\"data\":{\"totalNanoAiu\":200000000000}}\n",
+        )
+        .unwrap();
+        let started = |node: &str, harness: &str, sid: &str, kind: &str| Event {
+            id: None,
+            run_id: run_id.into(),
+            ts: crate::event_log::now_iso(),
+            kind: EventKind::NodeStarted,
+            node_id: Some(node.into()),
+            iter: Some(1),
+            payload: Some(serde_json::json!({
+                "node_type": kind,
+                "harness": harness,
+                "session_id": sid
+            })),
+        };
+        let events = vec![
+            started("claude-node", "claude", "sid-claude", "code-mutating"),
+            started("copilot-node", "copilot", "sid-copilot", "doc-only"),
+        ];
+
+        let breakdown =
+            compute_run_cost_breakdown(&events, &claude, &copilot, repo.path(), run_id, &builtin());
+        let run_cost =
+            run_cost_or_absence(&events, &claude, &copilot, repo.path(), run_id, &builtin())
+                .unwrap();
+
+        assert_eq!(run_cost, breakdown.cost.unwrap());
+        assert_eq!(run_cost.by_harness.len(), 2);
+        assert!((run_cost.usd - 7.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn contribution_memo_refreshes_when_a_reported_cost_journal_changes() {
+        let home = tempfile::tempdir().unwrap();
+        let claude = home.path().join(".claude").join("projects");
+        let copilot = home.path().join(".copilot").join("session-state");
+        let repo = tempfile::tempdir().unwrap();
+        let journal = copilot.join("memo-session").join("events.jsonl");
+        std::fs::create_dir_all(journal.parent().unwrap()).unwrap();
+        std::fs::write(
+            &journal,
+            "{\"type\":\"session.shutdown\",\"data\":{\"totalNanoAiu\":100000000000}}\n",
+        )
+        .unwrap();
+        let events = vec![Event {
+            id: None,
+            run_id: "memo-run".into(),
+            ts: crate::event_log::now_iso(),
+            kind: EventKind::NodeStarted,
+            node_id: Some("worker".into()),
+            iter: Some(1),
+            payload: Some(serde_json::json!({
+                "node_type":"doc-only",
+                "harness":"copilot",
+                "session_id":"memo-session"
+            })),
+        }];
+
+        let first = compute_run_cost_breakdown_cached(
+            &events,
+            &claude,
+            &copilot,
+            repo.path(),
+            "memo-run",
+            &builtin(),
+        );
+        assert!((first.cost.unwrap().usd - 1.0).abs() < 1e-9);
+
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        std::fs::write(
+            &journal,
+            "{\"type\":\"session.shutdown\",\"data\":{\"totalNanoAiu\":200000000000}}\n",
+        )
+        .unwrap();
+        let refreshed = compute_run_cost_breakdown_cached(
+            &events,
+            &claude,
+            &copilot,
+            repo.path(),
+            "memo-run",
+            &builtin(),
+        );
+        assert!((refreshed.cost.unwrap().usd - 2.0).abs() < 1e-9);
     }
 }

--- a/crates/pdo-daemon/src/sandbox_run.rs
+++ b/crates/pdo-daemon/src/sandbox_run.rs
@@ -333,6 +333,10 @@ pub(crate) fn transcripts_root(
     }
 }
 
+pub(crate) fn copilot_store_root(home_root: &Path) -> PathBuf {
+    home_root.join(".copilot").join("session-state")
+}
+
 /// Merge a Run's staged transcripts back to `~/.claude/projects/` at its terminal
 /// transition (#408), so cost + stale-detection see them at the standard encoded
 /// dirname once the staging is eventually purged. No-op for `off`.

--- a/crates/pdo-daemon/src/stats.rs
+++ b/crates/pdo-daemon/src/stats.rs
@@ -1,26 +1,22 @@
 //! Instance-stats cockpit (#377, ADR-0029): cross-run, period-filterable
 //! aggregates for the Stats modal. Two endpoints split by cost class:
 //!
-//! - [`stats_overview`] — **Class A**, cheap indexed SQL. Runs/errors/sessions
-//!   per period (`GROUP BY strftime` over `events`, backed by
-//!   `idx_events_kind_ts`), fires per pipeline (`LEFT JOIN triggers`, backed by
-//!   `idx_trigger_fires_ts`), and the "triggers that created a run" KPI.
-//! - [`stats_cost`] — **Class B**, heavy. Enumerates the `run_started` events in
-//!   the period, resolves each run's estimated cost through the memoized
-//!   [`crate::run_cost::compute_run_cost_cached`], and folds the per-run scalars
-//!   app-side into by-period / by-pipeline / by-project buckets (cost has no
-//!   pipeline/project dimension in SQL, and "by project" needs the
-//!   `effective_repo_root` runtime fallback). It also carries the **resolved
-//!   price table** (#528): one row per family key — the winning tier and the
-//!   `$/MTok` in force — read from the SAME table the fold prices with, so the
-//!   Cost tab can never show a set the pricer would price otherwise (#373).
+//! - [`stats_overview`] keeps the indexed Runs and Triggers queries, then selects
+//!   the session cohort by `run_started.ts`. Every agentic `node_started` in a
+//!   selected Run counts, including later loop laps and restarts. The response
+//!   splits those executions by dynamic harness and Pipeline → Node identity.
+//! - [`stats_cost`] is the lazy heavy read. It selects the same Run cohort,
+//!   resolves memoized harness-specific contributions, and folds them into
+//!   period, Pipeline → Node, and Project → Pipeline → Node hierarchies. The
+//!   response includes readable denominators, unknown-cost reasons, and the
+//!   resolved price table used for derived Claude costs.
 //!
 //! Everything is derived on read — no snapshot table, no metric-freezing event
 //! (preserves ADR-0022). Aggregated cost is a **sum of lower bounds**: partial
 //! runs (an unpriced model) and null-cost runs (no transcript) are counted
 //! separately so a bucket is never silently undercounted (ADR-0001 honesty).
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -30,7 +26,6 @@ use axum::response::{IntoResponse, Response};
 use axum::Json;
 use serde::{Deserialize, Serialize};
 
-use crate::event_log::CostStat;
 use crate::AppState;
 
 /// Query string shared by both endpoints: an ISO-8601 `[from, to)` window and a
@@ -95,6 +90,138 @@ pub(crate) struct StatsOverview {
     pub sessions: Vec<BucketCount>,
     pub fires_by_pipeline: Vec<PipelineFireCount>,
     pub triggers_created_runs: TriggersCreatedRuns,
+    pub session_harnesses: Vec<String>,
+    pub sessions_by_period: Vec<StatsSessionPeriod>,
+    pub sessions_by_pipeline: Vec<StatsSessionEntity>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct HarnessCount {
+    pub total: u64,
+    pub by_harness: BTreeMap<String, u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct StatsSessionHarness {
+    pub harness: String,
+    pub executions: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct StatsSessionPeriod {
+    pub bucket: String,
+    pub harnesses: Vec<StatsSessionHarness>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct StatsSessionEntity {
+    pub id: String,
+    pub name: String,
+    pub executions: u64,
+    pub harnesses: Vec<StatsSessionHarness>,
+    pub by_period: Vec<StatsSessionPeriod>,
+    pub nodes: Vec<StatsSessionEntity>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct SessionNodeBuilder {
+    name: String,
+    count: HarnessCount,
+    periods: BTreeMap<String, HarnessCount>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct SessionPipelineBuilder {
+    name: String,
+    count: HarnessCount,
+    periods: BTreeMap<String, HarnessCount>,
+    nodes: BTreeMap<String, SessionNodeBuilder>,
+}
+
+fn increment_harness(count: &mut HarnessCount, harness: &str) {
+    count.total += 1;
+    *count.by_harness.entry(harness.to_string()).or_default() += 1;
+}
+
+fn harness_rows(count: BTreeMap<String, u64>) -> Vec<StatsSessionHarness> {
+    count
+        .into_iter()
+        .map(|(harness, executions)| StatsSessionHarness {
+            harness,
+            executions,
+        })
+        .collect()
+}
+
+fn period_rows(periods: BTreeMap<String, HarnessCount>) -> Vec<StatsSessionPeriod> {
+    periods
+        .into_iter()
+        .map(|(bucket, count)| StatsSessionPeriod {
+            bucket,
+            harnesses: harness_rows(count.by_harness),
+        })
+        .collect()
+}
+
+fn finish_node(id: String, builder: SessionNodeBuilder) -> StatsSessionEntity {
+    StatsSessionEntity {
+        id,
+        name: builder.name,
+        executions: builder.count.total,
+        harnesses: harness_rows(builder.count.by_harness),
+        by_period: period_rows(builder.periods),
+        nodes: Vec::new(),
+    }
+}
+
+fn finish_pipeline(id: String, builder: SessionPipelineBuilder) -> StatsSessionEntity {
+    let mut nodes: Vec<StatsSessionEntity> = builder
+        .nodes
+        .into_iter()
+        .map(|(id, node)| finish_node(id, node))
+        .collect();
+    nodes.sort_by(|a, b| {
+        b.executions
+            .cmp(&a.executions)
+            .then_with(|| a.id.cmp(&b.id))
+    });
+    StatsSessionEntity {
+        id,
+        name: builder.name,
+        executions: builder.count.total,
+        harnesses: harness_rows(builder.count.by_harness),
+        by_period: period_rows(builder.periods),
+        nodes,
+    }
+}
+
+fn project_identity(
+    payload: &serde_json::Value,
+    daemon_root: &Path,
+    projects: &[crate::project_store::Project],
+) -> (String, String) {
+    let root = cost_project_root(payload, daemon_root);
+    let root_text = root.to_string_lossy().into_owned();
+    if let Some(project) = projects
+        .iter()
+        .find(|project| project.members.iter().any(|member| member == &root_text))
+    {
+        return (project.id.clone(), project.name.clone());
+    }
+    let name = root
+        .file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty())
+        .unwrap_or(&root_text)
+        .to_string();
+    (root_text, name)
+}
+
+struct SessionStats {
+    sessions: Vec<BucketCount>,
+    periods: Vec<StatsSessionPeriod>,
+    harnesses: Vec<String>,
+    pipelines: Vec<StatsSessionEntity>,
 }
 
 /// Count events of one `kind` per period bucket. Backed by `idx_events_kind_ts`.
@@ -169,6 +296,163 @@ async fn triggers_created_runs(
     })
 }
 
+async fn session_stats(
+    state: &AppState,
+    q: &StatsQuery,
+    fmt: &str,
+) -> Result<SessionStats, sqlx::Error> {
+    type SessionRow = (
+        String,
+        String,
+        Option<String>,
+        Option<i64>,
+        Option<String>,
+        Option<i64>,
+        Option<String>,
+    );
+    let rows = sqlx::query_as::<_, SessionRow>(
+        "SELECT strftime(?, cohort.ts), cohort.run_id, cohort.payload, event.id, \
+                event.node_id, event.iter, event.payload \
+         FROM events cohort \
+         JOIN events event ON event.run_id = cohort.run_id AND event.kind = 'node_started' \
+         WHERE cohort.kind = 'run_started' AND cohort.ts >= ? AND cohort.ts < ? \
+         ORDER BY cohort.ts, event.id",
+    )
+    .bind(fmt)
+    .bind(&q.from)
+    .bind(&q.to)
+    .fetch_all(&state.db)
+    .await?;
+
+    let mut periods = BTreeMap::<String, HarnessCount>::new();
+    let mut session_periods = BTreeMap::<String, i64>::new();
+    let mut harnesses = BTreeSet::<String>::new();
+    let mut pipelines = BTreeMap::<String, SessionPipelineBuilder>::new();
+    let mut seen_executions = HashSet::new();
+
+    for (order, (bucket, run_id, run_payload, event_id, node_id, iter, event_payload)) in
+        rows.into_iter().enumerate()
+    {
+        let run_payload: serde_json::Value = run_payload
+            .as_deref()
+            .and_then(|payload| serde_json::from_str(payload).ok())
+            .unwrap_or(serde_json::Value::Null);
+        let event_payload: serde_json::Value = event_payload
+            .as_deref()
+            .and_then(|payload| serde_json::from_str(payload).ok())
+            .unwrap_or(serde_json::Value::Null);
+        let pipeline_id = run_payload
+            .get("pipeline_id")
+            .and_then(|value| value.as_str())
+            .or_else(|| {
+                run_payload
+                    .get("pipeline_name")
+                    .and_then(|value| value.as_str())
+            })
+            .unwrap_or("(unknown)")
+            .to_string();
+        let pipeline_name = run_payload
+            .get("pipeline_name")
+            .and_then(|value| value.as_str())
+            .unwrap_or(&pipeline_id)
+            .to_string();
+        let mut node_defs = BTreeMap::<String, (String, String)>::new();
+        if let Some(defs) = run_payload
+            .get("node_defs")
+            .and_then(|value| value.as_array())
+        {
+            for def in defs {
+                let Some(id) = def.get("id").and_then(|value| value.as_str()) else {
+                    continue;
+                };
+                let name = def
+                    .get("name")
+                    .and_then(|value| value.as_str())
+                    .unwrap_or(id)
+                    .to_string();
+                let node_type = def
+                    .get("node_type")
+                    .and_then(|value| value.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                node_defs.insert(id.to_string(), (name, node_type));
+            }
+        }
+
+        let Some(node_id) = node_id else {
+            continue;
+        };
+        let node_type = event_payload
+            .get("node_type")
+            .and_then(|value| value.as_str())
+            .or_else(|| node_defs.get(&node_id).map(|(_, kind)| kind.as_str()))
+            .unwrap_or("");
+        if node_type == "script" {
+            continue;
+        }
+        let harness = event_payload
+            .get("harness")
+            .and_then(|value| value.as_str())
+            .filter(|harness| !harness.is_empty())
+            .unwrap_or("claude")
+            .to_string();
+        let identity = crate::run_cost::frozen_execution_identity(
+            &harness,
+            event_payload
+                .get("session_id")
+                .and_then(|value| value.as_str()),
+            Some(&node_id),
+            iter,
+            event_id,
+            order,
+        );
+        if !seen_executions.insert((run_id, identity)) {
+            continue;
+        }
+
+        harnesses.insert(harness.clone());
+        increment_harness(periods.entry(bucket.clone()).or_default(), &harness);
+
+        let pipeline = pipelines.entry(pipeline_id.clone()).or_default();
+        pipeline.name = pipeline_name.clone();
+        increment_harness(&mut pipeline.count, &harness);
+        increment_harness(
+            pipeline.periods.entry(bucket.clone()).or_default(),
+            &harness,
+        );
+
+        *session_periods.entry(bucket.clone()).or_default() += 1;
+        let node_name = node_defs
+            .get(&node_id)
+            .map(|(name, _)| name.clone())
+            .unwrap_or_else(|| node_id.clone());
+        let node = pipeline.nodes.entry(node_id.clone()).or_default();
+        node.name = node_name;
+        increment_harness(&mut node.count, &harness);
+        increment_harness(node.periods.entry(bucket).or_default(), &harness);
+    }
+
+    let mut pipeline_rows: Vec<_> = pipelines
+        .into_iter()
+        .map(|(id, pipeline)| finish_pipeline(id, pipeline))
+        .collect();
+    pipeline_rows.sort_by(|a, b| {
+        b.executions
+            .cmp(&a.executions)
+            .then_with(|| a.id.cmp(&b.id))
+    });
+
+    Ok(SessionStats {
+        sessions: session_periods
+            .into_iter()
+            .map(|(bucket, count)| BucketCount { bucket, count })
+            .collect(),
+        periods: period_rows(periods),
+        harnesses: harnesses.into_iter().collect(),
+        pipelines: pipeline_rows,
+    })
+}
+
 /// Assemble the full overview payload (testable without an `AppState`).
 async fn compute_overview(
     db: &sqlx::SqlitePool,
@@ -199,6 +483,9 @@ async fn compute_overview(
         sessions,
         fires_by_pipeline: fires,
         triggers_created_runs: created,
+        session_harnesses: Vec::new(),
+        sessions_by_period: Vec::new(),
+        sessions_by_pipeline: Vec::new(),
     })
 }
 
@@ -214,9 +501,18 @@ pub(crate) async fn stats_overview(
         )
             .into_response();
     };
-    match compute_overview(&state.db, fmt, &q.from, &q.to).await {
-        Ok(overview) => Json(overview).into_response(),
-        Err(e) => (
+    match (
+        compute_overview(&state.db, fmt, &q.from, &q.to).await,
+        session_stats(&state, &q, fmt).await,
+    ) {
+        (Ok(mut overview), Ok(sessions)) => {
+            overview.sessions = sessions.sessions;
+            overview.session_harnesses = sessions.harnesses;
+            overview.sessions_by_period = sessions.periods;
+            overview.sessions_by_pipeline = sessions.pipelines;
+            Json(overview).into_response()
+        }
+        (Err(e), _) | (_, Err(e)) => (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(serde_json::json!({ "error": format!("stats overview failed: {e}") })),
         )
@@ -225,39 +521,6 @@ pub(crate) async fn stats_overview(
 }
 
 // --- Cost (Class B) ----------------------------------------------------------
-
-#[derive(Debug, Clone, PartialEq, Serialize)]
-pub(crate) struct CostPeriodBucket {
-    pub bucket: String,
-    /// Sum of priced per-run costs (a lower bound — see `partial`/`null`).
-    pub usd: f64,
-    /// Runs in this bucket whose cost is a lower bound (an unpriced model).
-    pub partial: i64,
-    /// Runs in this bucket with no transcript (excluded from `usd`, surfaced so
-    /// the bucket is never silently undercounted). Serialized as `"null"`.
-    #[serde(rename = "null")]
-    pub null_count: i64,
-    /// Total runs folded into this bucket (priced + partial + null).
-    pub runs: i64,
-    /// The union of every unpriced model family key seen across the bucket's
-    /// partial runs — sorted, de-duplicated (#425 AC#4). Empty ⟺ `partial == 0`.
-    /// Lets the chart name *which* models are dragging the bucket to a lower
-    /// bound, not just how many runs were affected.
-    pub unpriced_models: Vec<String>,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize)]
-pub(crate) struct CostKeyBucket {
-    pub key: String,
-    pub usd: f64,
-    pub partial: i64,
-    #[serde(rename = "null")]
-    pub null_count: i64,
-    pub runs: i64,
-    /// Union of unpriced model family keys across this bucket's partial runs
-    /// (#425 AC#4). See [`CostPeriodBucket::unpriced_models`].
-    pub unpriced_models: Vec<String>,
-}
 
 /// One resolved price row (#528): a family key, the tier that decides it, and the
 /// `$/MTok` actually in force. `tier` serializes as `"manual" | "fetched" |
@@ -273,113 +536,257 @@ pub(crate) struct ResolvedPriceRow {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
+pub(crate) struct StatsHarnessCost {
+    pub harness: String,
+    pub usd: Option<f64>,
+    pub estimated: bool,
+    pub partial: bool,
+    pub executions: i64,
+    pub readable: i64,
+    pub unknown: i64,
+    pub average_usd: Option<f64>,
+    pub unpriced_models: Vec<String>,
+    pub missing_reasons: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub(crate) struct StatsCostAggregate {
+    pub usd: Option<f64>,
+    pub average_usd: Option<f64>,
+    pub estimated: bool,
+    pub partial: bool,
+    pub executions: i64,
+    pub readable: i64,
+    pub unknown: i64,
+    pub unpriced_models: Vec<String>,
+    pub missing_reasons: Vec<String>,
+    pub harnesses: Vec<StatsHarnessCost>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub(crate) struct StatsCostPeriod {
+    pub bucket: String,
+    #[serde(flatten)]
+    pub aggregate: StatsCostAggregate,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub(crate) struct StatsCostEntity {
+    pub id: String,
+    pub name: String,
+    #[serde(flatten)]
+    pub aggregate: StatsCostAggregate,
+    pub by_period: Vec<StatsCostPeriod>,
+    pub nodes: Vec<StatsCostEntity>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub(crate) struct StatsProjectCostEntity {
+    #[serde(flatten)]
+    pub entity: StatsCostEntity,
+    pub pipelines: Vec<StatsCostEntity>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub(crate) struct StatsCost {
-    pub by_period: Vec<CostPeriodBucket>,
-    pub by_pipeline: Vec<CostKeyBucket>,
-    pub by_project: Vec<CostKeyBucket>,
-    /// The resolved price table (#528), one row per family key in BTreeMap
-    /// (alphabetical) order — the winning tier + resolved `$/MTok`. Independent of
-    /// the `[from, to)` window: it is a property of the price table, not the fold.
-    /// The pure [`fold_cost`] leaves this empty; the handler injects the live table
-    /// so the "Sync costs" button refreshes it on the same refetch it triggers.
+    pub harnesses: Vec<String>,
+    pub total: StatsCostAggregate,
+    pub by_period: Vec<StatsCostPeriod>,
+    pub by_pipeline: Vec<StatsCostEntity>,
+    pub by_project: Vec<StatsProjectCostEntity>,
     pub resolved: Vec<ResolvedPriceRow>,
 }
 
-/// One run's contribution to the cost fold: its period bucket, pipeline key,
-/// project key, and resolved cost (`None` = no transcript).
-struct CostRow {
-    bucket: String,
-    pipeline: String,
-    project: String,
-    cost: Option<CostStat>,
-}
-
-#[derive(Default, Clone)]
-struct CostAcc {
+#[derive(Debug, Clone, Default)]
+struct CostMetricAcc {
     usd: f64,
-    partial: i64,
-    null_count: i64,
-    runs: i64,
-    /// De-dated model keys no tier priced, unioned across the bucket's runs. A
-    /// `BTreeSet` so the emitted `Vec` is sorted + unique for free (#425 AC#4).
-    unpriced: std::collections::BTreeSet<String>,
+    readable_usd: f64,
+    has_usd: bool,
+    estimated: bool,
+    partial: bool,
+    executions: i64,
+    readable: i64,
+    unknown: i64,
+    unpriced_models: BTreeSet<String>,
+    missing_reasons: BTreeSet<String>,
 }
 
-impl CostAcc {
-    fn add(&mut self, cost: &Option<CostStat>) {
-        self.runs += 1;
-        match cost {
-            Some(c) => {
-                self.usd += c.usd;
-                if c.partial {
-                    self.partial += 1;
-                }
-                // Already de-dated by `run_cost::aggregate`; union names across
-                // the bucket so the chart can say which models, not just how many.
-                self.unpriced.extend(c.unpriced_models.iter().cloned());
+impl CostMetricAcc {
+    fn add_contribution(&mut self, contribution: &crate::run_cost::CostContribution) {
+        self.executions += contribution.executions;
+        self.readable += contribution.readable_executions;
+        self.unknown += contribution.executions - contribution.readable_executions;
+        if let Some(usd) = contribution.usd {
+            self.usd += usd;
+            self.has_usd = true;
+            if contribution.readable_executions > 0 {
+                self.readable_usd += usd;
             }
-            None => self.null_count += 1,
+        }
+        self.estimated |= contribution.form == Some(crate::event_log::CostForm::Derived);
+        self.partial |= contribution.partial;
+        self.unpriced_models
+            .extend(contribution.unpriced_models.iter().cloned());
+        self.missing_reasons
+            .extend(contribution.unavailable_reasons.iter().cloned());
+    }
+
+    fn add_run(&mut self, contributions: &[&crate::run_cost::CostContribution]) {
+        if contributions.is_empty() {
+            return;
+        }
+        self.executions += 1;
+        let mut all_readable = true;
+        let mut run_usd = 0.0;
+        for contribution in contributions {
+            if let Some(usd) = contribution.usd {
+                self.usd += usd;
+                run_usd += usd;
+                self.has_usd = true;
+            }
+            all_readable &= if contribution.executions > 0 {
+                contribution.readable_executions == contribution.executions
+            } else {
+                contribution.usd.is_some()
+            };
+            self.estimated |= contribution.form == Some(crate::event_log::CostForm::Derived);
+            self.partial |= contribution.partial;
+            self.unpriced_models
+                .extend(contribution.unpriced_models.iter().cloned());
+            self.missing_reasons
+                .extend(contribution.unavailable_reasons.iter().cloned());
+        }
+        if all_readable {
+            self.readable_usd += run_usd;
+        }
+        self.readable += i64::from(all_readable);
+        self.unknown += i64::from(!all_readable);
+    }
+
+    fn wire(&self) -> StatsCostAggregate {
+        StatsCostAggregate {
+            usd: self.has_usd.then_some(self.usd),
+            average_usd: (self.readable > 0).then_some(self.readable_usd / self.readable as f64),
+            estimated: self.estimated,
+            partial: self.partial,
+            executions: self.executions,
+            readable: self.readable,
+            unknown: self.unknown.max(0),
+            unpriced_models: self.unpriced_models.iter().cloned().collect(),
+            missing_reasons: self.missing_reasons.iter().cloned().collect(),
+            harnesses: Vec::new(),
+        }
+    }
+
+    fn wire_harness(&self, harness: String) -> StatsHarnessCost {
+        StatsHarnessCost {
+            harness,
+            usd: self.has_usd.then_some(self.usd),
+            estimated: self.estimated,
+            partial: self.partial,
+            executions: self.executions,
+            readable: self.readable,
+            unknown: self.unknown.max(0),
+            average_usd: (self.readable > 0).then_some(self.readable_usd / self.readable as f64),
+            unpriced_models: self.unpriced_models.iter().cloned().collect(),
+            missing_reasons: self.missing_reasons.iter().cloned().collect(),
         }
     }
 }
 
-/// Fold per-run cost rows into the three categorical breakdowns. Pure — the
-/// handler does the DB enumeration and cost resolution, this only accumulates,
-/// so it is unit-testable with synthetic rows.
-fn fold_cost(rows: &[CostRow]) -> StatsCost {
-    use std::collections::HashMap;
-    let mut by_period: HashMap<&str, CostAcc> = HashMap::new();
-    let mut by_pipeline: HashMap<&str, CostAcc> = HashMap::new();
-    let mut by_project: HashMap<&str, CostAcc> = HashMap::new();
-    for r in rows {
-        by_period.entry(&r.bucket).or_default().add(&r.cost);
-        by_pipeline.entry(&r.pipeline).or_default().add(&r.cost);
-        by_project.entry(&r.project).or_default().add(&r.cost);
+#[derive(Debug, Clone, Default)]
+struct CostAggregateAcc {
+    total: CostMetricAcc,
+    harnesses: BTreeMap<String, CostMetricAcc>,
+}
+
+impl CostAggregateAcc {
+    fn add_run(&mut self, contributions: &[crate::run_cost::CostContribution]) {
+        let all: Vec<_> = contributions.iter().collect();
+        self.total.add_run(&all);
+        let mut names = BTreeSet::new();
+        for contribution in contributions {
+            if contribution.executions > 0 || contribution.usd.is_some() {
+                names.insert(contribution.harness.clone());
+            }
+        }
+        for harness in names {
+            let matching: Vec<_> = contributions
+                .iter()
+                .filter(|contribution| contribution.harness == harness)
+                .collect();
+            self.harnesses
+                .entry(harness)
+                .or_default()
+                .add_run(&matching);
+        }
     }
 
-    // by_period sorts by label (chronological); the categorical axes sort by
-    // spend desc, then key, for a stable, meaningful order.
-    let mut period: Vec<CostPeriodBucket> = by_period
-        .into_iter()
-        .map(|(bucket, a)| CostPeriodBucket {
-            bucket: bucket.to_string(),
-            usd: a.usd,
-            partial: a.partial,
-            null_count: a.null_count,
-            runs: a.runs,
-            unpriced_models: a.unpriced.iter().cloned().collect(),
-        })
-        .collect();
-    period.sort_by(|a, b| a.bucket.cmp(&b.bucket));
+    fn add_contribution(&mut self, contribution: &crate::run_cost::CostContribution) {
+        self.total.add_contribution(contribution);
+        self.harnesses
+            .entry(contribution.harness.clone())
+            .or_default()
+            .add_contribution(contribution);
+    }
 
-    let to_key_buckets = |map: HashMap<&str, CostAcc>| {
-        let mut v: Vec<CostKeyBucket> = map
-            .into_iter()
-            .map(|(key, a)| CostKeyBucket {
-                key: key.to_string(),
-                usd: a.usd,
-                partial: a.partial,
-                null_count: a.null_count,
-                runs: a.runs,
-                unpriced_models: a.unpriced.iter().cloned().collect(),
-            })
+    fn wire(&self) -> StatsCostAggregate {
+        let mut aggregate = self.total.wire();
+        aggregate.harnesses = self
+            .harnesses
+            .iter()
+            .map(|(harness, metric)| metric.wire_harness(harness.clone()))
             .collect();
-        v.sort_by(|a, b| {
-            b.usd
-                .partial_cmp(&a.usd)
-                .unwrap_or(std::cmp::Ordering::Equal)
-                .then_with(|| a.key.cmp(&b.key))
-        });
-        v
-    };
+        aggregate
+    }
+}
 
-    StatsCost {
-        by_period: period,
-        by_pipeline: to_key_buckets(by_pipeline),
-        by_project: to_key_buckets(by_project),
-        // The pure fold knows nothing of prices; the handler fills this from the
-        // live table (#528).
-        resolved: Vec::new(),
+#[derive(Debug, Clone, Default)]
+struct CostEntityAcc {
+    name: String,
+    aggregate: CostAggregateAcc,
+    periods: BTreeMap<String, CostAggregateAcc>,
+    nodes: BTreeMap<String, CostEntityAcc>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct CostProjectAcc {
+    name: String,
+    aggregate: CostAggregateAcc,
+    periods: BTreeMap<String, CostAggregateAcc>,
+    pipelines: BTreeMap<String, CostEntityAcc>,
+}
+
+fn wire_periods(periods: BTreeMap<String, CostAggregateAcc>) -> Vec<StatsCostPeriod> {
+    periods
+        .into_iter()
+        .map(|(bucket, aggregate)| StatsCostPeriod {
+            bucket,
+            aggregate: aggregate.wire(),
+        })
+        .collect()
+}
+
+fn wire_cost_entity(id: String, entity: CostEntityAcc) -> StatsCostEntity {
+    let mut nodes: Vec<_> = entity
+        .nodes
+        .into_iter()
+        .map(|(id, node)| wire_cost_entity(id, node))
+        .collect();
+    nodes.sort_by(|a, b| {
+        b.aggregate
+            .usd
+            .unwrap_or(-1.0)
+            .partial_cmp(&a.aggregate.usd.unwrap_or(-1.0))
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.id.cmp(&b.id))
+    });
+    StatsCostEntity {
+        id,
+        name: entity.name,
+        aggregate: entity.aggregate.wire(),
+        by_period: wire_periods(entity.periods),
+        nodes,
     }
 }
 
@@ -420,6 +827,165 @@ fn cost_project_root(payload: &serde_json::Value, daemon_root: &Path) -> PathBuf
         .and_then(|v| v.as_str())
         .map(PathBuf::from)
         .unwrap_or_else(|| daemon_root.to_path_buf())
+}
+
+struct CostRunRow {
+    bucket: String,
+    pipeline_id: String,
+    pipeline_name: String,
+    project_id: String,
+    project_name: String,
+    node_names: BTreeMap<String, String>,
+    contributions: Vec<crate::run_cost::CostContribution>,
+}
+
+fn fold_harness_cost(runs: &[CostRunRow], resolved: Vec<ResolvedPriceRow>) -> StatsCost {
+    let mut total = CostAggregateAcc::default();
+    let mut periods = BTreeMap::<String, CostAggregateAcc>::new();
+    let mut pipelines = BTreeMap::<String, CostEntityAcc>::new();
+    let mut projects = BTreeMap::<String, CostProjectAcc>::new();
+    let mut active_harnesses = BTreeSet::new();
+
+    for run in runs {
+        total.add_run(&run.contributions);
+        periods
+            .entry(run.bucket.clone())
+            .or_default()
+            .add_run(&run.contributions);
+
+        let pipeline = pipelines.entry(run.pipeline_id.clone()).or_default();
+        pipeline.name = run.pipeline_name.clone();
+        pipeline.aggregate.add_run(&run.contributions);
+        pipeline
+            .periods
+            .entry(run.bucket.clone())
+            .or_default()
+            .add_run(&run.contributions);
+
+        let project = projects.entry(run.project_id.clone()).or_default();
+        project.name = run.project_name.clone();
+        project.aggregate.add_run(&run.contributions);
+        project
+            .periods
+            .entry(run.bucket.clone())
+            .or_default()
+            .add_run(&run.contributions);
+        let project_pipeline = project
+            .pipelines
+            .entry(run.pipeline_id.clone())
+            .or_default();
+        project_pipeline.name = run.pipeline_name.clone();
+        project_pipeline.aggregate.add_run(&run.contributions);
+        project_pipeline
+            .periods
+            .entry(run.bucket.clone())
+            .or_default()
+            .add_run(&run.contributions);
+
+        for contribution in &run.contributions {
+            if contribution.executions > 0 {
+                active_harnesses.insert(contribution.harness.clone());
+            }
+            let (id, name) = match contribution.scope {
+                crate::run_cost::CostScope::Node => {
+                    let id = contribution
+                        .node_id
+                        .clone()
+                        .unwrap_or_else(|| "(unknown)".to_string());
+                    let name = run
+                        .node_names
+                        .get(&id)
+                        .cloned()
+                        .unwrap_or_else(|| id.clone());
+                    (id, name)
+                }
+                crate::run_cost::CostScope::Infrastructure => (
+                    format!("{}:infrastructure", run.pipeline_id),
+                    "Infrastructure".to_string(),
+                ),
+                crate::run_cost::CostScope::Unassigned => (
+                    format!("{}:unassigned", run.pipeline_id),
+                    "Unassigned".to_string(),
+                ),
+            };
+            let node = pipeline.nodes.entry(id.clone()).or_default();
+            node.name = name.clone();
+            node.aggregate.add_contribution(contribution);
+            node.periods
+                .entry(run.bucket.clone())
+                .or_default()
+                .add_contribution(contribution);
+
+            let project_node = project_pipeline.nodes.entry(id).or_default();
+            project_node.name = name;
+            project_node.aggregate.add_contribution(contribution);
+            project_node
+                .periods
+                .entry(run.bucket.clone())
+                .or_default()
+                .add_contribution(contribution);
+        }
+    }
+
+    let mut by_pipeline: Vec<_> = pipelines
+        .into_iter()
+        .map(|(id, pipeline)| wire_cost_entity(id, pipeline))
+        .collect();
+    by_pipeline.sort_by(|a, b| {
+        b.aggregate
+            .usd
+            .unwrap_or(-1.0)
+            .partial_cmp(&a.aggregate.usd.unwrap_or(-1.0))
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.id.cmp(&b.id))
+    });
+
+    let mut by_project: Vec<_> = projects
+        .into_iter()
+        .map(|(id, project)| {
+            let mut pipelines: Vec<_> = project
+                .pipelines
+                .into_iter()
+                .map(|(id, pipeline)| wire_cost_entity(id, pipeline))
+                .collect();
+            pipelines.sort_by(|a, b| {
+                b.aggregate
+                    .usd
+                    .unwrap_or(-1.0)
+                    .partial_cmp(&a.aggregate.usd.unwrap_or(-1.0))
+                    .unwrap_or(std::cmp::Ordering::Equal)
+                    .then_with(|| a.id.cmp(&b.id))
+            });
+            StatsProjectCostEntity {
+                entity: StatsCostEntity {
+                    id,
+                    name: project.name,
+                    aggregate: project.aggregate.wire(),
+                    by_period: wire_periods(project.periods),
+                    nodes: Vec::new(),
+                },
+                pipelines,
+            }
+        })
+        .collect();
+    by_project.sort_by(|a, b| {
+        b.entity
+            .aggregate
+            .usd
+            .unwrap_or(-1.0)
+            .partial_cmp(&a.entity.aggregate.usd.unwrap_or(-1.0))
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.entity.id.cmp(&b.entity.id))
+    });
+
+    StatsCost {
+        harnesses: active_harnesses.into_iter().collect(),
+        total: total.wire(),
+        by_period: wire_periods(periods),
+        by_pipeline,
+        by_project,
+        resolved,
+    }
 }
 
 /// `GET /stats/cost` — Class B, memo + app-side fold. Heavy (fans over the
@@ -474,8 +1040,19 @@ pub(crate) async fn stats_cost(
     // not this one. The table's fingerprint is the memo's third key component, so a
     // sync is visible here without a daemon restart.
     let prices = crate::price_table::PriceTable::load(&home_root);
+    let copilot_root = crate::sandbox_run::copilot_store_root(&home_root);
+    let stored_projects = match crate::project_store::list(&state.db).await {
+        Ok(projects) => projects,
+        Err(error) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": format!("stats cost failed: {error}") })),
+            )
+                .into_response();
+        }
+    };
 
-    let mut cost_rows: Vec<CostRow> = Vec::with_capacity(rows.len());
+    let mut cost_rows: Vec<CostRunRow> = Vec::with_capacity(rows.len());
     for (run_id, bucket, payload) in rows {
         let payload: serde_json::Value = payload
             .as_deref()
@@ -484,15 +1061,21 @@ pub(crate) async fn stats_cost(
 
         // Pipeline key: `pipeline_id` going forward (#377), else the (always
         // present) `pipeline_name` — so grouping survives a rename (#230).
-        let pipeline = payload
+        let pipeline_id = payload
             .get("pipeline_id")
             .and_then(|v| v.as_str())
             .or_else(|| payload.get("pipeline_name").and_then(|v| v.as_str()))
             .unwrap_or("(unknown)")
             .to_string();
+        let pipeline_name = payload
+            .get("pipeline_name")
+            .and_then(|value| value.as_str())
+            .unwrap_or(&pipeline_id)
+            .to_string();
 
         let repo_root = cost_project_root(&payload, &state.repo_root);
-        let project = repo_root.to_string_lossy().into_owned();
+        let (project_id, project_name) =
+            project_identity(&payload, &state.repo_root, &stored_projects);
 
         // #408: read the transcripts from the sandboxed Run's staged home while it
         // is live (else `~/.claude/projects/`). Read `sandbox` straight off the
@@ -512,22 +1095,51 @@ pub(crate) async fn stats_cost(
             });
         let projects_root =
             crate::sandbox_run::transcripts_root(sandboxed, &run_id, &home_root, &sandbox_root);
-
-        let cost =
-            crate::run_cost::compute_run_cost_cached(&projects_root, &repo_root, &run_id, &prices);
-        cost_rows.push(CostRow {
+        let events = match crate::load_events(&state.db, &run_id).await {
+            Ok(events) => events,
+            Err(error) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({ "error": format!("stats cost failed: {error}") })),
+                )
+                    .into_response();
+            }
+        };
+        let breakdown = crate::run_cost::compute_run_cost_breakdown_cached(
+            &events,
+            &projects_root,
+            &copilot_root,
+            &repo_root,
+            &run_id,
+            &prices,
+        );
+        let node_names = payload
+            .get("node_defs")
+            .and_then(|value| value.as_array())
+            .into_iter()
+            .flatten()
+            .filter_map(|node| {
+                let id = node.get("id")?.as_str()?.to_string();
+                let name = node
+                    .get("name")
+                    .and_then(|value| value.as_str())
+                    .unwrap_or(&id)
+                    .to_string();
+                Some((id, name))
+            })
+            .collect();
+        cost_rows.push(CostRunRow {
             bucket,
-            pipeline,
-            project,
-            cost,
+            pipeline_id,
+            pipeline_name,
+            project_id,
+            project_name,
+            node_names,
+            contributions: breakdown.contributions,
         });
     }
 
-    // #528: carry the resolved price table alongside the fold — the same `prices`
-    // that billed every row above, so the Cost tab shows exactly what the pricer
-    // would apply, and a "Sync costs" refetch refreshes it in one round-trip.
-    let mut stats = fold_cost(&cost_rows);
-    stats.resolved = resolved_price_rows(&prices);
+    let stats = fold_harness_cost(&cost_rows, resolved_price_rows(&prices));
     Json(stats).into_response()
 }
 
@@ -543,6 +1155,19 @@ mod tests {
             .unwrap();
         crate::init_db(&db).await.unwrap();
         db
+    }
+
+    #[tokio::test]
+    async fn init_db_installs_the_idempotent_session_cohort_join_index() {
+        let db = mem_db().await;
+        crate::init_db(&db).await.unwrap();
+        let columns = sqlx::query_scalar::<_, String>(
+            "SELECT name FROM pragma_index_info('idx_events_run_kind_id') ORDER BY seqno",
+        )
+        .fetch_all(&db)
+        .await
+        .unwrap();
+        assert_eq!(columns, vec!["run_id", "kind", "id"]);
     }
 
     /// Insert a `run_started` + a terminal event for a run. `target_repo` is an
@@ -766,141 +1391,6 @@ mod tests {
     }
 
     #[test]
-    fn fold_cost_sums_and_propagates_partial_and_null() {
-        let rows = vec![
-            CostRow {
-                bucket: "2026-07-15".into(),
-                pipeline: "alpha".into(),
-                project: "/proj/A".into(),
-                cost: Some(CostStat {
-                    usd: 1.0,
-                    partial: false,
-                    unpriced_models: vec![],
-                    uncosted_harnesses: vec![],
-                }),
-            },
-            CostRow {
-                bucket: "2026-07-15".into(),
-                pipeline: "alpha".into(),
-                project: "/proj/A".into(),
-                cost: Some(CostStat {
-                    usd: 2.0,
-                    partial: true,
-                    unpriced_models: vec!["claude-sonnet-5".into()],
-                    uncosted_harnesses: vec![],
-                }),
-            },
-            CostRow {
-                bucket: "2026-07-16".into(),
-                pipeline: "beta".into(),
-                project: "/proj/B".into(),
-                cost: None, // no transcript
-            },
-        ];
-        let c = fold_cost(&rows);
-
-        // by_period: the 15th sums 1.0 + 2.0 with one partial run; the 16th is
-        // all-null (usd 0, null 1).
-        let d15 = c
-            .by_period
-            .iter()
-            .find(|b| b.bucket == "2026-07-15")
-            .unwrap();
-        assert!((d15.usd - 3.0).abs() < 1e-9);
-        assert_eq!(d15.partial, 1);
-        assert_eq!(d15.null_count, 0);
-        assert_eq!(d15.runs, 2);
-        // #425 AC#4: the unpriced model of the one partial run is named on the
-        // bucket, not just counted.
-        assert_eq!(d15.unpriced_models, vec!["claude-sonnet-5".to_string()]);
-        let d16 = c
-            .by_period
-            .iter()
-            .find(|b| b.bucket == "2026-07-16")
-            .unwrap();
-        assert_eq!(d16.usd, 0.0);
-        assert_eq!(d16.null_count, 1);
-        assert_eq!(d16.runs, 1);
-        // by_period is chronological.
-        assert_eq!(
-            c.by_period
-                .iter()
-                .map(|b| b.bucket.as_str())
-                .collect::<Vec<_>>(),
-            vec!["2026-07-15", "2026-07-16"]
-        );
-
-        // by_pipeline: alpha carries all the spend (sorted first, desc by usd).
-        assert_eq!(c.by_pipeline[0].key, "alpha");
-        assert!((c.by_pipeline[0].usd - 3.0).abs() < 1e-9);
-        assert_eq!(c.by_pipeline[0].partial, 1);
-        assert_eq!(c.by_pipeline[0].runs, 2);
-        assert_eq!(
-            c.by_pipeline[0].unpriced_models,
-            vec!["claude-sonnet-5".to_string()]
-        );
-        let beta = c.by_pipeline.iter().find(|b| b.key == "beta").unwrap();
-        assert_eq!(beta.usd, 0.0);
-        assert_eq!(beta.null_count, 1);
-        // A wholly-null bucket names nothing.
-        assert!(beta.unpriced_models.is_empty());
-
-        // by_project mirrors the pipeline split here.
-        assert_eq!(c.by_project[0].key, "/proj/A");
-        assert!((c.by_project[0].usd - 3.0).abs() < 1e-9);
-    }
-
-    #[test]
-    fn fold_cost_unions_and_dedups_unpriced_model_names_across_runs() {
-        // #425 AC#4: two partial runs in one bucket, sharing one offender and each
-        // bringing one of its own → the bucket names the UNION, sorted and unique.
-        let rows = vec![
-            CostRow {
-                bucket: "d".into(),
-                pipeline: "p".into(),
-                project: "/proj".into(),
-                cost: Some(CostStat {
-                    usd: 0.0,
-                    partial: true,
-                    unpriced_models: vec!["claude-sonnet-5".into(), "claude-fable-5".into()],
-                    uncosted_harnesses: vec![],
-                }),
-            },
-            CostRow {
-                bucket: "d".into(),
-                pipeline: "p".into(),
-                project: "/proj".into(),
-                cost: Some(CostStat {
-                    usd: 0.0,
-                    partial: true,
-                    unpriced_models: vec!["claude-fable-5".into(), "claude-opus-5".into()],
-                    uncosted_harnesses: vec![],
-                }),
-            },
-        ];
-        let c = fold_cost(&rows);
-        let d = c.by_period.iter().find(|b| b.bucket == "d").unwrap();
-        assert_eq!(d.partial, 2);
-        assert_eq!(
-            d.unpriced_models,
-            vec![
-                "claude-fable-5".to_string(),
-                "claude-opus-5".to_string(),
-                "claude-sonnet-5".to_string(),
-            ],
-            "union across the bucket, de-duplicated and sorted"
-        );
-    }
-
-    #[test]
-    fn fold_cost_leaves_resolved_empty_the_handler_fills_it() {
-        // The pure fold knows nothing of prices — the handler injects the live
-        // table (#528). This pins the contract so a future refactor can't wire the
-        // price table into the fold by accident.
-        assert!(fold_cost(&[]).resolved.is_empty());
-    }
-
-    #[test]
     fn resolved_price_rows_project_the_floor_faithfully() {
         // The projection `resolved_entries -> ResolvedPriceRow` is faithful: the
         // fourteen embedded families (since #527 floored the current generation),
@@ -938,6 +1428,70 @@ mod tests {
             cost_project_root(&payload, Path::new("/daemon/root")),
             PathBuf::from("/proj/A")
         );
+    }
+
+    #[test]
+    fn unnamed_project_uses_the_primary_repository_identity_and_readable_name() {
+        let payload = serde_json::json!({ "target_repo": "/repos/product-api" });
+        assert_eq!(
+            project_identity(&payload, Path::new("/daemon/root"), &[]),
+            ("/repos/product-api".to_string(), "product-api".to_string())
+        );
+    }
+
+    #[test]
+    fn harness_cost_fold_keeps_lower_bounds_and_unknown_columns_honest() {
+        let run = CostRunRow {
+            bucket: "2026-07-15".to_string(),
+            pipeline_id: "p".to_string(),
+            pipeline_name: "Pipeline".to_string(),
+            project_id: "/repo".to_string(),
+            project_name: "repo".to_string(),
+            node_names: BTreeMap::from([("n".to_string(), "Node".to_string())]),
+            contributions: vec![
+                crate::run_cost::CostContribution {
+                    harness: "claude".to_string(),
+                    scope: crate::run_cost::CostScope::Node,
+                    node_id: Some("n".to_string()),
+                    executions: 1,
+                    readable_executions: 1,
+                    usd: Some(0.0),
+                    form: Some(crate::event_log::CostForm::Derived),
+                    partial: true,
+                    unpriced_models: vec!["claude-fable-5".to_string()],
+                    unavailable_reasons: Vec::new(),
+                },
+                crate::run_cost::CostContribution {
+                    harness: "future".to_string(),
+                    scope: crate::run_cost::CostScope::Node,
+                    node_id: Some("n".to_string()),
+                    executions: 1,
+                    readable_executions: 0,
+                    usd: None,
+                    form: None,
+                    partial: false,
+                    unpriced_models: Vec::new(),
+                    unavailable_reasons: vec!["harness has no cost source".to_string()],
+                },
+            ],
+        };
+
+        let stats = fold_harness_cost(&[run], Vec::new());
+        assert_eq!(stats.harnesses, vec!["claude", "future"]);
+        assert_eq!(stats.total.usd, Some(0.0));
+        assert!(stats.total.partial);
+        assert_eq!(stats.total.executions, 1);
+        assert_eq!(stats.total.readable, 0);
+        assert_eq!(stats.total.unknown, 1);
+        assert_eq!(stats.total.average_usd, None);
+        assert_eq!(stats.total.unpriced_models, vec!["claude-fable-5"]);
+        let claude = &stats.total.harnesses[0];
+        assert_eq!(claude.average_usd, Some(0.0));
+        assert_eq!(claude.readable, 1);
+        let future = &stats.total.harnesses[1];
+        assert_eq!(future.usd, None);
+        assert_eq!(future.unknown, 1);
+        assert_eq!(future.missing_reasons, vec!["harness has no cost source"]);
     }
 
     #[test]

--- a/crates/pdo-daemon/tests/harness_freeze_resume.rs
+++ b/crates/pdo-daemon/tests/harness_freeze_resume.rs
@@ -173,6 +173,68 @@ async fn resolved_harness_is_frozen_on_node_started() {
 }
 
 #[tokio::test]
+async fn stats_exposes_frozen_harnesses_through_the_real_daemon() {
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+    let run_id = create_run(&daemon).await;
+    wait_for_both_started(&daemon, &run_id).await;
+    let period = "from=1970-01-01T00:00:00Z&to=2100-01-01T00:00:00Z&bucket=day";
+
+    let overview: serde_json::Value =
+        reqwest::get(format!("{}/stats/overview?{period}", daemon.url()))
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+    assert_eq!(
+        overview["session_harnesses"],
+        serde_json::json!(["claude", "opencode"])
+    );
+    let pipeline = overview["sessions_by_pipeline"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|row| row["name"] == PIPELINE_NAME)
+        .expect("the started Run belongs to the harness test Pipeline");
+    assert_eq!(pipeline["executions"], 2);
+    assert_eq!(
+        pipeline["harnesses"],
+        serde_json::json!([
+            {"harness":"claude","executions":1},
+            {"harness":"opencode","executions":1}
+        ])
+    );
+
+    let cost: serde_json::Value =
+        reqwest::get(format!("{}/stats/cost?{period}", daemon.url()))
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+    assert_eq!(cost["harnesses"], serde_json::json!(["claude", "opencode"]));
+    let pipeline = cost["by_pipeline"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|row| row["name"] == PIPELINE_NAME)
+        .expect("cost hierarchy keeps the Run's Pipeline");
+    assert_eq!(pipeline["executions"], 1);
+    let opencode = pipeline["harnesses"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|row| row["harness"] == "opencode")
+        .expect("a harness stays visible when it has no cost source");
+    assert!(opencode["usd"].is_null());
+    assert_eq!(opencode["unknown"], 1);
+    assert_eq!(
+        opencode["missing_reasons"],
+        serde_json::json!(["harness has no cost source"])
+    );
+}
+
+#[tokio::test]
 async fn resume_reposes_the_frozen_harness() {
     let daemon = TestDaemon::spawn(seed).await.unwrap();
     let run_id = create_run(&daemon).await;

--- a/crates/pdo-daemon/tests/run_scoped_pipeline.rs
+++ b/crates/pdo-daemon/tests/run_scoped_pipeline.rs
@@ -547,12 +547,14 @@ edges:
 
 // --- Issue #43: unrelated files under run worktree must not emit events ---
 
-/// Wait for ANY pipeline-related event on the WebSocket: either a run-scoped
-/// `pipeline_modified` event or a generic `pipeline_changed` broadcast.
-async fn next_any_pipeline_event(
+/// Wait for a pipeline event attributed to one of the paths changed by the test.
+/// Startup may still deliver a debounced event for the copied prompt; that is a
+/// different change and must not make this negative assertion flaky.
+async fn next_pipeline_event_for_paths(
     ws: &mut tokio_tungstenite::WebSocketStream<
         tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
     >,
+    paths: &[&std::path::Path],
     deadline: Duration,
 ) -> Option<serde_json::Value> {
     let result = timeout(deadline, async {
@@ -563,16 +565,17 @@ async fn next_any_pipeline_event(
                 continue;
             };
             let parsed: serde_json::Value = serde_json::from_str(text).ok()?;
-            // Run-scoped pipeline_modified event
-            if parsed["type"] == "event" {
-                if let Some(event) = parsed.get("event") {
-                    if event["kind"] == "pipeline_modified" {
-                        return Some(parsed.clone());
-                    }
-                }
-            }
-            // Generic pipeline_changed broadcast
-            if parsed["type"] == "pipeline_changed" {
+            let event_path =
+                if parsed["type"] == "event" && parsed["event"]["kind"] == "pipeline_modified" {
+                    parsed["event"]["payload"]["path"].as_str()
+                } else if parsed["type"] == "pipeline_changed" {
+                    parsed["path"].as_str()
+                } else {
+                    None
+                };
+            if event_path.is_some_and(|candidate| {
+                paths.iter().any(|path| path.to_string_lossy() == candidate)
+            }) {
                 return Some(parsed.clone());
             }
         }
@@ -601,14 +604,17 @@ async fn unrelated_md_in_run_worktree_does_not_emit_pipeline_event() {
     // exists and is watched via inotify). This reproduces the issue #43 bug:
     // the watcher falls through to the generic pipeline_changed broadcast.
     let run_dir = daemon.repo_root().join(".pdo/runs").join(&run_id);
-    std::fs::write(run_dir.join("README.md"), "# Unrelated doc\n").unwrap();
+    let readme = run_dir.join("README.md");
+    std::fs::write(&readme, "# Unrelated doc\n").unwrap();
 
     // Also write a .yaml that isn't pipeline.yaml
-    std::fs::write(run_dir.join("config.yaml"), "key: value\n").unwrap();
+    let config = run_dir.join("config.yaml");
+    std::fs::write(&config, "key: value\n").unwrap();
 
     // None of those writes should produce any pipeline event within 3 seconds
     // (watcher debounce is 1s, so 3s gives ample margin).
-    let evt = next_any_pipeline_event(&mut ws, Duration::from_secs(3)).await;
+    let evt =
+        next_pipeline_event_for_paths(&mut ws, &[&readme, &config], Duration::from_secs(3)).await;
     assert!(
         evt.is_none(),
         "unrelated .md files under run worktree must not emit pipeline events, got: {evt:?}"

--- a/docs/adr/0029-aggregated-stats-derive-and-index.md
+++ b/docs/adr/0029-aggregated-stats-derive-and-index.md
@@ -15,18 +15,21 @@ runs » est exactement ce fan-out interdit : mesuré à 2 502 transcripts / 1,1 
   qui fige une métrique. **Préserve ADR-0022** (Shape B, snapshot à la complétion, explicitement
   rejeté) et ADR-0001 (outil tranchant, étiquetage honnête).
 - **Deux classes, deux endpoints.** `GET /stats/overview` = SQL bon marché, index-backed
-  (`GROUP BY strftime`). `GET /stats/cost` = lourd, lazy, derrière un **memo RAM `(run_id,
-  mtime-max)`** (l'échappatoire sanctionnée par ADR-0022 lignes 84-85), borné à la période visible ;
-  le chemin single-run de `get_run` reste inchangé.
-- **Deux index idempotents** au boot : `events(kind, ts)` et `trigger_fires(ts)`
+  (`GROUP BY strftime` et jointure de cohorte). `GET /stats/cost` = lourd, lazy, derrière un
+  **memo RAM de contributions** indexé par le Run, les événements, les mtimes Claude/Copilot,
+  l'empreinte tarifaire et les racines de stockage, borné à la période visible ; le chemin
+  single-run de `get_run` reste inchangé.
+- **Trois index idempotents** au boot : `events(kind, ts)` pour sélectionner les cohortes,
+  `events(run_id, kind, id)` pour joindre seulement leurs démarrages de Node dans l'ordre, et
+  `trigger_fires(ts)`
   (`CREATE INDEX IF NOT EXISTS`, nativement idempotent — pas de garde PRAGMA, contrairement aux
   `ALTER ADD COLUMN` de #239/#244).
 - **`pipeline_id` porté par `RunStarted`** (fallback `pipeline_name`) pour que « par pipeline »
   survive un renommage (#230). Additif, rétro-compatible.
-- **Axes catégoriels du coût pliés côté app (Rust).** Le coût est un scalaire par-run sans dimension
-  pipeline/projet ; « par projet » = `effective_repo_root` (fallback runtime absent des tables). Les
-  cinq séries *nommées* (runs/sessions/erreurs/fires-par-pipeline/triggers-ayant-créé-un-run) restent
-  du SQL pur indexé.
+- **Axes catégoriels du coût pliés côté app (Rust).** Les contributions par Run portent le harnais,
+  le Node ou la catégorie Infrastructure/Non attribué ; « par projet » =
+  `effective_repo_root` (fallback runtime absent des tables). La sélection des cohortes et des
+  sessions reste du SQL indexé ; le pli hiérarchique reste en mémoire.
 - **Ventilation multi-harnais par exécution (#638).** La fenêtre sélectionne une cohorte de Runs par
   leur démarrage, puis attribue le coût complet de chaque exécution à son harnais, son Pipeline et son
   Node. Chaque harnais traduit sa propre source vers cette contribution commune ; une source moins
@@ -41,9 +44,10 @@ runs » est exactement ce fan-out interdit : mesuré à 2 502 transcripts / 1,1 
   (#427 : le remplissage de la table de prix est out-of-band, la lecture reste deux `fs::read` et un
   `const`), aucune divergence possible avec l'event log (source de vérité unique), le coût reste
   consultable pour un run archivé.
-- **Négatif / assumé.** Le memo vit en RAM (perdu au restart, reconstruit à la demande) et sa clé est
-  `(run_id, mtime-max, empreinte de la table de prix)` — le troisième composant est arrivé avec #427,
-  sans lui un sync resterait invisible ici jusqu'au redémarrage alors que `GET /runs/:id` dirait vrai.
+- **Négatif / assumé.** Le memo vit en RAM (perdu au restart, reconstruit à la demande) et sa clé
+  couvre `run_id`, l'empreinte des événements, les mtimes des transcripts Claude et journaux
+  Copilot, les racines injectées et l'empreinte de la table de prix. Sans cette dernière, un sync
+  resterait invisible ici jusqu'au redémarrage alors que `GET /runs/:id` dirait vrai.
   La table de prix se résout **`manuel → fetché → embarquée`**, le tier fetché étant alimenté hors du
   chemin de lecture (ADR-0022 amendement #427, ADR-0034). « Sessions/période » compte les *démarrages* de
   session (`node_started`), re-spawns et laps de boucle inclus (cohérent avec la stat par-run).

--- a/frontend/src/components/MarkdownArtifactModal.mermaidRemount.test.tsx
+++ b/frontend/src/components/MarkdownArtifactModal.mermaidRemount.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, act } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { useEffect } from "react";
+import { useRef } from "react";
 
 // #369 (residual flicker, after #532): a poll-driven parent re-render must NOT
 // remount the mermaid diagram. NodeDetailPanel polls node I/O and re-renders the
@@ -19,9 +19,11 @@ import { useEffect } from "react";
 let mountCount = 0;
 vi.mock("./MermaidDiagram", () => {
   function MermaidDiagramStub({ source }: { source: string }) {
-    useEffect(() => {
+    const mounted = useRef(false);
+    if (!mounted.current) {
+      mounted.current = true;
       mountCount++;
-    }, []);
+    }
     return <div data-testid="mermaid-stub">{source}</div>;
   }
   return { default: MermaidDiagramStub };

--- a/frontend/src/components/StatsCharts.test.tsx
+++ b/frontend/src/components/StatsCharts.test.tsx
@@ -268,6 +268,12 @@ describe("StatsCharts — harness drill-down (#638)", () => {
       const user = userEvent.setup();
       render(<StatsCharts tab="cost" overview={null} cost={COST} costError={null} />);
 
+      const navigation = screen.getByTestId("stats-drilldown-navigation");
+      expect(
+        within(navigation).getByRole("combobox", { name: "Cost grouping" }),
+      ).toBeInTheDocument();
+      expect(within(navigation).getByRole("listbox", { name: "Spenders" })).toBeInTheDocument();
+      expect(navigation.nextElementSibling).toBe(screen.getByTestId("stats-drilldown-detail"));
       expect(screen.getByTestId("stats-harness-card-claude")).toHaveTextContent("~$5.00†");
       expect(screen.getByTestId("stats-harness-card-copilot")).toHaveTextContent("$2.00");
       expect(screen.getByTestId("stats-harness-card-opencode")).toHaveTextContent("—");

--- a/frontend/src/components/StatsCharts.test.tsx
+++ b/frontend/src/components/StatsCharts.test.tsx
@@ -1,54 +1,321 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, it, expect } from "vitest";
 
 import StatsCharts from "./StatsCharts";
-import type { StatsCost } from "../types";
+import type { StatsCost, StatsHarnessCost, StatsOverview } from "../types";
 
 // The resolved price table (#528) lives on the Stats → Cost tab, fed by
 // `/stats/cost`. `by_period: []` means no spend, so the recharts chart never
 // mounts — these assertions exercise only the plain-DOM resolved section.
 const EMPTY_COST: StatsCost = {
+  harnesses: [],
+  total: {
+    usd: null,
+    average_usd: null,
+    estimated: true,
+    partial: false,
+    executions: 0,
+    readable: 0,
+    unknown: 0,
+    unpriced_models: [],
+    missing_reasons: [],
+    harnesses: [],
+  },
   by_period: [],
   by_pipeline: [],
   by_project: [],
   resolved: [],
 };
 
-describe("StatsCharts — the resolved price table on the Cost tab (#528)", () => {
-  it("renders one row per family with its winning tier and $/MTok", () => {
-    const cost: StatsCost = {
-      ...EMPTY_COST,
-      resolved: [
-        { key: "claude-opus-4-8", tier: "manual", input: 4.5, output: 22.5 },
-        { key: "claude-opus-5", tier: "fetched", input: 5, output: 25 },
-        { key: "claude-sonnet-4-5", tier: "embedded", input: 3, output: 15 },
+const COST_HARNESSES: StatsHarnessCost[] = [
+  {
+    harness: "claude",
+    usd: 5,
+    estimated: true,
+    partial: true,
+    executions: 2,
+    readable: 2,
+    unknown: 0,
+    average_usd: 2.5,
+    unpriced_models: ["claude-unknown"],
+    missing_reasons: [],
+  },
+  {
+    harness: "copilot",
+    usd: 2,
+    estimated: true,
+    partial: false,
+    executions: 1,
+    readable: 1,
+    unknown: 0,
+    average_usd: 2,
+    unpriced_models: [],
+    missing_reasons: [],
+  },
+  {
+    harness: "opencode",
+    usd: null,
+    estimated: true,
+    partial: false,
+    executions: 1,
+    readable: 0,
+    unknown: 1,
+    average_usd: null,
+    unpriced_models: [],
+    missing_reasons: ["no cost source"],
+  },
+];
+
+const COST: StatsCost = {
+  ...EMPTY_COST,
+  harnesses: ["claude", "copilot", "opencode"],
+  total: {
+    usd: 7,
+    average_usd: 7 / 3,
+    estimated: true,
+    partial: true,
+    executions: 4,
+    readable: 3,
+    unknown: 1,
+    unpriced_models: ["claude-unknown"],
+    missing_reasons: ["opencode has no cost source"],
+    harnesses: [
+      {
+        harness: "claude",
+        usd: 5,
+        estimated: true,
+        partial: true,
+        executions: 2,
+        readable: 2,
+        unknown: 0,
+        average_usd: 2.5,
+        unpriced_models: ["claude-unknown"],
+        missing_reasons: [],
+      },
+      {
+        harness: "copilot",
+        usd: 2,
+        estimated: true,
+        partial: false,
+        executions: 1,
+        readable: 1,
+        unknown: 0,
+        average_usd: 2,
+        unpriced_models: [],
+        missing_reasons: [],
+      },
+      {
+        harness: "opencode",
+        usd: null,
+        estimated: true,
+        partial: false,
+        executions: 1,
+        readable: 0,
+        unknown: 1,
+        average_usd: null,
+        unpriced_models: [],
+        missing_reasons: ["no cost source"],
+      },
+    ],
+  },
+  by_period: [
+    {
+      bucket: "2026-08-27",
+      ...EMPTY_COST.total,
+      ...{
+        usd: 7,
+        partial: true,
+        executions: 4,
+        readable: 3,
+        unknown: 1,
+        harnesses: COST_HARNESSES,
+      },
+    },
+  ],
+  by_pipeline: [
+    {
+      id: "pipe-technical-id",
+      name: "Implement loop",
+      ...EMPTY_COST.total,
+      usd: 7,
+      partial: true,
+      executions: 4,
+      readable: 3,
+      unknown: 1,
+      harnesses: COST_HARNESSES,
+      by_period: [
+        {
+          bucket: "2026-08-27",
+          ...EMPTY_COST.total,
+          usd: 7,
+          partial: true,
+          executions: 4,
+          readable: 3,
+          unknown: 1,
+          harnesses: COST_HARNESSES,
+        },
       ],
-    };
-    render(<StatsCharts tab="cost" overview={null} cost={cost} costError={null} />);
+      nodes: [
+        {
+          id: "node-cheap-id",
+          name: "Build",
+          ...EMPTY_COST.total,
+          usd: 2,
+          executions: 1,
+          readable: 1,
+          harnesses: [COST_HARNESSES[1]],
+          by_period: [],
+          nodes: [],
+        },
+        {
+          id: "node-expensive-id",
+          name: "Review",
+          ...EMPTY_COST.total,
+          usd: 5,
+          average_usd: 5,
+          partial: true,
+          executions: 2,
+          readable: 1,
+          unknown: 1,
+          harnesses: [COST_HARNESSES[0]],
+          by_period: [],
+          nodes: [],
+        },
+      ],
+    },
+  ],
+  by_project: [
+    {
+      id: "project-hidden-id",
+      name: "PDO",
+      ...EMPTY_COST.total,
+      usd: 7,
+      partial: true,
+      executions: 2,
+      readable: 2,
+      harnesses: COST_HARNESSES,
+      by_period: [],
+      nodes: [],
+      pipelines: [],
+    },
+  ],
+};
+COST.by_project[0].pipelines = [COST.by_pipeline[0]];
 
-    expect(screen.getByTestId("stats-cost-resolved")).toBeInTheDocument();
-    // The manually overridden family: winning $/MTok + the `manual` badge.
-    const manualRow = screen.getByTestId("price-row-claude-opus-4-8");
-    expect(manualRow).toHaveTextContent("$4.5/$22.5 /MTok");
-    expect(screen.getByTestId("price-row-tier-claude-opus-4-8")).toHaveTextContent("manual");
-    // A fetch-only family carries `fetched`, an untouched one `embedded`.
-    expect(screen.getByTestId("price-row-tier-claude-opus-5")).toHaveTextContent("fetched");
-    expect(screen.getByTestId("price-row-tier-claude-sonnet-4-5")).toHaveTextContent("embedded");
-  });
+const OVERVIEW: StatsOverview = {
+  buckets: ["2026-08-27"],
+  runs: [{ bucket: "2026-08-27", count: 1 }],
+  errors: [],
+  sessions: [{ bucket: "2026-08-27", count: 3 }],
+  session_harnesses: ["claude", "copilot"],
+  sessions_by_period: [
+    {
+      bucket: "2026-08-27",
+      harnesses: [
+        { harness: "claude", executions: 2 },
+        { harness: "copilot", executions: 1 },
+      ],
+    },
+  ],
+  sessions_by_pipeline: [
+    {
+      id: "pipe-hidden-id",
+      name: "Implement loop",
+      executions: 3,
+      harnesses: [
+        { harness: "claude", executions: 2 },
+        { harness: "copilot", executions: 1 },
+      ],
+      by_period: [],
+      nodes: [
+        {
+          id: "node-hidden-id",
+          name: "Review",
+          executions: 2,
+          harnesses: [{ harness: "claude", executions: 2 }],
+          by_period: [],
+          nodes: [],
+        },
+      ],
+    },
+  ],
+  fires_by_pipeline: [],
+  triggers_created_runs: { fired: 0, distinct_triggers: 0, enabled_triggers: 0 },
+};
 
-  it("renders nothing when the resolved table is empty (defensive vite-dev gap)", () => {
-    render(<StatsCharts tab="cost" overview={null} cost={EMPTY_COST} costError={null} />);
-    expect(screen.queryByTestId("stats-cost-resolved")).not.toBeInTheDocument();
-  });
+describe("StatsCharts — harness drill-down (#638)", () => {
+    it("shows harness session volumes and drills from a Pipeline into its Nodes", async () => {
+      const user = userEvent.setup();
+      render(<StatsCharts tab="sessions" overview={OVERVIEW} cost={null} costError={null} />);
 
-  it("does not render the resolved table off the Cost tab", () => {
-    const cost: StatsCost = {
-      ...EMPTY_COST,
-      resolved: [{ key: "claude-opus-4-8", tier: "embedded", input: 5, output: 25 }],
-    };
-    // `overview={null}` on a non-cost tab short-circuits to the loading note — no
-    // recharts, and definitively no resolved table outside its home.
-    render(<StatsCharts tab="runs" overview={null} cost={cost} costError={null} />);
-    expect(screen.queryByTestId("stats-cost-resolved")).not.toBeInTheDocument();
+      expect(screen.getByTestId("stats-harness-legend-claude")).toHaveStyle({
+        backgroundColor: "#f0883e",
+      });
+      expect(screen.getByTestId("stats-harness-legend-copilot")).toHaveStyle({
+        backgroundColor: "#58a6ff",
+      });
+      expect(screen.getAllByText("Implement loop")).toHaveLength(2);
+      expect(screen.queryByText("pipe-hidden-id")).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole("option", { name: /Implement loop/ }));
+      expect(screen.getByText("Review")).toBeInTheDocument();
+      expect(screen.getByText("2", { selector: "[data-harness='claude']" })).toBeInTheDocument();
+      expect(screen.queryByText("node-hidden-id")).not.toBeInTheDocument();
+    });
+
+    it("shows totals and readable-cost averages without presenting unknown cost as zero", async () => {
+      const user = userEvent.setup();
+      render(<StatsCharts tab="cost" overview={null} cost={COST} costError={null} />);
+
+      expect(screen.getByTestId("stats-harness-card-claude")).toHaveTextContent("~$5.00†");
+      expect(screen.getByTestId("stats-harness-card-copilot")).toHaveTextContent("$2.00");
+      expect(screen.getByTestId("stats-harness-card-opencode")).toHaveTextContent("—");
+      expect(screen.getByText(/1 Run without computable cost/i)).toBeInTheDocument();
+      expect(screen.getByTestId("stats-selection-headline")).toHaveTextContent(
+        "~$7.00† total · ~$2.33† per Run",
+      );
+      expect(screen.queryByText("~$0.00")).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole("option", { name: /Implement loop/ }));
+      expect(screen.getByRole("columnheader", { name: "Total" })).toBeInTheDocument();
+      const rows = screen.getAllByTestId("stats-detail-row");
+      expect(rows[0]).toHaveTextContent("Review");
+      expect(
+        within(rows[0]).getByRole("button", { name: /1 readable cost of 2 executions/i }),
+      ).toHaveTextContent("~$5.00† avg");
+      expect(rows[1]).toHaveTextContent("Build");
+      expect(rows[0]).toHaveTextContent("~$5.00");
+      expect(rows[0]).toHaveTextContent("~$2.50† avg");
+      expect(rows[0]).not.toHaveTextContent(/execution/i);
+      expect(screen.queryByText("node-expensive-id")).not.toBeInTheDocument();
+    });
+
+    it("exposes average coverage and lower-bound reasons through a focusable tooltip", async () => {
+      const user = userEvent.setup();
+      render(<StatsCharts tab="cost" overview={null} cost={COST} costError={null} />);
+      await user.click(screen.getByRole("option", { name: /Implement loop/ }));
+
+      const average = screen.getByRole("button", { name: /2 readable costs of 2.*lower bound/i });
+      await user.hover(average);
+      expect(await screen.findByTestId("tooltip-content")).toHaveTextContent(
+        /2 readable costs of 2 executions/i,
+      );
+      expect(screen.getByTestId("tooltip-content")).toHaveTextContent(/claude-unknown/i);
+    });
+
+  it("drills Project → Pipeline → Nodes", async () => {
+    const user = userEvent.setup();
+    render(<StatsCharts tab="cost" overview={null} cost={COST} costError={null} />);
+
+    await user.selectOptions(screen.getByRole("combobox", { name: "Cost grouping" }), "project");
+    expect(screen.getAllByText("PDO")).toHaveLength(2);
+    await user.click(screen.getByRole("option", { name: /PDO/ }));
+    await user.click(screen.getByRole("button", { name: "Open Implement loop" }));
+
+    expect(screen.getByTestId("stats-cost-breadcrumb")).toHaveTextContent(
+      "Total / PDO / Implement loop",
+    );
+    expect(screen.getByText("Review")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/StatsCharts.tsx
+++ b/frontend/src/components/StatsCharts.tsx
@@ -1,39 +1,43 @@
+import { useMemo, useState } from "react";
 import {
-  BarChart,
   Bar,
-  LineChart,
-  Line,
+  BarChart,
+  CartesianGrid,
+  Legend,
+  ResponsiveContainer,
+  Tooltip as RTooltip,
   XAxis,
   YAxis,
-  Tooltip as RTooltip,
-  Legend,
-  CartesianGrid,
-  ResponsiveContainer,
 } from "recharts";
-import type { StatsOverview, StatsCost, StatsCostBucket, PriceRow } from "../types";
-import { formatBucketCost } from "../lib/costLabel";
-
-// This module is the ONLY importer of `recharts`, so it is code-split via
-// `React.lazy` in StatsModal (the first lazy chunk in the repo) — recharts stays
-// out of the main bundle and loads when the Stats modal first opens.
+import type {
+  StatsCost,
+  StatsCostAggregate,
+  StatsCostEntity,
+  StatsCostPeriod,
+  StatsHarnessCost,
+  StatsOverview,
+  StatsProjectCostEntity,
+  StatsSessionEntity,
+  StatsSessionHarness,
+  StatsSessionPeriod,
+} from "../types";
+import { formatCostAmount } from "../lib/costLabel";
+import { harnessColor } from "../lib/harness";
+import { Tooltip, TooltipProvider } from "./ui/tooltip";
 
 export type StatsTab = "runs" | "sessions" | "triggers" | "cost";
 
-// Palette — reads on the dark UI; deliberately not the brand accent so series
-// stay distinguishable.
-const C = {
+const CHART = {
   runs: "#58a6ff",
   errors: "#f85149",
-  sessions: "#a371f7",
   fires: "#3fb950",
-  cost: "#d29922",
   grid: "#30363d",
   axis: "#8b949e",
 } as const;
 
 const AXIS_PROPS = {
-  stroke: C.axis,
-  tick: { fill: C.axis, fontSize: 10 },
+  stroke: CHART.axis,
+  tick: { fill: CHART.axis, fontSize: 10 },
 } as const;
 
 function ChartFrame({ children }: { children: React.ReactElement }) {
@@ -54,69 +58,259 @@ function EmptyNote({ children }: { children: React.ReactNode }) {
   );
 }
 
-/** Merge two per-bucket count series onto the ordered `buckets` x-axis. */
-function mergeCounts(
-  buckets: string[],
-  a: { bucket: string; count: number }[],
-  b: { bucket: string; count: number }[],
-): { bucket: string; runs: number; errors: number }[] {
-  const am = new Map(a.map((r) => [r.bucket, r.count]));
-  const bm = new Map(b.map((r) => [r.bucket, r.count]));
-  return buckets.map((bucket) => ({
-    bucket,
-    runs: am.get(bucket) ?? 0,
-    errors: bm.get(bucket) ?? 0,
+function HarnessLegend({ harnesses }: { harnesses: string[] }) {
+  return (
+    <div className="flex flex-wrap gap-3 text-fg-3" style={{ fontSize: "10.5px" }}>
+      {harnesses.map((harness) => (
+        <span key={harness} className="flex items-center gap-1.5">
+          <span
+            className="h-2 w-2 rounded-full"
+            style={{ backgroundColor: harnessColor(harness) }}
+            data-testid={`stats-harness-legend-${harness}`}
+          />
+          {harness}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function flattenPeriods(
+  periods: (StatsSessionPeriod | StatsCostPeriod)[],
+  value: "executions" | "usd",
+) {
+  return periods.map((period) => ({
+    bucket: period.bucket,
+    ...Object.fromEntries(
+      period.harnesses.map((harness) => [
+        harness.harness,
+        value === "usd" ? ("usd" in harness ? harness.usd : null) : harness.executions,
+      ]),
+    ),
   }));
+}
+
+function isHarnessCost(
+  metric: StatsSessionHarness | StatsHarnessCost | undefined,
+): metric is StatsHarnessCost {
+  return metric !== undefined && "average_usd" in metric;
+}
+
+function HarnessBars({
+  periods,
+  harnesses,
+  value,
+}: {
+  periods: (StatsSessionPeriod | StatsCostPeriod)[];
+  harnesses: string[];
+  value: "executions" | "usd";
+}) {
+  if (periods.length === 0) return <EmptyNote>No activity in this period.</EmptyNote>;
+  return (
+    <ChartFrame>
+      <BarChart data={flattenPeriods(periods, value)} margin={{ top: 8, right: 8, left: -12 }}>
+        <CartesianGrid stroke={CHART.grid} strokeDasharray="3 3" vertical={false} />
+        <XAxis dataKey="bucket" {...AXIS_PROPS} />
+        <YAxis allowDecimals={value === "usd"} {...AXIS_PROPS} />
+        <RTooltip
+          contentStyle={{ background: "#161b22", border: `1px solid ${CHART.grid}`, fontSize: 11 }}
+          formatter={(raw, name) => {
+            if (raw == null) return ["—", String(name)];
+            const amount = typeof raw === "number" ? raw : Number(raw);
+            const metric = periods
+              .flatMap((period) => period.harnesses)
+              .find((harness) => harness.harness === String(name));
+            const costMetric = isHarnessCost(metric) ? metric : undefined;
+            const label =
+              value === "usd"
+                ? formatCostAmount(
+                    amount,
+                    costMetric?.partial ?? false,
+                    costMetric?.estimated ?? true,
+                  )
+                : amount;
+            return [label, String(name)];
+          }}
+        />
+        <Legend wrapperStyle={{ fontSize: 11 }} />
+        {harnesses.map((harness) => (
+          <Bar
+            key={harness}
+            dataKey={harness}
+            name={harness}
+            stackId="harness"
+            fill={harnessColor(harness)}
+          />
+        ))}
+      </BarChart>
+    </ChartFrame>
+  );
 }
 
 function RunsTab({ overview }: { overview: StatsOverview }) {
   if (overview.buckets.length === 0) return <EmptyNote>No runs in this period.</EmptyNote>;
-  const data = mergeCounts(overview.buckets, overview.runs, overview.errors);
+  const runs = new Map(overview.runs.map((row) => [row.bucket, row.count]));
+  const errors = new Map(overview.errors.map((row) => [row.bucket, row.count]));
+  const data = overview.buckets.map((bucket) => ({
+    bucket,
+    runs: runs.get(bucket) ?? 0,
+    errors: errors.get(bucket) ?? 0,
+  }));
   return (
     <div data-testid="stats-chart-runs">
       <ChartFrame>
-        <BarChart data={data} margin={{ top: 8, right: 8, left: -18, bottom: 0 }}>
-          <CartesianGrid stroke={C.grid} strokeDasharray="3 3" vertical={false} />
+        <BarChart data={data} margin={{ top: 8, right: 8, left: -18 }}>
+          <CartesianGrid stroke={CHART.grid} strokeDasharray="3 3" vertical={false} />
           <XAxis dataKey="bucket" {...AXIS_PROPS} />
           <YAxis allowDecimals={false} {...AXIS_PROPS} />
           <RTooltip
-            contentStyle={{ background: "#161b22", border: `1px solid ${C.grid}`, fontSize: 11 }}
+            contentStyle={{ background: "#161b22", border: `1px solid ${CHART.grid}`, fontSize: 11 }}
           />
           <Legend wrapperStyle={{ fontSize: 11 }} />
-          <Bar dataKey="runs" name="Runs" fill={C.runs} radius={[2, 2, 0, 0]} />
-          <Bar dataKey="errors" name="Errors (failed)" fill={C.errors} radius={[2, 2, 0, 0]} />
+          <Bar dataKey="runs" name="Runs" fill={CHART.runs} />
+          <Bar dataKey="errors" name="Errors (failed)" fill={CHART.errors} />
         </BarChart>
       </ChartFrame>
     </div>
   );
 }
 
-function SessionsTab({ overview }: { overview: StatsOverview }) {
-  if (overview.buckets.length === 0)
-    return <EmptyNote>No node sessions in this period.</EmptyNote>;
-  const sm = new Map(overview.sessions.map((r) => [r.bucket, r.count]));
-  const data = overview.buckets.map((bucket) => ({ bucket, sessions: sm.get(bucket) ?? 0 }));
+function MasterList<T extends { id: string; name: string }>({
+  rows,
+  selected,
+  valueLabel,
+  onSelect,
+}: {
+  rows: T[];
+  selected: string | null;
+  valueLabel: (row: T) => string;
+  onSelect: (id: string | null) => void;
+}) {
+  const options = [{ id: "__total__", name: "Total" } as T, ...rows];
+  const selectedIndex = Math.max(
+    0,
+    options.findIndex((row) => (selected === null ? row.id === "__total__" : row.id === selected)),
+  );
+  const [focusIndex, setFocusIndex] = useState(selectedIndex);
+  const activeFocusIndex = Math.min(focusIndex, options.length - 1);
+
   return (
-    <div data-testid="stats-chart-sessions">
-      <ChartFrame>
-        <LineChart data={data} margin={{ top: 8, right: 8, left: -18, bottom: 0 }}>
-          <CartesianGrid stroke={C.grid} strokeDasharray="3 3" vertical={false} />
-          <XAxis dataKey="bucket" {...AXIS_PROPS} />
-          <YAxis allowDecimals={false} {...AXIS_PROPS} />
-          <RTooltip
-            contentStyle={{ background: "#161b22", border: `1px solid ${C.grid}`, fontSize: 11 }}
-          />
-          <Line
-            type="monotone"
-            dataKey="sessions"
-            name="Node sessions started"
-            stroke={C.sessions}
-            strokeWidth={2}
-            dot={{ r: 2 }}
-          />
-        </LineChart>
-      </ChartFrame>
+    <div
+      role="listbox"
+      aria-label="Spenders"
+      className="flex min-w-[250px] flex-col gap-1 border-r border-line pr-3"
+      onKeyDown={(event) => {
+        if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+          event.preventDefault();
+          const delta = event.key === "ArrowDown" ? 1 : -1;
+          setFocusIndex((activeFocusIndex + delta + options.length) % options.length);
+        } else if (event.key === "Enter") {
+          event.preventDefault();
+          const row = options[activeFocusIndex];
+          onSelect(row.id === "__total__" ? null : row.id);
+        } else if (event.key === "Backspace" || event.key === "ArrowLeft") {
+          event.preventDefault();
+          onSelect(null);
+        }
+      }}
+    >
+      {options.map((row, index) => {
+        const isSelected = row.id === (selected ?? "__total__");
+        return (
+          <button
+            key={row.id}
+            type="button"
+            role="option"
+            aria-selected={isSelected}
+            tabIndex={index === activeFocusIndex ? 0 : -1}
+            onFocus={() => setFocusIndex(index)}
+            onClick={() => onSelect(row.id === "__total__" ? null : row.id)}
+            className={`flex items-center justify-between gap-3 rounded px-2 py-2 text-left ${
+              isSelected ? "bg-bg-5 text-fg" : "text-fg-3 hover:bg-bg-3"
+            }`}
+            style={{ fontSize: "11.5px" }}
+          >
+            <span className="truncate">{row.name}</span>
+            <span className="shrink-0 font-mono text-fg-2">
+              {row.id === "__total__" ? "" : valueLabel(row)}
+            </span>
+          </button>
+        );
+      })}
     </div>
+  );
+}
+
+function SessionsTab({ overview }: { overview: StatsOverview }) {
+  const rows = useMemo(
+    () => [...overview.sessions_by_pipeline].sort((a, b) => b.executions - a.executions),
+    [overview.sessions_by_pipeline],
+  );
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const selected = rows.find((row) => row.id === selectedId) ?? null;
+  const periods = selected ? selected.by_period : overview.sessions_by_period;
+  const detailRows = selected?.nodes ?? rows;
+
+  return (
+    <div className="flex flex-col gap-4" data-testid="stats-chart-sessions">
+      <HarnessLegend harnesses={overview.session_harnesses} />
+      <HarnessBars periods={periods} harnesses={overview.session_harnesses} value="executions" />
+      <div className="flex min-h-[220px] gap-4">
+        <MasterList
+          rows={rows}
+          selected={selectedId}
+          valueLabel={(row) => String(row.executions)}
+          onSelect={setSelectedId}
+        />
+        <div className="min-w-0 flex-1">
+          <div className="mb-3 text-fg-4" style={{ fontSize: "10.5px" }}>
+            Total{selected ? ` / ${selected.name}` : ""}
+          </div>
+          <SessionTable rows={detailRows} harnesses={overview.session_harnesses} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SessionTable({ rows, harnesses }: { rows: StatsSessionEntity[]; harnesses: string[] }) {
+  return (
+    <table className="w-full table-fixed text-left" style={{ fontSize: "11px" }}>
+      <thead className="text-fg-4">
+        <tr>
+          <th className="pb-2 font-medium">Name</th>
+          <th className="w-20 pb-2 text-right font-medium">Total</th>
+          {harnesses.map((harness) => (
+            <th key={harness} className="w-24 pb-2 text-right font-medium">
+              <span className="inline-flex items-center gap-1">
+                <span
+                  className="h-2 w-2 rounded-full"
+                  style={{ backgroundColor: harnessColor(harness) }}
+                />
+                {harness}
+              </span>
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row) => (
+          <tr key={row.id} className="border-t border-line text-fg-2" tabIndex={0}>
+            <td className="py-2 pr-2">{row.name}</td>
+            <td className="py-2 text-right font-mono">{row.executions}</td>
+            {harnesses.map((harness) => (
+              <td
+                key={harness}
+                className="py-2 text-right font-mono"
+                data-harness={harness}
+              >
+                {row.harnesses.find((item) => item.harness === harness)?.executions ?? "—"}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
   );
 }
 
@@ -125,10 +319,7 @@ function TriggersTab({ overview }: { overview: StatsOverview }) {
   return (
     <div data-testid="stats-chart-triggers" className="flex flex-col gap-3">
       <div className="flex flex-wrap gap-2" style={{ fontSize: "11px" }}>
-        <span
-          className="rounded bg-bg-3 px-2 py-1 text-fg-2"
-          data-testid="stats-kpi-created-runs"
-        >
+        <span className="rounded bg-bg-3 px-2 py-1 text-fg-2" data-testid="stats-kpi-created-runs">
           Fires that created a run: <span className="font-mono text-fg">{kpi.fired}</span>
         </span>
         <span className="rounded bg-bg-3 px-2 py-1 text-fg-2" data-testid="stats-kpi-distinct">
@@ -140,17 +331,18 @@ function TriggersTab({ overview }: { overview: StatsOverview }) {
         <EmptyNote>No trigger fires in this period.</EmptyNote>
       ) : (
         <ChartFrame>
-          <BarChart
-            data={overview.fires_by_pipeline}
-            margin={{ top: 8, right: 8, left: -18, bottom: 0 }}
-          >
-            <CartesianGrid stroke={C.grid} strokeDasharray="3 3" vertical={false} />
+          <BarChart data={overview.fires_by_pipeline}>
+            <CartesianGrid stroke={CHART.grid} strokeDasharray="3 3" vertical={false} />
             <XAxis dataKey="pipeline_id" {...AXIS_PROPS} />
             <YAxis allowDecimals={false} {...AXIS_PROPS} />
             <RTooltip
-              contentStyle={{ background: "#161b22", border: `1px solid ${C.grid}`, fontSize: 11 }}
+              contentStyle={{
+                background: "#161b22",
+                border: `1px solid ${CHART.grid}`,
+                fontSize: 11,
+              }}
             />
-            <Bar dataKey="count" name="Fires" fill={C.fires} radius={[2, 2, 0, 0]} />
+            <Bar dataKey="count" name="Fires" fill={CHART.fires} />
           </BarChart>
         </ChartFrame>
       )}
@@ -158,153 +350,271 @@ function TriggersTab({ overview }: { overview: StatsOverview }) {
   );
 }
 
-/** One labelled cost row carrying the honesty vocabulary (`~$` / `†` / `—`). */
-function CostRow({ label, bucket }: { label: string; bucket: StatsCostBucket }) {
-  const c = formatBucketCost(
-    bucket.usd,
-    bucket.partial,
-    bucket.null,
-    bucket.runs,
-    bucket.unpriced_models,
-  );
-  return (
-    <div
-      className="flex items-center justify-between rounded bg-bg-3 px-2 py-1"
-      style={{ fontSize: "10.5px" }}
-      data-testid="stats-cost-row"
-      title={c.title}
-    >
-      <span className="text-fg-3">{label}</span>
-      <span className={`flex items-center gap-1 font-mono ${c.empty ? "text-fg-4" : "text-fg-2"}`}>
-        {c.text}
-        {c.dagger && (
-          <span className="text-st-await" title={c.title}>
-            †
-          </span>
-        )}
-      </span>
-    </div>
-  );
+function coverage(metric: StatsHarnessCost, unit: "Run" | "execution"): string {
+  const parts = [
+    `${metric.readable} readable ${metric.readable === 1 ? "cost" : "costs"} of ${metric.executions} ${
+      metric.executions === 1 ? unit : `${unit}s`
+    }`,
+  ];
+  if (metric.unpriced_models.length) {
+    parts.push(`Lower bound; unpriced: ${metric.unpriced_models.join(", ")}`);
+  }
+  if (metric.missing_reasons.length) parts.push(metric.missing_reasons.join("; "));
+  return parts.join(". ");
 }
 
-function CostSection({
-  title,
-  rows,
-}: {
-  title: string;
-  rows: { label: string; bucket: StatsCostBucket }[];
-}) {
+function HarnessCards({ aggregate }: { aggregate: StatsCostAggregate }) {
   return (
-    <div className="flex flex-col gap-1.5">
-      <h4 className="font-medium text-fg-2" style={{ fontSize: "11px" }}>
-        {title}
-      </h4>
-      {rows.length === 0 ? (
-        <EmptyNote>No runs in this period.</EmptyNote>
-      ) : (
-        <div className="flex flex-col gap-1">
-          {rows.map((r) => (
-            <CostRow key={r.label} label={r.label} bucket={r.bucket} />
-          ))}
-        </div>
-      )}
-    </div>
-  );
-}
-
-/** The resolved price table (#528): one row per family — the WINNING tier and the
- *  $/MTok actually in force. Reads the same table the fold bills with, so pressing
- *  "Sync costs" (just above) and reading what PDO can price happen in one place.
- *  Defensive `?.` for the same `vite dev` reason as the cost buckets. */
-function ResolvedPrices({ resolved }: { resolved: PriceRow[] | undefined }) {
-  if (!resolved?.length) return null;
-  return (
-    <div className="flex flex-col gap-1.5" data-testid="stats-cost-resolved">
-      <h4 className="font-medium text-fg-2" style={{ fontSize: "11px" }}>
-        What PDO can price
-      </h4>
-      <div className="flex flex-col gap-1">
-        {resolved.map((row) => (
-          <div
-            key={row.key}
-            className="flex items-center justify-between rounded bg-bg-3 px-2 py-1 font-mono text-fg-3"
-            style={{ fontSize: "10.5px" }}
-            data-testid={`price-row-${row.key}`}
-          >
-            <span>{row.key}</span>
-            <span className="flex items-center gap-2">
-              <span
-                className="rounded bg-bg-4 px-1.5 py-0.5 text-fg-4"
-                data-testid={`price-row-tier-${row.key}`}
-              >
-                {row.tier}
-              </span>
-              <span className="text-fg-2">
-                ${row.input}/${row.output} /MTok
-              </span>
-            </span>
+    <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-4">
+      {aggregate.harnesses.map((metric) => (
+        <div
+          key={metric.harness}
+          className="rounded-md border border-line bg-bg-3 p-3"
+          data-testid={`stats-harness-card-${metric.harness}`}
+        >
+          <div className="mb-2 flex items-center gap-1.5 text-fg-3" style={{ fontSize: "10.5px" }}>
+            <span
+              className="h-2 w-2 rounded-full"
+              style={{ backgroundColor: harnessColor(metric.harness) }}
+            />
+            {metric.harness}
           </div>
-        ))}
-      </div>
+          <div className="font-mono text-fg" style={{ fontSize: "15px" }}>
+            {formatCostAmount(metric.usd, metric.partial, metric.estimated)}
+          </div>
+          <div className="mt-1 text-fg-4" style={{ fontSize: "10px" }}>
+            {metric.average_usd === null
+              ? "— avg"
+              : `${formatCostAmount(metric.average_usd, metric.partial, metric.estimated)} avg`}
+          </div>
+        </div>
+      ))}
     </div>
   );
 }
 
-function CostTab({ cost, error }: { cost: StatsCost | null; error: string | null }) {
-  if (error)
+function CostCell({
+  metric,
+  unit,
+}: {
+  metric: StatsHarnessCost | undefined;
+  unit: "Run" | "execution";
+}) {
+  if (!metric) return <span className="font-mono text-fg-4">—</span>;
+  const detail = coverage(metric, unit);
+  return (
+    <div className="flex flex-col items-end font-mono">
+      <span>{formatCostAmount(metric.usd, metric.partial, metric.estimated)}</span>
+      <Tooltip content={detail} side="top">
+        <button
+          type="button"
+          aria-label={detail}
+          className="text-fg-4 underline decoration-dotted underline-offset-2"
+          style={{ fontSize: "9.5px" }}
+        >
+          {metric.average_usd === null
+            ? "— avg"
+            : `${formatCostAmount(metric.average_usd, metric.partial, metric.estimated)} avg`}
+        </button>
+      </Tooltip>
+    </div>
+  );
+}
+
+function CostTable({
+  rows,
+  harnesses,
+  unit,
+  onOpen,
+}: {
+  rows: StatsCostEntity[];
+  harnesses: string[];
+  unit: "Run" | "execution";
+  onOpen?: (row: StatsCostEntity) => void;
+}) {
+  const sorted = [...rows].sort((a, b) => (b.usd ?? -1) - (a.usd ?? -1));
+  return (
+    <TooltipProvider>
+      <table className="w-full table-fixed text-left" style={{ fontSize: "11px" }}>
+        <thead className="text-fg-4">
+          <tr>
+            <th className="pb-2 font-medium">Name</th>
+            <th className="w-28 pb-2 text-right font-medium">Total</th>
+            {harnesses.map((harness) => (
+              <th key={harness} className="w-28 pb-2 text-right font-medium">
+                <span className="inline-flex items-center gap-1">
+                  <span
+                    className="h-2 w-2 rounded-full"
+                    style={{ backgroundColor: harnessColor(harness) }}
+                  />
+                  {harness}
+                </span>
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {sorted.map((row) => (
+            <tr
+              key={row.id}
+              className="border-t border-line text-fg-2"
+              tabIndex={0}
+              data-testid="stats-detail-row"
+            >
+              <td className="py-2 pr-2">
+                {onOpen ? (
+                  <button
+                    type="button"
+                    aria-label={`Open ${row.name}`}
+                    onClick={() => onOpen(row)}
+                    className="text-left hover:text-fg"
+                  >
+                    {row.name}
+                  </button>
+                ) : (
+                  row.name
+                )}
+              </td>
+              <td className="py-2 text-right">
+                <CostCell
+                  unit={unit}
+                  metric={{
+                    harness: "total",
+                    usd: row.usd,
+                    estimated: row.estimated,
+                    partial: row.partial,
+                    executions: row.executions,
+                    readable: row.readable,
+                    unknown: row.unknown,
+                    average_usd: row.average_usd,
+                    unpriced_models: row.unpriced_models,
+                    missing_reasons: row.missing_reasons,
+                  }}
+                />
+              </td>
+              {harnesses.map((harness) => (
+                <td key={harness} className="py-2 text-right">
+                  <CostCell
+                    unit={unit}
+                    metric={row.harnesses.find((item) => item.harness === harness)}
+                  />
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </TooltipProvider>
+  );
+}
+
+function CostTab({
+  cost,
+  error,
+}: {
+  cost: StatsCost | null;
+  error: string | null;
+}) {
+  const [axis, setAxis] = useState<"pipeline" | "project">("pipeline");
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [drilledPipelineId, setDrilledPipelineId] = useState<string | null>(null);
+
+  if (error) {
     return (
-      <div
-        className="rounded-md border border-st-failed/30 bg-st-failed-bg px-3 py-2 text-st-failed"
-        style={{ fontSize: "11.5px" }}
-        data-testid="stats-cost-error"
-      >
+      <div className="rounded-md border border-st-failed/30 bg-st-failed-bg px-3 py-2 text-st-failed">
         {error}
       </div>
     );
-  // No synchronous loading flag (see useStats): null cost + no error = fetching.
+  }
   if (!cost) return <EmptyNote>Loading cost…</EmptyNote>;
 
-  const periodBars = cost.by_period.map((b) => ({ label: b.bucket, usd: b.usd }));
-  const hasSpend = cost.by_period.some((b) => b.usd > 0);
+  const rows = axis === "pipeline" ? cost.by_pipeline : cost.by_project;
+  const selected = rows.find((row) => row.id === selectedId) ?? null;
+  const drilledPipeline =
+    axis === "project" && selected
+      ? (selected as StatsProjectCostEntity).pipelines.find(
+          (pipeline) => pipeline.id === drilledPipelineId,
+        ) ?? null
+      : null;
+  const aggregate = drilledPipeline ?? selected ?? cost.total;
+  const periods = drilledPipeline
+    ? drilledPipeline.by_period
+    : selected
+      ? selected.by_period
+      : cost.by_period;
+  let detailRows: StatsCostEntity[];
+  let detailUnit: "Run" | "execution" = "Run";
+  let onOpen: ((row: StatsCostEntity) => void) | undefined;
+  if (drilledPipeline) {
+    detailRows = drilledPipeline.nodes;
+    detailUnit = "execution";
+  } else if (!selected) {
+    detailRows = axis === "project" ? cost.by_project : cost.by_pipeline;
+  } else if (axis === "project") {
+    detailRows = (selected as StatsProjectCostEntity).pipelines;
+    onOpen = (pipeline) => setDrilledPipelineId(pipeline.id);
+  } else {
+    detailRows = selected.nodes;
+    detailUnit = "execution";
+  }
 
   return (
-    <div className="flex flex-col gap-4" data-testid="stats-chart-cost">
-      <div className="text-fg-4" style={{ fontSize: "10.5px" }} data-testid="stats-cost-disclaimer">
-        Estimates from local Claude Code token usage × public list prices — not an invoice. A bucket
-        with any partial run is a lower bound (†); runs with no transcript are excluded (shown as —).
+    <div className="relative flex flex-col gap-4" data-testid="stats-chart-cost">
+      <div className="flex items-center justify-between gap-3">
+        <HarnessLegend harnesses={cost.harnesses} />
+        <select
+          aria-label="Cost grouping"
+          value={axis}
+          onChange={(event) => {
+            setAxis(event.target.value as "pipeline" | "project");
+            setSelectedId(null);
+            setDrilledPipelineId(null);
+          }}
+          className="rounded border border-line bg-bg-3 px-2 py-1 text-fg-2"
+        >
+          <option value="pipeline">By pipeline</option>
+          <option value="project">By project</option>
+        </select>
       </div>
-
-      {hasSpend && (
-        <ChartFrame>
-          <BarChart data={periodBars} margin={{ top: 8, right: 8, left: -8, bottom: 0 }}>
-            <CartesianGrid stroke={C.grid} strokeDasharray="3 3" vertical={false} />
-            <XAxis dataKey="label" {...AXIS_PROPS} />
-            <YAxis {...AXIS_PROPS} tickFormatter={(v) => `$${v}`} />
-            <RTooltip
-              contentStyle={{ background: "#161b22", border: `1px solid ${C.grid}`, fontSize: 11 }}
-              formatter={(value) => {
-                const v = typeof value === "number" ? value : Number(value) || 0;
-                return [`~$${v.toFixed(v < 1 ? 4 : 2)}`, "est. cost"];
-              }}
-            />
-            <Bar dataKey="usd" name="Est. cost" fill={C.cost} radius={[2, 2, 0, 0]} />
-          </BarChart>
-        </ChartFrame>
+      <div className="text-fg" data-testid="stats-selection-headline">
+        {formatCostAmount(aggregate.usd, aggregate.partial, aggregate.estimated)} total
+        {" · "}
+        {formatCostAmount(aggregate.average_usd, aggregate.partial, aggregate.estimated)} per Run
+      </div>
+      <HarnessCards aggregate={aggregate} />
+      {aggregate.unknown > 0 && (
+        <div className="text-st-await" style={{ fontSize: "10.5px" }}>
+          {aggregate.unknown} Run{aggregate.unknown === 1 ? "" : "s"} without computable cost
+        </div>
       )}
-
-      <CostSection
-        title="By period"
-        rows={cost.by_period.map((b) => ({ label: b.bucket, bucket: b }))}
-      />
-      <CostSection
-        title="By pipeline"
-        rows={cost.by_pipeline.map((b) => ({ label: b.key, bucket: b }))}
-      />
-      <CostSection
-        title="By project"
-        rows={cost.by_project.map((b) => ({ label: b.key, bucket: b }))}
-      />
-      <ResolvedPrices resolved={cost.resolved} />
+      <HarnessBars periods={periods} harnesses={cost.harnesses} value="usd" />
+      <div className="flex min-h-[240px] gap-4">
+        <MasterList
+          rows={rows}
+          selected={selectedId}
+          valueLabel={(row) => formatCostAmount(row.usd, row.partial, row.estimated)}
+          onSelect={(id) => {
+            setSelectedId(id);
+            setDrilledPipelineId(null);
+          }}
+        />
+        <div className="min-w-0 flex-1">
+          <div
+            className="mb-3 text-fg-4"
+            style={{ fontSize: "10.5px" }}
+            data-testid="stats-cost-breadcrumb"
+          >
+            Total{selected ? ` / ${selected.name}` : ""}
+            {drilledPipeline ? ` / ${drilledPipeline.name}` : ""}
+          </div>
+          <CostTable
+            rows={detailRows}
+            harnesses={cost.harnesses}
+            unit={detailUnit}
+            onOpen={onOpen}
+          />
+        </div>
+      </div>
     </div>
   );
 }
@@ -316,10 +626,15 @@ export interface StatsChartsProps {
   costError: string | null;
 }
 
-/** The chart surface for the active tab. Lazy-loaded (so recharts is code-split
- *  out of the main bundle). */
-export default function StatsCharts({ tab, overview, cost, costError }: StatsChartsProps) {
-  if (tab === "cost") return <CostTab cost={cost} error={costError} />;
+export default function StatsCharts({
+  tab,
+  overview,
+  cost,
+  costError,
+}: StatsChartsProps) {
+  if (tab === "cost") {
+    return <CostTab cost={cost} error={costError} />;
+  }
   if (!overview) return <EmptyNote>Loading…</EmptyNote>;
   if (tab === "runs") return <RunsTab overview={overview} />;
   if (tab === "sessions") return <SessionsTab overview={overview} />;

--- a/frontend/src/components/StatsCharts.tsx
+++ b/frontend/src/components/StatsCharts.tsx
@@ -198,7 +198,7 @@ function MasterList<T extends { id: string; name: string }>({
     <div
       role="listbox"
       aria-label="Spenders"
-      className="flex min-w-[250px] flex-col gap-1 border-r border-line pr-3"
+      className="flex flex-col gap-1"
       onKeyDown={(event) => {
         if (event.key === "ArrowDown" || event.key === "ArrowUp") {
           event.preventDefault();
@@ -256,12 +256,14 @@ function SessionsTab({ overview }: { overview: StatsOverview }) {
       <HarnessLegend harnesses={overview.session_harnesses} />
       <HarnessBars periods={periods} harnesses={overview.session_harnesses} value="executions" />
       <div className="flex min-h-[220px] gap-4">
-        <MasterList
-          rows={rows}
-          selected={selectedId}
-          valueLabel={(row) => String(row.executions)}
-          onSelect={setSelectedId}
-        />
+        <div className="min-w-[250px] border-r border-line pr-3">
+          <MasterList
+            rows={rows}
+            selected={selectedId}
+            valueLabel={(row) => String(row.executions)}
+            onSelect={setSelectedId}
+          />
+        </div>
         <div className="min-w-0 flex-1">
           <div className="mb-3 text-fg-4" style={{ fontSize: "10.5px" }}>
             Total{selected ? ` / ${selected.name}` : ""}
@@ -559,36 +561,29 @@ function CostTab({
   }
 
   return (
-    <div className="relative flex flex-col gap-4" data-testid="stats-chart-cost">
-      <div className="flex items-center justify-between gap-3">
-        <HarnessLegend harnesses={cost.harnesses} />
-        <select
-          aria-label="Cost grouping"
-          value={axis}
-          onChange={(event) => {
-            setAxis(event.target.value as "pipeline" | "project");
-            setSelectedId(null);
-            setDrilledPipelineId(null);
-          }}
-          className="rounded border border-line bg-bg-3 px-2 py-1 text-fg-2"
-        >
-          <option value="pipeline">By pipeline</option>
-          <option value="project">By project</option>
-        </select>
-      </div>
-      <div className="text-fg" data-testid="stats-selection-headline">
-        {formatCostAmount(aggregate.usd, aggregate.partial, aggregate.estimated)} total
-        {" · "}
-        {formatCostAmount(aggregate.average_usd, aggregate.partial, aggregate.estimated)} per Run
-      </div>
-      <HarnessCards aggregate={aggregate} />
-      {aggregate.unknown > 0 && (
-        <div className="text-st-await" style={{ fontSize: "10.5px" }}>
-          {aggregate.unknown} Run{aggregate.unknown === 1 ? "" : "s"} without computable cost
+    <div className="relative flex min-h-full" data-testid="stats-chart-cost">
+      <aside
+        className="w-[290px] shrink-0 border-r border-line pr-4"
+        data-testid="stats-drilldown-navigation"
+      >
+        <div className="mb-2 flex items-center justify-between gap-2">
+          <span className="text-fg-4" style={{ fontSize: "10.5px" }}>
+            Ranked by cost
+          </span>
+          <select
+            aria-label="Cost grouping"
+            value={axis}
+            onChange={(event) => {
+              setAxis(event.target.value as "pipeline" | "project");
+              setSelectedId(null);
+              setDrilledPipelineId(null);
+            }}
+            className="rounded border border-line bg-bg-3 px-2 py-1 text-fg-2"
+          >
+            <option value="pipeline">By pipeline</option>
+            <option value="project">By project</option>
+          </select>
         </div>
-      )}
-      <HarnessBars periods={periods} harnesses={cost.harnesses} value="usd" />
-      <div className="flex min-h-[240px] gap-4">
         <MasterList
           rows={rows}
           selected={selectedId}
@@ -598,15 +593,38 @@ function CostTab({
             setDrilledPipelineId(null);
           }}
         />
-        <div className="min-w-0 flex-1">
-          <div
-            className="mb-3 text-fg-4"
-            style={{ fontSize: "10.5px" }}
-            data-testid="stats-cost-breadcrumb"
-          >
-            Total{selected ? ` / ${selected.name}` : ""}
-            {drilledPipeline ? ` / ${drilledPipeline.name}` : ""}
+      </aside>
+
+      <div
+        className="min-w-0 flex-1 pl-5"
+        data-testid="stats-drilldown-detail"
+      >
+        <div
+          className="mb-3 text-fg-4"
+          style={{ fontSize: "10.5px" }}
+          data-testid="stats-cost-breadcrumb"
+        >
+          Total{selected ? ` / ${selected.name}` : ""}
+          {drilledPipeline ? ` / ${drilledPipeline.name}` : ""}
+        </div>
+        <HarnessLegend harnesses={cost.harnesses} />
+        <div className="mt-4 text-fg" data-testid="stats-selection-headline">
+          {formatCostAmount(aggregate.usd, aggregate.partial, aggregate.estimated)} total
+          {" · "}
+          {formatCostAmount(aggregate.average_usd, aggregate.partial, aggregate.estimated)} per Run
+        </div>
+        <div className="mt-4">
+          <HarnessCards aggregate={aggregate} />
+        </div>
+        {aggregate.unknown > 0 && (
+          <div className="mt-4 text-st-await" style={{ fontSize: "10.5px" }}>
+            {aggregate.unknown} Run{aggregate.unknown === 1 ? "" : "s"} without computable cost
           </div>
+        )}
+        <div className="mt-4">
+          <HarnessBars periods={periods} harnesses={cost.harnesses} value="usd" />
+        </div>
+        <div className="mt-4 min-h-[240px]">
           <CostTable
             rows={detailRows}
             harnesses={cost.harnesses}

--- a/frontend/src/components/StatsModal.test.tsx
+++ b/frontend/src/components/StatsModal.test.tsx
@@ -31,11 +31,32 @@ const OVERVIEW: StatsOverview = {
   runs: [{ bucket: "2026-07-30", count: 1 }],
   errors: [],
   sessions: [],
+  session_harnesses: [],
+  sessions_by_period: [],
+  sessions_by_pipeline: [],
   fires_by_pipeline: [],
   triggers_created_runs: { fired: 0, distinct_triggers: 0, enabled_triggers: 0 },
 };
 
-const COST: StatsCost = { by_period: [], by_pipeline: [], by_project: [], resolved: [] };
+const COST: StatsCost = {
+  harnesses: [],
+  total: {
+    usd: null,
+    average_usd: null,
+    estimated: true,
+    partial: false,
+    executions: 0,
+    readable: 0,
+    unknown: 0,
+    unpriced_models: [],
+    missing_reasons: [],
+    harnesses: [],
+  },
+  by_period: [],
+  by_pipeline: [],
+  by_project: [],
+  resolved: [],
+};
 
 function report(overrides: Partial<SyncCostPricesReport> = {}): SyncCostPricesReport {
   return {
@@ -57,6 +78,7 @@ async function openCostTab() {
   const user = userEvent.setup();
   render(<StatsModal open onClose={() => {}} />);
   await user.click(await screen.findByTestId("stats-tab-cost"));
+  await user.click(screen.getByTestId("stats-pricing-trigger"));
   return user;
 }
 
@@ -67,15 +89,16 @@ beforeEach(() => {
 });
 
 describe("StatsModal — price sync (#427, ADR-0034)", () => {
-  it("shows the Sync costs button only on the Cost tab", async () => {
+  it("keeps Sync costs inside the collapsed Pricing details panel", async () => {
     const user = userEvent.setup();
     render(<StatsModal open onClose={() => {}} />);
-    // Default tab is Runs: the table's staleness is not visible there, so neither is
-    // the button.
     expect(await screen.findByTestId("stats-tab-runs")).toBeInTheDocument();
     expect(screen.queryByTestId("stats-sync-prices")).not.toBeInTheDocument();
 
     await user.click(screen.getByTestId("stats-tab-cost"));
+    expect(screen.getByTestId("stats-pricing-trigger")).toBeInTheDocument();
+    expect(screen.queryByTestId("stats-sync-prices")).not.toBeInTheDocument();
+    await user.click(screen.getByTestId("stats-pricing-trigger"));
     expect(screen.getByTestId("stats-sync-prices")).toBeInTheDocument();
   });
 
@@ -90,6 +113,77 @@ describe("StatsModal — price sync (#427, ADR-0034)", () => {
     expect(box).toHaveTextContent("15 price row(s)");
     expect(screen.queryByTestId("stats-sync-noop")).not.toBeInTheDocument();
     expect(screen.queryByTestId("stats-sync-error")).not.toBeInTheDocument();
+  });
+
+  describe("StatsModal — full-screen Stats window (#638)", () => {
+    it("covers the application and exposes the four sections in a side rail", async () => {
+      render(<StatsModal open onClose={() => {}} />);
+
+      expect(await screen.findByTestId("stats-modal")).toHaveClass("h-screen", "w-screen");
+      const rail = screen.getByRole("tablist", { name: "Stats sections" });
+      expect(rail).toHaveClass("flex-col");
+      expect(screen.getAllByRole("tab")).toHaveLength(4);
+      expect(screen.getByRole("group", { name: "Period" })).toBeInTheDocument();
+    });
+
+    it("refreshes visible data without blanking it and advances the computed time", async () => {
+      const user = userEvent.setup();
+      render(<StatsModal open onClose={() => {}} />);
+      await waitFor(() => expect(fetchStatsOverviewMock).toHaveBeenCalledTimes(1));
+      expect(screen.getByTestId("stats-charts-stub")).toBeInTheDocument();
+      const before = screen.getByTestId("stats-computed-at").textContent;
+
+      await user.click(screen.getByTestId("stats-refresh"));
+      await waitFor(() => expect(fetchStatsOverviewMock).toHaveBeenCalledTimes(2));
+      expect(screen.getByTestId("stats-charts-stub")).toBeInTheDocument();
+      expect(screen.getByTestId("stats-computed-at")).toHaveTextContent(/Computed/);
+      expect(before).not.toBeNull();
+    });
+
+    it("closes Pricing details before closing Stats on Escape", async () => {
+      const user = userEvent.setup();
+      const onClose = vi.fn();
+      render(<StatsModal open onClose={onClose} />);
+      await user.click(screen.getByTestId("stats-tab-cost"));
+      await user.click(screen.getByTestId("stats-pricing-trigger"));
+      expect(screen.getByTestId("stats-pricing-details")).toBeInTheDocument();
+
+      await user.keyboard("{Escape}");
+      expect(screen.queryByTestId("stats-pricing-details")).not.toBeInTheDocument();
+      expect(onClose).not.toHaveBeenCalled();
+
+      await user.keyboard("{Escape}");
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it("lets an open coverage tooltip consume Escape before Stats", async () => {
+      const user = userEvent.setup();
+      const onClose = vi.fn();
+      const tooltip = document.createElement("div");
+      tooltip.dataset.testid = "tooltip-content";
+      tooltip.dataset.state = "delayed-open";
+      document.body.appendChild(tooltip);
+      render(<StatsModal open onClose={onClose} />);
+
+      await user.keyboard("{Escape}");
+      expect(onClose).not.toHaveBeenCalled();
+      tooltip.remove();
+    });
+
+    it("shows the resolved price table only inside Pricing details", async () => {
+      fetchStatsCostMock.mockResolvedValue({
+        ...COST,
+        resolved: [{ key: "claude-opus-5", tier: "fetched", input: 5, output: 25 }],
+      });
+      const user = userEvent.setup();
+      render(<StatsModal open onClose={() => {}} />);
+      await user.click(screen.getByTestId("stats-tab-cost"));
+      expect(screen.queryByText("claude-opus-5")).not.toBeInTheDocument();
+
+      await user.click(screen.getByTestId("stats-pricing-trigger"));
+      expect(await screen.findByText("claude-opus-5")).toBeInTheDocument();
+      expect(screen.getByText("$5/$25 /MTok")).toBeInTheDocument();
+    });
   });
 
   it("says when the manual tier shadows a fetched price", async () => {

--- a/frontend/src/components/StatsModal.tsx
+++ b/frontend/src/components/StatsModal.tsx
@@ -1,12 +1,10 @@
-import { Suspense, lazy, useEffect, useMemo, useState } from "react";
-import { X } from "lucide-react";
-import { useStats } from "../hooks/useStats";
+import { lazy, Suspense, useEffect, useMemo, useState } from "react";
+import { RotateCw, X } from "lucide-react";
 import { syncCostPrices } from "../api";
-import type { SyncCostPricesReport } from "../types";
+import { useStats } from "../hooks/useStats";
+import type { PriceRow, StatsCost, SyncCostPricesReport } from "../types";
 import type { StatsTab } from "./StatsCharts";
 
-// First `React.lazy` in the repo (#377): recharts is heavy, so StatsCharts (its
-// only importer) is code-split and loads when the modal first opens.
 const StatsCharts = lazy(() => import("./StatsCharts"));
 
 interface Props {
@@ -15,12 +13,6 @@ interface Props {
 }
 
 type Preset = "7d" | "30d" | "90d" | "all";
-
-interface Period {
-  from: string;
-  to: string;
-  bucket: string;
-}
 
 const PRESETS: { id: Preset; label: string }[] = [
   { id: "7d", label: "7 days" },
@@ -36,66 +28,162 @@ const TABS: { id: StatsTab; label: string }[] = [
   { id: "cost", label: "Cost" },
 ];
 
-/** UTC midnight of `d`, as an ISO-Z string — aligns with the daemon's UTC `ts`
- *  and its `strftime` day bucketing. */
-function utcDayStart(d: Date): string {
-  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate())).toISOString();
+function utcDayStart(date: Date): string {
+  return new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()),
+  ).toISOString();
 }
 
-/**
- * Resolve a preset to a half-open `[from, to)` window + a bucket granularity —
- * pure client-side view state (invariant #7: NOT `instance_config`). `to` is the
- * start of tomorrow (UTC) so all of today is included.
- */
-function presetPeriod(preset: Preset): Period {
+function presetPeriod(preset: Preset) {
   const now = new Date();
   const tomorrow = new Date(now);
   tomorrow.setUTCDate(tomorrow.getUTCDate() + 1);
-  const to = utcDayStart(tomorrow);
-
-  const daysAgo = (n: number): string => {
-    const d = new Date(now);
-    d.setUTCDate(d.getUTCDate() - n);
-    return utcDayStart(d);
+  const daysAgo = (days: number) => {
+    const date = new Date(now);
+    date.setUTCDate(date.getUTCDate() - days);
+    return utcDayStart(date);
   };
 
-  switch (preset) {
-    case "7d":
-      return { from: daysAgo(6), to, bucket: "day" };
-    case "30d":
-      return { from: daysAgo(29), to, bucket: "day" };
-    case "90d":
-      return { from: daysAgo(89), to, bucket: "week" };
-    case "all":
-      return { from: "1970-01-01T00:00:00.000Z", to, bucket: "month" };
-  }
+  if (preset === "7d") return { from: daysAgo(6), to: utcDayStart(tomorrow), bucket: "day" };
+  if (preset === "30d") return { from: daysAgo(29), to: utcDayStart(tomorrow), bucket: "day" };
+  if (preset === "90d") return { from: daysAgo(89), to: utcDayStart(tomorrow), bucket: "week" };
+  return {
+    from: "1970-01-01T00:00:00.000Z",
+    to: utcDayStart(tomorrow),
+    bucket: "month",
+  };
 }
 
-/**
- * Instance stats cockpit (#377, ADR-0029): a sister of SettingsModal, opened from
- * the TopBar. Cross-run aggregates filterable by period — runs/errors, node
- * sessions, trigger fires, and estimated cost (framed honestly). Two-endpoint
- * split: the overview loads on open; the cost tab lazily fetches `/stats/cost`
- * and code-splits recharts on first view.
- */
+function PriceRows({ rows }: { rows: PriceRow[] }) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      {rows.map((row) => (
+        <div
+          key={row.key}
+          className="flex items-center justify-between rounded bg-bg-3 px-2 py-1 font-mono text-fg-3"
+          style={{ fontSize: "10.5px" }}
+        >
+          <span>{row.key}</span>
+          <span>
+            <span className="mr-2 text-fg-4">{row.tier}</span>
+            <span className="text-fg-2">${row.input}/${row.output} /MTok</span>
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function SyncResult({ report }: { report: SyncCostPricesReport | null }) {
+  if (!report) return null;
+  if (report.noop) {
+    return (
+      <div className="text-fg-4" data-testid="stats-sync-noop">
+        {report.reason ?? "Price table already up to date."}
+      </div>
+    );
+  }
+  return (
+    <div
+      className="rounded-md border border-st-await/40 bg-st-await/10 px-3 py-2 text-fg-2"
+      data-testid="stats-sync-report"
+    >
+      <div>
+        {report.rows} price row(s) from <span className="font-mono">{report.source}</span>
+        {report.fetched_at ? ` at ${report.fetched_at}` : ""}.
+      </div>
+      <ul className="list-disc pl-4">
+        {report.added.length > 0 && <li>Newly priced: {report.added.join(", ")}</li>}
+        {report.updated.length > 0 && <li>Price changed: {report.updated.join(", ")}</li>}
+        {report.shadowed_by_manual.length > 0 && (
+          <li>
+            Kept from your <span className="font-mono">models.yaml</span> (overrides the fetched
+            price): {report.shadowed_by_manual.join(", ")}
+          </li>
+        )}
+        {report.rejected.length > 0 && <li>Refused by the source: {report.rejected.join("; ")}</li>}
+      </ul>
+    </div>
+  );
+}
+
+function PricingDetails({
+  cost,
+  syncing,
+  syncError,
+  syncReport,
+  onSync,
+}: {
+  cost: StatsCost | null;
+  syncing: boolean;
+  syncError: string | null;
+  syncReport: SyncCostPricesReport | null;
+  onSync: () => void;
+}) {
+  const warnings = cost
+    ? [...cost.total.unpriced_models, ...cost.total.missing_reasons]
+    : [];
+  return (
+    <aside
+      className="absolute inset-y-0 right-0 z-20 w-[min(420px,90vw)] overflow-y-auto border-l border-line bg-bg-4 p-4 shadow-2xl"
+      data-testid="stats-pricing-details"
+    >
+      <div className="mb-4 flex items-center justify-between">
+        <h3 className="font-semibold text-fg">Pricing details</h3>
+        <button
+          type="button"
+          onClick={onSync}
+          disabled={syncing}
+          data-testid="stats-sync-prices"
+          className="rounded-md border border-line-strong bg-bg-3 px-2 py-1 text-fg-2 disabled:opacity-40"
+        >
+          {syncing ? "Syncing…" : "Sync costs"}
+        </button>
+      </div>
+      <div className="flex flex-col gap-3" style={{ fontSize: "10.5px" }}>
+        {syncError && (
+          <div
+            className="rounded-md border border-st-failed/30 bg-st-failed-bg px-3 py-2 text-st-failed"
+            data-testid="stats-sync-error"
+          >
+            {syncError}
+          </div>
+        )}
+        <SyncResult report={syncReport} />
+        {warnings.map((warning) => (
+          <div key={warning} className="text-st-await">
+            {warning}
+          </div>
+        ))}
+        {cost?.resolved.length ? (
+          <PriceRows rows={cost.resolved} />
+        ) : (
+          <div className="text-fg-4">No resolved prices.</div>
+        )}
+      </div>
+    </aside>
+  );
+}
+
 export default function StatsModal({ open, onClose }: Props) {
   const [preset, setPreset] = useState<Preset>("30d");
   const [tab, setTab] = useState<StatsTab>("runs");
-  const period = useMemo(() => presetPeriod(preset), [preset]);
-
-  // Price sync (#427, ADR-0034). The triplet mirrors
-  // `guardTest`/`guardTesting`/`guardTestError` in TriggerDetailPanel — there is no
-  // global toast system in this app (the one mention of the word is a "no toast"
-  // comment), so every component renders its own message inline.
+  const [pricingOpen, setPricingOpen] = useState(false);
+  const [reloadKey, setReloadKey] = useState(0);
   const [syncReport, setSyncReport] = useState<SyncCostPricesReport | null>(null);
   const [syncing, setSyncing] = useState(false);
   const [syncError, setSyncError] = useState<string | null>(null);
-  // Bumped after a successful sync so `useStats` refetches `/stats/cost`. Without
-  // it the numbers would not move until the period changed: the button would have
-  // repaired the table and lied about it.
-  const [reloadKey, setReloadKey] = useState(0);
+  const period = useMemo(() => presetPeriod(preset), [preset]);
 
-  const { overview, cost, error, costError } = useStats(
+  const {
+    overview,
+    cost,
+    error,
+    costError,
+    computedAt,
+    overviewReloadKey,
+    costReloadKey,
+  } = useStats(
     open,
     period.from,
     period.to,
@@ -104,6 +192,33 @@ export default function StatsModal({ open, onClose }: Props) {
     reloadKey,
   );
 
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key !== "Escape" || event.defaultPrevented) return;
+      if (
+        document.querySelector(
+          '[data-testid="tooltip-content"][data-state="delayed-open"], [data-testid="tooltip-content"][data-state="instant-open"]',
+        )
+      ) {
+        return;
+      }
+      if (pricingOpen) setPricingOpen(false);
+      else onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onClose, pricingOpen]);
+
+  if (!open) return null;
+
+  const refreshing =
+    overviewReloadKey !== reloadKey || (tab === "cost" && costReloadKey !== reloadKey);
+
+  const refresh = () => {
+    setReloadKey((value) => value + 1);
+  };
+
   const onSyncPrices = async () => {
     setSyncing(true);
     setSyncError(null);
@@ -111,189 +226,149 @@ export default function StatsModal({ open, onClose }: Props) {
     try {
       const report = await syncCostPrices();
       setSyncReport(report);
-      // Even a noop bumps: the user asked, and a refetch is the honest confirmation
-      // that what they see is current.
-      setReloadKey((k) => k + 1);
-    } catch (e) {
-      setSyncError(e instanceof Error ? e.message : String(e));
+      setReloadKey((value) => value + 1);
+    } catch (cause) {
+      setSyncError(cause instanceof Error ? cause.message : String(cause));
     } finally {
       setSyncing(false);
     }
   };
 
-  // Escape-to-close (grafted from MarkdownArtifactModal — SettingsModal lacks it).
-  useEffect(() => {
-    if (!open) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [open, onClose]);
-
-  if (!open) return null;
-
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-      onClick={onClose}
-    >
-      <div
-        className="flex max-h-[85vh] w-[720px] flex-col rounded-lg border border-line bg-bg-4 shadow-xl"
-        onClick={(e) => e.stopPropagation()}
-        data-testid="stats-modal"
-      >
-        {/* Header */}
-        <div className="flex items-center justify-between border-b border-line px-4 py-3">
-          <h2 className="font-semibold text-fg" style={{ fontSize: "13.5px" }}>
-            Stats
-          </h2>
-          <button
-            onClick={onClose}
-            aria-label="Close stats"
-            className="grid h-6 w-6 place-items-center rounded text-fg-3 transition-colors hover:bg-bg-5 hover:text-fg"
-          >
-            <X size={14} />
-          </button>
-        </div>
-
-        {/* Period picker + tabs */}
-        <div className="flex flex-col gap-2 border-b border-line px-4 py-3">
+    <div className="fixed inset-0 z-50 bg-bg-2">
+      <div className="relative flex h-screen w-screen flex-col bg-bg-4" data-testid="stats-modal">
+        <header className="flex min-h-14 items-center gap-4 border-b border-line px-4">
+          <h2 className="font-semibold text-fg">Stats</h2>
           <div className="flex items-center gap-1" role="group" aria-label="Period">
-            {PRESETS.map((p) => (
+            {PRESETS.map((item) => (
               <button
-                key={p.id}
+                key={item.id}
                 type="button"
-                aria-pressed={preset === p.id}
-                data-testid={`stats-period-${p.id}`}
-                onClick={() => setPreset(p.id)}
-                className={`rounded-md border px-2.5 py-1 transition-colors ${
-                  preset === p.id
+                aria-pressed={preset === item.id}
+                data-testid={`stats-period-${item.id}`}
+                onClick={() => setPreset(item.id)}
+                className={`rounded-md border px-2.5 py-1 ${
+                  preset === item.id
                     ? "border-acc bg-acc/15 text-fg"
-                    : "border-line-strong bg-bg-3 text-fg-2 hover:bg-bg-4"
+                    : "border-line-strong bg-bg-3 text-fg-2"
                 }`}
                 style={{ fontSize: "11px" }}
               >
-                {p.label}
+                {item.label}
               </button>
             ))}
           </div>
-          <div className="flex items-center gap-1" role="tablist" aria-label="Stats sections">
-            {TABS.map((t) => (
+          <div
+            className="ml-auto text-fg-4"
+            style={{ fontSize: "10.5px" }}
+            data-testid="stats-computed-at"
+          >
+            {computedAt
+              ? `Computed ${computedAt.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}`
+              : "Computing…"}
+          </div>
+          <button
+            type="button"
+            onClick={refresh}
+            disabled={refreshing}
+            data-testid="stats-refresh"
+            className="flex items-center gap-1.5 rounded border border-line bg-bg-3 px-2 py-1 text-fg-2 disabled:opacity-60"
+          >
+            <RotateCw size={12} className={refreshing ? "animate-spin" : ""} />
+            Refresh
+          </button>
+          {tab === "cost" && (
+            <button
+              type="button"
+              onClick={() => setPricingOpen(true)}
+              data-testid="stats-pricing-trigger"
+              className="rounded border border-line bg-bg-3 px-2 py-1 text-fg-2"
+            >
+              Pricing details
+              {cost && cost.total.unpriced_models.length + cost.total.missing_reasons.length > 0
+                ? ` (${cost.total.unpriced_models.length + cost.total.missing_reasons.length})`
+                : ""}
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close stats"
+            className="grid h-7 w-7 place-items-center rounded text-fg-3 hover:bg-bg-5"
+          >
+            <X size={15} />
+          </button>
+        </header>
+
+        <div className="flex min-h-0 flex-1">
+          <nav
+            className="flex w-36 shrink-0 flex-col gap-1 border-r border-line bg-bg-3 p-3"
+            role="tablist"
+            aria-label="Stats sections"
+            onKeyDown={(event) => {
+              if (event.key !== "ArrowDown" && event.key !== "ArrowUp") return;
+              event.preventDefault();
+              const index = TABS.findIndex((item) => item.id === tab);
+              const delta = event.key === "ArrowDown" ? 1 : -1;
+              const next = TABS[(index + delta + TABS.length) % TABS.length];
+              setTab(next.id);
+              document.querySelector<HTMLElement>(`[data-testid='stats-tab-${next.id}']`)?.focus();
+            }}
+          >
+            {TABS.map((item) => (
               <button
-                key={t.id}
+                key={item.id}
                 type="button"
                 role="tab"
-                aria-selected={tab === t.id}
-                data-testid={`stats-tab-${t.id}`}
-                onClick={() => setTab(t.id)}
-                className={`rounded-md px-2.5 py-1 transition-colors ${
-                  tab === t.id ? "bg-bg-5 text-fg" : "text-fg-3 hover:bg-bg-3 hover:text-fg-2"
+                aria-selected={tab === item.id}
+                tabIndex={tab === item.id ? 0 : -1}
+                data-testid={`stats-tab-${item.id}`}
+                onClick={() => {
+                  setTab(item.id);
+                  if (item.id !== "cost") setPricingOpen(false);
+                }}
+                className={`rounded px-3 py-2 text-left ${
+                  tab === item.id ? "bg-bg-5 text-fg" : "text-fg-3 hover:bg-bg-4"
                 }`}
-                style={{ fontSize: "11.5px" }}
               >
-                {t.label}
+                {item.label}
               </button>
             ))}
-            {/* Price sync (#427). Only on the Cost tab — the one place the table's
-                staleness is visible — and pushed right with `ml-auto`. It lives here
-                rather than in StatsCharts because that component is lazy and strictly
-                presentational, with no access to the refetch; StatsModal owns
-                `useStats`. Style copied from TriggerDetailPanel's "Test guard". */}
-            {tab === "cost" && (
-              <button
-                type="button"
-                onClick={onSyncPrices}
-                disabled={syncing}
-                data-testid="stats-sync-prices"
-                title="Fetch public model prices and refresh the local price table"
-                className="ml-auto flex items-center gap-1.5 rounded-md border border-line-strong bg-bg-3 px-2 py-1 font-medium text-fg-2 transition-colors hover:bg-bg-4 disabled:opacity-40"
-                style={{ fontSize: "10.5px" }}
+          </nav>
+
+          <main className={`min-w-0 flex-1 overflow-y-auto p-5 ${refreshing ? "opacity-65" : ""}`}>
+            {error && (
+              <div
+                className="mb-3 rounded-md border border-st-failed/30 bg-st-failed-bg px-3 py-2 text-st-failed"
+                data-testid="stats-error"
               >
-                {syncing ? "Syncing…" : "Sync costs"}
-              </button>
+                {error}
+              </div>
             )}
-          </div>
+            <Suspense
+              fallback={
+                <div
+                  className="min-h-[220px] px-1 py-8 text-center text-fg-4"
+                  data-testid="stats-charts-loading"
+                >
+                  Loading charts…
+                </div>
+              }
+            >
+              <StatsCharts tab={tab} overview={overview} cost={cost} costError={costError} />
+            </Suspense>
+          </main>
         </div>
 
-        {/* Body */}
-        <div className="min-h-[260px] flex-1 overflow-y-auto px-4 py-4">
-          {error && (
-            <div
-              className="mb-3 rounded-md border border-st-failed/30 bg-st-failed-bg px-3 py-2 text-st-failed"
-              style={{ fontSize: "11.5px" }}
-              data-testid="stats-error"
-            >
-              {error}
-            </div>
-          )}
-          {/* #427: a failed sync NAMES the source (the daemon answers 502 with the
-              URL) — ADR-0030's rule that an explicitly requested effect which fails
-              is a hard error, never a silent fallback. */}
-          {syncError && (
-            <div
-              className="mb-3 rounded-md border border-st-failed/30 bg-st-failed-bg px-3 py-2 text-st-failed"
-              style={{ fontSize: "11.5px" }}
-              data-testid="stats-sync-error"
-            >
-              {syncError}
-            </div>
-          )}
-          {syncReport?.noop && (
-            <div
-              className="mb-3 text-fg-4"
-              style={{ fontSize: "10.5px" }}
-              data-testid="stats-sync-noop"
-            >
-              {syncReport.reason ?? "Price table already up to date."}
-            </div>
-          )}
-          {syncReport && !syncReport.noop && (
-            <div
-              className="mb-3 rounded-md border border-st-await/40 bg-st-await/10 px-3 py-2 text-fg-2"
-              style={{ fontSize: "10.5px" }}
-              data-testid="stats-sync-report"
-            >
-              <div>
-                {syncReport.rows} price row(s) from{" "}
-                <span className="font-mono">{syncReport.source}</span>
-                {syncReport.fetched_at ? ` at ${syncReport.fetched_at}` : ""}.
-              </div>
-              <ul className="list-disc pl-4">
-                {syncReport.added.length > 0 && (
-                  <li>Newly priced: {syncReport.added.join(", ")}</li>
-                )}
-                {syncReport.updated.length > 0 && (
-                  <li>Price changed: {syncReport.updated.join(", ")}</li>
-                )}
-                {/* Said, never hidden: a sync cannot silently erase a hand edit. */}
-                {syncReport.shadowed_by_manual.length > 0 && (
-                  <li>
-                    Kept from your <span className="font-mono">models.yaml</span>{" "}
-                    (overrides the fetched price):{" "}
-                    {syncReport.shadowed_by_manual.join(", ")}
-                  </li>
-                )}
-                {syncReport.rejected.length > 0 && (
-                  <li>Refused by the source: {syncReport.rejected.join("; ")}</li>
-                )}
-              </ul>
-            </div>
-          )}
-          <Suspense
-            fallback={
-              <div
-                className="px-1 py-8 text-center text-fg-4"
-                style={{ fontSize: "11.5px" }}
-                data-testid="stats-charts-loading"
-              >
-                Loading charts…
-              </div>
-            }
-          >
-            <StatsCharts tab={tab} overview={overview} cost={cost} costError={costError} />
-          </Suspense>
-        </div>
+        {pricingOpen && (
+          <PricingDetails
+            cost={cost}
+            syncing={syncing}
+            syncError={syncError}
+            syncReport={syncReport}
+            onSync={onSyncPrices}
+          />
+        )}
       </div>
     </div>
   );

--- a/frontend/src/hooks/useStats.test.ts
+++ b/frontend/src/hooks/useStats.test.ts
@@ -14,11 +14,32 @@ const OVERVIEW: StatsOverview = {
   runs: [{ bucket: "2026-07-15", count: 2 }],
   errors: [],
   sessions: [],
+  session_harnesses: [],
+  sessions_by_period: [],
+  sessions_by_pipeline: [],
   fires_by_pipeline: [],
   triggers_created_runs: { fired: 0, distinct_triggers: 0, enabled_triggers: 1 },
 };
 
-const COST: StatsCost = { by_period: [], by_pipeline: [], by_project: [], resolved: [] };
+const COST: StatsCost = {
+  harnesses: [],
+  total: {
+    usd: null,
+    average_usd: null,
+    estimated: true,
+    partial: false,
+    executions: 0,
+    readable: 0,
+    unknown: 0,
+    unpriced_models: [],
+    missing_reasons: [],
+    harnesses: [],
+  },
+  by_period: [],
+  by_pipeline: [],
+  by_project: [],
+  resolved: [],
+};
 
 beforeEach(() => {
   vi.mocked(api.fetchStatsOverview).mockReset().mockResolvedValue(OVERVIEW);
@@ -51,6 +72,20 @@ describe("useStats (#377)", () => {
     rerender({ costActive: true });
     await waitFor(() => expect(result.current.cost).toEqual(COST));
     expect(api.fetchStatsCost).toHaveBeenCalledWith("F", "T", "day");
+  });
+
+  it("does not refetch cost when returning from another section", async () => {
+    const { rerender } = renderHook(
+      ({ costActive }) => useStats(true, "F", "T", "day", costActive),
+      { initialProps: { costActive: true } },
+    );
+    await waitFor(() => expect(api.fetchStatsCost).toHaveBeenCalledTimes(1));
+
+    rerender({ costActive: false });
+    rerender({ costActive: true });
+    await Promise.resolve();
+
+    expect(api.fetchStatsCost).toHaveBeenCalledTimes(1);
   });
 
   it("refetches overview when the period changes", async () => {

--- a/frontend/src/hooks/useStats.ts
+++ b/frontend/src/hooks/useStats.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { fetchStatsOverview, fetchStatsCost } from "../api";
 import type { StatsOverview, StatsCost } from "../types";
 
@@ -34,6 +34,11 @@ export function useStats(
   const [cost, setCost] = useState<StatsCost | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [costError, setCostError] = useState<string | null>(null);
+  const [computedAt, setComputedAt] = useState<Date | null>(null);
+  const [overviewReloadKey, setOverviewReloadKey] = useState(0);
+  const [costReloadKey, setCostReloadKey] = useState(0);
+  const costRequestKey = `${from}\u0000${to}\u0000${bucket}\u0000${reloadKey}`;
+  const requestedCostKey = useRef<string | null>(null);
 
   // Overview: eager on open + on every period change.
   useEffect(() => {
@@ -44,10 +49,15 @@ export function useStats(
         if (!cancelled) {
           setOverview(data);
           setError(null);
+          setComputedAt(new Date());
+          setOverviewReloadKey(reloadKey);
         }
       })
       .catch((e) => {
-        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+        if (!cancelled) {
+          setError(e instanceof Error ? e.message : String(e));
+          setOverviewReloadKey(reloadKey);
+        }
       });
     return () => {
       cancelled = true;
@@ -57,21 +67,32 @@ export function useStats(
   // Cost: lazy — only once the cost tab is active, then on period change too.
   useEffect(() => {
     if (!open || !costActive) return;
-    let cancelled = false;
+    if (requestedCostKey.current === costRequestKey) return;
+    requestedCostKey.current = costRequestKey;
     fetchStatsCost(from, to, bucket)
       .then((data) => {
-        if (!cancelled) {
+        if (requestedCostKey.current === costRequestKey) {
           setCost(data);
           setCostError(null);
+          setComputedAt(new Date());
+          setCostReloadKey(reloadKey);
         }
       })
       .catch((e) => {
-        if (!cancelled) setCostError(e instanceof Error ? e.message : String(e));
+        if (requestedCostKey.current === costRequestKey) {
+          setCostError(e instanceof Error ? e.message : String(e));
+          setCostReloadKey(reloadKey);
+        }
       });
-    return () => {
-      cancelled = true;
-    };
-  }, [open, costActive, from, to, bucket, reloadKey]);
+  }, [open, costActive, from, to, bucket, reloadKey, costRequestKey]);
 
-  return { overview, cost, error, costError };
+  return {
+    overview,
+    cost,
+    error,
+    costError,
+    computedAt,
+    overviewReloadKey,
+    costReloadKey,
+  };
 }

--- a/frontend/src/lib/costLabel.test.ts
+++ b/frontend/src/lib/costLabel.test.ts
@@ -1,9 +1,5 @@
 import { describe, it, expect } from "vitest";
-import {
-  costPrecision,
-  formatEstCost,
-  formatBucketCost,
-} from "./costLabel";
+import { costPrecision, formatCostAmount, formatEstCost } from "./costLabel";
 
 describe("costPrecision", () => {
   it("uses 4 decimals below $1 and 2 at or above", () => {
@@ -11,6 +7,14 @@ describe("costPrecision", () => {
     expect(costPrecision(0.999)).toBe(4);
     expect(costPrecision(1)).toBe(2);
     expect(costPrecision(12.5)).toBe(2);
+  });
+
+  describe("formatCostAmount (#638)", () => {
+    it("distinguishes derived estimates from reported cost", () => {
+      expect(formatCostAmount(2, false, true)).toBe("~$2.00");
+      expect(formatCostAmount(2, false, false)).toBe("$2.00");
+      expect(formatCostAmount(null, false, false)).toBe("—");
+    });
   });
 });
 
@@ -74,60 +78,5 @@ describe("formatEstCost (single run, #272)", () => {
     expect(c.title).toMatch(/harnesses .* have no cost source/);
     // Not framed as a lower bound — there is no figure at all.
     expect(c.title).not.toContain("claude-fable-5");
-  });
-});
-
-describe("formatBucketCost (aggregate, #377)", () => {
-  it("sums a plain bucket with no partial/null contributions", () => {
-    const c = formatBucketCost(3.4, 0, 0, 2);
-    expect(c.text).toBe("~$3.40");
-    expect(c.dagger).toBe(false);
-    expect(c.empty).toBe(false);
-    expect(c.title).toMatch(/estimate/i);
-    expect(c.title).not.toMatch(/lower bound/i);
-    expect(c.title).not.toMatch(/no transcript/i);
-  });
-
-  it("marks a bucket with a partial run as a lower bound and counts it", () => {
-    const c = formatBucketCost(5.0, 1, 0, 3);
-    expect(c.dagger).toBe(true);
-    expect(c.text).toBe("~$5.00");
-    expect(c.title).toMatch(/lower bound/i);
-    expect(c.title).toMatch(/1 partial run\b/);
-  });
-
-  it("names the unioned unpriced models alongside the partial-run count (#425)", () => {
-    const c = formatBucketCost(5.0, 2, 0, 4, ["claude-fable-5", "claude-sonnet-5"]);
-    expect(c.dagger).toBe(true);
-    expect(c.title).toMatch(/lower bound/i);
-    expect(c.title).toContain("claude-fable-5");
-    expect(c.title).toContain("claude-sonnet-5");
-    expect(c.title).toMatch(/2 partial runs/);
-  });
-
-  it("pluralises partial run count", () => {
-    expect(formatBucketCost(5.0, 2, 0, 4).title).toMatch(/2 partial runs/);
-  });
-
-  it("surfaces null-cost runs in the tooltip without inflating the figure", () => {
-    const c = formatBucketCost(2.0, 0, 1, 3);
-    expect(c.text).toBe("~$2.00");
-    expect(c.empty).toBe(false);
-    expect(c.title).toMatch(/1 run had no transcript \(excluded\)/);
-  });
-
-  it("renders — (never $0) for a bucket with no priced runs (all null)", () => {
-    const c = formatBucketCost(0, 0, 3, 3);
-    expect(c.text).toBe("—");
-    expect(c.empty).toBe(true);
-    expect(c.text).not.toContain("$");
-    // The tooltip still explains why it is empty.
-    expect(c.title).toMatch(/3 runs had no transcript/);
-  });
-
-  it("renders — for a bucket with no runs at all", () => {
-    const c = formatBucketCost(0, 0, 0, 0);
-    expect(c.text).toBe("—");
-    expect(c.empty).toBe(true);
   });
 });

--- a/frontend/src/lib/costLabel.ts
+++ b/frontend/src/lib/costLabel.ts
@@ -12,6 +12,17 @@ export function costPrecision(usd: number): number {
   return usd < 1 ? 4 : 2;
 }
 
+/** Cost text shared by aggregate cells for derived and harness-reported values. */
+export function formatCostAmount(
+  usd: number | null,
+  partial: boolean,
+  estimated: boolean,
+): string {
+  if (usd === null) return "—";
+  const amount = `$${usd.toFixed(costPrecision(usd))}`;
+  return `${estimated ? `~${amount}` : amount}${partial ? "†" : ""}`;
+}
+
 /** Base note framing any cost figure as an estimate (matches `/estimate/i`). */
 export const COST_ESTIMATE_NOTE =
   "Estimate from local Claude Code token usage × public list prices — not an invoice.";
@@ -88,51 +99,5 @@ export function formatEstCost(
     text: `~$${usd.toFixed(costPrecision(usd))}`,
     dagger: partial,
     title: COST_ESTIMATE_NOTE + (partial ? lowerBoundClause(unpricedModels) : ""),
-  };
-}
-
-export interface CostBucketLabel extends CostLabel {
-  /** Nothing priced (no runs, or every run lacked a transcript) → render `—`. */
-  empty: boolean;
-}
-
-function plural(n: number, word: string): string {
-  return `${n} ${word}${n === 1 ? "" : "s"}`;
-}
-
-/**
- * Format an aggregated cost bucket (#377). A bucket is a **sum of lower bounds**:
- *
- * - any `partial` run makes the whole bucket a lower bound (`†`), and the
- *   excluded model family keys are named when known (#425);
- * - runs with no transcript (`nullCount`) are excluded from `usd` but surfaced
- *   in the tooltip so the bucket is never silently undercounted;
- * - a bucket with nothing priced (`runs === 0`, or every run was null) renders
- *   `—`, never `$0` (a wrong number, not a placeholder).
- */
-export function formatBucketCost(
-  usd: number,
-  partialCount: number,
-  nullCount: number,
-  runs: number,
-  unpricedModels: string[] = [],
-): CostBucketLabel {
-  const priced = runs - nullCount;
-  const empty = priced <= 0;
-  const partial = partialCount > 0;
-
-  let title = COST_ESTIMATE_NOTE;
-  if (partial) {
-    title += lowerBoundClause(unpricedModels, ` (${plural(partialCount, "partial run")}).`);
-  }
-  if (nullCount > 0) {
-    title += ` ${plural(nullCount, "run")} had no transcript (excluded).`;
-  }
-
-  return {
-    text: empty ? "—" : `~$${usd.toFixed(costPrecision(usd))}`,
-    dagger: partial,
-    title,
-    empty,
   };
 }

--- a/frontend/src/lib/harness.test.ts
+++ b/frontend/src/lib/harness.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { harnessColor } from "./harness";
+
+describe("harnessColor (#638)", () => {
+  it("pins Copilot blue and Claude orange", () => {
+    expect(harnessColor("copilot")).toBe("#58a6ff");
+    expect(harnessColor("claude")).toBe("#f0883e");
+  });
+
+  it("assigns a stable colour to a future harness", () => {
+    expect(harnessColor("future-harness")).toBe(harnessColor("future-harness"));
+    expect(harnessColor("future-harness")).not.toBe(harnessColor("another-harness"));
+  });
+});

--- a/frontend/src/lib/harness.ts
+++ b/frontend/src/lib/harness.ts
@@ -11,6 +11,25 @@ import type { HarnessDescriptorsView, NodeDef } from "../types";
 /** The floor of the precedence chain — a node with no pin runs on `claude`. */
 export const HARNESS_FLOOR = "claude";
 
+const PINNED_HARNESS_COLORS: Record<string, string> = {
+  copilot: "#58a6ff",
+  claude: "#f0883e",
+};
+
+/** Stable series colour shared by every harness visualization. */
+export function harnessColor(name: string): string {
+  const normalized = name.trim().toLowerCase();
+  const pinned = PINNED_HARNESS_COLORS[normalized];
+  if (pinned) return pinned;
+
+  let hash = 2166136261;
+  for (const char of normalized) {
+    hash ^= char.codePointAt(0) ?? 0;
+    hash = Math.imul(hash, 16777619);
+  }
+  return `hsl(${(hash >>> 0) % 360} 64% 58%)`;
+}
+
 /** One harness as the picker offers it (#586): its name and whether its binary is
  *  installed (an uninstalled harness renders greyed and non-selectable). */
 export interface HarnessOption {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1140,32 +1140,77 @@ export interface StatsOverview {
   errors: StatsBucketCount[];
   /** `node_started` starts (re-spawns and loop laps included, manager excluded). */
   sessions: StatsBucketCount[];
+  /** Harness columns active in the selected Run cohort. */
+  session_harnesses: string[];
+  /** Session starts split by harness for the stacked chart. */
+  sessions_by_period: StatsSessionPeriod[];
+  /** Pipeline → Node session hierarchy. */
+  sessions_by_pipeline: StatsSessionEntity[];
   fires_by_pipeline: StatsPipelineFireCount[];
   triggers_created_runs: StatsTriggersCreatedRuns;
 }
 
-/** A cost breakdown row. Cost is a **sum of lower bounds**: `partial` runs and
- *  `null` runs (no transcript, excluded from `usd`) are counted separately so
- *  the number is never silently undercounted (ADR-0001 / ADR-0022). */
-export interface StatsCostBucket {
-  usd: number;
-  /** Runs whose cost is a lower bound (an unpriced model was excluded). */
-  partial: number;
-  /** Runs with no transcript, excluded from `usd` but surfaced. */
-  null: number;
-  /** Total runs folded here (priced + partial + null). */
-  runs: number;
-  /** Union of the family keys no tier priced across this bucket's partial runs,
-   *  sorted + de-duplicated (#425 AC#4). Empty ⟺ `partial === 0`. */
-  unpriced_models: string[];
+export interface StatsSessionHarness {
+  harness: string;
+  executions: number;
 }
 
-export interface StatsCostPeriodBucket extends StatsCostBucket {
+export interface StatsSessionPeriod {
+  bucket: string;
+  harnesses: StatsSessionHarness[];
+}
+
+export interface StatsSessionEntity {
+  id: string;
+  name: string;
+  executions: number;
+  harnesses: StatsSessionHarness[];
+  by_period: StatsSessionPeriod[];
+  nodes: StatsSessionEntity[];
+}
+
+/** One harness's cost and denominator coverage within an aggregate. */
+export interface StatsHarnessCost {
+  harness: string;
+  /** Null means no readable contribution, never zero. */
+  usd: number | null;
+  estimated: boolean;
+  partial: boolean;
+  executions: number;
+  readable: number;
+  unknown: number;
+  average_usd: number | null;
+  unpriced_models: string[];
+  missing_reasons: string[];
+}
+
+/** Cost shared by Total, periods, Projects, Pipelines and Nodes. */
+export interface StatsCostAggregate {
+  usd: number | null;
+  average_usd: number | null;
+  estimated: boolean;
+  partial: boolean;
+  executions: number;
+  readable: number;
+  unknown: number;
+  unpriced_models: string[];
+  missing_reasons: string[];
+  harnesses: StatsHarnessCost[];
+}
+
+export interface StatsCostPeriod extends StatsCostAggregate {
   bucket: string;
 }
 
-export interface StatsCostKeyBucket extends StatsCostBucket {
-  key: string;
+export interface StatsCostEntity extends StatsCostAggregate {
+  id: string;
+  name: string;
+  by_period: StatsCostPeriod[];
+  nodes: StatsCostEntity[];
+}
+
+export interface StatsProjectCostEntity extends StatsCostEntity {
+  pipelines: StatsCostEntity[];
 }
 
 /** One resolved price row (#528): a family, the tier that decides it, the price in
@@ -1182,9 +1227,11 @@ export interface PriceRow {
 }
 
 export interface StatsCost {
-  by_period: StatsCostPeriodBucket[];
-  by_pipeline: StatsCostKeyBucket[];
-  by_project: StatsCostKeyBucket[];
+  harnesses: string[];
+  total: StatsCostAggregate;
+  by_period: StatsCostPeriod[];
+  by_pipeline: StatsCostEntity[];
+  by_project: StatsProjectCostEntity[];
   /** The resolved price table, one row per family in alphabetical order (#528).
    *  Window-independent — a property of the price table, not the fold. Refreshed
    *  by the "Sync costs" refetch on the Cost tab. */


### PR DESCRIPTION
## Summary

- aggregate Sessions and Cost by harness across Runs, Pipelines, Projects, Nodes, and infrastructure
- replace Stats with the approved full-screen drill-down layout and pricing details slide-over
- preserve honest unknown/lower-bound costs, stable harness colors, explicit refresh, and historical attribution
- bump the daemon to 1.38.0

## Validation

- `make build`
- `make test`
- Feature Path: pass (10/10, no findings)

Closes #638
