### PR TITLE
feat: le Pipeline Manager devient opt-in — run managerless, start/stop à la demande, profil dédié — 1.69.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ ascendante** : la casse se signale ici et par un bump majeur, jamais en gardant 
 morts. Seule contrainte non négociable — les **données historiques restent lisibles** : un Run
 archivé s'ouvre et se chiffre quelle que soit la version qui a écrit son payload.
 
+## 1.69.0
+
+**Le Pipeline Manager devient opt-in** — plus de session `pdo-mgr-*` systématique : un run naît
+sans manager, et l'onglet Manager apparaît sur tout run vivant avec un état vide (« No manager
+on this run », bouton « Start manager », lien vers Settings) ; la session se lance à la demande
+(`POST /runs/{id}/manager/start`, idempotent) et se stoppe avec confirmation en deux temps
+(`POST /runs/{id}/manager/stop`). Deux réglages d'instance rejoignent Settings › Agents ›
+Pipeline Manager : `manager_enabled` (auto-spawn à la création d'un run — machinerie stored →
+env → default d'ADR-0015, seam `PDO_MANAGER_ENABLED`) et `manager_profile`, qui épingle le
+manager sur un profil d'agent (harnais · modèle · effort, écrasant le tier du run) avec repli
+averti « Follow the Run » si le profil nommé a disparu — la valeur stockée n'est jamais
+réécrite, et un PUT nommant un profil inconnu est un 400. `has_manager` est un fait observé
+(sonde `tmux has-session` à chaque `GET /runs/{id}`), jamais un état projeté : arrêt manuel,
+sweep d'orphelins et restart du daemon ne peuvent pas désynchroniser l'UI. La réservation du
+nom passe sur des events `ManagerStarted` / `ManagerStopped` (ADR-0038) émis avant le spawn
+tmux sur tous les chemins, auto comme manuel.
+
 ## 1.68.0
 
 **Liaison forte orchestrateur ↔ enfants** (#724 ; story #709, spec #719, ADR-0064). Un nœud

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "1.68.0"
+version = "1.69.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "1.68.0"
+version = "1.69.0"
 license = "MIT"
 description = "Prompt-Driven Orchestrator — a local daemon that runs and supervises agentic coding pipelines"
 repository = "https://github.com/Loulen/prompt-driven-orchestrator"

--- a/crates/pdo-daemon/src/event_log.rs
+++ b/crates/pdo-daemon/src/event_log.rs
@@ -195,6 +195,22 @@ pub enum EventKind {
     /// prep failure emits `RunFailed` instead (no dedicated failed-prep event). Wire
     /// form: `"sandbox_prep_ready"`.
     SandboxPrepReady,
+    /// Informational (manager on demand): a Pipeline Manager session was
+    /// **reserved** for this Run. Written by every spawn path (the automatic
+    /// spawn at create when `manager_enabled` resolves on, and the manual start
+    /// endpoint) — the durable event lands FIRST, the tmux spawn after, so the
+    /// orphan sweep's reservation-before-spawn invariant (ADR-0038) holds for a
+    /// mid-Run start too. Projects nothing: the wire's `has_manager` is an
+    /// OBSERVED fact (the live tmux session), never derived from this log — a
+    /// spawn that failed after the reservation reads `false`, not `true`.
+    /// Wire form: `"manager_started"`.
+    ManagerStarted,
+    /// Informational (manager on demand): the Run's Pipeline Manager session
+    /// was stopped by the user (the Manager tab's Stop control). A stop on a
+    /// session that is already gone is a calm no-op that still writes the event.
+    /// Projects nothing — same observed-fact discipline as
+    /// [`EventKind::ManagerStarted`]. Wire form: `"manager_stopped"`.
+    ManagerStopped,
     CommandIssued,
 }
 
@@ -1507,6 +1523,10 @@ pub(crate) fn project(events: &[Event]) -> Option<RunState> {
 
             // Informational only: the node stays Running, no node/run state touched.
             EventKind::NodeBlockedOnLimit | EventKind::NodeAutoCompleteObserved => {}
+
+            // Informational only (manager on demand): the manager's existence is
+            // an observed tmux fact, never projected — see the variants' docs.
+            EventKind::ManagerStarted | EventKind::ManagerStopped => {}
 
             EventKind::CommandIssued => apply_command_event(&mut state, event),
         }

--- a/crates/pdo-daemon/src/instance_config.rs
+++ b/crates/pdo-daemon/src/instance_config.rs
@@ -132,6 +132,33 @@ pub(crate) struct InstanceConfig {
     /// nullable TEXT column; `NULL` ⇒ empty.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub skills: Vec<crate::skill_selection::SkillRef>,
+    /// Stored manager auto-start flag as `0`/`1`, or `None` when unset (manager
+    /// on demand). `None` falls through to the env seam
+    /// ([`MANAGER_ENABLED_ENV`]) then the built-in default (`false` — a Run
+    /// starts managerless and the user starts one from the Manager tab when they
+    /// want it). The resolver ([`resolve_manager_enabled`]) owns the precedence;
+    /// the create-run chokepoint reads it FRESH at the edge and it gates **only
+    /// the automatic spawn** — a manual start from the Manager tab is always
+    /// available, which is what keeps the setting honest ("default off", not
+    /// "forbidden").
+    ///
+    /// `Option<i64>` and not `Option<bool>` for the same reason as
+    /// [`Self::autocomplete_turn_end`]: `NULL` is what makes the
+    /// `stored → env → default` fall-through work; a stored `0` is a decision
+    /// that beats the env.
+    pub manager_enabled: Option<i64>,
+    /// Stored **agent-profile name** the manager is pinned to, or `None` when
+    /// unset (« Follow the Run »): the manager mirrors the Run's harness
+    /// (`Run → instance → floor` via `agent_choice::resolve_infra`) and lands on
+    /// the default agent profile for model/effort. A stored name **pins** the
+    /// manager to that profile's harness · model · effort, overriding the Run
+    /// tier — the Run tier always resolves, so a pin that merely replaced the
+    /// floor would almost never fire. `Some("")` is the clear sentinel —
+    /// [`update`] normalises it to SQL `NULL`. A stored name whose profile was
+    /// later deleted (or renamed) falls back to « Follow the Run » at resolve
+    /// time, never a silent rewrite of the stored value (the #432 tombstone
+    /// treatment; `GET /settings` names the dangle in the UI).
+    pub manager_profile: Option<String>,
     /// RFC3339-millis UTC timestamp of the last write (or the seed).
     pub updated_at: String,
 }
@@ -200,6 +227,16 @@ pub(crate) struct UpdateInstanceConfig {
     /// A flat `Option<Vec>` rather than a double-`Option`: an empty selection IS
     /// the clear, there is no third state.
     pub skills: Option<Vec<crate::skill_selection::SkillRef>>,
+    /// Set the manager auto-start flag (manager on demand): `Some(true)` stores
+    /// `1`, `Some(false)` stores `0`, `None` leaves it untouched. Same set-only,
+    /// `0`-not-`NULL` discipline as [`Self::autocomplete_turn_end`]: unticking
+    /// must persist a stored `0` that beats a `PDO_MANAGER_ENABLED=1`, which a
+    /// `NULL` fall-through would not.
+    pub manager_enabled: Option<bool>,
+    /// Set the manager profile pin (an agent-profile NAME): `Some("")` clears it
+    /// back to unset (« Follow the Run », same `""`-sentinel as
+    /// `default_model`); `None` leaves it untouched.
+    pub manager_profile: Option<String>,
 }
 
 impl UpdateInstanceConfig {
@@ -218,6 +255,8 @@ impl UpdateInstanceConfig {
             && self.update_check.is_none()
             && self.agent_choice.is_none()
             && self.skills.is_none()
+            && self.manager_enabled.is_none()
+            && self.manager_profile.is_none()
     }
 }
 
@@ -245,6 +284,8 @@ pub(crate) async fn init(db: &SqlitePool) -> Result<(), sqlx::Error> {
             libassist_idle_ttl_secs INTEGER,
             agent_choice       TEXT,
             update_check       INTEGER,
+            manager_enabled    INTEGER,
+            manager_profile    TEXT,
             updated_at         TEXT NOT NULL
         )",
     )
@@ -422,6 +463,36 @@ pub(crate) async fn init(db: &SqlitePool) -> Result<(), sqlx::Error> {
             .await?;
     }
 
+    // Additive migration (manager on demand): NULLABLE keeps every existing
+    // install on the pre-change behaviour is FALSE here on purpose — the change
+    // itself — but the column must stay NULLABLE so a stored `0` remains a
+    // *decision* that beats the env, and so the env tier can still speak.
+    let has_manager_enabled = sqlx::query(
+        "SELECT 1 FROM pragma_table_info('instance_config') WHERE name = 'manager_enabled'",
+    )
+    .fetch_optional(db)
+    .await?
+    .is_some();
+    if !has_manager_enabled {
+        sqlx::query("ALTER TABLE instance_config ADD COLUMN manager_enabled INTEGER")
+            .execute(db)
+            .await?;
+    }
+
+    // Additive migration (manager on demand): the agent-profile pin, NULLABLE so
+    // unset reads « Follow the Run ».
+    let has_manager_profile = sqlx::query(
+        "SELECT 1 FROM pragma_table_info('instance_config') WHERE name = 'manager_profile'",
+    )
+    .fetch_optional(db)
+    .await?
+    .is_some();
+    if !has_manager_profile {
+        sqlx::query("ALTER TABLE instance_config ADD COLUMN manager_profile TEXT")
+            .execute(db)
+            .await?;
+    }
+
     Ok(())
 }
 
@@ -455,6 +526,10 @@ fn row_to_config(row: &sqlx::sqlite::SqliteRow) -> InstanceConfig {
         skills: crate::skill_selection::from_stored_json(
             row.try_get::<Option<String>, _>("skills").unwrap_or(None),
         ),
+        // Manager on demand: `try_get` so a row read before the column migration
+        // still maps (same posture as `update_check` above).
+        manager_enabled: row.try_get("manager_enabled").unwrap_or(None),
+        manager_profile: row.try_get("manager_profile").unwrap_or(None),
         updated_at: row.get("updated_at"),
     }
 }
@@ -523,6 +598,12 @@ pub(crate) async fn update(
     }
     if edit.skills.is_some() {
         sets.push("skills = ?");
+    }
+    if edit.manager_enabled.is_some() {
+        sets.push("manager_enabled = ?");
+    }
+    if edit.manager_profile.is_some() {
+        sets.push("manager_profile = ?");
     }
     // Always bump the write timestamp on a real edit.
     sets.push("updated_at = ?");
@@ -598,6 +679,17 @@ pub(crate) async fn update(
             &crate::skill_selection::normalise(v),
         ));
     }
+    if let Some(v) = edit.manager_enabled {
+        // 0/1, never NULL: unticking must persist a stored `0` that beats a
+        // `PDO_MANAGER_ENABLED=1`, not fall through to it (manager on demand).
+        query = query.bind(if v { 1_i64 } else { 0_i64 });
+    }
+    if let Some(v) = edit.manager_profile {
+        // "" = clear sentinel → SQL NULL (back to « Follow the Run »), mirroring
+        // default_model/default_harness: a stored "" would win precedence and be
+        // read as a pin to nothing.
+        query = query.bind(if v.is_empty() { None } else { Some(v) });
+    }
     query = query.bind(crate::event_log::now_iso());
     query.execute(db).await?;
 
@@ -633,6 +725,38 @@ pub(crate) async fn set_triggers_paused(db: &SqlitePool, paused: bool) -> Result
         .execute(db)
         .await?;
     Ok(())
+}
+
+/// Env seam for the manager auto-start flag (manager on demand / ADR-0015).
+/// Read only inside [`resolve_manager_enabled`], the `stored → env → default`
+/// precedence — never elsewhere. Same truthy vocabulary as
+/// [`AUTO_FAIL_ENV`]: `1`/`true`/`yes`/`on` (case-insensitive) is truthy;
+/// anything else (incl. unset) is falsey.
+pub(crate) const MANAGER_ENABLED_ENV: &str = "PDO_MANAGER_ENABLED";
+
+/// Built-in default for the manager auto-start flag: **off** — a Run starts
+/// managerless and the user starts one from the Manager tab when they want it.
+pub(crate) const MANAGER_ENABLED_DEFAULT: bool = false;
+
+/// The manager auto-start flag, `stored → env → default(false)` (manager on
+/// demand). `stored` is the `manager_enabled` column value (`Some(0/1)`: a
+/// stored decision, `None` unset). Pure over its `stored` arg; reads the env
+/// only when `stored` is `None`, so a stored `0` beats a
+/// `PDO_MANAGER_ENABLED=1`.
+pub(crate) fn resolve_manager_enabled(stored: Option<i64>) -> bool {
+    match stored {
+        Some(v) => v != 0,
+        None => std::env::var(MANAGER_ENABLED_ENV)
+            .ok()
+            .map(|s| {
+                let t = s.trim();
+                t.eq_ignore_ascii_case("1")
+                    || t.eq_ignore_ascii_case("true")
+                    || t.eq_ignore_ascii_case("yes")
+                    || t.eq_ignore_ascii_case("on")
+            })
+            .unwrap_or(MANAGER_ENABLED_DEFAULT),
+    }
 }
 
 /// Env seam for the instance-wide `auto_fail` default (ADR-0049 / ADR-0015).
@@ -744,6 +868,8 @@ mod tests {
         assert_eq!(cfg.default_auto_name, None);
         assert_eq!(cfg.default_harness, None);
         assert!(cfg.default_harness_model.is_empty());
+        assert_eq!(cfg.manager_enabled, None);
+        assert_eq!(cfg.manager_profile, None);
         assert!(!cfg.updated_at.is_empty(), "seed must stamp updated_at");
     }
 
@@ -795,6 +921,80 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(get(&db).await.unwrap().default_harness_model, map);
+    }
+
+    /// Manager on demand: the auto-start flag is a set-only `0`/`1` knob — both
+    /// directions persist a stored decision. The resolver is pure over its
+    /// `stored` arg, so a stored `0` beats the env tier by construction (no env
+    /// manipulation here: parallel tests share the process environment).
+    #[tokio::test]
+    async fn update_sets_and_reads_back_manager_enabled_both_ways() {
+        let db = test_db().await;
+        let updated = update(
+            &db,
+            UpdateInstanceConfig {
+                manager_enabled: Some(true),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(updated.manager_enabled, Some(1));
+        assert!(resolve_manager_enabled(updated.manager_enabled));
+
+        let off = update(
+            &db,
+            UpdateInstanceConfig {
+                manager_enabled: Some(false),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(off.manager_enabled, Some(0));
+        assert!(
+            !resolve_manager_enabled(off.manager_enabled),
+            "a stored 0 is a decision, not a fall-through"
+        );
+    }
+
+    /// Manager on demand: the profile pin round-trips, `""` clears back to SQL
+    /// NULL (« Follow the Run »), and unset resolves to the default (false) with
+    /// no env tier speaking.
+    #[tokio::test]
+    async fn update_sets_and_clears_manager_profile() {
+        let db = test_db().await;
+        let updated = update(
+            &db,
+            UpdateInstanceConfig {
+                manager_profile: Some("reviewer".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(updated.manager_profile.as_deref(), Some("reviewer"));
+
+        let cleared = update(
+            &db,
+            UpdateInstanceConfig {
+                manager_profile: Some(String::new()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            cleared.manager_profile, None,
+            "empty string must clear the pin back to NULL"
+        );
+        let raw: Option<String> =
+            sqlx::query_scalar("SELECT manager_profile FROM instance_config WHERE id = 1")
+                .fetch_optional(&db)
+                .await
+                .unwrap()
+                .flatten();
+        assert_eq!(raw, None, "clear must persist NULL, never ''");
     }
 
     #[tokio::test]

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -9180,7 +9180,8 @@ async fn spawn_manager_session(
     let session_name = tmux_session_manager::manager_session_name(run_id);
     // The manager follows the harness OF THE RUN — `Run → instance → floor`, no node
     // tier and deliberately no model/effort — so "this Run runs on X" holds with no
-    // exception. An unknown name falls back to `claude` with a warning rather than
+    // exception … unless a stored `manager_profile` pin says otherwise (applied
+    // just below). An unknown name falls back to `claude` with a warning rather than
     // failing the Run: the first NODE spawn is where an unknown harness fails fast
     // (ADR-0037), and the manager is a best-effort assist that must not wedge the Run.
     let run_state = reload_run_state(state, run_id)
@@ -9198,7 +9199,29 @@ async fn spawn_manager_session(
         &profiles,
         agent_profile::DEFAULT_PROFILE_ID,
     );
-    let manager_harness_name = manager_agent.combo.harness.clone();
+    // The stored `manager_profile` pin, applied AFTER « Follow the Run » so a pin
+    // fully wins (design §2.2): the profile's harness · model · effort replace the
+    // Run-tier combo entirely — a pin that only replaced the floor would almost
+    // never fire, since the Run tier always resolves. A pin naming a profile that
+    // was deleted (or renamed) AFTER registration warns and falls back to « Follow
+    // the Run » — loud, and the stored value is never rewritten (#432 tombstone).
+    let stored_pin = config
+        .as_ref()
+        .and_then(|cfg| cfg.manager_profile.as_deref())
+        .map(str::trim)
+        .filter(|p| !p.is_empty());
+    let found = match stored_pin {
+        Some(pin) => agent_profile::find_by_name_ci(&state.db, pin)
+            .await
+            .map_err(|e| e.to_string()),
+        None => Ok(None),
+    };
+    let (manager_combo, pin_warning) =
+        apply_manager_profile_pin(stored_pin, found, manager_agent.combo.clone());
+    if let Some(warning) = &pin_warning {
+        warn!("manager for run {run_id}: {warning}");
+    }
+    let manager_harness_name = manager_combo.harness.clone();
     // Resolve against the DISK TIER, through the same registry the node spawns use,
     // so "this Run runs on X" holds even when X is a user-declared harness.
     let harness_home_root = sandbox_run::sandbox_home_roots(state)
@@ -9258,8 +9281,8 @@ async fn spawn_manager_session(
         // being read as a node's.
         tmux_session_manager::SessionTail::Agent {
             harness: &manager_harness,
-            model: manager_agent.combo.model.as_deref(),
-            effort: manager_agent.combo.effort.as_deref(),
+            model: manager_combo.model.as_deref(),
+            effort: manager_combo.effort.as_deref(),
             session_id: None,
         },
         sandbox_wrap.as_ref(),
@@ -9270,6 +9293,42 @@ async fn spawn_manager_session(
         error!("failed to spawn manager tmux session: {e}");
     } else {
         info!("Spawned manager session: {session_name}");
+    }
+}
+
+/// Apply the stored `manager_profile` pin to the manager's « Follow the Run »
+/// combo (design §2.2 « Manager profile »). `stored` is the trimmable
+/// instance-config value; `found` is the `agent_profile::find_by_name_ci` answer
+/// for it (errors stringified so the helper stays pure and unit-testable).
+///
+/// Returns the combo to launch with — the named profile's harness · model ·
+/// effort when the pin resolves, otherwise the « Follow the Run » combo
+/// untouched — plus a warning for a pin that could not fire (profile missing or
+/// unreadable): the fallback is loud, and the stored value is never rewritten.
+fn apply_manager_profile_pin(
+    stored: Option<&str>,
+    found: Result<Option<agent_profile::AgentProfile>, String>,
+    follow_run: agent_choice::ResolvedCombo,
+) -> (agent_choice::ResolvedCombo, Option<String>) {
+    let Some(pin) = stored else {
+        return (follow_run, None);
+    };
+    match found {
+        Ok(Some(profile)) => (profile.combo(), None),
+        Ok(None) => (
+            follow_run,
+            Some(format!(
+                "manager profile `{pin}` names no agent profile — falling back to \
+                 « Follow the Run »"
+            )),
+        ),
+        Err(e) => (
+            follow_run,
+            Some(format!(
+                "cannot read agent profile `{pin}` ({e}) — falling back to \
+                 « Follow the Run »"
+            )),
+        ),
     }
 }
 
@@ -9731,7 +9790,11 @@ async fn build_settings_view(state: &AppState) -> Result<serde_json::Value, sqlx
     // The profile pin: a stored agent-profile NAME, or unset (« Follow the
     // Run »). No env tier — unlike the flag, a pin is a pure stored decision.
     let mp_stored = cfg.manager_profile.as_deref().filter(|s| !s.is_empty());
-    let mp_source = if mp_stored.is_some() { "stored" } else { "default" };
+    let mp_source = if mp_stored.is_some() {
+        "stored"
+    } else {
+        "default"
+    };
 
     // Not a `settings_field` — it has no stored/env/default tier. Folded in here so
     // the modal learns the default AND whether Docker can run a sandbox in ONE fetch.
@@ -37727,7 +37790,10 @@ edges:
         assert_eq!(fresh["manager_enabled"]["effective"], false);
         assert_eq!(fresh["manager_enabled"]["source"], "default");
         assert_eq!(fresh["manager_enabled"]["default"], false);
-        assert_eq!(fresh["manager_profile"]["effective"], serde_json::Value::Null);
+        assert_eq!(
+            fresh["manager_profile"]["effective"],
+            serde_json::Value::Null
+        );
 
         let (status, view) = put_settings_resp(&state, r#"{"manager_enabled": true}"#).await;
         assert_eq!(status, StatusCode::OK, "got {view}");
@@ -37759,15 +37825,9 @@ edges:
     #[tokio::test]
     async fn put_settings_persists_and_clears_the_manager_profile_pin() {
         let state = test_state().await;
-        let profile = agent_profile::create(
-            &state.db,
-            "reviewer",
-            "claude",
-            Some("sonnet"),
-            None,
-        )
-        .await
-        .unwrap();
+        let profile = agent_profile::create(&state.db, "reviewer", "claude", Some("sonnet"), None)
+            .await
+            .unwrap();
 
         let (status, view) = put_settings_resp(&state, r#"{"manager_profile": "reviewer"}"#).await;
         assert_eq!(status, StatusCode::OK, "got {view}");
@@ -37778,7 +37838,10 @@ edges:
         // SQL NULL, never as an empty string that would win precedence.
         let (status, view) = put_settings_resp(&state, r#"{"manager_profile": ""}"#).await;
         assert_eq!(status, StatusCode::OK, "got {view}");
-        assert_eq!(view["manager_profile"]["effective"], serde_json::Value::Null);
+        assert_eq!(
+            view["manager_profile"]["effective"],
+            serde_json::Value::Null
+        );
         assert_eq!(view["manager_profile"]["source"], "default");
         assert_eq!(
             instance_config::get(&state.db)
@@ -37803,7 +37866,10 @@ edges:
         let (status, body) = put_settings_resp(&state, r#"{"manager_profile": "ghost"}"#).await;
         assert_eq!(status, StatusCode::BAD_REQUEST, "got {body}");
         assert!(
-            body["error"].as_str().unwrap().contains("unknown manager profile `ghost`"),
+            body["error"]
+                .as_str()
+                .unwrap()
+                .contains("unknown manager profile `ghost`"),
             "got {body}"
         );
         assert_eq!(
@@ -37814,6 +37880,77 @@ edges:
             None,
             "a refused edit must persist nothing"
         );
+    }
+
+    #[test]
+    fn no_pin_leaves_the_follow_the_run_combo_untouched() {
+        let follow_run = agent_choice::ResolvedCombo {
+            harness: "codex".into(),
+            model: Some("gpt-5".into()),
+            effort: Some("high".into()),
+        };
+        let (combo, warning) = apply_manager_profile_pin(None, Ok(None), follow_run.clone());
+        assert_eq!(combo, follow_run);
+        assert_eq!(warning, None);
+    }
+
+    #[test]
+    fn a_resolved_pin_fully_replaces_the_follow_the_run_combo() {
+        // Strong pin (design §2.2, decision #3): harness, model AND effort come
+        // from the profile — the Run tier never leaks through.
+        let follow_run = agent_choice::ResolvedCombo {
+            harness: "codex".into(),
+            model: Some("gpt-5".into()),
+            effort: Some("high".into()),
+        };
+        let profile = agent_profile::AgentProfile {
+            id: "p1".into(),
+            name: "CheapManager".into(),
+            harness: "claude".into(),
+            model: Some("haiku".into()),
+            effort: None,
+            created_at: "2026-01-01".into(),
+            updated_at: "2026-01-01".into(),
+        };
+        let (combo, warning) =
+            apply_manager_profile_pin(Some("CheapManager"), Ok(Some(profile)), follow_run);
+        assert_eq!(combo.harness, "claude");
+        assert_eq!(combo.model.as_deref(), Some("haiku"));
+        assert_eq!(combo.effort, None);
+        assert_eq!(warning, None);
+    }
+
+    #[test]
+    fn a_pin_to_a_missing_profile_falls_back_with_a_warning_naming_it() {
+        // #432 tombstone discipline: the profile was deleted after the pin was
+        // stored — the spawn falls back to « Follow the Run », loudly, and the
+        // stored value is never rewritten (nothing here persists anything).
+        let follow_run = agent_choice::ResolvedCombo {
+            harness: "codex".into(),
+            model: None,
+            effort: None,
+        };
+        let (combo, warning) =
+            apply_manager_profile_pin(Some("ghost"), Ok(None), follow_run.clone());
+        assert_eq!(combo, follow_run);
+        let warning = warning.expect("a missing pin must warn");
+        assert!(warning.contains("`ghost`"), "got: {warning}");
+        assert!(warning.contains("Follow the Run"), "got: {warning}");
+    }
+
+    #[test]
+    fn a_pin_that_cannot_be_looked_up_falls_back_with_a_warning() {
+        let follow_run = agent_choice::ResolvedCombo {
+            harness: "claude".into(),
+            model: None,
+            effort: None,
+        };
+        let (combo, warning) =
+            apply_manager_profile_pin(Some("p"), Err("db locked".into()), follow_run.clone());
+        assert_eq!(combo, follow_run);
+        let warning = warning.expect("a failed lookup must warn");
+        assert!(warning.contains("db locked"), "got: {warning}");
+        assert!(warning.contains("Follow the Run"), "got: {warning}");
     }
 
     #[tokio::test]

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -4374,6 +4374,11 @@ fn build_router(state: Arc<AppState>) -> Router {
         )
         .route("/sessions/{session_id}/attach", post(session_attach))
         .route("/sessions/{run_id}/manager/attach", post(manager_attach))
+        // Manager on demand: start/stop the Run's Pipeline Manager from the
+        // Manager tab. Start is idempotent (a double-click is a benign
+        // re-answer); stop on a dead session is a calm no-op.
+        .route("/runs/{run_id}/manager/start", post(start_run_manager))
+        .route("/runs/{run_id}/manager/stop", post(stop_run_manager))
         .route("/sessions/{run_id}/shell", post(open_run_shell))
         // The library pipeline authoring assistant (ADR-0051). No pipeline id in the
         // path: there is ONE assistant for the whole daemon. `POST` is
@@ -8947,10 +8952,25 @@ async fn create_run_inner(
         }
     }
 
+    // Manager on demand: the automatic spawn is GATED on the instance setting
+    // (`stored → env PDO_MANAGER_ENABLED → false`), read FRESH at the edge like
+    // every instance knob. It is NOT a permission — the Manager tab's manual
+    // start is always available, which is what keeps the setting honest — and it
+    // applies to future Runs only: a live Run is unaffected by a mid-flight
+    // toggle.
+    let manager_enabled = instance_config::resolve_manager_enabled(
+        instance_config::get(&state.db)
+            .await
+            .ok()
+            .and_then(|cfg| cfg.manager_enabled),
+    );
+
     if sandbox.is_off() {
         // Host path — inline, no docker.
         spawn_ready_after_event(state, &run_id).await;
-        spawn_manager_session(state, &run_id, &worktree_dir, name_hint, false).await;
+        if manager_enabled {
+            spawn_manager_session(state, &run_id, &worktree_dir, name_hint, false).await;
+        }
     } else {
         // Eager fail-fast prep on a detached task: the 201 must not block on a
         // first-run `docker build` (ADR-0023). Image + container + staging are
@@ -9011,14 +9031,16 @@ async fn create_run_inner(
                     // single REPLAY point for every spawn deferred while the prep ran.
                     mark_sandbox_prep_ready(&task_state, &task_run_id).await;
                     spawn_ready_after_event(&task_state, &task_run_id).await;
-                    spawn_manager_session(
-                        &task_state,
-                        &task_run_id,
-                        &task_worktree,
-                        name_hint,
-                        true,
-                    )
-                    .await;
+                    if manager_enabled {
+                        spawn_manager_session(
+                            &task_state,
+                            &task_run_id,
+                            &task_worktree,
+                            name_hint,
+                            true,
+                        )
+                        .await;
+                    }
                 }
                 Ok(Err(e)) => {
                     fail_run_sandbox_prep(
@@ -9216,6 +9238,11 @@ async fn spawn_manager_session(
         workdir: worktree_dir,
         set_env: &manager_set_env,
     });
+    // Reservation before spawn (ADR-0038, extended to every path): the durable
+    // event lands FIRST, the tmux spawn after. The projection ignores this kind —
+    // the wire's `has_manager` stays an observed tmux fact, so a spawn that fails
+    // after the reservation reads `false`, not `true`.
+    emit_run_event(state, run_id, event_log::EventKind::ManagerStarted, None).await;
     if let Err(e) = tmux_session_manager::spawn(
         &session_name,
         &full_prompt,
@@ -9680,6 +9707,32 @@ async fn build_settings_view(state: &AppState) -> Result<serde_json::Value, sqlx
         "default"
     };
 
+    // Manager on demand: the auto-start flag, `stored → env → default(false)` —
+    // the SAME resolver the create-run chokepoint consumes, so the disclosed
+    // value cannot drift.
+    let me_stored = cfg.manager_enabled.map(|v| v != 0);
+    let me_env = std::env::var(instance_config::MANAGER_ENABLED_ENV)
+        .ok()
+        .map(|s| {
+            let t = s.trim();
+            t.eq_ignore_ascii_case("1")
+                || t.eq_ignore_ascii_case("true")
+                || t.eq_ignore_ascii_case("yes")
+                || t.eq_ignore_ascii_case("on")
+        });
+    let me_effective = instance_config::resolve_manager_enabled(cfg.manager_enabled);
+    let me_source = if me_stored.is_some() {
+        "stored"
+    } else if me_env.is_some() {
+        "env"
+    } else {
+        "default"
+    };
+    // The profile pin: a stored agent-profile NAME, or unset (« Follow the
+    // Run »). No env tier — unlike the flag, a pin is a pure stored decision.
+    let mp_stored = cfg.manager_profile.as_deref().filter(|s| !s.is_empty());
+    let mp_source = if mp_stored.is_some() { "stored" } else { "default" };
+
     // Not a `settings_field` — it has no stored/env/default tier. Folded in here so
     // the modal learns the default AND whether Docker can run a sandbox in ONE fetch.
     // Advisory: it grays out `full`/`minimal`, but the run-advance fail-fast
@@ -9874,6 +9927,21 @@ async fn build_settings_view(state: &AppState) -> Result<serde_json::Value, sqlx
             uc_env,
             update_check::UPDATE_CHECK_DEFAULT,
         ),
+        // Manager on demand: off by default — a Run starts managerless and the
+        // Manager tab's Start button (or the Settings toggle for future Runs)
+        // brings one up.
+        "manager_enabled": settings_field_bool(
+            me_effective,
+            me_source,
+            me_stored,
+            me_env,
+            instance_config::MANAGER_ENABLED_DEFAULT,
+        ),
+        // The agent-profile NAME the manager is pinned to, or null (« Follow the
+        // Run » — the manager mirrors the Run's harness/model/effort). A stored
+        // name whose profile was deleted dangles: the UI renders the #432
+        // tombstone, and the spawn falls back to « Follow the Run ».
+        "manager_profile": settings_field_str(mp_stored, mp_source, mp_stored, None),
         "updated_at": cfg.updated_at,
     }))
 }
@@ -10841,6 +10909,37 @@ async fn put_settings(
         // RESOLVES. Same shared gate as the Trigger surfaces.
         if let Err(msg) = validate_sandbox_ref(&state.db, s).await {
             return bad(&msg);
+        }
+    }
+    if let Some(p) = req.manager_profile.as_deref() {
+        // "" = clear sentinel (back to « Follow the Run »); anything else must
+        // name an EXISTING agent profile. A pin to nothing would silently fall
+        // back at spawn time, so it is refused at registration — the #432
+        // tombstone then only ever arises from a LATER profile deletion/rename,
+        // which no PUT can prevent.
+        if !p.is_empty() {
+            match agent_profile::find_by_name_ci(&state.db, p).await {
+                Ok(Some(_)) => {}
+                Ok(None) => {
+                    let names = agent_profile::list(&state.db)
+                        .await
+                        .map(|profiles| {
+                            profiles
+                                .iter()
+                                .map(|profile| profile.name.as_str())
+                                .collect::<Vec<_>>()
+                                .join(", ")
+                        })
+                        .unwrap_or_default();
+                    return bad(&format!(
+                        "unknown manager profile `{p}`: it names no agent profile — a pin to \
+                         nothing would silently fall back to « Follow the Run ». Known profiles: {names}"
+                    ));
+                }
+                Err(e) => {
+                    return bad(&format!("cannot check agent profile `{p}`: {e}"));
+                }
+            }
         }
     }
     if let Some(h) = req.default_harness.as_deref() {
@@ -12727,6 +12826,18 @@ async fn get_run(
             );
             let mut response = serde_json::to_value(run_state).expect("RunState serializes");
             inject_frozen_node_provisioning(&mut response, &events);
+            // Manager on demand: an OBSERVED fact, not a projected one — the
+            // panel must know whether the session really exists, and a live tmux
+            // probe is the only honest source (a projected flag would drift from
+            // the orphan sweep, a manual stop or a daemon restart). One
+            // `has-session` per detail fetch, the same cost class as the disk
+            // reads above.
+            let socket = state.tmux_socket();
+            let has_manager = tmux_session_manager::session_exists(
+                &socket,
+                &tmux_session_manager::manager_session_name(&run_id),
+            );
+            response["has_manager"] = serde_json::Value::Bool(has_manager);
             Json(response).into_response()
         }
 
@@ -16687,6 +16798,145 @@ async fn session_attach(
         )
             .into_response(),
     }
+}
+
+/// Response of `POST /runs/{run_id}/manager/start` (manager on demand).
+#[derive(Serialize)]
+struct ManagerStartResponse {
+    ok: bool,
+    session: String,
+    /// `true` when THIS call spawned the session; `false` when it already
+    /// existed — a double-click Start is an idempotent re-answer, not an error.
+    created: bool,
+}
+
+/// Start the Run's Pipeline Manager on demand (manager on demand).
+///
+/// The Manager tab's Start button is ALWAYS available — the `manager_enabled`
+/// setting gates only the automatic spawn at Run creation, never this — so the
+/// handler is gated on nothing but the Run existing and its worktree still
+/// being on disk (an archived Run has none left to work in).
+///
+/// Idempotency and the racing discipline are the run shell's
+/// create-then-verify rule: `session_exists` first (a benign re-answer), spawn,
+/// then verify again — a concurrent start may have won the `new-session`, and a
+/// spawn failure after our own reservation event must read as an error, not a
+/// silent success (the projection ignores `ManagerStarted`; the wire's
+/// `has_manager` stays the observed tmux fact).
+async fn start_run_manager(
+    State(state): State<Arc<AppState>>,
+    AxumPath(run_id): AxumPath<String>,
+) -> Response {
+    let (_, run_state) = match load_projected(&state, &run_id).await {
+        Ok(t) => t,
+        Err(resp) => return *resp,
+    };
+
+    let session_name = tmux_session_manager::manager_session_name(&run_id);
+    let socket = state.tmux_socket();
+    if tmux_session_manager::session_exists(&socket, &session_name) {
+        return (
+            StatusCode::OK,
+            Json(ManagerStartResponse {
+                ok: true,
+                session: session_name,
+                created: false,
+            }),
+        )
+            .into_response();
+    }
+
+    // The manager works in the Run's worktree; an archived/cleaned Run has none
+    // left, and a session spawned into a dead cwd would only fail at tmux.
+    let repo_root = effective_repo_root(&state, &run_state);
+    let worktree_dir = crate::worktree_ops::worktree_dir_for_run(&repo_root, &run_id);
+    if !worktree_dir.exists() {
+        return (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({
+                "error": "this run's worktree no longer exists (archived or cleaned) — there is nothing for a manager to work in"
+            })),
+        )
+            .into_response();
+    }
+
+    // The create path's name_hint discipline, reconstructed from the projected
+    // state: a placeholder name still carries its rename instruction, a named
+    // Run is left alone, and a nameless Run derives from its input. The FIRST
+    // start (manual or automatic) names the Run best-effort, exactly as before.
+    let name_hint = match run_state.name.as_deref() {
+        Some(name) if name.starts_with("Untitled run") => {
+            prompt_augmenter::RunNameHint::Placeholder
+        }
+        Some(_) => prompt_augmenter::RunNameHint::UserProvided,
+        None => match run_state.input.as_deref() {
+            Some(input) if !input.trim().is_empty() => {
+                prompt_augmenter::RunNameHint::DeriveFromInput
+            }
+            _ => prompt_augmenter::RunNameHint::Placeholder,
+        },
+    };
+
+    spawn_manager_session(
+        &state,
+        &run_id,
+        &worktree_dir,
+        name_hint,
+        !run_state.sandbox.is_off(),
+    )
+    .await;
+
+    // Create-then-verify (the run shell's benign-race rule).
+    if !tmux_session_manager::session_exists(&socket, &session_name) {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({
+                "error": "the manager tmux session did not come up (see the daemon logs)"
+            })),
+        )
+            .into_response();
+    }
+    (
+        StatusCode::OK,
+        Json(ManagerStartResponse {
+            ok: true,
+            session: session_name,
+            created: true,
+        }),
+    )
+        .into_response()
+}
+
+/// Stop the Run's Pipeline Manager (manager on demand). Cost control is the
+/// point of the feature, so the session must be killable from the panel — not
+/// only by the orphan sweep or a manual `tmux kill-session`.
+///
+/// Stop on a session that is already gone is a calm no-op that still answers
+/// `200` ("nothing to stop"), and still writes its `ManagerStopped` event: the
+/// projection ignores the kind, so the durable record never lies about state.
+async fn stop_run_manager(
+    State(state): State<Arc<AppState>>,
+    AxumPath(run_id): AxumPath<String>,
+) -> Response {
+    // Durable first, kill after — the same order the start path keeps.
+    emit_run_event(&state, &run_id, event_log::EventKind::ManagerStopped, None).await;
+
+    let session_name = tmux_session_manager::manager_session_name(&run_id);
+    let socket = state.tmux_socket();
+    if !tmux_session_manager::session_exists(&socket, &session_name) {
+        return (
+            StatusCode::OK,
+            Json(serde_json::json!({ "ok": true, "stopped": false })),
+        )
+            .into_response();
+    }
+    tmux_session_manager::kill(&socket, &session_name);
+    info!("Stopped manager session: {session_name}");
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({ "ok": true, "stopped": true })),
+    )
+        .into_response()
 }
 
 async fn manager_attach(
@@ -23165,6 +23415,121 @@ mod tests {
         assert!(body.get("loc").is_none() || body["loc"].is_null());
         // No transcript dir for this seeded run → `cost` is omitted (None) → "—".
         assert!(body.get("cost").is_none() || body["cost"].is_null());
+    }
+
+    #[tokio::test]
+    async fn get_run_payload_carries_has_manager_as_an_observed_fact() {
+        // Manager on demand: the wire's `has_manager` is an OBSERVED tmux fact,
+        // probed at fetch time — never a projected flag. In the test env no tmux
+        // session exists, so a freshly seeded run reads `false` even though no
+        // event ever said otherwise; a spawned-then-swept session would read the
+        // same way, which is exactly the desynchronisation a projected flag
+        // cannot survive.
+        let state = test_state().await;
+        let run_id = "manager-payload";
+        seed_completed_run(&state, run_id).await;
+
+        let app = build_router(state.clone());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/runs/{run_id}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: serde_json::Value = serde_json::from_slice(
+            &axum::body::to_bytes(resp.into_body(), usize::MAX)
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(body["has_manager"], false);
+    }
+
+    #[tokio::test]
+    async fn start_manager_on_a_run_without_a_worktree_is_refused() {
+        // Manager on demand: the start endpoint is always available (the
+        // `manager_enabled` setting gates only the automatic spawn), but a run
+        // whose worktree is gone (archived/cleaned) has nothing for a manager
+        // to work in — refused with a 409 naming why, never a spawn into a dead
+        // cwd.
+        let state = test_state().await;
+        let run_id = "manager-start-noworktree";
+        seed_completed_run(&state, run_id).await;
+
+        let app = build_router(state.clone());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/runs/{run_id}/manager/start"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+        let body: serde_json::Value = serde_json::from_slice(
+            &axum::body::to_bytes(resp.into_body(), usize::MAX)
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+        assert!(
+            body["error"]
+                .as_str()
+                .unwrap()
+                .contains("worktree no longer exists"),
+            "got {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn start_manager_on_an_unknown_run_is_a_404() {
+        let state = test_state().await;
+        let app = build_router(state.clone());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/runs/no-such-run/manager/start")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn stop_manager_on_a_dead_session_is_a_calm_noop() {
+        // Manager on demand: stopping a session that is already gone answers
+        // 200 with `stopped: false` — and still writes its ManagerStopped
+        // event, which the projection ignores.
+        let state = test_state().await;
+        let app = build_router(state.clone());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/runs/manager-stop-ghost/manager/stop")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: serde_json::Value = serde_json::from_slice(
+            &axum::body::to_bytes(resp.into_body(), usize::MAX)
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(body["ok"], true);
+        assert_eq!(body["stopped"], false);
     }
 
     #[test]
@@ -37347,6 +37712,107 @@ edges:
                 .unwrap()
                 .default_auto_name,
             Some(1)
+        );
+    }
+
+    #[tokio::test]
+    async fn put_settings_round_trips_the_manager_enabled_flag_both_ways() {
+        // Manager on demand: the checkbox is authoritative in BOTH directions.
+        // Unticking must persist a stored `0` (not a clear back to NULL), or it
+        // could never override a `PDO_MANAGER_ENABLED=1`. The fresh view also
+        // discloses the built-in default: OFF — a Run starts managerless.
+        let state = test_state().await;
+
+        let (_, fresh) = put_settings_resp(&state, "{}").await;
+        assert_eq!(fresh["manager_enabled"]["effective"], false);
+        assert_eq!(fresh["manager_enabled"]["source"], "default");
+        assert_eq!(fresh["manager_enabled"]["default"], false);
+        assert_eq!(fresh["manager_profile"]["effective"], serde_json::Value::Null);
+
+        let (status, view) = put_settings_resp(&state, r#"{"manager_enabled": true}"#).await;
+        assert_eq!(status, StatusCode::OK, "got {view}");
+        assert_eq!(view["manager_enabled"]["effective"], true);
+        assert_eq!(view["manager_enabled"]["source"], "stored");
+        assert_eq!(
+            instance_config::get(&state.db)
+                .await
+                .unwrap()
+                .manager_enabled,
+            Some(1),
+            "on must persist a stored 1"
+        );
+
+        let (status, view) = put_settings_resp(&state, r#"{"manager_enabled": false}"#).await;
+        assert_eq!(status, StatusCode::OK, "got {view}");
+        assert_eq!(view["manager_enabled"]["effective"], false);
+        assert_eq!(view["manager_enabled"]["source"], "stored");
+        assert_eq!(
+            instance_config::get(&state.db)
+                .await
+                .unwrap()
+                .manager_enabled,
+            Some(0),
+            "off must persist a stored 0, never NULL"
+        );
+    }
+
+    #[tokio::test]
+    async fn put_settings_persists_and_clears_the_manager_profile_pin() {
+        let state = test_state().await;
+        let profile = agent_profile::create(
+            &state.db,
+            "reviewer",
+            "claude",
+            Some("sonnet"),
+            None,
+        )
+        .await
+        .unwrap();
+
+        let (status, view) = put_settings_resp(&state, r#"{"manager_profile": "reviewer"}"#).await;
+        assert_eq!(status, StatusCode::OK, "got {view}");
+        assert_eq!(view["manager_profile"]["effective"], "reviewer");
+        assert_eq!(view["manager_profile"]["source"], "stored");
+
+        // "" is the clear sentinel — back to « Follow the Run », persisted as
+        // SQL NULL, never as an empty string that would win precedence.
+        let (status, view) = put_settings_resp(&state, r#"{"manager_profile": ""}"#).await;
+        assert_eq!(status, StatusCode::OK, "got {view}");
+        assert_eq!(view["manager_profile"]["effective"], serde_json::Value::Null);
+        assert_eq!(view["manager_profile"]["source"], "default");
+        assert_eq!(
+            instance_config::get(&state.db)
+                .await
+                .unwrap()
+                .manager_profile,
+            None,
+            "clear must persist NULL, never ''"
+        );
+
+        // Keep the profile referenced so `create`'s row is not dead code.
+        assert_eq!(profile.name, "reviewer");
+    }
+
+    #[tokio::test]
+    async fn put_settings_refuses_an_unknown_manager_profile() {
+        // A pin to nothing would silently fall back to « Follow the Run » at
+        // spawn time — refused at registration instead. (The #432 tombstone
+        // only ever arises from a LATER profile deletion, which no PUT can
+        // prevent.)
+        let state = test_state().await;
+        let (status, body) = put_settings_resp(&state, r#"{"manager_profile": "ghost"}"#).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST, "got {body}");
+        assert!(
+            body["error"].as_str().unwrap().contains("unknown manager profile `ghost`"),
+            "got {body}"
+        );
+        assert_eq!(
+            instance_config::get(&state.db)
+                .await
+                .unwrap()
+                .manager_profile,
+            None,
+            "a refused edit must persist nothing"
         );
     }
 

--- a/crates/pdo-daemon/tests/common/mod.rs
+++ b/crates/pdo-daemon/tests/common/mod.rs
@@ -545,6 +545,28 @@ impl TestDaemon {
         format!("http://{}", self.addr)
     }
 
+    /// Manager on demand: flip the instance auto-start flag ON for this daemon.
+    ///
+    /// The default is now OFF — a Run starts managerless — so any test asserting
+    /// the auto-spawned manager (its session, its preamble, or the `claude`
+    /// staging set it fills as the Run's first claude session) must opt back in
+    /// explicitly, the same way a user would. Per-daemon through `PUT /settings`
+    /// (the stored tier), never a process-global `std::env::set_var` (#181).
+    /// Call it after [`TestDaemon::spawn`] and BEFORE creating the Run.
+    pub async fn enable_manager(&self) {
+        let resp = reqwest::Client::new()
+            .put(format!("{}/settings", self.url()))
+            .json(&serde_json::json!({ "manager_enabled": true }))
+            .send()
+            .await
+            .expect("PUT /settings (manager_enabled)");
+        assert!(
+            resp.status().is_success(),
+            "enabling the manager failed: {}",
+            resp.status()
+        );
+    }
+
     pub fn repo_root(&self) -> &Path {
         self.tempdir.path()
     }

--- a/crates/pdo-daemon/tests/harness_freeze_resume.rs
+++ b/crates/pdo-daemon/tests/harness_freeze_resume.rs
@@ -296,6 +296,9 @@ async fn wait_for_manager_session(daemon: &TestDaemon, run_id: &str) -> bool {
 #[tokio::test]
 async fn run_harness_moves_the_free_node_and_manager() {
     let daemon = TestDaemon::spawn(seed).await.unwrap();
+    // Manager on demand: this test asserts the auto-spawned manager, so it opts
+    // back in explicitly (the new default starts every Run managerless).
+    daemon.enable_manager().await;
     let run_id = create_run_with_harness(&daemon, Some("opencode")).await;
     let evs = wait_for_both_started(&daemon, &run_id).await;
 

--- a/crates/pdo-daemon/tests/sandbox_profiles.rs
+++ b/crates/pdo-daemon/tests/sandbox_profiles.rs
@@ -1324,6 +1324,9 @@ async fn unchecking_settings_json_still_starts_thanks_to_the_staging_set() {
     let daemon = TestDaemon::spawn_with_docker_override(seed(), docker)
         .await
         .unwrap();
+    // Manager on demand: the Run's first claude session (hence the staged set)
+    // is the manager — opt back in, the new default starts every Run managerless.
+    daemon.enable_manager().await;
     fabricate_host_home(daemon.repo_root());
 
     assert_eq!(

--- a/crates/pdo-daemon/tests/sandbox_tracer.rs
+++ b/crates/pdo-daemon/tests/sandbox_tracer.rs
@@ -232,6 +232,7 @@ async fn minimal_run_prepares_wraps_and_completes() {
         TestDaemon::spawn_with_docker_override(seed("#!/usr/bin/env bash\ntrue\n"), docker)
             .await
             .unwrap();
+    daemon.enable_manager().await;
 
     let run_id = start_run(&daemon, Some("minimal")).await;
 
@@ -631,6 +632,7 @@ async fn full_run_stages_allowlist_and_completes() {
         TestDaemon::spawn_with_docker_override(seed("#!/usr/bin/env bash\ntrue\n"), docker)
             .await
             .unwrap();
+    daemon.enable_manager().await;
     fabricate_host_claude(daemon.repo_root());
 
     let run_id = start_run(&daemon, Some("full")).await;
@@ -737,6 +739,7 @@ async fn minimal_run_stages_the_staging_set_against_a_fabricated_host() {
         TestDaemon::spawn_with_docker_override(seed("#!/usr/bin/env bash\ntrue\n"), docker)
             .await
             .unwrap();
+    daemon.enable_manager().await;
     fabricate_host_claude(daemon.repo_root());
 
     let run_id = start_run(&daemon, Some("minimal")).await;
@@ -795,6 +798,7 @@ async fn full_excludes_projects_and_bulky_host_state() {
         TestDaemon::spawn_with_docker_override(seed("#!/usr/bin/env bash\ntrue\n"), docker)
             .await
             .unwrap();
+    daemon.enable_manager().await;
     fabricate_host_claude(daemon.repo_root());
 
     let run_id = start_run(&daemon, Some("full")).await;
@@ -1547,6 +1551,7 @@ async fn sandboxed_manager_preamble_uses_the_container_side_url() {
         TestDaemon::spawn_with_docker_override(seed("#!/usr/bin/env bash\ntrue\n"), docker)
             .await
             .unwrap();
+    daemon.enable_manager().await;
 
     let run_id = start_run(&daemon, Some("minimal")).await;
     wait_node_status(&daemon, &run_id, "running").await;
@@ -1585,6 +1590,12 @@ async fn off_run_manager_preamble_stays_on_localhost() {
         TestDaemon::spawn_with_docker_override(seed("#!/usr/bin/env bash\ntrue\n"), docker)
             .await
             .unwrap();
+    daemon.enable_manager().await;
+    // The enable call answers through `GET /settings`' view, which runs the
+    // advisory Docker probe — a docker invocation that is NOT the Run's. Reset
+    // the argv baseline so the assertion below still means "the off RUN never
+    // invokes docker".
+    std::fs::write(&log, b"").unwrap();
 
     let run_id = start_run(&daemon, None).await;
     let port = daemon.addr.port();

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,6 +43,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
+    "@types/hast": "^3.0.5",
     "@types/node": "^24.12.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -93,6 +93,9 @@ importers:
       '@testing-library/user-event':
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
+      '@types/hast':
+        specifier: ^3.0.5
+        version: 3.0.5
       '@types/node':
         specifier: ^24.12.2
         version: 24.12.2
@@ -1177,8 +1180,8 @@ packages:
   '@types/geojson@7946.0.16':
     resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
-  '@types/hast@3.0.4':
-    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+  '@types/hast@3.0.5':
+    resolution: {integrity: sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -4691,7 +4694,7 @@ snapshots:
 
   '@types/geojson@7946.0.16': {}
 
-  '@types/hast@3.0.4':
+  '@types/hast@3.0.5':
     dependencies:
       '@types/unist': 3.0.3
 
@@ -5754,7 +5757,7 @@ snapshots:
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
       '@types/estree': 1.0.8
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
       '@types/unist': 3.0.3
       comma-separated-tokens: 2.0.3
       devlop: 1.1.0
@@ -5773,7 +5776,7 @@ snapshots:
 
   hast-util-whitespace@3.0.0:
     dependencies:
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
 
   headers-polyfill@5.0.1:
     dependencies:
@@ -6164,7 +6167,7 @@ snapshots:
   mdast-util-mdx-expression@2.0.1:
     dependencies:
       '@types/estree-jsx': 1.0.5
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       mdast-util-from-markdown: 2.0.3
@@ -6175,7 +6178,7 @@ snapshots:
   mdast-util-mdx-jsx@3.2.0:
     dependencies:
       '@types/estree-jsx': 1.0.5
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
       '@types/mdast': 4.0.4
       '@types/unist': 3.0.3
       ccount: 2.0.1
@@ -6192,7 +6195,7 @@ snapshots:
   mdast-util-mdxjs-esm@2.0.1:
     dependencies:
       '@types/estree-jsx': 1.0.5
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       mdast-util-from-markdown: 2.0.3
@@ -6207,7 +6210,7 @@ snapshots:
 
   mdast-util-to-hast@13.2.1:
     dependencies:
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
       '@types/mdast': 4.0.4
       '@ungap/structured-clone': 1.3.1
       devlop: 1.1.0
@@ -6732,7 +6735,7 @@ snapshots:
 
   react-markdown@10.1.0(@types/react@19.2.14)(react@19.2.5):
     dependencies:
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
       '@types/mdast': 4.0.4
       '@types/react': 19.2.14
       devlop: 1.1.0
@@ -6825,7 +6828,7 @@ snapshots:
 
   remark-rehype@11.1.2:
     dependencies:
-      '@types/hast': 3.0.4
+      '@types/hast': 3.0.5
       '@types/mdast': 4.0.4
       mdast-util-to-hast: 13.2.1
       unified: 11.0.5

--- a/frontend/src/App.settingsClose.test.tsx
+++ b/frontend/src/App.settingsClose.test.tsx
@@ -113,6 +113,8 @@ vi.mock("./api", () => {
       env: null,
       default: true,
     },
+    manager_enabled: { effective: false, source: "default", stored: null, env: null, default: false },
+    manager_profile: { effective: null, source: "default", stored: null, env: null, default: null },
     update_check: { effective: true, source: "default", stored: null, env: null, default: true },
     price_table: {
       manual_path: "/home/user/.pdo/prices/models.yaml",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -804,6 +804,8 @@ export default function App() {
                 initialTab={infoPanelInitialTab}
                 scrollToLine={infoPanelScrollToLine}
                 assistantId={assistantId}
+                onRefreshRun={refreshRun}
+                onOpenSettings={() => openSettings({ category: "agents", section: "pipeline-manager" })}
               />
             ) : paneOwner === "editTab" ? (
               <>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1194,6 +1194,27 @@ export function killNode(
   );
 }
 
+/** Manager on demand: start the Run's Pipeline Manager session on demand.
+ *  Idempotent — the daemon answers `created: false` when the session already
+ *  existed (a double-click Start is a benign re-answer). */
+export function startRunManager(runId: string): Promise<{ ok: boolean; session: string; created: boolean }> {
+  return request(
+    "POST",
+    `/runs/${encodeURIComponent(runId)}/manager/start`,
+    { label: `POST /runs/${runId}/manager/start` },
+  );
+}
+
+/** Manager on demand: stop the Run's Pipeline Manager session. A stop on a
+ *  session that is already gone is a calm no-op (`stopped: false`). */
+export function stopRunManager(runId: string): Promise<{ ok: boolean; stopped: boolean }> {
+  return request(
+    "POST",
+    `/runs/${encodeURIComponent(runId)}/manager/stop`,
+    { label: `POST /runs/${runId}/manager/stop` },
+  );
+}
+
 export function restartNode(
   runId: string,
   nodeId: string,

--- a/frontend/src/components/NewRunModal.test.tsx
+++ b/frontend/src/components/NewRunModal.test.tsx
@@ -860,6 +860,8 @@ describe("NewRunModal — auto-naming default (#338)", () => {
       autocomplete_turn_end: { effective: false, source: "default", stored: null, env: null, default: false },
       default_auto_name: { effective, source: effective ? "default" : "stored", stored: effective ? null : false, env: null, default: true },
       update_check: { effective: true, source: "default", stored: null, env: null, default: true },
+      manager_enabled: { effective: false, source: "default", stored: null, env: null, default: false },
+      manager_profile: { effective: null, source: "default", stored: null, env: null, default: null },
       price_table: { manual_path: null, fetched_path: null, source: null, fetched_at: null, fetched_rows: 0, manual_keys: [], reason: null },
       updated_at: "2026-07-01T10:00:00.000Z",
     };
@@ -1614,6 +1616,8 @@ describe("NewRunModal — sandbox selector (#410)", () => {
     default_auto_name: { effective: true, source: "default", stored: null, env: null, default: true },
       // #427: required on InstanceSettings; this modal does not read it.
       update_check: { effective: true, source: "default", stored: null, env: null, default: true },
+      manager_enabled: { effective: false, source: "default", stored: null, env: null, default: false },
+      manager_profile: { effective: null, source: "default", stored: null, env: null, default: null },
       price_table: { manual_path: "/home/user/.pdo/prices/models.yaml", fetched_path: "/home/user/.pdo/prices/fetched.json", source: null, fetched_at: null, fetched_rows: 0, manual_keys: [], reason: null },
       updated_at: "2026-07-01T10:00:00.000Z",
       ...overrides,
@@ -1947,6 +1951,8 @@ describe("NewRunModal — the launch dialog can defer to default_sandbox (#452)"
     default_auto_name: { effective: true, source: "default", stored: null, env: null, default: true },
       // #427: required on InstanceSettings; this modal does not read it.
       update_check: { effective: true, source: "default", stored: null, env: null, default: true },
+      manager_enabled: { effective: false, source: "default", stored: null, env: null, default: false },
+      manager_profile: { effective: null, source: "default", stored: null, env: null, default: null },
       price_table: { manual_path: "/home/user/.pdo/prices/models.yaml", fetched_path: "/home/user/.pdo/prices/fetched.json", source: null, fetched_at: null, fetched_rows: 0, manual_keys: [], reason: null },
       updated_at: "2026-07-01T10:00:00.000Z",
       ...overrides,
@@ -2160,6 +2166,8 @@ describe("NewRunModal — the target repo is required at the boundary (#470)", (
     default_auto_name: { effective: true, source: "default", stored: null, env: null, default: true },
       // #427: required on InstanceSettings; this modal does not read it.
       update_check: { effective: true, source: "default", stored: null, env: null, default: true },
+      manager_enabled: { effective: false, source: "default", stored: null, env: null, default: false },
+      manager_profile: { effective: null, source: "default", stored: null, env: null, default: null },
       price_table: { manual_path: "/home/user/.pdo/prices/models.yaml", fetched_path: "/home/user/.pdo/prices/fetched.json", source: null, fetched_at: null, fetched_rows: 0, manual_keys: [], reason: null },
       updated_at: "2026-07-01T10:00:00.000Z",
     });
@@ -2514,6 +2522,8 @@ describe("NewRunModal — harness selector (#551)", () => {
       autocomplete_turn_end: { effective: false, source: "default", stored: null, env: null, default: false },
       default_auto_name: { effective: true, source: "default", stored: null, env: null, default: true },
       update_check: { effective: true, source: "default", stored: null, env: null, default: true },
+      manager_enabled: { effective: false, source: "default", stored: null, env: null, default: false },
+      manager_profile: { effective: null, source: "default", stored: null, env: null, default: null },
       price_table: { manual_path: null, fetched_path: null, source: null, fetched_at: null, fetched_rows: 0, manual_keys: [], reason: null },
       updated_at: "2026-07-01T10:00:00.000Z",
       ...overrides,

--- a/frontend/src/components/PipelineInfoPanel.test.tsx
+++ b/frontend/src/components/PipelineInfoPanel.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { RunState, PipelineDef } from "../types";
 
@@ -7,7 +7,7 @@ import type { RunState, PipelineDef } from "../types";
 // children (network-fetching diff, tmux terminal) so the test stays focused on the
 // #410 sandbox surface and never touches the network.
 vi.mock("./DiffSection", () => ({ default: () => null }));
-vi.mock("./TmuxTerminal", () => ({ default: () => null }));
+vi.mock("./TmuxTerminal", () => ({ default: vi.fn(() => null) }));
 
 // #302 / ADR-0048: the Assistant tab drives create-if-absent / reap-on-leave
 // against the daemon. Mock those two api helpers so the tests can assert the
@@ -18,12 +18,16 @@ const {
   fetchPipelineDocument,
   fetchRunPipelineDocument,
   fetchPipelineSkillsSidecar,
+  startRunManager,
+  stopRunManager,
 } = vi.hoisted(() => ({
   openLibraryAssistant: vi.fn(),
   closeLibraryAssistant: vi.fn(),
   fetchPipelineDocument: vi.fn(),
   fetchRunPipelineDocument: vi.fn(),
   fetchPipelineSkillsSidecar: vi.fn(),
+  startRunManager: vi.fn(),
+  stopRunManager: vi.fn(),
 }));
 vi.mock("../api", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../api")>();
@@ -34,10 +38,13 @@ vi.mock("../api", async (importOriginal) => {
     fetchPipelineDocument,
     fetchRunPipelineDocument,
     fetchPipelineSkillsSidecar,
+    startRunManager,
+    stopRunManager,
   };
 });
 
 import PipelineInfoPanel from "./PipelineInfoPanel";
+import TmuxTerminal from "./TmuxTerminal";
 import type { TabId } from "./PipelineInfoPanel";
 
 function makeRun(overrides: Partial<RunState> = {}): RunState {
@@ -129,6 +136,148 @@ describe("PipelineInfoPanel — accessible names (#397)", () => {
     );
     await userEvent.click(screen.getByRole("button", { name: "Close pipeline info" }));
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});
+
+// Manager on demand: the Manager tab shows for EVERY live Run — an empty
+// state with a Start button when no session exists, the terminal when one
+// does — plus the transient starting state, the failure retry, and the
+// confirmed Stop.
+describe("PipelineInfoPanel — Manager tab (manager on demand)", () => {
+  beforeEach(() => {
+    startRunManager.mockReset();
+    stopRunManager.mockReset();
+    startRunManager.mockResolvedValue({ ok: true, session: "pdo-mgr-run-abc1234567", created: true });
+    stopRunManager.mockResolvedValue({ ok: true, stopped: true });
+  });
+
+  it("shows the empty state with a Start button for a managerless run (the new default)", () => {
+    renderPanel(makeRun());
+    const tab = screen.getByTestId("info-tab-manager");
+    expect(tab).toBeInTheDocument();
+    expect(screen.queryByTestId("manager-empty-state")).not.toBeInTheDocument();
+    fireEvent.click(tab);
+    expect(screen.getByTestId("manager-empty-state")).toBeInTheDocument();
+    expect(screen.getByTestId("manager-start")).toHaveTextContent("Start manager");
+    expect(screen.getByTestId("manager-enable-settings")).toBeInTheDocument();
+    expect(screen.queryByTestId("manager-live")).not.toBeInTheDocument();
+  });
+
+  it("shows the amber nudge dot only while the run waits on the user with no manager", () => {
+    const { rerender } = render(
+      <PipelineInfoPanel run={makeRun({ status: "awaiting_user" })} pipeline={null} onClose={() => {}} />,
+    );
+    expect(screen.getByTestId("manager-tab-dot")).toBeInTheDocument();
+
+    rerender(
+      <PipelineInfoPanel run={makeRun({ status: "running" })} pipeline={null} onClose={() => {}} />,
+    );
+    expect(screen.queryByTestId("manager-tab-dot")).not.toBeInTheDocument();
+  });
+
+  it("does not show the nudge dot once a manager is live", () => {
+    render(
+      <PipelineInfoPanel
+        run={makeRun({ status: "awaiting_user", has_manager: true })}
+        pipeline={null}
+        onClose={() => {}}
+      />,
+    );
+    expect(screen.queryByTestId("manager-tab-dot")).not.toBeInTheDocument();
+  });
+
+  it("mounts the terminal for a run whose manager exists, with a Stop control", () => {
+    vi.mocked(TmuxTerminal).mockImplementation(() => <div data-testid="terminal-stub" />);
+    renderPanel(makeRun({ has_manager: true }));
+    fireEvent.click(screen.getByTestId("info-tab-manager"));
+    expect(screen.getByTestId("manager-live")).toBeInTheDocument();
+    expect(screen.getByTestId("terminal-stub")).toBeInTheDocument();
+    expect(screen.getByTestId("manager-stop")).toBeInTheDocument();
+    expect(screen.queryByTestId("manager-empty-state")).not.toBeInTheDocument();
+  });
+
+  it("starts the manager from the empty state and refetches the run", async () => {
+    const onRefreshRun = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <PipelineInfoPanel run={makeRun()} pipeline={null} onClose={() => {}} onRefreshRun={onRefreshRun} />,
+    );
+    fireEvent.click(screen.getByTestId("info-tab-manager"));
+    await user.click(screen.getByTestId("manager-start"));
+
+    await waitFor(() => expect(startRunManager).toHaveBeenCalledWith("run-abc1234567"));
+    expect(onRefreshRun).toHaveBeenCalled();
+    // The transient state holds until the refreshed run state flips has_manager.
+    expect(screen.getByTestId("manager-starting")).toBeInTheDocument();
+  });
+
+  it("swaps to the live terminal once has_manager flips true", async () => {
+    vi.mocked(TmuxTerminal).mockImplementation(() => <div data-testid="terminal-stub" />);
+    const { rerender } = render(
+      <PipelineInfoPanel run={makeRun()} pipeline={null} onClose={() => {}} onRefreshRun={() => {}} />,
+    );
+    fireEvent.click(screen.getByTestId("info-tab-manager"));
+    fireEvent.click(screen.getByTestId("manager-start"));
+    await waitFor(() => expect(startRunManager).toHaveBeenCalled());
+    expect(screen.getByTestId("manager-starting")).toBeInTheDocument();
+
+    rerender(
+      <PipelineInfoPanel
+        run={makeRun({ has_manager: true })}
+        pipeline={null}
+        onClose={() => {}}
+        onRefreshRun={() => {}}
+      />,
+    );
+    expect(screen.getByTestId("manager-live")).toBeInTheDocument();
+    expect(screen.getByTestId("terminal-stub")).toBeInTheDocument();
+  });
+
+  it("renders the failure with a Retry when the start refuses", async () => {
+    startRunManager.mockRejectedValue(new Error("tmux server dead"));
+    const user = userEvent.setup();
+    renderPanel(makeRun());
+    fireEvent.click(screen.getByTestId("info-tab-manager"));
+    await user.click(screen.getByTestId("manager-start"));
+
+    expect(await screen.findByTestId("manager-start-error")).toHaveTextContent(
+      /failed to start the manager/i,
+    );
+    expect(screen.getByTestId("manager-retry")).toBeInTheDocument();
+  });
+
+  it("stops the manager only through the confirmation, then refetches", async () => {
+    vi.mocked(TmuxTerminal).mockImplementation(() => <div data-testid="terminal-stub" />);
+    const onRefreshRun = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <PipelineInfoPanel
+        run={makeRun({ has_manager: true })}
+        pipeline={null}
+        onClose={() => {}}
+        onRefreshRun={onRefreshRun}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("info-tab-manager"));
+
+    // One click only asks — it must not kill anything yet.
+    await user.click(screen.getByTestId("manager-stop"));
+    expect(stopRunManager).not.toHaveBeenCalled();
+
+    await user.click(screen.getByTestId("manager-stop-confirm"));
+    await waitFor(() => expect(stopRunManager).toHaveBeenCalledWith("run-abc1234567"));
+    expect(onRefreshRun).toHaveBeenCalled();
+  });
+
+  it("opens Settings from the empty state's enable-for-every-run link", async () => {
+    const onOpenSettings = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <PipelineInfoPanel run={makeRun()} pipeline={null} onClose={() => {}} onOpenSettings={onOpenSettings} />,
+    );
+    fireEvent.click(screen.getByTestId("info-tab-manager"));
+    await user.click(screen.getByTestId("manager-enable-settings"));
+    expect(onOpenSettings).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/frontend/src/components/PipelineInfoPanel.tsx
+++ b/frontend/src/components/PipelineInfoPanel.tsx
@@ -1,10 +1,10 @@
 import { useState, useMemo, useRef, useEffect } from "react";
-import { Info, Terminal, X, FileText, Code, Box, Loader, Bot, Copy, Download, ChevronDown, ChevronRight } from "lucide-react";
+import { Info, Terminal, X, FileText, Code, Box, Loader, Bot, Copy, Download, ChevronDown, ChevronRight, Play, PowerOff } from "lucide-react";
 import { SectionHead } from "./InspectorPrimitives";
 import TmuxTerminal from "./TmuxTerminal";
 import DiffSection from "./DiffSection";
 import type { LibraryPipelineEntry } from "../api";
-import { fetchPipelineDocument, fetchPipelineSkillsSidecar, fetchRunPipelineDocument, fetchRunPipelineSkillsSidecar, openLibraryAssistant } from "../api";
+import { fetchPipelineDocument, fetchPipelineSkillsSidecar, fetchRunPipelineDocument, fetchRunPipelineSkillsSidecar, openLibraryAssistant, startRunManager, stopRunManager } from "../api";
 import type { RunState, PipelineDef } from "../types";
 import { isLiveRun } from "../types";
 import { formatDuration, useRunDuration } from "../lib/runDuration";
@@ -53,6 +53,14 @@ interface Props {
    *  the assistant which template to work on (the daemon's focus does), and no
    *  longer owns its lifecycle (`useLibassistLifecycle`, mounted in `App`). */
   assistantId?: string | null;
+  /** Manager on demand: refetch the Run state after a start/stop, so
+   *  `has_manager` flips and the tab swaps its empty state for the terminal
+   *  (the WS push usually lands first; this is the belt to its braces). */
+  onRefreshRun?: () => void;
+  /** Manager on demand: the empty state's « enable it for every run in
+   *  Settings » link — the host opens the surface on Agents › Pipeline
+   *  Manager (the existing programmatic entry, #690 story 18). */
+  onOpenSettings?: () => void;
 }
 
 const STATUS_DOT: Record<string, string> = {
@@ -72,30 +80,42 @@ export default function PipelineInfoPanel({
   initialTab,
   scrollToLine,
   assistantId,
+  onRefreshRun,
+  onOpenSettings,
 }: Props) {
   const pipelineName = run?.pipeline_name ?? pipeline?.name ?? "Untitled";
   const variables = pipeline?.variables ?? {};
   const variableEntries = Object.entries(variables);
   const managerSession = run ? `pdo-mgr-${run.run_id}` : null;
 
-  const hasManager = !!managerSession;
+  // Manager on demand: the Manager tab shows for EVERY live Run — an empty
+  // state with a Start button when no session exists (the new default
+  // posture), the terminal when one does. It also stays for a
+  // completed/archived Run whose session survives until cleanup (post-mortem
+  // interrogation). Only a template (no Run at all) hides it — the Assistant
+  // tab covers templates instead (#302).
   // #302: the Assistant is the mirror of the Manager — it exists only for a
   // library *template* (no live Run) with a resolvable pipeline id. Manager and
   // Assistant are therefore never both shown.
   const hasAssistant = !run && !!assistantId;
   const [activeTab, setActiveTab] = useState<TabId>(initialTab ?? "info");
   const resolvedTab =
-    (activeTab === "manager" && !hasManager) ||
+    (activeTab === "manager" && !run) ||
     (activeTab === "assistant" && !hasAssistant)
       ? "info"
       : activeTab;
 
   const tabs: { id: TabId; label: string; icon: typeof Info; show: boolean }[] = [
     { id: "info", label: "Info", icon: FileText, show: true },
-    { id: "manager", label: "Manager", icon: Terminal, show: hasManager },
+    { id: "manager", label: "Manager", icon: Terminal, show: run != null },
     { id: "assistant", label: "Assistant", icon: Bot, show: hasAssistant },
     { id: "yaml", label: "YAML", icon: Code, show: true },
   ];
+
+  // The quiet nudge (manager on demand): the exact moment a manager helps most
+  // is when the Run is parked on the user — an amber dot on the tab points it
+  // out without banners or auto-switching.
+  const nudgeManager = run?.status === "awaiting_user" && !(run.has_manager ?? false);
 
   return (
     <aside
@@ -138,6 +158,13 @@ export default function PipelineInfoPanel({
             >
               <t.icon size={12} />
               {t.label}
+              {t.id === "manager" && nudgeManager && (
+                <span
+                  className="h-1.5 w-1.5 rounded-full bg-st-await"
+                  aria-hidden
+                  data-testid="manager-tab-dot"
+                />
+              )}
             </button>
           ))}
       </div>
@@ -152,29 +179,14 @@ export default function PipelineInfoPanel({
         />
       )}
 
-      {resolvedTab === "manager" && managerSession && run && (
-        <div
-          className="flex min-h-0 flex-1 flex-col"
-          style={{ fontSize: "11.5px" }}
-        >
-          <div className="flex items-center gap-2 border-b border-line px-3 py-2">
-            <Terminal size={14} className="text-fg-3" />
-            <span className="text-fg-2" style={{ fontSize: "11px" }}>
-              Pipeline Manager
-            </span>
-            <span
-              className="font-mono text-fg-4"
-              style={{ fontSize: "10px" }}
-            >
-              {managerSession}
-            </span>
-          </div>
-          <TmuxTerminal
-            session={managerSession}
-            expanded
-            status={run.status}
-          />
-        </div>
+      {resolvedTab === "manager" && run && managerSession && (
+        <ManagerTab
+          key={run.run_id}
+          run={run}
+          session={managerSession}
+          onRefreshRun={onRefreshRun}
+          onOpenSettings={onOpenSettings}
+        />
       )}
 
       {resolvedTab === "assistant" && hasAssistant && assistantId && (
@@ -193,6 +205,223 @@ export default function PipelineInfoPanel({
         />
       )}
     </aside>
+  );
+}
+
+/**
+ * The Manager tab body (manager on demand): the Run's Pipeline Manager, started
+ * only when the user asks for it. Four states, keyed on the OBSERVED
+ * `run.has_manager` fact the daemon probes in tmux at fetch time — never on a
+ * constructed session name (the pre-change code would happily mount a terminal
+ * for a session that did not exist):
+ *
+ * - **empty** — the new default posture: a centered card explaining what the
+ *   manager would do and what it costs, a Start button, and a link to flip the
+ *   per-Run default in Settings;
+ * - **starting** — the POST round-trip plus the gap until the next run-state
+ *   fetch flips `has_manager` (the same beat the Assistant tab has);
+ * - **error** — a failed spawn, with a Retry, mirroring `AssistantTab`;
+ * - **live** — today's terminal, unchanged, plus a Stop control with a
+ *   confirmation: cost control is the point of the feature, so the session
+ *   must be killable from the panel, not only by the orphan sweep.
+ *
+ * The tab (and its Run) can be left and revisited freely: nothing here stops
+ * the session — the manager outlives Run completion for post-mortem questions.
+ */
+function ManagerTab({
+  run,
+  session,
+  onRefreshRun,
+  onOpenSettings,
+}: {
+  run: RunState;
+  session: string;
+  onRefreshRun?: () => void;
+  onOpenSettings?: () => void;
+}) {
+  const hasManager = run.has_manager ?? false;
+  const [starting, setStarting] = useState(false);
+  const [stopping, setStopping] = useState(false);
+  const [confirmingStop, setConfirmingStop] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const start = async () => {
+    setError(null);
+    setStarting(true);
+    try {
+      // Idempotent on the daemon (a double-click is a benign re-answer). The
+      // "starting" state holds until the refreshed run state flips
+      // `has_manager` — the terminal mounts then, not here.
+      await startRunManager(run.run_id);
+      onRefreshRun?.();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      setStarting(false);
+    }
+  };
+
+  const stop = async () => {
+    setStopping(true);
+    try {
+      await stopRunManager(run.run_id);
+      onRefreshRun?.();
+      setConfirmingStop(false);
+      // Done with the transient state: once the refreshed run state lands, the
+      // empty state — not a stale "starting…" — must be what the tab shows.
+      setStarting(false);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setStopping(false);
+    }
+  };
+
+  if (hasManager) {
+    return (
+      <div
+        className="flex min-h-0 flex-1 flex-col"
+        style={{ fontSize: "11.5px" }}
+        data-testid="manager-live"
+      >
+        <div className="flex items-center gap-2 border-b border-line px-3 py-2">
+          <Terminal size={14} className="shrink-0 text-fg-3" />
+          <div className="flex min-w-0 flex-1 flex-col">
+            <span className="text-fg-2" style={{ fontSize: "11px" }}>
+              Pipeline Manager
+            </span>
+            <span
+              className="truncate font-mono text-fg-4"
+              style={{ fontSize: "10px" }}
+            >
+              {session}
+            </span>
+          </div>
+          {confirmingStop ? (
+            <span className="flex shrink-0 items-center gap-1.5">
+              <span className="text-fg-3" style={{ fontSize: "10.5px" }}>
+                Stop the manager?
+              </span>
+              <button
+                onClick={() => void stop()}
+                disabled={stopping}
+                className="rounded border border-st-failed/40 bg-st-failed-bg px-2 py-0.5 text-st-failed transition-colors hover:border-st-failed disabled:opacity-40"
+                style={{ fontSize: "10.5px" }}
+                data-testid="manager-stop-confirm"
+              >
+                {stopping ? "Stopping…" : "Stop"}
+              </button>
+              <button
+                onClick={() => setConfirmingStop(false)}
+                className="rounded border border-line-strong bg-bg-3 px-2 py-0.5 text-fg-3 transition-colors hover:text-fg-2"
+                style={{ fontSize: "10.5px" }}
+                data-testid="manager-stop-cancel"
+              >
+                Cancel
+              </button>
+            </span>
+          ) : (
+            <button
+              onClick={() => setConfirmingStop(true)}
+              className="flex shrink-0 items-center gap-1 rounded border border-line-strong bg-bg-3 px-2 py-1 text-fg-3 transition-colors hover:border-st-failed hover:text-st-failed"
+              style={{ fontSize: "10.5px" }}
+              data-testid="manager-stop"
+              title="Stop the manager session (survives until cleanup otherwise)"
+            >
+              <PowerOff size={11} />
+              Stop
+            </button>
+          )}
+        </div>
+        {error && (
+          <div
+            className="border-b border-st-failed/30 bg-st-failed-bg px-3 py-1.5 text-st-failed"
+            style={{ fontSize: "10.5px" }}
+            role="alert"
+            data-testid="manager-error"
+          >
+            {error}
+          </div>
+        )}
+        <TmuxTerminal session={session} expanded status={run.status} />
+      </div>
+    );
+  }
+
+  if (starting) {
+    return (
+      <div
+        className="flex flex-1 flex-col items-center justify-center gap-3 text-fg-4"
+        style={{ fontSize: "11.5px" }}
+        data-testid="manager-starting"
+      >
+        <Loader size={18} className="animate-spin text-acc" />
+        Starting the manager…
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div
+        className="flex flex-1 flex-col items-center justify-center gap-3 px-6 text-center"
+        style={{ fontSize: "11.5px" }}
+        data-testid="manager-start-error"
+      >
+        <div className="text-st-failed" role="alert">
+          Failed to start the manager: {error}
+        </div>
+        <button
+          onClick={() => void start()}
+          className="rounded-md bg-acc px-3 py-1.5 font-medium text-[#04140d] transition-colors hover:bg-acc-dim"
+          style={{ fontSize: "11.5px" }}
+          data-testid="manager-retry"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="flex flex-1 flex-col items-center justify-center gap-3 px-8 text-center"
+      style={{ fontSize: "11.5px" }}
+      data-testid="manager-empty-state"
+    >
+      <div className="grid h-11 w-11 place-items-center rounded-lg bg-bg-3 text-fg-3">
+        <Terminal size={18} />
+      </div>
+      <div className="font-medium text-fg" style={{ fontSize: "13px" }}>
+        No manager on this run
+      </div>
+      <p
+        className="max-w-[260px] text-fg-3"
+        style={{ fontSize: "11.5px", lineHeight: 1.55 }}
+      >
+        The manager is a conversational agent that can drive this run — retry
+        nodes, resolve merges, unblock it when it waits on you. It is off by
+        default to keep costs down.
+      </p>
+      <button
+        onClick={() => void start()}
+        className="mt-1 flex items-center gap-1.5 rounded-md bg-acc px-3.5 py-2 font-medium text-[#04140d] transition-colors hover:bg-acc-dim"
+        style={{ fontSize: "12px" }}
+        data-testid="manager-start"
+      >
+        <Play size={12} />
+        Start manager
+      </button>
+      <div className="text-fg-4" style={{ fontSize: "10.5px" }}>
+        or{" "}
+        <button
+          onClick={() => onOpenSettings?.()}
+          className="cursor-pointer text-fg-3 underline decoration-fg-5 underline-offset-2 transition-colors hover:text-fg"
+          data-testid="manager-enable-settings"
+        >
+          enable it for every run in Settings
+        </button>
+      </div>
+    </div>
   );
 }
 

--- a/frontend/src/components/SettingsSurface.test.tsx
+++ b/frontend/src/components/SettingsSurface.test.tsx
@@ -129,6 +129,9 @@ function sample(overrides: Partial<InstanceSettings> = {}): InstanceSettings {
       env: null,
       default: true,
     },
+    // Manager on demand: off by default (a Run starts managerless), no pin (« Follow the Run »).
+    manager_enabled: { effective: false, source: "default", stored: null, env: null, default: false },
+    manager_profile: { effective: null, source: "default", stored: null, env: null, default: null },
     // Price table (#427): the default state of every instance — neither file exists,
     // never synced, nothing inert. The paths are reported all the same.
     update_check: { effective: true, source: "default", stored: null, env: null, default: true },
@@ -958,6 +961,106 @@ describe("SettingsSurface — default Run auto-naming (#338)", () => {
     expect(note).toHaveTextContent(/stored value \(off\)/i);
     expect(note).toHaveTextContent("PDO_DEFAULT_AUTO_NAME=on");
     expect(note).toHaveTextContent(/overridden/i);
+  });
+});
+
+describe("SettingsSurface — Pipeline Manager section (manager on demand)", () => {
+  beforeEach(() => {
+    fetchSettingsMock.mockReset();
+    updateSettingsMock.mockReset();
+    browseFsMock.mockReset();
+    browseFsMock.mockResolvedValue(BROWSE_HOME);
+    resetProfileMocks();
+    fetchAgentProfilesMock.mockReset();
+    fetchAgentProfilesMock.mockResolvedValue({
+      profiles: [
+        { id: "default", name: "Default", harness: "claude", model: null, effort: null },
+        { id: "p-easy", name: "claude very easy", harness: "claude", model: "sonnet", effort: "low" },
+      ],
+    });
+  });
+
+  it("renders the toggle (off by default) and the profile select seeded on « Follow the Run »", async () => {
+    fetchSettingsMock.mockResolvedValue(sample());
+    render(<SettingsSurface open onClose={() => {}} />);
+    fireEvent.click(screen.getByTestId("settings-category-agents"));
+    const box = (await screen.findByTestId("setting-manager-enabled")) as HTMLInputElement;
+    expect(box.checked).toBe(false);
+    const select = screen.getByTestId("setting-manager-profile") as HTMLSelectElement;
+    expect(select.value).toBe("");
+    // The profile options arrive with the async profiles fetch.
+    await waitFor(() =>
+      expect(
+        within(select).getAllByRole("option").map((o) => o.textContent),
+      ).toContain("claude very easy"),
+    );
+    const options = within(select).getAllByRole("option").map((o) => o.textContent);
+    expect(options).toContain("Follow the Run");
+  });
+
+  it("shows the tombstone and a warning for a stored pin whose profile is gone — never a rewrite", async () => {
+    fetchSettingsMock.mockResolvedValue(
+      sample({
+        manager_profile: { effective: "gone", source: "stored", stored: "gone", env: null, default: null },
+      }),
+    );
+    render(<SettingsSurface open onClose={() => {}} />);
+    const select = (await screen.findByTestId("setting-manager-profile")) as HTMLSelectElement;
+    expect(select.value).toBe("gone");
+    expect(screen.getByTestId("setting-manager-profile-missing")).toBeInTheDocument();
+    expect(screen.getByTestId("setting-manager-profile-missing-note")).toHaveTextContent(
+      /falls back to « Follow the Run »/i,
+    );
+  });
+
+  it("saves the flag as a plain bool and the pin as a profile name; Save stays clean otherwise", async () => {
+    fetchSettingsMock.mockResolvedValue(sample());
+    updateSettingsMock.mockResolvedValue(sample());
+    render(<SettingsSurface open onClose={() => {}} />);
+    fireEvent.click(screen.getByTestId("settings-category-agents"));
+
+    fireEvent.click(await screen.findByTestId("setting-manager-enabled"));
+    // Wait for the profiles fetch so the option exists before the change.
+    await screen.findByTestId("settings-section-body-pipeline-manager");
+    await waitFor(() =>
+      expect(screen.getByTestId("setting-manager-profile").textContent).toContain("Follow the Run"),
+    );
+    await waitFor(() => {
+      const select = screen.getByTestId("setting-manager-profile");
+      expect([...select.querySelectorAll("option")].some((o) => o.value === "claude very easy")).toBe(true);
+    });
+    fireEvent.change(screen.getByTestId("setting-manager-profile"), {
+      target: { value: "claude very easy" },
+    });
+    fireEvent.click(screen.getByTestId("settings-save"));
+
+    await waitFor(() => expect(updateSettingsMock).toHaveBeenCalledTimes(1));
+    expect(updateSettingsMock).toHaveBeenCalledWith({
+      manager_enabled: true,
+      manager_profile: "claude very easy",
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId("settings-footer-status")).toHaveTextContent("Saved"),
+    );
+  });
+
+  it("clears the pin with the empty-string sentinel when back on « Follow the Run »", async () => {
+    fetchSettingsMock.mockResolvedValue(
+      sample({
+        manager_profile: { effective: "claude very easy", source: "stored", stored: "claude very easy", env: null, default: null },
+      }),
+    );
+    updateSettingsMock.mockResolvedValue(sample());
+    render(<SettingsSurface open onClose={() => {}} />);
+    fireEvent.click(screen.getByTestId("settings-category-agents"));
+
+    fireEvent.change(await screen.findByTestId("setting-manager-profile"), {
+      target: { value: "" },
+    });
+    fireEvent.click(screen.getByTestId("settings-save"));
+
+    await waitFor(() => expect(updateSettingsMock).toHaveBeenCalledTimes(1));
+    expect(updateSettingsMock).toHaveBeenCalledWith({ manager_profile: "" });
   });
 });
 
@@ -1877,12 +1980,17 @@ describe("SettingsSurface — Agents and Sandbox & worktrees as inline sections 
       .map((b) => b.textContent?.replace("Unsaved changes", "").trim() ?? "");
   }
 
-  it("Agents lists Harness & models, Agent profiles, Skills and mounts the profiles panel inline", async () => {
+  it("Agents lists Harness & models, Agent profiles, Pipeline Manager, Skills and mounts the profiles panel inline", async () => {
     render(<SettingsSurface open onClose={() => {}} />);
     await screen.findByTestId("setting-session-cap");
     fireEvent.click(screen.getByTestId("settings-category-agents"));
     const page = screen.getByTestId("settings-page-agents");
-    expect(sectionLabels(page)).toEqual(["Harness & models", "Agent profiles", "Skills"]);
+    expect(sectionLabels(page)).toEqual([
+      "Harness & models",
+      "Agent profiles",
+      "Pipeline Manager",
+      "Skills",
+    ]);
 
     // The instance form fields sit in Harness & models.
     const harness = screen.getByTestId("settings-section-body-harness-models");

--- a/frontend/src/components/SettingsSurface.tsx
+++ b/frontend/src/components/SettingsSurface.tsx
@@ -112,6 +112,8 @@ interface DraftValues {
   defaultSandbox: string;
   autocompleteTurnEnd: boolean;
   defaultAutoName: boolean;
+  managerEnabled: boolean;
+  managerProfile: string;
 }
 
 function seedFrom(settings: InstanceSettings): DraftValues {
@@ -127,6 +129,9 @@ function seedFrom(settings: InstanceSettings): DraftValues {
     defaultSandbox: settings.default_sandbox.effective ?? "off",
     autocompleteTurnEnd: settings.autocomplete_turn_end.effective,
     defaultAutoName: settings.default_auto_name.effective,
+    managerEnabled: settings.manager_enabled.effective,
+    // "" = « Follow the Run » (the clear sentinel on the wire too).
+    managerProfile: settings.manager_profile.stored ?? "",
   };
 }
 
@@ -187,6 +192,10 @@ function computeDirty(values: DraftValues, settings: InstanceSettings): Set<Sett
     dirty.add("harness-models");
   }
   if (values.defaultSandbox !== settings.default_sandbox.effective) dirty.add("default-sandbox");
+  if (values.managerEnabled !== settings.manager_enabled.effective) dirty.add("manager-enabled");
+  if (values.managerProfile !== (settings.manager_profile.stored ?? "")) {
+    dirty.add("manager-profile");
+  }
   return dirty;
 }
 
@@ -294,6 +303,15 @@ export default function SettingsSurface({
     values.defaultSandbox !== "" &&
     !settings.sandbox_profiles.some((p) => p.name === values.defaultSandbox);
 
+  // Manager on demand (#432 tombstone): a stored pin whose profile no longer
+  // exists (deleted or renamed) is never silently rewritten — the select keeps
+  // the stored value under a « missing » option and a warning names the
+  // fallback the spawn will take.
+  const missingManagerProfile =
+    !!values &&
+    values.managerProfile !== "" &&
+    !agentProfiles.some((profile) => profile.name === values.managerProfile);
+
   /** Validate and build the PUT payload from the draft. `null` + error when invalid. */
   const buildPatch = (): { patch: UpdateSettingsRequest } | { error: string } => {
     if (!values || !settings) return { patch: {} };
@@ -364,6 +382,15 @@ export default function SettingsSurface({
     }
     if (values.defaultAutoName !== settings.default_auto_name.effective) {
       patch.default_auto_name = values.defaultAutoName;
+    }
+    // Manager on demand: the flag is a plain bool (`false` persists as a stored
+    // `0`); the pin is a profile NAME with `""` as the clear sentinel (« Follow
+    // the Run »).
+    if (values.managerEnabled !== settings.manager_enabled.effective) {
+      patch.manager_enabled = values.managerEnabled;
+    }
+    if (values.managerProfile !== (settings.manager_profile.stored ?? "")) {
+      patch.manager_profile = values.managerProfile.trim();
     }
     return { patch };
   };
@@ -646,7 +673,9 @@ export default function SettingsSurface({
                             gives it a short descriptive name. Turn this off and such a Run
                             keeps a stable <span className="font-mono">Untitled run …</span>{" "}
                             placeholder instead. This is only the <strong>default</strong>: the
-                            New Run box and each Trigger can override it.
+                            New Run box and each Trigger can override it. Naming is the
+                            manager's job, so a managerless Run stays unnamed until its first
+                            manager start (which passes the same instruction).
                           </>
                         }
                         source={defaultAutoNameSourceNote(settings.default_auto_name)}
@@ -799,6 +828,90 @@ export default function SettingsSurface({
                   />
                 </Section>
                 <Section section={item.sections[2]}>
+                  {/* Manager on demand: the auto-start flag (off by default — a
+                      Run starts managerless) and the profile pin, both part of
+                      the instance form (Save). A manual start from the Manager
+                      tab is ALWAYS available — the flag is a default, not a
+                      permission. */}
+                  <CheckboxRow
+                    id="manager-enabled"
+                    checked={values.managerEnabled}
+                    onChange={(v) => setField("managerEnabled", v)}
+                    dirty={rollup.fields.has("manager-enabled")}
+                    label="Start the manager with each Run"
+                    help={
+                      <>
+                        When on, every Run launch spawns its{" "}
+                        <span className="font-mono">pdo-mgr-…</span> session — the
+                        pre-change behaviour. When off (the new default), the Run
+                        starts managerless and you start one from the Manager tab
+                        when you want it. This is only the <strong>default</strong>: a
+                        manual start is never blocked.
+                      </>
+                    }
+                    source={managerEnabledSourceNote(settings.manager_enabled)}
+                  />
+                  {/* The pin. Stored as a profile NAME: a stored name whose
+                      profile was later deleted (or renamed) gets the #432
+                      tombstone treatment — a « missing » option and a warning,
+                      never a silent rewrite. The spawn itself falls back to
+                      « Follow the Run ». */}
+                  <FieldBlock
+                    label="Manager profile"
+                    htmlFor="setting-manager-profile"
+                    dirty={rollup.fields.has("manager-profile")}
+                    help={
+                      <>
+                        Which agent preset the manager runs as. « Follow the Run »
+                        keeps today's rule — the manager mirrors the Run's harness
+                        and lands on the default profile for model and effort. A
+                        named profile <strong>pins</strong> the manager to that
+                        harness · model · effort, whatever the Run chose (e.g. a
+                        cheaper model, since a manager mostly talks). Picks from
+                        Settings › Agents › Agent profiles.
+                      </>
+                    }
+                    source={managerProfileSourceNote(settings.manager_profile)}
+                    sourceTestId="setting-source-manager-profile"
+                  >
+                    <select
+                      id="setting-manager-profile"
+                      data-testid="setting-manager-profile"
+                      value={values.managerProfile}
+                      onChange={(e) => setField("managerProfile", e.target.value)}
+                      className={`w-[280px] rounded-md border bg-bg-3 px-2.5 py-1.5 text-fg transition-colors focus:border-acc focus:outline-none ${
+                        rollup.fields.has("manager-profile") ? "border-st-await" : "border-line-strong"
+                      }`}
+                      style={{ fontSize: "12px" }}
+                    >
+                      {/* "" = unset = « Follow the Run » — today's rule, unchanged. */}
+                      <option value="">Follow the Run</option>
+                      {agentProfiles.map((profile) => (
+                        <option key={profile.id} value={profile.name}>
+                          {profile.name}
+                        </option>
+                      ))}
+                      {/* Tombstone (#432): a stored name is NEVER silently rewritten. */}
+                      {missingManagerProfile && (
+                        <option value={values.managerProfile} data-testid="setting-manager-profile-missing">
+                          {values.managerProfile} — missing
+                        </option>
+                      )}
+                    </select>
+                    {missingManagerProfile && (
+                      <div
+                        className="text-st-await"
+                        style={{ fontSize: "10.5px" }}
+                        data-testid="setting-manager-profile-missing-note"
+                      >
+                        No agent profile named « {values.managerProfile} » any more. The manager
+                        falls back to « Follow the Run » until you pick another one (or clear
+                        this).
+                      </div>
+                    )}
+                  </FieldBlock>
+                </Section>
+                <Section section={item.sections[3]}>
                   {/* #669/ADR-0062: the instance tier of the skills selection — part of the
                       instance form (Save), unlike the bank below it. */}
                   <SkillSelector
@@ -2014,6 +2127,33 @@ function defaultAutoNameSourceNote(field: BoolSettingField): string {
     return `Source: env ${envDisplay ?? "PDO_DEFAULT_AUTO_NAME"}.`;
   }
   return `Source: built-in default (${onOff(field.default)}).`;
+}
+
+/** Which tier the manager auto-start flag comes from (manager on demand). A real
+ *  built-in default (`off`), and both directions of a save are a stored decision —
+ *  same shape as {@link defaultAutoNameSourceNote}. */
+function managerEnabledSourceNote(field: BoolSettingField): string {
+  const onOff = (v: boolean) => (v ? "on" : "off");
+  const envDisplay = field.env != null ? `PDO_MANAGER_ENABLED=${onOff(field.env)}` : null;
+  if (field.source === "stored") {
+    const base = `Source: stored value (${onOff(field.effective)}).`;
+    return envDisplay
+      ? `${base} Env ${envDisplay} is set but overridden.`
+      : `${base} Overrides env and default.`;
+  }
+  if (field.source === "env") {
+    return `Source: env ${envDisplay ?? "PDO_MANAGER_ENABLED"}.`;
+  }
+  return `Source: built-in default (${onOff(field.default)}) — runs start managerless.`;
+}
+
+/** Which tier the manager profile pin comes from (manager on demand). No env tier
+ *  and no stored default value: unset IS « Follow the Run ». */
+function managerProfileSourceNote(field: StringSettingField): string {
+  if (field.source === "stored" && field.stored) {
+    return `Source: stored value (pins the manager to « ${field.stored} »).`;
+  }
+  return "Source: unset — the manager follows the Run.";
 }
 
 /** Which tier the instance default_sandbox comes from (#410). Unlike `default_model` there

--- a/frontend/src/components/SettingsSurface.versionUpdate.test.tsx
+++ b/frontend/src/components/SettingsSurface.versionUpdate.test.tsx
@@ -66,6 +66,8 @@ function settings(): InstanceSettings {
     home: "/home/user",
     autocomplete_turn_end: { effective: false, source: "default", stored: null, env: null, default: false },
     default_auto_name: { effective: true, source: "default", stored: null, env: null, default: true },
+    manager_enabled: { effective: false, source: "default", stored: null, env: null, default: false },
+    manager_profile: { effective: null, source: "default", stored: null, env: null, default: null },
     update_check: { effective: true, source: "default", stored: null, env: null, default: true },
     price_table: {
       manual_path: "/home/user/.pdo/prices/models.yaml",

--- a/frontend/src/components/settingsCategories.ts
+++ b/frontend/src/components/settingsCategories.ts
@@ -14,6 +14,7 @@ export type SettingsSectionId =
   | "version-update"
   | "harness-models"
   | "agent-profiles"
+  | "pipeline-manager"
   | "skills"
   | "sandbox"
   | "staging-profiles"
@@ -89,6 +90,12 @@ export const SETTINGS_CATEGORIES: SettingsCategory[] = [
         ownPersistence: true,
       },
       {
+        id: "pipeline-manager",
+        label: "Pipeline Manager",
+        description:
+          "The conversational agent attached to each Run — off by default, started on demand from the Manager tab.",
+      },
+      {
         id: "skills",
         label: "Skills",
         description:
@@ -161,7 +168,9 @@ export type SettingsFieldId =
   | "default-harness"
   | "harness-models"
   | "default-sandbox"
-  | "update-check";
+  | "update-check"
+  | "manager-enabled"
+  | "manager-profile";
 
 export const FIELD_SECTION: Record<SettingsFieldId, SettingsSectionId> = {
   "session-cap": "runtime-limits",
@@ -176,6 +185,8 @@ export const FIELD_SECTION: Record<SettingsFieldId, SettingsSectionId> = {
   "harness-models": "harness-models",
   "default-sandbox": "sandbox",
   "update-check": "version-update",
+  "manager-enabled": "pipeline-manager",
+  "manager-profile": "pipeline-manager",
 };
 
 export function categoryOf(section: SettingsSectionId): SettingsCategory {

--- a/frontend/src/lib/newRunForm.test.ts
+++ b/frontend/src/lib/newRunForm.test.ts
@@ -47,6 +47,8 @@ function settings(over: Partial<InstanceSettings> = {}): InstanceSettings {
     home: "/home/user",
     autocomplete_turn_end: { effective: false, source: "default", stored: null, env: null, default: false },
     default_auto_name: { effective: true, source: "default", stored: null, env: null, default: true },
+    manager_enabled: { effective: false, source: "default", stored: null, env: null, default: false },
+    manager_profile: { effective: null, source: "default", stored: null, env: null, default: null },
     update_check: { effective: true, source: "default", stored: null, env: null, default: true },
     price_table: { manual_path: null, fetched_path: null, source: null, fetched_at: null, fetched_rows: 0, manual_keys: [], reason: null },
     updated_at: "2026-07-01T10:00:00.000Z",

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -317,6 +317,22 @@ export interface InstanceSettings {
    */
   update_check: BoolSettingField;
   /**
+   * Manager on demand: does every new Run automatically spawn its Pipeline
+   * Manager session? **Off by default** — a Run starts managerless and the user
+   * starts one from the Manager tab when they want it. Gates ONLY the automatic
+   * spawn: a manual start from the Manager tab is always available. Stored
+   * `0`/`1` discipline like the other plain-bool knobs.
+   */
+  manager_enabled: BoolSettingField;
+  /**
+   * Manager on demand: the agent-profile NAME the manager is pinned to, or
+   * `null` (« Follow the Run » — the manager mirrors the Run's harness · model
+   * · effort). A named profile overrides the Run tier. A stored name whose
+   * profile was later deleted dangles: the Settings surface renders the #432
+   * tombstone, and the spawn falls back to « Follow the Run ».
+   */
+  manager_profile: StringSettingField;
+  /**
    * Which price tiers are in force (#427, ADR-0034) — an observed STATE, not a
    * settings knob, hence no `{effective, source, stored, env, default}` shape.
    *
@@ -475,6 +491,15 @@ export interface UpdateSettingsRequest {
   /** Version check switch (#697). Same plain-bool discipline: `false` persists as a
    *  stored `0` that beats a `PDO_UPDATE_CHECK=1`. */
   update_check?: boolean;
+  /** Manager on demand: auto-spawn the manager with each Run. Same plain-bool
+   *  discipline: `false` persists as a stored `0` that beats a
+   *  `PDO_MANAGER_ENABLED=1`. */
+  manager_enabled?: boolean;
+  /** Manager on demand: the agent-profile NAME the manager is pinned to; `""`
+   *  clears it back to « Follow the Run » (same `""`-sentinel as
+   *  `default_model`). The daemon 400s a name that does not match an existing
+   *  profile. */
+  manager_profile?: string;
 }
 
 /** How the running binary was installed (#697) — what a future Update delegates to. */
@@ -1072,6 +1097,13 @@ export interface RunState {
    * on older payloads.
    */
   sessions_spawned?: number;
+  /**
+   * Manager on demand: whether the Run's Pipeline Manager session exists RIGHT
+   * NOW — an observed fact probed in tmux at fetch time, never a projected one
+   * (a manual stop, the orphan sweep or a daemon restart would desynchronise a
+   * derived flag). Absent on older payloads, read as `false`.
+   */
+  has_manager?: boolean;
   /**
    * Lines changed for the run (`git diff --numstat` of the run branch, `.pdo/`
    * excluded), or null/absent once the branch is gone (archived/cleaned) — the


### PR DESCRIPTION
## Résumé

Le manager de pipeline n'est plus spawné systématiquement : il devient **opt-in**, lançable à la demande depuis l'UI, avec un profil d'agent dédié épinglable.

### Daemon (`crates/pdo-daemon`)
- **Nouveaux réglages d'instance** (machinerie stored → env → default, ADR-0015) :
  - `manager_enabled` — opt-in de l'auto-spawn à la création d'un run (default `false`, seam `PDO_MANAGER_ENABLED`) ;
  - `manager_profile` — épingle le manager sur un profil d'agent (harnais · modèle · effort, écrasant le tier du run) ; repli averti « Follow the Run » si le profil nommé a disparu (traitement tombstone #432), valeur stockée jamais réécrite ; un PUT nommant un profil inconnu est un 400.
- **Endpoints** : `POST /runs/{id}/manager/start` (idempotent, 404/409 lisibles) et `POST /runs/{id}/manager/stop` (session déjà morte = 200 calme).
- **`has_manager` est un fait observé** : sonde `tmux has-session` à chaque `GET /runs/{id}` — aucun risque de désynchronisation avec l'état projeté.
- **Réservation du nom** : events `ManagerStarted` / `ManagerStopped` (ADR-0038) émis avant le spawn tmux sur tous les chemins.

### Frontend (`frontend/`)
- **Onglet Manager sur tout run vivant**, quatre états : vide (pitch + « Start manager »), démarrage (spinner), vivant (terminal + Stop à confirmation), erreur (Retry). Lien programmatique vers Settings › Agents › Pipeline Manager.
- **Section Settings « Pipeline Manager »** : toggle + select de profil avec « Follow the Run », tombstone (« \<nom\> — missing ») + avertissement, disclosures de source.
- **Point ambré** sur l'onglet quand le run est `awaiting_user` sans manager.

### Release
- `chore(release): 1.69.0` — Cargo.toml / Cargo.lock / CHANGELOG.md.

## QA

Les 9 Feature Paths agéntiques (surface-first, navigateur réel) sont **verts**, y compris FP-7 (le pin de profil est appliqué au spawn — vérifié sur `/proc/<pid>/cmdline`, les deux chemins manuel et auto) — voir le rapport QA de la run.

## Notes

- Fix au passage : `frontend/package.json` déclare `@types/hast` (échec `tsc -b` sur pnpm install frais, pré-existant).