### PR TITLE
fix(frontend): dropdowns close on outside click / Escape (#686) — 1.56.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "1.56.1"
+version = "1.56.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "1.56.1"
+version = "1.56.2"
 license = "MIT"
 description = "Prompt-Driven Orchestrator — a local daemon that runs and supervises agentic coding pipelines"
 repository = "https://github.com/Loulen/prompt-driven-orchestrator"

--- a/frontend/src/components/AgentControl.test.tsx
+++ b/frontend/src/components/AgentControl.test.tsx
@@ -33,6 +33,40 @@ describe("AgentControl", () => {
     expect(onChange).toHaveBeenCalledWith({ mode: "profile", profile_id: "p1" });
   });
 
+  function renderOpen() {
+    render(
+      <AgentControl
+        choice={{ mode: "inherit" }}
+        onChange={vi.fn()}
+        profiles={profiles}
+        catalog={catalog}
+        inherited={{ harness: "claude", model: null, effort: null }}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("agent-control"));
+    expect(screen.getByTestId("agent-control-popover")).toBeInTheDocument();
+    expect(screen.getByTestId("agent-control")).toHaveAttribute("aria-expanded", "true");
+  }
+
+  it("closes on a click outside the control (#686)", () => {
+    renderOpen();
+    fireEvent.mouseDown(document.body);
+    expect(screen.queryByTestId("agent-control-popover")).not.toBeInTheDocument();
+    expect(screen.getByTestId("agent-control")).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("stays open on a click inside the popover", () => {
+    renderOpen();
+    fireEvent.mouseDown(screen.getByText("Profiles"));
+    expect(screen.getByTestId("agent-control-popover")).toBeInTheDocument();
+  });
+
+  it("closes on Escape (#686)", () => {
+    renderOpen();
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.queryByTestId("agent-control-popover")).not.toBeInTheDocument();
+  });
+
   it("marks a missing profile and falls through to the inherited combination", () => {
     const resolved = resolveAgentChoice(
       { mode: "profile", profile_id: "gone" },

--- a/frontend/src/components/AgentControl.tsx
+++ b/frontend/src/components/AgentControl.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Bookmark, Check, ChevronDown, ChevronLeft, GitFork, SlidersHorizontal, TriangleAlert } from "lucide-react";
 import type { AgentChoice, AgentCombination, AgentProfile } from "../types";
 import type { HarnessCatalog } from "../lib/harness";
@@ -51,13 +51,39 @@ export default function AgentControl({
     : GitFork;
   const harnessOption = findHarnessOption(catalog, custom.harness);
 
+  const rootRef = useRef<HTMLDivElement>(null);
+
   const close = () => {
     setOpen(false);
     setCustomPane(false);
   };
 
+  // Dismiss on outside click and Escape (#686). The nested Harness/Model/Effort
+  // pickers render through a portal, so a click or key inside one of them lands
+  // outside `rootRef` — those events belong to the nested menu and are ignored.
+  useEffect(() => {
+    if (!open) return;
+    const insidePortaledMenu = (target: EventTarget | null) =>
+      target instanceof Element && target.closest('[data-slot="dropdown-menu-content"]') != null;
+    const onMouseDown = (event: MouseEvent) => {
+      const target = event.target;
+      if (rootRef.current?.contains(target as Node) || insidePortaledMenu(target)) return;
+      close();
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape" || event.defaultPrevented || insidePortaledMenu(event.target)) return;
+      close();
+    };
+    document.addEventListener("mousedown", onMouseDown);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", onMouseDown);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [open]);
+
   return (
-    <div className="relative" data-testid={`${testId}-root`}>
+    <div ref={rootRef} className="relative" data-testid={`${testId}-root`}>
       <span className="mb-1 block uppercase tracking-wider text-fg-4" style={{ fontSize: 9 }}>{label}</span>
       <button
         type="button"

--- a/frontend/src/components/SkillSelector.test.tsx
+++ b/frontend/src/components/SkillSelector.test.tsx
@@ -141,4 +141,28 @@ describe("SkillSelector", () => {
     fireEvent.click(screen.getByTestId("sel"));
     expect(screen.getByTestId("sel-empty")).toHaveTextContent("The bank is empty");
   });
+
+  it("closes on a mousedown outside the picker (#686)", () => {
+    render(<SkillSelector tier="node" own={[]} bank={bank} onChange={vi.fn()} testId="sel" />);
+    fireEvent.click(screen.getByTestId("sel"));
+    expect(screen.getByTestId("sel-popover")).toBeInTheDocument();
+    fireEvent.mouseDown(document.body);
+    expect(screen.queryByTestId("sel-popover")).toBeNull();
+    expect(screen.getByTestId("sel")).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("stays open on a mousedown inside the picker (#686)", () => {
+    render(<SkillSelector tier="node" own={[]} bank={bank} onChange={vi.fn()} testId="sel" />);
+    fireEvent.click(screen.getByTestId("sel"));
+    fireEvent.mouseDown(screen.getByTestId("sel-option-c"));
+    expect(screen.getByTestId("sel-popover")).toBeInTheDocument();
+  });
+
+  it("closes on Escape (#686)", () => {
+    render(<SkillSelector tier="node" own={[]} bank={bank} onChange={vi.fn()} testId="sel" />);
+    fireEvent.click(screen.getByTestId("sel"));
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.queryByTestId("sel-popover")).toBeNull();
+    expect(screen.getByTestId("sel")).toHaveAttribute("aria-expanded", "false");
+  });
 });

--- a/frontend/src/components/SkillSelector.tsx
+++ b/frontend/src/components/SkillSelector.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { ChevronDown, ChevronRight, Folder, FolderOpen, Sparkles, TriangleAlert, X } from "lucide-react";
 import type { SkillBank, SkillRef, SkillTier } from "../types";
 import { buildRows } from "../lib/skillTree";
@@ -47,6 +47,28 @@ export default function SkillSelector({
 }) {
   const [open, setOpen] = useState(false);
   const [filter, setFilter] = useState("");
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  // Dismiss on outside click and Escape (#686, same pattern as AgentControl):
+  // the picker is an absolute overlay that hides the fields below it, so it
+  // must close on any gesture that is not aimed at it.
+  useEffect(() => {
+    if (!open) return;
+    const onMouseDown = (event: MouseEvent) => {
+      if (rootRef.current?.contains(event.target as Node)) return;
+      setOpen(false);
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape" || event.defaultPrevented) return;
+      setOpen(false);
+    };
+    document.addEventListener("mousedown", onMouseDown);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", onMouseDown);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [open]);
   // Folders start expanded (every skill visible at a glance); `null` = untouched.
   const [collapsedOverride, setCollapsedOverride] = useState<Set<string> | null>(null);
   const expanded = useMemo(() => {
@@ -104,7 +126,7 @@ export default function SkillSelector({
   };
 
   return (
-    <div className="relative" data-testid={`${testId}-root`}>
+    <div ref={rootRef} className="relative" data-testid={`${testId}-root`}>
       <span className="mb-1 block uppercase tracking-wider text-fg-4" style={{ fontSize: 9 }}>{label}</span>
       <button
         type="button"


### PR DESCRIPTION
Closes #686.

## What
- `AgentControl.tsx`: the Agent popover closes on outside click and on Escape, so it no longer blocks the Skills picker.
- `SkillSelector.tsx`: the Skills picker gets the same outside-click + Escape dismissal.
- Unit tests added for both components.
- Version bump 1.56.1 → 1.56.2 (Cargo.toml / Cargo.lock).

## Verification
- `vitest run`: 2134 passed / 18 skipped; `tsc -b` and `eslint` clean (fix node).
- Agentic FP (#686 acceptance criteria) run against the branch UI: **Pass** on all 4 criteria, including the Skills picker outside-click that failed in iteration 1.

Pipeline `Bugfix-auto-clean`, run `20260904-160343-9a0da84`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)