### PR TITLE
feat(update): « What's new » changelog modal on version click (#698) — 1.60.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ ascendante** : la casse se signale ici et par un bump majeur, jamais en gardant 
 morts. Seule contrainte non négociable — les **données historiques restent lisibles** : un Run
 archivé s'ouvre et se chiffre quelle que soit la version qui a écrit son payload.
 
+## 1.60.0
+
+**Modale « What's new » au clic sur la version** (#698 ; story #695, spec #696).
+Cliquer la version dans la barre de statut ouvre une modale markdown listant les notes des
+versions manquées (plus récente en premier, pré-releases exclues, liens vers les releases GitHub),
+servie par `GET /update/changelog`. Si le check est désactivé ou la source injoignable, la modale
+signale le repli et affiche le `CHANGELOG.md` embarqué dans le binaire ; à jour, elle l'indique et
+affiche ce même changelog. Le pied de page rappelle la commande de mise à jour manuelle (copie en un clic).
+
 ## 1.59.0
 
 **Vérification de version par le daemon et section « Version & update » en lecture** (#697 ; story #695).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "1.59.0"
+version = "1.60.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "1.59.0"
+version = "1.60.0"
 license = "MIT"
 description = "Prompt-Driven Orchestrator — a local daemon that runs and supervises agentic coding pipelines"
 repository = "https://github.com/Loulen/prompt-driven-orchestrator"

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -403,6 +403,10 @@ struct AppState {
     update_cache: tokio::sync::Mutex<Option<update_check::UpdateCache>>,
     /// Serialises version checks; a second concurrent "Check now" answers 409.
     update_check_lock: tokio::sync::Mutex<()>,
+    /// The release list behind « What's new » (#698), memoised per latest version:
+    /// `(latest_version, releases)`. Opening the modal twice on the same latest
+    /// costs one request to the release source, not two.
+    update_releases: tokio::sync::Mutex<Option<(String, Vec<update_check::Release>)>>,
     /// Extra WebSocket Origin allowlist entries from `PDO_ALLOWED_WS_ORIGINS`,
     /// parsed + normalised at boot. Shared by BOTH WS upgrades (`/ws` and
     /// `/sessions/{id}/pty`) via [`pty_bridge::check_origin`]; the four localhost
@@ -2462,6 +2466,7 @@ pub async fn serve_with_config(
         update_source_url: config.update_source_url,
         update_cache: tokio::sync::Mutex::new(None),
         update_check_lock: tokio::sync::Mutex::new(()),
+        update_releases: tokio::sync::Mutex::new(None),
         allowed_ws_origins: config.allowed_ws_origins,
         libassist_focus: Mutex::new(None),
     });
@@ -4124,6 +4129,7 @@ fn build_router(state: Arc<AppState>) -> Router {
         .route("/settings/cost-prices/sync", post(sync_cost_prices))
         .route("/update", get(get_update_status))
         .route("/update/check", post(check_update_now))
+        .route("/update/changelog", get(get_update_changelog))
         .route(
             "/settings/agent-profiles",
             get(list_agent_profiles).post(create_agent_profile),
@@ -9887,6 +9893,81 @@ async fn check_update_now(State(state): State<Arc<AppState>>) -> Response {
             let mut view = update_status_view(&state).await;
             view["error"] = serde_json::json!(e);
             (StatusCode::BAD_GATEWAY, Json(view)).into_response()
+        }
+    }
+}
+
+/// `GET /update/changelog` — the « What's new » document (#698): the release notes
+/// of every version strictly newer than the installed one, newest first, one `##`
+/// heading per version. The release list is fetched from the source on demand (and
+/// memoised per latest version); the payload says where its body comes from:
+///
+/// - `source: "releases"` — assembled from the missed releases;
+/// - `source: "embedded"`, `fallback_reason: null` — up to date, the embedded
+///   `CHANGELOG.md` is the nominal body;
+/// - `source: "embedded"`, `fallback_reason: "…"` — the list was NOT available
+///   (check off, source unreachable at last check, list fetch failed).
+///
+/// Never an error to the caller: the embedded changelog always answers.
+async fn get_update_changelog(State(state): State<Arc<AppState>>) -> Response {
+    load_update_cache(&state).await;
+    let installed = env!("CARGO_PKG_VERSION");
+    let enabled = update_check_enabled(&state.db).await;
+    let cache = state.update_cache.lock().await.clone();
+
+    if !enabled {
+        return Json(update_check::embedded_changelog(
+            installed,
+            None,
+            "The update check is off.",
+        ))
+        .into_response();
+    }
+    let latest = cache.as_ref().and_then(|c| c.latest_version.clone());
+    let Some(latest) = latest else {
+        let reason = match cache.as_ref().and_then(|c| c.error.as_deref()) {
+            Some(_) => "The release source was unreachable at the last check.",
+            None => "The release source has not been checked yet.",
+        };
+        return Json(update_check::embedded_changelog(installed, None, reason)).into_response();
+    };
+    if !update_check::is_newer(installed, &latest) {
+        // Up to date: nothing to assemble, the embedded changelog is the body.
+        return Json(update_check::assemble_changelog(
+            installed,
+            Some(&latest),
+            &[],
+        ))
+        .into_response();
+    }
+
+    let memo = state.update_releases.lock().await.clone();
+    let releases = match memo {
+        Some((for_latest, rels)) if for_latest == latest => Ok(rels),
+        _ => {
+            let url = update_check::releases_list_url(&update_source_url(&state));
+            let fetched = update_check::fetch_releases(&url).await;
+            if let Ok(rels) = &fetched {
+                *state.update_releases.lock().await = Some((latest.clone(), rels.clone()));
+            }
+            fetched.map_err(|e| format!("release list unavailable: {url}: {e}"))
+        }
+    };
+    match releases {
+        Ok(rels) => Json(update_check::assemble_changelog(
+            installed,
+            Some(&latest),
+            &rels,
+        ))
+        .into_response(),
+        Err(e) => {
+            warn!("update changelog: {e} — falling back to the embedded changelog");
+            Json(update_check::embedded_changelog(
+                installed,
+                Some(&latest),
+                "The release source was unreachable when loading the release notes.",
+            ))
+            .into_response()
         }
     }
 }
@@ -18847,6 +18928,7 @@ mod tests {
             update_source_url: None,
             update_cache: tokio::sync::Mutex::new(None),
             update_check_lock: tokio::sync::Mutex::new(()),
+            update_releases: tokio::sync::Mutex::new(None),
             allowed_ws_origins: Vec::new(),
             libassist_focus: Mutex::new(None),
         })
@@ -20779,6 +20861,7 @@ mod tests {
             update_source_url: None,
             update_cache: tokio::sync::Mutex::new(None),
             update_check_lock: tokio::sync::Mutex::new(()),
+            update_releases: tokio::sync::Mutex::new(None),
             allowed_ws_origins: Vec::new(),
             libassist_focus: Mutex::new(None),
         })
@@ -25245,6 +25328,7 @@ mod tests {
             update_source_url: None,
             update_cache: tokio::sync::Mutex::new(None),
             update_check_lock: tokio::sync::Mutex::new(()),
+            update_releases: tokio::sync::Mutex::new(None),
             allowed_ws_origins: Vec::new(),
             libassist_focus: Mutex::new(None),
         })
@@ -31320,6 +31404,7 @@ edges: []
             update_source_url: None,
             update_cache: tokio::sync::Mutex::new(None),
             update_check_lock: tokio::sync::Mutex::new(()),
+            update_releases: tokio::sync::Mutex::new(None),
             allowed_ws_origins: Vec::new(),
             libassist_focus: Mutex::new(None),
         });
@@ -31522,6 +31607,7 @@ edges: []
             update_source_url: None,
             update_cache: tokio::sync::Mutex::new(None),
             update_check_lock: tokio::sync::Mutex::new(()),
+            update_releases: tokio::sync::Mutex::new(None),
             allowed_ws_origins: Vec::new(),
             libassist_focus: Mutex::new(None),
         });

--- a/crates/pdo-daemon/src/update_check.rs
+++ b/crates/pdo-daemon/src/update_check.rs
@@ -246,6 +246,205 @@ pub(crate) async fn fetch_latest(url: &str) -> Result<String, String> {
 }
 
 // ------------------------------------------------------------------------------------
+// Changelog (#698)
+// ------------------------------------------------------------------------------------
+
+/// The `CHANGELOG.md` at the repository root, embedded at compile time: the
+/// fallback body of « What's new » when the release list is unavailable, and the
+/// body shown to an up-to-date daemon. It lists breaking changes only.
+pub const EMBEDDED_CHANGELOG: &str = include_str!("../../../CHANGELOG.md");
+
+/// One published release, trimmed to what the changelog needs.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Release {
+    /// Bare `major.minor.patch`, tag prefix stripped.
+    pub version: String,
+    /// `published_at` as GitHub sends it (RFC3339), when present.
+    pub published_at: Option<String>,
+    /// The release page, when present.
+    pub html_url: Option<String>,
+    /// Release notes, verbatim markdown. Empty when the release has none.
+    pub body: String,
+}
+
+/// Where the changelog lives, or why it could not come from the releases.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ChangelogSource {
+    /// Assembled from the release notes strictly newer than the installed version.
+    Releases,
+    /// The `CHANGELOG.md` embedded in this build.
+    Embedded,
+}
+
+/// The assembled « What's new » payload.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Changelog {
+    pub installed_version: String,
+    pub latest_version: Option<String>,
+    /// Versions strictly newer than the installed one, newest first. Empty when
+    /// up to date or when the list was unavailable.
+    pub missed_versions: Vec<String>,
+    pub source: ChangelogSource,
+    /// Set exactly when `source == embedded` because the releases were NOT
+    /// available (check off, source unreachable, list fetch failed). `None` for
+    /// an up-to-date daemon: showing the embedded changelog is then the nominal
+    /// answer, not a fallback.
+    pub fallback_reason: Option<String>,
+    pub markdown: String,
+}
+
+/// The releases-list URL for a `releases/latest` source URL: drop the trailing
+/// `/latest` (GitHub: `/repos/{owner}/{repo}/releases`). A source that does not
+/// end in `/latest` is used as is.
+pub fn releases_list_url(latest_url: &str) -> String {
+    let trimmed = latest_url.trim_end_matches('/');
+    match trimmed.strip_suffix("/latest") {
+        Some(base) => base.to_string(),
+        None => trimmed.to_string(),
+    }
+}
+
+/// Parse the GitHub `releases` list payload. Drafts and pre-releases are dropped,
+/// as are entries whose tag is not a version. A payload that is not a JSON array
+/// is an error (the caller falls back to the embedded changelog with the reason).
+pub fn parse_releases_body(body: &str) -> Result<Vec<Release>, String> {
+    let doc: serde_json::Value =
+        serde_json::from_str(body).map_err(|e| format!("releases payload is not JSON: {e}"))?;
+    let items = doc
+        .as_array()
+        .ok_or_else(|| "releases payload is not a JSON array".to_string())?;
+    Ok(items
+        .iter()
+        .filter(|r| !r["draft"].as_bool().unwrap_or(false))
+        .filter(|r| !r["prerelease"].as_bool().unwrap_or(false))
+        .filter_map(|r| {
+            let tag = r["tag_name"].as_str()?;
+            let (maj, min, pat) = parse_version(tag)?;
+            Some(Release {
+                version: format!("{maj}.{min}.{pat}"),
+                published_at: r["published_at"].as_str().map(str::to_string),
+                html_url: r["html_url"].as_str().map(str::to_string),
+                body: r["body"].as_str().unwrap_or("").to_string(),
+            })
+        })
+        .collect())
+}
+
+/// Keep the releases strictly newer than `installed`, newest first. Unparseable
+/// entries (or an unparseable `installed`) yield an empty list: never a claim on a
+/// guess.
+pub fn missed_releases(installed: &str, releases: &[Release]) -> Vec<Release> {
+    let Some(installed) = parse_version(installed) else {
+        return Vec::new();
+    };
+    let mut out: Vec<(u64, u64, u64, Release)> = releases
+        .iter()
+        .filter_map(|r| {
+            let v = parse_version(&r.version)?;
+            (v > installed).then(|| (v.0, v.1, v.2, r.clone()))
+        })
+        .collect();
+    out.sort_by_key(|r| std::cmp::Reverse((r.0, r.1, r.2)));
+    out.dedup_by(|a, b| (a.0, a.1, a.2) == (b.0, b.1, b.2));
+    out.into_iter().map(|(_, _, _, r)| r).collect()
+}
+
+/// One markdown document from the missed releases: `## vX.Y.Z`, then a muted
+/// `Released <date> · [GitHub release](url)` line, then the notes verbatim.
+pub fn render_releases_markdown(missed: &[Release]) -> String {
+    let mut md = String::new();
+    for r in missed {
+        md.push_str(&format!("## v{}\n\n", r.version));
+        let mut meta: Vec<String> = Vec::new();
+        if let Some(at) = r.published_at.as_deref() {
+            let date = at.split('T').next().unwrap_or(at);
+            meta.push(format!("Released {date}"));
+        }
+        if let Some(url) = r.html_url.as_deref() {
+            meta.push(format!("[GitHub release]({url})"));
+        }
+        if !meta.is_empty() {
+            md.push_str(&format!("*{}*\n\n", meta.join(" · ")));
+        }
+        let body = r.body.trim();
+        if body.is_empty() {
+            md.push_str("_No release notes._\n\n");
+        } else {
+            md.push_str(body);
+            md.push_str("\n\n");
+        }
+    }
+    md.trim_end().to_string()
+}
+
+/// Assemble the changelog from a release list: missed versions (newest first) and
+/// their markdown. With nothing newer, the embedded changelog is the body and
+/// `missed_versions` is empty; `fallback_reason` stays `None` (nominal up-to-date).
+pub fn assemble_changelog(
+    installed: &str,
+    latest: Option<&str>,
+    releases: &[Release],
+) -> Changelog {
+    let missed = missed_releases(installed, releases);
+    if missed.is_empty() {
+        return Changelog {
+            installed_version: installed.to_string(),
+            latest_version: latest.map(str::to_string),
+            missed_versions: Vec::new(),
+            source: ChangelogSource::Embedded,
+            fallback_reason: None,
+            markdown: EMBEDDED_CHANGELOG.to_string(),
+        };
+    }
+    Changelog {
+        installed_version: installed.to_string(),
+        latest_version: latest.map(str::to_string),
+        missed_versions: missed.iter().map(|r| r.version.clone()).collect(),
+        source: ChangelogSource::Releases,
+        fallback_reason: None,
+        markdown: render_releases_markdown(&missed),
+    }
+}
+
+/// The embedded changelog as an explicit fallback, with the reason it is one.
+pub fn embedded_changelog(installed: &str, latest: Option<&str>, reason: &str) -> Changelog {
+    Changelog {
+        installed_version: installed.to_string(),
+        latest_version: latest.map(str::to_string),
+        missed_versions: Vec::new(),
+        source: ChangelogSource::Embedded,
+        fallback_reason: Some(reason.to_string()),
+        markdown: EMBEDDED_CHANGELOG.to_string(),
+    }
+}
+
+/// GET the releases list, bounded by [`UPDATE_FETCH_TIMEOUT`], same headers as
+/// [`fetch_latest`].
+pub(crate) async fn fetch_releases(url: &str) -> Result<Vec<Release>, String> {
+    let client = reqwest::Client::builder()
+        .timeout(UPDATE_FETCH_TIMEOUT)
+        .user_agent(format!("pdo/{}", env!("CARGO_PKG_VERSION")))
+        .build()
+        .map_err(|e| e.to_string())?;
+    let mut req = client
+        .get(url)
+        .header("accept", "application/vnd.github+json");
+    if let Ok(token) = std::env::var(GITHUB_TOKEN_ENV) {
+        if !token.is_empty() {
+            req = req.bearer_auth(token);
+        }
+    }
+    let resp = req.send().await.map_err(|e| e.to_string())?;
+    let status = resp.status();
+    if !status.is_success() {
+        return Err(format!("HTTP {status}"));
+    }
+    let body = resp.text().await.map_err(|e| e.to_string())?;
+    parse_releases_body(&body)
+}
+
+// ------------------------------------------------------------------------------------
 // Cache
 // ------------------------------------------------------------------------------------
 
@@ -471,5 +670,119 @@ mod tests {
     fn update_check_resolves_stored_over_default() {
         assert!(update_check_with(Some(1)));
         assert!(!update_check_with(Some(0)));
+    }
+
+    fn rel(v: &str, body: &str) -> Release {
+        Release {
+            version: v.to_string(),
+            published_at: Some(format!("2026-09-0{}T10:00:00Z", v.len() % 9 + 1)),
+            html_url: Some(format!(
+                "https://github.com/Loulen/prompt-driven-orchestrator/releases/tag/v{v}"
+            )),
+            body: body.to_string(),
+        }
+    }
+
+    #[test]
+    fn releases_list_url_drops_latest() {
+        assert_eq!(
+            releases_list_url(RELEASE_SOURCE_URL_DEFAULT),
+            "https://api.github.com/repos/Loulen/prompt-driven-orchestrator/releases"
+        );
+        assert_eq!(
+            releases_list_url("http://127.0.0.1:1/releases/latest/"),
+            "http://127.0.0.1:1/releases"
+        );
+        assert_eq!(releases_list_url("http://x/list"), "http://x/list");
+    }
+
+    #[test]
+    fn releases_body_drops_drafts_prereleases_and_non_versions() {
+        let body = r#"[
+          {"tag_name":"v1.60.0","published_at":"2026-09-06T00:00:00Z","html_url":"u1","body":"- a"},
+          {"tag_name":"v1.61.0-rc.1","prerelease":true,"body":"rc"},
+          {"tag_name":"v1.62.0","draft":true,"body":"draft"},
+          {"tag_name":"nightly","body":"x"},
+          {"tag_name":"v1.59.0","body":null}
+        ]"#;
+        let rels = parse_releases_body(body).unwrap();
+        assert_eq!(
+            rels.iter().map(|r| r.version.as_str()).collect::<Vec<_>>(),
+            ["1.60.0", "1.59.0"]
+        );
+        assert_eq!(
+            rels[0].published_at.as_deref(),
+            Some("2026-09-06T00:00:00Z")
+        );
+        assert_eq!(rels[0].html_url.as_deref(), Some("u1"));
+        assert_eq!(rels[1].body, "");
+        assert!(parse_releases_body(r#"{"tag_name":"v1"}"#).is_err());
+        assert!(parse_releases_body("<html>").is_err());
+    }
+
+    #[test]
+    fn missed_releases_are_strictly_newer_and_sorted_desc() {
+        let all = vec![
+            rel("1.58.1", "same"),
+            rel("1.60.0", "newest"),
+            rel("1.57.0", "older"),
+            rel("1.59.0", "middle"),
+            rel("1.59.0", "duplicate"),
+            rel("2.0.0", "major"),
+        ];
+        let missed = missed_releases("1.58.1", &all);
+        assert_eq!(
+            missed
+                .iter()
+                .map(|r| r.version.as_str())
+                .collect::<Vec<_>>(),
+            ["2.0.0", "1.60.0", "1.59.0"]
+        );
+        assert!(missed_releases("2.0.0", &all).is_empty());
+        assert!(missed_releases("garbage", &all).is_empty());
+    }
+
+    #[test]
+    fn assembled_markdown_has_one_heading_per_version_newest_first() {
+        let all = vec![
+            rel("1.59.0", "- first\n"),
+            rel("1.60.0", ""),
+            rel("1.58.1", "old"),
+        ];
+        let c = assemble_changelog("1.58.1", Some("1.60.0"), &all);
+        assert_eq!(c.source, ChangelogSource::Releases);
+        assert_eq!(c.fallback_reason, None);
+        assert_eq!(c.missed_versions, ["1.60.0", "1.59.0"]);
+        let h60 = c.markdown.find("## v1.60.0").unwrap();
+        let h59 = c.markdown.find("## v1.59.0").unwrap();
+        assert!(h60 < h59, "newest first:\n{}", c.markdown);
+        assert!(!c.markdown.contains("## v1.58.1"));
+        assert!(c.markdown.contains("*Released 2026-09-"));
+        assert!(c.markdown.contains("[GitHub release](https://github.com/"));
+        assert!(c.markdown.contains("- first"));
+        assert!(c.markdown.contains("_No release notes._"));
+    }
+
+    #[test]
+    fn up_to_date_and_fallback_use_the_embedded_changelog() {
+        let all = vec![rel("1.58.1", "same")];
+        let c = assemble_changelog("1.58.1", Some("1.58.1"), &all);
+        assert_eq!(c.source, ChangelogSource::Embedded);
+        assert_eq!(
+            c.fallback_reason, None,
+            "up to date is nominal, not a fallback"
+        );
+        assert!(c.missed_versions.is_empty());
+        assert_eq!(c.markdown, EMBEDDED_CHANGELOG);
+        assert!(EMBEDDED_CHANGELOG.starts_with("# Changelog"));
+
+        let f = embedded_changelog("1.58.1", None, "The update check is off.");
+        assert_eq!(f.source, ChangelogSource::Embedded);
+        assert_eq!(
+            f.fallback_reason.as_deref(),
+            Some("The update check is off.")
+        );
+        assert_eq!(f.latest_version, None);
+        assert_eq!(f.markdown, EMBEDDED_CHANGELOG);
     }
 }

--- a/crates/pdo-daemon/tests/update_check.rs
+++ b/crates/pdo-daemon/tests/update_check.rs
@@ -16,7 +16,13 @@
 //!      value `null`, `POST /update/check` refused 409, setting persisted in `/settings`;
 //!   6. « Check now » forces a hit and moves `checked_at`;
 //!   7. the install-method / supervision fields are one of the declared values with
-//!      the manual command that matches.
+//!      the manual command that matches;
+//!   8. (#698) `GET /update/changelog` assembles the release notes strictly newer than
+//!      the installed version, newest first, one heading per version, from the
+//!      fixture's release LIST (memoised: one hit per latest version); it falls back
+//!      to the embedded `CHANGELOG.md` with an explicit reason when the check is off
+//!      or the source unreachable, and reports « up to date » with the embedded body
+//!      when the fixture publishes the installed version.
 
 use crate::common::TestDaemon;
 use std::net::SocketAddr;
@@ -27,9 +33,19 @@ use std::sync::Arc;
 /// The shape of GitHub's `releases/latest`, trimmed to what the parser reads.
 const RELEASE_NEWER: &str = r#"{"tag_name":"v99.0.0","name":"pdo 99.0.0","prerelease":false}"#;
 
+/// The shape of GitHub's `releases` list, trimmed to what the changelog reads: two
+/// newer versions (out of order on purpose), one pre-release, one ancient release.
+const RELEASES_LIST: &str = r###"[
+  {"tag_name":"v98.0.0","published_at":"2026-09-04T10:00:00Z","html_url":"https://example.test/releases/tag/v98.0.0","body":"## Highlights\n\n- ninety-eight\n"},
+  {"tag_name":"v99.0.0","published_at":"2026-09-05T10:00:00Z","html_url":"https://example.test/releases/tag/v99.0.0","body":"- ninety-nine\n\n| a | b |\n|---|---|\n| 1 | 2 |\n"},
+  {"tag_name":"v100.0.0-rc.1","prerelease":true,"body":"rc"},
+  {"tag_name":"v0.0.1","published_at":"2020-01-01T00:00:00Z","body":"ancient"}
+]"###;
+
 struct Fixture {
     addr: SocketAddr,
     hits: Arc<AtomicUsize>,
+    list_hits: Arc<AtomicUsize>,
     _task: tokio::task::JoinHandle<()>,
 }
 
@@ -40,21 +56,43 @@ impl Fixture {
     fn hits(&self) -> usize {
         self.hits.load(Ordering::SeqCst)
     }
+    fn list_hits(&self) -> usize {
+        self.list_hits.load(Ordering::SeqCst)
+    }
 }
 
 async fn spawn_fixture(body: &'static str) -> Fixture {
+    spawn_fixture_with_list(body, RELEASES_LIST).await
+}
+
+/// A fixture serving `releases/latest` AND the `releases` list (#698), each with
+/// its own hit counter.
+async fn spawn_fixture_with_list(body: &'static str, list: &'static str) -> Fixture {
     let hits = Arc::new(AtomicUsize::new(0));
+    let list_hits = Arc::new(AtomicUsize::new(0));
     let counter = hits.clone();
-    let app = axum::Router::new().route(
-        "/releases/latest",
-        axum::routing::get(move || {
-            let counter = counter.clone();
-            async move {
-                counter.fetch_add(1, Ordering::SeqCst);
-                ([("content-type", "application/json")], body)
-            }
-        }),
-    );
+    let list_counter = list_hits.clone();
+    let app = axum::Router::new()
+        .route(
+            "/releases/latest",
+            axum::routing::get(move || {
+                let counter = counter.clone();
+                async move {
+                    counter.fetch_add(1, Ordering::SeqCst);
+                    ([("content-type", "application/json")], body)
+                }
+            }),
+        )
+        .route(
+            "/releases",
+            axum::routing::get(move || {
+                let counter = list_counter.clone();
+                async move {
+                    counter.fetch_add(1, Ordering::SeqCst);
+                    ([("content-type", "application/json")], list)
+                }
+            }),
+        );
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     let task = tokio::spawn(async move {
@@ -63,6 +101,7 @@ async fn spawn_fixture(body: &'static str) -> Fixture {
     Fixture {
         addr,
         hits,
+        list_hits,
         _task: task,
     }
 }
@@ -313,4 +352,142 @@ async fn disabling_the_check_stops_all_egress_and_persists() {
     );
     put_update_check(&daemon, true).await;
     assert_eq!(update_json(&daemon).await["latest_version"], "99.0.0");
+}
+
+async fn changelog(daemon: &TestDaemon) -> serde_json::Value {
+    let resp = reqwest::get(format!("{}/update/changelog", daemon.url()))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200, "the changelog always answers");
+    assert!(
+        content_type(&resp).starts_with("application/json"),
+        "GET /update/changelog must be registered (the SPA fallback answers text/html)"
+    );
+    resp.json().await.unwrap()
+}
+
+#[tokio::test]
+async fn changelog_assembles_missed_releases_newest_first_and_memoises_the_list() {
+    let fixture = spawn_fixture(RELEASE_NEWER).await;
+    let daemon = TestDaemon::spawn_with_update_source(seed, fixture.url())
+        .await
+        .unwrap();
+
+    // Before any check: honest fallback, zero egress (the list is never fetched
+    // without a known newer version).
+    let body = changelog(&daemon).await;
+    assert_eq!(body["source"], "embedded");
+    assert_eq!(body["latest_version"], serde_json::Value::Null);
+    assert_eq!(
+        body["fallback_reason"],
+        "The release source has not been checked yet."
+    );
+    assert!(body["markdown"]
+        .as_str()
+        .unwrap()
+        .starts_with("# Changelog"));
+    assert_eq!(fixture.list_hits(), 0);
+
+    daemon.run_update_check_tick().await;
+    let body = changelog(&daemon).await;
+    assert_eq!(body["installed_version"], env!("CARGO_PKG_VERSION"));
+    assert_eq!(body["latest_version"], "99.0.0");
+    assert_eq!(body["source"], "releases");
+    assert_eq!(body["fallback_reason"], serde_json::Value::Null);
+    assert_eq!(
+        body["missed_versions"],
+        serde_json::json!(["99.0.0", "98.0.0"]),
+        "strictly newer, sorted desc, pre-release and ancient dropped"
+    );
+    let md = body["markdown"].as_str().unwrap();
+    let h99 = md.find("## v99.0.0").expect("one heading per version");
+    let h98 = md.find("## v98.0.0").expect("one heading per version");
+    assert!(h99 < h98, "newest first:\n{md}");
+    assert!(!md.contains("## v0.0.1"), "older releases are not listed");
+    assert!(!md.contains("100.0.0"), "pre-releases are not listed");
+    assert!(md.contains("Released 2026-09-05"));
+    assert!(md.contains("[GitHub release](https://example.test/releases/tag/v99.0.0)"));
+    assert!(md.contains("- ninety-nine"), "notes verbatim");
+    assert!(md.contains("| a | b |"), "GFM table verbatim");
+
+    // Memoised per latest version: another read costs no list fetch.
+    changelog(&daemon).await;
+    assert_eq!(
+        fixture.list_hits(),
+        1,
+        "the list is fetched once per latest version"
+    );
+}
+
+#[tokio::test]
+async fn changelog_falls_back_to_the_embedded_file_with_a_reason() {
+    // Check off: no egress at all, explicit reason.
+    let fixture = spawn_fixture(RELEASE_NEWER).await;
+    let daemon = TestDaemon::spawn_with_update_source(seed, fixture.url())
+        .await
+        .unwrap();
+    daemon.run_update_check_tick().await;
+    put_update_check(&daemon, false).await;
+    let body = changelog(&daemon).await;
+    assert_eq!(body["source"], "embedded");
+    assert_eq!(body["fallback_reason"], "The update check is off.");
+    assert_eq!(body["latest_version"], serde_json::Value::Null);
+    assert_eq!(body["missed_versions"], serde_json::json!([]));
+    assert!(body["markdown"]
+        .as_str()
+        .unwrap()
+        .starts_with("# Changelog"));
+    assert_eq!(fixture.list_hits(), 0, "off: the list is never fetched");
+
+    // Source unreachable at the last check: same body, the other reason.
+    let dead = TestDaemon::spawn_with_update_source(seed, dead_url().await)
+        .await
+        .unwrap();
+    dead.run_update_check_tick().await;
+    let body = changelog(&dead).await;
+    assert_eq!(body["source"], "embedded");
+    assert_eq!(
+        body["fallback_reason"],
+        "The release source was unreachable at the last check."
+    );
+    assert!(body["markdown"].as_str().unwrap().contains("## 1.59.0"));
+}
+
+#[tokio::test]
+async fn changelog_on_an_up_to_date_daemon_says_so_with_the_embedded_body() {
+    // The fixture publishes exactly the installed version.
+    let latest: &'static str = Box::leak(
+        format!(
+            r#"{{"tag_name":"v{}","name":"pdo","prerelease":false}}"#,
+            env!("CARGO_PKG_VERSION")
+        )
+        .into_boxed_str(),
+    );
+    let fixture = spawn_fixture_with_list(latest, "[]").await;
+    let daemon = TestDaemon::spawn_with_update_source(seed, fixture.url())
+        .await
+        .unwrap();
+    daemon.run_update_check_tick().await;
+    let body = changelog(&daemon).await;
+    assert_eq!(body["latest_version"], env!("CARGO_PKG_VERSION"));
+    assert_eq!(
+        body["missed_versions"],
+        serde_json::json!([]),
+        "nothing missed"
+    );
+    assert_eq!(body["source"], "embedded");
+    assert_eq!(
+        body["fallback_reason"],
+        serde_json::Value::Null,
+        "up to date is nominal, not a fallback"
+    );
+    assert!(body["markdown"]
+        .as_str()
+        .unwrap()
+        .starts_with("# Changelog"));
+    assert_eq!(
+        fixture.list_hits(),
+        0,
+        "no list fetch when nothing is newer"
+    );
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,6 +18,7 @@ import RunInfoSidebar from "./components/RunInfoSidebar";
 import NewRunModal, { RUN_INTENT } from "./components/NewRunModal";
 import SettingsSurface, { type SettingsPosition, type StatsOpenIntent } from "./components/SettingsSurface";
 import VersionBadge from "./components/VersionBadge";
+import ChangelogModal from "./components/ChangelogModal";
 import { useUpdateStatus } from "./hooks/useUpdateStatus";
 import type { UpdateStatus } from "./types";
 import StatsModal from "./components/StatsModal";
@@ -179,6 +180,9 @@ export default function App() {
   const { run: selectedRun, select: selectRun, refresh: refreshRun } = useSelectedRun();
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
   const [newRunModalOpen, setNewRunModalOpen] = useState(false);
+  // #698: the « What's new » changelog modal, opened from the status-bar version (and
+  // from Settings › Version & update). Lives here next to the other modals.
+  const [changelogOpen, setChangelogOpen] = useState(false);
   // #690: Settings and Stats are full-window surfaces on one shared shell, one open at a
   // time. `openSettings` / `openStats` are the single openers: the gear and the chart icon
   // call them bare (the surface lands where the user last was), programmatic entries pass a
@@ -827,8 +831,18 @@ export default function App() {
         status={status}
         sessions={sessions}
         update={updateStatus}
-        onOpenVersion={() => openSettings({ category: "general", section: "version-update" })}
+        onOpenVersion={() => setChangelogOpen(true)}
       />
+      {changelogOpen && (
+        <ChangelogModal
+          update={updateStatus}
+          onClose={() => setChangelogOpen(false)}
+          onOpenVersionSettings={() => {
+            setChangelogOpen(false);
+            openSettings({ category: "general", section: "version-update" });
+          }}
+        />
+      )}
       <NewRunModal
         open={newRunModalOpen}
         onClose={handleCloseNewRunModal}
@@ -852,6 +866,7 @@ export default function App() {
         onSaved={refreshSessions}
         initialPosition={settingsEntry.position}
         onOpenStats={openStats}
+        onOpenChangelog={() => setChangelogOpen(true)}
       />
       <StatsModal
         key={statsEntry.key}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,4 +1,4 @@
-import type { PipelineListEntry, PipelineDetail, PipelineDef, RunListEntry, RunState, PortDef, PortSide, PortType, FrontmatterFieldDecl, FrontmatterViolation, Trigger, TriggerFire, DaemonStatus, InstanceSettings, UpdateSettingsRequest, StatsOverview, StatsCost, StatsPerformance, SandboxProfile, SandboxProfileImage, SandboxProfileReferents, SyncCostPricesReport, UpdateStatus, Project, BranchRef, AgentChoice, AgentProfile, AgentProfileReferents, ProvisioningPlan, ProvisioningRules, Skill, SkillBank, SkillDetail, SkillFile, SkillFileContent, SkillFilesUpload, SkillFolder, SkillReferents, SkillRef, SkillScanResult, SkillImportItem, SkillImportReport, SkillRescanReport, RecentSkillSource } from "./types";
+import type { PipelineListEntry, PipelineDetail, PipelineDef, RunListEntry, RunState, PortDef, PortSide, PortType, FrontmatterFieldDecl, FrontmatterViolation, Trigger, TriggerFire, DaemonStatus, InstanceSettings, UpdateSettingsRequest, StatsOverview, StatsCost, StatsPerformance, SandboxProfile, SandboxProfileImage, SandboxProfileReferents, SyncCostPricesReport, UpdateStatus, UpdateChangelog, Project, BranchRef, AgentChoice, AgentProfile, AgentProfileReferents, ProvisioningPlan, ProvisioningRules, Skill, SkillBank, SkillDetail, SkillFile, SkillFileContent, SkillFilesUpload, SkillFolder, SkillReferents, SkillRef, SkillScanResult, SkillImportItem, SkillImportReport, SkillRescanReport, RecentSkillSource } from "./types";
 import { foldHarnessOntoNode } from "./lib/harness";
 
 const BASE = "";
@@ -166,6 +166,15 @@ export function fetchUpdateStatus(): Promise<UpdateStatus> {
 
 export function checkForUpdateNow(): Promise<UpdateStatus> {
   return request<UpdateStatus>("POST", "/update/check", { label: "POST /update/check" });
+}
+
+/**
+ * « What's new » (#698): the release notes of every version strictly newer than the
+ * installed one, newest first — or the embedded `CHANGELOG.md` with an explicit
+ * `fallback_reason` when the release list is unavailable. Always answers 200.
+ */
+export function fetchUpdateChangelog(): Promise<UpdateChangelog> {
+  return request<UpdateChangelog>("GET", "/update/changelog");
 }
 
 export function fetchSettings(): Promise<InstanceSettings> {

--- a/frontend/src/components/ChangelogModal.test.tsx
+++ b/frontend/src/components/ChangelogModal.test.tsx
@@ -1,0 +1,202 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { UpdateChangelog, UpdateStatus } from "../types";
+
+const fetchUpdateChangelogMock = vi.fn();
+
+vi.mock("../api", () => ({
+  fetchUpdateChangelog: (...args: unknown[]) => fetchUpdateChangelogMock(...args),
+  fetchArtifact: vi.fn(),
+  fetchNodeIO: vi.fn(),
+  artifactUrl: (runId: string, path: string) => `/runs/${runId}/artifact?path=${path}`,
+}));
+
+// The real react-markdown is ESM-heavy; a passthrough keeps the assertions on the TEXT
+// the viewer receives (headings, bullets, links) — GFM/mermaid rendering is covered by
+// the viewer's own tests.
+vi.mock("react-markdown", () => ({
+  default: ({ children }: { children: string }) => <div data-testid="markdown-body">{children}</div>,
+}));
+vi.mock("remark-gfm", () => ({ default: () => null }));
+
+import ChangelogModal from "./ChangelogModal";
+
+function status(overrides: Partial<UpdateStatus> = {}): UpdateStatus {
+  return {
+    installed_version: "1.58.1",
+    latest_version: "1.59.0",
+    newer_available: true,
+    checked_at: "2026-09-05T08:00:00Z",
+    source: "GitHub Releases",
+    source_url: "https://api.github.com/repos/Loulen/prompt-driven-orchestrator/releases/latest",
+    check_enabled: true,
+    install_method: "homebrew",
+    manual_command: "brew update && brew upgrade Loulen/tap/pdo",
+    supervision: "systemd",
+    reason: null,
+    last_error: null,
+    ...overrides,
+  };
+}
+
+const NEWER: UpdateChangelog = {
+  installed_version: "1.58.1",
+  latest_version: "1.60.0",
+  missed_versions: ["1.60.0", "1.59.0"],
+  source: "releases",
+  fallback_reason: null,
+  markdown:
+    "## v1.60.0\n\n*Released 2026-09-06 · [GitHub release](https://github.com/x/y/releases/tag/v1.60.0)*\n\n- sixty\n\n## v1.59.0\n\n- fifty-nine\n",
+};
+
+const UP_TO_DATE: UpdateChangelog = {
+  installed_version: "1.58.1",
+  latest_version: "1.58.1",
+  missed_versions: [],
+  source: "embedded",
+  fallback_reason: null,
+  markdown: "# Changelog\n\n## 1.58.1\n\n**Livraison**\n",
+};
+
+const FALLBACK: UpdateChangelog = {
+  installed_version: "1.58.1",
+  latest_version: null,
+  missed_versions: [],
+  source: "embedded",
+  fallback_reason: "The update check is off.",
+  markdown: "# Changelog\n\n## 1.58.1\n",
+};
+
+describe("ChangelogModal (#698)", () => {
+  beforeEach(() => {
+    fetchUpdateChangelogMock.mockReset();
+  });
+
+  it("fetches the changelog once on mount", async () => {
+    fetchUpdateChangelogMock.mockResolvedValue(NEWER);
+    const { rerender } = render(
+      <ChangelogModal update={status()} onClose={() => {}} onOpenVersionSettings={() => {}} />,
+    );
+    expect(screen.getByTestId("changelog-modal")).toBeInTheDocument();
+    await waitFor(() => expect(fetchUpdateChangelogMock).toHaveBeenCalledTimes(1));
+    // A parent re-render (e.g. the update status landing) does not refetch.
+    rerender(<ChangelogModal update={status({ checked_at: "2026-09-05T09:00:00Z" })} onClose={() => {}} onOpenVersionSettings={() => {}} />);
+    await screen.findByTestId("markdown-body");
+    expect(fetchUpdateChangelogMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("lists the missed versions newest first with the installed → latest header", async () => {
+    fetchUpdateChangelogMock.mockResolvedValue(NEWER);
+    render(<ChangelogModal update={status()} onClose={() => {}} onOpenVersionSettings={() => {}} />);
+    expect(screen.getByText("Loading...")).toBeInTheDocument();
+    const body = await screen.findByTestId("markdown-body");
+    const md = body.textContent ?? "";
+    expect(md.indexOf("## v1.60.0")).toBeGreaterThanOrEqual(0);
+    expect(md.indexOf("## v1.60.0")).toBeLessThan(md.indexOf("## v1.59.0"));
+    expect(md).toContain("- sixty");
+
+    const header = screen.getByTestId("changelog-header");
+    expect(header).toHaveTextContent("What's new");
+    expect(header).toHaveTextContent("v1.58.1");
+    expect(screen.getByTestId("changelog-latest")).toHaveTextContent("v1.60.0");
+    expect(screen.getByTestId("changelog-behind")).toHaveTextContent("2 versions behind");
+    expect(screen.queryByTestId("changelog-uptodate")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("changelog-fallback")).not.toBeInTheDocument();
+
+    // Footer: the manual command for the detected method, with Copy command.
+    expect(screen.getByTestId("changelog-manual-command")).toHaveTextContent(
+      "brew update && brew upgrade Loulen/tap/pdo",
+    );
+    expect(screen.getByTestId("changelog-copy-command")).toHaveTextContent("Copy command");
+    expect(screen.getByText(/To update, run in a terminal/)).toBeInTheDocument();
+  });
+
+  it("says « up to date » with the embedded changelog when nothing is missed", async () => {
+    fetchUpdateChangelogMock.mockResolvedValue(UP_TO_DATE);
+    render(
+      <ChangelogModal
+        update={status({ latest_version: "1.58.1", newer_available: false })}
+        onClose={() => {}}
+        onOpenVersionSettings={() => {}}
+      />,
+    );
+    expect(await screen.findByTestId("changelog-uptodate")).toHaveTextContent("up to date");
+    expect(screen.getByTestId("changelog-uptodate-banner")).toHaveTextContent(/You run the latest release/);
+    expect(screen.getByTestId("markdown-body")).toHaveTextContent("# Changelog");
+    expect(screen.queryByTestId("changelog-behind")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("changelog-fallback")).not.toBeInTheDocument();
+    expect(screen.getByText(/Nothing to update/)).toBeInTheDocument();
+  });
+
+  it("signals the fallback to the embedded changelog with its reason", async () => {
+    fetchUpdateChangelogMock.mockResolvedValue(FALLBACK);
+    render(
+      <ChangelogModal
+        update={status({ check_enabled: false, latest_version: null, newer_available: false })}
+        onClose={() => {}}
+        onOpenVersionSettings={() => {}}
+      />,
+    );
+    const banner = await screen.findByTestId("changelog-fallback");
+    expect(banner).toHaveTextContent("Release notes unavailable");
+    expect(banner).toHaveTextContent("The update check is off.");
+    expect(banner).toHaveTextContent(/breaking changes only/);
+    expect(screen.getByTestId("markdown-body")).toHaveTextContent("# Changelog");
+    // Bare version in the header: no arrow, no « up to date » claim.
+    expect(screen.getByTestId("changelog-header")).toHaveTextContent("v1.58.1");
+    expect(screen.queryByTestId("changelog-latest")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("changelog-uptodate")).not.toBeInTheDocument();
+  });
+
+  it("shows the endpoint error in a banner and keeps the footer", async () => {
+    fetchUpdateChangelogMock.mockRejectedValue(new Error("HTTP 500"));
+    render(<ChangelogModal update={status()} onClose={() => {}} onOpenVersionSettings={() => {}} />);
+    expect(await screen.findByTestId("changelog-error")).toHaveTextContent("Could not load the changelog: HTTP 500.");
+    expect(screen.getByTestId("changelog-copy-command")).toBeInTheDocument();
+  });
+
+  it("declares an unknown install method: manual text, no Copy", async () => {
+    fetchUpdateChangelogMock.mockResolvedValue(NEWER);
+    render(
+      <ChangelogModal
+        update={status({ install_method: "unknown", manual_command: "Build from source, then restart the daemon." })}
+        onClose={() => {}}
+        onOpenVersionSettings={() => {}}
+      />,
+    );
+    await screen.findByTestId("markdown-body");
+    expect(screen.getByText(/Install method not detected/)).toBeInTheDocument();
+    expect(screen.getByTestId("changelog-manual-command")).toHaveTextContent("Build from source");
+    expect(screen.queryByTestId("changelog-copy-command")).not.toBeInTheDocument();
+    expect(screen.getByTestId("changelog-open-settings")).toBeInTheDocument();
+  });
+
+  it("copies the command, then reads « Copied » for a moment", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+    fetchUpdateChangelogMock.mockResolvedValue(NEWER);
+    render(<ChangelogModal update={status()} onClose={() => {}} onOpenVersionSettings={() => {}} />);
+    await screen.findByTestId("markdown-body");
+    fireEvent.click(screen.getByTestId("changelog-copy-command"));
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith("brew update && brew upgrade Loulen/tap/pdo"));
+    await waitFor(() => expect(screen.getByTestId("changelog-copy-command")).toHaveTextContent("Copied"));
+    vi.advanceTimersByTime(1600);
+    await waitFor(() => expect(screen.getByTestId("changelog-copy-command")).toHaveTextContent("Copy command"));
+    vi.useRealTimers();
+  });
+
+  it("« Version & update » hands over to Settings; Esc and X close", async () => {
+    fetchUpdateChangelogMock.mockResolvedValue(NEWER);
+    const onClose = vi.fn();
+    const onOpenVersionSettings = vi.fn();
+    render(<ChangelogModal update={status()} onClose={onClose} onOpenVersionSettings={onOpenVersionSettings} />);
+    await screen.findByTestId("markdown-body");
+    fireEvent.click(screen.getByTestId("changelog-open-settings"));
+    expect(onOpenVersionSettings).toHaveBeenCalledTimes(1);
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByLabelText("Close"));
+    expect(onClose).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/components/ChangelogModal.tsx
+++ b/frontend/src/components/ChangelogModal.tsx
@@ -1,0 +1,249 @@
+import { useEffect, useRef, useState } from "react";
+import type { ReactNode } from "react";
+import { Check, Copy, SlidersHorizontal, TriangleAlert, WifiOff } from "lucide-react";
+import MarkdownArtifactModal from "./MarkdownArtifactModal";
+import { fetchUpdateChangelog } from "../api";
+import type { UpdateChangelog, UpdateStatus } from "../types";
+
+/**
+ * « What's new » (#698): the changelog of the versions missed since the installed one,
+ * opened from the status-bar version. Composes the markdown artifact viewer with an
+ * in-memory source fed by `GET /update/changelog`, and the shared update status for
+ * the footer (install method, manual command).
+ *
+ * Header: `v<installed> → v<latest> · N version(s) behind` (latest in amber, the pill's
+ * token) — or a green `up to date` pill — or the bare version when the latest is unknown.
+ * Banner: grey for up to date (« You run the latest release… »), amber when the body is
+ * the embedded changelog as a FALLBACK (source unreachable / check off), red when the
+ * endpoint itself failed. The words « up to date » appear here and in Settings only —
+ * never in the bar (#697 rule).
+ * Footer: the manual command with « Copy command » (the next ticket's Update button
+ * takes that slot), and a « Version & update » link to Settings. An unknown install
+ * method declares its absence: warning + the manual text, no Copy (ADR-0045).
+ */
+export default function ChangelogModal({
+  update,
+  onClose,
+  onOpenVersionSettings,
+}: {
+  update: UpdateStatus | null;
+  onClose: () => void;
+  onOpenVersionSettings: () => void;
+}) {
+  const [changelog, setChangelog] = useState<UpdateChangelog | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  // The modal is MOUNTED when open (App renders it conditionally), so every open is a
+  // fresh fetch — a reopen after an update never shows stale notes. The daemon memoises
+  // the release list, so this costs no egress.
+  useEffect(() => {
+    let cancelled = false;
+    fetchUpdateChangelog()
+      .then((doc) => {
+        if (cancelled) return;
+        setChangelog(doc);
+        setLoading(false);
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return;
+        setError(e instanceof Error ? e.message : String(e));
+        setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const installed = changelog?.installed_version ?? update?.installed_version ?? null;
+  const latest = changelog?.latest_version ?? null;
+  const missed = changelog?.missed_versions ?? [];
+  const upToDate = changelog != null && latest != null && missed.length === 0 && changelog.fallback_reason == null;
+  const behind = missed.length;
+
+  return (
+    <MarkdownArtifactModal
+      runId=""
+      portName="What's new"
+      source={{ kind: "inline", content: changelog?.markdown ?? null, loading }}
+      onClose={onClose}
+      widthClass="w-[680px]"
+      testId="changelog-modal"
+      header={
+        <div className="flex min-w-0 items-center gap-2.5" data-testid="changelog-header">
+          <span className="font-medium text-fg" style={{ fontSize: "13px" }}>
+            What's new
+          </span>
+          {installed && (
+            <span className="flex items-center gap-1.5 font-mono text-fg-4" style={{ fontSize: "11px" }}>
+              <span>v{installed}</span>
+              {behind > 0 && latest && (
+                <>
+                  <span>→</span>
+                  <span className="text-st-await" data-testid="changelog-latest">
+                    v{latest}
+                  </span>
+                  <span data-testid="changelog-behind">
+                    · {behind} version{behind > 1 ? "s" : ""} behind
+                  </span>
+                </>
+              )}
+              {upToDate && (
+                <span
+                  className="rounded-full border border-st-done/40 bg-st-done-bg px-1.5 leading-[14px] text-st-done"
+                  style={{ fontSize: "9.5px" }}
+                  data-testid="changelog-uptodate"
+                >
+                  up to date
+                </span>
+              )}
+            </span>
+          )}
+        </div>
+      }
+      banner={
+        error ? (
+          <Banner tone="failed" testId="changelog-error">
+            Could not load the changelog: {error}.
+          </Banner>
+        ) : changelog?.fallback_reason ? (
+          <Banner tone="await" icon={<WifiOff size={13} />} testId="changelog-fallback">
+            <span className="font-medium">Release notes unavailable</span> — {changelog.fallback_reason}{" "}
+            Showing the changelog embedded in this build; it lists{" "}
+            <strong>breaking changes only</strong>.
+          </Banner>
+        ) : upToDate ? (
+          <Banner tone="muted" icon={<Check size={13} />} testId="changelog-uptodate-banner">
+            You run the latest release. Below is the changelog embedded in this build (breaking
+            changes only).
+          </Banner>
+        ) : null
+      }
+      footer={
+        <ChangelogFooter update={update} upToDate={upToDate} onOpenVersionSettings={onOpenVersionSettings} />
+      }
+    />
+  );
+}
+
+function Banner({
+  tone,
+  icon,
+  children,
+  testId,
+}: {
+  tone: "muted" | "await" | "failed";
+  icon?: ReactNode;
+  children: ReactNode;
+  testId?: string;
+}) {
+  const cls =
+    tone === "await"
+      ? "border-st-await/50 bg-st-await-bg text-st-await"
+      : tone === "failed"
+        ? "border-st-failed/50 bg-st-failed-bg text-st-failed"
+        : "border-line bg-bg-0 text-fg-3";
+  return (
+    <div
+      className={`mb-3 flex items-start gap-2 rounded border px-3 py-2 ${cls}`}
+      style={{ fontSize: "11.5px", lineHeight: 1.45 }}
+      data-testid={testId}
+    >
+      {icon && <span className="mt-px shrink-0">{icon}</span>}
+      <span>{children}</span>
+    </div>
+  );
+}
+
+function ChangelogFooter({
+  update,
+  upToDate,
+  onOpenVersionSettings,
+}: {
+  update: UpdateStatus | null;
+  upToDate: boolean;
+  onOpenVersionSettings: () => void;
+}) {
+  const [copied, setCopied] = useState(false);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(
+    () => () => {
+      if (timer.current) clearTimeout(timer.current);
+    },
+    [],
+  );
+
+  const copy = async () => {
+    if (!update) return;
+    try {
+      await navigator.clipboard.writeText(update.manual_command);
+      setCopied(true);
+      if (timer.current) clearTimeout(timer.current);
+      timer.current = setTimeout(() => setCopied(false), 1500);
+    } catch {
+      /* clipboard unavailable: the command is selectable text anyway */
+    }
+  };
+
+  const unknown = update?.install_method === "unknown";
+
+  return (
+    <div className="flex items-end justify-between gap-4" data-testid="changelog-footer">
+      <div className="flex min-w-0 flex-col gap-0.5" style={{ fontSize: "11px" }}>
+        {update == null ? (
+          <span className="text-fg-4">Loading the daemon's version state…</span>
+        ) : unknown ? (
+          <>
+            <span className="flex items-center gap-1.5 text-fg-3">
+              <TriangleAlert size={12} className="text-st-await" />
+              Install method not detected — PDO will not update itself.
+            </span>
+            <span className="text-fg-4" data-testid="changelog-manual-command">
+              {update.manual_command}
+            </span>
+          </>
+        ) : (
+          <>
+            <span className="text-fg-4">
+              {upToDate
+                ? "Nothing to update. To reinstall manually:"
+                : "To update, run in a terminal (the daemon restarts, tmux sessions survive):"}
+            </span>
+            <code
+              className="truncate font-mono text-fg-2"
+              style={{ fontSize: "11px" }}
+              data-testid="changelog-manual-command"
+            >
+              {update.manual_command}
+            </code>
+          </>
+        )}
+      </div>
+      <div className="flex shrink-0 items-center gap-2">
+        <button
+          type="button"
+          onClick={onOpenVersionSettings}
+          className="flex items-center gap-1.5 rounded px-2 py-1.5 text-fg-3 hover:bg-bg-3 hover:text-fg-2"
+          style={{ fontSize: "11px" }}
+          data-testid="changelog-open-settings"
+        >
+          <SlidersHorizontal size={12} />
+          Version & update
+        </button>
+        {update && !unknown && (
+          <button
+            type="button"
+            onClick={() => void copy()}
+            className="flex items-center gap-1.5 rounded border border-line-strong bg-bg-3 px-2.5 py-1.5 text-fg-2 hover:border-acc"
+            style={{ fontSize: "11px" }}
+            title="Copy the manual update command"
+            data-testid="changelog-copy-command"
+          >
+            {copied ? <Check size={12} /> : <Copy size={12} />}
+            {copied ? "Copied" : "Copy command"}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/MarkdownArtifactModal.tsx
+++ b/frontend/src/components/MarkdownArtifactModal.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
+import type { ReactNode } from "react";
 import { X, ChevronLeft, ChevronRight } from "lucide-react";
 import Markdown from "react-markdown";
 import type { Components } from "react-markdown";
@@ -28,7 +29,11 @@ export type ArtifactSource =
       portKind: "input" | "output";
       iterations: IterationInfo[];
       initialIter: number;
-    };
+    }
+  // #698: an in-memory markdown document (the « What's new » changelog). Nothing is
+  // fetched: `content` IS the body; `loading` shows the viewer's own loading text
+  // while the caller is still fetching. `runId` is unused for this kind (pass `""`).
+  | { kind: "inline"; content: string | null; loading?: boolean };
 
 interface Props {
   runId: string;
@@ -36,6 +41,15 @@ interface Props {
   portType?: PortType;
   source: ArtifactSource;
   onClose: () => void;
+  /** #698: replaces the `portName` + path header block. The close X stays. */
+  header?: ReactNode;
+  /** #698: rendered at the top of the body, above the markdown. */
+  banner?: ReactNode;
+  /** #698: a fixed bar under the scrolling body. */
+  footer?: ReactNode;
+  /** #698: Tailwind width class; artifacts use the 560px default. */
+  widthClass?: string;
+  testId?: string;
 }
 
 export default function MarkdownArtifactModal({
@@ -44,7 +58,15 @@ export default function MarkdownArtifactModal({
   portType = "markdown",
   source,
   onClose,
+  header,
+  banner,
+  footer,
+  widthClass = "w-[560px]",
+  testId,
 }: Props) {
+  const isInline = source.kind === "inline";
+  const inlineContent = source.kind === "inline" ? source.content : null;
+  const inlineLoading = source.kind === "inline" ? !!source.loading : false;
   const iterNumbers = useMemo(
     () =>
       source.kind === "iter-nav"
@@ -114,14 +136,18 @@ export default function MarkdownArtifactModal({
   // markdown (and unlike image), its content flows through `fetchArtifact`, so
   // the fetch effect below (which only short-circuits on `isImage`) still runs.
   const isHtml = portType === "html";
-  const [content, setContent] = useState<string | null>(null);
-  const [loading, setLoading] = useState(!isImage);
+  const [fetchedContent, setContent] = useState<string | null>(null);
+  const [fetchedLoading, setLoading] = useState(!isImage && !isInline);
+  // #698: an inline source never fetches — its content/loading are read straight from
+  // the prop (the caller fetches, the viewer renders), no state to keep in sync.
+  const content = isInline ? inlineContent : fetchedContent;
+  const loading = isInline ? inlineLoading : fetchedLoading;
   // The ordered image list + clicked index currently shown fullscreen in the
   // lightbox, or null when it is closed (#312).
   const [lightbox, setLightbox] = useState<{ images: string[]; index: number } | null>(null);
 
   useEffect(() => {
-    if (isImage) return;
+    if (isImage || isInline) return;
 
     let cancelled = false;
 
@@ -150,7 +176,7 @@ export default function MarkdownArtifactModal({
     return () => {
       cancelled = true;
     };
-  }, [runId, file?.path, file?.exists, isImage]);
+  }, [runId, file?.path, file?.exists, isImage, isInline]);
 
   const goPrevIter = useCallback(() => {
     if (!hasIterNav || iterIndex <= 0) return;
@@ -195,6 +221,20 @@ export default function MarkdownArtifactModal({
   // the routed <MermaidDiagram>, hence no flicker.
   const markdownComponents = useMemo<Components>(
     () => ({
+      // #698: an absolute http(s) link leaves the app in a new tab — a release note
+      // pointing at GitHub must never navigate the SPA away. Relative links stay.
+      a: ({ href, children, ...rest }) => {
+        const external = typeof href === "string" && /^https?:\/\//i.test(href);
+        return (
+          <a
+            href={href}
+            {...rest}
+            {...(external ? { target: "_blank", rel: "noreferrer" } : {})}
+          >
+            {children}
+          </a>
+        );
+      },
       img: ({ src, alt }) => {
         const url = typeof src === "string" ? src : undefined;
         return (
@@ -239,7 +279,8 @@ export default function MarkdownArtifactModal({
   );
 
   const frontmatter = file?.frontmatter;
-  const bodyContent = content ? stripFrontmatter(content) : null;
+  // An inline document is rendered as given (a release note may open on a `---` rule).
+  const bodyContent = content ? (isInline ? content : stripFrontmatter(content)) : null;
 
   return (
     <div
@@ -250,24 +291,27 @@ export default function MarkdownArtifactModal({
       }}
     >
       <div
-        className="flex max-h-[80vh] w-[560px] flex-col overflow-hidden rounded-lg border border-line-strong bg-bg-2"
+        className={`flex max-h-[80vh] ${widthClass} max-w-[calc(100vw-32px)] flex-col overflow-hidden rounded-lg border border-line-strong bg-bg-2`}
         style={{ boxShadow: "0 30px 80px rgba(0,0,0,0.6)" }}
+        data-testid={testId}
       >
         {/* Header */}
         <div className="flex items-center justify-between border-b border-line px-4 py-3">
-          <div className="flex items-center gap-2">
-            <span className="font-medium text-fg" style={{ fontSize: "13px" }}>
-              {portName}
-            </span>
-            {file?.path && (
-              <span
-                className="font-mono text-fg-4"
-                style={{ fontSize: "10px" }}
-              >
-                {file.path}
+          {header ?? (
+            <div className="flex items-center gap-2">
+              <span className="font-medium text-fg" style={{ fontSize: "13px" }}>
+                {portName}
               </span>
-            )}
-          </div>
+              {file?.path && (
+                <span
+                  className="font-mono text-fg-4"
+                  style={{ fontSize: "10px" }}
+                >
+                  {file.path}
+                </span>
+              )}
+            </div>
+          )}
           <div className="flex items-center gap-2">
             {hasIterNav && (
               <div className="flex items-center gap-1" data-testid="iter-nav">
@@ -328,6 +372,7 @@ export default function MarkdownArtifactModal({
             <button
               onClick={onClose}
               className="rounded p-1 text-fg-3 hover:bg-bg-3 hover:text-fg"
+              aria-label="Close"
             >
               <X size={14} />
             </button>
@@ -378,6 +423,7 @@ export default function MarkdownArtifactModal({
             )
           ) : (
             <>
+              {banner}
               {/* Frontmatter card */}
               {frontmatter && Object.keys(frontmatter).length > 0 && (
                 <div
@@ -408,7 +454,7 @@ export default function MarkdownArtifactModal({
                     {bodyContent}
                   </Markdown>
                 </div>
-              ) : (
+              ) : isInline ? null : (
                 <span className="text-fg-4" style={{ fontSize: "11px" }}>
                   {file?.exists ? "Could not load content." : "File does not exist yet."}
                 </span>
@@ -416,6 +462,10 @@ export default function MarkdownArtifactModal({
             </>
           )}
         </div>
+
+        {footer && (
+          <div className="shrink-0 border-t border-line bg-bg-1 px-4 py-3">{footer}</div>
+        )}
       </div>
 
       {lightbox && (

--- a/frontend/src/components/SettingsSurface.tsx
+++ b/frontend/src/components/SettingsSurface.tsx
@@ -89,6 +89,8 @@ interface Props {
   initialPosition?: SettingsPosition;
   /** Diagnostics › Price table links to Stats › Cost › Pricing details (one surface at a time). */
   onOpenStats?: (intent: StatsOpenIntent) => void;
+  /** #698: Version & update › « What's new » opens the changelog modal over the surface. */
+  onOpenChangelog?: () => void;
 }
 
 /** Advisory ceiling: caps above this enter the tmux-server-collapse zone
@@ -229,6 +231,7 @@ export default function SettingsSurface({
   onSaved,
   initialPosition,
   onOpenStats,
+  onOpenChangelog,
 }: Props) {
   const { settings, settled, save, refresh } = useSettings(open);
   const { profiles: agentProfiles, refresh: refreshAgentProfiles } = useAgentProfiles(open);
@@ -672,7 +675,11 @@ export default function SettingsSurface({
                 ) : (
                   loading
                 )}
-                <VersionUpdateSection section={item.sections[3]} active={open} />
+                <VersionUpdateSection
+                  section={item.sections[3]}
+                  active={open}
+                  onOpenChangelog={onOpenChangelog}
+                />
               </>
             )}
 
@@ -1194,7 +1201,15 @@ function InterfaceSection({ section }: { section: SettingsSection }) {
  * unknown (off / unreachable / never) → `—` + the reason. The bar's badge follows via
  * the bus, so disabling the check removes it immediately.
  */
-function VersionUpdateSection({ section, active }: { section: SettingsSection; active: boolean }) {
+function VersionUpdateSection({
+  section,
+  active,
+  onOpenChangelog,
+}: {
+  section: SettingsSection;
+  active: boolean;
+  onOpenChangelog?: () => void;
+}) {
   const { status, setStatus, refresh } = useUpdateStatus(active);
   const [checking, setChecking] = useState(false);
   const [toggling, setToggling] = useState(false);
@@ -1293,7 +1308,21 @@ function VersionUpdateSection({ section, active }: { section: SettingsSection; a
         </KeyValueRow>
         <KeyValueRow label="Latest release" testId="setting-version-latest">
           {status.latest_version ? (
-            <span className={`font-mono ${newer ? "text-st-await" : ""}`}>v{status.latest_version}</span>
+            <>
+              <span className={`font-mono ${newer ? "text-st-await" : ""}`}>v{status.latest_version}</span>
+              {onOpenChangelog && (
+                <button
+                  type="button"
+                  onClick={onOpenChangelog}
+                  className="ml-2 inline-flex items-center gap-1 text-fg-3 underline decoration-fg-5 underline-offset-2 hover:text-fg"
+                  data-testid="setting-version-whats-new"
+                  title={newer ? "See what changed since your version" : "See the changelog of this build"}
+                >
+                  <FileText size={10} />
+                  What's new
+                </button>
+              )}
+            </>
           ) : (
             <>
               <span className="font-mono">—</span>

--- a/frontend/src/components/VersionBadge.test.tsx
+++ b/frontend/src/components/VersionBadge.test.tsx
@@ -24,7 +24,7 @@ function status(overrides: Partial<UpdateStatus> = {}): UpdateStatus {
 // #697 — the status-bar version is a button; the `→ latest` pill appears ONLY when the
 // daemon's cache knows a strictly newer release AND the check is on.
 describe("VersionBadge", () => {
-  it("shows the installed version as a button that opens Version & update", () => {
+  it("shows the installed version as a button that opens What's new", () => {
     const onClick = vi.fn();
     render(<VersionBadge version="1.58.1" update={status()} onClick={onClick} />);
     const btn = screen.getByTestId("statusbar-version");
@@ -40,6 +40,10 @@ describe("VersionBadge", () => {
     expect(screen.getByTestId("statusbar-version")).toHaveAttribute(
       "title",
       expect.stringContaining("v1.59.0 is available"),
+    );
+    expect(screen.getByTestId("statusbar-version")).toHaveAttribute(
+      "title",
+      expect.stringContaining("what's new"),
     );
   });
 

--- a/frontend/src/components/VersionBadge.tsx
+++ b/frontend/src/components/VersionBadge.tsx
@@ -2,11 +2,12 @@ import type { UpdateStatus } from "../types";
 import { newerAvailable } from "../lib/updateStatus";
 
 /**
- * The status-bar version (#697): a BUTTON that opens Settings › General › Version &
- * update. When the daemon's cache knows a newer release, an amber pill `→ <latest>`
- * says how far behind we are (same family as the `ephemeral` pill). Nothing else:
- * up to date, offline, disabled or never checked all render the bare version — the
- * bar never claims "up to date".
+ * The status-bar version (#697): a BUTTON that opens the « What's new » changelog
+ * modal (#698 — Settings › Version & update stays one click away from its footer).
+ * When the daemon's cache knows a newer release, an amber pill `→ <latest>` says how
+ * far behind we are (same family as the `ephemeral` pill). Nothing else: up to date,
+ * offline, disabled or never checked all render the bare version — the bar never
+ * claims "up to date".
  */
 export default function VersionBadge({
   version,
@@ -19,8 +20,8 @@ export default function VersionBadge({
 }) {
   const newer = newerAvailable(update);
   const title = newer
-    ? `v${update!.latest_version} is available — open Version & update`
-    : "Open Version & update";
+    ? `v${update!.latest_version} is available — see what's new`
+    : "What's new in this build";
   return (
     <button
       type="button"

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -800,8 +800,14 @@ body {
 .artifact-markdown h2 { font-size: 13px; }
 .artifact-markdown h3 { font-size: 12px; }
 .artifact-markdown p { margin: 0.5em 0; }
+/* Tailwind preflight strips `list-style`; artifacts (and the #698 changelog) are
+   bullet-heavy, so restore the markers. */
 .artifact-markdown ul,
 .artifact-markdown ol { margin: 0.5em 0; padding-left: 1.5em; }
+.artifact-markdown ul { list-style: disc; }
+.artifact-markdown ol { list-style: decimal; }
+.artifact-markdown a { color: var(--color-acc); text-decoration: underline; text-underline-offset: 2px; }
+.artifact-markdown a:hover { color: var(--color-fg); }
 .artifact-markdown li { margin: 0.25em 0; }
 .artifact-markdown code {
   font-family: var(--font-mono);

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -504,6 +504,25 @@ export interface UpdateStatus {
   /** The last check's error, kept beside the last good values. */
   last_error: string | null;
 }
+
+/** Where the « What's new » body comes from (#698). */
+export type ChangelogSource = "releases" | "embedded";
+
+/** `GET /update/changelog` — the release notes strictly newer than the installed version. */
+export interface UpdateChangelog {
+  installed_version: string;
+  latest_version: string | null;
+  /** Versions strictly newer than the installed one, newest first; empty when up to date or unavailable. */
+  missed_versions: string[];
+  source: ChangelogSource;
+  /**
+   * Set exactly when the body is the embedded changelog BECAUSE the releases were not
+   * available (check off, source unreachable). `null` for an up-to-date daemon.
+   */
+  fallback_reason: string | null;
+  /** Markdown, newest version first, one `## vX.Y.Z` heading per version. */
+  markdown: string;
+}
 // `for-each` was removed (ADR-0011 / #151): a fan-out is now a `collection`
 // loop region, not a node. The backend keeps the variant only to migrate old
 // YAML into a region. `loop` was likewise removed in #171.


### PR DESCRIPTION
Closes #698 (sub-ticket of story #695, spec #696). Base: `integration/695-in-app-update`.

## What
- Daemon: `GET /update/changelog` aggregates the release notes of the versions missed since the installed one (newest first, pre-releases excluded), reusing `ReleaseChecker` / `UpdateStatus` from #697. Falls back to the `CHANGELOG.md` embedded in the binary, with a `fallback_reason`, when the check is off or the source unreachable.
- Frontend: the status-bar version becomes a button opening `ChangelogModal` (markdown artifact rendering: GFM, tables, mermaid). States: newer versions available, fallback (amber banner), up to date (green pill + grey banner). Footer shows the manual update command with a Copy button (ADR-0045), and a link to Settings › General › Version & update.
- Version bump 1.59.0 → 1.60.0, CHANGELOG entry.

## Gate (local)
- Build + Rust and frontend tests green (implementation node).
- FP (#698) run with playwright-cli against the built daemon and a mocked release source: **FP-1, FP-2, FP-3 all pass**. Non-blocking findings: long `script` install command is ellipsised in the 680px footer (Copy still copies the full command); the 4+ versions scrolling state was only covered by the prototype.

🤖 Generated with [Claude Code](https://claude.com/claude-code)