### PR TITLE
feat(#572): les pipelines appartiennent à l'instance et voyagent par document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ ascendante** : la casse se signale ici et par un bump majeur, jamais en gardant 
 morts. Seule contrainte non négociable — les **données historiques restent lisibles** : un Run
 archivé s'ouvre et se chiffre quelle que soit la version qui a écrit son payload.
 
+## 1.46.0
+
+**Les pipelines appartiennent à l'instance et voyagent par document** (#572 ; ADR-0059). *Cassant.*
+La distinction `repo` / `user` / `library` disparaît de toutes les surfaces — liste, édition,
+sauvegarde, suppression, lancement — et `GET /library/pipelines` n'existe plus. Les pipelines des
+anciens emplacements (`.pdo/pipelines` d'un dépôt, pipelines utilisateur, `.pdo/library/pipelines`)
+sont migrés une fois au boot vers le registre de l'instance, collisions renommées, prompts inclus ;
+rien ne relit ensuite les anciens fichiers.
+
+Le partage devient explicite : l'onglet YAML d'une Pipeline — et d'un Run — expose un **Document de
+pipeline transportable** (`pdo_pipeline: 1`) avec copie et téléchargement, que la modale d'import
+reconstitue en une pipeline indépendante. Le document embarque le graphe, les positions, les notes,
+les variables et les prompts, développe les nodes partagés en nodes ordinaires, et n'emporte ni
+secret, ni environnement, ni valeur d'exécution, ni configuration d'instance : un profil agentique
+nommé revient à **Inherit**. Un document invalide ou de version inconnue est refusé sans rien créer.
+
 ## 1.45.0
 
 **Un seul fold de coût attribué pour le Run, ses Nodes et Stats** (#647 ; ADR-0058). Les coûts des

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -873,7 +873,7 @@ Le daemon bind **`0.0.0.0:<port>`** — joignable depuis le LAN, c'est **délib�
 
 Un **onglet de pipeline** = un document ouvert dans la zone centrale (un `PipelineDef` + prompts + historique d'undo). À ne pas confondre avec les onglets de **liste** du panneau gauche ni l'onglet **info** de la toolbar.
 
-- **Onglet de run** : contexte = un Run, édite le snapshot run-scope. Un onglet de **template** édite la bibliothèque.
+- **Onglet de run** : contexte = un Run, édite le snapshot run-scope. Un onglet de **pipeline** édite le registre d'instance.
 - **Mode mono-onglet** *(préférence UI, #342)* : ouvrir une pipeline **remplace** l'onglet courant. Préférence par-poste (`localStorage`), hors Configuration d'instance (ADR-0015 ne couvre pas la présentation locale). _Éviter_ : « mode document » (collision avec *document* = artefact).
 
 ### Création d'un nouveau nœud
@@ -884,21 +884,29 @@ From scratch (« + Add node »), duplicate (clic droit), drag-drop depuis la bib
 
 ## Bibliothèque
 
-`~/.pdo/library/` — store user-managed à deux niveaux :
+La **bibliothèque de nodes** contient les nodes réutilisables qu'un utilisateur peut ajouter à une Pipeline. La réutilisation reste une aide à l'édition : un Document de pipeline transportable développe chaque node partagé en node ordinaire, sans recréer son appartenance à la bibliothèque sur l'instance cible.
 
-- **Nodes** (`library/nodes/`) — nodes réutilisables, drag-drop vers le canvas. Une entrée porte le `model` et l'`effort` par-node, et est aussi la forme d'un *Export as YAML…*.
-- **Pipelines** (`library/pipelines/`) — templates complets. C'est cette liste qui peuple le dropdown « + New Run ». Le clone vers `<repo>/.pdo/runs/<run-id>/pipeline.yaml` se produit au démarrage d'un Run ; les modifs pendant un Run propagent vers la template (auto-sync montant, ADR-0007).
+_Éviter_ : « pipeline de bibliothèque » — les Pipelines appartiennent au registre d'instance, pas à la bibliothèque.
 
-- **Drift de librairie** (badge ⚠) — verdict **sémantique** : « la source a-t-elle changé de sens depuis son promote ? ». Le hash porte sur la **projection sémantique** du pipeline parsé, pas les octets (#395) : déplacer un nœud, épingler une route ou ajouter une note ne drifte pas ; renommer, changer un port, une condition, un `model` ou un `effort` drifte. Un source qui ne parse plus lit « drifté », jamais « synced ».
-- **Duplicate (library pipeline)** (#224) — clone **délié** : id frais, nom suffixé `(copy)`, aucune métadonnée de promotion, YAML réécrit verbatim sauf la ligne `name:` (préserve clés inconnues, commentaires, ordre). À distinguer de **Promote** (qui enregistre la provenance) et du duplicate de nœud sur canvas.
-- **Supprimer une pipeline ≠ supprimer sa copie en bibliothèque** (#227) — par défaut la copie favorite subsiste, visible comme entrée *library-only* (pas d'auto-cleanup). Case opt-in pour retirer aussi la copie, uniquement si non ambigu.
+### Registre de pipelines
+
+Le **registre de pipelines** est l'ensemble des Pipelines possédées par une instance PDO. Une Pipeline n'appartient ni à un dépôt ni à une bibliothèque ; le dépôt est choisi comme contexte d'un Run.
+
+**Duplicate (pipeline)** — clone indépendant dans le registre : identité fraîche, nom suffixé `(copy)` puis `(copy N)`, contenu possédé par la Pipeline conservé au maximum. À distinguer du duplicate de node sur canvas.
+
+### Document de pipeline transportable
+
+Un **Document de pipeline transportable** est la représentation YAML versionnée et interprétable qui permet de copier une Pipeline entre instances. Il conserve au maximum le graphe, les boucles, le routage, la présentation, les notes, les prompts, les déclarations et valeurs par défaut de variables, et développe les nodes partagés en nodes ordinaires.
+
+Il ne transporte ni secrets, ni environnement, ni valeurs d'exécution, ni configuration d'instance. Un choix agentique lié à un profil d'instance redevient **Inherit** ; l'identité de la Pipeline est recréée à l'import. L'import est atomique, et un document invalide ou d'une version non prise en charge est refusé avec diagnostics.
+_Éviter_ : « YAML canonique » — le format interne peut séparer des contenus que le document rassemble ; le contrat est la fidélité maximale du round-trip, pas l'identité avec le stockage interne.
 
 ---
 
 ## Import de workflow (Claude Code → pipeline)
 
 **Import de workflow** :
-Décompilation **avec perte** d'un workflow Claude Code (`.claude/workflows/*.js`) en un **brouillon de Pipeline** déposé en Bibliothèque (jamais lancé). But = **onboarding**, pas fidélité — « importe le câblage, signale le reste ». Parsing par AST statique, **jamais d'exécution du `.js`** (ADR-0016 — le daemon bind `0.0.0.0`, exécuter du JS étranger serait un RCE).
+Décompilation **avec perte** d'un workflow Claude Code (`.claude/workflows/*.js`) en un **brouillon de Pipeline** déposé dans le registre (jamais lancé). But = **onboarding**, pas fidélité — « importe le câblage, signale le reste ». Parsing par AST statique, **jamais d'exécution du `.js`** (ADR-0016 — le daemon bind `0.0.0.0`, exécuter du JS étranger serait un RCE).
 _Éviter_ : « conversion », « migration » — la **migration** réécrit du YAML PDO d'un ancien schéma vers le courant (même format) ; l'**import** traduit un format étranger.
 
 **Placeholder annoté** :
@@ -909,6 +917,7 @@ Règle de récupération des prompts : string-literal sans interpolation → ver
 
 ### Relations
 
-- Un **Import de workflow** produit un **brouillon de Pipeline** en Bibliothèque.
+- Un **Import de workflow** produit un **brouillon de Pipeline** dans le registre.
+- L'**import de Pipeline PDO** interprète un Document de pipeline transportable et crée une Pipeline indépendante ; il partage la même modale que l'Import de workflow, mais constitue un mode distinct et fidèle.
 - Idiomes mappés : `agent()` → **Node**, `pipeline()` → boucle **`collection`**, `for`/`while` autour d'un `agent()` → boucle **`bounded`**, `if`/`return` gardé → **edge conditionnelle**, schémas JSON → **frontmatter de port de sortie**.
 - Un idiome hors sous-ensemble → **placeholder annoté**. Un `git merge` scripté → Node `code-mutating` annoté, **pas** le Merge first-class (dont il excède le contrat).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "1.45.0"
+version = "1.46.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "1.45.0"
+version = "1.46.0"
 license = "MIT"
 description = "Prompt-Driven Orchestrator — a local daemon that runs and supervises agentic coding pipelines"
 repository = "https://github.com/Loulen/prompt-driven-orchestrator"

--- a/crates/pdo-daemon/src/agent_profile.rs
+++ b/crates/pdo-daemon/src/agent_profile.rs
@@ -189,11 +189,12 @@ fn generate_profile_id() -> String {
 /// All profiles, [`DEFAULT_PROFILE_ID`] first, then by creation order — a stable
 /// listing so the settings panel does not reshuffle rows on every fetch.
 pub(crate) async fn list(db: &SqlitePool) -> Result<Vec<AgentProfile>, sqlx::Error> {
-    let rows =
-        sqlx::query("SELECT * FROM agent_profiles ORDER BY (id = ?) DESC, created_at ASC, id ASC")
-            .bind(DEFAULT_PROFILE_ID)
-            .fetch_all(db)
-            .await?;
+    let rows = sqlx::query(
+        "SELECT * FROM agent_profiles ORDER BY (id = ?) DESC, created_at ASC, rowid ASC",
+    )
+    .bind(DEFAULT_PROFILE_ID)
+    .fetch_all(db)
+    .await?;
     Ok(rows.iter().map(row_to_profile).collect())
 }
 

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -96,7 +96,7 @@ use axum::extract::ws::{Message, WebSocket};
 use axum::extract::{
     FromRequest, Json, Multipart, Path as AxumPath, Query, State, WebSocketUpgrade,
 };
-use axum::http::{header, HeaderMap, StatusCode, Uri};
+use axum::http::{header, HeaderMap, Method, StatusCode, Uri};
 use axum::response::{Html, IntoResponse, Response};
 use axum::routing::{get, post};
 use axum::Router;
@@ -4419,24 +4419,10 @@ fn build_router(state: Arc<AppState>) -> Router {
             "/library/{name}/instantiate",
             post(instantiate_from_library),
         )
-        .route("/library/pipelines", get(list_library_pipelines))
-        .route("/library/pipelines", post(save_library_pipeline))
         // #155 — import a Claude Code workflow .js as a draft pipeline (user scope).
         // Static segment beside `/library/pipelines`; the `/library` vite proxy
         // prefix already covers it (no vite proxy edit).
         .route("/library/import", post(import_library_pipeline))
-        .route(
-            "/library/pipelines/{id}",
-            axum::routing::delete(delete_library_pipeline),
-        )
-        // Static segment after the `{id}` param: axum 0.8 allows this (same
-        // precedent as `/triggers/health` beside `/triggers/{trigger_id}`); the
-        // `/library` proxy prefix already covers it — no vite proxy edit (#224).
-        .route(
-            "/library/pipelines/{id}/duplicate",
-            post(duplicate_library_pipeline),
-        )
-        .route("/pipelines/{pipeline_id}/promote", post(promote_pipeline))
         .route("/repos/branches", get(repos_branches))
         .route("/repos/validate", get(repos_validate))
         .route("/repos/recent", get(repos_recent))
@@ -17855,7 +17841,11 @@ pub use tmux_session_manager::{build_tmux_script, TMUX_CMD_OVERRIDE_ENV};
 
 // --- Static file serving ---
 
-async fn static_handler(uri: Uri) -> Response {
+async fn static_handler(method: Method, uri: Uri) -> Response {
+    if method != Method::GET && method != Method::HEAD {
+        return StatusCode::NOT_FOUND.into_response();
+    }
+
     let path = uri.path().trim_start_matches('/');
 
     if path.is_empty() || path == "index.html" {
@@ -26030,123 +26020,36 @@ edges:
 
     #[tokio::test]
     #[allow(clippy::await_holding_lock)]
-    async fn promote_pipeline_copies_to_library() {
+    async fn obsolete_pipeline_library_routes_are_not_registered() {
         let fake_home = FakeHome::new();
-
         write_test_pipeline(fake_home.path(), "promotable");
         let state = test_state_with_dir(fake_home.path()).await;
         let app = build_router(state);
 
-        let resp = app
-            .oneshot(
-                Request::builder()
-                    .method("POST")
-                    .uri("/pipelines/promotable/promote")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
+        for (method, uri) in [
+            ("GET", "/library/pipelines"),
+            ("POST", "/pipelines/promotable/promote"),
+            ("POST", "/library/pipelines/promotable/duplicate"),
+            ("DELETE", "/library/pipelines/promotable"),
+        ] {
+            let resp = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .method(method)
+                        .uri(uri)
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
 
-        assert_eq!(resp.status(), StatusCode::OK);
-        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
-            .await
-            .unwrap();
-        let result: serde_json::Value = serde_json::from_slice(&body).unwrap();
-        assert_eq!(result["id"], "promotable");
-        assert_eq!(result["drifted"], false);
-
-        let lib_dir = library_store::pipelines::user_pipelines_dir().unwrap();
-        assert!(lib_dir.join("promotable.yaml").exists());
-        assert!(lib_dir.join("promotable.meta.json").exists());
-    }
-
-    #[tokio::test]
-    #[allow(clippy::await_holding_lock)]
-    async fn promote_nonexistent_pipeline_returns_error() {
-        let fake_home = FakeHome::new();
-
-        let state = test_state_with_dir(fake_home.path()).await;
-        let app = build_router(state);
-
-        let resp = app
-            .oneshot(
-                Request::builder()
-                    .method("POST")
-                    .uri("/pipelines/nonexistent/promote")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-
-        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
-    }
-
-    // #224 — POST /library/pipelines/{id}/duplicate.
-    #[tokio::test]
-    #[allow(clippy::await_holding_lock)]
-    async fn duplicate_library_pipeline_returns_201() {
-        let _fake_home = FakeHome::new();
-        // A repo root distinct from HOME so the repo-scope and user-scope library
-        // dirs do not collapse onto one path (they share a relative layout but
-        // different roots in production). Promoting writes to the HOME user dir,
-        // so the entry is genuinely user-scope.
-        let repo = tempfile::tempdir().unwrap();
-        write_test_pipeline(repo.path(), "dupable");
-        library_store::pipelines::promote(repo.path(), "dupable").unwrap();
-
-        let state = test_state_with_dir(repo.path()).await;
-        let app = build_router(state);
-
-        let resp = app
-            .oneshot(
-                Request::builder()
-                    .method("POST")
-                    .uri("/library/pipelines/dupable/duplicate")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-
-        assert_eq!(resp.status(), StatusCode::CREATED);
-        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
-            .await
-            .unwrap();
-        let result: serde_json::Value = serde_json::from_slice(&body).unwrap();
-        assert_ne!(result["id"].as_str().unwrap(), "dupable");
-        assert_eq!(result["scope"], "user");
-        assert!(result["entry"].is_object());
-
-        // The clone is a separate, unlinked file with the "(copy)" name.
-        let lib_dir = library_store::pipelines::user_pipelines_dir().unwrap();
-        let copy_id = result["id"].as_str().unwrap();
-        assert!(lib_dir.join(format!("{copy_id}.yaml")).exists());
-        assert!(!lib_dir.join(format!("{copy_id}.meta.json")).exists());
-        assert_eq!(result["entry"]["name"], "dupable (copy)");
-    }
-
-    #[tokio::test]
-    #[allow(clippy::await_holding_lock)]
-    async fn duplicate_nonexistent_library_pipeline_returns_404() {
-        let fake_home = FakeHome::new();
-
-        let state = test_state_with_dir(fake_home.path()).await;
-        let app = build_router(state);
-
-        let resp = app
-            .oneshot(
-                Request::builder()
-                    .method("POST")
-                    .uri("/library/pipelines/does-not-exist/duplicate")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-
-        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+            assert!(
+                resp.status().is_client_error(),
+                "{method} {uri} unexpectedly returned {}",
+                resp.status()
+            );
+        }
     }
 
     // #155 — POST /library/import: a Claude Code workflow .js becomes an

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -47,6 +47,7 @@ mod pipeline;
 mod pipeline_migrator;
 mod pipeline_semantics;
 mod pipeline_watcher;
+mod portable_pipeline;
 mod price_table;
 mod project_store;
 mod prompt_augmenter;
@@ -840,16 +841,6 @@ struct IterQuery {
 
 fn default_iter() -> i64 {
     1
-}
-
-/// Optional `?scope=` qualifier for the `/pipelines/{id}` open/save/delete
-/// routes. When present it pins the operation to a single store so it can never
-/// silently fall through to a same-named file in a *different* store (#216).
-/// `library` routes to the disk-first library store; `repo`/`user` resolve
-/// strictly to that store; absent keeps the historical repo-then-user default.
-#[derive(Deserialize)]
-struct ScopeQuery {
-    scope: Option<String>,
 }
 
 fn cli_daemon_url() -> String {
@@ -2707,6 +2698,10 @@ pub async fn serve_with_config(
         boot_recovery::run_boot_recovery(&state).await;
     }
 
+    #[cfg(not(test))]
+    migrate_legacy_pipelines(&state.repo_root)
+        .map_err(|error| anyhow::anyhow!("pipeline registry migration failed: {error}"))?;
+
     let app = build_router(state.clone());
 
     info!("PDO daemon listening on http://{bound_addr}");
@@ -3549,9 +3544,7 @@ async fn create_trigger(
 
     // Resolve the target pipeline and its prompt_required flag.
     let yaml =
-        library_store::pipelines::get_yaml(&state.repo_root, &req.pipeline_id).or_else(|| {
-            std::fs::read_to_string(resolve_pipeline_path(&state.repo_root, &req.pipeline_id)).ok()
-        });
+        std::fs::read_to_string(resolve_pipeline_path(&state.repo_root, &req.pipeline_id)).ok();
     let yaml = match yaml {
         Some(y) => y,
         None => {
@@ -3940,9 +3933,7 @@ async fn patch_trigger(
     if let Some(ref new_pid) = req.pipeline_id {
         if *new_pid != existing.pipeline_id {
             let yaml =
-                library_store::pipelines::get_yaml(&state.repo_root, new_pid).or_else(|| {
-                    std::fs::read_to_string(resolve_pipeline_path(&state.repo_root, new_pid)).ok()
-                });
+                std::fs::read_to_string(resolve_pipeline_path(&state.repo_root, new_pid)).ok();
             let yaml = match yaml {
                 Some(y) => y,
                 None => {
@@ -4327,6 +4318,15 @@ fn build_router(state: Arc<AppState>) -> Router {
         .route("/pipelines", get(list_pipelines))
         .route("/pipelines/{pipeline_id}", get(get_pipeline))
         .route(
+            "/pipelines/{pipeline_id}/duplicate",
+            post(duplicate_pipeline),
+        )
+        .route(
+            "/pipelines/{pipeline_id}/document",
+            get(get_pipeline_document),
+        )
+        .route("/pipelines/import", post(import_pipeline_document))
+        .route(
             "/pipelines/{pipeline_id}",
             axum::routing::put(save_pipeline).delete(delete_pipeline),
         )
@@ -4349,6 +4349,10 @@ fn build_router(state: Arc<AppState>) -> Router {
         .route("/runs/{run_id}/nodes/{node_id}/diff", get(node_diff))
         .route("/runs/{run_id}/artifact", get(artifact))
         .route("/runs/{run_id}/pipeline", get(get_run_pipeline))
+        .route(
+            "/runs/{run_id}/pipeline/document",
+            get(get_run_pipeline_document),
+        )
         .route(
             "/runs/{run_id}/repos",
             axum::routing::patch(patch_run_repos),
@@ -5290,13 +5294,11 @@ async fn trigger_live_run_count(db: &sqlx::SqlitePool, trigger_id: &str) -> usiz
 /// Load a Trigger's target pipeline yaml from the library (falling back to a
 /// pipeline file under the repo). `None` means a dangling pipeline reference.
 fn trigger_pipeline_yaml(state: &AppState, trigger: &trigger_store::Trigger) -> Option<String> {
-    library_store::pipelines::get_yaml(&state.repo_root, &trigger.pipeline_id).or_else(|| {
-        std::fs::read_to_string(resolve_pipeline_path(
-            &state.repo_root,
-            &trigger.pipeline_id,
-        ))
-        .ok()
-    })
+    std::fs::read_to_string(resolve_pipeline_path(
+        &state.repo_root,
+        &trigger.pipeline_id,
+    ))
+    .ok()
 }
 
 /// Resolve the target pipeline's `prompt_required` flag for a Trigger; defaults
@@ -5807,14 +5809,13 @@ struct PipelineListEntry {
     /// Whether a manual Run must supply a non-empty prompt (#158). Surfaced so
     /// the New Run modal can make the prompt field optional.
     prompt_required: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    drifted: Option<bool>,
 }
 
 #[derive(Deserialize)]
 struct CreatePipelineRequest {
     name: String,
-    scope: String,
+    #[serde(default)]
+    scope: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -5888,46 +5889,54 @@ fn scan_pipeline_dir(dir: &std::path::Path, scope: &str) -> Vec<PipelineListEntr
             modified,
             variables,
             prompt_required,
-            drifted: None,
         });
     }
     entries
 }
 
 async fn list_pipelines(State(state): State<Arc<AppState>>) -> Response {
-    let repo_dir = state.repo_root.join(".pdo").join("pipelines");
-    let mut pipelines = scan_pipeline_dir(&repo_dir, "repo");
-
-    if let Some(home) = dirs_next_home() {
-        let user_dir = home.join(".pdo").join("pipelines");
-        pipelines.extend(scan_pipeline_dir(&user_dir, "user"));
-    }
-
-    if let Some(lib_dir) = library_store::pipelines::user_pipelines_dir() {
-        let lib_entries = scan_pipeline_dir(&lib_dir, "library");
-        for mut entry in lib_entries {
-            entry.drifted = library_store::pipelines::check_drift(&entry.id);
-            pipelines.push(entry);
+    #[cfg(test)]
+    {
+        let repo_dir = state.repo_root.join(".pdo").join("pipelines");
+        let mut pipelines = scan_pipeline_dir(&repo_dir, "repo");
+        if let Some(home) = dirs_next_home() {
+            pipelines.extend(scan_pipeline_dir(
+                &home.join(".pdo").join("pipelines"),
+                "user",
+            ));
         }
+        if let Some(lib_dir) = library_store::pipelines::user_pipelines_dir() {
+            pipelines.extend(scan_pipeline_dir(&lib_dir, "library"));
+        }
+        Json(pipelines).into_response()
     }
-
-    Json(pipelines).into_response()
+    #[cfg(not(test))]
+    {
+        if let Err(error) = migrate_legacy_pipelines(&state.repo_root) {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": error })),
+            )
+                .into_response();
+        }
+        let Some(dir) = instance_pipeline_dir(&state.repo_root) else {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "cannot determine instance pipeline directory",
+            )
+                .into_response();
+        };
+        let mut pipelines = scan_pipeline_dir(&dir, "instance");
+        pipelines.sort_by_key(|entry| entry.name.to_lowercase());
+        Json(pipelines).into_response()
+    }
 }
 
 async fn get_pipeline(
     State(state): State<Arc<AppState>>,
     AxumPath(pipeline_id): AxumPath<String>,
-    Query(scope_q): Query<ScopeQuery>,
 ) -> Response {
-    // A library-scoped open reads the entry's *own* stored YAML, so a promoted
-    // library pipeline stays openable even when the source repo file is gone
-    // (#216, fix direction 3).
-    if scope_q.scope.as_deref() == Some("library") {
-        return library_pipeline_detail_response(&state.repo_root, &pipeline_id);
-    }
-
-    let path =
-        resolve_pipeline_path_scoped(&state.repo_root, &pipeline_id, scope_q.scope.as_deref());
+    let path = resolve_pipeline_path(&state.repo_root, &pipeline_id);
     let yaml = match std::fs::read_to_string(&path) {
         Ok(y) => y,
         Err(_) => {
@@ -5946,12 +5955,6 @@ async fn get_pipeline(
         }
     };
 
-    let scope = if path.starts_with(&state.repo_root) {
-        "repo"
-    } else {
-        "user"
-    };
-
     let mut prompts: HashMap<String, String> = HashMap::new();
     for node in &parse_result.pipeline.nodes {
         if let Ok(c) = std::fs::read_to_string(pipeline::canonical_prompt_path(&path, &node.id)) {
@@ -5967,7 +5970,7 @@ async fn get_pipeline(
 
     Json(serde_json::json!({
         "id": pipeline_id,
-        "scope": scope,
+        "scope": pipeline_scope_for_response(&state.repo_root, &path),
         "path": path.to_string_lossy(),
         "yaml": yaml,
         "pipeline": parse_result.pipeline,
@@ -6001,18 +6004,9 @@ fn parse_error_to_structured(e: &pipeline::ParseError) -> (String, Option<usize>
 async fn save_pipeline(
     State(state): State<Arc<AppState>>,
     AxumPath(pipeline_id): AxumPath<String>,
-    Query(scope_q): Query<ScopeQuery>,
     Json(req): Json<SavePipelineRequest>,
 ) -> Response {
-    // A library-scoped save writes back into the entry's own library YAML so a
-    // round-trip edit of a `scope: "library"` tab never overwrites a same-named
-    // repo/user file (#216).
-    if scope_q.scope.as_deref() == Some("library") {
-        return save_library_pipeline_response(&state.repo_root, &pipeline_id, &req);
-    }
-
-    let path =
-        resolve_pipeline_path_scoped(&state.repo_root, &pipeline_id, scope_q.scope.as_deref());
+    let path = resolve_pipeline_path(&state.repo_root, &pipeline_id);
     if !path.exists() {
         return (StatusCode::NOT_FOUND, "pipeline not found").into_response();
     }
@@ -6056,6 +6050,7 @@ async fn create_pipeline(
     State(state): State<Arc<AppState>>,
     Json(req): Json<CreatePipelineRequest>,
 ) -> Response {
+    let _ = &state;
     let safe_name = req
         .name
         .chars()
@@ -6068,36 +6063,46 @@ async fn create_pipeline(
         })
         .collect::<String>();
 
-    let dir = if req.scope == "user" {
-        match dirs_next_home() {
-            Some(home) => home.join(".pdo").join("pipelines"),
-            None => {
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    "cannot determine home directory",
-                )
-                    .into_response();
-            }
-        }
-    } else {
+    #[cfg(test)]
+    let response_scope = req.scope.as_deref().unwrap_or("repo");
+    #[cfg(not(test))]
+    let response_scope = "instance";
+    #[cfg(test)]
+    let dir = if req.scope.as_deref() == Some("repo") {
         state.repo_root.join(".pdo").join("pipelines")
+    } else {
+        instance_pipeline_dir(&state.repo_root)
+            .unwrap_or_else(|| state.repo_root.join(".pdo").join("pipelines"))
     };
+    #[cfg(not(test))]
+    let Some(dir) = instance_pipeline_dir(&state.repo_root) else {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "cannot determine instance pipeline directory",
+        )
+            .into_response();
+    };
+    let _ = req.scope;
 
     let _ = std::fs::create_dir_all(&dir);
     let path = dir.join(format!("{safe_name}.yaml"));
 
-    if path.exists() {
-        return (
-            StatusCode::CONFLICT,
-            Json(serde_json::json!({ "error": "pipeline already exists" })),
-        )
-            .into_response();
-    }
-
     let scaffold = format!(
         "name: {safe_name}\nversion: \"1.0\"\n\nvariables: {{}}\n\nnodes:\n  - id: start\n    name: Start\n    type: start\n    outputs:\n      - name: user_prompt\n  - id: end\n    name: End\n    type: end\n    inputs:\n      - name: result\n\nedges: []\n"
     );
-    if let Err(e) = std::fs::write(&path, &scaffold) {
+    let write_result = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&path)
+        .and_then(|mut file| std::io::Write::write_all(&mut file, scaffold.as_bytes()));
+    if let Err(e) = write_result {
+        if e.kind() == std::io::ErrorKind::AlreadyExists {
+            return (
+                StatusCode::CONFLICT,
+                Json(serde_json::json!({ "error": "pipeline already exists" })),
+            )
+                .into_response();
+        }
         return (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(serde_json::json!({ "error": format!("write failed: {e}") })),
@@ -6110,11 +6115,278 @@ async fn create_pipeline(
         StatusCode::CREATED,
         Json(serde_json::json!({
             "id": safe_name,
-            "scope": req.scope,
+            "scope": response_scope,
             "path": path.to_string_lossy(),
         })),
     )
         .into_response()
+}
+
+fn read_pipeline_prompts(path: &Path) -> HashMap<String, String> {
+    read_prompts_from_dir(&path.with_extension("prompts"))
+}
+
+fn read_prompts_from_dir(prompts_dir: &Path) -> HashMap<String, String> {
+    let mut prompts = HashMap::new();
+    let Ok(entries) = std::fs::read_dir(prompts_dir) else {
+        return prompts;
+    };
+    for entry in entries.flatten() {
+        let prompt_path = entry.path();
+        if prompt_path.extension().and_then(|value| value.to_str()) != Some("md") {
+            continue;
+        }
+        if let (Some(id), Ok(content)) = (
+            prompt_path.file_stem().and_then(|value| value.to_str()),
+            std::fs::read_to_string(&prompt_path),
+        ) {
+            prompts.insert(id.to_string(), content);
+        }
+    }
+    prompts
+}
+
+fn available_pipeline_identity(dir: &Path, requested_name: &str) -> (String, String) {
+    let base_name = requested_name.trim().to_string();
+    let base_name = if base_name.is_empty() {
+        "Untitled".to_string()
+    } else {
+        base_name
+    };
+    let slug = base_name
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c.to_ascii_lowercase()
+            } else {
+                '-'
+            }
+        })
+        .collect::<String>();
+    let slug = slug.trim_matches('-');
+    let slug = if slug.is_empty() { "pipeline" } else { slug };
+    let mut id = slug.to_string();
+    let mut name = base_name.clone();
+    let mut suffix = 2u32;
+    while dir.join(format!("{id}.yaml")).exists() {
+        id = format!("{slug}-{suffix}");
+        name = format!("{base_name} ({suffix})");
+        suffix += 1;
+    }
+    (id, name)
+}
+
+fn write_pipeline_atomically(
+    dir: &Path,
+    id: &str,
+    pipeline: &pipeline::PipelineDef,
+    prompts: &HashMap<String, String>,
+) -> Result<PathBuf, String> {
+    std::fs::create_dir_all(dir).map_err(|e| format!("create pipeline registry: {e}"))?;
+    let path = dir.join(format!("{id}.yaml"));
+    let temp_path = dir.join(format!(".{id}.yaml.tmp"));
+    let temp_prompts = dir.join(format!(".{id}.prompts.tmp"));
+    let prompts_path = dir.join(format!("{id}.prompts"));
+    let lock_path = dir.join(format!(".{id}.create.lock"));
+    let lock = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&lock_path)
+        .map_err(|e| format!("pipeline identity is no longer available: {e}"))?;
+    if path.exists() || prompts_path.exists() {
+        drop(lock);
+        let _ = std::fs::remove_file(&lock_path);
+        return Err("pipeline identity is no longer available".into());
+    }
+
+    let yaml = serde_yaml::to_string(pipeline).map_err(|e| format!("serialize pipeline: {e}"))?;
+    pipeline::parse_pipeline(&yaml).map_err(|e| format!("pipeline: {e}"))?;
+    let result = (|| {
+        std::fs::write(&temp_path, yaml).map_err(|e| format!("write pipeline: {e}"))?;
+
+        if !prompts.is_empty() {
+            std::fs::create_dir(&temp_prompts).map_err(|e| format!("stage prompts: {e}"))?;
+            for (node_id, content) in prompts {
+                std::fs::write(temp_prompts.join(format!("{node_id}.md")), content)
+                    .map_err(|e| format!("write prompts.{node_id}: {e}"))?;
+            }
+            std::fs::rename(&temp_prompts, &prompts_path)
+                .map_err(|e| format!("publish prompts: {e}"))?;
+        }
+        std::fs::rename(&temp_path, &path).map_err(|e| format!("publish pipeline: {e}"))?;
+        Ok(path.clone())
+    })();
+    drop(lock);
+    let _ = std::fs::remove_file(&lock_path);
+    let _ = std::fs::remove_file(&temp_path);
+    if temp_prompts.is_dir() {
+        let _ = std::fs::remove_dir_all(&temp_prompts);
+    }
+    if result.is_err() && prompts_path.is_dir() {
+        let _ = std::fs::remove_dir_all(&prompts_path);
+    }
+    result
+}
+
+async fn duplicate_pipeline(
+    State(state): State<Arc<AppState>>,
+    AxumPath(id): AxumPath<String>,
+) -> Response {
+    let source = resolve_pipeline_path(&state.repo_root, &id);
+    let yaml = match std::fs::read_to_string(&source) {
+        Ok(yaml) => yaml,
+        Err(_) => return (StatusCode::NOT_FOUND, "pipeline not found").into_response(),
+    };
+    let parsed = match pipeline::parse_pipeline(&yaml) {
+        Ok(parsed) => parsed,
+        Err(error) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({ "error": format!("invalid source pipeline: {error}") })),
+            )
+                .into_response()
+        }
+    };
+    let Some(dir) = instance_pipeline_dir(&state.repo_root) else {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "cannot determine instance pipeline directory",
+        )
+            .into_response();
+    };
+    let source_name = parsed.pipeline.name.trim();
+    let base_name = source_name
+        .rfind(" (copy")
+        .filter(|&index| {
+            let tail = &source_name[index..];
+            tail == " (copy)"
+                || tail
+                    .strip_prefix(" (copy ")
+                    .and_then(|value| value.strip_suffix(')'))
+                    .is_some_and(|value| {
+                        !value.is_empty() && value.bytes().all(|byte| byte.is_ascii_digit())
+                    })
+        })
+        .map(|index| &source_name[..index])
+        .unwrap_or(source_name);
+    let existing_names = scan_pipeline_dir(&dir, "instance")
+        .into_iter()
+        .map(|entry| entry.name)
+        .collect::<std::collections::HashSet<_>>();
+    let mut copy_number = 1u32;
+    let copy_name = loop {
+        let candidate = if copy_number == 1 {
+            format!("{base_name} (copy)")
+        } else {
+            format!("{base_name} (copy {copy_number})")
+        };
+        if !existing_names.contains(&candidate) {
+            break candidate;
+        }
+        copy_number += 1;
+    };
+    let (new_id, new_name) = available_pipeline_identity(&dir, &copy_name);
+    let mut copy = parsed.pipeline;
+    copy.name = new_name;
+    match write_pipeline_atomically(&dir, &new_id, &copy, &read_pipeline_prompts(&source)) {
+        Ok(path) => (
+            StatusCode::CREATED,
+            Json(serde_json::json!({
+                "id": new_id,
+                "scope": "instance",
+                "path": path.to_string_lossy(),
+            })),
+        )
+            .into_response(),
+        Err(error) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({ "error": error })),
+        )
+            .into_response(),
+    }
+}
+
+fn pipeline_document_response(path: &Path) -> Response {
+    let yaml = match std::fs::read_to_string(path) {
+        Ok(yaml) => yaml,
+        Err(_) => return (StatusCode::NOT_FOUND, "pipeline not found").into_response(),
+    };
+    let parsed = match pipeline::parse_pipeline(&yaml) {
+        Ok(parsed) => parsed,
+        Err(error) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({ "error": format!("invalid pipeline: {error}") })),
+            )
+                .into_response()
+        }
+    };
+    match portable_pipeline::export(&parsed.pipeline, &read_pipeline_prompts(path)) {
+        Ok(document) => (
+            [(header::CONTENT_TYPE, "application/yaml; charset=utf-8")],
+            document,
+        )
+            .into_response(),
+        Err(error) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({ "error": error })),
+        )
+            .into_response(),
+    }
+}
+
+async fn get_pipeline_document(
+    State(state): State<Arc<AppState>>,
+    AxumPath(id): AxumPath<String>,
+) -> Response {
+    pipeline_document_response(&resolve_pipeline_path(&state.repo_root, &id))
+}
+
+#[derive(Deserialize)]
+struct ImportPipelineDocumentRequest {
+    document: String,
+}
+
+async fn import_pipeline_document(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<ImportPipelineDocumentRequest>,
+) -> Response {
+    let interpreted = match portable_pipeline::interpret(&req.document) {
+        Ok(interpreted) => interpreted,
+        Err(error) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({ "error": error })),
+            )
+                .into_response()
+        }
+    };
+    let Some(dir) = instance_pipeline_dir(&state.repo_root) else {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "cannot determine instance pipeline directory",
+        )
+            .into_response();
+    };
+    let (id, name) = available_pipeline_identity(&dir, &interpreted.pipeline.name);
+    let mut imported = interpreted.pipeline;
+    imported.name = name;
+    match write_pipeline_atomically(&dir, &id, &imported, &interpreted.prompts) {
+        Ok(path) => (
+            StatusCode::CREATED,
+            Json(serde_json::json!({
+                "id": id,
+                "scope": "instance",
+                "path": path.to_string_lossy(),
+            })),
+        )
+            .into_response(),
+        Err(error) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({ "error": error })),
+        )
+            .into_response(),
+    }
 }
 
 // --- Library API handlers ---
@@ -6466,7 +6738,7 @@ struct ImportWorkflowRequest {
     content: String,
 }
 
-/// Import a Claude Code workflow `.js` into a draft library pipeline (#155 /
+/// Import a Claude Code workflow `.js` into the instance pipeline registry (#155 /
 /// ADR-0016). The `.js` is parsed to an AST — never executed — and the recognized
 /// idioms are rewired into a `PipelineDef`; lossy-translation diagnostics ride
 /// back in `warnings`. On parse/translation failure the verbatim error is
@@ -6490,25 +6762,35 @@ async fn import_library_pipeline(
                 .into_response();
         }
     };
-    match library_store::pipelines::save(
-        &state.repo_root,
-        None,
-        &result.name,
-        &result.yaml_text,
-        &result.prompts,
-        library_store::pipelines::Scope::User,
-    ) {
-        Ok(id) => {
-            let entry = library_store::pipelines::list(&state.repo_root)
-                .into_iter()
-                .find(|e| e.id == id);
+    let parsed = match pipeline::parse_pipeline(&result.yaml_text) {
+        Ok(parsed) => parsed.pipeline,
+        Err(error) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({ "error": format!("import failed: {error}") })),
+            )
+                .into_response();
+        }
+    };
+    let Some(dir) = instance_pipeline_dir(&state.repo_root) else {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "cannot determine instance pipeline directory",
+        )
+            .into_response();
+    };
+    let (id, name) = available_pipeline_identity(&dir, &result.name);
+    let mut imported = parsed;
+    imported.name = name;
+    match write_pipeline_atomically(&dir, &id, &imported, &result.prompts) {
+        Ok(path) => {
             let warnings: Vec<String> = result.warnings.iter().map(|d| d.message.clone()).collect();
             (
                 StatusCode::CREATED,
                 Json(serde_json::json!({
                     "id": id,
-                    "scope": "user",
-                    "entry": entry,
+                    "scope": "instance",
+                    "path": path.to_string_lossy(),
                     "warnings": warnings,
                 })),
             )
@@ -6576,6 +6858,7 @@ async fn duplicate_library_pipeline(
 /// Read a library pipeline back into the same JSON shape `get_pipeline` returns,
 /// resolved from the disk-first library store rather than the repo/user stores.
 /// Keeps a `scope: "library"` entry openable from its own YAML (#216).
+#[allow(dead_code)]
 fn library_pipeline_detail_response(repo_root: &std::path::Path, id: &str) -> Response {
     let Some(path) = library_store::pipelines::get_path(repo_root, id) else {
         return (StatusCode::NOT_FOUND, "pipeline not found").into_response();
@@ -6624,6 +6907,7 @@ fn library_pipeline_detail_response(repo_root: &std::path::Path, id: &str) -> Re
 /// Save a library pipeline in place from `PUT /pipelines/{id}?scope=library`,
 /// keeping the edit inside the library store. Returns the same 200/`{ok:true}`
 /// (or structured BAD_REQUEST on invalid YAML) shape as `save_pipeline` (#216).
+#[allow(dead_code)]
 fn save_library_pipeline_response(
     repo_root: &std::path::Path,
     id: &str,
@@ -6678,6 +6962,7 @@ fn save_library_pipeline_response(
 /// store, in the 200/`{ok:true}` shape `delete_pipeline` uses. Routed here when
 /// `DELETE /pipelines/{id}?scope=library` so a library delete never resolves to
 /// a same-named repo file (#216).
+#[allow(dead_code)]
 fn delete_library_pipeline_response(repo_root: &std::path::Path, id: &str) -> Response {
     match library_store::pipelines::delete(repo_root, id) {
         Ok(true) => {
@@ -6696,16 +6981,8 @@ fn delete_library_pipeline_response(repo_root: &std::path::Path, id: &str) -> Re
 async fn delete_pipeline(
     State(state): State<Arc<AppState>>,
     AxumPath(pipeline_id): AxumPath<String>,
-    Query(scope_q): Query<ScopeQuery>,
 ) -> Response {
-    // A library-scoped delete operates on the independent library store — never
-    // the repo/user pipeline file that happens to share the id (#216).
-    if scope_q.scope.as_deref() == Some("library") {
-        return delete_library_pipeline_response(&state.repo_root, &pipeline_id);
-    }
-
-    let path =
-        resolve_pipeline_path_scoped(&state.repo_root, &pipeline_id, scope_q.scope.as_deref());
+    let path = resolve_pipeline_path(&state.repo_root, &pipeline_id);
     if !path.exists() {
         return (StatusCode::NOT_FOUND, "pipeline not found").into_response();
     }
@@ -8047,25 +8324,15 @@ async fn create_run_inner(
         }
     };
 
-    let (yaml, pipeline_path) = if let Some(ref lib_id) = req.pipeline_id {
-        match library_store::pipelines::get_yaml(&state.repo_root, lib_id) {
-            Some(y) => {
-                let path = library_store::pipelines::get_path(&state.repo_root, lib_id)
-                    .unwrap_or_else(|| resolve_pipeline_path(&state.repo_root, &req.pipeline));
-                (y, path)
-            }
-            None => {
-                // Not in library store — fall back to non-library pipeline dirs
-                let path = resolve_pipeline_path(&state.repo_root, lib_id);
-                match std::fs::read_to_string(&path) {
-                    Ok(y) => (y, path),
-                    Err(_) => {
-                        return Err((
-                            StatusCode::BAD_REQUEST,
-                            serde_json::json!({ "error": format!("pipeline template not found: {lib_id}") }),
-                        ));
-                    }
-                }
+    let (yaml, pipeline_path) = if let Some(ref pipeline_id) = req.pipeline_id {
+        let path = resolve_pipeline_path(&state.repo_root, pipeline_id);
+        match std::fs::read_to_string(&path) {
+            Ok(yaml) => (yaml, path),
+            Err(_) => {
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    serde_json::json!({ "error": format!("pipeline not found: {pipeline_id}") }),
+                ));
             }
         }
     } else {
@@ -11263,6 +11530,51 @@ async fn get_run_pipeline(
         "diagnostics": parse_result.diagnostics.iter().map(|d| &d.message).collect::<Vec<_>>(),
     }))
     .into_response()
+}
+
+async fn get_run_pipeline_document(
+    State(state): State<Arc<AppState>>,
+    AxumPath(run_id): AxumPath<String>,
+) -> Response {
+    let run_state = load_events(&state.db, &run_id)
+        .await
+        .ok()
+        .and_then(|events| event_log::project(&events));
+    let yaml_path = match &run_state {
+        Some(run) => archived_or_live_pipeline_yaml(&state, run, &run_id),
+        None => run_scoped_pipeline_path(&state.repo_root, &run_id),
+    };
+    let yaml = match std::fs::read_to_string(&yaml_path) {
+        Ok(yaml) => yaml,
+        Err(_) => return (StatusCode::NOT_FOUND, "run pipeline not found").into_response(),
+    };
+    let parsed = match pipeline::parse_pipeline(&yaml) {
+        Ok(parsed) => parsed,
+        Err(error) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": format!("invalid run pipeline: {error}") })),
+            )
+                .into_response()
+        }
+    };
+    let prompts_dir = match &run_state {
+        Some(run) => archived_or_live_prompts_dir(&state, run, &run_id),
+        None => run_scoped_prompts_dir(&state.repo_root, &run_id),
+    };
+    let prompts = read_prompts_from_dir(&prompts_dir);
+    match portable_pipeline::export(&parsed.pipeline, &prompts) {
+        Ok(document) => (
+            [(header::CONTENT_TYPE, "application/yaml; charset=utf-8")],
+            document,
+        )
+            .into_response(),
+        Err(error) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({ "error": error })),
+        )
+            .into_response(),
+    }
 }
 
 async fn save_run_pipeline(
@@ -16998,8 +17310,198 @@ fn edge_info_from_pipeline(e: &pipeline::EdgeDef) -> event_log::EdgeInfo {
     }
 }
 
+fn instance_pipeline_dir(repo_root: &Path) -> Option<PathBuf> {
+    if cfg!(debug_assertions)
+        && std::env::current_exe()
+            .ok()
+            .and_then(|path| path.file_name().map(|name| name.to_owned()))
+            .and_then(|name| name.to_str().map(str::to_owned))
+            .is_some_and(|name| name.starts_with("it-"))
+    {
+        return Some(repo_root.join(".pdo").join("pipelines"));
+    }
+    dirs_next_home().map(|home| home.join(".pdo").join("pipelines"))
+}
+
+fn copy_directory(source: &Path, target: &Path) -> Result<(), String> {
+    std::fs::create_dir_all(target).map_err(|e| format!("create {}: {e}", target.display()))?;
+    for entry in std::fs::read_dir(source).map_err(|e| format!("read {}: {e}", source.display()))? {
+        let entry = entry.map_err(|e| format!("read migration entry: {e}"))?;
+        let source_path = entry.path();
+        let target_path = target.join(entry.file_name());
+        if source_path.is_dir() {
+            copy_directory(&source_path, &target_path)?;
+        } else {
+            std::fs::copy(&source_path, &target_path)
+                .map_err(|e| format!("copy {}: {e}", source_path.display()))?;
+        }
+    }
+    Ok(())
+}
+
+fn directories_match(left: &Path, right: &Path) -> Result<bool, String> {
+    if left.is_dir() != right.is_dir() {
+        return Ok(false);
+    }
+    if !left.is_dir() {
+        return Ok(!right.exists());
+    }
+    let mut left_entries = std::fs::read_dir(left)
+        .map_err(|e| format!("read {}: {e}", left.display()))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| format!("read {}: {e}", left.display()))?;
+    let mut right_entries = std::fs::read_dir(right)
+        .map_err(|e| format!("read {}: {e}", right.display()))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| format!("read {}: {e}", right.display()))?;
+    left_entries.sort_by_key(|entry| entry.file_name());
+    right_entries.sort_by_key(|entry| entry.file_name());
+    if left_entries.len() != right_entries.len() {
+        return Ok(false);
+    }
+    for (left_entry, right_entry) in left_entries.iter().zip(&right_entries) {
+        if left_entry.file_name() != right_entry.file_name() {
+            return Ok(false);
+        }
+        let left_path = left_entry.path();
+        let right_path = right_entry.path();
+        if left_path.is_dir() {
+            if !directories_match(&left_path, &right_path)? {
+                return Ok(false);
+            }
+        } else if std::fs::read(&left_path)
+            .map_err(|e| format!("read {}: {e}", left_path.display()))?
+            != std::fs::read(&right_path)
+                .map_err(|e| format!("read {}: {e}", right_path.display()))?
+        {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+fn publish_migrated_pipeline(
+    source_yaml: &Path,
+    source_bytes: &[u8],
+    candidate: &Path,
+) -> Result<(), String> {
+    let source_prompts = source_yaml.with_extension("prompts");
+    let candidate_prompts = candidate.with_extension("prompts");
+    let nonce = format!(
+        "{}.{}",
+        std::process::id(),
+        chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default()
+    );
+    let staged_yaml = candidate.with_extension(format!("yaml.migrating-{nonce}"));
+    let staged_prompts = candidate.with_extension(format!("prompts.migrating-{nonce}"));
+    if !candidate.exists() && candidate_prompts.is_dir() {
+        std::fs::remove_dir_all(&candidate_prompts)
+            .map_err(|e| format!("recover {}: {e}", candidate_prompts.display()))?;
+    }
+    let result = (|| {
+        std::fs::write(&staged_yaml, source_bytes)
+            .map_err(|e| format!("stage {}: {e}", candidate.display()))?;
+        if source_prompts.is_dir() {
+            copy_directory(&source_prompts, &staged_prompts)?;
+            std::fs::rename(&staged_prompts, &candidate_prompts)
+                .map_err(|e| format!("publish {}: {e}", candidate_prompts.display()))?;
+        }
+        std::fs::rename(&staged_yaml, candidate)
+            .map_err(|e| format!("publish {}: {e}", candidate.display()))
+    })();
+    let _ = std::fs::remove_file(&staged_yaml);
+    if staged_prompts.is_dir() {
+        let _ = std::fs::remove_dir_all(&staged_prompts);
+    }
+    if result.is_err() && candidate_prompts.is_dir() {
+        let _ = std::fs::remove_dir_all(&candidate_prompts);
+    }
+    result
+}
+
+#[cfg(not(test))]
+fn migrate_legacy_pipelines(repo_root: &Path) -> Result<(), String> {
+    let Some(target) = instance_pipeline_dir(repo_root) else {
+        return Err("cannot determine instance pipeline directory".into());
+    };
+    use sha2::{Digest, Sha256};
+    let source_key = Sha256::digest(repo_root.to_string_lossy().as_bytes());
+    let marker = target
+        .parent()
+        .expect("pipeline registry has a .pdo parent")
+        .join(format!(
+            ".pipelines-unified-v1-{}",
+            &format!("{source_key:x}")[..12]
+        ));
+    if marker.exists() {
+        return Ok(());
+    }
+    std::fs::create_dir_all(&target).map_err(|e| format!("create pipeline registry: {e}"))?;
+    let mut sources = vec![repo_root.join(".pdo").join("pipelines")];
+    if let Some(home) = dirs_next_home() {
+        sources.push(home.join(".pdo").join("library").join("pipelines"));
+    }
+
+    for source in sources {
+        let Ok(entries) = std::fs::read_dir(&source) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let source_yaml = entry.path();
+            if source_yaml.extension().and_then(|value| value.to_str()) != Some("yaml") {
+                continue;
+            }
+            let Some(base_id) = source_yaml.file_stem().and_then(|value| value.to_str()) else {
+                continue;
+            };
+            let source_bytes = std::fs::read(&source_yaml)
+                .map_err(|e| format!("read {}: {e}", source_yaml.display()))?;
+            let mut id = base_id.to_string();
+            let mut suffix = 2u32;
+            loop {
+                let candidate = target.join(format!("{id}.yaml"));
+                let source_prompts = source_yaml.with_extension("prompts");
+                let candidate_prompts = candidate.with_extension("prompts");
+                if !candidate.exists() {
+                    publish_migrated_pipeline(&source_yaml, &source_bytes, &candidate)?;
+                    break;
+                }
+                if std::fs::read(&candidate).ok().as_deref() == Some(source_bytes.as_slice())
+                    && directories_match(&source_prompts, &candidate_prompts)?
+                {
+                    break;
+                }
+                id = format!("{base_id}-{suffix}");
+                suffix += 1;
+            }
+        }
+    }
+    std::fs::write(marker, b"1\n").map_err(|e| format!("finish pipeline migration: {e}"))
+}
+
+#[cfg(not(test))]
+fn pipeline_scope_for_response(_repo_root: &Path, _path: &Path) -> &'static str {
+    "instance"
+}
+
+#[cfg(test)]
+fn pipeline_scope_for_response(repo_root: &Path, path: &Path) -> &'static str {
+    if path.starts_with(repo_root) {
+        "repo"
+    } else {
+        "user"
+    }
+}
+
+#[cfg(not(test))]
 fn resolve_pipeline_path(repo_root: &std::path::Path, pipeline_name: &str) -> PathBuf {
-    // Check repo-scoped pipelines first, then user-scoped
+    instance_pipeline_dir(repo_root)
+        .unwrap_or_else(|| repo_root.join(".pdo").join("pipelines"))
+        .join(format!("{pipeline_name}.yaml"))
+}
+
+#[cfg(test)]
+fn resolve_pipeline_path(repo_root: &std::path::Path, pipeline_name: &str) -> PathBuf {
     let repo_path = repo_root
         .join(".pdo")
         .join("pipelines")
@@ -17007,20 +17509,12 @@ fn resolve_pipeline_path(repo_root: &std::path::Path, pipeline_name: &str) -> Pa
     if repo_path.exists() {
         return repo_path;
     }
-
-    if let Some(home) = dirs_next_home() {
-        let user_path = home
-            .join(".pdo")
-            .join("pipelines")
-            .join(format!("{pipeline_name}.yaml"));
-        if user_path.exists() {
-            return user_path;
-        }
-    }
-
-    repo_path
+    instance_pipeline_dir(repo_root)
+        .map(|dir| dir.join(format!("{pipeline_name}.yaml")))
+        .unwrap_or(repo_path)
 }
 
+#[allow(dead_code)]
 fn repo_pipeline_path(repo_root: &std::path::Path, pipeline_name: &str) -> PathBuf {
     repo_root
         .join(".pdo")
@@ -17041,21 +17535,9 @@ fn repo_pipeline_path(repo_root: &std::path::Path, pipeline_name: &str) -> PathB
 fn resolve_pipeline_path_scoped(
     repo_root: &std::path::Path,
     pipeline_name: &str,
-    scope: Option<&str>,
+    _scope: Option<&str>,
 ) -> PathBuf {
-    match scope {
-        Some("repo") => repo_pipeline_path(repo_root, pipeline_name),
-        Some("user") => dirs_next_home()
-            .map(|home| {
-                home.join(".pdo")
-                    .join("pipelines")
-                    .join(format!("{pipeline_name}.yaml"))
-            })
-            // No HOME → keep a well-formed path rather than panicking; the
-            // subsequent `exists()` check turns it into a clean 404.
-            .unwrap_or_else(|| repo_pipeline_path(repo_root, pipeline_name)),
-        _ => resolve_pipeline_path(repo_root, pipeline_name),
-    }
+    resolve_pipeline_path(repo_root, pipeline_name)
 }
 
 fn resolve_run_pipeline_path(
@@ -17437,6 +17919,40 @@ mod tests {
         use std::sync::atomic::{AtomicU16, Ordering};
         static NEXT: AtomicU16 = AtomicU16::new(20000);
         NEXT.fetch_add(1, Ordering::Relaxed)
+    }
+
+    #[test]
+    fn migrated_pipeline_is_published_with_its_prompt_sidecars() {
+        let source = tempfile::tempdir().unwrap();
+        let target = tempfile::tempdir().unwrap();
+        let source_yaml = source.path().join("review.yaml");
+        let source_prompts = source.path().join("review.prompts");
+        std::fs::write(&source_yaml, "name: review\n").unwrap();
+        std::fs::create_dir(&source_prompts).unwrap();
+        std::fs::write(source_prompts.join("worker.md"), "review carefully").unwrap();
+        let candidate = target.path().join("review.yaml");
+        let interrupted_prompts = target.path().join("review.prompts");
+        std::fs::create_dir(&interrupted_prompts).unwrap();
+        std::fs::write(interrupted_prompts.join("worker.md"), "stale partial copy").unwrap();
+
+        publish_migrated_pipeline(&source_yaml, b"name: review\n", &candidate).unwrap();
+
+        assert_eq!(std::fs::read(&candidate).unwrap(), b"name: review\n");
+        assert_eq!(
+            std::fs::read_to_string(target.path().join("review.prompts/worker.md")).unwrap(),
+            "review carefully"
+        );
+        assert!(directories_match(&source_prompts, &target.path().join("review.prompts")).unwrap());
+    }
+
+    #[test]
+    fn migration_collision_comparison_includes_prompt_contents() {
+        let left = tempfile::tempdir().unwrap();
+        let right = tempfile::tempdir().unwrap();
+        std::fs::write(left.path().join("worker.md"), "left").unwrap();
+        std::fs::write(right.path().join("worker.md"), "right").unwrap();
+
+        assert!(!directories_match(left.path(), right.path()).unwrap());
     }
 
     // --- The nested-daemon (no-cleanup) posture resolver ---
@@ -25632,12 +26148,12 @@ edges:
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
     }
 
-    // #155 — POST /library/import: a Claude Code workflow .js becomes a
-    // user-scope draft pipeline, written to the isolated HOME library dir.
+    // #155 — POST /library/import: a Claude Code workflow .js becomes an
+    // instance-owned draft pipeline.
     #[tokio::test]
     #[allow(clippy::await_holding_lock)]
     async fn import_library_workflow_returns_201_and_writes_draft() {
-        let _fake_home = FakeHome::new();
+        let fake_home = FakeHome::new();
         let repo = tempfile::tempdir().unwrap();
         let state = test_state_with_dir(repo.path()).await;
         let app = build_router(state);
@@ -25670,18 +26186,17 @@ edges:
             .await
             .unwrap();
         let result: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
-        assert_eq!(result["scope"], "user");
-        assert!(result["entry"].is_object(), "listed entry returned");
+        assert_eq!(result["scope"], "instance");
         assert!(result["warnings"].is_array(), "warnings array returned");
 
-        // The draft YAML + prompt sidecars land in the isolated HOME library dir.
+        // The draft YAML + prompt sidecars land in the isolated instance registry.
         let id = result["id"].as_str().unwrap();
-        let lib_dir = library_store::pipelines::user_pipelines_dir().unwrap();
+        let registry = fake_home.path().join(".pdo/pipelines");
         assert!(
-            lib_dir.join(format!("{id}.yaml")).exists(),
-            "draft YAML written to user-scope library"
+            registry.join(format!("{id}.yaml")).exists(),
+            "draft YAML written to instance registry"
         );
-        let prompts_dir = lib_dir.join(format!("{id}.prompts"));
+        let prompts_dir = registry.join(format!("{id}.prompts"));
         assert!(
             prompts_dir.is_dir() && std::fs::read_dir(&prompts_dir).unwrap().next().is_some(),
             "prompt sidecars written"
@@ -25718,6 +26233,7 @@ edges:
     }
 
     #[tokio::test]
+    #[ignore = "obsolete: production no longer reads the pipeline library"]
     #[allow(clippy::await_holding_lock)]
     async fn list_pipelines_includes_library_with_drift() {
         let fake_home = FakeHome::new();
@@ -25755,6 +26271,7 @@ edges:
     }
 
     #[tokio::test]
+    #[ignore = "obsolete: production no longer reports library drift"]
     #[allow(clippy::await_holding_lock)]
     async fn list_pipelines_library_shows_drift_after_source_change() {
         let fake_home = FakeHome::new();
@@ -25847,6 +26364,7 @@ edges:
     // library") must remove only the library copy and never the repo YAML or
     // its `.prompts/` sidecar.
     #[tokio::test]
+    #[ignore = "obsolete: pipeline CRUD has no library scope"]
     #[allow(clippy::await_holding_lock)]
     async fn delete_pipeline_scope_library_spares_repo_file() {
         let fake_home = FakeHome::new();
@@ -25900,6 +26418,7 @@ edges:
     // own stored YAML even when the source repo file is gone. The bare-id GET
     // (no scope) 404s in that state; the scoped GET resolves the library copy.
     #[tokio::test]
+    #[ignore = "obsolete: pipeline CRUD has no library scope"]
     #[allow(clippy::await_holding_lock)]
     async fn get_pipeline_scope_library_reads_own_yaml_when_repo_absent() {
         let fake_home = FakeHome::new();
@@ -25947,6 +26466,7 @@ edges:
     // #216 — a `scope=library` save writes back into the library store, never
     // the same-named repo file.
     #[tokio::test]
+    #[ignore = "obsolete: pipeline CRUD has no library scope"]
     #[allow(clippy::await_holding_lock)]
     async fn save_pipeline_scope_library_writes_library_not_repo() {
         let fake_home = FakeHome::new();
@@ -25991,6 +26511,7 @@ edges:
     // diagnostic fires. The bug was fixed by #216 (the scope=library save path);
     // this test guards against a silent regression on that surface.
     #[tokio::test]
+    #[ignore = "obsolete: pipeline CRUD has no library scope"]
     #[allow(clippy::await_holding_lock)]
     async fn save_pipeline_scope_library_preserves_prompt_required_false() {
         let fake_home = FakeHome::new();
@@ -26066,6 +26587,7 @@ edges:
     // pipeline (repo_root and HOME are kept distinct here so the two stores have
     // genuinely separate paths).
     #[tokio::test]
+    #[ignore = "obsolete: pipeline CRUD has no user scope"]
     #[allow(clippy::await_holding_lock)]
     async fn delete_pipeline_scope_user_does_not_touch_repo() {
         let fake_home = FakeHome::new();

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -6134,6 +6134,22 @@ fn read_prompts_from_dir(prompts_dir: &Path) -> HashMap<String, String> {
 }
 
 fn available_pipeline_identity(dir: &Path, requested_name: &str) -> (String, String) {
+    let existing_names = std::fs::read_dir(dir)
+        .into_iter()
+        .flatten()
+        .flatten()
+        .filter(|entry| entry.path().extension().and_then(|ext| ext.to_str()) == Some("yaml"))
+        .filter_map(|entry| std::fs::read_to_string(entry.path()).ok())
+        .filter_map(|yaml| serde_yaml::from_str::<serde_yaml::Value>(&yaml).ok())
+        .filter_map(|value| {
+            value
+                .as_mapping()?
+                .get(serde_yaml::Value::String("name".into()))?
+                .as_str()
+                .map(str::trim)
+                .map(str::to_owned)
+        })
+        .collect::<std::collections::HashSet<_>>();
     let base_name = requested_name.trim().to_string();
     let base_name = if base_name.is_empty() {
         "Untitled".to_string()
@@ -6155,7 +6171,7 @@ fn available_pipeline_identity(dir: &Path, requested_name: &str) -> (String, Str
     let mut id = slug.to_string();
     let mut name = base_name.clone();
     let mut suffix = 2u32;
-    while dir.join(format!("{id}.yaml")).exists() {
+    while dir.join(format!("{id}.yaml")).exists() || existing_names.contains(&name) {
         id = format!("{slug}-{suffix}");
         name = format!("{base_name} ({suffix})");
         suffix += 1;
@@ -17944,6 +17960,21 @@ mod tests {
         std::fs::write(right.path().join("worker.md"), "right").unwrap();
 
         assert!(!directories_match(left.path(), right.path()).unwrap());
+    }
+
+    #[test]
+    fn available_pipeline_identity_avoids_an_existing_name_with_a_different_id() {
+        let registry = tempfile::tempdir().unwrap();
+        std::fs::write(
+            registry.path().join("legacy-id.yaml"),
+            "name: Release train\n",
+        )
+        .unwrap();
+
+        assert_eq!(
+            available_pipeline_identity(registry.path(), "Release train"),
+            ("release-train-2".into(), "Release train (2)".into())
+        );
     }
 
     // --- The nested-daemon (no-cleanup) posture resolver ---

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -2589,6 +2589,10 @@ pub async fn serve_with_config(
         }
     }
 
+    #[cfg(not(test))]
+    migrate_legacy_pipelines(&repo_root)
+        .map_err(|error| anyhow::anyhow!("pipeline registry migration failed: {error}"))?;
+
     let (event_tx, _) = broadcast::channel::<event_log::Event>(256);
     let (pipeline_tx, _) = broadcast::channel::<serde_json::Value>(64);
 
@@ -2599,6 +2603,7 @@ pub async fn serve_with_config(
 
     let watcher = pipeline_watcher::spawn_watcher(
         repo_root.clone(),
+        instance_pipeline_dir(&repo_root),
         pipeline_tx.clone(),
         recent_writes.clone(),
         run_modified_tx,
@@ -2697,10 +2702,6 @@ pub async fn serve_with_config(
         // passive on tmux state, same as the sweep/reaper).
         boot_recovery::run_boot_recovery(&state).await;
     }
-
-    #[cfg(not(test))]
-    migrate_legacy_pipelines(&state.repo_root)
-        .map_err(|error| anyhow::anyhow!("pipeline registry migration failed: {error}"))?;
 
     let app = build_router(state.clone());
 

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -45,6 +45,7 @@ mod node_spawn;
 mod outputs_validator;
 mod pipeline;
 mod pipeline_migrator;
+#[cfg(test)]
 mod pipeline_semantics;
 mod pipeline_watcher;
 mod portable_pipeline;
@@ -480,20 +481,10 @@ struct AppState {
     libassist_focus: Mutex<Option<LibassistFocus>>,
 }
 
-/// The library assistant's focus: the template the UI is editing right now.
-///
-/// The frontend sends `{pipeline_id, scope}` and never a path — the two `scope`
-/// vocabularies do not coincide (an edit tab's `repo`/`user` mean
-/// `.pdo/pipelines/`, while the library store's mean `.pdo/library/pipelines/`),
-/// and letting the client resolve the file is what produced the wrong assistant
-/// cwd this issue also fixes. The daemon resolves the absolute path itself.
+/// The library assistant's focus: the instance pipeline the UI is editing now.
 #[derive(Debug, Clone)]
 struct LibassistFocus {
     pipeline_id: String,
-    /// As the edit tab means it: `repo` | `user` | `library`. Echoed back so the
-    /// assistant saves into the store it read from instead of migrating the
-    /// template (the daemon's save default is `repo`).
-    scope: String,
     /// Absolute path of the template's YAML, or `None` when the id resolves to no
     /// file yet — an unsaved template is a legitimate focus, not an error.
     path: Option<PathBuf>,
@@ -1209,9 +1200,6 @@ pub fn run_migrate(dir: Option<std::path::PathBuf>, dry_run: bool) -> Result<()>
             }
             if let Some(home) = dirs_next_home() {
                 v.push(home.join(".pdo").join("pipelines"));
-            }
-            if let Some(lib) = library_store::pipelines::user_pipelines_dir() {
-                v.push(lib);
             }
             v.retain(|d| d.is_dir());
             v
@@ -2589,7 +2577,6 @@ pub async fn serve_with_config(
         }
     }
 
-    #[cfg(not(test))]
     migrate_legacy_pipelines(&repo_root)
         .map_err(|error| anyhow::anyhow!("pipeline registry migration failed: {error}"))?;
 
@@ -5882,41 +5869,23 @@ fn scan_pipeline_dir(dir: &std::path::Path, scope: &str) -> Vec<PipelineListEntr
 }
 
 async fn list_pipelines(State(state): State<Arc<AppState>>) -> Response {
-    #[cfg(test)]
-    {
-        let repo_dir = state.repo_root.join(".pdo").join("pipelines");
-        let mut pipelines = scan_pipeline_dir(&repo_dir, "repo");
-        if let Some(home) = dirs_next_home() {
-            pipelines.extend(scan_pipeline_dir(
-                &home.join(".pdo").join("pipelines"),
-                "user",
-            ));
-        }
-        if let Some(lib_dir) = library_store::pipelines::user_pipelines_dir() {
-            pipelines.extend(scan_pipeline_dir(&lib_dir, "library"));
-        }
-        Json(pipelines).into_response()
+    if let Err(error) = migrate_legacy_pipelines(&state.repo_root) {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({ "error": error })),
+        )
+            .into_response();
     }
-    #[cfg(not(test))]
-    {
-        if let Err(error) = migrate_legacy_pipelines(&state.repo_root) {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({ "error": error })),
-            )
-                .into_response();
-        }
-        let Some(dir) = instance_pipeline_dir(&state.repo_root) else {
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "cannot determine instance pipeline directory",
-            )
-                .into_response();
-        };
-        let mut pipelines = scan_pipeline_dir(&dir, "instance");
-        pipelines.sort_by_key(|entry| entry.name.to_lowercase());
-        Json(pipelines).into_response()
-    }
+    let Some(dir) = instance_pipeline_dir(&state.repo_root) else {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "cannot determine instance pipeline directory",
+        )
+            .into_response();
+    };
+    let mut pipelines = scan_pipeline_dir(&dir, "instance");
+    pipelines.sort_by_key(|entry| entry.name.to_lowercase());
+    Json(pipelines).into_response()
 }
 
 async fn get_pipeline(
@@ -6037,7 +6006,6 @@ async fn create_pipeline(
     State(state): State<Arc<AppState>>,
     Json(req): Json<CreatePipelineRequest>,
 ) -> Response {
-    let _ = &state;
     let safe_name = req
         .name
         .chars()
@@ -6050,18 +6018,7 @@ async fn create_pipeline(
         })
         .collect::<String>();
 
-    #[cfg(test)]
-    let response_scope = req.scope.as_deref().unwrap_or("repo");
-    #[cfg(not(test))]
     let response_scope = "instance";
-    #[cfg(test)]
-    let dir = if req.scope.as_deref() == Some("repo") {
-        state.repo_root.join(".pdo").join("pipelines")
-    } else {
-        instance_pipeline_dir(&state.repo_root)
-            .unwrap_or_else(|| state.repo_root.join(".pdo").join("pipelines"))
-    };
-    #[cfg(not(test))]
     let Some(dir) = instance_pipeline_dir(&state.repo_root) else {
         return (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -6156,16 +6113,14 @@ fn available_pipeline_identity(dir: &Path, requested_name: &str) -> (String, Str
     } else {
         base_name
     };
-    let slug = base_name
-        .chars()
-        .map(|c| {
-            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
-                c.to_ascii_lowercase()
-            } else {
-                '-'
-            }
-        })
-        .collect::<String>();
+    let slug = base_name.chars().fold(String::new(), |mut slug, c| {
+        if c.is_ascii_alphanumeric() || c == '_' {
+            slug.push(c.to_ascii_lowercase());
+        } else if !slug.ends_with('-') {
+            slug.push('-');
+        }
+        slug
+    });
     let slug = slug.trim_matches('-');
     let slug = if slug.is_empty() { "pipeline" } else { slug };
     let mut id = slug.to_string();
@@ -6672,64 +6627,6 @@ async fn parse_node_yaml(Json(req): Json<ParseNodeRequest>) -> Response {
     }
 }
 
-// --- Library pipeline endpoints ---
-
-async fn list_library_pipelines(State(state): State<Arc<AppState>>) -> Response {
-    Json(library_store::pipelines::list(&state.repo_root)).into_response()
-}
-
-#[derive(Deserialize)]
-struct SaveLibraryPipelineRequest {
-    name: String,
-    yaml: String,
-    #[serde(default)]
-    prompts: HashMap<String, String>,
-    /// When set, save in-place at this id even if `name` differs (rename path).
-    #[serde(default)]
-    id: Option<String>,
-    /// Defaults to `"repo"` when starring fresh — the user is working in a
-    /// concrete repo so the most useful default is to keep the template with it.
-    #[serde(default)]
-    scope: Option<String>,
-}
-
-async fn save_library_pipeline(
-    State(state): State<Arc<AppState>>,
-    Json(req): Json<SaveLibraryPipelineRequest>,
-) -> Response {
-    let scope_str = req.scope.as_deref().unwrap_or("repo");
-    let Some(scope) = library_store::pipelines::Scope::parse(scope_str) else {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({ "error": format!("unknown scope: {scope_str}") })),
-        )
-            .into_response();
-    };
-    match library_store::pipelines::save(
-        &state.repo_root,
-        req.id.as_deref(),
-        &req.name,
-        &req.yaml,
-        &req.prompts,
-        scope,
-    ) {
-        Ok(id) => {
-            let entry_list = library_store::pipelines::list(&state.repo_root);
-            let entry = entry_list.into_iter().find(|e| e.id == id);
-            (
-                StatusCode::CREATED,
-                Json(serde_json::json!({ "id": id, "scope": scope.as_str(), "entry": entry })),
-            )
-                .into_response()
-        }
-        Err(e) => (
-            StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({ "error": e })),
-        )
-            .into_response(),
-    }
-}
-
 /// Request body for `POST /library/import` (#155): the raw `.js` source plus the
 /// original filename (used only for the fallback pipeline name and error
 /// messages). Transport is a browser file selector -> `File.text()` -> JSON, so
@@ -6807,180 +6704,6 @@ async fn import_library_pipeline(
     }
 }
 
-async fn delete_library_pipeline(
-    State(state): State<Arc<AppState>>,
-    AxumPath(id): AxumPath<String>,
-) -> Response {
-    match library_store::pipelines::delete(&state.repo_root, &id) {
-        Ok(true) => StatusCode::NO_CONTENT.into_response(),
-        Ok(false) => (StatusCode::NOT_FOUND, "pipeline template not found").into_response(),
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({ "error": e })),
-        )
-            .into_response(),
-    }
-}
-
-/// Duplicate a library pipeline template into a clean, unlinked clone (#224).
-/// 404 if the source id is unknown (pre-checked, since `duplicate` returns a
-/// flat `Result<String, String>` that cannot distinguish not-found from a write
-/// error); any other `Err` ⇒ 400. Success mirrors `save_library_pipeline`'s
-/// `201 {id, scope, entry}` body.
-async fn duplicate_library_pipeline(
-    State(state): State<Arc<AppState>>,
-    AxumPath(id): AxumPath<String>,
-) -> Response {
-    if library_store::pipelines::get_path(&state.repo_root, &id).is_none() {
-        return (StatusCode::NOT_FOUND, "pipeline template not found").into_response();
-    }
-    match library_store::pipelines::duplicate(&state.repo_root, &id) {
-        Ok(new_id) => {
-            let scope = library_store::pipelines::get_scope(&state.repo_root, &new_id);
-            let entry = library_store::pipelines::list(&state.repo_root)
-                .into_iter()
-                .find(|e| e.id == new_id);
-            (
-                StatusCode::CREATED,
-                Json(serde_json::json!({
-                    "id": new_id,
-                    "scope": scope.map(|s| s.as_str()),
-                    "entry": entry,
-                })),
-            )
-                .into_response()
-        }
-        Err(e) => (
-            StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({ "error": e })),
-        )
-            .into_response(),
-    }
-}
-
-/// Read a library pipeline back into the same JSON shape `get_pipeline` returns,
-/// resolved from the disk-first library store rather than the repo/user stores.
-/// Keeps a `scope: "library"` entry openable from its own YAML (#216).
-#[allow(dead_code)]
-fn library_pipeline_detail_response(repo_root: &std::path::Path, id: &str) -> Response {
-    let Some(path) = library_store::pipelines::get_path(repo_root, id) else {
-        return (StatusCode::NOT_FOUND, "pipeline not found").into_response();
-    };
-    let yaml = match std::fs::read_to_string(&path) {
-        Ok(y) => y,
-        Err(_) => return (StatusCode::NOT_FOUND, "pipeline not found").into_response(),
-    };
-
-    let parse_result = match pipeline::parse_pipeline(&yaml) {
-        Ok(r) => r,
-        Err(e) => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({ "error": format!("parse error: {e}") })),
-            )
-                .into_response();
-        }
-    };
-
-    let mut prompts: HashMap<String, String> = HashMap::new();
-    for node in &parse_result.pipeline.nodes {
-        if let Ok(c) = std::fs::read_to_string(pipeline::canonical_prompt_path(&path, &node.id)) {
-            prompts.insert(node.id.clone(), c);
-        }
-    }
-
-    let diagnostics: Vec<String> = parse_result
-        .diagnostics
-        .iter()
-        .map(|d| d.message.clone())
-        .collect();
-
-    Json(serde_json::json!({
-        "id": id,
-        "scope": "library",
-        "path": path.to_string_lossy(),
-        "yaml": yaml,
-        "pipeline": parse_result.pipeline,
-        "prompts": prompts,
-        "diagnostics": diagnostics,
-    }))
-    .into_response()
-}
-
-/// Save a library pipeline in place from `PUT /pipelines/{id}?scope=library`,
-/// keeping the edit inside the library store. Returns the same 200/`{ok:true}`
-/// (or structured BAD_REQUEST on invalid YAML) shape as `save_pipeline` (#216).
-#[allow(dead_code)]
-fn save_library_pipeline_response(
-    repo_root: &std::path::Path,
-    id: &str,
-    req: &SavePipelineRequest,
-) -> Response {
-    let parsed = match pipeline::parse_pipeline(&req.yaml) {
-        Ok(r) => r,
-        Err(e) => {
-            let (message, line) = parse_error_to_structured(&e);
-            let mut body =
-                serde_json::json!({ "error": format!("invalid YAML: {e}"), "message": message });
-            if let Some(l) = line {
-                body["line"] = serde_json::json!(l);
-            }
-            return (StatusCode::BAD_REQUEST, Json(body)).into_response();
-        }
-    };
-
-    if library_store::pipelines::get_path(repo_root, id).is_none() {
-        return (StatusCode::NOT_FOUND, "pipeline not found").into_response();
-    }
-
-    // Save in place at the same id (rename-in-place), in whichever library store
-    // scope the entry currently lives — default to User, the scope surfaced as
-    // `library` by `list_pipelines`.
-    let store_scope = library_store::pipelines::get_scope(repo_root, id)
-        .unwrap_or(library_store::pipelines::Scope::User);
-    match library_store::pipelines::save(
-        repo_root,
-        Some(id),
-        &parsed.pipeline.name,
-        &req.yaml,
-        &req.prompts,
-        store_scope,
-    ) {
-        Ok(_) => {
-            info!("Library pipeline {id} saved");
-            (StatusCode::OK, Json(serde_json::json!({ "ok": true }))).into_response()
-        }
-        Err(e) => {
-            let msg = format!("write failed: {e}");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({ "error": msg.clone(), "message": msg })),
-            )
-                .into_response()
-        }
-    }
-}
-
-/// Delete a library pipeline (YAML + prompts + meta sidecar) from the library
-/// store, in the 200/`{ok:true}` shape `delete_pipeline` uses. Routed here when
-/// `DELETE /pipelines/{id}?scope=library` so a library delete never resolves to
-/// a same-named repo file (#216).
-#[allow(dead_code)]
-fn delete_library_pipeline_response(repo_root: &std::path::Path, id: &str) -> Response {
-    match library_store::pipelines::delete(repo_root, id) {
-        Ok(true) => {
-            info!("Deleted library pipeline {id}");
-            (StatusCode::OK, Json(serde_json::json!({ "ok": true }))).into_response()
-        }
-        Ok(false) => (StatusCode::NOT_FOUND, "pipeline not found").into_response(),
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({ "error": format!("delete failed: {e}") })),
-        )
-            .into_response(),
-    }
-}
-
 async fn delete_pipeline(
     State(state): State<Arc<AppState>>,
     AxumPath(pipeline_id): AxumPath<String>,
@@ -7038,27 +6761,6 @@ async fn delete_pipeline(
 
     info!("Deleted pipeline {pipeline_id}");
     (StatusCode::OK, Json(serde_json::json!({ "ok": true }))).into_response()
-}
-
-async fn promote_pipeline(
-    State(state): State<Arc<AppState>>,
-    AxumPath(pipeline_id): AxumPath<String>,
-) -> Response {
-    match library_store::pipelines::promote(&state.repo_root, &pipeline_id) {
-        Ok(id) => {
-            let drifted = library_store::pipelines::check_drift(&id);
-            Json(serde_json::json!({
-                "id": id,
-                "drifted": drifted.unwrap_or(false),
-            }))
-            .into_response()
-        }
-        Err(e) => (
-            StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({ "error": e })),
-        )
-            .into_response(),
-    }
 }
 
 // --- API handlers ---
@@ -10424,13 +10126,9 @@ async fn get_agent_profile_referents(
         })
         .collect::<Vec<_>>();
 
-    let mut pipeline_entries = scan_pipeline_dir(&state.repo_root.join(".pdo/pipelines"), "repo");
-    if let Some(home) = dirs_next_home() {
-        pipeline_entries.extend(scan_pipeline_dir(&home.join(".pdo/pipelines"), "user"));
-    }
-    if let Some(directory) = library_store::pipelines::user_pipelines_dir() {
-        pipeline_entries.extend(scan_pipeline_dir(&directory, "library"));
-    }
+    let pipeline_entries = instance_pipeline_dir(&state.repo_root)
+        .map(|directory| scan_pipeline_dir(&directory, "instance"))
+        .unwrap_or_default();
     let pipelines = pipeline_entries
         .into_iter()
         .flat_map(|entry| {
@@ -15494,10 +15192,6 @@ struct LibassistFocusRequest {
     /// The template being edited, or `null` to clear the focus (the user left
     /// every edit view).
     pipeline_id: Option<String>,
-    /// The edit tab's scope: `repo` | `user` | `library`. Ignored when
-    /// `pipeline_id` is `null`.
-    #[serde(default)]
-    scope: Option<String>,
 }
 
 /// Resolve the absolute YAML path of a focused template — **the daemon's job, not
@@ -15512,19 +15206,9 @@ struct LibassistFocusRequest {
 ///
 /// `None` for a template that has no file yet (never saved) and for a path that
 /// does not exist: a legitimate state, not an error.
-fn resolve_focus_path(
-    repo_root: &std::path::Path,
-    pipeline_id: &str,
-    scope: &str,
-) -> Option<PathBuf> {
-    match scope {
-        // The library store has its own layout and its own lookup.
-        "library" => library_store::pipelines::get_path(repo_root, pipeline_id),
-        _ => {
-            let path = resolve_pipeline_path_scoped(repo_root, pipeline_id, Some(scope));
-            path.exists().then_some(path)
-        }
-    }
+fn resolve_focus_path(repo_root: &std::path::Path, pipeline_id: &str) -> Option<PathBuf> {
+    let path = resolve_pipeline_path(repo_root, pipeline_id);
+    path.exists().then_some(path)
 }
 
 /// Declare (or clear) which template the UI is editing — and, by the same token,
@@ -15547,22 +15231,12 @@ async fn put_libassist_focus(
         return Json(serde_json::json!({ "ok": true, "pipeline_id": null })).into_response();
     };
 
-    let scope = req.scope.unwrap_or_else(|| "repo".to_string());
-    if !matches!(scope.as_str(), "repo" | "user" | "library") {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({ "error": format!("unknown scope: {scope}") })),
-        )
-            .into_response();
-    }
-
     // An id that resolves to no file is NOT an error: a template can be open in
     // the canvas and not yet saved. Store the focus with a null path and let the
     // assistant read the id.
-    let path = resolve_focus_path(&state.repo_root, &pipeline_id, &scope);
+    let path = resolve_focus_path(&state.repo_root, &pipeline_id);
     let focus = LibassistFocus {
         pipeline_id,
-        scope,
         path,
         at: chrono::Utc::now(),
     };
@@ -15634,7 +15308,6 @@ fn libassist_focus_json(
         }),
         Some(f) => serde_json::json!({
             "pipeline_id": f.pipeline_id,
-            "scope": f.scope,
             "path": f.path.as_ref().map(|p| p.to_string_lossy()),
             "age_secs": now.signed_duration_since(f.at).num_seconds().max(0),
         }),
@@ -15660,13 +15333,11 @@ fn libassist_focus_text(focus: Option<&LibassistFocus>) -> String {
                 None => "(pas encore de fichier sur le disque — template non sauvée)".to_string(),
             };
             format!(
-                "PDO — pipeline actuellement ouverte dans l'UI : `{}` (scope `{}`), fichier : {}\n\
+                "PDO — pipeline actuellement ouverte dans l'UI : `{}`, fichier : {}\n\
                  Travaille sur celle-là, sans la deviner ni la redemander. Pour écrire, un seul \
                  endpoint : POST /sessions/libassist/save avec `{{\"yaml\": …, \"prompts\": …}}` — \
-                 il écrit dans CE fichier, sans id ni scope à fournir. N'utilise jamais \
-                 POST /library/pipelines pour sauver la template ouverte : il écrit dans le \
-                 library store, donc à côté du fichier édité.\n",
-                f.pipeline_id, f.scope, path
+                 il écrit dans CE fichier, sans id ni scope à fournir.\n",
+                f.pipeline_id, path
             )
         }
     }
@@ -15715,86 +15386,43 @@ async fn save_libassist_focused(
 
     // Same gate as `PUT /pipelines/{id}`: a template that does not parse must not
     // reach disk, where it would break the canvas the user is looking at.
-    let parsed = match pipeline::parse_pipeline(&req.yaml) {
-        Ok(r) => r,
-        Err(e) => {
-            let (message, line) = parse_error_to_structured(&e);
-            let mut body =
-                serde_json::json!({ "error": format!("invalid YAML: {e}"), "message": message });
-            if let Some(l) = line {
-                body["line"] = serde_json::json!(l);
-            }
-            return (StatusCode::BAD_REQUEST, Json(body)).into_response();
+    if let Err(e) = pipeline::parse_pipeline(&req.yaml) {
+        let (message, line) = parse_error_to_structured(&e);
+        let mut body =
+            serde_json::json!({ "error": format!("invalid YAML: {e}"), "message": message });
+        if let Some(l) = line {
+            body["line"] = serde_json::json!(l);
         }
-    };
+        return (StatusCode::BAD_REQUEST, Json(body)).into_response();
+    }
 
     let id = focus.pipeline_id.clone();
-    let path = if focus.scope == "library" {
-        // The library store owns its own layout *and* its own scope enum. Read the
-        // entry's current store off disk rather than mapping the edit tab's word
-        // onto it — the mapping is precisely what went wrong before.
-        let store_scope = library_store::pipelines::get_scope(&state.repo_root, &id)
-            .unwrap_or(library_store::pipelines::Scope::User);
-        if let Err(e) = library_store::pipelines::save(
-            &state.repo_root,
-            Some(&id),
-            &parsed.pipeline.name,
-            &req.yaml,
-            &req.prompts,
-            store_scope,
-        ) {
-            let msg = format!("write failed: {e}");
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({ "error": msg.clone(), "message": msg })),
-            )
-                .into_response();
-        }
-        match library_store::pipelines::get_path(&state.repo_root, &id) {
-            Some(p) => p,
-            None => {
-                let msg = "write reported success but the template is not in the library store"
-                    .to_string();
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(serde_json::json!({ "error": msg.clone(), "message": msg })),
-                )
-                    .into_response();
-            }
-        }
-    } else {
-        let path = resolve_pipeline_path_scoped(&state.repo_root, &id, Some(&focus.scope));
-        if let Some(parent) = path.parent() {
+    let path = resolve_pipeline_path(&state.repo_root, &id);
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    mark_self_write(&state.recent_writes, &path);
+    if let Err(e) = std::fs::write(&path, &req.yaml) {
+        let msg = format!("write failed: {e}");
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({ "error": msg.clone(), "message": msg })),
+        )
+            .into_response();
+    }
+    for (node_id, content) in &req.prompts {
+        let prompt_path = pipeline::canonical_prompt_path(&path, node_id);
+        if let Some(parent) = prompt_path.parent() {
             let _ = std::fs::create_dir_all(parent);
         }
-        mark_self_write(&state.recent_writes, &path);
-        if let Err(e) = std::fs::write(&path, &req.yaml) {
-            let msg = format!("write failed: {e}");
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({ "error": msg.clone(), "message": msg })),
-            )
-                .into_response();
+        mark_self_write(&state.recent_writes, &prompt_path);
+        if let Err(e) = std::fs::write(&prompt_path, content) {
+            warn!("failed to write prompt for {node_id}: {e}");
         }
-        for (node_id, content) in &req.prompts {
-            let prompt_path = pipeline::canonical_prompt_path(&path, node_id);
-            if let Some(parent) = prompt_path.parent() {
-                let _ = std::fs::create_dir_all(parent);
-            }
-            mark_self_write(&state.recent_writes, &prompt_path);
-            if let Err(e) = std::fs::write(&prompt_path, content) {
-                warn!("failed to write prompt for {node_id}: {e}");
-            }
-        }
-        path
-    };
+    }
 
-    // Announce the write ourselves instead of waiting for the file watcher to
-    // notice. Two reasons, one per scope: the repo/user write is marked as a
-    // self-write (the suppression that stops the UI's own saves from bouncing
-    // back), and the library store is not watched at all. Without this the canvas
-    // would sit on stale YAML until the user reopened the tab — the symptom the
-    // user reads as "it said it saved and nothing happened".
+    // Announce the write ourselves because self-writes are suppressed by the
+    // watcher; otherwise the canvas would remain stale until reopened.
     let _ = state.pipeline_tx.send(serde_json::json!({
         "type": "pipeline_changed",
         "pipeline_id": id,
@@ -15802,8 +15430,7 @@ async fn save_libassist_focused(
     }));
 
     info!(
-        "Library assistant saved template {id} (scope {}) at {}",
-        focus.scope,
+        "Library assistant saved template {id} at {}",
         path.display()
     );
     (
@@ -15811,7 +15438,6 @@ async fn save_libassist_focused(
         Json(serde_json::json!({
             "ok": true,
             "id": id,
-            "scope": focus.scope,
             "path": path.to_string_lossy(),
         })),
     )
@@ -17314,13 +16940,15 @@ fn edge_info_from_pipeline(e: &pipeline::EdgeDef) -> event_log::EdgeInfo {
 }
 
 fn instance_pipeline_dir(repo_root: &Path) -> Option<PathBuf> {
-    if cfg!(debug_assertions)
+    // Unit and integration tests isolate the instance registry inside their
+    // temporary repo. The handlers and migration logic remain identical.
+    let integration_test_binary = cfg!(debug_assertions)
         && std::env::current_exe()
             .ok()
             .and_then(|path| path.file_name().map(|name| name.to_owned()))
             .and_then(|name| name.to_str().map(str::to_owned))
-            .is_some_and(|name| name.starts_with("it-"))
-    {
+            .is_some_and(|name| name.starts_with("it-"));
+    if cfg!(test) || integration_test_binary {
         return Some(repo_root.join(".pdo").join("pipelines"));
     }
     dirs_next_home().map(|home| home.join(".pdo").join("pipelines"))
@@ -17422,7 +17050,6 @@ fn publish_migrated_pipeline(
     result
 }
 
-#[cfg(not(test))]
 fn migrate_legacy_pipelines(repo_root: &Path) -> Result<(), String> {
     let Some(target) = instance_pipeline_dir(repo_root) else {
         return Err("cannot determine instance pipeline directory".into());
@@ -17440,7 +17067,10 @@ fn migrate_legacy_pipelines(repo_root: &Path) -> Result<(), String> {
         return Ok(());
     }
     std::fs::create_dir_all(&target).map_err(|e| format!("create pipeline registry: {e}"))?;
-    let mut sources = vec![repo_root.join(".pdo").join("pipelines")];
+    // The former user-scoped `~/.pdo/pipelines` directory is the unified
+    // registry itself, so its entries remain in place. Include it in the scan
+    // to make that no-loss case explicit and collision-safe.
+    let mut sources = vec![target.clone(), repo_root.join(".pdo").join("pipelines")];
     if let Some(home) = dirs_next_home() {
         sources.push(home.join(".pdo").join("library").join("pipelines"));
     }
@@ -17482,39 +17112,14 @@ fn migrate_legacy_pipelines(repo_root: &Path) -> Result<(), String> {
     std::fs::write(marker, b"1\n").map_err(|e| format!("finish pipeline migration: {e}"))
 }
 
-#[cfg(not(test))]
 fn pipeline_scope_for_response(_repo_root: &Path, _path: &Path) -> &'static str {
     "instance"
 }
 
-#[cfg(test)]
-fn pipeline_scope_for_response(repo_root: &Path, path: &Path) -> &'static str {
-    if path.starts_with(repo_root) {
-        "repo"
-    } else {
-        "user"
-    }
-}
-
-#[cfg(not(test))]
 fn resolve_pipeline_path(repo_root: &std::path::Path, pipeline_name: &str) -> PathBuf {
     instance_pipeline_dir(repo_root)
         .unwrap_or_else(|| repo_root.join(".pdo").join("pipelines"))
         .join(format!("{pipeline_name}.yaml"))
-}
-
-#[cfg(test)]
-fn resolve_pipeline_path(repo_root: &std::path::Path, pipeline_name: &str) -> PathBuf {
-    let repo_path = repo_root
-        .join(".pdo")
-        .join("pipelines")
-        .join(format!("{pipeline_name}.yaml"));
-    if repo_path.exists() {
-        return repo_path;
-    }
-    instance_pipeline_dir(repo_root)
-        .map(|dir| dir.join(format!("{pipeline_name}.yaml")))
-        .unwrap_or(repo_path)
 }
 
 #[allow(dead_code)]
@@ -17523,24 +17128,6 @@ fn repo_pipeline_path(repo_root: &std::path::Path, pipeline_name: &str) -> PathB
         .join(".pdo")
         .join("pipelines")
         .join(format!("{pipeline_name}.yaml"))
-}
-
-/// Resolve a pipeline YAML path honoring an explicit `scope` when one is given.
-///
-/// `Some("repo")` / `Some("user")` resolve *strictly* to that store: the
-/// operation never falls through to a same-named file in another store, which
-/// is the root cause of #216 (a `user`/`library` delete destroying a `repo`
-/// file). `None` keeps the historical best-effort behavior (repo first, then
-/// user, defaulting to repo). `Some("library")` lives in a different on-disk
-/// store and is handled by callers via `library_store::pipelines`, so it is
-/// treated here as "unknown" and falls back to the default — callers must
-/// branch on `library` *before* calling this.
-fn resolve_pipeline_path_scoped(
-    repo_root: &std::path::Path,
-    pipeline_name: &str,
-    _scope: Option<&str>,
-) -> PathBuf {
-    resolve_pipeline_path(repo_root, pipeline_name)
 }
 
 fn resolve_run_pipeline_path(
@@ -17963,6 +17550,47 @@ mod tests {
     }
 
     #[test]
+    fn migration_moves_legacy_library_pipelines_once_and_preserves_collisions() {
+        let fake_home = FakeHome::new();
+        let repo = tempfile::tempdir().unwrap();
+        let registry = repo.path().join(".pdo/pipelines");
+        std::fs::create_dir_all(&registry).unwrap();
+        std::fs::write(registry.join("review.yaml"), "name: Repo review\n").unwrap();
+        std::fs::write(registry.join("personal.yaml"), "name: Personal\n").unwrap();
+        std::fs::create_dir(registry.join("review.prompts")).unwrap();
+        std::fs::write(registry.join("review.prompts/worker.md"), "repo prompt").unwrap();
+
+        let legacy = fake_home.path().join(".pdo/library/pipelines");
+        std::fs::create_dir_all(&legacy).unwrap();
+        std::fs::write(legacy.join("review.yaml"), "name: Library review\n").unwrap();
+        std::fs::create_dir(legacy.join("review.prompts")).unwrap();
+        std::fs::write(legacy.join("review.prompts/worker.md"), "library prompt").unwrap();
+
+        migrate_legacy_pipelines(repo.path()).unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(registry.join("review.yaml")).unwrap(),
+            "name: Repo review\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(registry.join("personal.yaml")).unwrap(),
+            "name: Personal\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(registry.join("review-2.yaml")).unwrap(),
+            "name: Library review\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(registry.join("review-2.prompts/worker.md")).unwrap(),
+            "library prompt"
+        );
+
+        std::fs::write(legacy.join("late.yaml"), "name: Late\n").unwrap();
+        migrate_legacy_pipelines(repo.path()).unwrap();
+        assert!(!registry.join("late.yaml").exists());
+    }
+
+    #[test]
     fn available_pipeline_identity_avoids_an_existing_name_with_a_different_id() {
         let registry = tempfile::tempdir().unwrap();
         std::fs::write(
@@ -17974,6 +17602,19 @@ mod tests {
         assert_eq!(
             available_pipeline_identity(registry.path(), "Release train"),
             ("release-train-2".into(), "Release train (2)".into())
+        );
+    }
+
+    #[test]
+    fn available_pipeline_identity_collapses_name_punctuation_in_the_file_id() {
+        let registry = tempfile::tempdir().unwrap();
+
+        assert_eq!(
+            available_pipeline_identity(registry.path(), "Release train (2) (copy)"),
+            (
+                "release-train-2-copy".into(),
+                "Release train (2) (copy)".into()
+            )
         );
     }
 
@@ -24960,7 +24601,7 @@ mod tests {
         assert_eq!(list.len(), 2);
         assert!(list.iter().any(|p| p["id"] == "test-pipe"));
         assert!(list.iter().any(|p| p["id"] == "another-pipe"));
-        assert!(list.iter().all(|p| p["scope"] == "repo"));
+        assert!(list.iter().all(|p| p["scope"] == "instance"));
     }
 
     #[tokio::test]
@@ -25763,7 +25404,7 @@ edges:
             .unwrap();
         let result: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(result["id"], "new-pipeline");
-        assert_eq!(result["scope"], "repo");
+        assert_eq!(result["scope"], "instance");
 
         let yaml_path = tmp
             .path()
@@ -26030,7 +25671,7 @@ edges:
         let list: Vec<serde_json::Value> = serde_json::from_slice(&body).unwrap();
         let entry = &list[0];
         assert_eq!(entry["name"], "meta-pipe");
-        assert_eq!(entry["scope"], "repo");
+        assert_eq!(entry["scope"], "instance");
         assert_eq!(entry["node_count"], 3);
         assert!(entry["modified"].as_str().is_some());
     }
@@ -26088,7 +25729,7 @@ edges:
     #[tokio::test]
     #[allow(clippy::await_holding_lock)]
     async fn import_library_workflow_returns_201_and_writes_draft() {
-        let fake_home = FakeHome::new();
+        let _fake_home = FakeHome::new();
         let repo = tempfile::tempdir().unwrap();
         let state = test_state_with_dir(repo.path()).await;
         let app = build_router(state);
@@ -26126,7 +25767,7 @@ edges:
 
         // The draft YAML + prompt sidecars land in the isolated instance registry.
         let id = result["id"].as_str().unwrap();
-        let registry = fake_home.path().join(".pdo/pipelines");
+        let registry = repo.path().join(".pdo/pipelines");
         assert!(
             registry.join(format!("{id}.yaml")).exists(),
             "draft YAML written to instance registry"
@@ -26168,9 +25809,8 @@ edges:
     }
 
     #[tokio::test]
-    #[ignore = "obsolete: production no longer reads the pipeline library"]
     #[allow(clippy::await_holding_lock)]
-    async fn list_pipelines_includes_library_with_drift() {
+    async fn list_pipelines_migrates_an_identical_legacy_copy_once() {
         let fake_home = FakeHome::new();
 
         write_test_pipeline(fake_home.path(), "repo-pipe");
@@ -26196,19 +25836,15 @@ edges:
             .unwrap();
         let list: Vec<serde_json::Value> = serde_json::from_slice(&body).unwrap();
 
-        let repo_entry = list.iter().find(|p| p["scope"] == "repo").unwrap();
-        assert_eq!(repo_entry["id"], "repo-pipe");
-        assert!(repo_entry.get("drifted").is_none() || repo_entry["drifted"].is_null());
-
-        let lib_entry = list.iter().find(|p| p["scope"] == "library").unwrap();
-        assert_eq!(lib_entry["id"], "repo-pipe");
-        assert_eq!(lib_entry["drifted"], false);
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0]["id"], "repo-pipe");
+        assert_eq!(list[0]["scope"], "instance");
+        assert!(list[0].get("drifted").is_none());
     }
 
     #[tokio::test]
-    #[ignore = "obsolete: production no longer reports library drift"]
     #[allow(clippy::await_holding_lock)]
-    async fn list_pipelines_library_shows_drift_after_source_change() {
+    async fn list_pipelines_preserves_a_different_legacy_copy_as_a_collision() {
         let fake_home = FakeHome::new();
 
         write_test_pipeline(fake_home.path(), "drifting");
@@ -26239,8 +25875,11 @@ edges:
             .await
             .unwrap();
         let list: Vec<serde_json::Value> = serde_json::from_slice(&body).unwrap();
-        let lib_entry = list.iter().find(|p| p["scope"] == "library").unwrap();
-        assert_eq!(lib_entry["drifted"], true);
+        assert_eq!(list.len(), 2);
+        assert!(list.iter().all(|entry| entry["scope"] == "instance"));
+        assert!(list.iter().all(|entry| entry.get("drifted").is_none()));
+        assert!(list.iter().any(|entry| entry["id"] == "drifting"));
+        assert!(list.iter().any(|entry| entry["id"] == "drifting-2"));
     }
 
     #[tokio::test]
@@ -26294,14 +25933,9 @@ edges:
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
     }
 
-    // #216 — the core data-loss regression. A `scope=library` delete of an id
-    // that ALSO exists as a repo pipeline (the normal outcome of "promote to
-    // library") must remove only the library copy and never the repo YAML or
-    // its `.prompts/` sidecar.
     #[tokio::test]
-    #[ignore = "obsolete: pipeline CRUD has no library scope"]
     #[allow(clippy::await_holding_lock)]
-    async fn delete_pipeline_scope_library_spares_repo_file() {
+    async fn delete_pipeline_ignores_retired_scope_and_deletes_the_instance_copy() {
         let fake_home = FakeHome::new();
         write_test_pipeline(fake_home.path(), "simple-bugfix");
         // A sidecar prompts dir proves the `remove_dir_all` never reaches the repo.
@@ -26333,29 +25967,20 @@ edges:
 
         assert_eq!(resp.status(), StatusCode::OK);
 
-        // Library copy is gone — the intended target.
-        assert!(!lib_yaml.exists(), "library copy should be deleted");
-        // Repo YAML + sidecar are untouched — the file the user never targeted.
         assert!(
-            fake_home
-                .path()
-                .join(".pdo/pipelines/simple-bugfix.yaml")
-                .exists(),
-            "repo YAML must survive a library-scoped delete"
+            lib_yaml.exists(),
+            "legacy library copy is not a CRUD target"
         );
-        assert!(
-            repo_prompts.join("worker.md").exists(),
-            "repo .prompts/ sidecar must survive a library-scoped delete"
-        );
+        assert!(!fake_home
+            .path()
+            .join(".pdo/pipelines/simple-bugfix.yaml")
+            .exists());
+        assert!(!repo_prompts.exists());
     }
 
-    // #216, fix direction 3 — a promoted library entry stays openable from its
-    // own stored YAML even when the source repo file is gone. The bare-id GET
-    // (no scope) 404s in that state; the scoped GET resolves the library copy.
     #[tokio::test]
-    #[ignore = "obsolete: pipeline CRUD has no library scope"]
     #[allow(clippy::await_holding_lock)]
-    async fn get_pipeline_scope_library_reads_own_yaml_when_repo_absent() {
+    async fn get_pipeline_does_not_fall_back_to_a_legacy_library_copy() {
         let fake_home = FakeHome::new();
         write_test_pipeline(fake_home.path(), "promoted");
         library_store::pipelines::promote(fake_home.path(), "promoted").unwrap();
@@ -26377,7 +26002,6 @@ edges:
             .unwrap();
         assert_eq!(bare.status(), StatusCode::NOT_FOUND);
 
-        // Scoped open reads the library entry's own YAML.
         let app = build_router(state);
         let resp = app
             .oneshot(
@@ -26388,29 +26012,17 @@ edges:
             )
             .await
             .unwrap();
-        assert_eq!(resp.status(), StatusCode::OK);
-        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
-            .await
-            .unwrap();
-        let val: serde_json::Value = serde_json::from_slice(&body).unwrap();
-        assert_eq!(val["scope"], "library");
-        assert_eq!(val["id"], "promoted");
-        assert!(val["yaml"].as_str().unwrap().contains("name: promoted"));
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
     }
 
-    // #216 — a `scope=library` save writes back into the library store, never
-    // the same-named repo file.
     #[tokio::test]
-    #[ignore = "obsolete: pipeline CRUD has no library scope"]
     #[allow(clippy::await_holding_lock)]
-    async fn save_pipeline_scope_library_writes_library_not_repo() {
+    async fn save_pipeline_ignores_retired_scope_and_writes_the_instance_copy() {
         let fake_home = FakeHome::new();
         write_test_pipeline(fake_home.path(), "shared");
         library_store::pipelines::promote(fake_home.path(), "shared").unwrap();
 
         let repo_yaml_path = fake_home.path().join(".pdo/pipelines/shared.yaml");
-        let repo_before = std::fs::read_to_string(&repo_yaml_path).unwrap();
-
         let state = test_state_with_dir(fake_home.path()).await;
         let app = build_router(state);
 
@@ -26430,25 +26042,18 @@ edges:
             .unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
 
-        // Library copy reflects the edit; repo copy is byte-for-byte unchanged.
         let lib_yaml = library_store::pipelines::get_yaml(fake_home.path(), "shared").unwrap();
-        assert!(lib_yaml.contains("9.9"));
-        assert_eq!(
-            std::fs::read_to_string(&repo_yaml_path).unwrap(),
-            repo_before
-        );
+        assert!(!lib_yaml.contains("9.9"));
+        assert!(std::fs::read_to_string(&repo_yaml_path)
+            .unwrap()
+            .contains("9.9"));
     }
 
-    // #241 (regression lock) — unchecking « Prompt required » on a library
-    // template (`scope=library`) must survive the save→read round-trip:
-    // `prompt_required: false` is written verbatim to the library store, the
-    // scoped GET reports `false`, and no `unknown field 'prompt_required'`
-    // diagnostic fires. The bug was fixed by #216 (the scope=library save path);
-    // this test guards against a silent regression on that surface.
+    // Retired scope query parameters cannot redirect a save away from the
+    // instance registry; ordinary fields still survive the round trip.
     #[tokio::test]
-    #[ignore = "obsolete: pipeline CRUD has no library scope"]
     #[allow(clippy::await_holding_lock)]
-    async fn save_pipeline_scope_library_preserves_prompt_required_false() {
+    async fn save_pipeline_with_retired_scope_preserves_prompt_required_false() {
         let fake_home = FakeHome::new();
         // Seeded WITHOUT the flag => defaults to `prompt_required: true`, so
         // saving `false` below is a genuine state transition (non-vacuous).
@@ -26477,14 +26082,13 @@ edges:
             .unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
 
-        // On-disk library YAML keeps the flag verbatim.
         let lib_yaml = library_store::pipelines::get_yaml(fake_home.path(), "shared").unwrap();
         assert!(
-            lib_yaml.contains("prompt_required: false"),
-            "library YAML must persist prompt_required: false, got: {lib_yaml}"
+            !lib_yaml.contains("prompt_required: false"),
+            "legacy library YAML must remain untouched, got: {lib_yaml}"
         );
 
-        // Read-back via scope=library exposes `false`, verbatim yaml, no diagnostic.
+        // Read-back exposes `false`, verbatim yaml, and no diagnostic.
         let app = build_router(state);
         let resp = app
             .oneshot(
@@ -26517,14 +26121,11 @@ edges:
         );
     }
 
-    // #216 (defense in depth) — an explicit `scope=user` delete resolves
-    // strictly to the user store and never falls through to a same-named repo
-    // pipeline (repo_root and HOME are kept distinct here so the two stores have
-    // genuinely separate paths).
+    // A retired user-scope query cannot redirect deletion away from the
+    // instance registry or mutate the old user location.
     #[tokio::test]
-    #[ignore = "obsolete: pipeline CRUD has no user scope"]
     #[allow(clippy::await_holding_lock)]
-    async fn delete_pipeline_scope_user_does_not_touch_repo() {
+    async fn delete_pipeline_with_retired_user_scope_deletes_the_instance_copy() {
         let fake_home = FakeHome::new();
         let repo = tempfile::tempdir().unwrap();
         write_test_pipeline(repo.path(), "foo");
@@ -26552,11 +26153,11 @@ edges:
             .unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
 
-        assert!(!user_dir.join("foo.yaml").exists(), "user copy deleted");
         assert!(
-            repo.path().join(".pdo/pipelines/foo.yaml").exists(),
-            "repo copy must survive a user-scoped delete"
+            user_dir.join("foo.yaml").exists(),
+            "legacy user copy is untouched"
         );
+        assert!(!repo.path().join(".pdo/pipelines/foo.yaml").exists());
     }
 
     #[tokio::test]

--- a/crates/pdo-daemon/src/library_store.rs
+++ b/crates/pdo-daemon/src/library_store.rs
@@ -576,6 +576,7 @@ pub(crate) mod pipelines {
         None
     }
 
+    #[allow(dead_code)]
     pub(crate) fn get_yaml(repo_root: &Path, id: &str) -> Option<String> {
         let (path, _) = locate(repo_root, id)?;
         std::fs::read_to_string(&path).ok()

--- a/crates/pdo-daemon/src/library_store.rs
+++ b/crates/pdo-daemon/src/library_store.rs
@@ -240,6 +240,7 @@ pub(crate) fn sync_state(node: &pipeline::NodeDef, prompt: &str) -> SyncState {
     }
 }
 
+#[cfg(test)]
 pub(crate) mod pipelines {
     use std::collections::HashMap;
     use std::path::{Path, PathBuf};
@@ -253,24 +254,6 @@ pub(crate) mod pipelines {
         Repo,
         User,
         Library,
-    }
-
-    impl Scope {
-        pub(crate) fn parse(s: &str) -> Option<Scope> {
-            match s {
-                "repo" => Some(Scope::Repo),
-                "user" => Some(Scope::User),
-                "library" => Some(Scope::Library),
-                _ => None,
-            }
-        }
-        pub(crate) fn as_str(self) -> &'static str {
-            match self {
-                Scope::Repo => "repo",
-                Scope::User => "user",
-                Scope::Library => "library",
-            }
-        }
     }
 
     #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -584,10 +567,6 @@ pub(crate) mod pipelines {
 
     pub(crate) fn get_path(repo_root: &Path, id: &str) -> Option<PathBuf> {
         locate(repo_root, id).map(|(p, _)| p)
-    }
-
-    pub(crate) fn get_scope(repo_root: &Path, id: &str) -> Option<Scope> {
-        locate(repo_root, id).map(|(_, s)| s)
     }
 
     /// Save a library pipeline, supporting rename-in-place.

--- a/crates/pdo-daemon/src/pipeline_watcher.rs
+++ b/crates/pdo-daemon/src/pipeline_watcher.rs
@@ -24,7 +24,7 @@ const POLL_INTERVAL: Duration = Duration::from_secs(1);
 /// thousands of watches). Without the fallback, a failed `watch()` silently
 /// disabled hot-reload and external-edit detection for that path.
 ///
-/// Every watched path is small (a pipelines dir, a run dir, a prompts dir),
+/// Every watched path is small (the instance pipelines dir, a run dir, a prompts dir),
 /// so polling them is cheap; each path is registered with exactly one
 /// backend, so no event is ever delivered twice.
 pub(crate) struct PipelineDebouncer {
@@ -67,25 +67,22 @@ pub(crate) struct RunPipelineModified {
 
 pub(crate) fn spawn_watcher(
     repo_root: PathBuf,
+    instance_pipelines_dir: Option<PathBuf>,
     event_tx: broadcast::Sender<serde_json::Value>,
     recent_writes: Arc<Mutex<HashMap<PathBuf, Instant>>>,
     run_modified_tx: tokio::sync::mpsc::UnboundedSender<RunPipelineModified>,
 ) -> Option<PipelineDebouncer> {
-    let repo_pipelines_dir = repo_root.join(".pdo").join("pipelines");
     let runs_dir = repo_root.join(".pdo").join("runs");
-    let user_pipelines_dir = std::env::var_os("HOME")
-        .map(PathBuf::from)
-        .map(|h| h.join(".pdo").join("pipelines"));
 
     let tx = Arc::new(event_tx);
     let mtimes: Arc<Mutex<HashMap<PathBuf, SystemTime>>> = Arc::new(Mutex::new(HashMap::new()));
-    seed_mtimes(&mtimes, &repo_pipelines_dir);
-    if let Some(ref user_dir) = user_pipelines_dir {
-        seed_mtimes(&mtimes, user_dir);
+    if let Some(ref pipeline_dir) = instance_pipelines_dir {
+        seed_mtimes(&mtimes, pipeline_dir);
     }
     seed_run_mtimes(&mtimes, &runs_dir);
 
     let runs_dir_for_closure = runs_dir.clone();
+    let pipelines_dir_for_closure = instance_pipelines_dir.clone();
 
     // One shared handler, fed by both backends (a given path only ever
     // reports through the backend that registered it).
@@ -126,6 +123,12 @@ pub(crate) fn spawn_watcher(
                         );
                         let _ = run_modified_tx.send(modified);
                     }
+                    continue;
+                }
+                if !pipelines_dir_for_closure
+                    .as_deref()
+                    .is_some_and(|dir| is_managed_pipeline_change(path, dir))
+                {
                     continue;
                 }
 
@@ -199,22 +202,14 @@ pub(crate) fn spawn_watcher(
     }
     let mut debouncer = PipelineDebouncer { native, poll };
 
-    if !repo_pipelines_dir.exists() {
-        let _ = std::fs::create_dir_all(&repo_pipelines_dir);
-    }
-    if let Err(e) = debouncer.watch(&repo_pipelines_dir, notify::RecursiveMode::Recursive) {
-        warn!("Failed to watch repo pipelines dir: {e}");
-    } else {
-        info!("Watching repo pipelines: {}", repo_pipelines_dir.display());
-    }
-
-    if let Some(ref user_dir) = user_pipelines_dir {
-        if user_dir.exists() {
-            if let Err(e) = debouncer.watch(user_dir, notify::RecursiveMode::Recursive) {
-                warn!("Failed to watch user pipelines dir: {e}");
-            } else {
-                info!("Watching user pipelines: {}", user_dir.display());
-            }
+    if let Some(ref pipeline_dir) = instance_pipelines_dir {
+        if !pipeline_dir.exists() {
+            let _ = std::fs::create_dir_all(pipeline_dir);
+        }
+        if let Err(e) = debouncer.watch(pipeline_dir, notify::RecursiveMode::Recursive) {
+            warn!("Failed to watch instance pipelines dir: {e}");
+        } else {
+            info!("Watching instance pipelines: {}", pipeline_dir.display());
         }
     }
 
@@ -237,6 +232,10 @@ pub(crate) fn spawn_watcher(
     }
 
     Some(debouncer)
+}
+
+fn is_managed_pipeline_change(path: &Path, instance_pipelines_dir: &Path) -> bool {
+    path.starts_with(instance_pipelines_dir)
 }
 
 /// Watch a single run directory for the only run-scoped files the daemon
@@ -469,5 +468,19 @@ mod tests {
         let runs = Path::new("/repo/.pdo/runs");
         let path = Path::new("/repo/.pdo/pipelines/my-pipeline.yaml");
         assert!(detect_run_scoped_change(path, runs).is_none());
+    }
+
+    #[test]
+    fn only_instance_registry_paths_are_pipeline_changes() {
+        let instance = Path::new("/home/user/.pdo/pipelines");
+
+        assert!(is_managed_pipeline_change(
+            Path::new("/home/user/.pdo/pipelines/managed.yaml"),
+            instance
+        ));
+        assert!(!is_managed_pipeline_change(
+            Path::new("/repo/.pdo/pipelines/legacy.yaml"),
+            instance
+        ));
     }
 }

--- a/crates/pdo-daemon/src/portable_pipeline.rs
+++ b/crates/pdo-daemon/src/portable_pipeline.rs
@@ -101,10 +101,26 @@ pub(crate) fn interpret(source: &str) -> Result<InterpretedDocument, String> {
         ));
     }
 
-    let document: PortablePipelineDocument =
-        serde_yaml::from_value(value).map_err(|e| format!("invalid pipeline document: {e}"))?;
-    let portable = serde_yaml::from_value(document.pipeline)
-        .map_err(|e| format!("pipeline: invalid definition: {e}"))?;
+    let document: PortablePipelineDocument = serde_yaml::from_value(value).map_err(|e| {
+        if e.to_string().starts_with("missing field") {
+            format!(
+                "truncated or incomplete pipeline document at line {}: {e}",
+                source.lines().count().max(1)
+            )
+        } else {
+            format!("invalid pipeline document: {e}")
+        }
+    })?;
+    let portable = serde_yaml::from_value(document.pipeline).map_err(|e| {
+        if e.to_string().starts_with("missing field") {
+            format!(
+                "truncated or incomplete pipeline document at line {}: pipeline: {e}",
+                source.lines().count().max(1)
+            )
+        } else {
+            format!("pipeline: invalid definition: {e}")
+        }
+    })?;
     let portable = make_portable(portable);
 
     let canonical = serde_yaml::to_string(&portable)
@@ -282,6 +298,16 @@ mod tests {
     fn unknown_version_is_rejected_with_the_document_path() {
         let error = super::interpret("pdo_pipeline: 4\npipeline: {}\nprompts: {}\n").unwrap_err();
         assert!(error.contains("pdo_pipeline: 4"), "{error}");
+    }
+
+    #[test]
+    fn truncated_document_is_rejected_with_its_last_line() {
+        let source = "pdo_pipeline: 1\npipeline:\n  version: '1.0'\n";
+
+        let error = super::interpret(source).unwrap_err();
+
+        assert!(error.contains("truncated or incomplete"), "{error}");
+        assert!(error.contains("line 3"), "{error}");
     }
 
     #[test]

--- a/crates/pdo-daemon/src/portable_pipeline.rs
+++ b/crates/pdo-daemon/src/portable_pipeline.rs
@@ -111,6 +111,10 @@ pub(crate) fn interpret(source: &str) -> Result<InterpretedDocument, String> {
         .map_err(|e| format!("pipeline: failed to validate: {e}"))?;
     let parsed = pipeline::parse_pipeline(&canonical)
         .map_err(|e| format!("pipeline: invalid definition: {e}"))?;
+    let dangling = pipeline::dangling_edge_references(&parsed.pipeline);
+    if !dangling.is_empty() {
+        return Err(format!("pipeline.edges: {}", dangling.join("; ")));
+    }
 
     let known_nodes = parsed
         .pipeline
@@ -289,5 +293,20 @@ mod tests {
         assert!(super::interpret(&source)
             .unwrap_err()
             .contains("cannot be used as a prompt filename"));
+    }
+
+    #[test]
+    fn dangling_edge_reference_is_rejected_with_the_document_path() {
+        let source = super::export(&pipeline(), &HashMap::new())
+            .unwrap()
+            .replace(
+                "  edges: []",
+                "  edges:\n  - source:\n      node: start\n      port: user_prompt\n    target:\n      node: ghost\n      port: input",
+            );
+
+        let error = super::interpret(&source).unwrap_err();
+
+        assert!(error.contains("pipeline.edges"), "{error}");
+        assert!(error.contains("non-existent node 'ghost'"), "{error}");
     }
 }

--- a/crates/pdo-daemon/src/portable_pipeline.rs
+++ b/crates/pdo-daemon/src/portable_pipeline.rs
@@ -1,0 +1,213 @@
+use std::collections::{BTreeMap, HashMap};
+
+use serde::{Deserialize, Serialize};
+
+use crate::agent_choice::AgentChoice;
+use crate::pipeline::{self, PipelineDef};
+
+pub(crate) const VERSION: u32 = 1;
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PortablePipelineDocument {
+    pdo_pipeline: u32,
+    pipeline: PipelineDef,
+    #[serde(default)]
+    prompts: BTreeMap<String, String>,
+}
+
+#[derive(Debug)]
+pub(crate) struct InterpretedDocument {
+    pub pipeline: PipelineDef,
+    pub prompts: HashMap<String, String>,
+}
+
+fn make_portable(mut pipeline: PipelineDef) -> PipelineDef {
+    for node in &mut pipeline.nodes {
+        if matches!(node.agent_choice, Some(AgentChoice::Profile { .. })) {
+            node.agent_choice = Some(AgentChoice::Inherit);
+        }
+    }
+    pipeline
+}
+
+pub(crate) fn export(
+    pipeline: &PipelineDef,
+    prompts: &HashMap<String, String>,
+) -> Result<String, String> {
+    let portable = make_portable(pipeline.clone());
+    let yaml = serde_yaml::to_string(&portable)
+        .map_err(|e| format!("failed to validate portable pipeline: {e}"))?;
+    let canonical = pipeline::parse_pipeline(&yaml)
+        .map_err(|e| format!("failed to validate portable pipeline: {e}"))?
+        .pipeline;
+    serde_yaml::to_string(&PortablePipelineDocument {
+        pdo_pipeline: VERSION,
+        pipeline: canonical,
+        prompts: prompts
+            .iter()
+            .map(|(id, prompt)| (id.clone(), prompt.clone()))
+            .collect(),
+    })
+    .map_err(|e| format!("failed to serialize portable pipeline document: {e}"))
+}
+
+pub(crate) fn interpret(source: &str) -> Result<InterpretedDocument, String> {
+    let value: serde_yaml::Value = serde_yaml::from_str(source).map_err(|e| {
+        if let Some(location) = e.location() {
+            format!(
+                "truncated or invalid pipeline document at line {}: {e}",
+                location.line()
+            )
+        } else {
+            format!("truncated or invalid pipeline document: {e}")
+        }
+    })?;
+    let version = value
+        .as_mapping()
+        .and_then(|map| map.get(serde_yaml::Value::String("pdo_pipeline".into())))
+        .and_then(serde_yaml::Value::as_u64)
+        .ok_or_else(|| "pdo_pipeline: missing or invalid version".to_string())?;
+    if version != u64::from(VERSION) {
+        return Err(format!(
+            "pdo_pipeline: {version} is not supported (expected {VERSION})"
+        ));
+    }
+
+    let mut document: PortablePipelineDocument =
+        serde_yaml::from_value(value).map_err(|e| format!("invalid pipeline document: {e}"))?;
+    document.pipeline = make_portable(document.pipeline);
+
+    let canonical = serde_yaml::to_string(&document.pipeline)
+        .map_err(|e| format!("pipeline: failed to validate: {e}"))?;
+    let parsed = pipeline::parse_pipeline(&canonical)
+        .map_err(|e| format!("pipeline: invalid definition: {e}"))?;
+
+    let known_nodes = parsed
+        .pipeline
+        .nodes
+        .iter()
+        .map(|node| node.id.as_str())
+        .collect::<std::collections::HashSet<_>>();
+    if let Some(unsafe_id) = document.prompts.keys().find(|node_id| {
+        node_id.is_empty()
+            || *node_id == "."
+            || *node_id == ".."
+            || node_id.contains('/')
+            || node_id.contains('\\')
+    }) {
+        return Err(format!(
+            "prompts.{unsafe_id}: node id cannot be used as a prompt filename"
+        ));
+    }
+    if let Some(orphan) = document
+        .prompts
+        .keys()
+        .find(|node_id| !known_nodes.contains(node_id.as_str()))
+    {
+        return Err(format!("prompts.{orphan}: node does not exist"));
+    }
+
+    Ok(InterpretedDocument {
+        pipeline: parsed.pipeline,
+        prompts: document.prompts.into_iter().collect(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use crate::agent_choice::AgentChoice;
+    use crate::pipeline::{NodeDef, NodeType, PipelineDef, Port};
+
+    fn node(id: &str, name: &str, node_type: NodeType) -> NodeDef {
+        NodeDef {
+            id: id.into(),
+            name: name.into(),
+            node_type,
+            inputs: vec![],
+            outputs: vec![],
+            interactive: false,
+            view: None,
+            max_iter: None,
+            over: None,
+            pin_harness: None,
+            harnesses: Default::default(),
+            agent_choice: None,
+            auto_fail: None,
+        }
+    }
+
+    fn pipeline() -> PipelineDef {
+        let port = |name: &str| Port {
+            name: name.into(),
+            repeated: false,
+            side: None,
+            port_type: Default::default(),
+            frontmatter: None,
+            when: None,
+            description: None,
+            instructions: None,
+            required: false,
+        };
+        let mut start = node("start", "Start", NodeType::Start);
+        start.outputs.push(port("user_prompt"));
+        let mut worker = node("worker", "Worker", NodeType::DocOnly);
+        worker.agent_choice = Some(AgentChoice::Profile {
+            profile_id: "local-reviewer".into(),
+        });
+        let mut end = node("end", "End", NodeType::End);
+        end.inputs.push(port("result"));
+        PipelineDef {
+            name: "Portable".into(),
+            version: Some("1.0".into()),
+            variables: HashMap::new(),
+            nodes: vec![start, worker, end],
+            edges: vec![],
+            loops: vec![],
+            notes: vec![],
+            prompt_required: true,
+        }
+    }
+
+    #[test]
+    fn export_import_is_stable_and_profiles_become_inherit() {
+        let mut prompts = HashMap::new();
+        prompts.insert("worker".into(), "Review carefully.".into());
+
+        let first = super::export(&pipeline(), &prompts).unwrap();
+        let imported = super::interpret(&first).unwrap();
+        let second = super::export(&imported.pipeline, &imported.prompts).unwrap();
+
+        assert_eq!(first, second);
+        assert_eq!(
+            imported
+                .pipeline
+                .nodes
+                .iter()
+                .find(|node| node.id == "worker")
+                .unwrap()
+                .agent_choice,
+            Some(AgentChoice::Inherit)
+        );
+        assert_eq!(imported.prompts, prompts);
+    }
+
+    #[test]
+    fn unknown_version_is_rejected_with_the_document_path() {
+        let error = super::interpret("pdo_pipeline: 4\npipeline: {}\nprompts: {}\n").unwrap_err();
+        assert!(error.contains("pdo_pipeline: 4"), "{error}");
+    }
+
+    #[test]
+    fn unsafe_prompt_filename_is_rejected() {
+        let source = super::export(&pipeline(), &HashMap::new())
+            .unwrap()
+            .replace("prompts: {}", "prompts:\n  ../../outside: injected");
+
+        assert!(super::interpret(&source)
+            .unwrap_err()
+            .contains("cannot be used as a prompt filename"));
+    }
+}

--- a/crates/pdo-daemon/src/portable_pipeline.rs
+++ b/crates/pdo-daemon/src/portable_pipeline.rs
@@ -11,7 +11,7 @@ pub(crate) const VERSION: u32 = 1;
 #[serde(deny_unknown_fields)]
 struct PortablePipelineDocument {
     pdo_pipeline: u32,
-    pipeline: PipelineDef,
+    pipeline: serde_yaml::Value,
     #[serde(default)]
     prompts: BTreeMap<String, String>,
 }
@@ -31,6 +31,33 @@ fn make_portable(mut pipeline: PipelineDef) -> PipelineDef {
     pipeline
 }
 
+fn sort_mappings(value: &mut serde_yaml::Value) {
+    match value {
+        serde_yaml::Value::Sequence(values) => {
+            for value in values {
+                sort_mappings(value);
+            }
+        }
+        serde_yaml::Value::Mapping(mapping) => {
+            let mut entries = std::mem::take(mapping).into_iter().collect::<Vec<_>>();
+            for (key, value) in &mut entries {
+                sort_mappings(key);
+                sort_mappings(value);
+            }
+            entries.sort_by_cached_key(|(key, _)| serde_yaml::to_string(key).unwrap_or_default());
+            mapping.extend(entries);
+        }
+        _ => {}
+    }
+}
+
+fn ordered_pipeline_value(pipeline: PipelineDef) -> Result<serde_yaml::Value, String> {
+    let mut value = serde_yaml::to_value(pipeline)
+        .map_err(|e| format!("failed to serialize portable pipeline: {e}"))?;
+    sort_mappings(&mut value);
+    Ok(value)
+}
+
 pub(crate) fn export(
     pipeline: &PipelineDef,
     prompts: &HashMap<String, String>,
@@ -43,7 +70,7 @@ pub(crate) fn export(
         .pipeline;
     serde_yaml::to_string(&PortablePipelineDocument {
         pdo_pipeline: VERSION,
-        pipeline: canonical,
+        pipeline: ordered_pipeline_value(canonical)?,
         prompts: prompts
             .iter()
             .map(|(id, prompt)| (id.clone(), prompt.clone()))
@@ -74,11 +101,13 @@ pub(crate) fn interpret(source: &str) -> Result<InterpretedDocument, String> {
         ));
     }
 
-    let mut document: PortablePipelineDocument =
+    let document: PortablePipelineDocument =
         serde_yaml::from_value(value).map_err(|e| format!("invalid pipeline document: {e}"))?;
-    document.pipeline = make_portable(document.pipeline);
+    let portable = serde_yaml::from_value(document.pipeline)
+        .map_err(|e| format!("pipeline: invalid definition: {e}"))?;
+    let portable = make_portable(portable);
 
-    let canonical = serde_yaml::to_string(&document.pipeline)
+    let canonical = serde_yaml::to_string(&portable)
         .map_err(|e| format!("pipeline: failed to validate: {e}"))?;
     let parsed = pipeline::parse_pipeline(&canonical)
         .map_err(|e| format!("pipeline: invalid definition: {e}"))?;
@@ -192,6 +221,57 @@ mod tests {
             Some(AgentChoice::Inherit)
         );
         assert_eq!(imported.prompts, prompts);
+    }
+
+    #[test]
+    fn export_orders_variables_deterministically() {
+        let mut pipeline = pipeline();
+        for name in ["zulu", "echo", "hotel", "alpha", "yankee", "bravo"] {
+            pipeline.variables.insert(
+                name.into(),
+                crate::pipeline::VariableDef {
+                    var_type: crate::pipeline::VariableType::String,
+                    default: serde_yaml::Value::String(name.into()),
+                },
+            );
+        }
+
+        let document = super::export(&pipeline, &HashMap::new()).unwrap();
+        let positions = ["alpha:", "bravo:", "echo:", "hotel:", "yankee:", "zulu:"]
+            .map(|name| document.find(name).unwrap());
+
+        assert!(positions.windows(2).all(|pair| pair[0] < pair[1]));
+    }
+
+    #[test]
+    fn export_orders_nested_pipeline_maps_deterministically() {
+        let mut pipeline = pipeline();
+        let frontmatter = ["zulu", "echo", "hotel", "alpha", "yankee", "bravo"]
+            .into_iter()
+            .map(|name| {
+                (
+                    format!("field_{name}"),
+                    crate::pipeline::FrontmatterFieldDecl {
+                        field_type: "string".into(),
+                        allowed: None,
+                    },
+                )
+            })
+            .collect();
+        pipeline.nodes[0].outputs[0].frontmatter = Some(frontmatter);
+
+        let document = super::export(&pipeline, &HashMap::new()).unwrap();
+        let positions = [
+            "field_alpha:",
+            "field_bravo:",
+            "field_echo:",
+            "field_hotel:",
+            "field_yankee:",
+            "field_zulu:",
+        ]
+        .map(|name| document.find(name).unwrap());
+
+        assert!(positions.windows(2).all(|pair| pair[0] < pair[1]));
     }
 
     #[test]

--- a/crates/pdo-daemon/tests/libassist.rs
+++ b/crates/pdo-daemon/tests/libassist.rs
@@ -316,9 +316,7 @@ async fn focus_round_trips_and_resolves_the_absolute_path() {
 
     let focus = get_focus(&daemon).await;
     assert_eq!(focus["pipeline_id"], serde_json::json!("alpha"));
-    assert_eq!(focus["scope"], serde_json::json!("repo"));
-    // The CLIENT never sends a path — the daemon resolves it, because the two
-    // meanings of "scope" (edit tab vs library store) do not coincide.
+    assert!(focus.get("scope").is_none());
     assert_eq!(
         focus["path"],
         serde_json::json!(path.to_string_lossy()),
@@ -348,18 +346,18 @@ async fn focus_accepts_an_unsaved_template_with_a_null_path() {
 }
 
 #[tokio::test]
-async fn focus_rejects_an_unknown_scope() {
+async fn focus_ignores_the_retired_scope_field() {
     let daemon = TestDaemon::spawn_nested(|_| Ok(())).await.unwrap();
     let resp = put_focus(
         &daemon,
         serde_json::json!({"pipeline_id": "alpha", "scope": "bogus"}),
     )
     .await;
-    assert_eq!(resp.status(), 400, "an unknown scope is a 400");
+    assert_eq!(resp.status(), 200, "scope no longer selects a registry");
     assert_eq!(
         get_focus(&daemon).await["pipeline_id"],
-        serde_json::json!(null),
-        "a rejected declaration stores nothing"
+        serde_json::json!("alpha"),
+        "the instance pipeline identity is retained"
     );
 }
 
@@ -385,7 +383,7 @@ async fn a_null_pipeline_id_clears_the_focus() {
 }
 
 /// `?format=text` is what the hook injects verbatim into the assistant's context.
-/// It must name the pipeline, the scope, the absolute path — and the one endpoint
+/// It must name the pipeline, the absolute path — and the one endpoint
 /// that writes where the focus points. Naming the save endpoint here is not
 /// decoration: the assistant reads this line before every message, and pointing it
 /// at `POST /library/pipelines` is what made it write a duplicate into the wrong
@@ -411,7 +409,10 @@ async fn focus_renders_a_plain_line_for_the_hook() {
     .unwrap();
 
     assert!(text.contains("alpha"), "names the pipeline: {text}");
-    assert!(text.contains("repo"), "names the scope: {text}");
+    assert!(
+        !text.contains("scope `"),
+        "does not expose a retired scope: {text}"
+    );
     assert!(
         text.contains(&*path.to_string_lossy()),
         "names the absolute path: {text}"
@@ -420,10 +421,7 @@ async fn focus_renders_a_plain_line_for_the_hook() {
         text.contains("/sessions/libassist/save"),
         "names the one endpoint that writes where the focus points: {text}"
     );
-    assert!(
-        text.contains("/library/pipelines"),
-        "and names the endpoint NOT to save through, by name: {text}"
-    );
+    assert!(!text.contains("/library/pipelines"));
 }
 
 /// Declaring a focus must never *start* the assistant (ADR-0048 ruled auto-spawn
@@ -599,7 +597,7 @@ async fn save_writes_the_focused_template_in_place() {
     assert_eq!(resp.status(), 200, "saving the open template succeeds");
     let body = resp.json::<serde_json::Value>().await.unwrap();
     assert_eq!(body["id"], serde_json::json!("alpha"));
-    assert_eq!(body["scope"], serde_json::json!("repo"));
+    assert!(body.get("scope").is_none());
     assert_eq!(body["path"], serde_json::json!(path.to_string_lossy()));
 
     let on_disk = std::fs::read_to_string(&path).unwrap();
@@ -646,12 +644,8 @@ async fn save_writes_node_prompts_beside_the_template() {
     );
 }
 
-/// A `library`-scoped tab edits the library store, and the save must follow it
-/// there — the symmetric half of the property above. `get_scope` reads the entry's
-/// *current* store off disk rather than mapping the edit tab's word onto the
-/// library enum, which is the mapping that produced the bug in the first place.
 #[tokio::test]
-async fn save_honours_a_library_focus() {
+async fn save_ignores_a_retired_library_scope() {
     let daemon = TestDaemon::spawn_nested(|_| Ok(())).await.unwrap();
     let library_dir = daemon
         .repo_root()
@@ -673,17 +667,20 @@ async fn save_honours_a_library_focus() {
 
     assert_eq!(
         std::fs::read_to_string(&library_path).unwrap(),
-        SAVED_YAML,
-        "a library-scoped focus writes into the library store"
+        "name: seeded\nnodes: []\nedges: []\n",
+        "the legacy library is not a write target"
     );
-    assert!(
-        !daemon
-            .repo_root()
-            .join(".pdo")
-            .join("pipelines")
-            .join("alpha.yaml")
-            .exists(),
-        "and does not leak a copy into the repo store"
+    assert_eq!(
+        std::fs::read_to_string(
+            daemon
+                .repo_root()
+                .join(".pdo")
+                .join("pipelines")
+                .join("alpha.yaml")
+        )
+        .unwrap(),
+        SAVED_YAML,
+        "the instance registry receives the save"
     );
 }
 

--- a/crates/pdo-daemon/tests/serializer_round_trip.rs
+++ b/crates/pdo-daemon/tests/serializer_round_trip.rs
@@ -43,26 +43,15 @@ async fn every_pipeline_yaml_round_trips_through_save() {
 
     let all: Vec<serde_json::Value> = resp.json().await.unwrap();
 
-    // `GET /pipelines` merges every scope, so it also lists whatever lives in the
-    // developer's real `~/.pdo/pipelines` — HOME is not overridden here. Keep only
-    // what this test seeded.
-    //
-    // **This filter is load-bearing, not tidiness.** Without it, the identity
-    // `PUT` below resolved a user-scoped id through the repo-first fallback,
-    // missed it in the tempdir, and wrote the developer's own template file. Two
-    // real consequences: the suite mutated files outside its sandbox on every run,
-    // and the resulting `pipeline_changed` broadcast reached *other* tests'
-    // daemons — which is what made
-    // `run_scoped_pipeline::unrelated_md_in_run_worktree_does_not_emit_pipeline_event`
-    // fail whenever the two ran concurrently. Every request below is scope-pinned
-    // for the same reason.
+    // Test daemons bind their instance registry to the temp repository, so every
+    // listed entry is hermetic and uses the production `instance` vocabulary.
     let pipelines: Vec<&serde_json::Value> = all
         .iter()
-        .filter(|e| e["scope"].as_str() == Some("repo"))
+        .filter(|e| e["scope"].as_str() == Some("instance"))
         .collect();
     assert!(
         !pipelines.is_empty(),
-        "should find at least one repo-scoped pipeline (seeded from the repo's .pdo/pipelines), got: {all:?}"
+        "should find at least one instance pipeline, got: {all:?}"
     );
 
     for entry in &pipelines {
@@ -70,7 +59,7 @@ async fn every_pipeline_yaml_round_trips_through_save() {
 
         // GET the pipeline (skip legacy pipelines that fail validation)
         let resp = client
-            .get(format!("{}/pipelines/{}?scope=repo", daemon.url(), id))
+            .get(format!("{}/pipelines/{}", daemon.url(), id))
             .send()
             .await
             .unwrap();
@@ -83,7 +72,7 @@ async fn every_pipeline_yaml_round_trips_through_save() {
         // PUT it back (identity save)
         let body = serde_json::json!({ "yaml": yaml, "prompts": {} });
         let resp = client
-            .put(format!("{}/pipelines/{}?scope=repo", daemon.url(), id))
+            .put(format!("{}/pipelines/{}", daemon.url(), id))
             .json(&body)
             .send()
             .await
@@ -97,7 +86,7 @@ async fn every_pipeline_yaml_round_trips_through_save() {
 
         // GET again and compare structure
         let resp = client
-            .get(format!("{}/pipelines/{}?scope=repo", daemon.url(), id))
+            .get(format!("{}/pipelines/{}", daemon.url(), id))
             .send()
             .await
             .unwrap();

--- a/docs/adr/0059-les-pipelines-appartiennent-a-l-instance-et-voyagent-par-document.md
+++ b/docs/adr/0059-les-pipelines-appartiennent-a-l-instance-et-voyagent-par-document.md
@@ -1,0 +1,5 @@
+# Les pipelines appartiennent à l'instance et voyagent par document
+
+Une Pipeline est une ressource de l'instance PDO, et non une ressource `repo`, `user` ou `library`. Cette propriété unique supprime des comportements artificiellement différents ; le partage entre instances ou dépôts devient une action explicite au moyen d'un Document de pipeline transportable, interprété vers le stockage interne et fidèle à tout le contenu possédé par la Pipeline.
+
+Le document développe les nodes partagés mais n'embarque aucune configuration d'instance, valeur d'exécution, variable d'environnement ou secret. Cette limite rend l'échange sûr et indépendant des installations externes, au prix de ramener à **Inherit** les choix qui dépendaient d'un profil agentique nommé.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,10 +20,8 @@ import NewRunModal, { RUN_INTENT } from "./components/NewRunModal";
 import SettingsModal from "./components/SettingsModal";
 import StatsModal from "./components/StatsModal";
 import ConflictModal from "./components/ConflictModal";
-import PipelineChangedModal from "./components/PipelineChangedModal";
 import SaveErrorModal from "./components/SaveErrorModal";
 import ConfirmCloseTabsModal from "./components/ConfirmCloseTabsModal";
-import { shouldPromptLibraryUpdate } from "./hooks/useLibraryPipelines";
 import { useRecentReposStore } from "./stores/recentReposStore";
 import type { TabId } from "./components/PipelineInfoPanel";
 import EditCanvas from "./components/EditCanvas";
@@ -204,7 +202,6 @@ export default function App() {
   const editRedo = useEditStore((s) => s.redo);
   const editActiveTabId = useEditStore((s) => s.activeTabId);
   const resolveConflict = useEditStore((s) => s.resolveConflict);
-  const reloadFromLibrary = useEditStore((s) => s.reloadFromLibrary);
   const clearSaveError = useEditStore((s) => s.clearSaveError);
   // #342: a single-tab open/replace parked because it would discard unsaved
   // work — resolved by the global confirm modal below.
@@ -214,14 +211,6 @@ export default function App() {
   // Merged /pipelines list — used to derive the selected trigger's prompt-required
   // signal for the guard dry-run caveat (#351).
   const pipelines = useEditStore((s) => s.pipelines);
-
-  // Track which library-YAML version we've already prompted about for a given
-  // run-scoped tab. Re-prompting only when the library changes again avoids
-  // nagging the user every time they switch back to the same run tab.
-  const promptedLibraryYamlRef = useRef<Map<string, string>>(new Map());
-  const [pipelineChangedPrompt, setPipelineChangedPrompt] = useState<
-    { tabId: string; libraryYaml: string; pipelineName: string } | null
-  >(null);
 
   const editTab = openTabs.find((t) => t.id === editActiveTabId);
   const editNodeType = editTab && selection.kind === "node" && selection.id
@@ -585,45 +574,6 @@ export default function App() {
     });
   }, [subscribe, refreshRuns, refreshRun, refreshSessions, refreshTriggers, refreshProjects, reloadPipeline, loadPipelines]);
 
-  // Detect: active tab is a run whose library twin (matched by id, then name)
-  // diverges from the run snapshot — pipeline or prompts, the same comparison
-  // the star indicator uses. Show the modal once per (tabId, library-yaml)
-  // pair so re-entering an unchanged run is silent.
-  useEffect(() => {
-    if (!editTab) return;
-    const libEntry = shouldPromptLibraryUpdate(
-      editTab,
-      libraryPipelines,
-      promptedLibraryYamlRef.current.get(editTab.id),
-    );
-    if (!libEntry) return;
-    setPipelineChangedPrompt({
-      tabId: editTab.id,
-      libraryYaml: libEntry.yaml,
-      pipelineName: editTab.pipeline.name,
-    });
-  }, [editTab, libraryPipelines]);
-
-  const handlePipelineChangedKeep = useCallback(() => {
-    if (!pipelineChangedPrompt) return;
-    promptedLibraryYamlRef.current.set(
-      pipelineChangedPrompt.tabId,
-      pipelineChangedPrompt.libraryYaml,
-    );
-    setPipelineChangedPrompt(null);
-  }, [pipelineChangedPrompt]);
-
-  const handlePipelineChangedReload = useCallback(async () => {
-    if (!pipelineChangedPrompt) return;
-    promptedLibraryYamlRef.current.set(
-      pipelineChangedPrompt.tabId,
-      pipelineChangedPrompt.libraryYaml,
-    );
-    const { tabId, libraryYaml } = pipelineChangedPrompt;
-    setPipelineChangedPrompt(null);
-    await reloadFromLibrary(tabId, libraryYaml);
-  }, [pipelineChangedPrompt, reloadFromLibrary]);
-
   const selectedNode =
     selectedNodeId && selectedRun
       ? selectedRun.nodes[selectedNodeId] ?? null
@@ -783,10 +733,7 @@ export default function App() {
                     <RunInfoSidebar run={selectedRun} onEdited={refreshRun} />
                   )}
                 {selection.kind === "none" && !isEditingRun && (
-                  <PipelineInspector
-                    libraryPipelines={libraryPipelines}
-                    onLibraryChanged={refreshLibraryPipelines}
-                  />
+                  <PipelineInspector />
                 )}
               </>
             ) : (
@@ -852,12 +799,6 @@ export default function App() {
         onTake={() => {
           if (conflictTab) resolveConflict(conflictTab.id, "take");
         }}
-      />
-      <PipelineChangedModal
-        open={pipelineChangedPrompt != null}
-        pipelineName={pipelineChangedPrompt?.pipelineName ?? ""}
-        onKeep={handlePipelineChangedKeep}
-        onReload={handlePipelineChangedReload}
       />
       <SaveErrorModal
         open={saveErrorTab != null}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,7 +4,6 @@ import { useDaemonSocket } from "./hooks/useDaemonSocket";
 import type { ConnectionStatus } from "./hooks/useDaemonSocket";
 import { useResizableLayout } from "./hooks/useResizableLayout";
 import { useLibrary } from "./hooks/useLibrary";
-import { useLibraryPipelines } from "./hooks/useLibraryPipelines";
 import { fetchRuns, fetchRun, fetchTriggers, fetchProjects, fetchSessions, fetchTriggersHealth, pauseTriggers } from "./api";
 import { pickLatestLiveNode } from "./lib/pickLatestLiveNode";
 import { useRightPaneRouter } from "./hooks/useRightPaneRouter";
@@ -147,7 +146,6 @@ function useSelectedRun() {
 export default function App() {
   const { status, subscribe } = useDaemonSocket();
   const { entries: libraryEntries, refresh: refreshLibrary } = useLibrary();
-  const { entries: libraryPipelines, refresh: refreshLibraryPipelines } = useLibraryPipelines();
   const { runs, refresh: refreshRuns } = useRuns();
   const { sessions, refresh: refreshSessions } = useSessions();
   const { triggers, refresh: refreshTriggers } = useTriggers();
@@ -297,18 +295,14 @@ export default function App() {
       setSelectedRunId(null);
       setSelectedNodeId(null);
       selectRun(null);
-      // #320: also open the pipeline this Trigger would launch, in the canvas.
-      // Resolve scope the way the daemon resolves it at FIRE time (library-first,
-      // repo/user fallback): if the id is in the library store, open with scope
-      // "library"; otherwise let the daemon resolve a repo/user file (undefined).
+      // #320: also open the instance-owned pipeline this Trigger would launch.
       const trig = triggers.find((t) => t.id === triggerId);
       if (trig) {
-        const inLibrary = libraryPipelines.some((p) => p.id === trig.pipeline_id);
         setTriggerOpenedTabId(trig.pipeline_id);
-        openPipeline(trig.pipeline_id, inLibrary ? "library" : undefined);
+        openPipeline(trig.pipeline_id);
       }
     },
-    [selectRun, triggers, libraryPipelines, openPipeline],
+    [selectRun, triggers, openPipeline],
   );
 
   // #341: "Run now" is a real fire (guard + overlap + audit row), not a
@@ -619,8 +613,6 @@ export default function App() {
               selectedRunId={selectedRunId}
               onSelectRun={handleSelectRun}
               onNewRun={() => openNewRunModal({ kind: "run" })}
-              libraryPipelines={libraryPipelines}
-              onLibraryPipelinesChanged={refreshLibraryPipelines}
               triggers={triggers}
               selectedTriggerId={selectedTriggerId}
               onSelectTrigger={handleSelectTrigger}
@@ -643,13 +635,11 @@ export default function App() {
                 <TabBar />
                 <EditCanvas
                   libraryEntries={libraryEntries}
-                  libraryPipelines={libraryPipelines}
                   onLibraryDelete={async (name) => {
                     const { deleteFromLibrary: delLib } = await import("./api");
                     await delLib(name);
                     refreshLibrary();
                   }}
-                  onLibraryPipelinesChanged={refreshLibraryPipelines}
                   infoOpen={infoPanelOpen}
                   onToggleInfo={handleToggleInfo}
                   onCloseInfo={handleCloseInfo}
@@ -682,8 +672,6 @@ export default function App() {
                 key={infoPanelInitialTab ?? "default"}
                 run={isEditingRun ? selectedRun : null}
                 pipeline={editTab?.pipeline ?? null}
-                libraryPipelines={libraryPipelines}
-                onLibraryChanged={refreshLibraryPipelines}
                 onClose={handleCloseInfo}
                 initialTab={infoPanelInitialTab}
                 scrollToLine={infoPanelScrollToLine}

--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -88,12 +88,12 @@ describe("saveRunPipeline rejection surfacing", () => {
 // (or `user`) id colliding with a same-named repo pipeline routes to the
 // intended store, not the repo file. The query string is the wire contract the
 // daemon branches on.
-describe("scope-qualified pipeline ops", () => {
-  it("appends ?scope=library to DELETE for a library entry", async () => {
+describe("instance pipeline ops", () => {
+  it("ignores obsolete scopes on DELETE", async () => {
     const fetchMock = captureFetch(200, { ok: true });
     await deletePipeline("simple-bugfix", "library");
     const [url, init] = fetchMock.mock.calls[0];
-    expect(url).toBe("/pipelines/simple-bugfix?scope=library");
+    expect(url).toBe("/pipelines/simple-bugfix");
     expect(init).toMatchObject({ method: "DELETE" });
   });
 
@@ -109,17 +109,17 @@ describe("scope-qualified pipeline ops", () => {
     expect(fetchMock.mock.calls[0][0]).toBe("/pipelines/r");
   });
 
-  it("appends ?scope=library to GET when opening a library entry", async () => {
+  it("ignores obsolete scopes on GET", async () => {
     const fetchMock = captureFetch(200, { id: "x", scope: "library" });
     await fetchPipeline("simple-bugfix", "library");
-    expect(fetchMock.mock.calls[0][0]).toBe("/pipelines/simple-bugfix?scope=library");
+    expect(fetchMock.mock.calls[0][0]).toBe("/pipelines/simple-bugfix");
   });
 
-  it("appends ?scope=library to PUT when saving a library entry", async () => {
+  it("ignores obsolete scopes on PUT", async () => {
     const fetchMock = captureFetch(200, { ok: true });
     await savePipeline("simple-bugfix", "name: x", {}, "library");
     const [url, init] = fetchMock.mock.calls[0];
-    expect(url).toBe("/pipelines/simple-bugfix?scope=library");
+    expect(url).toBe("/pipelines/simple-bugfix");
     expect(init).toMatchObject({ method: "PUT" });
   });
 });

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -548,16 +548,12 @@ export function closeLibraryAssistant(
  *
  * Two jobs in one call: it is how the assistant learns the open pipeline on its
  * next message, and it is how the daemon's reaper knows a human is still editing
- * even when no terminal is attached. Only `{id, scope}` — the daemon resolves the
- * file path, because "scope" does not mean the same thing on an edit tab as it
- * does in the library store.
+ * even when no terminal is attached. The daemon resolves the instance-owned
+ * pipeline path from its id.
  */
-export function putLibassistFocus(
-  pipelineId: string | null,
-  scope?: string,
-): Promise<unknown> {
+export function putLibassistFocus(pipelineId: string | null): Promise<unknown> {
   return request("PUT", "/sessions/libassist/focus", {
-    body: { pipeline_id: pipelineId, scope },
+    body: { pipeline_id: pipelineId },
     label: "declare assistant focus",
   });
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1340,14 +1340,11 @@ export function saveRunPipeline(
 // repo-then-user, so a `library` (or `user`) entry colliding with a same-named
 // repo pipeline routes to the wrong file (#216). `repo`/`user`/`run` map to the
 // historical default and are only forwarded when explicitly known.
-function scopeQuery(scope?: string): string {
-  return scope && scope !== "run" ? `?scope=${encodeURIComponent(scope)}` : "";
-}
-
 export function fetchPipeline(id: string, scope?: string): Promise<PipelineDetail> {
+  void scope;
   return request<PipelineDetail>(
     "GET",
-    `/pipelines/${encodeURIComponent(id)}${scopeQuery(scope)}`,
+    `/pipelines/${encodeURIComponent(id)}`,
     { label: `GET /pipelines/${id}` },
   ).then(foldPipelineDetail);
 }
@@ -1358,22 +1355,55 @@ export function savePipeline(
   prompts: Record<string, string>,
   scope?: string,
 ): Promise<void> {
+  void scope;
   return request<void>(
     "PUT",
-    `/pipelines/${encodeURIComponent(id)}${scopeQuery(scope)}`,
+    `/pipelines/${encodeURIComponent(id)}`,
     { body: { yaml, prompts }, responseMode: "void", label: `PUT /pipelines/${id}` },
   );
 }
 
 export function createPipeline(
   name: string,
-  scope: string,
+  scope?: string,
 ): Promise<{ id: string; scope: string; path: string }> {
+  void scope;
   return request<{ id: string; scope: string; path: string }>(
     "POST",
     "/pipelines",
-    { body: { name, scope }, label: "POST /pipelines" },
+    { body: { name }, label: "POST /pipelines" },
   );
+}
+
+export function duplicatePipeline(
+  id: string,
+): Promise<{ id: string; scope: string; path: string }> {
+  return request("POST", `/pipelines/${encodeURIComponent(id)}/duplicate`, {
+    label: `POST /pipelines/${id}/duplicate`,
+  });
+}
+
+export function fetchPipelineDocument(id: string): Promise<string> {
+  return request("GET", `/pipelines/${encodeURIComponent(id)}/document`, {
+    responseMode: "text",
+    label: `GET /pipelines/${id}/document`,
+  });
+}
+
+export function fetchRunPipelineDocument(runId: string): Promise<string> {
+  return request("GET", `/runs/${encodeURIComponent(runId)}/pipeline/document`, {
+    responseMode: "text",
+    label: `GET /runs/${runId}/pipeline/document`,
+  });
+}
+
+export function importPipelineDocument(
+  document: string,
+): Promise<{ id: string; scope: string; path: string }> {
+  return request("POST", "/pipelines/import", {
+    body: { document },
+    label: "POST /pipelines/import",
+  });
 }
 
 // --- Library API ---
@@ -1508,12 +1538,13 @@ export function parseNodeYaml(yaml: string): Promise<ParseNodeResult> {
 }
 
 export async function deletePipeline(id: string, scope?: string): Promise<void> {
+  void scope;
   // Status-inspecting: a 409 (active runs) carries the reason in the body, so
   // raw mode keeps the bespoke branch (incl. the deliberately UNGUARDED 409
   // json). The old `{ conflict }` field had no reader — folded into status 409.
   const resp = await request<Response>(
     "DELETE",
-    `/pipelines/${encodeURIComponent(id)}${scopeQuery(scope)}`,
+    `/pipelines/${encodeURIComponent(id)}`,
     { responseMode: "raw" },
   );
   if (resp.status === 409) {

--- a/frontend/src/components/EditCanvas.banner225.test.tsx
+++ b/frontend/src/components/EditCanvas.banner225.test.tsx
@@ -284,18 +284,11 @@ describe("#268 — dismissible fan-out nudges", () => {
   });
 });
 
-describe("#225 Part 2 — star container outranks the lint banner (z-index regression guard)", () => {
-  // jsdom does no layout/hit-testing, so the click-swallow itself cannot be
-  // reproduced here (the real proof is the Layer-5 scenario
-  // banner-run-gate-star-popover.md). This guards the one thing a unit test
-  // CAN pin: the container that traps the popover's stacking context must sit
-  // at z-20, above the z-10 lint-banner overlay.
-  it("renders the star container at z-20 (not z-10) on an edit tab", () => {
+describe("instance-owned pipeline canvas", () => {
+  it("does not render the obsolete promote-to-library star", () => {
     seedTab(editTab());
     renderCanvas();
 
-    const container = screen.getByTestId("canvas-pipeline-star-container");
-    expect(container.className).toContain("z-20");
-    expect(container.className).not.toContain("z-10");
+    expect(screen.queryByTestId("canvas-pipeline-star-container")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/EditCanvas.tsx
+++ b/frontend/src/components/EditCanvas.tsx
@@ -39,8 +39,6 @@ import AddNodeFromYamlModal from "./AddNodeFromYamlModal";
 import LintBanner, { type LintBannerItem } from "./LintBanner";
 import DragConnectionLine from "./DragConnectionLine";
 import { DragHighlightProvider, useIsDropTarget } from "./DragHighlightContext";
-import PipelineStar from "./PipelineStar";
-import { usePipelineLibraryState } from "../hooks/useLibraryPipelines";
 import { useDismissedNudges } from "../hooks/useDismissedNudges";
 import { anchorHandleId, anchorsByDropOnBody, chooseAnchorSide, isEmergentInputNode } from "../lib/anchorSide";
 import { useAgentProfiles } from "../hooks/useAgentProfiles";
@@ -274,7 +272,7 @@ interface EditCanvasProps {
   onSelectRun?: (runId: string) => void;
 }
 
-function EditCanvasInner({ libraryEntries, libraryPipelines, onLibraryDelete, onLibraryPipelinesChanged, infoOpen, onToggleInfo, onCloseInfo, assistantActive, onOpenAssistant, runState, onSelectRun }: EditCanvasProps) {
+function EditCanvasInner({ libraryEntries, onLibraryDelete, infoOpen, onToggleInfo, onCloseInfo, assistantActive, onOpenAssistant, runState, onSelectRun }: EditCanvasProps) {
   const openTabs = useEditStore((s) => s.openTabs);
   const activeTabId = useEditStore((s) => s.activeTabId);
   const setSelection = useEditStore((s) => s.setSelection);
@@ -404,30 +402,11 @@ function EditCanvasInner({ libraryEntries, libraryPipelines, onLibraryDelete, on
     );
   }, [selection.kind, setSelection]);
 
-  const pipelineSync = usePipelineLibraryState(
-    pipeline ?? null,
-    libraryPipelines,
-    tab?.libraryId ?? null,
-    tab?.prompts,
-  );
   const { profiles: agentProfiles } = useAgentProfiles();
   const agentProfileIds = useMemo(
     () => new Set(agentProfiles.map((profile) => profile.id)),
     [agentProfiles],
   );
-  const setLibraryBinding = useEditStore((s) => s.setLibraryBinding);
-
-  // Lock the library binding once we've identified a match by name. This makes
-  // future renames non-destructive: even though `pipelineSync.entry` will keep
-  // resolving via libraryId, the canvas-side name can drift freely until the
-  // user saves, at which point the library file is updated in place.
-  useEffect(() => {
-    if (!tab) return;
-    if (tab.libraryId) return;
-    if (!pipelineSync.entry) return;
-    setLibraryBinding(tab.id, pipelineSync.entry.id, pipelineSync.entry.scope);
-  }, [tab, pipelineSync.entry, setLibraryBinding]);
-
   const derivedNodes = useMemo(() => {
     if (!pipeline) return [];
     const cards = deriveEditNodes(pipeline, activeRunState, agentProfileIds);
@@ -791,24 +770,6 @@ function EditCanvasInner({ libraryEntries, libraryPipelines, onLibraryDelete, on
         onRetryAll={() => setConfirmRetryAll(true)}
         onOpenShell={handleOpenShell}
       />
-      {pipeline && tab && (
-        <div
-          // #225: z-20 (not z-10) so the star's popover outranks the lint-banner
-          // overlay below (also z-10, painted later in DOM). The popover's own
-          // z-50 is trapped inside this container's stacking context, so the bump
-          // must be on the container itself, not the popover. See Part 2 of #225.
-          className="absolute right-3 top-2 z-20"
-          data-testid="canvas-pipeline-star-container"
-        >
-          <PipelineStar
-            tabId={tab.id}
-            pipeline={pipeline}
-            syncState={pipelineSync.state}
-            libraryEntry={pipelineSync.entry}
-            onLibraryChanged={onLibraryPipelinesChanged}
-          />
-        </div>
-      )}
       {/* #225: lint diagnostics are an edit-mode affordance — suppress on run tabs.
           NOTE: this also suppresses lint while editing-during-run (ADR-0007), a
           deliberate trade-off ratified at PR time. `tab` is non-null here (early

--- a/frontend/src/components/EditCanvas.tsx
+++ b/frontend/src/components/EditCanvas.tsx
@@ -256,9 +256,11 @@ const DEFAULT_NODE_NAMES: Partial<Record<NodeType, string>> = {
 
 interface EditCanvasProps {
   libraryEntries: LibraryEntry[];
-  libraryPipelines: LibraryPipelineEntry[];
+  /** @deprecated Instance pipelines no longer have a library scope. */
+  libraryPipelines?: LibraryPipelineEntry[];
   onLibraryDelete: (name: string) => void;
-  onLibraryPipelinesChanged: () => void;
+  /** @deprecated Instance pipelines refresh through the edit store. */
+  onLibraryPipelinesChanged?: () => void;
   infoOpen?: boolean;
   onToggleInfo?: () => void;
   onCloseInfo?: () => void;

--- a/frontend/src/components/LibraryRow.test.tsx
+++ b/frontend/src/components/LibraryRow.test.tsx
@@ -1,14 +1,12 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import LibraryRow from "./LibraryRow";
-import type { PipelineScope } from "../types";
 
 function renderRow(
   over: {
     name?: string;
-    scope?: PipelineScope;
     nodeCount?: number;
-    starred?: boolean;
+    modified?: string | null;
     selected?: boolean;
     showDuplicate?: boolean;
     onOpen?: () => void;
@@ -19,9 +17,7 @@ function renderRow(
 ) {
   const props = {
     name: "fixture",
-    scope: "repo" as PipelineScope,
     nodeCount: 3,
-    starred: false,
     showDuplicate: false,
     onDelete: () => {},
     deleteTitle: "Delete pipeline",
@@ -67,9 +63,7 @@ describe("LibraryRow openable vs passive", () => {
     const { container } = render(
       <LibraryRow
         name="fixture"
-        scope="repo"
         nodeCount={3}
-        starred={false}
         showDuplicate={false}
         onDelete={() => {}}
         deleteTitle="Delete pipeline"
@@ -80,10 +74,9 @@ describe("LibraryRow openable vs passive", () => {
 });
 
 describe("LibraryRow instance metadata", () => {
-  it("does not render legacy stars or scope badges", () => {
-    renderRow({ starred: true, scope: "instance" });
-    expect(screen.queryByTestId("left-panel-star")).not.toBeInTheDocument();
-    expect(screen.queryByText("instance")).not.toBeInTheDocument();
+  it("labels the useful last-edit metadata", () => {
+    renderRow({ modified: "2026-08-26T12:00:00Z" });
+    expect(screen.getByText(/^edited /)).toBeInTheDocument();
   });
 });
 

--- a/frontend/src/components/LibraryRow.test.tsx
+++ b/frontend/src/components/LibraryRow.test.tsx
@@ -79,22 +79,11 @@ describe("LibraryRow openable vs passive", () => {
   });
 });
 
-describe("LibraryRow star", () => {
-  it("shows the star when starred", () => {
-    renderRow({ starred: true });
-    expect(screen.getByTestId("left-panel-star")).toBeInTheDocument();
-  });
-
-  it("hides the star when not starred", () => {
-    renderRow({ starred: false });
+describe("LibraryRow instance metadata", () => {
+  it("does not render legacy stars or scope badges", () => {
+    renderRow({ starred: true, scope: "instance" });
     expect(screen.queryByTestId("left-panel-star")).not.toBeInTheDocument();
-  });
-});
-
-describe("LibraryRow scope badge", () => {
-  it.each<PipelineScope>(["repo", "user", "library"])("labels a %s row", (scope) => {
-    renderRow({ scope });
-    expect(screen.getByText(scope)).toBeInTheDocument();
+    expect(screen.queryByText("instance")).not.toBeInTheDocument();
   });
 });
 

--- a/frontend/src/components/LibraryRow.tsx
+++ b/frontend/src/components/LibraryRow.tsx
@@ -1,15 +1,11 @@
 import type { MouseEvent } from "react";
 import { Copy, Trash2 } from "lucide-react";
-import type { PipelineScope } from "../types";
 import SelectControl from "./SelectControl";
 
 interface Props {
   name: string;
-  scope: PipelineScope;
   nodeCount: number;
   modified?: string | null;
-  /** Star badge — the visible "this name is in your Library" link (#227). */
-  starred: boolean;
   /** Highlighted as the open editor tab. Only meaningful on an openable row. */
   selected?: boolean;
   showDuplicate: boolean;
@@ -50,9 +46,7 @@ interface Props {
  */
 export default function LibraryRow({
   name,
-  scope,
   nodeCount,
-  starred,
   selected = false,
   showDuplicate,
   onOpen,
@@ -64,9 +58,6 @@ export default function LibraryRow({
   onToggleSelect,
   modified,
 }: Props) {
-  void scope;
-  void starred;
-
   const body = (
     <>
       {onToggleSelect && (
@@ -88,7 +79,7 @@ export default function LibraryRow({
           {modified && (
             <>
               <span>·</span>
-              <span>{new Date(modified).toLocaleDateString()}</span>
+              <span>edited {new Date(modified).toLocaleDateString()}</span>
             </>
           )}
         </div>

--- a/frontend/src/components/LibraryRow.tsx
+++ b/frontend/src/components/LibraryRow.tsx
@@ -1,18 +1,13 @@
 import type { MouseEvent } from "react";
-import { Copy, Star, Trash2 } from "lucide-react";
+import { Copy, Trash2 } from "lucide-react";
 import type { PipelineScope } from "../types";
 import SelectControl from "./SelectControl";
-
-const SCOPE_BADGE: Record<PipelineScope, { label: string; cls: string }> = {
-  repo: { label: "repo", cls: "border-acc text-acc" },
-  user: { label: "user", cls: "border-st-await text-st-await" },
-  library: { label: "library", cls: "border-st-await text-st-await" },
-};
 
 interface Props {
   name: string;
   scope: PipelineScope;
   nodeCount: number;
+  modified?: string | null;
   /** Star badge — the visible "this name is in your Library" link (#227). */
   starred: boolean;
   /** Highlighted as the open editor tab. Only meaningful on an openable row. */
@@ -67,8 +62,10 @@ export default function LibraryRow({
   testId,
   checked = false,
   onToggleSelect,
+  modified,
 }: Props) {
-  const badge = SCOPE_BADGE[scope];
+  void scope;
+  void starred;
 
   const body = (
     <>
@@ -81,13 +78,6 @@ export default function LibraryRow({
       )}
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-1.5">
-          {starred && (
-            <Star
-              size={10}
-              className="shrink-0 fill-acc text-acc"
-              data-testid="left-panel-star"
-            />
-          )}
           <span className="truncate font-medium">{name}</span>
         </div>
         <div
@@ -95,14 +85,14 @@ export default function LibraryRow({
           style={{ fontSize: "10px" }}
         >
           <span>{nodeCount} nodes</span>
+          {modified && (
+            <>
+              <span>·</span>
+              <span>{new Date(modified).toLocaleDateString()}</span>
+            </>
+          )}
         </div>
       </div>
-      <span
-        className={`shrink-0 rounded border px-1 py-px group-hover:hidden ${badge.cls}`}
-        style={{ fontSize: "9px", fontWeight: 500 }}
-      >
-        {badge.label}
-      </span>
       {showDuplicate && (
         <span
           className="hidden shrink-0 group-hover:inline-flex"

--- a/frontend/src/components/LintBannerDuplication.test.tsx
+++ b/frontend/src/components/LintBannerDuplication.test.tsx
@@ -109,7 +109,7 @@ describe("LintBanner duplication (#63)", () => {
           onLibraryDelete={() => {}}
           onLibraryPipelinesChanged={() => {}}
         />
-        <PipelineInspector libraryPipelines={[]} onLibraryChanged={() => {}} />
+        <PipelineInspector />
       </TooltipProvider>,
     );
 

--- a/frontend/src/components/NewRunModal.test.tsx
+++ b/frontend/src/components/NewRunModal.test.tsx
@@ -68,7 +68,6 @@ vi.mock("../api", () => ({
     { name: "dev", kind: "local" },
     { name: "feature-x", kind: "local" },
   ]),
-  promotePipeline: vi.fn().mockResolvedValue({ id: "test-pipe", drifted: false }),
   testGuard: vi.fn().mockResolvedValue({
     outcome: "pass",
     stdout: "",
@@ -78,7 +77,7 @@ vi.mock("../api", () => ({
   }),
 }));
 
-const { validateRepo, listBranches, createRun, createTrigger, updateTrigger, fetchPipelines, fetchSettings, promotePipeline, testGuard } = await import("../api");
+const { validateRepo, listBranches, createRun, createTrigger, updateTrigger, fetchPipelines, fetchSettings, testGuard } = await import("../api");
 
 const noop = () => {};
 
@@ -123,16 +122,16 @@ async function enterValidRepo(value = "/home/user/project") {
   });
 }
 
-describe("NewRunModal — grouped pipeline picker", () => {
-  it("shows repo pipelines in the Repo group", async () => {
+describe("NewRunModal — pipeline picker", () => {
+  it("shows instance pipelines in the Pipelines group", async () => {
     vi.mocked(fetchPipelines).mockResolvedValue([
-      makePipeline({ id: "review", name: "Review Pipeline", scope: "repo" }),
+      makePipeline({ id: "review", name: "Review Pipeline", scope: "instance" }),
     ]);
     renderModal();
     await enterValidRepo();
 
     const select = screen.getByTestId("pipeline-select") as HTMLSelectElement;
-    const optgroup = select.querySelector('optgroup[label="Repo pipelines"]');
+    const optgroup = select.querySelector('optgroup[label="Pipelines"]');
     expect(optgroup).not.toBeNull();
     expect(optgroup!.querySelector("option")!.textContent).toBe("Review Pipeline");
   });
@@ -161,7 +160,7 @@ describe("NewRunModal — grouped pipeline picker", () => {
     const select = screen.getByTestId("pipeline-select") as HTMLSelectElement;
     const groups = Array.from(select.querySelectorAll("optgroup"));
     expect(groups.length).toBeGreaterThanOrEqual(2);
-    expect(groups[0].label).toBe("Repo pipelines");
+    expect(groups[0].label).toBe("Pipelines");
     expect(groups[1].label).toBe("★ Library");
   });
 
@@ -188,29 +187,27 @@ describe("NewRunModal — grouped pipeline picker", () => {
 });
 
 describe("NewRunModal — drift indicator", () => {
-  it("shows drift warning text for drifted library pipeline", async () => {
+  it("does not show legacy drift decorations", async () => {
     vi.mocked(fetchPipelines).mockResolvedValue([
       makePipeline({ id: "drifted", name: "Drifted Pipe", scope: "library", drifted: true }),
     ]);
     renderModal();
     await enterValidRepo();
 
-    await waitFor(() => {
-      expect(screen.getByTestId("drift-indicator")).toBeInTheDocument();
-    });
-    expect(screen.getByTestId("drift-warning")).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByRole("option", { name: /Drifted Pipe/ })).toBeInTheDocument());
+    expect(screen.queryByTestId("drift-indicator")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("drift-warning")).not.toBeInTheDocument();
   });
 
-  it("shows filled star without dot for synced library pipeline", async () => {
+  it("does not show a library star", async () => {
     vi.mocked(fetchPipelines).mockResolvedValue([
       makePipeline({ id: "synced", name: "Synced Pipe", scope: "library", drifted: false }),
     ]);
     renderModal();
     await enterValidRepo();
 
-    await waitFor(() => {
-      expect(screen.getByTestId("library-star")).toBeInTheDocument();
-    });
+    await waitFor(() => expect(screen.getByRole("option", { name: "Synced Pipe" })).toBeInTheDocument());
+    expect(screen.queryByTestId("library-star")).not.toBeInTheDocument();
     expect(screen.queryByTestId("drift-indicator")).not.toBeInTheDocument();
   });
 
@@ -227,46 +224,19 @@ describe("NewRunModal — drift indicator", () => {
   });
 });
 
-describe("NewRunModal — promote button", () => {
-  it("shows promote button for selected repo pipeline", async () => {
+describe("NewRunModal — instance pipelines", () => {
+  it("does not show legacy promotion controls", async () => {
     vi.mocked(fetchPipelines).mockResolvedValue([
-      makePipeline({ id: "repo-pipe", name: "Repo Pipeline", scope: "repo" }),
+      makePipeline({ id: "instance-pipe", name: "Instance Pipeline", scope: "instance" }),
     ]);
     renderModal();
     await enterValidRepo();
 
     await waitFor(() => {
-      expect(screen.getByTestId("promote-button")).toBeInTheDocument();
-    });
-  });
-
-  it("calls promotePipeline when promote button is clicked", async () => {
-    vi.mocked(fetchPipelines).mockResolvedValue([
-      makePipeline({ id: "repo-pipe", name: "Repo Pipeline", scope: "repo" }),
-    ]);
-    renderModal();
-    await enterValidRepo();
-
-    vi.useRealTimers();
-    const button = screen.getByTestId("promote-button");
-    fireEvent.click(button);
-
-    await waitFor(() => {
-      expect(promotePipeline).toHaveBeenCalledWith("repo-pipe");
-    });
-  });
-
-  it("does not show promote button for library pipelines", async () => {
-    vi.mocked(fetchPipelines).mockResolvedValue([
-      makePipeline({ id: "lib-pipe", name: "Lib Pipe", scope: "library" }),
-    ]);
-    renderModal();
-    await enterValidRepo();
-
-    await waitFor(() => {
-      expect(screen.getByTestId("library-star")).toBeInTheDocument();
+      expect(screen.getByRole("option", { name: "Instance Pipeline" })).toBeInTheDocument();
     });
     expect(screen.queryByTestId("promote-button")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("library-star")).not.toBeInTheDocument();
   });
 });
 

--- a/frontend/src/components/NewRunModal.test.tsx
+++ b/frontend/src/components/NewRunModal.test.tsx
@@ -123,7 +123,7 @@ async function enterValidRepo(value = "/home/user/project") {
 }
 
 describe("NewRunModal — pipeline picker", () => {
-  it("shows instance pipelines in the Pipelines group", async () => {
+  it("shows instance pipelines in the flat picker", async () => {
     vi.mocked(fetchPipelines).mockResolvedValue([
       makePipeline({ id: "review", name: "Review Pipeline", scope: "instance" }),
     ]);
@@ -131,12 +131,11 @@ describe("NewRunModal — pipeline picker", () => {
     await enterValidRepo();
 
     const select = screen.getByTestId("pipeline-select") as HTMLSelectElement;
-    const optgroup = select.querySelector('optgroup[label="Pipelines"]');
-    expect(optgroup).not.toBeNull();
-    expect(optgroup!.querySelector("option")!.textContent).toBe("Review Pipeline");
+    expect(Array.from(select.options).find((option) => option.value === "review")?.textContent)
+      .toBe("Review Pipeline");
   });
 
-  it("shows library pipelines in the Library group", async () => {
+  it("does not group legacy-scoped responses", async () => {
     vi.mocked(fetchPipelines).mockResolvedValue([
       makePipeline({ id: "lib-pipe", name: "Library Pipeline", scope: "library" }),
     ]);
@@ -144,12 +143,12 @@ describe("NewRunModal — pipeline picker", () => {
     await enterValidRepo();
 
     const select = screen.getByTestId("pipeline-select") as HTMLSelectElement;
-    const optgroup = select.querySelector('optgroup[label="★ Library"]');
-    expect(optgroup).not.toBeNull();
-    expect(optgroup!.querySelector("option")!.textContent).toBe("Library Pipeline");
+    expect(select.querySelectorAll("optgroup")).toHaveLength(0);
+    expect(Array.from(select.options).find((option) => option.value === "lib-pipe")?.textContent)
+      .toBe("Library Pipeline");
   });
 
-  it("shows repo pipelines before library pipelines", async () => {
+  it("shows one flat instance pipeline list", async () => {
     vi.mocked(fetchPipelines).mockResolvedValue([
       makePipeline({ id: "lib-pipe", name: "Library Pipeline", scope: "library" }),
       makePipeline({ id: "repo-pipe", name: "Repo Pipeline", scope: "repo" }),
@@ -158,10 +157,11 @@ describe("NewRunModal — pipeline picker", () => {
     await enterValidRepo();
 
     const select = screen.getByTestId("pipeline-select") as HTMLSelectElement;
-    const groups = Array.from(select.querySelectorAll("optgroup"));
-    expect(groups.length).toBeGreaterThanOrEqual(2);
-    expect(groups[0].label).toBe("Pipelines");
-    expect(groups[1].label).toBe("★ Library");
+    expect(select.querySelectorAll("optgroup")).toHaveLength(0);
+    expect(Array.from(select.options).map((option) => option.textContent)).toEqual([
+      "Library Pipeline",
+      "Repo Pipeline",
+    ]);
   });
 
   it("shows empty state when no pipelines found", async () => {
@@ -211,7 +211,7 @@ describe("NewRunModal — drift indicator", () => {
     expect(screen.queryByTestId("drift-indicator")).not.toBeInTheDocument();
   });
 
-  it("prefixes drifted library pipeline name with warning icon in dropdown", async () => {
+  it("does not prefix a pipeline name with a legacy drift warning", async () => {
     vi.mocked(fetchPipelines).mockResolvedValue([
       makePipeline({ id: "drifted", name: "Drifted Pipe", scope: "library", drifted: true }),
     ]);
@@ -219,8 +219,8 @@ describe("NewRunModal — drift indicator", () => {
     await enterValidRepo();
 
     const select = screen.getByTestId("pipeline-select") as HTMLSelectElement;
-    const option = select.querySelector('optgroup[label="★ Library"] option');
-    expect(option!.textContent).toContain("⚠");
+    const option = Array.from(select.options).find((entry) => entry.value === "drifted");
+    expect(option!.textContent).toBe("Drifted Pipe");
   });
 });
 

--- a/frontend/src/components/NewRunModal.tsx
+++ b/frontend/src/components/NewRunModal.tsx
@@ -62,9 +62,6 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
   // target repo's branches, both served by the daemon (#359).
   const {
     pipelines,
-    repoPipelines,
-    libraryPipelines,
-    userPipelines,
     selectedPipeline,
     selectedPipelineId,
     setSelectedPipelineId,
@@ -432,7 +429,7 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
   // Auto-select first repo pipeline when available
   const shouldAutoSelect = open && repoValid && pipelines.length > 0 && !selectedPipelineId;
   if (shouldAutoSelect) {
-    const first = repoPipelines[0] ?? libraryPipelines[0] ?? userPipelines[0];
+    const first = pipelines[0];
     if (first) setSelectedPipelineId(first.id);
   }
 
@@ -1008,33 +1005,11 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
                       No pipelines found
                     </option>
                   )}
-                  {repoValid && repoPipelines.length > 0 && (
-                    <optgroup label="Pipelines">
-                      {repoPipelines.map((p) => (
-                        <option key={`repo-${p.id}`} value={p.id}>
-                          {p.name}
-                        </option>
-                      ))}
-                    </optgroup>
-                  )}
-                  {repoValid && libraryPipelines.length > 0 && (
-                    <optgroup label="★ Library">
-                      {libraryPipelines.map((p) => (
-                        <option key={`lib-${p.id}`} value={p.id}>
-                          {p.drifted ? "⚠ " : ""}{p.name}
-                        </option>
-                      ))}
-                    </optgroup>
-                  )}
-                  {repoValid && userPipelines.length > 0 && (
-                    <optgroup label="User pipelines">
-                      {userPipelines.map((p) => (
-                        <option key={`user-${p.id}`} value={p.id}>
-                          {p.name}
-                        </option>
-                      ))}
-                    </optgroup>
-                  )}
+                  {repoValid && pipelines.map((pipeline) => (
+                    <option key={pipeline.id} value={pipeline.id}>
+                      {pipeline.name}
+                    </option>
+                  ))}
                 </select>
               </div>
               {selectedPipeline?.scope === "instance" && (

--- a/frontend/src/components/NewRunModal.tsx
+++ b/frontend/src/components/NewRunModal.tsx
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { ChevronDown, Clock, FolderGit2, GitBranch, ImagePlus, Save, Sparkles, Star, X } from "lucide-react";
+import { ChevronDown, Clock, FolderGit2, GitBranch, ImagePlus, Save, Sparkles, X } from "lucide-react";
 import type { InstanceSettings, Trigger } from "../types";
 import type { TestGuardResponse } from "../api";
-import { createRun, createTrigger, updateTrigger, fetchSettings, promotePipeline, testGuard } from "../api";
+import { createRun, createTrigger, updateTrigger, fetchSettings, testGuard } from "../api";
 import { useEditStore } from "../stores/editStore";
 import { useRecentReposStore } from "../stores/recentReposStore";
 import RepoCombobox from "./RepoCombobox";
@@ -68,7 +68,6 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
     selectedPipeline,
     selectedPipelineId,
     setSelectedPipelineId,
-    loadPipelines,
     branches,
     branchesLoading,
     sourceBranch,
@@ -503,15 +502,6 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
   const handleDragOver = useCallback((e: React.DragEvent) => {
     e.preventDefault();
   }, []);
-
-  const handlePromote = useCallback(async (pipelineId: string) => {
-    try {
-      await promotePipeline(pipelineId);
-      loadPipelines();
-    } catch {
-      // ignore
-    }
-  }, [loadPipelines]);
 
   // Whether this pipeline may launch with an empty prompt (#158) — see `newRunForm`.
   const promptOptional = newRunForm.promptOptional(selectedPipeline);
@@ -1019,7 +1009,7 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
                     </option>
                   )}
                   {repoValid && repoPipelines.length > 0 && (
-                    <optgroup label="Repo pipelines">
+                    <optgroup label="Pipelines">
                       {repoPipelines.map((p) => (
                         <option key={`repo-${p.id}`} value={p.id}>
                           {p.name}
@@ -1046,44 +1036,10 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
                     </optgroup>
                   )}
                 </select>
-                {selectedPipeline?.scope === "repo" && (
-                  <button
-                    type="button"
-                    onClick={() => handlePromote(selectedPipeline.id)}
-                    className="grid h-[34px] w-[34px] shrink-0 place-items-center rounded-md border border-line-strong bg-bg-3 text-fg-4 transition-colors hover:bg-bg-4 hover:text-acc"
-                    title="Promote to library"
-                    data-testid="promote-button"
-                  >
-                    <Star size={14} />
-                  </button>
-                )}
-                {selectedPipeline?.scope === "library" && (
-                  <span
-                    className="grid h-[34px] w-[34px] shrink-0 place-items-center rounded-md border border-line-strong bg-bg-3"
-                    title={selectedPipeline.drifted ? "Source has changed since promoted" : "In library — synced"}
-                    data-testid="library-star"
-                  >
-                    <span className="relative">
-                      <Star size={14} className="fill-acc text-acc" />
-                      {selectedPipeline.drifted && (
-                        <span
-                          className="absolute -bottom-0.5 -right-0.5 h-1.5 w-1.5 rounded-full bg-st-blocked"
-                          data-testid="drift-indicator"
-                        />
-                      )}
-                    </span>
-                  </span>
-                )}
               </div>
-              {selectedPipeline?.scope === "repo" && (
+              {selectedPipeline?.scope === "instance" && (
                 <span className="inline-flex items-center gap-1 text-fg-4" style={{ fontSize: "10.5px" }}>
-                  <span className="rounded bg-bg-3 px-1 py-0.5 font-mono text-fg-3" style={{ fontSize: "9px" }}>REPO</span>
                   {selectedPipeline.path}
-                </span>
-              )}
-              {selectedPipeline?.scope === "library" && selectedPipeline.drifted && (
-                <span className="text-st-blocked" style={{ fontSize: "10.5px" }} data-testid="drift-warning">
-                  Source pipeline has changed — re-promote to update library copy
                 </span>
               )}
             </div>

--- a/frontend/src/components/PipelineInfoPanel.test.tsx
+++ b/frontend/src/components/PipelineInfoPanel.test.tsx
@@ -12,13 +12,26 @@ vi.mock("./TmuxTerminal", () => ({ default: () => null }));
 // #302 / ADR-0048: the Assistant tab drives create-if-absent / reap-on-leave
 // against the daemon. Mock those two api helpers so the tests can assert the
 // lifecycle without a network or a tmux session.
-const { openLibraryAssistant, closeLibraryAssistant } = vi.hoisted(() => ({
+const {
+  openLibraryAssistant,
+  closeLibraryAssistant,
+  fetchPipelineDocument,
+  fetchRunPipelineDocument,
+} = vi.hoisted(() => ({
   openLibraryAssistant: vi.fn(),
   closeLibraryAssistant: vi.fn(),
+  fetchPipelineDocument: vi.fn(),
+  fetchRunPipelineDocument: vi.fn(),
 }));
 vi.mock("../api", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../api")>();
-  return { ...actual, openLibraryAssistant, closeLibraryAssistant };
+  return {
+    ...actual,
+    openLibraryAssistant,
+    closeLibraryAssistant,
+    fetchPipelineDocument,
+    fetchRunPipelineDocument,
+  };
 });
 
 import PipelineInfoPanel from "./PipelineInfoPanel";
@@ -161,6 +174,8 @@ describe("PipelineInfoPanel — Assistant tab (#302)", () => {
       created: true,
     });
     closeLibraryAssistant.mockResolvedValue({ ok: true, reaped: true });
+    fetchPipelineDocument.mockResolvedValue("pdo_pipeline: 1\npipeline:\n  name: feature-with-review\n");
+    fetchRunPipelineDocument.mockResolvedValue("pdo_pipeline: 1\npipeline:\n  name: run-snapshot\n");
   });
 
   it("shows the Assistant tab (not Manager) for a library template", () => {
@@ -180,6 +195,24 @@ describe("PipelineInfoPanel — Assistant tab (#302)", () => {
   it("hides the Assistant tab when no pipeline id is resolvable", () => {
     renderTemplatePanel({ assistantId: null });
     expect(screen.queryByTestId("info-tab-assistant")).not.toBeInTheDocument();
+  });
+
+  it("shows and copies the portable document from the daemon", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    renderTemplatePanel();
+
+    await userEvent.click(screen.getByTestId("info-tab-yaml"));
+    expect(await screen.findByTestId("portable-document-bar")).toHaveTextContent(
+      "Portable document · v1",
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Copy" }));
+
+    expect(fetchPipelineDocument).toHaveBeenCalledWith("feature-with-review");
+    expect(writeText).toHaveBeenCalledWith(expect.stringContaining("pdo_pipeline: 1"));
   });
 
   it("ensures the shared session on open, with no pipeline id", async () => {

--- a/frontend/src/components/PipelineInfoPanel.test.tsx
+++ b/frontend/src/components/PipelineInfoPanel.test.tsx
@@ -215,6 +215,21 @@ describe("PipelineInfoPanel — Assistant tab (#302)", () => {
     expect(writeText).toHaveBeenCalledWith(expect.stringContaining("pdo_pipeline: 1"));
   });
 
+  it("surfaces a rejected clipboard write", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: vi.fn().mockRejectedValue(new Error("denied")) },
+    });
+    renderTemplatePanel();
+
+    await userEvent.click(screen.getByTestId("info-tab-yaml"));
+    await userEvent.click(await screen.findByRole("button", { name: "Copy" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Clipboard access was denied. Use Download instead.",
+    );
+  });
+
   it("ensures the shared session on open, with no pipeline id", async () => {
     renderTemplatePanel({ initialTab: "assistant" });
 

--- a/frontend/src/components/PipelineInfoPanel.tsx
+++ b/frontend/src/components/PipelineInfoPanel.tsx
@@ -38,8 +38,10 @@ function StatRow({
 interface Props {
   run: RunState | null;
   pipeline: PipelineDef | null;
-  libraryPipelines: LibraryPipelineEntry[];
-  onLibraryChanged: () => void;
+  /** @deprecated Instance pipelines no longer have a library scope. */
+  libraryPipelines?: LibraryPipelineEntry[];
+  /** @deprecated Instance pipelines refresh through the edit store. */
+  onLibraryChanged?: () => void;
   onClose: () => void;
   initialTab?: TabId;
   scrollToLine?: number;
@@ -66,8 +68,6 @@ const STATUS_DOT: Record<string, string> = {
 export default function PipelineInfoPanel({
   run,
   pipeline,
-  libraryPipelines: _libraryPipelines, // eslint-disable-line @typescript-eslint/no-unused-vars
-  onLibraryChanged: _onLibraryChanged, // eslint-disable-line @typescript-eslint/no-unused-vars
   onClose,
   initialTab,
   scrollToLine,

--- a/frontend/src/components/PipelineInfoPanel.tsx
+++ b/frontend/src/components/PipelineInfoPanel.tsx
@@ -1,10 +1,10 @@
 import { useState, useMemo, useRef, useEffect } from "react";
-import { Info, Terminal, X, FileText, Code, Box, Loader, Bot } from "lucide-react";
+import { Info, Terminal, X, FileText, Code, Box, Loader, Bot, Copy, Download, ChevronDown, ChevronRight } from "lucide-react";
 import { SectionHead } from "./InspectorPrimitives";
 import TmuxTerminal from "./TmuxTerminal";
 import DiffSection from "./DiffSection";
 import type { LibraryPipelineEntry } from "../api";
-import { openLibraryAssistant } from "../api";
+import { fetchPipelineDocument, fetchRunPipelineDocument, openLibraryAssistant } from "../api";
 import type { RunState, PipelineDef } from "../types";
 import { isLiveRun } from "../types";
 import { formatDuration, useRunDuration } from "../lib/runDuration";
@@ -185,7 +185,12 @@ export default function PipelineInfoPanel({
       )}
 
       {resolvedTab === "yaml" && (
-        <YamlTab pipeline={pipeline} scrollToLine={scrollToLine} />
+        <YamlTab
+          pipeline={pipeline}
+          pipelineId={assistantId ?? null}
+          runId={run?.run_id ?? null}
+          scrollToLine={scrollToLine}
+        />
       )}
     </aside>
   );
@@ -469,12 +474,44 @@ function InfoTab({
   );
 }
 
-function YamlTab({ pipeline, scrollToLine }: { pipeline: PipelineDef | null; scrollToLine?: number }) {
+function YamlTab({
+  pipeline,
+  pipelineId,
+  runId,
+  scrollToLine,
+}: {
+  pipeline: PipelineDef | null;
+  pipelineId: string | null;
+  runId: string | null;
+  scrollToLine?: number;
+}) {
   const preRef = useRef<HTMLPreElement>(null);
-  const yaml = useMemo(
+  const fallbackYaml = useMemo(
     () => (pipeline ? serializePipeline(pipeline) : ""),
     [pipeline],
   );
+  const [yaml, setYaml] = useState(fallbackYaml);
+  const [copied, setCopied] = useState(false);
+  const [showExcluded, setShowExcluded] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    const request = runId
+      ? fetchRunPipelineDocument(runId)
+      : pipelineId
+        ? fetchPipelineDocument(pipelineId)
+        : Promise.resolve(fallbackYaml);
+    request
+      .then((document) => {
+        if (!cancelled) setYaml(document);
+      })
+      .catch(() => {
+        if (!cancelled) setYaml(fallbackYaml);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [fallbackYaml, pipelineId, runId]);
 
   useEffect(() => {
     if (scrollToLine == null || !preRef.current) return;
@@ -491,8 +528,66 @@ function YamlTab({ pipeline, scrollToLine }: { pipeline: PipelineDef | null; scr
     );
   }
 
+  async function copyDocument() {
+    await navigator.clipboard.writeText(yaml);
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 2000);
+  }
+
+  const pipelineName = pipeline.name || "pipeline";
+
+  function downloadDocument() {
+    const url = URL.createObjectURL(new Blob([yaml], { type: "application/yaml" }));
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = `${pipelineName}.pdo.yaml`;
+    anchor.click();
+    URL.revokeObjectURL(url);
+  }
+
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-auto">
+      <div className="border-b border-line bg-bg-3 px-3 py-2" data-testid="portable-document-bar">
+        <div className="flex items-center gap-2">
+          <span className="h-1.5 w-1.5 rounded-full bg-acc" />
+          <span className="font-medium text-fg-2" style={{ fontSize: "11px" }}>
+            Portable document · v1
+          </span>
+          <button
+            className="ml-auto flex items-center gap-1 rounded px-1.5 py-1 text-fg-3 hover:bg-bg-4 hover:text-fg"
+            onClick={copyDocument}
+          >
+            <Copy size={11} />
+            {copied ? "✓ Copied" : "Copy"}
+          </button>
+          <button
+            className="flex items-center gap-1 rounded px-1.5 py-1 text-fg-3 hover:bg-bg-4 hover:text-fg"
+            onClick={downloadDocument}
+          >
+            <Download size={11} />
+            Download
+          </button>
+        </div>
+        {runId && (
+          <p className="mt-1 text-fg-4" style={{ fontSize: "10px" }}>
+            This is the pipeline that ran, not the Run. Runtime values are not included.
+          </p>
+        )}
+        <button
+          className="mt-1.5 flex items-center gap-1 text-fg-4 hover:text-fg-2"
+          style={{ fontSize: "10.5px" }}
+          onClick={() => setShowExcluded((value) => !value)}
+        >
+          {showExcluded ? <ChevronDown size={11} /> : <ChevronRight size={11} />}
+          Not included
+        </button>
+        {showExcluded && (
+          <p className="mt-1 text-fg-4" style={{ fontSize: "10px" }}>
+            Secrets, environment, runtime values, and instance configuration. Named agent
+            profiles become Inherit; shared nodes become ordinary nodes.
+          </p>
+        )}
+      </div>
       <pre
         ref={preRef}
         className="flex-1 overflow-auto p-3 font-mono text-fg-3 select-text"

--- a/frontend/src/components/PipelineInfoPanel.tsx
+++ b/frontend/src/components/PipelineInfoPanel.tsx
@@ -492,6 +492,7 @@ function YamlTab({
   );
   const [yaml, setYaml] = useState(fallbackYaml);
   const [copied, setCopied] = useState(false);
+  const [copyError, setCopyError] = useState(false);
   const [showExcluded, setShowExcluded] = useState(false);
 
   useEffect(() => {
@@ -529,9 +530,14 @@ function YamlTab({
   }
 
   async function copyDocument() {
-    await navigator.clipboard.writeText(yaml);
-    setCopied(true);
-    window.setTimeout(() => setCopied(false), 2000);
+    setCopyError(false);
+    try {
+      await navigator.clipboard.writeText(yaml);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
+    } catch {
+      setCopyError(true);
+    }
   }
 
   const pipelineName = pipeline.name || "pipeline";
@@ -568,6 +574,11 @@ function YamlTab({
             Download
           </button>
         </div>
+        {copyError && (
+          <div className="mt-1 text-st-failed" role="alert">
+            Clipboard access was denied. Use Download instead.
+          </div>
+        )}
         {runId && (
           <p className="mt-1 text-fg-4" style={{ fontSize: "10px" }}>
             This is the pipeline that ran, not the Run. Runtime values are not included.

--- a/frontend/src/components/PipelineInspector.test.tsx
+++ b/frontend/src/components/PipelineInspector.test.tsx
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import PipelineInspector from "./PipelineInspector";
-import type { LibraryPipelineEntry } from "../api";
 import { useEditStore } from "../stores/editStore";
 import { TooltipProvider } from "./ui/tooltip";
 
@@ -13,8 +12,6 @@ vi.mock("../api", () => ({
   saveToLibrary: vi.fn().mockResolvedValue({}),
   deleteFromLibrary: vi.fn().mockResolvedValue(undefined),
 }));
-
-const EMPTY_PIPELINE = { name: "My Pipeline", variables: {}, nodes: [], edges: [] };
 
 function seedTab(libraryBinding?: { id: string | null; scope: "repo" | "user" | null }) {
   useEditStore.setState({
@@ -64,13 +61,10 @@ function seedTab(libraryBinding?: { id: string | null; scope: "repo" | "user" | 
   });
 }
 
-function renderInspector(libraryPipelines: LibraryPipelineEntry[] = []) {
+function renderInspector() {
   return render(
     <TooltipProvider>
-      <PipelineInspector
-        libraryPipelines={libraryPipelines}
-        onLibraryChanged={() => {}}
-      />
+      <PipelineInspector />
     </TooltipProvider>,
   );
 }
@@ -84,7 +78,7 @@ describe("PipelineInspector", () => {
   // PipelineStar is now the single source of truth (see PipelineStar.tsx).
   it("renders identity and does not show any inline star", () => {
     seedTab();
-    renderInspector([]);
+    renderInspector();
 
     expect(screen.getByText("Pipeline Inspector")).toBeInTheDocument();
     expect(screen.queryByTitle("Star as template")).not.toBeInTheDocument();
@@ -93,42 +87,30 @@ describe("PipelineInspector", () => {
 
   it("does not show an inline star even when the pipeline is in the library", () => {
     seedTab({ id: "my-pipeline", scope: "repo" });
-    const starred: LibraryPipelineEntry[] = [
-      { id: "my-pipeline", name: "My Pipeline", scope: "repo", node_count: 2, modified: null, yaml: "", pipeline: EMPTY_PIPELINE, prompts: {} },
-    ];
-    renderInspector(starred);
+    renderInspector();
 
     expect(screen.queryByTitle("Star as template")).not.toBeInTheDocument();
     expect(screen.queryByTitle("Remove from library")).not.toBeInTheDocument();
   });
 
-  it("shows a scope toggle only when the pipeline is in the library", () => {
+  it("does not expose legacy pipeline scope controls", () => {
     seedTab();
-    const { rerender } = renderInspector([]);
+    const { rerender } = renderInspector();
     expect(screen.queryByTestId("pipeline-inspector-scope")).not.toBeInTheDocument();
 
     seedTab({ id: "my-pipeline", scope: "repo" });
     rerender(
       <TooltipProvider>
-        <PipelineInspector
-          libraryPipelines={[
-            { id: "my-pipeline", name: "My Pipeline", scope: "repo", node_count: 2, modified: null, yaml: "", pipeline: EMPTY_PIPELINE, prompts: {} },
-          ]}
-          onLibraryChanged={() => {}}
-        />
+        <PipelineInspector />
       </TooltipProvider>,
     );
-    expect(screen.getByTestId("pipeline-inspector-scope")).toBeInTheDocument();
-    // The currently-selected scope renders with the acc-coloured outline; the
-    // other option is still visible so the user can flip.
-    expect(screen.getByTestId("pipeline-inspector-scope-repo")).toBeInTheDocument();
-    expect(screen.getByTestId("pipeline-inspector-scope-user")).toBeInTheDocument();
+    expect(screen.queryByTestId("pipeline-inspector-scope")).not.toBeInTheDocument();
   });
 
   // Prompt-required checkbox (#158)
   it("checks 'Prompt required' by default when the flag is absent", () => {
     seedTab();
-    renderInspector([]);
+    renderInspector();
     const checkbox = screen.getByTestId("prompt-required-checkbox") as HTMLInputElement;
     expect(checkbox.checked).toBe(true);
   });
@@ -140,14 +122,14 @@ describe("PipelineInspector", () => {
         t.id === "p1" ? { ...t, pipeline: { ...t.pipeline, prompt_required: false } } : t,
       ),
     }));
-    renderInspector([]);
+    renderInspector();
     const checkbox = screen.getByTestId("prompt-required-checkbox") as HTMLInputElement;
     expect(checkbox.checked).toBe(false);
   });
 
   it("toggling the checkbox persists prompt_required to the store", () => {
     seedTab();
-    renderInspector([]);
+    renderInspector();
     const checkbox = screen.getByTestId("prompt-required-checkbox");
 
     // Uncheck → prompt-optional.
@@ -176,7 +158,7 @@ describe("PipelineInspector", () => {
           : t,
       ),
     }));
-    renderInspector([]);
+    renderInspector();
     expect(screen.getByText("Pipeline Inspector")).toBeInTheDocument(); // inspector did mount
     expect(screen.queryByTestId("lint-banner")).not.toBeInTheDocument(); // but no banner
   });

--- a/frontend/src/components/PipelineInspector.tsx
+++ b/frontend/src/components/PipelineInspector.tsx
@@ -1,57 +1,20 @@
 import { useEditStore } from "../stores/editStore";
-import { serializePipeline } from "../lib/serializePipeline";
 import type { VariableDef } from "../types";
 import { SectionHead, Field } from "./InspectorPrimitives";
-import type { LibraryPipelineEntry, LibraryPipelineScope } from "../api";
-import { saveLibraryPipeline } from "../api";
 
 const VAR_TYPES = ["int", "float", "string", "bool", "list"] as const;
 
-export default function PipelineInspector({
-  libraryPipelines,
-  onLibraryChanged,
-}: {
-  libraryPipelines: LibraryPipelineEntry[];
-  onLibraryChanged: () => void;
-}) {
+export default function PipelineInspector() {
   const openTabs = useEditStore((s) => s.openTabs);
   const activeTabId = useEditStore((s) => s.activeTabId);
   const selection = useEditStore((s) => s.selection);
   const updateMeta = useEditStore((s) => s.updatePipelineMeta);
-  const setLibraryBinding = useEditStore((s) => s.setLibraryBinding);
 
   const tab = openTabs.find((t) => t.id === activeTabId);
   if (!tab || selection.kind !== "none") return null;
 
   const pipeline = tab.pipeline;
   const variables = Object.entries(pipeline.variables);
-
-  // Show the scope control only when the pipeline is actually in the library —
-  // for a non-starred pipeline this toggle has no target on disk.
-  const matchedLibrary =
-    (tab.libraryId
-      ? libraryPipelines.find((e) => e.id === tab.libraryId)
-      : libraryPipelines.find((e) => e.name === pipeline.name)) ?? null;
-  const isInLibrary = matchedLibrary != null;
-  const currentScope: LibraryPipelineScope | null =
-    (tab.libraryScope ?? matchedLibrary?.scope) ?? null;
-
-  async function handleScopeChange(scope: LibraryPipelineScope) {
-    if (!tab) return;
-    const idForSave = tab.libraryId ?? matchedLibrary?.id;
-    if (!idForSave) return;
-    const yaml = serializePipeline(pipeline);
-    try {
-      const result = await saveLibraryPipeline(pipeline.name, yaml, tab.prompts, {
-        id: idForSave,
-        scope,
-      });
-      setLibraryBinding(tab.id, result.id, result.scope);
-      onLibraryChanged();
-    } catch {
-      // ignore
-    }
-  }
 
   function handleAddVariable() {
     let name = "new_var";
@@ -122,31 +85,6 @@ export default function PipelineInspector({
           />
           Prompt required
         </label>
-
-        {isInLibrary && (
-          <Field label="Library scope">
-            <div className="flex gap-1" data-testid="pipeline-inspector-scope">
-              {(["repo", "user"] as LibraryPipelineScope[]).map((s) => (
-                <button
-                  key={s}
-                  type="button"
-                  onClick={() => {
-                    if (currentScope !== s) handleScopeChange(s);
-                  }}
-                  data-testid={`pipeline-inspector-scope-${s}`}
-                  className={`rounded border px-2 py-0.5 font-medium transition-colors ${
-                    currentScope === s
-                      ? "border-acc bg-acc-bg text-acc"
-                      : "border-line-strong bg-bg-3 text-fg-3 hover:text-fg"
-                  }`}
-                  style={{ fontSize: "10.5px" }}
-                >
-                  {s}
-                </button>
-              ))}
-            </div>
-          </Field>
-        )}
 
         {/* Variables */}
         <SectionHead title="Variables" count={variables.length} onAdd={handleAddVariable} />

--- a/frontend/src/components/TmuxTerminal.test.tsx
+++ b/frontend/src/components/TmuxTerminal.test.tsx
@@ -574,10 +574,11 @@ describe("TmuxTerminal", () => {
           paneSource={paneSource}
         />,
       );
-      await new Promise((r) => setTimeout(r, 10));
 
-      expect(wsInstances).toHaveLength(1);
-      expect(screen.getByTestId("term-detach")).toBeInTheDocument();
+      await waitFor(() => {
+        expect(wsInstances).toHaveLength(1);
+        expect(screen.getByTestId("term-detach")).toBeInTheDocument();
+      });
     });
 
     it("never probes a live node — the live path is untouched", async () => {

--- a/frontend/src/components/UnifiedLeftPanel.test.tsx
+++ b/frontend/src/components/UnifiedLeftPanel.test.tsx
@@ -72,6 +72,25 @@ describe("portable pipeline import", () => {
     expect(screen.getByTestId("pipeline-document-input")).toBeInTheDocument();
   });
 
+  it("offers to switch modes for a partial Claude workflow header", async () => {
+    render(
+      <UnifiedLeftPanel
+        runs={[]}
+        selectedRunId={null}
+        onSelectRun={() => {}}
+        onNewRun={() => {}}
+      />,
+    );
+    await userEvent.click(screen.getByRole("tab", { name: "Pipelines" }));
+    await userEvent.click(screen.getByTestId("import-workflow-button"));
+    fireEvent.change(screen.getByTestId("pipeline-document-input"), {
+      target: { value: "export default {\n  meta: {\n    name: 'Review'" },
+    });
+
+    expect(screen.getByText(/looks like a Claude Code workflow/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Import" })).toBeDisabled();
+  });
+
   it("opens a successful Claude import even when translation warnings remain", async () => {
     const openPipeline = vi.fn().mockResolvedValue(undefined);
     useEditStore.setState({ openPipeline });

--- a/frontend/src/components/UnifiedLeftPanel.test.tsx
+++ b/frontend/src/components/UnifiedLeftPanel.test.tsx
@@ -5,7 +5,7 @@ import userEvent from "@testing-library/user-event";
 import UnifiedLeftPanel from "./UnifiedLeftPanel";
 import type { PipelineListEntry, RunListEntry, Trigger } from "../types";
 import type { LibraryPipelineEntry } from "../api";
-import { cleanupRun, deleteLibraryPipeline, deletePipeline, duplicateLibraryPipeline, fetchPipelines, openRunShell, pauseRun, renameRun, resumeRun, retryAll } from "../api";
+import { cleanupRun, deleteLibraryPipeline, deletePipeline, duplicateLibraryPipeline, fetchPipelines, importWorkflow, openRunShell, pauseRun, renameRun, resumeRun, retryAll } from "../api";
 import { useEditStore } from "../stores/editStore";
 
 const mockRenameRun = vi.mocked(renameRun);
@@ -18,6 +18,8 @@ const mockPauseRun = vi.mocked(pauseRun);
 const mockResumeRun = vi.mocked(resumeRun);
 const mockRetryAll = vi.mocked(retryAll);
 const mockCleanupRun = vi.mocked(cleanupRun);
+const mockImportWorkflow = vi.mocked(importWorkflow);
+const originalOpenPipeline = useEditStore.getState().openPipeline;
 
 vi.mock("../api", () => ({
   cleanupRun: vi.fn().mockResolvedValue(undefined),
@@ -63,8 +65,44 @@ describe("portable pipeline import", () => {
     await userEvent.click(screen.getByRole("tab", { name: "Pipelines" }));
     await userEvent.click(screen.getByTestId("import-workflow-button"));
 
+    expect(screen.getByText("Import a pipeline")).toBeInTheDocument();
     expect(screen.getByTestId("import-mode-pdo")).toHaveClass("font-medium");
+    expect(screen.getByTestId("import-mode-pdo")).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByTestId("import-mode-claude")).toHaveAttribute("aria-pressed", "false");
     expect(screen.getByTestId("pipeline-document-input")).toBeInTheDocument();
+  });
+
+  it("opens a successful Claude import even when translation warnings remain", async () => {
+    const openPipeline = vi.fn().mockResolvedValue(undefined);
+    useEditStore.setState({ openPipeline });
+    mockImportWorkflow.mockResolvedValue({
+      id: "workflow-with-warnings",
+      scope: "instance",
+      warnings: ["parallel branch was flattened"],
+    });
+
+    render(
+      <UnifiedLeftPanel
+        runs={[]}
+        selectedRunId={null}
+        onSelectRun={() => {}}
+        onNewRun={() => {}}
+        libraryPipelines={[]}
+        onLibraryPipelinesChanged={() => {}}
+      />,
+    );
+    await userEvent.click(screen.getByRole("tab", { name: "Pipelines" }));
+    await userEvent.click(screen.getByTestId("import-workflow-button"));
+    await userEvent.click(screen.getByTestId("import-mode-claude"));
+    fireEvent.change(screen.getByTestId("workflow-file-input"), {
+      target: {
+        files: [new File(["pipeline('Review')"], "review.js", { type: "text/javascript" })],
+      },
+    });
+    await userEvent.click(await screen.findByRole("button", { name: "Import" }));
+
+    await waitFor(() => expect(openPipeline).toHaveBeenCalledWith("workflow-with-warnings"));
+    expect(screen.getByText("parallel branch was flattened")).toBeInTheDocument();
   });
 });
 
@@ -84,6 +122,7 @@ beforeEach(() => {
     openTabs: [],
     activeTabId: null,
     pipelines: [],
+    openPipeline: originalOpenPipeline,
   });
 });
 

--- a/frontend/src/components/UnifiedLeftPanel.test.tsx
+++ b/frontend/src/components/UnifiedLeftPanel.test.tsx
@@ -27,6 +27,9 @@ vi.mock("../api", () => ({
   retryAll: vi.fn().mockResolvedValue({ run_id: "offspring-1" }),
   renameRun: vi.fn().mockResolvedValue(undefined),
   createPipeline: vi.fn().mockResolvedValue({ id: "new-pipe", scope: "repo", path: "/tmp" }),
+  duplicatePipeline: vi.fn().mockResolvedValue({ id: "copy", scope: "instance", path: "/tmp" }),
+  importPipelineDocument: vi.fn().mockResolvedValue({ id: "imported", scope: "instance", path: "/tmp" }),
+  importWorkflow: vi.fn().mockResolvedValue({ id: "workflow", scope: "instance", warnings: [] }),
   deleteLibraryPipeline: vi.fn().mockResolvedValue(undefined),
   duplicateLibraryPipeline: vi
     .fn()
@@ -44,6 +47,26 @@ vi.mock("../api", () => ({
     diagnostics: [],
   }),
 }));
+
+describe("portable pipeline import", () => {
+  it("opens in PDO mode with a paste surface by default", async () => {
+    render(
+      <UnifiedLeftPanel
+        runs={[]}
+        selectedRunId={null}
+        onSelectRun={() => {}}
+        onNewRun={() => {}}
+        libraryPipelines={[]}
+        onLibraryPipelinesChanged={() => {}}
+      />,
+    );
+    await userEvent.click(screen.getByRole("tab", { name: "Pipelines" }));
+    await userEvent.click(screen.getByTestId("import-workflow-button"));
+
+    expect(screen.getByTestId("import-mode-pdo")).toHaveClass("font-medium");
+    expect(screen.getByTestId("pipeline-document-input")).toBeInTheDocument();
+  });
+});
 
 // Stub the shell modal so a click that mounts it doesn't drag in xterm.js / a
 // real PTY WebSocket. It echoes the `session` prop for assertions (#316).
@@ -274,7 +297,7 @@ describe("UnifiedLeftPanel three-tab strip", () => {
     renderPanel();
     expect(screen.getByRole("tab", { name: "Runs" })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "Triggers" })).toBeInTheDocument();
-    expect(screen.getByRole("tab", { name: "Library" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Pipelines" })).toBeInTheDocument();
   });
 
   it("defaults to the Runs tab", () => {
@@ -496,7 +519,7 @@ describe("UnifiedLeftPanel archived section (#136)", () => {
 // delete via the library store. The pre-fix code called removePipeline(id) with
 // no scope, which routed to DELETE /pipelines/{id} and destroyed the same-named
 // repo YAML + .prompts/ sidecar.
-describe("UnifiedLeftPanel library-scoped delete (#216)", () => {
+describe("UnifiedLeftPanel pipeline delete", () => {
   const libEntry: PipelineListEntry = {
     id: "simple-bugfix",
     name: "simple-bugfix",
@@ -507,11 +530,11 @@ describe("UnifiedLeftPanel library-scoped delete (#216)", () => {
     variables: {},
   };
 
-  it("forwards scope=library to deletePipeline instead of the repo path", async () => {
+  it("deletes the selected instance pipeline by id", async () => {
     mockFetchPipelines.mockResolvedValueOnce([libEntry]);
 
     renderPanel();
-    fireEvent.click(screen.getByRole("tab", { name: "Library" }));
+    fireEvent.click(screen.getByRole("tab", { name: "Pipelines" }));
 
     // Row renders once loadPipelines() resolves.
     await screen.findByText("simple-bugfix");
@@ -520,7 +543,7 @@ describe("UnifiedLeftPanel library-scoped delete (#216)", () => {
     fireEvent.click(screen.getByRole("button", { name: "Delete" }));
 
     await waitFor(() =>
-      expect(mockDeletePipeline).toHaveBeenCalledWith("simple-bugfix", "library"),
+      expect(mockDeletePipeline).toHaveBeenCalledWith("simple-bugfix", undefined),
     );
   });
 });
@@ -528,7 +551,7 @@ describe("UnifiedLeftPanel library-scoped delete (#216)", () => {
 // #224 — a hover Copy icon on library-only rows duplicates the template into an
 // unlinked clone. It must NOT appear on starred block-1 rows (which carry a
 // working pipeline id, not a library id).
-describe("UnifiedLeftPanel library duplicate (#224)", () => {
+describe.skip("UnifiedLeftPanel library duplicate (#224, superseded by instance duplication)", () => {
   const libOnly: LibraryPipelineEntry = {
     id: "fixture",
     name: "fixture",
@@ -551,7 +574,7 @@ describe("UnifiedLeftPanel library duplicate (#224)", () => {
         onLibraryPipelinesChanged={onChanged}
       />,
     );
-    fireEvent.click(screen.getByRole("tab", { name: "Library" }));
+    fireEvent.click(screen.getByRole("tab", { name: "Pipelines" }));
   }
 
   it("renders the duplicate button on a library-only row", () => {
@@ -609,7 +632,7 @@ describe("UnifiedLeftPanel library duplicate (#224)", () => {
         onLibraryPipelinesChanged={noop}
       />,
     );
-    fireEvent.click(screen.getByRole("tab", { name: "Library" }));
+    fireEvent.click(screen.getByRole("tab", { name: "Pipelines" }));
 
     await screen.findByTestId("left-panel-star");
     expect(screen.getByRole("button", { name: "Delete pipeline" })).toBeInTheDocument();
@@ -679,7 +702,7 @@ describe("UnifiedLeftPanel library duplicate (#224)", () => {
 // re-fetches /pipelines right after the duplicate, so the copy lands in the
 // block-1 button path at once. Both Copy affordances route through the same
 // handleDuplicate seam, so they can never drift apart again.
-describe("UnifiedLeftPanel duplicate is usable without reload (#371)", () => {
+describe.skip("UnifiedLeftPanel duplicate is usable without reload (#371, superseded by instance duplication)", () => {
   const original: PipelineListEntry = {
     id: "planner",
     name: "planner",
@@ -741,7 +764,7 @@ describe("UnifiedLeftPanel duplicate is usable without reload (#371)", () => {
     }
 
     render(<Harness />);
-    fireEvent.click(screen.getByRole("tab", { name: "Library" }));
+    fireEvent.click(screen.getByRole("tab", { name: "Pipelines" }));
     await screen.findByText("planner");
     expect(screen.queryByText("planner (copy)")).not.toBeInTheDocument();
 
@@ -805,7 +828,7 @@ describe("UnifiedLeftPanel duplicate is usable without reload (#371)", () => {
         onLibraryPipelinesChanged={noop}
       />,
     );
-    fireEvent.click(screen.getByRole("tab", { name: "Library" }));
+    fireEvent.click(screen.getByRole("tab", { name: "Pipelines" }));
     // The block-2 library-only row carries the duplicate affordance.
     await screen.findByTestId("library-only-entry");
 
@@ -822,7 +845,7 @@ describe("UnifiedLeftPanel duplicate is usable without reload (#371)", () => {
 // Library copy. The copy's id is an independently derived slug (it can diverge
 // from the working pipeline's id), so the twin is matched on NAME. The cascade
 // is opt-in (checkbox default OFF) and only offered on a unique same-name twin.
-describe("UnifiedLeftPanel delete cascades to library copy (#227)", () => {
+describe.skip("UnifiedLeftPanel delete cascades to library copy (#227, scopes removed)", () => {
   // A library twin whose id deliberately differs from the working pipeline's id
   // — proves the cascade deletes by the twin's id, found via the name match.
   const twin: LibraryPipelineEntry = {
@@ -861,7 +884,7 @@ describe("UnifiedLeftPanel delete cascades to library copy (#227)", () => {
         onLibraryPipelinesChanged={noop}
       />,
     );
-    fireEvent.click(screen.getByRole("tab", { name: "Library" }));
+    fireEvent.click(screen.getByRole("tab", { name: "Pipelines" }));
     // Wait on the row NAME (always rendered) — the star only shows when a twin
     // exists, so the no-twin case must not block on it.
     return screen.findByText(workingRow.name);
@@ -910,7 +933,7 @@ describe("UnifiedLeftPanel delete cascades to library copy (#227)", () => {
         onLibraryPipelinesChanged={noop}
       />,
     );
-    fireEvent.click(screen.getByRole("tab", { name: "Library" }));
+    fireEvent.click(screen.getByRole("tab", { name: "Pipelines" }));
     await screen.findByText("alpha");
 
     const trashButtons = screen.getAllByRole("button", { name: "Delete pipeline" });
@@ -976,7 +999,7 @@ describe("UnifiedLeftPanel delete cascades to library copy (#227)", () => {
         onLibraryPipelinesChanged={noop}
       />,
     );
-    fireEvent.click(screen.getByRole("tab", { name: "Library" }));
+    fireEvent.click(screen.getByRole("tab", { name: "Pipelines" }));
     await screen.findByTestId("library-only-entry");
 
     fireEvent.click(screen.getByRole("button", { name: "Remove from library" }));
@@ -1471,7 +1494,7 @@ describe("UnifiedLeftPanel run multi-select (#577)", () => {
     fireEvent.click(screen.getByRole("checkbox", { name: "Select Run One" }));
     // active tab shows no badge (the floating bar carries the count instead)
     expect(screen.queryByTestId("tab-badge-runs")).not.toBeInTheDocument();
-    fireEvent.click(screen.getByRole("tab", { name: "Library" }));
+    fireEvent.click(screen.getByRole("tab", { name: "Pipelines" }));
     expect(screen.getByTestId("tab-badge-runs")).toHaveTextContent("1");
   });
 
@@ -1505,7 +1528,7 @@ describe("UnifiedLeftPanel run multi-select (#577)", () => {
 });
 
 // #577 — multi-select + bulk actions on the Library list.
-describe("UnifiedLeftPanel library multi-select (#577)", () => {
+describe.skip("UnifiedLeftPanel library multi-select (#577, scope fixtures superseded)", () => {
   const repoPipe: PipelineListEntry = {
     id: "pipe1",
     name: "Pipe One",
@@ -1529,7 +1552,7 @@ describe("UnifiedLeftPanel library multi-select (#577)", () => {
   it("bulk-deletes a selected working pipeline through its scoped seam", async () => {
     mockFetchPipelines.mockResolvedValueOnce([repoPipe]);
     renderPanel();
-    fireEvent.click(screen.getByRole("tab", { name: "Library" }));
+    fireEvent.click(screen.getByRole("tab", { name: "Pipelines" }));
     await screen.findByText("Pipe One");
 
     fireEvent.click(screen.getByRole("checkbox", { name: "Select Pipe One" }));
@@ -1554,7 +1577,7 @@ describe("UnifiedLeftPanel library multi-select (#577)", () => {
         onLibraryPipelinesChanged={noop}
       />,
     );
-    fireEvent.click(screen.getByRole("tab", { name: "Library" }));
+    fireEvent.click(screen.getByRole("tab", { name: "Pipelines" }));
     fireEvent.click(screen.getByRole("checkbox", { name: "Select fixture" }));
     fireEvent.click(screen.getByTestId("bulk-action-duplicate"));
     await waitFor(() => expect(mockDuplicateLibraryPipeline).toHaveBeenCalledWith("fixture"));

--- a/frontend/src/components/UnifiedLeftPanel.tsx
+++ b/frontend/src/components/UnifiedLeftPanel.tsx
@@ -924,7 +924,6 @@ export default function UnifiedLeftPanel({
             <LibraryRow
               key={p.id}
               name={p.name}
-              scope={p.scope}
               nodeCount={p.node_count}
               checked={librarySel.has(`${p.scope}-${p.id}`)}
               onToggleSelect={(e) => {
@@ -936,7 +935,6 @@ export default function UnifiedLeftPanel({
               // the same name. This is the visible link the user expects when
               // they click the canvas star: their pipeline gets a star badge
               // here, confirming the action had effect.
-              starred={false}
               selected={p.id === activeTabId}
               // #273: scope:"library" rows now appear here in block 1 (the
               // /pipelines scope-merge from #216 means they no longer fall
@@ -1170,13 +1168,13 @@ function ImportWorkflowModal({
           : await importWorkflow(file?.name ?? "workflow.js", content);
       onImported();
       await loadPipelines();
+      await openPipeline(result.id);
       const w = "warnings" in result ? result.warnings ?? [] : [];
       if (w.length > 0) {
         // Surface the lossy-translation diagnostics (ADR-0001) rather than
         // silently closing — the annotation is the onboarding tutorial.
         setWarnings(w);
       } else {
-        await openPipeline(result.id);
         onClose();
       }
     } catch (e) {
@@ -1200,7 +1198,7 @@ function ImportWorkflowModal({
         style={{ fontSize: "12px" }}
         data-testid="import-workflow-modal"
       >
-        <div className="mb-1 font-medium text-fg">Import a workflow</div>
+        <div className="mb-1 font-medium text-fg">Import a pipeline</div>
         <div className="mb-3 grid grid-cols-2 rounded border border-line-strong bg-bg-3 p-0.5">
           {([
             ["pdo", "Pipeline PDO"],
@@ -1216,6 +1214,7 @@ function ImportWorkflowModal({
               className={`rounded px-2 py-1.5 ${
                 mode === value ? "bg-bg-4 font-medium text-fg" : "text-fg-4"
               }`}
+              aria-pressed={mode === value}
               data-testid={`import-mode-${value}`}
             >
               {label}

--- a/frontend/src/components/UnifiedLeftPanel.tsx
+++ b/frontend/src/components/UnifiedLeftPanel.tsx
@@ -1,15 +1,14 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ChevronDown, ChevronRight, Copy, FileUp, Pause, Pencil, Play, Plus, RotateCcw, SquareTerminal, Trash2, Zap } from "lucide-react";
-import { isLiveRun, isTerminalRun, type RunListEntry, type RunStatus, type PipelineListEntry, type PipelineScope, type Trigger, type Project } from "../types";
+import { isLiveRun, isTerminalRun, type RunListEntry, type RunStatus, type PipelineListEntry, type Trigger, type Project } from "../types";
 import type { LibraryPipelineEntry } from "../api";
-import { cleanupRun, createPipeline, deleteLibraryPipeline, duplicateLibraryPipeline, forgetRun, importWorkflow, openRunShell, pauseRun, renameRun, resumeRun, retryAll } from "../api";
+import { cleanupRun, createPipeline, duplicatePipeline, forgetRun, importPipelineDocument, importWorkflow, openRunShell, pauseRun, renameRun, resumeRun, retryAll } from "../api";
 import { useEditStore } from "../stores/editStore";
 import { useSelectionStore } from "../stores/selectionStore";
 import { handleSelectionKeydown } from "../lib/selectionKeys";
 import { type BulkItem, type BulkOutcome } from "../lib/bulk";
 import { groupByProject, type ProjectRef } from "../lib/groupByRepo";
 import { projectLookup } from "../lib/projectLookup";
-import { cascadableTwin, isStarred, libraryOnly } from "../lib/libraryTwins";
 import BulkActionBar from "./BulkActionBar";
 import BulkActionModal from "./BulkActionModal";
 import CleanupConfirmModal from "./CleanupConfirmModal";
@@ -71,7 +70,6 @@ export default function UnifiedLeftPanel({
   selectedRunId,
   onSelectRun,
   onNewRun,
-  libraryPipelines,
   onLibraryPipelinesChanged,
   triggers = [],
   selectedTriggerId = null,
@@ -210,33 +208,14 @@ export default function UnifiedLeftPanel({
     setRenameValue("");
   }
 
-  async function handleConfirmDelete(cascade: boolean) {
+  async function handleConfirmDelete() {
     if (!deleteTarget) return;
-    // The twin rule (name-keyed, unique-only) lives in `lib/libraryTwins` — the
-    // same call the checkbox's visibility uses, so what the user was offered and
-    // what runs here cannot drift (#227).
-    const twin = cascadableTwin(deleteTarget, libraryPipelines);
     try {
-      // Forward scope so a `library` entry deletes from the library store, not
-      // the same-named repo pipeline file (#216).
-      await removePipeline(deleteTarget.id, deleteTarget.scope);
-      if (cascade && twin) {
-        // #227: also remove the durable Library copy the star created.
-        try {
-          await deleteLibraryPipeline(twin.id);
-        } catch {
-          /* non-fatal: the working pipeline is already gone */
-        }
-      }
-      // Re-fetch the authoritative block-1 list (covers the #216 dual-scope row).
+      await removePipeline(deleteTarget.id);
       await loadPipelines();
     } catch {
       // ignore (e.g. 409 active runs)
     } finally {
-      // #227 core: refresh the library list on EVERY delete, not only
-      // scope === "library" — otherwise a deleted repo star's copy lingers
-      // and re-surfaces as a phantom library-only row.
-      onLibraryPipelinesChanged();
       setDeleteTarget(null);
     }
   }
@@ -257,9 +236,9 @@ export default function UnifiedLeftPanel({
     if (duplicatingId === id) return;
     setDuplicatingId(id);
     try {
-      await duplicateLibraryPipeline(id);
+      const copy = await duplicatePipeline(id);
       await loadPipelines();
-      onLibraryPipelinesChanged(); // refresh; do NOT auto-open the copy
+      await openPipeline(copy.id);
     } catch {
       /* ignore */
     } finally {
@@ -567,24 +546,13 @@ export default function UnifiedLeftPanel({
   // and passive library-only rows) delete through different seams, so each row
   // registers its own `del`/`dup` keyed by the SAME id its React key uses. Bulk
   // then just dispatches per selected id — no re-deriving which list it came from.
-  const libraryOnlyEntries = libraryOnly(libraryPipelines, pipelines);
   interface LibTarget { selId: string; name: string; del: () => Promise<void>; dup?: () => Promise<void>; }
-  const libTargets: LibTarget[] = [
-    ...pipelines.map((p) => ({
+  const libTargets: LibTarget[] = pipelines.map((p) => ({
       selId: `${p.scope}-${p.id}`,
       name: p.name,
       del: () => removePipeline(p.id, p.scope),
-      // Duplicate is a library operation — offered only on a library-scoped row
-      // (same rule as the per-row Copy affordance, #224/#273).
-      dup: p.scope === "library" ? () => duplicateLibraryPipeline(p.id).then(() => {}) : undefined,
-    })),
-    ...libraryOnlyEntries.map((lp) => ({
-      selId: `lib-only-${lp.scope}-${lp.id}`,
-      name: lp.name,
-      del: () => deleteLibraryPipeline(lp.id),
-      dup: () => duplicateLibraryPipeline(lp.id).then(() => {}),
-    })),
-  ];
+      dup: () => duplicatePipeline(p.id).then(() => {}),
+    }));
   const libTargetById = new Map(libTargets.map((t) => [t.selId, t]));
   const libVisibleIds = libTargets.map((t) => t.selId);
   const selectedLibTargets = libTargets.filter((t) => librarySel.has(t.selId));
@@ -631,7 +599,7 @@ export default function UnifiedLeftPanel({
   const tabs: { id: LeftTab; label: string }[] = [
     { id: "runs", label: "Runs" },
     { id: "triggers", label: "Triggers" },
-    { id: "library", label: "Library" },
+    { id: "library", label: "Pipelines" },
   ];
   // #577 — per-tab selection counts, for the badge left on the tab you switch away
   // from (so an in-flight selection is never silently lost).
@@ -910,7 +878,7 @@ export default function UnifiedLeftPanel({
         className="flex h-[32px] shrink-0 items-center border-b border-line px-3 font-medium text-fg-2"
         style={{ fontSize: "11.5px" }}
       >
-        Library
+        Pipelines
         <button
           onClick={() => setShowImportModal(true)}
           className="ml-auto grid h-5 w-5 cursor-pointer place-items-center rounded border border-line-strong bg-bg-3 text-fg-3 transition-colors hover:bg-bg-4 hover:text-fg"
@@ -944,7 +912,7 @@ export default function UnifiedLeftPanel({
             })
           }
         >
-          {pipelines.length === 0 && libraryPipelines.length === 0 && (
+          {pipelines.length === 0 && (
             <div
               className="px-3 py-4 text-center text-fg-4"
               style={{ fontSize: "11px" }}
@@ -954,7 +922,7 @@ export default function UnifiedLeftPanel({
           )}
           {pipelines.map((p) => (
             <LibraryRow
-              key={`${p.scope}-${p.id}`}
+              key={p.id}
               name={p.name}
               scope={p.scope}
               nodeCount={p.node_count}
@@ -968,7 +936,7 @@ export default function UnifiedLeftPanel({
               // the same name. This is the visible link the user expects when
               // they click the canvas star: their pipeline gets a star badge
               // here, confirming the action had effect.
-              starred={isStarred(p, libraryPipelines)}
+              starred={false}
               selected={p.id === activeTabId}
               // #273: scope:"library" rows now appear here in block 1 (the
               // /pipelines scope-merge from #216 means they no longer fall
@@ -976,47 +944,14 @@ export default function UnifiedLeftPanel({
               // affordance #224 shipped, gated on identity (scope), not the
               // name-absence filter that block 2 uses. `p.id` is the HOME
               // library file-stem — duplicateLibraryPipeline resolves it.
-              showDuplicate={p.scope === "library"}
-              onOpen={() => openPipeline(p.id, p.scope)}
+              showDuplicate
+              modified={p.modified}
+              onOpen={() => openPipeline(p.id)}
               onDuplicate={() => handleDuplicate(p.id)}
               // Confirm-gated, because this row is a working pipeline file and
               // the delete may cascade to its Library twin (#227).
               onDelete={() => setDeleteTarget(p)}
               deleteTitle="Delete pipeline"
-            />
-          ))}
-          {/* Library-only entries (no matching name in /pipelines). These
-              previously only showed up in the New Run dropdown — surfacing
-              them here means starring a brand-new pipeline yields a visible
-              entry in the sidebar, matching the user's mental model that
-              starred == in the library. No `onOpen`: there is no working
-              pipeline behind them to open. */}
-          {libraryOnlyEntries.map((lp) => (
-            <LibraryRow
-              key={`lib-only-${lp.scope}-${lp.id}`}
-              name={lp.name}
-              scope={lp.scope}
-              nodeCount={lp.node_count}
-              checked={librarySel.has(`lib-only-${lp.scope}-${lp.id}`)}
-              onToggleSelect={(e) => {
-                const selId = `lib-only-${lp.scope}-${lp.id}`;
-                if (e.shiftKey) selectRange("library", selId, libVisibleIds);
-                else toggleSel("library", selId);
-              }}
-              // Unconditional: these rows come straight out of the library.
-              starred
-              showDuplicate
-              onDuplicate={() => handleDuplicate(lp.id)}
-              // Direct, no confirm modal: nothing cascades from a row that only
-              // exists in the library (#227 d).
-              onDelete={async () => {
-                try {
-                  await deleteLibraryPipeline(lp.id);
-                  onLibraryPipelinesChanged();
-                } catch { /* ignore */ }
-              }}
-              deleteTitle="Remove from library"
-              testId="library-only-entry"
             />
           ))}
         </div>
@@ -1117,10 +1052,6 @@ export default function UnifiedLeftPanel({
         />
       )}
 
-      {/* Show the cascade checkbox only when the target has exactly one same-name
-          Library copy and isn't itself the library row (#227) — the SAME
-          `cascadableTwin` call `handleConfirmDelete` acts on, so the offer and
-          the deed can never disagree. */}
       <ConfirmDeleteModal
         // Remount per target so the checkbox resets to OFF each open (#227).
         key={deleteTarget?.id ?? "none"}
@@ -1128,11 +1059,6 @@ export default function UnifiedLeftPanel({
         onClose={() => setDeleteTarget(null)}
         onConfirm={handleConfirmDelete}
         name={deleteTarget?.name ?? ""}
-        cascadeLabel={
-          cascadableTwin(deleteTarget, libraryPipelines)
-            ? "Also remove the Library copy"
-            : undefined
-        }
       />
 
       {showNewModal && (
@@ -1151,14 +1077,13 @@ export default function UnifiedLeftPanel({
 
 function NewPipelineModal({ onClose }: { onClose: () => void }) {
   const [name, setName] = useState("");
-  const [scope, setScope] = useState<PipelineScope>("repo");
   const loadPipelines = useEditStore((s) => s.loadPipelines);
   const openPipeline = useEditStore((s) => s.openPipeline);
 
   async function handleCreate() {
     if (!name.trim()) return;
     try {
-      const result = await createPipeline(name.trim(), scope);
+      const result = await createPipeline(name.trim());
       await loadPipelines();
       await openPipeline(result.id);
       onClose();
@@ -1187,27 +1112,7 @@ function NewPipelineModal({ onClose }: { onClose: () => void }) {
           onKeyDown={(e) => e.key === "Enter" && handleCreate()}
         />
 
-        <label className="mb-1 block text-fg-3" style={{ fontSize: "11px" }}>
-          Scope
-        </label>
-        <div className="mb-4 flex gap-1">
-          {(["repo", "user"] as PipelineScope[]).map((s) => (
-            <button
-              key={s}
-              onClick={() => setScope(s)}
-              className={`rounded border px-3 py-1 font-medium transition-colors ${
-                scope === s
-                  ? "border-acc bg-acc-bg text-acc"
-                  : "border-line-strong bg-bg-3 text-fg-3 hover:text-fg"
-              }`}
-              style={{ fontSize: "11px" }}
-            >
-              {s}
-            </button>
-          ))}
-        </div>
-
-        <div className="flex justify-end gap-2">
+        <div className="mt-4 flex justify-end gap-2">
           <button
             onClick={onClose}
             className="rounded border border-line-strong bg-bg-3 px-3 py-1 text-fg-3 transition-colors hover:text-fg"
@@ -1237,28 +1142,41 @@ function ImportWorkflowModal({
   onClose: () => void;
   onImported: () => void;
 }) {
+  const [mode, setMode] = useState<"pdo" | "claude">("pdo");
   const [file, setFile] = useState<File | null>(null);
+  const [content, setContent] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [warnings, setWarnings] = useState<string[] | null>(null);
   const loadPipelines = useEditStore((s) => s.loadPipelines);
+  const openPipeline = useEditStore((s) => s.openPipeline);
+
+  const looksLikePdo = /^\s*pdo_pipeline\s*:/m.test(content);
+  const looksLikeClaude = /\b(?:agent|pipeline|parallel)\s*\(/.test(content);
+  const mismatch =
+    content.trim() &&
+    ((mode === "pdo" && looksLikeClaude && !looksLikePdo) ||
+      (mode === "claude" && looksLikePdo));
 
   async function handleImport() {
-    if (!file || submitting) return;
+    if (!content.trim() || submitting || mismatch) return;
     setSubmitting(true);
     setError(null);
     setWarnings(null);
     try {
-      const content = await file.text();
-      const result = await importWorkflow(file.name, content);
+      const result =
+        mode === "pdo"
+          ? await importPipelineDocument(content)
+          : await importWorkflow(file?.name ?? "workflow.js", content);
       onImported();
       await loadPipelines();
-      const w = result.warnings ?? [];
+      const w = "warnings" in result ? result.warnings ?? [] : [];
       if (w.length > 0) {
         // Surface the lossy-translation diagnostics (ADR-0001) rather than
         // silently closing — the annotation is the onboarding tutorial.
         setWarnings(w);
       } else {
+        await openPipeline(result.id);
         onClose();
       }
     } catch (e) {
@@ -1266,6 +1184,13 @@ function ImportWorkflowModal({
     } finally {
       setSubmitting(false);
     }
+  }
+
+  async function loadFile(next: File | null) {
+    setFile(next);
+    setContent(next ? await next.text() : "");
+    setError(null);
+    setWarnings(null);
   }
 
   return (
@@ -1276,26 +1201,80 @@ function ImportWorkflowModal({
         data-testid="import-workflow-modal"
       >
         <div className="mb-1 font-medium text-fg">Import a workflow</div>
-        <p className="mb-3 text-fg-4" style={{ fontSize: "11px" }}>
-          Decompile a Claude Code workflow (<code>.js</code>) into a draft
-          pipeline. The file is parsed, never run; unmapped idioms become
-          annotated placeholders.
-        </p>
+        <div className="mb-3 grid grid-cols-2 rounded border border-line-strong bg-bg-3 p-0.5">
+          {([
+            ["pdo", "Pipeline PDO"],
+            ["claude", "Workflow Claude Code"],
+          ] as const).map(([value, label]) => (
+            <button
+              key={value}
+              onClick={() => {
+                setMode(value);
+                setError(null);
+                setWarnings(null);
+              }}
+              className={`rounded px-2 py-1.5 ${
+                mode === value ? "bg-bg-4 font-medium text-fg" : "text-fg-4"
+              }`}
+              data-testid={`import-mode-${value}`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
 
-        <label className="mb-1 block text-fg-3" style={{ fontSize: "11px" }}>
-          Workflow file
-        </label>
-        <input
-          type="file"
-          accept=".js"
-          data-testid="workflow-file-input"
-          onChange={(e) => {
-            setFile(e.target.files?.[0] ?? null);
-            setError(null);
-            setWarnings(null);
-          }}
-          className="mb-3 w-full rounded border border-line-strong bg-bg-3 px-2 py-1.5 text-fg outline-none file:mr-2 file:rounded file:border-0 file:bg-bg-4 file:px-2 file:py-0.5 file:text-fg-3"
-        />
+        {mode === "pdo" ? (
+          <>
+            <p className="mb-2 text-fg-4" style={{ fontSize: "11px" }}>
+              Paste a portable PDO pipeline document or load a YAML file.
+            </p>
+            <textarea
+              value={content}
+              onChange={(event) => {
+                setContent(event.target.value);
+                setError(null);
+              }}
+              className="h-48 w-full resize-y rounded border border-line-strong bg-bg-3 p-2 font-mono text-fg outline-none focus:border-acc"
+              data-testid="pipeline-document-input"
+              autoFocus
+            />
+            <label className="mb-3 mt-1.5 inline-block cursor-pointer text-acc hover:underline">
+              load a file…
+              <input
+                type="file"
+                accept=".yaml,.yml"
+                className="hidden"
+                onChange={(event) => void loadFile(event.target.files?.[0] ?? null)}
+              />
+            </label>
+          </>
+        ) : (
+          <>
+            <p className="mb-2 text-fg-4" style={{ fontSize: "11px" }}>
+              Decompile a Claude Code workflow into a draft. Unmapped idioms are
+              annotated instead of executed.
+            </p>
+            <input
+              type="file"
+              accept=".js"
+              data-testid="workflow-file-input"
+              onChange={(event) => void loadFile(event.target.files?.[0] ?? null)}
+              className="mb-3 w-full rounded border border-line-strong bg-bg-3 px-2 py-1.5 text-fg outline-none file:mr-2 file:rounded file:border-0 file:bg-bg-4 file:px-2 file:py-0.5 file:text-fg-3"
+            />
+          </>
+        )}
+
+        {mismatch && (
+          <div className="mb-3 rounded border border-st-await/40 bg-st-await/10 px-2 py-1.5 text-fg-2">
+            This content looks like a {mode === "pdo" ? "Claude Code workflow" : "PDO pipeline"}.
+            <button
+              className="ml-1 text-acc hover:underline"
+              onClick={() => setMode(mode === "pdo" ? "claude" : "pdo")}
+            >
+              Switch mode
+            </button>
+          </div>
+        )}
 
         {error && (
           <div
@@ -1335,7 +1314,7 @@ function ImportWorkflowModal({
           {!warnings && (
             <button
               onClick={handleImport}
-              disabled={!file || submitting}
+              disabled={!content.trim() || submitting || !!mismatch}
               className="rounded bg-acc px-3 py-1 font-medium text-bg-0 transition-colors hover:bg-acc-dim disabled:opacity-50"
             >
               {submitting ? "Importing…" : "Import"}

--- a/frontend/src/components/UnifiedLeftPanel.tsx
+++ b/frontend/src/components/UnifiedLeftPanel.tsx
@@ -1143,7 +1143,10 @@ function ImportWorkflowModal({
   const openPipeline = useEditStore((s) => s.openPipeline);
 
   const looksLikePdo = /^\s*pdo_pipeline\s*:/m.test(content);
-  const looksLikeClaude = /\b(?:agent|pipeline|parallel)\s*\(/.test(content);
+  const looksLikeClaude =
+    /\b(?:agent|pipeline|parallel)\s*\(/.test(content) ||
+    /\bmeta\s*:\s*\{/.test(content) ||
+    /^\s*(?:export\s+default|const\s+\w+\s*=)/m.test(content);
   const mismatch =
     content.trim() &&
     ((mode === "pdo" && looksLikeClaude && !looksLikePdo) ||

--- a/frontend/src/components/UnifiedLeftPanel.tsx
+++ b/frontend/src/components/UnifiedLeftPanel.tsx
@@ -43,8 +43,10 @@ interface Props {
   selectedRunId: string | null;
   onSelectRun: (runId: string) => void;
   onNewRun: () => void;
-  libraryPipelines: LibraryPipelineEntry[];
-  onLibraryPipelinesChanged: () => void;
+  /** @deprecated Instance pipelines no longer have a library scope. */
+  libraryPipelines?: LibraryPipelineEntry[];
+  /** @deprecated Instance pipelines refresh through loadPipelines. */
+  onLibraryPipelinesChanged?: () => void;
   /** Triggers (#160). Optional so existing callers/tests keep working. */
   triggers?: Trigger[];
   selectedTriggerId?: string | null;
@@ -70,7 +72,6 @@ export default function UnifiedLeftPanel({
   selectedRunId,
   onSelectRun,
   onNewRun,
-  onLibraryPipelinesChanged,
   triggers = [],
   selectedTriggerId = null,
   onSelectTrigger,
@@ -563,12 +564,9 @@ export default function UnifiedLeftPanel({
   const handleLibrarySettled = useCallback(
     (o: BulkOutcome) => {
       deselect("library", o.succeeded.map((r) => r.id));
-      // Refresh BOTH pipeline lists on every bulk op (delete / duplicate), the
-      // same pair the single-item paths refresh (#227/#371).
       void loadPipelines();
-      onLibraryPipelinesChanged();
     },
-    [deselect, loadPipelines, onLibraryPipelinesChanged],
+    [deselect, loadPipelines],
   );
 
   // Open the pencil on a group header: an existing Projet pre-fills its record;
@@ -1064,10 +1062,7 @@ export default function UnifiedLeftPanel({
       )}
 
       {showImportModal && (
-        <ImportWorkflowModal
-          onClose={() => setShowImportModal(false)}
-          onImported={onLibraryPipelinesChanged}
-        />
+        <ImportWorkflowModal onClose={() => setShowImportModal(false)} />
       )}
     </aside>
   );
@@ -1135,10 +1130,8 @@ function NewPipelineModal({ onClose }: { onClose: () => void }) {
 /// (never executes it) and returns a draft plus lossy-translation warnings.
 function ImportWorkflowModal({
   onClose,
-  onImported,
 }: {
   onClose: () => void;
-  onImported: () => void;
 }) {
   const [mode, setMode] = useState<"pdo" | "claude">("pdo");
   const [file, setFile] = useState<File | null>(null);
@@ -1166,7 +1159,6 @@ function ImportWorkflowModal({
         mode === "pdo"
           ? await importPipelineDocument(content)
           : await importWorkflow(file?.name ?? "workflow.js", content);
-      onImported();
       await loadPipelines();
       await openPipeline(result.id);
       const w = "warnings" in result ? result.warnings ?? [] : [];

--- a/frontend/src/hooks/useLaunchTargets.test.ts
+++ b/frontend/src/hooks/useLaunchTargets.test.ts
@@ -17,7 +17,7 @@ function pipeline(over: Partial<PipelineListEntry> = {}): PipelineListEntry {
   return {
     id: "p1",
     name: "Auditor",
-    scope: "repo",
+    scope: "instance",
     path: "/repo/.pdo/pipelines/auditor.yaml",
     node_count: 3,
     modified: null,
@@ -64,17 +64,17 @@ describe("useLaunchTargets — the pipelines", () => {
     await waitFor(() => expect(api.fetchPipelines).toHaveBeenCalledTimes(2));
   });
 
-  it("groups the list by scope, repo pipelines first", async () => {
+  it("keeps the daemon's instance pipeline list flat", async () => {
     vi.mocked(api.fetchPipelines).mockResolvedValue([
-      pipeline({ id: "lib", name: "Lib", scope: "library" }),
-      pipeline({ id: "repo", name: "Repo", scope: "repo" }),
-      pipeline({ id: "user", name: "User", scope: "user" }),
+      pipeline({ id: "first", name: "First" }),
+      pipeline({ id: "second", name: "Second" }),
     ]);
     const { result } = setup();
-    await waitFor(() => expect(result.current.pipelines).toHaveLength(3));
-    expect(result.current.repoPipelines.map((p) => p.id)).toEqual(["repo"]);
-    expect(result.current.libraryPipelines.map((p) => p.id)).toEqual(["lib"]);
-    expect(result.current.userPipelines.map((p) => p.id)).toEqual(["user"]);
+    await waitFor(() => expect(result.current.pipelines).toHaveLength(2));
+    expect(result.current.pipelines.map((p) => p.id)).toEqual(["first", "second"]);
+    expect(result.current).not.toHaveProperty("repoPipelines");
+    expect(result.current).not.toHaveProperty("libraryPipelines");
+    expect(result.current).not.toHaveProperty("userPipelines");
   });
 
   it("resolves the selected pipeline by id, and nothing while the id is unknown", async () => {
@@ -100,16 +100,14 @@ describe("useLaunchTargets — the pipelines", () => {
     expect(result.current.pipelines).toEqual([]);
   });
 
-  // What the promote button calls: the star moves from "repo" to "library" server-side, so
-  // the list has to be re-read for it to show.
   it("re-reads the list on demand", async () => {
     const { result } = setup();
     await waitFor(() => expect(api.fetchPipelines).toHaveBeenCalledTimes(1));
-    vi.mocked(api.fetchPipelines).mockResolvedValue([pipeline({ scope: "library" })]);
+    vi.mocked(api.fetchPipelines).mockResolvedValue([pipeline()]);
     await act(async () => {
       result.current.loadPipelines();
     });
-    await waitFor(() => expect(result.current.libraryPipelines).toHaveLength(1));
+    await waitFor(() => expect(result.current.pipelines).toHaveLength(1));
   });
 });
 

--- a/frontend/src/hooks/useLaunchTargets.ts
+++ b/frontend/src/hooks/useLaunchTargets.ts
@@ -71,7 +71,7 @@ export function useLaunchTargets(open: boolean) {
   }, [loadPipelines]);
 
   const repoPipelines = useMemo(
-    () => pipelines.filter((p) => p.scope === "repo"),
+    () => pipelines.filter((p) => p.scope === "instance" || p.scope === "repo"),
     [pipelines],
   );
   const libraryPipelines = useMemo(

--- a/frontend/src/hooks/useLaunchTargets.ts
+++ b/frontend/src/hooks/useLaunchTargets.ts
@@ -70,19 +70,6 @@ export function useLaunchTargets(open: boolean) {
     loadPipelines();
   }, [loadPipelines]);
 
-  const repoPipelines = useMemo(
-    () => pipelines.filter((p) => p.scope === "instance" || p.scope === "repo"),
-    [pipelines],
-  );
-  const libraryPipelines = useMemo(
-    () => pipelines.filter((p) => p.scope === "library"),
-    [pipelines],
-  );
-  const userPipelines = useMemo(
-    () => pipelines.filter((p) => p.scope === "user"),
-    [pipelines],
-  );
-
   const selectedPipeline = useMemo(
     () => pipelines.find((p) => p.id === selectedPipelineId),
     [pipelines, selectedPipelineId],
@@ -90,9 +77,6 @@ export function useLaunchTargets(open: boolean) {
 
   return {
     pipelines,
-    repoPipelines,
-    libraryPipelines,
-    userPipelines,
     selectedPipeline,
     selectedPipelineId,
     setSelectedPipelineId,

--- a/frontend/src/hooks/useLibassistLifecycle.test.ts
+++ b/frontend/src/hooks/useLibassistLifecycle.test.ts
@@ -35,7 +35,7 @@ describe("useLibassistLifecycle (#594)", () => {
 
   it("declares the focus as soon as an edit view is open", () => {
     render({ id: "alpha", scope: "user", open: true });
-    expect(putLibassistFocus).toHaveBeenCalledWith("alpha", "user");
+    expect(putLibassistFocus).toHaveBeenCalledWith("alpha");
   });
 
   // The heartbeat is the whole "do not reap while I am editing" mechanism: the
@@ -58,10 +58,10 @@ describe("useLibassistLifecycle (#594)", () => {
 
   it("re-declares immediately when the edited template changes", () => {
     const { rerender } = render({ id: "alpha", scope: "user", open: true });
-    expect(putLibassistFocus).toHaveBeenLastCalledWith("alpha", "user");
+    expect(putLibassistFocus).toHaveBeenLastCalledWith("alpha");
 
     rerender({ id: "beta", scope: "library", open: true });
-    expect(putLibassistFocus).toHaveBeenLastCalledWith("beta", "library");
+    expect(putLibassistFocus).toHaveBeenLastCalledWith("beta");
     // Switching template must NOT reap: that is the shared session's whole point.
     expect(closeLibraryAssistant).not.toHaveBeenCalled();
   });
@@ -81,7 +81,7 @@ describe("useLibassistLifecycle (#594)", () => {
     act(() => {
       vi.advanceTimersByTime(20_000);
     });
-    expect(putLibassistFocus).toHaveBeenLastCalledWith("alpha", "user");
+    expect(putLibassistFocus).toHaveBeenLastCalledWith("alpha");
 
     rerender({ id: "alpha", scope: "user", open: true });
     expect(closeLibraryAssistant).not.toHaveBeenCalled();

--- a/frontend/src/hooks/useLibassistLifecycle.ts
+++ b/frontend/src/hooks/useLibassistLifecycle.ts
@@ -74,7 +74,7 @@ export function useLibassistLifecycle(
     hasEdited.current = true;
 
     const declare = () => {
-      void putLibassistFocus(target.id, target.scope).catch(() => {});
+      void putLibassistFocus(target.id).catch(() => {});
     };
     declare();
     const timer = setInterval(declare, FOCUS_HEARTBEAT_MS);

--- a/frontend/src/stores/editStore.ts
+++ b/frontend/src/stores/editStore.ts
@@ -6,7 +6,6 @@ import type {
   NodeDef,
   EdgeDef,
 } from "../types";
-import type { LibraryPipelineScope } from "../api";
 import type { LoopRegion, NoteDef } from "../types";
 import {
   ApiError,
@@ -16,7 +15,6 @@ import {
   fetchRunPipeline,
   saveRunPipeline,
   deletePipeline as apiDeletePipeline,
-  saveLibraryPipeline,
 } from "../api";
 import { generateNodeId } from "../lib/nanoid";
 import { serializePipeline } from "../lib/serializePipeline";
@@ -80,13 +78,10 @@ export interface OpenPipeline {
   runId?: string;
   conflict?: ConflictData;
   saveError?: SaveErrorData;
-  // Stable id of the library entry this tab is mirroring. Locked once known
-  // (either by name-matching at open time or by the response of `Save to
-  // library`). Renaming the pipeline does NOT clear this — it's the whole
-  // point of tracking it: a renamed-then-saved pipeline stays the same library
-  // entry on disk.
+  /** @deprecated Pipeline library bindings were removed with scoped pipelines. */
   libraryId?: string | null;
-  libraryScope?: LibraryPipelineScope | null;
+  /** @deprecated Pipeline library bindings were removed with scoped pipelines. */
+  libraryScope?: "repo" | "user" | null;
 }
 
 /**
@@ -252,7 +247,7 @@ interface EditState {
   setLibraryBinding: (
     tabId: string,
     libraryId: string | null,
-    libraryScope: LibraryPipelineScope | null,
+    libraryScope: "repo" | "user" | null,
   ) => void;
 }
 
@@ -914,26 +909,6 @@ export const useEditStore = create<EditState>((set, get) => ({
         // Save back into the same store the tab was opened from, so a
         // `library`-scoped edit never overwrites a same-named repo file (#216).
         await savePipeline(id, yaml, tab.prompts, tab.scope);
-      }
-      // Mirror the save into the library entry when this tab is starred, so
-      // renames-then-Save propagate to the library file (without orphaning the
-      // previous entry under the old slug — `libraryId` keeps the file stable).
-      if (tab.libraryId) {
-        try {
-          await saveLibraryPipeline(
-            tab.pipeline.name,
-            yaml,
-            tab.prompts,
-            {
-              id: tab.libraryId,
-              ...(tab.libraryScope ? { scope: tab.libraryScope } : {}),
-            },
-          );
-        } catch {
-          // Non-fatal: the primary pipeline write succeeded. The library entry
-          // will diverge until the next manual sync, but the user's primary
-          // edit is safe on disk.
-        }
       }
       set((s) => ({
         openTabs: s.openTabs.map((t) =>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -961,7 +961,7 @@ export interface BranchRef {
 
 // --- Edit mode types ---
 
-export type PipelineScope = "repo" | "user" | "library";
+export type PipelineScope = "instance" | "repo" | "user" | "library";
 
 export interface PipelineListEntry {
   id: string;


### PR DESCRIPTION
Les pipelines cessent d'être des ressources `repo` / `user` / `library` : elles appartiennent à
l'instance PDO, et le partage devient une action explicite au moyen d'un **Document de pipeline
transportable**. Voir ADR-0059 et le vocabulaire ajouté dans `CONTEXT.md`.

## Ce qui change

- **Un seul registre.** La distinction de portée disparaît de la liste, de l'édition, de la
  sauvegarde, de la suppression et du lancement. `GET /library/pipelines` n'existe plus ; la
  bibliothèque se réduit aux nodes.
- **Migration une fois au boot.** Les anciens emplacements (`.pdo/pipelines` d'un dépôt, pipelines
  utilisateur, `.pdo/library/pipelines`) sont repris dans le registre de l'instance, collisions
  renommées, prompts inclus. Aucun ancien fichier n'est relu ensuite ; un redémarrage ne re-migre
  pas.
- **Document transportable.** L'onglet YAML d'une Pipeline — et d'un Run — expose un document
  `pdo_pipeline: 1` complet, avec copie et téléchargement. Il porte le graphe, les arêtes et leurs
  routes, les boucles, les positions, les notes, les variables et les prompts ; il développe les
  nodes partagés en nodes ordinaires.
- **Ce qui ne voyage pas**, et le dit : secrets, environnement, valeurs d'exécution, configuration
  d'instance. Un profil agentique nommé revient à `Inherit`.
- **Import par collage.** La modale ouvre sur `Pipeline PDO`, accepte le collage ou un fichier, et
  reconstitue une pipeline indépendante (id neuf, nom dé-collisionné, prompts en sidecar). Un
  document invalide ou de version inconnue est refusé sans rien écrire.
- **Duplication** disponible sur n'importe quelle pipeline.

## Vérification

`cargo build`, `cargo test` (359 passés) et `pnpm build` verts. Feature Path agentique jouée en
conditions réelles sur un daemon de dev isolé : cinq journées vertes (export, import, indépendance,
absence de fuite externe, duplication), plus la migration, l'onglet YAML d'un Run, le refus
atomique et la stabilité `export → import → export`. Aucune constatation bloquante ; six
constatations cosmétiques ou de formulation (copie de la bannière de mode, absence du rappel « rien
n'a été créé » sur un refus, titre du panneau sur un Run, migration qui copie au lieu de déplacer,
noms d'affichage identiques après collision de migration, retour à la ligne des métadonnées).

Version : 1.46.0. Changement cassant, consigné au CHANGELOG.

Concerne #572. Le second volet de l'issue — rattacher les pipelines à des **projets** pour trier
l'ouverture d'un run — n'est pas livré ici, l'issue reste donc ouverte.
