### PR TITLE
feat(stats): compare context and duration by harness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "1.42.0"
+version = "1.43.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "1.42.0"
+version = "1.43.0"
 license = "MIT"
 description = "Prompt-Driven Orchestrator — a local daemon that runs and supervises agentic coding pipelines"
 repository = "https://github.com/Loulen/prompt-driven-orchestrator"

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ PDO ships these harnesses compiled in. **Launching, attaching, resuming and comp
 | **End of turn** | Complete a node by itself when its turn ends. Absent ⇒ the agent runs `pdo complete`, or you do | ✅ an injected `Stop` hook, plus the transcript tail as the sweep's fallback | ❌ | ✅ the journal's explicit `assistant.turn_end` event |
 | **Usage-limit menu** | Notice a session parked on the harness's usage-limit menu (informational, no recovery) | ✅ the interactive "wait for limit to reset" menu, matched in a pane capture | ❌ | ❌ |
 | **Sandbox staging floor** | Hold a sandboxed session's staged home — credentials, settings, pre-granted trust | ✅ a staged `.claude` home — credentials, org managed settings, pre-granted trust | ❌ | ❌ |
+| **Context usage** | Measure a session's context-window peak, in tokens, for Stats → Performance (#585). Absent ⇒ no Context column for the harness, never an invented reading | ✅ derived — per-turn token usage from the transcript, deduplicated and maxed | ❌ | ✅ derived — the journal's cumulative usage counters, converted to a per-turn contribution and maxed |
 
 The version beside each harness is the **last validated** one — the build PDO's knowledge of that harness was measured against. It is a documented bound, not a guard: PDO launches on whatever version you have installed and says nothing about the difference. It is written down because the same harness can sit on one machine twice, months apart, with different event schemas and different model lists — and an inventory taken against the wrong install is worse than no inventory.
 
@@ -93,10 +94,11 @@ Why a capability is absent:
 | `opencode` | End of turn | It exposes no end-of-turn signal PDO can read: its argv template carries no `{settings}` hole for a `Stop` hook, and it has no transcript for a sweep to tail (see above). |
 | `opencode` | Usage-limit menu | The menu wording is `claude`'s. Matching another harness's pane against it would invent a state, and the probe triggers no recovery anyway (ADR-0012). |
 | `opencode` | Sandbox staging floor | Configuring a harness is a documented prerequisite, not PDO code. A sandboxed Run on it holds by your image and the profile's `$HOME` exceptions, and PDO says so once, visibly. |
+| `opencode` | Context usage | Its own SQLite reports token usage in four buckets that do not map onto `claude`'s (see Cost above), and it carries no transcript PDO can tail (see Transcript above) — a context peak is code, written per harness (#585), and nobody has written that code yet. |
 | `copilot` | Usage-limit menu | The menu wording is `claude`'s, its own documentation admits the textual anchor drifts each release, and the probe triggers no recovery (ADR-0012). Declaring it absent degrades nothing actionable. |
 | `copilot` | Sandbox staging floor | Configuring a harness is a documented prerequisite, not PDO code (ADR-0031). A sandboxed Run on it holds by your image and the profile's `$HOME` exceptions, and PDO says so once, visibly. |
 
-A harness **you** declare in `~/.pdo/harnesses/descriptors.yaml` carries no code, so it is absent on all five — it still launches, attaches, resumes, and completes when its agent runs `pdo complete`. That is a legitimate way to run a harness, not a broken one.
+A harness **you** declare in `~/.pdo/harnesses/descriptors.yaml` carries no code, so it is absent on all six — it still launches, attaches, resumes, and completes when its agent runs `pdo complete`. That is a legitimate way to run a harness, not a broken one.
 
 <!-- support-table:end -->
 

--- a/crates/pdo-daemon/src/context_peak.rs
+++ b/crates/pdo-daemon/src/context_peak.rs
@@ -1,0 +1,444 @@
+//! Harness-specific context-window **peak** parsing (#585, Stats → Performance).
+//!
+//! A session's context peak is the maximum "occupancy" any one of its turns
+//! reached — never a percentage, never converted through a model's context-window
+//! catalogue (explicitly out of scope, see the issue's "Out of Scope" §1/§2). Each
+//! harness reports occupancy in its own shape, so each gets its own parser; there
+//! is no generic "usage" struct shared across them (ADR-0051: a capability is
+//! code, written harness by harness, never a shared heuristic).
+//!
+//! Both parsers are **pure**: transcript/journal text in, `Option<u64>` tokens
+//! out. No I/O, no clock — the caller ([`crate::stats_performance`]) resolves the
+//! file and injects its bytes, exactly like [`crate::run_cost`] and
+//! [`crate::copilot_journal`] already do for cost.
+//!
+//! ## Claude (#585 Implementation Decisions §"Pour Claude")
+//!
+//! A turn's occupancy is `input_tokens` (non-cache) + `cache_read_input_tokens` +
+//! `cache_creation_input_tokens` (both the 5m/1h buckets) + `output_tokens` — the
+//! same four cache/input buckets [`crate::run_cost`] costs, plus the turn's own
+//! output. Unlike cost, which **sums** every line, a context peak takes the
+//! **max**: each assistant message already carries the *whole* conversation's
+//! current window occupancy (Claude's `input_tokens`/cache fields are not
+//! per-message deltas — they are the full context sent for that turn), so the
+//! largest single turn IS the session's peak.
+//!
+//! Messages replayed on resume/compaction are deduplicated by `(message.id,
+//! requestId)` before the max is taken — **the same dedup key** `run_cost`'s
+//! `aggregate` uses for cost, because a replayed message is not a second, larger
+//! turn; counting it twice would let a resume/compaction artefact invent a peak
+//! that never happened.
+//!
+//! ## Copilot (#585 Implementation Decisions §"Pour Copilot")
+//!
+//! Copilot's `session.usage_checkpoint` / `session.shutdown` events (the same two
+//! kinds [`crate::copilot_journal::reported_cost_usd`] reads) carry a `usage`
+//! object whose `inputTokens` / `outputTokens` fields are **cumulative since
+//! session start** — mirroring `totalNanoAiu`'s own cumulative semantics. Two
+//! rules the issue is explicit about:
+//!
+//! - `inputTokens` **already includes** whatever the journal separately reports
+//!   as cache (`cacheReadTokens` / `cacheCreationTokens`), so those two buckets are
+//!   read for information only and are **never added again** — doing so would
+//!   double-count the cache.
+//! - the cumulative counters are converted to their **per-turn contribution**
+//!   (this reading minus the previous one) before the max is sought — the
+//!   cumulative *total* grows monotonically and would otherwise always crown the
+//!   session's LAST turn as its peak, whatever that turn actually occupied.
+//!
+//! A turn's occupancy is then `Δ inputTokens + Δ outputTokens` for that
+//! checkpoint. The session's peak is the max across all such deltas.
+
+use serde_json::Value;
+
+// --- Claude ------------------------------------------------------------------
+
+/// One assistant message's dedup key and context occupancy — the same four
+/// cache/input buckets [`crate::run_cost`]'s `Usage` costs, plus output, folded
+/// into a single total rather than costed.
+struct ClaudeTurn {
+    message_id: Option<String>,
+    request_id: Option<String>,
+    occupancy: u64,
+}
+
+/// Parse one Claude transcript line into a [`ClaudeTurn`], or `None` to skip it —
+/// tolerant of torn/invalid JSON, `<synthetic>` messages, and non-assistant lines,
+/// mirroring `run_cost::parse_line`'s tolerance exactly (a session transcript is
+/// external input, never trusted to be well-formed).
+fn parse_claude_line(raw: &str) -> Option<ClaudeTurn> {
+    let v: Value = serde_json::from_str(raw).ok()?;
+    if v.get("type").and_then(|t| t.as_str()) != Some("assistant") {
+        return None;
+    }
+    if v.get("isApiErrorMessage").and_then(|b| b.as_bool()) == Some(true) {
+        return None;
+    }
+    let msg = v.get("message")?;
+    let model = msg.get("model").and_then(|m| m.as_str())?;
+    if model == "<synthetic>" {
+        return None;
+    }
+    let usage = msg.get("usage")?;
+    let field = |k: &str| usage.get(k).and_then(|x| x.as_u64()).unwrap_or(0);
+    let input = field("input_tokens");
+    let output = field("output_tokens");
+    let cache_read = field("cache_read_input_tokens");
+    let (cache_create_5m, cache_create_1h) = match usage.get("cache_creation") {
+        Some(cc) => (
+            cc.get("ephemeral_5m_input_tokens")
+                .and_then(|x| x.as_u64())
+                .unwrap_or(0),
+            cc.get("ephemeral_1h_input_tokens")
+                .and_then(|x| x.as_u64())
+                .unwrap_or(0),
+        ),
+        None => (field("cache_creation_input_tokens"), 0),
+    };
+    let occupancy = input + output + cache_read + cache_create_5m + cache_create_1h;
+    if occupancy == 0 {
+        return None;
+    }
+    Some(ClaudeTurn {
+        message_id: msg.get("id").and_then(|x| x.as_str()).map(String::from),
+        request_id: v
+            .get("requestId")
+            .and_then(|x| x.as_str())
+            .map(String::from),
+        occupancy,
+    })
+}
+
+/// The session's context peak, in tokens — the maximum per-turn occupancy across
+/// every **deduplicated** assistant message in `text` (a Claude JSONL transcript,
+/// main session or subagent — the parser is the same either way, ADR-0051's "a
+/// capability is proper to the harness", not to the role). `None` when the
+/// transcript carries no readable usage at all — never `Some(0)`, so an absent
+/// reading is never mistaken for a session that used no context.
+pub(crate) fn claude_session_peak(text: &str) -> Option<u64> {
+    let mut seen = std::collections::HashSet::new();
+    text.lines()
+        .filter_map(parse_claude_line)
+        .filter(|turn| {
+            match &turn.message_id {
+                Some(id) => seen.insert((id.clone(), turn.request_id.clone())),
+                // No id to dedup on: never collapsed with another line.
+                None => true,
+            }
+        })
+        .map(|turn| turn.occupancy)
+        .max()
+}
+
+/// The `[start, end]` wall-clock span covered by every top-level `"timestamp"`
+/// field found across `text`'s lines (a Claude JSONL transcript) — the "reliable
+/// start/end bounds" #585's subagent-duration user story asks for, since a
+/// subagent has no `node_started`/`node_completed` pair of its own (only its
+/// parent Node does). Both timestamps are the transcript's own RFC-3339 strings,
+/// unparsed here: the caller ([`crate::stats_performance`]) already owns
+/// `chrono` diffing for every other duration in Performance, so this stays a
+/// pure string min/max, not a second date library entry point.
+///
+/// `None` when not a single line carries a readable `timestamp` — the caller
+/// reports a motivated absence rather than inventing a duration (#585 explicitly
+/// forbids inventing a subagent duration without reliable bounds).
+pub(crate) fn claude_transcript_time_span(text: &str) -> Option<(String, String)> {
+    let mut min: Option<String> = None;
+    let mut max: Option<String> = None;
+    for raw in text.lines() {
+        let Ok(value) = serde_json::from_str::<Value>(raw) else {
+            continue;
+        };
+        let Some(ts) = value.get("timestamp").and_then(|t| t.as_str()) else {
+            continue;
+        };
+        if min.as_deref().is_none_or(|m| ts < m) {
+            min = Some(ts.to_string());
+        }
+        if max.as_deref().is_none_or(|m| ts > m) {
+            max = Some(ts.to_string());
+        }
+    }
+    min.zip(max)
+}
+
+// --- Copilot -------------------------------------------------------------------
+
+/// One `usage` reading off a Copilot journal event — cumulative since session
+/// start, exactly like `totalNanoAiu`.
+struct CopilotReading {
+    input: u64,
+    output: u64,
+}
+
+fn parse_copilot_usage(value: &Value) -> Option<CopilotReading> {
+    let usage = value.get("data")?.get("usage")?;
+    let input = usage.get("inputTokens").and_then(|v| v.as_u64())?;
+    let output = usage
+        .get("outputTokens")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    Some(CopilotReading { input, output })
+}
+
+/// The session's context peak, in tokens — the maximum per-turn occupancy across
+/// every `session.usage_checkpoint` / `session.shutdown` reading in `journal`.
+/// Each reading is **cumulative**, so occupancy is the delta from the previous
+/// reading (the first reading's delta is against a zero baseline); `inputTokens`
+/// already includes whatever the journal separately reports as cache, so only
+/// `inputTokens` and `outputTokens` are read — `cacheReadTokens` /
+/// `cacheCreationTokens`, if present, are never added a second time. `None` when
+/// the journal carries no usage reading at all.
+pub(crate) fn copilot_session_peak(journal: &str) -> Option<u64> {
+    let mut prev_input = 0u64;
+    let mut prev_output = 0u64;
+    let mut peak: Option<u64> = None;
+    for raw in journal.lines() {
+        let raw = raw.trim();
+        if raw.is_empty() {
+            continue;
+        }
+        let Ok(value) = serde_json::from_str::<Value>(raw) else {
+            continue;
+        };
+        let ty = value.get("type").and_then(|t| t.as_str()).unwrap_or("");
+        if ty != "session.usage_checkpoint" && ty != "session.shutdown" {
+            continue;
+        }
+        let Some(reading) = parse_copilot_usage(&value) else {
+            continue;
+        };
+        // Cumulative counters never legitimately shrink; a shrink would only mean
+        // a new session reused the same journal path — clamp at 0 rather than
+        // underflow or invent a negative turn.
+        let delta =
+            reading.input.saturating_sub(prev_input) + reading.output.saturating_sub(prev_output);
+        prev_input = reading.input;
+        prev_output = reading.output;
+        peak = Some(peak.map_or(delta, |p: u64| p.max(delta)));
+    }
+    peak
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- Claude --------------------------------------------------------------
+
+    fn claude_line(
+        id: &str,
+        request: &str,
+        input: u64,
+        output: u64,
+        cache_read: u64,
+        cache_5m: u64,
+    ) -> String {
+        serde_json::json!({
+            "type": "assistant",
+            "requestId": request,
+            "message": {
+                "id": id,
+                "model": "claude-opus-4-8",
+                "usage": {
+                    "input_tokens": input,
+                    "output_tokens": output,
+                    "cache_read_input_tokens": cache_read,
+                    "cache_creation": { "ephemeral_5m_input_tokens": cache_5m, "ephemeral_1h_input_tokens": 0 }
+                }
+            }
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn claude_peak_is_the_largest_turns_four_bucket_sum_plus_output() {
+        // Three turns, non-monotonic sizes: the peak is turn 2's sum
+        // (400+50+300+0 = 750), not the last turn nor a running total.
+        let text = format!(
+            "{}\n{}\n{}\n",
+            claude_line("m1", "r1", 100, 20, 50, 0),
+            claude_line("m2", "r2", 400, 50, 300, 0),
+            claude_line("m3", "r3", 100, 10, 100, 0),
+        );
+        assert_eq!(claude_session_peak(&text), Some(750));
+    }
+
+    #[test]
+    fn claude_dedup_keeps_the_replayed_message_from_inflating_the_peak() {
+        // The same (message.id, requestId) written twice (resume/compaction
+        // replay, ADR-0022) must count once — the peak must not double it.
+        let one_turn = claude_line("m1", "r1", 400, 50, 300, 0);
+        let replayed = format!("{one_turn}\n{one_turn}\n");
+        assert_eq!(claude_session_peak(&replayed), Some(750));
+        // A second, larger turn after the replay still wins on its own merits.
+        let text = format!("{replayed}{}\n", claude_line("m2", "r2", 900, 10, 0, 0));
+        assert_eq!(claude_session_peak(&text), Some(910));
+    }
+
+    #[test]
+    fn claude_peak_is_absent_without_message_id_dedup_key_but_still_counted() {
+        // A line without `message.id` has no dedup key: it is never collapsed
+        // with another line (never seen twice in practice, but must not panic
+        // or silently vanish).
+        let raw = serde_json::json!({
+            "type": "assistant",
+            "requestId": "r1",
+            "message": { "model": "claude-opus-4-8", "usage": { "input_tokens": 10, "output_tokens": 5 } }
+        })
+        .to_string();
+        assert_eq!(claude_session_peak(&format!("{raw}\n")), Some(15));
+    }
+
+    #[test]
+    fn claude_peak_is_none_on_no_readable_usage() {
+        assert_eq!(claude_session_peak(""), None);
+        assert_eq!(claude_session_peak("not json\n"), None);
+        // A synthetic message (compaction summary) carries no real usage.
+        let synthetic = serde_json::json!({
+            "type": "assistant",
+            "message": { "model": "<synthetic>", "usage": { "input_tokens": 999 } }
+        })
+        .to_string();
+        assert_eq!(claude_session_peak(&format!("{synthetic}\n")), None);
+    }
+
+    #[test]
+    fn claude_peak_reused_for_a_subagent_transcript() {
+        // #585: a subagent transcript is read by the exact same parser as the
+        // parent's — the peak has no notion of "role", only of turns.
+        let text = claude_line("sub-1", "r1", 200, 30, 0, 0);
+        assert_eq!(claude_session_peak(&format!("{text}\n")), Some(230));
+    }
+
+    // --- Claude time span ------------------------------------------------------
+
+    fn claude_line_at(id: &str, ts: &str) -> String {
+        serde_json::json!({
+            "type": "assistant",
+            "timestamp": ts,
+            "requestId": "r",
+            "message": { "id": id, "model": "claude-opus-4-8", "usage": { "input_tokens": 1 } }
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn claude_time_span_is_the_min_and_max_timestamp_out_of_order() {
+        // Lines out of chronological order (a subagent transcript is not
+        // guaranteed sorted by wall clock) — min/max, not first/last line.
+        let text = format!(
+            "{}\n{}\n{}\n",
+            claude_line_at("m1", "2026-01-01T00:00:05Z"),
+            claude_line_at("m2", "2026-01-01T00:00:01Z"),
+            claude_line_at("m3", "2026-01-01T00:00:09Z"),
+        );
+        assert_eq!(
+            claude_transcript_time_span(&text),
+            Some((
+                "2026-01-01T00:00:01Z".to_string(),
+                "2026-01-01T00:00:09Z".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn claude_time_span_degenerates_to_a_single_instant_for_one_line() {
+        let text = claude_line_at("m1", "2026-01-01T00:00:05Z");
+        assert_eq!(
+            claude_transcript_time_span(&format!("{text}\n")),
+            Some((
+                "2026-01-01T00:00:05Z".to_string(),
+                "2026-01-01T00:00:05Z".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn claude_time_span_is_none_without_a_single_readable_timestamp() {
+        assert_eq!(claude_transcript_time_span(""), None);
+        assert_eq!(claude_transcript_time_span("not json\n"), None);
+        let no_ts = serde_json::json!({
+            "type": "assistant",
+            "message": { "id": "m1", "model": "claude-opus-4-8", "usage": { "input_tokens": 1 } }
+        })
+        .to_string();
+        assert_eq!(claude_transcript_time_span(&format!("{no_ts}\n")), None);
+    }
+
+    // --- Copilot ---------------------------------------------------------------
+
+    fn checkpoint(input: u64, output: u64, cache_read: u64) -> String {
+        serde_json::json!({
+            "type": "session.usage_checkpoint",
+            "data": {
+                "totalNanoAiu": 1,
+                "usage": {
+                    "inputTokens": input,
+                    "outputTokens": output,
+                    "cacheReadTokens": cache_read,
+                    "cacheCreationTokens": 0
+                }
+            }
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn copilot_peak_converts_cumulative_counters_to_a_per_turn_contribution() {
+        // Two turns: cumulative inputTokens grows 500 -> 1300 (turn 2 alone added
+        // 800), outputTokens grows 100 -> 260 (turn 2 added 160). Turn 1's own
+        // contribution (500 + 100 = 600) is smaller than turn 2's (800 + 160 =
+        // 960) — the max must be turn 2's contribution, not the final cumulative
+        // total (1300 + 260 = 1560), which a naive "read the last checkpoint"
+        // would wrongly report.
+        let journal = format!(
+            "{}\n{}\n",
+            checkpoint(500, 100, 0),
+            checkpoint(1300, 260, 0)
+        );
+        assert_eq!(copilot_session_peak(&journal), Some(960));
+    }
+
+    #[test]
+    fn copilot_peak_never_double_counts_cache_already_inside_input_tokens() {
+        // `inputTokens` already includes the cache; a naive parser that also adds
+        // `cacheReadTokens` would inflate the peak past what actually occupied the
+        // window. A single turn: inputTokens=1000 (which already covers the 400
+        // reported as cache) + outputTokens=50 => peak must be 1050, not 1450.
+        let journal = checkpoint(1000, 50, 400);
+        assert_eq!(copilot_session_peak(&format!("{journal}\n")), Some(1050));
+    }
+
+    #[test]
+    fn copilot_peak_first_checkpoint_deltas_against_a_zero_baseline() {
+        let journal = checkpoint(700, 80, 0);
+        assert_eq!(copilot_session_peak(&format!("{journal}\n")), Some(780));
+    }
+
+    #[test]
+    fn copilot_peak_reads_shutdown_as_a_reading_too() {
+        let shutdown = serde_json::json!({
+            "type": "session.shutdown",
+            "data": { "totalNanoAiu": 1, "usage": { "inputTokens": 300, "outputTokens": 20 } }
+        })
+        .to_string();
+        assert_eq!(copilot_session_peak(&format!("{shutdown}\n")), Some(320));
+    }
+
+    #[test]
+    fn copilot_peak_is_none_on_no_readable_usage() {
+        assert_eq!(copilot_session_peak(""), None);
+        assert_eq!(copilot_session_peak("garbage\n"), None);
+        let no_usage =
+            serde_json::json!({ "type": "assistant.turn_end", "data": { "turnId": "0" } })
+                .to_string();
+        assert_eq!(copilot_session_peak(&format!("{no_usage}\n")), None);
+    }
+
+    #[test]
+    fn copilot_peak_tolerant_of_torn_lines() {
+        let torn = format!("{{not json\n{}\ngarbage\n", checkpoint(500, 100, 0));
+        assert_eq!(copilot_session_peak(&torn), Some(600));
+    }
+}

--- a/crates/pdo-daemon/src/distribution.rs
+++ b/crates/pdo-daemon/src/distribution.rs
@@ -1,0 +1,142 @@
+//! R-7 six-number distribution summary (#585, Stats → Performance).
+//!
+//! Every Performance boxplot cell is backed by the same six statistics — mean,
+//! median, Q1, Q3, min, max — computed once here rather than once per caller
+//! (Node, Pipeline, Infrastructure role, subagent group all fold through this).
+//! Quartiles use **R-7** (linear interpolation between closest ranks — R's
+//! default `quantile()` type, and Excel/NumPy's default), per the issue's
+//! Implementation Decisions: "Les quartiles utilisent l'interpolation linéaire
+//! R-7." A one-value sample is valid and yields six identical statistics (the
+//! issue's explicit acceptance criterion), not a degenerate `None`.
+//!
+//! Pure, allocation-light, no I/O: `&[f64]` in, `Option<SixStats>` out. `None`
+//! only for an empty sample — the caller (never this module) turns "no readable
+//! values" into a coverage/absence-reasons pair; a distribution itself does not
+//! know why a value is missing, only how many there were.
+
+/// The six statistics one boxplot cell renders: the box (Q1–Q3), the median
+/// line, the mean dot, and the whiskers (min/max).
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize)]
+pub(crate) struct SixStats {
+    pub mean: f64,
+    pub median: f64,
+    pub q1: f64,
+    pub q3: f64,
+    pub min: f64,
+    pub max: f64,
+}
+
+/// The R-7 quantile of `sorted` (already sorted ascending, non-empty) at
+/// probability `p` ∈ [0, 1]: linear interpolation between the two closest ranks.
+/// `h = (n - 1) * p` is the fractional rank; the integer part indexes the lower
+/// value, the fractional part interpolates toward the next one. A single-value
+/// sample has `n - 1 == 0`, so `h` is always `0` and every quantile collapses to
+/// that one value — the "valid boxplot from one observation" acceptance
+/// criterion falls out of the formula, no special case needed.
+fn r7_quantile(sorted: &[f64], p: f64) -> f64 {
+    let n = sorted.len();
+    if n == 1 {
+        return sorted[0];
+    }
+    let h = (n - 1) as f64 * p;
+    let lo = h.floor() as usize;
+    let hi = (lo + 1).min(n - 1);
+    let frac = h - lo as f64;
+    sorted[lo] + frac * (sorted[hi] - sorted[lo])
+}
+
+/// Fold `values` (unordered, any finite `f64`) into the six R-7 statistics, or
+/// `None` if `values` is empty. NaN/infinite inputs are the caller's bug (a
+/// parsed token count is always a non-negative finite integer promoted to
+/// `f64`) — this function does not defend against them beyond the sort not
+/// panicking (`f64::total_cmp`).
+pub(crate) fn r7_distribution(values: &[f64]) -> Option<SixStats> {
+    if values.is_empty() {
+        return None;
+    }
+    let mut sorted = values.to_vec();
+    sorted.sort_by(f64::total_cmp);
+    let mean = sorted.iter().sum::<f64>() / sorted.len() as f64;
+    Some(SixStats {
+        mean,
+        median: r7_quantile(&sorted, 0.5),
+        q1: r7_quantile(&sorted, 0.25),
+        q3: r7_quantile(&sorted, 0.75),
+        min: sorted[0],
+        max: *sorted.last().expect("non-empty"),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn close(a: f64, b: f64) -> bool {
+        (a - b).abs() < 1e-9
+    }
+
+    #[test]
+    fn r7_on_an_asymmetric_odd_sample() {
+        // Values chosen to make mean, median and quartiles all distinct, so a
+        // test that swaps two of them fails loudly.
+        let values = [2.0, 5.0, 5.0, 9.0, 100.0, 3.0, 7.0];
+        let stats = r7_distribution(&values).unwrap();
+        assert!(close(stats.mean, 18.714_285_714_285_715), "{stats:?}");
+        assert!(close(stats.median, 5.0), "{stats:?}");
+        assert!(close(stats.q1, 4.0), "{stats:?}");
+        assert!(close(stats.q3, 8.0), "{stats:?}");
+        assert_eq!(stats.min, 2.0);
+        assert_eq!(stats.max, 100.0);
+    }
+
+    #[test]
+    fn r7_on_an_even_sample_interpolates_between_the_two_middle_ranks() {
+        let values = [10.0, 20.0, 30.0, 40.0];
+        let stats = r7_distribution(&values).unwrap();
+        assert!(close(stats.q1, 17.5), "{stats:?}");
+        assert!(close(stats.median, 25.0), "{stats:?}");
+        assert!(close(stats.q3, 32.5), "{stats:?}");
+        assert_eq!(stats.min, 10.0);
+        assert_eq!(stats.max, 40.0);
+        assert!(close(stats.mean, 25.0));
+    }
+
+    #[test]
+    fn r7_is_order_independent() {
+        let ordered = [1.0, 2.0, 3.0, 4.0, 5.0];
+        let shuffled = [4.0, 1.0, 5.0, 3.0, 2.0];
+        assert_eq!(r7_distribution(&ordered), r7_distribution(&shuffled));
+    }
+
+    #[test]
+    fn a_single_value_sample_is_a_valid_boxplot_of_six_identical_values() {
+        // #585 AC: "Un échantillon d'une valeur produit un boxplot valide" — all
+        // six statistics equal that one value, not a `None`/degenerate cell.
+        let stats = r7_distribution(&[42.0]).unwrap();
+        assert_eq!(
+            stats,
+            SixStats {
+                mean: 42.0,
+                median: 42.0,
+                q1: 42.0,
+                q3: 42.0,
+                min: 42.0,
+                max: 42.0,
+            }
+        );
+    }
+
+    #[test]
+    fn an_empty_sample_has_no_distribution() {
+        assert_eq!(r7_distribution(&[]), None);
+    }
+
+    #[test]
+    fn two_value_sample_interpolates_quartiles_toward_the_endpoints() {
+        let stats = r7_distribution(&[0.0, 10.0]).unwrap();
+        // n=2: h(0.25) = 0.25, h(0.75) = 0.75 — quartiles sit inside the pair.
+        assert!(close(stats.q1, 2.5), "{stats:?}");
+        assert!(close(stats.median, 5.0), "{stats:?}");
+        assert!(close(stats.q3, 7.5), "{stats:?}");
+    }
+}

--- a/crates/pdo-daemon/src/harness_probes.rs
+++ b/crates/pdo-daemon/src/harness_probes.rs
@@ -188,6 +188,42 @@ impl UsageLimitAnchor {
     }
 }
 
+/// How PDO measures a harness's **context-window peak** — the maximum per-turn
+/// occupancy a session reached, in tokens (#585, Stats → Performance). A
+/// marker, not the parser itself: [`crate::context_peak`] holds the actual
+/// per-harness token math, so this enum can never describe a mechanism that
+/// module does not implement.
+///
+/// Absent ⇒ Performance shows no Context column for this harness at all (it
+/// never invents a boxplot from a metric it cannot read).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ContextUsageSource {
+    /// Claude Code's per-message `usage` (input + both cache buckets + output),
+    /// deduplicated across resume/compaction replays, maxed over the session's
+    /// turns — [`crate::context_peak::claude_session_peak`].
+    ClaudeTranscriptPeak,
+    /// GitHub Copilot's event journal `usage` readings, converted from their
+    /// cumulative-since-session-start counters to a per-turn contribution before
+    /// the max is sought — [`crate::context_peak::copilot_session_peak`].
+    CopilotJournalPeak,
+}
+
+impl ContextUsageSource {
+    /// How this source reads in the published support table. See
+    /// [`CostSource::label`] for why the label sits on the variant.
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            ContextUsageSource::ClaudeTranscriptPeak => {
+                "derived — per-turn token usage from the transcript, deduplicated and maxed"
+            }
+            ContextUsageSource::CopilotJournalPeak => {
+                "derived — the journal's cumulative usage counters, converted to a per-turn \
+                 contribution and maxed"
+            }
+        }
+    }
+}
+
 /// The sandbox staging floor a harness guarantees (ADR-0031).
 ///
 /// Absent ⇒ a sandboxed Run on this harness holds only by the user's image and
@@ -239,6 +275,11 @@ pub(crate) trait HarnessProbes: Sync {
     /// The sandbox staging floor, or `None` (a sandboxed Run says its absence
     /// once).
     fn staging_floor(&self) -> Option<StagingFloor> {
+        None
+    }
+    /// The context-usage source, or `None` (Performance shows no Context column
+    /// for this harness). #585.
+    fn context_usage_source(&self) -> Option<ContextUsageSource> {
         None
     }
 
@@ -305,6 +346,48 @@ pub(crate) trait HarnessProbes: Sync {
     fn classify_hard_error(&self, _tail: &str) -> Option<String> {
         None
     }
+
+    /// This harness's context-window peak for one transcript/journal's `text`, in
+    /// tokens (#585). The default is `None` — a harness with no
+    /// [`Self::context_usage_source`] never reaches a parser at all, so
+    /// `crate::stats_performance` never has to name `claude`'s or `copilot`'s
+    /// parser itself (that was exactly the ADR-0051 regression: a generic caller
+    /// `match`ing on the harness string to pick a parsing function). `claude`
+    /// dispatches to [`crate::context_peak::claude_session_peak`], `copilot` to
+    /// [`crate::context_peak::copilot_session_peak`] — each pure, injected text
+    /// in, `Option<u64>` out.
+    fn context_peak(&self, _text: &str) -> Option<u64> {
+        None
+    }
+
+    /// This session's own **subagent** transcripts — declared-group discovery
+    /// under one main session, for Stats → Performance's subagent breakdown
+    /// (#585, issue user stories #27/#28/#36). Each entry is `(file_stem,
+    /// transcript_text)`; the caller (`crate::stats_performance`) decides the
+    /// declared-group label from the stem — this method's only job is "where do
+    /// this session's subagent transcripts live, if this harness has that
+    /// concept at all".
+    ///
+    /// The default is an **empty `Vec`**, not a `match harness { .. }` the caller
+    /// has to write: a harness with no nested-subagent convention (every harness
+    /// but `claude` today) answers "none" from the dispatch itself, so its
+    /// absence is a value, never a silently-skipped branch (ADR-0051 §2). This is
+    /// deliberately investigated, not assumed, for `copilot`: its event journal
+    /// declares no delegate/subagent event kind at all (only
+    /// `assistant.turn_end`, `session.error`, `session.usage_checkpoint`,
+    /// `session.shutdown` — see [`crate::copilot_journal`]'s module doc), and its
+    /// store has no per-directory nesting under a session id to enumerate in the
+    /// first place (`<store>/<session-id>/events.jsonl`, flat). A future harness
+    /// that DOES expose declared subagent identity overrides this method with its
+    /// own discovery, exactly like `claude`'s below — never a shared heuristic.
+    fn subagent_transcripts(
+        &self,
+        _project_root: &Path,
+        _working_dir: &Path,
+        _session_id: &str,
+    ) -> Vec<(String, String)> {
+        Vec::new()
+    }
 }
 
 /// The `claude` capabilities — all five, exactly as they are today. This slice is
@@ -327,6 +410,11 @@ impl HarnessProbes for ClaudeProbes {
     }
     fn staging_floor(&self) -> Option<StagingFloor> {
         Some(StagingFloor::ClaudeDotClaude)
+    }
+
+    /// #585: Claude's per-turn token usage, deduplicated and maxed.
+    fn context_usage_source(&self) -> Option<ContextUsageSource> {
+        Some(ContextUsageSource::ClaudeTranscriptPeak)
     }
 
     /// `claude`'s transcript resolution: by the pinned session id when the node
@@ -360,6 +448,56 @@ impl HarnessProbes for ClaudeProbes {
     fn detect_usage_limit(&self, pane: &str) -> bool {
         crate::stale_detector::detect_usage_limit(pane)
     }
+
+    /// `claude`'s context-peak parser: per-message token `usage`, deduplicated
+    /// and maxed ([`crate::context_peak::claude_session_peak`]). #585.
+    fn context_peak(&self, text: &str) -> Option<u64> {
+        crate::context_peak::claude_session_peak(text)
+    }
+
+    /// `claude`'s subagent discovery: every `*.jsonl` transcript under this main
+    /// session's own `subagents/` directory
+    /// (`<project_root>/<encoded_cwd>/<session_id>/subagents/`, recursed exactly
+    /// like [`crate::run_cost`]'s own transcript glob) — the only harness with a
+    /// confirmed nested-subagent convention today (#585).
+    fn subagent_transcripts(
+        &self,
+        project_root: &Path,
+        working_dir: &Path,
+        session_id: &str,
+    ) -> Vec<(String, String)> {
+        let dir = project_root
+            .join(crate::run_cost::cc_project_dirname(working_dir))
+            .join(session_id)
+            .join("subagents");
+        let mut out = Vec::new();
+        collect_jsonl_stems(&dir, &mut out);
+        out
+    }
+}
+
+/// Recurse `dir`, pairing every `*.jsonl` file's stem with its text — the raw
+/// discovery step behind [`ClaudeProbes::subagent_transcripts`]. No grouping
+/// heuristic lives here: labelling a stem as a declared group or falling back to
+/// "Unidentified subagent" is `crate::stats_performance`'s own concern, not a
+/// harness capability.
+fn collect_jsonl_stems(dir: &Path, out: &mut Vec<(String, String)>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_jsonl_stems(&path, out);
+        } else if path.extension().and_then(|e| e.to_str()) == Some("jsonl") {
+            let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+                continue;
+            };
+            if let Ok(text) = std::fs::read_to_string(&path) {
+                out.push((stem.to_string(), text));
+            }
+        }
+    }
 }
 
 /// The single `claude` instance handed out by [`probes_for`]. Zero-sized, so this
@@ -379,6 +517,13 @@ static CLAUDE_PROBES: ClaudeProbes = ClaudeProbes;
 ///
 /// The three present capabilities dispatch to `copilot`'s own implementation — its
 /// event journal, never `claude`'s cwd-keyed JSONL store.
+///
+/// `subagent_transcripts` is left at the trait's default (empty) — investigated,
+/// not assumed: `copilot`'s journal declares no delegate/subagent event kind
+/// ([`crate::copilot_journal`]'s module doc lists all four it does carry), and its
+/// store is flat (`<store>/<session-id>/events.jsonl`, no directory nesting under
+/// a session to enumerate). That absence is the value this dispatch returns for
+/// `copilot`, not a `crate::stats_performance` branch that silently skips it.
 struct CopilotProbes;
 
 impl HarnessProbes for CopilotProbes {
@@ -395,6 +540,12 @@ impl HarnessProbes for CopilotProbes {
         Some(TurnEndSubstrate::CopilotEventJournal)
     }
     // usage_limit_anchor / staging_floor stay `None` — declared absent (see above).
+
+    /// #585: Copilot's cumulative journal usage counters, converted to a
+    /// per-turn contribution and maxed.
+    fn context_usage_source(&self) -> Option<ContextUsageSource> {
+        Some(ContextUsageSource::CopilotJournalPeak)
+    }
 
     /// `copilot`'s transcript resolution: the session's event journal, at
     /// `<store>/<session-id>/events.jsonl` — by the **session identity PDO
@@ -422,6 +573,15 @@ impl HarnessProbes for CopilotProbes {
         crate::copilot_journal::turn_ended(tail)
     }
     // detect_usage_limit stays the trait default (`false`) — no anchor.
+
+    /// `copilot`'s context-peak parser: the journal's cumulative usage counters,
+    /// converted to a per-turn contribution and maxed
+    /// ([`crate::context_peak::copilot_session_peak`]). #585.
+    fn context_peak(&self, text: &str) -> Option<u64> {
+        crate::context_peak::copilot_session_peak(text)
+    }
+    // subagent_transcripts stays the trait default (empty) — see the struct doc
+    // comment above for why that is an investigated absence, not an assumption.
 
     /// `copilot` exits 0 on a hard model failure (ADR-0052), so its exit is not a
     /// verdict — the journal is.
@@ -473,6 +633,29 @@ pub(crate) fn resolve_transcript(
     session_id: Option<&str>,
 ) -> Option<PathBuf> {
     resolved(harness).resolve_transcript(projects_root, working_dir, session_id)
+}
+
+/// `harness`'s context-window peak for this transcript/journal `text`, dispatched
+/// to its implementation (ADR-0051 §585) — the seam
+/// [`crate::stats_performance`] calls instead of matching the harness string
+/// itself to pick `claude_session_peak` vs `copilot_session_peak`. A harness with
+/// no [`HarnessProbes::context_usage_source`] answers `None`.
+pub(crate) fn context_peak(harness: &str, text: &str) -> Option<u64> {
+    resolved(harness).context_peak(text)
+}
+
+/// `harness`'s subagent transcripts for one main session, dispatched to its
+/// implementation (ADR-0051 §585) — `claude` discovers them under
+/// `subagents/`, every other harness answers an empty `Vec` (a value, not a
+/// silently-skipped branch). [`crate::stats_performance`] applies its own
+/// declared-group labelling to whatever this returns.
+pub(crate) fn subagent_transcripts(
+    harness: &str,
+    project_root: &Path,
+    working_dir: &Path,
+    session_id: &str,
+) -> Vec<(String, String)> {
+    resolved(harness).subagent_transcripts(project_root, working_dir, session_id)
 }
 
 /// Whether `harness` constates an end of turn from this transcript `tail`,
@@ -550,6 +733,7 @@ pub(crate) struct Capabilities {
     pub turn_end: bool,
     pub usage_limit: bool,
     pub staging: bool,
+    pub context_usage: bool,
 }
 
 impl Capabilities {
@@ -561,12 +745,13 @@ impl Capabilities {
         turn_end: false,
         usage_limit: false,
         staging: false,
+        context_usage: false,
     };
 }
 
-/// Resolve `harness` to its five capability booleans. `None` from the factory ⇒
+/// Resolve `harness` to its six capability booleans. `None` from the factory ⇒
 /// [`Capabilities::NONE`], so an unknown or data-declared harness is absent on all
-/// five — the property the whole slice rests on.
+/// six — the property the whole slice rests on.
 pub(crate) fn capabilities(harness: &str) -> Capabilities {
     match probes_for(harness) {
         None => Capabilities::NONE,
@@ -576,6 +761,7 @@ pub(crate) fn capabilities(harness: &str) -> Capabilities {
             turn_end: p.turn_end_substrate().is_some(),
             usage_limit: p.usage_limit_anchor().is_some(),
             staging: p.staging_floor().is_some(),
+            context_usage: p.context_usage_source().is_some(),
         },
     }
 }
@@ -586,6 +772,16 @@ pub(crate) fn capabilities(harness: &str) -> Capabilities {
 pub(crate) fn can_cost(harness: &str) -> bool {
     let c = capabilities(harness);
     c.cost && c.transcript
+}
+
+/// Whether PDO can measure `harness`'s context-window peak (#585): it needs both
+/// a context-usage source and a way to find the transcript that source reads.
+/// Mirrors [`can_cost`]'s shape — a harness with a source but no transcript
+/// resolution (impossible today, but not structurally excluded) would still read
+/// "absent", never a made-up zero.
+pub(crate) fn can_measure_context(harness: &str) -> bool {
+    let c = capabilities(harness);
+    c.context_usage && c.transcript
 }
 
 /// The one-time note for a sandboxed Run whose node runs on a harness with no
@@ -622,6 +818,10 @@ mod tests {
         assert!(bare.turn_end_substrate().is_none());
         assert!(bare.usage_limit_anchor().is_none());
         assert!(bare.staging_floor().is_none());
+        assert!(bare.context_peak("anything").is_none());
+        assert!(bare
+            .subagent_transcripts(Path::new("/root"), Path::new("/wd"), "sid")
+            .is_empty());
     }
 
     #[test]
@@ -656,9 +856,29 @@ mod tests {
                 turn_end: true,
                 usage_limit: true,
                 staging: true,
+                context_usage: true,
             }
         );
         assert!(can_cost(CLAUDE));
+    }
+
+    #[test]
+    fn claude_and_copilot_declare_context_usage_others_do_not() {
+        // #585: Performance's "context usage" capability. Claude and Copilot each
+        // declare their own mechanism; a data-declared harness (and `opencode`)
+        // gets `None` like every other capability.
+        assert_eq!(
+            probes_for(CLAUDE).unwrap().context_usage_source(),
+            Some(ContextUsageSource::ClaudeTranscriptPeak)
+        );
+        assert_eq!(
+            probes_for(COPILOT).unwrap().context_usage_source(),
+            Some(ContextUsageSource::CopilotJournalPeak)
+        );
+        assert!(capabilities(CLAUDE).context_usage);
+        assert!(capabilities(COPILOT).context_usage);
+        assert!(!capabilities(OPENCODE).context_usage);
+        assert!(!capabilities("never-seen").context_usage);
     }
 
     #[test]
@@ -690,6 +910,7 @@ mod tests {
                 turn_end: true,
                 usage_limit: false,
                 staging: false,
+                context_usage: true,
             }
         );
         // A reported cost is still a cost PDO can produce (source + a resolvable
@@ -880,5 +1101,80 @@ mod tests {
         assert!(note.contains("`my-custom-harness`"));
         assert!(note.contains("no staging floor"));
         assert!(note.contains("$HOME"));
+    }
+
+    // --- #585 review follow-up: context_peak / subagent_transcripts dispatch ----
+
+    fn claude_turn(id: &str, input: u64, output: u64) -> String {
+        serde_json::json!({
+            "type": "assistant",
+            "requestId": format!("r-{id}"),
+            "message": {
+                "id": id,
+                "model": "claude-opus-4-8",
+                "usage": { "input_tokens": input, "output_tokens": output }
+            }
+        })
+        .to_string()
+    }
+
+    fn copilot_checkpoint(input: u64, output: u64) -> String {
+        serde_json::json!({
+            "type": "session.usage_checkpoint",
+            "data": {
+                "totalNanoAiu": 1,
+                "usage": { "inputTokens": input, "outputTokens": output, "cacheReadTokens": 0, "cacheCreationTokens": 0 }
+            }
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn context_peak_dispatches_to_each_harnesss_own_parser_not_the_others() {
+        // The public dispatch (`crate::harness_probes::context_peak`), not the
+        // `ClaudeProbes`/`CopilotProbes` methods directly — this is exactly the
+        // seam `crate::stats_performance` calls instead of a hard-coded
+        // `match harness.as_str() { .. }` (ADR-0051 review follow-up).
+        let claude_text = claude_turn("m1", 100, 20);
+        assert_eq!(context_peak(CLAUDE, &claude_text), Some(120));
+        // Claude's parser on a Copilot-shaped journal finds nothing (proves the
+        // dispatch, not a shared heuristic, is what's under test).
+        let copilot_text = copilot_checkpoint(500, 100);
+        assert_eq!(context_peak(CLAUDE, &copilot_text), None);
+        assert_eq!(context_peak(COPILOT, &copilot_text), Some(600));
+        // A harness with no context-usage source answers `None` from the
+        // dispatch itself, never a guess.
+        assert_eq!(context_peak(OPENCODE, &claude_text), None);
+        assert_eq!(context_peak("never-seen", &claude_text), None);
+    }
+
+    #[test]
+    fn subagent_transcripts_dispatches_only_claude_to_its_directory_convention() {
+        let tmp = tempfile::tempdir().unwrap();
+        let project_root = tmp.path().join("projects");
+        let working_dir = Path::new("/home/user/project");
+        let encoded = crate::stale_detector::encode_working_dir(working_dir);
+        let subagents_dir = project_root.join(&encoded).join("sid-1").join("subagents");
+        std::fs::create_dir_all(&subagents_dir).unwrap();
+        std::fs::write(
+            subagents_dir.join("reviewer.jsonl"),
+            claude_turn("m2", 10, 5),
+        )
+        .unwrap();
+
+        // `claude` discovers the file, stem verbatim (grouping is the caller's
+        // job, not this dispatch's — see the trait method's doc comment).
+        let claude_found = subagent_transcripts(CLAUDE, &project_root, working_dir, "sid-1");
+        assert_eq!(claude_found.len(), 1);
+        assert_eq!(claude_found[0].0, "reviewer");
+
+        // `copilot` has no nested-subagent convention: the SAME directory
+        // existing on disk is never picked up for it — a motivated absence
+        // (the dispatch answers empty), never a silently-skipped branch.
+        let copilot_found = subagent_transcripts(COPILOT, &project_root, working_dir, "sid-1");
+        assert!(copilot_found.is_empty());
+
+        // A data-declared harness: empty too, from the trait default.
+        assert!(subagent_transcripts(OPENCODE, &project_root, working_dir, "sid-1").is_empty());
     }
 }

--- a/crates/pdo-daemon/src/harness_support.rs
+++ b/crates/pdo-daemon/src/harness_support.rs
@@ -44,10 +44,10 @@ pub const BEGIN_MARKER: &str = "<!-- support-table:begin -->";
 /// The HTML comment closing the generated block.
 pub const END_MARKER: &str = "<!-- support-table:end -->";
 
-/// One of the five capabilities the support table publishes, in publication order.
+/// One of the six capabilities the support table publishes, in publication order.
 ///
-/// A closed enum is right *here* (unlike the harness axis, ADR-0045): the five are
-/// the trait's five methods, so a sixth capability is a code change in
+/// A closed enum is right *here* (unlike the harness axis, ADR-0045): the six are
+/// the trait's six methods, so a seventh capability is a code change in
 /// [`crate::harness_probes`] anyway — and this `match` is then the compiler's
 /// reminder to publish it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -57,16 +57,18 @@ pub(crate) enum Capability {
     TurnEnd,
     UsageLimit,
     Staging,
+    ContextUsage,
 }
 
 impl Capability {
-    /// The five, in the order the table lists them.
-    pub(crate) const ALL: [Capability; 5] = [
+    /// The six, in the order the table lists them.
+    pub(crate) const ALL: [Capability; 6] = [
         Capability::Cost,
         Capability::Transcript,
         Capability::TurnEnd,
         Capability::UsageLimit,
         Capability::Staging,
+        Capability::ContextUsage,
     ];
 
     /// The capability's column name in the published table.
@@ -77,6 +79,7 @@ impl Capability {
             Capability::TurnEnd => "End of turn",
             Capability::UsageLimit => "Usage-limit menu",
             Capability::Staging => "Sandbox staging floor",
+            Capability::ContextUsage => "Context usage",
         }
     }
 
@@ -103,6 +106,11 @@ impl Capability {
                 "Hold a sandboxed session's staged home — credentials, \
                                     settings, pre-granted trust"
             }
+            Capability::ContextUsage => {
+                "Measure a session's context-window peak, in tokens, for Stats → \
+                                        Performance (#585). Absent ⇒ no Context column for the \
+                                        harness, never an invented reading"
+            }
         }
     }
 
@@ -117,6 +125,7 @@ impl Capability {
             Capability::TurnEnd => p.turn_end_substrate().map(|t| t.label()),
             Capability::UsageLimit => p.usage_limit_anchor().map(|u| u.label()),
             Capability::Staging => p.staging_floor().map(|s| s.label()),
+            Capability::ContextUsage => p.context_usage_source().map(|c| c.label()),
         }
     }
 }
@@ -125,7 +134,7 @@ impl Capability {
 /// motive is prose; enforced, because a missing entry fails a test rather than
 /// publishing a bare ❌.
 ///
-/// A data-declared harness needs no row: it is absent on all five for one reason —
+/// A data-declared harness needs no row: it is absent on all six for one reason —
 /// PDO carries no code for it — and the block says that in a sentence.
 const ABSENCES: &[(&str, Capability, &str)] = &[
     (
@@ -158,6 +167,13 @@ const ABSENCES: &[(&str, Capability, &str)] = &[
         Capability::Staging,
         "Configuring a harness is a documented prerequisite, not PDO code. A sandboxed Run on it \
          holds by your image and the profile's `$HOME` exceptions, and PDO says so once, visibly.",
+    ),
+    (
+        OPENCODE,
+        Capability::ContextUsage,
+        "Its own SQLite reports token usage in four buckets that do not map onto `claude`'s \
+         (see Cost above), and it carries no transcript PDO can tail (see Transcript above) — a \
+         context peak is code, written per harness (#585), and nobody has written that code yet.",
     ),
     (
         COPILOT,
@@ -258,7 +274,7 @@ pub fn render() -> String {
 
     out.push_str(
         "\nA harness **you** declare in `~/.pdo/harnesses/descriptors.yaml` carries no code, so it \
-         is absent on all five — it still launches, attaches, resumes, and completes when its \
+         is absent on all six — it still launches, attaches, resumes, and completes when its \
          agent runs `pdo complete`. That is a legitimate way to run a harness, not a broken one.\n\n",
     );
     out.push_str(END_MARKER);
@@ -384,7 +400,7 @@ mod tests {
 
     #[test]
     fn the_matrix_reads_the_dispatch_table_not_a_hand_written_list() {
-        // claude: five present. copilot: three present, two absent. opencode: none.
+        // claude: six present. copilot: four present, two absent. opencode: none.
         // These are read through `mechanism`, so this test pins the *wiring*, not a
         // duplicate of the capability declaration.
         assert!(Capability::ALL
@@ -394,17 +410,18 @@ mod tests {
         assert!(Capability::TurnEnd.mechanism(COPILOT).is_some());
         assert!(Capability::UsageLimit.mechanism(COPILOT).is_none());
         assert!(Capability::Staging.mechanism(COPILOT).is_none());
+        assert!(Capability::ContextUsage.mechanism(COPILOT).is_some());
         assert!(Capability::ALL
             .iter()
             .all(|c| c.mechanism(OPENCODE).is_none()));
-        // A harness PDO carries no code for: absent on all five, no per-name code.
+        // A harness PDO carries no code for: absent on all six, no per-name code.
         assert!(Capability::ALL
             .iter()
             .all(|c| c.mechanism("my-custom-harness").is_none()));
     }
 
     #[test]
-    fn render_names_every_harness_its_version_and_the_five_capabilities() {
+    fn render_names_every_harness_its_version_and_the_six_capabilities() {
         let block = render();
         for d in embedded_floor() {
             assert!(

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -11,9 +11,11 @@ mod boot_recovery;
 pub(crate) mod completion_refusal;
 #[allow(dead_code)]
 mod condition;
+mod context_peak;
 mod copilot_journal;
 #[allow(dead_code)]
 mod cron_schedule;
+mod distribution;
 mod edge_router;
 mod event_log;
 #[allow(dead_code)]
@@ -67,6 +69,7 @@ mod scheduler_interpreter;
 mod service_unit;
 pub mod stale_detector;
 mod stats;
+mod stats_performance;
 mod switch_router;
 pub mod tmux_session_manager;
 mod transition_guard;
@@ -4459,6 +4462,10 @@ fn build_router(state: Arc<AppState>) -> Router {
         // fetched only when the cost tab is shown).
         .route("/stats/overview", get(stats::stats_overview))
         .route("/stats/cost", get(stats::stats_cost))
+        .route(
+            "/stats/performance",
+            get(stats_performance::stats_performance),
+        )
         // Out-of-Run audit feed (#507, ADR-0044). NEW top-level `/audit` prefix
         // → added to the vite dev proxy whitelist (frontend/vite.config.ts) so a
         // dev-mode GET hits the daemon instead of the SPA fallback (same trap as
@@ -17991,6 +17998,1413 @@ mod tests {
         assert_eq!(body["by_project"][0]["unknown"], 3);
         assert_eq!(body["by_project"][0]["pipelines"][0]["id"], "p1");
         assert!(!body["resolved"].as_array().unwrap().is_empty());
+    }
+
+    /// `GET /stats/performance` (#585) — the whole shape in one cohort: success-only
+    /// filtering (a loop lap, a stopped-then-restarted attempt, a script node, a
+    /// failed Run, a failed merge-resolver attempt all excluded/retained per the
+    /// issue's rules), stable Pipeline/Node identity with "latest name wins",
+    /// Pipeline aggregation pooling from raw main sessions (not from the Nodes'
+    /// own means), the whole-cohort `total`, Claude subagent grouping (declared
+    /// name + the "Unidentified subagent" fallback for an opaque id), a harness
+    /// with no context-usage source still keeping its Duration, and both
+    /// Infrastructure roles (Pipeline Manager, Merge resolver).
+    #[tokio::test]
+    async fn stats_performance_returns_pipeline_node_subagent_and_infrastructure_metrics() {
+        struct Cleanup(std::path::PathBuf);
+        impl Drop for Cleanup {
+            fn drop(&mut self) {
+                let _ = std::fs::remove_dir_all(&self.0);
+            }
+        }
+
+        let mut state = test_state().await;
+        let home = state
+            .repo_root
+            .join(".pdo")
+            .join("test-stats-performance")
+            .join(uuid::Uuid::new_v4().to_string());
+        let _cleanup = Cleanup(home.clone());
+        std::fs::create_dir_all(&home).unwrap();
+        Arc::get_mut(&mut state).unwrap().sandbox_home_override = Some(home.clone());
+        let repo = state.repo_root.to_string_lossy().into_owned();
+
+        async fn insert_event(
+            db: &sqlx::SqlitePool,
+            run: &str,
+            ts: &str,
+            kind: &str,
+            node: Option<&str>,
+            iter: Option<i64>,
+            payload: serde_json::Value,
+        ) {
+            sqlx::query(
+                "INSERT INTO events (run_id, ts, kind, node_id, iter, payload) \
+                 VALUES (?, ?, ?, ?, ?, ?)",
+            )
+            .bind(run)
+            .bind(ts)
+            .bind(kind)
+            .bind(node)
+            .bind(iter)
+            .bind(payload.to_string())
+            .execute(db)
+            .await
+            .unwrap();
+        }
+
+        // --- run_started: two runs of pipeline p1 (latest name "Loop V2" wins),
+        // one run of pipeline p2, one run of p1 that will fail outright (so its
+        // Pipeline Manager attempt is excluded, never even "expected").
+        insert_event(
+            &state.db,
+            "perf-r1",
+            "2026-07-15T09:00:00Z",
+            "run_started",
+            None,
+            None,
+            serde_json::json!({
+                "pipeline_id":"p1","pipeline_name":"Loop V1","target_repo":repo,"harness":"claude",
+                "node_defs":[
+                    {"id":"worker","name":"Worker V1","node_type":"code-mutating"},
+                    {"id":"build","name":"Build","node_type":"script"}
+                ]
+            }),
+        )
+        .await;
+        insert_event(
+            &state.db,
+            "perf-r2",
+            "2026-07-16T09:00:00Z",
+            "run_started",
+            None,
+            None,
+            serde_json::json!({
+                "pipeline_id":"p1","pipeline_name":"Loop V2","target_repo":repo,"harness":"copilot",
+                "node_defs":[{"id":"worker","name":"Worker V2","node_type":"code-mutating"}]
+            }),
+        )
+        .await;
+        insert_event(
+            &state.db,
+            "perf-r3",
+            "2026-07-17T09:00:00Z",
+            "run_started",
+            None,
+            None,
+            serde_json::json!({
+                "pipeline_id":"p2","pipeline_name":"Other pipeline","target_repo":repo,"harness":"claude",
+                "node_defs":[{"id":"solo","name":"Solo","node_type":"code-mutating"}]
+            }),
+        )
+        .await;
+        insert_event(
+            &state.db,
+            "perf-r4",
+            "2026-07-18T09:00:00Z",
+            "run_started",
+            None,
+            None,
+            serde_json::json!({
+                "pipeline_id":"p1","pipeline_name":"Loop V2","target_repo":repo,"harness":"claude",
+                "node_defs":[]
+            }),
+        )
+        .await;
+
+        // --- perf-r1: worker's loop lap (iter 1, 2), a stopped attempt on iter 3
+        // that is then restarted and succeeds, a fourth iter on a harness with no
+        // context source, plus a script node that must never appear at all.
+        insert_event(
+            &state.db, "perf-r1", "2026-07-15T09:10:00Z", "node_started",
+            Some("worker"), Some(1),
+            serde_json::json!({"node_type":"code-mutating","harness":"claude","session_id":"claude-1"}),
+        ).await;
+        insert_event(
+            &state.db,
+            "perf-r1",
+            "2026-07-15T09:20:00Z",
+            "node_completed",
+            Some("worker"),
+            Some(1),
+            serde_json::json!({}),
+        )
+        .await;
+        insert_event(
+            &state.db, "perf-r1", "2026-07-15T09:30:00Z", "node_started",
+            Some("worker"), Some(2),
+            serde_json::json!({"node_type":"code-mutating","harness":"claude","session_id":"claude-2"}),
+        ).await;
+        insert_event(
+            &state.db,
+            "perf-r1",
+            "2026-07-15T09:35:00Z",
+            "node_completed",
+            Some("worker"),
+            Some(2),
+            serde_json::json!({}),
+        )
+        .await;
+        insert_event(
+            &state.db, "perf-r1", "2026-07-15T09:40:00Z", "node_started",
+            Some("worker"), Some(3),
+            serde_json::json!({"node_type":"code-mutating","harness":"claude","session_id":"claude-3"}),
+        ).await;
+        insert_event(
+            &state.db,
+            "perf-r1",
+            "2026-07-15T09:41:00Z",
+            "node_stopped",
+            Some("worker"),
+            Some(3),
+            serde_json::json!({}),
+        )
+        .await;
+        insert_event(
+            &state.db, "perf-r1", "2026-07-15T09:45:00Z", "node_started",
+            Some("worker"), Some(3),
+            serde_json::json!({"node_type":"code-mutating","harness":"claude","session_id":"claude-3b"}),
+        ).await;
+        insert_event(
+            &state.db,
+            "perf-r1",
+            "2026-07-15T09:50:00Z",
+            "node_completed",
+            Some("worker"),
+            Some(3),
+            serde_json::json!({}),
+        )
+        .await;
+        insert_event(
+            &state.db, "perf-r1", "2026-07-15T10:00:00Z", "node_started",
+            Some("worker"), Some(4),
+            serde_json::json!({"node_type":"code-mutating","harness":"future-harness","session_id":"future-1"}),
+        ).await;
+        insert_event(
+            &state.db,
+            "perf-r1",
+            "2026-07-15T10:05:00Z",
+            "node_completed",
+            Some("worker"),
+            Some(4),
+            serde_json::json!({}),
+        )
+        .await;
+        insert_event(
+            &state.db,
+            "perf-r1",
+            "2026-07-15T09:10:00Z",
+            "node_started",
+            Some("build"),
+            Some(1),
+            serde_json::json!({"node_type":"script","harness":"claude","session_id":"build-1"}),
+        )
+        .await;
+        insert_event(
+            &state.db,
+            "perf-r1",
+            "2026-07-15T09:11:00Z",
+            "node_completed",
+            Some("build"),
+            Some(1),
+            serde_json::json!({}),
+        )
+        .await;
+
+        // Pipeline Manager: one successful Run.
+        insert_event(
+            &state.db,
+            "perf-r1",
+            "2026-07-15T09:55:00Z",
+            "run_completed",
+            None,
+            None,
+            serde_json::json!({}),
+        )
+        .await;
+        // Merge resolver: one failed attempt (excluded), then one successful
+        // pairing scoped to worker's iter-3 restart (its own worktree).
+        insert_event(
+            &state.db,
+            "perf-r1",
+            "2026-07-15T09:51:00Z",
+            "merge_resolver_started",
+            None,
+            None,
+            serde_json::json!({}),
+        )
+        .await;
+        insert_event(
+            &state.db,
+            "perf-r1",
+            "2026-07-15T09:51:30Z",
+            "merge_resolver_failed",
+            None,
+            None,
+            serde_json::json!({}),
+        )
+        .await;
+        insert_event(
+            &state.db,
+            "perf-r1",
+            "2026-07-15T09:52:00Z",
+            "merge_resolver_started",
+            None,
+            None,
+            serde_json::json!({"conflicting_node_id":"worker","iter":3}),
+        )
+        .await;
+        insert_event(
+            &state.db,
+            "perf-r1",
+            "2026-07-15T09:53:00Z",
+            "merge_resolver_completed",
+            None,
+            None,
+            serde_json::json!({}),
+        )
+        .await;
+
+        // --- perf-r2: worker's one Copilot execution.
+        insert_event(
+            &state.db, "perf-r2", "2026-07-16T09:10:00Z", "node_started",
+            Some("worker"), Some(1),
+            serde_json::json!({"node_type":"code-mutating","harness":"copilot","session_id":"copilot-1"}),
+        ).await;
+        insert_event(
+            &state.db,
+            "perf-r2",
+            "2026-07-16T09:20:00Z",
+            "node_completed",
+            Some("worker"),
+            Some(1),
+            serde_json::json!({}),
+        )
+        .await;
+
+        // --- perf-r3: p2's solo node, one Claude execution. Also a second
+        // successful Run, pooled into the same Pipeline Manager role.
+        insert_event(
+            &state.db, "perf-r3", "2026-07-17T09:10:00Z", "node_started",
+            Some("solo"), Some(1),
+            serde_json::json!({"node_type":"code-mutating","harness":"claude","session_id":"claude-solo"}),
+        ).await;
+        insert_event(
+            &state.db,
+            "perf-r3",
+            "2026-07-17T09:16:00Z",
+            "node_completed",
+            Some("solo"),
+            Some(1),
+            serde_json::json!({}),
+        )
+        .await;
+        insert_event(
+            &state.db,
+            "perf-r3",
+            "2026-07-17T09:20:00Z",
+            "run_completed",
+            None,
+            None,
+            serde_json::json!({}),
+        )
+        .await;
+
+        // --- perf-r4: the whole Run fails outright — never an "expected"
+        // Pipeline Manager attempt at all.
+        insert_event(
+            &state.db,
+            "perf-r4",
+            "2026-07-18T09:05:00Z",
+            "run_failed",
+            None,
+            None,
+            serde_json::json!({}),
+        )
+        .await;
+
+        // --- Claude transcripts (main sessions + one Node's two subagents).
+        let claude_root = home.join(".claude").join("projects");
+        let write_claude_main = |run_id: &str,
+                                 node_id: &str,
+                                 iter: i64,
+                                 session: &str,
+                                 tokens: u64| {
+            let dir = claude_root.join(stale_detector::encode_working_dir(
+                &worktree_ops::sub_worktree_path(&state.repo_root, run_id, node_id, iter),
+            ));
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(
+                dir.join(format!("{session}.jsonl")),
+                format!(
+                    r#"{{"type":"assistant","message":{{"model":"claude-opus-4-8","usage":{{"input_tokens":{tokens},"output_tokens":0}}}}}}"#
+                ),
+            )
+            .unwrap();
+            dir
+        };
+        let worker1_dir = write_claude_main("perf-r1", "worker", 1, "claude-1", 20000);
+        write_claude_main("perf-r1", "worker", 2, "claude-2", 25000);
+        let worker3_dir = write_claude_main("perf-r1", "worker", 3, "claude-3b", 30000);
+        write_claude_main("perf-r3", "solo", 1, "claude-solo", 45000);
+
+        // --- Infrastructure subagents (#585 user story #36): a Pipeline
+        // Manager session left in the Run's own top-level worktree (never
+        // colliding with a code-mutating Node's disjoint sub-worktree) and a
+        // Merge resolver session left in the conflicting Node's own
+        // iter-3 worktree, alongside (and excluded from) that Node's own
+        // "claude-3b" session — resolved by exclusion, never by path alone.
+        let pm_project_dir = claude_root.join(stale_detector::encode_working_dir(
+            &worktree_ops::worktree_dir_for_run(&state.repo_root, "perf-r1"),
+        ));
+        std::fs::create_dir_all(&pm_project_dir).unwrap();
+        std::fs::write(
+            pm_project_dir.join("pm-session.jsonl"),
+            r#"{"type":"assistant","message":{"model":"claude-opus-4-8","usage":{"input_tokens":12000,"output_tokens":0}}}"#,
+        )
+        .unwrap();
+        let pm_subagents_dir = pm_project_dir.join("pm-session").join("subagents");
+        std::fs::create_dir_all(&pm_subagents_dir).unwrap();
+        std::fs::write(
+            pm_subagents_dir.join("reviewer.jsonl"),
+            "{\"type\":\"assistant\",\"timestamp\":\"2026-07-15T09:50:10Z\",\"message\":{\"model\":\"claude-opus-4-8\",\"usage\":{\"input_tokens\":8000,\"output_tokens\":0}}}\n\
+             {\"type\":\"user\",\"timestamp\":\"2026-07-15T09:50:40Z\"}\n",
+        )
+        .unwrap();
+
+        std::fs::write(
+            worker3_dir.join("mr-session.jsonl"),
+            r#"{"type":"assistant","message":{"model":"claude-opus-4-8","usage":{"input_tokens":9000,"output_tokens":0}}}"#,
+        )
+        .unwrap();
+        let mr_subagents_dir = worker3_dir.join("mr-session").join("subagents");
+        std::fs::create_dir_all(&mr_subagents_dir).unwrap();
+        std::fs::write(
+            mr_subagents_dir.join("patch-reviewer.jsonl"),
+            "{\"type\":\"assistant\",\"timestamp\":\"2026-07-15T09:52:10Z\",\"message\":{\"model\":\"claude-opus-4-8\",\"usage\":{\"input_tokens\":7000,\"output_tokens\":0}}}\n\
+             {\"type\":\"user\",\"timestamp\":\"2026-07-15T09:52:40Z\"}\n",
+        )
+        .unwrap();
+
+        let subagents_dir = worker1_dir.join("claude-1").join("subagents");
+        std::fs::create_dir_all(&subagents_dir).unwrap();
+        std::fs::write(
+            subagents_dir.join("explore.jsonl"),
+            "{\"type\":\"assistant\",\"timestamp\":\"2026-07-15T09:10:00Z\",\"message\":{\"model\":\"claude-opus-4-8\",\"usage\":{\"input_tokens\":55000,\"output_tokens\":0}}}\n\
+             {\"type\":\"user\",\"timestamp\":\"2026-07-15T09:15:00Z\"}\n",
+        )
+        .unwrap();
+        std::fs::write(
+            subagents_dir.join("3fa85f64-5717-4562-b3fc-2c963f66afa6.jsonl"),
+            "{\"type\":\"assistant\",\"message\":{\"model\":\"claude-opus-4-8\",\"usage\":{\"input_tokens\":30000,\"output_tokens\":0}}}\n",
+        )
+        .unwrap();
+
+        // --- Copilot journal for the one Copilot execution.
+        let copilot_dir = home
+            .join(".copilot")
+            .join("session-state")
+            .join("copilot-1");
+        std::fs::create_dir_all(&copilot_dir).unwrap();
+        std::fs::write(
+            copilot_dir.join("events.jsonl"),
+            r#"{"type":"session.shutdown","data":{"usage":{"inputTokens":40000,"outputTokens":0}}}"#,
+        )
+        .unwrap();
+
+        let response = build_router(state)
+            .oneshot(
+                Request::builder()
+                    .uri("/stats/performance?from=2026-07-15T00:00:00Z&to=2026-07-19T00:00:00Z")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body: serde_json::Value = serde_json::from_slice(
+            &axum::body::to_bytes(response.into_body(), usize::MAX)
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            body["harnesses"],
+            serde_json::json!(["claude", "copilot", "future-harness"])
+        );
+
+        // --- Pipeline identity + latest-name-wins.
+        let by_pipeline = body["by_pipeline"].as_array().unwrap();
+        assert_eq!(by_pipeline.len(), 2, "got: {by_pipeline:#?}");
+        let p1 = by_pipeline.iter().find(|p| p["id"] == "p1").unwrap();
+        assert_eq!(p1["name"], "Loop V2");
+        let p2 = by_pipeline.iter().find(|p| p["id"] == "p2").unwrap();
+        assert_eq!(p2["name"], "Other pipeline");
+
+        // --- Node identity + latest-name-wins + success-only filtering: 3
+        // observations (loop lap + restart), never 4 (stopped attempt excluded)
+        // or 5 (script node excluded).
+        let nodes = p1["nodes"].as_array().unwrap();
+        assert_eq!(
+            nodes.len(),
+            1,
+            "the script node must never appear: {nodes:#?}"
+        );
+        let worker = &nodes[0];
+        assert_eq!(worker["id"], "worker");
+        assert_eq!(worker["name"], "Worker V2");
+        let worker_harnesses = worker["harnesses"].as_array().unwrap();
+        let worker_claude = worker_harnesses
+            .iter()
+            .find(|h| h["harness"] == "claude")
+            .unwrap();
+        assert_eq!(worker_claude["context"]["measured"], 3);
+        assert_eq!(worker_claude["context"]["expected"], 3);
+        assert_eq!(worker_claude["context"]["stats"]["min"], 20000.0);
+        assert_eq!(worker_claude["context"]["stats"]["max"], 30000.0);
+        assert_eq!(worker_claude["context"]["stats"]["mean"], 25000.0);
+        assert_eq!(worker_claude["context"]["stats"]["median"], 25000.0);
+        assert_eq!(worker_claude["duration"]["measured"], 3);
+        assert_eq!(worker_claude["duration"]["stats"]["min"], 300000.0);
+        assert_eq!(worker_claude["duration"]["stats"]["max"], 600000.0);
+        assert_eq!(worker_claude["duration"]["stats"]["mean"], 400000.0);
+        let worker_copilot = worker_harnesses
+            .iter()
+            .find(|h| h["harness"] == "copilot")
+            .unwrap();
+        assert_eq!(worker_copilot["context"]["stats"]["mean"], 40000.0);
+        assert_eq!(worker_copilot["duration"]["stats"]["mean"], 600000.0);
+        let worker_future = worker_harnesses
+            .iter()
+            .find(|h| h["harness"] == "future-harness")
+            .unwrap();
+        assert!(
+            worker_future["context"]["stats"].is_null(),
+            "a harness with no context source must never fake a value: {worker_future}"
+        );
+        assert_eq!(
+            worker_future["context"]["measured"], 0,
+            "coverage survives a fully absent metric: {worker_future}"
+        );
+        assert_eq!(worker_future["context"]["expected"], 1);
+        assert_eq!(
+            worker_future["context"]["missing_reasons"],
+            serde_json::json!(["harness has no context-usage source"])
+        );
+        assert_eq!(worker_future["duration"]["stats"]["mean"], 300000.0);
+        assert_eq!(worker_future["duration"]["measured"], 1);
+        assert_eq!(worker_future["duration"]["expected"], 1);
+
+        // --- Subagent grouping: declared name + "Unidentified subagent" fallback,
+        // never touching the parent Node's own distribution above.
+        let subagents = worker["subagents"].as_array().unwrap();
+        assert_eq!(subagents.len(), 2, "got: {subagents:#?}");
+        let explore = subagents.iter().find(|s| s["name"] == "explore").unwrap();
+        let explore_claude = explore["harnesses"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|h| h["harness"] == "claude")
+            .unwrap();
+        assert_eq!(explore_claude["context"]["stats"]["mean"], 55000.0);
+        assert_eq!(explore_claude["duration"]["stats"]["mean"], 300000.0);
+        let unidentified = subagents
+            .iter()
+            .find(|s| s["name"] == "Unidentified subagent")
+            .unwrap();
+        let unidentified_claude = unidentified["harnesses"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|h| h["harness"] == "claude")
+            .unwrap();
+        assert_eq!(unidentified_claude["context"]["stats"]["mean"], 30000.0);
+        assert!(
+            unidentified_claude["duration"]["stats"].is_null(),
+            "no reliable bounds in this subagent transcript: {unidentified_claude}"
+        );
+        assert_eq!(unidentified_claude["duration"]["measured"], 0);
+        assert_eq!(
+            unidentified_claude["duration"]["missing_reasons"],
+            serde_json::json!(["no reliable start/end bounds in subagent transcript"])
+        );
+
+        // --- Pipeline aggregation pools from raw main sessions, matching its own
+        // single Node here exactly (p1 has only one Node).
+        let p1_claude = p1["harnesses"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|h| h["harness"] == "claude")
+            .unwrap();
+        assert_eq!(p1_claude["context"]["stats"]["mean"], 25000.0);
+
+        // --- p2's solo Node.
+        let p2_worker = &p2["nodes"].as_array().unwrap()[0];
+        assert_eq!(p2_worker["id"], "solo");
+        let p2_claude = p2_worker["harnesses"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|h| h["harness"] == "claude")
+            .unwrap();
+        assert_eq!(p2_claude["context"]["stats"]["mean"], 45000.0);
+
+        // --- `total`: every main-session Claude observation across BOTH
+        // pipelines pooled together (never Infrastructure, never subagents).
+        let total_claude = body["total"]["harnesses"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|h| h["harness"] == "claude")
+            .unwrap();
+        assert_eq!(total_claude["context"]["measured"], 4);
+        assert_eq!(total_claude["context"]["stats"]["min"], 20000.0);
+        assert_eq!(total_claude["context"]["stats"]["max"], 45000.0);
+        assert_eq!(total_claude["context"]["stats"]["mean"], 30000.0);
+        assert_eq!(total_claude["context"]["stats"]["median"], 27500.0);
+
+        // --- Infrastructure: Pipeline Manager pools BOTH successful Runs (never
+        // the failed one); Merge resolver keeps only its successful pairing.
+        // Both roles now discover their own residual Claude session — and its
+        // subagents — by exclusion from the directory their turns are known to
+        // land in (#585 user story #36), never guessing at the ambiguous ones.
+        let infra = body["infrastructure"].as_array().unwrap();
+        assert_eq!(infra.len(), 2, "got: {infra:#?}");
+        let pipeline_manager = infra
+            .iter()
+            .find(|r| r["id"] == "pipeline-manager")
+            .unwrap();
+        assert_eq!(pipeline_manager["name"], "Pipeline Manager");
+        let pm_claude = pipeline_manager["harnesses"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|h| h["harness"] == "claude")
+            .unwrap();
+        // perf-r1's Run resolves a session (measured); perf-r3's Run leaves no
+        // attributable session in its own top-level worktree (absent, but
+        // coverage survives: expected still counts it).
+        assert_eq!(pm_claude["context"]["measured"], 1);
+        assert_eq!(pm_claude["context"]["expected"], 2);
+        assert_eq!(pm_claude["context"]["stats"]["mean"], 12000.0);
+        assert_eq!(
+            pm_claude["context"]["missing_reasons"],
+            serde_json::json!(["no attributable session for this infrastructure role"])
+        );
+        assert_eq!(pm_claude["duration"]["measured"], 2);
+        assert_eq!(pm_claude["duration"]["expected"], 2);
+        assert_eq!(pm_claude["duration"]["stats"]["min"], 1200000.0);
+        assert_eq!(pm_claude["duration"]["stats"]["max"], 3300000.0);
+        let pm_subagents = pipeline_manager["subagents"].as_array().unwrap();
+        assert_eq!(pm_subagents.len(), 1, "got: {pm_subagents:#?}");
+        let pm_reviewer_claude = pm_subagents[0]["harnesses"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|h| h["harness"] == "claude")
+            .unwrap();
+        assert_eq!(pm_subagents[0]["name"], "reviewer");
+        assert_eq!(pm_reviewer_claude["context"]["stats"]["mean"], 8000.0);
+        assert_eq!(pm_reviewer_claude["duration"]["stats"]["mean"], 30000.0);
+
+        let merge_resolver = infra.iter().find(|r| r["id"] == "merge-resolver").unwrap();
+        assert_eq!(merge_resolver["name"], "Merge resolver");
+        let mr_claude = merge_resolver["harnesses"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|h| h["harness"] == "claude")
+            .unwrap();
+        assert_eq!(mr_claude["context"]["measured"], 1);
+        assert_eq!(mr_claude["context"]["stats"]["mean"], 9000.0);
+        assert_eq!(mr_claude["duration"]["measured"], 1);
+        assert_eq!(mr_claude["duration"]["stats"]["mean"], 60000.0);
+        let mr_subagents = merge_resolver["subagents"].as_array().unwrap();
+        assert_eq!(mr_subagents.len(), 1, "got: {mr_subagents:#?}");
+        let mr_patch_claude = mr_subagents[0]["harnesses"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|h| h["harness"] == "claude")
+            .unwrap();
+        assert_eq!(mr_subagents[0]["name"], "patch-reviewer");
+        assert_eq!(mr_patch_claude["context"]["stats"]["mean"], 7000.0);
+        assert_eq!(mr_patch_claude["duration"]["stats"]["mean"], 30000.0);
+
+        // --- infrastructure_total: both Infrastructure roles' raw observations
+        // pooled together — NOT the mean of Pipeline Manager's mean and Merge
+        // resolver's mean (#585 review follow-up, blocker 3). Context pools
+        // Pipeline Manager's one measured peak (12000) with Merge resolver's
+        // one measured peak (9000): 2 measured out of 3 expected occurrences
+        // (Pipeline Manager's own expected=2 + Merge resolver's own expected=1).
+        // Duration pools all three occurrences directly, since every occurrence
+        // is paired Run/resolver timestamps with no absence possible here.
+        let infra_total_claude = body["infrastructure_total"]["harnesses"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|h| h["harness"] == "claude")
+            .unwrap();
+        assert_eq!(infra_total_claude["context"]["expected"], 3);
+        assert_eq!(infra_total_claude["context"]["measured"], 2);
+        assert_eq!(infra_total_claude["context"]["stats"]["mean"], 10500.0);
+        assert_eq!(infra_total_claude["duration"]["expected"], 3);
+        assert_eq!(infra_total_claude["duration"]["measured"], 3);
+        assert_eq!(infra_total_claude["duration"]["stats"]["mean"], 1520000.0);
+    }
+
+    /// `GET /stats/performance` (#585, user story #36) — an Infrastructure
+    /// role's own session is never guessed at by path or timing alone: a
+    /// non-code-mutating Claude Node sharing the Pipeline Manager's top-level
+    /// worktree, with no recorded `session_id`, makes that directory's
+    /// residual session ambiguous — Context (and its subagents) stays a
+    /// motivated absence rather than an unsafe guess, while Duration (paired
+    /// from `RunStarted`/`RunCompleted` timestamps, no session lookup
+    /// involved) is unaffected.
+    #[tokio::test]
+    async fn stats_performance_infrastructure_context_is_ambiguous_when_a_shared_session_has_no_recorded_identity(
+    ) {
+        struct Cleanup(std::path::PathBuf);
+        impl Drop for Cleanup {
+            fn drop(&mut self) {
+                let _ = std::fs::remove_dir_all(&self.0);
+            }
+        }
+
+        let mut state = test_state().await;
+        let home = state
+            .repo_root
+            .join(".pdo")
+            .join("test-stats-performance-ambiguous")
+            .join(uuid::Uuid::new_v4().to_string());
+        let _cleanup = Cleanup(home.clone());
+        std::fs::create_dir_all(&home).unwrap();
+        Arc::get_mut(&mut state).unwrap().sandbox_home_override = Some(home.clone());
+        let repo = state.repo_root.to_string_lossy().into_owned();
+
+        async fn insert_event(
+            db: &sqlx::SqlitePool,
+            run: &str,
+            ts: &str,
+            kind: &str,
+            node: Option<&str>,
+            iter: Option<i64>,
+            payload: serde_json::Value,
+        ) {
+            sqlx::query(
+                "INSERT INTO events (run_id, ts, kind, node_id, iter, payload) \
+                 VALUES (?, ?, ?, ?, ?, ?)",
+            )
+            .bind(run)
+            .bind(ts)
+            .bind(kind)
+            .bind(node)
+            .bind(iter)
+            .bind(payload.to_string())
+            .execute(db)
+            .await
+            .unwrap();
+        }
+
+        insert_event(
+            &state.db,
+            "perf-amb",
+            "2026-08-01T09:00:00Z",
+            "run_started",
+            None,
+            None,
+            serde_json::json!({
+                "pipeline_id":"amb","pipeline_name":"Ambiguous","target_repo":repo,"harness":"claude",
+                "node_defs":[{"id":"docs","name":"Docs","node_type":"doc-only"}]
+            }),
+        )
+        .await;
+        // A non-code-mutating (so it shares the Run's top-level worktree)
+        // Claude Node with no recorded `session_id` — the directory can no
+        // longer be trusted to hold only the Pipeline Manager's own session.
+        insert_event(
+            &state.db,
+            "perf-amb",
+            "2026-08-01T09:10:00Z",
+            "node_started",
+            Some("docs"),
+            Some(1),
+            serde_json::json!({"node_type":"doc-only","harness":"claude"}),
+        )
+        .await;
+        insert_event(
+            &state.db,
+            "perf-amb",
+            "2026-08-01T09:15:00Z",
+            "node_completed",
+            Some("docs"),
+            Some(1),
+            serde_json::json!({}),
+        )
+        .await;
+        insert_event(
+            &state.db,
+            "perf-amb",
+            "2026-08-01T09:20:00Z",
+            "run_completed",
+            None,
+            None,
+            serde_json::json!({}),
+        )
+        .await;
+
+        // A residual session does exist in the shared directory — but it must
+        // never be attributed, since the co-resident Node's own identity is
+        // unknown.
+        let claude_root = home.join(".claude").join("projects");
+        let pm_project_dir = claude_root.join(stale_detector::encode_working_dir(
+            &worktree_ops::worktree_dir_for_run(&state.repo_root, "perf-amb"),
+        ));
+        std::fs::create_dir_all(&pm_project_dir).unwrap();
+        std::fs::write(
+            pm_project_dir.join("pm-session.jsonl"),
+            r#"{"type":"assistant","message":{"model":"claude-opus-4-8","usage":{"input_tokens":12000,"output_tokens":0}}}"#,
+        )
+        .unwrap();
+
+        let response = build_router(state)
+            .oneshot(
+                Request::builder()
+                    .uri("/stats/performance?from=2026-08-01T00:00:00Z&to=2026-08-02T00:00:00Z")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body: serde_json::Value = serde_json::from_slice(
+            &axum::body::to_bytes(response.into_body(), usize::MAX)
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+
+        let infra = body["infrastructure"].as_array().unwrap();
+        let pipeline_manager = infra
+            .iter()
+            .find(|r| r["id"] == "pipeline-manager")
+            .unwrap();
+        let pm_claude = pipeline_manager["harnesses"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|h| h["harness"] == "claude")
+            .unwrap();
+        assert_eq!(pm_claude["context"]["measured"], 0);
+        assert_eq!(pm_claude["context"]["expected"], 1);
+        assert!(pm_claude["context"]["stats"].is_null());
+        assert_eq!(
+            pm_claude["context"]["missing_reasons"],
+            serde_json::json!(["ambiguous session identity in a directory shared with a Node"])
+        );
+        assert!(
+            pipeline_manager["subagents"].as_array().unwrap().is_empty(),
+            "an ambiguous session must never contribute subagents either: {pipeline_manager}"
+        );
+        // Duration is untouched by the ambiguity — it never looked at a
+        // session file at all.
+        assert_eq!(pm_claude["duration"]["measured"], 1);
+        assert_eq!(pm_claude["duration"]["stats"]["mean"], 1200000.0);
+    }
+
+    /// #585 review follow-up (blocker 4): Copilot's journal has no declared
+    /// subagent concept, and its store is flat — this must be a **motivated**
+    /// absence (the dispatch answers empty), not a coincidence of never having
+    /// the right directory to look in. Proven by planting a directory that
+    /// *would* read as subagents under Claude's convention right next to the
+    /// Copilot session's own journal, and asserting it never surfaces: the
+    /// Copilot execution's own Context is still read correctly (the absence is
+    /// specific to subagent discovery, not a wholesale failure to read Copilot
+    /// at all).
+    #[tokio::test]
+    async fn stats_performance_copilot_subagents_are_a_motivated_absence_not_silently_missing() {
+        struct Cleanup(std::path::PathBuf);
+        impl Drop for Cleanup {
+            fn drop(&mut self) {
+                let _ = std::fs::remove_dir_all(&self.0);
+            }
+        }
+
+        let mut state = test_state().await;
+        let home = state
+            .repo_root
+            .join(".pdo")
+            .join("test-stats-performance-copilot-subagents")
+            .join(uuid::Uuid::new_v4().to_string());
+        let _cleanup = Cleanup(home.clone());
+        std::fs::create_dir_all(&home).unwrap();
+        Arc::get_mut(&mut state).unwrap().sandbox_home_override = Some(home.clone());
+        let repo = state.repo_root.to_string_lossy().into_owned();
+
+        sqlx::query(
+            "INSERT INTO events (run_id, ts, kind, node_id, iter, payload) VALUES \
+             ('perf-cs1', '2026-08-01T09:00:00Z', 'run_started', NULL, NULL, ?)",
+        )
+        .bind(
+            serde_json::json!({
+                "pipeline_id":"p1","pipeline_name":"Loop","target_repo":repo,"harness":"copilot",
+                "node_defs":[{"id":"worker","name":"Worker","node_type":"code-mutating"}]
+            })
+            .to_string(),
+        )
+        .execute(&state.db)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO events (run_id, ts, kind, node_id, iter, payload) VALUES \
+             ('perf-cs1', '2026-08-01T09:10:00Z', 'node_started', 'worker', 1, ?)",
+        )
+        .bind(
+            serde_json::json!({"node_type":"code-mutating","harness":"copilot","session_id":"copilot-cs1"})
+                .to_string(),
+        )
+        .execute(&state.db)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO events (run_id, ts, kind, node_id, iter, payload) VALUES \
+             ('perf-cs1', '2026-08-01T09:20:00Z', 'node_completed', 'worker', 1, '{}')",
+        )
+        .execute(&state.db)
+        .await
+        .unwrap();
+
+        let copilot_session_dir = home
+            .join(".copilot")
+            .join("session-state")
+            .join("copilot-cs1");
+        std::fs::create_dir_all(&copilot_session_dir).unwrap();
+        std::fs::write(
+            copilot_session_dir.join("events.jsonl"),
+            r#"{"type":"session.shutdown","data":{"usage":{"inputTokens":12000,"outputTokens":0}}}"#,
+        )
+        .unwrap();
+        // Plant a directory that reads as subagents under Claude's own
+        // convention, right next to the Copilot session's journal.
+        let lookalike_subagents = copilot_session_dir.join("subagents");
+        std::fs::create_dir_all(&lookalike_subagents).unwrap();
+        std::fs::write(
+            lookalike_subagents.join("reviewer.jsonl"),
+            "{\"type\":\"assistant\",\"message\":{\"model\":\"claude-opus-4-8\",\"usage\":{\"input_tokens\":999,\"output_tokens\":0}}}\n",
+        )
+        .unwrap();
+
+        let response = build_router(state)
+            .oneshot(
+                Request::builder()
+                    .uri("/stats/performance?from=2026-08-01T00:00:00Z&to=2026-08-02T00:00:00Z")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body: serde_json::Value = serde_json::from_slice(
+            &axum::body::to_bytes(response.into_body(), usize::MAX)
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+
+        let by_pipeline = body["by_pipeline"].as_array().unwrap();
+        let p1 = by_pipeline.iter().find(|p| p["id"] == "p1").unwrap();
+        let worker = &p1["nodes"].as_array().unwrap()[0];
+        let worker_copilot = worker["harnesses"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|h| h["harness"] == "copilot")
+            .unwrap();
+        // The motivated absence is scoped to subagents — Context itself still
+        // reads correctly for the Copilot execution.
+        assert_eq!(worker_copilot["context"]["measured"], 1);
+        assert_eq!(worker_copilot["context"]["stats"]["mean"], 12000.0);
+        assert!(
+            worker["subagents"].as_array().unwrap().is_empty(),
+            "a look-alike subagents/ directory must never surface for copilot: {worker}"
+        );
+    }
+
+    /// `GET /stats/performance` (#585 review follow-up, blocker 2) — the
+    /// result is cached in memory: a repeat request for the identical `[from,
+    /// to)` window, with nothing in the cohort's events or the underlying
+    /// Claude transcript changed, is served from the memo — [`fold_performance`]
+    /// (the transcript-reading heavy fold) never runs a second time — while
+    /// still returning the exact same payload a fresh computation would.
+    #[tokio::test]
+    async fn stats_performance_result_is_memoized_and_reused_when_nothing_changed() {
+        struct Cleanup(std::path::PathBuf);
+        impl Drop for Cleanup {
+            fn drop(&mut self) {
+                let _ = std::fs::remove_dir_all(&self.0);
+            }
+        }
+
+        let mut state = test_state().await;
+        let home = state
+            .repo_root
+            .join(".pdo")
+            .join("test-stats-performance-cache")
+            .join(uuid::Uuid::new_v4().to_string());
+        let _cleanup = Cleanup(home.clone());
+        std::fs::create_dir_all(&home).unwrap();
+        Arc::get_mut(&mut state).unwrap().sandbox_home_override = Some(home.clone());
+        let repo = state.repo_root.to_string_lossy().into_owned();
+
+        async fn insert_event(
+            db: &sqlx::SqlitePool,
+            run: &str,
+            ts: &str,
+            kind: &str,
+            node: Option<&str>,
+            iter: Option<i64>,
+            payload: serde_json::Value,
+        ) {
+            sqlx::query(
+                "INSERT INTO events (run_id, ts, kind, node_id, iter, payload) \
+                 VALUES (?, ?, ?, ?, ?, ?)",
+            )
+            .bind(run)
+            .bind(ts)
+            .bind(kind)
+            .bind(node)
+            .bind(iter)
+            .bind(payload.to_string())
+            .execute(db)
+            .await
+            .unwrap();
+        }
+
+        insert_event(
+            &state.db,
+            "cache-r1",
+            "2031-01-15T09:00:00Z",
+            "run_started",
+            None,
+            None,
+            serde_json::json!({
+                "pipeline_id":"cp1","pipeline_name":"Cache Pipeline","target_repo":repo,"harness":"claude",
+                "node_defs":[{"id":"worker","name":"Worker","node_type":"code-mutating"}]
+            }),
+        )
+        .await;
+        insert_event(
+            &state.db, "cache-r1", "2031-01-15T09:10:00Z", "node_started",
+            Some("worker"), Some(1),
+            serde_json::json!({"node_type":"code-mutating","harness":"claude","session_id":"cache-1"}),
+        )
+        .await;
+        insert_event(
+            &state.db,
+            "cache-r1",
+            "2031-01-15T09:20:00Z",
+            "node_completed",
+            Some("worker"),
+            Some(1),
+            serde_json::json!({}),
+        )
+        .await;
+
+        let claude_root = home.join(".claude").join("projects");
+        let dir = claude_root.join(stale_detector::encode_working_dir(
+            &worktree_ops::sub_worktree_path(&state.repo_root, "cache-r1", "worker", 1),
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("cache-1.jsonl"),
+            r#"{"type":"assistant","message":{"model":"claude-opus-4-8","usage":{"input_tokens":10000,"output_tokens":0}}}"#,
+        )
+        .unwrap();
+
+        let from = "2031-01-15T00:00:00Z";
+        let to = "2031-01-16T00:00:00Z";
+        let uri = format!("/stats/performance?from={from}&to={to}");
+
+        async fn call(state: &Arc<AppState>, uri: &str) -> serde_json::Value {
+            let response = build_router(state.clone())
+                .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            serde_json::from_slice(
+                &axum::body::to_bytes(response.into_body(), usize::MAX)
+                    .await
+                    .unwrap(),
+            )
+            .unwrap()
+        }
+
+        let first = call(&state, &uri).await;
+        let after_first = stats_performance::recompute_count_for_test(from, to);
+        assert_eq!(
+            after_first, 1,
+            "first request must run the heavy fold exactly once"
+        );
+
+        let second = call(&state, &uri).await;
+        let after_second = stats_performance::recompute_count_for_test(from, to);
+        assert_eq!(
+            after_second, after_first,
+            "an identical repeat request must be served from the memo, not recomputed"
+        );
+        assert_eq!(
+            first, second,
+            "a memo hit must return byte-for-byte the same payload"
+        );
+        let refreshed = call(&state, &format!("{uri}&refresh=true")).await;
+        assert_eq!(
+            stats_performance::recompute_count_for_test(from, to),
+            after_second + 1,
+            "an explicit user refresh must bypass the memo"
+        );
+        assert_eq!(first, refreshed);
+        let worker_claude = first["by_pipeline"][0]["nodes"][0]["harnesses"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|h| h["harness"] == "claude")
+            .unwrap();
+        assert_eq!(worker_claude["context"]["stats"]["mean"], 10000.0);
+    }
+
+    /// `GET /stats/performance` (#585 review follow-up, blocker 2) — the memo
+    /// key covers both halves the issue calls out: cohort **event** state (a
+    /// newly appended Run changes the answer on the very next identical
+    /// request) and **transcript/journal source** state (rewriting a session's
+    /// own file — same events, same session id, new content/mtime — does too).
+    /// Neither can silently serve a stale answer.
+    #[tokio::test]
+    async fn stats_performance_cache_is_invalidated_by_new_events_and_by_transcript_changes() {
+        struct Cleanup(std::path::PathBuf);
+        impl Drop for Cleanup {
+            fn drop(&mut self) {
+                let _ = std::fs::remove_dir_all(&self.0);
+            }
+        }
+
+        let mut state = test_state().await;
+        let home = state
+            .repo_root
+            .join(".pdo")
+            .join("test-stats-performance-cache-invalidation")
+            .join(uuid::Uuid::new_v4().to_string());
+        let _cleanup = Cleanup(home.clone());
+        std::fs::create_dir_all(&home).unwrap();
+        Arc::get_mut(&mut state).unwrap().sandbox_home_override = Some(home.clone());
+        let repo = state.repo_root.to_string_lossy().into_owned();
+
+        async fn insert_event(
+            db: &sqlx::SqlitePool,
+            run: &str,
+            ts: &str,
+            kind: &str,
+            node: Option<&str>,
+            iter: Option<i64>,
+            payload: serde_json::Value,
+        ) {
+            sqlx::query(
+                "INSERT INTO events (run_id, ts, kind, node_id, iter, payload) \
+                 VALUES (?, ?, ?, ?, ?, ?)",
+            )
+            .bind(run)
+            .bind(ts)
+            .bind(kind)
+            .bind(node)
+            .bind(iter)
+            .bind(payload.to_string())
+            .execute(db)
+            .await
+            .unwrap();
+        }
+
+        insert_event(
+            &state.db,
+            "cache-i1",
+            "2031-02-15T09:00:00Z",
+            "run_started",
+            None,
+            None,
+            serde_json::json!({
+                "pipeline_id":"cip1","pipeline_name":"Cache Invalidation Pipeline","target_repo":repo,"harness":"claude",
+                "node_defs":[{"id":"worker","name":"Worker","node_type":"code-mutating"}]
+            }),
+        )
+        .await;
+        insert_event(
+            &state.db, "cache-i1", "2031-02-15T09:10:00Z", "node_started",
+            Some("worker"), Some(1),
+            serde_json::json!({"node_type":"code-mutating","harness":"claude","session_id":"cache-i-1"}),
+        )
+        .await;
+        insert_event(
+            &state.db,
+            "cache-i1",
+            "2031-02-15T09:20:00Z",
+            "node_completed",
+            Some("worker"),
+            Some(1),
+            serde_json::json!({}),
+        )
+        .await;
+
+        let claude_root = home.join(".claude").join("projects");
+        let dir = claude_root.join(stale_detector::encode_working_dir(
+            &worktree_ops::sub_worktree_path(&state.repo_root, "cache-i1", "worker", 1),
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("cache-i-1.jsonl"),
+            r#"{"type":"assistant","message":{"model":"claude-opus-4-8","usage":{"input_tokens":10000,"output_tokens":0}}}"#,
+        )
+        .unwrap();
+
+        let from = "2031-02-15T00:00:00Z";
+        let to = "2031-02-17T00:00:00Z";
+        let uri = format!("/stats/performance?from={from}&to={to}");
+
+        async fn call(state: &Arc<AppState>, uri: &str) -> serde_json::Value {
+            let response = build_router(state.clone())
+                .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            serde_json::from_slice(
+                &axum::body::to_bytes(response.into_body(), usize::MAX)
+                    .await
+                    .unwrap(),
+            )
+            .unwrap()
+        }
+
+        let first = call(&state, &uri).await;
+        assert_eq!(stats_performance::recompute_count_for_test(from, to), 1);
+        let worker_claude_first = first["by_pipeline"][0]["nodes"][0]["harnesses"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|h| h["harness"] == "claude")
+            .unwrap()
+            .clone();
+        assert_eq!(worker_claude_first["context"]["measured"], 1);
+        assert_eq!(worker_claude_first["context"]["stats"]["mean"], 10000.0);
+
+        // --- (a) cohort event state: a second Run appears in the same window.
+        insert_event(
+            &state.db,
+            "cache-i2",
+            "2031-02-16T09:00:00Z",
+            "run_started",
+            None,
+            None,
+            serde_json::json!({
+                "pipeline_id":"cip1","pipeline_name":"Cache Invalidation Pipeline","target_repo":repo,"harness":"claude",
+                "node_defs":[{"id":"worker","name":"Worker","node_type":"code-mutating"}]
+            }),
+        )
+        .await;
+        insert_event(
+            &state.db, "cache-i2", "2031-02-16T09:10:00Z", "node_started",
+            Some("worker"), Some(1),
+            serde_json::json!({"node_type":"code-mutating","harness":"claude","session_id":"cache-i-2"}),
+        )
+        .await;
+        insert_event(
+            &state.db,
+            "cache-i2",
+            "2031-02-16T09:20:00Z",
+            "node_completed",
+            Some("worker"),
+            Some(1),
+            serde_json::json!({}),
+        )
+        .await;
+        let dir2 = claude_root.join(stale_detector::encode_working_dir(
+            &worktree_ops::sub_worktree_path(&state.repo_root, "cache-i2", "worker", 1),
+        ));
+        std::fs::create_dir_all(&dir2).unwrap();
+        std::fs::write(
+            dir2.join("cache-i-2.jsonl"),
+            r#"{"type":"assistant","message":{"model":"claude-opus-4-8","usage":{"input_tokens":20000,"output_tokens":0}}}"#,
+        )
+        .unwrap();
+
+        let after_new_run = call(&state, &uri).await;
+        assert_eq!(
+            stats_performance::recompute_count_for_test(from, to),
+            2,
+            "a new Run in the same window must force a recompute"
+        );
+        let worker_claude_after_new_run = after_new_run["by_pipeline"][0]["nodes"][0]["harnesses"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|h| h["harness"] == "claude")
+            .unwrap();
+        assert_eq!(
+            worker_claude_after_new_run["context"]["measured"], 2,
+            "the new Run's own Context observation must now be pooled: {after_new_run:#?}"
+        );
+
+        // --- (b) transcript/journal source state: rewrite the FIRST Run's own
+        // session file in place (no new event at all) with a different token
+        // count.
+        std::fs::write(
+            dir.join("cache-i-1.jsonl"),
+            r#"{"type":"assistant","message":{"model":"claude-opus-4-8","usage":{"input_tokens":99000,"output_tokens":0}}}"#,
+        )
+        .unwrap();
+
+        let after_transcript_rewrite = call(&state, &uri).await;
+        assert_eq!(
+            stats_performance::recompute_count_for_test(from, to),
+            3,
+            "rewriting a session's own transcript, with no new event, must still force a recompute"
+        );
+        let worker_claude_after_rewrite = after_transcript_rewrite["by_pipeline"][0]["nodes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|n| n["id"] == "worker")
+            .unwrap()["harnesses"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|h| h["harness"] == "claude")
+            .unwrap()
+            .clone();
+        // Node-level rows sum over both Runs' own Worker iter-1 sessions; only
+        // cache-i1's was rewritten (10000 -> 99000), cache-i2's (20000) is
+        // unaffected — the mean must reflect the rewrite, not the stale value.
+        assert_eq!(worker_claude_after_rewrite["context"]["measured"], 2);
+        assert_eq!(
+            worker_claude_after_rewrite["context"]["stats"]["mean"],
+            (99000.0 + 20000.0) / 2.0
+        );
+    }
+
+    /// An empty cohort (no Runs in the window) is not an error — an empty
+    /// Performance payload, distinct from the source-wide-unreadable case below.
+    #[tokio::test]
+    async fn stats_performance_empty_cohort_is_not_an_error() {
+        let state = test_state().await;
+        let response = build_router(state)
+            .oneshot(
+                Request::builder()
+                    .uri("/stats/performance?from=2026-01-01T00:00:00Z&to=2026-01-02T00:00:00Z")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body: serde_json::Value = serde_json::from_slice(
+            &axum::body::to_bytes(response.into_body(), usize::MAX)
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(body["harnesses"], serde_json::json!([]));
+        assert_eq!(body["by_pipeline"], serde_json::json!([]));
+        assert_eq!(body["infrastructure"], serde_json::json!([]));
+        assert_eq!(body["total"]["harnesses"], serde_json::json!([]));
+    }
+
+    /// A harness's whole transcript source existing but unreadable (permissions,
+    /// a corrupted mount) is a visible endpoint error — distinct from a single
+    /// unreadable session, which just degrades to a local absence reason.
+    #[tokio::test]
+    async fn stats_performance_source_wide_unreadable_is_a_visible_error() {
+        struct Cleanup(std::path::PathBuf);
+        impl Drop for Cleanup {
+            fn drop(&mut self) {
+                let _ = std::fs::set_permissions(
+                    &self.0,
+                    std::os::unix::fs::PermissionsExt::from_mode(0o755),
+                );
+                let _ = std::fs::remove_dir_all(&self.0);
+            }
+        }
+
+        let mut state = test_state().await;
+        let home = state
+            .repo_root
+            .join(".pdo")
+            .join("test-stats-performance-unreadable")
+            .join(uuid::Uuid::new_v4().to_string());
+        std::fs::create_dir_all(&home).unwrap();
+        Arc::get_mut(&mut state).unwrap().sandbox_home_override = Some(home.clone());
+        let repo = state.repo_root.to_string_lossy().into_owned();
+
+        sqlx::query(
+            "INSERT INTO events (run_id, ts, kind, node_id, iter, payload) VALUES \
+             ('perf-unreadable', '2026-07-15T09:00:00Z', 'run_started', NULL, NULL, ?)",
+        )
+        .bind(
+            serde_json::json!({
+                "pipeline_id":"p1","pipeline_name":"Loop","target_repo":repo,"harness":"claude",
+                "node_defs":[{"id":"worker","name":"Worker","node_type":"code-mutating"}]
+            })
+            .to_string(),
+        )
+        .execute(&state.db)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO events (run_id, ts, kind, node_id, iter, payload) VALUES \
+             ('perf-unreadable', '2026-07-15T09:10:00Z', 'node_started', 'worker', 1, ?)",
+        )
+        .bind(
+            serde_json::json!({"node_type":"code-mutating","harness":"claude","session_id":"claude-1"})
+                .to_string(),
+        )
+        .execute(&state.db)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO events (run_id, ts, kind, node_id, iter, payload) VALUES \
+             ('perf-unreadable', '2026-07-15T09:20:00Z', 'node_completed', 'worker', 1, '{}')",
+        )
+        .execute(&state.db)
+        .await
+        .unwrap();
+
+        let claude_root = home.join(".claude").join("projects");
+        std::fs::create_dir_all(&claude_root).unwrap();
+        std::fs::set_permissions(
+            &claude_root,
+            std::os::unix::fs::PermissionsExt::from_mode(0o000),
+        )
+        .unwrap();
+        let _cleanup = Cleanup(claude_root.clone());
+
+        let response = build_router(state)
+            .oneshot(
+                Request::builder()
+                    .uri("/stats/performance?from=2026-07-15T00:00:00Z&to=2026-07-16T00:00:00Z")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let body: serde_json::Value = serde_json::from_slice(
+            &axum::body::to_bytes(response.into_body(), usize::MAX)
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+        let message = body["error"].as_str().unwrap_or_default();
+        assert!(
+            message.contains("Claude"),
+            "the error must name the harness/source: {message}"
+        );
     }
 
     /// Like [`test_state`], but with an injected [`ServiceHealth`] so the

--- a/crates/pdo-daemon/src/run_cost.rs
+++ b/crates/pdo-daemon/src/run_cost.rs
@@ -719,10 +719,8 @@ fn copilot_reported_cost(events: &[crate::event_log::Event], copilot_root: &Path
 
 /// Assemble the Run's cost, **ventilated by harness** (#615, ADR-0052 §3), from its
 /// already-computed `claude` derived slice and a fresh read of the `copilot`
-/// reported slice. Shared by the uncached ([`run_cost_or_absence`]) and cached
-/// ([`run_cost_or_absence_cached`]) paths so the Run line and the Stats aggregate
-/// take the **same** shape (*correctif 5*). `None` when neither harness contributed
-/// a cost (no claude transcript dir and no copilot reading) — the surfaces' "—".
+/// reported slice. `None` when neither harness contributed a cost (no claude
+/// transcript dir and no copilot reading) — the surfaces' "—".
 fn ventilate(
     claude: Option<CostStat>,
     events: &[crate::event_log::Event],
@@ -821,28 +819,6 @@ fn slices_or_empty(ventilated: Option<CostStat>) -> Vec<HarnessCost> {
 /// ids); `claude_root` is the #408 seam's Claude Code `projects/` root; `copilot_root`
 /// is the copilot session-state store root.
 pub(crate) fn run_cost_or_absence(
-    events: &[crate::event_log::Event],
-    claude_root: &Path,
-    copilot_root: &Path,
-    repo_root: &Path,
-    run_id: &str,
-    prices: &PriceTable,
-) -> Option<CostStat> {
-    let uncosted = uncosted_harnesses(events);
-    let claude = compute_run_cost(claude_root, repo_root, run_id, prices);
-    let ventilated = ventilate(claude, events, copilot_root);
-    if !uncosted.is_empty() {
-        return Some(cost_unavailable(uncosted, slices_or_empty(ventilated)));
-    }
-    ventilated
-}
-
-/// [`run_cost_or_absence`] on the memoized claude path (*correctif 5*): the Stats
-/// aggregate and the Run line take the **same** honest, ventilated shape, so a
-/// mixed Run never reads "—" on one surface and a figure on the other. Only the
-/// derived (`claude`) slice is memoized (the expensive transcript fold); the
-/// reported (`copilot`) slice is a cheap re-read of a handful of small journals.
-pub(crate) fn run_cost_or_absence_cached(
     events: &[crate::event_log::Event],
     claude_root: &Path,
     copilot_root: &Path,
@@ -1697,10 +1673,7 @@ mod tests {
     }
 
     #[test]
-    fn the_cached_path_also_says_the_slices_under_an_unavailable_total() {
-        // *Correctif 5* holds under the fix: the Stats aggregate and the Run line
-        // take the same shape, absence included, so a trio Run never ventilates on
-        // one surface and stays mute on the other.
+    fn the_run_cost_path_says_the_slices_under_an_unavailable_total() {
         let home = tempfile::tempdir().unwrap();
         let projects = home.path().join(".claude").join("projects");
         let copilot = home.path().join(".copilot").join("session-state");
@@ -1719,7 +1692,7 @@ mod tests {
             node_started_sid("p", "copilot", "sid-cop-cached"),
         ];
 
-        let cost = run_cost_or_absence_cached(
+        let cost = run_cost_or_absence(
             &events,
             &projects,
             &copilot,

--- a/crates/pdo-daemon/src/run_cost.rs
+++ b/crates/pdo-daemon/src/run_cost.rs
@@ -1002,7 +1002,12 @@ fn breakdown_memo() -> &'static Mutex<BreakdownMemoMap> {
     BREAKDOWN_MEMO.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
-fn copilot_mtime_millis(events: &[crate::event_log::Event], copilot_root: &Path) -> i64 {
+/// Max mtime (epoch millis) across every Copilot `events.jsonl` a Run's own
+/// events reference by `session_id` — the Copilot mirror of
+/// [`max_transcript_mtime_millis`]'s Claude walk. `pub(crate)` so a whole-cohort
+/// cache key (e.g. `stats_performance`'s) can fold a Run's Copilot contribution
+/// in alongside its Claude one without re-deriving this lookup.
+pub(crate) fn copilot_mtime_millis(events: &[crate::event_log::Event], copilot_root: &Path) -> i64 {
     events
         .iter()
         .filter_map(|event| {
@@ -1027,7 +1032,12 @@ fn copilot_mtime_millis(events: &[crate::event_log::Event], copilot_root: &Path)
         .unwrap_or(0)
 }
 
-fn event_fingerprint(events: &[crate::event_log::Event]) -> u64 {
+/// Order-and-content fingerprint of a Run's own event log — any append,
+/// edit, or replay changes it. `pub(crate)` so any other cache keyed on "this
+/// Run's events haven't changed" (not just this module's own cost memo) can
+/// reuse the exact same hash rather than defining a second, possibly
+/// inconsistent one.
+pub(crate) fn event_fingerprint(events: &[crate::event_log::Event]) -> u64 {
     let mut hasher = DefaultHasher::new();
     for event in events {
         event.run_id.hash(&mut hasher);

--- a/crates/pdo-daemon/src/stats_performance.rs
+++ b/crates/pdo-daemon/src/stats_performance.rs
@@ -1,0 +1,1327 @@
+//! `GET /stats/performance` (#585): compare context and duration by Node and
+//! harness across Claude/Copilot. The fifth Stats section, alongside
+//! `stats::stats_overview` and `stats::stats_cost` — same cohort rule (Runs
+//! selected by `run_started` date, full execution retained), same derive-at-read
+//! posture (ADR-0029: no snapshot table, no persisted aggregate, an in-memory
+//! memo only), but its own success-only filter and its own two units (a token
+//! peak, a wall-clock duration) instead of a dollar figure.
+//!
+//! ## Shape
+//!
+//! Wire shape is [`StatsPerformance`]: `harnesses` (the columns), `total` (the
+//! whole cohort pooled — see its doc comment), `by_pipeline` (Pipeline →
+//! Nodes → subagent groups, [`PerformanceEntity`]'s recursive shape), a
+//! separate `infrastructure` branch (no Project view — out of scope) and
+//! `infrastructure_total` (both Infrastructure roles pooled raw, the
+//! `total`/`by_pipeline` split's own mirror one level up — see its doc
+//! comment, #585 review follow-up). The overall tree (`StatsPerformance` /
+//! `StatsPerformanceEntity` / `StatsHarnessPerformance`) is the **agreed seam
+//! with the frontend** (`frontend/src/types.ts`) — that frontend code was this
+//! module's original reference. [`StatsDistribution`] itself has since been
+//! revised past what `frontend/src/types.ts` currently declares (see its own
+//! doc comment: an always-present coverage object with a nullable `stats`
+//! payload, not an all-or-nothing nullable cell) — a change coordinated with,
+//! not silently made against, the frontend owner; `frontend/src/types.ts` is
+//! expected to catch up to this shape, along with the new `infrastructure_total`
+//! field, rather than the other way around. A Node's row
+//! also carries its discovered subagent groups as children — grouped by
+//! declared name, "Unidentified subagent" when none reads as stable (see
+//! [`claude_subagent_group`]) — which never feed their parent's own
+//! distribution (Implementation Decisions: "Le
+//! contexte d'une exécution de Node porte uniquement sur sa session
+//! principale"). Duration is in **milliseconds** (matches the frontend's own
+//! `value / 1_000` seconds conversion); Context is a raw peak token count.
+//!
+//! ## What counts as an observation
+//!
+//! Only a **successful** attempt is an observation, mirroring the issue's
+//! success-only filter: a `NodeStarted` for `(node_id, iter)` must be answered by
+//! a `NodeCompleted`/`NodeAutoCompleted` for the *same* `(node_id, iter)` before
+//! any other terminal event for that key. This single rule, applied by walking
+//! the raw event log exactly like [`crate::run_cost::compute_run_cost_breakdown`]
+//! does for cost, is what naturally satisfies three separate acceptance criteria
+//! with no extra bookkeeping:
+//!
+//! - a loop lap or a restart is a distinct `(node_id, iter)` key → two
+//!   observations, not one;
+//! - an attempt stopped before its restart (`NodeStopped`/`NodeFailed` on that
+//!   key) is simply never matched to a `NodeCompleted` → excluded;
+//! - a script node (`node_type == "script"`) never opens a pending attempt at
+//!   all → never appears in Performance (out of scope, like a failed attempt).
+//!
+//! Infrastructure mirrors the same idea one level up: the Pipeline Manager's one
+//! observation per Run is `RunStarted` → `RunCompleted` (never `RunFailed`); a
+//! Merge resolver's is `MergeResolverStarted` → the next `MergeResolverCompleted`
+//! (resolvers carry no `node_id`/`iter`, so pairing is chronological — only one
+//! resolver runs at a time per Run).
+//!
+//! ## Context resolution
+//!
+//! Context usage is resolved via [`crate::context_peak`] from the same
+//! transcript/journal locations [`crate::run_cost`] already reads (Claude:
+//! `<projects_root>/<encoded_cwd>/<session_id>.jsonl`; Copilot:
+//! `<copilot_root>/<session_id>/events.jsonl`).
+//!
+//! ## Infrastructure subagents — a resolved-by-exclusion session identity
+//!
+//! Neither `RunStarted`/`RunCompleted` nor `MergeResolverStarted`/`Completed`
+//! ever freezes a `session_id` for its role (unlike `NodeStarted`), so an
+//! Infrastructure role's own Context/subagents cannot be read off an event
+//! field the way a Node's can. This module resolves one instead, by exclusion,
+//! narrowly scoped to the one directory each role's turns are known to land
+//! in — mirroring [`crate::run_cost`]'s existing "residual Claude cost"
+//! technique for the same role (whole-run cost minus every attributed Node's
+//! own cost) but working at session granularity, in one directory at a time,
+//! so a discovered session can be traced to its own `subagents/` the same way
+//! a Node's can:
+//!
+//! - **Pipeline Manager** orchestrates from the Run's own top-level working
+//!   directory ([`crate::worktree_ops::worktree_dir_for_run`]) — the same
+//!   directory every non-code-mutating Node also runs in (a code-mutating
+//!   Node gets its own disjoint [`crate::worktree_ops::sub_worktree_path`], so
+//!   it never collides). Every Claude `.jsonl` file in that directory that
+//!   isn't a known Node's own `session_id` is a Pipeline Manager candidate.
+//! - **Merge resolver** operates on the conflicting Node's own worktree
+//!   (`MergeResolverStarted`'s `conflicting_node_id`/`iter` payload fields
+//!   resolve the same `sub_worktree_path` that Node ran in) — every Claude
+//!   `.jsonl` file there that isn't one of that Node's own known
+//!   `session_id`s (across every attempt at that `(node_id, iter)`, including
+//!   a stopped-then-restarted one) is a Merge resolver candidate.
+//!
+//! Exactly one remaining candidate is attributed to the role (its own Context
+//! peak, its own `subagents/`, read exactly like a Node's — a subagent still
+//! counts even if the role's own attempt around it later failed, matching a
+//! Node's own subagent semantics). Zero candidates is an ordinary absence (the
+//! role made no attributable Claude calls, or ran under a harness with no
+//! session-file source at all — Copilot's session store has no per-directory
+//! nesting to exclude from, so it can never resolve one). More than one
+//! candidate — or a shared directory containing a non-code-mutating,
+//! non-script Claude Node with **no** recorded `session_id` at all, so it
+//! can't be excluded by name — is an ambiguous result, never guessed at by
+//! path or timing alone (issue: "Une session historique sans identité fiable
+//! n'est jamais attribuée par proximité temporelle ou par chemin").
+
+use std::collections::hash_map::DefaultHasher;
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::hash::{Hash, Hasher};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex, OnceLock};
+
+use axum::extract::{Query, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::distribution::r7_distribution;
+use crate::event_log::EventKind;
+use crate::AppState;
+
+/// Query string: an ISO-8601 `[from, to)` window — the same cohort rule as
+/// `/stats/overview` and `/stats/cost`, but no `bucket`: Performance has no
+/// time-series axis (out of scope, "Afficher des graphes temporels").
+#[derive(Debug, Deserialize)]
+pub(crate) struct PerformanceQuery {
+    pub from: String,
+    pub to: String,
+    /// Explicit user refresh bypasses an otherwise-current memo entry.
+    #[serde(default)]
+    pub refresh: bool,
+}
+
+/// One metric's (Context or Duration) coverage for one row × one harness:
+/// `measured` readable values out of `expected` (successful attempts, whether
+/// or not this metric could be read for them), why any gap between the two
+/// exists, and the R-7 six-stat summary — present only when `measured > 0`.
+///
+/// This object is **never null on the wire**: coverage (`measured`/`expected`/
+/// `missing_reasons`) is a property of the metric itself and must stay visible
+/// even when nothing was measured at all — "une mesure absente ne devient
+/// jamais zéro" means the absence must be *explained*, not that the coverage
+/// bookkeeping disappears with it. Only `stats` — the six numbers a boxplot
+/// needs — becomes `null`, and only when `measured == 0` (there is nothing to
+/// summarize). This was changed from an earlier all-or-nothing `Option<...>`
+/// cell precisely because that shape silently dropped `expected`/
+/// `missing_reasons` for a fully absent metric, which the frontend cannot
+/// honestly render ("never ran" vs "no reliable bounds" need to stay
+/// distinguishable even with zero readable values).
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub(crate) struct StatsDistribution {
+    pub stats: Option<crate::distribution::SixStats>,
+    pub measured: i64,
+    pub expected: i64,
+    pub missing_reasons: Vec<String>,
+}
+
+/// Context + Duration for one row, under one harness. Matches the frontend's
+/// `StatsHarnessPerformance` — `context`/`duration` are always a
+/// [`StatsDistribution`] object, never `null` (see its doc comment).
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub(crate) struct StatsHarnessPerformance {
+    pub harness: String,
+    pub context: StatsDistribution,
+    pub duration: StatsDistribution,
+}
+
+/// One row's metrics across every harness it saw at least one successful
+/// observation under. Matches the frontend's `StatsPerformanceAggregate`.
+#[derive(Debug, Clone, Default, PartialEq, Serialize)]
+pub(crate) struct PerformanceAggregate {
+    pub harnesses: Vec<StatsHarnessPerformance>,
+}
+
+/// One node in the Pipeline→Node / Infrastructure→role / subagent-group tree —
+/// a single recursive shape for all three, matching the frontend's
+/// `StatsPerformanceEntity` (`extends StatsPerformanceAggregate`, i.e. an `id`
+/// and `name` plus the same `harnesses` field, plus `nodes` and `subagents`
+/// children). A Pipeline's `subagents` is always empty (subagents are declared
+/// on Nodes, never Pipelines); a Node's/subagent-group's `nodes` is always
+/// empty (no further nesting below a Node); an Infrastructure role's `nodes`
+/// is always empty, but its `subagents` is populated exactly like a Node's
+/// (issue user story #36 — see the module doc's "Infrastructure subagents"
+/// section for how a role's own session is found).
+#[derive(Debug, Clone, Default, PartialEq, Serialize)]
+pub(crate) struct PerformanceEntity {
+    pub id: String,
+    pub name: String,
+    pub harnesses: Vec<StatsHarnessPerformance>,
+    pub nodes: Vec<PerformanceEntity>,
+    pub subagents: Vec<PerformanceEntity>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize)]
+pub(crate) struct StatsPerformance {
+    /// Every harness with at least one successful observation in the cohort —
+    /// the columns the client renders (Claude/Copilot today; ADR-0051 leaves
+    /// room for more without a client change).
+    pub harnesses: Vec<String>,
+    /// Every successful main-session Node observation pooled across the WHOLE
+    /// cohort (every Pipeline, every Node) — the same "pool the raw
+    /// observations, don't average the averages" rule the issue applies to a
+    /// Pipeline's own Nodes, just one level up. Deliberately excludes
+    /// Infrastructure roles (Pipeline Manager / Merge resolver measure a
+    /// different kind of thing — a whole Run's or resolver's wall-clock, not a
+    /// Node execution) — a scoped assumption, since the issue does not spell
+    /// out whether the headline figure should blend the two.
+    pub total: PerformanceAggregate,
+    pub by_pipeline: Vec<PerformanceEntity>,
+    pub infrastructure: Vec<PerformanceEntity>,
+    /// Every successful Infrastructure-role observation (Pipeline Manager's own
+    /// occurrences and Merge resolver's own occurrences) pooled together at the
+    /// **raw-observation** level — never a mean of the two roles' own means.
+    /// This exists precisely so the client's master/detail view (the whole
+    /// Infrastructure branch's own boxplot, alongside its two rows'
+    /// individually) never has to fabricate one by averaging averages, the
+    /// same failure mode [`Self::total`] avoids for Pipeline → Node (#585
+    /// review follow-up, blocker 3). Never pools a role's `subagents` — those
+    /// stay scoped to their own role, exactly like a Node's subagents are
+    /// never folded into [`Self::total`] either.
+    pub infrastructure_total: PerformanceAggregate,
+}
+
+/// Why the whole request failed, distinct from a per-observation absence
+/// (issue: "Une source entière illisible produit une erreur visible... Une
+/// session isolée sans télémétrie exploitable produit une absence locale").
+pub(crate) enum PerformanceError {
+    /// A harness's entire transcript/journal root exists but could not be
+    /// listed (permissions, corrupted mount, …) — as opposed to `NotFound`,
+    /// which just means "no sessions yet" and is not an error.
+    SourceUnreadable(String),
+    Db(String),
+}
+
+impl IntoResponse for PerformanceError {
+    fn into_response(self) -> Response {
+        let message = match self {
+            PerformanceError::SourceUnreadable(msg) => msg,
+            PerformanceError::Db(e) => format!("stats performance failed: {e}"),
+        };
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({ "error": message })),
+        )
+            .into_response()
+    }
+}
+
+/// `GET /stats/performance` — Class B heavy read (fans over the harness
+/// transcript corpora), fetched lazily on-demand only (issue: "Performance ne
+/// charge ses données qu'à son ouverture ou lors d'un Refresh explicite" — the
+/// client, not this handler, owns the "on demand" half; this handler simply
+/// never runs on a timer).
+pub(crate) async fn stats_performance(
+    State(state): State<Arc<AppState>>,
+    Query(q): Query<PerformanceQuery>,
+) -> Response {
+    match compute_performance(&state, &q.from, &q.to, q.refresh).await {
+        Ok(payload) => Json(payload).into_response(),
+        Err(error) => error.into_response(),
+    }
+}
+
+// --- Accumulation --------------------------------------------------------------
+
+/// Running fold for one metric on one row × harness: raw readable values (for
+/// the eventual R-7 fold) plus the expected/absent bookkeeping.
+#[derive(Debug, Default)]
+struct MetricAcc {
+    values: Vec<f64>,
+    expected: i64,
+    absence_reasons: BTreeSet<String>,
+}
+
+impl MetricAcc {
+    fn observe(&mut self, value: Option<f64>, absence_reason: Option<&str>) {
+        self.expected += 1;
+        match value {
+            Some(v) => self.values.push(v),
+            None => {
+                if let Some(reason) = absence_reason {
+                    self.absence_reasons.insert(reason.to_string());
+                }
+            }
+        }
+    }
+
+    /// Always returns a coverage object; `stats` is `None` only when nothing
+    /// was readable at all (`measured == 0`) — see [`StatsDistribution`]'s doc
+    /// comment.
+    fn finish(self) -> StatsDistribution {
+        StatsDistribution {
+            stats: r7_distribution(&self.values),
+            measured: self.values.len() as i64,
+            expected: self.expected,
+            missing_reasons: self.absence_reasons.into_iter().collect(),
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct HarnessAcc {
+    context: MetricAcc,
+    duration: MetricAcc,
+}
+
+impl HarnessAcc {
+    fn finish(self, harness: String) -> StatsHarnessPerformance {
+        StatsHarnessPerformance {
+            harness,
+            context: self.context.finish(),
+            duration: self.duration.finish(),
+        }
+    }
+}
+
+fn finish_by_harness(acc: BTreeMap<String, HarnessAcc>) -> Vec<StatsHarnessPerformance> {
+    acc.into_iter().map(|(h, a)| a.finish(h)).collect()
+}
+
+#[derive(Debug, Default)]
+struct SubagentAcc {
+    by_harness: BTreeMap<String, HarnessAcc>,
+}
+
+#[derive(Debug, Default)]
+struct NodeAcc {
+    name: String,
+    by_harness: BTreeMap<String, HarnessAcc>,
+    subagents: BTreeMap<String, SubagentAcc>,
+}
+
+fn finish_subagents(subagents: BTreeMap<String, SubagentAcc>) -> Vec<PerformanceEntity> {
+    subagents
+        .into_iter()
+        .map(|(group, acc)| PerformanceEntity {
+            id: group.clone(),
+            name: group,
+            harnesses: finish_by_harness(acc.by_harness),
+            nodes: Vec::new(),
+            subagents: Vec::new(),
+        })
+        .collect()
+}
+
+fn finish_node(id: String, acc: NodeAcc) -> PerformanceEntity {
+    PerformanceEntity {
+        id,
+        name: acc.name,
+        harnesses: finish_by_harness(acc.by_harness),
+        nodes: Vec::new(),
+        subagents: finish_subagents(acc.subagents),
+    }
+}
+
+/// Same shape as [`finish_node`], for an Infrastructure role — `id`/`name` are
+/// the role's own fixed identity, not `acc.name` (an infra `NodeAcc` never
+/// sets it).
+fn finish_infra_role(id: &str, name: &str, acc: NodeAcc) -> PerformanceEntity {
+    PerformanceEntity {
+        id: id.to_string(),
+        name: name.to_string(),
+        harnesses: finish_by_harness(acc.by_harness),
+        nodes: Vec::new(),
+        subagents: finish_subagents(acc.subagents),
+    }
+}
+
+#[derive(Debug, Default)]
+struct PipelineAcc {
+    name: String,
+    by_harness: BTreeMap<String, HarnessAcc>,
+    nodes: BTreeMap<String, NodeAcc>,
+}
+
+fn finish_pipeline(id: String, acc: PipelineAcc) -> PerformanceEntity {
+    PerformanceEntity {
+        id,
+        name: acc.name,
+        harnesses: finish_by_harness(acc.by_harness),
+        nodes: acc
+            .nodes
+            .into_iter()
+            .map(|(id, node)| finish_node(id, node))
+            .collect(),
+        subagents: Vec::new(),
+    }
+}
+
+// --- Node identity/type resolution ---------------------------------------------
+
+fn node_defs_from_payload(payload: &Value) -> BTreeMap<String, (String, String)> {
+    let mut defs = BTreeMap::new();
+    if let Some(list) = payload.get("node_defs").and_then(|v| v.as_array()) {
+        for def in list {
+            let Some(id) = def.get("id").and_then(|v| v.as_str()) else {
+                continue;
+            };
+            let name = def
+                .get("name")
+                .and_then(|v| v.as_str())
+                .unwrap_or(id)
+                .to_string();
+            let node_type = def
+                .get("node_type")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            defs.insert(id.to_string(), (name, node_type));
+        }
+    }
+    defs
+}
+
+// --- Subagent declared-group heuristic ------------------------------------------
+
+/// Whether `stem` reads as an opaque, machine-generated identifier (a UUID, or
+/// a long run of hex digits) rather than a human-legible declared name.
+fn looks_like_opaque_id(stem: &str) -> bool {
+    let is_uuid = stem.len() == 36
+        && stem.as_bytes().iter().enumerate().all(|(i, b)| match i {
+            8 | 13 | 18 | 23 => *b == b'-',
+            _ => b.is_ascii_hexdigit(),
+        });
+    let is_long_hex = stem.len() >= 16 && stem.chars().all(|c| c.is_ascii_hexdigit());
+    is_uuid || is_long_hex
+}
+
+/// The declared group a discovered subagent transcript file falls under
+/// (issue user stories #27/#28): the file's own name, verbatim, unless it reads
+/// as an opaque generated id — in which case the harness declared no stable
+/// identity and the file falls into the explicit "Unidentified subagent"
+/// fallback bucket, so it is never silently dropped.
+///
+/// **Scoped assumption**: no real Claude Code subagent transcript naming
+/// convention is confirmed anywhere in this repository (only anonymous
+/// filenames like `side.jsonl` appear in existing fixtures/tests, see
+/// `run_cost.rs`). Filename is the only signal available without inventing an
+/// unconfirmed in-transcript field, so it is the one used here; if a harness's
+/// subagent files are later found to embed a `subagent_type` (or similar) key,
+/// this is the seam to extend.
+fn claude_subagent_group(file_stem: &str) -> String {
+    if file_stem.is_empty() || looks_like_opaque_id(file_stem) {
+        "Unidentified subagent".to_string()
+    } else {
+        file_stem.to_string()
+    }
+}
+
+// --- Source readability (visible endpoint error) --------------------------------
+
+/// Confirm `root` (a harness's whole transcript/journal source) is listable, or
+/// name it in a visible error. `NotFound` is not an error — it means "this
+/// harness has never written a session yet", not "the source is broken".
+/// Checked once per distinct root the cohort touches (memoized by the caller),
+/// never per session — a single unreadable session degrades to a local,
+/// silent absence instead (issue's explicit source-vs-session distinction).
+fn ensure_source_readable(root: &Path, harness_label: &str) -> Result<(), PerformanceError> {
+    if !root.exists() {
+        return Ok(());
+    }
+    match std::fs::read_dir(root) {
+        Ok(_) => Ok(()),
+        Err(error) => Err(PerformanceError::SourceUnreadable(format!(
+            "{harness_label} transcript source at {} is unreadable: {error}",
+            root.display()
+        ))),
+    }
+}
+
+// --- Context/duration resolution -------------------------------------------------
+
+fn parse_ts(ts: &str) -> Option<chrono::DateTime<chrono::FixedOffset>> {
+    chrono::DateTime::parse_from_rfc3339(ts).ok()
+}
+
+fn duration_millis(started_at: &str, completed_at: &str) -> Option<f64> {
+    let start = parse_ts(started_at)?;
+    let end = parse_ts(completed_at)?;
+    Some((end - start).num_milliseconds() as f64)
+}
+
+/// One harness's storage root to resolve a session's transcript against — the
+/// one remaining harness-name check in this module, and deliberately not one
+/// [`crate::harness_probes`] absorbs: it picks between two independently
+/// **computed** roots (a per-Run, sandbox-aware Claude root vs a global,
+/// home-based Copilot root, see [`compute_performance`]), not between two
+/// **behaviours**. ADR-0051 governs the latter — which parser reads a
+/// transcript, which directory convention finds a subagent — and both of
+/// those now dispatch exclusively through `crate::harness_probes` below, never
+/// through a `match harness.as_str() { .. }` written in this module.
+fn source_root<'a>(harness: &str, claude_root: &'a Path, copilot_root: &'a Path) -> &'a Path {
+    if harness == crate::harness_registry::COPILOT {
+        copilot_root
+    } else {
+        claude_root
+    }
+}
+
+/// One harness's context peak for one main session, or the absence reason.
+/// Dispatches exclusively through [`crate::harness_probes`] (ADR-0051): this
+/// function never names `claude_session_peak`/`copilot_session_peak`, nor
+/// `claude`/`copilot`'s own transcript path convention — it asks
+/// [`crate::harness_probes::resolve_transcript`] for the file and
+/// [`crate::harness_probes::context_peak`] for the reading, gated on
+/// [`crate::harness_probes::can_measure_context`]. The source's readability is
+/// checked here too (once per distinct root, via `seen_roots`) — only for a
+/// harness that actually has a context-usage source, so an unrelated harness
+/// (e.g. `opencode`) never triggers a Claude/Copilot root check it doesn't need.
+fn main_session_context(
+    harness: &str,
+    root: &Path,
+    working_dir: &Path,
+    session_id: Option<&str>,
+    seen_roots: &mut HashSet<PathBuf>,
+) -> Result<(Option<f64>, Option<&'static str>), PerformanceError> {
+    if !crate::harness_probes::can_measure_context(harness) {
+        return Ok((None, Some("harness has no context-usage source")));
+    }
+    check_root_once(root, &harness_display_label(harness), seen_roots)?;
+    let Some(session_id) = session_id.filter(|s| !s.is_empty()) else {
+        return Ok((None, Some("no session identity")));
+    };
+    let Some(path) =
+        crate::harness_probes::resolve_transcript(harness, root, working_dir, Some(session_id))
+    else {
+        return Ok((None, Some("no attributable transcript")));
+    };
+    Ok(match std::fs::read_to_string(&path) {
+        Ok(text) => match crate::harness_probes::context_peak(harness, &text) {
+            Some(peak) => (Some(peak as f64), None),
+            None => (None, Some("no readable context usage in transcript")),
+        },
+        Err(_) => (None, Some("no attributable transcript")),
+    })
+}
+
+/// The subagent transcript files discovered for one main session under
+/// `harness`, already grouped into their declared label ([`claude_subagent_group`]).
+/// Dispatches exclusively through [`crate::harness_probes::subagent_transcripts`]
+/// (ADR-0051): a harness with no nested-subagent convention (every harness but
+/// `claude` today, `copilot` included — see [`crate::harness_probes`]'s
+/// `CopilotProbes` doc comment for the investigated motive) answers an empty
+/// `Vec` from the dispatch itself, never a `match`/`if harness == ..` written
+/// here.
+fn subagent_groups(
+    harness: &str,
+    root: &Path,
+    working_dir: &Path,
+    session_id: Option<&str>,
+) -> Vec<(String, String)> {
+    let Some(session_id) = session_id.filter(|s| !s.is_empty()) else {
+        return Vec::new();
+    };
+    crate::harness_probes::subagent_transcripts(harness, root, working_dir, session_id)
+        .into_iter()
+        .map(|(stem, text)| (claude_subagent_group(&stem), text))
+        .collect()
+}
+
+// --- The per-run walk ------------------------------------------------------------
+
+struct PendingNode {
+    started_at: String,
+    harness: String,
+    session_id: Option<String>,
+    node_type: String,
+}
+
+/// A `MergeResolverStarted` awaiting its pairing `MergeResolverCompleted` —
+/// `conflicting_node_id`/`iter` (its own payload fields) resolve the working
+/// directory an attributed session is looked for in (see the module doc's
+/// "Infrastructure subagents" section).
+struct MergeResolverPending {
+    started_at: String,
+    conflicting_node_id: Option<String>,
+    iter: Option<i64>,
+}
+
+/// Fold every discovered subagent transcript (already labelled by
+/// [`subagent_groups`]) into `subagents`' declared groups, under `harness`.
+/// Shared between a Node's own subagents and an Infrastructure role's (issue
+/// user story #36 — a role's subagents are grouped exactly like a Node's).
+///
+/// The context peak dispatches through [`crate::harness_probes::context_peak`]
+/// (ADR-0051), like every other reading in this module. The duration span does
+/// not: no capability marker exists yet for "start/end bounds from a
+/// transcript" (only Claude's subagent convention exists at all today, see
+/// [`crate::harness_probes`]'s `CopilotProbes` doc comment), so
+/// [`crate::context_peak::claude_transcript_time_span`] stays a direct call —
+/// the seam to extend if a second harness ever grows subagent transcripts of
+/// its own with a different span shape.
+fn fold_subagents(
+    subagents: &mut BTreeMap<String, SubagentAcc>,
+    files: Vec<(String, String)>,
+    harness: &str,
+) {
+    for (group, text) in files {
+        let sub = subagents.entry(group).or_default();
+        let sub_acc = sub.by_harness.entry(harness.to_string()).or_default();
+        let peak = crate::harness_probes::context_peak(harness, &text);
+        sub_acc.context.observe(
+            peak.map(|p| p as f64),
+            (peak.is_none()).then_some("no readable context usage in transcript"),
+        );
+        let span = crate::context_peak::claude_transcript_time_span(&text);
+        let sub_duration = span.and_then(|(a, b)| duration_millis(&a, &b));
+        sub_acc.duration.observe(
+            sub_duration,
+            sub_duration
+                .is_none()
+                .then_some("no reliable start/end bounds in subagent transcript"),
+        );
+    }
+}
+
+/// Resolve one successful main-session Node execution's Context/Duration into
+/// `node_acc` (its Node), `pipeline_by_harness` (its Pipeline, pooled) and
+/// `total_by_harness` (the whole cohort, pooled one level further — see
+/// [`StatsPerformance::total`]'s doc comment) alike, and fold every discovered
+/// subagent transcript into the Node's own subagent groups (never into any of
+/// the three harness accumulators — Implementation Decisions).
+#[allow(clippy::too_many_arguments)]
+fn record_node_success(
+    node_acc: &mut NodeAcc,
+    pipeline_by_harness: &mut BTreeMap<String, HarnessAcc>,
+    total_by_harness: &mut BTreeMap<String, HarnessAcc>,
+    claude_root: &Path,
+    copilot_root: &Path,
+    working_dir: &Path,
+    pending: &PendingNode,
+    completed_at: &str,
+    seen_roots: &mut HashSet<PathBuf>,
+) -> Result<(), PerformanceError> {
+    let harness = pending.harness.clone();
+    let root = source_root(&harness, claude_root, copilot_root);
+    let (context, reason) = main_session_context(
+        &harness,
+        root,
+        working_dir,
+        pending.session_id.as_deref(),
+        seen_roots,
+    )?;
+    let duration = duration_millis(&pending.started_at, completed_at);
+
+    for acc in [
+        node_acc.by_harness.entry(harness.clone()).or_default(),
+        pipeline_by_harness.entry(harness.clone()).or_default(),
+        total_by_harness.entry(harness.clone()).or_default(),
+    ] {
+        acc.context.observe(context, reason);
+        acc.duration.observe(
+            duration,
+            duration.is_none().then_some("unparseable timestamp"),
+        );
+    }
+
+    let files = subagent_groups(&harness, root, working_dir, pending.session_id.as_deref());
+    fold_subagents(&mut node_acc.subagents, files, &harness);
+
+    Ok(())
+}
+
+/// Capitalize `harness`'s first letter for a human-facing message (`"claude"`
+/// → `"Claude"`, `"copilot"` → `"Copilot"`) — display prose, not a capability
+/// decision, so it needs no `match`/dispatch: every harness name capitalizes
+/// the same way.
+fn harness_display_label(harness: &str) -> String {
+    let mut chars = harness.chars();
+    match chars.next() {
+        Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+        None => String::new(),
+    }
+}
+
+fn check_root_once(
+    root: &Path,
+    label: &str,
+    seen: &mut HashSet<PathBuf>,
+) -> Result<(), PerformanceError> {
+    if seen.insert(root.to_path_buf()) {
+        ensure_source_readable(root, label)?;
+    }
+    Ok(())
+}
+
+// --- Infrastructure role session resolution (by exclusion) -----------------------
+
+/// Every Claude `session_id` a Node is known to have opened at `(node_id,
+/// iter)`, across every attempt (including a stopped-then-restarted one that
+/// shares the same working directory) — the exclusion list an Infrastructure
+/// role's own session is resolved against. Populated for every `NodeStarted`
+/// seen, regardless of node type or outcome, since even a failed/stopped
+/// attempt's session file still occupies the shared directory.
+#[derive(Debug, Clone)]
+struct NodeStartRecord {
+    node_type: String,
+    harness: String,
+    session_id: Option<String>,
+}
+
+/// One directory's worth of Claude sessions, resolved down to the ONE not
+/// already known to belong to a Node — or why that couldn't be done. Mirrors
+/// `run_cost.rs`'s `ambiguous_shared_claude` guard, but at session (not
+/// dollar) granularity: an ambiguous directory is never attributed by path
+/// alone (see the module doc's "Infrastructure subagents" section).
+enum InfraSession {
+    /// Exactly one unattributed `.jsonl` file: `(project_dir, session_id)`.
+    One(PathBuf, String),
+    /// The directory doesn't exist, or every file in it is already a known
+    /// Node's own session — an ordinary, non-ambiguous absence.
+    None,
+    /// More than one unattributed file, or a Claude Node shares this directory
+    /// with no recorded `session_id` at all (so it can't be excluded by name)
+    /// — cannot be safely attributed to anything.
+    Ambiguous,
+}
+
+fn resolve_infra_session(
+    claude_root: &Path,
+    working_dir: &Path,
+    excluded_session_ids: &HashSet<String>,
+    directory_ambiguous: bool,
+) -> InfraSession {
+    if directory_ambiguous {
+        return InfraSession::Ambiguous;
+    }
+    let project_dir = claude_root.join(crate::run_cost::cc_project_dirname(working_dir));
+    let Ok(entries) = std::fs::read_dir(&project_dir) else {
+        return InfraSession::None;
+    };
+    let mut candidates = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
+            continue;
+        }
+        let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+            continue;
+        };
+        if excluded_session_ids.contains(stem) {
+            continue;
+        }
+        candidates.push(stem.to_string());
+    }
+    match candidates.len() {
+        0 => InfraSession::None,
+        1 => InfraSession::One(project_dir, candidates.remove(0)),
+        _ => InfraSession::Ambiguous,
+    }
+}
+
+/// Context peak + subagent transcripts for one resolved Infrastructure-role
+/// Claude session, or the motivated absence when none could be attributed.
+/// Read exactly like a Node's own session (`main_session_context`/
+/// `subagent_groups`) — a subagent still counts even if the role's own
+/// attempt around it later failed (same semantics as a Node's subagents).
+/// `harness` is threaded through to the dispatch calls (ADR-0051) even though
+/// the caller only ever reaches this for `claude` today (the resolve-by-
+/// exclusion directory scan above it is structurally Claude-only, see the
+/// module doc's "Infrastructure subagents" section) — so this stays correct
+/// unchanged if a second harness ever grows the same directory convention.
+fn infra_claude_observation(
+    harness: &str,
+    claude_root: &Path,
+    working_dir: &Path,
+    excluded_session_ids: &HashSet<String>,
+    directory_ambiguous: bool,
+) -> (Option<f64>, Option<&'static str>, Vec<(String, String)>) {
+    match resolve_infra_session(
+        claude_root,
+        working_dir,
+        excluded_session_ids,
+        directory_ambiguous,
+    ) {
+        InfraSession::Ambiguous => (
+            None,
+            Some("ambiguous session identity in a directory shared with a Node"),
+            Vec::new(),
+        ),
+        InfraSession::None => (
+            None,
+            Some("no attributable session for this infrastructure role"),
+            Vec::new(),
+        ),
+        InfraSession::One(project_dir, session_id) => {
+            let path = project_dir.join(format!("{session_id}.jsonl"));
+            match std::fs::read_to_string(&path) {
+                Ok(text) => {
+                    let peak = crate::harness_probes::context_peak(harness, &text);
+                    let subs =
+                        subagent_groups(harness, claude_root, working_dir, Some(&session_id));
+                    (
+                        peak.map(|p| p as f64),
+                        peak.is_none()
+                            .then_some("no readable context usage in transcript"),
+                        subs,
+                    )
+                }
+                Err(_) => (None, Some("no attributable transcript"), Vec::new()),
+            }
+        }
+    }
+}
+
+/// Resolve and fold one Infrastructure role's Context/Duration/subagents for
+/// one occurrence into `acc` (its own role) and `infra_total_by_harness` (both
+/// roles pooled, raw — [`StatsPerformance::infrastructure_total`]'s doc
+/// comment) alike — shared by the Pipeline Manager and Merge resolver arms of
+/// the per-run walk (they differ only in which directory and exclusion set
+/// apply).
+#[allow(clippy::too_many_arguments)]
+fn record_infra_success(
+    acc: &mut NodeAcc,
+    infra_total_by_harness: &mut BTreeMap<String, HarnessAcc>,
+    run_harness: &str,
+    claude_root: &Path,
+    working_dir: Option<&Path>,
+    excluded_session_ids: &HashSet<String>,
+    directory_ambiguous: bool,
+    duration: Option<f64>,
+    seen_roots: &mut HashSet<PathBuf>,
+) -> Result<(), PerformanceError> {
+    let (context, reason, subs) = if run_harness != crate::harness_registry::CLAUDE {
+        (
+            None,
+            Some("harness has no context-usage source"),
+            Vec::new(),
+        )
+    } else if let Some(working_dir) = working_dir {
+        check_root_once(claude_root, &harness_display_label(run_harness), seen_roots)?;
+        infra_claude_observation(
+            run_harness,
+            claude_root,
+            working_dir,
+            excluded_session_ids,
+            directory_ambiguous,
+        )
+    } else {
+        (
+            None,
+            Some("no attributable session for this infrastructure role"),
+            Vec::new(),
+        )
+    };
+
+    let harness_acc = acc.by_harness.entry(run_harness.to_string()).or_default();
+    harness_acc.context.observe(context, reason);
+    harness_acc.duration.observe(
+        duration,
+        duration.is_none().then_some("unparseable timestamp"),
+    );
+
+    let total_acc = infra_total_by_harness
+        .entry(run_harness.to_string())
+        .or_default();
+    total_acc.context.observe(context, reason);
+    total_acc.duration.observe(
+        duration,
+        duration.is_none().then_some("unparseable timestamp"),
+    );
+
+    if run_harness == crate::harness_registry::CLAUDE {
+        fold_subagents(&mut acc.subagents, subs, run_harness);
+    }
+
+    Ok(())
+}
+
+// --- Whole-cohort memo -------------------------------------------------------
+//
+// The issue requires the result "cached in memory according to events and
+// observed sources" (not persisted — ADR-0029) — the same posture
+// `run_cost.rs`'s per-Run breakdown memo already established, just pitched one
+// level up: `compute_performance` folds the WHOLE cohort into shared mutable
+// accumulators in a single entangled pass (unlike a per-Run breakdown, no
+// piece of it is an independent, separately-memoizable result), so this memos
+// the **whole computed [`StatsPerformance`]** rather than a per-Run slice.
+//
+// The key is `(from, to, fingerprint)`, where `fingerprint` folds — for every
+// Run whose `RunStarted` falls in `[from, to)` — that Run's own event-log
+// fingerprint ([`crate::run_cost::event_fingerprint`], reused verbatim so the
+// two memos can never disagree about what "the events changed" means) and the
+// max mtime across every transcript/journal file the Run's own events could
+// possibly reference, Claude ([`crate::run_cost::max_transcript_mtime_millis`])
+// and Copilot ([`crate::run_cost::copilot_mtime_millis`]) alike. A new event
+// appended to any Run in range, a rewritten transcript, or a widened `[from,
+// to)` all change the key and force a recompute; nothing outside that
+// footprint can silently go stale, and nothing inside it can silently serve a
+// stale answer. `[from, to)` is part of the key (not just an input folded into
+// the fingerprint) so two different windows can never collide even if their
+// event footprints coincided.
+//
+// A subtlety worth spelling out: this key intentionally does **not** cover a
+// residual Infrastructure session discovered by exclusion (Pipeline
+// Manager/Merge resolver's own directory scan) with its own separate mtime —
+// that discovery only ever walks a directory this same Run's own Claude root
+// already covers via `max_transcript_mtime_millis`'s recursive walk, so a new
+// or rewritten residual file already bumps the same max.
+//
+// No explicit cache-busting query parameter exists (or is needed): the issue
+// describes "Refresh" as the client re-issuing the identical `[from, to)`
+// query on demand (Implementation Decisions: "l'utilisateur déclenche
+// Refresh"), and the natural key already recomputes whenever anything in that
+// window actually changed — a same-window, no-new-data Refresh reusing the
+// memoized answer is the cache doing its job, not staleness.
+const PERFORMANCE_MEMO_CAP: usize = 256;
+
+type PerformanceMemoKey = (String, String, u64);
+type PerformanceMemoMap = HashMap<PerformanceMemoKey, StatsPerformance>;
+
+static PERFORMANCE_MEMO: OnceLock<Mutex<PerformanceMemoMap>> = OnceLock::new();
+
+fn performance_memo() -> &'static Mutex<PerformanceMemoMap> {
+    PERFORMANCE_MEMO.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Test-only recompute counter, keyed by the exact memo key — proves a memo
+/// hit truly skips [`fold_performance`] rather than merely producing an
+/// identical answer by coincidence. Keyed (not a bare total) so tests running
+/// concurrently in the same process never interfere with each other as long
+/// as each picks its own `[from, to)` window (the convention every test below
+/// follows). `#[cfg(test)]`-gated: zero footprint in the production binary.
+#[cfg(test)]
+static RECOMPUTE_COUNTS: OnceLock<Mutex<HashMap<PerformanceMemoKey, u32>>> = OnceLock::new();
+
+#[cfg(test)]
+fn record_recompute_for_test(key: &PerformanceMemoKey) {
+    let mut counts = RECOMPUTE_COUNTS
+        .get_or_init(|| Mutex::new(HashMap::new()))
+        .lock()
+        .unwrap_or_else(|error| error.into_inner());
+    *counts.entry(key.clone()).or_insert(0) += 1;
+}
+
+/// Total number of times [`fold_performance`] actually ran for requests whose
+/// `[from, to)` matched `(from, to)` — regardless of which fingerprint hash
+/// accompanied each call. `pub(crate)` so `lib.rs`'s HTTP-contract tests can
+/// assert a repeat request was served from the memo (count unchanged) or
+/// correctly forced a recompute (count incremented) without reaching into the
+/// map's internals.
+#[cfg(test)]
+pub(crate) fn recompute_count_for_test(from: &str, to: &str) -> u32 {
+    RECOMPUTE_COUNTS
+        .get_or_init(|| Mutex::new(HashMap::new()))
+        .lock()
+        .unwrap_or_else(|error| error.into_inner())
+        .iter()
+        .filter(|((f, t, _), _)| f == from && t == to)
+        .map(|(_, count)| *count)
+        .sum()
+}
+
+/// One Run's own pre-loaded material for the heavy fold — split out of the
+/// cheap event-log + mtime pass (`compute_performance`) so a memo hit never
+/// has to pay for [`fold_performance`]'s transcript reads (context peak
+/// parsing, subagent directory scans) at all, only the cheap DB reads and
+/// `stat` calls needed to know whether anything changed.
+struct RunContext {
+    run_id: String,
+    payload: Value,
+    events: Vec<crate::event_log::Event>,
+    claude_root: PathBuf,
+    repo_root: PathBuf,
+}
+
+// --- Whole-cohort computation ------------------------------------------------------
+
+async fn compute_performance(
+    state: &AppState,
+    from: &str,
+    to: &str,
+    refresh: bool,
+) -> Result<StatsPerformance, PerformanceError> {
+    let rows = sqlx::query_as::<_, (String, Option<String>)>(
+        "SELECT run_id, payload FROM events \
+         WHERE kind = 'run_started' AND ts >= ? AND ts < ? ORDER BY ts",
+    )
+    .bind(from)
+    .bind(to)
+    .fetch_all(&state.db)
+    .await
+    .map_err(|e| PerformanceError::Db(e.to_string()))?;
+
+    let (home_root, sandbox_root) =
+        crate::sandbox_run::sandbox_home_roots(state).unwrap_or_else(|_| {
+            let home = PathBuf::from(std::env::var("HOME").unwrap_or_default());
+            let sandbox = home.join(".pdo").join("sandbox");
+            (home, sandbox)
+        });
+    let copilot_root = crate::sandbox_run::copilot_store_root(&home_root);
+
+    let mut contexts: Vec<RunContext> = Vec::new();
+    let mut key_hasher = DefaultHasher::new();
+    for (run_id, payload) in rows {
+        let payload: Value = payload
+            .as_deref()
+            .and_then(|p| serde_json::from_str(p).ok())
+            .unwrap_or(Value::Null);
+        let repo_root = payload
+            .get("target_repo")
+            .and_then(|v| v.as_str())
+            .map(PathBuf::from)
+            .unwrap_or_else(|| state.repo_root.clone());
+        let sandboxed = payload
+            .get("sandbox")
+            .and_then(|v| v.as_str())
+            .is_some_and(|s| {
+                let t = s.trim();
+                !t.is_empty() && !t.eq_ignore_ascii_case(crate::event_log::SandboxMode::OFF_WIRE)
+            });
+        let claude_root =
+            crate::sandbox_run::transcripts_root(sandboxed, &run_id, &home_root, &sandbox_root);
+
+        let events = crate::load_events(&state.db, &run_id)
+            .await
+            .map_err(|e| PerformanceError::Db(e.to_string()))?;
+
+        run_id.hash(&mut key_hasher);
+        crate::run_cost::event_fingerprint(&events).hash(&mut key_hasher);
+        crate::run_cost::max_transcript_mtime_millis(&claude_root, &repo_root, &run_id)
+            .hash(&mut key_hasher);
+        crate::run_cost::copilot_mtime_millis(&events, &copilot_root).hash(&mut key_hasher);
+
+        contexts.push(RunContext {
+            run_id,
+            payload,
+            events,
+            claude_root,
+            repo_root,
+        });
+    }
+    let key: PerformanceMemoKey = (from.to_string(), to.to_string(), key_hasher.finish());
+
+    if !refresh {
+        let guard = performance_memo()
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        if let Some(hit) = guard.get(&key) {
+            return Ok(hit.clone());
+        }
+    }
+
+    #[cfg(test)]
+    record_recompute_for_test(&key);
+
+    let value = fold_performance(contexts, &copilot_root)?;
+
+    let mut guard = performance_memo()
+        .lock()
+        .unwrap_or_else(|error| error.into_inner());
+    if guard.len() >= PERFORMANCE_MEMO_CAP {
+        guard.clear();
+    }
+    guard.insert(key, value.clone());
+    Ok(value)
+}
+
+/// The heavy fold itself — every transcript read, every subagent directory
+/// scan, gated behind the memo in [`compute_performance`]. Pure/synchronous:
+/// every Run's events are already loaded ([`RunContext`]), so nothing here
+/// touches `state.db` again.
+fn fold_performance(
+    contexts: Vec<RunContext>,
+    copilot_root: &Path,
+) -> Result<StatsPerformance, PerformanceError> {
+    let mut seen_roots: HashSet<PathBuf> = HashSet::new();
+    let mut pipelines: BTreeMap<String, PipelineAcc> = BTreeMap::new();
+    let mut total_by_harness: BTreeMap<String, HarnessAcc> = BTreeMap::new();
+    let mut infrastructure_total_by_harness: BTreeMap<String, HarnessAcc> = BTreeMap::new();
+    let mut pipeline_manager_acc = NodeAcc::default();
+    let mut merge_resolver_acc = NodeAcc::default();
+    let mut harnesses_seen: BTreeSet<String> = BTreeSet::new();
+
+    for RunContext {
+        run_id,
+        payload,
+        events,
+        claude_root,
+        repo_root,
+    } in contexts
+    {
+        let pipeline_id = payload
+            .get("pipeline_id")
+            .and_then(|v| v.as_str())
+            .or_else(|| payload.get("pipeline_name").and_then(|v| v.as_str()))
+            .unwrap_or("(unknown)")
+            .to_string();
+        let pipeline_name = payload
+            .get("pipeline_name")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&pipeline_id)
+            .to_string();
+        let node_defs = node_defs_from_payload(&payload);
+        let run_harness = payload
+            .get("harness")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .unwrap_or(crate::harness_registry::CLAUDE)
+            .to_string();
+
+        let pipeline_acc = pipelines.entry(pipeline_id.clone()).or_default();
+        pipeline_acc.name = pipeline_name;
+
+        let mut pending: HashMap<(String, i64), PendingNode> = HashMap::new();
+        let mut node_starts: HashMap<(String, i64), Vec<NodeStartRecord>> = HashMap::new();
+        let mut pipeline_manager_started: Option<String> = None;
+        let mut merge_resolver_started: Option<MergeResolverPending> = None;
+
+        for event in &events {
+            let iter = event.iter.unwrap_or(1);
+            match event.kind {
+                EventKind::RunStarted => {
+                    pipeline_manager_started = Some(event.ts.clone());
+                }
+                EventKind::NodeStarted => {
+                    let Some(node_id) = event.node_id.clone() else {
+                        continue;
+                    };
+                    let event_payload = event.payload.as_ref();
+                    let node_type = event_payload
+                        .and_then(|p| p.get("node_type"))
+                        .and_then(|v| v.as_str())
+                        .or_else(|| node_defs.get(&node_id).map(|(_, ty)| ty.as_str()))
+                        .unwrap_or("")
+                        .to_string();
+                    let harness = event_payload
+                        .and_then(|p| p.get("harness"))
+                        .and_then(|v| v.as_str())
+                        .filter(|s| !s.is_empty())
+                        .unwrap_or(crate::harness_registry::CLAUDE)
+                        .to_string();
+                    let session_id = event_payload
+                        .and_then(|p| p.get("session_id"))
+                        .and_then(|v| v.as_str())
+                        .filter(|s| !s.is_empty())
+                        .map(str::to_string);
+                    node_starts
+                        .entry((node_id.clone(), iter))
+                        .or_default()
+                        .push(NodeStartRecord {
+                            node_type: node_type.clone(),
+                            harness: harness.clone(),
+                            session_id: session_id.clone(),
+                        });
+                    if node_type == "script" {
+                        continue;
+                    }
+                    pending.insert(
+                        (node_id, iter),
+                        PendingNode {
+                            started_at: event.ts.clone(),
+                            harness,
+                            session_id,
+                            node_type,
+                        },
+                    );
+                }
+                EventKind::NodeCompleted | EventKind::NodeAutoCompleted => {
+                    let Some(node_id) = event.node_id.clone() else {
+                        continue;
+                    };
+                    if let Some(p) = pending.remove(&(node_id.clone(), iter)) {
+                        let node_name = node_defs
+                            .get(&node_id)
+                            .map(|(name, _)| name.clone())
+                            .unwrap_or_else(|| node_id.clone());
+                        let node_acc = pipeline_acc.nodes.entry(node_id).or_default();
+                        node_acc.name = node_name;
+                        let working_dir = if p.node_type == "code-mutating" {
+                            crate::worktree_ops::sub_worktree_path(
+                                &repo_root,
+                                &run_id,
+                                event.node_id.as_deref().unwrap_or(""),
+                                iter,
+                            )
+                        } else {
+                            crate::worktree_ops::worktree_dir_for_run(&repo_root, &run_id)
+                        };
+                        harnesses_seen.insert(p.harness.clone());
+                        record_node_success(
+                            node_acc,
+                            &mut pipeline_acc.by_harness,
+                            &mut total_by_harness,
+                            &claude_root,
+                            copilot_root,
+                            &working_dir,
+                            &p,
+                            &event.ts,
+                            &mut seen_roots,
+                        )?;
+                    }
+                }
+                EventKind::NodeFailed
+                | EventKind::NodeStopped
+                | EventKind::NodeInterrupted
+                | EventKind::NodeStale => {
+                    if let Some(node_id) = &event.node_id {
+                        pending.remove(&(node_id.clone(), iter));
+                    }
+                }
+                EventKind::MergeResolverStarted => {
+                    let payload = event.payload.as_ref();
+                    merge_resolver_started = Some(MergeResolverPending {
+                        started_at: event.ts.clone(),
+                        conflicting_node_id: payload
+                            .and_then(|p| p.get("conflicting_node_id"))
+                            .and_then(|v| v.as_str())
+                            .map(str::to_string),
+                        iter: payload.and_then(|p| p.get("iter")).and_then(|v| v.as_i64()),
+                    });
+                }
+                EventKind::MergeResolverCompleted => {
+                    if let Some(started) = merge_resolver_started.take() {
+                        harnesses_seen.insert(run_harness.clone());
+                        let duration = duration_millis(&started.started_at, &event.ts);
+                        let (working_dir, excluded, ambiguous) =
+                            match (&started.conflicting_node_id, started.iter) {
+                                (Some(conflicting_node_id), Some(conflict_iter)) => {
+                                    let dir = crate::worktree_ops::sub_worktree_path(
+                                        &repo_root,
+                                        &run_id,
+                                        conflicting_node_id,
+                                        conflict_iter,
+                                    );
+                                    let records = node_starts
+                                        .get(&(conflicting_node_id.clone(), conflict_iter))
+                                        .cloned()
+                                        .unwrap_or_default();
+                                    let excluded: HashSet<String> = records
+                                        .iter()
+                                        .filter_map(|r| r.session_id.clone())
+                                        .collect();
+                                    let ambiguous = records.iter().any(|r| {
+                                        r.harness == crate::harness_registry::CLAUDE
+                                            && r.session_id.is_none()
+                                    });
+                                    (Some(dir), excluded, ambiguous)
+                                }
+                                _ => (None, HashSet::new(), false),
+                            };
+                        record_infra_success(
+                            &mut merge_resolver_acc,
+                            &mut infrastructure_total_by_harness,
+                            &run_harness,
+                            &claude_root,
+                            working_dir.as_deref(),
+                            &excluded,
+                            ambiguous,
+                            duration,
+                            &mut seen_roots,
+                        )?;
+                    }
+                }
+                EventKind::MergeResolverFailed => {
+                    merge_resolver_started = None;
+                }
+                EventKind::RunCompleted => {
+                    if let Some(started_at) = pipeline_manager_started.take() {
+                        harnesses_seen.insert(run_harness.clone());
+                        let duration = duration_millis(&started_at, &event.ts);
+                        let topdir = crate::worktree_ops::worktree_dir_for_run(&repo_root, &run_id);
+                        let excluded: HashSet<String> = node_starts
+                            .values()
+                            .flatten()
+                            .filter_map(|r| r.session_id.clone())
+                            .collect();
+                        let ambiguous = node_starts.values().flatten().any(|r| {
+                            r.node_type != "script"
+                                && r.node_type != "code-mutating"
+                                && r.harness == crate::harness_registry::CLAUDE
+                                && r.session_id.is_none()
+                        });
+                        record_infra_success(
+                            &mut pipeline_manager_acc,
+                            &mut infrastructure_total_by_harness,
+                            &run_harness,
+                            &claude_root,
+                            Some(&topdir),
+                            &excluded,
+                            ambiguous,
+                            duration,
+                            &mut seen_roots,
+                        )?;
+                    }
+                }
+                EventKind::RunFailed | EventKind::RunSkipped => {
+                    pipeline_manager_started = None;
+                }
+                _ => {}
+            }
+        }
+    }
+
+    let mut pipeline_rows: Vec<PerformanceEntity> = pipelines
+        .into_iter()
+        .map(|(id, acc)| finish_pipeline(id, acc))
+        .collect();
+    pipeline_rows.sort_by(|a, b| a.id.cmp(&b.id));
+
+    let mut infrastructure = Vec::new();
+    if !pipeline_manager_acc.by_harness.is_empty() {
+        infrastructure.push(finish_infra_role(
+            "pipeline-manager",
+            "Pipeline Manager",
+            pipeline_manager_acc,
+        ));
+    }
+    if !merge_resolver_acc.by_harness.is_empty() {
+        infrastructure.push(finish_infra_role(
+            "merge-resolver",
+            "Merge resolver",
+            merge_resolver_acc,
+        ));
+    }
+
+    Ok(StatsPerformance {
+        harnesses: harnesses_seen.into_iter().collect(),
+        total: PerformanceAggregate {
+            harnesses: finish_by_harness(total_by_harness),
+        },
+        by_pipeline: pipeline_rows,
+        infrastructure,
+        infrastructure_total: PerformanceAggregate {
+            harnesses: finish_by_harness(infrastructure_total_by_harness),
+        },
+    })
+}

--- a/crates/pdo-daemon/tests/harness_freeze_resume.rs
+++ b/crates/pdo-daemon/tests/harness_freeze_resume.rs
@@ -205,13 +205,12 @@ async fn stats_exposes_frozen_harnesses_through_the_real_daemon() {
         ])
     );
 
-    let cost: serde_json::Value =
-        reqwest::get(format!("{}/stats/cost?{period}", daemon.url()))
-            .await
-            .unwrap()
-            .json()
-            .await
-            .unwrap();
+    let cost: serde_json::Value = reqwest::get(format!("{}/stats/cost?{period}", daemon.url()))
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
     assert_eq!(cost["harnesses"], serde_json::json!(["claude", "opencode"]));
     let pipeline = cost["by_pipeline"]
         .as_array()

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,4 +1,4 @@
-import type { PipelineListEntry, PipelineDetail, PipelineDef, RunListEntry, RunState, PortDef, PortSide, PortType, FrontmatterFieldDecl, FrontmatterViolation, Trigger, TriggerFire, DaemonStatus, InstanceSettings, UpdateSettingsRequest, StatsOverview, StatsCost, SandboxProfile, SandboxProfileImage, SandboxProfileReferents, SyncCostPricesReport, Project, BranchRef } from "./types";
+import type { PipelineListEntry, PipelineDetail, PipelineDef, RunListEntry, RunState, PortDef, PortSide, PortType, FrontmatterFieldDecl, FrontmatterViolation, Trigger, TriggerFire, DaemonStatus, InstanceSettings, UpdateSettingsRequest, StatsOverview, StatsCost, StatsPerformance, SandboxProfile, SandboxProfileImage, SandboxProfileReferents, SyncCostPricesReport, Project, BranchRef } from "./types";
 import { foldHarnessOntoNode } from "./lib/harness";
 
 const BASE = "";
@@ -286,6 +286,17 @@ export function fetchStatsCost(
   bucket: string,
 ): Promise<StatsCost> {
   return request<StatsCost>("GET", "/stats/cost", { query: { from, to, bucket } });
+}
+
+/** Context and wall-clock distributions. Heavy journal reads, so callers load it lazily. */
+export function fetchStatsPerformance(
+  from: string,
+  to: string,
+  refresh = false,
+): Promise<StatsPerformance> {
+  return request<StatsPerformance>("GET", "/stats/performance", {
+    query: { from, to, ...(refresh ? { refresh: true } : {}) },
+  });
 }
 
 export function fetchRun(runId: string): Promise<RunState> {

--- a/frontend/src/components/StatsCharts.test.tsx
+++ b/frontend/src/components/StatsCharts.test.tsx
@@ -3,7 +3,12 @@ import userEvent from "@testing-library/user-event";
 import { describe, it, expect } from "vitest";
 
 import StatsCharts from "./StatsCharts";
-import type { StatsCost, StatsHarnessCost, StatsOverview } from "../types";
+import type {
+  StatsCost,
+  StatsHarnessCost,
+  StatsOverview,
+  StatsPerformance,
+} from "../types";
 
 // The resolved price table (#528) lives on the Stats → Cost tab, fed by
 // `/stats/cost`. `by_period: []` means no spend, so the recharts chart never
@@ -244,6 +249,88 @@ const OVERVIEW: StatsOverview = {
   triggers_created_runs: { fired: 0, distinct_triggers: 0, enabled_triggers: 0 },
 };
 
+const distribution = (mean: number, measured = 2, expected = 2) => ({
+  stats: {
+    min: mean - 20,
+    q1: mean - 10,
+    median: mean,
+    mean,
+    q3: mean + 10,
+    max: mean + 20,
+  },
+  measured,
+  expected,
+  missing_reasons: measured === expected ? [] : ["no reliable bounds"],
+});
+
+const PERFORMANCE: StatsPerformance = {
+  harnesses: ["claude", "copilot"],
+  total: {
+    harnesses: [
+      { harness: "claude", context: distribution(96_000), duration: distribution(410_000) },
+      { harness: "copilot", context: distribution(68_000), duration: distribution(505_000) },
+    ],
+  },
+  infrastructure_total: {
+    harnesses: [
+      { harness: "claude", context: distribution(20_000), duration: distribution(120_000) },
+    ],
+  },
+  by_pipeline: [
+    {
+      id: "pipeline-id",
+      name: "Implement loop",
+      harnesses: [
+        { harness: "claude", context: distribution(90_000), duration: distribution(300_000) },
+        { harness: "copilot", context: distribution(60_000), duration: distribution(500_000) },
+      ],
+      nodes: [
+        {
+          id: "design-id",
+          name: "Design",
+          harnesses: [
+            { harness: "claude", context: distribution(141_000), duration: distribution(350_000) },
+            { harness: "copilot", context: distribution(84_000), duration: distribution(420_000, 1, 2) },
+          ],
+          nodes: [],
+          subagents: [
+            {
+              id: "explore",
+              name: "Explore",
+              harnesses: [
+                {
+                  harness: "claude",
+                  context: distribution(55_000),
+                  duration: {
+                    stats: null,
+                    measured: 0,
+                    expected: 1,
+                    missing_reasons: ["no reliable bounds"],
+                  },
+                },
+              ],
+              nodes: [],
+              subagents: [],
+            },
+          ],
+        },
+      ],
+      subagents: [],
+    },
+  ],
+  infrastructure: [
+    {
+      id: "pipeline-manager",
+      name: "Pipeline Manager",
+      harnesses: [
+        { harness: "claude", context: distribution(20_000), duration: distribution(120_000) },
+      ],
+      nodes: [],
+      subagents: [],
+    },
+  ],
+};
+
 describe("StatsCharts — harness drill-down (#638)", () => {
     it("shows harness session volumes and drills from a Pipeline into its Nodes", async () => {
       const user = userEvent.setup();
@@ -252,9 +339,11 @@ describe("StatsCharts — harness drill-down (#638)", () => {
       expect(screen.getByTestId("stats-harness-legend-claude")).toHaveStyle({
         backgroundColor: "#f0883e",
       });
+
       expect(screen.getByTestId("stats-harness-legend-copilot")).toHaveStyle({
         backgroundColor: "#58a6ff",
       });
+
       expect(screen.getAllByText("Implement loop")).toHaveLength(2);
       expect(screen.queryByText("pipe-hidden-id")).not.toBeInTheDocument();
 
@@ -323,5 +412,94 @@ describe("StatsCharts — harness drill-down (#638)", () => {
       "Total / PDO / Implement loop",
     );
     expect(screen.getByText("Review")).toBeInTheDocument();
+  });
+});
+
+describe("StatsCharts — Performance (#585)", () => {
+  it("drills from Pipeline to Nodes and expands subagent types", async () => {
+    const user = userEvent.setup();
+    render(
+      <StatsCharts
+        tab="performance"
+        overview={null}
+        cost={null}
+        costError={null}
+        performance={PERFORMANCE}
+        performanceError={null}
+      />,
+    );
+
+    expect(screen.getByText("Ranked by context")).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Context (peak tokens)" })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Duration (wall-clock)" })).toBeInTheDocument();
+    await user.click(screen.getByRole("option", { name: /Implement loop/ }));
+    expect(screen.getByText("Design")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Expand Design subagents" }));
+    expect(screen.getByText("Explore")).toBeInTheDocument();
+  });
+
+  it("uses shared metric scales, exposes R-7 values and coverage, and sorts by duration", async () => {
+    const user = userEvent.setup();
+    render(
+      <StatsCharts
+        tab="performance"
+        overview={null}
+        cost={null}
+        costError={null}
+        performance={PERFORMANCE}
+        performanceError={null}
+      />,
+    );
+    await user.click(screen.getByRole("option", { name: /Implement loop/ }));
+
+    const contextPlots = screen.getAllByTestId("performance-context-boxplot");
+    expect(contextPlots[0]).toHaveAttribute("data-scale-max", "141020");
+    expect(contextPlots[1]).toHaveAttribute("data-scale-max", "141020");
+    const coverage = screen.getByRole("button", { name: /Design · claude · Context/ });
+    await user.hover(coverage);
+    expect(await screen.findByTestId("tooltip-content")).toHaveTextContent(
+      /Max.*Q3.*Mean.*Median.*Q1.*Min.*2 measured of 2 successful executions/i,
+    );
+
+    await user.selectOptions(screen.getByRole("combobox", { name: "Performance sort" }), "duration");
+    expect(screen.getByText("Ranked by duration")).toBeInTheDocument();
+  });
+
+  it("distinguishes loading, empty, and source errors", () => {
+    const { rerender } = render(
+      <StatsCharts
+        tab="performance"
+        overview={null}
+        cost={null}
+        costError={null}
+        performance={null}
+        performanceError={null}
+      />,
+    );
+    expect(screen.getByText("Loading performance…")).toBeInTheDocument();
+
+    rerender(
+      <StatsCharts
+        tab="performance"
+        overview={null}
+        cost={null}
+        costError={null}
+        performance={{ ...PERFORMANCE, by_pipeline: [], infrastructure: [] }}
+        performanceError={null}
+      />,
+    );
+    expect(screen.getByText("No successful executions in this period.")).toBeInTheDocument();
+
+    rerender(
+      <StatsCharts
+        tab="performance"
+        overview={null}
+        cost={null}
+        costError={null}
+        performance={null}
+        performanceError="Claude journal could not be read"
+      />,
+    );
+    expect(screen.getByText("Claude journal could not be read")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/StatsCharts.tsx
+++ b/frontend/src/components/StatsCharts.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react";
+import { ChevronDown, ChevronRight } from "lucide-react";
 import {
   Bar,
   BarChart,
@@ -16,6 +17,10 @@ import type {
   StatsCostPeriod,
   StatsHarnessCost,
   StatsOverview,
+  StatsDistribution,
+  StatsPerformance,
+  StatsPerformanceAggregate,
+  StatsPerformanceEntity,
   StatsProjectCostEntity,
   StatsSessionEntity,
   StatsSessionHarness,
@@ -25,7 +30,7 @@ import { formatCostAmount } from "../lib/costLabel";
 import { harnessColor } from "../lib/harness";
 import { Tooltip, TooltipProvider } from "./ui/tooltip";
 
-export type StatsTab = "runs" | "sessions" | "triggers" | "cost";
+export type StatsTab = "runs" | "sessions" | "triggers" | "cost" | "performance";
 
 const CHART = {
   runs: "#58a6ff",
@@ -180,11 +185,13 @@ function MasterList<T extends { id: string; name: string }>({
   selected,
   valueLabel,
   onSelect,
+  ariaLabel = "Spenders",
 }: {
   rows: T[];
   selected: string | null;
   valueLabel: (row: T) => string;
   onSelect: (id: string | null) => void;
+  ariaLabel?: string;
 }) {
   const options = [{ id: "__total__", name: "Total" } as T, ...rows];
   const selectedIndex = Math.max(
@@ -197,7 +204,7 @@ function MasterList<T extends { id: string; name: string }>({
   return (
     <div
       role="listbox"
-      aria-label="Spenders"
+      aria-label={ariaLabel}
       className="flex flex-col gap-1"
       onKeyDown={(event) => {
         if (event.key === "ArrowDown" || event.key === "ArrowUp") {
@@ -637,11 +644,368 @@ function CostTab({
   );
 }
 
+type PerformanceMetric = "context" | "duration";
+
+function performanceScore(
+  aggregate: StatsPerformanceAggregate,
+  metric: PerformanceMetric,
+): [number, number] {
+  const distributions = aggregate.harnesses
+    .map((item) => item[metric])
+    .filter((item) => item.stats !== null);
+  return [
+    Math.max(-1, ...distributions.map((item) => item.stats!.mean)),
+    Math.max(-1, ...distributions.map((item) => item.stats!.median)),
+  ];
+}
+
+function sortPerformance<T extends StatsPerformanceAggregate & { name: string }>(
+  rows: T[],
+  metric: PerformanceMetric,
+): T[] {
+  return [...rows].sort((a, b) => {
+    const [aMean, aMedian] = performanceScore(a, metric);
+    const [bMean, bMedian] = performanceScore(b, metric);
+    return bMean - aMean || bMedian - aMedian || a.name.localeCompare(b.name);
+  });
+}
+
+function formatPerformanceValue(value: number, metric: PerformanceMetric): string {
+  if (metric === "context") {
+    return value >= 1_000 ? `${Math.round(value / 1_000)}k` : Math.round(value).toString();
+  }
+  const seconds = Math.round(value / 1_000);
+  const minutes = Math.floor(seconds / 60);
+  return minutes ? `${minutes}m${String(seconds % 60).padStart(2, "0")}s` : `${seconds}s`;
+}
+
+function distributionDetail(
+  name: string,
+  harness: string,
+  metric: PerformanceMetric,
+  value: StatsDistribution,
+): string {
+  const label = metric === "context" ? "Context" : "Duration";
+  const fmt = (raw: number) => formatPerformanceValue(raw, metric);
+  const stats = value.stats;
+  if (!stats) {
+    return `${name} · ${harness} · ${label}. 0 measured of ${value.expected} successful executions. Missing: ${value.missing_reasons.join("; ")}.`;
+  }
+  const reasons = value.missing_reasons.length
+    ? ` Missing: ${value.missing_reasons.join("; ")}.`
+    : "";
+  return `${name} · ${harness} · ${label}. Max ${fmt(stats.max)} · Q3 ${fmt(stats.q3)} · Mean ${fmt(stats.mean)} · Median ${fmt(stats.median)} · Q1 ${fmt(stats.q1)} · Min ${fmt(stats.min)}. ${value.measured} measured of ${value.expected} successful executions.${reasons}`;
+}
+
+function DistributionPlot({
+  name,
+  harness,
+  metric,
+  value,
+  scaleMax,
+}: {
+  name: string;
+  harness: string;
+  metric: PerformanceMetric;
+  value: StatsDistribution;
+  scaleMax: number;
+}) {
+  if (!value.stats) {
+    const detail = `${name} · ${harness} · ${metric === "context" ? "Context" : "Duration"}. 0 measured of ${value.expected} successful executions. Missing: ${value.missing_reasons.join("; ")}.`;
+    return (
+      <Tooltip content={detail} side="top">
+        <button
+          type="button"
+          aria-label={detail}
+          className="text-left text-fg-4 underline decoration-dotted underline-offset-2"
+        >
+          — {value.missing_reasons[0] ?? "not measurable"}
+        </button>
+      </Tooltip>
+    );
+  }
+  const stats = value.stats;
+  const pct = (raw: number) => `${Math.max(0, Math.min(100, (raw / scaleMax) * 100))}%`;
+  const detail = distributionDetail(name, harness, metric, value);
+  const partial = value.measured < value.expected;
+  return (
+    <div className="flex min-w-0 flex-col gap-1">
+      <div
+        className="relative h-4 min-w-28"
+        data-testid={`performance-${metric}-boxplot`}
+        data-scale-max={scaleMax}
+        aria-hidden="true"
+      >
+        <span
+          className="absolute top-[7px] h-px bg-fg-4"
+          style={{ left: pct(stats.min), width: pct(stats.max - stats.min) }}
+        />
+        <span
+          className="absolute top-[4px] h-[7px] border border-current opacity-70"
+          style={{
+            color: harnessColor(harness),
+            left: pct(stats.q1),
+            width: pct(Math.max(stats.q3 - stats.q1, scaleMax * 0.005)),
+          }}
+        />
+        <span
+          className="absolute top-[3px] h-[9px] w-px bg-fg"
+          style={{ left: pct(stats.median) }}
+        />
+        <span
+          className="absolute top-[5px] h-[5px] w-[5px] -translate-x-1/2 rounded-full bg-current"
+          style={{ color: harnessColor(harness), left: pct(stats.mean) }}
+        />
+      </div>
+      <Tooltip content={detail} side="top">
+        <button
+          type="button"
+          aria-label={detail}
+          className="w-fit text-left font-mono text-fg-4 underline decoration-dotted underline-offset-2"
+          style={{ fontSize: "9.5px" }}
+        >
+          {formatPerformanceValue(stats.mean, metric)} avg · n={value.measured}
+          {partial ? " ⚠" : ""}
+        </button>
+      </Tooltip>
+    </div>
+  );
+}
+
+function PerformanceCards({ aggregate }: { aggregate: StatsPerformanceAggregate }) {
+  return (
+    <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-4">
+      {aggregate.harnesses.map((item) => (
+        <div key={item.harness} className="rounded-md border border-line bg-bg-3 p-3">
+          <div className="mb-2 flex items-center gap-1.5 text-fg-3">
+            <span
+              className="h-2 w-2 rounded-full"
+              style={{ backgroundColor: harnessColor(item.harness) }}
+            />
+            {item.harness}
+          </div>
+          <div className="font-mono text-fg">
+            {item.context.stats
+              ? formatPerformanceValue(item.context.stats.median, "context")
+              : "—"}{" "}
+            median context
+          </div>
+          <div className="font-mono text-fg-3">
+            {item.duration.stats
+              ? formatPerformanceValue(item.duration.stats.median, "duration")
+              : "—"}{" "}
+            median duration
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function PerformanceTable({
+  rows,
+  harnesses,
+  sort,
+}: {
+  rows: StatsPerformanceEntity[];
+  harnesses: string[];
+  sort: PerformanceMetric;
+}) {
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const ordered = sortPerformance(rows, sort);
+  const visible = ordered.flatMap((row) => [
+    { row, child: false },
+    ...(expanded.has(row.id)
+      ? sortPerformance(row.subagents, sort).map((child) => ({ row: child, child: true }))
+      : []),
+  ]);
+  const scaleRows = rows.flatMap((row) => [row, ...row.subagents]);
+  const scaleMax = (metric: PerformanceMetric) =>
+    Math.max(
+      1,
+      ...scaleRows.flatMap((row) =>
+        row.harnesses.map((item) => item[metric].stats?.max ?? 0),
+      ),
+    );
+  const contextMax = scaleMax("context");
+  const durationMax = scaleMax("duration");
+
+  return (
+    <TooltipProvider>
+      <table className="w-full table-fixed text-left" style={{ fontSize: "11px" }}>
+        <thead className="text-fg-4">
+          <tr>
+            <th className="w-48 pb-2 font-medium">Name</th>
+            <th className="pb-2 font-medium">Context (peak tokens)</th>
+            <th className="pb-2 font-medium">Duration (wall-clock)</th>
+          </tr>
+        </thead>
+        <tbody>
+          {visible.map(({ row, child }) => (
+            <tr key={`${child ? "subagent" : "entity"}-${row.id}`} className="border-t border-line">
+              <td className={`py-2 pr-2 text-fg-2 ${child ? "pl-7" : ""}`}>
+                {!child && row.subagents.length > 0 ? (
+                  <button
+                    type="button"
+                    aria-label={`${expanded.has(row.id) ? "Collapse" : "Expand"} ${row.name} subagents`}
+                    onClick={() =>
+                      setExpanded((current) => {
+                        const next = new Set(current);
+                        if (next.has(row.id)) next.delete(row.id);
+                        else next.add(row.id);
+                        return next;
+                      })
+                    }
+                    className="inline-flex items-center gap-1 hover:text-fg"
+                  >
+                    {expanded.has(row.id) ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+                    {row.name}
+                  </button>
+                ) : (
+                  row.name
+                )}
+              </td>
+              {(["context", "duration"] as const).map((metric) => (
+                <td key={metric} className="py-2 pr-3 align-top">
+                  <div className="grid gap-1.5">
+                    {harnesses.map((harness) => (
+                      <div key={harness} className="flex items-start gap-2">
+                        <span
+                          className="mt-1 h-[7px] w-[7px] shrink-0 rounded-full"
+                          style={{ backgroundColor: harnessColor(harness) }}
+                        />
+                        <DistributionPlot
+                          name={row.name}
+                          harness={harness}
+                          metric={metric}
+                          value={
+                            row.harnesses.find((item) => item.harness === harness)?.[metric] ?? {
+                              stats: null,
+                              measured: 0,
+                              expected: 0,
+                              missing_reasons: [`never ran on ${harness}`],
+                            }
+                          }
+                          scaleMax={metric === "context" ? contextMax : durationMax}
+                        />
+                      </div>
+                    ))}
+                  </div>
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </TooltipProvider>
+  );
+}
+
+function PerformanceTab({
+  performance,
+  error,
+}: {
+  performance: StatsPerformance | null;
+  error: string | null;
+}) {
+  const [sort, setSort] = useState<PerformanceMetric>("context");
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  if (error) {
+    return (
+      <div className="rounded-md border border-st-failed/30 bg-st-failed-bg px-3 py-2 text-st-failed">
+        {error}
+      </div>
+    );
+  }
+  if (!performance) return <EmptyNote>Loading performance…</EmptyNote>;
+  if (performance.by_pipeline.length === 0 && performance.infrastructure.length === 0) {
+    return <EmptyNote>No successful executions in this period.</EmptyNote>;
+  }
+
+  const infrastructureRow: StatsPerformanceEntity = {
+    id: "__infrastructure__",
+    name: "Infrastructure",
+    ...performance.infrastructure_total,
+    nodes: performance.infrastructure,
+    subagents: [],
+  };
+  const masterRows = sortPerformance(
+    [...performance.by_pipeline, infrastructureRow],
+    sort,
+  );
+  const selected = masterRows.find((row) => row.id === selectedId) ?? null;
+  const aggregate = selected ?? performance.total;
+  const detailRows = selected
+    ? selected.id === "__infrastructure__"
+      ? performance.infrastructure
+      : selected.nodes
+    : masterRows;
+  const contexts = aggregate.harnesses.map((item) =>
+    item.context.stats ? formatPerformanceValue(item.context.stats.median, "context") : "—",
+  );
+  const durations = aggregate.harnesses.map((item) =>
+    item.duration.stats ? formatPerformanceValue(item.duration.stats.median, "duration") : "—",
+  );
+
+  return (
+    <div className="relative flex min-h-full" data-testid="stats-chart-performance">
+      <aside className="w-[290px] shrink-0 border-r border-line pr-4">
+        <div className="mb-2 flex items-center justify-between gap-2">
+          <span className="text-fg-4" style={{ fontSize: "10.5px" }}>
+            Ranked by {sort}
+          </span>
+          <select
+            aria-label="Performance sort"
+            value={sort}
+            onChange={(event) => setSort(event.target.value as PerformanceMetric)}
+            className="rounded border border-line bg-bg-3 px-2 py-1 text-fg-2"
+          >
+            <option value="context">By context</option>
+            <option value="duration">By duration</option>
+          </select>
+        </div>
+        <MasterList
+          rows={masterRows}
+          selected={selectedId}
+          ariaLabel="Performance groups"
+          valueLabel={(row) => {
+            const [mean] = performanceScore(row, sort);
+            return mean < 0 ? "—" : formatPerformanceValue(mean, sort);
+          }}
+          onSelect={setSelectedId}
+        />
+      </aside>
+      <div className="min-w-0 flex-1 pl-5">
+        <div className="mb-3 text-fg-4" style={{ fontSize: "10.5px" }}>
+          Total{selected ? ` / ${selected.name}` : ""}
+        </div>
+        <HarnessLegend harnesses={performance.harnesses} />
+        <div className="mt-4 text-fg" data-testid="stats-performance-headline">
+          {contexts.join(" / ") || "—"} median peak context · {durations.join(" / ") || "—"} median
+          duration
+        </div>
+        <div className="mt-4">
+          <PerformanceCards aggregate={aggregate} />
+        </div>
+        <div className="mt-4 min-h-[240px]">
+          <PerformanceTable
+            rows={detailRows}
+            harnesses={performance.harnesses}
+            sort={sort}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export interface StatsChartsProps {
   tab: StatsTab;
   overview: StatsOverview | null;
   cost: StatsCost | null;
   costError: string | null;
+  performance?: StatsPerformance | null;
+  performanceError?: string | null;
 }
 
 export default function StatsCharts({
@@ -649,7 +1013,12 @@ export default function StatsCharts({
   overview,
   cost,
   costError,
+  performance = null,
+  performanceError = null,
 }: StatsChartsProps) {
+  if (tab === "performance") {
+    return <PerformanceTab performance={performance} error={performanceError} />;
+  }
   if (tab === "cost") {
     return <CostTab cost={cost} error={costError} />;
   }

--- a/frontend/src/components/StatsModal.test.tsx
+++ b/frontend/src/components/StatsModal.test.tsx
@@ -4,6 +4,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 const fetchStatsOverviewMock = vi.fn();
 const fetchStatsCostMock = vi.fn();
+const fetchStatsPerformanceMock = vi.fn();
 const syncCostPricesMock = vi.fn();
 
 // Every api function StatsModal (or anything it renders) touches MUST be in this
@@ -13,6 +14,7 @@ const syncCostPricesMock = vi.fn();
 vi.mock("../api", () => ({
   fetchStatsOverview: (...args: unknown[]) => fetchStatsOverviewMock(...args),
   fetchStatsCost: (...args: unknown[]) => fetchStatsCostMock(...args),
+  fetchStatsPerformance: (...args: unknown[]) => fetchStatsPerformanceMock(...args),
   syncCostPrices: (...args: unknown[]) => syncCostPricesMock(...args),
 }));
 
@@ -85,6 +87,13 @@ async function openCostTab() {
 beforeEach(() => {
   fetchStatsOverviewMock.mockReset().mockResolvedValue(OVERVIEW);
   fetchStatsCostMock.mockReset().mockResolvedValue(COST);
+  fetchStatsPerformanceMock.mockReset().mockResolvedValue({
+    harnesses: [],
+    total: { harnesses: [] },
+    infrastructure_total: { harnesses: [] },
+    by_pipeline: [],
+    infrastructure: [],
+  });
   syncCostPricesMock.mockReset().mockResolvedValue(report());
 });
 
@@ -116,14 +125,27 @@ describe("StatsModal — price sync (#427, ADR-0034)", () => {
   });
 
   describe("StatsModal — full-screen Stats window (#638)", () => {
-    it("covers the application and exposes the four sections in a side rail", async () => {
+    it("covers the application and exposes Performance as the fifth side-rail section", async () => {
       render(<StatsModal open onClose={() => {}} />);
 
       expect(await screen.findByTestId("stats-modal")).toHaveClass("h-screen", "w-screen");
       const rail = screen.getByRole("tablist", { name: "Stats sections" });
       expect(rail).toHaveClass("flex-col");
-      expect(screen.getAllByRole("tab")).toHaveLength(4);
+      expect(screen.getAllByRole("tab")).toHaveLength(5);
+      expect(screen.getByTestId("stats-tab-performance")).toHaveTextContent("Performance");
       expect(screen.getByRole("group", { name: "Period" })).toBeInTheDocument();
+    });
+
+    it("loads Performance only when opened and refreshes it explicitly", async () => {
+      const user = userEvent.setup();
+      render(<StatsModal open onClose={() => {}} />);
+      await waitFor(() => expect(fetchStatsOverviewMock).toHaveBeenCalledTimes(1));
+      expect(fetchStatsPerformanceMock).not.toHaveBeenCalled();
+
+      await user.click(screen.getByTestId("stats-tab-performance"));
+      await waitFor(() => expect(fetchStatsPerformanceMock).toHaveBeenCalledTimes(1));
+      await user.click(screen.getByTestId("stats-refresh"));
+      await waitFor(() => expect(fetchStatsPerformanceMock).toHaveBeenCalledTimes(2));
     });
 
     it("refreshes visible data without blanking it and advances the computed time", async () => {

--- a/frontend/src/components/StatsModal.tsx
+++ b/frontend/src/components/StatsModal.tsx
@@ -26,6 +26,7 @@ const TABS: { id: StatsTab; label: string }[] = [
   { id: "sessions", label: "Sessions" },
   { id: "triggers", label: "Triggers" },
   { id: "cost", label: "Cost" },
+  { id: "performance", label: "Performance" },
 ];
 
 function utcDayStart(date: Date): string {
@@ -180,15 +181,19 @@ export default function StatsModal({ open, onClose }: Props) {
     cost,
     error,
     costError,
+    performance,
+    performanceError,
     computedAt,
     overviewReloadKey,
     costReloadKey,
+    performanceReloadKey,
   } = useStats(
     open,
     period.from,
     period.to,
     period.bucket,
     tab === "cost",
+    tab === "performance",
     reloadKey,
   );
 
@@ -213,7 +218,9 @@ export default function StatsModal({ open, onClose }: Props) {
   if (!open) return null;
 
   const refreshing =
-    overviewReloadKey !== reloadKey || (tab === "cost" && costReloadKey !== reloadKey);
+    overviewReloadKey !== reloadKey ||
+    (tab === "cost" && costReloadKey !== reloadKey) ||
+    (tab === "performance" && performanceReloadKey !== reloadKey);
 
   const refresh = () => {
     setReloadKey((value) => value + 1);
@@ -355,7 +362,14 @@ export default function StatsModal({ open, onClose }: Props) {
                 </div>
               }
             >
-              <StatsCharts tab={tab} overview={overview} cost={cost} costError={costError} />
+              <StatsCharts
+                tab={tab}
+                overview={overview}
+                cost={cost}
+                costError={costError}
+                performance={performance}
+                performanceError={performanceError}
+              />
             </Suspense>
           </main>
         </div>

--- a/frontend/src/hooks/useStats.test.ts
+++ b/frontend/src/hooks/useStats.test.ts
@@ -7,6 +7,7 @@ import type { StatsOverview, StatsCost } from "../types";
 vi.mock("../api", () => ({
   fetchStatsOverview: vi.fn(),
   fetchStatsCost: vi.fn(),
+  fetchStatsPerformance: vi.fn(),
 }));
 
 const OVERVIEW: StatsOverview = {
@@ -40,30 +41,40 @@ const COST: StatsCost = {
   by_project: [],
   resolved: [],
 };
+const PERFORMANCE = {
+  harnesses: [],
+  total: { harnesses: [] },
+  infrastructure_total: { harnesses: [] },
+  by_pipeline: [],
+  infrastructure: [],
+};
 
 beforeEach(() => {
   vi.mocked(api.fetchStatsOverview).mockReset().mockResolvedValue(OVERVIEW);
   vi.mocked(api.fetchStatsCost).mockReset().mockResolvedValue(COST);
+  vi.mocked(api.fetchStatsPerformance).mockReset().mockResolvedValue(PERFORMANCE);
 });
 
 describe("useStats (#377)", () => {
   it("fetches overview eagerly on open, but not cost", async () => {
-    const { result } = renderHook(() => useStats(true, "F", "T", "day", false));
+    const { result } = renderHook(() => useStats(true, "F", "T", "day", false, false));
     await waitFor(() => expect(result.current.overview).toEqual(OVERVIEW));
     expect(api.fetchStatsOverview).toHaveBeenCalledWith("F", "T", "day");
     expect(api.fetchStatsCost).not.toHaveBeenCalled();
+    expect(api.fetchStatsPerformance).not.toHaveBeenCalled();
   });
 
   it("does not fetch anything while closed", async () => {
-    renderHook(() => useStats(false, "F", "T", "day", true));
+    renderHook(() => useStats(false, "F", "T", "day", true, true));
     await Promise.resolve();
     expect(api.fetchStatsOverview).not.toHaveBeenCalled();
     expect(api.fetchStatsCost).not.toHaveBeenCalled();
+    expect(api.fetchStatsPerformance).not.toHaveBeenCalled();
   });
 
   it("fetches cost lazily, only once the cost tab is active (two-endpoint split)", async () => {
     const { result, rerender } = renderHook(
-      ({ costActive }) => useStats(true, "F", "T", "day", costActive),
+      ({ costActive }) => useStats(true, "F", "T", "day", costActive, false),
       { initialProps: { costActive: false } },
     );
     await waitFor(() => expect(result.current.overview).toEqual(OVERVIEW));
@@ -74,9 +85,37 @@ describe("useStats (#377)", () => {
     expect(api.fetchStatsCost).toHaveBeenCalledWith("F", "T", "day");
   });
 
+  it("fetches performance lazily and does not refetch when returning to the tab", async () => {
+    const { result, rerender } = renderHook(
+      ({ active }) => useStats(true, "F", "T", "day", false, active),
+      { initialProps: { active: false } },
+    );
+    expect(api.fetchStatsPerformance).not.toHaveBeenCalled();
+
+    rerender({ active: true });
+    await waitFor(() => expect(result.current.performance).toEqual(PERFORMANCE));
+    expect(api.fetchStatsPerformance).toHaveBeenCalledWith("F", "T", false);
+
+    rerender({ active: false });
+    rerender({ active: true });
+    await Promise.resolve();
+    expect(api.fetchStatsPerformance).toHaveBeenCalledTimes(1);
+  });
+
+  it("bypasses the performance memo after explicit refresh", async () => {
+    const { rerender } = renderHook(
+      ({ reloadKey }) => useStats(true, "F", "T", "day", false, true, reloadKey),
+      { initialProps: { reloadKey: 0 } },
+    );
+    await waitFor(() => expect(api.fetchStatsPerformance).toHaveBeenCalledWith("F", "T", false));
+
+    rerender({ reloadKey: 1 });
+    await waitFor(() => expect(api.fetchStatsPerformance).toHaveBeenLastCalledWith("F", "T", true));
+  });
+
   it("does not refetch cost when returning from another section", async () => {
     const { rerender } = renderHook(
-      ({ costActive }) => useStats(true, "F", "T", "day", costActive),
+      ({ costActive }) => useStats(true, "F", "T", "day", costActive, false),
       { initialProps: { costActive: true } },
     );
     await waitFor(() => expect(api.fetchStatsCost).toHaveBeenCalledTimes(1));
@@ -90,7 +129,7 @@ describe("useStats (#377)", () => {
 
   it("refetches overview when the period changes", async () => {
     const { rerender } = renderHook(
-      ({ bucket }) => useStats(true, "F", "T", bucket, false),
+      ({ bucket }) => useStats(true, "F", "T", bucket, false, false),
       { initialProps: { bucket: "day" } },
     );
     await waitFor(() => expect(api.fetchStatsOverview).toHaveBeenCalledTimes(1));
@@ -101,14 +140,21 @@ describe("useStats (#377)", () => {
 
   it("surfaces an overview fetch error", async () => {
     vi.mocked(api.fetchStatsOverview).mockRejectedValueOnce(new Error("boom"));
-    const { result } = renderHook(() => useStats(true, "F", "T", "day", false));
+    const { result } = renderHook(() => useStats(true, "F", "T", "day", false, false));
     await waitFor(() => expect(result.current.error).toBe("boom"));
   });
 
   it("surfaces a cost fetch error only for the cost class", async () => {
     vi.mocked(api.fetchStatsCost).mockRejectedValueOnce(new Error("cost-boom"));
-    const { result } = renderHook(() => useStats(true, "F", "T", "day", true));
+    const { result } = renderHook(() => useStats(true, "F", "T", "day", true, false));
     await waitFor(() => expect(result.current.costError).toBe("cost-boom"));
+    expect(result.current.error).toBeNull();
+  });
+
+  it("surfaces a performance source error separately", async () => {
+    vi.mocked(api.fetchStatsPerformance).mockRejectedValueOnce(new Error("journal unreadable"));
+    const { result } = renderHook(() => useStats(true, "F", "T", "day", false, true));
+    await waitFor(() => expect(result.current.performanceError).toBe("journal unreadable"));
     expect(result.current.error).toBeNull();
   });
 });

--- a/frontend/src/hooks/useStats.ts
+++ b/frontend/src/hooks/useStats.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
-import { fetchStatsOverview, fetchStatsCost } from "../api";
-import type { StatsOverview, StatsCost } from "../types";
+import { fetchStatsOverview, fetchStatsCost, fetchStatsPerformance } from "../api";
+import type { StatsOverview, StatsCost, StatsPerformance } from "../types";
 
 /**
  * State for the Stats modal (#377, ADR-0029). Two-endpoint split by cost class:
@@ -28,17 +28,23 @@ export function useStats(
   to: string,
   bucket: string,
   costActive: boolean,
+  performanceActive: boolean,
   reloadKey: number = 0,
 ) {
   const [overview, setOverview] = useState<StatsOverview | null>(null);
   const [cost, setCost] = useState<StatsCost | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [costError, setCostError] = useState<string | null>(null);
+  const [performance, setPerformance] = useState<StatsPerformance | null>(null);
+  const [performanceError, setPerformanceError] = useState<string | null>(null);
   const [computedAt, setComputedAt] = useState<Date | null>(null);
   const [overviewReloadKey, setOverviewReloadKey] = useState(0);
   const [costReloadKey, setCostReloadKey] = useState(0);
+  const [performanceReloadKey, setPerformanceReloadKey] = useState(0);
   const costRequestKey = `${from}\u0000${to}\u0000${bucket}\u0000${reloadKey}`;
   const requestedCostKey = useRef<string | null>(null);
+  const performanceRequestKey = `${from}\u0000${to}\u0000${reloadKey}`;
+  const requestedPerformanceKey = useRef<string | null>(null);
 
   // Overview: eager on open + on every period change.
   useEffect(() => {
@@ -86,13 +92,37 @@ export function useStats(
       });
   }, [open, costActive, from, to, bucket, reloadKey, costRequestKey]);
 
+  useEffect(() => {
+    if (!open || !performanceActive) return;
+    if (requestedPerformanceKey.current === performanceRequestKey) return;
+    requestedPerformanceKey.current = performanceRequestKey;
+    fetchStatsPerformance(from, to, reloadKey > 0)
+      .then((data) => {
+        if (requestedPerformanceKey.current === performanceRequestKey) {
+          setPerformance(data);
+          setPerformanceError(null);
+          setComputedAt(new Date());
+          setPerformanceReloadKey(reloadKey);
+        }
+      })
+      .catch((e) => {
+        if (requestedPerformanceKey.current === performanceRequestKey) {
+          setPerformanceError(e instanceof Error ? e.message : String(e));
+          setPerformanceReloadKey(reloadKey);
+        }
+      });
+  }, [open, performanceActive, from, to, reloadKey, performanceRequestKey]);
+
   return {
     overview,
     cost,
     error,
     costError,
+    performance,
+    performanceError,
     computedAt,
     overviewReloadKey,
     costReloadKey,
+    performanceReloadKey,
   };
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1277,3 +1277,44 @@ export interface StatsCost {
    *  by the "Sync costs" refetch on the Cost tab. */
   resolved: PriceRow[];
 }
+
+/** One R-7 distribution and its measurement coverage (#585). */
+export interface StatsDistribution {
+  stats: {
+    min: number;
+    q1: number;
+    median: number;
+    mean: number;
+    q3: number;
+    max: number;
+  } | null;
+  measured: number;
+  expected: number;
+  missing_reasons: string[];
+}
+
+export interface StatsHarnessPerformance {
+  harness: string;
+  context: StatsDistribution;
+  duration: StatsDistribution;
+}
+
+export interface StatsPerformanceAggregate {
+  harnesses: StatsHarnessPerformance[];
+}
+
+export interface StatsPerformanceEntity extends StatsPerformanceAggregate {
+  id: string;
+  name: string;
+  nodes: StatsPerformanceEntity[];
+  subagents: StatsPerformanceEntity[];
+}
+
+/** Derived `GET /stats/performance` payload. */
+export interface StatsPerformance {
+  harnesses: string[];
+  total: StatsPerformanceAggregate;
+  infrastructure_total: StatsPerformanceAggregate;
+  by_pipeline: StatsPerformanceEntity[];
+  infrastructure: StatsPerformanceEntity[];
+}


### PR DESCRIPTION
## Summary

- add lazy Performance stats for Pipeline, Node, subagent, and Infrastructure distributions
- parse Claude and Copilot context peaks and expose shared-scale context/duration boxplots
- add explicit refresh, sorting, coverage details, empty/error states, and support-matrix metadata
- bump the release version to 1.43.0

## Validation

- `make check`
- `make test`
- `make lint`
- `make build`
- Feature Path #585: pass, no findings

Closes #585