### PR TITLE
feat(#725): badge « orchestrated » cliquable + toggle « racines seules » — 1.67.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,19 @@ sous-commande crée un run mécaniquement lié à ce run + nœud ; hors session,
 vaut par défaut celui du parent. Les refus du daemon remontent tels quels sur stderr avec un code
 non nul.
 
+## 1.67.0
+
+**La liste de runs rend visible et navigable la provenance « orchestré »** (#725 ; story #709).
+Tout run enfant porte un badge neutre (GitFork) à côté du badge trigger — accent/Zap pour un
+trigger, gris/GitFork pour un enfant orchestré, les deux coexistent ; un orphelin (parent
+oublié) reste visible mais dimmé et inerte. Le badge est cliquable : il ouvre le run parent
+dans la vue et le met en surbrillance (`stopPropagation`, scroll-into-view). Quatrième axe de
+filtre « racines seules » (chip icon-only GitFork, ON par défaut, offert seulement s'il existe
+au moins un run orchestré) : les enfants disparaissent, le filtre s'applique avant le split
+actifs/archivés, et le ✕ « Clear filters » réinitialise le toggle. Tout est calcul de vue sur
+`parent_run_id` (#720) — aucun endpoint nouveau, symboles seuls dans la liste, mots dans les
+`title` (tooltips comptés : nom du trigger, total d'enfants).
+
 ## 1.65.0
 
 **Un run créé depuis une session de nœud porte sa provenance mécaniquement** (#720 ; story #709,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "1.66.0"
+version = "1.67.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "1.66.0"
+version = "1.67.0"
 license = "MIT"
 description = "Prompt-Driven Orchestrator — a local daemon that runs and supervises agentic coding pipelines"
 repository = "https://github.com/Loulen/prompt-driven-orchestrator"

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  msw: true

--- a/frontend/src/App.settingsClose.test.tsx
+++ b/frontend/src/App.settingsClose.test.tsx
@@ -396,7 +396,7 @@ describe("App — Settings surface closes (#717 sibling-key regression)", () => 
     await user.click(await screen.findByRole("button", { name: "Close settings" }));
     void surface;
     await expectClosed();
-  });
+  }, 20_000);
 
   it("closes via the Cancel button", async () => {
     const user = userEvent.setup();
@@ -405,7 +405,7 @@ describe("App — Settings surface closes (#717 sibling-key regression)", () => 
     await openSettings(user);
     await user.click(screen.getByTestId("settings-cancel"));
     await expectClosed();
-  });
+  }, 20_000);
 
   it("closes via Escape", async () => {
     const user = userEvent.setup();
@@ -414,5 +414,5 @@ describe("App — Settings surface closes (#717 sibling-key regression)", () => 
     await openSettings(user);
     await user.keyboard("{Escape}");
     await expectClosed();
-  });
+  }, 20_000);
 });

--- a/frontend/src/components/RunFilters.tsx
+++ b/frontend/src/components/RunFilters.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown, X } from "lucide-react";
+import { ChevronDown, GitFork, X } from "lucide-react";
 import type { RunListEntry, Trigger } from "../types";
 import {
   DropdownMenu,
@@ -10,6 +10,8 @@ import {
   EMPTY_RUN_FILTER,
   MANUAL_TRIGGER,
   NONE,
+  isFilterActive,
+  isRootRun,
   pipelineKey,
   repoKey,
   triggerKey,
@@ -133,7 +135,12 @@ export default function RunFilters({
         : triggers.find((t) => t.id === v)?.name ?? v,
   }));
 
-  const anyActive = value.repo !== null || value.pipeline !== null || value.trigger !== null;
+  // #725 — the orchestrated toggle is offered only when at least one orchestrated
+  // run exists: an instance that never orchestrates sees exactly the old strip.
+  // Counted over ALL runs, not the filtered view, so the toggle never flickers
+  // away while it is doing the hiding.
+  const childCount = runs.filter((r) => !isRootRun(r)).length;
+  const anyActive = isFilterActive(value);
 
   return (
     <div className="flex shrink-0 items-center gap-1 border-b border-line px-2 py-1.5">
@@ -158,6 +165,34 @@ export default function RunFilters({
         selected={value.trigger}
         onSelect={(trigger) => onChange({ ...value, trigger })}
       />
+      {/* #725 — « show orchestrated runs » as an icon-only chip (lucide GitFork;
+          the words live in the tooltip — user decision 2026-09-06). Deliberate
+          inversion vs the dropdowns, where accent means "narrowing": here ON
+          (accent) means everything is shown; OFF greys the chip and narrows the
+          list to roots. The clear ✕ appearing alongside keeps the strip honest. */}
+      {childCount > 0 && (
+        <button
+          type="button"
+          data-testid="run-filter-orchestrated"
+          aria-pressed={value.showOrchestrated}
+          title={
+            value.showOrchestrated
+              ? `Orchestrated runs shown — click to hide the ${childCount} run${childCount === 1 ? "" : "s"} started by another run (roots only).`
+              : `Orchestrated runs hidden — ${childCount} run${childCount === 1 ? "" : "s"} started by another run. Click to show them.`
+          }
+          aria-label={
+            value.showOrchestrated ? "Hide orchestrated runs" : "Show orchestrated runs"
+          }
+          className={`flex shrink-0 cursor-pointer items-center rounded border bg-bg-3 px-2 py-[3px] transition-colors hover:bg-bg-4 ${
+            value.showOrchestrated
+              ? "border-acc text-acc"
+              : "border-line-strong text-fg-4"
+          }`}
+          onClick={() => onChange({ ...value, showOrchestrated: !value.showOrchestrated })}
+        >
+          <GitFork size={10} />
+        </button>
+      )}
       {anyActive && (
         <button
           data-testid="run-filter-clear"

--- a/frontend/src/components/SettingsSurface.test.tsx
+++ b/frontend/src/components/SettingsSurface.test.tsx
@@ -398,7 +398,7 @@ describe("SettingsSurface", () => {
     expect(screen.getByTestId("setting-price-table-manual-path")).toHaveTextContent(
       "claude-opus-4-8",
     );
-  });
+  }, 20_000);
 
   it("lists the resolved harnesses and stays silent when no descriptor is inert (#553)", async () => {
     fetchSettingsMock.mockResolvedValue(sample());

--- a/frontend/src/components/UnifiedLeftPanel.test.tsx
+++ b/frontend/src/components/UnifiedLeftPanel.test.tsx
@@ -1619,6 +1619,150 @@ describe("UnifiedLeftPanel run filters (#336)", () => {
 });
 
 // #577 — multi-select + bulk actions on the Runs list.
+// #725 — provenance badge « orchestrated » on child runs (click → parent) and
+// the « show orchestrated runs » toggle in the filter strip (ON by default; OFF
+// narrows to roots). Same session-only filter state; the clear ✕ resets it.
+describe("UnifiedLeftPanel orchestrated badge + roots-only toggle (#725)", () => {
+  const trig: Trigger = {
+    id: "trg-1",
+    name: "Nightly audit",
+    pipeline_id: "auditor",
+    pipeline_name: "auditor",
+    input_template: "",
+    variables: {},
+    cron: "0 9 * * *",
+    overlap_policy: "skip",
+    auto_name: true,
+    enabled: true,
+  };
+
+  const runs: RunListEntry[] = [
+    { run_id: "epic", pipeline_name: "orchestrate-epic", status: "running", started_at: null, name: "Refonte auth — orchestrateur" },
+    { run_id: "kid", pipeline_name: "implement-loop", status: "running", started_at: null, name: "#731 login form", parent_run_id: "epic" },
+    { run_id: "kid-trig", pipeline_name: "implement-loop", status: "running", started_at: null, name: "#733 logout — nightly", parent_run_id: "epic", triggered_by: "trg-1" },
+    { run_id: "orphan", pipeline_name: "implement-loop", status: "failed", started_at: null, name: "#700 spike", parent_run_id: "forgotten" },
+    { run_id: "arch-kid", pipeline_name: "implement-loop", status: "archived", started_at: null, name: "old child", parent_run_id: "epic" },
+  ];
+
+  it("shows the orchestrated badge on a child run and not on a root", () => {
+    renderPanel({ runs: [runs[0], runs[1]] });
+    expect(screen.getByTestId("run-orchestrated-badge")).toBeInTheDocument();
+    // Only the child row carries it — one badge for one child.
+    expect(screen.getAllByTestId("run-orchestrated-badge")).toHaveLength(1);
+  });
+
+  it("coexists with the trigger badge on the same run", () => {
+    renderPanel({ runs: [runs[2]] });
+    expect(screen.getByTestId("run-trigger-badge")).toBeInTheDocument();
+    expect(screen.getByTestId("run-orchestrated-badge")).toBeInTheDocument();
+  });
+
+  it("names the parent run in the badge tooltip", () => {
+    renderPanel({ runs: [runs[0], runs[1]] });
+    expect(screen.getByTestId("run-orchestrated-badge")).toHaveAttribute(
+      "title",
+      "Orchestrated by “Refonte auth — orchestrateur” — click to open the parent run",
+    );
+  });
+
+  it("clicking the badge selects the parent run, not the child", () => {
+    const onSelectRun = vi.fn();
+    render(
+      <UnifiedLeftPanel
+        runs={[runs[0], runs[1]]}
+        selectedRunId={null}
+        onSelectRun={onSelectRun}
+        onNewRun={noop}
+        libraryPipelines={[]}
+        onLibraryPipelinesChanged={noop}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("run-orchestrated-badge"));
+    expect(onSelectRun).toHaveBeenCalledTimes(1);
+    expect(onSelectRun).toHaveBeenCalledWith("epic");
+  });
+
+  it("dims an orphan badge (parent forgotten) and makes its click a no-op", () => {
+    const onSelectRun = vi.fn();
+    render(
+      <UnifiedLeftPanel
+        runs={[runs[3]]}
+        selectedRunId={null}
+        onSelectRun={onSelectRun}
+        onNewRun={noop}
+        libraryPipelines={[]}
+        onLibraryPipelinesChanged={noop}
+      />,
+    );
+    const badge = screen.getByTestId("run-orchestrated-badge");
+    expect(badge).toHaveAttribute("aria-disabled", "true");
+    expect(badge).toHaveAttribute(
+      "title",
+      "Orchestrated by a run that was forgotten",
+    );
+    fireEvent.click(badge);
+    expect(onSelectRun).not.toHaveBeenCalled();
+  });
+
+  it("tooltip of the trigger badge names the trigger", () => {
+    renderPanel({ runs: [runs[2]], triggers: [trig] });
+    expect(screen.getByTestId("run-trigger-badge")).toHaveAttribute(
+      "title",
+      "Created by trigger “Nightly audit” — click to open it in the Triggers tab",
+    );
+  });
+
+  it("hides the toggle when no orchestrated run exists", () => {
+    renderPanel({ runs: [runs[0]] });
+    expect(screen.queryByTestId("run-filter-orchestrated")).not.toBeInTheDocument();
+  });
+
+  it("shows the toggle pressed ON by default and hides children when switched off", async () => {
+    const user = userEvent.setup();
+    renderPanel({ runs });
+    const toggle = screen.getByTestId("run-filter-orchestrated");
+    expect(toggle).toHaveAttribute("aria-pressed", "true");
+
+    await user.click(toggle);
+    expect(screen.getByTestId("run-filter-orchestrated")).toHaveAttribute("aria-pressed", "false");
+    // Only roots remain — the epic; every child (incl. the archived one) hides,
+    // and with zero archived runs left the whole section disappears.
+    const labels = screen.getAllByTestId("run-display-label").map((el) => el.textContent);
+    expect(labels).toEqual(["Refonte auth — orchestrateur"]);
+    expect(screen.queryByTestId("run-archived-section")).not.toBeInTheDocument();
+
+    await user.click(screen.getByTestId("run-filter-orchestrated"));
+    expect(screen.getAllByTestId("run-display-label")).toHaveLength(4);
+  });
+
+  it("composes with the other filter axes (AND)", async () => {
+    const user = userEvent.setup();
+    renderPanel({ runs });
+
+    await user.click(screen.getByTestId("run-filter-orchestrated"));
+    await user.click(screen.getByTestId("run-filter-pipeline"));
+    await user.click(await screen.findByTestId("run-filter-option-implement-loop"));
+
+    // implement-loop runs are all children; roots-only leaves nothing.
+    expect(screen.queryAllByTestId("run-display-label")).toHaveLength(0);
+    expect(screen.getByTestId("run-filter-empty")).toBeInTheDocument();
+  });
+
+  it("the clear control resets the toggle to ON", async () => {
+    const user = userEvent.setup();
+    renderPanel({ runs });
+
+    await user.click(screen.getByTestId("run-filter-orchestrated"));
+    // Narrowed to roots ⇒ the strip grew a clear ✕.
+    expect(screen.getByTestId("run-filter-clear")).toBeInTheDocument();
+
+    await user.click(screen.getByTestId("run-filter-clear"));
+    expect(screen.getByTestId("run-filter-orchestrated")).toHaveAttribute("aria-pressed", "true");
+    expect(screen.queryByTestId("run-filter-clear")).not.toBeInTheDocument();
+    expect(screen.getAllByTestId("run-display-label")).toHaveLength(4);
+  });
+});
+
 describe("UnifiedLeftPanel run multi-select (#577)", () => {
   const twoRuns: RunListEntry[] = [
     { run_id: "r1", pipeline_name: "p", status: "completed", started_at: null, name: "Run One", effective_repo: "/repo/a" },

--- a/frontend/src/components/UnifiedLeftPanel.tsx
+++ b/frontend/src/components/UnifiedLeftPanel.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { ChevronDown, ChevronRight, Copy, FileUp, Pause, Pencil, Play, Plus, RotateCcw, SquareTerminal, Trash2, X, Zap } from "lucide-react";
+import { ChevronDown, ChevronRight, Copy, FileUp, GitFork, Pause, Pencil, Play, Plus, RotateCcw, SquareTerminal, Trash2, X, Zap } from "lucide-react";
 import { isLiveRun, isTerminalRun, type RunListEntry, type RunStatus, type PipelineListEntry, type Trigger, type Project } from "../types";
 import type { LibraryPipelineEntry } from "../api";
 import { cleanupRun, createPipeline, duplicatePipeline, forgetRun, importPipelineDocument, importWorkflow, openRunShell, pauseRun, renameRun, resumeRun, retryAll } from "../api";
@@ -19,7 +19,7 @@ import ForgetRunModal from "./ForgetRunModal";
 import LibraryRow from "./LibraryRow";
 import ProjectEditModal from "./ProjectEditModal";
 import RunFilters from "./RunFilters";
-import { EMPTY_RUN_FILTER, runMatchesFilter } from "./runFilter";
+import { EMPTY_RUN_FILTER, isFilterActive, runMatchesFilter } from "./runFilter";
 import RunShellModal from "./RunShellModal";
 import SelectControl from "./SelectControl";
 import TriggersListPanel from "./TriggersListPanel";
@@ -283,6 +283,7 @@ export default function UnifiedLeftPanel({
     return (
       <button
         key={run.run_id}
+        data-run-row={run.run_id}
         onClick={() => onSelectRun(run.run_id)}
         className={`group flex w-full cursor-pointer items-center gap-2 border-b border-l-2 border-line-soft px-3 py-2 text-left transition-colors ${
           rowSelected
@@ -337,12 +338,20 @@ export default function UnifiedLeftPanel({
             <span className="truncate" data-testid="run-pipeline-name">
               {run.pipeline_name}
             </span>
+            {/* #725 — provenance badges, icon-only (user decision 2026-09-06):
+                the words live in the `title`; `aria-label` carries the word for
+                AT. Same bordered 9px-chip shape so both read as "provenance",
+                different colours so they are never confused: the trigger is
+                accent-green, orchestrated is neutral grey. Both can coexist
+                (a child run may also be trigger-launched). */}
             {run.triggered_by && (
               <span
                 role="button"
-                title="Created by a trigger — open the Triggers tab"
-                className="flex shrink-0 cursor-pointer items-center gap-0.5 rounded border border-acc px-1 text-acc"
-                style={{ fontSize: "9px" }}
+                aria-label="trigger"
+                title={`Created by trigger “${
+                  triggers.find((t) => t.id === run.triggered_by)?.name ?? run.triggered_by
+                }” — click to open it in the Triggers tab`}
+                className="flex shrink-0 cursor-pointer items-center rounded border border-acc px-1.5 py-[2px] text-acc transition-colors hover:bg-acc-bg"
                 data-testid="run-trigger-badge"
                 onClick={(e) => {
                   e.stopPropagation();
@@ -350,10 +359,42 @@ export default function UnifiedLeftPanel({
                   setActiveTab("triggers");
                 }}
               >
-                <Zap size={8} />
-                trigger
+                <Zap size={9} />
               </span>
             )}
+            {run.parent_run_id &&
+              (() => {
+                // Parent resolved client-side from the list (no fetch). An
+                // orphan (parent forgotten) keeps its badge — the run WAS
+                // orchestrated — but dimmed and inert.
+                const parent = runs.find((r) => r.run_id === run.parent_run_id);
+                return (
+                  <span
+                    role="button"
+                    aria-label="orchestrated"
+                    aria-disabled={parent ? undefined : true}
+                    title={
+                      parent
+                        ? `Orchestrated by “${parent.name || parent.run_id}” — click to open the parent run`
+                        : "Orchestrated by a run that was forgotten"
+                    }
+                    className={`flex shrink-0 items-center rounded border border-fg-4 px-1.5 py-[2px] text-fg-3 transition-colors ${
+                      parent
+                        ? "cursor-pointer hover:border-fg-3 hover:text-fg-2"
+                        : "cursor-default opacity-70"
+                    }`}
+                    data-testid="run-orchestrated-badge"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      if (!parent) return;
+                      setScrollRequest(parent.run_id);
+                      if (parent.run_id !== selectedRunId) onSelectRun(parent.run_id);
+                    }}
+                  >
+                    <GitFork size={9} />
+                  </span>
+                );
+              })()}
           </div>
         </div>
         {!isRenaming && (
@@ -475,8 +516,22 @@ export default function UnifiedLeftPanel({
     () => runs.filter((r) => runMatchesFilter(r, runFilter)),
     [runs, runFilter],
   );
-  const filterActive =
-    runFilter.repo !== null || runFilter.pipeline !== null || runFilter.trigger !== null;
+  const filterActive = isFilterActive(runFilter);
+
+  // #725 — after an orchestrated-badge click, scroll the parent's row into view:
+  // the parent is usually above its children but can sit off-screen on long
+  // lists (and inside the Archived section, whose auto-expand only lands after
+  // the selection re-renders). The request rides STATE (not a ref) so the row
+  // mapper stays ref-free (react-hooks/refs); the effect consumes it one-shot.
+  const runsScrollRef = useRef<HTMLDivElement>(null);
+  const [scrollRequest, setScrollRequest] = useState<string | null>(null);
+  useEffect(() => {
+    if (scrollRequest === null || selectedRunId !== scrollRequest) return;
+    setScrollRequest(null);
+    runsScrollRef.current
+      ?.querySelector(`[data-run-row="${scrollRequest}"]`)
+      ?.scrollIntoView({ block: "nearest" });
+  }, [scrollRequest, selectedRunId]);
 
   // #136 — archived runs live in their own flat, collapsible section below the
   // active list; the active list keeps the #258 per-repo grouping.
@@ -709,6 +764,7 @@ export default function UnifiedLeftPanel({
           />
         )}
         <div
+          ref={runsScrollRef}
           className="flex-1 overflow-y-auto outline-none"
           tabIndex={-1}
           onKeyDown={(e) =>

--- a/frontend/src/components/runFilter.test.ts
+++ b/frontend/src/components/runFilter.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import {
+  EMPTY_RUN_FILTER,
+  isFilterActive,
+  isRootRun,
+  runMatchesFilter,
+  type RunFilterValue,
+} from "./runFilter";
+import type { RunListEntry } from "../types";
+
+/* #725 — the fourth filter axis. `showOrchestrated: false` narrows the list to
+   root runs (no `parent_run_id`); it composes with the three #336 axes with AND
+   semantics and is part of `isFilterActive`, so the strip's clear ✕ resets it. */
+
+const run = (over: Partial<RunListEntry>): RunListEntry => ({
+  run_id: "r",
+  pipeline_name: "p",
+  status: "running",
+  started_at: null,
+  ...over,
+});
+
+const root = run({ run_id: "root" });
+const child = run({ run_id: "child", parent_run_id: "root" });
+
+describe("runFilter #725 — showOrchestrated axis", () => {
+  it("defaults to showing orchestrated runs (EMPTY_RUN_FILTER)", () => {
+    expect(EMPTY_RUN_FILTER.showOrchestrated).toBe(true);
+    expect(runMatchesFilter(child, EMPTY_RUN_FILTER)).toBe(true);
+    expect(runMatchesFilter(root, EMPTY_RUN_FILTER)).toBe(true);
+  });
+
+  it("classifies roots and children from parent_run_id", () => {
+    expect(isRootRun(root)).toBe(true);
+    expect(isRootRun(child)).toBe(false);
+    // A null parent id (daemon ships the field on every entry) is still a root.
+    expect(isRootRun(run({ parent_run_id: null }))).toBe(true);
+  });
+
+  it("hides children and keeps roots when showOrchestrated is false", () => {
+    const f: RunFilterValue = { ...EMPTY_RUN_FILTER, showOrchestrated: false };
+    expect(runMatchesFilter(child, f)).toBe(false);
+    expect(runMatchesFilter(root, f)).toBe(true);
+  });
+
+  it("composes with the other axes with AND semantics", () => {
+    const alpha = run({ run_id: "a", effective_repo: "/repos/alpha", parent_run_id: "root" });
+    const f: RunFilterValue = {
+      repo: "/repos/alpha",
+      pipeline: null,
+      trigger: null,
+      showOrchestrated: false,
+    };
+    // Matches the repo axis but is a child ⇒ filtered out.
+    expect(runMatchesFilter(alpha, f)).toBe(false);
+    // Relax the toggle ⇒ visible again.
+    expect(runMatchesFilter(alpha, { ...f, showOrchestrated: true })).toBe(true);
+  });
+
+  it("reports the toggle in isFilterActive so the clear ✕ resets it", () => {
+    expect(isFilterActive(EMPTY_RUN_FILTER)).toBe(false);
+    expect(isFilterActive({ ...EMPTY_RUN_FILTER, showOrchestrated: false })).toBe(true);
+    expect(isFilterActive({ ...EMPTY_RUN_FILTER, repo: "/repos/x" })).toBe(true);
+  });
+});

--- a/frontend/src/components/runFilter.ts
+++ b/frontend/src/components/runFilter.ts
@@ -21,12 +21,19 @@ export interface RunFilterValue {
   pipeline: string | null;
   /** A trigger id, or MANUAL_TRIGGER for manually launched runs. */
   trigger: string | null;
+  /**
+   * #725 — whether runs started by another run (orchestrated children) are
+   * listed. ON by default ("déplié par défaut", issue #725): a child parked
+   * `awaiting_user` must stay visible, so hiding it is an explicit act.
+   */
+  showOrchestrated: boolean;
 }
 
 export const EMPTY_RUN_FILTER: RunFilterValue = {
   repo: null,
   pipeline: null,
   trigger: null,
+  showOrchestrated: true,
 };
 
 /** The filter key for a run on each axis (empty/missing values bucket to a sentinel). */
@@ -41,10 +48,28 @@ export function triggerKey(r: RunListEntry): string {
   return r.triggered_by ?? MANUAL_TRIGGER;
 }
 
-/** AND predicate over the three axes; a null axis means "All". */
+/** #725 — a root run is one no other run started. */
+export function isRootRun(r: RunListEntry): boolean {
+  return !r.parent_run_id;
+}
+
+/**
+ * AND predicate over the four axes; a null axis means "All", and
+ * `showOrchestrated: false` narrows the list to roots (#725).
+ */
 export function runMatchesFilter(r: RunListEntry, f: RunFilterValue): boolean {
   if (f.repo !== null && repoKey(r) !== f.repo) return false;
   if (f.pipeline !== null && pipelineKey(r) !== f.pipeline) return false;
   if (f.trigger !== null && triggerKey(r) !== f.trigger) return false;
+  if (!f.showOrchestrated && !isRootRun(r)) return false;
   return true;
+}
+
+/**
+ * True when at least one axis narrows the list — the condition for the strip's
+ * clear ✕ (and the empty state's). #725 adds the orchestrated toggle to it, so
+ * clearing resets the toggle to ON for free.
+ */
+export function isFilterActive(f: RunFilterValue): boolean {
+  return f.repo !== null || f.pipeline !== null || f.trigger !== null || !f.showOrchestrated;
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -604,6 +604,12 @@ export interface RunListEntry {
   /** Provenance: the id of the Trigger that created this Run, if any (#160). */
   triggered_by?: string | null;
   /**
+   * Provenance (#720, ADR-0064): the id of the run that orchestrated this one,
+   * if any. Shipped by the daemon on every `GET /runs` entry; declared optional
+   * so existing test fixtures that omit it still typecheck.
+   */
+  parent_run_id?: string | null;
+  /**
    * Resolved target repo for "group by project" (#258): the run's `target_repo`,
    * or the daemon's `repo_root` when unset. Always sent by the daemon; declared
    * optional so existing test fixtures that omit it still typecheck.

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -64,5 +64,10 @@ export default defineConfig({
     globals: true,
     setupFiles: ['./src/test/setup.ts'],
     exclude: ['e2e/**', 'node_modules/**'],
+    // Heavy App/EditCanvas jsdom renders routinely exceed vitest's 5s default
+    // when the suite runs on a loaded machine (parallel workers); the failures
+    // were pure timeouts moving between unrelated heavy tests run to run.
+    // 20s matches the per-test bump already used for the mermaid import test.
+    testTimeout: 20_000,
   },
 })


### PR DESCRIPTION
## Contenu

Ticket [#725](https://github.com/Loulen/prompt-driven-orchestrator/issues/725) (story #709) — liste de runs :

- Badge « orchestrated » (GitFork, gris neutre) sur les run **enfants** uniquement, à côté du badge trigger (accent/Zap, désormais icon-only) ; orphelin dimmé et inerte. Clic → ouvre le run parent + scrollIntoView.
- 4ᵉ axe de filtre « racines seules » (chip icon-only GitFork, ON par défaut, offerte seulement si des runs orchestrés existent) ; filtre appliqué avant le split actifs/archivés ; le ✕ « Clear filters » réinitialise le toggle.
- Tout est calcul de vue sur `parent_run_id` (#720) — aucun endpoint nouveau.

## Release

- `chore(release): 1.67.0` — bump minor + entrée CHANGELOG.
- Drive-by build : `frontend/pnpm-workspace.yaml` approuve le build script `msw` (pnpm 11 fait échouer `pnpm install` sinon — bloquait `build.rs`).

## Validation

- Unitaires : `runFilter.test.ts` + bloc #725 dans `UnifiedLeftPanel.test.tsx` (verts).
- **FP #725 vert** (agentic test, verdict Pass) : 3 Feature Paths vérifiés sur stack réelle, 0 erreur console, fidèle au design. Détail dans le rapport d'agentic test du run.