### PR TITLE
feat(sandbox): set de staging pi rempli au spawn du nœud, mounts vides, merge-back, which du binaire (#708) — 1.62.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ ascendante** : la casse se signale ici et par un bump majeur, jamais en gardant 
 morts. Seule contrainte non négociable — les **données historiques restent lisibles** : un Run
 archivé s'ouvre et se chiffre quelle que soit la version qui a écrit son payload.
 
+## 1.62.0
+
+**Set de staging `pi` rempli au spawn du nœud** (#708 ; story #702, spec #704, ADR-0063). Le conteneur
+sandbox naît avec les homes des harnais first-party montés **vides** (`~/.pi/agent`) ; le set d'un harnais
+(auth, settings, catalogue, extensions, skills — jamais `sessions/`) est copié **une fois par (Run,
+harnais)**, au spawn du premier nœud qui le résout, derrière un marqueur `<staging>/sets/<harnais>`. Un Run
+claude-only n'embarque donc jamais l'auth `pi`. L'env du set (`PI_SKIP_VERSION_CHECK`, `PI_TELEMETRY`) voyage
+dans le `docker exec` ; les sessions `pi` sont rapatriées sur l'hôte au merge-back sous le même dossier
+encodé, et le coût/contexte lit le sink stagé tant que le Run vit. Au spawn sandboxé, PDO fait un `which`
+du binaire dans le conteneur : absent ⇒ un WARN par Run et le nœud passe **Interrupted** avec la raison
+`harness_binary_missing` (PDO ne fournit pas l'image, ajoutez `pi` au profil). Numérotation : `main` porte
+déjà 1.61.x (mise à jour in-app), la ligne `pi` saute donc à 1.62.0.
+
 ## 1.60.0
 
 **Harnais `pi` instrumenté** (#707 ; story #702, spec #704). Le descripteur embarqué `pi` remplit les

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "1.60.0"
+version = "1.62.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "1.60.0"
+version = "1.62.0"
 license = "MIT"
 description = "Prompt-Driven Orchestrator — a local daemon that runs and supervises agentic coding pipelines"
 repository = "https://github.com/Loulen/prompt-driven-orchestrator"

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ PDO can launch, attach, resume, and complete nodes with every built-in harness.
 | **Transcript** | Find the session transcript | ✅ the JSONL transcript, keyed by working directory | ❌ | ✅ the event journal, keyed by the session identity PDO imposed | ✅ the session JSONL in the working directory's folder, keyed by the session identity PDO imposed |
 | **End of turn** | Complete a node when its turn ends | ✅ an injected `Stop` hook, plus the transcript tail as the sweep's fallback | ❌ | ✅ the journal's explicit `assistant.turn_end` event | ✅ an injected `agent_settled` extension, plus the session tail as the sweep's fallback |
 | **Usage-limit menu** | Detect the harness usage-limit menu | ✅ the interactive "wait for limit to reset" menu, matched in a pane capture | ❌ | ❌ | ❌ |
-| **Sandbox staging set** | Stage the harness home in a sandbox and disarm its blocking dialogs | ✅ the `.claude` home: credentials and org managed settings copied, trust and permissions bypass fixed up, transcripts harvested back | ❌ | ❌ | ❌ |
+| **Sandbox staging set** | Stage the harness home in a sandbox and disarm its blocking dialogs | ✅ the `.claude` home: credentials and org managed settings copied, trust and permissions bypass fixed up, transcripts harvested back | ❌ | ❌ | ✅ the `.pi/agent` home: auth, settings, model catalogue, extensions, skills, prompts, themes and bin copied, sessions harvested back |
 | **Context usage** | Show peak context-window usage | ✅ derived: per-turn token usage from the transcript, deduplicated and maxed | ❌ | ✅ derived: the journal's cumulative usage counters, converted to a per-turn contribution and maxed | ✅ derived: per-message `usage.totalTokens` from the session, deduplicated and maxed, read against the catalogue's context window |
 
 Each header shows the last validated harness version; PDO does not enforce it. The sandbox image is not provided by PDO: it is the profile's image, and the harness binary must already be in it (ADR-0063).
@@ -121,6 +121,7 @@ Custom descriptors in `~/.pdo/harnesses/descriptors.yaml` can launch, attach, re
 | An approved working directory | Trust the target repository root once; trust cascades to subdirectories |
 | An installed version | Compare your installed harness with the last validated version in the support table |
 | A model catalogue for `pi` | Keep pi's model catalogue reachable from its home (`~/.pi/agent`): pi prices each message from it, and a message it cannot price makes the node's cost read "—" rather than `$0` |
+| `pi` in the sandbox image | PDO does not provide the sandbox image. For a sandboxed `pi` node your image must contain the `pi` binary: PDO checks it with a `which` at spawn, and a node whose binary is missing goes `Interrupted` with that reason (ADR-0063) |
 
 Outside sandboxed runs, PDO does not stage any harness's home.
 

--- a/crates/pdo-daemon/src/harness_probes.rs
+++ b/crates/pdo-daemon/src/harness_probes.rs
@@ -296,9 +296,11 @@ pub(crate) enum AutonomyFixup {
 /// [`staging_set_absence_note`]). `None` is a declared value (ADR-0051), published
 /// in the support table.
 ///
-/// The set is **data**; [`crate::sandbox_staging`] is the one interpreter. Today it
-/// is applied at `prepare` (the Run's staging), #708 moves the copy to the spawn of
-/// the first node that resolves the harness (ADR-0063 §3) — same data, later moment.
+/// The set is **data**; [`crate::sandbox_staging`] is the one interpreter. It is
+/// copied at the spawn of the **first** session of the Run that resolves the harness
+/// (`sandbox_staging::fill_staging_set`, #708, ADR-0063 §3) — never at `RunStarted`,
+/// never for a harness the Run does not launch. Its `home_root` is mounted **empty**
+/// at container creation so that later copy lands under a mount.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct StagingSet {
     /// The support-table cell: what this harness stages, in the reader's words.
@@ -367,6 +369,34 @@ pub(crate) const CLAUDE_STAGING_SET: StagingSet = StagingSet {
         AutonomyFixup::ClaudeBypassPermissions,
         AutonomyFixup::ClaudeJsonBaseline,
     ],
+};
+
+/// `pi`'s staging set (#708, ADR-0063): the whole `.pi/agent/` home **except**
+/// `sessions/` — `auth.json`, `settings.json`, the model catalogue (`models.json`),
+/// extensions, skills, prompts, themes and `bin/` — so a session in the container
+/// authenticates, prices its messages and finds its extensions exactly as on the
+/// host. Two env vars ride the `docker exec` with it: `PI_SKIP_VERSION_CHECK=1` (PDO
+/// decides when the target moves, not a startup banner) and `PI_TELEMETRY=0`. **No**
+/// `PI_OFFLINE` — the catalogue is copied, the network is not cut.
+///
+/// `sessions/` is the transcript sink: created empty on the way in and harvested at
+/// merge-back under the same cwd-encoded dirname (the worktree is mounted at its
+/// host path, ADR-0030, so pi names the folder identically inside and out). **No**
+/// autonomy fixup: `-a` on pi's argv already disarms every approval dialog.
+pub(crate) const PI_STAGING_SET: StagingSet = StagingSet {
+    label: "the `.pi/agent` home — auth, settings, model catalogue, extensions, skills, \
+            prompts, themes and bin copied, sessions harvested back",
+    home_root: ".pi/agent",
+    entries: &[StagingEntry {
+        rel: ".pi/agent",
+        absent_note: Some(
+            "pi is not set up on this host; the container starts with an empty pi home",
+        ),
+    }],
+    excludes: &[],
+    env: &[("PI_SKIP_VERSION_CHECK", "1"), ("PI_TELEMETRY", "0")],
+    transcripts: &[".pi/agent/sessions"],
+    fixups: &[],
 };
 
 /// Every staging set a first-party harness declares, in registry order. The
@@ -705,8 +735,8 @@ impl HarnessProbes for CopilotProbes {
 /// The single `copilot` instance handed out by [`probes_for`]. Zero-sized.
 static COPILOT_PROBES: CopilotProbes = CopilotProbes;
 
-/// The `pi` capabilities (#705/#707, story #702; ADR-0051/0052/0043) — **five**
-/// present, **two** declared absent with their motive:
+/// The `pi` capabilities (#705/#707/#708, story #702; ADR-0051/0052/0043/0063) —
+/// **six** present, **one** declared absent with its motive:
 ///
 /// - **cost**: a **reported** cost of constant **1.0** — pi writes `usage.cost.total`
 ///   in dollars on every assistant message, from its embedded catalogue; PDO sums
@@ -726,7 +756,8 @@ static COPILOT_PROBES: CopilotProbes = CopilotProbes;
 /// - the **usage-limit menu anchor** is absent, explicitly: the probe is
 ///   informational, its anchor is claude's wording, and it triggers no recovery
 ///   (ADR-0012, ADR-0051 §"Limites");
-/// - the **staging set** is absent in this ticket: #708 declares it (ADR-0063).
+/// - the **staging set**: `.pi/agent/` minus `sessions/`, plus two env vars, no
+///   autonomy fixup ([`PI_STAGING_SET`], #708, ADR-0063).
 ///
 /// `subagent_transcripts` stays at the trait's default (empty): pi's session store is
 /// flat per cwd (one file per session id, no nesting under a session to enumerate).
@@ -747,9 +778,10 @@ impl HarnessProbes for PiProbes {
     fn usage_limit_anchor(&self) -> Option<UsageLimitAnchor> {
         None
     }
-    /// Declared absent until #708 (ADR-0063).
+    /// [`PI_STAGING_SET`]: `.pi/agent/` minus `sessions/`, two env vars, no fixup
+    /// (#708, ADR-0063).
     fn staging_set(&self) -> Option<StagingSet> {
-        None
+        Some(PI_STAGING_SET)
     }
     fn context_usage_source(&self) -> Option<ContextUsageSource> {
         Some(ContextUsageSource::PiSessionPeak)
@@ -1191,9 +1223,10 @@ mod tests {
     }
 
     #[test]
-    fn pi_has_its_five_capabilities_and_declares_two_absent() {
-        // #707 / ADR-0051: `pi` is instrumented — five capabilities dispatch to ITS
-        // implementation (`crate::pi_session`), two are explicit `None`s.
+    fn pi_has_its_six_capabilities_and_declares_one_absent() {
+        // #707/#708 / ADR-0051: `pi` is instrumented — five capabilities dispatch to
+        // ITS implementation (`crate::pi_session`), the staging set is its own data,
+        // one capability is an explicit `None`.
         let p = probes_for(PI).expect("pi has probes (first-party)");
         assert_eq!(p.cost_source(), Some(CostSource::ReportedByConstant));
         assert_eq!(
@@ -1212,9 +1245,10 @@ mod tests {
             p.usage_limit_anchor().is_none(),
             "usage-limit anchor declared absent"
         );
-        assert!(
-            p.staging_set().is_none(),
-            "staging declared absent (#708, ADR-0063)"
+        assert_eq!(
+            p.staging_set(),
+            Some(PI_STAGING_SET),
+            "pi's own staging set (#708, ADR-0063)"
         );
         assert_eq!(
             capabilities(PI),
@@ -1223,17 +1257,17 @@ mod tests {
                 transcript: true,
                 turn_end: true,
                 usage_limit: false,
-                staging: false,
+                staging: true,
                 context_usage: true,
             }
         );
         // Consequences a reader sees: a pi Run is costable and measurable, the
-        // turn-end setting is honoured (no absence note), the sandbox still says its
-        // absence once.
+        // turn-end setting is honoured (no absence note), and a sandboxed Run stages
+        // its home (no absence note either).
         assert!(can_cost(PI));
         assert!(can_measure_context(PI));
         assert_eq!(turn_end_absence_note(PI), None);
-        assert!(staging_set_absence_note(PI).is_some());
+        assert_eq!(staging_set_absence_note(PI), None);
         // The exit code is no verdict: pi stays resident after a hard error.
         assert!(!exit_code_is_verdict(PI));
         // Behaviour is pi's own, never claude's parsers on pi's store.
@@ -1536,14 +1570,43 @@ mod tests {
         assert!(set.excludes.is_empty());
     }
 
-    /// Only `claude` declares a set today; `copilot`, `pi` (until #708) and
-    /// `opencode` are explicit `None`s, so the generic consumers see exactly one set.
+    /// `claude` and `pi` declare a set; `copilot` and `opencode` are explicit
+    /// `None`s, so the generic consumers (mounts, merge-back, profile refusals) see
+    /// exactly two sets, in registry order.
     #[test]
-    fn staging_sets_lists_claude_only() {
+    fn staging_sets_lists_claude_then_pi() {
         let sets = staging_sets();
-        assert_eq!(sets.len(), 1, "{sets:?}");
+        assert_eq!(sets.len(), 2, "{sets:?}");
         assert_eq!(sets[0].0, CLAUDE);
         assert_eq!(sets[0].1, CLAUDE_STAGING_SET);
+        assert_eq!(sets[1].0, PI);
+        assert_eq!(sets[1].1, PI_STAGING_SET);
+    }
+
+    /// ADR-0063 / #708: pi's set is the whole `.pi/agent` minus `sessions/`, two env
+    /// vars, no fixup, and never `PI_OFFLINE`. Pinned so a later edit is a visible
+    /// change of contract.
+    #[test]
+    fn pi_staging_set_is_the_agent_home_minus_sessions_with_two_env_vars_and_no_fixup() {
+        let set = PI_STAGING_SET;
+        assert_eq!(set.home_root, ".pi/agent");
+        let entries: Vec<&str> = set.entries.iter().map(|e| e.rel).collect();
+        assert_eq!(entries, [".pi/agent"]);
+        assert_eq!(set.transcripts, [".pi/agent/sessions"]);
+        assert!(
+            set.fixups.is_empty(),
+            "`-a` on the argv disarms pi's dialogs"
+        );
+        assert_eq!(
+            set.env,
+            [("PI_SKIP_VERSION_CHECK", "1"), ("PI_TELEMETRY", "0")]
+        );
+        assert!(
+            set.env.iter().all(|(k, _)| *k != "PI_OFFLINE"),
+            "the catalogue is copied, the network is not cut"
+        );
+        assert!(set.label.contains("auth"));
+        assert!(set.label.contains("sessions harvested back"));
     }
 
     fn claude_turn(id: &str, input: u64, output: u64) -> String {

--- a/crates/pdo-daemon/src/harness_support.rs
+++ b/crates/pdo-daemon/src/harness_support.rs
@@ -242,14 +242,14 @@ mod tests {
         assert!(Capability::ALL
             .iter()
             .all(|c| c.mechanism(OPENCODE).is_none()));
-        // #707: pi is instrumented — cost, transcript, end of turn and context
-        // present, usage-limit and staging explicitly absent (the latter until #708).
+        // #707/#708: pi is instrumented — cost, transcript, end of turn, context and
+        // the staging set present, only the usage-limit menu explicitly absent.
         assert!(Capability::Cost.mechanism(PI).is_some());
         assert!(Capability::Transcript.mechanism(PI).is_some());
         assert!(Capability::TurnEnd.mechanism(PI).is_some());
         assert!(Capability::ContextUsage.mechanism(PI).is_some());
         assert!(Capability::UsageLimit.mechanism(PI).is_none());
-        assert!(Capability::Staging.mechanism(PI).is_none());
+        assert!(Capability::Staging.mechanism(PI).is_some());
         assert!(render().contains("`pi` 0.85.1"));
         assert!(render().contains("`agent_settled` extension"));
         assert!(Capability::ALL

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -8670,14 +8670,6 @@ async fn spawn_manager_session(
         prompt_augmenter::build_manager_prompt(run_id, &daemon_url, &static_prompt, name_hint);
 
     let session_name = tmux_session_manager::manager_session_name(run_id);
-    // The manager runs inside the Run's container too when sandboxed.
-    let sandbox_wrap = sandboxed.then(|| tmux_session_manager::SandboxWrap {
-        docker_bin: state.docker_cmd_override.as_deref().unwrap_or("docker"),
-        uid: sandbox_container::host_uid(),
-        gid: sandbox_container::host_gid(),
-        marker: &session_name,
-        workdir: worktree_dir,
-    });
     // The manager follows the harness OF THE RUN — `Run → instance → floor`, no node
     // tier and deliberately no model/effort — so "this Run runs on X" holds with no
     // exception. An unknown name falls back to `claude` with a warning rather than
@@ -8713,6 +8705,31 @@ async fn spawn_manager_session(
             );
             harness_registry::claude()
         });
+    // #708: the manager runs the Run's harness inside the container, so it fills that
+    // harness's staging set (once per Run — the first node may not have spawned yet)
+    // and carries its env on the exec. Best-effort: a fill error must not wedge the
+    // best-effort manager assist, so it degrades to no env (the first NODE spawn is
+    // the authoritative fail-fast on an unfillable set).
+    let manager_set_env: Vec<(String, String)> = match (sandboxed, run_state.as_ref()) {
+        (true, Some(rs)) => {
+            let trusted = effective_repo_root(state, rs);
+            sandbox_run::stage_harness_set(state, rs, &manager_harness_name, &trusted)
+                .unwrap_or_else(|e| {
+                    warn!("manager for run {run_id}: staging `{manager_harness_name}` set failed (best-effort): {e:#}");
+                    Vec::new()
+                })
+        }
+        _ => Vec::new(),
+    };
+    // The manager runs inside the Run's container too when sandboxed.
+    let sandbox_wrap = sandboxed.then(|| tmux_session_manager::SandboxWrap {
+        docker_bin: state.docker_cmd_override.as_deref().unwrap_or("docker"),
+        uid: sandbox_container::host_uid(),
+        gid: sandbox_container::host_gid(),
+        marker: &session_name,
+        workdir: worktree_dir,
+        set_env: &manager_set_env,
+    });
     if let Err(e) = tmux_session_manager::spawn(
         &session_name,
         &full_prompt,
@@ -11612,10 +11629,15 @@ async fn get_run(
             // are an instance concept) while transcripts come from `projects_root`,
             // which moves for a sandboxed Run.
             let prices = price_table::PriceTable::load(&home_root);
-            // Neither `copilot` nor `pi` declares a staging set, so their session
-            // stores are read from the host home (`.copilot/session-state/`,
-            // `.pi/agent/sessions/`).
-            let stores = sandbox_run::HarnessStores::from_home(&home_root);
+            // `copilot`'s journal is on the host; `pi`'s moves per Run (#708) — the
+            // staged sink while this sandboxed Run lives, the host store after
+            // merge-back — mirroring the Claude root's sandbox-aware seam above.
+            let stores = sandbox_run::HarnessStores::for_run(
+                !run_state.sandbox.is_off(),
+                &run_state.run_id,
+                &home_root,
+                &sandbox_root,
+            );
             augment_run_state_from_disk(
                 &mut run_state,
                 &events,
@@ -12316,10 +12338,15 @@ async fn run_stale_detection(state: &Arc<AppState>) {
             &home_root,
             &sandbox_root,
         );
-        // Neither `copilot` nor `pi` declares a staging set, so each resolves its
-        // transcript from its host-home store. Picked per node below by the frozen
-        // harness (`HarnessStores::root_for`).
-        let stores = sandbox_run::HarnessStores::from_home(&home_root);
+        // `copilot` resolves from the host journal; `pi` from the sandbox-aware store
+        // (#708). Picked per node below by the frozen harness
+        // (`HarnessStores::root_for`).
+        let stores = sandbox_run::HarnessStores::for_run(
+            !run_state.sandbox.is_off(),
+            run_id,
+            &home_root,
+            &sandbox_root,
+        );
 
         let running = stale_detector::running_nodes(&run_state);
         for (node_id, iter) in &running {
@@ -12758,14 +12785,6 @@ pub(crate) async fn reattach_node_session(
         return ReattachOutcome::WorkingDirMissing;
     }
 
-    // A resumed sandboxed session re-enters its container.
-    let sandbox_wrap = (!run_state.sandbox.is_off()).then(|| tmux_session_manager::SandboxWrap {
-        docker_bin: state.docker_cmd_override.as_deref().unwrap_or("docker"),
-        uid: sandbox_container::host_uid(),
-        gid: sandbox_container::host_gid(),
-        marker: session_name,
-        workdir: &working_dir,
-    });
     // A resume restores the model but loses the effort level, so re-pose the level
     // the node was LAUNCHED with, and resume by the pinned session id.
     let launch_effort = find_launch_effort(events, node_id, iter);
@@ -12834,6 +12853,28 @@ pub(crate) async fn reattach_node_session(
         };
     }
     drop(admission_guard);
+
+    // #708: the frozen harness's staging set is already on disk (filled at the first
+    // spawn, marker present) — `stage_harness_set` returns its env idempotently, which
+    // the re-entered container session carries. Best-effort: never block a recovery.
+    let set_env = if run_state.sandbox.is_off() {
+        Vec::new()
+    } else {
+        sandbox_run::stage_harness_set(state, run_state, &descriptor.name, repo_root)
+            .unwrap_or_else(|e| {
+                warn!("reattach run {run_id} node {node_id}: staging `{}` set failed (best-effort): {e:#}", descriptor.name);
+                Vec::new()
+            })
+    };
+    // A resumed sandboxed session re-enters its container.
+    let sandbox_wrap = (!run_state.sandbox.is_off()).then(|| tmux_session_manager::SandboxWrap {
+        docker_bin: state.docker_cmd_override.as_deref().unwrap_or("docker"),
+        uid: sandbox_container::host_uid(),
+        gid: sandbox_container::host_gid(),
+        marker: session_name,
+        workdir: &working_dir,
+        set_env: &set_env,
+    });
 
     if let Err(e) = tmux_session_manager::resume(
         session_name,
@@ -13381,12 +13422,16 @@ async fn spawn_merge_resolver(
     };
     let _ = append_event(state, &resolver_started).await;
 
+    // DEAD in production (ADR-0006); the resolver would follow the Run's harness, so
+    // an empty set env is acceptable here — it never runs a real pi session.
+    let resolver_set_env: Vec<(String, String)> = Vec::new();
     let sandbox_wrap = (!sandbox_mode.is_off()).then(|| tmux_session_manager::SandboxWrap {
         docker_bin: state.docker_cmd_override.as_deref().unwrap_or("docker"),
         uid: sandbox_container::host_uid(),
         gid: sandbox_container::host_gid(),
         marker: &session_name,
         workdir: worktree_dir,
+        set_env: &resolver_set_env,
     });
     // Follows the harness OF THE RUN, exactly like the manager: `Run → instance →
     // floor`, no node tier, no model/effort. An unknown name falls back to `claude`
@@ -14841,6 +14886,10 @@ async fn force_spawn_node(
         // silently misses the `Stop` hook on this seam alone.
         inject_hook: stored_autocomplete_turn_end(&state.db).await,
         harness_registry: Some(&harness_registry),
+        // #708: a sandboxed force-spawn fills the resolved harness's staging set at
+        // this spawn, exactly like the scheduler. `harness_home_root` is already the
+        // host `$HOME` (or the embedded-floor fallback); pass it only when sandboxed.
+        sandbox_home_root: (!run_state.sandbox.is_off()).then_some(harness_home_root.as_path()),
     };
 
     // Hold the lock from the count until the reservation event is appended — exactly
@@ -15483,12 +15532,17 @@ async fn open_run_shell(
         }
     }
 
+    // A run shell runs bash, not a harness tail: no staging-set env to forward. A
+    // hand-typed `pi` inside it still reads the staged `.pi/agent` home (mounted),
+    // and can export the two vars itself; PDO does not pre-pose them for a shell.
+    const NO_SET_ENV: &[(String, String)] = &[];
     let sandbox_wrap = (!run_state.sandbox.is_off()).then(|| tmux_session_manager::SandboxWrap {
         docker_bin: state.docker_cmd_override.as_deref().unwrap_or("docker"),
         uid: sandbox_container::host_uid(),
         gid: sandbox_container::host_gid(),
         marker: &session,
         workdir: &worktree,
+        set_env: NO_SET_ENV,
     });
     match tmux_session_manager::spawn_shell(
         &session,

--- a/crates/pdo-daemon/src/node_primitives.rs
+++ b/crates/pdo-daemon/src/node_primitives.rs
@@ -57,6 +57,11 @@ pub(crate) struct StartNodeParams<'a> {
     /// honours the **disk tier**, so a force-spawn reaches a user-declared harness
     /// exactly like the scheduler does; `None` is the embedded floor only.
     pub harness_registry: Option<&'a harness_registry::HarnessRegistry>,
+    /// Host `$HOME` for a sandboxed Run (#708): the root under which the resolved
+    /// harness's staging set is filled at this spawn, mirroring `spawn_node`. `None`
+    /// on the host path and when the daemon cannot resolve `$HOME` — the set is then
+    /// not filled here (a scheduler spawn or the manager already did, idempotently).
+    pub sandbox_home_root: Option<&'a Path>,
 }
 
 /// Everything needed to launch the node's tmux session, once its reservation has
@@ -111,6 +116,9 @@ struct StartNodeSandbox {
     docker_bin: String,
     uid: u32,
     gid: u32,
+    /// The resolved harness's staging-set env (#708), forwarded on the `docker exec`.
+    /// Empty for `claude` and for a fill that could not run.
+    set_env: Vec<(String, String)>,
 }
 
 impl StartNodeSpawn {
@@ -149,6 +157,7 @@ impl StartNodeSpawn {
                 gid: sbx.gid,
                 marker: &self.session_name,
                 workdir: &self.working_dir,
+                set_env: &sbx.set_env,
             });
         tmux_session_manager::spawn(
             &self.session_name,
@@ -473,6 +482,39 @@ pub(crate) fn start_node(params: &StartNodeParams<'_>) -> StartNodeResult {
     }
     // Model + effort feed both the tail and the `NodeStarted` payload, which the
     // resume path reads back to re-pose `--effort`.
+    // #708 / ADR-0063 §3: fill the resolved harness's staging set into this Run's
+    // staging (once per Run, idempotent behind the marker) so a force-spawned node
+    // carries the same staged home + env as a scheduled one. `None` home ⇒ skip (a
+    // scheduler spawn or the manager fills it). A fill error degrades to no env
+    // rather than failing this manual path — the scheduler spawn is the fail-fast.
+    let sandbox_set_env: Vec<(String, String)> = match (
+        sandboxed,
+        params.sandbox_home_root,
+        harness_descriptor.as_ref(),
+    ) {
+        (true, Some(home), Some(d)) => {
+            let sandbox_root = home.join(".pdo").join("sandbox");
+            match crate::sandbox_staging::fill_staging_set(
+                home,
+                &sandbox_root,
+                params.run_id,
+                &d.name,
+                Some(params.repo_root),
+            ) {
+                Ok(fill) => fill.env(),
+                Err(e) => {
+                    tracing::warn!(
+                        "force-spawn of node {}: staging `{}` set failed (best-effort): {e:#}",
+                        params.node_id,
+                        d.name
+                    );
+                    Vec::new()
+                }
+            }
+        }
+        _ => Vec::new(),
+    };
+
     let resolved_model = resolved_harness.as_ref().and_then(|r| r.model.clone());
     let resolved_effort = resolved_harness.as_ref().and_then(|r| r.effort.clone());
     // Pin a session id only for a harness that can honour it (`claude`).
@@ -537,6 +579,7 @@ pub(crate) fn start_node(params: &StartNodeParams<'_>) -> StartNodeResult {
         docker_bin: params.docker_cmd_override.unwrap_or("docker").to_string(),
         uid: crate::sandbox_container::host_uid(),
         gid: crate::sandbox_container::host_gid(),
+        set_env: sandbox_set_env,
     });
     let spawn = StartNodeSpawn {
         session_name,
@@ -1103,6 +1146,7 @@ mod tests {
             project_harness: None,
             inject_hook: false,
             harness_registry: None,
+            sandbox_home_root: None,
         };
 
         let result = start_node(&params);
@@ -1147,6 +1191,7 @@ mod tests {
             project_harness: None,
             inject_hook: false,
             harness_registry: None,
+            sandbox_home_root: None,
         };
 
         let result = start_node(&params);
@@ -1191,6 +1236,7 @@ mod tests {
             project_harness: None,
             inject_hook: true,
             harness_registry: None,
+            sandbox_home_root: None,
         };
         let result = start_node(&params);
         assert_eq!(result.outcome, PrimitiveOutcome::Executed);
@@ -1243,6 +1289,7 @@ mod tests {
             project_harness: None,
             inject_hook: true,
             harness_registry: None,
+            sandbox_home_root: None,
         };
         let result = start_node(&params);
         assert_eq!(result.outcome, PrimitiveOutcome::Executed);
@@ -1306,6 +1353,7 @@ mod tests {
             project_harness: None,
             inject_hook: false,
             harness_registry: None,
+            sandbox_home_root: None,
         };
 
         let input_paths = resolve_inputs(&params, node);
@@ -1369,6 +1417,7 @@ mod tests {
             project_harness: None,
             inject_hook: false,
             harness_registry: None,
+            sandbox_home_root: None,
         };
 
         let input_paths = resolve_inputs(&params, node);
@@ -1429,6 +1478,7 @@ mod tests {
             project_harness: None,
             inject_hook: false,
             harness_registry: None,
+            sandbox_home_root: None,
         };
         let input_paths = resolve_inputs(&params, node);
         assert_eq!(
@@ -1533,6 +1583,7 @@ mod tests {
             project_harness: None,
             inject_hook: false,
             harness_registry: None,
+            sandbox_home_root: None,
         };
 
         let input_paths = resolve_inputs(&params, node);
@@ -1606,6 +1657,7 @@ mod tests {
             project_harness: None,
             inject_hook: false,
             harness_registry: None,
+            sandbox_home_root: None,
         };
 
         let input_paths = resolve_inputs(&params, node);
@@ -1709,6 +1761,7 @@ mod tests {
             project_harness: None,
             inject_hook: false,
             harness_registry: None,
+            sandbox_home_root: None,
         };
 
         let input_paths = resolve_inputs(&params, node);
@@ -1777,6 +1830,7 @@ mod tests {
             project_harness: None,
             inject_hook: false,
             harness_registry: None,
+            sandbox_home_root: None,
         };
 
         let input_paths = resolve_inputs(&params, node);
@@ -1845,6 +1899,7 @@ mod tests {
             project_harness: None,
             inject_hook: false,
             harness_registry: None,
+            sandbox_home_root: None,
         };
 
         let input_paths = resolve_inputs(&params, node);
@@ -2094,6 +2149,7 @@ mod tests {
             project_harness: None,
             inject_hook: false,
             harness_registry: None,
+            sandbox_home_root: None,
         };
 
         let result = start_node(&params);

--- a/crates/pdo-daemon/src/node_spawn.rs
+++ b/crates/pdo-daemon/src/node_spawn.rs
@@ -121,6 +121,33 @@ fn warn_missing_staging_set_once(run_id: &str, harness: &str) {
     }
 }
 
+/// #708 / ADR-0063 §5: say ONCE per `(run, harness)` that the resolved harness's
+/// binary is absent from the sandbox image. Every node of the Run that resolves
+/// that harness then goes `Interrupted` with the same reason (ADR-0049), but the
+/// log carries the sentence once — a retry loop must not turn one missing binary
+/// into a wall of warnings. PDO does not provide the image (the profile does), so
+/// the sentence tells the user what to change: their image.
+fn warn_binary_missing_in_image_once(run_id: &str, harness: &str, binary: &str) {
+    use std::collections::HashSet;
+    use std::sync::Mutex;
+    static SAID: Mutex<Option<HashSet<(String, String)>>> = Mutex::new(None);
+
+    let mut guard = SAID.lock().unwrap_or_else(|e| e.into_inner());
+    let said = guard.get_or_insert_with(HashSet::new);
+    if said.insert((run_id.to_string(), harness.to_string())) {
+        warn!(
+            "run {run_id}: sandbox: harness `{harness}` binary `{binary}` is absent from the \
+             sandbox image — PDO does not provide the image; add `{binary}` to the profile's \
+             image (ADR-0063). Every node of this Run resolving `{harness}` is Interrupted"
+        );
+    }
+}
+
+/// The `reason_code` of a node interrupted because its harness binary is absent from
+/// the sandbox image (#708, ADR-0063 §5 / ADR-0049). Distinct from `spawn_aborted`:
+/// nothing broke in PDO — the image lacks the binary, and only the user can fix that.
+pub(crate) const HARNESS_BINARY_MISSING_CODE: &str = "harness_binary_missing";
+
 /// #613 / ADR-0051 (AC #7): say ONCE per `(run, harness)` that turn-end
 /// auto-completion is enabled but the node's harness has no end-of-turn substrate,
 /// so the setting cannot be honoured for it. The message is the pure
@@ -630,9 +657,8 @@ pub(crate) async fn spawn_node(
                 Some(d) => {
                     // #553 / ADR-0063: a sandboxed Run whose node runs on a harness
                     // with no staging set holds only by the profile's image and
-                    // its `$HOME` exceptions — say it once, visibly (today only
-                    // `claude`'s set is applied, per Run, whatever the harness; #708
-                    // fills each set at the spawn that resolves its harness).
+                    // its `$HOME` exceptions — say it once, visibly. A harness WITH
+                    // a set gets it filled below, at this very spawn (#708).
                     if run_sandboxed {
                         warn_missing_staging_set_once(run_id, &r.harness);
                     }
@@ -646,8 +672,99 @@ pub(crate) async fn spawn_node(
             }
         }
     };
+    // #708 / ADR-0063 §3: the env of the resolved harness's staging set, forwarded on
+    // the `docker exec` of a sandboxed node. Empty on the host path and for a harness
+    // whose set declares none (`claude`).
+    let mut set_env: Vec<(String, String)> = Vec::new();
     if let Some(d) = &harness_descriptor {
-        if deps.tmux_cmd_override.is_none() && !tmux_session_manager::binary_available(&d.binary) {
+        if run_sandboxed {
+            // ADR-0063 §5: the binary must exist IN THE CONTAINER — the host's PATH says
+            // nothing about the profile's image. A `which` at spawn, never a version
+            // check; absent ⇒ said once per Run, node `Interrupted` with that reason
+            // (ADR-0049), nothing created. A probe that could not answer (docker itself
+            // failed) is not an absence: warn and let the spawn fail on its own terms.
+            let docker_bin = deps.docker_cmd_override.unwrap_or("docker").to_string();
+            let (rid, binary) = (run_id.to_string(), d.binary.clone());
+            let uid = crate::sandbox_container::host_uid();
+            let gid = crate::sandbox_container::host_gid();
+            let probe = tokio::task::spawn_blocking(move || {
+                crate::sandbox_container::binary_present_in_container(
+                    &docker_bin,
+                    &rid,
+                    uid,
+                    gid,
+                    &binary,
+                )
+            })
+            .await
+            .unwrap_or_else(|je| Err(anyhow::anyhow!("binary probe panicked: {je}")));
+            match probe {
+                Ok(true) => {}
+                Ok(false) => {
+                    warn_binary_missing_in_image_once(run_id, &d.name, &d.binary);
+                    let reason = format!(
+                        "harness `{}` binary `{}` is absent from the sandbox image — PDO does \
+                         not provide the image; add `{}` to the profile's image (ADR-0063)",
+                        d.name, d.binary, d.binary
+                    );
+                    interrupt_spawn_before_start_with_code(
+                        deps,
+                        spawn_ctx.repo_root,
+                        run_id,
+                        &node.id,
+                        iter,
+                        None,
+                        HARNESS_BINARY_MISSING_CODE,
+                        &reason,
+                    )
+                    .await;
+                    return SpawnOutcome::Failed {
+                        reason: format!("node {}: {reason}", node.id),
+                    };
+                }
+                Err(e) => {
+                    warn!(
+                        "run {run_id}: node {}: could not probe `{}` in the sandbox container \
+                         ({e:#}); spawning anyway",
+                        node.id, d.binary
+                    );
+                }
+            }
+            // ADR-0063 §3: fill the harness's staging set NOW if this Run has not yet —
+            // the first node that resolves `pi` copies `.pi/agent`, the second finds
+            // the marker, a claude-only Run never copies it. Trust is pre-granted on
+            // `repo_root`, the common ancestor of every worktree (claude's fixup).
+            let home_root = spawn_home_root(&deps);
+            let sandbox_root = home_root.join(".pdo").join("sandbox");
+            match crate::sandbox_staging::fill_staging_set(
+                &home_root,
+                &sandbox_root,
+                run_id,
+                &d.name,
+                Some(spawn_ctx.repo_root),
+            ) {
+                Ok(fill) => set_env = fill.env(),
+                Err(e) => {
+                    let reason = format!(
+                        "node {}: failed to stage the `{}` set into the sandbox: {e:#}",
+                        node.id, d.name
+                    );
+                    interrupt_spawn_before_start(
+                        deps,
+                        spawn_ctx.repo_root,
+                        run_id,
+                        &node.id,
+                        iter,
+                        None,
+                        &reason,
+                    )
+                    .await;
+                    return SpawnOutcome::Failed { reason };
+                }
+            }
+        } else if deps.tmux_cmd_override.is_none()
+            && !tmux_session_manager::binary_available(&d.binary)
+        {
             return SpawnOutcome::Failed {
                 reason: format!(
                     "node {}: harness '{}' binary '{}' not found in PATH {} \
@@ -1197,6 +1314,7 @@ pub(crate) async fn spawn_node(
         gid: crate::sandbox_container::host_gid(),
         marker: &session_name,
         workdir: &working_dir,
+        set_env: &set_env,
     });
     // #433 / ADR-0043: arm the turn-end `Stop` hook only when the operator has
     // opted into turn-end auto-completion (the SAME setting as the daemon sweep,
@@ -1296,7 +1414,35 @@ async fn interrupt_spawn_before_start(
     orphan: Option<&(PathBuf, String)>,
     reason: &str,
 ) {
-    error!("Run {run_id}: node {node_id} spawn aborted before NodeStarted — {reason}");
+    interrupt_spawn_before_start_with_code(
+        deps,
+        repo_root,
+        run_id,
+        node_id,
+        iter,
+        orphan,
+        "spawn_aborted",
+        reason,
+    )
+    .await
+}
+
+/// [`interrupt_spawn_before_start`] with an explicit machine `reason_code` (#601):
+/// `spawn_aborted` for a PDO-side abort, [`HARNESS_BINARY_MISSING_CODE`] when the
+/// sandbox image lacks the harness binary (#708) — a distinct code, because the fix
+/// is the user's image, not a retry.
+#[allow(clippy::too_many_arguments)]
+async fn interrupt_spawn_before_start_with_code(
+    deps: SpawnDeps<'_>,
+    repo_root: &std::path::Path,
+    run_id: &str,
+    node_id: &str,
+    iter: i64,
+    orphan: Option<&(PathBuf, String)>,
+    code: &str,
+    reason: &str,
+) {
+    error!("Run {run_id}: node {node_id} spawn aborted before NodeStarted — {code}: {reason}");
     if let Some((sub_worktree_dir, sub_branch)) = orphan {
         reap_orphan_sub_worktree(repo_root, sub_worktree_dir, sub_branch);
     }
@@ -1309,10 +1455,11 @@ async fn interrupt_spawn_before_start(
         iter: Some(iter),
         // #601: prefix the machine slug so the node reason is `<code>: <prose>`
         // and [`finalize`](crate::event_log) derives `awaiting_reason_code`
-        // (`spawn_aborted`). `source: "spawn"` is retained for existing readers.
+        // (`spawn_aborted`, `harness_binary_missing`). `source: "spawn"` is retained
+        // for existing readers.
         payload: Some(serde_json::json!({
-            "reason": format!("spawn_aborted: {reason}"),
-            "reason_code": "spawn_aborted",
+            "reason": format!("{code}: {reason}"),
+            "reason_code": code,
             "source": "spawn",
         })),
     };

--- a/crates/pdo-daemon/src/sandbox_container.rs
+++ b/crates/pdo-daemon/src/sandbox_container.rs
@@ -165,6 +165,14 @@ pub(crate) struct ContainerSpec<'a> {
     /// **réévalue jamais** les mounts. Cohérent avec le gel d'ADR-0031 §6 — un profil
     /// édité en cours de Run ne remonte rien — mais jusqu'ici non dit.
     pub extra_mounts: &'a [crate::sandbox_staging::StagedMount],
+    /// Racines de home des harnais first-party **hors `.claude`** (#708, ADR-0063 §3)
+    /// — calculées par [`crate::sandbox_staging::harness_home_mounts`] : un
+    /// `-v <staging>/home/.pi/agent:<host_home>/.pi/agent:rw` par staging set dont la
+    /// racine n'est pas déjà un mount fixe. Montées **vides** au create, remplies au
+    /// spawn du premier nœud qui résout le harnais (`fill_staging_set`). Posées juste
+    /// après les 4 `-v` fixes, avant la queue du profil : ce sont des mounts **de
+    /// PDO**, pas de l'utilisateur, et leur liste ne dépend que du registre embarqué.
+    pub harness_homes: &'a [crate::sandbox_staging::StagedMount],
     /// Env du profil de staging (#468, ADR-0031 §8) — la liste GELÉE à la création du Run,
     /// résolue au bord par `sandbox_run::frozen_env`. Queue **variable** comme
     /// [`ContainerSpec::extra_mounts`] : vide ⇒ argv byte-identique à #432 (propriété que
@@ -240,9 +248,10 @@ fn create_env(run_id: &str, spec: &ContainerSpec) -> Vec<(String, String)> {
 
 /// Argv `docker create` (après le binaire `docker`). Ordre canonique FIGÉ par le golden test :
 /// `--init`, `--name`, `--user` numérique, `--add-host`, `-w`, les `-e` fusionnés
-/// ([`create_env`] : 4 fixes + la queue du profil, #468), les 4 `-v` **fixes**, puis la
-/// **queue variable** des mounts d'exception `$HOME` (#432), l'image, et le trailing
-/// `sleep infinity` (le conteneur dort ; les tails entrent par `docker exec`).
+/// ([`create_env`] : 4 fixes + la queue du profil, #468), les 4 `-v` **fixes**, les
+/// racines de home des harnais first-party montées **vides** (#708 : `.pi/agent`),
+/// puis la **queue variable** des mounts d'exception `$HOME` (#432), l'image, et le
+/// trailing `sleep infinity` (le conteneur dort ; les tails entrent par `docker exec`).
 ///
 /// La queue de mounts est **entre** les `-v` fixes et l'image — position forcée par Docker :
 /// après l'image, tout argument devient la commande. Elle est triée par chemin relatif
@@ -296,6 +305,17 @@ pub(crate) fn create_args(run_id: &str, spec: &ContainerSpec) -> Vec<String> {
         "-v".to_string(),
         format!("{}:/usr/local/bin/pdo:ro", spec.pdo_bin.display()),
     ]);
+    // Racines de home des harnais first-party (#708, ADR-0063 §3) : montées VIDES,
+    // remplies au spawn. Après les 4 fixes (ce sont des mounts de PDO), avant la queue
+    // du profil (celle de l'utilisateur).
+    for mount in spec.harness_homes {
+        args.push("-v".to_string());
+        args.push(format!(
+            "{}:{}:rw",
+            mount.source.display(),
+            mount.target.display()
+        ));
+    }
     // Queue variable (#432) : un `-v <source>:<target>:rw` par entrée d'exception
     // `$HOME` réellement stagée. Vide ⇒ l'argv reste byte-identique à #406.
     for mount in spec.extra_mounts {
@@ -677,6 +697,61 @@ pub(crate) fn kill_session_in_container(
     )
 }
 
+/// Le binaire `binary` est-il résolvable **dans le conteneur** du Run (#708, ADR-0063 §5) ?
+/// Un `docker exec --user <uid>:<gid> <name> bash -lc 'command -v -- <binary>'` — le
+/// **même** shell de login que la tail de la session, donc le même `PATH` qu'elle
+/// verra. `Ok(true)` / `Ok(false)` sur un verdict du shell ; `Err` quand `docker`
+/// lui-même n'a pas pu rendre de verdict (binaire absent, conteneur disparu) — que
+/// l'appelant distingue : une sonde qui n'a pas répondu n'est pas un binaire absent.
+///
+/// **Jamais** une validation d'image : un binaire présent mais d'une version non
+/// validée passe, comme sur l'hôte (ADR-0063 « limites »). Et pas de `--version` : un
+/// `which` n'exécute pas le harnais.
+pub(crate) fn binary_present_in_container(
+    docker_bin: &str,
+    run_id: &str,
+    uid: u32,
+    gid: u32,
+    binary: &str,
+) -> Result<bool> {
+    let name = container_name(run_id);
+    let user = format!("{uid}:{gid}");
+    let script = format!("command -v -- {} >/dev/null 2>&1", sh_single_quote(binary));
+    let output = match Command::new(docker_bin)
+        .arg("exec")
+        .arg("--user")
+        .arg(&user)
+        .arg(&name)
+        .arg("bash")
+        .arg("-lc")
+        .arg(&script)
+        .output()
+    {
+        Ok(output) => output,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Err(anyhow::Error::new(e)).context(DOCKER_NOT_FOUND_MSG);
+        }
+        Err(e) => {
+            return Err(e).context("failed to run `docker exec` to probe a harness binary");
+        }
+    };
+    if output.status.success() {
+        return Ok(true);
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if is_absent_stderr(&stderr) || stderr.contains("is not running") {
+        anyhow::bail!(
+            "sandbox container `{name}` cannot answer a binary probe — `docker exec` exited \
+             with {}: {stderr}",
+            output.status
+        );
+    }
+    // `command -v` exits 1 (or 127 from a `bash -lc` that could not find it) when
+    // the name does not resolve; any other shell verdict is read the same way — the
+    // only thing that says "present" is a zero exit.
+    Ok(false)
+}
+
 /// `docker rm -f <name>` au `cleanup_run`. Idempotent : conteneur déjà absent (sentinelle) →
 /// `Ok`. C'est LE verbe « destroy / destruction » du conteneur (distinct de
 /// [`kill_session_in_container`], qui ne tue qu'un arbre de session).
@@ -879,6 +954,9 @@ mod tests {
         /// Queue variable (#432). Vide par défaut — c'est ce qui garde l'argv
         /// byte-identique à #406 pour un profil sans entrée d'exception `$HOME`.
         extras: Vec<crate::sandbox_staging::StagedMount>,
+        /// Racines de home des harnais first-party hors `.claude` (#708). Par
+        /// défaut celle de `pi`, comme en production (le registre embarqué la porte).
+        harness_homes: Vec<crate::sandbox_staging::StagedMount>,
         /// Queue variable (#468). Vide par défaut, pour la même raison.
         env: BTreeMap<String, String>,
         /// Queue variable (ADR-0047). Vide par défaut — un Run sans secondaire
@@ -897,6 +975,10 @@ mod tests {
                 host_home: PathBuf::from("/home/u"),
                 image: "pdo-sandbox:h-abc123".to_string(),
                 extras: Vec::new(),
+                harness_homes: vec![crate::sandbox_staging::StagedMount {
+                    source: PathBuf::from("/sb/r1/home/.pi/agent"),
+                    target: PathBuf::from("/home/u/.pi/agent"),
+                }],
                 env: BTreeMap::new(),
                 writable_gitdirs: Vec::new(),
             }
@@ -939,6 +1021,7 @@ mod tests {
                 gid: 1000,
                 daemon_port: 6172,
                 extra_mounts: &self.extras,
+                harness_homes: &self.harness_homes,
                 env: &self.env,
                 writable_secondary_gitdirs: &self.writable_gitdirs,
             }
@@ -1055,7 +1138,8 @@ mod tests {
         ])
     }
 
-    /// Les 4 `-v` fixes (identity mounts).
+    /// Les 4 `-v` fixes (identity mounts) + la racine de home de `pi` montée vide
+    /// (#708, ADR-0063 §3 — `.claude` est déjà le mount `claude-home`).
     fn create_argv_mounts() -> Vec<String> {
         strings(&[
             "-v",
@@ -1066,6 +1150,8 @@ mod tests {
             "/sb/r1/.claude.json:/home/u/.claude.json:rw",
             "-v",
             "/host/bin/pdo:/usr/local/bin/pdo:ro",
+            "-v",
+            "/sb/r1/home/.pi/agent:/home/u/.pi/agent:rw",
         ])
     }
 
@@ -1089,6 +1175,36 @@ mod tests {
         let mut expected = create_argv_fixed();
         expected.extend(create_argv_suffix());
         assert_eq!(create_args("r1", &fx.spec()), expected);
+    }
+
+    /// #708 : la racine de home d'un harnais first-party est montée VIDE, juste après
+    /// les 4 `-v` fixes et AVANT la queue du profil. Sans aucune racine (un registre
+    /// où seul `claude` déclare un set), l'argv est byte-identique à celui d'avant.
+    #[test]
+    fn harness_home_roots_sit_between_the_fixed_mounts_and_the_profile_queue() {
+        let mut fx = Fixtures::sample().with_extras(&[".gitconfig"]);
+        let with = create_args("r1", &fx.spec());
+        let pi_at = with
+            .iter()
+            .position(|a| a == "/sb/r1/home/.pi/agent:/home/u/.pi/agent:rw")
+            .expect("pi's home root is mounted");
+        let pdo_at = with
+            .iter()
+            .position(|a| a == "/host/bin/pdo:/usr/local/bin/pdo:ro")
+            .unwrap();
+        let gitconfig_at = with
+            .iter()
+            .position(|a| a == "/sb/r1/home/.gitconfig:/home/u/.gitconfig:rw")
+            .unwrap();
+        assert!(pdo_at < pi_at && pi_at < gitconfig_at, "{with:?}");
+
+        fx.harness_homes.clear();
+        let without = create_args("r1", &fx.spec());
+        assert_eq!(without.len(), with.len() - 2, "one root = exactly 2 args");
+        assert!(
+            !without.iter().any(|a| a.contains(".pi/agent")),
+            "no set ⇒ no pi mount: {without:?}"
+        );
     }
 
     /// Une liste précise → une queue précise, insérée entre les `-v` fixes et l'image.
@@ -1846,5 +1962,53 @@ mod tests {
     fn container_name_schema() {
         assert_eq!(container_name("r"), "pdo-sbx-r");
         assert_eq!(container_name("20260101-abcdef"), "pdo-sbx-20260101-abcdef");
+    }
+
+    /// #708 / ADR-0063 §5: a `which` in the container. `command -v` exits 0 ⇒ present.
+    #[test]
+    fn binary_present_in_container_true_on_zero_exit() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (docker, log) = write_fake_docker(tmp.path(), &FakeSpec::default());
+        assert!(binary_present_in_container(&docker, "r1", 1000, 1000, "pi").unwrap());
+        // It really ran a `docker exec` (never the binary itself).
+        assert!(log_lines(&log).contains(&"exec".to_string()));
+    }
+
+    /// A non-zero shell exit (the name did not resolve) is a clean `Ok(false)`, not an
+    /// error — the caller turns it into a node `Interrupted`, said once per Run.
+    #[test]
+    fn binary_present_in_container_false_when_command_v_fails() {
+        let tmp = tempfile::tempdir().unwrap();
+        let spec = FakeSpec {
+            exec_exit: 1,
+            ..FakeSpec::default()
+        };
+        let (docker, _log) = write_fake_docker(tmp.path(), &spec);
+        assert!(!binary_present_in_container(&docker, "r1", 1000, 1000, "pi").unwrap());
+    }
+
+    /// A container that is gone / not running is NOT a binary absence: it is an `Err`,
+    /// so the caller can tell "image lacks the binary" from "could not probe".
+    #[test]
+    fn binary_present_in_container_errors_when_the_container_is_absent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let spec = FakeSpec {
+            exec_exit: 1,
+            exec_stderr: "Error: No such container: pdo-sbx-r1".to_string(),
+            ..FakeSpec::default()
+        };
+        let (docker, _log) = write_fake_docker(tmp.path(), &spec);
+        let err = binary_present_in_container(&docker, "r1", 1000, 1000, "pi").unwrap_err();
+        assert!(format!("{err:#}").contains("cannot answer a binary probe"));
+    }
+
+    /// A missing `docker` binary is an `Err` naming the absence (never `Ok(false)`).
+    #[test]
+    fn binary_present_in_container_errors_when_docker_is_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let missing = tmp.path().join("no-such-docker");
+        let err = binary_present_in_container(missing.to_str().unwrap(), "r1", 1000, 1000, "pi")
+            .unwrap_err();
+        assert!(format!("{err:#}").contains("not found on PATH"));
     }
 }

--- a/crates/pdo-daemon/src/sandbox_run.rs
+++ b/crates/pdo-daemon/src/sandbox_run.rs
@@ -331,23 +331,42 @@ pub(crate) fn copilot_store_root(home_root: &Path) -> PathBuf {
     home_root.join(".copilot").join("session-state")
 }
 
-/// The `pi` sessions store root — `<home_root>/.pi/agent/sessions/`, where each
-/// working directory's folder holds `<timestamp>_<session-id>.jsonl` files (#707,
-/// [`crate::pi_session`]).
-///
-/// The **host** home, like [`copilot_store_root`]: `pi` declares no staging set in
-/// this ticket (#708 brings it, ADR-0063), so its session is read where the harness
-/// wrote it. A sandboxed pi node mounts its worktree at the same absolute path, so
-/// the cwd-keyed folder name is identical host-side. Path math only.
+/// The `pi` sessions store root on the **host** — `<home_root>/.pi/agent/sessions/`,
+/// where each working directory's folder holds `<timestamp>_<session-id>.jsonl`
+/// files (#707, [`crate::pi_session`]). Path math only; the per-Run seam that moves
+/// it while a sandboxed Run lives is [`HarnessStores::for_run`].
 pub(crate) fn pi_store_root(home_root: &Path) -> PathBuf {
     home_root.join(".pi").join("agent").join("sessions")
 }
 
-/// The store roots of the first-party harnesses whose transcripts are read from the
-/// **host** home rather than a Run's staged home (#707): one field per harness, so a
+/// Where a Run's `pi` sessions are read (#708, ADR-0063): the **staged** sink
+/// (`<staging>/home/.pi/agent/sessions/`) while a sandboxed Run's staging exists —
+/// pi writes there in real time through the rw mount of its home root — else the
+/// host store where `merge_back` flushed them. The same dispatch rule as
+/// [`transcripts_root`] (keyed on the staging dir's existence, never on the Run's
+/// status), so the cost of a sandboxed pi Run reads while the Run lives AND after
+/// its merge-back. The cwd-encoded folder name is identical on both sides because
+/// the worktree is mounted at its host path (ADR-0030).
+pub(crate) fn pi_sessions_root(
+    sandboxed: bool,
+    run_id: &str,
+    home_root: &Path,
+    sandbox_root: &Path,
+) -> PathBuf {
+    if sandboxed && sandbox_staging::staging_dir_for_run(sandbox_root, run_id).exists() {
+        sandbox_staging::staged_path(sandbox_root, run_id, ".pi/agent/sessions")
+    } else {
+        pi_store_root(home_root)
+    }
+}
+
+/// The store roots of the reported-cost harnesses (#707): one field per harness, so a
 /// consumer that reads several harnesses' stores threads one value instead of one
-/// root per harness. `claude`'s root is not here: it moves per Run
-/// ([`transcripts_root`]), and stays the caller's separate `claude_root`.
+/// root per harness. `copilot` (no staging set) is always the host store; `pi` moves
+/// per Run like `claude` does ([`pi_sessions_root`], #708) — build the struct with
+/// [`HarnessStores::for_run`] for a Run, [`HarnessStores::from_home`] for the host
+/// only. `claude`'s root is not here: it stays the caller's separate `claude_root`
+/// ([`transcripts_root`]).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct HarnessStores {
     /// [`copilot_store_root`].
@@ -357,11 +376,29 @@ pub(crate) struct HarnessStores {
 }
 
 impl HarnessStores {
-    /// Both host-home roots derived from `home_root`.
+    /// Both **host**-home roots derived from `home_root` — the `off` Run's view, and
+    /// the view of a sandboxed Run whose staging is gone. Test-only since #708: every
+    /// production caller now threads the per-Run [`Self::for_run`] (pi's store moves
+    /// with the sandbox), and the cost/perf unit tests exercise the host-only view.
+    #[cfg(test)]
     pub(crate) fn from_home(home_root: &Path) -> Self {
         HarnessStores {
             copilot: copilot_store_root(home_root),
             pi: pi_store_root(home_root),
+        }
+    }
+
+    /// The roots **for one Run** (#708): `copilot` on the host, `pi` on the staged
+    /// sink while a sandboxed Run's staging exists ([`pi_sessions_root`]).
+    pub(crate) fn for_run(
+        sandboxed: bool,
+        run_id: &str,
+        home_root: &Path,
+        sandbox_root: &Path,
+    ) -> Self {
+        HarnessStores {
+            copilot: copilot_store_root(home_root),
+            pi: pi_sessions_root(sandboxed, run_id, home_root, sandbox_root),
         }
     }
 
@@ -416,6 +453,39 @@ pub(crate) async fn merge_back_best_effort(state: &AppState, run_id: &str) {
     });
 }
 
+/// Fill `harness`'s staging set into a sandboxed Run's staging **once per Run**,
+/// and return the env the session's `docker exec` must carry (#708, ADR-0063 §3).
+/// The AppState-side entry point for the infra sessions (manager, merge resolver,
+/// reattach); `spawn_node` calls the pure [`sandbox_staging::fill_staging_set`]
+/// with the roots it already holds. A no-op (empty env) for `off`, and for a harness
+/// with no set — whose absence is said once by the caller. Hard error when the set
+/// cannot be copied: a session on an unfillable home would hang on a dialog.
+pub(crate) fn stage_harness_set(
+    state: &AppState,
+    run_state: &RunState,
+    harness: &str,
+    trusted_root: &Path,
+) -> Result<Vec<(String, String)>> {
+    if run_state.sandbox.is_off() {
+        return Ok(Vec::new());
+    }
+    let (home_root, sandbox_root) = sandbox_home_roots(state)?;
+    let fill = sandbox_staging::fill_staging_set(
+        &home_root,
+        &sandbox_root,
+        &run_state.run_id,
+        harness,
+        Some(trusted_root),
+    )
+    .with_context(|| {
+        format!(
+            "failed to stage the `{harness}` set for run {}",
+            run_state.run_id
+        )
+    })?;
+    Ok(fill.env())
+}
+
 /// Guarantee the Run's sandbox is ready to accept `docker exec` tails: staged
 /// home present, image built, container up. Idempotent — safe to call at
 /// create-time, boot recovery, spawn-time, and run-shell open.
@@ -429,16 +499,14 @@ pub(crate) fn ensure_ready(ctx: &SandboxContext) -> Result<()> {
         return Ok(()); // off: gated by callers; no docker touched.
     };
 
-    // 1. Stage the Claude home ONCE. The ~1 GB `full` walk must not repeat on
-    //    every ensure_ready — gate on the staging dir already existing.
-    //    `prepare` then applies `claude`'s **staging set** (#426, ADR-0031 §1;
-    //    ADR-0063) in BOTH sandboxed modes, mode-agnostically: valid credentials, the org managed-
-    //    settings baseline, the accepted permissions bypass, trust pre-granted on
-    //    `repo_root` (the common ancestor of the pipeline worktree AND every node
-    //    sub-worktree), and an empty `projects/` sink. Each guarantee is met either
-    //    by a copy of the host file or by a fallback synthesis — which is why an
-    //    autonomous Run never blocks on the "trust this folder?", "managed settings
-    //    require approval" or bypass-permissions dialogs.
+    // 1. Stage the profile ONCE. The ~1 GB `full` walk must not repeat on every
+    //    ensure_ready — gate on the staging dir already existing. No harness
+    //    **staging set** is applied here any more (#708, ADR-0063 §3): `claude`'s
+    //    five guarantees (credentials, org managed-settings baseline, permissions
+    //    bypass, trust pre-granted on `repo_root`, empty `projects/` sink) and `pi`'s
+    //    home are copied by `stage_harness_set` at the spawn of the first session of
+    //    the Run that resolves that harness — so a claude-only Run never carries pi's
+    //    auth, and vice versa.
     let staging_dir = sandbox_staging::staging_dir_for_run(&ctx.sandbox_root, &ctx.run_id);
     if !staging_dir.exists() {
         // Name the profile AND the list once per staging, so "why does this Run carry
@@ -468,15 +536,17 @@ pub(crate) fn ensure_ready(ctx: &SandboxContext) -> Result<()> {
         }
         // `Some(repo_root)` unconditionally: the `off` arm of the old match was DEAD —
         // the `let Some(entries) = … else { return }` above has already excluded it.
-        sandbox_staging::prepare(
-            &ctx.home_root,
-            &ctx.sandbox_root,
-            entries,
-            &ctx.run_id,
-            Some(ctx.repo_root.as_path()),
-        )
-        .with_context(|| format!("failed to stage the sandbox home for run {}", ctx.run_id))?;
+        sandbox_staging::prepare(&ctx.home_root, &ctx.sandbox_root, entries, &ctx.run_id)
+            .with_context(|| format!("failed to stage the sandbox home for run {}", ctx.run_id))?;
     }
+    // #708 / ADR-0063 §3: the sources of the fixed mounts exist — every first-party
+    // harness home root, EMPTY until the first node that resolves the harness fills
+    // it at spawn (`fill_staging_set`), and the `.claude.json` sibling. Unconditional
+    // (cheap, idempotent): a staging prepared by a pre-#708 daemon lacks the `pi` root,
+    // and a `docker create` whose mount source is missing yields a root-owned
+    // directory (rule M1 of `extra_mounts`).
+    sandbox_staging::ensure_mount_anchors(&ctx.sandbox_root, &ctx.run_id)
+        .with_context(|| format!("failed to anchor the sandbox mounts for run {}", ctx.run_id))?;
 
     // 2. Ensure the Run's image exists locally, per the plan resolved at the edge:
     //    pull-then-retag `<name>:h-<hash>` from GHCR (registry, default) or build it from the
@@ -515,6 +585,10 @@ pub(crate) fn ensure_ready(ctx: &SandboxContext) -> Result<()> {
     // and this derivation gives the same answer either way.
     let extra =
         sandbox_staging::extra_mounts(&ctx.sandbox_root, &ctx.run_id, &ctx.host_home, entries);
+    // #708: the empty home root of every first-party harness whose root is not
+    // already a fixed mount (`pi`'s `.pi/agent`; `claude`'s is `claude-home`).
+    let harness_homes =
+        sandbox_staging::harness_home_mounts(&ctx.sandbox_root, &ctx.run_id, &ctx.host_home);
     let spec = sandbox_container::ContainerSpec {
         image_ref: &image_ref,
         repo_root: &ctx.repo_root,
@@ -527,6 +601,7 @@ pub(crate) fn ensure_ready(ctx: &SandboxContext) -> Result<()> {
         gid: ctx.gid,
         daemon_port: ctx.daemon_port,
         extra_mounts: &extra,
+        harness_homes: &harness_homes,
         // #468: the FROZEN env. `ensure_running` only consults the spec on its `Absent`
         // arm — `docker start` never re-evaluates a pre-existing container's env, any more
         // than its mounts. That is exactly the freeze of ADR-0031 §6/§8, guaranteed twice.
@@ -851,31 +926,46 @@ mod tests {
         );
     }
 
+    /// #708 / ADR-0063 §3: `ensure_ready` no longer applies `claude`'s staging set —
+    /// it anchors an EMPTY `.claude.json` (no trust) so the fixed mount has a source.
+    /// The five guarantees (trust, bypass) are filled at the first claude spawn by
+    /// `fill_staging_set`, which this test drives directly (as `spawn_node` does).
     #[test]
-    fn ensure_ready_full_seeds_trust_for_repo_root() {
+    fn ensure_ready_anchors_empty_json_and_the_first_claude_spawn_seeds_trust() {
         let tmp = tempfile::tempdir().unwrap();
         let (docker, _log) = write_fake_docker(tmp.path());
         let ctx = test_ctx(tmp.path(), docker, full());
 
         retry_etxtbsy(|| ensure_ready(&ctx)).unwrap();
 
-        // #409 D5: full stages a `.claude.json`, and ensure_ready pre-approves the
-        // Run's repo_root trust dialog in it — even when the host had no
-        // `.claude.json` (an autonomous Run must not block on "trust this folder?").
+        // ensure_ready anchors a `.claude.json` for the fixed mount, but WITHOUT trust.
         let staged = sandbox_staging::staged_claude_json(&ctx.sandbox_root, "r1");
-        assert!(staged.is_file(), "full staging writes a .claude.json");
-        let json: serde_json::Value =
-            serde_json::from_str(&std::fs::read_to_string(&staged).unwrap()).unwrap();
+        assert!(staged.is_file(), "ensure_ready anchors a .claude.json");
         let key = ctx.repo_root.to_string_lossy().into_owned();
-        assert_eq!(
-            json["projects"][&key]["hasTrustDialogAccepted"],
-            serde_json::json!(true),
-            "full must pre-approve the repo_root trust dialog: {json}"
+        let before: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&staged).unwrap()).unwrap();
+        assert!(
+            before["projects"][&key]["hasTrustDialogAccepted"].is_null(),
+            "no trust before the first claude spawn: {before}"
         );
 
-        // #426: the staging set runs through the REAL caller, not just a direct
-        // `prepare` call. `test_ctx`'s home carries credentials only, so G3 lands on
-        // its synthesis branch.
+        // The first claude spawn fills the set: trust on repo_root + bypass permissions.
+        sandbox_staging::fill_staging_set(
+            &ctx.home_root,
+            &ctx.sandbox_root,
+            "r1",
+            crate::harness_registry::CLAUDE,
+            Some(ctx.repo_root.as_path()),
+        )
+        .unwrap();
+
+        let after: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&staged).unwrap()).unwrap();
+        assert_eq!(
+            after["projects"][&key]["hasTrustDialogAccepted"],
+            serde_json::json!(true),
+            "the claude spawn pre-approves the repo_root trust dialog: {after}"
+        );
         let staged_settings =
             sandbox_staging::staged_claude_home(&ctx.sandbox_root, "r1").join("settings.json");
         let settings: serde_json::Value =
@@ -883,7 +973,89 @@ mod tests {
         assert_eq!(
             settings["skipDangerousModePermissionPrompt"],
             serde_json::json!(true),
-            "ensure_ready must hold the staging set: {settings}"
+            "the claude spawn holds the bypass fixup: {settings}"
+        );
+    }
+
+    /// #708: filling `pi`'s set copies `.pi/agent` (minus `sessions/`) into the staged
+    /// pi home, creates the empty `sessions/` sink, and reports pi's two env vars — no
+    /// fixup, no `.claude` write. A second fill is a marker no-op.
+    #[test]
+    fn filling_pi_set_stages_the_agent_home_and_reports_env() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        std::fs::create_dir_all(home.join(".pi/agent/extensions")).unwrap();
+        std::fs::write(home.join(".pi/agent/auth.json"), "{\"token\":1}").unwrap();
+        std::fs::write(home.join(".pi/agent/models.json"), "[]").unwrap();
+        // A host session file that must NOT be copied on the way in.
+        std::fs::create_dir_all(home.join(".pi/agent/sessions/enc")).unwrap();
+        std::fs::write(home.join(".pi/agent/sessions/enc/s.jsonl"), "x\n").unwrap();
+        let sandbox_root = tmp.path().join("sandbox");
+
+        let fill = sandbox_staging::fill_staging_set(
+            &home,
+            &sandbox_root,
+            "r1",
+            crate::harness_registry::PI,
+            None,
+        )
+        .unwrap();
+        assert_eq!(
+            fill.env(),
+            vec![
+                ("PI_SKIP_VERSION_CHECK".to_string(), "1".to_string()),
+                ("PI_TELEMETRY".to_string(), "0".to_string()),
+            ]
+        );
+        let staged = sandbox_staging::staged_path(&sandbox_root, "r1", ".pi/agent");
+        assert!(staged.join("auth.json").is_file(), "auth copied");
+        assert!(staged.join("models.json").is_file(), "catalogue copied");
+        assert!(staged.join("extensions").is_dir(), "extensions copied");
+        let sink = staged.join("sessions");
+        assert!(sink.is_dir(), "sessions sink created");
+        assert!(
+            !sink.join("enc/s.jsonl").exists(),
+            "host sessions are NOT copied in (transcripts sink is empty)"
+        );
+
+        // Idempotent: second fill is a marker no-op (AlreadyFilled), env still reported.
+        let again = sandbox_staging::fill_staging_set(
+            &home,
+            &sandbox_root,
+            "r1",
+            crate::harness_registry::PI,
+            None,
+        )
+        .unwrap();
+        assert!(!again.env().is_empty());
+    }
+
+    /// A claude-only Run never carries pi's auth: filling only `claude` leaves the
+    /// staged pi home empty (it exists as a mount anchor, but nothing was copied).
+    #[test]
+    fn a_claude_only_run_has_no_pi_auth_in_its_staging() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path().join("home");
+        std::fs::create_dir_all(home.join(".claude")).unwrap();
+        std::fs::write(home.join(".claude/.credentials.json"), "{}").unwrap();
+        std::fs::create_dir_all(home.join(".pi/agent")).unwrap();
+        std::fs::write(home.join(".pi/agent/auth.json"), "{}").unwrap();
+        let sandbox_root = tmp.path().join("sandbox");
+
+        sandbox_staging::prepare(&home, &sandbox_root, &[], "r1").unwrap();
+        sandbox_staging::fill_staging_set(
+            &home,
+            &sandbox_root,
+            "r1",
+            crate::harness_registry::CLAUDE,
+            None,
+        )
+        .unwrap();
+
+        let pi_home = sandbox_staging::staged_path(&sandbox_root, "r1", ".pi/agent");
+        assert!(
+            !pi_home.join("auth.json").exists(),
+            "a claude-only Run must not have pi's auth in its staging"
         );
     }
 

--- a/crates/pdo-daemon/src/sandbox_staging.rs
+++ b/crates/pdo-daemon/src/sandbox_staging.rs
@@ -32,17 +32,22 @@
 //!   `projects/<enc>/<uuid>/subagents/*.jsonl` (profondeur 9). Le copy-set doit
 //!   *égaler* le read-set de [`crate::run_cost`] (`collect_jsonl_recursive`),
 //!   sinon le coût des runs sandboxés est sous-estimé (régression silencieuse).
-//! - **Le staging set d'un harnais est profil-agnostique** (#426, ADR-0031 §1 ;
-//!   ADR-0063). [`prepare`] est en **deux phases** : matérialisation des entrées du
-//!   profil, puis [`apply_staging_set`] pour chaque set déclaré par un harnais
-//!   first-party ([`crate::harness_probes::staging_sets`]) — entrées copiées de
-//!   l'hôte, puits de transcripts créés vides, *autonomy fixups* synthétisés. Pour
+//! - **Le staging set d'un harnais est profil-agnostique et se remplit au spawn**
+//!   (#426, ADR-0031 §1 ; #708, ADR-0063 §3). [`prepare`] matérialise les entrées du
+//!   profil et **ancre** les mounts ([`ensure_mount_anchors`]) : la racine de home de
+//!   chaque harnais first-party ([`StagingSet::home_root`]) existe **vide**, le
+//!   `.claude.json` sibling existe (objet vide) — un mount dont la source manque
+//!   ferait créer par Docker un répertoire root-owned. Le set lui-même —
+//!   [`fill_staging_set`] : entrées copiées de l'hôte, puits de transcripts créés
+//!   vides, *autonomy fixups* synthétisés — est posé **au spawn de la première
+//!   session du Run qui résout le harnais**, gardé par un marqueur par `(Run,
+//!   harnais)`. Un Run claude-only n'a jamais l'auth de `pi` dans son conteneur ; un
+//!   nœud repris ne re-copie pas ; un nœud ré-épinglé à chaud obtient son set. Pour
 //!   `claude`, ce sont les **cinq garanties** d'ADR-0031 §1, octet pour octet :
 //!   chacune satisfaite soit par une copie de l'hôte, soit par une synthèse de repli.
-//!   `minimal`, c'est exactement le set (liste vide). Les fixups qui désarment un
-//!   dialogue bloquant (confiance, bypass permissions) ne sont pas cosmétiques : un
-//!   agent non surveillé se figerait dessus. Ce module est **l'interprète unique**
-//!   d'un set ; il n'en déclare aucun.
+//!   Les fixups qui désarment un dialogue bloquant (confiance, bypass permissions) ne
+//!   sont pas cosmétiques : un agent non surveillé se figerait dessus. Ce module est
+//!   **l'interprète unique** d'un set ; il n'en déclare aucun.
 //! - **Une entrée hors `.claude` est copiée puis montée** (#432, ADR-0031 §4) :
 //!   `<staging>/home/<rel>` → `$HOME/<rel>` en rw, **jamais** un bind direct du
 //!   fichier hôte. Un `git config --global` du conteneur touche la copie, pas le
@@ -67,6 +72,12 @@ use crate::harness_probes::{AutonomyFixup, StagingSet};
 /// nom court ne sert plus qu'aux fixtures de test, qui le pinnent contre le set.
 #[cfg(test)]
 const REMOTE_SETTINGS_FILE: &str = "remote-settings.json";
+
+/// La racine de home de `claude` : servie par le mount fixe `claude-home`, jamais un
+/// anchor ni un mount de home de harnais séparé (ADR-0063 §3). Bare `.claude` n'est
+/// pas classé `ClaudeHome` par [`crate::sandbox_profile::landing`] (qui ne strippe que
+/// `.claude/`), d'où ce littéral de garde.
+const CLAUDE_HOME_REL: &str = ".claude";
 
 /// Le `settings.json` du home stagé — porteur de la garantie G3
 /// ([`crate::harness_probes::AutonomyFixup::ClaudeBypassPermissions`]).
@@ -186,43 +197,32 @@ pub(crate) fn extra_mounts(
         .collect()
 }
 
-/// Seede le *staged Claude home* et renvoie sa racine (`<sandbox_root>/<run_id>`).
+/// Seede le staging d'un Run et renvoie sa racine (`<sandbox_root>/<run_id>`).
 ///
-/// **Deux phases** (#426, ADR-0031 §1 ; ADR-0063) :
+/// **Deux gestes** (#432 ; #708, ADR-0063 §3) :
 /// 1. *matérialisation du profil* — une passe sur la liste d'entrées **gelée** ;
-/// 2. *[`apply_staging_set`]* pour chaque set déclaré
-///    ([`crate::harness_probes::staging_sets`]) — profil-agnostique. Pour `claude` :
-///    les **cinq garanties** (credentials, managed settings de l'org, bypass
-///    permissions, confiance sur `trusted_root` + onboarding, `projects/` vide).
+/// 2. *[`ensure_mount_anchors`]* — la racine de home de chaque harnais first-party
+///    existe **vide**, le `.claude.json` sibling existe : ce sont les sources des
+///    mounts fixes du `docker create`, qui doivent exister **avant** le conteneur.
 ///
-/// La phase 2 tourne **après** la phase 1, jamais dedans : un set est un
-/// *check-then-repair* sur ce qui est effectivement posé sur disque (« satisfaite
-/// soit par une copie de l'hôte, soit par une synthèse de repli » n'est décidable
-/// qu'à ce moment-là). Le double write sur `settings.json` quand l'entrée est cochée
-/// (copiée par le profil, puis mergée par le fixup) est **voulu** : le fixup est
-/// merge-aware, il ne doit pas être profil-aware.
-///
-/// Aujourd'hui **tous** les sets déclarés sont appliqués ici, au staging du Run, quel
-/// que soit le harnais des nœuds — le comportement d'avant ADR-0063, où seul `claude`
-/// déclare un set. #708 déplace la copie au spawn du premier nœud qui résout le
-/// harnais (ADR-0063 §3) ; la donnée ne change pas, le moment si.
+/// Le staging set d'un harnais n'est **plus** posé ici : [`fill_staging_set`] le
+/// copie au spawn de la première session du Run qui résout ce harnais. Ce que le
+/// conteneur contient est exactement ce que le Run a résolu — un Run claude-only
+/// n'a jamais l'auth de `pi`. Le fixup de `claude` reste *merge-aware* et non
+/// profil-aware : quand l'entrée `settings.json` est cochée, le profil la copie ici
+/// et le fixup la merge au spawn — ce double write est **voulu**.
 ///
 /// `entries` (#432) occupe le slot de l'ancien `mode` : c'est la liste **résolue et
 /// gelée** dans `RunStarted`, jamais le réglage vivant (ADR-0031 §6). `sandbox_staging::Mode`
-/// a disparu — la phase 2 est déjà agnostique depuis #426 et les défauts virtuels sont
-/// des listes nommées, `minimal` étant la vide. Garder un `Mode` à côté d'une liste
-/// recréerait exactement la mode-awareness que le set vient de supprimer.
+/// a disparu — les défauts virtuels sont des listes nommées, `minimal` étant la vide.
 ///
-/// Idempotent (`create_dir_all` ; copy-or-overwrite ; merges non destructifs) et
-/// **additif** — jamais de suppression (ADR-0031 §6). `trusted_root` : racine à
-/// pré-approuver dans le `.claude.json` stagé ; `None` = pas de bloc `projects`
-/// (le reste du set est tenu quand même).
+/// Idempotent (`create_dir_all` ; copy-or-overwrite) et **additif** — jamais de
+/// suppression (ADR-0031 §6).
 pub(crate) fn prepare(
     home_root: &Path,
     sandbox_root: &Path,
     entries: &[String],
     run_id: &str,
-    trusted_root: Option<&Path>,
 ) -> Result<PathBuf> {
     let staging = staging_dir_for_run(sandbox_root, run_id);
     let home = staged_claude_home(sandbox_root, run_id);
@@ -233,18 +233,179 @@ pub(crate) fn prepare(
     let staged_json = staged_claude_json(sandbox_root, run_id);
 
     materialise_entries(home_root, &src, &home, &staged_json, &staging, entries)?;
-    for (harness, set) in crate::harness_probes::staging_sets() {
-        apply_staging_set(
-            home_root,
-            sandbox_root,
-            run_id,
-            &harness,
-            &set,
-            trusted_root,
-        )?;
-    }
+    ensure_mount_anchors(sandbox_root, run_id)?;
 
     Ok(staging)
+}
+
+/// Les **sources des mounts fixes** existent, vides quand rien ne les a remplies
+/// (#708, ADR-0063 §3) : la racine de home de **chaque** staging set déclaré
+/// ([`StagingSet::home_root`] → [`staged_path`]) et le `.claude.json` sibling (un
+/// mount de *fichier* : absent, Docker créerait un **répertoire** root-owned à sa
+/// place et Claude Code ne pourrait plus l'écrire — synthétisé en objet vide `{}`
+/// 0600, que le fixup [`AutonomyFixup::ClaudeJsonBaseline`] complète au spawn).
+///
+/// Idempotent et additif ; appelé par [`prepare`] **et** par chaque `ensure_ready`
+/// (un staging préparé par un daemon d'avant #708 n'a pas la racine `pi` : la créer
+/// avant le `docker create` évite le répertoire root-owned de la règle M1 de
+/// [`extra_mounts`]).
+pub(crate) fn ensure_mount_anchors(sandbox_root: &Path, run_id: &str) -> Result<()> {
+    for (harness, set) in crate::harness_probes::staging_sets() {
+        // `claude`'s `.claude` home is the fixed `claude-home` mount, seeded whole by
+        // the profile — it needs no separate anchor. `landing(".claude")` classifies
+        // bare `.claude` as a HomeExtra (only `.claude/` is stripped), so guard on the
+        // exact name rather than the classifier.
+        if set.home_root == CLAUDE_HOME_REL {
+            continue;
+        }
+        let root = staged_path(sandbox_root, run_id, set.home_root);
+        std::fs::create_dir_all(&root).with_context(|| {
+            format!(
+                "create the empty staged {harness} home root {}",
+                root.display()
+            )
+        })?;
+    }
+    let staged_json = staged_claude_json(sandbox_root, run_id);
+    if !staged_json.exists() {
+        std::fs::write(&staged_json, "{}")
+            .with_context(|| format!("anchor staged .claude.json {}", staged_json.display()))?;
+        set_mode_0600(&staged_json)?;
+    }
+    Ok(())
+}
+
+/// Les mounts des **racines de home des harnais first-party** (#708, ADR-0063 §3) :
+/// un `-v <staging>/home/<home_root>:<host_home>/<home_root>:rw` par staging set dont
+/// la racine n'est **pas** déjà servie par un mount fixe (`.claude` l'est —
+/// `claude-home` —, `.pi/agent` ne l'est pas). Montées **vides** à la création du
+/// conteneur, remplies par [`fill_staging_set`] au spawn.
+///
+/// Total (aucun test de disque, contrairement à [`extra_mounts`]) : la source est
+/// créée par [`ensure_mount_anchors`] sur tous les chemins qui mènent au `docker
+/// create`. Ordre = ordre du registre, déterministe pour le golden.
+pub(crate) fn harness_home_mounts(
+    sandbox_root: &Path,
+    run_id: &str,
+    host_home: &Path,
+) -> Vec<StagedMount> {
+    use crate::sandbox_profile::Landing;
+    crate::harness_probes::staging_sets()
+        .into_iter()
+        .filter(|(_, set)| set.home_root != CLAUDE_HOME_REL)
+        .filter_map(
+            |(_, set)| match crate::sandbox_profile::landing(set.home_root) {
+                Landing::HomeExtra { rel } => Some(StagedMount {
+                    source: staged_home_extras(sandbox_root, run_id).join(rel),
+                    target: host_home.join(rel),
+                }),
+                // `.claude.json`, or `.claude/<sub>` : servis par les mounts fixes.
+                Landing::ClaudeHome { .. } | Landing::ClaudeJson => None,
+            },
+        )
+        .collect()
+}
+
+/// Ce qu'a produit [`fill_staging_set`] pour un `(Run, harnais)`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum StagingFill {
+    /// Le harnais ne déclare aucun set (ADR-0051 : valeur déclarée, dite une fois
+    /// par l'appelant).
+    NoSet,
+    /// Le set vient d'être copié — c'est le premier spawn du Run qui résout ce
+    /// harnais.
+    Filled(StagingSet),
+    /// Le marqueur existait : un spawn antérieur du Run a déjà posé ce set (nœud
+    /// repris, second nœud du même harnais, manager puis nœud).
+    AlreadyFilled(StagingSet),
+}
+
+impl StagingFill {
+    /// Le set résolu, quel que soit le moment de sa copie ; `None` sans set.
+    pub(crate) fn set(&self) -> Option<&StagingSet> {
+        match self {
+            StagingFill::NoSet => None,
+            StagingFill::Filled(set) | StagingFill::AlreadyFilled(set) => Some(set),
+        }
+    }
+
+    /// L'env du set, prêt pour le `docker exec` (vide sans set — `claude` n'en a pas,
+    /// donc l'argv de ses nœuds reste byte-identique).
+    pub(crate) fn env(&self) -> Vec<(String, String)> {
+        self.set()
+            .map(|set| {
+                set.env
+                    .iter()
+                    .map(|(k, v)| (k.to_string(), v.to_string()))
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+}
+
+/// `<staging_dir>/sets/<harness>` — le **marqueur** « le set de ce harnais est posé
+/// dans ce Run ». Écrit **après** la copie : un crash entre les deux fait recopier
+/// (additif, idempotent), jamais sauter.
+fn staging_set_marker(sandbox_root: &Path, run_id: &str, harness: &str) -> PathBuf {
+    staging_dir_for_run(sandbox_root, run_id)
+        .join("sets")
+        .join(harness)
+}
+
+/// Pose le staging set de `harness` dans le staging du Run **si ce Run ne l'a pas
+/// encore** (#708, ADR-0063 §3) : la première session du Run qui résout ce harnais
+/// copie le set ([`apply_staging_set`]) puis écrit le marqueur ; toute session
+/// suivante du même harnais — un second nœud, un nœud repris, un nœud ré-épinglé —
+/// trouve le marqueur et ne recopie rien. Un harnais sans set rend
+/// [`StagingFill::NoSet`] sans toucher le disque.
+///
+/// Écrit exclusivement dans le staging (jamais l'hôte, jamais le conteneur : la
+/// copie atterrit sous la racine de home montée vide par [`ensure_mount_anchors`],
+/// donc elle est visible dans le conteneur sans recréation). `trusted_root` : la
+/// racine à pré-approuver par le fixup `claude` (le `repo_root` effectif du Run).
+///
+/// **Fail-fast** : une garantie intenable doit échouer au spawn (le nœud passe
+/// `Interrupted`, ADR-0049), pas produire une session qui pend sur un dialogue.
+pub(crate) fn fill_staging_set(
+    home_root: &Path,
+    sandbox_root: &Path,
+    run_id: &str,
+    harness: &str,
+    trusted_root: Option<&Path>,
+) -> Result<StagingFill> {
+    let Some(set) = crate::harness_probes::probes_for(harness).and_then(|p| p.staging_set()) else {
+        return Ok(StagingFill::NoSet);
+    };
+    let marker = staging_set_marker(sandbox_root, run_id, harness);
+    if marker.exists() {
+        return Ok(StagingFill::AlreadyFilled(set));
+    }
+    apply_staging_set(home_root, sandbox_root, run_id, harness, &set, trusted_root)?;
+    if let Some(parent) = marker.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("create staging set markers dir {}", parent.display()))?;
+    }
+    std::fs::write(&marker, "")
+        .with_context(|| format!("write staging set marker {}", marker.display()))?;
+    info!(
+        "sandbox: run {run_id} staged the `{harness}` set at spawn ({} entr{}, {} transcript sink{}, {} fixup{}, env: {})",
+        set.entries.len(),
+        if set.entries.len() == 1 { "y" } else { "ies" },
+        set.transcripts.len(),
+        if set.transcripts.len() == 1 { "" } else { "s" },
+        set.fixups.len(),
+        if set.fixups.len() == 1 { "" } else { "s" },
+        if set.env.is_empty() {
+            "none".to_string()
+        } else {
+            set.env
+                .iter()
+                .map(|(k, _)| *k)
+                .collect::<Vec<_>>()
+                .join(", ")
+        }
+    );
+    Ok(StagingFill::Filled(set))
 }
 
 /// Phase 1 : une passe unique sur la liste gelée, chaque entrée routée par le
@@ -417,12 +578,11 @@ fn copy_glob_one_level(src_dir: &Path, dst_dir: &Path, pattern: &str) -> Result<
 ///
 /// Pour `claude`, c'est ADR-0031 §1 mot pour mot : G1 credentials, G2 managed
 /// settings de l'org (entrées) ; G5 `projects/` vide (puits) ; G3 bypass permissions,
-/// G4 baseline `.claude.json` (fixups). L'`env` du set n'est pas posé ici : il se
-/// pose avec le remplissage au spawn (#708) ; `claude` n'en a pas.
+/// G4 baseline `.claude.json` (fixups). L'`env` du set n'est pas posé ici : il part
+/// sur le `docker exec` de la session ([`StagingFill::env`]) ; `claude` n'en a pas.
 ///
-/// Politique d'écriture : **fail-fast**. `prepare` tourne avant l'existence du
-/// conteneur ; une garantie intenable doit échouer là, pas produire un Run qui pend
-/// sur un dialogue sans personne devant. Ni le best-effort de
+/// Politique d'écriture : **fail-fast**. Une garantie intenable doit échouer au
+/// spawn, pas produire une session qui pend sur un dialogue sans personne devant. Ni le best-effort de
 /// [`copy_tree_preserving`] (arbre de 1 Go volatil) ni l'avalage de
 /// [`copy_jsonl_tree`] (transition terminale, ADR-0023) ne s'appliquent ici.
 fn apply_staging_set(
@@ -512,10 +672,14 @@ fn apply_staging_set(
 }
 
 /// Récupère les transcripts (`**/*.jsonl`) de **chaque puits déclaré par un staging
-/// set** ([`crate::harness_probes::staging_sets`] ; `claude` : `.claude/projects`)
-/// du staging vers `<home_root>/<puits>/`, **récursivement** (transcripts de sessions
-/// *et* de sous-agents `<uuid>/subagents/*.jsonl`), sous le même dirname encodé.
-/// Générique depuis ADR-0063 : aucun chemin de harnais n'est codé ici.
+/// set** ([`crate::harness_probes::staging_sets`] ; `claude` : `.claude/projects`,
+/// `pi` : `.pi/agent/sessions`) du staging vers `<home_root>/<puits>/`,
+/// **récursivement** (transcripts de sessions *et* de sous-agents
+/// `<uuid>/subagents/*.jsonl`), sous le même dirname encodé — pour `pi`, le nom du
+/// dossier dérive du cwd, identique dedans et dehors puisque le worktree est monté à
+/// son chemin absolu hôte (ADR-0030 ; ADR-0063 « limites »). Générique : aucun
+/// chemin de harnais n'est codé ici ; un puits jamais rempli (Run sans nœud de ce
+/// harnais) est un no-op.
 ///
 /// Idempotent : copie ssi le fichier hôte est **absent** OU **strictement plus
 /// petit** (transcripts append-only ⇒ `staging > hôte ⇔ contenu nouveau`). Ne
@@ -872,6 +1036,36 @@ fn atomic_copy_into(src: &Path, dst: &Path, dest_dir: &Path) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The pre-#708 shape of `prepare`, for the tests that pin `claude`'s five
+    /// guarantees: stage the profile, then fill `claude`'s set as the first claude
+    /// spawn of the Run would. New tests that care about the *moment* of the copy
+    /// call `prepare` and `fill_staging_set` separately.
+    fn prepare_and_fill(
+        home_root: &Path,
+        sandbox_root: &Path,
+        entries: &[String],
+        run_id: &str,
+        trusted_root: Option<&Path>,
+    ) -> Result<PathBuf> {
+        // Faithful to `ensure_ready`: `prepare` runs ONCE (gated on the staging dir),
+        // then `fill_staging_set` (marker-gated, idempotent) fills `claude`'s set as
+        // the first claude spawn would. Calling `prepare` unconditionally twice would
+        // re-copy the host `settings.json` over the merged one while the marker made
+        // the fill skip the bypass merge — a shape production never reaches.
+        let staging = staging_dir_for_run(sandbox_root, run_id);
+        if !staging.exists() {
+            prepare(home_root, sandbox_root, entries, run_id)?;
+        }
+        fill_staging_set(
+            home_root,
+            sandbox_root,
+            run_id,
+            crate::harness_registry::CLAUDE,
+            trusted_root,
+        )?;
+        Ok(staging)
+    }
     use std::os::unix::fs::PermissionsExt;
 
     // Un dirname encodé réaliste (cf. `stale_detector::encode_working_dir`) —
@@ -1008,7 +1202,7 @@ mod tests {
         let sandbox_dir = tempfile::tempdir().unwrap();
         fabricate_home(home_dir.path());
 
-        let staging = prepare(
+        let staging = prepare_and_fill(
             home_dir.path(),
             sandbox_dir.path(),
             &full_entries(),
@@ -1075,7 +1269,7 @@ mod tests {
         let sandbox_dir = tempfile::tempdir().unwrap();
         fabricate_home(home_dir.path());
 
-        prepare(
+        prepare_and_fill(
             home_dir.path(),
             sandbox_dir.path(),
             &full_entries(),
@@ -1111,7 +1305,7 @@ mod tests {
         write(&home_dir.path().join(".claude/settings.json"), "{}");
 
         // Ne doit pas paniquer / échouer sur les entrées absentes.
-        prepare(
+        prepare_and_fill(
             home_dir.path(),
             sandbox_dir.path(),
             &full_entries(),
@@ -1147,7 +1341,7 @@ mod tests {
         let sandbox_dir = tempfile::tempdir().unwrap();
         fabricate_home(home_dir.path());
 
-        prepare(
+        prepare_and_fill(
             home_dir.path(),
             sandbox_dir.path(),
             &full_entries(),
@@ -1201,7 +1395,7 @@ mod tests {
             .unwrap();
 
         // Ne panique pas / n'échoue pas malgré l'entrée cassée (D3).
-        prepare(
+        prepare_and_fill(
             home_dir.path(),
             sandbox_dir.path(),
             &full_entries(),
@@ -1226,7 +1420,7 @@ mod tests {
         fabricate_home(home_dir.path()); // `.claude.json` hôte porte `oauthAccount`
         let trusted = Path::new("/repo/root");
 
-        prepare(
+        prepare_and_fill(
             home_dir.path(),
             sandbox_dir.path(),
             &full_entries(),
@@ -1261,7 +1455,7 @@ mod tests {
         let sandbox_dir = tempfile::tempdir().unwrap();
         fabricate_home(home_dir.path()); // skills/settings existent → prouvent l'exclusion
 
-        prepare(home_dir.path(), sandbox_dir.path(), &[], "run1", None).unwrap();
+        prepare_and_fill(home_dir.path(), sandbox_dir.path(), &[], "run1", None).unwrap();
         let home = staged_claude_home(sandbox_dir.path(), "run1");
 
         // Ensemble EXACT (trié ASCII) = les fichiers du set, rien d'autre.
@@ -1308,7 +1502,7 @@ mod tests {
         );
         let trusted = Path::new("/repo/root");
 
-        prepare(
+        prepare_and_fill(
             home_dir.path(),
             sandbox_dir.path(),
             &[],
@@ -1335,7 +1529,7 @@ mod tests {
         let home_dir = tempfile::tempdir().unwrap();
         let sandbox_dir = tempfile::tempdir().unwrap();
 
-        prepare(home_dir.path(), sandbox_dir.path(), &[], "run1", None).unwrap();
+        prepare_and_fill(home_dir.path(), sandbox_dir.path(), &[], "run1", None).unwrap();
 
         let json: serde_json::Value = serde_json::from_str(
             &std::fs::read_to_string(staged_claude_json(sandbox_dir.path(), "run1")).unwrap(),
@@ -1357,7 +1551,7 @@ mod tests {
         let sandbox_dir = tempfile::tempdir().unwrap();
         fabricate_home(home_dir.path());
 
-        prepare(
+        prepare_and_fill(
             home_dir.path(),
             sandbox_dir.path(),
             &full_entries(),
@@ -1378,7 +1572,7 @@ mod tests {
         let sandbox_dir = tempfile::tempdir().unwrap();
         fabricate_home(home_dir.path());
 
-        prepare(home_dir.path(), sandbox_dir.path(), &[], "run1", None).unwrap();
+        prepare_and_fill(home_dir.path(), sandbox_dir.path(), &[], "run1", None).unwrap();
 
         let home = staged_claude_home(sandbox_dir.path(), "run1");
         assert_eq!(
@@ -1396,7 +1590,7 @@ mod tests {
         fabricate_home_without_org(home_dir.path());
 
         // Aucune erreur : l'absence est le cas majoritaire (`info!` + no-op).
-        prepare(
+        prepare_and_fill(
             home_dir.path(),
             sandbox_dir.path(),
             &full_entries(),
@@ -1418,7 +1612,7 @@ mod tests {
         let sandbox_dir = tempfile::tempdir().unwrap();
         fabricate_home_without_org(home_dir.path());
 
-        prepare(home_dir.path(), sandbox_dir.path(), &[], "run1", None).unwrap();
+        prepare_and_fill(home_dir.path(), sandbox_dir.path(), &[], "run1", None).unwrap();
 
         let home = staged_claude_home(sandbox_dir.path(), "run1");
         assert!(!home.join(REMOTE_SETTINGS_FILE).exists());
@@ -1439,7 +1633,7 @@ mod tests {
         let host_settings = home_dir.path().join(".claude").join(SETTINGS_FILE);
         write(&host_settings, r#"{"hooks":{"Stop":[]},"model":"opus"}"#);
 
-        prepare(
+        prepare_and_fill(
             home_dir.path(),
             sandbox_dir.path(),
             &full_entries(),
@@ -1468,7 +1662,7 @@ mod tests {
             &format!(r#"{{"{BYPASS_PERMISSIONS_KEY}":true,"model":"opus"}}"#),
         );
 
-        prepare(
+        prepare_and_fill(
             home_dir.path(),
             sandbox_dir.path(),
             &full_entries(),
@@ -1492,7 +1686,7 @@ mod tests {
             &format!(r#"{{"{BYPASS_PERMISSIONS_KEY}":false}}"#),
         );
 
-        prepare(
+        prepare_and_fill(
             home_dir.path(),
             sandbox_dir.path(),
             &full_entries(),
@@ -1514,7 +1708,7 @@ mod tests {
         let sandbox_dir = tempfile::tempdir().unwrap();
         fabricate_home_without_org(home_dir.path()); // aucun settings.json hôte
 
-        prepare(
+        prepare_and_fill(
             home_dir.path(),
             sandbox_dir.path(),
             &full_entries(),
@@ -1535,7 +1729,7 @@ mod tests {
         let sandbox_dir = tempfile::tempdir().unwrap();
         fabricate_home(home_dir.path()); // settings hôte riches (hooks)
 
-        prepare(home_dir.path(), sandbox_dir.path(), &[], "run1", None).unwrap();
+        prepare_and_fill(home_dir.path(), sandbox_dir.path(), &[], "run1", None).unwrap();
 
         // La phrase d'ADR-0031 §1 sous forme de test : la même garantie, satisfaite
         // par une synthèse ici et par un merge en `full`.
@@ -1557,7 +1751,7 @@ mod tests {
         // Dégradation GRACIEUSE (miroir du seed de trust) : en dur, un seul
         // caractère malformé dans `~/.claude/settings.json` empêcherait TOUT Run
         // sandboxé de démarrer.
-        prepare(
+        prepare_and_fill(
             home_dir.path(),
             sandbox_dir.path(),
             &full_entries(),
@@ -1582,7 +1776,7 @@ mod tests {
             "[1,2]",
         );
 
-        prepare(
+        prepare_and_fill(
             home_dir.path(),
             sandbox_dir.path(),
             &full_entries(),
@@ -1622,7 +1816,7 @@ mod tests {
             fabricate_home(home_dir.path());
             let trusted = Path::new("/repo/root");
 
-            prepare(
+            prepare_and_fill(
                 home_dir.path(),
                 sandbox_dir.path(),
                 entries,
@@ -1684,11 +1878,11 @@ mod tests {
         let trusted = Path::new("/repo/root");
         let (home_p, sandbox_p) = (home_dir.path(), sandbox_dir.path());
 
-        prepare(home_p, sandbox_p, &full_entries(), "run1", Some(trusted)).unwrap();
+        prepare_and_fill(home_p, sandbox_p, &full_entries(), "run1", Some(trusted)).unwrap();
         // Le conteneur (simulé) a écrit un transcript dans le puits.
         stage_transcript(sandbox_p, "run1", &format!("{ENC}/s.jsonl"), "line\n");
 
-        prepare(home_p, sandbox_p, &full_entries(), "run1", Some(trusted)).unwrap();
+        prepare_and_fill(home_p, sandbox_p, &full_entries(), "run1", Some(trusted)).unwrap();
 
         let home = staged_claude_home(sandbox_p, "run1");
         let settings = read_json(&home.join(SETTINGS_FILE));
@@ -1728,7 +1922,7 @@ mod tests {
         fabricate_home(home_dir.path());
 
         let entries = vec![".gitconfig".to_string(), ".config/gh".to_string()];
-        prepare(home_dir.path(), sandbox_dir.path(), &entries, "run1", None).unwrap();
+        prepare_and_fill(home_dir.path(), sandbox_dir.path(), &entries, "run1", None).unwrap();
 
         let extras = staged_home_extras(sandbox_dir.path(), "run1");
         assert_eq!(
@@ -1762,7 +1956,7 @@ mod tests {
         let gh = home_dir.path().join(".config/gh");
         std::os::unix::fs::symlink("hosts.yml", gh.join("alias.yml")).unwrap();
 
-        prepare(
+        prepare_and_fill(
             home_dir.path(),
             sandbox_dir.path(),
             &[".config/gh".to_string()],
@@ -1791,7 +1985,7 @@ mod tests {
         let sandbox_dir = tempfile::tempdir().unwrap();
         fabricate_home(home_dir.path());
 
-        prepare(
+        prepare_and_fill(
             home_dir.path(),
             sandbox_dir.path(),
             &[".not-here".to_string(), ".gitconfig".to_string()],
@@ -1884,7 +2078,7 @@ mod tests {
         // Avant `prepare` : rien sur disque → aucun mount (M1).
         assert!(extra_mounts(sandbox_dir.path(), "run1", host_home, &entries).is_empty());
 
-        prepare(home_dir.path(), sandbox_dir.path(), &entries, "run1", None).unwrap();
+        prepare_and_fill(home_dir.path(), sandbox_dir.path(), &entries, "run1", None).unwrap();
 
         // Après : la même liste gelée donne le mount, sans que `prepare` l'ait renvoyé.
         let after = extra_mounts(sandbox_dir.path(), "run1", host_home, &entries);
@@ -1909,7 +2103,7 @@ mod tests {
             "# nested\n",
         );
 
-        prepare(
+        prepare_and_fill(
             home_dir.path(),
             sandbox_dir.path(),
             &[".claude/*.md".to_string()],
@@ -1934,12 +2128,17 @@ mod tests {
         let sandbox_dir = tempfile::tempdir().unwrap();
         fabricate_home(home_dir.path());
 
-        prepare(home_dir.path(), sandbox_dir.path(), &[], "run1", None).unwrap();
+        prepare_and_fill(home_dir.path(), sandbox_dir.path(), &[], "run1", None).unwrap();
 
         let home = staged_claude_home(sandbox_dir.path(), "run1");
         assert!(!home.join("skills").exists());
         assert!(!home.join("CLAUDE.md").exists());
-        assert!(!staged_home_extras(sandbox_dir.path(), "run1").exists());
+        // No PROFILE extra was staged; the only thing under `home/` is the empty
+        // `.pi/agent` mount anchor (#708) — created empty, never a profile copy.
+        let extras = staged_home_extras(sandbox_dir.path(), "run1");
+        let pi_anchor = extras.join(".pi/agent");
+        assert!(pi_anchor.is_dir() && std::fs::read_dir(&pi_anchor).unwrap().next().is_none());
+        assert!(!extras.join(".gitconfig").exists() && !extras.join(".config").exists());
         // Plancher intact.
         assert!(home.join(".credentials.json").is_file());
         assert!(home.join("projects").is_dir());
@@ -2164,7 +2363,7 @@ mod tests {
         let sandbox_dir = tempfile::tempdir().unwrap();
         let (home, sandbox) = (home_dir.path(), sandbox_dir.path());
 
-        prepare(home, sandbox, &[], "run1", None).unwrap();
+        prepare_and_fill(home, sandbox, &[], "run1", None).unwrap();
         // Le conteneur (simulé) écrit un transcript dans le puits projects/.
         stage_transcript(sandbox, "run1", &format!("{ENC}/sess.jsonl"), "hello\n");
 

--- a/crates/pdo-daemon/src/stats.rs
+++ b/crates/pdo-daemon/src/stats.rs
@@ -1034,9 +1034,9 @@ pub(crate) async fn stats_cost(
     // not this one. The table's fingerprint is the memo's third key component, so a
     // sync is visible here without a daemon restart.
     let prices = crate::price_table::PriceTable::load(&home_root);
-    // Host-home stores of the reported-cost harnesses (`copilot`, `pi`): neither
-    // declares a staging set, so their files are read where the harness wrote them.
-    let stores = crate::sandbox_run::HarnessStores::from_home(&home_root);
+    // `copilot`'s store is always the host journal (no staging set); `pi`'s moves per
+    // Run (#708) — the staged sink while a sandboxed Run lives, the host store after
+    // merge-back — so `stores` is rebuilt inside the per-Run loop below, not here.
     let stored_projects = match crate::project_store::list(&state.db).await {
         Ok(projects) => projects,
         Err(error) => {
@@ -1091,6 +1091,13 @@ pub(crate) async fn stats_cost(
             });
         let projects_root =
             crate::sandbox_run::transcripts_root(sandboxed, &run_id, &home_root, &sandbox_root);
+        // #708: pi's store follows the same sandbox-aware seam as the Claude root.
+        let stores = crate::sandbox_run::HarnessStores::for_run(
+            sandboxed,
+            &run_id,
+            &home_root,
+            &sandbox_root,
+        );
         let events = match crate::load_events(&state.db, &run_id).await {
             Ok(events) => events,
             Err(error) => {

--- a/crates/pdo-daemon/src/stats_performance.rs
+++ b/crates/pdo-daemon/src/stats_performance.rs
@@ -824,6 +824,10 @@ struct RunContext {
     events: Vec<crate::event_log::Event>,
     claude_root: PathBuf,
     repo_root: PathBuf,
+    /// The reported-cost stores FOR THIS RUN (#708): `pi`'s follows the same
+    /// sandbox-aware seam as `claude_root` (staged sink while a sandboxed Run lives,
+    /// host store after merge-back), `copilot`'s is always the host journal.
+    stores: HarnessStores,
 }
 
 async fn compute_performance(
@@ -848,7 +852,6 @@ async fn compute_performance(
             let sandbox = home.join(".pdo").join("sandbox");
             (home, sandbox)
         });
-    let stores = HarnessStores::from_home(&home_root);
 
     let mut contexts: Vec<RunContext> = Vec::new();
     let mut key_hasher = DefaultHasher::new();
@@ -871,6 +874,8 @@ async fn compute_performance(
             });
         let claude_root =
             crate::sandbox_run::transcripts_root(sandboxed, &run_id, &home_root, &sandbox_root);
+        // #708: pi's store follows the same sandbox-aware seam as the Claude root.
+        let stores = HarnessStores::for_run(sandboxed, &run_id, &home_root, &sandbox_root);
 
         let events = crate::load_events(&state.db, &run_id)
             .await
@@ -895,6 +900,7 @@ async fn compute_performance(
             events,
             claude_root,
             repo_root,
+            stores,
         });
     }
     let key: PerformanceMemoKey = (from.to_string(), to.to_string(), key_hasher.finish());
@@ -911,7 +917,7 @@ async fn compute_performance(
     #[cfg(test)]
     record_recompute_for_test(&key);
 
-    let value = fold_performance(contexts, &stores)?;
+    let value = fold_performance(contexts)?;
 
     let mut guard = performance_memo()
         .lock()
@@ -926,10 +932,7 @@ async fn compute_performance(
 /// The heavy fold — every transcript read and subagent directory scan, gated
 /// behind the memo. Synchronous: events are already loaded into [`RunContext`],
 /// so nothing here touches `state.db` again.
-fn fold_performance(
-    contexts: Vec<RunContext>,
-    stores: &HarnessStores,
-) -> Result<StatsPerformance, PerformanceError> {
+fn fold_performance(contexts: Vec<RunContext>) -> Result<StatsPerformance, PerformanceError> {
     let mut seen_roots: HashSet<PathBuf> = HashSet::new();
     let mut pipelines: BTreeMap<String, PipelineAcc> = BTreeMap::new();
     let mut total_by_harness: BTreeMap<String, HarnessAcc> = BTreeMap::new();
@@ -944,6 +947,7 @@ fn fold_performance(
         events,
         claude_root,
         repo_root,
+        stores,
     } in contexts
     {
         let pipeline_id = payload
@@ -1058,7 +1062,7 @@ fn fold_performance(
                             &mut pipeline_acc.by_harness,
                             &mut total_by_harness,
                             &claude_root,
-                            stores,
+                            &stores,
                             &working_dir,
                             &p,
                             &event.ts,

--- a/crates/pdo-daemon/src/tmux_session_manager.rs
+++ b/crates/pdo-daemon/src/tmux_session_manager.rs
@@ -197,6 +197,13 @@ pub struct SandboxWrap<'a> {
     /// The node's working dir → `docker exec -w <workdir>` (the load-bearing cwd
     /// inside the container).
     pub workdir: &'a Path,
+    /// The env of the resolved harness's **staging set** (#708, ADR-0063 §1 —
+    /// `pi`: `PI_SKIP_VERSION_CHECK=1`, `PI_TELEMETRY=0`), forwarded on the exec as
+    /// explicit `-e K=V` **before** the per-node catalogue. The descriptor's own
+    /// `env` block is exported host-side and never crosses the exec, so this is the
+    /// only way a set's env reaches the container. Empty for `claude` (no env) ⇒ its
+    /// exec argv is byte-identical to before.
+    pub set_env: &'a [(String, String)],
 }
 
 /// Splice the container-exec prefix (from [`crate::sandbox_container`]) around a
@@ -210,6 +217,14 @@ fn wrap_tail_in_docker_exec(
     extra_env: &[(String, String)],
     base_tail: &str,
 ) -> String {
+    // #708: the staging set's env leads, then the per-node catalogue. Both are
+    // valued `-e K=V` on the exec — a host-side export would not cross it.
+    let exec_env: Vec<(String, String)> = wrap
+        .set_env
+        .iter()
+        .cloned()
+        .chain(extra_env.iter().cloned())
+        .collect();
     let mut argv = vec![wrap.docker_bin.to_string()];
     argv.extend(crate::sandbox_container::exec_prefix_with_env(
         run_id,
@@ -217,7 +232,7 @@ fn wrap_tail_in_docker_exec(
         wrap.gid,
         wrap.workdir,
         wrap.marker,
-        extra_env,
+        &exec_env,
     ));
     argv.push("bash".to_string());
     argv.push("-lc".to_string());
@@ -3701,6 +3716,7 @@ mod tests {
             gid: 1000,
             marker: "pdo-run-abc-solo-iter-1",
             workdir: Path::new("/wd"),
+            set_env: &[],
         };
         let script = build_tmux_script(
             "run-abc",
@@ -4270,7 +4286,78 @@ mod tests {
             gid: 1000,
             marker,
             workdir,
+            set_env: &[],
         }
+    }
+
+    /// #708: a staging set's env (pi's two vars) rides the exec as valued `-e K=V`,
+    /// before the catalogue and never as a host-side export; an empty set env leaves
+    /// the exec argv byte-identical (claude).
+    #[test]
+    fn sandbox_wrap_forwards_the_staging_set_env_on_the_exec() {
+        let harness = crate::harness_registry::pi();
+        let set_env = vec![
+            ("PI_SKIP_VERSION_CHECK".to_string(), "1".to_string()),
+            ("PI_TELEMETRY".to_string(), "0".to_string()),
+        ];
+        let wrap = SandboxWrap {
+            docker_bin: "docker",
+            uid: 1000,
+            gid: 1000,
+            marker: "pdo-run-abc-solo-iter-1",
+            workdir: Path::new("/wd"),
+            set_env: &set_env,
+        };
+        let tail = SessionTail::Agent {
+            harness: &harness,
+            model: None,
+            effort: None,
+            session_id: Some("sid-1"),
+        };
+        let with = build_tmux_script(
+            "run-abc",
+            "solo",
+            1,
+            5172,
+            TEST_SESSION_PATH,
+            Path::new("/wd/.pdo/prompts/solo.md"),
+            None,
+            tail,
+            Some(&wrap),
+            None,
+        );
+        let exec_at = with.find(" exec -i -t ").expect("a docker exec");
+        let container_at = with.find("pdo-sbx-run-abc").expect("the container name");
+        let exec_argv = &with[exec_at..container_at];
+        assert!(
+            exec_argv.contains("-e PI_SKIP_VERSION_CHECK=1 -e PI_TELEMETRY=0 --user 1000:1000"),
+            "the set env is valued `-e` pairs on the exec, before --user: {exec_argv}"
+        );
+
+        let bare = sample_wrap("pdo-run-abc-solo-iter-1", Path::new("/wd"));
+        let without = build_tmux_script(
+            "run-abc",
+            "solo",
+            1,
+            5172,
+            TEST_SESSION_PATH,
+            Path::new("/wd/.pdo/prompts/solo.md"),
+            None,
+            SessionTail::Agent {
+                harness: &harness,
+                model: None,
+                effort: None,
+                session_id: Some("sid-1"),
+            },
+            Some(&bare),
+            None,
+        );
+        let exec_at = without.find(" exec -i -t ").unwrap();
+        let container_at = without.find("pdo-sbx-run-abc").unwrap();
+        assert!(
+            !without[exec_at..container_at].contains("PI_TELEMETRY"),
+            "no set env ⇒ nothing added to the exec: {without}"
+        );
     }
 
     #[test]

--- a/crates/pdo-daemon/tests/sandbox_profiles.rs
+++ b/crates/pdo-daemon/tests/sandbox_profiles.rs
@@ -820,14 +820,22 @@ async fn an_entry_under_claude_adds_no_mount() {
     assert!(wait_until(|| log_text(&log).contains("create")).await);
 
     let specs = mount_specs(&log);
+    // The 4 FIXED mounts + pi's empty home root anchor (#708, ADR-0063 §3), which is a
+    // PDO mount, not a profile `$HOME` exception.
     assert_eq!(
         specs.len(),
-        4,
-        "only the 4 FIXED mounts (repo, claude-home, .claude.json, pdo bin); specs={specs:?}"
+        5,
+        "the 4 FIXED mounts + pi's home root; specs={specs:?}"
     );
     assert!(
-        !staged_extras(&daemon, &run_id).exists(),
-        "no `$HOME` exception ⇒ no <staging>/home at all"
+        specs.iter().any(|s| s.contains("/home/.pi/agent:")),
+        "pi's home root is mounted empty; specs={specs:?}"
+    );
+    // The only thing under `<staging>/home` is pi's anchor — no profile exception.
+    assert!(
+        staged_extras(&daemon, &run_id).join(".pi/agent").is_dir()
+            && !staged_extras(&daemon, &run_id).join(".gitconfig").exists(),
+        "no `$HOME` exception ⇒ nothing under <staging>/home but pi's anchor"
     );
 }
 

--- a/crates/pdo-daemon/tests/sandbox_tracer.rs
+++ b/crates/pdo-daemon/tests/sandbox_tracer.rs
@@ -268,6 +268,11 @@ async fn minimal_run_prepares_wraps_and_completes() {
     // is SYNTHESISED down to the bypass key — otherwise the session stalls on the
     // bypass-permissions prompt with nobody watching.
     let home = staged_home(&daemon, &run_id);
+    // #708: `claude`'s set is filled at the node's spawn — wait on its marker.
+    assert!(
+        wait_until(|| staged_set_marker(&daemon, &run_id, "claude").exists()).await,
+        "the claude set must be staged once the node is running"
+    );
     let settings: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(home.join("settings.json")).unwrap())
             .unwrap();
@@ -583,6 +588,19 @@ fn staged_home(daemon: &TestDaemon, run_id: &str) -> PathBuf {
         .join("claude-home")
 }
 
+/// The `<staging>/sets/<harness>` marker fill_staging_set writes AFTER copying the
+/// whole set (#708). Waiting on it is the reliable "the claude set is fully staged"
+/// signal — unlike `settings.json`, which the `full` profile copies during the eager
+/// prep, before the set is filled at the node's spawn.
+fn staged_set_marker(daemon: &TestDaemon, run_id: &str, harness: &str) -> PathBuf {
+    daemon
+        .repo_root()
+        .join(".pdo/sandbox")
+        .join(run_id)
+        .join("sets")
+        .join(harness)
+}
+
 fn staged_json(daemon: &TestDaemon, run_id: &str) -> PathBuf {
     daemon
         .repo_root()
@@ -627,9 +645,11 @@ async fn full_run_stages_allowlist_and_completes() {
     assert_eq!(run["nodes"][NODE_ID]["status"], "running", "run: {run}");
 
     let home = staged_home(&daemon, &run_id);
+    // #708: the claude set is filled at the node's SPAWN. Wait on its marker (written
+    // after the whole set) rather than settings.json, which `full` copies earlier.
     assert!(
-        wait_until(|| home.join("settings.json").is_file()).await,
-        "staged settings.json should exist once the node is running"
+        wait_until(|| staged_set_marker(&daemon, &run_id, "claude").exists()).await,
+        "the claude set must be staged once the node is running"
     );
 
     assert!(home.join("skills/foo/skill.md").is_file());
@@ -724,7 +744,7 @@ async fn minimal_run_stages_the_staging_set_against_a_fabricated_host() {
 
     let home = staged_home(&daemon, &run_id);
     assert!(
-        wait_until(|| home.join("settings.json").is_file()).await,
+        wait_until(|| staged_set_marker(&daemon, &run_id, "claude").exists()).await,
         "staging should be seeded once the node is running"
     );
 
@@ -781,9 +801,12 @@ async fn full_excludes_projects_and_bulky_host_state() {
     wait_node_status(&daemon, &run_id, "running").await;
 
     let home = staged_home(&daemon, &run_id);
+    // #708: the `projects/` sink is created by the claude set at the node's SPAWN
+    // (not by the eager prep). For `full`, `settings.json` arrives earlier via the
+    // profile copy, so wait on the fill-created sink, not on settings.json.
     assert!(
-        wait_until(|| home.join("settings.json").is_file()).await,
-        "staging should be seeded once the node is running"
+        wait_until(|| home.join("projects").is_dir()).await,
+        "the claude spawn must create the projects/ sink"
     );
 
     // Allowlist, not denylist.
@@ -842,12 +865,17 @@ async fn full_never_mounts_the_real_host_claude() {
             );
         }
     }
-    // The `full` default declares nothing outside `~/.claude`, so the extra-mount queue is
-    // empty: exactly the 4 fixed mounts.
+    // The `full` default declares nothing outside `~/.claude`, so the profile extra-mount
+    // queue is empty: the 4 fixed mounts + pi's empty home root anchor (#708), whose
+    // source is a staged path, never the host.
     assert_eq!(
         specs.len(),
-        4,
-        "`full` must add no `$HOME`-exception mount; specs={specs:?}"
+        5,
+        "`full` adds no `$HOME`-exception mount, only pi's home root; specs={specs:?}"
+    );
+    assert!(
+        specs.iter().any(|s| s.contains("/home/.pi/agent:")),
+        "pi's home root is mounted empty; specs={specs:?}"
     );
 }
 

--- a/docs/test-scenarios/HP-02-run-to-completion.md
+++ b/docs/test-scenarios/HP-02-run-to-completion.md
@@ -39,20 +39,20 @@ Features validated while crossing the run screens (grafted from retired per-issu
   business outcome by two visibly different routes. The `off` twin is the **control**: without it, a
   green sandboxed Run proves nothing (a Run that silently fell back to the host path also looks
   green). See the journey's §10-12 and the dedicated checks below.
-- **Agentic harness, as a three-way pin** (PRD #549 / #612, ADR-0045, ADR-0046, ADR-0051, ADR-0052):
-  a **three-node** pipeline runs one node pinned to **`claude`**, one to **`opencode`** and one to
-  **`copilot`** in the **same Run**. The set is the control, exactly as for the sandbox: a
-  single-harness Run that silently resolved to the `claude` floor is indistinguishable from a
-  correctly resolved one, so the other two are what make the four-tier resolution observable at all.
-  The three are also the whole spread of PDO's instrumentation in one Run — five capabilities, three,
-  and none — which is what the README's **Support** table publishes. See the journey's §14-16.
+- **Agentic harness, as a four-way pin** (PRD #549 / #612 / #702, ADR-0045, ADR-0046, ADR-0051,
+  ADR-0052, ADR-0063): a **four-node** pipeline runs one node pinned to **`claude`**, one to
+  **`opencode`**, one to **`copilot`** and one to **`pi`** in the **same Run**. The set is the
+  control, exactly as for the sandbox: a single-harness Run that silently resolved to the `claude`
+  floor is indistinguishable from a correctly resolved one, so the others are what make the four-tier
+  resolution observable at all. The four are also the whole spread of PDO's instrumentation in one Run
+  — which is what the README's **Support** table publishes. See the journey's §14-16.
 
 ## Preconditions
 
 - The app is running locally and reachable in a browser; status bar shows the daemon **connected**.
 - `claude` is on `PATH` (the daemon shells out to it for each node session).
-- `opencode` and `copilot` are on `PATH` too: the two other harnesses of the embedded floor
-  (ADR-0045), and the three-way pin needs all three binaries resident. `PATH` here means the
+- `opencode`, `copilot` and `pi` are on `PATH` too: the three other harnesses of the embedded floor
+  (ADR-0045), and the four-way pin needs all four binaries resident. `PATH` here means the
   **daemon's**, enriched from your login shell (ADR-0055) — a harness installed by a user package
   manager and invisible to a systemd service is the usual reason a pin fails to spawn.
 - Each harness is **logged in**, and the target repository's root has been **trusted once** for
@@ -98,20 +98,26 @@ Features validated while crossing the run screens (grafted from retired per-issu
     you go`) → it lists the floor entry by entry, and its **Image** control offers
     `default` / `dockerfile` / `registry`, the `default` option saying in one sentence that the tag is
     the SHA-256 of the seeded Dockerfile's bytes.
-14. **Three-way harness pin.** Seed a **three-node** pipeline: three parallel nodes, each asked for a
+14. **Four-way harness pin.** Seed a **four-node** pipeline: four parallel nodes, each asked for a
     single line of output. In the **node inspector**, pin the first node's harness to **`claude`**, the
-    second's to **`opencode`** and the third's to **`copilot`**; each node's inspector reads back which
-    harness it **resolves** to. On the `opencode` node, also set a **model** through the picker's
-    `Custom…` escape hatch — a `provider/model` slug that supports tool use (e.g.
+    second's to **`opencode`**, the third's to **`copilot`** and the fourth's to **`pi`**; each node's
+    inspector reads back which harness it **resolves** to. On the `opencode` node, also set a **model**
+    through the picker's `Custom…` escape hatch — a `provider/model` slug that supports tool use (e.g.
     `openrouter/anthropic/claude-haiku-4.5`). **This is not optional**, and the notes say why. On the
     `copilot` node, read the **effort** picker and **leave it alone**: its stops come from the
     installed binary (ADR-0053), and reading them is the cheapest proof the served catalogue reached
-    the UI. Its **model** control is a free-text field, not a list — see the checks.
+    the UI. Its **model** control is a free-text field, not a list — see the checks. On the `pi` node,
+    the effort picker offers pi's `--thinking` stops and the cost column is live (pi reports its cost
+    in dollars, #707).
 15. Open **New Run** on it. Set the Run's **Harness** field to **`claude`** and sandbox to **`off`**,
     then Launch. Setting the Run tier to `claude` is what turns the other two pins into a real proof:
-    they must still run `opencode` and `copilot` *against* the tier above them. All three nodes start,
-    all three reach **completed**, and the Run reaches **Completed** with the End `result` port
-    **received**: one Run, three harnesses, one outcome.
+    they must still run `opencode`, `copilot` and `pi` *against* the tier above them. All four nodes
+    start, all four reach **completed**, and the Run reaches **Completed** with the End `result` port
+    **received**: one Run, four harnesses, one outcome. Run it **sandboxed** too (a profile whose image
+    carries all four binaries): the `claude` and `pi` nodes both complete, and Stats shows a cost slice
+    for each **while the Run lives and after it ends** — pi's sessions are harvested back from the
+    container (ADR-0063). A sandboxed Run whose image lacks `pi` leaves the `pi` node **Interrupted**
+    with « binary absent from the image », said once in the Run.
 16. **The `copilot` node, end to end.** Watch that node specifically, without touching it: it starts,
     its pane shows an **interactive** `copilot` session (not a one-shot that exits), and when its turn
     ends the node goes **completed on its own** — nobody typed `pdo complete`, and no one attached.
@@ -162,9 +168,9 @@ Features validated while crossing the run screens (grafted from retired per-issu
   floor entry by entry, offers the three-way **Image** control, warns on credential-bearing entries,
   and lists a profile's referents before confirming its deletion.
 
-#### Harness three-way pin (steps 14-16)
+#### Harness four-way pin (steps 14-16)
 
-- The node inspector offers **Default / claude / opencode / copilot** and reads back the **resolved**
+- The node inspector offers **Default / claude / opencode / copilot / pi** and reads back the **resolved**
   harness, saying whether that is a **pin** or the **floor** ("Resolved: opencode (pinned)" vs
   "Resolved: claude (floor — no pin)").
 - Saving writes the pin as the node's own `pin_harness`, and the custom model under the **resolved

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -903,7 +903,8 @@ export interface RunState {
   /**
    * The machine slug companion of {@link awaiting_reason} (#601): a stable
    * snake_case code (`session_died`, `run_stalled`, `unrouted`,
-   * `region_exhausted`, `spawn_aborted`, `merge_conflict`, …) to branch on —
+   * `region_exhausted`, `spawn_aborted`, `harness_binary_missing`,
+   * `merge_conflict`, …) to branch on —
    * next to the human prose, the same slug+prose contract as a refusal body
    * (ADR-0035). Absent for an interactive wait.
    */


### PR DESCRIPTION
Closes #708 (story #702, spec #704, ADR-0063).

## What
- `pi` declares a staging set (`.pi/agent/` minus `sessions/`, env `PI_SKIP_VERSION_CHECK=1`, `PI_TELEMETRY=0`).
- Harness homes are mounted **empty** at container creation; a set is copied once per (Run, harness) at the spawn of the first node resolving that harness, behind a `<staging>/sets/<harness>` marker. Claude-only Runs never carry pi auth.
- Set env rides the `docker exec`; pi sessions are merged back to the host under the cwd-encoded dirname; cost/context read the staged sink while the Run lives.
- Sandboxed spawn probes the harness binary in the container: absent ⇒ one WARN per Run, node `Interrupted` with reason `harness_binary_missing`. No version check.
- README support table + prerequisite, HP-02 step 14 extended to four harnesses.

## Checks
- `cargo check --workspace`, clippy `-D warnings`: clean. `cargo test -p pdo-daemon --lib`: 2417 passed.
- FP #708 (playwright-cli, debug daemon, two sandbox profiles): **Pass** on the three scenarios. Non-blocking: Interrupted banner says "Session died —" although the spawn was aborted before start.

## Version
1.62.0 — `main` already carries 1.61.1 (in-app update line), so this line jumps past it. Expect a CHANGELOG/version conflict when `integration/702-pi-harness` goes to `main` (human merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)