### PR TITLE
feat(#653): remplacer doc-only et code-mutating par `agent` avec isolation explicite

### DIFF
--- a/.pdo/pipelines/disk-janitor.yaml
+++ b/.pdo/pipelines/disk-janitor.yaml
@@ -11,6 +11,7 @@ nodes:
   - id: reap
     name: Reclaim disk
     type: script
+    isolated_worktree: false
     outputs:
       - { name: out, side: bottom }
     view: { x: 120, y: 40 }

--- a/.pdo/pipelines/planner.yaml
+++ b/.pdo/pipelines/planner.yaml
@@ -14,7 +14,8 @@ nodes:
     view: { x: 288, y: 374 }
   - id: D3InFdSK
     name: Planner-grill-me
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     interactive: true
     inputs:
       - { name: in, side: top }

--- a/.pdo/pipelines/review-loop.yaml
+++ b/.pdo/pipelines/review-loop.yaml
@@ -9,7 +9,8 @@ nodes:
     side: right
 - id: XBG5Cxkn
   name: implementer
-  type: code-mutating
+  type: agent
+  isolated_worktree: true
   view:
     x: 335
     y: 249
@@ -18,7 +19,8 @@ nodes:
     side: right
 - id: Qws9KzRZ
   name: reviewer
-  type: doc-only
+  type: agent
+  isolated_worktree: false
   view:
     x: 500
     y: 100

--- a/.pdo/pipelines/simple-bugfix.yaml
+++ b/.pdo/pipelines/simple-bugfix.yaml
@@ -21,7 +21,8 @@ nodes:
     y: 517
 - id: 9LvO3oid
   name: Debugger
-  type: code-mutating
+  type: agent
+  isolated_worktree: true
   view:
     x: 529
     y: -10
@@ -43,7 +44,8 @@ nodes:
     port_type: image_list
 - id: KHFCO0US
   name: implementer
-  type: code-mutating
+  type: agent
+  isolated_worktree: true
   view:
     x: 1109
     y: -19
@@ -52,7 +54,8 @@ nodes:
     side: bottom
 - id: 9NOnrpKY
   name: Visual tester
-  type: code-mutating
+  type: agent
+  isolated_worktree: true
   view:
     x: 1152
     y: 371
@@ -71,7 +74,8 @@ nodes:
     port_type: image_list
 - id: mWllKR47
   name: Ship It
-  type: code-mutating
+  type: agent
+  isolated_worktree: true
   view:
     x: 748
     y: 399

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,33 @@ ascendante** : la casse se signale ici et par un bump majeur, jamais en gardant 
 morts. Seule contrainte non négociable — les **données historiques restent lisibles** : un Run
 archivé s'ouvre et se chiffre quelle que soit la version qui a écrit son payload.
 
+## 1.47.0
+
+**`agent` remplace `doc-only` et `code-mutating` ; l'isolation devient explicite** (#653 ;
+ADR-0060). *Cassant.* Les deux anciens types nommaient un *effet* alors que le runtime n'y lisait
+qu'un répertoire de travail. Un seul type agentique subsiste, `agent`, et l'endroit où le NodeRun
+travaille s'écrit sur le Node : `isolated_worktree: true|false`.
+
+La rupture est franche — **ni alias, ni migrateur, ni diagnostic dédié**. `doc-only` et
+`code-mutating` prennent le chemin de n'importe quelle valeur invalide : coercition vers `agent`
+avec l'avertissement générique de type inconnu, donc un Node qui perd son sous-worktree sans le
+dire. **Les Pipelines existantes se convertissent à la main** : un ancien `doc-only` devient un
+`agent` avec `isolated_worktree: false`, un ancien `code-mutating` un `agent` avec
+`isolated_worktree: true`. Les Pipelines livrées dans ce dépôt sont réécrites ; **celles de
+l'instance (`~/.pdo/pipelines/`) ne le sont pas** — elles sont hors du dépôt.
+
+Le Document écrit toujours le choix pour un `agent` et un `script`, même à la valeur par défaut
+(Agent isolé, Script partagé) : on lit où le Node travaille au lieu de se rappeler un défaut.
+`merge` reste isolé d'office et n'expose aucun réglage ; `start` et `end` n'en portent aucun.
+L'isolation est **gelée au spawn du NodeRun** — une édition déplace le prochain lancement, jamais
+une exécution vivante, et une reprise retrouve le répertoire qu'elle avait quitté.
+
+Côté éditeur, l'inspecteur remplace le sélecteur de type par un type figé et une section
+« Workspace » qui nomme les deux lieux et affiche le répertoire résolu ; le canvas remplace les deux
+marqueurs `doc-only` / `code-mutating` par un glyphe de branche sur les Nodes qui forkent un
+worktree (l'`agent` isolé et le `merge`). L'import de workflow ne devine plus : un rôle importé
+devient un `agent` isolé, sans heuristique de prompt, de nom ni de sortie.
+
 ## 1.46.0
 
 **Les pipelines appartiennent à l'instance et voyagent par document** (#572 ; ADR-0059). *Cassant.*

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -72,7 +72,7 @@ Le **modèle** dit *quel agent* tourne, le **niveau d'effort** *combien il réfl
 - **Le catalogue se lit d'abord dans la source *générée*** *(terme, ADR-0056)* : un binaire n'énumère pas forcément là où on regarde. Le catalogue a trois sources, par préférence décroissante — le **script de complétion** (`<binaire> completion bash`, généré à partir des choix que le CLI déclare, donc préféré), le **sujet d'aide des réglages** (`<binaire> help config`), puis `--help`. Chaque axe (modèles, efforts) appartient à la **source la mieux placée qui répond pour lui**. `--help` tourne en premier quand même, parce que c'est là qu'un CLI **déclare ses sous-commandes** : on n'exécute que celles qu'il annonce (`claude` n'a pas de `completion` et lit l'argv comme un prompt — la lancer à l'aveugle coûterait un timeout de cinq secondes dans une réponse `/settings`). Mesuré : le `--help` de copilot 1.0.80 énumère ses efforts mais décrit `--model` en prose — le lire seul faisait conclure « copilot n'a pas de catalogue » alors qu'il en a un (#629). _Éviter_ : « la source du catalogue » au singulier ; choisir la source par nom de harnais (l'échelle est harnais-agnostique).
 - **Effort demandé ≠ effort obtenu** : le flag exprime une **intention** — un niveau non supporté retombe en silence, un plafond d'organisation peut clamper, un skill/sous-agent peut surclasser le niveau de session. À lire comme un levier de déterminisme et de latence, pas un cadran de coût. _Éviter_ : « effort garanti », « effort du run », « mode économique », « modèle global », « modèle du run ».
 - **Sémantique, pas layout** : la carte entre dans le **diff sémantique** et le `content_hash` de la bibliothèque.
-- **S'applique aux nodes qui lancent un agent** (`doc-only`, `code-mutating`, `merge`), jamais à un node `script`.
+- **S'applique aux nodes qui lancent un agent** (`agent`, `merge`), jamais à un node `script`.
 - **Ce que la reprise conserve dépend du harnais** : sur `claude`, le modèle survit, l'effort non — PDO le re-pose depuis l'événement de démarrage, jamais depuis le YAML courant, qui a pu être édité entre-temps (#424, ADR-0007). Le YAML est la vérité au *spawn*, l'event log au *resume*.
 - **Défaut d'instance** (#347) : un modèle par harnais peut être posé daemon-wide (Configuration d'instance, ADR-0015).
 
@@ -91,12 +91,12 @@ _Éviter_ : « profil » seul (ambigu avec le profil de staging), « preset », 
 
 ### Node `script` — exécution déterministe (ADR-0017)
 
-Un node **`script`** exécute le bash de l'auteur au lieu de lancer Claude, dans une **session tmux** attachable comme tout NodeRun (ADR-0005) : exit 0 ⇒ `completed`, non-zéro ou timeout ⇒ `failed`. En v1 il est d'**effet doc-only** (tourne dans le worktree du Run, doit le laisser propre).
+Un node **`script`** exécute le bash de l'auteur au lieu de lancer Claude, dans une **session tmux** attachable comme tout NodeRun (ADR-0005) : exit 0 ⇒ `completed`, non-zéro ou timeout ⇒ `failed`. Il partage le worktree du Run par défaut et porte le même choix d'isolation qu'un `agent` (cf. *Isolation de Node*).
 
 - **I/O par variables d'environnement** (`PDO_INPUT_<PORT>`, `PDO_OUTPUT_<PORT>`, `PDO_ARTIFACTS_DIR`, `PDO_VAR_<NAME>`…) : un script ne lit pas le préambule prose. Il écrit lui-même ses outputs ; la validation d'outputs s'applique en **fail-fast** (pas de retry interactif — la session a quitté). Contrat de refus → ADR-0035.
 - **Corps** stocké dans le slot prompt du node. Un corps vide fait échouer le lancement (fail-loud).
 - **Ni `model` ni `effort`** (aucun agent lancé).
-- **Sharp tool** : même surface de confiance que le guard de Trigger et le bash d'un agent — le bash de l'auteur dans son propre pipeline. Un script doc-only qui commit laisse l'arbre propre : responsabilité de l'auteur.
+- **Sharp tool** : même surface de confiance que le guard de Trigger et le bash d'un agent — le bash de l'auteur dans son propre pipeline. Un script non isolé qui commit laisse l'arbre propre : responsabilité de l'auteur.
 
 ## Dataflow
 
@@ -128,7 +128,7 @@ edges:
 
 ### Évaluation — multi-match, pas d'ordre
 
-À l'arrivée d'un artefact sur un output port, **toutes** les edges sortantes dont la clause est satisfaite **firent** — le flux peut fan-out vers plusieurs nœuds simultanément. Pas de `first-match-wins`. Si deux conditions se chevauchent, les deux branches partent : c'est voulu (ADR-0001, *sharp tool*) — le designer écrit des conditions disjointes pour un XOR, ou converge un fan-out `code-mutating` via un `Merge`. Une edge **`else`** fire **uniquement si aucune edge sœur** (même output port source) n'a matché.
+À l'arrivée d'un artefact sur un output port, **toutes** les edges sortantes dont la clause est satisfaite **firent** — le flux peut fan-out vers plusieurs nœuds simultanément. Pas de `first-match-wins`. Si deux conditions se chevauchent, les deux branches partent : c'est voulu (ADR-0001, *sharp tool*) — le designer écrit des conditions disjointes pour un XOR, ou converge un fan-out de Nodes isolés via un `Merge`. Une edge **`else`** fire **uniquement si aucune edge sœur** (même output port source) n'a matché.
 
 Feedback runtime : un nœud qui a firé passe au vert ; les edges déclenchées sont marquées sur le canvas.
 
@@ -182,7 +182,7 @@ loops:
 
 - **Succès anticipé** : une edge forward conditionnelle quittant un membre (`verdict=PASS → end`).
 - **Épuisement** (`bounded`) : à `iter = max_iter`, la re-entry est plafonnée. Le designer **peut** câbler une sortie d'épuisement (`when: { iter: { gte: $max } }`). Sinon, la boucle entre dans un état **bloqué « exhausted — unrouted »** explicite (jamais de stall silencieux), routable par le Pipeline Manager. Pas d'auto-proceed implicite.
-- **`collection`** : **barrière** — les edges quittant la boucle firent **une seule fois, quand tous les items sont terminés**. Liste vide → barrière immédiate. Items `code-mutating` → chacun son sous-worktree, convergence via `Merge`.
+- **`collection`** : **barrière** — les edges quittant la boucle firent **une seule fois, quand tous les items sont terminés**. Liste vide → barrière immédiate. Items isolés → chacun son sous-worktree, convergence via `Merge`.
 
 ### Imbrication — différée
 
@@ -219,7 +219,7 @@ Une **Note** est une annotation de documentation **inerte** posée sur le canvas
 - **`view` = layout, pas sémantique** : deux pipelines ne différant que par leurs notes comparent égaux.
 - **Mutable pendant un Run** : inerte, aucune session à orphaner — jamais rejetée sur un Run actif (contraste avec la suppression d'un node non-`pending`, interdite par ADR-0007).
 
-_Éviter_ : « commentaire » (évoque un commentaire YAML `#` ou d'issue), « placeholder annoté » (qui est un **vrai** nœud `doc-only` produit par l'import de workflow, ADR-0016).
+_Éviter_ : « commentaire » (évoque un commentaire YAML `#` ou d'issue), « placeholder annoté » (qui est un **vrai** nœud `agent` produit par l'import de workflow, ADR-0016).
 
 ---
 
@@ -314,16 +314,13 @@ PDO **ne gère pas** les skills, sous-agents, plugins ou MCP d'un harnais. Ce qu
 
 ---
 
-## `code-mutating` vs `doc-only`
+## Placement d'un NodeRun
 
-Chaque Node est typé par son **effet sur le code** :
+Où travaille un NodeRun est écrit sur le Node (cf. *Isolation de Node*, ADR-0060), jamais déduit de son type. Un Node isolé reçoit un sous-worktree forké depuis la branche du Pipeline Run et le merge dans cette branche à sa complétion. Un Node non isolé travaille directement dans le worktree du Run.
 
-- **`code-mutating`** — Implementer, Refactorer, Merge. Reçoit un sous-worktree forké depuis la branche du Pipeline Run. Peut éditer/commit/merger. À la fin du NodeRun, son sous-worktree est mergé dans la branche du Pipeline Run.
-- **`doc-only`** — Planner, Reviewer, Architect. Pas de sous-worktree. Lit la branche du Pipeline Run en read-only. Écrit uniquement dans le Blackboard.
+Parallélisation : les Nodes non isolés sont gratis-parallèles et partagent leur arbre de travail ; les Nodes isolés parallèles voient leurs branches mergées séquentiellement à la fin (ordre de complétion).
 
-Garde-fou : à la fin d'un NodeRun `doc-only`, la branche du Pipeline Run doit rester intacte. Violation détectée ⇒ le NodeRun échoue.
-
-Parallélisation : les `doc-only` sont gratis-parallèles ; les `code-mutating` parallèles voient leurs branches mergées séquentiellement à la fin (ordre de complétion).
+Le choix est **gelé au spawn du NodeRun** : une édition du Document déplace le prochain lancement, jamais une exécution vivante (ADR-0007).
 
 ### Merge-back d'un sous-worktree (ADR-0036)
 
@@ -335,7 +332,7 @@ Le merge-back suppose que le tip de la branche pipeline reste un **ancêtre** de
 
 ## Merge — nœud first-class
 
-Le **`Merge`** est un nœud first-class du DAG, type `code-mutating`, à placer explicitement par le designer (ADR-0006). L'utilisateur dessine la convergence ; le runtime ne l'invente pas.
+Le **`Merge`** est un nœud first-class du DAG, isolé d'office et sans réglage, à placer explicitement par le designer (ADR-0006). L'utilisateur dessine la convergence ; le runtime ne l'invente pas.
 
 ### Forme
 
@@ -345,13 +342,13 @@ Le **`Merge`** est un nœud first-class du DAG, type `code-mutating`, à placer 
 ### Sémantique runtime
 
 1. **Barrière edge-centrée** (addendum ADR-0006) : le Merge est prêt quand toutes ses edges entrantes sont résolues — chacune a soit **firé**, soit est **morte** (producteur complété sans firer, ou lui-même mort) — et qu'au moins une a firé. Il consomme uniquement les branches firées. Un Merge dont toutes les branches sont mortes est lui-même mort et sauté tant que `End` reste atteignable ; sinon le Run **halt explicitement** (« unrouted »), jamais de stall silencieux.
-2. **Fork** d'un sous-worktree depuis la branche du Pipeline Run, **`git merge`** de chaque upstream `code-mutating`.
+2. **Fork** d'un sous-worktree depuis la branche du Pipeline Run, **`git merge`** de chaque upstream isolé.
 3. **Si conflit** → spawn Claude Code dans le sous-worktree, qui lit le Blackboard pour reconstituer les intentions, résout, commit, écrit le `merged.md`.
 4. **Si pas de conflit** → `merged.md` trivial, commit, sans LLM.
 
 ### Lint info-only
 
-Un fan-out `code-mutating` sans `Merge` downstream affiche un diagnostic info-only sur le canvas (ADR-0001 : pas bloquant). Le canvas est l'unique surface des diagnostics pipeline-wide (#63).
+Un fan-out de Nodes isolés sans `Merge` downstream affiche un diagnostic info-only sur le canvas (ADR-0001 : pas bloquant). Le canvas est l'unique surface des diagnostics pipeline-wide (#63).
 
 ---
 
@@ -611,7 +608,7 @@ Exposées comme `POST /runs/<id>/commands` :
 | `extend_cycle` | (Legacy, cycles hors région) — refusé sur un membre de région : utiliser `bump_region` |
 | `resume_run` | Relance le Run depuis l'état actuel (post-conflit résolu, etc.) |
 | `kill_node` | Tue un NodeRun en cours (le marque `failed`) |
-| `restart_node` | Re-spawn un NodeRun au **même `iter`** ; sur un nœud `code-mutating`/`merge`, le sous-worktree est réutilisé en place — le travail non commité survit (#489). Préconditions et refus → ADR-0037 |
+| `restart_node` | Re-spawn un NodeRun au **même `iter`** ; sur un nœud isolé, le sous-worktree est réutilisé en place — le travail non commité survit (#489). Préconditions et refus → ADR-0037 |
 | `mark_node_done` | Force la complétion (nœud `interactive`, ou récupération d'un failed corrigé à la main). Même corps que `pdo complete` : refus 409 nommé → ADR-0035 |
 | `inject_artifact` | Pose un artefact à la main dans le Blackboard |
 | `cleanup_run` | Supprime branches, worktrees, artefacts (archive d'abord — ADR-0020) |
@@ -919,7 +916,7 @@ Décompilation **avec perte** d'un workflow Claude Code (`.claude/workflows/*.js
 _Éviter_ : « conversion », « migration » — la **migration** réécrit du YAML PDO d'un ancien schéma vers le courant (même format) ; l'**import** traduit un format étranger.
 
 **Placeholder annoté** :
-Nœud `doc-only` dont le corps explique un idiome de workflow que l'import v1 ne matérialise pas. L'annotation **est** le tutoriel d'onboarding : elle nomme ce qu'un utilisateur PDO n'écrirait jamais à la main (gestion worktrees, boucle budgétaire — remplacés par des features plateforme) et le traduit en interaction délibérée. Distinct du *nom placeholder* d'un Run.
+Nœud `agent` dont le corps explique un idiome de workflow que l'import v1 ne matérialise pas. L'annotation **est** le tutoriel d'onboarding : elle nomme ce qu'un utilisateur PDO n'écrirait jamais à la main (gestion worktrees, boucle budgétaire — remplacés par des features plateforme) et le traduit en interaction délibérée. Distinct du *nom placeholder* d'un Run.
 
 **Extraction verbatim** :
 Règle de récupération des prompts : string-literal sans interpolation → verbatim ; template-literal avec `${…}` → texte statique verbatim + marqueurs câblables ; prompt sans texte statique → placeholder annoté.
@@ -929,4 +926,4 @@ Règle de récupération des prompts : string-literal sans interpolation → ver
 - Un **Import de workflow** produit un **brouillon de Pipeline** dans le registre.
 - L'**import de Pipeline PDO** interprète un Document de pipeline transportable et crée une Pipeline indépendante ; il partage la même modale que l'Import de workflow, mais constitue un mode distinct et fidèle.
 - Idiomes mappés : `agent()` → **Node**, `pipeline()` → boucle **`collection`**, `for`/`while` autour d'un `agent()` → boucle **`bounded`**, `if`/`return` gardé → **edge conditionnelle**, schémas JSON → **frontmatter de port de sortie**.
-- Un idiome hors sous-ensemble → **placeholder annoté**. Un `git merge` scripté → Node `code-mutating` annoté, **pas** le Merge first-class (dont il excède le contrat).
+- Un idiome hors sous-ensemble → **placeholder annoté**. Un `git merge` scripté → Node `agent` annoté, **pas** le Merge first-class (dont il excède le contrat).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "1.46.0"
+version = "1.47.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "1.46.0"
+version = "1.47.0"
 license = "MIT"
 description = "Prompt-Driven Orchestrator — a local daemon that runs and supervises agentic coding pipelines"
 repository = "https://github.com/Loulen/prompt-driven-orchestrator"

--- a/crates/pdo-daemon/src/admission.rs
+++ b/crates/pdo-daemon/src/admission.rs
@@ -167,6 +167,7 @@ mod tests {
             run.nodes.insert(
                 (*id).into(),
                 NodeState {
+                    isolated_worktree: None,
                     harness: None,
                     cost: None,
                     node_id: (*id).into(),

--- a/crates/pdo-daemon/src/boot_recovery.rs
+++ b/crates/pdo-daemon/src/boot_recovery.rs
@@ -28,8 +28,8 @@ use tracing::{error, warn};
 use crate::worktree_ops::sub_worktree_branch;
 use crate::{admission, event_log, tmux_session_manager};
 use crate::{
-    append_event, effective_repo_root, find_node_type, load_all_run_ids, load_events,
-    reconcile_run_level_stall, retry_waiting_nodes, AppState,
+    append_event, effective_repo_root, load_all_run_ids, load_events, reconcile_run_level_stall,
+    retry_waiting_nodes, AppState,
 };
 
 /// Reconcile persisted run state against the live process world at daemon boot.
@@ -296,8 +296,8 @@ fn detect_merged_without_event(
     }
 }
 
-/// Pure detection of the git/event-log divergence in #213 AC3: a node owning a
-/// sub-worktree branch (`code-mutating` / `merge`) that is **not** marked
+/// Pure detection of the git/event-log divergence in #213 AC3: an **isolated**
+/// node (#653) — one owning a sub-worktree branch — that is **not** marked
 /// `Completed` in the event log, yet whose branch `is_merged` reports as merged
 /// into the pipeline branch. Returns `(node_id, sub_branch, status)` triples.
 ///
@@ -312,8 +312,11 @@ where
 {
     let mut out = Vec::new();
     for (node_id, ns) in &run_state.nodes {
-        let node_type = find_node_type(run_state, node_id);
-        if !matches!(node_type, Some("code-mutating") | Some("merge")) {
+        // #653/ADR-0060: a sub-branch exists iff the node is isolated. Read off
+        // the Run snapshot (this sweep holds no event log): a node whose frozen
+        // value differs has an `is_merged` probe answer of its own anyway — an
+        // absent branch simply never reports merged.
+        if !crate::snapshot_isolation(run_state, node_id) {
             continue;
         }
         // #620: a `Skipped` node is settled and never held a sub-branch — exclude
@@ -352,15 +355,16 @@ mod tests {
     fn run_state_with_node(
         run_id: &str,
         node_id: &str,
-        node_type: &str,
+        isolated: bool,
         status: event_log::NodeStatus,
         iter: i64,
     ) -> event_log::RunState {
         let mut rs = event_log::RunState::new(run_id.into(), "test".into());
         rs.node_defs.push(event_log::NodeDefInfo {
+            isolated_worktree: Some(isolated),
             id: node_id.into(),
             name: None,
-            node_type: node_type.into(),
+            node_type: "agent".into(),
             view_x: None,
             view_y: None,
             inputs: Vec::new(),
@@ -369,6 +373,7 @@ mod tests {
         rs.nodes.insert(
             node_id.into(),
             event_log::NodeState {
+                isolated_worktree: None,
                 harness: None,
                 cost: None,
                 node_id: node_id.into(),
@@ -406,13 +411,13 @@ mod tests {
     }
 
     #[test]
-    fn merged_without_event_flags_a_merged_uncompleted_code_node() {
-        // #213 AC3: a code-mutating node whose sub-worktree branch is merged but
+    fn merged_without_event_flags_a_merged_uncompleted_isolated_node() {
+        // #213 AC3: an isolated node whose sub-worktree branch is merged but
         // which never recorded a NodeCompleted is a git/event-log divergence.
         let rs = run_state_with_node(
             "20260101-120000-abc",
             "impl",
-            "code-mutating",
+            true,
             event_log::NodeStatus::Running,
             1,
         );
@@ -432,7 +437,7 @@ mod tests {
         let rs = run_state_with_node(
             "20260101-120000-abc",
             "impl",
-            "code-mutating",
+            true,
             event_log::NodeStatus::Completed,
             1,
         );
@@ -441,25 +446,25 @@ mod tests {
     }
 
     #[test]
-    fn merged_without_event_ignores_unmerged_and_doc_only() {
-        // Doc-only nodes own no sub-worktree branch; an unmerged branch is fine.
+    fn merged_without_event_ignores_unmerged_and_shared_worktree() {
+        // A non-isolated node owns no sub-worktree branch; an unmerged branch is fine.
         let doc = run_state_with_node(
             "20260101-120000-abc",
             "doc",
-            "doc-only",
+            false,
             event_log::NodeStatus::Running,
             1,
         );
         assert!(merged_without_event_nodes("20260101-120000-abc", &doc, |_| true).is_empty());
 
-        let cm = run_state_with_node(
+        let isolated = run_state_with_node(
             "20260101-120000-abc",
             "impl",
-            "code-mutating",
+            true,
             event_log::NodeStatus::Running,
             1,
         );
-        assert!(merged_without_event_nodes("20260101-120000-abc", &cm, |_| false).is_empty());
+        assert!(merged_without_event_nodes("20260101-120000-abc", &isolated, |_| false).is_empty());
     }
 
     // Per-module coverage for the git probe that the closure-injected tests above

--- a/crates/pdo-daemon/src/completion_refusal.rs
+++ b/crates/pdo-daemon/src/completion_refusal.rs
@@ -38,7 +38,7 @@ pub(crate) enum CompletionRefusal {
     MergeFailed { error: String },
     /// Conflit de merge ; `MergeConflictDetected` + `RunFailed` déjà appendés.
     MergeConflict { node_id: String },
-    /// Node `doc-only`/`script` ayant sali des fichiers suivis ; `NodeFailed` +
+    /// Node non-isolated ayant sali des fichiers suivis ; `NodeFailed` +
     /// `RunFailed` déjà appendés.
     DocImmutabilityViolated { node_id: String },
     /// Ports de sortie déclarés sans artefact. Le node reste vivant.
@@ -159,7 +159,7 @@ impl CompletionRefusal {
                 serde_json::json!({ "message": format!("merge conflict on {node_id}") })
             }
             Self::DocImmutabilityViolated { node_id } => serde_json::json!({
-                "message": format!("doc-only node {node_id} violated code immutability")
+                "message": format!("non-isolated node {node_id} violated code immutability")
             }),
             Self::MissingOutputs { missing } => serde_json::json!({ "missing": missing }),
             Self::ScriptValidationFailed { detail } => serde_json::json!({ "detail": detail }),
@@ -194,7 +194,7 @@ impl CompletionRefusal {
             }
             Self::MergeConflict { node_id } => format!("merge conflict on {node_id}"),
             Self::DocImmutabilityViolated { node_id } => {
-                format!("doc-only node {node_id} violated code immutability")
+                format!("non-isolated node {node_id} violated code immutability")
             }
             Self::MissingOutputs { missing } => {
                 format!("missing declared outputs: {}", missing.join(", "))

--- a/crates/pdo-daemon/src/event_log.rs
+++ b/crates/pdo-daemon/src/event_log.rs
@@ -45,6 +45,14 @@ pub struct NodeDefInfo {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     pub node_type: String,
+    /// Where this node works (#653, ADR-0060), as the Run's pipeline snapshot
+    /// froze it: `true` ⇒ its own sub-worktree, `false` ⇒ the Run worktree.
+    /// `None` for a type that carries no isolation (`merge` is isolated by
+    /// construction; structural nodes have no worktree of their own) and for a
+    /// pre-#653 snapshot. `skip_serializing_if` keeps the wire byte-identical
+    /// when absent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub isolated_worktree: Option<bool>,
     pub view_x: Option<f64>,
     pub view_y: Option<f64>,
     pub inputs: Vec<PortBrief>,
@@ -524,6 +532,14 @@ pub struct NodeState {
     /// snapshot; `skip_serializing_if` keeps the wire byte-identical when absent.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub harness: Option<String>,
+    /// #653/ADR-0060: the isolation this NodeRun was **frozen** on at spawn,
+    /// read from the `NodeStarted` payload. This — not the current document — is
+    /// what says where the live iteration works, so editing the graph mid-run
+    /// never moves a running node between worktrees. `None` for a node that
+    /// never opened a `NodeStarted`, for a structural node, or for a pre-#653
+    /// snapshot.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub isolated_worktree: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cost: Option<NodeCost>,
     pub status: NodeStatus,
@@ -1930,6 +1946,7 @@ fn apply_node_event(state: &mut RunState, event: &Event) {
                     .entry(node_id.clone())
                     .or_insert_with(|| NodeState {
                         harness: None,
+                        isolated_worktree: None,
                         cost: None,
                         node_id: node_id.clone(),
                         status: NodeStatus::Waiting,
@@ -1966,6 +1983,7 @@ fn apply_node_event(state: &mut RunState, event: &Event) {
                     .entry(node_id.clone())
                     .or_insert_with(|| NodeState {
                         harness: None,
+                        isolated_worktree: None,
                         cost: None,
                         node_id: node_id.clone(),
                         status: NodeStatus::Running,
@@ -2004,6 +2022,18 @@ fn apply_node_event(state: &mut RunState, event: &Event) {
                     .filter(|s| !s.is_empty())
                 {
                     node.harness = Some(h.to_string());
+                }
+                // #653/ADR-0060: freeze where this NodeRun works, the same way.
+                // A re-spawn of the same iteration re-poses the frozen value
+                // rather than re-reading the (possibly edited) document, so the
+                // recovery path lands back in the working directory it left.
+                if let Some(isolated) = event
+                    .payload
+                    .as_ref()
+                    .and_then(|p| p.get("isolated_worktree"))
+                    .and_then(|v| v.as_bool())
+                {
+                    node.isolated_worktree = Some(isolated);
                 }
                 upsert_iteration(&mut node.iterations, iteration);
             }
@@ -2056,6 +2086,7 @@ fn apply_node_event(state: &mut RunState, event: &Event) {
                         node_id.clone(),
                         NodeState {
                             harness: None,
+                            isolated_worktree: None,
                             cost: None,
                             node_id: node_id.clone(),
                             status: done_status.clone(),
@@ -2175,6 +2206,7 @@ fn apply_node_event(state: &mut RunState, event: &Event) {
                     .entry(node_id.clone())
                     .or_insert_with(|| NodeState {
                         harness: None,
+                        isolated_worktree: None,
                         cost: None,
                         node_id: node_id.clone(),
                         status: NodeStatus::Interrupted,
@@ -2301,6 +2333,7 @@ fn apply_switch_event(state: &mut RunState, event: &Event) {
                 .entry(node_id.to_string())
                 .or_insert_with(|| NodeState {
                     harness: None,
+                    isolated_worktree: None,
                     cost: None,
                     node_id: node_id.to_string(),
                     status: NodeStatus::Completed,
@@ -3490,6 +3523,7 @@ mod tests {
         assert_eq!(value["harness"], "copilot");
         let bare = super::NodeState {
             harness: None,
+            isolated_worktree: None,
             cost: None,
             node_id: "x".into(),
             status: NodeStatus::Waiting,
@@ -4478,7 +4512,7 @@ mod tests {
 
     fn node_def(id: &str) -> serde_json::Value {
         serde_json::json!({
-            "id": id, "node_type": "doc-only",
+            "id": id, "node_type": "agent", "isolated_worktree": false,
             "inputs": [{"name": "task", "side": "left"}],
             "outputs": [{"name": "out", "side": "right"}]
         })
@@ -4628,7 +4662,7 @@ mod tests {
             EventKind::RunStarted,
             None,
             serde_json::json!({
-                "pipeline_name": "isolated",
+                "pipeline_name": "fan-out",
                 "input": "go",
                 "node_defs": [start_node_def(), end_node_def(), node_def("a"), node_def("b")],
                 "edges": [edge_info("start", "a"), edge_info("start", "b")],
@@ -6445,6 +6479,7 @@ mod tests {
     ) -> NodeState {
         NodeState {
             harness: None,
+            isolated_worktree: None,
             cost: None,
             node_id: id.to_string(),
             status,
@@ -7334,14 +7369,14 @@ mod tests {
             "node_defs": [
                 { "id": "start", "inputs": [], "node_type": "start", "outputs": [ { "name": "user_prompt", "side": "right" } ], "view_x": null, "view_y": null },
                 { "id": "end", "inputs": [ { "name": "result", "side": "left" } ], "node_type": "end", "outputs": [], "view_x": null, "view_y": null },
-                { "id": "planner", "inputs": [ { "name": "task", "side": "left" } ], "node_type": "doc-only", "outputs": [ { "name": "out", "side": "right" } ], "view_x": null, "view_y": null },
-                { "id": "worker", "inputs": [ { "name": "task", "side": "left" } ], "node_type": "doc-only", "outputs": [ { "name": "out", "side": "right" } ], "view_x": null, "view_y": null },
-                { "id": "auto", "inputs": [ { "name": "task", "side": "left" } ], "node_type": "doc-only", "outputs": [ { "name": "out", "side": "right" } ], "view_x": null, "view_y": null },
-                { "id": "stopped", "inputs": [ { "name": "task", "side": "left" } ], "node_type": "doc-only", "outputs": [ { "name": "out", "side": "right" } ], "view_x": null, "view_y": null },
-                { "id": "stale", "inputs": [ { "name": "task", "side": "left" } ], "node_type": "doc-only", "outputs": [ { "name": "out", "side": "right" } ], "view_x": null, "view_y": null },
-                { "id": "temp", "inputs": [ { "name": "task", "side": "left" } ], "node_type": "doc-only", "outputs": [ { "name": "out", "side": "right" } ], "view_x": null, "view_y": null },
-                { "id": "interactive", "inputs": [ { "name": "task", "side": "left" } ], "node_type": "doc-only", "outputs": [ { "name": "out", "side": "right" } ], "view_x": null, "view_y": null },
-                { "id": "sw", "inputs": [ { "name": "task", "side": "left" } ], "node_type": "doc-only", "outputs": [ { "name": "out", "side": "right" } ], "view_x": null, "view_y": null }
+                { "id": "planner", "inputs": [ { "name": "task", "side": "left" } ], "node_type": "agent", "isolated_worktree": false, "outputs": [ { "name": "out", "side": "right" } ], "view_x": null, "view_y": null },
+                { "id": "worker", "inputs": [ { "name": "task", "side": "left" } ], "node_type": "agent", "isolated_worktree": false, "outputs": [ { "name": "out", "side": "right" } ], "view_x": null, "view_y": null },
+                { "id": "auto", "inputs": [ { "name": "task", "side": "left" } ], "node_type": "agent", "isolated_worktree": false, "outputs": [ { "name": "out", "side": "right" } ], "view_x": null, "view_y": null },
+                { "id": "stopped", "inputs": [ { "name": "task", "side": "left" } ], "node_type": "agent", "isolated_worktree": false, "outputs": [ { "name": "out", "side": "right" } ], "view_x": null, "view_y": null },
+                { "id": "stale", "inputs": [ { "name": "task", "side": "left" } ], "node_type": "agent", "isolated_worktree": false, "outputs": [ { "name": "out", "side": "right" } ], "view_x": null, "view_y": null },
+                { "id": "temp", "inputs": [ { "name": "task", "side": "left" } ], "node_type": "agent", "isolated_worktree": false, "outputs": [ { "name": "out", "side": "right" } ], "view_x": null, "view_y": null },
+                { "id": "interactive", "inputs": [ { "name": "task", "side": "left" } ], "node_type": "agent", "isolated_worktree": false, "outputs": [ { "name": "out", "side": "right" } ], "view_x": null, "view_y": null },
+                { "id": "sw", "inputs": [ { "name": "task", "side": "left" } ], "node_type": "agent", "isolated_worktree": false, "outputs": [ { "name": "out", "side": "right" } ], "view_x": null, "view_y": null }
             ],
             "nodes": {
                 "auto": {

--- a/crates/pdo-daemon/src/graph_resolver.rs
+++ b/crates/pdo-daemon/src/graph_resolver.rs
@@ -394,6 +394,7 @@ mod tests {
 
     fn make_node(id: &str, node_type: NodeType, inputs: &[&str], outputs: &[&str]) -> NodeDef {
         NodeDef {
+            isolated_worktree: None,
             id: id.into(),
             name: id.into(),
             node_type,
@@ -438,6 +439,7 @@ mod tests {
 
     fn make_loop_node(id: &str, max_iter: i64) -> NodeDef {
         NodeDef {
+            isolated_worktree: None,
             id: id.into(),
             name: id.into(),
             node_type: NodeType::Loop,
@@ -564,6 +566,7 @@ mod tests {
 
     fn completed_node(id: &str) -> NodeState {
         NodeState {
+            isolated_worktree: None,
             harness: None,
             cost: None,
             node_id: id.into(),
@@ -582,6 +585,7 @@ mod tests {
 
     fn running_node(id: &str) -> NodeState {
         NodeState {
+            isolated_worktree: None,
             harness: None,
             cost: None,
             node_id: id.into(),
@@ -604,9 +608,9 @@ mod tests {
     fn ready_nodes_skips_switch() {
         let pipeline = make_pipeline(
             vec![
-                make_node("upstream", NodeType::DocOnly, &["in"], &["out"]),
+                make_node("upstream", NodeType::Agent, &["in"], &["out"]),
                 make_node("sw", NodeType::Switch, &["in"], &["pass", "default"]),
-                make_node("downstream", NodeType::DocOnly, &["in"], &["out"]),
+                make_node("downstream", NodeType::Agent, &["in"], &["out"]),
             ],
             vec![
                 make_edge("upstream", "out", "sw", "in"),
@@ -633,8 +637,8 @@ mod tests {
         // completion alone. Otherwise the guarded branch would always fire.
         let pipeline = make_pipeline(
             vec![
-                make_node("classifier", NodeType::DocOnly, &["task"], &["triage"]),
-                make_node("hotfix", NodeType::CodeMutating, &["triage"], &["patch"]),
+                make_node("classifier", NodeType::Agent, &["task"], &["triage"]),
+                make_node("hotfix", NodeType::Agent, &["triage"], &["patch"]),
             ],
             vec![make_cond_edge(
                 "classifier",
@@ -662,8 +666,8 @@ mod tests {
     fn ready_nodes_skips_target_reached_only_by_else_edge() {
         let pipeline = make_pipeline(
             vec![
-                make_node("classifier", NodeType::DocOnly, &["task"], &["triage"]),
-                make_node("backlog", NodeType::DocOnly, &["triage"], &["note"]),
+                make_node("classifier", NodeType::Agent, &["task"], &["triage"]),
+                make_node("backlog", NodeType::Agent, &["triage"], &["note"]),
             ],
             vec![make_cond_edge(
                 "classifier",
@@ -693,8 +697,8 @@ mod tests {
         // a normal entry point once that upstream completes.
         let pipeline = make_pipeline(
             vec![
-                make_node("a", NodeType::DocOnly, &["task"], &["out"]),
-                make_node("b", NodeType::DocOnly, &["in"], &["out"]),
+                make_node("a", NodeType::Agent, &["task"], &["out"]),
+                make_node("b", NodeType::Agent, &["in"], &["out"]),
             ],
             vec![make_edge("a", "out", "b", "in")],
         );
@@ -710,8 +714,8 @@ mod tests {
     fn ready_nodes_linear_chain_first_ready() {
         let pipeline = make_pipeline(
             vec![
-                make_node("planner", NodeType::DocOnly, &["task"], &["plan"]),
-                make_node("implementer", NodeType::DocOnly, &["plan"], &["summary"]),
+                make_node("planner", NodeType::Agent, &["task"], &["plan"]),
+                make_node("implementer", NodeType::Agent, &["plan"], &["summary"]),
             ],
             vec![make_edge("planner", "plan", "implementer", "plan")],
         );
@@ -725,9 +729,9 @@ mod tests {
     fn ready_nodes_fan_in_waits_for_all() {
         let pipeline = make_pipeline(
             vec![
-                make_node("a", NodeType::DocOnly, &["task"], &["out"]),
-                make_node("b", NodeType::DocOnly, &["task"], &["out"]),
-                make_node("c", NodeType::DocOnly, &["in-a", "in-b"], &["out"]),
+                make_node("a", NodeType::Agent, &["task"], &["out"]),
+                make_node("b", NodeType::Agent, &["task"], &["out"]),
+                make_node("c", NodeType::Agent, &["in-a", "in-b"], &["out"]),
             ],
             vec![
                 make_edge("a", "out", "c", "in-a"),
@@ -749,7 +753,7 @@ mod tests {
         let pipeline = make_pipeline(
             vec![
                 make_loop_node("loop1", 5),
-                make_node("worker", NodeType::DocOnly, &["in"], &["out"]),
+                make_node("worker", NodeType::Agent, &["in"], &["out"]),
             ],
             vec![make_edge("loop1", "body", "worker", "in")],
         );
@@ -765,8 +769,8 @@ mod tests {
         let pipeline = make_pipeline(
             vec![
                 make_loop_node("loop1", 5),
-                make_node("a", NodeType::DocOnly, &["in"], &["out"]),
-                make_node("b", NodeType::DocOnly, &["in"], &["out"]),
+                make_node("a", NodeType::Agent, &["in"], &["out"]),
+                make_node("b", NodeType::Agent, &["in"], &["out"]),
                 make_node("sw", NodeType::Switch, &["in"], &["pass", "default"]),
             ],
             vec![
@@ -788,7 +792,7 @@ mod tests {
             vec![
                 make_loop_node("outer", 3),
                 make_loop_node("inner", 5),
-                make_node("inner_worker", NodeType::DocOnly, &["in"], &["out"]),
+                make_node("inner_worker", NodeType::Agent, &["in"], &["out"]),
             ],
             vec![
                 make_edge("outer", "body", "inner", "in"),
@@ -824,7 +828,7 @@ mod tests {
     #[test]
     fn body_subgraph_non_loop_node_returns_error() {
         let pipeline = make_pipeline(
-            vec![make_node("a", NodeType::DocOnly, &["in"], &["out"])],
+            vec![make_node("a", NodeType::Agent, &["in"], &["out"])],
             vec![],
         );
         assert_eq!(
@@ -838,8 +842,8 @@ mod tests {
         let pipeline = make_pipeline(
             vec![
                 make_loop_node("loop1", 5),
-                make_node("a", NodeType::DocOnly, &["in"], &["out"]),
-                make_node("b", NodeType::DocOnly, &["in"], &["out"]),
+                make_node("a", NodeType::Agent, &["in"], &["out"]),
+                make_node("b", NodeType::Agent, &["in"], &["out"]),
             ],
             vec![
                 make_edge("loop1", "body", "a", "in"),
@@ -858,8 +862,8 @@ mod tests {
         let pipeline = make_pipeline(
             vec![
                 make_loop_node("loop1", 5),
-                make_node("impl", NodeType::CodeMutating, &["in"], &["out"]),
-                make_node("reviewer", NodeType::DocOnly, &["in"], &["review"]),
+                make_node("impl", NodeType::Agent, &["in"], &["out"]),
+                make_node("reviewer", NodeType::Agent, &["in"], &["review"]),
                 make_node("sw", NodeType::Switch, &["in"], &["pass", "default"]),
             ],
             vec![
@@ -885,9 +889,9 @@ mod tests {
     fn downstream_linear_chain() {
         let pipeline = make_pipeline(
             vec![
-                make_node("a", NodeType::DocOnly, &["in"], &["out"]),
-                make_node("b", NodeType::DocOnly, &["in"], &["out"]),
-                make_node("c", NodeType::DocOnly, &["in"], &["out"]),
+                make_node("a", NodeType::Agent, &["in"], &["out"]),
+                make_node("b", NodeType::Agent, &["in"], &["out"]),
+                make_node("c", NodeType::Agent, &["in"], &["out"]),
             ],
             vec![
                 make_edge("a", "out", "b", "in"),
@@ -904,10 +908,10 @@ mod tests {
     fn downstream_branching_dag() {
         let pipeline = make_pipeline(
             vec![
-                make_node("a", NodeType::DocOnly, &["in"], &["out"]),
-                make_node("b", NodeType::DocOnly, &["in"], &["out"]),
-                make_node("c", NodeType::DocOnly, &["in"], &["out"]),
-                make_node("d", NodeType::DocOnly, &["in-b", "in-c"], &["out"]),
+                make_node("a", NodeType::Agent, &["in"], &["out"]),
+                make_node("b", NodeType::Agent, &["in"], &["out"]),
+                make_node("c", NodeType::Agent, &["in"], &["out"]),
+                make_node("d", NodeType::Agent, &["in-b", "in-c"], &["out"]),
             ],
             vec![
                 make_edge("a", "out", "b", "in"),
@@ -926,8 +930,8 @@ mod tests {
     fn downstream_from_leaf_is_empty() {
         let pipeline = make_pipeline(
             vec![
-                make_node("a", NodeType::DocOnly, &["in"], &["out"]),
-                make_node("b", NodeType::DocOnly, &["in"], &["out"]),
+                make_node("a", NodeType::Agent, &["in"], &["out"]),
+                make_node("b", NodeType::Agent, &["in"], &["out"]),
             ],
             vec![make_edge("a", "out", "b", "in")],
         );
@@ -941,9 +945,9 @@ mod tests {
         let pipeline = make_pipeline(
             vec![
                 make_loop_node("loop1", 5),
-                make_node("impl", NodeType::CodeMutating, &["in"], &["out"]),
-                make_node("reviewer", NodeType::DocOnly, &["in"], &["review"]),
-                make_node("downstream", NodeType::DocOnly, &["in"], &["out"]),
+                make_node("impl", NodeType::Agent, &["in"], &["out"]),
+                make_node("reviewer", NodeType::Agent, &["in"], &["review"]),
+                make_node("downstream", NodeType::Agent, &["in"], &["out"]),
             ],
             vec![
                 make_edge("loop1", "body", "impl", "in"),
@@ -970,14 +974,9 @@ mod tests {
         // walk with the forward slice only: `end`, never `impl`.
         let pipeline = make_pipeline(
             vec![
-                make_node(
-                    "impl",
-                    NodeType::CodeMutating,
-                    &["task", "review"],
-                    &["code"],
-                ),
-                make_node("rev", NodeType::DocOnly, &["code"], &["review"]),
-                make_node("end", NodeType::DocOnly, &["result"], &[]),
+                make_node("impl", NodeType::Agent, &["task", "review"], &["code"]),
+                make_node("rev", NodeType::Agent, &["code"], &["review"]),
+                make_node("end", NodeType::Agent, &["result"], &[]),
             ],
             vec![
                 make_edge("impl", "code", "rev", "code"),     // 0
@@ -1005,14 +1004,9 @@ mod tests {
         // regardless — the excluded back-edge only ever pointed back at `impl`.
         let pipeline = make_pipeline(
             vec![
-                make_node(
-                    "impl",
-                    NodeType::CodeMutating,
-                    &["task", "review"],
-                    &["code"],
-                ),
-                make_node("rev", NodeType::DocOnly, &["code"], &["review"]),
-                make_node("end", NodeType::DocOnly, &["result"], &[]),
+                make_node("impl", NodeType::Agent, &["task", "review"], &["code"]),
+                make_node("rev", NodeType::Agent, &["code"], &["review"]),
+                make_node("end", NodeType::Agent, &["result"], &[]),
             ],
             vec![
                 make_edge("impl", "code", "rev", "code"),     // 0
@@ -1034,8 +1028,8 @@ mod tests {
             vec![
                 make_loop_node("outer", 3),
                 make_loop_node("inner", 5),
-                make_node("worker", NodeType::DocOnly, &["in"], &["out"]),
-                make_node("final", NodeType::DocOnly, &["in"], &["out"]),
+                make_node("worker", NodeType::Agent, &["in"], &["out"]),
+                make_node("final", NodeType::Agent, &["in"], &["out"]),
             ],
             vec![
                 make_edge("outer", "body", "inner", "in"),
@@ -1064,9 +1058,9 @@ mod tests {
                     &["in"],
                     &["pass", "fail", "default"],
                 ),
-                make_node("pass-handler", NodeType::DocOnly, &["in"], &["out"]),
-                make_node("fail-handler", NodeType::DocOnly, &["in"], &["out"]),
-                make_node("merge", NodeType::DocOnly, &["in-p", "in-f"], &["out"]),
+                make_node("pass-handler", NodeType::Agent, &["in"], &["out"]),
+                make_node("fail-handler", NodeType::Agent, &["in"], &["out"]),
+                make_node("merge", NodeType::Agent, &["in-p", "in-f"], &["out"]),
             ],
             vec![
                 make_edge("sw", "pass", "pass-handler", "in"),
@@ -1088,8 +1082,8 @@ mod tests {
     fn downstream_does_not_include_start_node() {
         let pipeline = make_pipeline(
             vec![
-                make_node("a", NodeType::DocOnly, &["in"], &["out"]),
-                make_node("b", NodeType::DocOnly, &["in"], &["out"]),
+                make_node("a", NodeType::Agent, &["in"], &["out"]),
+                make_node("b", NodeType::Agent, &["in"], &["out"]),
             ],
             vec![
                 make_edge("a", "out", "b", "in"),
@@ -1108,9 +1102,9 @@ mod tests {
     fn nodes_remaining_all_pending() {
         let pipeline = make_pipeline(
             vec![
-                make_node("a", NodeType::DocOnly, &["in"], &["out"]),
-                make_node("b", NodeType::DocOnly, &["in"], &["out"]),
-                make_node("c", NodeType::DocOnly, &["in"], &["out"]),
+                make_node("a", NodeType::Agent, &["in"], &["out"]),
+                make_node("b", NodeType::Agent, &["in"], &["out"]),
+                make_node("c", NodeType::Agent, &["in"], &["out"]),
             ],
             vec![
                 make_edge("a", "out", "b", "in"),
@@ -1125,9 +1119,9 @@ mod tests {
     fn nodes_remaining_partial_completion() {
         let pipeline = make_pipeline(
             vec![
-                make_node("a", NodeType::DocOnly, &["in"], &["out"]),
-                make_node("b", NodeType::DocOnly, &["in"], &["out"]),
-                make_node("c", NodeType::DocOnly, &["in"], &["out"]),
+                make_node("a", NodeType::Agent, &["in"], &["out"]),
+                make_node("b", NodeType::Agent, &["in"], &["out"]),
+                make_node("c", NodeType::Agent, &["in"], &["out"]),
             ],
             vec![
                 make_edge("a", "out", "b", "in"),
@@ -1144,8 +1138,8 @@ mod tests {
     fn nodes_remaining_running_counts_as_remaining() {
         let pipeline = make_pipeline(
             vec![
-                make_node("a", NodeType::DocOnly, &["in"], &["out"]),
-                make_node("b", NodeType::DocOnly, &["in"], &["out"]),
+                make_node("a", NodeType::Agent, &["in"], &["out"]),
+                make_node("b", NodeType::Agent, &["in"], &["out"]),
             ],
             vec![make_edge("a", "out", "b", "in")],
         );
@@ -1159,8 +1153,8 @@ mod tests {
     fn nodes_remaining_all_completed() {
         let pipeline = make_pipeline(
             vec![
-                make_node("a", NodeType::DocOnly, &["in"], &["out"]),
-                make_node("b", NodeType::DocOnly, &["in"], &["out"]),
+                make_node("a", NodeType::Agent, &["in"], &["out"]),
+                make_node("b", NodeType::Agent, &["in"], &["out"]),
             ],
             vec![make_edge("a", "out", "b", "in")],
         );
@@ -1176,7 +1170,7 @@ mod tests {
         let pipeline = make_pipeline(
             vec![
                 make_node("start", NodeType::Start, &[], &["out"]),
-                make_node("worker", NodeType::DocOnly, &["in"], &["out"]),
+                make_node("worker", NodeType::Agent, &["in"], &["out"]),
                 make_node("end", NodeType::End, &["result"], &[]),
             ],
             vec![
@@ -1193,7 +1187,7 @@ mod tests {
         let pipeline = make_pipeline(
             vec![
                 make_loop_node("loop1", 5),
-                make_node("impl", NodeType::CodeMutating, &["in"], &["out"]),
+                make_node("impl", NodeType::Agent, &["in"], &["out"]),
                 make_node("sw", NodeType::Switch, &["in"], &["pass", "default"]),
             ],
             vec![
@@ -1217,8 +1211,8 @@ mod tests {
         // implementer -> reviewer -> implementer is one cycle of two members.
         let pipeline = make_pipeline(
             vec![
-                make_node("impl", NodeType::CodeMutating, &["review"], &["code"]),
-                make_node("rev", NodeType::DocOnly, &["code"], &["review"]),
+                make_node("impl", NodeType::Agent, &["review"], &["code"]),
+                make_node("rev", NodeType::Agent, &["code"], &["review"]),
             ],
             vec![
                 make_edge("impl", "code", "rev", "code"),
@@ -1237,14 +1231,9 @@ mod tests {
         // (ADR-0011 / #148: self-edge included).
         let pipeline = make_pipeline(
             vec![
-                make_node("a", NodeType::DocOnly, &["in"], &["out"]),
-                make_node(
-                    "worker",
-                    NodeType::CodeMutating,
-                    &["seed", "again"],
-                    &["out"],
-                ),
-                make_node("b", NodeType::DocOnly, &["in"], &["out"]),
+                make_node("a", NodeType::Agent, &["in"], &["out"]),
+                make_node("worker", NodeType::Agent, &["seed", "again"], &["out"]),
+                make_node("b", NodeType::Agent, &["in"], &["out"]),
             ],
             vec![
                 make_edge("a", "out", "worker", "seed"),
@@ -1263,9 +1252,9 @@ mod tests {
         // A pure DAG has no cycles — nothing to auto-materialize.
         let pipeline = make_pipeline(
             vec![
-                make_node("a", NodeType::DocOnly, &["in"], &["out"]),
-                make_node("b", NodeType::DocOnly, &["in"], &["out"]),
-                make_node("c", NodeType::DocOnly, &["in"], &["out"]),
+                make_node("a", NodeType::Agent, &["in"], &["out"]),
+                make_node("b", NodeType::Agent, &["in"], &["out"]),
+                make_node("c", NodeType::Agent, &["in"], &["out"]),
             ],
             vec![
                 make_edge("a", "out", "b", "in"),
@@ -1283,13 +1272,8 @@ mod tests {
         let pipeline = make_pipeline(
             vec![
                 make_node("start", NodeType::Start, &[], &["user_prompt"]),
-                make_node(
-                    "impl",
-                    NodeType::CodeMutating,
-                    &["task", "review"],
-                    &["code"],
-                ),
-                make_node("rev", NodeType::DocOnly, &["code"], &["review"]),
+                make_node("impl", NodeType::Agent, &["task", "review"], &["code"]),
+                make_node("rev", NodeType::Agent, &["code"], &["review"]),
             ],
             vec![
                 make_edge("start", "user_prompt", "impl", "task"),

--- a/crates/pdo-daemon/src/input_resolution.rs
+++ b/crates/pdo-daemon/src/input_resolution.rs
@@ -203,6 +203,7 @@ mod tests {
     fn node_with_iterations(id: &str, iters: &[(i64, NodeStatus)]) -> NodeState {
         let (head_iter, head_status) = iters.last().cloned().unwrap_or((1, NodeStatus::Pending));
         NodeState {
+            isolated_worktree: None,
             harness: None,
             cost: None,
             node_id: id.to_string(),
@@ -439,6 +440,7 @@ mod tests {
 
     fn node_def(id: &str, node_type: crate::pipeline::NodeType) -> crate::pipeline::NodeDef {
         crate::pipeline::NodeDef {
+            isolated_worktree: None,
             id: id.into(),
             name: id.into(),
             node_type,
@@ -463,7 +465,7 @@ mod tests {
             variables: HashMap::new(),
             nodes: vec![
                 node_def("planner", source_type),
-                node_def("implementer", crate::pipeline::NodeType::CodeMutating),
+                node_def("implementer", crate::pipeline::NodeType::Agent),
             ],
             edges: vec![EdgeDef {
                 source: EdgeEndpoint {
@@ -511,7 +513,7 @@ mod tests {
         // latest-completed iter — no matter the consumer's own iter. This is the
         // one decision node_io_resolver used to get wrong (it read the consumer's
         // iter positionally); all three consumers now inherit this assertion.
-        let pipeline = wire_pipeline(false, crate::pipeline::NodeType::DocOnly);
+        let pipeline = wire_pipeline(false, crate::pipeline::NodeType::Agent);
         let state = state_with(vec![node_with_iterations(
             "planner",
             &[(1, NodeStatus::Failed), (2, NodeStatus::Completed)],
@@ -538,7 +540,7 @@ mod tests {
     fn resolve_consumer_inputs_repeated_pools_only_completed_iters() {
         // #353 within the unified seam: a repeated edge enumerates one concrete
         // path per COMPLETED source iter (iter-2 failed → quarantined), ascending.
-        let pipeline = wire_pipeline(true, crate::pipeline::NodeType::DocOnly);
+        let pipeline = wire_pipeline(true, crate::pipeline::NodeType::Agent);
         let state = state_with(vec![node_with_iterations(
             "planner",
             &[
@@ -585,7 +587,7 @@ mod tests {
         // Override/injection flows: nothing completed → the path points where the
         // artifact will appear (positional consumer_iter), preserving prior
         // behaviour for start_node-ahead-of-deps.
-        let pipeline = wire_pipeline(false, crate::pipeline::NodeType::DocOnly);
+        let pipeline = wire_pipeline(false, crate::pipeline::NodeType::Agent);
         let state = state_with(vec![node_with_iterations(
             "planner",
             &[(1, NodeStatus::Running)],

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -6476,6 +6476,11 @@ const KNOWN_NODE_KEYS: &[&str] = &[
     // node carrying it must not be told it is "unknown field ... (ignored)"
     // when parse_node_spec silently keeps it off the library entry.
     "agent_choice",
+    // #653/ADR-0060: where the node works. `normalize_node_value` stamps the
+    // type's default onto every `agent`/`script`, so this key is present on
+    // virtually every pasted node spec — announcing it as an ignored field would
+    // be a warning about a loss that never happens.
+    "isolated_worktree",
     // Accepted-and-dropped, not a semantic loss → no warning.
     "id",
     "view",
@@ -6538,7 +6543,7 @@ fn parse_node_spec(yaml: &str) -> Result<serde_json::Value, String> {
     }
 
     // 5. Normalize the node `type` in place — shared with `parse_pipeline`:
-    //    default/coerce to doc-only (warnings), refuse retired `for-each`.
+    //    default/coerce to non-isolated (warnings), refuse retired `for-each`.
     let mut warnings: Vec<String> = pipeline::normalize_node_value(&mut value)
         .map_err(|e| format!("{e}"))?
         .into_iter()
@@ -6589,6 +6594,15 @@ fn parse_node_spec(yaml: &str) -> Result<serde_json::Value, String> {
         .get("agent_choice")
         .map(yaml_value_to_json)
         .unwrap_or(serde_json::Value::Null);
+    // #653/ADR-0060: where the pasted node works. `normalize_node_value` above
+    // already stamped the type's default onto an `agent`/`script` that said
+    // nothing, so this is never a guess — and reading it here is what keeps a
+    // node that opted out of isolation from silently forking one on instantiation
+    // (the silent loss ADR-0001/#268 forbid). `null` for the types that carry no
+    // isolation, which the canvas then leaves off the node.
+    let isolated_worktree = value
+        .get(pipeline::ISOLATED_WORKTREE_KEY)
+        .and_then(serde_yaml::Value::as_bool);
 
     // 8. Deserialize the (normalized) map into a LibraryEntry. `prompt` defaults
     //    to empty (a structural node carries none); unknown fields are ignored.
@@ -6610,6 +6624,8 @@ fn parse_node_spec(yaml: &str) -> Result<serde_json::Value, String> {
             "harnesses": harnesses,
             // #563: the node's agent-profile choice, carried verbatim.
             "agent_choice": agent_choice,
+            // #653: where the node works.
+            "isolated_worktree": isolated_worktree,
             "max_iter": entry.max_iter,
             "branches": entry.branches,
         },
@@ -11658,10 +11674,9 @@ async fn run_stale_detection(state: &Arc<AppState>) {
 
         let running = stale_detector::running_nodes(&run_state);
         for (node_id, iter) in &running {
-            let node_type = find_node_type(&run_state, node_id);
-            let is_cm = matches!(node_type, Some("code-mutating") | Some("merge"));
-
-            let working_dir = if is_cm {
+            // #653/ADR-0060: the sweep probes where the NodeRun actually works —
+            // its frozen isolation, not a type that no longer implies a directory.
+            let working_dir = if node_run_isolation(&events, &run_state, node_id, *iter) {
                 sub_worktree_path(&repo_root, run_id, node_id, *iter)
             } else {
                 worktree_dir.clone()
@@ -11766,7 +11781,7 @@ async fn run_stale_detection(state: &Arc<AppState>) {
                 stale_detector::Detection::TurnEnded => {
                     // #469 §3: complete through the SAME body `POST …/done`
                     // runs, not by appending a terminal event here. On a
-                    // `code-mutating`/`merge` node a bare append would record a
+                    // isolated node a bare append would record a
                     // `Completed` whose commit stayed on `pdo/sub-…`, leaving the
                     // downstream with nothing — the exact defect of the old
                     // observe-only design's `Act` half.
@@ -12129,14 +12144,21 @@ pub(crate) async fn reattach_node_session(
     iter: i64,
     session_name: &str,
 ) -> ReattachOutcome {
-    let node_type = find_node_type(run_state, node_id).unwrap_or("doc-only");
+    let node_type = find_node_type(run_state, node_id).unwrap_or("agent");
     // #248 / ADR-0017: never resume a `script` node via `claude --continue`.
     if node_type == "script" {
         return ReattachOutcome::ScriptNode;
     }
 
-    let working_dir =
-        tmux_session_manager::working_dir_for_node(repo_root, run_id, node_id, iter, node_type);
+    // #653: the FROZEN isolation of this iteration — re-attaching has to open the
+    // directory the session actually runs in, not the one the document now names.
+    let working_dir = tmux_session_manager::working_dir_for_node(
+        repo_root,
+        run_id,
+        node_id,
+        iter,
+        node_run_isolation(events, run_state, node_id, iter),
+    );
     if !working_dir.exists() {
         return ReattachOutcome::WorkingDirMissing;
     }
@@ -12553,6 +12575,38 @@ fn find_node_type<'a>(run_state: &'a event_log::RunState, node_id: &str) -> Opti
         .map(|nd| nd.node_type.as_str())
 }
 
+/// Where a node works according to the Run's **pipeline snapshot** (#653,
+/// ADR-0060) — the answer for an iteration that has not started, and the
+/// fallback for one whose events predate #653.
+///
+/// A snapshot that states the isolation is authoritative. Absent it, the type's
+/// default stands in: `merge` is isolated by construction, an `agent` is
+/// isolated, a `script` shares the Run worktree, and a structural node has no
+/// worktree of its own.
+fn snapshot_isolation(run_state: &event_log::RunState, node_id: &str) -> bool {
+    let Some(def) = run_state.node_defs.iter().find(|nd| nd.id == node_id) else {
+        return false;
+    };
+    def.isolated_worktree
+        .unwrap_or(matches!(def.node_type.as_str(), "merge" | "agent"))
+}
+
+/// Where a node's iteration `iter` works (#653, ADR-0060): its FROZEN answer
+/// when it has one, the Run snapshot's otherwise.
+///
+/// Every reader that has the event log on hand goes through here, so a node that
+/// started isolated is still read as isolated after someone edits the document
+/// mid-run — the freeze is a property of the NodeRun, not of the file.
+fn node_run_isolation(
+    events: &[event_log::Event],
+    run_state: &event_log::RunState,
+    node_id: &str,
+    iter: i64,
+) -> bool {
+    merge_action::frozen_isolation(events, node_id, iter)
+        .unwrap_or_else(|| snapshot_isolation(run_state, node_id))
+}
+
 async fn node_prompt(
     State(state): State<Arc<AppState>>,
     AxumPath((run_id, node_id)): AxumPath<(String, String)>,
@@ -12570,9 +12624,16 @@ async fn node_prompt(
     }
 
     let repo_root = effective_repo_root(&state, &run_state);
-    let node_type = find_node_type(&run_state, &node_id).unwrap_or("doc-only");
-    let working_dir =
-        tmux_session_manager::working_dir_for_node(&repo_root, &run_id, &node_id, iter, node_type);
+    let working_dir = tmux_session_manager::working_dir_for_node(
+        &repo_root,
+        &run_id,
+        &node_id,
+        iter,
+        // #653: the prompt file lives wherever the NodeRun works. Read from the
+        // snapshot: this endpoint holds no event log, and a started iteration's
+        // frozen value equals it unless the document was edited mid-run.
+        snapshot_isolation(&run_state, &node_id),
+    );
 
     let prompt_path = working_dir
         .join(".pdo")
@@ -13136,7 +13197,7 @@ impl CompletionAttempt {
 /// The whole body lives in that shared function since #469 §3, because the
 /// liveness sweep's turn-end auto-completion must take the *same* path: the
 /// forgotten-run refusal (#328), the completion guard (#212/#354), the
-/// sub-worktree commit+merge, the doc-only cleanliness check, output validation,
+/// sub-worktree commit+merge, the non-isolated cleanliness check, output validation,
 /// the terminal append, then the detached reap+advance tail (#304/ADR-0023).
 async fn node_done(
     State(state): State<Arc<AppState>>,
@@ -13336,7 +13397,7 @@ async fn complete_node_iteration(
     let worktree_dir = worktree_dir_for_run(&repo_root, &run_id);
 
     // Transition guard (#212, #354): validate the completion against the
-    // projected state BEFORE any side effect (sub-worktree merge, doc-only
+    // projected state BEFORE any side effect (sub-worktree merge, non-isolated
     // cleanliness check, output validation, downstream dispatch). A duplicate
     // completion is a no-op — it must not merge again nor re-trigger downstream
     // spawns. The pure decision lives in the shared head.
@@ -13369,8 +13430,12 @@ async fn complete_node_iteration(
         return CompletionAttempt::refused(refusal);
     }
 
-    match find_node_type(&pre_run_state, &node_id) {
-        Some("code-mutating") | Some("merge") => {
+    // #653/ADR-0060: the completion path branches on where the NodeRun WORKED,
+    // read from its frozen isolation — not on a type that no longer implies a
+    // working directory. An isolated NodeRun merges its sub-worktree back; a
+    // non-isolated one is held to the shared worktree's cleanliness contract.
+    match node_run_isolation(&events, &pre_run_state, &node_id, iter) {
+        true => {
             let sub_wt_dir = sub_worktree_path(&repo_root, &run_id, &node_id, iter);
             let sub_branch = sub_worktree_branch(&run_id, &node_id, iter);
 
@@ -13531,12 +13596,13 @@ async fn complete_node_iteration(
                 }
             }
         }
-        // A `script` node (#248 / ADR-0017) is doc-only-effect in v1: like a
-        // doc-only node it runs in the run's shared worktree and must leave
-        // tracked files clean (untracked artifacts are fine — the guard ignores
-        // `??`). The sharp-tool caveat (a script that `git commit`s leaves a
-        // clean tree and passes) is documented in ADR-0017.
-        Some("doc-only") | Some("script") => match worktree_has_tracked_changes(&worktree_dir) {
+        // A non-isolated agent or script runs in the Run's shared worktree and
+        // must leave tracked files clean (untracked artifacts are fine — the
+        // guard ignores `??`). The sharp-tool caveat (a node that `git commit`s
+        // leaves a clean tree and passes) is documented in ADR-0017. #654 turns
+        // this refusal into an in-place delivery; until then a shared worktree
+        // keeps the contract it had.
+        false => match worktree_has_tracked_changes(&worktree_dir) {
             Ok(true) => {
                 // ADR-0049: a completion refusal is a runtime give-up, not a
                 // deliberate failure — `Interrupted`, never `Failed`. The run
@@ -13551,7 +13617,7 @@ async fn complete_node_iteration(
                     iter: Some(iter),
                     payload: Some(serde_json::json!({
                         "reason": format!(
-                            "doc_violated_code_immutability: doc-only node {node_id} \
+                            "doc_violated_code_immutability: non-isolated node {node_id} \
                              violated code immutability (modified tracked files)"
                         ),
                         "reason_code": "doc_violated_code_immutability",
@@ -13559,7 +13625,7 @@ async fn complete_node_iteration(
                 };
                 let _ = append_event(state, &interrupt_event).await;
 
-                warn!("Doc-only node {node_id} modified tracked files in run {run_id}");
+                warn!("Non-isolated node {node_id} modified tracked files in run {run_id}");
                 // Same leak as the merge-conflict path (#503 AC5): this refusal
                 // parks the Run, so the node's session has nothing left to do.
                 reap_dead_node_after_run_failure(
@@ -13581,7 +13647,6 @@ async fn complete_node_iteration(
                 warn!("Could not check worktree cleanliness for {node_id}: {e}");
             }
         },
-        _ => {}
     }
 
     let pipeline_path =
@@ -16911,16 +16976,11 @@ fn node_def_from_pipeline(n: &pipeline::NodeDef) -> event_log::NodeDefInfo {
     event_log::NodeDefInfo {
         id: n.id.clone(),
         name: Some(n.name.clone()),
-        node_type: match n.node_type {
-            pipeline::NodeType::DocOnly => "doc-only".into(),
-            pipeline::NodeType::CodeMutating => "code-mutating".into(),
-            pipeline::NodeType::Start => "start".into(),
-            pipeline::NodeType::End => "end".into(),
-            pipeline::NodeType::Switch => "switch".into(),
-            pipeline::NodeType::Loop => "loop".into(),
-            pipeline::NodeType::Merge => "merge".into(),
-            pipeline::NodeType::Script => "script".into(),
-        },
+        node_type: n.node_type.as_str().into(),
+        // #653/ADR-0060: the isolation the Run's snapshot froze for this node —
+        // what the completion path reads back to know whether a sub-worktree has
+        // to be merged, without re-deriving it from a type that no longer says.
+        isolated_worktree: n.isolated_worktree,
         view_x: n.view.as_ref().map(|v| v.x),
         view_y: n.view.as_ref().map(|v| v.y),
         inputs: n.inputs.iter().map(|p| port_brief(p, "left")).collect(),
@@ -17386,7 +17446,7 @@ fn short(sha: &str) -> &str {
 /// Reap the session of a node whose completion just killed the Run (#503 AC5).
 ///
 /// Called from the refusal paths that append `RunFailed` — a merge-back conflict
-/// and a doc-only immutability violation. Those return a refusal *to a
+/// and a non-isolated immutability violation. Those return a refusal *to a
 /// `pdo complete` running inside the very session being killed*, so the kill has
 /// to outlive this request: detached, exactly like `node_done`'s reap (#304,
 /// ADR-0023), or the response never reaches the CLI and #490's exit codes lose
@@ -17663,19 +17723,46 @@ mod tests {
     fn parse_node_spec_happy_path_library_shape() {
         // Exactly what the front export emits (LibraryEntry shape) → no warnings.
         let body = parse_node_spec(
-            "name: Writer\ntype: doc-only\noutputs:\n  - name: adr\nprompt: |\n  Write an ADR.\n",
+            "name: Writer\ntype: agent\nisolated_worktree: false\noutputs:\n  - name: adr\nprompt: |\n  Write an ADR.\n",
         )
         .unwrap();
-        assert_eq!(body["spec"]["type"], "doc-only");
+        assert_eq!(body["spec"]["type"], "agent");
         assert_eq!(body["spec"]["name"], "Writer");
         assert_eq!(body["spec"]["outputs"][0]["name"], "adr");
+        // #653: the pasted node's opt-out of isolation rides through — dropping
+        // it would silently fork a sub-worktree on instantiation.
+        assert_eq!(body["spec"]["isolated_worktree"], false);
         assert_eq!(body["prompt"], "Write an ADR.\n");
         assert_eq!(body["warnings"].as_array().unwrap().len(), 0);
     }
 
+    /// #653 / ADR-0060: a node pasted with no isolation line gets its type's
+    /// default stamped and states it in the spec — the canvas never has to
+    /// re-derive it. A type that carries no isolation reports `null`.
+    #[test]
+    fn parse_node_spec_states_the_isolation_for_every_node() {
+        for (yaml, expected) in [
+            ("name: n\ntype: agent\n", serde_json::json!(true)),
+            ("name: n\ntype: script\n", serde_json::json!(false)),
+            (
+                "name: n\ntype: agent\nisolated_worktree: false\n",
+                serde_json::json!(false),
+            ),
+            ("name: n\ntype: start\n", serde_json::Value::Null),
+        ] {
+            let body = parse_node_spec(yaml).unwrap();
+            assert_eq!(body["spec"]["isolated_worktree"], expected, "{yaml}");
+            assert_eq!(
+                body["warnings"].as_array().unwrap().len(),
+                0,
+                "the stamped default is not a loss to warn about: {yaml}"
+            );
+        }
+    }
+
     #[test]
     fn parse_node_spec_missing_name_is_hard_error() {
-        let err = parse_node_spec("type: doc-only\n").unwrap_err();
+        let err = parse_node_spec("type: agent\n").unwrap_err();
         assert!(err.contains("name"), "{err}");
     }
 
@@ -17711,9 +17798,9 @@ mod tests {
     }
 
     #[test]
-    fn parse_node_spec_missing_type_defaults_doc_only_with_warning() {
+    fn parse_node_spec_missing_type_defaults_agent_with_warning() {
         let body = parse_node_spec("name: n\n").unwrap();
-        assert_eq!(body["spec"]["type"], "doc-only");
+        assert_eq!(body["spec"]["type"], "agent");
         let ws = body["warnings"].as_array().unwrap();
         assert!(
             ws.iter()
@@ -17723,9 +17810,9 @@ mod tests {
     }
 
     #[test]
-    fn parse_node_spec_unknown_type_coerces_doc_only_with_warning() {
+    fn parse_node_spec_unknown_type_coerces_agent_with_warning() {
         let body = parse_node_spec("name: n\ntype: bogus\n").unwrap();
-        assert_eq!(body["spec"]["type"], "doc-only");
+        assert_eq!(body["spec"]["type"], "agent");
         let ws = body["warnings"].as_array().unwrap();
         assert!(
             ws.iter()
@@ -17736,7 +17823,7 @@ mod tests {
 
     #[test]
     fn parse_node_spec_legacy_types_kept_verbatim() {
-        // Legacy switch/loop are NOT coerced to doc-only (silent semantic loss is
+        // Legacy switch/loop are NOT coerced to `agent` (silent semantic loss is
         // forbidden, ADR-0001/#268) — imported as-is (a soft warning is fine).
         for t in ["switch", "loop"] {
             let body = parse_node_spec(&format!("name: n\ntype: {t}\n")).unwrap();
@@ -17746,8 +17833,9 @@ mod tests {
 
     #[test]
     fn parse_node_spec_unknown_field_warns_but_still_parses() {
-        let body = parse_node_spec("name: n\ntype: doc-only\nwidget: 3\n").unwrap();
-        assert_eq!(body["spec"]["type"], "doc-only");
+        let body =
+            parse_node_spec("name: n\ntype: agent\nisolated_worktree: false\nwidget: 3\n").unwrap();
+        assert_eq!(body["spec"]["type"], "agent");
         let ws = body["warnings"].as_array().unwrap();
         assert!(
             ws.iter()
@@ -17759,18 +17847,21 @@ mod tests {
     #[test]
     fn parse_node_spec_drops_id_and_view_without_warning() {
         // id is regenerated on add, view re-centred — dropping them is not a loss.
-        let body = parse_node_spec("name: n\ntype: doc-only\nid: keepme\nview:\n  x: 1\n  y: 2\n")
-            .unwrap();
+        let body = parse_node_spec(
+            "name: n\ntype: agent\nisolated_worktree: false\nid: keepme\nview:\n  x: 1\n  y: 2\n",
+        )
+        .unwrap();
         assert_eq!(body["warnings"].as_array().unwrap().len(), 0);
         assert!(body["spec"].get("id").is_none());
     }
 
     #[test]
     fn parse_node_spec_model_round_trips() {
-        let body = parse_node_spec("name: n\ntype: code-mutating\nmodel: opus\n").unwrap();
+        let body = parse_node_spec("name: n\ntype: agent\nisolated_worktree: true\nmodel: opus\n")
+            .unwrap();
         assert_eq!(body["spec"]["model"], "opus");
         // A node on the account default omits `model:` → null in the spec.
-        let plain = parse_node_spec("name: n\ntype: doc-only\n").unwrap();
+        let plain = parse_node_spec("name: n\ntype: agent\nisolated_worktree: false\n").unwrap();
         assert!(plain["spec"]["model"].is_null());
     }
 
@@ -17797,7 +17888,7 @@ mod tests {
             ev(
                 "legacy",
                 1,
-                Some(serde_json::json!({"node_type": "doc-only"})),
+                Some(serde_json::json!({"node_type": "agent", "isolated_worktree": false})),
             ),
             // Guard-probe shape (never appended in production, but harmless here).
             ev("nopayload", 1, None),
@@ -17844,8 +17935,10 @@ mod tests {
         // #424: the only test that catches the `json!` spec in `parse_node_spec`
         // dropping the effort — the macro compiles perfectly without the key, so
         // *Add node from YAML…* would silently create an effort-less node.
-        let body =
-            parse_node_spec("name: n\ntype: code-mutating\nmodel: opus\neffort: low\n").unwrap();
+        let body = parse_node_spec(
+            "name: n\ntype: agent\nisolated_worktree: true\nmodel: opus\neffort: low\n",
+        )
+        .unwrap();
         assert_eq!(body["spec"]["effort"], "low");
         assert_eq!(body["spec"]["model"], "opus");
         // …and `effort` is a KNOWN node key: a YAML that parses fine must NOT be
@@ -17858,7 +17951,7 @@ mod tests {
             body["warnings"]
         );
         // A node on the account default omits `effort:` → null in the spec.
-        let plain = parse_node_spec("name: n\ntype: doc-only\n").unwrap();
+        let plain = parse_node_spec("name: n\ntype: agent\nisolated_worktree: false\n").unwrap();
         assert!(plain["spec"]["effort"].is_null());
     }
 
@@ -17867,14 +17960,16 @@ mod tests {
         // #424: the wire is free-text. A level the curated UI set does not know
         // must reach the spec verbatim, not be dropped or coerced (the picker
         // renders it in a dedicated pass-through segment).
-        let body = parse_node_spec("name: n\ntype: doc-only\neffort: turbo\n").unwrap();
+        let body =
+            parse_node_spec("name: n\ntype: agent\nisolated_worktree: false\neffort: turbo\n")
+                .unwrap();
         assert_eq!(body["spec"]["effort"], "turbo");
         assert_eq!(body["warnings"].as_array().unwrap().len(), 0);
     }
 
     #[test]
     fn parse_node_spec_prompt_absent_defaults_empty() {
-        let body = parse_node_spec("name: n\ntype: doc-only\n").unwrap();
+        let body = parse_node_spec("name: n\ntype: agent\nisolated_worktree: false\n").unwrap();
         assert_eq!(body["prompt"], "");
     }
 
@@ -17889,7 +17984,7 @@ mod tests {
                     .header("content-type", "application/json")
                     .body(Body::from(
                         serde_json::to_string(&serde_json::json!({
-                            "yaml": "name: n\ntype: doc-only\nprompt: |\n  hi\n"
+                            "yaml": "name: n\ntype: agent\nisolated_worktree: false\nprompt: |\n  hi\n"
                         }))
                         .unwrap(),
                     ))
@@ -17904,7 +17999,7 @@ mod tests {
                 .unwrap(),
         )
         .unwrap();
-        assert_eq!(body["spec"]["type"], "doc-only");
+        assert_eq!(body["spec"]["type"], "agent");
         assert_eq!(body["prompt"], "hi\n");
     }
 
@@ -17918,7 +18013,7 @@ mod tests {
                     .uri("/nodes/parse")
                     .header("content-type", "application/json")
                     .body(Body::from(
-                        serde_json::to_string(&serde_json::json!({ "yaml": "type: doc-only\n" }))
+                        serde_json::to_string(&serde_json::json!({ "yaml": "type: agent\n" }))
                             .unwrap(),
                     ))
                     .unwrap(),
@@ -18143,7 +18238,7 @@ mod tests {
             Some(serde_json::json!({
                 "pipeline_id": "p-out",
                 "pipeline_name": "Outside",
-                "node_defs": [{"id":"worker","name":"Outside worker","node_type":"doc-only"}]
+                "node_defs": [{"id":"worker","name":"Outside worker","node_type":"agent", "isolated_worktree":false}]
             })),
         )
         .await;
@@ -18153,7 +18248,7 @@ mod tests {
             "node_started",
             Some("worker"),
             Some(1),
-            Some(serde_json::json!({"node_type":"doc-only","harness":"claude"})),
+            Some(serde_json::json!({"node_type":"agent", "isolated_worktree":false,"harness":"claude"})),
         )
         .await;
 
@@ -18168,17 +18263,17 @@ mod tests {
                 "pipeline_name": "Pipeline old",
                 "target_repo": "/repos/product",
                 "node_defs": [
-                    {"id":"worker","name":"Worker old","node_type":"doc-only"},
+                    {"id":"worker","name":"Worker old","node_type":"agent", "isolated_worktree":false},
                     {"id":"build","name":"Build","node_type":"script"}
                 ]
             })),
         )
         .await;
         for (harness, node_type, session_id) in [
-            (None, "doc-only", None),
-            (Some("copilot"), "doc-only", Some("copilot-resurrected")),
-            (Some("copilot"), "doc-only", Some("copilot-resurrected")),
-            (Some("copilot"), "doc-only", Some("copilot-restart")),
+            (None, "agent", None),
+            (Some("copilot"), "agent", Some("copilot-resurrected")),
+            (Some("copilot"), "agent", Some("copilot-resurrected")),
+            (Some("copilot"), "agent", Some("copilot-restart")),
             (None, "script", None),
         ] {
             insert(
@@ -18210,7 +18305,7 @@ mod tests {
                 "pipeline_id": "p1",
                 "pipeline_name": "Pipeline latest",
                 "target_repo": "/repos/product",
-                "node_defs": [{"id":"worker","name":"Worker latest","node_type":"doc-only"}]
+                "node_defs": [{"id":"worker","name":"Worker latest","node_type":"agent", "isolated_worktree":false}]
             })),
         )
         .await;
@@ -18222,7 +18317,7 @@ mod tests {
                 Some("worker"),
                 Some(iter),
                 Some(serde_json::json!({
-                    "node_type":"doc-only",
+                    "node_type":"agent", "isolated_worktree":false,
                     "harness":"future-harness",
                     "session_id":session_id
                 })),
@@ -18374,7 +18469,7 @@ mod tests {
                     "pipeline_name":format!("Pipeline {}", index + 1),
                     "target_repo":repo,
                     "harness":"claude",
-                    "node_defs":[{"id":"worker","name":format!("Worker {}", index + 1),"node_type":"code-mutating"}]
+                    "node_defs":[{"id":"worker","name":format!("Worker {}", index + 1),"node_type":"agent", "isolated_worktree":true}]
                 }),
             )
             .await;
@@ -18386,7 +18481,7 @@ mod tests {
             "node_started",
             Some("worker"),
             Some(1),
-            serde_json::json!({"node_type":"code-mutating","harness":"claude","session_id":"claude-1"}),
+            serde_json::json!({"node_type":"agent", "isolated_worktree":true,"harness":"claude","session_id":"claude-1"}),
         )
         .await;
         insert_event(
@@ -18396,7 +18491,7 @@ mod tests {
             "node_started",
             Some("worker"),
             Some(1),
-            serde_json::json!({"node_type":"code-mutating","harness":"copilot","session_id":"copilot-1"}),
+            serde_json::json!({"node_type":"agent", "isolated_worktree":true,"harness":"copilot","session_id":"copilot-1"}),
         )
         .await;
         insert_event(
@@ -18406,7 +18501,7 @@ mod tests {
             "node_started",
             Some("worker"),
             Some(2),
-            serde_json::json!({"node_type":"code-mutating","harness":"future-harness","session_id":"future-1"}),
+            serde_json::json!({"node_type":"agent", "isolated_worktree":true,"harness":"future-harness","session_id":"future-1"}),
         )
         .await;
         insert_event(
@@ -18416,7 +18511,7 @@ mod tests {
             "node_started",
             Some("worker"),
             Some(1),
-            serde_json::json!({"node_type":"code-mutating","harness":"future-harness","session_id":"future-2"}),
+            serde_json::json!({"node_type":"agent", "isolated_worktree":true,"harness":"future-harness","session_id":"future-2"}),
         )
         .await;
         insert_event(
@@ -18426,7 +18521,7 @@ mod tests {
             "node_started",
             Some("worker"),
             Some(1),
-            serde_json::json!({"node_type":"doc-only"}),
+            serde_json::json!({"node_type":"agent", "isolated_worktree":false}),
         )
         .await;
 
@@ -18644,7 +18739,7 @@ mod tests {
             serde_json::json!({
                 "pipeline_id":"p1","pipeline_name":"Loop V1","target_repo":repo,"harness":"claude",
                 "node_defs":[
-                    {"id":"worker","name":"Worker V1","node_type":"code-mutating"},
+                    {"id":"worker","name":"Worker V1","node_type":"agent", "isolated_worktree":true},
                     {"id":"build","name":"Build","node_type":"script"}
                 ]
             }),
@@ -18659,7 +18754,7 @@ mod tests {
             None,
             serde_json::json!({
                 "pipeline_id":"p1","pipeline_name":"Loop V2","target_repo":repo,"harness":"copilot",
-                "node_defs":[{"id":"worker","name":"Worker V2","node_type":"code-mutating"}]
+                "node_defs":[{"id":"worker","name":"Worker V2","node_type":"agent", "isolated_worktree":true}]
             }),
         )
         .await;
@@ -18672,7 +18767,7 @@ mod tests {
             None,
             serde_json::json!({
                 "pipeline_id":"p2","pipeline_name":"Other pipeline","target_repo":repo,"harness":"claude",
-                "node_defs":[{"id":"solo","name":"Solo","node_type":"code-mutating"}]
+                "node_defs":[{"id":"solo","name":"Solo","node_type":"agent", "isolated_worktree":true}]
             }),
         )
         .await;
@@ -18696,7 +18791,7 @@ mod tests {
         insert_event(
             &state.db, "perf-r1", "2026-07-15T09:10:00Z", "node_started",
             Some("worker"), Some(1),
-            serde_json::json!({"node_type":"code-mutating","harness":"claude","session_id":"claude-1"}),
+            serde_json::json!({"node_type":"agent", "isolated_worktree":true,"harness":"claude","session_id":"claude-1"}),
         ).await;
         insert_event(
             &state.db,
@@ -18711,7 +18806,7 @@ mod tests {
         insert_event(
             &state.db, "perf-r1", "2026-07-15T09:30:00Z", "node_started",
             Some("worker"), Some(2),
-            serde_json::json!({"node_type":"code-mutating","harness":"claude","session_id":"claude-2"}),
+            serde_json::json!({"node_type":"agent", "isolated_worktree":true,"harness":"claude","session_id":"claude-2"}),
         ).await;
         insert_event(
             &state.db,
@@ -18726,7 +18821,7 @@ mod tests {
         insert_event(
             &state.db, "perf-r1", "2026-07-15T09:40:00Z", "node_started",
             Some("worker"), Some(3),
-            serde_json::json!({"node_type":"code-mutating","harness":"claude","session_id":"claude-3"}),
+            serde_json::json!({"node_type":"agent", "isolated_worktree":true,"harness":"claude","session_id":"claude-3"}),
         ).await;
         insert_event(
             &state.db,
@@ -18741,7 +18836,7 @@ mod tests {
         insert_event(
             &state.db, "perf-r1", "2026-07-15T09:45:00Z", "node_started",
             Some("worker"), Some(3),
-            serde_json::json!({"node_type":"code-mutating","harness":"claude","session_id":"claude-3b"}),
+            serde_json::json!({"node_type":"agent", "isolated_worktree":true,"harness":"claude","session_id":"claude-3b"}),
         ).await;
         insert_event(
             &state.db,
@@ -18756,7 +18851,7 @@ mod tests {
         insert_event(
             &state.db, "perf-r1", "2026-07-15T10:00:00Z", "node_started",
             Some("worker"), Some(4),
-            serde_json::json!({"node_type":"code-mutating","harness":"future-harness","session_id":"future-1"}),
+            serde_json::json!({"node_type":"agent", "isolated_worktree":true,"harness":"future-harness","session_id":"future-1"}),
         ).await;
         insert_event(
             &state.db,
@@ -18847,7 +18942,7 @@ mod tests {
         insert_event(
             &state.db, "perf-r2", "2026-07-16T09:10:00Z", "node_started",
             Some("worker"), Some(1),
-            serde_json::json!({"node_type":"code-mutating","harness":"copilot","session_id":"copilot-1"}),
+            serde_json::json!({"node_type":"agent", "isolated_worktree":true,"harness":"copilot","session_id":"copilot-1"}),
         ).await;
         insert_event(
             &state.db,
@@ -18865,7 +18960,7 @@ mod tests {
         insert_event(
             &state.db, "perf-r3", "2026-07-17T09:10:00Z", "node_started",
             Some("solo"), Some(1),
-            serde_json::json!({"node_type":"code-mutating","harness":"claude","session_id":"claude-solo"}),
+            serde_json::json!({"node_type":"agent", "isolated_worktree":true,"harness":"claude","session_id":"claude-solo"}),
         ).await;
         insert_event(
             &state.db,
@@ -18928,7 +19023,7 @@ mod tests {
 
         // --- Infrastructure subagents (#585 user story #36): a Pipeline
         // Manager session left in the Run's own top-level worktree (never
-        // colliding with a code-mutating Node's disjoint sub-worktree) and a
+        // colliding with an isolated Node's disjoint sub-worktree) and a
         // Merge resolver session left in the conflicting Node's own
         // iter-3 worktree, alongside (and excluded from) that Node's own
         // "claude-3b" session — resolved by exclusion, never by path alone.
@@ -19235,7 +19330,7 @@ mod tests {
 
     /// `GET /stats/performance` (#585, user story #36) — an Infrastructure
     /// role's own session is never guessed at by path or timing alone: a
-    /// non-code-mutating Claude Node sharing the Pipeline Manager's top-level
+    /// non-isolated Claude Node sharing the Pipeline Manager's top-level
     /// worktree, with no recorded `session_id`, makes that directory's
     /// residual session ambiguous — Context (and its subagents) stays a
     /// motivated absence rather than an unsafe guess, while Duration (paired
@@ -19295,11 +19390,11 @@ mod tests {
             None,
             serde_json::json!({
                 "pipeline_id":"amb","pipeline_name":"Ambiguous","target_repo":repo,"harness":"claude",
-                "node_defs":[{"id":"docs","name":"Docs","node_type":"doc-only"}]
+                "node_defs":[{"id":"docs","name":"Docs","node_type":"agent", "isolated_worktree":false}]
             }),
         )
         .await;
-        // A non-code-mutating (so it shares the Run's top-level worktree)
+        // A non-isolated (so it shares the Run's top-level worktree)
         // Claude Node with no recorded `session_id` — the directory can no
         // longer be trusted to hold only the Pipeline Manager's own session.
         insert_event(
@@ -19309,7 +19404,7 @@ mod tests {
             "node_started",
             Some("docs"),
             Some(1),
-            serde_json::json!({"node_type":"doc-only","harness":"claude"}),
+            serde_json::json!({"node_type":"agent", "isolated_worktree":false,"harness":"claude"}),
         )
         .await;
         insert_event(
@@ -19428,7 +19523,7 @@ mod tests {
         .bind(
             serde_json::json!({
                 "pipeline_id":"p1","pipeline_name":"Loop","target_repo":repo,"harness":"copilot",
-                "node_defs":[{"id":"worker","name":"Worker","node_type":"code-mutating"}]
+                "node_defs":[{"id":"worker","name":"Worker","node_type":"agent", "isolated_worktree":true}]
             })
             .to_string(),
         )
@@ -19440,7 +19535,7 @@ mod tests {
              ('perf-cs1', '2026-08-01T09:10:00Z', 'node_started', 'worker', 1, ?)",
         )
         .bind(
-            serde_json::json!({"node_type":"code-mutating","harness":"copilot","session_id":"copilot-cs1"})
+            serde_json::json!({"node_type":"agent", "isolated_worktree":true,"harness":"copilot","session_id":"copilot-cs1"})
                 .to_string(),
         )
         .execute(&state.db)
@@ -19569,14 +19664,14 @@ mod tests {
             None,
             serde_json::json!({
                 "pipeline_id":"cp1","pipeline_name":"Cache Pipeline","target_repo":repo,"harness":"claude",
-                "node_defs":[{"id":"worker","name":"Worker","node_type":"code-mutating"}]
+                "node_defs":[{"id":"worker","name":"Worker","node_type":"agent", "isolated_worktree":true}]
             }),
         )
         .await;
         insert_event(
             &state.db, "cache-r1", "2031-01-15T09:10:00Z", "node_started",
             Some("worker"), Some(1),
-            serde_json::json!({"node_type":"code-mutating","harness":"claude","session_id":"cache-1"}),
+            serde_json::json!({"node_type":"agent", "isolated_worktree":true,"harness":"claude","session_id":"cache-1"}),
         )
         .await;
         insert_event(
@@ -19711,14 +19806,14 @@ mod tests {
             None,
             serde_json::json!({
                 "pipeline_id":"cip1","pipeline_name":"Cache Invalidation Pipeline","target_repo":repo,"harness":"claude",
-                "node_defs":[{"id":"worker","name":"Worker","node_type":"code-mutating"}]
+                "node_defs":[{"id":"worker","name":"Worker","node_type":"agent", "isolated_worktree":true}]
             }),
         )
         .await;
         insert_event(
             &state.db, "cache-i1", "2031-02-15T09:10:00Z", "node_started",
             Some("worker"), Some(1),
-            serde_json::json!({"node_type":"code-mutating","harness":"claude","session_id":"cache-i-1"}),
+            serde_json::json!({"node_type":"agent", "isolated_worktree":true,"harness":"claude","session_id":"cache-i-1"}),
         )
         .await;
         insert_event(
@@ -19783,14 +19878,14 @@ mod tests {
             None,
             serde_json::json!({
                 "pipeline_id":"cip1","pipeline_name":"Cache Invalidation Pipeline","target_repo":repo,"harness":"claude",
-                "node_defs":[{"id":"worker","name":"Worker","node_type":"code-mutating"}]
+                "node_defs":[{"id":"worker","name":"Worker","node_type":"agent", "isolated_worktree":true}]
             }),
         )
         .await;
         insert_event(
             &state.db, "cache-i2", "2031-02-16T09:10:00Z", "node_started",
             Some("worker"), Some(1),
-            serde_json::json!({"node_type":"code-mutating","harness":"claude","session_id":"cache-i-2"}),
+            serde_json::json!({"node_type":"agent", "isolated_worktree":true,"harness":"claude","session_id":"cache-i-2"}),
         )
         .await;
         insert_event(
@@ -19927,7 +20022,7 @@ mod tests {
         .bind(
             serde_json::json!({
                 "pipeline_id":"p1","pipeline_name":"Loop","target_repo":repo,"harness":"claude",
-                "node_defs":[{"id":"worker","name":"Worker","node_type":"code-mutating"}]
+                "node_defs":[{"id":"worker","name":"Worker","node_type":"agent", "isolated_worktree":true}]
             })
             .to_string(),
         )
@@ -19939,7 +20034,7 @@ mod tests {
              ('perf-unreadable', '2026-07-15T09:10:00Z', 'node_started', 'worker', 1, ?)",
         )
         .bind(
-            serde_json::json!({"node_type":"code-mutating","harness":"claude","session_id":"claude-1"})
+            serde_json::json!({"node_type":"agent", "isolated_worktree":true,"harness":"claude","session_id":"claude-1"})
                 .to_string(),
         )
         .execute(&state.db)
@@ -21378,7 +21473,7 @@ mod tests {
                 node_id: Some("worker".into()),
                 iter: Some(1),
                 payload: Some(serde_json::json!({
-                    "node_type": "doc-only",
+                    "node_type": "agent", "isolated_worktree": false,
                     "harness": "claude",
                     "session_id": "sid"
                 })),
@@ -22085,7 +22180,7 @@ mod tests {
         let run_id = "cleanup-sub-wt";
         let state = test_state_with_dir(repo).await;
 
-        seed_run_with_node(&state, run_id, "impl-1", "code-mutating").await;
+        seed_run_with_node(&state, run_id, "impl-1", true).await;
         for ev in [
             event_log::Event {
                 id: None,
@@ -22776,7 +22871,7 @@ mod tests {
                 Some(serde_json::json!({
                     "pipeline_name": "conflict",
                     "node_defs": [
-                        { "id": "worker", "node_type": "code-mutating", "inputs": [], "outputs": [] }
+                        { "id": "worker", "node_type": "agent", "isolated_worktree": true, "inputs": [], "outputs": [] }
                     ],
                     "edges": []
                 })),
@@ -22981,7 +23076,7 @@ mod tests {
                     Some(serde_json::json!({
                         "pipeline_name": "interactive",
                         "node_defs": [
-                            { "id": "worker", "node_type": "doc-only", "inputs": [], "outputs": [] }
+                            { "id": "worker", "node_type": "agent", "isolated_worktree": false, "inputs": [], "outputs": [] }
                         ],
                         "edges": []
                     })),
@@ -23273,6 +23368,7 @@ mod tests {
     ) -> event_log::RunState {
         let mut rs = event_log::RunState::new(run_id.into(), "test".into());
         rs.node_defs.push(event_log::NodeDefInfo {
+            isolated_worktree: None,
             id: node_id.into(),
             name: None,
             node_type: node_type.into(),
@@ -23284,6 +23380,7 @@ mod tests {
         rs.nodes.insert(
             node_id.into(),
             event_log::NodeState {
+                isolated_worktree: None,
                 harness: None,
                 cost: None,
                 node_id: node_id.into(),
@@ -23323,9 +23420,10 @@ mod tests {
 
     fn doc_node_def(id: &str) -> pipeline::NodeDef {
         pipeline::NodeDef {
+            isolated_worktree: None,
             id: id.into(),
             name: id.into(),
-            node_type: pipeline::NodeType::DocOnly,
+            node_type: pipeline::NodeType::Agent,
             inputs: Vec::new(),
             outputs: Vec::new(),
             interactive: false,
@@ -23357,7 +23455,7 @@ mod tests {
         }
     }
 
-    /// Two doc-only nodes wired `a -> b`. `a` is the entry node (no incoming
+    /// Two non-isolated nodes wired `a -> b`. `a` is the entry node (no incoming
     /// edges), `b` only spawns once `a` completes.
     fn linear_two_node_pipeline() -> pipeline::PipelineDef {
         pipeline::PipelineDef {
@@ -23376,7 +23474,7 @@ mod tests {
         run_state_with_node(
             "20260613-012555-stall",
             node_id,
-            "doc-only",
+            "agent",
             event_log::NodeStatus::Failed,
             1,
         )
@@ -23432,7 +23530,7 @@ mod tests {
         let run_state = run_state_with_node(
             "20260613-live",
             "a",
-            "doc-only",
+            "agent",
             event_log::NodeStatus::Running,
             1,
         );
@@ -23454,7 +23552,7 @@ mod tests {
         let mut run_state = run_state_with_node(
             "20260613-await",
             "a",
-            "doc-only",
+            "agent",
             event_log::NodeStatus::AwaitingUser,
             1,
         );
@@ -23501,6 +23599,7 @@ mod tests {
         run_state.nodes.insert(
             "a".into(),
             event_log::NodeState {
+                isolated_worktree: None,
                 harness: None,
                 cost: None,
                 node_id: "a".into(),
@@ -23557,6 +23656,7 @@ mod tests {
         run_state.nodes.insert(
             "a".into(),
             event_log::NodeState {
+                isolated_worktree: None,
                 harness: None,
                 cost: None,
                 node_id: "a".into(),
@@ -23578,6 +23678,7 @@ mod tests {
         run_state.nodes.insert(
             "b".into(),
             event_log::NodeState {
+                isolated_worktree: None,
                 harness: None,
                 cost: None,
                 node_id: "b".into(),
@@ -23767,7 +23868,7 @@ mod tests {
         let run_state = run_state_with_node(
             "20260630-live-old",
             "a",
-            "doc-only",
+            "agent",
             event_log::NodeStatus::Running,
             1,
         );
@@ -23806,6 +23907,7 @@ mod tests {
             rs.nodes.insert(
                 node_id.into(),
                 event_log::NodeState {
+                    isolated_worktree: None,
                     harness: None,
                     cost: None,
                     node_id: node_id.into(),
@@ -23939,7 +24041,7 @@ mod tests {
         std::fs::create_dir_all(&pipelines).unwrap();
         std::fs::write(
             pipelines.join("stall-test.yaml"),
-            "name: stall-test\nversion: \"1.0\"\nprompt_required: false\nnodes:\n  - id: start\n    name: Start\n    type: start\n    outputs:\n      - name: user_prompt\n  - id: a\n    name: a\n    type: doc-only\n    inputs:\n      - name: task\n    outputs:\n      - name: result\n  - id: b\n    name: b\n    type: doc-only\n    inputs:\n      - name: in\n    outputs:\n      - name: out\n  - id: end\n    name: End\n    type: end\n    inputs:\n      - name: result\nedges:\n  - source: { node: start, port: user_prompt }\n    target: { node: a, port: task }\n  - source: { node: a, port: result }\n    target: { node: b, port: in }\n  - source: { node: b, port: out }\n    target: { node: end, port: result }\n",
+            "name: stall-test\nversion: \"1.0\"\nprompt_required: false\nnodes:\n  - id: start\n    name: Start\n    type: start\n    outputs:\n      - name: user_prompt\n  - id: a\n    name: a\n    type: agent\n    isolated_worktree: false\n    inputs:\n      - name: task\n    outputs:\n      - name: result\n  - id: b\n    name: b\n    type: agent\n    isolated_worktree: false\n    inputs:\n      - name: in\n    outputs:\n      - name: out\n  - id: end\n    name: End\n    type: end\n    inputs:\n      - name: result\nedges:\n  - source: { node: start, port: user_prompt }\n    target: { node: a, port: task }\n  - source: { node: a, port: result }\n    target: { node: b, port: in }\n  - source: { node: b, port: out }\n    target: { node: end, port: result }\n",
         )
         .unwrap();
 
@@ -24049,7 +24151,7 @@ mod tests {
         std::fs::create_dir_all(&pipelines).unwrap();
         std::fs::write(
             pipelines.join("stall-test.yaml"),
-            "name: stall-test\nversion: \"1.0\"\nprompt_required: false\nnodes:\n  - id: start\n    name: Start\n    type: start\n    outputs:\n      - name: user_prompt\n  - id: a\n    name: a\n    type: doc-only\n    inputs:\n      - name: task\n    outputs:\n      - name: result\n  - id: b\n    name: b\n    type: doc-only\n    inputs:\n      - name: in\n    outputs:\n      - name: out\n  - id: end\n    name: End\n    type: end\n    inputs:\n      - name: result\nedges:\n  - source: { node: start, port: user_prompt }\n    target: { node: a, port: task }\n  - source: { node: a, port: result }\n    target: { node: b, port: in }\n  - source: { node: b, port: out }\n    target: { node: end, port: result }\n",
+            "name: stall-test\nversion: \"1.0\"\nprompt_required: false\nnodes:\n  - id: start\n    name: Start\n    type: start\n    outputs:\n      - name: user_prompt\n  - id: a\n    name: a\n    type: agent\n    isolated_worktree: false\n    inputs:\n      - name: task\n    outputs:\n      - name: result\n  - id: b\n    name: b\n    type: agent\n    isolated_worktree: false\n    inputs:\n      - name: in\n    outputs:\n      - name: out\n  - id: end\n    name: End\n    type: end\n    inputs:\n      - name: result\nedges:\n  - source: { node: start, port: user_prompt }\n    target: { node: a, port: task }\n  - source: { node: a, port: result }\n    target: { node: b, port: in }\n  - source: { node: b, port: out }\n    target: { node: end, port: result }\n",
         )
         .unwrap();
 
@@ -24362,8 +24464,8 @@ mod tests {
 
         // Doc-only variant: a run cut at the fork tip with NO commit changed nothing.
         // With HEAD still parked on the divergent branch, the honest answer is {0,0,0}
-        // (the triage's "even doc-only, zero files" case), not the phantom.
-        let doc_run = "loc-parked-doc-only";
+        // (the triage's "even non-isolated, zero files" case), not the phantom.
+        let doc_run = "loc-parked-non-isolated";
         git(&["branch", &format!("pdo/run-{doc_run}"), &default_branch]);
         assert_eq!(
             compute_run_loc(repo, doc_run, &default_branch).expect("branch present -> Some"),
@@ -24372,12 +24474,12 @@ mod tests {
                 deletions: 0,
                 files_changed: 0,
             },
-            "a doc-only run reads 0, not the parked-checkout phantom"
+            "a run that changed nothing reads 0, not the parked-checkout phantom"
         );
     }
 
     #[tokio::test]
-    async fn node_done_with_cm_node_def_in_events() {
+    async fn node_def_isolation_projects_from_the_run_snapshot() {
         let state = test_state().await;
         let run_id = "test-cm-node-done";
 
@@ -24392,7 +24494,7 @@ mod tests {
                 "pipeline_name": "cm-test",
                 "input": "test",
                 "node_defs": [
-                    { "id": "impl-1", "node_type": "code-mutating", "inputs": [], "outputs": [] }
+                    { "id": "impl-1", "node_type": "agent", "isolated_worktree": true, "inputs": [], "outputs": [] }
                 ],
                 "edges": []
             })),
@@ -24406,13 +24508,17 @@ mod tests {
             kind: event_log::EventKind::NodeStarted,
             node_id: Some("impl-1".into()),
             iter: Some(1),
-            payload: Some(serde_json::json!({ "node_type": "code-mutating" })),
+            payload: Some(serde_json::json!({ "node_type": "agent", "isolated_worktree": true })),
         };
         append_event(&state, &node_started).await.unwrap();
 
         let events = load_events(&state.db, run_id).await.unwrap();
         let run_state = event_log::project(&events).unwrap();
-        assert_eq!(find_node_type(&run_state, "impl-1"), Some("code-mutating"));
+        assert_eq!(find_node_type(&run_state, "impl-1"), Some("agent"));
+        // #653/ADR-0060: the snapshot carries where the node works, and the
+        // NodeRun's own frozen answer agrees with it on a first spawn.
+        assert!(snapshot_isolation(&run_state, "impl-1"));
+        assert!(node_run_isolation(&events, &run_state, "impl-1", 1));
     }
 
     async fn test_state_with_dir(dir: &std::path::Path) -> Arc<AppState> {
@@ -24484,7 +24590,7 @@ mod tests {
         let pipelines_dir = dir.join(".pdo").join("pipelines");
         std::fs::create_dir_all(&pipelines_dir).unwrap();
         let yaml = format!(
-            "name: {name}\nversion: \"1.0\"\nnodes:\n{START_END_YAML}  - id: worker\n    name: worker\n    type: doc-only\n    inputs:\n      - name: task\n    outputs:\n      - name: result\n"
+            "name: {name}\nversion: \"1.0\"\nnodes:\n{START_END_YAML}  - id: worker\n    name: worker\n    type: agent\n    isolated_worktree: false\n    inputs:\n      - name: task\n    outputs:\n      - name: result\n"
         );
         std::fs::write(pipelines_dir.join(format!("{name}.yaml")), yaml).unwrap();
     }
@@ -24495,7 +24601,7 @@ mod tests {
         let pipelines_dir = dir.join(".pdo").join("pipelines");
         std::fs::create_dir_all(&pipelines_dir).unwrap();
         let yaml = format!(
-            "name: {id}\nversion: \"1.0\"\nprompt_required: false\nnodes:\n{START_END_YAML}  - id: worker\n    name: worker\n    type: doc-only\n    inputs:\n      - name: task\n    outputs:\n      - name: result\n"
+            "name: {id}\nversion: \"1.0\"\nprompt_required: false\nnodes:\n{START_END_YAML}  - id: worker\n    name: worker\n    type: agent\n    isolated_worktree: false\n    inputs:\n      - name: task\n    outputs:\n      - name: result\n"
         );
         std::fs::write(pipelines_dir.join(format!("{id}.yaml")), yaml).unwrap();
     }
@@ -24615,7 +24721,7 @@ mod tests {
         // Prompt-optional pipeline.
         let pipelines_dir = tmp.path().join(".pdo").join("pipelines");
         let yaml = format!(
-            "name: optional-pipe\nversion: \"1.0\"\nprompt_required: false\nnodes:\n{START_END_YAML}  - id: worker\n    name: worker\n    type: doc-only\n    inputs:\n      - name: task\n    outputs:\n      - name: result\n"
+            "name: optional-pipe\nversion: \"1.0\"\nprompt_required: false\nnodes:\n{START_END_YAML}  - id: worker\n    name: worker\n    type: agent\n    isolated_worktree: false\n    inputs:\n      - name: task\n    outputs:\n      - name: result\n"
         );
         std::fs::write(pipelines_dir.join("optional-pipe.yaml"), yaml).unwrap();
 
@@ -25284,12 +25390,14 @@ nodes:
       - { name: user_prompt, side: right }
   - id: aaaa0001
     name: implementer
-    type: code-mutating
+    type: agent
+    isolated_worktree: true
     outputs:
       - { name: code, side: right }
   - id: aaaa0002
     name: reviewer
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     outputs:
       - name: review
         side: right
@@ -25589,7 +25697,7 @@ edges:
         let state = test_state_with_dir(tmp.path()).await;
         let app = build_router(state);
 
-        let yaml = format!("name: prompt-save\nversion: \"1.0\"\nnodes:\n{START_END_YAML}  - id: ab12cd34\n    name: worker\n    type: doc-only\n    inputs:\n      - name: task\n    outputs:\n      - name: result\n");
+        let yaml = format!("name: prompt-save\nversion: \"1.0\"\nnodes:\n{START_END_YAML}  - id: ab12cd34\n    name: worker\n    type: agent\n    isolated_worktree: false\n    inputs:\n      - name: task\n    outputs:\n      - name: result\n");
         let body = serde_json::json!({
             "yaml": yaml,
             "prompts": { "ab12cd34": "You are a worker agent." }
@@ -26954,11 +27062,13 @@ edges:
     // node_prompt endpoint — Layer 2 contract tests
     // -----------------------------------------------------------------------
 
+    /// Seed a Run whose single `agent` node has already started, with the
+    /// isolation (#653) that decides where its NodeRun works.
     async fn seed_run_with_node(
         state: &Arc<AppState>,
         run_id: &str,
         node_id: &str,
-        node_type: &str,
+        isolated: bool,
     ) {
         let run_started = event_log::Event {
             id: None,
@@ -26971,7 +27081,13 @@ edges:
                 "pipeline_name": "test-pipe",
                 "input": "test",
                 "node_defs": [
-                    { "id": node_id, "node_type": node_type, "inputs": [], "outputs": [] }
+                    {
+                        "id": node_id,
+                        "node_type": "agent",
+                        "isolated_worktree": isolated,
+                        "inputs": [],
+                        "outputs": []
+                    }
                 ],
                 "edges": []
             })),
@@ -26985,7 +27101,9 @@ edges:
             kind: event_log::EventKind::NodeStarted,
             node_id: Some(node_id.into()),
             iter: Some(1),
-            payload: Some(serde_json::json!({ "node_type": node_type })),
+            payload: Some(
+                serde_json::json!({ "node_type": "agent", "isolated_worktree": isolated }),
+            ),
         };
         append_event(state, &node_started).await.unwrap();
     }
@@ -27013,7 +27131,7 @@ edges:
         let tmp = tempfile::tempdir().unwrap();
         let state = test_state_with_dir(tmp.path()).await;
         let run_id = "prompt-test-no-node";
-        seed_run_with_node(&state, run_id, "worker", "doc-only").await;
+        seed_run_with_node(&state, run_id, "worker", false).await;
 
         let app = build_router(state);
         let resp = app
@@ -27034,7 +27152,7 @@ edges:
         let tmp = tempfile::tempdir().unwrap();
         let state = test_state_with_dir(tmp.path()).await;
         let run_id = "prompt-test-no-file";
-        seed_run_with_node(&state, run_id, "worker", "doc-only").await;
+        seed_run_with_node(&state, run_id, "worker", false).await;
 
         let app = build_router(state);
         let resp = app
@@ -27064,7 +27182,7 @@ edges:
         .unwrap();
 
         let state = test_state_with_dir(tmp.path()).await;
-        seed_run_with_node(&state, run_id, "worker", "doc-only").await;
+        seed_run_with_node(&state, run_id, "worker", false).await;
 
         let app = build_router(state);
         let resp = app
@@ -27105,7 +27223,7 @@ edges:
         std::fs::write(prompt_dir.join("worker-iter-1.md"), "prompt content").unwrap();
 
         let state = test_state_with_dir(tmp.path()).await;
-        seed_run_with_node(&state, run_id, "worker", "doc-only").await;
+        seed_run_with_node(&state, run_id, "worker", false).await;
 
         let app = build_router(state);
         let resp = app
@@ -27129,7 +27247,7 @@ edges:
 
         let run_id = "prompt-cm-survive";
         let state = test_state_with_dir(repo).await;
-        seed_run_with_node(&state, run_id, "impl-1", "code-mutating").await;
+        seed_run_with_node(&state, run_id, "impl-1", true).await;
 
         // Create real worktrees
         let wt_dir = repo.join(".pdo/runs").join(run_id).join("worktree");
@@ -27170,7 +27288,7 @@ edges:
         assert_eq!(
             resp.status(),
             StatusCode::OK,
-            "prompt endpoint must return 200 for completed code-mutating node iter"
+            "prompt endpoint must return 200 for completed isolated node iter"
         );
 
         let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
@@ -27194,7 +27312,7 @@ edges:
         std::fs::write(
             &pipeline_path,
             format!(
-                "name: io-test-pipe\nnodes:\n{START_END_YAML}  - id: planner\n    name: planner\n    type: doc-only\n    inputs:\n      - name: task\n    outputs:\n      - name: plan\n  - id: implementer\n    name: implementer\n    type: code-mutating\n    inputs:\n      - name: plan\n    outputs:\n      - name: summary\nedges:\n  - source: {{ node: planner, port: plan }}\n    target: {{ node: implementer, port: plan }}\n"
+                "name: io-test-pipe\nnodes:\n{START_END_YAML}  - id: planner\n    name: planner\n    type: agent\n    isolated_worktree: false\n    inputs:\n      - name: task\n    outputs:\n      - name: plan\n  - id: implementer\n    name: implementer\n    type: agent\n    isolated_worktree: true\n    inputs:\n      - name: plan\n    outputs:\n      - name: summary\nedges:\n  - source: {{ node: planner, port: plan }}\n    target: {{ node: implementer, port: plan }}\n"
             ),
         )
         .unwrap();
@@ -27223,8 +27341,8 @@ edges:
                     "pipeline_name": "io-test-pipe",
                     "input": "test",
                     "node_defs": [
-                        { "id": "planner", "node_type": "doc-only", "inputs": ["task"], "outputs": ["plan"] },
-                        { "id": "implementer", "node_type": "code-mutating", "inputs": ["plan"], "outputs": ["summary"] }
+                        { "id": "planner", "node_type": "agent", "isolated_worktree": false, "inputs": ["task"], "outputs": ["plan"] },
+                        { "id": "implementer", "node_type": "agent", "isolated_worktree": true, "inputs": ["plan"], "outputs": ["summary"] }
                     ],
                     "edges": [
                         { "source_node": "planner", "source_port": "plan", "target_node": "implementer", "target_port": "plan" }
@@ -27520,7 +27638,7 @@ edges:
         let pipelines_dir = dir.join(".pdo").join("pipelines");
         std::fs::create_dir_all(&pipelines_dir).unwrap();
         let yaml = format!(
-            "name: {name}\nversion: \"1.0\"\nnodes:\n{START_END_YAML}  - id: worker\n    name: worker\n    type: doc-only\n    inputs:\n      - name: task\n    outputs:\n      - name: summary\n      - name: report\n    view: {{ x: 100, y: 100 }}\nedges: []\n"
+            "name: {name}\nversion: \"1.0\"\nnodes:\n{START_END_YAML}  - id: worker\n    name: worker\n    type: agent\n    isolated_worktree: false\n    inputs:\n      - name: task\n    outputs:\n      - name: summary\n      - name: report\n    view: {{ x: 100, y: 100 }}\nedges: []\n"
         );
         std::fs::write(pipelines_dir.join(format!("{name}.yaml")), yaml).unwrap();
     }
@@ -27794,13 +27912,13 @@ edges:
 
     // --- Transition guard wiring (#212, closes #195 #196 #197 #198 #201) ---
 
-    /// Pipeline `worker -> consumer` (both doc-only, no declared outputs) so
+    /// Pipeline `worker -> consumer` (both non-isolated, no declared outputs) so
     /// downstream re-spawn behavior is observable in the event log.
     fn write_pipeline_with_consumer(dir: &std::path::Path, name: &str) {
         let pipelines_dir = dir.join(".pdo").join("pipelines");
         std::fs::create_dir_all(&pipelines_dir).unwrap();
         let yaml = format!(
-            "name: {name}\nversion: \"1.0\"\nnodes:\n{START_END_YAML}  - id: worker\n    name: worker\n    type: doc-only\n    inputs:\n      - name: task\n    outputs:\n      - name: result\n  - id: consumer\n    name: consumer\n    type: doc-only\n    inputs:\n      - name: feed\n    outputs:\n      - name: out\nedges:\n  - source: {{ node: worker, port: result }}\n    target: {{ node: consumer, port: feed }}\n"
+            "name: {name}\nversion: \"1.0\"\nnodes:\n{START_END_YAML}  - id: worker\n    name: worker\n    type: agent\n    isolated_worktree: false\n    inputs:\n      - name: task\n    outputs:\n      - name: result\n  - id: consumer\n    name: consumer\n    type: agent\n    isolated_worktree: false\n    inputs:\n      - name: feed\n    outputs:\n      - name: out\nedges:\n  - source: {{ node: worker, port: result }}\n    target: {{ node: consumer, port: feed }}\n"
         );
         std::fs::write(pipelines_dir.join(format!("{name}.yaml")), yaml).unwrap();
     }
@@ -28453,7 +28571,7 @@ edges:
         let pipelines_dir = tmp.path().join(".pdo").join("pipelines");
         std::fs::create_dir_all(&pipelines_dir).unwrap();
         let yaml = format!(
-            "name: {pipe_name}\nversion: \"1.0\"\nnodes:\n{START_END_YAML}  - id: a\n    name: a\n    type: doc-only\n    inputs: [{{ name: in }}]\n    outputs: [{{ name: out }}]\n  - id: b\n    name: b\n    type: doc-only\n    inputs: [{{ name: in }}]\n    outputs: [{{ name: out }}]\n  - id: c\n    name: c\n    type: doc-only\n    inputs: [{{ name: in }}]\n    outputs: [{{ name: out }}]\nedges:\n  - source: {{ node: a, port: out }}\n    target: {{ node: b, port: in }}\n  - source: {{ node: b, port: out }}\n    target: {{ node: c, port: in }}\n"
+            "name: {pipe_name}\nversion: \"1.0\"\nnodes:\n{START_END_YAML}  - id: a\n    name: a\n    type: agent\n    isolated_worktree: false\n    inputs: [{{ name: in }}]\n    outputs: [{{ name: out }}]\n  - id: b\n    name: b\n    type: agent\n    isolated_worktree: false\n    inputs: [{{ name: in }}]\n    outputs: [{{ name: out }}]\n  - id: c\n    name: c\n    type: agent\n    isolated_worktree: false\n    inputs: [{{ name: in }}]\n    outputs: [{{ name: out }}]\nedges:\n  - source: {{ node: a, port: out }}\n    target: {{ node: b, port: in }}\n  - source: {{ node: b, port: out }}\n    target: {{ node: c, port: in }}\n"
         );
         std::fs::write(pipelines_dir.join(format!("{pipe_name}.yaml")), yaml).unwrap();
 
@@ -28546,7 +28664,7 @@ edges:
         let pipelines_dir = tmp.path().join(".pdo").join("pipelines");
         std::fs::create_dir_all(&pipelines_dir).unwrap();
         let yaml = format!(
-            "name: {pipe_name}\nversion: \"1.0\"\nnodes:\n{START_END_YAML}  - id: a\n    name: a\n    type: doc-only\n    inputs: [{{ name: in }}]\n    outputs: [{{ name: out }}]\n  - id: b\n    name: b\n    type: doc-only\n    inputs: [{{ name: in }}]\n    outputs: [{{ name: out }}]\nedges:\n  - source: {{ node: a, port: out }}\n    target: {{ node: b, port: in }}\n  - source: {{ node: b, port: out }}\n    target: {{ node: a, port: in }}\n    when: \"iter < 3\"\n"
+            "name: {pipe_name}\nversion: \"1.0\"\nnodes:\n{START_END_YAML}  - id: a\n    name: a\n    type: agent\n    isolated_worktree: false\n    inputs: [{{ name: in }}]\n    outputs: [{{ name: out }}]\n  - id: b\n    name: b\n    type: agent\n    isolated_worktree: false\n    inputs: [{{ name: in }}]\n    outputs: [{{ name: out }}]\nedges:\n  - source: {{ node: a, port: out }}\n    target: {{ node: b, port: in }}\n  - source: {{ node: b, port: out }}\n    target: {{ node: a, port: in }}\n    when: \"iter < 3\"\n"
         );
         std::fs::write(pipelines_dir.join(format!("{pipe_name}.yaml")), yaml).unwrap();
 
@@ -29585,9 +29703,9 @@ edges:
         // #489: the body is no longer a blind `{"ok":true}`. It reports the real
         // effect — `spawned:[{node_id,iter}]` plus what happened to the
         // sub-worktree — because the arm now READS `spawn_node`'s return.
-        // `worker` is `doc-only` (`write_test_pipeline`), so it owns no
+        // `worker` is non-isolated (`write_test_pipeline`), so it owns no
         // sub-worktree: `reused_sub_worktree:false`, `base_sha:null`. The
-        // `code-mutating` twin below is the one that can see #489 at all.
+        // isolated twin below is the one that can see #489 at all.
         let tmp = tempfile::tempdir().unwrap();
         write_test_pipeline(tmp.path(), "restart-pipe");
         let state = test_state_with_dir(tmp.path()).await;
@@ -29639,22 +29757,22 @@ edges:
         assert_eq!(started[0].iter, Some(1));
     }
 
-    /// The pipeline the `code-mutating` restart twin needs: `worker` owns a
+    /// The pipeline the isolated restart twin needs: `worker` owns a
     /// sub-worktree, which is the ONLY node class #489 breaks.
-    fn write_code_mutating_pipeline(dir: &std::path::Path, name: &str) {
+    fn write_isolated_node_pipeline(dir: &std::path::Path, name: &str) {
         let pipelines_dir = dir.join(".pdo").join("pipelines");
         std::fs::create_dir_all(&pipelines_dir).unwrap();
         let yaml = format!(
-            "name: {name}\nversion: \"1.0\"\nnodes:\n{START_END_YAML}  - id: worker\n    name: worker\n    type: code-mutating\n    inputs:\n      - name: task\n    outputs:\n      - name: result\n"
+            "name: {name}\nversion: \"1.0\"\nnodes:\n{START_END_YAML}  - id: worker\n    name: worker\n    type: agent\n    isolated_worktree: true\n    inputs:\n      - name: task\n    outputs:\n      - name: result\n"
         );
         std::fs::write(pipelines_dir.join(format!("{name}.yaml")), yaml).unwrap();
     }
 
     #[tokio::test]
-    async fn restart_node_on_a_code_mutating_node_reuses_its_sub_worktree() {
+    async fn restart_node_on_an_isolated_node_reuses_its_sub_worktree() {
         // #489, the class that mattered. `write_test_pipeline`'s `worker` is
-        // `doc-only`, so the repo's only `restart_node` happy path was
-        // STRUCTURALLY incapable of seeing this bug: a `doc-only` node owns no
+        // non-isolated, so the repo's only `restart_node` happy path was
+        // STRUCTURALLY incapable of seeing this bug: a non-isolated node owns no
         // sub-worktree, and `git worktree add -b` was never replayed.
         //
         // Here the first restart CREATES the sub-worktree and the second one has
@@ -29663,7 +29781,7 @@ edges:
         // the log — the whole issue, in two HTTP calls.
         let tmp = tempfile::tempdir().unwrap();
         let dir = tmp.path();
-        write_code_mutating_pipeline(dir, "restart-cm");
+        write_isolated_node_pipeline(dir, "restart-cm");
         init_test_repo(dir);
         let state = test_state_with_dir(dir).await;
         let run_id = "restart-cm-run";
@@ -30018,7 +30136,8 @@ nodes:
       - name: user_prompt
   - id: worker
     name: worker
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
     outputs:
@@ -30050,7 +30169,8 @@ nodes:
       - name: user_prompt
   - id: planner
     name: planner
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
     outputs:
@@ -30375,7 +30495,8 @@ nodes:
       - name: result
   - id: n1
     name: Reviewer
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: code
     outputs:
@@ -30471,7 +30592,7 @@ edges: []
                     .body(Body::from(
                         serde_json::to_string(&serde_json::json!({
                             "name": "Reviewer",
-                            "type": "doc-only",
+                            "type": "agent",
                             "inputs": [{"name": "code"}],
                             "outputs": [{"name": "review"}],
                             "interactive": false,
@@ -30648,7 +30769,7 @@ edges: []
                     .body(Body::from(
                         serde_json::to_string(&serde_json::json!({
                             "name": "DraftReviewer",
-                            "type": "doc-only",
+                            "type": "agent",
                             "inputs": [{"name": "in"}],
                             "outputs": [{"name": "out"}],
                             "interactive": false,
@@ -31010,7 +31131,7 @@ edges: []
 
         let run_id = "diff-empty";
         let state = test_state_with_dir(repo).await;
-        seed_run_with_node(&state, run_id, "impl-1", "code-mutating").await;
+        seed_run_with_node(&state, run_id, "impl-1", true).await;
 
         let wt_dir = repo.join(".pdo/runs").join(run_id).join("worktree");
         let pipeline_branch = format!("pdo/run-{run_id}");
@@ -31046,7 +31167,7 @@ edges: []
 
         let run_id = "diff-agg";
         let state = test_state_with_dir(repo).await;
-        seed_run_with_node(&state, run_id, "impl-1", "code-mutating").await;
+        seed_run_with_node(&state, run_id, "impl-1", true).await;
 
         let wt_dir = repo.join(".pdo/runs").join(run_id).join("worktree");
         let pipeline_branch = format!("pdo/run-{run_id}");
@@ -31103,7 +31224,7 @@ edges: []
 
         let run_id = "diff-fork";
         let state = test_state_with_dir(repo).await;
-        seed_run_with_node(&state, run_id, "impl-1", "code-mutating").await;
+        seed_run_with_node(&state, run_id, "impl-1", true).await;
 
         let wt_dir = repo.join(".pdo/runs").join(run_id).join("worktree");
         let pipeline_branch = format!("pdo/run-{run_id}");
@@ -31222,7 +31343,7 @@ edges: []
                 "input": "test",
                 "fork_sha": fork_sha,
                 "node_defs": [
-                    { "id": "impl-1", "node_type": "code-mutating", "inputs": [], "outputs": [] }
+                    { "id": "impl-1", "node_type": "agent", "isolated_worktree": true, "inputs": [], "outputs": [] }
                 ],
                 "edges": []
             })),
@@ -31286,7 +31407,7 @@ edges: []
 
         let run_id = "diff-pdo";
         let state = test_state_with_dir(repo).await;
-        seed_run_with_node(&state, run_id, "impl-1", "code-mutating").await;
+        seed_run_with_node(&state, run_id, "impl-1", true).await;
 
         let wt_dir = repo.join(".pdo/runs").join(run_id).join("worktree");
         let pipeline_branch = format!("pdo/run-{run_id}");
@@ -31344,7 +31465,7 @@ edges: []
 
         let run_id = "diff-node";
         let state = test_state_with_dir(repo).await;
-        seed_run_with_node(&state, run_id, "impl-1", "code-mutating").await;
+        seed_run_with_node(&state, run_id, "impl-1", true).await;
 
         let wt_dir = repo.join(".pdo/runs").join(run_id).join("worktree");
         let pipeline_branch = format!("pdo/run-{run_id}");
@@ -31404,7 +31525,7 @@ edges: []
 
         let run_id = "diff-no-node";
         let state = test_state_with_dir(repo).await;
-        seed_run_with_node(&state, run_id, "impl-1", "code-mutating").await;
+        seed_run_with_node(&state, run_id, "impl-1", true).await;
 
         let wt_dir = repo.join(".pdo/runs").join(run_id).join("worktree");
         let pipeline_branch = format!("pdo/run-{run_id}");
@@ -32347,15 +32468,19 @@ edges: []
     /// one-node pipeline plus the four dir borrows. Returns owned values the
     /// caller keeps alive; the `SpawnContext` is built at the call site from
     /// borrows of these.
+    /// An `agent` node and its one-node pipeline. `isolated` (#653) is what
+    /// decides whether the spawn cuts a sub-worktree — the axis the retired
+    /// non-isolated / isolated types used to stand in for here.
     fn spawn_test_fixture(
         repo_root: &std::path::Path,
         node_id: &str,
-        node_type: pipeline::NodeType,
+        isolated: bool,
     ) -> (pipeline::PipelineDef, pipeline::NodeDef, std::path::PathBuf) {
         let node = pipeline::NodeDef {
+            isolated_worktree: Some(isolated),
             id: node_id.into(),
             name: node_id.into(),
-            node_type,
+            node_type: pipeline::NodeType::Agent,
             inputs: Vec::new(),
             outputs: Vec::new(),
             interactive: false,
@@ -32398,8 +32523,7 @@ edges: []
         let run_id = "spawn-unit-throttle";
         seed_run_for_node_control(&state, run_id, "spawn-unit").await;
 
-        let (pipeline, node, pipeline_path) =
-            spawn_test_fixture(tmp.path(), "worker", pipeline::NodeType::DocOnly);
+        let (pipeline, node, pipeline_path) = spawn_test_fixture(tmp.path(), "worker", false);
         let artifacts_dir = tmp.path().join("artifacts");
         let resolved_vars = HashMap::new();
         let ctx = SpawnContext {
@@ -32457,14 +32581,13 @@ edges: []
         let pipeline_branch = format!("pdo/run-{run_id}");
         create_worktree(repo, &wt_dir, &pipeline_branch, "HEAD").unwrap();
 
-        // Arm the one-shot spawn poison: the code-mutating spawn will create its
+        // Arm the one-shot spawn poison: the isolated spawn will create its
         // sub-worktree, then panic at the span head (before NodeStarted).
         state
             .panic_on_spawn
             .store(true, std::sync::atomic::Ordering::SeqCst);
 
-        let (pipeline, node, pipeline_path) =
-            spawn_test_fixture(repo, "worker", pipeline::NodeType::CodeMutating);
+        let (pipeline, node, pipeline_path) = spawn_test_fixture(repo, "worker", true);
         let artifacts_dir = wt_dir.join(".pdo").join("artifacts");
         let resolved_vars = HashMap::new();
         let ctx = SpawnContext {
@@ -32544,8 +32667,8 @@ edges: []
     /// *file* named `.pdo/prompts` where a directory is expected. `create_dir_all`
     /// returns `AlreadyExists` (os error 17) BEFORE tmux is ever invoked, for
     /// every node type — no real tmux, no debug poison. `commit` decides whether
-    /// the file is only on disk (a doc-only node runs straight in `worktree_dir`)
-    /// or committed onto HEAD (a code-mutating node's sub-worktree is a fresh
+    /// the file is only on disk (a non-isolated node runs straight in `worktree_dir`)
+    /// or committed onto HEAD (an isolated node's sub-worktree is a fresh
     /// checkout of the pipeline branch that must carry the collision file).
     fn plant_pdo_prompts_file(dir: &std::path::Path, commit: bool) {
         let pdo = dir.join(".pdo");
@@ -32590,7 +32713,7 @@ edges: []
     /// returns a lying `Spawned`. It appends `NodeFailed` (legal — the iteration
     /// is `Running`) THEN `RunFailed`, moving both node and run terminal with the
     /// TRUE cause (a tmux spawn failure), never the false `session_died` the
-    /// liveness sweep would have written ~30s later. A doc-only node owns no
+    /// liveness sweep would have written ~30s later. A non-isolated node owns no
     /// sub-worktree, so nothing is reaped.
     #[tokio::test]
     async fn spawn_node_tmux_err_fails_run_loud_no_worktree() {
@@ -32602,12 +32725,11 @@ edges: []
         let run_id = "spawn-unit-tmuxerr-noworktree";
         seed_run_for_node_control(&state, run_id, "spawn-unit").await;
 
-        // Plant the collision file directly in the doc-only node's working dir
+        // Plant the collision file directly in the non-isolated node's working dir
         // (= `worktree_dir`); no commit needed since it runs there in place.
         plant_pdo_prompts_file(repo, false);
 
-        let (pipeline, node, pipeline_path) =
-            spawn_test_fixture(repo, "worker", pipeline::NodeType::DocOnly);
+        let (pipeline, node, pipeline_path) = spawn_test_fixture(repo, "worker", false);
         let artifacts_dir = repo.join(".pdo").join("artifacts");
         let resolved_vars = HashMap::new();
         let ctx = SpawnContext {
@@ -32669,7 +32791,7 @@ edges: []
         );
     }
 
-    /// #508 (fresh sub-worktree → reap): a code-mutating node whose fresh
+    /// #508 (fresh sub-worktree → reap): an isolated node whose fresh
     /// sub-worktree this spawn created reaps that orphan (dir + branch) on a tmux
     /// spawn failure, exactly as the pre-start abort does — the run goes terminal
     /// with no leaked worktree.
@@ -32689,8 +32811,7 @@ edges: []
         let pipeline_branch = format!("pdo/run-{run_id}");
         create_worktree(repo, &wt_dir, &pipeline_branch, "HEAD").unwrap();
 
-        let (pipeline, node, pipeline_path) =
-            spawn_test_fixture(repo, "worker", pipeline::NodeType::CodeMutating);
+        let (pipeline, node, pipeline_path) = spawn_test_fixture(repo, "worker", true);
         let artifacts_dir = wt_dir.join(".pdo").join("artifacts");
         let resolved_vars = HashMap::new();
         let ctx = SpawnContext {
@@ -32790,8 +32911,7 @@ edges: []
             "precondition: the reused sub-worktree exists"
         );
 
-        let (pipeline, node, pipeline_path) =
-            spawn_test_fixture(repo, "worker", pipeline::NodeType::CodeMutating);
+        let (pipeline, node, pipeline_path) = spawn_test_fixture(repo, "worker", true);
         let artifacts_dir = wt_dir.join(".pdo").join("artifacts");
         let resolved_vars = HashMap::new();
         let ctx = SpawnContext {
@@ -32858,10 +32978,9 @@ edges: []
 
         let run_id = "spawn-unit-refuse";
         // Seeds RunStarted + NodeStarted worker iter-1 (iter-1 is live).
-        seed_run_with_node(&state, run_id, "worker", "doc-only").await;
+        seed_run_with_node(&state, run_id, "worker", false).await;
 
-        let (pipeline, node, pipeline_path) =
-            spawn_test_fixture(tmp.path(), "worker", pipeline::NodeType::DocOnly);
+        let (pipeline, node, pipeline_path) = spawn_test_fixture(tmp.path(), "worker", false);
         let artifacts_dir = tmp.path().join("artifacts");
         let resolved_vars = HashMap::new();
         let ctx = SpawnContext {
@@ -32955,8 +33074,7 @@ edges: []
         let run_id = "spawn-unit-sbx-pending";
         seed_sandboxed_run_mid_prep(&state, run_id, "spawn-unit").await;
 
-        let (pipeline, node, pipeline_path) =
-            spawn_test_fixture(tmp.path(), "worker", pipeline::NodeType::DocOnly);
+        let (pipeline, node, pipeline_path) = spawn_test_fixture(tmp.path(), "worker", false);
         let artifacts_dir = tmp.path().join("artifacts");
         let resolved_vars = HashMap::new();
         let ctx = SpawnContext {
@@ -33009,8 +33127,7 @@ edges: []
         // RunStarted with no `sandbox` key at all → SandboxMode::Off, prep = None.
         seed_run_for_node_control(&state, run_id, "spawn-unit").await;
 
-        let (pipeline, node, pipeline_path) =
-            spawn_test_fixture(tmp.path(), "worker", pipeline::NodeType::DocOnly);
+        let (pipeline, node, pipeline_path) = spawn_test_fixture(tmp.path(), "worker", false);
         let artifacts_dir = tmp.path().join("artifacts");
         let resolved_vars = HashMap::new();
         let ctx = SpawnContext {
@@ -33027,6 +33144,143 @@ edges: []
         assert!(
             matches!(outcome, SpawnOutcome::Spawned { .. }),
             "an `off` Run must spawn exactly as before the precondition, got {outcome:?}"
+        );
+    }
+
+    /// #653 / ADR-0060 — **placement**: an Agent works where its
+    /// `isolated_worktree` says, and the spawn FREEZES that answer onto
+    /// `NodeStarted`. Both values, one real git repo.
+    #[tokio::test]
+    async fn spawn_places_an_agent_by_its_isolation_and_freezes_it() {
+        for isolated in [false, true] {
+            let tmp = tempfile::tempdir().unwrap();
+            let repo = tmp.path();
+            init_test_repo(repo);
+            let state = test_state_with_dir(repo).await;
+
+            let run_id = if isolated { "iso-yes" } else { "iso-no" };
+            seed_run_for_node_control(&state, run_id, "spawn-unit").await;
+            let wt_dir = repo.join(".pdo/runs").join(run_id).join("worktree");
+            create_worktree(repo, &wt_dir, &format!("pdo/run-{run_id}"), "HEAD").unwrap();
+
+            let (pipeline, node, pipeline_path) = spawn_test_fixture(repo, "worker", isolated);
+            let artifacts_dir = wt_dir.join(".pdo").join("artifacts");
+            let resolved_vars = HashMap::new();
+            let ctx = SpawnContext {
+                pipeline: &pipeline,
+                run_id,
+                pipeline_path: &pipeline_path,
+                worktree_dir: &wt_dir,
+                artifacts_dir: &artifacts_dir,
+                resolved_vars: &resolved_vars,
+                repo_root: repo,
+            };
+            let outcome = spawn_node(SpawnDeps::from_state(&state), &ctx, &node, 1).await;
+            assert!(
+                matches!(outcome, SpawnOutcome::Spawned { .. }),
+                "isolated={isolated}: spawn must start, got {outcome:?}"
+            );
+
+            // The sub-worktree exists iff the node asked for one.
+            let sub_wt = sub_worktree_path(repo, run_id, "worker", 1);
+            assert_eq!(
+                sub_wt.exists(),
+                isolated,
+                "isolated={isolated}: sub-worktree presence must follow the node's own line"
+            );
+
+            // …and the answer is frozen on the start event, not re-derived later.
+            let events = load_events(&state.db, run_id).await.unwrap();
+            assert_eq!(
+                merge_action::frozen_isolation(&events, "worker", 1),
+                Some(isolated),
+                "isolated={isolated}: NodeStarted must record the isolation it launched with"
+            );
+            let run_state = event_log::project(&events).unwrap();
+            assert_eq!(
+                run_state.nodes["worker"].isolated_worktree,
+                Some(isolated),
+                "isolated={isolated}: the projection must expose the frozen value"
+            );
+        }
+    }
+
+    /// #653 / ADR-0060 — **the freeze bites**: once a NodeRun has started, a
+    /// document that now says the opposite does not move it. A re-spawn of the
+    /// same iteration reads the frozen answer, so recovery lands back in the
+    /// working directory the interrupted attempt left.
+    #[tokio::test]
+    async fn a_live_iteration_keeps_its_frozen_working_directory() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path();
+        init_test_repo(repo);
+        let state = test_state_with_dir(repo).await;
+
+        let run_id = "iso-freeze";
+        seed_run_for_node_control(&state, run_id, "spawn-unit").await;
+        let wt_dir = repo.join(".pdo/runs").join(run_id).join("worktree");
+        create_worktree(repo, &wt_dir, &format!("pdo/run-{run_id}"), "HEAD").unwrap();
+
+        // First spawn: shared worktree.
+        let (pipeline, shared_node, pipeline_path) = spawn_test_fixture(repo, "worker", false);
+        let artifacts_dir = wt_dir.join(".pdo").join("artifacts");
+        let resolved_vars = HashMap::new();
+        let ctx = SpawnContext {
+            pipeline: &pipeline,
+            run_id,
+            pipeline_path: &pipeline_path,
+            worktree_dir: &wt_dir,
+            artifacts_dir: &artifacts_dir,
+            resolved_vars: &resolved_vars,
+            repo_root: repo,
+        };
+        spawn_node(SpawnDeps::from_state(&state), &ctx, &shared_node, 1).await;
+
+        // The author now flips the node to isolated and the SAME iteration is
+        // re-spawned (a restart). It must stay in the Run worktree.
+        let mut isolated_node = shared_node.clone();
+        isolated_node.isolated_worktree = Some(true);
+        spawn_node(SpawnDeps::from_state(&state), &ctx, &isolated_node, 1).await;
+
+        assert!(
+            !sub_worktree_path(repo, run_id, "worker", 1).exists(),
+            "an isolation edit must not fork a sub-worktree under a live iteration"
+        );
+        let events = load_events(&state.db, run_id).await.unwrap();
+        assert_eq!(
+            merge_action::frozen_isolation(&events, "worker", 1),
+            Some(false),
+            "the re-spawn must carry the ORIGINAL frozen isolation forward"
+        );
+
+        // The next iteration is a new NodeRun and reads the document afresh.
+        append_event(
+            &state,
+            &event_log::Event {
+                id: None,
+                run_id: run_id.into(),
+                ts: event_log::now_iso(),
+                kind: event_log::EventKind::NodeCompleted,
+                node_id: Some("worker".into()),
+                iter: Some(1),
+                payload: None,
+            },
+        )
+        .await
+        .unwrap();
+        let outcome = spawn_node(SpawnDeps::from_state(&state), &ctx, &isolated_node, 2).await;
+        assert!(
+            matches!(outcome, SpawnOutcome::Spawned { .. }),
+            "iter 2 must spawn, got {outcome:?}"
+        );
+        assert_eq!(
+            merge_action::frozen_isolation(
+                &load_events(&state.db, run_id).await.unwrap(),
+                "worker",
+                2
+            ),
+            Some(true),
+            "a fresh iteration must pick up the edited isolation"
         );
     }
 
@@ -33051,7 +33305,7 @@ edges: []
         // artifact read; `worker` has no incoming edge, so it is a root the readiness
         // sweep reports ready from the very first tick.
         let yaml = format!(
-            "name: sbx-advance\nversion: \"1.0\"\nnodes:\n{START_END_YAML}  - id: worker\n    name: worker\n    type: doc-only\n    inputs:\n      - name: task\n    outputs:\n      - name: result\n"
+            "name: sbx-advance\nversion: \"1.0\"\nnodes:\n{START_END_YAML}  - id: worker\n    name: worker\n    type: agent\n    isolated_worktree: false\n    inputs:\n      - name: task\n    outputs:\n      - name: result\n"
         );
         let yaml = yaml.as_str();
         let run_dir = repo_root.join(".pdo").join("runs").join(run_id);
@@ -33183,14 +33437,16 @@ nodes:
       - name: user_prompt
   - id: worker
     name: Worker
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
     outputs:
       - name: code
   - id: reviewer
     name: Reviewer
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: code
     outputs:
@@ -33303,7 +33559,8 @@ nodes:
       - name: user_prompt
   - id: worker
     name: Worker
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
     outputs:
@@ -33366,7 +33623,8 @@ nodes:
       - name: user_prompt
   - id: worker
     name: Worker
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
     outputs:
@@ -33426,7 +33684,8 @@ nodes:
       - name: user_prompt
   - id: worker
     name: Worker
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
     outputs:
@@ -33611,7 +33870,7 @@ edges:
         seed_run_for_node_control(&state, run_id, "test-pipe").await;
         seed_node_started(&state, run_id, "worker", 1).await;
         // The resurrection branch is only reached when the node's working dir still
-        // exists (a doc-only node's dir is the run's pipeline worktree).
+        // exists (a non-isolated node's dir is the run's pipeline worktree).
         std::fs::create_dir_all(worktree_dir_for_run(repo_root, run_id)).unwrap();
 
         let started_before = load_events(&state.db, run_id)
@@ -33682,14 +33941,16 @@ nodes:
       - name: user_prompt
   - id: worker
     name: Worker
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
     outputs:
       - name: code
   - id: reviewer
     name: Reviewer
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: code
     outputs:
@@ -33791,7 +34052,8 @@ nodes:
       - name: user_prompt
   - id: worker
     name: Worker
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
     outputs:
@@ -34350,7 +34612,7 @@ edges:
         let pipelines_dir = tmp.path().join(".pdo").join("pipelines");
         std::fs::create_dir_all(&pipelines_dir).unwrap();
         let yaml = format!(
-            "name: dangling-pipe\nversion: \"1.0\"\nnodes:\n{START_END_YAML}  - id: worker\n    name: worker\n    type: doc-only\n    outputs:\n      - name: result\nedges:\n  - source: {{ node: worker, port: resullt }}\n    target: {{ node: end, port: result }}\n"
+            "name: dangling-pipe\nversion: \"1.0\"\nnodes:\n{START_END_YAML}  - id: worker\n    name: worker\n    type: agent\n    isolated_worktree: false\n    outputs:\n      - name: result\nedges:\n  - source: {{ node: worker, port: resullt }}\n    target: {{ node: end, port: result }}\n"
         );
         std::fs::write(pipelines_dir.join("dangling-pipe.yaml"), yaml).unwrap();
         // #470: the target repo is now checked FIRST in `create_run_inner`, so this
@@ -35422,7 +35684,7 @@ edges:
         let pipelines_dir = dir.join(".pdo").join("pipelines");
         std::fs::create_dir_all(&pipelines_dir).unwrap();
         let yaml = format!(
-            "name: {name}\nversion: \"1.0\"\nnodes:\n{START_END_YAML}  - id: worker\n    name: worker\n    type: doc-only\n    inputs:\n      - name: task\n    outputs:\n      - name: review\n        frontmatter:\n          verdict:\n            type: enum\n            allowed: [PASS, FAIL]\n"
+            "name: {name}\nversion: \"1.0\"\nnodes:\n{START_END_YAML}  - id: worker\n    name: worker\n    type: agent\n    isolated_worktree: false\n    inputs:\n      - name: task\n    outputs:\n      - name: review\n        frontmatter:\n          verdict:\n            type: enum\n            allowed: [PASS, FAIL]\n"
         );
         std::fs::write(pipelines_dir.join(format!("{name}.yaml")), yaml).unwrap();
     }
@@ -35598,11 +35860,11 @@ edges:
             .contains("output validation after retry"));
     }
 
-    /// New coverage: no test reached the doc-only immutability arm before #490. It
+    /// New coverage: no test reached the non-isolated immutability arm before #490. It
     /// needs a real git worktree with a dirty **tracked** file (an untracked artefact
     /// is ignored by the guard).
     #[tokio::test]
-    async fn doc_only_immutability_violation_is_409_not_200() {
+    async fn shared_worktree_immutability_violation_is_409_not_200() {
         let tmp = tempfile::tempdir().unwrap();
         let repo = tmp.path();
         init_git_repo_for_refusal_tests(repo);
@@ -35614,7 +35876,11 @@ edges:
         let wt_dir = worktree_dir_for_run(repo, run_id);
         create_worktree(repo, &wt_dir, &format!("pdo/run-{run_id}"), "HEAD").unwrap();
         // Dirty a TRACKED file from inside the run's worktree.
-        std::fs::write(wt_dir.join("tracked.txt"), "mutated by a doc-only node\n").unwrap();
+        std::fs::write(
+            wt_dir.join("tracked.txt"),
+            "mutated by a non-isolated node\n",
+        )
+        .unwrap();
         assert!(worktree_has_tracked_changes(&wt_dir).unwrap());
 
         // `find_node_type` reads the PROJECTED node defs, not the YAML on disk, so
@@ -35630,7 +35896,7 @@ edges:
                 payload: Some(serde_json::json!({
                     "pipeline_name": pipe,
                     "node_defs": [
-                        { "id": "worker", "node_type": "doc-only", "inputs": [], "outputs": [] }
+                        { "id": "worker", "node_type": "agent", "isolated_worktree": false, "inputs": [], "outputs": [] }
                     ],
                     "edges": [],
                 })),
@@ -35702,7 +35968,7 @@ edges:
         std::fs::write(
             pipelines_dir.join(format!("{pipe}.yaml")),
             format!(
-                "name: {pipe}\nversion: \"1.0\"\nnodes:\n{START_END_YAML}  - id: impl_a\n    name: impl_a\n    type: code-mutating\n    inputs:\n      - name: task\n    outputs:\n      - name: patch\n  - id: impl_b\n    name: impl_b\n    type: code-mutating\n    inputs:\n      - name: task\n    outputs:\n      - name: patch\n"
+                "name: {pipe}\nversion: \"1.0\"\nnodes:\n{START_END_YAML}  - id: impl_a\n    name: impl_a\n    type: agent\n    isolated_worktree: true\n    inputs:\n      - name: task\n    outputs:\n      - name: patch\n  - id: impl_b\n    name: impl_b\n    type: agent\n    isolated_worktree: true\n    inputs:\n      - name: task\n    outputs:\n      - name: patch\n"
             ),
         )
         .unwrap();
@@ -35741,8 +36007,8 @@ edges:
                 payload: Some(serde_json::json!({
                     "pipeline_name": pipe,
                     "node_defs": [
-                        { "id": "impl_a", "node_type": "code-mutating", "inputs": [], "outputs": [] },
-                        { "id": "impl_b", "node_type": "code-mutating", "inputs": [], "outputs": [] },
+                        { "id": "impl_a", "node_type": "agent", "isolated_worktree": true, "inputs": [], "outputs": [] },
+                        { "id": "impl_b", "node_type": "agent", "isolated_worktree": true, "inputs": [], "outputs": [] },
                     ],
                     "edges": [],
                 })),
@@ -35884,7 +36150,7 @@ edges:
         std::fs::write(
             pipelines_dir.join(format!("{pipe}.yaml")),
             format!(
-                "name: {pipe}\nversion: \"1.0\"\nnodes:\n{START_END_YAML}  - id: ship\n    name: ship\n    type: code-mutating\n    inputs:\n      - name: task\n    outputs:\n      - name: patch\n"
+                "name: {pipe}\nversion: \"1.0\"\nnodes:\n{START_END_YAML}  - id: ship\n    name: ship\n    type: agent\n    isolated_worktree: true\n    inputs:\n      - name: task\n    outputs:\n      - name: patch\n"
             ),
         )
         .unwrap();
@@ -35943,7 +36209,7 @@ edges:
                 payload: Some(serde_json::json!({
                     "pipeline_name": pipe,
                     "node_defs": [
-                        { "id": "ship", "node_type": "code-mutating", "inputs": [], "outputs": [] },
+                        { "id": "ship", "node_type": "agent", "isolated_worktree": true, "inputs": [], "outputs": [] },
                     ],
                     "edges": [],
                 })),

--- a/crates/pdo-daemon/src/library_store.rs
+++ b/crates/pdo-daemon/src/library_store.rs
@@ -1023,9 +1023,10 @@ mod tests {
 
     fn make_node(name: &str) -> pipeline::NodeDef {
         pipeline::NodeDef {
+            isolated_worktree: None,
             id: "test-id".to_string(),
             name: name.to_string(),
-            node_type: pipeline::NodeType::DocOnly,
+            node_type: pipeline::NodeType::Agent,
             inputs: vec![pipeline::Port {
                 name: "in".to_string(),
                 repeated: false,
@@ -1105,7 +1106,7 @@ mod tests {
 
             let entry1 = LibraryEntry {
                 name: "Alpha".to_string(),
-                node_type: pipeline::NodeType::DocOnly,
+                node_type: pipeline::NodeType::Agent,
                 inputs: vec![],
                 outputs: vec![],
                 interactive: false,
@@ -1153,7 +1154,7 @@ mod tests {
             // The real entry, parked at the collision slug.
             let entry = LibraryEntry {
                 name: "Typed Reviewer".to_string(),
-                node_type: pipeline::NodeType::DocOnly,
+                node_type: pipeline::NodeType::Agent,
                 inputs: vec![],
                 outputs: vec![],
                 interactive: false,
@@ -1211,7 +1212,7 @@ mod tests {
     fn yaml_round_trip_lossless() {
         let entry = LibraryEntry {
             name: "Complex Node".to_string(),
-            node_type: pipeline::NodeType::CodeMutating,
+            node_type: pipeline::NodeType::Agent,
             // #345/#296: a per-node model must round-trip losslessly.
             model: Some("opus".to_string()),
             // #424: and so must a per-node effort.
@@ -1280,7 +1281,7 @@ mod tests {
         // key, and must round-trip to None (#345/#296 — skip_serializing_if).
         let entry = LibraryEntry {
             name: "Plain".to_string(),
-            node_type: pipeline::NodeType::DocOnly,
+            node_type: pipeline::NodeType::Agent,
             inputs: vec![],
             outputs: vec![],
             interactive: false,
@@ -1315,7 +1316,7 @@ mod tests {
         // entry — the alternative is `diverged` forever (the #345 trap).
         let entry = LibraryEntry {
             name: "Plain".to_string(),
-            node_type: pipeline::NodeType::DocOnly,
+            node_type: pipeline::NodeType::Agent,
             inputs: vec![],
             outputs: vec![],
             interactive: false,
@@ -1370,7 +1371,7 @@ mod tests {
         with_temp_home(|| {
             let base = LibraryEntry {
                 name: String::new(),
-                node_type: pipeline::NodeType::DocOnly,
+                node_type: pipeline::NodeType::Agent,
                 inputs: vec![],
                 outputs: vec![],
                 interactive: false,
@@ -1409,7 +1410,7 @@ mod tests {
 
     fn sample_pipeline_yaml(name: &str) -> String {
         format!(
-            "name: {name}\nnodes:\n  - id: start\n    name: Start\n    type: start\n    outputs:\n      - name: user_prompt\n  - id: planner\n    name: Planner\n    type: doc-only\n    inputs:\n      - name: in\n    outputs:\n      - name: plan\n  - id: end\n    name: End\n    type: end\n    inputs:\n      - name: result\nedges:\n  - source: {{ node: start, port: user_prompt }}\n    target: {{ node: planner, port: in }}\n  - source: {{ node: planner, port: plan }}\n    target: {{ node: end, port: result }}\n"
+            "name: {name}\nnodes:\n  - id: start\n    name: Start\n    type: start\n    outputs:\n      - name: user_prompt\n  - id: planner\n    name: Planner\n    type: agent\n    isolated_worktree: false\n    inputs:\n      - name: in\n    outputs:\n      - name: plan\n  - id: end\n    name: End\n    type: end\n    inputs:\n      - name: result\nedges:\n  - source: {{ node: start, port: user_prompt }}\n    target: {{ node: planner, port: in }}\n  - source: {{ node: planner, port: plan }}\n    target: {{ node: end, port: result }}\n"
         )
     }
 
@@ -1694,7 +1695,7 @@ mod tests {
     fn json_round_trip_preserves_all_port_fields() {
         let entry = LibraryEntry {
             name: "Typed Node".to_string(),
-            node_type: pipeline::NodeType::DocOnly,
+            node_type: pipeline::NodeType::Agent,
             model: None,
             effort: None,
             inputs: vec![
@@ -1791,7 +1792,7 @@ mod tests {
         with_temp_home(|| {
             let entry = LibraryEntry {
                 name: "Schema Node".to_string(),
-                node_type: pipeline::NodeType::CodeMutating,
+                node_type: pipeline::NodeType::Agent,
                 model: None,
                 effort: None,
                 inputs: vec![pipeline::Port {
@@ -2221,7 +2222,7 @@ mod tests {
         format!(
             "name: {name}\nversion: '1.0'\nnodes:\n\
              - id: start\n  name: Start\n  type: start\n  outputs:\n  - name: user_prompt\n  view: {{x: 300, y: 60}}\n\
-             - id: planner\n  name: Planner\n  type: doc-only\n  outputs:\n  - name: plan\n  view: {{x: {planner_x}, y: 260}}\n\
+             - id: planner\n  name: Planner\n  type: agent\n  isolated_worktree: false\n  outputs:\n  - name: plan\n  view: {{x: {planner_x}, y: 260}}\n\
              - id: end\n  name: End\n  type: end\n  inputs:\n  - name: result\n  view: {{x: 300, y: 460}}\n\
              edges:\n\
              - source: {{node: start, port: user_prompt}}\n  target: {{node: planner, port: in}}\n\
@@ -2279,7 +2280,7 @@ mod tests {
         // Same document as `laid_out_pipeline("Demo", 300, "")`: indented block
         // sequences, double-quoted version, block-style `view`, keys reordered, and
         // port defaults spelled out instead of left to the parser.
-        let reserialized = "name: Demo\nversion: \"1.0\"\nnodes:\n  - id: start\n    type: start\n    name: Start\n    view:\n      y: 60\n      x: 300\n    outputs:\n      - name: user_prompt\n        repeated: false\n        side: right\n        port_type: markdown\n  - id: planner\n    type: doc-only\n    name: Planner\n    view:\n      y: 260\n      x: 300\n    outputs:\n      - name: plan\n        side: right\n  - id: end\n    type: end\n    name: End\n    view:\n      y: 460\n      x: 300\n    inputs:\n      - name: result\n        side: left\nedges:\n  - target: {node: planner, port: in}\n    source: {node: start, port: user_prompt}\n  - target: {node: end, port: result}\n    source: {node: planner, port: plan}\n";
+        let reserialized = "name: Demo\nversion: \"1.0\"\nnodes:\n  - id: start\n    type: start\n    name: Start\n    view:\n      y: 60\n      x: 300\n    outputs:\n      - name: user_prompt\n        repeated: false\n        side: right\n        port_type: markdown\n  - id: planner\n    type: agent\n    isolated_worktree: false\n    name: Planner\n    view:\n      y: 260\n      x: 300\n    outputs:\n      - name: plan\n        side: right\n  - id: end\n    type: end\n    name: End\n    view:\n      y: 460\n      x: 300\n    inputs:\n      - name: result\n        side: left\nedges:\n  - target: {node: planner, port: in}\n    source: {node: start, port: user_prompt}\n  - target: {node: end, port: result}\n    source: {node: planner, port: plan}\n";
         let prompts = HashMap::new();
         let handwritten = laid_out_pipeline("Demo", 300, "");
         assert_ne!(
@@ -2320,7 +2321,7 @@ mod tests {
             ),
             (
                 "per-node model",
-                base.replace("  type: doc-only", "  type: doc-only\n  model: opus"),
+                base.replace("  type: agent", "  type: agent\n  model: opus"),
             ),
             (
                 "edge condition",
@@ -2333,7 +2334,7 @@ mod tests {
                 "added node",
                 base.replace(
                     "edges:",
-                    "- id: extra\n  name: Extra\n  type: doc-only\n  outputs:\n  - name: o\nedges:",
+                    "- id: extra\n  name: Extra\n  type: agent\n  isolated_worktree: false\n  outputs:\n  - name: o\nedges:",
                 ),
             ),
             (

--- a/crates/pdo-daemon/src/loop_region.rs
+++ b/crates/pdo-daemon/src/loop_region.rs
@@ -547,9 +547,10 @@ mod tests {
 
     fn node(id: &str, inputs: &[&str], outputs: &[&str]) -> NodeDef {
         NodeDef {
+            isolated_worktree: None,
             id: id.into(),
             name: id.into(),
-            node_type: NodeType::DocOnly,
+            node_type: NodeType::Agent,
             inputs: inputs
                 .iter()
                 .map(|n| Port {

--- a/crates/pdo-daemon/src/merge_action.rs
+++ b/crates/pdo-daemon/src/merge_action.rs
@@ -1,7 +1,7 @@
 /// Pure decision logic for Merge node outcomes, plus the merge-back decision
 /// #503 needed: *may a conflicting merge-back be resolved in the node's favour?*
 ///
-/// Given the result of attempting git merges on upstream code-mutating branches,
+/// Given the result of attempting git merges on upstream isolated branches,
 /// determines whether the Merge node can auto-complete (no conflicts) or needs
 /// to spawn a Claude Code resolver session (conflicts detected).
 ///
@@ -60,6 +60,32 @@ pub(crate) fn spawn_base_sha(events: &[Event], node_id: &str, iter: i64) -> Opti
         .map(str::trim)
         .filter(|sha| !sha.is_empty())
         .map(String::from)
+}
+
+/// The isolation FROZEN onto `(node_id, iter)` at spawn (#653, ADR-0060).
+///
+/// Anchored on the **last** `NodeStarted` for the pair, exactly like
+/// [`spawn_base_sha`] above: `restart_node` and `invalidate_nodes` re-spawn the
+/// same iteration, and the spawn path carries the frozen value forward onto the
+/// new event rather than re-reading the document. That is what makes "an
+/// isolation edit cannot move a running iteration" true — the re-spawn lands
+/// back in the working directory the interrupted one left.
+///
+/// `None` — the node never started, or a pre-#653 run whose events say nothing —
+/// means the caller falls back to the document's answer.
+pub(crate) fn frozen_isolation(events: &[Event], node_id: &str, iter: i64) -> Option<bool> {
+    events
+        .iter()
+        .rev()
+        .find(|e| {
+            e.kind == EventKind::NodeStarted
+                && e.node_id.as_deref() == Some(node_id)
+                && e.iter.unwrap_or(1) == iter
+        })?
+        .payload
+        .as_ref()?
+        .get("isolated_worktree")?
+        .as_bool()
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/pdo-daemon/src/mutation_validator.rs
+++ b/crates/pdo-daemon/src/mutation_validator.rs
@@ -206,6 +206,7 @@ mod tests {
 
     fn simple_node(id: &str, node_type: pipeline::NodeType) -> pipeline::NodeDef {
         pipeline::NodeDef {
+            isolated_worktree: None,
             id: id.to_string(),
             name: id.to_string(),
             node_type,
@@ -224,6 +225,7 @@ mod tests {
 
     fn loop_node(id: &str, max_iter: i64) -> pipeline::NodeDef {
         pipeline::NodeDef {
+            isolated_worktree: None,
             id: id.to_string(),
             name: id.to_string(),
             node_type: pipeline::NodeType::Loop,
@@ -261,6 +263,7 @@ mod tests {
             state.nodes.insert(
                 id.to_string(),
                 event_log::NodeState {
+                    isolated_worktree: None,
                     harness: None,
                     cost: None,
                     node_id: id.to_string(),
@@ -283,10 +286,10 @@ mod tests {
     #[test]
     fn allows_deleting_pending_node() {
         let old = pipeline(vec![
-            simple_node("a", pipeline::NodeType::DocOnly),
-            simple_node("b", pipeline::NodeType::DocOnly),
+            simple_node("a", pipeline::NodeType::Agent),
+            simple_node("b", pipeline::NodeType::Agent),
         ]);
-        let new = pipeline(vec![simple_node("a", pipeline::NodeType::DocOnly)]);
+        let new = pipeline(vec![simple_node("a", pipeline::NodeType::Agent)]);
         let rs = run_state_with_nodes(vec![
             ("a", event_log::NodeStatus::Running),
             ("b", event_log::NodeStatus::Pending),
@@ -302,10 +305,10 @@ mod tests {
     #[test]
     fn rejects_deleting_running_node() {
         let old = pipeline(vec![
-            simple_node("a", pipeline::NodeType::DocOnly),
-            simple_node("b", pipeline::NodeType::DocOnly),
+            simple_node("a", pipeline::NodeType::Agent),
+            simple_node("b", pipeline::NodeType::Agent),
         ]);
-        let new = pipeline(vec![simple_node("b", pipeline::NodeType::DocOnly)]);
+        let new = pipeline(vec![simple_node("b", pipeline::NodeType::Agent)]);
         let rs = run_state_with_nodes(vec![
             ("a", event_log::NodeStatus::Running),
             ("b", event_log::NodeStatus::Pending),
@@ -320,10 +323,10 @@ mod tests {
     #[test]
     fn rejects_deleting_completed_node() {
         let old = pipeline(vec![
-            simple_node("a", pipeline::NodeType::DocOnly),
-            simple_node("b", pipeline::NodeType::DocOnly),
+            simple_node("a", pipeline::NodeType::Agent),
+            simple_node("b", pipeline::NodeType::Agent),
         ]);
-        let new = pipeline(vec![simple_node("b", pipeline::NodeType::DocOnly)]);
+        let new = pipeline(vec![simple_node("b", pipeline::NodeType::Agent)]);
         let rs = run_state_with_nodes(vec![
             ("a", event_log::NodeStatus::Completed),
             ("b", event_log::NodeStatus::Pending),
@@ -337,7 +340,7 @@ mod tests {
 
     #[test]
     fn rejects_deleting_failed_node() {
-        let old = pipeline(vec![simple_node("a", pipeline::NodeType::DocOnly)]);
+        let old = pipeline(vec![simple_node("a", pipeline::NodeType::Agent)]);
         let new = pipeline(vec![]);
         let rs = run_state_with_nodes(vec![("a", event_log::NodeStatus::Failed)]);
 
@@ -348,7 +351,7 @@ mod tests {
 
     #[test]
     fn rejects_deleting_awaiting_user_node() {
-        let old = pipeline(vec![simple_node("a", pipeline::NodeType::DocOnly)]);
+        let old = pipeline(vec![simple_node("a", pipeline::NodeType::Agent)]);
         let new = pipeline(vec![]);
         let rs = run_state_with_nodes(vec![("a", event_log::NodeStatus::AwaitingUser)]);
 
@@ -359,10 +362,10 @@ mod tests {
 
     #[test]
     fn allows_adding_new_nodes() {
-        let old = pipeline(vec![simple_node("a", pipeline::NodeType::DocOnly)]);
+        let old = pipeline(vec![simple_node("a", pipeline::NodeType::Agent)]);
         let new = pipeline(vec![
-            simple_node("a", pipeline::NodeType::DocOnly),
-            simple_node("b", pipeline::NodeType::CodeMutating),
+            simple_node("a", pipeline::NodeType::Agent),
+            simple_node("b", pipeline::NodeType::Agent),
         ]);
         let rs = run_state_with_nodes(vec![("a", event_log::NodeStatus::Running)]);
 
@@ -373,12 +376,12 @@ mod tests {
     #[test]
     fn allows_adding_new_edges() {
         let old = pipeline(vec![
-            simple_node("a", pipeline::NodeType::DocOnly),
-            simple_node("b", pipeline::NodeType::DocOnly),
+            simple_node("a", pipeline::NodeType::Agent),
+            simple_node("b", pipeline::NodeType::Agent),
         ]);
         let mut new = pipeline(vec![
-            simple_node("a", pipeline::NodeType::DocOnly),
-            simple_node("b", pipeline::NodeType::DocOnly),
+            simple_node("a", pipeline::NodeType::Agent),
+            simple_node("b", pipeline::NodeType::Agent),
         ]);
         new.edges.push(pipeline::EdgeDef {
             source: pipeline::EdgeEndpoint {
@@ -486,8 +489,8 @@ mod tests {
     #[test]
     fn multiple_rejections_reported() {
         let old = pipeline(vec![
-            simple_node("a", pipeline::NodeType::DocOnly),
-            simple_node("b", pipeline::NodeType::DocOnly),
+            simple_node("a", pipeline::NodeType::Agent),
+            simple_node("b", pipeline::NodeType::Agent),
             loop_node("loop-1", 5),
         ]);
         let new = pipeline(vec![loop_node("loop-1", 1)]);
@@ -524,8 +527,8 @@ mod tests {
 
     fn pipeline_with_region(region: pipeline::LoopRegion) -> pipeline::PipelineDef {
         let mut p = pipeline(vec![
-            simple_node("impl", pipeline::NodeType::CodeMutating),
-            simple_node("rev", pipeline::NodeType::DocOnly),
+            simple_node("impl", pipeline::NodeType::Agent),
+            simple_node("rev", pipeline::NodeType::Agent),
         ]);
         p.loops = vec![region];
         p
@@ -664,8 +667,8 @@ mod tests {
         // ADR-0007 (amended, #211/#206): a running node is immutable, including
         // its type — spawn used the live pipeline, `pdo complete` replays
         // the run snapshot; a mid-session type swap desyncs the two.
-        let old = pipeline(vec![simple_node("a", pipeline::NodeType::DocOnly)]);
-        let new = pipeline(vec![simple_node("a", pipeline::NodeType::CodeMutating)]);
+        let old = pipeline(vec![simple_node("a", pipeline::NodeType::Agent)]);
+        let new = pipeline(vec![simple_node("a", pipeline::NodeType::Script)]);
         let rs = run_state_with_nodes(vec![("a", event_log::NodeStatus::Running)]);
 
         let result = validate_run_mutation(&old, &new, &rs);
@@ -682,8 +685,8 @@ mod tests {
     fn rejects_changing_type_of_awaiting_user_node() {
         // An awaiting_user node still holds its tmux session — same invariant
         // as running.
-        let old = pipeline(vec![simple_node("a", pipeline::NodeType::DocOnly)]);
-        let new = pipeline(vec![simple_node("a", pipeline::NodeType::CodeMutating)]);
+        let old = pipeline(vec![simple_node("a", pipeline::NodeType::Agent)]);
+        let new = pipeline(vec![simple_node("a", pipeline::NodeType::Script)]);
         let rs = run_state_with_nodes(vec![("a", event_log::NodeStatus::AwaitingUser)]);
 
         let result = validate_run_mutation(&old, &new, &rs);
@@ -694,10 +697,10 @@ mod tests {
     #[test]
     fn rejects_retyping_running_script_node() {
         // #248 / ADR-0007(d): a live `script` node is immutable including its
-        // type — retyping it away (script → doc-only) mid-run would desync the
+        // type — retyping it away (script → agent) mid-run would desync the
         // live pipeline from the run snapshot exactly as for any other node.
         let old = pipeline(vec![simple_node("a", pipeline::NodeType::Script)]);
-        let new = pipeline(vec![simple_node("a", pipeline::NodeType::DocOnly)]);
+        let new = pipeline(vec![simple_node("a", pipeline::NodeType::Agent)]);
         let rs = run_state_with_nodes(vec![("a", event_log::NodeStatus::Running)]);
 
         let result = validate_run_mutation(&old, &new, &rs);
@@ -715,7 +718,7 @@ mod tests {
         // A not-yet-spawned script node has no session/snapshot to desync — its
         // type is freely editable before it runs.
         let old = pipeline(vec![simple_node("a", pipeline::NodeType::Script)]);
-        let new = pipeline(vec![simple_node("a", pipeline::NodeType::CodeMutating)]);
+        let new = pipeline(vec![simple_node("a", pipeline::NodeType::Agent)]);
         let rs = run_state_with_nodes(vec![("a", event_log::NodeStatus::Pending)]);
 
         let result = validate_run_mutation(&old, &new, &rs);
@@ -732,12 +735,12 @@ mod tests {
         // snapshot to desync — its type is freely editable; the scheduler will
         // spawn it from the live pipeline.
         let old = pipeline(vec![
-            simple_node("a", pipeline::NodeType::DocOnly),
-            simple_node("b", pipeline::NodeType::DocOnly),
+            simple_node("a", pipeline::NodeType::Agent),
+            simple_node("b", pipeline::NodeType::Agent),
         ]);
         let new = pipeline(vec![
-            simple_node("a", pipeline::NodeType::CodeMutating),
-            simple_node("b", pipeline::NodeType::CodeMutating),
+            simple_node("a", pipeline::NodeType::Script),
+            simple_node("b", pipeline::NodeType::Script),
         ]);
         // "a" pending in run state, "b" not in run state at all.
         let rs = run_state_with_nodes(vec![("a", event_log::NodeStatus::Pending)]);
@@ -753,8 +756,8 @@ mod tests {
     fn allows_changing_type_of_completed_node() {
         // A completed node holds no live session; it will not re-run this iter,
         // and a future lap re-spawns from the live pipeline consistently.
-        let old = pipeline(vec![simple_node("a", pipeline::NodeType::DocOnly)]);
-        let new = pipeline(vec![simple_node("a", pipeline::NodeType::CodeMutating)]);
+        let old = pipeline(vec![simple_node("a", pipeline::NodeType::Agent)]);
+        let new = pipeline(vec![simple_node("a", pipeline::NodeType::Script)]);
         let rs = run_state_with_nodes(vec![("a", event_log::NodeStatus::Completed)]);
 
         let result = validate_run_mutation(&old, &new, &rs);
@@ -764,10 +767,10 @@ mod tests {
     #[test]
     fn node_not_in_run_state_treated_as_pending() {
         let old = pipeline(vec![
-            simple_node("a", pipeline::NodeType::DocOnly),
-            simple_node("b", pipeline::NodeType::DocOnly),
+            simple_node("a", pipeline::NodeType::Agent),
+            simple_node("b", pipeline::NodeType::Agent),
         ]);
-        let new = pipeline(vec![simple_node("a", pipeline::NodeType::DocOnly)]);
+        let new = pipeline(vec![simple_node("a", pipeline::NodeType::Agent)]);
         let rs = run_state_with_nodes(vec![("a", event_log::NodeStatus::Running)]);
 
         let result = validate_run_mutation(&old, &new, &rs);

--- a/crates/pdo-daemon/src/node_io_resolver.rs
+++ b/crates/pdo-daemon/src/node_io_resolver.rs
@@ -297,6 +297,7 @@ mod tests {
     fn run_state_with(node_id: &str, iters: &[(i64, NodeStatus)]) -> RunState {
         let (head_iter, head_status) = iters.last().cloned().unwrap_or((1, NodeStatus::Pending));
         let node = NodeState {
+            isolated_worktree: None,
             harness: None,
             cost: None,
             node_id: node_id.to_string(),
@@ -331,9 +332,10 @@ mod tests {
             variables: HashMap::new(),
             nodes: vec![
                 NodeDef {
+                    isolated_worktree: None,
                     id: "planner".into(),
                     name: "planner".into(),
-                    node_type: NodeType::DocOnly,
+                    node_type: NodeType::Agent,
                     inputs: vec![Port {
                         name: "task".into(),
                         repeated: false,
@@ -366,9 +368,10 @@ mod tests {
                     auto_fail: None,
                 },
                 NodeDef {
+                    isolated_worktree: None,
                     id: "implementer".into(),
                     name: "implementer".into(),
-                    node_type: NodeType::CodeMutating,
+                    node_type: NodeType::Agent,
                     inputs: vec![Port {
                         name: "plan".into(),
                         repeated: false,
@@ -534,9 +537,10 @@ mod tests {
             variables: HashMap::new(),
             nodes: vec![
                 NodeDef {
+                    isolated_worktree: None,
                     id: "reviewer".into(),
                     name: "reviewer".into(),
-                    node_type: NodeType::DocOnly,
+                    node_type: NodeType::Agent,
                     inputs: vec![],
                     outputs: vec![Port {
                         name: "review".into(),
@@ -559,9 +563,10 @@ mod tests {
                     auto_fail: None,
                 },
                 NodeDef {
+                    isolated_worktree: None,
                     id: "implementer".into(),
                     name: "implementer".into(),
-                    node_type: NodeType::CodeMutating,
+                    node_type: NodeType::Agent,
                     inputs: vec![Port {
                         name: "reviews".into(),
                         repeated: true,
@@ -732,9 +737,10 @@ mod tests {
             variables: HashMap::new(),
             nodes: vec![
                 NodeDef {
+                    isolated_worktree: None,
                     id: "a".into(),
                     name: "a".into(),
-                    node_type: NodeType::DocOnly,
+                    node_type: NodeType::Agent,
                     inputs: vec![],
                     outputs: vec![Port {
                         name: "out".into(),
@@ -757,9 +763,10 @@ mod tests {
                     auto_fail: None,
                 },
                 NodeDef {
+                    isolated_worktree: None,
                     id: "b".into(),
                     name: "b".into(),
-                    node_type: NodeType::DocOnly,
+                    node_type: NodeType::Agent,
                     inputs: vec![],
                     outputs: vec![Port {
                         name: "out".into(),
@@ -782,9 +789,10 @@ mod tests {
                     auto_fail: None,
                 },
                 NodeDef {
+                    isolated_worktree: None,
                     id: "merger".into(),
                     name: "merger".into(),
-                    node_type: NodeType::DocOnly,
+                    node_type: NodeType::Agent,
                     inputs: vec![Port {
                         name: "docs".into(),
                         repeated: false,
@@ -875,9 +883,10 @@ mod tests {
             variables: HashMap::new(),
             nodes: vec![
                 NodeDef {
+                    isolated_worktree: None,
                     id: "planner".into(),
                     name: "planner".into(),
-                    node_type: NodeType::DocOnly,
+                    node_type: NodeType::Agent,
                     inputs: vec![],
                     outputs: vec![Port {
                         name: "plan".into(),
@@ -900,9 +909,10 @@ mod tests {
                     auto_fail: None,
                 },
                 NodeDef {
+                    isolated_worktree: None,
                     id: "implementer".into(),
                     name: "implementer".into(),
-                    node_type: NodeType::CodeMutating,
+                    node_type: NodeType::Agent,
                     // Declares NO inputs — the input is emergent.
                     inputs: vec![],
                     outputs: vec![],
@@ -959,9 +969,10 @@ mod tests {
         }
 
         let mk_node = |id: &str, has_out: bool| NodeDef {
+            isolated_worktree: None,
             id: id.into(),
             name: id.into(),
-            node_type: NodeType::DocOnly,
+            node_type: NodeType::Agent,
             inputs: vec![],
             outputs: if has_out {
                 vec![Port {
@@ -1044,9 +1055,10 @@ mod tests {
         }
 
         let mk_node = |id: &str, out: Option<&str>| NodeDef {
+            isolated_worktree: None,
             id: id.into(),
             name: id.into(),
-            node_type: NodeType::DocOnly,
+            node_type: NodeType::Agent,
             inputs: vec![],
             outputs: out
                 .map(|o| {
@@ -1136,9 +1148,10 @@ mod tests {
             version: None,
             variables: HashMap::new(),
             nodes: vec![NodeDef {
+                isolated_worktree: None,
                 id: "designer".into(),
                 name: "designer".into(),
-                node_type: NodeType::DocOnly,
+                node_type: NodeType::Agent,
                 inputs: vec![],
                 outputs: vec![Port {
                     name: "report".into(),

--- a/crates/pdo-daemon/src/node_primitives.rs
+++ b/crates/pdo-daemon/src/node_primitives.rs
@@ -241,8 +241,11 @@ pub(crate) fn start_node(params: &StartNodeParams<'_>) -> StartNodeResult {
 
     let input_paths = resolve_inputs(params, node);
 
-    let has_sub_worktree = node.node_type == pipeline::NodeType::CodeMutating
-        || node.node_type == pipeline::NodeType::Merge;
+    // #653 / ADR-0060: where this NodeRun works, read off the document. Unlike
+    // `node_spawn`, this path never re-poses a live iteration — the
+    // `has_node_started_event` guard above already answered `AlreadyDone` for any
+    // iteration that has started — so there is no frozen value to prefer here.
+    let has_sub_worktree = node.is_isolated();
 
     // #503 / ADR-0036: the commit the sub-worktree was cut from, recorded on
     // `NodeStarted` below. Without it a merge-back conflict on this iteration can
@@ -518,6 +521,9 @@ pub(crate) fn start_node(params: &StartNodeParams<'_>) -> StartNodeResult {
         payload: Some(serde_json::json!({
             "prompt_preview": full_prompt.chars().take(500).collect::<String>(),
             "node_type": node_type_str(&node.node_type),
+            // #653/ADR-0060: FREEZE where this NodeRun works. Mirrors the
+            // `spawn_node` payload — every later reader asks this event.
+            "isolated_worktree": has_sub_worktree,
             "input_paths": input_paths,
             // #424: launch-time model + effort, **resolved**. Mirrors the
             // `spawn_node` payload; see the comment there for why the model is
@@ -532,7 +538,7 @@ pub(crate) fn start_node(params: &StartNodeParams<'_>) -> StartNodeResult {
             // and every pre-#473 row. Mirrors the `spawn_node` payload.
             "session_id": session_id,
             // #503: the sub-worktree's base commit. Absent for a node with no
-            // sub-worktree (`doc-only`/`script`), which never merges back.
+            // sub-worktree (a non-isolated agent/script), which never merges back.
             "base_sha": spawn_base_sha,
         })),
     };
@@ -685,16 +691,7 @@ fn resolve_inputs(
 }
 
 fn node_type_str(nt: &pipeline::NodeType) -> &'static str {
-    match nt {
-        pipeline::NodeType::DocOnly => "doc-only",
-        pipeline::NodeType::CodeMutating => "code-mutating",
-        pipeline::NodeType::Start => "start",
-        pipeline::NodeType::End => "end",
-        pipeline::NodeType::Switch => "switch",
-        pipeline::NodeType::Loop => "loop",
-        pipeline::NodeType::Merge => "merge",
-        pipeline::NodeType::Script => "script",
-    }
+    nt.as_str()
 }
 
 // ---------------------------------------------------------------------------
@@ -933,6 +930,10 @@ mod tests {
 
     fn make_node(id: &str, node_type: NodeType, inputs: &[&str], outputs: &[&str]) -> NodeDef {
         NodeDef {
+            // #653: these fixtures exercise graph wiring, not worktrees — a
+            // shared-worktree node keeps them out of `git worktree add` on a
+            // scratch dir. Isolation-sensitive tests state `Some(true)`.
+            isolated_worktree: Some(false),
             id: id.into(),
             name: id.into(),
             node_type,
@@ -977,9 +978,10 @@ mod tests {
 
     fn make_node_with_repeated_input(id: &str, port_name: &str) -> NodeDef {
         NodeDef {
+            isolated_worktree: None,
             id: id.into(),
             name: id.into(),
-            node_type: NodeType::DocOnly,
+            node_type: NodeType::Agent,
             inputs: vec![Port {
                 name: port_name.into(),
                 repeated: true,
@@ -1037,6 +1039,7 @@ mod tests {
 
     fn running_node(id: &str, iter: i64) -> NodeState {
         NodeState {
+            isolated_worktree: None,
             harness: None,
             cost: None,
             node_id: id.into(),
@@ -1060,6 +1063,7 @@ mod tests {
 
     fn completed_node(id: &str, iter: i64) -> NodeState {
         NodeState {
+            isolated_worktree: None,
             harness: None,
             cost: None,
             node_id: id.into(),
@@ -1083,6 +1087,7 @@ mod tests {
 
     fn pending_node(id: &str) -> NodeState {
         NodeState {
+            isolated_worktree: None,
             harness: None,
             cost: None,
             node_id: id.into(),
@@ -1109,7 +1114,7 @@ mod tests {
             name: "test".into(),
             version: None,
             variables: HashMap::new(),
-            nodes: vec![make_node("worker", NodeType::DocOnly, &["task"], &["out"])],
+            nodes: vec![make_node("worker", NodeType::Agent, &["task"], &["out"])],
             edges: vec![],
             loops: Vec::new(),
             notes: Vec::new(),
@@ -1208,7 +1213,7 @@ mod tests {
             name: "test".into(),
             version: None,
             variables: HashMap::new(),
-            nodes: vec![make_node("worker", NodeType::DocOnly, &[], &["out"])],
+            nodes: vec![make_node("worker", NodeType::Agent, &[], &["out"])],
             edges: vec![],
             loops: Vec::new(),
             notes: Vec::new(),
@@ -1315,8 +1320,8 @@ mod tests {
             version: None,
             variables: HashMap::new(),
             nodes: vec![
-                make_node("planner", NodeType::DocOnly, &["task"], &["plan"]),
-                make_node("implementer", NodeType::DocOnly, &["plan"], &["summary"]),
+                make_node("planner", NodeType::Agent, &["task"], &["plan"]),
+                make_node("implementer", NodeType::Agent, &["plan"], &["summary"]),
             ],
             edges: vec![make_edge("planner", "plan", "implementer", "plan")],
             loops: Vec::new(),
@@ -1379,8 +1384,8 @@ mod tests {
             version: None,
             variables: HashMap::new(),
             nodes: vec![
-                make_node("planner", NodeType::DocOnly, &["task"], &["plan"]),
-                make_node("implementer", NodeType::DocOnly, &["plan"], &["summary"]),
+                make_node("planner", NodeType::Agent, &["task"], &["plan"]),
+                make_node("implementer", NodeType::Agent, &["plan"], &["summary"]),
             ],
             edges: vec![make_edge("planner", "plan", "implementer", "plan")],
             loops: Vec::new(),
@@ -1445,9 +1450,9 @@ mod tests {
             version: None,
             variables: HashMap::new(),
             nodes: vec![
-                make_node("up", NodeType::DocOnly, &["task"], &["code"]),
+                make_node("up", NodeType::Agent, &["task"], &["code"]),
                 // `impl` declares no inputs — the `code` input is emergent.
-                make_node("impl", NodeType::DocOnly, &[], &["out"]),
+                make_node("impl", NodeType::Agent, &[], &["out"]),
             ],
             edges: vec![make_edge("up", "code", "impl", "code")],
             loops: Vec::new(),
@@ -1504,8 +1509,8 @@ mod tests {
             version: None,
             variables: HashMap::new(),
             nodes: vec![
-                make_node("skipme", NodeType::DocOnly, &["task"], &["decl_out"]),
-                make_node("down", NodeType::DocOnly, &["edge_out"], &["z"]),
+                make_node("skipme", NodeType::Agent, &["task"], &["decl_out"]),
+                make_node("down", NodeType::Agent, &["edge_out"], &["z"]),
             ],
             // The outgoing edge reads a DIFFERENT source port than the declared one.
             edges: vec![make_edge("skipme", "edge_out", "down", "edge_out")],
@@ -1536,7 +1541,7 @@ mod tests {
             name: "test".into(),
             version: None,
             variables: HashMap::new(),
-            nodes: vec![make_node("lonely", NodeType::DocOnly, &["task"], &[])],
+            nodes: vec![make_node("lonely", NodeType::Agent, &["task"], &[])],
             edges: vec![],
             loops: Vec::new(),
             notes: Vec::new(),
@@ -1561,7 +1566,7 @@ mod tests {
             name: "test".into(),
             version: None,
             variables: HashMap::new(),
-            nodes: vec![make_node("entry", NodeType::DocOnly, &["task"], &["out"])],
+            nodes: vec![make_node("entry", NodeType::Agent, &["task"], &["out"])],
             edges: vec![],
             loops: Vec::new(),
             notes: Vec::new(),
@@ -1612,11 +1617,11 @@ mod tests {
             version: None,
             variables: HashMap::new(),
             nodes: vec![
-                make_node("planner", NodeType::DocOnly, &["task"], &["plan"]),
-                make_node("researcher", NodeType::DocOnly, &["task"], &["research"]),
+                make_node("planner", NodeType::Agent, &["task"], &["plan"]),
+                make_node("researcher", NodeType::Agent, &["task"], &["research"]),
                 make_node(
                     "implementer",
-                    NodeType::DocOnly,
+                    NodeType::Agent,
                     &["plan", "research"],
                     &["summary"],
                 ),
@@ -1678,6 +1683,7 @@ mod tests {
     fn completed_node_iters(id: &str, iters: &[(i64, NodeStatus)]) -> NodeState {
         let (head_iter, head_status) = iters.last().cloned().unwrap_or((1, NodeStatus::Pending));
         NodeState {
+            isolated_worktree: None,
             harness: None,
             cost: None,
             node_id: id.into(),
@@ -1713,7 +1719,7 @@ mod tests {
             version: None,
             variables: HashMap::new(),
             nodes: vec![
-                make_node("reviewer", NodeType::DocOnly, &["task"], &["review"]),
+                make_node("reviewer", NodeType::Agent, &["task"], &["review"]),
                 make_node_with_repeated_input("implementer", "reviews"),
             ],
             edges: vec![EdgeDef {
@@ -1792,8 +1798,8 @@ mod tests {
             version: None,
             variables: HashMap::new(),
             nodes: vec![
-                make_node("reviewer", NodeType::DocOnly, &["task"], &["review"]),
-                make_node("implementer", NodeType::DocOnly, &["review"], &["summary"]),
+                make_node("reviewer", NodeType::Agent, &["task"], &["review"]),
+                make_node("implementer", NodeType::Agent, &["review"], &["summary"]),
             ],
             edges: vec![make_edge("reviewer", "review", "implementer", "review")],
             loops: Vec::new(),
@@ -1857,8 +1863,8 @@ mod tests {
             version: None,
             variables: HashMap::new(),
             nodes: vec![
-                make_node("reviewer", NodeType::DocOnly, &["task"], &["review"]),
-                make_node("implementer", NodeType::DocOnly, &["review"], &["summary"]),
+                make_node("reviewer", NodeType::Agent, &["task"], &["review"]),
+                make_node("implementer", NodeType::Agent, &["review"], &["summary"]),
             ],
             edges: vec![make_edge("reviewer", "review", "implementer", "review")],
             loops: Vec::new(),
@@ -2136,7 +2142,7 @@ mod tests {
             name: "test".into(),
             version: None,
             variables: HashMap::new(),
-            nodes: vec![make_node("worker", NodeType::DocOnly, &["task"], &["out"])],
+            nodes: vec![make_node("worker", NodeType::Agent, &["task"], &["out"])],
             edges: vec![],
             loops: Vec::new(),
             notes: Vec::new(),

--- a/crates/pdo-daemon/src/node_spawn.rs
+++ b/crates/pdo-daemon/src/node_spawn.rs
@@ -540,12 +540,19 @@ pub(crate) async fn spawn_node(
         }
     }
 
-    let has_sub_worktree = node.node_type == pipeline::NodeType::CodeMutating
-        || node.node_type == pipeline::NodeType::Merge;
+    // #653 / ADR-0060: where this NodeRun works. The FROZEN value wins over the
+    // document — a re-spawn of the same iteration (restart / invalidate) must
+    // land back in the directory the interrupted one left, even if the graph was
+    // edited in between (ADR-0007). Only a first spawn reads the node's own
+    // `isolated_worktree`, and that reading is what gets frozen below.
+    let has_sub_worktree = loaded
+        .as_ref()
+        .and_then(|(events, _)| merge_action::frozen_isolation(events, &node.id, iter))
+        .unwrap_or_else(|| node.is_isolated());
 
     // Track the sub-worktree + branch this spawn creates so an abort in the
     // panic-isolated span below can reap them (#279). `None` for nodes that own
-    // no worktree (doc-only / control nodes).
+    // no worktree (a non-isolated agent/script, control nodes).
     let mut orphan_to_reap: Option<(PathBuf, String)> = None;
     // #503 / ADR-0036: the commit the sub-worktree is cut from, recorded on
     // `NodeStarted`. It is the sole basis on which a later merge-back conflict may
@@ -570,7 +577,7 @@ pub(crate) async fn spawn_node(
         // #489-B: `ensure_sub_worktree`, not `create_sub_worktree`. The bare create
         // replayed `git worktree add -b <branch>` on a branch that already existed
         // and failed with exit 255 on EVERY re-spawn of the same iteration — i.e. on
-        // every `restart_node` of a `code-mutating` / `merge` node, 100% of the time.
+        // every `restart_node` of an isolated node, 100% of the time.
         match ensure_sub_worktree(
             spawn_ctx.repo_root,
             &sub_wt_dir,
@@ -800,16 +807,13 @@ pub(crate) async fn spawn_node(
             iter: Some(iter),
             payload: Some(serde_json::json!({
                 "prompt_preview": full_prompt.chars().take(500).collect::<String>(),
-                "node_type": match node.node_type {
-                    pipeline::NodeType::DocOnly => "doc-only",
-                    pipeline::NodeType::CodeMutating => "code-mutating",
-                    pipeline::NodeType::Start => "start",
-                    pipeline::NodeType::End => "end",
-                    pipeline::NodeType::Switch => "switch",
-                    pipeline::NodeType::Loop => "loop",
-                    pipeline::NodeType::Merge => "merge",
-                    pipeline::NodeType::Script => "script",
-                },
+                "node_type": node.node_type.as_str(),
+                // #653/ADR-0060: FREEZE where this NodeRun works. Every later
+                // reader — the re-spawn above, the restart probe, the completion
+                // path's merge-back decision — asks this event, never the
+                // document, so an isolation edit lands on the next launch and
+                // never under a live node's feet.
+                "isolated_worktree": has_sub_worktree,
                 // #424: the launch-time model and effort, **resolved** (post
                 // node → instance precedence, post empty-string collapse) — not
                 // the raw `NodeDef` values. This is what the resume path reads

--- a/crates/pdo-daemon/src/outputs_validator.rs
+++ b/crates/pdo-daemon/src/outputs_validator.rs
@@ -298,9 +298,10 @@ mod tests {
 
     fn make_node(id: &str, outputs: Vec<Port>) -> NodeDef {
         NodeDef {
+            isolated_worktree: None,
             id: id.into(),
             name: id.into(),
-            node_type: NodeType::DocOnly,
+            node_type: NodeType::Agent,
             inputs: Vec::new(),
             outputs,
             interactive: false,

--- a/crates/pdo-daemon/src/pipeline.rs
+++ b/crates/pdo-daemon/src/pipeline.rs
@@ -28,8 +28,11 @@ pub(crate) struct Diagnostic {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub(crate) enum NodeType {
-    DocOnly,
-    CodeMutating,
+    /// The one agentic node type (#653 / ADR-0060). It replaces the retired pair
+    /// of types, which named an *effect* while the runtime only ever read them as
+    /// a working-directory decision. Where the NodeRun works is now the node's
+    /// own `isolated_worktree` line, not a guess from its type.
+    Agent,
     Start,
     End,
     Switch,
@@ -38,23 +41,47 @@ pub(crate) enum NodeType {
     /// A node that runs author-written bash deterministically instead of
     /// launching Claude (#248 / ADR-0017). Runs in a tmux session (attachable
     /// like any NodeRun) whose tail is `timeout N bash <body>`: exit 0 ⇒ node
-    /// completes, non-zero/timeout ⇒ node fails. v1 is doc-only-effect (no
-    /// sub-worktree; runs in the run's shared worktree).
+    /// completes, non-zero/timeout ⇒ node fails. Shares the Run worktree by
+    /// default and opts into isolation like any `agent` (#653).
     Script,
 }
 
 impl NodeType {
-    /// A *regular* node (doc-only / code-mutating / script) declares no inputs:
-    /// its inputs are emergent, derived from incoming edges and named after the
-    /// edge target port (#149 / ADR-0011). Structural nodes (start/end/switch/
-    /// loop/merge) keep their required, declared input ports. A `script`
-    /// node consumes whole artifacts by edge just like a work node, so its inputs
-    /// are emergent too (#248).
+    /// A *regular* node (agent / script) declares no inputs: its inputs are
+    /// emergent, derived from incoming edges and named after the edge target
+    /// port (#149 / ADR-0011). Structural nodes (start/end/switch/loop/merge)
+    /// keep their required, declared input ports. A `script` node consumes whole
+    /// artifacts by edge just like a work node, so its inputs are emergent too
+    /// (#248).
     pub(crate) fn has_emergent_inputs(&self) -> bool {
-        matches!(
-            self,
-            NodeType::DocOnly | NodeType::CodeMutating | NodeType::Script
-        )
+        matches!(self, NodeType::Agent | NodeType::Script)
+    }
+
+    /// The isolation this type carries when the document says nothing (#653 /
+    /// ADR-0060): an `agent` is isolated, a `script` shares the Run worktree,
+    /// and every other type carries no isolation setting at all — `merge` is
+    /// isolated by construction, structural nodes never run in a worktree of
+    /// their own. `None` is what keeps `isolated_worktree` off a Merge/Start/End
+    /// document instead of writing a line nobody may edit.
+    pub(crate) fn default_isolation(&self) -> Option<bool> {
+        match self {
+            NodeType::Agent => Some(true),
+            NodeType::Script => Some(false),
+            _ => None,
+        }
+    }
+
+    /// The wire/YAML spelling of this type — the single place the strings live.
+    pub(crate) fn as_str(&self) -> &'static str {
+        match self {
+            NodeType::Agent => "agent",
+            NodeType::Start => "start",
+            NodeType::End => "end",
+            NodeType::Switch => "switch",
+            NodeType::Loop => "loop",
+            NodeType::Merge => "merge",
+            NodeType::Script => "script",
+        }
     }
 }
 
@@ -200,6 +227,38 @@ pub(crate) struct NodeDef {
     /// Projet / instance. Semantic, not layout.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub auto_fail: Option<bool>,
+    /// Where this node's NodeRun works (#653, ADR-0060). `true` ⇒ a sub-worktree
+    /// of its own; `false` ⇒ the Run's shared worktree. Carried only by `agent`
+    /// and `script`, where [`normalize_node_value`] fills the type's default
+    /// (`agent` isolated, `script` shared) so the parsed document ALWAYS states
+    /// the choice — including when it equals the default. `None` on `merge`
+    /// (isolated by construction) and on structural nodes (no worktree of their
+    /// own). Semantic, not layout: moving a node between worktrees changes what
+    /// the pipeline does, so it enters the diff and the library content hash.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub isolated_worktree: Option<bool>,
+}
+
+impl NodeDef {
+    /// Whether this node's NodeRun gets a sub-worktree of its own (#653,
+    /// ADR-0060). `merge` is isolated by construction and exposes no setting;
+    /// `agent`/`script` read their explicit line, falling back to the type's
+    /// default for a `NodeDef` built in code rather than parsed; every other
+    /// type runs in the Run worktree.
+    ///
+    /// This is the *document's* answer. A live NodeRun reads its FROZEN answer
+    /// off `NodeStarted` instead — editing the graph never moves a running
+    /// iteration between worktrees.
+    pub(crate) fn is_isolated(&self) -> bool {
+        match self.node_type {
+            NodeType::Merge => true,
+            NodeType::Agent | NodeType::Script => self
+                .isolated_worktree
+                .or_else(|| self.node_type.default_isolation())
+                .unwrap_or(false),
+            _ => false,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -457,18 +516,17 @@ const KNOWN_TOP_LEVEL_KEYS: &[&str] = &[
 ];
 
 /// The node `type` strings the parser accepts verbatim. Anything else is coerced
-/// to `doc-only` with a warning (see `normalize_node_value`); `for-each`/`foreach`
+/// to `agent` with a warning (see `normalize_node_value`); `for-each`/`foreach`
 /// are refused outright (retired in ADR-0011).
+///
+/// #653 / ADR-0060: `doc-only` and `code-mutating` are GONE, with no alias and no
+/// migrator. They now take the same generic path as any other invalid value —
+/// coerced to `agent` with the unknown-type warning — because a bespoke
+/// diagnostic for a retired type is a compatibility branch by another name.
 pub(crate) const VALID_NODE_TYPES: &[&str] = &[
-    "doc-only",
-    "code-mutating",
-    "start",
-    "end",
-    "switch",
-    "loop",
-    "merge",
+    "agent", "start", "end", "switch", "loop", "merge",
     // #248: without this, a `type: script` node is silently rewritten to
-    // `doc-only` with only a diagnostic (see the layer-1 test).
+    // `agent` with only a diagnostic (see the layer-1 test).
     "script",
 ];
 
@@ -479,10 +537,15 @@ pub(crate) const VALID_NODE_TYPES: &[&str] = &[
 /// for node-type handling:
 ///
 /// - `for-each` / `foreach` → hard `Err` (the type was removed in ADR-0011;
-///   coercing a fan-out to `doc-only` would run each item's work zero times).
-/// - missing `type` → default to `doc-only` (noisy warning).
-/// - unknown `type` → coerce to `doc-only` (noisy warning).
+///   coercing a fan-out to `agent` would run each item's work zero times).
+/// - missing `type` → default to `agent` (noisy warning).
+/// - unknown `type` → coerce to `agent` (noisy warning). This is the arm the
+///   retired `doc-only` / `code-mutating` now land in (#653).
 /// - a known type (incl. legacy `switch`/`loop`) → left untouched, no warning.
+///
+/// It then stamps the node's isolation default (#653): an `agent`/`script` with
+/// no `isolated_worktree` key gets its type's default written in, so a parsed
+/// document always states where the node works.
 ///
 /// A non-mapping value (e.g. a stray scalar in the `nodes:` list) is a no-op.
 pub(crate) fn normalize_node_value(
@@ -501,7 +564,7 @@ pub(crate) fn normalize_node_value(
 
     match node_map.get(&type_key).and_then(|v| v.as_str()) {
         // ForEach is RETIRED (ADR-0011 / #269): a hard refusal, not the
-        // warn+coerce below — silently rewriting a fan-out node to doc-only
+        // warn+coerce below — silently rewriting a fan-out node to a work node
         // would run each item's work zero times.
         Some(t @ ("for-each" | "foreach")) => {
             return Err(ParseError::MissingField(format!(
@@ -512,21 +575,23 @@ pub(crate) fn normalize_node_value(
         None => {
             diagnostics.push(Diagnostic {
                 severity: Severity::Warning,
-                message: format!("node '{node_id}': missing 'type', defaulting to 'doc-only'"),
+                message: format!("node '{node_id}': missing 'type', defaulting to 'agent'"),
             });
-            node_map.insert(type_key, serde_yaml::Value::String("doc-only".into()));
+            node_map.insert(type_key, serde_yaml::Value::String("agent".into()));
         }
         Some(t) if !VALID_NODE_TYPES.contains(&t) => {
             diagnostics.push(Diagnostic {
                 severity: Severity::Warning,
                 message: format!(
-                    "node '{node_id}': unknown node type '{t}', defaulting to 'doc-only'"
+                    "node '{node_id}': unknown node type '{t}', defaulting to 'agent'"
                 ),
             });
-            node_map.insert(type_key, serde_yaml::Value::String("doc-only".into()));
+            node_map.insert(type_key, serde_yaml::Value::String("agent".into()));
         }
         _ => {}
     }
+
+    stamp_isolation_default(node_map);
 
     // #550: fold a legacy flat `model:` / `effort:` into `harnesses.claude.*` so
     // that a parse is lossless even before the on-disk migrator has rewritten the
@@ -535,6 +600,42 @@ pub(crate) fn normalize_node_value(
     fold_flat_model_effort_into_harnesses(node_map);
 
     Ok(diagnostics)
+}
+
+/// The node key that says where a NodeRun works (#653, ADR-0060).
+pub(crate) const ISOLATED_WORKTREE_KEY: &str = "isolated_worktree";
+
+/// Write a node's isolation default into the raw YAML when the document is
+/// silent (#653, ADR-0060).
+///
+/// This is what makes "the Document always states the choice" true without
+/// asking every author to type the line: an `agent` with no `isolated_worktree`
+/// parses as isolated and *re-serializes* saying so. A type that carries no
+/// isolation (`merge`, `start`, `end`, `switch`, `loop`) has any stray key
+/// dropped rather than round-tripped — a Merge is isolated by construction, and
+/// a line nobody may edit would only invite someone to edit it.
+///
+/// Runs after the type normalization above, so it reads the coerced type.
+fn stamp_isolation_default(node_map: &mut serde_yaml::Mapping) {
+    let key = serde_yaml::Value::String(ISOLATED_WORKTREE_KEY.into());
+    let default = match node_map
+        .get(serde_yaml::Value::String("type".into()))
+        .and_then(|v| v.as_str())
+    {
+        Some("agent") => Some(true),
+        Some("script") => Some(false),
+        _ => None,
+    };
+    match default {
+        Some(value) => {
+            if !node_map.get(&key).map(|v| v.is_bool()).unwrap_or(false) {
+                node_map.insert(key, serde_yaml::Value::Bool(value));
+            }
+        }
+        None => {
+            node_map.remove(&key);
+        }
+    }
 }
 
 /// Fold a node's legacy flat `model:` / `effort:` keys (#296/#424) into
@@ -730,7 +831,7 @@ pub(crate) fn parse_pipeline(yaml: &str) -> Result<ParseResult, ParseError> {
     }
 
     for node in &pipeline.nodes {
-        if !matches!(node.node_type, NodeType::DocOnly | NodeType::CodeMutating) {
+        if node.node_type != NodeType::Agent {
             for port in node
                 .outputs
                 .iter()
@@ -1091,7 +1192,8 @@ nodes:
       - name: result
   - id: ab12cd34
     name: planner
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
     outputs:
@@ -1112,7 +1214,7 @@ nodes:
             .find(|n| n.id == "ab12cd34")
             .unwrap();
         assert_eq!(node.name, "planner");
-        assert_eq!(node.node_type, NodeType::DocOnly);
+        assert_eq!(node.node_type, NodeType::Agent);
         assert_eq!(node.inputs.len(), 1);
         assert_eq!(node.inputs[0].name, "task");
         assert_eq!(node.outputs.len(), 1);
@@ -1128,7 +1230,8 @@ nodes:
 name: no-name
 nodes:
   - id: ab12cd34
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: in
     outputs:
@@ -1147,7 +1250,8 @@ name: old-style
 nodes:
   - id: ab12cd34
     name: worker
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     prompt_file: prompts/worker.md
     inputs:
       - name: in
@@ -1188,7 +1292,8 @@ nodes:
       - name: result
   - id: ab12cd34
     name: worker
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs: []
     outputs: []
 "#;
@@ -1209,7 +1314,8 @@ nodes:
       - name: user_prompt
   - id: ab12cd34
     name: worker
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs: []
     outputs: []
 "#;
@@ -1323,7 +1429,8 @@ name: with-halt
 nodes:
   - id: ab12cd34
     name: reviewer
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     outputs:
       - name: review
 edges:
@@ -1343,7 +1450,8 @@ name: with-reason
 nodes:
   - id: ab12cd34
     name: reviewer
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     outputs:
       - name: review
 edges:
@@ -1370,19 +1478,22 @@ name: conditional-edges
 nodes:
   - id: ab000001
     name: reviewer
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     outputs:
       - name: review
   - id: ab000002
     name: implementer
-    type: code-mutating
+    type: agent
+    isolated_worktree: true
     inputs:
       - name: review
     outputs:
       - name: code
   - id: ab000003
     name: archiver
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: review
     outputs:
@@ -1421,7 +1532,8 @@ name: interactive-pipe
 nodes:
   - id: ab000001
     name: griller
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     interactive: true
     inputs:
       - name: task
@@ -1429,7 +1541,8 @@ nodes:
       - name: brief
   - id: ab000002
     name: worker
-    type: code-mutating
+    type: agent
+    isolated_worktree: true
     inputs:
       - name: brief
     outputs:
@@ -1545,14 +1658,16 @@ variables:
 nodes:
   - id: ab000001
     name: planner
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
     outputs:
       - name: plan
   - id: ab000002
     name: implementer
-    type: code-mutating
+    type: agent
+    isolated_worktree: true
     inputs:
       - name: plan
     outputs:
@@ -1579,12 +1694,14 @@ name: dangling
 nodes:
   - id: ab000001
     name: planner
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     outputs:
       - name: plan
   - id: ab000002
     name: implementer
-    type: doc-only
+    type: agent
+    isolated_worktree: false
 edges:
   - source: { node: ab000001, port: plaan }
     target: { node: ab000002, port: spec }
@@ -1617,12 +1734,14 @@ name: dangling-node
 nodes:
   - id: ab000001
     name: planner
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     outputs:
       - name: plan
   - id: ab000002
     name: implementer
-    type: doc-only
+    type: agent
+    isolated_worktree: false
 edges:
   - source: { node: ab000001, port: plan }
     target: { node: ghost, port: plan }
@@ -1653,7 +1772,8 @@ nodes:
       - name: user_prompt
   - id: ab000001
     name: planner
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     outputs:
       - name: plan
   - id: end
@@ -1686,7 +1806,8 @@ nodes:
       - name: user_prompt
   - id: ab000001
     name: worker
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     outputs:
       - name: out
   - id: end
@@ -1729,7 +1850,8 @@ name: bad-edge
 nodes:
   - id: ab000001
     name: planner
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     outputs:
       - name: plan
 edges:
@@ -1751,7 +1873,7 @@ edges:
     #[test]
     fn warns_on_source_port_typo_but_not_emergent_target() {
         // Outputs stay declared, so a source-port typo is still a warning. Inputs
-        // on a regular (doc-only / code-mutating) node are emergent (#149): the
+        // on a regular (agent / script) node are emergent (#149): the
         // input is derived from the edge and named after the target port, so any
         // target port is valid by construction — no false-positive "target port
         // not found" diagnostic (regression guard for run-minimal / edit-and-save).
@@ -1761,12 +1883,14 @@ name: bad-port
 nodes:
   - id: ab000001
     name: planner
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     outputs:
       - name: plan
   - id: ab000002
     name: implementer
-    type: doc-only
+    type: agent
+    isolated_worktree: false
 edges:
   - source: { node: ab000001, port: plaan }
     target: { node: ab000002, port: anything }
@@ -1801,7 +1925,8 @@ nodes:
       - name: user_prompt
   - id: ab000001
     name: only
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     outputs:
       - name: out
   - id: end
@@ -1842,14 +1967,16 @@ name: cycle
 nodes:
   - id: ab000001
     name: implementer
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: review
     outputs:
       - name: code
   - id: ab000002
     name: reviewer
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: code
     outputs:
@@ -1884,12 +2011,14 @@ name: with-region
 nodes:
   - id: ab000001
     name: implementer
-    type: code-mutating
+    type: agent
+    isolated_worktree: true
     outputs:
       - name: code
   - id: ab000002
     name: reviewer
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     outputs:
       - name: review
 loops:
@@ -1923,7 +2052,8 @@ name: with-collection
 nodes:
   - id: ab000001
     name: triage
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     outputs:
       - name: plan
         frontmatter:
@@ -1931,7 +2061,8 @@ nodes:
             type: list
   - id: ab000002
     name: fixer
-    type: code-mutating
+    type: agent
+    isolated_worktree: true
     outputs:
       - name: fix
 loops:
@@ -1966,7 +2097,8 @@ name: with-view
 nodes:
   - id: ab12cd34
     name: planner
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     view: { x: 100, y: 200 }
     outputs:
       - name: plan
@@ -1993,12 +2125,14 @@ name: conditional
 nodes:
   - id: ab000001
     name: reviewer
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     outputs:
       - name: review
   - id: ab000002
     name: implementer
-    type: code-mutating
+    type: agent
+    isolated_worktree: true
     inputs:
       - name: review
     outputs:
@@ -2025,12 +2159,14 @@ name: repeated-edge
 nodes:
   - id: ab000001
     name: reviewer
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     outputs:
       - name: review
   - id: ab000002
     name: implementer
-    type: code-mutating
+    type: agent
+    isolated_worktree: true
     outputs:
       - name: code
 edges:
@@ -2058,12 +2194,14 @@ name: routed-edge
 nodes:
   - id: ab000001
     name: reviewer
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     outputs:
       - name: review
   - id: ab000002
     name: implementer
-    type: code-mutating
+    type: agent
+    isolated_worktree: true
     outputs:
       - name: code
 edges:
@@ -2103,12 +2241,14 @@ name: anchored-edge
 nodes:
   - id: ab000001
     name: planner
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     outputs:
       - name: plan
   - id: ab000002
     name: implementer
-    type: code-mutating
+    type: agent
+    isolated_worktree: true
     outputs:
       - name: code
 edges:
@@ -2136,12 +2276,14 @@ name: unanchored-edge
 nodes:
   - id: ab000001
     name: planner
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     outputs:
       - name: plan
   - id: ab000002
     name: implementer
-    type: code-mutating
+    type: agent
+    isolated_worktree: true
     outputs:
       - name: code
 edges:
@@ -2166,12 +2308,14 @@ name: auto-edge
 nodes:
   - id: ab000001
     name: planner
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     outputs:
       - name: plan
   - id: ab000002
     name: implementer
-    type: code-mutating
+    type: agent
+    isolated_worktree: true
     outputs:
       - name: code
 edges:
@@ -2192,12 +2336,14 @@ name: plain-edge
 nodes:
   - id: ab000001
     name: planner
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     outputs:
       - name: plan
   - id: ab000002
     name: implementer
-    type: code-mutating
+    type: agent
+    isolated_worktree: true
     outputs:
       - name: code
 edges:
@@ -2217,7 +2363,8 @@ name: multi-port
 nodes:
   - id: ab000001
     name: planner
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
     outputs:
@@ -2225,7 +2372,8 @@ nodes:
       - name: task_list
   - id: ab000002
     name: implementer
-    type: code-mutating
+    type: agent
+    isolated_worktree: true
     inputs:
       - name: plan
       - name: task_list
@@ -2233,7 +2381,8 @@ nodes:
       - name: summary
   - id: ab000003
     name: reviewer
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: summary
     outputs:
@@ -2260,7 +2409,8 @@ name: with-schema
 nodes:
   - id: ab12cd34
     name: reviewer
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: code
     outputs:
@@ -2314,7 +2464,8 @@ name: sides-test
 nodes:
   - id: ab12cd34
     name: worker
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: left-in
         side: left
@@ -2362,7 +2513,8 @@ name: defaults-test
 nodes:
   - id: ab12cd34
     name: worker
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: a
       - name: b
@@ -2461,7 +2613,7 @@ nodes:
 
     /// The shipped `disk-janitor` pipeline (#480, #128 Track A) must always parse
     /// cleanly: the `reap` node stays a `script` node (a silent degrade to
-    /// `doc-only` would spend an LLM turn and lose determinism) and no diagnostic
+    /// non-isolated would spend an LLM turn and lose determinism) and no diagnostic
     /// is error-severity. `serializer_round_trip` only asserts *if* a pipeline is
     /// valid (it `continue`s past a non-200 GET); this pins that it *is*.
     #[test]
@@ -2533,9 +2685,9 @@ nodes:
     }
 
     #[test]
-    fn script_node_is_not_rewritten_to_doc_only() {
+    fn script_node_is_not_rewritten_to_agent() {
         // ⚠️ silent-failure guard: `script` must be in `valid_types`, else
-        // `parse_pipeline` degrades the node to `doc-only` with a diagnostic.
+        // `parse_pipeline` degrades the node to non-isolated with a diagnostic.
         let yaml = with_start_end(
             r#"
 name: script-not-rewritten
@@ -2555,7 +2707,7 @@ nodes:
         assert_eq!(
             node.node_type,
             NodeType::Script,
-            "must not degrade to doc-only"
+            "must not degrade to non-isolated"
         );
         assert!(
             !result
@@ -2575,6 +2727,7 @@ nodes:
     #[test]
     fn script_node_roundtrips_via_serde() {
         let node = NodeDef {
+            isolated_worktree: None,
             id: "s1".into(),
             name: "notify".into(),
             node_type: NodeType::Script,
@@ -2616,7 +2769,8 @@ name: legacy-pipeline
 nodes:
   - id: ab000001
     name: planner
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
     outputs:
@@ -2649,7 +2803,8 @@ name: profile-pipeline
 nodes:
   - id: ab000001
     name: planner
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
     outputs:
@@ -2689,7 +2844,8 @@ name: custom-pipeline
 nodes:
   - id: ab000001
     name: planner
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
     outputs:
@@ -2820,7 +2976,8 @@ name: switch-test
 nodes:
   - id: reviewer
     name: Reviewer
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     outputs:
       - name: review
         frontmatter:
@@ -2867,7 +3024,8 @@ name: switch-no-default
 nodes:
   - id: reviewer
     name: Reviewer
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     outputs:
       - name: review
         frontmatter:
@@ -2909,7 +3067,8 @@ name: switch-explicit-default
 nodes:
   - id: reviewer
     name: Reviewer
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     outputs:
       - name: review
         frontmatter:
@@ -3158,14 +3317,16 @@ nodes:
       - name: done
   - id: ab000002
     name: implementer
-    type: code-mutating
+    type: agent
+    isolated_worktree: true
     inputs:
       - name: task
     outputs:
       - name: code
   - id: ab000003
     name: reviewer
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: code
     outputs:
@@ -3252,12 +3413,14 @@ name: cyclic
 nodes:
   - id: ab000001
     name: implementer
-    type: code-mutating
+    type: agent
+    isolated_worktree: true
     outputs:
       - name: code
   - id: ab000002
     name: reviewer
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     outputs:
       - name: review
 edges:
@@ -3304,12 +3467,14 @@ name: cyclic-declared
 nodes:
   - id: ab000001
     name: implementer
-    type: code-mutating
+    type: agent
+    isolated_worktree: true
     outputs:
       - name: code
   - id: ab000002
     name: reviewer
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     outputs:
       - name: review
 edges:
@@ -3388,7 +3553,7 @@ loops:
         let types: Vec<&NodeType> = result.pipeline.nodes.iter().map(|n| &n.node_type).collect();
         assert!(types.contains(&&NodeType::Start));
         assert!(types.contains(&&NodeType::End));
-        assert!(types.contains(&&NodeType::DocOnly));
+        assert!(types.contains(&&NodeType::Agent));
     }
 
     // --- Switch upstream schema resolution tests (issue #64) ---
@@ -3401,7 +3566,8 @@ name: typed-switch
 nodes:
   - id: reviewer
     name: Reviewer
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: code
     outputs:
@@ -3468,7 +3634,8 @@ name: untyped-switch
 nodes:
   - id: reviewer
     name: Reviewer
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: code
     outputs:
@@ -3500,7 +3667,8 @@ name: bad-switch-when
 nodes:
   - id: reviewer
     name: Reviewer
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: code
     outputs:
@@ -3540,7 +3708,8 @@ name: untyped-upstream
 nodes:
   - id: reviewer
     name: Reviewer
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: code
     outputs:
@@ -3602,7 +3771,8 @@ name: valid-switch
 nodes:
   - id: reviewer
     name: Reviewer
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: code
     outputs:
@@ -3710,7 +3880,8 @@ name: not-a-switch
 nodes:
   - id: planner
     name: Planner
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
     outputs:
@@ -3726,7 +3897,7 @@ nodes:
 
     #[test]
     fn foreach_node_type_is_refused_at_parse() {
-        // Not warn+coerce: silently rewriting a fan-out node to doc-only would
+        // Not warn+coerce: silently rewriting a fan-out node to non-isolated would
         // run each item's work zero times. The error names the migration path.
         for t in ["for-each", "foreach"] {
             let yaml = format!(
@@ -3778,7 +3949,7 @@ edges: []
             "{}",
             diags[0].message
         );
-        assert_eq!(type_str(&v).as_deref(), Some("doc-only"));
+        assert_eq!(type_str(&v).as_deref(), Some("agent"));
     }
 
     #[test]
@@ -3791,7 +3962,7 @@ edges: []
             "{}",
             diags[0].message
         );
-        assert_eq!(type_str(&v).as_deref(), Some("doc-only"));
+        assert_eq!(type_str(&v).as_deref(), Some("agent"));
     }
 
     #[test]
@@ -3802,6 +3973,177 @@ edges: []
             assert!(diags.is_empty(), "type {t} should not warn");
             assert_eq!(type_str(&v).as_deref(), Some(*t));
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // #653 / ADR-0060 — `agent` + explicit isolation
+    // -----------------------------------------------------------------------
+
+    fn isolation_of(v: &serde_yaml::Value) -> Option<Option<bool>> {
+        let map = v.as_mapping()?;
+        Some(
+            map.get(serde_yaml::Value::String(ISOLATED_WORKTREE_KEY.into()))
+                .map(|value| value.as_bool().expect("isolation must be a bool")),
+        )
+    }
+
+    #[test]
+    fn a_silent_agent_parses_isolated_and_says_so() {
+        // The editor default is `true`, and the parsed document STATES it: an
+        // author who never touched the control still reads where the node works.
+        let mut v = node_value("id: n1\nname: X\ntype: agent\n");
+        assert!(normalize_node_value(&mut v).unwrap().is_empty());
+        assert_eq!(isolation_of(&v), Some(Some(true)));
+    }
+
+    #[test]
+    fn a_silent_script_parses_shared_and_says_so() {
+        let mut v = node_value("id: n1\nname: X\ntype: script\n");
+        assert!(normalize_node_value(&mut v).unwrap().is_empty());
+        assert_eq!(isolation_of(&v), Some(Some(false)));
+    }
+
+    #[test]
+    fn an_explicit_isolation_is_never_overwritten() {
+        for (written, expected) in [("false", false), ("true", true)] {
+            for node_type in ["agent", "script"] {
+                let mut v = node_value(&format!(
+                    "id: n1\nname: X\ntype: {node_type}\nisolated_worktree: {written}\n"
+                ));
+                assert!(normalize_node_value(&mut v).unwrap().is_empty());
+                assert_eq!(
+                    isolation_of(&v),
+                    Some(Some(expected)),
+                    "{node_type} wrote {written}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn types_without_isolation_carry_no_line() {
+        // A Merge is isolated by construction and Start/End own no worktree —
+        // writing a line nobody may edit would only invite someone to edit it.
+        // A stray key is dropped rather than round-tripped.
+        for node_type in ["merge", "start", "end", "switch", "loop"] {
+            let mut v = node_value(&format!(
+                "id: n1\nname: X\ntype: {node_type}\nisolated_worktree: false\n"
+            ));
+            normalize_node_value(&mut v).unwrap();
+            assert_eq!(isolation_of(&v), Some(None), "type {node_type}");
+        }
+    }
+
+    #[test]
+    fn retired_types_fail_like_any_other_invalid_value() {
+        // #653: no alias, no migrator, no bespoke diagnostic. The two retired
+        // types take the generic unknown-type path — the message must not name
+        // them any differently than `bogus`.
+        for retired in ["doc-only", "code-mutating"] {
+            let mut v = node_value(&format!("id: n1\nname: X\ntype: {retired}\n"));
+            let diags = normalize_node_value(&mut v).unwrap();
+            assert_eq!(diags.len(), 1, "type {retired}");
+            assert_eq!(
+                diags[0].message,
+                format!("node 'n1': unknown node type '{retired}', defaulting to 'agent'")
+            );
+            assert_eq!(type_str(&v).as_deref(), Some("agent"));
+        }
+    }
+
+    #[test]
+    fn isolation_round_trips_through_the_pipeline_serializer() {
+        let yaml = "\
+name: iso
+nodes:
+  - id: start
+    name: Start
+    type: start
+    outputs:
+      - name: user_prompt
+  - id: shared
+    name: Shared
+    type: agent
+    isolated_worktree: false
+  - id: forked
+    name: Forked
+    type: agent
+  - id: builder
+    name: Builder
+    type: script
+  - id: sandboxed
+    name: Sandboxed
+    type: script
+    isolated_worktree: true
+  - id: end
+    name: End
+    type: end
+    inputs:
+      - name: result
+edges: []
+";
+        let parsed = parse_pipeline(yaml).unwrap().pipeline;
+        let by_id = |id: &str| parsed.nodes.iter().find(|n| n.id == id).unwrap();
+        assert_eq!(by_id("shared").isolated_worktree, Some(false));
+        assert_eq!(by_id("forked").isolated_worktree, Some(true));
+        assert_eq!(by_id("builder").isolated_worktree, Some(false));
+        assert_eq!(by_id("sandboxed").isolated_worktree, Some(true));
+
+        // Re-serialize and re-parse: every agent/script still states its choice.
+        let out = serde_yaml::to_string(&parsed).unwrap();
+        assert_eq!(out.matches("isolated_worktree:").count(), 4, "{out}");
+        let again = parse_pipeline(&out).unwrap().pipeline;
+        for node in &again.nodes {
+            let original = parsed.nodes.iter().find(|n| n.id == node.id).unwrap();
+            assert_eq!(
+                node.isolated_worktree, original.isolated_worktree,
+                "{}",
+                node.id
+            );
+        }
+    }
+
+    #[test]
+    fn is_isolated_reads_the_line_and_merge_reads_nothing() {
+        let yaml = "\
+name: iso
+nodes:
+  - id: shared
+    name: Shared
+    type: agent
+    isolated_worktree: false
+  - id: forked
+    name: Forked
+    type: agent
+  - id: gather
+    name: Gather
+    type: merge
+    inputs:
+      - name: branches
+        repeated: true
+    outputs:
+      - name: merged
+  - id: start
+    name: Start
+    type: start
+    outputs:
+      - name: user_prompt
+  - id: end
+    name: End
+    type: end
+    inputs:
+      - name: result
+edges: []
+";
+        let parsed = parse_pipeline(yaml).unwrap().pipeline;
+        let by_id = |id: &str| parsed.nodes.iter().find(|n| n.id == id).unwrap();
+        assert!(!by_id("shared").is_isolated());
+        assert!(by_id("forked").is_isolated());
+        assert!(
+            by_id("gather").is_isolated(),
+            "a Merge is isolated by construction, with no line to read"
+        );
+        assert!(!by_id("start").is_isolated());
     }
 
     #[test]
@@ -3867,7 +4209,8 @@ name: per-node-model
 nodes:
   - id: ab000001
     name: implementer
-    type: code-mutating
+    type: agent
+    isolated_worktree: true
     model: opus
     outputs:
       - name: code
@@ -3917,7 +4260,8 @@ name: no-model
 nodes:
   - id: ab000001
     name: implementer
-    type: code-mutating
+    type: agent
+    isolated_worktree: true
     outputs:
       - name: code
 "#,
@@ -3948,14 +4292,16 @@ name: per-node-effort
 nodes:
   - id: ab000001
     name: implementer
-    type: code-mutating
+    type: agent
+    isolated_worktree: true
     model: opus
     effort: low
     outputs:
       - name: code
   - id: ab000002
     name: exotic
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     effort: turbo
     outputs:
       - name: notes
@@ -4008,7 +4354,8 @@ name: no-effort
 nodes:
   - id: ab000001
     name: implementer
-    type: code-mutating
+    type: agent
+    isolated_worktree: true
     outputs:
       - name: code
 "#,
@@ -4034,7 +4381,8 @@ name: frontmatter-rt
 nodes:
   - id: reviewer
     name: reviewer
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: code
     outputs:
@@ -4074,7 +4422,8 @@ name: switch-rt
 nodes:
   - id: reviewer
     name: reviewer
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: code
     outputs:
@@ -4127,7 +4476,8 @@ name: multi-when-rt
 nodes:
   - id: reviewer
     name: reviewer
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: code
     outputs:
@@ -4185,7 +4535,8 @@ nodes:
       - name: user_prompt
   - id: worker
     name: Worker
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
     outputs:
@@ -4223,7 +4574,8 @@ nodes:
       - name: user_prompt
   - id: designer
     name: Designer
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
     outputs:
@@ -4273,7 +4625,8 @@ nodes:
       - name: user_prompt
   - id: designer
     name: Designer
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
     outputs:
@@ -4323,7 +4676,8 @@ nodes:
       - name: user_prompt
   - id: tester
     name: Tester
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: screens
         port_type: image_list
@@ -4483,14 +4837,16 @@ nodes:
       - name: user_prompt
   - id: ab000001
     name: implementer
-    type: code-mutating
+    type: agent
+    isolated_worktree: true
     inputs:
       - name: task
     outputs:
       - name: code
   - id: ab000002
     name: reviewer
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: code
     outputs:

--- a/crates/pdo-daemon/src/pipeline_migrator.rs
+++ b/crates/pdo-daemon/src/pipeline_migrator.rs
@@ -106,7 +106,7 @@ fn needs_migration(yaml_value: &serde_yaml::Value) -> bool {
                 return true;
             }
         }
-        // Inputs are emergent (#149): a *regular* node (doc-only / code-mutating)
+        // Inputs are emergent (#149): a *regular* node (agent / script)
         // that still declares any input needs migration so the declared port is
         // dropped (and a `repeated` flag migrated onto its edge). Structural
         // nodes (for-each here; start/end/switch/loop/merge already `continue`d
@@ -166,7 +166,8 @@ nodes:
     view: { x: 100, y: 160 }
   - id: XBG5Cxkn
     name: implementer
-    type: code-mutating
+    type: agent
+    isolated_worktree: true
     inputs:
       - { name: task, side: left }
     outputs:
@@ -174,7 +175,8 @@ nodes:
     view: { x: 335, y: 249 }
   - id: Qws9KzRZ
     name: reviewer
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - { name: code, side: left }
     outputs:
@@ -664,8 +666,8 @@ fn body_terminal(
     (terminal, out_port)
 }
 
-/// #149: inputs are emergent. Strip declared `inputs` from regular (doc-only /
-/// code-mutating) nodes. Structural nodes (start/end/merge/loop/for-each) keep
+/// #149: inputs are emergent. Strip declared `inputs` from regular (non-isolated /
+/// isolated) nodes. Structural nodes (start/end/merge/loop/for-each) keep
 /// their required ports. Any `repeated: true` declared input is migrated onto
 /// the matching incoming edge so loop accumulation is preserved.
 fn drop_declared_inputs(doc: &mut serde_yaml::Value) {
@@ -1596,8 +1598,12 @@ pub(crate) fn migrate_stranded_flat_prompts(pipelines_dir: &Path) -> Result<usiz
     Ok(moved)
 }
 
-/// Detects fan-outs where 2+ code-mutating nodes share a common downstream
+/// Detects fan-outs where 2+ **isolated** nodes (#653) share a common downstream
 /// target but no Merge node sits between them and the target.
+///
+/// Isolation, not the node's type, is what makes a fan-out risky: two nodes that
+/// each fork a sub-worktree produce two branches nothing reconciles, while two
+/// nodes sharing the Run worktree already write to one tree.
 ///
 /// Returns info-only diagnostics (ADR-0001: non-blocking).
 // #494: exercised only by this module's unit tests since demotion; kept as a tested helper.
@@ -1605,10 +1611,10 @@ pub(crate) fn migrate_stranded_flat_prompts(pipelines_dir: &Path) -> Result<usiz
 pub(crate) fn lint_missing_merge(pipeline: &PipelineDef) -> Vec<Diagnostic> {
     let mut diagnostics = Vec::new();
 
-    let cm_ids: HashSet<&str> = pipeline
+    let isolated_ids: HashSet<&str> = pipeline
         .nodes
         .iter()
-        .filter(|n| n.node_type == NodeType::CodeMutating)
+        .filter(|n| n.node_type != NodeType::Merge && n.is_isolated())
         .map(|n| n.id.as_str())
         .collect();
 
@@ -1619,22 +1625,22 @@ pub(crate) fn lint_missing_merge(pipeline: &PipelineDef) -> Vec<Diagnostic> {
         .map(|n| n.id.as_str())
         .collect();
 
-    let mut target_cm_sources: HashMap<&str, Vec<&str>> = HashMap::new();
+    let mut target_isolated_sources: HashMap<&str, Vec<&str>> = HashMap::new();
 
     for edge in &pipeline.edges {
         let src = edge.source.node.as_str();
         let tgt = edge.target.node.as_str();
-        if cm_ids.contains(src) && !merge_ids.contains(tgt) {
-            target_cm_sources.entry(tgt).or_default().push(src);
+        if isolated_ids.contains(src) && !merge_ids.contains(tgt) {
+            target_isolated_sources.entry(tgt).or_default().push(src);
         }
     }
 
-    for (target_id, sources) in &target_cm_sources {
+    for (target_id, sources) in &target_isolated_sources {
         if sources.len() >= 2 {
             diagnostics.push(Diagnostic {
                 severity: Severity::Warning,
                 message: format!(
-                    "node '{}' receives edges from {} code-mutating nodes ({}) without a Merge node — \
+                    "node '{}' receives edges from {} isolated nodes ({}) without a Merge node — \
                      parallel code changes may conflict at merge time",
                     target_id,
                     sources.len(),
@@ -1694,7 +1700,8 @@ nodes:
       - name: user_prompt
   - id: aBcD1234
     name: implementer
-    type: code-mutating
+    type: agent
+    isolated_worktree: true
     outputs:
       - name: code
         side: right
@@ -1728,7 +1735,8 @@ nodes:
       - name: user_prompt
   - id: aBcD1234
     name: implementer
-    type: code-mutating
+    type: agent
+    isolated_worktree: true
     model: opus
     effort: low
     outputs:
@@ -1814,7 +1822,7 @@ edges: []
     #[test]
     fn drops_declared_inputs_on_regular_nodes() {
         // #149: inputs are emergent (derived from edges). The migrator strips the
-        // now-redundant declared `inputs` from doc-only / code-mutating nodes.
+        // now-redundant declared `inputs` from agent / script nodes.
         let yaml = r#"
 name: test
 version: "1.0"
@@ -1831,7 +1839,8 @@ nodes:
       - name: result
   - id: aBcD1234
     name: planner
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
         side: left
@@ -1888,13 +1897,15 @@ nodes:
       - name: result
   - id: aBcD1234
     name: reviewer
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     outputs:
       - name: review
         side: right
   - id: eFgH5678
     name: implementer
-    type: code-mutating
+    type: agent
+    isolated_worktree: true
     inputs:
       - name: reviews
         side: left
@@ -1943,7 +1954,8 @@ name: review-loop
 version: "1.0"
 nodes:
   - id: implementer
-    type: code-mutating
+    type: agent
+    isolated_worktree: true
     prompt_file: .pdo/prompts/implementer.md
     inputs:
       - name: review
@@ -1951,7 +1963,8 @@ nodes:
       - name: code
     view: { x: 100, y: 160 }
   - id: reviewer
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     prompt_file: .pdo/prompts/reviewer.md
     inputs:
       - name: code
@@ -1997,7 +2010,8 @@ name: test
 version: "1.0"
 nodes:
   - id: worker
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs: []
     outputs:
       - name: out
@@ -2036,7 +2050,8 @@ name: demo
 version: "1.0"
 nodes:
   - id: agent
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     prompt_file: old/path/agent.md
     inputs: []
     outputs: []
@@ -2062,7 +2077,8 @@ version: "1.0"
 nodes:
   - id: aBcD1234
     name: worker
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
       - name: context
@@ -2111,7 +2127,8 @@ nodes:
       - name: result
   - id: aBcD1234
     name: worker
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     outputs:
       - name: plan
         side: top
@@ -2131,7 +2148,7 @@ edges: []
         std::fs::create_dir_all(&old_prompt_dir).unwrap();
         std::fs::write(old_prompt_dir.join("mynode.md"), "hello prompt").unwrap();
 
-        let yaml = "name: test\nversion: '1.0'\nnodes:\n  - id: mynode\n    type: doc-only\n    prompt_file: old_prompts/mynode.md\n    inputs: []\n    outputs: []\nedges: []\n".to_string();
+        let yaml = "name: test\nversion: '1.0'\nnodes:\n  - id: mynode\n    type: agent\n    isolated_worktree: false\n    prompt_file: old_prompts/mynode.md\n    inputs: []\n    outputs: []\nedges: []\n".to_string();
         std::fs::write(&yaml_path, &yaml).unwrap();
 
         let migrated = migrate_pipeline_file(&yaml_path).unwrap();
@@ -2157,7 +2174,7 @@ edges: []
         std::fs::write(tmp.path().join("readme.md"), "# hi").unwrap();
         std::fs::write(
             tmp.path().join("pipe.yaml"),
-            "name: p\nversion: '1.0'\nnodes:\n  - id: n1\n    type: doc-only\n    inputs: []\n    outputs: []\nedges: []\n",
+            "name: p\nversion: '1.0'\nnodes:\n  - id: n1\n    type: agent\n    isolated_worktree: false\n    inputs: []\n    outputs: []\nedges: []\n",
         )
         .unwrap();
 
@@ -2242,7 +2259,8 @@ nodes:
       - name: user_prompt
   - id: aBcD1234
     name: worker
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
         side: left
@@ -2282,7 +2300,8 @@ nodes:
         side: right
   - id: aBcD1234
     name: reviewer
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: code
         side: left
@@ -2291,7 +2310,8 @@ nodes:
         side: right
   - id: eFgH5678
     name: implementer
-    type: code-mutating
+    type: agent
+    isolated_worktree: true
     inputs:
       - name: review
         side: left
@@ -2391,7 +2411,8 @@ nodes:
         side: right
   - id: reviewer1
     name: reviewer
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: code
         side: left
@@ -2440,11 +2461,12 @@ edges:
 
     use crate::pipeline::{EdgeDef, EdgeEndpoint, NodeDef, Port, PortSide, PortType};
 
-    fn make_cm_node(id: &str) -> NodeDef {
+    fn make_isolated_node(id: &str) -> NodeDef {
         NodeDef {
+            isolated_worktree: Some(true),
             id: id.into(),
             name: id.into(),
-            node_type: NodeType::CodeMutating,
+            node_type: NodeType::Agent,
             inputs: vec![Port {
                 name: "in".into(),
                 repeated: false,
@@ -2480,6 +2502,7 @@ edges:
 
     fn make_merge_node(id: &str) -> NodeDef {
         NodeDef {
+            isolated_worktree: None,
             id: id.into(),
             name: id.into(),
             node_type: NodeType::Merge,
@@ -2516,11 +2539,12 @@ edges:
         }
     }
 
-    fn make_doc_node(id: &str) -> NodeDef {
+    fn make_shared_node(id: &str) -> NodeDef {
         NodeDef {
+            isolated_worktree: Some(false),
             id: id.into(),
             name: id.into(),
-            node_type: NodeType::DocOnly,
+            node_type: NodeType::Agent,
             inputs: vec![Port {
                 name: "in".into(),
                 repeated: false,
@@ -2579,9 +2603,9 @@ edges:
             version: None,
             variables: HashMap::new(),
             nodes: vec![
-                make_cm_node("impl-a"),
-                make_cm_node("impl-b"),
-                make_doc_node("reviewer"),
+                make_isolated_node("impl-a"),
+                make_isolated_node("impl-b"),
+                make_shared_node("reviewer"),
             ],
             edges: vec![
                 make_edge("impl-a", "out", "reviewer", "in"),
@@ -2605,10 +2629,10 @@ edges:
             version: None,
             variables: HashMap::new(),
             nodes: vec![
-                make_cm_node("impl-a"),
-                make_cm_node("impl-b"),
+                make_isolated_node("impl-a"),
+                make_isolated_node("impl-b"),
                 make_merge_node("merger"),
-                make_doc_node("downstream"),
+                make_shared_node("downstream"),
             ],
             edges: vec![
                 make_edge("impl-a", "out", "merger", "branches"),
@@ -2633,7 +2657,7 @@ edges:
             name: "single-cm".into(),
             version: None,
             variables: HashMap::new(),
-            nodes: vec![make_cm_node("impl-a"), make_doc_node("reviewer")],
+            nodes: vec![make_isolated_node("impl-a"), make_shared_node("reviewer")],
             edges: vec![make_edge("impl-a", "out", "reviewer", "in")],
             loops: Vec::new(),
             notes: Vec::new(),
@@ -2644,15 +2668,15 @@ edges:
     }
 
     #[test]
-    fn lint_no_warning_for_doc_only_fan_out() {
+    fn lint_no_warning_for_shared_worktree_fan_out() {
         let pipeline = PipelineDef {
-            name: "doc-fan-out".into(),
+            name: "shared-worktree-fan-out".into(),
             version: None,
             variables: HashMap::new(),
             nodes: vec![
-                make_doc_node("plan-a"),
-                make_doc_node("plan-b"),
-                make_doc_node("summary"),
+                make_shared_node("plan-a"),
+                make_shared_node("plan-b"),
+                make_shared_node("summary"),
             ],
             edges: vec![
                 make_edge("plan-a", "out", "summary", "in"),
@@ -2685,7 +2709,8 @@ nodes:
         side: right
   - id: aBcD1234
     name: lister
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     outputs:
       - name: plan
         side: right
@@ -2704,7 +2729,8 @@ nodes:
         side: right
   - id: wRkR5678
     name: worker
-    type: code-mutating
+    type: agent
+    isolated_worktree: true
     outputs:
       - name: out
         side: right
@@ -2754,7 +2780,8 @@ nodes:
         side: right
   - id: aBcD1234
     name: lister
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     outputs:
       - name: plan
         side: right
@@ -2774,7 +2801,8 @@ nodes:
         side: right
   - id: wRkR5678
     name: worker
-    type: code-mutating
+    type: agent
+    isolated_worktree: true
     outputs:
       - name: out
         side: right
@@ -2861,7 +2889,8 @@ nodes:
         side: right
   - id: liStErAA
     name: lister
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     outputs:
       - name: plan
         side: right
@@ -2881,7 +2910,8 @@ nodes:
         side: right
   - id: wRkRAAAA
     name: worker-a
-    type: code-mutating
+    type: agent
+    isolated_worktree: true
     outputs:
       - name: out
         side: right
@@ -2901,7 +2931,8 @@ nodes:
         side: right
   - id: wRkRBBBB
     name: worker-b
-    type: code-mutating
+    type: agent
+    isolated_worktree: true
     outputs:
       - name: out
         side: right
@@ -2956,7 +2987,8 @@ nodes:
         side: right
   - id: aBcD1234
     name: lister
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     outputs:
       - name: plan
         side: right
@@ -2976,7 +3008,8 @@ nodes:
         side: right
   - id: wRkR5678
     name: worker
-    type: code-mutating
+    type: agent
+    isolated_worktree: true
     outputs:
       - name: out
         side: right
@@ -3011,7 +3044,8 @@ name: foreach-human-id
 version: "1.0"
 nodes:
   - id: lister
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     outputs:
       - name: plan
         side: right
@@ -3030,7 +3064,8 @@ nodes:
       - name: done
         side: right
   - id: worker
-    type: code-mutating
+    type: agent
+    isolated_worktree: true
     outputs:
       - name: out
         side: right
@@ -3068,7 +3103,8 @@ name: loop-human-id
 version: "1.0"
 nodes:
   - id: feeder
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     outputs:
       - name: plan
         side: right
@@ -3087,7 +3123,8 @@ nodes:
       - name: done
         side: right
   - id: fixer
-    type: code-mutating
+    type: agent
+    isolated_worktree: true
     outputs:
       - name: out
         side: right
@@ -3231,7 +3268,8 @@ nodes:
       - { name: user_prompt, side: right }
   - id: aaaa0001
     name: triage
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     outputs:
       - name: out
         side: right
@@ -3249,7 +3287,8 @@ nodes:
       - { name: done, side: right }
   - id: aaaa0002
     name: fixer
-    type: code-mutating
+    type: agent
+    isolated_worktree: true
     outputs:
       - { name: out, side: right }
   - id: end
@@ -3385,7 +3424,7 @@ edges:
         yaml.push_str("\nversion: \"1.0\"\nnodes:\n");
         for id in node_ids {
             yaml.push_str(&format!(
-                "  - id: {id}\n    name: {id}\n    type: doc-only\n    outputs:\n      - name: out\n"
+                "  - id: {id}\n    name: {id}\n    type: agent\n    isolated_worktree: false\n    outputs:\n      - name: out\n"
             ));
         }
         yaml.push_str("edges: []\n");

--- a/crates/pdo-daemon/src/pipeline_semantics.rs
+++ b/crates/pdo-daemon/src/pipeline_semantics.rs
@@ -166,6 +166,13 @@ struct NodeProjection<'a> {
     /// content hash (absent key), so this field flags drift only when set.
     #[serde(skip_serializing_if = "Option::is_none")]
     auto_fail: Option<bool>,
+    /// Where the node's NodeRun works (#653, ADR-0060). Semantic: moving a node
+    /// between the Run worktree and one of its own changes what the pipeline
+    /// does — a parallel pair that shared a tree does not become the same
+    /// pipeline once one of them forks. `skip_serializing_if` keeps a structural
+    /// node (which carries no isolation) byte-identical to its pre-#653 hash.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    isolated_worktree: Option<bool>,
     inputs: Vec<PortProjection<'a>>,
     outputs: Vec<PortProjection<'a>>,
 }
@@ -186,6 +193,7 @@ impl<'a> NodeProjection<'a> {
             harnesses,
             agent_choice,
             auto_fail,
+            isolated_worktree,
         } = node;
         let _layout = view; // LAYOUT_FIELDS["node"]
         Self {
@@ -199,6 +207,7 @@ impl<'a> NodeProjection<'a> {
             max_iter: max_iter.as_ref().map(canon_yaml),
             over: over.as_deref(),
             auto_fail: *auto_fail,
+            isolated_worktree: *isolated_worktree,
             inputs: inputs.iter().map(PortProjection::of).collect(),
             outputs: outputs.iter().map(PortProjection::of).collect(),
         }
@@ -401,7 +410,7 @@ mod tests {
         format!(
             "name: drift-demo\nversion: '1.0'\nnodes:\n\
              - id: start\n  name: Start\n  type: start\n  outputs:\n  - name: user_prompt\n  view:\n    x: 300\n    y: 60\n\
-             - id: doer\n  name: Doer\n  type: doc-only\n  outputs:\n  - name: out\n  view:\n    x: {doer_x}\n    y: 260\n\
+             - id: doer\n  name: Doer\n  type: agent\n  isolated_worktree: false\n  outputs:\n  - name: out\n  view:\n    x: {doer_x}\n    y: 260\n\
              - id: end\n  name: End\n  type: end\n  inputs:\n  - name: result\n  view:\n    x: 300\n    y: 460\n\
              edges:\n\
              - source: {{node: start, port: user_prompt}}\n  target: {{node: doer, port: in}}\n  {edge_mode}\n\
@@ -481,7 +490,7 @@ mod tests {
             ),
             (
                 "per-node model",
-                base.replace("  type: doc-only", "  type: doc-only\n  model: opus"),
+                base.replace("  type: agent", "  type: agent\n  model: opus"),
             ),
             (
                 // #424. This list is maintained BY HAND — nothing in the build
@@ -491,15 +500,15 @@ mod tests {
                 // badge would never light up on an effort change: the user would
                 // launch a stale copy believing it current.
                 "per-node effort",
-                base.replace("  type: doc-only", "  type: doc-only\n  effort: low"),
+                base.replace("  type: agent", "  type: agent\n  effort: low"),
             ),
             (
                 // #550/ADR-0046: a pinned harness changes what runs the node, so it
                 // is a semantic change — the library drift badge and the diff see it.
                 "pin_harness",
                 base.replace(
-                    "  type: doc-only",
-                    "  type: doc-only\n  pin_harness: opencode",
+                    "  type: agent",
+                    "  type: agent\n  pin_harness: opencode",
                 ),
             ),
             (
@@ -509,8 +518,8 @@ mod tests {
                 // projection itself.
                 "harnesses map",
                 base.replace(
-                    "  type: doc-only",
-                    "  type: doc-only\n  harnesses:\n    claude:\n      model: opus",
+                    "  type: agent",
+                    "  type: agent\n  harnesses:\n    claude:\n      model: opus",
                 ),
             ),
             (
@@ -531,7 +540,7 @@ mod tests {
                 "added node",
                 base.replace(
                     "edges:",
-                    "- id: extra\n  name: Extra\n  type: doc-only\n  outputs:\n  - name: o\nedges:",
+                    "- id: extra\n  name: Extra\n  type: agent\n  isolated_worktree: false\n  outputs:\n  - name: o\nedges:",
                 ),
             ),
             (

--- a/crates/pdo-daemon/src/portable_pipeline.rs
+++ b/crates/pdo-daemon/src/portable_pipeline.rs
@@ -172,6 +172,7 @@ mod tests {
 
     fn node(id: &str, name: &str, node_type: NodeType) -> NodeDef {
         NodeDef {
+            isolated_worktree: None,
             id: id.into(),
             name: name.into(),
             node_type,
@@ -202,7 +203,7 @@ mod tests {
         };
         let mut start = node("start", "Start", NodeType::Start);
         start.outputs.push(port("user_prompt"));
-        let mut worker = node("worker", "Worker", NodeType::DocOnly);
+        let mut worker = node("worker", "Worker", NodeType::Agent);
         worker.agent_choice = Some(AgentChoice::Profile {
             profile_id: "local-reviewer".into(),
         });

--- a/crates/pdo-daemon/src/prompt_augmenter.rs
+++ b/crates/pdo-daemon/src/prompt_augmenter.rs
@@ -80,9 +80,9 @@ pub(crate) struct AugmentContext<'a> {
     #[allow(dead_code)]
     pub daemon_url: &'a str,
     pub foreach_context: Option<ForEachContext>,
-    /// For code-mutating / merge nodes: the per-iteration sub-worktree the
+    /// For isolated / merge nodes: the per-iteration sub-worktree the
     /// agent must edit in. Set to `None` for nodes that run directly in the
-    /// pipeline worktree (doc-only, switch, loop, etc.).
+    /// pipeline worktree (non-isolated, switch, loop, etc.).
     pub source_worktree_dir: Option<&'a Path>,
     pub input_images: Vec<String>,
     /// Whether the Start node's user prompt (`_input/output.md`) carries any
@@ -543,18 +543,15 @@ pub(crate) fn build_preamble(ctx: &AugmentContext<'_>) -> String {
     } else {
         let ext_list = IMAGE_EXTENSIONS.join(", .");
         for output in &outputs {
-            let instructions = matches!(
-                ctx.node.node_type,
-                NodeType::DocOnly | NodeType::CodeMutating
-            )
-            .then(|| {
-                ctx.node
-                    .outputs
-                    .iter()
-                    .find(|port| port.name == output.port_name)
-                    .and_then(|port| port.instructions.as_deref())
-            })
-            .flatten();
+            let instructions = (ctx.node.node_type == NodeType::Agent)
+                .then(|| {
+                    ctx.node
+                        .outputs
+                        .iter()
+                        .find(|port| port.name == output.port_name)
+                        .and_then(|port| port.instructions.as_deref())
+                })
+                .flatten();
             match output.port_type {
                 PortType::Image => {
                     preamble.push_str(&format!(
@@ -1014,7 +1011,7 @@ curl -X POST {daemon_url}/runs/{run_id}/commands \
 
 ### 5. restart_node
 
-Kill a NodeRun and re-spawn it on the **same iter** with a new session. On a `code-mutating` or `merge` node the sub-worktree is **reused in place**, so the dead session's uncommitted work is still there.
+Kill a NodeRun and re-spawn it on the **same iter** with a new session. On an isolated node the sub-worktree is **reused in place**, so the dead session's uncommitted work is still there.
 
 ```bash
 curl -X POST {daemon_url}/runs/{run_id}/commands \
@@ -1196,9 +1193,10 @@ mod tests {
             version: Some("1.0".into()),
             variables: HashMap::new(),
             nodes: vec![NodeDef {
+                isolated_worktree: None,
                 id: "planner".into(),
                 name: "planner".into(),
-                node_type: NodeType::DocOnly,
+                node_type: NodeType::Agent,
                 inputs: vec![Port {
                     name: "task".into(),
                     repeated: false,
@@ -1487,6 +1485,7 @@ mod tests {
     fn script_with_repeated_laps_pipeline() -> PipelineDef {
         let mut pipeline = sample_pipeline();
         pipeline.nodes.push(NodeDef {
+            isolated_worktree: None,
             id: "collector".into(),
             name: "collector".into(),
             node_type: NodeType::Script,
@@ -1610,9 +1609,10 @@ mod tests {
     fn edge_based_input_resolution() {
         let mut pipeline = sample_pipeline();
         pipeline.nodes.push(NodeDef {
+            isolated_worktree: None,
             id: "implementer".into(),
             name: "implementer".into(),
-            node_type: NodeType::CodeMutating,
+            node_type: NodeType::Agent,
             inputs: vec![Port {
                 name: "plan".into(),
                 repeated: false,
@@ -1692,9 +1692,10 @@ mod tests {
             ..Default::default()
         });
         pipeline.nodes.push(NodeDef {
+            isolated_worktree: None,
             id: "implementer".into(),
             name: "implementer".into(),
-            node_type: NodeType::CodeMutating,
+            node_type: NodeType::Agent,
             inputs: vec![],
             outputs: vec![],
             interactive: false,
@@ -1726,9 +1727,10 @@ mod tests {
         // the incoming edge. The preamble must still enumerate it.
         let mut pipeline = sample_pipeline();
         pipeline.nodes.push(NodeDef {
+            isolated_worktree: None,
             id: "implementer".into(),
             name: "implementer".into(),
-            node_type: NodeType::CodeMutating,
+            node_type: NodeType::Agent,
             inputs: vec![],
             outputs: vec![],
             interactive: false,
@@ -1774,9 +1776,10 @@ mod tests {
         // on a declared input port. planner → implementer, port `plans`.
         let mut pipeline = sample_pipeline();
         pipeline.nodes.push(NodeDef {
+            isolated_worktree: None,
             id: "implementer".into(),
             name: "implementer".into(),
-            node_type: NodeType::CodeMutating,
+            node_type: NodeType::Agent,
             inputs: vec![],
             outputs: vec![],
             interactive: false,
@@ -1918,9 +1921,10 @@ mod tests {
             variables: HashMap::new(),
             nodes: vec![
                 NodeDef {
+                    isolated_worktree: None,
                     id: "planner".into(),
                     name: "planner".into(),
-                    node_type: NodeType::DocOnly,
+                    node_type: NodeType::Agent,
                     inputs: vec![],
                     outputs: vec![Port {
                         name: "plan".into(),
@@ -1943,9 +1947,10 @@ mod tests {
                     auto_fail: None,
                 },
                 NodeDef {
+                    isolated_worktree: None,
                     id: "researcher".into(),
                     name: "researcher".into(),
-                    node_type: NodeType::DocOnly,
+                    node_type: NodeType::Agent,
                     inputs: vec![],
                     outputs: vec![Port {
                         name: "context".into(),
@@ -1968,9 +1973,10 @@ mod tests {
                     auto_fail: None,
                 },
                 NodeDef {
+                    isolated_worktree: None,
                     id: "implementer".into(),
                     name: "implementer".into(),
-                    node_type: NodeType::CodeMutating,
+                    node_type: NodeType::Agent,
                     inputs: vec![
                         Port {
                             name: "plan".into(),
@@ -2086,9 +2092,10 @@ mod tests {
             version: None,
             variables: HashMap::new(),
             nodes: vec![NodeDef {
+                isolated_worktree: None,
                 id: "reviewer".into(),
                 name: "reviewer".into(),
-                node_type: NodeType::DocOnly,
+                node_type: NodeType::Agent,
                 inputs: vec![Port {
                     name: "code".into(),
                     repeated: false,
@@ -2434,9 +2441,10 @@ mod tests {
             version: None,
             variables: HashMap::new(),
             nodes: vec![NodeDef {
+                isolated_worktree: None,
                 id: "designer".into(),
                 name: "designer".into(),
-                node_type: NodeType::DocOnly,
+                node_type: NodeType::Agent,
                 inputs: vec![],
                 outputs: vec![Port {
                     name: "screenshot".into(),
@@ -2489,9 +2497,10 @@ mod tests {
             version: None,
             variables: HashMap::new(),
             nodes: vec![NodeDef {
+                isolated_worktree: None,
                 id: "gallery".into(),
                 name: "gallery".into(),
-                node_type: NodeType::DocOnly,
+                node_type: NodeType::Agent,
                 inputs: vec![],
                 outputs: vec![Port {
                     name: "photos".into(),
@@ -2539,9 +2548,10 @@ mod tests {
             version: None,
             variables: HashMap::new(),
             nodes: vec![NodeDef {
+                isolated_worktree: None,
                 id: "node".into(),
                 name: "node".into(),
-                node_type: NodeType::DocOnly,
+                node_type: NodeType::Agent,
                 inputs: vec![],
                 outputs: vec![Port {
                     name: "img".into(),

--- a/crates/pdo-daemon/src/restart_verdict.rs
+++ b/crates/pdo-daemon/src/restart_verdict.rs
@@ -6,7 +6,7 @@
 //! est inexprimable. Avant #489 le bras jetait le `SpawnOutcome` de `spawn_node`
 //! — pas même un `let _ =` — et répondait `200 {"ok":true}` sur les cinq issues,
 //! y compris `Failed`, y compris un `node_id` absent du pipeline, et y compris le
-//! cas où le sous-worktree existait déjà (100 % des nœuds `code-mutating`/`merge`).
+//! cas où le sous-worktree existait déjà (100 % des nœuds isolated).
 //!
 //! Patron cloné de `completion_refusal` (#490, ADR-0035), **pas le type** : celui-ci
 //! est un type tout-refus, sur lequel « jamais 2xx » est un prédicat global. Ici il

--- a/crates/pdo-daemon/src/run_advance.rs
+++ b/crates/pdo-daemon/src/run_advance.rs
@@ -597,9 +597,10 @@ mod tests {
 
     fn doc_node(id: &str) -> NodeDef {
         NodeDef {
+            isolated_worktree: None,
             id: id.into(),
             name: id.into(),
-            node_type: NodeType::DocOnly,
+            node_type: NodeType::Agent,
             inputs: vec![Port {
                 name: "task".into(),
                 repeated: false,
@@ -650,9 +651,10 @@ mod tests {
 
     fn node_def_info(id: &str) -> NodeDefInfo {
         NodeDefInfo {
+            isolated_worktree: None,
             id: id.into(),
             name: None,
-            node_type: "doc-only".into(),
+            node_type: "agent".into(),
             view_x: None,
             view_y: None,
             inputs: Vec::new(),
@@ -662,6 +664,7 @@ mod tests {
 
     fn completed_node(id: &str) -> NodeState {
         NodeState {
+            isolated_worktree: None,
             harness: None,
             cost: None,
             node_id: id.into(),
@@ -680,6 +683,7 @@ mod tests {
 
     fn running_node(id: &str) -> NodeState {
         NodeState {
+            isolated_worktree: None,
             harness: None,
             cost: None,
             node_id: id.into(),
@@ -838,6 +842,7 @@ mod tests {
     fn node_iter(id: &str, iter: i64, status: NodeStatus) -> NodeState {
         let completed_at = (status == NodeStatus::Completed).then(|| "t1".to_string());
         NodeState {
+            isolated_worktree: None,
             harness: None,
             cost: None,
             node_id: id.into(),

--- a/crates/pdo-daemon/src/run_command.rs
+++ b/crates/pdo-daemon/src/run_command.rs
@@ -1524,7 +1524,7 @@ async fn dispatch(state: Arc<AppState>, run_id: String, cmd: RunCommand) -> Resp
             // `CommandIssued`, THEN discovered the Run / the pipeline / the node, and
             // finally dropped `spawn_node`'s return without so much as a `let _ =`.
             // Every one of the five `SpawnOutcome`s answered `200 {"ok":true}` — and
-            // on a `code-mutating` / `merge` node the spawn failed 100% of the time
+            // on an isolated node the spawn failed 100% of the time
             // (`git worktree add -b` on a branch that already exists, exit 255),
             // which is the whole of #489: session dead, zero events, node still
             // projected `Running`, and 30 s later the liveness sweep inventing
@@ -1693,8 +1693,12 @@ async fn dispatch(state: Arc<AppState>, run_id: String, cmd: RunCommand) -> Resp
             // knowable is paid for with a kill. `Absent` / `Reusable` / `Recyclable`
             // all proceed — `ensure_sub_worktree` handles each, and never destroys
             // work in flight.
-            let owns_sub_worktree = node.node_type == pipeline::NodeType::CodeMutating
-                || node.node_type == pipeline::NodeType::Merge;
+            // #653/ADR-0060: read the isolation FROZEN on this iteration, not the
+            // document's — the re-spawn below will land in the frozen directory,
+            // so probing the other one would classify a worktree nobody is about
+            // to use (and skip the one that matters).
+            let owns_sub_worktree = crate::merge_action::frozen_isolation(&events, &node_id, iter)
+                .unwrap_or(node.is_isolated());
             if owns_sub_worktree {
                 let sub_wt_dir =
                     crate::worktree_ops::sub_worktree_path(&repo_root, &run_id, &node_id, iter);
@@ -3252,6 +3256,7 @@ mod tests {
             version: None,
             variables: HashMap::new(),
             nodes: vec![NodeDef {
+                isolated_worktree: None,
                 id: "sw1".into(),
                 name: "switch".into(),
                 node_type: NodeType::Switch,
@@ -3319,9 +3324,10 @@ mod tests {
             version: None,
             variables: HashMap::new(),
             nodes: vec![NodeDef {
+                isolated_worktree: None,
                 id: "b".into(),
                 name: "b".into(),
-                node_type: NodeType::DocOnly,
+                node_type: NodeType::Agent,
                 inputs: vec![Port {
                     name: "in".into(),
                     repeated: false,

--- a/crates/pdo-daemon/src/run_cost.rs
+++ b/crates/pdo-daemon/src/run_cost.rs
@@ -151,7 +151,7 @@ pub(crate) fn compute_run_cost_breakdown(
     run_id: &str,
     prices: &PriceTable,
 ) -> RunCostBreakdown {
-    let node_types: BTreeMap<String, String> = events
+    let node_defs: Vec<&serde_json::Value> = events
         .iter()
         .find(|event| event.kind == crate::event_log::EventKind::RunStarted)
         .and_then(|event| event.payload.as_ref())
@@ -159,11 +159,31 @@ pub(crate) fn compute_run_cost_breakdown(
         .and_then(|value| value.as_array())
         .into_iter()
         .flatten()
+        .collect();
+    let node_types: BTreeMap<String, String> = node_defs
+        .iter()
         .filter_map(|node| {
             Some((
                 node.get("id")?.as_str()?.to_string(),
                 node.get("node_type")?.as_str()?.to_string(),
             ))
+        })
+        .collect();
+    // #653/ADR-0060: which nodes work in a sub-worktree of their own, from the
+    // Run snapshot. Attribution asks this and not the node's type, because the
+    // type no longer says where the transcript's `cwd` will be.
+    let snapshot_isolation: BTreeMap<String, bool> = node_defs
+        .iter()
+        .filter_map(|node| {
+            let id = node.get("id")?.as_str()?.to_string();
+            let isolated = node
+                .get("isolated_worktree")
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(matches!(
+                    node.get("node_type").and_then(serde_json::Value::as_str),
+                    Some("agent") | Some("merge")
+                ));
+            Some((id, isolated))
         })
         .collect();
     let node_type = |event: &crate::event_log::Event| {
@@ -180,6 +200,22 @@ pub(crate) fn compute_run_cost_breakdown(
                     .and_then(|id| node_types.get(id))
                     .cloned()
             })
+    };
+    // The NodeRun's FROZEN isolation, else the snapshot's answer for its node.
+    let isolated = |event: &crate::event_log::Event| {
+        event
+            .payload
+            .as_ref()
+            .and_then(|payload| payload.get("isolated_worktree"))
+            .and_then(serde_json::Value::as_bool)
+            .or_else(|| {
+                event
+                    .node_id
+                    .as_ref()
+                    .and_then(|id| snapshot_isolation.get(id))
+                    .copied()
+            })
+            .unwrap_or(false)
     };
     let mut executions = Vec::new();
     let mut seen_executions = HashSet::new();
@@ -212,8 +248,8 @@ pub(crate) fn compute_run_cost_breakdown(
         if !seen_executions.insert(identity) {
             continue;
         }
-        let kind = node_type(event);
-        let working_dir = if kind.as_deref() == Some("code-mutating") {
+        let is_isolated = isolated(event);
+        let working_dir = if is_isolated {
             event.node_id.as_deref().map(|node_id| {
                 crate::worktree_ops::sub_worktree_path(
                     repo_root,
@@ -229,7 +265,7 @@ pub(crate) fn compute_run_cost_breakdown(
             working_dir.map(|working_dir| claude_root.join(cc_project_dirname(&working_dir)));
         let legacy_claim = harness == crate::harness_registry::CLAUDE
             && session_id.is_none()
-            && kind.as_deref() == Some("code-mutating")
+            && is_isolated
             && project
                 .as_ref()
                 .is_some_and(|project| claimed_legacy_projects.insert(project.clone()));
@@ -237,7 +273,7 @@ pub(crate) fn compute_run_cost_breakdown(
             Some("missing node identity".to_string())
         } else if harness == crate::harness_registry::CLAUDE
             && session_id.is_none()
-            && kind.as_deref() == Some("code-mutating")
+            && is_isolated
             && !legacy_claim
         {
             Some("cost not separable from an earlier start in the same iteration".to_string())
@@ -1870,7 +1906,7 @@ mod tests {
             node_id: Some("worker".into()),
             iter: Some(1),
             payload: Some(serde_json::json!({
-                "node_type": "doc-only",
+                "node_type": "agent", "isolated_worktree": false,
                 "harness": "copilot",
                 "session_id": sid
             })),
@@ -1929,7 +1965,7 @@ mod tests {
             node_id: Some(node.into()),
             iter: Some(1),
             payload: Some(serde_json::json!({
-                "node_type":"code-mutating",
+                "node_type":"agent", "isolated_worktree":true,
                 "harness":harness,
                 "session_id":session_id
             })),
@@ -1968,7 +2004,7 @@ mod tests {
             kind: EventKind::NodeStarted,
             node_id: Some("worker".into()),
             iter: Some(1),
-            payload: Some(serde_json::json!({ "node_type":"doc-only" })),
+            payload: Some(serde_json::json!({ "node_type":"agent", "isolated_worktree":false })),
         };
 
         let breakdown = compute_run_cost_breakdown(
@@ -2027,7 +2063,7 @@ mod tests {
             node_id: Some("worker".into()),
             iter: Some(1),
             payload: Some(serde_json::json!({
-                "node_type": "code-mutating",
+                "node_type": "agent", "isolated_worktree": true,
                 "harness": "claude",
                 "session_id": "sid"
             })),
@@ -2075,7 +2111,7 @@ mod tests {
             node_id: Some("worker".into()),
             iter: Some(1),
             payload: Some(serde_json::json!({
-                "node_type": "code-mutating",
+                "node_type": "agent", "isolated_worktree": true,
                 "harness": "claude",
                 "session_id": sid
             })),
@@ -2243,13 +2279,13 @@ mod tests {
         let mut started = event(None, None);
         started.payload = Some(serde_json::json!({
             "node_defs": [
-                {"id":"legacy-agent","node_type":"doc-only"},
+                {"id":"legacy-agent","node_type":"agent", "isolated_worktree":false},
                 {"id":"deterministic","node_type":"script"}
             ]
         }));
         let events = vec![
             started,
-            event(Some("legacy-agent"), Some("doc-only")),
+            event(Some("legacy-agent"), Some("agent")),
             event(Some("deterministic"), None),
         ];
 
@@ -2317,7 +2353,7 @@ mod tests {
             "{\"type\":\"session.usage_checkpoint\",\"data\":{\"totalNanoAiu\":200000000000}}\n",
         )
         .unwrap();
-        let started = |node: &str, harness: &str, sid: &str, kind: &str| Event {
+        let started = |node: &str, harness: &str, sid: &str, isolated: bool| Event {
             id: None,
             run_id: run_id.into(),
             ts: crate::event_log::now_iso(),
@@ -2325,14 +2361,15 @@ mod tests {
             node_id: Some(node.into()),
             iter: Some(1),
             payload: Some(serde_json::json!({
-                "node_type": kind,
+                "node_type": "agent",
+                "isolated_worktree": isolated,
                 "harness": harness,
                 "session_id": sid
             })),
         };
         let events = vec![
-            started("claude-node", "claude", "sid-claude", "code-mutating"),
-            started("copilot-node", "copilot", "sid-copilot", "doc-only"),
+            started("claude-node", "claude", "sid-claude", true),
+            started("copilot-node", "copilot", "sid-copilot", false),
         ];
 
         let breakdown =
@@ -2376,7 +2413,7 @@ mod tests {
             node_id: Some("worker".into()),
             iter: Some(1),
             payload: Some(serde_json::json!({
-                "node_type":"doc-only",
+                "node_type":"agent", "isolated_worktree":false,
                 "harness":"copilot",
                 "session_id":"memo-session"
             })),

--- a/crates/pdo-daemon/src/scheduler.rs
+++ b/crates/pdo-daemon/src/scheduler.rs
@@ -1725,9 +1725,10 @@ mod tests {
 
     fn make_node(id: &str, inputs: &[&str], outputs: &[&str]) -> NodeDef {
         NodeDef {
+            isolated_worktree: None,
             id: id.into(),
             name: id.into(),
-            node_type: NodeType::DocOnly,
+            node_type: NodeType::Agent,
             inputs: inputs
                 .iter()
                 .map(|n| Port {
@@ -1769,6 +1770,7 @@ mod tests {
 
     fn make_end_node() -> NodeDef {
         NodeDef {
+            isolated_worktree: None,
             id: "end".into(),
             name: "End".into(),
             node_type: NodeType::End,
@@ -1862,6 +1864,7 @@ mod tests {
 
     fn completed_node(id: &str) -> NodeState {
         NodeState {
+            isolated_worktree: None,
             harness: None,
             cost: None,
             node_id: id.into(),
@@ -1880,6 +1883,7 @@ mod tests {
 
     fn completed_node_iter(id: &str, iter: i64) -> NodeState {
         NodeState {
+            isolated_worktree: None,
             harness: None,
             cost: None,
             node_id: id.into(),
@@ -1898,6 +1902,7 @@ mod tests {
 
     fn running_node(id: &str) -> NodeState {
         NodeState {
+            isolated_worktree: None,
             harness: None,
             cost: None,
             node_id: id.into(),
@@ -3067,6 +3072,7 @@ mod tests {
 
     fn make_switch_node(id: &str, branch_outputs: Vec<Port>) -> NodeDef {
         NodeDef {
+            isolated_worktree: None,
             id: id.into(),
             name: id.into(),
             node_type: NodeType::Switch,
@@ -3771,6 +3777,7 @@ mod tests {
 
     fn make_loop_node(id: &str, max_iter: i64) -> NodeDef {
         NodeDef {
+            isolated_worktree: None,
             id: id.into(),
             name: id.into(),
             node_type: NodeType::Loop,
@@ -4338,6 +4345,7 @@ mod tests {
 
     fn make_start_node(id: &str) -> NodeDef {
         NodeDef {
+            isolated_worktree: None,
             id: id.into(),
             name: id.into(),
             node_type: NodeType::Start,
@@ -4989,7 +4997,8 @@ nodes:
       - name: user_prompt
   - id: ab000001
     name: lister
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
     outputs:
@@ -4999,7 +5008,8 @@ nodes:
             type: list
   - id: ab000003
     name: worker
-    type: code-mutating
+    type: agent
+    isolated_worktree: true
     inputs:
       - name: in
     outputs:
@@ -5088,14 +5098,16 @@ nodes:
       - name: user_prompt
   - id: ab000001
     name: lister
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
     outputs:
       - name: plan
   - id: ab000003
     name: worker
-    type: code-mutating
+    type: agent
+    isolated_worktree: true
     inputs:
       - name: in
     outputs:

--- a/crates/pdo-daemon/src/scheduler_dispatcher.rs
+++ b/crates/pdo-daemon/src/scheduler_dispatcher.rs
@@ -55,9 +55,10 @@ mod tests {
 
     fn make_node(id: &str, inputs: &[&str], outputs: &[&str]) -> NodeDef {
         NodeDef {
+            isolated_worktree: None,
             id: id.into(),
             name: id.into(),
-            node_type: NodeType::DocOnly,
+            node_type: NodeType::Agent,
             inputs: inputs
                 .iter()
                 .map(|n| Port {
@@ -121,6 +122,7 @@ mod tests {
 
     fn running_node(id: &str) -> NodeState {
         NodeState {
+            isolated_worktree: None,
             harness: None,
             cost: None,
             node_id: id.into(),
@@ -139,6 +141,7 @@ mod tests {
 
     fn waiting_node(id: &str, iter: i64) -> NodeState {
         NodeState {
+            isolated_worktree: None,
             harness: None,
             cost: None,
             node_id: id.into(),
@@ -182,6 +185,7 @@ mod tests {
 
     fn completed_node(id: &str) -> NodeState {
         NodeState {
+            isolated_worktree: None,
             harness: None,
             cost: None,
             node_id: id.into(),

--- a/crates/pdo-daemon/src/scheduler_interpreter.rs
+++ b/crates/pdo-daemon/src/scheduler_interpreter.rs
@@ -378,7 +378,8 @@ nodes:
       - name: user_prompt
   - id: producer
     name: Producer
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
     outputs:
@@ -388,14 +389,16 @@ nodes:
             type: list
   - id: itemizer
     name: Itemizer
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: plan
     outputs:
       - name: item_note
   - id: sibling
     name: Sibling
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: in
     outputs:

--- a/crates/pdo-daemon/src/stale_detector.rs
+++ b/crates/pdo-daemon/src/stale_detector.rs
@@ -350,7 +350,7 @@ pub fn encode_working_dir(dir: &Path) -> String {
 /// dir, so an exact-name lookup returns *this node's own* transcript regardless of
 /// how many other `.jsonl` files share the dir.
 ///
-/// This is the fix for the manager-vs-node collision: a non-`code-mutating`/`merge`
+/// This is the fix for the manager-vs-node collision: a non-isolated
 /// node's cwd is the Run worktree, which is also the manager's cwd (and every
 /// sibling non-CM node's), so one CC project dir holds several `.jsonl` and
 /// [`find_session_jsonl`]'s newest-mtime pick returns whichever was touched last —
@@ -501,7 +501,7 @@ pub fn validate_outputs(
 /// Only [`Detection::SessionDied`] has an event of its own here.
 /// [`Detection::TurnEnded`] deliberately produces **none** (#469 §3): appending a
 /// `NodeAutoCompleted` straight into the log was the defect of the old design —
-/// on a `code-mutating` / `merge` node it would record a `Completed` whose commit
+/// on an isolated node it would record a `Completed` whose commit
 /// stayed on the `pdo/sub-…` branch, with the downstream receiving nothing. Its
 /// terminal event is appended by the *shared node-completion body*, past the
 /// forgotten-run refusal, the completion guard and
@@ -558,7 +558,7 @@ pub trait NodeProbes {
     /// ([`session_jsonl_by_id`]) — the transcript named `<uuid>.jsonl`, this node's
     /// own — and only falls back to the newest-mtime pick ([`find_session_jsonl`])
     /// for a pre-#473 node with no recorded id. Without that, a
-    /// non-`code-mutating`/`merge` node shares its cwd (the Run worktree) with the
+    /// non-isolated node shares its cwd (the Run worktree) with the
     /// manager's `claude`, so the newest `.jsonl` was usually the manager's and the
     /// turn-end verdict was read off the wrong conversation.
     ///
@@ -1624,7 +1624,7 @@ SwapFree:         204800 kB
         let pipeline_path = tmp.path().join("pipeline.yaml");
         std::fs::write(
             &pipeline_path,
-            "name: test\nnodes:\n  - id: start\n    name: Start\n    type: start\n    inputs: []\n    outputs:\n      - name: user_prompt\n  - id: worker\n    name: Worker\n    type: doc-only\n    inputs:\n      - name: task\n    outputs: []\n  - id: end\n    name: End\n    type: end\n    inputs:\n      - name: result\n    outputs: []\nedges:\n  - source: { node: start, port: user_prompt }\n    target: { node: worker, port: task }\n",
+            "name: test\nnodes:\n  - id: start\n    name: Start\n    type: start\n    inputs: []\n    outputs:\n      - name: user_prompt\n  - id: worker\n    name: Worker\n    type: agent\n    isolated_worktree: false\n    inputs:\n      - name: task\n    outputs: []\n  - id: end\n    name: End\n    type: end\n    inputs:\n      - name: result\n    outputs: []\nedges:\n  - source: { node: start, port: user_prompt }\n    target: { node: worker, port: task }\n",
         )
         .unwrap();
 
@@ -1645,7 +1645,7 @@ SwapFree:         204800 kB
         let pipeline_path = tmp.path().join("pipeline.yaml");
         std::fs::write(
             &pipeline_path,
-            "name: test\nnodes:\n  - id: start\n    name: Start\n    type: start\n    inputs: []\n    outputs:\n      - name: user_prompt\n  - id: worker\n    name: Worker\n    type: doc-only\n    inputs:\n      - name: task\n    outputs:\n      - name: report\n  - id: end\n    name: End\n    type: end\n    inputs:\n      - name: result\n    outputs: []\nedges:\n  - source: { node: start, port: user_prompt }\n    target: { node: worker, port: task }\n",
+            "name: test\nnodes:\n  - id: start\n    name: Start\n    type: start\n    inputs: []\n    outputs:\n      - name: user_prompt\n  - id: worker\n    name: Worker\n    type: agent\n    isolated_worktree: false\n    inputs:\n      - name: task\n    outputs:\n      - name: report\n  - id: end\n    name: End\n    type: end\n    inputs:\n      - name: result\n    outputs: []\nedges:\n  - source: { node: start, port: user_prompt }\n    target: { node: worker, port: task }\n",
         )
         .unwrap();
 

--- a/crates/pdo-daemon/src/stats_performance.rs
+++ b/crates/pdo-daemon/src/stats_performance.rs
@@ -77,7 +77,7 @@
 //!
 //! - **Pipeline Manager** orchestrates from the Run's own top-level working
 //!   directory ([`crate::worktree_ops::worktree_dir_for_run`]) — the same
-//!   directory every non-code-mutating Node also runs in (a code-mutating
+//!   directory every non-isolated Node also runs in (an isolated
 //!   Node gets its own disjoint [`crate::worktree_ops::sub_worktree_path`], so
 //!   it never collides). Every Claude `.jsonl` file in that directory that
 //!   isn't a known Node's own `session_id` is a Pipeline Manager candidate.
@@ -95,7 +95,7 @@
 //! role made no attributable Claude calls, or ran under a harness with no
 //! session-file source at all — Copilot's session store has no per-directory
 //! nesting to exclude from, so it can never resolve one). More than one
-//! candidate — or a shared directory containing a non-code-mutating,
+//! candidate — or a shared directory containing a non-isolated,
 //! non-script Claude Node with **no** recorded `session_id` at all, so it
 //! can't be excluded by name — is an ambiguous result, never guessed at by
 //! path or timing alone (issue: "Une session historique sans identité fiable
@@ -388,7 +388,7 @@ fn finish_pipeline(id: String, acc: PipelineAcc) -> PerformanceEntity {
 
 // --- Node identity/type resolution ---------------------------------------------
 
-fn node_defs_from_payload(payload: &Value) -> BTreeMap<String, (String, String)> {
+fn node_defs_from_payload(payload: &Value) -> BTreeMap<String, (String, String, bool)> {
     let mut defs = BTreeMap::new();
     if let Some(list) = payload.get("node_defs").and_then(|v| v.as_array()) {
         for def in list {
@@ -405,7 +405,13 @@ fn node_defs_from_payload(payload: &Value) -> BTreeMap<String, (String, String)>
                 .and_then(|v| v.as_str())
                 .unwrap_or("")
                 .to_string();
-            defs.insert(id.to_string(), (name, node_type));
+            // #653/ADR-0060: where the node works. The snapshot states it for an
+            // `agent`/`script`; the type's default stands in for a pre-#653 Run.
+            let isolated = def
+                .get("isolated_worktree")
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(matches!(node_type.as_str(), "agent" | "merge"));
+            defs.insert(id.to_string(), (name, node_type, isolated));
         }
     }
     defs
@@ -563,7 +569,8 @@ struct PendingNode {
     started_at: String,
     harness: String,
     session_id: Option<String>,
-    node_type: String,
+    /// Where the NodeRun works (#653) — its own sub-worktree, or the Run's.
+    isolated: bool,
 }
 
 /// A `MergeResolverStarted` awaiting its pairing `MergeResolverCompleted` —
@@ -694,6 +701,8 @@ fn check_root_once(
 #[derive(Debug, Clone)]
 struct NodeStartRecord {
     node_type: String,
+    /// Where the NodeRun works (#653) — its own sub-worktree, or the Run's.
+    isolated: bool,
     harness: String,
     session_id: Option<String>,
 }
@@ -1120,9 +1129,17 @@ fn fold_performance(
                     let node_type = event_payload
                         .and_then(|p| p.get("node_type"))
                         .and_then(|v| v.as_str())
-                        .or_else(|| node_defs.get(&node_id).map(|(_, ty)| ty.as_str()))
+                        .or_else(|| node_defs.get(&node_id).map(|(_, ty, _)| ty.as_str()))
                         .unwrap_or("")
                         .to_string();
+                    // #653/ADR-0060: the FROZEN isolation of this attempt, else
+                    // the snapshot's. This decides which directory its sessions
+                    // live in, which the type used to imply.
+                    let isolated = event_payload
+                        .and_then(|p| p.get("isolated_worktree"))
+                        .and_then(serde_json::Value::as_bool)
+                        .or_else(|| node_defs.get(&node_id).map(|(_, _, iso)| *iso))
+                        .unwrap_or(false);
                     let harness = event_payload
                         .and_then(|p| p.get("harness"))
                         .and_then(|v| v.as_str())
@@ -1139,6 +1156,7 @@ fn fold_performance(
                         .or_default()
                         .push(NodeStartRecord {
                             node_type: node_type.clone(),
+                            isolated,
                             harness: harness.clone(),
                             session_id: session_id.clone(),
                         });
@@ -1151,7 +1169,7 @@ fn fold_performance(
                             started_at: event.ts.clone(),
                             harness,
                             session_id,
-                            node_type,
+                            isolated,
                         },
                     );
                 }
@@ -1162,11 +1180,11 @@ fn fold_performance(
                     if let Some(p) = pending.remove(&(node_id.clone(), iter)) {
                         let node_name = node_defs
                             .get(&node_id)
-                            .map(|(name, _)| name.clone())
+                            .map(|(name, ..)| name.clone())
                             .unwrap_or_else(|| node_id.clone());
                         let node_acc = pipeline_acc.nodes.entry(node_id).or_default();
                         node_acc.name = node_name;
-                        let working_dir = if p.node_type == "code-mutating" {
+                        let working_dir = if p.isolated {
                             crate::worktree_ops::sub_worktree_path(
                                 &repo_root,
                                 &run_id,
@@ -1266,7 +1284,7 @@ fn fold_performance(
                             .collect();
                         let ambiguous = node_starts.values().flatten().any(|r| {
                             r.node_type != "script"
-                                && r.node_type != "code-mutating"
+                                && !r.isolated
                                 && r.harness == crate::harness_registry::CLAUDE
                                 && r.session_id.is_none()
                         });

--- a/crates/pdo-daemon/src/switch_router.rs
+++ b/crates/pdo-daemon/src/switch_router.rs
@@ -41,6 +41,7 @@ mod tests {
 
     fn make_switch(outputs: Vec<Port>) -> NodeDef {
         NodeDef {
+            isolated_worktree: None,
             id: "sw".into(),
             name: "test-switch".into(),
             node_type: NodeType::Switch,

--- a/crates/pdo-daemon/src/tmux_session_manager.rs
+++ b/crates/pdo-daemon/src/tmux_session_manager.rs
@@ -87,7 +87,7 @@ pub enum SessionTail<'a> {
         /// <uuid>`). Claude Code names its transcript `<session_id>.jsonl`, so
         /// pinning it lets the liveness sweep resolve a node's transcript by
         /// *identity* instead of by the newest `.jsonl` in a cwd it shares with the
-        /// manager and any sibling non-`code-mutating`/`merge` node. `None` *or* an
+        /// manager and any sibling non-isolated node. `None` *or* an
         /// empty string ⇒ no `--session-id`, byte-identical legacy tail — the state
         /// for infra sessions (`__manager__` / `__merge_resolver__`) that own no
         /// `NodeStarted`, are never probed by the sweep and are never resumed.
@@ -571,7 +571,7 @@ pub fn build_tmux_script(
 /// id (recorded on `NodeStarted` at spawn), the tail is `claude --resume <uuid>`,
 /// which re-enters *this node's* transcript. The pre-#473 tail was a bare
 /// `--continue`, which re-enters "the most recent conversation of the cwd" — and
-/// for a non-`code-mutating`/`merge` node that cwd is the Run worktree, shared with
+/// for a non-isolated node that cwd is the Run worktree, shared with
 /// the manager's `claude` and any sibling non-CM node, so a resumed node could pick
 /// up the *manager's* (or a sibling's) conversation. `session_id` = `None` or empty
 /// (a pre-#473 row with no recorded id) falls back to that bare `--continue`,
@@ -2066,14 +2066,21 @@ pub fn apply_sweep(socket: &str, decisions: &[SweepDecision]) -> SweepTally {
 }
 
 /// Resolve the working_dir for a NodeRun given run context.
+/// Where a NodeRun's files live: its own sub-worktree when `isolated`, the Run's
+/// shared worktree otherwise (#653, ADR-0060).
+///
+/// Pre-#653 this keyed off the node *type* string (`code-mutating` ⇒ its own
+/// tree). Isolation is now a per-node choice that the type no longer implies, so
+/// callers pass the answer — frozen from `NodeStarted` for a live iteration,
+/// read off the document otherwise.
 pub fn working_dir_for_node(
     repo_root: &Path,
     run_id: &str,
     node_id: &str,
     iter: i64,
-    node_type: &str,
+    isolated: bool,
 ) -> PathBuf {
-    if node_type == "code-mutating" {
+    if isolated {
         repo_root
             .join(".pdo")
             .join("runs")

--- a/crates/pdo-daemon/src/workflow_importer.rs
+++ b/crates/pdo-daemon/src/workflow_importer.rs
@@ -6,8 +6,8 @@
 //! so running an imported file's code would be an RCE, cf. #260) and the
 //! recognized idioms are rewired:
 //!
-//! - `agent(prompt, opts)` -> a regular node (`doc-only`, upgraded to
-//!   `code-mutating` on strong mutation keywords / `isolation: 'worktree'`).
+//! - `agent(prompt, opts)` -> an isolated `agent` node (#653): the import maps a
+//!   role, never a guess about what that role will touch.
 //! - `for` / `while` **whose body contains an `agent()`** -> a `bounded` loop
 //!   region; a plumbing loop (no `agent()` in the body) is left alone — the guard
 //!   that prevents a phantom `bounded` (ADR-0016).
@@ -446,12 +446,6 @@ impl Importer {
         // computed further down.
         let effort_expr = opts.and_then(|o| object_prop(o, "effort"));
         let effort = effort_expr.and_then(string_literal_value);
-        let isolation_wt = opts
-            .and_then(|o| object_prop(o, "isolation"))
-            .and_then(string_literal_value)
-            .as_deref()
-            == Some("worktree");
-
         let seed = label_static
             .clone()
             .filter(|s| !s.is_empty())
@@ -493,8 +487,6 @@ impl Importer {
             }
         };
 
-        let node_type = infer_node_type(&prompt_body, &display_name, isolation_wt);
-
         // Output port frontmatter from `opts.schema` (const ref or inline object).
         let frontmatter = opts.and_then(|o| object_prop(o, "schema")).and_then(|s| {
             let s = s.without_parentheses();
@@ -530,10 +522,16 @@ impl Importer {
             );
         }
 
+        // #653 / ADR-0060: an imported agent role is an isolated `agent`, full
+        // stop. The pre-#653 importer sniffed the prompt and the label for
+        // mutation keywords to pick between non-isolated and isolated; a
+        // guess about what a foreign prompt will touch is exactly the thing the
+        // explicit isolation line replaces.
         let node = NodeDef {
             id: id.clone(),
             name: display_name,
-            node_type,
+            node_type: NodeType::Agent,
+            isolated_worktree: Some(true),
             inputs: vec![plain_port("in")],
             outputs: vec![out_port],
             interactive: false,
@@ -799,18 +797,13 @@ impl Importer {
             return;
         }
         let mut new_cursor: Cursor = Vec::new();
-        let mut any_mutating = false;
+        let mut any_isolated = false;
         for a in agents {
             // Each sibling is entered from the same upstream sources (fan-out).
             let mut branch_cursor = entry_sources.clone();
             let id = self.emit_agent(a, &mut branch_cursor);
-            if self
-                .nodes
-                .last()
-                .map(|n| n.node_type == NodeType::CodeMutating)
-                == Some(true)
-            {
-                any_mutating = true;
+            if self.nodes.last().map(|n| n.is_isolated()) == Some(true) {
+                any_isolated = true;
             }
             new_cursor.push(Pending {
                 node: id,
@@ -819,8 +812,8 @@ impl Importer {
                 is_else: false,
             });
         }
-        if any_mutating {
-            self.warn("`parallel(...)` avec des nœuds code-mutating — envisage un nœud Merge en aval (lint info-only ADR-0006, pas d'auto-insertion)");
+        if any_isolated {
+            self.warn("`parallel(...)` avec des nœuds isolés — envisage un nœud Merge en aval (lint info-only ADR-0006, pas d'auto-insertion)");
         }
         *cursor = new_cursor;
     }
@@ -937,6 +930,7 @@ fn start_node() -> NodeDef {
         id: "start".into(),
         name: "Start".into(),
         node_type: NodeType::Start,
+        isolated_worktree: None,
         inputs: vec![],
         outputs: vec![plain_port("user_prompt")],
         interactive: false,
@@ -955,6 +949,7 @@ fn end_node(agent_count: usize) -> NodeDef {
         id: "end".into(),
         name: "End".into(),
         node_type: NodeType::End,
+        isolated_worktree: None,
         inputs: vec![plain_port("result")],
         outputs: vec![],
         interactive: false,
@@ -968,27 +963,6 @@ fn end_node(agent_count: usize) -> NodeDef {
         harnesses: Default::default(),
         agent_choice: None,
         auto_fail: None,
-    }
-}
-
-fn infer_node_type(prompt: &str, name: &str, isolation_worktree: bool) -> NodeType {
-    if isolation_worktree {
-        return NodeType::CodeMutating;
-    }
-    let hay = format!("{} {}", name.to_lowercase(), prompt.to_lowercase());
-    const MUTATION_KW: &[&str] = &[
-        "commit",
-        "git add",
-        "git merge",
-        "implémente",
-        "implemente",
-        "implement",
-        "worktree",
-    ];
-    if MUTATION_KW.iter().any(|k| hay.contains(k)) {
-        NodeType::CodeMutating
-    } else {
-        NodeType::DocOnly
     }
 }
 

--- a/crates/pdo-daemon/src/worktree_ops.rs
+++ b/crates/pdo-daemon/src/worktree_ops.rs
@@ -453,7 +453,7 @@ pub(crate) struct EnsuredSubWorktree {
 ///
 /// Replaces the bare `create_sub_worktree` at both production sites, which failed
 /// with exit 255 (`a branch named … already exists`) on **every** re-spawn of the
-/// same iteration, i.e. on every `restart_node` of a `code-mutating` or `merge`
+/// same iteration, i.e. on every `restart_node` of an isolated
 /// node.
 ///
 /// The contract, state by state:
@@ -870,7 +870,7 @@ fn unmerged_paths(worktree_dir: &std::path::Path) -> Vec<String> {
 ///
 /// - a dirty pipeline worktree would lose uncommitted tracked work to the
 ///   `git reset --hard` — `git merge` fails loudly where `reset --hard` destroys
-///   in silence. It can legitimately be dirty: a `doc-only`/`script` node in
+///   in silence. It can legitimately be dirty: a non-isolated node in
 ///   flight, the leftovers of a `doc_violated_code_immutability` (never reverted),
 ///   the Run shell, the resident `__manager__` agent.
 /// - unrelated histories: `git merge` also fails (`refusing to merge unrelated
@@ -1550,7 +1550,7 @@ mod tests {
         let node = rebased_terminal_node_repo(&tmp, true);
 
         // Something else lands on the pipeline branch after the sub-worktree was cut
-        // — a doc-only node committing its docs, say.
+        // — a non-isolated node committing its docs, say.
         std::fs::write(node.pipeline_wt.join("PLAN.md"), "# plan\n").unwrap();
         for args in [vec!["add", "-A"], vec!["commit", "-m", "docs: a plan"]] {
             assert!(std::process::Command::new("git")
@@ -1752,7 +1752,7 @@ mod tests {
     }
 
     #[test]
-    fn doc_only_clean_worktree_passes() {
+    fn shared_worktree_clean_passes() {
         let tmp = tempfile::tempdir().unwrap();
         let repo = tmp.path();
         init_test_repo(repo);
@@ -1766,7 +1766,7 @@ mod tests {
     }
 
     #[test]
-    fn doc_only_dirty_worktree_detected() {
+    fn shared_worktree_dirty_detected() {
         let tmp = tempfile::tempdir().unwrap();
         let repo = tmp.path();
         init_test_repo(repo);
@@ -1783,7 +1783,7 @@ mod tests {
     }
 
     #[test]
-    fn doc_only_untracked_files_not_flagged() {
+    fn shared_worktree_untracked_files_not_flagged() {
         let tmp = tempfile::tempdir().unwrap();
         let repo = tmp.path();
         init_test_repo(repo);

--- a/crates/pdo-daemon/tests/admission_concurrency.rs
+++ b/crates/pdo-daemon/tests/admission_concurrency.rs
@@ -29,7 +29,8 @@ nodes:
       - name: user_prompt
   - id: solo
     name: solo
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: in
     outputs:

--- a/crates/pdo-daemon/tests/cli_complete_does_not_panic.rs
+++ b/crates/pdo-daemon/tests/cli_complete_does_not_panic.rs
@@ -36,7 +36,8 @@ nodes:
       - name: user_prompt
   - id: solo
     name: solo
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: in
     outputs:

--- a/crates/pdo-daemon/tests/cost_prices.rs
+++ b/crates/pdo-daemon/tests/cost_prices.rs
@@ -40,7 +40,8 @@ nodes:
       - { name: user_prompt, side: bottom }
   - id: worker
     name: Worker
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - { name: in, side: top }
     outputs:

--- a/crates/pdo-daemon/tests/edit_self_write_loop.rs
+++ b/crates/pdo-daemon/tests/edit_self_write_loop.rs
@@ -20,7 +20,8 @@ nodes:
       - name: user_prompt
   - id: worker
     name: worker
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
     outputs:
@@ -45,7 +46,8 @@ nodes:
       - name: user_prompt
   - id: worker
     name: worker
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
       - name: extra

--- a/crates/pdo-daemon/tests/frontmatter_validation.rs
+++ b/crates/pdo-daemon/tests/frontmatter_validation.rs
@@ -26,7 +26,8 @@ nodes:
       - name: user_prompt
   - id: reviewer
     name: reviewer
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
     outputs:

--- a/crates/pdo-daemon/tests/guard_dry_run.rs
+++ b/crates/pdo-daemon/tests/guard_dry_run.rs
@@ -24,7 +24,8 @@ nodes:
       - name: user_prompt
   - id: solo
     name: solo
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: in
     outputs:

--- a/crates/pdo-daemon/tests/guard_dry_run_timeout.rs
+++ b/crates/pdo-daemon/tests/guard_dry_run_timeout.rs
@@ -20,7 +20,8 @@ nodes:
       - name: user_prompt
   - id: solo
     name: solo
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: in
     outputs:

--- a/crates/pdo-daemon/tests/harness_freeze_resume.rs
+++ b/crates/pdo-daemon/tests/harness_freeze_resume.rs
@@ -1,6 +1,6 @@
 //! Layer 3a (#550, ADR-0046) — the harness axis, end to end through the daemon.
 //!
-//! A two-node `doc-only` pipeline: one node with no pin (⇒ the `claude` floor),
+//! A two-node non-isolated pipeline: one node with no pin (⇒ the `claude` floor),
 //! one `pin_harness: opencode`. Spawned through the **tmux command seam** (a
 //! harmless `sleep`, never a real agent), the test proves:
 //!   1. the resolved harness is **frozen** in each node's `NodeStarted` event, and
@@ -23,13 +23,15 @@ nodes:
       - name: user_prompt
   - id: aaaaaaaa
     name: on-claude
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     outputs:
       - name: out
     view: { x: 200, y: 60 }
   - id: bbbbbbbb
     name: on-opencode
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     pin_harness: opencode
     outputs:
       - name: out

--- a/crates/pdo-daemon/tests/harness_resume_frozen_gone.rs
+++ b/crates/pdo-daemon/tests/harness_resume_frozen_gone.rs
@@ -22,7 +22,8 @@ nodes:
       - name: user_prompt
   - id: cccccccc
     name: on-ghost
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     pin_harness: ghost
     outputs:
       - name: out

--- a/crates/pdo-daemon/tests/hot_reload_conflict.rs
+++ b/crates/pdo-daemon/tests/hot_reload_conflict.rs
@@ -23,7 +23,8 @@ nodes:
       - name: user_prompt
   - id: worker
     name: worker
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
     outputs:
@@ -48,7 +49,8 @@ nodes:
       - name: user_prompt
   - id: worker
     name: worker-renamed
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
       - name: context

--- a/crates/pdo-daemon/tests/libassist.rs
+++ b/crates/pdo-daemon/tests/libassist.rs
@@ -551,7 +551,8 @@ nodes:
       - name: user_prompt
   - id: gamma
     name: GAMMA
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
     outputs:

--- a/crates/pdo-daemon/tests/library_node_ports.rs
+++ b/crates/pdo-daemon/tests/library_node_ports.rs
@@ -11,7 +11,7 @@ async fn library_node_preserves_all_port_fields() {
 
     let payload = serde_json::json!({
         "name": "Typed Reviewer",
-        "type": "doc-only",
+        "type": "agent",
         "inputs": [
             {
                 "name": "code",

--- a/crates/pdo-daemon/tests/loop_command_truth.rs
+++ b/crates/pdo-daemon/tests/loop_command_truth.rs
@@ -19,7 +19,8 @@ nodes:
       - name: user_prompt
   - id: worker
     name: worker
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
     outputs:
@@ -55,7 +56,8 @@ nodes:
       - name: user_prompt
   - id: planner
     name: planner
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
     outputs:
@@ -88,12 +90,14 @@ nodes:
       - name: user_prompt
   - id: impl
     name: impl
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     outputs:
       - name: code
   - id: rev
     name: rev
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     outputs:
       - name: review
   - id: end

--- a/crates/pdo-daemon/tests/mid_run_edits.rs
+++ b/crates/pdo-daemon/tests/mid_run_edits.rs
@@ -19,7 +19,8 @@ nodes:
       - name: user_prompt
   - id: worker
     name: Worker
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
     outputs:
@@ -126,12 +127,9 @@ async fn changing_type_of_live_node_is_rejected_with_message() {
     let run_id = create_run(&daemon).await;
     wait_for_node_status(&daemon.url(), &run_id, "worker", &["running"]).await;
 
-    // Same graph, but the worker's type flips doc-only -> code-mutating.
-    let yaml_with_type_change = PIPELINE_YAML.replace(
-        "    name: Worker\n    type: doc-only",
-        "    name: Worker\n    type: code-mutating",
-    );
-    assert!(yaml_with_type_change.contains("code-mutating"), "guard");
+    // Same graph, but the worker's type flips `agent` -> `script`.
+    let yaml_with_type_change = PIPELINE_YAML.replace("    type: agent", "    type: script");
+    assert!(yaml_with_type_change.contains("type: script"), "guard");
 
     let resp = reqwest::Client::new()
         .put(format!("{}/runs/{}/pipeline", daemon.url(), run_id))
@@ -156,6 +154,50 @@ async fn changing_type_of_live_node_is_rejected_with_message() {
     );
 }
 
+/// #653 / ADR-0060: isolation is NOT the type. Moving a live node's
+/// `isolated_worktree` is a legal edit — it is frozen at spawn, so it lands on
+/// the next launch instead of dragging a running session between worktrees. The
+/// mid-run edit policy must let it through where a type change is refused.
+#[tokio::test]
+async fn changing_isolation_of_live_node_is_accepted() {
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+    let run_id = create_run(&daemon).await;
+    wait_for_node_status(&daemon.url(), &run_id, "worker", &["running"]).await;
+
+    let yaml_with_isolation_change = PIPELINE_YAML.replace(
+        "    isolated_worktree: false",
+        "    isolated_worktree: true",
+    );
+    assert_ne!(yaml_with_isolation_change, PIPELINE_YAML, "guard");
+
+    let resp = reqwest::Client::new()
+        .put(format!("{}/runs/{}/pipeline", daemon.url(), run_id))
+        .json(&serde_json::json!({ "yaml": yaml_with_isolation_change, "prompts": {} }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.status(),
+        200,
+        "an isolation edit applies to future NodeRuns and must not be rejected"
+    );
+
+    // And the live iteration is unmoved: its frozen answer still says shared.
+    let run: serde_json::Value = reqwest::Client::new()
+        .get(format!("{}/runs/{}", daemon.url(), run_id))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(
+        run["nodes"]["worker"]["isolated_worktree"], false,
+        "the running NodeRun keeps the isolation it was spawned with; got {run}"
+    );
+}
+
 #[tokio::test]
 async fn adding_node_and_edge_mid_run_succeeds() {
     let daemon = TestDaemon::spawn(seed).await.unwrap();
@@ -172,7 +214,8 @@ nodes:
       - name: user_prompt
   - id: worker
     name: Worker
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
     outputs:
@@ -180,7 +223,8 @@ nodes:
     view: { x: 200, y: 100 }
   - id: reviewer
     name: Reviewer
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     outputs:
       - name: feedback
     view: { x: 400, y: 100 }
@@ -225,7 +269,8 @@ nodes:
       - name: user_prompt
   - id: worker
     name: Worker
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
     outputs:
@@ -233,7 +278,8 @@ nodes:
     view: { x: 200, y: 100 }
   - id: reviewer
     name: Reviewer
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     outputs:
       - name: feedback
     view: { x: 400, y: 100 }

--- a/crates/pdo-daemon/tests/multi_iter.rs
+++ b/crates/pdo-daemon/tests/multi_iter.rs
@@ -22,7 +22,8 @@ nodes:
       - name: user_prompt
   - id: reviewer
     name: reviewer
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
     outputs:

--- a/crates/pdo-daemon/tests/multi_repo_run.rs
+++ b/crates/pdo-daemon/tests/multi_repo_run.rs
@@ -21,7 +21,8 @@ nodes:
       - name: user_prompt
   - id: worker
     name: worker
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
     outputs:

--- a/crates/pdo-daemon/tests/mutation_policy.rs
+++ b/crates/pdo-daemon/tests/mutation_policy.rs
@@ -15,7 +15,8 @@ nodes:
       - name: user_prompt
   - id: worker
     name: Worker
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
     outputs:
@@ -144,7 +145,8 @@ nodes:
       - name: user_prompt
   - id: worker
     name: Worker
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
     outputs:
@@ -152,7 +154,8 @@ nodes:
     view: { x: 200, y: 100 }
   - id: reviewer
     name: Reviewer
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: code
     outputs:
@@ -208,7 +211,8 @@ nodes:
       - name: user_prompt
   - id: worker
     name: Worker
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
     outputs:
@@ -216,7 +220,8 @@ nodes:
     view: { x: 200, y: 100 }
   - id: pending-node
     name: PendingNode
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: data
     outputs:
@@ -254,7 +259,8 @@ nodes:
       - name: user_prompt
   - id: worker
     name: Worker
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
     outputs:

--- a/crates/pdo-daemon/tests/node_done_detach.rs
+++ b/crates/pdo-daemon/tests/node_done_detach.rs
@@ -25,7 +25,7 @@ use crate::common::TestDaemon;
 use tokio::io::AsyncWriteExt;
 
 const PIPELINE_NAME: &str = "detach-tail";
-// start → a → b → end; doc-only nodes so completion needs no sub-worktree merge.
+// start → a → b → end; non-isolated nodes so completion needs no sub-worktree merge.
 const PIPELINE_YAML: &str = r#"name: detach-tail
 version: "1.0"
 nodes:
@@ -36,14 +36,16 @@ nodes:
       - name: user_prompt
   - id: a
     name: a
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: in
     outputs:
       - name: out
   - id: b
     name: b
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: in
     outputs:
@@ -160,7 +162,7 @@ where
     }
 }
 
-/// Satisfy output validation for a doc-only node before `pdo complete`: write
+/// Satisfy output validation for a non-isolated node before `pdo complete`: write
 /// the artifact its declared `out` port expects, exactly where the agent would.
 fn write_out_artifact(daemon: &TestDaemon, run_id: &str, node_id: &str) {
     let dir = daemon

--- a/crates/pdo-daemon/tests/node_io.rs
+++ b/crates/pdo-daemon/tests/node_io.rs
@@ -17,14 +17,16 @@ nodes:
       - name: user_prompt
   - id: planner
     name: planner
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
     outputs:
       - name: plan
   - id: implementer
     name: implementer
-    type: code-mutating
+    type: agent
+    isolated_worktree: true
     inputs:
       - name: plan
     outputs:

--- a/crates/pdo-daemon/tests/node_prompt.rs
+++ b/crates/pdo-daemon/tests/node_prompt.rs
@@ -18,7 +18,8 @@ nodes:
       - name: user_prompt
   - id: worker
     name: worker
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
     outputs:

--- a/crates/pdo-daemon/tests/process_lifecycle.rs
+++ b/crates/pdo-daemon/tests/process_lifecycle.rs
@@ -27,7 +27,8 @@ nodes:
       - name: user_prompt
   - id: worker
     name: worker
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: in
     outputs:

--- a/crates/pdo-daemon/tests/project_harness_resolution.rs
+++ b/crates/pdo-daemon/tests/project_harness_resolution.rs
@@ -1,7 +1,7 @@
 //! Layer 3 (#552, ADR-0046) — the **Projet** tier of the harness axis, end to end
 //! through the daemon.
 //!
-//! A single unpinned `doc-only` node, spawned through the **tmux command seam** (a
+//! A single unpinned non-isolated node, spawned through the **tmux command seam** (a
 //! harmless `sleep`, never a real agent). With no node pin and no instance
 //! default, the only tier that can name a harness is the **Projet** of the Run's
 //! primary repo. The tests prove:
@@ -27,7 +27,8 @@ nodes:
       - name: user_prompt
   - id: aaaaaaaa
     name: worker
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     outputs:
       - name: out
     view: { x: 200, y: 60 }

--- a/crates/pdo-daemon/tests/recent_repos.rs
+++ b/crates/pdo-daemon/tests/recent_repos.rs
@@ -13,7 +13,8 @@ nodes:
       - name: user_prompt
   - id: worker
     name: worker
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
     outputs:

--- a/crates/pdo-daemon/tests/restart_node_truth.rs
+++ b/crates/pdo-daemon/tests/restart_node_truth.rs
@@ -19,8 +19,8 @@ use crate::common::TestDaemon;
 
 const PIPELINE_NAME: &str = "restart-truth";
 
-/// `planner` is `doc-only` (owns no sub-worktree — the positive control), `impl-1`
-/// is `code-mutating` (the only class #489 broke) and `runner` is a `script` node
+/// `planner` is non-isolated (owns no sub-worktree — the positive control), `impl-1`
+/// is isolated (the only class #489 broke) and `runner` is a `script` node
 /// whose body a test empties to provoke `SpawnOutcome::Failed`.
 const PIPELINE_YAML: &str = r#"name: restart-truth
 version: "1.0"
@@ -32,14 +32,16 @@ nodes:
       - name: user_prompt
   - id: planner
     name: planner
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
     outputs:
       - name: plan
   - id: impl-1
     name: impl-1
-    type: code-mutating
+    type: agent
+    isolated_worktree: true
     inputs:
       - name: plan
     outputs:
@@ -268,13 +270,13 @@ fn kill_session(daemon: &TestDaemon, run_id: &str, node_id: &str, iter: i64) {
 // Spawned — the positive control
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// A `doc-only` node owns no sub-worktree, so it is the one class `restart_node`
+/// A non-isolated node owns no sub-worktree, so it is the one class `restart_node`
 /// always worked on. It is here as the control: the new body must report the real
 /// spawn, and the three sub-worktree fields must be present-and-empty rather than
 /// absent, so a client reading `body.base_sha` never gets `undefined` depending on
 /// the node's type.
 #[tokio::test]
-async fn restarting_a_doc_only_node_reports_the_spawn_it_really_did() {
+async fn restarting_a_non_isolated_node_reports_the_spawn_it_really_did() {
     let daemon = TestDaemon::spawn(seed).await.unwrap();
     let run_id = create_run(&daemon).await;
     wait_for_node_status(&daemon, &run_id, "planner", "running").await;
@@ -676,7 +678,7 @@ fn private_gitdir(sub_worktree_dir: &std::path::Path) -> std::path::PathBuf {
     std::path::PathBuf::from(raw)
 }
 
-/// **THE #516 end-to-end proof.** A `code-mutating` node killed mid git-operation
+/// **THE #516 end-to-end proof.** An isolated node killed mid git-operation
 /// leaves BOTH an `index.lock` and a `MERGE_HEAD` in its sub-worktree's private
 /// gitdir. `restart_node` must:
 ///
@@ -692,7 +694,7 @@ async fn a_restart_inventories_every_interrupted_git_op_and_routes_it_to_the_pre
     let run_id = create_run(&daemon).await;
     wait_for_node_status(&daemon, &run_id, "planner", "running").await;
 
-    // Complete `planner` so `impl-1` (the only code-mutating node) spawns and cuts
+    // Complete `planner` so `impl-1` (the only isolated node) spawns and cuts
     // its per-iteration sub-worktree.
     let plan_dir = daemon
         .repo_root()

--- a/crates/pdo-daemon/tests/retry_loop_member.rs
+++ b/crates/pdo-daemon/tests/retry_loop_member.rs
@@ -33,14 +33,16 @@ nodes:
       - name: user_prompt
   - id: impl
     name: impl
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
     outputs:
       - name: code
   - id: rev
     name: rev
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: code
     outputs:

--- a/crates/pdo-daemon/tests/run_diff_range.rs
+++ b/crates/pdo-daemon/tests/run_diff_range.rs
@@ -27,7 +27,8 @@ nodes:
       - name: user_prompt
   - id: solo
     name: solo
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: in
     outputs:

--- a/crates/pdo-daemon/tests/run_naming.rs
+++ b/crates/pdo-daemon/tests/run_naming.rs
@@ -30,7 +30,8 @@ nodes:
       - name: user_prompt
   - id: worker
     name: worker
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
     outputs:

--- a/crates/pdo-daemon/tests/run_scoped_pipeline.rs
+++ b/crates/pdo-daemon/tests/run_scoped_pipeline.rs
@@ -21,7 +21,8 @@ nodes:
       - name: user_prompt
   - id: planner
     name: planner
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
     outputs:
@@ -426,7 +427,8 @@ nodes:
       - name: user_prompt
   - id: planner
     name: planner
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
     outputs:
@@ -434,7 +436,8 @@ nodes:
     view: { x: 100, y: 100 }
   - id: implementer
     name: implementer
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: plan
     outputs:
@@ -497,7 +500,8 @@ nodes:
       - name: user_prompt
   - id: planner
     name: planner
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
     outputs:
@@ -505,7 +509,8 @@ nodes:
     view: { x: 100, y: 100 }
   - id: implementer
     name: implementer
-    type: code-mutating
+    type: agent
+    isolated_worktree: true
     inputs:
       - name: plan
     outputs:
@@ -634,7 +639,8 @@ nodes:
       - name: user_prompt
   - id: planner
     name: planner
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
     outputs:
@@ -642,7 +648,8 @@ nodes:
     view: { x: 100, y: 100 }
   - id: implementer
     name: implementer
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: plan
     outputs:
@@ -738,7 +745,8 @@ nodes:
       - name: user_prompt
   - id: planner
     name: planner
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
     outputs:

--- a/crates/pdo-daemon/tests/run_shell.rs
+++ b/crates/pdo-daemon/tests/run_shell.rs
@@ -50,7 +50,7 @@ edges:
     target: { node: end, port: result }
 "#;
 
-/// `start → worker → end` with a `code-mutating` worker. Under the daemon's
+/// `start → worker → end` with an isolated worker. Under the daemon's
 /// default `exec sleep 600` override the worker never completes, so the run
 /// stays `running` (live) — the negative case for the eligibility gate.
 const LIVE_YAML: &str = r#"name: shell-live
@@ -63,7 +63,8 @@ nodes:
       - name: user_prompt
   - id: worker
     name: worker
-    type: code-mutating
+    type: agent
+    isolated_worktree: true
     inputs:
       - name: in
     outputs:

--- a/crates/pdo-daemon/tests/runs_list_target_repo.rs
+++ b/crates/pdo-daemon/tests/runs_list_target_repo.rs
@@ -32,7 +32,8 @@ nodes:
       - name: user_prompt
   - id: worker
     name: worker
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
     outputs:

--- a/crates/pdo-daemon/tests/sandbox_observability.rs
+++ b/crates/pdo-daemon/tests/sandbox_observability.rs
@@ -32,7 +32,7 @@ use tempfile::TempDir;
 
 const NODE_ID: &str = "worker";
 
-/// `start → worker(doc-only, in→out) → end`. A doc-only node uses the agent tail
+/// `start → worker(non-isolated, in→out) → end`. A non-isolated node uses the agent tail
 /// so `tmux_cmd_override` (`exec sleep 600`) is honoured — the session stays
 /// alive for the live-run observability paths. Completing `worker` (with its
 /// `out` present) drives the whole run terminal.
@@ -46,7 +46,8 @@ nodes:
       - name: user_prompt
   - id: worker
     name: worker
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: in
     outputs:
@@ -265,7 +266,7 @@ async fn simulate_node_done(daemon: &TestDaemon, run_id: &str) {
     );
 }
 
-/// The Run's pipeline worktree (the doc-only worker's cwd — non-CM nodes run
+/// The Run's pipeline worktree (the non-isolated worker's cwd — non-isolated nodes run
 /// there). Both the cost prefix and the stale probe encode THIS path.
 fn worktree_dir(daemon: &TestDaemon, run_id: &str) -> PathBuf {
     daemon

--- a/crates/pdo-daemon/tests/sandbox_tracer.rs
+++ b/crates/pdo-daemon/tests/sandbox_tracer.rs
@@ -352,7 +352,7 @@ async fn off_run_never_invokes_docker() {
     let (_fake_dir, docker, log) = write_fake_docker();
     // A real body that writes its declared output and self-signals `pdo complete`
     // on the host (off path). The sentinel is untracked → passes the
-    // doc-only-effect clean guard.
+    // shared-worktree clean guard.
     let daemon = TestDaemon::spawn_with_docker_override(
         seed(
             "#!/usr/bin/env bash\nset -euo pipefail\n\

--- a/crates/pdo-daemon/tests/script_node.rs
+++ b/crates/pdo-daemon/tests/script_node.rs
@@ -172,7 +172,7 @@ async fn wait_for_node_status(
 #[tokio::test]
 async fn script_node_completes_on_exit_zero() {
     ensure_pdo_on_path();
-    // Body: write a sentinel (untracked → passes the doc-only-effect clean
+    // Body: write a sentinel (untracked → passes the shared-worktree clean
     // guard) and the declared output via $PDO_OUTPUT_OUT.
     let body = "#!/usr/bin/env bash\nset -euo pipefail\n\
         echo ok > SENTINEL_SCRIPT\n\

--- a/crates/pdo-daemon/tests/serializer_round_trip.rs
+++ b/crates/pdo-daemon/tests/serializer_round_trip.rs
@@ -125,7 +125,8 @@ nodes:
       - name: user_prompt
   - id: reviewer
     name: reviewer
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: code
     outputs:

--- a/crates/pdo-daemon/tests/session_cap_admission.rs
+++ b/crates/pdo-daemon/tests/session_cap_admission.rs
@@ -31,7 +31,8 @@ nodes:
       - name: user_prompt
   - id: solo
     name: solo
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: in
     outputs:

--- a/crates/pdo-daemon/tests/spawn_abort_recovery.rs
+++ b/crates/pdo-daemon/tests/spawn_abort_recovery.rs
@@ -6,7 +6,7 @@
 //!
 //! The abort is forced deterministically with the `PDO_DEBUG_PANIC_SPAWN`
 //! one-shot poison (armed per-daemon via `arm_spawn_panic`, no process-global
-//! env — #181). The entry node is `code-mutating` so the spawn creates a
+//! env — #181). The entry node is isolated so the spawn creates a
 //! sub-worktree to reap; arming the poison before `POST /runs` makes the
 //! entry-node spawn (the first and only `spawn_node` call) consume it. No tmux
 //! is required: the panic fires before the session spawn.
@@ -27,7 +27,8 @@ nodes:
       - name: user_prompt
   - id: worker
     name: worker
-    type: code-mutating
+    type: agent
+    isolated_worktree: true
     inputs:
       - name: in
     outputs:

--- a/crates/pdo-daemon/tests/start_node.rs
+++ b/crates/pdo-daemon/tests/start_node.rs
@@ -17,7 +17,8 @@ nodes:
       - name: user_prompt
   - id: only
     name: only
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
     outputs:

--- a/crates/pdo-daemon/tests/sub_worktree_survive.rs
+++ b/crates/pdo-daemon/tests/sub_worktree_survive.rs
@@ -1,14 +1,14 @@
 //! Layer 3a — sub-worktree survival integration tests for issues #32 and #489.
 //!
-//! Spawns a real TestDaemon with a code-mutating pipeline, creates a run,
-//! marks the code-mutating node done, then asserts:
+//! Spawns a real TestDaemon with an isolated-node pipeline, creates a run,
+//! marks the isolated node done, then asserts:
 //! - the sub-worktree directory still exists on disk
 //! - GET /runs/{run_id}/nodes/{node_id}/prompt?iter=1 returns 200
 //!
 //! #489 extends the file to the other half of "survives": a `restart_node` on the
 //! same node must re-spawn it **without destroying the dead session's uncommitted
 //! work**. That is the regression the whole issue is about, and this pipeline
-//! already has the only node class that can see it (`code-mutating`).
+//! already has the only node class that can see it (isolated).
 
 use crate::common::TestDaemon;
 
@@ -24,7 +24,8 @@ nodes:
       - name: user_prompt
   - id: impl-1
     name: impl-1
-    type: code-mutating
+    type: agent
+    isolated_worktree: true
     inputs:
       - name: task
     outputs:
@@ -191,7 +192,7 @@ where
     panic!("timed out waiting for {what}");
 }
 
-/// **THE #489 REGRESSION.** A `restart_node` on a `code-mutating` node whose
+/// **THE #489 REGRESSION.** A `restart_node` on an isolated node whose
 /// sub-worktree already exists must genuinely re-spawn it, and must not touch the
 /// work in flight.
 ///
@@ -386,7 +387,7 @@ async fn a_panic_on_a_reused_sub_worktree_destroys_nothing() {
     assert_eq!(git_out(&sub_wt_dir, &["rev-parse", "HEAD"]), head_before);
 }
 
-/// Layer 3a: after marking a code-mutating node done, the sub-worktree
+/// Layer 3a: after marking an isolated node done, the sub-worktree
 /// directory must still exist on disk and the prompt endpoint must return 200.
 #[tokio::test]
 async fn sub_worktree_survives_node_completion() {
@@ -456,7 +457,7 @@ async fn sub_worktree_survives_node_completion() {
     assert_eq!(
         resp.status(),
         200,
-        "prompt endpoint must return 200 for completed code-mutating node"
+        "prompt endpoint must return 200 for completed isolated node"
     );
 
     let body = resp.text().await.unwrap();

--- a/crates/pdo-daemon/tests/switch_when_validation.rs
+++ b/crates/pdo-daemon/tests/switch_when_validation.rs
@@ -18,7 +18,8 @@ nodes:
       - name: user_prompt
   - id: reviewer
     name: reviewer
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
     outputs:
@@ -61,7 +62,8 @@ nodes:
       - name: user_prompt
   - id: reviewer
     name: reviewer
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
     outputs:

--- a/crates/pdo-daemon/tests/tmux_lifecycle.rs
+++ b/crates/pdo-daemon/tests/tmux_lifecycle.rs
@@ -33,7 +33,8 @@ nodes:
       - name: user_prompt
   - id: worker
     name: worker
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: in
     outputs:
@@ -412,14 +413,16 @@ nodes:
       - name: user_prompt
   - id: worker
     name: worker
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: in
     outputs:
       - name: out
   - id: second
     name: second
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: in
     outputs:

--- a/crates/pdo-daemon/tests/tmux_run_spawn.rs
+++ b/crates/pdo-daemon/tests/tmux_run_spawn.rs
@@ -25,7 +25,8 @@ nodes:
       - name: user_prompt
   - id: solo
     name: solo
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: in
     outputs:

--- a/crates/pdo-daemon/tests/trigger_scheduler.rs
+++ b/crates/pdo-daemon/tests/trigger_scheduler.rs
@@ -24,7 +24,8 @@ nodes:
       - name: user_prompt
   - id: solo
     name: solo
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: in
     outputs:

--- a/crates/pdo-daemon/tests/turn_end_autocomplete.rs
+++ b/crates/pdo-daemon/tests/turn_end_autocomplete.rs
@@ -8,7 +8,7 @@
 //! - with the setting **off**, a node that visibly finished its turn with valid
 //!   outputs is left alone (AC8);
 //! - with the setting **on**, that node is completed through the *same* body as
-//!   `POST …/done`, and a `code-mutating` node's commit lands on the pipeline
+//!   `POST …/done`, and an isolated node's commit lands on the pipeline
 //!   branch (AC9 — the §3 defect);
 //! - flipping the setting takes effect on the next sweep, no restart (AC10).
 //!
@@ -44,7 +44,8 @@ nodes:
       - name: user_prompt
   - id: worker
     name: worker
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: in
     outputs:
@@ -71,7 +72,8 @@ nodes:
       - name: user_prompt
   - id: worker
     name: worker
-    type: code-mutating
+    type: agent
+    isolated_worktree: true
     inputs:
       - name: in
     outputs:
@@ -795,13 +797,13 @@ async fn auto_done_with_missing_output_is_recoverable_and_records_nothing() {
 
 // --- AC9: the §3 defect — the commit must reach the pipeline branch ----------
 
-/// The test that catches the defect of the old design: on a `code-mutating` node,
+/// The test that catches the defect of the old design: on an isolated node,
 /// auto-completion must go through the same body as `POST …/done` —
 /// `commit_and_merge_sub_worktree_inner` included — or the node records
 /// `Completed` with its work stranded on `pdo/sub-…` and the downstream gets
 /// nothing.
 #[tokio::test]
-async fn auto_completing_a_code_mutating_node_merges_its_commit() {
+async fn auto_completing_an_isolated_node_merges_its_commit() {
     if !tmux_available() {
         eprintln!("tmux not on PATH — skipping");
         return;
@@ -819,7 +821,7 @@ async fn auto_completing_a_code_mutating_node_merges_its_commit() {
     assert!(wait_for_session(&socket, &session, Duration::from_secs(5)).await);
 
     let worktree = home.join(".pdo/runs").join(&run_id).join("worktree");
-    // A code-mutating node works in its OWN sub-worktree, and that is the cwd its
+    // An isolated node works in its OWN sub-worktree, and that is the cwd its
     // transcript is keyed on.
     let sub_worktree = home
         .join(".pdo/runs")
@@ -859,7 +861,7 @@ async fn auto_completing_a_code_mutating_node_merges_its_commit() {
             .await
             .as_deref(),
         Some("completed"),
-        "the finished code-mutating node must auto-complete"
+        "the finished isolated node must auto-complete"
     );
     let kinds = event_kinds(&daemon.url(), &run_id).await;
     assert!(

--- a/crates/pdo-daemon/tests/waiting_node_starvation.rs
+++ b/crates/pdo-daemon/tests/waiting_node_starvation.rs
@@ -29,7 +29,7 @@ use pdo_daemon::tmux_session_manager;
 
 const PIPELINE_NAME: &str = "starve";
 
-/// `start` fans out to two `doc-only` nodes that both go `Running` the instant a
+/// `start` fans out to two non-isolated nodes that both go `Running` the instant a
 /// Run is created — each consuming an admission slot — so a single Run of this
 /// pipeline saturates a cap of 2. `leader` alone feeds `end`; `leaf1` is a leaf,
 /// which is what lets us kill it while `leader` stays alive.
@@ -43,14 +43,16 @@ nodes:
       - name: user_prompt
   - id: leaf1
     name: leaf1
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
     outputs:
       - name: plan
   - id: leader
     name: leader
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
     outputs:

--- a/docs/design-brief.md
+++ b/docs/design-brief.md
@@ -82,7 +82,7 @@ The bulk of the screen. Renders the pipeline DAG of the currently selected run u
 
 - **Nodes** are styled as rounded rectangular boxes (~180×80 px), with:
   - Node name (top, bold).
-  - Node type badge: `code-mutating` (small icon: pen-on-code) or `doc-only` (small icon: document).
+  - Node type icon (`agent`, `script`, `merge`, `start`, `end`), plus a discreet branch glyph on the nodes that fork a worktree of their own.
   - Status indicator border or fill — same color scheme as the run-status icons (blue pulsing if running, gray if pending, green if done, etc.).
   - For nodes inside a topological cycle (with a back-edge), show an iteration counter `iter: 3/5` if applicable.
   - Input/output handles on left/right sides, one per port, labeled with port name.
@@ -200,7 +200,8 @@ The right panel adapts to the selection:
 
 **If a Node is selected:**
 - Section "Identity": id (auto-generated, editable), Name (display name).
-- Section "Type": radio between `code-mutating` and `doc-only`. Tooltip explains: "code-mutating gets its own git worktree and can commit; doc-only reads the pipeline branch and only writes Blackboard artifacts."
+- Section "Type": a static label (`agent`, or `script` for deterministic bash) — the type names the execution role and is not a toggle.
+- Section "Workspace": a radio pair between `Isolated worktree` ("a sub-worktree of the Node's own") and `Run worktree` ("shared with the whole Run"), with the resolved working directory printed underneath in monospace. Isolated is the default for an `agent`, the Run worktree for a `script`. Absent on `merge` (isolated by construction) and on Start/End.
 - Section "Behavior": toggle `interactive` (with help text: "When true, this node pauses after spawning and waits for the user to interact via terminal and click 'Mark complete' in run mode.").
 - Section "Prompt": a large textarea (≥10 rows, monospace, markdown) bound to the node's external prompt file (e.g. `prompts/<node-id>.md`). Auto-saved.
 - Section "Inputs": list of input ports. Each row: port name (editable), `repeated` toggle (with tooltip: "When true, this port reads all artifacts matching `iter-*/<port>.md` instead of just the latest."). "+ Add input port" button.
@@ -277,7 +278,7 @@ Do **not** design:
 
 Generate a clickable mockup with at least these screens / states:
 
-1. Run mode, default — a Run is selected, currently running with 2 active nodes (one `code-mutating` Implementer, one `doc-only` Reviewer).
+1. Run mode, default — a Run is selected, currently running with 2 active nodes (an isolated Implementer, a Reviewer sharing the Run worktree).
 2. Run mode — a Run is selected, blocked at a halt (max iterations reached). Manager attach button highlighted.
 3. Run mode — a Run is selected, awaiting user input on an interactive node. Right panel shows the awaiting-user banner and the Mark complete button.
 4. Edit mode — an existing pipeline open in the canvas, one node selected, right panel shows the node inspector.

--- a/docs/recipes/disk-janitor.md
+++ b/docs/recipes/disk-janitor.md
@@ -1,7 +1,7 @@
 # Recipe — unattended disk janitor (#128 Track A, #480)
 
 **Problem.** Every Run forks one or more git worktrees under `.pdo/runs/<run-id>/`.
-A worktree of a JS repo carries a full `node_modules` (~1 GB); a code-mutating
+A worktree of a JS repo carries a full `node_modules` (~1 GB); an isolated
 node recompiles into its own `target/`. A machine that fires Triggers around the
 clock accumulates terminal-Run residue and slows daemon startup (recursive inotify
 watch setup over the accumulated checkouts).
@@ -27,9 +27,9 @@ Two pieces, **both now shipped as tracked artifacts** (they used to be prose her
    existing `cleanup_run` command. The Trigger fires it on a schedule so the
    residue is handled even when nobody is watching.
 
-Why a `script` node + Rust and **not** the earlier `doc-only` + `python3` sketch:
+Why a `script` node + Rust and **not** the earlier agent + `python3` sketch:
 the sandbox image ships **neither `jq` nor `python3`**, so a bash/JSON prompt is
-dead on arrival there; and a `doc-only` node spends an LLM turn on a purely
+dead on arrival there; and an `agent` node spends an LLM turn on a purely
 mechanical task and is non-deterministic. A `script` node running deterministic
 Rust (`pdo reap`) is testable end-to-end in CI with **zero stubbing** (ADR-0017),
 and the policy itself is a pure, unit-tested function (`reap_policy`).
@@ -153,7 +153,7 @@ curl -s -X POST "$PDO_DAEMON_URL/triggers" \
 ## 5. Out of scope here (tracked separately)
 
 The disk-fill *incidents* (`.pdo/runs` spiking to tens of GB) are dominated by
-`target/` directories inside **live** Runs — one per code-mutating sub-worktree, at
+`target/` directories inside **live** Runs — one per isolated sub-worktree, at
 the same commit — which are **never** reapable by construction (`is_terminal()`).
 The janitor closes the *terminal-Run residue* leak and removes the human from that
 loop; it does **not** shrink a running build's footprint. Sharing a cargo build

--- a/frontend/e2e/canvas-port-labels.spec.ts
+++ b/frontend/e2e/canvas-port-labels.spec.ts
@@ -16,7 +16,7 @@ import { fileURLToPath } from "node:url";
 //
 // This spec seeds one node of each kind that still parses (legacy `switch`/
 // `loop` types migrate to generic agent nodes; `type: for-each` is hard-refused
-// since ADR-0011 — its slot here is a plain doc-only node with the same body/
+// since ADR-0011 — its slot here is a plain non-isolated node with the same body/
 // done port shape) and asserts: every output port renders
 // a dot, the merge input pill is present, hovering an output dot reveals its
 // label, and dragging from an output dot shows the dynamic edge label.
@@ -40,7 +40,8 @@ nodes:
     view: { x: 0, y: 200 }
   - id: planner
     name: Planner
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
         side: left
@@ -79,7 +80,8 @@ nodes:
     view: { x: 500, y: 300 }
   - id: fe1
     name: per-item
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: in
         side: left
@@ -104,7 +106,8 @@ nodes:
     view: { x: 750, y: 300 }
   - id: impl1
     name: implementer
-    type: code-mutating
+    type: agent
+    isolated_worktree: true
     inputs:
       - name: in
         side: left
@@ -152,7 +155,7 @@ test("every output port renders a dot and the merge input keeps its pill", async
 
   // Output ports render as dots (`port-output-<name>`). The seed declares 10
   // output ports across the node types: user_prompt, plan, pass, default,
-  // body, done (loop), body, done (per-item doc-only), merged, out.
+  // body, done (loop), body, done (per-item non-isolated), merged, out.
   const outputDots = page.locator('[data-testid^="port-output-"]');
   await expect(outputDots).toHaveCount(10, { timeout: 5_000 });
 

--- a/frontend/e2e/canvas-undo-redo.spec.ts
+++ b/frontend/e2e/canvas-undo-redo.spec.ts
@@ -33,7 +33,8 @@ nodes:
     view: { x: 0, y: 100 }
   - id: alpha
     name: alpha
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - { name: in, side: left }
     outputs:
@@ -41,7 +42,8 @@ nodes:
     view: { x: 250, y: 100 }
   - id: beta
     name: beta
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - { name: in, side: left }
     outputs:

--- a/frontend/e2e/cold-start-integration.spec.ts
+++ b/frontend/e2e/cold-start-integration.spec.ts
@@ -37,7 +37,8 @@ nodes:
     view: { x: 200, y: 0 }
   - id: worker
     name: worker
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     prompt_file: ${PIPELINE_NAME}.prompts/worker.md
     inputs:
       - name: task

--- a/frontend/e2e/collection-region.spec.ts
+++ b/frontend/e2e/collection-region.spec.ts
@@ -39,7 +39,8 @@ nodes:
     view: { x: 0, y: 200 }
   - id: upstream
     name: upstream
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: in
         side: left
@@ -52,7 +53,8 @@ nodes:
     view: { x: 250, y: 200 }
   - id: worker
     name: worker
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: in
         side: left

--- a/frontend/e2e/edit-drag-no-teleport.spec.ts
+++ b/frontend/e2e/edit-drag-no-teleport.spec.ts
@@ -32,7 +32,8 @@ nodes:
     view: { x: 0, y: 200 }
   - id: dragger
     name: dragger
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     prompt_file: ${PIPELINE_NAME}.prompts/dragger.md
     inputs:
       - { name: in, side: left }

--- a/frontend/e2e/edit-self-write.spec.ts
+++ b/frontend/e2e/edit-self-write.spec.ts
@@ -34,7 +34,8 @@ nodes:
     view: { x: 0, y: 100 }
   - id: alpha
     name: alpha
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     prompt_file: ${PIPELINE_NAME}.prompts/alpha.md
     inputs:
       - { name: in, side: left }
@@ -43,7 +44,8 @@ nodes:
     view: { x: 200, y: 100 }
   - id: beta
     name: beta
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     prompt_file: ${PIPELINE_NAME}.prompts/beta.md
     inputs:
       - { name: in, side: left }

--- a/frontend/e2e/failed-node.spec.ts
+++ b/frontend/e2e/failed-node.spec.ts
@@ -42,7 +42,8 @@ nodes:
     view: { x: 100, y: 0 }
   - id: worker
     name: worker
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - { name: task, side: top }
     outputs:

--- a/frontend/e2e/force-start-pending-node.spec.ts
+++ b/frontend/e2e/force-start-pending-node.spec.ts
@@ -35,7 +35,8 @@ nodes:
     view: { x: 0, y: 100 }
   - id: worker-a
     name: Worker A
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: in
     outputs:
@@ -43,7 +44,8 @@ nodes:
     view: { x: 200, y: 100 }
   - id: worker-b
     name: Worker B
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: in
     outputs:

--- a/frontend/e2e/group-move-nodes.spec.ts
+++ b/frontend/e2e/group-move-nodes.spec.ts
@@ -35,7 +35,8 @@ nodes:
     view: { x: 0, y: 300 }
   - id: alpha
     name: alpha
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - { name: in, side: left }
     outputs:
@@ -43,7 +44,8 @@ nodes:
     view: { x: 240, y: 100 }
   - id: beta
     name: beta
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - { name: in, side: left }
     outputs:
@@ -51,7 +53,8 @@ nodes:
     view: { x: 240, y: 320 }
   - id: gamma
     name: gamma
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - { name: in, side: left }
     outputs:

--- a/frontend/e2e/hot-reload-conflict.spec.ts
+++ b/frontend/e2e/hot-reload-conflict.spec.ts
@@ -34,7 +34,8 @@ nodes:
     view: { x: 0, y: 100 }
   - id: alpha
     name: alpha
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     prompt_file: ${PIPELINE_NAME}.prompts/alpha.md
     inputs:
       - { name: in, side: left }
@@ -65,7 +66,8 @@ nodes:
     view: { x: 0, y: 100 }
   - id: alpha
     name: alpha
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     prompt_file: ${PIPELINE_NAME}.prompts/alpha.md
     inputs:
       - { name: in, side: left }
@@ -74,7 +76,8 @@ nodes:
     view: { x: 200, y: 100 }
   - id: beta
     name: beta
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - { name: in, side: left }
     outputs:

--- a/frontend/e2e/initial-prompt.spec.ts
+++ b/frontend/e2e/initial-prompt.spec.ts
@@ -27,7 +27,8 @@ nodes:
     view: { x: 100, y: 0 }
   - id: worker
     name: worker
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     prompt_file: ${PIPELINE_NAME}.prompts/worker.md
     inputs:
       - { name: task, side: top }

--- a/frontend/e2e/inspector-tabs.spec.ts
+++ b/frontend/e2e/inspector-tabs.spec.ts
@@ -37,7 +37,8 @@ nodes:
     view: { x: 0, y: 100 }
   - id: worker-a
     name: Worker A
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: in
     outputs:
@@ -45,7 +46,8 @@ nodes:
     view: { x: 200, y: 100 }
   - id: worker-b
     name: Worker B
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: in
     outputs:

--- a/frontend/e2e/interrupted-node-fp.spec.ts
+++ b/frontend/e2e/interrupted-node-fp.spec.ts
@@ -42,7 +42,8 @@ nodes:
     view: { x: 100, y: 0 }
   - id: worker
     name: worker
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - { name: task, side: top }
     outputs:

--- a/frontend/e2e/library-node-ports.spec.ts
+++ b/frontend/e2e/library-node-ports.spec.ts
@@ -31,7 +31,8 @@ nodes:
     view: { x: 0, y: 200 }
   - id: reviewer
     name: reviewer
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: code
       - name: context
@@ -144,7 +145,7 @@ test("instantiating from library restores ports and frontmatter", async ({
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         name: "reviewer",
-        type: "doc-only",
+        type: "agent",
         inputs: [
           { name: "code", repeated: false },
           { name: "context", repeated: true },

--- a/frontend/e2e/loop-review-loop.spec.ts
+++ b/frontend/e2e/loop-review-loop.spec.ts
@@ -33,7 +33,8 @@ nodes:
     view: { x: 0, y: 0 }
   - id: impl1
     name: implementer
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - { name: in, side: left }
     outputs:
@@ -41,7 +42,8 @@ nodes:
     view: { x: 200, y: 160 }
   - id: reviewer
     name: reviewer
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - { name: in, side: left }
     outputs:

--- a/frontend/e2e/node-icons.spec.ts
+++ b/frontend/e2e/node-icons.spec.ts
@@ -11,10 +11,11 @@ import { fileURLToPath } from "node:url";
 // The backend still parses the legacy variants but migrates them onto generic
 // agent nodes, so they render with the agent icon and no code/doc marker.
 //
-// This spec seeds start + two generic agents (one doc-only, one code-mutating)
-// + merge + end and asserts: structural icons for start/end/merge, the agent
-// icon for the generics, no text pills, and exactly the two explicit code/doc
-// markers.
+// This spec seeds start + two Agents (one sharing the Run worktree, one
+// isolated) + merge + end and asserts: structural icons for start/end/merge, the
+// agent icon for both Agents, no text pills, and the isolation marker on exactly
+// the nodes that fork a worktree of their own (#653: the isolated Agent and the
+// Merge, which is isolated by construction).
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const WORKSPACE_ROOT = path.resolve(__dirname, "..", "..");
@@ -35,7 +36,8 @@ nodes:
     view: { x: 0, y: 300 }
   - id: planner
     name: Planner
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: in
         side: left
@@ -45,7 +47,8 @@ nodes:
     view: { x: 250, y: 200 }
   - id: implementer
     name: Implementer
-    type: code-mutating
+    type: agent
+    isolated_worktree: true
     inputs:
       - name: in
         side: left
@@ -116,7 +119,7 @@ test("each node type renders its structural icon", async ({ page }) => {
   await expect(page.locator("[data-testid='node-icon-end']").first()).toBeVisible({ timeout: 3_000 });
   await expect(page.locator("[data-testid='node-icon-merge']").first()).toBeVisible({ timeout: 3_000 });
 
-  // Generic agent nodes (doc-only + code-mutating) render the agent icon.
+  // Both Agents render the agent icon, whatever their workspace.
   const agentIcons = page.locator("[data-testid='node-icon-agent']");
   await expect(agentIcons).toHaveCount(2, { timeout: 3_000 });
 
@@ -154,7 +157,7 @@ test("no text pills are present on any node", async ({ page }) => {
   }
 });
 
-test("code-mutating and doc-only markers are present and visually distinct", async ({
+test("the isolation marker rides only the nodes that fork a worktree (#653)", async ({
   page,
 }) => {
   await page.goto("/");
@@ -165,13 +168,18 @@ test("code-mutating and doc-only markers are present and visually distinct", asy
   await openPipelineForEdit(page, PIPELINE_NAME);
   await page.waitForTimeout(500);
 
-  // There should be exactly 2 code/doc markers (one per generic agent node)
-  const markers = page.locator("[data-testid='code-doc-marker']");
+  // Two markers: the isolated Agent, and the Merge (isolated by construction).
+  // The Agent that shares the Run worktree carries none — absence IS the signal.
+  const markers = page.locator("[data-testid='isolation-marker']");
   await expect(markers).toHaveCount(2, { timeout: 3_000 });
 
-  // One should be code-mutating, one should be doc-only
-  const codeMarker = page.locator("[data-testid='code-doc-marker'][data-marker-type='code-mutating']");
-  const docMarker = page.locator("[data-testid='code-doc-marker'][data-marker-type='doc-only']");
-  await expect(codeMarker).toHaveCount(1);
-  await expect(docMarker).toHaveCount(1);
+  await expect(
+    page.getByTestId("rf__node-implementer").getByTestId("isolation-marker"),
+  ).toHaveCount(1);
+  await expect(
+    page.getByTestId("rf__node-merger").getByTestId("isolation-marker"),
+  ).toHaveCount(1);
+  await expect(
+    page.getByTestId("rf__node-planner").getByTestId("isolation-marker"),
+  ).toHaveCount(0);
 });

--- a/frontend/e2e/node-io-modal.spec.ts
+++ b/frontend/e2e/node-io-modal.spec.ts
@@ -31,7 +31,8 @@ nodes:
     view: { x: 0, y: 0 }
   - id: reviewer
     name: reviewer
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
     outputs:

--- a/frontend/e2e/output-schema-editor.spec.ts
+++ b/frontend/e2e/output-schema-editor.spec.ts
@@ -32,7 +32,8 @@ nodes:
     view: { x: 0, y: 200 }
   - id: reviewer
     name: reviewer
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
     outputs:

--- a/frontend/e2e/pipeline-info-panel.spec.ts
+++ b/frontend/e2e/pipeline-info-panel.spec.ts
@@ -54,7 +54,8 @@ nodes:
     view: { x: 0, y: 100 }
   - id: worker
     name: worker
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: in
     outputs:
@@ -219,7 +220,7 @@ test("YAML tab shows serialized pipeline and updates on mutation (#69)", async (
 
   // Add a new node via toolbar. Since #307/#310 `toolbar-add` is a dropdown
   // (Node | Note) — open it, then pick "Node" (`add-menu-node`), which inserts a
-  // `code-mutating` node whose default name is "implementer" (node ids are random
+  // isolated node whose default name is "implementer" (node ids are random
   // nanoids, no longer `node-N`).
   await dismissConflictIfPresent(page);
   await page.getByTestId("toolbar-add").click();

--- a/frontend/e2e/recent-repos.spec.ts
+++ b/frontend/e2e/recent-repos.spec.ts
@@ -23,7 +23,8 @@ nodes:
     view: { x: 0, y: 100 }
   - id: worker
     name: Worker
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     prompt_file: ${PIPELINE_NAME}.prompts/worker.md
     inputs:
       - name: task

--- a/frontend/e2e/remote-branches.spec.ts
+++ b/frontend/e2e/remote-branches.spec.ts
@@ -34,7 +34,8 @@ nodes:
     view: { x: 100, y: 0 }
   - id: worker
     name: worker
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     prompt_file: ${PIPELINE_NAME}.prompts/worker.md
     inputs:
       - { name: task, side: top }

--- a/frontend/e2e/render-html-artifact.spec.ts
+++ b/frontend/e2e/render-html-artifact.spec.ts
@@ -36,7 +36,8 @@ nodes:
     view: { x: 0, y: 200 }
   - id: designer
     name: designer
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     prompt_file: ${PIPELINE_NAME}.prompts/designer.md
     inputs:
       - { name: in, side: left }

--- a/frontend/e2e/render-mermaid-artifact.spec.ts
+++ b/frontend/e2e/render-mermaid-artifact.spec.ts
@@ -35,7 +35,8 @@ nodes:
     view: { x: 0, y: 200 }
   - id: diagrammer
     name: diagrammer
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     prompt_file: ${PIPELINE_NAME}.prompts/diagrammer.md
     inputs:
       - { name: in, side: left }

--- a/frontend/e2e/resizable-panels.spec.ts
+++ b/frontend/e2e/resizable-panels.spec.ts
@@ -31,7 +31,8 @@ nodes:
       - name: user_prompt
   - id: alpha
     name: alpha
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: in
     outputs:

--- a/frontend/e2e/run-edit-toggle.spec.ts
+++ b/frontend/e2e/run-edit-toggle.spec.ts
@@ -25,7 +25,8 @@ nodes:
       - name: user_prompt
   - id: planner
     name: planner
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: task
     outputs:

--- a/frontend/e2e/runs-filter.spec.ts
+++ b/frontend/e2e/runs-filter.spec.ts
@@ -33,7 +33,8 @@ nodes:
     view: { x: 0, y: 100 }
   - id: worker
     name: Worker
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     prompt_file: ${name}.prompts/worker.md
     inputs:
       - name: task

--- a/frontend/e2e/runs-triggers-by-repo.spec.ts
+++ b/frontend/e2e/runs-triggers-by-repo.spec.ts
@@ -36,7 +36,8 @@ nodes:
     view: { x: 0, y: 100 }
   - id: worker
     name: Worker
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     prompt_file: ${PIPELINE_NAME}.prompts/worker.md
     inputs:
       - name: task

--- a/frontend/e2e/save-button.spec.ts
+++ b/frontend/e2e/save-button.spec.ts
@@ -32,7 +32,8 @@ nodes:
     view: { x: 0, y: 100 }
   - id: alpha
     name: alpha
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     prompt_file: ${PIPELINE_NAME}.prompts/alpha.md
     inputs:
       - { name: in, side: left }

--- a/frontend/e2e/save-error-modal.spec.ts
+++ b/frontend/e2e/save-error-modal.spec.ts
@@ -32,7 +32,8 @@ nodes:
     view: { x: 0, y: 100 }
   - id: alpha
     name: alpha
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     prompt_file: ${PIPELINE_NAME}.prompts/alpha.md
     inputs:
       - { name: in, side: left }

--- a/frontend/e2e/start-node.spec.ts
+++ b/frontend/e2e/start-node.spec.ts
@@ -32,7 +32,8 @@ nodes:
     view: { x: 0, y: 100 }
   - id: only
     name: only
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     prompt_file: ${PIPELINE_NAME}.prompts/only.md
     inputs:
       - name: task

--- a/frontend/e2e/switch-typed-when.spec.ts
+++ b/frontend/e2e/switch-typed-when.spec.ts
@@ -35,7 +35,8 @@ nodes:
     view: { x: 200, y: 0 }
   - id: reviewer
     name: reviewer
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - { name: task, side: top }
     outputs:

--- a/frontend/e2e/tabbar-overflow.spec.ts
+++ b/frontend/e2e/tabbar-overflow.spec.ts
@@ -34,7 +34,8 @@ nodes:
       - name: user_prompt
   - id: alpha
     name: alpha
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: in
     outputs:

--- a/frontend/e2e/terminal-preview.spec.ts
+++ b/frontend/e2e/terminal-preview.spec.ts
@@ -32,7 +32,8 @@ nodes:
     view: { x: 100, y: 0 }
   - id: echoer
     name: echoer
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: in
     outputs:

--- a/frontend/e2e/terminated-node-minimized.spec.ts
+++ b/frontend/e2e/terminated-node-minimized.spec.ts
@@ -36,7 +36,8 @@ nodes:
     view: { x: 100, y: 0 }
   - id: worker
     name: worker
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - { name: task, side: top }
     outputs:

--- a/frontend/e2e/triangle-handle-side.spec.ts
+++ b/frontend/e2e/triangle-handle-side.spec.ts
@@ -36,7 +36,8 @@ nodes:
     view: { x: 0, y: 100 }
   - id: checker
     name: checker
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     prompt_file: ${PIPELINE_NAME}.prompts/checker.md
     inputs:
       - name: task

--- a/frontend/e2e/xterm-scroll-wheel.spec.ts
+++ b/frontend/e2e/xterm-scroll-wheel.spec.ts
@@ -44,7 +44,8 @@ nodes:
     view: { x: 100, y: 0 }
   - id: scroller
     name: scroller
-    type: doc-only
+    type: agent
+    isolated_worktree: false
     inputs:
       - name: in
     outputs:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -382,7 +382,7 @@ export default function App() {
     switch (editNodeType) {
       case "merge": return <MergeInspector />;
       // #248: `script` reuses NodeInspector, which shows the Script (bash) editor
-      // and hides the model field / doc-only↔code-mutating toggle for it.
+      // and hides the model field for it.
       // Without this case a script node would fall through and — before the
       // in-inspector conditionals — render the wrong (agent) surface.
       case "script":
@@ -391,6 +391,7 @@ export default function App() {
           libraryEntries={libraryEntries}
           onLibraryChanged={refreshLibrary}
           readOnly={isActiveRunArchived}
+          runNode={selection.id ? selectedRun?.nodes?.[selection.id] : null}
         />
       );
     }
@@ -703,6 +704,7 @@ export default function App() {
                     libraryEntries={libraryEntries}
                     onLibraryChanged={refreshLibrary}
                     readOnly={isActiveRunArchived}
+                    runNode={selection.id ? selectedRun?.nodes?.[selection.id] : null}
                   />
                 ) : selection.kind === "edge" ? (
                   <EdgeDetailPanel trigger={edgeTrigger} />

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1515,6 +1515,9 @@ export interface ParseNodeResult {
      *  model/effort re-homing onto `claude`. */
     pin_harness?: string | null;
     harnesses?: Record<string, { model?: string; effort?: string }> | null;
+    /** #653/ADR-0060: where the node works. `null` for the types that carry no
+     *  isolation (`merge`, `start`, `end`). */
+    isolated_worktree?: boolean | null;
     max_iter?: number | string | null;
     branches?: number | null;
   };

--- a/frontend/src/components/AddNodeFromYamlModal.test.tsx
+++ b/frontend/src/components/AddNodeFromYamlModal.test.tsx
@@ -37,7 +37,7 @@ function okResult(overrides: Partial<ParseNodeResult> = {}): ParseNodeResult {
   return {
     spec: {
       name: "Imported",
-      type: "doc-only",
+      type: "agent",
       inputs: [],
       outputs: [{ name: "out", repeated: false, side: "right" }],
       interactive: false,
@@ -64,7 +64,7 @@ describe("AddNodeFromYamlModal (#345)", () => {
     render(<AddNodeFromYamlModal getDropPosition={drop} onClose={onClose} />);
 
     fireEvent.change(screen.getByTestId("add-node-yaml-textarea"), {
-      target: { value: "name: Imported\ntype: doc-only\n" },
+      target: { value: "name: Imported\ntype: agent\nisolated_worktree: false\n" },
     });
     fireEvent.click(screen.getByTestId("add-node-yaml-submit"));
 
@@ -79,11 +79,29 @@ describe("AddNodeFromYamlModal (#345)", () => {
     expect(st.selection).toEqual({ kind: "node", id: "fresh-node-id" });
   });
 
+  it("carries the pasted node's workspace onto the canvas (#653)", async () => {
+    // A node that opted OUT of isolation must not silently fork a sub-worktree
+    // once instantiated — the isolation line travels with the spec.
+    mockParse.mockResolvedValue(
+      okResult({ spec: { ...okResult().spec, isolated_worktree: false } }),
+    );
+    render(<AddNodeFromYamlModal getDropPosition={drop} onClose={() => {}} />);
+    fireEvent.change(screen.getByTestId("add-node-yaml-textarea"), {
+      target: { value: "name: Imported\ntype: agent\nisolated_worktree: false\n" },
+    });
+    fireEvent.click(screen.getByTestId("add-node-yaml-submit"));
+
+    await waitFor(() =>
+      expect(useEditStore.getState().openTabs[0].pipeline.nodes).toHaveLength(1),
+    );
+    expect(useEditStore.getState().openTabs[0].pipeline.nodes[0].isolated_worktree).toBe(false);
+  });
+
   it("the created node is undoable in one step", async () => {
     mockParse.mockResolvedValue(okResult());
     render(<AddNodeFromYamlModal getDropPosition={drop} onClose={() => {}} />);
     fireEvent.change(screen.getByTestId("add-node-yaml-textarea"), {
-      target: { value: "name: Imported\ntype: doc-only\n" },
+      target: { value: "name: Imported\ntype: agent\nisolated_worktree: false\n" },
     });
     fireEvent.click(screen.getByTestId("add-node-yaml-submit"));
     await waitFor(() => expect(useEditStore.getState().openTabs[0].pipeline.nodes).toHaveLength(1));
@@ -107,7 +125,7 @@ describe("AddNodeFromYamlModal (#345)", () => {
 
   it("warnings create the node AND show the amber list (does not auto-close)", async () => {
     mockParse.mockResolvedValue(
-      okResult({ warnings: ["node 'x': unknown node type 'bogus', defaulting to 'doc-only'"] }),
+      okResult({ warnings: ["node 'x': unknown node type 'bogus', defaulting to 'agent'"] }),
     );
     const onClose = vi.fn();
     render(<AddNodeFromYamlModal getDropPosition={drop} onClose={onClose} />);
@@ -123,7 +141,7 @@ describe("AddNodeFromYamlModal (#345)", () => {
 
   it("a .yaml upload fills the textarea from the file text", async () => {
     render(<AddNodeFromYamlModal getDropPosition={drop} onClose={() => {}} />);
-    const file = new File(["name: FromFile\ntype: doc-only\n"], "node.yaml", {
+    const file = new File(["name: FromFile\ntype: agent\nisolated_worktree: false\n"], "node.yaml", {
       type: "text/yaml",
     });
     fireEvent.change(screen.getByTestId("add-node-yaml-file"), { target: { files: [file] } });

--- a/frontend/src/components/AddNodeFromYamlModal.tsx
+++ b/frontend/src/components/AddNodeFromYamlModal.tsx
@@ -64,6 +64,9 @@ export default function AddNodeFromYamlModal({
         inputs: result.spec.inputs.map((p) => libraryPortToPortDef(p, "left")),
         outputs: result.spec.outputs.map((p) => libraryPortToPortDef(p, "right")),
         interactive: result.spec.interactive,
+        // #653/ADR-0060: carry the pasted node's workspace through. Dropping it
+        // would silently fork a sub-worktree for a node that opted out.
+        isolated_worktree: result.spec.isolated_worktree ?? null,
         pin_harness: result.spec.pin_harness ?? null,
         harnesses: result.spec.harnesses ?? undefined,
         // Fallback flat values (a legacy library/export with no `harnesses` map);
@@ -121,7 +124,7 @@ export default function AddNodeFromYamlModal({
             setWarnings(null);
           }}
           disabled={warnings != null}
-          placeholder={"name: My node\ntype: doc-only\nprompt: |\n  ..."}
+          placeholder={"name: My node\ntype: agent\nisolated_worktree: false\nprompt: |\n  ..."}
           data-testid="add-node-yaml-textarea"
           className="mb-2 h-40 w-full resize-y rounded border border-line-strong bg-bg-3 px-2 py-1.5 font-mono text-fg outline-none focus:border-acc disabled:opacity-60"
           style={{ fontSize: "11px", lineHeight: "1.5" }}

--- a/frontend/src/components/DiffSection.test.tsx
+++ b/frontend/src/components/DiffSection.test.tsx
@@ -112,7 +112,7 @@ describe("DiffSection", () => {
     expect(screen.getByText("No changes")).toBeInTheDocument();
   });
 
-  it("shows dropdown with completed code-mutating nodes", async () => {
+  it("shows dropdown with completed isolated nodes only (#653)", async () => {
     const run = makeRun({
       nodes: {
         "impl-1": makeNodeState({ node_id: "impl-1" }),
@@ -125,7 +125,8 @@ describe("DiffSection", () => {
         {
           id: "impl-1",
           name: "Implementer",
-          node_type: "code-mutating",
+          node_type: "agent",
+          isolated_worktree: true,
           view_x: 0,
           view_y: 0,
           inputs: [],
@@ -134,7 +135,8 @@ describe("DiffSection", () => {
         {
           id: "reviewer-1",
           name: "Reviewer",
-          node_type: "doc-only",
+          node_type: "agent",
+          isolated_worktree: false,
           view_x: 0,
           view_y: 0,
           inputs: [],
@@ -172,7 +174,8 @@ describe("DiffSection", () => {
         {
           id: "impl-1",
           name: "Implementer",
-          node_type: "code-mutating",
+          node_type: "agent",
+          isolated_worktree: true,
           view_x: 0,
           view_y: 0,
           inputs: [],

--- a/frontend/src/components/DiffSection.tsx
+++ b/frontend/src/components/DiffSection.tsx
@@ -15,11 +15,19 @@ export default function DiffSection({ run }: Props) {
   const [selectedNode, setSelectedNode] = useState<string>("");
   const [collapsedFiles, setCollapsedFiles] = useState<Set<number>>(new Set());
 
-  const codeMutatingNodes = useMemo(() => {
+  // #653/ADR-0060: a per-node diff exists for a node that worked in a
+  // sub-worktree of its own — it has a branch to diff. Isolation, not the node's
+  // type, is what says so; the frozen value on the NodeRun wins over the
+  // snapshot, because that is where the iteration actually ran.
+  const isolatedNodes = useMemo(() => {
     if (!run) return [];
     return run.node_defs.filter((nd) => {
       const ns = run.nodes[nd.id];
-      return nd.node_type === "code-mutating" && ns?.status === "completed";
+      const isolated =
+        ns?.isolated_worktree ??
+        nd.isolated_worktree ??
+        (nd.node_type === "agent" || nd.node_type === "merge");
+      return isolated && ns?.status === "completed";
     });
   }, [run]);
 
@@ -94,7 +102,7 @@ export default function DiffSection({ run }: Props) {
             </div>
           ) : (
             <>
-              {codeMutatingNodes.length > 0 && (
+              {isolatedNodes.length > 0 && (
                 <select
                   data-testid="diff-node-select"
                   value={selectedNode}
@@ -103,7 +111,7 @@ export default function DiffSection({ run }: Props) {
                   style={{ fontSize: "10.5px" }}
                 >
                   <option value="">Aggregate (all changes)</option>
-                  {codeMutatingNodes.map((nd) => (
+                  {isolatedNodes.map((nd) => (
                     <option key={nd.id} value={nd.id}>
                       {nd.name ?? nd.id}
                     </option>

--- a/frontend/src/components/EdgeClickBehavior.test.ts
+++ b/frontend/src/components/EdgeClickBehavior.test.ts
@@ -27,7 +27,7 @@ function makeNode(overrides: Partial<NodeDef> = {}): NodeDef {
   return {
     id: "default",
     name: "Default",
-    type: "doc-only",
+    type: "agent",
     inputs: [{ name: "in", repeated: false }],
     outputs: [{ name: "out", repeated: false }],
     interactive: false,

--- a/frontend/src/components/EdgeDetailPanel.test.tsx
+++ b/frontend/src/components/EdgeDetailPanel.test.tsx
@@ -9,7 +9,7 @@ function reviewer(): NodeDef {
   return {
     id: "reviewer",
     name: "reviewer",
-    type: "doc-only",
+    type: "agent",
     inputs: [{ name: "task", repeated: false, side: "left" }],
     outputs: [
       {
@@ -31,7 +31,7 @@ function impl(): NodeDef {
   return {
     id: "impl",
     name: "implementer",
-    type: "code-mutating",
+    type: "agent",
     inputs: [{ name: "review", repeated: false, side: "left" }],
     outputs: [{ name: "diff", repeated: false, side: "right" }],
     interactive: false,

--- a/frontend/src/components/EditCanvas.archived315.test.tsx
+++ b/frontend/src/components/EditCanvas.archived315.test.tsx
@@ -73,7 +73,7 @@ const PIPELINE = {
     {
       id: "worker",
       name: "Worker",
-      type: "doc-only" as const,
+      type: "agent" as const,
       interactive: false,
       inputs: [{ name: "task", repeated: false, side: "left" as const }],
       outputs: [{ name: "result", repeated: false, side: "right" as const }],

--- a/frontend/src/components/EditCanvas.banner225.test.tsx
+++ b/frontend/src/components/EditCanvas.banner225.test.tsx
@@ -163,7 +163,7 @@ const NUDGE_PIPELINE = {
     {
       id: "triage",
       name: "Triage",
-      type: "doc-only" as const,
+      type: "agent" as const,
       interactive: false,
       inputs: [],
       outputs: [
@@ -178,7 +178,7 @@ const NUDGE_PIPELINE = {
     {
       id: "fixer",
       name: "Fixer",
-      type: "code-mutating" as const,
+      type: "agent" as const,
       interactive: false,
       inputs: [{ name: "in", repeated: false, side: "left" as const }],
       outputs: [],

--- a/frontend/src/components/EditCanvas.isolation653.test.tsx
+++ b/frontend/src/components/EditCanvas.isolation653.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import EditCanvas from "./EditCanvas";
+import { useEditStore, type OpenPipeline } from "../stores/editStore";
+import { TooltipProvider } from "./ui/tooltip";
+
+// jsdom has no ResizeObserver; ReactFlow's container measurement needs it.
+globalThis.ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+// The toolbar renders OUTSIDE <ReactFlow>, so collapsing the canvas body to a
+// passthrough <div> leaves the add-node menu — the surface under test — intact.
+vi.mock("@xyflow/react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@xyflow/react")>();
+  return {
+    ...actual,
+    ReactFlow: (props: { children?: React.ReactNode }) => (
+      <div data-testid="reactflow-stub">{props.children}</div>
+    ),
+  };
+});
+
+vi.mock("../api", () => ({
+  fetchAgentProfiles: vi.fn().mockResolvedValue({ profiles: [] }),
+  fetchLibrary: vi.fn().mockResolvedValue([]),
+  fetchLibraryPipelines: vi.fn().mockResolvedValue([]),
+  saveLibraryPipeline: vi.fn().mockResolvedValue({ id: "p", scope: "repo" }),
+  deleteLibraryPipeline: vi.fn().mockResolvedValue(undefined),
+  saveToLibrary: vi.fn().mockResolvedValue({}),
+  deleteFromLibrary: vi.fn().mockResolvedValue(undefined),
+}));
+
+function emptyTab(): OpenPipeline {
+  return {
+    id: "p1",
+    scope: "repo",
+    pipeline: { name: "p1", version: "1.0", variables: {}, nodes: [], edges: [] },
+    prompts: {},
+    diagnostics: [],
+    dirty: false,
+    externalDirty: false,
+    libraryId: null,
+    libraryScope: null,
+  };
+}
+
+function renderCanvas() {
+  return render(
+    <TooltipProvider>
+      <EditCanvas
+        libraryEntries={[]}
+        libraryPipelines={[]}
+        onLibraryDelete={() => {}}
+        onLibraryPipelinesChanged={() => {}}
+      />
+    </TooltipProvider>,
+  );
+}
+
+beforeEach(() => {
+  useEditStore.setState({
+    openTabs: [emptyTab()],
+    activeTabId: "p1",
+    selection: { kind: "none", id: null },
+  });
+});
+
+/**
+ * #653 / ADR-0060 — the editor's initial values. Isolated is the safe placement
+ * for an Agent, so it is the default; a Script stays out of a sub-worktree so
+ * lightweight runtime and artifact work stays lightweight. Both are written
+ * down at creation, never left implicit.
+ */
+describe("EditCanvas — new-node isolation defaults (#653)", () => {
+  it("creates an Agent isolated, and says so on the node", async () => {
+    renderCanvas();
+    fireEvent.click(screen.getByTestId("toolbar-add"));
+    fireEvent.click(await screen.findByTestId("add-menu-node"));
+
+    const nodes = useEditStore.getState().openTabs[0].pipeline.nodes;
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0].type).toBe("agent");
+    expect(nodes[0].isolated_worktree).toBe(true);
+  });
+
+  it("creates a Script in the Run worktree, and says so on the node", () => {
+    renderCanvas();
+    fireEvent.click(screen.getByTestId("toolbar-script"));
+
+    const nodes = useEditStore.getState().openTabs[0].pipeline.nodes;
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0].type).toBe("script");
+    expect(nodes[0].isolated_worktree).toBe(false);
+  });
+
+  it("creates a Merge with no isolation to state — it forks by construction", () => {
+    renderCanvas();
+    fireEvent.click(screen.getByTestId("toolbar-merge"));
+
+    const nodes = useEditStore.getState().openTabs[0].pipeline.nodes;
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0].type).toBe("merge");
+    expect(nodes[0].isolated_worktree).toBeUndefined();
+  });
+});

--- a/frontend/src/components/EditCanvas.nodes.test.tsx
+++ b/frontend/src/components/EditCanvas.nodes.test.tsx
@@ -101,28 +101,34 @@ describe("EditNode start/end markers — green-on-complete (issue #105, inline r
 });
 
 describe("EditNode slim card (issue #149)", () => {
-  function workProps(overrides: Partial<{ interactive: boolean }> = {}) {
+  function workProps(overrides: Partial<{ interactive: boolean; isolated: boolean }> = {}) {
     const data = {
       label: "rewrite_section",
       nodeId: "nd_4f2a",
-      nodeType: "code-mutating" as NodeType,
+      nodeType: "agent" as NodeType,
       status: "pending" as NodeStatus,
       reached: false,
       inputs: [],
       outputs: [{ name: "out", side: "right" as const }],
       interactive: overrides.interactive ?? false,
+      isolated: overrides.isolated ?? false,
     };
     return {
-      ...markerProps({ nodeType: "code-mutating" }),
+      ...markerProps({ nodeType: "agent" }),
       id: "nd_4f2a",
       data,
     } as unknown as Parameters<typeof EditNode>[0];
   }
 
-  it("shows the node name and the code/doc marker", () => {
-    render(<EditNode {...workProps()} />, { wrapper: Wrapper });
+  it("shows the node name and the isolation marker (#653)", () => {
+    render(<EditNode {...workProps({ isolated: true })} />, { wrapper: Wrapper });
     expect(screen.getByText("rewrite_section")).toBeTruthy();
-    expect(screen.getByTestId("code-doc-marker")).toBeTruthy();
+    expect(screen.getByTestId("isolation-marker")).toBeTruthy();
+  });
+
+  it("leaves a shared-worktree node unmarked (#653)", () => {
+    render(<EditNode {...workProps({ isolated: false })} />, { wrapper: Wrapper });
+    expect(screen.queryByTestId("isolation-marker")).toBeNull();
   });
 
   it("does not render the node id on the card", () => {
@@ -181,7 +187,7 @@ describe("EditNode emergent anchoring keyed on node type (issue #175)", () => {
     // edge could anchor by drop and they all snapped to the left. Anchoring is
     // keyed on node TYPE now, so the per-side anchors appear regardless.
     const { container } = render(
-      <EditNode {...nodeProps("code-mutating", [{ name: "in", side: "left" }])} />,
+      <EditNode {...nodeProps("agent", [{ name: "in", side: "left" }])} />,
       { wrapper: Wrapper },
     );
     const handleIds = Array.from(container.querySelectorAll(".react-flow__handle")).map((h) =>

--- a/frontend/src/components/EditCanvas.test.ts
+++ b/frontend/src/components/EditCanvas.test.ts
@@ -20,7 +20,7 @@ function makePipeline(): PipelineDef {
       {
         id: "impl",
         name: "implementer",
-        type: "code-mutating",
+        type: "agent",
         inputs: [{ name: "in", repeated: false, side: "left" }],
         outputs: [{ name: "out", repeated: false, side: "right" }],
         interactive: false,
@@ -29,7 +29,7 @@ function makePipeline(): PipelineDef {
       {
         id: "sw1",
         name: "gate",
-        type: "doc-only",
+        type: "agent",
         inputs: [{ name: "in", repeated: false, side: "left" }],
         outputs: [
           { name: "branch", repeated: false, side: "right" },
@@ -41,7 +41,7 @@ function makePipeline(): PipelineDef {
       {
         id: "fe1",
         name: "fixer",
-        type: "code-mutating",
+        type: "agent",
         inputs: [{ name: "in", repeated: false, side: "left" }],
         outputs: [{ name: "fix", repeated: false, side: "right" }],
         interactive: false,
@@ -162,8 +162,8 @@ describe("markerReached", () => {
   it("is false for non-marker node types even on a completed run", () => {
     const run = runWith("completed");
     const others: NodeType[] = [
-      "doc-only",
-      "code-mutating",
+      "agent",
+      "agent",
       "merge",
     ];
     for (const t of others) expect(markerReached(t, run)).toBe(false);
@@ -209,7 +209,7 @@ describe("deriveEditNodes — start/end green-on-complete flag (issue #105, inli
         {
           id: "work",
           name: "implementer",
-          type: "code-mutating",
+          type: "agent",
           inputs: [{ name: "in", repeated: false, side: "left" }],
           outputs: [{ name: "out", repeated: false, side: "right" }],
           interactive: false,
@@ -339,7 +339,7 @@ describe("deriveEditEdges — condition pills always visible at midpoint (issue 
         {
           id: "classifier",
           name: "classifier",
-          type: "doc-only",
+          type: "agent",
           inputs: [{ name: "task", repeated: false, side: "left" }],
           outputs: [{ name: "triage", repeated: false, side: "right" }],
           interactive: false,
@@ -348,7 +348,7 @@ describe("deriveEditEdges — condition pills always visible at midpoint (issue 
         {
           id: "hotfix",
           name: "hotfix",
-          type: "code-mutating",
+          type: "agent",
           inputs: [{ name: "triage", repeated: false, side: "left" }],
           outputs: [{ name: "patch", repeated: false, side: "right" }],
           interactive: false,
@@ -357,7 +357,7 @@ describe("deriveEditEdges — condition pills always visible at midpoint (issue 
         {
           id: "backlog",
           name: "backlog",
-          type: "doc-only",
+          type: "agent",
           inputs: [{ name: "triage", repeated: false, side: "left" }],
           outputs: [{ name: "note", repeated: false, side: "right" }],
           interactive: false,
@@ -406,7 +406,7 @@ describe("deriveEditEdges — condition pills always visible at midpoint (issue 
         {
           id: "a",
           name: "a",
-          type: "doc-only",
+          type: "agent",
           inputs: [],
           outputs: [{ name: "out", repeated: false, side: "right" }],
           interactive: false,
@@ -415,7 +415,7 @@ describe("deriveEditEdges — condition pills always visible at midpoint (issue 
         {
           id: "b",
           name: "b",
-          type: "doc-only",
+          type: "agent",
           inputs: [{ name: "in", repeated: false, side: "left" }],
           outputs: [],
           interactive: false,
@@ -445,7 +445,7 @@ describe("deriveEditEdges — incoming edge anchor side (issue #168)", () => {
         {
           id: "src",
           name: "src",
-          type: "doc-only",
+          type: "agent",
           inputs: [],
           outputs: [{ name: "out", repeated: false, side: "right" }],
           interactive: false,
@@ -455,7 +455,7 @@ describe("deriveEditEdges — incoming edge anchor side (issue #168)", () => {
           id: "dst",
           name: "dst",
           // Emergent: no declared inputs, so the arrow lands on the body (#149).
-          type: "code-mutating",
+          type: "agent",
           inputs: [],
           outputs: [{ name: "out", repeated: false, side: "right" }],
           interactive: false,
@@ -507,7 +507,7 @@ describe("deriveLoopRegions — bounded region rendering (ADR-0011 / #148)", () 
         {
           id: "impl",
           name: "implementer",
-          type: "code-mutating",
+          type: "agent",
           inputs: [],
           outputs: [{ name: "code", repeated: false, side: "right" }],
           interactive: false,
@@ -516,7 +516,7 @@ describe("deriveLoopRegions — bounded region rendering (ADR-0011 / #148)", () 
         {
           id: "rev",
           name: "reviewer",
-          type: "doc-only",
+          type: "agent",
           inputs: [],
           outputs: [{ name: "review", repeated: false, side: "right" }],
           interactive: false,
@@ -611,7 +611,7 @@ describe("buildLoopRegionNodes — box behind, chrome above (#167 / #455)", () =
         {
           id: "impl",
           name: "implementer",
-          type: "code-mutating",
+          type: "agent",
           inputs: [],
           outputs: [{ name: "code", repeated: false, side: "right" }],
           interactive: false,
@@ -620,7 +620,7 @@ describe("buildLoopRegionNodes — box behind, chrome above (#167 / #455)", () =
         {
           id: "rev",
           name: "reviewer",
-          type: "doc-only",
+          type: "agent",
           inputs: [],
           outputs: [{ name: "review", repeated: false, side: "right" }],
           interactive: false,

--- a/frontend/src/components/EditCanvas.tsx
+++ b/frontend/src/components/EditCanvas.tsx
@@ -27,7 +27,7 @@ import { generateNodeId } from "../lib/nanoid";
 import { collectionFanoutFields, collectionFanoutNudges, regionsDestroyedByEdgeRemoval } from "../lib/loopRegions";
 import DestroyLoopModal from "./DestroyLoopModal";
 import PortRow from "./PortRow";
-import { NodeTypeIcon, CodeDocMarker } from "./NodeTypeIcon";
+import { NodeTypeIcon, IsolationMarker } from "./NodeTypeIcon";
 import { NodeCard } from "./NodeCard";
 import { LoopRegionNode } from "./LoopRegionNode";
 import { NoteNode } from "./NoteNode";
@@ -109,7 +109,7 @@ export function EditNode({ data, id, selected }: NodeProps<Node<EditNodeData>>) 
   const inputImages =
     data.nodeType === "start" ? (data.inputImages ?? []) : [];
 
-  // Emergent work nodes (`doc-only`/`code-mutating`) anchor incoming edges by
+  // Emergent work nodes (non-isolated/isolated) anchor incoming edges by
   // drop position; declared-port nodes (End) keep their fixed side. Keyed on
   // node TYPE so a work node carrying a vestigial declared `in` still anchors by
   // drop (#175) rather than being mistaken for a fixed-side declared port.
@@ -188,7 +188,7 @@ export function EditNode({ data, id, selected }: NodeProps<Node<EditNodeData>>) 
           )}
         </span>
         <span className="font-medium text-fg">{data.label}</span>
-        <CodeDocMarker type={data.nodeType} />
+        <IsolationMarker isolated={data.isolated === true} />
         {data.loopBadge && (
           <span
             data-testid={data.loopBadge.kind === "collection" ? "collection-badge" : "loop-badge"}
@@ -249,7 +249,7 @@ const nodeTypes = { edit: EditNode, merge: MergeEditNode, loopRegion: LoopRegion
 const edgeTypes = { orthogonal: OrthogonalEdge };
 
 const DEFAULT_NODE_NAMES: Partial<Record<NodeType, string>> = {
-  "code-mutating": "implementer",
+  "agent": "implementer",
   "merge": "merge",
   "script": "script",
 };
@@ -715,8 +715,11 @@ function EditCanvasInner({ libraryEntries, onLibraryDelete, infoOpen, onToggleIn
       case "script":
         // #248: a script node's inputs are emergent (edge-derived), like a work
         // node — it declares none. One default output for its `output.md`.
+        // #653: a new Script shares the Run worktree — the inverse default of an
+        // Agent, so lightweight runtime and artifact work stays lightweight.
         newNode = {
           id, name, type, interactive: false, view,
+          isolated_worktree: false,
           inputs: [],
           outputs: [{ name: "out", repeated: false, side: "right" }],
         };
@@ -724,6 +727,9 @@ function EditCanvasInner({ libraryEntries, onLibraryDelete, infoOpen, onToggleIn
       default:
         newNode = {
           id, name, type, interactive: false, view,
+          // #653/ADR-0060: a new Agent is isolated. The safe placement is the
+          // default, and sharing the Run worktree is an explicit opt-out.
+          isolated_worktree: true,
           inputs: [{ name: "in", repeated: false, side: "left" }],
           outputs: [{ name: "out", repeated: false, side: "right" }],
         };

--- a/frontend/src/components/EditToolbar.test.tsx
+++ b/frontend/src/components/EditToolbar.test.tsx
@@ -61,12 +61,12 @@ describe("EditToolbar", () => {
     expect(onAddNote).not.toHaveBeenCalled();
   });
 
-  it("dropdown Node item calls onAddNode with code-mutating (#307)", async () => {
+  it("dropdown Node item calls onAddNode with agent (#307/#653)", async () => {
     const user = userEvent.setup();
     renderToolbar();
     await user.click(screen.getByTestId("toolbar-add"));
     await user.click(await screen.findByTestId("add-menu-node"));
-    expect(onAddNode).toHaveBeenCalledWith("code-mutating");
+    expect(onAddNode).toHaveBeenCalledWith("agent");
     expect(onAddNote).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/components/EditToolbar.tsx
+++ b/frontend/src/components/EditToolbar.tsx
@@ -97,7 +97,7 @@ export default function EditToolbar({ onAddNode, onAddNote, onAddNodeFromYaml, l
                 data-testid="add-menu-node"
                 className="flex cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-fg-2 transition-colors hover:bg-bg-4"
                 style={{ fontSize: "11.5px" }}
-                onClick={() => onAddNode("code-mutating")}
+                onClick={() => onAddNode("agent")}
               >
                 <Box size={13} className="shrink-0 text-fg-4" />
                 <span>Node</span>

--- a/frontend/src/components/ExportNodeYamlModal.test.tsx
+++ b/frontend/src/components/ExportNodeYamlModal.test.tsx
@@ -7,7 +7,7 @@ function node(overrides: Partial<NodeDef> = {}): NodeDef {
   return {
     id: "n1abc",
     name: "Writer",
-    type: "doc-only",
+    type: "agent",
     inputs: [],
     outputs: [{ name: "adr", repeated: false, side: "right" }],
     interactive: false,

--- a/frontend/src/components/LibraryDropdown.test.tsx
+++ b/frontend/src/components/LibraryDropdown.test.tsx
@@ -20,7 +20,7 @@ vi.mock("../api", () => ({
   instantiateFromLibrary: vi.fn().mockResolvedValue({
     spec: {
       name: "Test",
-      type: "doc-only",
+      type: "agent",
       inputs: [],
       outputs: [],
       interactive: false,
@@ -36,7 +36,7 @@ vi.mock("../lib/nanoid", () => ({
 function makeEntry(name: string, prompt = "Some prompt"): LibraryEntry {
   return {
     name,
-    type: "doc-only",
+    type: "agent",
     inputs: [{ name: "in", repeated: false }],
     outputs: [{ name: "out", repeated: false }],
     interactive: false,

--- a/frontend/src/components/LibraryDropdown.tsx
+++ b/frontend/src/components/LibraryDropdown.tsx
@@ -8,8 +8,9 @@ import type { NodeDef, NodeType } from "../types";
 import { Tooltip } from "./ui/tooltip";
 
 const TYPE_ICONS: Record<string, string> = {
-  "code-mutating": "CM",
-  "doc-only": "DO",
+  // #653: one agentic type, one badge. The pair of `CM`/`DO` letters was the
+  // library's echo of the retired type split.
+  "agent": "AG",
 };
 
 export default function LibraryDropdown({

--- a/frontend/src/components/LintBanner.test.tsx
+++ b/frontend/src/components/LintBanner.test.tsx
@@ -24,11 +24,11 @@ describe("LintBanner", () => {
   it("renders diagnostic messages", () => {
     render(
       <LintBanner
-        items={[lint("node 'reviewer' receives edges from 2 code-mutating nodes without a Merge")]}
+        items={[lint("node 'reviewer' receives edges from 2 isolated nodes without a Merge")]}
         onDismiss={noop}
       />,
     );
-    expect(screen.getByText(/code-mutating nodes without a Merge/)).toBeInTheDocument();
+    expect(screen.getByText(/isolated nodes without a Merge/)).toBeInTheDocument();
   });
 
   it("renders multiple diagnostics", () => {

--- a/frontend/src/components/LintBannerDuplication.test.tsx
+++ b/frontend/src/components/LintBannerDuplication.test.tsx
@@ -78,7 +78,7 @@ function seedNoSelectionWithDiagnostics() {
           ],
         },
         prompts: {},
-        diagnostics: ["node 'reviewer' receives edges from 2 code-mutating nodes without a Merge"],
+        diagnostics: ["node 'reviewer' receives edges from 2 isolated nodes without a Merge"],
         dirty: false,
         externalDirty: false,
         libraryId: null,

--- a/frontend/src/components/LoopRegionNode.test.tsx
+++ b/frontend/src/components/LoopRegionNode.test.tsx
@@ -23,7 +23,7 @@ function makeNode(id: string): NodeDef {
   return {
     id,
     name: id,
-    type: "code-mutating",
+    type: "agent",
     inputs: [],
     outputs: [{ name: "out", repeated: false, side: "right" }],
     interactive: false,

--- a/frontend/src/components/MergeNode.tsx
+++ b/frontend/src/components/MergeNode.tsx
@@ -4,7 +4,7 @@ import { useEditStore } from "../stores/editStore";
 import { STATUS_DOT } from "../nodeStyles";
 import { NodeCard } from "./NodeCard";
 import PortRow from "./PortRow";
-import { NodeTypeIcon } from "./NodeTypeIcon";
+import { NodeTypeIcon, IsolationMarker } from "./NodeTypeIcon";
 import { useIsDropTarget } from "./DragHighlightContext";
 
 interface MergeEditData {
@@ -38,6 +38,10 @@ export function MergeEditNode({ data, id, selected }: NodeProps<Node<MergeEditDa
       <div className="flex items-center gap-2">
         <NodeTypeIcon type="merge" size={14} className="shrink-0 text-acc" />
         <span className="font-medium text-fg">{data.label}</span>
+        {/* #653: a Merge is isolated by construction and carries the marker
+            anyway — unmarked, it would read as LESS isolated than the Agent
+            feeding it. Coherence of reading before economy of pixels. */}
+        <IsolationMarker isolated />
       </div>
       <div className="mt-0.5 font-mono text-fg-4" style={{ fontSize: "9px" }}>
         {data.nodeId}

--- a/frontend/src/components/NodeInspector.test.tsx
+++ b/frontend/src/components/NodeInspector.test.tsx
@@ -67,7 +67,7 @@ vi.mock("../api", () => ({
   instantiateFromLibrary: vi.fn().mockResolvedValue({
     spec: {
       name: "reviewer",
-      type: "doc-only",
+      type: "agent",
       inputs: [],
       outputs: [],
       interactive: false,
@@ -93,7 +93,7 @@ function seedTabWithReviewer(dirty: boolean, prompt = "Review this code.") {
             {
               id: "rv1",
               name: "reviewer",
-              type: "doc-only",
+              type: "agent",
               interactive: false,
               inputs: [{ name: "in", repeated: false, side: "left" }],
               outputs: [{ name: "out", repeated: false, side: "right" }],
@@ -127,7 +127,7 @@ function seedPooledReviewPipeline() {
             {
               id: "sec",
               name: "security-reviewer",
-              type: "doc-only",
+              type: "agent",
               interactive: false,
               inputs: [],
               outputs: [{ name: "review", repeated: false, side: "right" }],
@@ -136,7 +136,7 @@ function seedPooledReviewPipeline() {
             {
               id: "perf",
               name: "perf-reviewer",
-              type: "doc-only",
+              type: "agent",
               interactive: false,
               inputs: [],
               outputs: [{ name: "review", repeated: false, side: "right" }],
@@ -145,7 +145,7 @@ function seedPooledReviewPipeline() {
             {
               id: "impl",
               name: "implementer",
-              type: "code-mutating",
+              type: "agent",
               interactive: false,
               inputs: [],
               outputs: [
@@ -228,7 +228,7 @@ describe("NodeInspector — script node surface (#248)", () => {
     expect(screen.queryByTestId("node-effort-option-low")).toBeNull();
   });
 
-  it("shows a static script type label, not the doc-only/code-mutating toggle", () => {
+  it("shows a static script type label (#248/#653: types are not toggles)", () => {
     seedTabWithScript();
     renderInspector({ libraryEntries: [], onLibraryChanged: () => {} });
     expect(screen.getByTestId("script-type-label")).toBeInTheDocument();
@@ -385,7 +385,7 @@ function seedSelfFeedPipeline() {
             {
               id: "cc1",
               name: "cycler",
-              type: "doc-only",
+              type: "agent",
               interactive: false,
               inputs: [],
               outputs: [{ name: "in", repeated: false, side: "right" }],
@@ -490,7 +490,7 @@ describe("NodeInspector StarButton — library save is independent of pipeline s
     expect(mockSave).toHaveBeenCalledTimes(1);
     expect(mockSave).toHaveBeenCalledWith({
       name: "reviewer",
-      type: "doc-only",
+      type: "agent",
       inputs: [{ name: "in", repeated: false, side: "left" }],
       outputs: [{ name: "out", repeated: false, side: "right" }],
       interactive: false,
@@ -540,7 +540,7 @@ describe("NodeInspector StarButton — library save is independent of pipeline s
   it("opens the popover when node is already synced with library", () => {
     const synced: LibraryEntry = {
       name: "reviewer",
-      type: "doc-only",
+      type: "agent",
       inputs: [{ name: "in", repeated: false, side: "left" }],
       outputs: [{ name: "out", repeated: false, side: "right" }],
       interactive: false,
@@ -574,7 +574,7 @@ function seedNode(node: Record<string, unknown>) {
             {
               id: "n1",
               name: "worker",
-              type: "doc-only",
+              type: "agent",
               interactive: false,
               inputs: [{ name: "in", repeated: false, side: "left" }],
               outputs: [{ name: "out", repeated: false, side: "right" }],
@@ -657,7 +657,7 @@ describe("NodeInspector — harness axis (#550, ADR-0046)", () => {
 describe("NodeInspector — the model field does not follow the selection (#617)", () => {
   function seedTwoNodes() {
     const base = {
-      type: "doc-only" as const,
+      type: "agent" as const,
       interactive: false,
       inputs: [],
       outputs: [{ name: "out", repeated: false, side: "right" as const }],
@@ -728,5 +728,77 @@ describe("NodeInspector — the model field does not follow the selection (#617)
     expect(cop.model ?? null).toBeNull();
     // …and the tab is not dirtied by a field the user only looked at.
     expect(useEditStore.getState().openTabs[0].dirty).toBe(false);
+  });
+});
+
+/**
+ * #653 / ADR-0060 — the Workspace section. Two named places, the resolved path
+ * underneath, and nothing at all on the types that carry no isolation.
+ */
+describe("NodeInspector — Workspace (#653)", () => {
+  it("shows a static agent type label instead of a type toggle", () => {
+    seedTabWithReviewer(false);
+    renderInspector({ libraryEntries: [], onLibraryChanged: () => {} });
+    expect(screen.getByTestId("agent-type-label")).toBeInTheDocument();
+  });
+
+  it("preselects Isolated worktree for an agent that states nothing", () => {
+    seedTabWithReviewer(false);
+    renderInspector({ libraryEntries: [], onLibraryChanged: () => {} });
+    expect(screen.getByTestId("workspace-isolated")).toHaveAttribute("aria-checked", "true");
+    expect(screen.getByTestId("workspace-shared")).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("preselects Run worktree for a script that states nothing", () => {
+    seedTabWithScript();
+    renderInspector({ libraryEntries: [], onLibraryChanged: () => {} });
+    expect(screen.getByTestId("workspace-shared")).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("writes the chosen value onto the node without touching its type", () => {
+    seedTabWithReviewer(false);
+    renderInspector({ libraryEntries: [], onLibraryChanged: () => {} });
+
+    fireEvent.click(screen.getByTestId("workspace-shared"));
+    const node = useEditStore.getState().openTabs[0].pipeline.nodes[0];
+    expect(node.isolated_worktree).toBe(false);
+    expect(node.type).toBe("agent");
+  });
+
+  it("shows the resolved working directory and updates it on click", () => {
+    seedTabWithReviewer(false);
+    renderInspector({ libraryEntries: [], onLibraryChanged: () => {} });
+
+    expect(screen.getByTestId("workspace-path")).toHaveTextContent(
+      ".pdo/runs/<run>/nodes/rv1/iter-<n>",
+    );
+    fireEvent.click(screen.getByTestId("workspace-shared"));
+    expect(screen.getByTestId("workspace-path")).toHaveTextContent(
+      ".pdo/runs/<run>/worktree",
+    );
+  });
+
+  it("shows the FROZEN value, read-only, once the NodeRun has started", () => {
+    // The document says isolated; the live iteration was spawned shared. Run mode
+    // shows where the Node actually works and refuses to move it.
+    seedTabWithReviewer(false);
+    renderInspector({
+      libraryEntries: [],
+      onLibraryChanged: () => {},
+      runNode: {
+        node_id: "rv1",
+        status: "running",
+        iter: 1,
+        started_at: null,
+        completed_at: null,
+        failure_reason: null,
+        iterations: [],
+        isolated_worktree: false,
+      },
+    });
+
+    expect(screen.getByTestId("workspace-shared")).toHaveAttribute("aria-checked", "true");
+    expect(screen.getByTestId("workspace-isolated")).toBeDisabled();
+    expect(screen.getByTestId("workspace-frozen")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/NodeInspector.tsx
+++ b/frontend/src/components/NodeInspector.tsx
@@ -1,9 +1,10 @@
 import { useState, useRef, useEffect } from "react";
 import { Star } from "lucide-react";
 import { useEditStore } from "../stores/editStore";
-import type { NodeDef, NodeType, PortDef } from "../types";
+import type { NodeDef, NodeState, NodeType, PortDef } from "../types";
 import { SectionHead, Field } from "./InspectorPrimitives";
 import OutputPortCard from "./OutputPortCard";
+import { NodeTypeIcon } from "./NodeTypeIcon";
 import PooledInputRow from "./PooledInputRow";
 import { useHarnessCatalog } from "../hooks/useHarnessCatalog";
 import { useAgentProfiles } from "../hooks/useAgentProfiles";
@@ -12,6 +13,7 @@ import HarnessSelect from "./HarnessSelect";
 import ModelPicker from "./ModelPicker";
 import EffortPicker from "./EffortPicker";
 import { findHarnessOption, resolveEditorHarness } from "../lib/harness";
+import { carriesIsolation, nodeIsolation, worktreePathFor } from "../lib/nodeIsolation";
 import DestroyLoopModal from "./DestroyLoopModal";
 import { derivePooledInputs } from "../lib/derivePooledInputs";
 import { regionsDestroyedByEdgeRemoval } from "../lib/loopRegions";
@@ -21,18 +23,36 @@ import { saveToLibrary, deleteFromLibrary, instantiateFromLibrary, libraryPortTo
 import { useLibraryState } from "../hooks/useLibrary";
 import type { LibrarySyncState } from "../hooks/useLibrary";
 
-const TYPE_TOOLTIPS: Record<string, string> = {
-  "code-mutating": "Receives a forked sub-worktree. Can edit, commit, and merge code.",
-  "doc-only": "Reads code in read-only. Only writes Markdown artifacts to the Blackboard.",
-};
+
+/**
+ * #653 / ADR-0060: the two places a NodeRun can work, named and described in one
+ * breath. A radio pair rather than a switch — "off" would name neither place.
+ */
+const WORKSPACE_CHOICES = [
+  {
+    isolated: true,
+    label: "Isolated worktree",
+    hint: "a sub-worktree of the Node's own",
+  },
+  {
+    isolated: false,
+    label: "Run worktree",
+    hint: "shared with the whole Run",
+  },
+] as const;
 
 export default function NodeInspector({
   libraryEntries,
   onLibraryChanged,
   readOnly,
+  runNode,
 }: {
   libraryEntries: LibraryEntry[];
   onLibraryChanged: () => void;
+  /** #653: the live NodeRun's projected state, on a run canvas. Its frozen
+   *  `isolated_worktree` is what the Workspace section reads in run mode —
+   *  where the iteration ACTUALLY works, which an edit no longer moves. */
+  runNode?: NodeState | null;
   /** #339: hides the per-source input × — set for archived runs only
    * (mirrors the canvas readOnly, #315/ADR-0020). Scoped to the × alone;
    * the rest of the inspector's archived story is the #315 gap. */
@@ -89,10 +109,17 @@ export default function NodeInspector({
   // not declared on the node. Same-named edges pool into one list input.
   const pooledInputs = derivePooledInputs(tab.pipeline, node.id);
 
-  // #248: a `script` node runs deterministic bash, not an agent — so its type is
-  // fixed (no doc-only↔code-mutating toggle), it has no model, and its "prompt"
-  // is a bash body whose I/O arrives as PDO_* env vars, not a prose preamble.
+  // #248: a `script` node runs deterministic bash, not an agent — so it has no
+  // model, and its "prompt" is a bash body whose I/O arrives as PDO_* env vars,
+  // not a prose preamble.
   const isScript = node.type === "script";
+  // #653/ADR-0060: the frozen isolation of the live NodeRun, when there is one.
+  // In run mode the Workspace choice becomes a *state*: a Node that changed
+  // working directory under its own feet would be silent corruption, so the
+  // section shows where the iteration actually works and stops being editable.
+  const frozenIsolation = runNode?.isolated_worktree;
+  const isolation = frozenIsolation ?? nodeIsolation(node);
+  const isolationFrozen = frozenIsolation != null;
 
   // #339: delete one contributing edge of a pooled input — the canonical
   // "delete an input" since inputs are emergent (#149/ADR-0011). Last-cycle
@@ -171,39 +198,77 @@ export default function NodeInspector({
           />
         </Field>
 
-        {/* Type */}
+        {/* Type — #653/ADR-0060: there is one agentic type, so this is a static
+            label like `script` already was. The pair of buttons it replaces
+            offered non-isolated/isolated, i.e. a working-directory choice
+            wearing a type's clothes; that choice now lives in Workspace below. */}
         <SectionHead title="Type" />
-        {isScript ? (
-          // #248: a script node's type is fixed. Show a static label rather than
-          // the doc-only↔code-mutating toggle (which can't even express "script"
-          // and would silently retype the node away on click).
-          <div
-            data-testid="script-type-label"
-            className="rounded border border-fg-4 bg-bg-3 px-2 py-1 font-medium text-fg"
-            style={{ fontSize: "10px" }}
-          >
-            script (deterministic bash)
-          </div>
-        ) : (
-          <div className="flex gap-1">
-            {(["code-mutating", "doc-only"] as NodeType[]).map((t) => (
-              <Tooltip key={t} content={TYPE_TOOLTIPS[t] ?? t}>
+        <div
+          data-testid={isScript ? "script-type-label" : "agent-type-label"}
+          className="flex items-center gap-2 rounded border border-fg-4 bg-bg-3 px-2 py-1 font-medium text-fg"
+          style={{ fontSize: "10px" }}
+        >
+          <NodeTypeIcon type={node.type} size={11} className="shrink-0 text-fg-3" />
+          <span>{isScript ? "script (deterministic bash)" : node.type}</span>
+        </div>
+
+        {/* Workspace — #653/ADR-0060: where this Node's NodeRun works. A pair of
+            named places, not a switch: the working directory is a choice between
+            two locations, not a feature you turn on. The resolved path underneath
+            is the point — the author reads where the Node will write instead of
+            deducing it. Absent on `merge` (isolated by construction) and on
+            Start/End, because a greyed control invites you to look for the way to
+            un-grey it. */}
+        {carriesIsolation(node.type) && isolation !== null && (
+          <>
+            <SectionHead title="Workspace" />
+            <div data-testid="workspace-choice" className="flex flex-col gap-1">
+              {WORKSPACE_CHOICES.map((choice) => (
                 <button
-                  onClick={() => handleField("type", t)}
-                  className={`flex-1 cursor-pointer rounded border px-2 py-1 font-medium transition-colors ${
-                    node.type === t
-                      ? t === "code-mutating"
-                        ? "border-acc bg-acc-bg text-acc"
-                        : "border-fg-4 bg-bg-3 text-fg"
-                      : "border-line-strong bg-bg-3 text-fg-4 hover:text-fg-3"
-                  }`}
-                  style={{ fontSize: "10px" }}
+                  key={String(choice.isolated)}
+                  data-testid={`workspace-${choice.isolated ? "isolated" : "shared"}`}
+                  aria-checked={isolation === choice.isolated}
+                  role="radio"
+                  disabled={isolationFrozen}
+                  onClick={() => handleField("isolated_worktree", choice.isolated)}
+                  className={`flex items-start gap-2 rounded border px-2 py-1.5 text-left transition-colors ${
+                    isolation === choice.isolated
+                      ? "border-acc bg-acc-bg"
+                      : "border-line-strong bg-bg-3 hover:border-fg-4"
+                  } ${isolationFrozen ? "cursor-default opacity-70" : "cursor-pointer"}`}
                 >
-                  {t}
+                  <span
+                    className={`mt-[3px] h-2.5 w-2.5 shrink-0 rounded-full border ${
+                      isolation === choice.isolated ? "border-acc bg-acc" : "border-fg-4"
+                    }`}
+                  />
+                  <span className="flex flex-col">
+                    <span
+                      className={`font-medium ${isolation === choice.isolated ? "text-acc" : "text-fg-2"}`}
+                      style={{ fontSize: "10.5px" }}
+                    >
+                      {choice.label}
+                    </span>
+                    <span className="text-fg-4" style={{ fontSize: "9.5px" }}>
+                      {choice.hint}
+                    </span>
+                  </span>
                 </button>
-              </Tooltip>
-            ))}
-          </div>
+              ))}
+            </div>
+            <span
+              data-testid="workspace-path"
+              className="break-all rounded border border-line bg-bg-3 px-2 py-1 font-mono text-fg-4"
+              style={{ fontSize: "9.5px" }}
+            >
+              {worktreePathFor(node.id, isolation)}
+            </span>
+            {isolationFrozen && (
+              <span data-testid="workspace-frozen" className="text-fg-4" style={{ fontSize: "9.5px" }}>
+                Frozen at spawn — an edit applies to the next NodeRun.
+              </span>
+            )}
+          </>
         )}
 
         {/* Behavior */}
@@ -328,7 +393,7 @@ export default function NodeInspector({
               onRemove={() => handleRemoveOutput(i)}
               schema={port.frontmatter}
               onSchemaChange={(fm) => handleUpdateOutput(i, { frontmatter: fm ?? null })}
-              allowInstructions={node.type === "doc-only" || node.type === "code-mutating"}
+              allowInstructions={node.type === "agent"}
             />
           ))}
         </div>

--- a/frontend/src/components/NodeTypeIcon.tsx
+++ b/frontend/src/components/NodeTypeIcon.tsx
@@ -1,4 +1,4 @@
-import { User, GitMerge, Play, Square, Code, FileText, SquareTerminal } from "lucide-react";
+import { User, GitMerge, Play, Square, GitBranch, SquareTerminal } from "lucide-react";
 import type { NodeType } from "../types";
 
 interface IconProps {
@@ -23,20 +23,24 @@ export function NodeTypeIcon({ type, size = 14, className }: IconProps) {
   }
 }
 
-export function CodeDocMarker({ type }: { type: NodeType }) {
-  if (type === "code-mutating") {
-    return (
-      <span data-testid="code-doc-marker" data-marker-type="code-mutating" className="ml-auto flex shrink-0 items-center">
-        <Code size={11} className="text-acc" />
-      </span>
-    );
-  }
-  if (type === "doc-only") {
-    return (
-      <span data-testid="code-doc-marker" data-marker-type="doc-only" className="ml-auto flex shrink-0 items-center">
-        <FileText size={11} className="text-fg-4" />
-      </span>
-    );
-  }
-  return null;
+/**
+ * #653 / ADR-0060: the canvas answers "does this Node fork its own worktree?"
+ * without opening the inspector. One glyph, present or absent — it replaced the
+ * pair of non-isolated / isolated markers, which read as two pseudo-types.
+ *
+ * A branch glyph, not a dotted card border: the border competed with the
+ * selection ring and the status borders, and a marker mistaken for a selection
+ * state costs more than it says.
+ */
+export function IsolationMarker({ isolated }: { isolated: boolean }) {
+  if (!isolated) return null;
+  return (
+    <span
+      data-testid="isolation-marker"
+      title="Isolated worktree — this Node forks a sub-worktree of its own"
+      className="ml-auto flex shrink-0 items-center"
+    >
+      <GitBranch size={11} className="text-acc" />
+    </span>
+  );
 }

--- a/frontend/src/components/PipelineInspector.test.tsx
+++ b/frontend/src/components/PipelineInspector.test.tsx
@@ -154,7 +154,7 @@ describe("PipelineInspector", () => {
     useEditStore.setState((s) => ({
       openTabs: s.openTabs.map((t) =>
         t.id === "p1"
-          ? { ...t, diagnostics: ["node 'reviewer' receives edges from 2 code-mutating nodes without a Merge"] }
+          ? { ...t, diagnostics: ["node 'reviewer' receives edges from 2 isolated nodes without a Merge"] }
           : t,
       ),
     }));

--- a/frontend/src/components/RegionInspector.test.tsx
+++ b/frontend/src/components/RegionInspector.test.tsx
@@ -8,7 +8,7 @@ function makeNode(id: string, name: string): NodeDef {
   return {
     id,
     name,
-    type: "code-mutating",
+    type: "agent",
     inputs: [],
     outputs: [{ name: "out", repeated: false, side: "right" }],
     interactive: false,

--- a/frontend/src/components/SidePicker.test.tsx
+++ b/frontend/src/components/SidePicker.test.tsx
@@ -53,7 +53,7 @@ describe("SidePicker retrofit in NodeInspector PortRow", () => {
     return {
       id: "n1",
       name: "test-node",
-      type: "doc-only",
+      type: "agent",
       inputs: [{ name: "in", repeated: false, side: "left" }],
       outputs: [{ name: "out", repeated: false, side: "right" }],
       interactive: false,

--- a/frontend/src/components/editNodeDerivation.test.ts
+++ b/frontend/src/components/editNodeDerivation.test.ts
@@ -52,7 +52,7 @@ describe("deriveEditEdges targetHandle anchoring (#149)", () => {
     // handle (legacy anchoring) — a real rendered handle, so xyflow keeps the
     // edge (no error 008).
     const p = pipeline(
-      [node("src", "doc-only", [], ["plan"]), node("dst", "code-mutating", [], ["code"])],
+      [node("src", "agent", [], ["plan"]), node("dst", "agent", [], ["code"])],
       [{ source: { node: "src", port: "plan" }, target: { node: "dst", port: "plan" } }],
     );
     const edges = deriveEditEdges(p);
@@ -62,7 +62,7 @@ describe("deriveEditEdges targetHandle anchoring (#149)", () => {
 
   it("keeps the declared port for the End node (it retains a `result` input handle)", () => {
     const p = pipeline(
-      [node("src", "doc-only", [], ["plan"]), node("end", "end", ["result"], [])],
+      [node("src", "agent", [], ["plan"]), node("end", "end", ["result"], [])],
       [{ source: { node: "src", port: "plan" }, target: { node: "end", port: "result" } }],
     );
     const edges = deriveEditEdges(p);
@@ -71,7 +71,7 @@ describe("deriveEditEdges targetHandle anchoring (#149)", () => {
 
   it("keeps the declared port for structural nodes (merge)", () => {
     const p = pipeline(
-      [node("src", "doc-only", [], ["plan"]), node("m", "merge", ["branches"], ["merged"])],
+      [node("src", "agent", [], ["plan"]), node("m", "merge", ["branches"], ["merged"])],
       [{ source: { node: "src", port: "plan" }, target: { node: "m", port: "branches" } }],
     );
     const edges = deriveEditEdges(p);
@@ -81,9 +81,9 @@ describe("deriveEditEdges targetHandle anchoring (#149)", () => {
   it("binds both same-named edges to a side body handle when they pool into one body input (default left)", () => {
     const p = pipeline(
       [
-        node("a", "doc-only", [], ["plan"]),
-        node("b", "doc-only", [], ["plan"]),
-        node("dst", "code-mutating", [], ["code"]),
+        node("a", "agent", [], ["plan"]),
+        node("b", "agent", [], ["plan"]),
+        node("dst", "agent", [], ["code"]),
       ],
       [
         { source: { node: "a", port: "plan" }, target: { node: "dst", port: "plan" } },
@@ -100,9 +100,9 @@ describe("deriveEditEdges targetHandle anchoring (#149)", () => {
     // sides; each keeps its own anchor.
     const p = pipeline(
       [
-        node("a", "doc-only", [], ["plan"]),
-        node("b", "doc-only", [], ["plan"]),
-        node("dst", "code-mutating", [], ["code"]),
+        node("a", "agent", [], ["plan"]),
+        node("b", "agent", [], ["plan"]),
+        node("dst", "agent", [], ["code"]),
       ],
       [
         { source: { node: "a", port: "plan" }, target: { node: "dst", port: "plan" }, target_side: "top" },
@@ -142,12 +142,12 @@ describe("deriveEditEdges — work node with a vestigial declared `in` still anc
         {
           id: "src",
           name: "src",
-          type: "doc-only",
+          type: "agent",
           inputs: [],
           outputs: [{ name: "plan", repeated: false, side: "right" as const }],
           interactive: false,
         },
-        workNode("dst", "code-mutating", ["code"]),
+        workNode("dst", "agent", ["code"]),
       ],
       edges: [
         {
@@ -198,7 +198,7 @@ describe("deriveLoopRegions — collection regions (#151)", () => {
     // renders as a compact badge on the member card with the fan-out glyph `⇉`,
     // NOT a box and NOT the `↻` loop glyph.
     const p = pipelineWith(
-      [node("fixer", "code-mutating", ["fix"])],
+      [node("fixer", "agent", ["fix"])],
       [{ id: "per-issue", kind: "collection", over: "issues", members: ["fixer"] }],
     );
     const regions = deriveLoopRegions(p, null);
@@ -217,7 +217,7 @@ describe("deriveLoopRegions — collection regions (#151)", () => {
 
   it("renders a multi-member collection as a box", () => {
     const p = pipelineWith(
-      [node("fix-a", "code-mutating", ["a"]), node("fix-b", "code-mutating", ["b"])],
+      [node("fix-a", "agent", ["a"]), node("fix-b", "agent", ["b"])],
       [{ id: "per-issue", kind: "collection", over: "issues", members: ["fix-a", "fix-b"] }],
     );
     const regions = deriveLoopRegions(p, null);
@@ -231,7 +231,7 @@ describe("deriveLoopRegions — collection regions (#151)", () => {
     // `⇉ ...` text, kind `collection`) so the canvas can render the compact badge
     // on the card rather than a box.
     const p = pipelineWith(
-      [node("fixer", "code-mutating", ["fix"])],
+      [node("fixer", "agent", ["fix"])],
       [{ id: "per-issue", kind: "collection", over: "issues", members: ["fixer"] }],
     );
     const cards = deriveEditNodes(p, null);
@@ -248,7 +248,7 @@ describe("deriveLoopRegions — collection regions (#151)", () => {
     // compact `↻ <counter>` badge — otherwise the loop is invisible on the
     // canvas. The glyph is the loop glyph, not the collection `⇉`.
     const p = pipelineWith(
-      [node("worker", "code-mutating", ["out"])],
+      [node("worker", "agent", ["out"])],
       [{ id: "spin", kind: "bounded", members: ["worker"], max_iter: 4 }],
     );
     const cards = deriveEditNodes(p, null);
@@ -302,7 +302,7 @@ describe("deriveLoopRegions — collection regions (#151)", () => {
 
   const collectionPipeline = () =>
     pipelineWith(
-      [node("fixer", "code-mutating", ["fix"])],
+      [node("fixer", "agent", ["fix"])],
       [{ id: "per-issue", kind: "collection", over: "issues", members: ["fixer"] }],
     );
 
@@ -333,7 +333,7 @@ describe("deriveLoopRegions — collection regions (#151)", () => {
 
   it("does not attach a loop badge to a node that is no member", () => {
     const p = pipelineWith(
-      [node("fixer", "code-mutating", ["fix"]), node("other", "doc-only", ["x"])],
+      [node("fixer", "agent", ["fix"]), node("other", "agent", ["x"])],
       [{ id: "per-issue", kind: "collection", over: "issues", members: ["fixer"] }],
     );
     const cards = deriveEditNodes(p, null);

--- a/frontend/src/components/editNodeDerivation.ts
+++ b/frontend/src/components/editNodeDerivation.ts
@@ -3,6 +3,7 @@ import { MarkerType } from "@xyflow/react";
 import type { EdgeWaypoint, LoopRegion, NodeStatus, NodeType, PipelineDef, PortSide, RunState, RunStatus } from "../types";
 import type { OrthogonalEdgeData } from "./OrthogonalEdge";
 import { anchorHandleId, isEmergentInputNode } from "../lib/anchorSide";
+import { isNodeIsolated } from "../lib/nodeIsolation";
 
 /**
  * A run "reaches its end" when it terminates successfully (`completed`). At
@@ -88,6 +89,12 @@ export function deriveEditNodes(
         label: n.name ?? n.id,
         nodeId: n.id,
         nodeType: n.type,
+        // #653/ADR-0060: the canvas marker's input. On a live Run the FROZEN
+        // answer wins — the marker has to say where the NodeRun works, and an
+        // edit that has not launched yet moved the document, not the session.
+        // `merge` renders through its own component, so this only ever answers
+        // for agent/script/structural.
+        isolated: runState?.nodes?.[n.id]?.isolated_worktree ?? isNodeIsolated(n),
         status,
         reached: markerReached(n.type, runState),
         // Input images uploaded with the run surface on the start marker only
@@ -427,7 +434,7 @@ export function edgeIndexFromId(edgeId: string): number | null {
  *   via `PortPill`, so the edge keeps its declared port name.
  * - Declared-port `edit` nodes (the End node's `result`) keep that declared,
  *   side-fixed handle — those ports are unaffected by anchoring (#168).
- * - Emergent work nodes (`doc-only` / `code-mutating`, ADR-0011 / #149) render
+ * - Emergent work nodes (`agent`, ADR-0011 / #149) render
  *   one body-covering target handle PER SIDE. The edge binds to the handle for
  *   its chosen `target_side` (#168) so the arrow anchors and routes from that
  *   side; absent a `target_side`, it binds to the left handle, reproducing the

--- a/frontend/src/components/ui/tooltip.test.tsx
+++ b/frontend/src/components/ui/tooltip.test.tsx
@@ -73,11 +73,11 @@ describe("Tooltip accessible name (#397)", () => {
 
   it("leaves a text button's visible label as its name (WCAG 2.5.3)", () => {
     renderWithProvider(
-      <Tooltip content="A node that edits source code in its own worktree.">
-        <button data-testid="t">code-mutating</button>
+      <Tooltip content="A Node that forks a sub-worktree of its own.">
+        <button data-testid="t">Isolated worktree</button>
       </Tooltip>,
     );
-    expect(screen.getByTestId("t")).toHaveAccessibleName("code-mutating");
+    expect(screen.getByTestId("t")).toHaveAccessibleName("Isolated worktree");
     expect(screen.getByTestId("t")).not.toHaveAttribute("aria-label");
   });
 

--- a/frontend/src/components/ui/tooltip.tsx
+++ b/frontend/src/components/ui/tooltip.tsx
@@ -18,9 +18,9 @@ export function TooltipProvider({ children }: { children: ReactNode }) {
 // now supplied here so the next icon button is born named.
 //
 // The rule is deliberately narrow — the tooltip text is borrowed as a name only
-// when the trigger cannot name itself. A text button (NodeInspector's
-// `code-mutating` / `doc-only` pills) keeps its visible label: replacing it with
-// a long tooltip sentence would break "label in name" (WCAG 2.5.3).
+// when the trigger cannot name itself. A text button (NodeInspector's Workspace
+// choices) keeps its visible label: replacing it with a long tooltip sentence
+// would break "label in name" (WCAG 2.5.3).
 const INTERACTIVE_TAGS = new Set(["button", "a"]);
 
 /** Text this element renders itself. Host elements are transparent (recurse); a

--- a/frontend/src/hooks/useLibrary.test.ts
+++ b/frontend/src/hooks/useLibrary.test.ts
@@ -7,7 +7,7 @@ function makeNode(overrides: Partial<NodeDef> = {}): NodeDef {
   return {
     id: "n1",
     name: "Reviewer",
-    type: "doc-only",
+    type: "agent",
     inputs: [{ name: "code", repeated: false, side: "left" }],
     outputs: [{ name: "review", repeated: false, side: "right" }],
     interactive: false,
@@ -19,7 +19,7 @@ function makeNode(overrides: Partial<NodeDef> = {}): NodeDef {
 function makeEntry(overrides: Partial<LibraryEntry> = {}): LibraryEntry {
   return {
     name: "Reviewer",
-    type: "doc-only",
+    type: "agent",
     inputs: [{ name: "code", repeated: false, side: "left" }],
     outputs: [{ name: "review", repeated: false, side: "right" }],
     interactive: false,
@@ -53,7 +53,7 @@ describe("computeSyncState", () => {
   });
 
   it("returns diverged when type differs", () => {
-    const node = makeNode({ type: "code-mutating" });
+    const node = makeNode({ type: "script" });
     const entries = [makeEntry()];
     expect(computeSyncState(node, "You review code.", entries)).toBe("diverged");
   });

--- a/frontend/src/hooks/useLibraryPipelines.test.ts
+++ b/frontend/src/hooks/useLibraryPipelines.test.ts
@@ -11,7 +11,7 @@ function node(id: string, over: Partial<NodeDef> = {}): NodeDef {
   return {
     id,
     name: id,
-    type: "doc-only",
+    type: "agent",
     interactive: false,
     inputs: [],
     outputs: [],
@@ -324,7 +324,7 @@ describe("computePipelineSyncState", () => {
   it("ignores the entry's raw yaml formatting entirely", () => {
     const canvas = def();
     const library = entry(def(), {
-      yaml: '{ "name": "My Pipeline", "nodes": [ { "id": "a", "name": "a", "type": "doc-only" } ] }\n',
+      yaml: '{ "name": "My Pipeline", "nodes": [ { "id": "a", "name": "a", "type": "agent" } ] }\n',
     });
     const result = computePipelineSyncState(canvas, [library]);
     expect(result.state).toBe("synced");

--- a/frontend/src/hooks/useRightPaneRouter.test.ts
+++ b/frontend/src/hooks/useRightPaneRouter.test.ts
@@ -269,7 +269,7 @@ describe("useRightPaneRouter — runNode synthesis (#204)", () => {
           selectedRun: makeRun({
             status: "running",
             nodes: {},
-            node_defs: [{ id: "n2", node_type: "code-mutating" }] as never,
+            node_defs: [{ id: "n2", node_type: "agent" }] as never,
           }),
         }),
       ),
@@ -288,7 +288,7 @@ describe("useRightPaneRouter — runNode synthesis (#204)", () => {
           selectedRun: makeRun({
             status: "completed",
             nodes: {},
-            node_defs: [{ id: "n2", node_type: "code-mutating" }] as never,
+            node_defs: [{ id: "n2", node_type: "agent" }] as never,
           }),
         }),
       ),

--- a/frontend/src/lib/anchorSide.test.ts
+++ b/frontend/src/lib/anchorSide.test.ts
@@ -92,8 +92,8 @@ describe("anchorHandleId / sideFromAnchorHandle round-trip", () => {
 
 describe("isEmergentInputNode", () => {
   it("treats work nodes and script as emergent-input (#149 / #248)", () => {
-    expect(isEmergentInputNode("doc-only")).toBe(true);
-    expect(isEmergentInputNode("code-mutating")).toBe(true);
+    expect(isEmergentInputNode("agent")).toBe(true);
+    expect(isEmergentInputNode("agent")).toBe(true);
     expect(isEmergentInputNode("script")).toBe(true);
   });
 

--- a/frontend/src/lib/anchorSide.ts
+++ b/frontend/src/lib/anchorSide.ts
@@ -16,7 +16,7 @@ export const ANCHOR_SIDES: readonly PortSide[] = ["left", "right", "top", "botto
  * land anywhere on the node body and anchor on the side nearest the drop point,
  * rather than binding to a declared, fixed-side input handle.
  *
- * The work-node types (`doc-only`, `code-mutating`) are emergent. This is keyed
+ * The work-node type (`agent`) is emergent. This is keyed
  * on the node TYPE, not the declared input count: the #149 migration that drops
  * declared inputs was never carried through to node creation or the on-disk
  * pipeline YAMLs, so a work node frequently still carries a single vestigial
@@ -31,7 +31,7 @@ export const ANCHOR_SIDES: readonly PortSide[] = ["left", "right", "top", "botto
 export function isEmergentInputNode(type: NodeType): boolean {
   // #248: a `script` node consumes whole artifacts by edge like a work node, so
   // its inputs are emergent too — anchor incoming edges to the body by drop.
-  return type === "doc-only" || type === "code-mutating" || type === "script";
+  return type === "agent" || type === "script";
 }
 
 /**

--- a/frontend/src/lib/derivePooledInputs.test.ts
+++ b/frontend/src/lib/derivePooledInputs.test.ts
@@ -6,7 +6,7 @@ function node(id: string, extra: Partial<NodeDef> = {}): NodeDef {
   return {
     id,
     name: id,
-    type: "doc-only",
+    type: "agent",
     inputs: [],
     outputs: [],
     interactive: false,

--- a/frontend/src/lib/edgeFields.test.ts
+++ b/frontend/src/lib/edgeFields.test.ts
@@ -12,7 +12,7 @@ function pipeline(): PipelineDef {
       {
         id: "reviewer",
         name: "reviewer",
-        type: "doc-only",
+        type: "agent",
         inputs: [{ name: "task", repeated: false }],
         outputs: [
           {
@@ -31,7 +31,7 @@ function pipeline(): PipelineDef {
       {
         id: "impl",
         name: "impl",
-        type: "code-mutating",
+        type: "agent",
         inputs: [{ name: "review", repeated: false }],
         outputs: [{ name: "diff", repeated: false }],
         interactive: false,

--- a/frontend/src/lib/layoutFields.test.ts
+++ b/frontend/src/lib/layoutFields.test.ts
@@ -53,7 +53,7 @@ const OUTPUT: Complete<PortDef> = {
 const NODE: Complete<NodeDef> = {
   id: "n1",
   name: "Node One",
-  type: "code-mutating",
+  type: "agent",
   inputs: [INPUT],
   outputs: [OUTPUT],
   interactive: true,
@@ -74,6 +74,9 @@ const NODE: Complete<NodeDef> = {
   pin_harness: "claude",
   harnesses: { claude: { model: "opus", effort: "low" } },
   agent_choice: { mode: "profile", profile_id: "deep-work" },
+  // #653/ADR-0060: same caveat again — the emission proof is in
+  // `serializePipeline.test.ts` ("an agent always writes its isolation line").
+  isolated_worktree: false,
 };
 const EDGE: Complete<EdgeDef> = {
   source: { node: "n1", port: "out" },

--- a/frontend/src/lib/layoutFields.ts
+++ b/frontend/src/lib/layoutFields.ts
@@ -49,7 +49,10 @@ export const SEMANTIC_FIELDS: Record<SerializerScope, readonly string[]> = {
   // pipeline diff and the library content hash. What is load-bearing is their
   // ABSENCE from LAYOUT_FIELDS.node: that is what keeps `stripLayout` from dropping
   // them.
-  node: ["id", "name", "type", "interactive", "agent_choice", "pin_harness", "harnesses", "max_iter", "inputs", "outputs"] satisfies (keyof NodeDef)[],
+  // #653/ADR-0060: `isolated_worktree` is SEMANTIC — moving a node between the
+  // Run worktree and one of its own changes what the pipeline does, so the
+  // library star and the pipeline diff must both see it.
+  node: ["id", "name", "type", "interactive", "agent_choice", "pin_harness", "harnesses", "max_iter", "isolated_worktree", "inputs", "outputs"] satisfies (keyof NodeDef)[],
   // `side` is SEMANTIC today (emitted, not stripped) — deliberate, see #355 D5:
   // the node-library star already treats port side as identity, so the pipeline
   // diff must agree or the two stars contradict each other on the same edit.

--- a/frontend/src/lib/loopRegions.test.ts
+++ b/frontend/src/lib/loopRegions.test.ts
@@ -15,8 +15,8 @@ import type { EdgeDef, NodeDef, PipelineDef } from "../types";
 function reviewLoop(): PipelineDef {
   const nodes: NodeDef[] = [
     { id: "start", name: "start", type: "start", inputs: [], outputs: [{ name: "user_prompt", repeated: false, side: "right" }], interactive: false },
-    { id: "impl", name: "impl", type: "code-mutating", inputs: [], outputs: [{ name: "code", repeated: false, side: "right" }], interactive: false },
-    { id: "rev", name: "rev", type: "doc-only", inputs: [], outputs: [{ name: "review", repeated: false, side: "right" }], interactive: false },
+    { id: "impl", name: "impl", type: "agent", inputs: [], outputs: [{ name: "code", repeated: false, side: "right" }], interactive: false },
+    { id: "rev", name: "rev", type: "agent", inputs: [], outputs: [{ name: "review", repeated: false, side: "right" }], interactive: false },
   ];
   const edges: EdgeDef[] = [
     { source: { node: "start", port: "user_prompt" }, target: { node: "impl", port: "task" } },
@@ -48,9 +48,9 @@ describe("regionsDestroyedByEdgeRemoval (#150)", () => {
   it("deleting a non-last cycle edge keeps a region with two cycles", () => {
     // impl <-> rev AND impl -> rev -> mid -> impl: two cycles close the region.
     const nodes: NodeDef[] = [
-      { id: "impl", name: "impl", type: "code-mutating", inputs: [], outputs: [{ name: "code", repeated: false, side: "right" }], interactive: false },
-      { id: "rev", name: "rev", type: "doc-only", inputs: [], outputs: [{ name: "review", repeated: false, side: "right" }, { name: "extra", repeated: false, side: "right" }], interactive: false },
-      { id: "mid", name: "mid", type: "doc-only", inputs: [], outputs: [{ name: "more", repeated: false, side: "right" }], interactive: false },
+      { id: "impl", name: "impl", type: "agent", inputs: [], outputs: [{ name: "code", repeated: false, side: "right" }], interactive: false },
+      { id: "rev", name: "rev", type: "agent", inputs: [], outputs: [{ name: "review", repeated: false, side: "right" }, { name: "extra", repeated: false, side: "right" }], interactive: false },
+      { id: "mid", name: "mid", type: "agent", inputs: [], outputs: [{ name: "more", repeated: false, side: "right" }], interactive: false },
     ];
     const edges: EdgeDef[] = [
       { source: { node: "impl", port: "code" }, target: { node: "rev", port: "code" } }, // 0
@@ -177,7 +177,7 @@ function listNode(id: string, port: string): NodeDef {
   return {
     id,
     name: id,
-    type: "doc-only",
+    type: "agent",
     inputs: [],
     outputs: [
       {
@@ -191,7 +191,7 @@ function listNode(id: string, port: string): NodeDef {
   };
 }
 
-function plainNode(id: string, type: NodeDef["type"] = "code-mutating"): NodeDef {
+function plainNode(id: string, type: NodeDef["type"] = "agent"): NodeDef {
   return {
     id,
     name: id,
@@ -231,7 +231,7 @@ describe("collectionFanoutNudges (#151)", () => {
     const p: PipelineDef = {
       name: "p",
       variables: {},
-      nodes: [plainNode("a", "doc-only"), plainNode("b")],
+      nodes: [plainNode("a", "agent"), plainNode("b")],
       edges: [{ source: { node: "a", port: "out" }, target: { node: "b", port: "in" } }],
     };
     expect(collectionFanoutNudges(p)).toHaveLength(0);
@@ -270,7 +270,7 @@ describe("collectionFanoutFields (#269)", () => {
     const p: PipelineDef = {
       name: "p",
       variables: {},
-      nodes: [plainNode("a", "doc-only"), plainNode("b")],
+      nodes: [plainNode("a", "agent"), plainNode("b")],
       edges: [edge("a", "out", "b")],
     };
     expect(collectionFanoutFields(p, ["b"])).toEqual([]);

--- a/frontend/src/lib/nodeIsolation.test.ts
+++ b/frontend/src/lib/nodeIsolation.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import {
+  carriesIsolation,
+  isNodeIsolated,
+  nodeIsolation,
+  worktreePathFor,
+} from "./nodeIsolation";
+import type { NodeDef, NodeType } from "../types";
+
+function node(type: NodeType, isolated?: boolean): NodeDef {
+  return {
+    id: "n1",
+    name: "n1",
+    type,
+    inputs: [],
+    outputs: [],
+    interactive: false,
+    ...(isolated === undefined ? {} : { isolated_worktree: isolated }),
+  };
+}
+
+describe("nodeIsolation (#653 / ADR-0060)", () => {
+  it("defaults an Agent to isolated and a Script to the Run worktree", () => {
+    expect(nodeIsolation(node("agent"))).toBe(true);
+    expect(nodeIsolation(node("script"))).toBe(false);
+  });
+
+  it("reads an explicit value over the default, both ways", () => {
+    expect(nodeIsolation(node("agent", false))).toBe(false);
+    expect(nodeIsolation(node("script", true))).toBe(true);
+  });
+
+  it("gives merge and structural nodes no isolation to state", () => {
+    for (const type of ["merge", "start", "end"] as const) {
+      expect(nodeIsolation(node(type))).toBeNull();
+      expect(carriesIsolation(type)).toBe(false);
+    }
+    expect(carriesIsolation("agent")).toBe(true);
+    expect(carriesIsolation("script")).toBe(true);
+  });
+
+  it("still reports a Merge as isolated — it forks by construction", () => {
+    // Unmarked on the canvas, a Merge would read as LESS isolated than the
+    // Agent feeding it, which is the opposite of the truth.
+    expect(isNodeIsolated(node("merge"))).toBe(true);
+    expect(isNodeIsolated(node("start"))).toBe(false);
+    expect(isNodeIsolated(node("agent"))).toBe(true);
+    expect(isNodeIsolated(node("agent", false))).toBe(false);
+  });
+
+  it("resolves the two working directories by node id", () => {
+    expect(worktreePathFor("spec", true)).toBe(".pdo/runs/<run>/nodes/spec/iter-<n>");
+    expect(worktreePathFor("spec", false)).toBe(".pdo/runs/<run>/worktree");
+  });
+});

--- a/frontend/src/lib/nodeIsolation.ts
+++ b/frontend/src/lib/nodeIsolation.ts
@@ -1,0 +1,65 @@
+import type { NodeDef, NodeType } from "../types";
+
+/**
+ * #653 / ADR-0060 — the one owner of "where does this node work?" on the client.
+ *
+ * The retired non-isolated / isolated types named an *effect* while the
+ * runtime only ever read them as a working-directory decision. `agent` names the
+ * role; `isolated_worktree` names the directory. Everything on this axis — the
+ * inspector's Workspace section, the canvas marker, the serializer's
+ * unconditional emit, the new-node defaults — reads it from here, so the editor
+ * and the daemon cannot drift apart on what a silent document means.
+ */
+
+/**
+ * The isolation a type carries when the document says nothing. `null` means the
+ * type carries no isolation at all: `merge` is isolated by construction (it
+ * exposes no control — a Merge that could share a tree would have nothing to
+ * merge), and structural nodes never run in a worktree of their own.
+ */
+const DEFAULT_ISOLATION: Record<NodeType, boolean | null> = {
+  agent: true,
+  script: false,
+  merge: null,
+  start: null,
+  end: null,
+};
+
+/** Whether the inspector offers this type a Workspace choice at all. */
+export function carriesIsolation(type: NodeType): boolean {
+  return DEFAULT_ISOLATION[type] !== null;
+}
+
+/**
+ * A node's isolation as the document states it, falling back to its type's
+ * default. `null` for a type that carries none — the signal the serializer uses
+ * to leave the key off and the inspector uses to hide the section.
+ */
+export function nodeIsolation(node: NodeDef): boolean | null {
+  const fallback = DEFAULT_ISOLATION[node.type] ?? null;
+  if (fallback === null) return null;
+  return node.isolated_worktree ?? fallback;
+}
+
+/**
+ * Whether a node's NodeRun forks a worktree of its own — the canvas marker's
+ * predicate. Unlike [`nodeIsolation`] this answers for `merge` too, which is
+ * isolated without a line to read: the marker has to say so, or a Merge would
+ * look *less* isolated than the Agent feeding it.
+ */
+export function isNodeIsolated(node: NodeDef): boolean {
+  if (node.type === "merge") return true;
+  return nodeIsolation(node) === true;
+}
+
+/**
+ * The working directory the NodeRun will actually get, relative to the repo
+ * root. Displayed under the Workspace choice so the author reads the path
+ * instead of deducing it. `<run>` and `<n>` stay placeholders in the editor —
+ * neither the Run nor the iteration exists yet.
+ */
+export function worktreePathFor(nodeId: string, isolated: boolean): string {
+  return isolated
+    ? `.pdo/runs/<run>/nodes/${nodeId}/iter-<n>`
+    : `.pdo/runs/<run>/worktree`;
+}

--- a/frontend/src/lib/serializePipeline.test.ts
+++ b/frontend/src/lib/serializePipeline.test.ts
@@ -30,12 +30,12 @@ describe("serializePipeline round-trip: YAML structural correctness", () => {
 
   it("serializes a bounded loops: region block (ADR-0011 / #148)", () => {
     const impl: NodeDef = {
-      id: "impl", name: "implementer", type: "code-mutating",
+      id: "impl", name: "implementer", type: "agent",
       inputs: [], outputs: [{ name: "code", repeated: false, side: "right" }],
       interactive: false, view: { x: 200, y: 0 },
     };
     const rev: NodeDef = {
-      id: "rev", name: "reviewer", type: "doc-only",
+      id: "rev", name: "reviewer", type: "agent",
       inputs: [], outputs: [{ name: "review", repeated: false, side: "right" }],
       interactive: false, view: { x: 300, y: 0 },
     };
@@ -54,7 +54,7 @@ describe("serializePipeline round-trip: YAML structural correctness", () => {
 
   it("serializes a collection loops: region with its over: field (#269)", () => {
     const worker: NodeDef = {
-      id: "worker", name: "worker", type: "code-mutating",
+      id: "worker", name: "worker", type: "agent",
       inputs: [], outputs: [{ name: "out", repeated: false, side: "right" }],
       interactive: false, view: { x: 200, y: 0 },
     };
@@ -93,7 +93,7 @@ describe("serializePipeline round-trip: YAML structural correctness", () => {
 
   it("emits a per-node model override when set (#296)", () => {
     const impl: NodeDef = {
-      id: "impl", name: "implementer", type: "code-mutating",
+      id: "impl", name: "implementer", type: "agent",
       inputs: [], outputs: [{ name: "code", repeated: false, side: "right" }],
       interactive: false, view: { x: 200, y: 0 }, model: "opus",
     };
@@ -103,7 +103,7 @@ describe("serializePipeline round-trip: YAML structural correctness", () => {
 
   it("omits model when unset — the byte-identical / no-diverge default (#296)", () => {
     const impl: NodeDef = {
-      id: "impl", name: "implementer", type: "code-mutating",
+      id: "impl", name: "implementer", type: "agent",
       inputs: [], outputs: [{ name: "code", repeated: false, side: "right" }],
       interactive: false, view: { x: 200, y: 0 },
     };
@@ -115,7 +115,7 @@ describe("serializePipeline round-trip: YAML structural correctness", () => {
     // store and renders in the inspector even when the serializer forgets it —
     // only reading the emitted YAML proves it persists.
     const impl: NodeDef = {
-      id: "impl", name: "implementer", type: "code-mutating",
+      id: "impl", name: "implementer", type: "agent",
       inputs: [], outputs: [{ name: "code", repeated: false, side: "right" }],
       interactive: false, view: { x: 200, y: 0 }, model: "opus", effort: "low",
     };
@@ -126,7 +126,7 @@ describe("serializePipeline round-trip: YAML structural correctness", () => {
 
   it("emits an unknown effort level verbatim (#424, free-text wire)", () => {
     const impl: NodeDef = {
-      id: "impl", name: "implementer", type: "code-mutating",
+      id: "impl", name: "implementer", type: "agent",
       inputs: [], outputs: [{ name: "code", repeated: false, side: "right" }],
       interactive: false, view: { x: 200, y: 0 }, effort: "turbo",
     };
@@ -138,7 +138,7 @@ describe("serializePipeline round-trip: YAML structural correctness", () => {
   // "model: opus"); these pin the STRUCTURE and the pin.
   it("folds model/effort under harnesses.claude for an unpinned node (#550)", () => {
     const impl: NodeDef = {
-      id: "impl", name: "implementer", type: "code-mutating",
+      id: "impl", name: "implementer", type: "agent",
       inputs: [], outputs: [{ name: "code", repeated: false, side: "right" }],
       interactive: false, view: { x: 200, y: 0 }, model: "opus", effort: "low",
     };
@@ -152,7 +152,7 @@ describe("serializePipeline round-trip: YAML structural correctness", () => {
 
   it("emits pin_harness and folds model under the PINNED harness (#550)", () => {
     const impl: NodeDef = {
-      id: "impl", name: "implementer", type: "code-mutating",
+      id: "impl", name: "implementer", type: "agent",
       inputs: [], outputs: [{ name: "code", repeated: false, side: "right" }],
       interactive: false, view: { x: 200, y: 0 },
       pin_harness: "opencode", model: "openrouter/foo",
@@ -165,7 +165,7 @@ describe("serializePipeline round-trip: YAML structural correctness", () => {
   it("preserves a non-resolved harness's entry across a round-trip (#550)", () => {
     // Editing on the resolved harness (claude) must not clobber opencode's entry.
     const impl: NodeDef = {
-      id: "impl", name: "implementer", type: "code-mutating",
+      id: "impl", name: "implementer", type: "agent",
       inputs: [], outputs: [{ name: "code", repeated: false, side: "right" }],
       interactive: false, view: { x: 200, y: 0 },
       model: "opus", // resolved = claude (no pin)
@@ -178,7 +178,7 @@ describe("serializePipeline round-trip: YAML structural correctness", () => {
 
   it("omits harnesses entirely for a plain node (#550, no-diverge default)", () => {
     const impl: NodeDef = {
-      id: "impl", name: "implementer", type: "code-mutating",
+      id: "impl", name: "implementer", type: "agent",
       inputs: [], outputs: [{ name: "code", repeated: false, side: "right" }],
       interactive: false, view: { x: 200, y: 0 },
     };
@@ -193,7 +193,7 @@ describe("serializePipeline round-trip: YAML structural correctness", () => {
     // `claude` answers with a stderr warning and a silent fall back to the default.
     for (const effort of [undefined, null, ""]) {
       const impl: NodeDef = {
-        id: "impl", name: "implementer", type: "code-mutating",
+        id: "impl", name: "implementer", type: "agent",
         inputs: [], outputs: [{ name: "code", repeated: false, side: "right" }],
         interactive: false, view: { x: 200, y: 0 }, effort,
       };
@@ -203,7 +203,7 @@ describe("serializePipeline round-trip: YAML structural correctness", () => {
 
   it("serializes output port with frontmatter at correct indentation", () => {
     const reviewer: NodeDef = {
-      id: "reviewer", name: "reviewer", type: "doc-only",
+      id: "reviewer", name: "reviewer", type: "agent",
       inputs: [{ name: "code", repeated: false, side: "left" }],
       outputs: [{
         name: "review", repeated: false, side: "right",
@@ -230,7 +230,7 @@ describe("serializePipeline round-trip: YAML structural correctness", () => {
 
   it("round-trips multiline output instructions and omits blank values", () => {
     const reviewer: NodeDef = {
-      id: "reviewer", name: "reviewer", type: "doc-only",
+      id: "reviewer", name: "reviewer", type: "agent",
       inputs: [],
       outputs: [{
         name: "review", repeated: false, side: "right",
@@ -249,7 +249,7 @@ describe("serializePipeline round-trip: YAML structural correctness", () => {
 
   it("serializes an edge when clause at correct indentation", () => {
     const gate: NodeDef = {
-      id: "gate", name: "gate", type: "doc-only",
+      id: "gate", name: "gate", type: "agent",
       inputs: [{ name: "in", repeated: false, side: "left" }],
       outputs: [{ name: "out", repeated: false, side: "right" }],
       interactive: false, view: { x: 200, y: 0 },
@@ -278,7 +278,7 @@ describe("serializePipeline round-trip: YAML structural correctness", () => {
 
   it("serializes a manual edge's mode and waypoints (shareable routing, #154)", () => {
     const gate: NodeDef = {
-      id: "gate", name: "gate", type: "doc-only",
+      id: "gate", name: "gate", type: "agent",
       inputs: [{ name: "in", repeated: false, side: "left" }],
       outputs: [{ name: "out", repeated: false, side: "right" }],
       interactive: false, view: { x: 200, y: 0 },
@@ -306,7 +306,7 @@ describe("serializePipeline round-trip: YAML structural correctness", () => {
 
   it("omits routing fields for an auto edge (no waypoints stored, #154)", () => {
     const gate: NodeDef = {
-      id: "gate", name: "gate", type: "doc-only",
+      id: "gate", name: "gate", type: "agent",
       inputs: [{ name: "in", repeated: false, side: "left" }],
       outputs: [{ name: "out", repeated: false, side: "right" }],
       interactive: false, view: { x: 200, y: 0 },
@@ -327,7 +327,7 @@ describe("serializePipeline round-trip: YAML structural correctness", () => {
 
   it("serializes an edge's target_side so the drop-position anchor survives reload (#168)", () => {
     const impl: NodeDef = {
-      id: "impl", name: "impl", type: "code-mutating",
+      id: "impl", name: "impl", type: "agent",
       inputs: [], outputs: [{ name: "out", repeated: false, side: "right" }],
       interactive: false, view: { x: 200, y: 0 },
     };
@@ -345,7 +345,7 @@ describe("serializePipeline round-trip: YAML structural correctness", () => {
 
   it("omits target_side for a left-anchored (legacy) edge (#168)", () => {
     const impl: NodeDef = {
-      id: "impl", name: "impl", type: "code-mutating",
+      id: "impl", name: "impl", type: "agent",
       inputs: [], outputs: [{ name: "out", repeated: false, side: "right" }],
       interactive: false, view: { x: 200, y: 0 },
     };
@@ -362,7 +362,7 @@ describe("serializePipeline round-trip: YAML structural correctness", () => {
 
   it("serializes multi-field frontmatter with all fields at same depth", () => {
     const node: NodeDef = {
-      id: "multi", name: "multi", type: "doc-only",
+      id: "multi", name: "multi", type: "agent",
       inputs: [{ name: "in", repeated: false }],
       outputs: [{
         name: "out", repeated: false,
@@ -392,7 +392,7 @@ describe("serializePipeline round-trip: YAML structural correctness", () => {
 
   it("serializes a deeply nested edge when clause with in-predicate correctly", () => {
     const gate: NodeDef = {
-      id: "gate", name: "gate", type: "doc-only",
+      id: "gate", name: "gate", type: "agent",
       inputs: [{ name: "in", repeated: false, side: "left" }],
       outputs: [{ name: "out", repeated: false, side: "right" }],
       interactive: false, view: { x: 200, y: 0 },
@@ -452,13 +452,13 @@ describe("serializePipeline persists edge when/else (ADR-0011)", () => {
       variables: {},
       nodes: [
         {
-          id: "reviewer", name: "reviewer", type: "doc-only",
+          id: "reviewer", name: "reviewer", type: "agent",
           inputs: [{ name: "task", repeated: false, side: "left" }],
           outputs: [{ name: "verdict", repeated: false, side: "right" }],
           interactive: false, view: { x: 0, y: 0 },
         },
         {
-          id: "impl", name: "impl", type: "code-mutating",
+          id: "impl", name: "impl", type: "agent",
           inputs: [{ name: "review", repeated: false, side: "left" }],
           outputs: [{ name: "diff", repeated: false, side: "right" }],
           interactive: false, view: { x: 200, y: 0 },
@@ -530,7 +530,7 @@ describe("serializePipeline persists port_type", () => {
     const tester: NodeDef = {
       id: "9NOnrpKY",
       name: "Tester",
-      type: "doc-only",
+      type: "agent",
       inputs: [
         { name: "screens", repeated: false, side: "left", port_type: "image_list" },
       ],
@@ -570,7 +570,7 @@ describe("serializePipeline persists port_type", () => {
     const designer: NodeDef = {
       id: "designer0",
       name: "Designer",
-      type: "doc-only",
+      type: "agent",
       inputs: [],
       outputs: [
         { name: "report", repeated: false, side: "right", port_type: "html" },
@@ -598,7 +598,7 @@ describe("exportNodeAsYaml (#345)", () => {
     return {
       id: "abc12345",
       name: "Reviewer",
-      type: "doc-only",
+      type: "agent",
       inputs: [],
       outputs: [{ name: "review", repeated: false, side: "right" }],
       interactive: false,
@@ -703,7 +703,7 @@ describe("exportNodeAsYaml (#345)", () => {
   });
 
   it("is library-entry-shaped: name + type at the root", () => {
-    expect(exportNodeAsYaml(node(), "p").startsWith("name: Reviewer\ntype: doc-only")).toBe(true);
+    expect(exportNodeAsYaml(node(), "p").startsWith("name: Reviewer\ntype: agent")).toBe(true);
   });
 
   // #457: the third frontmatter emit site — same null-stripping rule.
@@ -751,7 +751,7 @@ describe("serializePipeline strips null frontmatter keys (#457)", () => {
     return {
       name: "fm-test", version: "1.0", variables: {},
       nodes: [{
-        id: "reviewer", name: "reviewer", type: "doc-only",
+        id: "reviewer", name: "reviewer", type: "agent",
         inputs: [{ name: "code", repeated: false, side: "left", frontmatter }],
         outputs: [{ name: "review", repeated: false, side: "right", frontmatter }],
         interactive: false, view: { x: 0, y: 0 },
@@ -789,5 +789,58 @@ describe("serializePipeline strips null frontmatter keys (#457)", () => {
     const fromDaemon = serializePipeline(withFrontmatter({ approved: { type: "bool", allowed: null } }));
     const fromAuthor = serializePipeline(withFrontmatter({ approved: { type: "bool" } }));
     expect(fromDaemon).toBe(fromAuthor);
+  });
+});
+
+/**
+ * #653 / ADR-0060 — the isolation line is written UNCONDITIONALLY for an
+ * `agent`/`script`, including at the editor default. A document that omits it
+ * makes the reader recall a default; one that states it does not.
+ */
+describe("isolated_worktree emission (#653)", () => {
+  function pipelineWith(node: NodeDef): PipelineDef {
+    return { name: "iso", version: "1.0", variables: {}, nodes: [node], edges: [] };
+  }
+  function agent(overrides: Partial<NodeDef> = {}): NodeDef {
+    return {
+      id: "impl", name: "implementer", type: "agent",
+      inputs: [], outputs: [], interactive: false, view: { x: 0, y: 0 },
+      ...overrides,
+    };
+  }
+
+  it("writes the line for an agent that never stated it — at the default", () => {
+    const yaml = serializePipeline(pipelineWith(agent()));
+    expect(yaml).toContain("isolated_worktree: true");
+  });
+
+  it("writes the line for a script that never stated it — at the default", () => {
+    const yaml = serializePipeline(pipelineWith(agent({ type: "script" })));
+    expect(yaml).toContain("isolated_worktree: false");
+  });
+
+  it("writes both explicit values verbatim", () => {
+    for (const value of [true, false]) {
+      const yaml = serializePipeline(pipelineWith(agent({ isolated_worktree: value })));
+      expect(yaml).toContain(`isolated_worktree: ${value}`);
+    }
+  });
+
+  it("never writes the line for a merge or a structural node", () => {
+    for (const type of ["merge", "start", "end"] as const) {
+      const yaml = serializePipeline(
+        pipelineWith(agent({ type, isolated_worktree: true })),
+      );
+      expect(yaml).not.toContain("isolated_worktree");
+    }
+  });
+
+  it("carries the line through the single-node export too", () => {
+    expect(exportNodeAsYaml(agent({ isolated_worktree: false }), "p")).toContain(
+      "isolated_worktree: false",
+    );
+    expect(exportNodeAsYaml(agent({ type: "merge" }), "p")).not.toContain(
+      "isolated_worktree",
+    );
   });
 });

--- a/frontend/src/lib/serializePipeline.ts
+++ b/frontend/src/lib/serializePipeline.ts
@@ -31,6 +31,7 @@ import type {
 } from "../types";
 // #550: the per-harness fold (pure, `../types`-only) — keeps this module pure.
 import { foldNodeIntoHarnesses } from "./harness";
+import { nodeIsolation } from "./nodeIsolation";
 
 /**
  * Drops the null-valued keys of every frontmatter declaration (#457).
@@ -92,6 +93,12 @@ export function pipelineToYamlObject(p: PipelineDef): Record<string, unknown> {
       type: n.type,
     };
     if (n.interactive) node.interactive = true;
+    // #653/ADR-0060: where the node works, written UNCONDITIONALLY for an
+    // `agent`/`script` — even at the editor default. A document that omits the
+    // line makes the reader recall a default; one that states it does not. Never
+    // emitted for `merge` (isolated by construction) or a structural node.
+    const isolation = nodeIsolation(n);
+    if (isolation !== null) node.isolated_worktree = isolation;
     // #550/ADR-0046: the harness axis replaces flat `model:`/`effort:`. The pin is
     // emitted when set; the flat model/effort view is folded back into the
     // resolved harness's entry in the per-harness `harnesses` map, emitted only
@@ -283,6 +290,10 @@ export function exportNodeAsYaml(node: NodeDef, prompt: string): string {
     type: node.type,
   };
   if (node.interactive) obj.interactive = true;
+  // #653: same unconditional emit as `pipelineToYamlObject` — an exported node
+  // carries its worktree placement, so a re-import does not re-guess it.
+  const isolation = nodeIsolation(node);
+  if (isolation !== null) obj.isolated_worktree = isolation;
   if (node.pin_harness) obj.pin_harness = node.pin_harness;
   if (node.agent_choice && node.agent_choice.mode !== "inherit") {
     obj.agent_choice = node.agent_choice;

--- a/frontend/src/portDescriptions.test.ts
+++ b/frontend/src/portDescriptions.test.ts
@@ -16,12 +16,12 @@ describe("getPortDescription", () => {
 
   it("returns yaml description when no hardcoded match", () => {
     expect(
-      getPortDescription("doc-only", "input", "plan", "The implementation plan"),
+      getPortDescription("agent", "input", "plan", "The implementation plan"),
     ).toBe("The implementation plan");
   });
 
   it("returns port name as fallback", () => {
-    expect(getPortDescription("doc-only", "output", "review")).toBe("review");
+    expect(getPortDescription("agent", "output", "review")).toBe("review");
   });
 
   it("prefers hardcoded over yaml description", () => {

--- a/frontend/src/stores/editStore.test.ts
+++ b/frontend/src/stores/editStore.test.ts
@@ -57,7 +57,7 @@ function makeNode(overrides: Partial<NodeDef> = {}): NodeDef {
   return {
     id: "default",
     name: "Default",
-    type: "doc-only",
+    type: "agent",
     inputs: [{ name: "in", repeated: false }],
     outputs: [{ name: "out", repeated: false }],
     interactive: false,
@@ -896,7 +896,7 @@ describe("serializePipeline (via save) emits structural node fields", () => {
   // bound on the `loops:` block (ADR-0011). So an ordinary node must serialize
   // clean, with no stray `max_iter` key.
   it("does not emit max_iter for a node without one", async () => {
-    const docNode = makeNode({ id: "doc1", type: "doc-only" });
+    const docNode = makeNode({ id: "doc1", type: "agent" });
     seedTabWithPipeline(makePipeline([docNode]));
 
     await useEditStore.getState().save("test-tab");
@@ -1191,7 +1191,7 @@ describe("mutations set dirty without auto-saving", () => {
 
     useEditStore.getState().addNode({
       id: "new-node",
-      type: "doc-only",
+      type: "agent",
       inputs: [],
       outputs: [],
       interactive: false,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -464,7 +464,9 @@ export interface UpdateSettingsRequest {
 // YAML into a region. `loop` was likewise removed in #171.
 // `script` (#248 / ADR-0017) runs author-written bash deterministically instead
 // of launching Claude; the FE union is not 1:1 with the backend enum.
-export type NodeType = "doc-only" | "code-mutating" | "start" | "end" | "merge" | "script";
+// `agent` (#653 / ADR-0060) replaces `doc-only` and `code-mutating`: the type
+// names the execution role, and where the NodeRun works is `isolated_worktree`.
+export type NodeType = "agent" | "start" | "end" | "merge" | "script";
 
 export interface RunListEntry {
   run_id: string;
@@ -649,6 +651,13 @@ export interface NodeState {
    * skip) or a pre-#616 daemon.
    */
   harness?: string;
+  /**
+   * #653/ADR-0060: where this NodeRun was FROZEN to work at spawn — `true` its
+   * own sub-worktree, `false` the Run's. This, not the document, is what the run
+   * inspector shows: editing the graph never moves a live iteration. Absent for a
+   * node that never started, a structural node, or a pre-#653 daemon.
+   */
+  isolated_worktree?: boolean;
   cost?: NodeCost | null;
 }
 
@@ -684,6 +693,8 @@ export interface NodeDefInfo {
   id: string;
   name?: string | null;
   node_type: NodeType;
+  /** #653: where the node works, as the Run's pipeline snapshot froze it. */
+  isolated_worktree?: boolean | null;
   view_x: number | null;
   view_y: number | null;
   inputs: PortBrief[];
@@ -1035,6 +1046,12 @@ export interface NodeDef {
   harnesses?: Record<string, HarnessSettings>;
   /** Atomic agent selection for this node. Missing/`inherit` continues precedence. */
   agent_choice?: AgentChoice | null;
+  /** #653/ADR-0060: where this node's NodeRun works — `true` a sub-worktree of
+   *  its own, `false` the Run's shared worktree. Carried by `agent` and `script`
+   *  only, and ALWAYS serialized for them (including at the default), so a
+   *  document never leaves the reader to guess. Absent on `merge` (isolated by
+   *  construction) and on structural nodes. */
+  isolated_worktree?: boolean | null;
 }
 
 export interface AgentCombination {

--- a/prompts/builtin/library-assistant.md
+++ b/prompts/builtin/library-assistant.md
@@ -45,7 +45,8 @@ loops: [ ... ]                    # optional; bounded loop regions
 nodes:
   - id: implement                 # stable slug, unique in the pipeline
     name: implementer             # display label
-    type: code-mutating
+    type: agent
+    isolated_worktree: true
     inputs:                       # emergent for work nodes — usually omit; named by edges
       - { name: in, side: left }
     outputs:
@@ -63,14 +64,26 @@ nodes:
 
 - `start` — the entry; its output carries the user prompt. One per pipeline.
 - `end` — the terminal sink. One per pipeline.
-- `code-mutating` — an agent node that edits the repo (gets a sub-worktree).
-- `doc-only` — an agent node with no repo side effect (analysis, review, design).
+- `agent` — a node that runs an agentic harness on its system prompt.
   Add `interactive: true` for a node a human drives and marks done by hand.
 - `script` — deterministic author-written bash instead of an agent (ADR-0017).
 - `merge` — joins parallel branches back together (ADR-0006).
 - `switch` — mechanical fan-out on a typed value.
 
-Work nodes (`code-mutating` / `doc-only` / `script`) have **emergent inputs**: an
+**Where a node works** (`isolated_worktree:`, ADR-0060). Every `agent` and every
+`script` states it, always — write the line even when it equals the default:
+
+- `true` — the NodeRun gets a sub-worktree of its own. The default for an
+  `agent`, and what parallel branches need to avoid sharing an uncommitted tree.
+- `false` — the NodeRun works directly in the Run's shared worktree. The default
+  for a `script`, and the right choice for a sequential pipeline that does not
+  need a fork per role.
+
+`merge` is isolated by construction and carries no line; `start`/`end` carry none
+either. There is no `doc-only` or `code-mutating` — a node's type names its
+execution role, never a guess about what it will touch.
+
+Work nodes (`agent` / `script`) have **emergent inputs**: an
 input port is created from each incoming edge and named after the edge's target
 port — you normally don't declare `inputs:` on them. Structural nodes
 (`start`/`end`/`merge`/`switch`) keep declared ports.

--- a/prompts/builtin/merge-resolver.md
+++ b/prompts/builtin/merge-resolver.md
@@ -1,6 +1,6 @@
 You are the Merge Resolver.
 
-A `git merge` between two parallel `code-mutating` branches in this Pipeline Run has produced conflicts. The conflicted worktree is your current working directory.
+A `git merge` between two parallel isolated-worktree branches in this Pipeline Run has produced conflicts. The conflicted worktree is your current working directory.
 
 Each upstream NodeRun wrote its outputs to the Blackboard at:
 


### PR DESCRIPTION
Les types `doc-only` et `code-mutating` nommaient un effet — « ce Node touche du code » — alors que le
runtime n'y lisait qu'une seule chose : dans quel répertoire lancer le NodeRun. Un seul type agentique
subsiste, `agent`, et le lieu de travail s'écrit explicitement sur le Node : `isolated_worktree: true|false`.

## Ce qui change

- **Schéma.** `normalize_node_value` stampe le défaut du type (Agent isolé, Script partagé), donc un
  Document parsé énonce toujours le choix, même à la valeur par défaut. `merge` et les Nodes
  structurels ne portent pas la ligne. Rupture franche : pas d'alias, pas de migrateur.
- **Runtime.** Le placement lit `NodeDef::is_isolated()` au premier spawn, puis la valeur **gelée** sur
  `NodeStarted`. Une édition déplace le prochain lancement, jamais une exécution vivante ; une reprise
  retrouve son répertoire.
- **Éditeur.** Type figé + section « Workspace » : deux lieux nommés, décrits, avec le répertoire résolu
  en monospace. Le canvas marque d'un glyphe de branche les Nodes qui forkent.
- **Import de workflow.** Un rôle importé devient un `agent` isolé.

## Vérification

Build `cargo` + `pnpm` verts, tests verts. Feature Path joué contre la stack réelle (daemon de test,
dépôt jetable, UI au navigateur) : **Pass** sur les trois étapes.

- Deux Agents, l'un isolé l'autre sur le worktree du Run → chemins résolus distincts, en direct.
- Aller-retour save/reload → les deux lignes `isolated_worktree` sérialisées, valeurs restaurées.
- Run réel → chaque Agent écrit son `pwd` dans le répertoire annoncé ; un seul sous-worktree créé.

Findings non bloquants : le radio sélectionné est ambré là où la maquette C le peint en vert (décision
de design) ; le canvas accepte des arêtes en double (préexistant, sans rapport) ; le dialogue de
confiance `claude` au premier lancement dans un sous-worktree neuf (connu, documenté).

Closes #653

🤖 Generated with [Claude Code](https://claude.com/claude-code)
