### PR TITLE
feat(#721): CLI pdo run create — thin client of POST /runs — 1.66.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ ascendante** : la casse se signale ici et par un bump majeur, jamais en gardant 
 morts. Seule contrainte non négociable — les **données historiques restent lisibles** : un Run
 archivé s'ouvre et se chiffre quelle que soit la version qui a écrit son payload.
 
+## 1.66.0
+
+**`pdo run create <pipeline>` — créer un run enfant depuis une session de nœud** (#721 ; story #709,
+spec #719, ADR-0064). Nouvelle sous-commande CLI, client mince de `POST /runs` : chaque champ de
+creation passe en flag (input, variables, skills, agent_choice, harness, sandbox, target_repo(s),
+source_branch, name, auto_name, auto_fail, provisioning). L'identité voyage avec la session,
+jamais dans le corps : lancée depuis une session de nœud (`PDO_RUN_ID` / `PDO_NODE_ID`), la
+sous-commande crée un run mécaniquement lié à ce run + nœud ; hors session, le run est racine et
+`--target-repo` devient obligatoire (refus lisible du daemon, ADR-0033). Le projet de l'enfant
+vaut par défaut celui du parent. Les refus du daemon remontent tels quels sur stderr avec un code
+non nul.
+
 ## 1.65.0
 
 **Un run créé depuis une session de nœud porte sa provenance mécaniquement** (#720 ; story #709,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "1.65.0"
+version = "1.66.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "1.65.0"
+version = "1.66.0"
 license = "MIT"
 description = "Prompt-Driven Orchestrator — a local daemon that runs and supervises agentic coding pipelines"
 repository = "https://github.com/Loulen/prompt-driven-orchestrator"

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -230,6 +230,76 @@ pub enum Commands {
         #[command(subcommand)]
         action: DocsAction,
     },
+    /// Talk to a running daemon's Run surface.
+    Run {
+        #[command(subcommand)]
+        action: Box<RunAction>,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum RunAction {
+    /// Create a Run — the thin CLI client of the daemon's `POST /runs`
+    /// (issue #721, ADR-0064).
+    ///
+    /// Identity travels with the session, never in the body: run from a node
+    /// session (the `PDO_RUN_ID` / `PDO_NODE_ID` env vars the session is
+    /// wrapped with), the created Run is mechanically linked to that Run + node
+    /// (`parent_run_id` / `parent_node_id`); run from a plain terminal, it is a
+    /// root Run. The child's project defaults to the parent's — `--target-repo`
+    /// overrides it explicitly. Daemon refusals (unknown pipeline, a refused
+    /// session claim, …) print the daemon's own `error` sentence and exit
+    /// non-zero.
+    Create {
+        /// The pipeline to run, resolved by the daemon against its pipeline stores.
+        pipeline: String,
+        /// Prompt for the Run's start node. A prompt-optional pipeline accepts
+        /// the empty default.
+        #[arg(short, long, default_value = "")]
+        input: String,
+        /// Run variables as a JSON object: `--variables '{"pool":"a"}'`.
+        #[arg(long)]
+        variables: Option<String>,
+        /// Skills selected at the Run tier (#669, ADR-0062): comma-separated
+        /// ids (`--skills a,b`) or a JSON list of `{id, name}` objects.
+        #[arg(long)]
+        skills: Option<String>,
+        /// Agentic profile at the Run tier (ADR-0057) as JSON —
+        /// `{"mode":"profile","profile_id":"…"}` or
+        /// `{"mode":"custom","harness":"…","model":"…","effort":"…"}`.
+        #[arg(long)]
+        agent_choice: Option<String>,
+        /// Agentic harness (ADR-0046): free text, validated at spawn.
+        #[arg(long)]
+        harness: Option<String>,
+        /// Sandbox isolation: `off`, or the name of a staging profile.
+        #[arg(long)]
+        sandbox: Option<String>,
+        /// Primary target repo (path or URL, like the UI's create modal).
+        /// Overrides the parent Run's project — ADR-0033 keeps the boundary.
+        #[arg(long)]
+        target_repo: Option<String>,
+        /// Secondary repos as a JSON list of `{repo, base_branch?, read_only?}`
+        /// (ADR-0042).
+        #[arg(long)]
+        target_repos: Option<String>,
+        /// Branch the primary repo starts from (default: its local HEAD).
+        #[arg(long)]
+        source_branch: Option<String>,
+        /// Display name for the Run.
+        #[arg(long)]
+        name: Option<String>,
+        /// Whether the manager may auto-name the Run (default: resolved by the
+        /// daemon from the presence of `--name`).
+        #[arg(long)]
+        auto_name: Option<bool>,
+        /// The Run's `auto_fail` preference (ADR-0049).
+        #[arg(long)]
+        auto_fail: Option<bool>,
+        /// Run-level provisioning rules as JSON (ADR-0061).
+        #[arg(long)]
+        provisioning: Option<String>,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -1069,6 +1139,157 @@ pub fn run_skip(reason: String) -> Result<()> {
         let status = resp.status();
         let body = resp.text().unwrap_or_default();
         anyhow::bail!("daemon returned {status}: {body}");
+    }
+    Ok(())
+}
+
+/// The session identity this CLI process carries via the `PDO_RUN_ID` /
+/// `PDO_NODE_ID` env vars every node session is wrapped with
+/// (`tmux_session_manager::wrap_with_env`). Only a non-empty PAIR is a claim —
+/// a lone var means out of session (mirror of the daemon's
+/// `session_claim_from_headers`): the created Run is then a root.
+fn session_env_claim() -> Option<(String, String)> {
+    let clean = |v: Result<String, std::env::VarError>| {
+        v.ok()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+    };
+    let run_id = clean(std::env::var("PDO_RUN_ID"))?;
+    let node_id = clean(std::env::var("PDO_NODE_ID"))?;
+    Some((run_id, node_id))
+}
+
+/// Parse a JSON-typed flag. The error names the flag, so an agent reading the
+/// stderr knows which argument was malformed.
+fn parse_json_arg(flag: &str, raw: &str) -> Result<serde_json::Value> {
+    serde_json::from_str(raw).with_context(|| format!("invalid JSON for --{flag}: {raw}"))
+}
+
+/// `--skills`: comma-separated ids (`a,b`) or a JSON list of `{id, name}`
+/// objects. Ids become `{id}` objects — the wire shape of the Run tier's
+/// `SkillRef` list (`name` defaults; #668: identity is the id).
+fn parse_skills_arg(raw: &str) -> Result<serde_json::Value> {
+    let trimmed = raw.trim();
+    if trimmed.starts_with('[') {
+        return parse_json_arg("skills", trimmed);
+    }
+    let refs: Vec<serde_json::Value> = trimmed
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|id| serde_json::json!({ "id": id }))
+        .collect();
+    Ok(serde_json::json!(refs))
+}
+
+/// One-shot `pdo run create` (issue #721, ADR-0064): the thin CLI client of the
+/// daemon's `POST /runs`. Like the other one-shots, blocking `reqwest` and no
+/// tokio runtime (see `main.rs`); plain `Result` → `0`/`1` exit mapping — only
+/// `pdo complete` owns an exit-code contract (#490).
+///
+/// The body is built field by field rather than by serialising a struct, so the
+/// pass-through stays visibly in lock-step with the daemon's
+/// `CREATE_RUN_FIELDS` — and provenance never enters it: identity travels in
+/// the session headers, exactly like the UI's fetch calls.
+pub fn run_run_create(action: RunAction) -> Result<()> {
+    let RunAction::Create {
+        pipeline,
+        input,
+        variables,
+        skills,
+        agent_choice,
+        harness,
+        sandbox,
+        target_repo,
+        target_repos,
+        source_branch,
+        name,
+        auto_name,
+        auto_fail,
+        provisioning,
+    } = action;
+
+    let url = cli_daemon_url();
+
+    let mut body = serde_json::Map::new();
+    body.insert("pipeline".into(), serde_json::json!(pipeline));
+    body.insert("input".into(), serde_json::json!(input));
+    if let Some(v) = variables {
+        body.insert("variables".into(), parse_json_arg("variables", &v)?);
+    }
+    if let Some(v) = skills {
+        body.insert("skills".into(), parse_skills_arg(&v)?);
+    }
+    if let Some(v) = agent_choice {
+        body.insert("agent_choice".into(), parse_json_arg("agent-choice", &v)?);
+    }
+    if let Some(v) = harness {
+        // No validation here (ADR-0045) — the daemon refuses an unknown one at
+        // spawn, naming it.
+        body.insert("harness".into(), serde_json::json!(v));
+    }
+    if let Some(v) = sandbox {
+        body.insert("sandbox".into(), serde_json::json!(v));
+    }
+    if let Some(v) = target_repo {
+        body.insert("target_repo".into(), serde_json::json!(v));
+    }
+    if let Some(v) = target_repos {
+        body.insert("target_repos".into(), parse_json_arg("target-repos", &v)?);
+    }
+    if let Some(v) = source_branch {
+        body.insert("source_branch".into(), serde_json::json!(v));
+    }
+    if let Some(v) = name {
+        body.insert("name".into(), serde_json::json!(v));
+    }
+    if let Some(v) = auto_name {
+        body.insert("auto_name".into(), serde_json::json!(v));
+    }
+    if let Some(v) = auto_fail {
+        body.insert("auto_fail".into(), serde_json::json!(v));
+    }
+    if let Some(v) = provisioning {
+        body.insert("provisioning".into(), parse_json_arg("provisioning", &v)?);
+    }
+
+    let session = session_env_claim();
+    let mut req = reqwest::blocking::Client::new()
+        .post(format!("{url}/runs"))
+        .json(&body);
+    if let Some((run_id, node_id)) = &session {
+        req = req
+            .header(SESSION_RUN_HEADER, run_id)
+            .header(SESSION_NODE_HEADER, node_id);
+    }
+    let resp = req.send().context("failed to reach daemon")?;
+
+    let status = resp.status();
+    let raw = resp.text().unwrap_or_default();
+    if !status.is_success() {
+        // Readable: surface the daemon's own `error` sentence when there is one
+        // (unknown pipeline, refused session claim, …), the raw body otherwise.
+        let parsed: serde_json::Value =
+            serde_json::from_str(&raw).unwrap_or(serde_json::Value::Null);
+        let detail = parsed
+            .get("error")
+            .and_then(|v| v.as_str())
+            .unwrap_or(raw.as_str());
+        anyhow::bail!("daemon refused run creation ({status}): {detail}");
+    }
+    let parsed: serde_json::Value = serde_json::from_str(&raw)
+        .with_context(|| format!("unreadable success body from daemon: {raw}"))?;
+    let run_id = parsed
+        .get("run_id")
+        .and_then(|v| v.as_str())
+        .with_context(|| format!("`run_id` missing from daemon response: {raw}"))?
+        .to_string();
+
+    match session {
+        Some((parent_run, parent_node)) => {
+            println!("Run {run_id} created — child of run {parent_run} (node {parent_node}).")
+        }
+        None => println!("Run {run_id} created (root run)."),
     }
     Ok(())
 }
@@ -28196,6 +28417,146 @@ edges:
     fn cli_service_requires_an_action() {
         // `pdo service` with no subcommand is a usage error, not a silent no-op.
         assert!(Cli::try_parse_from(["pdo", "service"]).is_err());
+    }
+
+    #[test]
+    fn cli_parses_run_create_bare() {
+        // The one-argument common case: pipeline positional, everything else
+        // deferred to the daemon (empty input, session-derived parent).
+        let cli = Cli::try_parse_from(["pdo", "run", "create", "my-pipeline"]).unwrap();
+        let Commands::Run { action } = cli.command else {
+            panic!("expected Run subcommand")
+        };
+        let RunAction::Create {
+            pipeline,
+            input,
+            variables,
+            skills,
+            harness,
+            target_repo,
+            name,
+            ..
+        } = *action;
+        assert_eq!(pipeline, "my-pipeline");
+        assert_eq!(
+            input, "",
+            "empty input defers to the pipeline's prompt_required"
+        );
+        assert!(variables.is_none());
+        assert!(skills.is_none());
+        assert!(harness.is_none());
+        assert!(target_repo.is_none());
+        assert!(name.is_none());
+    }
+
+    #[test]
+    fn cli_parses_run_create_flags() {
+        let cli = Cli::try_parse_from([
+            "pdo",
+            "run",
+            "create",
+            "my-pipeline",
+            "--input",
+            "do the work",
+            "--variables",
+            r#"{"pool":"a"}"#,
+            "--skills",
+            "alpha,beta",
+            "--agent-choice",
+            r#"{"mode":"custom","harness":"pi"}"#,
+            "--harness",
+            "pi",
+            "--sandbox",
+            "off",
+            "--target-repo",
+            "/somewhere/repo",
+            "--target-repos",
+            r#"[{"repo":"/somewhere/other","read_only":true}]"#,
+            "--source-branch",
+            "feat/x",
+            "--name",
+            "child run",
+            "--auto-name",
+            "false",
+            "--auto-fail",
+            "true",
+            "--provisioning",
+            r#"{}"#,
+        ])
+        .unwrap();
+        let Commands::Run { action } = cli.command else {
+            panic!("expected Run subcommand")
+        };
+        let RunAction::Create {
+            pipeline,
+            input,
+            variables,
+            skills,
+            agent_choice,
+            harness,
+            sandbox,
+            target_repo,
+            target_repos,
+            source_branch,
+            name,
+            auto_name,
+            auto_fail,
+            provisioning,
+        } = *action;
+        assert_eq!(pipeline, "my-pipeline");
+        assert_eq!(input, "do the work");
+        assert_eq!(variables.as_deref(), Some(r#"{"pool":"a"}"#));
+        assert_eq!(skills.as_deref(), Some("alpha,beta"));
+        assert_eq!(
+            agent_choice.as_deref(),
+            Some(r#"{"mode":"custom","harness":"pi"}"#)
+        );
+        assert_eq!(harness.as_deref(), Some("pi"));
+        assert_eq!(sandbox.as_deref(), Some("off"));
+        assert_eq!(target_repo.as_deref(), Some("/somewhere/repo"));
+        assert_eq!(
+            target_repos.as_deref(),
+            Some(r#"[{"repo":"/somewhere/other","read_only":true}]"#)
+        );
+        assert_eq!(source_branch.as_deref(), Some("feat/x"));
+        assert_eq!(name.as_deref(), Some("child run"));
+        assert_eq!(auto_name, Some(false));
+        assert_eq!(auto_fail, Some(true));
+        assert_eq!(provisioning.as_deref(), Some("{}"));
+    }
+
+    #[test]
+    fn cli_run_requires_an_action() {
+        assert!(Cli::try_parse_from(["pdo", "run"]).is_err());
+    }
+
+    #[test]
+    fn run_create_skills_arg_accepts_ids_and_json() {
+        // Comma-separated ids become the wire shape of the Run tier's SkillRef
+        // list — `{id}` objects whose `name` the daemon defaults (#668).
+        let parsed = parse_skills_arg("alpha, beta ,,gamma").unwrap();
+        assert_eq!(
+            parsed,
+            serde_json::json!([{ "id": "alpha" }, { "id": "beta" }, { "id": "gamma" }])
+        );
+        // A JSON list passes through verbatim — `{id, name}` labels survive.
+        let parsed = parse_skills_arg(r#"[{"id":"a","name":"A"}]"#).unwrap();
+        assert_eq!(parsed, serde_json::json!([{ "id": "a", "name": "A" }]));
+        assert!(parse_skills_arg("[broken").is_err());
+    }
+
+    #[test]
+    fn run_create_session_env_claim_needs_a_pair() {
+        // Mirror of the daemon's `session_claim_from_headers`: only a non-empty
+        // PAIR is a claim. Gated on the vars being unset, so this can't race a
+        // real session's env (same guard pattern as the nested-context tests).
+        if std::env::var("PDO_RUN_ID").is_ok() || std::env::var("PDO_NODE_ID").is_ok() {
+            return;
+        }
+        assert!(
+            session_env_claim().is_none(),
+            "no env vars ⇒ out of session"
+        );
     }
 
     // --- Layer 3a: `run_service` against a recording fake env (#156, D4).

--- a/crates/pdo-daemon/src/main.rs
+++ b/crates/pdo-daemon/src/main.rs
@@ -1,8 +1,8 @@
 use anyhow::{Context, Result};
 use clap::Parser;
 use pdo_daemon::{
-    run_complete, run_daemon, run_docs, run_fail, run_migrate, run_reap, run_service, run_skip,
-    Cli, Commands,
+    run_complete, run_daemon, run_docs, run_fail, run_migrate, run_reap, run_run_create,
+    run_service, run_skip, Cli, Commands,
 };
 use std::process::ExitCode;
 
@@ -53,6 +53,7 @@ fn main() -> ExitCode {
             budget_secs,
         } => run_reap(count, dry_run, ttl_hours, terminal_ttl_hours, budget_secs),
         Commands::Docs { action } => run_docs(action),
+        Commands::Run { action } => run_run_create(*action),
     };
 
     if let Err(e) = res {

--- a/crates/pdo-daemon/src/prompt_augmenter.rs
+++ b/crates/pdo-daemon/src/prompt_augmenter.rs
@@ -805,6 +805,31 @@ pub(crate) fn build_preamble(ctx: &AugmentContext<'_>) -> String {
         );
     }
 
+    // CLI capabilities (#721, ADR-0064): `pdo run create` is the universal
+    // create-child-Run lever, documented like `pdo complete` above — any node
+    // session (agent or script) can orchestrate, the provenance is the
+    // daemon's business, never the caller's.
+    preamble.push_str("## Orchestration — creating child Runs\n\n");
+    preamble.push_str(
+        "You can create child Runs from this session with the `pdo run create` CLI \
+         capability — a thin client of the daemon's `POST /runs`:\n\
+         ```\n\
+         pdo run create <pipeline> [--input \"…\"] [--name \"…\"] [--target-repo /path/to/repo]\n\
+         ```\n\n\
+         - Run from a node session (like this one), the created Run is \
+         mechanically linked to this Run and this node — provenance is never \
+         declared by the caller, and the daemon refuses any parent field in the body.\n\
+         - The child's project defaults to this Run's project; override it \
+         explicitly with `--target-repo`.\n\
+         - Every creation field passes through as a flag: `--input`, \
+         `--variables '<json>'`, `--skills a,b`, `--agent-choice '<json>'`, \
+         `--harness`, `--sandbox`, `--target-repo`, `--target-repos '<json>'`, \
+         `--source-branch`, `--name`, `--auto-name`, `--auto-fail`, \
+         `--provisioning '<json>'`.\n\
+         - The daemon's refusals (unknown pipeline, …) print on stderr with a \
+         non-zero exit.\n\n",
+    );
+
     if !ctx.variables.is_empty() {
         preamble.push_str("## Pipeline Variables\n\n");
         for (name, value) in ctx.variables {
@@ -1536,6 +1561,11 @@ mod tests {
         assert!(preamble.contains("pdo fail --reason"));
         // #245: non-interactive nodes learn the graceful no-op primitive.
         assert!(preamble.contains("pdo skip --reason"));
+        // #721 / ADR-0064: run creation is a documented CLI capability of every
+        // node session — provenance follows the session, never the caller.
+        assert!(preamble.contains("pdo run create"));
+        assert!(preamble.contains("mechanically linked"));
+        assert!(preamble.contains("--target-repo"));
     }
 
     #[test]

--- a/crates/pdo-daemon/tests/cli_run_create.rs
+++ b/crates/pdo-daemon/tests/cli_run_create.rs
@@ -1,0 +1,345 @@
+//! Layer 3a — the `pdo run create` CLI contract (issue #721, ADR-0064): a thin
+//! client of the daemon's `POST /runs`, tested like `cli_complete_does_not_panic.rs`
+//! by spawning the real `pdo` binary in a subprocess.
+//!
+//! - From a node session (`PDO_RUN_ID` / `PDO_NODE_ID` env, the exact vars the
+//!   session is wrapped with): the created Run is mechanically linked to that
+//!   Run + node, and its project defaults to the parent's.
+//! - From a plain terminal (no env): a root Run — no error about a missing
+//!   session context.
+//! - Flags pass through to `POST /runs`: the daemon's frozen Run state carries
+//!   what the CLI named.
+//! - Daemon refusals (unknown pipeline) surface the daemon's own `error`
+//!   sentence on stderr with a non-zero exit.
+
+use std::process::Command;
+
+use crate::common::TestDaemon;
+
+const PIPELINE_NAME: &str = "cli-run-create-parent";
+const PIPELINE_YAML: &str = r#"name: cli-run-create-parent
+version: "1.0"
+nodes:
+  - id: start
+    name: Start
+    type: start
+    outputs:
+      - name: user_prompt
+  - id: worker
+    name: worker
+    type: agent
+    isolated_worktree: false
+    inputs:
+      - name: task
+    outputs:
+      - name: result
+    view: { x: 200, y: 100 }
+  - id: end
+    name: End
+    type: end
+    inputs:
+      - name: result
+edges:
+  - source: { node: start, port: user_prompt }
+    target: { node: worker, port: task }
+"#;
+
+const CHILD_PIPELINE_NAME: &str = "cli-run-create-child";
+const CHILD_PIPELINE_YAML: &str = r#"name: cli-run-create-child
+version: "1.0"
+nodes:
+  - id: start
+    name: Start
+    type: start
+    outputs:
+      - name: user_prompt
+  - id: end
+    name: End
+    type: end
+    inputs:
+      - name: result
+edges:
+  - source: { node: start, port: user_prompt }
+    target: { node: end, port: result }
+"#;
+
+fn git_init_with_commit(repo: &std::path::Path) -> anyhow::Result<()> {
+    let run = |args: &[&str]| -> anyhow::Result<()> {
+        let out = Command::new("git").args(args).current_dir(repo).output()?;
+        if !out.status.success() {
+            anyhow::bail!(
+                "git {:?} failed: {}",
+                args,
+                String::from_utf8_lossy(&out.stderr)
+            );
+        }
+        Ok(())
+    };
+    run(&["init", "-q", "-b", "main"])?;
+    run(&["config", "user.email", "test@example.com"])?;
+    run(&["config", "user.name", "Test"])?;
+    run(&["config", "commit.gpgsign", "false"])?;
+    std::fs::write(repo.join(".gitignore"), ".pdo/runs/\n")?;
+    run(&["add", "."])?;
+    run(&["commit", "-q", "-m", "init"])?;
+    Ok(())
+}
+
+fn seed(repo: &std::path::Path) -> anyhow::Result<()> {
+    let pipelines_dir = repo.join(".pdo").join("pipelines");
+    std::fs::create_dir_all(&pipelines_dir)?;
+    std::fs::write(
+        pipelines_dir.join(format!("{PIPELINE_NAME}.yaml")),
+        PIPELINE_YAML,
+    )?;
+    let prompts_dir = pipelines_dir.join(format!("{PIPELINE_NAME}.prompts"));
+    std::fs::create_dir_all(&prompts_dir)?;
+    std::fs::write(prompts_dir.join("worker.md"), "You are a worker.\n")?;
+    std::fs::write(
+        pipelines_dir.join(format!("{CHILD_PIPELINE_NAME}.yaml")),
+        CHILD_PIPELINE_YAML,
+    )?;
+    git_init_with_commit(repo)?;
+    Ok(())
+}
+
+/// Run the real binary against `daemon`. `session` carries the env vars a node
+/// session is wrapped with; `None` is a plain user terminal. On a **blocking**
+/// task so the host runtime stays free to serve the daemon's HTTP requests.
+async fn run_pdo_run_create(
+    daemon_url: &str,
+    args: &[&str],
+    session: Option<(&str, &str)>,
+) -> (Option<i32>, String, String) {
+    let bin = env!("CARGO_BIN_EXE_pdo");
+    let mut cmd = Command::new(bin);
+    cmd.args(["run", "create"]).args(args);
+    cmd.env("PDO_DAEMON_URL", daemon_url);
+    // Out of session the vars must be ABSENT, not empty — a real terminal has
+    // no PDO_* env at all.
+    cmd.env_remove("PDO_RUN_ID");
+    cmd.env_remove("PDO_NODE_ID");
+    if let Some((run_id, node_id)) = session {
+        cmd.env("PDO_RUN_ID", run_id);
+        cmd.env("PDO_NODE_ID", node_id);
+    }
+    let output =
+        tokio::task::spawn_blocking(move || cmd.output().expect("failed to spawn pdo run create"))
+            .await
+            .expect("blocking task panicked");
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    assert!(
+        !stderr.contains("panicked"),
+        "pdo run create must not panic. stderr=\n{stderr}\nstdout=\n{stdout}"
+    );
+    (output.status.code(), stdout, stderr)
+}
+
+async fn get_json(daemon: &TestDaemon, path: &str) -> (u16, serde_json::Value) {
+    let resp = reqwest::get(format!("{}{}", daemon.url(), path))
+        .await
+        .unwrap();
+    let status = resp.status().as_u16();
+    let json: serde_json::Value = resp.json().await.unwrap();
+    (status, json)
+}
+
+async fn create_root_run(daemon: &TestDaemon) -> String {
+    let body = serde_json::json!({
+        "pipeline": PIPELINE_NAME,
+        "input": "hello world",
+        "target_repo": daemon.target_repo(),
+    });
+    let resp = reqwest::Client::new()
+        .post(format!("{}/runs", daemon.url()))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 201, "POST /runs should return 201");
+    let json: serde_json::Value = resp.json().await.unwrap();
+    json["run_id"].as_str().unwrap().to_string()
+}
+
+/// Wait until the parent's `worker` node holds a live session (the TestDaemon's
+/// tmux override `exec sleep 600` keeps it alive indefinitely).
+async fn wait_node_running(daemon: &TestDaemon, run_id: &str, node_id: &str) {
+    for _ in 0..100 {
+        let (status, run) = get_json(daemon, &format!("/runs/{run_id}")).await;
+        assert_eq!(status, 200);
+        if run["nodes"][node_id]["status"] == "running" {
+            return;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+    panic!("node {node_id} of run {run_id} never reached `running`");
+}
+
+/// Extract the created run's id from the CLI's stdout — `Run <id> created …`.
+fn run_id_from_stdout(stdout: &str) -> String {
+    let rest = stdout
+        .trim()
+        .strip_prefix("Run ")
+        .unwrap_or_else(|| panic!("stdout should announce the run identity: {stdout}"));
+    rest.split_whitespace()
+        .next()
+        .unwrap_or_else(|| panic!("stdout should carry the run id: {stdout}"))
+        .to_string()
+}
+
+#[tokio::test]
+async fn from_a_node_session_the_created_run_is_a_linked_child() {
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+    let parent = create_root_run(&daemon).await;
+    wait_node_running(&daemon, &parent, "worker").await;
+
+    // NO --target-repo: the child's project defaults to the parent's (spec
+    // #719 story 13) — the one-flag common case the CLI exists for.
+    let (code, stdout, stderr) = run_pdo_run_create(
+        &daemon.url(),
+        &[CHILD_PIPELINE_NAME, "--input", "child work"],
+        Some((&parent, "worker")),
+    )
+    .await;
+    assert_eq!(code, Some(0), "stderr=\n{stderr}\nstdout=\n{stdout}");
+    let child_id = run_id_from_stdout(&stdout);
+    assert!(
+        stdout.contains(&parent) && stdout.contains("worker"),
+        "the CLI displays the child's identity WITH its parent link: {stdout}"
+    );
+
+    // The HTTP surface of the daemon is the witness of the mechanical link.
+    let (status, run) = get_json(&daemon, &format!("/runs/{child_id}")).await;
+    assert_eq!(status, 200);
+    assert_eq!(run["parent_run_id"], parent, "linked to the session's run");
+    assert_eq!(
+        run["parent_node_id"], "worker",
+        "linked to the session's node"
+    );
+    assert_eq!(
+        run["target_repo"],
+        daemon.target_repo(),
+        "child project defaults to the parent's"
+    );
+}
+
+#[tokio::test]
+async fn from_a_plain_terminal_the_created_run_is_a_root() {
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+
+    // No session env at all, and ADR-0033 keeps the boundary: an explicit
+    // --target-repo is required out of session.
+    let (code, stdout, stderr) = run_pdo_run_create(
+        &daemon.url(),
+        &[
+            CHILD_PIPELINE_NAME,
+            "--input",
+            "standalone work",
+            "--target-repo",
+            &daemon.target_repo(),
+        ],
+        None,
+    )
+    .await;
+    assert_eq!(code, Some(0), "stderr=\n{stderr}\nstdout=\n{stdout}");
+    let run_id = run_id_from_stdout(&stdout);
+    assert!(
+        stdout.contains("root"),
+        "out of session the CLI says the run is a root: {stdout}"
+    );
+
+    let (status, run) = get_json(&daemon, &format!("/runs/{run_id}")).await;
+    assert_eq!(status, 200);
+    assert!(
+        run.get("parent_run_id").is_none(),
+        "an out-of-session create is a root run: {run}"
+    );
+    assert!(run.get("parent_node_id").is_none());
+}
+
+#[tokio::test]
+async fn creation_flags_pass_through_to_the_daemon() {
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+    let parent = create_root_run(&daemon).await;
+    wait_node_running(&daemon, &parent, "worker").await;
+
+    // Overriding skills and the agentic profile (FP #3): the child run runs
+    // with those settings — frozen into its RunStarted, projected on GET.
+    let (code, stdout, stderr) = run_pdo_run_create(
+        &daemon.url(),
+        &[
+            CHILD_PIPELINE_NAME,
+            "--input",
+            "flagged child",
+            "--name",
+            "flagged child",
+            "--skills",
+            "alpha,beta",
+            "--harness",
+            "pi",
+            "--source-branch",
+            "main",
+            "--auto-fail",
+            "true",
+        ],
+        Some((&parent, "worker")),
+    )
+    .await;
+    assert_eq!(code, Some(0), "stderr=\n{stderr}\nstdout=\n{stdout}");
+    let child_id = run_id_from_stdout(&stdout);
+
+    let (status, run) = get_json(&daemon, &format!("/runs/{child_id}")).await;
+    assert_eq!(status, 200);
+    let skills: Vec<&str> = run["skills"]
+        .as_array()
+        .expect("skills projected on the run state")
+        .iter()
+        .filter_map(|s| s["id"].as_str())
+        .collect();
+    assert_eq!(
+        skills,
+        vec!["alpha", "beta"],
+        "Run-tier skills pass through"
+    );
+    assert_eq!(run["harness"], "pi", "the harness flag passes through");
+    assert_eq!(run["name"], "flagged child");
+    assert_eq!(run["auto_fail"], true);
+    assert_eq!(run["parent_run_id"], parent, "still mechanically linked");
+}
+
+#[tokio::test]
+async fn daemon_refusals_surface_readably() {
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+
+    // Unknown pipeline: the daemon's own sentence, not a bare status.
+    let (code, stdout, stderr) = run_pdo_run_create(
+        &daemon.url(),
+        &["no-such-pipeline", "--target-repo", &daemon.target_repo()],
+        None,
+    )
+    .await;
+    assert_ne!(code, Some(0), "a refused create must exit non-zero");
+    assert!(
+        stderr.contains("daemon refused run creation"),
+        "the refusal names the daemon as its source: {stderr}"
+    );
+    assert!(
+        stderr.contains("cannot read pipeline"),
+        "the refusal carries the daemon's error sentence: {stderr}"
+    );
+    assert!(
+        stdout.trim().is_empty(),
+        "a refused create prints nothing to stdout: {stdout}"
+    );
+
+    // Unreachable daemon: a breakdown, also non-zero.
+    let (code, _stdout, stderr) = run_pdo_run_create(
+        "http://127.0.0.1:1",
+        &[CHILD_PIPELINE_NAME, "--target-repo", "/tmp/x"],
+        None,
+    )
+    .await;
+    assert_ne!(code, Some(0));
+    assert!(stderr.contains("failed to reach daemon"), "{stderr}");
+}

--- a/crates/pdo-daemon/tests/it.rs
+++ b/crates/pdo-daemon/tests/it.rs
@@ -23,6 +23,9 @@ mod admission_concurrency;
 #[path = "cli_complete_does_not_panic.rs"]
 mod cli_complete_does_not_panic;
 
+#[path = "cli_run_create.rs"]
+mod cli_run_create;
+
 #[path = "cost_prices.rs"]
 mod cost_prices;
 


### PR DESCRIPTION
## Contenu

Implémentation de #721 (story #709, spec #719, ADR-0064) :

- **`pdo run create <pipeline>`** : client mince de `POST /runs` — chaque champ de création passe en flag (input, variables, skills, agent_choice, harness, sandbox, target_repo(s), source_branch, name, auto_name, auto_fail, provisioning).
- **Identité par session, jamais dans le corps** : depuis une session de nœud (`PDO_RUN_ID` / `PDO_NODE_ID`), le run créé est mécaniquement lié au run + nœud parents ; hors session, run racine (`--target-repo` obligatoire, refus lisible ADR-0033).
- Le projet de l'enfant vaut par défaut celui du parent (`--target-repo` pour override).
- Les refus du daemon remontent tels quels sur stderr, exit non nul.
- Le preamble runtime documente la commande comme capacité CLI de toute session de nœud.
- Release **1.66.0** (minor) + entrée CHANGELOG.

Tests : unitaires CLI-shape + intégration spawnant le vrai binaire contre un daemon vivant (enfant lié / run racine / pass-through des flags / refus lisibles).

## Validation

Gate agentic **vert** — FP de #721 exécuté sur le vrai binaire + vrai daemon : les 3 étapes du Feature Path passent (enfant lié, run racine hors session, override skills/agent_choice), refus lisibles vérifiés. Détail + captures dans l'artifact de validation du run.

Closes #721