### PR TITLE
fix(pipelines): un document exporté par PDO est importable par PDO

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -899,7 +899,9 @@ Le **registre de pipelines** est l'ensemble des Pipelines possédées par une in
 Un **Document de pipeline transportable** est la représentation YAML versionnée et interprétable qui permet de copier une Pipeline entre instances. Il conserve au maximum le graphe, les boucles, le routage, la présentation, les notes, les prompts, les déclarations et valeurs par défaut de variables, et développe les nodes partagés en nodes ordinaires.
 
 Il ne transporte ni secrets, ni environnement, ni valeurs d'exécution, ni configuration d'instance. Un choix agentique lié à un profil d'instance redevient **Inherit** ; l'identité de la Pipeline est recréée à l'import. L'import est atomique, et un document invalide ou d'une version non prise en charge est refusé avec diagnostics.
-_Éviter_ : « YAML canonique » — le format interne peut séparer des contenus que le document rassemble ; le contrat est la fidélité maximale du round-trip, pas l'identité avec le stockage interne.
+
+**Un document produit par PDO est importable par PDO** : l'export ne peut pas émettre ce que l'import refuse, sinon la panne tombe sur la machine de destination — celle qui ne peut rien corriger. Les prompts vivent en fichiers annexes nommés par identifiant de node, et un node supprimé y laissait le sien : la clé morte rendait la Pipeline non transportable. L'invariant *clés ⊆ nodes* se tient donc partout où les prompts franchissent une frontière — sauvegarde, export, écriture au registre — et, à l'import, un prompt sans node est un **reliquat** qu'on écarte avec un avertissement, jamais un motif de refus. Reste fatale la seule clé qui ne peut pas être un nom de fichier : elle désigne un chemin, pas un node.
+_Éviter_ : « YAML canonique » — le format interne peut séparer des contenus que le document rassemble ; le contrat est la fidélité maximale du round-trip, pas l'identité avec le stockage interne. « Document corrompu » pour un reliquat de prompt — un reliquat se jette, une corruption se refuse.
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "1.46.0"
+version = "1.46.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "1.46.0"
+version = "1.46.1"
 license = "MIT"
 description = "Prompt-Driven Orchestrator — a local daemon that runs and supervises agentic coding pipelines"
 repository = "https://github.com/Loulen/prompt-driven-orchestrator"

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -5967,15 +5967,18 @@ async fn save_pipeline(
         return (StatusCode::NOT_FOUND, "pipeline not found").into_response();
     }
 
-    if let Err(e) = pipeline::parse_pipeline(&req.yaml) {
-        let (message, line) = parse_error_to_structured(&e);
-        let mut body =
-            serde_json::json!({ "error": format!("invalid YAML: {e}"), "message": message });
-        if let Some(l) = line {
-            body["line"] = serde_json::json!(l);
+    let saved = match pipeline::parse_pipeline(&req.yaml) {
+        Ok(parsed) => parsed.pipeline,
+        Err(e) => {
+            let (message, line) = parse_error_to_structured(&e);
+            let mut body =
+                serde_json::json!({ "error": format!("invalid YAML: {e}"), "message": message });
+            if let Some(l) = line {
+                body["line"] = serde_json::json!(l);
+            }
+            return (StatusCode::BAD_REQUEST, Json(body)).into_response();
         }
-        return (StatusCode::BAD_REQUEST, Json(body)).into_response();
-    }
+    };
 
     mark_self_write(&state.recent_writes, &path);
     if let Err(e) = std::fs::write(&path, &req.yaml) {
@@ -5997,6 +6000,7 @@ async fn save_pipeline(
             warn!("failed to write prompt for {node_id}: {e}");
         }
     }
+    prune_orphan_prompts(&state, &path, &saved);
 
     info!("Pipeline {pipeline_id} saved");
     (StatusCode::OK, Json(serde_json::json!({ "ok": true }))).into_response()
@@ -6068,6 +6072,26 @@ async fn create_pipeline(
 
 fn read_pipeline_prompts(path: &Path) -> HashMap<String, String> {
     read_prompts_from_dir(&path.with_extension("prompts"))
+}
+
+/// Delete the sidecar prompts of nodes the pipeline no longer defines.
+///
+/// A save carries the prompts of the nodes the editor still knows about and says
+/// nothing about the ones it dropped, so without this the `.md` of a deleted
+/// node survives forever: invisible in the UI, and enough to make the pipeline's
+/// portable document un-importable. The saved YAML is the authority — not the
+/// keys of the request, which are only the subset the client chose to send.
+fn prune_orphan_prompts(state: &AppState, path: &Path, saved: &pipeline::PipelineDef) {
+    let on_disk = read_pipeline_prompts(path);
+    let (_, orphans) = pipeline::split_live_prompts(saved, &on_disk);
+    for node_id in orphans {
+        let prompt_path = pipeline::canonical_prompt_path(path, &node_id);
+        mark_self_write(&state.recent_writes, &prompt_path);
+        match std::fs::remove_file(&prompt_path) {
+            Ok(()) => info!("Removed prompt of deleted node {node_id}"),
+            Err(e) => warn!("failed to remove prompt for deleted node {node_id}: {e}"),
+        }
+    }
 }
 
 fn read_prompts_from_dir(prompts_dir: &Path) -> HashMap<String, String> {
@@ -6159,12 +6183,15 @@ fn write_pipeline_atomically(
 
     let yaml = serde_yaml::to_string(pipeline).map_err(|e| format!("serialize pipeline: {e}"))?;
     pipeline::parse_pipeline(&yaml).map_err(|e| format!("pipeline: {e}"))?;
+    // Never seed a fresh registry entry with a leftover: duplicate copies
+    // the source sidecar dir wholesale, orphans included.
+    let (prompts, _) = pipeline::split_live_prompts(pipeline, prompts);
     let result = (|| {
         std::fs::write(&temp_path, yaml).map_err(|e| format!("write pipeline: {e}"))?;
 
         if !prompts.is_empty() {
             std::fs::create_dir(&temp_prompts).map_err(|e| format!("stage prompts: {e}"))?;
-            for (node_id, content) in prompts {
+            for (node_id, content) in &prompts {
                 std::fs::write(temp_prompts.join(format!("{node_id}.md")), content)
                     .map_err(|e| format!("write prompts.{node_id}: {e}"))?;
             }
@@ -6336,6 +6363,7 @@ async fn import_pipeline_document(
                 "id": id,
                 "scope": "instance",
                 "path": path.to_string_lossy(),
+                "warnings": interpreted.warnings,
             })),
         )
             .into_response(),

--- a/crates/pdo-daemon/src/pipeline.rs
+++ b/crates/pdo-daemon/src/pipeline.rs
@@ -1036,6 +1036,36 @@ pub(crate) fn resolve_switch_upstream_schema(
     source_port.frontmatter.clone()
 }
 
+/// Split a prompt map into the entries whose key is a live node and the ids of
+/// those that are not.
+///
+/// The sidecar prompt dir is keyed by node id and outlives the nodes it was
+/// written for: delete a node and its `.md` stays on disk. Every consumer that
+/// validates a pipeline against its prompts — the portable-document importer
+/// above all — requires *keys ⊆ nodes*, so apply this wherever prompts cross a
+/// boundary and that invariant holds by construction rather than by luck.
+pub(crate) fn split_live_prompts(
+    pipeline: &PipelineDef,
+    prompts: &HashMap<String, String>,
+) -> (HashMap<String, String>, Vec<String>) {
+    let live = pipeline
+        .nodes
+        .iter()
+        .map(|node| node.id.as_str())
+        .collect::<HashSet<_>>();
+    let mut kept = HashMap::with_capacity(prompts.len());
+    let mut orphans = Vec::new();
+    for (node_id, content) in prompts {
+        if live.contains(node_id.as_str()) {
+            kept.insert(node_id.clone(), content.clone());
+        } else {
+            orphans.push(node_id.clone());
+        }
+    }
+    orphans.sort();
+    (kept, orphans)
+}
+
 pub(crate) fn canonical_prompt_path(pipeline_path: &Path, node_id: &str) -> std::path::PathBuf {
     let dir = pipeline_path.parent().unwrap_or(std::path::Path::new("."));
     let stem = pipeline_path

--- a/crates/pdo-daemon/src/portable_pipeline.rs
+++ b/crates/pdo-daemon/src/portable_pipeline.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, HashMap};
 
 use serde::{Deserialize, Serialize};
+use tracing::info;
 
 use crate::agent_choice::AgentChoice;
 use crate::pipeline::{self, PipelineDef};
@@ -20,6 +21,9 @@ struct PortablePipelineDocument {
 pub(crate) struct InterpretedDocument {
     pub pipeline: PipelineDef,
     pub prompts: HashMap<String, String>,
+    /// Non-fatal diagnostics — today, prompts dropped because they name a node
+    /// the document does not define.
+    pub warnings: Vec<String>,
 }
 
 fn make_portable(mut pipeline: PipelineDef) -> PipelineDef {
@@ -68,13 +72,22 @@ pub(crate) fn export(
     let canonical = pipeline::parse_pipeline(&yaml)
         .map_err(|e| format!("failed to validate portable pipeline: {e}"))?
         .pipeline;
+    // The exporter's contract has to be the importer's: the prompts come
+    // straight off a sidecar dir that can hold leftovers of deleted nodes, and
+    // emitting one produced a document PDO itself refuses to import.
+    let (live_prompts, orphans) = pipeline::split_live_prompts(&canonical, prompts);
+    if !orphans.is_empty() {
+        info!(
+            "portable export of '{}': dropped {} prompt(s) with no node: {}",
+            canonical.name,
+            orphans.len(),
+            orphans.join(", ")
+        );
+    }
     serde_yaml::to_string(&PortablePipelineDocument {
         pdo_pipeline: VERSION,
         pipeline: ordered_pipeline_value(canonical)?,
-        prompts: prompts
-            .iter()
-            .map(|(id, prompt)| (id.clone(), prompt.clone()))
-            .collect(),
+        prompts: live_prompts.into_iter().collect(),
     })
     .map_err(|e| format!("failed to serialize portable pipeline document: {e}"))
 }
@@ -132,12 +145,8 @@ pub(crate) fn interpret(source: &str) -> Result<InterpretedDocument, String> {
         return Err(format!("pipeline.edges: {}", dangling.join("; ")));
     }
 
-    let known_nodes = parsed
-        .pipeline
-        .nodes
-        .iter()
-        .map(|node| node.id.as_str())
-        .collect::<std::collections::HashSet<_>>();
+    // A key that cannot be a filename stays fatal: it is an attempt to write
+    // outside the sidecar dir, not a leftover.
     if let Some(unsafe_id) = document.prompts.keys().find(|node_id| {
         node_id.is_empty()
             || *node_id == "."
@@ -149,17 +158,21 @@ pub(crate) fn interpret(source: &str) -> Result<InterpretedDocument, String> {
             "prompts.{unsafe_id}: node id cannot be used as a prompt filename"
         ));
     }
-    if let Some(orphan) = document
-        .prompts
-        .keys()
-        .find(|node_id| !known_nodes.contains(node_id.as_str()))
-    {
-        return Err(format!("prompts.{orphan}: node does not exist"));
-    }
+
+    // A prompt naming no node, on the other hand, is a droppable leftover
+    // Rejecting the whole document over one made pipelines exported by
+    // older versions un-importable, on the machine least able to fix them.
+    let all_prompts = document.prompts.into_iter().collect::<HashMap<_, _>>();
+    let (prompts, orphans) = pipeline::split_live_prompts(&parsed.pipeline, &all_prompts);
+    let warnings = orphans
+        .iter()
+        .map(|node_id| format!("prompts.{node_id}: no such node in the document — prompt ignored"))
+        .collect();
 
     Ok(InterpretedDocument {
         pipeline: parsed.pipeline,
-        prompts: document.prompts.into_iter().collect(),
+        prompts,
+        warnings,
     })
 }
 
@@ -334,5 +347,45 @@ mod tests {
 
         assert!(error.contains("pipeline.edges"), "{error}");
         assert!(error.contains("non-existent node 'ghost'"), "{error}");
+    }
+
+    /// The export is the last place the "keys ⊆ nodes" invariant can be
+    /// restored before the document leaves the machine that can still fix it.
+    #[test]
+    fn export_drops_prompts_of_nodes_that_no_longer_exist() {
+        let mut prompts = HashMap::new();
+        prompts.insert("worker".into(), "Review carefully.".into());
+        prompts.insert("FBKE6BhH".into(), "Prompt of a deleted node.".into());
+
+        let document = super::export(&pipeline(), &prompts).unwrap();
+
+        assert!(!document.contains("FBKE6BhH"), "{document}");
+        assert!(document.contains("Review carefully."), "{document}");
+        let imported = super::interpret(&document).unwrap();
+        assert_eq!(imported.prompts.len(), 1);
+        assert!(imported.warnings.is_empty());
+    }
+
+    /// A document produced by an older PDO still carries the orphan. It
+    /// is a leftover, not a corruption: import it and say what was dropped.
+    #[test]
+    fn orphan_prompt_is_dropped_with_a_warning_instead_of_rejecting_the_document() {
+        let source = super::export(&pipeline(), &HashMap::new())
+            .unwrap()
+            .replace(
+                "prompts: {}",
+                "prompts:\n  FBKE6BhH: Prompt of a deleted node.",
+            );
+
+        let imported = super::interpret(&source).unwrap();
+
+        assert!(imported.prompts.is_empty());
+        assert_eq!(imported.warnings.len(), 1);
+        assert!(
+            imported.warnings[0].contains("prompts.FBKE6BhH"),
+            "{:?}",
+            imported.warnings
+        );
+        assert_eq!(imported.pipeline.nodes.len(), 3);
     }
 }

--- a/crates/pdo-daemon/tests/it.rs
+++ b/crates/pdo-daemon/tests/it.rs
@@ -98,6 +98,9 @@ mod node_prompt;
 #[path = "notes_round_trip.rs"]
 mod notes_round_trip;
 
+#[path = "pipeline_prompt_orphans.rs"]
+mod pipeline_prompt_orphans;
+
 #[path = "process_lifecycle.rs"]
 mod process_lifecycle;
 

--- a/crates/pdo-daemon/tests/pipeline_prompt_orphans.rs
+++ b/crates/pdo-daemon/tests/pipeline_prompt_orphans.rs
@@ -1,0 +1,300 @@
+//! Layer 3a — the sidecar prompt dir must never make a pipeline un-portable.
+//!
+//! Prompts live one file per node in `<stem>.prompts/<node-id>.md`, and the
+//! portable document carries them as a map keyed by node id. Deleting a node
+//! used to leave its `.md` behind: the export then emitted a key naming no
+//! node, and PDO's own importer rejected the whole document — on the *other*
+//! machine, the one that cannot fix the source.
+//!
+//! The unit tests in `portable_pipeline` build the prompt map in memory, so it
+//! can never hold an orphan. These go through the real filesystem sidecar and
+//! the real HTTP handlers, which is exactly where the bug lived.
+
+use crate::common::TestDaemon;
+
+const TWO_NODE_YAML: &str = r#"name: portable-prompts
+version: "1.0"
+nodes:
+  - id: start
+    name: Start
+    type: start
+    outputs:
+      - name: user_prompt
+  - id: worker
+    name: Worker
+    type: doc-only
+    inputs:
+      - name: in
+    outputs:
+      - name: out
+  - id: end
+    name: End
+    type: end
+    inputs:
+      - name: result
+edges:
+  - source: { node: start, port: user_prompt }
+    target: { node: worker, port: in }
+  - source: { node: worker, port: out }
+    target: { node: end, port: result }
+"#;
+
+/// The same pipeline with `worker` removed — what the editor sends after a
+/// right-click → Delete → Save.
+const ONE_NODE_YAML: &str = r#"name: portable-prompts
+version: "1.0"
+nodes:
+  - id: start
+    name: Start
+    type: start
+    outputs:
+      - name: user_prompt
+  - id: end
+    name: End
+    type: end
+    inputs:
+      - name: result
+edges:
+  - source: { node: start, port: user_prompt }
+    target: { node: end, port: result }
+"#;
+
+fn seed(repo: &std::path::Path) -> anyhow::Result<()> {
+    let dir = repo.join(".pdo").join("pipelines");
+    std::fs::create_dir_all(dir.join("portable-prompts.prompts"))?;
+    std::fs::write(dir.join("portable-prompts.yaml"), TWO_NODE_YAML)?;
+    std::fs::write(
+        dir.join("portable-prompts.prompts").join("worker.md"),
+        "Review carefully.",
+    )?;
+    Ok(())
+}
+
+/// The source of the poison: a save that drops a node must drop its prompt too.
+#[tokio::test]
+async fn saving_without_a_node_removes_its_prompt_file() {
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+    let prompts_dir = daemon
+        .repo_root()
+        .join(".pdo")
+        .join("pipelines")
+        .join("portable-prompts.prompts");
+    assert!(prompts_dir.join("worker.md").exists());
+
+    let resp = reqwest::Client::new()
+        .put(format!("{}/pipelines/portable-prompts", daemon.url()))
+        .json(&serde_json::json!({ "yaml": ONE_NODE_YAML, "prompts": {} }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    assert!(
+        !prompts_dir.join("worker.md").exists(),
+        "the prompt of the deleted node survived the save"
+    );
+}
+
+/// A save that keeps a node must keep its prompt, even when the client sends no
+/// prompt map at all — pruning is driven by the saved YAML, not by the request.
+#[tokio::test]
+async fn saving_without_sending_prompts_keeps_the_prompts_of_live_nodes() {
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+    let prompts_dir = daemon
+        .repo_root()
+        .join(".pdo")
+        .join("pipelines")
+        .join("portable-prompts.prompts");
+
+    let resp = reqwest::Client::new()
+        .put(format!("{}/pipelines/portable-prompts", daemon.url()))
+        .json(&serde_json::json!({ "yaml": TWO_NODE_YAML }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    assert_eq!(
+        std::fs::read_to_string(prompts_dir.join("worker.md")).unwrap(),
+        "Review carefully."
+    );
+}
+
+/// The reported journey, minus the second machine: a pipeline already poisoned
+/// on disk (by a PDO that predates the fix) must still export a document its own
+/// importer accepts.
+#[tokio::test]
+async fn a_pipeline_with_an_orphan_prompt_on_disk_still_round_trips() {
+    let daemon = TestDaemon::spawn(|repo| {
+        seed(repo)?;
+        // The leftover of a node deleted before the fix landed.
+        std::fs::write(
+            repo.join(".pdo")
+                .join("pipelines")
+                .join("portable-prompts.prompts")
+                .join("FBKE6BhH.md"),
+            "Prompt of a node that no longer exists.",
+        )?;
+        Ok(())
+    })
+    .await
+    .unwrap();
+    let client = reqwest::Client::new();
+
+    let document = client
+        .get(format!(
+            "{}/pipelines/portable-prompts/document",
+            daemon.url()
+        ))
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+    assert!(
+        !document.contains("FBKE6BhH"),
+        "the export carried the dead key:\n{document}"
+    );
+
+    let resp = client
+        .post(format!("{}/pipelines/import", daemon.url()))
+        .json(&serde_json::json!({ "document": document }))
+        .send()
+        .await
+        .unwrap();
+    let status = resp.status();
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(status, 201, "{body}");
+
+    let imported = daemon
+        .repo_root()
+        .join(".pdo")
+        .join("pipelines")
+        .join(format!("{}.prompts", body["id"].as_str().unwrap()));
+    assert!(imported.join("worker.md").exists());
+    assert!(!imported.join("FBKE6BhH.md").exists());
+    assert_eq!(body["warnings"].as_array().unwrap().len(), 0);
+}
+
+/// A document written by an older PDO still holds the dead key. It is a
+/// leftover, not a corruption: import it, drop it, and say so.
+#[tokio::test]
+async fn a_document_carrying_a_dead_prompt_key_imports_with_a_warning() {
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+    let client = reqwest::Client::new();
+
+    let document = client
+        .get(format!(
+            "{}/pipelines/portable-prompts/document",
+            daemon.url()
+        ))
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+    // Re-poison the document the way pre-fix PDO emitted it.
+    let document = format!("{document}  FBKE6BhH: Prompt of a deleted node.\n");
+    assert!(document.contains("FBKE6BhH"));
+
+    let resp = client
+        .post(format!("{}/pipelines/import", daemon.url()))
+        .json(&serde_json::json!({ "document": document }))
+        .send()
+        .await
+        .unwrap();
+    let status = resp.status();
+    let body: serde_json::Value = resp.json().await.unwrap();
+
+    assert_eq!(status, 201, "{body}");
+    let warnings = body["warnings"].as_array().unwrap();
+    assert_eq!(warnings.len(), 1, "{body}");
+    assert!(
+        warnings[0].as_str().unwrap().contains("prompts.FBKE6BhH"),
+        "{body}"
+    );
+    let imported = daemon
+        .repo_root()
+        .join(".pdo")
+        .join("pipelines")
+        .join(format!("{}.prompts", body["id"].as_str().unwrap()));
+    assert!(!imported.join("FBKE6BhH.md").exists());
+}
+
+/// The one prompt key that stays fatal: it names a path, not a node.
+#[tokio::test]
+async fn a_prompt_key_that_escapes_the_sidecar_dir_is_still_refused() {
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+    let client = reqwest::Client::new();
+
+    let document = client
+        .get(format!(
+            "{}/pipelines/portable-prompts/document",
+            daemon.url()
+        ))
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+    let document = format!("{document}  ../../outside: injected\n");
+
+    let resp = client
+        .post(format!("{}/pipelines/import", daemon.url()))
+        .json(&serde_json::json!({ "document": document }))
+        .send()
+        .await
+        .unwrap();
+    let status = resp.status();
+    let body: serde_json::Value = resp.json().await.unwrap();
+
+    assert_eq!(status, 400, "{body}");
+    assert!(
+        body["error"]
+            .as_str()
+            .unwrap()
+            .contains("cannot be used as a prompt filename"),
+        "{body}"
+    );
+}
+
+/// Duplicating a poisoned pipeline must not carry the leftover into the copy.
+#[tokio::test]
+async fn duplicating_a_pipeline_leaves_its_orphan_prompts_behind() {
+    let daemon = TestDaemon::spawn(|repo| {
+        seed(repo)?;
+        std::fs::write(
+            repo.join(".pdo")
+                .join("pipelines")
+                .join("portable-prompts.prompts")
+                .join("FBKE6BhH.md"),
+            "Prompt of a node that no longer exists.",
+        )?;
+        Ok(())
+    })
+    .await
+    .unwrap();
+
+    let resp = reqwest::Client::new()
+        .post(format!(
+            "{}/pipelines/portable-prompts/duplicate",
+            daemon.url()
+        ))
+        .send()
+        .await
+        .unwrap();
+    let status = resp.status();
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(status, 201, "{body}");
+
+    let copy = daemon
+        .repo_root()
+        .join(".pdo")
+        .join("pipelines")
+        .join(format!("{}.prompts", body["id"].as_str().unwrap()));
+    assert!(copy.join("worker.md").exists());
+    assert!(!copy.join("FBKE6BhH.md").exists());
+}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1393,9 +1393,11 @@ export function fetchRunPipelineDocument(runId: string): Promise<string> {
   });
 }
 
+/// `warnings` carries the non-fatal diagnostics of the import — today, prompts
+/// dropped because they name a node the document does not define.
 export function importPipelineDocument(
   document: string,
-): Promise<{ id: string; scope: string; path: string }> {
+): Promise<{ id: string; scope: string; path: string; warnings: string[] }> {
   return request("POST", "/pipelines/import", {
     body: { document },
     label: "POST /pipelines/import",

--- a/frontend/src/components/UnifiedLeftPanel.test.tsx
+++ b/frontend/src/components/UnifiedLeftPanel.test.tsx
@@ -5,7 +5,7 @@ import userEvent from "@testing-library/user-event";
 import UnifiedLeftPanel from "./UnifiedLeftPanel";
 import type { PipelineListEntry, RunListEntry, Trigger } from "../types";
 import type { LibraryPipelineEntry } from "../api";
-import { cleanupRun, deleteLibraryPipeline, deletePipeline, duplicateLibraryPipeline, fetchPipelines, importWorkflow, openRunShell, pauseRun, renameRun, resumeRun, retryAll } from "../api";
+import { cleanupRun, deleteLibraryPipeline, deletePipeline, duplicateLibraryPipeline, fetchPipelines, importPipelineDocument, importWorkflow, openRunShell, pauseRun, renameRun, resumeRun, retryAll } from "../api";
 import { useEditStore } from "../stores/editStore";
 
 const mockRenameRun = vi.mocked(renameRun);
@@ -19,6 +19,7 @@ const mockResumeRun = vi.mocked(resumeRun);
 const mockRetryAll = vi.mocked(retryAll);
 const mockCleanupRun = vi.mocked(cleanupRun);
 const mockImportWorkflow = vi.mocked(importWorkflow);
+const mockImportPipelineDocument = vi.mocked(importPipelineDocument);
 const originalOpenPipeline = useEditStore.getState().openPipeline;
 
 vi.mock("../api", () => ({
@@ -30,7 +31,9 @@ vi.mock("../api", () => ({
   renameRun: vi.fn().mockResolvedValue(undefined),
   createPipeline: vi.fn().mockResolvedValue({ id: "new-pipe", scope: "repo", path: "/tmp" }),
   duplicatePipeline: vi.fn().mockResolvedValue({ id: "copy", scope: "instance", path: "/tmp" }),
-  importPipelineDocument: vi.fn().mockResolvedValue({ id: "imported", scope: "instance", path: "/tmp" }),
+  importPipelineDocument: vi
+    .fn()
+    .mockResolvedValue({ id: "imported", scope: "instance", path: "/tmp", warnings: [] }),
   importWorkflow: vi.fn().mockResolvedValue({ id: "workflow", scope: "instance", warnings: [] }),
   deleteLibraryPipeline: vi.fn().mockResolvedValue(undefined),
   duplicateLibraryPipeline: vi
@@ -122,6 +125,44 @@ describe("portable pipeline import", () => {
 
     await waitFor(() => expect(openPipeline).toHaveBeenCalledWith("workflow-with-warnings"));
     expect(screen.getByText("parallel branch was flattened")).toBeInTheDocument();
+  });
+
+  // A PDO document carrying a prompt for a node it no longer defines is
+  // a leftover, not a corruption: the import goes through and says what it
+  // dropped, instead of the 400 that used to strand the user on the destination
+  // machine with an opaque node id and a YAML textarea.
+  it("opens a PDO import that dropped a stale prompt, and names what it dropped", async () => {
+    const openPipeline = vi.fn().mockResolvedValue(undefined);
+    useEditStore.setState({ openPipeline });
+    mockImportPipelineDocument.mockResolvedValue({
+      id: "document-with-warnings",
+      scope: "instance",
+      path: "/tmp/document-with-warnings.yaml",
+      warnings: ["prompts.FBKE6BhH: no such node in the document — prompt ignored"],
+    });
+
+    render(
+      <UnifiedLeftPanel
+        runs={[]}
+        selectedRunId={null}
+        onSelectRun={() => {}}
+        onNewRun={() => {}}
+        libraryPipelines={[]}
+        onLibraryPipelinesChanged={() => {}}
+      />,
+    );
+    await userEvent.click(screen.getByRole("tab", { name: "Pipelines" }));
+    await userEvent.click(screen.getByTestId("import-workflow-button"));
+    fireEvent.change(screen.getByTestId("pipeline-document-input"), {
+      target: { value: "pdo_pipeline: 1\npipeline: {}\n" },
+    });
+    await userEvent.click(await screen.findByRole("button", { name: "Import" }));
+
+    await waitFor(() => expect(openPipeline).toHaveBeenCalledWith("document-with-warnings"));
+    expect(screen.getByTestId("import-workflow-warnings")).toHaveTextContent(
+      "prompts.FBKE6BhH",
+    );
+    expect(screen.getByText(/Imported with 1 warning:/)).toBeInTheDocument();
   });
 });
 

--- a/frontend/src/components/UnifiedLeftPanel.tsx
+++ b/frontend/src/components/UnifiedLeftPanel.tsx
@@ -1166,8 +1166,9 @@ function ImportWorkflowModal({
       await openPipeline(result.id);
       const w = "warnings" in result ? result.warnings ?? [] : [];
       if (w.length > 0) {
-        // Surface the lossy-translation diagnostics (ADR-0001) rather than
-        // silently closing — the annotation is the onboarding tutorial.
+        // Surface the diagnostics rather than silently closing: for a Claude
+        // workflow the lossy-translation annotation is the onboarding tutorial
+        // (ADR-0001); for a PDO document it says what the import dropped.
         setWarnings(w);
       } else {
         onClose();
@@ -1287,7 +1288,7 @@ function ImportWorkflowModal({
             data-testid="import-workflow-warnings"
           >
             <div className="mb-1 font-medium text-st-await">
-              Imported with {warnings.length} translation warning
+              Imported with {warnings.length} warning
               {warnings.length === 1 ? "" : "s"}:
             </div>
             <ul className="list-disc pl-4">


### PR DESCRIPTION
## Le bug

Les prompts d'une pipeline vivent en fichiers annexes nommés par identifiant de node. Supprimer un
node laissait son `.md` sur disque. L'export émettait alors une clé `prompts.<id>` ne désignant
aucun node, et l'importeur refusait le document entier : `400 prompts.<id>: node does not exist`.

La panne tombait sur la machine de destination, celle qui n'a aucun moyen de corriger la source.
Cinq des pipelines de l'instance de dev étaient déjà dans cet état : leur document n'était
importable nulle part.

## Le correctif

L'invariant *clés ⊆ nodes* se tient désormais aux quatre frontières que les prompts franchissent :

| Frontière | Avant | Après |
|---|---|---|
| Sauvegarde | l'orphelin reste sur disque | un save élague les `.md` des nodes absents du YAML enregistré (le YAML fait autorité, pas les clés envoyées par le client) |
| Export | le document emporte la clé morte | seuls les prompts d'un node vivant partent, ce qui répare les pipelines déjà empoisonnées sans migration au boot |
| Import | refus du document entier | avertissement nommé dans la modale, le reste est importé |
| Écriture au registre | duplicate et import recopient le reliquat | la copie part propre |

Reste fatale la seule clé qui ne peut pas être un nom de fichier (`../../outside`) : elle désigne un
chemin, pas un node.

## Tests

`make test` vert : 2647 tests Rust, 1938 frontend. `make check` et `make lint` verts.

Ajoutés par ce correctif : 2 unitaires sur le round-trip du document, 6 d'intégration qui passent
par le vrai répertoire annexe et les vrais handlers HTTP (le seul test de round-trip existant
construisait la map en mémoire, où l'orphelin ne peut pas exister), 1 frontend sur l'affichage de
l'avertissement.

## Recette agentique — 9 Feature Paths verts, 0 finding bloquant

Montage : quatre daemons jetables, `HOME` distinct chacun, dont un sur le binaire 1.46.0 installé
comme contrôle pré-fix. L'instance vive `:6160` n'a servi qu'en lecture (`GET
/pipelines/:id/document`) pour fournir les documents legacy, et reste inchangée.

| FP | Ce qui est vérifié | Verdict |
|---|---|---|
| FP-0 | *Contrôle pré-fix* : le binaire 1.46.0 refuse bien les 5 documents empoisonnés (`400` ×5) et accepte le témoin sain | bug reproduit |
| FP-1 | Un document legacy portant la clé morte s'importe sur une machine neuve, et la modale nomme ce qu'elle a écarté | Pass |
| FP-2 | L'export répare les 5 pipelines empoisonnées sans migration : `dead=[]` contre `dead=[…]` sur les mêmes servies par `:6160` | Pass |
| FP-3 | Supprimer un node + Save élague son `.md` ; ré-export puis ré-import à `201`, 0 avertissement. En pré-fix, les deux orphelins restent et le ré-import reste à `400` | Pass |
| FP-4 | Fidélité du transfert sur 6 pipelines : ids, compteurs d'edges, prompts vivants byte-identiques (sha256), aucun orphelin semé à destination | Pass |
| FP-5 | Un duplicate n'hérite pas du reliquat (6 prompts dont 1 orphelin → la copie en a 5) | Pass |
| FP-6 | Garde-fou : `../../outside` reste `400`, rien créé, rien écrit hors du répertoire annexe | Pass |
| FP-7 | Un save sans map de prompts n'efface pas les prompts vivants | Pass |
| FP-8 | Non-régression : le bandeau renommé sert encore le mode Workflow Claude Code | Pass |
| FP-9 | Le prochain save d'une pipeline déjà empoisonnée élague son orphelin | Pass |

Console navigateur : 0 erreur, 0 warning sur tout le parcours UI. Six captures annotées dans
`.pdo/runs/20260831-083110-82fcd07/worktree/.pdo/artifacts/s35ylZ0a/iter-1/feature-screens/`.

### Findings non bloquants, laissés ouverts

- **L'export écarte le reliquat sans le dire à la machine source.** Le dépliant « Not included » du
  volet *Pipeline info > YAML* ne liste que « Secrets, environment, runtime values, instance
  configuration ». La destination reçoit un avertissement nommé, la source n'apprend rien. Une ligne
  dans ce dépliant suffirait.
- **Le mot « translation » a disparu du bandeau du mode Claude Code** (cosmétique). Le renommage
  `translation warning` → `warning` était nécessaire pour qu'un bandeau serve deux modes ; le
  message lui-même reste explicite.
- La lecture alternative du rapport initial (un import réussi dont les edges manqueraient) est
  **écartée, pas confirmée** : non reproduite sur 6 pipelines, edges, labels conditionnels,
  waypoints et régions de boucle tous préservés.

## Version

1.46.0 → **1.46.1**. Pas d'entrée CHANGELOG : correctif non cassant dont le titre de commit dit
tout, conformément à la politique du fichier.

## Pas d'issue

Aucune issue GitHub ne portait ce bug (vérifié : `#654`/`#655` portent l'isolation des Agents). Les
critères d'acceptation viennent du `how_to_reproduce` du node Debugger et du tableau des quatre
frontières ci-dessus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)