### PR TITLE
fix(daemon): startup banner advertises http://localhost:<port> (#541) — 1.73.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ ascendante** : la casse se signale ici et par un bump majeur, jamais en gardant 
 morts. Seule contrainte non négociable — les **données historiques restent lisibles** : un Run
 archivé s'ouvre et se chiffre quelle que soit la version qui a écrit son payload.
 
+## 1.73.2
+
+**Le bandeau de démarrage du daemon annonce une URL navigable** (#541). `pdo daemon` écoute toujours
+sur `0.0.0.0:<port>` (#260), mais un navigateur ouvert sur `http://0.0.0.0:<port>` envoie une
+`Origin` que le garde WebSocket (#564) refuse : UI à moitié chargée, pied de page « reconnecting… ».
+La ligne de log garde l'adresse de bind pour l'opérateur et ajoute `— open http://localhost:<port>`
+(bind non spécifié `0.0.0.0`/`::` → `localhost` ; bind concret annoncé tel quel).
+
 ## 1.73.1
 
 **Stats › Cost — le headline d'un pipeline n'agrège plus le coût Infrastructure/Unassigned** (#742).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "1.73.1"
+version = "1.73.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "1.73.1"
+version = "1.73.2"
 license = "MIT"
 description = "Prompt-Driven Orchestrator — a local daemon that runs and supervises agentic coding pipelines"
 repository = "https://github.com/Loulen/prompt-driven-orchestrator"

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -2618,6 +2618,22 @@ impl DaemonConfig {
     }
 }
 
+/// The URL to advertise for a listener bound at `bound_addr` (#541).
+///
+/// An unspecified bind (`0.0.0.0` / `::`) is a *listen* address, not a
+/// *connect* address: browsers do reach it, but they then send
+/// `Origin: http://0.0.0.0:<port>`, which the WS guard refuses. Map it to
+/// `localhost`, the one host every default allowlist entry accepts. A concrete
+/// bind (`127.0.0.1`, a LAN IP) is advertised as-is.
+pub fn advertised_url(bound_addr: std::net::SocketAddr) -> String {
+    let ip = bound_addr.ip();
+    if ip.is_unspecified() {
+        format!("http://localhost:{}", bound_addr.port())
+    } else {
+        format!("http://{bound_addr}")
+    }
+}
+
 pub async fn serve(addr: SocketAddr, repo_root: PathBuf) -> Result<DaemonHandle> {
     serve_with_config(addr, repo_root, DaemonConfig::from_env()).await
 }
@@ -2794,7 +2810,14 @@ pub async fn serve_with_config(
 
     let app = build_router(state.clone());
 
-    info!("PDO daemon listening on http://{bound_addr}");
+    // #541: the bind address (`0.0.0.0`) is deliberate (#260) but is NOT a URL a
+    // browser can use — the WS Origin guard (#564) only knows `localhost` and
+    // `127.0.0.1`, so `http://0.0.0.0:<port>` half-loads the UI and 403s every
+    // socket. Advertise the URL that actually works, keep the bind for operators.
+    info!(
+        "PDO daemon listening on {bound_addr} — open {}",
+        advertised_url(bound_addr)
+    );
 
     // Only speak up when the operator configured extras — silence is the
     // localhost-only default. A malformed entry is KEPT, never fail-fast: a
@@ -19575,6 +19598,25 @@ mod tests {
     use axum::body::Body;
     use axum::http::Request;
     use tower::util::ServiceExt;
+
+    /// #541 — the startup banner must hand the user a URL the WS Origin guard
+    /// accepts. `0.0.0.0` (and `::`) are listen-only and map to `localhost`;
+    /// a concrete bind is advertised verbatim.
+    #[test]
+    fn advertised_url_maps_unspecified_bind_to_localhost() {
+        let v4: SocketAddr = "0.0.0.0:5172".parse().unwrap();
+        assert_eq!(advertised_url(v4), "http://localhost:5172");
+        let v6: SocketAddr = "[::]:5172".parse().unwrap();
+        assert_eq!(advertised_url(v6), "http://localhost:5172");
+    }
+
+    #[test]
+    fn advertised_url_keeps_concrete_bind() {
+        let lo: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        assert_eq!(advertised_url(lo), "http://127.0.0.1:0");
+        let lan: SocketAddr = "192.168.1.20:5172".parse().unwrap();
+        assert_eq!(advertised_url(lan), "http://192.168.1.20:5172");
+    }
 
     /// A unique fake daemon port per test state, so the derived tmux socket
     /// (`tmux_socket_name(port)` = `pdo-<port>`) is distinct per test. Tests spawn

--- a/crates/pdo-daemon/src/stats.rs
+++ b/crates/pdo-daemon/src/stats.rs
@@ -2352,7 +2352,12 @@ mod tests {
         let node = claude_node_contribution(
             "n",
             Some(5.0),
-            vec![model_slice("claude-opus-4-8", true, Some("high"), Some(5.0))],
+            vec![model_slice(
+                "claude-opus-4-8",
+                true,
+                Some("high"),
+                Some(5.0),
+            )],
         );
         let infra = crate::run_cost::CostContribution {
             harness: "claude".to_string(),
@@ -2366,7 +2371,12 @@ mod tests {
             partial: false,
             unpriced_models: Vec::new(),
             unavailable_reasons: Vec::new(),
-            model_slices: vec![model_slice("claude-opus-4-8", true, Some("high"), Some(2.0))],
+            model_slices: vec![model_slice(
+                "claude-opus-4-8",
+                true,
+                Some("high"),
+                Some(2.0),
+            )],
         };
         let unassigned = crate::run_cost::CostContribution {
             usd: Some(1.0),
@@ -2392,7 +2402,11 @@ mod tests {
             .collect();
         assert_eq!(
             rows,
-            vec![("n", Some(5.0)), ("p:infrastructure", Some(2.0)), ("p:unassigned", Some(1.0))],
+            vec![
+                ("n", Some(5.0)),
+                ("p:infrastructure", Some(2.0)),
+                ("p:unassigned", Some(1.0))
+            ],
             "infrastructure/unassigned stay visible as node rows"
         );
 


### PR DESCRIPTION
Closes #541

## What

\`pdo daemon\` keeps binding \`0.0.0.0:<port>\` (#260) but the startup line now reads:

\`\`\`
PDO daemon listening on 0.0.0.0:5172 — open http://localhost:5172
\`\`\`

Opening \`http://0.0.0.0:<port>\` sends an \`Origin\` the WS guard (#564) refuses, so the UI half-loads and the footer stays on "reconnecting…". \`advertised_url()\` maps an unspecified bind (\`0.0.0.0\` / \`::\`) to \`localhost\` and advertises a concrete bind verbatim.

## Verification

- Unit tests \`advertised_url_maps_unspecified_bind_to_localhost\` and \`advertised_url_keeps_concrete_bind\` pass.
- Agentic FP-541 (isolated daemon on :5541, playwright-cli): banner URL opens the UI with "Daemon: connected", 0 console errors, WS upgrade with the advertised Origin → 101. Control on the old \`0.0.0.0\` URL still 403s as designed.

## Notes

- Version 1.73.1 → 1.73.2 (patch). \`integration/674-page-mounts\` already carries 1.74.0; that branch's CHANGELOG/Cargo bump will need a trivial merge resolution when it lands on main.
- \`stats.rs\` hunk is rustfmt-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)