### PR TITLE
prefactor(sandbox): StagingFloor devient StagingSet + autonomy fixups par harnais (#706)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ ascendante** : la casse se signale ici et par un bump majeur, jamais en gardant 
 morts. Seule contrainte non négociable — les **données historiques restent lisibles** : un Run
 archivé s'ouvre et se chiffre quelle que soit la version qui a écrit son payload.
 
+## 1.58.2
+
+**Prefactor sandbox : `StagingFloor` devient `StagingSet`** (#706 ; story #702, spec #704, ADR-0063).
+La capacité de staging rend désormais, par harnais, un set (entrées `$HOME`-relatives, exclusions, env,
+entrées *transcripts*) plus des autonomy fixups ; le merge-back parcourt les entrées *transcripts* de tous
+les sets. `claude` est ré-exprimé dans cette forme, octet pour octet (cinq garanties ADR-0031 intactes) ;
+`copilot` et `opencode` déclarent `None`. Aucun changement observable ; la ligne « Sandbox staging set »
+du tableau de support remplace « staging floor ».
+
 ## 1.58.1
 
 **Livraison de la story Settings revamp** (#688 ; spec #689) : fusion de `integration/688-settings-revamp`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "1.58.1"
+version = "1.58.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "1.58.1"
+version = "1.58.2"
 license = "MIT"
 description = "Prompt-Driven Orchestrator — a local daemon that runs and supervises agentic coding pipelines"
 repository = "https://github.com/Loulen/prompt-driven-orchestrator"

--- a/README.md
+++ b/README.md
@@ -104,10 +104,10 @@ PDO can launch, attach, resume, and complete nodes with every built-in harness.
 | **Transcript** | Find the session transcript | ✅ the JSONL transcript, keyed by working directory | ❌ | ✅ the event journal, keyed by the session identity PDO imposed |
 | **End of turn** | Complete a node when its turn ends | ✅ an injected `Stop` hook, plus the transcript tail as the sweep's fallback | ❌ | ✅ the journal's explicit `assistant.turn_end` event |
 | **Usage-limit menu** | Detect the harness usage-limit menu | ✅ the interactive "wait for limit to reset" menu, matched in a pane capture | ❌ | ❌ |
-| **Sandbox staging floor** | Stage credentials, settings, and trust in a sandbox | ✅ a staged `.claude` home: credentials, org managed settings, pre-granted trust | ❌ | ❌ |
+| **Sandbox staging set** | Stage the harness home in a sandbox and disarm its blocking dialogs | ✅ the `.claude` home: credentials and org managed settings copied, trust and permissions bypass fixed up, transcripts harvested back | ❌ | ❌ |
 | **Context usage** | Show peak context-window usage | ✅ derived: per-turn token usage from the transcript, deduplicated and maxed | ❌ | ✅ derived: the journal's cumulative usage counters, converted to a per-turn contribution and maxed |
 
-Each header shows the last validated harness version; PDO does not enforce it.
+Each header shows the last validated harness version; PDO does not enforce it. The sandbox image is not provided by PDO: it is the profile's image, and the harness binary must already be in it (ADR-0063).
 
 Custom descriptors in `~/.pdo/harnesses/descriptors.yaml` can launch, attach, resume, and complete nodes through `pdo complete`.
 

--- a/crates/pdo-daemon/src/harness_probes.rs
+++ b/crates/pdo-daemon/src/harness_probes.rs
@@ -2,8 +2,8 @@
 //!
 //! Everything PDO knows how to do **beyond launching** a harness is a
 //! **capability**, written harness by harness: estimate a cost, resolve a
-//! transcript, constate an end of turn, spot a usage-limit menu, hold a staging
-//! floor. This module is the factory for those capabilities — and its whole
+//! transcript, constate an end of turn, spot a usage-limit menu, declare a staging
+//! set. This module is the factory for those capabilities — and its whole
 //! point is to make their **absence legible**: never supplied, never silent.
 //!
 //! The shape is deliberate and was settled at the grilling (do not redraw it):
@@ -52,9 +52,9 @@
 //!   harness with no substrate is **said once** ([`turn_end_absence_note`]) rather
 //!   than being a silent no-op.
 //! - **sandbox** ([`crate::node_spawn`]): a sandboxed Run on a harness with no
-//!   [`HarnessProbes::staging_floor`] is **said once, visibly** — it holds only by
-//!   the user's image and the profile's `$HOME` exceptions, without the plancher's
-//!   guarantees (ADR-0031).
+//!   [`HarnessProbes::staging_set`] is **said once, visibly** — it holds only by
+//!   the user's image and the profile's `$HOME` exceptions, with no staged home and
+//!   no autonomy fixups (ADR-0063).
 //!
 //! This module is narrow on purpose: it fabricates **capabilities, never a
 //! launch** (a launch is data — the argv template of [`crate::harness_registry`]).
@@ -216,26 +216,135 @@ impl ContextUsageSource {
     }
 }
 
-/// The sandbox staging floor a harness guarantees (ADR-0031).
-///
-/// Absent ⇒ a sandboxed Run on this harness holds only by the user's image and
-/// the profile's `$HOME` exceptions, without the plancher's guarantees — and PDO
-/// says so once (see [`staging_floor_absence_note`]).
+/// One `$HOME`-relative entry of a harness's staging set (ADR-0063 §1): copied
+/// from the host into the Run's staging on the way in.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum StagingFloor {
-    /// The `.claude` staged home: valid credentials, org managed settings, bypass
-    /// permissions accepted, trust pre-granted to the Run root, empty `projects/`.
-    ClaudeDotClaude,
+pub(crate) struct StagingEntry {
+    /// `$HOME`-relative path (`.claude/.credentials.json`, `.pi/agent/auth.json`).
+    /// Routed by the same classifier as a profile entry
+    /// ([`crate::sandbox_profile::landing`]), so the copy view and the mount view
+    /// cannot drift.
+    pub(crate) rel: &'static str,
+    /// What to log at `info` when the host lacks the entry, or `None` for a silent
+    /// skip. `Some` is for an entry whose absence is the **common** case yet worth a
+    /// line (an org baseline on an install with no org): a `warn!` per Run would
+    /// train the reader to ignore warnings.
+    pub(crate) absent_note: Option<&'static str>,
 }
 
-impl StagingFloor {
+/// A write that disarms a **blocking dialog** once a staging set is copied
+/// (ADR-0063 §2). Distinct from the set itself: the set is what the harness
+/// *reads* to behave as on the host; a fixup is what PDO *writes* so an unattended
+/// session never waits for a human. `claude` has them; `copilot` and `pi` carry the
+/// equivalent on their argv (`--allow-all`, `-a`) and declare none.
+///
+/// Each variant is applied by [`crate::sandbox_staging`], the only module that
+/// writes into a staging — this enum only *names* the write.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AutonomyFixup {
+    /// `skipDangerousModePermissionPrompt: true` in the staged `.claude/settings.json`
+    /// — merged into the host copy when the profile staged it, synthesised as a
+    /// one-key file otherwise (ADR-0031 §1 G3).
+    ClaudeBypassPermissions,
+    /// The staged `.claude.json` baseline: `hasCompletedOnboarding`, plus trust
+    /// pre-granted on the Run root when there is one (ADR-0031 §1 G4).
+    ClaudeJsonBaseline,
+}
+
+/// The sandbox **staging set** a harness declares (ADR-0063 §1): the `$HOME`
+/// entries and env that make a session in the container behave as on the host,
+/// plus its **transcript sinks** and its [`AutonomyFixup`]s.
+///
+/// Absent ⇒ a sandboxed Run on this harness holds only by the user's image and
+/// the profile's `$HOME` exceptions — and PDO says so once (see
+/// [`staging_set_absence_note`]). `None` is a declared value (ADR-0051), published
+/// in the support table.
+///
+/// The set is **data**; [`crate::sandbox_staging`] is the one interpreter. Today it
+/// is applied at `prepare` (the Run's staging), #708 moves the copy to the spawn of
+/// the first node that resolves the harness (ADR-0063 §3) — same data, later moment.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct StagingSet {
+    /// The support-table cell: what this harness stages, in the reader's words.
+    pub(crate) label: &'static str,
+    /// The harness's home root under `$HOME` (`.claude`, `.pi/agent`): the directory
+    /// mounted (empty until filled) for every first-party harness (ADR-0063 §3).
+    pub(crate) home_root: &'static str,
+    /// Entries copied from the host, whole. Refused as profile entries: the set owns
+    /// them in every profile.
+    pub(crate) entries: &'static [StagingEntry],
+    /// `$HOME`-relative sub-paths **skipped** when an entry above is a directory.
+    pub(crate) excludes: &'static [&'static str],
+    /// Env vars the harness needs inside the container (`PI_TELEMETRY=0`). Posed
+    /// with the set; `claude` needs none.
+    pub(crate) env: &'static [(&'static str, &'static str)],
+    /// `$HOME`-relative transcript sinks: created **empty** on the way in (never
+    /// copied — copying would break the merge-back idempotence and the cost fold),
+    /// **harvested** at merge-back under the same encoded dirname. Refused as
+    /// profile entries.
+    pub(crate) transcripts: &'static [&'static str],
+    /// The blocking-dialog disarms applied once the set is on disk.
+    pub(crate) fixups: &'static [AutonomyFixup],
+}
+
+impl StagingSet {
     pub(crate) fn label(self) -> &'static str {
-        match self {
-            StagingFloor::ClaudeDotClaude => {
-                "a staged `.claude` home — credentials, org managed settings, pre-granted trust"
-            }
-        }
+        self.label
     }
+}
+
+/// `claude`'s staging set — the five guarantees of ADR-0031 §1, byte for byte,
+/// re-expressed as data (ADR-0063 amends §1: they are *claude's*, one set among
+/// others):
+///
+/// - **G1 credentials** → entry `.claude/.credentials.json` (0600 preserved by
+///   `std::fs::copy`; absent on the host → silent no-op, auth fails later and it is
+///   not `prepare`'s call);
+/// - **G2 org managed settings** → entry `.claude/remote-settings.json` (absent →
+///   `info!` no-op, the majority case; present but uncopyable → hard error, a
+///   compliance surprise);
+/// - **G3 bypass permissions** → [`AutonomyFixup::ClaudeBypassPermissions`];
+/// - **G4 `.claude.json` baseline** → [`AutonomyFixup::ClaudeJsonBaseline`];
+/// - **G5 empty transcript sink** → transcripts `.claude/projects`.
+///
+/// The `~/.claude` allowlist itself (skills, plugins, settings…) is NOT here: it is
+/// the user's `full` profile ([`crate::sandbox_profile::DEFAULT_FULL_ENTRIES`]),
+/// the harness-agnostic diff of ADR-0063 §4.
+pub(crate) const CLAUDE_STAGING_SET: StagingSet = StagingSet {
+    label: "the `.claude` home — credentials and org managed settings copied, trust and \
+            permissions bypass fixed up, transcripts harvested back",
+    home_root: ".claude",
+    entries: &[
+        StagingEntry {
+            rel: ".claude/.credentials.json",
+            absent_note: None,
+        },
+        StagingEntry {
+            rel: ".claude/remote-settings.json",
+            absent_note: Some("nothing to consent to (no-op)"),
+        },
+    ],
+    excludes: &[],
+    env: &[],
+    transcripts: &[".claude/projects"],
+    fixups: &[
+        AutonomyFixup::ClaudeBypassPermissions,
+        AutonomyFixup::ClaudeJsonBaseline,
+    ],
+};
+
+/// Every staging set a first-party harness declares, in registry order. The
+/// generic consumers (the transcript merge-back, the profile grammar's refusals)
+/// iterate this rather than naming `claude`, so a harness that declares a set is
+/// harvested and protected with no second edit (ADR-0063).
+pub(crate) fn staging_sets() -> Vec<(String, StagingSet)> {
+    crate::harness_registry::embedded_floor()
+        .into_iter()
+        .filter_map(|d| {
+            let set = probes_for(&d.name)?.staging_set()?;
+            Some((d.name, set))
+        })
+        .collect()
 }
 
 /// The capabilities of one harness. **Every method defaults to "absent"**
@@ -262,9 +371,9 @@ pub(crate) trait HarnessProbes: Sync {
     fn usage_limit_anchor(&self) -> Option<UsageLimitAnchor> {
         None
     }
-    /// The sandbox staging floor, or `None` (a sandboxed Run says its absence
-    /// once).
-    fn staging_floor(&self) -> Option<StagingFloor> {
+    /// The sandbox staging set, or `None` (a sandboxed Run says its absence
+    /// once). ADR-0063.
+    fn staging_set(&self) -> Option<StagingSet> {
         None
     }
     /// The context-usage source, or `None` (Performance shows no Context column
@@ -390,8 +499,8 @@ impl HarnessProbes for ClaudeProbes {
     fn usage_limit_anchor(&self) -> Option<UsageLimitAnchor> {
         Some(UsageLimitAnchor::ClaudePaneMenu)
     }
-    fn staging_floor(&self) -> Option<StagingFloor> {
-        Some(StagingFloor::ClaudeDotClaude)
+    fn staging_set(&self) -> Option<StagingSet> {
+        Some(CLAUDE_STAGING_SET)
     }
 
     fn context_usage_source(&self) -> Option<ContextUsageSource> {
@@ -484,8 +593,8 @@ static CLAUDE_PROBES: ClaudeProbes = ClaudeProbes;
 ///   own documentation admits the textual anchor drifts each version, and it
 ///   triggers no recovery (ADR-0012) — a second harness declaring it absent
 ///   degrades nothing actionable (ADR-0051 §"Limites");
-/// - the **staging floor** is absent: configuring a harness is a documented
-///   prerequisite, not PDO code (ADR-0031 / CONTEXT.md § "Harnais agentique").
+/// - the **staging set** is absent: configuring `copilot` is a documented
+///   prerequisite, not PDO code (ADR-0063 / CONTEXT.md § "Harnais agentique").
 ///
 /// The three present capabilities dispatch to `copilot`'s own implementation — its
 /// event journal, never `claude`'s cwd-keyed JSONL store.
@@ -510,7 +619,7 @@ impl HarnessProbes for CopilotProbes {
     fn turn_end_substrate(&self) -> Option<TurnEndSubstrate> {
         Some(TurnEndSubstrate::CopilotEventJournal)
     }
-    // usage_limit_anchor / staging_floor stay `None` — declared absent (see above).
+    // usage_limit_anchor / staging_set stay `None` — declared absent (see above).
 
     fn context_usage_source(&self) -> Option<ContextUsageSource> {
         Some(ContextUsageSource::CopilotJournalPeak)
@@ -651,7 +760,7 @@ pub(crate) fn exit_code_is_verdict(harness: &str) -> bool {
 /// turn-end auto-completion is enabled (ADR-0051 / correctif AC #7). `Some(msg)`
 /// when the setting cannot be honoured for `harness`, `None` for a harness that
 /// has the substrate (`claude`). Pure and testable, the twin of
-/// [`staging_floor_absence_note`]: the setting stops being a silent no-op.
+/// [`staging_set_absence_note`]: the setting stops being a silent no-op.
 pub(crate) fn turn_end_absence_note(harness: &str) -> Option<String> {
     if capabilities(harness).turn_end {
         return None;
@@ -720,7 +829,7 @@ pub(crate) fn capabilities(harness: &str) -> Capabilities {
             transcript: p.transcript_resolution().is_some(),
             turn_end: p.turn_end_substrate().is_some(),
             usage_limit: p.usage_limit_anchor().is_some(),
-            staging: p.staging_floor().is_some(),
+            staging: p.staging_set().is_some(),
             context_usage: p.context_usage_source().is_some(),
         },
     }
@@ -745,17 +854,17 @@ pub(crate) fn can_measure_context(harness: &str) -> bool {
 }
 
 /// The one-time note for a sandboxed Run whose node runs on a harness with no
-/// staging floor (ADR-0031). `Some(msg)` when `harness` lacks the floor,
-/// `None` when it has it (`claude`). Pure and testable, modelled on
+/// staging set (ADR-0063). `Some(msg)` when `harness` lacks a set, `None` when it
+/// declares one (`claude`). Pure and testable, modelled on
 /// `price_table::diagnostic`.
-pub(crate) fn staging_floor_absence_note(harness: &str) -> Option<String> {
+pub(crate) fn staging_set_absence_note(harness: &str) -> Option<String> {
     if capabilities(harness).staging {
         return None;
     }
     Some(format!(
-        "sandbox: harness `{harness}` has no staging floor (#553, ADR-0031) — this Run's session \
-         holds only by the profile's image and its `$HOME` exceptions, without the plancher's \
-         guarantees (credentials, org managed settings, pre-granted trust, empty projects/)"
+        "sandbox: harness `{harness}` has no staging set (#553, ADR-0063) — this Run's session \
+         holds only by the profile's image and its `$HOME` exceptions, without a staged home \
+         (credentials, settings) or autonomy fixups (pre-granted trust, permissions bypass)"
     ))
 }
 
@@ -777,7 +886,7 @@ mod tests {
         assert!(bare.transcript_resolution().is_none());
         assert!(bare.turn_end_substrate().is_none());
         assert!(bare.usage_limit_anchor().is_none());
-        assert!(bare.staging_floor().is_none());
+        assert!(bare.staging_set().is_none());
         assert!(bare.context_peak("anything").is_none());
         assert!(bare
             .subagent_transcripts(Path::new("/root"), Path::new("/wd"), "sid")
@@ -802,7 +911,7 @@ mod tests {
             p.usage_limit_anchor(),
             Some(UsageLimitAnchor::ClaudePaneMenu)
         );
-        assert_eq!(p.staging_floor(), Some(StagingFloor::ClaudeDotClaude));
+        assert_eq!(p.staging_set(), Some(CLAUDE_STAGING_SET));
     }
 
     #[test]
@@ -855,7 +964,7 @@ mod tests {
             p.usage_limit_anchor().is_none(),
             "usage-limit declared absent"
         );
-        assert!(p.staging_floor().is_none(), "staging floor declared absent");
+        assert!(p.staging_set().is_none(), "staging set declared absent");
 
         assert_eq!(
             capabilities(COPILOT),
@@ -1041,12 +1150,45 @@ mod tests {
     }
 
     #[test]
-    fn staging_floor_absence_note_fires_only_for_a_harness_without_the_floor() {
-        assert_eq!(staging_floor_absence_note(CLAUDE), None);
-        let note = staging_floor_absence_note("my-custom-harness").expect("a note");
+    fn staging_set_absence_note_fires_only_for_a_harness_without_a_set() {
+        assert_eq!(staging_set_absence_note(CLAUDE), None);
+        let note = staging_set_absence_note("my-custom-harness").expect("a note");
         assert!(note.contains("`my-custom-harness`"));
-        assert!(note.contains("no staging floor"));
+        assert!(note.contains("no staging set"));
         assert!(note.contains("$HOME"));
+    }
+
+    /// ADR-0063: the five guarantees of ADR-0031 §1 are `claude`'s set, as data.
+    /// Pinned here so a later edit to the set is a visible change of contract.
+    #[test]
+    fn claude_staging_set_carries_the_five_guarantees_of_adr_0031() {
+        let set = CLAUDE_STAGING_SET;
+        assert_eq!(set.home_root, ".claude");
+        let entries: Vec<&str> = set.entries.iter().map(|e| e.rel).collect();
+        assert_eq!(
+            entries,
+            [".claude/.credentials.json", ".claude/remote-settings.json"]
+        );
+        assert_eq!(set.transcripts, [".claude/projects"]);
+        assert_eq!(
+            set.fixups,
+            [
+                AutonomyFixup::ClaudeBypassPermissions,
+                AutonomyFixup::ClaudeJsonBaseline
+            ]
+        );
+        assert!(set.env.is_empty(), "claude needs no env in the container");
+        assert!(set.excludes.is_empty());
+    }
+
+    /// Only `claude` declares a set today; `copilot` and `opencode` are explicit
+    /// `None`s, so the generic consumers see exactly one set.
+    #[test]
+    fn staging_sets_lists_claude_only() {
+        let sets = staging_sets();
+        assert_eq!(sets.len(), 1, "{sets:?}");
+        assert_eq!(sets[0].0, CLAUDE);
+        assert_eq!(sets[0].1, CLAUDE_STAGING_SET);
     }
 
     fn claude_turn(id: &str, input: u64, output: u64) -> String {

--- a/crates/pdo-daemon/src/harness_support.rs
+++ b/crates/pdo-daemon/src/harness_support.rs
@@ -60,7 +60,7 @@ impl Capability {
             Capability::Transcript => "Transcript",
             Capability::TurnEnd => "End of turn",
             Capability::UsageLimit => "Usage-limit menu",
-            Capability::Staging => "Sandbox staging floor",
+            Capability::Staging => "Sandbox staging set",
             Capability::ContextUsage => "Context usage",
         }
     }
@@ -73,7 +73,9 @@ impl Capability {
             Capability::Transcript => "Find the session transcript",
             Capability::TurnEnd => "Complete a node when its turn ends",
             Capability::UsageLimit => "Detect the harness usage-limit menu",
-            Capability::Staging => "Stage credentials, settings, and trust in a sandbox",
+            Capability::Staging => {
+                "Stage the harness home in a sandbox and disarm its blocking dialogs"
+            }
             Capability::ContextUsage => "Show peak context-window usage",
         }
     }
@@ -88,7 +90,7 @@ impl Capability {
             Capability::Transcript => p.transcript_resolution().map(|t| t.label()),
             Capability::TurnEnd => p.turn_end_substrate().map(|t| t.label()),
             Capability::UsageLimit => p.usage_limit_anchor().map(|u| u.label()),
-            Capability::Staging => p.staging_floor().map(|s| s.label()),
+            Capability::Staging => p.staging_set().map(|s| s.label()),
             Capability::ContextUsage => p.context_usage_source().map(|c| c.label()),
         }
     }
@@ -136,7 +138,9 @@ pub fn render() -> String {
     }
 
     out.push_str(
-        "\nEach header shows the last validated harness version; PDO does not enforce it.\n",
+        "\nEach header shows the last validated harness version; PDO does not enforce it. \
+         The sandbox image is not provided by PDO: it is the profile's image, and the harness \
+         binary must already be in it (ADR-0063).\n",
     );
 
     out.push_str(

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -10890,7 +10890,7 @@ fn sandbox_profile_view(
         let enabled = profile.resolved.entries.iter().any(|e| e == extra);
         entries.push(sandbox_entry_view(home_root, extra, None, enabled));
     }
-    let floor: Vec<serde_json::Value> = sandbox_profile::FLOOR_GUARANTEES
+    let floor: Vec<serde_json::Value> = sandbox_profile::STAGING_GUARANTEES
         .iter()
         .map(|g| serde_json::json!({ "id": g.id, "label": g.label, "path": g.path }))
         .collect();
@@ -11607,7 +11607,7 @@ async fn get_run(
             // are an instance concept) while transcripts come from `projects_root`,
             // which moves for a sandboxed Run.
             let prices = price_table::PriceTable::load(&home_root);
-            // Copilot has no staging floor, so its session journals are read from the
+            // Copilot has no staging set, so its session journals are read from the
             // host `.copilot/session-state/`.
             let copilot_root = sandbox_run::copilot_store_root(&home_root);
             augment_run_state_from_disk(
@@ -12310,7 +12310,7 @@ async fn run_stale_detection(state: &Arc<AppState>) {
             &home_root,
             &sandbox_root,
         );
-        // Copilot has no staging floor, so it resolves its transcript from the host
+        // Copilot has no staging set, so it resolves its transcript from the host
         // `.copilot/session-state/`. Picked per node below by the frozen harness.
         let copilot_root = sandbox_run::copilot_store_root(&home_root);
 

--- a/crates/pdo-daemon/src/node_spawn.rs
+++ b/crates/pdo-daemon/src/node_spawn.rs
@@ -100,18 +100,18 @@ fn spawn_home_root(deps: &SpawnDeps<'_>) -> PathBuf {
         .unwrap_or_default()
 }
 
-/// #553 / ADR-0031: say ONCE per `(run, harness)` that a sandboxed Run's node runs
-/// on a harness with no staging floor. The message is the pure
-/// [`crate::harness_probes::staging_floor_absence_note`] (so it is unit-tested
+/// #553 / ADR-0063: say ONCE per `(run, harness)` that a sandboxed Run's node runs
+/// on a harness with no staging set. The message is the pure
+/// [`crate::harness_probes::staging_set_absence_note`] (so it is unit-tested
 /// there, not against a terminal); the process-static dedup keeps a busy scheduler
 /// from repeating it on every retry or collection lap. A no-op for `claude`, which
-/// has the floor.
-fn warn_missing_staging_floor_once(run_id: &str, harness: &str) {
+/// declares a set.
+fn warn_missing_staging_set_once(run_id: &str, harness: &str) {
     use std::collections::HashSet;
     use std::sync::Mutex;
     static SAID: Mutex<Option<HashSet<(String, String)>>> = Mutex::new(None);
 
-    let Some(note) = crate::harness_probes::staging_floor_absence_note(harness) else {
+    let Some(note) = crate::harness_probes::staging_set_absence_note(harness) else {
         return;
     };
     let mut guard = SAID.lock().unwrap_or_else(|e| e.into_inner());
@@ -147,7 +147,7 @@ fn warn_turn_end_unsupported_once(run_id: &str, harness: &str) {
 /// #563 (AC13/AC14): say ONCE per `(run, tier, profile_id)` that a tier named a
 /// `Profile` reference absent from the atomic snapshot — the walk warned and
 /// behaved as `Inherit` for that tier rather than failing the spawn. Deduped the
-/// same way as [`warn_missing_staging_floor_once`] so a busy scheduler replaying
+/// same way as [`warn_missing_staging_set_once`] so a busy scheduler replaying
 /// the same stale reference doesn't spam the log every retry.
 fn warn_missing_agent_profile_once(
     run_id: &str,
@@ -628,12 +628,13 @@ pub(crate) async fn spawn_node(
             let registry = harness_registry::HarnessRegistry::load(&spawn_home_root(&deps));
             match registry.resolve(&r.harness) {
                 Some(d) => {
-                    // #553 / ADR-0031: a sandboxed Run whose node runs on a harness
-                    // with no staging floor holds only by the profile's image and
-                    // its `$HOME` exceptions — say it once, visibly (the plancher is
-                    // claude-specific and built per-Run regardless of the harness).
+                    // #553 / ADR-0063: a sandboxed Run whose node runs on a harness
+                    // with no staging set holds only by the profile's image and
+                    // its `$HOME` exceptions — say it once, visibly (today only
+                    // `claude`'s set is applied, per Run, whatever the harness; #708
+                    // fills each set at the spawn that resolves its harness).
                     if run_sandboxed {
-                        warn_missing_staging_floor_once(run_id, &r.harness);
+                        warn_missing_staging_set_once(run_id, &r.harness);
                     }
                     Some(d)
                 }

--- a/crates/pdo-daemon/src/sandbox_container.rs
+++ b/crates/pdo-daemon/src/sandbox_container.rs
@@ -597,8 +597,8 @@ fn start_container(docker_bin: &str, name: &str) -> Result<()> {
 /// **Best-effort, par choix** : la grande majorité des Runs n'invoquent jamais `sudo`. Faire
 /// échouer un Run parce qu'une commodité n'a pas pu être posée serait pire que le défaut
 /// corrigé — donc `warn!` et on continue, jamais de `?` vers l'appelant (miroir de
-/// `sandbox_run::kill_session_best_effort`). C'est l'exact opposé de la politique du plancher de
-/// staging, et pour une raison nette : le plancher désarme des dialogues qui **bloquent** un
+/// `sandbox_run::kill_session_best_effort`). C'est l'exact opposé de la politique des autonomy fixups du
+/// staging set, et pour une raison nette : un fixup désarme des dialogues qui **bloquent** un
 /// agent non surveillé, ici l'agent voit juste une commande échouer.
 ///
 /// Sur les trois branches et pas seulement `Absent` : un conteneur créé par un daemon antérieur

--- a/crates/pdo-daemon/src/sandbox_profile.rs
+++ b/crates/pdo-daemon/src/sandbox_profile.rs
@@ -45,12 +45,13 @@
 //!    [`DEFAULT_FULL_ENTRIES`]. It is still not a *diff* — an image is one value, not a list, so
 //!    "poses nothing" resolves to the default outright rather than folding against it.
 //!
-//! 4. **The floor is not editable, and not an entry either** (ADR-0031 §1). The five
-//!    guarantees [`crate::sandbox_staging`] holds in every profile are satisfied either
-//!    by an entry or by a fallback synthesis. Two of them need *keys* in a file the
-//!    profile may also carry (class **(b)** below) — unchecking those is safe. Three
-//!    need the *whole* file, so they are class **(c)**: shown read-only, never
-//!    checkable, and **refused as extras** too.
+//! 4. **A harness's staging set is not editable, and not an entry either** (ADR-0031
+//!    §1, ADR-0063). The five guarantees [`crate::sandbox_staging`] holds for `claude`
+//!    in every profile are satisfied either by an entry or by a fallback synthesis. Two
+//!    of them need *keys* in a file the profile may also carry (class **(b)** below) —
+//!    unchecking those is safe. Three need the *whole* file, so they are class **(c)**:
+//!    shown read-only, never checkable, and **refused as extras** too — for the entries
+//!    and transcript sinks of **every** declared set ([`set_owned_paths`]).
 //!
 //! ## No rename in v1
 //!
@@ -68,7 +69,7 @@ use sqlx::{Row, SqlitePool};
 /// The virtual default that carries the full replica of the host `~/.claude`.
 pub(crate) const FULL_PROFILE: &str = "full";
 /// The virtual default that carries **nothing** in its own right: `minimal` *is* the
-/// staging floor, which is exactly the empty entry list.
+/// harness staging set alone, which is exactly the empty entry list.
 pub(crate) const MINIMAL_PROFILE: &str = "minimal";
 
 /// The two names that resolve with no database row (ADR-0031 §2). Creating one *is*
@@ -102,8 +103,8 @@ pub(crate) struct DefaultEntry {
     /// `$HOME`-relative path or one-level glob.
     pub path: &'static str,
     pub kind: EntryKind,
-    /// Class **(b)**: unchecking it does NOT make the file absent — the staging floor
-    /// re-synthesises the keys it needs. Exactly two entries, and the UI must say so,
+    /// Class **(b)**: unchecking it does NOT make the file absent — an autonomy fixup
+    /// of the staging set re-synthesises the keys it needs. Exactly two entries, and the UI must say so,
     /// or unchecking looks more destructive than it is.
     pub resynthesised: bool,
     /// Static, server-owned advisory shown under the entry. Static on purpose: a real
@@ -116,7 +117,7 @@ pub(crate) struct DefaultEntry {
 /// The `full` profile — the built-in default every profile except `minimal` diffs
 /// against. Order here is the *editor's* reading order; [`resolve_entry_list`] sorts.
 ///
-/// `.credentials.json` is deliberately absent: it is a **floor** guarantee (G1), and
+/// `.credentials.json` is deliberately absent: it is a **staging set** entry (G1), and
 /// having it in both places made the constant lie about being a list of entries.
 pub(crate) const DEFAULT_FULL_ENTRIES: &[DefaultEntry] = &[
     DefaultEntry {
@@ -209,56 +210,71 @@ pub(crate) const DEFAULT_PROFILE_IMAGE: DefaultProfileImage = DefaultProfileImag
     dockerfile: None,
 };
 
-/// One class-**(c)** floor guarantee: satisfied by the *whole* file, so it is neither
-/// checkable nor addable. Shown read-only in the editor because without that block a
-/// `minimal` profile's screen looks broken and the user wrongly concludes the container
-/// starts with no credentials.
-pub(crate) struct FloorGuarantee {
+/// One class-**(c)** staging-set guarantee: satisfied by the *whole* file, so it is
+/// neither checkable nor addable. Shown read-only in the editor because without that
+/// block a `minimal` profile's screen looks broken and the user wrongly concludes the
+/// container starts with no credentials.
+pub(crate) struct StagingGuarantee {
     pub id: &'static str,
     /// What the container gets, in the user's words.
     pub label: &'static str,
-    /// The `$HOME`-relative path the floor owns, when there is one.
+    /// The `$HOME`-relative path the staging set owns, when there is one.
     pub path: Option<&'static str>,
 }
 
-/// The staging floor, verbatim from [`crate::sandbox_staging::enforce_staging_floor`].
-/// G3/G4 appear here as guarantees even though their files are class-(b) *entries* —
-/// the difference is the rule that decides the classes: **(b) = the floor needs keys in
-/// the file; (c) = the floor needs the file whole.**
-pub(crate) const FLOOR_GUARANTEES: &[FloorGuarantee] = &[
-    FloorGuarantee {
+/// `claude`'s staging set in the user's words, verbatim from
+/// [`crate::harness_probes::CLAUDE_STAGING_SET`] (ADR-0031 §1 G1–G5). G3/G4 appear
+/// here as guarantees even though their files are class-(b) *entries* — the
+/// difference is the rule that decides the classes: **(b) = the fixup needs keys in
+/// the file; (c) = the set needs the file whole.**
+///
+/// Served on the wire under the historical key `floor` (the editor's read-only block):
+/// a wire field, frozen for the frontend and its tests, not a term this code uses.
+pub(crate) const STAGING_GUARANTEES: &[StagingGuarantee] = &[
+    StagingGuarantee {
         id: "credentials",
         label: "Valid Claude credentials",
         path: Some(".claude/.credentials.json"),
     },
-    FloorGuarantee {
+    StagingGuarantee {
         id: "org-managed-settings",
         label: "Your organisation's managed settings, consented",
         path: Some(".claude/remote-settings.json"),
     },
-    FloorGuarantee {
+    StagingGuarantee {
         id: "bypass-permissions",
         label: "Permissions bypass accepted (no blocking dialog)",
         path: None,
     },
-    FloorGuarantee {
+    StagingGuarantee {
         id: "run-root-trust",
         label: "Trust pre-granted on the Run's repo root",
         path: None,
     },
-    FloorGuarantee {
+    StagingGuarantee {
         id: "empty-projects",
         label: "An empty projects/ transcript sink",
         path: Some(".claude/projects"),
     },
 ];
 
-/// Paths the floor owns **whole** — refused as extras, never checkable.
-const FLOOR_OWNED_PATHS: &[&str] = &[
-    ".claude/.credentials.json",
-    ".claude/remote-settings.json",
-    ".claude/projects",
-];
+/// Paths a staging set owns **whole** — refused as extras, never checkable: the
+/// entries and the transcript sinks of **every** declared set (ADR-0063), read from
+/// the dispatch table so a harness that declares a set is protected with no second
+/// edit. Copying a transcript sink would break the merge-back idempotence and the
+/// cost fold; copying a set entry would make the profile lie about owning it.
+pub(crate) fn set_owned_paths() -> Vec<&'static str> {
+    crate::harness_probes::staging_sets()
+        .into_iter()
+        .flat_map(|(_, set)| {
+            set.entries
+                .iter()
+                .map(|e| e.rel)
+                .chain(set.transcripts.iter().copied())
+                .collect::<Vec<_>>()
+        })
+        .collect()
+}
 
 /// Where an entry lands in the staging. The SINGLE classifier shared by the copy view
 /// and the mount view (see the module header, idea 2).
@@ -391,13 +407,10 @@ pub(crate) fn validate_entry(raw: &str) -> Result<String, String> {
              every other Run's staging into this one"
         ));
     }
-    if FLOOR_OWNED_PATHS.contains(&norm.as_str())
-        || FLOOR_OWNED_PATHS
-            .iter()
-            .any(|p| norm.starts_with(&format!("{p}/")))
-    {
+    let owned = set_owned_paths();
+    if owned.contains(&norm.as_str()) || owned.iter().any(|p| norm.starts_with(&format!("{p}/"))) {
         return Err(format!(
-            "`{norm}`: the staging floor owns that path in every profile — it is \
+            "`{norm}`: the harness staging set owns that path in every profile — it is \
              guaranteed, not selectable"
         ));
     }
@@ -405,7 +418,7 @@ pub(crate) fn validate_entry(raw: &str) -> Result<String, String> {
 }
 
 /// The built-in default a profile diffs against: **empty** for `minimal` (which *is*
-/// the floor), the `full` list for every other name.
+/// the staging set alone), the `full` list for every other name.
 ///
 /// So a brand-new profile starts as a copy of `full` with everything checked — which is
 /// what makes "uncheck `.claude/plugins`" the two-click operation the issue asks for.
@@ -990,7 +1003,7 @@ mod tests {
         assert!(got.inactive_disabled.is_empty());
     }
 
-    /// `minimal` IS the floor: the empty list, not an error and not a special case.
+    /// `minimal` IS the staging set alone: the empty list, not an error and not a special case.
     #[test]
     fn minimal_default_resolves_to_the_empty_list() {
         let base = base_entries(MINIMAL_PROFILE);
@@ -1350,10 +1363,10 @@ mod tests {
         assert!(validate_profile_image(&reg(&"a".repeat(MAX_IMAGE_REF_LEN))).is_ok());
     }
 
-    /// Exactly two class-(b) entries — the floor re-synthesises those two files, so
+    /// Exactly two class-(b) entries — the set's fixups re-synthesise those two files, so
     /// unchecking them is safe. The UI copy depends on this count being right.
     #[test]
-    fn exactly_two_default_entries_are_resynthesised_by_the_floor() {
+    fn exactly_two_default_entries_are_resynthesised_by_the_fixups() {
         let resynth: Vec<&str> = DEFAULT_FULL_ENTRIES
             .iter()
             .filter(|e| e.resynthesised)

--- a/crates/pdo-daemon/src/sandbox_run.rs
+++ b/crates/pdo-daemon/src/sandbox_run.rs
@@ -45,7 +45,7 @@ pub(crate) struct SandboxContext {
     /// the repo + every node sub-worktree under `.pdo/runs/` + `.pdo/prompts`.
     pub(crate) repo_root: PathBuf,
     /// The Run's pipeline worktree (`-w` cosmetic at create; the trust dialog is
-    /// seeded by the staging floor on `repo_root`, the common ancestor of every
+    /// seeded by the staging set's trust fixup on `repo_root`, the common ancestor of every
     /// worktree, in BOTH sandboxed modes — #426).
     pub(crate) run_worktree: PathBuf,
     pub(crate) daemon_port: u16,
@@ -324,7 +324,7 @@ pub(crate) fn transcripts_root(
 /// where each session's event journal lives at `<session-id>/events.jsonl` (#615).
 ///
 /// Always the **host** home, unlike [`transcripts_root`]: `copilot` declares **no
-/// staging floor** (ADR-0031 / #615), so a sandboxed Run has no staged copilot home
+/// staging set** (ADR-0063 / #615), so a sandboxed Run has no staged copilot home
 /// to mirror — the journal is read where the harness wrote it. Path math only; this
 /// module never reads `$HOME` (the caller injects `home_root`).
 pub(crate) fn copilot_store_root(home_root: &Path) -> PathBuf {
@@ -381,8 +381,8 @@ pub(crate) fn ensure_ready(ctx: &SandboxContext) -> Result<()> {
 
     // 1. Stage the Claude home ONCE. The ~1 GB `full` walk must not repeat on
     //    every ensure_ready — gate on the staging dir already existing.
-    //    `prepare` then holds the **staging floor** (#426, ADR-0031 §1) in BOTH
-    //    sandboxed modes, mode-agnostically: valid credentials, the org managed-
+    //    `prepare` then applies `claude`'s **staging set** (#426, ADR-0031 §1;
+    //    ADR-0063) in BOTH sandboxed modes, mode-agnostically: valid credentials, the org managed-
     //    settings baseline, the accepted permissions bypass, trust pre-granted on
     //    `repo_root` (the common ancestor of the pipeline worktree AND every node
     //    sub-worktree), and an empty `projects/` sink. Each guarantee is met either
@@ -823,7 +823,7 @@ mod tests {
             "full must pre-approve the repo_root trust dialog: {json}"
         );
 
-        // #426: the staging floor runs through the REAL caller, not just a direct
+        // #426: the staging set runs through the REAL caller, not just a direct
         // `prepare` call. `test_ctx`'s home carries credentials only, so G3 lands on
         // its synthesis branch.
         let staged_settings =
@@ -833,7 +833,7 @@ mod tests {
         assert_eq!(
             settings["skipDangerousModePermissionPrompt"],
             serde_json::json!(true),
-            "ensure_ready must hold the staging floor: {settings}"
+            "ensure_ready must hold the staging set: {settings}"
         );
     }
 

--- a/crates/pdo-daemon/src/sandbox_staging.rs
+++ b/crates/pdo-daemon/src/sandbox_staging.rs
@@ -32,13 +32,17 @@
 //!   `projects/<enc>/<uuid>/subagents/*.jsonl` (profondeur 9). Le copy-set doit
 //!   *égaler* le read-set de [`crate::run_cost`] (`collect_jsonl_recursive`),
 //!   sinon le coût des runs sandboxés est sous-estimé (régression silencieuse).
-//! - **Le plancher de staging est profil-agnostique** (#426, ADR-0031 §1).
-//!   [`prepare`] est en **deux phases** : matérialisation des entrées du profil, puis
-//!   [`enforce_staging_floor`] qui tient **cinq garanties** quel que soit le profil —
+//! - **Le staging set d'un harnais est profil-agnostique** (#426, ADR-0031 §1 ;
+//!   ADR-0063). [`prepare`] est en **deux phases** : matérialisation des entrées du
+//!   profil, puis [`apply_staging_set`] pour chaque set déclaré par un harnais
+//!   first-party ([`crate::harness_probes::staging_sets`]) — entrées copiées de
+//!   l'hôte, puits de transcripts créés vides, *autonomy fixups* synthétisés. Pour
+//!   `claude`, ce sont les **cinq garanties** d'ADR-0031 §1, octet pour octet :
 //!   chacune satisfaite soit par une copie de l'hôte, soit par une synthèse de repli.
-//!   `minimal`, c'est exactement le plancher (liste vide). Les trois garanties qui
-//!   désarment un dialogue bloquant (confiance, managed settings de l'org, bypass
-//!   permissions) ne sont pas cosmétiques : un agent non surveillé se figerait dessus.
+//!   `minimal`, c'est exactement le set (liste vide). Les fixups qui désarment un
+//!   dialogue bloquant (confiance, bypass permissions) ne sont pas cosmétiques : un
+//!   agent non surveillé se figerait dessus. Ce module est **l'interprète unique**
+//!   d'un set ; il n'en déclare aucun.
 //! - **Une entrée hors `.claude` est copiée puis montée** (#432, ADR-0031 §4) :
 //!   `<staging>/home/<rel>` → `$HOME/<rel>` en rw, **jamais** un bind direct du
 //!   fichier hôte. Un `git config --global` du conteneur touche la copie, pas le
@@ -52,14 +56,20 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use anyhow::{Context, Result};
 use tracing::{info, warn};
 
+use crate::harness_probes::{AutonomyFixup, StagingSet};
+
 /// Baseline de managed settings poussée par l'organisation, cachée par Claude Code
 /// dans `~/.claude/`. Garantie G2 : recopiée dans les **deux** modes, jamais via
-/// [`FULL_ALLOWLIST_FILES`]. Sans elle, la session bute sur le dialogue
-/// « managed settings require approval » (le consentement est comparé au contenu
-/// de ce fichier) et un Run autonome reste planté.
+/// le profil. Sans elle, la session bute sur le dialogue « managed settings require
+/// approval » (le consentement est comparé au contenu de ce fichier) et un Run
+/// autonome reste planté. Depuis ADR-0063 le chemin runtime est une **entrée du
+/// staging set de `claude`** ([`crate::harness_probes::CLAUDE_STAGING_SET`]) ; le
+/// nom court ne sert plus qu'aux fixtures de test, qui le pinnent contre le set.
+#[cfg(test)]
 const REMOTE_SETTINGS_FILE: &str = "remote-settings.json";
 
-/// Le `settings.json` du home stagé — porteur de la garantie G3.
+/// Le `settings.json` du home stagé — porteur de la garantie G3
+/// ([`crate::harness_probes::AutonomyFixup::ClaudeBypassPermissions`]).
 const SETTINGS_FILE: &str = "settings.json";
 
 /// Clé top-level qui désarme le prompt de confirmation du
@@ -97,6 +107,21 @@ pub(crate) fn staged_claude_json(sandbox_root: &Path, run_id: &str) -> PathBuf {
 /// l'utilisateur.
 pub(crate) fn staged_home_extras(sandbox_root: &Path, run_id: &str) -> PathBuf {
     staging_dir_for_run(sandbox_root, run_id).join("home")
+}
+
+/// Où une entrée `$HOME`-relative atterrit dans le staging d'un Run — **la** vue
+/// chemin du classificateur [`crate::sandbox_profile::landing`], partagée par le
+/// profil et par les staging sets (ADR-0063) : `.claude/<rel>` →
+/// `claude-home/<rel>`, `.claude.json` → le sibling, tout le reste → `home/<rel>`.
+/// Un glob n'a pas de chemin unique : il dégrade en son motif littéral (aucun set
+/// n'en déclare ; le profil les expanse lui-même).
+pub(crate) fn staged_path(sandbox_root: &Path, run_id: &str, rel: &str) -> PathBuf {
+    use crate::sandbox_profile::Landing;
+    match crate::sandbox_profile::landing(rel) {
+        Landing::ClaudeHome { rel, .. } => staged_claude_home(sandbox_root, run_id).join(rel),
+        Landing::ClaudeJson => staged_claude_json(sandbox_root, run_id),
+        Landing::HomeExtra { rel } => staged_home_extras(sandbox_root, run_id).join(rel),
+    }
 }
 
 /// Un bind-mount d'exception `$HOME` : `source` (dans le staging) → `target` (dans
@@ -163,29 +188,35 @@ pub(crate) fn extra_mounts(
 
 /// Seede le *staged Claude home* et renvoie sa racine (`<sandbox_root>/<run_id>`).
 ///
-/// **Deux phases** (#426, ADR-0031 §1) :
+/// **Deux phases** (#426, ADR-0031 §1 ; ADR-0063) :
 /// 1. *matérialisation du profil* — une passe sur la liste d'entrées **gelée** ;
-/// 2. *[`enforce_staging_floor`]* — profil-agnostique, tient les **cinq garanties**
-///    (credentials, managed settings de l'org, bypass permissions, confiance sur
-///    `trusted_root` + onboarding, `projects/` vide).
+/// 2. *[`apply_staging_set`]* pour chaque set déclaré
+///    ([`crate::harness_probes::staging_sets`]) — profil-agnostique. Pour `claude` :
+///    les **cinq garanties** (credentials, managed settings de l'org, bypass
+///    permissions, confiance sur `trusted_root` + onboarding, `projects/` vide).
 ///
-/// La phase 2 tourne **après** la phase 1, jamais dedans : le plancher est un
+/// La phase 2 tourne **après** la phase 1, jamais dedans : un set est un
 /// *check-then-repair* sur ce qui est effectivement posé sur disque (« satisfaite
 /// soit par une copie de l'hôte, soit par une synthèse de repli » n'est décidable
 /// qu'à ce moment-là). Le double write sur `settings.json` quand l'entrée est cochée
-/// (copiée par le profil, puis mergée par le plancher) est **voulu** : le plancher est
+/// (copiée par le profil, puis mergée par le fixup) est **voulu** : le fixup est
 /// merge-aware, il ne doit pas être profil-aware.
+///
+/// Aujourd'hui **tous** les sets déclarés sont appliqués ici, au staging du Run, quel
+/// que soit le harnais des nœuds — le comportement d'avant ADR-0063, où seul `claude`
+/// déclare un set. #708 déplace la copie au spawn du premier nœud qui résout le
+/// harnais (ADR-0063 §3) ; la donnée ne change pas, le moment si.
 ///
 /// `entries` (#432) occupe le slot de l'ancien `mode` : c'est la liste **résolue et
 /// gelée** dans `RunStarted`, jamais le réglage vivant (ADR-0031 §6). `sandbox_staging::Mode`
 /// a disparu — la phase 2 est déjà agnostique depuis #426 et les défauts virtuels sont
 /// des listes nommées, `minimal` étant la vide. Garder un `Mode` à côté d'une liste
-/// recréerait exactement la mode-awareness que le plancher vient de supprimer.
+/// recréerait exactement la mode-awareness que le set vient de supprimer.
 ///
 /// Idempotent (`create_dir_all` ; copy-or-overwrite ; merges non destructifs) et
 /// **additif** — jamais de suppression (ADR-0031 §6). `trusted_root` : racine à
 /// pré-approuver dans le `.claude.json` stagé ; `None` = pas de bloc `projects`
-/// (le reste du plancher est tenu quand même).
+/// (le reste du set est tenu quand même).
 pub(crate) fn prepare(
     home_root: &Path,
     sandbox_root: &Path,
@@ -202,7 +233,16 @@ pub(crate) fn prepare(
     let staged_json = staged_claude_json(sandbox_root, run_id);
 
     materialise_entries(home_root, &src, &home, &staged_json, &staging, entries)?;
-    enforce_staging_floor(&src, &home, &staged_json, trusted_root)?;
+    for (harness, set) in crate::harness_probes::staging_sets() {
+        apply_staging_set(
+            home_root,
+            sandbox_root,
+            run_id,
+            &harness,
+            &set,
+            trusted_root,
+        )?;
+    }
 
     Ok(staging)
 }
@@ -212,8 +252,8 @@ pub(crate) fn prepare(
 /// [`extra_mounts`] consulte, donc la vue *copie* et la vue *mount* ne peuvent pas
 /// diverger.
 ///
-/// N'inclut **aucune** garantie du plancher : celui-ci tourne juste après, quelle que
-/// soit la liste. Une liste vide (`minimal`) est un no-op exact — la traduction
+/// N'inclut **aucune** entrée d'un staging set : ceux-ci tournent juste après, quelle
+/// que soit la liste. Une liste vide (`minimal`) est un no-op exact — la traduction
 /// littérale de l'ancien bras `Mode::Minimal => {}`.
 ///
 /// Politique manquant-sur-l'hôte : `warn!` + skip, pour les entrées du **défaut**
@@ -252,10 +292,10 @@ fn materialise_entries(
             Landing::ClaudeHome { rel, glob: false } => {
                 let from = src.join(rel);
                 let to = home.join(rel);
-                stage_path(&from, &to, &claude_copy_root, entry)?;
+                stage_path(&from, &to, &claude_copy_root, &[], entry)?;
             }
             // `.claude.json` sibling, verbatim (mode préservé). La confiance et
-            // l'onboarding y sont mergés ensuite par le plancher (G4).
+            // l'onboarding y sont mergés ensuite par le fixup `ClaudeJsonBaseline` (G4).
             Landing::ClaudeJson => {
                 let from = home_root.join(".claude.json");
                 if !from.exists() {
@@ -276,7 +316,7 @@ fn materialise_entries(
                 let from = home_root.join(rel);
                 let to = staging.join("home").join(rel);
                 let copy_root = std::fs::canonicalize(&from).unwrap_or_else(|_| from.clone());
-                stage_path(&from, &to, &copy_root, entry)?;
+                stage_path(&from, &to, &copy_root, &[], entry)?;
             }
         }
     }
@@ -285,9 +325,15 @@ fn materialise_entries(
 
 /// Stage une entrée dont on ne sait pas a priori si c'est un fichier ou un dossier.
 /// Dossier → walk préservant symlinks + bits exécutables ([`copy_tree_preserving`],
-/// best-effort par entrée) ; fichier → [`std::fs::copy`] (mode préservé, dont 0600) ;
-/// absent → `warn!` + skip.
-fn stage_path(from: &Path, to: &Path, copy_root: &Path, entry: &str) -> Result<()> {
+/// best-effort par entrée, `skip` = sous-chemins hôte absolus à ne pas copier) ;
+/// fichier → [`std::fs::copy`] (mode préservé, dont 0600) ; absent → `warn!` + skip.
+fn stage_path(
+    from: &Path,
+    to: &Path,
+    copy_root: &Path,
+    skip: &[PathBuf],
+    entry: &str,
+) -> Result<()> {
     let Ok(md) = std::fs::symlink_metadata(from) else {
         warn!(
             "sandbox staging: profile entry `{entry}` is absent on the host ({}) — skipped",
@@ -299,7 +345,7 @@ fn stage_path(from: &Path, to: &Path, copy_root: &Path, entry: &str) -> Result<(
     // est ce que l'utilisateur a désigné.
     if md.file_type().is_symlink() || md.file_type().is_dir() {
         if from.is_dir() {
-            copy_tree_preserving(from, to, copy_root, 0);
+            copy_tree_preserving(from, to, copy_root, skip, 0);
             return Ok(());
         }
         if !from.exists() {
@@ -351,93 +397,125 @@ fn copy_glob_one_level(src_dir: &Path, dst_dir: &Path, pattern: &str) -> Result<
     Ok(())
 }
 
-/// **Le plancher de staging** (#426, ADR-0031 §1) : les garanties que `prepare`
-/// tient dans les **deux** modes — et demain quel que soit le profil. Chacune est
-/// satisfaite soit par une **copie de l'hôte** (phase 1 ou ici), soit par une
-/// **synthèse de repli**. Écrit exclusivement dans le staging ; ne touche jamais
-/// l'hôte.
+/// Applique **un staging set** (ADR-0063) au staging d'un Run : les garanties que
+/// `prepare` tient quel que soit le profil. Écrit exclusivement dans le staging ; ne
+/// touche jamais l'hôte. Trois gestes, dans cet ordre, sur des chemins disjoints :
 ///
-/// - **G1 credentials** — `.credentials.json` copié (0600 préservé par
-///   [`std::fs::copy`]). Absent hôte → no-op (l'auth échouera plus loin, ce n'est
-///   pas à `prepare` d'en juger).
-/// - **G2 managed settings de l'org** — [`REMOTE_SETTINGS_FILE`] copié verbatim.
-///   Absent hôte → `info!` + no-op (cas majoritaire : install sans org ; un `warn!`
-///   par Run entraînerait à ignorer les warnings). Présent mais copie en échec →
-///   erreur **dure** : c'est une surprise de conformité, pas un détail.
-/// - **G3 bypass permissions** — [`BYPASS_PERMISSIONS_KEY`] à `true` dans le
-///   `settings.json` stagé : **mergé** dans la copie hôte en `full`, **synthétisé**
-///   en `minimal`. Fichier corrompu/non-objet → `warn!` + remplacé (symétrie avec
-///   G4 : durcir ferait qu'un seul caractère malformé dans `~/.claude/settings.json`
-///   empêcherait **tout** Run sandboxé).
-/// - **G4 baseline `.claude.json`** — `hasCompletedOnboarding` (défaut défensif,
-///   `or_insert`) + confiance sur `trusted_root` si fournie, 0600 réappliqué.
-///   Inconditionnelle : `sandbox_container` monte ce chemin **toujours**, donc ne
-///   rien écrire laisserait Docker créer un *répertoire* par-dessus
-///   `$HOME/.claude.json`.
-/// - **G5 puits de transcripts** — `projects/` créé **vide**.
+/// 1. **Entrées** — chaque `rel` copié de `$HOME/<rel>` vers [`staged_path`]. Un
+///    fichier via [`std::fs::copy`] (mode préservé, dont 0600 des credentials) ; un
+///    répertoire via [`copy_tree_preserving`] en sautant `excludes` et les puits de
+///    transcripts. Absent hôte → no-op, avec la ligne `info!` de l'entrée si elle en
+///    porte une (un `warn!` par Run entraînerait à ignorer les warnings). Présent
+///    mais copie en échec → erreur **dure** : c'est une surprise de conformité, pas
+///    un détail.
+/// 2. **Puits de transcripts** — créés **vides** (jamais copiés : ni le puits hôte ni
+///    le sous-dir encodé n'existent pour un Run frais ; les copier casserait
+///    l'idempotence du merge-back et le calcul de coût).
+/// 3. **Autonomy fixups** — les écritures qui désarment un dialogue bloquant
+///    ([`AutonomyFixup`]), chacune un merge non destructif dans ce que la phase 1 a
+///    posé, ou une synthèse quand elle n'a rien posé.
+///
+/// Pour `claude`, c'est ADR-0031 §1 mot pour mot : G1 credentials, G2 managed
+/// settings de l'org (entrées) ; G5 `projects/` vide (puits) ; G3 bypass permissions,
+/// G4 baseline `.claude.json` (fixups). L'`env` du set n'est pas posé ici : il se
+/// pose avec le remplissage au spawn (#708) ; `claude` n'en a pas.
 ///
 /// Politique d'écriture : **fail-fast**. `prepare` tourne avant l'existence du
 /// conteneur ; une garantie intenable doit échouer là, pas produire un Run qui pend
 /// sur un dialogue sans personne devant. Ni le best-effort de
 /// [`copy_tree_preserving`] (arbre de 1 Go volatil) ni l'avalage de
 /// [`copy_jsonl_tree`] (transition terminale, ADR-0023) ne s'appliquent ici.
-fn enforce_staging_floor(
-    src: &Path,
-    home: &Path,
-    staged_json: &Path,
+fn apply_staging_set(
+    home_root: &Path,
+    sandbox_root: &Path,
+    run_id: &str,
+    harness: &str,
+    set: &StagingSet,
     trusted_root: Option<&Path>,
 ) -> Result<()> {
-    // G1 — auth. En `minimal`, c'est la seule chose copiée de `~/.claude`
-    // (`oauthAccount`/`userID` de `.claude.json` sont du cache profil PII inutile).
-    copy_file_if_present(
-        &src.join(".credentials.json"),
-        &home.join(".credentials.json"),
-    )?;
-
-    // G2 — baseline de managed settings de l'org, writer UNIQUE (jamais l'allowlist).
-    let remote_src = src.join(REMOTE_SETTINGS_FILE);
-    if remote_src.exists() {
-        let remote_dst = home.join(REMOTE_SETTINGS_FILE);
-        std::fs::copy(&remote_src, &remote_dst).with_context(|| {
-            format!(
-                "stage org managed settings {} -> {}",
-                remote_src.display(),
-                remote_dst.display()
-            )
-        })?;
-    } else {
-        // Cas majoritaire (install sans organisation). `info!` et non `debug!` : le
-        // filtre par défaut du daemon est `pdo_daemon=info,info` (`main.rs`).
-        info!(
-            "sandbox staging: no {REMOTE_SETTINGS_FILE} at {} — nothing to consent to (no-op)",
-            remote_src.display()
-        );
+    // 1 — entrées. `skip` = exclusions + puits de transcripts, en chemins hôte absolus
+    // (c'est ce que le walk compare).
+    let skip: Vec<PathBuf> = set
+        .excludes
+        .iter()
+        .chain(set.transcripts.iter())
+        .map(|rel| home_root.join(rel))
+        .collect();
+    for entry in set.entries {
+        let from = home_root.join(entry.rel);
+        let to = staged_path(sandbox_root, run_id, entry.rel);
+        if !from.exists() {
+            if let Some(note) = entry.absent_note {
+                // `info!` et non `debug!` : le filtre par défaut du daemon est
+                // `pdo_daemon=info,info` (`main.rs`).
+                info!(
+                    "sandbox staging: no {} at {} — {note}",
+                    entry.rel,
+                    from.display()
+                );
+            }
+            continue;
+        }
+        if from.is_dir() {
+            let copy_root = std::fs::canonicalize(&from).unwrap_or_else(|_| from.clone());
+            copy_tree_preserving(&from, &to, &copy_root, &skip, 0);
+        } else {
+            if let Some(parent) = to.parent() {
+                std::fs::create_dir_all(parent)
+                    .with_context(|| format!("create parent {}", parent.display()))?;
+            }
+            std::fs::copy(&from, &to).with_context(|| {
+                format!(
+                    "stage {harness} set entry {} -> {}",
+                    from.display(),
+                    to.display()
+                )
+            })?;
+        }
     }
 
-    // G3 — bypass permissions. `insert` (pas `entry().or_insert()`) : un `false`
-    // hôte doit être écrasé, sinon l'agent se bloque sur le prompt. Pas de `chmod`
-    // (ce n'est pas un secret ; `fs::write` tronque en place et préserve donc le
-    // mode hôte en `full`) et pas de tmp+rename : aucun lecteur concurrent n'existe
-    // avant le conteneur — contrairement à `merge_back`/`atomic_copy_into`.
-    edit_json_object(&home.join(SETTINGS_FILE), "staged settings.json", |obj| {
-        obj.insert(BYPASS_PERMISSIONS_KEY.to_string(), serde_json::json!(true));
-    })?;
+    // 2 — puits de transcripts, créés VIDES.
+    for rel in set.transcripts {
+        let sink = staged_path(sandbox_root, run_id, rel);
+        std::fs::create_dir_all(&sink).with_context(|| {
+            format!(
+                "create staged {harness} transcripts sink {}",
+                sink.display()
+            )
+        })?;
+    }
 
-    // G4 — baseline du `.claude.json` stagé (onboarding + confiance).
-    ensure_claude_json_baseline(staged_json, trusted_root)?;
-
-    // G5 — `projects/` créé VIDE (puits de transcripts runtime). Ni
-    // `~/.claude/projects/` ni le sous-dir encodé n'existent pour un run frais.
-    let projects = home.join("projects");
-    std::fs::create_dir_all(&projects)
-        .with_context(|| format!("create staged projects sink {}", projects.display()))?;
+    // 3 — autonomy fixups.
+    for fixup in set.fixups {
+        match fixup {
+            // G3 — bypass permissions. `insert` (pas `entry().or_insert()`) : un
+            // `false` hôte doit être écrasé, sinon l'agent se bloque sur le prompt.
+            // Pas de `chmod` (ce n'est pas un secret ; `fs::write` tronque en place et
+            // préserve donc le mode hôte en `full`) et pas de tmp+rename : aucun
+            // lecteur concurrent n'existe avant le conteneur — contrairement à
+            // `merge_back`/`atomic_copy_into`.
+            AutonomyFixup::ClaudeBypassPermissions => {
+                let settings = staged_claude_home(sandbox_root, run_id).join(SETTINGS_FILE);
+                edit_json_object(&settings, "staged settings.json", |obj| {
+                    obj.insert(BYPASS_PERMISSIONS_KEY.to_string(), serde_json::json!(true));
+                })?;
+            }
+            // G4 — baseline du `.claude.json` stagé (onboarding + confiance).
+            AutonomyFixup::ClaudeJsonBaseline => {
+                let staged_json = staged_path(sandbox_root, run_id, ".claude.json");
+                ensure_claude_json_baseline(&staged_json, trusted_root)?;
+            }
+        }
+    }
 
     Ok(())
 }
 
-/// Récupère les transcripts (`projects/**/*.jsonl`) du staging vers
-/// `<home_root>/.claude/projects/`, **récursivement** (transcripts de sessions
+/// Récupère les transcripts (`**/*.jsonl`) de **chaque puits déclaré par un staging
+/// set** ([`crate::harness_probes::staging_sets`] ; `claude` : `.claude/projects`)
+/// du staging vers `<home_root>/<puits>/`, **récursivement** (transcripts de sessions
 /// *et* de sous-agents `<uuid>/subagents/*.jsonl`), sous le même dirname encodé.
+/// Générique depuis ADR-0063 : aucun chemin de harnais n'est codé ici.
 ///
 /// Idempotent : copie ssi le fichier hôte est **absent** OU **strictement plus
 /// petit** (transcripts append-only ⇒ `staging > hôte ⇔ contenu nouveau`). Ne
@@ -447,20 +525,24 @@ fn enforce_staging_floor(
 /// l'appelant (la transition terminale du Run ne doit pas dépendre de ce merge).
 /// `projects/` staging absent (run sans session) = no-op propre.
 pub(crate) fn merge_back(home_root: &Path, sandbox_root: &Path, run_id: &str) -> Result<()> {
-    let src = staged_claude_home(sandbox_root, run_id).join("projects");
-    let dest = home_root.join(".claude").join("projects");
-    if !src.is_dir() {
-        return Ok(()); // rien écrit
-    }
-    let Ok(entries) = std::fs::read_dir(&src) else {
-        return Ok(());
-    };
-    // Un Run = plusieurs dirs encodés (un par worktree de node, manager,
-    // merge-resolver). Itérer TOUS les sous-dossiers, jamais supposer un seul.
-    for entry in entries.flatten() {
-        let proj = entry.path();
-        if proj.is_dir() {
-            copy_jsonl_tree(&proj, &dest.join(entry.file_name()));
+    for (_, set) in crate::harness_probes::staging_sets() {
+        for rel in set.transcripts {
+            let src = staged_path(sandbox_root, run_id, rel);
+            let dest = home_root.join(rel);
+            if !src.is_dir() {
+                continue; // rien écrit
+            }
+            let Ok(entries) = std::fs::read_dir(&src) else {
+                continue;
+            };
+            // Un Run = plusieurs dirs encodés (un par worktree de node, manager,
+            // merge-resolver). Itérer TOUS les sous-dossiers, jamais supposer un seul.
+            for entry in entries.flatten() {
+                let proj = entry.path();
+                if proj.is_dir() {
+                    copy_jsonl_tree(&proj, &dest.join(entry.file_name()));
+                }
+            }
         }
     }
     Ok(())
@@ -540,7 +622,7 @@ fn edit_json_object(
     Ok(())
 }
 
-/// Garantie **G4** du plancher : le `.claude.json` stagé porte
+/// Garantie **G4** du set de `claude` ([`AutonomyFixup::ClaudeJsonBaseline`]) : le `.claude.json` stagé porte
 /// `hasCompletedOnboarding` et, si `trusted_root` est fournie, la confiance de cette
 /// racine (héritée par les descendants → couvre les worktrees de nodes). Merge non
 /// destructif dans le fichier hôte copié en `full` (profil `oauthAccount`, autres
@@ -613,11 +695,13 @@ const MAX_COPY_DEPTH: u32 = 64;
 /// Claude qui mutent `node_modules`) ne doit pas faire échouer le Run.
 ///
 /// `copy_root` = racine (canonique) au-delà de laquelle une cible de symlink est
-/// jugée « échappante ». `depth` = profondeur courante ([`MAX_COPY_DEPTH`]).
+/// jugée « échappante ». `skip` = chemins hôte absolus **non copiés** (exclusions et
+/// puits de transcripts d'un staging set, ADR-0063 ; vide pour le profil). `depth` =
+/// profondeur courante ([`MAX_COPY_DEPTH`]).
 ///
 /// N.B. : ne PAS réutiliser `copy_dir_all` de `lib.rs` — il n'est pas
 /// symlink-aware (`std::fs::copy` déréférence).
-fn copy_tree_preserving(src: &Path, dst: &Path, copy_root: &Path, depth: u32) {
+fn copy_tree_preserving(src: &Path, dst: &Path, copy_root: &Path, skip: &[PathBuf], depth: u32) {
     if depth > MAX_COPY_DEPTH {
         warn!(
             "sandbox copy: max depth {MAX_COPY_DEPTH} exceeded at {}, skipping subtree",
@@ -641,6 +725,9 @@ fn copy_tree_preserving(src: &Path, dst: &Path, copy_root: &Path, depth: u32) {
     };
     for entry in entries.flatten() {
         let from = entry.path();
+        if skip.contains(&from) {
+            continue;
+        }
         let to = dst.join(entry.file_name());
         let Ok(md) = std::fs::symlink_metadata(&from) else {
             warn!(
@@ -653,7 +740,7 @@ fn copy_tree_preserving(src: &Path, dst: &Path, copy_root: &Path, depth: u32) {
         if ft.is_symlink() {
             stage_symlink(&from, &to, copy_root, depth);
         } else if ft.is_dir() {
-            copy_tree_preserving(&from, &to, copy_root, depth + 1);
+            copy_tree_preserving(&from, &to, copy_root, skip, depth + 1);
         } else if ft.is_file() {
             if let Err(e) = std::fs::copy(&from, &to) {
                 warn!(
@@ -708,7 +795,7 @@ fn stage_symlink(from: &Path, to: &Path, copy_root: &Path, depth: u32) {
             );
         }
     } else if canonical.is_dir() {
-        copy_tree_preserving(&canonical, to, &canonical, depth + 1);
+        copy_tree_preserving(&canonical, to, &canonical, &[], depth + 1);
     } else if canonical.is_file() {
         let _ = std::fs::remove_file(to);
         if let Err(e) = std::fs::copy(&canonical, to) {
@@ -856,7 +943,7 @@ mod tests {
         write(&claude.join("settings.json"), r#"{"hooks":{"Stop":[]}}"#);
         write(&claude.join("settings.local.json"), r#"{"local":true}"#);
         // Baseline de managed settings de l'org — hors allowlist, stagée par le
-        // plancher (G2) dans les DEUX modes. Miroir de la fixture couche 3
+        // set de `claude` (G2) dans les DEUX modes. Miroir de la fixture couche 3
         // (`sandbox_tracer::fabricate_host_claude`) : les deux doivent dériver
         // ensemble.
         write(&claude.join(REMOTE_SETTINGS_FILE), ORG_BASELINE);
@@ -1045,7 +1132,7 @@ mod tests {
         // G4 est INCONDITIONNELLE depuis #426 : sans elle, l'hôte n'ayant pas de
         // `~/.claude.json`, rien n'était stagé — et `sandbox_container` monte ce
         // chemin toujours, donc Docker créait un *répertoire* par-dessus
-        // `$HOME/.claude.json`. Le plancher ferme ce footgun.
+        // `$HOME/.claude.json`. Le fixup G4 ferme ce footgun.
         let staged_json = staged_claude_json(sandbox_dir.path(), "run1");
         assert_eq!(
             read_json(&staged_json),
@@ -1165,11 +1252,11 @@ mod tests {
         assert_eq!(mode_of(&staged), 0o600);
     }
 
-    /// *L'*assertion que `minimal` == le plancher, ni plus ni moins (#426) : le
-    /// contenu exact de `claude-home/` est le plancher, alors que l'hôte porte tout
+    /// *L'*assertion que `minimal` == le staging set, ni plus ni moins (#426) : le
+    /// contenu exact de `claude-home/` est le set de `claude`, alors que l'hôte porte tout
     /// l'appareil `full` (skills, plugins, settings riches…).
     #[test]
-    fn prepare_minimal_stages_only_the_floor() {
+    fn prepare_minimal_stages_only_the_staging_set() {
         let home_dir = tempfile::tempdir().unwrap();
         let sandbox_dir = tempfile::tempdir().unwrap();
         fabricate_home(home_dir.path()); // skills/settings existent → prouvent l'exclusion
@@ -1177,7 +1264,7 @@ mod tests {
         prepare(home_dir.path(), sandbox_dir.path(), &[], "run1", None).unwrap();
         let home = staged_claude_home(sandbox_dir.path(), "run1");
 
-        // Ensemble EXACT (trié ASCII) = les fichiers du plancher, rien d'autre.
+        // Ensemble EXACT (trié ASCII) = les fichiers du set, rien d'autre.
         let mut names: Vec<String> = std::fs::read_dir(&home)
             .unwrap()
             .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
@@ -1196,7 +1283,7 @@ mod tests {
         assert!(!home.join("skills").exists());
         assert_eq!(mode_of(&home.join(".credentials.json")), 0o600);
         // G3 : `settings.json` est la SYNTHÈSE à une clé, pas celui de l'hôte (qui
-        // porte des `hooks`) — c'est la fourche synthèse-vs-copie du plancher.
+        // porte des `hooks`) — c'est la fourche synthèse-vs-copie du set.
         assert_eq!(
             read_json(&home.join(SETTINGS_FILE)),
             serde_json::json!({ BYPASS_PERMISSIONS_KEY: true })
@@ -1320,7 +1407,7 @@ mod tests {
 
         let home = staged_claude_home(sandbox_dir.path(), "run1");
         assert!(!home.join(REMOTE_SETTINGS_FILE).exists());
-        // …et le plancher n'a PAS avorté en cours de route.
+        // …et le set n'a PAS avorté en cours de route.
         assert!(home.join(SETTINGS_FILE).is_file());
         assert!(home.join("projects").is_dir());
     }
@@ -1511,14 +1598,14 @@ mod tests {
     }
 
     /// La forme exécutable d'ADR-0031 §1, et le test qu'un relecteur lit pour
-    /// répondre « le plancher est-il tenu ? ». La slice « profils » l'étendra
+    /// répondre « le set est-il tenu ? ». La slice « profils » l'étendra
     /// (même corps, plus « … même avec l'entrée décochée »).
     #[test]
-    fn prepare_floor_holds_in_both_modes() {
+    fn prepare_staging_set_holds_in_both_modes() {
         // #432: "both modes" is now "the two virtual defaults' resolved lists", plus a
         // THIRD case that only profiles make reachable — `full` with the class-(b) entry
         // `.claude/settings.json` UNCHECKED. That case is the whole reason ADR-0031 §1
-        // states the floor as guarantees rather than files: G3 must still hold, by
+        // states the set as guarantees rather than files: G3 must still hold, by
         // synthesis, on a profile that explicitly refused the host file.
         let full_no_settings: Vec<String> = full_entries()
             .into_iter()
@@ -1590,7 +1677,7 @@ mod tests {
     /// supprime jamais ») et répond à la question du double write sur
     /// `settings.json` en `full` : le second merge n'écrase ni ne duplique rien.
     #[test]
-    fn prepare_twice_keeps_the_floor_and_is_additive() {
+    fn prepare_twice_keeps_the_staging_set_and_is_additive() {
         let home_dir = tempfile::tempdir().unwrap();
         let sandbox_dir = tempfile::tempdir().unwrap();
         fabricate_home(home_dir.path());
@@ -1840,9 +1927,9 @@ mod tests {
     }
 
     /// Une liste VIDE est le no-op exact de l'ancien bras `Mode::Minimal => {}` : rien en
-    /// propre, tout le plancher.
+    /// propre, tout le set.
     #[test]
-    fn an_empty_entry_list_stages_the_floor_and_nothing_else() {
+    fn an_empty_entry_list_stages_the_staging_set_and_nothing_else() {
         let home_dir = tempfile::tempdir().unwrap();
         let sandbox_dir = tempfile::tempdir().unwrap();
         fabricate_home(home_dir.path());

--- a/crates/pdo-daemon/tests/sandbox_profiles.rs
+++ b/crates/pdo-daemon/tests/sandbox_profiles.rs
@@ -845,10 +845,10 @@ async fn a_bad_entry_is_rejected_at_profile_write() {
         "../outside",                   // escapes $HOME
         ".config/../../etc/passwd",     // escapes after a normalisation
         "..\\..\\etc",                  // a backslash is a legal Linux filename char
-        ".claude/projects",             // the runtime transcripts sink (floor-owned)
+        ".claude/projects",             // the runtime transcripts sink (set-owned)
         ".claude/projects/-enc",        // …and anything under it
-        ".claude/.credentials.json",    // floor-owned whole
-        ".claude/remote-settings.json", // floor-owned whole
+        ".claude/.credentials.json",    // set-owned whole
+        ".claude/remote-settings.json", // set-owned whole
         ".claude",                      // the staged home is already mounted whole
         ".pdo",                         // holds the staging root itself
         ".claude/*.md",                 // a glob: authored by the default, never by hand
@@ -1237,13 +1237,13 @@ async fn unedited_defaults_have_no_row_and_editing_stores_a_diff() {
         );
         assert!(view["updated_at"].is_null(), "{name}: {view}");
     }
-    // `minimal` IS the floor. Without the read-only floor block the screen looks broken and
+    // `minimal` IS the staging set alone. Without the read-only guarantees block (wire key `floor`) the screen looks broken and
     // the user wrongly concludes the container starts with no credentials.
     let minimal: serde_json::Value = get_profile(&daemon, "minimal").await.json().await.unwrap();
     assert_eq!(minimal["resolved"], serde_json::json!([]));
     assert!(
         minimal["floor"].as_array().unwrap().len() >= 5,
-        "the floor block must be present and read-only: {minimal}"
+        "the guarantees block must be present and read-only: {minimal}"
     );
 
     let view: serde_json::Value = put_profile(&daemon, "full", &[".claude/plugins"], &[])
@@ -1307,10 +1307,10 @@ async fn unedited_defaults_have_no_row_and_editing_stores_a_diff() {
     assert_eq!(view["resolved"], serde_json::json!([]));
 }
 
-/// The floor re-synthesises a one-key `settings.json` carrying the permissions bypass. This
-/// is why ADR-0031 §1 states the floor as *guarantees* rather than as *files*.
+/// The staging set's fixup re-synthesises a one-key `settings.json` carrying the permissions
+/// bypass. This is why ADR-0031 §1 states the set as *guarantees* rather than as *files*.
 #[tokio::test]
-async fn unchecking_settings_json_still_starts_thanks_to_the_floor() {
+async fn unchecking_settings_json_still_starts_thanks_to_the_staging_set() {
     ensure_pdo_on_path();
     let (_fake, docker, _log) = write_fake_docker();
     let daemon = TestDaemon::spawn_with_docker_override(seed(), docker)
@@ -1334,7 +1334,7 @@ async fn unchecking_settings_json_still_starts_thanks_to_the_floor() {
     let staged = staged_home(&daemon, &run_id).join("settings.json");
     assert!(
         wait_until(|| staged.is_file()).await,
-        "the floor must synthesise settings.json even when unchecked"
+        "the staging set must synthesise settings.json even when unchecked"
     );
     let settings: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(&staged).unwrap()).unwrap();

--- a/crates/pdo-daemon/tests/sandbox_tracer.rs
+++ b/crates/pdo-daemon/tests/sandbox_tracer.rs
@@ -274,7 +274,7 @@ async fn minimal_run_prepares_wraps_and_completes() {
     assert_eq!(
         settings,
         serde_json::json!({ BYPASS_PERMISSIONS_KEY: true }),
-        "minimal must synthesise settings.json to the floor's single key"
+        "minimal must synthesise settings.json to the staging set's single key"
     );
 
     write_node_output(&daemon, &run_id, "hello from the sandbox\n");
@@ -496,13 +496,13 @@ async fn kill_node_issues_exactly_one_in_container_kill() {
 // what PDO **stages** and the **argv/mounts** it hands `docker create`.
 
 /// Org managed-settings baseline cached by Claude Code in `~/.claude/` — the
-/// guarantee G2 of the staging floor (#426).
+/// guarantee G2 of the staging set (#426).
 const ORG_BASELINE_FILE: &str = "remote-settings.json";
 /// Stand-in content for [`ORG_BASELINE_FILE`]. The real host file carries an org
 /// OTEL bearer: assertions here compare against this fixture, never the real one.
 const ORG_BASELINE: &str = r#"{"org":"baseline"}"#;
 /// The top-level key that disarms the `--dangerously-skip-permissions` prompt —
-/// guarantee G3 of the staging floor (#426).
+/// guarantee G3 of the staging set (#426).
 const BYPASS_PERMISSIONS_KEY: &str = "skipDangerousModePermissionPrompt";
 
 /// A realistic host `~/.claude` (+ sibling `.claude.json`) under `home`. Deliberate
@@ -538,7 +538,7 @@ fn fabricate_host_claude(home: &Path) {
     write(claude.join("output-styles/s.md"), "style\n");
     write(claude.join("settings.json"), r#"{"hooks":{"Stop":[]}}"#);
     write(claude.join("settings.local.json"), r#"{"local":true}"#);
-    // OUTSIDE the `full` allowlist: the staging floor is its single writer, in BOTH
+    // OUTSIDE the `full` allowlist: the staging set is its single writer, in BOTH
     // modes. Stand-in content — the real host file carries an org OTEL bearer.
     write(claude.join(ORG_BASELINE_FILE), ORG_BASELINE);
     write_mode(
@@ -557,7 +557,7 @@ fn fabricate_host_claude(home: &Path) {
         claude.join("projects/-enc-host/old.jsonl"),
         "{\"host\":1}\n",
     );
-    // PII-bearing: `full` stages it, then the floor merges onboarding + trust into it.
+    // PII-bearing: `full` stages it, then the set's fixup merges onboarding + trust into it.
     write(
         home.join(".claude.json"),
         r#"{"host":"profile","oauthAccount":{"x":1}}"#,
@@ -622,7 +622,7 @@ async fn full_run_stages_allowlist_and_completes() {
         "run must project sandbox=full: {run}"
     );
 
-    // Running ⇒ eager prep (the full walk + the floor) is done.
+    // Running ⇒ eager prep (the full walk + the staging set) is done.
     let run = wait_node_status(&daemon, &run_id, "running").await;
     assert_eq!(run["nodes"][NODE_ID]["status"], "running", "run: {run}");
 
@@ -652,7 +652,7 @@ async fn full_run_stages_allowlist_and_completes() {
         .unwrap()
         .contains("hooks"));
     // Floor guarantee G2: the org baseline is staged VERBATIM though it lives OUTSIDE
-    // the `full` allowlist — the floor is its single writer.
+    // the `full` allowlist — the staging set is its single writer.
     assert_eq!(
         std::fs::read_to_string(home.join(ORG_BASELINE_FILE)).unwrap(),
         ORG_BASELINE,
@@ -690,7 +690,7 @@ async fn full_run_stages_allowlist_and_completes() {
     assert_eq!(
         json["projects"][&repo_key]["hasTrustDialogAccepted"],
         serde_json::json!(true),
-        "the floor seeds trust for the Run's repo_root: {json}"
+        "the staging set seeds trust for the Run's repo_root: {json}"
     );
     assert!(
         !home.join(".claude.json").exists(),
@@ -707,10 +707,10 @@ async fn full_run_stages_allowlist_and_completes() {
 }
 
 /// The only layer-3 test driving `minimal` with a real host `~/.claude` present, which is
-/// where the floor's copy-vs-synthesis fork lives. Without a fabricated host, G2 takes its
+/// where the set's copy-vs-synthesis fork lives. Without a fabricated host, G2 takes its
 /// no-op branch in every layer-3 test.
 #[tokio::test]
-async fn minimal_run_stages_the_floor_against_a_fabricated_host() {
+async fn minimal_run_stages_the_staging_set_against_a_fabricated_host() {
     ensure_pdo_on_path();
     let (_fake_dir, docker, _log) = write_fake_docker();
     let daemon =
@@ -732,7 +732,7 @@ async fn minimal_run_stages_the_floor_against_a_fabricated_host() {
     assert_eq!(
         std::fs::read_to_string(home.join(ORG_BASELINE_FILE)).unwrap(),
         ORG_BASELINE,
-        "the floor stages the org baseline in `minimal` too"
+        "the staging set stages the org baseline in `minimal` too"
     );
 
     // G3, SYNTHESIS branch: the host `settings.json` carries `hooks`; the staged one
@@ -755,7 +755,7 @@ async fn minimal_run_stages_the_floor_against_a_fabricated_host() {
     assert_eq!(
         std::fs::read_to_string(&host_settings).unwrap(),
         r#"{"hooks":{"Stop":[]}}"#,
-        "the floor must never write to the host `~/.claude`"
+        "the staging set must never write to the host `~/.claude`"
     );
 
     write_node_output(&daemon, &run_id, "minimal output\n");

--- a/docs/test-scenarios/HP-02-run-to-completion.md
+++ b/docs/test-scenarios/HP-02-run-to-completion.md
@@ -153,7 +153,7 @@ Features validated while crossing the run screens (grafted from retired per-issu
   announced is a **blocking finding** — that inversion is the #445 regression.
 - The sandboxed node's terminal preview shows a live `claude` session **with no interactive dialog**:
   no managed-settings approval, no bypass-permissions warning. That silence is the entire point of
-  the staging floor (#426) and it is only observable here.
+  the staging set's autonomy fixups (#426, ADR-0063) and it is only observable here.
 - **Both** Runs reach **Completed**, End `result` **received**, and the output artifact opens from
   the host UI in both cases (for the sandboxed one, that is the merge-back).
 - The `off` twin shows **no** preparation phase.

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -137,7 +137,7 @@ export interface SandboxProfileEntry {
   from_default: boolean;
   enabled: boolean;
   /**
-   * Class (b): unchecking does NOT make the file absent — the staging floor
+   * Class (b): unchecking does NOT make the file absent — the staging set's fixup
    * re-synthesises the keys it needs. Exactly two entries. The UI must say so, or
    * unchecking reads as more destructive than it is.
    */
@@ -151,12 +151,12 @@ export interface SandboxProfileEntry {
 }
 
 /**
- * One class-(c) floor guarantee (#432): satisfied by the WHOLE file, so it is neither
- * checkable nor addable. Rendered read-only — without this block a `minimal` profile's
- * screen looks broken and the user wrongly concludes the container starts with no
- * credentials.
+ * One class-(c) staging-set guarantee (#432, ADR-0063): satisfied by the WHOLE file, so it
+ * is neither checkable nor addable. Rendered read-only — without this block a `minimal`
+ * profile's screen looks broken and the user wrongly concludes the container starts with no
+ * credentials. Served under the historical wire key `floor`.
  */
-export interface SandboxFloorGuarantee {
+export interface SandboxStagingGuarantee {
   id: string;
   label: string;
   path: string | null;
@@ -177,7 +177,7 @@ export interface SandboxProfile {
   /** Signalled no-ops, never errors (ADR-0031 §2). */
   redundant_extras: string[];
   inactive_disabled: string[];
-  floor: SandboxFloorGuarantee[];
+  floor: SandboxStagingGuarantee[];
   sensitive_prefixes: string[];
   /**
    * Environment variables posed at `docker create` for every Run on this profile (#468,


### PR DESCRIPTION
## Ticket

#706 — story #702, spec #704, ADR-0063. Pur prefactor, zéro changement observable.

## Contenu

- `StagingFloor` renommé `StagingSet` : entrées `$HOME`-relatives, exclusions, env, entrées *transcripts*, plus `AutonomyFixups` ; `None` reste explicite (`copilot`, `opencode`).
- `claude` ré-exprimé dans cette forme, cinq garanties ADR-0031 intactes ; attendus des tests existants inchangés.
- Merge-back générique sur les entrées *transcripts* de tous les sets (idempotence et dirname encodé conservés).
- Grammaire des profils : refuse toujours les puits de transcripts de tous les sets.
- Tableau de support : ligne « Sandbox staging set ».
- Version 1.58.2 + CHANGELOG.

## Gate locale

- `cargo nextest run -p pdo-daemon` : 2790 passed, 0 failed.
- FP #706 (`/agentic-tests`) : **Pass**. Runs sandboxés `claude` full et minimal identiques avant/après (set exact en `minimal`, transcripts remontés, coût affiché). Étape 3 (`copilot`) substituée par `opencode` : `copilot` absent de la machine et de l'image `pdo-sandbox`. À rejouer sur une machine équipée avant clôture de la story.
- Non bloquant, pré-existant : le profil `full` rejoue les hooks hôte dans l'image (`python: not found`).

Closes #706

🤖 Generated with [Claude Code](https://claude.com/claude-code)