### PR TITLE
feat(#655): l'isolation voyage par la bibliothèque et par l'import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ ascendante** : la casse se signale ici et par un bump majeur, jamais en gardant 
 morts. Seule contrainte non négociable — les **données historiques restent lisibles** : un Run
 archivé s'ouvre et se chiffre quelle que soit la version qui a écrit son payload.
 
+## 1.48.0
+
+**L'isolation voyage par la bibliothèque et par l'import** (#655 ; ADR-0060). Une entrée de
+bibliothèque `agent` ou `script` porte désormais `isolated_worktree`, l'instanciation le restitue
+tel quel, et l'aperçu de la bibliothèque nomme le workspace de chaque entrée. Sans ça, une entrée
+étoilée retombait sur le défaut de son type à chaque dépôt sur le canvas : un Agent garé dans le
+worktree du Run en forkait un à lui, en silence.
+
+L'isolation entre du même coup dans l'identité de l'entrée. **Conséquence à l'upgrade** : une
+entrée écrite avant cette version ne dit rien de son workspace ; elle se lit au défaut de son type
+(Agent isolé, Script partagé) — donc rien ne bouge pour la majorité des entrées, mais un Node que
+vous aviez sorti de son isolation lira `out of sync` face à son entrée jusqu'à ce que vous la
+mettiez à jour. C'est la divergence réelle, pas un faux positif.
+
+Import de workflow : tout rôle importé, placeholder annoté compris, devient un `agent` **isolé** et
+le brouillon écrit la ligne. L'import ne déduit jamais l'isolation du prompt, du nom du rôle, de ses
+sorties ni de son appartenance à une région `collection`.
+
 ## 1.47.0
 
 **`agent` remplace `doc-only` et `code-mutating` ; l'isolation devient explicite** (#653 ;

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -892,6 +892,8 @@ From scratch (« + Add node »), duplicate (clic droit), drag-drop depuis la bib
 
 La **bibliothèque de nodes** contient les nodes réutilisables qu'un utilisateur peut ajouter à une Pipeline. La réutilisation reste une aide à l'édition : un Document de pipeline transportable développe chaque node partagé en node ordinaire, sans recréer son appartenance à la bibliothèque sur l'instance cible.
 
+Une entrée `agent` ou `script` **énonce son isolation** (cf. *Isolation de Node*) comme elle énonce son harnais et ses ports : l'entrée porte le choix, l'instanciation le restitue tel quel, et une entrée écrite avant que le champ existe se lit au défaut de son type — jamais comme un silence. L'isolation entre donc dans l'**identité sémantique** de l'entrée : deux Nodes identiques au worktree près ne sont pas le même contenu, et l'étoile de synchronisation le dit. Une entrée `merge`, `start` ou `end` ne porte aucune ligne, un Merge étant isolé par construction.
+
 _Éviter_ : « pipeline de bibliothèque » — les Pipelines appartiennent au registre d'instance, pas à la bibliothèque.
 
 ### Registre de pipelines
@@ -927,3 +929,4 @@ Règle de récupération des prompts : string-literal sans interpolation → ver
 - L'**import de Pipeline PDO** interprète un Document de pipeline transportable et crée une Pipeline indépendante ; il partage la même modale que l'Import de workflow, mais constitue un mode distinct et fidèle.
 - Idiomes mappés : `agent()` → **Node**, `pipeline()` → boucle **`collection`**, `for`/`while` autour d'un `agent()` → boucle **`bounded`**, `if`/`return` gardé → **edge conditionnelle**, schémas JSON → **frontmatter de port de sortie**.
 - Un idiome hors sous-ensemble → **placeholder annoté**. Un `git merge` scripté → Node `agent` annoté, **pas** le Merge first-class (dont il excède le contrat).
+- Tout rôle importé — placeholder annoté compris — devient un Node `agent` **isolé**, et le brouillon écrit la ligne. L'import ne déduit jamais l'isolation du prompt, du nom du rôle, de ses sorties ni de son appartenance à une région `collection` : un workflow étranger n'a pas d'avis sur les worktrees, et en inventer un est précisément la devinette qu'ADR-0060 supprime. L'auteur arbitre ensuite sur le canvas.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "1.47.0"
+version = "1.48.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "1.47.0"
+version = "1.48.0"
 license = "MIT"
 description = "Prompt-Driven Orchestrator — a local daemon that runs and supervises agentic coding pipelines"
 repository = "https://github.com/Loulen/prompt-driven-orchestrator"

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -6374,13 +6374,15 @@ struct SaveToLibraryRequest {
     effort: Option<String>,
     #[serde(default)]
     prompt: String,
+    /// Where an instance of this entry works (#655/ADR-0060). Optional so a
+    /// client that omits it stars the node on its type's default (stamped by
+    /// `library_store::save`) instead of 400-ing — same posture as `model`.
+    #[serde(default)]
+    isolated_worktree: Option<bool>,
 }
 
-async fn save_to_library(
-    State(_state): State<Arc<AppState>>,
-    Json(req): Json<SaveToLibraryRequest>,
-) -> Response {
-    let entry = library_store::LibraryEntry {
+async fn save_to_library(Json(req): Json<SaveToLibraryRequest>) -> Response {
+    let mut entry = library_store::LibraryEntry {
         name: req.name,
         node_type: req.node_type,
         inputs: req.inputs,
@@ -6391,7 +6393,11 @@ async fn save_to_library(
         max_iter: None,
         branches: None,
         prompt: req.prompt,
+        isolated_worktree: req.isolated_worktree,
     };
+    // #655: stamp before saving AND before answering, so the 201 body shows the
+    // choice the library recorded rather than the silence the client sent.
+    entry.stamp_isolation();
 
     if let Err(e) = library_store::save(&entry) {
         return (
@@ -6433,6 +6439,12 @@ async fn instantiate_from_library(AxumPath(name): AxumPath<String>) -> Response 
                     // #424: same for the effort level — without it, instantiating
                     // drops the level and the fresh node reads `diverged` at once.
                     "effort": entry.effort,
+                    // #655/ADR-0060: restore the entry's workspace exactly. Left
+                    // out, the canvas would fall back to the type default and an
+                    // Agent starred in the Run's worktree would silently fork one
+                    // of its own on every instantiation. `null` for the types that
+                    // carry no isolation — the canvas leaves the key off those.
+                    "isolated_worktree": entry.isolated_worktree,
                 },
                 "prompt": prompt,
             }))
@@ -6594,20 +6606,15 @@ fn parse_node_spec(yaml: &str) -> Result<serde_json::Value, String> {
         .get("agent_choice")
         .map(yaml_value_to_json)
         .unwrap_or(serde_json::Value::Null);
-    // #653/ADR-0060: where the pasted node works. `normalize_node_value` above
-    // already stamped the type's default onto an `agent`/`script` that said
-    // nothing, so this is never a guess — and reading it here is what keeps a
-    // node that opted out of isolation from silently forking one on instantiation
-    // (the silent loss ADR-0001/#268 forbid). `null` for the types that carry no
-    // isolation, which the canvas then leaves off the node.
-    let isolated_worktree = value
-        .get(pipeline::ISOLATED_WORKTREE_KEY)
-        .and_then(serde_yaml::Value::as_bool);
-
     // 8. Deserialize the (normalized) map into a LibraryEntry. `prompt` defaults
     //    to empty (a structural node carries none); unknown fields are ignored.
-    let entry: library_store::LibraryEntry =
+    //    #655: `isolated_worktree` is a LibraryEntry field, so the pasted node's
+    //    workspace rides through the same door as the rest of it — and
+    //    `normalize_node_value` above already stamped the type default onto a
+    //    silent `agent`/`script`, so what comes out is never a guess.
+    let mut entry: library_store::LibraryEntry =
         serde_yaml::from_value(value).map_err(|e| format!("{e}"))?;
+    entry.stamp_isolation();
 
     Ok(serde_json::json!({
         "spec": {
@@ -6625,7 +6632,7 @@ fn parse_node_spec(yaml: &str) -> Result<serde_json::Value, String> {
             // #563: the node's agent-profile choice, carried verbatim.
             "agent_choice": agent_choice,
             // #653: where the node works.
-            "isolated_worktree": isolated_worktree,
+            "isolated_worktree": entry.isolated_worktree,
             "max_iter": entry.max_iter,
             "branches": entry.branches,
         },
@@ -17749,6 +17756,12 @@ mod tests {
                 serde_json::json!(false),
             ),
             ("name: n\ntype: start\n", serde_json::Value::Null),
+            // #655: a stray line on a type that carries no isolation is dropped,
+            // not round-tripped — a Merge is isolated by construction.
+            (
+                "name: n\ntype: merge\nisolated_worktree: false\n",
+                serde_json::Value::Null,
+            ),
         ] {
             let body = parse_node_spec(yaml).unwrap();
             assert_eq!(body["spec"]["isolated_worktree"], expected, "{yaml}");
@@ -30794,6 +30807,98 @@ edges: []
 
         // Cleanup
         let _ = library_store::delete("DraftReviewer");
+        if let Some(p) = prev_home {
+            std::env::set_var("HOME", p);
+        }
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// #655/ADR-0060 — the library round-trip that the Feature Path walks:
+    /// star a non-isolated Agent, then instantiate it somewhere else and get the
+    /// same workspace back. `POST /library` and `POST /library/{}/instantiate`
+    /// are both disk-only, so they are driven directly rather than through a
+    /// router (no AppState needed since `save_to_library` dropped its unused one).
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn library_round_trip_restores_the_entrys_workspace() {
+        let _guard = crate::library_store::HOME_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let tmp = std::env::temp_dir().join(format!("pdo-lib-iso-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&tmp).unwrap();
+        let prev_home = std::env::var("HOME").ok();
+        std::env::set_var("HOME", &tmp);
+
+        async fn body_of(resp: Response) -> serde_json::Value {
+            serde_json::from_slice(
+                &axum::body::to_bytes(resp.into_body(), usize::MAX)
+                    .await
+                    .unwrap(),
+            )
+            .unwrap()
+        }
+
+        // An Agent the author parked in the Run's worktree — the interesting case,
+        // because it is the one the type default would silently overwrite.
+        let saved = save_to_library(Json(
+            serde_json::from_value(serde_json::json!({
+                "name": "SharedScribe",
+                "type": "agent",
+                "inputs": [{"name": "in"}],
+                "outputs": [{"name": "out"}],
+                "interactive": false,
+                "isolated_worktree": false,
+                "prompt": "Write the note.",
+            }))
+            .unwrap(),
+        ))
+        .await;
+        assert_eq!(saved.status(), StatusCode::CREATED);
+        assert_eq!(body_of(saved).await["isolated_worktree"], false);
+
+        let spec =
+            body_of(instantiate_from_library(AxumPath("SharedScribe".to_string())).await).await;
+        assert_eq!(
+            spec["spec"]["isolated_worktree"], false,
+            "instantiating must restore the parked workspace, not the type default",
+        );
+
+        // A request that says nothing is stamped with the type's default rather
+        // than stored as a silence — so the entry always states where it works.
+        let saved = save_to_library(Json(
+            serde_json::from_value(serde_json::json!({
+                "name": "SilentScribe",
+                "type": "agent",
+                "prompt": "Write the note.",
+            }))
+            .unwrap(),
+        ))
+        .await;
+        assert_eq!(body_of(saved).await["isolated_worktree"], true);
+
+        // A type that carries no isolation reports `null`; the canvas leaves the
+        // key off such a node entirely.
+        let saved = save_to_library(Json(
+            serde_json::from_value(serde_json::json!({
+                "name": "Gatherer",
+                "type": "merge",
+                "isolated_worktree": false,
+                "prompt": "",
+            }))
+            .unwrap(),
+        ))
+        .await;
+        assert_eq!(
+            body_of(saved).await["isolated_worktree"],
+            serde_json::Value::Null
+        );
+        let spec = body_of(instantiate_from_library(AxumPath("Gatherer".to_string())).await).await;
+        assert_eq!(spec["spec"]["isolated_worktree"], serde_json::Value::Null);
+
+        for name in ["SharedScribe", "SilentScribe", "Gatherer"] {
+            let _ = library_store::delete(name);
+        }
         if let Some(p) = prev_home {
             std::env::set_var("HOME", p);
         }

--- a/crates/pdo-daemon/src/library_store.rs
+++ b/crates/pdo-daemon/src/library_store.rs
@@ -36,6 +36,52 @@ pub(crate) struct LibraryEntry {
     /// library files always carry a prompt, so this is purely additive.
     #[serde(default)]
     pub prompt: String,
+    /// Where an instance of this entry works (#655, ADR-0060). The library is
+    /// isolation-aware for the same reason it became model-aware in #345: an
+    /// entry that forgot the field would restore the *type default* on every
+    /// instantiation, silently forking a worktree for an Agent its author had
+    /// parked in the Run's — and the star would read `diverged` forever.
+    ///
+    /// Always `Some` for `agent`/`script` (stamped by [`normalized_isolation`]
+    /// on every read and write, so a pre-#655 file states its choice too), and
+    /// always `None` for the types that carry none. `skip_serializing_if` is
+    /// what keeps a starred Merge/Start/End file free of a line nobody may edit.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub isolated_worktree: Option<bool>,
+}
+
+impl LibraryEntry {
+    /// This entry's isolation, made explicit (#655, ADR-0060).
+    ///
+    /// The type has the last word on *whether* there is a choice at all, and the
+    /// entry has the last word on *which* — the same precedence
+    /// `NodeDef::is_isolated` uses, so the library and the Document cannot read
+    /// one silence two ways. A stray value on a Merge is dropped rather than
+    /// round-tripped, mirroring `pipeline::stamp_isolation_default`.
+    fn normalized_isolation(&self) -> Option<bool> {
+        let default = self.node_type.default_isolation()?;
+        Some(self.isolated_worktree.unwrap_or(default))
+    }
+
+    /// Stamp [`normalized_isolation`] onto the entry. Every path that produces an
+    /// entry — a disk read, a star, a `POST /library` — runs this, so "an entry
+    /// states where it works" holds by construction instead of by convention.
+    pub(crate) fn stamp_isolation(&mut self) {
+        self.isolated_worktree = self.normalized_isolation();
+    }
+}
+
+/// Deserialize one library file and make its isolation explicit (#655).
+///
+/// The single door onto the on-disk format: `list`, `get`, `find_by_name` and
+/// `find_path_by_name` all read through it, so a pre-#655 entry (no
+/// `isolated_worktree` line) is seen by everything downstream as carrying its
+/// type's default — not as a silence that would read `diverged` against a node
+/// sitting on that very default.
+fn parse_entry(contents: &str) -> Option<LibraryEntry> {
+    let mut entry = serde_yaml::from_str::<LibraryEntry>(contents).ok()?;
+    entry.stamp_isolation();
+    Some(entry)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -96,7 +142,7 @@ pub(crate) fn list() -> Vec<LibraryEntry> {
             continue;
         }
         if let Ok(contents) = std::fs::read_to_string(&path) {
-            if let Ok(entry) = serde_yaml::from_str::<LibraryEntry>(&contents) {
+            if let Some(entry) = parse_entry(&contents) {
                 entries.push(entry);
             }
         }
@@ -117,7 +163,7 @@ pub(crate) fn get(name: &str) -> Option<LibraryEntry> {
     // out-of-disk write) must not shadow an entry that still lives on disk —
     // otherwise `list` surfaces it while `get`/instantiate 404 on the same name.
     if let Ok(contents) = std::fs::read_to_string(&path) {
-        if let Ok(entry) = serde_yaml::from_str::<LibraryEntry>(&contents) {
+        if let Some(entry) = parse_entry(&contents) {
             if entry.name == name {
                 return Some(entry);
             }
@@ -134,7 +180,7 @@ fn find_by_name(dir: &Path, name: &str) -> Option<LibraryEntry> {
             continue;
         }
         if let Ok(contents) = std::fs::read_to_string(&path) {
-            if let Ok(lib_entry) = serde_yaml::from_str::<LibraryEntry>(&contents) {
+            if let Some(lib_entry) = parse_entry(&contents) {
                 if lib_entry.name == name {
                     return Some(lib_entry);
                 }
@@ -154,7 +200,12 @@ pub(crate) fn save(entry: &LibraryEntry) -> Result<(), String> {
         dir.join(format!("{slug}.yaml"))
     });
 
-    let yaml = serde_yaml::to_string(entry).map_err(|e| format!("serialization error: {e}"))?;
+    // #655: the file on disk states where the entry works, including at the
+    // type's default — the same discipline `normalize_node_value` applies to a
+    // pipeline Document, so a starred node and its library file read alike.
+    let mut entry = entry.clone();
+    entry.stamp_isolation();
+    let yaml = serde_yaml::to_string(&entry).map_err(|e| format!("serialization error: {e}"))?;
     std::fs::write(&path, yaml).map_err(|e| format!("write error: {e}"))?;
     Ok(())
 }
@@ -174,7 +225,7 @@ fn find_path_by_name(dir: &Path, name: &str) -> Option<PathBuf> {
     let direct = dir.join(format!("{slug}.yaml"));
     if direct.exists() {
         if let Ok(contents) = std::fs::read_to_string(&direct) {
-            if let Ok(entry) = serde_yaml::from_str::<LibraryEntry>(&contents) {
+            if let Some(entry) = parse_entry(&contents) {
                 if entry.name == name {
                     return Some(direct);
                 }
@@ -188,7 +239,7 @@ fn find_path_by_name(dir: &Path, name: &str) -> Option<PathBuf> {
             continue;
         }
         if let Ok(contents) = std::fs::read_to_string(&path) {
-            if let Ok(lib_entry) = serde_yaml::from_str::<LibraryEntry>(&contents) {
+            if let Some(lib_entry) = parse_entry(&contents) {
                 if lib_entry.name == name {
                     return Some(path);
                 }
@@ -201,7 +252,7 @@ fn find_path_by_name(dir: &Path, name: &str) -> Option<PathBuf> {
 // #494: exercised only by this module's unit tests since demotion; kept as a tested helper.
 #[allow(dead_code)]
 pub(crate) fn entry_from_node(node: &pipeline::NodeDef, prompt: &str) -> LibraryEntry {
-    LibraryEntry {
+    let mut entry = LibraryEntry {
         name: node.name.clone(),
         node_type: node.node_type.clone(),
         inputs: node.inputs.clone(),
@@ -223,7 +274,14 @@ pub(crate) fn entry_from_node(node: &pipeline::NodeDef, prompt: &str) -> Library
         max_iter: None,
         branches: None,
         prompt: prompt.to_string(),
-    }
+        // #655/ADR-0060: the node's workspace is part of what gets starred. Read
+        // through `stamp_isolation` below, so a node whose document is silent
+        // stars as its type's default rather than as a silence — otherwise the
+        // very node that produced the entry would read `diverged` against it.
+        isolated_worktree: node.isolated_worktree,
+    };
+    entry.stamp_isolation();
+    entry
 }
 
 // #494: exercised only by this module's unit tests since demotion; kept as a tested helper.
@@ -1107,6 +1165,7 @@ mod tests {
             let entry1 = LibraryEntry {
                 name: "Alpha".to_string(),
                 node_type: pipeline::NodeType::Agent,
+                isolated_worktree: Some(true),
                 inputs: vec![],
                 outputs: vec![],
                 interactive: false,
@@ -1155,6 +1214,7 @@ mod tests {
             let entry = LibraryEntry {
                 name: "Typed Reviewer".to_string(),
                 node_type: pipeline::NodeType::Agent,
+                isolated_worktree: Some(true),
                 inputs: vec![],
                 outputs: vec![],
                 interactive: false,
@@ -1213,6 +1273,7 @@ mod tests {
         let entry = LibraryEntry {
             name: "Complex Node".to_string(),
             node_type: pipeline::NodeType::Agent,
+            isolated_worktree: Some(true),
             // #345/#296: a per-node model must round-trip losslessly.
             model: Some("opus".to_string()),
             // #424: and so must a per-node effort.
@@ -1282,6 +1343,7 @@ mod tests {
         let entry = LibraryEntry {
             name: "Plain".to_string(),
             node_type: pipeline::NodeType::Agent,
+            isolated_worktree: Some(true),
             inputs: vec![],
             outputs: vec![],
             interactive: false,
@@ -1317,6 +1379,7 @@ mod tests {
         let entry = LibraryEntry {
             name: "Plain".to_string(),
             node_type: pipeline::NodeType::Agent,
+            isolated_worktree: Some(true),
             inputs: vec![],
             outputs: vec![],
             interactive: false,
@@ -1366,12 +1429,126 @@ mod tests {
         });
     }
 
+    /// #655/ADR-0060: an entry states where it works, and the statement survives
+    /// the disk. Not "carries the field": a saved Agent parked in the Run's
+    /// worktree must come back parked there, or every instantiation would fork.
+    #[test]
+    fn isolation_round_trips_through_disk() {
+        with_temp_home(|| {
+            for (node_type, isolated) in [
+                (pipeline::NodeType::Agent, false),
+                (pipeline::NodeType::Agent, true),
+                (pipeline::NodeType::Script, true),
+                (pipeline::NodeType::Script, false),
+            ] {
+                let mut node = make_node("Traveller");
+                node.node_type = node_type.clone();
+                node.isolated_worktree = Some(isolated);
+                save(&entry_from_node(&node, "p")).unwrap();
+                assert_eq!(
+                    get("Traveller").unwrap().isolated_worktree,
+                    Some(isolated),
+                    "{node_type:?} isolated={isolated}"
+                );
+            }
+        });
+    }
+
+    /// The entry states its choice even when the node was silent about it — the
+    /// #345 discipline applied to isolation. A silence on disk would make the very
+    /// node that produced the entry read `diverged` against it.
+    #[test]
+    fn entry_from_node_stamps_the_type_default() {
+        let mut agent = make_node("Silent Agent");
+        assert_eq!(agent.isolated_worktree, None);
+        assert_eq!(
+            entry_from_node(&agent, "p").isolated_worktree,
+            Some(true),
+            "a silent agent stars as isolated"
+        );
+
+        agent.node_type = pipeline::NodeType::Script;
+        assert_eq!(
+            entry_from_node(&agent, "p").isolated_worktree,
+            Some(false),
+            "a silent script stars on the Run's worktree"
+        );
+
+        // A type that carries no isolation drops a stray value rather than
+        // round-tripping a line nobody may edit (mirrors `stamp_isolation_default`).
+        agent.node_type = pipeline::NodeType::Merge;
+        agent.isolated_worktree = Some(false);
+        assert_eq!(entry_from_node(&agent, "p").isolated_worktree, None);
+    }
+
+    /// A starred Merge/Start/End writes no isolation line at all.
+    #[test]
+    fn isolation_key_is_absent_for_types_that_carry_none() {
+        let mut node = make_node("Gatherer");
+        node.node_type = pipeline::NodeType::Merge;
+        let yaml = serde_yaml::to_string(&entry_from_node(&node, "p")).unwrap();
+        assert!(
+            !yaml.contains("isolated_worktree"),
+            "isolation leaked onto a Merge entry:\n{yaml}"
+        );
+    }
+
+    /// #655: two nodes that differ only by where they work are NOT the same
+    /// content — the star must say so. Same trap as #345/#424, one field later.
+    #[test]
+    fn sync_state_diverges_on_isolation_change() {
+        with_temp_home(|| {
+            let mut node = make_node("Worker");
+            node.isolated_worktree = Some(false);
+            save(&entry_from_node(&node, "prompt")).unwrap();
+            assert_eq!(sync_state(&node, "prompt"), SyncState::Synced);
+
+            node.isolated_worktree = Some(true);
+            assert_eq!(sync_state(&node, "prompt"), SyncState::Diverged);
+
+            // Going silent is going back to the Agent default (isolated), which
+            // still differs from the entry's explicit `false`.
+            node.isolated_worktree = None;
+            assert_eq!(sync_state(&node, "prompt"), SyncState::Diverged);
+        });
+    }
+
+    /// A pre-#655 entry file carries no isolation line. Reading it as a silence
+    /// would flip every already-starred node to `diverged` on upgrade, so the
+    /// read stamps the type's default instead — the same migration-free posture
+    /// `compute_drift` takes for pre-#395 hashes.
+    #[test]
+    fn pre_655_entry_reads_as_its_type_default() {
+        with_temp_home(|| {
+            let mut node = make_node("Legacy");
+            node.isolated_worktree = None;
+
+            // The pre-#655 file: today's entry with the isolation line removed.
+            let today = serde_yaml::to_string(&entry_from_node(&node, "p")).unwrap();
+            let legacy: String = today
+                .lines()
+                .filter(|l| !l.starts_with("isolated_worktree"))
+                .map(|l| format!("{l}\n"))
+                .collect();
+            assert_ne!(legacy, today, "the fixture must actually drop the line");
+
+            let dir = library_dir().unwrap();
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(dir.join("legacy.yaml"), legacy).unwrap();
+
+            assert_eq!(get("Legacy").unwrap().isolated_worktree, Some(true));
+            assert_eq!(list()[0].isolated_worktree, Some(true));
+            assert_eq!(sync_state(&node, "p"), SyncState::Synced);
+        });
+    }
+
     #[test]
     fn list_is_sorted_alphabetically() {
         with_temp_home(|| {
             let base = LibraryEntry {
                 name: String::new(),
                 node_type: pipeline::NodeType::Agent,
+                isolated_worktree: Some(true),
                 inputs: vec![],
                 outputs: vec![],
                 interactive: false,
@@ -1696,6 +1873,7 @@ mod tests {
         let entry = LibraryEntry {
             name: "Typed Node".to_string(),
             node_type: pipeline::NodeType::Agent,
+            isolated_worktree: Some(true),
             model: None,
             effort: None,
             inputs: vec![
@@ -1793,6 +1971,7 @@ mod tests {
             let entry = LibraryEntry {
                 name: "Schema Node".to_string(),
                 node_type: pipeline::NodeType::Agent,
+                isolated_worktree: Some(true),
                 model: None,
                 effort: None,
                 inputs: vec![pipeline::Port {
@@ -2060,6 +2239,42 @@ mod tests {
         let h1 = pipelines::content_hash(&sample_pipeline_yaml("A"), &prompts);
         let h2 = pipelines::content_hash(&sample_pipeline_yaml("B"), &prompts);
         assert_ne!(h1, h2);
+    }
+
+    /// #655/ADR-0060: isolation is content, so it moves the library's digest.
+    /// The star ignores layout (#355/#395) — but where a Node works is not
+    /// layout: a promoted pipeline whose Agent moves out of the Run's worktree
+    /// has drifted, and the badge has to say so.
+    #[test]
+    fn content_hash_changes_on_isolation_diff() {
+        let prompts = HashMap::new();
+        let shared = sample_pipeline_yaml("Same");
+        assert!(shared.contains("isolated_worktree: false"));
+        let forked = shared.replace("isolated_worktree: false", "isolated_worktree: true");
+        assert_ne!(
+            pipelines::content_hash(&shared, &prompts),
+            pipelines::content_hash(&forked, &prompts),
+            "two pipelines differing only by isolation are not the same content",
+        );
+    }
+
+    /// The other half of the same claim: a pipeline SILENT about isolation hashes
+    /// like one that spells out the default, because the parser stamps it. Without
+    /// this, saving a hand-written file from the canvas would read as drift.
+    #[test]
+    fn content_hash_ignores_a_silent_default() {
+        let prompts = HashMap::new();
+        let spelled = sample_pipeline_yaml("Same");
+        let silent = spelled.replace("    isolated_worktree: false\n", "");
+        assert_ne!(silent, spelled, "the fixture must actually drop the line");
+        // `agent` defaults to isolated, so the silence is only equivalent once the
+        // spelled-out value matches that default.
+        let spelled_default =
+            spelled.replace("isolated_worktree: false", "isolated_worktree: true");
+        assert_eq!(
+            pipelines::content_hash(&silent, &prompts),
+            pipelines::content_hash(&spelled_default, &prompts),
+        );
     }
 
     #[test]

--- a/crates/pdo-daemon/src/workflow_importer.rs
+++ b/crates/pdo-daemon/src/workflow_importer.rs
@@ -1830,6 +1830,65 @@ mod tests {
         assert!(collection[0].over.is_some(), "collection carries an `over`");
     }
 
+    /// #655/ADR-0060: every imported role is an isolated `agent`, and the YAML
+    /// says so out loud — a foreign workflow arrives without an opinion on
+    /// worktrees, and inventing one for it is the guesswork #653 retired.
+    #[test]
+    fn imported_roles_are_isolated_agents_and_the_yaml_says_so() {
+        let src = r#"agent(`Read the docs and summarise.`, { label: 'reader' })"#;
+        let (result, parsed) = import_and_parse(src, "t");
+        let node = parsed.nodes.iter().find(|n| n.name == "reader").unwrap();
+        assert_eq!(node.node_type, NodeType::Agent);
+        assert_eq!(node.isolated_worktree, Some(true));
+        assert!(
+            result.yaml_text.contains("isolated_worktree: true"),
+            "the emitted document must state the isolation:\n{}",
+            result.yaml_text
+        );
+    }
+
+    /// The four signals the pre-#653 importer used to sniff, plus the one #655
+    /// adds: a `collection` region. None of them may move the isolation — a
+    /// read-only-sounding prompt is still an isolated Agent.
+    #[test]
+    fn import_never_infers_isolation_from_prompt_name_outputs_or_collection() {
+        for (label, src) in [
+            (
+                "a read-only-sounding prompt",
+                r#"agent(`Only read the docs. Do not write, edit or commit anything.`, { label: 'reader' })"#,
+            ),
+            (
+                "a documentation-sounding name",
+                r#"agent(`work`, { label: 'docs-writer' })"#,
+            ),
+            (
+                "a schema'd output",
+                r#"agent(`work`, { label: 'reader', schema: { type: 'object', properties: { verdict: { type: 'string' } } } })"#,
+            ),
+            (
+                "a collection member",
+                r#"const items = []; await pipeline(items, (p) => agent(`per-item`, { label: 'reader' }))"#,
+            ),
+            (
+                "an annotated placeholder (N3)",
+                r#"const build = () => 'x'; agent(build(), { label: 'reader' })"#,
+            ),
+        ] {
+            let (_result, parsed) = import_and_parse(src, "t");
+            let node = parsed
+                .nodes
+                .iter()
+                .find(|n| n.node_type == NodeType::Agent)
+                .unwrap_or_else(|| panic!("{label}: no agent node"));
+            assert_eq!(node.node_type, NodeType::Agent, "{label}");
+            assert_eq!(
+                node.isolated_worktree,
+                Some(true),
+                "{label} must not move the isolation"
+            );
+        }
+    }
+
     #[test]
     fn if_equality_becomes_when_edge() {
         let src = r#"const r = await agent(`triage`, { label: 'triage' }); if (r.verdict === 'Bug') { return {} }"#;

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1441,6 +1441,10 @@ export interface LibraryEntry {
   max_iter?: number | null;
   branches?: number | null;
   prompt: string;
+  /** #655/ADR-0060: where an instance of this entry works. Always stated by the
+   * daemon for `agent`/`script` (stamped at the type's default when the entry
+   * predates #655); `null` for the types that carry no isolation. */
+  isolated_worktree?: boolean | null;
 }
 
 export function fetchLibrary(): Promise<LibraryEntry[]> {
@@ -1458,6 +1462,9 @@ export interface LibrarySaveSpec {
   /** Per-node effort override (#424). Omit/undefined ⇒ account default. */
   effort?: string | null;
   prompt: string;
+  /** #655/ADR-0060: where the starred node works. Omitted ⇒ the daemon stamps
+   * the type's default; `null` for a type that carries no isolation. */
+  isolated_worktree?: boolean | null;
 }
 
 export function saveToLibrary(spec: LibrarySaveSpec): Promise<LibraryEntry> {
@@ -1483,6 +1490,10 @@ export interface InstantiateResult {
     model?: string | null;
     /** Per-node effort override (#424). Null ⇒ account default. */
     effort?: string | null;
+    /** #655/ADR-0060: the entry's workspace, restored verbatim onto the new
+     * node. Dropping it would fall back to the type default and silently fork a
+     * worktree for an Agent starred in the Run's. */
+    isolated_worktree?: boolean | null;
   };
   prompt: string;
 }

--- a/frontend/src/components/LibraryDropdown.test.tsx
+++ b/frontend/src/components/LibraryDropdown.test.tsx
@@ -135,4 +135,56 @@ describe("LibraryDropdown", () => {
     fireEvent.click(screen.getByTestId("toolbar-library"));
     expect(screen.queryByTestId("library-add-node-from-yaml")).toBeNull();
   });
+
+  // --- #655 / ADR-0060: the library is isolation-aware -----------------------
+
+  it("names each entry's workspace in the preview", () => {
+    const entries = [
+      makeEntry("Forker"),
+      { ...makeEntry("Sharer"), isolated_worktree: false },
+      { ...makeEntry("Gatherer"), type: "merge" },
+    ];
+    renderDropdown({ entries, onDelete: vi.fn() });
+    fireEvent.click(screen.getByTestId("toolbar-library"));
+
+    // A silent entry (pre-#655 on disk) still reads as the Agent default.
+    expect(screen.getByTestId("library-workspace-isolated")).toHaveTextContent(
+      "Isolated worktree",
+    );
+    expect(screen.getByTestId("library-workspace-shared")).toHaveTextContent("Run worktree");
+    // A Merge carries no workspace, so the row shows no label to argue with.
+    expect(screen.getAllByTestId(/^library-workspace-/)).toHaveLength(2);
+    // …and each row wears its type's canvas glyph rather than a two-letter
+    // badge that only knew `agent`.
+    expect(screen.getAllByTestId("node-icon-agent")).toHaveLength(2);
+    expect(screen.getByTestId("node-icon-merge")).toBeInTheDocument();
+  });
+
+  it("restores the entry's workspace onto the dropped node", async () => {
+    const { instantiateFromLibrary } = await import("../api");
+    vi.mocked(instantiateFromLibrary).mockResolvedValueOnce({
+      spec: {
+        name: "Sharer",
+        type: "agent",
+        inputs: [],
+        outputs: [],
+        interactive: false,
+        isolated_worktree: false,
+      },
+      prompt: "test prompt",
+    });
+
+    renderDropdown({ entries: [makeEntry("Sharer")], onDelete: vi.fn() });
+    fireEvent.click(screen.getByTestId("toolbar-library"));
+    fireEvent.mouseEnter(screen.getByText("Sharer").closest("div.group")!);
+    fireEvent.click(screen.getByTitle("Add to canvas"));
+
+    await vi.waitFor(() => {
+      const tab = useEditStore.getState().openTabs[0];
+      expect(tab.pipeline.nodes).toHaveLength(1);
+      // Not `undefined`: falling back to the type default would fork a
+      // sub-worktree for an Agent its author had parked in the Run's.
+      expect(tab.pipeline.nodes[0].isolated_worktree).toBe(false);
+    });
+  });
 });

--- a/frontend/src/components/LibraryDropdown.tsx
+++ b/frontend/src/components/LibraryDropdown.tsx
@@ -4,14 +4,11 @@ import type { LibraryEntry } from "../api";
 import { instantiateFromLibrary, libraryPortToPortDef } from "../api";
 import { useEditStore } from "../stores/editStore";
 import { generateNodeId } from "../lib/nanoid";
+import { resolveIsolation, workspaceLabel } from "../lib/nodeIsolation";
+import { NodeTypeIcon } from "./NodeTypeIcon";
 import type { NodeDef, NodeType } from "../types";
 import { Tooltip } from "./ui/tooltip";
 
-const TYPE_ICONS: Record<string, string> = {
-  // #653: one agentic type, one badge. The pair of `CM`/`DO` letters was the
-  // library's echo of the retired type split.
-  "agent": "AG",
-};
 
 export default function LibraryDropdown({
   entries,
@@ -64,6 +61,10 @@ export default function LibraryDropdown({
         model: result.spec.model ?? null,
         // #424: effort-aware too.
         effort: result.spec.effort ?? null,
+        // #655/ADR-0060: and isolation-aware. Without this the dropped node
+        // falls back to its type's default, so an Agent starred in the Run's
+        // worktree would fork one of its own on every instantiation.
+        isolated_worktree: result.spec.isolated_worktree ?? null,
         view,
       };
       addNode(node);
@@ -165,6 +166,10 @@ function LibraryRow({
 }) {
   const [hovered, setHovered] = useState(false);
   const preview = entry.prompt.slice(0, 60).replace(/\n/g, " ");
+  // #655/ADR-0060: the preview names the entry's workspace, so "which of my two
+  // Reviewers is the one that shares the Run's tree?" is answered before the
+  // drop rather than after it. `null` on the types that carry no isolation.
+  const isolation = resolveIsolation(entry.type, entry.isolated_worktree);
 
   return (
     <div
@@ -172,15 +177,26 @@ function LibraryRow({
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
     >
-      <span
-        className="shrink-0 rounded bg-bg-5 px-1 py-0.5 font-mono text-fg-4"
-        style={{ fontSize: "8px" }}
-      >
-        {TYPE_ICONS[entry.type] ?? "??"}
+      {/* #655: the same glyph the canvas and the inspector use for the type.
+          The two-letter badge it replaces only knew `agent`, so a starred
+          `script` — or any other type — read `??` in its own library. */}
+      <span className="shrink-0 text-fg-4">
+        <NodeTypeIcon type={entry.type as NodeType} size={12} />
       </span>
       <div className="min-w-0 flex-1">
-        <div className="truncate font-medium text-fg" style={{ fontSize: "11px" }}>
-          {entry.name}
+        <div className="flex items-baseline gap-1.5">
+          <span className="truncate font-medium text-fg" style={{ fontSize: "11px" }}>
+            {entry.name}
+          </span>
+          {isolation !== null && (
+            <span
+              data-testid={`library-workspace-${isolation ? "isolated" : "shared"}`}
+              className="shrink-0 text-fg-4"
+              style={{ fontSize: "9px" }}
+            >
+              {workspaceLabel(isolation)}
+            </span>
+          )}
         </div>
         <div className="truncate text-fg-4" style={{ fontSize: "10px" }}>
           {preview || "No prompt"}

--- a/frontend/src/components/NodeInspector.test.tsx
+++ b/frontend/src/components/NodeInspector.test.tsx
@@ -3,7 +3,12 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import NodeInspector from "./NodeInspector";
 import type { LibraryEntry } from "../api";
-import { saveToLibrary, deleteFromLibrary, fetchSettings } from "../api";
+import {
+  saveToLibrary,
+  deleteFromLibrary,
+  fetchSettings,
+  instantiateFromLibrary,
+} from "../api";
 import { useEditStore } from "../stores/editStore";
 import { TooltipProvider } from "./ui/tooltip";
 
@@ -498,6 +503,9 @@ describe("NodeInspector StarButton — library save is independent of pipeline s
       model: null,
       // #424: effort-aware too; an effort-less node sends null.
       effort: null,
+      // #655: isolation-aware too — a node silent about its workspace stars on
+      // its type's resolved default, not on the silence.
+      isolated_worktree: true,
       prompt: "Review this code.",
     });
   });
@@ -535,6 +543,52 @@ describe("NodeInspector StarButton — library save is independent of pipeline s
       },
       { name: "empty", repeated: false, side: "right" },
     ]);
+  });
+
+  it("stars the node's chosen workspace, not its type's default (#655)", () => {
+    seedTabWithReviewer(false);
+    useEditStore.getState().openTabs[0].pipeline.nodes[0].isolated_worktree = false;
+    renderInspector({ libraryEntries: [], onLibraryChanged: () => {} });
+
+    fireEvent.click(screen.getByTitle("Save to library"));
+
+    expect(mockSave.mock.calls[0][0].isolated_worktree).toBe(false);
+  });
+
+  it("resets the workspace from the library entry (#655)", async () => {
+    // The entry parks the Agent in the Run's worktree; resetting must put the
+    // node back there rather than on the `agent` default.
+    vi.mocked(instantiateFromLibrary).mockResolvedValueOnce({
+      spec: {
+        name: "reviewer",
+        type: "agent",
+        inputs: [],
+        outputs: [],
+        interactive: false,
+        isolated_worktree: false,
+      },
+      prompt: "Review this code.",
+    });
+    const diverged: LibraryEntry = {
+      name: "reviewer",
+      type: "agent",
+      inputs: [{ name: "in", repeated: false, side: "left" }],
+      outputs: [{ name: "out", repeated: false, side: "right" }],
+      interactive: false,
+      isolated_worktree: false,
+      prompt: "Review this code.",
+    };
+    seedTabWithReviewer(false, "Review this code.");
+    renderInspector({ libraryEntries: [diverged], onLibraryChanged: () => {} });
+
+    fireEvent.click(screen.getByTitle("In your library — out of sync"));
+    fireEvent.click(screen.getByText(/Reset from library/i));
+
+    await vi.waitFor(() => {
+      expect(
+        useEditStore.getState().openTabs[0].pipeline.nodes[0].isolated_worktree,
+      ).toBe(false);
+    });
   });
 
   it("opens the popover when node is already synced with library", () => {

--- a/frontend/src/components/NodeInspector.tsx
+++ b/frontend/src/components/NodeInspector.tsx
@@ -13,7 +13,12 @@ import HarnessSelect from "./HarnessSelect";
 import ModelPicker from "./ModelPicker";
 import EffortPicker from "./EffortPicker";
 import { findHarnessOption, resolveEditorHarness } from "../lib/harness";
-import { carriesIsolation, nodeIsolation, worktreePathFor } from "../lib/nodeIsolation";
+import {
+  WORKSPACE_CHOICES,
+  carriesIsolation,
+  nodeIsolation,
+  worktreePathFor,
+} from "../lib/nodeIsolation";
 import DestroyLoopModal from "./DestroyLoopModal";
 import { derivePooledInputs } from "../lib/derivePooledInputs";
 import { regionsDestroyedByEdgeRemoval } from "../lib/loopRegions";
@@ -28,19 +33,6 @@ import type { LibrarySyncState } from "../hooks/useLibrary";
  * #653 / ADR-0060: the two places a NodeRun can work, named and described in one
  * breath. A radio pair rather than a switch — "off" would name neither place.
  */
-const WORKSPACE_CHOICES = [
-  {
-    isolated: true,
-    label: "Isolated worktree",
-    hint: "a sub-worktree of the Node's own",
-  },
-  {
-    isolated: false,
-    label: "Run worktree",
-    hint: "shared with the whole Run",
-  },
-] as const;
-
 export default function NodeInspector({
   libraryEntries,
   onLibraryChanged,
@@ -517,6 +509,10 @@ function StarButton({
       // annotation, so omitting a field here compiles fine — the star would just
       // read `diverged` forever.
       effort: node.effort ?? null,
+      // #655/ADR-0060: star where the node works, resolved (not raw) so a node
+      // sitting silently on its type's default stars on that default instead of
+      // on a silence — a silence would read `diverged` the instant it was saved.
+      isolated_worktree: nodeIsolation(node),
       prompt,
     };
   }
@@ -557,6 +553,9 @@ function StarButton({
         model: result.spec.model ?? null,
         // #424: and the effort level.
         effort: result.spec.effort ?? null,
+        // #655/ADR-0060: and the workspace — resetting to the library must put
+        // the node back where the entry says it works, not where its type would.
+        isolated_worktree: result.spec.isolated_worktree ?? null,
       });
       updatePromptFn(result.prompt);
       setPopoverOpen(false);

--- a/frontend/src/hooks/useLibrary.test.ts
+++ b/frontend/src/hooks/useLibrary.test.ts
@@ -108,6 +108,37 @@ describe("computeSyncState", () => {
     expect(computeSyncState(node, "You review code.", entries)).toBe("synced");
   });
 
+  it("returns diverged when the workspace differs (#655)", () => {
+    // Two Agents identical but for where they work are NOT the same content:
+    // one forks a sub-worktree, the other writes into the Run's. Same trap as
+    // #345/#424 — nothing but this comparison makes the star say so.
+    const node = makeNode({ isolated_worktree: false });
+    const entries = [makeEntry({ isolated_worktree: true })];
+    expect(computeSyncState(node, "You review code.", entries)).toBe("diverged");
+  });
+
+  it("returns synced when node and entry share the same workspace (#655)", () => {
+    const node = makeNode({ isolated_worktree: false });
+    const entries = [makeEntry({ isolated_worktree: false })];
+    expect(computeSyncState(node, "You review code.", entries)).toBe("synced");
+  });
+
+  it("treats a silent workspace as the type default on both sides (#655)", () => {
+    // A pre-#655 entry states no line, and a node can be silent too. Both mean
+    // "the Agent default", so the star must not read diverged on the silence.
+    expect(computeSyncState(makeNode(), "You review code.", [makeEntry()])).toBe("synced");
+    expect(
+      computeSyncState(makeNode(), "You review code.", [
+        makeEntry({ isolated_worktree: true }),
+      ]),
+    ).toBe("synced");
+    expect(
+      computeSyncState(makeNode({ isolated_worktree: false }), "You review code.", [
+        makeEntry(),
+      ]),
+    ).toBe("diverged");
+  });
+
   it("returns diverged when interactive differs", () => {
     const node = makeNode({ interactive: true });
     const entries = [makeEntry()];

--- a/frontend/src/hooks/useLibrary.ts
+++ b/frontend/src/hooks/useLibrary.ts
@@ -3,6 +3,7 @@ import { fetchLibrary } from "../api";
 import type { LibraryEntry } from "../api";
 import type { NodeDef, PortDef } from "../types";
 import { deepEqual } from "../lib/deepEqual";
+import { nodeIsolation, resolveIsolation } from "../lib/nodeIsolation";
 
 export type LibrarySyncState = "outline" | "synced" | "diverged";
 
@@ -75,6 +76,11 @@ export function computeSyncState(
     // here, and this is the verdict the user actually SEES on the star. A missing
     // field reads `synced` while the two differ: bug #345, one field later.
     (entry.effort ?? null) === (node.effort ?? null) &&
+    // #655/ADR-0060: where the node works is part of its identity — two nodes
+    // that differ only by workspace are not the same content. Compared through
+    // `resolveIsolation` on both sides so a silence and a spelled-out default
+    // read alike (an entry saved before #655 states no line).
+    resolveIsolation(entry.type, entry.isolated_worktree) === nodeIsolation(node) &&
     entry.prompt === prompt &&
     portsMatch(node.inputs, entry.inputs) &&
     portsMatch(node.outputs, entry.outputs)

--- a/frontend/src/lib/nodeIsolation.test.ts
+++ b/frontend/src/lib/nodeIsolation.test.ts
@@ -1,8 +1,11 @@
 import { describe, it, expect } from "vitest";
 import {
+  WORKSPACE_CHOICES,
   carriesIsolation,
   isNodeIsolated,
   nodeIsolation,
+  resolveIsolation,
+  workspaceLabel,
   worktreePathFor,
 } from "./nodeIsolation";
 import type { NodeDef, NodeType } from "../types";
@@ -51,5 +54,30 @@ describe("nodeIsolation (#653 / ADR-0060)", () => {
   it("resolves the two working directories by node id", () => {
     expect(worktreePathFor("spec", true)).toBe(".pdo/runs/<run>/nodes/spec/iter-<n>");
     expect(worktreePathFor("spec", false)).toBe(".pdo/runs/<run>/worktree");
+  });
+});
+
+describe("resolveIsolation — the library's door (#655)", () => {
+  it("reads a stated value, else the type default", () => {
+    expect(resolveIsolation("agent", undefined)).toBe(true);
+    expect(resolveIsolation("agent", null)).toBe(true);
+    expect(resolveIsolation("agent", false)).toBe(false);
+    expect(resolveIsolation("script", undefined)).toBe(false);
+    expect(resolveIsolation("script", true)).toBe(true);
+  });
+
+  it("gives no isolation to a type that carries none, stated or not", () => {
+    // A library entry's `type` crosses the wire as a bare string, so an unknown
+    // type must resolve to `null` rather than to a guess.
+    for (const type of ["merge", "start", "end", "switch", "loop", "nonsense"]) {
+      expect(resolveIsolation(type, undefined)).toBeNull();
+      expect(resolveIsolation(type, true)).toBeNull();
+    }
+  });
+
+  it("names each workspace once, for every surface that shows one", () => {
+    expect(workspaceLabel(true)).toBe("Isolated worktree");
+    expect(workspaceLabel(false)).toBe("Run worktree");
+    expect(WORKSPACE_CHOICES.map((c) => c.isolated)).toEqual([true, false]);
   });
 });

--- a/frontend/src/lib/nodeIsolation.ts
+++ b/frontend/src/lib/nodeIsolation.ts
@@ -31,14 +31,55 @@ export function carriesIsolation(type: NodeType): boolean {
 }
 
 /**
+ * The two places a NodeRun can work, named and described once (#653/#655). The
+ * inspector renders them as radio choices and the library preview reuses the
+ * label, so the editor speaks of a workspace in exactly one vocabulary — the
+ * "new vocabulary everywhere" #655 asks for is a shared constant, not a
+ * convention repeated per component.
+ */
+export const WORKSPACE_CHOICES = [
+  {
+    isolated: true,
+    label: "Isolated worktree",
+    hint: "a sub-worktree of the Node's own",
+  },
+  {
+    isolated: false,
+    label: "Run worktree",
+    hint: "shared with the whole Run",
+  },
+] as const;
+
+/** The label for a workspace, for a surface too small to show both choices. */
+export function workspaceLabel(isolated: boolean): string {
+  return WORKSPACE_CHOICES.find((c) => c.isolated === isolated)!.label;
+}
+
+/**
+ * Isolation resolved from a stated value and a type, with the type having the
+ * last word on whether there is a choice at all. `null` for a type that carries
+ * none — the signal the serializer uses to leave the key off and the inspector
+ * uses to hide the section.
+ *
+ * Takes the type as a bare string so the node library can call it too (#655): a
+ * `LibraryEntry.type` crosses the wire untyped, and an entry saved for an
+ * unknown type must resolve to `null` rather than to a guess.
+ */
+export function resolveIsolation(
+  type: string,
+  stated: boolean | null | undefined,
+): boolean | null {
+  const fallback = DEFAULT_ISOLATION[type as NodeType] ?? null;
+  if (fallback === null) return null;
+  return stated ?? fallback;
+}
+
+/**
  * A node's isolation as the document states it, falling back to its type's
- * default. `null` for a type that carries none — the signal the serializer uses
- * to leave the key off and the inspector uses to hide the section.
+ * default.
  */
 export function nodeIsolation(node: NodeDef): boolean | null {
-  const fallback = DEFAULT_ISOLATION[node.type] ?? null;
-  if (fallback === null) return null;
-  return node.isolated_worktree ?? fallback;
+  return resolveIsolation(node.type, node.isolated_worktree);
 }
 
 /**


### PR DESCRIPTION
Closes #655.

Une entrée de bibliothèque retombait sur le défaut de son type à chaque dépôt sur le canvas : un Agent garé dans le worktree du Run en forkait un à lui, sans le dire. `LibraryEntry` porte maintenant `isolated_worktree`, et une entrée écrite avant #655 se relit au défaut de son type — pas comme un silence, sinon toute étoile existante virait `out of sync` à l'upgrade.

- **Bibliothèque** — `parse_entry` est la porte unique du format sur disque et estampille le choix à la lecture ; `save`, `entry_from_node` et `POST /library` l'estampillent à l'écriture. `instantiate` restitue tel quel ; un type sans isolation (merge/start/end) voit une valeur parasite retirée. L'isolation entre dans l'identité de l'entrée : deux Nodes identiques au worktree près divergent, côté daemon comme côté canvas.
- **Import** — un rôle importé, placeholder annoté compris, reste un `agent` isolé. Les tests ferment les cinq signaux que l'importeur ne doit pas suivre : prompt, nom du rôle, schéma de sortie, appartenance à une région `collection`, placeholder.
- **Éditeur** — `WORKSPACE_CHOICES` descend dans `nodeIsolation.ts` ; l'aperçu de bibliothèque nomme le workspace dans le vocabulaire de l'inspecteur et porte le glyphe de type du canvas, à la place d'un badge à deux lettres qui ne connaissait que `agent`.

Version : 1.47.0 -> 1.48.0.

## Vérification

`make check` et `make test` verts (2660 tests Rust, 1968 front).

Feature Path #655 joué par un agent contre le daemon compilé depuis la branche (`v1.48.0`), sur un `HOME` et un dépôt sandbox jetables — **4/4 étapes vertes**, plus les 5 critères d'acceptation vérifiés au-delà du chemin nominal (l'isolation participe au diff sémantique, l'importeur ne devine pas, les placeholders et les Scripts portent une valeur explicite, les aperçus utilisent le nouveau vocabulaire). Aucun finding bloquant, aucune erreur console.

Deux findings hors périmètre à verser au backlog, tous deux préexistants :
- un rôle appelé par un helper inconnu (non `agent()`) disparaît à l'import sans diagnostic ;
- réimporter le même workflow crée un doublon `(2)` au lieu de proposer d'écraser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)