### PR TITLE
feat(#723): toggle « Orchestrator » + onglet Orchestration + pastilles — 1.70.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,25 @@ ascendante** : la casse se signale ici et par un bump majeur, jamais en gardant 
 morts. Seule contrainte non négociable — les **données historiques restent lisibles** : un Run
 archivé s'ouvre et se chiffre quelle que soit la version qui a écrit son payload.
 
+## 1.70.0
+
+**Toggle « Orchestrator » + onglet Orchestration + pastilles** (#723 ; story #709, spec #719,
+ADR-0064). Un nœud agent gagne un toggle « Orchestrator » dans son détail d'édition (sous
+« Interactive », gelé au spawn, immuable pendant le run — ADR-0007) qui fait quatre choses : il
+pose la référence du skill `pdo-orchestrate` sur le nœud (visible dans le sélecteur, comptée dans
+le diff sémantique, retirable avec l'avertissement « skill absent » existant) ; il fait
+amender le prompt du NodeRun au spawn d'une ligne d'invocation `/pdo-orchestrate` et du bloc
+de contrat Orchestration — rendus après le prompt de rôle, jamais dans la textarea (toggle et
+texte ne peuvent pas diverger), toggle off étant byte-identique au pré-#723 ; le préambule
+runtime documente `pdo run create` au titre des capacités CLI (universel, pré-#723). En run, le
+panneau de détail du nœud orchestrator se coupe en deux onglets « I/O » (défaut, contenu
+inchangé) et « Orchestration » : la liste des enfants du nœud via `GET /runs/{id}/children`
+(statut, démarré, durée qui tique, coût), un clic sur le titre ouvrant le run enfant avec barre
+« ← Back to Orchestrator » qui revient au parent sur l'onglet Orchestration, et des pastilles
+vert/rouge/bleu avec compteurs (finis/échoués/en cours — un enfant `awaiting_user` compte en
+bleu) en en-tête d'onglet et sur la carte dans le canvas, masquées tant qu'il n'y a aucun enfant.
+Les nœuds sans toggle restent strictement identiques.
+
 ## 1.69.0
 
 **Le Pipeline Manager devient opt-in** — plus de session `pdo-mgr-*` systématique : un run naît

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "1.69.0"
+version = "1.70.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "1.69.0"
+version = "1.70.0"
 license = "MIT"
 description = "Prompt-Driven Orchestrator — a local daemon that runs and supervises agentic coding pipelines"
 repository = "https://github.com/Loulen/prompt-driven-orchestrator"

--- a/crates/pdo-daemon/src/prompt_augmenter.rs
+++ b/crates/pdo-daemon/src/prompt_augmenter.rs
@@ -855,7 +855,26 @@ pub(crate) fn build_preamble(ctx: &AugmentContext<'_>) -> String {
 
 pub(crate) fn build_full_prompt(ctx: &AugmentContext<'_>, role_prompt: &str) -> String {
     let preamble = build_preamble(ctx);
-    format!("{preamble}---\n\n{role_prompt}")
+    if ctx.node.orchestrator {
+        format!("{preamble}---\n\n{role_prompt}{}", orchestrator_amendment())
+    } else {
+        format!("{preamble}---\n\n{role_prompt}")
+    }
+}
+
+/// The fixed « Orchestration » amendment (#723, ADR-0064) appended AFTER the
+/// role prompt of a node whose `orchestrator` toggle is on. The invocation line
+/// plus the contract block: PDO files it at spawn — rendered to the session,
+/// never editable, never present in the author's prompt textarea — so the
+/// toggle and the text cannot drift. Mirrors the block the UI shows attached
+/// under the prompt textarea (NodeInspector) byte for byte.
+fn orchestrator_amendment() -> String {
+    "\n\n---\n\n/pdo-orchestrate\n\
+     \n\
+     ## Orchestration\n\
+     You may create child runs with `pdo run create`. This node completes\n\
+     only once every child run is terminal; a failed child parks it awaiting you.\n"
+        .to_string()
 }
 
 /// Middle tier of `stored → env → default(true)`; resolved by
@@ -1912,6 +1931,36 @@ mod tests {
         assert!(full.contains("# PDO Runtime Preamble"));
         assert!(full.contains("You are a planner. Plan well."));
         assert!(full.contains("---"));
+    }
+
+    #[test]
+    fn orchestrator_prompt_carries_the_amendment_after_the_role() {
+        // #723 / ADR-0064: the toggle on ⇒ the invocation line + the contract
+        // block are filed AFTER the role prompt, at spawn — never in the
+        // author's textarea. Toggle off ⇒ byte-identical to the pre-#723
+        // prompt.
+        let mut pipeline = sample_pipeline();
+        pipeline.nodes[0].orchestrator = true;
+        let node = &pipeline.nodes[0];
+        let vars = HashMap::new();
+        let ctx = sample_ctx(&pipeline, node, &vars);
+
+        let full = build_full_prompt(&ctx, "You are a planner. Plan well.");
+        let after_role = full
+            .split("You are a planner. Plan well.")
+            .nth(1)
+            .expect("role prompt present");
+        assert!(after_role.contains("/pdo-orchestrate"));
+        assert!(after_role.contains("## Orchestration"));
+        assert!(after_role.contains("pdo run create"));
+        assert!(after_role.contains("a failed child parks it awaiting you"));
+        // The role prompt itself is untouched by the amendment.
+        assert!(!full.starts_with("/pdo-orchestrate"));
+
+        let plain_pipeline = sample_pipeline();
+        let plain = sample_ctx(&plain_pipeline, &plain_pipeline.nodes[0], &vars);
+        let bare = build_full_prompt(&plain, "You are a worker. Work.");
+        assert!(!bare.contains("/pdo-orchestrate"), "a node without the toggle keeps its pre-#723 prompt");
     }
 
     #[test]

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useReducer, useRef, useState } from "react";
-import { Settings, BarChart3 } from "lucide-react";
+import { ArrowLeft, GitFork, Settings, BarChart3 } from "lucide-react";
 import { useDaemonSocket } from "./hooks/useDaemonSocket";
 import type { ConnectionStatus } from "./hooks/useDaemonSocket";
 import { useResizableLayout } from "./hooks/useResizableLayout";
@@ -493,6 +493,9 @@ export default function App() {
           provisioningRepository={selectedRun.target_repo ?? ""}
           inheritedProvisioning={selectedRun.provisioning_rules}
           provisioningGitRef={`pdo/run-${selectedRun.run_id}`}
+          isOrchestratorNode={selectedRun.node_defs?.find((d) => d.id === selection.id)?.orchestrator ?? false}
+          onOpenChildRun={handleOpenChildRun}
+          initialDetailTab={landOnOrchestration === runNode.node_id ? "orchestration" : "io"}
         />
       );
     }
@@ -588,15 +591,36 @@ export default function App() {
     setSelection({ kind: "node", id: nodeId });
   }, [selectedRun, selection.kind, selection.id, setSelection]);
 
+  // #723 — the way back from a child run opened in an Orchestration tab: parent
+  // run + orchestrator node. Declared before `handleSelectRun`, which clears
+  // both on any navigation — the bar's visibility is derived (child run
+  // selected), so no effect ever needs to reconcile them.
+  const [orchestratorReturn, setOrchestratorReturn] = useState<{
+    parentRunId: string;
+    parentRunName: string;
+    nodeId: string;
+    nodeName: string;
+    childRunId: string;
+  } | null>(null);
+  // One-shot landing: set by the back gesture, consumed by the remount of the
+  // orchestrator's NodeDetailPanel (I/O stays the default everywhere else).
+  const [landOnOrchestration, setLandOnOrchestration] = useState<string | null>(null);
+
   const handleSelectRun = useCallback(
     async (runId: string) => {
+      // #723: any navigation away from the child run ends the back-bar story
+      // and any pending Orchestration-tab landing — both are one gesture old.
+      // (Purely derived visibility does the rest: the bar only ever renders
+      // while the child run is the selected one.)
+      setOrchestratorReturn(null);
+      setLandOnOrchestration(null);
       setSelectedTriggerId(null);
       setSelectedRunId(runId);
       selectRun(runId);
       setSelectedNodeId(null);
       await openRunPipeline(runId);
     },
-    [selectRun, openRunPipeline],
+    [selectRun, openRunPipeline, setOrchestratorReturn, setLandOnOrchestration],
   );
 
   const handleRunCreated = useCallback(
@@ -606,6 +630,35 @@ export default function App() {
     },
     [refreshRuns, handleSelectRun],
   );
+
+  // #723 — opening a child run from the Orchestration tab: record the way back
+  // (parent run + orchestrator node) AFTER the navigation, so the shared
+  // `handleSelectRun`'s clear does not wipe it.
+  const handleOpenChildRun = useCallback(
+    async (childRunId: string) => {
+      if (!selectedRun || selection.kind !== "node" || !selection.id) return;
+      const entry = {
+        parentRunId: selectedRun.run_id,
+        parentRunName: selectedRun.name || selectedRun.pipeline_name,
+        nodeId: selection.id,
+        nodeName:
+          selectedRun.node_defs?.find((d) => d.id === selection.id)?.name ?? selection.id,
+        childRunId,
+      };
+      await handleSelectRun(childRunId);
+      setOrchestratorReturn(entry);
+    },
+    [selectedRun, selection, handleSelectRun, setOrchestratorReturn],
+  );
+  const handleBackToOrchestrator = useCallback(async () => {
+    if (!orchestratorReturn) return;
+    const { parentRunId, nodeId } = orchestratorReturn;
+    await handleSelectRun(parentRunId);
+    // One-shot landing: the panel remounts on this selection and seeds its
+    // detail tab from it — two gestures deep, two gestures back.
+    setLandOnOrchestration(nodeId);
+    setSelection({ kind: "node", id: nodeId });
+  }, [orchestratorReturn, handleSelectRun, setSelection, setLandOnOrchestration]);
 
   useEffect(() => {
     // #315: never fire a save for an archived run — the tab is read-only and a
@@ -761,6 +814,25 @@ export default function App() {
             {hasEditTab ? (
               <div className="flex h-full min-w-0 flex-col">
                 <TabBar />
+                {orchestratorReturn && selectedRun?.run_id === orchestratorReturn.childRunId && (
+                  <button
+                    type="button"
+                    data-testid="orchestrator-back-bar"
+                    onClick={handleBackToOrchestrator}
+                    className="flex shrink-0 cursor-pointer items-center gap-1.5 border-b border-line bg-bg-2 px-3 py-1 text-fg-3 transition-colors hover:text-fg"
+                    style={{ fontSize: "11px" }}
+                    title="Back to the orchestrator node, on its Orchestration tab"
+                  >
+                    <ArrowLeft size={12} />
+                    <span>
+                      Back to <span className="font-medium text-fg-2">{orchestratorReturn.nodeName}</span>
+                      <span className="text-fg-4"> · {orchestratorReturn.parentRunName}</span>
+                    </span>
+                    <span className="ml-auto flex items-center gap-1 text-fg-4" style={{ fontSize: "10px" }}>
+                      <GitFork size={10} /> child run
+                    </span>
+                  </button>
+                )}
                 <EditCanvas
                   libraryEntries={libraryEntries}
                   onLibraryDelete={async (name) => {
@@ -876,6 +948,9 @@ export default function App() {
                     runId={selectedRun.run_id}
                     isArchived={isArchived}
                     nodeName={selectedRun.node_defs?.find((d) => d.id === selectedNodeId)?.name}
+                    isOrchestratorNode={selectedRun.node_defs?.find((d) => d.id === selectedNodeId)?.orchestrator ?? false}
+                    onOpenChildRun={handleOpenChildRun}
+                    initialDetailTab={landOnOrchestration === selectedNode.node_id ? "orchestration" : "io"}
                   />
                 )}
                 {!selectedNode && selectedNodeType !== "start" && isArchived && selectedRun && (

--- a/frontend/src/components/EditCanvas.tsx
+++ b/frontend/src/components/EditCanvas.tsx
@@ -44,6 +44,10 @@ import { anchorHandleId, anchorsByDropOnBody, chooseAnchorSide, isEmergentInputN
 import { useAgentProfiles } from "../hooks/useAgentProfiles";
 import { useSkillBank } from "../hooks/useSkillBank";
 import { Bookmark, SlidersHorizontal, TriangleAlert } from "lucide-react";
+// #723 — orchestrator pastilles on the run-view node card.
+import { ChildCountPills } from "./OrchestrationTab";
+import { childrenOfNode, countChildren, totalChildren, useRunChildren } from "../lib/orchestration";
+import type { ChildCounts } from "../lib/orchestration";
 
 // The four emergent body anchor handles (#168), each pinned to its side-centre
 // with the matching xyflow `Position` so a bound incoming edge arrives from that
@@ -83,6 +87,10 @@ interface EditNodeData {
   // Absent on non-member nodes and on multi-member regions (boxed instead).
   loopBadge?: { text: string; kind: LoopKind };
   agentMode?: "inherit" | "profile" | "custom" | "broken";
+  /** #723: the node carries the « Orchestrator » toggle (ADR-0064). */
+  orchestrator?: boolean;
+  /** #723: child-run counters of an orchestrator node (run view only). */
+  childCounts?: ChildCounts;
   [key: string]: unknown;
 }
 
@@ -205,6 +213,14 @@ export function EditNode({ data, id, selected }: NodeProps<Node<EditNodeData>>) 
           </span>
         )}
       </div>
+      {/* #723 — orchestrator pastilles: a row under the title (the card grows
+          a line); omitted entirely without children, so a node that never
+          orchestrated stays byte-identical. */}
+      {data.childCounts && totalChildren(data.childCounts) > 0 && (
+        <div className="mt-1.5 flex items-center gap-2 pl-[22px]" data-testid="node-child-pills-row">
+          <ChildCountPills counts={data.childCounts} size="xs" testId="node-child-pills" />
+        </div>
+      )}
       {inputImages.length > 0 && (
         <div className="mt-2 flex flex-wrap gap-1.5" data-testid="start-node-images">
           {inputImages.map((name) => (
@@ -413,9 +429,20 @@ function EditCanvasInner({ libraryEntries, onLibraryDelete, infoOpen, onToggleIn
   // #669: the bank's ids, for the missing-skill lint above the canvas.
   const { bank: skillBank, loaded: skillBankLoaded } = useSkillBank();
   const skillIds = useMemo(() => new Set(skillBank.skills.map((skill) => skill.id)), [skillBank]);
+  // #723 — children of the run, polled with the view; mapped onto the cards of
+  // nodes whose frozen `orchestrator` toggle is on. Template tabs never poll
+  // (no run state → no children) and stay untouched.
+  const runChildren = useRunChildren(activeRunState?.run_id ?? null, activeRunState != null);
   const derivedNodes = useMemo(() => {
     if (!pipeline) return [];
-    const cards = deriveEditNodes(pipeline, activeRunState, agentProfileIds);
+    const cards = deriveEditNodes(pipeline, activeRunState, agentProfileIds).map((card) => {
+      if (!(card.data as { orchestrator?: boolean }).orchestrator) return card;
+      const runId = activeRunState?.run_id ?? null;
+      if (!runId) return card;
+      const nodeChildren = childrenOfNode(runChildren, runId, card.id);
+      if (nodeChildren.length === 0) return card;
+      return { ...card, data: { ...card.data, childCounts: countChildren(nodeChildren) } };
+    });
     // Bounded loop regions (ADR-0011 / #148) render as translucent boxes BEHIND
     // their member cards. Each multi-member region is backed by a decorative,
     // non-interactive `loopRegion` node so it tracks pan/zoom with the graph;
@@ -429,7 +456,7 @@ function EditCanvasInner({ libraryEntries, onLibraryDelete, infoOpen, onToggleIn
     // pipeline alone (independent of run state).
     const noteNodes: Node[] = buildNoteNodes(pipeline);
     return [...regionNodes, ...cards, ...noteNodes];
-  }, [pipeline, activeRunState, agentProfileIds]);
+  }, [pipeline, activeRunState, agentProfileIds, runChildren]);
   const derivedEdges = useMemo(
     () => (pipeline ? deriveEditEdges(pipeline) : []),
     [pipeline],

--- a/frontend/src/components/NodeDetailPanel.tsx
+++ b/frontend/src/components/NodeDetailPanel.tsx
@@ -41,6 +41,13 @@ import {
   EMPTY_PROVISIONING_RULES,
   hasProvisioningRules,
 } from "../lib/provisioning";
+// #723 — Orchestration tab + pastilles.
+import { ChildCountPills, OrchestrationTab } from "./OrchestrationTab";
+import {
+  childrenOfNode,
+  countChildren,
+  useRunChildren,
+} from "../lib/orchestration";
 
 const STATUS_LABELS: Record<NodeStatus, string> = {
   pending: "Pending",
@@ -63,6 +70,14 @@ interface Props {
   provisioningRepository?: string;
   inheritedProvisioning?: ScopedProvisioningRules[];
   provisioningGitRef?: string;
+  /** #723: the node's frozen « Orchestrator » toggle (ADR-0064) — mounts the
+   *  I/O | Orchestration tab pair and the pastilles. Absent ⇒ plain I/O pane,
+   *  byte-identical to the pre-#723 panel. */
+  isOrchestratorNode?: boolean;
+  /** #723: open a child run listed in the Orchestration tab (App records the way back). */
+  onOpenChildRun?: (childRunId: string) => void;
+  /** #723: land on the Orchestration tab (the back arrow from a child run). */
+  initialDetailTab?: "io" | "orchestration";
 }
 
 // The terminal inset has three mutually exclusive display modes (#346):
@@ -231,8 +246,19 @@ export default function NodeDetailPanel({
   provisioningRepository = "",
   inheritedProvisioning,
   provisioningGitRef = "HEAD",
+  isOrchestratorNode = false,
+  onOpenChildRun,
+  initialDetailTab = "io",
 }: Props) {
   const [modal, setModal] = useState<ModalState | null>(null);
+  // #723 — an orchestrator NodeRun splits its lower pane into I/O | Orchestration.
+  // I/O stays the default; the choice is per mounted node (remount = back to I/O).
+  const [detailTab, setDetailTab] = useState<"io" | "orchestration">(initialDetailTab);
+  // The children read polls with the run view cadence (never pushed), whether or
+  // not the tab is open — the tab-header pastilles count from the same read.
+  const childrenData = useRunChildren(runId, isOrchestratorNode);
+  const nodeChildren = childrenOfNode(childrenData, runId, node.node_id);
+  const childCounts = countChildren(nodeChildren);
   // Seed at mount only (no reactive effect on status): the issue trigger is
   // "clicking the node" (= selection / mount), not a live transition. A node
   // is `key`-ed by node_id at both mount sites, so selecting another terminated
@@ -762,6 +788,42 @@ export default function NodeDetailPanel({
               )}
             </div>
 
+            {/* #723 — I/O | Orchestration tabs, only for an orchestrator node.
+                Below « Mark complete » (the escape hatch stays reachable from
+                both tabs), above the I/O content. */}
+            {isOrchestratorNode && (
+              <div className="flex shrink-0 border-b border-line" data-testid="detail-tabs">
+                {(["io", "orchestration"] as const).map((tab) => {
+                  const active = detailTab === tab;
+                  return (
+                    <button
+                      key={tab}
+                      type="button"
+                      data-testid={`detail-tab-${tab}`}
+                      data-active={active}
+                      onClick={() => setDetailTab(tab)}
+                      className={`flex flex-1 cursor-pointer items-center justify-center gap-1.5 py-1.5 transition-colors ${
+                        active ? "border-b-2 border-acc font-medium text-fg" : "text-fg-3 hover:text-fg-2"
+                      }`}
+                      style={{ fontSize: "11px" }}
+                    >
+                      {tab === "io" ? "I/O" : "Orchestration"}
+                      {tab === "orchestration" && <ChildCountPills counts={childCounts} size="xs" testId="tab-child-pills" />}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+            {isOrchestratorNode && detailTab === "orchestration" ? (
+              <OrchestrationTab
+                childRuns={nodeChildren}
+                counts={childCounts}
+                nodeLive={node.status === "running" || node.status === "awaiting_user"}
+                nodeAwaiting={node.status === "awaiting_user"}
+                onOpenChild={(id) => onOpenChildRun?.(id)}
+              />
+            ) : (
+              <>
             {/* Inputs section */}
             {inputs.length > 0 && (
               <IOSection
@@ -793,6 +855,8 @@ export default function NodeDetailPanel({
               status={node.status}
               isArchived={isArchived}
             />
+              </>
+            )}
           </div>
         );
 

--- a/frontend/src/components/NodeInspector.tsx
+++ b/frontend/src/components/NodeInspector.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect, useMemo } from "react";
-import { Star } from "lucide-react";
+import { GitFork, Lock, Star, TriangleAlert } from "lucide-react";
 import { useEditStore } from "../stores/editStore";
-import type { NodeDef, NodeState, NodeType, PortDef } from "../types";
+import type { NodeDef, NodeState, NodeType, PortDef, SkillRef } from "../types";
 import { SectionHead, Field } from "./InspectorPrimitives";
 import OutputPortCard from "./OutputPortCard";
 import { NodeTypeIcon } from "./NodeTypeIcon";
@@ -145,6 +145,30 @@ export default function NodeInspector({
   const frozenIsolation = runNode?.isolated_worktree;
   const isolation = frozenIsolation ?? nodeIsolation(node);
   const isolationFrozen = frozenIsolation != null;
+
+  // #723/ADR-0064 — the « Orchestrator » toggle's state and freeze. In run mode
+  // the toggle follows the same ADR-0007 discipline as the Workspace choice:
+  // once the NodeRun spawned, its frozen copy applies, so the switch reads off
+  // and only says so — an edit applies to the next NodeRun.
+  const ORCHESTRATE_SKILL_REF: SkillRef = { id: "pdo-orchestrate", name: "pdo-orchestrate" };
+  const isOrchestrator = node.orchestrator ?? false;
+  const orchestratorFrozen = runNode != null && runNode.status !== "pending";
+  const hasOrchestrateSkill = (node.skills ?? []).some((s) => s.id === ORCHESTRATE_SKILL_REF.id);
+  // Toggle ON ⇒ seed the skill reference (unless it is already there). The
+  // seeded skill is visible — and removable — in the Skills selector below;
+  // the toggle stays the single source of intent (amber warning + re-add).
+  function setOrchestrator(next: boolean) {
+    const own = node!.skills ?? [];
+    const skills = next
+      ? (own.some((s) => s.id === ORCHESTRATE_SKILL_REF.id) ? own : [...own, ORCHESTRATE_SKILL_REF])
+      : own.filter((s) => s.id !== ORCHESTRATE_SKILL_REF.id);
+    handleField("skills", skills.length > 0 ? skills : undefined);
+    handleField("orchestrator", next);
+  }
+  function seedOrchestrateSkill() {
+    if (hasOrchestrateSkill) return;
+    handleField("skills", [...(node!.skills ?? []), ORCHESTRATE_SKILL_REF]);
+  }
 
   // #339: delete one contributing edge of a pooled input — the canonical
   // "delete an input" since inputs are emergent (#149/ADR-0011). Last-cycle
@@ -358,6 +382,73 @@ export default function NodeInspector({
           </div>
         </Tooltip>
 
+        {/* #723/ADR-0064: the « Orchestrator » toggle — a behavior of the node,
+            like Interactive, one row under it. Agent nodes only (a script runs
+            no agent, so a child-run contract there would silently do nothing).
+            Turning it on also seeds the `pdo-orchestrate` skill reference and
+            PDO files the fixed /pdo-orchestrate amendment into the prompt at
+            spawn (rendered below the textarea; never editable there). The
+            toggle is the single source of intent: removing the skill by hand
+            keeps the toggle on and warns, with a one-click re-add. */}
+        {!isScript && (
+          <Tooltip
+            content="Lets this node create child runs (pdo run create). Adds the pdo-orchestrate skill to the node and a fixed /pdo-orchestrate line to the prompt PDO files at spawn. Frozen once the NodeRun spawns."
+            side="left"
+          >
+            <div className="flex flex-col gap-1">
+              <div className="flex items-center justify-between">
+                <span className="flex items-center gap-1.5 text-fg-3">
+                  <GitFork size={11} className="text-fg-4" />
+                  Orchestrator
+                  {orchestratorFrozen && <Lock size={9} className="text-fg-4" />}
+                </span>
+                <button
+                  data-testid="node-orchestrator-toggle"
+                  aria-pressed={isOrchestrator}
+                  disabled={orchestratorFrozen || readOnly}
+                  onClick={() => setOrchestrator(!isOrchestrator)}
+                  className={`relative h-5 w-9 rounded-full transition-colors ${
+                    orchestratorFrozen || readOnly ? "cursor-not-allowed opacity-60" : "cursor-pointer"
+                  } ${isOrchestrator ? "bg-acc" : "bg-bg-5"}`}
+                >
+                  <span
+                    className={`absolute top-0.5 left-0.5 h-4 w-4 rounded-full bg-fg transition-transform ${
+                      isOrchestrator ? "translate-x-[16px]" : "translate-x-0"
+                    }`}
+                  />
+                </button>
+              </div>
+              {orchestratorFrozen && (
+                <span className="text-fg-4" style={{ fontSize: "9.5px" }}>
+                  Frozen at spawn — an edit applies to the next NodeRun.
+                </span>
+              )}
+              {isOrchestrator && !hasOrchestrateSkill && (
+                <span
+                  data-testid="node-orchestrator-skill-missing"
+                  className="flex items-start gap-1 rounded border border-st-blocked/40 bg-st-blocked/10 px-2 py-1 text-st-blocked"
+                  style={{ fontSize: "9.5px", lineHeight: 1.4 }}
+                >
+                  <TriangleAlert size={10} className="mt-[1px] shrink-0" />
+                  <span>
+                    The pdo-orchestrate skill was removed: the agent will get the /pdo-orchestrate line but no
+                    instructions.{" "}
+                    {!orchestratorFrozen && !readOnly && (
+                      <button
+                        type="button"
+                        className="cursor-pointer underline"
+                        onClick={seedOrchestrateSkill}
+                      >
+                        Re-add it
+                      </button>
+                    )}
+                  </span>
+                </span>
+              )}
+            </div>
+          </Tooltip>
+        )}
+
         {!isScript && (
           <>
             <AgentControl
@@ -456,10 +547,34 @@ export default function NodeInspector({
           data-testid={isScript ? "script-body" : undefined}
           value={promptContent}
           onChange={(e) => updatePrompt(node.id, e.target.value)}
-          className="min-h-[120px] w-full resize-y rounded border border-line-strong bg-bg-3 px-2 py-1.5 font-mono text-fg outline-none focus:border-acc"
+          className={`min-h-[120px] w-full resize-y rounded border border-line-strong bg-bg-3 px-2 py-1.5 font-mono text-fg outline-none focus:border-acc ${
+            !isScript && isOrchestrator ? "rounded-b-none border-b-0 border-dashed" : ""
+          }`}
           style={{ fontSize: "11px", lineHeight: "1.5" }}
           placeholder={isScript ? "#!/usr/bin/env bash\n# e.g. curl -X POST \"$DISCORD_WEBHOOK\" ..." : "Enter the node's role prompt..."}
         />
+
+        {/* #723 — the amendment PDO files at spawn when Orchestrator is on.
+            Rendered, never editable, never in the textarea: toggle and text
+            cannot drift. Dashed block visually attached under the textarea. */}
+        {!isScript && isOrchestrator && (
+          <div
+            data-testid="node-orchestrator-prompt-amendment"
+            className="rounded-b border border-t-0 border-dashed border-line-strong bg-bg-2 px-2 py-1.5"
+          >
+            <div className="mb-1 flex items-center gap-1 text-fg-4" style={{ fontSize: "9.5px" }}>
+              <Lock size={9} />
+              Added by PDO at spawn (Orchestrator)
+            </div>
+            <pre className="whitespace-pre-wrap font-mono text-fg-3" style={{ fontSize: "10.5px", lineHeight: 1.5 }}>
+{`/pdo-orchestrate
+
+## Orchestration
+You may create child runs with \`pdo run create\`. This node completes
+only once every child run is terminal; a failed child parks it awaiting you.`}
+            </pre>
+          </div>
+        )}
 
         {/* Inputs — emergent (#149): derived from incoming edges, read-only.
             Same-named edges pool into one logical list input that spells out

--- a/frontend/src/components/OrchestrationTab.tsx
+++ b/frontend/src/components/OrchestrationTab.tsx
@@ -1,0 +1,237 @@
+// #723 — Orchestration tab of the NodeRun detail panel + the shared count pastilles.
+import { useEffect, useState } from "react";
+import { ExternalLink, GitFork } from "lucide-react";
+import type { RunStatus } from "../types";
+import { isLiveRun } from "../types";
+import { formatDuration } from "../lib/runDuration";
+import { formatCostAmount } from "../lib/costLabel";
+import {
+  childCostKnown,
+  childCostText,
+  type ChildCounts,
+  type RunChildEntry,
+  totalChildren,
+} from "../lib/orchestration";
+
+const RUN_STATUS_LABEL: Record<RunStatus, string> = {
+  running: "Running",
+  awaiting_user: "Awaiting user",
+  completed: "Completed",
+  failed: "Failed",
+  skipped: "Skipped",
+  halted: "Halted",
+  paused: "Paused",
+  archived: "Archived",
+};
+
+function runStatusDot(status: RunStatus): string {
+  if (status === "failed") return "bg-st-failed";
+  if (status === "awaiting_user") return "bg-st-await";
+  if (status === "paused") return "bg-st-stopped";
+  if (isLiveRun(status)) return "bg-st-running";
+  return "bg-st-done";
+}
+
+/**
+ * The green / red / blue counters: a coloured dot with the number beside it.
+ * Same component on the canvas node and in the tab header, so the two can
+ * never disagree; a zero counter is omitted, and the whole cluster is omitted
+ * when there is no child at all (nodes that never orchestrated stay clean).
+ */
+export function ChildCountPills({
+  counts,
+  size = "sm",
+  testId = "child-count-pills",
+}: {
+  counts: ChildCounts;
+  size?: "sm" | "xs";
+  testId?: string;
+}) {
+  if (totalChildren(counts) === 0) return null;
+  const dot = size === "xs" ? 6 : 7;
+  const fs = size === "xs" ? 9.5 : 10.5;
+  const item = (n: number, bg: string, label: string, id: string) =>
+    n > 0 ? (
+      <span
+        key={id}
+        data-testid={`${testId}-${id}`}
+        title={`${n} ${label} child run${n > 1 ? "s" : ""}`}
+        className="inline-flex items-center gap-1 font-mono text-fg-2"
+        style={{ fontSize: fs, lineHeight: 1 }}
+      >
+        <span className={`inline-block rounded-full ${bg}`} style={{ width: dot, height: dot }} />
+        {n}
+      </span>
+    ) : null;
+  return (
+    <span
+      className="inline-flex items-center gap-2"
+      data-testid={testId}
+      aria-label={`${counts.finished} finished, ${counts.failed} failed, ${counts.running} running child runs`}
+    >
+      {item(counts.finished, "bg-st-done", "finished", "finished")}
+      {item(counts.failed, "bg-st-failed", "failed", "failed")}
+      {item(counts.running, "bg-st-running", "running", "running")}
+    </span>
+  );
+}
+
+/**
+ * The tick a live child's duration counts against. `Date.now()` is impure and
+ * may not be called during render — the clock lives in a timer callback
+ * instead, and `null` (before the first tick) renders a bare « … ».
+ */
+function useNow(live: boolean): number | null {
+  const [now, setNow] = useState<number | null>(null);
+  useEffect(() => {
+    if (!live) return;
+    const tick = () => setNow(Date.now());
+    const id = setInterval(tick, 1000);
+    return () => clearInterval(id);
+  }, [live]);
+  return live ? now : null;
+}
+
+function ChildRow({
+  child,
+  onOpen,
+}: {
+  child: RunChildEntry;
+  onOpen: (runId: string) => void;
+}) {
+  const live = isLiveRun(child.status);
+  const now = useNow(live);
+  const started = child.started_at ? new Date(child.started_at) : null;
+  const ended = child.completed_at
+    ? new Date(child.completed_at).getTime()
+    : now;
+  const duration =
+    started && ended != null ? formatDuration(ended - started.getTime()) : null;
+  const failed = child.status === "failed";
+  return (
+    <li
+      data-testid="orchestration-child"
+      data-run-id={child.run_id}
+      className={`group flex flex-col gap-0.5 rounded border px-2 py-1.5 ${
+        failed ? "border-st-failed/40 bg-st-failed-bg/40" : "border-line bg-bg-3"
+      }`}
+    >
+      <div className="flex items-center gap-1.5">
+        <span
+          title={RUN_STATUS_LABEL[child.status] ?? child.status}
+          className={`h-1.5 w-1.5 shrink-0 rounded-full ${runStatusDot(child.status)} ${live ? "animate-pulse" : ""}`}
+        />
+        <button
+          type="button"
+          data-testid="orchestration-child-title"
+          onClick={() => onOpen(child.run_id)}
+          title="Open this child run — the back arrow brings you back here"
+          className="flex min-w-0 flex-1 cursor-pointer items-center gap-1 text-left font-medium text-fg hover:text-acc hover:underline"
+          style={{ fontSize: "11.5px" }}
+        >
+          <span className="truncate">{child.name || child.run_id}</span>
+          <ExternalLink size={10} className="shrink-0 opacity-0 transition-opacity group-hover:opacity-100" />
+        </button>
+      </div>
+      <div className="flex items-center gap-1 pl-3 font-mono text-fg-4" style={{ fontSize: "9.5px" }}>
+        <span className="truncate">{child.pipeline_name}</span>
+        {started && (
+          <span>
+            {" · "}
+            started {started.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
+          </span>
+        )}
+        {duration && (
+          <span data-testid="orchestration-child-duration">
+            {" · "}
+            {duration}
+            {live ? "…" : ""}
+          </span>
+        )}
+        <span data-testid="orchestration-child-cost" className="ml-auto">
+          {childCostText(child.cost)}
+        </span>
+      </div>
+    </li>
+  );
+}
+
+export function OrchestrationTab({
+  childRuns,
+  counts,
+  nodeLive,
+  nodeAwaiting,
+  onOpenChild,
+}: {
+  childRuns: RunChildEntry[];
+  counts: ChildCounts;
+  /** The orchestrator node's session is still live (children may still appear). */
+  nodeLive: boolean;
+  /** The node is `awaiting_user` — with a failed child, the tab says why. */
+  nodeAwaiting: boolean;
+  onOpenChild: (runId: string) => void;
+}) {
+  if (childRuns.length === 0) {
+    return (
+      <div
+        data-testid="orchestration-empty"
+        className="flex flex-1 flex-col items-center justify-center gap-1.5 px-6 py-8 text-center text-fg-4"
+        style={{ fontSize: "11px" }}
+      >
+        <GitFork size={16} className="text-fg-5" />
+        {nodeLive ? (
+          <>
+            <span className="text-fg-3">No child run yet.</span>
+            <span>
+              The agent creates them with <code className="font-mono text-fg-3">pdo run create</code>; they
+              will appear here as they start.
+            </span>
+          </>
+        ) : (
+          <span>This node created no child run.</span>
+        )}
+      </div>
+    );
+  }
+  return (
+    <div className="flex flex-col gap-1.5 px-3 py-2" data-testid="orchestration-tab">
+      {nodeAwaiting && counts.failed > 0 && (
+        <div
+          data-testid="orchestration-failed-banner"
+          className="rounded border border-st-failed/40 bg-st-failed-bg px-2 py-1.5 text-st-failed"
+          style={{ fontSize: "10.5px", lineHeight: 1.45 }}
+        >
+          {counts.failed} child run{counts.failed > 1 ? "s" : ""} failed — the node waits for you. Open the
+          child to retry it, or <em>Mark complete</em> above to force the node through.
+        </div>
+      )}
+      {nodeLive && counts.running > 0 && (
+        <div className="flex items-center gap-1.5 text-fg-4" style={{ fontSize: "10px" }}>
+          <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-st-running" />
+          Node completes once every child is terminal.
+        </div>
+      )}
+      <ul className="flex flex-col gap-1">
+        {childRuns.map((child) => (
+          <ChildRow key={child.run_id} child={child} onOpen={onOpenChild} />
+        ))}
+      </ul>
+      <div className="flex items-center justify-between font-mono text-fg-4" style={{ fontSize: "9.5px" }}>
+        <span>
+          {childRuns.length} child run{childRuns.length > 1 ? "s" : ""}
+        </span>
+        <span title="Sum of the children's estimated costs">
+          Σ{" "}
+          {(() => {
+            const known = childRuns.map((c) => childCostKnown(c.cost));
+            const summable = known.filter((v): v is number => v != null);
+            if (summable.length === 0) return "—";
+            const sum = summable.reduce((acc, v) => acc + v, 0);
+            const partial = summable.length < childRuns.length;
+            return formatCostAmount(sum, partial, true);
+          })()}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/editNodeDerivation.ts
+++ b/frontend/src/components/editNodeDerivation.ts
@@ -113,6 +113,12 @@ export function deriveEditNodes(
         // collection (#151) or `↻ ...` for a single-member bounded loop (#173).
         // Absent on non-member nodes and multi-member regions (boxed instead).
         loopBadge,
+        // #723/ADR-0064: the node's « Orchestrator » toggle. On a live Run the
+        // FROZEN answer (the snapshot's NodeDefInfo) wins, exactly like
+        // `isolated` above; on a template the document says. The canvas pastilles
+        // (EditCanvas) attach the child counters to cards where this is true.
+        orchestrator:
+          runState?.node_defs?.find((d) => d.id === n.id)?.orchestrator ?? n.orchestrator ?? false,
       },
     };
   });

--- a/frontend/src/lib/layoutFields.test.ts
+++ b/frontend/src/lib/layoutFields.test.ts
@@ -80,6 +80,10 @@ const NODE: Complete<NodeDef> = {
   // #653/ADR-0060: same caveat again — the emission proof is in
   // `serializePipeline.test.ts` ("an agent always writes its isolation line").
   isolated_worktree: false,
+  // #723/ADR-0064: same caveat once more — `Complete<NodeDef>` forces the
+  // field; the emission proof lives in `serializePipeline.test.ts` ("the
+  // orchestrator toggle lands in the YAML object").
+  orchestrator: true,
 };
 const EDGE: Complete<EdgeDef> = {
   source: { node: "n1", port: "out" },

--- a/frontend/src/lib/layoutFields.ts
+++ b/frontend/src/lib/layoutFields.ts
@@ -54,7 +54,10 @@ export const SEMANTIC_FIELDS: Record<SerializerScope, readonly string[]> = {
   // library star and the pipeline diff must both see it.
   // #669/ADR-0062: `skills` is SEMANTIC — the skills a node carries change what
   // its NodeRun works with, so a selection edit versions the pipeline.
-  node: ["id", "name", "type", "interactive", "agent_choice", "skills", "pin_harness", "harnesses", "provisioning", "max_iter", "isolated_worktree", "inputs", "outputs"] satisfies (keyof NodeDef)[],
+  // #723/ADR-0064: `orchestrator` is SEMANTIC for the same reason the backend's
+  // NodeProjection already says — it changes the node's completion contract,
+  // its prompt at spawn and its skills.
+  node: ["id", "name", "type", "interactive", "agent_choice", "skills", "pin_harness", "harnesses", "provisioning", "max_iter", "isolated_worktree", "orchestrator", "inputs", "outputs"] satisfies (keyof NodeDef)[],
   // `side` is SEMANTIC today (emitted, not stripped) — deliberate, see #355 D5:
   // the node-library star already treats port side as identity, so the pipeline
   // diff must agree or the two stars contradict each other on the same edit.

--- a/frontend/src/lib/orchestration.test.ts
+++ b/frontend/src/lib/orchestration.test.ts
@@ -1,0 +1,75 @@
+// #723 — unit tests for the shared orchestration read model: the counters the
+// pastilles render and the cost vocabulary they speak.
+import { describe, expect, it } from "vitest";
+import {
+  childCostKnown,
+  childCostText,
+  countChildren,
+  totalChildren,
+  type RunChildEntry,
+} from "./orchestration";
+
+function child(status: RunChildEntry["status"], cost?: RunChildEntry["cost"]): RunChildEntry {
+  return { run_id: `run-${status}-${Math.random()}`, pipeline_name: "p", status, cost };
+}
+
+describe("countChildren (#723)", () => {
+  it("buckets failed / running / finished with the three pills totalling the children", () => {
+    const counts = countChildren([
+      child("completed"),
+      child("skipped"),
+      child("failed"),
+      child("running"),
+      child("awaiting_user"),
+      child("paused"),
+    ]);
+    expect(counts).toEqual({ finished: 2, failed: 1, running: 3 });
+    expect(totalChildren(counts)).toBe(6);
+  });
+
+  it("counts awaiting_user and paused as RUNNING (blue) — design decision 3", () => {
+    // The blue pill is "still to settle"; a failed child is red. The two sets
+    // stay disjoint, so awaiting/paused children never read finished.
+    const counts = countChildren([child("awaiting_user"), child("paused")]);
+    expect(counts.running).toBe(2);
+    expect(counts.finished).toBe(0);
+    expect(counts.failed).toBe(0);
+  });
+
+  it("an empty list yields all-zero counts — the pills hide everywhere", () => {
+    expect(totalChildren(countChildren([]))).toBe(0);
+  });
+});
+
+describe("childCostText / childCostKnown (#723)", () => {
+  it("renders — for an absent cost, never $0", () => {
+    expect(childCostText(undefined)).toBe("—");
+  });
+
+  it("renders — for a child with no costable session (usd 0, no slice)", () => {
+    expect(childCostText({ usd: 0, partial: false })).toBe("—");
+    expect(childCostKnown({ usd: 0, partial: false })).toBeNull();
+  });
+
+  it("renders — when a harness has no cost source, the sum is refused", () => {
+    const cost = { usd: 1.5, partial: false, uncosted_harnesses: ["opencode"] };
+    expect(childCostText(cost)).toBe("—");
+    expect(childCostKnown(cost)).toBeNull();
+  });
+
+  it("renders a derived estimate with the ~ frame, and its dollars as summable", () => {
+    const cost = { usd: 0.5, partial: false };
+    expect(childCostText(cost)).toBe("~$0.5000");
+    expect(childCostKnown(cost)).toBe(0.5);
+  });
+
+  it("renders an exact reported total without the ~", () => {
+    const cost = {
+      usd: 2,
+      partial: false,
+      by_harness: [{ harness: "pi", usd: 2, form: "reported" as const, partial: false, unpriced_models: [], reported_in_usd: true }],
+    };
+    expect(childCostText(cost)).toBe("$2.00");
+    expect(childCostKnown(cost)).toBe(2);
+  });
+});

--- a/frontend/src/lib/orchestration.ts
+++ b/frontend/src/lib/orchestration.ts
@@ -1,0 +1,132 @@
+// #723 — Orchestration read model shared by the Orchestration tab, the tab-header
+// pastilles and the canvas pastilles, so the three surfaces can never disagree.
+import { useEffect, useState } from "react";
+import type { HarnessCost, RunStatus } from "../types";
+import { isLiveRun } from "../types";
+import { formatEstCost } from "./costLabel";
+
+/** One child of `GET /runs/{id}/children` (daemon `RunChildEntry`). */
+export interface RunChildEntry {
+  run_id: string;
+  pipeline_name: string;
+  name?: string;
+  status: RunStatus;
+  started_at?: string;
+  completed_at?: string;
+  /** The daemon's CostStat, derived on read (ADR-0052) — never persisted.
+   *  Shape mirrors `RunState.cost` (no `form` at the top level: the per-slice
+   *  forms live in `by_harness`). */
+  cost?: {
+    usd: number;
+    partial: boolean;
+    unpriced_models?: string[];
+    uncosted_harnesses?: string[];
+    by_harness?: HarnessCost[];
+  };
+}
+
+export interface RunChildrenGroup {
+  node_id: string | null;
+  children: RunChildEntry[];
+}
+
+export interface RunChildrenResponse {
+  run_id: string;
+  nodes: RunChildrenGroup[];
+}
+
+/** Pastille counters: green / red / blue. */
+export interface ChildCounts {
+  finished: number;
+  failed: number;
+  running: number;
+}
+
+/**
+ * `awaiting_user` / `paused` count as **running** (decision 3 of the design,
+ * 2026-09-07): the blue pill is "still to settle", and a failed child is red
+ * — the two sets stay disjoint, so the three pills always total the children.
+ */
+export function countChildren(children: RunChildEntry[]): ChildCounts {
+  const counts: ChildCounts = { finished: 0, failed: 0, running: 0 };
+  for (const child of children) {
+    if (child.status === "failed") counts.failed += 1;
+    else if (isLiveRun(child.status)) counts.running += 1;
+    else counts.finished += 1;
+  }
+  return counts;
+}
+
+export function totalChildren(counts: ChildCounts): number {
+  return counts.finished + counts.failed + counts.running;
+}
+
+/**
+ * The child's cost, rendered through the shared honesty vocabulary (#272/#377):
+ * "—" when unavailable, never "$0". Unavailable means: the cost is absent,
+ * a harness has no cost source (the helper itself refuses to sum), or there
+ * was simply no costable session (`usd == 0` and no per-harness slice).
+ */
+export function childCostText(cost?: RunChildEntry["cost"]): string {
+  if (!cost) return "—";
+  const byHarness = cost.by_harness ?? [];
+  if ((cost.uncosted_harnesses?.length ?? 0) > 0) {
+    return formatEstCost(cost.usd, cost.partial, cost.unpriced_models ?? [], cost.uncosted_harnesses ?? [], byHarness).text;
+  }
+  if (cost.usd === 0 && byHarness.length === 0) return "—";
+  return formatEstCost(cost.usd, cost.partial, cost.unpriced_models ?? [], [], byHarness).text;
+}
+
+/** The child's summable dollars, or `null` when its cost is unavailable (the
+ *  footer's Σ marks itself partial on any `null`). */
+export function childCostKnown(cost?: RunChildEntry["cost"]): number | null {
+  if (!cost) return null;
+  if ((cost.uncosted_harnesses?.length ?? 0) > 0) return null;
+  if (cost.usd === 0 && (cost.by_harness ?? []).length === 0) return null;
+  return cost.usd;
+}
+
+/**
+ * Poll `GET /runs/{id}/children` at the same cadence as the run view refresh
+ * (never pushed — design §3). Non-2xx and network errors keep the last good
+ * read: a momentarily unreachable daemon must not blank a surface the user is
+ * reading. The response is NEVER reset to null between runs — `childrenOfNode`
+ * guards on the response's own `run_id`, so a stale read can never dress
+ * another run's cards (no setState-in-effect reset to trip the compiler).
+ */
+export function useRunChildren(runId: string | null, enabled: boolean): RunChildrenResponse | null {
+  const [data, setData] = useState<RunChildrenResponse | null>(null);
+  useEffect(() => {
+    if (!runId || !enabled) return;
+    let cancelled = false;
+    const load = async () => {
+      try {
+        const res = await fetch(`/runs/${runId}/children`);
+        if (!res.ok) return;
+        const json = (await res.json()) as RunChildrenResponse;
+        if (!cancelled) setData(json);
+      } catch {
+        /* keep the last good read */
+      }
+    };
+    void load();
+    const id = setInterval(load, 3000);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, [runId, enabled]);
+  return data;
+}
+
+/** This node's slice of the children response, in the daemon's (chronological)
+ *  order — empty unless the read belongs to THIS run (the hook never resets,
+ *  so the consumer must run-guard). */
+export function childrenOfNode(
+  data: RunChildrenResponse | null,
+  runId: string,
+  nodeId: string,
+): RunChildEntry[] {
+  if (!data || data.run_id !== runId) return [];
+  return data.nodes.find((g) => g.node_id === nodeId)?.children ?? [];
+}

--- a/frontend/src/lib/serializePipeline.test.ts
+++ b/frontend/src/lib/serializePipeline.test.ts
@@ -228,6 +228,27 @@ describe("serializePipeline round-trip: YAML structural correctness", () => {
     expect(typeIndent).toBe(allowedIndent);
   });
 
+  it("serializes the orchestrator toggle only when on (#723)", () => {
+    const plain: NodeDef = {
+      id: "plain", name: "plain", type: "agent",
+      inputs: [],
+      outputs: [{ name: "out", repeated: false, side: "right" }],
+      interactive: false,
+    };
+    // A node without the toggle serializes byte-identically to its pre-#723
+    // shape — the key is absent, like `interactive`.
+    expect(serializePipeline(makeFullPipeline([plain]))).not.toContain("orchestrator:");
+
+    const orchestrator: NodeDef = {
+      ...plain,
+      id: "orch", name: "orch",
+      orchestrator: true,
+      skills: [{ id: "pdo-orchestrate", name: "pdo-orchestrate" }],
+    };
+    const yaml = serializePipeline(makeFullPipeline([orchestrator]));
+    expect(yaml).toContain("orchestrator: true");
+  });
+
   it("round-trips multiline output instructions and omits blank values", () => {
     const reviewer: NodeDef = {
       id: "reviewer", name: "reviewer", type: "agent",

--- a/frontend/src/lib/serializePipeline.ts
+++ b/frontend/src/lib/serializePipeline.ts
@@ -100,6 +100,11 @@ export function pipelineToYamlObject(p: PipelineDef): Record<string, unknown> {
     // emitted for `merge` (isolated by construction) or a structural node.
     const isolation = nodeIsolation(n);
     if (isolation !== null) node.isolated_worktree = isolation;
+    // #723/ADR-0064: the « Orchestrator » toggle. Emitted only when on, like
+    // `interactive` — a node without the toggle serializes byte-identically to
+    // its pre-#723 shape. Must be mirrored in `exportNodeAsYaml` below and
+    // classified in `layoutFields.ts` (SEMANTIC_FIELDS.node).
+    if (n.orchestrator) node.orchestrator = true;
     // #550/ADR-0046: the harness axis replaces flat `model:`/`effort:`. The pin is
     // emitted when set; the flat model/effort view is folded back into the
     // resolved harness's entry in the per-harness `harnesses` map, emitted only
@@ -303,6 +308,9 @@ export function exportNodeAsYaml(node: NodeDef, prompt: string): string {
   // carries its worktree placement, so a re-import does not re-guess it.
   const isolation = nodeIsolation(node);
   if (isolation !== null) obj.isolated_worktree = isolation;
+  // #723/ADR-0064: same conditional emit as `pipelineToYamlObject` — the
+  // « Orchestrator » toggle travels with an exported node.
+  if (node.orchestrator) obj.orchestrator = true;
   if (node.pin_harness) obj.pin_harness = node.pin_harness;
   if (node.agent_choice && node.agent_choice.mode !== "inherit") {
     obj.agent_choice = node.agent_choice;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -895,6 +895,9 @@ export interface NodeDefInfo {
   node_type: NodeType;
   /** #653: where the node works, as the Run's pipeline snapshot froze it. */
   isolated_worktree?: boolean | null;
+  /** #723/ADR-0064: the « Orchestrator » toggle, frozen at run start — drives
+   *  the Orchestration tab, the pastilles and the binding in the run view. */
+  orchestrator?: boolean;
   view_x: number | null;
   view_y: number | null;
   inputs: PortBrief[];
@@ -1262,6 +1265,12 @@ export interface NodeDef {
    *  document never leaves the reader to guess. Absent on `merge` (isolated by
    *  construction) and on structural nodes. */
   isolated_worktree?: boolean | null;
+  /** #723/ADR-0064: the « Orchestrator » toggle. `true` ⇒ the node's NodeRun is
+   *  held by the strong orchestrator↔children binding while its child runs are
+   *  non-terminal, gets the `/pdo-orchestrate` prompt amendment at spawn and
+   *  carries the seeded `pdo-orchestrate` skill reference. NOT a node type.
+   *  Semantic — in the diff and the library content hash. Agent nodes only. */
+  orchestrator?: boolean;
 }
 
 export interface AgentCombination {


### PR DESCRIPTION
## Summary

Implements #723 (story #709, spec #719, ADR-0064) — sub-ticket PR, auto-merge per the green local check (build + tests + green Feature Path).

- **Toggle « Orchestrator »** (agent nodes only, frozen at spawn, ADR-0007) in the node edit detail, under « Interactive ».
- **Auto-managed skill reference**: toggling on/off adds/removes the `pdo-orchestrate` skill reference — visible in the selector, counted in the semantic diff, removable with the existing « skill absent » warning.
- **Prompt amendment at spawn**: the NodeRun prompt gets the `/pdo-orchestrate` invocation line + the Orchestration contract block after the role prompt — rendered, never in the textarea; toggle off is byte-identical to pre-#723.
- **Orchestration tab in run view**: I/O (default) | Orchestration tabs fed by `GET /runs/{id}/children` — child list (status, started, ticking duration, cost), clickable child title → child run with « ← Back to Orchestrator » bar landing back on the Orchestration tab.
- **Status pills** (finished/failed/running — `awaiting_user` counts blue) with counters on the tab header and the canvas card, hidden while there are no children. Nodes without the toggle are untouched.
- `chore(release): 1.70.0` — Cargo + CHANGELOG.

## Checks

- `make check` ✅ (cargo check + tsc + support table)
- `make test` ✅ (nextest 2923 passed · vitest 2264 passed · doctests ok)
- **Feature Path #723** ✅ — QA run `b4kko9SV`, 4/4 FPs green against the real dev stack (`make dev`), no blocking finding (4 non-blocking, cosmetic or out-of-scope).

Closes #723