### PR TITLE
feat(#720): provenance mécanique parent/enfant + endpoint enfants — 1.65.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ ascendante** : la casse se signale ici et par un bump majeur, jamais en gardant 
 morts. Seule contrainte non négociable — les **données historiques restent lisibles** : un Run
 archivé s'ouvre et se chiffre quelle que soit la version qui a écrit son payload.
 
+## 1.65.0
+
+**Un run créé depuis une session de nœud porte sa provenance mécaniquement** (#720 ; story #709,
+spec #719, ADR-0064). `POST /runs` lit l'identité de session (headers `X-PDO-Session-Run-Id` /
+`X-PDO-Session-Node-Id`, alimentés par `PDO_RUN_ID` / `PDO_NODE_ID` dans le sandbox) et, après
+vérification d'une session de nœud **vivante**, gèle `parent_run_id` + `parent_node_id` dans le
+`RunStarted` — la provenance ne se déclare jamais : toute clé de parent fournie dans le corps
+répond 400 en champ inconnu, et un claim invalide (run inconnu, nœud inconnu, nœud sans session
+vivante) répond 403 avant tout effet. Sans claim, le run est racine ; le projet de l'enfant vaut
+par défaut celui du parent, overridable explicitement, sans héritage spécial sandbox/harnais.
+`RunState` et la liste de runs projettent les deux champs, et le nouvel endpoint
+`GET /runs/{id}/children` groupe les enfants par nœud parent avec statut, `started_at`,
+`completed_at` et coût **dérivé à la lecture** via le cache existant (jamais persisté, ADR-0052 —
+indisponible ⇒ clé absente, jamais `$0`). Un enfant reste un run ordinaire : il s'ouvre dans
+l'éditeur avec son propre graphe.
+
 ## 1.64.0
 
 **Le skill `pdo-orchestrate` est semé dans la Banque de skills** (#722). Premier mécanisme de

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "1.64.0"
+version = "1.65.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "1.64.0"
+version = "1.65.0"
 license = "MIT"
 description = "Prompt-Driven Orchestrator — a local daemon that runs and supervises agentic coding pipelines"
 repository = "https://github.com/Loulen/prompt-driven-orchestrator"

--- a/crates/pdo-daemon/src/event_log.rs
+++ b/crates/pdo-daemon/src/event_log.rs
@@ -1093,6 +1093,19 @@ pub struct RunState {
     /// Provenance: the id of the Trigger that created this Run, if any.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub triggered_by: Option<String>,
+    /// Provenance: the Run whose node session created this one (ADR-0064).
+    /// **Mechanical**: posed by the daemon at create time from the caller's
+    /// verified live node session — never declared by the caller, whose body may
+    /// not even carry a parent field. `None` on a **root run** — every historical
+    /// Run, and any Run created outside a node session. Immutable, like
+    /// [`RunState::triggered_by`]: frozen into `RunStarted`, never mutated.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_run_id: Option<String>,
+    /// The parent Run's node whose session created this Run (ADR-0064) — the key
+    /// `GET /runs/{id}/children` groups by. Frozen with
+    /// [`RunState::parent_run_id`], same posture.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_node_id: Option<String>,
     /// The library pipeline id this Run was created from (#377). Written to the
     /// `RunStarted` payload going forward; consumers (aggregated "by pipeline"
     /// stats) fall back to `pipeline_name` when it is absent — historical runs,
@@ -1164,6 +1177,8 @@ impl RunState {
             skills: Vec::new(),
             auto_fail: None,
             triggered_by: None,
+            parent_run_id: None,
+            parent_node_id: None,
             pipeline_id: None,
             sessions_spawned: 0,
             loc: None,
@@ -1785,6 +1800,14 @@ fn apply_run_event(state: &mut RunState, event: &Event) {
                 }
                 if let Some(tb) = payload.get("triggered_by").and_then(|v| v.as_str()) {
                     state.triggered_by = Some(tb.to_string());
+                }
+                // ADR-0064: the mechanical parent provenance the daemon froze at
+                // create. Absent keys ⇒ a root run (every historical Run).
+                if let Some(pr) = payload.get("parent_run_id").and_then(|v| v.as_str()) {
+                    state.parent_run_id = Some(pr.to_string());
+                }
+                if let Some(pn) = payload.get("parent_node_id").and_then(|v| v.as_str()) {
+                    state.parent_node_id = Some(pn.to_string());
                 }
                 if let Some(pid) = payload.get("pipeline_id").and_then(|v| v.as_str()) {
                     state.pipeline_id = Some(pid.to_string());
@@ -3249,6 +3272,33 @@ mod tests {
         assert_eq!(state.sandbox, SandboxMode::Profile("full".into()));
         assert_eq!(state.sandbox_entries, None);
         assert_eq!(state.sandbox_entries_raw_error, None);
+    }
+
+    /// ADR-0064: the mechanical parent provenance is projected when the payload
+    /// carries it, and stays `None` on every historical payload (a root run).
+    #[test]
+    fn parent_provenance_projects_from_run_started_and_defaults_to_root() {
+        let with_parent = vec![make_event_with_payload(
+            EventKind::RunStarted,
+            None,
+            serde_json::json!({
+                "pipeline_name": "p",
+                "parent_run_id": "run-parent",
+                "parent_node_id": "worker",
+            }),
+        )];
+        let state = project(&with_parent).unwrap();
+        assert_eq!(state.parent_run_id.as_deref(), Some("run-parent"));
+        assert_eq!(state.parent_node_id.as_deref(), Some("worker"));
+
+        let legacy = vec![make_event_with_payload(
+            EventKind::RunStarted,
+            None,
+            serde_json::json!({ "pipeline_name": "p" }),
+        )];
+        let state = project(&legacy).unwrap();
+        assert_eq!(state.parent_run_id, None);
+        assert_eq!(state.parent_node_id, None);
     }
 
     /// A present-but-unreadable list keeps its RAW value, so the prep can name it in the

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -670,6 +670,13 @@ struct RunListEntry {
     /// Provenance: the Trigger that created this Run, if any.
     #[serde(skip_serializing_if = "Option::is_none")]
     triggered_by: Option<String>,
+    /// Provenance: the parent Run + node whose session created this Run
+    /// (ADR-0064) — the key the "orchestrated" badge and the "root runs only"
+    /// filter read. `None` on a root run. Mechanical: never caller-declared.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    parent_run_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    parent_node_id: Option<String>,
     /// Resolved target repo for "group by project": the run's `target_repo`, or
     /// the daemon's `repo_root` when unset. Only runs predating the hardened
     /// create boundary (ADR-0033) can be unset — this is a READ, so keep the
@@ -4104,6 +4111,7 @@ fn build_router(state: Arc<AppState>) -> Router {
         .route("/runs/reapable", get(list_reapable_runs))
         .route("/sessions", get(sessions))
         .route("/runs/{run_id}", get(get_run).delete(forget_run))
+        .route("/runs/{run_id}/children", get(list_run_children))
         .route("/runs/{run_id}/events", get(get_run_events))
         .route("/runs/{run_id}/nodes/{node_id}/done", post(node_done))
         .route("/runs/{run_id}/nodes/{node_id}/fail", post(node_fail))
@@ -5594,7 +5602,7 @@ async fn fire_one_trigger(
                 auto_fail: None,
                 provisioning: provisioning::ProvisioningRules::default(),
             };
-            let record = match create_run_inner(state, req, Vec::new()).await {
+            let record = match create_run_inner(state, req, Vec::new(), None).await {
                 Ok(run_id) => trigger_store::FireRecord {
                     outcome: "fired".to_string(),
                     reason: None,
@@ -7817,7 +7825,80 @@ async fn parse_multipart_create_run(
     Ok((req, images))
 }
 
+/// The session identity a `POST /runs` caller carries via the
+/// `X-PDO-Session-Run-Id` / `X-PDO-Session-Node-Id` headers — the exact values
+/// of the `PDO_RUN_ID` / `PDO_NODE_ID` env vars every node session is wrapped
+/// with (`tmux_session_manager::wrap_with_env`). Never a body field: provenance
+/// is mechanical (ADR-0064), so the daemon — not the caller — decides the
+/// parent, and any parent key in the body is refused as unknown.
+#[derive(Debug, Clone)]
+struct SessionClaim {
+    run_id: String,
+    node_id: String,
+}
+
+const SESSION_RUN_HEADER: &str = "X-PDO-Session-Run-Id";
+const SESSION_NODE_HEADER: &str = "X-PDO-Session-Node-Id";
+
+/// Read the session claim from the request headers. Only a pair of non-empty
+/// values is a claim — a lone header is not (the caller is out of session).
+fn session_claim_from_headers(headers: &HeaderMap) -> Option<SessionClaim> {
+    let run_id = headers
+        .get(SESSION_RUN_HEADER)
+        .and_then(|v| v.to_str().ok())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())?;
+    let node_id = headers
+        .get(SESSION_NODE_HEADER)
+        .and_then(|v| v.to_str().ok())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())?;
+    Some(SessionClaim {
+        run_id: run_id.to_string(),
+        node_id: node_id.to_string(),
+    })
+}
+
+/// Verify a session claim for mechanical provenance (ADR-0064) and hand back the
+/// claimed parent Run's projected state — the child's project defaults to it.
+///
+/// The session is the only witness the provenance trusts, and the daemon knows
+/// it already: a claim is accepted only when the named Run projects a node that
+/// **currently holds a live session** ([`event_log::NodeStatus::holds_session`]).
+/// A stale or invented claim is refused before any effect — no worktree, no
+/// event. A claim on a node that is `Waiting` (admission-throttled) is refused
+/// too: no session exists there to speak.
+async fn verify_session_claim(
+    state: &Arc<AppState>,
+    claim: &SessionClaim,
+) -> Result<event_log::RunState, (StatusCode, serde_json::Value)> {
+    let refuse = |msg: String| (StatusCode::FORBIDDEN, serde_json::json!({ "error": msg }));
+    let Some((_, parent)) = reload_run_state_with(&state.db, &claim.run_id).await else {
+        return Err(refuse(format!(
+            "session claim refused: run `{}` does not exist (or has no run log)",
+            claim.run_id
+        )));
+    };
+    let Some(node) = parent.nodes.get(&claim.node_id) else {
+        return Err(refuse(format!(
+            "session claim refused: run `{}` has no node `{}`",
+            claim.run_id, claim.node_id
+        )));
+    };
+    if !node.status.holds_session() {
+        return Err(refuse(format!(
+            "session claim refused: node `{}` of run `{}` holds no live session \
+             (status: {:?}); provenance follows a live node session",
+            claim.node_id, claim.run_id, node.status
+        )));
+    }
+    Ok(parent)
+}
+
 async fn create_run(State(state): State<Arc<AppState>>, req: axum::extract::Request) -> Response {
+    // ADR-0064: read the session claim BEFORE the body is consumed — identity
+    // travels in headers, never in the body (whose parent fields are refused).
+    let session = session_claim_from_headers(req.headers());
     let content_type = req
         .headers()
         .get(header::CONTENT_TYPE)
@@ -7885,7 +7966,7 @@ async fn create_run(State(state): State<Arc<AppState>>, req: axum::extract::Requ
         (parsed, Vec::new())
     };
 
-    create_run_core(&state, parsed_req, images).await
+    create_run_core(&state, parsed_req, images, session).await
 }
 
 /// Validate the user input against the pipeline's `prompt_required` flag. A
@@ -7936,8 +8017,9 @@ async fn create_run_core(
     state: &Arc<AppState>,
     req: CreateRunRequest,
     images: Vec<ImageFile>,
+    session: Option<SessionClaim>,
 ) -> Response {
-    match create_run_inner(state, req, images).await {
+    match create_run_inner(state, req, images, session).await {
         Ok(run_id) => (StatusCode::CREATED, Json(CreateRunResponse { run_id })).into_response(),
         Err((status, body)) => (status, Json(body)).into_response(),
     }
@@ -7946,12 +8028,22 @@ async fn create_run_core(
 /// The Run-creation logic, returning the new `run_id` on success or a
 /// `(status, body)` pair on failure. `create_run_core` wraps this into an HTTP
 /// `Response`; the trigger scheduler calls it directly to learn the run id for
-/// `triggered_by` provenance.
+/// `triggered_by` provenance — with `session: None`, a fired Run is always a
+/// root (a Trigger is not a node session).
 async fn create_run_inner(
     state: &Arc<AppState>,
     req: CreateRunRequest,
     images: Vec<ImageFile>,
+    session: Option<SessionClaim>,
 ) -> Result<String, (StatusCode, serde_json::Value)> {
+    // ADR-0064: provenance is mechanical. Verify the session claim FIRST — before
+    // any effect (worktree, snapshots, event) — and keep the parent's projected
+    // state: the child's project defaults to it when the request names none.
+    let parent = match &session {
+        Some(claim) => Some(verify_session_claim(state, claim).await?),
+        None => None,
+    };
+
     // The target repo is REQUIRED at the creation boundary (ADR-0033): the daemon's
     // own `repo_root` stays its storage root but is never an implicit Run target, or
     // a Run mutates code in a repository nobody named. The read side keeps its
@@ -7960,6 +8052,11 @@ async fn create_run_inner(
     // Normalise the multi-repo shape down to the scalar here, so the ENTIRE
     // downstream primary path (worktree, merge-back, cost) stays unchanged and the
     // array only ever ADDS secondaries.
+    //
+    // One exception, itself mechanical (ADR-0064): a Run created from a node
+    // session defaults to the PARENT's project when the request names none — an
+    // orchestrated child is an ordinary run whose common case inherits the
+    // orchestrator's repo. An explicit `target_repo`/`target_repos` always wins.
     let effective_target_repo: Option<String> = req
         .target_repo
         .clone()
@@ -7969,6 +8066,11 @@ async fn create_run_inner(
                 .first()
                 .map(|r| r.repo.clone())
                 .filter(|s| !s.trim().is_empty())
+        })
+        .or_else(|| {
+            parent
+                .as_ref()
+                .map(|p| effective_repo_root(state, p).to_string_lossy().into_owned())
         });
     let run_repo_root = match required_target_repo(effective_target_repo.as_deref()) {
         Ok(p) => p,
@@ -8430,6 +8532,14 @@ async fn create_run_inner(
         if !trigger_id.is_empty() {
             run_payload["triggered_by"] = serde_json::json!(trigger_id);
         }
+    }
+    // ADR-0064: FREEZE the mechanical parent provenance — decided by the daemon
+    // from the verified session claim, never read from the body (which refuses
+    // any parent key outright). Written ONLY when the create came from a live
+    // node session, so an out-of-session create keeps the historical root shape.
+    if let (Some(parent), Some(claim)) = (&parent, &session) {
+        run_payload["parent_run_id"] = serde_json::json!(parent.run_id);
+        run_payload["parent_node_id"] = serde_json::json!(claim.node_id);
     }
     // Carry the library pipeline id so aggregated "by pipeline" stats survive a
     // pipeline rename. The consumer falls back to `pipeline_name` when absent.
@@ -12184,6 +12294,8 @@ async fn list_runs(State(state): State<Arc<AppState>>) -> Response {
                 awaiting_reason_code: run_state.awaiting_reason_code,
                 name: run_state.name,
                 triggered_by: run_state.triggered_by,
+                parent_run_id: run_state.parent_run_id,
+                parent_node_id: run_state.parent_node_id,
                 effective_repo,
             });
         }
@@ -12439,6 +12551,165 @@ fn inject_frozen_node_provisioning(response: &mut serde_json::Value, events: &[e
             }
         }
     }
+}
+
+/// One child Run of `GET /runs/{run_id}/children` — the read model the
+/// Orchestration view consumes. Ordinary projection fields, plus a cost
+/// **derived on read** through the cost cache, never persisted (ADR-0052):
+/// `None` means unavailable and the surface renders "—", never `$0`.
+#[derive(Serialize)]
+struct RunChildEntry {
+    run_id: String,
+    pipeline_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
+    status: event_log::RunStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    started_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    completed_at: Option<String>,
+    /// Derived on read via the cost cache (ADR-0052) — never persisted. Absent
+    /// (JSON `null`/omitted) when the cost is unavailable: the surface renders
+    /// "—", never `$0`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cost: Option<event_log::CostStat>,
+}
+
+/// One group of `GET /runs/{run_id}/children`: all children spawned by ONE
+/// node's sessions of the parent Run. `node_id: None` groups the (theoretically
+/// impossible but tolerated) children whose `RunStarted` carried no node id —
+/// grouped last, never dropped.
+#[derive(Serialize)]
+struct RunChildrenGroup {
+    node_id: Option<String>,
+    children: Vec<RunChildEntry>,
+}
+
+#[derive(Serialize)]
+struct RunChildrenResponse {
+    run_id: String,
+    nodes: Vec<RunChildrenGroup>,
+}
+
+/// `GET /runs/{run_id}/children` — the dedicated children read (ADR-0064):
+/// every Run whose mechanical `parent_run_id` is this Run, grouped by parent
+/// node, in the parent's node-definition order (unknown/absent node last),
+/// children chronological within a group. Cost and duration live HERE, not on
+/// `GET /runs` — the global list stays cheap (ADR-0052: derived on read, never
+/// persisted).
+async fn list_run_children(
+    State(state): State<Arc<AppState>>,
+    AxumPath(run_id): AxumPath<String>,
+) -> Response {
+    // The parent must exist, so a typo'd id is a 404 — not a silent empty list
+    // (which would be indistinguishable from a childless Run).
+    let Some((_, parent_state)) = reload_run_state_with(&state.db, &run_id).await else {
+        return (StatusCode::NOT_FOUND, "run not found").into_response();
+    };
+
+    let run_ids = match load_all_run_ids(&state.db).await {
+        Ok(ids) => ids,
+        Err(e) => {
+            return (StatusCode::INTERNAL_SERVER_ERROR, format!("error: {e}")).into_response();
+        }
+    };
+
+    let mut by_node: HashMap<Option<String>, Vec<RunChildEntry>> = HashMap::new();
+    for child_id in run_ids {
+        if child_id == run_id {
+            continue;
+        }
+        let events = match load_events(&state.db, &child_id).await {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        let Some(child) = event_log::project(&events) else {
+            continue;
+        };
+        if child.parent_run_id.as_deref() != Some(run_id.as_str()) {
+            continue;
+        }
+        let cost = derive_run_cost(&state, &child, &events);
+        let entry = RunChildEntry {
+            run_id: child.run_id,
+            pipeline_name: child.pipeline_name,
+            name: child.name,
+            status: child.status,
+            started_at: child.started_at,
+            completed_at: child.completed_at,
+            cost,
+        };
+        by_node.entry(child.parent_node_id).or_default().push(entry);
+    }
+
+    // Group order: the parent's own node-definition order, so the response reads
+    // like the pipeline; a group keyed by an unknown or absent node id lands last.
+    let mut nodes: Vec<RunChildrenGroup> = Vec::new();
+    let mut seen: std::collections::HashSet<Option<String>> = Default::default();
+    let mut push_group = |node_id: Option<String>, by_node: &mut HashMap<_, _>| {
+        if !seen.insert(node_id.clone()) {
+            return;
+        }
+        let mut children: Vec<RunChildEntry> = by_node.remove(&node_id).unwrap_or_default();
+        if children.is_empty() {
+            return;
+        }
+        children.sort_by(|a, b| match (&a.started_at, &b.started_at) {
+            (Some(x), Some(y)) => x.cmp(y),
+            (Some(_), None) => std::cmp::Ordering::Less,
+            (None, Some(_)) => std::cmp::Ordering::Greater,
+            (None, None) => std::cmp::Ordering::Equal,
+        });
+        nodes.push(RunChildrenGroup { node_id, children });
+    };
+    for def in &parent_state.node_defs {
+        push_group(Some(def.id.clone()), &mut by_node);
+    }
+    let mut leftover_keys: Vec<Option<String>> = by_node.keys().cloned().collect();
+    leftover_keys.sort();
+    for key in leftover_keys {
+        push_group(key, &mut by_node);
+    }
+
+    Json(RunChildrenResponse { run_id, nodes }).into_response()
+}
+
+/// Derive a Run's USD cost on read via the cost cache — the same fold
+/// `GET /runs/{id}` augments its state with, WITHOUT the LOC walk. `None` ⇒ the
+/// surface renders "—", never `$0` (ADR-0052). Not a wrapper that hides the
+/// injected roots: every input stays an explicit argument at the call edge.
+fn derive_run_cost(
+    state: &AppState,
+    run_state: &event_log::RunState,
+    events: &[event_log::Event],
+) -> Option<event_log::CostStat> {
+    let (home_root, sandbox_root) = sandbox_run::sandbox_home_roots(state).unwrap_or_else(|_| {
+        let home = std::path::PathBuf::from(std::env::var("HOME").unwrap_or_default());
+        let sandbox = home.join(".pdo").join("sandbox");
+        (home, sandbox)
+    });
+    let projects_root = sandbox_run::transcripts_root(
+        !run_state.sandbox.is_off(),
+        &run_state.run_id,
+        &home_root,
+        &sandbox_root,
+    );
+    let prices = price_table::PriceTable::load(&home_root);
+    let stores = sandbox_run::HarnessStores::for_run(
+        !run_state.sandbox.is_off(),
+        &run_state.run_id,
+        &home_root,
+        &sandbox_root,
+    );
+    run_cost::compute_run_cost_breakdown_cached(
+        events,
+        &projects_root,
+        &stores,
+        &effective_repo_root(state, run_state),
+        &run_state.run_id,
+        &prices,
+    )
+    .cost
 }
 
 async fn get_run_events(

--- a/crates/pdo-daemon/src/run_command.rs
+++ b/crates/pdo-daemon/src/run_command.rs
@@ -2116,7 +2116,9 @@ async fn dispatch(state: Arc<AppState>, run_id: String, cmd: RunCommand) -> Resp
                     .map(|scoped| scoped.rules.clone())
                     .unwrap_or_default(),
             };
-            let new_run_resp = create_run_core(&state, new_run_req, Vec::new()).await;
+            // ADR-0064: a retried Run is created by the daemon, not from a node
+            // session — it is a root even when the archived original had a parent.
+            let new_run_resp = create_run_core(&state, new_run_req, Vec::new(), None).await;
 
             info!("retry_all: archived run {run_id}, created new run");
             new_run_resp

--- a/crates/pdo-daemon/tests/it.rs
+++ b/crates/pdo-daemon/tests/it.rs
@@ -145,6 +145,9 @@ mod run_shell;
 #[path = "runs_list_target_repo.rs"]
 mod runs_list_target_repo;
 
+#[path = "run_provenance.rs"]
+mod run_provenance;
+
 #[path = "sandbox_observability.rs"]
 mod sandbox_observability;
 

--- a/crates/pdo-daemon/tests/run_provenance.rs
+++ b/crates/pdo-daemon/tests/run_provenance.rs
@@ -1,0 +1,510 @@
+//! Layer 3a — mechanical parent provenance + children endpoint (issue #720,
+//! ADR-0064). Boots a real daemon and probes its HTTP surface:
+//!
+//! - A run created via `POST /runs` **from a live node session** (the
+//!   `X-PDO-Session-Run-Id` / `X-PDO-Session-Node-Id` headers, same values as
+//!   the `PDO_RUN_ID` / `PDO_NODE_ID` env vars a node is wrapped with) carries
+//!   `parent_run_id` + `parent_node_id` on `GET /runs/{id}` and `GET /runs` —
+//!   and its project defaults to the parent's (ADR-0033: still a required
+//!   boundary, so the default is the PARENT's repo, never the daemon root).
+//! - A body declaring a parent (`parent_run_id` / `parent_node_id`) is refused
+//!   with a named `400` — provenance is never declarable.
+//! - A session claim that names no live node session is refused `403` before
+//!   any effect; a create without a claim is a root run (no parent fields).
+//! - `GET /runs/{id}/children` lists children grouped by parent node with
+//!   status, `started_at`, `completed_at` and a read-derived cost (absent here,
+//!   rendered "—" — never `$0`, ADR-0052); a childless run returns an empty
+//!   list and an unknown run a `404`.
+
+use crate::common::TestDaemon;
+
+const PIPELINE_NAME: &str = "provenance-test";
+const PIPELINE_YAML: &str = r#"name: provenance-test
+version: "1.0"
+nodes:
+  - id: start
+    name: Start
+    type: start
+    outputs:
+      - name: user_prompt
+  - id: worker
+    name: worker
+    type: agent
+    isolated_worktree: false
+    inputs:
+      - name: task
+    outputs:
+      - name: result
+    view: { x: 200, y: 100 }
+  - id: end
+    name: End
+    type: end
+    inputs:
+      - name: result
+edges:
+  - source: { node: start, port: user_prompt }
+    target: { node: worker, port: task }
+"#;
+
+const CHILD_PIPELINE_NAME: &str = "provenance-child";
+const CHILD_PIPELINE_YAML: &str = r#"name: provenance-child
+version: "1.0"
+nodes:
+  - id: start
+    name: Start
+    type: start
+    outputs:
+      - name: user_prompt
+  - id: end
+    name: End
+    type: end
+    inputs:
+      - name: result
+edges:
+  - source: { node: start, port: user_prompt }
+    target: { node: end, port: result }
+"#;
+
+fn git_init_with_commit(repo: &std::path::Path) -> anyhow::Result<()> {
+    let run = |args: &[&str]| -> anyhow::Result<()> {
+        let out = std::process::Command::new("git")
+            .args(args)
+            .current_dir(repo)
+            .output()?;
+        if !out.status.success() {
+            anyhow::bail!(
+                "git {:?} failed: {}",
+                args,
+                String::from_utf8_lossy(&out.stderr)
+            );
+        }
+        Ok(())
+    };
+    run(&["init", "-q", "-b", "main"])?;
+    run(&["config", "user.email", "test@example.com"])?;
+    run(&["config", "user.name", "Test"])?;
+    run(&["config", "commit.gpgsign", "false"])?;
+    std::fs::write(repo.join(".gitignore"), ".pdo/runs/\n")?;
+    run(&["add", "."])?;
+    run(&["commit", "-q", "-m", "init"])?;
+    Ok(())
+}
+
+fn seed(repo: &std::path::Path) -> anyhow::Result<()> {
+    let pipelines_dir = repo.join(".pdo").join("pipelines");
+    std::fs::create_dir_all(&pipelines_dir)?;
+    std::fs::write(
+        pipelines_dir.join(format!("{PIPELINE_NAME}.yaml")),
+        PIPELINE_YAML,
+    )?;
+    let prompts_dir = pipelines_dir.join(format!("{PIPELINE_NAME}.prompts"));
+    std::fs::create_dir_all(&prompts_dir)?;
+    std::fs::write(prompts_dir.join("worker.md"), "You are a worker.\n")?;
+    std::fs::write(
+        pipelines_dir.join(format!("{CHILD_PIPELINE_NAME}.yaml")),
+        CHILD_PIPELINE_YAML,
+    )?;
+    git_init_with_commit(repo)?;
+    Ok(())
+}
+
+/// The distinct repo every create names explicitly (the boundary ADR-0033 keeps).
+fn other_repo() -> anyhow::Result<String> {
+    let repo = tempfile::tempdir()?;
+    git_init_with_commit(repo.path())?;
+    let path = repo.path().to_string_lossy().to_string();
+    // Leak the tempdir: the daemon reads the repo later (worktree creation).
+    std::mem::forget(repo);
+    Ok(path)
+}
+
+async fn create_root_run(daemon: &TestDaemon) -> String {
+    let body = serde_json::json!({
+        "pipeline": PIPELINE_NAME,
+        "input": "hello world",
+        "target_repo": daemon.target_repo(),
+    });
+    let resp = reqwest::Client::new()
+        .post(format!("{}/runs", daemon.url()))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 201, "POST /runs should return 201");
+    let json: serde_json::Value = resp.json().await.unwrap();
+    json["run_id"].as_str().unwrap().to_string()
+}
+
+async fn get_json(daemon: &TestDaemon, path: &str) -> (u16, serde_json::Value) {
+    let resp = reqwest::get(format!("{}{}", daemon.url(), path))
+        .await
+        .unwrap();
+    let status = resp.status().as_u16();
+    let json: serde_json::Value = resp.json().await.unwrap();
+    (status, json)
+}
+
+/// Post a create-run body with the given session headers.
+async fn post_run(
+    daemon: &TestDaemon,
+    body: serde_json::Value,
+    session: Option<(&str, &str)>,
+) -> reqwest::Response {
+    let mut req = reqwest::Client::new()
+        .post(format!("{}/runs", daemon.url()))
+        .json(&body);
+    if let Some((run_id, node_id)) = session {
+        req = req
+            .header("X-PDO-Session-Run-Id", run_id)
+            .header("X-PDO-Session-Node-Id", node_id);
+    }
+    req.send().await.unwrap()
+}
+
+/// Wait until the node projects as Running (its tmux session holds).
+async fn wait_node_running(daemon: &TestDaemon, run_id: &str, node_id: &str) {
+    for _ in 0..100 {
+        let (status, run) = get_json(daemon, &format!("/runs/{run_id}")).await;
+        assert_eq!(status, 200);
+        if run["nodes"][node_id]["status"] == "running" {
+            return;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+    panic!("node {node_id} of run {run_id} never reached `running`");
+}
+
+/// Wait for the parent's `worker` node to hold a live session. The scheduler
+/// spawns it once the start node completes; the TestDaemon's tmux override
+/// (`exec sleep 600`) keeps the session alive indefinitely.
+async fn start_worker(daemon: &TestDaemon, run_id: &str) {
+    wait_node_running(daemon, run_id, "worker").await;
+}
+
+#[tokio::test]
+async fn child_run_from_node_session_carries_mechanical_parent() {
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+    let parent = create_root_run(&daemon).await;
+    start_worker(&daemon, &parent).await;
+
+    // Created FROM the worker's session, with NO target_repo: the child's
+    // project defaults to the parent's (spec #719: project du parent par
+    // défaut), never to the daemon root (ADR-0033 keeps the boundary).
+    let resp = post_run(
+        &daemon,
+        serde_json::json!({
+            "pipeline": CHILD_PIPELINE_NAME,
+            "input": "child work",
+        }),
+        Some((&parent, "worker")),
+    )
+    .await;
+    assert_eq!(resp.status(), 201, "session-backed create should succeed");
+    let child: serde_json::Value = resp.json().await.unwrap();
+    let child_id = child["run_id"].as_str().unwrap().to_string();
+
+    // GET /runs/{id} exposes the mechanical provenance.
+    let (status, run) = get_json(&daemon, &format!("/runs/{child_id}")).await;
+    assert_eq!(status, 200);
+    assert_eq!(
+        run["parent_run_id"], parent,
+        "parent_run_id is the session's run"
+    );
+    assert_eq!(
+        run["parent_node_id"], "worker",
+        "parent_node_id is the session's node"
+    );
+    assert_eq!(
+        run["target_repo"],
+        daemon.target_repo(),
+        "child project defaults to the parent's"
+    );
+
+    // GET /runs exposes the same fields for the badge and the root-only filter.
+    let (status, runs) = get_json(&daemon, "/runs").await;
+    assert_eq!(status, 200);
+    let entry = runs
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|r| r["run_id"] == child["run_id"])
+        .expect("child run in list");
+    assert_eq!(entry["parent_run_id"], parent);
+    assert_eq!(entry["parent_node_id"], "worker");
+
+    // The root run itself carries no parent (root run).
+    let root_entry = runs
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|r| r["run_id"] == parent)
+        .expect("root run in list");
+    assert!(
+        root_entry.get("parent_run_id").is_none(),
+        "a root run has no parent_run_id"
+    );
+    assert!(root_entry.get("parent_node_id").is_none());
+}
+
+#[tokio::test]
+async fn declared_parent_is_refused_out_of_session() {
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+
+    // Provenance never travels in the body: the two keys are not accepted fields.
+    for field in ["parent_run_id", "parent_node_id"] {
+        let body = serde_json::json!({
+            "pipeline": CHILD_PIPELINE_NAME,
+            "input": "child work",
+            "target_repo": daemon.target_repo(),
+            field: "some-run",
+        });
+        let resp = post_run(&daemon, body, None).await;
+        assert_eq!(resp.status(), 400, "declared `{field}` must be refused");
+        let err: serde_json::Value = resp.json().await.unwrap();
+        let msg = err["error"].as_str().unwrap_or("");
+        assert!(
+            msg.contains(field),
+            "refusal names the offending field `{field}`: {msg}"
+        );
+    }
+
+    // …and even FROM a session, a declared parent stays refused: the daemon
+    // decides the parent, the body never does.
+    let parent = create_root_run(&daemon).await;
+    start_worker(&daemon, &parent).await;
+    let body = serde_json::json!({
+        "pipeline": CHILD_PIPELINE_NAME,
+        "input": "child work",
+        "parent_run_id": "run-i-declare",
+    });
+    let resp = post_run(&daemon, body, Some((&parent, "worker"))).await;
+    assert_eq!(
+        resp.status(),
+        400,
+        "a declared parent is refused even in session"
+    );
+}
+
+#[tokio::test]
+async fn bogus_or_stale_session_claim_is_refused() {
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+    let body = serde_json::json!({
+        "pipeline": CHILD_PIPELINE_NAME,
+        "input": "child work",
+        "target_repo": daemon.target_repo(),
+    });
+
+    // Unknown run.
+    let resp = post_run(&daemon, body.clone(), Some(("no-such-run", "worker"))).await;
+    assert_eq!(resp.status(), 403, "a claim on an unknown run is refused");
+    let err: serde_json::Value = resp.json().await.unwrap();
+    assert!(
+        err["error"].as_str().unwrap_or("").contains("no-such-run"),
+        "refusal names the claimed run: {:?}",
+        err
+    );
+
+    // Real run, unknown node.
+    let parent = create_root_run(&daemon).await;
+    let resp = post_run(&daemon, body.clone(), Some((&parent, "no-such-node"))).await;
+    assert_eq!(resp.status(), 403, "a claim on an unknown node is refused");
+
+    // A node whose session is GONE: complete the worker explicitly (`pdo
+    // complete`'s endpoint), which detaches its session and leaves the node
+    // `completed` — holding no session.
+    let exited = TestDaemon::spawn_with_override(seed, Some("exec true".to_string()))
+        .await
+        .unwrap();
+    let done_parent = create_root_run(&exited).await;
+    wait_node_running(&exited, &done_parent, "worker").await;
+    // The completion validator requires the node's declared output; write it
+    // into the run worktree like the (already-dead) session would have.
+    let out_dir = exited
+        .repo_root()
+        .join(".pdo")
+        .join("runs")
+        .join(&done_parent)
+        .join("worktree")
+        .join(".pdo")
+        .join("artifacts")
+        .join("worker")
+        .join("iter-1")
+        .join("result");
+    std::fs::create_dir_all(&out_dir).unwrap();
+    std::fs::write(out_dir.join("output.md"), "done\n").unwrap();
+    let resp = reqwest::Client::new()
+        .post(format!(
+            "{}/runs/{done_parent}/nodes/worker/done",
+            exited.url()
+        ))
+        .json(&serde_json::json!({ "iter": 1 }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200, "worker completion should succeed");
+    for _ in 0..100 {
+        let (status, run) = get_json(&exited, &format!("/runs/{done_parent}")).await;
+        assert_eq!(status, 200);
+        if run["nodes"]["worker"]["status"] == "completed" {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+    let done_body = serde_json::json!({
+        "pipeline": CHILD_PIPELINE_NAME,
+        "input": "child work",
+        "target_repo": exited.target_repo(),
+    });
+    let resp = post_run(&exited, done_body, Some((&done_parent, "worker"))).await;
+    assert_eq!(resp.status(), 403, "a node holding no session is refused");
+    let err: serde_json::Value = resp.json().await.unwrap();
+    assert!(
+        err["error"]
+            .as_str()
+            .unwrap_or("")
+            .contains("holds no live session"),
+        "refusal says why: {:?}",
+        err
+    );
+
+    // No run was created by any of the refused claims.
+    let (status, runs) = get_json(&daemon, "/runs").await;
+    assert_eq!(status, 200);
+    assert_eq!(
+        runs.as_array().unwrap().len(),
+        1,
+        "refused claims create nothing"
+    );
+}
+
+#[tokio::test]
+async fn run_created_without_session_is_a_root() {
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+    let run_id = create_root_run(&daemon).await;
+
+    let (status, run) = get_json(&daemon, &format!("/runs/{run_id}")).await;
+    assert_eq!(status, 200);
+    assert!(
+        run.get("parent_run_id").is_none(),
+        "an out-of-session create is a root run"
+    );
+    assert!(run.get("parent_node_id").is_none());
+
+    // An explicit target repo still wins over the (absent) parent default.
+    let explicit = other_repo().unwrap();
+    let resp = post_run(
+        &daemon,
+        serde_json::json!({
+            "pipeline": CHILD_PIPELINE_NAME,
+            "input": "sibling work",
+            "target_repo": explicit,
+        }),
+        None,
+    )
+    .await;
+    assert_eq!(resp.status(), 201);
+    let sibling: serde_json::Value = resp.json().await.unwrap();
+    let (status, run) = get_json(
+        &daemon,
+        &format!("/runs/{}", sibling["run_id"].as_str().unwrap()),
+    )
+    .await;
+    assert_eq!(status, 200);
+    assert_eq!(run["target_repo"], explicit, "explicit repo override holds");
+}
+
+#[tokio::test]
+async fn children_endpoint_lists_children_grouped_by_parent_node() {
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+    let parent = create_root_run(&daemon).await;
+    start_worker(&daemon, &parent).await;
+
+    // Two children from the same node session, one explicitly re-pointed at a
+    // different repo (overridable, spec #719 story 13) — still the parent's
+    // children: no special inheritance, an ordinary run. Names are explicit so
+    // the assertions don't race the manager's async auto-naming.
+    let explicit_repo = other_repo().unwrap();
+    for (name, repo) in [
+        ("child one", None),
+        ("child two", Some(explicit_repo.as_str())),
+    ] {
+        let mut body = serde_json::json!({
+            "pipeline": CHILD_PIPELINE_NAME,
+            "input": name,
+            "name": name,
+        });
+        if let Some(repo) = repo {
+            body["target_repo"] = serde_json::json!(repo);
+        }
+        let resp = post_run(&daemon, body, Some((&parent, "worker"))).await;
+        assert_eq!(resp.status(), 201);
+    }
+
+    let (status, children) = get_json(&daemon, &format!("/runs/{parent}/children")).await;
+    assert_eq!(status, 200);
+    assert_eq!(children["run_id"], parent);
+
+    let nodes = children["nodes"].as_array().expect("nodes is an array");
+    assert_eq!(nodes.len(), 1, "grouped by the ONE parent node used");
+    assert_eq!(nodes[0]["node_id"], "worker");
+
+    let group = nodes[0]["children"]
+        .as_array()
+        .expect("children is an array");
+    assert_eq!(group.len(), 2, "both children listed");
+
+    // Chronological within the group: "child one" first.
+    assert_eq!(group[0]["name"], "child one");
+    assert_eq!(group[1]["name"], "child two");
+
+    for child in group {
+        assert!(child["run_id"].is_string());
+        assert_eq!(child["pipeline_name"], CHILD_PIPELINE_NAME);
+        assert_eq!(
+            child["status"], "running",
+            "a child is an ordinary live run"
+        );
+        assert!(
+            child["started_at"].is_string(),
+            "started_at present: {:?}",
+            child
+        );
+        assert!(
+            child.get("completed_at").is_none(),
+            "a live child has no completed_at"
+        );
+        // ADR-0052: the cost is derived on read; with no transcripts to read it
+        // is ABSENT, and the surface renders "—" — never `$0`.
+        assert!(
+            child.get("cost").is_none() || child["cost"].is_null(),
+            "unavailable cost is never fabricated: {:?}",
+            child
+        );
+    }
+
+    // An explicit repo override did not change the parent link (mechanical).
+    assert!(group[1]["run_id"].is_string());
+
+    // A child is itself listed as a parent of nothing: its children list is empty.
+    let child_id = group[0]["run_id"].as_str().unwrap().to_string();
+    let (status, grandchildren) = get_json(&daemon, &format!("/runs/{child_id}/children")).await;
+    assert_eq!(status, 200);
+    assert_eq!(
+        grandchildren["nodes"].as_array().unwrap().len(),
+        0,
+        "a childless run returns an empty list"
+    );
+}
+
+#[tokio::test]
+async fn children_endpoint_404_for_unknown_run() {
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+    let resp = reqwest::get(format!("{}/runs/no-such-run/children", daemon.url()))
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        404,
+        "an unknown run is a 404, not an empty list"
+    );
+}


### PR DESCRIPTION
## What

Sub-ticket #720 (story #709, spec #719, ADR-0064) :

- `POST /runs` lit l'identité de session (`X-PDO-Session-Run-Id` / `-Node-Id`, alimentés par `PDO_RUN_ID`/`PDO_NODE_ID`) et, après vérification d'une session de nœud **vivante**, gèle `parent_run_id` + `parent_node_id` dans le `RunStarted`. La provenance ne se déclare pas : toute clé de parent dans le corps → 400 champ inconnu ; claim invalide (run inconnu, nœud inconnu, session morte) → 403 avant tout effet. Sans claim → run racine.
- Projet de l'enfant = celui du parent par défaut, overridable explicitement.
- `RunState` + liste de runs projettent les deux champs.
- `GET /runs/{id}/children` : enfants groupés par nœud parent, statut, started/completed, coût dérivé à la lecture via le cache (jamais persisté, ADR-0052 — indisponible ⇒ clé absente, jamais `$0`).

## Release

- version 1.64.0 → **1.65.0** (minor), entrée CHANGELOG.

## Local check (vert)

- `cargo build` + `cargo test` : 2450 unit + 441 integration ✅
- frontend : `tsc -b` ✅, `vite build` ✅, `vitest run` 2227 passed ✅
- `scripts/layout-ratchet.sh` : 185/185, 83/83 ✅
- **Feature Path #720 : ✅ Pass** (campagne agentic-tests itération 1, live daemon sur le build du worktree — les 3 étapes vertes, aucun finding bloquant ; 3 findings non bloquants hors périmètre, voir l'artefact de run)

Closes #720