### PR TITLE
#735: Stats › Cost « By model » de bout en bout pour claude

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ ascendante** : la casse se signale ici et par un bump majeur, jamais en gardant 
 morts. Seule contrainte non négociable — les **données historiques restent lisibles** : un Run
 archivé s'ouvre et se chiffre quelle que soit la version qui a écrit son payload.
 
+## 1.71.0
+
+**Stats › Cost « By model » pour claude** (#735 ; story #733, spec #734, ADR-0065). Le select
+« Cost grouping » gagne l'option « By model » : drill master/detail Modèle → effort → Pipeline →
+Node réutilisant l'existant, ids de modèle verbatim (un alias épinglé et l'id observé restent deux
+lignes, jamais de repli sur une famille). Côté backend, la capacité de harnais (ADR-0051)
+s'enrichit d'une source d'identité observée : `claude` lit le modèle par message des transcripts
+(coût ventilé par message, une session à deux modèles coûtant et comptant dans chaque bucket),
+tandis que `pi`/`copilot`/`opencode` retombent sur le modèle demandé au `node_started` ; le fold
+de coût porte des slices model × effort (effort « not set » italique quand ni demandé ni observé)
+et la memo reste intacte (ADR-0029). Le wire `/stats/cost` s'enrichit additivement : `by_model`,
+couples modèle × effort en feuilles de Node sur les axes By pipeline/By project, provenance
+`observed | requested | mixed` par bucket (marque « ? », les mots vivant dans les infobulles —
+jamais le mot « real »), couvertures par bucket et `by_period` à chaque niveau. Titre
+« per execution » sur l'axe modèle et au niveau Node, « per Run » ailleurs.
+
 ## 1.70.0
 
 **Toggle « Orchestrator » + onglet Orchestration + pastilles** (#723 ; story #709, spec #719,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "1.70.0"
+version = "1.71.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "1.70.0"
+version = "1.71.0"
 license = "MIT"
 description = "Prompt-Driven Orchestrator — a local daemon that runs and supervises agentic coding pipelines"
 repository = "https://github.com/Loulen/prompt-driven-orchestrator"

--- a/crates/pdo-daemon/src/harness_probes.rs
+++ b/crates/pdo-daemon/src/harness_probes.rs
@@ -86,6 +86,24 @@ pub(crate) enum CostSource {
     ReportedByConstant,
 }
 
+/// The **observed execution identity** capability (ADR-0065): what of the
+/// model × effort pair a harness's **source** reports for a running execution.
+/// The startup event is never this — it is the *requested* fallback, and Stats
+/// always says which of the two it read.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ObservedIdentitySource {
+    /// The source names the model **per message** (claude's transcript); the
+    /// effort is never written by the source, so it stays requested.
+    ModelPerMessage,
+    /// The source names both the model and the effort (`pi` per message,
+    /// `copilot` per usage point). **Deferred**: no first-party harness returns
+    /// this yet — they declare `None` explicitly until their ticket (ADR-0051:
+    /// `None` is a declared absence, not a missing dispatch), so both values
+    /// fall back to the requested ones.
+    #[allow(dead_code)] // the variant IS the next harness ticket's dispatch target
+    ModelAndEffort,
+}
+
 impl CostSource {
     /// How this source reads in the published support table
     /// ([`crate::harness_support`]). The label lives on the variant so the table
@@ -423,6 +441,12 @@ pub(crate) trait HarnessProbes: Sync {
     fn cost_source(&self) -> Option<CostSource> {
         None
     }
+    /// What of the model × effort pair the harness's source reports, or `None`
+    /// (both values fall back to the requested ones — declared absence,
+    /// ADR-0065 §1).
+    fn observed_identity_source(&self) -> Option<ObservedIdentitySource> {
+        None
+    }
     /// How PDO finds this harness's transcript, or `None`.
     fn transcript_resolution(&self) -> Option<TranscriptResolution> {
         None
@@ -555,6 +579,12 @@ struct ClaudeProbes;
 impl HarnessProbes for ClaudeProbes {
     fn cost_source(&self) -> Option<CostSource> {
         Some(CostSource::DerivedFromTranscript)
+    }
+    /// The transcript names the model per assistant message — the observed
+    /// model ADR-0065 reads first. The effort is never written by the source,
+    /// so it stays requested (measured 2026-09-07, #733).
+    fn observed_identity_source(&self) -> Option<ObservedIdentitySource> {
+        Some(ObservedIdentitySource::ModelPerMessage)
     }
     fn transcript_resolution(&self) -> Option<TranscriptResolution> {
         Some(TranscriptResolution::ClaudeJsonl)
@@ -1074,6 +1104,14 @@ pub(crate) fn capabilities(harness: &str) -> Capabilities {
     }
 }
 
+/// The observed-execution-identity capability of `harness` (ADR-0065), or `None`
+/// when the source is mute — the fold then falls back to the requested model and
+/// effort and marks them `requested`. `pi`/`copilot` declare `None` explicitly
+/// until their ticket, even though their sources could answer.
+pub(crate) fn observed_identity_source(harness: &str) -> Option<ObservedIdentitySource> {
+    probes_for(harness).and_then(|probes| probes.observed_identity_source())
+}
+
 /// Whether PDO can derive a Run's cost for `harness`: it needs both a cost source
 /// and a way to find the transcript that source reads. A data-declared harness has
 /// neither, so its Run's cost is "—" with a reason rather than a silent `$0`.
@@ -1168,6 +1206,22 @@ mod tests {
             }
         );
         assert!(can_cost(CLAUDE));
+    }
+
+    #[test]
+    fn only_claude_declares_the_observed_identity_capability() {
+        // ADR-0065: the observed model/effort is a capability, read source-first.
+        // `claude` implements it here (model per message); `pi` and `copilot`
+        // return `None` EXPLICITLY until their ticket — a declared absence, not a
+        // missing dispatch (ADR-0051) — so both fall back to the requested values.
+        assert_eq!(
+            observed_identity_source(CLAUDE),
+            Some(ObservedIdentitySource::ModelPerMessage)
+        );
+        assert_eq!(observed_identity_source(COPILOT), None);
+        assert_eq!(observed_identity_source(PI), None);
+        assert_eq!(observed_identity_source(OPENCODE), None);
+        assert_eq!(observed_identity_source("never-seen"), None);
     }
 
     #[test]
@@ -1388,16 +1442,14 @@ mod tests {
 
     #[test]
     fn copilot_turn_end_dispatches_to_its_journal_parser_not_claudes() {
-        let copilot_tail =
-            "{\"type\":\"assistant.turn_start\",\"data\":{}}\n{\"type\":\"assistant.turn_end\",\"data\":{}}\n";
+        let copilot_tail = "{\"type\":\"assistant.turn_start\",\"data\":{}}\n{\"type\":\"assistant.turn_end\",\"data\":{}}\n";
         assert!(turn_ended(COPILOT, copilot_tail));
         assert!(
             !turn_ended(CLAUDE, copilot_tail),
             "not claude's JSONL shape"
         );
         // A trailing hard error is not a finished turn (harness exits 0 on it).
-        let errored =
-            "{\"type\":\"assistant.turn_start\",\"data\":{}}\n{\"type\":\"session.error\",\"data\":{\"message\":\"boom\"}}\n";
+        let errored = "{\"type\":\"assistant.turn_start\",\"data\":{}}\n{\"type\":\"session.error\",\"data\":{\"message\":\"boom\"}}\n";
         assert!(!turn_ended(COPILOT, errored));
     }
 

--- a/crates/pdo-daemon/src/run_advance.rs
+++ b/crates/pdo-daemon/src/run_advance.rs
@@ -925,9 +925,21 @@ mod tests {
             payload: None,
             ..marker.clone()
         };
-        assert!(binding_marker_present(&[marker.clone()], "orch", 2));
-        assert!(!binding_marker_present(&[marker.clone()], "orch", 1));
-        assert!(!binding_marker_present(&[marker.clone()], "other", 2));
+        assert!(binding_marker_present(
+            std::slice::from_ref(&marker),
+            "orch",
+            2
+        ));
+        assert!(!binding_marker_present(
+            std::slice::from_ref(&marker),
+            "orch",
+            1
+        ));
+        assert!(!binding_marker_present(
+            std::slice::from_ref(&marker),
+            "other",
+            2
+        ));
         assert!(!binding_marker_present(&[interactive_spawn], "orch", 2));
     }
 

--- a/crates/pdo-daemon/src/run_cost.rs
+++ b/crates/pdo-daemon/src/run_cost.rs
@@ -82,6 +82,41 @@ pub(crate) struct CostContribution {
     pub partial: bool,
     pub unpriced_models: Vec<String>,
     pub unavailable_reasons: Vec<String>,
+    /// The execution's cost **ventilated by model × effort** (ADR-0065) — the
+    /// raw material of the « By model » axis and the Node leaves' pairs. One
+    /// slice per model the execution provably ran on; empty for a harness with
+    /// no cost source (absent from the axis, never a "default of X" bucket)
+    /// and for a mute source with no requested model.
+    pub model_slices: Vec<ModelEffortSlice>,
+}
+
+/// One model bucket of one execution's cost (ADR-0065). An execution with two
+/// models produces two slices and counts — and costs — in both buckets, so a
+/// bucket's average per execution stays coherent with its cost (ADR-0065 §3).
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct ModelEffortSlice {
+    /// The model id **verbatim** (ADR-0065 §2): no aliasing, no de-dating, no
+    /// fallback to the price table's undated family.
+    pub model: String,
+    /// `true` when the harness's source reported this id (observed); `false`
+    /// when it is the startup event's requested id, read in fallback because
+    /// the source was mute.
+    pub model_observed: bool,
+    /// The execution's effort, or `None` when neither source named one — the
+    /// "not set" bucket, never merged with a real effort.
+    pub effort: Option<String>,
+    /// `Some(false)` = requested, `Some(true)` = observed, `None` when `effort`
+    /// is `None` (not set has no provenance to show).
+    pub effort_observed: Option<bool>,
+    pub usd: Option<f64>,
+    /// Derived (transcript × price table) — the wire's `~` flag. A reported
+    /// slice (`copilot`, `pi`) and an unreadable one are not estimates of this
+    /// fold.
+    pub estimated: bool,
+    pub partial: bool,
+    pub executions: i64,
+    pub unpriced_models: Vec<String>,
+    pub missing_reasons: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -136,6 +171,11 @@ struct Execution {
     harness: String,
     node_id: Option<String>,
     session_id: Option<String>,
+    /// The model × effort FROZEN in the startup event (ADR-0046) — the
+    /// **requested** values the fold falls back to when the source is mute
+    /// (ADR-0065 §1). `None` when the event named nothing.
+    requested_model: Option<String>,
+    requested_effort: Option<String>,
     /// Where this execution worked (#653): the store folder of a cwd-keyed harness
     /// (`claude`'s encoded project dir, `pi`'s session folder) derives from it.
     working_dir: Option<PathBuf>,
@@ -240,6 +280,16 @@ fn collect_executions(
             .and_then(|p| p.get("session_id"))
             .and_then(|v| v.as_str())
             .filter(|s| !s.is_empty());
+        let requested_model = payload
+            .and_then(|p| p.get("model"))
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .map(str::to_string);
+        let requested_effort = payload
+            .and_then(|p| p.get("effort"))
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .map(str::to_string);
         let identity = frozen_execution_identity(
             harness,
             session_id,
@@ -288,6 +338,8 @@ fn collect_executions(
             harness: harness.to_string(),
             node_id: event.node_id.clone(),
             session_id: session_id.map(str::to_string),
+            requested_model,
+            requested_effort,
             working_dir,
             project,
             legacy_claim,
@@ -356,6 +408,94 @@ fn reported_execution_cost(
     )
 }
 
+/// The **model × effort slices** of one execution (ADR-0065): the observed
+/// per-message models when the source named any, else the requested id in
+/// fallback — with the execution's own availability carried along. A harness
+/// with no cost source gets NO slices (absent from « By model », never a
+/// "default of X" bucket), and so does a mute source with no requested model:
+/// nothing is invented.
+fn execution_model_slices(
+    execution: &Execution,
+    observed_models: Option<BTreeMap<String, ModelUsage>>,
+    usd: Option<f64>,
+    form: Option<CostForm>,
+    partial: bool,
+    unpriced_models: Vec<String>,
+    missing_reasons: Vec<String>,
+) -> Vec<ModelEffortSlice> {
+    if !crate::harness_probes::can_cost(&execution.harness)
+        || crate::harness_probes::observed_identity_source(&execution.harness).is_none()
+            && execution.requested_model.is_none()
+    {
+        return Vec::new();
+    }
+    if let Some(models) = observed_models {
+        if !models.is_empty() {
+            // Observed: one slice per verbatim id the source named, the effort
+            // requested (`claude`'s source never writes it — ADR-0065 §1).
+            return models
+                .into_iter()
+                .map(|(model, usage)| ModelEffortSlice {
+                    model,
+                    model_observed: true,
+                    effort: execution.requested_effort.clone(),
+                    effort_observed: execution.requested_effort.as_ref().map(|_| false),
+                    usd: Some(usage.usd),
+                    estimated: true,
+                    partial: !usage.unpriced.is_empty(),
+                    executions: 1,
+                    unpriced_models: usage.unpriced.into_iter().collect(),
+                    missing_reasons: Vec::new(),
+                })
+                .collect();
+        }
+    }
+    // Source mute for the model (or no readable transcript): the requested id
+    // in fallback, carrying the execution's own readability.
+    execution
+        .requested_model
+        .clone()
+        .map(|model| {
+            vec![ModelEffortSlice {
+                model,
+                model_observed: false,
+                effort: execution.requested_effort.clone(),
+                effort_observed: execution.requested_effort.as_ref().map(|_| false),
+                usd,
+                estimated: form == Some(CostForm::Derived) && usd.is_some(),
+                partial,
+                executions: 1,
+                unpriced_models,
+                missing_reasons,
+            }]
+        })
+        .unwrap_or_default()
+}
+
+/// Leftover (infrastructure / unassigned) cost, ventilated by its observed
+/// models. No effort: those sessions have no node and no startup event, so they
+/// land in the "not set" bucket (ADR-0065).
+fn leftover_model_slices(
+    models: &BTreeMap<String, ModelUsage>,
+    executions: i64,
+) -> Vec<ModelEffortSlice> {
+    models
+        .iter()
+        .map(|(model, usage)| ModelEffortSlice {
+            model: model.clone(),
+            model_observed: true,
+            effort: None,
+            effort_observed: None,
+            usd: Some(usage.usd),
+            estimated: true,
+            partial: !usage.unpriced.is_empty(),
+            executions,
+            unpriced_models: usage.unpriced.iter().cloned().collect(),
+            missing_reasons: Vec::new(),
+        })
+        .collect()
+}
+
 pub(crate) fn compute_run_cost_breakdown(
     events: &[crate::event_log::Event],
     claude_root: &Path,
@@ -420,6 +560,7 @@ pub(crate) fn compute_run_cost_breakdown(
     let mut seen_messages = HashSet::new();
     for (index, execution) in executions.iter().enumerate() {
         let mut reported_in_usd = false;
+        let mut observed_models: Option<BTreeMap<String, ModelUsage>> = None;
         let (cost, form, reason) = if !crate::harness_probes::can_cost(&execution.harness) {
             (None, None, Some("harness has no cost source".to_string()))
         } else if crate::harness_probes::probes_for(&execution.harness)
@@ -445,15 +586,10 @@ pub(crate) fn compute_run_cost_breakdown(
             && execution.unavailable_reason.is_none()
             && owned_files[index]
         {
-            (
-                Some(aggregate_with_seen(
-                    owned_lines[index].drain(..),
-                    prices,
-                    &mut seen_messages,
-                )),
-                Some(CostForm::Derived),
-                None,
-            )
+            let (stat, by_model) =
+                aggregate_by_model(owned_lines[index].drain(..), prices, &mut seen_messages);
+            observed_models = Some(by_model);
+            (Some(stat), Some(CostForm::Derived), None)
         } else {
             (
                 None,
@@ -465,6 +601,23 @@ pub(crate) fn compute_run_cost_breakdown(
             )
         };
         let usd = cost.as_ref().map(|cost| cost.usd);
+        let unavailable_reasons: Vec<String> = cost
+            .is_none()
+            .then_some(reason)
+            .flatten()
+            .into_iter()
+            .collect();
+        let model_slices = execution_model_slices(
+            execution,
+            observed_models,
+            usd,
+            form,
+            cost.as_ref().map(|cost| cost.partial).unwrap_or(false),
+            cost.as_ref()
+                .map(|cost| cost.unpriced_models.clone())
+                .unwrap_or_default(),
+            unavailable_reasons.clone(),
+        );
         contributions.push(CostContribution {
             harness: execution.harness.clone(),
             scope: CostScope::Node,
@@ -479,12 +632,8 @@ pub(crate) fn compute_run_cost_breakdown(
                 .as_ref()
                 .map(|cost| cost.unpriced_models.clone())
                 .unwrap_or_default(),
-            unavailable_reasons: cost
-                .is_none()
-                .then_some(reason)
-                .flatten()
-                .into_iter()
-                .collect(),
+            unavailable_reasons,
+            model_slices,
         });
     }
 
@@ -510,7 +659,7 @@ pub(crate) fn compute_run_cost_breakdown(
             && !execution.legacy_claim
     });
     let leftover = leftover_files
-        .then(|| aggregate_with_seen(leftover_lines.into_iter(), prices, &mut seen_messages));
+        .then(|| aggregate_by_model(leftover_lines.into_iter(), prices, &mut seen_messages));
     if infrastructure_executions > 0 {
         let attributable = !ambiguous_shared_claude;
         contributions.push(CostContribution {
@@ -528,15 +677,15 @@ pub(crate) fn compute_run_cost_breakdown(
                 0
             },
             usd: attributable
-                .then(|| leftover.as_ref().map(|cost| cost.usd))
+                .then(|| leftover.as_ref().map(|(cost, _)| cost.usd))
                 .flatten(),
             form: (attributable && leftover.is_some()).then_some(CostForm::Derived),
             reported_in_usd: false,
-            partial: attributable && leftover.as_ref().is_some_and(|cost| cost.partial),
+            partial: attributable && leftover.as_ref().is_some_and(|(cost, _)| cost.partial),
             unpriced_models: if attributable {
                 leftover
                     .as_ref()
-                    .map(|cost| cost.unpriced_models.clone())
+                    .map(|(cost, _)| cost.unpriced_models.clone())
                     .unwrap_or_default()
             } else {
                 Vec::new()
@@ -546,9 +695,20 @@ pub(crate) fn compute_run_cost_breakdown(
             } else {
                 vec!["no attributable infrastructure cost".to_string()]
             },
+            // The infrastructure sessions' models are observed off the same
+            // leftover lines; they carry no effort ("not set"). Unattributable
+            // leftovers go to the Unassigned bucket below instead.
+            model_slices: if attributable {
+                leftover
+                    .as_ref()
+                    .map(|(_, models)| leftover_model_slices(models, infrastructure_executions))
+                    .unwrap_or_default()
+            } else {
+                Vec::new()
+            },
         });
     }
-    if let Some(cost) =
+    if let Some((cost, models)) =
         leftover.filter(|_| ambiguous_shared_claude || infrastructure_executions == 0)
     {
         contributions.push(CostContribution {
@@ -565,6 +725,10 @@ pub(crate) fn compute_run_cost_breakdown(
             unavailable_reasons: vec![
                 "Claude transcript cannot be matched to a node or infrastructure".to_string(),
             ],
+            // The orphan lines' models are still known (observed) even though
+            // their node is not: they ventilate inside the model axis, under the
+            // pipeline's "Unassigned" node, effort "not set".
+            model_slices: leftover_model_slices(&models, 0),
         });
     }
 
@@ -732,29 +896,62 @@ fn aggregate(lines: impl Iterator<Item = Line>, prices: &PriceTable) -> CostStat
     aggregate_with_seen(lines, prices, &mut seen)
 }
 
+/// The run-level aggregate alone — the per-model ventilation is only consumed
+/// by the breakdown's execution loop, so the run-cost helpers keep this shape.
+#[cfg(test)]
 fn aggregate_with_seen(
     lines: impl Iterator<Item = Line>,
     prices: &PriceTable,
     seen: &mut HashSet<(String, Option<String>)>,
 ) -> CostStat {
+    aggregate_by_model(lines, prices, seen).0
+}
+
+/// Per-model cost subtotals of one transcript fold — the raw material of
+/// [`ModelEffortSlice`] (ADR-0065). Keyed by the **verbatim** `message.model`;
+/// unpriced ids still land here (at $0) so the axis can name the model and mark
+/// it `†`, with the family remembered per id just like the run-level set.
+#[derive(Debug, Clone, Default, PartialEq)]
+struct ModelUsage {
+    usd: f64,
+    unpriced: BTreeSet<String>,
+}
+
+/// [`aggregate_with_seen`] plus the per-model ventilation the « By model » axis
+/// folds (ADR-0065). The run-level [`CostStat`] is byte-identical to before —
+/// the axis is additive, the totals never move.
+fn aggregate_by_model(
+    lines: impl Iterator<Item = Line>,
+    prices: &PriceTable,
+    seen: &mut HashSet<(String, Option<String>)>,
+) -> (CostStat, BTreeMap<String, ModelUsage>) {
     let mut usd = 0.0;
     let mut unpriced: BTreeSet<String> = BTreeSet::new();
+    let mut by_model: BTreeMap<String, ModelUsage> = BTreeMap::new();
     for l in lines {
         if let Some(id) = &l.message_id {
             if !seen.insert((id.clone(), l.request_id.clone())) {
                 continue; // duplicate: replay on resume/compaction
             }
         }
+        let entry = by_model.entry(l.model.clone()).or_default();
         match prices.price_for(&l.model) {
-            Some(p) => usd += line_cost(&l.usage, p.input, p.output),
+            Some(p) => {
+                let line_usd = line_cost(&l.usage, p.input, p.output);
+                usd += line_usd;
+                entry.usd += line_usd;
+            }
             // Unknown real model → $0 + named in the lower-bound signal (#425).
             None => {
                 unpriced.insert(strip_date_suffix(&l.model).to_string());
+                entry
+                    .unpriced
+                    .insert(strip_date_suffix(&l.model).to_string());
             }
         }
     }
     let unpriced_models: Vec<String> = unpriced.into_iter().collect();
-    CostStat {
+    let stat = CostStat {
         usd,
         partial: !unpriced_models.is_empty(),
         unpriced_models,
@@ -766,7 +963,8 @@ fn aggregate_with_seen(
         // by-harness breakdown is assembled by the attributed fold, which pairs
         // this derived slice with `copilot`'s reported one (#615).
         by_harness: Vec::new(),
-    }
+    };
+    (stat, by_model)
 }
 
 /// The distinct harnesses this Run launched a node on that have **no cost
@@ -2476,5 +2674,272 @@ mod tests {
             &builtin(),
         );
         assert!((refreshed.cost.unwrap().usd - 2.0).abs() < 1e-9);
+    }
+
+    // --- model × effort slices (ADR-0065, #735) ---
+
+    /// Seed a claude transcript attributed to session `s1` (the file IS the
+    /// identity: `<session-id>.jsonl` inside the encoded cwd dir).
+    fn seed_session_transcript(projects: &Path, repo: &Path, run_id: &str, body: &str) {
+        let worktree = repo.join(".pdo").join("runs").join(run_id).join("worktree");
+        let proj = projects.join(cc_project_dirname(&worktree));
+        std::fs::create_dir_all(&proj).unwrap();
+        std::fs::write(proj.join("s1.jsonl"), format!("{body}\n")).unwrap();
+    }
+
+    fn claude_start(run_id: &str, model: Option<&str>, effort: Option<&str>) -> Event {
+        Event {
+            id: None,
+            run_id: run_id.into(),
+            ts: crate::event_log::now_iso(),
+            kind: EventKind::NodeStarted,
+            node_id: Some("worker".into()),
+            iter: Some(1),
+            payload: Some(serde_json::json!({
+                "node_type": "agent", "isolated_worktree": false,
+                "harness": "claude", "session_id": "s1",
+                "model": model, "effort": effort
+            })),
+        }
+    }
+
+    #[test]
+    fn a_two_model_transcript_ventilates_cost_and_executions_per_model() {
+        let home = tempfile::tempdir().unwrap();
+        let claude = home.path().join(".claude").join("projects");
+        let stores = crate::sandbox_run::HarnessStores::from_home(home.path());
+        let repo = tempfile::tempdir().unwrap();
+        let run_id = "two-models";
+        // opus-4-8 5/25 and sonnet-5 3/15: two observed models in one session.
+        seed_session_transcript(
+            &claude,
+            repo.path(),
+            run_id,
+            &format!(
+                "{}\n{}",
+                assistant("m1", "r1", "claude-opus-4-8", 1_000_000, 0),
+                assistant("m2", "r2", "claude-sonnet-5", 1_000_000, 0)
+            ),
+        );
+
+        let events = vec![claude_start(run_id, Some("claude-opus-4-8"), Some("high"))];
+        let breakdown =
+            compute_run_cost_breakdown(&events, &claude, &stores, repo.path(), run_id, &builtin());
+        let node = breakdown
+            .contributions
+            .iter()
+            .find(|contribution| contribution.scope == CostScope::Node)
+            .unwrap();
+
+        assert_eq!(node.model_slices.len(), 2, "one slice per observed model");
+        let opus = node
+            .model_slices
+            .iter()
+            .find(|slice| slice.model == "claude-opus-4-8")
+            .unwrap();
+        let sonnet = node
+            .model_slices
+            .iter()
+            .find(|slice| slice.model == "claude-sonnet-5")
+            .unwrap();
+        // Verbatim ids (no de-dating), observed provenance, requested effort.
+        assert!((opus.usd.unwrap() - 5.0).abs() < 1e-9);
+        assert!((sonnet.usd.unwrap() - 3.0).abs() < 1e-9);
+        for slice in [opus, sonnet] {
+            assert!(slice.model_observed);
+            assert_eq!(slice.effort.as_deref(), Some("high"));
+            assert_eq!(slice.effort_observed, Some(false));
+            assert_eq!(slice.executions, 1, "the execution counts in each bucket");
+            assert!(slice.estimated);
+            assert!(!slice.partial);
+        }
+        assert!((node.usd.unwrap() - 8.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn an_unpriced_observed_model_is_its_own_marked_slice() {
+        let home = tempfile::tempdir().unwrap();
+        let claude = home.path().join(".claude").join("projects");
+        let stores = crate::sandbox_run::HarnessStores::from_home(home.path());
+        let repo = tempfile::tempdir().unwrap();
+        let run_id = "unpriced-slice";
+        seed_session_transcript(
+            &claude,
+            repo.path(),
+            run_id,
+            &assistant("m1", "r1", "claude-fable-9-20260101", 1_000_000, 0),
+        );
+        let events = vec![claude_start(run_id, Some("claude-fable-9-20260101"), None)];
+        let breakdown =
+            compute_run_cost_breakdown(&events, &claude, &stores, repo.path(), run_id, &builtin());
+        let node = breakdown
+            .contributions
+            .iter()
+            .find(|contribution| contribution.scope == CostScope::Node)
+            .unwrap();
+        assert_eq!(node.model_slices.len(), 1);
+        let slice = &node.model_slices[0];
+        assert_eq!(
+            slice.model, "claude-fable-9-20260101",
+            "verbatim, never de-dated"
+        );
+        assert_eq!(slice.usd, Some(0.0));
+        assert!(slice.partial);
+        assert_eq!(slice.unpriced_models, vec!["claude-fable-9"]);
+    }
+
+    #[test]
+    fn a_mute_source_falls_back_to_the_requested_model_and_marks_it() {
+        let home = tempfile::tempdir().unwrap();
+        let claude = home.path().join(".claude").join("projects");
+        let stores = crate::sandbox_run::HarnessStores::from_home(home.path());
+        let repo = tempfile::tempdir().unwrap();
+        let run_id = "mute-source";
+        // No transcript for the claude node → the startup event's id in fallback,
+        // carrying the execution's unreadability.
+        let events = vec![claude_start(run_id, Some("sonnet"), Some("medium"))];
+        let breakdown =
+            compute_run_cost_breakdown(&events, &claude, &stores, repo.path(), run_id, &builtin());
+        let node = breakdown
+            .contributions
+            .iter()
+            .find(|contribution| contribution.scope == CostScope::Node)
+            .unwrap();
+        assert_eq!(node.model_slices.len(), 1);
+        let slice = &node.model_slices[0];
+        assert_eq!(slice.model, "sonnet");
+        assert!(!slice.model_observed, "the source was mute: requested");
+        assert_eq!(slice.effort.as_deref(), Some("medium"));
+        assert_eq!(slice.effort_observed, Some(false));
+        assert_eq!(slice.usd, None);
+        assert_eq!(
+            slice.missing_reasons,
+            vec!["no attributable Claude transcript"]
+        );
+    }
+
+    #[test]
+    fn a_reported_slice_falls_back_to_the_requested_model_without_estimating() {
+        let home = tempfile::tempdir().unwrap();
+        let claude = home.path().join(".claude").join("projects");
+        let copilot = home.path().join(".copilot").join("session-state");
+        let stores = crate::sandbox_run::HarnessStores::from_home(home.path());
+        let repo = tempfile::tempdir().unwrap();
+        seed_copilot_journal(&copilot, "s1", 100_000_000_000);
+        let events = vec![Event {
+            id: None,
+            run_id: "reported-fallback".into(),
+            ts: crate::event_log::now_iso(),
+            kind: EventKind::NodeStarted,
+            node_id: Some("worker".into()),
+            iter: Some(1),
+            payload: Some(serde_json::json!({
+                "node_type": "agent", "isolated_worktree": false,
+                "harness": "copilot", "session_id": "s1",
+                "model": "gpt-5", "effort": "high"
+            })),
+        }];
+        let breakdown = compute_run_cost_breakdown(
+            &events,
+            &claude,
+            &stores,
+            repo.path(),
+            "reported-fallback",
+            &builtin(),
+        );
+        let node = breakdown
+            .contributions
+            .iter()
+            .find(|contribution| contribution.scope == CostScope::Node)
+            .unwrap();
+        assert_eq!(node.model_slices.len(), 1);
+        let slice = &node.model_slices[0];
+        assert_eq!(slice.model, "gpt-5");
+        assert!(!slice.model_observed, "pi/copilot defer the capability");
+        assert!((slice.usd.unwrap() - 1.0).abs() < 1e-9);
+        assert!(!slice.estimated, "a reported cost is never a ~estimate");
+    }
+
+    #[test]
+    fn a_harness_without_cost_source_has_no_model_slices() {
+        let home = tempfile::tempdir().unwrap();
+        let claude = home.path().join(".claude").join("projects");
+        let stores = crate::sandbox_run::HarnessStores::from_home(home.path());
+        let repo = tempfile::tempdir().unwrap();
+        // opencode pinned to a model: absent from « By model », never a
+        // "default of X" bucket (#735 AC).
+        let events = vec![Event {
+            id: None,
+            run_id: "no-source".into(),
+            ts: crate::event_log::now_iso(),
+            kind: EventKind::NodeStarted,
+            node_id: Some("worker".into()),
+            iter: Some(1),
+            payload: Some(serde_json::json!({
+                "node_type": "agent", "isolated_worktree": false,
+                "harness": "opencode", "model": "claude-opus-4-8"
+            })),
+        }];
+        let breakdown = compute_run_cost_breakdown(
+            &events,
+            &claude,
+            &stores,
+            repo.path(),
+            "no-source",
+            &builtin(),
+        );
+        let node = breakdown
+            .contributions
+            .iter()
+            .find(|contribution| contribution.scope == CostScope::Node)
+            .unwrap();
+        assert!(node.model_slices.is_empty());
+        assert_eq!(node.usd, None);
+    }
+
+    #[test]
+    fn unattributable_leftover_ventilates_by_observed_model_with_no_effort() {
+        let home = tempfile::tempdir().unwrap();
+        let claude = home.path().join(".claude").join("projects");
+        let stores = crate::sandbox_run::HarnessStores::from_home(home.path());
+        let repo = tempfile::tempdir().unwrap();
+        let run_id = "orphan-models";
+        // A transcript with no attributable node (no session id, non-isolated):
+        // the lines end up Unassigned, but their models are still observed.
+        seed_transcript(
+            &claude,
+            repo.path(),
+            run_id,
+            &format!(
+                "{}\n{}\n",
+                assistant("m1", "r1", "claude-opus-4-8", 1_000_000, 0),
+                assistant("m2", "r2", "claude-sonnet-5", 1_000_000, 0)
+            ),
+        );
+        let events = vec![Event {
+            id: None,
+            run_id: run_id.into(),
+            ts: crate::event_log::now_iso(),
+            kind: EventKind::NodeStarted,
+            node_id: Some("worker".into()),
+            iter: Some(1),
+            payload: Some(serde_json::json!({
+                "node_type": "agent", "isolated_worktree": false, "harness": "claude"
+            })),
+        }];
+        let breakdown =
+            compute_run_cost_breakdown(&events, &claude, &stores, repo.path(), run_id, &builtin());
+        let unassigned = breakdown
+            .contributions
+            .iter()
+            .find(|contribution| contribution.scope == CostScope::Unassigned)
+            .expect("orphan lines stay unassigned");
+        assert_eq!(unassigned.model_slices.len(), 2);
+        for slice in &unassigned.model_slices {
+            assert!(slice.model_observed);
+            assert_eq!(slice.effort, None, "no startup event: effort not set");
+            assert_eq!(slice.effort_observed, None);
+            assert_eq!(slice.executions, 0);
+        }
     }
 }

--- a/crates/pdo-daemon/src/stats.rs
+++ b/crates/pdo-daemon/src/stats.rs
@@ -574,6 +574,67 @@ pub(crate) struct StatsCostEntity {
     pub aggregate: StatsCostAggregate,
     pub by_period: Vec<StatsCostPeriod>,
     pub nodes: Vec<StatsCostEntity>,
+    /// The Node's cost split into model × effort pairs (ADR-0065) — Node leaves
+    /// only, so the drill-down ends there; omitted (never an empty array) on the
+    /// other levels.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub models: Vec<StatsModelEffortPair>,
+}
+
+/// Where a model/effort value was read from (ADR-0065 §1): the harness's source
+/// (observed — the norm, never marked) or the startup event (requested — marked
+/// « ? »), or both across the bucket's executions (mixed).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum StatsProvenance {
+    Observed,
+    Requested,
+    Mixed,
+}
+
+/// Observed and requested counts decide the label; both present in one bucket is
+/// the honest « mixed ».
+fn provenance(observed: i64, requested: i64) -> StatsProvenance {
+    match (observed > 0, requested > 0) {
+        (true, false) => StatsProvenance::Observed,
+        (false, true) => StatsProvenance::Requested,
+        (_, _) => StatsProvenance::Mixed,
+    }
+}
+
+/// One model × effort pair of a Node leaf (ADR-0065): the same aggregate shape
+/// as any cost row, plus the pair identity and where each half was read from.
+/// `effort = None` is the "not set" bucket — never merged with a real effort.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub(crate) struct StatsModelEffortPair {
+    #[serde(flatten)]
+    pub aggregate: StatsCostAggregate,
+    pub model: String,
+    pub model_provenance: StatsProvenance,
+    pub effort: Option<String>,
+    pub effort_provenance: Option<StatsProvenance>,
+}
+
+/// One effort level under a model, in the « By model » tree: the entity's `id`
+/// is the effort string ("" for not set) and its `name` the effort or
+/// "not set".
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub(crate) struct StatsEffortCostEntity {
+    #[serde(flatten)]
+    pub entity: StatsCostEntity,
+    pub effort: Option<String>,
+    pub provenance: Option<StatsProvenance>,
+    pub pipelines: Vec<StatsCostEntity>,
+}
+
+/// One model (verbatim id) of the « By model » axis, with its effort tree:
+/// Model → Effort → Pipeline → Node.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub(crate) struct StatsModelCostEntity {
+    #[serde(flatten)]
+    pub entity: StatsCostEntity,
+    pub provenance: StatsProvenance,
+    pub efforts: Vec<StatsEffortCostEntity>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
@@ -590,6 +651,7 @@ pub(crate) struct StatsCost {
     pub by_period: Vec<StatsCostPeriod>,
     pub by_pipeline: Vec<StatsCostEntity>,
     pub by_project: Vec<StatsProjectCostEntity>,
+    pub by_model: Vec<StatsModelCostEntity>,
     pub resolved: Vec<ResolvedPriceRow>,
 }
 
@@ -688,6 +750,28 @@ impl CostMetricAcc {
             missing_reasons: self.missing_reasons.iter().cloned().collect(),
         }
     }
+
+    /// The same lower-bound bookkeeping, for one model × effort slice (ADR-0065).
+    /// An execution counts — and costs — in every bucket it provably ran on, so a
+    /// bucket's executions may sum to more than the execution count of its
+    /// parent aggregate; that double count is the design, not a leak.
+    fn add_slice(&mut self, slice: &crate::run_cost::ModelEffortSlice) {
+        self.executions += slice.executions;
+        let readable = i64::from(slice.usd.is_some()) * slice.executions;
+        self.readable += readable;
+        self.unknown += slice.executions - readable;
+        if let Some(usd) = slice.usd {
+            self.usd += usd;
+            self.has_usd = true;
+            self.readable_usd += usd;
+        }
+        self.estimated |= slice.estimated;
+        self.partial |= slice.partial;
+        self.unpriced_models
+            .extend(slice.unpriced_models.iter().cloned());
+        self.missing_reasons
+            .extend(slice.missing_reasons.iter().cloned());
+    }
 }
 
 #[derive(Debug, Clone, Default)]
@@ -726,6 +810,14 @@ impl CostAggregateAcc {
             .add_contribution(contribution);
     }
 
+    fn add_slice(&mut self, harness: &str, slice: &crate::run_cost::ModelEffortSlice) {
+        self.total.add_slice(slice);
+        self.harnesses
+            .entry(harness.to_string())
+            .or_default()
+            .add_slice(slice);
+    }
+
     fn wire(&self) -> StatsCostAggregate {
         let mut aggregate = self.total.wire();
         aggregate.harnesses = self
@@ -743,6 +835,201 @@ struct CostEntityAcc {
     aggregate: CostAggregateAcc,
     periods: BTreeMap<String, CostAggregateAcc>,
     nodes: BTreeMap<String, CostEntityAcc>,
+    /// The Node leaf's model × effort pairs (ADR-0065) — only node-level accs
+    /// ever receive slices, so pipeline-level wiring emits an empty vec.
+    pairs: BTreeMap<(String, Option<String>), ModelPairAcc>,
+}
+
+/// One model × effort bucket, accumulated over the executions that landed in
+/// it. The observed/requested counters decide the wire's provenance, including
+/// the « mixed » case (some executions read from the source, some fell back to
+/// the startup event).
+#[derive(Debug, Clone, Default)]
+struct ModelPairAcc {
+    metric: CostMetricAcc,
+    harnesses: BTreeMap<String, CostMetricAcc>,
+    model_observed: i64,
+    model_requested: i64,
+    effort_observed: i64,
+    effort_requested: i64,
+}
+
+impl ModelPairAcc {
+    fn add_slice(&mut self, harness: &str, slice: &crate::run_cost::ModelEffortSlice) {
+        self.metric.add_slice(slice);
+        self.harnesses
+            .entry(harness.to_string())
+            .or_default()
+            .add_slice(slice);
+        if slice.model_observed {
+            self.model_observed += 1;
+        } else {
+            self.model_requested += 1;
+        }
+        match slice.effort_observed {
+            Some(true) => self.effort_observed += 1,
+            Some(false) => self.effort_requested += 1,
+            None => {}
+        }
+    }
+
+    fn wire(self, model: String, effort: Option<String>) -> StatsModelEffortPair {
+        let mut aggregate = self.metric.wire();
+        aggregate.harnesses = self
+            .harnesses
+            .into_iter()
+            .map(|(harness, metric)| metric.wire_harness(harness))
+            .collect();
+        StatsModelEffortPair {
+            aggregate,
+            model_provenance: provenance(self.model_observed, self.model_requested),
+            effort_provenance: effort
+                .as_ref()
+                .map(|_| provenance(self.effort_observed, self.effort_requested)),
+            model,
+            effort,
+        }
+    }
+}
+
+/// Sort key shared by every cost row: dollars first (a missing reading last),
+/// then id — the same order the pipeline/node levels already use.
+fn cost_then_id(
+    a_usd: Option<f64>,
+    a_id: &str,
+    b_usd: Option<f64>,
+    b_id: &str,
+) -> std::cmp::Ordering {
+    b_usd
+        .unwrap_or(-1.0)
+        .partial_cmp(&a_usd.unwrap_or(-1.0))
+        .unwrap_or(std::cmp::Ordering::Equal)
+        .then_with(|| a_id.cmp(b_id))
+}
+
+fn wire_pairs(
+    pairs: BTreeMap<(String, Option<String>), ModelPairAcc>,
+) -> Vec<StatsModelEffortPair> {
+    let mut rows: Vec<StatsModelEffortPair> = pairs
+        .into_iter()
+        .map(|((model, effort), acc)| acc.wire(model, effort))
+        .collect();
+    rows.sort_by(|a, b| {
+        cost_then_id(a.aggregate.usd, &a.model, b.aggregate.usd, &b.model)
+            .then_with(|| a.effort.cmp(&b.effort))
+    });
+    rows
+}
+
+/// One pipeline level of the « By model » tree. `entity.nodes` stays empty —
+/// the node level rides beside it so `wire_cost_entity` can't recurse into it.
+#[derive(Debug, Clone, Default)]
+struct ModelAxisPipelineAcc {
+    entity: CostEntityAcc,
+    nodes: BTreeMap<String, CostEntityAcc>,
+}
+
+/// One effort level under a model. `effort: None` is the "not set" bucket.
+#[derive(Debug, Clone, Default)]
+struct ModelEffortAcc {
+    aggregate: CostAggregateAcc,
+    periods: BTreeMap<String, CostAggregateAcc>,
+    pipelines: BTreeMap<String, ModelAxisPipelineAcc>,
+    model_observed: i64,
+    model_requested: i64,
+    effort_observed: i64,
+    effort_requested: i64,
+}
+
+/// One model (verbatim id) of the « By model » axis.
+#[derive(Debug, Clone, Default)]
+struct ModelAcc {
+    aggregate: CostAggregateAcc,
+    periods: BTreeMap<String, CostAggregateAcc>,
+    efforts: BTreeMap<Option<String>, ModelEffortAcc>,
+    model_observed: i64,
+    model_requested: i64,
+}
+
+/// Wire the whole « By model » tree: Model → Effort → Pipeline → Node, ranked by
+/// cost at every level. Every level carries `by_period` so the harness-stacked
+/// bars follow the drill.
+fn wire_by_model(models: BTreeMap<String, ModelAcc>) -> Vec<StatsModelCostEntity> {
+    let mut rows: Vec<StatsModelCostEntity> = models
+        .into_iter()
+        .map(|(model, acc)| {
+            let mut efforts: Vec<StatsEffortCostEntity> = acc
+                .efforts
+                .into_iter()
+                .map(|(effort, effort_acc)| {
+                    let mut pipelines: Vec<StatsCostEntity> = effort_acc
+                        .pipelines
+                        .into_iter()
+                        .map(|(id, pipeline_acc)| {
+                            let mut entity = wire_cost_entity(id, pipeline_acc.entity);
+                            let mut nodes: Vec<StatsCostEntity> = pipeline_acc
+                                .nodes
+                                .into_iter()
+                                .map(|(id, node)| wire_cost_entity(id, node))
+                                .collect();
+                            nodes.sort_by(|a, b| {
+                                cost_then_id(a.aggregate.usd, &a.id, b.aggregate.usd, &b.id)
+                            });
+                            entity.nodes = nodes;
+                            entity
+                        })
+                        .collect();
+                    pipelines.sort_by(|a, b| {
+                        cost_then_id(a.aggregate.usd, &a.id, b.aggregate.usd, &b.id)
+                    });
+                    StatsEffortCostEntity {
+                        entity: StatsCostEntity {
+                            id: effort.clone().unwrap_or_default(),
+                            name: effort.clone().unwrap_or_else(|| "not set".to_string()),
+                            aggregate: effort_acc.aggregate.wire(),
+                            by_period: wire_periods(effort_acc.periods),
+                            nodes: Vec::new(),
+                            models: Vec::new(),
+                        },
+                        provenance: effort.as_ref().map(|_| {
+                            provenance(effort_acc.effort_observed, effort_acc.effort_requested)
+                        }),
+                        effort,
+                        pipelines,
+                    }
+                })
+                .collect();
+            efforts.sort_by(|a, b| {
+                cost_then_id(
+                    a.entity.aggregate.usd,
+                    &a.entity.id,
+                    b.entity.aggregate.usd,
+                    &b.entity.id,
+                )
+            });
+            StatsModelCostEntity {
+                entity: StatsCostEntity {
+                    id: model.clone(),
+                    name: model,
+                    aggregate: acc.aggregate.wire(),
+                    by_period: wire_periods(acc.periods),
+                    nodes: Vec::new(),
+                    models: Vec::new(),
+                },
+                provenance: provenance(acc.model_observed, acc.model_requested),
+                efforts,
+            }
+        })
+        .collect();
+    rows.sort_by(|a, b| {
+        cost_then_id(
+            a.entity.aggregate.usd,
+            &a.entity.id,
+            b.entity.aggregate.usd,
+            &b.entity.id,
+        )
+    });
+    rows
 }
 
 #[derive(Debug, Clone, Default)]
@@ -783,6 +1070,7 @@ fn wire_cost_entity(id: String, entity: CostEntityAcc) -> StatsCostEntity {
         aggregate: entity.aggregate.wire(),
         by_period: wire_periods(entity.periods),
         nodes,
+        models: wire_pairs(entity.pairs),
     }
 }
 
@@ -840,6 +1128,7 @@ fn fold_harness_cost(runs: &[CostRunRow], resolved: Vec<ResolvedPriceRow>) -> St
     let mut periods = BTreeMap::<String, CostAggregateAcc>::new();
     let mut pipelines = BTreeMap::<String, CostEntityAcc>::new();
     let mut projects = BTreeMap::<String, CostProjectAcc>::new();
+    let mut models_axis = BTreeMap::<String, ModelAcc>::new();
     let mut active_harnesses = BTreeSet::new();
 
     for run in runs {
@@ -912,14 +1201,84 @@ fn fold_harness_cost(runs: &[CostRunRow], resolved: Vec<ResolvedPriceRow>) -> St
                 .or_default()
                 .add_contribution(contribution);
 
-            let project_node = project_pipeline.nodes.entry(id).or_default();
-            project_node.name = name;
+            let project_node = project_pipeline.nodes.entry(id.clone()).or_default();
+            project_node.name = name.clone();
             project_node.aggregate.add_contribution(contribution);
             project_node
                 .periods
                 .entry(run.bucket.clone())
                 .or_default()
                 .add_contribution(contribution);
+
+            // ADR-0065: the Node leaf's model × effort pairs, plus the whole
+            // « By model » tree — one pass over the same slices, the same node
+            // identity as the axes above. Slices land in every level of both
+            // hierarchies so headline, cards and period bars all re-scope.
+            for slice in &contribution.model_slices {
+                let pair_key = (slice.model.clone(), slice.effort.clone());
+                node.pairs
+                    .entry(pair_key.clone())
+                    .or_default()
+                    .add_slice(&contribution.harness, slice);
+                project_node
+                    .pairs
+                    .entry(pair_key)
+                    .or_default()
+                    .add_slice(&contribution.harness, slice);
+
+                let model = models_axis.entry(slice.model.clone()).or_default();
+                model.aggregate.add_slice(&contribution.harness, slice);
+                model
+                    .periods
+                    .entry(run.bucket.clone())
+                    .or_default()
+                    .add_slice(&contribution.harness, slice);
+                if slice.model_observed {
+                    model.model_observed += 1;
+                } else {
+                    model.model_requested += 1;
+                }
+
+                let effort = model.efforts.entry(slice.effort.clone()).or_default();
+                effort.aggregate.add_slice(&contribution.harness, slice);
+                effort
+                    .periods
+                    .entry(run.bucket.clone())
+                    .or_default()
+                    .add_slice(&contribution.harness, slice);
+                if slice.model_observed {
+                    effort.model_observed += 1;
+                } else {
+                    effort.model_requested += 1;
+                }
+                match slice.effort_observed {
+                    Some(true) => effort.effort_observed += 1,
+                    Some(false) => effort.effort_requested += 1,
+                    None => {}
+                }
+
+                let axis_pipeline = effort.pipelines.entry(run.pipeline_id.clone()).or_default();
+                axis_pipeline.entity.name = run.pipeline_name.clone();
+                axis_pipeline
+                    .entity
+                    .aggregate
+                    .add_slice(&contribution.harness, slice);
+                axis_pipeline
+                    .entity
+                    .periods
+                    .entry(run.bucket.clone())
+                    .or_default()
+                    .add_slice(&contribution.harness, slice);
+
+                let axis_node = axis_pipeline.nodes.entry(id.clone()).or_default();
+                axis_node.name = name.clone();
+                axis_node.aggregate.add_slice(&contribution.harness, slice);
+                axis_node
+                    .periods
+                    .entry(run.bucket.clone())
+                    .or_default()
+                    .add_slice(&contribution.harness, slice);
+            }
         }
     }
 
@@ -959,6 +1318,7 @@ fn fold_harness_cost(runs: &[CostRunRow], resolved: Vec<ResolvedPriceRow>) -> St
                     aggregate: project.aggregate.wire(),
                     by_period: wire_periods(project.periods),
                     nodes: Vec::new(),
+                    models: Vec::new(),
                 },
                 pipelines,
             }
@@ -980,6 +1340,7 @@ fn fold_harness_cost(runs: &[CostRunRow], resolved: Vec<ResolvedPriceRow>) -> St
         by_period: wire_periods(periods),
         by_pipeline,
         by_project,
+        by_model: wire_by_model(models_axis),
         resolved,
     }
 }
@@ -1461,6 +1822,7 @@ mod tests {
                     partial: true,
                     unpriced_models: vec!["claude-fable-5".to_string()],
                     unavailable_reasons: Vec::new(),
+                    model_slices: Vec::new(),
                 },
                 crate::run_cost::CostContribution {
                     harness: "future".to_string(),
@@ -1474,6 +1836,7 @@ mod tests {
                     partial: false,
                     unpriced_models: Vec::new(),
                     unavailable_reasons: vec!["harness has no cost source".to_string()],
+                    model_slices: Vec::new(),
                 },
             ],
         };
@@ -1519,6 +1882,286 @@ mod tests {
         let ov = compute_overview(&db, "%Y-%m-%d", FROM, TO).await.unwrap();
         assert_eq!(ov.runs.len(), 1);
         assert_eq!(ov.runs[0].count, 1);
+    }
+
+    // --- « By model » axis (ADR-0065, #735) ---
+
+    fn model_slice(
+        model: &str,
+        observed: bool,
+        effort: Option<&str>,
+        usd: Option<f64>,
+    ) -> crate::run_cost::ModelEffortSlice {
+        crate::run_cost::ModelEffortSlice {
+            model: model.to_string(),
+            model_observed: observed,
+            effort: effort.map(String::from),
+            effort_observed: effort.map(|_| false),
+            usd,
+            estimated: usd.is_some(),
+            partial: false,
+            executions: 1,
+            unpriced_models: Vec::new(),
+            missing_reasons: usd
+                .is_none()
+                .then(|| "no attributable Claude transcript".to_string())
+                .into_iter()
+                .collect(),
+        }
+    }
+
+    fn node_run_row(
+        bucket: &str,
+        node_id: &str,
+        node_name: &str,
+        contributions: Vec<crate::run_cost::CostContribution>,
+    ) -> CostRunRow {
+        CostRunRow {
+            bucket: bucket.to_string(),
+            pipeline_id: "p".to_string(),
+            pipeline_name: "Impl".to_string(),
+            project_id: "/repo".to_string(),
+            project_name: "repo".to_string(),
+            node_names: BTreeMap::from([(node_id.to_string(), node_name.to_string())]),
+            contributions,
+        }
+    }
+
+    fn claude_node_contribution(
+        node_id: &str,
+        usd: Option<f64>,
+        slices: Vec<crate::run_cost::ModelEffortSlice>,
+    ) -> crate::run_cost::CostContribution {
+        crate::run_cost::CostContribution {
+            harness: "claude".to_string(),
+            scope: crate::run_cost::CostScope::Node,
+            node_id: Some(node_id.to_string()),
+            executions: 1,
+            readable_executions: i64::from(usd.is_some()),
+            usd,
+            form: usd.map(|_| crate::event_log::CostForm::Derived),
+            reported_in_usd: false,
+            partial: false,
+            unpriced_models: Vec::new(),
+            unavailable_reasons: usd
+                .is_none()
+                .then(|| "no attributable Claude transcript".to_string())
+                .into_iter()
+                .collect(),
+            model_slices: slices,
+        }
+    }
+
+    #[test]
+    fn by_model_tree_ventilates_models_efforts_pipelines_nodes_and_names_provenance() {
+        // Run A: one execution, two observed models (opus@high, sonnet@medium).
+        let run_a = node_run_row(
+            "2026-09-01",
+            "n",
+            "Worker",
+            vec![claude_node_contribution(
+                "n",
+                Some(8.0),
+                vec![
+                    model_slice("claude-opus-4-8", true, Some("high"), Some(5.0)),
+                    model_slice("claude-sonnet-5", true, Some("medium"), Some(3.0)),
+                ],
+            )],
+        );
+        // Run B: a mute-source execution falling back to the requested sonnet@high.
+        let run_b = node_run_row(
+            "2026-09-02",
+            "n2",
+            "Other",
+            vec![claude_node_contribution(
+                "n2",
+                None,
+                vec![model_slice("claude-sonnet-5", false, Some("high"), None)],
+            )],
+        );
+
+        let stats = fold_harness_cost(&[run_a, run_b], Vec::new());
+        let models = &stats.by_model;
+        assert_eq!(
+            models
+                .iter()
+                .map(|m| m.entity.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["claude-opus-4-8", "claude-sonnet-5"],
+            "ranked by cost, ids verbatim"
+        );
+
+        let opus = &models[0];
+        assert_eq!(opus.provenance, StatsProvenance::Observed);
+        assert_eq!(opus.entity.aggregate.usd, Some(5.0));
+        assert_eq!(opus.entity.aggregate.executions, 1);
+
+        let sonnet = &models[1];
+        assert_eq!(
+            sonnet.provenance,
+            StatsProvenance::Mixed,
+            "one execution observed it, one fell back to the requested id"
+        );
+        assert_eq!(sonnet.entity.aggregate.usd, Some(3.0));
+        assert_eq!(
+            sonnet.entity.aggregate.executions, 2,
+            "one execution per bucket"
+        );
+        let effort_names: Vec<&str> = sonnet
+            .efforts
+            .iter()
+            .map(|e| e.entity.name.as_str())
+            .collect();
+        assert_eq!(effort_names, vec!["medium", "high"], "ranked by cost");
+        let medium = &sonnet.efforts[0];
+        assert_eq!(medium.entity.id, "medium");
+        assert_eq!(medium.effort.as_deref(), Some("medium"));
+        assert_eq!(medium.provenance, Some(StatsProvenance::Requested));
+        let pipeline = &medium.pipelines[0];
+        assert_eq!(pipeline.id, "p");
+        assert_eq!(pipeline.nodes.len(), 1);
+        assert_eq!(pipeline.nodes[0].name, "Worker");
+        let high = &sonnet.efforts[1];
+        assert_eq!(high.entity.aggregate.usd, None);
+        assert_eq!(high.entity.aggregate.unknown, 1);
+        assert_eq!(
+            high.entity.aggregate.missing_reasons,
+            vec!["no attributable Claude transcript"]
+        );
+        assert!(high.pipelines[0]
+            .nodes
+            .iter()
+            .any(|node| node.name == "Other"));
+
+        // The by_pipeline leaves carry the pairs; the by_model leaves do not.
+        let pipeline_row = stats.by_pipeline.iter().find(|row| row.id == "p").unwrap();
+        let worker = pipeline_row
+            .nodes
+            .iter()
+            .find(|node| node.id == "n")
+            .unwrap();
+        assert_eq!(worker.models.len(), 2);
+        let pair = &worker.models[0];
+        assert_eq!(pair.model, "claude-opus-4-8");
+        assert_eq!(pair.model_provenance, StatsProvenance::Observed);
+        assert_eq!(pair.effort.as_deref(), Some("high"));
+        assert_eq!(pair.effort_provenance, Some(StatsProvenance::Requested));
+        assert_eq!(pair.aggregate.usd, Some(5.0));
+        assert_eq!(pair.aggregate.harnesses[0].harness, "claude");
+        let other = pipeline_row
+            .nodes
+            .iter()
+            .find(|node| node.id == "n2")
+            .unwrap();
+        assert_eq!(other.models.len(), 1);
+        assert_eq!(other.models[0].model_provenance, StatsProvenance::Requested);
+    }
+
+    #[test]
+    fn by_model_keeps_not_set_effort_distinct_and_puts_a_dollar_value_on_it() {
+        // Infrastructure (leftover) sessions carry observed models but no effort.
+        let infra = crate::run_cost::CostContribution {
+            harness: "claude".to_string(),
+            scope: crate::run_cost::CostScope::Infrastructure,
+            node_id: None,
+            executions: 1,
+            readable_executions: 1,
+            usd: Some(2.0),
+            form: Some(crate::event_log::CostForm::Derived),
+            reported_in_usd: false,
+            partial: false,
+            unpriced_models: Vec::new(),
+            unavailable_reasons: Vec::new(),
+            model_slices: vec![model_slice("claude-opus-4-8", true, None, Some(2.0))],
+        };
+        let run = node_run_row("2026-09-01", "n", "Worker", vec![infra]);
+
+        let stats = fold_harness_cost(&[run], Vec::new());
+        let opus = stats
+            .by_model
+            .iter()
+            .find(|m| m.entity.id == "claude-opus-4-8")
+            .unwrap();
+        assert_eq!(opus.efforts.len(), 1);
+        let not_set = &opus.efforts[0];
+        assert_eq!(not_set.entity.id, "", "not set is the empty effort id");
+        assert_eq!(not_set.entity.name, "not set");
+        assert_eq!(not_set.effort, None);
+        assert_eq!(
+            not_set.provenance, None,
+            "not set has no provenance to show"
+        );
+        assert_eq!(not_set.entity.aggregate.usd, Some(2.0));
+        assert_eq!(not_set.pipelines[0].nodes[0].name, "Infrastructure");
+    }
+
+    #[test]
+    fn by_model_never_counts_a_harness_without_cost_source() {
+        let run = node_run_row(
+            "2026-09-01",
+            "n",
+            "Worker",
+            vec![crate::run_cost::CostContribution {
+                harness: "opencode".to_string(),
+                scope: crate::run_cost::CostScope::Node,
+                node_id: Some("n".to_string()),
+                executions: 1,
+                readable_executions: 0,
+                usd: None,
+                form: None,
+                reported_in_usd: false,
+                partial: false,
+                unpriced_models: Vec::new(),
+                unavailable_reasons: vec!["harness has no cost source".to_string()],
+                model_slices: Vec::new(),
+            }],
+        );
+        let stats = fold_harness_cost(&[run], Vec::new());
+        assert!(
+            stats.by_model.is_empty(),
+            "a harness without a cost source is absent, never a \"default of X\" bucket"
+        );
+        // The existing axes keep saying the absence.
+        assert_eq!(stats.total.unknown, 1);
+        assert_eq!(
+            stats.total.missing_reasons,
+            vec!["harness has no cost source"]
+        );
+    }
+
+    #[test]
+    fn by_model_periods_follow_the_drill_for_the_harness_bars() {
+        let run = node_run_row(
+            "2026-09-01",
+            "n",
+            "Worker",
+            vec![claude_node_contribution(
+                "n",
+                Some(5.0),
+                vec![model_slice(
+                    "claude-opus-4-8",
+                    true,
+                    Some("high"),
+                    Some(5.0),
+                )],
+            )],
+        );
+        let stats = fold_harness_cost(&[run], Vec::new());
+        let opus = &stats.by_model[0];
+        assert_eq!(opus.entity.by_period.len(), 1);
+        assert_eq!(opus.entity.by_period[0].bucket, "2026-09-01");
+        assert_eq!(opus.entity.by_period[0].aggregate.usd, Some(5.0));
+        assert_eq!(opus.efforts[0].entity.by_period[0].aggregate.usd, Some(5.0));
+        assert_eq!(
+            opus.efforts[0].pipelines[0].by_period[0].aggregate.usd,
+            Some(5.0)
+        );
+        assert_eq!(
+            opus.efforts[0].pipelines[0].nodes[0].by_period[0]
+                .aggregate
+                .usd,
+            Some(5.0)
+        );
     }
 
     #[test]

--- a/crates/pdo-daemon/tests/it.rs
+++ b/crates/pdo-daemon/tests/it.rs
@@ -29,6 +29,9 @@ mod cli_run_create;
 #[path = "cost_prices.rs"]
 mod cost_prices;
 
+#[path = "stats_cost_by_model.rs"]
+mod stats_cost_by_model;
+
 #[path = "update_apply.rs"]
 mod update_apply;
 #[path = "update_check.rs"]

--- a/crates/pdo-daemon/tests/orchestrator_binding.rs
+++ b/crates/pdo-daemon/tests/orchestrator_binding.rs
@@ -244,7 +244,7 @@ fn write_output(daemon: &TestDaemon, run_id: &str, node: &str, port: &str) {
         .join(".pdo")
         .join("artifacts")
         .join(node)
-        .join(format!("iter-1"))
+        .join("iter-1")
         .join(port);
     std::fs::create_dir_all(&dir).unwrap();
     std::fs::write(dir.join("output.md"), "done\n").unwrap();

--- a/crates/pdo-daemon/tests/stats_cost_by_model.rs
+++ b/crates/pdo-daemon/tests/stats_cost_by_model.rs
@@ -1,0 +1,296 @@
+//! Layer 3 (#735, ADR-0065) — the Stats › Cost « By model » axis, end to end
+//! through a real daemon.
+//!
+//! Two `claude` Runs execute the same worker Node with two different pinned
+//! models (the Feature Path): Run A pins the full id `claude-sonnet-5`, Run B
+//! pins the alias `opus` and plants **no transcript**, so its source is mute
+//! and the requested id shows up as its own `requested` row. Run A's session
+//! carries **two** models (the main one plus a subagent on another model), so
+//! the cost ventilates per message and the execution counts in each bucket.
+//!
+//! What is proven here rather than in unit tests (ADR-0004's règle d'or):
+//!   1. `GET /stats/cost` answers with a `by_model` tree: Model → Effort →
+//!      Pipeline → Node, ids verbatim, ranked by cost;
+//!   2. observed vs requested provenance rides the wire, and the alias pin and
+//!      the observed full id are two rows (ADR-0065 §2 — never merged);
+//!   3. a two-model session costs — and counts — in each bucket, the average
+//!      per execution staying coherent with the bucket's cost (ADR-0065 §3);
+//!   4. the Node leaves of `by_pipeline` carry the model × effort pairs, with
+//!      the effort marked requested.
+
+use crate::common::TestDaemon;
+use std::process::Command;
+
+fn tmux_available() -> bool {
+    Command::new("tmux")
+        .arg("-V")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn worker_yaml(name: &str, model: &str) -> String {
+    format!(
+        r#"name: {name}
+version: "1.0"
+nodes:
+  - id: start
+    name: Start
+    type: start
+    outputs:
+      - name: user_prompt
+  - id: worker
+    name: Worker
+    type: agent
+    isolated_worktree: false
+    pin_harness: claude
+    harnesses:
+      claude:
+        model: {model}
+        effort: high
+    inputs:
+      - {{ name: task, side: top }}
+    outputs:
+      - {{ name: out, side: bottom }}
+  - id: end
+    name: End
+    type: end
+    inputs:
+      - {{ name: result, side: top }}
+edges:
+  - source: {{ node: start, port: user_prompt }}
+    target: {{ node: worker, port: task }}
+  - source: {{ node: worker, port: out }}
+    target: {{ node: end, port: result }}
+"#
+    )
+}
+
+fn seed(repo: &std::path::Path) -> anyhow::Result<()> {
+    let pipelines = repo.join(".pdo").join("pipelines");
+    std::fs::create_dir_all(&pipelines)?;
+    for (name, model) in [("bymodel-a", "claude-sonnet-5"), ("bymodel-b", "opus")] {
+        std::fs::write(
+            pipelines.join(format!("{name}.yaml")),
+            worker_yaml(name, model),
+        )?;
+        let prompts = pipelines.join(format!("{name}.prompts"));
+        std::fs::create_dir_all(&prompts)?;
+        std::fs::write(prompts.join("worker.md"), "Work.\n")?;
+    }
+    let run = |args: &[&str]| -> anyhow::Result<()> {
+        let out = Command::new("git").args(args).current_dir(repo).output()?;
+        anyhow::ensure!(out.status.success(), "git {args:?} failed");
+        Ok(())
+    };
+    run(&["init", "-q", "-b", "main"])?;
+    run(&["config", "user.email", "t@example.com"])?;
+    run(&["config", "user.name", "Test"])?;
+    run(&["config", "commit.gpgsign", "false"])?;
+    std::fs::write(repo.join(".gitignore"), ".pdo/runs/\n")?;
+    run(&["add", "."])?;
+    run(&["commit", "-q", "-m", "init"])?;
+    Ok(())
+}
+
+async fn create_run(daemon: &TestDaemon, pipeline: &str) -> String {
+    let resp = reqwest::Client::new()
+        .post(format!("{}/runs", daemon.url()))
+        .json(&serde_json::json!({
+            "pipeline": pipeline,
+            "input": "go",
+            "target_repo": daemon.target_repo(),
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 201, "POST /runs should create the run");
+    resp.json::<serde_json::Value>().await.unwrap()["run_id"]
+        .as_str()
+        .unwrap()
+        .to_string()
+}
+
+/// Wait until `node_id`'s latest `node_started` carries the pinned model — the
+/// freeze the cost fold reads.
+async fn wait_for_started(daemon: &TestDaemon, run_id: &str, node_id: &str) {
+    for _ in 0..100 {
+        let evs: serde_json::Value = reqwest::get(format!("{}/runs/{run_id}/events", daemon.url()))
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        let started = evs
+            .as_array()
+            .unwrap()
+            .iter()
+            .rev()
+            .find(|e| e["kind"] == "node_started" && e["node_id"] == node_id);
+        if started
+            .and_then(|e| e["payload"]["model"].as_str())
+            .is_some()
+        {
+            return;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+    let evs: serde_json::Value = reqwest::get(format!("{}/runs/{run_id}/events", daemon.url()))
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    panic!("{node_id} should have started with a frozen model within the timeout; events: {evs}");
+}
+
+/// Plant a transcript for the run's shared worktree cwd, attributed to the
+/// node's pinned session — `lines` is the raw JSONL body.
+fn plant_session(daemon: &TestDaemon, run_id: &str, session_id: &str, lines: &[String]) {
+    let worktree = daemon
+        .repo_root()
+        .join(".pdo/runs")
+        .join(run_id)
+        .join("worktree");
+    let enc = pdo_daemon::stale_detector::encode_working_dir(&worktree);
+    let proj = daemon.repo_root().join(".claude/projects").join(enc);
+    std::fs::create_dir_all(&proj).unwrap();
+    std::fs::write(proj.join(format!("{session_id}.jsonl")), lines.join("\n")).unwrap();
+}
+
+fn assistant(id: &str, model: &str, input: u64) -> String {
+    format!(
+        "{{\"type\":\"assistant\",\"requestId\":\"r-{id}\",\"message\":{{\"id\":\"{id}\",\
+         \"model\":\"{model}\",\"usage\":{{\"input_tokens\":{input},\"output_tokens\":0}}}}}}"
+    )
+}
+
+async fn stats_cost(daemon: &TestDaemon) -> serde_json::Value {
+    reqwest::get(format!(
+        "{}/stats/cost?from=1970-01-01T00:00:00Z&to=2100-01-01T00:00:00Z&bucket=day",
+        daemon.url()
+    ))
+    .await
+    .unwrap()
+    .json()
+    .await
+    .unwrap()
+}
+
+#[tokio::test]
+async fn by_model_ventilates_observed_models_requested_fallback_and_node_pairs() {
+    if !tmux_available() {
+        return; // the node must actually spawn to freeze model/effort/session
+    }
+    // The home override puts `~/.claude` under the test's own tempdir —
+    // hermetic, no real `$HOME` touched (the seam the transcript plants read).
+    let daemon = TestDaemon::spawn_with_home_override(seed, Some("exec sleep 600".to_string()))
+        .await
+        .unwrap();
+
+    // Run A: pinned `claude-sonnet-5`, observed per message — plus a subagent
+    // turn on opus-4-8 in the SAME session (ADR-0065 §3: one execution, two
+    // buckets, each coherent with its own cost).
+    let run_a = create_run(&daemon, "bymodel-a").await;
+    wait_for_started(&daemon, &run_a, "worker").await;
+    let sid_a = daemon.pinned_session_id(&run_a, "worker").await;
+    // opus-4-8 5/25 · 1_000_000 in → $5.00 ; sonnet-5 3/15 · 1_000_000 → $3.00.
+    plant_session(
+        &daemon,
+        &run_a,
+        &sid_a,
+        &[
+            assistant("m1", "claude-sonnet-5", 1_000_000),
+            assistant("m2", "claude-opus-4-8", 1_000_000),
+        ],
+    );
+
+    // Run B: pinned the ALIAS `opus`, no transcript — the source is mute, the
+    // requested id falls back and is marked `requested` on the wire.
+    let run_b = create_run(&daemon, "bymodel-b").await;
+    wait_for_started(&daemon, &run_b, "worker").await;
+
+    let cost = stats_cost(&daemon).await;
+    let models = cost["by_model"].as_array().expect("by_model on the wire");
+    let ids: Vec<&str> = models.iter().filter_map(|m| m["id"].as_str()).collect();
+    assert_eq!(
+        ids,
+        vec!["claude-opus-4-8", "claude-sonnet-5", "opus"],
+        "ranked by cost; the alias pin and the observed full id are two rows"
+    );
+
+    let opus = &models[0];
+    assert_eq!(opus["provenance"], "observed");
+    assert_eq!(opus["usd"], 5.0);
+    assert_eq!(opus["executions"], 1);
+    assert_eq!(opus["average_usd"], 5.0);
+    // Model → Effort → Pipeline → Node, ids verbatim at every level.
+    let efforts = opus["efforts"].as_array().unwrap();
+    assert_eq!(efforts.len(), 1);
+    assert_eq!(efforts[0]["id"], "high");
+    assert_eq!(
+        efforts[0]["provenance"], "requested",
+        "claude's source never writes the effort"
+    );
+    let pipelines = efforts[0]["pipelines"].as_array().unwrap();
+    assert_eq!(pipelines[0]["id"], "bymodel-a");
+    assert!(pipelines[0]["nodes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|n| n["name"] == "Worker"));
+
+    let sonnet = &models[1];
+    assert_eq!(sonnet["provenance"], "observed");
+    assert_eq!(sonnet["usd"], 3.0);
+
+    let alias = &models[2];
+    assert_eq!(alias["id"], "opus");
+    assert_eq!(
+        alias["provenance"], "requested",
+        "a mute source marks the fallback"
+    );
+    assert!(alias["usd"].is_null(), "no reading, never an invented $0");
+    assert_eq!(alias["unknown"], 1);
+
+    // The Node leaves of by_pipeline end the drill with model × effort pairs.
+    let pipeline = cost["by_pipeline"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|row| row["id"] == "bymodel-a")
+        .expect("run A's pipeline");
+    let worker = pipeline["nodes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|n| n["name"] == "Worker")
+        .expect("the worker Node");
+    let pairs = worker["models"]
+        .as_array()
+        .expect("Node leaves carry pairs");
+    let pair_ids: Vec<&str> = pairs.iter().filter_map(|p| p["model"].as_str()).collect();
+    assert_eq!(
+        pair_ids,
+        vec!["claude-opus-4-8", "claude-sonnet-5"],
+        "the two-model session ventilates into two pairs"
+    );
+    for pair in pairs {
+        assert_eq!(pair["effort"], "high");
+        assert_eq!(pair["effort_provenance"], "requested");
+        assert_eq!(pair["model_provenance"], "observed");
+        assert_eq!(pair["executions"], 1, "the execution counts in each bucket");
+    }
+    let opus_pair = pairs
+        .iter()
+        .find(|p| p["model"] == "claude-opus-4-8")
+        .unwrap();
+    assert_eq!(opus_pair["usd"], 5.0);
+
+    // The pipeline axes stay untouched in shape: the totals still sum both runs.
+    let total = &cost["total"];
+    assert_eq!(total["usd"], 8.0);
+    // Two honest gaps: run B's unreadable node, and the infrastructure slice
+    // neither run can attribute (each node's transcript owns its lines).
+    assert_eq!(total["unknown"], 2);
+}

--- a/frontend/src/App.settingsClose.test.tsx
+++ b/frontend/src/App.settingsClose.test.tsx
@@ -295,6 +295,7 @@ vi.mock("./api", () => {
         total: emptyAggregate,
         by_period: [],
         by_pipeline: [],
+        by_model: [],
         by_project: [],
         resolved: [],
       }),
@@ -303,6 +304,7 @@ vi.mock("./api", () => {
         total: { harnesses: [] },
         infrastructure_total: { harnesses: [] },
         by_pipeline: [],
+        by_model: [],
         infrastructure: [],
       }),
       syncCostPrices: vi.fn().mockResolvedValue({

--- a/frontend/src/components/StatsCharts.test.tsx
+++ b/frontend/src/components/StatsCharts.test.tsx
@@ -6,6 +6,7 @@ import StatsCharts from "./StatsCharts";
 import type {
   StatsCost,
   StatsHarnessCost,
+  StatsModelEffortPair,
   StatsOverview,
   StatsPerformance,
 } from "../types";
@@ -29,6 +30,7 @@ const EMPTY_COST: StatsCost = {
   },
   by_period: [],
   by_pipeline: [],
+  by_model: [],
   by_project: [],
   resolved: [],
 };
@@ -207,6 +209,129 @@ const COST: StatsCost = {
   ],
 };
 COST.by_project[0].pipelines = [COST.by_pipeline[0]];
+
+// The « By model » axis (#735, ADR-0065). One requested model (the alias pin
+// "sonnet") beside one observed one, each with its effort tree — including the
+// "not set" bucket — and the Node leaves of by_pipeline carrying pairs.
+const MODEL_PAIR: StatsModelEffortPair = {
+  model: "claude-opus-4-8",
+  model_provenance: "observed",
+  effort: "high",
+  effort_provenance: "requested",
+  usd: 2,
+  average_usd: 2,
+  estimated: true,
+  partial: false,
+  executions: 1,
+  readable: 1,
+  unknown: 0,
+  unpriced_models: [],
+  missing_reasons: [],
+  harnesses: [COST_HARNESSES[0]],
+};
+
+const effortEntity = (
+  id: string,
+  usd: number | null,
+  provenance: StatsModelEffortPair["effort_provenance"],
+) => ({
+  id,
+  name: id === "" ? "not set" : id,
+  effort: id === "" ? null : id,
+  provenance,
+  usd,
+  average_usd: usd,
+  estimated: true,
+  partial: false,
+  executions: 1,
+  readable: usd === null ? 0 : 1,
+  unknown: usd === null ? 1 : 0,
+  unpriced_models: [],
+  missing_reasons: usd === null ? ["no attributable Claude transcript"] : [],
+  harnesses: [],
+  by_period: [],
+  nodes: [],
+  models: [],
+  pipelines: [
+    {
+      id: "pipe-technical-id",
+      name: "Implement loop",
+      usd,
+      average_usd: usd,
+      estimated: true,
+      partial: false,
+      executions: 1,
+      readable: usd === null ? 0 : 1,
+      unknown: usd === null ? 1 : 0,
+      unpriced_models: [],
+      missing_reasons: [],
+      harnesses: [],
+      by_period: [],
+      models: [],
+      nodes: [
+        {
+          id: "node-under-model-id",
+          name: "Review",
+          usd,
+          average_usd: usd,
+          estimated: true,
+          partial: false,
+          executions: 1,
+          readable: usd === null ? 0 : 1,
+          unknown: usd === null ? 1 : 0,
+          unpriced_models: [],
+          missing_reasons: [],
+          harnesses: [],
+          by_period: [],
+          nodes: [],
+          models: [],
+        },
+      ],
+    },
+  ],
+});
+
+COST.by_model = [
+  {
+    id: "sonnet",
+    name: "sonnet",
+    provenance: "requested",
+    usd: 5,
+    average_usd: 5,
+    estimated: true,
+    partial: false,
+    executions: 2,
+    readable: 2,
+    unknown: 0,
+    unpriced_models: [],
+    missing_reasons: [],
+    harnesses: [],
+    by_period: [],
+    nodes: [],
+    models: [],
+    efforts: [effortEntity("high", 4, "requested"), effortEntity("", null, null)],
+  },
+  {
+    id: "claude-opus-4-8",
+    name: "claude-opus-4-8",
+    provenance: "observed",
+    usd: 4,
+    average_usd: 4,
+    estimated: true,
+    partial: false,
+    executions: 1,
+    readable: 1,
+    unknown: 0,
+    unpriced_models: [],
+    missing_reasons: [],
+    harnesses: [],
+    by_period: [],
+    nodes: [],
+    models: [],
+    efforts: [effortEntity("high", 4, "requested")],
+  },
+];
+COST.by_pipeline[0].nodes[1].models = [MODEL_PAIR];
 
 const OVERVIEW: StatsOverview = {
   buckets: ["2026-08-27"],
@@ -412,6 +537,151 @@ describe("StatsCharts — harness drill-down (#638)", () => {
       "Total / PDO / Implement loop",
     );
     expect(screen.getByText("Review")).toBeInTheDocument();
+  });
+});
+
+describe("StatsCharts — Cost « By model » (#735, ADR-0065)", () => {
+  it("offers the three groupings; choosing By model resets the drill and marks provenance", async () => {
+    const user = userEvent.setup();
+    render(<StatsCharts tab="cost" overview={null} cost={COST} costError={null} />);
+
+    const grouping = screen.getByRole("combobox", { name: "Cost grouping" });
+    const options = within(grouping).getAllByRole("option");
+    expect(options.map((option) => option.textContent)).toEqual([
+      "By pipeline",
+      "By project",
+      "By model",
+    ]);
+
+    // A selection made on another axis does not survive the switch.
+    await user.click(screen.getByRole("option", { name: /Implement loop/ }));
+    await user.selectOptions(grouping, "model");
+    expect(screen.getByTestId("stats-cost-breadcrumb")).toHaveTextContent("Total");
+    const modelRows = screen.getAllByTestId("stats-detail-row");
+    expect(modelRows[0]).toHaveTextContent("sonnet");
+    expect(modelRows[1]).toHaveTextContent("claude-opus-4-8");
+    // Only the requested model carries the « ? » — the observed one is the norm.
+    expect(within(modelRows[0]).getAllByTestId("stats-provenance-model")).toHaveLength(1);
+    expect(
+      within(modelRows[1]).queryAllByTestId("stats-provenance-model"),
+    ).toHaveLength(0);
+    // The axis hint, only on By model.
+    expect(screen.getByText(/Model ids verbatim, one row per id/i)).toBeInTheDocument();
+  });
+
+  it("drills model → effort → pipeline → node and pops back through the crumbs", async () => {
+    const user = userEvent.setup();
+    render(<StatsCharts tab="cost" overview={null} cost={COST} costError={null} />);
+    await user.selectOptions(screen.getByRole("combobox", { name: "Cost grouping" }), "model");
+
+    await user.click(screen.getByRole("option", { name: /sonnet/ }));
+    expect(screen.getByTestId("stats-cost-breadcrumb")).toHaveTextContent(
+      "Total / sonnet",
+    );
+    expect(screen.getByText("not set")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Open high" }));
+    expect(screen.getByTestId("stats-cost-breadcrumb")).toHaveTextContent(
+      "Total / sonnet / high",
+    );
+    await user.click(screen.getByRole("button", { name: "Open Implement loop" }));
+    expect(screen.getByTestId("stats-cost-breadcrumb")).toHaveTextContent(
+      "Total / sonnet / high / Implement loop",
+    );
+    expect(screen.getAllByTestId("stats-detail-row")[0]).toHaveTextContent("Review");
+    // Node leaves are the floor: no chevron on the model axis.
+    expect(screen.queryByTestId("stats-node-toggle")).not.toBeInTheDocument();
+
+    // Clicking the effort crumb drops the pipeline; Total resets everything.
+    await user.click(screen.getByRole("button", { name: "Back to high" }));
+    expect(screen.getByTestId("stats-cost-breadcrumb")).toHaveTextContent(
+      "Total / sonnet / high",
+    );
+    expect(screen.getByRole("button", { name: "Open Implement loop" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Back to Total" }));
+    expect(screen.getByTestId("stats-cost-breadcrumb")).toHaveTextContent(/^Total$/);
+    expect(screen.getAllByTestId("stats-detail-row")[0]).toHaveTextContent("sonnet");
+  });
+
+  it("keeps the not-set effort a bucket of its own and explains it on hover", async () => {
+    const user = userEvent.setup();
+    render(<StatsCharts tab="cost" overview={null} cost={COST} costError={null} />);
+    await user.selectOptions(screen.getByRole("combobox", { name: "Cost grouping" }), "model");
+    await user.click(screen.getByRole("option", { name: /sonnet/ }));
+
+    const rows = screen.getAllByTestId("stats-detail-row");
+    expect(rows[0]).toHaveTextContent("high");
+    expect(rows[1]).toHaveTextContent("not set");
+    expect(
+      rows.filter((row) => within(row).queryAllByText(/not set/).length > 0),
+    ).toHaveLength(1);
+    await user.hover(within(rows[1]).getByText("not set"));
+    expect(await screen.findByTestId("tooltip-content")).toHaveTextContent(
+      "no effort requested at node startup nor observed in transcripts",
+    );
+  });
+
+  it("expands Node leaves into model × effort pairs on By pipeline, not on By model", async () => {
+    const user = userEvent.setup();
+    render(<StatsCharts tab="cost" overview={null} cost={COST} costError={null} />);
+
+    await user.click(screen.getByRole("option", { name: /Implement loop/ }));
+    const rows = screen.getAllByTestId("stats-detail-row");
+    const review = rows.find((row) => row.textContent?.includes("Review"))!;
+    const build = rows.find((row) => row.textContent?.includes("Build"))!;
+    // Only the Node with pairs carries a chevron.
+    expect(within(review).getByTestId("stats-node-toggle")).toBeInTheDocument();
+    expect(within(build).queryByTestId("stats-node-toggle")).not.toBeInTheDocument();
+
+    await user.click(within(review).getByTestId("stats-node-toggle"));
+    const pairRows = screen.getAllByTestId("stats-model-effort-row");
+    expect(pairRows).toHaveLength(1);
+    expect(pairRows[0]).toHaveTextContent(/claude-opus-4-8\s*·\s*high/);
+    expect(pairRows[0]).toHaveTextContent("~$2.00");
+    // The pair's effort is requested: it carries the mark, the model does not.
+    expect(within(pairRows[0]).getAllByTestId("stats-provenance-effort")).toHaveLength(1);
+    expect(
+      within(pairRows[0]).queryAllByTestId("stats-provenance-model"),
+    ).toHaveLength(0);
+
+    // Under By model the model × effort path IS the drill: no chevrons anywhere.
+    await user.selectOptions(screen.getByRole("combobox", { name: "Cost grouping" }), "model");
+    await user.click(screen.getByRole("option", { name: /sonnet/ }));
+    await user.click(screen.getByRole("button", { name: "Open high" }));
+    await user.click(screen.getByRole("button", { name: "Open Implement loop" }));
+    expect(screen.queryByTestId("stats-node-toggle")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("stats-model-effort-row")).not.toBeInTheDocument();
+  });
+
+  it("reads per execution on the model axis and per Run at Total on By pipeline", async () => {
+    const user = userEvent.setup();
+    render(<StatsCharts tab="cost" overview={null} cost={COST} costError={null} />);
+
+    const headline = screen.getByTestId("stats-selection-headline");
+    expect(headline).toHaveTextContent("per Run");
+
+    await user.selectOptions(screen.getByRole("combobox", { name: "Cost grouping" }), "model");
+    expect(headline).toHaveTextContent("per execution");
+
+    // Back on By pipeline, the Node level counts executions; Total counts Runs.
+    await user.selectOptions(screen.getByRole("combobox", { name: "Cost grouping" }), "pipeline");
+    await user.click(screen.getByRole("option", { name: /Implement loop/ }));
+    expect(headline).toHaveTextContent("per execution");
+    await user.click(screen.getByRole("button", { name: "Back to Total" }));
+    expect(headline).toHaveTextContent("per Run");
+  });
+
+  it("never says « real » — the vocabulary is observed/requested", async () => {
+    const user = userEvent.setup();
+    render(<StatsCharts tab="cost" overview={null} cost={COST} costError={null} />);
+    await user.selectOptions(screen.getByRole("combobox", { name: "Cost grouping" }), "model");
+    await user.click(screen.getByRole("option", { name: /sonnet/ }));
+
+    for (const mark of screen.getAllByTestId("stats-provenance-effort")) {
+      expect(mark.getAttribute("aria-label")).toMatch(/requested at node startup/);
+      expect(mark.getAttribute("aria-label")).not.toMatch(/\breal\b/);
+    }
+    expect(document.body.textContent).not.toMatch(/\breal\b/);
   });
 });
 

--- a/frontend/src/components/StatsCharts.tsx
+++ b/frontend/src/components/StatsCharts.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { Fragment, useMemo, useState } from "react";
 import { ChevronDown, ChevronRight } from "lucide-react";
 import {
   Bar,
@@ -15,8 +15,11 @@ import type {
   StatsCostAggregate,
   StatsCostEntity,
   StatsCostPeriod,
+  StatsEffortCostEntity,
   StatsHarnessCost,
+  StatsModelEffortPair,
   StatsOverview,
+  StatsProvenance,
   StatsDistribution,
   StatsPerformance,
   StatsPerformanceAggregate,
@@ -186,12 +189,15 @@ function MasterList<T extends { id: string; name: string }>({
   valueLabel,
   onSelect,
   ariaLabel = "Spenders",
+  monoName = false,
 }: {
   rows: T[];
   selected: string | null;
   valueLabel: (row: T) => string;
   onSelect: (id: string | null) => void;
   ariaLabel?: string;
+  /** Model ids are ids — render them mono (ADR-0065 §2). */
+  monoName?: boolean;
 }) {
   const options = [{ id: "__total__", name: "Total" } as T, ...rows];
   const selectedIndex = Math.max(
@@ -237,7 +243,7 @@ function MasterList<T extends { id: string; name: string }>({
             }`}
             style={{ fontSize: "11.5px" }}
           >
-            <span className="truncate">{row.name}</span>
+            <span className={`truncate ${monoName ? "font-mono" : ""}`}>{row.name}</span>
             <span className="shrink-0 font-mono text-fg-2">
               {row.id === "__total__" ? "" : valueLabel(row)}
             </span>
@@ -430,18 +436,131 @@ function CostCell({
   );
 }
 
+/** Where a requested value was read from — the « ? » tooltip copy (ADR-0065 §1).
+ *  Observed values are the norm and carry nothing; the vocabulary never says
+ *  "real". */
+const PROVENANCE_COPY: Record<Exclude<StatsProvenance, "observed">, string> = {
+  requested: "requested at node startup, not observed in transcripts",
+  mixed: "partly requested at node startup, not observed in every transcript",
+};
+
+/** Hovering the italic "not set" effort says why the bucket exists. */
+const NOT_SET_COPY = "no effort requested at node startup nor observed in transcripts";
+
+function ProvenanceMark({
+  provenance,
+  target,
+}: {
+  provenance: Exclude<StatsProvenance, "observed">;
+  target: "model" | "effort";
+}) {
+  const copy = PROVENANCE_COPY[provenance];
+  return (
+    <Tooltip content={copy} side="top">
+      <button
+        type="button"
+        aria-label={copy}
+        data-testid={`stats-provenance-${target}`}
+        className="ml-0.5 align-super text-fg-4 hover:text-fg-2"
+        style={{ fontSize: "8.5px" }}
+      >
+        ?
+      </button>
+    </Tooltip>
+  );
+}
+
+function Breadcrumb({
+  crumbs,
+}: {
+  crumbs: { label: string; onClick?: () => void }[];
+}) {
+  return (
+    <div
+      className="mb-3 text-fg-4"
+      style={{ fontSize: "10.5px" }}
+      data-testid="stats-cost-breadcrumb"
+    >
+      {crumbs.map((crumb, index) => (
+        <span key={`${crumb.label}-${index}`}>
+          {index > 0 ? " / " : ""}
+          {crumb.onClick ? (
+            <button
+              type="button"
+              aria-label={`Back to ${crumb.label}`}
+              onClick={crumb.onClick}
+              className="hover:text-fg-2 underline decoration-dotted underline-offset-2"
+            >
+              {crumb.label}
+            </button>
+          ) : (
+            <span className="text-fg-3">{crumb.label}</span>
+          )}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function pairMetric(pair: StatsModelEffortPair): StatsHarnessCost {
+  return {
+    harness: "total",
+    usd: pair.usd,
+    estimated: pair.estimated,
+    partial: pair.partial,
+    executions: pair.executions,
+    readable: pair.readable,
+    unknown: pair.unknown,
+    average_usd: pair.average_usd,
+    unpriced_models: pair.unpriced_models,
+    missing_reasons: pair.missing_reasons,
+  };
+}
+
+function effortNameCell(row: StatsEffortCostEntity): React.ReactNode {
+  if (row.effort === null) {
+    // The "not set" bucket: hovering the italic word explains it (ADR-0065 §1).
+    // A plain span — the row-name button around it stays the single interactive
+    // element, and the tooltip is a description, not a second control.
+    return (
+      <Tooltip content={NOT_SET_COPY} side="top">
+        <span className="italic text-fg-4">not set</span>
+      </Tooltip>
+    );
+  }
+  return (
+    <span className="inline-flex items-baseline gap-0.5">
+      {row.name}
+      {row.provenance && row.provenance !== "observed" && (
+        <ProvenanceMark provenance={row.provenance} target="effort" />
+      )}
+    </span>
+  );
+}
+
 function CostTable({
   rows,
   harnesses,
   unit,
   onOpen,
+  renderName,
+  expandablePairs = false,
 }: {
   rows: StatsCostEntity[];
   harnesses: string[];
   unit: "Run" | "execution";
   onOpen?: (row: StatsCostEntity) => void;
+  /** Replaces the default (button-or-plain) name cell — the model axis marks
+   *  provenance and renders "not set" in its own voice. */
+  renderName?: (row: StatsCostEntity) => React.ReactNode;
+  /** Node rows gain a chevron unfolding their model × effort pairs (ADR-0065).
+   *  Off on the model axis, where the model × effort path is already the drill. */
+  expandablePairs?: boolean;
 }) {
   const sorted = [...rows].sort((a, b) => (b.usd ?? -1) - (a.usd ?? -1));
+  // Expansion state lives HERE and dies with the table: the parent keys the
+  // table on the drill path, so a stale expanded set never leaks across Nodes.
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
   return (
     <TooltipProvider>
       <table className="w-full table-fixed text-left" style={{ fontSize: "11px" }}>
@@ -463,59 +582,143 @@ function CostTable({
           </tr>
         </thead>
         <tbody>
-          {sorted.map((row) => (
-            <tr
-              key={row.id}
-              className="border-t border-line text-fg-2"
-              tabIndex={0}
-              data-testid="stats-detail-row"
-            >
-              <td className="py-2 pr-2">
-                {onOpen ? (
-                  <button
-                    type="button"
-                    aria-label={`Open ${row.name}`}
-                    onClick={() => onOpen(row)}
-                    className="text-left hover:text-fg"
-                  >
-                    {row.name}
-                  </button>
-                ) : (
-                  row.name
-                )}
-              </td>
-              <td className="py-2 text-right">
-                <CostCell
-                  unit={unit}
-                  metric={{
-                    harness: "total",
-                    usd: row.usd,
-                    estimated: row.estimated,
-                    partial: row.partial,
-                    executions: row.executions,
-                    readable: row.readable,
-                    unknown: row.unknown,
-                    average_usd: row.average_usd,
-                    unpriced_models: row.unpriced_models,
-                    missing_reasons: row.missing_reasons,
-                  }}
-                />
-              </td>
-              {harnesses.map((harness) => (
-                <td key={harness} className="py-2 text-right">
-                  <CostCell
-                    unit={unit}
-                    metric={row.harnesses.find((item) => item.harness === harness)}
-                  />
-                </td>
-              ))}
-            </tr>
-          ))}
+          {sorted.map((row) => {
+            const pairs = expandablePairs ? (row.models ?? []) : [];
+            return (
+              <Fragment key={row.id}>
+                <tr
+                  className="border-t border-line text-fg-2"
+                  tabIndex={0}
+                  data-testid="stats-detail-row"
+                >
+                  <td className="py-2 pr-2">
+                    <span className="inline-flex items-center gap-1">
+                      {pairs.length > 0 ? (
+                        <button
+                          type="button"
+                          aria-label={`${expanded.has(row.id) ? "Collapse" : "Expand"} ${row.name} models`}
+                          data-testid="stats-node-toggle"
+                          onClick={() =>
+                            setExpanded((current) => {
+                              const next = new Set(current);
+                              if (next.has(row.id)) next.delete(row.id);
+                              else next.add(row.id);
+                              return next;
+                            })
+                          }
+                          className="shrink-0 hover:text-fg"
+                        >
+                          {expanded.has(row.id) ? (
+                            <ChevronDown size={12} />
+                          ) : (
+                            <ChevronRight size={12} />
+                          )}
+                        </button>
+                      ) : null}
+                      {(() => {
+                        const content = renderName ? renderName(row) : row.name;
+                        return onOpen ? (
+                          <button
+                            type="button"
+                            aria-label={`Open ${row.name}`}
+                            onClick={() => onOpen(row)}
+                            className="text-left hover:text-fg"
+                          >
+                            {content}
+                          </button>
+                        ) : (
+                          <span>{content}</span>
+                        );
+                      })()}
+                    </span>
+                  </td>
+                  <td className="py-2 text-right">
+                    <CostCell
+                      unit={unit}
+                      metric={{
+                        harness: "total",
+                        usd: row.usd,
+                        estimated: row.estimated,
+                        partial: row.partial,
+                        executions: row.executions,
+                        readable: row.readable,
+                        unknown: row.unknown,
+                        average_usd: row.average_usd,
+                        unpriced_models: row.unpriced_models,
+                        missing_reasons: row.missing_reasons,
+                      }}
+                    />
+                  </td>
+                  {harnesses.map((harness) => (
+                    <td key={harness} className="py-2 text-right">
+                      <CostCell
+                        unit={unit}
+                        metric={row.harnesses.find((item) => item.harness === harness)}
+                      />
+                    </td>
+                  ))}
+                </tr>
+                {expanded.has(row.id)
+                  ? pairs.map((pair) => (
+                      <tr
+                        key={`${row.id}-${pair.model}-${pair.effort ?? ""}`}
+                        className="border-t border-line bg-bg-3/40 text-fg-3"
+                        data-testid="stats-model-effort-row"
+                      >
+                        <td className="py-2 pl-7 pr-2">
+                          <span className="inline-flex items-baseline gap-0.5">
+                            <span className="font-mono">{pair.model}</span>
+                            {pair.model_provenance !== "observed" && (
+                              <ProvenanceMark
+                                provenance={pair.model_provenance}
+                                target="model"
+                              />
+                            )}
+                            <span className="text-fg-4">·</span>
+                            {pair.effort === null ? (
+                              <Tooltip content={NOT_SET_COPY} side="top">
+                                <span className="italic text-fg-4">not set</span>
+                              </Tooltip>
+                            ) : (
+                              <span className="inline-flex items-baseline gap-0.5">
+                                {pair.effort}
+                                {pair.effort_provenance &&
+                                  pair.effort_provenance !== "observed" && (
+                                    <ProvenanceMark
+                                      provenance={pair.effort_provenance}
+                                      target="effort"
+                                    />
+                                  )}
+                              </span>
+                            )}
+                          </span>
+                        </td>
+                        <td className="py-2 text-right">
+                          <CostCell unit={unit} metric={pairMetric(pair)} />
+                        </td>
+                        {harnesses.map((harness) => (
+                          <td key={harness} className="py-2 text-right">
+                            <CostCell
+                              unit={unit}
+                              metric={pair.harnesses.find(
+                                (item) => item.harness === harness,
+                              )}
+                            />
+                          </td>
+                        ))}
+                      </tr>
+                    ))
+                  : null}
+              </Fragment>
+            );
+          })}
         </tbody>
       </table>
     </TooltipProvider>
   );
 }
+
+type CostAxis = "pipeline" | "project" | "model";
 
 function CostTab({
   cost,
@@ -524,9 +727,15 @@ function CostTab({
   cost: StatsCost | null;
   error: string | null;
 }) {
-  const [axis, setAxis] = useState<"pipeline" | "project">("pipeline");
+  const [axis, setAxis] = useState<CostAxis>("pipeline");
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [drilledPipelineId, setDrilledPipelineId] = useState<string | null>(null);
+  // The model axis drills Model → Effort → Pipeline → Node (ADR-0065). The
+  // effort id is "" for the "not set" bucket, so selection is `null` vs value,
+  // never falsy-compared.
+  const [selectedModelId, setSelectedModelId] = useState<string | null>(null);
+  const [selectedEffortId, setSelectedEffortId] = useState<string | null>(null);
+  const [selectedPipelineId, setSelectedPipelineId] = useState<string | null>(null);
 
   if (error) {
     return (
@@ -537,35 +746,128 @@ function CostTab({
   }
   if (!cost) return <EmptyNote>Loading cost…</EmptyNote>;
 
-  const rows = axis === "pipeline" ? cost.by_pipeline : cost.by_project;
-  const selected = rows.find((row) => row.id === selectedId) ?? null;
+  const toTotal = () => {
+    setSelectedId(null);
+    setDrilledPipelineId(null);
+    setSelectedModelId(null);
+    setSelectedEffortId(null);
+    setSelectedPipelineId(null);
+  };
+
+  // Model axis: resolve the drill path.
+  const model =
+    axis === "model"
+      ? (cost.by_model.find((row) => row.id === selectedModelId) ?? null)
+      : null;
+  const effort =
+    model && selectedEffortId !== null
+      ? (model.efforts.find((row) => row.id === selectedEffortId) ?? null)
+      : null;
+  const modelPipeline =
+    effort && selectedPipelineId !== null
+      ? (effort.pipelines.find((row) => row.id === selectedPipelineId) ?? null)
+      : null;
+
+  const rows: StatsCostEntity[] =
+    axis === "pipeline"
+      ? cost.by_pipeline
+      : axis === "project"
+        ? cost.by_project
+        : cost.by_model;
+  const selected =
+    axis === "model" ? null : (rows.find((row) => row.id === selectedId) ?? null);
   const drilledPipeline =
     axis === "project" && selected
-      ? (selected as StatsProjectCostEntity).pipelines.find(
+      ? ((selected as StatsProjectCostEntity).pipelines.find(
           (pipeline) => pipeline.id === drilledPipelineId,
-        ) ?? null
+        ) ?? null)
       : null;
-  const aggregate = drilledPipeline ?? selected ?? cost.total;
-  const periods = drilledPipeline
-    ? drilledPipeline.by_period
-    : selected
-      ? selected.by_period
-      : cost.by_period;
+
+  const aggregate =
+    axis === "model"
+      ? (modelPipeline ?? effort ?? model ?? cost.total)
+      : (drilledPipeline ?? selected ?? cost.total);
+  const periods =
+    axis === "model"
+      ? (modelPipeline ?? effort ?? model)?.by_period ?? cost.by_period
+      : drilledPipeline
+        ? drilledPipeline.by_period
+        : selected
+          ? selected.by_period
+          : cost.by_period;
+
+  // The denominator the headline names (ADR-0065 §3): a model bucket counts
+  // executions — the whole model axis reads "per execution" — and so does the
+  // Node level of the other axes.
+  const atNodeLevel =
+    axis === "model" ? true : axis === "pipeline" ? selected !== null : drilledPipeline !== null;
+  const detailUnit: "Run" | "execution" = atNodeLevel ? "execution" : "Run";
+
   let detailRows: StatsCostEntity[];
-  let detailUnit: "Run" | "execution" = "Run";
+  let detailRenderName: ((row: StatsCostEntity) => React.ReactNode) | undefined;
   let onOpen: ((row: StatsCostEntity) => void) | undefined;
-  if (drilledPipeline) {
+  if (axis === "model") {
+    if (modelPipeline) {
+      detailRows = modelPipeline.nodes;
+    } else if (effort) {
+      detailRows = effort.pipelines;
+      onOpen = (row) => setSelectedPipelineId(row.id);
+    } else if (model) {
+      detailRows = model.efforts;
+      detailRenderName = (row) => effortNameCell(row as StatsEffortCostEntity);
+      onOpen = (row) => setSelectedEffortId(row.id);
+    } else {
+      detailRows = cost.by_model;
+      detailRenderName = (row) => (
+        <span className="inline-flex items-baseline gap-0.5">
+          <span className="font-mono" title={row.name}>
+            {row.name}
+          </span>
+          {(() => {
+            const provenance = cost.by_model.find((m) => m.id === row.id)?.provenance;
+            return provenance && provenance !== "observed" ? (
+              <ProvenanceMark provenance={provenance} target="model" />
+            ) : null;
+          })()}
+        </span>
+      );
+      onOpen = (row) => setSelectedModelId(row.id);
+    }
+  } else if (drilledPipeline) {
     detailRows = drilledPipeline.nodes;
-    detailUnit = "execution";
   } else if (!selected) {
-    detailRows = axis === "project" ? cost.by_project : cost.by_pipeline;
+    detailRows = rows;
   } else if (axis === "project") {
     detailRows = (selected as StatsProjectCostEntity).pipelines;
     onOpen = (pipeline) => setDrilledPipelineId(pipeline.id);
   } else {
     detailRows = selected.nodes;
-    detailUnit = "execution";
   }
+
+  const crumbs: { label: string; onClick?: () => void }[] = [
+    { label: "Total", onClick: toTotal },
+  ];
+  if (axis === "model") {
+    if (model)
+      crumbs.push({
+        label: model.name,
+        onClick: () => {
+          setSelectedEffortId(null);
+          setSelectedPipelineId(null);
+        },
+      });
+    if (effort)
+      crumbs.push({ label: effort.name, onClick: () => setSelectedPipelineId(null) });
+    if (modelPipeline) crumbs.push({ label: modelPipeline.name });
+  } else {
+    if (selected) crumbs.push({ label: selected.name, onClick: () => setDrilledPipelineId(null) });
+    if (drilledPipeline) crumbs.push({ label: drilledPipeline.name });
+  }
+  // Every crumb but the last pops the levels it shadows (design: clickable
+  // breadcrumb for all three axes once there are four levels).
+  const clickableCrumbs = crumbs.map((crumb, index) =>
+    index === crumbs.length - 1 ? { label: crumb.label } : crumb,
+  );
 
   return (
     <div className="relative flex min-h-full" data-testid="stats-chart-cost">
@@ -581,51 +883,59 @@ function CostTab({
             aria-label="Cost grouping"
             value={axis}
             onChange={(event) => {
-              setAxis(event.target.value as "pipeline" | "project");
-              setSelectedId(null);
-              setDrilledPipelineId(null);
+              setAxis(event.target.value as CostAxis);
+              toTotal();
             }}
             className="rounded border border-line bg-bg-3 px-2 py-1 text-fg-2"
           >
             <option value="pipeline">By pipeline</option>
             <option value="project">By project</option>
+            <option value="model">By model</option>
           </select>
         </div>
         <MasterList
           rows={rows}
-          selected={selectedId}
+          selected={axis === "model" ? selectedModelId : selectedId}
+          monoName={axis === "model"}
           valueLabel={(row) => formatCostAmount(row.usd, row.partial, row.estimated)}
           onSelect={(id) => {
-            setSelectedId(id);
-            setDrilledPipelineId(null);
+            if (axis === "model") {
+              setSelectedModelId(id);
+              setSelectedEffortId(null);
+              setSelectedPipelineId(null);
+            } else {
+              setSelectedId(id);
+              setDrilledPipelineId(null);
+            }
           }}
         />
+        {axis === "model" && (
+          <div className="mt-3 text-fg-4" style={{ fontSize: "10.5px" }}>
+            Model ids verbatim, one row per id. Hover ? for where a value comes
+            from. Harnesses without a cost source do not appear.
+          </div>
+        )}
       </aside>
 
       <div
         className="min-w-0 flex-1 pl-5"
         data-testid="stats-drilldown-detail"
       >
-        <div
-          className="mb-3 text-fg-4"
-          style={{ fontSize: "10.5px" }}
-          data-testid="stats-cost-breadcrumb"
-        >
-          Total{selected ? ` / ${selected.name}` : ""}
-          {drilledPipeline ? ` / ${drilledPipeline.name}` : ""}
-        </div>
+        <Breadcrumb crumbs={clickableCrumbs} />
         <HarnessLegend harnesses={cost.harnesses} />
         <div className="mt-4 text-fg" data-testid="stats-selection-headline">
           {formatCostAmount(aggregate.usd, aggregate.partial, aggregate.estimated)} total
           {" · "}
-          {formatCostAmount(aggregate.average_usd, aggregate.partial, aggregate.estimated)} per Run
+          {formatCostAmount(aggregate.average_usd, aggregate.partial, aggregate.estimated)} per{" "}
+          {detailUnit}
         </div>
         <div className="mt-4">
           <HarnessCards aggregate={aggregate} />
         </div>
         {aggregate.unknown > 0 && (
           <div className="mt-4 text-st-await" style={{ fontSize: "10.5px" }}>
-            {aggregate.unknown} Run{aggregate.unknown === 1 ? "" : "s"} without computable cost
+            {aggregate.unknown} {detailUnit}
+            {aggregate.unknown === 1 ? "" : "s"} without computable cost
           </div>
         )}
         <div className="mt-4">
@@ -633,10 +943,13 @@ function CostTab({
         </div>
         <div className="mt-4 min-h-[240px]">
           <CostTable
+            key={`${axis}-${selectedId ?? ""}-${drilledPipelineId ?? ""}-${selectedModelId ?? ""}-${selectedEffortId ?? "total"}-${selectedPipelineId ?? ""}`}
             rows={detailRows}
             harnesses={cost.harnesses}
             unit={detailUnit}
             onOpen={onOpen}
+            renderName={detailRenderName}
+            expandablePairs={axis !== "model"}
           />
         </div>
       </div>

--- a/frontend/src/components/StatsModal.test.tsx
+++ b/frontend/src/components/StatsModal.test.tsx
@@ -56,6 +56,7 @@ const COST: StatsCost = {
   },
   by_period: [],
   by_pipeline: [],
+  by_model: [],
   by_project: [],
   resolved: [],
 };
@@ -92,6 +93,7 @@ beforeEach(() => {
     total: { harnesses: [] },
     infrastructure_total: { harnesses: [] },
     by_pipeline: [],
+    by_model: [],
     infrastructure: [],
   });
   syncCostPricesMock.mockReset().mockResolvedValue(report());

--- a/frontend/src/hooks/useStats.test.ts
+++ b/frontend/src/hooks/useStats.test.ts
@@ -38,6 +38,7 @@ const COST: StatsCost = {
   },
   by_period: [],
   by_pipeline: [],
+  by_model: [],
   by_project: [],
   resolved: [],
 };
@@ -46,6 +47,7 @@ const PERFORMANCE = {
   total: { harnesses: [] },
   infrastructure_total: { harnesses: [] },
   by_pipeline: [],
+  by_model: [],
   infrastructure: [],
 };
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1559,6 +1559,38 @@ export interface StatsCostEntity extends StatsCostAggregate {
   name: string;
   by_period: StatsCostPeriod[];
   nodes: StatsCostEntity[];
+  /** The Node's cost split into model × effort pairs (ADR-0065) — Node leaves
+   *  only; the server omits it (never sends an empty array) on other levels. */
+  models?: StatsModelEffortPair[];
+}
+
+/** Where a model/effort value was read from (ADR-0065 §1): the harness's source
+ *  (observed — the norm, never marked) or the node startup event (requested —
+ *  marked « ? »), or both across the bucket's executions (mixed). */
+export type StatsProvenance = "observed" | "requested" | "mixed";
+
+/** One model × effort pair of a Node leaf (ADR-0065). `effort = null` is the
+ *  "not set" bucket — never merged with a real effort. */
+export interface StatsModelEffortPair extends StatsCostAggregate {
+  model: string;
+  model_provenance: StatsProvenance;
+  effort: string | null;
+  effort_provenance: StatsProvenance | null;
+}
+
+/** One effort level under a model in the « By model » tree: `id` is the effort
+ *  string ("" for not set), `name` the effort or "not set". */
+export interface StatsEffortCostEntity extends StatsCostEntity {
+  effort: string | null;
+  provenance: StatsProvenance | null;
+  pipelines: StatsCostEntity[];
+}
+
+/** One model (verbatim id) of the « By model » axis: Model → Effort → Pipeline
+ *  → Node. */
+export interface StatsModelCostEntity extends StatsCostEntity {
+  provenance: StatsProvenance;
+  efforts: StatsEffortCostEntity[];
 }
 
 export interface StatsProjectCostEntity extends StatsCostEntity {
@@ -1584,6 +1616,9 @@ export interface StatsCost {
   by_period: StatsCostPeriod[];
   by_pipeline: StatsCostEntity[];
   by_project: StatsProjectCostEntity[];
+  /** The « By model » axis (ADR-0065): models ranked by cost, each with its
+   *  effort → pipeline → node tree. */
+  by_model: StatsModelCostEntity[];
   /** The resolved price table, one row per family in alphabetical order (#528).
    *  Window-independent — a property of the price table, not the fold. Refreshed
    *  by the "Sync costs" refetch on the Cost tab. */


### PR DESCRIPTION
## Contenu

Implémente #735 (spec #734, story #733, ADR-0065) — sous-ticket PR vers \`integration/733-stats-by-model\`.

### Backend
- **Capacité de harnais** (ADR-0051) : \`ObservedIdentitySource\` — \`claude\` implémente la lecture du modèle observé par message ; \`pi\`/\`copilot\`/\`opencode\` rendent \`None\` explicitement et retombent sur le demandé.
- **Fold de coût** (\`run_cost\`) : chaque contribution porte ses **slices model × effort** — ids verbatim, ventilation par message pour \`claude\`, repli demandé quand la source est muette, absence pour un harnais sans source de coût ; une session à deux modèles coûte et compte dans chaque bucket (ADR-0065 §3) ; leftover ventilé, effort « not set ». Memo intact (ADR-0029).
- **Wire additif** (\`/stats/cost\`) : \`by_model\` (Modèle → effort → Pipeline → Node), couples modèle × effort sur les feuilles Node, provenance \`observed | requested | mixed\` par bucket, couvertures par bucket, \`by_period\` à chaque niveau.

### Frontend
- Option « By model » (reprise du drill master/detail existant) : ids mono, breadcrumb cliquable sur les trois axes, marques « ? » de provenance (copie du design, jamais « réel »), « not set » italique avec sa phrase, chevrons de couples sur By pipeline/By project (sub-rows teintées), headline « per execution » / « per Run » selon le niveau.

### Checks locaux (verts)
- \`cargo nextest run --workspace\` : 2935 ✓ ; doc tests ✓ ; clippy \`-D warnings\` ✓ ; fmt ✓ ; support table ✓
- frontend : \`tsc -b\` ✓ ; eslint ✓ ; vitest 2270 ✓ (0 failed)
- Tests ajoutés : 11 unités Rust (slices + fold), 1 test HTTP daemon réel (deux Runs, alias vs id observé, session à deux modèles), 6 vitest.

FP (parcours UI sandbox) à dérouler avant l'auto-merge, comme prévu au ticket.