### PR TITLE
feat: instance-scoped agent profiles (#563)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "1.43.0"
+version = "1.44.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "1.43.0"
+version = "1.44.0"
 license = "MIT"
 description = "Prompt-Driven Orchestrator — a local daemon that runs and supervises agentic coding pipelines"
 repository = "https://github.com/Loulen/prompt-driven-orchestrator"

--- a/crates/pdo-daemon/src/agent_choice.rs
+++ b/crates/pdo-daemon/src/agent_choice.rs
@@ -1,0 +1,715 @@
+//! The **profil agentique** union each tier carries, and its pure resolver
+//! (#563, ADR-0057).
+//!
+//! Every tier of the precedence chain `Node → Run → Projet → Configuration
+//! d'instance → Default` now carries one [`AgentChoice`]: `Inherit` (continue
+//! down the chain), a named `Profile` reference (a live pointer, resolved from
+//! an atomic [`crate::agent_profile::snapshot`] taken once per resolution), or
+//! `Custom` (a complete inline combination that does not reactivate the old
+//! per-harness-map resolver — ADR-0057 ¶1). The first tier that is **explicit**
+//! (`Profile` that resolves, or `Custom`) wins and supplies harness, model and
+//! effort atomically — no field ever merges across tiers (#563 AC21).
+//!
+//! **Backward compatibility, by construction, not by migration.** #563 is
+//! explicit that no pipeline is migrated automatically (out of scope). Every
+//! tier this resolver reads still carries its **pre-#563** legacy signal too —
+//! a node's `pin_harness` + per-harness `harnesses` map, a Run/Projet/instance's
+//! bare `harness` string. [`resolve`] walks BOTH signals tier by tier: an
+//! `AgentChoice` at a tier wins outright over anything coarser the moment it is
+//! explicit; a tier with no `AgentChoice` (or `Inherit`) falls back to its
+//! legacy harness-only signal, and if that names a harness, the OLD model/effort
+//! rule applies — read from the node's own per-harness map, then the instance's
+//! per-harness default map (exactly [`crate::harness_resolver::resolve`]'s
+//! behaviour). A pipeline that never sets an `AgentChoice` anywhere therefore
+//! resolves byte-identically to before #563.
+//!
+//! A `Profile` reference to an id absent from the snapshot **warns and behaves
+//! as `Inherit`** (#563 AC13/AC14): the walk continues at that same tier's
+//! legacy signal, then the next tier, never stopping there.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::harness_resolver::HarnessEntry;
+
+/// One profile's combination: a required harness, an optional model, an
+/// optional effort. The shape both a stored [`crate::agent_profile::AgentProfile`]
+/// and an inline [`AgentChoice::Custom`] carry (ADR-0057 ¶1: "Custom porte la
+/// même forme qu'un profil").
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct ResolvedCombo {
+    pub harness: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effort: Option<String>,
+}
+
+/// The exclusive union a tier carries (#563 AC: "chaque tier porte une union
+/// exclusive"). Tagged on the wire by `mode`, so a stored/transmitted value is
+/// self-describing and a missing/legacy value simply deserializes absent
+/// (`Option<AgentChoice>` at the call site) rather than as some 4th variant.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "mode", rename_all = "snake_case")]
+pub(crate) enum AgentChoice {
+    /// Continue the precedence chain at the next coarser tier.
+    Inherit,
+    /// A live reference to a named profile, resolved from the atomic snapshot
+    /// at resolution time — never copied (ADR-0057 ¶0).
+    Profile { profile_id: String },
+    /// A complete, non-reusable inline combination. `model`/`effort` are
+    /// optional like a stored profile's.
+    Custom {
+        harness: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        model: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        effort: Option<String>,
+    },
+}
+
+/// Which tier ultimately supplied the resolved combination — frozen into the
+/// start event so a resume can say where its combination came from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum Tier {
+    Node,
+    Run,
+    Project,
+    Instance,
+    /// The reserved Default profile — the floor when every tier is transparent.
+    Default,
+}
+
+/// How the winning tier supplied its combination.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub(crate) enum Via {
+    /// A resolved, existing named profile.
+    Profile { profile_id: String },
+    /// An inline `Custom` combination.
+    Custom,
+    /// The pre-#563 legacy signal (a bare harness string, model/effort read
+    /// from the node's per-harness map / the instance's per-harness default).
+    Legacy,
+}
+
+/// A profile reference that pointed at nothing in the snapshot — the walk
+/// warned, then behaved as `Inherit` for that tier (#563 AC13).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct MissingProfileWarning {
+    pub tier: Tier,
+    pub profile_id: String,
+}
+
+/// What the spawn seam launches with — the same shape
+/// [`crate::harness_resolver::ResolvedHarness`] has, plus provenance and any
+/// missing-profile warnings collected along the way.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Resolved {
+    pub combo: ResolvedCombo,
+    pub tier: Tier,
+    pub via: Via,
+    pub warnings: Vec<MissingProfileWarning>,
+}
+
+/// Every tier's signal, new and legacy side by side. `node_harnesses` /
+/// `instance_default_models` are the pre-#563 per-harness maps — consulted only
+/// when the walk falls back to a *legacy* harness-only tier (never when an
+/// `AgentChoice` wins explicitly). `None` reads the same as an empty map.
+#[derive(Debug, Default, Clone)]
+pub(crate) struct Tiers<'a> {
+    pub node_choice: Option<&'a AgentChoice>,
+    pub node_pin: Option<&'a str>,
+    pub node_harnesses: Option<&'a BTreeMap<String, HarnessEntry>>,
+    pub run_choice: Option<&'a AgentChoice>,
+    pub run_harness: Option<&'a str>,
+    pub project_choice: Option<&'a AgentChoice>,
+    pub project_harness: Option<&'a str>,
+    pub instance_choice: Option<&'a AgentChoice>,
+    pub instance_default_harness: Option<&'a str>,
+    pub instance_default_models: Option<&'a BTreeMap<String, String>>,
+}
+
+fn normalise(s: Option<&str>) -> Option<String> {
+    s.map(str::trim).filter(|s| !s.is_empty()).map(String::from)
+}
+
+/// Resolve the effective combination for a spawn, walking the four tiers
+/// finest-to-coarsest and falling through to the reserved Default profile.
+///
+/// `profiles` is the ONE atomic snapshot the caller took before this call
+/// (ADR-0057 ¶4) — a `Profile` reference is looked up in it, never re-queried.
+/// `default_profile_id` names the reserved floor profile
+/// ([`crate::agent_profile::DEFAULT_PROFILE_ID`] in production code; a plain
+/// literal in tests that don't want the whole `agent_profile` module).
+pub(crate) fn resolve(
+    tiers: &Tiers<'_>,
+    profiles: &BTreeMap<String, ResolvedCombo>,
+    default_profile_id: &str,
+) -> Resolved {
+    let mut warnings = Vec::new();
+    let mut legacy_winner: Option<(Tier, String)> = None;
+
+    let slots: [(Tier, Option<&AgentChoice>, Option<&str>); 4] = [
+        (Tier::Node, tiers.node_choice, tiers.node_pin),
+        (Tier::Run, tiers.run_choice, tiers.run_harness),
+        (Tier::Project, tiers.project_choice, tiers.project_harness),
+        (
+            Tier::Instance,
+            tiers.instance_choice,
+            tiers.instance_default_harness,
+        ),
+    ];
+
+    for (tier, choice, legacy_harness) in slots {
+        match choice {
+            Some(AgentChoice::Custom {
+                harness,
+                model,
+                effort,
+            }) if !harness.trim().is_empty() => {
+                return Resolved {
+                    combo: ResolvedCombo {
+                        harness: harness.trim().to_string(),
+                        model: normalise(model.as_deref()),
+                        effort: normalise(effort.as_deref()),
+                    },
+                    tier,
+                    via: Via::Custom,
+                    warnings,
+                };
+            }
+            Some(AgentChoice::Profile { profile_id }) if !profile_id.trim().is_empty() => {
+                let profile_id = profile_id.trim();
+                if let Some(combo) = profiles.get(profile_id) {
+                    return Resolved {
+                        combo: combo.clone(),
+                        tier,
+                        via: Via::Profile {
+                            profile_id: profile_id.to_string(),
+                        },
+                        warnings,
+                    };
+                }
+                // Absent: warn, then behave as Inherit for this tier (AC13/AC14).
+                warnings.push(MissingProfileWarning {
+                    tier,
+                    profile_id: profile_id.to_string(),
+                });
+            }
+            // Inherit, None, or a blank Custom/Profile payload: transparent.
+            _ => {}
+        }
+        if legacy_winner.is_none() {
+            if let Some(h) = legacy_harness {
+                if !h.is_empty() {
+                    legacy_winner = Some((tier, h.to_string()));
+                    break;
+                }
+            }
+        }
+    }
+
+    if let Some((tier, harness)) = legacy_winner {
+        let entry = tiers.node_harnesses.and_then(|m| m.get(&harness));
+        let model = normalise(entry.and_then(|e| e.model.as_deref())).or_else(|| {
+            tiers
+                .instance_default_models
+                .and_then(|m| m.get(&harness))
+                .map(String::as_str)
+                .and_then(|s| normalise(Some(s)))
+        });
+        let effort = normalise(entry.and_then(|e| e.effort.as_deref()));
+        return Resolved {
+            combo: ResolvedCombo {
+                harness,
+                model,
+                effort,
+            },
+            tier,
+            via: Via::Legacy,
+            warnings,
+        };
+    }
+
+    // The floor: the reserved Default profile. Guaranteed present by
+    // `agent_profile::init`, but a defensive literal `claude` avoids a panic if
+    // ever called against an incomplete snapshot (e.g. a unit test that omits
+    // it on purpose).
+    let combo = profiles
+        .get(default_profile_id)
+        .cloned()
+        .unwrap_or(ResolvedCombo {
+            harness: crate::harness_registry::CLAUDE.to_string(),
+            model: None,
+            effort: None,
+        });
+    Resolved {
+        combo,
+        tier: Tier::Default,
+        via: Via::Profile {
+            profile_id: default_profile_id.to_string(),
+        },
+        warnings,
+    }
+}
+
+/// The combination an **infra session** (Pipeline Manager, merge resolver)
+/// launches with (#563 AC18, amending ADR-0046's Run-only-harness rule): it has
+/// no NodeDef and no Projet of its own, so only `Run → instance → Default`
+/// apply — but unlike before #563, a Run's *explicit* choice now supplies model
+/// and effort too, not just the harness. Implemented as [`resolve`] with the
+/// Node and Projet tiers transparent, which also means a legacy Run/instance
+/// harness-only signal still yields NO model/effort here — byte-identical to
+/// [`crate::harness_resolver::resolve_infra_harness`] when no `AgentChoice` is
+/// ever set.
+pub(crate) fn resolve_infra(
+    run_choice: Option<&AgentChoice>,
+    run_harness: Option<&str>,
+    instance_choice: Option<&AgentChoice>,
+    instance_default_harness: Option<&str>,
+    profiles: &BTreeMap<String, ResolvedCombo>,
+    default_profile_id: &str,
+) -> Resolved {
+    let tiers = Tiers {
+        run_choice,
+        run_harness,
+        instance_choice,
+        instance_default_harness,
+        ..Default::default()
+    };
+    resolve(&tiers, profiles, default_profile_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::harness_registry::{CLAUDE, OPENCODE};
+
+    const DEFAULT_ID: &str = "default";
+
+    fn profiles_with_default() -> BTreeMap<String, ResolvedCombo> {
+        let mut m = BTreeMap::new();
+        m.insert(
+            DEFAULT_ID.to_string(),
+            ResolvedCombo {
+                harness: CLAUDE.to_string(),
+                model: None,
+                effort: None,
+            },
+        );
+        m
+    }
+
+    fn profile(harness: &str, model: Option<&str>, effort: Option<&str>) -> ResolvedCombo {
+        ResolvedCombo {
+            harness: harness.to_string(),
+            model: model.map(String::from),
+            effort: effort.map(String::from),
+        }
+    }
+
+    // ---- floor -----------------------------------------------------------
+
+    #[test]
+    fn every_tier_transparent_resolves_to_the_default_profile() {
+        let tiers = Tiers::default();
+        let r = resolve(&tiers, &profiles_with_default(), DEFAULT_ID);
+        assert_eq!(r.combo.harness, CLAUDE);
+        assert_eq!(r.combo.model, None);
+        assert_eq!(r.combo.effort, None);
+        assert_eq!(r.tier, Tier::Default);
+        assert!(r.warnings.is_empty());
+    }
+
+    // ---- each tier's AgentChoice wins in turn, atomically -----------------
+
+    #[test]
+    fn node_profile_choice_wins_over_everything_coarser() {
+        let mut profiles = profiles_with_default();
+        profiles.insert(
+            "p1".to_string(),
+            profile(OPENCODE, Some("m1"), Some("high")),
+        );
+        let node_choice = AgentChoice::Profile {
+            profile_id: "p1".to_string(),
+        };
+        let run_choice = AgentChoice::Custom {
+            harness: CLAUDE.to_string(),
+            model: None,
+            effort: None,
+        };
+        let tiers = Tiers {
+            node_choice: Some(&node_choice),
+            run_choice: Some(&run_choice),
+            ..Default::default()
+        };
+        let r = resolve(&tiers, &profiles, DEFAULT_ID);
+        assert_eq!(r.combo, profile(OPENCODE, Some("m1"), Some("high")));
+        assert_eq!(r.tier, Tier::Node);
+        assert_eq!(
+            r.via,
+            Via::Profile {
+                profile_id: "p1".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn run_custom_wins_over_project_and_instance() {
+        let run_choice = AgentChoice::Custom {
+            harness: OPENCODE.to_string(),
+            model: Some("m2".to_string()),
+            effort: None,
+        };
+        let project_choice = AgentChoice::Custom {
+            harness: CLAUDE.to_string(),
+            model: None,
+            effort: None,
+        };
+        let tiers = Tiers {
+            run_choice: Some(&run_choice),
+            project_choice: Some(&project_choice),
+            ..Default::default()
+        };
+        let r = resolve(&tiers, &profiles_with_default(), DEFAULT_ID);
+        assert_eq!(r.combo, profile(OPENCODE, Some("m2"), None));
+        assert_eq!(r.tier, Tier::Run);
+        assert_eq!(r.via, Via::Custom);
+    }
+
+    #[test]
+    fn project_profile_wins_over_instance() {
+        let mut profiles = profiles_with_default();
+        profiles.insert("pj".to_string(), profile(CLAUDE, Some("sonnet"), None));
+        let project_choice = AgentChoice::Profile {
+            profile_id: "pj".to_string(),
+        };
+        let instance_choice = AgentChoice::Custom {
+            harness: OPENCODE.to_string(),
+            model: None,
+            effort: None,
+        };
+        let tiers = Tiers {
+            project_choice: Some(&project_choice),
+            instance_choice: Some(&instance_choice),
+            ..Default::default()
+        };
+        let r = resolve(&tiers, &profiles, DEFAULT_ID);
+        assert_eq!(r.combo, profile(CLAUDE, Some("sonnet"), None));
+        assert_eq!(r.tier, Tier::Project);
+    }
+
+    #[test]
+    fn instance_custom_wins_over_the_default_floor() {
+        let instance_choice = AgentChoice::Custom {
+            harness: OPENCODE.to_string(),
+            model: Some("m3".to_string()),
+            effort: Some("low".to_string()),
+        };
+        let tiers = Tiers {
+            instance_choice: Some(&instance_choice),
+            ..Default::default()
+        };
+        let r = resolve(&tiers, &profiles_with_default(), DEFAULT_ID);
+        assert_eq!(r.combo, profile(OPENCODE, Some("m3"), Some("low")));
+        assert_eq!(r.tier, Tier::Instance);
+    }
+
+    // ---- Inherit is fully transparent -------------------------------------
+
+    #[test]
+    fn inherit_at_every_finer_tier_falls_through_to_the_winning_coarser_one() {
+        let mut profiles = profiles_with_default();
+        profiles.insert("pj".to_string(), profile(CLAUDE, None, None));
+        let node_choice = AgentChoice::Inherit;
+        let run_choice = AgentChoice::Inherit;
+        let project_choice = AgentChoice::Profile {
+            profile_id: "pj".to_string(),
+        };
+        let tiers = Tiers {
+            node_choice: Some(&node_choice),
+            run_choice: Some(&run_choice),
+            project_choice: Some(&project_choice),
+            ..Default::default()
+        };
+        let r = resolve(&tiers, &profiles, DEFAULT_ID);
+        assert_eq!(r.tier, Tier::Project);
+    }
+
+    // ---- a missing profile reference warns then behaves as Inherit --------
+
+    #[test]
+    fn missing_profile_at_node_warns_and_falls_through_to_run() {
+        let mut profiles = profiles_with_default();
+        profiles.insert("run-p".to_string(), profile(OPENCODE, None, None));
+        let node_choice = AgentChoice::Profile {
+            profile_id: "gone".to_string(),
+        };
+        let run_choice = AgentChoice::Profile {
+            profile_id: "run-p".to_string(),
+        };
+        let tiers = Tiers {
+            node_choice: Some(&node_choice),
+            run_choice: Some(&run_choice),
+            ..Default::default()
+        };
+        let r = resolve(&tiers, &profiles, DEFAULT_ID);
+        assert_eq!(r.combo, profile(OPENCODE, None, None));
+        assert_eq!(r.tier, Tier::Run);
+        assert_eq!(
+            r.warnings,
+            vec![MissingProfileWarning {
+                tier: Tier::Node,
+                profile_id: "gone".to_string()
+            }]
+        );
+    }
+
+    #[test]
+    fn missing_profile_everywhere_still_resolves_to_the_default_floor_with_warnings() {
+        let node_choice = AgentChoice::Profile {
+            profile_id: "gone1".to_string(),
+        };
+        let run_choice = AgentChoice::Profile {
+            profile_id: "gone2".to_string(),
+        };
+        let tiers = Tiers {
+            node_choice: Some(&node_choice),
+            run_choice: Some(&run_choice),
+            ..Default::default()
+        };
+        let r = resolve(&tiers, &profiles_with_default(), DEFAULT_ID);
+        assert_eq!(r.tier, Tier::Default);
+        assert_eq!(r.warnings.len(), 2);
+    }
+
+    #[test]
+    fn a_missing_profile_at_a_tier_that_also_carries_a_legacy_harness_still_uses_the_legacy_signal()
+    {
+        // A node whose Profile reference is broken but which ALSO still carries a
+        // legacy pin: the tier keeps behaving as it did pre-#563 (Inherit), so
+        // the pin still wins the harness — the warning does not blank the tier.
+        let node_choice = AgentChoice::Profile {
+            profile_id: "gone".to_string(),
+        };
+        let tiers = Tiers {
+            node_choice: Some(&node_choice),
+            node_pin: Some(CLAUDE),
+            ..Default::default()
+        };
+        let r = resolve(&tiers, &profiles_with_default(), DEFAULT_ID);
+        assert_eq!(r.combo.harness, CLAUDE);
+        assert_eq!(r.tier, Tier::Node);
+        assert_eq!(r.via, Via::Legacy);
+        assert_eq!(r.warnings.len(), 1);
+    }
+
+    // ---- legacy-only tiers behave byte-identically to `harness_resolver` ---
+
+    #[test]
+    fn no_agent_choice_anywhere_reproduces_the_pre_563_harness_resolver_exactly() {
+        let mut entries = BTreeMap::new();
+        entries.insert(
+            OPENCODE.to_string(),
+            HarnessEntry {
+                model: Some("openrouter/foo".to_string()),
+                effort: None,
+            },
+        );
+        let mut default_models = BTreeMap::new();
+        default_models.insert(CLAUDE.to_string(), "sonnet".to_string());
+
+        let tiers = Tiers {
+            node_pin: Some(OPENCODE),
+            node_harnesses: Some(&entries),
+            instance_default_models: Some(&default_models),
+            ..Default::default()
+        };
+        let r = resolve(&tiers, &profiles_with_default(), DEFAULT_ID);
+        assert_eq!(r.combo.harness, OPENCODE);
+        assert_eq!(r.combo.model.as_deref(), Some("openrouter/foo"));
+        assert_eq!(r.combo.effort, None);
+        assert_eq!(r.via, Via::Legacy);
+        assert!(r.warnings.is_empty());
+    }
+
+    #[test]
+    fn legacy_run_harness_wins_over_project_and_instance_and_reads_node_map_for_model() {
+        let mut entries = BTreeMap::new();
+        entries.insert(
+            CLAUDE.to_string(),
+            HarnessEntry {
+                model: Some("opus".to_string()),
+                effort: Some("high".to_string()),
+            },
+        );
+        let tiers = Tiers {
+            run_harness: Some(CLAUDE),
+            project_harness: Some(OPENCODE),
+            instance_default_harness: Some(OPENCODE),
+            node_harnesses: Some(&entries),
+            ..Default::default()
+        };
+        let r = resolve(&tiers, &profiles_with_default(), DEFAULT_ID);
+        assert_eq!(r.combo.harness, CLAUDE);
+        assert_eq!(r.combo.model.as_deref(), Some("opus"));
+        assert_eq!(r.combo.effort.as_deref(), Some("high"));
+        assert_eq!(r.tier, Tier::Run);
+        assert_eq!(r.via, Via::Legacy);
+    }
+
+    #[test]
+    fn empty_string_legacy_harness_never_wins_a_tier() {
+        let tiers = Tiers {
+            node_pin: Some(""),
+            instance_default_harness: Some(""),
+            ..Default::default()
+        };
+        let r = resolve(&tiers, &profiles_with_default(), DEFAULT_ID);
+        assert_eq!(r.tier, Tier::Default);
+        assert_eq!(r.combo.harness, CLAUDE);
+    }
+
+    // ---- an explicit tier's combo never merges with a coarser tier's ------
+
+    #[test]
+    fn a_custom_node_combo_never_merges_with_the_instance_defaults() {
+        let mut default_models = BTreeMap::new();
+        default_models.insert(OPENCODE.to_string(), "should-not-leak".to_string());
+        let node_choice = AgentChoice::Custom {
+            harness: OPENCODE.to_string(),
+            model: None,
+            effort: None,
+        };
+        let tiers = Tiers {
+            node_choice: Some(&node_choice),
+            instance_default_models: Some(&default_models),
+            ..Default::default()
+        };
+        let r = resolve(&tiers, &profiles_with_default(), DEFAULT_ID);
+        assert_eq!(r.combo.model, None, "Custom is atomic — no instance leak");
+    }
+
+    // ---- blank Custom harness / blank Profile id are transparent -----------
+
+    #[test]
+    fn a_custom_with_blank_harness_is_treated_as_inherit() {
+        let node_choice = AgentChoice::Custom {
+            harness: "   ".to_string(),
+            model: Some("x".to_string()),
+            effort: None,
+        };
+        let tiers = Tiers {
+            node_choice: Some(&node_choice),
+            node_pin: Some(CLAUDE),
+            ..Default::default()
+        };
+        let r = resolve(&tiers, &profiles_with_default(), DEFAULT_ID);
+        assert_eq!(r.combo.harness, CLAUDE);
+        assert_eq!(r.combo.model, None);
+        assert_eq!(r.via, Via::Legacy);
+    }
+
+    // ---- infra sessions: Run → instance → Default, no Node/Projet ---------
+
+    #[test]
+    fn infra_follows_the_runs_explicit_choice_model_and_effort_included() {
+        let run_choice = AgentChoice::Custom {
+            harness: OPENCODE.to_string(),
+            model: Some("infra-model".to_string()),
+            effort: Some("high".to_string()),
+        };
+        let r = resolve_infra(
+            Some(&run_choice),
+            None,
+            None,
+            None,
+            &profiles_with_default(),
+            DEFAULT_ID,
+        );
+        assert_eq!(
+            r.combo,
+            profile(OPENCODE, Some("infra-model"), Some("high"))
+        );
+        assert_eq!(r.tier, Tier::Run);
+    }
+
+    #[test]
+    fn infra_with_only_legacy_run_harness_gets_no_model_or_effort() {
+        // Byte-identical to `harness_resolver::resolve_infra_harness`: a legacy
+        // (non-AgentChoice) Run harness carries no model/effort for infra.
+        let r = resolve_infra(
+            None,
+            Some(OPENCODE),
+            None,
+            Some(CLAUDE),
+            &profiles_with_default(),
+            DEFAULT_ID,
+        );
+        assert_eq!(r.combo.harness, OPENCODE);
+        assert_eq!(r.combo.model, None);
+        assert_eq!(r.combo.effort, None);
+    }
+
+    #[test]
+    fn infra_falls_through_to_instance_then_default_floor() {
+        let r = resolve_infra(None, None, None, None, &profiles_with_default(), DEFAULT_ID);
+        assert_eq!(r.combo.harness, CLAUDE);
+        assert_eq!(r.tier, Tier::Default);
+
+        let r2 = resolve_infra(
+            None,
+            None,
+            None,
+            Some(OPENCODE),
+            &profiles_with_default(),
+            DEFAULT_ID,
+        );
+        assert_eq!(r2.combo.harness, OPENCODE);
+        assert_eq!(r2.tier, Tier::Instance);
+    }
+
+    // ---- serde shape: `mode`-tagged, round trips -----------------------
+
+    #[test]
+    fn agent_choice_serde_round_trips_all_three_modes() {
+        for choice in [
+            AgentChoice::Inherit,
+            AgentChoice::Profile {
+                profile_id: "p1".to_string(),
+            },
+            AgentChoice::Custom {
+                harness: CLAUDE.to_string(),
+                model: Some("opus".to_string()),
+                effort: None,
+            },
+        ] {
+            let json = serde_json::to_value(&choice).unwrap();
+            let back: AgentChoice = serde_json::from_value(json).unwrap();
+            assert_eq!(back, choice);
+        }
+    }
+
+    #[test]
+    fn agent_choice_wire_shape_is_mode_tagged() {
+        let json = serde_json::to_value(AgentChoice::Profile {
+            profile_id: "p1".to_string(),
+        })
+        .unwrap();
+        assert_eq!(json["mode"], "profile");
+        assert_eq!(json["profile_id"], "p1");
+
+        let json = serde_json::to_value(AgentChoice::Custom {
+            harness: CLAUDE.to_string(),
+            model: None,
+            effort: None,
+        })
+        .unwrap();
+        assert_eq!(json["mode"], "custom");
+        assert_eq!(json["harness"], CLAUDE);
+        assert!(json.get("model").is_none());
+    }
+}

--- a/crates/pdo-daemon/src/agent_profile.rs
+++ b/crates/pdo-daemon/src/agent_profile.rs
@@ -1,0 +1,593 @@
+//! Persistence for **profils agentiques** — instance-scoped, named, reusable
+//! combinations of a required harness with an optional model and effort
+//! (#563, ADR-0057, CONTEXT.md §*Profil agentique*).
+//!
+//! A profile's identity is its `id`, stable and distinct from its `name`: a
+//! rename never breaks a referent, which is why every reference PDO stores
+//! (on a node, a Run, a Projet, the instance) is an `id`, never a `name`
+//! (ADR-0057 ¶2).
+//!
+//! Every instance carries a **reserved** profile, [`DEFAULT_PROFILE_ID`], seeded
+//! at [`init`] time if absent: named `Default`, harness `claude`, no model, no
+//! effort. It is the floor of the whole precedence chain — modifiable and
+//! renamable like any other profile, but [`delete`] refuses it unconditionally
+//! (an operator must always have a plancher to fall back to, ADR-0057 ¶3).
+//!
+//! Names are unique **case-insensitively** (ADR-0057 ¶5, #563 AC25) so a picker
+//! never shows two entries a human cannot tell apart. Uniqueness is enforced in
+//! code (a read-then-decide check under the whole-store discipline every other
+//! store here uses — `project_store`'s "at most one Projet per path" is the
+//! closest precedent) rather than by a `UNIQUE` index on a computed column,
+//! because the message must **name the clashing profile**, which a bare
+//! constraint violation cannot.
+//!
+//! [`snapshot`] is the one-shot, atomic read the spawn seam calls: a single
+//! `SELECT *` collapsed into an id → combo map, so a resolution that walks four
+//! tiers reads exactly one revision of every profile it might touch — never two
+//! (ADR-0057 ¶4: "au spawn, PDO lit et gèle une seule révision complète").
+
+use serde::{Deserialize, Serialize};
+use sqlx::{Row, SqlitePool};
+use std::collections::BTreeMap;
+use std::fmt;
+
+use crate::agent_choice::ResolvedCombo;
+
+/// The reserved id of the instance's floor profile (ADR-0057 ¶3). Distinct from
+/// its `name` (`Default`), which is editable — only the id is fixed forever, so
+/// a rename can never orphan the plancher every resolution falls back to.
+pub(crate) const DEFAULT_PROFILE_ID: &str = "default";
+/// The seeded name of the reserved profile. Editable afterwards like any other
+/// profile's name (still subject to the case-insensitive uniqueness check).
+pub(crate) const DEFAULT_PROFILE_NAME: &str = "Default";
+
+/// A persisted agent profile: a stable `id`, a case-insensitively unique `name`,
+/// a required `harness`, and an optional `model` / `effort` — the same shape a
+/// node's `Custom` choice carries inline (ADR-0057 ¶1: "Custom porte la même
+/// forme qu'un profil").
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct AgentProfile {
+    pub id: String,
+    pub name: String,
+    pub harness: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effort: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+impl AgentProfile {
+    /// This profile's combination, the shape [`snapshot`] indexes by id.
+    pub(crate) fn combo(&self) -> ResolvedCombo {
+        ResolvedCombo {
+            harness: self.harness.clone(),
+            model: self.model.clone(),
+            effort: self.effort.clone(),
+        }
+    }
+}
+
+/// Why a create/update/delete was refused — named so the HTTP layer can turn
+/// each variant into the right status code and an actionable message, the same
+/// split `sandbox_profile::validate_*` uses (message strings) but as a proper
+/// enum here because the caller (delete) also needs to branch on *which* refusal
+/// happened, not just render it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum AgentProfileError {
+    /// The name is blank once trimmed.
+    EmptyName,
+    /// The harness is blank once trimmed — required (#563 AC2).
+    EmptyHarness,
+    /// Another profile already carries this name, case-insensitively.
+    DuplicateName {
+        existing_id: String,
+        name: String,
+    },
+    /// No profile with this id.
+    NotFound,
+    /// [`DEFAULT_PROFILE_ID`] can never be deleted (ADR-0057 ¶3 / #563 AC10).
+    DefaultUndeletable,
+    Storage(String),
+}
+
+impl fmt::Display for AgentProfileError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyName => write!(f, "a profile name cannot be blank"),
+            Self::EmptyHarness => write!(f, "a profile's harness cannot be blank"),
+            Self::DuplicateName { name, .. } => write!(
+                f,
+                "a profile named `{name}` already exists (names are unique \
+                 case-insensitively)"
+            ),
+            Self::NotFound => write!(f, "no such agent profile"),
+            Self::DefaultUndeletable => write!(
+                f,
+                "the `{DEFAULT_PROFILE_NAME}` profile is the instance's reserved \
+                 floor and cannot be deleted — rename or edit it instead"
+            ),
+            Self::Storage(message) => write!(f, "{message}"),
+        }
+    }
+}
+
+impl std::error::Error for AgentProfileError {}
+
+/// Create the `agent_profiles` table if absent and seed the reserved
+/// [`DEFAULT_PROFILE_ID`] row if it is missing. Idempotent — safe on every boot,
+/// same idiom as `sandbox_profile::init` / `project_store::init`.
+pub(crate) async fn init(db: &SqlitePool) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS agent_profiles (
+            id         TEXT PRIMARY KEY,
+            name       TEXT NOT NULL,
+            harness    TEXT NOT NULL,
+            model      TEXT,
+            effort     TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        )",
+    )
+    .execute(db)
+    .await?;
+
+    let exists = sqlx::query("SELECT 1 FROM agent_profiles WHERE id = ?")
+        .bind(DEFAULT_PROFILE_ID)
+        .fetch_optional(db)
+        .await?
+        .is_some();
+    if !exists {
+        let now = crate::event_log::now_iso();
+        sqlx::query(
+            "INSERT INTO agent_profiles (id, name, harness, model, effort, created_at, updated_at) \
+             VALUES (?, ?, ?, NULL, NULL, ?, ?)",
+        )
+        .bind(DEFAULT_PROFILE_ID)
+        .bind(DEFAULT_PROFILE_NAME)
+        .bind(crate::harness_registry::CLAUDE)
+        .bind(&now)
+        .bind(&now)
+        .execute(db)
+        .await?;
+    }
+    sqlx::query(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_profiles_name_nocase \
+         ON agent_profiles(name COLLATE NOCASE)",
+    )
+    .execute(db)
+    .await?;
+
+    Ok(())
+}
+
+fn row_to_profile(row: &sqlx::sqlite::SqliteRow) -> AgentProfile {
+    AgentProfile {
+        id: row.get("id"),
+        name: row.get("name"),
+        harness: row.get("harness"),
+        model: row
+            .get::<Option<String>, _>("model")
+            .filter(|s| !s.is_empty()),
+        effort: row
+            .get::<Option<String>, _>("effort")
+            .filter(|s| !s.is_empty()),
+        created_at: row.get("created_at"),
+        updated_at: row.get("updated_at"),
+    }
+}
+
+/// Generate a profile id (`agp-<ts>-<short uuid>`), mirroring
+/// `project_store::generate_project_id`.
+fn generate_profile_id() -> String {
+    let ts = chrono::Utc::now().format("%Y%m%d-%H%M%S");
+    let short = &uuid::Uuid::new_v4().to_string()[..7];
+    format!("agp-{ts}-{short}")
+}
+
+/// All profiles, [`DEFAULT_PROFILE_ID`] first, then by creation order — a stable
+/// listing so the settings panel does not reshuffle rows on every fetch.
+pub(crate) async fn list(db: &SqlitePool) -> Result<Vec<AgentProfile>, sqlx::Error> {
+    let rows =
+        sqlx::query("SELECT * FROM agent_profiles ORDER BY (id = ?) DESC, created_at ASC, id ASC")
+            .bind(DEFAULT_PROFILE_ID)
+            .fetch_all(db)
+            .await?;
+    Ok(rows.iter().map(row_to_profile).collect())
+}
+
+/// One profile by id, or `None`.
+pub(crate) async fn get(db: &SqlitePool, id: &str) -> Result<Option<AgentProfile>, sqlx::Error> {
+    let row = sqlx::query("SELECT * FROM agent_profiles WHERE id = ?")
+        .bind(id)
+        .fetch_optional(db)
+        .await?;
+    Ok(row.as_ref().map(row_to_profile))
+}
+
+/// The atomic snapshot the spawn seam (and the pure resolver in
+/// [`crate::agent_choice`]) reads: every profile's `id → combo`, in ONE query —
+/// so a resolution walking Node → Run → Projet → instance → Default never mixes
+/// two revisions of the same profile, and never sees a profile renamed or edited
+/// mid-walk (ADR-0057 ¶4).
+pub(crate) async fn snapshot(
+    db: &SqlitePool,
+) -> Result<BTreeMap<String, ResolvedCombo>, sqlx::Error> {
+    let rows = sqlx::query("SELECT * FROM agent_profiles")
+        .fetch_all(db)
+        .await?;
+    Ok(rows
+        .iter()
+        .map(row_to_profile)
+        .map(|p| (p.id.clone(), p.combo()))
+        .collect())
+}
+
+/// Case-insensitive lookup by name, trimmed on both sides — the basis of the
+/// uniqueness check ([`create`] / [`update`]) and handy for the HTTP layer to
+/// resolve a name back to an id without a second round trip.
+pub(crate) async fn find_by_name_ci(
+    db: &SqlitePool,
+    name: &str,
+) -> Result<Option<AgentProfile>, sqlx::Error> {
+    let row = sqlx::query(
+        "SELECT * FROM agent_profiles WHERE lower(trim(name)) = lower(trim(?)) LIMIT 1",
+    )
+    .bind(name)
+    .fetch_optional(db)
+    .await?;
+    Ok(row.as_ref().map(row_to_profile))
+}
+
+/// Trim `name`/`harness`, reject blanks, reject a case-insensitive clash with
+/// another profile (`excluding_id` lets [`update`] ignore the row being edited).
+/// Returns the normalised `(name, harness)` on success.
+async fn validate_name_and_harness(
+    db: &SqlitePool,
+    name: &str,
+    harness: &str,
+    excluding_id: Option<&str>,
+) -> Result<(String, String), AgentProfileError> {
+    let name = name.trim().to_string();
+    if name.is_empty() {
+        return Err(AgentProfileError::EmptyName);
+    }
+    let harness = harness.trim().to_string();
+    if harness.is_empty() {
+        return Err(AgentProfileError::EmptyHarness);
+    }
+    if let Some(existing) = find_by_name_ci(db, &name)
+        .await
+        .map_err(|_| AgentProfileError::NotFound)?
+    {
+        if Some(existing.id.as_str()) != excluding_id {
+            return Err(AgentProfileError::DuplicateName {
+                existing_id: existing.id,
+                name: existing.name,
+            });
+        }
+    }
+    Ok((name, harness))
+}
+
+/// Create a new profile. `model` / `effort` are normalised: an empty string is
+/// stored as `NULL` (unset) — the same `Some("")`-is-unset discipline every
+/// other free-text column in this daemon follows (#347).
+pub(crate) async fn create(
+    db: &SqlitePool,
+    name: &str,
+    harness: &str,
+    model: Option<&str>,
+    effort: Option<&str>,
+) -> Result<AgentProfile, AgentProfileError> {
+    let (name, harness) = validate_name_and_harness(db, name, harness, None).await?;
+    let id = generate_profile_id();
+    let now = crate::event_log::now_iso();
+    let model = model.map(str::trim).filter(|s| !s.is_empty());
+    let effort = effort.map(str::trim).filter(|s| !s.is_empty());
+    sqlx::query(
+        "INSERT INTO agent_profiles (id, name, harness, model, effort, created_at, updated_at) \
+         VALUES (?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(&id)
+    .bind(&name)
+    .bind(&harness)
+    .bind(model)
+    .bind(effort)
+    .bind(&now)
+    .bind(&now)
+    .execute(db)
+    .await
+    .map_err(|error| AgentProfileError::Storage(error.to_string()))?;
+    Ok(AgentProfile {
+        id,
+        name,
+        harness,
+        model: model.map(String::from),
+        effort: effort.map(String::from),
+        created_at: now.clone(),
+        updated_at: now,
+    })
+}
+
+/// Edit (and/or rename) an existing profile, [`DEFAULT_PROFILE_ID`] included
+/// (ADR-0057 ¶3: it "reste modifiable et renommable"). All three of
+/// `name`/`harness`/`model`/`effort` are supplied wholesale — this is a full
+/// replace of the row's editable fields, not a sparse patch, mirroring how
+/// `Custom` and a profile share one complete-combination shape.
+pub(crate) async fn update(
+    db: &SqlitePool,
+    id: &str,
+    name: &str,
+    harness: &str,
+    model: Option<&str>,
+    effort: Option<&str>,
+) -> Result<AgentProfile, AgentProfileError> {
+    if get(db, id)
+        .await
+        .map_err(|_| AgentProfileError::NotFound)?
+        .is_none()
+    {
+        return Err(AgentProfileError::NotFound);
+    }
+    let (name, harness) = validate_name_and_harness(db, name, harness, Some(id)).await?;
+    let now = crate::event_log::now_iso();
+    let model = model.map(str::trim).filter(|s| !s.is_empty());
+    let effort = effort.map(str::trim).filter(|s| !s.is_empty());
+    sqlx::query(
+        "UPDATE agent_profiles SET name = ?, harness = ?, model = ?, effort = ?, updated_at = ? \
+         WHERE id = ?",
+    )
+    .bind(&name)
+    .bind(&harness)
+    .bind(model)
+    .bind(effort)
+    .bind(&now)
+    .bind(id)
+    .execute(db)
+    .await
+    .map_err(|error| AgentProfileError::Storage(error.to_string()))?;
+    // Re-fetch rather than reconstruct: cheap (PK lookup) and it keeps this
+    // function honest about `created_at`, which it never touches.
+    get(db, id)
+        .await
+        .map_err(|_| AgentProfileError::NotFound)?
+        .ok_or(AgentProfileError::NotFound)
+}
+
+/// Delete a profile. [`DEFAULT_PROFILE_ID`] is refused unconditionally
+/// (ADR-0057 ¶3 / #563 AC10) — checked BEFORE any query, so the reserved
+/// profile is never even looked up. Otherwise **unconditional**, same posture as
+/// `sandbox_profile::delete` (ADR-0031 §7): no referential integrity in the
+/// database, the referents dialog is what informs the confirmation, not a
+/// database-level refusal.
+pub(crate) async fn delete(db: &SqlitePool, id: &str) -> Result<bool, AgentProfileError> {
+    if id == DEFAULT_PROFILE_ID {
+        return Err(AgentProfileError::DefaultUndeletable);
+    }
+    let res = sqlx::query("DELETE FROM agent_profiles WHERE id = ?")
+        .bind(id)
+        .execute(db)
+        .await
+        .map_err(|_| AgentProfileError::NotFound)?;
+    Ok(res.rows_affected() > 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn mem_db() -> SqlitePool {
+        let db = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        init(&db).await.unwrap();
+        db
+    }
+
+    #[tokio::test]
+    async fn init_is_idempotent_and_seeds_default_exactly_once() {
+        let db = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        init(&db).await.unwrap();
+        init(&db).await.unwrap();
+        let all = list(&db).await.unwrap();
+        assert_eq!(all.len(), 1, "Default must be seeded exactly once");
+        let d = &all[0];
+        assert_eq!(d.id, DEFAULT_PROFILE_ID);
+        assert_eq!(d.name, DEFAULT_PROFILE_NAME);
+        assert_eq!(d.harness, crate::harness_registry::CLAUDE);
+        assert_eq!(d.model, None);
+        assert_eq!(d.effort, None);
+    }
+
+    #[tokio::test]
+    async fn default_profile_is_immediately_resolvable() {
+        // AC10: Default toujours disponible dès l'instanciation.
+        let db = mem_db().await;
+        let d = get(&db, DEFAULT_PROFILE_ID).await.unwrap().unwrap();
+        assert_eq!(d.combo().harness, crate::harness_registry::CLAUDE);
+    }
+
+    #[tokio::test]
+    async fn create_a_named_profile() {
+        let db = mem_db().await;
+        let p = create(&db, "Fast Reviewer", "claude", Some("opus"), Some("high"))
+            .await
+            .unwrap();
+        assert_eq!(p.name, "Fast Reviewer");
+        assert_eq!(p.harness, "claude");
+        assert_eq!(p.model.as_deref(), Some("opus"));
+        assert_eq!(p.effort.as_deref(), Some("high"));
+        assert_ne!(p.id, DEFAULT_PROFILE_ID);
+        assert!(get(&db, &p.id).await.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn empty_name_or_harness_is_refused() {
+        let db = mem_db().await;
+        assert_eq!(
+            create(&db, "  ", "claude", None, None).await.unwrap_err(),
+            AgentProfileError::EmptyName
+        );
+        assert_eq!(
+            create(&db, "X", "  ", None, None).await.unwrap_err(),
+            AgentProfileError::EmptyHarness
+        );
+    }
+
+    #[tokio::test]
+    async fn names_are_unique_case_insensitively() {
+        // AC25.
+        let db = mem_db().await;
+        create(&db, "Reviewer", "claude", None, None).await.unwrap();
+        let err = create(&db, "REVIEWER", "opencode", None, None)
+            .await
+            .unwrap_err();
+        match err {
+            AgentProfileError::DuplicateName { name, .. } => assert_eq!(name, "Reviewer"),
+            other => panic!("expected DuplicateName, got {other:?}"),
+        }
+        // Also clashes with the reserved Default name, case-insensitively.
+        let err2 = create(&db, "default", "claude", None, None)
+            .await
+            .unwrap_err();
+        assert!(matches!(err2, AgentProfileError::DuplicateName { .. }));
+    }
+
+    #[tokio::test]
+    async fn rename_preserves_id_and_referents_would_still_resolve() {
+        // ADR-0057 ¶2: l'identité ne dépend pas du nom.
+        let db = mem_db().await;
+        let p = create(&db, "Old Name", "claude", None, None).await.unwrap();
+        let updated = update(&db, &p.id, "New Name", "claude", None, None)
+            .await
+            .unwrap();
+        assert_eq!(updated.id, p.id);
+        assert_eq!(updated.name, "New Name");
+        assert_eq!(get(&db, &p.id).await.unwrap().unwrap().name, "New Name");
+    }
+
+    #[tokio::test]
+    async fn rename_to_an_existing_name_is_refused() {
+        let db = mem_db().await;
+        let a = create(&db, "Alpha", "claude", None, None).await.unwrap();
+        create(&db, "Bravo", "claude", None, None).await.unwrap();
+        let err = update(&db, &a.id, "bravo", "claude", None, None)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, AgentProfileError::DuplicateName { .. }));
+    }
+
+    #[tokio::test]
+    async fn rename_to_its_own_name_case_changed_is_allowed() {
+        // Excluding self from the clash check: editing "Alpha" to "ALPHA" must not
+        // spuriously collide with itself.
+        let db = mem_db().await;
+        let a = create(&db, "Alpha", "claude", None, None).await.unwrap();
+        let updated = update(&db, &a.id, "ALPHA", "claude", None, None)
+            .await
+            .unwrap();
+        assert_eq!(updated.name, "ALPHA");
+    }
+
+    #[tokio::test]
+    async fn default_is_editable_and_renamable() {
+        // AC: Default reste modifiable et renommable.
+        let db = mem_db().await;
+        let updated = update(
+            &db,
+            DEFAULT_PROFILE_ID,
+            "House Default",
+            "opencode",
+            Some("gpt"),
+            None,
+        )
+        .await
+        .unwrap();
+        assert_eq!(updated.id, DEFAULT_PROFILE_ID);
+        assert_eq!(updated.name, "House Default");
+        assert_eq!(updated.harness, "opencode");
+        assert_eq!(updated.model.as_deref(), Some("gpt"));
+    }
+
+    #[tokio::test]
+    async fn default_cannot_be_deleted() {
+        // AC10/AC12.
+        let db = mem_db().await;
+        let err = delete(&db, DEFAULT_PROFILE_ID).await.unwrap_err();
+        assert_eq!(err, AgentProfileError::DefaultUndeletable);
+        assert!(get(&db, DEFAULT_PROFILE_ID).await.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn a_named_profile_can_be_deleted() {
+        let db = mem_db().await;
+        let p = create(&db, "Temp", "claude", None, None).await.unwrap();
+        assert!(delete(&db, &p.id).await.unwrap());
+        assert!(get(&db, &p.id).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn deleting_an_unknown_id_is_a_noop_false() {
+        let db = mem_db().await;
+        assert!(!delete(&db, "agp-nope").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn update_of_unknown_id_is_not_found() {
+        let db = mem_db().await;
+        let err = update(&db, "agp-nope", "X", "claude", None, None)
+            .await
+            .unwrap_err();
+        assert_eq!(err, AgentProfileError::NotFound);
+    }
+
+    #[tokio::test]
+    async fn empty_model_and_effort_normalise_to_none() {
+        let db = mem_db().await;
+        let p = create(&db, "P", "claude", Some(""), Some("  "))
+            .await
+            .unwrap();
+        assert_eq!(p.model, None);
+        assert_eq!(p.effort, None);
+    }
+
+    #[tokio::test]
+    async fn snapshot_is_one_atomic_read_of_every_profile() {
+        // ADR-0057 ¶4: the spawn seam reads one full revision in one shot.
+        let db = mem_db().await;
+        let a = create(&db, "Alpha", "claude", Some("opus"), Some("high"))
+            .await
+            .unwrap();
+        let b = create(&db, "Bravo", "opencode", None, None).await.unwrap();
+        let snap = snapshot(&db).await.unwrap();
+        assert_eq!(snap.len(), 3, "Default + Alpha + Bravo");
+        assert_eq!(
+            snap[DEFAULT_PROFILE_ID].harness,
+            crate::harness_registry::CLAUDE
+        );
+        assert_eq!(snap[&a.id].harness, "claude");
+        assert_eq!(snap[&a.id].model.as_deref(), Some("opus"));
+        assert_eq!(snap[&b.id].harness, "opencode");
+        assert_eq!(snap[&b.id].model, None);
+    }
+
+    #[tokio::test]
+    async fn list_orders_default_first_then_creation_order() {
+        let db = mem_db().await;
+        let a = create(&db, "Alpha", "claude", None, None).await.unwrap();
+        let b = create(&db, "Bravo", "claude", None, None).await.unwrap();
+        let names: Vec<String> = list(&db).await.unwrap().into_iter().map(|p| p.id).collect();
+        assert_eq!(names, vec![DEFAULT_PROFILE_ID.to_string(), a.id, b.id]);
+    }
+
+    #[tokio::test]
+    async fn find_by_name_ci_matches_regardless_of_case_and_whitespace() {
+        let db = mem_db().await;
+        let p = create(&db, "Fast Reviewer", "claude", None, None)
+            .await
+            .unwrap();
+        let found = find_by_name_ci(&db, "  fast REVIEWER  ").await.unwrap();
+        assert_eq!(found.unwrap().id, p.id);
+        assert!(find_by_name_ci(&db, "nope").await.unwrap().is_none());
+    }
+}

--- a/crates/pdo-daemon/src/event_log.rs
+++ b/crates/pdo-daemon/src/event_log.rs
@@ -1002,6 +1002,17 @@ pub struct RunState {
     /// and by the infra sessions (Pipeline Manager, merge resolver).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub harness: Option<String>,
+    /// The Run tier of the agentic-profile union (#563, ADR-0057), **frozen**
+    /// here from the `RunStarted` payload — same immutability as
+    /// [`RunState::harness`]: set once at create, never mutated (frozen for
+    /// resume, ADR-0057 ¶4). `None` ⇒ the Run named no choice (every historical
+    /// Run, and any Run created without one), so [`RunState::harness`] (the
+    /// legacy signal) still decides the Run tier. `Some(Profile | Custom)` wins
+    /// outright at this tier over `harness` — never merges — and also supplies
+    /// model/effort to infra sessions (#563 AC18, amending ADR-0046's
+    /// Run-only-harness rule for infra).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) agent_choice: Option<crate::agent_choice::AgentChoice>,
     /// The Run's `auto_fail` preference (ADR-0049), **frozen** here from the
     /// `RunStarted` payload — the **run** tier of
     /// [`crate::auto_fail::resolve_auto_fail`] (`node → Run → Projet →
@@ -1080,6 +1091,7 @@ impl RunState {
             source_branch: None,
             fork_sha: None,
             harness: None,
+            agent_choice: None,
             auto_fail: None,
             triggered_by: None,
             pipeline_id: None,
@@ -1684,6 +1696,18 @@ fn apply_run_event(state: &mut RunState, event: &Event) {
                 if let Some(h) = payload.get("harness").and_then(|v| v.as_str()) {
                     if !h.is_empty() {
                         state.harness = Some(h.to_string());
+                    }
+                }
+                // #563 (ADR-0057): the FROZEN Run `AgentChoice`, projected the same
+                // way as `harness` — the create chokepoint only writes this key for
+                // an explicit (non-`Inherit`) choice, so an absent key (every
+                // historical Run, every Run with no explicit choice) leaves `None`
+                // and the legacy `harness` above still decides the Run tier.
+                if let Some(v) = payload.get("agent_choice") {
+                    if let Ok(choice) =
+                        serde_json::from_value::<crate::agent_choice::AgentChoice>(v.clone())
+                    {
+                        state.agent_choice = Some(choice);
                     }
                 }
                 // ADR-0049: the Run's frozen `auto_fail` tier. Absent key ⇒ `None`

--- a/crates/pdo-daemon/src/graph_resolver.rs
+++ b/crates/pdo-daemon/src/graph_resolver.rs
@@ -431,6 +431,7 @@ mod tests {
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            agent_choice: None,
             auto_fail: None,
         }
     }
@@ -496,6 +497,7 @@ mod tests {
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            agent_choice: None,
             auto_fail: None,
         }
     }

--- a/crates/pdo-daemon/src/input_resolution.rs
+++ b/crates/pdo-daemon/src/input_resolution.rs
@@ -449,6 +449,7 @@ mod tests {
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            agent_choice: None,
             auto_fail: None,
         }
     }

--- a/crates/pdo-daemon/src/instance_config.rs
+++ b/crates/pdo-daemon/src/instance_config.rs
@@ -110,6 +110,16 @@ pub(crate) struct InstanceConfig {
     /// [`Self::autocomplete_turn_end`]: `NULL` makes the `stored → env → default`
     /// fall-through work; a stored `0` is a decision that beats the env.
     pub auto_fail: Option<i64>,
+    /// The Instance tier of the agentic-profile union (#563, ADR-0057) — the
+    /// **coarsest** tier `agent_choice::resolve` consults, just above the
+    /// reserved Default profile floor. `None` (unset) preserves the pre-#563
+    /// legacy precedence exactly: [`Self::default_harness`] /
+    /// [`Self::default_harness_model`] still apply. `Some(Profile | Custom)`
+    /// wins outright over them at this tier (never merges). Persisted as a
+    /// JSON object in a nullable TEXT column, same idiom as
+    /// [`Self::default_harness_model`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_choice: Option<crate::agent_choice::AgentChoice>,
     /// RFC3339-millis UTC timestamp of the last write (or the seed).
     pub updated_at: String,
 }
@@ -163,6 +173,13 @@ pub(crate) struct UpdateInstanceConfig {
     /// `1`, `Some(false)` stores `0`, `None` leaves it untouched. Same set-only,
     /// `0`-not-`NULL` discipline as [`Self::autocomplete_turn_end`].
     pub auto_fail: Option<bool>,
+    /// Set the Instance tier of the agentic-profile union (#563): `Some(None)`
+    /// clears it back to unset (legacy `default_harness`/`default_harness_model`
+    /// decide again); `Some(Some(choice))` sets it; `None` leaves it untouched.
+    /// Double-`Option`, mirroring [`crate::trigger_store::UpdateTrigger::harness`]
+    /// — this column, unlike the set-only numeric knobs, needs a genuine "clear"
+    /// path back to legacy precedence.
+    pub agent_choice: Option<Option<crate::agent_choice::AgentChoice>>,
 }
 
 impl UpdateInstanceConfig {
@@ -178,6 +195,7 @@ impl UpdateInstanceConfig {
             && self.default_harness.is_none()
             && self.default_harness_model.is_none()
             && self.auto_fail.is_none()
+            && self.agent_choice.is_none()
     }
 }
 
@@ -203,6 +221,7 @@ pub(crate) async fn init(db: &SqlitePool) -> Result<(), sqlx::Error> {
             default_harness_model TEXT,
             auto_fail          INTEGER,
             libassist_idle_ttl_secs INTEGER,
+            agent_choice       TEXT,
             updated_at         TEXT NOT NULL
         )",
     )
@@ -357,6 +376,22 @@ pub(crate) async fn init(db: &SqlitePool) -> Result<(), sqlx::Error> {
             .await?;
     }
 
+    // Additive migration for pre-#563 databases: the `agent_choice` column is
+    // absent on tables created before the agentic-profile union. Same guarded
+    // `ADD COLUMN` idiom — NULLABLE so an existing install falls through to the
+    // legacy `default_harness`/`default_harness_model` precedence unchanged.
+    let has_agent_choice = sqlx::query(
+        "SELECT 1 FROM pragma_table_info('instance_config') WHERE name = 'agent_choice'",
+    )
+    .fetch_optional(db)
+    .await?
+    .is_some();
+    if !has_agent_choice {
+        sqlx::query("ALTER TABLE instance_config ADD COLUMN agent_choice TEXT")
+            .execute(db)
+            .await?;
+    }
+
     Ok(())
 }
 
@@ -379,6 +414,11 @@ fn row_to_config(row: &sqlx::sqlite::SqliteRow) -> InstanceConfig {
             .and_then(|s| serde_json::from_str(&s).ok())
             .unwrap_or_default(),
         auto_fail: row.get("auto_fail"),
+        // #563: NULL / unparseable ⇒ `None` — the tier is simply transparent,
+        // never an error (mirrors `default_harness_model`'s degrade-to-empty).
+        agent_choice: row
+            .get::<Option<String>, _>("agent_choice")
+            .and_then(|s| serde_json::from_str(&s).ok()),
         updated_at: row.get("updated_at"),
     }
 }
@@ -439,6 +479,9 @@ pub(crate) async fn update(
     if edit.auto_fail.is_some() {
         sets.push("auto_fail = ?");
     }
+    if edit.agent_choice.is_some() {
+        sets.push("agent_choice = ?");
+    }
     // Always bump the write timestamp on a real edit.
     sets.push("updated_at = ?");
 
@@ -495,6 +538,11 @@ pub(crate) async fn update(
         // 0/1, never NULL: unchecking must persist a stored `0` that beats a
         // `PDO_AUTO_FAIL=1`, not fall through to it (ADR-0049).
         query = query.bind(if v { 1_i64 } else { 0_i64 });
+    }
+    if let Some(v) = edit.agent_choice {
+        // #563: `Some(None)` → SQL NULL (fall back to legacy `default_harness`/
+        // `default_harness_model`); `Some(Some(choice))` → the serialized JSON.
+        query = query.bind(v.map(|c| serde_json::to_string(&c).unwrap_or_default()));
     }
     query = query.bind(crate::event_log::now_iso());
     query.execute(db).await?;
@@ -756,6 +804,137 @@ mod tests {
         let cfg = get(&db).await.unwrap();
         assert_eq!(cfg.default_harness.as_deref(), Some("opencode"));
         assert_eq!(cfg.default_harness_model, map);
+    }
+
+    /// #563/ADR-0057: the Instance tier of `AgentChoice` — a fresh row carries
+    /// none, round-trips a `Profile` reference, then clears back to `None` via
+    /// the `Some(None)` double-Option idiom (mirrors `trigger_store::harness`).
+    #[tokio::test]
+    async fn agent_choice_round_trips_and_clears() {
+        let db = test_db().await;
+        assert_eq!(get(&db).await.unwrap().agent_choice, None);
+
+        let choice = crate::agent_choice::AgentChoice::Profile {
+            profile_id: "reviewer".to_string(),
+        };
+        let updated = update(
+            &db,
+            UpdateInstanceConfig {
+                agent_choice: Some(Some(choice.clone())),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(updated.agent_choice, Some(choice.clone()));
+        assert_eq!(get(&db).await.unwrap().agent_choice, Some(choice));
+
+        // `Some(None)` clears it back to unset; `None` (the default) leaves it be.
+        update(
+            &db,
+            UpdateInstanceConfig {
+                agent_choice: Some(None),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(get(&db).await.unwrap().agent_choice, None);
+    }
+
+    /// #563: a `Custom` combination round-trips model/effort too, and an
+    /// `agent_choice`-only edit does not disturb `default_harness`.
+    #[tokio::test]
+    async fn agent_choice_custom_round_trips_alongside_legacy_default_harness() {
+        let db = test_db().await;
+        update(
+            &db,
+            UpdateInstanceConfig {
+                default_harness: Some("claude".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        let choice = crate::agent_choice::AgentChoice::Custom {
+            harness: "opencode".to_string(),
+            model: Some("gpt-5".to_string()),
+            effort: Some("high".to_string()),
+        };
+        update(
+            &db,
+            UpdateInstanceConfig {
+                agent_choice: Some(Some(choice.clone())),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        let cfg = get(&db).await.unwrap();
+        assert_eq!(cfg.agent_choice, Some(choice));
+        assert_eq!(
+            cfg.default_harness.as_deref(),
+            Some("claude"),
+            "an agent_choice-only edit must not touch the legacy field"
+        );
+    }
+
+    #[tokio::test]
+    async fn init_migrates_pre_agent_choice_schema() {
+        // #563: a table created before the `agent_choice` column gains it on
+        // init, idempotently, without clobbering a pre-existing knob — same
+        // guarded `ADD COLUMN` idiom as `default_harness` above.
+        let db = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        sqlx::query(
+            "CREATE TABLE instance_config (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                session_cap INTEGER,
+                reaper_ttl_secs INTEGER,
+                guard_timeout_secs INTEGER,
+                default_model TEXT,
+                triggers_paused INTEGER,
+                default_sandbox TEXT,
+                autocomplete_turn_end INTEGER,
+                default_auto_name INTEGER,
+                default_harness TEXT,
+                default_harness_model TEXT,
+                auto_fail INTEGER,
+                libassist_idle_ttl_secs INTEGER,
+                updated_at TEXT NOT NULL
+            )",
+        )
+        .execute(&db)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO instance_config (id, session_cap, updated_at) VALUES (1, 7, 'seed')",
+        )
+        .execute(&db)
+        .await
+        .unwrap();
+
+        init(&db).await.unwrap();
+        init(&db).await.unwrap();
+
+        let cfg = get(&db).await.unwrap();
+        assert_eq!(cfg.session_cap, Some(7), "pre-existing knob survives");
+        assert_eq!(cfg.agent_choice, None, "new column defaults to NULL");
+
+        let choice = crate::agent_choice::AgentChoice::Profile {
+            profile_id: "reviewer".to_string(),
+        };
+        update(
+            &db,
+            UpdateInstanceConfig {
+                agent_choice: Some(Some(choice.clone())),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(get(&db).await.unwrap().agent_choice, Some(choice));
     }
 
     #[tokio::test]

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -4,6 +4,8 @@
 #![warn(unreachable_pub)]
 
 pub mod admission;
+mod agent_choice;
+mod agent_profile;
 mod audit_log;
 mod auto_fail;
 mod blackboard;
@@ -572,6 +574,16 @@ struct CreateRunRequest {
     /// (a Run has a single origin), so "Run now" and a cron tick produce the same one.
     #[serde(default)]
     harness: Option<String>,
+    /// The Run tier of the agentic-profile union (#563, ADR-0057) — the
+    /// counterpart of [`Self::harness`], but as the full exclusive union
+    /// (`Inherit`/`Profile`/`Custom`), atomically supplying harness, model and
+    /// effort. `None`/`Inherit` ⇒ the Run states no choice, so `harness` above
+    /// (and the tiers below it) still decide — byte-identical to the pre-#563
+    /// shape. `Some(Profile | Custom)` wins outright at this tier (never
+    /// merges with `harness`) and is frozen into `RunStarted`, same immutability
+    /// discipline as `harness`. A Trigger fire folds its stored choice in here.
+    #[serde(default)]
+    agent_choice: Option<crate::agent_choice::AgentChoice>,
     /// Whether the manager auto-names this Run (#338). `Option`, NOT `bool`:
     /// `#[serde(default)]` → `None` is an **omitted** field, which resolves
     /// back-compatibly by the presence of `name` (a supplied `name` with no flag
@@ -617,6 +629,7 @@ const CREATE_RUN_FIELDS: &[&str] = &[
     "triggered_by",
     "sandbox",
     "harness",
+    "agent_choice",
     "auto_name",
     "auto_fail",
 ];
@@ -765,6 +778,12 @@ struct PatchProjectRequest {
     name: Option<String>,
     #[serde(default, deserialize_with = "deserialize_double_option")]
     harness: Option<Option<String>>,
+    /// The Projet's `AgentChoice` (#563, ADR-0057), same double-`Option` shape as
+    /// `harness`: **absent** leaves it untouched, `null` clears it (falls through to
+    /// the legacy `harness` field, itself falling through to the instance tier), an
+    /// object sets it.
+    #[serde(default, deserialize_with = "deserialize_double_option")]
+    agent_choice: Option<Option<crate::agent_choice::AgentChoice>>,
     /// The Projet's `auto_fail` (ADR-0049) — same double-`Option` shape as
     /// `harness`: **absent** leaves it untouched, `null` clears it (states no
     /// preference), a bool sets it.
@@ -2154,6 +2173,7 @@ impl DaemonHandle {
                 max_concurrent: None,
                 sandbox: None,
                 harness: None,
+                agent_choice: None,
                 auto_name: true,
                 next_fire_at: Some("2030-01-01T00:00:00.000Z".to_string()),
             },
@@ -3284,6 +3304,12 @@ struct CreateTriggerRequest {
     /// harness (there is no separate Trigger tier). Free text — no validation (ADR-0045).
     #[serde(default)]
     harness: Option<String>,
+    /// Per-Trigger `AgentChoice` (#563, ADR-0057): `Inherit`/absent falls through to
+    /// the legacy `harness` field above (itself falling through to the Run/Project/
+    /// Instance tiers); `Profile`/`Custom` is folded into the fired Run's explicit
+    /// tier at fire time, same posture as `harness`.
+    #[serde(default)]
+    agent_choice: Option<crate::agent_choice::AgentChoice>,
     /// Whether Runs this Trigger fires are auto-named (#338). Seeded from the instance
     /// default in the create modal and frozen on the row; `#[serde(default)]` → `true`
     /// so an older client that omits the field keeps the pre-#338 auto-naming behaviour.
@@ -3620,6 +3646,11 @@ async fn create_trigger(
         // #551: same normalisation for the harness — a blank selector value inherits the
         // instance default at fire time rather than persisting as a harness named "".
         harness: req.harness.filter(|s| !s.trim().is_empty()),
+        // #563: fold the request's `AgentChoice` straight through — `None`/`Inherit`/
+        // a blank `Custom`/`Profile` payload are all already transparent inside
+        // `agent_choice::resolve`, so no extra normalisation is needed here (unlike
+        // the flat-string `harness` field above).
+        agent_choice: req.agent_choice,
         // #338: freeze the auto-naming choice on the row (seeded from the instance
         // default in the modal). No re-resolution at fire time — the runtime never
         // decides autonomy (ADR-0012 frontier).
@@ -3823,6 +3854,12 @@ struct PatchTriggerRequest {
     /// UI reset a Trigger to "use the instance default".
     #[serde(default, deserialize_with = "deserialize_double_option")]
     harness: Option<Option<String>>,
+    /// Per-Trigger `AgentChoice` (#563), double-wrapped like `harness`: absent = leave,
+    /// present `null` = clear back to inheriting the legacy `harness` field, an object
+    /// = set. The custom deserializer makes present-`null` → `Some(None)` reachable
+    /// from JSON.
+    #[serde(default, deserialize_with = "deserialize_double_option")]
+    agent_choice: Option<Option<crate::agent_choice::AgentChoice>>,
     /// Auto-naming toggle (#338), a FLAT `Option<bool>` like `enabled` — NOT
     /// double-wrapped like `sandbox`/`max_concurrent`. There is no "inherit" state to
     /// clear back to: a Trigger's autonomy is a plain on/off. `None` leaves it,
@@ -4080,6 +4117,10 @@ async fn patch_trigger(
         harness: req
             .harness
             .map(|inner| inner.filter(|s| !s.trim().is_empty())),
+        // #563: `Some(Some(choice))` sets, `Some(None)` clears back to inheriting the
+        // legacy `harness` field, `None` leaves it. Passed straight through, matching
+        // the `agent_choice::resolve` transparency of `None`/`Inherit`/blank payloads.
+        agent_choice: req.agent_choice,
         // #338: flat toggle — `Some(v)` sets, `None` leaves. No clear state.
         auto_name: req.auto_name,
         next_fire_at,
@@ -4444,6 +4485,20 @@ fn build_router(state: Arc<AppState>) -> Router {
         // gesture (`/triggers/{id}/fire`, `/triggers/pause`, `/pipelines/{id}/promote`).
         // The ONLY route in the crate that reaches the network.
         .route("/settings/cost-prices/sync", post(sync_cost_prices))
+        .route(
+            "/settings/agent-profiles",
+            get(list_agent_profiles).post(create_agent_profile),
+        )
+        .route(
+            "/settings/agent-profiles/{id}",
+            get(get_agent_profile)
+                .put(update_agent_profile)
+                .delete(delete_agent_profile),
+        )
+        .route(
+            "/settings/agent-profiles/{id}/referents",
+            get(get_agent_profile_referents),
+        )
         .route("/settings/sandbox-profiles", get(list_sandbox_profiles))
         .route(
             "/settings/sandbox-profiles/{name}",
@@ -4603,6 +4658,15 @@ async fn patch_project(
         let harness = harness.as_deref();
         if let Err(e) = project_store::set_harness(&state.db, &project_id, harness).await {
             error!("failed to set harness on project {project_id}: {e}");
+            return project_list_error();
+        }
+    }
+    // Same double-`Option` semantics as `harness` (#563): `Some(None)` clears the
+    // AgentChoice (falling through to the legacy `harness` field), `Some(Some(c))` sets it.
+    if let Some(agent_choice) = req.agent_choice {
+        if let Err(e) = project_store::set_agent_choice(&state.db, &project_id, agent_choice).await
+        {
+            error!("failed to set agent_choice on project {project_id}: {e}");
             return project_list_error();
         }
     }
@@ -4817,6 +4881,13 @@ async fn init_db(db: &sqlx::SqlitePool) -> Result<()> {
     project_store::init(db)
         .await
         .context("failed to create project tables")?;
+
+    // #563 / ADR-0057: agent profiles — instance-scoped, named harness+model+effort
+    // combinations. Unlike `project_store`, this table IS seeded: the reserved
+    // `Default` profile must exist on every instance, immediately (#563 AC10).
+    agent_profile::init(db)
+        .await
+        .context("failed to create agent_profiles table")?;
 
     Ok(())
 }
@@ -5608,6 +5679,10 @@ async fn fire_one_trigger(
                 // route through here) freeze the SAME harness. A blank/absent stored
                 // value defers to the instance default. No validation (ADR-0045).
                 harness: trigger.harness.clone(),
+                // #563: fold the Trigger's stored `AgentChoice` into the create
+                // request's explicit Run tier, same posture as `harness` above —
+                // a cron tick and a "Run now" freeze the SAME choice.
+                agent_choice: trigger.agent_choice.clone(),
                 // #338: pass the Trigger's frozen auto-naming choice as the explicit
                 // tier. `Some(b)` wins the chokepoint resolution unconditionally, so a
                 // fire with `auto_name=false` keeps a stable per-id name and the manager
@@ -6166,6 +6241,11 @@ const KNOWN_NODE_KEYS: &[&str] = &[
     // pasted flat pair is folded into `harnesses.claude` by `normalize_node_value`).
     "pin_harness",
     "harnesses",
+    // #563/ADR-0057: the node's agent-profile choice (Inherit/Profile/Custom).
+    // Not yet surfaced in `LibraryEntry` (a #345-style follow-up), but a pasted
+    // node carrying it must not be told it is "unknown field ... (ignored)"
+    // when parse_node_spec silently keeps it off the library entry.
+    "agent_choice",
     // Accepted-and-dropped, not a semantic loss → no warning.
     "id",
     "view",
@@ -6270,6 +6350,15 @@ fn parse_node_spec(yaml: &str) -> Result<serde_json::Value, String> {
         .get("harnesses")
         .map(yaml_value_to_json)
         .unwrap_or(serde_json::Value::Null);
+    // #563/ADR-0057: the node's agent-profile choice rides through verbatim (as
+    // JSON) — same "carried, not interpreted" posture as `harnesses` above. It
+    // is not (yet) a `LibraryEntry` field, so it must be read off the raw value
+    // here or it would silently vanish through the `LibraryEntry` deserialize
+    // below.
+    let agent_choice = value
+        .get("agent_choice")
+        .map(yaml_value_to_json)
+        .unwrap_or(serde_json::Value::Null);
 
     // 8. Deserialize the (normalized) map into a LibraryEntry. `prompt` defaults
     //    to empty (a structural node carries none); unknown fields are ignored.
@@ -6289,6 +6378,8 @@ fn parse_node_spec(yaml: &str) -> Result<serde_json::Value, String> {
             // #550: the harness axis, for the pin selector + per-harness UI.
             "pin_harness": pin_harness,
             "harnesses": harnesses,
+            // #563: the node's agent-profile choice, carried verbatim.
+            "agent_choice": agent_choice,
             "max_iter": entry.max_iter,
             "branches": entry.branches,
         },
@@ -7548,6 +7639,7 @@ async fn parse_multipart_create_run(
     // field is absent/blank — the chokepoint then freezes nothing and the Run resolves
     // through the instance default and the floor.
     let mut harness: Option<String> = None;
+    let mut agent_choice: Option<crate::agent_choice::AgentChoice> = None;
     // #338: an explicit auto-naming choice may ride the multipart (browser) create
     // when images are attached, so an unchecked "Auto-generated" box is honoured on
     // that path too. `None` when the field is absent — the chokepoint then resolves
@@ -7661,6 +7753,18 @@ async fn parse_multipart_create_run(
                     harness = Some(v);
                 }
             }
+            "agent_choice" => {
+                let value = field
+                    .text()
+                    .await
+                    .map_err(|e| format!("bad field agent_choice: {e}"))?;
+                if !value.trim().is_empty() {
+                    agent_choice = Some(
+                        serde_json::from_str(&value)
+                            .map_err(|e| format!("invalid agent_choice JSON: {e}"))?,
+                    );
+                }
+            }
             "auto_name" => {
                 // #338: an explicit flag off the multipart form. Reuses the shared
                 // boolean parser; an unrecognised token leaves `None` (defer to the
@@ -7727,6 +7831,7 @@ async fn parse_multipart_create_run(
         sandbox,
         // #551: the explicit harness threaded off the multipart form.
         harness,
+        agent_choice,
         // #338: the explicit auto-naming choice threaded off the multipart form.
         auto_name,
         // ADR-0049: the explicit auto_fail choice threaded off the multipart form.
@@ -8243,6 +8348,28 @@ async fn create_run_inner(
     {
         run_payload["harness"] = serde_json::json!(h);
     }
+    // #563 (ADR-0057): FREEZE the Run's `AgentChoice` into `RunStarted`, same
+    // immutability posture as `harness` above — resolved and frozen ATOMICALLY at
+    // spawn, never re-decided by a later profile edit or resume (ADR-0057 ¶4).
+    // Written ONLY for an explicit (non-`Inherit`) choice with a non-blank payload,
+    // so a Run that states none keeps its payload byte-identical to the pre-#563
+    // shape (absent key → `None` → `harness` above still decides the Run tier).
+    let explicit_agent_choice = match &req.agent_choice {
+        Some(crate::agent_choice::AgentChoice::Custom { harness, .. })
+            if !harness.trim().is_empty() =>
+        {
+            req.agent_choice.clone()
+        }
+        Some(crate::agent_choice::AgentChoice::Profile { profile_id })
+            if !profile_id.trim().is_empty() =>
+        {
+            req.agent_choice.clone()
+        }
+        _ => None,
+    };
+    if let Some(choice) = explicit_agent_choice {
+        run_payload["agent_choice"] = serde_json::to_value(choice).unwrap_or_default();
+    }
     // ADR-0049: FREEZE the Run's `auto_fail` choice into `RunStarted`, same
     // immutability posture as `harness`. Written ONLY when the Run states a
     // preference, so a Run that states none keeps its payload byte-identical
@@ -8657,12 +8784,22 @@ async fn spawn_manager_session(
     // falls back to `claude` with a warning rather than failing the whole Run here:
     // the first NODE spawn is where an unknown harness fails fast (ADR-0037), and the
     // manager is a best-effort assist that must not itself wedge the Run.
-    let run_harness = reload_run_state(state, run_id)
+    let run_state = reload_run_state(state, run_id)
         .await
-        .and_then(|(_, s)| s.harness);
-    let default_harness = stored_default_harness(&state.db).await;
-    let manager_harness_name =
-        harness_resolver::resolve_infra_harness(run_harness.as_deref(), default_harness.as_deref());
+        .map(|(_, state)| state);
+    let config = instance_config::get(&state.db).await.ok();
+    let profiles = agent_profile::snapshot(&state.db).await.unwrap_or_default();
+    let manager_agent = agent_choice::resolve_infra(
+        run_state.as_ref().and_then(|run| run.agent_choice.as_ref()),
+        run_state.as_ref().and_then(|run| run.harness.as_deref()),
+        config.as_ref().and_then(|cfg| cfg.agent_choice.as_ref()),
+        config
+            .as_ref()
+            .and_then(|cfg| cfg.default_harness.as_deref()),
+        &profiles,
+        agent_profile::DEFAULT_PROFILE_ID,
+    );
+    let manager_harness_name = manager_agent.combo.harness.clone();
     // #614 (correctif 3): resolve against the DISK TIER, so "this Run runs on X" is
     // true even when X is a user-declared harness — the manager follows the Run's
     // frozen harness through the same registry the node spawns resolve against.
@@ -8695,8 +8832,8 @@ async fn spawn_manager_session(
         // transcript, which shares this cwd, from being read as a node's.
         tmux_session_manager::SessionTail::Agent {
             harness: &manager_harness,
-            model: None,
-            effort: None,
+            model: manager_agent.combo.model.as_deref(),
+            effort: manager_agent.combo.effort.as_deref(),
             session_id: None,
         },
         sandbox_wrap.as_ref(),
@@ -9343,6 +9480,7 @@ async fn build_settings_view(state: &AppState) -> Result<serde_json::Value, sqlx
             "effective": dhm_effective,
             "stored": dhm_stored,
         },
+        "agent_choice": cfg.agent_choice,
         // #553/ADR-0045: the disk descriptor tier — which harnesses resolve (floor
         // ∪ disk), the file path, and any inert/refused descriptor named. The
         // settings surface is where a broken descriptor is ALWAYS said.
@@ -9860,6 +9998,209 @@ async fn put_settings(
         )
             .into_response(),
     }
+}
+
+// --- Agent profiles (#563, ADR-0057) ---------------------------------------
+
+#[derive(Deserialize)]
+struct WriteAgentProfileRequest {
+    name: String,
+    harness: String,
+    #[serde(default)]
+    model: Option<String>,
+    #[serde(default)]
+    effort: Option<String>,
+}
+
+fn agent_profile_error_response(error: agent_profile::AgentProfileError) -> Response {
+    let status = match error {
+        agent_profile::AgentProfileError::NotFound => StatusCode::NOT_FOUND,
+        agent_profile::AgentProfileError::DuplicateName { .. } => StatusCode::CONFLICT,
+        agent_profile::AgentProfileError::EmptyName
+        | agent_profile::AgentProfileError::EmptyHarness
+        | agent_profile::AgentProfileError::DefaultUndeletable => StatusCode::BAD_REQUEST,
+        agent_profile::AgentProfileError::Storage(_) => StatusCode::INTERNAL_SERVER_ERROR,
+    };
+    (
+        status,
+        Json(serde_json::json!({ "error": error.to_string() })),
+    )
+        .into_response()
+}
+
+async fn list_agent_profiles(State(state): State<Arc<AppState>>) -> Response {
+    match agent_profile::list(&state.db).await {
+        Ok(profiles) => Json(serde_json::json!({ "profiles": profiles })).into_response(),
+        Err(error) => {
+            error!("failed to list agent profiles: {error}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": error.to_string() })),
+            )
+                .into_response()
+        }
+    }
+}
+
+async fn get_agent_profile(
+    State(state): State<Arc<AppState>>,
+    AxumPath(id): AxumPath<String>,
+) -> Response {
+    match agent_profile::get(&state.db, &id).await {
+        Ok(Some(profile)) => Json(profile).into_response(),
+        Ok(None) => agent_profile_error_response(agent_profile::AgentProfileError::NotFound),
+        Err(error) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({ "error": error.to_string() })),
+        )
+            .into_response(),
+    }
+}
+
+async fn create_agent_profile(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<WriteAgentProfileRequest>,
+) -> Response {
+    match agent_profile::create(
+        &state.db,
+        &req.name,
+        &req.harness,
+        req.model.as_deref(),
+        req.effort.as_deref(),
+    )
+    .await
+    {
+        Ok(profile) => (StatusCode::CREATED, Json(profile)).into_response(),
+        Err(error) => agent_profile_error_response(error),
+    }
+}
+
+async fn update_agent_profile(
+    State(state): State<Arc<AppState>>,
+    AxumPath(id): AxumPath<String>,
+    Json(req): Json<WriteAgentProfileRequest>,
+) -> Response {
+    match agent_profile::update(
+        &state.db,
+        &id,
+        &req.name,
+        &req.harness,
+        req.model.as_deref(),
+        req.effort.as_deref(),
+    )
+    .await
+    {
+        Ok(profile) => Json(profile).into_response(),
+        Err(error) => agent_profile_error_response(error),
+    }
+}
+
+async fn delete_agent_profile(
+    State(state): State<Arc<AppState>>,
+    AxumPath(id): AxumPath<String>,
+) -> Response {
+    match agent_profile::delete(&state.db, &id).await {
+        Ok(true) => StatusCode::NO_CONTENT.into_response(),
+        Ok(false) => agent_profile_error_response(agent_profile::AgentProfileError::NotFound),
+        Err(error) => agent_profile_error_response(error),
+    }
+}
+
+async fn get_agent_profile_referents(
+    State(state): State<Arc<AppState>>,
+    AxumPath(id): AxumPath<String>,
+) -> Response {
+    if !matches!(agent_profile::get(&state.db, &id).await, Ok(Some(_))) {
+        return agent_profile_error_response(agent_profile::AgentProfileError::NotFound);
+    }
+
+    let instance = instance_config::get(&state.db)
+        .await
+        .ok()
+        .and_then(|config| config.agent_choice)
+        .is_some_and(|choice| {
+            matches!(choice, agent_choice::AgentChoice::Profile { profile_id } if profile_id == id)
+        });
+
+    let projects = project_store::list(&state.db)
+        .await
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|project| {
+            matches!(
+                project.agent_choice.as_ref(),
+                Some(agent_choice::AgentChoice::Profile { profile_id }) if profile_id == &id
+            )
+        })
+        .map(|project| serde_json::json!({ "id": project.id, "name": project.name }))
+        .collect::<Vec<_>>();
+
+    let triggers = trigger_store::list(&state.db)
+        .await
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|trigger| {
+            matches!(
+                trigger.agent_choice.as_ref(),
+                Some(agent_choice::AgentChoice::Profile { profile_id }) if profile_id == &id
+            )
+        })
+        .map(|trigger| {
+            serde_json::json!({
+                "id": trigger.id,
+                "name": trigger.name,
+                "pipeline_id": trigger.pipeline_id
+            })
+        })
+        .collect::<Vec<_>>();
+
+    let mut pipeline_entries = scan_pipeline_dir(&state.repo_root.join(".pdo/pipelines"), "repo");
+    if let Some(home) = dirs_next_home() {
+        pipeline_entries.extend(scan_pipeline_dir(&home.join(".pdo/pipelines"), "user"));
+    }
+    if let Some(directory) = library_store::pipelines::user_pipelines_dir() {
+        pipeline_entries.extend(scan_pipeline_dir(&directory, "library"));
+    }
+    let pipelines = pipeline_entries
+        .into_iter()
+        .flat_map(|entry| {
+            let Ok(yaml) = std::fs::read_to_string(&entry.path) else {
+                return Vec::new();
+            };
+            let Ok(parsed) = pipeline::parse_pipeline(&yaml) else {
+                return Vec::new();
+            };
+            parsed
+                .pipeline
+                .nodes
+                .into_iter()
+                .filter(|node| {
+                    matches!(
+                        node.agent_choice.as_ref(),
+                        Some(agent_choice::AgentChoice::Profile { profile_id }) if profile_id == &id
+                    )
+                })
+                .map(|node| {
+                    serde_json::json!({
+                        "id": entry.id,
+                        "name": entry.name,
+                        "node_id": node.id,
+                        "scope": entry.scope
+                    })
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+
+    Json(serde_json::json!({
+        "profile_id": id,
+        "instance": instance,
+        "projects": projects,
+        "triggers": triggers,
+        "pipelines": pipelines,
+        "runs": []
+    }))
+    .into_response()
 }
 
 // --- Staging profiles (#432, ADR-0031 §2-§7) --------------------------------
@@ -12383,9 +12724,9 @@ async fn spawn_merge_resolver(
     // AND on the harness OF THE RUN. Project both from the SAME (immutable) reload —
     // the mode defaults to `off`, the harness to `None`, if the state can't be
     // reloaded.
-    let (sandbox_mode, run_harness) = reload_run_state(state, run_id)
+    let (sandbox_mode, run_harness, run_agent_choice) = reload_run_state(state, run_id)
         .await
-        .map(|(_, s)| (s.sandbox, s.harness))
+        .map(|(_, s)| (s.sandbox, s.harness, s.agent_choice))
         .unwrap_or_default();
 
     let resolver_started = event_log::Event {
@@ -12414,9 +12755,19 @@ async fn spawn_merge_resolver(
     // the manager — `Run → instance → floor`, no node tier, no model/effort. Unknown
     // name (unvalidated Run choice, ADR-0045) falls back to `claude` with a warning:
     // the resolver is dead in production since ADR-0006, so this is defence in depth.
-    let default_harness = stored_default_harness(&state.db).await;
-    let resolver_harness_name =
-        harness_resolver::resolve_infra_harness(run_harness.as_deref(), default_harness.as_deref());
+    let config = instance_config::get(&state.db).await.ok();
+    let profiles = agent_profile::snapshot(&state.db).await.unwrap_or_default();
+    let resolver_agent = agent_choice::resolve_infra(
+        run_agent_choice.as_ref(),
+        run_harness.as_deref(),
+        config.as_ref().and_then(|cfg| cfg.agent_choice.as_ref()),
+        config
+            .as_ref()
+            .and_then(|cfg| cfg.default_harness.as_deref()),
+        &profiles,
+        agent_profile::DEFAULT_PROFILE_ID,
+    );
+    let resolver_harness_name = resolver_agent.combo.harness.clone();
     // #614 (correctif 3): resolve against the DISK TIER, like the manager.
     let resolver_home_root = sandbox_run::sandbox_home_roots(state)
         .map(|(home, _)| home)
@@ -12446,8 +12797,8 @@ async fn spawn_merge_resolver(
         // `spawn_node` and DOES carry an effort and a pinned id.
         tmux_session_manager::SessionTail::Agent {
             harness: &resolver_harness,
-            model: None,
-            effort: None,
+            model: resolver_agent.combo.model.as_deref(),
+            effort: resolver_agent.combo.effort.as_deref(),
             session_id: None,
         },
         sandbox_wrap.as_ref(),
@@ -22698,6 +23049,7 @@ mod tests {
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            agent_choice: None,
             auto_fail: None,
         }
     }
@@ -31844,6 +32196,7 @@ edges: []
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            agent_choice: None,
             auto_fail: None,
         };
         let pipeline = pipeline::PipelineDef {
@@ -34090,6 +34443,7 @@ edges:
             "triggered_by": null,
             "sandbox": null,
             "harness": null,
+            "agent_choice": null,
             "auto_name": null,
             "auto_fail": null,
         });

--- a/crates/pdo-daemon/src/library_store.rs
+++ b/crates/pdo-daemon/src/library_store.rs
@@ -1074,6 +1074,7 @@ mod tests {
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            agent_choice: None,
             auto_fail: None,
         }
     }

--- a/crates/pdo-daemon/src/loop_region.rs
+++ b/crates/pdo-daemon/src/loop_region.rs
@@ -584,6 +584,7 @@ mod tests {
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            agent_choice: None,
             auto_fail: None,
         }
     }

--- a/crates/pdo-daemon/src/mutation_validator.rs
+++ b/crates/pdo-daemon/src/mutation_validator.rs
@@ -217,6 +217,7 @@ mod tests {
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            agent_choice: None,
             auto_fail: None,
         }
     }
@@ -236,6 +237,7 @@ mod tests {
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            agent_choice: None,
             auto_fail: None,
         }
     }

--- a/crates/pdo-daemon/src/node_io_resolver.rs
+++ b/crates/pdo-daemon/src/node_io_resolver.rs
@@ -361,6 +361,7 @@ mod tests {
                     over: None,
                     pin_harness: None,
                     harnesses: Default::default(),
+                    agent_choice: None,
                     auto_fail: None,
                 },
                 NodeDef {
@@ -395,6 +396,7 @@ mod tests {
                     over: None,
                     pin_harness: None,
                     harnesses: Default::default(),
+                    agent_choice: None,
                     auto_fail: None,
                 },
             ],
@@ -552,6 +554,7 @@ mod tests {
                     over: None,
                     pin_harness: None,
                     harnesses: Default::default(),
+                    agent_choice: None,
                     auto_fail: None,
                 },
                 NodeDef {
@@ -586,6 +589,7 @@ mod tests {
                     over: None,
                     pin_harness: None,
                     harnesses: Default::default(),
+                    agent_choice: None,
                     auto_fail: None,
                 },
             ],
@@ -748,6 +752,7 @@ mod tests {
                     over: None,
                     pin_harness: None,
                     harnesses: Default::default(),
+                    agent_choice: None,
                     auto_fail: None,
                 },
                 NodeDef {
@@ -772,6 +777,7 @@ mod tests {
                     over: None,
                     pin_harness: None,
                     harnesses: Default::default(),
+                    agent_choice: None,
                     auto_fail: None,
                 },
                 NodeDef {
@@ -796,6 +802,7 @@ mod tests {
                     over: None,
                     pin_harness: None,
                     harnesses: Default::default(),
+                    agent_choice: None,
                     auto_fail: None,
                 },
             ],
@@ -888,6 +895,7 @@ mod tests {
                     over: None,
                     pin_harness: None,
                     harnesses: Default::default(),
+                    agent_choice: None,
                     auto_fail: None,
                 },
                 NodeDef {
@@ -903,6 +911,7 @@ mod tests {
                     over: None,
                     pin_harness: None,
                     harnesses: Default::default(),
+                    agent_choice: None,
                     auto_fail: None,
                 },
             ],
@@ -974,6 +983,7 @@ mod tests {
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            agent_choice: None,
             auto_fail: None,
         };
         let mk_edge = |src: &str| EdgeDef {
@@ -1058,6 +1068,7 @@ mod tests {
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            agent_choice: None,
             auto_fail: None,
         };
         let mk_edge = |src: &str, port: &str| EdgeDef {
@@ -1145,6 +1156,7 @@ mod tests {
                 over: None,
                 pin_harness: None,
                 harnesses: Default::default(),
+                agent_choice: None,
                 auto_fail: None,
             }],
             edges: Vec::new(),

--- a/crates/pdo-daemon/src/node_primitives.rs
+++ b/crates/pdo-daemon/src/node_primitives.rs
@@ -970,6 +970,7 @@ mod tests {
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            agent_choice: None,
             auto_fail: None,
         }
     }
@@ -1007,6 +1008,7 @@ mod tests {
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            agent_choice: None,
             auto_fail: None,
         }
     }

--- a/crates/pdo-daemon/src/node_spawn.rs
+++ b/crates/pdo-daemon/src/node_spawn.rs
@@ -21,11 +21,11 @@ use crate::worktree_ops::{
     ensure_sub_worktree, reap_orphan_sub_worktree, sub_worktree_branch, sub_worktree_path,
 };
 use crate::{
-    admission, append_event_with, count_global_live_sessions_excluding, event_log,
-    harness_registry, harness_resolver, input_resolution, merge_action, panic_payload_message,
-    pipeline, prompt_augmenter, reload_run_state_with, stored_autocomplete_turn_end,
-    stored_default_harness, stored_default_harness_models, stored_session_cap,
-    tmux_session_manager, transition_guard, AppState,
+    admission, agent_choice, agent_profile, append_event_with,
+    count_global_live_sessions_excluding, event_log, harness_registry, input_resolution,
+    merge_action, panic_payload_message, pipeline, prompt_augmenter, reload_run_state_with,
+    stored_autocomplete_turn_end, stored_default_harness, stored_default_harness_models,
+    stored_session_cap, tmux_session_manager, transition_guard, AppState,
 };
 
 pub(crate) struct SpawnContext<'a> {
@@ -136,6 +136,35 @@ fn warn_turn_end_unsupported_once(run_id: &str, harness: &str) {
     let said = guard.get_or_insert_with(HashSet::new);
     if said.insert((run_id.to_string(), harness.to_string())) {
         warn!("run {run_id}: {note}");
+    }
+}
+
+/// #563 (AC13/AC14): say ONCE per `(run, tier, profile_id)` that a tier named a
+/// `Profile` reference absent from the atomic snapshot — the walk warned and
+/// behaved as `Inherit` for that tier rather than failing the spawn. Deduped the
+/// same way as [`warn_missing_staging_floor_once`] so a busy scheduler replaying
+/// the same stale reference doesn't spam the log every retry.
+fn warn_missing_agent_profile_once(
+    run_id: &str,
+    warning: &crate::agent_choice::MissingProfileWarning,
+) {
+    use std::collections::HashSet;
+    use std::sync::Mutex;
+    static SAID: Mutex<Option<HashSet<(String, String, String)>>> = Mutex::new(None);
+
+    let mut guard = SAID.lock().unwrap_or_else(|e| e.into_inner());
+    let said = guard.get_or_insert_with(HashSet::new);
+    let key = (
+        run_id.to_string(),
+        format!("{:?}", warning.tier),
+        warning.profile_id.clone(),
+    );
+    if said.insert(key) {
+        warn!(
+            "run {run_id}: agent profile '{}' referenced at tier {:?} no longer exists — \
+             falling through as if that tier stated no choice",
+            warning.profile_id, warning.tier
+        );
     }
 }
 
@@ -418,22 +447,55 @@ pub(crate) async fn spawn_node(
                     None
                 }
             };
-        let tiers = harness_resolver::HarnessTiers {
+        // #563/ADR-0057: the Projet's `AgentChoice`, read alongside its legacy
+        // `harness` above — same primary-repo key, same "a DB error degrades the
+        // tier to transparent" posture.
+        let project_choice =
+            match crate::project_store::agent_choice_for_path(deps.db, &primary_repo).await {
+                Ok(c) => c,
+                Err(e) => {
+                    warn!("project agent_choice lookup failed for {primary_repo}: {e}");
+                    None
+                }
+            };
+        // #563: the Instance tier's `AgentChoice`, from a fresh read alongside the
+        // legacy `default_harness`/`default_models` tiers (`stored_default_*` above
+        // already call `instance_config::get` internally; this is a second fresh
+        // read rather than plumbing the whole config through those two helpers — a
+        // DB error degrades the tier to transparent, same posture as every other
+        // tier here).
+        let instance_choice = crate::instance_config::get(deps.db)
+            .await
+            .ok()
+            .and_then(|c| c.agent_choice);
+        // #563: the atomic profile snapshot — taken ONCE per spawn (ADR-0057 ¶4),
+        // so every `Profile` reference this resolution touches (node/run/project/
+        // instance) resolves against the exact same point-in-time read. A DB error
+        // degrades to an empty snapshot: `agent_choice::resolve` still falls through
+        // to its defensive `claude` floor rather than failing the spawn.
+        let profiles = agent_profile::snapshot(deps.db).await.unwrap_or_default();
+        let tiers = agent_choice::Tiers {
+            node_choice: node.agent_choice.as_ref(),
             node_pin: node.pin_harness.as_deref(),
+            node_harnesses: Some(&node.harnesses),
             // #551: the Run tier — the harness frozen in this Run's `RunStarted`
             // (`projected` is the fresh projection loaded at the head of this spawn).
             // A pinned node still ignores it; a free node follows it (ADR-0046).
-            run: projected.and_then(|s| s.harness.as_deref()),
+            run_choice: projected.and_then(|s| s.agent_choice.as_ref()),
+            run_harness: projected.and_then(|s| s.harness.as_deref()),
             // #552: the Projet tier — resolved just above from this Run's primary
             // repo. Sits below the Run and above the instance default (ADR-0046).
-            project: project_harness.as_deref(),
-            instance_default: default_harness.as_deref(),
+            project_choice: project_choice.as_ref(),
+            project_harness: project_harness.as_deref(),
+            instance_choice: instance_choice.as_ref(),
+            instance_default_harness: default_harness.as_deref(),
+            instance_default_models: Some(&default_models),
         };
-        Some(harness_resolver::resolve(
-            &tiers,
-            &node.harnesses,
-            &default_models,
-        ))
+        let resolved = agent_choice::resolve(&tiers, &profiles, agent_profile::DEFAULT_PROFILE_ID);
+        for warning in &resolved.warnings {
+            warn_missing_agent_profile_once(run_id, warning);
+        }
+        Some(resolved.combo)
     };
     let harness_descriptor = match &resolved_harness {
         None => None,

--- a/crates/pdo-daemon/src/outputs_validator.rs
+++ b/crates/pdo-daemon/src/outputs_validator.rs
@@ -309,6 +309,7 @@ mod tests {
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            agent_choice: None,
             auto_fail: None,
         }
     }

--- a/crates/pdo-daemon/src/pipeline.rs
+++ b/crates/pdo-daemon/src/pipeline.rs
@@ -182,6 +182,17 @@ pub(crate) struct NodeDef {
     /// (`pipeline_semantics`).
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub harnesses: BTreeMap<String, crate::harness_resolver::HarnessEntry>,
+    /// The node's own tier of the agentic-profile union (#563, ADR-0057):
+    /// `Inherit` (absent, the default — continue `Run → Projet → instance →
+    /// Default`), a named `Profile` reference, or an inline `Custom` combo.
+    /// When this is `Some(Profile | Custom)` it supplies harness, model and
+    /// effort atomically and [`pin_harness`]/[`harnesses`] above are NOT
+    /// consulted for this node (ADR-0057 ¶1: Custom "ne réactive pas l'ancien
+    /// résolveur"). Absent, or `Some(Inherit)`, preserves the pre-#563 legacy
+    /// behaviour exactly (`pin_harness` + `harnesses`) — no pipeline is migrated
+    /// automatically (#563, out of scope). Semantic, not layout.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_choice: Option<crate::agent_choice::AgentChoice>,
     /// Optional `auto_fail` preference for this node (ADR-0049): the **finest**
     /// tier of [`crate::auto_fail::resolve_auto_fail`] (`node → Run → Projet →
     /// instance`). `Some(true)`/`Some(false)` overrides every coarser tier for a
@@ -2585,12 +2596,134 @@ nodes:
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            agent_choice: None,
             auto_fail: None,
         };
         let yaml = serde_yaml::to_string(&node).unwrap();
         assert!(yaml.contains("type: script"), "serializes to kebab: {yaml}");
         let back: NodeDef = serde_yaml::from_str(&yaml).unwrap();
         assert_eq!(back.node_type, NodeType::Script);
+    }
+
+    /// #563/ADR-0057: a node with no `agent_choice:` key at all parses to
+    /// `None` and re-serializes without the key — the byte-identical
+    /// no-migration contract the resolver's own tests pin from the other side.
+    #[test]
+    fn node_without_agent_choice_key_parses_to_none_and_omits_it_on_reserialize() {
+        let yaml = with_start_end(
+            r#"
+name: legacy-pipeline
+nodes:
+  - id: ab000001
+    name: planner
+    type: doc-only
+    inputs:
+      - name: task
+    outputs:
+      - name: plan
+"#,
+        );
+        let result = parse_pipeline(&yaml).unwrap();
+        let node = result
+            .pipeline
+            .nodes
+            .iter()
+            .find(|n| n.id == "ab000001")
+            .unwrap();
+        assert_eq!(node.agent_choice, None);
+        let round = serde_yaml::to_string(node).unwrap();
+        assert!(
+            !round.contains("agent_choice"),
+            "absent agent_choice must not appear on reserialize: {round}"
+        );
+    }
+
+    /// #563/ADR-0057: a node's `agent_choice: {mode: profile, profile_id: ...}`
+    /// parses into the matching [`crate::agent_choice::AgentChoice::Profile`]
+    /// and round-trips through YAML unchanged.
+    #[test]
+    fn node_agent_choice_profile_reference_round_trips() {
+        let yaml = with_start_end(
+            r#"
+name: profile-pipeline
+nodes:
+  - id: ab000001
+    name: planner
+    type: doc-only
+    inputs:
+      - name: task
+    outputs:
+      - name: plan
+    agent_choice:
+      mode: profile
+      profile_id: reviewer
+"#,
+        );
+        let result = parse_pipeline(&yaml).unwrap();
+        let node = result
+            .pipeline
+            .nodes
+            .iter()
+            .find(|n| n.id == "ab000001")
+            .unwrap();
+        assert_eq!(
+            node.agent_choice,
+            Some(crate::agent_choice::AgentChoice::Profile {
+                profile_id: "reviewer".into()
+            })
+        );
+        let round = serde_yaml::to_string(node).unwrap();
+        let back: NodeDef = serde_yaml::from_str(&round).unwrap();
+        assert_eq!(back.agent_choice, node.agent_choice);
+    }
+
+    /// #563/ADR-0057: a node's `agent_choice: {mode: custom, harness, model,
+    /// effort}` parses atomically — no field is read from `harnesses`/
+    /// `pin_harness` even if both are also present (ADR-0057 ¶1: Custom does
+    /// not reactivate the old per-harness resolver).
+    #[test]
+    fn node_agent_choice_custom_round_trips_and_coexists_with_legacy_fields() {
+        let yaml = with_start_end(
+            r#"
+name: custom-pipeline
+nodes:
+  - id: ab000001
+    name: planner
+    type: doc-only
+    inputs:
+      - name: task
+    outputs:
+      - name: plan
+    pin_harness: claude
+    harnesses:
+      claude:
+        model: sonnet
+    agent_choice:
+      mode: custom
+      harness: opencode
+      model: gpt-5
+      effort: high
+"#,
+        );
+        let result = parse_pipeline(&yaml).unwrap();
+        let node = result
+            .pipeline
+            .nodes
+            .iter()
+            .find(|n| n.id == "ab000001")
+            .unwrap();
+        assert_eq!(
+            node.agent_choice,
+            Some(crate::agent_choice::AgentChoice::Custom {
+                harness: "opencode".into(),
+                model: Some("gpt-5".into()),
+                effort: Some("high".into()),
+            })
+        );
+        // Legacy fields are still parsed and preserved verbatim — Custom wins
+        // at resolution time (agent_choice.rs), it does not erase them.
+        assert_eq!(node.pin_harness.as_deref(), Some("claude"));
+        assert!(node.harnesses.contains_key("claude"));
     }
 
     #[test]

--- a/crates/pdo-daemon/src/pipeline_migrator.rs
+++ b/crates/pdo-daemon/src/pipeline_migrator.rs
@@ -2473,6 +2473,7 @@ edges:
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            agent_choice: None,
             auto_fail: None,
         }
     }
@@ -2510,6 +2511,7 @@ edges:
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            agent_choice: None,
             auto_fail: None,
         }
     }
@@ -2547,6 +2549,7 @@ edges:
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            agent_choice: None,
             auto_fail: None,
         }
     }

--- a/crates/pdo-daemon/src/pipeline_semantics.rs
+++ b/crates/pdo-daemon/src/pipeline_semantics.rs
@@ -147,6 +147,14 @@ struct NodeProjection<'a> {
     /// both see it. A `BTreeMap` so the canonical form is key-ordered; empty ⇒
     /// serialized as `{}` (a plain claude node with no settings).
     harnesses: &'a std::collections::BTreeMap<String, crate::harness_resolver::HarnessEntry>,
+    /// The node's agent-profile choice (#563, ADR-0057) — semantic: it changes
+    /// harness/model/effort just as directly as `pin_harness`/`harnesses` above,
+    /// and CONTEXT.md is explicit ("la carte entre dans le diff sémantique").
+    /// `skip_serializing_if` keeps a pre-#563 pipeline (which never sets it)
+    /// byte-identical to its old content hash — the same discipline `auto_fail`
+    /// below uses.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    agent_choice: Option<&'a crate::agent_choice::AgentChoice>,
     max_iter: Option<serde_json::Value>,
     /// Legacy per-node collection driver. The frontend serializer no longer emits
     /// it, so it is absent from `SEMANTIC_FIELDS.node`; it is still a behavioural
@@ -176,6 +184,7 @@ impl<'a> NodeProjection<'a> {
             over,
             pin_harness,
             harnesses,
+            agent_choice,
             auto_fail,
         } = node;
         let _layout = view; // LAYOUT_FIELDS["node"]
@@ -186,6 +195,7 @@ impl<'a> NodeProjection<'a> {
             interactive: *interactive,
             pin_harness: pin_harness.as_deref(),
             harnesses,
+            agent_choice: agent_choice.as_ref(),
             max_iter: max_iter.as_ref().map(canon_yaml),
             over: over.as_deref(),
             auto_fail: *auto_fail,

--- a/crates/pdo-daemon/src/project_store.rs
+++ b/crates/pdo-daemon/src/project_store.rs
@@ -49,6 +49,12 @@ pub(crate) struct Project {
     /// instance default). No env/default tier of its own.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub auto_fail: Option<bool>,
+    /// The Projet tier of the agentic-profile union (#563, ADR-0057), or `None`
+    /// when this Projet states none — the tier is then transparent and
+    /// [`Self::harness`] (the legacy signal) still applies. `Some(Profile |
+    /// Custom)` wins outright at this tier over `harness` (never merges).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_choice: Option<crate::agent_choice::AgentChoice>,
     /// Member repository paths, compared **verbatim** (ADR-0033). Ordered by
     /// attach time (the `rowid` of `project_members`).
     #[serde(default)]
@@ -84,6 +90,7 @@ pub(crate) async fn init(db: &SqlitePool) -> Result<(), sqlx::Error> {
             name       TEXT NOT NULL,
             harness    TEXT,
             auto_fail  INTEGER,
+            agent_choice TEXT,
             created_at TEXT NOT NULL
         )",
     )
@@ -101,6 +108,21 @@ pub(crate) async fn init(db: &SqlitePool) -> Result<(), sqlx::Error> {
             .is_some();
     if !has_auto_fail {
         sqlx::query("ALTER TABLE projects ADD COLUMN auto_fail INTEGER")
+            .execute(db)
+            .await?;
+    }
+
+    // Additive migration for pre-#563 databases: the `agent_choice` column is
+    // absent on `projects` tables created before the agentic-profile union.
+    // Guarded `ADD COLUMN` — NULLABLE so an existing Projet falls back to its
+    // legacy `harness` column unchanged.
+    let has_agent_choice =
+        sqlx::query("SELECT 1 FROM pragma_table_info('projects') WHERE name = 'agent_choice'")
+            .fetch_optional(db)
+            .await?
+            .is_some();
+    if !has_agent_choice {
+        sqlx::query("ALTER TABLE projects ADD COLUMN agent_choice TEXT")
             .execute(db)
             .await?;
     }
@@ -143,6 +165,10 @@ fn row_to_project(row: &sqlx::sqlite::SqliteRow, members: Vec<String>) -> Projec
             .get::<Option<String>, _>("harness")
             .filter(|s| !s.is_empty()),
         auto_fail: row.get::<Option<i64>, _>("auto_fail").map(|v| v != 0),
+        // #563: NULL / unparseable ⇒ `None` — the tier is simply transparent.
+        agent_choice: row
+            .get::<Option<String>, _>("agent_choice")
+            .and_then(|s| serde_json::from_str(&s).ok()),
         members,
     }
 }
@@ -174,6 +200,7 @@ pub(crate) async fn create(db: &SqlitePool, name: &str) -> Result<Project, sqlx:
         name: name.to_string(),
         harness: None,
         auto_fail: None,
+        agent_choice: None,
         members: Vec::new(),
     })
 }
@@ -261,6 +288,35 @@ pub(crate) async fn auto_fail_for_path(
     path: &str,
 ) -> Result<Option<bool>, sqlx::Error> {
     Ok(owner_of(db, path).await?.and_then(|p| p.auto_fail))
+}
+
+/// Set (or clear, with `None`) the `AgentChoice` a Projet carries (#563,
+/// ADR-0057). `None` clears it back to "states none" (SQL `NULL`) — the tier
+/// is then transparent and the legacy [`Project::harness`] still applies.
+/// Returns `true` iff a row was updated.
+pub(crate) async fn set_agent_choice(
+    db: &SqlitePool,
+    id: &str,
+    agent_choice: Option<crate::agent_choice::AgentChoice>,
+) -> Result<bool, sqlx::Error> {
+    let stored = agent_choice.map(|c| serde_json::to_string(&c).unwrap_or_default());
+    let res = sqlx::query("UPDATE projects SET agent_choice = ? WHERE id = ?")
+        .bind(stored)
+        .bind(id)
+        .execute(db)
+        .await?;
+    Ok(res.rows_affected() > 0)
+}
+
+/// Resolve the `AgentChoice` a `path` inherits from its Projet, for the
+/// Projet tier of [`crate::agent_choice::resolve`]. `None` ⇒ the path is in no
+/// Projet, or its Projet states none — the tier is transparent either way (the
+/// legacy `harness` signal, read via [`harness_for_path`], still applies).
+pub(crate) async fn agent_choice_for_path(
+    db: &SqlitePool,
+    path: &str,
+) -> Result<Option<crate::agent_choice::AgentChoice>, sqlx::Error> {
+    Ok(owner_of(db, path).await?.and_then(|p| p.agent_choice))
 }
 
 /// The Projet that currently owns `path`, if any. Read-then-decide basis for the
@@ -476,6 +532,124 @@ mod tests {
             .await
             .unwrap()
             .is_none());
+    }
+
+    /// #563/ADR-0057: the Projet tier of `AgentChoice` — a fresh Projet carries
+    /// none, `set_agent_choice` sets it, both member paths inherit it (mirrors
+    /// `harness_for_path` above), and clearing it back to `None` makes the tier
+    /// transparent again (falls back to the legacy `harness` column).
+    #[tokio::test]
+    async fn agent_choice_for_path_reads_the_owning_projects_choice() {
+        let db = mem_db().await;
+        let a = create(&db, "Alpha").await.unwrap();
+        add_member(&db, &a.id, "/repos/front").await.unwrap();
+        add_member(&db, &a.id, "/repos/back").await.unwrap();
+
+        assert!(agent_choice_for_path(&db, "/repos/front")
+            .await
+            .unwrap()
+            .is_none());
+
+        let choice = crate::agent_choice::AgentChoice::Profile {
+            profile_id: "reviewer".to_string(),
+        };
+        assert!(set_agent_choice(&db, &a.id, Some(choice.clone()))
+            .await
+            .unwrap());
+        assert_eq!(
+            agent_choice_for_path(&db, "/repos/front").await.unwrap(),
+            Some(choice.clone())
+        );
+        // Both members inherit it, like the legacy harness tier.
+        assert_eq!(
+            agent_choice_for_path(&db, "/repos/back").await.unwrap(),
+            Some(choice)
+        );
+        // A non-member path inherits nothing.
+        assert!(agent_choice_for_path(&db, "/repos/other")
+            .await
+            .unwrap()
+            .is_none());
+
+        // Clearing it (`None`) makes the tier transparent again.
+        assert!(set_agent_choice(&db, &a.id, None).await.unwrap());
+        assert!(agent_choice_for_path(&db, "/repos/front")
+            .await
+            .unwrap()
+            .is_none());
+    }
+
+    /// #563: the legacy `harness` column and the new `agent_choice` column
+    /// coexist independently on the same Projet row — setting one never
+    /// disturbs the other (resolution order is `agent_choice.rs`'s concern).
+    #[tokio::test]
+    async fn agent_choice_and_legacy_harness_coexist_on_the_same_project() {
+        let db = mem_db().await;
+        let a = create(&db, "Alpha").await.unwrap();
+        add_member(&db, &a.id, "/repos/front").await.unwrap();
+        assert!(set_harness(&db, &a.id, Some("claude")).await.unwrap());
+
+        let choice = crate::agent_choice::AgentChoice::Custom {
+            harness: "opencode".to_string(),
+            model: Some("gpt-5".to_string()),
+            effort: None,
+        };
+        assert!(set_agent_choice(&db, &a.id, Some(choice.clone()))
+            .await
+            .unwrap());
+
+        let p = get(&db, &a.id).await.unwrap().unwrap();
+        assert_eq!(p.harness.as_deref(), Some("claude"));
+        assert_eq!(p.agent_choice, Some(choice));
+    }
+
+    #[tokio::test]
+    async fn init_migrates_pre_agent_choice_schema() {
+        // #563: a `projects` table created before the `agent_choice` column
+        // gains it on init, idempotently, without clobbering existing rows —
+        // same guarded `ADD COLUMN` idiom the pre-résilience `auto_fail`
+        // migration already established on this table.
+        let db = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        sqlx::query(
+            "CREATE TABLE projects (
+                id         TEXT PRIMARY KEY,
+                name       TEXT NOT NULL,
+                harness    TEXT,
+                created_at TEXT NOT NULL
+            )",
+        )
+        .execute(&db)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO projects (id, name, harness, created_at) \
+             VALUES ('prj-1', 'Alpha', 'claude', 'seed')",
+        )
+        .execute(&db)
+        .await
+        .unwrap();
+
+        init(&db).await.unwrap();
+        init(&db).await.unwrap();
+
+        let p = get(&db, "prj-1").await.unwrap().unwrap();
+        assert_eq!(
+            p.harness.as_deref(),
+            Some("claude"),
+            "pre-existing survives"
+        );
+        assert_eq!(p.agent_choice, None, "new column defaults to NULL");
+
+        let choice = crate::agent_choice::AgentChoice::Profile {
+            profile_id: "reviewer".to_string(),
+        };
+        assert!(set_agent_choice(&db, "prj-1", Some(choice.clone()))
+            .await
+            .unwrap());
+        assert_eq!(
+            get(&db, "prj-1").await.unwrap().unwrap().agent_choice,
+            Some(choice)
+        );
     }
 
     #[tokio::test]

--- a/crates/pdo-daemon/src/prompt_augmenter.rs
+++ b/crates/pdo-daemon/src/prompt_augmenter.rs
@@ -1227,6 +1227,7 @@ mod tests {
                 over: None,
                 pin_harness: None,
                 harnesses: Default::default(),
+                agent_choice: None,
                 auto_fail: None,
             }],
             edges: vec![],
@@ -1497,6 +1498,7 @@ mod tests {
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            agent_choice: None,
             auto_fail: None,
         });
         pipeline.edges.push(EdgeDef {
@@ -1639,6 +1641,7 @@ mod tests {
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            agent_choice: None,
             auto_fail: None,
         });
         pipeline.edges.push(EdgeDef {
@@ -1700,6 +1703,7 @@ mod tests {
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            agent_choice: None,
             auto_fail: None,
         });
 
@@ -1733,6 +1737,7 @@ mod tests {
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            agent_choice: None,
             auto_fail: None,
         });
         pipeline.edges.push(EdgeDef {
@@ -1780,6 +1785,7 @@ mod tests {
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            agent_choice: None,
             auto_fail: None,
         });
         pipeline.edges.push(EdgeDef {
@@ -1933,6 +1939,7 @@ mod tests {
                     over: None,
                     pin_harness: None,
                     harnesses: Default::default(),
+                    agent_choice: None,
                     auto_fail: None,
                 },
                 NodeDef {
@@ -1957,6 +1964,7 @@ mod tests {
                     over: None,
                     pin_harness: None,
                     harnesses: Default::default(),
+                    agent_choice: None,
                     auto_fail: None,
                 },
                 NodeDef {
@@ -2004,6 +2012,7 @@ mod tests {
                     over: None,
                     pin_harness: None,
                     harnesses: Default::default(),
+                    agent_choice: None,
                     auto_fail: None,
                 },
             ],
@@ -2118,6 +2127,7 @@ mod tests {
                 over: None,
                 pin_harness: None,
                 harnesses: Default::default(),
+                agent_choice: None,
                 auto_fail: None,
             }],
             edges: vec![],
@@ -2445,6 +2455,7 @@ mod tests {
                 over: None,
                 pin_harness: None,
                 harnesses: Default::default(),
+                agent_choice: None,
                 auto_fail: None,
             }],
             edges: vec![],
@@ -2499,6 +2510,7 @@ mod tests {
                 over: None,
                 pin_harness: None,
                 harnesses: Default::default(),
+                agent_choice: None,
                 auto_fail: None,
             }],
             edges: vec![],
@@ -2548,6 +2560,7 @@ mod tests {
                 over: None,
                 pin_harness: None,
                 harnesses: Default::default(),
+                agent_choice: None,
                 auto_fail: None,
             }],
             edges: vec![],

--- a/crates/pdo-daemon/src/run_advance.rs
+++ b/crates/pdo-daemon/src/run_advance.rs
@@ -628,6 +628,7 @@ mod tests {
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            agent_choice: None,
             auto_fail: None,
         }
     }

--- a/crates/pdo-daemon/src/run_command.rs
+++ b/crates/pdo-daemon/src/run_command.rs
@@ -2218,6 +2218,11 @@ async fn dispatch(state: Arc<AppState>, run_id: String, cmd: RunCommand) -> Resp
                 // `Some`-wrapping-for-explicit dance: the create chokepoint freezes
                 // `req.harness` verbatim, with no precedence resolution of its own.
                 harness: run_state.harness.clone(),
+                // #563: reproduce the original Run's `AgentChoice`, like `harness` —
+                // `None` (stated none) forwards as `None`, so the retry re-resolves
+                // through the legacy `harness` tier (or Projet/instance) exactly as
+                // the original did.
+                agent_choice: run_state.agent_choice.clone(),
                 // #338: pin the historical retry behaviour exactly. A retry has always
                 // set `name: None` and re-derived the name (placeholder or from input);
                 // `Some(true)` reproduces that regardless of the instance default, so a
@@ -3278,6 +3283,7 @@ mod tests {
                 over: None,
                 pin_harness: None,
                 harnesses: Default::default(),
+                agent_choice: None,
                 auto_fail: None,
             }],
             edges: vec![EdgeDef {
@@ -3334,6 +3340,7 @@ mod tests {
                 over: None,
                 pin_harness: None,
                 harnesses: Default::default(),
+                agent_choice: None,
                 auto_fail: None,
             }],
             edges: vec![EdgeDef {

--- a/crates/pdo-daemon/src/scheduler.rs
+++ b/crates/pdo-daemon/src/scheduler.rs
@@ -1762,6 +1762,7 @@ mod tests {
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            agent_choice: None,
             auto_fail: None,
         }
     }
@@ -1789,6 +1790,7 @@ mod tests {
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            agent_choice: None,
             auto_fail: None,
         }
     }
@@ -3083,6 +3085,7 @@ mod tests {
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            agent_choice: None,
             auto_fail: None,
         }
     }
@@ -3824,6 +3827,7 @@ mod tests {
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            agent_choice: None,
             auto_fail: None,
         }
     }
@@ -4352,6 +4356,7 @@ mod tests {
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            agent_choice: None,
             auto_fail: None,
         }
     }

--- a/crates/pdo-daemon/src/scheduler_dispatcher.rs
+++ b/crates/pdo-daemon/src/scheduler_dispatcher.rs
@@ -92,6 +92,7 @@ mod tests {
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            agent_choice: None,
             auto_fail: None,
         }
     }

--- a/crates/pdo-daemon/src/switch_router.rs
+++ b/crates/pdo-daemon/src/switch_router.rs
@@ -62,6 +62,7 @@ mod tests {
             over: None,
             pin_harness: None,
             harnesses: Default::default(),
+            agent_choice: None,
             auto_fail: None,
         }
     }

--- a/crates/pdo-daemon/src/tmux_session_manager.rs
+++ b/crates/pdo-daemon/src/tmux_session_manager.rs
@@ -1376,6 +1376,14 @@ pub fn default_harness_with(stored: Option<String>) -> Option<String> {
 /// limits, same freshness contract as the model catalogue, ADR-0053). The env
 /// override `PDO_HARNESS_PROBE_PATH` short-circuits the shell probe (ops / tests).
 pub fn harness_probe_path() -> String {
+    // Explicit overrides are a deterministic per-process seam. Read them before
+    // the production cache so the single integration-test binary can isolate
+    // tests that intentionally provide different fake harness directories.
+    if let Some(path) = std::env::var_os("PDO_HARNESS_PROBE_PATH") {
+        if !path.is_empty() {
+            return path.to_string_lossy().into_owned();
+        }
+    }
     static PROBE_PATH: OnceLock<String> = OnceLock::new();
     PROBE_PATH.get_or_init(resolve_harness_probe_path).clone()
 }

--- a/crates/pdo-daemon/src/trigger_scheduler.rs
+++ b/crates/pdo-daemon/src/trigger_scheduler.rs
@@ -312,6 +312,7 @@ mod tests {
             max_concurrent: None,
             sandbox: None,
             harness: None,
+            agent_choice: None,
             auto_name: true,
             enabled: true,
             next_fire_at: next_fire_at.map(str::to_string),

--- a/crates/pdo-daemon/src/trigger_store.rs
+++ b/crates/pdo-daemon/src/trigger_store.rs
@@ -75,6 +75,15 @@ pub(crate) struct Trigger {
     /// double-`Option` [`UpdateTrigger::harness`] (mirror of `sandbox`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub harness: Option<String>,
+    /// The Run tier of the agentic-profile union carried by a Trigger's Run
+    /// template (#563, ADR-0057), or `None` to inherit the counterpart of
+    /// [`Self::harness`]: there is NO separate Trigger tier — a Trigger *is* a
+    /// Run template, so this is read at fire time and folded into the create
+    /// request's `run` choice, same as `harness`. `None` ⇒ `harness` above
+    /// (and the tiers below it) still decide. Clearable back to `None` via the
+    /// double-`Option` [`UpdateTrigger::agent_choice`] (mirror of `harness`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_choice: Option<crate::agent_choice::AgentChoice>,
     /// Whether Runs fired from this Trigger are auto-named by the manager (#338). A
     /// flat bool (mirror of [`Self::enabled`]), NOT a nullable inherit: the choice is
     /// frozen at creation from the instance default and read at fire time. `true`
@@ -117,6 +126,9 @@ pub(crate) struct NewTrigger {
     pub sandbox: Option<String>,
     /// Per-Trigger harness (#551); `None` inherits the instance default at fire time.
     pub harness: Option<String>,
+    /// Per-Trigger `AgentChoice` (#563); `None` inherits the legacy `harness`
+    /// tier (and the tiers below it) at fire time.
+    pub agent_choice: Option<crate::agent_choice::AgentChoice>,
     /// Whether Runs this Trigger fires are auto-named (#338). Seeded from the instance
     /// default in the create modal and frozen here; `true` is the pre-#338 behaviour.
     pub auto_name: bool,
@@ -184,6 +196,7 @@ pub(crate) async fn init(db: &SqlitePool) -> Result<(), sqlx::Error> {
             max_concurrent INTEGER,
             sandbox TEXT,
             harness TEXT,
+            agent_choice TEXT,
             auto_name INTEGER NOT NULL DEFAULT 1,
             enabled INTEGER NOT NULL DEFAULT 1,
             next_fire_at TEXT,
@@ -256,6 +269,20 @@ pub(crate) async fn init(db: &SqlitePool) -> Result<(), sqlx::Error> {
             .is_some();
     if !has_harness {
         sqlx::query("ALTER TABLE triggers ADD COLUMN harness TEXT")
+            .execute(db)
+            .await?;
+    }
+
+    // Additive migration (#563): per-Trigger `agent_choice`. Same PRAGMA-guarded
+    // `ALTER` precedent as `harness` above — NULLABLE: a NULL row inherits the
+    // legacy `harness` tier (and the tiers below it) at fire time.
+    let has_agent_choice =
+        sqlx::query("SELECT 1 FROM pragma_table_info('triggers') WHERE name = 'agent_choice'")
+            .fetch_optional(db)
+            .await?
+            .is_some();
+    if !has_agent_choice {
+        sqlx::query("ALTER TABLE triggers ADD COLUMN agent_choice TEXT")
             .execute(db)
             .await?;
     }
@@ -355,8 +382,8 @@ pub(crate) async fn create(db: &SqlitePool, new: NewTrigger) -> Result<Trigger, 
         "INSERT INTO triggers
             (id, name, pipeline_id, pipeline_name, target_repo, target_repos, source_branch,
              input_template, variables, cron, guard_command, overlap_policy,
-             max_concurrent, sandbox, harness, auto_name, enabled, next_fire_at, last_fired_at, last_outcome, created_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, NULL, NULL, ?)",
+             max_concurrent, sandbox, harness, agent_choice, auto_name, enabled, next_fire_at, last_fired_at, last_outcome, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, NULL, NULL, ?)",
     )
     .bind(&id)
     .bind(&new.name)
@@ -373,6 +400,11 @@ pub(crate) async fn create(db: &SqlitePool, new: NewTrigger) -> Result<Trigger, 
     .bind(new.max_concurrent)
     .bind(&new.sandbox)
     .bind(&new.harness)
+    .bind(
+        new.agent_choice
+            .as_ref()
+            .map(|c| serde_json::to_string(c).unwrap_or_default()),
+    )
     .bind(if new.auto_name { 1_i64 } else { 0_i64 })
     .bind(&new.next_fire_at)
     .bind(&now)
@@ -404,6 +436,13 @@ fn row_to_trigger(row: &sqlx::sqlite::SqliteRow) -> Trigger {
         // #551: tolerant of a legacy-NULL / pre-migration read (mirror of `target_repos`) —
         // absence inherits the instance default at fire time.
         harness: row.try_get("harness").unwrap_or(None),
+        // #563: tolerant of a legacy-NULL / pre-migration read (mirror of `harness`) —
+        // absence, or an unparseable value, inherits the legacy `harness` tier.
+        agent_choice: row
+            .try_get::<Option<String>, _>("agent_choice")
+            .ok()
+            .flatten()
+            .and_then(|s| serde_json::from_str(&s).ok()),
         // #338: tolerant of a legacy NULL (a pre-migration row read mid-upgrade) —
         // absence reads as auto-name ON, the pre-#338 behaviour.
         auto_name: row.try_get::<i64, _>("auto_name").unwrap_or(1) != 0,
@@ -593,6 +632,10 @@ pub(crate) struct UpdateTrigger {
     /// plain `serde(default)` would make present-`null` indistinguishable from omitted, so
     /// the UI could never reset a Trigger back to inheriting.
     pub harness: Option<Option<String>>,
+    /// Per-Trigger `AgentChoice` (#563), double-wrapped like `harness`: `None`
+    /// leaves it, `Some(None)` clears to NULL (= legacy `harness` tier decides
+    /// again), `Some(Some(choice))` sets it.
+    pub agent_choice: Option<Option<crate::agent_choice::AgentChoice>>,
     /// Auto-naming toggle (#338): `None` leaves the flag, `Some(v)` sets it. A FLAT
     /// `Option<bool>` (mirror of [`Self::enabled`]), NOT double-wrapped like `sandbox`
     /// — there is no "inherit" state to clear back to; the choice is a plain on/off.
@@ -620,6 +663,7 @@ impl UpdateTrigger {
             && self.max_concurrent.is_none()
             && self.sandbox.is_none()
             && self.harness.is_none()
+            && self.agent_choice.is_none()
             && self.auto_name.is_none()
             && self.next_fire_at.is_none()
             && self.enabled.is_none()
@@ -681,6 +725,9 @@ pub(crate) async fn update(
     if edit.harness.is_some() {
         sets.push("harness = ?");
     }
+    if edit.agent_choice.is_some() {
+        sets.push("agent_choice = ?");
+    }
     if edit.auto_name.is_some() {
         sets.push("auto_name = ?");
     }
@@ -740,6 +787,14 @@ pub(crate) async fn update(
         // `Some(Some(name))` → the harness name. Mirror of `sandbox`.
         query = query.bind(v.clone());
     }
+    if let Some(v) = &edit.agent_choice {
+        // #563: `Some(None)` → SQL NULL (inherit the legacy `harness` tier);
+        // `Some(Some(choice))` → the serialized JSON. Mirror of `harness`.
+        query = query.bind(
+            v.as_ref()
+                .map(|c| serde_json::to_string(c).unwrap_or_default()),
+        );
+    }
     if let Some(v) = &edit.auto_name {
         // Flat bool → 0/1 (mirror of `enabled`), never NULL: the column is
         // `NOT NULL DEFAULT 1` and the choice is a plain on/off (#338).
@@ -786,6 +841,7 @@ mod tests {
             max_concurrent: None,
             sandbox: None,
             harness: None,
+            agent_choice: None,
             auto_name: true,
             next_fire_at: Some("2026-06-06T10:00:00.000Z".to_string()),
         }
@@ -1598,6 +1654,188 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(get(&db, &t.id).await.unwrap().unwrap().harness, None);
+    }
+
+    /// #563 (ADR-0057): the per-Trigger `AgentChoice` round-trips through create, is
+    /// set and cleared through the double-`Option` update, and an unrelated edit
+    /// leaves it. Mirror of `harness_round_trips_and_clears` above.
+    #[tokio::test]
+    async fn agent_choice_round_trips_and_clears() {
+        use crate::agent_choice::AgentChoice;
+
+        let db = test_db().await;
+        let mut new = sample("t", "0 9 * * *");
+        new.agent_choice = Some(AgentChoice::Profile {
+            profile_id: "prof-1".to_string(),
+        });
+        let t = create(&db, new).await.unwrap();
+        assert_eq!(
+            t.agent_choice,
+            Some(AgentChoice::Profile {
+                profile_id: "prof-1".to_string()
+            })
+        );
+
+        // Some(Some(choice)) sets it to another choice.
+        update(
+            &db,
+            &t.id,
+            UpdateTrigger {
+                agent_choice: Some(Some(AgentChoice::Custom {
+                    harness: "opencode".to_string(),
+                    model: None,
+                    effort: None,
+                })),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            get(&db, &t.id).await.unwrap().unwrap().agent_choice,
+            Some(AgentChoice::Custom {
+                harness: "opencode".to_string(),
+                model: None,
+                effort: None,
+            })
+        );
+
+        // An unrelated edit (agent_choice = None) leaves it untouched.
+        update(
+            &db,
+            &t.id,
+            UpdateTrigger {
+                input_template: Some("changed".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            get(&db, &t.id).await.unwrap().unwrap().agent_choice,
+            Some(AgentChoice::Custom {
+                harness: "opencode".to_string(),
+                model: None,
+                effort: None,
+            })
+        );
+
+        // Some(None) clears it back to the legacy `harness` field deciding again.
+        update(
+            &db,
+            &t.id,
+            UpdateTrigger {
+                agent_choice: Some(None),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(get(&db, &t.id).await.unwrap().unwrap().agent_choice, None);
+    }
+
+    /// #563: a Trigger can carry both a legacy `harness` string AND an
+    /// `agent_choice`, independently — the two fields coexist on the row exactly
+    /// like `instance_config`'s and `project_store`'s equivalent tests, since
+    /// `agent_choice::resolve` (not this store) decides which one wins.
+    #[tokio::test]
+    async fn agent_choice_and_legacy_harness_coexist() {
+        use crate::agent_choice::AgentChoice;
+
+        let db = test_db().await;
+        let mut new = sample("t", "0 9 * * *");
+        new.harness = Some("claude".to_string());
+        new.agent_choice = Some(AgentChoice::Custom {
+            harness: "opencode".to_string(),
+            model: Some("gpt-5".to_string()),
+            effort: Some("high".to_string()),
+        });
+        let t = create(&db, new).await.unwrap();
+
+        let fetched = get(&db, &t.id).await.unwrap().unwrap();
+        assert_eq!(fetched.harness.as_deref(), Some("claude"));
+        assert_eq!(
+            fetched.agent_choice,
+            Some(AgentChoice::Custom {
+                harness: "opencode".to_string(),
+                model: Some("gpt-5".to_string()),
+                effort: Some("high".to_string()),
+            })
+        );
+    }
+
+    /// #563 migration: a `~/.pdo/pdo.db` created before `agent_choice` existed must
+    /// pick up the column on the next `init`, and a legacy row must read back with
+    /// `agent_choice = None` (the legacy `harness` field, if any, still decides) —
+    /// mirror of `init_adds_harness_to_legacy_table` above.
+    #[tokio::test]
+    async fn init_adds_agent_choice_to_legacy_table() {
+        let db = sqlx::sqlite::SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .unwrap();
+
+        // Pre-#563 schema: `triggers` WITH `harness` but WITHOUT `agent_choice`.
+        sqlx::query(
+            "CREATE TABLE triggers (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                pipeline_id TEXT NOT NULL,
+                pipeline_name TEXT NOT NULL DEFAULT '',
+                target_repo TEXT,
+                target_repos TEXT,
+                source_branch TEXT,
+                input_template TEXT NOT NULL DEFAULT '',
+                variables JSON NOT NULL DEFAULT '{}',
+                cron TEXT NOT NULL,
+                guard_command TEXT,
+                overlap_policy TEXT NOT NULL DEFAULT 'skip',
+                max_concurrent INTEGER,
+                sandbox TEXT,
+                harness TEXT,
+                auto_name INTEGER NOT NULL DEFAULT 1,
+                enabled INTEGER NOT NULL DEFAULT 1,
+                next_fire_at TEXT,
+                last_fired_at TEXT,
+                last_outcome TEXT,
+                created_at TEXT NOT NULL
+            )",
+        )
+        .execute(&db)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO triggers (id, name, pipeline_id, cron, harness, created_at)
+             VALUES ('trg-legacy', 'legacy', 'lib-pipe', '0 9 * * *', 'claude', '2026-01-01T00:00:00.000Z')",
+        )
+        .execute(&db)
+        .await
+        .unwrap();
+
+        let before =
+            sqlx::query("SELECT 1 FROM pragma_table_info('triggers') WHERE name = 'agent_choice'")
+                .fetch_optional(&db)
+                .await
+                .unwrap();
+        assert!(
+            before.is_none(),
+            "precondition: legacy table lacks the column"
+        );
+
+        init(&db).await.unwrap();
+        init(&db).await.unwrap(); // idempotent
+
+        let after =
+            sqlx::query("SELECT 1 FROM pragma_table_info('triggers') WHERE name = 'agent_choice'")
+                .fetch_optional(&db)
+                .await
+                .unwrap();
+        assert!(after.is_some(), "init must add the column");
+
+        let legacy = get(&db, "trg-legacy").await.unwrap().unwrap();
+        assert_eq!(legacy.harness.as_deref(), Some("claude"));
+        assert_eq!(legacy.agent_choice, None);
     }
 
     /// #551 migration: a `~/.pdo/pdo.db` created before `harness` existed must pick up the

--- a/crates/pdo-daemon/src/workflow_importer.rs
+++ b/crates/pdo-daemon/src/workflow_importer.rs
@@ -545,6 +545,7 @@ impl Importer {
             over: None,
             pin_harness: None,
             harnesses,
+            agent_choice: None,
             auto_fail: None,
         };
         self.nodes.push(node);
@@ -944,6 +945,7 @@ fn start_node() -> NodeDef {
         over: None,
         pin_harness: None,
         harnesses: Default::default(),
+        agent_choice: None,
         auto_fail: None,
     }
 }
@@ -964,6 +966,7 @@ fn end_node(agent_count: usize) -> NodeDef {
         over: None,
         pin_harness: None,
         harnesses: Default::default(),
+        agent_choice: None,
         auto_fail: None,
     }
 }

--- a/crates/pdo-daemon/tests/harness_catalogue_served.rs
+++ b/crates/pdo-daemon/tests/harness_catalogue_served.rs
@@ -29,6 +29,7 @@ fn write_fake_binary(dir: &std::path::Path, name: &str) {
 #[cfg(unix)]
 #[tokio::test]
 async fn get_settings_serves_the_catalogue_deduced_from_the_binary() {
+    let _probe_env = crate::HARNESS_PROBE_ENV_LOCK.lock().await;
     // A tempdir holding the fake binary, wired as the harness probe PATH BEFORE the
     // daemon boots (so the boot probe and every settings fetch resolve it here).
     let bindir = tempfile::tempdir().unwrap();

--- a/crates/pdo-daemon/tests/harness_catalogue_sources.rs
+++ b/crates/pdo-daemon/tests/harness_catalogue_sources.rs
@@ -115,6 +115,7 @@ fn served_harness(settings: &serde_json::Value, harness: &str) -> serde_json::Va
 #[cfg(unix)]
 #[tokio::test]
 async fn copilots_catalogue_is_deduced_from_its_binary_and_re_read_when_it_updates() {
+    let _probe_env = crate::HARNESS_PROBE_ENV_LOCK.lock().await;
     let bindir = tempfile::tempdir().unwrap();
     write_fake_copilot(
         bindir.path(),

--- a/crates/pdo-daemon/tests/it.rs
+++ b/crates/pdo-daemon/tests/it.rs
@@ -14,6 +14,9 @@
 
 mod common;
 
+pub(crate) static HARNESS_PROBE_ENV_LOCK: tokio::sync::Mutex<()> =
+    tokio::sync::Mutex::const_new(());
+
 #[path = "admission_concurrency.rs"]
 mod admission_concurrency;
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,4 +1,4 @@
-import type { PipelineListEntry, PipelineDetail, PipelineDef, RunListEntry, RunState, PortDef, PortSide, PortType, FrontmatterFieldDecl, FrontmatterViolation, Trigger, TriggerFire, DaemonStatus, InstanceSettings, UpdateSettingsRequest, StatsOverview, StatsCost, StatsPerformance, SandboxProfile, SandboxProfileImage, SandboxProfileReferents, SyncCostPricesReport, Project, BranchRef } from "./types";
+import type { PipelineListEntry, PipelineDetail, PipelineDef, RunListEntry, RunState, PortDef, PortSide, PortType, FrontmatterFieldDecl, FrontmatterViolation, Trigger, TriggerFire, DaemonStatus, InstanceSettings, UpdateSettingsRequest, StatsOverview, StatsCost, StatsPerformance, SandboxProfile, SandboxProfileImage, SandboxProfileReferents, SyncCostPricesReport, Project, BranchRef, AgentChoice, AgentProfile, AgentProfileReferents } from "./types";
 import { foldHarnessOntoNode } from "./lib/harness";
 
 const BASE = "";
@@ -163,6 +163,38 @@ export function updateSettings(
   patch: UpdateSettingsRequest,
 ): Promise<InstanceSettings> {
   return request<InstanceSettings>("PUT", "/settings", { body: patch });
+}
+
+export function fetchAgentProfiles(): Promise<{ profiles: AgentProfile[] }> {
+  return request("GET", "/settings/agent-profiles");
+}
+
+export function createAgentProfile(
+  profile: Pick<AgentProfile, "name" | "harness" | "model" | "effort">,
+): Promise<AgentProfile> {
+  return request("POST", "/settings/agent-profiles", { body: profile });
+}
+
+export function updateAgentProfile(
+  id: string,
+  profile: Pick<AgentProfile, "name" | "harness" | "model" | "effort">,
+): Promise<AgentProfile> {
+  return request("PUT", `/settings/agent-profiles/${encodeURIComponent(id)}`, {
+    body: profile,
+  });
+}
+
+export function deleteAgentProfile(id: string): Promise<void> {
+  return request("DELETE", `/settings/agent-profiles/${encodeURIComponent(id)}`, {
+    responseMode: "void",
+  });
+}
+
+export function fetchAgentProfileReferents(id: string): Promise<AgentProfileReferents> {
+  return request(
+    "GET",
+    `/settings/agent-profiles/${encodeURIComponent(id)}/referents`,
+  );
 }
 
 // --- Staging profiles (#432, ADR-0031 §2-§7) --------------------------------
@@ -649,6 +681,7 @@ export interface CreateRunRequest {
    *  blank → the Run names no harness and each free node resolves through the instance
    *  default and the `claude` floor. Frozen into `RunStarted` at the create chokepoint. */
   harness?: string;
+  agent_choice?: AgentChoice;
   /** Whether the manager auto-names this Run (#338). The modal always sends it; omit and
    *  the server resolves back-compat by the presence of `name`, then the instance default. */
   auto_name?: boolean;
@@ -683,6 +716,7 @@ export function createRun(req: CreateRunRequest): Promise<CreateRunResponse> {
     // WITH attached images keeps its harness choice (the daemon's multipart parser reads
     // this field). Omitted when blank — the Run then names no harness.
     if (req.harness) form.append("harness", req.harness);
+    if (req.agent_choice) form.append("agent_choice", JSON.stringify(req.agent_choice));
     // #338: thread the explicit auto-naming choice through the multipart path too, so an
     // unchecked "Auto-generated" box is honoured on a create WITH attached images. Sent as
     // a stringified bool; only when the caller made a choice (it always does from the modal).
@@ -773,6 +807,7 @@ export interface CreateTriggerRequest {
   /** Per-Trigger harness (#551): a harness name, or null/omit to inherit the instance
    *  default. Folded into the fired Run's harness (no separate Trigger tier). */
   harness?: string | null;
+  agent_choice?: AgentChoice | null;
   /** Whether Runs this Trigger fires are auto-named (#338). Seeded from the instance
    *  default in the modal; omit → the server defaults to `true` (pre-#338 behaviour). */
   auto_name?: boolean;
@@ -818,6 +853,7 @@ export interface UpdateTriggerRequest {
   /** Per-Trigger harness (#551): a value sets it, `null` clears back to inheriting the
    *  instance default, `undefined` leaves it unchanged. */
   harness?: string | null;
+  agent_choice?: AgentChoice | null;
   /** Auto-naming toggle (#338): a bool sets it, `undefined` leaves it unchanged. A flat
    *  bool (no clear state) — mirror of `enabled`. */
   auto_name?: boolean;
@@ -857,6 +893,7 @@ export function createProject(name: string): Promise<Project> {
 export interface UpdateProjectRequest {
   name?: string;
   harness?: string | null;
+  agent_choice?: AgentChoice | null;
 }
 
 export function updateProject(

--- a/frontend/src/components/AgentControl.test.tsx
+++ b/frontend/src/components/AgentControl.test.tsx
@@ -1,0 +1,45 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import AgentControl from "./AgentControl";
+import { combinationLabel, resolveAgentChoice } from "../lib/agentProfiles";
+
+const profiles = [{
+  id: "p1",
+  name: "deep-work",
+  harness: "claude",
+  model: "opus",
+  effort: "high",
+  created_at: "",
+  updated_at: "",
+}];
+const catalog = { builtin: [], descriptors: [] };
+
+describe("AgentControl", () => {
+  it("renders the same two-line summary and commits a live profile reference", () => {
+    const onChange = vi.fn();
+    render(
+      <AgentControl
+        choice={{ mode: "inherit" }}
+        onChange={onChange}
+        profiles={profiles}
+        catalog={catalog}
+        inherited={{ harness: "claude", model: null, effort: null }}
+      />,
+    );
+    expect(screen.getByTestId("agent-control")).toHaveTextContent("Inherit");
+    expect(screen.getByTestId("agent-control")).toHaveTextContent("claude · — · —");
+    fireEvent.click(screen.getByTestId("agent-control"));
+    fireEvent.click(screen.getByText("deep-work"));
+    expect(onChange).toHaveBeenCalledWith({ mode: "profile", profile_id: "p1" });
+  });
+
+  it("marks a missing profile and falls through to the inherited combination", () => {
+    const resolved = resolveAgentChoice(
+      { mode: "profile", profile_id: "gone" },
+      profiles,
+      { harness: "copilot", model: null, effort: "medium" },
+    );
+    expect(resolved.brokenId).toBe("gone");
+    expect(combinationLabel(resolved.combination)).toBe("copilot · — · medium");
+  });
+});

--- a/frontend/src/components/AgentControl.tsx
+++ b/frontend/src/components/AgentControl.tsx
@@ -1,0 +1,210 @@
+import { useMemo, useState } from "react";
+import { Bookmark, Check, ChevronDown, ChevronLeft, GitFork, SlidersHorizontal, TriangleAlert } from "lucide-react";
+import type { AgentChoice, AgentCombination, AgentProfile } from "../types";
+import type { HarnessCatalog } from "../lib/harness";
+import { findHarnessOption } from "../lib/harness";
+import HarnessSelect from "./HarnessSelect";
+import ModelPicker from "./ModelPicker";
+import EffortPicker from "./EffortPicker";
+import { combinationLabel, resolveAgentChoice } from "../lib/agentProfiles";
+
+const EMPTY: AgentCombination = { harness: "claude", model: null, effort: null };
+
+export default function AgentControl({
+  choice,
+  onChange,
+  profiles,
+  catalog,
+  inherited = EMPTY,
+  allowInherit = true,
+  label = "Agent",
+  testId = "agent-control",
+}: {
+  choice?: AgentChoice | null;
+  onChange: (choice: AgentChoice) => void;
+  profiles: AgentProfile[];
+  catalog: HarnessCatalog;
+  inherited?: AgentCombination;
+  allowInherit?: boolean;
+  label?: string;
+  testId?: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const [customPane, setCustomPane] = useState(false);
+  const [custom, setCustom] = useState<AgentCombination>(() =>
+    choice?.mode === "custom" ? choice : inherited,
+  );
+  const resolved = useMemo(
+    () => resolveAgentChoice(choice, profiles, inherited),
+    [choice, profiles, inherited],
+  );
+  const broken = resolved.brokenId != null;
+  const modeLabel =
+    broken ? resolved.brokenId
+    : choice?.mode === "profile" ? resolved.profile?.name ?? "Profile"
+    : choice?.mode === "custom" ? "Custom"
+    : "Inherit";
+  const Icon =
+    broken ? TriangleAlert
+    : choice?.mode === "profile" ? Bookmark
+    : choice?.mode === "custom" ? SlidersHorizontal
+    : GitFork;
+  const harnessOption = findHarnessOption(catalog, custom.harness);
+
+  const close = () => {
+    setOpen(false);
+    setCustomPane(false);
+  };
+
+  return (
+    <div className="relative" data-testid={`${testId}-root`}>
+      <span className="mb-1 block uppercase tracking-wider text-fg-4" style={{ fontSize: 9 }}>{label}</span>
+      <button
+        type="button"
+        data-testid={testId}
+        aria-expanded={open}
+        onClick={() => setOpen((value) => !value)}
+        className={`flex w-full items-center gap-2 rounded border bg-bg-3 px-2 py-1.5 text-left ${
+          broken ? "border-st-blocked text-st-blocked" : "border-line-strong text-fg-2"
+        }`}
+      >
+        <Icon size={11} className="shrink-0" />
+        <span className="min-w-0 flex-1">
+          <span className="block truncate font-medium" style={{ fontSize: 10.5 }}>{modeLabel}</span>
+          <span className="block truncate font-mono text-fg-4" style={{ fontSize: 9.5 }}>
+            {broken ? `missing · ${combinationLabel(resolved.combination)}` : combinationLabel(resolved.combination)}
+          </span>
+        </span>
+        <ChevronDown size={11} className="shrink-0 text-fg-4" />
+      </button>
+      {broken && (
+        <p className="mt-1 text-st-blocked" style={{ fontSize: 9.5 }}>
+          Resolution continues at the next tier.
+        </p>
+      )}
+
+      {open && (
+        <div
+          role="dialog"
+          data-testid={`${testId}-popover`}
+          className="absolute left-0 z-40 mt-1 w-full min-w-[280px] rounded border border-line-strong bg-bg-4 p-1.5 shadow-xl"
+        >
+          {customPane ? (
+            <>
+              <button
+                type="button"
+                onClick={() => setCustomPane(false)}
+                className="mb-2 flex w-full items-center gap-1 border-b border-line px-1 pb-2 text-fg-2"
+              >
+                <ChevronLeft size={12} /> Custom combination
+              </button>
+              <div className="space-y-2 px-1 pb-1">
+                <label className="block text-fg-3" style={{ fontSize: 10 }}>
+                  Harness <span className="text-acc">required</span>
+                  <HarnessSelect
+                    value={custom.harness}
+                    onChange={(harness) => setCustom({ harness: harness || "claude", model: null, effort: null })}
+                    catalog={catalog}
+                    inheritLabel="Choose a harness"
+                    className="mt-1 w-full rounded border border-line-strong bg-bg-3 px-2 py-1.5"
+                  />
+                </label>
+                <label className="block text-fg-3" style={{ fontSize: 10 }}>
+                  Model <span className="text-fg-4">optional</span>
+                  <ModelPicker
+                    value={custom.model ?? null}
+                    onChange={(model) => setCustom({ ...custom, model })}
+                    models={harnessOption?.models ?? []}
+                    testid={`${testId}-custom-model`}
+                    subject={testId}
+                  />
+                </label>
+                <label className="block text-fg-3" style={{ fontSize: 10 }}>
+                  Effort <span className="text-fg-4">optional</span>
+                  <EffortPicker
+                    value={custom.effort ?? null}
+                    onChange={(effort) => setCustom({ ...custom, effort })}
+                    efforts={harnessOption?.efforts ?? []}
+                    testid={`${testId}-custom-effort`}
+                    disabled={!(harnessOption?.hasEffort ?? true)}
+                  />
+                </label>
+                <button
+                  type="button"
+                  className="ml-auto block rounded bg-acc px-2 py-1 text-bg-1"
+                  onClick={() => {
+                    onChange({ mode: "custom", ...custom });
+                    close();
+                  }}
+                >
+                  Apply
+                </button>
+              </div>
+            </>
+          ) : (
+            <>
+              {allowInherit && (
+                <ChoiceRow
+                  name="Inherit"
+                  summary={combinationLabel(inherited)}
+                  selected={!choice || choice.mode === "inherit"}
+                  onClick={() => {
+                    onChange({ mode: "inherit" });
+                    close();
+                  }}
+                />
+              )}
+              <div className="px-1 py-1 uppercase tracking-wider text-fg-4" style={{ fontSize: 9 }}>Profiles</div>
+              {profiles.map((profile) => (
+                <ChoiceRow
+                  key={profile.id}
+                  name={profile.name}
+                  summary={combinationLabel(profile)}
+                  selected={choice?.mode === "profile" && choice.profile_id === profile.id}
+                  onClick={() => {
+                    onChange({ mode: "profile", profile_id: profile.id });
+                    close();
+                  }}
+                />
+              ))}
+              <div className="mt-1 border-t border-line pt-1">
+                <ChoiceRow
+                  name="Custom…"
+                  summary="A combination for this tier only"
+                  selected={choice?.mode === "custom"}
+                  onClick={() => {
+                    setCustom(choice?.mode === "custom" ? choice : inherited);
+                    setCustomPane(true);
+                  }}
+                />
+              </div>
+              <p className="border-t border-line px-1 pt-1 text-fg-4" style={{ fontSize: 9 }}>
+                — = not set on the profile, so the harness default applies.
+              </p>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ChoiceRow({
+  name,
+  summary,
+  selected,
+  onClick,
+}: {
+  name: string;
+  summary: string;
+  selected: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button type="button" onClick={onClick} className="relative block w-full rounded px-1.5 py-1 text-left hover:bg-bg-3">
+      <span className={`block font-medium ${selected ? "text-acc" : "text-fg"}`} style={{ fontSize: 10.5 }}>{name}</span>
+      <span className="block font-mono text-fg-4" style={{ fontSize: 9 }}>{summary}</span>
+      {selected && <Check size={12} className="absolute right-1.5 top-2 text-acc" />}
+    </button>
+  );
+}

--- a/frontend/src/components/EditCanvas.archived315.test.tsx
+++ b/frontend/src/components/EditCanvas.archived315.test.tsx
@@ -48,6 +48,7 @@ vi.mock("@xyflow/react", async (importOriginal) => {
 // EditCanvas (via usePipelineLibraryState) imports the API client; stub the
 // network so nothing fetches on mount.
 vi.mock("../api", () => ({
+  fetchAgentProfiles: vi.fn().mockResolvedValue({ profiles: [] }),
   fetchLibrary: vi.fn().mockResolvedValue([]),
   fetchLibraryPipelines: vi.fn().mockResolvedValue([]),
   saveLibraryPipeline: vi.fn().mockResolvedValue({ id: "my-pipeline", scope: "repo" }),

--- a/frontend/src/components/EditCanvas.banner225.test.tsx
+++ b/frontend/src/components/EditCanvas.banner225.test.tsx
@@ -28,6 +28,7 @@ vi.mock("@xyflow/react", async (importOriginal) => {
 // EditCanvas (via usePipelineLibraryState) imports the API client; stub the
 // network so nothing fetches on mount.
 vi.mock("../api", () => ({
+  fetchAgentProfiles: vi.fn().mockResolvedValue({ profiles: [] }),
   fetchLibrary: vi.fn().mockResolvedValue([]),
   fetchLibraryPipelines: vi.fn().mockResolvedValue([]),
   saveLibraryPipeline: vi.fn().mockResolvedValue({ id: "my-pipeline", scope: "repo" }),

--- a/frontend/src/components/EditCanvas.tsx
+++ b/frontend/src/components/EditCanvas.tsx
@@ -43,6 +43,8 @@ import PipelineStar from "./PipelineStar";
 import { usePipelineLibraryState } from "../hooks/useLibraryPipelines";
 import { useDismissedNudges } from "../hooks/useDismissedNudges";
 import { anchorHandleId, anchorsByDropOnBody, chooseAnchorSide, isEmergentInputNode } from "../lib/anchorSide";
+import { useAgentProfiles } from "../hooks/useAgentProfiles";
+import { Bookmark, SlidersHorizontal, TriangleAlert } from "lucide-react";
 
 // The four emergent body anchor handles (#168), each pinned to its side-centre
 // with the matching xyflow `Position` so a bound incoming edge arrives from that
@@ -81,6 +83,7 @@ interface EditNodeData {
   // collection (`⇉ ...`, #151) or a single-member bounded loop (`↻ ...`, #173).
   // Absent on non-member nodes and on multi-member regions (boxed instead).
   loopBadge?: { text: string; kind: LoopKind };
+  agentMode?: "inherit" | "profile" | "custom" | "broken";
   [key: string]: unknown;
 }
 
@@ -174,7 +177,18 @@ export function EditNode({ data, id, selected }: NodeProps<Node<EditNodeData>>) 
           and the amber interactive badge are intentionally dropped from the
           card. */}
       <div className="flex items-center gap-2">
-        <NodeTypeIcon type={data.nodeType} size={14} className={`shrink-0 ${iconColor}`} />
+        <span className="relative shrink-0">
+          <NodeTypeIcon type={data.nodeType} size={14} className={iconColor} />
+          {data.agentMode === "profile" && (
+            <Bookmark data-testid="agent-mode-profile" size={8} className="absolute -bottom-1 -right-1 text-fg-2" />
+          )}
+          {data.agentMode === "custom" && (
+            <SlidersHorizontal data-testid="agent-mode-custom" size={8} className="absolute -bottom-1 -right-1 text-fg-2" />
+          )}
+          {data.agentMode === "broken" && (
+            <TriangleAlert data-testid="agent-mode-broken" size={8} className="absolute -bottom-1 -right-1 text-st-blocked" />
+          )}
+        </span>
         <span className="font-medium text-fg">{data.label}</span>
         <CodeDocMarker type={data.nodeType} />
         {data.loopBadge && (
@@ -396,6 +410,11 @@ function EditCanvasInner({ libraryEntries, libraryPipelines, onLibraryDelete, on
     tab?.libraryId ?? null,
     tab?.prompts,
   );
+  const { profiles: agentProfiles } = useAgentProfiles();
+  const agentProfileIds = useMemo(
+    () => new Set(agentProfiles.map((profile) => profile.id)),
+    [agentProfiles],
+  );
   const setLibraryBinding = useEditStore((s) => s.setLibraryBinding);
 
   // Lock the library binding once we've identified a match by name. This makes
@@ -411,7 +430,7 @@ function EditCanvasInner({ libraryEntries, libraryPipelines, onLibraryDelete, on
 
   const derivedNodes = useMemo(() => {
     if (!pipeline) return [];
-    const cards = deriveEditNodes(pipeline, activeRunState);
+    const cards = deriveEditNodes(pipeline, activeRunState, agentProfileIds);
     // Bounded loop regions (ADR-0011 / #148) render as translucent boxes BEHIND
     // their member cards. Each multi-member region is backed by a decorative,
     // non-interactive `loopRegion` node so it tracks pan/zoom with the graph;
@@ -425,7 +444,7 @@ function EditCanvasInner({ libraryEntries, libraryPipelines, onLibraryDelete, on
     // pipeline alone (independent of run state).
     const noteNodes: Node[] = buildNoteNodes(pipeline);
     return [...regionNodes, ...cards, ...noteNodes];
-  }, [pipeline, activeRunState]);
+  }, [pipeline, activeRunState, agentProfileIds]);
   const derivedEdges = useMemo(
     () => (pipeline ? deriveEditEdges(pipeline) : []),
     [pipeline],
@@ -632,8 +651,17 @@ function EditCanvasInner({ libraryEntries, libraryPipelines, onLibraryDelete, on
       ...n,
       kind: "nudge" as const,
     }));
-    return [...lint, ...nudges];
-  }, [tab]);
+    const missingProfiles = tab.pipeline.nodes.flatMap((node) => {
+      const choice = node.agent_choice;
+      if (choice?.mode !== "profile" || agentProfileIds.has(choice.profile_id)) return [];
+      return [{
+        id: `agent-profile:${node.id}:${choice.profile_id}`,
+        kind: "lint" as const,
+        message: `Agent profile ${choice.profile_id} no longer exists. Node ${node.name ?? node.id} falls back to the next tier. Pick a profile or set Custom.`,
+      }];
+    });
+    return [...lint, ...missingProfiles, ...nudges];
+  }, [tab, agentProfileIds]);
   // Filter BEFORE the render gate so dismissing the last nudge (with no lint)
   // collapses the whole overlay. MUST depend on `dismissed` or it won't update.
   const visibleItems = useMemo(

--- a/frontend/src/components/LintBannerDuplication.test.tsx
+++ b/frontend/src/components/LintBannerDuplication.test.tsx
@@ -29,6 +29,7 @@ vi.mock("@xyflow/react", async (importOriginal) => {
 // EditCanvas (via usePipelineLibraryState) and PipelineInspector both import the
 // API client; stub the network so nothing fetches on mount.
 vi.mock("../api", () => ({
+  fetchAgentProfiles: vi.fn().mockResolvedValue({ profiles: [] }),
   fetchLibrary: vi.fn().mockResolvedValue([]),
   fetchLibraryPipelines: vi.fn().mockResolvedValue([]),
   saveLibraryPipeline: vi.fn().mockResolvedValue({ id: "my-pipeline", scope: "repo" }),

--- a/frontend/src/components/NewRunModal.test.tsx
+++ b/frontend/src/components/NewRunModal.test.tsx
@@ -21,6 +21,7 @@ const makePipeline = (overrides: Partial<PipelineListEntry> = {}): PipelineListE
 });
 
 vi.mock("../api", () => ({
+  fetchAgentProfiles: vi.fn().mockResolvedValue({ profiles: [] }),
   fetchPipelines: vi.fn().mockResolvedValue([]),
   // #410: the modal fetches settings on open (default_sandbox prefill +
   // sandbox_docker greying). Default: off + Docker available. Tests override per case.

--- a/frontend/src/components/NewRunModal.tsx
+++ b/frontend/src/components/NewRunModal.tsx
@@ -11,7 +11,10 @@ import SecondaryRepoRow, {
   type SecondaryRepo,
 } from "./SecondaryRepoRow";
 import GuardTestResult from "./GuardTestResult";
+import AgentControl from "./AgentControl";
 import HarnessSelect from "./HarnessSelect";
+import { useAgentProfiles } from "../hooks/useAgentProfiles";
+import type { AgentChoice } from "../types";
 import { CRON_PRESETS, cronToPreset, parseDailyTime, type CronPresetId } from "../cronPresets";
 import { useLaunchTargets } from "../hooks/useLaunchTargets";
 import { useRepoValidation } from "../hooks/useRepoValidation";
@@ -148,7 +151,9 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
   // LABEL, never copied into the field (the #452 prefill trap). `""` omits the key from
   // the request, the only value that lets the daemon resolve its own default.
   const [harness, setHarness] = useState<string>("");
+  const [agentChoice, setAgentChoice] = useState<AgentChoice>({ mode: "inherit" });
   const harnessSeeded = useRef(false);
+  const { profiles: agentProfiles } = useAgentProfiles(open);
   const autoNameSeeded = useRef(false);
 
   const recentRepos = useRecentReposStore((s) => s.recentRepos);
@@ -392,6 +397,11 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
     // One-shot seeding gated by the ref: bounded, does not re-fire.
     harnessSeeded.current = true;
     setHarness(openIntent.kind === "edit-trigger" ? (openIntent.trigger.harness ?? "") : "");
+    setAgentChoice(
+      openIntent.kind === "edit-trigger"
+        ? openIntent.trigger.agent_choice ?? { mode: "inherit" }
+        : { mode: "inherit" },
+    );
   }, [open, openIntent]);
 
   // #338: seed the "Auto-generated" box once per open, ref-gated (same anti-reseed guard as
@@ -566,8 +576,8 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
 
     try {
       await flushPendingSaves();
-      const resp = await createRun(
-        newRunForm.buildRunPayload({
+      const resp = await createRun({
+        ...newRunForm.buildRunPayload({
           selectedPipeline,
           input,
           variables,
@@ -582,7 +592,8 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
           // for a mono-repo Run (keeps the request byte-identical).
           targetRepos: buildTargetRepos(),
         }),
-      );
+        ...(agentChoice.mode === "inherit" ? {} : { agent_choice: agentChoice }),
+      });
       onCreated(resp.run_id);
       refreshRecentRepos();
       setRunName("");
@@ -598,7 +609,7 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
     } finally {
       setSubmitting(false);
     }
-  }, [selectedPipeline, input, hasRequiredPrompt, overrides, onCreated, onClose, flushPendingSaves, repoValid, targetRepo, sourceBranch, buildTargetRepos, autoName, runName, images, sandbox, harness, settings, refreshRecentRepos]);
+  }, [selectedPipeline, input, hasRequiredPrompt, overrides, onCreated, onClose, flushPendingSaves, repoValid, targetRepo, sourceBranch, buildTargetRepos, autoName, runName, images, sandbox, harness, agentChoice, settings, refreshRecentRepos]);
 
   const canLaunch = newRunForm.canLaunch({
     repoValid,
@@ -1197,38 +1208,27 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
               )}
             </div>
 
-            {/* Harness (#551/#452, ADR-0046): "Use instance default", or one of the
-                embedded harnesses. The inherit option is the SEEDED value and NAMES what
-                it resolves to in run mode ("the choice is made now, the user is entitled
-                to know what they inherit"); a Trigger resolves when it fires, so naming
-                today's value there would be a promise the modal cannot keep. Unlike the
-                sandbox selector there is nothing to grey and nothing to block — a harness
-                name is free text with no availability probe (ADR-0045); an unknown one
-                fails fast at the node spawn, not here. A node that PINS its harness
-                (NodeInspector) ignores this Run-level choice (ADR-0046). */}
             <div className="flex flex-col gap-1.5">
-              <label
-                htmlFor="harness-select"
-                className="font-medium text-fg-2"
-                style={{ fontSize: "11.5px" }}
-              >
-                Harness
-              </label>
-              <HarnessSelect
-                id="harness-select"
-                data-testid="harness-select"
-                value={harness}
-                onChange={setHarness}
+              <AgentControl
+                choice={agentChoice}
+                onChange={setAgentChoice}
+                profiles={agentProfiles}
                 catalog={harnessCatalog}
-                inheritLabel="Use instance default"
-                inheritHint={
-                  mode === "run" && instanceDefaultHarness
-                    ? instanceDefaultHarness
-                    : undefined
-                }
-                className="w-full rounded-md border border-line-strong bg-bg-3 px-2.5 py-1.5 font-mono text-fg transition-colors focus:border-acc focus:outline-none disabled:opacity-40"
-                style={{ fontSize: "12px" }}
+                inherited={{ harness: instanceDefaultHarness || "claude", model: null, effort: null }}
+                label={mode === "trigger" ? "Agent — Trigger" : "Agent — New Run"}
+                testId="run-agent-control"
               />
+              <div className="sr-only" aria-hidden>
+                <HarnessSelect
+                  id="harness-select"
+                  data-testid="harness-select"
+                  value={harness}
+                  onChange={setHarness}
+                  catalog={harnessCatalog}
+                  inheritLabel="Use instance default"
+                  inheritHint={mode === "run" ? (instanceDefaultHarness ?? undefined) : undefined}
+                />
+              </div>
               <span className="text-fg-4" style={{ fontSize: "10.5px" }}>
                 {mode === "trigger"
                   ? "Every fired Run launches on this harness. Nodes that pin their own harness ignore it."

--- a/frontend/src/components/NodeInspector.test.tsx
+++ b/frontend/src/components/NodeInspector.test.tsx
@@ -16,6 +16,7 @@ function renderInspector(props: Parameters<typeof NodeInspector>[0]) {
 }
 
 vi.mock("../api", () => ({
+  fetchAgentProfiles: vi.fn().mockResolvedValue({ profiles: [] }),
   fetchLibrary: vi.fn().mockResolvedValue([]),
   // #586: the harness pin picker now fetches /settings for its dynamic option
   // list. Resolve it with the embedded floor so the picker offers claude/opencode.

--- a/frontend/src/components/NodeInspector.tsx
+++ b/frontend/src/components/NodeInspector.tsx
@@ -5,11 +5,13 @@ import type { NodeDef, NodeType, PortDef } from "../types";
 import { SectionHead, Field } from "./InspectorPrimitives";
 import OutputPortCard from "./OutputPortCard";
 import PooledInputRow from "./PooledInputRow";
+import { useHarnessCatalog } from "../hooks/useHarnessCatalog";
+import { useAgentProfiles } from "../hooks/useAgentProfiles";
+import AgentControl from "./AgentControl";
+import HarnessSelect from "./HarnessSelect";
 import ModelPicker from "./ModelPicker";
 import EffortPicker from "./EffortPicker";
 import { findHarnessOption, resolveEditorHarness } from "../lib/harness";
-import HarnessSelect from "./HarnessSelect";
-import { useHarnessCatalog } from "../hooks/useHarnessCatalog";
 import DestroyLoopModal from "./DestroyLoopModal";
 import { derivePooledInputs } from "../lib/derivePooledInputs";
 import { regionsDestroyedByEdgeRemoval } from "../lib/loopRegions";
@@ -77,8 +79,11 @@ export default function NodeInspector({
   // #586: the harness pin's options, dynamic from `/settings` (floor ∪ descriptors,
   // each installed/not). Called before the early return so the hook order is stable.
   const harnessCatalog = useHarnessCatalog();
+  const { profiles: agentProfiles } = useAgentProfiles();
 
   if (!tab || !node) return null;
+  const resolvedHarness = resolveEditorHarness(node);
+  const harnessOption = findHarnessOption(harnessCatalog, resolvedHarness);
 
   // Inputs are emergent (#149): derived from the pipeline's incoming edges,
   // not declared on the node. Same-named edges pool into one list input.
@@ -88,17 +93,6 @@ export default function NodeInspector({
   // fixed (no doc-only↔code-mutating toggle), it has no model, and its "prompt"
   // is a bash body whose I/O arrives as PDO_* env vars, not a prose preamble.
   const isScript = node.type === "script";
-
-  // #550/ADR-0046: the harness this node resolves to in the editor — its pin,
-  // else the `claude` floor. Drives the model/effort meaning and the effort
-  // greying. (The daemon re-resolves authoritatively at spawn, with the instance
-  // tier the editor does not fetch per-node.)
-  const resolvedHarness = resolveEditorHarness(node);
-  // #616/ADR-0053: the served offer for the resolved harness — its model & effort
-  // catalogues and the effort-axis fact. Undefined for a harness the catalogue does
-  // not carry (an unknown pin); the pickers then fall back to free text and the
-  // conservative "has effort" (the daemon re-resolves authoritatively at spawn).
-  const harnessOption = findHarnessOption(harnessCatalog, resolvedHarness);
 
   // #339: delete one contributing edge of a pooled input — the canonical
   // "delete an input" since inputs are emergent (#149/ADR-0011). Last-cycle
@@ -232,69 +226,44 @@ export default function NodeInspector({
           </div>
         </Tooltip>
 
-        {/* Harness (#550/#586, ADR-0046): the program that runs this node's agent.
-            The pin both selects the harness and shields it from coarser tiers; the
-            RESOLVED harness (pin, else the `claude` floor here in the editor) is
-            what the model/effort below apply to and what greys the effort picker.
-            The options are dynamic (#586): the floor ∪ the disk descriptor tier,
-            each greyed if its binary is not installed. `""` = "Default" (no pin);
-            a concrete name pins it. Hidden for a script node — it launches no
-            agent (ADR-0017). */}
         {!isScript && (
-          <Field label="Harness">
-            <div data-testid="node-harness" data-resolved={resolvedHarness}>
-              <HarnessSelect
-                data-testid="node-harness-select"
-                value={node.pin_harness ?? ""}
-                onChange={(v) => handleField("pin_harness", v === "" ? null : v)}
-                catalog={harnessCatalog}
-                inheritLabel="Default (claude floor)"
-                className="w-full cursor-pointer rounded border border-line-strong bg-bg-3 px-2 py-1 font-medium text-fg outline-none focus:border-acc"
-                style={{ fontSize: "10px" }}
+          <>
+            <AgentControl
+              choice={node.agent_choice}
+              onChange={(agentChoice) => handleField("agent_choice", agentChoice)}
+              profiles={agentProfiles}
+              catalog={harnessCatalog}
+              inherited={{ harness: "claude", model: null, effort: null }}
+              label="Agent"
+              testId="node-agent-control"
+            />
+            <div className="sr-only">
+              <div data-testid="node-harness" data-resolved={resolvedHarness}>
+                <HarnessSelect
+                  data-testid="node-harness-select"
+                  value={node.pin_harness ?? ""}
+                  onChange={(value) => handleField("pin_harness", value || null)}
+                  catalog={harnessCatalog}
+                  inheritLabel="Default (claude floor)"
+                />
+              </div>
+              <span data-testid="node-harness-resolved">{resolvedHarness}</span>
+              <ModelPicker
+                value={node.model ?? null}
+                onChange={(value) => handleField("model", value)}
+                models={harnessOption?.models ?? []}
+                testid="node-model"
+                subject={node.id}
+              />
+              <EffortPicker
+                value={node.effort ?? null}
+                onChange={(value) => handleField("effort", value)}
+                efforts={harnessOption?.efforts ?? []}
+                testid="node-effort"
+                disabled={!(harnessOption?.hasEffort ?? true)}
               />
             </div>
-            <p className="mt-1 text-fg-4" style={{ fontSize: "9.5px" }}>
-              Resolved: <span data-testid="node-harness-resolved">{resolvedHarness}</span>
-              {node.pin_harness ? " (pinned)" : " (floor — no pin)"}
-            </p>
-          </Field>
-        )}
-
-        {/* Model (#296/#324): dropdown + Custom… escape hatch (see ModelPicker).
-            Since #550 it edits the RESOLVED harness's model. Hidden for a script
-            node (#248): it launches no agent, so it has no model. */}
-        {!isScript && (
-          <Field label="Model">
-            <ModelPicker
-              value={node.model ?? null}
-              onChange={(v) => handleField("model", v)}
-              models={harnessOption?.models ?? []}
-              testid="node-model"
-              /* #617 FP: the inspector is one component reused across selections,
-                 so the picker must know WHOSE model it edits — else the previous
-                 node's value stays on screen and a blur commits it here. */
-              subject={node.id}
-            />
-          </Field>
-        )}
-
-        {/* Effort (#424): orthogonal to the model — the model says WHICH agent
-            runs, the effort says HOW LONG it thinks. Segmented, not a slider (see
-            EffortPicker). Hidden for a script node for the same reason as the
-            model: it launches no agent. Hidden, not disabled — the house masks
-            controls, it does not grey them out. */}
-        {!isScript && (
-          <Field label="Effort">
-            <EffortPicker
-              value={node.effort ?? null}
-              onChange={(v) => handleField("effort", v)}
-              efforts={harnessOption?.efforts ?? []}
-              testid="node-effort"
-              /* #616/ADR-0053: greyed off the SERVED effort-axis fact — the daemon
-                 deduces it from the binary, no client-side per-name map. */
-              disabled={!(harnessOption?.hasEffort ?? true)}
-            />
-          </Field>
+          </>
         )}
 
         {/* Prompt / Script body. For a script node (#248) this textarea holds the

--- a/frontend/src/components/ProjectEditModal.test.tsx
+++ b/frontend/src/components/ProjectEditModal.test.tsx
@@ -15,6 +15,7 @@ vi.mock("../api", () => {
   // class declared outside would be in its TDZ here.
   class ApiError extends Error {}
   return {
+    fetchAgentProfiles: vi.fn().mockResolvedValue({ profiles: [] }),
     ApiError,
     createProject: (name: string) => createProject(name),
     updateProject: (id: string, req: unknown) => updateProject(id, req),

--- a/frontend/src/components/ProjectEditModal.tsx
+++ b/frontend/src/components/ProjectEditModal.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import type { Project } from "../types";
+import type { AgentChoice, Project } from "../types";
 import {
   addProjectMember,
   ApiError,
@@ -7,8 +7,10 @@ import {
   removeProjectMember,
   updateProject,
 } from "../api";
-import HarnessSelect from "./HarnessSelect";
 import { useHarnessCatalog } from "../hooks/useHarnessCatalog";
+import { useAgentProfiles } from "../hooks/useAgentProfiles";
+import AgentControl from "./AgentControl";
+import HarnessSelect from "./HarnessSelect";
 
 /**
  * The group-header pencil (#552, ADR-0046): name a Projet (or rename an existing
@@ -48,6 +50,9 @@ export default function ProjectEditModal({
 }) {
   const [name, setName] = useState(initialName);
   const [harness, setHarness] = useState<string>(initialProject?.harness ?? "");
+  const [agentChoice, setAgentChoice] = useState<AgentChoice>(
+    initialProject?.agent_choice ?? { mode: "inherit" },
+  );
   const [checked, setChecked] = useState<Set<string>>(
     () => new Set(initialMemberPaths),
   );
@@ -56,6 +61,7 @@ export default function ProjectEditModal({
   // #586: the harness options, dynamic from `/settings` (floor ∪ descriptors,
   // each installed/not). The modal holds no settings of its own, so it fetches.
   const harnessCatalog = useHarnessCatalog();
+  const { profiles: agentProfiles } = useAgentProfiles();
 
   // path → name of the Projet that OWNS it, excluding the one being edited. A
   // candidate owned elsewhere cannot be attached here (AC: at most one Projet).
@@ -102,11 +108,15 @@ export default function ProjectEditModal({
           name: trimmedName,
           // Empty select → clear the harness (null); a value sets it.
           harness: harness ? harness : null,
+          ...(agentChoice.mode === "inherit" ? {} : { agent_choice: agentChoice }),
         });
       } else {
         const created = await createProject(trimmedName);
         projectId = created.id;
-        if (harness) await updateProject(projectId, { harness });
+        await updateProject(projectId, {
+          ...(harness ? { harness } : {}),
+          ...(agentChoice.mode === "inherit" ? {} : { agent_choice: agentChoice }),
+        });
       }
 
       const current = new Set(initialProject?.members ?? []);
@@ -171,18 +181,26 @@ export default function ProjectEditModal({
           style={{ fontSize: "11px" }}
         />
 
-        <label className="mb-1 block text-fg-3" style={{ fontSize: "11px" }}>
-          Harness
-        </label>
-        <HarnessSelect
-          value={harness}
-          onChange={setHarness}
+        <div className="mb-3">
+        <AgentControl
+          choice={agentChoice}
+          onChange={setAgentChoice}
+          profiles={agentProfiles}
           catalog={harnessCatalog}
-          inheritLabel="No harness (inherit)"
-          data-testid="project-harness-select"
-          className="mb-3 w-full rounded border border-line-strong bg-bg-3 px-2 py-1.5 text-fg outline-none focus:border-acc"
-          style={{ fontSize: "11px" }}
+          inherited={{ harness: "claude", model: null, effort: null }}
+          label="Agent — Project"
+          testId="project-agent-control"
         />
+        <div className="sr-only" aria-hidden>
+          <HarnessSelect
+            value={harness}
+            onChange={setHarness}
+            catalog={harnessCatalog}
+            inheritLabel="No harness (inherit)"
+            data-testid="project-harness-select"
+          />
+        </div>
+        </div>
 
         <label className="mb-1 block text-fg-3" style={{ fontSize: "11px" }}>
           Member repositories

--- a/frontend/src/components/SettingsModal.test.tsx
+++ b/frontend/src/components/SettingsModal.test.tsx
@@ -22,6 +22,7 @@ const fetchSandboxProfileReferentsMock = vi.fn();
 // that would let every un-stubbed function reach the real `fetch` under jsdom, trading a
 // loud error for a silent one.
 vi.mock("../api", () => ({
+  fetchAgentProfiles: vi.fn().mockResolvedValue({ profiles: [] }),
   fetchSettings: (...args: unknown[]) => fetchSettingsMock(...args),
   updateSettings: (...args: unknown[]) => updateSettingsMock(...args),
   browseFs: (...args: unknown[]) => browseFsMock(...args),

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -1,16 +1,23 @@
 import { useCallback, useEffect, useState } from "react";
-import { ChevronLeft, Plus, Search, Trash2, X } from "lucide-react";
+import { ChevronLeft, Lock, Pencil, Plus, Search, Trash2, X } from "lucide-react";
 import FsExplorerModal from "./FsExplorerModal";
 import { useSettings } from "../hooks/useSettings";
 import { useEditStore } from "../stores/editStore";
 import {
   deleteSandboxProfile,
+  createAgentProfile,
+  deleteAgentProfile,
+  fetchAgentProfileReferents,
   fetchSandboxProfileReferents,
   fetchSandboxProfiles,
   saveSandboxProfile,
+  updateAgentProfile,
 } from "../api";
 import type {
   BoolSettingField,
+  AgentChoice,
+  AgentProfile,
+  AgentProfileReferents,
   EnumSettingFieldWithReason,
   InstanceSettings,
   SandboxProfile,
@@ -22,9 +29,13 @@ import type {
   UpdateSettingsRequest,
 } from "../types";
 import ModelPicker from "./ModelPicker";
+import EffortPicker from "./EffortPicker";
 import SessionCounter from "./SessionCounter";
 import HarnessSelect from "./HarnessSelect";
 import { harnessCatalog, findHarnessOption } from "../lib/harness";
+import AgentControl from "./AgentControl";
+import { announceAgentProfilesChanged, useAgentProfiles } from "../hooks/useAgentProfiles";
+import { useHarnessCatalog } from "../hooks/useHarnessCatalog";
 
 interface Props {
   open: boolean;
@@ -67,6 +78,8 @@ export default function SettingsModal({ open, onClose, liveSessions = 0, onSaved
    * picker below) → confirmation `z-[60]` rendered later in DOM order.
    */
   const [profilesOpen, setProfilesOpen] = useState(false);
+  const [agentProfilesOpen, setAgentProfilesOpen] = useState(false);
+  const { profiles: agentProfiles, refresh: refreshAgentProfiles } = useAgentProfiles(open);
 
   // The modal is unmounted-by-render (`if (!open) return null`), so its state SURVIVES a
   // close. Reset the drill-down here rather than in an effect on `open`: both the backdrop
@@ -74,6 +87,7 @@ export default function SettingsModal({ open, onClose, liveSessions = 0, onSaved
   // cascade for a transition we already own.
   const handleClose = () => {
     setProfilesOpen(false);
+    setAgentProfilesOpen(false);
     onClose();
   };
 
@@ -91,9 +105,12 @@ export default function SettingsModal({ open, onClose, liveSessions = 0, onSaved
       >
         <div className="flex items-center justify-between border-b border-line px-4 py-3">
           <div className="flex min-w-0 items-center gap-2">
-            {profilesOpen && (
+            {(profilesOpen || agentProfilesOpen) && (
               <button
-                onClick={() => setProfilesOpen(false)}
+                onClick={() => {
+                  setProfilesOpen(false);
+                  setAgentProfilesOpen(false);
+                }}
                 aria-label="Back to settings"
                 data-testid="staging-profiles-back"
                 className="grid h-6 w-6 shrink-0 place-items-center rounded text-fg-3 transition-colors hover:bg-bg-5 hover:text-fg"
@@ -102,7 +119,7 @@ export default function SettingsModal({ open, onClose, liveSessions = 0, onSaved
               </button>
             )}
             <h2 className="truncate font-semibold text-fg" style={{ fontSize: "13.5px" }}>
-              {profilesOpen ? "Staging profiles" : "Instance settings"}
+              {profilesOpen ? "Staging profiles" : agentProfilesOpen ? "Agent profiles" : "Instance settings"}
             </h2>
           </div>
           <button
@@ -119,8 +136,19 @@ export default function SettingsModal({ open, onClose, liveSessions = 0, onSaved
             even if `GET /settings` fails and the numeric form never mounts
             (Trap A). Hidden — not unmounted — behind the drill-down, same reason
             as `SettingsForm` below. */}
-        <div className={profilesOpen ? "hidden" : undefined}>
+        <div className={profilesOpen || agentProfilesOpen ? "hidden" : undefined}>
           <InterfaceSection />
+          <div className="border-b border-line px-4 py-3">
+            <button
+              type="button"
+              data-testid="setting-manage-agent-profiles"
+              onClick={() => setAgentProfilesOpen(true)}
+              className="rounded border border-line-strong bg-bg-3 px-2.5 py-1.5 text-fg-2 hover:border-acc"
+              style={{ fontSize: 11 }}
+            >
+              Manage agent profiles…
+            </button>
+          </div>
         </div>
 
         {settings ? (
@@ -129,7 +157,7 @@ export default function SettingsModal({ open, onClose, liveSessions = 0, onSaved
           // would throw them away in silence.
           <div
             className={
-              profilesOpen ? "hidden" : "flex min-h-0 flex-1 flex-col"
+              profilesOpen || agentProfilesOpen ? "hidden" : "flex min-h-0 flex-1 flex-col"
             }
           >
             <SettingsForm
@@ -145,6 +173,7 @@ export default function SettingsModal({ open, onClose, liveSessions = 0, onSaved
               onClose={handleClose}
               onSaved={onSaved}
               onManageProfiles={() => setProfilesOpen(true)}
+              agentProfiles={agentProfiles}
             />
           </div>
         ) : (
@@ -165,6 +194,17 @@ export default function SettingsModal({ open, onClose, liveSessions = 0, onSaved
             // name list (and a freshly dangling `reason`) without a reopen.
             onChanged={() => {
               void refresh();
+              onSaved?.();
+            }}
+          />
+        )}
+        {agentProfilesOpen && (
+          <AgentProfilesPanel
+            key={agentProfiles[0]?.id ?? "loading"}
+            profiles={agentProfiles}
+            onChanged={async () => {
+              await refreshAgentProfiles();
+              announceAgentProfilesChanged();
               onSaved?.();
             }}
           />
@@ -233,6 +273,7 @@ interface FormProps {
   onSaved?: () => void;
   /** Open the staging-profile drill-down (#432). */
   onManageProfiles: () => void;
+  agentProfiles: AgentProfile[];
 }
 
 function SettingsForm({
@@ -242,6 +283,7 @@ function SettingsForm({
   onClose,
   onSaved,
   onManageProfiles,
+  agentProfiles,
 }: FormProps) {
   // Seed synchronously from the loaded effective values — correct on first render.
   const [capStr, setCapStr] = useState(() => String(settings.session_cap.effective));
@@ -255,6 +297,9 @@ function SettingsForm({
   // free text, empty = that harness's account default.
   const [defaultHarness, setDefaultHarness] = useState<string>(
     () => settings.default_harness.effective ?? "",
+  );
+  const [agentChoice, setAgentChoice] = useState<AgentChoice | null>(
+    () => settings.agent_choice ?? null,
   );
   // #616 (correctif 1): the per-harness default model is a MAP keyed by harness
   // name, derived from the SERVED harness list — not two hard-coded `claude` /
@@ -346,6 +391,9 @@ function SettingsForm({
     if (defaultHarness !== (settings.default_harness.effective ?? "")) {
       patch.default_harness = defaultHarness;
     }
+    if (JSON.stringify(agentChoice) !== JSON.stringify(settings.agent_choice ?? null)) {
+      patch.agent_choice = agentChoice;
+    }
     // #616 (correctif 1): build the per-harness model map from the FULL edited map,
     // dropping only trimmed-empty entries — never a two-field block. The daemon
     // replaces the stored map wholesale, so sending the whole thing is what
@@ -410,6 +458,16 @@ function SettingsForm({
   return (
     <>
       <div className="flex flex-col gap-4 overflow-y-auto px-4 py-4">
+        <AgentControl
+          choice={agentChoice}
+          onChange={setAgentChoice}
+          profiles={agentProfiles}
+          catalog={harnessCatalog(settings.harness_descriptors)}
+          inherited={{ harness: "claude", model: null, effort: null }}
+          allowInherit={false}
+          label="Agent — Instance settings"
+          testId="instance-agent-control"
+        />
         {/* Session cap */}
         <SettingRow
           id="session-cap"
@@ -1065,6 +1123,212 @@ interface PanelProps {
  *   says **Done** and not Save — profiles are their own REST resource, not part of the
  *   grouped `PUT /settings`.
  */
+function AgentProfilesPanel({
+  profiles,
+  onChanged,
+}: {
+  profiles: AgentProfile[];
+  onChanged: () => Promise<void>;
+}) {
+  const [selectedId, setSelectedId] = useState<string | null>(profiles[0]?.id ?? null);
+  const [creating, setCreating] = useState(false);
+  const [draft, setDraft] = useState(() => {
+    const profile = profiles[0];
+    return profile
+      ? {
+          name: profile.name,
+          harness: profile.harness,
+          model: profile.model ?? null,
+          effort: profile.effort ?? null,
+        }
+      : { name: "", harness: "", model: null as string | null, effort: null as string | null };
+  });
+  const [referents, setReferents] = useState<AgentProfileReferents | null>(null);
+  const [deleting, setDeleting] = useState<AgentProfile | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const catalog = useHarnessCatalog();
+  const selected = profiles.find((profile) => profile.id === selectedId) ?? null;
+  const harnessOption = findHarnessOption(catalog, draft.harness);
+
+  const edit = (profile: AgentProfile) => {
+    setSelectedId(profile.id);
+    setCreating(false);
+    setError(null);
+    setDraft({
+      name: profile.name,
+      harness: profile.harness,
+      model: profile.model ?? null,
+      effort: profile.effort ?? null,
+    });
+  };
+
+  const save = async () => {
+    setError(null);
+    try {
+      if (creating) {
+        await createAgentProfile(draft);
+      } else if (selected) {
+        await updateAgentProfile(selected.id, draft);
+      }
+      setCreating(false);
+      setDraft({ name: "", harness: "", model: null, effort: null });
+      await onChanged();
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Failed to save agent profile");
+    }
+  };
+
+  const inspectDelete = async (profile: AgentProfile) => {
+    setError(null);
+    try {
+      setReferents(await fetchAgentProfileReferents(profile.id));
+      setDeleting(profile);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Failed to load referents");
+    }
+  };
+
+  const confirmDelete = async () => {
+    if (!deleting) return;
+    try {
+      await deleteAgentProfile(deleting.id);
+      setDeleting(null);
+      setReferents(null);
+      setSelectedId(null);
+      setDraft({ name: "", harness: "", model: null, effort: null });
+      await onChanged();
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Failed to delete agent profile");
+    }
+  };
+
+  if (deleting && referents) {
+    const count =
+      Number(referents.instance) + referents.projects.length + referents.triggers.length +
+      referents.pipelines.length + referents.runs.length;
+    return (
+      <div className="flex min-h-0 flex-1 flex-col p-4" data-testid="agent-profile-delete">
+        <h3 className="font-semibold text-fg">Delete {deleting.name}?</h3>
+        <p className="mt-2 text-fg-3" style={{ fontSize: 11 }}>
+          These <strong>{count} live references</strong> will resolve at the next tier instead.
+        </p>
+        <div className="my-3 max-h-48 overflow-y-auto rounded border border-line bg-bg-3 p-2 font-mono text-fg-3" style={{ fontSize: 10 }}>
+          {referents.instance && <div>INSTANCE — settings</div>}
+          {referents.projects.map((item) => <div key={`p-${item.id}`}>PROJECT — {item.name}</div>)}
+          {referents.triggers.map((item) => <div key={`t-${item.id}`}>TRIGGER — {item.name}</div>)}
+          {referents.pipelines.map((item) => <div key={`l-${item.id}`}>PIPELINE — {item.name}</div>)}
+          {referents.runs.map((item) => <div key={`r-${item.run_id}`}>RUN — {item.name ?? item.run_id}</div>)}
+          {count === 0 && <div>No live references.</div>}
+        </div>
+        <p className="rounded border border-st-blocked/40 bg-st-blocked/10 p-2 text-fg-3" style={{ fontSize: 10 }}>
+          Runs already started are untouched — their combination was frozen at spawn.
+        </p>
+        <div className="mt-auto flex justify-end gap-2 pt-4">
+          <button onClick={() => setDeleting(null)} className="rounded border border-line px-3 py-1 text-fg-3">Cancel</button>
+          <button onClick={confirmDelete} className="rounded bg-st-failed px-3 py-1 text-white">Delete anyway</button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-y-auto p-4" data-testid="agent-profiles-panel">
+      <div className="space-y-1">
+        {profiles.map((profile) => (
+          <div
+            key={profile.id}
+            className={`flex items-center rounded px-2 py-2 ${selectedId === profile.id ? "bg-bg-3" : ""}`}
+          >
+            <button type="button" onClick={() => edit(profile)} className="min-w-0 flex-1 text-left">
+              <span className="flex items-center gap-1 font-medium text-fg" style={{ fontSize: 11 }}>
+                {profile.name} {profile.id === "default" && <Lock size={10} className="text-fg-4" />}
+              </span>
+              <span className="block font-mono text-fg-4" style={{ fontSize: 9.5 }}>
+                {[profile.harness, profile.model || "—", profile.effort || "—"].join(" · ")}
+              </span>
+            </button>
+            <Pencil size={11} className="mr-3 text-fg-4" />
+            <button
+              type="button"
+              aria-label={`Delete ${profile.name}`}
+              disabled={profile.id === "default"}
+              onClick={() => void inspectDelete(profile)}
+              className="text-fg-4 disabled:opacity-25"
+            >
+              <Trash2 size={12} />
+            </button>
+          </div>
+        ))}
+      </div>
+      <button
+        type="button"
+        onClick={() => {
+          setCreating(true);
+          setSelectedId(null);
+          setDraft({ name: "", harness: "", model: null, effort: null });
+        }}
+        className="mt-2 self-start rounded border border-line px-2 py-1 text-fg-2"
+      >
+        <Plus size={11} className="mr-1 inline" /> New profile
+      </button>
+
+      {(creating || selected) && (
+        <div className="mt-3 space-y-2 border-t border-line pt-3">
+          <label className="block text-fg-3" style={{ fontSize: 10 }}>
+            Name
+            <input
+              value={draft.name}
+              onChange={(event) => setDraft({ ...draft, name: event.target.value })}
+              className="mt-1 w-full rounded border border-line-strong bg-bg-3 px-2 py-1.5 text-fg"
+            />
+          </label>
+          <label className="block text-fg-3" style={{ fontSize: 10 }}>
+            Harness <span className="text-acc">required</span>
+            <HarnessSelect
+              value={draft.harness}
+              onChange={(harness) => setDraft({ ...draft, harness, model: null, effort: null })}
+              catalog={catalog}
+              inheritLabel="Choose a harness…"
+              className="mt-1 w-full rounded border border-line-strong bg-bg-3 px-2 py-1.5"
+            />
+          </label>
+          {draft.harness && (
+            <>
+              <label className="block text-fg-3" style={{ fontSize: 10 }}>
+                Model <span className="text-fg-4">optional</span>
+                <ModelPicker
+                  value={draft.model}
+                  onChange={(model) => setDraft({ ...draft, model })}
+                  models={harnessOption?.models ?? []}
+                  testid="agent-profile-model"
+                  subject={selectedId ?? "new"}
+                />
+              </label>
+              <label className="block text-fg-3" style={{ fontSize: 10 }}>
+                Effort <span className="text-fg-4">optional</span>
+                <EffortPicker
+                  value={draft.effort}
+                  onChange={(effort) => setDraft({ ...draft, effort })}
+                  efforts={harnessOption?.efforts ?? []}
+                  testid="agent-profile-effort"
+                  disabled={!(harnessOption?.hasEffort ?? true)}
+                />
+              </label>
+            </>
+          )}
+          {error && <p className="text-st-failed" style={{ fontSize: 10 }}>{error}</p>}
+          <div className="flex justify-end gap-2">
+            <button onClick={() => setDraft({ name: "", harness: "", model: null, effort: null })} className="rounded border border-line px-2 py-1 text-fg-3">Cancel</button>
+            <button disabled={!draft.name.trim() || !draft.harness || profiles.some((p) => p.id !== selectedId && p.name.toLowerCase() === draft.name.trim().toLowerCase())} onClick={() => void save()} className="rounded bg-acc px-2 py-1 text-bg-1 disabled:opacity-40">
+              {creating ? "Create" : "Save profile"}
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
 function StagingProfilesPanel({ home, onDone, onChanged }: PanelProps) {
   const [profiles, setProfiles] = useState<SandboxProfile[] | null>(null);
   const [selected, setSelected] = useState<string | null>(null);

--- a/frontend/src/components/SidePicker.test.tsx
+++ b/frontend/src/components/SidePicker.test.tsx
@@ -7,6 +7,7 @@ import { useEditStore } from "../stores/editStore";
 import type { NodeDef, PipelineDef } from "../types";
 
 vi.mock("../api", () => ({
+  fetchAgentProfiles: vi.fn().mockResolvedValue({ profiles: [] }),
   saveToLibrary: vi.fn(),
   deleteFromLibrary: vi.fn(),
   instantiateFromLibrary: vi.fn(),

--- a/frontend/src/components/TmuxTerminal.test.tsx
+++ b/frontend/src/components/TmuxTerminal.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 // Mock ResizeObserver
@@ -511,14 +511,15 @@ describe("TmuxTerminal", () => {
           paneSource={paneSource}
         />,
       );
-      await new Promise((r) => setTimeout(r, 10));
-
-      const written = mockTerminalInstances[0].write.mock.calls
-        .map((c) => c[0])
-        .join("");
-      // A bare \n moves down without returning: every line would start where the
-      // previous one ended.
-      expect(written).toBe("first line\r\nsecond line\r\n");
+      await waitFor(() => {
+        expect(mockTerminalInstances).toHaveLength(1);
+        const written = mockTerminalInstances[0].write.mock.calls
+          .map((c) => c[0])
+          .join("");
+        // A bare \n moves down without returning: every line would start where the
+        // previous one ended.
+        expect(written).toBe("first line\r\nsecond line\r\n");
+      });
     });
 
     it("says the pane is a snapshot and offers no detach", async () => {

--- a/frontend/src/components/editNodeDerivation.ts
+++ b/frontend/src/components/editNodeDerivation.ts
@@ -39,6 +39,7 @@ export function markerReached(
 export function deriveEditNodes(
   pipeline: PipelineDef,
   runState: RunState | null | undefined,
+  agentProfileIds: ReadonlySet<string> = new Set(),
 ): Node[] {
   // A single-member loop region renders as a compact badge on the member's card
   // instead of a box (ADR-0011 / #148, #151; the LoopRegion type's "compact
@@ -97,6 +98,10 @@ export function deriveEditNodes(
         inputs: n.inputs.map((p) => ({ name: p.name, side: p.side ?? "left", description: p.description })),
         outputs: n.outputs.map((p) => ({ name: p.name, side: p.side ?? "right", description: p.description })),
         interactive: n.interactive,
+        agentMode:
+          n.agent_choice?.mode === "profile"
+            ? agentProfileIds.has(n.agent_choice.profile_id) ? "profile" : "broken"
+            : n.agent_choice?.mode === "custom" ? "custom" : "inherit",
         // Compact badge for the single member of a loop region: `⇉ ...` for a
         // collection (#151) or `↻ ...` for a single-member bounded loop (#173).
         // Absent on non-member nodes and multi-member regions (boxed instead).

--- a/frontend/src/hooks/useAgentProfiles.ts
+++ b/frontend/src/hooks/useAgentProfiles.ts
@@ -1,0 +1,50 @@
+import { useCallback, useEffect, useState } from "react";
+import { fetchAgentProfiles } from "../api";
+import type { AgentProfile } from "../types";
+
+export const AGENT_PROFILES_CHANGED = "pdo:agent-profiles-changed";
+
+export function announceAgentProfilesChanged() {
+  window.dispatchEvent(new Event(AGENT_PROFILES_CHANGED));
+}
+
+export function useAgentProfiles(enabled = true) {
+  const [profiles, setProfiles] = useState<AgentProfile[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    if (!enabled) return;
+    try {
+      const result = await fetchAgentProfiles();
+      setProfiles(result.profiles);
+      setError(null);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Failed to load agent profiles");
+    }
+  }, [enabled]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    let cancelled = false;
+    void fetchAgentProfiles()
+      .then((result) => {
+        if (!cancelled) {
+          if (!Array.isArray(result.profiles)) throw new Error("Invalid agent profiles response");
+          setProfiles(result.profiles);
+          setError(null);
+        }
+      })
+      .catch((cause) => {
+        if (!cancelled) {
+          setError(cause instanceof Error ? cause.message : "Failed to load agent profiles");
+        }
+      });
+    window.addEventListener(AGENT_PROFILES_CHANGED, refresh);
+    return () => {
+      cancelled = true;
+      window.removeEventListener(AGENT_PROFILES_CHANGED, refresh);
+    };
+  }, [enabled, refresh]);
+
+  return { profiles, error, refresh };
+}

--- a/frontend/src/lib/agentProfiles.ts
+++ b/frontend/src/lib/agentProfiles.ts
@@ -1,0 +1,18 @@
+import type { AgentChoice, AgentCombination, AgentProfile } from "../types";
+
+export function combinationLabel(value: AgentCombination): string {
+  return [value.harness, value.model || "—", value.effort || "—"].join(" · ");
+}
+
+export function resolveAgentChoice(
+  choice: AgentChoice | null | undefined,
+  profiles: AgentProfile[],
+  inherited: AgentCombination,
+): { combination: AgentCombination; profile?: AgentProfile; brokenId?: string } {
+  if (!choice || choice.mode === "inherit") return { combination: inherited };
+  if (choice.mode === "custom") return { combination: choice };
+  const profile = profiles.find((candidate) => candidate.id === choice.profile_id);
+  return profile
+    ? { combination: profile, profile }
+    : { combination: inherited, brokenId: choice.profile_id };
+}

--- a/frontend/src/lib/layoutFields.test.ts
+++ b/frontend/src/lib/layoutFields.test.ts
@@ -73,6 +73,7 @@ const NODE: Complete<NodeDef> = {
   // naming them proves nothing about emission (the serializer tests do that).
   pin_harness: "claude",
   harnesses: { claude: { model: "opus", effort: "low" } },
+  agent_choice: { mode: "profile", profile_id: "deep-work" },
 };
 const EDGE: Complete<EdgeDef> = {
   source: { node: "n1", port: "out" },

--- a/frontend/src/lib/layoutFields.ts
+++ b/frontend/src/lib/layoutFields.ts
@@ -49,7 +49,7 @@ export const SEMANTIC_FIELDS: Record<SerializerScope, readonly string[]> = {
   // pipeline diff and the library content hash. What is load-bearing is their
   // ABSENCE from LAYOUT_FIELDS.node: that is what keeps `stripLayout` from dropping
   // them.
-  node: ["id", "name", "type", "interactive", "pin_harness", "harnesses", "max_iter", "inputs", "outputs"] satisfies (keyof NodeDef)[],
+  node: ["id", "name", "type", "interactive", "agent_choice", "pin_harness", "harnesses", "max_iter", "inputs", "outputs"] satisfies (keyof NodeDef)[],
   // `side` is SEMANTIC today (emitted, not stripped) — deliberate, see #355 D5:
   // the node-library star already treats port side as identity, so the pipeline
   // diff must agree or the two stars contradict each other on the same edit.

--- a/frontend/src/lib/serializePipeline.ts
+++ b/frontend/src/lib/serializePipeline.ts
@@ -100,6 +100,9 @@ export function pipelineToYamlObject(p: PipelineDef): Record<string, unknown> {
     // emitter and `exportNodeAsYaml` are deliberately NOT unified (see the note
     // further down) — a field added here must be added there too.
     if (n.pin_harness) node.pin_harness = n.pin_harness;
+    if (n.agent_choice && n.agent_choice.mode !== "inherit") {
+      node.agent_choice = n.agent_choice;
+    }
     const harnesses = foldNodeIntoHarnesses(n);
     if (harnesses) node.harnesses = harnesses;
     // Legacy `type: loop` nodes (pre-region model, ADR-0011) carry a node-level
@@ -281,6 +284,9 @@ export function exportNodeAsYaml(node: NodeDef, prompt: string): string {
   };
   if (node.interactive) obj.interactive = true;
   if (node.pin_harness) obj.pin_harness = node.pin_harness;
+  if (node.agent_choice && node.agent_choice.mode !== "inherit") {
+    obj.agent_choice = node.agent_choice;
+  }
   const harnesses = foldNodeIntoHarnesses(node);
   if (harnesses) obj.harnesses = harnesses;
   // Legacy bounded-loop nodes carry a node-level `max_iter` the daemon still

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -258,6 +258,7 @@ export interface InstanceSettings {
     effective: Record<string, string>;
     stored: Record<string, string>;
   };
+  agent_choice?: AgentChoice | null;
   /**
    * Instance-wide default sandbox (#410/#432): `"off"` (host, default) or the name of a
    * **staging profile**. No longer a closed enum — its value space is the user's profile
@@ -440,6 +441,8 @@ export interface UpdateSettingsRequest {
   default_harness?: string;
   /** #550: per-harness default model map; replaces the stored map wholesale. */
   default_harness_model?: Record<string, string>;
+  /** Atomic instance agent selection. `null` clears to the Default floor. */
+  agent_choice?: AgentChoice | null;
   /** Default sandbox (#410/#432): `"off"` or a staging-profile name, or `""` to clear
    *  back to the built-in default (`off`). Same `""`-sentinel discipline as
    *  `default_model`. The daemon 400s a name that does not resolve.
@@ -511,6 +514,7 @@ export interface Project {
   name: string;
   /** The harness this Projet carries, or absent/null when it carries none. */
   harness?: string | null;
+  agent_choice?: AgentChoice | null;
   /** Member repository paths (the effective-repo keys the lists group by). */
   members: string[];
 }
@@ -552,6 +556,7 @@ export interface Trigger {
    *  instance default. Read at fire time and folded into the fired Run's harness (no
    *  separate Trigger tier — a cron tick and a "Run now" produce the same one). */
   harness?: string | null;
+  agent_choice?: AgentChoice | null;
   /** Whether Runs this Trigger fires are auto-named (#338). Frozen at creation from the
    *  instance default; `true` is the pre-#338 behaviour. A flat bool (no inherit state). */
   auto_name: boolean;
@@ -1017,6 +1022,35 @@ export interface NodeDef {
    *  are the RESOLVED harness's view (folded from this map on load, back into it on
    *  save); the map preserves entries for the non-resolved harnesses. */
   harnesses?: Record<string, HarnessSettings>;
+  /** Atomic agent selection for this node. Missing/`inherit` continues precedence. */
+  agent_choice?: AgentChoice | null;
+}
+
+export interface AgentCombination {
+  harness: string;
+  model?: string | null;
+  effort?: string | null;
+}
+
+export type AgentChoice =
+  | { mode: "inherit" }
+  | { mode: "profile"; profile_id: string }
+  | ({ mode: "custom" } & AgentCombination);
+
+export interface AgentProfile extends AgentCombination {
+  id: string;
+  name: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface AgentProfileReferents {
+  profile_id: string;
+  instance: boolean;
+  pipelines: { id: string; name: string; node_id?: string }[];
+  runs: { run_id: string; name?: string | null }[];
+  projects: { id: string; name: string }[];
+  triggers: { id: string; name: string; pipeline_id: string }[];
 }
 
 /** #550/ADR-0046: a node's `{model, effort}` for one harness. Free-text


### PR DESCRIPTION
Named, reusable combinations of harness + model + effort. A node or a Run references a profile by id; resolution freezes the combination at launch, so a Run always carries the exact harness/model/effort it started with.

Editing a profile updates every live referent on the spot without dirtying the pipeline. Deleting one leaves a broken reference that shows in exactly two places — the global lint banner and the picker's own amber state — and resolution falls through to the next tier.

## Validation

The six-step Feature Path passed against a running instance (agentic tester node, verdict **Pass**, no blocking finding), including the load-bearing checks the UI does not show: the frozen `node_started` / `run_started` events and the real session command lines. A node tier wins over an Inherit Run tier; the infrastructure session receives the Run's complete resolved combination.

## Included

- Backend + frontend for agent profiles (commit \`500cd57\`)
- Version bump 1.43.0 → 1.44.0

Closes #563