### PR TITLE
feat(#654): une seule livraison Git pour les Agents et les Scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,46 @@ ascendante** : la casse se signale ici et par un bump majeur, jamais en gardant 
 morts. Seule contrainte non négociable — les **données historiques restent lisibles** : un Run
 archivé s'ouvre et se chiffre quelle que soit la version qui a écrit son payload.
 
+## 1.49.0
+
+**Un seul contrat de livraison pour les Agents et les Scripts** (#654 ; ADR-0060). *Cassant.*
+Un Node ne reçoit plus aucune consigne Git : il modifie des fichiers, et le runtime livre ce
+qu'il laisse. À la complétion, PDO conserve les commits que le Node a pris lui-même, stage le
+reste avec la sémantique de `git add -A` et crée **un** commit `<node-id> iter-<N>: completed`
+sous l'identité Git configurée, sans trailer. Un Node isolé voit ensuite son sous-worktree
+mergé dans la branche du Run ; un Node non isolé a déjà commité sur place. Aucun changement
+restant ⇒ aucun commit, donc jamais de commit vide.
+
+Cette livraison est **une seule opération** que traversent les quatre chemins de complétion :
+la complétion automatique (hook `Stop` et veille de fin de tour), `pdo complete`, la complétion
+manuelle (`mark_node_done`) et la fin d'un Script. Elle s'exécute **avant** l'événement terminal,
+donc avant tout départ de l'aval : un Node isolé forké ensuite voit le travail d'un Node non
+isolé amont. La complétion manuelle ne faisait auparavant ni merge ni commit — l'asymétrie
+qu'ADR-0035 consignait comme limite acceptée disparaît.
+
+**Le refus `doc_violated_code_immutability` est supprimé, avec toutes ses surfaces.** Un Node non
+isolé qui modifie des fichiers suivis n'est plus refusé : son travail est livré. Le slug disparaît
+du corps de refus, de l'`awaiting_reason_code`, du message de `pdo complete` et du client. Le
+refus `merge_failed` est remplacé par **`delivery_failed`** (`500`), qui couvre désormais le
+staging, le commit et le merge : il appende un `NodeInterrupted`, parque le Run `awaiting_user`
+et **conserve le travail sur disque**, sans rien annuler ni nettoyer.
+
+**Le staging n'exclut rien.** PDO ne retire aucun de ses propres chemins runtime : le `.gitignore`
+du dépôt cible est l'unique politique d'exclusion. Un dépôt qui n'ignore que `.pdo/runs/` verra
+donc le blackboard (`.pdo/artifacts/`, `.pdo/prompts/`) entrer dans les commits de livraison de
+ses Nodes non isolés — ignorez `.pdo/` comme le fait ce dépôt.
+
+**Nouvel événement `node_delivered`** (`before` / `after`, les deux têtes de la branche du Run),
+projeté sur `nodes.<id>.delivery`. Le **diff par NodeRun** s'y appuie : il existe désormais pour
+tout Agent ou Script qui a livré des changements, isolé ou non, et n'est plus réservé aux Nodes
+qui possédaient une branche `pdo/sub-*`. Le sélecteur de diff de l'UI liste ce que les NodeRuns
+ont livré, plus ce qu'ils sont. Comme le diff du Run, il exclut `.pdo/`.
+
+**Posture d'outil tranchant conservée.** Plusieurs Nodes non isolés peuvent tourner en même temps :
+le runtime n'ajoute aucune sérialisation. Le premier qui complète commite tout l'état non ignoré
+alors visible, sous son propre message — l'isolation reste le moyen d'obtenir une attribution
+fiable.
+
 ## 1.48.0
 
 **L'isolation voyage par la bibliothèque et par l'import** (#655 ; ADR-0060). Une entrée de

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "1.48.0"
+version = "1.49.0"
 license = "MIT"
 description = "Prompt-Driven Orchestrator — a local daemon that runs and supervises agentic coding pipelines"
 repository = "https://github.com/Loulen/prompt-driven-orchestrator"

--- a/crates/pdo-daemon/src/admission.rs
+++ b/crates/pdo-daemon/src/admission.rs
@@ -181,6 +181,7 @@ mod tests {
                     frontmatter_retries: 0,
                     frontmatter_violations: Vec::new(),
                     missing_outputs: Vec::new(),
+                    delivery: None,
                 },
             );
         }

--- a/crates/pdo-daemon/src/boot_recovery.rs
+++ b/crates/pdo-daemon/src/boot_recovery.rs
@@ -387,6 +387,7 @@ mod tests {
                 frontmatter_retries: 0,
                 frontmatter_violations: Vec::new(),
                 missing_outputs: Vec::new(),
+                delivery: None,
             },
         );
         rs

--- a/crates/pdo-daemon/src/completion_refusal.rs
+++ b/crates/pdo-daemon/src/completion_refusal.rs
@@ -34,13 +34,12 @@ pub(crate) enum CompletionRefusal {
     /// porte le slug : c'est ce qui rend le refus lisible côté client, qui relisait
     /// jusqu'ici *tout* `409` comme `missing_outputs`.
     CompletionRejected { message: String },
-    /// Commit/merge du sous-worktree en échec — panne, pas verdict, donc `500`.
-    MergeFailed { error: String },
+    /// La livraison (#654 / ADR-0060) a échoué — staging, commit ou merge. Panne,
+    /// pas verdict, donc `500`. Un `NodeInterrupted` est déjà appendé et le Run
+    /// est parqué `AwaitingUser` : le travail reste sur disque, intact.
+    DeliveryFailed { node_id: String, error: String },
     /// Conflit de merge ; `MergeConflictDetected` + `RunFailed` déjà appendés.
     MergeConflict { node_id: String },
-    /// Node non-isolated ayant sali des fichiers suivis ; `NodeFailed` +
-    /// `RunFailed` déjà appendés.
-    DocImmutabilityViolated { node_id: String },
     /// Ports de sortie déclarés sans artefact. Le node reste vivant.
     MissingOutputs { missing: Vec<String> },
     /// Fail-fast d'un node `script` (ADR-0017) ; `NodeFailed` + `RunFailed`
@@ -51,8 +50,8 @@ pub(crate) enum CompletionRefusal {
     FrontmatterRetryPending { violations: Vec<serde_json::Value> },
     /// Un nœud a modifié un fichier **suivi** d'un dépôt secondaire read-only
     /// (#465, ADR-0042). Garde de complétion, **pas** une panne : aucun événement
-    /// terminal n'est appendé (contrairement à `DocImmutabilityViolated`), le nœud
-    /// reste vivant, l'agent nettoie le secondaire (`git checkout`) et re-complète.
+    /// terminal n'est appendé (contrairement à `DeliveryFailed`), le nœud reste
+    /// vivant, l'agent nettoie le secondaire (`git checkout`) et re-complète.
     /// `recoverable:false` par choix de #465 — le read-only d'un secondaire est un
     /// contrat, non un retry de sortie ; le slug (jamais le seul statut) discrimine.
     SecondaryRepoDirtied { alias: String, message: String },
@@ -84,9 +83,8 @@ impl CompletionRefusal {
             Self::RunNotFound => "run_not_found",
             Self::Internal { .. } => "internal_error",
             Self::CompletionRejected { .. } => "completion_rejected",
-            Self::MergeFailed { .. } => "merge_failed",
+            Self::DeliveryFailed { .. } => "delivery_failed",
             Self::MergeConflict { .. } => "merge_conflict",
-            Self::DocImmutabilityViolated { .. } => "doc_violated_code_immutability",
             Self::MissingOutputs { .. } => "missing_outputs",
             Self::ScriptValidationFailed { .. } => "script_validation_failed",
             Self::FrontmatterRetryPending { .. } => "frontmatter_retry_pending",
@@ -125,12 +123,11 @@ impl CompletionRefusal {
             Self::RunForgotten { .. } => StatusCode::GONE,
             Self::RunNotFound => StatusCode::NOT_FOUND,
             // Pannes, pas verdicts.
-            Self::Internal { .. } | Self::MergeFailed { .. } | Self::AppendFailed { .. } => {
+            Self::Internal { .. } | Self::DeliveryFailed { .. } | Self::AppendFailed { .. } => {
                 StatusCode::INTERNAL_SERVER_ERROR
             }
             Self::CompletionRejected { .. }
             | Self::MergeConflict { .. }
-            | Self::DocImmutabilityViolated { .. }
             | Self::MissingOutputs { .. }
             | Self::ScriptValidationFailed { .. }
             | Self::FrontmatterRetryPending { .. }
@@ -152,15 +149,13 @@ impl CompletionRefusal {
             Self::RunNotFound => serde_json::json!({ "message": "run not found" }),
             Self::Internal { error } => serde_json::json!({ "message": error }),
             Self::CompletionRejected { message } => serde_json::json!({ "message": message }),
-            Self::MergeFailed { error } | Self::AppendFailed { error } => {
-                serde_json::json!({ "message": error })
-            }
+            Self::AppendFailed { error } => serde_json::json!({ "message": error }),
+            Self::DeliveryFailed { node_id, error } => serde_json::json!({
+                "message": format!("failed to deliver {node_id}'s work: {error}")
+            }),
             Self::MergeConflict { node_id } => {
                 serde_json::json!({ "message": format!("merge conflict on {node_id}") })
             }
-            Self::DocImmutabilityViolated { node_id } => serde_json::json!({
-                "message": format!("non-isolated node {node_id} violated code immutability")
-            }),
             Self::MissingOutputs { missing } => serde_json::json!({ "missing": missing }),
             Self::ScriptValidationFailed { detail } => serde_json::json!({ "detail": detail }),
             Self::FrontmatterRetryPending { violations }
@@ -189,13 +184,10 @@ impl CompletionRefusal {
             Self::RunNotFound => "run not found".into(),
             Self::Internal { error } => error.clone(),
             Self::CompletionRejected { message } => message.clone(),
-            Self::MergeFailed { error } => {
-                format!("commit/merge of the sub-worktree failed: {error}")
+            Self::DeliveryFailed { node_id, error } => {
+                format!("failed to deliver {node_id}'s work: {error}")
             }
             Self::MergeConflict { node_id } => format!("merge conflict on {node_id}"),
-            Self::DocImmutabilityViolated { node_id } => {
-                format!("non-isolated node {node_id} violated code immutability")
-            }
             Self::MissingOutputs { missing } => {
                 format!("missing declared outputs: {}", missing.join(", "))
             }
@@ -269,14 +261,12 @@ mod tests {
             CompletionRefusal::CompletionRejected {
                 message: "resume the run first".into(),
             },
-            CompletionRefusal::MergeFailed {
-                error: "boom".into(),
+            CompletionRefusal::DeliveryFailed {
+                node_id: "impl".into(),
+                error: "git add -A failed".into(),
             },
             CompletionRefusal::MergeConflict {
                 node_id: "impl".into(),
-            },
-            CompletionRefusal::DocImmutabilityViolated {
-                node_id: "scribe".into(),
             },
             CompletionRefusal::MissingOutputs {
                 missing: vec!["review".into()],
@@ -317,9 +307,8 @@ mod tests {
                 CompletionRefusal::RunNotFound => "RunNotFound",
                 CompletionRefusal::Internal { .. } => "Internal",
                 CompletionRefusal::CompletionRejected { .. } => "CompletionRejected",
-                CompletionRefusal::MergeFailed { .. } => "MergeFailed",
+                CompletionRefusal::DeliveryFailed { .. } => "DeliveryFailed",
                 CompletionRefusal::MergeConflict { .. } => "MergeConflict",
-                CompletionRefusal::DocImmutabilityViolated { .. } => "DocImmutabilityViolated",
                 CompletionRefusal::MissingOutputs { .. } => "MissingOutputs",
                 CompletionRefusal::ScriptValidationFailed { .. } => "ScriptValidationFailed",
                 CompletionRefusal::FrontmatterRetryPending { .. } => "FrontmatterRetryPending",
@@ -414,7 +403,10 @@ mod tests {
                 StatusCode::INTERNAL_SERVER_ERROR,
             ),
             (
-                CompletionRefusal::MergeFailed { error: "e".into() },
+                CompletionRefusal::DeliveryFailed {
+                    node_id: "n".into(),
+                    error: "e".into(),
+                },
                 StatusCode::INTERNAL_SERVER_ERROR,
             ),
             (

--- a/crates/pdo-daemon/src/event_log.rs
+++ b/crates/pdo-daemon/src/event_log.rs
@@ -83,6 +83,16 @@ pub enum EventKind {
     /// projection materialises the node so the incident is visible. Wire form:
     /// `"node_interrupted"`.
     NodeInterrupted,
+    /// PDO delivered a NodeRun's work onto the Run's branch (#654 / ADR-0060):
+    /// its own commits kept, whatever it left behind committed under
+    /// `<node-id> iter-<N>: completed`, then merged back if it was isolated.
+    ///
+    /// Written **only when the branch actually moved** — a NodeRun that left
+    /// nothing writes no commit and no event — and always *before* the terminal
+    /// completion event, so "delivered, then done" is the order the log reads in.
+    /// Payload: `before` / `after`, the two Run-branch tips, projected onto
+    /// [`NodeState::delivery`]. Wire form: `"node_delivered"`.
+    NodeDelivered,
     MergeConflictDetected,
     /// A merge-back conflicted and was resolved **in the node's favour** instead of
     /// failing the Run (#503, ADR-0036): the node's branch had stopped being a
@@ -573,6 +583,28 @@ pub struct NodeState {
     /// byte-identical for any non-`script` failure.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub missing_outputs: Vec<String>,
+    /// #654/ADR-0060: what this NodeRun **delivered** onto the Run's branch — the
+    /// two tips its delivery moved the branch between, so `git diff before after`
+    /// is exactly its contribution.
+    ///
+    /// Present for any NodeRun that delivered changes, isolated or not; absent for
+    /// one that delivered nothing (no commit was written) and on any pre-#654 log.
+    /// It is the presence of *changes*, never the node's type or isolation, that
+    /// makes a per-node diff answerable — which is the whole point of recording it
+    /// here rather than re-deriving it from a `pdo/sub-*` branch that a
+    /// non-isolated NodeRun does not have.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub delivery: Option<NodeDelivery>,
+}
+
+/// The two Run-branch tips one delivery moved between (#654 / ADR-0060).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct NodeDelivery {
+    /// The Run branch's tip before the delivery.
+    pub before: String,
+    /// The Run branch's tip after it. Never equal to `before` — a delivery that
+    /// moved nothing records no event at all.
+    pub after: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -1417,6 +1449,7 @@ pub(crate) fn project(events: &[Event]) -> Option<RunState> {
             | EventKind::NodeAwaitingUser
             | EventKind::NodeFailed
             | EventKind::NodeInterrupted
+            | EventKind::NodeDelivered
             | EventKind::NodeStopped
             | EventKind::NodeStale
             | EventKind::NodeInvalidated
@@ -1959,6 +1992,7 @@ fn apply_node_event(state: &mut RunState, event: &Event) {
                         frontmatter_retries: 0,
                         frontmatter_violations: Vec::new(),
                         missing_outputs: Vec::new(),
+                        delivery: None,
                     });
                 node.status = NodeStatus::Waiting;
                 node.iter = iter;
@@ -1996,6 +2030,7 @@ fn apply_node_event(state: &mut RunState, event: &Event) {
                         frontmatter_retries: 0,
                         frontmatter_violations: Vec::new(),
                         missing_outputs: Vec::new(),
+                        delivery: None,
                     });
                 node.status = NodeStatus::Running;
                 node.iter = iter;
@@ -2104,6 +2139,7 @@ fn apply_node_event(state: &mut RunState, event: &Event) {
                             frontmatter_retries: 0,
                             frontmatter_violations: Vec::new(),
                             missing_outputs: Vec::new(),
+                            delivery: None,
                         },
                     );
                 }
@@ -2219,6 +2255,7 @@ fn apply_node_event(state: &mut RunState, event: &Event) {
                         frontmatter_retries: 0,
                         frontmatter_violations: Vec::new(),
                         missing_outputs: Vec::new(),
+                        delivery: None,
                     });
                 // Node-level status derives from the LATEST iteration, mirroring
                 // the `NodeFailed` #196/#212 guard: interrupting an older iter
@@ -2300,6 +2337,26 @@ fn apply_node_event(state: &mut RunState, event: &Event) {
                 }
             }
         }
+        // #654 / ADR-0060: what the delivery put on the Run's branch. Read from
+        // the payload rather than re-derived, because the tips are the only trace
+        // of a non-isolated NodeRun's contribution — it owns no branch to diff.
+        // The last delivery for the node wins: a re-run of the same node delivers
+        // again, and the diff must show the latest one.
+        EventKind::NodeDelivered => {
+            if let (Some(node_id), Some(payload)) = (&event.node_id, &event.payload) {
+                if let Some(node) = state.nodes.get_mut(node_id) {
+                    if let (Some(before), Some(after)) = (
+                        payload.get("before").and_then(|v| v.as_str()),
+                        payload.get("after").and_then(|v| v.as_str()),
+                    ) {
+                        node.delivery = Some(NodeDelivery {
+                            before: before.to_string(),
+                            after: after.to_string(),
+                        });
+                    }
+                }
+            }
+        }
         _ => {}
     }
 }
@@ -2346,6 +2403,7 @@ fn apply_switch_event(state: &mut RunState, event: &Event) {
                     frontmatter_retries: 0,
                     frontmatter_violations: Vec::new(),
                     missing_outputs: Vec::new(),
+                    delivery: None,
                 });
             node.status = NodeStatus::Completed;
             node.completed_at = Some(event.ts.clone());
@@ -3536,6 +3594,7 @@ mod tests {
             frontmatter_retries: 0,
             frontmatter_violations: vec![],
             missing_outputs: vec![],
+            delivery: None,
         };
         assert!(
             serde_json::to_value(&bare)
@@ -6500,6 +6559,7 @@ mod tests {
             frontmatter_retries: 0,
             frontmatter_violations: Vec::new(),
             missing_outputs: Vec::new(),
+            delivery: None,
         }
     }
 

--- a/crates/pdo-daemon/src/graph_resolver.rs
+++ b/crates/pdo-daemon/src/graph_resolver.rs
@@ -580,6 +580,7 @@ mod tests {
             frontmatter_retries: 0,
             frontmatter_violations: Vec::new(),
             missing_outputs: Vec::new(),
+            delivery: None,
         }
     }
 
@@ -599,6 +600,7 @@ mod tests {
             frontmatter_retries: 0,
             frontmatter_violations: Vec::new(),
             missing_outputs: Vec::new(),
+            delivery: None,
         }
     }
 

--- a/crates/pdo-daemon/src/input_resolution.rs
+++ b/crates/pdo-daemon/src/input_resolution.rs
@@ -225,6 +225,7 @@ mod tests {
             frontmatter_retries: 0,
             frontmatter_violations: Vec::new(),
             missing_outputs: Vec::new(),
+            delivery: None,
         }
     }
 

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -114,10 +114,9 @@ use tracing::{error, info, warn};
 #[cfg(test)]
 use crate::worktree_ops::{commit_and_merge_sub_worktree, create_sub_worktree};
 use crate::worktree_ops::{
-    commit_and_merge_sub_worktree_inner, create_secondary_snapshot, create_worktree,
-    remove_secondary_snapshot, rev_parse_verified, secondary_snapshot_path, sub_worktree_branch,
-    sub_worktree_path, validate_merge_resolution, worktree_dir_for_run,
-    worktree_has_tracked_changes, MergeResult,
+    create_secondary_snapshot, create_worktree, remove_secondary_snapshot, rev_parse_verified,
+    secondary_snapshot_path, sub_worktree_branch, sub_worktree_path, validate_merge_resolution,
+    worktree_dir_for_run, worktree_has_tracked_changes,
 };
 // #356: spawn primitive carved into `node_spawn`. Imported unqualified here so
 // the many construction sites (`SpawnContext { .. }`) need no per-site path
@@ -1005,8 +1004,10 @@ fn refusal_headline(slug: &str, body: &serde_json::Value) -> String {
             "your output frontmatter still did not match after the retry".into()
         }
         "script_validation_failed" => "this script node's declared outputs did not validate".into(),
-        "doc_violated_code_immutability" => {
-            "this node may not modify tracked files, and the worktree is dirty".into()
+        "delivery_failed" => {
+            "PDO could not deliver your work onto the run's branch — it is still on disk, \
+             untouched"
+                .into()
         }
         "merge_conflict" => "merging your sub-worktree into the pipeline branch conflicted".into(),
         "merge_resolution_failed" | "merge_resolver_failed" | "merge_resolver_spawned" => {
@@ -11124,11 +11125,30 @@ async fn node_diff(
         None => return (StatusCode::NOT_FOUND, "node not found").into_response(),
     };
 
-    let pipeline_branch = format!("pdo/run-{run_id}");
-    let sub_branch = sub_worktree_branch(&run_id, &node_id, node.iter);
+    // #654 / ADR-0060: the delivery is what a NodeRun contributed, so the diff is
+    // between the two Run-branch tips it moved between — the ONE answer that works
+    // for a non-isolated NodeRun (which owns no branch to diff) as well as for an
+    // isolated one. The type and the isolation never enter into it.
+    //
+    // The `pdo/sub-*` fallback is for a NodeRun that has not delivered yet: an
+    // isolated node still working, or a pre-#654 Run whose log carries no
+    // delivery. Its work is real and visible on its branch; it is just not on the
+    // Run's branch yet.
+    let (left, right) = match &node.delivery {
+        Some(d) => (d.before.clone(), d.after.clone()),
+        None => (
+            format!("pdo/run-{run_id}"),
+            sub_worktree_branch(&run_id, &node_id, node.iter),
+        ),
+    };
 
+    // `:(exclude).pdo/` mirrors `run_diff`: the blackboard artefacts are the Run's
+    // plumbing, not the node's contribution, and a delivery stages them like
+    // anything else the repo does not ignore (#654 — `.gitignore` is the target
+    // repo's policy, and PDO must not pretend otherwise at commit time; this is
+    // the *reading* surface).
     let output = match std::process::Command::new("git")
-        .args(["diff", &pipeline_branch, &sub_branch])
+        .args(["diff", &left, &right, "--", ".", ":(exclude).pdo/"])
         .current_dir(&state.repo_root)
         .output()
     {
@@ -12785,7 +12805,7 @@ async fn artifact(
 }
 
 /// Spawn the automatic merge resolver. **DEAD in production** since ADR-0006:
-/// reached only from `MergeResult::ConflictPendingResolution`, which is built only
+/// reached only from `DeliveryOutcome::ConflictPendingResolution`, which is built only
 /// under `keep_conflict == true`, which no production caller passes.
 ///
 /// Returns a typed refusal rather than a `Response` (#490, ADR-0035 §6): both its
@@ -13262,7 +13282,7 @@ async fn merge_resolver_done(state: &Arc<AppState>, run_id: &str) -> Response {
         Ok(false) => {}
         Err(e) => {
             return completion_refusal::refusal_response(
-                &completion_refusal::CompletionRefusal::MergeFailed {
+                &completion_refusal::CompletionRefusal::Internal {
                     error: format!("forgotten-run check failed: {e}"),
                 },
             );
@@ -13346,6 +13366,293 @@ fn secondary_repos_dirtied_refusal(
     None
 }
 
+/// **The** delivery of a NodeRun's work onto the Run's branch (#654 / ADR-0060).
+///
+/// Every completion path reaches this one function — `pdo complete`, the injected
+/// `Stop` hook, the liveness sweep's turn-end auto-completion, a human's *Mark
+/// complete* (`mark_node_done`) and a `script` node's own tail — and it runs
+/// **before** the terminal event is appended, therefore before any downstream node
+/// is dispatched: an isolated successor forked after this point sees a
+/// non-isolated predecessor's work.
+///
+/// PDO gives the Node no git instruction: it edits files, and the runtime delivers
+/// what it left. Whatever the node committed itself is kept as it is; whatever it
+/// left behind becomes one commit under `<node-id> iter-<N>: completed`, staged
+/// with `git add -A` semantics and the repo's own `.gitignore` as the only
+/// exclusion policy. An isolated NodeRun then has its sub-worktree merged back; a
+/// non-isolated one has already committed in place. Nothing left behind ⇒ no
+/// commit, no event, no empty commit.
+///
+/// `None` ⇒ the completion may carry on. `Some(refusal)` ⇒ it must stop, and every
+/// refusal built here has already appended its own parking events — the caller
+/// only projects it.
+#[allow(clippy::too_many_arguments)]
+async fn deliver_node_run(
+    state: &Arc<AppState>,
+    events: &[event_log::Event],
+    run_state: &event_log::RunState,
+    repo_root: &std::path::Path,
+    worktree_dir: &std::path::Path,
+    run_id: &str,
+    node_id: &str,
+    iter: i64,
+) -> Option<completion_refusal::CompletionRefusal> {
+    // #653/ADR-0060: where the NodeRun WORKED, read from its frozen isolation —
+    // not from a type that no longer implies a working directory.
+    let isolated = node_run_isolation(events, run_state, node_id, iter);
+    let node_worktree_dir = if isolated {
+        sub_worktree_path(repo_root, run_id, node_id, iter)
+    } else {
+        worktree_dir.to_path_buf()
+    };
+    let sub_branch = sub_worktree_branch(run_id, node_id, iter);
+
+    // An absent workspace is not a git failure. A Run whose worktree is gone —
+    // archived or cleaned up (ADR-0020) — has nothing to deliver in place, and
+    // parking the Run over it would punish a completion that arrives late through
+    // no fault of the node. Warn and let it through, exactly as the pre-#654
+    // cleanliness probe did. An ISOLATED NodeRun deliberately does not take this
+    // exit: its merge-back must still fail loudly if either worktree is missing,
+    // because that is #489's silent-loss guard.
+    if !isolated && !worktree_ops::is_git_worktree(worktree_dir) {
+        warn!(
+            "Run {run_id}: {} is not a git worktree — nothing to deliver for {node_id} iter-{iter}",
+            worktree_dir.display()
+        );
+        return None;
+    }
+
+    // #503 / ADR-0036: the commit an isolated sub-worktree was cut from, read off
+    // the log we already loaded. On a conflict, `worktree_ops` compares it to the
+    // pipeline branch's actual tip: still equal ⇒ the divergence is the run's own
+    // history rewritten by this node, and resolving in its favour drops nothing.
+    // No base recorded ⇒ no resolution.
+    let spawn_base = merge_action::spawn_base_sha(events, node_id, iter);
+
+    // The lock guards the *git operation*, not the nodes' work: two non-isolated
+    // NodeRuns still run side by side in the shared worktree with no runtime
+    // serialisation (ADR-0060). It only stops two deliveries from racing on the
+    // same index — which git would refuse anyway — and it is what makes "the first
+    // one to complete commits everything then visible" a statement rather than a
+    // coin toss.
+    let delivery = {
+        let _lock = state.merge_lock.lock().await;
+        worktree_ops::deliver_node_work(
+            worktree_dir,
+            &node_worktree_dir,
+            isolated,
+            &sub_branch,
+            node_id,
+            iter,
+            false,
+            spawn_base.as_deref(),
+        )
+    };
+
+    let outcome = match delivery {
+        Ok(o) => o,
+        Err(e) => {
+            // A staging, commit or merge failure is an infra give-up, never a
+            // business failure (ADR-0049): the node is `Interrupted`, the Run
+            // parks `AwaitingUser` with the reason, and the work stays on disk
+            // exactly where the node left it — nothing is reverted, nothing is
+            // cleaned.
+            let reason = format!("delivery_failed: could not deliver {node_id} iter-{iter}: {e:#}");
+            error!("{reason}");
+            let interrupt_event = event_log::Event {
+                id: None,
+                run_id: run_id.to_string(),
+                ts: event_log::now_iso(),
+                kind: event_log::EventKind::NodeInterrupted,
+                node_id: Some(node_id.to_string()),
+                iter: Some(iter),
+                payload: Some(serde_json::json!({
+                    "reason": reason,
+                    "reason_code": "delivery_failed",
+                })),
+            };
+            let _ = append_event(state, &interrupt_event).await;
+            reap_dead_node_after_run_failure(
+                state,
+                repo_root,
+                run_id,
+                node_id,
+                iter,
+                !run_state.sandbox.is_off(),
+            );
+            return Some(completion_refusal::CompletionRefusal::DeliveryFailed {
+                node_id: node_id.to_string(),
+                error: format!("{e:#}"),
+            });
+        }
+    };
+
+    match outcome {
+        // The Run's branch carries the node's work — or the node left nothing and
+        // the branch did not move. Either way the completion continues; only the
+        // first case is worth an event, and that event is what makes the NodeRun's
+        // diff answerable whatever its type or isolation.
+        worktree_ops::DeliveryOutcome::Delivered(delivered) => {
+            if delivered.changed() {
+                let event = event_log::Event {
+                    id: None,
+                    run_id: run_id.to_string(),
+                    ts: event_log::now_iso(),
+                    kind: event_log::EventKind::NodeDelivered,
+                    node_id: Some(node_id.to_string()),
+                    iter: Some(iter),
+                    payload: Some(serde_json::json!({
+                        "before": delivered.before,
+                        "after": delivered.after,
+                        "isolated": isolated,
+                    })),
+                };
+                let _ = append_event(state, &event).await;
+            } else {
+                info!("Node {node_id} iter-{iter} delivered nothing — no commit taken");
+            }
+            None
+        }
+        // #503: not a failure — but PDO rewrote a branch, so it is logged with both
+        // tips, the resolution commit and the blast radius. The completion
+        // continues exactly as a clean merge would.
+        worktree_ops::DeliveryOutcome::ResolvedInNodeFavour(adoption) => {
+            let resolved = event_log::Event {
+                id: None,
+                run_id: run_id.to_string(),
+                ts: event_log::now_iso(),
+                kind: event_log::EventKind::MergeResolvedInNodeFavour,
+                node_id: Some(node_id.to_string()),
+                iter: Some(iter),
+                payload: Some(serde_json::json!({
+                    "reason": format!(
+                        "merge-back of {node_id} conflicted on {} file(s) and was resolved in \
+                         the node's favour",
+                        adoption.conflicting_files.len(),
+                    ),
+                    "rule": worktree_ops::ADOPTION_RULE,
+                    "pipeline_tip": adoption.pipeline_tip,
+                    "node_tip": adoption.node_tip,
+                    "merge_commit": adoption.merge_commit,
+                    "conflicting_files": adoption.conflicting_files,
+                })),
+            };
+            let _ = append_event(state, &resolved).await;
+            warn!(
+                "Run {run_id}: merge-back of {node_id} resolved in the node's favour \
+                 ({} conflicting file(s)); pipeline branch now at {} (#503)",
+                adoption.conflicting_files.len(),
+                adoption.merge_commit,
+            );
+            // The adoption moved the Run's branch too, so it delivered — and the
+            // node's diff must show what landed.
+            let delivered = event_log::Event {
+                id: None,
+                run_id: run_id.to_string(),
+                ts: event_log::now_iso(),
+                kind: event_log::EventKind::NodeDelivered,
+                node_id: Some(node_id.to_string()),
+                iter: Some(iter),
+                payload: Some(serde_json::json!({
+                    "before": adoption.pipeline_tip,
+                    "after": adoption.merge_commit,
+                    "isolated": isolated,
+                })),
+            };
+            let _ = append_event(state, &delivered).await;
+            None
+        }
+        worktree_ops::DeliveryOutcome::Conflict(conflict) => {
+            let reason = format!(
+                "merge conflict on {node_id}: {} conflicting file(s) merging {} into the \
+                 pipeline branch at {}",
+                conflict.conflicting_files.len(),
+                short(&conflict.node_tip),
+                short(&conflict.pipeline_tip),
+            );
+            let conflict_event = event_log::Event {
+                id: None,
+                run_id: run_id.to_string(),
+                ts: event_log::now_iso(),
+                kind: event_log::EventKind::MergeConflictDetected,
+                node_id: Some(node_id.to_string()),
+                iter: Some(iter),
+                payload: Some(serde_json::json!({
+                    "reason": format!("conflict merging {node_id} into pipeline branch"),
+                    // #503 AC3/AC4: git's own report (stdout included — the half
+                    // that pre-#503 was dropped, and the only half a conflict
+                    // writes), the two tips, and the file list.
+                    "detail": conflict.detail,
+                    "pipeline_tip": conflict.pipeline_tip,
+                    "node_tip": conflict.node_tip,
+                    "conflicting_files": conflict.conflicting_files,
+                })),
+            };
+            let _ = append_event(state, &conflict_event).await;
+
+            // #503 AC5 / ADR-0049: the delivery just failed on a merge conflict — a
+            // runtime give-up, NOT a business failure. Mark the node `Interrupted`
+            // (not `Failed`): the run parks `AwaitingUser` with the reason (derived
+            // in `finalize`), never `RunFailed`. This still closes the window where
+            // the node stayed projected `running` for ever with a live session and
+            // a UI offering Stop/Retry; the worktree with the conflicting work is
+            // preserved for the human to resolve and reopen.
+            let node_interrupted = event_log::Event {
+                id: None,
+                run_id: run_id.to_string(),
+                ts: event_log::now_iso(),
+                kind: event_log::EventKind::NodeInterrupted,
+                node_id: Some(node_id.to_string()),
+                iter: Some(iter),
+                // #601: prefix the refusal slug so `finalize` derives
+                // `awaiting_reason_code = merge_conflict` from the node.
+                payload: Some(serde_json::json!({
+                    "reason": format!("merge_conflict: {reason}"),
+                    "reason_code": "merge_conflict",
+                })),
+            };
+            let _ = append_event(state, &node_interrupted).await;
+
+            warn!("Merge conflict for node {node_id} in run {run_id}: {reason}");
+            reap_dead_node_after_run_failure(
+                state,
+                repo_root,
+                run_id,
+                node_id,
+                iter,
+                !run_state.sandbox.is_off(),
+            );
+            Some(completion_refusal::CompletionRefusal::MergeConflict {
+                node_id: node_id.to_string(),
+            })
+        }
+        worktree_ops::DeliveryOutcome::ConflictPendingResolution(conflict) => {
+            let conflict_event = event_log::Event {
+                id: None,
+                run_id: run_id.to_string(),
+                ts: event_log::now_iso(),
+                kind: event_log::EventKind::MergeConflictDetected,
+                node_id: Some(node_id.to_string()),
+                iter: Some(iter),
+                payload: Some(serde_json::json!({
+                    "reason": format!("conflict merging {node_id} into pipeline branch"),
+                    "detail": conflict.detail,
+                    "pipeline_tip": conflict.pipeline_tip,
+                    "node_tip": conflict.node_tip,
+                    "conflicting_files": conflict.conflicting_files,
+                })),
+            };
+            let _ = append_event(state, &conflict_event).await;
+
+            // DEAD in production (ADR-0035 §6): `keep_conflict` is never `true`, so
+            // `ConflictPendingResolution` is never built. The two resolver arms
+            // ride the type at zero test cost; removing the whole vestigial
+            // subsystem is ADR-0006 fallout, not this ticket.
+            Some(spawn_merge_resolver(state, run_id, node_id, iter, worktree_dir).await)
+        }
+    }
+}
+
 async fn complete_node_iteration(
     state: &Arc<AppState>,
     run_id: String,
@@ -13369,11 +13676,9 @@ async fn complete_node_iteration(
         }
         Ok(false) => {}
         Err(e) => {
-            return CompletionAttempt::refused(
-                completion_refusal::CompletionRefusal::MergeFailed {
-                    error: format!("forgotten-run check failed: {e}"),
-                },
-            );
+            return CompletionAttempt::refused(completion_refusal::CompletionRefusal::Internal {
+                error: format!("forgotten-run check failed: {e}"),
+            });
         }
     }
 
@@ -13437,223 +13742,21 @@ async fn complete_node_iteration(
         return CompletionAttempt::refused(refusal);
     }
 
-    // #653/ADR-0060: the completion path branches on where the NodeRun WORKED,
-    // read from its frozen isolation — not on a type that no longer implies a
-    // working directory. An isolated NodeRun merges its sub-worktree back; a
-    // non-isolated one is held to the shared worktree's cleanliness contract.
-    match node_run_isolation(&events, &pre_run_state, &node_id, iter) {
-        true => {
-            let sub_wt_dir = sub_worktree_path(&repo_root, &run_id, &node_id, iter);
-            let sub_branch = sub_worktree_branch(&run_id, &node_id, iter);
-
-            // #503 / ADR-0036: the commit this sub-worktree was cut from, read off
-            // the log we already loaded. On a conflict, `worktree_ops` compares it
-            // to the pipeline branch's actual tip: still equal ⇒ the divergence is
-            // the run's own history rewritten by this node, and resolving in its
-            // favour drops nothing. No base recorded ⇒ no resolution.
-            let spawn_base = merge_action::spawn_base_sha(&events, &node_id, iter);
-
-            let _lock = state.merge_lock.lock().await;
-            let merge_result = match commit_and_merge_sub_worktree_inner(
-                &sub_wt_dir,
-                &worktree_dir,
-                &sub_branch,
-                &node_id,
-                iter,
-                false,
-                spawn_base.as_deref(),
-            ) {
-                Ok(r) => r,
-                Err(e) => {
-                    error!("failed to commit/merge sub-worktree for {node_id}: {e}");
-                    return CompletionAttempt::refused(
-                        completion_refusal::CompletionRefusal::MergeFailed {
-                            error: e.to_string(),
-                        },
-                    );
-                }
-            };
-            match merge_result {
-                MergeResult::Success => {}
-                // #503: not a failure — but PDO rewrote a branch, so it is logged
-                // with both tips, the resolution commit and the blast radius. The
-                // completion continues exactly as a clean merge would.
-                MergeResult::ResolvedInNodeFavour(adoption) => {
-                    let resolved = event_log::Event {
-                        id: None,
-                        run_id: run_id.clone(),
-                        ts: event_log::now_iso(),
-                        kind: event_log::EventKind::MergeResolvedInNodeFavour,
-                        node_id: Some(node_id.clone()),
-                        iter: Some(iter),
-                        payload: Some(serde_json::json!({
-                            "reason": format!(
-                                "merge-back of {node_id} conflicted on {} file(s) and was \
-                                 resolved in the node's favour",
-                                adoption.conflicting_files.len(),
-                            ),
-                            "rule": worktree_ops::ADOPTION_RULE,
-                            "pipeline_tip": adoption.pipeline_tip,
-                            "node_tip": adoption.node_tip,
-                            "merge_commit": adoption.merge_commit,
-                            "conflicting_files": adoption.conflicting_files,
-                        })),
-                    };
-                    let _ = append_event(state, &resolved).await;
-                    warn!(
-                        "Run {run_id}: merge-back of {node_id} resolved in the node's favour \
-                         ({} conflicting file(s)); pipeline branch now at {} (#503)",
-                        adoption.conflicting_files.len(),
-                        adoption.merge_commit,
-                    );
-                }
-                MergeResult::Conflict(conflict) => {
-                    let reason = format!(
-                        "merge conflict on {node_id}: {} conflicting file(s) merging {} into the \
-                         pipeline branch at {}",
-                        conflict.conflicting_files.len(),
-                        short(&conflict.node_tip),
-                        short(&conflict.pipeline_tip),
-                    );
-                    let conflict_event = event_log::Event {
-                        id: None,
-                        run_id: run_id.clone(),
-                        ts: event_log::now_iso(),
-                        kind: event_log::EventKind::MergeConflictDetected,
-                        node_id: Some(node_id.clone()),
-                        iter: Some(iter),
-                        payload: Some(serde_json::json!({
-                            "reason": format!("conflict merging {node_id} into pipeline branch"),
-                            // #503 AC3/AC4: git's own report (stdout included — the
-                            // half that pre-#503 was dropped, and the only half a
-                            // conflict writes), the two tips, and the file list.
-                            "detail": conflict.detail,
-                            "pipeline_tip": conflict.pipeline_tip,
-                            "node_tip": conflict.node_tip,
-                            "conflicting_files": conflict.conflicting_files,
-                        })),
-                    };
-                    let _ = append_event(state, &conflict_event).await;
-
-                    // #503 AC5 / ADR-0049: the node's `pdo complete` just failed on
-                    // a merge conflict — a runtime give-up, NOT a business failure.
-                    // Mark the node `Interrupted` (not `Failed`): the run parks
-                    // `AwaitingUser` with the reason (derived in `finalize`), never
-                    // `RunFailed`. This still closes the window where the node stayed
-                    // projected `running` for ever with a live session and a UI
-                    // offering Stop/Retry; the worktree with the conflicting work is
-                    // preserved for the human to resolve and reopen.
-                    let node_interrupted = event_log::Event {
-                        id: None,
-                        run_id: run_id.clone(),
-                        ts: event_log::now_iso(),
-                        kind: event_log::EventKind::NodeInterrupted,
-                        node_id: Some(node_id.clone()),
-                        iter: Some(iter),
-                        // #601: prefix the refusal slug so `finalize` derives
-                        // `awaiting_reason_code = merge_conflict` from the node.
-                        payload: Some(serde_json::json!({
-                            "reason": format!("merge_conflict: {reason}"),
-                            "reason_code": "merge_conflict",
-                        })),
-                    };
-                    let _ = append_event(state, &node_interrupted).await;
-
-                    warn!("Merge conflict for node {node_id} in run {run_id}: {reason}");
-                    reap_dead_node_after_run_failure(
-                        state,
-                        &repo_root,
-                        &run_id,
-                        &node_id,
-                        iter,
-                        !pre_run_state.sandbox.is_off(),
-                    );
-                    return CompletionAttempt::refused(
-                        completion_refusal::CompletionRefusal::MergeConflict {
-                            node_id: node_id.clone(),
-                        },
-                    );
-                }
-                MergeResult::ConflictPendingResolution(conflict) => {
-                    let conflict_event = event_log::Event {
-                        id: None,
-                        run_id: run_id.clone(),
-                        ts: event_log::now_iso(),
-                        kind: event_log::EventKind::MergeConflictDetected,
-                        node_id: Some(node_id.clone()),
-                        iter: Some(iter),
-                        payload: Some(serde_json::json!({
-                            "reason": format!("conflict merging {node_id} into pipeline branch"),
-                            "detail": conflict.detail,
-                            "pipeline_tip": conflict.pipeline_tip,
-                            "node_tip": conflict.node_tip,
-                            "conflicting_files": conflict.conflicting_files,
-                        })),
-                    };
-                    let _ = append_event(state, &conflict_event).await;
-
-                    // DEAD in production (ADR-0035 §6): `keep_conflict` is never
-                    // `true`, so `ConflictPendingResolution` is never built. The two
-                    // resolver arms ride the new type at zero test cost; removing
-                    // the whole vestigial subsystem is ADR-0006 fallout, not this
-                    // bug fix.
-                    return CompletionAttempt::refused(
-                        spawn_merge_resolver(state, &run_id, &node_id, iter, &worktree_dir).await,
-                    );
-                }
-            }
-        }
-        // A non-isolated agent or script runs in the Run's shared worktree and
-        // must leave tracked files clean (untracked artifacts are fine — the
-        // guard ignores `??`). The sharp-tool caveat (a node that `git commit`s
-        // leaves a clean tree and passes) is documented in ADR-0017. #654 turns
-        // this refusal into an in-place delivery; until then a shared worktree
-        // keeps the contract it had.
-        false => match worktree_has_tracked_changes(&worktree_dir) {
-            Ok(true) => {
-                // ADR-0049: a completion refusal is a runtime give-up, not a
-                // deliberate failure — `Interrupted`, never `Failed`. The run
-                // parks `AwaitingUser` (derived in `finalize`) so the human can
-                // fix the tracked-file violation and reopen.
-                let interrupt_event = event_log::Event {
-                    id: None,
-                    run_id: run_id.clone(),
-                    ts: event_log::now_iso(),
-                    kind: event_log::EventKind::NodeInterrupted,
-                    node_id: Some(node_id.clone()),
-                    iter: Some(iter),
-                    payload: Some(serde_json::json!({
-                        "reason": format!(
-                            "doc_violated_code_immutability: non-isolated node {node_id} \
-                             violated code immutability (modified tracked files)"
-                        ),
-                        "reason_code": "doc_violated_code_immutability",
-                    })),
-                };
-                let _ = append_event(state, &interrupt_event).await;
-
-                warn!("Non-isolated node {node_id} modified tracked files in run {run_id}");
-                // Same leak as the merge-conflict path (#503 AC5): this refusal
-                // parks the Run, so the node's session has nothing left to do.
-                reap_dead_node_after_run_failure(
-                    state,
-                    &repo_root,
-                    &run_id,
-                    &node_id,
-                    iter,
-                    !pre_run_state.sandbox.is_off(),
-                );
-                return CompletionAttempt::refused(
-                    completion_refusal::CompletionRefusal::DocImmutabilityViolated {
-                        node_id: node_id.clone(),
-                    },
-                );
-            }
-            Ok(false) => {}
-            Err(e) => {
-                warn!("Could not check worktree cleanliness for {node_id}: {e}");
-            }
-        },
+    // #654 / ADR-0060: the ONE delivery every completion path goes through, run
+    // before the terminal event and therefore before any downstream spawn.
+    if let Some(refusal) = deliver_node_run(
+        state,
+        &events,
+        &pre_run_state,
+        &repo_root,
+        &worktree_dir,
+        &run_id,
+        &node_id,
+        iter,
+    )
+    .await
+    {
+        return CompletionAttempt::refused(refusal);
     }
 
     let pipeline_path =
@@ -17452,15 +17555,15 @@ fn short(sha: &str) -> &str {
 
 /// Reap the session of a node whose completion just killed the Run (#503 AC5).
 ///
-/// Called from the refusal paths that append `RunFailed` — a merge-back conflict
-/// and a non-isolated immutability violation. Those return a refusal *to a
-/// `pdo complete` running inside the very session being killed*, so the kill has
-/// to outlive this request: detached, exactly like `node_done`'s reap (#304,
-/// ADR-0023), or the response never reaches the CLI and #490's exit codes lose
-/// their meaning.
+/// Called from the refusal paths that park the Run — a merge-back conflict and a
+/// failed delivery (#654). Those return a refusal *to a `pdo complete` running
+/// inside the very session being killed*, so the kill has to outlive this request:
+/// detached, exactly like `node_done`'s reap (#304, ADR-0023), or the response
+/// never reaches the CLI and #490's exit codes lose their meaning.
 ///
-/// Not called on the `MergeFailed` error path: that one leaves the Run alive and
-/// the agent free to retry, so its session is still doing something.
+/// Not called on the still-your-turn refusals (a missing output, a frontmatter
+/// retry): those leave the Run alive and the agent free to fix and re-complete, so
+/// its session is still doing something.
 fn reap_dead_node_after_run_failure(
     state: &Arc<AppState>,
     repo_root: &std::path::Path,
@@ -22229,7 +22332,7 @@ mod tests {
         std::fs::write(sub_wt_dir.join("foo.rs"), "fn main() {}\n").unwrap();
         let result =
             commit_and_merge_sub_worktree(&sub_wt_dir, &wt_dir, &sub_branch, "impl-1", 1).unwrap();
-        assert!(matches!(result, MergeResult::Success));
+        assert!(matches!(result, worktree_ops::MergeResult::Success));
 
         // Sub-worktree must exist before cleanup (refs #32)
         assert!(sub_wt_dir.exists());
@@ -23407,6 +23510,7 @@ mod tests {
                 frontmatter_retries: 0,
                 frontmatter_violations: Vec::new(),
                 missing_outputs: Vec::new(),
+                delivery: None,
             },
         );
         rs
@@ -23626,6 +23730,7 @@ mod tests {
                 frontmatter_retries: 0,
                 frontmatter_violations: Vec::new(),
                 missing_outputs: Vec::new(),
+                delivery: None,
             },
         );
         // An open loop region (exhausted at max_iter, not done) awaiting a route.
@@ -23683,6 +23788,7 @@ mod tests {
                 frontmatter_retries: 0,
                 frontmatter_violations: Vec::new(),
                 missing_outputs: Vec::new(),
+                delivery: None,
             },
         );
         // Node `b` is throttled `Waiting`: ready but no admission slot yet. No
@@ -23705,6 +23811,7 @@ mod tests {
                 frontmatter_retries: 0,
                 frontmatter_violations: Vec::new(),
                 missing_outputs: Vec::new(),
+                delivery: None,
             },
         );
 
@@ -23941,6 +24048,7 @@ mod tests {
                     frontmatter_retries: 0,
                     frontmatter_violations: Vec::new(),
                     missing_outputs: Vec::new(),
+                    delivery: None,
                 },
             );
         }
@@ -27284,7 +27392,7 @@ edges:
         std::fs::write(sub_wt_dir.join("foo.rs"), "fn main() {}\n").unwrap();
         let result =
             commit_and_merge_sub_worktree(&sub_wt_dir, &wt_dir, &sub_branch, "impl-1", 1).unwrap();
-        assert!(matches!(result, MergeResult::Success));
+        assert!(matches!(result, worktree_ops::MergeResult::Success));
 
         // Prompt endpoint must return 200 for the completed iter
         let app = build_router(state);
@@ -35965,31 +36073,37 @@ edges:
             .contains("output validation after retry"));
     }
 
-    /// New coverage: no test reached the non-isolated immutability arm before #490. It
-    /// needs a real git worktree with a dirty **tracked** file (an untracked artefact
-    /// is ignored by the guard).
+    /// #654 / ADR-0060: the inverse of the pre-#654 test that lived here. A
+    /// non-isolated NodeRun that modifies a TRACKED file is no longer refused —
+    /// PDO commits its work onto the Run's branch and the completion goes
+    /// through, on `POST …/done` and on the `mark_node_done` command arm alike.
     #[tokio::test]
-    async fn shared_worktree_immutability_violation_is_409_not_200() {
+    async fn a_shared_worktree_node_that_dirties_a_tracked_file_is_delivered_not_refused() {
         let tmp = tempfile::tempdir().unwrap();
         let repo = tmp.path();
         init_git_repo_for_refusal_tests(repo);
-        let pipe = "doc-immutability";
+        let pipe = "shared-delivery";
         write_pipeline_with_outputs(repo, pipe);
 
         let state = test_state_with_dir(repo).await;
-        let run_id = "doc-immutability-run";
+        let run_id = "shared-delivery-run";
         let wt_dir = worktree_dir_for_run(repo, run_id);
-        create_worktree(repo, &wt_dir, &format!("pdo/run-{run_id}"), "HEAD").unwrap();
-        // Dirty a TRACKED file from inside the run's worktree.
+        let pipeline_branch = format!("pdo/run-{run_id}");
+        create_worktree(repo, &wt_dir, &pipeline_branch, "HEAD").unwrap();
+        // A tracked file modified AND a brand-new untracked one: both are the
+        // node's work, and `git add -A` takes both.
         std::fs::write(
             wt_dir.join("tracked.txt"),
             "mutated by a non-isolated node\n",
         )
         .unwrap();
+        std::fs::write(wt_dir.join("brand_new.rs"), "pub fn added() {}\n").unwrap();
         assert!(worktree_has_tracked_changes(&wt_dir).unwrap());
+        write_artifact_for(repo, run_id, "worker", "summary", "s\n");
+        write_artifact_for(repo, run_id, "worker", "report", "r\n");
 
-        // `find_node_type` reads the PROJECTED node defs, not the YAML on disk, so
-        // the cleanliness arm is only reached when `RunStarted` carries them.
+        // The isolation is read from the PROJECTED node defs, so `RunStarted` has
+        // to carry them.
         for event in [
             event_log::Event {
                 id: None,
@@ -36019,45 +36133,143 @@ edges:
             append_event(&state, &event).await.unwrap();
         }
 
-        let (status, ct, raw) = done_triplet(&state, run_id, "worker", "{}").await;
-        assert_eq!((status, ct.as_str()), (StatusCode::CONFLICT, JSON_CT));
-        let body: serde_json::Value = serde_json::from_str(&raw).unwrap();
-        assert_eq!(body["error"], "doc_violated_code_immutability");
-        assert_eq!(body["recoverable"], false);
-        assert!(body["message"]
-            .as_str()
-            .unwrap()
-            .contains("code immutability"));
+        let (status, _, _) = done_triplet(&state, run_id, "worker", "{}").await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "a non-isolated node that edited files must complete, not be refused"
+        );
 
-        // ADR-0049: the refusal parks the run (NodeInterrupted → AwaitingUser),
-        // it never fails it.
+        // The commit landed on the Run's branch, under the deterministic message.
+        let log = std::process::Command::new("git")
+            .args(["log", "--format=%s", "-1", &pipeline_branch])
+            .current_dir(repo)
+            .output()
+            .unwrap();
+        assert_eq!(
+            String::from_utf8_lossy(&log.stdout).trim(),
+            "worker iter-1: completed"
+        );
+        // …and it carries BOTH the tracked edit and the new file.
+        let files = std::process::Command::new("git")
+            .args(["show", "--name-only", "--format=", &pipeline_branch])
+            .current_dir(repo)
+            .output()
+            .unwrap();
+        let files = String::from_utf8_lossy(&files.stdout);
+        assert!(
+            files.contains("tracked.txt") && files.contains("brand_new.rs"),
+            "the delivery commits every non-ignored change; got: {files}"
+        );
+
+        // The delivery is recorded, before the terminal event, with both tips.
+        let events = load_events(&state.db, run_id).await.unwrap();
+        let delivered_at = events
+            .iter()
+            .position(|e| e.kind == event_log::EventKind::NodeDelivered)
+            .expect("a delivery that moved the branch records NodeDelivered");
+        let completed_at = events
+            .iter()
+            .position(|e| e.kind == event_log::EventKind::NodeCompleted)
+            .expect("the node completed");
+        assert!(
+            delivered_at < completed_at,
+            "the delivery must precede the terminal event"
+        );
+        let projected = event_log::project(&events).unwrap();
+        let delivery = projected.nodes["worker"]
+            .delivery
+            .as_ref()
+            .expect("the projection carries the delivery");
+        assert_ne!(delivery.before, delivery.after);
+        assert!(!events
+            .iter()
+            .any(|e| e.kind == event_log::EventKind::NodeInterrupted));
+    }
+
+    /// #654: a NodeRun that left nothing takes NO commit — the Run's branch does
+    /// not move and no `NodeDelivered` is recorded.
+    #[tokio::test]
+    async fn a_node_that_left_nothing_takes_no_commit() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path();
+        init_git_repo_for_refusal_tests(repo);
+        // No declared output port: this test is about the delivery, not about
+        // output validation.
+        let pipe = "shared-noop";
+        let pipelines_dir = repo.join(".pdo").join("pipelines");
+        std::fs::create_dir_all(&pipelines_dir).unwrap();
+        std::fs::write(
+            pipelines_dir.join(format!("{pipe}.yaml")),
+            format!(
+                "name: {pipe}\nversion: \"1.0\"\nnodes:\n{START_END_YAML}  - id: worker\n    name: worker\n    type: agent\n    isolated_worktree: false\n    inputs:\n      - name: task\nedges: []\n"
+            ),
+        )
+        .unwrap();
+
+        let state = test_state_with_dir(repo).await;
+        let run_id = "shared-noop-run";
+        let wt_dir = worktree_dir_for_run(repo, run_id);
+        let pipeline_branch = format!("pdo/run-{run_id}");
+        create_worktree(repo, &wt_dir, &pipeline_branch, "HEAD").unwrap();
+        let tip_before = std::process::Command::new("git")
+            .args(["rev-parse", &pipeline_branch])
+            .current_dir(repo)
+            .output()
+            .unwrap();
+        let tip_before = String::from_utf8_lossy(&tip_before.stdout)
+            .trim()
+            .to_string();
+
+        for event in [
+            event_log::Event {
+                id: None,
+                run_id: run_id.into(),
+                ts: event_log::now_iso(),
+                kind: event_log::EventKind::RunStarted,
+                node_id: None,
+                iter: None,
+                payload: Some(serde_json::json!({
+                    "pipeline_name": pipe,
+                    "node_defs": [
+                        { "id": "worker", "node_type": "agent", "isolated_worktree": false, "inputs": [], "outputs": [] }
+                    ],
+                    "edges": [],
+                })),
+            },
+            event_log::Event {
+                id: None,
+                run_id: run_id.into(),
+                ts: event_log::now_iso(),
+                kind: event_log::EventKind::NodeStarted,
+                node_id: Some("worker".into()),
+                iter: Some(1),
+                payload: None,
+            },
+        ] {
+            append_event(&state, &event).await.unwrap();
+        }
+
+        let (status, _, _) = done_triplet(&state, run_id, "worker", "{}").await;
+        assert_eq!(status, StatusCode::OK);
+
+        let tip_after = std::process::Command::new("git")
+            .args(["rev-parse", &pipeline_branch])
+            .current_dir(repo)
+            .output()
+            .unwrap();
+        assert_eq!(
+            String::from_utf8_lossy(&tip_after.stdout).trim(),
+            tip_before,
+            "no change ⇒ no commit, empty or otherwise"
+        );
         let events = load_events(&state.db, run_id).await.unwrap();
         assert!(
             !events
                 .iter()
-                .any(|e| e.kind == event_log::EventKind::RunFailed),
-            "the runtime never fails the run on a completion refusal (ADR-0049)"
+                .any(|e| e.kind == event_log::EventKind::NodeDelivered),
+            "a no-op delivery records nothing"
         );
-        assert_eq!(
-            events
-                .iter()
-                .filter(|e| e.kind == event_log::EventKind::NodeInterrupted
-                    && e.node_id.as_deref() == Some("worker"))
-                .count(),
-            1
-        );
-        assert_eq!(
-            event_log::project(&events).unwrap().status,
-            event_log::RunStatus::AwaitingUser
-        );
-
-        // Route asymmetry, asserted rather than assumed (ADR-0035, accepted limit):
-        // the command arm runs neither the merge nor the cleanliness check, so it
-        // cannot reach this refusal — it falls straight through to output validation.
-        let (cmd_status, _, cmd_raw) = mark_done_triplet(&state, run_id, "worker").await;
-        let cmd_body: serde_json::Value = serde_json::from_str(&cmd_raw).unwrap();
-        assert_eq!(cmd_status, StatusCode::CONFLICT);
-        assert_ne!(cmd_body["error"], "doc_violated_code_immutability");
     }
 
     /// New coverage: no test reached the merge-conflict arm before #490 either. Two

--- a/crates/pdo-daemon/src/mutation_validator.rs
+++ b/crates/pdo-daemon/src/mutation_validator.rs
@@ -277,6 +277,7 @@ mod tests {
                     frontmatter_retries: 0,
                     frontmatter_violations: vec![],
                     missing_outputs: vec![],
+                    delivery: None,
                 },
             );
         }

--- a/crates/pdo-daemon/src/node_io_resolver.rs
+++ b/crates/pdo-daemon/src/node_io_resolver.rs
@@ -319,6 +319,7 @@ mod tests {
             frontmatter_retries: 0,
             frontmatter_violations: Vec::new(),
             missing_outputs: Vec::new(),
+            delivery: None,
         };
         let mut s = RunState::new("run-1".into(), "test".into());
         s.nodes.insert(node_id.to_string(), node);

--- a/crates/pdo-daemon/src/node_primitives.rs
+++ b/crates/pdo-daemon/src/node_primitives.rs
@@ -330,6 +330,10 @@ pub(crate) fn start_node(params: &StartNodeParams<'_>) -> StartNodeResult {
         daemon_url: &crate::sandbox_container::daemon_url(params.daemon_port, sandboxed),
         foreach_context: None,
         source_worktree_dir: has_sub_worktree.then_some(working_dir.as_path()),
+        // #654: the same section, from the other isolation. This site only
+        // ever builds a preamble for a node that spawns a session, so the
+        // two are exhaustive and mutually exclusive.
+        shared_worktree_dir: (!has_sub_worktree).then_some(working_dir.as_path()),
         input_images: Vec::new(),
         start_prompt_present,
         source_iters: crate::input_resolution::resolved_source_iters(
@@ -657,7 +661,7 @@ fn resolve_inputs(
     let mut input_paths = HashMap::new();
 
     // #486 / #600: overrides win over any edge resolution AND cover **emergent**
-    // input ports. A `DocOnly`/`CodeMutating`/`Script` node declares no `inputs`
+    // input ports. An `Agent`/`Script` node declares no `inputs`
     // (its inputs are derived from incoming edges), so keying overrides only off
     // `node.inputs` would silently drop an operator's dummy input on exactly those
     // nodes. Insert every override first — the declared-port loop below then fills
@@ -1058,6 +1062,7 @@ mod tests {
             frontmatter_retries: 0,
             frontmatter_violations: Vec::new(),
             missing_outputs: Vec::new(),
+            delivery: None,
         }
     }
 
@@ -1082,6 +1087,7 @@ mod tests {
             frontmatter_retries: 0,
             frontmatter_violations: Vec::new(),
             missing_outputs: Vec::new(),
+            delivery: None,
         }
     }
 
@@ -1101,6 +1107,7 @@ mod tests {
             frontmatter_retries: 0,
             frontmatter_violations: Vec::new(),
             missing_outputs: Vec::new(),
+            delivery: None,
         }
     }
 
@@ -1441,7 +1448,7 @@ mod tests {
 
     #[test]
     fn override_applies_to_an_emergent_input_port() {
-        // #486 / #600: a DocOnly/CodeMutating node declares NO input ports (its
+        // #486 / #600: an `agent` node declares NO input ports (its
         // inputs are emergent from edges), so an override keyed on the edge's target
         // port must still attach — otherwise the operator's dummy input is silently
         // dropped on exactly those nodes.
@@ -1705,6 +1712,7 @@ mod tests {
             frontmatter_retries: 0,
             frontmatter_violations: Vec::new(),
             missing_outputs: Vec::new(),
+            delivery: None,
         }
     }
 

--- a/crates/pdo-daemon/src/node_spawn.rs
+++ b/crates/pdo-daemon/src/node_spawn.rs
@@ -771,6 +771,10 @@ pub(crate) async fn spawn_node(
             daemon_url: &crate::sandbox_container::daemon_url(deps.port, run_sandboxed),
             foreach_context,
             source_worktree_dir: has_sub_worktree.then_some(working_dir.as_path()),
+            // #654: the same section, from the other isolation. This site only
+            // ever builds a preamble for a node that spawns a session, so the
+            // two are exhaustive and mutually exclusive.
+            shared_worktree_dir: (!has_sub_worktree).then_some(working_dir.as_path()),
             input_images,
             start_prompt_present,
             source_iters,

--- a/crates/pdo-daemon/src/prompt_augmenter.rs
+++ b/crates/pdo-daemon/src/prompt_augmenter.rs
@@ -84,6 +84,11 @@ pub(crate) struct AugmentContext<'a> {
     /// agent must edit in. Set to `None` for nodes that run directly in the
     /// pipeline worktree (non-isolated, switch, loop, etc.).
     pub source_worktree_dir: Option<&'a Path>,
+    /// For a NON-isolated agent/script (#654 / ADR-0060): the Run's shared
+    /// worktree it works in. Mutually exclusive with `source_worktree_dir` — the
+    /// two render the same "Source code edits" section from the two isolations —
+    /// and `None` for anything that spawns no session.
+    pub shared_worktree_dir: Option<&'a Path>,
     pub input_images: Vec<String>,
     /// Whether the Start node's user prompt (`_input/output.md`) carries any
     /// non-whitespace content. Precomputed by the daemon (it owns the artifacts
@@ -714,7 +719,22 @@ pub(crate) fn build_preamble(ctx: &AugmentContext<'_>) -> String {
         }
     }
 
-    // Source code edits (only for nodes that get a per-iteration sub-worktree)
+    // Source code edits. Two isolations, one section, and NO git instruction in
+    // either (#654 / ADR-0060): the Node edits files, the runtime delivers what it
+    // leaves. What differs is only *where* the NodeRun works.
+    if let Some(shared_wt) = ctx.shared_worktree_dir {
+        preamble.push_str("## Source code edits\n\n");
+        preamble.push_str(&format!(
+            "Your working directory `{}` is the **run's shared worktree**: other \
+             nodes of this run may work in it at the same time. Make **all** \
+             source code edits there — do not `cd` elsewhere to edit files.\n\n\
+             You do not have to run any git command. When this node finishes, PDO \
+             keeps whatever you committed yourself and commits everything else you \
+             left behind onto the run's branch. Anything the repository's \
+             `.gitignore` covers stays out; everything else goes in.\n\n",
+            shared_wt.display()
+        ));
+    }
     if let Some(sub_wt) = ctx.source_worktree_dir {
         preamble.push_str("## Source code edits\n\n");
         preamble.push_str(&format!(
@@ -726,10 +746,11 @@ pub(crate) fn build_preamble(ctx: &AugmentContext<'_>) -> String {
              worktree* (a different directory, shared with other nodes). \
              Treat those paths as read-only/write-only for artefacts; never \
              edit source code there.\n\n\
-             When you run `pdo complete`, your committed changes are \
-             automatically merged from this sub-worktree back into the \
-             pipeline worktree. Edits made outside this directory will be \
-             silently dropped from the merge.\n\n",
+             You do not have to run any git command. When this node finishes, PDO \
+             keeps whatever you committed yourself, commits everything else you \
+             left behind, then merges this worktree back into the pipeline \
+             worktree. Edits made outside this directory are not part of that \
+             delivery.\n\n",
             sub_wt.display()
         ));
 
@@ -951,8 +972,8 @@ On `curl {daemon_url}/runs/{run_id}` a parked run carries:
   schedulable); `unrouted` / `region_exhausted` / `region_ended_unrouted` (routing left no
   live path — route it with `end_region`/`bump_region` or the exit edge); `merge_conflict`,
   `merge_resolution_failed`, `script_validation_failed`, `frontmatter_retry_exhausted`,
-  `doc_violated_code_immutability` (a completion give-up); `agent_fail_awaiting` (an agent
-  `pdo fail` awaiting your confirmation).
+  `delivery_failed` (a completion give-up); `agent_fail_awaiting` (an agent `pdo fail`
+  awaiting your confirmation).
 - **`awaiting_reason`** — the same cause in prose, for the human.
 
 `awaiting_reason_code` **absent** on an `awaiting_user` run means the wait is *interactive*
@@ -1250,6 +1271,7 @@ mod tests {
             daemon_url: "http://localhost:5172",
             foreach_context: None,
             source_worktree_dir: None,
+            shared_worktree_dir: None,
             input_images: Vec::new(),
             start_prompt_present: false,
             source_iters: HashMap::new(),
@@ -2759,6 +2781,67 @@ mod tests {
         assert!(
             !preamble.contains("interrupted git operation"),
             "no ops means no interrupted-op notice: {preamble}"
+        );
+    }
+
+    // --- #654 / ADR-0060: one "Source code edits" section per isolation, and NO
+    // git instruction in either. The Node edits files; the runtime delivers. ---
+
+    /// A NON-isolated NodeRun gets the section too — pre-#654 it got nothing —
+    /// and it names the shared worktree plus the delivery contract, without ever
+    /// asking for a git command.
+    #[test]
+    fn preamble_tells_a_shared_worktree_node_that_pdo_delivers_what_it_leaves() {
+        let pipeline = sample_pipeline();
+        let node = &pipeline.nodes[0];
+        let vars = HashMap::new();
+        let mut ctx = sample_ctx(&pipeline, node, &vars);
+        ctx.shared_worktree_dir = Some(Path::new("/repo/.pdo/runs/r/worktree"));
+
+        let preamble = build_preamble(&ctx);
+        assert!(preamble.contains("## Source code edits"), "{preamble}");
+        assert!(
+            preamble.contains("run's shared worktree")
+                && preamble.contains("/repo/.pdo/runs/r/worktree"),
+            "it names where the NodeRun works: {preamble}"
+        );
+        assert!(
+            preamble.contains("do not have to run any git command"),
+            "the delivery contract replaces every git instruction: {preamble}"
+        );
+        assert!(
+            preamble.contains(".gitignore"),
+            "…and says what stays out: {preamble}"
+        );
+        assert!(
+            !preamble.contains("dedicated git worktree"),
+            "the two isolations never render together: {preamble}"
+        );
+    }
+
+    /// The isolated section keeps its "edit here, not elsewhere" rule and states
+    /// the same contract — commits kept, the rest committed, then merged back.
+    #[test]
+    fn preamble_tells_an_isolated_node_its_work_is_committed_then_merged_back() {
+        let pipeline = sample_pipeline();
+        let node = &pipeline.nodes[0];
+        let vars = HashMap::new();
+        let mut ctx = sample_ctx(&pipeline, node, &vars);
+        ctx.source_worktree_dir = Some(Path::new(SUB_WT));
+
+        let preamble = build_preamble(&ctx);
+        assert!(preamble.contains("dedicated git worktree"), "{preamble}");
+        assert!(
+            preamble.contains("do not have to run any git command"),
+            "no git instruction is conditioned on anything any more: {preamble}"
+        );
+        assert!(
+            preamble.contains("keeps whatever you committed yourself"),
+            "the node's own commits survive, and it is told so: {preamble}"
+        );
+        assert!(
+            !preamble.contains("run's shared worktree"),
+            "the two isolations never render together: {preamble}"
         );
     }
 

--- a/crates/pdo-daemon/src/run_advance.rs
+++ b/crates/pdo-daemon/src/run_advance.rs
@@ -634,7 +634,7 @@ mod tests {
         }
     }
 
-    /// A pipeline of root DocOnly nodes (no edges) — every node is immediately
+    /// A pipeline of root `agent` nodes (no edges) — every node is immediately
     /// ready, so `compute_ready_to_spawn` reflects pure declaration order.
     fn roots_pipeline(ids: &[&str]) -> PipelineDef {
         PipelineDef {
@@ -678,6 +678,7 @@ mod tests {
             frontmatter_retries: 0,
             frontmatter_violations: Vec::new(),
             missing_outputs: Vec::new(),
+            delivery: None,
         }
     }
 
@@ -697,6 +698,7 @@ mod tests {
             frontmatter_retries: 0,
             frontmatter_violations: Vec::new(),
             missing_outputs: Vec::new(),
+            delivery: None,
         }
     }
 
@@ -861,6 +863,7 @@ mod tests {
             frontmatter_retries: 0,
             frontmatter_violations: Vec::new(),
             missing_outputs: Vec::new(),
+            delivery: None,
         }
     }
 

--- a/crates/pdo-daemon/src/run_command.rs
+++ b/crates/pdo-daemon/src/run_command.rs
@@ -620,6 +620,29 @@ async fn dispatch(state: Arc<AppState>, run_id: String, cmd: RunCommand) -> Resp
             let pipeline_path = resolve_run_pipeline_path(&repo_root, &run_id, pipeline_name);
             let worktree_dir = worktree_dir_for_run(&repo_root, &run_id);
             let artifacts_dir = worktree_dir.join(".pdo").join("artifacts");
+
+            // #654 / ADR-0060: the manual completion delivers like every other
+            // one. Pre-#654 this arm ran neither the merge-back nor any
+            // worktree check, so an interactive node marked complete from the UI
+            // left its sub-worktree stranded and its shared-worktree edits
+            // uncommitted — the asymmetry ADR-0035 recorded as an accepted limit
+            // and this ticket removes. Same single operation, same events, before
+            // the terminal append and therefore before the downstream spawn.
+            if let Some(refusal) = crate::deliver_node_run(
+                &state,
+                &events,
+                rs_ref,
+                &repo_root,
+                &worktree_dir,
+                &run_id,
+                &node_id,
+                iter,
+            )
+            .await
+            {
+                return completion_refusal::refusal_response(&refusal);
+            }
+
             // The shared chokepoint (#490). Both surfaces project the refusal
             // through the same single function, which is what makes "a refusal is
             // never a 2xx" cover `POST /commands` too.

--- a/crates/pdo-daemon/src/scheduler.rs
+++ b/crates/pdo-daemon/src/scheduler.rs
@@ -1878,6 +1878,7 @@ mod tests {
             frontmatter_retries: 0,
             frontmatter_violations: Vec::new(),
             missing_outputs: Vec::new(),
+            delivery: None,
         }
     }
 
@@ -1897,6 +1898,7 @@ mod tests {
             frontmatter_retries: 0,
             frontmatter_violations: Vec::new(),
             missing_outputs: Vec::new(),
+            delivery: None,
         }
     }
 
@@ -1916,6 +1918,7 @@ mod tests {
             frontmatter_retries: 0,
             frontmatter_violations: Vec::new(),
             missing_outputs: Vec::new(),
+            delivery: None,
         }
     }
 

--- a/crates/pdo-daemon/src/scheduler_dispatcher.rs
+++ b/crates/pdo-daemon/src/scheduler_dispatcher.rs
@@ -136,6 +136,7 @@ mod tests {
             frontmatter_retries: 0,
             frontmatter_violations: Vec::new(),
             missing_outputs: Vec::new(),
+            delivery: None,
         }
     }
 
@@ -155,6 +156,7 @@ mod tests {
             frontmatter_retries: 0,
             frontmatter_violations: Vec::new(),
             missing_outputs: Vec::new(),
+            delivery: None,
         }
     }
 
@@ -199,6 +201,7 @@ mod tests {
             frontmatter_retries: 0,
             frontmatter_violations: Vec::new(),
             missing_outputs: Vec::new(),
+            delivery: None,
         }
     }
 

--- a/crates/pdo-daemon/src/worktree_ops.rs
+++ b/crates/pdo-daemon/src/worktree_ops.rs
@@ -635,6 +635,191 @@ pub(crate) fn commit_and_merge_sub_worktree(
     )
 }
 
+/// The message PDO puts on the commit it creates for a NodeRun's leftover changes
+/// (#654 / ADR-0060). Deterministic, and the **only** thing PDO writes on it: no
+/// trailer, no author override — the delivery uses the configured git identity, so
+/// a repo's own hooks and conventions see an ordinary commit.
+pub(crate) fn delivery_commit_message(node_id: &str, iter: i64) -> String {
+    format!("{node_id} iter-{iter}: completed")
+}
+
+/// Stage everything git does not ignore and commit it under
+/// [`delivery_commit_message`], or answer `Ok(None)` when nothing was left to
+/// commit (#654 / ADR-0060).
+///
+/// Staging is plain `git add -A` with **no PDO-specific exclusion**: the target
+/// repo's `.gitignore` is the single exclusion policy, runtime paths included. A
+/// node that already committed its own work reaches this with a clean index and
+/// gets `None` — its commits are kept as they are, and no empty commit is ever
+/// written.
+///
+/// #489: the exit STATUS of `git add -A` is checked, not just the spawn. Discarding
+/// it loses the whole node's work in silence, and reusing a sub-worktree (#489-B)
+/// promotes that from latent to routine. The measured chain, with a leftover
+/// `index.lock`:
+///
+/// ```text
+/// git add -A                  -> exit 128  "Unable to create '…/index.lock': File exists"
+/// git diff --cached --quiet   -> exit 0    => NO COMMIT TAKEN
+/// git merge pdo/sub-…         -> "Already up to date."  exit 0
+/// => MergeResult::Success — the agent's file is ABSENT from the pipeline worktree
+/// ```
+///
+/// `pdo complete` answered `Success`, the Run went green, and 100% of the
+/// uncommitted work vanished with no conflict, no event and no trace — the silent
+/// loss ADR-0004 forbids. `bail!` here surfaces as
+/// `CompletionRefusal::DeliveryFailed`, which is loud and parks the Run.
+pub(crate) fn stage_and_commit(
+    worktree_dir: &std::path::Path,
+    node_id: &str,
+    iter: i64,
+) -> Result<Option<String>> {
+    let add_output = std::process::Command::new("git")
+        .args(["add", "-A"])
+        .current_dir(worktree_dir)
+        .output()
+        .with_context(|| format!("git add -A failed to run in {}", worktree_dir.display()))?;
+    if !add_output.status.success() {
+        anyhow::bail!(
+            "git add -A in {} failed, refusing to report a delivery that would drop the node's \
+             work: {}",
+            worktree_dir.display(),
+            git_report(&add_output)
+        );
+    }
+
+    let status_output = std::process::Command::new("git")
+        .args(["diff", "--cached", "--quiet"])
+        .current_dir(worktree_dir)
+        .output()
+        .context("git diff --cached failed")?;
+
+    // Exit 0 ⇒ the index matches HEAD ⇒ nothing left to deliver. No empty commit.
+    if status_output.status.success() {
+        return Ok(None);
+    }
+
+    let commit_msg = delivery_commit_message(node_id, iter);
+    let output = std::process::Command::new("git")
+        .args(["commit", "-m", &commit_msg])
+        .current_dir(worktree_dir)
+        .output()
+        .with_context(|| format!("git commit failed to run in {}", worktree_dir.display()))?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "git commit in {} failed: {}",
+            worktree_dir.display(),
+            git_report(&output)
+        );
+    }
+
+    Ok(Some(rev_parse(worktree_dir, "HEAD")?))
+}
+
+/// What a delivery did to the Run's branch (#654 / ADR-0060).
+///
+/// `before == after` is the **no-op**: the NodeRun left nothing git could see, so
+/// the Run's branch did not move and no commit was written. Every other case is a
+/// delivery whose content is exactly `git diff before after` — which is what makes
+/// a per-NodeRun diff answerable without knowing whether the node was isolated.
+#[derive(Debug, Clone)]
+pub(crate) struct Delivered {
+    /// The Run branch's tip before the delivery.
+    pub before: String,
+    /// The Run branch's tip after it.
+    pub after: String,
+}
+
+impl Delivered {
+    /// Did the Run's branch actually move?
+    pub(crate) fn changed(&self) -> bool {
+        self.before != self.after
+    }
+}
+
+/// The outcome of the single delivery operation every completion path goes through
+/// (#654 / ADR-0060).
+///
+/// The conflict arms only ever come from an isolated NodeRun: a non-isolated one
+/// commits in place and has nothing to merge.
+#[derive(Debug)]
+pub(crate) enum DeliveryOutcome {
+    /// The work is on the Run's branch (possibly a no-op — see [`Delivered`]).
+    Delivered(Delivered),
+    /// The merge-back conflicted and was resolved in the node's favour (#503).
+    ResolvedInNodeFavour(MergeAdoption),
+    Conflict(MergeConflict),
+    ConflictPendingResolution(MergeConflict),
+}
+
+/// **The** delivery: keep the NodeRun's own commits, commit whatever it left
+/// behind, and put the result on the Run's branch (#654 / ADR-0060).
+///
+/// One operation for both isolations, because the difference is a *where*, not a
+/// *what*: an isolated NodeRun commits in its sub-worktree and its branch is then
+/// merged into the Run's; a non-isolated one commits directly in the Run's
+/// worktree. Both keep any commit the node made itself, both refuse to write an
+/// empty commit, and both stage under the repo's own `.gitignore` with no
+/// PDO-specific exclusion.
+///
+/// No serialisation is added for the shared worktree beyond what git itself needs:
+/// two non-isolated NodeRuns may run concurrently, and the first one here commits
+/// every non-ignored change then visible — under its own deterministic message.
+/// Isolation, not the runtime, is how an author buys reliable attribution.
+///
+/// `spawn_base`: the commit an isolated NodeRun's sub-worktree was cut from, per its
+/// `NodeStarted` (`merge_action::spawn_base_sha`). `None` — a pre-#503 Run, or a
+/// spawn that recorded none — forbids the #503 resolution: an unknown base is not a
+/// licence to rewrite a branch. Ignored when the NodeRun is not isolated.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn deliver_node_work(
+    run_worktree_dir: &std::path::Path,
+    node_worktree_dir: &std::path::Path,
+    isolated: bool,
+    sub_branch: &str,
+    node_id: &str,
+    iter: i64,
+    keep_conflict: bool,
+    spawn_base: Option<&str>,
+) -> Result<DeliveryOutcome> {
+    let before = rev_parse(run_worktree_dir, "HEAD")?;
+
+    if !isolated {
+        // In place: the node worked in the Run's worktree, so its commit IS the
+        // delivery. Nothing to merge, nothing to conflict with.
+        stage_and_commit(run_worktree_dir, node_id, iter)?;
+        let after = rev_parse(run_worktree_dir, "HEAD")?;
+        if before == after {
+            info!("Node {node_id} iter-{iter} left nothing to deliver in the run worktree");
+        } else {
+            info!("Delivered {node_id} iter-{iter} in place: {before} -> {after}");
+        }
+        return Ok(DeliveryOutcome::Delivered(Delivered { before, after }));
+    }
+
+    let merge = commit_and_merge_sub_worktree_inner(
+        node_worktree_dir,
+        run_worktree_dir,
+        sub_branch,
+        node_id,
+        iter,
+        keep_conflict,
+        spawn_base,
+    )?;
+
+    Ok(match merge {
+        MergeResult::Success => DeliveryOutcome::Delivered(Delivered {
+            after: rev_parse(run_worktree_dir, "HEAD")?,
+            before,
+        }),
+        MergeResult::ResolvedInNodeFavour(adoption) => {
+            DeliveryOutcome::ResolvedInNodeFavour(adoption)
+        }
+        MergeResult::Conflict(c) => DeliveryOutcome::Conflict(c),
+        MergeResult::ConflictPendingResolution(c) => DeliveryOutcome::ConflictPendingResolution(c),
+    })
+}
+
 /// `spawn_base`: the commit this sub-worktree was cut from, per its `NodeStarted`
 /// (`merge_action::spawn_base_sha`). `None` — a pre-#503 Run, or a spawn that
 /// recorded none — forbids the #503 resolution: an unknown base is not a licence to
@@ -648,56 +833,9 @@ pub(crate) fn commit_and_merge_sub_worktree_inner(
     keep_conflict: bool,
     spawn_base: Option<&str>,
 ) -> Result<MergeResult> {
-    // #489: the exit STATUS of `git add -A`, not just the spawn. Discarding it
-    // loses the whole node's work in silence, and reusing a sub-worktree (#489-B)
-    // promotes that from latent to routine. The measured chain, with a leftover
-    // `index.lock`:
-    //
-    // ```text
-    // git add -A                  -> exit 128  "Unable to create '…/index.lock': File exists"
-    // git diff --cached --quiet   -> exit 0    => NO COMMIT TAKEN
-    // git merge pdo/sub-…         -> "Already up to date."  exit 0
-    // => MergeResult::Success — the agent's file is ABSENT from the pipeline worktree
-    // ```
-    //
-    // `pdo complete` answered `Success`, the Run went green, and 100% of the
-    // uncommitted work vanished with no conflict, no event and no trace — the
-    // silent loss ADR-0004 forbids. Nothing in #503 fires either: no
-    // `MergeConflictDetected`, no `NodeFailed`, no `failure_reason`. `bail!` here
-    // surfaces as `CompletionRefusal::MergeFailed` (a 500 the caller already
-    // handles), which is loud.
-    let add_output = std::process::Command::new("git")
-        .args(["add", "-A"])
-        .current_dir(sub_worktree_dir)
-        .output()
-        .context("git add failed in sub-worktree")?;
-    if !add_output.status.success() {
-        anyhow::bail!(
-            "git add -A in sub-worktree failed, refusing to report a merge that would drop the \
-             node's work: {}",
-            git_report(&add_output)
-        );
-    }
-
-    let status_output = std::process::Command::new("git")
-        .args(["diff", "--cached", "--quiet"])
-        .current_dir(sub_worktree_dir)
-        .output()
-        .context("git diff --cached failed")?;
-
-    if !status_output.status.success() {
-        let commit_msg = format!("{node_id} iter-{iter}: completed");
-        let output = std::process::Command::new("git")
-            .args(["commit", "-m", &commit_msg])
-            .current_dir(sub_worktree_dir)
-            .output()
-            .context("git commit failed in sub-worktree")?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            anyhow::bail!("git commit in sub-worktree failed: {stderr}");
-        }
-    }
+    // The node's own commits are kept; only what it left uncommitted becomes a
+    // commit here, and nothing at all when it left nothing (#654).
+    stage_and_commit(sub_worktree_dir, node_id, iter)?;
 
     // Both tips, read BEFORE the merge mutates either worktree (#503 AC4): a
     // post-mortem that has to rediscover these two SHAs by hand is the
@@ -870,9 +1008,9 @@ fn unmerged_paths(worktree_dir: &std::path::Path) -> Vec<String> {
 ///
 /// - a dirty pipeline worktree would lose uncommitted tracked work to the
 ///   `git reset --hard` — `git merge` fails loudly where `reset --hard` destroys
-///   in silence. It can legitimately be dirty: a non-isolated node in
-///   flight, the leftovers of a `doc_violated_code_immutability` (never reverted),
-///   the Run shell, the resident `__manager__` agent.
+///   in silence. It can legitimately be dirty: a non-isolated node in flight
+///   (#654 — it works there and PDO delivers what it leaves), the Run shell, the
+///   resident `__manager__` agent.
 /// - unrelated histories: `git merge` also fails (`refusing to merge unrelated
 ///   histories`) when the two tips share no ancestor. That is not a diverged
 ///   pipeline branch, and adopting would replace the run's whole tree.
@@ -968,6 +1106,25 @@ fn resolve_in_node_favour(
     }
 
     Ok(merge_commit)
+}
+
+/// Is `dir` an existing directory inside a git working tree?
+///
+/// The precondition of a delivery (#654): a directory git knows nothing about has
+/// nothing to deliver, and that is not the same thing as a git operation failing
+/// inside a real worktree. Probed with git's own question rather than guessed from
+/// an error string.
+pub(crate) fn is_git_worktree(dir: &std::path::Path) -> bool {
+    if !dir.is_dir() {
+        return false;
+    }
+    std::process::Command::new("git")
+        .args(["rev-parse", "--is-inside-work-tree"])
+        .current_dir(dir)
+        .output()
+        .is_ok_and(|out| {
+            out.status.success() && String::from_utf8_lossy(&out.stdout).trim() == "true"
+        })
 }
 
 pub(crate) fn worktree_has_tracked_changes(worktree_dir: &std::path::Path) -> Result<bool> {
@@ -1749,6 +1906,184 @@ mod tests {
 
         // The structural rule holds — the base IS the tip — and it is still refused.
         assert!(!adoption_allowed(repo, &ours, &alien, Some(&ours)).unwrap());
+    }
+
+    // ── #654 / ADR-0060: the delivery primitive ─────────────────────────────
+
+    /// A tree with nothing to stage yields NO commit — the branch does not move.
+    #[test]
+    fn stage_and_commit_takes_no_empty_commit() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path();
+        init_test_repo(repo);
+        let before = rev_parse(repo, "HEAD").unwrap();
+
+        assert_eq!(stage_and_commit(repo, "n", 1).unwrap(), None);
+        assert_eq!(rev_parse(repo, "HEAD").unwrap(), before);
+    }
+
+    /// `git add -A` semantics with the repo's `.gitignore` as the ONLY exclusion:
+    /// a new file, a modification and a deletion all go in, an ignored file does
+    /// not, and the message is the deterministic one.
+    #[test]
+    fn stage_and_commit_follows_add_dash_a_and_the_repo_gitignore() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path();
+        init_test_repo(repo);
+        let git = |args: &[&str]| {
+            std::process::Command::new("git")
+                .args(args)
+                .current_dir(repo)
+                .output()
+                .unwrap()
+        };
+        std::fs::write(repo.join(".gitignore"), "ignored/\n").unwrap();
+        std::fs::write(repo.join("doomed.txt"), "bye\n").unwrap();
+        git(&["add", "-A"]);
+        git(&["commit", "-m", "base"]);
+
+        std::fs::write(repo.join("README.md"), "# changed\n").unwrap();
+        std::fs::remove_file(repo.join("doomed.txt")).unwrap();
+        std::fs::write(repo.join("added.rs"), "pub fn added() {}\n").unwrap();
+        std::fs::create_dir_all(repo.join("ignored")).unwrap();
+        std::fs::write(repo.join("ignored/noise.txt"), "noise\n").unwrap();
+
+        let sha = stage_and_commit(repo, "impl-1", 3).unwrap().unwrap();
+        assert_eq!(sha, rev_parse(repo, "HEAD").unwrap());
+
+        let subject = String::from_utf8_lossy(&git(&["log", "--format=%s", "-1"]).stdout)
+            .trim()
+            .to_string();
+        assert_eq!(subject, "impl-1 iter-3: completed");
+
+        let files = String::from_utf8_lossy(&git(&["show", "--name-status", "--format="]).stdout)
+            .to_string();
+        assert!(files.contains("M\tREADME.md"), "{files}");
+        assert!(files.contains("D\tdoomed.txt"), "{files}");
+        assert!(files.contains("A\tadded.rs"), "{files}");
+        assert!(
+            !files.contains("noise.txt"),
+            "an ignored file stays out: {files}"
+        );
+    }
+
+    /// #489: a staging failure is LOUD. A leftover `index.lock` makes `git add -A`
+    /// exit non-zero; the delivery must bail instead of reporting a success that
+    /// silently drops the node's work.
+    #[test]
+    fn stage_and_commit_bails_on_a_staging_failure() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path();
+        init_test_repo(repo);
+        std::fs::write(repo.join("work.rs"), "pub fn work() {}\n").unwrap();
+        std::fs::write(repo.join(".git/index.lock"), "").unwrap();
+
+        let err = stage_and_commit(repo, "n", 1).unwrap_err().to_string();
+        assert!(
+            err.contains("git add -A"),
+            "the error names the step: {err}"
+        );
+        assert!(
+            repo.join("work.rs").exists(),
+            "a failed delivery destroys nothing"
+        );
+    }
+
+    /// The non-isolated arm: the node worked in the Run's worktree, so its commit
+    /// IS the delivery — no merge, and the two reported tips bracket it.
+    #[test]
+    fn deliver_in_place_commits_on_the_run_branch() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path();
+        init_test_repo(repo);
+
+        let run_id = "test-deliver-inplace";
+        let wt_dir = repo.join(".pdo/runs").join(run_id).join("worktree");
+        let pipeline_branch = format!("pdo/run-{run_id}");
+        create_worktree(repo, &wt_dir, &pipeline_branch, "HEAD").unwrap();
+        std::fs::write(wt_dir.join("shared.rs"), "pub fn shared() {}\n").unwrap();
+
+        let outcome = deliver_node_work(
+            &wt_dir, &wt_dir, false, "unused", "shared-1", 1, false, None,
+        )
+        .unwrap();
+        let DeliveryOutcome::Delivered(d) = outcome else {
+            panic!("a non-isolated delivery never conflicts");
+        };
+        assert!(d.changed());
+        assert_eq!(d.after, rev_parse(&wt_dir, "HEAD").unwrap());
+        assert_eq!(d.after, rev_parse(repo, &pipeline_branch).unwrap());
+    }
+
+    /// The no-op reports itself as one: same tip on both sides, no commit taken.
+    #[test]
+    fn deliver_in_place_on_a_clean_tree_is_a_no_op() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path();
+        init_test_repo(repo);
+
+        let run_id = "test-deliver-noop";
+        let wt_dir = repo.join(".pdo/runs").join(run_id).join("worktree");
+        create_worktree(repo, &wt_dir, &format!("pdo/run-{run_id}"), "HEAD").unwrap();
+
+        let outcome = deliver_node_work(
+            &wt_dir, &wt_dir, false, "unused", "shared-1", 1, false, None,
+        )
+        .unwrap();
+        let DeliveryOutcome::Delivered(d) = outcome else {
+            panic!("expected a delivery");
+        };
+        assert!(!d.changed(), "before == after ⇒ nothing was committed");
+    }
+
+    /// The isolated arm: commit in the sub-worktree, then merge it into the Run's
+    /// branch. The reported tips bracket the merge.
+    #[test]
+    fn deliver_isolated_commits_then_merges_back() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path();
+        init_test_repo(repo);
+
+        let run_id = "test-deliver-isolated";
+        let wt_dir = repo.join(".pdo/runs").join(run_id).join("worktree");
+        let pipeline_branch = format!("pdo/run-{run_id}");
+        create_worktree(repo, &wt_dir, &pipeline_branch, "HEAD").unwrap();
+        let sub_wt = sub_worktree_path(repo, run_id, "forked-1", 1);
+        let sub_branch = sub_worktree_branch(run_id, "forked-1", 1);
+        create_sub_worktree(repo, &sub_wt, &sub_branch, &pipeline_branch).unwrap();
+        std::fs::write(sub_wt.join("forked.rs"), "pub fn forked() {}\n").unwrap();
+
+        let outcome = deliver_node_work(
+            &wt_dir,
+            &sub_wt,
+            true,
+            &sub_branch,
+            "forked-1",
+            1,
+            false,
+            None,
+        )
+        .unwrap();
+        let DeliveryOutcome::Delivered(d) = outcome else {
+            panic!("a clean merge-back delivers");
+        };
+        assert!(d.changed());
+        assert!(wt_dir.join("forked.rs").exists());
+        assert_eq!(d.after, rev_parse(repo, &pipeline_branch).unwrap());
+    }
+
+    /// A directory git knows nothing about is not a worktree — the precondition
+    /// the runtime reads before deciding there is anything to deliver.
+    #[test]
+    fn is_git_worktree_answers_for_a_real_worktree_and_a_bare_directory() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path();
+        init_test_repo(repo);
+        assert!(is_git_worktree(repo));
+
+        let orphan = tempfile::tempdir().unwrap();
+        assert!(!is_git_worktree(orphan.path()));
+        assert!(!is_git_worktree(&orphan.path().join("nope")));
     }
 
     #[test]

--- a/crates/pdo-daemon/tests/it.rs
+++ b/crates/pdo-daemon/tests/it.rs
@@ -86,6 +86,9 @@ mod multi_repo_run;
 #[path = "mutation_policy.rs"]
 mod mutation_policy;
 
+#[path = "node_delivery.rs"]
+mod node_delivery;
+
 #[path = "node_done_detach.rs"]
 mod node_done_detach;
 

--- a/crates/pdo-daemon/tests/node_delivery.rs
+++ b/crates/pdo-daemon/tests/node_delivery.rs
@@ -1,0 +1,756 @@
+//! Layer 3a — the delivery of a NodeRun's work onto the Run's branch (#654 /
+//! ADR-0060).
+//!
+//! Every test here drives a **real temporary git repository**: the delivery is a
+//! sequence of `git add -A` / `git commit` / `git merge`, and a fake would only
+//! prove the fake. `script` nodes carry most of the matrix because they are the
+//! one node type that runs end to end in CI with zero stubbing (their body IS
+//! deterministic bash — see `script_node.rs`); the `agent` arms drive
+//! `POST …/nodes/:id/done` against a node whose session is the default
+//! `exec sleep 600` override, which is exactly what a live agent's `pdo complete`
+//! does.
+//!
+//! Covered, one dimension per test: both node types, both isolations, new files,
+//! deleted files, ignored files, a node's own pre-existing commits, the no-op, a
+//! git error, concurrency in the shared worktree, and the per-NodeRun diff.
+
+use std::process::Command;
+use std::time::Duration;
+
+use crate::common::{ensure_pdo_on_path, TestDaemon};
+
+// ── fixture ──────────────────────────────────────────────────────────────────
+
+/// A repo with one tracked file, one file the repo *ignores*, and a `.gitignore`
+/// that covers PDO's run directory — the shape every target repo is expected to
+/// have (ADR-0060: `.gitignore` is the single exclusion policy).
+fn git_init_with_commit(repo: &std::path::Path) -> anyhow::Result<()> {
+    let run = |args: &[&str]| -> anyhow::Result<()> {
+        let out = Command::new("git").args(args).current_dir(repo).output()?;
+        if !out.status.success() {
+            anyhow::bail!(
+                "git {:?} failed: {}",
+                args,
+                String::from_utf8_lossy(&out.stderr)
+            );
+        }
+        Ok(())
+    };
+    run(&["init", "-q", "-b", "main"])?;
+    run(&["config", "user.email", "delivery@test.local"])?;
+    run(&["config", "user.name", "Delivery Test"])?;
+    run(&["config", "commit.gpgsign", "false"])?;
+    // PDO's runtime paths are ignored BY THE TARGET REPO, which is the whole
+    // exclusion policy (ADR-0060): the delivery itself excludes nothing. Inside a
+    // run's worktree the blackboard sits at `.pdo/artifacts/`, so a repo that only
+    // ignores `.pdo/runs/` would have every delivery carry its own plumbing —
+    // mirrors this project's own `.gitignore`.
+    std::fs::write(
+        repo.join(".gitignore"),
+        ".pdo/runs/\n.pdo/artifacts/\n.pdo/prompts/\nscratch/\n",
+    )?;
+    std::fs::write(repo.join("tracked.txt"), "original\n")?;
+    std::fs::write(repo.join("doomed.txt"), "delete me\n")?;
+    run(&["add", "-A"])?;
+    run(&["commit", "-q", "-m", "init"])?;
+    Ok(())
+}
+
+fn git_out(repo: &std::path::Path, args: &[&str]) -> String {
+    let out = Command::new("git")
+        .args(args)
+        .current_dir(repo)
+        .output()
+        .expect("git");
+    assert!(
+        out.status.success(),
+        "git {args:?} failed: {}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+/// A `start → worker → end` pipeline whose single worker carries the given type
+/// and isolation. The worker declares no output port: these tests are about the
+/// delivery, not about output validation.
+fn one_worker_pipeline(name: &str, node_type: &str, isolated: bool) -> String {
+    format!(
+        "name: {name}\nversion: \"1.0\"\nnodes:\n  \
+         - id: start\n    name: Start\n    type: start\n    outputs:\n      - name: user_prompt\n  \
+         - id: worker\n    name: worker\n    type: {node_type}\n    isolated_worktree: {isolated}\n  \
+         - id: end\n    name: End\n    type: end\n    inputs:\n      - name: result\n\
+         edges:\n  \
+         - source: {{ node: start, port: user_prompt }}\n    target: {{ node: worker, port: in }}\n  \
+         - source: {{ node: start, port: user_prompt }}\n    target: {{ node: end, port: result }}\n"
+    )
+}
+
+/// Seed a pipeline YAML plus one prompt file per node (a `script` node's prompt
+/// slot IS its bash body) and initialise the git repo.
+fn seed(
+    yaml: String,
+    name: &'static str,
+    prompts: Vec<(&'static str, String)>,
+) -> impl FnOnce(&std::path::Path) -> anyhow::Result<()> {
+    move |repo: &std::path::Path| {
+        let pipelines_dir = repo.join(".pdo").join("pipelines");
+        std::fs::create_dir_all(&pipelines_dir)?;
+        std::fs::write(pipelines_dir.join(format!("{name}.yaml")), &yaml)?;
+        let prompts_dir = pipelines_dir.join(format!("{name}.prompts"));
+        std::fs::create_dir_all(&prompts_dir)?;
+        for (node, body) in &prompts {
+            std::fs::write(prompts_dir.join(format!("{node}.md")), body)?;
+        }
+        git_init_with_commit(repo)?;
+        Ok(())
+    }
+}
+
+async fn start_run(daemon: &TestDaemon, pipeline: &str) -> String {
+    let body = serde_json::json!({
+        "pipeline": pipeline,
+        "input": "deliver",
+        "target_repo": daemon.target_repo(),
+    });
+    let resp = reqwest::Client::new()
+        .post(format!("{}/runs", daemon.url()))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 201, "POST /runs should create the run");
+    resp.json::<serde_json::Value>().await.unwrap()["run_id"]
+        .as_str()
+        .unwrap()
+        .to_string()
+}
+
+async fn get_run(daemon: &TestDaemon, run_id: &str) -> serde_json::Value {
+    reqwest::get(format!("{}/runs/{run_id}", daemon.url()))
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap()
+}
+
+/// Poll until `nodes[node_id].status` reaches `expected`, or give up. Returns the
+/// last run JSON either way, so the assertion that follows can print it.
+async fn wait_for_node_status(
+    daemon: &TestDaemon,
+    run_id: &str,
+    node_id: &str,
+    expected: &str,
+) -> serde_json::Value {
+    let started = std::time::Instant::now();
+    let mut last = serde_json::Value::Null;
+    while started.elapsed() < Duration::from_secs(30) {
+        let run = get_run(daemon, run_id).await;
+        if run["nodes"][node_id]["status"] == expected {
+            return run;
+        }
+        last = run;
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+    last
+}
+
+async fn complete(daemon: &TestDaemon, run_id: &str, node_id: &str) -> reqwest::StatusCode {
+    reqwest::Client::new()
+        .post(format!(
+            "{}/runs/{run_id}/nodes/{node_id}/done",
+            daemon.url()
+        ))
+        .json(&serde_json::json!({ "iter": 1 }))
+        .send()
+        .await
+        .unwrap()
+        .status()
+}
+
+fn run_worktree(daemon: &TestDaemon, run_id: &str) -> std::path::PathBuf {
+    daemon
+        .repo_root()
+        .join(".pdo/runs")
+        .join(run_id)
+        .join("worktree")
+}
+
+fn sub_worktree(daemon: &TestDaemon, run_id: &str, node_id: &str) -> std::path::PathBuf {
+    daemon
+        .repo_root()
+        .join(".pdo/runs")
+        .join(run_id)
+        .join("nodes")
+        .join(node_id)
+        .join("iter-1")
+}
+
+// ── script × shared worktree ─────────────────────────────────────────────────
+
+/// A non-isolated `script` modifies a tracked file, deletes another and creates a
+/// new one. All three land in one commit on the Run's branch, under the
+/// deterministic message — and the ignored file does not.
+#[tokio::test]
+async fn a_shared_script_delivers_edits_deletions_and_new_files() {
+    ensure_pdo_on_path();
+    let name = "deliver-shared-script";
+    let body = "#!/usr/bin/env bash\nset -euo pipefail\n\
+        printf 'rewritten\\n' > tracked.txt\n\
+        rm doomed.txt\n\
+        printf 'pub fn added() {}\\n' > added.rs\n\
+        mkdir -p scratch && printf 'noise\\n' > scratch/ignored.txt\n";
+    let daemon = TestDaemon::spawn(seed(
+        one_worker_pipeline(name, "script", false),
+        "deliver-shared-script",
+        vec![("worker", body.to_string())],
+    ))
+    .await
+    .unwrap();
+
+    let run_id = start_run(&daemon, name).await;
+    let run = wait_for_node_status(&daemon, &run_id, "worker", "completed").await;
+    assert_eq!(run["nodes"]["worker"]["status"], "completed", "run: {run}");
+
+    let repo = daemon.repo_root();
+    let branch = format!("pdo/run-{run_id}");
+    assert_eq!(
+        git_out(repo, &["log", "--format=%s", "-1", &branch]),
+        "worker iter-1: completed",
+        "PDO writes its own deterministic message"
+    );
+    let files = git_out(repo, &["show", "--name-status", "--format=", &branch]);
+    assert!(files.contains("M\ttracked.txt"), "modified: {files}");
+    assert!(files.contains("D\tdoomed.txt"), "deleted: {files}");
+    assert!(files.contains("A\tadded.rs"), "added: {files}");
+    assert!(
+        !files.contains("ignored.txt"),
+        "an ignored file is never delivered — `.gitignore` is the only policy: {files}"
+    );
+
+    // The projection carries the delivery, so the per-node diff is answerable for
+    // a node that never owned a branch.
+    let delivery = &run["nodes"]["worker"]["delivery"];
+    assert!(
+        delivery["before"].is_string() && delivery["after"].is_string(),
+        "a delivering NodeRun records both tips: {run}"
+    );
+    let diff: String = reqwest::get(format!("{}/runs/{run_id}/nodes/worker/diff", daemon.url()))
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+    assert!(
+        diff.contains("added.rs") && diff.contains("tracked.txt"),
+        "the diff of a non-isolated NodeRun shows what it delivered: {diff}"
+    );
+}
+
+/// A NodeRun that leaves nothing behind takes no commit — empty or otherwise.
+#[tokio::test]
+async fn a_node_that_leaves_nothing_takes_no_commit() {
+    ensure_pdo_on_path();
+    let name = "deliver-noop";
+    let body = "#!/usr/bin/env bash\nset -euo pipefail\ntrue\n";
+    let daemon = TestDaemon::spawn(seed(
+        one_worker_pipeline(name, "script", false),
+        "deliver-noop",
+        vec![("worker", body.to_string())],
+    ))
+    .await
+    .unwrap();
+
+    let repo = daemon.repo_root();
+    let run_id = start_run(&daemon, name).await;
+    let run = wait_for_node_status(&daemon, &run_id, "worker", "completed").await;
+    assert_eq!(run["nodes"]["worker"]["status"], "completed", "run: {run}");
+
+    let branch = format!("pdo/run-{run_id}");
+    assert_eq!(
+        git_out(repo, &["log", "--format=%s", "-1", &branch]),
+        "init",
+        "nothing to deliver ⇒ the run's branch never moved"
+    );
+    assert!(
+        run["nodes"]["worker"]["delivery"].is_null(),
+        "a no-op delivery records nothing: {run}"
+    );
+}
+
+/// A node that commits its own work keeps those commits, and PDO tops them with
+/// exactly one commit for what was left uncommitted.
+#[tokio::test]
+async fn pre_existing_commits_are_kept_and_topped_by_one_delivery_commit() {
+    ensure_pdo_on_path();
+    let name = "deliver-own-commits";
+    let body = "#!/usr/bin/env bash\nset -euo pipefail\n\
+        printf 'mine\\n' > mine.txt\n\
+        git add mine.txt\n\
+        git commit -q -m 'worker: my own commit'\n\
+        printf 'leftover\\n' > leftover.txt\n";
+    let daemon = TestDaemon::spawn(seed(
+        one_worker_pipeline(name, "script", false),
+        "deliver-own-commits",
+        vec![("worker", body.to_string())],
+    ))
+    .await
+    .unwrap();
+
+    let repo = daemon.repo_root();
+    let run_id = start_run(&daemon, name).await;
+    let run = wait_for_node_status(&daemon, &run_id, "worker", "completed").await;
+    assert_eq!(run["nodes"]["worker"]["status"], "completed", "run: {run}");
+
+    let branch = format!("pdo/run-{run_id}");
+    let subjects = git_out(repo, &["log", "--format=%s", "-3", &branch]);
+    let subjects: Vec<&str> = subjects.lines().collect();
+    assert_eq!(
+        subjects,
+        vec!["worker iter-1: completed", "worker: my own commit", "init"],
+        "the node's own commit survives, PDO adds one on top"
+    );
+}
+
+/// A node that committed *everything* itself leaves nothing to commit: its
+/// commits are kept and no second one is written.
+#[tokio::test]
+async fn a_node_that_committed_everything_gets_no_extra_commit() {
+    ensure_pdo_on_path();
+    let name = "deliver-all-own";
+    let body = "#!/usr/bin/env bash\nset -euo pipefail\n\
+        printf 'mine\\n' > mine.txt\n\
+        git add -A\n\
+        git commit -q -m 'worker: everything, by hand'\n";
+    let daemon = TestDaemon::spawn(seed(
+        one_worker_pipeline(name, "script", false),
+        "deliver-all-own",
+        vec![("worker", body.to_string())],
+    ))
+    .await
+    .unwrap();
+
+    let repo = daemon.repo_root();
+    let run_id = start_run(&daemon, name).await;
+    let run = wait_for_node_status(&daemon, &run_id, "worker", "completed").await;
+    assert_eq!(run["nodes"]["worker"]["status"], "completed", "run: {run}");
+
+    let branch = format!("pdo/run-{run_id}");
+    assert_eq!(
+        git_out(repo, &["log", "--format=%s", "-1", &branch]),
+        "worker: everything, by hand",
+        "a clean tree ⇒ no empty commit on top"
+    );
+}
+
+// ── script × its own sub-worktree ────────────────────────────────────────────
+
+/// An isolated `script` works in its own sub-worktree and PDO merges it back —
+/// the same full cycle an isolated agent gets.
+#[tokio::test]
+async fn an_isolated_script_works_and_delivers_from_its_sub_worktree() {
+    ensure_pdo_on_path();
+    let name = "deliver-isolated-script";
+    let body = "#!/usr/bin/env bash\nset -euo pipefail\n\
+        printf 'pub fn from_the_sub_worktree() {}\\n' > sub.rs\n";
+    let daemon = TestDaemon::spawn(seed(
+        one_worker_pipeline(name, "script", true),
+        "deliver-isolated-script",
+        vec![("worker", body.to_string())],
+    ))
+    .await
+    .unwrap();
+
+    let repo = daemon.repo_root();
+    let run_id = start_run(&daemon, name).await;
+    let run = wait_for_node_status(&daemon, &run_id, "worker", "completed").await;
+    assert_eq!(run["nodes"]["worker"]["status"], "completed", "run: {run}");
+
+    // It really did work in its own directory, not in the Run's.
+    assert!(
+        sub_worktree(&daemon, &run_id, "worker")
+            .join("sub.rs")
+            .exists(),
+        "an isolated script works in its sub-worktree"
+    );
+    let branch = format!("pdo/run-{run_id}");
+    let files = git_out(repo, &["show", "--name-only", "--format=", &branch]);
+    assert!(
+        files.contains("sub.rs"),
+        "…and PDO merges that work into the run's branch: {files}"
+    );
+    assert!(
+        run_worktree(&daemon, &run_id).join("sub.rs").exists(),
+        "the merge lands in the run's worktree too"
+    );
+    assert!(
+        !run["nodes"]["worker"]["delivery"].is_null(),
+        "an isolated delivery is recorded like any other: {run}"
+    );
+}
+
+// ── the Feature Path: shared upstream, isolated downstream ───────────────────
+
+/// The FP of #654: a non-isolated node's work is on the Run's branch **before**
+/// the downstream node is dispatched, so an isolated successor forked afterwards
+/// sees it. Both deliveries end up on the branch, in order.
+#[tokio::test]
+async fn an_isolated_downstream_node_sees_an_upstream_shared_node_work() {
+    ensure_pdo_on_path();
+    let name = "deliver-handoff";
+    let yaml = format!(
+        "name: {name}\nversion: \"1.0\"\nnodes:\n  \
+         - id: start\n    name: Start\n    type: start\n    outputs:\n      - name: user_prompt\n  \
+         - id: shared\n    name: shared\n    type: script\n    isolated_worktree: false\n    outputs:\n      - name: out\n  \
+         - id: forked\n    name: forked\n    type: script\n    isolated_worktree: true\n    outputs:\n      - name: out\n  \
+         - id: end\n    name: End\n    type: end\n    inputs:\n      - name: result\n\
+         edges:\n  \
+         - source: {{ node: start, port: user_prompt }}\n    target: {{ node: shared, port: in }}\n  \
+         - source: {{ node: shared, port: out }}\n    target: {{ node: forked, port: in }}\n  \
+         - source: {{ node: forked, port: out }}\n    target: {{ node: end, port: result }}\n"
+    );
+    // The downstream node PROVES it sees the upstream work: it reads the file and
+    // fails (exit 1) if it is not there.
+    let shared_body = "#!/usr/bin/env bash\nset -euo pipefail\n\
+        printf 'from the shared node\\n' > handoff.txt\n\
+        printf 'ok\\n' > \"$PDO_OUTPUT_OUT\"\n";
+    let forked_body = "#!/usr/bin/env bash\nset -euo pipefail\n\
+        grep -q 'from the shared node' handoff.txt\n\
+        printf 'seen\\n' > forked.txt\n\
+        printf 'ok\\n' > \"$PDO_OUTPUT_OUT\"\n";
+    let daemon = TestDaemon::spawn(seed(
+        yaml,
+        "deliver-handoff",
+        vec![
+            ("shared", shared_body.to_string()),
+            ("forked", forked_body.to_string()),
+        ],
+    ))
+    .await
+    .unwrap();
+
+    let repo = daemon.repo_root();
+    let run_id = start_run(&daemon, name).await;
+    let run = wait_for_node_status(&daemon, &run_id, "forked", "completed").await;
+    assert_eq!(
+        run["nodes"]["forked"]["status"], "completed",
+        "the downstream node must find the upstream file in its fresh fork; run: {run}"
+    );
+
+    let branch = format!("pdo/run-{run_id}");
+    let files = git_out(repo, &["log", "--name-only", "--format=", &branch]);
+    assert!(
+        files.contains("handoff.txt") && files.contains("forked.txt"),
+        "both deliveries are on the run's branch: {files}"
+    );
+    // Both NodeRuns have a diff, whatever their isolation.
+    for node in ["shared", "forked"] {
+        assert!(
+            !run["nodes"][node]["delivery"].is_null(),
+            "{node} delivered and must say so: {run}"
+        );
+    }
+}
+
+// ── agent × both isolations, driven through `pdo complete` ───────────────────
+
+/// The `agent` half of the matrix, non-isolated: the node makes no git call at
+/// all — the test writes files into its working directory exactly as an agent
+/// would — and `POST …/done` delivers them.
+#[tokio::test]
+async fn a_shared_agent_delivers_what_it_left_in_the_run_worktree() {
+    let name = "deliver-shared-agent";
+    let daemon = TestDaemon::spawn(seed(
+        one_worker_pipeline(name, "agent", false),
+        "deliver-shared-agent",
+        vec![("worker", "You are a worker.\n".to_string())],
+    ))
+    .await
+    .unwrap();
+
+    let repo = daemon.repo_root();
+    let run_id = start_run(&daemon, name).await;
+    let run = wait_for_node_status(&daemon, &run_id, "worker", "running").await;
+    assert_eq!(run["nodes"]["worker"]["status"], "running", "run: {run}");
+
+    let wt = run_worktree(&daemon, &run_id);
+    std::fs::write(wt.join("tracked.txt"), "edited by the agent\n").unwrap();
+    std::fs::write(wt.join("agent_new.rs"), "pub fn agent() {}\n").unwrap();
+
+    assert_eq!(complete(&daemon, &run_id, "worker").await, 200);
+
+    let branch = format!("pdo/run-{run_id}");
+    assert_eq!(
+        git_out(repo, &["log", "--format=%s", "-1", &branch]),
+        "worker iter-1: completed"
+    );
+    let files = git_out(repo, &["show", "--name-only", "--format=", &branch]);
+    assert!(
+        files.contains("tracked.txt") && files.contains("agent_new.rs"),
+        "a non-isolated agent's edits reach the run's branch: {files}"
+    );
+}
+
+/// The `agent` half, isolated: it works in its sub-worktree, PDO commits what is
+/// left and merges the branch back.
+#[tokio::test]
+async fn an_isolated_agent_delivers_from_its_sub_worktree() {
+    let name = "deliver-isolated-agent";
+    let daemon = TestDaemon::spawn(seed(
+        one_worker_pipeline(name, "agent", true),
+        "deliver-isolated-agent",
+        vec![("worker", "You are a worker.\n".to_string())],
+    ))
+    .await
+    .unwrap();
+
+    let repo = daemon.repo_root();
+    let run_id = start_run(&daemon, name).await;
+    let run = wait_for_node_status(&daemon, &run_id, "worker", "running").await;
+    assert_eq!(run["nodes"]["worker"]["status"], "running", "run: {run}");
+
+    let sub = sub_worktree(&daemon, &run_id, "worker");
+    assert!(sub.is_dir(), "an isolated agent gets a sub-worktree");
+    std::fs::write(sub.join("forked.rs"), "pub fn forked() {}\n").unwrap();
+
+    assert_eq!(complete(&daemon, &run_id, "worker").await, 200);
+
+    let branch = format!("pdo/run-{run_id}");
+    let files = git_out(repo, &["log", "--name-only", "--format=", &branch]);
+    assert!(files.contains("forked.rs"), "merged back: {files}");
+}
+
+// ── a git error is loud, and destroys nothing ────────────────────────────────
+
+/// A staging failure interrupts the NodeRun, parks the Run `awaiting_user`, and
+/// leaves the work exactly where the node left it.
+#[tokio::test]
+async fn a_git_failure_interrupts_the_node_and_keeps_the_work() {
+    let name = "deliver-git-error";
+    let daemon = TestDaemon::spawn(seed(
+        one_worker_pipeline(name, "agent", false),
+        "deliver-git-error",
+        vec![("worker", "You are a worker.\n".to_string())],
+    ))
+    .await
+    .unwrap();
+
+    let run_id = start_run(&daemon, name).await;
+    let run = wait_for_node_status(&daemon, &run_id, "worker", "running").await;
+    assert_eq!(run["nodes"]["worker"]["status"], "running", "run: {run}");
+
+    let wt = run_worktree(&daemon, &run_id);
+    std::fs::write(wt.join("precious.rs"), "pub fn precious() {}\n").unwrap();
+    // A leftover `index.lock` is the real-world shape of this failure (#489): it
+    // makes `git add -A` exit non-zero without touching the working tree.
+    let git_dir = git_out(&wt, &["rev-parse", "--absolute-git-dir"]);
+    std::fs::write(std::path::Path::new(&git_dir).join("index.lock"), "").unwrap();
+
+    let status = complete(&daemon, &run_id, "worker").await;
+    assert_eq!(
+        status, 500,
+        "a delivery that cannot run is a panne, not a verdict"
+    );
+
+    let run = wait_for_node_status(&daemon, &run_id, "worker", "interrupted").await;
+    assert_eq!(
+        run["nodes"]["worker"]["status"], "interrupted",
+        "a git failure interrupts the NodeRun, it never fails it: {run}"
+    );
+    assert_eq!(run["status"], "awaiting_user", "the run parks: {run}");
+    assert_eq!(
+        run["awaiting_reason_code"], "delivery_failed",
+        "the cause is named in the run state: {run}"
+    );
+    assert!(
+        wt.join("precious.rs").exists(),
+        "the work stays on disk, untouched"
+    );
+}
+
+// ── two shared NodeRuns at once ──────────────────────────────────────────────
+
+/// Two non-isolated NodeRuns run side by side with no serialisation added by the
+/// runtime, and the first one to complete commits every non-ignored change then
+/// visible — under its own name. The test asserts the *state*, never who wrote
+/// which file: the sharp-tool posture is precisely that PDO does not pretend to
+/// attribute it (ADR-0060).
+#[tokio::test]
+async fn two_shared_nodes_run_concurrently_and_the_state_is_delivered_whole() {
+    ensure_pdo_on_path();
+    let name = "deliver-concurrent";
+    let yaml = format!(
+        "name: {name}\nversion: \"1.0\"\nnodes:\n  \
+         - id: start\n    name: Start\n    type: start\n    outputs:\n      - name: user_prompt\n  \
+         - id: left\n    name: left\n    type: script\n    isolated_worktree: false\n    outputs:\n      - name: out\n  \
+         - id: right\n    name: right\n    type: script\n    isolated_worktree: false\n    outputs:\n      - name: out\n  \
+         - id: end\n    name: End\n    type: end\n    inputs:\n      - name: result\n\
+         edges:\n  \
+         - source: {{ node: start, port: user_prompt }}\n    target: {{ node: left, port: in }}\n  \
+         - source: {{ node: start, port: user_prompt }}\n    target: {{ node: right, port: in }}\n  \
+         - source: {{ node: left, port: out }}\n    target: {{ node: end, port: result }}\n  \
+         - source: {{ node: right, port: out }}\n    target: {{ node: end, port: result }}\n"
+    );
+    let body_for = |file: &str| {
+        format!(
+            "#!/usr/bin/env bash\nset -euo pipefail\n\
+             printf 'concurrent\\n' > {file}\n\
+             printf 'ok\\n' > \"$PDO_OUTPUT_OUT\"\n"
+        )
+    };
+    let daemon = TestDaemon::spawn(seed(
+        yaml,
+        "deliver-concurrent",
+        vec![
+            ("left", body_for("left.txt")),
+            ("right", body_for("right.txt")),
+        ],
+    ))
+    .await
+    .unwrap();
+
+    let repo = daemon.repo_root();
+    let run_id = start_run(&daemon, name).await;
+    for node in ["left", "right"] {
+        let run = wait_for_node_status(&daemon, &run_id, node, "completed").await;
+        assert_eq!(
+            run["nodes"][node]["status"], "completed",
+            "{node} must complete — the runtime serialises nothing; run: {run}"
+        );
+    }
+
+    // Both files are on the branch. WHICH commit carries which is deliberately
+    // not asserted: whoever completed first took whatever was there.
+    let branch = format!("pdo/run-{run_id}");
+    let files = git_out(repo, &["log", "--name-only", "--format=", &branch]);
+    assert!(
+        files.contains("left.txt") && files.contains("right.txt"),
+        "the shared worktree's whole state reaches the branch: {files}"
+    );
+    let subjects = git_out(repo, &["log", "--format=%s", &branch]);
+    assert!(
+        subjects
+            .lines()
+            .any(|s| s == "left iter-1: completed" || s == "right iter-1: completed"),
+        "at least one delivery commit carries its own node's name: {subjects}"
+    );
+}
+
+// ── recovery: an isolated script keeps its directory and its work ────────────
+
+/// An isolated `script` gets the whole cycle, recovery included: killing its
+/// session and restarting the same iteration REUSES its sub-worktree in place, so
+/// the work it had already written is still there for the second attempt to
+/// deliver. Nothing here is agent-specific — the sub-worktree is a property of the
+/// isolation, not of the node type (#654 / ADR-0060).
+#[tokio::test]
+async fn restarting_an_interrupted_isolated_script_reuses_its_directory_and_work() {
+    ensure_pdo_on_path();
+    let name = "deliver-script-restart";
+    // Write first, then hang: the kill lands with real work on disk.
+    let body = "#!/usr/bin/env bash\nset -euo pipefail\n\
+        printf 'half done\\n' > partial.txt\n\
+        sleep 120\n";
+    let daemon = TestDaemon::spawn(seed(
+        one_worker_pipeline(name, "script", true),
+        "deliver-script-restart",
+        vec![("worker", body.to_string())],
+    ))
+    .await
+    .unwrap();
+
+    let run_id = start_run(&daemon, name).await;
+    wait_for_node_status(&daemon, &run_id, "worker", "running").await;
+    let sub = sub_worktree(&daemon, &run_id, "worker");
+    // The body has to have run far enough to have written its file.
+    let started = std::time::Instant::now();
+    while !sub.join("partial.txt").exists() && started.elapsed() < Duration::from_secs(30) {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    assert!(
+        sub.join("partial.txt").exists(),
+        "the script must have written its partial work before the kill"
+    );
+
+    let _ = Command::new("tmux")
+        .args([
+            "-L",
+            &daemon.tmux_socket(),
+            "kill-session",
+            "-t",
+            &format!("pdo-{run_id}-worker-iter-1"),
+        ])
+        .output();
+
+    let resp = reqwest::Client::new()
+        .post(format!("{}/runs/{run_id}/commands", daemon.url()))
+        .json(&serde_json::json!({
+            "kind": "restart_node", "node_id": "worker", "iter": 1
+        }))
+        .send()
+        .await
+        .unwrap();
+    let status = resp.status();
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(status, 200, "restart_node: {body}");
+    assert_eq!(
+        body["reused_sub_worktree"], true,
+        "the restart reuses the directory rather than cutting a new one: {body}"
+    );
+    assert!(
+        sub.join("partial.txt").exists(),
+        "…and the work the first attempt left is still there"
+    );
+}
+
+// ── the manual completion delivers too ───────────────────────────────────────
+
+/// AC1: the human's *Mark complete* (`mark_node_done`) is a completion path like
+/// any other and goes through the same delivery. Pre-#654 this arm ran neither
+/// the merge-back nor any worktree handling, so an interactive node marked done
+/// from the UI stranded its work.
+#[tokio::test]
+async fn the_manual_completion_delivers_like_every_other() {
+    let name = "deliver-manual";
+    let daemon = TestDaemon::spawn(seed(
+        one_worker_pipeline(name, "agent", true),
+        "deliver-manual",
+        vec![("worker", "You are a worker.\n".to_string())],
+    ))
+    .await
+    .unwrap();
+
+    let repo = daemon.repo_root();
+    let run_id = start_run(&daemon, name).await;
+    wait_for_node_status(&daemon, &run_id, "worker", "running").await;
+
+    let sub = sub_worktree(&daemon, &run_id, "worker");
+    std::fs::write(sub.join("by_hand.rs"), "pub fn by_hand() {}\n").unwrap();
+
+    let resp = reqwest::Client::new()
+        .post(format!("{}/runs/{run_id}/commands", daemon.url()))
+        .json(&serde_json::json!({
+            "kind": "mark_node_done", "node_id": "worker", "iter": 1
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        200,
+        "mark_node_done should complete the node"
+    );
+
+    let branch = format!("pdo/run-{run_id}");
+    let files = git_out(repo, &["log", "--name-only", "--format=", &branch]);
+    assert!(
+        files.contains("by_hand.rs"),
+        "the manual completion merged the sub-worktree back: {files}"
+    );
+    let run = get_run(&daemon, &run_id).await;
+    assert!(
+        !run["nodes"]["worker"]["delivery"].is_null(),
+        "…and recorded the delivery: {run}"
+    );
+}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -345,7 +345,7 @@ export type MarkNodeDoneRefusal =
   | "frontmatter_retry_pending"
   | "frontmatter_retry_exhausted"
   | "script_validation_failed"
-  | "doc_violated_code_immutability"
+  | "delivery_failed"
   | "merge_conflict"
   | "merge_resolution_failed"
   | "completion_rejected";
@@ -355,7 +355,7 @@ const KNOWN_REFUSALS: readonly string[] = [
   "frontmatter_retry_pending",
   "frontmatter_retry_exhausted",
   "script_validation_failed",
-  "doc_violated_code_immutability",
+  "delivery_failed",
   "merge_conflict",
   "merge_resolution_failed",
   "completion_rejected",

--- a/frontend/src/components/DiffSection.test.tsx
+++ b/frontend/src/components/DiffSection.test.tsx
@@ -112,14 +112,22 @@ describe("DiffSection", () => {
     expect(screen.getByText("No changes")).toBeInTheDocument();
   });
 
-  it("shows dropdown with completed isolated nodes only (#653)", async () => {
+  it("lists every node that delivered changes, isolated or not (#654)", async () => {
     const run = makeRun({
       nodes: {
-        "impl-1": makeNodeState({ node_id: "impl-1" }),
+        // Isolated, delivered.
+        "impl-1": makeNodeState({
+          node_id: "impl-1",
+          delivery: { before: "aaa", after: "bbb" },
+        }),
+        // NON-isolated, delivered — the node the pre-#654 picker dropped.
         "reviewer-1": makeNodeState({
           node_id: "reviewer-1",
           status: "completed",
+          delivery: { before: "bbb", after: "ccc" },
         }),
+        // Isolated but delivered nothing: no diff to show.
+        "scribe-1": makeNodeState({ node_id: "scribe-1", status: "completed" }),
       },
       node_defs: [
         {
@@ -142,6 +150,16 @@ describe("DiffSection", () => {
           inputs: [],
           outputs: [],
         },
+        {
+          id: "scribe-1",
+          name: "Scribe",
+          node_type: "agent",
+          isolated_worktree: true,
+          view_x: 0,
+          view_y: 0,
+          inputs: [],
+          outputs: [],
+        },
       ],
     });
 
@@ -156,9 +174,10 @@ describe("DiffSection", () => {
     expect(select).toBeInTheDocument();
 
     const options = select.querySelectorAll("option");
-    expect(options.length).toBe(2);
+    expect(options.length).toBe(3);
     expect(options[0].textContent).toBe("Aggregate (all changes)");
     expect(options[1].textContent).toContain("Implementer");
+    expect(options[2].textContent).toContain("Reviewer");
   });
 
   it("fetches per-node diff when a node is selected", async () => {
@@ -168,7 +187,10 @@ describe("DiffSection", () => {
 
     const run = makeRun({
       nodes: {
-        "impl-1": makeNodeState({ node_id: "impl-1" }),
+        "impl-1": makeNodeState({
+          node_id: "impl-1",
+          delivery: { before: "aaa", after: "bbb" },
+        }),
       },
       node_defs: [
         {

--- a/frontend/src/components/DiffSection.tsx
+++ b/frontend/src/components/DiffSection.tsx
@@ -15,20 +15,13 @@ export default function DiffSection({ run }: Props) {
   const [selectedNode, setSelectedNode] = useState<string>("");
   const [collapsedFiles, setCollapsedFiles] = useState<Set<number>>(new Set());
 
-  // #653/ADR-0060: a per-node diff exists for a node that worked in a
-  // sub-worktree of its own — it has a branch to diff. Isolation, not the node's
-  // type, is what says so; the frozen value on the NodeRun wins over the
-  // snapshot, because that is where the iteration actually ran.
-  const isolatedNodes = useMemo(() => {
+  // #654/ADR-0060: a per-node diff exists for a NodeRun that DELIVERED changes —
+  // isolated or not, agent or script. What it delivered is the two run-branch
+  // tips it moved between, so the type and the isolation say nothing here; only
+  // the delivery does.
+  const deliveringNodes = useMemo(() => {
     if (!run) return [];
-    return run.node_defs.filter((nd) => {
-      const ns = run.nodes[nd.id];
-      const isolated =
-        ns?.isolated_worktree ??
-        nd.isolated_worktree ??
-        (nd.node_type === "agent" || nd.node_type === "merge");
-      return isolated && ns?.status === "completed";
-    });
+    return run.node_defs.filter((nd) => Boolean(run.nodes[nd.id]?.delivery));
   }, [run]);
 
   const files = useMemo(() => parseUnifiedDiff(diff), [diff]);
@@ -102,7 +95,7 @@ export default function DiffSection({ run }: Props) {
             </div>
           ) : (
             <>
-              {isolatedNodes.length > 0 && (
+              {deliveringNodes.length > 0 && (
                 <select
                   data-testid="diff-node-select"
                   value={selectedNode}
@@ -111,7 +104,7 @@ export default function DiffSection({ run }: Props) {
                   style={{ fontSize: "10.5px" }}
                 >
                   <option value="">Aggregate (all changes)</option>
-                  {isolatedNodes.map((nd) => (
+                  {deliveringNodes.map((nd) => (
                     <option key={nd.id} value={nd.id}>
                       {nd.name ?? nd.id}
                     </option>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -658,7 +658,21 @@ export interface NodeState {
    * node that never started, a structural node, or a pre-#653 daemon.
    */
   isolated_worktree?: boolean;
+  /**
+   * #654/ADR-0060: what this NodeRun DELIVERED onto the run's branch — the two
+   * tips its delivery moved the branch between. Present for any NodeRun that
+   * delivered changes, isolated or not; absent for one that delivered nothing
+   * (no commit was written) and on a pre-#654 daemon. Its presence, never the
+   * node's type or isolation, is what says a per-node diff exists.
+   */
+  delivery?: NodeDelivery | null;
   cost?: NodeCost | null;
+}
+
+/** The two run-branch tips one delivery moved between (#654 / ADR-0060). */
+export interface NodeDelivery {
+  before: string;
+  after: string;
 }
 
 export interface EdgeInfo {

--- a/prompts/builtin/library-assistant.md
+++ b/prompts/builtin/library-assistant.md
@@ -83,6 +83,11 @@ nodes:
 either. There is no `doc-only` or `code-mutating` — a node's type names its
 execution role, never a guess about what it will touch.
 
+Either way, **never write git steps into a node's prompt**: the runtime keeps
+whatever a node committed itself, commits everything else it left behind, and
+merges an isolated NodeRun's worktree back — before the node is declared done and
+the downstream starts (#654 / ADR-0060).
+
 Work nodes (`agent` / `script`) have **emergent inputs**: an
 input port is created from each incoming edge and named after the edge's target
 port — you normally don't declare `inputs:` on them. Structural nodes


### PR DESCRIPTION
Closes #654

Un Node ne reçoit plus aucune consigne Git. Il modifie des fichiers ; le runtime livre ce qu'il laisse. `worktree_ops::deliver_node_work` conserve les commits que le Node a pris lui-même, stage le reste avec la sémantique de `git add -A`, crée un commit `<node-id> iter-<N>: completed` s'il reste quelque chose, puis merge le sous-worktree quand le Node est isolé. Rien à livrer, aucun commit.

**Chemin unique.** Les quatre routes de complétion — hook Stop et veille, `pdo complete`, `mark_node_done`, fin de Script — traversent `deliver_node_run` avant l'événement terminal, donc avant tout départ de l'aval. La complétion manuelle ne faisait ni merge ni commit : l'asymétrie qu'ADR-0035 consignait comme limite acceptée disparaît.

**Refus.** `doc_violated_code_immutability` disparaît avec toutes ses surfaces. `merge_failed` devient `delivery_failed` et couvre staging, commit et merge : il appende un `NodeInterrupted`, parque le Run en `awaiting_user`, conserve le travail sur disque. Un répertoire que git ne connaît pas n'est pas une panne.

**Diff.** Nouvel événement `node_delivered` (`before`/`after`), projeté sur `nodes.<id>.delivery`. Le diff par NodeRun existe désormais pour tout Agent ou Script qui a livré, isolé ou non ; le sélecteur de l'UI liste ce que les NodeRuns ont livré, pas seulement ce qu'ils sont. Comme le diff du Run, il exclut `.pdo/`.

## Validation

- `cargo test --workspace` : **2300 + 372 tests verts, 0 échec**.
- **Feature Path #654 : Pass**, cinq étapes sur cinq, aucun finding. Journey conduit contre un daemon réel construit depuis ce commit, sur un dépôt Git jetable et un `HOME` dédié. Pipeline `agentA` (Agent, non isolé) → `scriptB` (Script, isolé) : commit déterministe sur la branche du Run, `base_sha` de l'aval égal au commit de l'amont, merge du sous-worktree, `node_delivered` toujours avant `node_completed`. Un second Run n'écrivant que sous `.pdo/` termine avec `delivery: null` sur les deux nœuds et une branche inchangée.
- `.gitignore` reste la seule politique d'exclusion : un fichier ignoré écrit par l'agent est absent des deux commits.

Version bump 1.48.0 → 1.49.0, CHANGELOG à jour (#655 avait déjà pris 1.48.0 ; rebasé sur son merge, suite verte : 2310 + 372 tests).
