### PR TITLE
feat(skills): livraison des skills effectifs dans le worktree (#672)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ ascendante** : la casse se signale ici et par un bump majeur, jamais en gardant 
 morts. Seule contrainte non négociable — les **données historiques restent lisibles** : un Run
 archivé s'ouvre et se chiffre quelle que soit la version qui a écrit son payload.
 
+## 1.55.0
+
+**Livraison des skills effectifs dans le worktree** (#672 ; story #666, spec #667 ; ADR-0062). Quand
+PDO crée un worktree (celui du Run ou le sous-worktree d'un nœud isolé), il y copie les skills
+effectifs du nœud dans `.agents/skills/<name>/` et pose un lien relatif `.claude/skills/<name>` par
+skill. Le contenu est **gelé au Run** : instantané additif sous `.pdo/runs/<run>/skills/`, hors
+worktree ; éditer la banque après le lancement ne change rien aux nœuds suivants. Les chemins livrés
+sont exclus du versionnage au grain du skill (lignes `# pdo <run>` dans `info/exclude` du dépôt
+cible, retirées au nettoyage du Run) et filtrés du commit de complétion même après `git add -A`.
+Un `.agents/skills/<name>` versionné reste intact et suivi ; le skill PDO homonyme est ignoré et
+signalé (`skipped_skills` sur `RunStarted` / `NodeStarted`, visible dans l'inspecteur du nœud).
+
 ## 1.54.0
 
 **Import de skills depuis une Source** (#670 ; story #666, spec #667). Depuis la banque, *+ Add ▾ ›

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1926,7 +1926,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "1.54.0"
+version = "1.55.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "1.54.0"
+version = "1.55.0"
 license = "MIT"
 description = "Prompt-Driven Orchestrator — a local daemon that runs and supervises agentic coding pipelines"
 repository = "https://github.com/Loulen/prompt-driven-orchestrator"

--- a/crates/pdo-daemon/src/admission.rs
+++ b/crates/pdo-daemon/src/admission.rs
@@ -155,6 +155,7 @@ mod tests {
                 (*id).into(),
                 NodeState {
                     missing_skills: Vec::new(),
+                    skipped_skills: Vec::new(),
                     skills: None,
                     isolated_worktree: None,
                     harness: None,

--- a/crates/pdo-daemon/src/boot_recovery.rs
+++ b/crates/pdo-daemon/src/boot_recovery.rs
@@ -338,6 +338,7 @@ mod tests {
             node_id.into(),
             event_log::NodeState {
                 missing_skills: Vec::new(),
+                skipped_skills: Vec::new(),
                 skills: None,
                 isolated_worktree: None,
                 harness: None,

--- a/crates/pdo-daemon/src/event_log.rs
+++ b/crates/pdo-daemon/src/event_log.rs
@@ -545,6 +545,11 @@ pub struct NodeState {
     /// without them (a warning, never a failure). Absent when empty.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub(crate) missing_skills: Vec<crate::skill_selection::MissingSkill>,
+    /// #672: skills promised to this NodeRun that could not be written into its
+    /// worktree (versioned homonym, occupied path, content gone) — the node ran
+    /// without them. Absent when empty.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) skipped_skills: Vec<crate::skill_delivery::SkippedSkill>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cost: Option<NodeCost>,
     pub status: NodeStatus,
@@ -1969,6 +1974,7 @@ fn apply_node_event(state: &mut RunState, event: &Event) {
                         isolated_worktree: None,
                         skills: None,
                         missing_skills: Vec::new(),
+                        skipped_skills: Vec::new(),
                         cost: None,
                         node_id: node_id.clone(),
                         status: NodeStatus::Waiting,
@@ -2009,6 +2015,7 @@ fn apply_node_event(state: &mut RunState, event: &Event) {
                         isolated_worktree: None,
                         skills: None,
                         missing_skills: Vec::new(),
+                        skipped_skills: Vec::new(),
                         cost: None,
                         node_id: node_id.clone(),
                         status: NodeStatus::Running,
@@ -2076,6 +2083,13 @@ fn apply_node_event(state: &mut RunState, event: &Event) {
                     .and_then(|p| p.get("missing_skills"))
                     .and_then(|v| serde_json::from_value(v.clone()).ok())
                     .unwrap_or_default();
+                // #672: what the delivery could not write into the worktree.
+                node.skipped_skills = event
+                    .payload
+                    .as_ref()
+                    .and_then(|p| p.get("skipped_skills"))
+                    .and_then(|v| serde_json::from_value(v.clone()).ok())
+                    .unwrap_or_default();
                 upsert_iteration(&mut node.iterations, iteration);
             }
         }
@@ -2123,6 +2137,7 @@ fn apply_node_event(state: &mut RunState, event: &Event) {
                             isolated_worktree: None,
                             skills: None,
                             missing_skills: Vec::new(),
+                            skipped_skills: Vec::new(),
                             cost: None,
                             node_id: node_id.clone(),
                             status: done_status.clone(),
@@ -2244,6 +2259,7 @@ fn apply_node_event(state: &mut RunState, event: &Event) {
                         isolated_worktree: None,
                         skills: None,
                         missing_skills: Vec::new(),
+                        skipped_skills: Vec::new(),
                         cost: None,
                         node_id: node_id.clone(),
                         status: NodeStatus::Interrupted,
@@ -2393,6 +2409,7 @@ fn apply_switch_event(state: &mut RunState, event: &Event) {
                     isolated_worktree: None,
                     skills: None,
                     missing_skills: Vec::new(),
+                    skipped_skills: Vec::new(),
                     cost: None,
                     node_id: node_id.to_string(),
                     status: NodeStatus::Completed,
@@ -3546,6 +3563,7 @@ mod tests {
         assert_eq!(value["harness"], "copilot");
         let bare = super::NodeState {
             missing_skills: Vec::new(),
+            skipped_skills: Vec::new(),
             skills: None,
             harness: None,
             isolated_worktree: None,
@@ -6470,6 +6488,7 @@ mod tests {
     ) -> NodeState {
         NodeState {
             missing_skills: Vec::new(),
+            skipped_skills: Vec::new(),
             skills: None,
             harness: None,
             isolated_worktree: None,

--- a/crates/pdo-daemon/src/graph_resolver.rs
+++ b/crates/pdo-daemon/src/graph_resolver.rs
@@ -564,6 +564,7 @@ mod tests {
     fn completed_node(id: &str) -> NodeState {
         NodeState {
             missing_skills: Vec::new(),
+            skipped_skills: Vec::new(),
             skills: None,
             isolated_worktree: None,
             harness: None,
@@ -586,6 +587,7 @@ mod tests {
     fn running_node(id: &str) -> NodeState {
         NodeState {
             missing_skills: Vec::new(),
+            skipped_skills: Vec::new(),
             skills: None,
             isolated_worktree: None,
             harness: None,

--- a/crates/pdo-daemon/src/input_resolution.rs
+++ b/crates/pdo-daemon/src/input_resolution.rs
@@ -204,6 +204,7 @@ mod tests {
         let (head_iter, head_status) = iters.last().cloned().unwrap_or((1, NodeStatus::Pending));
         NodeState {
             missing_skills: Vec::new(),
+            skipped_skills: Vec::new(),
             skills: None,
             isolated_worktree: None,
             harness: None,

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -73,6 +73,7 @@ mod scheduler_dispatcher;
 mod scheduler_interpreter;
 mod service_unit;
 mod skill_bank;
+mod skill_delivery;
 mod skill_selection;
 pub mod stale_detector;
 mod stats;
@@ -8031,6 +8032,48 @@ async fn create_run_inner(
     if !run_skills.is_empty() {
         run_payload["skills"] = serde_json::to_value(&run_skills).unwrap_or_default();
     }
+    // #672 / ADR-0062: FREEZE the resolved instance + Projet + Run selection (ids,
+    // bank names, origin tiers) — the base every node spawn of this Run adds its own
+    // tier to. The bank's names are read once here; a later rename or edit of the
+    // bank never reaches this Run (its content is snapshotted below). Written only
+    // when non-empty so a Run selecting nothing keeps the historical payload shape.
+    // An id the bank does not know is a warning on the Run, never a refusal.
+    let frozen_skills = {
+        let instance_skills = instance_config::get(&state.db)
+            .await
+            .map(|c| c.skills)
+            .unwrap_or_default();
+        let project_skills =
+            crate::project_store::skills_for_path(&state.db, &run_repo_root.to_string_lossy())
+                .await
+                .unwrap_or_default();
+        let bank = crate::skill_bank::snapshot_names(&state.db)
+            .await
+            .unwrap_or_default();
+        let tiers = crate::skill_selection::SkillTiers {
+            instance: Some(&instance_skills),
+            project: Some(&project_skills),
+            run: Some(&run_skills),
+            node: None,
+        };
+        let resolved = crate::skill_selection::resolve(&tiers, &bank);
+        for missing in &resolved.missing {
+            warn!(
+                "run {run_id}: skill '{}' ({}) selected at {:?} is no longer in the bank; \
+                 the Run proceeds without it",
+                missing.name, missing.id, missing.tiers
+            );
+        }
+        if !resolved.missing.is_empty() {
+            run_payload["missing_skills"] =
+                serde_json::to_value(&resolved.missing).unwrap_or_default();
+        }
+        if !resolved.skills.is_empty() {
+            run_payload[crate::skill_delivery::RUN_STARTED_FROZEN_KEY] =
+                serde_json::to_value(&resolved.skills).unwrap_or_default();
+        }
+        resolved.skills
+    };
     // FREEZE the Run's `auto_fail` choice (ADR-0049), same immutability posture as
     // `harness`. Absent ⇒ resolve through the project / instance tiers.
     if let Some(af) = req.auto_fail {
@@ -8098,7 +8141,9 @@ async fn create_run_inner(
         run_payload["provisioning_rules"] = serde_json::json!(frozen_provisioning);
     }
 
-    let run_started = event_log::Event {
+    // `mut`: the skill delivery below (#672) appends `skipped_skills` once the
+    // worktree exists, before the event is appended.
+    let mut run_started = event_log::Event {
         id: None,
         run_id: run_id.clone(),
         ts: event_log::now_iso(),
@@ -8132,6 +8177,63 @@ async fn create_run_inner(
                 )
             }),
         ));
+    }
+
+    // #672 / ADR-0062: snapshot the frozen selection's content under the Run dir
+    // (outside the worktree), then deliver it into the Run worktree — the tree the
+    // non-isolated nodes, the Pipeline Manager and the run shell work in. Paths are
+    // excluded per skill in the target repo's `info/exclude` and recorded in the
+    // worktree's provisioning manifest, so no skill ever reaches the Run branch. A
+    // versioned homonym is skipped and reported on the Run; an I/O failure refuses
+    // the Run like a provisioning failure (never a partial environment).
+    let skill_delivery = crate::skill_delivery::snapshot_skills(
+        &state.repo_root,
+        &run_repo_root,
+        &run_id,
+        &frozen_skills,
+    )
+    .and_then(|mut skipped| {
+        let mut report = crate::skill_delivery::deliver(
+            &worktree_dir,
+            &crate::skill_delivery::snapshot_root(&run_repo_root, &run_id),
+            &run_id,
+            &frozen_skills,
+        )?;
+        skipped.append(&mut report.skipped);
+        report.skipped = skipped;
+        Ok(report)
+    });
+    match skill_delivery {
+        Ok(report) => {
+            for skipped in &report.skipped {
+                warn!(
+                    "run {run_id}: skill '{}' not delivered: {}",
+                    skipped.name, skipped.reason
+                );
+            }
+            if !report.skipped.is_empty() {
+                if let Some(payload) = run_started.payload.as_mut() {
+                    payload["skipped_skills"] =
+                        serde_json::to_value(&report.skipped).unwrap_or_default();
+                }
+            }
+        }
+        Err(e) => {
+            let _ = crate::skill_delivery::remove_exclusions(&run_repo_root, &run_id);
+            crate::worktree_ops::reap_orphan_run_worktree(
+                &run_repo_root,
+                &worktree_dir,
+                &branch_name,
+            );
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                serde_json::json!({
+                    "error": format!(
+                        "Run not created. Skill delivery failed: {e:#}. No node was spawned."
+                    )
+                }),
+            ));
+        }
     }
 
     // Materialise each secondary as a detached, pinned snapshot beside
@@ -15702,6 +15804,13 @@ async fn cleanup_run(state: &AppState, run_id: &str) -> Response {
                 );
             }
         }
+    }
+
+    // #672 / ADR-0062: take back the per-skill exclusions this Run wrote in the target
+    // repo's `info/exclude` (its `# pdo <run-id>` marked lines only — every other
+    // line, PDO's for another Run or the user's, stays intact).
+    if let Err(e) = crate::skill_delivery::remove_exclusions(&repo_root, run_id) {
+        warn!("cleanup_run: cannot remove skill exclusions for run {run_id}: {e:#}");
     }
 
     for pattern in [format!("pdo/run-{run_id}"), format!("pdo/sub-{run_id}*")] {
@@ -23275,6 +23384,7 @@ mod tests {
             node_id.into(),
             event_log::NodeState {
                 missing_skills: Vec::new(),
+                skipped_skills: Vec::new(),
                 skills: None,
                 isolated_worktree: None,
                 harness: None,
@@ -23491,6 +23601,7 @@ mod tests {
             "a".into(),
             event_log::NodeState {
                 missing_skills: Vec::new(),
+                skipped_skills: Vec::new(),
                 skills: None,
                 isolated_worktree: None,
                 harness: None,
@@ -23548,6 +23659,7 @@ mod tests {
             "a".into(),
             event_log::NodeState {
                 missing_skills: Vec::new(),
+                skipped_skills: Vec::new(),
                 skills: None,
                 isolated_worktree: None,
                 harness: None,
@@ -23573,6 +23685,7 @@ mod tests {
             "b".into(),
             event_log::NodeState {
                 missing_skills: Vec::new(),
+                skipped_skills: Vec::new(),
                 skills: None,
                 isolated_worktree: None,
                 harness: None,
@@ -23805,6 +23918,7 @@ mod tests {
                 node_id.into(),
                 event_log::NodeState {
                     missing_skills: Vec::new(),
+                    skipped_skills: Vec::new(),
                     skills: None,
                     isolated_worktree: None,
                     harness: None,

--- a/crates/pdo-daemon/src/mutation_validator.rs
+++ b/crates/pdo-daemon/src/mutation_validator.rs
@@ -266,6 +266,7 @@ mod tests {
                 id.to_string(),
                 event_log::NodeState {
                     missing_skills: Vec::new(),
+                    skipped_skills: Vec::new(),
                     skills: None,
                     isolated_worktree: None,
                     harness: None,

--- a/crates/pdo-daemon/src/node_io_resolver.rs
+++ b/crates/pdo-daemon/src/node_io_resolver.rs
@@ -295,6 +295,7 @@ mod tests {
         let (head_iter, head_status) = iters.last().cloned().unwrap_or((1, NodeStatus::Pending));
         let node = NodeState {
             missing_skills: Vec::new(),
+            skipped_skills: Vec::new(),
             skills: None,
             isolated_worktree: None,
             harness: None,

--- a/crates/pdo-daemon/src/node_primitives.rs
+++ b/crates/pdo-daemon/src/node_primitives.rs
@@ -984,6 +984,7 @@ mod tests {
     fn running_node(id: &str, iter: i64) -> NodeState {
         NodeState {
             missing_skills: Vec::new(),
+            skipped_skills: Vec::new(),
             skills: None,
             isolated_worktree: None,
             harness: None,
@@ -1011,6 +1012,7 @@ mod tests {
     fn completed_node(id: &str, iter: i64) -> NodeState {
         NodeState {
             missing_skills: Vec::new(),
+            skipped_skills: Vec::new(),
             skills: None,
             isolated_worktree: None,
             harness: None,
@@ -1038,6 +1040,7 @@ mod tests {
     fn pending_node(id: &str) -> NodeState {
         NodeState {
             missing_skills: Vec::new(),
+            skipped_skills: Vec::new(),
             skills: None,
             isolated_worktree: None,
             harness: None,
@@ -1614,6 +1617,7 @@ mod tests {
         let (head_iter, head_status) = iters.last().cloned().unwrap_or((1, NodeStatus::Pending));
         NodeState {
             missing_skills: Vec::new(),
+            skipped_skills: Vec::new(),
             skills: None,
             isolated_worktree: None,
             harness: None,

--- a/crates/pdo-daemon/src/node_spawn.rs
+++ b/crates/pdo-daemon/src/node_spawn.rs
@@ -65,6 +65,10 @@ pub(crate) struct SpawnDeps<'a> {
     /// user-declared harness resolves at spawn — and so a layer-3 test that sets
     /// the override reads descriptors from its own tempdir, never the real home.
     pub(crate) home_override: Option<&'a std::path::Path>,
+    /// #672: the daemon's repo root, where the Banque de skills keeps its content
+    /// (`.pdo/skills/<id>/`) — distinct from the Run's target repo, which is
+    /// where the snapshot and the worktrees live.
+    pub(crate) bank_root: &'a std::path::Path,
 }
 
 impl<'a> SpawnDeps<'a> {
@@ -79,6 +83,7 @@ impl<'a> SpawnDeps<'a> {
             tmux_cmd_override: state.tmux_cmd_override.as_deref(),
             docker_cmd_override: state.docker_cmd_override.as_deref(),
             home_override: state.sandbox_home_override.as_deref(),
+            bank_root: &state.repo_root,
         }
     }
 }
@@ -523,31 +528,88 @@ pub(crate) async fn spawn_node(
     // ONCE so every id resolves against the same point in time. A DB error
     // degrades a tier to empty — a skill lookup never fails a spawn. A `script`
     // node carries none (refused at parse) and launches no agent: `None`.
+    //
+    // #672: the instance + Projet + Run tiers come from the selection FROZEN on
+    // `RunStarted` (ids AND names — the delivered folder is named after the frozen
+    // name, so a rename in the bank after the Run started never delivers the same
+    // skill twice under two names). Only the Node tier is read from the document
+    // here. A Run created before #672 has no frozen base: its outer tiers are read
+    // fresh, as #669 did.
     let resolved_skills = if node.node_type == pipeline::NodeType::Script {
         None
     } else {
-        let primary_repo = projected
-            .and_then(|s| s.target_repo.clone())
-            .unwrap_or_else(|| spawn_ctx.repo_root.to_string_lossy().into_owned());
-        let project_skills =
-            match crate::project_store::skills_for_path(deps.db, &primary_repo).await {
-                Ok(skills) => skills,
-                Err(e) => {
-                    warn!("project skills lookup failed for {primary_repo}: {e}");
-                    Vec::new()
+        let frozen_base = loaded
+            .as_ref()
+            .and_then(|(events, _)| crate::skill_delivery::frozen_run_skills(events));
+        let mut bank = crate::skill_bank::snapshot_names(deps.db)
+            .await
+            .unwrap_or_default();
+        let (instance_skills, project_skills, run_skills): (
+            Vec<crate::skill_selection::SkillRef>,
+            Vec<crate::skill_selection::SkillRef>,
+            Vec<crate::skill_selection::SkillRef>,
+        ) = match &frozen_base {
+            Some(base) => {
+                let mut by_tier = (Vec::new(), Vec::new(), Vec::new());
+                // Known skills pin their frozen name in the bank map; the ids the bank
+                // had already lost at create are re-posed in their tiers WITHOUT a
+                // bank entry, so `resolve` reports them missing again on this node.
+                let frozen_refs = base
+                    .skills
+                    .iter()
+                    .map(|s| {
+                        bank.insert(s.id.clone(), s.name.clone());
+                        (s.id.clone(), s.name.clone(), s.tiers.clone())
+                    })
+                    .chain(
+                        base.missing
+                            .iter()
+                            .map(|m| (m.id.clone(), m.name.clone(), m.tiers.clone())),
+                    );
+                for (id, name, tiers) in frozen_refs {
+                    let sref = crate::skill_selection::SkillRef { id, name };
+                    for tier in &tiers {
+                        match tier {
+                            crate::skill_selection::SkillTier::Instance => {
+                                by_tier.0.push(sref.clone())
+                            }
+                            crate::skill_selection::SkillTier::Project => {
+                                by_tier.1.push(sref.clone())
+                            }
+                            crate::skill_selection::SkillTier::Run => by_tier.2.push(sref.clone()),
+                            crate::skill_selection::SkillTier::Node => {}
+                        }
+                    }
                 }
-            };
-        let instance_skills = crate::instance_config::get(deps.db)
-            .await
-            .map(|c| c.skills)
-            .unwrap_or_default();
-        let bank = crate::skill_bank::snapshot_names(deps.db)
-            .await
-            .unwrap_or_default();
+                by_tier
+            }
+            None => {
+                let primary_repo = projected
+                    .and_then(|s| s.target_repo.clone())
+                    .unwrap_or_else(|| spawn_ctx.repo_root.to_string_lossy().into_owned());
+                let project_skills =
+                    match crate::project_store::skills_for_path(deps.db, &primary_repo).await {
+                        Ok(skills) => skills,
+                        Err(e) => {
+                            warn!("project skills lookup failed for {primary_repo}: {e}");
+                            Vec::new()
+                        }
+                    };
+                let instance_skills = crate::instance_config::get(deps.db)
+                    .await
+                    .map(|c| c.skills)
+                    .unwrap_or_default();
+                (
+                    instance_skills,
+                    project_skills,
+                    projected.map(|s| s.skills.clone()).unwrap_or_default(),
+                )
+            }
+        };
         let tiers = crate::skill_selection::SkillTiers {
             instance: Some(&instance_skills),
             project: Some(&project_skills),
-            run: projected.map(|s| s.skills.as_slice()),
+            run: Some(&run_skills),
             node: Some(&node.skills),
         };
         let resolved = crate::skill_selection::resolve(&tiers, &bank);
@@ -746,6 +808,62 @@ pub(crate) async fn spawn_node(
     } else {
         spawn_ctx.worktree_dir.to_path_buf()
     };
+
+    // #672 / ADR-0062: deliver the skills effectifs into the tree this NodeRun works
+    // in — its own sub-worktree, or the shared Run worktree (where the Run's frozen
+    // base already sits since create; only what is new is written). The content
+    // comes from the Run snapshot, extended here (additively) with what this node's
+    // own tier adds; `.agents/skills/<name>` + `.claude/skills/<name>` are excluded
+    // per skill in the target repo's `info/exclude` and recorded for the completion
+    // commit's filter. A versioned homonym is skipped and recorded on `NodeStarted`
+    // (visible on the node); an I/O failure refuses the spawn like provisioning.
+    let mut skipped_skills: Vec<crate::skill_delivery::SkippedSkill> = Vec::new();
+    if let Some(resolved) = resolved_skills.as_ref() {
+        let delivery = crate::skill_delivery::snapshot_skills(
+            deps.bank_root,
+            spawn_ctx.repo_root,
+            run_id,
+            &resolved.skills,
+        )
+        .and_then(|mut skipped| {
+            let mut report = crate::skill_delivery::deliver(
+                &working_dir,
+                &crate::skill_delivery::snapshot_root(spawn_ctx.repo_root, run_id),
+                run_id,
+                &resolved.skills,
+            )?;
+            skipped.append(&mut report.skipped);
+            Ok(skipped)
+        });
+        match delivery {
+            Ok(skipped) => {
+                for s in &skipped {
+                    warn!(
+                        "run {run_id} node {}: skill '{}' not delivered: {}",
+                        node.id, s.name, s.reason
+                    );
+                }
+                skipped_skills = skipped;
+            }
+            Err(e) => {
+                let reason = format!(
+                    "skill delivery failed for {}: {e:#}; no node was spawned",
+                    node.id
+                );
+                interrupt_spawn_before_start(
+                    deps,
+                    spawn_ctx.repo_root,
+                    run_id,
+                    &node.id,
+                    iter,
+                    orphan_to_reap.as_ref(),
+                    &reason,
+                )
+                .await;
+                return SpawnOutcome::Failed { reason };
+            }
+        }
+    }
 
     // #550/#347/#424: the model and effort come from the harness resolved above
     // (post node → instance precedence, post empty-string collapse), read from the
@@ -962,6 +1080,10 @@ pub(crate) async fn spawn_node(
                     .as_ref()
                     .map(|r| r.missing.clone())
                     .unwrap_or_default(),
+                // #672: what the delivery could not write into the worktree (a
+                // versioned homonym, an occupied path, content gone) — the node
+                // runs without those and the node view says so.
+                "skipped_skills": skipped_skills,
                 // #473: the pinned Claude Code session id the agent launches with
                 // (`claude --session-id <uuid>`). The sweep resolves this node's
                 // transcript by it (`<uuid>.jsonl`), and the resume path re-enters

--- a/crates/pdo-daemon/src/provisioning.rs
+++ b/crates/pdo-daemon/src/provisioning.rs
@@ -465,7 +465,7 @@ fn provisioning_manifest_path(worktree: &Path) -> Result<Option<std::path::PathB
     }))
 }
 
-fn record_materialized_paths(worktree: &Path, paths: &[String]) -> Result<()> {
+pub(crate) fn record_materialized_paths(worktree: &Path, paths: &[String]) -> Result<()> {
     let Some(manifest) = provisioning_manifest_path(worktree)? else {
         return Ok(());
     };

--- a/crates/pdo-daemon/src/run_advance.rs
+++ b/crates/pdo-daemon/src/run_advance.rs
@@ -564,6 +564,7 @@ mod tests {
     fn completed_node(id: &str) -> NodeState {
         NodeState {
             missing_skills: Vec::new(),
+            skipped_skills: Vec::new(),
             skills: None,
             isolated_worktree: None,
             harness: None,
@@ -586,6 +587,7 @@ mod tests {
     fn running_node(id: &str) -> NodeState {
         NodeState {
             missing_skills: Vec::new(),
+            skipped_skills: Vec::new(),
             skills: None,
             isolated_worktree: None,
             harness: None,
@@ -732,6 +734,7 @@ mod tests {
         let completed_at = (status == NodeStatus::Completed).then(|| "t1".to_string());
         NodeState {
             missing_skills: Vec::new(),
+            skipped_skills: Vec::new(),
             skills: None,
             isolated_worktree: None,
             harness: None,

--- a/crates/pdo-daemon/src/scheduler.rs
+++ b/crates/pdo-daemon/src/scheduler.rs
@@ -1692,6 +1692,7 @@ mod tests {
     fn completed_node(id: &str) -> NodeState {
         NodeState {
             missing_skills: Vec::new(),
+            skipped_skills: Vec::new(),
             skills: None,
             isolated_worktree: None,
             harness: None,
@@ -1714,6 +1715,7 @@ mod tests {
     fn completed_node_iter(id: &str, iter: i64) -> NodeState {
         NodeState {
             missing_skills: Vec::new(),
+            skipped_skills: Vec::new(),
             skills: None,
             isolated_worktree: None,
             harness: None,
@@ -1736,6 +1738,7 @@ mod tests {
     fn running_node(id: &str) -> NodeState {
         NodeState {
             missing_skills: Vec::new(),
+            skipped_skills: Vec::new(),
             skills: None,
             isolated_worktree: None,
             harness: None,

--- a/crates/pdo-daemon/src/scheduler_dispatcher.rs
+++ b/crates/pdo-daemon/src/scheduler_dispatcher.rs
@@ -122,6 +122,7 @@ mod tests {
     fn running_node(id: &str) -> NodeState {
         NodeState {
             missing_skills: Vec::new(),
+            skipped_skills: Vec::new(),
             skills: None,
             isolated_worktree: None,
             harness: None,
@@ -144,6 +145,7 @@ mod tests {
     fn waiting_node(id: &str, iter: i64) -> NodeState {
         NodeState {
             missing_skills: Vec::new(),
+            skipped_skills: Vec::new(),
             skills: None,
             isolated_worktree: None,
             harness: None,
@@ -191,6 +193,7 @@ mod tests {
     fn completed_node(id: &str) -> NodeState {
         NodeState {
             missing_skills: Vec::new(),
+            skipped_skills: Vec::new(),
             skills: None,
             isolated_worktree: None,
             harness: None,

--- a/crates/pdo-daemon/src/skill_delivery.rs
+++ b/crates/pdo-daemon/src/skill_delivery.rs
@@ -1,0 +1,753 @@
+//! **Delivery** of a NodeRun's skills effectifs into the worktree it works in
+//! (#672, spec #667, ADR-0062, CONTEXT.md §*Banque de skills* — *Livraison*).
+//!
+//! One mechanism for every harness: the skills are **copied** into
+//! `.agents/skills/<name>/` of the worktree, with one symbolic link per skill in
+//! `.claude/skills/<name>` (the only two locations `claude`, `copilot` and
+//! `opencode` read without configuration — ADR-0062 measured that `claude` reads
+//! `.claude/skills` but not `.agents/skills`). The price — files PDO writes into a
+//! repository it does not own — is paid by a **per-skill Git exclusion**:
+//!
+//! - every delivered path is written to the target repo's `info/exclude`
+//!   (shared by all its worktrees, never versioned), one path per skill and never a
+//!   parent folder, each preceded by a `# pdo <run-id>` marker line so
+//!   [`remove_exclusions`] can take exactly them back at Run cleanup;
+//! - every delivered path is also recorded in the worktree's provisioning manifest
+//!   (ADR-0061), so the completion commit filters it even when the agent staged it
+//!   itself with `git add -A`.
+//!
+//! A versioned `.agents/skills/` or `.claude/skills/` stays intact and tracked: a
+//! skill **homonymous with a versioned one is skipped with a warning**, never
+//! overwritten; a pre-existing `.claude/skills` (real folder or symlink) receives
+//! the per-skill links beside its own content.
+//!
+//! **Content is frozen at the Run**: the bank's folders are copied ONCE into the
+//! Run's snapshot (`<repo>/.pdo/runs/<run-id>/skills/<id>/`, outside the worktree)
+//! and every delivery reads the snapshot, never the bank. The snapshot is
+//! **additive** — a node whose selection changed after the Run started gets its new
+//! skill snapshotted at its own spawn; nothing is ever purged during the Run.
+
+use std::collections::BTreeSet;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::skill_selection::EffectiveSkill;
+
+/// Marker written on its own line before each excluded path. The run id follows
+/// so the cleanup of one Run never touches another Run's lines.
+pub(crate) const EXCLUDE_MARKER: &str = "# pdo";
+
+/// Payload key of the `RunStarted` event carrying the resolved
+/// instance + Projet + Run selection (ids, bank names, tiers) frozen at create.
+pub(crate) const RUN_STARTED_FROZEN_KEY: &str = "frozen_skills";
+
+/// Where one Run's frozen skill content lives: beside `worktree/`, under the Run
+/// directory (removed with it at cleanup), never inside a worktree.
+pub(crate) fn snapshot_root(run_repo_root: &Path, run_id: &str) -> PathBuf {
+    run_repo_root
+        .join(".pdo")
+        .join("runs")
+        .join(run_id)
+        .join("skills")
+}
+
+/// A skill the node was promised but that could not be written into the worktree.
+/// Never a failure: the node runs without it and the Run view says so.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct SkippedSkill {
+    pub id: String,
+    pub name: String,
+    pub reason: String,
+}
+
+/// What one [`deliver`] call did.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct DeliveryReport {
+    /// Names present in the worktree after the call (freshly written or already
+    /// delivered by an earlier spawn into the same worktree).
+    pub delivered: Vec<String>,
+    pub skipped: Vec<SkippedSkill>,
+}
+
+/// Copy the bank folders of `skills` into the Run snapshot, **additively**: a
+/// skill already snapshotted is left exactly as it is (frozen at the Run), one
+/// absent from the bank is reported back (its content cannot be frozen — the spawn
+/// will list it as skipped). `bank_root` is the daemon's repo root (where
+/// `.pdo/skills/<id>/` lives); `run_repo_root` is the Run's target repo.
+pub(crate) fn snapshot_skills(
+    bank_root: &Path,
+    run_repo_root: &Path,
+    run_id: &str,
+    skills: &[EffectiveSkill],
+) -> Result<Vec<SkippedSkill>> {
+    let root = snapshot_root(run_repo_root, run_id);
+    let mut skipped = Vec::new();
+    for skill in skills {
+        let dest = root.join(&skill.id);
+        if dest.is_dir() {
+            continue;
+        }
+        let source = crate::skill_bank::skill_dir(bank_root, &skill.id);
+        if !source.join(crate::skill_bank::SKILL_MD).is_file() {
+            skipped.push(SkippedSkill {
+                id: skill.id.clone(),
+                name: skill.name.clone(),
+                reason: "skill content is absent from the bank".into(),
+            });
+            continue;
+        }
+        // Write beside, then rename: a crash mid-copy never leaves a half snapshot
+        // that a later spawn would take for a frozen one.
+        let staging = root.join(format!(".{}.tmp", skill.id));
+        let _ = std::fs::remove_dir_all(&staging);
+        copy_dir(&source, &staging)
+            .with_context(|| format!("snapshot skill {} from {}", skill.id, source.display()))?;
+        std::fs::rename(&staging, &dest)
+            .with_context(|| format!("commit snapshot of skill {}", skill.id))?;
+    }
+    Ok(skipped)
+}
+
+/// Deliver `skills` from the Run snapshot into `worktree`. Idempotent per
+/// worktree: a skill already delivered there (recorded in the worktree's
+/// provisioning manifest) is counted delivered and left untouched.
+pub(crate) fn deliver(
+    worktree: &Path,
+    snapshot_root: &Path,
+    run_id: &str,
+    skills: &[EffectiveSkill],
+) -> Result<DeliveryReport> {
+    let mut report = DeliveryReport::default();
+    if skills.is_empty() {
+        return Ok(report);
+    }
+    let manifest: BTreeSet<Vec<u8>> = crate::provisioning::materialized_paths(worktree)?
+        .into_iter()
+        .collect();
+    let mut exclusions: Vec<String> = Vec::new();
+    let mut recorded: Vec<String> = Vec::new();
+
+    for skill in skills {
+        let name = skill.name.trim();
+        if name.is_empty() || name.contains('/') || name.contains('\\') || name.starts_with('.') {
+            report.skipped.push(SkippedSkill {
+                id: skill.id.clone(),
+                name: skill.name.clone(),
+                reason: "skill name cannot be used as a folder name".into(),
+            });
+            continue;
+        }
+        let agents_rel = format!(".agents/skills/{name}");
+        let claude_rel = format!(".claude/skills/{name}");
+        let dest = worktree.join(&agents_rel);
+        let link = worktree.join(&claude_rel);
+
+        let already_ours = manifest.contains(agents_rel.as_bytes());
+        if already_ours && dest.is_dir() {
+            report.delivered.push(name.to_string());
+            continue;
+        }
+
+        // A versioned homonym (any tracked path under either location) is never
+        // touched: the repo's own skill stays tracked, PDO's is skipped, loudly.
+        if is_tracked(worktree, &agents_rel)? || is_tracked(worktree, &claude_rel)? {
+            report.skipped.push(SkippedSkill {
+                id: skill.id.clone(),
+                name: name.to_string(),
+                reason: format!("a versioned skill named '{name}' exists in the target repo"),
+            });
+            continue;
+        }
+        if std::fs::symlink_metadata(&dest).is_ok() {
+            report.skipped.push(SkippedSkill {
+                id: skill.id.clone(),
+                name: name.to_string(),
+                reason: format!("{agents_rel} already exists in the worktree"),
+            });
+            continue;
+        }
+
+        let source = snapshot_root.join(&skill.id);
+        if !source.join(crate::skill_bank::SKILL_MD).is_file() {
+            report.skipped.push(SkippedSkill {
+                id: skill.id.clone(),
+                name: name.to_string(),
+                reason: "skill content is absent from the Run snapshot".into(),
+            });
+            continue;
+        }
+
+        copy_dir(&source, &dest)
+            .with_context(|| format!("copy skill '{name}' into {}", dest.display()))?;
+        exclusions.push(format!("/{agents_rel}/"));
+        recorded.push(agents_rel.clone());
+
+        // The `.claude/skills/<name>` link, relative so it survives a bind mount
+        // (sandbox) at another absolute path. A pre-existing `.claude/skills`
+        // (folder or symlink) is used as is; an occupied `<name>` slot is never
+        // overwritten (it may already resolve to our copy when `.claude/skills`
+        // itself links to `.agents/skills`).
+        let claude_dir = worktree.join(".claude").join("skills");
+        std::fs::create_dir_all(&claude_dir)
+            .with_context(|| format!("create {}", claude_dir.display()))?;
+        match std::fs::symlink_metadata(&link) {
+            Ok(_) => {
+                let resolves_to_copy = link
+                    .canonicalize()
+                    .ok()
+                    .zip(dest.canonicalize().ok())
+                    .is_some_and(|(a, b)| a == b);
+                if !resolves_to_copy {
+                    report.skipped.push(SkippedSkill {
+                        id: skill.id.clone(),
+                        name: name.to_string(),
+                        reason: format!(
+                            "{claude_rel} already exists and was left alone; the skill is only \
+                             in {agents_rel}"
+                        ),
+                    });
+                }
+            }
+            Err(_) => {
+                symlink_dir(Path::new("../../.agents/skills").join(name), &link)
+                    .with_context(|| format!("link {}", link.display()))?;
+                // The link is only excluded when `.claude/skills` is a real folder of
+                // this worktree: through a symlinked `.claude/skills`, Git sees the
+                // link blob, not what is behind it.
+                if std::fs::symlink_metadata(&claude_dir).is_ok_and(|m| !m.file_type().is_symlink())
+                {
+                    exclusions.push(format!("/{claude_rel}"));
+                    recorded.push(claude_rel.clone());
+                }
+            }
+        }
+        report.delivered.push(name.to_string());
+    }
+
+    if !exclusions.is_empty() {
+        add_exclusions(worktree, run_id, &exclusions)?;
+        crate::provisioning::record_materialized_paths(worktree, &recorded)?;
+    }
+    Ok(report)
+}
+
+/// The instance + Projet + Run selection frozen on `RunStarted`: the skills the
+/// bank knew at create, and the ids it no longer had (kept so every node of the
+/// Run keeps reporting them as missing, with their stored label and tiers). `None`
+/// for a Run created before #672 (the spawn then reads those tiers fresh).
+pub(crate) fn frozen_run_skills(events: &[crate::event_log::Event]) -> Option<FrozenRunSkills> {
+    let payload = events
+        .iter()
+        .find(|e| e.kind == crate::event_log::EventKind::RunStarted)
+        .and_then(|e| e.payload.as_ref())?;
+    let skills: Option<Vec<EffectiveSkill>> = payload
+        .get(RUN_STARTED_FROZEN_KEY)
+        .and_then(|v| serde_json::from_value(v.clone()).ok());
+    let missing: Option<Vec<crate::skill_selection::MissingSkill>> = payload
+        .get("missing_skills")
+        .and_then(|v| serde_json::from_value(v.clone()).ok());
+    if skills.is_none() && missing.is_none() {
+        return None;
+    }
+    Some(FrozenRunSkills {
+        skills: skills.unwrap_or_default(),
+        missing: missing.unwrap_or_default(),
+    })
+}
+
+/// See [`frozen_run_skills`].
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct FrozenRunSkills {
+    pub skills: Vec<EffectiveSkill>,
+    pub missing: Vec<crate::skill_selection::MissingSkill>,
+}
+
+/// Remove every `# pdo <run-id>` marker and the path line it introduces from the
+/// repo's `info/exclude`. Lines PDO did not write — and other Runs' lines — stay
+/// byte for byte. A repo without an exclude file is a no-op.
+pub(crate) fn remove_exclusions(repo_root: &Path, run_id: &str) -> Result<()> {
+    let Some(exclude) = exclude_path(repo_root)? else {
+        return Ok(());
+    };
+    let content = match std::fs::read_to_string(&exclude) {
+        Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => return Err(e).with_context(|| format!("read {}", exclude.display())),
+    };
+    let marker = format!("{EXCLUDE_MARKER} {run_id}");
+    let mut kept: Vec<&str> = Vec::new();
+    let mut lines = content.lines().peekable();
+    while let Some(line) = lines.next() {
+        if line.trim_end() == marker {
+            lines.next();
+            continue;
+        }
+        kept.push(line);
+    }
+    let mut out = kept.join("\n");
+    if !out.is_empty() {
+        out.push('\n');
+    }
+    std::fs::write(&exclude, out).with_context(|| format!("write {}", exclude.display()))
+}
+
+/// The exclusion lines of one Run, as currently written (tests and diagnostics).
+#[cfg(test)]
+pub(crate) fn exclusions_of(repo_root: &Path, run_id: &str) -> Vec<String> {
+    let Ok(Some(exclude)) = exclude_path(repo_root) else {
+        return Vec::new();
+    };
+    let content = std::fs::read_to_string(exclude).unwrap_or_default();
+    let marker = format!("{EXCLUDE_MARKER} {run_id}");
+    let mut out = Vec::new();
+    let mut lines = content.lines().peekable();
+    while let Some(line) = lines.next() {
+        if line.trim_end() == marker {
+            if let Some(path) = lines.next() {
+                out.push(path.to_string());
+            }
+        }
+    }
+    out
+}
+
+fn add_exclusions(worktree: &Path, run_id: &str, patterns: &[String]) -> Result<()> {
+    let Some(exclude) = exclude_path(worktree)? else {
+        anyhow::bail!(
+            "{} is not inside a Git work tree; cannot exclude delivered skills",
+            worktree.display()
+        );
+    };
+    let existing = std::fs::read_to_string(&exclude).unwrap_or_default();
+    let marker = format!("{EXCLUDE_MARKER} {run_id}");
+    let present: BTreeSet<&str> = {
+        let mut set = BTreeSet::new();
+        let mut lines = existing.lines().peekable();
+        while let Some(line) = lines.next() {
+            if line.trim_end() == marker {
+                if let Some(path) = lines.next() {
+                    set.insert(path.trim_end());
+                }
+            }
+        }
+        set
+    };
+    let missing: Vec<&String> = patterns
+        .iter()
+        .filter(|p| !present.contains(p.as_str()))
+        .collect();
+    if missing.is_empty() {
+        return Ok(());
+    }
+    if let Some(parent) = exclude.parent() {
+        std::fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
+    }
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&exclude)
+        .with_context(|| format!("open {}", exclude.display()))?;
+    if !existing.is_empty() && !existing.ends_with('\n') {
+        file.write_all(b"\n")?;
+    }
+    for pattern in missing {
+        writeln!(file, "{marker}")?;
+        writeln!(file, "{pattern}")?;
+    }
+    Ok(())
+}
+
+/// `<common git dir>/info/exclude` of the repository `dir` belongs to (a worktree
+/// resolves to the shared common dir). `None` outside a work tree.
+fn exclude_path(dir: &Path) -> Result<Option<PathBuf>> {
+    let output = std::process::Command::new("git")
+        .args([
+            "rev-parse",
+            "--is-inside-work-tree",
+            "--git-path",
+            "info/exclude",
+        ])
+        .current_dir(dir)
+        .output()
+        .with_context(|| format!("locate Git metadata for {}", dir.display()))?;
+    if !output.status.success() {
+        return Ok(None);
+    }
+    let text = String::from_utf8_lossy(&output.stdout);
+    let mut lines = text.lines();
+    if lines.next() != Some("true") {
+        return Ok(None);
+    }
+    let Some(path) = lines.next().filter(|l| !l.is_empty()) else {
+        return Ok(None);
+    };
+    let path = PathBuf::from(path);
+    Ok(Some(if path.is_absolute() {
+        path
+    } else {
+        dir.join(path)
+    }))
+}
+
+fn is_tracked(worktree: &Path, rel: &str) -> Result<bool> {
+    let output = std::process::Command::new("git")
+        .args(["ls-files", "-z", "--", rel])
+        .current_dir(worktree)
+        .output()
+        .with_context(|| format!("git ls-files {rel} in {}", worktree.display()))?;
+    Ok(output.status.success() && !output.stdout.is_empty())
+}
+
+/// Recursive copy that reproduces symlinks as symlinks (never dereferenced) and
+/// refuses nothing else: a skill folder is plain files.
+fn copy_dir(source: &Path, dest: &Path) -> Result<()> {
+    std::fs::create_dir_all(dest).with_context(|| format!("create {}", dest.display()))?;
+    for entry in std::fs::read_dir(source).with_context(|| format!("read {}", source.display()))? {
+        let entry = entry?;
+        let from = entry.path();
+        let to = dest.join(entry.file_name());
+        let meta = std::fs::symlink_metadata(&from)?;
+        if meta.file_type().is_symlink() {
+            let target = std::fs::read_link(&from)?;
+            symlink_any(&target, &to)?;
+        } else if meta.is_dir() {
+            copy_dir(&from, &to)?;
+        } else {
+            std::fs::copy(&from, &to)
+                .with_context(|| format!("copy {} to {}", from.display(), to.display()))?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn symlink_dir(target: impl AsRef<Path>, link: &Path) -> std::io::Result<()> {
+    std::os::unix::fs::symlink(target, link)
+}
+
+#[cfg(windows)]
+fn symlink_dir(target: impl AsRef<Path>, link: &Path) -> std::io::Result<()> {
+    std::os::windows::fs::symlink_dir(target, link)
+}
+
+#[cfg(unix)]
+fn symlink_any(target: &Path, link: &Path) -> std::io::Result<()> {
+    std::os::unix::fs::symlink(target, link)
+}
+
+#[cfg(windows)]
+fn symlink_any(target: &Path, link: &Path) -> std::io::Result<()> {
+    std::os::windows::fs::symlink_file(target, link)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::skill_selection::SkillTier;
+
+    fn git(dir: &Path, args: &[&str]) -> String {
+        let out = std::process::Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .output()
+            .unwrap();
+        assert!(
+            out.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        String::from_utf8_lossy(&out.stdout).into_owned()
+    }
+
+    /// A repo with one commit, plus a linked worktree on a `pdo/run-<id>` branch —
+    /// the shape a Run works in.
+    fn repo_and_worktree(run_id: &str) -> (tempfile::TempDir, PathBuf) {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        git(&repo, &["init", "-q", "-b", "main"]);
+        git(&repo, &["config", "user.email", "t@e.com"]);
+        git(&repo, &["config", "user.name", "T"]);
+        git(&repo, &["config", "commit.gpgsign", "false"]);
+        std::fs::write(repo.join("README.md"), "hi\n").unwrap();
+        std::fs::write(repo.join(".gitignore"), ".pdo/runs/\n").unwrap();
+        git(&repo, &["add", "."]);
+        git(&repo, &["commit", "-q", "-m", "init"]);
+        let wt = repo.join(".pdo").join("runs").join(run_id).join("worktree");
+        std::fs::create_dir_all(wt.parent().unwrap()).unwrap();
+        let branch = format!("pdo/run-{run_id}");
+        git(
+            &repo,
+            &[
+                "worktree",
+                "add",
+                "-q",
+                "-b",
+                &branch,
+                wt.to_str().unwrap(),
+                "main",
+            ],
+        );
+        (tmp, wt)
+    }
+
+    fn bank_with(tmp: &Path, id: &str, name: &str) -> PathBuf {
+        let bank_root = tmp.join("bank");
+        let dir = crate::skill_bank::skill_dir(&bank_root, id);
+        std::fs::create_dir_all(dir.join("references")).unwrap();
+        std::fs::write(
+            dir.join("SKILL.md"),
+            format!("---\nname: {name}\ndescription: d\n---\n\n# {name}\n"),
+        )
+        .unwrap();
+        std::fs::write(dir.join("references").join("notes.md"), "ref\n").unwrap();
+        bank_root
+    }
+
+    fn eff(id: &str, name: &str) -> EffectiveSkill {
+        EffectiveSkill {
+            id: id.into(),
+            name: name.into(),
+            tiers: vec![SkillTier::Instance],
+        }
+    }
+
+    fn repo_of(wt: &Path) -> PathBuf {
+        wt.ancestors().nth(4).unwrap().to_path_buf()
+    }
+
+    #[test]
+    fn delivers_copy_and_link_and_keeps_git_status_clean() {
+        let (tmp, wt) = repo_and_worktree("r1");
+        let repo = repo_of(&wt);
+        let bank = bank_with(tmp.path(), "s1", "tdd");
+        let skills = [eff("s1", "tdd")];
+        let skipped = snapshot_skills(&bank, &repo, "r1", &skills).unwrap();
+        assert!(skipped.is_empty());
+        let report = deliver(&wt, &snapshot_root(&repo, "r1"), "r1", &skills).unwrap();
+        assert_eq!(report.delivered, vec!["tdd".to_string()]);
+        assert!(report.skipped.is_empty());
+
+        assert!(wt.join(".agents/skills/tdd/SKILL.md").is_file());
+        assert!(wt.join(".agents/skills/tdd/references/notes.md").is_file());
+        let link = wt.join(".claude/skills/tdd");
+        assert!(std::fs::symlink_metadata(&link)
+            .unwrap()
+            .file_type()
+            .is_symlink());
+        assert!(link.join("SKILL.md").is_file(), "link resolves to the copy");
+
+        assert_eq!(
+            git(&wt, &["status", "--porcelain"]),
+            "",
+            "worktree is clean"
+        );
+        // Even an agent's `git add -A && git commit` cannot take the skill along.
+        git(&wt, &["add", "-A"]);
+        assert_eq!(git(&wt, &["diff", "--cached", "--name-only"]), "");
+
+        let excl = exclusions_of(&repo, "r1");
+        assert_eq!(
+            excl,
+            vec![
+                "/.agents/skills/tdd/".to_string(),
+                "/.claude/skills/tdd".to_string()
+            ]
+        );
+        // The provisioning manifest lists both, so the completion commit filters them.
+        let recorded = crate::provisioning::materialized_paths(&wt).unwrap();
+        assert!(recorded.contains(&b".agents/skills/tdd".to_vec()));
+        assert!(recorded.contains(&b".claude/skills/tdd".to_vec()));
+    }
+
+    #[test]
+    fn a_second_delivery_into_the_same_worktree_is_idempotent() {
+        let (tmp, wt) = repo_and_worktree("r2");
+        let repo = repo_of(&wt);
+        let bank = bank_with(tmp.path(), "s1", "tdd");
+        let skills = [eff("s1", "tdd")];
+        snapshot_skills(&bank, &repo, "r2", &skills).unwrap();
+        let root = snapshot_root(&repo, "r2");
+        deliver(&wt, &root, "r2", &skills).unwrap();
+        let report = deliver(&wt, &root, "r2", &skills).unwrap();
+        assert_eq!(report.delivered, vec!["tdd".to_string()]);
+        assert!(report.skipped.is_empty());
+        assert_eq!(exclusions_of(&repo, "r2").len(), 2, "no duplicated lines");
+    }
+
+    #[test]
+    fn a_versioned_homonym_is_kept_tracked_and_the_pdo_skill_is_skipped() {
+        let (tmp, wt) = repo_and_worktree("r3");
+        let repo = repo_of(&wt);
+        // The target repo versions its own `.agents/skills/x`.
+        std::fs::create_dir_all(repo.join(".agents/skills/x")).unwrap();
+        std::fs::write(repo.join(".agents/skills/x/SKILL.md"), "repo's own\n").unwrap();
+        git(&repo, &["add", "."]);
+        git(&repo, &["commit", "-q", "-m", "own skill"]);
+        git(&wt, &["merge", "-q", "main"]);
+
+        let bank = bank_with(tmp.path(), "sx", "x");
+        let skills = [eff("sx", "x")];
+        snapshot_skills(&bank, &repo, "r3", &skills).unwrap();
+        let report = deliver(&wt, &snapshot_root(&repo, "r3"), "r3", &skills).unwrap();
+        assert!(report.delivered.is_empty());
+        assert_eq!(report.skipped.len(), 1);
+        assert!(report.skipped[0].reason.contains("versioned"));
+
+        assert_eq!(
+            std::fs::read_to_string(wt.join(".agents/skills/x/SKILL.md")).unwrap(),
+            "repo's own\n"
+        );
+        assert!(!wt.join(".claude/skills/x").exists());
+        assert!(
+            exclusions_of(&repo, "r3").is_empty(),
+            "nothing of x is ignored"
+        );
+        assert_eq!(
+            git(&wt, &["ls-files", ".agents/skills/x"]).trim(),
+            ".agents/skills/x/SKILL.md"
+        );
+    }
+
+    #[test]
+    fn an_existing_claude_skills_folder_receives_the_links_without_being_overwritten() {
+        let (tmp, wt) = repo_and_worktree("r4");
+        let repo = repo_of(&wt);
+        std::fs::create_dir_all(repo.join(".claude/skills/own")).unwrap();
+        std::fs::write(repo.join(".claude/skills/own/SKILL.md"), "own\n").unwrap();
+        git(&repo, &["add", "."]);
+        git(&repo, &["commit", "-q", "-m", "own claude skill"]);
+        git(&wt, &["merge", "-q", "main"]);
+
+        let bank = bank_with(tmp.path(), "s1", "tdd");
+        let skills = [eff("s1", "tdd")];
+        snapshot_skills(&bank, &repo, "r4", &skills).unwrap();
+        let report = deliver(&wt, &snapshot_root(&repo, "r4"), "r4", &skills).unwrap();
+        assert_eq!(report.delivered, vec!["tdd".to_string()]);
+        assert!(wt.join(".claude/skills/own/SKILL.md").is_file());
+        assert!(wt.join(".claude/skills/tdd/SKILL.md").is_file());
+        assert_eq!(git(&wt, &["status", "--porcelain"]), "");
+    }
+
+    #[test]
+    fn a_symlinked_claude_skills_pointing_at_agents_skills_needs_no_second_link() {
+        let (tmp, wt) = repo_and_worktree("r5");
+        let repo = repo_of(&wt);
+        std::fs::create_dir_all(repo.join(".claude")).unwrap();
+        symlink_dir("../.agents/skills", &repo.join(".claude/skills")).unwrap();
+        std::fs::create_dir_all(repo.join(".agents/skills")).unwrap();
+        std::fs::write(repo.join(".agents/skills/.keep"), "").unwrap();
+        git(&repo, &["add", "."]);
+        git(&repo, &["commit", "-q", "-m", "symlinked claude skills"]);
+        git(&wt, &["merge", "-q", "main"]);
+
+        let bank = bank_with(tmp.path(), "s1", "tdd");
+        let skills = [eff("s1", "tdd")];
+        snapshot_skills(&bank, &repo, "r5", &skills).unwrap();
+        let report = deliver(&wt, &snapshot_root(&repo, "r5"), "r5", &skills).unwrap();
+        assert_eq!(report.delivered, vec!["tdd".to_string()]);
+        assert!(report.skipped.is_empty());
+        assert!(wt.join(".claude/skills/tdd/SKILL.md").is_file());
+        assert_eq!(git(&wt, &["status", "--porcelain"]), "");
+        assert_eq!(
+            exclusions_of(&repo, "r5"),
+            vec!["/.agents/skills/tdd/".to_string()]
+        );
+    }
+
+    #[test]
+    fn cleanup_removes_only_this_runs_marked_lines() {
+        let (tmp, wt) = repo_and_worktree("r6");
+        let repo = repo_of(&wt);
+        let exclude = exclude_path(&repo).unwrap().unwrap();
+        std::fs::create_dir_all(exclude.parent().unwrap()).unwrap();
+        std::fs::write(
+            &exclude,
+            "# user line\n*.swp\n# pdo other-run\n/.agents/skills/zzz/\n",
+        )
+        .unwrap();
+
+        let bank = bank_with(tmp.path(), "s1", "tdd");
+        let skills = [eff("s1", "tdd")];
+        snapshot_skills(&bank, &repo, "r6", &skills).unwrap();
+        deliver(&wt, &snapshot_root(&repo, "r6"), "r6", &skills).unwrap();
+        assert_eq!(exclusions_of(&repo, "r6").len(), 2);
+
+        remove_exclusions(&repo, "r6").unwrap();
+        assert_eq!(
+            std::fs::read_to_string(&exclude).unwrap(),
+            "# user line\n*.swp\n# pdo other-run\n/.agents/skills/zzz/\n"
+        );
+        assert!(exclusions_of(&repo, "r6").is_empty());
+        // Idempotent, and harmless on a repo with no exclude file at all.
+        remove_exclusions(&repo, "r6").unwrap();
+        let bare = tempfile::tempdir().unwrap();
+        remove_exclusions(bare.path(), "r6").unwrap();
+    }
+
+    #[test]
+    fn snapshot_is_frozen_and_additive() {
+        let (tmp, wt) = repo_and_worktree("r7");
+        let repo = repo_of(&wt);
+        let bank = bank_with(tmp.path(), "s1", "tdd");
+        let first = [eff("s1", "tdd")];
+        snapshot_skills(&bank, &repo, "r7", &first).unwrap();
+        // Editing the bank after the Run started changes nothing delivered.
+        std::fs::write(
+            crate::skill_bank::skill_dir(&bank, "s1").join("SKILL.md"),
+            "---\nname: tdd\ndescription: edited\n---\n",
+        )
+        .unwrap();
+        snapshot_skills(&bank, &repo, "r7", &first).unwrap();
+        deliver(&wt, &snapshot_root(&repo, "r7"), "r7", &first).unwrap();
+        let delivered = std::fs::read_to_string(wt.join(".agents/skills/tdd/SKILL.md")).unwrap();
+        assert!(
+            delivered.contains("description: d"),
+            "frozen content, not the edit"
+        );
+
+        // A node whose selection adds a skill later gets it snapshotted (additive).
+        bank_with(tmp.path(), "s2", "grilling");
+        let both = [eff("s1", "tdd"), eff("s2", "grilling")];
+        let skipped = snapshot_skills(&bank, &repo, "r7", &both).unwrap();
+        assert!(skipped.is_empty());
+        assert!(snapshot_root(&repo, "r7").join("s2/SKILL.md").is_file());
+        let report = deliver(&wt, &snapshot_root(&repo, "r7"), "r7", &both).unwrap();
+        assert_eq!(
+            report.delivered,
+            vec!["tdd".to_string(), "grilling".to_string()]
+        );
+
+        // A skill deleted from the bank before it was ever snapshotted is reported.
+        let gone = [eff("s3", "gone")];
+        let skipped = snapshot_skills(&bank, &repo, "r7", &gone).unwrap();
+        assert_eq!(skipped.len(), 1);
+        let report = deliver(&wt, &snapshot_root(&repo, "r7"), "r7", &gone).unwrap();
+        assert_eq!(report.skipped.len(), 1);
+        assert!(report.skipped[0].reason.contains("snapshot"));
+    }
+
+    #[test]
+    fn the_completion_commit_filters_a_skill_the_agent_force_added() {
+        let (tmp, wt) = repo_and_worktree("r8");
+        let repo = repo_of(&wt);
+        let bank = bank_with(tmp.path(), "s1", "tdd");
+        let skills = [eff("s1", "tdd")];
+        snapshot_skills(&bank, &repo, "r8", &skills).unwrap();
+        deliver(&wt, &snapshot_root(&repo, "r8"), "r8", &skills).unwrap();
+        // The agent bypasses the exclusion on purpose and leaves real work too.
+        git(
+            &wt,
+            &["add", "-f", ".agents/skills/tdd", ".claude/skills/tdd"],
+        );
+        std::fs::write(wt.join("work.txt"), "done\n").unwrap();
+        let sha = crate::worktree_ops::stage_and_commit(&wt, "n", 1).unwrap();
+        assert!(sha.is_some());
+        let files = git(&wt, &["show", "--name-only", "--format=", "HEAD"]);
+        assert_eq!(files.trim(), "work.txt");
+        assert_eq!(git(&wt, &["status", "--porcelain"]), "");
+    }
+}

--- a/crates/pdo-daemon/src/skill_selection.rs
+++ b/crates/pdo-daemon/src/skill_selection.rs
@@ -4,8 +4,10 @@
 //!
 //! Four additive tiers carry the same key `skills`, a list of [`SkillRef`]
 //! (`id` + `name`): the Configuration d'instance, the Projet owning the Run's
-//! primary repo, the Run (frozen into `RunStarted` at create, seeded from the
-//! Trigger for a fired Run) and the Node of the pipeline document. Unlike the
+//! primary repo, the Run (seeded from the Trigger for a fired Run) and the Node of
+//! the pipeline document. Since #672 the first three are resolved ONCE at create
+//! and frozen on `RunStarted` (`frozen_skills`, see `skill_delivery`); a node spawn
+//! adds only its own tier to that base. Unlike the
 //! agentic profile (`agent_choice`, ADR-0057) where the finest explicit tier
 //! *wins*, skills are a **strict additive union**: no tier removes a skill an
 //! outer tier selected (CONTEXT.md: « aucun tier ne retire un skill hérité »).

--- a/crates/pdo-daemon/src/worktree_ops.rs
+++ b/crates/pdo-daemon/src/worktree_ops.rs
@@ -66,6 +66,12 @@ pub(crate) fn reap_orphan_sub_worktree(
 
 pub(crate) fn reap_orphan_run_worktree(repo_root: &Path, worktree_dir: &Path, branch: &str) {
     reap_orphan_sub_worktree(repo_root, worktree_dir, branch);
+    // #672: a Run aborted at create may already have snapshotted skills beside the
+    // worktree and excluded their paths in the repo's `info/exclude`; take both back.
+    if let Some(run_id) = branch.strip_prefix("pdo/run-") {
+        let _ = crate::skill_delivery::remove_exclusions(repo_root, run_id);
+        let _ = std::fs::remove_dir_all(crate::skill_delivery::snapshot_root(repo_root, run_id));
+    }
     if let Some(run_dir) = worktree_dir.parent() {
         let _ = std::fs::remove_dir(run_dir);
     }

--- a/crates/pdo-daemon/tests/it.rs
+++ b/crates/pdo-daemon/tests/it.rs
@@ -146,6 +146,9 @@ mod sandbox_profiles;
 #[path = "skill_bank.rs"]
 mod skill_bank;
 
+#[path = "skill_delivery.rs"]
+mod skill_delivery;
+
 #[path = "sandbox_tracer.rs"]
 mod sandbox_tracer;
 

--- a/crates/pdo-daemon/tests/skill_bank.rs
+++ b/crates/pdo-daemon/tests/skill_bank.rs
@@ -868,7 +868,6 @@ async fn file_endpoints_on_an_unknown_skill_are_404() {
     assert_eq!(resp.status(), StatusCode::NOT_FOUND);
 }
 
-
 // ---------------------------------------------------------------------------
 // #669 — selection by tier, skills effectifs with origin, referents populated.
 // A real daemon, a seeded pipeline, nodes spawned through the tmux command seam

--- a/crates/pdo-daemon/tests/skill_delivery.rs
+++ b/crates/pdo-daemon/tests/skill_delivery.rs
@@ -1,0 +1,404 @@
+//! Layer 3 (#672, ADR-0062) — skills **delivered in the worktree, never
+//! committed**, end to end through the daemon.
+//!
+//! A real daemon over a tempdir repo; a skill selected at the instance tier and
+//! another on the node; a Run whose repo already versions its own
+//! `.agents/skills/x`. The assertions are the Feature Path's: what the frozen
+//! events say, what the worktree contains, what `git status` and the Run branch
+//! show, and what `info/exclude` holds before and after cleanup.
+
+use std::path::{Path, PathBuf};
+
+use crate::common::TestDaemon;
+
+const PIPELINE_NAME: &str = "skill-delivery-test";
+
+fn pipeline_yaml(node_skills: &str) -> String {
+    format!(
+        r#"name: {PIPELINE_NAME}
+version: "1.0"
+nodes:
+  - id: start
+    name: Start
+    type: start
+    outputs:
+      - name: user_prompt
+  - id: aaaaaaaa
+    name: worker
+    type: agent
+    isolated_worktree: false
+{node_skills}    outputs:
+      - name: out
+    view: {{ x: 200, y: 60 }}
+  - id: end
+    name: End
+    type: end
+    inputs:
+      - name: result
+edges:
+  - source: {{ node: start, port: user_prompt }}
+    target: {{ node: aaaaaaaa, port: task }}
+  - source: {{ node: aaaaaaaa, port: out }}
+    target: {{ node: end, port: result }}
+"#
+    )
+}
+
+fn git(dir: &Path, args: &[&str]) -> String {
+    let out = std::process::Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+/// A repo with one commit that already versions `.agents/skills/x/SKILL.md`.
+fn seed(repo: &Path) -> anyhow::Result<()> {
+    let pipelines_dir = repo.join(".pdo").join("pipelines");
+    std::fs::create_dir_all(&pipelines_dir)?;
+    std::fs::write(
+        pipelines_dir.join(format!("{PIPELINE_NAME}.yaml")),
+        pipeline_yaml(""),
+    )?;
+    let prompts_dir = pipelines_dir.join(format!("{PIPELINE_NAME}.prompts"));
+    std::fs::create_dir_all(&prompts_dir)?;
+    std::fs::write(prompts_dir.join("aaaaaaaa.md"), "You are the worker.\n")?;
+    std::fs::create_dir_all(repo.join(".agents/skills/x"))?;
+    std::fs::write(
+        repo.join(".agents/skills/x/SKILL.md"),
+        "---\nname: x\ndescription: the repo's own\n---\n",
+    )?;
+    git(repo, &["init", "-q", "-b", "main"]);
+    git(repo, &["config", "user.email", "test@example.com"]);
+    git(repo, &["config", "user.name", "Test"]);
+    git(repo, &["config", "commit.gpgsign", "false"]);
+    std::fs::write(repo.join(".gitignore"), ".pdo/runs/\n")?;
+    git(repo, &["add", "."]);
+    git(repo, &["commit", "-q", "-m", "init"]);
+    Ok(())
+}
+
+fn skill_md(name: &str, description: &str) -> String {
+    format!("---\nname: {name}\ndescription: {description}\n---\n\n# {name}\n")
+}
+
+async fn create_skill(daemon: &TestDaemon, name: &str) -> String {
+    let resp = reqwest::Client::new()
+        .post(format!("{}/settings/skills", daemon.url()))
+        .json(&serde_json::json!({ "content": skill_md(name, "a skill for the delivery test") }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        201,
+        "POST /settings/skills should return 201"
+    );
+    let json: serde_json::Value = resp.json().await.unwrap();
+    json["id"].as_str().unwrap().to_string()
+}
+
+async fn select_at_instance(daemon: &TestDaemon, skills: serde_json::Value) {
+    let resp = reqwest::Client::new()
+        .put(format!("{}/settings", daemon.url()))
+        .json(&serde_json::json!({ "skills": skills }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200, "PUT /settings should return 200");
+}
+
+async fn create_run(daemon: &TestDaemon, body: serde_json::Value) -> String {
+    let resp = reqwest::Client::new()
+        .post(format!("{}/runs", daemon.url()))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 201, "POST /runs should return 201");
+    let json: serde_json::Value = resp.json().await.unwrap();
+    json["run_id"].as_str().unwrap().to_string()
+}
+
+async fn events(daemon: &TestDaemon, run_id: &str) -> Vec<serde_json::Value> {
+    let v: serde_json::Value = reqwest::get(format!("{}/runs/{run_id}/events", daemon.url()))
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    v.as_array().cloned().unwrap_or_default()
+}
+
+fn find<'a>(evs: &'a [serde_json::Value], kind: &str) -> Option<&'a serde_json::Value> {
+    evs.iter().rev().find(|e| e["kind"] == kind)
+}
+
+async fn wait_for_node_started(daemon: &TestDaemon, run_id: &str) -> serde_json::Value {
+    for _ in 0..100 {
+        let evs = events(daemon, run_id).await;
+        if let Some(e) = evs
+            .iter()
+            .rev()
+            .find(|e| e["kind"] == "node_started" && e["node_id"] == "aaaaaaaa")
+        {
+            return e.clone();
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+    panic!("worker node should have started within the timeout");
+}
+
+async fn cleanup(daemon: &TestDaemon, run_id: &str) {
+    let resp = reqwest::Client::new()
+        .post(format!("{}/runs/{run_id}/commands", daemon.url()))
+        .json(&serde_json::json!({ "kind": "cleanup_run" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200, "cleanup_run should return 200");
+}
+
+fn worktree_of(daemon: &TestDaemon, run_id: &str) -> PathBuf {
+    daemon
+        .repo_root()
+        .join(".pdo")
+        .join("runs")
+        .join(run_id)
+        .join("worktree")
+}
+
+/// `git status --porcelain` minus PDO's own runtime paths (`.pdo/artifacts`,
+/// `.pdo/prompts`), which the target repo's `.gitignore` owns (ADR-0060) — the seed
+/// here ignores only `.pdo/runs/`.
+fn status_outside_pdo(worktree: &Path) -> String {
+    git(worktree, &["status", "--porcelain"])
+        .lines()
+        .filter(|l| !l.contains(".pdo/"))
+        .map(|l| format!("{l}\n"))
+        .collect()
+}
+
+fn exclude_file(repo: &Path) -> PathBuf {
+    repo.join(".git").join("info").join("exclude")
+}
+
+fn pdo_exclude_lines(repo: &Path) -> Vec<String> {
+    std::fs::read_to_string(exclude_file(repo))
+        .unwrap_or_default()
+        .lines()
+        .filter(|l| l.starts_with("# pdo"))
+        .map(String::from)
+        .collect()
+}
+
+/// FP steps 1-5: instance skill + node skill, versioned homonym, frozen events,
+/// clean status, no skill on the Run branch, exclusions gone after cleanup.
+#[tokio::test]
+async fn skills_are_delivered_in_the_worktree_frozen_and_never_committed() {
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+    let repo = daemon.repo_root().to_path_buf();
+    // A user line the cleanup must leave alone.
+    std::fs::create_dir_all(repo.join(".git/info")).unwrap();
+    std::fs::write(exclude_file(&repo), "# mine\n*.swp\n").unwrap();
+
+    let tdd = create_skill(&daemon, "tdd").await;
+    let grilling = create_skill(&daemon, "grilling").await;
+    let homonym = create_skill(&daemon, "x").await;
+    select_at_instance(
+        &daemon,
+        serde_json::json!([{ "id": tdd, "name": "tdd" }, { "id": homonym, "name": "x" }]),
+    )
+    .await;
+
+    // The node selects `grilling` — its own tier, read at spawn.
+    let node_skills = format!("    skills:\n      - id: {grilling}\n        name: grilling\n");
+    std::fs::write(
+        repo.join(".pdo/pipelines")
+            .join(format!("{PIPELINE_NAME}.yaml")),
+        pipeline_yaml(&node_skills),
+    )
+    .unwrap();
+
+    let run_id = create_run(
+        &daemon,
+        serde_json::json!({
+            "pipeline": PIPELINE_NAME,
+            "input": "go",
+            "target_repo": daemon.target_repo(),
+        }),
+    )
+    .await;
+    let worktree = worktree_of(&daemon, &run_id);
+
+    // RunStarted freezes the instance + Projet + Run selection, with the homonym
+    // reported as skipped at the Run level (delivered into the Run worktree).
+    let evs = events(&daemon, &run_id).await;
+    let run_started = find(&evs, "run_started").expect("run_started");
+    let frozen = run_started["payload"]["frozen_skills"]
+        .as_array()
+        .expect("frozen_skills on RunStarted");
+    assert_eq!(frozen.len(), 2);
+    assert_eq!(frozen[0]["name"], "tdd");
+    assert_eq!(frozen[0]["tiers"], serde_json::json!(["instance"]));
+    let skipped = run_started["payload"]["skipped_skills"]
+        .as_array()
+        .expect("skipped_skills on RunStarted");
+    assert_eq!(skipped.len(), 1);
+    assert_eq!(skipped[0]["name"], "x");
+
+    // The node spawns: NodeStarted freezes the union and the homonym warning.
+    let node_started = wait_for_node_started(&daemon, &run_id).await;
+    let names: Vec<&str> = node_started["payload"]["skills"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|s| s["name"].as_str().unwrap())
+        .collect();
+    assert_eq!(names, vec!["tdd", "x", "grilling"]);
+    let node_skipped = node_started["payload"]["skipped_skills"]
+        .as_array()
+        .unwrap();
+    assert_eq!(node_skipped.len(), 1);
+    assert_eq!(node_skipped[0]["name"], "x");
+    assert!(node_skipped[0]["reason"]
+        .as_str()
+        .unwrap()
+        .contains("versioned"));
+
+    // FP 3: the skills are on disk, in both locations; the repo's own `x` is intact
+    // and tracked; `git status` is clean.
+    assert!(worktree.join(".agents/skills/tdd/SKILL.md").is_file());
+    assert!(worktree.join(".agents/skills/grilling/SKILL.md").is_file());
+    assert!(worktree.join(".claude/skills/tdd/SKILL.md").is_file());
+    assert!(worktree.join(".claude/skills/grilling/SKILL.md").is_file());
+    assert!(
+        std::fs::symlink_metadata(worktree.join(".claude/skills/tdd"))
+            .unwrap()
+            .file_type()
+            .is_symlink()
+    );
+    assert_eq!(
+        std::fs::read_to_string(worktree.join(".agents/skills/x/SKILL.md")).unwrap(),
+        "---\nname: x\ndescription: the repo's own\n---\n"
+    );
+    assert!(!worktree.join(".claude/skills/x").exists());
+    assert_eq!(
+        git(&worktree, &["ls-files", ".agents/skills/x"]).trim(),
+        ".agents/skills/x/SKILL.md"
+    );
+    assert_eq!(status_outside_pdo(&worktree), "");
+
+    // Content frozen at the Run: editing the bank now changes nothing delivered,
+    // even to a node spawned later.
+    let resp = reqwest::Client::new()
+        .put(format!(
+            "{}/settings/skills/{tdd}/files/SKILL.md",
+            daemon.url()
+        ))
+        .body(skill_md("tdd", "EDITED after the Run started"))
+        .send()
+        .await
+        .unwrap();
+    assert!(
+        resp.status().is_success(),
+        "PUT SKILL.md: {}",
+        resp.status()
+    );
+    assert!(
+        std::fs::read_to_string(worktree.join(".agents/skills/tdd/SKILL.md"))
+            .unwrap()
+            .contains("a skill for the delivery test")
+    );
+    assert!(
+        std::fs::read_to_string(
+            repo.join(".pdo/runs")
+                .join(&run_id)
+                .join("skills")
+                .join(&tdd)
+                .join("SKILL.md")
+        )
+        .unwrap()
+        .contains("a skill for the delivery test"),
+        "the Run snapshot is the frozen content"
+    );
+
+    // FP 4: even `git add -A && git commit` by the agent takes no skill along, and
+    // the Run's diff against its fork point shows none.
+    std::fs::write(worktree.join("work.txt"), "agent work\n").unwrap();
+    git(&worktree, &["add", "-A"]);
+    git(&worktree, &["commit", "-q", "-m", "agent commit"]);
+    let committed = git(&worktree, &["diff", "--name-only", "main...HEAD"]);
+    let committed: Vec<String> = committed
+        .lines()
+        .filter(|l| !l.starts_with(".pdo/"))
+        .map(String::from)
+        .collect();
+    assert_eq!(committed, vec!["work.txt".to_string()]);
+    assert_eq!(status_outside_pdo(&worktree), "");
+
+    // The exclusions are per skill, never a parent folder, marked `# pdo <run-id>`.
+    let exclude = std::fs::read_to_string(exclude_file(&repo)).unwrap();
+    assert!(exclude.contains("/.agents/skills/tdd/\n"));
+    assert!(exclude.contains("/.claude/skills/grilling\n"));
+    assert!(!exclude.contains("/.agents/skills/\n"));
+    assert!(!exclude.contains("/.agents/skills/x"));
+    assert!(pdo_exclude_lines(&repo)
+        .iter()
+        .all(|l| l == &format!("# pdo {run_id}")));
+
+    // FP 5: cleanup removes every `# pdo` line and nothing else.
+    cleanup(&daemon, &run_id).await;
+    assert_eq!(
+        std::fs::read_to_string(exclude_file(&repo)).unwrap(),
+        "# mine\n*.swp\n"
+    );
+}
+
+/// Changing a node's selection after the Run started reaches a node not yet
+/// launched (additive snapshot), while the instance tier stays as frozen.
+#[tokio::test]
+async fn a_selection_changed_before_spawn_is_snapshotted_additively() {
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+
+    let tdd = create_skill(&daemon, "tdd").await;
+    select_at_instance(&daemon, serde_json::json!([{ "id": tdd, "name": "tdd" }])).await;
+
+    let run_id = create_run(
+        &daemon,
+        serde_json::json!({
+            "pipeline": PIPELINE_NAME,
+            "input": "go",
+            "target_repo": daemon.target_repo(),
+        }),
+    )
+    .await;
+    let worktree = worktree_of(&daemon, &run_id);
+    assert!(worktree.join(".agents/skills/tdd/SKILL.md").is_file());
+
+    // After the Run started the instance tier is cleared: the Run keeps what it
+    // froze (the additive node-tier snapshot is covered by the module's unit test —
+    // the spawn here races the edit, so it is not asserted end to end).
+    select_at_instance(&daemon, serde_json::json!([])).await;
+
+    let node_started = wait_for_node_started(&daemon, &run_id).await;
+    let names: Vec<&str> = node_started["payload"]["skills"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|s| s["name"].as_str().unwrap())
+        .collect();
+    assert_eq!(
+        names,
+        vec!["tdd"],
+        "the frozen instance tier still delivers tdd"
+    );
+    assert!(worktree.join(".agents/skills/tdd/SKILL.md").is_file());
+    assert_eq!(status_outside_pdo(&worktree), "");
+}

--- a/frontend/src/components/NodeInspector.tsx
+++ b/frontend/src/components/NodeInspector.tsx
@@ -393,6 +393,15 @@ export default function NodeInspector({
                     {" "}· missing: {runNode.missing_skills.map((skill) => skill.name || skill.id).join(", ")}
                   </span>
                 )}
+                {runNode.skipped_skills && runNode.skipped_skills.length > 0 && (
+                  <span
+                    className="text-st-blocked"
+                    data-testid="node-skills-skipped"
+                    title={runNode.skipped_skills.map((skill) => `${skill.name}: ${skill.reason}`).join("\n")}
+                  >
+                    {" "}· not delivered: {runNode.skipped_skills.map((skill) => skill.name || skill.id).join(", ")}
+                  </span>
+                )}
               </p>
             )}
             <div className="sr-only">

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -718,6 +718,12 @@ export interface NodeState {
   skills?: EffectiveSkill[];
   /** #669: selected ids the bank no longer knew at spawn — the node ran without them. */
   missing_skills?: MissingSkill[];
+  /**
+   * #672: skills promised to this NodeRun that the delivery could not write into
+   * its worktree (a versioned homonym in the target repo, an occupied path, content
+   * gone from the bank) — the node ran without them.
+   */
+  skipped_skills?: SkippedSkill[];
   /** Node provisioning recipe frozen into this iteration's NodeStarted event. */
   provisioning?: ProvisioningRules;
   /** Time this iteration's isolated worktree recipe was first materialized. */
@@ -1566,4 +1572,11 @@ export interface EffectiveSkill extends SkillRef {
 /** A selected id the bank no longer knew at spawn. */
 export interface MissingSkill extends SkillRef {
   tiers: SkillTier[];
+}
+
+/** #672: a skill not delivered into a worktree, with the reason it was skipped. */
+export interface SkippedSkill {
+  id: string;
+  name: string;
+  reason: string;
 }


### PR DESCRIPTION
Sub-ticket #672 of story #666 (spec #667, ADR-0062).

## What
- New module `skill_delivery.rs`: snapshot of the effective skills frozen at the Run (`.pdo/runs/<run>/skills/`, additive), copied into every PDO-created worktree under `.agents/skills/<name>/` with a relative `.claude/skills/<name>` symlink.
- Per-skill exclusion via `# pdo <run-id>` marked lines in the target repo's `info/exclude`, never a parent folder; removed by `cleanup_run` / orphan reap. Paths also recorded in the provisioning manifest so the completion commit filters them even after `git add -A`.
- Versioned homonym (`.agents/skills/x` tracked) left intact and tracked; the PDO skill is skipped and reported as `skipped_skills` on `RunStarted` / `NodeStarted` (node inspector shows "not delivered" with the reason).
- Existing `.claude/skills` (folder or symlink) receives per-skill links without overwriting.
- Bump to 1.55.0 + CHANGELOG entry.

## Validation
- Feature Path driven against a real `claude` session on a debug daemon: all 5 FP steps pass (agent lists both skills, `git status` clean, versioned skill tracked, Run diff has no skill file, `info/exclude` clean after cleanup).
- `make check` green; `cargo nextest`: 2776 passed; frontend vitest: 2110 passed, 18 skipped.

## Non-blocking findings from the FP
- `GET /runs/<id>/diff` runs `git` in the daemon's `repo_root`, not the Run's `target_repo` (pre-existing, multi-repo Runs #470).
- `copilot` / `opencode` not installed on the test machine; only `claude` exercised.

Closes #672

🤖 Generated with [Claude Code](https://claude.com/claude-code)