### PR TITLE
feat(#724): liaison forte orchestrateur ↔ enfants — 1.68.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ ascendante** : la casse se signale ici et par un bump majeur, jamais en gardant 
 morts. Seule contrainte non négociable — les **données historiques restent lisibles** : un Run
 archivé s'ouvre et se chiffre quelle que soit la version qui a écrit son payload.
 
+## 1.68.0
+
+**Liaison forte orchestrateur ↔ enfants** (#724 ; story #709, spec #719, ADR-0064). Un nœud
+portant le toggle « Orchestrator » (posé par #723, gelé dans le snapshot `node_defs` de
+`RunStarted`) ne peut plus se compléter tant que ses runs enfants (`parent_run_id` +
+`parent_node_id`, ADR-0064) sont non terminaux : `pdo complete` est refusé en 409
+`children_pending` avec compteur (active/failed, exit 3 recoverable tant qu'aucun enfant n'a
+échoué, exit 4 dès qu'un enfant est `failed`). Au refus, un marqueur `NodeAwaitingUser`
+(`reason: children_pending`, idempotent) parque le nœud et arme un watcher détaché qui, dès que
+tous les enfants sont terminaux sans échec, complète le nœud par la voie commune (source
+`children_settled` — livraison, validation, terminal, advance identiques à un `pdo complete`).
+Un enfant `awaiting_user`/`paused` retient aussi le nœud ; l'arbitrage utilisateur (retry,
+`Mark complete`) ou le forçage `mark_node_done` — volontairement non gated — dénouent. Aucune
+propagation de mort vers le bas : la liaison ne fait que lire — stop, archive et forget du
+parent ne touchent pas les enfants, un restart ré-adopte les enfants vivants, et un nœud sans
+toggle n'est jamais retenu.
+
 ## 1.66.0
 
 **`pdo run create <pipeline>` — créer un run enfant depuis une session de nœud** (#721 ; story #709,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "1.67.0"
+version = "1.68.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "1.67.0"
+version = "1.68.0"
 license = "MIT"
 description = "Prompt-Driven Orchestrator — a local daemon that runs and supervises agentic coding pipelines"
 repository = "https://github.com/Loulen/prompt-driven-orchestrator"

--- a/crates/pdo-daemon/src/boot_recovery.rs
+++ b/crates/pdo-daemon/src/boot_recovery.rs
@@ -326,6 +326,7 @@ mod tests {
         let mut rs = event_log::RunState::new(run_id.into(), "test".into());
         rs.node_defs.push(event_log::NodeDefInfo {
             isolated_worktree: Some(isolated),
+            orchestrator: false,
             id: node_id.into(),
             name: None,
             node_type: "agent".into(),

--- a/crates/pdo-daemon/src/completion_refusal.rs
+++ b/crates/pdo-daemon/src/completion_refusal.rs
@@ -94,6 +94,21 @@ pub(crate) enum CompletionRefusal {
     MergeResolverFailed {
         reason: String,
     },
+    /// Liaison forte orchestrateur ↔ enfants (#724 / ADR-0064) : le nœud est
+    /// orchestrator (toggle gelé au démarrage du Run) et ses runs enfants (mêmes
+    /// `parent_run_id` + `parent_node_id`) ne sont pas tous terminaux. Le nœud
+    /// reste vivant : aucun événement terminal n'est appendé, la livraison n'a
+    /// pas lieu. Avec au moins un enfant `failed`, le NodeRun est parqué
+    /// `AwaitingUser` (le `NodeAwaitingUser` porte `reason: "children_pending"`)
+    /// et la décision appartient à l'utilisateur — retry de l'enfant ou forçage
+    /// (`mark_node_done`), jamais à l'agent.
+    ChildrenPending {
+        node_id: String,
+        /// Enfants encore non terminaux (running / awaiting_user / paused).
+        active: usize,
+        /// Enfants `failed` — ceux que l'utilisateur doit trancher.
+        failed: usize,
+    },
 }
 
 impl CompletionRefusal {
@@ -116,6 +131,7 @@ impl CompletionRefusal {
             Self::MergeResolutionFailed { .. } => "merge_resolution_failed",
             Self::MergeResolverSpawned { .. } => "merge_resolver_spawned",
             Self::MergeResolverFailed { .. } => "merge_resolver_failed",
+            Self::ChildrenPending { .. } => "children_pending",
         }
     }
 
@@ -125,7 +141,12 @@ impl CompletionRefusal {
     pub(crate) fn recoverable(&self) -> bool {
         matches!(
             self,
-            Self::MissingOutputs { .. } | Self::FrontmatterRetryPending { .. }
+            Self::MissingOutputs { .. }
+                | Self::FrontmatterRetryPending { .. }
+                // Des enfants simplement en cours : l'agent garde la main — il
+                // attend qu'ils se terminent et re-complète. Avec un enfant
+                // `failed`, c'est l'utilisateur qui tranche (exit 4).
+                | Self::ChildrenPending { failed: 0, .. }
         )
     }
 
@@ -149,7 +170,8 @@ impl CompletionRefusal {
             | Self::SecondaryRepoDirtied { .. }
             | Self::MergeResolutionFailed { .. }
             | Self::MergeResolverSpawned { .. }
-            | Self::MergeResolverFailed { .. } => StatusCode::CONFLICT,
+            | Self::MergeResolverFailed { .. }
+            | Self::ChildrenPending { .. } => StatusCode::CONFLICT,
         }
     }
 
@@ -185,6 +207,16 @@ impl CompletionRefusal {
             }
             Self::MergeResolverSpawned { node_id } => serde_json::json!({
                 "message": format!("merge conflict on {node_id}: resolver spawned")
+            }),
+            Self::ChildrenPending {
+                node_id,
+                active,
+                failed,
+            } => serde_json::json!({
+                "node_id": node_id,
+                "active": active,
+                "failed": failed,
+                "message": children_pending_message(node_id, *active, *failed),
             }),
         }
     }
@@ -225,7 +257,30 @@ impl CompletionRefusal {
             Self::MergeResolverFailed { reason } => {
                 format!("merge resolver spawn failed: {reason}")
             }
+            Self::ChildrenPending {
+                node_id,
+                active,
+                failed,
+            } => children_pending_message(node_id, *active, *failed),
         }
+    }
+}
+
+/// Le message « avec compteur » du refus de liaison (#724) : l'agent (et la
+/// surface) voient COMBIEN d'enfants retiennent encore le nœud, et lesquels
+/// réclament l'utilisateur.
+fn children_pending_message(node_id: &str, active: usize, failed: usize) -> String {
+    if failed > 0 {
+        format!(
+            "orchestrator node `{node_id}` is held by its child runs: {active} active, \
+             {failed} failed — the node is awaiting the user: retry the failed child run or \
+             force-complete the node"
+        )
+    } else {
+        format!(
+            "orchestrator node `{node_id}` is held by its child runs: {active} active — \
+             complete again once every child run is terminal"
+        )
     }
 }
 
@@ -308,6 +363,11 @@ mod tests {
             CompletionRefusal::MergeResolverFailed {
                 reason: "spawn failed".into(),
             },
+            CompletionRefusal::ChildrenPending {
+                node_id: "orch".into(),
+                active: 2,
+                failed: 1,
+            },
         ];
 
         // Plancher de couverture : le `match` sans joker force à nommer chaque
@@ -330,6 +390,7 @@ mod tests {
                 CompletionRefusal::MergeResolutionFailed { .. } => "MergeResolutionFailed",
                 CompletionRefusal::MergeResolverSpawned { .. } => "MergeResolverSpawned",
                 CompletionRefusal::MergeResolverFailed { .. } => "MergeResolverFailed",
+                CompletionRefusal::ChildrenPending { .. } => "ChildrenPending",
             };
             seen.insert(key);
         }
@@ -391,9 +452,41 @@ mod tests {
                 r,
                 CompletionRefusal::MissingOutputs { .. }
                     | CompletionRefusal::FrontmatterRetryPending { .. }
+                    // La liaison forte laisse la main à l'agent tant qu'aucun
+                    // enfant n'a échoué (#724).
+                    | CompletionRefusal::ChildrenPending { failed: 0, .. }
             );
             assert_eq!(r.recoverable(), expected, "{} recoverable()", r.slug());
         }
+        // Avec un enfant `failed`, la décision est à l'utilisateur (exit 4).
+        let failed_child = CompletionRefusal::ChildrenPending {
+            node_id: "orch".into(),
+            active: 1,
+            failed: 1,
+        };
+        assert!(!failed_child.recoverable());
+    }
+
+    /// Le refus de liaison compte : le message porte les deux compteurs (#724).
+    #[test]
+    fn children_pending_message_counts_active_and_failed() {
+        let r = CompletionRefusal::ChildrenPending {
+            node_id: "orch".into(),
+            active: 2,
+            failed: 0,
+        };
+        let reason = r.reason();
+        assert!(reason.contains("2 active"), "{reason}");
+        assert!(!reason.contains("failed"), "{reason}");
+
+        let r = CompletionRefusal::ChildrenPending {
+            node_id: "orch".into(),
+            active: 1,
+            failed: 3,
+        };
+        let reason = r.reason();
+        assert!(reason.contains("1 active"), "{reason}");
+        assert!(reason.contains("3 failed"), "{reason}");
     }
 
     /// « Jamais `2xx` » **≠** « toujours `409` ».

--- a/crates/pdo-daemon/src/event_log.rs
+++ b/crates/pdo-daemon/src/event_log.rs
@@ -53,6 +53,12 @@ pub struct NodeDefInfo {
     /// when absent.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub isolated_worktree: Option<bool>,
+    /// The « Orchestrator » toggle (#723/#724, ADR-0064) as the Run's snapshot
+    /// froze it at start: `true` ⇒ the strong orchestrator↔children binding
+    /// holds this node's NodeRun. `false` (default) keeps every pre-#723 run
+    /// unbound; `skip_serializing_if` keeps the wire byte-identical when unset.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub orchestrator: bool,
     pub view_x: Option<f64>,
     pub view_y: Option<f64>,
     pub inputs: Vec<PortBrief>,

--- a/crates/pdo-daemon/src/graph_resolver.rs
+++ b/crates/pdo-daemon/src/graph_resolver.rs
@@ -430,6 +430,7 @@ mod tests {
             harnesses: Default::default(),
             agent_choice: None,
             auto_fail: None,
+            orchestrator: false,
         }
     }
 
@@ -498,6 +499,7 @@ mod tests {
             harnesses: Default::default(),
             agent_choice: None,
             auto_fail: None,
+            orchestrator: false,
         }
     }
 

--- a/crates/pdo-daemon/src/input_resolution.rs
+++ b/crates/pdo-daemon/src/input_resolution.rs
@@ -456,6 +456,7 @@ mod tests {
             harnesses: Default::default(),
             agent_choice: None,
             auto_fail: None,
+            orchestrator: false,
         }
     }
 

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -4962,7 +4962,7 @@ pub(crate) async fn append_event_with(
 /// them once the staging is purged. The walk runs detached, so it never adds latency
 /// or a failure mode to the terminal transition; it is idempotent, so a double-fire
 /// is safe.
-async fn append_event(state: &AppState, event: &event_log::Event) -> Result<()> {
+pub(crate) async fn append_event(state: &AppState, event: &event_log::Event) -> Result<()> {
     append_event_with(&state.db, &state.event_tx, event).await?;
     if matches!(
         event.kind,
@@ -4977,7 +4977,7 @@ async fn append_event(state: &AppState, event: &event_log::Event) -> Result<()> 
 }
 
 /// Whether a run_id has been tombstoned by forget (ADR-0024).
-async fn run_is_forgotten(db: &sqlx::SqlitePool, run_id: &str) -> Result<bool> {
+pub(crate) async fn run_is_forgotten(db: &sqlx::SqlitePool, run_id: &str) -> Result<bool> {
     let row: Option<(i64,)> =
         sqlx::query_as("SELECT 1 FROM forgotten_runs WHERE run_id = ? LIMIT 1")
             .bind(run_id)
@@ -5120,7 +5120,7 @@ async fn load_events(db: &sqlx::SqlitePool, run_id: &str) -> Result<Vec<event_lo
     Ok(rows.into_iter().map(|r| r.into_event()).collect())
 }
 
-async fn load_all_run_ids(db: &sqlx::SqlitePool) -> Result<Vec<String>> {
+pub(crate) async fn load_all_run_ids(db: &sqlx::SqlitePool) -> Result<Vec<String>> {
     let rows: Vec<(String,)> =
         sqlx::query_as("SELECT DISTINCT run_id FROM events ORDER BY run_id DESC")
             .fetch_all(db)
@@ -14715,6 +14715,12 @@ pub(crate) enum CompletionSource {
     /// fallback. Records `NodeAutoCompleted` like `TurnEnded`, differing only in the
     /// log label. The two are idempotent: whichever arrives second gets a `NoOp`.
     StopHook,
+    /// The strong binding settled (#724 / ADR-0064): the binding-parked
+    /// orchestrator node's watcher saw every child run terminal with no failure
+    /// and completed the node itself — « le nœud se complète ». Goes through the
+    /// SAME body as every other source (`complete_node_iteration`); the payload
+    /// signs WHO decided: the binding, not the agent.
+    ChildrenSettled,
 }
 
 impl CompletionSource {
@@ -14727,6 +14733,19 @@ impl CompletionSource {
             CompletionSource::TurnEnded => event_log::EventKind::NodeAutoCompleted,
             // Reuse the SAME event kind: no new projection / transition-guard arm.
             CompletionSource::StopHook => event_log::EventKind::NodeAutoCompleted,
+            // A truthful completion: the node IS complete, its children settled.
+            // `NodeAutoCompleted` would lie about WHO decided — the binding did.
+            CompletionSource::ChildrenSettled => event_log::EventKind::NodeCompleted,
+        }
+    }
+
+    /// The terminal event's payload. `None` keeps the historical wire shape for
+    /// the agent-driven sources; the daemon-driven one signs its verdict, the
+    /// same way `mark_node_done` signs `source: "mark_node_done"`.
+    fn payload(self) -> Option<serde_json::Value> {
+        match self {
+            Self::ChildrenSettled => Some(serde_json::json!({ "source": "children_settled" })),
+            _ => None,
         }
     }
 
@@ -14736,6 +14755,7 @@ impl CompletionSource {
             CompletionSource::Explicit => "node_done",
             CompletionSource::TurnEnded => "node_done(auto:turn_ended)",
             CompletionSource::StopHook => "node_done(auto:stop_hook)",
+            CompletionSource::ChildrenSettled => "node_done(children_settled)",
         }
     }
 }
@@ -14945,7 +14965,7 @@ fn secondary_repos_dirtied_refusal(
 /// refusal built here has already appended its own parking events — the caller
 /// only projects it.
 #[allow(clippy::too_many_arguments)]
-async fn deliver_node_run(
+pub(crate) async fn deliver_node_run(
     state: &Arc<AppState>,
     events: &[event_log::Event],
     run_state: &event_log::RunState,
@@ -15211,7 +15231,7 @@ async fn deliver_node_run(
     }
 }
 
-async fn complete_node_iteration(
+pub(crate) async fn complete_node_iteration(
     state: &Arc<AppState>,
     run_id: String,
     node_id: String,
@@ -15284,6 +15304,26 @@ async fn complete_node_iteration(
         };
     }
 
+    // Liaison forte orchestrateur ↔ enfants (#724 / ADR-0064): a node with the
+    // « Orchestrator » toggle does not terminate while its child runs are
+    // non-terminal. The gate sits after the transition guard but BEFORE any
+    // effect (delivery, validation): a refusal leaves the node alive and its
+    // session intact — and, with a `failed` child, parks the node
+    // `AwaitingUser` for the user's arbitration (retry the child, or force
+    // through `mark_node_done`, which is deliberately NOT gated).
+    if let Some(refusal) = run_advance::orchestrator_binding_refusal(
+        state,
+        &events,
+        &pre_run_state,
+        &run_id,
+        &node_id,
+        iter,
+    )
+    .await
+    {
+        return CompletionAttempt::refused(refusal);
+    }
+
     // Must sit here: after the transition gate but BEFORE any merge or terminal
     // event. Non-terminal by design — the node stays alive, so once the agent reverts
     // the tracked change and re-completes, the guard passes.
@@ -15335,11 +15375,12 @@ async fn complete_node_iteration(
         ts: event_log::now_iso(),
         // `NodeAutoCompleted` on the sweep path — same projection, same guard, but
         // the log must say the completion was automatic. Deliberately the event KIND
-        // and not a `source` field in the payload.
+        // and not a `source` field in the payload. The binding's own verdict
+        // (#724) signs its payload instead: the log says WHO completed and why.
         kind: source.event_kind(),
         node_id: Some(node_id.clone()),
         iter: Some(iter),
-        payload: None,
+        payload: source.payload(),
     };
 
     if let Err(e) = append_event(state, &event).await {
@@ -18433,6 +18474,10 @@ fn node_def_from_pipeline(n: &pipeline::NodeDef) -> event_log::NodeDefInfo {
         // what the completion path reads back to know whether a sub-worktree has
         // to be merged, without re-deriving it from a type that no longer says.
         isolated_worktree: n.isolated_worktree,
+        // #723/#724/ADR-0064: the « Orchestrator » toggle, frozen at run start —
+        // what the strong binding gate reads to know whether this node's NodeRun
+        // is held while its child runs are non-terminal.
+        orchestrator: n.orchestrator,
         view_x: n.view.as_ref().map(|v| v.x),
         view_y: n.view.as_ref().map(|v| v.y),
         inputs: n.inputs.iter().map(|p| port_brief(p, "left")).collect(),
@@ -18664,7 +18709,7 @@ fn resolve_run_pipeline_path(
 ///
 /// `Option<CompletionRefusal>` and not `Result<_, Response>`: `Response` is 128
 /// bytes, exactly the `clippy::result_large_err` threshold CI treats as an error.
-async fn check_output_validation_with_retry(
+pub(crate) async fn check_output_validation_with_retry(
     state: &AppState,
     pipeline_path: &std::path::Path,
     node_id: &str,
@@ -18842,7 +18887,7 @@ fn pane_snapshot_path(
 /// keeps working after the session is gone — then kills the session. A capture/write
 /// failure MUST still proceed to the kill, or a terminal node leaks a live session
 /// toward the tmux-collapse point.
-fn reap_node_session(
+pub(crate) fn reap_node_session(
     state: &AppState,
     repo_root: &std::path::Path,
     run_id: &str,
@@ -24824,6 +24869,7 @@ mod tests {
         let mut rs = event_log::RunState::new(run_id.into(), "test".into());
         rs.node_defs.push(event_log::NodeDefInfo {
             isolated_worktree: None,
+            orchestrator: false,
             id: node_id.into(),
             name: None,
             node_type: node_type.into(),
@@ -24892,6 +24938,7 @@ mod tests {
             harnesses: Default::default(),
             agent_choice: None,
             auto_fail: None,
+            orchestrator: false,
         }
     }
 
@@ -34194,6 +34241,7 @@ edges: []
             harnesses: Default::default(),
             agent_choice: None,
             auto_fail: None,
+            orchestrator: false,
         };
         let pipeline = pipeline::PipelineDef {
             name: "spawn-unit".into(),

--- a/crates/pdo-daemon/src/library_store.rs
+++ b/crates/pdo-daemon/src/library_store.rs
@@ -1082,6 +1082,7 @@ mod tests {
             harnesses: Default::default(),
             agent_choice: None,
             auto_fail: None,
+            orchestrator: false,
         }
     }
 

--- a/crates/pdo-daemon/src/loop_region.rs
+++ b/crates/pdo-daemon/src/loop_region.rs
@@ -548,6 +548,7 @@ mod tests {
             harnesses: Default::default(),
             agent_choice: None,
             auto_fail: None,
+            orchestrator: false,
         }
     }
 

--- a/crates/pdo-daemon/src/mutation_validator.rs
+++ b/crates/pdo-daemon/src/mutation_validator.rs
@@ -221,6 +221,7 @@ mod tests {
             harnesses: Default::default(),
             agent_choice: None,
             auto_fail: None,
+            orchestrator: false,
         }
     }
 
@@ -243,6 +244,7 @@ mod tests {
             harnesses: Default::default(),
             agent_choice: None,
             auto_fail: None,
+            orchestrator: false,
         }
     }
 

--- a/crates/pdo-daemon/src/node_io_resolver.rs
+++ b/crates/pdo-daemon/src/node_io_resolver.rs
@@ -368,6 +368,7 @@ mod tests {
                     harnesses: Default::default(),
                     agent_choice: None,
                     auto_fail: None,
+                    orchestrator: false,
                 },
                 NodeDef {
                     skills: Vec::new(),
@@ -405,6 +406,7 @@ mod tests {
                     harnesses: Default::default(),
                     agent_choice: None,
                     auto_fail: None,
+                    orchestrator: false,
                 },
             ],
             edges: vec![EdgeDef {
@@ -562,6 +564,7 @@ mod tests {
                     harnesses: Default::default(),
                     agent_choice: None,
                     auto_fail: None,
+                    orchestrator: false,
                 },
                 NodeDef {
                     skills: Vec::new(),
@@ -599,6 +602,7 @@ mod tests {
                     harnesses: Default::default(),
                     agent_choice: None,
                     auto_fail: None,
+                    orchestrator: false,
                 },
             ],
             edges: vec![EdgeDef {
@@ -763,6 +767,7 @@ mod tests {
                     harnesses: Default::default(),
                     agent_choice: None,
                     auto_fail: None,
+                    orchestrator: false,
                 },
                 NodeDef {
                     skills: Vec::new(),
@@ -790,6 +795,7 @@ mod tests {
                     harnesses: Default::default(),
                     agent_choice: None,
                     auto_fail: None,
+                    orchestrator: false,
                 },
                 NodeDef {
                     skills: Vec::new(),
@@ -817,6 +823,7 @@ mod tests {
                     harnesses: Default::default(),
                     agent_choice: None,
                     auto_fail: None,
+                    orchestrator: false,
                 },
             ],
             edges: vec![
@@ -912,6 +919,7 @@ mod tests {
                     harnesses: Default::default(),
                     agent_choice: None,
                     auto_fail: None,
+                    orchestrator: false,
                 },
                 NodeDef {
                     skills: Vec::new(),
@@ -930,6 +938,7 @@ mod tests {
                     harnesses: Default::default(),
                     agent_choice: None,
                     auto_fail: None,
+                    orchestrator: false,
                 },
             ],
             edges: vec![EdgeDef {
@@ -1004,6 +1013,7 @@ mod tests {
             harnesses: Default::default(),
             agent_choice: None,
             auto_fail: None,
+            orchestrator: false,
         };
         let mk_edge = |src: &str| EdgeDef {
             source: EdgeEndpoint {
@@ -1090,6 +1100,7 @@ mod tests {
             harnesses: Default::default(),
             agent_choice: None,
             auto_fail: None,
+            orchestrator: false,
         };
         let mk_edge = |src: &str, port: &str| EdgeDef {
             source: EdgeEndpoint {
@@ -1177,6 +1188,7 @@ mod tests {
                 harnesses: Default::default(),
                 agent_choice: None,
                 auto_fail: None,
+                orchestrator: false,
             }],
             edges: Vec::new(),
             loops: Vec::new(),

--- a/crates/pdo-daemon/src/node_primitives.rs
+++ b/crates/pdo-daemon/src/node_primitives.rs
@@ -959,6 +959,7 @@ mod tests {
             harnesses: Default::default(),
             agent_choice: None,
             auto_fail: None,
+            orchestrator: false,
         }
     }
 
@@ -999,6 +1000,7 @@ mod tests {
             harnesses: Default::default(),
             agent_choice: None,
             auto_fail: None,
+            orchestrator: false,
         }
     }
 

--- a/crates/pdo-daemon/src/outputs_validator.rs
+++ b/crates/pdo-daemon/src/outputs_validator.rs
@@ -310,6 +310,7 @@ mod tests {
             harnesses: Default::default(),
             agent_choice: None,
             auto_fail: None,
+            orchestrator: false,
         }
     }
 

--- a/crates/pdo-daemon/src/pipeline.rs
+++ b/crates/pdo-daemon/src/pipeline.rs
@@ -234,6 +234,15 @@ pub(crate) struct NodeDef {
     /// the pipeline does, so it enters the diff and the library content hash.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub isolated_worktree: Option<bool>,
+    /// The « Orchestrator » toggle (#723, ADR-0064). `true` ⇒ the node's NodeRun
+    /// is held by the strong orchestrator↔children binding (#724): the completion
+    /// gate refuses `pdo complete` while the child runs spawned from this node's
+    /// sessions (same `parent_run_id` + `parent_node_id`) are non-terminal. It is
+    /// NOT a node type — the spawn capacity stays universal; the toggle only adds
+    /// the binding contract (plus the #723 prompt amendment and skill reference).
+    /// Semantic, not layout — in the diff and the library content hash.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub orchestrator: bool,
 }
 
 impl NodeDef {
@@ -2835,6 +2844,7 @@ skills:
             agent_choice: None,
             skills: Vec::new(),
             auto_fail: None,
+            orchestrator: false,
         };
         let yaml = serde_yaml::to_string(&node).unwrap();
         assert!(yaml.contains("type: script"), "serializes to kebab: {yaml}");

--- a/crates/pdo-daemon/src/pipeline_migrator.rs
+++ b/crates/pdo-daemon/src/pipeline_migrator.rs
@@ -2456,6 +2456,7 @@ edges:
             harnesses: Default::default(),
             agent_choice: None,
             auto_fail: None,
+            orchestrator: false,
         }
     }
 
@@ -2496,6 +2497,7 @@ edges:
             harnesses: Default::default(),
             agent_choice: None,
             auto_fail: None,
+            orchestrator: false,
         }
     }
 
@@ -2536,6 +2538,7 @@ edges:
             harnesses: Default::default(),
             agent_choice: None,
             auto_fail: None,
+            orchestrator: false,
         }
     }
 

--- a/crates/pdo-daemon/src/pipeline_semantics.rs
+++ b/crates/pdo-daemon/src/pipeline_semantics.rs
@@ -158,6 +158,12 @@ struct NodeProjection<'a> {
     /// byte-identical to its pre-résilience content hash.
     #[serde(skip_serializing_if = "Option::is_none")]
     auto_fail: Option<bool>,
+    /// Semantic (#723/#724, ADR-0064): the « Orchestrator » toggle changes the
+    /// node's completion contract. `skip_serializing_if` keeps a node without the
+    /// toggle byte-identical to its pre-#723 content hash, the same discipline
+    /// `auto_fail` above uses.
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    orchestrator: bool,
     /// Where the node's NodeRun works (#653, ADR-0060). Semantic: moving a node
     /// between the Run worktree and one of its own changes what the pipeline
     /// does — a parallel pair that shared a tree does not become the same
@@ -186,6 +192,7 @@ impl<'a> NodeProjection<'a> {
             agent_choice,
             skills,
             auto_fail,
+            orchestrator,
             isolated_worktree,
         } = node;
         let _layout = view; // LAYOUT_FIELDS["node"]
@@ -201,6 +208,7 @@ impl<'a> NodeProjection<'a> {
             max_iter: max_iter.as_ref().map(canon_yaml),
             over: over.as_deref(),
             auto_fail: *auto_fail,
+            orchestrator: *orchestrator,
             isolated_worktree: *isolated_worktree,
             inputs: inputs.iter().map(PortProjection::of).collect(),
             outputs: outputs.iter().map(PortProjection::of).collect(),

--- a/crates/pdo-daemon/src/portable_pipeline.rs
+++ b/crates/pdo-daemon/src/portable_pipeline.rs
@@ -200,6 +200,7 @@ mod tests {
             harnesses: Default::default(),
             agent_choice: None,
             auto_fail: None,
+            orchestrator: false,
         }
     }
 

--- a/crates/pdo-daemon/src/prompt_augmenter.rs
+++ b/crates/pdo-daemon/src/prompt_augmenter.rs
@@ -1186,6 +1186,7 @@ mod tests {
                 harnesses: Default::default(),
                 agent_choice: None,
                 auto_fail: None,
+                orchestrator: false,
             }],
             edges: vec![],
             loops: Vec::new(),
@@ -1460,6 +1461,7 @@ mod tests {
             harnesses: Default::default(),
             agent_choice: None,
             auto_fail: None,
+            orchestrator: false,
         });
         pipeline.edges.push(EdgeDef {
             source: EdgeEndpoint {
@@ -1605,6 +1607,7 @@ mod tests {
             harnesses: Default::default(),
             agent_choice: None,
             auto_fail: None,
+            orchestrator: false,
         });
         pipeline.edges.push(EdgeDef {
             source: EdgeEndpoint {
@@ -1669,6 +1672,7 @@ mod tests {
             harnesses: Default::default(),
             agent_choice: None,
             auto_fail: None,
+            orchestrator: false,
         });
 
         let node = &pipeline.nodes[1]; // implementer
@@ -1705,6 +1709,7 @@ mod tests {
             harnesses: Default::default(),
             agent_choice: None,
             auto_fail: None,
+            orchestrator: false,
         });
         pipeline.edges.push(EdgeDef {
             source: EdgeEndpoint {
@@ -1755,6 +1760,7 @@ mod tests {
             harnesses: Default::default(),
             agent_choice: None,
             auto_fail: None,
+            orchestrator: false,
         });
         pipeline.edges.push(EdgeDef {
             source: EdgeEndpoint {
@@ -1911,6 +1917,7 @@ mod tests {
                     harnesses: Default::default(),
                     agent_choice: None,
                     auto_fail: None,
+                    orchestrator: false,
                 },
                 NodeDef {
                     skills: Vec::new(),
@@ -1938,6 +1945,7 @@ mod tests {
                     harnesses: Default::default(),
                     agent_choice: None,
                     auto_fail: None,
+                    orchestrator: false,
                 },
                 NodeDef {
                     skills: Vec::new(),
@@ -1988,6 +1996,7 @@ mod tests {
                     harnesses: Default::default(),
                     agent_choice: None,
                     auto_fail: None,
+                    orchestrator: false,
                 },
             ],
             edges: vec![
@@ -2105,6 +2114,7 @@ mod tests {
                 harnesses: Default::default(),
                 agent_choice: None,
                 auto_fail: None,
+                orchestrator: false,
             }],
             edges: vec![],
             loops: Vec::new(),
@@ -2435,6 +2445,7 @@ mod tests {
                 harnesses: Default::default(),
                 agent_choice: None,
                 auto_fail: None,
+                orchestrator: false,
             }],
             edges: vec![],
             loops: Vec::new(),
@@ -2492,6 +2503,7 @@ mod tests {
                 harnesses: Default::default(),
                 agent_choice: None,
                 auto_fail: None,
+                orchestrator: false,
             }],
             edges: vec![],
             loops: Vec::new(),
@@ -2544,6 +2556,7 @@ mod tests {
                 harnesses: Default::default(),
                 agent_choice: None,
                 auto_fail: None,
+                orchestrator: false,
             }],
             edges: vec![],
             loops: Vec::new(),

--- a/crates/pdo-daemon/src/run_advance.rs
+++ b/crates/pdo-daemon/src/run_advance.rs
@@ -15,8 +15,9 @@
 //!
 //! Don't collapse the per-caller tail divergence ratified by ADR-0023.
 
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
+use crate::completion_refusal;
 use crate::event_log;
 use crate::node_spawn::{spawn_node, SpawnContext, SpawnDeps};
 use crate::pipeline;
@@ -26,9 +27,9 @@ use crate::scheduler_interpreter::{self, SpawnDedup};
 use crate::transition_guard;
 use crate::worktree_ops::worktree_dir_for_run;
 use crate::{
-    append_event, effective_repo_root, handle_node_completion, load_events,
-    resolve_completed_frontmatter, resolve_run_pipeline_path, resolve_run_variables,
-    retry_waiting_nodes, AppState,
+    append_event, effective_repo_root, handle_node_completion, load_all_run_ids, load_events,
+    reload_run_state_with, resolve_completed_frontmatter, resolve_run_pipeline_path,
+    resolve_run_variables, retry_waiting_nodes, run_is_forgotten, AppState,
 };
 
 /// Advance one Run by a single tick: spawn whatever the scheduler says is ready
@@ -482,6 +483,305 @@ pub(crate) async fn complete_node(
     }
 }
 
+// ─ Liaison forte orchestrateur ↔ enfants (#724, ADR-0064) ────────────────────
+//
+// Le NodeRun d’un nœud « orchestrator » (toggle gelé au démarrage du Run,
+// `NodeDefInfo::orchestrator`) ne se termine pas pendant que ses runs enfants
+// (mêmes `parent_run_id` + `parent_node_id`, ADR-0064) sont non terminaux :
+//
+// - la **porte** ([`orchestrator_binding_refusal`]) refuse `pdo complete` tant
+//   que des enfants tournent, avec un message qui compte ; au moins un enfant
+//   `failed` parque le nœud `AwaitingUser` — l’agent a rendu la main, c’est
+//   l’utilisateur qui tranche (retry de l’enfant ou forçage `mark_node_done`,
+//   qui n’est PAS gated : c’est le forçage) — et pose le **pilote**
+//   ([`spawn_children_settled_watcher`]) qui complétera le nœud de lui-même
+//   quand tous les enfants seront terminaux — « le nœud se complète ».
+//
+// Aucune propagation de mort vers le bas : la liaison ne fait que RETENIR le
+// parent ; stop du nœud, archive et forget du parent ne touchent aucun enfant,
+// et un restart ré-adopte les enfants vivants (ils sont relus à chaque verdict,
+// jamais mis en cache).
+
+/// Le marqueur que la porte pose sur le NodeRun au refus : un `NodeAwaitingUser`
+/// portant cette raison. C’est lui qui distingue « l’orchestrator a rendu la
+/// main et attend ses enfants » d’un agent encore au travail (auquel on ne
+/// arrache jamais la main) et d’un nœud interactif simplement `AwaitingUser`.
+pub(crate) const BINDING_MARKER_REASON: &str = "children_pending";
+
+/// L’état des runs enfants d’UN nœud du Run parent, au moment de la lecture.
+#[derive(Debug, Default)]
+pub(crate) struct ChildrenSnapshot {
+    pub(crate) total: usize,
+    pub(crate) failed: Vec<String>,
+    pub(crate) active: Vec<String>,
+}
+
+/// Le verdict de la liaison sur un [`ChildrenSnapshot`].
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum ChildrenVerdict {
+    /// Aucun enfant : la liaison ne dit rien (un toggle sans spawn n’engage
+    /// rien — l’agent peut aussi n’avoir pas encore créé ses enfants).
+    NoChildren,
+    /// Tous les enfants sont terminaux, aucun n’est `failed` : le nœud peut
+    /// se compléter.
+    AllSettled,
+    /// Au moins un enfant est non terminal : le nœud attend. `failed` compte
+    /// les enfants `failed` — dès qu’il y en a un, l’arbitrage est à
+    /// l’utilisateur.
+    Pending { active: usize, failed: usize },
+}
+
+impl ChildrenSnapshot {
+    /// Terminal pour la liaison = non-vivant (`Completed`/`Skipped`/`Halted`/
+    /// `Archived`/`Failed`) ; `Failed` est le seul terminal qui parque le nœud
+    /// en attente utilisateur. Un enfant `Running`/`AwaitingUser`/`Paused`
+    /// retient le nœud — sauf s’il est tombstoné (forgotten) : son
+    /// propriétaire l’a explicitement abandonné, la liaison ne retient pas un
+    /// run qui n’existe plus.
+    pub(crate) fn verdict(&self) -> ChildrenVerdict {
+        if self.total == 0 {
+            return ChildrenVerdict::NoChildren;
+        }
+        let active = self.active.len();
+        if active == 0 && self.failed.is_empty() {
+            return ChildrenVerdict::AllSettled;
+        }
+        ChildrenVerdict::Pending {
+            active,
+            failed: self.failed.len(),
+        }
+    }
+}
+
+/// Lit les runs enfants du nœud `node_id` du Run `run_id` : tout Run dont le
+/// `RunStarted` mécanique porte ces deux valeurs de provenance. Recharge tout
+/// à chaque appel — c’est ce qui rend la ré-adoption au restart gratuite.
+pub(crate) async fn children_snapshot(
+    state: &AppState,
+    run_id: &str,
+    node_id: &str,
+) -> ChildrenSnapshot {
+    let mut snapshot = ChildrenSnapshot::default();
+    let Ok(run_ids) = load_all_run_ids(&state.db).await else {
+        error!("binding: failed to list runs for children of {node_id} in {run_id}");
+        return snapshot;
+    };
+    for child_id in run_ids {
+        if child_id == run_id {
+            continue;
+        }
+        let Ok(events) = load_events(&state.db, &child_id).await else {
+            continue;
+        };
+        let Some(child) = event_log::project(&events) else {
+            continue;
+        };
+        if child.parent_run_id.as_deref() != Some(run_id)
+            || child.parent_node_id.as_deref() != Some(node_id)
+        {
+            continue;
+        }
+        snapshot.total += 1;
+        match child.status {
+            event_log::RunStatus::Failed => snapshot.failed.push(child.run_id),
+            status if status.is_live() => {
+                // Un enfant oublié (tombstoné, ADR-0024) ne retient pas la
+                // liaison : il ne projetera jamais d’état terminal.
+                match run_is_forgotten(&state.db, &child.run_id).await {
+                    Ok(true) => {}
+                    _ => snapshot.active.push(child.run_id),
+                }
+            }
+            _ => {}
+        }
+    }
+    snapshot
+}
+
+/// La porte de complétion de la liaison forte. `None` ⇒ la complétion peut
+/// continuer ; `Some(refusal)` ⇒ refus avec compteur, marqueur d’attente posé
+/// (nœud parqué `AwaitingUser`) et pilote détaché (le watcher).
+pub(crate) async fn orchestrator_binding_refusal(
+    state: &std::sync::Arc<AppState>,
+    events: &[event_log::Event],
+    run_state: &event_log::RunState,
+    run_id: &str,
+    node_id: &str,
+    iter: i64,
+) -> Option<completion_refusal::CompletionRefusal> {
+    // Nœud sans toggle : aucune retenue — le comportement est inchangé.
+    if !run_state
+        .node_defs
+        .iter()
+        .any(|nd| nd.id == node_id && nd.orchestrator)
+    {
+        return None;
+    }
+    let snapshot = children_snapshot(state, run_id, node_id).await;
+    let ChildrenVerdict::Pending { active, failed } = snapshot.verdict() else {
+        return None;
+    };
+    // Marque l’attente de la liaison sur le NodeRun (idempotent : la porte est
+    // re-frappée à chaque tentative de complétion, l’événement ne s’empile pas).
+    // Le statut projeté passe à `AwaitingUser` — la surface montre un nœud qui
+    // attend — et le pilote ([`spawn_children_settled_watcher`]) saura que
+    // l’agent a rendu la main.
+    if !binding_marker_present(events, node_id, iter) {
+        let marker = event_log::Event {
+            id: None,
+            run_id: run_id.to_string(),
+            ts: event_log::now_iso(),
+            kind: event_log::EventKind::NodeAwaitingUser,
+            node_id: Some(node_id.to_string()),
+            iter: Some(iter),
+            payload: Some(serde_json::json!({
+                "reason": BINDING_MARKER_REASON,
+                "active": active,
+                "failed": failed,
+            })),
+        };
+        if let Err(e) = append_event(state, &marker).await {
+            error!(
+                "binding: failed to append the children_pending marker for {node_id} \
+                 iter-{iter} in {run_id}: {e}"
+            );
+        }
+    }
+    // Le pilote part à CHAQUE refus : idempotent par construction (le watcher
+    // sort au premier verdict, et une complétion déjà posée est un NoOp), il
+    // couvre aussi le cas « un watcher précédent est sorti sur un refus ».
+    spawn_children_settled_watcher(
+        std::sync::Arc::clone(state),
+        run_id.to_string(),
+        node_id.to_string(),
+        iter,
+    );
+    Some(completion_refusal::CompletionRefusal::ChildrenPending {
+        node_id: node_id.to_string(),
+        active,
+        failed,
+    })
+}
+
+/// Le **pilote** de la liaison — une tâche détachée (le « watcher ») posée par
+/// la porte à chaque refus. Tant que le nœud attend (marqueur `children_pending`,
+/// itération courante), il revérifie périodiquement le verdict : dès que tous
+/// les enfants sont terminaux sans échec, il complète le nœud de lui-même —
+/// « le nœud se complète » — par la voie commune
+/// ([`crate::complete_node_iteration`], source `ChildrenSettled`) : livraison,
+/// validation, événement terminal et advance sont exactement ceux d’un
+/// `pdo complete`. Ré-entrance bénigne : une complétion déjà posée est un NoOp
+/// (garde de transition), deux watchers qui s’évitent ne produisent qu’un
+/// `NodeCompleted`.
+///
+/// Pourquoi un watcher plutôt qu’un réveil à l’événement enfant : la liaison
+/// relit TOUT à chaque tick (provenance gelée, jamais mise en cache), ce qui
+/// rend la ré-adoption au restart gratuite et résiste à n’importe quel chemin
+/// par lequel un enfant se termine (`pdo complete`, `pdo fail`, forçage,
+/// sweep, restart de l’enfant).
+pub(crate) fn spawn_children_settled_watcher(
+    state: std::sync::Arc<AppState>,
+    run_id: String,
+    node_id: String,
+    iter: i64,
+) {
+    tokio::spawn(async move {
+        // Backoff : réactif au début (les tests comme les humains attendent un
+        // enfant qui vient de se terminer), économe ensuite (un orchestrator
+        // peut attendre des enfants pendant des heures — c’est le contrat).
+        let mut delay = std::time::Duration::from_millis(250);
+        loop {
+            tokio::time::sleep(delay).await;
+            delay = (delay * 2).min(std::time::Duration::from_secs(5));
+
+            // Un run oublié (ADR-0024) ne pilote plus rien.
+            if run_is_forgotten(&state.db, &run_id).await.unwrap_or(true) {
+                return;
+            }
+            let Some((parent_events, parent_state)) =
+                reload_run_state_with(&state.db, &run_id).await
+            else {
+                return;
+            };
+            let Some(node) = parent_state.nodes.get(&node_id) else {
+                return;
+            };
+            // Une itération plus récente possède désormais l’attente : ce
+            // watcher est périmé (restart du nœud → ré-adoption par la porte
+            // elle-même, qui relit les enfants vivants).
+            if node.iter != iter {
+                return;
+            }
+            if !matches!(
+                node.status,
+                event_log::NodeStatus::Running | event_log::NodeStatus::AwaitingUser
+            ) {
+                return; // déjà terminal, stoppé ou incident : plus rien à piloter
+            }
+            // Sans le marqueur, l’agent n’a pas encore rendu la main : on ne
+            // lui arrache jamais la complétion parce que ses enfants ont fini
+            // tôt — il re-complètera quand il voudra.
+            if !binding_marker_present(&parent_events, &node_id, iter) {
+                return;
+            }
+
+            let snapshot = children_snapshot(&state, &run_id, &node_id).await;
+            if snapshot.verdict() != ChildrenVerdict::AllSettled {
+                continue; // enfants encore actifs ou échoués : la liaison attend
+            }
+
+            info!(
+                "binding: every child run of orchestrator {node_id} iter-{iter} in run \
+                 {run_id} is terminal — completing the node"
+            );
+            match crate::complete_node_iteration(
+                &state,
+                run_id.clone(),
+                node_id.clone(),
+                iter,
+                crate::CompletionSource::ChildrenSettled,
+            )
+            .await
+            {
+                crate::CompletionAttempt::Completed => {
+                    info!(
+                        "binding: orchestrator {node_id} completed in run {run_id} \
+                         (children settled)"
+                    );
+                }
+                crate::CompletionAttempt::NoOp { reason } => {
+                    info!("binding: auto-completion was a no-op: {reason}");
+                }
+                crate::CompletionAttempt::Refused { refusal } => {
+                    // La porte commune a refusé (livraison, validation) : on
+                    // rend la main — une prochaine tentative de complétion
+                    // re-posera un watcher, et l’agent garde sa session.
+                    warn!(
+                        "binding: auto-completion of {node_id} in {run_id} refused ({}): {}",
+                        refusal.slug(),
+                        refusal.reason()
+                    );
+                }
+            }
+            return;
+        }
+    });
+}
+
+/// Le marqueur `children_pending` est-il déjà posé sur cette itération ?
+fn binding_marker_present(events: &[event_log::Event], node_id: &str, iter: i64) -> bool {
+    events.iter().any(|e| {
+        e.kind == event_log::EventKind::NodeAwaitingUser
+            && e.node_id.as_deref() == Some(node_id)
+            && e.iter == Some(iter)
+            && e.payload
+                .as_ref()
+                .and_then(|p| p.get("reason"))
+                .and_then(|v| v.as_str())
+                == Some(BINDING_MARKER_REASON)
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -530,6 +830,7 @@ mod tests {
             harnesses: Default::default(),
             agent_choice: None,
             auto_fail: None,
+            orchestrator: false,
         }
     }
 
@@ -551,6 +852,7 @@ mod tests {
     fn node_def_info(id: &str) -> NodeDefInfo {
         NodeDefInfo {
             isolated_worktree: None,
+            orchestrator: false,
             id: id.into(),
             name: None,
             node_type: "agent".into(),
@@ -559,6 +861,74 @@ mod tests {
             inputs: Vec::new(),
             outputs: Vec::new(),
         }
+    }
+
+    // ─ Liaison forte (#724) : le verdict est pur, il se teste sans daemon ──
+
+    fn snap(total: usize, failed: &[&str], active: &[&str]) -> ChildrenSnapshot {
+        ChildrenSnapshot {
+            total,
+            failed: failed.iter().map(|s| s.to_string()).collect(),
+            active: active.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn binding_verdicts_follow_the_contract() {
+        // Pas d'enfant : la liaison ne dit rien — un toggle sans spawn, ou un
+        // agent qui n'a pas encore créé ses enfants, complète normalement.
+        assert_eq!(snap(0, &[], &[]).verdict(), ChildrenVerdict::NoChildren);
+        // Tous terminaux (completed/skipped/…), aucun failed → complétion.
+        assert_eq!(snap(2, &[], &[]).verdict(), ChildrenVerdict::AllSettled);
+        // Un enfant actif (running / awaiting_user / paused) → le nœud attend.
+        assert_eq!(
+            snap(2, &[], &["c1"]).verdict(),
+            ChildrenVerdict::Pending {
+                active: 1,
+                failed: 0
+            }
+        );
+        // Un enfant failed (terminal) → arbitrage utilisateur, mais les autres
+        // enfants actifs comptent toujours dans l'attente.
+        assert_eq!(
+            snap(3, &["c1"], &["c2"]).verdict(),
+            ChildrenVerdict::Pending {
+                active: 1,
+                failed: 1
+            }
+        );
+        // Tous échoués : plus rien d'actif, mais le verdict reste un refus.
+        assert_eq!(
+            snap(2, &["c1", "c2"], &[]).verdict(),
+            ChildrenVerdict::Pending {
+                active: 0,
+                failed: 2
+            }
+        );
+    }
+
+    #[test]
+    fn binding_marker_is_detected_on_the_right_iteration_only() {
+        let marker = event_log::Event {
+            id: None,
+            run_id: "r".into(),
+            ts: "t".into(),
+            kind: event_log::EventKind::NodeAwaitingUser,
+            node_id: Some("orch".into()),
+            iter: Some(2),
+            payload: Some(serde_json::json!({ "reason": BINDING_MARKER_REASON })),
+        };
+        // Le NodeAwaitingUser d'un nœud interactif (payload vide) n'est pas un
+        // marqueur : la liaison ne doit pas le confondre avec son attente.
+        let interactive_spawn = event_log::Event {
+            kind: event_log::EventKind::NodeAwaitingUser,
+            payload: None,
+            ..marker.clone()
+        };
+        assert!(binding_marker_present(&[marker.clone()], "orch", 2));
+        assert!(!binding_marker_present(&[marker.clone()], "orch", 1));
+        assert!(!binding_marker_present(&[marker.clone()], "other", 2));
+        assert!(!binding_marker_present(&[interactive_spawn], "orch", 2));
     }
 
     fn completed_node(id: &str) -> NodeState {

--- a/crates/pdo-daemon/src/run_command.rs
+++ b/crates/pdo-daemon/src/run_command.rs
@@ -3136,6 +3136,7 @@ mod tests {
                 harnesses: Default::default(),
                 agent_choice: None,
                 auto_fail: None,
+                orchestrator: false,
             }],
             edges: vec![EdgeDef {
                 source: EdgeEndpoint {
@@ -3195,6 +3196,7 @@ mod tests {
                 harnesses: Default::default(),
                 agent_choice: None,
                 auto_fail: None,
+                orchestrator: false,
             }],
             edges: vec![EdgeDef {
                 source: EdgeEndpoint {

--- a/crates/pdo-daemon/src/scheduler.rs
+++ b/crates/pdo-daemon/src/scheduler.rs
@@ -1591,6 +1591,7 @@ mod tests {
             harnesses: Default::default(),
             agent_choice: None,
             auto_fail: None,
+            orchestrator: false,
         }
     }
 
@@ -1621,6 +1622,7 @@ mod tests {
             harnesses: Default::default(),
             agent_choice: None,
             auto_fail: None,
+            orchestrator: false,
         }
     }
 
@@ -2927,6 +2929,7 @@ mod tests {
             harnesses: Default::default(),
             agent_choice: None,
             auto_fail: None,
+            orchestrator: false,
         }
     }
 
@@ -3661,6 +3664,7 @@ mod tests {
             harnesses: Default::default(),
             agent_choice: None,
             auto_fail: None,
+            orchestrator: false,
         }
     }
 
@@ -4174,6 +4178,7 @@ mod tests {
             harnesses: Default::default(),
             agent_choice: None,
             auto_fail: None,
+            orchestrator: false,
         }
     }
 

--- a/crates/pdo-daemon/src/scheduler_dispatcher.rs
+++ b/crates/pdo-daemon/src/scheduler_dispatcher.rs
@@ -94,6 +94,7 @@ mod tests {
             harnesses: Default::default(),
             agent_choice: None,
             auto_fail: None,
+            orchestrator: false,
         }
     }
 

--- a/crates/pdo-daemon/src/switch_router.rs
+++ b/crates/pdo-daemon/src/switch_router.rs
@@ -66,6 +66,7 @@ mod tests {
             harnesses: Default::default(),
             agent_choice: None,
             auto_fail: None,
+            orchestrator: false,
         }
     }
 

--- a/crates/pdo-daemon/src/workflow_importer.rs
+++ b/crates/pdo-daemon/src/workflow_importer.rs
@@ -514,6 +514,7 @@ impl Importer {
             agent_choice: None,
             skills: Vec::new(),
             auto_fail: None,
+            orchestrator: false,
         };
         self.nodes.push(node);
         self.prompts.insert(id.clone(), prompt_body);
@@ -896,6 +897,7 @@ fn start_node() -> NodeDef {
         agent_choice: None,
         skills: Vec::new(),
         auto_fail: None,
+        orchestrator: false,
     }
 }
 
@@ -919,6 +921,7 @@ fn end_node(agent_count: usize) -> NodeDef {
         agent_choice: None,
         skills: Vec::new(),
         auto_fail: None,
+        orchestrator: false,
     }
 }
 

--- a/crates/pdo-daemon/tests/it.rs
+++ b/crates/pdo-daemon/tests/it.rs
@@ -148,6 +148,9 @@ mod runs_list_target_repo;
 #[path = "run_provenance.rs"]
 mod run_provenance;
 
+#[path = "orchestrator_binding.rs"]
+mod orchestrator_binding;
+
 #[path = "sandbox_observability.rs"]
 mod sandbox_observability;
 

--- a/crates/pdo-daemon/tests/orchestrator_binding.rs
+++ b/crates/pdo-daemon/tests/orchestrator_binding.rs
@@ -1,0 +1,566 @@
+//! Layer 3a — la liaison forte orchestrateur ↔ enfants (issue #724, ADR-0064).
+//! Sibling of `run_provenance.rs` (qui pose la provenance mécanique) : ici, la
+//! provenance EXISTE et le toggle « Orchestrator » la rend contractuelle.
+//!
+//! - `pdo complete` sur un nœud orchestrator est refusé tant que ses runs
+//!   enfants (mêmes `parent_run_id` + `parent_node_id`) sont non terminaux,
+//!   avec un message qui COMPTE (`children_pending`, `active`/`failed`) ;
+//! - tous les enfants terminaux → le nœud se complète de lui-même (le watcher
+//!   de la liaison passe par la même voie qu'un `pdo complete`) ;
+//! - un enfant `failed` parque le nœud `awaiting_user` — l'arbitrage est à
+//!   l'utilisateur : le forçage (`mark_node_done`, volontairement pas gated)
+//!   et le retry de l'enfant fonctionnent ;
+//! - aucun effet des gestes parent (stop du nœud, forget du run) sur les
+//!   enfants ; un restart ré-adopte les enfants vivants et reprend l'attente ;
+//! - un nœud SANS toggle n'est jamais retenu.
+
+use crate::common::TestDaemon;
+
+const PIPELINE_NAME: &str = "binding-test";
+const CHILD_PIPELINE_NAME: &str = "binding-child";
+
+/// `worker` porte le toggle « Orchestrator » : sa liaison est forte (#724).
+const PIPELINE_YAML: &str = r#"name: binding-test
+version: "1.0"
+nodes:
+  - id: start
+    name: Start
+    type: start
+    outputs:
+      - name: user_prompt
+  - id: worker
+    name: worker
+    type: agent
+    orchestrator: true
+    isolated_worktree: false
+    inputs:
+      - name: task
+    outputs:
+      - name: result
+    view: { x: 200, y: 100 }
+  - id: end
+    name: End
+    type: end
+    inputs:
+      - name: result
+edges:
+  - source: { node: start, port: user_prompt }
+    target: { node: worker, port: task }
+  - source: { node: worker, port: result }
+    target: { node: end, port: result }
+"#;
+
+/// La même pipeline SANS le toggle : le contrôle négatif (aucune retenue).
+const PLAIN_PIPELINE_YAML: &str = r#"name: binding-plain
+version: "1.0"
+nodes:
+  - id: start
+    name: Start
+    type: start
+    outputs:
+      - name: user_prompt
+  - id: worker
+    name: worker
+    type: agent
+    isolated_worktree: false
+    inputs:
+      - name: task
+    outputs:
+      - name: result
+    view: { x: 200, y: 100 }
+  - id: end
+    name: End
+    type: end
+    inputs:
+      - name: result
+edges:
+  - source: { node: start, port: user_prompt }
+    target: { node: worker, port: task }
+  - source: { node: worker, port: result }
+    target: { node: end, port: result }
+"#;
+
+const CHILD_PIPELINE_YAML: &str = r#"name: binding-child
+version: "1.0"
+nodes:
+  - id: start
+    name: Start
+    type: start
+    outputs:
+      - name: user_prompt
+  - id: doer
+    name: doer
+    type: agent
+    isolated_worktree: false
+    inputs:
+      - name: task
+    outputs:
+      - name: work
+    view: { x: 200, y: 100 }
+  - id: end
+    name: End
+    type: end
+    inputs:
+      - name: result
+edges:
+  - source: { node: start, port: user_prompt }
+    target: { node: doer, port: task }
+  - source: { node: doer, port: work }
+    target: { node: end, port: result }
+"#;
+
+fn git_init_with_commit(repo: &std::path::Path) -> anyhow::Result<()> {
+    let run = |args: &[&str]| -> anyhow::Result<()> {
+        let out = std::process::Command::new("git")
+            .args(args)
+            .current_dir(repo)
+            .output()?;
+        if !out.status.success() {
+            anyhow::bail!(
+                "git {:?} failed: {}",
+                args,
+                String::from_utf8_lossy(&out.stderr)
+            );
+        }
+        Ok(())
+    };
+    run(&["init", "-q", "-b", "main"])?;
+    run(&["config", "user.email", "test@example.com"])?;
+    run(&["config", "user.name", "Test"])?;
+    run(&["config", "commit.gpgsign", "false"])?;
+    std::fs::write(repo.join(".gitignore"), ".pdo/runs/\n")?;
+    run(&["add", "."])?;
+    run(&["commit", "-q", "-m", "init"])?;
+    Ok(())
+}
+
+fn seed_pipelines(repo: &std::path::Path) -> anyhow::Result<()> {
+    let pipelines_dir = repo.join(".pdo").join("pipelines");
+    std::fs::create_dir_all(&pipelines_dir)?;
+    std::fs::write(
+        pipelines_dir.join(format!("{PIPELINE_NAME}.yaml")),
+        PIPELINE_YAML,
+    )?;
+    std::fs::write(
+        pipelines_dir.join("binding-plain.yaml"),
+        PLAIN_PIPELINE_YAML,
+    )?;
+    let prompts_dir = pipelines_dir.join(format!("{PIPELINE_NAME}.prompts"));
+    std::fs::create_dir_all(&prompts_dir)?;
+    std::fs::write(prompts_dir.join("worker.md"), "You are the orchestrator.\n")?;
+    let child_prompts = pipelines_dir.join(format!("{CHILD_PIPELINE_NAME}.prompts"));
+    std::fs::create_dir_all(&child_prompts)?;
+    std::fs::write(child_prompts.join("doer.md"), "You are a doer.\n")?;
+    std::fs::write(
+        pipelines_dir.join(format!("{CHILD_PIPELINE_NAME}.yaml")),
+        CHILD_PIPELINE_YAML,
+    )?;
+    git_init_with_commit(repo)?;
+    Ok(())
+}
+
+fn seed(repo: &std::path::Path) -> anyhow::Result<()> {
+    seed_pipelines(repo)
+}
+
+fn seed_plain(repo: &std::path::Path) -> anyhow::Result<()> {
+    seed_pipelines(repo)
+}
+
+async fn create_run(
+    daemon: &TestDaemon,
+    pipeline: &str,
+    session: Option<(&str, &str)>,
+    extra: serde_json::Value,
+) -> String {
+    let mut body = serde_json::json!({
+        "pipeline": pipeline,
+        "input": "work",
+        "target_repo": daemon.target_repo(),
+    });
+    if let Some(obj) = extra.as_object() {
+        for (k, v) in obj {
+            body[k.clone()] = v.clone();
+        }
+    }
+    let mut req = reqwest::Client::new()
+        .post(format!("{}/runs", daemon.url()))
+        .json(&body);
+    if let Some((run_id, node_id)) = session {
+        req = req
+            .header("X-PDO-Session-Run-Id", run_id)
+            .header("X-PDO-Session-Node-Id", node_id);
+    }
+    let resp = req.send().await.unwrap();
+    let status = resp.status();
+    let body_text = resp.text().await.unwrap_or_default();
+    assert_eq!(status, 201, "POST /runs should return 201: {body_text}");
+    let json: serde_json::Value = serde_json::from_str(&body_text).unwrap();
+    json["run_id"].as_str().unwrap().to_string()
+}
+
+async fn get_json(daemon: &TestDaemon, path: &str) -> (u16, serde_json::Value) {
+    let resp = reqwest::get(format!("{}{}", daemon.url(), path))
+        .await
+        .unwrap();
+    let status = resp.status().as_u16();
+    let json: serde_json::Value = resp.json().await.unwrap();
+    (status, json)
+}
+
+async fn node_status(daemon: &TestDaemon, run_id: &str, node_id: &str) -> String {
+    let (status, run) = get_json(daemon, &format!("/runs/{run_id}")).await;
+    assert_eq!(status, 200);
+    run["nodes"][node_id]["status"]
+        .as_str()
+        .unwrap_or("<absent>")
+        .to_string()
+}
+
+async fn wait_node_status(daemon: &TestDaemon, run_id: &str, node_id: &str, want: &str) {
+    for _ in 0..200 {
+        if node_status(daemon, run_id, node_id).await == want {
+            return;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+    panic!("node {node_id} of run {run_id} never reached `{want}`");
+}
+
+/// Start the parent's `worker` and wait until its tmux session holds.
+async fn start_worker(daemon: &TestDaemon, run_id: &str) {
+    wait_node_status(daemon, run_id, "worker", "running").await;
+}
+
+/// Write a child's (or the worker's) declared output into the run worktree, so
+/// the output validator lets the completion through.
+fn write_output(daemon: &TestDaemon, run_id: &str, node: &str, port: &str) {
+    let dir = daemon
+        .repo_root()
+        .join(".pdo")
+        .join("runs")
+        .join(run_id)
+        .join("worktree")
+        .join(".pdo")
+        .join("artifacts")
+        .join(node)
+        .join(format!("iter-1"))
+        .join(port);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("output.md"), "done\n").unwrap();
+}
+
+/// `pdo complete`'s endpoint, returning (status, body).
+async fn complete_node(
+    daemon: &TestDaemon,
+    run_id: &str,
+    node_id: &str,
+) -> (u16, serde_json::Value) {
+    let resp = reqwest::Client::new()
+        .post(format!(
+            "{}/runs/{run_id}/nodes/{node_id}/done",
+            daemon.url()
+        ))
+        .json(&serde_json::json!({ "iter": 1 }))
+        .send()
+        .await
+        .unwrap();
+    let status = resp.status().as_u16();
+    // A granted completion answers plain `ok`; a refusal answers JSON.
+    let text = resp.text().await.unwrap_or_default();
+    let json = serde_json::from_str(&text).unwrap_or(serde_json::Value::String(text));
+    (status, json)
+}
+
+/// Drive a child to terminal: complete its `doer` (the tmux override keeps the
+/// session alive, but `pdo complete`'s endpoint reaps it itself).
+async fn settle_child(daemon: &TestDaemon, child_id: &str) {
+    write_output(daemon, child_id, "doer", "work");
+    let (status, body) = complete_node(daemon, child_id, "doer").await;
+    assert_eq!(status, 200, "child completion should succeed: {body:?}");
+    wait_node_status(daemon, child_id, "doer", "completed").await;
+}
+
+#[tokio::test]
+async fn complete_is_refused_with_a_counter_while_children_run() {
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+    let parent = create_run(&daemon, PIPELINE_NAME, None, serde_json::json!({})).await;
+    start_worker(&daemon, &parent).await;
+
+    // Two children spawned from the worker's session (mechanical provenance).
+    let child_a = create_run(
+        &daemon,
+        CHILD_PIPELINE_NAME,
+        Some((&parent, "worker")),
+        serde_json::json!({}),
+    )
+    .await;
+    let child_b = create_run(
+        &daemon,
+        CHILD_PIPELINE_NAME,
+        Some((&parent, "worker")),
+        serde_json::json!({}),
+    )
+    .await;
+
+    // `pdo complete` is refused with the counter in the message AND the body.
+    let (status, body) = complete_node(&daemon, &parent, "worker").await;
+    assert_eq!(status, 409, "the binding refuses while children run");
+    assert_eq!(body["error"], "children_pending", "{body:?}");
+    assert_eq!(body["active"], 2, "both children counted: {body:?}");
+    assert_eq!(body["failed"], 0);
+    assert_eq!(
+        body["recoverable"], true,
+        "no child failed: still the agent's turn (exit 3)"
+    );
+    let message = body["message"].as_str().unwrap();
+    assert!(message.contains('2'), "the message counts: {message}");
+
+    // The node is parked `awaiting_user` (the binding marker), still alive.
+    wait_node_status(&daemon, &parent, "worker", "awaiting_user").await;
+
+    // Children were NOT touched by the refusal.
+    for child in [&child_a, &child_b] {
+        let (status, run) = get_json(&daemon, &format!("/runs/{child}")).await;
+        assert_eq!(status, 200);
+        assert_eq!(run["status"], "running", "a child keeps living");
+    }
+}
+
+#[tokio::test]
+async fn the_node_completes_itself_once_every_child_is_terminal() {
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+    let parent = create_run(&daemon, PIPELINE_NAME, None, serde_json::json!({})).await;
+    start_worker(&daemon, &parent).await;
+
+    let child_a = create_run(
+        &daemon,
+        CHILD_PIPELINE_NAME,
+        Some((&parent, "worker")),
+        serde_json::json!({}),
+    )
+    .await;
+    let child_b = create_run(
+        &daemon,
+        CHILD_PIPELINE_NAME,
+        Some((&parent, "worker")),
+        serde_json::json!({}),
+    )
+    .await;
+
+    // The agent hands back control: refused, binding-parked, watcher armed.
+    let (status, _) = complete_node(&daemon, &parent, "worker").await;
+    assert_eq!(status, 409);
+
+    // The children settle — NO further agent gesture happens.
+    write_output(&daemon, &parent, "worker", "result");
+    settle_child(&daemon, &child_a).await;
+    settle_child(&daemon, &child_b).await;
+
+    // « Le nœud se complète » : the watcher drives the SAME completion path.
+    wait_node_status(&daemon, &parent, "worker", "completed").await;
+
+    // The log says WHO decided: the binding, not the agent.
+    let (status, events) = get_json(&daemon, &format!("/runs/{parent}/events")).await;
+    assert_eq!(status, 200);
+    let raw = serde_json::to_string(&events).unwrap();
+    assert!(
+        raw.contains("children_settled"),
+        "the terminal event is signed by the binding: {raw}"
+    );
+}
+
+#[tokio::test]
+async fn a_failed_child_parks_the_node_and_the_user_decides() {
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+    let parent = create_run(&daemon, PIPELINE_NAME, None, serde_json::json!({})).await;
+    start_worker(&daemon, &parent).await;
+
+    let child = create_run(
+        &daemon,
+        CHILD_PIPELINE_NAME,
+        Some((&parent, "worker")),
+        // auto_fail on the CHILD: an agent `pdo fail` terminalises it to
+        // `failed` instead of parking it awaiting confirmation.
+        serde_json::json!({ "auto_fail": true }),
+    )
+    .await;
+
+    // First refusal: the child is running (active=1, failed=0).
+    let (status, body) = complete_node(&daemon, &parent, "worker").await;
+    assert_eq!(status, 409);
+    assert_eq!(body["active"], 1);
+    assert_eq!(body["failed"], 0);
+
+    // The child fails.
+    let resp = reqwest::Client::new()
+        .post(format!("{}/runs/{child}/nodes/doer/fail", daemon.url()))
+        .json(&serde_json::json!({ "reason": "broken", "iter": 1 }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200, "the child fails");
+    for _ in 0..100 {
+        let (status, run) = get_json(&daemon, &format!("/runs/{child}")).await;
+        assert_eq!(status, 200);
+        if run["status"] == "failed" {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+
+    // Second refusal: the counter now names the failure and the decision is
+    // NOT the agent's any more (exit 4 — the user tranches).
+    let (status, body) = complete_node(&daemon, &parent, "worker").await;
+    assert_eq!(status, 409, "a failed child keeps the node held");
+    assert_eq!(body["error"], "children_pending");
+    assert_eq!(body["failed"], 1, "{body:?}");
+    assert_eq!(
+        body["recoverable"], false,
+        "a failed child hands the decision to the user"
+    );
+    let message = body["message"].as_str().unwrap();
+    assert!(message.contains("1 failed"), "{message}");
+    wait_node_status(&daemon, &parent, "worker", "awaiting_user").await;
+
+    // Le forçage utilisateur (`mark_node_done`) is deliberately NOT gated:
+    // it is the user's tranching gesture. (The worker's declared output is
+    // written so the completion validator lets the force through.)
+    write_output(&daemon, &parent, "worker", "result");
+    let resp = reqwest::Client::new()
+        .post(format!("{}/runs/{parent}/commands", daemon.url()))
+        .json(&serde_json::json!({
+            "kind": "mark_node_done",
+            "node_id": "worker",
+            "iter": 1,
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200, "forcing works despite the failed child");
+    wait_node_status(&daemon, &parent, "worker", "completed").await;
+}
+
+#[tokio::test]
+async fn retrying_the_failed_child_lets_the_node_complete_itself() {
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+    let parent = create_run(&daemon, PIPELINE_NAME, None, serde_json::json!({})).await;
+    start_worker(&daemon, &parent).await;
+
+    let child = create_run(
+        &daemon,
+        CHILD_PIPELINE_NAME,
+        Some((&parent, "worker")),
+        serde_json::json!({ "auto_fail": true }),
+    )
+    .await;
+
+    let (status, _) = complete_node(&daemon, &parent, "worker").await;
+    assert_eq!(status, 409);
+
+    let resp = reqwest::Client::new()
+        .post(format!("{}/runs/{child}/nodes/doer/fail", daemon.url()))
+        .json(&serde_json::json!({ "reason": "broken", "iter": 1 }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    // The user tranches by RETRYING the failed child: a targeted
+    // `mark_node_done` re-opens the failed run and completes it (ADR-0049).
+    write_output(&daemon, &child, "doer", "work");
+    let resp = reqwest::Client::new()
+        .post(format!("{}/runs/{child}/commands", daemon.url()))
+        .json(&serde_json::json!({
+            "kind": "mark_node_done",
+            "node_id": "doer",
+            "iter": 1,
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200, "the retried child completes");
+    wait_node_status(&daemon, &child, "doer", "completed").await;
+
+    // The retried child settled → the orchestrator completes itself.
+    write_output(&daemon, &parent, "worker", "result");
+    wait_node_status(&daemon, &parent, "worker", "completed").await;
+}
+
+#[tokio::test]
+async fn a_node_without_the_toggle_is_never_held() {
+    let daemon = TestDaemon::spawn(seed_plain).await.unwrap();
+    let parent = create_run(&daemon, "binding-plain", None, serde_json::json!({})).await;
+    start_worker(&daemon, &parent).await;
+
+    let _child = create_run(
+        &daemon,
+        CHILD_PIPELINE_NAME,
+        Some((&parent, "worker")),
+        serde_json::json!({}),
+    )
+    .await;
+
+    // No toggle, no binding: the completion goes through even though a child
+    // is still running. « Un agent sans toggle qui spawne des enfants n'est
+    // pas retenu — la liaison est le contrat du toggle. »
+    write_output(&daemon, &parent, "worker", "result");
+    let (status, body) = complete_node(&daemon, &parent, "worker").await;
+    assert_eq!(status, 200, "no toggle → no retention: {body:?}");
+    wait_node_status(&daemon, &parent, "worker", "completed").await;
+}
+
+#[tokio::test]
+async fn stop_and_forget_of_the_parent_leave_the_children_intact() {
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+    let parent = create_run(&daemon, PIPELINE_NAME, None, serde_json::json!({})).await;
+    start_worker(&daemon, &parent).await;
+
+    let child_a = create_run(
+        &daemon,
+        CHILD_PIPELINE_NAME,
+        Some((&parent, "worker")),
+        serde_json::json!({}),
+    )
+    .await;
+    let child_b = create_run(
+        &daemon,
+        CHILD_PIPELINE_NAME,
+        Some((&parent, "worker")),
+        serde_json::json!({}),
+    )
+    .await;
+
+    // Stop the orchestrator node: no death propagates DOWN.
+    let resp = reqwest::Client::new()
+        .post(format!("{}/runs/{parent}/nodes/worker/stop", daemon.url()))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200, "the node stops");
+    for child in [&child_a, &child_b] {
+        let (status, run) = get_json(&daemon, &format!("/runs/{child}")).await;
+        assert_eq!(status, 200);
+        assert_eq!(run["status"], "running", "stop of the node keeps children");
+    }
+
+    // Restart the node: the living children are re-adopted, the wait resumes.
+    let resp = reqwest::Client::new()
+        .post(format!("{}/runs/{parent}/commands", daemon.url()))
+        .json(&serde_json::json!({
+            "kind": "restart_node",
+            "node_id": "worker",
+            "iter": 1,
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200, "the node restarts");
+    start_worker(&daemon, &parent).await;
+    let (status, body) = complete_node(&daemon, &parent, "worker").await;
+    assert_eq!(
+        status, 409,
+        "re-adoption: the binding holds again (children still live)"
+    );
+    assert_eq!(body["active"], 2, "{body:?}");
+}

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  msw: set this to true or false


### PR DESCRIPTION
Closes #724 (story #709, spec #719, ADR-0064)

## Contenu

- `NodeDef` porte le toggle « Orchestrator » (sémantique, dans le diff et le content hash), gelé au démarrage du Run dans le snapshot `node_defs` de `RunStarted`
- Porte de complétion : `pdo complete` d'un nœud orchestrator est refusé tant que ses runs enfants (mêmes `parent_run_id` + `parent_node_id`) sont non terminaux — 409 `children_pending` avec compteur (active/failed), `recoverable` false dès qu'un enfant est `failed`
- Au refus : marqueur `NodeAwaitingUser` (`reason: children_pending`, idempotent) + watcher détaché qui complète le nœud par la voie commune dès que tous les enfants sont terminaux sans échec (`CompletionSource::ChildrenSettled`)
- Forçage utilisateur `mark_node_done` volontairement non gated ; aucune propagation de mort vers le bas (stop/archive/forget du parent n touchent pas les enfants), restart → ré-adoption des enfants vivants ; nœud sans toggle jamais retenu

## Validation

- Feature Path exécuté sur le système réel (daemon compilé depuis ce worktree, UI pilotée surface-first) : **5/5 journeys verts, 0 blocking finding** (refus avec compteur, arbitrage enfant échoué + auto-complétion, restart/ré-adoption, contrôle négatif sans toggle, archive du parent → enfants intacts) — 3 findings non bloquants (affichage du badge après re-refus, stop d'un nœud parqué, environnement de test partagé)
- `cargo test -p pdo-daemon` : 451 passed, 0 failed

## Version

`chore(release): 1.68.0` (Cargo.toml + Cargo.lock + CHANGELOG) ; branche synchronisée avec `integration/709-recursive-orchestration` (1.66.0 / 1.67.0 merges).