### PR TITLE
Release 1.73.0 — #737 Performance « By model » : pic de contexte et durée par modèle, second select de groupement, drill Node → modèle × effort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ ascendante** : la casse se signale ici et par un bump majeur, jamais en gardant 
 morts. Seule contrainte non négociable — les **données historiques restent lisibles** : un Run
 archivé s'ouvre et se chiffre quelle que soit la version qui a écrit son payload.
 
+## 1.73.0
+
+**Stats › Performance « By model » — pic de contexte et durée par modèle** (#737 ; story #733, spec
+#734, ADR-0065). Le deuxième select de groupement (« By pipeline » / « By model ») est indépendant
+du tri (« By context » / « By duration »). En « By model », l'arbre Modèle → effort → Pipeline →
+Node porte le pic de contexte médian et la durée médiane avec les mêmes boîtes à six statistiques,
+`measured` / `expected` / `missing_reasons` inchangés : le pic de chaque fichier de session est
+attribué au **modèle de ce fichier** (un sous-agent a le sien), même découpage que Cost — source
+d'abord (ADR-0065 §1 : `claude` par message, `pi` modèle + fournisseur + niveau de réflexion,
+`copilot` modèle + effort aux points d'usage), repli sur le demandé marqué « ? » sinon, rien
+inventé quand ni l'une ni l'autre ne parle. En « By pipeline », le drill d'un Node se termine par
+ses couples modèle × effort (pics et durées distincts côte à côte) ; la ligne Infrastructure reste
+conservée sur cet axe et hors de l'axe modèle. Provenance en infobulle comme dans Cost. Wire
+additif (`by_model`, `models` sur les feuilles Node) ; memo de Performance invalidé par les mêmes
+empreintes (événements, mtimes) — rien de matérialisé.
+
 ## 1.72.0
 
 **Sources pi et copilot — modèle et effort observés, fusion inter-harnais par id verbatim** (#736 ;

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "1.72.0"
+version = "1.73.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "1.72.0"
+version = "1.73.0"
 license = "MIT"
 description = "Prompt-Driven Orchestrator — a local daemon that runs and supervises agentic coding pipelines"
 repository = "https://github.com/Loulen/prompt-driven-orchestrator"

--- a/crates/pdo-daemon/src/harness_probes.rs
+++ b/crates/pdo-daemon/src/harness_probes.rs
@@ -102,6 +102,19 @@ pub(crate) enum ObservedIdentitySource {
     ModelAndEffort,
 }
 
+/// One observed model × effort identity a harness's source reports **in one
+/// session file's text** (ADR-0065 §1): the verbatim model id, the effort the
+/// source named with it, and the provider (tooltip only, never part of the
+/// identity — ADR-0065 §2). The raw material of the Performance « By model »
+/// axis, where the context peak follows the session **file**, so the identity
+/// is read per file, not per execution (#737).
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct ObservedIdentity {
+    pub model: String,
+    pub effort: Option<String>,
+    pub provider: Option<String>,
+}
+
 impl ObservedIdentitySource {
     /// How this source reads in the published support table
     /// ([`crate::harness_support`]). The label lives on the variant so the table
@@ -583,6 +596,18 @@ pub(crate) trait HarnessProbes: Sync {
     ) -> Vec<(String, String)> {
         Vec::new()
     }
+
+    /// The model × effort identities this harness's source reports **in one
+    /// session file's text** (ADR-0065 §1), in first-appearance order — one
+    /// entry per model the source names, a subagent file carrying its own (#737:
+    /// the context peak follows the file, so the identity is read per file).
+    /// The default is an **empty `Vec`**, not a `match harness { .. }`: a harness
+    /// whose source is mute (or unknown) answers "nothing observed" from the
+    /// dispatch itself, and the caller falls back to the requested identity
+    /// (or invents nothing when there is none — ADR-0065 §1).
+    fn observed_identities(&self, _text: &str) -> Vec<ObservedIdentity> {
+        Vec::new()
+    }
 }
 
 /// The `claude` capabilities — all five, exactly as they are today. This slice is
@@ -663,6 +688,46 @@ impl HarnessProbes for ClaudeProbes {
             .join("subagents");
         let mut out = Vec::new();
         collect_jsonl_stems(&dir, &mut out);
+        out
+    }
+
+    /// The verbatim `message.model` ids the transcript's own assistant messages
+    /// carry (same tolerance as the cost fold's line parser: API-error and
+    /// `<synthetic>` lines are not model readings). The effort is never written
+    /// by this source — it stays requested (ADR-0065 §1).
+    fn observed_identities(&self, text: &str) -> Vec<ObservedIdentity> {
+        let mut seen = std::collections::HashSet::new();
+        let mut out = Vec::new();
+        for raw in text.lines() {
+            let Ok(value) = serde_json::from_str::<serde_json::Value>(raw) else {
+                continue;
+            };
+            if value.get("type").and_then(|t| t.as_str()) != Some("assistant") {
+                continue;
+            }
+            if value
+                .get("isApiErrorMessage")
+                .and_then(serde_json::Value::as_bool)
+                == Some(true)
+            {
+                continue;
+            }
+            let Some(model) = value
+                .get("message")
+                .and_then(|m| m.get("model"))
+                .and_then(|m| m.as_str())
+                .filter(|m| !m.is_empty() && *m != "<synthetic>")
+            else {
+                continue;
+            };
+            if seen.insert(model.to_string()) {
+                out.push(ObservedIdentity {
+                    model: model.to_string(),
+                    effort: None,
+                    provider: None,
+                });
+            }
+        }
         out
     }
 }
@@ -767,6 +832,19 @@ impl HarnessProbes for CopilotProbes {
 
     fn context_peak(&self, text: &str) -> Option<u64> {
         crate::context_peak::copilot_session_peak(text)
+    }
+
+    /// The model in effect at the journal's usage points, with the reasoning
+    /// effort then in force (#736) — the observed identity of one journal (#737).
+    fn observed_identities(&self, text: &str) -> Vec<ObservedIdentity> {
+        crate::copilot_journal::observed_usage(text)
+            .into_iter()
+            .map(|usage| ObservedIdentity {
+                model: usage.model,
+                effort: usage.effort,
+                provider: None,
+            })
+            .collect()
     }
 
     /// `copilot` exits 0 on a hard model failure (ADR-0052), so its exit is not a
@@ -877,6 +955,20 @@ impl HarnessProbes for PiProbes {
     fn classify_hard_error(&self, tail: &str) -> Option<String> {
         crate::pi_session::hard_error(tail)
     }
+
+    /// The per-message model (and provider) plus the thinking level in force,
+    /// grouped by model × effort (#736) — the observed identity of one session
+    /// (#737).
+    fn observed_identities(&self, text: &str) -> Vec<ObservedIdentity> {
+        crate::pi_session::observed_usage(text)
+            .into_iter()
+            .map(|usage| ObservedIdentity {
+                model: usage.model,
+                effort: usage.effort,
+                provider: usage.provider,
+            })
+            .collect()
+    }
 }
 
 /// The single `pi` instance handed out by [`probes_for`]. Zero-sized.
@@ -924,6 +1016,16 @@ pub(crate) fn resolve_transcript(
 /// no [`HarnessProbes::context_usage_source`] answers `None`.
 pub(crate) fn context_peak(harness: &str, text: &str) -> Option<u64> {
     resolved(harness).context_peak(text)
+}
+
+/// The observed model × effort identities one session file's `text` reports,
+/// dispatched to the harness's own reader (ADR-0065 §1, #737) — `claude`'s
+/// per-message ids, `pi`'s per-message model + thinking level, `copilot`'s
+/// usage-point model + effort. A harness with no
+/// [`HarnessProbes::observed_identity_source`] answers an empty `Vec`: the
+/// caller falls back to the requested identity, or invents nothing.
+pub(crate) fn observed_identities(harness: &str, text: &str) -> Vec<ObservedIdentity> {
+    resolved(harness).observed_identities(text)
 }
 
 /// `harness`'s subagent transcripts for one main session, dispatched to its
@@ -1256,6 +1358,70 @@ mod tests {
         );
         assert_eq!(observed_identity_source(OPENCODE), None);
         assert_eq!(observed_identity_source("never-seen"), None);
+    }
+
+    /// #737: the per-file reader behind the Performance « By model » axis —
+    /// each harness answers from its own source, a mute one answers empty.
+    #[test]
+    fn observed_identities_read_each_harnesss_own_source_per_file() {
+        // claude: the verbatim ids of the transcript's own assistant messages,
+        // in first-appearance order; API-error and synthetic lines are not
+        // readings; the effort is never written by this source.
+        let claude_text = concat!(
+            r#"{"type":"assistant","message":{"model":"claude-opus-4-8","usage":{"input_tokens":10}}}"#,
+            "\n",
+            r#"{"type":"assistant","message":{"model":"claude-opus-4-8","usage":{"input_tokens":10}}}"#,
+            "\n",
+            r#"{"type":"assistant","isApiErrorMessage":true,"message":{"model":"claude-opus-4-8"}}"#,
+            "\n",
+            r#"{"type":"assistant","message":{"model":"<synthetic>","usage":{"input_tokens":10}}}"#,
+            "\n",
+            r#"{"type":"assistant","message":{"model":"claude-sonnet-4-5","usage":{"input_tokens":10}}}"#,
+            "\n",
+            "{not json\n",
+        );
+        assert_eq!(
+            observed_identities(CLAUDE, claude_text),
+            vec![
+                ObservedIdentity {
+                    model: "claude-opus-4-8".into(),
+                    effort: None,
+                    provider: None,
+                },
+                ObservedIdentity {
+                    model: "claude-sonnet-4-5".into(),
+                    effort: None,
+                    provider: None,
+                },
+            ]
+        );
+        assert!(observed_identities(CLAUDE, "{not json\n").is_empty());
+
+        // pi: the session names the model, the provider and the thinking level
+        // per message (#736's own reader).
+        let turn = "\
+{\"type\":\"message\",\"message\":{\"role\":\"assistant\",\"model\":\"claude-opus-4-8\",\"provider\":\"openrouter\",\"usage\":{\"totalTokens\":10,\"cost\":{\"total\":0.01}}}}\n";
+        let pi = observed_identities(PI, turn);
+        assert_eq!(pi.len(), 1);
+        assert_eq!(pi[0].model, "claude-opus-4-8");
+        assert_eq!(pi[0].provider.as_deref(), Some("openrouter"));
+
+        // copilot: the model in effect at the usage points with the effort in
+        // force (#736's own reader).
+        let journal = concat!(
+            r#"{"type":"session.start","data":{"selectedModel":"gpt-5","reasoningEffort":"medium"}}"#,
+            "\n",
+            r#"{"type":"session.usage_checkpoint","data":{"totalNanoAiu":5000000000,"modelCacheState":[{"modelId":"gpt-5"}]}}"#,
+        );
+        let copilot = observed_identities(COPILOT, journal);
+        assert_eq!(copilot.len(), 1);
+        assert_eq!(copilot[0].model, "gpt-5");
+        assert_eq!(copilot[0].effort.as_deref(), Some("medium"));
+
+        // A data-declared harness answers empty from the dispatch itself —
+        // never `claude`'s parser.
+        assert!(observed_identities(OPENCODE, claude_text).is_empty());
+        assert!(observed_identities("never-seen", claude_text).is_empty());
     }
 
     #[test]

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -21993,6 +21993,382 @@ mod tests {
         );
     }
 
+    /// `GET /stats/performance` (#737, ADR-0065) — the « By model » axis: the
+    /// peak of each session file is attributed to the model of THAT file (a
+    /// subagent has its own bucket), a mute source falls back to the requested
+    /// model × effort (marked `requested`), a harness with an observed source
+    /// (`copilot`) buckets its journal's model + effort, and the `by_pipeline`
+    /// Node leaf carries its model × effort couples — the drill "Node → modèle
+    /// × effort". The existing memo fingerprints cover the axis: a subagent
+    /// file's rewrite forces a recompute, an unchanged state is a memo hit.
+    #[tokio::test]
+    async fn stats_performance_by_model_ventilates_each_session_file_to_its_own_model() {
+        struct Cleanup(std::path::PathBuf);
+        impl Drop for Cleanup {
+            fn drop(&mut self) {
+                let _ = std::fs::remove_dir_all(&self.0);
+            }
+        }
+
+        let mut state = test_state().await;
+        let home = state
+            .repo_root
+            .join(".pdo")
+            .join("test-stats-performance-by-model")
+            .join(uuid::Uuid::new_v4().to_string());
+        let _cleanup = Cleanup(home.clone());
+        std::fs::create_dir_all(&home).unwrap();
+        Arc::get_mut(&mut state).unwrap().sandbox_home_override = Some(home.clone());
+        let repo = state.repo_root.to_string_lossy().into_owned();
+
+        async fn insert_event(
+            db: &sqlx::SqlitePool,
+            run: &str,
+            ts: &str,
+            kind: &str,
+            node: Option<&str>,
+            iter: Option<i64>,
+            payload: serde_json::Value,
+        ) {
+            sqlx::query(
+                "INSERT INTO events (run_id, ts, kind, node_id, iter, payload) \
+                 VALUES (?, ?, ?, ?, ?, ?)",
+            )
+            .bind(run)
+            .bind(ts)
+            .bind(kind)
+            .bind(node)
+            .bind(iter)
+            .bind(payload.to_string())
+            .execute(db)
+            .await
+            .unwrap();
+        }
+
+        // perf-m1: a claude Node run twice — iter 1 whose session file names
+        // its model (opus) and whose subagent runs on another one (sonnet);
+        // iter 2 whose file names no model at all (mute source), falling back
+        // to the requested model × effort.
+        insert_event(
+            &state.db,
+            "perf-m1",
+            "2026-08-01T09:00:00Z",
+            "run_started",
+            None,
+            None,
+            serde_json::json!({
+                "pipeline_id":"mp1","pipeline_name":"Model loop","target_repo":repo,"harness":"claude",
+                "node_defs":[{"id":"worker","name":"Worker","node_type":"agent", "isolated_worktree":true}]
+            }),
+        )
+        .await;
+        insert_event(
+            &state.db, "perf-m1", "2026-08-01T09:10:00Z", "node_started",
+            Some("worker"), Some(1),
+            serde_json::json!({"node_type":"agent", "isolated_worktree":true,"harness":"claude","session_id":"m1-iter1"}),
+        ).await;
+        insert_event(
+            &state.db,
+            "perf-m1",
+            "2026-08-01T09:20:00Z",
+            "node_completed",
+            Some("worker"),
+            Some(1),
+            serde_json::json!({}),
+        )
+        .await;
+        insert_event(
+            &state.db, "perf-m1", "2026-08-01T09:30:00Z", "node_started",
+            Some("worker"), Some(2),
+            serde_json::json!({"node_type":"agent", "isolated_worktree":true,"harness":"claude","session_id":"m1-iter2","model":"sonnet","effort":"high"}),
+        ).await;
+        insert_event(
+            &state.db,
+            "perf-m1",
+            "2026-08-01T09:35:00Z",
+            "node_completed",
+            Some("worker"),
+            Some(2),
+            serde_json::json!({}),
+        )
+        .await;
+        // perf-m2: one copilot execution — its journal names the model AND the
+        // effort at the usage points, so both are observed.
+        insert_event(
+            &state.db,
+            "perf-m2",
+            "2026-08-02T09:00:00Z",
+            "run_started",
+            None,
+            None,
+            serde_json::json!({
+                "pipeline_id":"mp2","pipeline_name":"Other pipeline","target_repo":repo,"harness":"copilot",
+                "node_defs":[{"id":"solo","name":"Solo","node_type":"agent", "isolated_worktree":true}]
+            }),
+        )
+        .await;
+        insert_event(
+            &state.db, "perf-m2", "2026-08-02T09:10:00Z", "node_started",
+            Some("solo"), Some(1),
+            serde_json::json!({"node_type":"agent", "isolated_worktree":true,"harness":"copilot","session_id":"m-copilot-1"}),
+        ).await;
+        insert_event(
+            &state.db,
+            "perf-m2",
+            "2026-08-02T09:20:00Z",
+            "node_completed",
+            Some("solo"),
+            Some(1),
+            serde_json::json!({}),
+        )
+        .await;
+
+        // --- claude transcripts: iter 1's main file (opus) + subagent file
+        // (sonnet — its own bucket), iter 2's mute file (no model line).
+        let claude_root = home.join(".claude").join("projects");
+        let dir1 = claude_root.join(stale_detector::encode_working_dir(
+            &worktree_ops::sub_worktree_path(&state.repo_root, "perf-m1", "worker", 1),
+        ));
+        std::fs::create_dir_all(&dir1).unwrap();
+        std::fs::write(
+            dir1.join("m1-iter1.jsonl"),
+            r#"{"type":"assistant","message":{"model":"claude-opus-4-8","usage":{"input_tokens":20000,"output_tokens":0}}}"#,
+        )
+        .unwrap();
+        let subagents_dir = dir1.join("m1-iter1").join("subagents");
+        std::fs::create_dir_all(&subagents_dir).unwrap();
+        std::fs::write(
+            subagents_dir.join("explore.jsonl"),
+            "{\"type\":\"assistant\",\"timestamp\":\"2026-08-01T09:10:00Z\",\"message\":{\"model\":\"claude-sonnet-4-5\",\"usage\":{\"input_tokens\":55000,\"output_tokens\":0}}}\n\
+             {\"type\":\"user\",\"timestamp\":\"2026-08-01T09:15:00Z\"}\n",
+        )
+        .unwrap();
+        let dir2 = claude_root.join(stale_detector::encode_working_dir(
+            &worktree_ops::sub_worktree_path(&state.repo_root, "perf-m1", "worker", 2),
+        ));
+        std::fs::create_dir_all(&dir2).unwrap();
+        // A file that reads but says nothing: no model line, no readable peak.
+        std::fs::write(dir2.join("m1-iter2.jsonl"), "{not json\n").unwrap();
+
+        // --- copilot journal: the model and effort at the usage point, plus
+        // the peak reading the shutdown carries.
+        let copilot_dir = home
+            .join(".copilot")
+            .join("session-state")
+            .join("m-copilot-1");
+        std::fs::create_dir_all(&copilot_dir).unwrap();
+        std::fs::write(
+            copilot_dir.join("events.jsonl"),
+            r#"{"type":"session.start","data":{"selectedModel":"gpt-5","reasoningEffort":"medium"}}
+{"type":"session.usage_checkpoint","data":{"totalNanoAiu":5000000000,"modelCacheState":[{"modelId":"gpt-5"}]}}
+{"type":"session.shutdown","data":{"usage":{"inputTokens":40000,"outputTokens":0}}}"#,
+        )
+        .unwrap();
+
+        let from = "2026-08-01T00:00:00Z";
+        let to = "2026-08-03T00:00:00Z";
+        let uri = format!("/stats/performance?from={from}&to={to}");
+        async fn call(state: &Arc<AppState>, uri: &str) -> serde_json::Value {
+            let response = build_router(state.clone())
+                .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            serde_json::from_slice(
+                &axum::body::to_bytes(response.into_body(), usize::MAX)
+                    .await
+                    .unwrap(),
+            )
+            .unwrap()
+        }
+
+        let body = call(&state, &uri).await;
+        let by_model = body["by_model"].as_array().unwrap();
+        let ids: Vec<&str> = by_model
+            .iter()
+            .filter_map(|row| row["id"].as_str())
+            .collect();
+        assert_eq!(
+            ids,
+            vec!["claude-opus-4-8", "claude-sonnet-4-5", "gpt-5", "sonnet"],
+            "one verbatim row per model id, harness-agnostic: {by_model:#?}"
+        );
+
+        let find_model = |body: &serde_json::Value, id: &str| {
+            body["by_model"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .find(|row| row["id"] == id)
+                .unwrap()
+                .clone()
+        };
+        let node_of =
+            |model: &serde_json::Value| model["efforts"][0]["pipelines"][0]["nodes"][0].clone();
+
+        // Observed main-session model: the Node's peak + the execution's
+        // wall-clock, effort « not set » (no effort in the startup event).
+        let opus = find_model(&body, "claude-opus-4-8");
+        assert_eq!(opus["provenance"], "observed");
+        assert_eq!(opus["efforts"][0]["effort"], serde_json::Value::Null);
+        assert_eq!(opus["efforts"][0]["name"], "not set");
+        assert_eq!(opus["efforts"][0]["pipelines"][0]["id"], "mp1");
+        let opus_node = node_of(&opus);
+        assert_eq!(opus_node["id"], "worker");
+        assert_eq!(opus_node["harnesses"][0]["harness"], "claude");
+        assert_eq!(opus_node["harnesses"][0]["context"]["measured"], 1);
+        assert_eq!(
+            opus_node["harnesses"][0]["context"]["stats"]["max"],
+            20000.0
+        );
+        assert_eq!(
+            opus_node["harnesses"][0]["duration"]["stats"]["max"],
+            600000.0
+        );
+        // The by_model Node row carries no couples — the path IS the drill, so
+        // the empty field is omitted on the wire (never an empty array).
+        assert!(opus_node.get("models").is_none());
+
+        // The subagent file's own model: its own bucket, its own peak and its
+        // own transcript time span as duration.
+        let sonnet_observed = find_model(&body, "claude-sonnet-4-5");
+        assert_eq!(sonnet_observed["provenance"], "observed");
+        let sonnet_node = node_of(&sonnet_observed);
+        assert_eq!(sonnet_node["id"], "worker");
+        assert_eq!(
+            sonnet_node["harnesses"][0]["context"]["stats"]["max"],
+            55000.0
+        );
+        assert_eq!(
+            sonnet_node["harnesses"][0]["duration"]["stats"]["max"],
+            300000.0
+        );
+
+        // A mute source falls back to the requested model × effort, marked.
+        let sonnet_requested = find_model(&body, "sonnet");
+        assert_eq!(sonnet_requested["provenance"], "requested");
+        assert_eq!(sonnet_requested["efforts"][0]["effort"], "high");
+        assert_eq!(sonnet_requested["efforts"][0]["provenance"], "requested");
+        let requested_node = node_of(&sonnet_requested);
+        assert_eq!(requested_node["id"], "worker");
+        assert_eq!(requested_node["harnesses"][0]["context"]["measured"], 0);
+        assert_eq!(
+            requested_node["harnesses"][0]["context"]["missing_reasons"],
+            serde_json::json!(["no readable context usage in transcript"])
+        );
+        assert_eq!(
+            requested_node["harnesses"][0]["duration"]["stats"]["max"],
+            300000.0
+        );
+
+        // copilot: model AND effort observed from the journal; the context peak
+        // rides the same journal.
+        let gpt5 = find_model(&body, "gpt-5");
+        assert_eq!(gpt5["provenance"], "observed");
+        assert_eq!(gpt5["efforts"][0]["effort"], "medium");
+        assert_eq!(gpt5["efforts"][0]["provenance"], "observed");
+        let gpt5_node = node_of(&gpt5);
+        assert_eq!(gpt5_node["id"], "solo");
+        assert_eq!(
+            gpt5_node["harnesses"][0]["context"]["stats"]["max"],
+            40000.0
+        );
+        assert_eq!(
+            gpt5_node["harnesses"][0]["duration"]["stats"]["max"],
+            600000.0
+        );
+
+        // --- by_pipeline is untouched at the top, but its Node leaf now ends
+        // with the model × effort couples.
+        let worker = body["by_pipeline"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|p| p["id"] == "mp1")
+            .unwrap()["nodes"]
+            .as_array()
+            .unwrap()[0]
+            .clone();
+        assert_eq!(worker["harnesses"][0]["context"]["measured"], 1);
+        assert_eq!(
+            worker["harnesses"][0]["context"]["missing_reasons"],
+            serde_json::json!(["no readable context usage in transcript"])
+        );
+        let couples = worker["models"].as_array().unwrap();
+        assert_eq!(couples.len(), 3, "got: {couples:#?}");
+        let couple_keys: Vec<String> = couples
+            .iter()
+            .map(|pair| {
+                format!(
+                    "{}·{}",
+                    pair["model"].as_str().unwrap(),
+                    pair["effort"].as_str().unwrap_or("not set")
+                )
+            })
+            .collect();
+        assert_eq!(
+            couple_keys,
+            vec![
+                "claude-opus-4-8·not set",
+                "claude-sonnet-4-5·not set",
+                "sonnet·high"
+            ]
+        );
+        let opus_couple = &couples[0];
+        assert_eq!(opus_couple["model_provenance"], "observed");
+        assert_eq!(opus_couple["effort_provenance"], serde_json::Value::Null);
+        assert_eq!(
+            opus_couple["harnesses"][0]["context"]["stats"]["max"],
+            20000.0
+        );
+        let sonnet_high_couple = &couples[2];
+        assert_eq!(sonnet_high_couple["model_provenance"], "requested");
+        assert_eq!(sonnet_high_couple["effort_provenance"], "requested");
+        let sonnet_sub_couple = &couples[1];
+        assert_eq!(sonnet_sub_couple["model_provenance"], "observed");
+        assert_eq!(
+            sonnet_sub_couple["harnesses"][0]["context"]["stats"]["max"],
+            55000.0
+        );
+
+        // The whole-cohort total pools the main-session observations only —
+        // never a subagent, never Infrastructure. Untouched by the axis.
+        let total_claude = body["total"]["harnesses"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|h| h["harness"] == "claude")
+            .unwrap();
+        assert_eq!(total_claude["context"]["measured"], 1);
+
+        // --- the memo key covers the axis: unchanged state is a hit, a
+        // subagent file's rewrite (no event at all) forces a recompute that
+        // moves ITS model's bucket.
+        let _ = call(&state, &uri).await;
+        assert_eq!(
+            stats_performance::recompute_count_for_test(from, to),
+            1,
+            "an unchanged state must be a memo hit"
+        );
+        std::fs::write(
+            subagents_dir.join("explore.jsonl"),
+            "{\"type\":\"assistant\",\"timestamp\":\"2026-08-01T09:10:00Z\",\"message\":{\"model\":\"claude-sonnet-4-5\",\"usage\":{\"input_tokens\":66000,\"output_tokens\":0}}}\n\
+             {\"type\":\"user\",\"timestamp\":\"2026-08-01T09:15:00Z\"}\n",
+        )
+        .unwrap();
+        let after_rewrite = call(&state, &uri).await;
+        assert_eq!(
+            stats_performance::recompute_count_for_test(from, to),
+            2,
+            "rewriting a subagent file, with no new event, must force a recompute"
+        );
+        let rewritten = find_model(&after_rewrite, "claude-sonnet-4-5");
+        assert_eq!(
+            node_of(&rewritten)["harnesses"][0]["context"]["stats"]["max"],
+            66000.0
+        );
+    }
+
     /// An empty cohort (no Runs in the window) is not an error — an empty
     /// Performance payload, distinct from the source-wide-unreadable case below.
     #[tokio::test]

--- a/crates/pdo-daemon/src/prompt_augmenter.rs
+++ b/crates/pdo-daemon/src/prompt_augmenter.rs
@@ -1960,7 +1960,10 @@ mod tests {
         let plain_pipeline = sample_pipeline();
         let plain = sample_ctx(&plain_pipeline, &plain_pipeline.nodes[0], &vars);
         let bare = build_full_prompt(&plain, "You are a worker. Work.");
-        assert!(!bare.contains("/pdo-orchestrate"), "a node without the toggle keeps its pre-#723 prompt");
+        assert!(
+            !bare.contains("/pdo-orchestrate"),
+            "a node without the toggle keeps its pre-#723 prompt"
+        );
     }
 
     #[test]

--- a/crates/pdo-daemon/src/stats.rs
+++ b/crates/pdo-daemon/src/stats.rs
@@ -606,8 +606,8 @@ pub(crate) enum StatsProvenance {
 }
 
 /// Observed and requested counts decide the label; both present in one bucket is
-/// the honest « mixed ».
-fn provenance(observed: i64, requested: i64) -> StatsProvenance {
+/// the honest « mixed ». Shared with the Performance « By model » axis (#737).
+pub(crate) fn provenance(observed: i64, requested: i64) -> StatsProvenance {
     match (observed > 0, requested > 0) {
         (true, false) => StatsProvenance::Observed,
         (false, true) => StatsProvenance::Requested,

--- a/crates/pdo-daemon/src/stats_performance.rs
+++ b/crates/pdo-daemon/src/stats_performance.rs
@@ -17,6 +17,30 @@
 //! principale"). Duration is in **milliseconds** (matching the frontend's
 //! `value / 1_000`); Context is a raw peak token count.
 //!
+//! ### The « By model » axis (#737, ADR-0065)
+//!
+//! `by_model` is a second, additive tree over the SAME observations — Modèle →
+//! effort → Pipeline → Node — where a session **file**'s peak (and its
+//! duration) is attributed to the model of **that file**, a subagent having
+//! its own (ADR-0065 §3, "le pic de contexte suit le fichier de session"). The
+//! identity is read source-first (ADR-0065 §1): `claude`'s per-message ids,
+//! `pi`'s per-message model + thinking level, `copilot`'s usage-point model +
+//! effort; a mute source falls back to the startup event's requested model +
+//! effort, marked `requested`; a mute source with **no** requested model (and
+//! a subagent file — which has no startup event at all) invents nothing and
+//! lands in no bucket. A file naming several models counts in **each** bucket
+//! (the same "une exécution compte dans chaque bucket où elle a coûté" rule as
+//! Cost, one bucket per model here). Node leaves of `by_pipeline` carry their
+//! `models` couples — the drill "Node → modèle × effort" — with the same
+//! distributions, so the two groupings never disagree about a bucket. Every
+//! level pools **raw observations** (never a mean of means) and says its
+//! provenance (`observed` / `requested` / `mixed`). Infrastructure roles stay
+//! out of the axis: their sessions are residual-by-exclusion, carry no model
+//! identity of their own, and the axis compares **Node** executions — the
+//! by_pipeline tree keeps them, as today. Duration buckets follow the same
+//! per-file attribution: a main session contributes its execution's
+//! wall-clock, a subagent file its own transcript time span.
+//!
 //! ## What counts as an observation
 //!
 //! Only a **successful** attempt is an observation, mirroring the issue's
@@ -156,6 +180,49 @@ pub(crate) struct PerformanceEntity {
     pub harnesses: Vec<StatsHarnessPerformance>,
     pub nodes: Vec<PerformanceEntity>,
     pub subagents: Vec<PerformanceEntity>,
+    /// The Node's observations split into model × effort couples (ADR-0065) —
+    /// Node leaves only, so the drill-down ends there; omitted (never an empty
+    /// array) on the other levels, and on the `by_model` Node rows (the path is
+    /// already the drill).
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub models: Vec<PerformanceModelEffortPair>,
+}
+
+/// One model × effort couple of a Node leaf (ADR-0065): the performance
+/// analogue of `stats::StatsModelEffortPair` — the same aggregate shape plus
+/// the pair identity and where each half was read from. `effort = None` is the
+/// "not set" bucket — never merged with a real effort.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub(crate) struct PerformanceModelEffortPair {
+    #[serde(flatten)]
+    pub aggregate: PerformanceAggregate,
+    pub model: String,
+    pub model_provenance: crate::stats::StatsProvenance,
+    pub effort: Option<String>,
+    pub effort_provenance: Option<crate::stats::StatsProvenance>,
+}
+
+/// One effort level under a model, in the Performance « By model » tree: the
+/// entity's `id` is the effort string ("" for not set) and its `name` the
+/// effort or "not set".
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub(crate) struct PerformanceEffortEntity {
+    #[serde(flatten)]
+    pub entity: PerformanceEntity,
+    pub effort: Option<String>,
+    pub provenance: Option<crate::stats::StatsProvenance>,
+    pub pipelines: Vec<PerformanceEntity>,
+}
+
+/// One model (verbatim id) of the Performance « By model » axis, with its
+/// effort tree: Model → Effort → Pipeline → Node. Both harnesses run on the
+/// same id are one row, the harness staying a column (ADR-0065 §2).
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub(crate) struct StatsModelPerformanceEntity {
+    #[serde(flatten)]
+    pub entity: PerformanceEntity,
+    pub provenance: crate::stats::StatsProvenance,
+    pub efforts: Vec<PerformanceEffortEntity>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize)]
@@ -175,6 +242,12 @@ pub(crate) struct StatsPerformance {
     /// never has to fabricate one by averaging averages. Never pools a role's
     /// `subagents` (same rule as [`Self::total`]).
     pub infrastructure_total: PerformanceAggregate,
+    /// The « By model » axis (ADR-0065): the SAME successful main-session Node
+    /// observations as `total`, bucketed by the model of the session **file**
+    /// each observation came from (a subagent file keeps its own bucket). Node
+    /// executions only — Infrastructure roles carry no model identity and stay
+    /// on `by_pipeline` (module doc, « The « By model » axis »).
+    pub by_model: Vec<StatsModelPerformanceEntity>,
 }
 
 /// Why the whole request failed, distinct from a per-observation absence
@@ -235,6 +308,15 @@ impl MetricAcc {
         }
     }
 
+    /// Pool another accumulator's RAW observations into this one — never a mean
+    /// of means (the whole module pools at the raw level).
+    fn fold(&mut self, other: &MetricAcc) {
+        self.values.extend_from_slice(&other.values);
+        self.expected += other.expected;
+        self.absence_reasons
+            .extend(other.absence_reasons.iter().cloned());
+    }
+
     fn finish(self) -> StatsDistribution {
         StatsDistribution {
             stats: r7_distribution(&self.values),
@@ -275,6 +357,10 @@ struct NodeAcc {
     name: String,
     by_harness: BTreeMap<String, HarnessAcc>,
     subagents: BTreeMap<String, SubagentAcc>,
+    /// The Node's model × effort couples (ADR-0065): the same observations as
+    /// `by_harness`, bucketed by the model of the session **file** each came
+    /// from — the drill "Node → modèle × effort" of `by_pipeline` (#737).
+    pairs: BTreeMap<ModelEffortKey, ModelPairAcc>,
 }
 
 fn finish_subagents(subagents: BTreeMap<String, SubagentAcc>) -> Vec<PerformanceEntity> {
@@ -286,6 +372,7 @@ fn finish_subagents(subagents: BTreeMap<String, SubagentAcc>) -> Vec<Performance
             harnesses: finish_by_harness(acc.by_harness),
             nodes: Vec::new(),
             subagents: Vec::new(),
+            models: Vec::new(),
         })
         .collect()
 }
@@ -297,6 +384,7 @@ fn finish_node(id: String, acc: NodeAcc) -> PerformanceEntity {
         harnesses: finish_by_harness(acc.by_harness),
         nodes: Vec::new(),
         subagents: finish_subagents(acc.subagents),
+        models: wire_model_pairs(acc.pairs),
     }
 }
 
@@ -309,6 +397,9 @@ fn finish_infra_role(id: &str, name: &str, acc: NodeAcc) -> PerformanceEntity {
         harnesses: finish_by_harness(acc.by_harness),
         nodes: Vec::new(),
         subagents: finish_subagents(acc.subagents),
+        // Infrastructure carries no model identity (module doc): an empty
+        // `models` is omitted on the wire, never an empty array.
+        models: Vec::new(),
     }
 }
 
@@ -330,7 +421,264 @@ fn finish_pipeline(id: String, acc: PipelineAcc) -> PerformanceEntity {
             .map(|(id, node)| finish_node(id, node))
             .collect(),
         subagents: Vec::new(),
+        models: Vec::new(),
     }
+}
+
+// --- « By model » axis (#737, ADR-0065) ---------------------------------------
+
+/// A model × effort bucket key: the **verbatim** model id (ADR-0065 §2, no
+/// normalisation, no alias table) and the effort it ran with — `None` is the
+/// "not set" bucket, never merged with a real effort.
+type ModelEffortKey = (String, Option<String>);
+
+/// The model × effort a session file's observation is attributed to
+/// (ADR-0065 §1): observed from the harness's source when it speaks, else the
+/// startup event's requested identity. Provenance is decided per observation —
+/// a bucket whose observations mix both says « mixed ».
+struct ModelIdentity {
+    model: String,
+    effort: Option<String>,
+    model_observed: bool,
+    effort_observed: Option<bool>,
+}
+
+/// One model × effort bucket, accumulated over the session-file observations
+/// that landed in it. The observed/requested counters decide the wire's
+/// provenance, including the « mixed » case.
+#[derive(Debug, Default)]
+struct ModelPairAcc {
+    by_harness: BTreeMap<String, HarnessAcc>,
+    model_observed: i64,
+    model_requested: i64,
+    effort_observed: i64,
+    effort_requested: i64,
+}
+
+impl ModelPairAcc {
+    /// Observe one session file's context peak + duration into this bucket.
+    #[allow(clippy::too_many_arguments)]
+    fn observe(
+        &mut self,
+        harness: &str,
+        context: (Option<f64>, Option<&'static str>),
+        duration: (Option<f64>, Option<&'static str>),
+        identity: &ModelIdentity,
+    ) {
+        let acc = self.by_harness.entry(harness.to_string()).or_default();
+        acc.context.observe(context.0, context.1);
+        acc.duration.observe(duration.0, duration.1);
+        if identity.model_observed {
+            self.model_observed += 1;
+        } else {
+            self.model_requested += 1;
+        }
+        match identity.effort_observed {
+            Some(true) => self.effort_observed += 1,
+            Some(false) => self.effort_requested += 1,
+            None => {}
+        }
+    }
+}
+
+/// One (pipeline, Node) slot of the by_model tree: the Node's rows under the
+/// model buckets it provably ran on.
+#[derive(Debug, Default)]
+struct ModelAxisNodeAcc {
+    name: String,
+    pairs: BTreeMap<ModelEffortKey, ModelPairAcc>,
+}
+
+/// One pipeline level of the by_model tree.
+#[derive(Debug, Default)]
+struct ModelAxisPipelineAcc {
+    name: String,
+    pairs: BTreeMap<ModelEffortKey, ModelPairAcc>,
+    nodes: BTreeMap<String, ModelAxisNodeAcc>,
+}
+
+/// One effort level under a model. `effort: None` is the "not set" bucket.
+#[derive(Debug, Default)]
+struct ModelAxisEffortAcc {
+    pairs: BTreeMap<ModelEffortKey, ModelPairAcc>,
+    pipelines: BTreeMap<String, ModelAxisPipelineAcc>,
+}
+
+/// One model (verbatim id) of the by_model axis.
+#[derive(Debug, Default)]
+struct ModelAxisModelAcc {
+    pairs: BTreeMap<ModelEffortKey, ModelPairAcc>,
+    efforts: BTreeMap<Option<String>, ModelAxisEffortAcc>,
+}
+
+/// Attribute one session file's observation to every model × effort bucket its
+/// identity names (ADR-0065 §3: the peak follows the file; a file naming two
+/// models counts in both). Walks the by_model tree — Node, Pipeline, Effort
+/// and Model levels each keep their own raw pool — plus the Node's own couples
+/// on the `by_pipeline` side.
+#[allow(clippy::too_many_arguments)]
+fn record_model_observation(
+    model_axis: &mut BTreeMap<String, ModelAxisModelAcc>,
+    node_pairs: &mut BTreeMap<ModelEffortKey, ModelPairAcc>,
+    pipeline_id: &str,
+    pipeline_name: &str,
+    node_id: &str,
+    node_name: &str,
+    harness: &str,
+    identity: &ModelIdentity,
+    context: (Option<f64>, Option<&'static str>),
+    duration: (Option<f64>, Option<&'static str>),
+) {
+    let key = (identity.model.clone(), identity.effort.clone());
+    node_pairs
+        .entry(key.clone())
+        .or_default()
+        .observe(harness, context, duration, identity);
+
+    let model_acc = model_axis.entry(identity.model.clone()).or_default();
+    let effort_acc = model_acc
+        .efforts
+        .entry(identity.effort.clone())
+        .or_default();
+    let pipeline_acc = effort_acc
+        .pipelines
+        .entry(pipeline_id.to_string())
+        .or_default();
+    pipeline_acc.name = pipeline_name.to_string();
+    let node_acc = pipeline_acc.nodes.entry(node_id.to_string()).or_default();
+    node_acc.name = node_name.to_string();
+    for acc in [
+        model_acc.pairs.entry(key.clone()).or_default(),
+        effort_acc.pairs.entry(key.clone()).or_default(),
+        pipeline_acc.pairs.entry(key.clone()).or_default(),
+        node_acc.pairs.entry(key).or_default(),
+    ] {
+        acc.observe(harness, context, duration, identity);
+    }
+}
+
+/// Pool a set of model × effort buckets back into one raw-observation
+/// aggregate — the level rows of the by_model tree, never a mean of means.
+fn pool_pairs(pairs: &BTreeMap<ModelEffortKey, ModelPairAcc>) -> PerformanceAggregate {
+    let mut by_harness: BTreeMap<String, HarnessAcc> = BTreeMap::new();
+    for pair in pairs.values() {
+        for (harness, acc) in &pair.by_harness {
+            let target = by_harness.entry(harness.clone()).or_default();
+            target.context.fold(&acc.context);
+            target.duration.fold(&acc.duration);
+        }
+    }
+    PerformanceAggregate {
+        harnesses: finish_by_harness(by_harness),
+    }
+}
+
+/// Observed/requested totals over a set of buckets — the provenance a level
+/// row reports.
+fn provenance_totals(pairs: &BTreeMap<ModelEffortKey, ModelPairAcc>) -> (i64, i64, i64, i64) {
+    pairs.values().fold((0, 0, 0, 0), |(mo, mr, eo, er), acc| {
+        (
+            mo + acc.model_observed,
+            mr + acc.model_requested,
+            eo + acc.effort_observed,
+            er + acc.effort_requested,
+        )
+    })
+}
+
+fn wire_model_pairs(
+    pairs: BTreeMap<ModelEffortKey, ModelPairAcc>,
+) -> Vec<PerformanceModelEffortPair> {
+    pairs
+        .into_iter()
+        .map(|((model, effort), acc)| PerformanceModelEffortPair {
+            model_provenance: crate::stats::provenance(acc.model_observed, acc.model_requested),
+            effort_provenance: effort
+                .as_ref()
+                .map(|_| crate::stats::provenance(acc.effort_observed, acc.effort_requested)),
+            aggregate: PerformanceAggregate {
+                harnesses: finish_by_harness(acc.by_harness),
+            },
+            model,
+            effort,
+        })
+        .collect()
+}
+
+/// Wire the whole Performance « By model » tree: Model → Effort → Pipeline →
+/// Node. Every level's aggregate pools its own raw observations; the Node rows
+/// carry no `models` — the path is already the drill.
+fn wire_model_axis(
+    models: BTreeMap<String, ModelAxisModelAcc>,
+) -> Vec<StatsModelPerformanceEntity> {
+    models
+        .into_iter()
+        .map(|(model, model_acc)| {
+            let (model_observed, model_requested, _, _) = provenance_totals(&model_acc.pairs);
+            let efforts = model_acc
+                .efforts
+                .into_iter()
+                .map(|(effort, effort_acc)| {
+                    let (_, _, effort_observed, effort_requested) =
+                        provenance_totals(&effort_acc.pairs);
+                    let effort_provenance = effort
+                        .as_ref()
+                        .map(|_| crate::stats::provenance(effort_observed, effort_requested));
+                    let pipelines = effort_acc
+                        .pipelines
+                        .into_iter()
+                        .map(|(id, pipeline_acc)| {
+                            let nodes = pipeline_acc
+                                .nodes
+                                .into_iter()
+                                .map(|(id, node_acc)| PerformanceEntity {
+                                    id,
+                                    name: node_acc.name,
+                                    harnesses: pool_pairs(&node_acc.pairs).harnesses,
+                                    nodes: Vec::new(),
+                                    subagents: Vec::new(),
+                                    models: Vec::new(),
+                                })
+                                .collect();
+                            PerformanceEntity {
+                                id,
+                                name: pipeline_acc.name,
+                                harnesses: pool_pairs(&pipeline_acc.pairs).harnesses,
+                                nodes,
+                                subagents: Vec::new(),
+                                models: Vec::new(),
+                            }
+                        })
+                        .collect();
+                    PerformanceEffortEntity {
+                        entity: PerformanceEntity {
+                            id: effort.clone().unwrap_or_default(),
+                            name: effort.clone().unwrap_or_else(|| "not set".to_string()),
+                            harnesses: pool_pairs(&effort_acc.pairs).harnesses,
+                            nodes: Vec::new(),
+                            subagents: Vec::new(),
+                            models: Vec::new(),
+                        },
+                        effort,
+                        provenance: effort_provenance,
+                        pipelines,
+                    }
+                })
+                .collect();
+            StatsModelPerformanceEntity {
+                entity: PerformanceEntity {
+                    id: model.clone(),
+                    name: model,
+                    harnesses: pool_pairs(&model_acc.pairs).harnesses,
+                    nodes: Vec::new(),
+                    subagents: Vec::new(),
+                    models: Vec::new(),
+                },
+                provenance: crate::stats::provenance(model_observed, model_requested),
+                efforts,
+            }
+        })
+        .collect()
 }
 
 // --- Node identity/type resolution ---------------------------------------------
@@ -427,36 +775,126 @@ fn source_root<'a>(harness: &str, claude_root: &'a Path, stores: &'a HarnessStor
     stores.root_for(harness, claude_root)
 }
 
-/// One harness's context peak for one main session, or the absence reason.
-/// The root readability check sits *after* the `can_measure_context` gate, so a
+/// One main session's observation: `(context peak, absence reason, file text)`.
+type MainObservation = (Option<f64>, Option<&'static str>, Option<String>);
+
+/// One harness's context peak for one main session, or the absence reason,
+/// plus the session file's text — the same read feeds the peak and the
+/// observed model identity (#737), so the file is read once. The root
+/// readability check sits *after* the `can_measure_context` gate, so a
 /// harness with no context source (e.g. `opencode`) never triggers a
 /// Claude/Copilot root check it does not need.
-fn main_session_context(
+fn main_session_observation(
     harness: &str,
     root: &Path,
     working_dir: &Path,
     session_id: Option<&str>,
     seen_roots: &mut HashSet<PathBuf>,
-) -> Result<(Option<f64>, Option<&'static str>), PerformanceError> {
+) -> Result<MainObservation, PerformanceError> {
     if !crate::harness_probes::can_measure_context(harness) {
-        return Ok((None, Some("harness has no context-usage source")));
+        return Ok((None, Some("harness has no context-usage source"), None));
     }
     check_root_once(root, &harness_display_label(harness), seen_roots)?;
     let Some(session_id) = session_id.filter(|s| !s.is_empty()) else {
-        return Ok((None, Some("no session identity")));
+        return Ok((None, Some("no session identity"), None));
     };
     let Some(path) =
         crate::harness_probes::resolve_transcript(harness, root, working_dir, Some(session_id))
     else {
-        return Ok((None, Some("no attributable transcript")));
+        return Ok((None, Some("no attributable transcript"), None));
     };
     Ok(match std::fs::read_to_string(&path) {
         Ok(text) => match crate::harness_probes::context_peak(harness, &text) {
-            Some(peak) => (Some(peak as f64), None),
-            None => (None, Some("no readable context usage in transcript")),
+            Some(peak) => (Some(peak as f64), None, Some(text)),
+            None => (
+                None,
+                Some("no readable context usage in transcript"),
+                Some(text),
+            ),
         },
-        Err(_) => (None, Some("no attributable transcript")),
+        Err(_) => (None, Some("no attributable transcript"), None),
     })
+}
+
+/// One session file's transcript text, by the harness's own resolution — the
+/// identity-only read for a harness whose context gate answered before the
+/// file was read (`copilot`'s journal is still worth reading for its observed
+/// model, #737).
+fn session_file_text(
+    harness: &str,
+    root: &Path,
+    working_dir: &Path,
+    session_id: Option<&str>,
+) -> Option<String> {
+    crate::harness_probes::resolve_transcript(harness, root, working_dir, session_id)
+        .and_then(|path| std::fs::read_to_string(path).ok())
+}
+
+/// The model × effort identities one MAIN session's observation is attributed
+/// to (ADR-0065 §1): the observed identities the harness's source reports when
+/// it speaks — `effort_observed` only where the source carries the effort
+/// (`pi`, `copilot`); `claude`'s effort stays the requested one. A mute source
+/// (or no readable file) falls back to the startup event's requested identity,
+/// marked `requested`; a mute source with **no** requested model invents
+/// nothing and yields no bucket.
+fn main_session_identities(
+    harness: &str,
+    root: &Path,
+    working_dir: &Path,
+    session_id: Option<&str>,
+    requested_model: Option<&str>,
+    requested_effort: Option<&str>,
+    already_read: Option<&str>,
+) -> Vec<ModelIdentity> {
+    let source = crate::harness_probes::observed_identity_source(harness);
+    let mut observed = Vec::new();
+    if source.is_some() {
+        let text = match already_read {
+            Some(text) => Some(text.to_string()),
+            None => session_file_text(harness, root, working_dir, session_id),
+        };
+        if let Some(text) = text {
+            observed = crate::harness_probes::observed_identities(harness, &text)
+                .into_iter()
+                .map(|identity| {
+                    // The source carries the effort (`pi`, `copilot`) — an
+                    // absent one is « not set », never refilled from the
+                    // startup event (source-first, ADR-0065 §1). `claude`'s
+                    // source never writes one: the requested effort stands.
+                    let (effort, effort_observed) = match source {
+                        Some(crate::harness_probes::ObservedIdentitySource::ModelAndEffort) => {
+                            let observed_effort = identity.effort;
+                            let observed = observed_effort.clone();
+                            (observed_effort, Some(observed.is_some()))
+                        }
+                        _ => (
+                            requested_effort.map(str::to_string),
+                            requested_effort.map(|_| false),
+                        ),
+                    };
+                    ModelIdentity {
+                        model: identity.model,
+                        effort,
+                        model_observed: true,
+                        effort_observed,
+                    }
+                })
+                .collect();
+        }
+    }
+    if !observed.is_empty() {
+        return observed;
+    }
+    requested_model
+        .map(|model| {
+            vec![ModelIdentity {
+                model: model.to_string(),
+                effort: requested_effort.map(str::to_string),
+                model_observed: false,
+                effort_observed: requested_effort.map(|_| false),
+            }]
+        })
+        .unwrap_or_default()
 }
 
 /// The subagent transcript files discovered for one main session, grouped by
@@ -484,6 +922,10 @@ struct PendingNode {
     session_id: Option<String>,
     /// Where the NodeRun works (#653) — its own sub-worktree, or the Run's.
     isolated: bool,
+    /// The requested model × effort, frozen in the startup event (ADR-0046) —
+    /// the fallback when the source is mute (ADR-0065 §1).
+    requested_model: Option<String>,
+    requested_effort: Option<String>,
 }
 
 /// A `MergeResolverStarted` awaiting its pairing `MergeResolverCompleted`.
@@ -495,15 +937,28 @@ struct MergeResolverPending {
     iter: Option<i64>,
 }
 
-/// Fold discovered subagent transcripts into their declared groups. Shared by a
-/// Node's subagents and an Infrastructure role's.
+/// Fold discovered subagent transcripts into their declared groups (the
+/// `by_pipeline` tree) and into the « By model » axis. Shared by a Node's
+/// subagents and an Infrastructure role's.
 ///
 /// The duration span alone bypasses the `harness_probes` dispatch: no capability
 /// marker exists yet for "start/end bounds from a transcript", so
 /// [`crate::context_peak::claude_transcript_time_span`] stays a direct call —
 /// the seam to extend when a second harness grows subagent transcripts.
+///
+/// `node_pairs` / `model_axis` are `Some` only for a Node's own subagents —
+/// the `by_pipeline` drill's couples and the « By model » axis are Node
+/// executions; an Infrastructure role's residual subagents stay off both
+/// (module doc, « The « By model » axis »).
+#[allow(clippy::too_many_arguments)]
 fn fold_subagents(
     subagents: &mut BTreeMap<String, SubagentAcc>,
+    mut node_pairs: Option<&mut BTreeMap<ModelEffortKey, ModelPairAcc>>,
+    mut model_axis: Option<&mut BTreeMap<String, ModelAxisModelAcc>>,
+    pipeline_id: &str,
+    pipeline_name: &str,
+    node_id: &str,
+    node_name: &str,
     files: Vec<(String, String)>,
     harness: &str,
 ) {
@@ -523,17 +978,76 @@ fn fold_subagents(
                 .is_none()
                 .then_some("no reliable start/end bounds in subagent transcript"),
         );
+
+        // ADR-0065 §3: the file's peak (and span) follows the file's own model —
+        // a subagent on another model lands in its own bucket. A subagent has no
+        // startup event, so ONLY the observed identities count: a mute file
+        // invents nothing (never a "default of X" bucket).
+        if let (Some(node_pairs), Some(model_axis)) =
+            (node_pairs.as_deref_mut(), model_axis.as_deref_mut())
+        {
+            let source = crate::harness_probes::observed_identity_source(harness);
+            if source.is_some() {
+                for identity in crate::harness_probes::observed_identities(harness, &text) {
+                    // Same source-first rule as a main session (ADR-0065 §1):
+                    // `pi`/`copilot` subagents would carry their own observed
+                    // effort; a mute effort is « not set », never requested.
+                    let (effort, effort_observed) = match source {
+                        Some(crate::harness_probes::ObservedIdentitySource::ModelAndEffort) => {
+                            let observed_effort = identity.effort;
+                            let observed = observed_effort.clone();
+                            (observed_effort, Some(observed.is_some()))
+                        }
+                        _ => (None, None),
+                    };
+                    let model_identity = ModelIdentity {
+                        model: identity.model,
+                        effort,
+                        model_observed: true,
+                        effort_observed,
+                    };
+                    record_model_observation(
+                        model_axis,
+                        node_pairs,
+                        pipeline_id,
+                        pipeline_name,
+                        node_id,
+                        node_name,
+                        harness,
+                        &model_identity,
+                        (
+                            peak.map(|p| p as f64),
+                            (peak.is_none()).then_some("no readable context usage in transcript"),
+                        ),
+                        (
+                            sub_duration,
+                            sub_duration
+                                .is_none()
+                                .then_some("no reliable start/end bounds in subagent transcript"),
+                        ),
+                    );
+                }
+            }
+        }
     }
 }
 
 /// Record one successful Node execution into its Node, its Pipeline and the
-/// cohort total alike. Discovered subagent transcripts go into the Node's own
-/// subagent groups and NEVER into any of the three harness accumulators.
+/// cohort total alike, plus the « By model » axis (#737): the main session's
+/// peak + duration goes to the model × effort bucket its own session file
+/// names (observed from the source, the startup event's requested identity in
+/// fallback). Discovered subagent transcripts go into the Node's own subagent
+/// groups and NEVER into any of the three harness accumulators.
 #[allow(clippy::too_many_arguments)]
 fn record_node_success(
     node_acc: &mut NodeAcc,
     pipeline_by_harness: &mut BTreeMap<String, HarnessAcc>,
     total_by_harness: &mut BTreeMap<String, HarnessAcc>,
+    model_axis: &mut BTreeMap<String, ModelAxisModelAcc>,
+    pipeline_id: &str,
+    pipeline_name: &str,
+    node_id: &str,
+    node_name: &str,
     claude_root: &Path,
     stores: &HarnessStores,
     working_dir: &Path,
@@ -543,7 +1057,7 @@ fn record_node_success(
 ) -> Result<(), PerformanceError> {
     let harness = pending.harness.clone();
     let root = source_root(&harness, claude_root, stores);
-    let (context, reason) = main_session_context(
+    let (context, reason, main_text) = main_session_observation(
         &harness,
         root,
         working_dir,
@@ -551,6 +1065,7 @@ fn record_node_success(
         seen_roots,
     )?;
     let duration = duration_millis(&pending.started_at, completed_at);
+    let duration_reason = duration.is_none().then_some("unparseable timestamp");
 
     for acc in [
         node_acc.by_harness.entry(harness.clone()).or_default(),
@@ -558,14 +1073,47 @@ fn record_node_success(
         total_by_harness.entry(harness.clone()).or_default(),
     ] {
         acc.context.observe(context, reason);
-        acc.duration.observe(
-            duration,
-            duration.is_none().then_some("unparseable timestamp"),
+        acc.duration.observe(duration, duration_reason);
+    }
+
+    // ADR-0065 §1: the main session's observation is attributed to the model(s)
+    // its own session file names — observed first, the requested identity in
+    // fallback, nothing invented when neither speaks.
+    for identity in main_session_identities(
+        &harness,
+        root,
+        working_dir,
+        pending.session_id.as_deref(),
+        pending.requested_model.as_deref(),
+        pending.requested_effort.as_deref(),
+        main_text.as_deref(),
+    ) {
+        record_model_observation(
+            model_axis,
+            &mut node_acc.pairs,
+            pipeline_id,
+            pipeline_name,
+            node_id,
+            node_name,
+            &harness,
+            &identity,
+            (context, reason),
+            (duration, duration_reason),
         );
     }
 
     let files = subagent_groups(&harness, root, working_dir, pending.session_id.as_deref());
-    fold_subagents(&mut node_acc.subagents, files, &harness);
+    fold_subagents(
+        &mut node_acc.subagents,
+        Some(&mut node_acc.pairs),
+        Some(model_axis),
+        pipeline_id,
+        pipeline_name,
+        node_id,
+        node_name,
+        files,
+        &harness,
+    );
 
     Ok(())
 }
@@ -754,7 +1302,20 @@ fn record_infra_success(
     );
 
     if run_harness == crate::harness_registry::CLAUDE {
-        fold_subagents(&mut acc.subagents, subs, run_harness);
+        // Infrastructure stays off the « By model » axis and its Node couples
+        // (module doc): the role's residual sessions carry no model identity of
+        // their own, and the axis compares Node executions.
+        fold_subagents(
+            &mut acc.subagents,
+            None,
+            None,
+            "",
+            "",
+            "",
+            "",
+            subs,
+            run_harness,
+        );
     }
 
     Ok(())
@@ -935,6 +1496,7 @@ async fn compute_performance(
 fn fold_performance(contexts: Vec<RunContext>) -> Result<StatsPerformance, PerformanceError> {
     let mut seen_roots: HashSet<PathBuf> = HashSet::new();
     let mut pipelines: BTreeMap<String, PipelineAcc> = BTreeMap::new();
+    let mut model_axis: BTreeMap<String, ModelAxisModelAcc> = BTreeMap::new();
     let mut total_by_harness: BTreeMap<String, HarnessAcc> = BTreeMap::new();
     let mut infrastructure_total_by_harness: BTreeMap<String, HarnessAcc> = BTreeMap::new();
     let mut pipeline_manager_acc = NodeAcc::default();
@@ -970,7 +1532,7 @@ fn fold_performance(contexts: Vec<RunContext>) -> Result<StatsPerformance, Perfo
             .to_string();
 
         let pipeline_acc = pipelines.entry(pipeline_id.clone()).or_default();
-        pipeline_acc.name = pipeline_name;
+        pipeline_acc.name = pipeline_name.clone();
 
         let mut pending: HashMap<(String, i64), PendingNode> = HashMap::new();
         let mut node_starts: HashMap<(String, i64), Vec<NodeStartRecord>> = HashMap::new();
@@ -1013,6 +1575,19 @@ fn fold_performance(contexts: Vec<RunContext>) -> Result<StatsPerformance, Perfo
                         .and_then(|v| v.as_str())
                         .filter(|s| !s.is_empty())
                         .map(str::to_string);
+                    // The requested model × effort, frozen at spawn (ADR-0046) —
+                    // the « By model » axis's fallback when the source is mute
+                    // (ADR-0065 §1). Same payload fields the cost fold reads.
+                    let requested_model = event_payload
+                        .and_then(|p| p.get("model"))
+                        .and_then(|v| v.as_str())
+                        .filter(|s| !s.is_empty())
+                        .map(str::to_string);
+                    let requested_effort = event_payload
+                        .and_then(|p| p.get("effort"))
+                        .and_then(|v| v.as_str())
+                        .filter(|s| !s.is_empty())
+                        .map(str::to_string);
                     node_starts
                         .entry((node_id.clone(), iter))
                         .or_default()
@@ -1032,6 +1607,8 @@ fn fold_performance(contexts: Vec<RunContext>) -> Result<StatsPerformance, Perfo
                             harness,
                             session_id,
                             isolated,
+                            requested_model,
+                            requested_effort,
                         },
                     );
                 }
@@ -1044,8 +1621,8 @@ fn fold_performance(contexts: Vec<RunContext>) -> Result<StatsPerformance, Perfo
                             .get(&node_id)
                             .map(|(name, ..)| name.clone())
                             .unwrap_or_else(|| node_id.clone());
-                        let node_acc = pipeline_acc.nodes.entry(node_id).or_default();
-                        node_acc.name = node_name;
+                        let node_acc = pipeline_acc.nodes.entry(node_id.clone()).or_default();
+                        node_acc.name = node_name.clone();
                         let working_dir = if p.isolated {
                             crate::worktree_ops::sub_worktree_path(
                                 &repo_root,
@@ -1061,6 +1638,11 @@ fn fold_performance(contexts: Vec<RunContext>) -> Result<StatsPerformance, Perfo
                             node_acc,
                             &mut pipeline_acc.by_harness,
                             &mut total_by_harness,
+                            &mut model_axis,
+                            &pipeline_id,
+                            &pipeline_name,
+                            &node_id,
+                            &node_name,
                             &claude_root,
                             &stores,
                             &working_dir,
@@ -1203,5 +1785,6 @@ fn fold_performance(contexts: Vec<RunContext>) -> Result<StatsPerformance, Perfo
         infrastructure_total: PerformanceAggregate {
             harnesses: finish_by_harness(infrastructure_total_by_harness),
         },
+        by_model: wire_model_axis(model_axis),
     })
 }

--- a/frontend/src/components/StatsCharts.test.tsx
+++ b/frontend/src/components/StatsCharts.test.tsx
@@ -4,6 +4,7 @@ import { describe, it, expect } from "vitest";
 
 import StatsCharts from "./StatsCharts";
 import type {
+  PerformanceModelEffortPair,
   StatsCost,
   StatsHarnessCost,
   StatsModelEffortPair,
@@ -409,6 +410,27 @@ const distribution = (mean: number, measured = 2, expected = 2) => ({
   missing_reasons: measured === expected ? [] : ["no reliable bounds"],
 });
 
+const DESIGN_MODELS: PerformanceModelEffortPair[] = [
+  {
+    model: "claude-opus-4-8",
+    model_provenance: "observed",
+    effort: null,
+    effort_provenance: null,
+    harnesses: [
+      { harness: "claude", context: distribution(150_000, 1, 1), duration: distribution(360_000, 1, 1) },
+    ],
+  },
+  {
+    model: "sonnet",
+    model_provenance: "requested",
+    effort: "high",
+    effort_provenance: "requested",
+    harnesses: [
+      { harness: "claude", context: distribution(95_000, 1, 1), duration: distribution(340_000, 1, 1) },
+    ],
+  },
+];
+
 const PERFORMANCE: StatsPerformance = {
   harnesses: ["claude", "copilot"],
   total: {
@@ -439,6 +461,7 @@ const PERFORMANCE: StatsPerformance = {
             { harness: "copilot", context: distribution(84_000), duration: distribution(420_000, 1, 2) },
           ],
           nodes: [],
+          models: DESIGN_MODELS,
           subagents: [
             {
               id: "explore",
@@ -475,6 +498,7 @@ const PERFORMANCE: StatsPerformance = {
       subagents: [],
     },
   ],
+  by_model: [],
 };
 
 describe("StatsCharts — harness drill-down (#638)", () => {
@@ -818,5 +842,304 @@ describe("StatsCharts — Performance (#585)", () => {
       />,
     );
     expect(screen.getByText("Claude journal could not be read")).toBeInTheDocument();
+  });
+});
+
+describe("StatsCharts — Performance « By model » (#737, ADR-0065)", () => {
+  /** A « By model » payload with one two-model Node: the main sessions ran on
+   *  `claude-opus-4-8`, one subagent file on `sonnet` (its own bucket), one
+   *  execution's source was mute and fell back to the requested model. */
+  const BY_MODEL: StatsPerformance = {
+    harnesses: ["claude", "copilot"],
+    total: {
+      harnesses: [
+        { harness: "claude", context: distribution(96_000), duration: distribution(410_000) },
+      ],
+    },
+    infrastructure_total: { harnesses: [] },
+    by_pipeline: [],
+    infrastructure: [],
+    by_model: [
+      {
+        id: "claude-opus-4-8",
+        name: "claude-opus-4-8",
+        provenance: "observed",
+        harnesses: [
+          { harness: "claude", context: distribution(140_000), duration: distribution(350_000) },
+        ],
+        nodes: [],
+        subagents: [],
+        efforts: [
+          {
+            id: "high",
+            name: "high",
+            effort: "high",
+            provenance: "observed",
+            harnesses: [
+              { harness: "claude", context: distribution(140_000), duration: distribution(350_000) },
+            ],
+            nodes: [],
+            subagents: [],
+            pipelines: [
+              {
+                id: "pipeline-id",
+                name: "Implement loop",
+                harnesses: [
+                  { harness: "claude", context: distribution(140_000), duration: distribution(350_000) },
+                ],
+                nodes: [
+                  {
+                    id: "design-id",
+                    name: "Design",
+                    harnesses: [
+                      { harness: "claude", context: distribution(140_000), duration: distribution(350_000) },
+                    ],
+                    nodes: [],
+                    subagents: [],
+                  },
+                ],
+                subagents: [],
+              },
+            ],
+          },
+          {
+            id: "",
+            name: "not set",
+            effort: null,
+            provenance: null,
+            harnesses: [
+              { harness: "claude", context: distribution(55_000), duration: distribution(90_000) },
+            ],
+            nodes: [],
+            subagents: [],
+            pipelines: [],
+          },
+        ],
+      },
+      {
+        id: "sonnet",
+        name: "sonnet",
+        provenance: "mixed",
+        harnesses: [
+          { harness: "claude", context: distribution(95_000), duration: distribution(340_000) },
+        ],
+        nodes: [],
+        subagents: [],
+        efforts: [
+          {
+            id: "",
+            name: "not set",
+            effort: null,
+            provenance: null,
+            harnesses: [
+              { harness: "claude", context: distribution(95_000), duration: distribution(340_000) },
+            ],
+            nodes: [],
+            subagents: [],
+            pipelines: [],
+          },
+        ],
+      },
+    ],
+  };
+
+  function renderModel(performance: StatsPerformance = BY_MODEL) {
+    return render(
+      <StatsCharts
+        tab="performance"
+        overview={null}
+        cost={null}
+        costError={null}
+        performance={performance}
+        performanceError={null}
+      />,
+    );
+  }
+
+  it("offers two independent selects: the grouping never moves the sort", async () => {
+    const user = userEvent.setup();
+    renderModel();
+
+    const grouping = screen.getByRole("combobox", { name: "Performance grouping" });
+    expect(
+      within(grouping).getAllByRole("option").map((option) => option.textContent),
+    ).toEqual(["By pipeline", "By model"]);
+    expect(screen.getByText("Ranked by context")).toBeInTheDocument();
+
+    // The sort stays put across a grouping switch — and the reverse.
+    await user.selectOptions(grouping, "model");
+    expect(screen.getByText("Ranked by context")).toBeInTheDocument();
+    await user.selectOptions(screen.getByRole("combobox", { name: "Performance sort" }), "duration");
+    expect(screen.getByText("Ranked by duration")).toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: "Performance grouping" })).toHaveValue("model");
+
+    // A selection made on another axis does not survive the switch.
+    await user.click(screen.getByRole("option", { name: /claude-opus-4-8/ }));
+    await user.selectOptions(screen.getByRole("combobox", { name: "Performance grouping" }), "pipeline");
+    // « By pipeline » keeps its one-line header; back on « By model » the
+    // breadcrumb is back at Total.
+    expect(screen.queryByTestId("stats-performance-breadcrumb")).not.toBeInTheDocument();
+    await user.selectOptions(screen.getByRole("combobox", { name: "Performance grouping" }), "model");
+    expect(screen.getByTestId("stats-performance-breadcrumb")).toHaveTextContent(/^Total$/);
+  });
+
+  it("drills model → effort → pipeline → node and pops back through the crumbs", async () => {
+    const user = userEvent.setup();
+    renderModel();
+    await user.selectOptions(screen.getByRole("combobox", { name: "Performance grouping" }), "model");
+
+    const rows = screen.getAllByTestId("stats-detail-row");
+    expect(rows[0]).toHaveTextContent("claude-opus-4-8");
+    expect(within(rows[0]).getByTestId("stats-model-name")).toHaveTextContent("claude-opus-4-8");
+    // Observed is the norm: no « ? » mark on the model row…
+    expect(within(rows[0]).queryAllByTestId("stats-provenance-model")).toHaveLength(0);
+    // …while the requested one carries it.
+    expect(within(rows[1]).getAllByTestId("stats-provenance-model")).toHaveLength(1);
+
+    await user.click(screen.getByRole("option", { name: /claude-opus-4-8/ }));
+    expect(screen.getByTestId("stats-performance-breadcrumb")).toHaveTextContent(
+      "Total / claude-opus-4-8",
+    );
+    expect(screen.getByText("not set")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Open high" }));
+    expect(screen.getByTestId("stats-performance-breadcrumb")).toHaveTextContent(
+      "Total / claude-opus-4-8 / high",
+    );
+    await user.click(screen.getByRole("button", { name: "Open Implement loop" }));
+    expect(screen.getByTestId("stats-performance-breadcrumb")).toHaveTextContent(
+      "Total / claude-opus-4-8 / high / Implement loop",
+    );
+    expect(screen.getAllByTestId("stats-detail-row")[0]).toHaveTextContent("Design");
+    // Node leaves are the floor: no couple chevron on the model axis.
+    expect(screen.queryByTestId("stats-node-toggle")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Back to high" }));
+    expect(screen.getByTestId("stats-performance-breadcrumb")).toHaveTextContent(
+      "Total / claude-opus-4-8 / high",
+    );
+    await user.click(screen.getByRole("button", { name: "Back to Total" }));
+    expect(screen.getByTestId("stats-performance-breadcrumb")).toHaveTextContent(/^Total$/);
+  });
+
+  it("marks provenance on hover like Cost, and keeps the not-set effort its own bucket", async () => {
+    const user = userEvent.setup();
+    renderModel();
+    await user.selectOptions(screen.getByRole("combobox", { name: "Performance grouping" }), "model");
+
+    await user.click(screen.getByRole("option", { name: /claude-opus-4-8/ }));
+    const notSet = screen.getAllByTestId("stats-detail-row")[1];
+    expect(notSet).toHaveTextContent("not set");
+    await user.hover(within(notSet).getByText("not set"));
+    expect(await screen.findByTestId("tooltip-content")).toHaveTextContent(
+      "no effort requested at node startup nor observed in transcripts",
+    );
+
+    // The requested model says so on hover, in the shared vocabulary (the
+    // tooltip renders its copy twice — visible + a11y — so substring match).
+    await user.click(screen.getByRole("button", { name: "Back to Total" }));
+    const sonnetRow = screen.getAllByTestId("stats-detail-row")[1];
+    const name = within(sonnetRow).getByTestId("stats-model-name");
+    await user.hover(name);
+    expect(await screen.findByTestId("tooltip-content")).toHaveTextContent(
+      "partly requested at node startup, not observed in every transcript",
+    );
+  });
+
+  it("expands a Node into its model × effort couples on By pipeline, not on By model", async () => {
+    const user = userEvent.setup();
+    const { unmount } = render(
+      <StatsCharts
+        tab="performance"
+        overview={null}
+        cost={null}
+        costError={null}
+        performance={PERFORMANCE}
+        performanceError={null}
+      />,
+    );
+
+    await user.click(screen.getByRole("option", { name: /Implement loop/ }));
+    const design = screen
+      .getAllByTestId("stats-detail-row")
+      .find((row) => row.textContent?.includes("Design"))!;
+    expect(within(design).getByTestId("stats-node-toggle")).toBeInTheDocument();
+
+    await user.click(within(design).getByTestId("stats-node-toggle"));
+    const coupleRows = screen.getAllByTestId("stats-performance-model-effort-row");
+    expect(coupleRows).toHaveLength(2);
+    // Distinct peaks and durations side by side, per harness dot included.
+    expect(coupleRows[0]).toHaveTextContent(/claude-opus-4-8\s*·\s*not set/);
+    expect(within(coupleRows[0]).getAllByTestId("performance-context-boxplot")).toHaveLength(1);
+    // The requested couple's model carries the « ? » mark; the effort too.
+    expect(coupleRows[1]).toHaveTextContent(/sonnet.*·.*high/);
+    // The requested couple carries the model and effort marks.
+    expect(within(coupleRows[1]).getAllByTestId("stats-provenance-effort")).toHaveLength(1);
+    expect(within(coupleRows[1]).getAllByTestId("stats-provenance-model")).toHaveLength(1);
+
+    // Under By model the path IS the drill: no chevrons anywhere.
+    unmount();
+    render(
+      <StatsCharts
+        tab="performance"
+        overview={null}
+        cost={null}
+        costError={null}
+        performance={{ ...PERFORMANCE, by_model: BY_MODEL.by_model }}
+        performanceError={null}
+      />,
+    );
+    await user.selectOptions(screen.getByRole("combobox", { name: "Performance grouping" }), "model");
+    await user.click(screen.getByRole("option", { name: /claude-opus-4-8/ }));
+    await user.click(screen.getByRole("button", { name: "Open high" }));
+    await user.click(screen.getByRole("button", { name: "Open Implement loop" }));
+    expect(screen.queryByTestId("stats-node-toggle")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("stats-performance-model-effort-row")).not.toBeInTheDocument();
+  });
+
+  it("keeps the Infrastructure row on By pipeline and out of By model", async () => {
+    const user = userEvent.setup();
+    render(
+      <StatsCharts
+        tab="performance"
+        overview={null}
+        cost={null}
+        costError={null}
+        performance={PERFORMANCE}
+        performanceError={null}
+      />,
+    );
+
+    expect(screen.getByRole("option", { name: /Infrastructure/ })).toBeInTheDocument();
+    await user.click(screen.getByRole("option", { name: /Infrastructure/ }));
+    expect(screen.getByText("Pipeline Manager")).toBeInTheDocument();
+
+    await user.selectOptions(screen.getByRole("combobox", { name: "Performance grouping" }), "model");
+    expect(screen.queryByRole("option", { name: /Infrastructure/ })).not.toBeInTheDocument();
+  });
+
+  it("renders the model axis with the shared headline, cards and empty states", async () => {
+    const user = userEvent.setup();
+    const { unmount } = renderModel();
+
+    const headline = screen.getByTestId("stats-performance-headline");
+    expect(headline).toHaveTextContent("median peak context");
+    expect(headline).toHaveTextContent("median duration");
+    unmount();
+
+    // An empty by_model beside a non-empty by_pipeline is an empty axis, not
+    // an empty tab.
+    render(
+      <StatsCharts
+        tab="performance"
+        overview={null}
+        cost={null}
+        costError={null}
+        performance={{ ...PERFORMANCE, by_model: [] }}
+        performanceError={null}
+      />,
+    );
+    await user.selectOptions(screen.getByRole("combobox", { name: "Performance grouping" }), "model");
+    expect(screen.getByText("No model observed in this period.")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/StatsCharts.test.tsx
+++ b/frontend/src/components/StatsCharts.test.tsx
@@ -1142,4 +1142,29 @@ describe("StatsCharts — Performance « By model » (#737, ADR-0065)", () => {
     await user.selectOptions(screen.getByRole("combobox", { name: "Performance grouping" }), "model");
     expect(screen.getByText("No model observed in this period.")).toBeInTheDocument();
   });
+
+  it("keeps the « ? » mark out of the drill button — no nested interactive (FP finding)", async () => {
+    const user = userEvent.setup();
+    const { unmount } = renderModel();
+
+    // On the By-model root the requested model's « ? » mark sits INSIDE the
+    // row's « Open … » button: the mark must be a plain span, not a second
+    // button (interactive-inside-interactive is invalid DOM).
+    await user.selectOptions(screen.getByRole("combobox", { name: "Performance grouping" }), "model");
+    const open = screen.getByRole("button", { name: "Open sonnet" });
+    expect(within(open).getAllByTestId("stats-provenance-model")).toHaveLength(1);
+    expect(open.querySelectorAll("button")).toHaveLength(0);
+    expect(within(open).getByTestId("stats-provenance-model").getAttribute("aria-label")).toMatch(
+      /requested at node startup/,
+    );
+    unmount();
+
+    // The Cost axis's « By model » root had the same nesting — fixed at the
+    // source, in the mark itself.
+    render(<StatsCharts tab="cost" overview={null} cost={COST} costError={null} />);
+    await user.selectOptions(screen.getByRole("combobox", { name: "Cost grouping" }), "model");
+    const costOpen = screen.getByRole("button", { name: "Open sonnet" });
+    expect(within(costOpen).getAllByTestId("stats-provenance-model")).toHaveLength(1);
+    expect(costOpen.querySelectorAll("button")).toHaveLength(0);
+  });
 });

--- a/frontend/src/components/StatsCharts.tsx
+++ b/frontend/src/components/StatsCharts.tsx
@@ -11,12 +11,14 @@ import {
   YAxis,
 } from "recharts";
 import type {
+  PerformanceEffortEntity,
   StatsCost,
   StatsCostAggregate,
   StatsCostEntity,
   StatsCostPeriod,
   StatsEffortCostEntity,
   StatsHarnessCost,
+  StatsHarnessPerformance,
   StatsModelEffortPair,
   StatsOverview,
   StatsProvenance,
@@ -447,6 +449,16 @@ const PROVENANCE_COPY: Record<Exclude<StatsProvenance, "observed">, string> = {
 /** Hovering the italic "not set" effort says why the bucket exists. */
 const NOT_SET_COPY = "no effort requested at node startup nor observed in transcripts";
 
+/** The Performance « By model » tooltip (#737): the wire carries the provenance
+ *  but not the per-harness source lines Cost shows, so the copy is the axis's
+ *  own honest summary (ADR-0065 §1). */
+function performanceProvenanceCopy(provenance: StatsProvenance | null | undefined): string {
+  if (!provenance || provenance === "observed") {
+    return "observed — the harness's source named the value";
+  }
+  return PROVENANCE_COPY[provenance];
+}
+
 function ProvenanceMark({
   provenance,
   target,
@@ -512,18 +524,22 @@ function ProvenanceName({
   provenance,
   harnesses,
   target,
+  content,
 }: {
   name: React.ReactNode;
   mono?: boolean;
   provenance: StatsProvenance | null | undefined;
   harnesses: StatsHarnessCost[];
   target: "model" | "effort";
+  /** Overrides the hover copy — the Performance axis carries provenance but no
+   *  per-harness source lines (#737). */
+  content?: string;
 }) {
   const lines = sourceLines(harnesses, target);
-  const content = lines.length ? lines.join("\n") : (provenance ?? "observed");
+  const tooltip = content ?? (lines.length ? lines.join("\n") : (provenance ?? "observed"));
   return (
     <span className="inline-flex items-baseline gap-0.5">
-      <Tooltip content={content} side="top">
+      <Tooltip content={tooltip} side="top">
         <span
           className={`${mono ? "font-mono" : ""} cursor-help whitespace-pre-line underline decoration-dotted decoration-transparent underline-offset-2 hover:decoration-fg-4`}
           data-testid={`stats-${target}-name`}
@@ -540,14 +556,18 @@ function ProvenanceName({
 
 function Breadcrumb({
   crumbs,
+  testid = "stats-cost-breadcrumb",
 }: {
   crumbs: { label: string; onClick?: () => void }[];
+  /** The Performance « By model » axis reuses the same breadcrumb under its own
+   *  test id (#737). */
+  testid?: string;
 }) {
   return (
     <div
       className="mb-3 text-fg-4"
       style={{ fontSize: "10.5px" }}
-      data-testid="stats-cost-breadcrumb"
+      data-testid={testid}
     >
       {crumbs.map((crumb, index) => (
         <span key={`${crumb.label}-${index}`}>
@@ -1195,16 +1215,49 @@ function PerformanceCards({ aggregate }: { aggregate: StatsPerformanceAggregate 
   );
 }
 
+function performanceEffortName(row: PerformanceEffortEntity): React.ReactNode {
+  if (row.effort === null) {
+    // The "not set" bucket: hovering the italic word explains it (ADR-0065 §1).
+    return (
+      <Tooltip content={NOT_SET_COPY} side="top">
+        <span className="italic text-fg-4">not set</span>
+      </Tooltip>
+    );
+  }
+  return (
+    <ProvenanceName
+      name={row.name}
+      provenance={row.provenance}
+      harnesses={[]}
+      target="effort"
+      content={performanceProvenanceCopy(row.provenance)}
+    />
+  );
+}
+
 function PerformanceTable({
   rows,
   harnesses,
   sort,
+  renderName,
+  onOpen,
+  expandablePairs = false,
 }: {
   rows: StatsPerformanceEntity[];
   harnesses: string[];
   sort: PerformanceMetric;
+  /** Replaces the default (button-or-plain) name cell — the model axis marks
+   *  provenance and renders "not set" in its own voice (#737). */
+  renderName?: (row: StatsPerformanceEntity) => React.ReactNode;
+  onOpen?: (row: StatsPerformanceEntity) => void;
+  /** Node rows gain a chevron unfolding their model × effort couples (ADR-0065).
+   *  Off on the model axis, where the model × effort path is already the drill. */
+  expandablePairs?: boolean;
 }) {
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  // The couples' own expansion, dying with the table like `expanded` — the
+  // parent keys the table on the drill path, so a stale set never leaks.
+  const [couplesExpanded, setCouplesExpanded] = useState<Set<string>>(new Set());
   const ordered = sortPerformance(rows, sort);
   const visible = ordered.flatMap((row) => [
     { row, child: false },
@@ -1212,6 +1265,8 @@ function PerformanceTable({
       ? sortPerformance(row.subagents, sort).map((child) => ({ row: child, child: true }))
       : []),
   ]);
+  // The shared scale is drawn from the rows and their subagents — a couple's
+  // peaks/durations come from those same session files, so they fit it.
   const scaleRows = rows.flatMap((row) => [row, ...row.subagents]);
   const scaleMax = (metric: PerformanceMetric) =>
     Math.max(
@@ -1222,6 +1277,39 @@ function PerformanceTable({
     );
   const contextMax = scaleMax("context");
   const durationMax = scaleMax("duration");
+
+  const metricCell = (
+    name: string,
+    rowHarnesses: StatsHarnessPerformance[] | undefined,
+    metric: PerformanceMetric,
+  ) => (
+    <td key={metric} className="py-2 pr-3 align-top">
+      <div className="grid gap-1.5">
+        {harnesses.map((harness) => (
+          <div key={harness} className="flex items-start gap-2">
+            <span
+              className="mt-1 h-[7px] w-[7px] shrink-0 rounded-full"
+              style={{ backgroundColor: harnessColor(harness) }}
+            />
+            <DistributionPlot
+              name={name}
+              harness={harness}
+              metric={metric}
+              value={
+                rowHarnesses?.find((item) => item.harness === harness)?.[metric] ?? {
+                  stats: null,
+                  measured: 0,
+                  expected: 0,
+                  missing_reasons: [`never ran on ${harness}`],
+                }
+              }
+              scaleMax={metric === "context" ? contextMax : durationMax}
+            />
+          </div>
+        ))}
+      </div>
+    </td>
+  );
 
   return (
     <TooltipProvider>
@@ -1234,65 +1322,130 @@ function PerformanceTable({
           </tr>
         </thead>
         <tbody>
-          {visible.map(({ row, child }) => (
-            <tr key={`${child ? "subagent" : "entity"}-${row.id}`} className="border-t border-line">
-              <td className={`py-2 pr-2 text-fg-2 ${child ? "pl-7" : ""}`}>
-                {!child && row.subagents.length > 0 ? (
-                  <button
-                    type="button"
-                    aria-label={`${expanded.has(row.id) ? "Collapse" : "Expand"} ${row.name} subagents`}
-                    onClick={() =>
-                      setExpanded((current) => {
-                        const next = new Set(current);
-                        if (next.has(row.id)) next.delete(row.id);
-                        else next.add(row.id);
-                        return next;
-                      })
-                    }
-                    className="inline-flex items-center gap-1 hover:text-fg"
-                  >
-                    {expanded.has(row.id) ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
-                    {row.name}
-                  </button>
-                ) : (
-                  row.name
-                )}
-              </td>
-              {(["context", "duration"] as const).map((metric) => (
-                <td key={metric} className="py-2 pr-3 align-top">
-                  <div className="grid gap-1.5">
-                    {harnesses.map((harness) => (
-                      <div key={harness} className="flex items-start gap-2">
-                        <span
-                          className="mt-1 h-[7px] w-[7px] shrink-0 rounded-full"
-                          style={{ backgroundColor: harnessColor(harness) }}
-                        />
-                        <DistributionPlot
-                          name={row.name}
-                          harness={harness}
-                          metric={metric}
-                          value={
-                            row.harnesses.find((item) => item.harness === harness)?.[metric] ?? {
-                              stats: null,
-                              measured: 0,
-                              expected: 0,
-                              missing_reasons: [`never ran on ${harness}`],
-                            }
+          {visible.map(({ row, child }) => {
+            const couples = !child && expandablePairs ? (row.models ?? []) : [];
+            return (
+              <Fragment key={`${child ? "subagent" : "entity"}-${row.id}`}>
+                <tr className="border-t border-line" data-testid="stats-detail-row">
+                  <td className={`py-2 pr-2 text-fg-2 ${child ? "pl-7" : ""}`}>
+                    <span className="inline-flex items-center gap-1">
+                      {couples.length > 0 ? (
+                        <button
+                          type="button"
+                          aria-label={`${couplesExpanded.has(row.id) ? "Collapse" : "Expand"} ${row.name} models`}
+                          data-testid="stats-node-toggle"
+                          onClick={() =>
+                            setCouplesExpanded((current) => {
+                              const next = new Set(current);
+                              if (next.has(row.id)) next.delete(row.id);
+                              else next.add(row.id);
+                              return next;
+                            })
                           }
-                          scaleMax={metric === "context" ? contextMax : durationMax}
-                        />
-                      </div>
-                    ))}
-                  </div>
-                </td>
-              ))}
-            </tr>
-          ))}
+                          className="shrink-0 hover:text-fg"
+                        >
+                          {couplesExpanded.has(row.id) ? (
+                            <ChevronDown size={12} />
+                          ) : (
+                            <ChevronRight size={12} />
+                          )}
+                        </button>
+                      ) : null}
+                      {!child && row.subagents.length > 0 ? (
+                        <button
+                          type="button"
+                          aria-label={`${expanded.has(row.id) ? "Collapse" : "Expand"} ${row.name} subagents`}
+                          onClick={() =>
+                            setExpanded((current) => {
+                              const next = new Set(current);
+                              if (next.has(row.id)) next.delete(row.id);
+                              else next.add(row.id);
+                              return next;
+                            })
+                          }
+                          className="shrink-0 hover:text-fg"
+                        >
+                          {expanded.has(row.id) ? (
+                            <ChevronDown size={12} />
+                          ) : (
+                            <ChevronRight size={12} />
+                          )}
+                        </button>
+                      ) : null}
+                      {(() => {
+                        const content = renderName ? renderName(row) : row.name;
+                        return onOpen ? (
+                          <button
+                            type="button"
+                            aria-label={`Open ${row.name}`}
+                            onClick={() => onOpen(row)}
+                            className="text-left hover:text-fg"
+                          >
+                            {content}
+                          </button>
+                        ) : (
+                          <span>{content}</span>
+                        );
+                      })()}
+                    </span>
+                  </td>
+                  {(["context", "duration"] as const).map((metric) =>
+                    metricCell(row.name, row.harnesses, metric),
+                  )}
+                </tr>
+                {couplesExpanded.has(row.id)
+                  ? couples.map((pair) => (
+                      <tr
+                        key={`${row.id}-${pair.model}-${pair.effort ?? ""}`}
+                        className="border-t border-line bg-bg-3/40 text-fg-3"
+                        data-testid="stats-performance-model-effort-row"
+                      >
+                        <td className="py-2 pl-7 pr-2">
+                          <span className="inline-flex items-baseline gap-1">
+                            <ProvenanceName
+                              name={pair.model}
+                              mono
+                              provenance={pair.model_provenance}
+                              harnesses={[]}
+                              target="model"
+                              content={performanceProvenanceCopy(pair.model_provenance)}
+                            />
+                            <span className="text-fg-4">·</span>
+                            {pair.effort === null ? (
+                              <Tooltip content={NOT_SET_COPY} side="top">
+                                <span className="italic text-fg-4">not set</span>
+                              </Tooltip>
+                            ) : (
+                              <ProvenanceName
+                                name={pair.effort}
+                                provenance={pair.effort_provenance}
+                                harnesses={[]}
+                                target="effort"
+                                content={performanceProvenanceCopy(pair.effort_provenance)}
+                              />
+                            )}
+                          </span>
+                        </td>
+                        {(["context", "duration"] as const).map((metric) =>
+                          metricCell(
+                            `${pair.model} · ${pair.effort ?? "not set"}`,
+                            pair.harnesses,
+                            metric,
+                          ),
+                        )}
+                      </tr>
+                    ))
+                  : null}
+              </Fragment>
+            );
+          })}
         </tbody>
       </table>
     </TooltipProvider>
   );
 }
+
+type PerformanceAxis = "pipeline" | "model";
 
 function PerformanceTab({
   performance,
@@ -1301,8 +1454,18 @@ function PerformanceTab({
   performance: StatsPerformance | null;
   error: string | null;
 }) {
+  // The second select (#737): grouping (« By pipeline » / « By model »), fully
+  // independent of the sort (« By context » / « By duration ») beside it.
+  const [axis, setAxis] = useState<PerformanceAxis>("pipeline");
   const [sort, setSort] = useState<PerformanceMetric>("context");
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  // The model axis drills Model → Effort → Pipeline → Node (ADR-0065). The
+  // effort id is "" for the "not set" bucket, so selection is `null` vs value,
+  // never falsy-compared.
+  const [selectedModelId, setSelectedModelId] = useState<string | null>(null);
+  const [selectedEffortId, setSelectedEffortId] = useState<string | null>(null);
+  const [selectedPipelineId, setSelectedPipelineId] = useState<string | null>(null);
+
   if (error) {
     return (
       <div className="rounded-md border border-st-failed/30 bg-st-failed-bg px-3 py-2 text-st-failed">
@@ -1311,9 +1474,25 @@ function PerformanceTab({
     );
   }
   if (!performance) return <EmptyNote>Loading performance…</EmptyNote>;
-  if (performance.by_pipeline.length === 0 && performance.infrastructure.length === 0) {
+  if (
+    performance.by_pipeline.length === 0 &&
+    performance.infrastructure.length === 0 &&
+    performance.by_model.length === 0
+  ) {
     return <EmptyNote>No successful executions in this period.</EmptyNote>;
   }
+  // A period whose observations all lack a resolvable model is an empty axis —
+  // its own absence, not a broken tab.
+  if (axis === "model" && performance.by_model.length === 0) {
+    return <EmptyNote>No model observed in this period.</EmptyNote>;
+  }
+
+  const toTotal = () => {
+    setSelectedId(null);
+    setSelectedModelId(null);
+    setSelectedEffortId(null);
+    setSelectedPipelineId(null);
+  };
 
   const infrastructureRow: StatsPerformanceEntity = {
     id: "__infrastructure__",
@@ -1322,22 +1501,99 @@ function PerformanceTab({
     nodes: performance.infrastructure,
     subagents: [],
   };
-  const masterRows = sortPerformance(
-    [...performance.by_pipeline, infrastructureRow],
-    sort,
-  );
-  const selected = masterRows.find((row) => row.id === selectedId) ?? null;
-  const aggregate = selected ?? performance.total;
-  const detailRows = selected
-    ? selected.id === "__infrastructure__"
-      ? performance.infrastructure
-      : selected.nodes
-    : masterRows;
+
+  // Model axis: resolve the drill path.
+  const model =
+    axis === "model"
+      ? (performance.by_model.find((row) => row.id === selectedModelId) ?? null)
+      : null;
+  const effort =
+    model && selectedEffortId !== null
+      ? (model.efforts.find((row) => row.id === selectedEffortId) ?? null)
+      : null;
+  const modelPipeline =
+    effort && selectedPipelineId !== null
+      ? (effort.pipelines.find((row) => row.id === selectedPipelineId) ?? null)
+      : null;
+
+  const masterRows =
+    axis === "model"
+      ? sortPerformance(performance.by_model, sort)
+      : sortPerformance([...performance.by_pipeline, infrastructureRow], sort);
+  const selected =
+    axis === "pipeline" ? (masterRows.find((row) => row.id === selectedId) ?? null) : null;
+  const aggregate =
+    axis === "model"
+      ? (modelPipeline ?? effort ?? model ?? performance.total)
+      : (selected ?? performance.total);
+
+  let detailRows: StatsPerformanceEntity[];
+  let detailRenderName: ((row: StatsPerformanceEntity) => React.ReactNode) | undefined;
+  let onOpen: ((row: StatsPerformanceEntity) => void) | undefined;
+  if (axis === "model") {
+    if (modelPipeline) {
+      // Node leaves are the floor: the model × effort path is the drill.
+      detailRows = modelPipeline.nodes;
+    } else if (effort) {
+      detailRows = effort.pipelines;
+      onOpen = (row) => setSelectedPipelineId(row.id);
+    } else if (model) {
+      detailRows = model.efforts;
+      detailRenderName = (row) => {
+        const match = model.efforts.find((item) => item.id === row.id);
+        return match ? performanceEffortName(match) : row.name;
+      };
+      onOpen = (row) => setSelectedEffortId(row.id);
+    } else {
+      detailRows = performance.by_model;
+      detailRenderName = (row) => {
+        const provenance = performance.by_model.find((m) => m.id === row.id)?.provenance;
+        return (
+          <ProvenanceName
+            name={row.name}
+            mono
+            provenance={provenance}
+            harnesses={[]}
+            target="model"
+            content={performanceProvenanceCopy(provenance)}
+          />
+        );
+      };
+      onOpen = (row) => setSelectedModelId(row.id);
+    }
+  } else if (selected) {
+    detailRows =
+      selected.id === "__infrastructure__" ? performance.infrastructure : selected.nodes;
+  } else {
+    detailRows = masterRows;
+  }
+
   const contexts = aggregate.harnesses.map((item) =>
     item.context.stats ? formatPerformanceValue(item.context.stats.median, "context") : "—",
   );
   const durations = aggregate.harnesses.map((item) =>
     item.duration.stats ? formatPerformanceValue(item.duration.stats.median, "duration") : "—",
+  );
+
+  // The model axis's breadcrumb; « By pipeline » keeps its one-line header.
+  const crumbs: { label: string; onClick?: () => void }[] = [
+    { label: "Total", onClick: toTotal },
+  ];
+  if (axis === "model") {
+    if (model)
+      crumbs.push({
+        label: model.name,
+        onClick: () => {
+          setSelectedEffortId(null);
+          setSelectedPipelineId(null);
+        },
+      });
+    if (effort) crumbs.push({ label: effort.name, onClick: () => setSelectedPipelineId(null) });
+    if (modelPipeline) crumbs.push({ label: modelPipeline.name });
+  }
+  // Every crumb but the last pops the levels it shadows.
+  const clickableCrumbs = crumbs.map((crumb, index) =>
+    index === crumbs.length - 1 ? { label: crumb.label } : crumb,
   );
 
   return (
@@ -1347,31 +1603,65 @@ function PerformanceTab({
           <span className="text-fg-4" style={{ fontSize: "10.5px" }}>
             Ranked by {sort}
           </span>
-          <select
-            aria-label="Performance sort"
-            value={sort}
-            onChange={(event) => setSort(event.target.value as PerformanceMetric)}
-            className="rounded border border-line bg-bg-3 px-2 py-1 text-fg-2"
-          >
-            <option value="context">By context</option>
-            <option value="duration">By duration</option>
-          </select>
+          <span className="flex items-center gap-1.5">
+            <select
+              aria-label="Performance grouping"
+              value={axis}
+              onChange={(event) => {
+                setAxis(event.target.value as PerformanceAxis);
+                toTotal();
+              }}
+              className="rounded border border-line bg-bg-3 px-2 py-1 text-fg-2"
+            >
+              <option value="pipeline">By pipeline</option>
+              <option value="model">By model</option>
+            </select>
+            <select
+              aria-label="Performance sort"
+              value={sort}
+              onChange={(event) => setSort(event.target.value as PerformanceMetric)}
+              className="rounded border border-line bg-bg-3 px-2 py-1 text-fg-2"
+            >
+              <option value="context">By context</option>
+              <option value="duration">By duration</option>
+            </select>
+          </span>
         </div>
         <MasterList
           rows={masterRows}
-          selected={selectedId}
+          selected={axis === "model" ? selectedModelId : selectedId}
+          monoName={axis === "model"}
           ariaLabel="Performance groups"
           valueLabel={(row) => {
             const [mean] = performanceScore(row, sort);
             return mean < 0 ? "—" : formatPerformanceValue(mean, sort);
           }}
-          onSelect={setSelectedId}
+          onSelect={(id) => {
+            if (axis === "model") {
+              setSelectedModelId(id);
+              setSelectedEffortId(null);
+              setSelectedPipelineId(null);
+            } else {
+              setSelectedId(id);
+            }
+          }}
         />
+        {axis === "model" && (
+          <div className="mt-3 text-fg-4" style={{ fontSize: "10.5px" }}>
+            Model ids verbatim, one row per id — the same id run through two
+            harnesses is one row, one column per harness. Hover a model or an
+            effort for where the value was read.
+          </div>
+        )}
       </aside>
       <div className="min-w-0 flex-1 pl-5">
-        <div className="mb-3 text-fg-4" style={{ fontSize: "10.5px" }}>
-          Total{selected ? ` / ${selected.name}` : ""}
-        </div>
+        {axis === "model" ? (
+          <Breadcrumb testid="stats-performance-breadcrumb" crumbs={clickableCrumbs} />
+        ) : (
+          <div className="mb-3 text-fg-4" style={{ fontSize: "10.5px" }}>
+            Total{selected ? ` / ${selected.name}` : ""}
+          </div>
+        )}
         <HarnessLegend harnesses={performance.harnesses} />
         <div className="mt-4 text-fg" data-testid="stats-performance-headline">
           {contexts.join(" / ") || "—"} median peak context · {durations.join(" / ") || "—"} median
@@ -1382,9 +1672,13 @@ function PerformanceTab({
         </div>
         <div className="mt-4 min-h-[240px]">
           <PerformanceTable
+            key={`${axis}-${selectedId ?? ""}-${selectedModelId ?? "total"}-${selectedEffortId ?? "total"}-${selectedPipelineId ?? ""}`}
             rows={detailRows}
             harnesses={performance.harnesses}
             sort={sort}
+            renderName={detailRenderName}
+            onOpen={onOpen}
+            expandablePairs={axis === "pipeline"}
           />
         </div>
       </div>

--- a/frontend/src/components/StatsCharts.tsx
+++ b/frontend/src/components/StatsCharts.tsx
@@ -467,17 +467,21 @@ function ProvenanceMark({
   target: "model" | "effort";
 }) {
   const copy = PROVENANCE_COPY[provenance];
+  // A plain span, not a button: the mark often lands inside the row-name drill
+  // button (« Open claude-… »), and interactive-inside-interactive is invalid
+  // DOM (FP #737 finding). The tooltip is a description, not a control — same
+  // voice as the « not set » bucket's italic word.
   return (
     <Tooltip content={copy} side="top">
-      <button
-        type="button"
+      <span
+        role="img"
         aria-label={copy}
         data-testid={`stats-provenance-${target}`}
-        className="ml-0.5 align-super text-fg-4 hover:text-fg-2"
+        className="ml-0.5 align-super text-fg-4"
         style={{ fontSize: "8.5px" }}
       >
         ?
-      </button>
+      </span>
     </Tooltip>
   );
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1663,6 +1663,39 @@ export interface StatsPerformanceEntity extends StatsPerformanceAggregate {
   name: string;
   nodes: StatsPerformanceEntity[];
   subagents: StatsPerformanceEntity[];
+  /** The Node's observations split into model × effort couples (ADR-0065) —
+   *  Node leaves only, in « By pipeline »; the server omits it (never sends an
+   *  empty array) on other levels, and the « By model » path is already the
+   *  drill (#737). */
+  models?: PerformanceModelEffortPair[];
+}
+
+/** One model × effort couple of a Performance Node leaf (ADR-0065): the same
+ *  aggregate shape plus the pair identity and where each half was read from.
+ *  `effort = null` is the "not set" bucket — never merged with a real effort.
+ *  The peak of each session file is attributed to the model of that file, a
+ *  subagent having its own (#737). */
+export interface PerformanceModelEffortPair extends StatsPerformanceAggregate {
+  model: string;
+  model_provenance: StatsProvenance;
+  effort: string | null;
+  effort_provenance: StatsProvenance | null;
+}
+
+/** One effort level under a model in Performance « By model »: `id` is the
+ *  effort string ("" for not set) and `name` the effort or "not set". */
+export interface PerformanceEffortEntity extends StatsPerformanceEntity {
+  effort: string | null;
+  provenance?: StatsProvenance | null;
+  pipelines: StatsPerformanceEntity[];
+}
+
+/** One model (verbatim id) of Performance « By model », with its effort tree:
+ *  Model → Effort → Pipeline → Node (#737). The same id run through two
+ *  harnesses is one row, the harness staying a column. */
+export interface StatsModelPerformanceEntity extends StatsPerformanceEntity {
+  provenance: StatsProvenance;
+  efforts: PerformanceEffortEntity[];
 }
 
 /** Derived `GET /stats/performance` payload. */
@@ -1672,6 +1705,9 @@ export interface StatsPerformance {
   infrastructure_total: StatsPerformanceAggregate;
   by_pipeline: StatsPerformanceEntity[];
   infrastructure: StatsPerformanceEntity[];
+  /** The « By model » axis (ADR-0065): the same observations bucketed by the
+   *  model of the session file each came from (#737). */
+  by_model: StatsModelPerformanceEntity[];
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #737 (story #733, spec #734, ADR-0065)

## What

L'onglet Performance gagne un second select de groupement (« By pipeline » / « By model »), indépendant du tri existant.

- **Wire additif** : `by_model` — arbre Modèle → effort → Pipeline → Node, pic de contexte médian et durée médiane, mêmes boîtes à six statistiques, `measured` / `expected` / `missing_reasons` inchangés.
- **Attribution par fichier** : le pic de chaque fichier de session va au modèle de CE fichier (un sous-agent a son propre bucket), même découpage que Cost — sources observées d'abord (`harness_probes` : claude par message, pi modèle+fournisseur+niveau de réflexion, copilot modèle+effort aux points d'usage), repli sur le demandé marqué « ? » sinon, rien inventé.
- **Drill « By pipeline »** : les feuilles Node portent leurs couples modèle × effort (pics et durées distincts côte à côte) ; ligne Infrastructure conservée.
- **Provenance en infobulle** comme dans Cost ; marque « ? » rendue en `<span role="img">` (retour FP iter-1 : pas de bouton imbriqué).
- Memo de Performance invalidé par les mêmes empreintes (événements, mtimes) — rien de matérialisé.
- Tests : HTTP sur `GET /stats/performance` avec fixtures multi-modèles, tests unitaires des readers, Vitest sur le second select, l'arbre 4 niveaux, l'expansion des couples et la ligne Infrastructure.
- Release 1.73.0 + entrée CHANGELOG.

## Validation

- `make check` vert (cargo check, typecheck, support-table)
- `make test` vert : nextest 2948 passed, Vitest 2278 passed
- Verdict agentic-test **Pass** (FP #737 validé sur l'UI réelle, 3/3 étapes, finding iter-1 corrigé et revérifié)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
