### PR TITLE
feat(#669): skills par tier et skills effectifs avec origine — 1.53.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ ascendante** : la casse se signale ici et par un bump majeur, jamais en gardant 
 morts. Seule contrainte non négociable — les **données historiques restent lisibles** : un Run
 archivé s'ouvre et se chiffre quelle que soit la version qui a écrit son payload.
 
+## 1.53.0
+
+**Skills : sélection par tier et skills effectifs avec origine** (#669 ; story #666, spec #667 ;
+ADR-0062). Un skill se coche à trois niveaux — Instance (réglages), Projet (fiche projet) et Nœud
+(inspecteur du pipeline) — et un lancement de Run hérite des deux premiers, avec des skills RUN
+ajoutés à la volée (cocher un dossier coche ses skills). L'inspecteur d'un nœud affiche la liste des
+*skills effectifs* avec l'origine de chacun (INSTANCE / PROJECT / NODE / RUN) et la liste figée au
+spawn (`NodeStarted.skills`). Supprimer un skill de la banque liste ses référents (projets, nœuds) ;
+les références orphelines gardent l'id, s'affichent barrées avec un avertissement (inspecteur, bandeau
+de lint du pipeline, modale New Run) et le Run se lance quand même, le skill étant ignoré
+(`missing_skills`). API : `GET /settings/skills/{id}/referents`.
+
 ## 1.52.0
 
 **Fichiers de référence d'un skill** (#671 ; story #666, spec #667 ; ADR-0062). Un skill peut

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1926,7 +1926,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "1.52.0"
+version = "1.53.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "1.52.0"
+version = "1.53.0"
 license = "MIT"
 description = "Prompt-Driven Orchestrator — a local daemon that runs and supervises agentic coding pipelines"
 repository = "https://github.com/Loulen/prompt-driven-orchestrator"

--- a/crates/pdo-daemon/src/admission.rs
+++ b/crates/pdo-daemon/src/admission.rs
@@ -154,6 +154,8 @@ mod tests {
             run.nodes.insert(
                 (*id).into(),
                 NodeState {
+                    missing_skills: Vec::new(),
+                    skills: None,
                     isolated_worktree: None,
                     harness: None,
                     cost: None,

--- a/crates/pdo-daemon/src/boot_recovery.rs
+++ b/crates/pdo-daemon/src/boot_recovery.rs
@@ -337,6 +337,8 @@ mod tests {
         rs.nodes.insert(
             node_id.into(),
             event_log::NodeState {
+                missing_skills: Vec::new(),
+                skills: None,
                 isolated_worktree: None,
                 harness: None,
                 cost: None,

--- a/crates/pdo-daemon/src/event_log.rs
+++ b/crates/pdo-daemon/src/event_log.rs
@@ -535,6 +535,16 @@ pub struct NodeState {
     /// snapshot.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub isolated_worktree: Option<bool>,
+    /// #669/ADR-0062: the **skills effectifs** this NodeRun was frozen with at
+    /// spawn (union of the four tiers, each with its origin), read from the
+    /// `NodeStarted` payload. `None` for a node that never started, a `script`
+    /// node (no agent) or a pre-#669 event.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) skills: Option<Vec<crate::skill_selection::EffectiveSkill>>,
+    /// #669: selected ids the bank no longer knew at spawn — the node ran
+    /// without them (a warning, never a failure). Absent when empty.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) missing_skills: Vec<crate::skill_selection::MissingSkill>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cost: Option<NodeCost>,
     pub status: NodeStatus,
@@ -1047,6 +1057,13 @@ pub struct RunState {
     /// Run-only-harness rule for infra).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) agent_choice: Option<crate::agent_choice::AgentChoice>,
+    /// The Run tier of the **skills** selection (#669, ADR-0062), **frozen** here
+    /// from the `RunStarted` payload — set once at create (a fired Run copies its
+    /// Trigger's list), never mutated. Read at every node spawn as the `run` slot
+    /// of `skill_selection::resolve`. Empty ⇒ the Run adds none (every
+    /// historical Run: the payload omits the key).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) skills: Vec<crate::skill_selection::SkillRef>,
     /// The Run's `auto_fail` preference (ADR-0049), **frozen** here from the
     /// `RunStarted` payload — the **run** tier of
     /// [`crate::auto_fail::resolve_auto_fail`] (`node → Run → Projet →
@@ -1127,6 +1144,7 @@ impl RunState {
             fork_sha: None,
             harness: None,
             agent_choice: None,
+            skills: Vec::new(),
             auto_fail: None,
             triggered_by: None,
             pipeline_id: None,
@@ -1734,6 +1752,15 @@ fn apply_run_event(state: &mut RunState, event: &Event) {
                         state.agent_choice = Some(choice);
                     }
                 }
+                // #669 (ADR-0062): the FROZEN Run-tier skills, written by the create
+                // chokepoint only when non-empty; absent ⇒ none (historical Runs).
+                if let Some(v) = payload.get("skills") {
+                    if let Ok(skills) =
+                        serde_json::from_value::<Vec<crate::skill_selection::SkillRef>>(v.clone())
+                    {
+                        state.skills = skills;
+                    }
+                }
                 // ADR-0049: the Run's frozen `auto_fail` tier. Absent key ⇒ `None`
                 // (the Run stated no preference — every historical Run).
                 if let Some(af) = payload.get("auto_fail").and_then(|v| v.as_bool()) {
@@ -1940,6 +1967,8 @@ fn apply_node_event(state: &mut RunState, event: &Event) {
                     .or_insert_with(|| NodeState {
                         harness: None,
                         isolated_worktree: None,
+                        skills: None,
+                        missing_skills: Vec::new(),
                         cost: None,
                         node_id: node_id.clone(),
                         status: NodeStatus::Waiting,
@@ -1978,6 +2007,8 @@ fn apply_node_event(state: &mut RunState, event: &Event) {
                     .or_insert_with(|| NodeState {
                         harness: None,
                         isolated_worktree: None,
+                        skills: None,
+                        missing_skills: Vec::new(),
                         cost: None,
                         node_id: node_id.clone(),
                         status: NodeStatus::Running,
@@ -2027,6 +2058,24 @@ fn apply_node_event(state: &mut RunState, event: &Event) {
                 {
                     node.isolated_worktree = Some(isolated);
                 }
+                // #669/ADR-0062: freeze the skills effectifs this session received,
+                // and the ids it was promised but the bank no longer had. A re-spawn
+                // re-freezes; a `script` node / pre-#669 event leaves `None`.
+                if let Some(skills) = event
+                    .payload
+                    .as_ref()
+                    .and_then(|p| p.get("skills"))
+                    .filter(|v| !v.is_null())
+                    .and_then(|v| serde_json::from_value(v.clone()).ok())
+                {
+                    node.skills = Some(skills);
+                }
+                node.missing_skills = event
+                    .payload
+                    .as_ref()
+                    .and_then(|p| p.get("missing_skills"))
+                    .and_then(|v| serde_json::from_value(v.clone()).ok())
+                    .unwrap_or_default();
                 upsert_iteration(&mut node.iterations, iteration);
             }
         }
@@ -2072,6 +2121,8 @@ fn apply_node_event(state: &mut RunState, event: &Event) {
                         NodeState {
                             harness: None,
                             isolated_worktree: None,
+                            skills: None,
+                            missing_skills: Vec::new(),
                             cost: None,
                             node_id: node_id.clone(),
                             status: done_status.clone(),
@@ -2191,6 +2242,8 @@ fn apply_node_event(state: &mut RunState, event: &Event) {
                     .or_insert_with(|| NodeState {
                         harness: None,
                         isolated_worktree: None,
+                        skills: None,
+                        missing_skills: Vec::new(),
                         cost: None,
                         node_id: node_id.clone(),
                         status: NodeStatus::Interrupted,
@@ -2338,6 +2391,8 @@ fn apply_switch_event(state: &mut RunState, event: &Event) {
                 .or_insert_with(|| NodeState {
                     harness: None,
                     isolated_worktree: None,
+                    skills: None,
+                    missing_skills: Vec::new(),
                     cost: None,
                     node_id: node_id.to_string(),
                     status: NodeStatus::Completed,
@@ -3490,6 +3545,8 @@ mod tests {
         let value = serde_json::to_value(&state.nodes["impl"]).unwrap();
         assert_eq!(value["harness"], "copilot");
         let bare = super::NodeState {
+            missing_skills: Vec::new(),
+            skills: None,
             harness: None,
             isolated_worktree: None,
             cost: None,
@@ -6412,6 +6469,8 @@ mod tests {
         iters: &[(i64, NodeStatus)],
     ) -> NodeState {
         NodeState {
+            missing_skills: Vec::new(),
+            skills: None,
             harness: None,
             isolated_worktree: None,
             cost: None,

--- a/crates/pdo-daemon/src/graph_resolver.rs
+++ b/crates/pdo-daemon/src/graph_resolver.rs
@@ -389,6 +389,7 @@ mod tests {
 
     fn make_node(id: &str, node_type: NodeType, inputs: &[&str], outputs: &[&str]) -> NodeDef {
         NodeDef {
+            skills: Vec::new(),
             isolated_worktree: None,
             id: id.into(),
             name: id.into(),
@@ -434,6 +435,7 @@ mod tests {
 
     fn make_loop_node(id: &str, max_iter: i64) -> NodeDef {
         NodeDef {
+            skills: Vec::new(),
             isolated_worktree: None,
             id: id.into(),
             name: id.into(),
@@ -561,6 +563,8 @@ mod tests {
 
     fn completed_node(id: &str) -> NodeState {
         NodeState {
+            missing_skills: Vec::new(),
+            skills: None,
             isolated_worktree: None,
             harness: None,
             cost: None,
@@ -581,6 +585,8 @@ mod tests {
 
     fn running_node(id: &str) -> NodeState {
         NodeState {
+            missing_skills: Vec::new(),
+            skills: None,
             isolated_worktree: None,
             harness: None,
             cost: None,

--- a/crates/pdo-daemon/src/input_resolution.rs
+++ b/crates/pdo-daemon/src/input_resolution.rs
@@ -203,6 +203,8 @@ mod tests {
     fn node_with_iterations(id: &str, iters: &[(i64, NodeStatus)]) -> NodeState {
         let (head_iter, head_status) = iters.last().cloned().unwrap_or((1, NodeStatus::Pending));
         NodeState {
+            missing_skills: Vec::new(),
+            skills: None,
             isolated_worktree: None,
             harness: None,
             cost: None,
@@ -438,6 +440,7 @@ mod tests {
 
     fn node_def(id: &str, node_type: crate::pipeline::NodeType) -> crate::pipeline::NodeDef {
         crate::pipeline::NodeDef {
+            skills: Vec::new(),
             isolated_worktree: None,
             id: id.into(),
             name: id.into(),

--- a/crates/pdo-daemon/src/instance_config.rs
+++ b/crates/pdo-daemon/src/instance_config.rs
@@ -120,6 +120,12 @@ pub(crate) struct InstanceConfig {
     /// [`Self::default_harness_model`].
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent_choice: Option<crate::agent_choice::AgentChoice>,
+    /// The Instance tier of the **skills** selection (#669, ADR-0062): the
+    /// baseline every node of every Run receives, unioned with the Projet, Run
+    /// and Node tiers by `skill_selection::resolve`. Stored as a JSON list in a
+    /// nullable TEXT column; `NULL` ⇒ empty.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub skills: Vec<crate::skill_selection::SkillRef>,
     /// RFC3339-millis UTC timestamp of the last write (or the seed).
     pub updated_at: String,
 }
@@ -180,6 +186,11 @@ pub(crate) struct UpdateInstanceConfig {
     /// — this column, unlike the set-only numeric knobs, needs a genuine "clear"
     /// path back to legacy precedence.
     pub agent_choice: Option<Option<crate::agent_choice::AgentChoice>>,
+    /// Replace the Instance tier's skills selection wholesale (#669): `Some(list)`
+    /// stores it (an empty list clears to `NULL`); `None` leaves it untouched.
+    /// A flat `Option<Vec>` rather than a double-`Option`: an empty selection IS
+    /// the clear, there is no third state.
+    pub skills: Option<Vec<crate::skill_selection::SkillRef>>,
 }
 
 impl UpdateInstanceConfig {
@@ -196,6 +207,7 @@ impl UpdateInstanceConfig {
             && self.default_harness_model.is_none()
             && self.auto_fail.is_none()
             && self.agent_choice.is_none()
+            && self.skills.is_none()
     }
 }
 
@@ -372,6 +384,19 @@ pub(crate) async fn init(db: &SqlitePool) -> Result<(), sqlx::Error> {
             .await?;
     }
 
+    // Additive migration, pre-#669: the Instance tier's skills selection. NULLABLE
+    // so an existing install selects nothing.
+    let has_skills =
+        sqlx::query("SELECT 1 FROM pragma_table_info('instance_config') WHERE name = 'skills'")
+            .fetch_optional(db)
+            .await?
+            .is_some();
+    if !has_skills {
+        sqlx::query("ALTER TABLE instance_config ADD COLUMN skills TEXT")
+            .execute(db)
+            .await?;
+    }
+
     Ok(())
 }
 
@@ -399,6 +424,10 @@ fn row_to_config(row: &sqlx::sqlite::SqliteRow) -> InstanceConfig {
         agent_choice: row
             .get::<Option<String>, _>("agent_choice")
             .and_then(|s| serde_json::from_str(&s).ok()),
+        // #669: NULL / unparseable ⇒ empty selection, never an error.
+        skills: crate::skill_selection::from_stored_json(
+            row.try_get::<Option<String>, _>("skills").unwrap_or(None),
+        ),
         updated_at: row.get("updated_at"),
     }
 }
@@ -462,6 +491,9 @@ pub(crate) async fn update(
     if edit.agent_choice.is_some() {
         sets.push("agent_choice = ?");
     }
+    if edit.skills.is_some() {
+        sets.push("skills = ?");
+    }
     // Always bump the write timestamp on a real edit.
     sets.push("updated_at = ?");
 
@@ -523,6 +555,13 @@ pub(crate) async fn update(
         // #563: `Some(None)` → SQL NULL (fall back to legacy `default_harness`/
         // `default_harness_model`); `Some(Some(choice))` → the serialized JSON.
         query = query.bind(v.map(|c| serde_json::to_string(&c).unwrap_or_default()));
+    }
+    if let Some(v) = edit.skills {
+        // #669: an empty selection stores NULL — "nothing selected" and "never
+        // set" read the same, and the tier stays transparent.
+        query = query.bind(crate::skill_selection::to_stored_json(
+            &crate::skill_selection::normalise(v),
+        ));
     }
     query = query.bind(crate::event_log::now_iso());
     query.execute(db).await?;

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -73,6 +73,7 @@ mod scheduler_dispatcher;
 mod scheduler_interpreter;
 mod service_unit;
 mod skill_bank;
+mod skill_selection;
 pub mod stale_detector;
 mod stats;
 mod stats_performance;
@@ -491,6 +492,12 @@ struct CreateRunRequest {
     /// Custom)` wins outright at this tier and never merges with `harness`.
     #[serde(default)]
     agent_choice: Option<crate::agent_choice::AgentChoice>,
+    /// The Run tier of the **skills** selection (#669, ADR-0062): ids (+ label)
+    /// added to every node of this Run, on top of the instance and Projet tiers.
+    /// Frozen into `RunStarted` at the create chokepoint (only when non-empty). A
+    /// Trigger fire folds its stored list in here, like `harness`.
+    #[serde(default)]
+    skills: Vec<crate::skill_selection::SkillRef>,
     /// Whether the manager auto-names this Run. Don't collapse to `bool`: `None`
     /// (omitted) must resolve by the presence of `name`, so a supplied `name` with
     /// no flag keeps the name; `Some(b)` is an explicit choice that wins.
@@ -532,6 +539,7 @@ const CREATE_RUN_FIELDS: &[&str] = &[
     "sandbox",
     "harness",
     "agent_choice",
+    "skills",
     "auto_name",
     "auto_fail",
     "provisioning",
@@ -669,6 +677,10 @@ struct PatchProjectRequest {
     /// and then to the instance tier.
     #[serde(default, deserialize_with = "deserialize_double_option")]
     agent_choice: Option<Option<crate::agent_choice::AgentChoice>>,
+    /// The Projet's skills selection (#669), replaced wholesale: absent leaves it,
+    /// a list sets it, an empty list clears it (flat — the empty list IS the clear).
+    #[serde(default)]
+    skills: Option<Vec<crate::skill_selection::SkillRef>>,
     /// The Projet's `auto_fail` (ADR-0049), same double-`Option` shape as
     /// `harness`; `null` states no preference.
     #[serde(default, deserialize_with = "deserialize_double_option")]
@@ -1983,6 +1995,7 @@ impl DaemonHandle {
                 sandbox: None,
                 harness: None,
                 agent_choice: None,
+                skills: Vec::new(),
                 auto_name: true,
                 next_fire_at: Some("2030-01-01T00:00:00.000Z".to_string()),
             },
@@ -2962,6 +2975,10 @@ struct CreateTriggerRequest {
     /// explicit tier at fire time.
     #[serde(default)]
     agent_choice: Option<crate::agent_choice::AgentChoice>,
+    /// The Run-tier skills every fired Run carries (#669, ADR-0062). Folded into
+    /// the fired Run's `skills` at fire time, like `harness`.
+    #[serde(default)]
+    skills: Vec<crate::skill_selection::SkillRef>,
     /// Whether Runs this Trigger fires are auto-named. Seeded from the instance
     /// default in the create modal and frozen on the row; defaults to `true` so an
     /// older client that omits the field keeps auto-naming.
@@ -3267,6 +3284,8 @@ async fn create_trigger(
         // No normalisation needed: `None`/`Inherit`/blank payloads are already
         // transparent inside `agent_choice::resolve`.
         agent_choice: req.agent_choice,
+        // #669: the store normalises (trim, dedupe) and stores NULL for empty.
+        skills: req.skills,
         // Frozen on the row, never re-resolved at fire time — the runtime never
         // decides autonomy (ADR-0012 frontier).
         auto_name: req.auto_name,
@@ -3461,6 +3480,10 @@ struct PatchTriggerRequest {
     /// back to inheriting the legacy `harness` field.
     #[serde(default, deserialize_with = "deserialize_double_option")]
     agent_choice: Option<Option<crate::agent_choice::AgentChoice>>,
+    /// The Run-tier skills (#669), replaced wholesale: absent leaves them, a list
+    /// sets them, an empty list clears them. Flat: the empty list IS the clear.
+    #[serde(default)]
+    skills: Option<Vec<crate::skill_selection::SkillRef>>,
     /// Auto-naming toggle — a FLAT `Option<bool>`, deliberately not double-wrapped:
     /// there is no "inherit" state to clear back to, a Trigger's autonomy is a plain
     /// on/off.
@@ -3690,6 +3713,7 @@ async fn patch_trigger(
             .harness
             .map(|inner| inner.filter(|s| !s.trim().is_empty())),
         agent_choice: req.agent_choice,
+        skills: req.skills,
         auto_name: req.auto_name,
         next_fire_at,
         // The enable bit and the forward next_fire_at must land in ONE atomic UPDATE,
@@ -4427,6 +4451,13 @@ async fn patch_project(
         if let Err(e) = project_store::set_agent_choice(&state.db, &project_id, agent_choice).await
         {
             error!("failed to set agent_choice on project {project_id}: {e}");
+            return project_list_error();
+        }
+    }
+    // #669: replace the Projet's skills selection wholesale; an empty list clears.
+    if let Some(skills) = req.skills {
+        if let Err(e) = project_store::set_skills(&state.db, &project_id, skills).await {
+            error!("failed to set skills on project {project_id}: {e}");
             return project_list_error();
         }
     }
@@ -5358,6 +5389,9 @@ async fn fire_one_trigger(
                 // here, so they freeze the SAME harness.
                 harness: trigger.harness.clone(),
                 agent_choice: trigger.agent_choice.clone(),
+                // #669: the Trigger's skills ARE the fired Run's Run tier, same as
+                // `harness` — a cron tick and a "Run now" freeze the SAME list.
+                skills: trigger.skills.clone(),
                 // `Some(b)` wins the chokepoint resolution unconditionally, so a fire
                 // with `auto_name=false` keeps a stable per-id name.
                 auto_name: Some(trigger.auto_name),
@@ -5685,6 +5719,7 @@ fn parse_error_to_structured(e: &pipeline::ParseError) -> (String, Option<usize>
         pipeline::ParseError::MissingField(field) => {
             (format!("missing required field: {field}"), None)
         }
+        pipeline::ParseError::InvalidField(message) => (message.clone(), None),
         pipeline::ParseError::UndeclaredWhenField {
             node_id,
             port,
@@ -7267,6 +7302,7 @@ async fn parse_multipart_create_run(
     let mut sandbox: Option<event_log::SandboxMode> = None;
     let mut harness: Option<String> = None;
     let mut agent_choice: Option<crate::agent_choice::AgentChoice> = None;
+    let mut skills: Vec<crate::skill_selection::SkillRef> = Vec::new();
     let mut auto_name: Option<bool> = None;
     let mut auto_fail: Option<bool> = None;
     let mut provisioning = provisioning::ProvisioningRules::default();
@@ -7383,6 +7419,18 @@ async fn parse_multipart_create_run(
                     );
                 }
             }
+            "skills" => {
+                // #669: a JSON list of `{id, name}`, mirrored from the JSON path so a
+                // Run created WITH images keeps its skills.
+                let value = field
+                    .text()
+                    .await
+                    .map_err(|e| format!("bad field skills: {e}"))?;
+                if !value.trim().is_empty() {
+                    skills = serde_json::from_str(&value)
+                        .map_err(|e| format!("invalid skills JSON: {e}"))?;
+                }
+            }
             "auto_name" => {
                 // An unrecognised token leaves `None`, deferring to the chokepoint's
                 // name-presence resolution.
@@ -7452,6 +7500,7 @@ async fn parse_multipart_create_run(
         sandbox,
         harness,
         agent_choice,
+        skills,
         auto_name,
         auto_fail,
         provisioning,
@@ -7972,6 +8021,15 @@ async fn create_run_inner(
     };
     if let Some(choice) = explicit_agent_choice {
         run_payload["agent_choice"] = serde_json::to_value(choice).unwrap_or_default();
+    }
+    // FREEZE the Run tier of the skills selection (#669, ADR-0062) — same posture as
+    // `harness`/`agent_choice`: set once here, never re-decided by a later edit of
+    // the bank or the Trigger. Written ONLY when non-empty, so a Run that selects
+    // none keeps the historical payload shape. Not validated against the bank: an
+    // unknown id is a spawn-time WARNING, never a refusal to launch (#669 AC).
+    let run_skills = crate::skill_selection::normalise(req.skills.clone());
+    if !run_skills.is_empty() {
+        run_payload["skills"] = serde_json::to_value(&run_skills).unwrap_or_default();
     }
     // FREEZE the Run's `auto_fail` choice (ADR-0049), same immutability posture as
     // `harness`. Absent ⇒ resolve through the project / instance tiers.
@@ -8994,6 +9052,8 @@ async fn build_settings_view(state: &AppState) -> Result<serde_json::Value, sqlx
             "stored": dhm_stored,
         },
         "agent_choice": cfg.agent_choice,
+        // #669: the Instance tier of the skills selection, as stored (ids + labels).
+        "skills": cfg.skills,
         // The settings surface is where a broken descriptor is ALWAYS said.
         "harness_descriptors": harness_descriptors_view,
         "default_sandbox": {
@@ -9900,11 +9960,15 @@ async fn delete_skill(
     }
 }
 
-/// `GET /settings/skills/{id}/referents` — who selects this skill, by tier:
-/// instance, projects, pipelines (node), not-yet-started runs. **Empty in #668**
-/// (no tier selects skills yet), but the shape is the one the delete dialog
-/// renders and the one the selector tickets will fill — same pattern as
-/// `get_agent_profile_referents`.
+/// `GET /settings/skills/{id}/referents` — who selects this skill, by tier
+/// (#669, same pattern as `get_agent_profile_referents`, ADR-0057): the
+/// instance, the Projets, the Triggers, the pipelines' nodes, and the **not yet
+/// started** Runs (a `run_started` whose payload selects the id, non-terminal,
+/// with no `node_started` yet — the only Runs whose resolution still lies
+/// ahead; a Run with a spawned node already froze its content at the Run).
+///
+/// Informative, never blocking: the delete is unconditional (`skill_bank::delete`),
+/// and every referent keeps the id and shows a warning afterwards.
 async fn get_skill_referents(
     State(state): State<Arc<AppState>>,
     AxumPath(id): AxumPath<String>,
@@ -9914,12 +9978,108 @@ async fn get_skill_referents(
         Ok(None) => return skill_error_response(skill_bank::SkillError::NotFound),
         Err(error) => return storage_error_response(error),
     }
+
+    let instance = instance_config::get(&state.db)
+        .await
+        .map(|config| skill_selection::selects(&config.skills, &id))
+        .unwrap_or(false);
+
+    let projects = project_store::list(&state.db)
+        .await
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|project| skill_selection::selects(&project.skills, &id))
+        .map(|project| serde_json::json!({ "id": project.id, "name": project.name }))
+        .collect::<Vec<_>>();
+
+    let triggers = trigger_store::list(&state.db)
+        .await
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|trigger| skill_selection::selects(&trigger.skills, &id))
+        .map(|trigger| {
+            serde_json::json!({
+                "id": trigger.id,
+                "name": trigger.name,
+                "pipeline_id": trigger.pipeline_id
+            })
+        })
+        .collect::<Vec<_>>();
+
+    let pipeline_entries = instance_pipeline_dir(&state.repo_root)
+        .map(|directory| scan_pipeline_dir(&directory, "instance"))
+        .unwrap_or_default();
+    let pipelines = pipeline_entries
+        .into_iter()
+        .flat_map(|entry| {
+            let Ok(yaml) = std::fs::read_to_string(&entry.path) else {
+                return Vec::new();
+            };
+            let Ok(parsed) = pipeline::parse_pipeline(&yaml) else {
+                return Vec::new();
+            };
+            parsed
+                .pipeline
+                .nodes
+                .into_iter()
+                .filter(|node| skill_selection::selects(&node.skills, &id))
+                .map(|node| {
+                    serde_json::json!({
+                        "id": entry.id,
+                        "name": entry.name,
+                        "node_id": node.id,
+                        "scope": entry.scope
+                    })
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+
+    // One indexed pass over `run_started` payloads: non-terminal Runs that have not
+    // spawned a single node yet (same terminality test as the sandbox-profile
+    // referents, plus the "no node_started" clause that makes them *not started*).
+    let rows: Result<Vec<(String, String)>, _> = sqlx::query_as(
+        "SELECT e.run_id, e.payload FROM events e \
+         WHERE e.kind = 'run_started' AND e.payload IS NOT NULL \
+           AND NOT EXISTS ( \
+             SELECT 1 FROM events t WHERE t.run_id = e.run_id AND t.kind IN \
+               ('run_completed', 'run_failed', 'run_skipped', 'run_halted', 'run_archived', \
+                'node_started') \
+           ) \
+         ORDER BY e.ts DESC",
+    )
+    .fetch_all(&state.db)
+    .await;
+    let runs: Vec<serde_json::Value> = match rows {
+        Ok(rows) => rows
+            .iter()
+            .filter_map(|(run_id, payload)| {
+                let val = serde_json::from_str::<serde_json::Value>(payload).ok()?;
+                let skills: Vec<skill_selection::SkillRef> =
+                    serde_json::from_value(val.get("skills")?.clone()).ok()?;
+                if !skill_selection::selects(&skills, &id) {
+                    return None;
+                }
+                Some(serde_json::json!({
+                    "run_id": run_id,
+                    "pipeline_name": val.get("pipeline_name").and_then(|v| v.as_str()),
+                    "name": val.get("name").and_then(|v| v.as_str()),
+                }))
+            })
+            .collect(),
+        Err(e) => {
+            error!("failed to query runs for skill referents: {e}");
+            Vec::new()
+        }
+    };
+
     Json(serde_json::json!({
         "skill_id": id,
-        "instance": false,
-        "projects": [],
-        "pipelines": [],
-        "runs": []
+        "instance": instance,
+        "projects": projects,
+        "triggers": triggers,
+        "pipelines": pipelines,
+        "runs": runs
     }))
     .into_response()
 }
@@ -23114,6 +23274,8 @@ mod tests {
         rs.nodes.insert(
             node_id.into(),
             event_log::NodeState {
+                missing_skills: Vec::new(),
+                skills: None,
                 isolated_worktree: None,
                 harness: None,
                 cost: None,
@@ -23153,6 +23315,7 @@ mod tests {
 
     fn doc_node_def(id: &str) -> pipeline::NodeDef {
         pipeline::NodeDef {
+            skills: Vec::new(),
             isolated_worktree: None,
             id: id.into(),
             name: id.into(),
@@ -23327,6 +23490,8 @@ mod tests {
         run_state.nodes.insert(
             "a".into(),
             event_log::NodeState {
+                missing_skills: Vec::new(),
+                skills: None,
                 isolated_worktree: None,
                 harness: None,
                 cost: None,
@@ -23382,6 +23547,8 @@ mod tests {
         run_state.nodes.insert(
             "a".into(),
             event_log::NodeState {
+                missing_skills: Vec::new(),
+                skills: None,
                 isolated_worktree: None,
                 harness: None,
                 cost: None,
@@ -23405,6 +23572,8 @@ mod tests {
         run_state.nodes.insert(
             "b".into(),
             event_log::NodeState {
+                missing_skills: Vec::new(),
+                skills: None,
                 isolated_worktree: None,
                 harness: None,
                 cost: None,
@@ -23635,6 +23804,8 @@ mod tests {
             rs.nodes.insert(
                 node_id.into(),
                 event_log::NodeState {
+                    missing_skills: Vec::new(),
+                    skills: None,
                     isolated_worktree: None,
                     harness: None,
                     cost: None,
@@ -32384,6 +32555,7 @@ edges: []
         isolated: bool,
     ) -> (pipeline::PipelineDef, pipeline::NodeDef, std::path::PathBuf) {
         let node = pipeline::NodeDef {
+            skills: Vec::new(),
             isolated_worktree: Some(isolated),
             id: node_id.into(),
             name: node_id.into(),
@@ -34764,6 +34936,7 @@ edges:
             "sandbox": null,
             "harness": null,
             "agent_choice": null,
+            "skills": [],
             "auto_name": null,
             "auto_fail": null,
             "provisioning": {},

--- a/crates/pdo-daemon/src/library_store.rs
+++ b/crates/pdo-daemon/src/library_store.rs
@@ -1047,6 +1047,7 @@ mod tests {
 
     fn make_node(name: &str) -> pipeline::NodeDef {
         pipeline::NodeDef {
+            skills: Vec::new(),
             isolated_worktree: None,
             id: "test-id".to_string(),
             name: name.to_string(),

--- a/crates/pdo-daemon/src/loop_region.rs
+++ b/crates/pdo-daemon/src/loop_region.rs
@@ -507,6 +507,7 @@ mod tests {
 
     fn node(id: &str, inputs: &[&str], outputs: &[&str]) -> NodeDef {
         NodeDef {
+            skills: Vec::new(),
             isolated_worktree: None,
             id: id.into(),
             name: id.into(),

--- a/crates/pdo-daemon/src/mutation_validator.rs
+++ b/crates/pdo-daemon/src/mutation_validator.rs
@@ -206,6 +206,7 @@ mod tests {
 
     fn simple_node(id: &str, node_type: pipeline::NodeType) -> pipeline::NodeDef {
         pipeline::NodeDef {
+            skills: Vec::new(),
             isolated_worktree: None,
             id: id.to_string(),
             name: id.to_string(),
@@ -225,6 +226,7 @@ mod tests {
 
     fn loop_node(id: &str, max_iter: i64) -> pipeline::NodeDef {
         pipeline::NodeDef {
+            skills: Vec::new(),
             isolated_worktree: None,
             id: id.to_string(),
             name: id.to_string(),
@@ -263,6 +265,8 @@ mod tests {
             state.nodes.insert(
                 id.to_string(),
                 event_log::NodeState {
+                    missing_skills: Vec::new(),
+                    skills: None,
                     isolated_worktree: None,
                     harness: None,
                     cost: None,

--- a/crates/pdo-daemon/src/node_io_resolver.rs
+++ b/crates/pdo-daemon/src/node_io_resolver.rs
@@ -294,6 +294,8 @@ mod tests {
     fn run_state_with(node_id: &str, iters: &[(i64, NodeStatus)]) -> RunState {
         let (head_iter, head_status) = iters.last().cloned().unwrap_or((1, NodeStatus::Pending));
         let node = NodeState {
+            missing_skills: Vec::new(),
+            skills: None,
             isolated_worktree: None,
             harness: None,
             cost: None,
@@ -330,6 +332,7 @@ mod tests {
             variables: HashMap::new(),
             nodes: vec![
                 NodeDef {
+                    skills: Vec::new(),
                     isolated_worktree: None,
                     id: "planner".into(),
                     name: "planner".into(),
@@ -366,6 +369,7 @@ mod tests {
                     auto_fail: None,
                 },
                 NodeDef {
+                    skills: Vec::new(),
                     isolated_worktree: None,
                     id: "implementer".into(),
                     name: "implementer".into(),
@@ -532,6 +536,7 @@ mod tests {
             variables: HashMap::new(),
             nodes: vec![
                 NodeDef {
+                    skills: Vec::new(),
                     isolated_worktree: None,
                     id: "reviewer".into(),
                     name: "reviewer".into(),
@@ -558,6 +563,7 @@ mod tests {
                     auto_fail: None,
                 },
                 NodeDef {
+                    skills: Vec::new(),
                     isolated_worktree: None,
                     id: "implementer".into(),
                     name: "implementer".into(),
@@ -731,6 +737,7 @@ mod tests {
             variables: HashMap::new(),
             nodes: vec![
                 NodeDef {
+                    skills: Vec::new(),
                     isolated_worktree: None,
                     id: "a".into(),
                     name: "a".into(),
@@ -757,6 +764,7 @@ mod tests {
                     auto_fail: None,
                 },
                 NodeDef {
+                    skills: Vec::new(),
                     isolated_worktree: None,
                     id: "b".into(),
                     name: "b".into(),
@@ -783,6 +791,7 @@ mod tests {
                     auto_fail: None,
                 },
                 NodeDef {
+                    skills: Vec::new(),
                     isolated_worktree: None,
                     id: "merger".into(),
                     name: "merger".into(),
@@ -877,6 +886,7 @@ mod tests {
             variables: HashMap::new(),
             nodes: vec![
                 NodeDef {
+                    skills: Vec::new(),
                     isolated_worktree: None,
                     id: "planner".into(),
                     name: "planner".into(),
@@ -903,6 +913,7 @@ mod tests {
                     auto_fail: None,
                 },
                 NodeDef {
+                    skills: Vec::new(),
                     isolated_worktree: None,
                     id: "implementer".into(),
                     name: "implementer".into(),
@@ -963,6 +974,7 @@ mod tests {
         }
 
         let mk_node = |id: &str, has_out: bool| NodeDef {
+            skills: Vec::new(),
             isolated_worktree: None,
             id: id.into(),
             name: id.into(),
@@ -1048,6 +1060,7 @@ mod tests {
         }
 
         let mk_node = |id: &str, out: Option<&str>| NodeDef {
+            skills: Vec::new(),
             isolated_worktree: None,
             id: id.into(),
             name: id.into(),
@@ -1138,6 +1151,7 @@ mod tests {
             version: None,
             variables: HashMap::new(),
             nodes: vec![NodeDef {
+                skills: Vec::new(),
                 isolated_worktree: None,
                 id: "designer".into(),
                 name: "designer".into(),

--- a/crates/pdo-daemon/src/node_primitives.rs
+++ b/crates/pdo-daemon/src/node_primitives.rs
@@ -872,6 +872,7 @@ mod tests {
 
     fn make_node(id: &str, node_type: NodeType, inputs: &[&str], outputs: &[&str]) -> NodeDef {
         NodeDef {
+            skills: Vec::new(),
             // #653: these fixtures exercise graph wiring, not worktrees — a
             // shared-worktree node keeps them out of `git worktree add` on a
             // scratch dir. Isolation-sensitive tests state `Some(true)`.
@@ -920,6 +921,7 @@ mod tests {
 
     fn make_node_with_repeated_input(id: &str, port_name: &str) -> NodeDef {
         NodeDef {
+            skills: Vec::new(),
             isolated_worktree: None,
             id: id.into(),
             name: id.into(),
@@ -981,6 +983,8 @@ mod tests {
 
     fn running_node(id: &str, iter: i64) -> NodeState {
         NodeState {
+            missing_skills: Vec::new(),
+            skills: None,
             isolated_worktree: None,
             harness: None,
             cost: None,
@@ -1006,6 +1010,8 @@ mod tests {
 
     fn completed_node(id: &str, iter: i64) -> NodeState {
         NodeState {
+            missing_skills: Vec::new(),
+            skills: None,
             isolated_worktree: None,
             harness: None,
             cost: None,
@@ -1031,6 +1037,8 @@ mod tests {
 
     fn pending_node(id: &str) -> NodeState {
         NodeState {
+            missing_skills: Vec::new(),
+            skills: None,
             isolated_worktree: None,
             harness: None,
             cost: None,
@@ -1605,6 +1613,8 @@ mod tests {
     fn completed_node_iters(id: &str, iters: &[(i64, NodeStatus)]) -> NodeState {
         let (head_iter, head_status) = iters.last().cloned().unwrap_or((1, NodeStatus::Pending));
         NodeState {
+            missing_skills: Vec::new(),
+            skills: None,
             isolated_worktree: None,
             harness: None,
             cost: None,

--- a/crates/pdo-daemon/src/node_spawn.rs
+++ b/crates/pdo-daemon/src/node_spawn.rs
@@ -168,6 +168,26 @@ fn warn_missing_agent_profile_once(
     }
 }
 
+/// #669 (ADR-0062): say ONCE per `(run, skill id)` that a tier selected a skill
+/// the bank no longer has — the node runs without it, the inspector and the
+/// pipeline banner carry the warning, and the Run is never refused. Same dedupe
+/// as [`warn_missing_agent_profile_once`].
+fn warn_missing_skill_once(run_id: &str, missing: &crate::skill_selection::MissingSkill) {
+    use std::collections::HashSet;
+    use std::sync::Mutex;
+    static SAID: Mutex<Option<HashSet<(String, String)>>> = Mutex::new(None);
+
+    let mut guard = SAID.lock().unwrap_or_else(|e| e.into_inner());
+    let said = guard.get_or_insert_with(HashSet::new);
+    if said.insert((run_id.to_string(), missing.id.clone())) {
+        warn!(
+            "run {run_id}: skill '{}' ({}) selected at {:?} no longer exists in the bank — \
+             the node runs without it",
+            missing.name, missing.id, missing.tiers
+        );
+    }
+}
+
 /// A collection-region member (ADR-0011 / #269) reads its OWN deposited item:
 /// the fan-out deposits `_item.md` under the entry's artifact dir, one per
 /// lap — there is no separate driver node like the retired ForEach.
@@ -493,6 +513,48 @@ pub(crate) async fn spawn_node(
             warn_missing_agent_profile_once(run_id, warning);
         }
         Some(resolved.combo)
+    };
+    // #669 / ADR-0062: the **skills effectifs** of this NodeRun — the strict
+    // additive union of the four tiers, resolved HERE at spawn like the harness
+    // (ADR-0046 sharing: editing a tier reaches a node not yet launched, never a
+    // live one). The Run tier is the list FROZEN on `RunStarted`; the Projet and
+    // instance tiers are read fresh, keyed by the same primary repo as the harness
+    // above; the Node tier is the document's `skills`. The bank snapshot is taken
+    // ONCE so every id resolves against the same point in time. A DB error
+    // degrades a tier to empty — a skill lookup never fails a spawn. A `script`
+    // node carries none (refused at parse) and launches no agent: `None`.
+    let resolved_skills = if node.node_type == pipeline::NodeType::Script {
+        None
+    } else {
+        let primary_repo = projected
+            .and_then(|s| s.target_repo.clone())
+            .unwrap_or_else(|| spawn_ctx.repo_root.to_string_lossy().into_owned());
+        let project_skills =
+            match crate::project_store::skills_for_path(deps.db, &primary_repo).await {
+                Ok(skills) => skills,
+                Err(e) => {
+                    warn!("project skills lookup failed for {primary_repo}: {e}");
+                    Vec::new()
+                }
+            };
+        let instance_skills = crate::instance_config::get(deps.db)
+            .await
+            .map(|c| c.skills)
+            .unwrap_or_default();
+        let bank = crate::skill_bank::snapshot_names(deps.db)
+            .await
+            .unwrap_or_default();
+        let tiers = crate::skill_selection::SkillTiers {
+            instance: Some(&instance_skills),
+            project: Some(&project_skills),
+            run: projected.map(|s| s.skills.as_slice()),
+            node: Some(&node.skills),
+        };
+        let resolved = crate::skill_selection::resolve(&tiers, &bank);
+        for missing in &resolved.missing {
+            warn_missing_skill_once(run_id, missing);
+        }
+        Some(resolved)
     };
     let harness_descriptor = match &resolved_harness {
         None => None,
@@ -891,6 +953,15 @@ pub(crate) async fn spawn_node(
                 // resume path re-poses what was launched, never what the YAML or a
                 // tier says now (ADR-0007). `null` for a `script` node (no agent).
                 "harness": resolved_harness.as_ref().map(|r| r.harness.as_str()),
+                // #669/ADR-0062: the skills effectifs this session receives, FROZEN
+                // with their origin tier (ids + current bank names), and the ids the
+                // bank no longer had — the node runs without those, and the Run view
+                // says so. `null` / empty for a `script` node (no agent).
+                "skills": resolved_skills.as_ref().map(|r| &r.skills),
+                "missing_skills": resolved_skills
+                    .as_ref()
+                    .map(|r| r.missing.clone())
+                    .unwrap_or_default(),
                 // #473: the pinned Claude Code session id the agent launches with
                 // (`claude --session-id <uuid>`). The sweep resolves this node's
                 // transcript by it (`<uuid>.jsonl`), and the resume path re-enters

--- a/crates/pdo-daemon/src/outputs_validator.rs
+++ b/crates/pdo-daemon/src/outputs_validator.rs
@@ -295,6 +295,7 @@ mod tests {
 
     fn make_node(id: &str, outputs: Vec<Port>) -> NodeDef {
         NodeDef {
+            skills: Vec::new(),
             isolated_worktree: None,
             id: id.into(),
             name: id.into(),

--- a/crates/pdo-daemon/src/pipeline.rs
+++ b/crates/pdo-daemon/src/pipeline.rs
@@ -210,6 +210,15 @@ pub(crate) struct NodeDef {
     /// the legacy behaviour exactly. Semantic, not layout.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent_choice: Option<crate::agent_choice::AgentChoice>,
+    /// The Node tier of the **skills** selection (#669, ADR-0062): the skills this
+    /// node's NodeRun receives on top of the instance, Projet and Run tiers
+    /// (strict additive union, `skill_selection::resolve`). Referenced by **id**;
+    /// the `name` beside it is a readable label the bank re-reads at spawn.
+    /// Semantic, not layout — in the diff and the library content hash. Refused
+    /// on a `script` node at parse ([`normalize_node_value`]): a script launches
+    /// no agent, so a skill there would be a setting that silently does nothing.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub skills: Vec<crate::skill_selection::SkillRef>,
     /// The **finest** tier of [`crate::auto_fail::resolve_auto_fail`] (`node → Run
     /// → Projet → instance`): `Some(_)` overrides every coarser tier for this
     /// node's `pdo fail`. Semantic, not layout.
@@ -481,6 +490,10 @@ pub(crate) enum ParseError {
     InvalidYaml(#[from] serde_yaml::Error),
     #[error("missing required field: {0}")]
     MissingField(String),
+    /// A field that is present but meaningless where it sits (#669: `skills` on
+    /// a `script` node). Refused at parse, naming the node and the fix.
+    #[error("{0}")]
+    InvalidField(String),
     #[error("switch node '{node_id}' output '{port}': when-clause field '{field}' not found in upstream schema")]
     UndeclaredWhenField {
         node_id: String,
@@ -580,6 +593,27 @@ pub(crate) fn normalize_node_value(
 
     stamp_isolation_default(node_map);
 
+    // #669 / ADR-0062: a `script` node runs deterministic bash and launches no
+    // agent, so a `skills` selection on it can never take effect. Refused rather
+    // than dropped: a setting that silently does nothing is the failure mode the
+    // spec names (« un réglage sans signification ne peut exister en silence »).
+    if node_map
+        .get(serde_yaml::Value::String("type".into()))
+        .and_then(|v| v.as_str())
+        .is_some_and(|t| t == "script")
+    {
+        if let Some(skills) = node_map.get(serde_yaml::Value::String(SKILLS_KEY.into())) {
+            let is_empty_list = skills.as_sequence().is_some_and(|s| s.is_empty());
+            if !skills.is_null() && !is_empty_list {
+                return Err(ParseError::InvalidField(format!(
+                    "node '{node_id}': a `script` node cannot carry `skills` — a script \
+                     launches no agent, so no skill would ever be read. Remove the \
+                     `skills` key, or make the node an `agent`"
+                )));
+            }
+        }
+    }
+
     // #550: fold a legacy flat `model:` / `effort:` into `harnesses.claude.*` so
     // that a parse is lossless even before the on-disk migrator has rewritten the
     // file. The migrator persists the same fold; this is the in-memory safety net
@@ -591,6 +625,9 @@ pub(crate) fn normalize_node_value(
 
 /// The node key that says where a NodeRun works (#653, ADR-0060).
 pub(crate) const ISOLATED_WORKTREE_KEY: &str = "isolated_worktree";
+
+/// The node key carrying its skills selection (#669, ADR-0062).
+pub(crate) const SKILLS_KEY: &str = "skills";
 
 /// Write a node's isolation default into the raw YAML when the document is
 /// silent (#653, ADR-0060).
@@ -2694,6 +2731,82 @@ nodes:
         assert!(NodeType::Script.has_emergent_inputs());
     }
 
+    /// #669 / ADR-0062: a `script` node carrying `skills` is refused at parse with
+    /// a message naming the node and the fix — a skill on a node that launches no
+    /// agent would be a setting that silently does nothing.
+    #[test]
+    fn script_node_with_skills_is_refused_at_parse() {
+        let yaml = r#"
+name: script-skills
+version: "1.0"
+nodes:
+  - id: start
+    name: Start
+    type: start
+    outputs:
+      - name: user_prompt
+  - id: sh
+    name: Shell
+    type: script
+    skills:
+      - id: 11111111-1111-1111-1111-111111111111
+        name: tdd
+    outputs:
+      - name: out
+  - id: end
+    name: End
+    type: end
+    inputs:
+      - name: result
+edges:
+  - source: { node: start, port: user_prompt }
+    target: { node: sh, port: in }
+  - source: { node: sh, port: out }
+    target: { node: end, port: result }
+"#;
+        let err = parse_pipeline(yaml).unwrap_err();
+        let message = err.to_string();
+        assert!(matches!(err, ParseError::InvalidField(_)), "{message}");
+        assert!(message.contains("node 'sh'"), "{message}");
+        assert!(message.contains("`script`"), "{message}");
+        assert!(message.contains("`skills`"), "{message}");
+        // An empty list or a null is not a selection: tolerated, not refused.
+        let tolerated = yaml.replace(
+            "    skills:\n      - id: 11111111-1111-1111-1111-111111111111\n        name: tdd\n",
+            "    skills: []\n",
+        );
+        assert!(parse_pipeline(&tolerated).is_ok());
+    }
+
+    /// #669: an `agent` node's `skills` (ids + labels) round-trip through parse
+    /// and re-serialization; an absent key parses to an empty list and is omitted
+    /// on the way back out.
+    #[test]
+    fn agent_node_skills_round_trip_and_absent_is_omitted() {
+        let yaml = r#"
+id: a1
+name: Worker
+type: agent
+skills:
+  - id: 11111111-1111-1111-1111-111111111111
+    name: tdd
+  - id: 22222222-2222-2222-2222-222222222222
+    name: grilling
+"#;
+        let node: NodeDef = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(node.skills.len(), 2);
+        assert_eq!(node.skills[0].name, "tdd");
+        let round = serde_yaml::to_string(&node).unwrap();
+        assert!(round.contains("skills:"), "{round}");
+        let back: NodeDef = serde_yaml::from_str(&round).unwrap();
+        assert_eq!(back.skills, node.skills);
+
+        let bare: NodeDef = serde_yaml::from_str("id: a2\nname: X\ntype: agent\n").unwrap();
+        assert!(bare.skills.is_empty());
+        let round = serde_yaml::to_string(&bare).unwrap();
+        assert!(!round.contains("skills"), "{round}");
+    }
+
     #[test]
     fn script_node_roundtrips_via_serde() {
         let node = NodeDef {
@@ -2720,6 +2833,7 @@ nodes:
             pin_harness: None,
             harnesses: Default::default(),
             agent_choice: None,
+            skills: Vec::new(),
             auto_fail: None,
         };
         let yaml = serde_yaml::to_string(&node).unwrap();

--- a/crates/pdo-daemon/src/pipeline_migrator.rs
+++ b/crates/pdo-daemon/src/pipeline_migrator.rs
@@ -2421,6 +2421,7 @@ edges:
 
     fn make_isolated_node(id: &str) -> NodeDef {
         NodeDef {
+            skills: Vec::new(),
             isolated_worktree: Some(true),
             id: id.into(),
             name: id.into(),
@@ -2460,6 +2461,7 @@ edges:
 
     fn make_merge_node(id: &str) -> NodeDef {
         NodeDef {
+            skills: Vec::new(),
             isolated_worktree: None,
             id: id.into(),
             name: id.into(),
@@ -2499,6 +2501,7 @@ edges:
 
     fn make_shared_node(id: &str) -> NodeDef {
         NodeDef {
+            skills: Vec::new(),
             isolated_worktree: Some(false),
             id: id.into(),
             name: id.into(),

--- a/crates/pdo-daemon/src/pipeline_semantics.rs
+++ b/crates/pdo-daemon/src/pipeline_semantics.rs
@@ -143,6 +143,11 @@ struct NodeProjection<'a> {
     /// content hash — the same discipline `auto_fail` below uses.
     #[serde(skip_serializing_if = "Option::is_none")]
     agent_choice: Option<&'a crate::agent_choice::AgentChoice>,
+    /// Semantic (#669, ADR-0062): the skills a node carries change what its
+    /// NodeRun works with. `skip_serializing_if` keeps a node that selects none
+    /// byte-identical to its pre-#669 content hash.
+    #[serde(skip_serializing_if = "<[_]>::is_empty")]
+    skills: &'a [crate::skill_selection::SkillRef],
     max_iter: Option<serde_json::Value>,
     /// Legacy per-node collection driver. The frontend serializer no longer emits
     /// it, so it is absent from `SEMANTIC_FIELDS.node`; it is still a behavioural
@@ -179,6 +184,7 @@ impl<'a> NodeProjection<'a> {
             pin_harness,
             harnesses,
             agent_choice,
+            skills,
             auto_fail,
             isolated_worktree,
         } = node;
@@ -191,6 +197,7 @@ impl<'a> NodeProjection<'a> {
             pin_harness: pin_harness.as_deref(),
             harnesses,
             agent_choice: agent_choice.as_ref(),
+            skills,
             max_iter: max_iter.as_ref().map(canon_yaml),
             over: over.as_deref(),
             auto_fail: *auto_fail,
@@ -507,6 +514,15 @@ mod tests {
                 base.replace(
                     "  type: agent",
                     "  type: agent\n  harnesses:\n    claude:\n      model: opus",
+                ),
+            ),
+            (
+                // #669/ADR-0062: the skills a node carries change what its NodeRun
+                // works with — a selection edit versions the pipeline.
+                "skills",
+                base.replace(
+                    "  type: agent",
+                    "  type: agent\n  skills:\n    - id: 11111111-1111-1111-1111-111111111111\n      name: tdd",
                 ),
             ),
             (

--- a/crates/pdo-daemon/src/portable_pipeline.rs
+++ b/crates/pdo-daemon/src/portable_pipeline.rs
@@ -185,6 +185,7 @@ mod tests {
 
     fn node(id: &str, name: &str, node_type: NodeType) -> NodeDef {
         NodeDef {
+            skills: Vec::new(),
             isolated_worktree: None,
             id: id.into(),
             name: name.into(),

--- a/crates/pdo-daemon/src/project_store.rs
+++ b/crates/pdo-daemon/src/project_store.rs
@@ -36,6 +36,11 @@ pub(crate) struct Project {
     /// wins outright at this tier over [`Self::harness`] (never merges).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent_choice: Option<crate::agent_choice::AgentChoice>,
+    /// The Projet tier of the **skills** selection (#669, ADR-0062): unioned with
+    /// the instance, Run and Node tiers by `skill_selection::resolve` for every
+    /// Run whose primary repo this Projet owns. Empty ⇒ transparent.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub skills: Vec<crate::skill_selection::SkillRef>,
     /// Member repository paths, compared **verbatim** (ADR-0033). Ordered by
     /// attach time (the `rowid` of `project_members`).
     #[serde(default)]
@@ -97,6 +102,19 @@ pub(crate) async fn init(db: &SqlitePool) -> Result<(), sqlx::Error> {
             .await?;
     }
 
+    // Pre-#669 databases have no `skills` column. Guarded `ADD COLUMN`, NULLABLE
+    // so an existing Projet selects nothing.
+    let has_skills =
+        sqlx::query("SELECT 1 FROM pragma_table_info('projects') WHERE name = 'skills'")
+            .fetch_optional(db)
+            .await?
+            .is_some();
+    if !has_skills {
+        sqlx::query("ALTER TABLE projects ADD COLUMN skills TEXT")
+            .execute(db)
+            .await?;
+    }
+
     // `path` is the PRIMARY KEY: at-most-one-Projet-per-path is a schema
     // invariant. `project_id` is indexed for the members-of lookup. No FK
     // ON DELETE cascade — deletes clear members explicitly (portable, and the
@@ -139,6 +157,10 @@ fn row_to_project(row: &sqlx::sqlite::SqliteRow, members: Vec<String>) -> Projec
         agent_choice: row
             .get::<Option<String>, _>("agent_choice")
             .and_then(|s| serde_json::from_str(&s).ok()),
+        // #669: NULL / unparseable ⇒ empty selection (transparent tier).
+        skills: crate::skill_selection::from_stored_json(
+            row.try_get::<Option<String>, _>("skills").unwrap_or(None),
+        ),
         members,
     }
 }
@@ -169,6 +191,7 @@ pub(crate) async fn create(db: &SqlitePool, name: &str) -> Result<Project, sqlx:
         harness: None,
         auto_fail: None,
         agent_choice: None,
+        skills: Vec::new(),
         members: Vec::new(),
     })
 }
@@ -264,6 +287,34 @@ pub(crate) async fn set_agent_choice(
         .execute(db)
         .await?;
     Ok(res.rows_affected() > 0)
+}
+
+/// Replace the Projet's skills selection wholesale (#669). An empty list clears
+/// to SQL `NULL` — the tier goes transparent.
+pub(crate) async fn set_skills(
+    db: &SqlitePool,
+    id: &str,
+    skills: Vec<crate::skill_selection::SkillRef>,
+) -> Result<bool, sqlx::Error> {
+    let stored = crate::skill_selection::to_stored_json(&crate::skill_selection::normalise(skills));
+    let res = sqlx::query("UPDATE projects SET skills = ? WHERE id = ?")
+        .bind(stored)
+        .bind(id)
+        .execute(db)
+        .await?;
+    Ok(res.rows_affected() > 0)
+}
+
+/// The Projet tier of `skill_selection::resolve`: the skills selected by the
+/// Projet owning `path`, or empty when no Projet owns it.
+pub(crate) async fn skills_for_path(
+    db: &SqlitePool,
+    path: &str,
+) -> Result<Vec<crate::skill_selection::SkillRef>, sqlx::Error> {
+    Ok(owner_of(db, path)
+        .await?
+        .map(|p| p.skills)
+        .unwrap_or_default())
 }
 
 /// The Projet tier of [`crate::agent_choice::resolve`]. `None` ⇒ transparent —

--- a/crates/pdo-daemon/src/prompt_augmenter.rs
+++ b/crates/pdo-daemon/src/prompt_augmenter.rs
@@ -1151,6 +1151,7 @@ mod tests {
             version: Some("1.0".into()),
             variables: HashMap::new(),
             nodes: vec![NodeDef {
+                skills: Vec::new(),
                 isolated_worktree: None,
                 id: "planner".into(),
                 name: "planner".into(),
@@ -1444,6 +1445,7 @@ mod tests {
     fn script_with_repeated_laps_pipeline() -> PipelineDef {
         let mut pipeline = sample_pipeline();
         pipeline.nodes.push(NodeDef {
+            skills: Vec::new(),
             isolated_worktree: None,
             id: "collector".into(),
             name: "collector".into(),
@@ -1568,6 +1570,7 @@ mod tests {
     fn edge_based_input_resolution() {
         let mut pipeline = sample_pipeline();
         pipeline.nodes.push(NodeDef {
+            skills: Vec::new(),
             isolated_worktree: None,
             id: "implementer".into(),
             name: "implementer".into(),
@@ -1651,6 +1654,7 @@ mod tests {
             ..Default::default()
         });
         pipeline.nodes.push(NodeDef {
+            skills: Vec::new(),
             isolated_worktree: None,
             id: "implementer".into(),
             name: "implementer".into(),
@@ -1686,6 +1690,7 @@ mod tests {
         // the incoming edge. The preamble must still enumerate it.
         let mut pipeline = sample_pipeline();
         pipeline.nodes.push(NodeDef {
+            skills: Vec::new(),
             isolated_worktree: None,
             id: "implementer".into(),
             name: "implementer".into(),
@@ -1735,6 +1740,7 @@ mod tests {
         // on a declared input port. planner → implementer, port `plans`.
         let mut pipeline = sample_pipeline();
         pipeline.nodes.push(NodeDef {
+            skills: Vec::new(),
             isolated_worktree: None,
             id: "implementer".into(),
             name: "implementer".into(),
@@ -1880,6 +1886,7 @@ mod tests {
             variables: HashMap::new(),
             nodes: vec![
                 NodeDef {
+                    skills: Vec::new(),
                     isolated_worktree: None,
                     id: "planner".into(),
                     name: "planner".into(),
@@ -1906,6 +1913,7 @@ mod tests {
                     auto_fail: None,
                 },
                 NodeDef {
+                    skills: Vec::new(),
                     isolated_worktree: None,
                     id: "researcher".into(),
                     name: "researcher".into(),
@@ -1932,6 +1940,7 @@ mod tests {
                     auto_fail: None,
                 },
                 NodeDef {
+                    skills: Vec::new(),
                     isolated_worktree: None,
                     id: "implementer".into(),
                     name: "implementer".into(),
@@ -2051,6 +2060,7 @@ mod tests {
             version: None,
             variables: HashMap::new(),
             nodes: vec![NodeDef {
+                skills: Vec::new(),
                 isolated_worktree: None,
                 id: "reviewer".into(),
                 name: "reviewer".into(),
@@ -2400,6 +2410,7 @@ mod tests {
             version: None,
             variables: HashMap::new(),
             nodes: vec![NodeDef {
+                skills: Vec::new(),
                 isolated_worktree: None,
                 id: "designer".into(),
                 name: "designer".into(),
@@ -2456,6 +2467,7 @@ mod tests {
             version: None,
             variables: HashMap::new(),
             nodes: vec![NodeDef {
+                skills: Vec::new(),
                 isolated_worktree: None,
                 id: "gallery".into(),
                 name: "gallery".into(),
@@ -2507,6 +2519,7 @@ mod tests {
             version: None,
             variables: HashMap::new(),
             nodes: vec![NodeDef {
+                skills: Vec::new(),
                 isolated_worktree: None,
                 id: "node".into(),
                 name: "node".into(),

--- a/crates/pdo-daemon/src/run_advance.rs
+++ b/crates/pdo-daemon/src/run_advance.rs
@@ -495,6 +495,7 @@ mod tests {
 
     fn doc_node(id: &str) -> NodeDef {
         NodeDef {
+            skills: Vec::new(),
             isolated_worktree: None,
             id: id.into(),
             name: id.into(),
@@ -562,6 +563,8 @@ mod tests {
 
     fn completed_node(id: &str) -> NodeState {
         NodeState {
+            missing_skills: Vec::new(),
+            skills: None,
             isolated_worktree: None,
             harness: None,
             cost: None,
@@ -582,6 +585,8 @@ mod tests {
 
     fn running_node(id: &str) -> NodeState {
         NodeState {
+            missing_skills: Vec::new(),
+            skills: None,
             isolated_worktree: None,
             harness: None,
             cost: None,
@@ -726,6 +731,8 @@ mod tests {
     fn node_iter(id: &str, iter: i64, status: NodeStatus) -> NodeState {
         let completed_at = (status == NodeStatus::Completed).then(|| "t1".to_string());
         NodeState {
+            missing_skills: Vec::new(),
+            skills: None,
             isolated_worktree: None,
             harness: None,
             cost: None,

--- a/crates/pdo-daemon/src/run_command.rs
+++ b/crates/pdo-daemon/src/run_command.rs
@@ -2093,6 +2093,9 @@ async fn dispatch(state: Arc<AppState>, run_id: String, cmd: RunCommand) -> Resp
                 // harness) forwards as `None`. Unlike `sandbox` this needs no
                 // `Some`-wrapping: the create chokepoint freezes `req.harness` verbatim.
                 harness: run_state.harness.clone(),
+                // #669: a retry reproduces the original Run tier's skills, same
+                // reason as `harness` — the union must not silently shrink.
+                skills: run_state.skills.clone(),
                 // Reproduce the original Run's `AgentChoice`, like `harness`: `None`
                 // forwards as `None`, so the retry re-resolves through the legacy
                 // `harness` tier exactly as the original did.
@@ -3096,6 +3099,7 @@ mod tests {
             version: None,
             variables: HashMap::new(),
             nodes: vec![NodeDef {
+                skills: Vec::new(),
                 isolated_worktree: None,
                 id: "sw1".into(),
                 name: "switch".into(),
@@ -3164,6 +3168,7 @@ mod tests {
             version: None,
             variables: HashMap::new(),
             nodes: vec![NodeDef {
+                skills: Vec::new(),
                 isolated_worktree: None,
                 id: "b".into(),
                 name: "b".into(),

--- a/crates/pdo-daemon/src/scheduler.rs
+++ b/crates/pdo-daemon/src/scheduler.rs
@@ -1550,6 +1550,7 @@ mod tests {
 
     fn make_node(id: &str, inputs: &[&str], outputs: &[&str]) -> NodeDef {
         NodeDef {
+            skills: Vec::new(),
             isolated_worktree: None,
             id: id.into(),
             name: id.into(),
@@ -1595,6 +1596,7 @@ mod tests {
 
     fn make_end_node() -> NodeDef {
         NodeDef {
+            skills: Vec::new(),
             isolated_worktree: None,
             id: "end".into(),
             name: "End".into(),
@@ -1689,6 +1691,8 @@ mod tests {
 
     fn completed_node(id: &str) -> NodeState {
         NodeState {
+            missing_skills: Vec::new(),
+            skills: None,
             isolated_worktree: None,
             harness: None,
             cost: None,
@@ -1709,6 +1713,8 @@ mod tests {
 
     fn completed_node_iter(id: &str, iter: i64) -> NodeState {
         NodeState {
+            missing_skills: Vec::new(),
+            skills: None,
             isolated_worktree: None,
             harness: None,
             cost: None,
@@ -1729,6 +1735,8 @@ mod tests {
 
     fn running_node(id: &str) -> NodeState {
         NodeState {
+            missing_skills: Vec::new(),
+            skills: None,
             isolated_worktree: None,
             harness: None,
             cost: None,
@@ -2891,6 +2899,7 @@ mod tests {
 
     fn make_switch_node(id: &str, branch_outputs: Vec<Port>) -> NodeDef {
         NodeDef {
+            skills: Vec::new(),
             isolated_worktree: None,
             id: id.into(),
             name: id.into(),
@@ -3586,6 +3595,7 @@ mod tests {
 
     fn make_loop_node(id: &str, max_iter: i64) -> NodeDef {
         NodeDef {
+            skills: Vec::new(),
             isolated_worktree: None,
             id: id.into(),
             name: id.into(),
@@ -4136,6 +4146,7 @@ mod tests {
 
     fn make_start_node(id: &str) -> NodeDef {
         NodeDef {
+            skills: Vec::new(),
             isolated_worktree: None,
             id: id.into(),
             name: id.into(),

--- a/crates/pdo-daemon/src/scheduler_dispatcher.rs
+++ b/crates/pdo-daemon/src/scheduler_dispatcher.rs
@@ -53,6 +53,7 @@ mod tests {
 
     fn make_node(id: &str, inputs: &[&str], outputs: &[&str]) -> NodeDef {
         NodeDef {
+            skills: Vec::new(),
             isolated_worktree: None,
             id: id.into(),
             name: id.into(),
@@ -120,6 +121,8 @@ mod tests {
 
     fn running_node(id: &str) -> NodeState {
         NodeState {
+            missing_skills: Vec::new(),
+            skills: None,
             isolated_worktree: None,
             harness: None,
             cost: None,
@@ -140,6 +143,8 @@ mod tests {
 
     fn waiting_node(id: &str, iter: i64) -> NodeState {
         NodeState {
+            missing_skills: Vec::new(),
+            skills: None,
             isolated_worktree: None,
             harness: None,
             cost: None,
@@ -185,6 +190,8 @@ mod tests {
 
     fn completed_node(id: &str) -> NodeState {
         NodeState {
+            missing_skills: Vec::new(),
+            skills: None,
             isolated_worktree: None,
             harness: None,
             cost: None,

--- a/crates/pdo-daemon/src/skill_bank.rs
+++ b/crates/pdo-daemon/src/skill_bank.rs
@@ -368,6 +368,22 @@ pub(crate) async fn list(db: &SqlitePool) -> Result<Vec<Skill>, sqlx::Error> {
     Ok(rows.iter().map(row_to_skill).collect())
 }
 
+/// The `id → name` map of the whole bank, read ONCE per resolution — the
+/// snapshot `skill_selection::resolve` names skills from (identity is the id;
+/// the stored label is only a fallback for a deleted one). Same posture as
+/// `agent_profile::snapshot` (ADR-0057 ¶4).
+pub(crate) async fn snapshot_names(
+    db: &SqlitePool,
+) -> Result<std::collections::BTreeMap<String, String>, sqlx::Error> {
+    let rows = sqlx::query("SELECT id, name FROM skills")
+        .fetch_all(db)
+        .await?;
+    Ok(rows
+        .iter()
+        .map(|row| (row.get::<String, _>("id"), row.get::<String, _>("name")))
+        .collect())
+}
+
 pub(crate) async fn get(db: &SqlitePool, id: &str) -> Result<Option<Skill>, sqlx::Error> {
     let row = sqlx::query("SELECT * FROM skills WHERE id = ?")
         .bind(id)

--- a/crates/pdo-daemon/src/skill_selection.rs
+++ b/crates/pdo-daemon/src/skill_selection.rs
@@ -1,0 +1,346 @@
+//! The **skills selected per tier** and their pure resolver into the **skills
+//! effectifs** of a NodeRun (#669, spec #667, ADR-0062, CONTEXT.md §*Banque de
+//! skills*).
+//!
+//! Four additive tiers carry the same key `skills`, a list of [`SkillRef`]
+//! (`id` + `name`): the Configuration d'instance, the Projet owning the Run's
+//! primary repo, the Run (frozen into `RunStarted` at create, seeded from the
+//! Trigger for a fired Run) and the Node of the pipeline document. Unlike the
+//! agentic profile (`agent_choice`, ADR-0057) where the finest explicit tier
+//! *wins*, skills are a **strict additive union**: no tier removes a skill an
+//! outer tier selected (CONTEXT.md: « aucun tier ne retire un skill hérité »).
+//!
+//! [`resolve`] is a function without side effects, called from the same spawn
+//! seam as `agent_choice::resolve` (`node_spawn`), against a snapshot of the
+//! bank's `id → name` map taken once per spawn. Identity is the **id**: the
+//! `name` a tier stores is a label written beside it for a readable document and
+//! is re-read from the bank at resolution (a rename never breaks a selection,
+//! #668 AC). An id absent from the bank is a **warning**, never a refusal: the
+//! node runs without that skill and the pipeline banner says so (#669 AC).
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+/// One selected skill as a tier stores it: the stable id, and the label the
+/// selector showed when the choice was made. `name` is informative only.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct SkillRef {
+    pub id: String,
+    #[serde(default)]
+    pub name: String,
+}
+
+/// Which tier selected a skill. Ordered coarsest → finest, the order the
+/// selectors list inherited skills in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum SkillTier {
+    Instance,
+    Project,
+    Run,
+    Node,
+}
+
+/// Every tier's selection side by side. `None` reads as empty.
+#[derive(Debug, Default, Clone)]
+pub(crate) struct SkillTiers<'a> {
+    pub instance: Option<&'a [SkillRef]>,
+    pub project: Option<&'a [SkillRef]>,
+    pub run: Option<&'a [SkillRef]>,
+    pub node: Option<&'a [SkillRef]>,
+}
+
+/// One effective skill: the id, its **current** bank name, and every tier that
+/// selected it (a skill checked at two tiers is delivered once, attributed to
+/// both).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct EffectiveSkill {
+    pub id: String,
+    pub name: String,
+    pub tiers: Vec<SkillTier>,
+}
+
+/// A selected id the bank no longer knows. The label is the stored one, so the
+/// warning can still name what was meant.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct MissingSkill {
+    pub id: String,
+    pub name: String,
+    pub tiers: Vec<SkillTier>,
+}
+
+/// The outcome of [`resolve`]: what the NodeRun receives, and what it was
+/// promised but cannot get.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct ResolvedSkills {
+    pub skills: Vec<EffectiveSkill>,
+    pub missing: Vec<MissingSkill>,
+}
+
+/// Union the four tiers, coarsest first, de-duplicated by id. `bank` is the
+/// `id → name` snapshot: a known id takes the bank's name (labels are not
+/// identity), an unknown id lands in `missing` with the stored label.
+pub(crate) fn resolve(tiers: &SkillTiers<'_>, bank: &BTreeMap<String, String>) -> ResolvedSkills {
+    // Insertion-ordered accumulation: first tier that names an id decides its
+    // position, later tiers only add themselves to `tiers`.
+    let mut order: Vec<String> = Vec::new();
+    let mut seen: BTreeMap<String, (String, Vec<SkillTier>)> = BTreeMap::new();
+
+    let slots: [(SkillTier, Option<&[SkillRef]>); 4] = [
+        (SkillTier::Instance, tiers.instance),
+        (SkillTier::Project, tiers.project),
+        (SkillTier::Run, tiers.run),
+        (SkillTier::Node, tiers.node),
+    ];
+    for (tier, refs) in slots {
+        for skill in refs.unwrap_or(&[]) {
+            let id = skill.id.trim();
+            if id.is_empty() {
+                continue;
+            }
+            match seen.get_mut(id) {
+                Some((_, tiers)) => {
+                    if !tiers.contains(&tier) {
+                        tiers.push(tier);
+                    }
+                }
+                None => {
+                    order.push(id.to_string());
+                    seen.insert(id.to_string(), (skill.name.trim().to_string(), vec![tier]));
+                }
+            }
+        }
+    }
+
+    let mut out = ResolvedSkills::default();
+    for id in order {
+        let (label, tiers) = seen.remove(&id).expect("every ordered id was inserted");
+        match bank.get(&id) {
+            Some(name) => out.skills.push(EffectiveSkill {
+                id,
+                name: name.clone(),
+                tiers,
+            }),
+            None => out.missing.push(MissingSkill {
+                id,
+                name: label,
+                tiers,
+            }),
+        }
+    }
+    out
+}
+
+/// Deserialize a tier's stored JSON list (a nullable TEXT column). `NULL`,
+/// empty or unparseable ⇒ an empty selection — the tier is transparent, never an
+/// error (the same degrade-to-empty as `default_harness_model`).
+pub(crate) fn from_stored_json(stored: Option<String>) -> Vec<SkillRef> {
+    stored
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .and_then(|s| serde_json::from_str::<Vec<SkillRef>>(s).ok())
+        .unwrap_or_default()
+}
+
+/// Serialize a selection for a nullable TEXT column: an empty list stores
+/// `NULL`, so "nothing selected" and "never set" read the same.
+pub(crate) fn to_stored_json(skills: &[SkillRef]) -> Option<String> {
+    if skills.is_empty() {
+        None
+    } else {
+        serde_json::to_string(skills).ok()
+    }
+}
+
+/// Normalise a selection as received on the wire: trim ids, drop blanks, keep
+/// the first occurrence of each id.
+pub(crate) fn normalise(skills: Vec<SkillRef>) -> Vec<SkillRef> {
+    let mut seen = std::collections::BTreeSet::new();
+    skills
+        .into_iter()
+        .filter_map(|s| {
+            let id = s.id.trim().to_string();
+            if id.is_empty() || !seen.insert(id.clone()) {
+                return None;
+            }
+            Some(SkillRef {
+                id,
+                name: s.name.trim().to_string(),
+            })
+        })
+        .collect()
+}
+
+/// Does `skills` select `id`?
+pub(crate) fn selects(skills: &[SkillRef], id: &str) -> bool {
+    skills.iter().any(|s| s.id == id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn r(id: &str, name: &str) -> SkillRef {
+        SkillRef {
+            id: id.into(),
+            name: name.into(),
+        }
+    }
+
+    fn bank(entries: &[(&str, &str)]) -> BTreeMap<String, String> {
+        entries
+            .iter()
+            .map(|(id, name)| (id.to_string(), name.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn union_is_additive_and_attributes_each_skill_to_its_tiers() {
+        let instance = [r("a", "tdd")];
+        let project = [r("b", "grilling")];
+        let node = [r("c", "code-review")];
+        let bank = bank(&[("a", "tdd"), ("b", "grilling"), ("c", "code-review")]);
+        let resolved = resolve(
+            &SkillTiers {
+                instance: Some(&instance),
+                project: Some(&project),
+                run: None,
+                node: Some(&node),
+            },
+            &bank,
+        );
+        assert_eq!(
+            resolved.skills,
+            vec![
+                EffectiveSkill {
+                    id: "a".into(),
+                    name: "tdd".into(),
+                    tiers: vec![SkillTier::Instance]
+                },
+                EffectiveSkill {
+                    id: "b".into(),
+                    name: "grilling".into(),
+                    tiers: vec![SkillTier::Project]
+                },
+                EffectiveSkill {
+                    id: "c".into(),
+                    name: "code-review".into(),
+                    tiers: vec![SkillTier::Node]
+                },
+            ]
+        );
+        assert!(resolved.missing.is_empty());
+    }
+
+    #[test]
+    fn a_skill_selected_at_two_tiers_is_delivered_once_with_both_origins() {
+        let instance = [r("a", "tdd")];
+        let run = [r("a", "tdd"), r("d", "docs")];
+        let bank = bank(&[("a", "tdd"), ("d", "docs")]);
+        let resolved = resolve(
+            &SkillTiers {
+                instance: Some(&instance),
+                run: Some(&run),
+                ..Default::default()
+            },
+            &bank,
+        );
+        assert_eq!(resolved.skills.len(), 2);
+        assert_eq!(resolved.skills[0].id, "a");
+        assert_eq!(
+            resolved.skills[0].tiers,
+            vec![SkillTier::Instance, SkillTier::Run]
+        );
+        assert_eq!(resolved.skills[1].tiers, vec![SkillTier::Run]);
+    }
+
+    #[test]
+    fn the_bank_name_wins_over_the_stored_label() {
+        let node = [r("a", "old-label")];
+        let bank = bank(&[("a", "renamed")]);
+        let resolved = resolve(
+            &SkillTiers {
+                node: Some(&node),
+                ..Default::default()
+            },
+            &bank,
+        );
+        assert_eq!(resolved.skills[0].name, "renamed");
+    }
+
+    #[test]
+    fn an_unknown_id_is_a_warning_not_a_refusal() {
+        let project = [r("gone", "deleted-skill")];
+        let node = [r("a", "tdd")];
+        let bank = bank(&[("a", "tdd")]);
+        let resolved = resolve(
+            &SkillTiers {
+                project: Some(&project),
+                node: Some(&node),
+                ..Default::default()
+            },
+            &bank,
+        );
+        assert_eq!(resolved.skills.len(), 1);
+        assert_eq!(
+            resolved.missing,
+            vec![MissingSkill {
+                id: "gone".into(),
+                name: "deleted-skill".into(),
+                tiers: vec![SkillTier::Project]
+            }]
+        );
+    }
+
+    #[test]
+    fn empty_tiers_and_blank_ids_are_transparent() {
+        let node = [r("  ", "blank"), r("a", "tdd")];
+        let bank = bank(&[("a", "tdd")]);
+        let resolved = resolve(
+            &SkillTiers {
+                node: Some(&node),
+                ..Default::default()
+            },
+            &bank,
+        );
+        assert_eq!(resolved.skills.len(), 1);
+        assert!(resolve(&SkillTiers::default(), &bank).skills.is_empty());
+    }
+
+    #[test]
+    fn stored_json_round_trips_and_degrades_to_empty() {
+        let skills = vec![r("a", "tdd"), r("b", "grilling")];
+        let stored = to_stored_json(&skills).unwrap();
+        assert_eq!(from_stored_json(Some(stored)), skills);
+        assert_eq!(to_stored_json(&[]), None);
+        assert!(from_stored_json(None).is_empty());
+        assert!(from_stored_json(Some("not json".into())).is_empty());
+        assert!(from_stored_json(Some("   ".into())).is_empty());
+    }
+
+    #[test]
+    fn normalise_trims_dedupes_and_drops_blanks() {
+        let out = normalise(vec![
+            r(" a ", " tdd "),
+            r("a", "dup"),
+            r("", "blank"),
+            r("b", "x"),
+        ]);
+        assert_eq!(out, vec![r("a", "tdd"), r("b", "x")]);
+        assert!(selects(&out, "b"));
+        assert!(!selects(&out, "z"));
+    }
+
+    #[test]
+    fn tier_serializes_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&SkillTier::Instance).unwrap(),
+            "\"instance\""
+        );
+        let e: EffectiveSkill =
+            serde_json::from_str(r#"{"id":"a","name":"tdd","tiers":["project","node"]}"#).unwrap();
+        assert_eq!(e.tiers, vec![SkillTier::Project, SkillTier::Node]);
+    }
+}

--- a/crates/pdo-daemon/src/switch_router.rs
+++ b/crates/pdo-daemon/src/switch_router.rs
@@ -41,6 +41,7 @@ mod tests {
 
     fn make_switch(outputs: Vec<Port>) -> NodeDef {
         NodeDef {
+            skills: Vec::new(),
             isolated_worktree: None,
             id: "sw".into(),
             name: "test-switch".into(),

--- a/crates/pdo-daemon/src/trigger_scheduler.rs
+++ b/crates/pdo-daemon/src/trigger_scheduler.rs
@@ -273,6 +273,7 @@ mod tests {
 
     fn trigger(cron: &str, next_fire_at: Option<&str>) -> Trigger {
         Trigger {
+            skills: Vec::new(),
             id: "trg-1".to_string(),
             name: "t".to_string(),
             pipeline_id: "p".to_string(),

--- a/crates/pdo-daemon/src/trigger_store.rs
+++ b/crates/pdo-daemon/src/trigger_store.rs
@@ -73,6 +73,11 @@ pub(crate) struct Trigger {
     /// [`Self::harness`]. `None` ⇒ `harness` (and the tiers below it) decide.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent_choice: Option<crate::agent_choice::AgentChoice>,
+    /// The skills a fired Run carries at its **Run** tier (#669, ADR-0062). Read
+    /// at fire time and folded into the create request's `skills`, exactly like
+    /// [`Self::harness`] — no separate Trigger tier. Empty ⇒ nothing added.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub skills: Vec<crate::skill_selection::SkillRef>,
     /// Whether Runs fired from this Trigger are auto-named by the manager. A flat
     /// bool (mirror of [`Self::enabled`]), NOT a nullable inherit: the choice is
     /// frozen at creation from the instance default and read at fire time.
@@ -115,6 +120,8 @@ pub(crate) struct NewTrigger {
     pub harness: Option<String>,
     /// `None` inherits the legacy `harness` tier (and below) at fire time.
     pub agent_choice: Option<crate::agent_choice::AgentChoice>,
+    /// The Run-tier skills every fired Run carries (#669). Empty ⇒ none.
+    pub skills: Vec<crate::skill_selection::SkillRef>,
     /// Seeded from the instance default in the create modal and frozen here.
     pub auto_name: bool,
     /// First scheduled fire, computed by the caller from the cron expression.
@@ -262,6 +269,18 @@ pub(crate) async fn init(db: &SqlitePool) -> Result<(), sqlx::Error> {
             .await?;
     }
 
+    // `skills` — NULLABLE (#669): a NULL row adds no skill at the Run tier.
+    let has_skills =
+        sqlx::query("SELECT 1 FROM pragma_table_info('triggers') WHERE name = 'skills'")
+            .fetch_optional(db)
+            .await?
+            .is_some();
+    if !has_skills {
+        sqlx::query("ALTER TABLE triggers ADD COLUMN skills TEXT")
+            .execute(db)
+            .await?;
+    }
+
     // `target_repos` — NULLABLE: a NULL row fires mono-repo.
     let has_target_repos =
         sqlx::query("SELECT 1 FROM pragma_table_info('triggers') WHERE name = 'target_repos'")
@@ -347,8 +366,8 @@ pub(crate) async fn create(db: &SqlitePool, new: NewTrigger) -> Result<Trigger, 
         "INSERT INTO triggers
             (id, name, pipeline_id, pipeline_name, target_repo, target_repos, source_branch,
              input_template, variables, cron, guard_command, overlap_policy,
-             max_concurrent, sandbox, harness, agent_choice, auto_name, enabled, next_fire_at, last_fired_at, last_outcome, created_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, NULL, NULL, ?)",
+             max_concurrent, sandbox, harness, agent_choice, skills, auto_name, enabled, next_fire_at, last_fired_at, last_outcome, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, NULL, NULL, ?)",
     )
     .bind(&id)
     .bind(&new.name)
@@ -370,6 +389,9 @@ pub(crate) async fn create(db: &SqlitePool, new: NewTrigger) -> Result<Trigger, 
             .as_ref()
             .map(|c| serde_json::to_string(c).unwrap_or_default()),
     )
+    .bind(crate::skill_selection::to_stored_json(
+        &crate::skill_selection::normalise(new.skills.clone()),
+    ))
     .bind(if new.auto_name { 1_i64 } else { 0_i64 })
     .bind(&new.next_fire_at)
     .bind(&now)
@@ -406,6 +428,10 @@ fn row_to_trigger(row: &sqlx::sqlite::SqliteRow) -> Trigger {
             .ok()
             .flatten()
             .and_then(|s| serde_json::from_str(&s).ok()),
+        // #669: absence (legacy NULL) or an unparseable value adds no skill.
+        skills: crate::skill_selection::from_stored_json(
+            row.try_get::<Option<String>, _>("skills").unwrap_or(None),
+        ),
         // A legacy NULL reads as auto-name ON.
         auto_name: row.try_get::<i64, _>("auto_name").unwrap_or(1) != 0,
         enabled: row.get::<i64, _>("enabled") != 0,
@@ -580,6 +606,9 @@ pub(crate) struct UpdateTrigger {
     pub harness: Option<Option<String>>,
     /// `Some(None)` clears to NULL = the legacy `harness` tier decides again.
     pub agent_choice: Option<Option<crate::agent_choice::AgentChoice>>,
+    /// Replace the Run-tier skills wholesale (#669). A flat `Option<Vec>`: an
+    /// empty list IS the clear (stored as NULL), there is no third state.
+    pub skills: Option<Vec<crate::skill_selection::SkillRef>>,
     /// A FLAT `Option<bool>`, NOT double-wrapped: there is no "inherit" state to
     /// clear back to; the choice is a plain on/off.
     pub auto_name: Option<bool>,
@@ -606,6 +635,7 @@ impl UpdateTrigger {
             && self.sandbox.is_none()
             && self.harness.is_none()
             && self.agent_choice.is_none()
+            && self.skills.is_none()
             && self.auto_name.is_none()
             && self.next_fire_at.is_none()
             && self.enabled.is_none()
@@ -670,6 +700,9 @@ pub(crate) async fn update(
     if edit.agent_choice.is_some() {
         sets.push("agent_choice = ?");
     }
+    if edit.skills.is_some() {
+        sets.push("skills = ?");
+    }
     if edit.auto_name.is_some() {
         sets.push("auto_name = ?");
     }
@@ -730,6 +763,11 @@ pub(crate) async fn update(
                 .map(|c| serde_json::to_string(c).unwrap_or_default()),
         );
     }
+    if let Some(v) = &edit.skills {
+        query = query.bind(crate::skill_selection::to_stored_json(
+            &crate::skill_selection::normalise(v.clone()),
+        ));
+    }
     if let Some(v) = &edit.auto_name {
         // Never NULL: the column is `NOT NULL DEFAULT 1`.
         query = query.bind(if *v { 1_i64 } else { 0_i64 });
@@ -776,6 +814,7 @@ mod tests {
             sandbox: None,
             harness: None,
             agent_choice: None,
+            skills: Vec::new(),
             auto_name: true,
             next_fire_at: Some("2026-06-06T10:00:00.000Z".to_string()),
         }

--- a/crates/pdo-daemon/src/workflow_importer.rs
+++ b/crates/pdo-daemon/src/workflow_importer.rs
@@ -512,6 +512,7 @@ impl Importer {
             pin_harness: None,
             harnesses,
             agent_choice: None,
+            skills: Vec::new(),
             auto_fail: None,
         };
         self.nodes.push(node);
@@ -893,6 +894,7 @@ fn start_node() -> NodeDef {
         pin_harness: None,
         harnesses: Default::default(),
         agent_choice: None,
+        skills: Vec::new(),
         auto_fail: None,
     }
 }
@@ -915,6 +917,7 @@ fn end_node(agent_count: usize) -> NodeDef {
         pin_harness: None,
         harnesses: Default::default(),
         agent_choice: None,
+        skills: Vec::new(),
         auto_fail: None,
     }
 }

--- a/crates/pdo-daemon/tests/skill_bank.rs
+++ b/crates/pdo-daemon/tests/skill_bank.rs
@@ -867,3 +867,507 @@ async fn file_endpoints_on_an_unknown_skill_are_404() {
         .unwrap();
     assert_eq!(resp.status(), StatusCode::NOT_FOUND);
 }
+
+
+// ---------------------------------------------------------------------------
+// #669 — selection by tier, skills effectifs with origin, referents populated.
+// A real daemon, a seeded pipeline, nodes spawned through the tmux command seam
+// (a harmless `sleep`). Every assertion is an HTTP response or an event payload.
+// ---------------------------------------------------------------------------
+
+const TIER_PIPELINE: &str = "skills-tiers";
+
+fn tier_pipeline_yaml(node_skills: &str) -> String {
+    format!(
+        r#"name: skills-tiers
+version: "1.0"
+nodes:
+  - id: start
+    name: Start
+    type: start
+    outputs:
+      - name: user_prompt
+  - id: aaaaaaaa
+    name: worker
+    type: agent
+    isolated_worktree: false
+{node_skills}    outputs:
+      - name: out
+    view: {{ x: 200, y: 60 }}
+  - id: end
+    name: End
+    type: end
+    inputs:
+      - name: result
+edges:
+  - source: {{ node: start, port: user_prompt }}
+    target: {{ node: aaaaaaaa, port: task }}
+  - source: {{ node: aaaaaaaa, port: out }}
+    target: {{ node: end, port: result }}
+"#
+    )
+}
+
+fn seed_tier_pipeline(repo: &Path) -> anyhow::Result<()> {
+    let pipelines_dir = repo.join(".pdo").join("pipelines");
+    std::fs::create_dir_all(&pipelines_dir)?;
+    std::fs::write(
+        pipelines_dir.join(format!("{TIER_PIPELINE}.yaml")),
+        tier_pipeline_yaml(""),
+    )?;
+    let prompts_dir = pipelines_dir.join(format!("{TIER_PIPELINE}.prompts"));
+    std::fs::create_dir_all(&prompts_dir)?;
+    std::fs::write(prompts_dir.join("aaaaaaaa.md"), "You are the worker.\n")?;
+    let run = |args: &[&str]| -> anyhow::Result<()> {
+        let out = std::process::Command::new("git")
+            .args(args)
+            .current_dir(repo)
+            .output()?;
+        anyhow::ensure!(
+            out.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        Ok(())
+    };
+    run(&["init", "-q", "-b", "main"])?;
+    run(&["config", "user.email", "test@example.com"])?;
+    run(&["config", "user.name", "Test"])?;
+    run(&["config", "commit.gpgsign", "false"])?;
+    std::fs::write(repo.join(".gitignore"), ".pdo/runs/\n")?;
+    run(&["add", "."])?;
+    run(&["commit", "-q", "-m", "init"])?;
+    Ok(())
+}
+
+/// A valid skill named `name`, created through the API; returns its `{id, name}`
+/// reference as the tiers store it.
+async fn create_named_skill(daemon: &TestDaemon, name: &str) -> serde_json::Value {
+    let content =
+        format!("---\nname: {name}\ndescription: The {name} method.\n---\n\n# {name}\n\nBody.\n");
+    let resp = post_skill(daemon, serde_json::json!({ "content": content })).await;
+    assert_eq!(resp.status(), StatusCode::CREATED, "skill `{name}`");
+    let skill: serde_json::Value = resp.json().await.unwrap();
+    serde_json::json!({ "id": skill["id"], "name": skill["name"] })
+}
+
+async fn post_json(daemon: &TestDaemon, path: &str, body: serde_json::Value) -> reqwest::Response {
+    reqwest::Client::new()
+        .post(format!("{}{path}", daemon.url()))
+        .json(&body)
+        .send()
+        .await
+        .unwrap()
+}
+
+async fn patch_json(daemon: &TestDaemon, path: &str, body: serde_json::Value) -> reqwest::Response {
+    reqwest::Client::new()
+        .patch(format!("{}{path}", daemon.url()))
+        .json(&body)
+        .send()
+        .await
+        .unwrap()
+}
+
+async fn events_of(daemon: &TestDaemon, run_id: &str) -> Vec<serde_json::Value> {
+    let v: serde_json::Value = get_json(daemon, &format!("/runs/{run_id}/events")).await;
+    v.as_array().cloned().unwrap_or_default()
+}
+
+/// The worker node's `NodeStarted` payload, once it exists.
+async fn wait_for_node_started(daemon: &TestDaemon, run_id: &str) -> serde_json::Value {
+    for _ in 0..80 {
+        let evs = events_of(daemon, run_id).await;
+        if let Some(e) = evs
+            .iter()
+            .rev()
+            .find(|e| e["kind"] == "node_started" && e["node_id"] == "aaaaaaaa")
+        {
+            return e["payload"].clone();
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+    panic!("worker node should have started within the timeout");
+}
+
+fn skill_ids(list: &serde_json::Value) -> Vec<String> {
+    list.as_array()
+        .map(|a| {
+            a.iter()
+                .map(|s| s["id"].as_str().unwrap().to_string())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn tiers_of(list: &serde_json::Value, id: &serde_json::Value) -> serde_json::Value {
+    list.as_array()
+        .and_then(|a| a.iter().find(|s| s["id"] == *id))
+        .map(|s| s["tiers"].clone())
+        .unwrap_or(serde_json::Value::Null)
+}
+
+/// FP steps 1–2 (#669): A at the instance tier, B on the Projet owning the repo,
+/// C on the node; the node's `NodeStarted` freezes the union with each origin,
+/// and the Run projection exposes it on the node.
+#[tokio::test]
+async fn skills_of_the_four_tiers_are_unioned_at_spawn_with_their_origin() {
+    let daemon = TestDaemon::spawn(seed_tier_pipeline).await.unwrap();
+    let primary = daemon.target_repo();
+    let a = create_named_skill(&daemon, "tdd").await;
+    let b = create_named_skill(&daemon, "grilling").await;
+    let c = create_named_skill(&daemon, "code-review").await;
+    let d = create_named_skill(&daemon, "docs").await;
+
+    // Instance tier — a settings knob, read back on GET.
+    let resp = put_json(&daemon, "/settings", serde_json::json!({ "skills": [a] })).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let settings = get_json(&daemon, "/settings").await;
+    assert_eq!(
+        skill_ids(&settings["skills"]),
+        vec![a["id"].as_str().unwrap()]
+    );
+
+    // Projet tier — the Projet owning the Run's primary repo.
+    let project: serde_json::Value = post_json(
+        &daemon,
+        "/projects",
+        serde_json::json!({ "name": "Product" }),
+    )
+    .await
+    .json()
+    .await
+    .unwrap();
+    let project_id = project["id"].as_str().unwrap().to_string();
+    assert_eq!(
+        post_json(
+            &daemon,
+            &format!("/projects/{project_id}/members"),
+            serde_json::json!({ "path": primary })
+        )
+        .await
+        .status(),
+        StatusCode::OK
+    );
+    let resp = patch_json(
+        &daemon,
+        &format!("/projects/{project_id}"),
+        serde_json::json!({ "skills": [b, a] }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let project: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(skill_ids(&project["skills"]).len(), 2, "{project}");
+
+    // Node tier — the document references skills by id, name beside it.
+    let node_skills = format!(
+        "    skills:\n      - id: {}\n        name: {}\n",
+        c["id"].as_str().unwrap(),
+        c["name"].as_str().unwrap()
+    );
+    let resp = put_json(
+        &daemon,
+        &format!("/pipelines/{TIER_PIPELINE}"),
+        serde_json::json!({ "yaml": tier_pipeline_yaml(&node_skills), "prompts": {} }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // Run tier — frozen on `RunStarted` when non-empty.
+    let resp = post_json(
+        &daemon,
+        "/runs",
+        serde_json::json!({
+            "pipeline": TIER_PIPELINE,
+            "input": "go",
+            "target_repo": primary,
+            "skills": [d],
+        }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let run: serde_json::Value = resp.json().await.unwrap();
+    let run_id = run["run_id"].as_str().unwrap().to_string();
+
+    let payload = wait_for_node_started(&daemon, &run_id).await;
+    let effective = &payload["skills"];
+    assert_eq!(
+        skill_ids(effective),
+        vec![
+            a["id"].as_str().unwrap(),
+            b["id"].as_str().unwrap(),
+            d["id"].as_str().unwrap(),
+            c["id"].as_str().unwrap()
+        ],
+        "union, coarsest tier first, de-duplicated: {payload}"
+    );
+    assert_eq!(
+        tiers_of(effective, &a["id"]),
+        serde_json::json!(["instance", "project"])
+    );
+    assert_eq!(
+        tiers_of(effective, &b["id"]),
+        serde_json::json!(["project"])
+    );
+    assert_eq!(tiers_of(effective, &d["id"]), serde_json::json!(["run"]));
+    assert_eq!(tiers_of(effective, &c["id"]), serde_json::json!(["node"]));
+    assert_eq!(payload["missing_skills"], serde_json::json!([]));
+
+    // The Run tier was frozen on `RunStarted`; the projection exposes both.
+    let evs = events_of(&daemon, &run_id).await;
+    let started = evs.iter().find(|e| e["kind"] == "run_started").unwrap();
+    assert_eq!(
+        skill_ids(&started["payload"]["skills"]),
+        vec![d["id"].as_str().unwrap()]
+    );
+    let state = get_json(&daemon, &format!("/runs/{run_id}")).await;
+    assert_eq!(skill_ids(&state["skills"]), vec![d["id"].as_str().unwrap()]);
+    assert_eq!(
+        skill_ids(&state["nodes"]["aaaaaaaa"]["skills"]).len(),
+        4,
+        "{state}"
+    );
+}
+
+/// FP step 4 (#669): a skill deleted from the bank but still selected produces a
+/// warning on the node (`missing_skills`) and the Run launches anyway.
+#[tokio::test]
+async fn a_deleted_skill_is_a_warning_on_the_node_never_a_refusal_to_launch() {
+    let daemon = TestDaemon::spawn(seed_tier_pipeline).await.unwrap();
+    let gone = create_named_skill(&daemon, "ephemeral").await;
+    let kept = create_named_skill(&daemon, "kept").await;
+    let gone_id = gone["id"].as_str().unwrap().to_string();
+
+    // Selected at the instance tier, then deleted from the bank.
+    assert_eq!(
+        put_json(
+            &daemon,
+            "/settings",
+            serde_json::json!({ "skills": [gone, kept] })
+        )
+        .await
+        .status(),
+        StatusCode::OK
+    );
+    let resp = reqwest::Client::new()
+        .delete(format!("{}/settings/skills/{gone_id}", daemon.url()))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+
+    let resp = post_json(
+        &daemon,
+        "/runs",
+        serde_json::json!({ "pipeline": TIER_PIPELINE, "input": "go", "target_repo": daemon.target_repo() }),
+    )
+    .await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::CREATED,
+        "the Run launches anyway"
+    );
+    let run: serde_json::Value = resp.json().await.unwrap();
+    let run_id = run["run_id"].as_str().unwrap().to_string();
+
+    let payload = wait_for_node_started(&daemon, &run_id).await;
+    assert_eq!(
+        skill_ids(&payload["skills"]),
+        vec![kept["id"].as_str().unwrap()]
+    );
+    assert_eq!(payload["missing_skills"][0]["id"], gone_id);
+    assert_eq!(
+        payload["missing_skills"][0]["name"], "ephemeral",
+        "the stored label survives"
+    );
+    assert_eq!(
+        payload["missing_skills"][0]["tiers"],
+        serde_json::json!(["instance"])
+    );
+    let state = get_json(&daemon, &format!("/runs/{run_id}")).await;
+    assert_eq!(state["status"], "running", "{state}");
+    assert_eq!(
+        state["nodes"]["aaaaaaaa"]["missing_skills"][0]["id"],
+        gone_id
+    );
+}
+
+/// AC (#669): a `script` node carrying `skills` is refused at parse with a clear
+/// message — on the single-node parse endpoint and on a pipeline write alike.
+#[tokio::test]
+async fn a_script_node_with_skills_is_refused_at_parse_over_http() {
+    let daemon = TestDaemon::spawn(seed_tier_pipeline).await.unwrap();
+    let resp = post_json(
+        &daemon,
+        "/nodes/parse",
+        serde_json::json!({
+            "yaml": "name: sh\ntype: script\nskills:\n  - id: 11111111-1111-1111-1111-111111111111\n    name: tdd\nprompt: |\n  echo hi\n"
+        }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    let message = body.to_string();
+    assert!(message.contains("script"), "{message}");
+    assert!(message.contains("skills"), "{message}");
+
+    let yaml = tier_pipeline_yaml(
+        "    skills:\n      - id: 11111111-1111-1111-1111-111111111111\n        name: tdd\n",
+    )
+    .replace(
+        "    type: agent\n    isolated_worktree: false",
+        "    type: script\n    isolated_worktree: false",
+    );
+    let resp = put_json(
+        &daemon,
+        &format!("/pipelines/{TIER_PIPELINE}"),
+        serde_json::json!({ "yaml": yaml, "prompts": {} }),
+    )
+    .await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::BAD_REQUEST,
+        "a pipeline write is refused too"
+    );
+}
+
+/// AC (#669): `GET /settings/skills/{id}/referents` lists the instance, the
+/// Projets, the Triggers and the pipelines' nodes that select the skill — and a
+/// rename never breaks any of them (identity is the id).
+#[tokio::test]
+async fn referents_list_every_tier_that_selects_the_skill() {
+    let daemon = TestDaemon::spawn(seed_tier_pipeline).await.unwrap();
+    let primary = daemon.target_repo();
+    let s = create_named_skill(&daemon, "shared").await;
+    let other = create_named_skill(&daemon, "other").await;
+    let id = s["id"].as_str().unwrap().to_string();
+
+    // Nothing selects it yet.
+    let referents = get_json(&daemon, &format!("/settings/skills/{id}/referents")).await;
+    assert_eq!(referents["instance"], false);
+    assert_eq!(referents["projects"], serde_json::json!([]));
+    assert_eq!(referents["triggers"], serde_json::json!([]));
+    assert_eq!(referents["pipelines"], serde_json::json!([]));
+    assert!(referents["runs"].is_array());
+
+    assert_eq!(
+        put_json(
+            &daemon,
+            "/settings",
+            serde_json::json!({ "skills": [s.clone()] })
+        )
+        .await
+        .status(),
+        StatusCode::OK
+    );
+    let project: serde_json::Value = post_json(
+        &daemon,
+        "/projects",
+        serde_json::json!({ "name": "Product" }),
+    )
+    .await
+    .json()
+    .await
+    .unwrap();
+    let project_id = project["id"].as_str().unwrap().to_string();
+    post_json(
+        &daemon,
+        &format!("/projects/{project_id}/members"),
+        serde_json::json!({ "path": primary }),
+    )
+    .await;
+    assert_eq!(
+        patch_json(
+            &daemon,
+            &format!("/projects/{project_id}"),
+            serde_json::json!({ "skills": [s.clone()] })
+        )
+        .await
+        .status(),
+        StatusCode::OK
+    );
+    let trigger: serde_json::Value = post_json(
+        &daemon,
+        "/triggers",
+        serde_json::json!({
+            "name": "nightly",
+            "pipeline_id": TIER_PIPELINE,
+            "cron": "0 3 * * *",
+            "input_template": "audit",
+            "target_repo": primary,
+            "skills": [s.clone(), other.clone()],
+        }),
+    )
+    .await
+    .json()
+    .await
+    .unwrap();
+    let trigger_id = trigger["id"].as_str().unwrap().to_string();
+    assert_eq!(skill_ids(&trigger["skills"]).len(), 2, "{trigger}");
+    let node_skills = format!("    skills:\n      - id: {id}\n        name: shared\n");
+    assert_eq!(
+        put_json(
+            &daemon,
+            &format!("/pipelines/{TIER_PIPELINE}"),
+            serde_json::json!({ "yaml": tier_pipeline_yaml(&node_skills), "prompts": {} }),
+        )
+        .await
+        .status(),
+        StatusCode::OK
+    );
+
+    // A rename touches the label only: every referent still resolves.
+    assert_eq!(
+        put_json(
+            &daemon,
+            &format!("/settings/skills/{id}"),
+            serde_json::json!({ "name": "shared-renamed" })
+        )
+        .await
+        .status(),
+        StatusCode::OK
+    );
+
+    let referents = get_json(&daemon, &format!("/settings/skills/{id}/referents")).await;
+    assert_eq!(referents["skill_id"], id);
+    assert_eq!(referents["instance"], true);
+    assert_eq!(referents["projects"][0]["id"], project_id);
+    assert_eq!(referents["projects"][0]["name"], "Product");
+    assert_eq!(referents["triggers"][0]["id"], trigger_id);
+    assert_eq!(referents["pipelines"][0]["name"], TIER_PIPELINE);
+    assert_eq!(referents["pipelines"][0]["node_id"], "aaaaaaaa");
+    assert!(referents["runs"].is_array());
+
+    // `other` is referenced by the trigger only.
+    let other_id = other["id"].as_str().unwrap();
+    let referents = get_json(&daemon, &format!("/settings/skills/{other_id}/referents")).await;
+    assert_eq!(referents["instance"], false);
+    assert_eq!(referents["projects"], serde_json::json!([]));
+    assert_eq!(referents["triggers"].as_array().unwrap().len(), 1);
+    assert_eq!(referents["pipelines"], serde_json::json!([]));
+
+    // Clearing a tier: an empty list clears (flat, no double-Option).
+    assert_eq!(
+        patch_json(
+            &daemon,
+            &format!("/triggers/{trigger_id}"),
+            serde_json::json!({ "skills": [] })
+        )
+        .await
+        .status(),
+        StatusCode::OK
+    );
+    let trigger = get_json(&daemon, &format!("/triggers/{trigger_id}")).await;
+    assert!(skill_ids(&trigger["skills"]).is_empty(), "{trigger}");
+    assert_eq!(
+        put_json(&daemon, "/settings", serde_json::json!({ "skills": [] }))
+            .await
+            .status(),
+        StatusCode::OK
+    );
+    let settings = get_json(&daemon, "/settings").await;
+    assert!(skill_ids(&settings["skills"]).is_empty(), "{settings}");
+    let referents = get_json(&daemon, &format!("/settings/skills/{id}/referents")).await;
+    assert_eq!(referents["instance"], false);
+    assert_eq!(referents["triggers"], serde_json::json!([]));
+}

--- a/crates/pdo-daemon/tests/waiting_node_starvation.rs
+++ b/crates/pdo-daemon/tests/waiting_node_starvation.rs
@@ -153,7 +153,10 @@ async fn node_status(daemon: &TestDaemon, run_id: &str, node: &str) -> Option<St
 }
 
 async fn wait_for_node_status(daemon: &TestDaemon, run_id: &str, node: &str, want: &str) {
-    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    // A poll bound, not a latency assertion: under the full parallel suite (2 700+
+    // tests, one daemon per test) a scheduler tick can take several seconds to
+    // land, and a 5 s bound flaked once. The happy path returns in well under 3 s.
+    let deadline = std::time::Instant::now() + Duration::from_secs(20);
     while std::time::Instant::now() < deadline {
         if node_status(daemon, run_id, node).await.as_deref() == Some(want) {
             return;
@@ -234,7 +237,10 @@ async fn boot_recovery_redrives_a_waiting_node_after_freeing_a_slot() {
 }
 
 async fn wait_for_a_redriven_node(daemon: &TestDaemon, run_b: &str) {
-    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    // A poll bound, not a latency assertion: under the full parallel suite (2 700+
+    // tests, one daemon per test) a scheduler tick can take several seconds to
+    // land, and a 5 s bound flaked once. The happy path returns in well under 3 s.
+    let deadline = std::time::Instant::now() + Duration::from_secs(20);
     loop {
         let leaf1 = node_status(daemon, run_b, "leaf1").await;
         let leader = node_status(daemon, run_b, "leader").await;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -368,6 +368,8 @@ export default function App() {
       isEditingRun && selectedRun ? `pdo/run-${selectedRun.run_id}` : "HEAD",
     runNode:
       isEditingRun && selection.id ? selectedRun?.nodes?.[selection.id] : null,
+    // #669: the Run tier's frozen skills, shown as inherited in the inspector.
+    runSkills: isEditingRun ? selectedRun?.skills ?? undefined : undefined,
   };
 
   // Both inspector panes are always rendered (with the inactive one hidden

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,4 +1,4 @@
-import type { PipelineListEntry, PipelineDetail, PipelineDef, RunListEntry, RunState, PortDef, PortSide, PortType, FrontmatterFieldDecl, FrontmatterViolation, Trigger, TriggerFire, DaemonStatus, InstanceSettings, UpdateSettingsRequest, StatsOverview, StatsCost, StatsPerformance, SandboxProfile, SandboxProfileImage, SandboxProfileReferents, SyncCostPricesReport, Project, BranchRef, AgentChoice, AgentProfile, AgentProfileReferents, ProvisioningPlan, ProvisioningRules, Skill, SkillBank, SkillDetail, SkillFile, SkillFileContent, SkillFilesUpload, SkillFolder, SkillReferents } from "./types";
+import type { PipelineListEntry, PipelineDetail, PipelineDef, RunListEntry, RunState, PortDef, PortSide, PortType, FrontmatterFieldDecl, FrontmatterViolation, Trigger, TriggerFire, DaemonStatus, InstanceSettings, UpdateSettingsRequest, StatsOverview, StatsCost, StatsPerformance, SandboxProfile, SandboxProfileImage, SandboxProfileReferents, SyncCostPricesReport, Project, BranchRef, AgentChoice, AgentProfile, AgentProfileReferents, ProvisioningPlan, ProvisioningRules, Skill, SkillBank, SkillDetail, SkillFile, SkillFileContent, SkillFilesUpload, SkillFolder, SkillReferents, SkillRef } from "./types";
 import { foldHarnessOntoNode } from "./lib/harness";
 
 const BASE = "";
@@ -679,6 +679,9 @@ export interface CreateRunRequest {
    *  default and the `claude` floor. Frozen into `RunStarted` at the create chokepoint. */
   harness?: string;
   agent_choice?: AgentChoice;
+  /** #669/ADR-0062: the Run tier of the skills selection, frozen into `RunStarted`
+   *  when non-empty. Omit for none. */
+  skills?: SkillRef[];
   /** Whether the manager auto-names this Run (#338). The modal always sends it; omit and
    *  the server resolves back-compat by the presence of `name`, then the instance default. */
   auto_name?: boolean;
@@ -710,6 +713,7 @@ export function createRun(req: CreateRunRequest): Promise<CreateRunResponse> {
     if (req.sandbox) form.append("sandbox", req.sandbox);
     if (req.harness) form.append("harness", req.harness);
     if (req.agent_choice) form.append("agent_choice", JSON.stringify(req.agent_choice));
+    if (req.skills && req.skills.length > 0) form.append("skills", JSON.stringify(req.skills));
     if (req.auto_name !== undefined) form.append("auto_name", String(req.auto_name));
     if (req.provisioning) form.append("provisioning", JSON.stringify(req.provisioning));
     for (const file of req.images!) {
@@ -834,6 +838,8 @@ export interface CreateTriggerRequest {
    *  default. Folded into the fired Run's harness (no separate Trigger tier). */
   harness?: string | null;
   agent_choice?: AgentChoice | null;
+  /** #669: the Run-tier skills every fired Run carries. Omit for none. */
+  skills?: SkillRef[];
   /** Whether Runs this Trigger fires are auto-named (#338). Seeded from the instance
    *  default in the modal; omit → the server defaults to `true` (pre-#338 behaviour). */
   auto_name?: boolean;
@@ -880,6 +886,8 @@ export interface UpdateTriggerRequest {
    *  instance default, `undefined` leaves it unchanged. */
   harness?: string | null;
   agent_choice?: AgentChoice | null;
+  /** #669: replace the Run-tier skills wholesale; `[]` clears. */
+  skills?: SkillRef[];
   /** Auto-naming toggle (#338): a bool sets it, `undefined` leaves it unchanged. A flat
    *  bool (no clear state) — mirror of `enabled`. */
   auto_name?: boolean;
@@ -916,6 +924,8 @@ export interface UpdateProjectRequest {
   name?: string;
   harness?: string | null;
   agent_choice?: AgentChoice | null;
+  /** #669: replace the Projet's skills wholesale; `[]` clears. */
+  skills?: SkillRef[];
 }
 
 export function updateProject(

--- a/frontend/src/components/EditCanvas.archived315.test.tsx
+++ b/frontend/src/components/EditCanvas.archived315.test.tsx
@@ -49,6 +49,9 @@ vi.mock("@xyflow/react", async (importOriginal) => {
 // network so nothing fetches on mount.
 vi.mock("../api", () => ({
   fetchAgentProfiles: vi.fn().mockResolvedValue({ profiles: [] }),
+  // #669: the skills selector's reads (bank + inherited tiers), empty by default.
+  fetchSkillBank: vi.fn().mockResolvedValue({ skills: [], folders: [], root_path: "" }),
+  fetchProjects: vi.fn().mockResolvedValue([]),
   fetchLibrary: vi.fn().mockResolvedValue([]),
   fetchLibraryPipelines: vi.fn().mockResolvedValue([]),
   saveLibraryPipeline: vi.fn().mockResolvedValue({ id: "my-pipeline", scope: "repo" }),

--- a/frontend/src/components/EditCanvas.banner225.test.tsx
+++ b/frontend/src/components/EditCanvas.banner225.test.tsx
@@ -29,6 +29,9 @@ vi.mock("@xyflow/react", async (importOriginal) => {
 // network so nothing fetches on mount.
 vi.mock("../api", () => ({
   fetchAgentProfiles: vi.fn().mockResolvedValue({ profiles: [] }),
+  // #669: the skills selector's reads (bank + inherited tiers), empty by default.
+  fetchSkillBank: vi.fn().mockResolvedValue({ skills: [], folders: [], root_path: "" }),
+  fetchProjects: vi.fn().mockResolvedValue([]),
   fetchLibrary: vi.fn().mockResolvedValue([]),
   fetchLibraryPipelines: vi.fn().mockResolvedValue([]),
   saveLibraryPipeline: vi.fn().mockResolvedValue({ id: "my-pipeline", scope: "repo" }),

--- a/frontend/src/components/EditCanvas.isolation653.test.tsx
+++ b/frontend/src/components/EditCanvas.isolation653.test.tsx
@@ -25,6 +25,9 @@ vi.mock("@xyflow/react", async (importOriginal) => {
 
 vi.mock("../api", () => ({
   fetchAgentProfiles: vi.fn().mockResolvedValue({ profiles: [] }),
+  // #669: the skills selector's reads (bank + inherited tiers), empty by default.
+  fetchSkillBank: vi.fn().mockResolvedValue({ skills: [], folders: [], root_path: "" }),
+  fetchProjects: vi.fn().mockResolvedValue([]),
   fetchLibrary: vi.fn().mockResolvedValue([]),
   fetchLibraryPipelines: vi.fn().mockResolvedValue([]),
   saveLibraryPipeline: vi.fn().mockResolvedValue({ id: "p", scope: "repo" }),

--- a/frontend/src/components/EditCanvas.tsx
+++ b/frontend/src/components/EditCanvas.tsx
@@ -42,6 +42,7 @@ import { DragHighlightProvider, useIsDropTarget } from "./DragHighlightContext";
 import { useDismissedNudges } from "../hooks/useDismissedNudges";
 import { anchorHandleId, anchorsByDropOnBody, chooseAnchorSide, isEmergentInputNode } from "../lib/anchorSide";
 import { useAgentProfiles } from "../hooks/useAgentProfiles";
+import { useSkillBank } from "../hooks/useSkillBank";
 import { Bookmark, SlidersHorizontal, TriangleAlert } from "lucide-react";
 
 // The four emergent body anchor handles (#168), each pinned to its side-centre
@@ -409,6 +410,9 @@ function EditCanvasInner({ libraryEntries, onLibraryDelete, infoOpen, onToggleIn
     () => new Set(agentProfiles.map((profile) => profile.id)),
     [agentProfiles],
   );
+  // #669: the bank's ids, for the missing-skill lint above the canvas.
+  const { bank: skillBank, loaded: skillBankLoaded } = useSkillBank();
+  const skillIds = useMemo(() => new Set(skillBank.skills.map((skill) => skill.id)), [skillBank]);
   const derivedNodes = useMemo(() => {
     if (!pipeline) return [];
     const cards = deriveEditNodes(pipeline, activeRunState, agentProfileIds);
@@ -641,8 +645,22 @@ function EditCanvasInner({ libraryEntries, onLibraryDelete, infoOpen, onToggleIn
         message: `Agent profile ${choice.profile_id} no longer exists. Node ${node.name ?? node.id} falls back to the next tier. Pick a profile or set Custom.`,
       }];
     });
-    return [...lint, ...missingProfiles, ...nudges];
-  }, [tab, agentProfileIds]);
+    // #669/ADR-0062: a node selecting a skill the bank no longer has. A warning,
+    // never a refusal — the node runs without it. Only once the bank has loaded,
+    // or every skill would flash as missing on the first render.
+    const missingSkills = !skillBankLoaded
+      ? []
+      : tab.pipeline.nodes.flatMap((node) =>
+          (node.skills ?? [])
+            .filter((skill) => !skillIds.has(skill.id))
+            .map((skill) => ({
+              id: `skill:${node.id}:${skill.id}`,
+              kind: "lint" as const,
+              message: `Skill ${skill.name || skill.id} no longer exists in the bank. Node ${node.name ?? node.id} runs without it; the pipeline still launches.`,
+            })),
+        );
+    return [...lint, ...missingProfiles, ...missingSkills, ...nudges];
+  }, [tab, agentProfileIds, skillIds, skillBankLoaded]);
   // Filter BEFORE the render gate so dismissing the last nudge (with no lint)
   // collapses the whole overlay. MUST depend on `dismissed` or it won't update.
   const visibleItems = useMemo(

--- a/frontend/src/components/LintBannerDuplication.test.tsx
+++ b/frontend/src/components/LintBannerDuplication.test.tsx
@@ -30,6 +30,9 @@ vi.mock("@xyflow/react", async (importOriginal) => {
 // API client; stub the network so nothing fetches on mount.
 vi.mock("../api", () => ({
   fetchAgentProfiles: vi.fn().mockResolvedValue({ profiles: [] }),
+  // #669: the skills selector's reads (bank + inherited tiers), empty by default.
+  fetchSkillBank: vi.fn().mockResolvedValue({ skills: [], folders: [], root_path: "" }),
+  fetchProjects: vi.fn().mockResolvedValue([]),
   fetchLibrary: vi.fn().mockResolvedValue([]),
   fetchLibraryPipelines: vi.fn().mockResolvedValue([]),
   saveLibraryPipeline: vi.fn().mockResolvedValue({ id: "my-pipeline", scope: "repo" }),

--- a/frontend/src/components/NewRunModal.test.tsx
+++ b/frontend/src/components/NewRunModal.test.tsx
@@ -22,6 +22,9 @@ const makePipeline = (overrides: Partial<PipelineListEntry> = {}): PipelineListE
 
 vi.mock("../api", () => ({
   fetchAgentProfiles: vi.fn().mockResolvedValue({ profiles: [] }),
+  // #669: the skills selector's reads (bank + inherited tiers), empty by default.
+  fetchSkillBank: vi.fn().mockResolvedValue({ skills: [], folders: [], root_path: "" }),
+  fetchProjects: vi.fn().mockResolvedValue([]),
   fetchPipelines: vi.fn().mockResolvedValue([]),
   // #410: the modal fetches settings on open (default_sandbox prefill +
   // sandbox_docker greying). Default: off + Docker available. Tests override per case.

--- a/frontend/src/components/NewRunModal.tsx
+++ b/frontend/src/components/NewRunModal.tsx
@@ -13,8 +13,11 @@ import SecondaryRepoRow, {
 import GuardTestResult from "./GuardTestResult";
 import AgentControl from "./AgentControl";
 import HarnessSelect from "./HarnessSelect";
+import SkillSelector from "./SkillSelector";
 import { useAgentProfiles } from "../hooks/useAgentProfiles";
-import type { AgentChoice } from "../types";
+import { useSkillBank } from "../hooks/useSkillBank";
+import { useSkillTiers } from "../hooks/useSkillTiers";
+import type { AgentChoice, SkillRef } from "../types";
 import { CRON_PRESETS, cronToPreset, parseDailyTime, type CronPresetId } from "../cronPresets";
 import { useLaunchTargets } from "../hooks/useLaunchTargets";
 import { useRepoValidation } from "../hooks/useRepoValidation";
@@ -155,8 +158,16 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
   // the request, the only value that lets the daemon resolve its own default.
   const [harness, setHarness] = useState<string>("");
   const [agentChoice, setAgentChoice] = useState<AgentChoice>({ mode: "inherit" });
+  // #669/ADR-0062: the Run tier of the skills selection (a Trigger stores the same
+  // list for its fired Runs). Inherits the instance and the Projet of the repo.
+  const [skills, setSkills] = useState<SkillRef[]>([]);
   const harnessSeeded = useRef(false);
   const { profiles: agentProfiles } = useAgentProfiles(open);
+  const { bank: skillBank } = useSkillBank(open);
+  // The instance tier comes from the modal's own `settings` read (#452: one
+  // `GET /settings` per open); only the Projets are read here.
+  const instanceSkills = useMemo(() => settings?.skills ?? [], [settings]);
+  const { inherited: inheritedSkillTiers } = useSkillTiers(targetRepo, open, instanceSkills);
   const autoNameSeeded = useRef(false);
 
   const recentRepos = useRecentReposStore((s) => s.recentRepos);
@@ -407,6 +418,9 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
         ? openIntent.trigger.agent_choice ?? { mode: "inherit" }
         : { mode: "inherit" },
     );
+    // #669: an `edit-trigger` round-trips the Trigger's own list; a run / new
+    // trigger seeds empty (the inherited tiers stay labels, never copied).
+    setSkills(openIntent.kind === "edit-trigger" ? openIntent.trigger.skills ?? [] : []);
   }, [open, openIntent]);
 
   // #338: seed the "Auto-generated" box once per open, ref-gated (same anti-reseed guard as
@@ -583,6 +597,7 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
           runName,
           sandbox,
           harness,
+          skills,
           images,
           // #465: full list ([0] = primary, [1..] = secondaries), or undefined
           // for a mono-repo Run (keeps the request byte-identical).
@@ -600,6 +615,7 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
       setInput("");
       setOverrides({});
       setImages([]);
+      setSkills([]);
       setProvisioning(EMPTY_PROVISIONING_RULES);
       onClose();
     } catch (e) {
@@ -607,7 +623,7 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
     } finally {
       setSubmitting(false);
     }
-  }, [selectedPipeline, input, hasRequiredPrompt, overrides, onCreated, onClose, flushPendingSaves, repoValid, targetRepo, sourceBranch, buildTargetRepos, autoName, runName, images, sandbox, harness, agentChoice, settings, refreshRecentRepos, provisioning]);
+  }, [selectedPipeline, input, hasRequiredPrompt, overrides, onCreated, onClose, flushPendingSaves, repoValid, targetRepo, sourceBranch, buildTargetRepos, autoName, runName, images, sandbox, harness, skills, agentChoice, settings, refreshRecentRepos, provisioning]);
 
   const canLaunch = provisioningValid && newRunForm.canLaunch({
     repoValid,
@@ -682,6 +698,7 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
       maxConcurrent,
       sandbox,
       harness,
+      skills,
       autoName,
       variables,
       // #465: full list ([0] = primary, [1..] = secondaries), or undefined for
@@ -734,6 +751,7 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
     buildTargetRepos,
     sandbox,
     harness,
+    skills,
     autoName,
     flushPendingSaves,
     onTriggerSaved,
@@ -1175,6 +1193,26 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
                 {mode === "trigger"
                   ? "Every fired Run launches on this harness. Nodes that pin their own harness ignore it."
                   : "The harness every free node runs on for this Run. Nodes that pin their own harness ignore it."}
+              </span>
+            </div>
+
+            {/* #669/ADR-0062: the Run tier of the skills selection. Inherited from
+                the instance and the Projet owning the target repo; a Trigger stores
+                the same list for every Run it fires. */}
+            <div className="flex flex-col gap-1.5">
+              <SkillSelector
+                tier="run"
+                own={skills}
+                onChange={setSkills}
+                inherited={inheritedSkillTiers}
+                bank={skillBank}
+                label={mode === "trigger" ? "Skills — Trigger" : "Skills — New Run"}
+                testId="run-skill-selector"
+              />
+              <span className="text-fg-4" style={{ fontSize: "10.5px" }}>
+                {mode === "trigger"
+                  ? "Every fired Run adds these skills to every node, on top of the instance and project tiers."
+                  : "Added to every node of this Run, on top of the instance and project tiers. Nodes add their own."}
               </span>
             </div>
           </div>

--- a/frontend/src/components/NodeInspector.test.tsx
+++ b/frontend/src/components/NodeInspector.test.tsx
@@ -22,6 +22,9 @@ function renderInspector(props: Parameters<typeof NodeInspector>[0]) {
 
 vi.mock("../api", () => ({
   fetchAgentProfiles: vi.fn().mockResolvedValue({ profiles: [] }),
+  // #669: the skills selector's reads (bank + inherited tiers), empty by default.
+  fetchSkillBank: vi.fn().mockResolvedValue({ skills: [], folders: [], root_path: "" }),
+  fetchProjects: vi.fn().mockResolvedValue([]),
   fetchLibrary: vi.fn().mockResolvedValue([]),
   // #586: the harness pin picker now fetches /settings for its dynamic option
   // list. Resolve it with the embedded floor so the picker offers claude/opencode.

--- a/frontend/src/components/NodeInspector.tsx
+++ b/frontend/src/components/NodeInspector.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useMemo } from "react";
 import { Star } from "lucide-react";
 import { useEditStore } from "../stores/editStore";
 import type { NodeDef, NodeState, NodeType, PortDef } from "../types";
@@ -9,6 +9,10 @@ import PooledInputRow from "./PooledInputRow";
 import { useHarnessCatalog } from "../hooks/useHarnessCatalog";
 import { useAgentProfiles } from "../hooks/useAgentProfiles";
 import AgentControl from "./AgentControl";
+import SkillSelector from "./SkillSelector";
+import { useSkillBank } from "../hooks/useSkillBank";
+import { useSkillTiers } from "../hooks/useSkillTiers";
+import type { InheritedTier } from "../lib/skillSelection";
 import HarnessSelect from "./HarnessSelect";
 import ModelPicker from "./ModelPicker";
 import EffortPicker from "./EffortPicker";
@@ -44,9 +48,12 @@ export default function NodeInspector({
   inheritedProvisioning,
   provisioningGitRef = "HEAD",
   runNode,
+  runSkills,
 }: {
   libraryEntries: LibraryEntry[];
   onLibraryChanged: () => void;
+  /** #669: the Run tier's frozen skills, on a run canvas — shown as inherited. */
+  runSkills?: import("../types").SkillRef[];
   /** #653: the live NodeRun's projected state, on a run canvas. Its frozen
    *  `isolated_worktree` is what the Workspace section reads in run mode —
    *  where the iteration ACTUALLY works, which an edit no longer moves. */
@@ -104,6 +111,19 @@ export default function NodeInspector({
   // each installed/not). Called before the early return so the hook order is stable.
   const harnessCatalog = useHarnessCatalog();
   const { profiles: agentProfiles } = useAgentProfiles();
+  // #669/ADR-0062: the bank (names, folders) and the coarser tiers this node
+  // inherits — the instance selection, the Projet owning the Run's repo when one
+  // is known (run canvas), and the Run's frozen list. Called before the early
+  // return so the hook order is stable.
+  const { bank: skillBank } = useSkillBank();
+  const { inherited: inheritedTiers } = useSkillTiers(provisioningRepository || null);
+  const inheritedSkillTiers = useMemo<InheritedTier[]>(
+    () =>
+      runSkills && runSkills.length > 0
+        ? [...inheritedTiers, { tier: "run", skills: runSkills }]
+        : inheritedTiers,
+    [inheritedTiers, runSkills],
+  );
 
   if (!tab || !node) return null;
   const provisioningOpen = provisioningOpenFor === node.id;
@@ -349,6 +369,32 @@ export default function NodeInspector({
               label="Agent"
               testId="node-agent-control"
             />
+            {/* #669/ADR-0062: the Node tier of the skills selection. Own skills are
+                live; inherited ones (instance, Projet, Run) are greyed with their
+                origin; the total is the strict additive union. An id the bank lost
+                warns here and on the pipeline banner — the node still runs. */}
+            <SkillSelector
+              tier="node"
+              own={node.skills ?? []}
+              onChange={(skills) => handleField("skills", skills.length > 0 ? skills : undefined)}
+              inherited={inheritedSkillTiers}
+              bank={skillBank}
+              label="Skills"
+              testId="node-skill-selector"
+            />
+            {runNode?.skills && (
+              <p className="text-fg-4" style={{ fontSize: 9.5 }} data-testid="node-skills-frozen">
+                Frozen at spawn:{" "}
+                {runNode.skills.length === 0
+                  ? "none"
+                  : runNode.skills.map((skill) => skill.name).join(", ")}
+                {runNode.missing_skills && runNode.missing_skills.length > 0 && (
+                  <span className="text-st-blocked">
+                    {" "}· missing: {runNode.missing_skills.map((skill) => skill.name || skill.id).join(", ")}
+                  </span>
+                )}
+              </p>
+            )}
             <div className="sr-only">
               <div data-testid="node-harness" data-resolved={resolvedHarness}>
                 <HarnessSelect

--- a/frontend/src/components/ProjectEditModal.test.tsx
+++ b/frontend/src/components/ProjectEditModal.test.tsx
@@ -16,6 +16,9 @@ vi.mock("../api", () => {
   class ApiError extends Error {}
   return {
     fetchAgentProfiles: vi.fn().mockResolvedValue({ profiles: [] }),
+    // #669: the skills selector's reads (bank + inherited tiers), empty by default.
+    fetchSkillBank: vi.fn().mockResolvedValue({ skills: [], folders: [], root_path: "" }),
+    fetchProjects: vi.fn().mockResolvedValue([]),
     ApiError,
     createProject: (name: string) => createProject(name),
     updateProject: (id: string, req: unknown) => updateProject(id, req),

--- a/frontend/src/components/ProjectEditModal.tsx
+++ b/frontend/src/components/ProjectEditModal.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import type { AgentChoice, Project } from "../types";
+import type { AgentChoice, Project, SkillRef } from "../types";
 import {
   addProjectMember,
   ApiError,
@@ -12,6 +12,9 @@ import { useAgentProfiles } from "../hooks/useAgentProfiles";
 import AgentControl from "./AgentControl";
 import HarnessSelect from "./HarnessSelect";
 import PersistedProvisioningEditor from "./PersistedProvisioningEditor";
+import SkillSelector from "./SkillSelector";
+import { useSkillBank } from "../hooks/useSkillBank";
+import { announceSkillTiersChanged, useSkillTiers } from "../hooks/useSkillTiers";
 
 /**
  * The group-header pencil (#552, ADR-0046): name a Projet (or rename an existing
@@ -54,6 +57,13 @@ export default function ProjectEditModal({
   const [agentChoice, setAgentChoice] = useState<AgentChoice>(
     initialProject?.agent_choice ?? { mode: "inherit" },
   );
+  // #669/ADR-0062: the Projet tier of the skills selection; inherits the instance.
+  const [skills, setSkills] = useState<SkillRef[]>(initialProject?.skills ?? []);
+  const skillsChanged =
+    skills.map((skill) => skill.id).join("\u0000") !==
+    (initialProject?.skills ?? []).map((skill) => skill.id).join("\u0000");
+  const { bank: skillBank } = useSkillBank();
+  const { instance: instanceSkills } = useSkillTiers(null);
   const [checked, setChecked] = useState<Set<string>>(
     () => new Set(initialMemberPaths),
   );
@@ -111,6 +121,8 @@ export default function ProjectEditModal({
           // Empty select → clear the harness (null); a value sets it.
           harness: harness ? harness : null,
           ...(agentChoice.mode === "inherit" ? {} : { agent_choice: agentChoice }),
+          // #669: replaced wholesale when it changed; an empty list clears the tier.
+          ...(skillsChanged ? { skills } : {}),
         });
       } else {
         const created = await createProject(trimmedName);
@@ -118,6 +130,7 @@ export default function ProjectEditModal({
         await updateProject(projectId, {
           ...(harness ? { harness } : {}),
           ...(agentChoice.mode === "inherit" ? {} : { agent_choice: agentChoice }),
+          ...(skills.length > 0 ? { skills } : {}),
         });
       }
 
@@ -132,6 +145,7 @@ export default function ProjectEditModal({
       for (const path of current) {
         if (!desired.has(path)) await removeProjectMember(projectId, path);
       }
+      if (skillsChanged) announceSkillTiersChanged();
       onSaved();
       onClose();
     } catch (e) {
@@ -193,6 +207,18 @@ export default function ProjectEditModal({
           label="Agent — Project"
           testId="project-agent-control"
         />
+        <div className="mt-2">
+          {/* #669/ADR-0062: the Projet tier; the instance selection is inherited. */}
+          <SkillSelector
+            tier="project"
+            own={skills}
+            onChange={setSkills}
+            inherited={[{ tier: "instance", skills: instanceSkills }]}
+            bank={skillBank}
+            label="Skills — Project"
+            testId="project-skill-selector"
+          />
+        </div>
         <div className="sr-only" aria-hidden>
           <HarnessSelect
             value={harness}

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -39,6 +39,9 @@ import { useHarnessCatalog } from "../hooks/useHarnessCatalog";
 import PersistedProvisioningEditor from "./PersistedProvisioningEditor";
 import SkillBankPanel from "./SkillBankPanel";
 import { announceSkillsChanged, useSkillBank } from "../hooks/useSkillBank";
+import SkillSelector from "./SkillSelector";
+import { announceSkillTiersChanged } from "../hooks/useSkillTiers";
+import type { SkillRef } from "../types";
 
 interface Props {
   open: boolean;
@@ -378,6 +381,12 @@ function SettingsForm({
   const [agentChoice, setAgentChoice] = useState<AgentChoice | null>(
     () => settings.agent_choice ?? null,
   );
+  // #669/ADR-0062: the Instance tier of the skills selection — the baseline every
+  // node of every Run receives. No inherited tier above it.
+  const [instanceSkills, setInstanceSkills] = useState<SkillRef[]>(
+    () => settings.skills ?? [],
+  );
+  const { bank: skillBank } = useSkillBank();
   // #616 (correctif 1): the per-harness default model is a MAP keyed by harness
   // name, derived from the SERVED harness list — not two hard-coded `claude` /
   // `opencode` fields. Seeded from the stored map so every harness that already
@@ -471,6 +480,11 @@ function SettingsForm({
     if (JSON.stringify(agentChoice) !== JSON.stringify(settings.agent_choice ?? null)) {
       patch.agent_choice = agentChoice;
     }
+    // #669: sent whole when the id list changed (an empty list clears the tier).
+    const storedSkillIds = (settings.skills ?? []).map((skill) => skill.id).join("\u0000");
+    if (instanceSkills.map((skill) => skill.id).join("\u0000") !== storedSkillIds) {
+      patch.skills = instanceSkills;
+    }
     // #616 (correctif 1): build the per-harness model map from the FULL edited map,
     // dropping only trimmed-empty entries — never a two-field block. The daemon
     // replaces the stored map wholesale, so sending the whole thing is what
@@ -519,6 +533,7 @@ function SettingsForm({
     setSubmitting(true);
     try {
       await save(patch);
+      if (patch.skills) announceSkillTiersChanged();
       onSaved?.();
       onClose();
     } catch (e) {
@@ -544,6 +559,15 @@ function SettingsForm({
           allowInherit={false}
           label="Agent — Instance settings"
           testId="instance-agent-control"
+        />
+        {/* #669/ADR-0062: the instance tier of the skills selection. */}
+        <SkillSelector
+          tier="instance"
+          own={instanceSkills}
+          onChange={setInstanceSkills}
+          bank={skillBank}
+          label="Skills — Instance settings"
+          testId="instance-skill-selector"
         />
         {/* Session cap */}
         <SettingRow

--- a/frontend/src/components/SidePicker.test.tsx
+++ b/frontend/src/components/SidePicker.test.tsx
@@ -8,6 +8,9 @@ import type { NodeDef, PipelineDef } from "../types";
 
 vi.mock("../api", () => ({
   fetchAgentProfiles: vi.fn().mockResolvedValue({ profiles: [] }),
+  // #669: the skills selector's reads (bank + inherited tiers), empty by default.
+  fetchSkillBank: vi.fn().mockResolvedValue({ skills: [], folders: [], root_path: "" }),
+  fetchProjects: vi.fn().mockResolvedValue([]),
   saveToLibrary: vi.fn(),
   deleteFromLibrary: vi.fn(),
   instantiateFromLibrary: vi.fn(),

--- a/frontend/src/components/SkillBankPanel.tsx
+++ b/frontend/src/components/SkillBankPanel.tsx
@@ -1081,8 +1081,13 @@ function DeleteSkillConfirm({
   onCancel: () => void;
   onConfirm: () => void;
 }) {
+  const triggers = referents.triggers ?? [];
   const count =
-    Number(referents.instance) + referents.projects.length + referents.pipelines.length + referents.runs.length;
+    Number(referents.instance) +
+    referents.projects.length +
+    triggers.length +
+    referents.pipelines.length +
+    referents.runs.length;
   return (
     <div className="flex min-h-0 flex-1 flex-col p-5" data-testid="skill-delete">
       <h3 className="font-semibold text-fg" style={{ fontSize: "17px" }}>
@@ -1106,6 +1111,7 @@ function DeleteSkillConfirm({
         {count === 0 && <div>No live references.</div>}
         {referents.instance && <ReferentLine tier="INSTANCE" label="settings" />}
         {referents.projects.map((item) => <ReferentLine key={`p-${item.id}`} tier="PROJECT" label={item.name} />)}
+        {triggers.map((item) => <ReferentLine key={`t-${item.id}`} tier="TRIGGER" label={item.name} />)}
         {referents.pipelines.map((item, i) => (
           <ReferentLine key={`l-${item.id}-${item.node_id ?? i}`} tier="PIPELINE" label={`${item.name}${item.node_id ? ` · node ${item.node_id}` : ""}`} />
         ))}

--- a/frontend/src/components/SkillSelector.test.tsx
+++ b/frontend/src/components/SkillSelector.test.tsx
@@ -1,0 +1,144 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import SkillSelector from "./SkillSelector";
+import type { Skill, SkillBank, SkillFolder } from "../types";
+
+const skill = (id: string, name: string, folder_id: string | null = null): Skill => ({
+  id,
+  name,
+  description: `${name} description`,
+  folder_id,
+  created_at: "2026-09-03T00:00:00.000Z",
+  updated_at: "2026-09-03T00:00:00.000Z",
+});
+const folder = (id: string, name: string, parent_id: string | null = null): SkillFolder => ({
+  id,
+  name,
+  parent_id,
+  created_at: "2026-09-03T00:00:00.000Z",
+  updated_at: "2026-09-03T00:00:00.000Z",
+});
+
+const bank: SkillBank = {
+  root_path: "/tmp/.pdo/skills",
+  folders: [folder("f-method", "method")],
+  skills: [
+    skill("a", "tdd", "f-method"),
+    skill("b", "grilling", "f-method"),
+    skill("c", "code-review"),
+  ],
+};
+
+describe("SkillSelector", () => {
+  it("shows own + inherited with their origin tier and the effective total (FP step 2)", () => {
+    render(
+      <SkillSelector
+        tier="node"
+        own={[{ id: "c", name: "code-review" }]}
+        inherited={[
+          { tier: "instance", skills: [{ id: "a", name: "tdd" }] },
+          { tier: "project", skills: [{ id: "b", name: "grilling" }], label: "Product" },
+        ]}
+        bank={bank}
+        onChange={vi.fn()}
+        testId="sel"
+      />,
+    );
+    expect(screen.getByTestId("sel-count")).toHaveTextContent("3 effective skills");
+    const a = screen.getByTestId("sel-row-a");
+    expect(a).toHaveTextContent("tdd");
+    expect(a).toHaveTextContent("Instance");
+    expect(a).toHaveAttribute("data-inherited", "true");
+    expect(a).toHaveAttribute("data-own", "false");
+    expect(screen.getByTestId("sel-row-b")).toHaveTextContent("Project");
+    const c = screen.getByTestId("sel-row-c");
+    expect(c).toHaveAttribute("data-own", "true");
+    expect(c).toHaveTextContent("Node");
+    // Only an own skill can be removed here: inherited ones stay (additive union).
+    expect(screen.getByTestId("sel-remove-c")).toBeInTheDocument();
+    expect(screen.queryByTestId("sel-remove-a")).toBeNull();
+  });
+
+  it("checks and unchecks a skill of the bank, keeping inherited ones greyed and locked", () => {
+    const onChange = vi.fn();
+    render(
+      <SkillSelector
+        tier="run"
+        own={[]}
+        inherited={[{ tier: "instance", skills: [{ id: "a", name: "tdd" }] }]}
+        bank={bank}
+        onChange={onChange}
+        testId="sel"
+      />,
+    );
+    fireEvent.click(screen.getByTestId("sel"));
+    expect(screen.getByTestId("sel-popover")).toBeInTheDocument();
+    // The inherited one is checked and disabled; the free one is unchecked.
+    const inherited = screen.getByTestId("sel-check-a") as HTMLInputElement;
+    expect(inherited.checked).toBe(true);
+    expect(inherited.disabled).toBe(true);
+    const free = screen.getByTestId("sel-check-c") as HTMLInputElement;
+    expect(free.checked).toBe(false);
+    fireEvent.click(free);
+    expect(onChange).toHaveBeenLastCalledWith([{ id: "c", name: "code-review" }]);
+  });
+
+  it("checking a folder checks its skills at this instant; unchecking removes them (FP step 3)", () => {
+    const onChange = vi.fn();
+    const { rerender } = render(
+      <SkillSelector tier="run" own={[{ id: "c", name: "code-review" }]} bank={bank} onChange={onChange} testId="sel" />,
+    );
+    fireEvent.click(screen.getByTestId("sel"));
+    fireEvent.click(screen.getByTestId("sel-folder-check-f-method"));
+    expect(onChange).toHaveBeenLastCalledWith([
+      { id: "c", name: "code-review" },
+      { id: "a", name: "tdd" },
+      { id: "b", name: "grilling" },
+    ]);
+    // With every skill of the folder own, the folder reads checked and unchecks them all.
+    rerender(
+      <SkillSelector
+        tier="run"
+        own={[{ id: "c", name: "code-review" }, { id: "a", name: "tdd" }, { id: "b", name: "grilling" }]}
+        bank={bank}
+        onChange={onChange}
+        testId="sel"
+      />,
+    );
+    const box = screen.getByTestId("sel-folder-check-f-method") as HTMLInputElement;
+    expect(box.checked).toBe(true);
+    fireEvent.click(box);
+    expect(onChange).toHaveBeenLastCalledWith([{ id: "c", name: "code-review" }]);
+  });
+
+  it("warns on an id the bank no longer has, without dropping it (FP step 4)", () => {
+    render(
+      <SkillSelector
+        tier="node"
+        own={[{ id: "gone", name: "deleted-skill" }, { id: "c", name: "code-review" }]}
+        bank={bank}
+        onChange={vi.fn()}
+        testId="sel"
+      />,
+    );
+    expect(screen.getByTestId("sel-count")).toHaveTextContent("1 effective skill");
+    const row = screen.getByTestId("sel-row-gone");
+    expect(row).toHaveAttribute("data-missing", "true");
+    expect(row).toHaveTextContent("deleted-skill");
+    expect(screen.getByTestId("sel-missing")).toHaveTextContent("no longer exists in the bank");
+    expect(screen.getByTestId("sel-missing")).toHaveTextContent("runs still start");
+  });
+
+  it("names a row from the bank even when the stored label is stale", () => {
+    render(<SkillSelector tier="node" own={[{ id: "a", name: "old-label" }]} bank={bank} onChange={vi.fn()} testId="sel" />);
+    expect(screen.getByTestId("sel-row-a")).toHaveTextContent("tdd");
+    expect(screen.getByTestId("sel-row-a")).not.toHaveTextContent("old-label");
+  });
+
+  it("says the bank is empty instead of an empty list", () => {
+    render(<SkillSelector tier="instance" own={[]} bank={{ skills: [], folders: [], root_path: "" }} onChange={vi.fn()} testId="sel" />);
+    expect(screen.getByTestId("sel-count")).toHaveTextContent("No skill");
+    fireEvent.click(screen.getByTestId("sel"));
+    expect(screen.getByTestId("sel-empty")).toHaveTextContent("The bank is empty");
+  });
+});

--- a/frontend/src/components/SkillSelector.tsx
+++ b/frontend/src/components/SkillSelector.tsx
@@ -1,0 +1,286 @@
+import { useMemo, useState } from "react";
+import { ChevronDown, ChevronRight, Folder, FolderOpen, Sparkles, TriangleAlert, X } from "lucide-react";
+import type { SkillBank, SkillRef, SkillTier } from "../types";
+import { buildRows } from "../lib/skillTree";
+import {
+  addRefs,
+  allSelected,
+  effectiveCountLabel,
+  removeRef,
+  resolveEffectiveSkills,
+  skillsInFolder,
+  SKILL_TIER_LABEL,
+  toRefs,
+  type InheritedTier,
+} from "../lib/skillSelection";
+
+const EMPTY_BANK: SkillBank = { skills: [], folders: [], root_path: "" };
+
+/**
+ * The ONE skills selector (#669, ADR-0062), shared by the Configuration
+ * d'instance, the Projet editor, the Run / Trigger creation and the node
+ * inspector. Each tier shows its **own** skills (live checkboxes), the
+ * **inherited** ones greyed with their origin tier, and the **effective total**
+ * (strict additive union — no tier removes an inherited skill). Checking a
+ * folder of the bank checks its skills *at this instant* (a gesture, never a
+ * stored reference). An id the bank no longer knows is a warning row: the tier
+ * keeps the id, the NodeRun runs without it.
+ */
+export default function SkillSelector({
+  tier,
+  own,
+  onChange,
+  inherited = [],
+  bank = EMPTY_BANK,
+  label = "Skills",
+  testId = "skill-selector",
+  readOnly = false,
+}: {
+  tier: SkillTier;
+  own: SkillRef[];
+  onChange: (skills: SkillRef[]) => void;
+  inherited?: InheritedTier[];
+  bank?: SkillBank;
+  label?: string;
+  testId?: string;
+  readOnly?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const [filter, setFilter] = useState("");
+  // Folders start expanded (every skill visible at a glance); `null` = untouched.
+  const [collapsedOverride, setCollapsedOverride] = useState<Set<string> | null>(null);
+  const expanded = useMemo(() => {
+    const all = new Set(bank.folders.map((folder) => folder.id));
+    if (!collapsedOverride) return all;
+    for (const id of collapsedOverride) all.delete(id);
+    return all;
+  }, [bank, collapsedOverride]);
+
+  const resolved = useMemo(
+    () => resolveEffectiveSkills(tier, own, inherited, bank),
+    [tier, own, inherited, bank],
+  );
+  const rows = useMemo(
+    () => buildRows(bank.folders, bank.skills, expanded, filter),
+    [bank, expanded, filter],
+  );
+  const inheritedById = useMemo(() => {
+    const map = new Map<string, SkillTier[]>();
+    for (const row of resolved.rows) {
+      const others = row.tiers.filter((t) => t !== tier);
+      if (others.length > 0) map.set(row.id, others);
+    }
+    return map;
+  }, [resolved, tier]);
+  const ownIds = useMemo(() => new Set(own.map((skill) => skill.id)), [own]);
+  const hasMissing = resolved.missing.length > 0;
+  const summary = resolved.rows
+    .filter((row) => !row.missing)
+    .map((row) => row.name)
+    .join(", ");
+
+  const toggleSkill = (id: string, name: string) => {
+    if (readOnly) return;
+    onChange(ownIds.has(id) ? removeRef(own, id) : addRefs(own, [{ id, name }]));
+  };
+  const toggleFolder = (folderId: string) => {
+    if (readOnly) return;
+    const skills = skillsInFolder(folderId, bank);
+    if (skills.length === 0) return;
+    if (allSelected(own, skills)) {
+      const drop = new Set(skills.map((skill) => skill.id));
+      onChange(own.filter((skill) => !drop.has(skill.id)));
+    } else {
+      onChange(addRefs(own, toRefs(skills)));
+    }
+  };
+  const toggleExpanded = (folderId: string) => {
+    setCollapsedOverride((prev) => {
+      const next = new Set(prev ?? []);
+      if (next.has(folderId)) next.delete(folderId);
+      else next.add(folderId);
+      return next;
+    });
+  };
+
+  return (
+    <div className="relative" data-testid={`${testId}-root`}>
+      <span className="mb-1 block uppercase tracking-wider text-fg-4" style={{ fontSize: 9 }}>{label}</span>
+      <button
+        type="button"
+        data-testid={testId}
+        aria-expanded={open}
+        disabled={readOnly}
+        onClick={() => setOpen((value) => !value)}
+        className={`flex w-full items-center gap-2 rounded border bg-bg-3 px-2 py-1.5 text-left ${
+          hasMissing ? "border-st-blocked text-st-blocked" : "border-line-strong text-fg-2"
+        } ${readOnly ? "cursor-default opacity-80" : ""}`}
+      >
+        {hasMissing ? <TriangleAlert size={11} className="shrink-0" /> : <Sparkles size={11} className="shrink-0" />}
+        <span className="min-w-0 flex-1">
+          <span className="block truncate font-medium" style={{ fontSize: 10.5 }} data-testid={`${testId}-count`}>
+            {effectiveCountLabel(resolved.effectiveCount)}
+          </span>
+          <span className="block truncate font-mono text-fg-4" style={{ fontSize: 9.5 }}>
+            {summary || "Pick skills from the bank"}
+          </span>
+        </span>
+        {!readOnly && <ChevronDown size={11} className="shrink-0 text-fg-4" />}
+      </button>
+
+      {resolved.rows.length > 0 && (
+        <ul className="mt-1 flex flex-col gap-0.5" data-testid={`${testId}-effective`}>
+          {resolved.rows.map((row) => (
+            <li
+              key={row.id}
+              data-testid={`${testId}-row-${row.id}`}
+              data-own={row.own}
+              data-inherited={row.inherited}
+              data-missing={row.missing}
+              data-tiers={row.tiers.join(" ")}
+              className={`flex items-center gap-1.5 rounded px-1.5 py-0.5 ${
+                row.missing ? "text-st-blocked" : row.own ? "text-fg-2" : "text-fg-4"
+              }`}
+              style={{ fontSize: 10 }}
+            >
+              {row.missing && <TriangleAlert size={10} className="shrink-0" />}
+              <span className={`min-w-0 flex-1 truncate font-mono ${row.missing ? "line-through" : ""}`}>{row.name}</span>
+              {row.tiers.map((t) => (
+                <span
+                  key={t}
+                  data-tier={t}
+                  className={`rounded border px-1 uppercase tracking-wider ${
+                    t === tier ? "border-acc/60 text-acc" : "border-line text-fg-4"
+                  }`}
+                  style={{ fontSize: 8 }}
+                  title={t === tier ? "Selected here" : `Inherited from the ${SKILL_TIER_LABEL[t].toLowerCase()} tier`}
+                >
+                  {SKILL_TIER_LABEL[t]}
+                </span>
+              ))}
+              {row.own && !readOnly && (
+                <button
+                  type="button"
+                  aria-label={`Remove ${row.name}`}
+                  data-testid={`${testId}-remove-${row.id}`}
+                  onClick={() => onChange(removeRef(own, row.id))}
+                  className="shrink-0 rounded p-0.5 text-fg-4 hover:text-fg-2"
+                >
+                  <X size={10} />
+                </button>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+      {hasMissing && (
+        <p className="mt-1 text-st-blocked" style={{ fontSize: 9.5 }} data-testid={`${testId}-missing`}>
+          {resolved.missing.length === 1
+            ? `Skill ${resolved.missing[0].name} no longer exists in the bank. It is skipped; runs still start.`
+            : `${resolved.missing.length} selected skills no longer exist in the bank. They are skipped; runs still start.`}
+        </p>
+      )}
+
+      {open && !readOnly && (
+        <div
+          role="dialog"
+          data-testid={`${testId}-popover`}
+          className="absolute left-0 z-40 mt-1 w-full min-w-[280px] rounded border border-line-strong bg-bg-4 p-1.5 shadow-xl"
+        >
+          <input
+            type="search"
+            value={filter}
+            onChange={(event) => setFilter(event.target.value)}
+            placeholder="Filter skills…"
+            data-testid={`${testId}-filter`}
+            className="mb-1 w-full rounded border border-line bg-bg-3 px-2 py-1 text-fg outline-none focus:border-acc"
+            style={{ fontSize: 10.5 }}
+          />
+          {bank.skills.length === 0 ? (
+            <p className="px-1 py-2 text-fg-4" style={{ fontSize: 10 }} data-testid={`${testId}-empty`}>
+              The bank is empty. Add skills in Settings → Skills.
+            </p>
+          ) : (
+            <ul className="max-h-64 overflow-y-auto" data-testid={`${testId}-tree`}>
+              {rows.map((row) => {
+                if (row.ref.kind === "folder" && row.folder) {
+                  const skills = skillsInFolder(row.folder.id, bank);
+                  const checked = allSelected(own, skills);
+                  const some = !checked && skills.some((skill) => ownIds.has(skill.id));
+                  return (
+                    <li
+                      key={`f-${row.folder.id}`}
+                      className="flex items-center gap-1.5 rounded px-1 py-0.5 hover:bg-bg-3"
+                      style={{ paddingLeft: 4 + row.depth * 12, fontSize: 10.5 }}
+                      data-testid={`${testId}-folder-${row.folder.id}`}
+                    >
+                      <input
+                        type="checkbox"
+                        aria-label={`Select every skill of ${row.folder.name}`}
+                        data-testid={`${testId}-folder-check-${row.folder.id}`}
+                        checked={checked}
+                        ref={(el) => {
+                          if (el) el.indeterminate = some;
+                        }}
+                        disabled={skills.length === 0}
+                        onChange={() => toggleFolder(row.folder!.id)}
+                        className="accent-acc"
+                      />
+                      <button
+                        type="button"
+                        onClick={() => toggleExpanded(row.folder!.id)}
+                        className="flex min-w-0 flex-1 items-center gap-1 text-left text-fg-2"
+                        aria-expanded={row.expanded}
+                      >
+                        {row.expanded ? <ChevronDown size={10} /> : <ChevronRight size={10} />}
+                        {row.expanded ? <FolderOpen size={11} className="text-fg-4" /> : <Folder size={11} className="text-fg-4" />}
+                        <span className="truncate">{row.folder.name}</span>
+                        <span className="text-fg-4" style={{ fontSize: 9 }}>{row.count}</span>
+                      </button>
+                    </li>
+                  );
+                }
+                if (row.ref.kind === "skill" && row.skill) {
+                  const skill = row.skill;
+                  const isOwn = ownIds.has(skill.id);
+                  const from = inheritedById.get(skill.id);
+                  return (
+                    <li
+                      key={`s-${skill.id}`}
+                      className="flex items-center gap-1.5 rounded px-1 py-0.5 hover:bg-bg-3"
+                      style={{ paddingLeft: 4 + row.depth * 12, fontSize: 10.5 }}
+                      data-testid={`${testId}-option-${skill.id}`}
+                    >
+                      <input
+                        type="checkbox"
+                        aria-label={skill.name}
+                        data-testid={`${testId}-check-${skill.id}`}
+                        checked={isOwn || !!from}
+                        disabled={!isOwn && !!from}
+                        onChange={() => toggleSkill(skill.id, skill.name)}
+                        className="accent-acc"
+                        title={from && !isOwn ? `Inherited from the ${from.map((t) => SKILL_TIER_LABEL[t].toLowerCase()).join(", ")} tier` : undefined}
+                      />
+                      <span className={`min-w-0 flex-1 truncate font-mono ${from && !isOwn ? "text-fg-4" : "text-fg"}`}>
+                        {skill.name}
+                      </span>
+                      {from && !isOwn && (
+                        <span className="rounded border border-line px-1 uppercase tracking-wider text-fg-4" style={{ fontSize: 8 }}>
+                          {from.map((t) => SKILL_TIER_LABEL[t]).join(" · ")}
+                        </span>
+                      )}
+                    </li>
+                  );
+                }
+                return null;
+              })}
+            </ul>
+          )}
+          <p className="mt-1 border-t border-line px-1 pt-1 text-fg-4" style={{ fontSize: 9 }}>
+            Inherited skills are greyed and cannot be removed here (additive union). Checking a folder checks its skills now.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/UnifiedLeftPanel.test.tsx
+++ b/frontend/src/components/UnifiedLeftPanel.test.tsx
@@ -54,6 +54,9 @@ vi.mock("../api", () => ({
   }),
   fetchSettings: vi.fn().mockResolvedValue({}),
   fetchAgentProfiles: vi.fn().mockResolvedValue({ profiles: [] }),
+  // #669: the skills selector's reads (bank + inherited tiers), empty by default.
+  fetchSkillBank: vi.fn().mockResolvedValue({ skills: [], folders: [], root_path: "" }),
+  fetchProjects: vi.fn().mockResolvedValue([]),
 }));
 
 describe("portable pipeline import", () => {

--- a/frontend/src/hooks/useSkillTiers.ts
+++ b/frontend/src/hooks/useSkillTiers.ts
@@ -1,0 +1,93 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { fetchProjects, fetchSettings } from "../api";
+import type { Project, SkillRef } from "../types";
+import type { InheritedTier } from "../lib/skillSelection";
+import { SKILLS_CHANGED } from "./useSkillBank";
+
+/**
+ * Window bus fired after a tier's skills selection is saved (#669): instance
+ * settings, a Projet. Selectors showing that tier as *inherited* refresh.
+ */
+export const SKILL_TIERS_CHANGED = "pdo:skill-tiers-changed";
+
+export function announceSkillTiersChanged() {
+  window.dispatchEvent(new Event(SKILL_TIERS_CHANGED));
+}
+
+/**
+ * The coarser tiers a selector inherits from (#669, ADR-0062): the instance
+ * selection, and the Projet owning `repoPath` (verbatim member match, ADR-0033)
+ * when a repo is known. Read fresh on mount and on the two buses; a failed read
+ * leaves the tier empty rather than blocking the selector.
+ *
+ * `instanceSkills`: a caller that already holds `GET /settings` (the run modal,
+ * #452: one settings read per open) passes its list and no second read happens.
+ */
+export function useSkillTiers(
+  repoPath?: string | null,
+  enabled = true,
+  instanceSkills?: SkillRef[],
+) {
+  const readsSettings = instanceSkills === undefined;
+  const [fetchedInstance, setFetchedInstance] = useState<SkillRef[]>([]);
+  const [projects, setProjects] = useState<Project[]>([]);
+
+  const apply = useCallback(
+    (
+      settings: PromiseSettledResult<{ skills?: SkillRef[] } | null>,
+      list: PromiseSettledResult<Project[]>,
+    ) => {
+      if (settings.status === "fulfilled" && settings.value) {
+        setFetchedInstance(settings.value.skills ?? []);
+      }
+      if (list.status === "fulfilled" && Array.isArray(list.value)) setProjects(list.value);
+    },
+    [],
+  );
+  const read = useCallback(
+    () =>
+      Promise.allSettled([
+        readsSettings ? fetchSettings() : Promise.resolve(null),
+        fetchProjects(),
+      ]),
+    [readsSettings],
+  );
+
+  const refresh = useCallback(() => {
+    if (!enabled) return;
+    void read().then(([settings, list]) => apply(settings, list));
+  }, [enabled, read, apply]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    let cancelled = false;
+    // Initial load inline (a subscription-style callback, not a synchronous
+    // setState in the effect body); the buses re-use `refresh`.
+    void read().then(([settings, list]) => {
+      if (!cancelled) apply(settings, list);
+    });
+    window.addEventListener(SKILL_TIERS_CHANGED, refresh);
+    window.addEventListener(SKILLS_CHANGED, refresh);
+    return () => {
+      cancelled = true;
+      window.removeEventListener(SKILL_TIERS_CHANGED, refresh);
+      window.removeEventListener(SKILLS_CHANGED, refresh);
+    };
+  }, [enabled, read, apply, refresh]);
+
+  const instance = instanceSkills ?? fetchedInstance;
+
+  const project = useMemo(() => {
+    const path = repoPath?.trim();
+    if (!path) return null;
+    return projects.find((candidate) => candidate.members.includes(path)) ?? null;
+  }, [projects, repoPath]);
+
+  const inherited = useMemo<InheritedTier[]>(() => {
+    const tiers: InheritedTier[] = [{ tier: "instance", skills: instance }];
+    if (project) tiers.push({ tier: "project", skills: project.skills ?? [], label: project.name });
+    return tiers;
+  }, [instance, project]);
+
+  return { instance, project, inherited, refresh };
+}

--- a/frontend/src/lib/layoutFields.test.ts
+++ b/frontend/src/lib/layoutFields.test.ts
@@ -73,6 +73,8 @@ const NODE: Complete<NodeDef> = {
   // naming them proves nothing about emission (the serializer tests do that).
   pin_harness: "claude",
   harnesses: { claude: { model: "opus", effort: "low" } },
+  // #669/ADR-0062: the node's skills selection (semantic; emitted when non-empty).
+  skills: [{ id: "11111111-1111-1111-1111-111111111111", name: "tdd" }],
   agent_choice: { mode: "profile", profile_id: "deep-work" },
   provisioning: { copy: [".env"], hardlink: [], symlink: [] },
   // #653/ADR-0060: same caveat again — the emission proof is in

--- a/frontend/src/lib/layoutFields.ts
+++ b/frontend/src/lib/layoutFields.ts
@@ -52,7 +52,9 @@ export const SEMANTIC_FIELDS: Record<SerializerScope, readonly string[]> = {
   // #653/ADR-0060: `isolated_worktree` is SEMANTIC — moving a node between the
   // Run worktree and one of its own changes what the pipeline does, so the
   // library star and the pipeline diff must both see it.
-  node: ["id", "name", "type", "interactive", "agent_choice", "pin_harness", "harnesses", "provisioning", "max_iter", "isolated_worktree", "inputs", "outputs"] satisfies (keyof NodeDef)[],
+  // #669/ADR-0062: `skills` is SEMANTIC — the skills a node carries change what
+  // its NodeRun works with, so a selection edit versions the pipeline.
+  node: ["id", "name", "type", "interactive", "agent_choice", "skills", "pin_harness", "harnesses", "provisioning", "max_iter", "isolated_worktree", "inputs", "outputs"] satisfies (keyof NodeDef)[],
   // `side` is SEMANTIC today (emitted, not stripped) — deliberate, see #355 D5:
   // the node-library star already treats port side as identity, so the pipeline
   // diff must agree or the two stars contradict each other on the same edit.

--- a/frontend/src/lib/newRunForm.test.ts
+++ b/frontend/src/lib/newRunForm.test.ts
@@ -659,6 +659,8 @@ describe("buildTriggerCreatePayload / buildTriggerUpdatePayload", () => {
       max_concurrent: 2,
       sandbox: "minimal",
       harness: null,
+      // #669: replaced wholesale on edit; no selection clears.
+      skills: [],
       auto_name: true,
       variables: { max_iter: 5 },
     });

--- a/frontend/src/lib/newRunForm.ts
+++ b/frontend/src/lib/newRunForm.ts
@@ -4,7 +4,7 @@ import type {
   TargetRepoInput,
   UpdateTriggerRequest,
 } from "../api";
-import type { InstanceSettings, PipelineListEntry, SandboxProfileRef } from "../types";
+import type { InstanceSettings, PipelineListEntry, SandboxProfileRef, SkillRef } from "../types";
 import { presetToCron, type CronPresetId } from "../cronPresets";
 import { HARNESS_FLOOR, harnessCatalog, type HarnessCatalog } from "./harness";
 
@@ -360,6 +360,8 @@ export interface RunPayloadInput {
   sandbox: string;
   /** #551: the harness selector value — `""` (inherit) or a concrete name. */
   harness: string;
+  /** #669: the Run tier of the skills selection. Empty ⇒ the key is omitted. */
+  skills?: SkillRef[];
   images: File[];
   /** #465: `[0]` = primary, `[1..]` = secondaries. Omit / `undefined` for a mono-repo Run. */
   targetRepos?: TargetRepoInput[];
@@ -375,6 +377,7 @@ export function buildRunPayload({
   runName,
   sandbox,
   harness,
+  skills,
   images,
   targetRepos,
 }: RunPayloadInput): CreateRunRequest {
@@ -401,6 +404,9 @@ export function buildRunPayload({
     // no harness and each free node resolves through the instance default and the floor —
     // exactly the "name the default, don't copy it" contract of the selector (#452).
     harness: harness || undefined,
+    // #669: the explicit Run-tier skills. An empty list OMITS the key, so the
+    // Run adds none and the payload stays byte-identical to the pre-#669 shape.
+    skills: skills && skills.length > 0 ? skills : undefined,
     images: images.length > 0 ? images : undefined,
   };
 }
@@ -419,6 +425,8 @@ export interface TriggerPayloadInput {
   sandbox: string;
   /** #551: the harness selector value — `""` (inherit) or a concrete name. */
   harness: string;
+  /** #669: the Run-tier skills every fired Run carries. */
+  skills?: SkillRef[];
   autoName: boolean;
   variables: Record<string, unknown>;
   /** #465: `[0]` = primary, `[1..]` = secondaries. Omit / `undefined` for a mono-repo Trigger. */
@@ -443,6 +451,7 @@ export function buildTriggerUpdatePayload({
   maxConcurrent,
   sandbox,
   harness,
+  skills,
   autoName,
   variables,
   targetRepos,
@@ -468,6 +477,8 @@ export function buildTriggerUpdatePayload({
     // #551: `""` (Use instance default) clears back to inheriting (`null`); a concrete
     // harness name sets it. Mirror of `sandbox`.
     harness: harness || null,
+    // #669: replaced wholesale on edit — an empty list clears the Trigger's skills.
+    skills: skills ?? [],
     // #338: round-trip the auto-naming choice (flat bool, mirror of `enabled`).
     auto_name: autoName,
     variables,
@@ -486,6 +497,7 @@ export function buildTriggerCreatePayload({
   maxConcurrent,
   sandbox,
   harness,
+  skills,
   autoName,
   variables,
   targetRepos,
@@ -506,6 +518,8 @@ export function buildTriggerCreatePayload({
     sandbox: sandbox || null,
     // #551: `""` (Use instance default) → `null` (inherit); a concrete harness sets it.
     harness: harness || null,
+    // #669: the Run-tier skills every fired Run carries; omitted when none.
+    ...(skills && skills.length > 0 ? { skills } : {}),
     // #338: freeze the auto-naming choice on the new Trigger (seeded from the
     // instance default when the modal opened).
     auto_name: autoName,

--- a/frontend/src/lib/serializePipeline.ts
+++ b/frontend/src/lib/serializePipeline.ts
@@ -111,6 +111,11 @@ export function pipelineToYamlObject(p: PipelineDef): Record<string, unknown> {
     if (n.agent_choice && n.agent_choice.mode !== "inherit") {
       node.agent_choice = n.agent_choice;
     }
+    // #669/ADR-0062: the node's skills, by id with their label, emitted only when
+    // non-empty so an unset node stays byte-identical to its pre-#669 document.
+    if (n.skills && n.skills.length > 0) {
+      node.skills = n.skills.map((skill) => ({ id: skill.id, name: skill.name }));
+    }
     const harnesses = foldNodeIntoHarnesses(n);
     if (harnesses) node.harnesses = harnesses;
     if (n.provisioning && hasProvisioningRules(n.provisioning)) {
@@ -301,6 +306,9 @@ export function exportNodeAsYaml(node: NodeDef, prompt: string): string {
   if (node.pin_harness) obj.pin_harness = node.pin_harness;
   if (node.agent_choice && node.agent_choice.mode !== "inherit") {
     obj.agent_choice = node.agent_choice;
+  }
+  if (node.skills && node.skills.length > 0) {
+    obj.skills = node.skills.map((skill) => ({ id: skill.id, name: skill.name }));
   }
   const harnesses = foldNodeIntoHarnesses(node);
   if (harnesses) obj.harnesses = harnesses;

--- a/frontend/src/lib/skillSelection.test.ts
+++ b/frontend/src/lib/skillSelection.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import type { Skill, SkillBank, SkillFolder } from "../types";
+import {
+  addRefs,
+  allSelected,
+  effectiveCountLabel,
+  missingIds,
+  removeRef,
+  resolveEffectiveSkills,
+  skillsInFolder,
+  toRefs,
+} from "./skillSelection";
+
+const skill = (id: string, name: string, folder_id: string | null = null): Skill => ({
+  id,
+  name,
+  description: `${name} description`,
+  folder_id,
+  created_at: "2026-09-03T00:00:00.000Z",
+  updated_at: "2026-09-03T00:00:00.000Z",
+});
+const folder = (id: string, name: string, parent_id: string | null = null): SkillFolder => ({
+  id,
+  name,
+  parent_id,
+  created_at: "2026-09-03T00:00:00.000Z",
+  updated_at: "2026-09-03T00:00:00.000Z",
+});
+
+const bank: SkillBank = {
+  root_path: "/tmp/.pdo/skills",
+  folders: [folder("f-method", "method"), folder("f-java", "java", "f-method")],
+  skills: [
+    skill("a", "tdd", "f-method"),
+    skill("b", "grilling", "f-method"),
+    skill("c", "code-review"),
+    skill("d", "spring", "f-java"),
+  ],
+};
+
+describe("resolveEffectiveSkills", () => {
+  it("unions the tiers coarsest first and attributes each row to its origin", () => {
+    const resolved = resolveEffectiveSkills(
+      "node",
+      [{ id: "c", name: "code-review" }],
+      [
+        { tier: "project", skills: [{ id: "b", name: "grilling" }] },
+        { tier: "instance", skills: [{ id: "a", name: "tdd" }] },
+      ],
+      bank,
+    );
+    expect(resolved.rows.map((row) => [row.id, row.tiers, row.own, row.inherited])).toEqual([
+      ["a", ["instance"], false, true],
+      ["b", ["project"], false, true],
+      ["c", ["node"], true, false],
+    ]);
+    expect(resolved.effectiveCount).toBe(3);
+    expect(resolved.missing).toEqual([]);
+  });
+
+  it("delivers a skill picked at two tiers once, own and inherited at the same time", () => {
+    const resolved = resolveEffectiveSkills(
+      "run",
+      [{ id: "a", name: "tdd" }, { id: "d", name: "spring" }],
+      [{ tier: "instance", skills: [{ id: "a", name: "tdd" }] }],
+      bank,
+    );
+    expect(resolved.rows).toHaveLength(2);
+    expect(resolved.rows[0]).toMatchObject({ id: "a", tiers: ["instance", "run"], own: true, inherited: true });
+    expect(resolved.rows[1]).toMatchObject({ id: "d", tiers: ["run"], own: true, inherited: false });
+    expect(resolved.effectiveCount).toBe(2);
+  });
+
+  it("names a row from the bank, not from the stored label", () => {
+    const resolved = resolveEffectiveSkills("node", [{ id: "a", name: "old-label" }], [], bank);
+    expect(resolved.rows[0].name).toBe("tdd");
+  });
+
+  it("flags an id the bank no longer knows as missing, excluded from the effective count", () => {
+    const resolved = resolveEffectiveSkills(
+      "node",
+      [{ id: "gone", name: "deleted" }],
+      [{ tier: "instance", skills: [{ id: "a", name: "tdd" }] }],
+      bank,
+    );
+    expect(resolved.rows.map((row) => row.id)).toEqual(["a", "gone"]);
+    expect(resolved.missing).toEqual([
+      expect.objectContaining({ id: "gone", name: "deleted", missing: true, tiers: ["node"] }),
+    ]);
+    expect(resolved.effectiveCount).toBe(1);
+  });
+
+  it("ignores blank ids and handles empty tiers", () => {
+    const resolved = resolveEffectiveSkills("node", [{ id: "  ", name: "x" }], [], bank);
+    expect(resolved.rows).toEqual([]);
+    expect(effectiveCountLabel(resolved.effectiveCount)).toBe("No skill");
+    expect(effectiveCountLabel(1)).toBe("1 effective skill");
+    expect(effectiveCountLabel(3)).toBe("3 effective skills");
+  });
+});
+
+describe("folder gesture", () => {
+  it("checking a folder yields its skills at this instant, recursively", () => {
+    expect(skillsInFolder("f-method", bank).map((skill) => skill.id)).toEqual(["a", "b", "d"]);
+    expect(skillsInFolder("f-java", bank).map((skill) => skill.id)).toEqual(["d"]);
+    expect(skillsInFolder("f-unknown", bank)).toEqual([]);
+  });
+
+  it("addRefs keeps order and de-duplicates; removeRef drops by id", () => {
+    const own = addRefs([{ id: "c", name: "code-review" }], toRefs(skillsInFolder("f-method", bank)));
+    expect(own.map((skill) => skill.id)).toEqual(["c", "a", "b", "d"]);
+    expect(addRefs(own, [{ id: "a", name: "tdd" }])).toHaveLength(4);
+    expect(removeRef(own, "a").map((skill) => skill.id)).toEqual(["c", "b", "d"]);
+  });
+
+  it("allSelected says whether every skill of a folder is already own", () => {
+    const own = toRefs(skillsInFolder("f-method", bank));
+    expect(allSelected(own, skillsInFolder("f-method", bank))).toBe(true);
+    expect(allSelected(removeRef(own, "d"), skillsInFolder("f-method", bank))).toBe(false);
+    expect(allSelected(own, [])).toBe(false);
+  });
+
+  it("missingIds lists own references the bank lost", () => {
+    expect(missingIds([{ id: "a", name: "tdd" }, { id: "zz", name: "lost" }], bank)).toEqual([
+      { id: "zz", name: "lost" },
+    ]);
+  });
+});

--- a/frontend/src/lib/skillSelection.ts
+++ b/frontend/src/lib/skillSelection.ts
@@ -1,0 +1,151 @@
+import type { Skill, SkillBank, SkillRef, SkillTier } from "../types";
+import { descendantFolderIds } from "./skillTree";
+
+/**
+ * Pure helpers behind the shared skills selector (#669, ADR-0062, CONTEXT.md
+ * §*Banque de skills*). The frontend mirror of `skill_selection.rs`: the same
+ * strict additive union of the four tiers, coarsest first, de-duplicated by id,
+ * each row attributed to every tier that selected it. Identity is the id — the
+ * bank's current name wins over the stored label, and an id the bank no longer
+ * knows is a *warning* row, never a refusal.
+ */
+
+export const SKILL_TIER_ORDER: readonly SkillTier[] = ["instance", "project", "run", "node"];
+
+export const SKILL_TIER_LABEL: Record<SkillTier, string> = {
+  instance: "Instance",
+  project: "Project",
+  run: "Run",
+  node: "Node",
+};
+
+/** One inherited tier as a selector receives it: which tier, and what it selected. */
+export interface InheritedTier {
+  tier: SkillTier;
+  skills: SkillRef[];
+  /** Optional origin label (a Projet's name, a Run's name) shown beside the tier. */
+  label?: string;
+}
+
+/** One row of the effective list a selector renders. */
+export interface EffectiveRow {
+  id: string;
+  /** The bank's current name, else the stored label. */
+  name: string;
+  /** Every tier that selected it, coarsest first. */
+  tiers: SkillTier[];
+  /** `true` when `ownTier` is among `tiers` — the checkbox is live. */
+  own: boolean;
+  /** `true` when at least one *other* tier selected it — shown greyed with its origin. */
+  inherited: boolean;
+  /** `true` when the bank no longer has the id — the warning row. */
+  missing: boolean;
+}
+
+export interface EffectiveSkills {
+  rows: EffectiveRow[];
+  /** Distinct known skills the NodeRun would receive (missing ones excluded). */
+  effectiveCount: number;
+  missing: EffectiveRow[];
+}
+
+/**
+ * Union `inherited` (coarser tiers) with `own` at `ownTier`, naming each id from
+ * `bank`. Order: first tier that names an id decides its position.
+ */
+export function resolveEffectiveSkills(
+  ownTier: SkillTier,
+  own: SkillRef[],
+  inherited: InheritedTier[],
+  bank: Pick<SkillBank, "skills">,
+): EffectiveSkills {
+  const known = new Map(bank.skills.map((skill) => [skill.id, skill]));
+  const order: string[] = [];
+  const acc = new Map<string, { label: string; tiers: SkillTier[] }>();
+  const slots: { tier: SkillTier; skills: SkillRef[] }[] = [
+    ...inherited.map((entry) => ({ tier: entry.tier, skills: entry.skills })),
+    { tier: ownTier, skills: own },
+  ].sort((a, b) => SKILL_TIER_ORDER.indexOf(a.tier) - SKILL_TIER_ORDER.indexOf(b.tier));
+  for (const { tier, skills } of slots) {
+    for (const skill of skills) {
+      const id = skill.id.trim();
+      if (!id) continue;
+      const entry = acc.get(id);
+      if (entry) {
+        if (!entry.tiers.includes(tier)) entry.tiers.push(tier);
+      } else {
+        order.push(id);
+        acc.set(id, { label: skill.name, tiers: [tier] });
+      }
+    }
+  }
+  const rows: EffectiveRow[] = order.map((id) => {
+    const { label, tiers } = acc.get(id)!;
+    const inBank = known.get(id);
+    const own = tiers.includes(ownTier);
+    return {
+      id,
+      name: inBank?.name ?? label ?? id,
+      tiers,
+      own,
+      inherited: tiers.some((tier) => tier !== ownTier),
+      missing: !inBank,
+    };
+  });
+  return {
+    rows,
+    effectiveCount: rows.filter((row) => !row.missing).length,
+    missing: rows.filter((row) => row.missing),
+  };
+}
+
+/** `{id, name}` references for `skills`, as a tier stores them. */
+export function toRefs(skills: Skill[]): SkillRef[] {
+  return skills.map((skill) => ({ id: skill.id, name: skill.name }));
+}
+
+/**
+ * The gesture behind "check a folder" (ADR-0062 « Dossier = geste, pas
+ * référence »): the skills in `folderId` and every folder below it, **at this
+ * instant**. The caller adds them to its own list; nothing stores the folder.
+ */
+export function skillsInFolder(folderId: string, bank: SkillBank): Skill[] {
+  const folders = descendantFolderIds(folderId, bank.folders);
+  return bank.skills.filter((skill) => skill.folder_id != null && folders.has(skill.folder_id));
+}
+
+/** Add `refs` to `own`, keeping order and de-duplicating by id. */
+export function addRefs(own: SkillRef[], refs: SkillRef[]): SkillRef[] {
+  const seen = new Set(own.map((skill) => skill.id));
+  const out = [...own];
+  for (const ref of refs) {
+    if (!seen.has(ref.id)) {
+      seen.add(ref.id);
+      out.push(ref);
+    }
+  }
+  return out;
+}
+
+export function removeRef(own: SkillRef[], id: string): SkillRef[] {
+  return own.filter((skill) => skill.id !== id);
+}
+
+/** Are *all* of `skills` in `own`? (empty ⇒ false: nothing to check) */
+export function allSelected(own: SkillRef[], skills: Skill[]): boolean {
+  if (skills.length === 0) return false;
+  const ids = new Set(own.map((skill) => skill.id));
+  return skills.every((skill) => ids.has(skill.id));
+}
+
+/** Ids `own` selects that the bank no longer has. */
+export function missingIds(own: SkillRef[], bank: Pick<SkillBank, "skills">): SkillRef[] {
+  const known = new Set(bank.skills.map((skill) => skill.id));
+  return own.filter((skill) => !known.has(skill.id));
+}
+
+/** `3 effective skills` / `1 effective skill` / `No skill`. */
+export function effectiveCountLabel(count: number): string {
+  if (count === 0) return "No skill";
+  return `${count} effective skill${count === 1 ? "" : "s"}`;
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -259,6 +259,8 @@ export interface InstanceSettings {
     stored: Record<string, string>;
   };
   agent_choice?: AgentChoice | null;
+  /** #669/ADR-0062: the Instance tier of the skills selection (ids + labels). */
+  skills?: SkillRef[];
   /**
    * Instance-wide default sandbox (#410/#432): `"off"` (host, default) or the name of a
    * **staging profile**. No longer a closed enum — its value space is the user's profile
@@ -443,6 +445,8 @@ export interface UpdateSettingsRequest {
   default_harness_model?: Record<string, string>;
   /** Atomic instance agent selection. `null` clears to the Default floor. */
   agent_choice?: AgentChoice | null;
+  /** #669: replace the Instance tier's skills wholesale; `[]` clears. */
+  skills?: SkillRef[];
   /** Default sandbox (#410/#432): `"off"` or a staging-profile name, or `""` to clear
    *  back to the built-in default (`off`). Same `""`-sentinel discipline as
    *  `default_model`. The daemon 400s a name that does not resolve.
@@ -517,6 +521,8 @@ export interface Project {
   /** The harness this Projet carries, or absent/null when it carries none. */
   harness?: string | null;
   agent_choice?: AgentChoice | null;
+  /** #669/ADR-0062: the Projet tier of the skills selection. Absent ⇒ none. */
+  skills?: SkillRef[];
   /** Member repository paths (the effective-repo keys the lists group by). */
   members: string[];
 }
@@ -603,6 +609,8 @@ export interface Trigger {
    *  separate Trigger tier — a cron tick and a "Run now" produce the same one). */
   harness?: string | null;
   agent_choice?: AgentChoice | null;
+  /** #669: the Run-tier skills every fired Run carries. Absent ⇒ none. */
+  skills?: SkillRef[];
   /** Whether Runs this Trigger fires are auto-named (#338). Frozen at creation from the
    *  instance default; `true` is the pre-#338 behaviour. A flat bool (no inherit state). */
   auto_name: boolean;
@@ -702,6 +710,14 @@ export interface NodeState {
    * node that never started, a structural node, or a pre-#653 daemon.
    */
   isolated_worktree?: boolean;
+  /**
+   * #669/ADR-0062: the skills effectifs this NodeRun was FROZEN with at spawn
+   * (union of the four tiers, each with its origin). Absent for a node that never
+   * started, a `script` node, or a pre-#669 daemon.
+   */
+  skills?: EffectiveSkill[];
+  /** #669: selected ids the bank no longer knew at spawn — the node ran without them. */
+  missing_skills?: MissingSkill[];
   /** Node provisioning recipe frozen into this iteration's NodeStarted event. */
   provisioning?: ProvisioningRules;
   /** Time this iteration's isolated worktree recipe was first materialized. */
@@ -848,6 +864,8 @@ export interface RunState {
   pipeline_name: string;
   name?: string | null;
   input: string | null;
+  /** #669: the Run tier of the skills selection, frozen on `RunStarted`. Absent ⇒ none. */
+  skills?: SkillRef[];
   started_at: string | null;
   completed_at: string | null;
   /**
@@ -1108,6 +1126,10 @@ export interface NodeDef {
   harnesses?: Record<string, HarnessSettings>;
   /** Atomic agent selection for this node. Missing/`inherit` continues precedence. */
   agent_choice?: AgentChoice | null;
+  /** #669/ADR-0062: the Node tier of the skills selection — ids with their label,
+   *  unioned with the instance, Projet and Run tiers at spawn. Semantic. Never
+   *  carried by a `script` node (refused at parse). */
+  skills?: SkillRef[];
   /** Resources added only when this isolated node worktree is first created. */
   provisioning?: ProvisioningRules;
   /** #653/ADR-0060: where this node's NodeRun works — `true` a sub-worktree of
@@ -1513,11 +1535,35 @@ export interface SkillDetail extends Skill {
   path: string;
 }
 
-/** Who selects a skill, by tier. Empty in #668 (no tier selects yet). */
+/** Who selects a skill, by tier (#669). */
 export interface SkillReferents {
   skill_id: string;
   instance: boolean;
   projects: { id: string; name: string }[];
+  triggers?: { id: string; name: string; pipeline_id: string }[];
   pipelines: { id: string; name: string; node_id?: string; scope?: string }[];
-  runs: { run_id: string; name?: string | null }[];
+  runs: { run_id: string; name?: string | null; pipeline_name?: string | null }[];
+}
+
+/**
+ * One selected skill as a tier stores it (#669, ADR-0062): the stable id and the
+ * label shown when it was picked. Identity is the id; the bank's current name
+ * wins at display and at spawn.
+ */
+export interface SkillRef {
+  id: string;
+  name: string;
+}
+
+/** The four additive tiers, coarsest first. */
+export type SkillTier = "instance" | "project" | "run" | "node";
+
+/** An effective skill frozen on a NodeRun, with every tier that selected it. */
+export interface EffectiveSkill extends SkillRef {
+  tiers: SkillTier[];
+}
+
+/** A selected id the bank no longer knew at spawn. */
+export interface MissingSkill extends SkillRef {
+  tiers: SkillTier[];
 }


### PR DESCRIPTION
Closes #669 (story #666, spec #667, ADR-0062).

## What
- Skill selection at three tiers: Instance (settings), Project (project modal), Node (pipeline inspector); Run launch inherits Instance + Project and can add RUN skills (ticking a folder ticks its skills).
- Node inspector shows the *effective skills* with their origin chip (INSTANCE / PROJECT / NODE / RUN) and the list frozen at spawn (`NodeStarted.skills`, `missing_skills`).
- Deleting a bank skill lists its referents (`GET /settings/skills/{id}/referents`); orphaned references keep the id, show struck-through with a warning (inspector, pipeline lint banner, New Run modal) and the Run still launches.
- Release bump 1.52.0 → 1.53.0 + CHANGELOG entry.

## Checks
- Rebased on `integration/666-skill-bank` (after #676); `tests/skill_bank.rs` and `frontend/src/api.ts` conflicts resolved by keeping both #671 and #669 additions.
- `cargo test --workspace`: all pass except tmux-contention flakes in the `it` target under parallel load; the one leftover (`node_delivery::two_shared_nodes_run_concurrently…`) passes in isolation (2/2).
- `cargo test --test it -- skill_bank`: 22 passed.
- Frontend: `tsc --noEmit` clean, vitest 2088 passed / 18 skipped.
- Agentic FP (#669) from the run: **Pass** on all 4 steps, 5 non-blocking findings (stale copy in Settings help text, bank detail "referenced by 0 tiers" vs. referents API, banner is node-tier only, banner doesn't refresh on out-of-band bank change, picker popover swallows Escape).

🤖 Generated with [Claude Code](https://claude.com/claude-code)