### PR TITLE
docs: make README easier to scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,139 +1,153 @@
 # Prompt Driven Orchestrator (PDO)
 
-**PDO is a graphical, agentic orchestrator built for software development.**
-You design pipelines on a visual canvas and run them on a deterministic runtime that keeps agents on the rails.
+PDO is a visual orchestrator for software-development agents.
 
-- **Deterministic routing** decides what runs next by mechanical rules, not an LLM's guess, so pipelines don't drift.
-- **Typed, enforced outputs** make every step produce a structured artifact you can read and trust, so you always understand what happened.
-- **Interactive Claude Code sessions** back every node, with a terminal right in the web UI: step in any time to watch, correct, or take over the development loop.
-- **Automated triggers** start pipelines on a schedule or from a script's signal, hands-free.
+![PDO web UI showing a feature pipeline, a live agent session, and typed output.](docs/pdo-ui.png)
 
-![PDO web UI: a feature pipeline mid-run, with a bounded implement/test loop on the canvas, a live Claude Code session in the web terminal, and a typed output (verdict, iteration, screenshots) on the right.](docs/pdo-ui.png)
+*A bounded implementation loop with a live terminal and typed output.*
 
-*A feature pipeline mid-run: a bounded implement/test loop, a live session in the web UI, and typed outputs the runtime routes on.*
+| Capability | Result |
+| --- | --- |
+| Visual pipelines | Build agent workflows on a canvas |
+| Deterministic routing | Route nodes with mechanical rules |
+| Typed outputs | Validate, preserve, and pass structured artifacts |
+| Interactive sessions | Watch, guide, or take over from the web terminal |
+| Triggers | Start runs on a schedule or from a script |
 
-## Install
+## Quick start
 
-Homebrew (macOS and Linux):
+### 1. Install PDO
+
+Homebrew works on macOS and Linux.
 
 ```bash
 brew install Loulen/tap/pdo
 ```
 
-Or the install script (Linux and macOS, x86_64 and ARM64):
+The install script supports Linux and macOS on x86_64 and ARM64.
 
 ```bash
 curl --proto '=https' --tlsv1.2 -LsSf https://github.com/Loulen/prompt-driven-orchestrator/releases/latest/download/pdo-daemon-installer.sh | sh
 ```
 
-Both install a checksum-verified `pdo` binary and put it on your `PATH`. Update with `brew upgrade pdo` or by re-running the script. Pin a version by replacing `latest` with a tag, e.g. `.../releases/download/v1.31.2/pdo-daemon-installer.sh`.
+Both methods install a checksum-verified `pdo` binary on your `PATH`.
 
-### Runtime requirements
+| Task | Command |
+| --- | --- |
+| Update with Homebrew | `brew upgrade pdo` |
+| Update with the script | Run the install script again |
+| Install a specific release | Replace `latest` with a tag such as `v1.31.2` |
 
-The binary embeds the whole web UI. The daemon shells out to two tools you install separately:
+### 2. Install runtime requirements
 
-- **tmux.** Every node and run shell is a tmux session.
-- **git.** Each node runs in its own git worktree.
+| Requirement | Purpose |
+| --- | --- |
+| `tmux` | Runs node and shell sessions |
+| `git` | Creates an isolated worktree for each node |
+| An agent harness | Runs the agent inside each node |
 
 ```bash
-brew install tmux git   # or your system package manager
+brew install tmux git
 ```
 
-Each node drives its agent through a harness of your choice. PDO ships descriptors for `claude` (the default), `opencode` and `copilot`, and the set is pluggable ([ADR-0045](docs/adr/0045-un-harnais-se-declare-par-un-template-d-argv-les-capacites-remplissent-les-trous.md)). You install the harness and its own dependencies. For Claude Code that means the `claude` CLI, Node.js >= 22 for MCP servers, and ripgrep. What each harness can and cannot do is in [Support](#support); what you have to set up yourself is in [Prerequisites](#prerequisites).
+PDO includes descriptors for `claude`, `opencode`, and `copilot`.
 
-Start the daemon:
+### 3. Start PDO
 
 ```bash
-pdo daemon                 # http://localhost:5172
+pdo daemon
 ```
 
-To run it at boot and survive logout, install it as a service (this works as-is after a Homebrew install):
+Open [http://localhost:5172](http://localhost:5172).
+
+### 4. Run PDO as a service
 
 ```bash
-pdo service install        # add --port to change 5172, --dry-run to preview
+pdo service install
 pdo service status
 pdo service uninstall
 ```
 
-### Behind a reverse proxy
+`pdo service install --port <port>` changes the default port, and `--dry-run` previews the service definition.
 
-The daemon binds `0.0.0.0:<port>` with **no authentication and no TLS** — it is meant to sit behind something that provides both. As a DNS-rebinding / cross-site-WebSocket-hijacking guard, both WebSockets (`/ws`, the dashboard event stream, and `/sessions/<id>/pty`, the terminal) reject any browser `Origin` other than `localhost` / `127.0.0.1:<port>`. Behind a reverse proxy or an ALB on a public domain the browser sends the *public* origin (`https://pdo.example.tld`), so with the default allowlist the terminal and dashboard go dark (HTTP 403).
+## Reverse proxy
 
-Name the public origin(s) with `PDO_ALLOWED_WS_ORIGINS`, a comma-separated list of **exact** origins (`scheme://host[:port]`, as the browser sends them) that **add to** the localhost defaults — loopback keeps working:
+The daemon listens on `0.0.0.0:<port>` without authentication or TLS.
+
+Put authentication and TLS in front of PDO before exposing it beyond a trusted network.
+
+Set every public browser origin as an exact `scheme://host[:port]` value.
 
 ```bash
 PDO_ALLOWED_WS_ORIGINS="https://pdo.example.tld,https://pdo.internal:8443" pdo daemon
 ```
 
-Set it in the service unit (`pdo service install` runs `pdo daemon` for you; add the variable to that unit's environment). Nothing changes on the client: the UI derives its WebSocket URL from `window.location`, so `wss://` behind TLS already works. This only restores the origin guard for your domain — it adds **neither auth nor TLS**; the proxy must carry authentication. The "Mono-user, local" posture is unchanged.
+| Setting | Behavior |
+| --- | --- |
+| Default WebSocket origins | `localhost` and `127.0.0.1:<port>` |
+| Extra WebSocket origins | Comma-separated `PDO_ALLOWED_WS_ORIGINS` values |
+| WebSocket routes | `/ws` and `/sessions/<id>/pty` |
+| TLS proxy | The UI uses `wss://` automatically |
 
-## Support
+Add `PDO_ALLOWED_WS_ORIGINS` to the service environment when the daemon runs as a service.
+
+## Harness support
 
 <!-- support-table:begin -->
 <!-- Generated from crates/pdo-daemon/src/harness_probes.rs. Do not edit by hand: run `make support-table`. `make check` fails if this block has drifted. -->
 
-PDO ships these harnesses compiled in. **Launching, attaching, resuming and completing a node work on every one of them.** Everything *beyond* launching is a **capability**, written harness by harness — and a harness that lacks one says so rather than quietly doing nothing.
+PDO can launch, attach, resume, and complete nodes with every built-in harness.
 
 | Capability | What PDO does with it | `claude` 2.1.246 | `opencode` 1.18.18 | `copilot` 1.0.80 |
 | --- | --- | --- | --- | --- |
-| **Cost** | Turn a Run into a dollar figure. Absent ⇒ the Run's cost reads "—" and names the harness, never `$0` | ✅ derived — per-message token usage × the price table | ❌ | ✅ reported — the harness's own billing unit × a published constant |
-| **Transcript** | Find the session's transcript on disk — what cost and end-of-turn read | ✅ the JSONL transcript, keyed by working directory | ❌ | ✅ the event journal, keyed by the session identity PDO imposed |
-| **End of turn** | Complete a node by itself when its turn ends. Absent ⇒ the agent runs `pdo complete`, or you do | ✅ an injected `Stop` hook, plus the transcript tail as the sweep's fallback | ❌ | ✅ the journal's explicit `assistant.turn_end` event |
-| **Usage-limit menu** | Notice a session parked on the harness's usage-limit menu (informational, no recovery) | ✅ the interactive "wait for limit to reset" menu, matched in a pane capture | ❌ | ❌ |
-| **Sandbox staging floor** | Hold a sandboxed session's staged home — credentials, settings, pre-granted trust | ✅ a staged `.claude` home — credentials, org managed settings, pre-granted trust | ❌ | ❌ |
-| **Context usage** | Measure a session's context-window peak, in tokens, for Stats → Performance (#585). Absent ⇒ no Context column for the harness, never an invented reading | ✅ derived — per-turn token usage from the transcript, deduplicated and maxed | ❌ | ✅ derived — the journal's cumulative usage counters, converted to a per-turn contribution and maxed |
+| **Cost** | Show the Run cost | ✅ derived: per-message token usage × the price table | ❌ | ✅ reported: the harness's own billing unit × a published constant |
+| **Transcript** | Find the session transcript | ✅ the JSONL transcript, keyed by working directory | ❌ | ✅ the event journal, keyed by the session identity PDO imposed |
+| **End of turn** | Complete a node when its turn ends | ✅ an injected `Stop` hook, plus the transcript tail as the sweep's fallback | ❌ | ✅ the journal's explicit `assistant.turn_end` event |
+| **Usage-limit menu** | Detect the harness usage-limit menu | ✅ the interactive "wait for limit to reset" menu, matched in a pane capture | ❌ | ❌ |
+| **Sandbox staging floor** | Stage credentials, settings, and trust in a sandbox | ✅ a staged `.claude` home: credentials, org managed settings, pre-granted trust | ❌ | ❌ |
+| **Context usage** | Show peak context-window usage | ✅ derived: per-turn token usage from the transcript, deduplicated and maxed | ❌ | ✅ derived: the journal's cumulative usage counters, converted to a per-turn contribution and maxed |
 
-The version beside each harness is the **last validated** one — the build PDO's knowledge of that harness was measured against. It is a documented bound, not a guard: PDO launches on whatever version you have installed and says nothing about the difference. It is written down because the same harness can sit on one machine twice, months apart, with different event schemas and different model lists — and an inventory taken against the wrong install is worse than no inventory.
+Each header shows the last validated harness version; PDO does not enforce it.
 
-Why a capability is absent:
-
-| Harness | Capability | Why |
-| --- | --- | --- |
-| `opencode` | Cost | It writes its own per-message cost into a SQLite in four buckets that do not map onto `claude`'s. A cost is code, never a declared mini-language (ADR-0045), and nobody has written that code yet. |
-| `opencode` | Transcript | It migrated its sessions into a SQLite and left months of dead JSON on disk. A store is not a contract, so PDO declares no resolution rather than read zeros off stale files. |
-| `opencode` | End of turn | It exposes no end-of-turn signal PDO can read: its argv template carries no `{settings}` hole for a `Stop` hook, and it has no transcript for a sweep to tail (see above). |
-| `opencode` | Usage-limit menu | The menu wording is `claude`'s. Matching another harness's pane against it would invent a state, and the probe triggers no recovery anyway (ADR-0012). |
-| `opencode` | Sandbox staging floor | Configuring a harness is a documented prerequisite, not PDO code. A sandboxed Run on it holds by your image and the profile's `$HOME` exceptions, and PDO says so once, visibly. |
-| `opencode` | Context usage | Its own SQLite reports token usage in four buckets that do not map onto `claude`'s (see Cost above), and it carries no transcript PDO can tail (see Transcript above) — a context peak is code, written per harness (#585), and nobody has written that code yet. |
-| `copilot` | Usage-limit menu | The menu wording is `claude`'s, its own documentation admits the textual anchor drifts each release, and the probe triggers no recovery (ADR-0012). Declaring it absent degrades nothing actionable. |
-| `copilot` | Sandbox staging floor | Configuring a harness is a documented prerequisite, not PDO code (ADR-0031). A sandboxed Run on it holds by your image and the profile's `$HOME` exceptions, and PDO says so once, visibly. |
-
-A harness **you** declare in `~/.pdo/harnesses/descriptors.yaml` carries no code, so it is absent on all six — it still launches, attaches, resumes, and completes when its agent runs `pdo complete`. That is a legitimate way to run a harness, not a broken one.
+Custom descriptors in `~/.pdo/harnesses/descriptors.yaml` can launch, attach, resume, and complete nodes through `pdo complete`.
 
 <!-- support-table:end -->
 
-## Prerequisites
+## Harness prerequisites
 
-PDO neither embeds nor installs a harness, and it does not configure one for you. Three things are yours to set up. None of them is code PDO could write on your behalf, and none of them is a bug when it is missing — but each one turns into a node that goes nowhere, so they are worth naming.
+| Requirement | Setup |
+| --- | --- |
+| Authentication | Log in with each harness before using it through PDO |
+| An approved working directory | Trust the target repository root once; trust cascades to subdirectories |
+| An installed version | Compare your installed harness with the last validated version in the support table |
 
-**Authentication.** Log each harness in yourself, the way its own documentation says. PDO launches the binary and inherits whatever session you already have — it never handles your credentials. **Outside a sandboxed Run, PDO does not stage any harness's home**: sessions load your `~/.claude`, your MCP servers, your `copilot` config, verbatim. Inside a sandbox it stages a home only for a harness that declares a staging floor (see [Support](#support)); for the others, a sandboxed Run holds by your image and the profile's `$HOME` exceptions, and PDO says so once rather than pretending.
+Outside sandboxed runs, PDO does not stage any harness's home.
 
-**An approved working directory.** A harness may gate its first turn behind a one-time "do you trust this folder?" dialog, and **the autonomy flags do not cover it**. Measured on `copilot`: `--allow-all` and `--no-ask-user` remove every tool, path and URL permission prompt, and the trust dialog still blocks interactive mode — the node sits there alive and mute, which is the least readable failure there is. The fix is one approval, not a flag: **trust cascades to subdirectories**, so trusting your target repository's root once covers every node sub-worktree PDO creates beneath it, for every Run, forever. Do it once, by hand, before the first Run on a new repo.
+Inside a sandbox, the image and profile define the available harness configuration.
 
-**An installed version.** The [Support](#support) table names the **last validated version** of each harness. PDO does not read your installed version, does not compare it, and will not refuse to launch on a different one — it is a bound you can read, not a guard that runs. Worth checking which build you actually have before trusting a row: half of a first `copilot` inventory was taken against a second, months-old install of the same harness sitting on the same machine.
+## How PDO works
 
-## Design principles
+| Principle | Behavior | Reference |
+| --- | --- | --- |
+| Deterministic orchestration | Typed outputs and graph rules choose the next node | [ADR-0002](docs/adr/0002-mechanical-conditionals-only.md), [ADR-0011](docs/adr/0011-conditional-edges-and-loop-regions.md) |
+| Typed artifacts | Each node emits validated frontmatter and a content body | [ADR-0020](docs/adr/0020-archive-preserves-outputs.md) |
+| Expert control | Interactive nodes wait for input and expose a live terminal | [ADR-0005](docs/adr/0005-inline-xterm-over-os-spawn.md) |
+| Deliberate autonomy | Only nodes placed in the pipeline can push, open PRs, or merge | [ADR-0012](docs/adr/0012-triggers-and-trust-earned-autonomy.md) |
+| Local agent setup | Sessions use your harness configuration and skills | [ADR-0045](docs/adr/0045-un-harnais-se-declare-par-un-template-d-argv-les-capacites-remplissent-les-trous.md) |
 
-**Deterministic orchestration.** The graph decides what runs next by mechanical rules on typed outputs, never an LLM router. Agents do the work inside each node, but they never decide the path between nodes, so a pipeline runs the same way every time and does not drift. ([ADR-0002](docs/adr/0002-mechanical-conditionals-only.md), [ADR-0011](docs/adr/0011-conditional-edges-and-loop-regions.md))
+See [CONTEXT.md](CONTEXT.md) for the domain model.
 
-**Tailored, typed outputs you can read and trust.** This is the heart of PDO. Each node emits a document whose shape you designed: a schema-checked frontmatter (verdict, score, decisions) plus a body that can be markdown, a mermaid diagram, an image set, or whatever fits the decision. The runtime validates it on completion (with one bounded chance for the agent to self-correct), routes the graph from it, feeds it to the next node as compact context, and keeps it after the run as a durable, auditable record. Your solution's reasoning becomes structured knowledge instead of a lost chat log. ([ADR-0020](docs/adr/0020-archive-preserves-outputs.md))
+## Development
 
-**Expert in the loop.** The evolution of "human in the loop". Rather than babysitting a run, the expert is handed only the information a decision actually needs, in the format built to convey it. That is the reason the outputs are typed and tailored: less watching, more pertinent input. And when you do step in, every node is a real Claude Code session with a terminal in the web UI, so you can watch, converse, correct, or take over. Mark a node `interactive` and it waits for your input by design. ([ADR-0005](docs/adr/0005-inline-xterm-over-os-spawn.md))
+### Prerequisites
 
-**Deliberate, then autonomous.** The default keeps the expert in the loop; full autonomy is something a pipeline earns, never a favor the runtime grants. PDO never pushes, opens PRs, or merges on its own: only a node you placed does. A pipeline behaves identically whether you launch it by hand or a trigger fires it. ([ADR-0012](docs/adr/0012-triggers-and-trust-earned-autonomy.md))
+| Tool | Version |
+| --- | --- |
+| [Rust](https://rustup.rs/) | Stable |
+| [Node.js](https://nodejs.org/) | 22 or newer |
+| [pnpm](https://pnpm.io/) | Use the version declared by the project |
 
-**It's your Claude Code.** PDO does not manage skills or config. Sessions load your `~/.claude` skills, your MCP servers, and your setup verbatim.
-
-See [CONTEXT.md](CONTEXT.md) for the full domain model.
-
-## Prerequisites (development)
-
-- [Rust](https://rustup.rs/) (stable)
-- [Node.js](https://nodejs.org/) >= 22
-
-## Local development
-
-### Frontend (Vite HMR)
+### Frontend
 
 ```bash
 cd frontend
@@ -141,17 +155,18 @@ pnpm install
 pnpm run dev
 ```
 
-The Vite dev server starts on `http://localhost:5173` and proxies `/ws`, `/sessions` and the REST routes to the daemon at `127.0.0.1:5172`. The two WebSocket proxies set `rewriteWsOrigin: true` so the daemon's Origin check (see *Behind a reverse proxy*) accepts the dev server — without it the dashboard and terminal would 403 in `make dev`.
+The Vite server runs at [http://localhost:5173](http://localhost:5173) with hot reload.
+
+It proxies API and WebSocket traffic to `127.0.0.1:5172`.
 
 ### Daemon
 
 ```bash
 cargo run -p pdo-daemon -- daemon
-# or with a custom port:
 cargo run -p pdo-daemon -- daemon --port 9999
 ```
 
-The daemon binds `0.0.0.0:5172` by default and serves the real embedded UI (the frontend `dist/` is built by `build.rs` and bundled via `rust-embed`), so `http://localhost:5172` works on its own. For frontend work, use the Vite dev server anyway — it gives you HMR and proxies API + WebSocket calls back to the daemon.
+The daemon serves the embedded frontend at [http://localhost:5172](http://localhost:5172).
 
 ### Production build
 
@@ -160,7 +175,7 @@ cd frontend && pnpm run build && cd ..
 cargo build --release -p pdo-daemon
 ```
 
-The release binary embeds the frontend `dist/` via `rust-embed` and serves it at `/`.
+The release binary embeds `frontend/dist/`.
 
 ### CLI
 
@@ -168,19 +183,22 @@ The release binary embeds the frontend `dist/` via `rust-embed` and serves it at
 cargo run -p pdo-daemon -- --help
 ```
 
-## Build & test commands
+### Build and test commands
 
-| Purpose             | Command                                              |
-| ------------------- | ---------------------------------------------------- |
-| Type-check Rust     | `cargo check --workspace --all-targets`              |
-| Test Rust           | `cargo test --workspace`                             |
-| Lint Rust           | `cargo clippy --workspace --all-targets -- -D warnings` |
-| Format Rust         | `cargo fmt --all --check`                            |
-| Type-check frontend | `cd frontend && pnpm run typecheck`                   |
-| Test frontend       | `cd frontend && pnpm run test`                        |
-| Lint frontend       | `cd frontend && pnpm run lint`                        |
-| Build frontend      | `cd frontend && pnpm run build`                       |
+| Purpose | Command |
+| --- | --- |
+| Check Rust | `cargo check --workspace --all-targets` |
+| Test Rust | `cargo test --workspace` |
+| Lint Rust | `cargo clippy --workspace --all-targets -- -D warnings` |
+| Check Rust formatting | `cargo fmt --all --check` |
+| Type-check frontend | `cd frontend && pnpm run typecheck` |
+| Test frontend | `cd frontend && pnpm run test` |
+| Lint frontend | `cd frontend && pnpm run lint` |
+| Build frontend | `cd frontend && pnpm run build` |
 
 ## Architecture
 
-See [CONTEXT.md](CONTEXT.md) for the domain glossary and `docs/adr/` for architectural decisions.
+| Resource | Content |
+| --- | --- |
+| [CONTEXT.md](CONTEXT.md) | Domain glossary and module map |
+| [`docs/adr/`](docs/adr/) | Architecture decisions |

--- a/crates/pdo-daemon/src/harness_support.rs
+++ b/crates/pdo-daemon/src/harness_support.rs
@@ -1,30 +1,25 @@
 //! The published support matrix — capability × harness, **rendered from the code
 //! that declares it** (#617, ADR-0045/0051).
 //!
-//! PDO's instrumentation is unequal on purpose: everything beyond launching a
-//! harness is a capability written harness by harness ([`crate::harness_probes`]).
-//! That inequality is only honest if it is **published** — which is this module.
+//! Everything beyond launching a harness is a capability written harness by
+//! harness ([`crate::harness_probes`]). This module publishes that matrix.
 //!
 //! The table has **one source of truth**: every ✅/❌ is read from
 //! [`crate::harness_probes::probes_for`] at render time, so adding a harness or a
 //! capability moves the table with no second edit, and `make check` fails if the
 //! committed block has drifted ([`check`]). Don't hand-write a cell.
 //!
-//! Two things cannot be read off the dispatch table, so they are declared here:
-//!
-//! - the **motive** of each absence ([`ABSENCES`]) — prose, not a boolean, and
-//!   enforced by [`tests::every_absence_on_the_floor_has_a_motive`] so the table
-//!   can never publish a bare ❌;
-//! - the **last validated version** of each binary
-//!   ([`crate::harness_registry::validated_version`]) — a documented bound, never a
-//!   guard: PDO launches on any installed version, silently (out of scope, #612).
+//! The **last validated version** of each binary cannot be read off the dispatch
+//! table, so [`crate::harness_registry::validated_version`] declares it. This is a
+//! documented bound, not a guard: PDO launches on any installed version (out of
+//! scope, #612).
 //!
 //! The *mechanism* behind a present capability is not declared here either: each
 //! capability enum labels its own variants (`CostSource::label`, …), so the table
 //! can never name a mechanism the code no longer dispatches to.
 
 use crate::harness_probes::probes_for;
-use crate::harness_registry::{embedded_floor, validated_version, COPILOT, OPENCODE};
+use crate::harness_registry::{embedded_floor, validated_version};
 
 /// The HTML comment opening the generated block in the README. Everything between
 /// this line and [`END_MARKER`] is owned by the generator.
@@ -74,30 +69,12 @@ impl Capability {
     /// actually costs them.
     pub(crate) fn blurb(self) -> &'static str {
         match self {
-            Capability::Cost => {
-                "Turn a Run into a dollar figure. Absent ⇒ the Run's cost reads \
-                                 \"—\" and names the harness, never `$0`"
-            }
-            Capability::Transcript => {
-                "Find the session's transcript on disk — what cost and end-of-turn read"
-            }
-            Capability::TurnEnd => {
-                "Complete a node by itself when its turn ends. Absent ⇒ the \
-                                    agent runs `pdo complete`, or you do"
-            }
-            Capability::UsageLimit => {
-                "Notice a session parked on the harness's usage-limit menu \
-                                       (informational, no recovery)"
-            }
-            Capability::Staging => {
-                "Hold a sandboxed session's staged home — credentials, \
-                                    settings, pre-granted trust"
-            }
-            Capability::ContextUsage => {
-                "Measure a session's context-window peak, in tokens, for Stats → \
-                                        Performance (#585). Absent ⇒ no Context column for the \
-                                        harness, never an invented reading"
-            }
+            Capability::Cost => "Show the Run cost",
+            Capability::Transcript => "Find the session transcript",
+            Capability::TurnEnd => "Complete a node when its turn ends",
+            Capability::UsageLimit => "Detect the harness usage-limit menu",
+            Capability::Staging => "Stage credentials, settings, and trust in a sandbox",
+            Capability::ContextUsage => "Show peak context-window usage",
         }
     }
 
@@ -117,76 +94,6 @@ impl Capability {
     }
 }
 
-/// Why an embedded harness is **absent** on a capability. Declared, because a
-/// motive is prose; enforced, because a missing entry fails a test rather than
-/// publishing a bare ❌.
-///
-/// A data-declared harness needs no row: it is absent on all six for one reason —
-/// PDO carries no code for it — and the block says that in a sentence.
-const ABSENCES: &[(&str, Capability, &str)] = &[
-    (
-        OPENCODE,
-        Capability::Cost,
-        "It writes its own per-message cost into a SQLite in four buckets that do not map onto \
-         `claude`'s. A cost is code, never a declared mini-language (ADR-0045), and nobody has \
-         written that code yet.",
-    ),
-    (
-        OPENCODE,
-        Capability::Transcript,
-        "It migrated its sessions into a SQLite and left months of dead JSON on disk. A store is \
-         not a contract, so PDO declares no resolution rather than read zeros off stale files.",
-    ),
-    (
-        OPENCODE,
-        Capability::TurnEnd,
-        "It exposes no end-of-turn signal PDO can read: its argv template carries no `{settings}` \
-         hole for a `Stop` hook, and it has no transcript for a sweep to tail (see above).",
-    ),
-    (
-        OPENCODE,
-        Capability::UsageLimit,
-        "The menu wording is `claude`'s. Matching another harness's pane against it would invent \
-         a state, and the probe triggers no recovery anyway (ADR-0012).",
-    ),
-    (
-        OPENCODE,
-        Capability::Staging,
-        "Configuring a harness is a documented prerequisite, not PDO code. A sandboxed Run on it \
-         holds by your image and the profile's `$HOME` exceptions, and PDO says so once, visibly.",
-    ),
-    (
-        OPENCODE,
-        Capability::ContextUsage,
-        "Its own SQLite reports token usage in four buckets that do not map onto `claude`'s \
-         (see Cost above), and it carries no transcript PDO can tail (see Transcript above) — a \
-         context peak is code, written per harness (#585), and nobody has written that code yet.",
-    ),
-    (
-        COPILOT,
-        Capability::UsageLimit,
-        "The menu wording is `claude`'s, its own documentation admits the textual anchor drifts \
-         each release, and the probe triggers no recovery (ADR-0012). Declaring it absent \
-         degrades nothing actionable.",
-    ),
-    (
-        COPILOT,
-        Capability::Staging,
-        "Configuring a harness is a documented prerequisite, not PDO code (ADR-0031). A sandboxed \
-         Run on it holds by your image and the profile's `$HOME` exceptions, and PDO says so \
-         once, visibly.",
-    ),
-];
-
-/// The declared motive for `harness` being absent on `capability`, or `None` when
-/// none was declared (which a test forbids for the embedded floor).
-pub(crate) fn absence_motive(harness: &str, capability: Capability) -> Option<&'static str> {
-    ABSENCES
-        .iter()
-        .find(|(h, c, _)| *h == harness && *c == capability)
-        .map(|(_, _, why)| *why)
-}
-
 /// Render the support block — everything that goes between the two markers.
 ///
 /// Pure: no IO, no clock. Harness axis = [`embedded_floor`] in declaration order,
@@ -201,10 +108,7 @@ pub fn render() -> String {
          run `make support-table`. `make check` fails if this block has drifted. -->\n\n",
     );
     out.push_str(
-        "PDO ships these harnesses compiled in. **Launching, attaching, resuming and completing a \
-         node work on every one of them.** Everything *beyond* launching is a **capability**, \
-         written harness by harness — and a harness that lacks one says so rather than quietly \
-         doing nothing.\n\n",
+        "PDO can launch, attach, resume, and complete nodes with every built-in harness.\n\n",
     );
 
     out.push_str("| Capability | What PDO does with it |");
@@ -221,7 +125,10 @@ pub fn render() -> String {
         out.push_str(&format!("| **{}** | {} |", cap.title(), cap.blurb()));
         for h in &harnesses {
             match cap.mechanism(h) {
-                Some(mechanism) => out.push_str(&format!(" ✅ {mechanism} |")),
+                Some(mechanism) => {
+                    let concise = mechanism.replace(" — ", ": ");
+                    out.push_str(&format!(" ✅ {concise} |"));
+                }
                 None => out.push_str(" ❌ |"),
             }
         }
@@ -229,36 +136,12 @@ pub fn render() -> String {
     }
 
     out.push_str(
-        "\nThe version beside each harness is the **last validated** one — the build PDO's \
-         knowledge of that harness was measured against. It is a documented bound, not a guard: \
-         PDO launches on whatever version you have installed and says nothing about the \
-         difference. It is written down because the same harness can sit on one machine twice, \
-         months apart, with different event schemas and different model lists — and an inventory \
-         taken against the wrong install is worse than no inventory.\n",
+        "\nEach header shows the last validated harness version; PDO does not enforce it.\n",
     );
 
-    let mut rows: Vec<(String, Capability)> = Vec::new();
-    for h in &harnesses {
-        for cap in Capability::ALL {
-            if cap.mechanism(h).is_none() {
-                rows.push((h.clone(), cap));
-            }
-        }
-    }
-    if !rows.is_empty() {
-        out.push_str("\nWhy a capability is absent:\n\n");
-        out.push_str("| Harness | Capability | Why |\n| --- | --- | --- |\n");
-        for (h, cap) in rows {
-            let why = absence_motive(&h, cap)
-                .unwrap_or("*(undocumented — this is a bug: see `harness_support::ABSENCES`)*");
-            out.push_str(&format!("| `{h}` | {} | {why} |\n", cap.title()));
-        }
-    }
-
     out.push_str(
-        "\nA harness **you** declare in `~/.pdo/harnesses/descriptors.yaml` carries no code, so it \
-         is absent on all six — it still launches, attaches, resumes, and completes when its \
-         agent runs `pdo complete`. That is a legitimate way to run a harness, not a broken one.\n\n",
+        "\nCustom descriptors in `~/.pdo/harnesses/descriptors.yaml` can launch, attach, resume, and \
+         complete nodes through `pdo complete`.\n\n",
     );
     out.push_str(END_MARKER);
     out.push('\n');
@@ -338,44 +221,7 @@ fn first_difference(committed: &str, expected: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::harness_registry::CLAUDE;
-
-    #[test]
-    fn every_absence_on_the_floor_has_a_motive() {
-        for d in embedded_floor() {
-            for cap in Capability::ALL {
-                if cap.mechanism(&d.name).is_none() {
-                    let why = absence_motive(&d.name, cap).unwrap_or_else(|| {
-                        panic!(
-                            "{} is absent on {} with no declared motive — add one to \
-                             harness_support::ABSENCES",
-                            d.name,
-                            cap.title()
-                        )
-                    });
-                    assert!(
-                        why.trim().len() > 20,
-                        "{} / {}: a motive must actually say something",
-                        d.name,
-                        cap.title()
-                    );
-                }
-            }
-        }
-    }
-
-    #[test]
-    fn no_motive_is_declared_for_a_capability_that_is_present() {
-        // A stale motive for a since-implemented capability is never rendered, so
-        // nothing but this catches the contradiction.
-        for (harness, cap, _) in ABSENCES {
-            assert!(
-                cap.mechanism(harness).is_none(),
-                "{harness} implements {} — remove its stale absence motive",
-                cap.title()
-            );
-        }
-    }
+    use crate::harness_registry::{CLAUDE, COPILOT, OPENCODE};
 
     #[test]
     fn the_matrix_reads_the_dispatch_table_not_a_hand_written_list() {
@@ -412,15 +258,9 @@ mod tests {
         for cap in Capability::ALL {
             assert!(block.contains(cap.title()), "{} missing", cap.title());
         }
-        assert!(block.contains("✅ derived — per-message token usage × the price table"));
+        assert!(block.contains("✅ derived: per-message token usage × the price table"));
         assert!(block.contains("❌"));
-        for (h, cap, why) in ABSENCES {
-            assert!(
-                block.contains(why),
-                "{h} / {} motive not published",
-                cap.title()
-            );
-        }
+        assert!(!block.contains("Why a capability is absent"));
         assert!(block.starts_with(BEGIN_MARKER));
         assert!(block.trim_end().ends_with(END_MARKER));
     }


### PR DESCRIPTION
## Summary

- reorganize the README around quick-start steps, tables, commands, and the existing screenshot
- keep runtime, harness, and development prerequisites concise
- remove explanations for unsupported harness capabilities
- update the generated support-table renderer to preserve the shorter format

## Checks

- `cargo test -p pdo-daemon harness_support`
- `cargo test -p pdo-daemon support_table_committed`
- `cargo clippy -p pdo-daemon --lib -- -D warnings`
- generated support-table drift check