### PR TITLE
feat(skills): banque de skills — modèle, API et panneau Settings (#668)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ ascendante** : la casse se signale ici et par un bump majeur, jamais en gardant 
 morts. Seule contrainte non négociable — les **données historiques restent lisibles** : un Run
 archivé s'ouvre et se chiffre quelle que soit la version qui a écrit son payload.
 
+## 1.51.0
+
+**Banque de skills** (#668 ; story #666, spec #667 ; ADR-0062). L'instance gère une banque de
+skills depuis *Instance settings › Manage skills…* : création par collage d'un `SKILL.md`
+(frontmatter validé en direct — nom kebab-case, description obligatoire —, refus sans écriture
+disque), rangement en dossiers par glisser-déposer, renommage inline (unicité insensible à la
+casse) et suppression précédée d'un inventaire des référents (instance, projets, pipelines, runs).
+Chaque skill vit sous `<repo>/.pdo/skills/<id>/SKILL.md`, à côté de `pdo.db`. API REST sous
+`/settings/skills`.
+
 ## 1.50.0
 
 **Provisionnement déclaratif des worktrees** (#630 ; ADR-0061). Un worktree de Run ou de Node

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1926,7 +1926,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "1.50.0"
+version = "1.51.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "1.50.0"
+version = "1.51.0"
 license = "MIT"
 description = "Prompt-Driven Orchestrator — a local daemon that runs and supervises agentic coding pipelines"
 repository = "https://github.com/Loulen/prompt-driven-orchestrator"

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -72,6 +72,7 @@ mod scheduler;
 mod scheduler_dispatcher;
 mod scheduler_interpreter;
 mod service_unit;
+mod skill_bank;
 pub mod stale_detector;
 mod stats;
 mod stats_performance;
@@ -100,7 +101,7 @@ use axum::extract::{
 };
 use axum::http::{header, HeaderMap, Method, StatusCode, Uri};
 use axum::response::{Html, IntoResponse, Response};
-use axum::routing::{get, post};
+use axum::routing::{get, post, put};
 use axum::Router;
 use clap::{Parser, Subcommand};
 use rust_embed::Embed;
@@ -4030,6 +4031,24 @@ fn build_router(state: Arc<AppState>) -> Router {
             "/settings/agent-profiles/{id}/referents",
             get(get_agent_profile_referents),
         )
+        // Banque de skills (#668, ADR-0062): the bank's index + content CRUD, the
+        // folder hierarchy, and the referents endpoint the delete dialog reads.
+        // Folders sit under their own prefix (`/settings/skill-folders`) rather than
+        // `/settings/skills/folders`, so they can never shadow a skill id.
+        .route("/settings/skills", get(list_skills).post(create_skill))
+        .route(
+            "/settings/skills/{id}",
+            get(get_skill).put(update_skill).delete(delete_skill),
+        )
+        .route("/settings/skills/{id}/referents", get(get_skill_referents))
+        .route(
+            "/settings/skill-folders",
+            get(list_skill_folders).post(create_skill_folder),
+        )
+        .route(
+            "/settings/skill-folders/{id}",
+            put(update_skill_folder).delete(delete_skill_folder),
+        )
         .route("/settings/sandbox-profiles", get(list_sandbox_profiles))
         .route(
             "/settings/sandbox-profiles/{name}",
@@ -4601,6 +4620,12 @@ async fn init_db(db: &sqlx::SqlitePool) -> Result<()> {
     agent_profile::init(db)
         .await
         .context("failed to create agent_profiles table")?;
+
+    // The Banque de skills index (#668, ADR-0062). Content lives on disk under
+    // `<repo_root>/.pdo/skills/<id>/`; nothing is seeded.
+    skill_bank::init(db)
+        .await
+        .context("failed to create skill bank tables")?;
 
     Ok(())
 }
@@ -9633,6 +9658,307 @@ async fn get_agent_profile_referents(
         "runs": []
     }))
     .into_response()
+}
+
+// ---------------------------------------------------------------------------
+// Banque de skills (#668, ADR-0062)
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize)]
+struct CreateSkillRequest {
+    /// The pasted `SKILL.md` text, frontmatter included.
+    content: String,
+    /// The bank label; defaults to the frontmatter `name`.
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    folder_id: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct UpdateSkillRequest {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_double_option")]
+    folder_id: Option<Option<String>>,
+}
+
+#[derive(Deserialize)]
+struct CreateSkillFolderRequest {
+    name: String,
+    #[serde(default)]
+    parent_id: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct UpdateSkillFolderRequest {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_double_option")]
+    parent_id: Option<Option<String>>,
+}
+
+/// A stable machine-readable code next to the human message, so the popup can
+/// light the right check without parsing English.
+fn skill_error_code(error: &skill_bank::SkillError) -> &'static str {
+    use skill_bank::SkillError as E;
+    match error {
+        E::NoFrontmatter => "no_frontmatter",
+        E::MalformedFrontmatter(_) => "malformed_frontmatter",
+        E::MissingName => "missing_name",
+        E::NameNotKebabCase(_) => "name_not_kebab_case",
+        E::MissingDescription => "missing_description",
+        E::EmptyBody => "empty_body",
+        E::DuplicateName { .. } => "duplicate_name",
+        E::EmptyLabel => "empty_label",
+        E::NotFound => "not_found",
+        E::FolderNotFound => "folder_not_found",
+        E::EmptyFolderName => "empty_folder_name",
+        E::FolderCycle => "folder_cycle",
+        E::Storage(_) => "storage",
+    }
+}
+
+fn skill_error_response(error: skill_bank::SkillError) -> Response {
+    use skill_bank::SkillError as E;
+    let status = match &error {
+        E::NotFound => StatusCode::NOT_FOUND,
+        E::DuplicateName { .. } => StatusCode::CONFLICT,
+        E::Storage(_) => StatusCode::INTERNAL_SERVER_ERROR,
+        E::NoFrontmatter
+        | E::MalformedFrontmatter(_)
+        | E::MissingName
+        | E::NameNotKebabCase(_)
+        | E::MissingDescription
+        | E::EmptyBody
+        | E::EmptyLabel
+        | E::FolderNotFound
+        | E::EmptyFolderName
+        | E::FolderCycle => StatusCode::BAD_REQUEST,
+    };
+    let mut body = serde_json::json!({
+        "error": error.to_string(),
+        "code": skill_error_code(&error),
+    });
+    if let E::DuplicateName { existing_id, name } = &error {
+        body["existing_id"] = serde_json::Value::String(existing_id.clone());
+        body["existing_name"] = serde_json::Value::String(name.clone());
+    }
+    (status, Json(body)).into_response()
+}
+
+fn storage_error_response(error: impl std::fmt::Display) -> Response {
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(serde_json::json!({ "error": error.to_string(), "code": "storage" })),
+    )
+        .into_response()
+}
+
+/// `GET /settings/skills` — the whole bank in one read: skills, folders, and the
+/// disk root the panel's footer names.
+async fn list_skills(State(state): State<Arc<AppState>>) -> Response {
+    let skills = match skill_bank::list(&state.db).await {
+        Ok(skills) => skills,
+        Err(error) => return storage_error_response(error),
+    };
+    let folders = match skill_bank::list_folders(&state.db).await {
+        Ok(folders) => folders,
+        Err(error) => return storage_error_response(error),
+    };
+    Json(serde_json::json!({
+        "skills": skills,
+        "folders": folders,
+        "root_path": skill_bank::skills_root(&state.repo_root).display().to_string(),
+    }))
+    .into_response()
+}
+
+async fn create_skill(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<CreateSkillRequest>,
+) -> Response {
+    match skill_bank::create(
+        &state.db,
+        &state.repo_root,
+        &req.content,
+        req.name.as_deref(),
+        req.folder_id.as_deref(),
+    )
+    .await
+    {
+        Ok(skill) => (StatusCode::CREATED, Json(skill)).into_response(),
+        Err(error) => skill_error_response(error),
+    }
+}
+
+/// `GET /settings/skills/{id}` — the row plus its content: the raw `SKILL.md`,
+/// the parsed frontmatter (for the read-only table), the body, and the reference
+/// files. A skill whose folder vanished from disk still answers with its row
+/// and `content: null`, never a 500: the row is the truth of the index.
+async fn get_skill(State(state): State<Arc<AppState>>, AxumPath(id): AxumPath<String>) -> Response {
+    let skill = match skill_bank::get(&state.db, &id).await {
+        Ok(Some(skill)) => skill,
+        Ok(None) => return skill_error_response(skill_bank::SkillError::NotFound),
+        Err(error) => return storage_error_response(error),
+    };
+    let content = skill_bank::read_skill_md(&state.repo_root, &id).ok();
+    let parsed = content
+        .as_deref()
+        .and_then(|text| skill_bank::validate_skill_md(text).ok());
+    let files = skill_bank::list_files(&state.repo_root, &id).unwrap_or_default();
+    let mut body = serde_json::to_value(&skill).unwrap_or_default();
+    body["content"] = serde_json::to_value(&content).unwrap_or_default();
+    // The table is rendered in the author's order: `serde_json` objects do not
+    // keep insertion order, so the keys travel separately.
+    body["frontmatter"] = parsed
+        .as_ref()
+        .map(|p| serde_json::to_value(&p.frontmatter).unwrap_or_default())
+        .unwrap_or(serde_json::Value::Null);
+    body["frontmatter_keys"] = parsed
+        .as_ref()
+        .map(|p| {
+            serde_json::Value::Array(
+                p.frontmatter
+                    .keys()
+                    .filter_map(|k| k.as_str().map(|s| serde_json::Value::String(s.to_string())))
+                    .collect(),
+            )
+        })
+        .unwrap_or(serde_json::Value::Null);
+    body["body"] = parsed
+        .as_ref()
+        .map(|p| serde_json::Value::String(p.body.clone()))
+        .unwrap_or(serde_json::Value::Null);
+    body["files"] = serde_json::to_value(&files).unwrap_or_default();
+    body["path"] = serde_json::Value::String(
+        skill_bank::skill_dir(&state.repo_root, &id)
+            .display()
+            .to_string(),
+    );
+    Json(body).into_response()
+}
+
+/// `PUT /settings/skills/{id}` — rename (label only) and/or move. Renaming never
+/// touches the disk: the folder carries the id (#668 AC).
+async fn update_skill(
+    State(state): State<Arc<AppState>>,
+    AxumPath(id): AxumPath<String>,
+    Json(req): Json<UpdateSkillRequest>,
+) -> Response {
+    match skill_bank::update(
+        &state.db,
+        &id,
+        req.name.as_deref(),
+        req.folder_id.as_ref().map(|f| f.as_deref()),
+    )
+    .await
+    {
+        Ok(skill) => Json(skill).into_response(),
+        Err(error) => skill_error_response(error),
+    }
+}
+
+async fn delete_skill(
+    State(state): State<Arc<AppState>>,
+    AxumPath(id): AxumPath<String>,
+) -> Response {
+    match skill_bank::delete(&state.db, &state.repo_root, &id).await {
+        Ok(true) => StatusCode::NO_CONTENT.into_response(),
+        Ok(false) => skill_error_response(skill_bank::SkillError::NotFound),
+        Err(error) => skill_error_response(error),
+    }
+}
+
+/// `GET /settings/skills/{id}/referents` — who selects this skill, by tier:
+/// instance, projects, pipelines (node), not-yet-started runs. **Empty in #668**
+/// (no tier selects skills yet), but the shape is the one the delete dialog
+/// renders and the one the selector tickets will fill — same pattern as
+/// `get_agent_profile_referents`.
+async fn get_skill_referents(
+    State(state): State<Arc<AppState>>,
+    AxumPath(id): AxumPath<String>,
+) -> Response {
+    match skill_bank::get(&state.db, &id).await {
+        Ok(Some(_)) => {}
+        Ok(None) => return skill_error_response(skill_bank::SkillError::NotFound),
+        Err(error) => return storage_error_response(error),
+    }
+    Json(serde_json::json!({
+        "skill_id": id,
+        "instance": false,
+        "projects": [],
+        "pipelines": [],
+        "runs": []
+    }))
+    .into_response()
+}
+
+async fn list_skill_folders(State(state): State<Arc<AppState>>) -> Response {
+    match skill_bank::list_folders(&state.db).await {
+        Ok(folders) => Json(serde_json::json!({ "folders": folders })).into_response(),
+        Err(error) => storage_error_response(error),
+    }
+}
+
+async fn create_skill_folder(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<CreateSkillFolderRequest>,
+) -> Response {
+    match skill_bank::create_folder(&state.db, &req.name, req.parent_id.as_deref()).await {
+        Ok(folder) => (StatusCode::CREATED, Json(folder)).into_response(),
+        Err(error) => skill_error_response(error),
+    }
+}
+
+/// A folder addressed by its own route that does not exist is a 404, while an
+/// unknown folder *named in a body* (a move target, a parent) stays a 400: the
+/// first is "no such resource", the second "your request is wrong".
+fn skill_folder_not_found_response() -> Response {
+    (
+        StatusCode::NOT_FOUND,
+        Json(serde_json::json!({
+            "error": skill_bank::SkillError::FolderNotFound.to_string(),
+            "code": "not_found",
+        })),
+    )
+        .into_response()
+}
+
+async fn update_skill_folder(
+    State(state): State<Arc<AppState>>,
+    AxumPath(id): AxumPath<String>,
+    Json(req): Json<UpdateSkillFolderRequest>,
+) -> Response {
+    match skill_bank::get_folder(&state.db, &id).await {
+        Ok(Some(_)) => {}
+        Ok(None) => return skill_folder_not_found_response(),
+        Err(error) => return storage_error_response(error),
+    }
+    match skill_bank::update_folder(
+        &state.db,
+        &id,
+        req.name.as_deref(),
+        req.parent_id.as_ref().map(|p| p.as_deref()),
+    )
+    .await
+    {
+        Ok(folder) => Json(folder).into_response(),
+        Err(error) => skill_error_response(error),
+    }
+}
+
+/// `DELETE /settings/skill-folders/{id}` — the folder's skills and sub-folders
+/// move to its parent. Never deletes a skill.
+async fn delete_skill_folder(
+    State(state): State<Arc<AppState>>,
+    AxumPath(id): AxumPath<String>,
+) -> Response {
+    match skill_bank::delete_folder(&state.db, &id).await {
+        Ok(true) => StatusCode::NO_CONTENT.into_response(),
+        Ok(false) => skill_folder_not_found_response(),
+        Err(error) => skill_error_response(error),
+    }
 }
 
 /// Serialise one resolved entry for the editor.

--- a/crates/pdo-daemon/src/skill_bank.rs
+++ b/crates/pdo-daemon/src/skill_bank.rs
@@ -1,0 +1,988 @@
+//! The **Banque de skills** (#668, spec #667, ADR-0062, CONTEXT.md §*Banque de
+//! skills*): the instance-scoped store of Skills PDO delivers into every worktree
+//! it creates.
+//!
+//! Two halves, one seam:
+//!
+//! - **Content on disk**, one folder per skill under `<repo_root>/.pdo/skills/<id>/`
+//!   holding the `SKILL.md` and its read-only reference files. The folder is keyed
+//!   by the **stable id**, never by the name — renaming a skill touches a row, not a
+//!   path (#668 AC "renommer ne déplace rien").
+//! - **Index in SQLite**: `skills` (id, name unique case-insensitively, description,
+//!   folder, provenance, dates) and `skill_folders` (a free hierarchy). The folder
+//!   is a UI gesture, not a reference: no tier ever stores a folder id (ADR-0062
+//!   "Dossier = geste, pas référence").
+//!
+//! Identity is the `id`; the `name` is a **label** the bank keeps unique so a
+//! selector never shows two indistinguishable rows. Same discipline as
+//! `agent_profile` (ADR-0057 ¶2/¶5), and the same reason the uniqueness check lives
+//! in code rather than in a bare `UNIQUE` index: the 409 must **name** the clash.
+//!
+//! [`validate_skill_md`] is the one gate to disk: a `SKILL.md` whose frontmatter the
+//! harness would ignore (no `name`, no `description`, empty body) is refused with a
+//! named reason and **nothing is written** (#668 AC "rien n'est écrit sur disque").
+
+use serde::{Deserialize, Serialize};
+use sqlx::{Row, SqlitePool};
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+/// The on-disk root of the bank, relative to the daemon's repo root — the same
+/// `.pdo/` the SQLite index lives in, so content and index travel together.
+pub(crate) fn skills_root(repo_root: &Path) -> PathBuf {
+    repo_root.join(".pdo").join("skills")
+}
+
+/// Where one skill's folder lives. Keyed by id, never by name.
+pub(crate) fn skill_dir(repo_root: &Path, id: &str) -> PathBuf {
+    skills_root(repo_root).join(id)
+}
+
+pub(crate) const SKILL_MD: &str = "SKILL.md";
+
+/// One row of the bank's index. `folder_id` is `None` at the root.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct Skill {
+    pub id: String,
+    pub name: String,
+    pub description: String,
+    #[serde(default)]
+    pub folder_id: Option<String>,
+    /// Provenance of an import (URL / local path). `None` for a pasted skill.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_commit: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+/// A folder of the bank's free hierarchy. `parent_id` is `None` at the root.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct SkillFolder {
+    pub id: String,
+    pub name: String,
+    #[serde(default)]
+    pub parent_id: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+/// A reference file of a skill (anything under its folder except `SKILL.md`),
+/// listed read-only.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct SkillFile {
+    /// Path relative to the skill's folder, `/`-separated.
+    pub path: String,
+    pub size: u64,
+}
+
+/// The parsed, validated content of a `SKILL.md` — what [`validate_skill_md`]
+/// returns and what `create` writes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ParsedSkillMd {
+    pub name: String,
+    pub description: String,
+    /// The whole frontmatter, for the read-only detail table. A `Mapping` (not a
+    /// `BTreeMap`) so the table keeps the author's key order.
+    pub frontmatter: serde_yaml::Mapping,
+    /// The markdown body after the closing `---`, trimmed.
+    pub body: String,
+}
+
+/// Why a write was refused. The HTTP layer maps each variant to a status; the
+/// message is the reason the popup shows in place.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum SkillError {
+    /// No `---` block at the top of the text.
+    NoFrontmatter,
+    MalformedFrontmatter(String),
+    MissingName,
+    /// `name` must be kebab-case: `^[a-z0-9]+(-[a-z0-9]+)*$`.
+    NameNotKebabCase(String),
+    MissingDescription,
+    EmptyBody,
+    /// Another skill already carries this label, case-insensitively.
+    DuplicateName {
+        existing_id: String,
+        name: String,
+    },
+    EmptyLabel,
+    NotFound,
+    FolderNotFound,
+    EmptyFolderName,
+    /// Moving a folder under itself or one of its descendants.
+    FolderCycle,
+    Storage(String),
+}
+
+impl fmt::Display for SkillError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NoFrontmatter => write!(
+                f,
+                "no frontmatter block: a SKILL.md starts with `---`, then `name:` and \
+                 `description:`, then `---`"
+            ),
+            Self::MalformedFrontmatter(reason) => {
+                write!(f, "the frontmatter is not valid YAML: {reason}")
+            }
+            Self::MissingName => write!(f, "the frontmatter has no `name`"),
+            Self::NameNotKebabCase(name) => write!(
+                f,
+                "`name: {name}` is not kebab-case (lowercase letters, digits and single \
+                 hyphens, e.g. `code-review`)"
+            ),
+            Self::MissingDescription => write!(
+                f,
+                "the frontmatter has no `description`; the harness would ignore this skill"
+            ),
+            Self::EmptyBody => write!(f, "the body after the frontmatter is empty"),
+            Self::DuplicateName { name, .. } => write!(
+                f,
+                "a skill named `{name}` already exists (names are unique case-insensitively)"
+            ),
+            Self::EmptyLabel => write!(f, "a skill name cannot be blank"),
+            Self::NotFound => write!(f, "no such skill"),
+            Self::FolderNotFound => write!(f, "no such skill folder"),
+            Self::EmptyFolderName => write!(f, "a folder name cannot be blank"),
+            Self::FolderCycle => write!(f, "a folder cannot be moved under itself"),
+            Self::Storage(message) => write!(f, "{message}"),
+        }
+    }
+}
+
+impl std::error::Error for SkillError {}
+
+impl From<sqlx::Error> for SkillError {
+    fn from(error: sqlx::Error) -> Self {
+        Self::Storage(error.to_string())
+    }
+}
+
+impl From<std::io::Error> for SkillError {
+    fn from(error: std::io::Error) -> Self {
+        Self::Storage(error.to_string())
+    }
+}
+
+/// Create the two index tables if absent. Idempotent, same idiom as
+/// `agent_profile::init`. Nothing is seeded: an untouched instance has an empty
+/// bank (FP step 1).
+pub(crate) async fn init(db: &SqlitePool) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS skill_folders (
+            id         TEXT PRIMARY KEY,
+            name       TEXT NOT NULL,
+            parent_id  TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        )",
+    )
+    .execute(db)
+    .await?;
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS skills (
+            id            TEXT PRIMARY KEY,
+            name          TEXT NOT NULL,
+            description   TEXT NOT NULL,
+            folder_id     TEXT,
+            source        TEXT,
+            source_commit TEXT,
+            created_at    TEXT NOT NULL,
+            updated_at    TEXT NOT NULL
+        )",
+    )
+    .execute(db)
+    .await?;
+    sqlx::query(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_skills_name_nocase \
+         ON skills(name COLLATE NOCASE)",
+    )
+    .execute(db)
+    .await?;
+    Ok(())
+}
+
+fn row_to_skill(row: &sqlx::sqlite::SqliteRow) -> Skill {
+    Skill {
+        id: row.get("id"),
+        name: row.get("name"),
+        description: row.get("description"),
+        folder_id: row.get("folder_id"),
+        source: row.get("source"),
+        source_commit: row.get("source_commit"),
+        created_at: row.get("created_at"),
+        updated_at: row.get("updated_at"),
+    }
+}
+
+fn row_to_folder(row: &sqlx::sqlite::SqliteRow) -> SkillFolder {
+    SkillFolder {
+        id: row.get("id"),
+        name: row.get("name"),
+        parent_id: row.get("parent_id"),
+        created_at: row.get("created_at"),
+        updated_at: row.get("updated_at"),
+    }
+}
+
+/// A skill id: a UUID, because the folder on disk carries it and the id travels
+/// in pipeline documents across instances (ADR-0062 "voyage par document").
+fn generate_skill_id() -> String {
+    uuid::Uuid::new_v4().to_string()
+}
+
+fn generate_folder_id() -> String {
+    format!("skf-{}", &uuid::Uuid::new_v4().to_string()[..8])
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+/// `^[a-z0-9]+(-[a-z0-9]+)*$` without a regex dependency.
+pub(crate) fn is_kebab_case(name: &str) -> bool {
+    if name.is_empty() || name.starts_with('-') || name.ends_with('-') || name.contains("--") {
+        return false;
+    }
+    name.chars()
+        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+}
+
+fn scalar_string(value: &serde_yaml::Value) -> Option<String> {
+    match value {
+        serde_yaml::Value::String(s) => Some(s.clone()),
+        serde_yaml::Value::Number(n) => Some(n.to_string()),
+        serde_yaml::Value::Bool(b) => Some(b.to_string()),
+        _ => None,
+    }
+}
+
+/// Split `content` into its frontmatter YAML text and its body. `None` when there
+/// is no opening `---` at the very top (leading whitespace tolerated).
+fn split_frontmatter(content: &str) -> Option<(&str, &str)> {
+    let trimmed = content.trim_start();
+    let rest = trimmed.strip_prefix("---")?;
+    // The opening fence must end its line.
+    let rest = rest
+        .strip_prefix("\r\n")
+        .or_else(|| rest.strip_prefix('\n'))?;
+    // Closing fence: a line that is exactly `---`.
+    let mut offset = 0;
+    for line in rest.split_inclusive('\n') {
+        if line.trim_end_matches(['\r', '\n']) == "---" {
+            let yaml = &rest[..offset];
+            let body = &rest[offset + line.len()..];
+            return Some((yaml, body));
+        }
+        offset += line.len();
+    }
+    None
+}
+
+/// The single gate to disk. Checks, in the order the paste popup lists them:
+/// frontmatter block found, `name` present and kebab-case, `description`
+/// present, body not empty. Uniqueness is the store's job (`create`).
+pub(crate) fn validate_skill_md(content: &str) -> Result<ParsedSkillMd, SkillError> {
+    let (yaml, body) = split_frontmatter(content).ok_or(SkillError::NoFrontmatter)?;
+    let frontmatter: serde_yaml::Mapping = if yaml.trim().is_empty() {
+        serde_yaml::Mapping::new()
+    } else {
+        serde_yaml::from_str(yaml).map_err(|e| SkillError::MalformedFrontmatter(e.to_string()))?
+    };
+    let name = frontmatter
+        .get(serde_yaml::Value::from("name"))
+        .and_then(scalar_string)
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .ok_or(SkillError::MissingName)?;
+    if !is_kebab_case(&name) {
+        return Err(SkillError::NameNotKebabCase(name));
+    }
+    let description = frontmatter
+        .get(serde_yaml::Value::from("description"))
+        .and_then(scalar_string)
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .ok_or(SkillError::MissingDescription)?;
+    let body = body.trim();
+    if body.is_empty() {
+        return Err(SkillError::EmptyBody);
+    }
+    Ok(ParsedSkillMd {
+        name,
+        description,
+        frontmatter,
+        body: body.to_string(),
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Skills — reads
+// ---------------------------------------------------------------------------
+
+/// All skills, by label then creation order — a stable listing the tree re-sorts
+/// by folder client-side.
+pub(crate) async fn list(db: &SqlitePool) -> Result<Vec<Skill>, sqlx::Error> {
+    let rows = sqlx::query("SELECT * FROM skills ORDER BY name COLLATE NOCASE ASC, created_at ASC")
+        .fetch_all(db)
+        .await?;
+    Ok(rows.iter().map(row_to_skill).collect())
+}
+
+pub(crate) async fn get(db: &SqlitePool, id: &str) -> Result<Option<Skill>, sqlx::Error> {
+    let row = sqlx::query("SELECT * FROM skills WHERE id = ?")
+        .bind(id)
+        .fetch_optional(db)
+        .await?;
+    Ok(row.as_ref().map(row_to_skill))
+}
+
+/// Case-insensitive lookup by label, trimmed on both sides.
+pub(crate) async fn find_by_name_ci(
+    db: &SqlitePool,
+    name: &str,
+) -> Result<Option<Skill>, sqlx::Error> {
+    let row = sqlx::query("SELECT * FROM skills WHERE lower(trim(name)) = lower(trim(?)) LIMIT 1")
+        .bind(name)
+        .fetch_optional(db)
+        .await?;
+    Ok(row.as_ref().map(row_to_skill))
+}
+
+async fn check_label_unique(
+    db: &SqlitePool,
+    name: &str,
+    excluding_id: Option<&str>,
+) -> Result<String, SkillError> {
+    let name = name.trim().to_string();
+    if name.is_empty() {
+        return Err(SkillError::EmptyLabel);
+    }
+    if let Some(existing) = find_by_name_ci(db, &name).await? {
+        if Some(existing.id.as_str()) != excluding_id {
+            return Err(SkillError::DuplicateName {
+                existing_id: existing.id,
+                name: existing.name,
+            });
+        }
+    }
+    Ok(name)
+}
+
+/// Read one skill's `SKILL.md` from disk.
+pub(crate) fn read_skill_md(repo_root: &Path, id: &str) -> Result<String, SkillError> {
+    Ok(std::fs::read_to_string(
+        skill_dir(repo_root, id).join(SKILL_MD),
+    )?)
+}
+
+/// List the reference files of a skill: everything under its folder except
+/// `SKILL.md`, recursively, sorted by path.
+pub(crate) fn list_files(repo_root: &Path, id: &str) -> Result<Vec<SkillFile>, SkillError> {
+    let root = skill_dir(repo_root, id);
+    let mut out = Vec::new();
+    fn walk(base: &Path, dir: &Path, out: &mut Vec<SkillFile>) -> std::io::Result<()> {
+        for entry in std::fs::read_dir(dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            let meta = entry.metadata()?;
+            if meta.is_dir() {
+                walk(base, &path, out)?;
+            } else {
+                let rel = path
+                    .strip_prefix(base)
+                    .unwrap_or(&path)
+                    .components()
+                    .map(|c| c.as_os_str().to_string_lossy().into_owned())
+                    .collect::<Vec<_>>()
+                    .join("/");
+                if rel == SKILL_MD {
+                    continue;
+                }
+                out.push(SkillFile {
+                    path: rel,
+                    size: meta.len(),
+                });
+            }
+        }
+        Ok(())
+    }
+    if root.is_dir() {
+        walk(&root, &root, &mut out)?;
+    }
+    out.sort_by(|a, b| a.path.cmp(&b.path));
+    Ok(out)
+}
+
+// ---------------------------------------------------------------------------
+// Skills — writes
+// ---------------------------------------------------------------------------
+
+async fn folder_exists(db: &SqlitePool, id: &str) -> Result<bool, sqlx::Error> {
+    Ok(sqlx::query("SELECT 1 FROM skill_folders WHERE id = ?")
+        .bind(id)
+        .fetch_optional(db)
+        .await?
+        .is_some())
+}
+
+/// Create a skill from pasted `SKILL.md` text. Order matters and is the AC:
+/// validate the content, check the label, insert the row, **then** write the
+/// folder — so a refusal never leaves a byte on disk, and a disk failure rolls the
+/// row back.
+///
+/// `label` overrides the bank label (defaults to the frontmatter `name`).
+pub(crate) async fn create(
+    db: &SqlitePool,
+    repo_root: &Path,
+    content: &str,
+    label: Option<&str>,
+    folder_id: Option<&str>,
+) -> Result<Skill, SkillError> {
+    let parsed = validate_skill_md(content)?;
+    let name = check_label_unique(db, label.unwrap_or(&parsed.name), None).await?;
+    let folder_id = match folder_id.map(str::trim).filter(|s| !s.is_empty()) {
+        Some(folder) => {
+            if !folder_exists(db, folder).await? {
+                return Err(SkillError::FolderNotFound);
+            }
+            Some(folder.to_string())
+        }
+        None => None,
+    };
+    let id = generate_skill_id();
+    let now = crate::event_log::now_iso();
+    sqlx::query(
+        "INSERT INTO skills (id, name, description, folder_id, source, source_commit, created_at, updated_at) \
+         VALUES (?, ?, ?, ?, NULL, NULL, ?, ?)",
+    )
+    .bind(&id)
+    .bind(&name)
+    .bind(&parsed.description)
+    .bind(&folder_id)
+    .bind(&now)
+    .bind(&now)
+    .execute(db)
+    .await?;
+
+    let dir = skill_dir(repo_root, &id);
+    let written =
+        std::fs::create_dir_all(&dir).and_then(|_| std::fs::write(dir.join(SKILL_MD), content));
+    if let Err(error) = written {
+        let _ = std::fs::remove_dir_all(&dir);
+        let _ = sqlx::query("DELETE FROM skills WHERE id = ?")
+            .bind(&id)
+            .execute(db)
+            .await;
+        return Err(SkillError::Storage(format!(
+            "failed to write {}: {error}",
+            dir.display()
+        )));
+    }
+
+    Ok(Skill {
+        id,
+        name,
+        description: parsed.description,
+        folder_id,
+        source: None,
+        source_commit: None,
+        created_at: now.clone(),
+        updated_at: now,
+    })
+}
+
+/// A sparse edit of the index row: rename (label only — the frontmatter `name`
+/// and the folder on disk are untouched, the id is the identity) and/or move to
+/// a folder (`Some(None)` = back to the root).
+pub(crate) async fn update(
+    db: &SqlitePool,
+    id: &str,
+    name: Option<&str>,
+    folder_id: Option<Option<&str>>,
+) -> Result<Skill, SkillError> {
+    let current = get(db, id).await?.ok_or(SkillError::NotFound)?;
+    let name = match name {
+        Some(candidate) => check_label_unique(db, candidate, Some(id)).await?,
+        None => current.name.clone(),
+    };
+    let folder_id = match folder_id {
+        None => current.folder_id.clone(),
+        Some(None) => None,
+        Some(Some(folder)) => {
+            let folder = folder.trim();
+            if folder.is_empty() {
+                None
+            } else {
+                if !folder_exists(db, folder).await? {
+                    return Err(SkillError::FolderNotFound);
+                }
+                Some(folder.to_string())
+            }
+        }
+    };
+    let now = crate::event_log::now_iso();
+    sqlx::query("UPDATE skills SET name = ?, folder_id = ?, updated_at = ? WHERE id = ?")
+        .bind(&name)
+        .bind(&folder_id)
+        .bind(&now)
+        .bind(id)
+        .execute(db)
+        .await?;
+    get(db, id).await?.ok_or(SkillError::NotFound)
+}
+
+/// Delete a skill: row first, then its folder on disk. **Unconditional** — no
+/// referential integrity, the referents dialog informs the confirmation (same
+/// posture as `agent_profile::delete`). Returns `false` when the id is unknown.
+pub(crate) async fn delete(
+    db: &SqlitePool,
+    repo_root: &Path,
+    id: &str,
+) -> Result<bool, SkillError> {
+    let res = sqlx::query("DELETE FROM skills WHERE id = ?")
+        .bind(id)
+        .execute(db)
+        .await?;
+    if res.rows_affected() == 0 {
+        return Ok(false);
+    }
+    let dir = skill_dir(repo_root, id);
+    if dir.exists() {
+        std::fs::remove_dir_all(&dir)?;
+    }
+    Ok(true)
+}
+
+// ---------------------------------------------------------------------------
+// Folders
+// ---------------------------------------------------------------------------
+
+pub(crate) async fn list_folders(db: &SqlitePool) -> Result<Vec<SkillFolder>, sqlx::Error> {
+    let rows =
+        sqlx::query("SELECT * FROM skill_folders ORDER BY name COLLATE NOCASE ASC, created_at ASC")
+            .fetch_all(db)
+            .await?;
+    Ok(rows.iter().map(row_to_folder).collect())
+}
+
+pub(crate) async fn get_folder(
+    db: &SqlitePool,
+    id: &str,
+) -> Result<Option<SkillFolder>, sqlx::Error> {
+    let row = sqlx::query("SELECT * FROM skill_folders WHERE id = ?")
+        .bind(id)
+        .fetch_optional(db)
+        .await?;
+    Ok(row.as_ref().map(row_to_folder))
+}
+
+async fn normalise_parent(
+    db: &SqlitePool,
+    parent_id: Option<&str>,
+) -> Result<Option<String>, SkillError> {
+    match parent_id.map(str::trim).filter(|s| !s.is_empty()) {
+        Some(parent) => {
+            if !folder_exists(db, parent).await? {
+                return Err(SkillError::FolderNotFound);
+            }
+            Ok(Some(parent.to_string()))
+        }
+        None => Ok(None),
+    }
+}
+
+/// Create a folder, at the root or under `parent_id`. Folder names are free
+/// (only blank is refused): two sibling folders may share a name, the id tells
+/// them apart and nothing references a folder.
+pub(crate) async fn create_folder(
+    db: &SqlitePool,
+    name: &str,
+    parent_id: Option<&str>,
+) -> Result<SkillFolder, SkillError> {
+    let name = name.trim();
+    if name.is_empty() {
+        return Err(SkillError::EmptyFolderName);
+    }
+    let parent_id = normalise_parent(db, parent_id).await?;
+    let id = generate_folder_id();
+    let now = crate::event_log::now_iso();
+    sqlx::query(
+        "INSERT INTO skill_folders (id, name, parent_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
+    )
+    .bind(&id)
+    .bind(name)
+    .bind(&parent_id)
+    .bind(&now)
+    .bind(&now)
+    .execute(db)
+    .await?;
+    Ok(SkillFolder {
+        id,
+        name: name.to_string(),
+        parent_id,
+        created_at: now.clone(),
+        updated_at: now,
+    })
+}
+
+/// Is `candidate` equal to `folder` or one of its descendants? Guards a move
+/// against creating a cycle.
+async fn is_self_or_descendant(
+    db: &SqlitePool,
+    folder: &str,
+    candidate: &str,
+) -> Result<bool, sqlx::Error> {
+    let mut cursor = Some(candidate.to_string());
+    let mut hops = 0;
+    while let Some(current) = cursor {
+        if current == folder {
+            return Ok(true);
+        }
+        hops += 1;
+        if hops > 1000 {
+            return Ok(true);
+        }
+        cursor = sqlx::query("SELECT parent_id FROM skill_folders WHERE id = ?")
+            .bind(&current)
+            .fetch_optional(db)
+            .await?
+            .and_then(|row| row.get::<Option<String>, _>("parent_id"));
+    }
+    Ok(false)
+}
+
+/// Rename and/or re-parent a folder (`Some(None)` = to the root).
+pub(crate) async fn update_folder(
+    db: &SqlitePool,
+    id: &str,
+    name: Option<&str>,
+    parent_id: Option<Option<&str>>,
+) -> Result<SkillFolder, SkillError> {
+    let current = get_folder(db, id)
+        .await?
+        .ok_or(SkillError::FolderNotFound)?;
+    let name = match name {
+        Some(candidate) => {
+            let candidate = candidate.trim();
+            if candidate.is_empty() {
+                return Err(SkillError::EmptyFolderName);
+            }
+            candidate.to_string()
+        }
+        None => current.name.clone(),
+    };
+    let parent_id = match parent_id {
+        None => current.parent_id.clone(),
+        Some(parent) => {
+            let parent = normalise_parent(db, parent).await?;
+            if let Some(parent) = &parent {
+                if is_self_or_descendant(db, id, parent).await? {
+                    return Err(SkillError::FolderCycle);
+                }
+            }
+            parent
+        }
+    };
+    let now = crate::event_log::now_iso();
+    sqlx::query("UPDATE skill_folders SET name = ?, parent_id = ?, updated_at = ? WHERE id = ?")
+        .bind(&name)
+        .bind(&parent_id)
+        .bind(&now)
+        .bind(id)
+        .execute(db)
+        .await?;
+    get_folder(db, id).await?.ok_or(SkillError::FolderNotFound)
+}
+
+/// Delete a folder. Its skills and sub-folders move to its parent: deleting a
+/// folder **never deletes a skill** (design decision of the #668 mock-up).
+pub(crate) async fn delete_folder(db: &SqlitePool, id: &str) -> Result<bool, SkillError> {
+    let Some(folder) = get_folder(db, id).await? else {
+        return Ok(false);
+    };
+    let now = crate::event_log::now_iso();
+    sqlx::query("UPDATE skills SET folder_id = ?, updated_at = ? WHERE folder_id = ?")
+        .bind(&folder.parent_id)
+        .bind(&now)
+        .bind(id)
+        .execute(db)
+        .await?;
+    sqlx::query("UPDATE skill_folders SET parent_id = ?, updated_at = ? WHERE parent_id = ?")
+        .bind(&folder.parent_id)
+        .bind(&now)
+        .bind(id)
+        .execute(db)
+        .await?;
+    sqlx::query("DELETE FROM skill_folders WHERE id = ?")
+        .bind(id)
+        .execute(db)
+        .await?;
+    Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const VALID: &str = "---\nname: tdd\ndescription: Test-driven development.\n---\n\n# TDD\n\nRed, green, refactor.\n";
+
+    async fn mem_db() -> SqlitePool {
+        let db = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        init(&db).await.unwrap();
+        db
+    }
+
+    #[test]
+    fn kebab_case_rules() {
+        assert!(is_kebab_case("tdd"));
+        assert!(is_kebab_case("code-review"));
+        assert!(is_kebab_case("a1-b2"));
+        assert!(!is_kebab_case("TDD"));
+        assert!(!is_kebab_case("code_review"));
+        assert!(!is_kebab_case("-lead"));
+        assert!(!is_kebab_case("trail-"));
+        assert!(!is_kebab_case("double--dash"));
+        assert!(!is_kebab_case(""));
+        assert!(!is_kebab_case("with space"));
+    }
+
+    #[test]
+    fn validate_accepts_a_complete_skill_md() {
+        let parsed = validate_skill_md(VALID).unwrap();
+        assert_eq!(parsed.name, "tdd");
+        assert_eq!(parsed.description, "Test-driven development.");
+        assert!(parsed.body.starts_with("# TDD"));
+        assert!(parsed
+            .frontmatter
+            .contains_key(serde_yaml::Value::from("name")));
+    }
+
+    #[test]
+    fn validate_refuses_each_missing_piece_with_a_named_reason() {
+        assert_eq!(
+            validate_skill_md("# no frontmatter\n\nbody").unwrap_err(),
+            SkillError::NoFrontmatter
+        );
+        assert_eq!(
+            validate_skill_md("---\ndescription: x\n---\nbody").unwrap_err(),
+            SkillError::MissingName
+        );
+        assert_eq!(
+            validate_skill_md("---\nname: TDD\ndescription: x\n---\nbody").unwrap_err(),
+            SkillError::NameNotKebabCase("TDD".into())
+        );
+        assert_eq!(
+            validate_skill_md("---\nname: tdd\n---\nbody").unwrap_err(),
+            SkillError::MissingDescription
+        );
+        assert_eq!(
+            validate_skill_md("---\nname: tdd\ndescription: x\n---\n\n  \n").unwrap_err(),
+            SkillError::EmptyBody
+        );
+        assert!(matches!(
+            validate_skill_md("---\nname: [\n---\nbody").unwrap_err(),
+            SkillError::MalformedFrontmatter(_)
+        ));
+        // An unclosed fence is "no frontmatter block", not a YAML error.
+        assert_eq!(
+            validate_skill_md("---\nname: tdd\ndescription: x\nbody").unwrap_err(),
+            SkillError::NoFrontmatter
+        );
+    }
+
+    #[tokio::test]
+    async fn create_writes_the_folder_keyed_by_id_and_indexes_the_row() {
+        let db = mem_db().await;
+        let root = tempfile::tempdir().unwrap();
+        let skill = create(&db, root.path(), VALID, None, None).await.unwrap();
+        assert_eq!(skill.name, "tdd");
+        assert_eq!(skill.description, "Test-driven development.");
+        assert_eq!(skill.folder_id, None);
+        let on_disk = skill_dir(root.path(), &skill.id).join(SKILL_MD);
+        assert_eq!(std::fs::read_to_string(on_disk).unwrap(), VALID);
+        assert_eq!(list(&db).await.unwrap().len(), 1);
+        assert!(list_files(root.path(), &skill.id).unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn invalid_content_writes_nothing() {
+        let db = mem_db().await;
+        let root = tempfile::tempdir().unwrap();
+        let err = create(&db, root.path(), "---\nname: tdd\n---\nbody", None, None)
+            .await
+            .unwrap_err();
+        assert_eq!(err, SkillError::MissingDescription);
+        assert!(list(&db).await.unwrap().is_empty());
+        assert!(!skills_root(root.path()).exists());
+    }
+
+    #[tokio::test]
+    async fn names_are_unique_case_insensitively() {
+        let db = mem_db().await;
+        let root = tempfile::tempdir().unwrap();
+        create(&db, root.path(), VALID, None, None).await.unwrap();
+        let err = create(&db, root.path(), VALID, Some("TDD"), None)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, SkillError::DuplicateName { ref name, .. } if name == "tdd"));
+        // Only one folder on disk: the refused create wrote nothing.
+        assert_eq!(
+            std::fs::read_dir(skills_root(root.path())).unwrap().count(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn rename_touches_the_label_only() {
+        let db = mem_db().await;
+        let root = tempfile::tempdir().unwrap();
+        let skill = create(&db, root.path(), VALID, None, None).await.unwrap();
+        let renamed = update(&db, &skill.id, Some("tdd-strict"), None)
+            .await
+            .unwrap();
+        assert_eq!(renamed.id, skill.id);
+        assert_eq!(renamed.name, "tdd-strict");
+        // Disk untouched: same folder, same content, frontmatter name still `tdd`.
+        let content = read_skill_md(root.path(), &skill.id).unwrap();
+        assert_eq!(content, VALID);
+        assert_eq!(validate_skill_md(&content).unwrap().name, "tdd");
+    }
+
+    #[tokio::test]
+    async fn rename_collision_is_refused_and_self_case_change_allowed() {
+        let db = mem_db().await;
+        let root = tempfile::tempdir().unwrap();
+        let a = create(&db, root.path(), VALID, None, None).await.unwrap();
+        create(&db, root.path(), VALID, Some("grilling"), None)
+            .await
+            .unwrap();
+        let err = update(&db, &a.id, Some("Grilling"), None)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, SkillError::DuplicateName { .. }));
+        let ok = update(&db, &a.id, Some("TDD"), None).await.unwrap();
+        assert_eq!(ok.name, "TDD");
+    }
+
+    #[tokio::test]
+    async fn move_into_a_folder_and_back_to_root() {
+        let db = mem_db().await;
+        let root = tempfile::tempdir().unwrap();
+        let skill = create(&db, root.path(), VALID, None, None).await.unwrap();
+        let folder = create_folder(&db, "méthode", None).await.unwrap();
+        let moved = update(&db, &skill.id, None, Some(Some(&folder.id)))
+            .await
+            .unwrap();
+        assert_eq!(moved.folder_id.as_deref(), Some(folder.id.as_str()));
+        let back = update(&db, &skill.id, None, Some(None)).await.unwrap();
+        assert_eq!(back.folder_id, None);
+        let err = update(&db, &skill.id, None, Some(Some("skf-nope")))
+            .await
+            .unwrap_err();
+        assert_eq!(err, SkillError::FolderNotFound);
+    }
+
+    #[tokio::test]
+    async fn delete_removes_row_and_folder() {
+        let db = mem_db().await;
+        let root = tempfile::tempdir().unwrap();
+        let skill = create(&db, root.path(), VALID, None, None).await.unwrap();
+        let dir = skill_dir(root.path(), &skill.id);
+        assert!(dir.exists());
+        assert!(delete(&db, root.path(), &skill.id).await.unwrap());
+        assert!(!dir.exists());
+        assert!(get(&db, &skill.id).await.unwrap().is_none());
+        assert!(!delete(&db, root.path(), &skill.id).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn list_files_excludes_skill_md_and_walks_subdirs() {
+        let db = mem_db().await;
+        let root = tempfile::tempdir().unwrap();
+        let skill = create(&db, root.path(), VALID, None, None).await.unwrap();
+        let dir = skill_dir(root.path(), &skill.id);
+        std::fs::write(dir.join("checklist.md"), "abc").unwrap();
+        std::fs::create_dir_all(dir.join("ref")).unwrap();
+        std::fs::write(dir.join("ref").join("a.txt"), "12345").unwrap();
+        let files = list_files(root.path(), &skill.id).unwrap();
+        assert_eq!(
+            files,
+            vec![
+                SkillFile {
+                    path: "checklist.md".into(),
+                    size: 3
+                },
+                SkillFile {
+                    path: "ref/a.txt".into(),
+                    size: 5
+                },
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn deleting_a_folder_moves_its_content_to_the_parent() {
+        let db = mem_db().await;
+        let root = tempfile::tempdir().unwrap();
+        let parent = create_folder(&db, "ippon", None).await.unwrap();
+        let child = create_folder(&db, "java", Some(&parent.id)).await.unwrap();
+        let grandchild = create_folder(&db, "spring", Some(&child.id)).await.unwrap();
+        let skill = create(&db, root.path(), VALID, None, Some(&child.id))
+            .await
+            .unwrap();
+        assert!(delete_folder(&db, &child.id).await.unwrap());
+        assert_eq!(
+            get(&db, &skill.id)
+                .await
+                .unwrap()
+                .unwrap()
+                .folder_id
+                .as_deref(),
+            Some(parent.id.as_str())
+        );
+        assert_eq!(
+            get_folder(&db, &grandchild.id)
+                .await
+                .unwrap()
+                .unwrap()
+                .parent_id
+                .as_deref(),
+            Some(parent.id.as_str())
+        );
+        assert!(get_folder(&db, &child.id).await.unwrap().is_none());
+        // Skill content untouched.
+        assert!(skill_dir(root.path(), &skill.id).join(SKILL_MD).exists());
+        assert!(!delete_folder(&db, &child.id).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn folder_moves_refuse_cycles_and_blank_names() {
+        let db = mem_db().await;
+        let a = create_folder(&db, "a", None).await.unwrap();
+        let b = create_folder(&db, "b", Some(&a.id)).await.unwrap();
+        assert_eq!(
+            update_folder(&db, &a.id, None, Some(Some(&b.id)))
+                .await
+                .unwrap_err(),
+            SkillError::FolderCycle
+        );
+        assert_eq!(
+            update_folder(&db, &a.id, None, Some(Some(&a.id)))
+                .await
+                .unwrap_err(),
+            SkillError::FolderCycle
+        );
+        assert_eq!(
+            create_folder(&db, "  ", None).await.unwrap_err(),
+            SkillError::EmptyFolderName
+        );
+        let renamed = update_folder(&db, &b.id, Some("bee"), Some(None))
+            .await
+            .unwrap();
+        assert_eq!(renamed.name, "bee");
+        assert_eq!(renamed.parent_id, None);
+    }
+}

--- a/crates/pdo-daemon/tests/it.rs
+++ b/crates/pdo-daemon/tests/it.rs
@@ -143,6 +143,9 @@ mod sandbox_observability;
 #[path = "sandbox_profiles.rs"]
 mod sandbox_profiles;
 
+#[path = "skill_bank.rs"]
+mod skill_bank;
+
 #[path = "sandbox_tracer.rs"]
 mod sandbox_tracer;
 

--- a/crates/pdo-daemon/tests/log_level_default.rs
+++ b/crates/pdo-daemon/tests/log_level_default.rs
@@ -55,8 +55,21 @@ fn info_logs_emitted_when_rust_log_is_unset() {
         }
     });
 
-    // 2s gives the runtime time to bind, log, and flush even on slow CI.
-    std::thread::sleep(Duration::from_secs(2));
+    // Poll for the line rather than sleeping a fixed 2 s: under the full suite
+    // (thousands of tests in parallel) a cold daemon can take longer than that to
+    // bind and flush, and the fixed window made this test flake on load alone.
+    // Return as soon as the line shows up; give up after a generous deadline.
+    let deadline = std::time::Instant::now() + Duration::from_secs(20);
+    loop {
+        let seen = buf
+            .lock()
+            .map(|g| g.contains("INFO") || g.contains("listening"))
+            .unwrap_or(false);
+        if seen || std::time::Instant::now() >= deadline {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
 
     let _ = child.kill();
     let _ = child.wait();

--- a/crates/pdo-daemon/tests/skill_bank.rs
+++ b/crates/pdo-daemon/tests/skill_bank.rs
@@ -1,0 +1,510 @@
+//! Layer 3a — the Banque de skills over HTTP (#668, ADR-0062).
+//!
+//! A **real daemon** over a tempdir: every assertion is an HTTP response or a
+//! file under `<repo_root>/.pdo/skills/<id>/`, never the shape of a table. Prior
+//! art: the agent-profile and staging-profile suites.
+
+use std::path::Path;
+
+use crate::common::TestDaemon;
+use reqwest::StatusCode;
+
+const VALID: &str = "---\nname: tdd\ndescription: Test-driven development. Red-green-refactor at pre-agreed seams.\nallowed-tools: Bash(npm:*) Bash(cargo:*)\n---\n\n# Test-driven development\n\nRed, green, refactor.\n";
+const NO_DESCRIPTION: &str = "---\nname: tdd\nallowed-tools: Bash(npm:*)\n---\n\n# Test-driven development\n\nRed, green, refactor.\n";
+
+fn skills_root(daemon: &TestDaemon) -> std::path::PathBuf {
+    daemon.repo_root().join(".pdo").join("skills")
+}
+
+async fn post_skill(daemon: &TestDaemon, body: serde_json::Value) -> reqwest::Response {
+    reqwest::Client::new()
+        .post(format!("{}/settings/skills", daemon.url()))
+        .json(&body)
+        .send()
+        .await
+        .unwrap()
+}
+
+async fn put_json(daemon: &TestDaemon, path: &str, body: serde_json::Value) -> reqwest::Response {
+    reqwest::Client::new()
+        .put(format!("{}{path}", daemon.url()))
+        .json(&body)
+        .send()
+        .await
+        .unwrap()
+}
+
+async fn get_json(daemon: &TestDaemon, path: &str) -> serde_json::Value {
+    reqwest::get(format!("{}{path}", daemon.url()))
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap()
+}
+
+async fn create_valid(daemon: &TestDaemon) -> serde_json::Value {
+    let resp = post_skill(daemon, serde_json::json!({ "content": VALID })).await;
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    resp.json().await.unwrap()
+}
+
+fn skill_dir_count(root: &Path) -> usize {
+    std::fs::read_dir(root).map(|d| d.count()).unwrap_or(0)
+}
+
+#[tokio::test]
+async fn fp_step_1_a_fresh_instance_has_an_empty_bank() {
+    let daemon = TestDaemon::spawn(|_| Ok(())).await.unwrap();
+    let bank = get_json(&daemon, "/settings/skills").await;
+    assert_eq!(bank["skills"], serde_json::json!([]));
+    assert_eq!(bank["folders"], serde_json::json!([]));
+    // The footer names the disk location: one folder per id under `.pdo/skills`.
+    assert_eq!(
+        bank["root_path"].as_str().unwrap(),
+        skills_root(&daemon).display().to_string()
+    );
+}
+
+#[tokio::test]
+async fn fp_step_2_pasting_a_valid_skill_md_indexes_it_and_writes_its_folder_by_id() {
+    let daemon = TestDaemon::spawn(|_| Ok(())).await.unwrap();
+    let skill = create_valid(&daemon).await;
+    let id = skill["id"].as_str().unwrap();
+    assert_eq!(skill["name"], "tdd");
+    assert_eq!(
+        skill["description"],
+        "Test-driven development. Red-green-refactor at pre-agreed seams."
+    );
+    assert!(skill["folder_id"].is_null());
+
+    // On disk: `<root>/<id>/SKILL.md`, byte-identical to the paste.
+    let on_disk = skills_root(&daemon).join(id).join("SKILL.md");
+    assert_eq!(std::fs::read_to_string(&on_disk).unwrap(), VALID);
+
+    // Listed with its name and description.
+    let bank = get_json(&daemon, "/settings/skills").await;
+    assert_eq!(bank["skills"].as_array().unwrap().len(), 1);
+    assert_eq!(bank["skills"][0]["name"], "tdd");
+
+    // Detail: raw content, parsed frontmatter for the table, body, files (none).
+    let detail = get_json(&daemon, &format!("/settings/skills/{id}")).await;
+    assert_eq!(detail["content"], VALID);
+    assert_eq!(detail["frontmatter"]["name"], "tdd");
+    assert_eq!(
+        detail["frontmatter"]["allowed-tools"],
+        "Bash(npm:*) Bash(cargo:*)"
+    );
+    assert!(detail["body"]
+        .as_str()
+        .unwrap()
+        .starts_with("# Test-driven development"));
+    assert_eq!(detail["files"], serde_json::json!([]));
+    assert_eq!(
+        detail["path"].as_str().unwrap(),
+        skills_root(&daemon).join(id).display().to_string()
+    );
+}
+
+#[tokio::test]
+async fn fp_step_3_missing_description_is_a_400_with_the_reason_and_nothing_on_disk() {
+    let daemon = TestDaemon::spawn(|_| Ok(())).await.unwrap();
+    let resp = post_skill(&daemon, serde_json::json!({ "content": NO_DESCRIPTION })).await;
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["code"], "missing_description");
+    assert!(body["error"].as_str().unwrap().contains("description"));
+
+    // Nothing appears, nothing is written.
+    let bank = get_json(&daemon, "/settings/skills").await;
+    assert_eq!(bank["skills"], serde_json::json!([]));
+    assert_eq!(skill_dir_count(&skills_root(&daemon)), 0);
+}
+
+#[tokio::test]
+async fn every_frontmatter_refusal_is_a_named_400() {
+    let daemon = TestDaemon::spawn(|_| Ok(())).await.unwrap();
+    let cases = [
+        ("# no frontmatter\n\nbody", "no_frontmatter"),
+        ("---\ndescription: x\n---\nbody", "missing_name"),
+        (
+            "---\nname: TDD\ndescription: x\n---\nbody",
+            "name_not_kebab_case",
+        ),
+        ("---\nname: tdd\ndescription: x\n---\n\n", "empty_body"),
+        ("---\nname: [\n---\nbody", "malformed_frontmatter"),
+    ];
+    for (content, code) in cases {
+        let resp = post_skill(&daemon, serde_json::json!({ "content": content })).await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST, "{code}");
+        let body: serde_json::Value = resp.json().await.unwrap();
+        assert_eq!(body["code"], code);
+    }
+    assert_eq!(skill_dir_count(&skills_root(&daemon)), 0);
+}
+
+#[tokio::test]
+async fn a_case_insensitive_name_collision_is_an_explicit_409() {
+    let daemon = TestDaemon::spawn(|_| Ok(())).await.unwrap();
+    let first = create_valid(&daemon).await;
+    // Same frontmatter, a label that differs only by case (the `name` field
+    // overrides the bank label; the frontmatter `name` itself must stay kebab-case).
+    let resp = post_skill(
+        &daemon,
+        serde_json::json!({ "content": VALID, "name": "TDD" }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::CONFLICT);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["code"], "duplicate_name");
+    assert_eq!(body["existing_id"], first["id"]);
+    assert_eq!(body["existing_name"], "tdd");
+    assert!(body["error"].as_str().unwrap().contains("`tdd`"));
+    // The refused paste wrote nothing: one folder only.
+    assert_eq!(skill_dir_count(&skills_root(&daemon)), 1);
+}
+
+#[tokio::test]
+async fn fp_step_4_create_a_folder_and_move_the_skill_into_it() {
+    let daemon = TestDaemon::spawn(|_| Ok(())).await.unwrap();
+    let skill = create_valid(&daemon).await;
+    let id = skill["id"].as_str().unwrap();
+
+    let resp = reqwest::Client::new()
+        .post(format!("{}/settings/skill-folders", daemon.url()))
+        .json(&serde_json::json!({ "name": "méthode" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let folder: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(folder["name"], "méthode");
+    assert!(folder["parent_id"].is_null());
+    let folder_id = folder["id"].as_str().unwrap();
+
+    let resp = put_json(
+        &daemon,
+        &format!("/settings/skills/{id}"),
+        serde_json::json!({ "folder_id": folder_id }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let moved: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(moved["folder_id"], folder_id);
+
+    // The tree shows it under the folder; the disk did not move.
+    let bank = get_json(&daemon, "/settings/skills").await;
+    assert_eq!(bank["skills"][0]["folder_id"], folder_id);
+    assert_eq!(bank["folders"][0]["id"], folder_id);
+    assert!(skills_root(&daemon).join(id).join("SKILL.md").exists());
+
+    // Back to the root with an explicit null.
+    let resp = put_json(
+        &daemon,
+        &format!("/settings/skills/{id}"),
+        serde_json::json!({ "folder_id": null }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let back: serde_json::Value = resp.json().await.unwrap();
+    assert!(back["folder_id"].is_null());
+
+    // An unknown folder is refused.
+    let resp = put_json(
+        &daemon,
+        &format!("/settings/skills/{id}"),
+        serde_json::json!({ "folder_id": "skf-nope" }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn fp_step_5_renaming_changes_the_label_only_and_moves_nothing() {
+    let daemon = TestDaemon::spawn(|_| Ok(())).await.unwrap();
+    let skill = create_valid(&daemon).await;
+    let id = skill["id"].as_str().unwrap();
+    let dir = skills_root(&daemon).join(id);
+    let before = std::fs::read_to_string(dir.join("SKILL.md")).unwrap();
+
+    let resp = put_json(
+        &daemon,
+        &format!("/settings/skills/{id}"),
+        serde_json::json!({ "name": "tdd-strict" }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let renamed: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(renamed["id"], id, "the id is the identity");
+    assert_eq!(renamed["name"], "tdd-strict");
+
+    // Same folder, same bytes, frontmatter `name` untouched: the detail is unchanged.
+    assert!(dir.exists());
+    assert_eq!(
+        std::fs::read_to_string(dir.join("SKILL.md")).unwrap(),
+        before
+    );
+    assert_eq!(skill_dir_count(&skills_root(&daemon)), 1);
+    let detail = get_json(&daemon, &format!("/settings/skills/{id}")).await;
+    assert_eq!(detail["name"], "tdd-strict");
+    assert_eq!(detail["frontmatter"]["name"], "tdd");
+
+    // A rename onto another skill's name (any case) is a 409; onto its own is fine.
+    let other = post_skill(
+        &daemon,
+        serde_json::json!({ "content": VALID.replace("name: tdd", "name: grilling") }),
+    )
+    .await;
+    assert_eq!(other.status(), StatusCode::CREATED);
+    let resp = put_json(
+        &daemon,
+        &format!("/settings/skills/{id}"),
+        serde_json::json!({ "name": "Grilling" }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::CONFLICT);
+    let resp = put_json(
+        &daemon,
+        &format!("/settings/skills/{id}"),
+        serde_json::json!({ "name": "TDD-Strict" }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn fp_step_6_referents_are_empty_and_delete_removes_row_and_folder() {
+    let daemon = TestDaemon::spawn(|_| Ok(())).await.unwrap();
+    let skill = create_valid(&daemon).await;
+    let id = skill["id"].as_str().unwrap();
+    let dir = skills_root(&daemon).join(id);
+
+    // The dialog reads the referents first: the endpoint exists, shaped by tier, empty.
+    let referents = get_json(&daemon, &format!("/settings/skills/{id}/referents")).await;
+    assert_eq!(referents["skill_id"], id);
+    assert_eq!(referents["instance"], false);
+    assert_eq!(referents["projects"], serde_json::json!([]));
+    assert_eq!(referents["pipelines"], serde_json::json!([]));
+    assert_eq!(referents["runs"], serde_json::json!([]));
+
+    let resp = reqwest::Client::new()
+        .delete(format!("{}/settings/skills/{id}", daemon.url()))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+    assert!(!dir.exists(), "the folder on disk is removed");
+    let bank = get_json(&daemon, "/settings/skills").await;
+    assert_eq!(bank["skills"], serde_json::json!([]));
+
+    // Gone means gone: 404 on every route for that id.
+    let resp = reqwest::get(format!("{}/settings/skills/{id}", daemon.url()))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    let resp = reqwest::get(format!("{}/settings/skills/{id}/referents", daemon.url()))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    let resp = reqwest::Client::new()
+        .delete(format!("{}/settings/skills/{id}", daemon.url()))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn folder_crud_nests_renames_and_deleting_moves_content_to_the_parent() {
+    let daemon = TestDaemon::spawn(|_| Ok(())).await.unwrap();
+    let client = reqwest::Client::new();
+    let mk = |name: &str, parent: Option<&str>| {
+        let client = client.clone();
+        let url = format!("{}/settings/skill-folders", daemon.url());
+        let body = serde_json::json!({ "name": name, "parent_id": parent });
+        async move {
+            let resp = client.post(url).json(&body).send().await.unwrap();
+            assert_eq!(resp.status(), StatusCode::CREATED);
+            resp.json::<serde_json::Value>().await.unwrap()
+        }
+    };
+    let ippon = mk("ippon", None).await;
+    let ippon_id = ippon["id"].as_str().unwrap();
+    let java = mk("java", Some(ippon_id)).await;
+    let java_id = java["id"].as_str().unwrap();
+    assert_eq!(java["parent_id"], ippon_id);
+
+    // A skill inside `java`.
+    let resp = post_skill(
+        &daemon,
+        serde_json::json!({ "content": VALID, "folder_id": java_id }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let skill: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(skill["folder_id"], java_id);
+
+    // Rename the folder.
+    let resp = put_json(
+        &daemon,
+        &format!("/settings/skill-folders/{java_id}"),
+        serde_json::json!({ "name": "java-spring" }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let renamed: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(renamed["name"], "java-spring");
+
+    // A cycle is refused; a blank name too; an unknown parent too.
+    let resp = put_json(
+        &daemon,
+        &format!("/settings/skill-folders/{ippon_id}"),
+        serde_json::json!({ "parent_id": java_id }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let resp = client
+        .post(format!("{}/settings/skill-folders", daemon.url()))
+        .json(&serde_json::json!({ "name": "  " }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let resp = client
+        .post(format!("{}/settings/skill-folders", daemon.url()))
+        .json(&serde_json::json!({ "name": "x", "parent_id": "skf-nope" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+
+    // Listed.
+    let listed = get_json(&daemon, "/settings/skill-folders").await;
+    assert_eq!(listed["folders"].as_array().unwrap().len(), 2);
+
+    // Delete `java`: its skill moves up to `ippon`; the skill itself survives.
+    let resp = client
+        .delete(format!("{}/settings/skill-folders/{java_id}", daemon.url()))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+    let bank = get_json(&daemon, "/settings/skills").await;
+    assert_eq!(bank["folders"].as_array().unwrap().len(), 1);
+    assert_eq!(bank["skills"][0]["folder_id"], ippon_id);
+    assert!(skills_root(&daemon)
+        .join(skill["id"].as_str().unwrap())
+        .join("SKILL.md")
+        .exists());
+
+    // Deleting `ippon` sends the skill to the root.
+    let resp = client
+        .delete(format!(
+            "{}/settings/skill-folders/{ippon_id}",
+            daemon.url()
+        ))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+    let bank = get_json(&daemon, "/settings/skills").await;
+    assert!(bank["skills"][0]["folder_id"].is_null());
+    let resp = client
+        .delete(format!(
+            "{}/settings/skill-folders/{ippon_id}",
+            daemon.url()
+        ))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn reference_files_on_disk_are_listed_read_only_in_the_detail() {
+    let daemon = TestDaemon::spawn(|_| Ok(())).await.unwrap();
+    let skill = create_valid(&daemon).await;
+    let id = skill["id"].as_str().unwrap();
+    let dir = skills_root(&daemon).join(id);
+    std::fs::write(dir.join("checklist.md"), "- [ ] one\n").unwrap();
+    std::fs::create_dir_all(dir.join("ref")).unwrap();
+    std::fs::write(dir.join("ref").join("a.txt"), "12345").unwrap();
+
+    let detail = get_json(&daemon, &format!("/settings/skills/{id}")).await;
+    assert_eq!(
+        detail["files"],
+        serde_json::json!([
+            { "path": "checklist.md", "size": 10 },
+            { "path": "ref/a.txt", "size": 5 },
+        ])
+    );
+}
+
+#[tokio::test]
+async fn the_bank_survives_a_daemon_restart() {
+    // The index is in `pdo.db`, the content on disk: both are under the repo root,
+    // so a fresh daemon over the same directory sees the same bank. Two daemons
+    // are booted in turn over ONE tempdir with `serve_with_config` directly (the
+    // `TestDaemon` constructors each own a fresh tempdir).
+    use pdo_daemon::{serve_with_config, DaemonConfig};
+    use std::net::SocketAddr;
+
+    let tempdir = tempfile::tempdir().unwrap();
+    let config = || DaemonConfig {
+        tmux_cmd_override: Some("exec sleep 600".to_string()),
+        panic_on_trigger_name: None,
+        panic_on_stale_sweep: false,
+        panic_on_spawn: false,
+        service_health_override: None,
+        docker_cmd_override: None,
+        sandbox_home_override: None,
+        price_source_url: None,
+        price_refresh_at_boot: false,
+        allowed_ws_origins: Vec::new(),
+        run_trigger_scheduler_loop: false,
+        nested_daemon: true,
+    };
+
+    let first = serve_with_config(
+        SocketAddr::from(([127, 0, 0, 1], 0)),
+        tempdir.path().to_path_buf(),
+        config(),
+    )
+    .await
+    .unwrap();
+    let url = format!("http://{}", first.addr);
+    let resp = reqwest::Client::new()
+        .post(format!("{url}/settings/skills"))
+        .json(&serde_json::json!({ "content": VALID }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let skill: serde_json::Value = resp.json().await.unwrap();
+    let id = skill["id"].as_str().unwrap().to_string();
+    first.task.abort();
+
+    let second = serve_with_config(
+        SocketAddr::from(([127, 0, 0, 1], 0)),
+        tempdir.path().to_path_buf(),
+        config(),
+    )
+    .await
+    .unwrap();
+    let url = format!("http://{}", second.addr);
+    let bank: serde_json::Value = reqwest::get(format!("{url}/settings/skills"))
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(bank["skills"][0]["id"], id);
+    let detail: serde_json::Value = reqwest::get(format!("{url}/settings/skills/{id}"))
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(detail["content"], VALID);
+    second.task.abort();
+}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,4 +1,4 @@
-import type { PipelineListEntry, PipelineDetail, PipelineDef, RunListEntry, RunState, PortDef, PortSide, PortType, FrontmatterFieldDecl, FrontmatterViolation, Trigger, TriggerFire, DaemonStatus, InstanceSettings, UpdateSettingsRequest, StatsOverview, StatsCost, StatsPerformance, SandboxProfile, SandboxProfileImage, SandboxProfileReferents, SyncCostPricesReport, Project, BranchRef, AgentChoice, AgentProfile, AgentProfileReferents, ProvisioningPlan, ProvisioningRules } from "./types";
+import type { PipelineListEntry, PipelineDetail, PipelineDef, RunListEntry, RunState, PortDef, PortSide, PortType, FrontmatterFieldDecl, FrontmatterViolation, Trigger, TriggerFire, DaemonStatus, InstanceSettings, UpdateSettingsRequest, StatsOverview, StatsCost, StatsPerformance, SandboxProfile, SandboxProfileImage, SandboxProfileReferents, SyncCostPricesReport, Project, BranchRef, AgentChoice, AgentProfile, AgentProfileReferents, ProvisioningPlan, ProvisioningRules, Skill, SkillBank, SkillDetail, SkillFolder, SkillReferents } from "./types";
 import { foldHarnessOntoNode } from "./lib/harness";
 
 const BASE = "";
@@ -1690,4 +1690,65 @@ export function promotePipeline(pipelineId: string): Promise<PromoteResult> {
     `/pipelines/${encodeURIComponent(pipelineId)}/promote`,
     { label: `POST /pipelines/${pipelineId}/promote` },
   );
+}
+
+// ---------------------------------------------------------------------------
+// Banque de skills (#668, ADR-0062). Separate REST resources under `/settings`,
+// NOT part of the grouped `PUT /settings`: a skill is a ROW plus a folder on disk.
+// Every gesture commits immediately (no unsaved state in the bank).
+// ---------------------------------------------------------------------------
+
+export function fetchSkillBank(): Promise<SkillBank> {
+  return request("GET", "/settings/skills");
+}
+
+export function createSkill(body: {
+  content: string;
+  name?: string;
+  folder_id?: string | null;
+}): Promise<Skill> {
+  return request("POST", "/settings/skills", { body });
+}
+
+export function fetchSkill(id: string): Promise<SkillDetail> {
+  return request("GET", `/settings/skills/${encodeURIComponent(id)}`);
+}
+
+/** Sparse edit: `name` renames the label only; `folder_id: null` moves to the root. */
+export function updateSkill(
+  id: string,
+  patch: { name?: string; folder_id?: string | null },
+): Promise<Skill> {
+  return request("PUT", `/settings/skills/${encodeURIComponent(id)}`, { body: patch });
+}
+
+export function deleteSkill(id: string): Promise<void> {
+  return request("DELETE", `/settings/skills/${encodeURIComponent(id)}`, {
+    responseMode: "void",
+  });
+}
+
+export function fetchSkillReferents(id: string): Promise<SkillReferents> {
+  return request("GET", `/settings/skills/${encodeURIComponent(id)}/referents`);
+}
+
+export function createSkillFolder(body: {
+  name: string;
+  parent_id?: string | null;
+}): Promise<SkillFolder> {
+  return request("POST", "/settings/skill-folders", { body });
+}
+
+export function updateSkillFolder(
+  id: string,
+  patch: { name?: string; parent_id?: string | null },
+): Promise<SkillFolder> {
+  return request("PUT", `/settings/skill-folders/${encodeURIComponent(id)}`, { body: patch });
+}
+
+/** The folder's skills and sub-folders move to its parent; no skill is deleted. */
+export function deleteSkillFolder(id: string): Promise<void> {
+  return request("DELETE", `/settings/skill-folders/${encodeURIComponent(id)}`, {
+    responseMode: "void",
+  });
 }

--- a/frontend/src/components/PasteSkillModal.test.tsx
+++ b/frontend/src/components/PasteSkillModal.test.tsx
@@ -1,0 +1,192 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const createSkillMock = vi.fn();
+
+vi.mock("../api", () => ({
+  createSkill: (...args: unknown[]) => createSkillMock(...args),
+  // Defined INSIDE the hoisted factory (a top-level class would not exist yet),
+  // with the real constructor signature so tests read like production code.
+  ApiError: class ApiError extends Error {
+    status?: number;
+    body?: unknown;
+    constructor(message: string, opts: { status?: number; body?: unknown } = {}) {
+      super(message);
+      this.status = opts.status;
+      this.body = opts.body;
+    }
+  },
+}));
+
+import { ApiError } from "../api";
+
+import PasteSkillModal from "./PasteSkillModal";
+import type { SkillFolder } from "../types";
+
+const VALID = `---
+name: tdd
+description: Test-driven development. Red-green-refactor at pre-agreed seams.
+allowed-tools: Bash(npm:*) Bash(cargo:*)
+---
+
+# Test-driven development
+
+Red, green, refactor.
+`;
+
+const t = "2026-09-03T10:00:00Z";
+const folders: SkillFolder[] = [
+  { id: "f-m", name: "méthode", parent_id: null, created_at: t, updated_at: t },
+  { id: "f-i", name: "ippon", parent_id: null, created_at: t, updated_at: t },
+  { id: "f-j", name: "java", parent_id: "f-i", created_at: t, updated_at: t },
+];
+
+function setup(overrides: Partial<React.ComponentProps<typeof PasteSkillModal>> = {}) {
+  const onClose = vi.fn();
+  const onCreated = vi.fn().mockResolvedValue(undefined);
+  render(
+    <PasteSkillModal
+      folders={folders}
+      existingNames={["grilling"]}
+      initialFolderId="f-m"
+      onClose={onClose}
+      onCreated={onCreated}
+      {...overrides}
+    />,
+  );
+  return { onClose, onCreated };
+}
+
+function checkState(id: string) {
+  return screen.getByTestId(`check-${id}`).getAttribute("data-state");
+}
+
+function paste(text: string) {
+  fireEvent.change(screen.getByTestId("paste-skill-text"), { target: { value: text } });
+}
+
+describe("PasteSkillModal (#668)", () => {
+  beforeEach(() => {
+    createSkillMock.mockReset();
+  });
+
+  it("opens with Create disabled, the five checks pending/failed, and the tree's folder pre-selected", () => {
+    setup();
+    expect(screen.getByTestId("paste-skill-create")).toBeDisabled();
+    expect(screen.getByTestId("paste-skill-checks").children).toHaveLength(5);
+    expect(checkState("frontmatter")).toBe("fail");
+    expect(checkState("unique")).toBe("pending");
+    // Blank text: no reason yet (nothing typed).
+    expect(screen.queryByTestId("paste-skill-reason")).toBeNull();
+    expect((screen.getByTestId("paste-skill-folder") as HTMLSelectElement).value).toBe("f-m");
+    // Nested folders read as a path.
+    expect(screen.getByRole("option", { name: "ippon / java" })).toBeInTheDocument();
+  });
+
+  it("FP step 2: a valid SKILL.md passes all five checks, previews the row, and Create posts it", async () => {
+    const { onClose, onCreated } = setup();
+    createSkillMock.mockResolvedValue({ id: "s-1", name: "tdd", description: "x", folder_id: "f-m" });
+    paste(VALID);
+
+    for (const id of ["frontmatter", "name", "description", "body", "unique"]) {
+      expect(checkState(id)).toBe("pass");
+    }
+    const preview = screen.getByTestId("paste-skill-preview");
+    expect(preview).toHaveTextContent("tdd");
+    expect(preview).toHaveTextContent("Test-driven development. Red-green-refactor at pre-agreed seams.");
+    expect(screen.queryByTestId("paste-skill-reason")).toBeNull();
+
+    const create = screen.getByTestId("paste-skill-create");
+    expect(create).toBeEnabled();
+    fireEvent.click(create);
+
+    await waitFor(() => expect(createSkillMock).toHaveBeenCalledTimes(1));
+    expect(createSkillMock).toHaveBeenCalledWith({ content: VALID, folder_id: "f-m" });
+    await waitFor(() => expect(onCreated).toHaveBeenCalledWith(expect.objectContaining({ id: "s-1" })));
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+
+  it("FP step 3: a SKILL.md without description turns the check red, explains, and keeps Create disabled", () => {
+    setup();
+    paste(VALID.replace(/description: .*\n/, ""));
+
+    expect(checkState("description")).toBe("fail");
+    expect(screen.getByTestId("check-description")).toHaveTextContent("description missing");
+    expect(screen.getByTestId("paste-skill-text")).toHaveAttribute("aria-invalid", "true");
+    const reason = screen.getByTestId("paste-skill-reason");
+    expect(reason).toHaveTextContent("Cannot create.");
+    expect(reason).toHaveTextContent(/no `description`/);
+    expect(reason).toHaveTextContent(/nothing was written/i);
+    expect(screen.getByTestId("paste-skill-create")).toBeDisabled();
+    expect(createSkillMock).not.toHaveBeenCalled();
+  });
+
+  it("detects a local case-insensitive collision before any request", () => {
+    setup({ existingNames: ["TDD"] });
+    paste(VALID);
+    expect(checkState("unique")).toBe("fail");
+    expect(screen.getByTestId("paste-skill-reason")).toHaveTextContent("Name already taken.");
+    expect(screen.getByTestId("paste-skill-create")).toBeDisabled();
+  });
+
+  it("renders a daemon 409 as the failing `unique` check, in place, and re-enables once the name changes", async () => {
+    setup({ existingNames: [] });
+    createSkillMock.mockRejectedValueOnce(
+      new ApiError("a skill named `tdd` already exists", { status: 409, body: { code: "duplicate_name" } }),
+    );
+    paste(VALID);
+    fireEvent.click(screen.getByTestId("paste-skill-create"));
+
+    await waitFor(() => expect(checkState("unique")).toBe("fail"));
+    expect(screen.getByTestId("paste-skill-reason")).toHaveTextContent("Name already taken.");
+    expect(screen.getByTestId("paste-skill-create")).toBeDisabled();
+    // Still one dialog, no modal on the modal.
+    expect(screen.getAllByRole("dialog")).toHaveLength(1);
+
+    paste(VALID.replace("name: tdd", "name: tdd-strict"));
+    expect(checkState("unique")).toBe("pass");
+    expect(screen.getByTestId("paste-skill-create")).toBeEnabled();
+  });
+
+  it("renders a daemon 400 like a local failure, on the check its code names", async () => {
+    setup({ existingNames: [] });
+    createSkillMock.mockRejectedValueOnce(
+      new ApiError("the frontmatter has no `description`", { status: 400, body: { code: "missing_description" } }),
+    );
+    paste(VALID);
+    fireEvent.click(screen.getByTestId("paste-skill-create"));
+    await waitFor(() => expect(checkState("description")).toBe("fail"));
+    expect(screen.getByTestId("paste-skill-reason")).toHaveTextContent("the frontmatter has no `description`");
+  });
+
+  it("asks before discarding typed text; closes at once when empty", () => {
+    const { onClose } = setup();
+    fireEvent.click(screen.getByLabelText("Close paste popup"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    onClose.mockClear();
+    paste("some text");
+    fireEvent.click(screen.getByLabelText("Close paste popup"));
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByTestId("paste-skill-discard-prompt")).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("paste-skill-discard"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("Escape goes through the same discard guard", () => {
+    const { onClose } = setup();
+    paste("draft");
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByTestId("paste-skill-discard-prompt")).toBeInTheDocument();
+  });
+
+  it("lets the operator change the target folder, root included", async () => {
+    setup({ existingNames: [] });
+    createSkillMock.mockResolvedValue({ id: "s-2", name: "tdd", description: "x", folder_id: null });
+    paste(VALID);
+    fireEvent.change(screen.getByTestId("paste-skill-folder"), { target: { value: "" } });
+    fireEvent.click(screen.getByTestId("paste-skill-create"));
+    await waitFor(() => expect(createSkillMock).toHaveBeenCalledWith({ content: VALID, folder_id: null }));
+  });
+});

--- a/frontend/src/components/PasteSkillModal.tsx
+++ b/frontend/src/components/PasteSkillModal.tsx
@@ -1,0 +1,360 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Check, ClipboardPaste, Folder, X } from "lucide-react";
+import { ApiError, createSkill } from "../api";
+import type { Skill, SkillFolder } from "../types";
+import { validateSkillMd, type CheckId, type CheckState } from "../lib/skillMd";
+import { folderPathLabel } from "../lib/skillTree";
+
+interface Props {
+  folders: SkillFolder[];
+  /** Current bank labels, for the live `unique` check. */
+  existingNames: string[];
+  /** Folder pre-selected when the popup opened (the tree's selection). */
+  initialFolderId: string | null;
+  onClose: () => void;
+  onCreated: (skill: Skill) => void | Promise<void>;
+}
+
+/** Map a daemon refusal `code` to the check it should light red. */
+const CODE_TO_CHECK: Record<string, CheckId> = {
+  no_frontmatter: "frontmatter",
+  malformed_frontmatter: "frontmatter",
+  missing_name: "name",
+  name_not_kebab_case: "name",
+  empty_label: "name",
+  missing_description: "description",
+  empty_body: "body",
+  duplicate_name: "unique",
+};
+
+/**
+ * "New skill from SKILL.md" (#668, FP steps 2-3): paste the text, five checks
+ * re-run on every keystroke, the preview card is exactly the tree row it will
+ * become, and Create enables only when all five pass. A refusal — local or a
+ * daemon 400/409 — is shown **in place** (red check, red textarea border, callout
+ * with reason and consequence), never as a modal on top of this modal.
+ *
+ * Nothing touches disk until Create: the daemon validates again and writes the
+ * folder only after the row is indexed. Same `z-[60]` layer as `FsExplorerModal`
+ * (they are never open at once).
+ */
+export default function PasteSkillModal({
+  folders,
+  existingNames,
+  initialFolderId,
+  onClose,
+  onCreated,
+}: Props) {
+  const [text, setText] = useState("");
+  const [folderId, setFolderId] = useState<string | null>(initialFolderId);
+  const [submitting, setSubmitting] = useState(false);
+  const [serverError, setServerError] = useState<{ code: string; message: string } | null>(null);
+  /** The text a 409 was returned for; the `unique` check stays red until it changes. */
+  const [duplicateFor, setDuplicateFor] = useState<string | null>(null);
+  const [confirmDiscard, setConfirmDiscard] = useState(false);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    textareaRef.current?.focus();
+  }, []);
+
+  const serverDuplicate = duplicateFor !== null && duplicateFor === text;
+  const validation = useMemo(
+    () => validateSkillMd(text, existingNames, serverDuplicate),
+    [text, existingNames, serverDuplicate],
+  );
+
+  // A daemon 400 for the CURRENT text overrides the check it names; any edit clears it.
+  const serverCheck: CheckId | null =
+    serverError && CODE_TO_CHECK[serverError.code] ? CODE_TO_CHECK[serverError.code] : null;
+  const checks = validation.checks.map((check) =>
+    serverCheck === check.id && check.state === "pass"
+      ? { ...check, state: "fail" as CheckState }
+      : check,
+  );
+  const failing = checks.some((check) => check.state === "fail");
+  const canCreate = validation.valid && !serverError && !submitting && text.trim() !== "";
+  const reason = serverError?.message ?? validation.reason;
+
+  const requestClose = () => {
+    if (text.trim() !== "" && !confirmDiscard) {
+      setConfirmDiscard(true);
+      return;
+    }
+    onClose();
+  };
+
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.stopPropagation();
+        requestClose();
+      }
+    };
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [text, confirmDiscard]);
+
+  const submit = async () => {
+    if (!canCreate) return;
+    setSubmitting(true);
+    setServerError(null);
+    try {
+      const skill = await createSkill({ content: text, folder_id: folderId });
+      await onCreated(skill);
+      onClose();
+    } catch (cause) {
+      if (cause instanceof ApiError) {
+        const body = cause.body as { code?: unknown } | null;
+        const code = typeof body?.code === "string" ? body.code : "";
+        if (cause.status === 409 || code === "duplicate_name") {
+          setDuplicateFor(text);
+        } else {
+          setServerError({ code, message: cause.message });
+        }
+      } else {
+        setServerError({
+          code: "",
+          message: cause instanceof Error ? cause.message : "Failed to create the skill",
+        });
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const preview = validation.parsed;
+  const previewName = preview.name ?? "(name)";
+  const previewDescription = preview.description ?? "(description)";
+  const selectedFolder = folders.find((folder) => folder.id === folderId) ?? null;
+
+  return (
+    <div
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-black/50"
+      onClick={(event) => {
+        event.stopPropagation();
+        requestClose();
+      }}
+      data-testid="paste-skill-backdrop"
+    >
+      <div
+        className="flex w-[1020px] max-w-[96vw] max-h-[88vh] flex-col rounded-lg border border-line bg-bg-4 shadow-xl"
+        onClick={(event) => event.stopPropagation()}
+        role="dialog"
+        aria-label="New skill from SKILL.md"
+        data-testid="paste-skill-modal"
+      >
+        <div className="flex items-center justify-between border-b border-line px-4 py-3">
+          <h3 className="flex items-center gap-2 font-semibold text-fg" style={{ fontSize: "13.5px" }}>
+            <ClipboardPaste size={14} className="text-fg-3" />
+            New skill from SKILL.md
+          </h3>
+          <button
+            type="button"
+            onClick={requestClose}
+            aria-label="Close paste popup"
+            className="grid h-6 w-6 place-items-center rounded text-fg-3 hover:bg-bg-5 hover:text-fg"
+          >
+            <X size={14} />
+          </button>
+        </div>
+
+        <div className="flex min-h-0 flex-1 gap-4 p-4">
+          {/* Left: the pasted text */}
+          <div className="flex min-w-0 flex-1 flex-col gap-2">
+            <textarea
+              ref={textareaRef}
+              value={text}
+              onChange={(event) => {
+                setText(event.target.value);
+                setServerError(null);
+                setConfirmDiscard(false);
+              }}
+              onPaste={() => setConfirmDiscard(false)}
+              spellCheck={false}
+              placeholder={"---\nname: my-skill\ndescription: What it does, when to use it.\n---\n\n# My skill\n\nInstructions…"}
+              aria-label="SKILL.md text"
+              aria-invalid={failing || undefined}
+              data-testid="paste-skill-text"
+              className={`min-h-[340px] flex-1 resize-none rounded-md border bg-bg-1 p-3 font-mono text-fg outline-none transition-colors ${
+                failing ? "border-st-failed" : text.trim() && validation.valid ? "border-acc/60" : "border-line-strong focus:border-acc"
+              }`}
+              style={{ fontSize: "11.5px", lineHeight: 1.55 }}
+            />
+            <div
+              className="rounded-md border border-dashed border-line px-3 py-2 text-fg-4"
+              style={{ fontSize: "10.5px" }}
+            >
+              Reference files (drag files here) arrive in a later ticket · SKILL.md only for now
+            </div>
+          </div>
+
+          {/* Right: checks, preview, folder */}
+          <div className="flex w-[330px] shrink-0 flex-col gap-4 overflow-y-auto">
+            <section>
+              <h4 className="mb-2 text-fg-4 uppercase tracking-wide" style={{ fontSize: "10px" }}>
+                Checks
+              </h4>
+              <ul className="flex flex-col gap-1.5" data-testid="paste-skill-checks">
+                {checks.map((check) => (
+                  <li
+                    key={check.id}
+                    className="flex items-center gap-2 text-fg-2"
+                    style={{ fontSize: "11.5px" }}
+                    data-testid={`check-${check.id}`}
+                    data-state={check.state}
+                  >
+                    <CheckDot state={check.state} />
+                    <span className={check.state === "fail" ? "text-fg" : check.state === "pending" ? "text-fg-4" : ""}>
+                      {check.label}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </section>
+
+            <section>
+              <h4 className="mb-2 text-fg-4 uppercase tracking-wide" style={{ fontSize: "10px" }}>
+                Will appear as
+              </h4>
+              <div
+                className={`rounded-md border border-line bg-bg-3 px-3 py-2.5 ${validation.valid ? "" : "opacity-70"}`}
+                data-testid="paste-skill-preview"
+              >
+                <div className={`font-semibold ${preview.name ? "text-fg" : "text-fg-4"}`} style={{ fontSize: "12.5px" }}>
+                  {previewName}
+                </div>
+                <div className={`mt-0.5 ${preview.description ? "text-fg-3" : "text-fg-4"}`} style={{ fontSize: "11px" }}>
+                  {previewDescription}
+                </div>
+              </div>
+              {reason && (
+                <div
+                  role="alert"
+                  className="mt-2 rounded-md border border-st-failed/50 bg-st-failed-bg px-3 py-2 text-fg-2"
+                  style={{ fontSize: "11px" }}
+                  data-testid="paste-skill-reason"
+                >
+                  <strong className="text-fg">
+                    {checks.find((c) => c.id === "unique")?.state === "fail" && !failingOther(checks)
+                      ? "Name already taken."
+                      : "Cannot create."}
+                  </strong>{" "}
+                  {reason}
+                </div>
+              )}
+            </section>
+
+            <section>
+              <h4 className="mb-2 text-fg-4 uppercase tracking-wide" style={{ fontSize: "10px" }}>
+                Folder
+              </h4>
+              <label className="flex items-center gap-2 rounded-md border border-line-strong bg-bg-3 px-2.5 py-1.5">
+                <Folder size={12} className="shrink-0 text-fg-3" />
+                <select
+                  value={folderId ?? ""}
+                  onChange={(event) => setFolderId(event.target.value || null)}
+                  aria-label="Folder"
+                  data-testid="paste-skill-folder"
+                  className="w-full bg-transparent text-fg outline-none"
+                  style={{ fontSize: "11.5px" }}
+                >
+                  <option value="">Root of the bank</option>
+                  {folders.map((folder) => (
+                    <option key={folder.id} value={folder.id}>
+                      {folderPathLabel(folder.id, folders)}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              {selectedFolder === null && folderId !== null && (
+                <p className="mt-1 text-st-blocked" style={{ fontSize: "10px" }}>
+                  That folder no longer exists; the skill will land at the root.
+                </p>
+              )}
+            </section>
+          </div>
+        </div>
+
+        <div className="flex items-center justify-between gap-3 border-t border-line px-4 py-3">
+          <span className="text-fg-4" style={{ fontSize: "10.5px" }}>
+            Validated as you type · nothing touches disk until Create
+          </span>
+          <div className="flex items-center gap-2">
+            {confirmDiscard ? (
+              <>
+                <span className="text-fg-2" style={{ fontSize: "11px" }} data-testid="paste-skill-discard-prompt">
+                  Discard the pasted text?
+                </span>
+                <button
+                  type="button"
+                  onClick={() => setConfirmDiscard(false)}
+                  className="rounded-md border border-line-strong bg-bg-3 px-3 py-1.5 text-fg-2 hover:bg-bg-4"
+                  style={{ fontSize: "11.5px" }}
+                >
+                  Keep editing
+                </button>
+                <button
+                  type="button"
+                  onClick={onClose}
+                  data-testid="paste-skill-discard"
+                  className="rounded-md bg-st-failed px-3 py-1.5 font-medium text-white hover:opacity-90"
+                  style={{ fontSize: "11.5px" }}
+                >
+                  Discard
+                </button>
+              </>
+            ) : (
+              <>
+                <button
+                  type="button"
+                  onClick={requestClose}
+                  className="rounded-md border border-line-strong bg-bg-3 px-3 py-1.5 text-fg-2 hover:bg-bg-4"
+                  style={{ fontSize: "11.5px" }}
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  onClick={() => void submit()}
+                  disabled={!canCreate}
+                  data-testid="paste-skill-create"
+                  className="rounded-md bg-acc px-3 py-1.5 font-medium text-bg-1 transition-opacity hover:opacity-90 disabled:opacity-40"
+                  style={{ fontSize: "11.5px" }}
+                >
+                  {submitting ? "Creating…" : "Create skill"}
+                </button>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function failingOther(checks: { id: CheckId; state: CheckState }[]): boolean {
+  return checks.some((check) => check.id !== "unique" && check.state === "fail");
+}
+
+function CheckDot({ state }: { state: CheckState }) {
+  if (state === "pass") {
+    return (
+      <span className="grid h-3.5 w-3.5 place-items-center rounded-full bg-acc/20 text-acc">
+        <Check size={9} strokeWidth={3} />
+      </span>
+    );
+  }
+  if (state === "fail") {
+    return (
+      <span className="grid h-3.5 w-3.5 place-items-center rounded-full bg-st-failed/20 text-st-failed">
+        <X size={9} strokeWidth={3} />
+      </span>
+    );
+  }
+  if (state === "warn") {
+    return <span className="grid h-3.5 w-3.5 place-items-center rounded-full bg-st-await/20 text-st-await font-bold" style={{ fontSize: 9 }}>!</span>;
+  }
+  return <span className="h-3.5 w-3.5 rounded-full border border-line-strong" />;
+}

--- a/frontend/src/components/SettingsModal.test.tsx
+++ b/frontend/src/components/SettingsModal.test.tsx
@@ -35,6 +35,21 @@ vi.mock("../api", () => ({
   fetchSandboxProfileReferents: (...args: unknown[]) =>
     fetchSandboxProfileReferentsMock(...args),
   fetchInstanceProvisioning: (...args: unknown[]) => fetchInstanceProvisioningMock(...args),
+  // #668: the skill bank drill-down. Same Proxy trap: every function `SkillBankPanel`
+  // / `PasteSkillModal` import must exist here or the panel throws on first access.
+  fetchSkillBank: vi.fn().mockResolvedValue({ skills: [], folders: [], root_path: "/home/user/.pdo/skills" }),
+  createSkill: vi.fn(),
+  fetchSkill: vi.fn(),
+  updateSkill: vi.fn(),
+  deleteSkill: vi.fn(),
+  fetchSkillReferents: vi.fn(),
+  createSkillFolder: vi.fn(),
+  updateSkillFolder: vi.fn(),
+  deleteSkillFolder: vi.fn(),
+  ApiError: class ApiError extends Error {
+    status?: number;
+    body?: unknown;
+  },
 }));
 
 import SettingsModal, { relativiseToHome } from "./SettingsModal";

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import { ChevronLeft, Lock, Pencil, Plus, Search, Trash2, X } from "lucide-react";
+import { ChevronLeft, FileText, Lock, Pencil, Plus, Search, Trash2, X } from "lucide-react";
 import FsExplorerModal from "./FsExplorerModal";
 import { useSettings } from "../hooks/useSettings";
 import { useEditStore } from "../stores/editStore";
@@ -37,6 +37,8 @@ import AgentControl from "./AgentControl";
 import { announceAgentProfilesChanged, useAgentProfiles } from "../hooks/useAgentProfiles";
 import { useHarnessCatalog } from "../hooks/useHarnessCatalog";
 import PersistedProvisioningEditor from "./PersistedProvisioningEditor";
+import SkillBankPanel from "./SkillBankPanel";
+import { announceSkillsChanged, useSkillBank } from "../hooks/useSkillBank";
 
 interface Props {
   open: boolean;
@@ -81,7 +83,16 @@ export default function SettingsModal({ open, onClose, liveSessions = 0, onSaved
   const [profilesOpen, setProfilesOpen] = useState(false);
   const [agentProfilesOpen, setAgentProfilesOpen] = useState(false);
   const [provisioningOpen, setProvisioningOpen] = useState(false);
+  /**
+   * Banque de skills drill-down (#668). Same shell, but it WIDENS the modal to
+   * 760 px for the visit (a folder tree plus a readable detail do not fit in
+   * 460) and comes back to 460 on Back. Two panes: tree left, read-only detail
+   * right.
+   */
+  const [skillsOpen, setSkillsOpen] = useState(false);
   const { profiles: agentProfiles, refresh: refreshAgentProfiles } = useAgentProfiles(open);
+  const { bank: skillBank, loaded: skillsLoaded, refresh: refreshSkills } = useSkillBank(open);
+  const drillDown = profilesOpen || agentProfilesOpen || skillsOpen;
 
   // The modal is unmounted-by-render (`if (!open) return null`), so its state SURVIVES a
   // close. Reset the drill-down here rather than in an effect on `open`: both the backdrop
@@ -90,6 +101,7 @@ export default function SettingsModal({ open, onClose, liveSessions = 0, onSaved
   const handleClose = () => {
     setProfilesOpen(false);
     setAgentProfilesOpen(false);
+    setSkillsOpen(false);
     setProvisioningOpen(false);
     onClose();
   };
@@ -102,17 +114,21 @@ export default function SettingsModal({ open, onClose, liveSessions = 0, onSaved
       onClick={handleClose}
     >
       <div
-        className="w-[460px] max-h-[85vh] flex flex-col overflow-y-auto rounded-lg border border-line bg-bg-4 shadow-xl"
+        className={`${
+          skillsOpen ? "w-[760px] h-[85vh]" : "w-[460px]"
+        } max-h-[85vh] flex flex-col overflow-y-auto rounded-lg border border-line bg-bg-4 shadow-xl transition-[width] duration-200`}
         onClick={(e) => e.stopPropagation()}
         data-testid="settings-modal"
+        data-drilldown={skillsOpen ? "skills" : agentProfilesOpen ? "agent-profiles" : profilesOpen ? "staging-profiles" : undefined}
       >
         <div className="flex items-center justify-between border-b border-line px-4 py-3">
           <div className="flex min-w-0 items-center gap-2">
-            {(profilesOpen || agentProfilesOpen) && (
+            {drillDown && (
               <button
                 onClick={() => {
                   setProfilesOpen(false);
                   setAgentProfilesOpen(false);
+                  setSkillsOpen(false);
                 }}
                 aria-label="Back to settings"
                 data-testid="staging-profiles-back"
@@ -122,7 +138,17 @@ export default function SettingsModal({ open, onClose, liveSessions = 0, onSaved
               </button>
             )}
             <h2 className="truncate font-semibold text-fg" style={{ fontSize: "13.5px" }}>
-              {profilesOpen ? "Staging profiles" : agentProfilesOpen ? "Agent profiles" : "Instance settings"}
+              {skillsOpen ? (
+                <>
+                  <span className="font-normal text-fg-3">Instance settings / </span>Skills
+                </>
+              ) : profilesOpen ? (
+                "Staging profiles"
+              ) : agentProfilesOpen ? (
+                "Agent profiles"
+              ) : (
+                "Instance settings"
+              )}
             </h2>
           </div>
           <button
@@ -139,7 +165,7 @@ export default function SettingsModal({ open, onClose, liveSessions = 0, onSaved
             even if `GET /settings` fails and the numeric form never mounts
             (Trap A). Hidden — not unmounted — behind the drill-down, same reason
             as `SettingsForm` below. */}
-        <div className={profilesOpen || agentProfilesOpen ? "hidden" : undefined}>
+        <div className={drillDown ? "hidden" : undefined}>
           <InterfaceSection />
           <div className="border-b border-line px-4 py-3">
             {provisioningOpen ? (
@@ -165,6 +191,32 @@ export default function SettingsModal({ open, onClose, liveSessions = 0, onSaved
               Manage agent profiles…
             </button>
           </div>
+          {/* Banque de skills (#668): entry point of the drill-down, with the bank's
+              size as a hint and the instance-tier reminder (selection lands in a
+              later ticket). */}
+          <div className="border-b border-line px-4 py-3">
+            <div className="flex items-center gap-3">
+              <button
+                type="button"
+                data-testid="setting-manage-skills"
+                onClick={() => setSkillsOpen(true)}
+                className="flex items-center gap-1.5 rounded border border-line-strong bg-bg-3 px-2.5 py-1.5 text-fg-2 hover:border-acc"
+                style={{ fontSize: 11 }}
+              >
+                <FileText size={11} />
+                Manage skills…
+              </button>
+              <span className="text-fg-4" style={{ fontSize: "10.5px" }} data-testid="setting-skills-count">
+                {skillsLoaded
+                  ? `${skillBank.skills.length} skill${skillBank.skills.length === 1 ? "" : "s"} · ${skillBank.folders.length} folder${skillBank.folders.length === 1 ? "" : "s"}`
+                  : ""}
+              </span>
+            </div>
+            <p className="mt-2 text-fg-4" style={{ fontSize: "10.5px" }}>
+              Skills selected here apply to every node of every run (instance tier).{" "}
+              <span className="text-fg-5">Selection arrives in a later ticket.</span>
+            </p>
+          </div>
         </div>
 
         {settings ? (
@@ -172,9 +224,7 @@ export default function SettingsModal({ open, onClose, liveSessions = 0, onSaved
           // UNSAVED edits (`capStr`, `model`, …) seeded on mount, and a conditional render
           // would throw them away in silence.
           <div
-            className={
-              profilesOpen || agentProfilesOpen ? "hidden" : "flex min-h-0 flex-1 flex-col"
-            }
+            className={drillDown ? "hidden" : "flex min-h-0 flex-1 flex-col"}
           >
             <SettingsForm
               // Re-seed if the loaded config changes (refetch / restart, or a profile write
@@ -211,6 +261,17 @@ export default function SettingsModal({ open, onClose, liveSessions = 0, onSaved
             onChanged={() => {
               void refresh();
               onSaved?.();
+            }}
+          />
+        )}
+        {skillsOpen && (
+          <SkillBankPanel
+            bank={skillBank}
+            loaded={skillsLoaded}
+            home={settings?.home ?? null}
+            onChanged={async () => {
+              await refreshSkills();
+              announceSkillsChanged();
             }}
           />
         )}

--- a/frontend/src/components/SkillBankPanel.test.tsx
+++ b/frontend/src/components/SkillBankPanel.test.tsx
@@ -1,0 +1,348 @@
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const fetchSkillMock = vi.fn();
+const updateSkillMock = vi.fn();
+const deleteSkillMock = vi.fn();
+const fetchSkillReferentsMock = vi.fn();
+const createSkillFolderMock = vi.fn();
+const updateSkillFolderMock = vi.fn();
+const deleteSkillFolderMock = vi.fn();
+const createSkillMock = vi.fn();
+
+vi.mock("../api", () => ({
+  fetchSkill: (...args: unknown[]) => fetchSkillMock(...args),
+  updateSkill: (...args: unknown[]) => updateSkillMock(...args),
+  deleteSkill: (...args: unknown[]) => deleteSkillMock(...args),
+  fetchSkillReferents: (...args: unknown[]) => fetchSkillReferentsMock(...args),
+  createSkillFolder: (...args: unknown[]) => createSkillFolderMock(...args),
+  updateSkillFolder: (...args: unknown[]) => updateSkillFolderMock(...args),
+  deleteSkillFolder: (...args: unknown[]) => deleteSkillFolderMock(...args),
+  createSkill: (...args: unknown[]) => createSkillMock(...args),
+  // Defined INSIDE the hoisted factory (a top-level class would not exist yet),
+  // with the real constructor signature so tests read like production code.
+  ApiError: class ApiError extends Error {
+    status?: number;
+    body?: unknown;
+    constructor(message: string, opts: { status?: number; body?: unknown } = {}) {
+      super(message);
+      this.status = opts.status;
+      this.body = opts.body;
+    }
+  },
+}));
+
+import { ApiError } from "../api";
+
+import SkillBankPanel from "./SkillBankPanel";
+import type { Skill, SkillBank, SkillDetail, SkillFolder } from "../types";
+
+const t = "2026-09-03T10:00:00Z";
+const folder = (id: string, name: string, parent_id: string | null = null): SkillFolder => ({
+  id,
+  name,
+  parent_id,
+  created_at: t,
+  updated_at: t,
+});
+const skill = (id: string, name: string, folder_id: string | null, description = "desc"): Skill => ({
+  id,
+  name,
+  description,
+  folder_id,
+  created_at: t,
+  updated_at: t,
+});
+
+const CONTENT = "---\nname: tdd\ndescription: Test-driven development.\nallowed-tools: Bash(npm:*)\n---\n\n# TDD\n\nRed, green, refactor.\n";
+
+function detailOf(s: Skill): SkillDetail {
+  return {
+    ...s,
+    content: CONTENT,
+    frontmatter: { name: "tdd", description: "Test-driven development.", "allowed-tools": "Bash(npm:*)" },
+    body: "# TDD\n\nRed, green, refactor.",
+    files: [{ path: "checklist.md", size: 1229 }],
+    path: `/home/user/.pdo/skills/${s.id}`,
+  };
+}
+
+const EMPTY: SkillBank = { skills: [], folders: [], root_path: "/home/user/.pdo/skills" };
+const POPULATED: SkillBank = {
+  root_path: "/home/user/.pdo/skills",
+  folders: [folder("f-m", "méthode"), folder("f-i", "ippon"), folder("f-j", "java", "f-i")],
+  skills: [
+    skill("s-tdd", "tdd", "f-m", "Test-driven development."),
+    skill("s-gr", "grilling", null, "Grill relentlessly."),
+    skill("s-cr", "code-review", null, "Review staged changes."),
+  ],
+};
+
+function setup(bank: SkillBank, loaded = true) {
+  const onChanged = vi.fn().mockResolvedValue(undefined);
+  const view = render(<SkillBankPanel bank={bank} loaded={loaded} home="/home/user" onChanged={onChanged} />);
+  return { onChanged, view };
+}
+
+describe("SkillBankPanel (#668)", () => {
+  beforeEach(() => {
+    for (const mock of [
+      fetchSkillMock,
+      updateSkillMock,
+      deleteSkillMock,
+      fetchSkillReferentsMock,
+      createSkillFolderMock,
+      updateSkillFolderMock,
+      deleteSkillFolderMock,
+      createSkillMock,
+    ]) {
+      mock.mockReset();
+    }
+    fetchSkillMock.mockImplementation(async (id: string) => {
+      const found = POPULATED.skills.find((s) => s.id === id) ?? skill(id, id, null);
+      return detailOf(found);
+    });
+  });
+
+  it("FP step 1: an empty bank shows the empty state with one primary action and the disk path", () => {
+    setup(EMPTY);
+    expect(screen.getByTestId("skill-bank-empty")).toHaveTextContent("No skills yet");
+    expect(screen.getByTestId("skill-paste-empty")).toBeInTheDocument();
+    expect(screen.getByTestId("skill-bank-footer")).toHaveTextContent("0 skills · 0 folders");
+    expect(screen.getByTestId("skill-bank-footer")).toHaveTextContent("~/.pdo/skills/<id>/");
+    // Vocabulary visible but muted: filter + folder button are there.
+    expect(screen.getByTestId("skill-filter")).toBeInTheDocument();
+    expect(screen.getByTestId("skill-new-folder")).toBeInTheDocument();
+  });
+
+  it("opens the paste popup from the empty state and from the toolbar", () => {
+    setup(EMPTY);
+    fireEvent.click(screen.getByTestId("skill-paste-empty"));
+    expect(screen.getByTestId("paste-skill-modal")).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText("Close paste popup"));
+    expect(screen.queryByTestId("paste-skill-modal")).toBeNull();
+    fireEvent.click(screen.getByTestId("skill-paste"));
+    expect(screen.getByTestId("paste-skill-modal")).toBeInTheDocument();
+  });
+
+  it("renders folders first with counts, root skills after, and the footer totals", () => {
+    setup(POPULATED);
+    const tree = screen.getByTestId("skill-tree");
+    const items = within(tree).getAllByRole("treeitem");
+    expect(items.map((item) => item.getAttribute("data-testid"))).toEqual([
+      "tree-folder-f-i",
+      "tree-folder-f-m",
+      "tree-skill-s-cr",
+      "tree-skill-s-gr",
+    ]);
+    expect(screen.getByTestId("tree-folder-f-m")).toHaveTextContent("1");
+    expect(screen.getByTestId("skill-bank-footer")).toHaveTextContent("3 skills · 3 folders");
+  });
+
+  it("expands a folder and shows the skill beneath it (FP step 4, tree side)", () => {
+    setup(POPULATED);
+    fireEvent.click(screen.getByLabelText("Expand méthode"));
+    expect(screen.getByTestId("tree-skill-s-tdd")).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText("Collapse méthode"));
+    expect(screen.queryByTestId("tree-skill-s-tdd")).toBeNull();
+  });
+
+  it("filters skills by name or description and keeps ancestor folders", () => {
+    setup(POPULATED);
+    fireEvent.change(screen.getByTestId("skill-filter"), { target: { value: "driven" } });
+    expect(screen.getByTestId("tree-folder-f-m")).toBeInTheDocument();
+    expect(screen.getByTestId("tree-skill-s-tdd")).toBeInTheDocument();
+    expect(screen.queryByTestId("tree-skill-s-gr")).toBeNull();
+    fireEvent.change(screen.getByTestId("skill-filter"), { target: { value: "zzz" } });
+    expect(screen.getByTestId("skill-tree")).toHaveTextContent("No skill matches");
+  });
+
+  it("selecting a skill shows the read-only detail: header, id, frontmatter table, body, files tab", async () => {
+    setup(POPULATED);
+    fireEvent.click(screen.getByTestId("tree-skill-s-gr"));
+    expect(screen.getByTestId("skill-detail-name")).toHaveTextContent("grilling");
+    expect(screen.getByTestId("skill-detail-description")).toHaveTextContent("Grill relentlessly.");
+    await waitFor(() => expect(fetchSkillMock).toHaveBeenCalledWith("s-gr"));
+    await waitFor(() => expect(screen.getByTestId("skill-frontmatter")).toBeInTheDocument());
+    const table = screen.getByTestId("skill-frontmatter");
+    expect(table).toHaveTextContent("allowed-tools");
+    expect(table).toHaveTextContent("Bash(npm:*)");
+    expect(table).toHaveTextContent("Read-only");
+    expect(screen.getByTestId("skill-body")).toHaveTextContent("Red, green, refactor.");
+    // No editor anywhere in the detail.
+    expect(within(screen.getByTestId("skill-detail")).queryByRole("textbox")).toBeNull();
+
+    fireEvent.click(screen.getByRole("tab", { name: /Files/ }));
+    const files = screen.getByTestId("skill-files");
+    expect(files).toHaveTextContent("SKILL.md");
+    expect(files).toHaveTextContent("checklist.md");
+    expect(files).toHaveTextContent("1.2 kB");
+    expect(within(files).getAllByText("read-only")).toHaveLength(2);
+  });
+
+  it("FP step 5: rename inline commits the label only and offers Undo", async () => {
+    const { onChanged } = setup(POPULATED);
+    updateSkillMock.mockResolvedValue({ ...POPULATED.skills[1], name: "grilling-hard" });
+    fireEvent.click(screen.getByTestId("tree-skill-s-gr"));
+    fireEvent.click(screen.getByTestId("skill-detail-rename"));
+    const input = screen.getByTestId("rename-input") as HTMLInputElement;
+    expect(input.value).toBe("grilling");
+    fireEvent.change(input, { target: { value: "grilling-hard" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    await waitFor(() => expect(updateSkillMock).toHaveBeenCalledWith("s-gr", { name: "grilling-hard" }));
+    await waitFor(() => expect(onChanged).toHaveBeenCalled());
+    expect(screen.getByTestId("skill-toast")).toHaveTextContent("Renamed grilling to grilling-hard");
+    fireEvent.click(screen.getByTestId("skill-toast-undo"));
+    await waitFor(() => expect(updateSkillMock).toHaveBeenLastCalledWith("s-gr", { name: "grilling" }));
+  });
+
+  it("a rename collision (409) stays in edit and reads under the row", async () => {
+    setup(POPULATED);
+    updateSkillMock.mockRejectedValue(new ApiError("taken", { status: 409, body: { code: "duplicate_name" } }));
+    fireEvent.click(screen.getByTestId("tree-skill-s-gr"));
+    fireEvent.keyDown(screen.getByTestId("skill-tree"), { key: "F2" });
+    const input = screen.getByTestId("rename-input");
+    fireEvent.change(input, { target: { value: "Code-Review" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    await waitFor(() => expect(screen.getByTestId("rename-error")).toHaveTextContent(/already taken/));
+    expect(screen.getByTestId("rename-input")).toBeInTheDocument();
+    fireEvent.keyDown(screen.getByTestId("rename-input"), { key: "Escape" });
+    expect(screen.queryByTestId("rename-input")).toBeNull();
+  });
+
+  it("FP step 4: dropping a skill on a folder PUTs the move and offers Undo", async () => {
+    const { onChanged } = setup(POPULATED);
+    updateSkillMock.mockResolvedValue({ ...POPULATED.skills[1], folder_id: "f-m" });
+    const dataTransfer = {
+      data: {} as Record<string, string>,
+      types: ["text/pdo-skill"],
+      effectAllowed: "",
+      dropEffect: "",
+      setData(type: string, value: string) {
+        this.data[type] = value;
+      },
+      getData(type: string) {
+        return this.data[type];
+      },
+    };
+    const row = screen.getByTestId("tree-skill-s-gr");
+    const handle = row.querySelector("[draggable='true']") as HTMLElement;
+    expect(handle).not.toBeNull();
+    fireEvent.dragStart(handle, { dataTransfer });
+    const target = screen.getByTestId("tree-folder-f-m");
+    fireEvent.dragOver(target, { dataTransfer });
+    expect(target).toHaveAttribute("data-drop-target", "true");
+    fireEvent.drop(target, { dataTransfer });
+    await waitFor(() => expect(updateSkillMock).toHaveBeenCalledWith("s-gr", { folder_id: "f-m" }));
+    await waitFor(() => expect(onChanged).toHaveBeenCalled());
+    expect(screen.getByTestId("skill-toast")).toHaveTextContent("Moved grilling to méthode");
+    fireEvent.click(screen.getByTestId("skill-toast-undo"));
+    await waitFor(() => expect(updateSkillMock).toHaveBeenLastCalledWith("s-gr", { folder_id: null }));
+  });
+
+  it("Move to… in the detail header is the keyboard fallback to the same move", async () => {
+    setup(POPULATED);
+    updateSkillMock.mockResolvedValue({ ...POPULATED.skills[1], folder_id: "f-j" });
+    fireEvent.click(screen.getByTestId("tree-skill-s-gr"));
+    fireEvent.click(screen.getByTestId("skill-detail-move"));
+    const picker = screen.getByTestId("move-picker");
+    fireEvent.click(within(picker).getByRole("menuitem", { name: /ippon \/ java/ }));
+    await waitFor(() => expect(updateSkillMock).toHaveBeenCalledWith("s-gr", { folder_id: "f-j" }));
+  });
+
+  it("FP step 6: Delete… lists the (empty) referents in place, then removes the skill", async () => {
+    const { onChanged } = setup(POPULATED);
+    fetchSkillReferentsMock.mockResolvedValue({
+      skill_id: "s-gr",
+      instance: false,
+      projects: [],
+      pipelines: [],
+      runs: [],
+    });
+    deleteSkillMock.mockResolvedValue(undefined);
+    fireEvent.click(screen.getByTestId("tree-skill-s-gr"));
+    fireEvent.click(screen.getByTestId("skill-detail-delete"));
+    await waitFor(() => expect(screen.getByTestId("skill-delete")).toBeInTheDocument());
+    expect(screen.getByTestId("skill-delete")).toHaveTextContent("Delete grilling?");
+    expect(screen.getByTestId("skill-referents")).toHaveTextContent("No live references.");
+    expect(screen.getByTestId("skill-delete")).toHaveTextContent("~/.pdo/skills/s-gr/");
+    // The tree stays: the operator keeps context.
+    expect(screen.getByTestId("skill-tree")).toBeInTheDocument();
+    expect(screen.getByTestId("skill-delete-confirm")).toHaveTextContent("Delete");
+    fireEvent.click(screen.getByTestId("skill-delete-confirm"));
+    await waitFor(() => expect(deleteSkillMock).toHaveBeenCalledWith("s-gr"));
+    await waitFor(() => expect(onChanged).toHaveBeenCalled());
+    expect(screen.queryByTestId("skill-delete")).toBeNull();
+  });
+
+  it("renders populated referents grouped by tier (the shape the endpoint is built for)", async () => {
+    setup(POPULATED);
+    fetchSkillReferentsMock.mockResolvedValue({
+      skill_id: "s-gr",
+      instance: true,
+      projects: [{ id: "p1", name: "acme-web-api" }],
+      pipelines: [{ id: "l1", name: "feature-with-review", node_id: "reviewer" }],
+      runs: [{ run_id: "run-e7a", name: null }],
+    });
+    fireEvent.click(screen.getByTestId("tree-skill-s-gr"));
+    fireEvent.keyDown(screen.getByTestId("skill-tree"), { key: "Delete" });
+    await waitFor(() => expect(screen.getByTestId("skill-delete")).toBeInTheDocument());
+    const box = screen.getByTestId("skill-referents");
+    expect(screen.getByTestId("skill-delete")).toHaveTextContent("4 live references");
+    expect(box).toHaveTextContent("INSTANCE");
+    expect(box).toHaveTextContent("PROJECT");
+    expect(box).toHaveTextContent("acme-web-api");
+    expect(box).toHaveTextContent("feature-with-review · node reviewer");
+    expect(box).toHaveTextContent("run-e7a (not started)");
+    expect(screen.getByTestId("skill-delete-confirm")).toHaveTextContent("Delete anyway");
+  });
+
+  it("creates a folder then enters rename; deleting a folder explains that its skills move up", async () => {
+    setup(POPULATED);
+    createSkillFolderMock.mockResolvedValue(folder("f-new", "New folder"));
+    fireEvent.click(screen.getByTestId("skill-new-folder"));
+    await waitFor(() => expect(createSkillFolderMock).toHaveBeenCalledWith({ name: "New folder", parent_id: null }));
+
+    // Folder kebab → Delete folder.
+    fireEvent.click(screen.getByTestId("tree-folder-f-m"));
+    fireEvent.click(screen.getByTestId("folder-detail-delete"));
+    expect(screen.getByTestId("folder-delete")).toHaveTextContent("Delete folder méthode?");
+    expect(screen.getByTestId("folder-delete")).toHaveTextContent(/Its 1 skill and sub-folders move to the root/);
+    expect(screen.getByTestId("folder-delete")).toHaveTextContent("No skill is deleted.");
+    deleteSkillFolderMock.mockResolvedValue(undefined);
+    fireEvent.click(screen.getByTestId("folder-delete-confirm"));
+    await waitFor(() => expect(deleteSkillFolderMock).toHaveBeenCalledWith("f-m"));
+  });
+
+  it("the kebab offers the same verbs as the detail header", () => {
+    setup(POPULATED);
+    fireEvent.click(screen.getByTestId("kebab-skill-s-gr"));
+    const menu = screen.getByTestId("tree-menu");
+    expect(within(menu).getAllByRole("menuitem").map((m) => m.textContent)).toEqual([
+      expect.stringContaining("Rename"),
+      expect.stringContaining("Move to…"),
+      expect.stringContaining("Copy id"),
+      expect.stringContaining("Delete…"),
+    ]);
+    fireEvent.click(screen.getByTestId("kebab-folder-f-i"));
+    const folderMenu = screen.getByTestId("tree-menu");
+    expect(within(folderMenu).getAllByRole("menuitem").map((m) => m.textContent)).toEqual([
+      expect.stringContaining("New subfolder"),
+      expect.stringContaining("Rename"),
+      expect.stringContaining("Delete folder"),
+    ]);
+  });
+
+  it("keyboard: ↓ selects rows, → expands, F2 renames", () => {
+    setup(POPULATED);
+    const tree = screen.getByTestId("skill-tree");
+    fireEvent.keyDown(tree, { key: "ArrowDown" });
+    expect(screen.getByTestId("tree-folder-f-i")).toHaveAttribute("data-selected", "true");
+    fireEvent.keyDown(tree, { key: "ArrowRight" });
+    expect(screen.getByTestId("tree-folder-f-j")).toBeInTheDocument();
+    fireEvent.keyDown(tree, { key: "ArrowDown" });
+    expect(screen.getByTestId("tree-folder-f-j")).toHaveAttribute("data-selected", "true");
+    fireEvent.keyDown(tree, { key: "F2" });
+    expect(screen.getByTestId("rename-input")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/SkillBankPanel.tsx
+++ b/frontend/src/components/SkillBankPanel.tsx
@@ -1,0 +1,1142 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  ClipboardPaste,
+  Copy,
+  FileText,
+  Folder,
+  FolderInput,
+  FolderPlus,
+  MoreVertical,
+  Pencil,
+  Search,
+  Trash2,
+} from "lucide-react";
+import Markdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import {
+  ApiError,
+  createSkillFolder,
+  deleteSkill,
+  deleteSkillFolder,
+  fetchSkill,
+  fetchSkillReferents,
+  updateSkill,
+  updateSkillFolder,
+} from "../api";
+import type { Skill, SkillBank, SkillDetail, SkillFolder, SkillReferents } from "../types";
+import { formatSize, timeAgo } from "../lib/skillMd";
+import {
+  descendantFolderIds,
+  folderCounts,
+  folderPathLabel,
+  sameRef,
+  shortId,
+  type TreeNodeRef,
+  type TreeRow,
+} from "../lib/skillTree";
+import SkillTree from "./SkillTree";
+import PasteSkillModal from "./PasteSkillModal";
+
+const REMARK_PLUGINS = [remarkGfm];
+const UNDO_MS = 6000;
+
+interface Props {
+  bank: SkillBank;
+  loaded: boolean;
+  /** Host `$HOME`, to shorten the disk path in the footer. `null` shows it as is. */
+  home: string | null;
+  /** Called after every successful write; the parent refetches and fires the bus. */
+  onChanged: () => Promise<void>;
+}
+
+type Pending =
+  | { kind: "delete-skill"; skill: Skill; referents: SkillReferents }
+  | { kind: "delete-folder"; folder: SkillFolder };
+
+interface Toast {
+  message: string;
+  undo?: () => Promise<void>;
+}
+
+function relativise(path: string, home: string | null): string {
+  if (home && path.startsWith(home + "/")) return "~" + path.slice(home.length);
+  return path;
+}
+
+/**
+ * The Banque de skills drill-down (#668): a 300 px tree on the left, a read-only
+ * detail on the right. Every gesture commits immediately (POST/PUT/DELETE) as
+ * the agent profiles do, so Back / Esc / close never lose anything; the only
+ * unsaved state is the paste popup's text, which asks before closing.
+ *
+ * Errors are shown in place — a red check in the popup, a collision under the
+ * row being renamed — never as a modal on top of the modal. Move and rename are
+ * undoable by toast (6 s); create and delete are not (delete goes through the
+ * referents confirmation, the pattern of agent profiles).
+ */
+export default function SkillBankPanel({ bank, loaded, home, onChanged }: Props) {
+  const { skills, folders } = bank;
+  const [selected, setSelected] = useState<TreeNodeRef | null>(null);
+  const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
+  const [filter, setFilter] = useState("");
+  const [pasteOpen, setPasteOpen] = useState(false);
+  const [detail, setDetail] = useState<SkillDetail | null>(null);
+  const [detailTab, setDetailTab] = useState<"skill" | "files">("skill");
+  const [renaming, setRenaming] = useState<TreeNodeRef | null>(null);
+  const [renameError, setRenameError] = useState<string | null>(null);
+  const [pending, setPending] = useState<Pending | null>(null);
+  const [menuFor, setMenuFor] = useState<TreeNodeRef | null>(null);
+  const [movePickerFor, setMovePickerFor] = useState<string | null>(null);
+  const [toast, setToast] = useState<Toast | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const toastTimer = useRef<number | null>(null);
+
+  const skillById = useMemo(() => new Map(skills.map((skill) => [skill.id, skill])), [skills]);
+  const folderById = useMemo(() => new Map(folders.map((folder) => [folder.id, folder])), [folders]);
+  const counts = useMemo(() => folderCounts(folders, skills), [folders, skills]);
+  const existingNames = useMemo(() => skills.map((skill) => skill.name), [skills]);
+
+  const selectedSkill = selected?.kind === "skill" ? skillById.get(selected.id) ?? null : null;
+  const selectedFolder = selected?.kind === "folder" ? folderById.get(selected.id) ?? null : null;
+  // A selection whose row vanished (deleted elsewhere, refetch) reads as nothing.
+  const selectedRef = selectedSkill || selectedFolder ? selected : null;
+
+  // Fetch the detail of the selected skill; key on id + updated_at so a rename
+  // refreshes the header without a manual refetch.
+  const selectedSkillId = selectedSkill?.id ?? null;
+  const selectedSkillVersion = selectedSkill?.updated_at ?? null;
+  // `detail` may lag the selection by one fetch; readers compare `detail.id`
+  // with the selected skill instead of clearing it here.
+  useEffect(() => {
+    if (!selectedSkillId) return;
+    let cancelled = false;
+    fetchSkill(selectedSkillId)
+      .then((result) => {
+        if (!cancelled) setDetail(result);
+      })
+      .catch((cause) => {
+        if (!cancelled) setError(cause instanceof Error ? cause.message : "Failed to load the skill");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedSkillId, selectedSkillVersion]);
+
+  // Close a kebab on outside click / Escape.
+  useEffect(() => {
+    if (!menuFor && !movePickerFor) return;
+    const close = () => {
+      setMenuFor(null);
+      setMovePickerFor(null);
+    };
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") close();
+    };
+    window.addEventListener("click", close);
+    window.addEventListener("keydown", onKey);
+    return () => {
+      window.removeEventListener("click", close);
+      window.removeEventListener("keydown", onKey);
+    };
+  }, [menuFor, movePickerFor]);
+
+  const showToast = useCallback((next: Toast) => {
+    if (toastTimer.current) window.clearTimeout(toastTimer.current);
+    setToast(next);
+    toastTimer.current = window.setTimeout(() => setToast(null), UNDO_MS);
+  }, []);
+  useEffect(
+    () => () => {
+      if (toastTimer.current) window.clearTimeout(toastTimer.current);
+    },
+    [],
+  );
+
+  const failWith = (cause: unknown, fallback: string) =>
+    setError(cause instanceof Error ? cause.message : fallback);
+
+  const expandTo = (folderId: string | null) => {
+    if (!folderId) return;
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      let cursor: string | null = folderId;
+      let hops = 0;
+      while (cursor && hops++ < 100) {
+        next.add(cursor);
+        cursor = folderById.get(cursor)?.parent_id ?? null;
+      }
+      return next;
+    });
+  };
+
+  // ---- gestures -----------------------------------------------------------
+
+  const moveSkill = async (skillId: string, folderId: string | null, withUndo = true) => {
+    const skill = skillById.get(skillId);
+    if (!skill) return;
+    if ((skill.folder_id ?? null) === folderId) return;
+    const from = skill.folder_id ?? null;
+    setError(null);
+    try {
+      await updateSkill(skillId, { folder_id: folderId });
+      await onChanged();
+      expandTo(folderId);
+      if (withUndo) {
+        showToast({
+          message: `Moved ${skill.name} to ${folderId ? folderById.get(folderId)?.name ?? "folder" : "the root"}`,
+          undo: async () => {
+            await updateSkill(skillId, { folder_id: from });
+            await onChanged();
+            expandTo(from);
+          },
+        });
+      }
+    } catch (cause) {
+      failWith(cause, "Failed to move the skill");
+    }
+  };
+
+  const moveFolder = async (folderId: string, parentId: string | null) => {
+    const folder = folderById.get(folderId);
+    if (!folder || (folder.parent_id ?? null) === parentId) return;
+    setError(null);
+    try {
+      await updateSkillFolder(folderId, { parent_id: parentId });
+      await onChanged();
+      expandTo(parentId);
+    } catch (cause) {
+      failWith(cause, "Failed to move the folder");
+    }
+  };
+
+  const commitRename = async (ref: TreeNodeRef, name: string) => {
+    setRenameError(null);
+    try {
+      if (ref.kind === "skill") {
+        const before = skillById.get(ref.id);
+        await updateSkill(ref.id, { name });
+        setRenaming(null);
+        await onChanged();
+        if (before) {
+          showToast({
+            message: `Renamed ${before.name} to ${name}`,
+            undo: async () => {
+              await updateSkill(ref.id, { name: before.name });
+              await onChanged();
+            },
+          });
+        }
+      } else {
+        const before = folderById.get(ref.id);
+        await updateSkillFolder(ref.id, { name });
+        setRenaming(null);
+        await onChanged();
+        if (before) {
+          showToast({
+            message: `Renamed folder ${before.name} to ${name}`,
+            undo: async () => {
+              await updateSkillFolder(ref.id, { name: before.name });
+              await onChanged();
+            },
+          });
+        }
+      }
+    } catch (cause) {
+      // Stay in edit: the collision (409) reads under the row.
+      setRenameError(
+        cause instanceof ApiError && cause.status === 409
+          ? `${name} is already taken (names are case-insensitive).`
+          : cause instanceof Error
+            ? cause.message
+            : "Rename failed",
+      );
+    }
+  };
+
+  const startRename = (ref: TreeNodeRef) => {
+    setMenuFor(null);
+    setRenameError(null);
+    setSelected(ref);
+    setRenaming(ref);
+  };
+
+  const newFolder = async (parentId: string | null) => {
+    setMenuFor(null);
+    setError(null);
+    try {
+      const folder = await createSkillFolder({ name: "New folder", parent_id: parentId });
+      await onChanged();
+      expandTo(parentId);
+      const ref: TreeNodeRef = { kind: "folder", id: folder.id };
+      setSelected(ref);
+      setRenaming(ref);
+    } catch (cause) {
+      failWith(cause, "Failed to create the folder");
+    }
+  };
+
+  const askDelete = async (ref: TreeNodeRef) => {
+    setMenuFor(null);
+    setError(null);
+    if (ref.kind === "skill") {
+      const skill = skillById.get(ref.id);
+      if (!skill) return;
+      try {
+        const referents = await fetchSkillReferents(skill.id);
+        setSelected(ref);
+        setPending({ kind: "delete-skill", skill, referents });
+      } catch (cause) {
+        failWith(cause, "Failed to load referents");
+      }
+    } else {
+      const folder = folderById.get(ref.id);
+      if (!folder) return;
+      setSelected(ref);
+      setPending({ kind: "delete-folder", folder });
+    }
+  };
+
+  const confirmDelete = async () => {
+    if (!pending) return;
+    setError(null);
+    try {
+      if (pending.kind === "delete-skill") {
+        await deleteSkill(pending.skill.id);
+      } else {
+        await deleteSkillFolder(pending.folder.id);
+      }
+      setPending(null);
+      setSelected(null);
+      await onChanged();
+    } catch (cause) {
+      failWith(cause, "Delete failed");
+    }
+  };
+
+  const copyId = async (id: string) => {
+    setMenuFor(null);
+    try {
+      await navigator.clipboard?.writeText(id);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch {
+      /* clipboard unavailable: nothing to do */
+    }
+  };
+
+  // ---- rendering ----------------------------------------------------------
+
+  const rootLabel = bank.root_path ? `${relativise(bank.root_path, home)}/<id>/` : "";
+
+  const renderActions = (row: TreeRow) => {
+    const ref = row.ref;
+    const isMenuOpen = sameRef(menuFor, ref);
+    return (
+      <>
+        <button
+          type="button"
+          aria-label={`Rename ${row.folder?.name ?? row.skill?.name ?? ""}`}
+          onClick={() => startRename(ref)}
+          className="grid h-5 w-5 place-items-center rounded text-fg-4 hover:bg-bg-4 hover:text-fg"
+        >
+          <Pencil size={11} />
+        </button>
+        <span className="relative">
+          <button
+            type="button"
+            aria-label={`More actions for ${row.folder?.name ?? row.skill?.name ?? ""}`}
+            aria-expanded={isMenuOpen}
+            data-testid={`kebab-${ref.kind}-${ref.id}`}
+            onClick={(event) => {
+              event.stopPropagation();
+              setMovePickerFor(null);
+              setMenuFor(isMenuOpen ? null : ref);
+            }}
+            className="grid h-5 w-5 place-items-center rounded text-fg-4 hover:bg-bg-4 hover:text-fg"
+          >
+            <MoreVertical size={11} />
+          </button>
+          {isMenuOpen && (
+            <div
+              role="menu"
+              data-testid="tree-menu"
+              className="absolute right-0 top-6 z-10 w-48 rounded-md border border-line bg-bg-4 p-1 shadow-xl"
+              onClick={(event) => event.stopPropagation()}
+            >
+              {ref.kind === "folder" ? (
+                <>
+                  <MenuItem icon={<FolderPlus size={12} />} label="New subfolder" onClick={() => void newFolder(ref.id)} />
+                  <MenuItem icon={<Pencil size={12} />} label="Rename" hint="F2" onClick={() => startRename(ref)} />
+                  <MenuSeparator />
+                  <MenuItem icon={<Trash2 size={12} />} label="Delete folder" hint="⌫" danger onClick={() => void askDelete(ref)} />
+                </>
+              ) : (
+                <>
+                  <MenuItem icon={<Pencil size={12} />} label="Rename" hint="F2" onClick={() => startRename(ref)} />
+                  <MenuItem
+                    icon={<FolderInput size={12} />}
+                    label="Move to…"
+                    onClick={() => {
+                      setMenuFor(null);
+                      setSelected(ref);
+                      setMovePickerFor(ref.id);
+                    }}
+                  />
+                  <MenuItem icon={<Copy size={12} />} label="Copy id" onClick={() => void copyId(ref.id)} />
+                  <MenuSeparator />
+                  <MenuItem icon={<Trash2 size={12} />} label="Delete…" hint="⌫" danger onClick={() => void askDelete(ref)} />
+                </>
+              )}
+            </div>
+          )}
+        </span>
+      </>
+    );
+  };
+
+  const emptyBank = loaded && skills.length === 0 && folders.length === 0;
+
+  return (
+    <div className="flex min-h-0 flex-1" data-testid="skill-bank-panel">
+      {/* Left: tree */}
+      <div className="flex w-[300px] shrink-0 flex-col border-r border-line">
+        <div className="flex items-center gap-2 px-3 py-2.5">
+          <label className="flex min-w-0 flex-1 items-center gap-1.5 rounded-md border border-line-strong bg-bg-3 px-2 py-1.5">
+            <Search size={12} className="shrink-0 text-fg-4" />
+            <input
+              value={filter}
+              onChange={(event) => setFilter(event.target.value)}
+              placeholder="Filter skills…"
+              aria-label="Filter skills"
+              data-testid="skill-filter"
+              className="min-w-0 flex-1 bg-transparent text-fg outline-none placeholder:text-fg-4"
+              style={{ fontSize: "11.5px" }}
+            />
+          </label>
+          <button
+            type="button"
+            onClick={() => void newFolder(selectedFolder?.id ?? (selectedSkill?.folder_id ?? null))}
+            aria-label="New folder"
+            title="New folder"
+            data-testid="skill-new-folder"
+            className="flex shrink-0 items-center gap-1 rounded-md border border-line-strong bg-bg-3 px-2 py-1.5 text-fg-2 hover:border-acc"
+          >
+            <Folder size={12} />
+            <span style={{ fontSize: "12px", lineHeight: 1 }}>+</span>
+          </button>
+          <button
+            type="button"
+            onClick={() => setPasteOpen(true)}
+            data-testid="skill-paste"
+            className="flex shrink-0 items-center gap-1.5 rounded-md bg-acc px-2.5 py-1.5 font-medium text-bg-1 hover:opacity-90"
+            style={{ fontSize: "11.5px" }}
+          >
+            <ClipboardPaste size={12} />
+            Paste skill
+          </button>
+        </div>
+
+        <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
+          <SkillTree
+            folders={folders}
+            skills={skills}
+            selected={selectedRef}
+            onSelect={(ref) => {
+              setSelected(ref);
+              setPending(null);
+              setMenuFor(null);
+            }}
+            expanded={expanded}
+            onToggle={(id) =>
+              setExpanded((prev) => {
+                const next = new Set(prev);
+                if (next.has(id)) next.delete(id);
+                else next.add(id);
+                return next;
+              })
+            }
+            filter={filter}
+            renaming={renaming}
+            renameError={renameError}
+            onRenameCommit={commitRename}
+            onRenameCancel={() => {
+              setRenaming(null);
+              setRenameError(null);
+            }}
+            onDropSkill={(skillId, folderId) => void moveSkill(skillId, folderId)}
+            renderActions={renderActions}
+            onRequestRename={startRename}
+            onRequestDelete={(ref) => void askDelete(ref)}
+            emptyState={
+              !loaded ? (
+                <div className="px-4 py-6 text-fg-4" style={{ fontSize: "11px" }}>
+                  Loading…
+                </div>
+              ) : filter.trim() ? (
+                <div className="px-4 py-6 text-fg-4" style={{ fontSize: "11px" }}>
+                  No skill matches “{filter.trim()}”.
+                </div>
+              ) : null
+            }
+          />
+        </div>
+
+        <div
+          className="flex items-center justify-between gap-2 border-t border-line px-3 py-2 text-fg-4"
+          style={{ fontSize: "10.5px" }}
+          data-testid="skill-bank-footer"
+        >
+          <span className="shrink-0 whitespace-nowrap">
+            {skills.length} skill{skills.length === 1 ? "" : "s"} · {folders.length} folder
+            {folders.length === 1 ? "" : "s"}
+          </span>
+          {rootLabel && (
+            <span className="truncate font-mono" title={bank.root_path}>
+              {rootLabel}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Right: detail / confirmation / empty state */}
+      <div className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-y-auto">
+        {error && (
+          <div
+            role="alert"
+            className="m-4 mb-0 rounded-md border border-st-failed/50 bg-st-failed-bg px-3 py-2 text-fg-2"
+            style={{ fontSize: "11px" }}
+            data-testid="skill-bank-error"
+          >
+            {error}
+          </div>
+        )}
+
+        {pending?.kind === "delete-skill" ? (
+          <DeleteSkillConfirm
+            skill={pending.skill}
+            referents={pending.referents}
+            path={relativise(`${bank.root_path}/${pending.skill.id}`, home)}
+            onCancel={() => setPending(null)}
+            onConfirm={() => void confirmDelete()}
+          />
+        ) : pending?.kind === "delete-folder" ? (
+          <DeleteFolderConfirm
+            folder={pending.folder}
+            count={counts.get(pending.folder.id) ?? 0}
+            parentName={pending.folder.parent_id ? folderById.get(pending.folder.parent_id)?.name ?? null : null}
+            onCancel={() => setPending(null)}
+            onConfirm={() => void confirmDelete()}
+          />
+        ) : selectedSkill ? (
+          <SkillDetailView
+            skill={selectedSkill}
+            detail={detail}
+            folders={folders}
+            tab={detailTab}
+            onTab={setDetailTab}
+            copied={copied}
+            onCopyId={() => void copyId(selectedSkill.id)}
+            onRename={() => startRename({ kind: "skill", id: selectedSkill.id })}
+            onMove={() => setMovePickerFor(selectedSkill.id)}
+            onDelete={() => void askDelete({ kind: "skill", id: selectedSkill.id })}
+            movePickerOpen={movePickerFor === selectedSkill.id}
+            onMoveTo={(folderId) => {
+              setMovePickerFor(null);
+              void moveSkill(selectedSkill.id, folderId);
+            }}
+          />
+        ) : selectedFolder ? (
+          <FolderDetailView
+            folder={selectedFolder}
+            folders={folders}
+            count={counts.get(selectedFolder.id) ?? 0}
+            onNewSubfolder={() => void newFolder(selectedFolder.id)}
+            onRename={() => startRename({ kind: "folder", id: selectedFolder.id })}
+            onDelete={() => void askDelete({ kind: "folder", id: selectedFolder.id })}
+            onMoveTo={(parentId) => void moveFolder(selectedFolder.id, parentId)}
+          />
+        ) : emptyBank ? (
+          <EmptyBank onPaste={() => setPasteOpen(true)} />
+        ) : (
+          <div className="flex flex-1 items-center justify-center p-8 text-center text-fg-4" style={{ fontSize: "11.5px" }}>
+            Select a skill to read it, or a folder to manage it.
+          </div>
+        )}
+
+        {toast && (
+          <div
+            role="status"
+            data-testid="skill-toast"
+            className="absolute bottom-3 left-1/2 flex -translate-x-1/2 items-center gap-3 rounded-md border border-line bg-bg-3 px-3 py-2 text-fg-2 shadow-xl"
+            style={{ fontSize: "11.5px" }}
+          >
+            <span>{toast.message}</span>
+            {toast.undo && (
+              <button
+                type="button"
+                data-testid="skill-toast-undo"
+                onClick={() => {
+                  const undo = toast.undo;
+                  setToast(null);
+                  if (toastTimer.current) window.clearTimeout(toastTimer.current);
+                  void undo?.().catch((cause) => failWith(cause, "Undo failed"));
+                }}
+                className="font-medium text-acc hover:underline"
+              >
+                Undo
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+
+      {pasteOpen && (
+        <PasteSkillModal
+          folders={folders}
+          existingNames={existingNames}
+          initialFolderId={selectedFolder?.id ?? selectedSkill?.folder_id ?? null}
+          onClose={() => setPasteOpen(false)}
+          onCreated={async (skill) => {
+            await onChanged();
+            expandTo(skill.folder_id ?? null);
+            setSelected({ kind: "skill", id: skill.id });
+            setDetailTab("skill");
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+
+function MenuItem({
+  icon,
+  label,
+  hint,
+  danger,
+  onClick,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  hint?: string;
+  danger?: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      role="menuitem"
+      onClick={onClick}
+      className={`flex w-full items-center gap-2 rounded px-2 py-1.5 text-left hover:bg-bg-5 ${
+        danger ? "text-st-failed" : "text-fg-2"
+      }`}
+      style={{ fontSize: "11.5px" }}
+    >
+      <span className="shrink-0">{icon}</span>
+      <span className="flex-1">{label}</span>
+      {hint && (
+        <span className="font-mono text-fg-4" style={{ fontSize: "10px" }}>
+          {hint}
+        </span>
+      )}
+    </button>
+  );
+}
+
+function MenuSeparator() {
+  return <div className="my-1 border-t border-line" />;
+}
+
+function EmptyBank({ onPaste }: { onPaste: () => void }) {
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center gap-3 p-8 text-center" data-testid="skill-bank-empty">
+      <div className="grid h-14 w-14 place-items-center rounded-xl border border-dashed border-line-strong text-fg-4">
+        <FileText size={20} />
+      </div>
+      <h3 className="font-semibold text-fg" style={{ fontSize: "14px" }}>
+        No skills yet
+      </h3>
+      <p className="max-w-[380px] text-fg-3" style={{ fontSize: "12px" }}>
+        Paste the text of a <span className="font-mono">SKILL.md</span> to add one. Skills are
+        delivered to every worktree PDO creates, never committed.
+      </p>
+      <button
+        type="button"
+        onClick={onPaste}
+        data-testid="skill-paste-empty"
+        className="mt-1 flex items-center gap-1.5 rounded-md bg-acc px-3 py-2 font-medium text-bg-1 hover:opacity-90"
+        style={{ fontSize: "12px" }}
+      >
+        <ClipboardPaste size={13} />
+        Paste skill
+      </button>
+      <p className="text-fg-4" style={{ fontSize: "11px" }}>
+        Import from a repo or a local folder arrives in a later ticket.
+      </p>
+    </div>
+  );
+}
+
+function ActionButton({
+  icon,
+  label,
+  onClick,
+  danger,
+  testid,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  onClick: () => void;
+  danger?: boolean;
+  testid?: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      data-testid={testid}
+      className={`flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 transition-colors ${
+        danger
+          ? "border-st-failed/40 text-st-failed hover:bg-st-failed-bg"
+          : "border-line-strong bg-bg-3 text-fg-2 hover:border-acc"
+      }`}
+      style={{ fontSize: "11.5px" }}
+    >
+      {icon}
+      {label}
+    </button>
+  );
+}
+
+function FolderPicker({
+  folders,
+  exclude,
+  current,
+  onPick,
+  onClose,
+}: {
+  folders: SkillFolder[];
+  /** Folder ids not offered (a folder cannot move under itself). */
+  exclude?: Set<string>;
+  current: string | null;
+  onPick: (folderId: string | null) => void;
+  onClose: () => void;
+}) {
+  const options = folders.filter((folder) => !exclude?.has(folder.id));
+  return (
+    <div
+      role="menu"
+      data-testid="move-picker"
+      className="absolute left-0 top-9 z-10 w-64 rounded-md border border-line bg-bg-4 p-1 shadow-xl"
+      onClick={(event) => event.stopPropagation()}
+    >
+      <div className="px-2 py-1 text-fg-4 uppercase tracking-wide" style={{ fontSize: "9.5px" }}>
+        Move to
+      </div>
+      <button
+        type="button"
+        role="menuitem"
+        onClick={() => onPick(null)}
+        disabled={current === null}
+        className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-fg-2 hover:bg-bg-5 disabled:opacity-40"
+        style={{ fontSize: "11.5px" }}
+      >
+        <Folder size={12} /> Root of the bank
+      </button>
+      {options.map((folder) => (
+        <button
+          key={folder.id}
+          type="button"
+          role="menuitem"
+          onClick={() => onPick(folder.id)}
+          disabled={current === folder.id}
+          className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-fg-2 hover:bg-bg-5 disabled:opacity-40"
+          style={{ fontSize: "11.5px" }}
+        >
+          <Folder size={12} className="shrink-0" />
+          <span className="truncate">{folderPathLabel(folder.id, folders)}</span>
+        </button>
+      ))}
+      <MenuSeparator />
+      <button
+        type="button"
+        onClick={onClose}
+        className="w-full rounded px-2 py-1 text-left text-fg-4 hover:bg-bg-5"
+        style={{ fontSize: "11px" }}
+      >
+        Cancel
+      </button>
+    </div>
+  );
+}
+
+function SkillDetailView({
+  skill,
+  detail,
+  folders,
+  tab,
+  onTab,
+  copied,
+  onCopyId,
+  onRename,
+  onMove,
+  onDelete,
+  movePickerOpen,
+  onMoveTo,
+}: {
+  skill: Skill;
+  detail: SkillDetail | null;
+  folders: SkillFolder[];
+  tab: "skill" | "files";
+  onTab: (tab: "skill" | "files") => void;
+  copied: boolean;
+  onCopyId: () => void;
+  onRename: () => void;
+  onMove: () => void;
+  onDelete: () => void;
+  movePickerOpen: boolean;
+  onMoveTo: (folderId: string | null) => void;
+}) {
+  const current = detail && detail.id === skill.id ? detail : null;
+  const fileCount = current?.files.length ?? 0;
+  const frontmatter = current?.frontmatter ?? null;
+  const frontmatterKeys = frontmatter
+    ? [
+        ...(current?.frontmatter_keys ?? []).filter((key) => key in frontmatter),
+        ...Object.keys(frontmatter).filter((key) => !(current?.frontmatter_keys ?? []).includes(key)),
+      ]
+    : [];
+  return (
+    <div className="flex min-h-0 flex-1 flex-col p-5" data-testid="skill-detail">
+      <div className="flex items-baseline gap-2">
+        <h3 className="truncate font-semibold text-fg" style={{ fontSize: "17px" }} data-testid="skill-detail-name">
+          {skill.name}
+        </h3>
+        <span className="flex items-center gap-1 font-mono text-fg-4" style={{ fontSize: "10.5px" }}>
+          id {shortId(skill.id)}
+          <button
+            type="button"
+            aria-label="Copy id"
+            title={skill.id}
+            onClick={onCopyId}
+            className="grid h-4 w-4 place-items-center rounded text-fg-4 hover:text-fg"
+          >
+            <Copy size={10} />
+          </button>
+          {copied && <span className="text-acc">copied</span>}
+        </span>
+      </div>
+      <p className="mt-1.5 text-fg-2" style={{ fontSize: "13px" }} data-testid="skill-detail-description">
+        {skill.description}
+      </p>
+      <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-fg-4" style={{ fontSize: "10.5px" }}>
+        <span>
+          {fileCount} file{fileCount === 1 ? "" : "s"}
+        </span>
+        <span>updated {timeAgo(skill.updated_at)}</span>
+        <span>created by {skill.source ? "import" : "paste"}</span>
+        <span>referenced by 0 tiers</span>
+      </div>
+
+      <div className="mt-3 flex items-center gap-2">
+        <ActionButton icon={<Pencil size={11} />} label="Rename" onClick={onRename} testid="skill-detail-rename" />
+        <span className="relative">
+          <ActionButton icon={<FolderInput size={11} />} label="Move to…" onClick={onMove} testid="skill-detail-move" />
+          {movePickerOpen && (
+            <FolderPicker
+              folders={folders}
+              current={skill.folder_id ?? null}
+              onPick={onMoveTo}
+              onClose={() => onMoveTo(skill.folder_id ?? null)}
+            />
+          )}
+        </span>
+        <span className="flex-1" />
+        <ActionButton icon={<Trash2 size={11} />} label="Delete…" onClick={onDelete} danger testid="skill-detail-delete" />
+      </div>
+
+      <div className="mt-4 flex gap-4 border-b border-line" role="tablist">
+        <TabButton active={tab === "skill"} onClick={() => onTab("skill")} label="SKILL.md" />
+        <TabButton
+          active={tab === "files"}
+          onClick={() => onTab("files")}
+          label={
+            <>
+              Files <span className="text-fg-4">· {fileCount}</span>
+            </>
+          }
+        />
+      </div>
+
+      {tab === "skill" ? (
+        <div className="mt-3 flex flex-col gap-4">
+          {frontmatter && frontmatterKeys.length > 0 && (
+            <div className="overflow-hidden rounded-md border border-line" data-testid="skill-frontmatter">
+              <div className="flex items-center justify-between bg-bg-3 px-3 py-1.5 text-fg-4 uppercase tracking-wide" style={{ fontSize: "9.5px" }}>
+                <span>Frontmatter</span>
+                <span>Read-only</span>
+              </div>
+              <table className="w-full" style={{ fontSize: "11.5px" }}>
+                <tbody>
+                  {frontmatterKeys.map((key) => {
+                    const value = frontmatter[key];
+                    return (
+                    <tr key={key} className="border-t border-line">
+                      <td className="w-[160px] px-3 py-1.5 align-top font-mono text-fg-3">{key}</td>
+                      <td className="px-3 py-1.5 font-mono text-fg">
+                        {typeof value === "string" ? value : JSON.stringify(value)}
+                      </td>
+                    </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+          {current === null ? (
+            <div className="text-fg-4" style={{ fontSize: "11px" }}>
+              Loading…
+            </div>
+          ) : current.body === null ? (
+            <div className="rounded-md border border-st-blocked/40 bg-st-blocked-bg px-3 py-2 text-fg-2" style={{ fontSize: "11px" }}>
+              The <span className="font-mono">SKILL.md</span> of this skill is missing on disk (
+              <span className="font-mono">{current.path}</span>). Delete the entry and paste it again.
+            </div>
+          ) : (
+            <div className="artifact-markdown prose-sm text-fg-2 [&_ul]:list-disc [&_ol]:list-decimal [&_ul]:pl-5 [&_ol]:pl-5" style={{ fontSize: "12.5px" }} data-testid="skill-body">
+              <Markdown remarkPlugins={REMARK_PLUGINS}>{current.body}</Markdown>
+            </div>
+          )}
+        </div>
+      ) : (
+        <div className="mt-3 flex flex-col gap-1" data-testid="skill-files">
+          <FileRow name="SKILL.md" size={current?.content ? new TextEncoder().encode(current.content).length : null} />
+          {current?.files.map((file) => <FileRow key={file.path} name={file.path} size={file.size} />)}
+          {current && current.files.length === 0 && (
+            <p className="mt-2 text-fg-4" style={{ fontSize: "11px" }}>
+              No reference files. Attaching files arrives in a later ticket.
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function FileRow({ name, size }: { name: string; size: number | null }) {
+  return (
+    <div className="flex items-center gap-2 rounded-md border border-line bg-bg-3 px-3 py-2" style={{ fontSize: "11.5px" }}>
+      <FileText size={12} className="shrink-0 text-fg-3" />
+      <span className="font-mono text-fg">{name}</span>
+      <span className="rounded border border-line px-1.5 text-fg-4" style={{ fontSize: "9.5px" }}>
+        read-only
+      </span>
+      <span className="flex-1" />
+      {size !== null && (
+        <span className="font-mono text-fg-4" style={{ fontSize: "10.5px" }}>
+          {formatSize(size)}
+        </span>
+      )}
+    </div>
+  );
+}
+
+function TabButton({ active, onClick, label }: { active: boolean; onClick: () => void; label: React.ReactNode }) {
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={active}
+      onClick={onClick}
+      className={`-mb-px border-b-2 px-1 pb-2 ${active ? "border-acc text-fg" : "border-transparent text-fg-3 hover:text-fg"}`}
+      style={{ fontSize: "12px" }}
+    >
+      {label}
+    </button>
+  );
+}
+
+function FolderDetailView({
+  folder,
+  folders,
+  count,
+  onNewSubfolder,
+  onRename,
+  onDelete,
+  onMoveTo,
+}: {
+  folder: SkillFolder;
+  folders: SkillFolder[];
+  count: number;
+  onNewSubfolder: () => void;
+  onRename: () => void;
+  onDelete: () => void;
+  onMoveTo: (parentId: string | null) => void;
+}) {
+  const [picker, setPicker] = useState(false);
+  const exclude = useMemo(() => descendantFolderIds(folder.id, folders), [folder.id, folders]);
+  return (
+    <div className="flex min-h-0 flex-1 flex-col p-5" data-testid="folder-detail">
+      <div className="flex items-center gap-2">
+        <Folder size={16} className="text-st-await" />
+        <h3 className="truncate font-semibold text-fg" style={{ fontSize: "17px" }}>
+          {folderPathLabel(folder.id, folders)}
+        </h3>
+      </div>
+      <p className="mt-1.5 text-fg-3" style={{ fontSize: "12px" }}>
+        {count} skill{count === 1 ? "" : "s"} in this folder and below. Checking a folder in a
+        selector will check its skills at that instant; nothing references a folder.
+      </p>
+      <div className="mt-3 flex items-center gap-2">
+        <ActionButton icon={<FolderPlus size={11} />} label="New subfolder" onClick={onNewSubfolder} testid="folder-detail-new" />
+        <ActionButton icon={<Pencil size={11} />} label="Rename" onClick={onRename} testid="folder-detail-rename" />
+        <span className="relative">
+          <ActionButton icon={<FolderInput size={11} />} label="Move to…" onClick={() => setPicker((p) => !p)} />
+          {picker && (
+            <FolderPicker
+              folders={folders}
+              exclude={exclude}
+              current={folder.parent_id ?? null}
+              onPick={(parentId) => {
+                setPicker(false);
+                onMoveTo(parentId);
+              }}
+              onClose={() => setPicker(false)}
+            />
+          )}
+        </span>
+        <span className="flex-1" />
+        <ActionButton icon={<Trash2 size={11} />} label="Delete folder" onClick={onDelete} danger testid="folder-detail-delete" />
+      </div>
+    </div>
+  );
+}
+
+function DeleteSkillConfirm({
+  skill,
+  referents,
+  path,
+  onCancel,
+  onConfirm,
+}: {
+  skill: Skill;
+  referents: SkillReferents;
+  path: string;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  const count =
+    Number(referents.instance) + referents.projects.length + referents.pipelines.length + referents.runs.length;
+  return (
+    <div className="flex min-h-0 flex-1 flex-col p-5" data-testid="skill-delete">
+      <h3 className="font-semibold text-fg" style={{ fontSize: "17px" }}>
+        Delete {skill.name}?
+      </h3>
+      <p className="mt-2 text-fg-3" style={{ fontSize: "12px" }}>
+        {count === 0 ? (
+          "No live reference. Nothing else will change."
+        ) : (
+          <>
+            These <strong className="text-fg">{count} live reference{count === 1 ? "" : "s"}</strong> will keep the id
+            and show a warning; their runs still start.
+          </>
+        )}
+      </p>
+      <div
+        className="mt-3 rounded-md border border-line bg-bg-3 px-3 py-2.5 font-mono text-fg-3"
+        style={{ fontSize: "10.5px" }}
+        data-testid="skill-referents"
+      >
+        {count === 0 && <div>No live references.</div>}
+        {referents.instance && <ReferentLine tier="INSTANCE" label="settings" />}
+        {referents.projects.map((item) => <ReferentLine key={`p-${item.id}`} tier="PROJECT" label={item.name} />)}
+        {referents.pipelines.map((item, i) => (
+          <ReferentLine key={`l-${item.id}-${item.node_id ?? i}`} tier="PIPELINE" label={`${item.name}${item.node_id ? ` · node ${item.node_id}` : ""}`} />
+        ))}
+        {referents.runs.map((item) => (
+          <ReferentLine key={`r-${item.run_id}`} tier="RUN" label={`${item.name ?? item.run_id} (not started)`} />
+        ))}
+      </div>
+      <p className="mt-3 rounded-md border border-st-blocked/40 bg-st-blocked-bg px-3 py-2 text-fg-2" style={{ fontSize: "11px" }}>
+        Runs already started are untouched: their skill content was frozen at spawn. The folder{" "}
+        <span className="font-mono">{path}/</span> is removed.
+      </p>
+      <div className="mt-4 flex justify-end gap-2">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="rounded-md border border-line-strong bg-bg-3 px-3 py-1.5 text-fg-2 hover:bg-bg-4"
+          style={{ fontSize: "11.5px" }}
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          onClick={onConfirm}
+          data-testid="skill-delete-confirm"
+          className="rounded-md bg-st-failed px-3 py-1.5 font-medium text-white hover:opacity-90"
+          style={{ fontSize: "11.5px" }}
+        >
+          {count === 0 ? "Delete" : "Delete anyway"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function ReferentLine({ tier, label }: { tier: string; label: string }) {
+  return (
+    <div className="flex gap-4">
+      <span className="w-[72px] shrink-0 text-fg-4">{tier}</span>
+      <span className="text-fg-2">{label}</span>
+    </div>
+  );
+}
+
+function DeleteFolderConfirm({
+  folder,
+  count,
+  parentName,
+  onCancel,
+  onConfirm,
+}: {
+  folder: SkillFolder;
+  count: number;
+  parentName: string | null;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  return (
+    <div className="flex min-h-0 flex-1 flex-col p-5" data-testid="folder-delete">
+      <h3 className="font-semibold text-fg" style={{ fontSize: "17px" }}>
+        Delete folder {folder.name}?
+      </h3>
+      <p className="mt-2 text-fg-3" style={{ fontSize: "12px" }}>
+        {count === 0
+          ? "The folder is empty."
+          : `Its ${count} skill${count === 1 ? "" : "s"} and sub-folders move to ${parentName ? `“${parentName}”` : "the root of the bank"}. No skill is deleted.`}
+      </p>
+      <div className="mt-4 flex justify-end gap-2">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="rounded-md border border-line-strong bg-bg-3 px-3 py-1.5 text-fg-2 hover:bg-bg-4"
+          style={{ fontSize: "11.5px" }}
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          onClick={onConfirm}
+          data-testid="folder-delete-confirm"
+          className="rounded-md bg-st-failed px-3 py-1.5 font-medium text-white hover:opacity-90"
+          style={{ fontSize: "11.5px" }}
+        >
+          Delete folder
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/SkillTree.tsx
+++ b/frontend/src/components/SkillTree.tsx
@@ -1,0 +1,403 @@
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import { ChevronDown, ChevronRight, FileText, Folder, FolderOpen } from "lucide-react";
+import type { Skill, SkillFolder } from "../types";
+import { buildRows, sameRef, type TreeNodeRef, type TreeRow } from "../lib/skillTree";
+
+export interface SkillTreeProps {
+  folders: SkillFolder[];
+  skills: Skill[];
+  selected: TreeNodeRef | null;
+  onSelect: (ref: TreeNodeRef) => void;
+  expanded: ReadonlySet<string>;
+  onToggle: (folderId: string) => void;
+  filter?: string;
+  /** Row currently in inline rename, if any. */
+  renaming?: TreeNodeRef | null;
+  renameError?: string | null;
+  onRenameCommit?: (ref: TreeNodeRef, name: string) => void | Promise<void>;
+  onRenameCancel?: () => void;
+  /** Called when a skill is dropped on a folder (`null` = the root area). */
+  onDropSkill?: (skillId: string, folderId: string | null) => void;
+  /** Hover / focus actions rendered at the right of a row (pencil, kebab…). */
+  renderActions?: (row: TreeRow) => ReactNode;
+  /** Keyboard verbs on the selected row. */
+  onRequestRename?: (ref: TreeNodeRef) => void;
+  onRequestDelete?: (ref: TreeNodeRef) => void;
+  onOpen?: (ref: TreeNodeRef) => void;
+  /** Rendered when `rows` is empty (empty bank or no filter match). */
+  emptyState?: ReactNode;
+  /** Optional row decoration (e.g. checkboxes for the future selector). */
+  renderLeading?: (row: TreeRow) => ReactNode;
+  draggable?: boolean;
+  className?: string;
+}
+
+/**
+ * The bank's tree (#668): folders first, then skills, at every level; counts on
+ * folders; inline rename; native HTML5 drag of a skill onto a folder (or onto
+ * the empty area below the rows, which is the root). Keyboard: ↑↓ move, →← fold
+ * a folder, F2 rename, Delete asks for deletion, Enter opens.
+ *
+ * Deliberately generic — the future tier selector renders the same rows with a
+ * `renderLeading` checkbox instead of drag (design note in #668).
+ */
+export default function SkillTree({
+  folders,
+  skills,
+  selected,
+  onSelect,
+  expanded,
+  onToggle,
+  filter = "",
+  renaming = null,
+  renameError = null,
+  onRenameCommit,
+  onRenameCancel,
+  onDropSkill,
+  renderActions,
+  onRequestRename,
+  onRequestDelete,
+  onOpen,
+  emptyState,
+  renderLeading,
+  draggable = true,
+  className = "",
+}: SkillTreeProps) {
+  const rows = buildRows(folders, skills, expanded, filter);
+  const [dropTarget, setDropTarget] = useState<string | "root" | null>(null);
+  const [dragging, setDragging] = useState<string | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const onKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (renaming) return; // the input owns the keys
+    if ((event.target as HTMLElement).tagName === "INPUT") return;
+    const index = rows.findIndex((row) => sameRef(row.ref, selected));
+    const select = (i: number) => {
+      const row = rows[Math.max(0, Math.min(rows.length - 1, i))];
+      if (row) onSelect(row.ref);
+    };
+    switch (event.key) {
+      case "ArrowDown":
+        event.preventDefault();
+        select(index < 0 ? 0 : index + 1);
+        break;
+      case "ArrowUp":
+        event.preventDefault();
+        select(index < 0 ? 0 : index - 1);
+        break;
+      case "ArrowRight": {
+        const row = rows[index];
+        if (row?.ref.kind === "folder" && !row.expanded) {
+          event.preventDefault();
+          onToggle(row.ref.id);
+        }
+        break;
+      }
+      case "ArrowLeft": {
+        const row = rows[index];
+        if (row?.ref.kind === "folder" && row.expanded) {
+          event.preventDefault();
+          onToggle(row.ref.id);
+        } else if (row) {
+          // Jump to the parent folder.
+          const parentId = row.ref.kind === "skill" ? row.skill?.folder_id : row.folder?.parent_id;
+          if (parentId) {
+            event.preventDefault();
+            onSelect({ kind: "folder", id: parentId });
+          }
+        }
+        break;
+      }
+      case "F2":
+        if (selected && onRequestRename) {
+          event.preventDefault();
+          onRequestRename(selected);
+        }
+        break;
+      case "Delete":
+        if (selected && onRequestDelete) {
+          event.preventDefault();
+          onRequestDelete(selected);
+        }
+        break;
+      case "Enter":
+        if (selected && onOpen) {
+          event.preventDefault();
+          onOpen(selected);
+        }
+        break;
+      default:
+        break;
+    }
+  };
+
+  const dropOnFolder = (event: React.DragEvent, folderId: string | null) => {
+    event.preventDefault();
+    event.stopPropagation();
+    const skillId = event.dataTransfer.getData("text/pdo-skill") || dragging;
+    setDropTarget(null);
+    setDragging(null);
+    if (skillId && onDropSkill) onDropSkill(skillId, folderId);
+  };
+
+  const allowDrop = (event: React.DragEvent, target: string | "root") => {
+    if (!dragging && !event.dataTransfer.types.includes("text/pdo-skill")) return;
+    event.preventDefault();
+    event.stopPropagation();
+    event.dataTransfer.dropEffect = "move";
+    if (dropTarget !== target) setDropTarget(target);
+  };
+
+  return (
+    <div
+      ref={containerRef}
+      role="tree"
+      tabIndex={0}
+      aria-label="Skills"
+      data-testid="skill-tree"
+      onKeyDown={onKeyDown}
+      className={`flex min-h-0 flex-1 flex-col outline-none ${className}`}
+    >
+      <div className="flex flex-col gap-px px-2 pt-1">
+        {rows.map((row) => (
+          <TreeRowView
+            key={`${row.ref.kind}:${row.ref.id}`}
+            row={row}
+            selected={sameRef(row.ref, selected)}
+            renaming={sameRef(row.ref, renaming)}
+            renameError={renameError}
+            onRenameCommit={onRenameCommit}
+            onRenameCancel={onRenameCancel}
+            onSelect={() => onSelect(row.ref)}
+            onToggle={() => row.ref.kind === "folder" && onToggle(row.ref.id)}
+            onDoubleClick={() => {
+              if (onRequestRename) onRequestRename(row.ref);
+            }}
+            actions={renderActions?.(row)}
+            leading={renderLeading?.(row)}
+            draggable={draggable && row.ref.kind === "skill"}
+            isDragging={dragging === row.ref.id}
+            isDropTarget={row.ref.kind === "folder" && dropTarget === row.ref.id}
+            onDragStart={(event) => {
+              event.dataTransfer.setData("text/pdo-skill", row.ref.id);
+              event.dataTransfer.effectAllowed = "move";
+              setDragging(row.ref.id);
+            }}
+            onDragEnd={() => {
+              setDragging(null);
+              setDropTarget(null);
+            }}
+            onDragOver={row.ref.kind === "folder" ? (event) => allowDrop(event, row.ref.id) : undefined}
+            onDragLeave={row.ref.kind === "folder" ? () => setDropTarget((t) => (t === row.ref.id ? null : t)) : undefined}
+            onDrop={row.ref.kind === "folder" ? (event) => dropOnFolder(event, row.ref.id) : undefined}
+          />
+        ))}
+      </div>
+      {/* Root drop zone: the space below the rows. */}
+      <div
+        className={`min-h-[48px] flex-1 rounded-md transition-colors ${
+          dropTarget === "root" ? "bg-acc/10 outline-dashed outline-1 outline-acc/50" : ""
+        }`}
+        data-testid="skill-tree-root-drop"
+        onDragOver={(event) => allowDrop(event, "root")}
+        onDragLeave={() => setDropTarget((t) => (t === "root" ? null : t))}
+        onDrop={(event) => dropOnFolder(event, null)}
+      >
+        {rows.length === 0 && emptyState}
+      </div>
+    </div>
+  );
+}
+
+function TreeRowView({
+  row,
+  selected,
+  renaming,
+  renameError,
+  onRenameCommit,
+  onRenameCancel,
+  onSelect,
+  onToggle,
+  onDoubleClick,
+  actions,
+  leading,
+  draggable,
+  isDragging,
+  isDropTarget,
+  onDragStart,
+  onDragEnd,
+  onDragOver,
+  onDragLeave,
+  onDrop,
+}: {
+  row: TreeRow;
+  selected: boolean;
+  renaming: boolean;
+  renameError: string | null;
+  onRenameCommit?: (ref: TreeNodeRef, name: string) => void | Promise<void>;
+  onRenameCancel?: () => void;
+  onSelect: () => void;
+  onToggle: () => void;
+  onDoubleClick: () => void;
+  actions?: ReactNode;
+  leading?: ReactNode;
+  draggable: boolean;
+  isDragging: boolean;
+  isDropTarget: boolean;
+  onDragStart: (event: React.DragEvent) => void;
+  onDragEnd: () => void;
+  onDragOver?: (event: React.DragEvent) => void;
+  onDragLeave?: () => void;
+  onDrop?: (event: React.DragEvent) => void;
+}) {
+  const isFolder = row.ref.kind === "folder";
+  const name = isFolder ? row.folder?.name ?? "" : row.skill?.name ?? "";
+  const indent = 8 + row.depth * 18;
+
+  return (
+    <div
+      role="treeitem"
+      aria-selected={selected}
+      aria-expanded={isFolder ? row.expanded : undefined}
+      data-testid={`tree-${row.ref.kind}-${row.ref.id}`}
+      data-selected={selected || undefined}
+      data-drop-target={isDropTarget || undefined}
+      className={`group relative flex flex-col rounded-md ${
+        isDropTarget
+          ? "bg-acc/15 outline outline-1 outline-acc"
+          : selected
+            ? "bg-acc/10 outline outline-1 outline-acc/40"
+            : "hover:bg-bg-5"
+      } ${isDragging ? "opacity-40" : ""}`}
+      onDragOver={onDragOver}
+      onDragLeave={onDragLeave}
+      onDrop={onDrop}
+      onClick={onSelect}
+      onDoubleClick={(event) => {
+        event.stopPropagation();
+        onDoubleClick();
+      }}
+    >
+      <div
+        className="flex min-h-[30px] items-center gap-1.5 pr-1"
+        style={{ paddingLeft: indent }}
+        draggable={draggable && !renaming}
+        onDragStart={draggable ? onDragStart : undefined}
+        onDragEnd={draggable ? onDragEnd : undefined}
+      >
+        {isFolder ? (
+          <button
+            type="button"
+            aria-label={row.expanded ? `Collapse ${name}` : `Expand ${name}`}
+            onClick={(event) => {
+              event.stopPropagation();
+              onToggle();
+            }}
+            className="grid h-4 w-4 shrink-0 place-items-center rounded text-fg-4 hover:text-fg"
+          >
+            {row.expanded ? <ChevronDown size={11} /> : <ChevronRight size={11} />}
+          </button>
+        ) : (
+          <span className="h-4 w-4 shrink-0" />
+        )}
+        {leading}
+        {isFolder ? (
+          row.expanded ? (
+            <FolderOpen size={13} className="shrink-0 text-st-await" />
+          ) : (
+            <Folder size={13} className="shrink-0 text-st-await" />
+          )
+        ) : (
+          <FileText size={13} className="shrink-0 text-fg-3" />
+        )}
+        {renaming ? (
+          <RenameInput
+            initial={name}
+            onCommit={(value) => onRenameCommit?.(row.ref, value)}
+            onCancel={() => onRenameCancel?.()}
+          />
+        ) : (
+          <span
+            className={`min-w-0 flex-1 truncate ${isFolder ? "font-medium text-fg" : "text-fg-2"}`}
+            style={{ fontSize: "12px" }}
+          >
+            {name}
+          </span>
+        )}
+        {isFolder && !renaming && (
+          <span className="shrink-0 font-mono text-fg-4 group-hover:hidden" style={{ fontSize: "10px" }}>
+            {row.count}
+          </span>
+        )}
+        {!renaming && actions && (
+          <span
+            className={`shrink-0 items-center gap-0.5 ${selected ? "flex" : "hidden group-hover:flex group-focus-within:flex"}`}
+            onClick={(event) => event.stopPropagation()}
+            onDoubleClick={(event) => event.stopPropagation()}
+          >
+            {actions}
+          </span>
+        )}
+      </div>
+      {renaming && (
+        <div className="pb-1 text-fg-4" style={{ paddingLeft: indent + 22, fontSize: "10px" }}>
+          {renameError ? (
+            <span className="text-st-failed" data-testid="rename-error">
+              {renameError}
+            </span>
+          ) : (
+            "Enter to save · Esc to cancel"
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function RenameInput({
+  initial,
+  onCommit,
+  onCancel,
+}: {
+  initial: string;
+  onCommit: (value: string) => void | Promise<void>;
+  onCancel: () => void;
+}) {
+  const [value, setValue] = useState(initial);
+  const ref = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    ref.current?.focus();
+    ref.current?.select();
+  }, []);
+  return (
+    <input
+      ref={ref}
+      value={value}
+      aria-label="New name"
+      data-testid="rename-input"
+      onChange={(event) => setValue(event.target.value)}
+      onClick={(event) => event.stopPropagation()}
+      onKeyDown={(event) => {
+        event.stopPropagation();
+        if (event.key === "Enter") {
+          event.preventDefault();
+          const trimmed = value.trim();
+          if (trimmed === "" || trimmed === initial) onCancel();
+          else void onCommit(trimmed);
+        } else if (event.key === "Escape") {
+          event.preventDefault();
+          onCancel();
+        }
+      }}
+      onBlur={() => {
+        // Blur commits like Enter (a click elsewhere should not lose the edit),
+        // except when nothing changed.
+        const trimmed = value.trim();
+        if (trimmed === "" || trimmed === initial) onCancel();
+        else void onCommit(trimmed);
+      }}
+      className="min-w-0 flex-1 rounded border border-acc bg-bg-1 px-1.5 py-0.5 text-fg outline-none"
+      style={{ fontSize: "12px" }}
+    />
+  );
+}

--- a/frontend/src/hooks/useSkillBank.ts
+++ b/frontend/src/hooks/useSkillBank.ts
@@ -1,0 +1,67 @@
+import { useCallback, useEffect, useState } from "react";
+import { fetchSkillBank } from "../api";
+import type { SkillBank } from "../types";
+
+/**
+ * Window bus fired after every write to the Banque de skills (#668), on the
+ * model of `pdo:agent-profiles-changed`: the future tier selectors (#669+) read
+ * the same list and must refresh after a paste / move / rename / delete here.
+ */
+export const SKILLS_CHANGED = "pdo:skills-changed";
+
+export function announceSkillsChanged() {
+  window.dispatchEvent(new Event(SKILLS_CHANGED));
+}
+
+const EMPTY: SkillBank = { skills: [], folders: [], root_path: "" };
+
+export function useSkillBank(enabled = true) {
+  const [bank, setBank] = useState<SkillBank>(EMPTY);
+  const [loaded, setLoaded] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    if (!enabled) return;
+    try {
+      const result = await fetchSkillBank();
+      if (!Array.isArray(result.skills) || !Array.isArray(result.folders)) {
+        throw new Error("Invalid skill bank response");
+      }
+      setBank(result);
+      setError(null);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Failed to load skills");
+    } finally {
+      setLoaded(true);
+    }
+  }, [enabled]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    let cancelled = false;
+    // Initial load inline (a subscription-style callback, not a synchronous
+    // setState in the effect body); the bus re-uses `refresh`.
+    fetchSkillBank()
+      .then((result) => {
+        if (cancelled) return;
+        if (!Array.isArray(result.skills) || !Array.isArray(result.folders)) {
+          throw new Error("Invalid skill bank response");
+        }
+        setBank(result);
+        setError(null);
+        setLoaded(true);
+      })
+      .catch((cause) => {
+        if (cancelled) return;
+        setError(cause instanceof Error ? cause.message : "Failed to load skills");
+        setLoaded(true);
+      });
+    window.addEventListener(SKILLS_CHANGED, refresh);
+    return () => {
+      cancelled = true;
+      window.removeEventListener(SKILLS_CHANGED, refresh);
+    };
+  }, [enabled, refresh]);
+
+  return { bank, loaded, error, refresh };
+}

--- a/frontend/src/lib/skillMd.test.ts
+++ b/frontend/src/lib/skillMd.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatSize,
+  isKebabCase,
+  parseSimpleYaml,
+  parseSkillMd,
+  splitFrontmatter,
+  timeAgo,
+  validateSkillMd,
+} from "./skillMd";
+
+const VALID = `---
+name: tdd
+description: Test-driven development. Red-green-refactor at pre-agreed seams.
+allowed-tools: Bash(npm:*) Bash(cargo:*)
+---
+
+# Test-driven development
+
+Red, green, refactor.
+`;
+
+function states(text: string, names?: string[]) {
+  return Object.fromEntries(validateSkillMd(text, names).checks.map((c) => [c.id, c.state]));
+}
+
+describe("skillMd — kebab-case", () => {
+  it.each(["tdd", "code-review", "a1-b2"])("accepts %s", (name) => {
+    expect(isKebabCase(name)).toBe(true);
+  });
+  it.each(["TDD", "code_review", "-lead", "trail-", "double--dash", "", "with space"])(
+    "refuses %s",
+    (name) => {
+      expect(isKebabCase(name)).toBe(false);
+    },
+  );
+});
+
+describe("skillMd — frontmatter split and parse", () => {
+  it("splits a closed block from its body", () => {
+    const split = splitFrontmatter(VALID);
+    expect(split?.yaml).toContain("name: tdd");
+    expect(split?.body.trim().startsWith("# Test-driven development")).toBe(true);
+  });
+
+  it("returns null without an opening or closing fence", () => {
+    expect(splitFrontmatter("# just markdown")).toBeNull();
+    expect(splitFrontmatter("---\nname: tdd\nbody without closing")).toBeNull();
+    expect(splitFrontmatter("--- not a fence\n---\n")).toBeNull();
+  });
+
+  it("parses scalars, quotes and block scalars", () => {
+    const parsed = parseSimpleYaml(
+      'name: "tdd"\ndescription: |\n  Line one\n  Line two\nother: \'x\'\n# comment\n',
+    );
+    expect(parsed.name).toBe("tdd");
+    expect(parsed.description).toBe("Line one\nLine two");
+    expect(parsed.other).toBe("x");
+  });
+
+  it("exposes name and description", () => {
+    const parsed = parseSkillMd(VALID);
+    expect(parsed.name).toBe("tdd");
+    expect(parsed.description).toMatch(/^Test-driven/);
+    expect(parsed.frontmatter?.["allowed-tools"]).toBe("Bash(npm:*) Bash(cargo:*)");
+  });
+});
+
+describe("skillMd — the five checks", () => {
+  it("passes a complete SKILL.md against an empty bank", () => {
+    const result = validateSkillMd(VALID, []);
+    expect(result.valid).toBe(true);
+    expect(result.reason).toBeNull();
+    expect(states(VALID, [])).toEqual({
+      frontmatter: "pass",
+      name: "pass",
+      description: "pass",
+      body: "pass",
+      unique: "pass",
+    });
+  });
+
+  it("leaves `unique` pending while the bank is unknown, so Create stays disabled", () => {
+    const result = validateSkillMd(VALID);
+    expect(result.valid).toBe(false);
+    expect(states(VALID).unique).toBe("pending");
+  });
+
+  it("flags a missing description with reason and consequence (FP step 3)", () => {
+    const text = VALID.replace(/description: .*\n/, "");
+    const result = validateSkillMd(text, []);
+    expect(result.valid).toBe(false);
+    expect(states(text, []).description).toBe("fail");
+    expect(result.reason).toMatch(/no `description`/);
+    expect(result.reason).toMatch(/nothing was written/i);
+  });
+
+  it("flags a non-kebab name", () => {
+    const text = VALID.replace("name: tdd", "name: TDD");
+    const result = validateSkillMd(text, []);
+    expect(states(text, []).name).toBe("fail");
+    expect(result.reason).toMatch(/not kebab-case/);
+  });
+
+  it("flags an empty body", () => {
+    const text = "---\nname: tdd\ndescription: x\n---\n\n   \n";
+    expect(states(text, []).body).toBe("fail");
+    expect(validateSkillMd(text, []).reason).toMatch(/body .* empty/i);
+  });
+
+  it("flags no frontmatter and leaves the field checks pending", () => {
+    const result = validateSkillMd("# no frontmatter\n\nbody", []);
+    expect(result.checks[0].state).toBe("fail");
+    expect(states("# no frontmatter", []).name).toBe("pending");
+    expect(result.reason).toMatch(/no frontmatter block/);
+  });
+
+  it("has no reason for blank text (nothing typed yet)", () => {
+    expect(validateSkillMd("", []).reason).toBeNull();
+  });
+
+  it("detects a case-insensitive name collision locally", () => {
+    const result = validateSkillMd(VALID, ["TDD", "grilling"]);
+    expect(result.valid).toBe(false);
+    expect(states(VALID, ["TDD"]).unique).toBe("fail");
+    expect(result.reason).toMatch(/`TDD` exists/);
+  });
+
+  it("marks `unique` failed after a server 409 even if the local bank did not know", () => {
+    const result = validateSkillMd(VALID, [], true);
+    expect(result.valid).toBe(false);
+    expect(result.checks.find((c) => c.id === "unique")?.state).toBe("fail");
+    expect(result.reason).toMatch(/`tdd` exists/);
+  });
+});
+
+describe("skillMd — display helpers", () => {
+  it("formats sizes", () => {
+    expect(formatSize(12)).toBe("12 B");
+    expect(formatSize(1229)).toBe("1.2 kB");
+    expect(formatSize(3 * 1024 * 1024)).toBe("3.0 MB");
+  });
+
+  it("formats relative times", () => {
+    const now = Date.parse("2026-09-03T12:00:00Z");
+    expect(timeAgo("2026-09-03T11:59:50Z", now)).toBe("just now");
+    expect(timeAgo("2026-09-03T11:58:00Z", now)).toBe("2 min ago");
+    expect(timeAgo("2026-09-03T09:00:00Z", now)).toBe("3 h ago");
+    expect(timeAgo("2026-08-31T12:00:00Z", now)).toBe("3 days ago");
+    expect(timeAgo("not a date", now)).toBe("not a date");
+  });
+});

--- a/frontend/src/lib/skillMd.ts
+++ b/frontend/src/lib/skillMd.ts
@@ -1,0 +1,243 @@
+/**
+ * Client-side mirror of the daemon's `skill_bank::validate_skill_md` (#668): the
+ * paste popup re-parses on every keystroke and lights five checks. The daemon
+ * stays authoritative (a 400/409 is rendered exactly like a local failure); this
+ * only exists so the operator sees the refusal before pressing Create.
+ *
+ * The frontmatter parser here is deliberately small: `key: value` lines, quoted
+ * scalars, and `key: |` / `key: >` block scalars — enough for a `SKILL.md`. It
+ * never claims to be YAML; anything odd is surfaced as `frontmatter` raw text
+ * and the daemon has the last word.
+ */
+
+export type CheckId = "frontmatter" | "name" | "description" | "body" | "unique";
+
+export type CheckState = "pass" | "fail" | "warn" | "pending";
+
+export interface SkillCheck {
+  id: CheckId;
+  state: CheckState;
+  /** The row label of the popup's check list. */
+  label: string;
+}
+
+export interface ParsedSkillMd {
+  /** `null` when no `---` block opens (and closes) the text. */
+  frontmatter: Record<string, string> | null;
+  /** Raw YAML text between the fences, for line highlighting. */
+  frontmatterText: string;
+  body: string;
+  name: string | null;
+  description: string | null;
+}
+
+export interface SkillMdValidation {
+  parsed: ParsedSkillMd;
+  checks: SkillCheck[];
+  /** All checks pass (the `unique` check counts only when `existingNames` is known). */
+  valid: boolean;
+  /** Reason + consequence, for the callout under the preview card. */
+  reason: string | null;
+}
+
+export const KEBAB_CASE = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+
+export function isKebabCase(name: string): boolean {
+  return KEBAB_CASE.test(name);
+}
+
+function unquote(raw: string): string {
+  const value = raw.trim();
+  if (value.length >= 2) {
+    const first = value[0];
+    const last = value[value.length - 1];
+    if ((first === '"' && last === '"') || (first === "'" && last === "'")) {
+      return value.slice(1, -1);
+    }
+  }
+  return value;
+}
+
+/** Split `text` into frontmatter YAML and body; `null` when no closed block. */
+export function splitFrontmatter(text: string): { yaml: string; body: string } | null {
+  const trimmed = text.replace(/^\s+/, "");
+  if (!trimmed.startsWith("---")) return null;
+  const afterFence = trimmed.slice(3);
+  if (!afterFence.startsWith("\n") && !afterFence.startsWith("\r\n")) return null;
+  const lines = afterFence.replace(/^\r?\n/, "").split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].replace(/\r$/, "") === "---") {
+      return { yaml: lines.slice(0, i).join("\n"), body: lines.slice(i + 1).join("\n") };
+    }
+  }
+  return null;
+}
+
+/** Minimal `key: value` parser (top-level keys only, block scalars folded). */
+export function parseSimpleYaml(yaml: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  const lines = yaml.split("\n");
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i].replace(/\r$/, "");
+    i++;
+    if (!line.trim() || line.trim().startsWith("#")) continue;
+    if (/^\s/.test(line)) continue; // nested content of a key we do not model
+    const match = /^([A-Za-z0-9_-]+)\s*:(.*)$/.exec(line);
+    if (!match) continue;
+    const key = match[1];
+    let value = match[2].trim();
+    if (value === "|" || value === ">" || value === "|-" || value === ">-") {
+      const block: string[] = [];
+      while (i < lines.length && (/^\s/.test(lines[i]) || lines[i].trim() === "")) {
+        block.push(lines[i].replace(/^\s+/, ""));
+        i++;
+      }
+      value = block.join(value.startsWith("|") ? "\n" : " ").trim();
+    } else if (value === "") {
+      // A key introducing a nested list/map: keep its raw following lines.
+      const block: string[] = [];
+      while (i < lines.length && (/^\s/.test(lines[i]) || lines[i].trim() === "")) {
+        block.push(lines[i].trim());
+        i++;
+      }
+      value = block.join(" ").trim();
+    } else {
+      value = unquote(value);
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
+export function parseSkillMd(text: string): ParsedSkillMd {
+  const split = splitFrontmatter(text);
+  if (!split) {
+    return { frontmatter: null, frontmatterText: "", body: text, name: null, description: null };
+  }
+  const frontmatter = parseSimpleYaml(split.yaml);
+  const name = frontmatter.name?.trim() || null;
+  const description = frontmatter.description?.trim() || null;
+  return { frontmatter, frontmatterText: split.yaml, body: split.body, name, description };
+}
+
+/**
+ * Run the five checks. `existingNames` is the bank's current labels (any case);
+ * pass `undefined` to leave the `unique` check pending (e.g. before the bank
+ * loaded). `serverDuplicate` forces the `unique` check red after a 409.
+ */
+export function validateSkillMd(
+  text: string,
+  existingNames?: readonly string[],
+  serverDuplicate = false,
+): SkillMdValidation {
+  const parsed = parseSkillMd(text);
+  const checks: SkillCheck[] = [];
+  let reason: string | null = null;
+
+  const hasFrontmatter = parsed.frontmatter !== null;
+  checks.push({
+    id: "frontmatter",
+    state: hasFrontmatter ? "pass" : "fail",
+    label: hasFrontmatter ? "Frontmatter block found" : "No frontmatter block",
+  });
+  if (!hasFrontmatter) {
+    reason =
+      text.trim() === ""
+        ? null
+        : "The text has no frontmatter block (`---` … `---`). The harness would ignore this skill, so nothing was written.";
+  }
+
+  const name = parsed.name;
+  let nameState: CheckState = "fail";
+  let nameLabel = "name missing";
+  if (!hasFrontmatter) {
+    nameState = "pending";
+    nameLabel = "name kebab-case";
+  } else if (name && isKebabCase(name)) {
+    nameState = "pass";
+    nameLabel = "name kebab-case";
+  } else if (name) {
+    nameLabel = "name is not kebab-case";
+    reason ??= `\`name: ${name}\` is not kebab-case (lowercase letters, digits, single hyphens). Nothing was written.`;
+  } else {
+    reason ??= "The frontmatter has no `name`. The harness would ignore this skill, so nothing was written.";
+  }
+  checks.push({ id: "name", state: nameState, label: nameLabel });
+
+  const description = parsed.description;
+  let descState: CheckState = "fail";
+  let descLabel = "description missing";
+  if (!hasFrontmatter) {
+    descState = "pending";
+    descLabel = "description present";
+  } else if (description) {
+    descState = "pass";
+    descLabel = "description present";
+  } else {
+    reason ??= "The frontmatter has no `description`. The harness would ignore this skill, so nothing was written.";
+  }
+  checks.push({ id: "description", state: descState, label: descLabel });
+
+  const bodyOk = parsed.body.trim().length > 0;
+  const bodyState: CheckState = !hasFrontmatter ? "pending" : bodyOk ? "pass" : "fail";
+  if (hasFrontmatter && !bodyOk) {
+    reason ??= "The body after the frontmatter is empty. Nothing was written.";
+  }
+  checks.push({
+    id: "body",
+    state: bodyState,
+    label: bodyState === "fail" ? "Body is empty" : "Body is not empty",
+  });
+
+  let uniqueState: CheckState = "pending";
+  let uniqueLabel = "Name unique in the bank";
+  if (serverDuplicate) {
+    uniqueState = "fail";
+    uniqueLabel = "Name already taken";
+  } else if (name && existingNames) {
+    const lower = name.toLowerCase();
+    const clash = existingNames.find((existing) => existing.toLowerCase() === lower);
+    if (clash) {
+      uniqueState = "fail";
+      uniqueLabel = "Name already taken";
+      if (nameState === "pass" && descState === "pass" && bodyOk) {
+        reason ??= `\`${clash}\` exists (names are case-insensitive). Rename in the frontmatter, or open the existing skill.`;
+      }
+    } else {
+      uniqueState = "pass";
+    }
+  }
+  if (serverDuplicate && name) {
+    reason ??= `\`${name}\` exists (names are case-insensitive). Rename in the frontmatter, or open the existing skill.`;
+  }
+  checks.push({ id: "unique", state: uniqueState, label: uniqueLabel });
+
+  const valid = checks.every((check) => check.state === "pass");
+  return { parsed, checks, valid, reason };
+}
+
+/** `1.2 kB`-style size for the Files tab. */
+export function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} kB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/** `updated 2 min ago`-style relative time; `now` is injectable for tests. */
+export function timeAgo(iso: string, now: number = Date.now()): string {
+  const then = Date.parse(iso);
+  if (Number.isNaN(then)) return iso;
+  const seconds = Math.max(0, Math.round((now - then) / 1000));
+  if (seconds < 45) return "just now";
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes} min ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours} h ago`;
+  const days = Math.round(hours / 24);
+  if (days < 30) return `${days} day${days === 1 ? "" : "s"} ago`;
+  const months = Math.round(days / 30);
+  if (months < 12) return `${months} month${months === 1 ? "" : "s"} ago`;
+  const years = Math.round(days / 365);
+  return `${years} year${years === 1 ? "" : "s"} ago`;
+}

--- a/frontend/src/lib/skillTree.test.ts
+++ b/frontend/src/lib/skillTree.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import type { Skill, SkillFolder } from "../types";
+import {
+  buildRows,
+  descendantFolderIds,
+  folderCounts,
+  folderPathLabel,
+  shortId,
+} from "./skillTree";
+
+const t = "2026-09-03T10:00:00Z";
+const folder = (id: string, name: string, parent_id: string | null = null): SkillFolder => ({
+  id,
+  name,
+  parent_id,
+  created_at: t,
+  updated_at: t,
+});
+const skill = (id: string, name: string, folder_id: string | null = null, description = ""): Skill => ({
+  id,
+  name,
+  description,
+  folder_id,
+  created_at: t,
+  updated_at: t,
+});
+
+const folders = [folder("f-m", "méthode"), folder("f-i", "ippon"), folder("f-j", "java", "f-i")];
+const skills = [
+  skill("s-tdd", "tdd", "f-m", "Test-driven development"),
+  skill("s-gr", "grilling", "f-m"),
+  skill("s-sp", "spring", "f-j"),
+  skill("s-cr", "code-review", null, "Review staged changes"),
+];
+
+describe("skillTree", () => {
+  it("labels a folder with its path", () => {
+    expect(folderPathLabel("f-j", folders)).toBe("ippon / java");
+    expect(folderPathLabel("f-m", folders)).toBe("méthode");
+  });
+
+  it("counts skills recursively", () => {
+    const counts = folderCounts(folders, skills);
+    expect(counts.get("f-m")).toBe(2);
+    expect(counts.get("f-j")).toBe(1);
+    expect(counts.get("f-i")).toBe(1);
+  });
+
+  it("collects descendant folder ids", () => {
+    expect([...descendantFolderIds("f-i", folders)].sort()).toEqual(["f-i", "f-j"]);
+  });
+
+  it("renders folders first then root skills, collapsed by default", () => {
+    const rows = buildRows(folders, skills, new Set());
+    expect(rows.map((row) => `${row.ref.kind}:${row.ref.id}`)).toEqual([
+      "folder:f-i",
+      "folder:f-m",
+      "skill:s-cr",
+    ]);
+    expect(rows[1].count).toBe(2);
+  });
+
+  it("expands a folder and indents its children", () => {
+    const rows = buildRows(folders, skills, new Set(["f-m"]));
+    const ids = rows.map((row) => row.ref.id);
+    expect(ids).toEqual(["f-i", "f-m", "s-gr", "s-tdd", "s-cr"]);
+    expect(rows.find((row) => row.ref.id === "s-tdd")?.depth).toBe(1);
+  });
+
+  it("filters by name or description, keeping ancestor folders expanded", () => {
+    const rows = buildRows(folders, skills, new Set(), "spring");
+    expect(rows.map((row) => row.ref.id)).toEqual(["f-i", "f-j", "s-sp"]);
+    const byDesc = buildRows(folders, skills, new Set(), "staged");
+    expect(byDesc.map((row) => row.ref.id)).toEqual(["s-cr"]);
+  });
+
+  it("puts a skill whose folder vanished back at the root", () => {
+    const rows = buildRows(folders, [skill("s-x", "orphan", "f-gone")], new Set());
+    expect(rows.map((row) => row.ref.id)).toContain("s-x");
+  });
+
+  it("shortens ids", () => {
+    expect(shortId("7c3e1234-aaaa-bbbb-cccc-000000a91f")).toBe("7c3e…a91f");
+    expect(shortId("short")).toBe("short");
+  });
+});

--- a/frontend/src/lib/skillTree.ts
+++ b/frontend/src/lib/skillTree.ts
@@ -1,0 +1,147 @@
+import type { Skill, SkillFolder } from "../types";
+
+/**
+ * Pure helpers behind the bank's tree (#668). Kept out of the component so the
+ * future tier selector can render the same rows with checkboxes instead of drag
+ * handles (the design note: "same nodes, checkboxes instead of drag").
+ */
+
+export type TreeNodeRef = { kind: "folder"; id: string } | { kind: "skill"; id: string };
+
+export interface TreeRow {
+  ref: TreeNodeRef;
+  depth: number;
+  /** Folder: the folder; skill: the skill. */
+  folder?: SkillFolder;
+  skill?: Skill;
+  /** Folder only: skills in it, recursively. */
+  count?: number;
+  /** Folder only: rendered expanded. */
+  expanded?: boolean;
+}
+
+export function sameRef(a: TreeNodeRef | null, b: TreeNodeRef | null): boolean {
+  return !!a && !!b && a.kind === b.kind && a.id === b.id;
+}
+
+const byName = <T extends { name: string; created_at: string }>(a: T, b: T) =>
+  a.name.localeCompare(b.name, undefined, { sensitivity: "base" }) ||
+  a.created_at.localeCompare(b.created_at);
+
+/** `parent / child` breadcrumb of a folder, for pickers. */
+export function folderPathLabel(folderId: string, folders: SkillFolder[]): string {
+  const byId = new Map(folders.map((folder) => [folder.id, folder]));
+  const parts: string[] = [];
+  let cursor: string | null = folderId;
+  let hops = 0;
+  while (cursor && hops++ < 100) {
+    const folder = byId.get(cursor);
+    if (!folder) break;
+    parts.unshift(folder.name);
+    cursor = folder.parent_id;
+  }
+  return parts.join(" / ");
+}
+
+/** Ids of `folderId` and every folder below it. */
+export function descendantFolderIds(folderId: string, folders: SkillFolder[]): Set<string> {
+  const out = new Set<string>([folderId]);
+  let grew = true;
+  while (grew) {
+    grew = false;
+    for (const folder of folders) {
+      if (folder.parent_id && out.has(folder.parent_id) && !out.has(folder.id)) {
+        out.add(folder.id);
+        grew = true;
+      }
+    }
+  }
+  return out;
+}
+
+/** Recursive skill count per folder. */
+export function folderCounts(folders: SkillFolder[], skills: Skill[]): Map<string, number> {
+  const counts = new Map<string, number>();
+  const parentOf = new Map(folders.map((folder) => [folder.id, folder.parent_id]));
+  for (const skill of skills) {
+    let cursor = skill.folder_id;
+    let hops = 0;
+    while (cursor && hops++ < 100) {
+      counts.set(cursor, (counts.get(cursor) ?? 0) + 1);
+      cursor = parentOf.get(cursor) ?? null;
+    }
+  }
+  return counts;
+}
+
+function matches(skill: Skill, needle: string): boolean {
+  return (
+    skill.name.toLowerCase().includes(needle) || skill.description.toLowerCase().includes(needle)
+  );
+}
+
+/**
+ * Flatten the bank into the rows the tree renders: folders first (sorted), then
+ * skills, at every level. A non-empty `filter` keeps only matching skills plus
+ * their ancestor folders, all expanded.
+ */
+export function buildRows(
+  folders: SkillFolder[],
+  skills: Skill[],
+  expanded: ReadonlySet<string>,
+  filter = "",
+): TreeRow[] {
+  const needle = filter.trim().toLowerCase();
+  const counts = folderCounts(folders, skills);
+  const visibleSkills = needle ? skills.filter((skill) => matches(skill, needle)) : skills;
+  // Folders to show under a filter: every ancestor of a visible skill.
+  let allowedFolders: Set<string> | null = null;
+  if (needle) {
+    allowedFolders = new Set();
+    const parentOf = new Map(folders.map((folder) => [folder.id, folder.parent_id]));
+    for (const skill of visibleSkills) {
+      let cursor = skill.folder_id;
+      let hops = 0;
+      while (cursor && hops++ < 100) {
+        allowedFolders.add(cursor);
+        cursor = parentOf.get(cursor) ?? null;
+      }
+    }
+  }
+
+  const rows: TreeRow[] = [];
+  const knownFolder = new Set(folders.map((folder) => folder.id));
+  const walk = (parentId: string | null, depth: number) => {
+    const children = folders
+      .filter((folder) => (folder.parent_id ?? null) === parentId)
+      .filter((folder) => !allowedFolders || allowedFolders.has(folder.id))
+      .sort(byName);
+    for (const folder of children) {
+      const isExpanded = needle ? true : expanded.has(folder.id);
+      rows.push({
+        ref: { kind: "folder", id: folder.id },
+        depth,
+        folder,
+        count: counts.get(folder.id) ?? 0,
+        expanded: isExpanded,
+      });
+      if (isExpanded) walk(folder.id, depth + 1);
+    }
+    const here = visibleSkills
+      .filter((skill) => {
+        const parent = skill.folder_id && knownFolder.has(skill.folder_id) ? skill.folder_id : null;
+        return parent === parentId;
+      })
+      .sort(byName);
+    for (const skill of here) {
+      rows.push({ ref: { kind: "skill", id: skill.id }, depth, skill });
+    }
+  };
+  walk(null, 0);
+  return rows;
+}
+
+/** Short id for the header: `7c3e…a91f`. */
+export function shortId(id: string): string {
+  return id.length > 12 ? `${id.slice(0, 4)}…${id.slice(-4)}` : id;
+}

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -2,6 +2,46 @@ import "@testing-library/jest-dom/vitest";
 import { afterEach } from "vitest";
 import { useSelectionStore } from "../stores/selectionStore";
 
+// Node ≥ 22 ships its own `localStorage` / `sessionStorage` on `globalThis`
+// (the experimental Web Storage, backed by `--localstorage-file`). Without that
+// flag the object exists but has none of the Storage methods, and vitest's jsdom
+// environment does not overwrite a global that is already defined — so every
+// test calling `localStorage.clear()` / `getItem()` blew up with "is not a
+// function" under Node 25. Replace any such stub with an in-memory Storage so
+// the suite behaves the same on every Node version.
+class MemoryStorage implements Storage {
+  private map = new Map<string, string>();
+  get length() {
+    return this.map.size;
+  }
+  clear() {
+    this.map.clear();
+  }
+  getItem(key: string) {
+    return this.map.has(key) ? (this.map.get(key) as string) : null;
+  }
+  key(index: number) {
+    return Array.from(this.map.keys())[index] ?? null;
+  }
+  removeItem(key: string) {
+    this.map.delete(key);
+  }
+  setItem(key: string, value: string) {
+    this.map.set(key, String(value));
+  }
+}
+
+for (const name of ["localStorage", "sessionStorage"] as const) {
+  const current = (globalThis as Record<string, unknown>)[name] as Partial<Storage> | undefined;
+  if (!current || typeof current.clear !== "function" || typeof current.getItem !== "function") {
+    Object.defineProperty(globalThis, name, {
+      value: new MemoryStorage(),
+      configurable: true,
+      writable: true,
+    });
+  }
+}
+
 // #577 — the multi-select store is a module singleton shared across every test;
 // reset it after each so a selection made in one test can't leak a floating bar
 // or a tab badge into the next.

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1443,3 +1443,65 @@ export interface StatsPerformance {
   by_pipeline: StatsPerformanceEntity[];
   infrastructure: StatsPerformanceEntity[];
 }
+
+// ---------------------------------------------------------------------------
+// Banque de skills (#668, ADR-0062)
+// ---------------------------------------------------------------------------
+
+/** One row of the bank's index. Identity is `id`; `name` is a unique label. */
+export interface Skill {
+  id: string;
+  name: string;
+  description: string;
+  /** `null` at the root of the bank. */
+  folder_id: string | null;
+  /** Provenance of an import; absent for a pasted skill. */
+  source?: string | null;
+  source_commit?: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+/** A folder of the bank's free hierarchy. A UI gesture, never a reference. */
+export interface SkillFolder {
+  id: string;
+  name: string;
+  parent_id: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+/** `GET /settings/skills`: the whole bank in one read. */
+export interface SkillBank {
+  skills: Skill[];
+  folders: SkillFolder[];
+  /** Where the skill folders live on disk (`<root>/<id>/SKILL.md`). */
+  root_path: string;
+}
+
+/** A reference file of a skill, listed read-only. */
+export interface SkillFile {
+  path: string;
+  size: number;
+}
+
+/** `GET /settings/skills/{id}`: the row plus its content. */
+export interface SkillDetail extends Skill {
+  /** Raw `SKILL.md`; `null` if the folder vanished from disk. */
+  content: string | null;
+  frontmatter: Record<string, unknown> | null;
+  /** Keys of `frontmatter` in the author's order (JSON objects do not keep it). */
+  frontmatter_keys?: string[] | null;
+  body: string | null;
+  files: SkillFile[];
+  path: string;
+}
+
+/** Who selects a skill, by tier. Empty in #668 (no tier selects yet). */
+export interface SkillReferents {
+  skill_id: string;
+  instance: boolean;
+  projects: { id: string; name: string }[];
+  pipelines: { id: string; name: string; node_id?: string; scope?: string }[];
+  runs: { run_id: string; name?: string | null }[];
+}


### PR DESCRIPTION
Sous-ticket `ready-for-agent` de la story #666 (spec #667). Closes #668.

## Contenu
- Modèle et stockage : `crates/pdo-daemon/src/skill_bank.rs`, skills sous `<repo>/.pdo/skills/<id>/SKILL.md`.
- API REST `/settings/skills` (création par collage, dossiers, renommage, suppression avec inventaire des référents).
- Frontend : `SkillBankPanel`, `SkillTree`, `PasteSkillModal`, intégration dans `SettingsModal`.
- Bump 1.50.0 -> 1.51.0 + entrée CHANGELOG.

## Vérification
- Implémentation : 2727 tests Rust et 2042 tests vitest verts (nœud implementer).
- Feature Path #668 (agentic tests, playwright-cli sur daemon + Vite réels) : **PASS** sur les 6 étapes + retour, 4 contrôles drive-by verts, aucun finding bloquant.
- Findings non bloquants remontés par le testeur : emplacement per-repo (`<repo>/.pdo/skills`) vs libellé « home PDO » du ticket ; popup de collage déjà en erreur à l'ouverture ; boutons du détail dossier sur deux lignes à 760 px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)