### PR TITLE
Story #674 — page mounts : pdo page mount|unmount|list et /pages/<name>/ (integration → main, v1.74.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ ascendante** : la casse se signale ici et par un bump majeur, jamais en gardant 
 morts. Seule contrainte non négociable — les **données historiques restent lisibles** : un Run
 archivé s'ouvre et se chiffre quelle que soit la version qui a écrit son payload.
 
+## 1.74.0
+
+**Page mounts — `pdo page mount|unmount|list` et service en lecture seule sous `/pages/<name>/`**
+(#743 ; story #674, ADR-0066, amendement de l'ADR-0028). Un agent ou un opérateur lie un nom à un
+répertoire du disque et l'ouvre aussitôt dans le navigateur en vrai HTML (type MIME deviné, scripts
+exécutés) ; le contenu servi est celui du disque à la requête, sans remount ni rebuild. Mêmes trois
+opérations en HTTP (`GET|POST /pages`, `DELETE /pages/{name}`), montages persistants au redémarrage.
+Un montage fait depuis une session de nœud porte l'id du Run et disparaît à son archivage ; hors Run
+il vit jusqu'au démontage et va dans l'`audit_log`. Fichier manquant sous `/pages/` = vrai 404
+(jamais le shell SPA) ; chemins canonisés et confinés au répertoire monté ; `.pdo/artifacts/` non
+montable. Le stockage vit dans un nouveau fichier `page_mount.rs` du crate daemon (module autonome :
+table + requêtes), d'où le ratchet de layout.
+
 ## 1.73.1
 
 **Stats › Cost — le headline d'un pipeline n'agrège plus le coût Infrastructure/Unassigned** (#742).

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -224,7 +224,7 @@ Le **Blackboard** est le store partagé où vivent tous les artefacts d'un Pipel
 
 Résolution des inputs : wire simple → dernière itération **complétée** du nœud source ; wire d'accumulation (`repeated`) → un artefact par itération complétée, ordonné par N. La résolution passe par la projection, pas par un glob disque (#353).
 
-**html** *(type de port de sortie)* : un port dont l'artefact est un `output.html` **rendu** dans une iframe sandboxée — HTML + CSS statiques, **aucun JS exécuté**, jamais servi en `text/html` par le daemon (ADR-0028). Surface de relecture, non consommée en aval en v1. _Éviter_ : « aperçu HTML interactif ».
+**html** *(type de port de sortie)* : un port dont l'artefact est un `output.html` **rendu** dans une iframe sandboxée — HTML + CSS statiques, **aucun JS exécuté**, jamais servi en `text/html` par le daemon (ADR-0028). Surface de relecture, non consommée en aval en v1. Pour montrer un prototype navigable, on passe par un **Page mount** (ADR-0066), pas par ce port. _Éviter_ : « aperçu HTML interactif ».
 
 ### Frontmatter — minimal
 
@@ -490,6 +490,10 @@ Le **repo cible** d'un Run ou d'un Trigger est le dépôt git dans lequel il tra
 La brique **unique** de sélection de chemin à la souris : un listing à **un niveau**, un composant, plusieurs consommateurs (sélecteur de repo, sélecteur de Dockerfile). Jamais de récursion, jamais de **contenus** renvoyés (noms seulement) ; liens cassés et fichiers spéciaux invisibles ; mode fichier = select-then-confirm. Surface non authentifiée comme tout le HTTP du daemon — portée LAN assumée (#260 closed). _Éviter_ : « repo browser » (généralisé en #431, sans alias).
 
 ---
+
+## Page mount
+
+**Page mount** *(montage de page)* : liaison explicite d'un **nom** à un **répertoire du disque**, servi en lecture seule et en vrai HTML (scripts exécutés) sous `/pages/<nom>/` — c'est ainsi qu'un agent ou un opérateur montre un prototype, un rapport ou un mockup à travers l'instance, sans rebuild (le contenu est celui du disque à la requête). Le geste est **délibéré** (`pdo page mount|unmount|list`, `POST/DELETE/GET /pages`) : c'est ce qui l'autorise à déroger à la sandbox des artefacts `html` (ADR-0066 amende ADR-0028). Un fichier absent sous `/pages/` est un **vrai 404**, jamais la coquille SPA ; le Blackboard n'est pas montable. Monté depuis un node, il porte le `run_id` et tombe à l'archivage du Run ; monté hors Run, il vit jusqu'au `unmount`. _Éviter_ : « static server », « artefact HTML » (ça, c'est le port `html`), « upload » (le répertoire existe déjà sur disque).
 
 ## Projet
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "1.73.1"
+version = "1.74.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "1.73.1"
+version = "1.74.0"
 license = "MIT"
 description = "Prompt-Driven Orchestrator — a local daemon that runs and supervises agentic coding pipelines"
 repository = "https://github.com/Loulen/prompt-driven-orchestrator"

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -43,6 +43,7 @@ mod node_io_resolver;
 mod node_primitives;
 mod node_spawn;
 mod outputs_validator;
+mod page_mount;
 mod pi_session;
 mod pipeline;
 mod pipeline_migrator;
@@ -107,12 +108,13 @@ use axum::extract::{
     FromRequest, Json, Multipart, Path as AxumPath, Query, State, WebSocketUpgrade,
 };
 use axum::http::{header, HeaderMap, Method, StatusCode, Uri};
-use axum::response::{Html, IntoResponse, Response};
+use axum::response::{Html, IntoResponse, Redirect, Response};
 use axum::routing::{get, post, put};
 use axum::Router;
 use clap::{Parser, Subcommand};
 use rust_embed::Embed;
 use serde::{Deserialize, Serialize};
+use tokio::io::AsyncReadExt;
 use tokio::sync::broadcast;
 use tokio::time;
 use tracing::{error, info, warn};
@@ -235,6 +237,21 @@ pub enum Commands {
         #[command(subcommand)]
         action: Box<RunAction>,
     },
+    /// Mount directories as live pages through the daemon.
+    Page {
+        #[command(subcommand)]
+        action: PageAction,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum PageAction {
+    /// Bind a name to a directory and serve it under `/pages/<name>/`.
+    Mount { name: String, directory: PathBuf },
+    /// List active page mounts.
+    List,
+    /// Remove a page mount.
+    Unmount { name: String },
 }
 
 #[derive(Subcommand, Debug)]
@@ -348,6 +365,10 @@ struct AppState {
     repo_root: PathBuf,
     port: u16,
     merge_lock: tokio::sync::Mutex<()>,
+    /// Serializes page-mount mutations with Run archival. The guard stays held
+    /// until `RunArchived` lands, so a verified node session cannot insert a
+    /// run-owned mount after cleanup removed that Run's mounts.
+    page_mount_lock: tokio::sync::Mutex<()>,
     /// Serializes admission so the slot check is atomic check-and-reserve. A
     /// spawn holds this from the moment it counts live sessions until it has
     /// appended the reservation event (`NodeStarted` / `NodeWaiting`). Without
@@ -1217,6 +1238,7 @@ pub fn run_run_create(action: RunAction) -> Result<()> {
     if let Some(v) = variables {
         body.insert("variables".into(), parse_json_arg("variables", &v)?);
     }
+
     if let Some(v) = skills {
         body.insert("skills".into(), parse_skills_arg(&v)?);
     }
@@ -1292,6 +1314,78 @@ pub fn run_run_create(action: RunAction) -> Result<()> {
         None => println!("Run {run_id} created (root run)."),
     }
     Ok(())
+}
+
+pub fn run_page(action: PageAction) -> Result<()> {
+    let url = cli_daemon_url();
+    let client = reqwest::blocking::Client::new();
+    let session = session_env_claim();
+    let with_identity = |request: reqwest::blocking::RequestBuilder| {
+        let mut request = request.header("X-PDO-Actor", "cli");
+        if let Some((run_id, node_id)) = &session {
+            request = request
+                .header(SESSION_RUN_HEADER, run_id)
+                .header(SESSION_NODE_HEADER, node_id);
+        }
+        request
+    };
+
+    match action {
+        PageAction::Mount { name, directory } => {
+            let directory = directory
+                .canonicalize()
+                .with_context(|| format!("cannot resolve {}", directory.display()))?;
+            let response = with_identity(client.post(format!("{url}/pages")))
+                .json(&serde_json::json!({ "name": name, "directory": directory }))
+                .send()
+                .context("failed to reach daemon")?;
+            let mount: page_mount::PageMount = page_cli_response(response, "mount page")?;
+            println!(
+                "Mounted {} at /pages/{}/ from {}.",
+                mount.name, mount.name, mount.directory
+            );
+        }
+        PageAction::List => {
+            let response = with_identity(client.get(format!("{url}/pages")))
+                .send()
+                .context("failed to reach daemon")?;
+            let mounts: Vec<page_mount::PageMount> = page_cli_response(response, "list pages")?;
+            for mount in mounts {
+                let run = mount.run_id.as_deref().unwrap_or("-");
+                println!(
+                    "{}\t{}\t{}\t{}",
+                    mount.name, mount.directory, run, mount.created_at
+                );
+            }
+        }
+        PageAction::Unmount { name } => {
+            let response = with_identity(client.delete(format!("{url}/pages/{name}")))
+                .send()
+                .context("failed to reach daemon")?;
+            let _: page_mount::PageMount = page_cli_response(response, "unmount page")?;
+            println!("Unmounted {name}.");
+        }
+    }
+    Ok(())
+}
+
+fn page_cli_response<T: serde::de::DeserializeOwned>(
+    response: reqwest::blocking::Response,
+    operation: &str,
+) -> Result<T> {
+    let status = response.status();
+    let raw = response.text().unwrap_or_default();
+    if !status.is_success() {
+        let parsed: serde_json::Value =
+            serde_json::from_str(&raw).unwrap_or(serde_json::Value::Null);
+        let detail = parsed
+            .get("error")
+            .and_then(|value| value.as_str())
+            .unwrap_or(raw.as_str());
+        anyhow::bail!("daemon refused to {operation} ({status}): {detail}");
+    }
+    serde_json::from_str(&raw)
+        .with_context(|| format!("unreadable success body from daemon: {raw}"))
 }
 
 /// One-shot `pdo docs`: render the documentation PDO generates from its own code,
@@ -2733,6 +2827,7 @@ pub async fn serve_with_config(
         repo_root,
         port: bound_addr.port(),
         merge_lock: tokio::sync::Mutex::new(()),
+        page_mount_lock: tokio::sync::Mutex::new(()),
         admission_lock: tokio::sync::Mutex::new(()),
         trigger_tick_lock: tokio::sync::Mutex::new(()),
         recent_writes,
@@ -4328,6 +4423,14 @@ fn build_router(state: Arc<AppState>) -> Router {
         .route("/pipelines", post(create_pipeline))
         .route("/runs", post(create_run))
         .route("/runs", get(list_runs))
+        .route("/pages", get(list_page_mounts).post(create_page_mount))
+        .route("/pages/", get(list_page_mounts))
+        .route(
+            "/pages/{name}",
+            get(redirect_page_mount).delete(delete_page_mount),
+        )
+        .route("/pages/{name}/", get(serve_page_mount_root))
+        .route("/pages/{name}/{*path}", get(serve_page_mount_file))
         // Static path — must stay declared before `/runs/{run_id}`.
         .route("/runs/reapable", get(list_reapable_runs))
         .route("/sessions", get(sessions))
@@ -4584,6 +4687,271 @@ struct ProvisioningPreviewRequest {
 
 fn default_provisioning_git_ref() -> String {
     "HEAD".to_string()
+}
+
+#[derive(Deserialize)]
+struct CreatePageMountRequest {
+    name: String,
+    directory: PathBuf,
+}
+
+async fn list_page_mounts(State(state): State<Arc<AppState>>) -> Response {
+    match page_mount::list(&state.db).await {
+        Ok(mounts) => Json(mounts).into_response(),
+        Err(error) => {
+            error!("failed to list page mounts: {error}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": "page mount storage error" })),
+            )
+                .into_response()
+        }
+    }
+}
+
+async fn create_page_mount(
+    State(state): State<Arc<AppState>>,
+    actor: audit_log::Actor,
+    headers: HeaderMap,
+    Json(request): Json<CreatePageMountRequest>,
+) -> Response {
+    let _guard = state.page_mount_lock.lock().await;
+    let session = session_claim_from_headers(&headers);
+    if let Some(claim) = &session {
+        if let Err((status, body)) = verify_session_claim(&state, claim).await {
+            return (status, Json(body)).into_response();
+        }
+    }
+
+    let mount = match page_mount::create(
+        &state.db,
+        &request.name,
+        &request.directory,
+        session.as_ref().map(|claim| claim.run_id.as_str()),
+    )
+    .await
+    {
+        Ok(mount) => mount,
+        Err(page_mount::MountError::Invalid(message)) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({ "error": message })),
+            )
+                .into_response()
+        }
+        Err(page_mount::MountError::Duplicate(name)) => {
+            return (
+                StatusCode::CONFLICT,
+                Json(serde_json::json!({
+                    "error": format!("page mount `{name}` is already mounted")
+                })),
+            )
+                .into_response()
+        }
+        Err(page_mount::MountError::Database(error)) => {
+            error!("failed to create page mount: {error}");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": "page mount storage error" })),
+            )
+                .into_response();
+        }
+    };
+
+    if let Err(error) = record_page_mount_mutation(
+        &state,
+        actor,
+        session.as_ref(),
+        "page_mount.mounted",
+        None,
+        Some(serde_json::json!(mount)),
+    )
+    .await
+    {
+        if let Err(rollback_error) = page_mount::remove(&state.db, &mount.name).await {
+            error!(
+                "failed to roll back page mount {} after event error: {rollback_error}",
+                mount.name
+            );
+        }
+        error!("failed to record page mount event: {error:#}");
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({ "error": "page mount event log error" })),
+        )
+            .into_response();
+    }
+    (StatusCode::CREATED, Json(mount)).into_response()
+}
+
+async fn delete_page_mount(
+    State(state): State<Arc<AppState>>,
+    actor: audit_log::Actor,
+    headers: HeaderMap,
+    AxumPath(name): AxumPath<String>,
+) -> Response {
+    let _guard = state.page_mount_lock.lock().await;
+    let session = session_claim_from_headers(&headers);
+    if let Some(claim) = &session {
+        if let Err((status, body)) = verify_session_claim(&state, claim).await {
+            return (status, Json(body)).into_response();
+        }
+    }
+
+    let mount = match page_mount::remove(&state.db, &name).await {
+        Ok(Some(mount)) => mount,
+        Ok(None) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({ "error": format!("page mount `{name}` not found") })),
+            )
+                .into_response()
+        }
+        Err(error) => {
+            error!("failed to remove page mount: {error}");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": "page mount storage error" })),
+            )
+                .into_response();
+        }
+    };
+
+    if let Err(error) = record_page_mount_mutation(
+        &state,
+        actor,
+        session.as_ref(),
+        "page_mount.unmounted",
+        Some(serde_json::json!(mount)),
+        None,
+    )
+    .await
+    {
+        if let Err(rollback_error) = page_mount::restore(&state.db, &mount).await {
+            error!(
+                "failed to restore page mount {} after event error: {rollback_error}",
+                mount.name
+            );
+        }
+        error!("failed to record page unmount event: {error:#}");
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({ "error": "page mount event log error" })),
+        )
+            .into_response();
+    }
+    Json(mount).into_response()
+}
+
+async fn record_page_mount_mutation(
+    state: &AppState,
+    actor: audit_log::Actor,
+    session: Option<&SessionClaim>,
+    action: &str,
+    before: Option<serde_json::Value>,
+    after: Option<serde_json::Value>,
+) -> Result<()> {
+    let mount = before.as_ref().or(after.as_ref());
+    let name = mount
+        .and_then(|value| value.get("name"))
+        .and_then(|value| value.as_str())
+        .unwrap_or("");
+    if let Some(claim) = session {
+        append_event(
+            state,
+            &event_log::Event {
+                id: None,
+                run_id: claim.run_id.clone(),
+                ts: event_log::now_iso(),
+                kind: event_log::EventKind::CommandIssued,
+                node_id: Some(claim.node_id.clone()),
+                iter: None,
+                payload: Some(serde_json::json!({
+                    "command": action,
+                    "page_mount": mount,
+                })),
+            },
+        )
+        .await?;
+    } else {
+        audit_log::record_best_effort(
+            &state.db,
+            audit_log::NewAuditEntry {
+                actor_hint: actor.as_hint().to_string(),
+                action: action.to_string(),
+                target_kind: Some("page_mount".to_string()),
+                target_id: Some(name.to_string()),
+                before,
+                after,
+            },
+        )
+        .await;
+    }
+    Ok(())
+}
+
+async fn redirect_page_mount(
+    State(state): State<Arc<AppState>>,
+    AxumPath(name): AxumPath<String>,
+) -> Response {
+    match page_mount::get(&state.db, &name).await {
+        Ok(Some(_)) => Redirect::permanent(&format!("/pages/{name}/")).into_response(),
+        Ok(None) => page_not_found(),
+        Err(error) => {
+            error!("failed to resolve page mount: {error}");
+            StatusCode::INTERNAL_SERVER_ERROR.into_response()
+        }
+    }
+}
+
+async fn serve_page_mount_root(
+    State(state): State<Arc<AppState>>,
+    AxumPath(name): AxumPath<String>,
+) -> Response {
+    serve_page_mount(&state, &name, "").await
+}
+
+async fn serve_page_mount_file(
+    State(state): State<Arc<AppState>>,
+    AxumPath((name, path)): AxumPath<(String, String)>,
+) -> Response {
+    serve_page_mount(&state, &name, &path).await
+}
+
+async fn serve_page_mount(state: &AppState, name: &str, path: &str) -> Response {
+    let mount = match page_mount::get(&state.db, name).await {
+        Ok(Some(mount)) => mount,
+        Ok(None) => return page_not_found(),
+        Err(error) => {
+            error!("failed to resolve page mount: {error}");
+            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+        }
+    };
+    let Some(opened) = page_mount::open_file(&mount, path) else {
+        return page_not_found();
+    };
+    let mime = mime_guess::from_path(&opened.mime_path).first_or_octet_stream();
+    let mut file = tokio::fs::File::from_std(opened.file);
+    let mut content = Vec::new();
+    if let Err(error) = file.read_to_end(&mut content).await {
+        error!("failed to read mounted page: {error}");
+        return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+    }
+    (
+        StatusCode::OK,
+        [(header::CONTENT_TYPE, mime.as_ref())],
+        content,
+    )
+        .into_response()
+}
+
+fn page_not_found() -> Response {
+    (
+        StatusCode::NOT_FOUND,
+        [(header::CONTENT_TYPE, "text/plain; charset=utf-8")],
+        "page not found",
+    )
+        .into_response()
 }
 
 fn provisioning_rules_through_scope(
@@ -5085,6 +5453,10 @@ async fn init_db(db: &sqlx::SqlitePool) -> Result<()> {
     audit_log::init(db)
         .await
         .context("failed to create audit_log table")?;
+
+    page_mount::init(db)
+        .await
+        .context("failed to create page_mounts table")?;
 
     // Materialised on demand — nothing seeded.
     project_store::init(db)
@@ -8105,6 +8477,12 @@ async fn verify_session_claim(
             claim.run_id
         )));
     };
+    if !parent.status.is_live() {
+        return Err(refuse(format!(
+            "session claim refused: run `{}` is not live (status: {:?})",
+            claim.run_id, parent.status
+        )));
+    }
     let Some(node) = parent.nodes.get(&claim.node_id) else {
         return Err(refuse(format!(
             "session claim refused: run `{}` has no node `{}`",
@@ -17715,6 +18093,7 @@ fn spawn_terminal_attach(terminal: &str, socket: &str, session_name: &str) -> Re
 }
 
 async fn cleanup_run(state: &AppState, run_id: &str) -> Response {
+    let _page_mount_guard = state.page_mount_lock.lock().await;
     let (_, run_state) = match load_projected(state, run_id).await {
         Ok(t) => t,
         Err(resp) => return *resp,
@@ -17724,6 +18103,15 @@ async fn cleanup_run(state: &AppState, run_id: &str) -> Response {
         return (
             StatusCode::CONFLICT,
             Json(serde_json::json!({ "error": "run is already archived" })),
+        )
+            .into_response();
+    }
+
+    if let Err(error) = page_mount::remove_for_run(&state.db, run_id).await {
+        error!("cleanup_run: failed to remove page mounts for run {run_id}: {error}");
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({ "error": "page mount cleanup failed" })),
         )
             .into_response();
     }
@@ -20183,6 +20571,7 @@ mod tests {
             repo_root: std::env::current_dir().unwrap(),
             port: next_test_daemon_port(),
             merge_lock: tokio::sync::Mutex::new(()),
+            page_mount_lock: tokio::sync::Mutex::new(()),
             admission_lock: tokio::sync::Mutex::new(()),
             trigger_tick_lock: tokio::sync::Mutex::new(()),
             recent_writes: Arc::new(Mutex::new(HashMap::new())),
@@ -22505,6 +22894,7 @@ mod tests {
             repo_root: std::env::current_dir().unwrap(),
             port: next_test_daemon_port(),
             merge_lock: tokio::sync::Mutex::new(()),
+            page_mount_lock: tokio::sync::Mutex::new(()),
             admission_lock: tokio::sync::Mutex::new(()),
             trigger_tick_lock: tokio::sync::Mutex::new(()),
             recent_writes: Arc::new(Mutex::new(HashMap::new())),
@@ -27085,6 +27475,7 @@ mod tests {
             repo_root: dir.to_path_buf(),
             port: next_test_daemon_port(),
             merge_lock: tokio::sync::Mutex::new(()),
+            page_mount_lock: tokio::sync::Mutex::new(()),
             admission_lock: tokio::sync::Mutex::new(()),
             trigger_tick_lock: tokio::sync::Mutex::new(()),
             recent_writes: Arc::new(Mutex::new(HashMap::new())),
@@ -33337,6 +33728,7 @@ edges: []
             repo_root: repo.clone(),
             port: next_test_daemon_port(),
             merge_lock: tokio::sync::Mutex::new(()),
+            page_mount_lock: tokio::sync::Mutex::new(()),
             admission_lock: tokio::sync::Mutex::new(()),
             trigger_tick_lock: tokio::sync::Mutex::new(()),
             recent_writes: Arc::new(Mutex::new(HashMap::new())),
@@ -33545,6 +33937,7 @@ edges: []
             repo_root: repo.clone(),
             port: next_test_daemon_port(),
             merge_lock: tokio::sync::Mutex::new(()),
+            page_mount_lock: tokio::sync::Mutex::new(()),
             admission_lock: tokio::sync::Mutex::new(()),
             trigger_tick_lock: tokio::sync::Mutex::new(()),
             recent_writes: Arc::new(Mutex::new(HashMap::new())),

--- a/crates/pdo-daemon/src/main.rs
+++ b/crates/pdo-daemon/src/main.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use clap::Parser;
 use pdo_daemon::{
-    run_complete, run_daemon, run_docs, run_fail, run_migrate, run_reap, run_run_create,
+    run_complete, run_daemon, run_docs, run_fail, run_migrate, run_page, run_reap, run_run_create,
     run_service, run_skip, Cli, Commands,
 };
 use std::process::ExitCode;
@@ -54,6 +54,7 @@ fn main() -> ExitCode {
         } => run_reap(count, dry_run, ttl_hours, terminal_ttl_hours, budget_secs),
         Commands::Docs { action } => run_docs(action),
         Commands::Run { action } => run_run_create(*action),
+        Commands::Page { action } => run_page(action),
     };
 
     if let Err(e) = res {

--- a/crates/pdo-daemon/src/page_mount.rs
+++ b/crates/pdo-daemon/src/page_mount.rs
@@ -1,0 +1,280 @@
+use std::ffi::CString;
+use std::fs::File;
+use std::os::fd::{AsRawFd, FromRawFd};
+use std::os::unix::ffi::OsStrExt;
+use std::path::{Component, Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use sqlx::{Row, SqlitePool};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct PageMount {
+    pub name: String,
+    pub directory: String,
+    pub run_id: Option<String>,
+    pub created_at: String,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum MountError {
+    #[error("{0}")]
+    Invalid(String),
+    #[error("page mount `{0}` is already mounted")]
+    Duplicate(String),
+    #[error(transparent)]
+    Database(#[from] sqlx::Error),
+}
+
+pub(crate) async fn init(db: &SqlitePool) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS page_mounts (
+            name       TEXT PRIMARY KEY,
+            directory  TEXT NOT NULL,
+            run_id     TEXT,
+            created_at TEXT NOT NULL
+        )",
+    )
+    .execute(db)
+    .await?;
+    sqlx::query("CREATE INDEX IF NOT EXISTS idx_page_mounts_run_id ON page_mounts(run_id)")
+        .execute(db)
+        .await?;
+    Ok(())
+}
+
+pub(crate) async fn create(
+    db: &SqlitePool,
+    name: &str,
+    directory: &Path,
+    run_id: Option<&str>,
+) -> Result<PageMount, MountError> {
+    validate_name(name)?;
+    let directory = canonical_mount_directory(directory)?;
+    let mount = PageMount {
+        name: name.to_string(),
+        directory: directory.to_string_lossy().into_owned(),
+        run_id: run_id.map(str::to_string),
+        created_at: crate::event_log::now_iso(),
+    };
+
+    let result = sqlx::query(
+        "INSERT INTO page_mounts (name, directory, run_id, created_at) VALUES (?, ?, ?, ?)",
+    )
+    .bind(&mount.name)
+    .bind(&mount.directory)
+    .bind(&mount.run_id)
+    .bind(&mount.created_at)
+    .execute(db)
+    .await;
+
+    match result {
+        Ok(_) => Ok(mount),
+        Err(error) if is_unique_violation(&error) => Err(MountError::Duplicate(name.to_string())),
+        Err(error) => Err(MountError::Database(error)),
+    }
+}
+
+pub(crate) async fn get(db: &SqlitePool, name: &str) -> Result<Option<PageMount>, sqlx::Error> {
+    let row =
+        sqlx::query("SELECT name, directory, run_id, created_at FROM page_mounts WHERE name = ?")
+            .bind(name)
+            .fetch_optional(db)
+            .await?;
+    row.as_ref().map(row_to_mount).transpose()
+}
+
+pub(crate) async fn list(db: &SqlitePool) -> Result<Vec<PageMount>, sqlx::Error> {
+    let rows = sqlx::query(
+        "SELECT name, directory, run_id, created_at FROM page_mounts ORDER BY name ASC",
+    )
+    .fetch_all(db)
+    .await?;
+    rows.iter().map(row_to_mount).collect()
+}
+
+pub(crate) async fn remove(db: &SqlitePool, name: &str) -> Result<Option<PageMount>, sqlx::Error> {
+    let Some(mount) = get(db, name).await? else {
+        return Ok(None);
+    };
+    sqlx::query("DELETE FROM page_mounts WHERE name = ?")
+        .bind(name)
+        .execute(db)
+        .await?;
+    Ok(Some(mount))
+}
+
+pub(crate) async fn remove_for_run(db: &SqlitePool, run_id: &str) -> Result<u64, sqlx::Error> {
+    Ok(sqlx::query("DELETE FROM page_mounts WHERE run_id = ?")
+        .bind(run_id)
+        .execute(db)
+        .await?
+        .rows_affected())
+}
+
+pub(crate) async fn restore(db: &SqlitePool, mount: &PageMount) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "INSERT INTO page_mounts (name, directory, run_id, created_at) VALUES (?, ?, ?, ?)",
+    )
+    .bind(&mount.name)
+    .bind(&mount.directory)
+    .bind(&mount.run_id)
+    .bind(&mount.created_at)
+    .execute(db)
+    .await?;
+    Ok(())
+}
+
+pub(crate) struct OpenedPage {
+    pub file: File,
+    pub mime_path: PathBuf,
+}
+
+pub(crate) fn open_file(mount: &PageMount, requested: &str) -> Option<OpenedPage> {
+    let relative = Path::new(requested);
+    let mut components = Vec::new();
+    for component in relative.components() {
+        match component {
+            Component::Normal(name) => components.push(name.to_owned()),
+            Component::CurDir => {}
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => return None,
+        }
+    }
+
+    let root = PathBuf::from(&mount.directory);
+    let mut directory = open_directory_path(&root)?;
+
+    if components.is_empty() {
+        return open_index(&directory);
+    }
+
+    for component in &components[..components.len() - 1] {
+        directory = open_at(&directory, component, true)?;
+    }
+    let last = components.last()?;
+    let file = open_at(&directory, last, false)?;
+    if file.metadata().ok()?.is_dir() {
+        return open_index(&file);
+    }
+    if !file.metadata().ok()?.is_file() {
+        return None;
+    }
+    Some(OpenedPage {
+        file,
+        mime_path: PathBuf::from(last),
+    })
+}
+
+fn open_directory_path(path: &Path) -> Option<File> {
+    if !path.is_absolute() {
+        return None;
+    }
+    let mut directory = File::open("/").ok()?;
+    for component in path.components() {
+        match component {
+            Component::RootDir | Component::CurDir => {}
+            Component::Normal(name) => directory = open_at(&directory, name, true)?,
+            Component::ParentDir | Component::Prefix(_) => return None,
+        }
+    }
+    Some(directory)
+}
+
+fn open_index(directory: &File) -> Option<OpenedPage> {
+    let file = open_at(directory, std::ffi::OsStr::new("index.html"), false)?;
+    if !file.metadata().ok()?.is_file() {
+        return None;
+    }
+    Some(OpenedPage {
+        file,
+        mime_path: PathBuf::from("index.html"),
+    })
+}
+
+fn open_at(directory: &File, name: &std::ffi::OsStr, require_directory: bool) -> Option<File> {
+    let name = CString::new(name.as_bytes()).ok()?;
+    let mut flags = libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_CLOEXEC;
+    if require_directory {
+        flags |= libc::O_DIRECTORY;
+    }
+    // The returned descriptor is owned on success and immediately wrapped in
+    // `File`; every path component is resolved beneath the already-open parent.
+    let fd = unsafe { libc::openat(directory.as_raw_fd(), name.as_ptr(), flags) };
+    if fd < 0 {
+        return None;
+    }
+    // SAFETY: `openat` returned a fresh owned descriptor and no other owner exists.
+    Some(unsafe { File::from_raw_fd(fd) })
+}
+
+fn validate_name(name: &str) -> Result<(), MountError> {
+    if name.is_empty()
+        || name.len() > 64
+        || !name
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || b"_-".contains(&byte))
+    {
+        return Err(MountError::Invalid(
+            "page mount name must match [a-z0-9_-]{1,64}".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn canonical_mount_directory(directory: &Path) -> Result<PathBuf, MountError> {
+    let canonical = directory.canonicalize().map_err(|error| {
+        MountError::Invalid(format!("cannot mount `{}`: {error}", directory.display()))
+    })?;
+    if !canonical.is_dir() {
+        return Err(MountError::Invalid(format!(
+            "cannot mount `{}`: path is not a directory",
+            canonical.display()
+        )));
+    }
+    let components: Vec<_> = canonical.components().collect();
+    if components
+        .windows(2)
+        .any(|pair| pair[0].as_os_str() == ".pdo" && pair[1].as_os_str() == "artifacts")
+    {
+        return Err(MountError::Invalid(
+            "directories under .pdo/artifacts cannot be mounted".to_string(),
+        ));
+    }
+    Ok(canonical)
+}
+
+fn is_unique_violation(error: &sqlx::Error) -> bool {
+    matches!(
+        error,
+        sqlx::Error::Database(database_error) if database_error.is_unique_violation()
+    )
+}
+
+fn row_to_mount(row: &sqlx::sqlite::SqliteRow) -> Result<PageMount, sqlx::Error> {
+    Ok(PageMount {
+        name: row.try_get("name")?,
+        directory: row.try_get("directory")?,
+        run_id: row.try_get("run_id")?,
+        created_at: row.try_get("created_at")?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn requested_files_must_remain_inside_the_mount() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("inside.html"), "inside").unwrap();
+        let mount = PageMount {
+            name: "demo".to_string(),
+            directory: root.path().canonicalize().unwrap().display().to_string(),
+            run_id: None,
+            created_at: "now".to_string(),
+        };
+
+        assert!(open_file(&mount, "inside.html").is_some());
+        assert!(open_file(&mount, "../../etc/passwd").is_none());
+        assert!(open_file(&mount, "missing.html").is_none());
+    }
+}

--- a/crates/pdo-daemon/src/prompt_augmenter.rs
+++ b/crates/pdo-daemon/src/prompt_augmenter.rs
@@ -827,7 +827,9 @@ pub(crate) fn build_preamble(ctx: &AugmentContext<'_>) -> String {
          `--source-branch`, `--name`, `--auto-name`, `--auto-fail`, \
          `--provisioning '<json>'`.\n\
          - The daemon's refusals (unknown pipeline, …) print on stderr with a \
-         non-zero exit.\n\n",
+         non-zero exit.\n\
+         - Mount a directory of generated pages with `pdo page mount <name> <dir>`; \
+         the daemon serves it live under `/pages/<name>/`.\n\n",
     );
 
     if !ctx.variables.is_empty() {
@@ -1587,6 +1589,7 @@ mod tests {
         assert!(preamble.contains("pdo run create"));
         assert!(preamble.contains("mechanically linked"));
         assert!(preamble.contains("--target-repo"));
+        assert!(preamble.contains("pdo page mount"));
     }
 
     #[test]

--- a/crates/pdo-daemon/tests/common/mod.rs
+++ b/crates/pdo-daemon/tests/common/mod.rs
@@ -23,6 +23,40 @@ pub struct TestDaemon {
 }
 
 impl TestDaemon {
+    pub async fn spawn_at(repo_root: &Path) -> Result<Self> {
+        std::fs::create_dir_all(repo_root)?;
+        let handle = serve_with_config(
+            SocketAddr::from(([127, 0, 0, 1], 0)),
+            repo_root.to_path_buf(),
+            DaemonConfig {
+                tmux_cmd_override: Some("exec sleep 600".to_string()),
+                panic_on_trigger_name: None,
+                panic_on_stale_sweep: false,
+                panic_on_spawn: false,
+                service_health_override: None,
+                docker_cmd_override: None,
+                sandbox_home_override: None,
+                price_source_url: None,
+                price_refresh_at_boot: false,
+                update_source_url: None,
+                run_update_check_loop: false,
+                update_executor_override: None,
+                install_method_override: None,
+                supervision_override: None,
+                relaunch_command: None,
+                allowed_ws_origins: Vec::new(),
+                run_trigger_scheduler_loop: false,
+                nested_daemon: false,
+            },
+        )
+        .await?;
+        Ok(Self {
+            addr: handle.addr,
+            tempdir: tempfile::tempdir()?,
+            handle: Some(handle),
+        })
+    }
+
     /// Spawn a fresh daemon backed by a tempdir. The `setup` callback receives the
     /// tempdir path and may seed it (write yaml, init a git repo, etc.) before the
     /// daemon starts.

--- a/crates/pdo-daemon/tests/it.rs
+++ b/crates/pdo-daemon/tests/it.rs
@@ -46,6 +46,9 @@ mod frontmatter_validation;
 #[path = "fs_browse.rs"]
 mod fs_browse;
 
+#[path = "page_mounts.rs"]
+mod page_mounts;
+
 #[path = "guard_dry_run.rs"]
 mod guard_dry_run;
 

--- a/crates/pdo-daemon/tests/page_mounts.rs
+++ b/crates/pdo-daemon/tests/page_mounts.rs
@@ -1,0 +1,509 @@
+use std::process::Command;
+
+use crate::common::TestDaemon;
+use reqwest::header::{CONTENT_TYPE, LOCATION};
+use serde_json::json;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+async fn mount(daemon: &TestDaemon, name: &str, directory: &std::path::Path) -> reqwest::Response {
+    reqwest::Client::new()
+        .post(format!("{}/pages", daemon.url()))
+        .json(&json!({ "name": name, "directory": directory }))
+        .send()
+        .await
+        .unwrap()
+}
+
+async fn raw_get(daemon: &TestDaemon, path: &str) -> String {
+    let mut stream = tokio::net::TcpStream::connect(daemon.addr).await.unwrap();
+    stream
+        .write_all(
+            format!(
+                "GET {path} HTTP/1.1\r\nHost: {}\r\nConnection: close\r\n\r\n",
+                daemon.addr
+            )
+            .as_bytes(),
+        )
+        .await
+        .unwrap();
+    let mut response = String::new();
+    stream.read_to_string(&mut response).await.unwrap();
+    response
+}
+
+async fn run_cli(daemon: &TestDaemon, args: Vec<String>) -> std::process::Output {
+    let daemon_url = daemon.url();
+    tokio::task::spawn_blocking(move || {
+        Command::new(env!("CARGO_BIN_EXE_pdo"))
+            .args(args)
+            .env("PDO_DAEMON_URL", daemon_url)
+            .env_remove("PDO_RUN_ID")
+            .env_remove("PDO_NODE_ID")
+            .output()
+            .unwrap()
+    })
+    .await
+    .unwrap()
+}
+
+fn seed_running_pipeline(repo: &std::path::Path) -> anyhow::Result<()> {
+    let pipeline_dir = repo.join(".pdo/pipelines");
+    std::fs::create_dir_all(pipeline_dir.join("page-owner.prompts"))?;
+    std::fs::write(
+        pipeline_dir.join("page-owner.yaml"),
+        r#"name: page-owner
+version: "1.0"
+nodes:
+  - id: start
+    name: Start
+    type: start
+    outputs: [{ name: user_prompt }]
+  - id: worker
+    name: worker
+    type: agent
+    isolated_worktree: false
+    inputs: [{ name: task }]
+    outputs: [{ name: result }]
+  - id: end
+    name: End
+    type: end
+    inputs: [{ name: result }]
+edges:
+  - source: { node: start, port: user_prompt }
+    target: { node: worker, port: task }
+"#,
+    )?;
+    std::fs::write(
+        pipeline_dir.join("page-owner.prompts/worker.md"),
+        "Build the page.",
+    )?;
+    let run = |args: &[&str]| -> anyhow::Result<()> {
+        let output = Command::new("git").args(args).current_dir(repo).output()?;
+        anyhow::ensure!(
+            output.status.success(),
+            "git failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        Ok(())
+    };
+    run(&["init", "-q", "-b", "main"])?;
+    run(&["config", "user.email", "test@example.com"])?;
+    run(&["config", "user.name", "Test"])?;
+    run(&["config", "commit.gpgsign", "false"])?;
+    std::fs::write(repo.join(".gitignore"), ".pdo/runs/\n")?;
+    run(&["add", "."])?;
+    run(&["commit", "-q", "-m", "init"])?;
+    Ok(())
+}
+
+async fn create_running_run(daemon: &TestDaemon) -> String {
+    let response = reqwest::Client::new()
+        .post(format!("{}/runs", daemon.url()))
+        .json(&json!({
+            "pipeline": "page-owner",
+            "input": "make a page",
+            "target_repo": daemon.target_repo(),
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 201);
+    let run_id = response.json::<serde_json::Value>().await.unwrap()["run_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    for _ in 0..100 {
+        let run: serde_json::Value = reqwest::get(format!("{}/runs/{run_id}", daemon.url()))
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        if run["nodes"]["worker"]["status"] == "running" {
+            return run_id;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+    panic!("worker did not start");
+}
+
+fn content_type(response: &reqwest::Response) -> &str {
+    response
+        .headers()
+        .get(CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or("")
+}
+
+#[tokio::test]
+async fn mounted_pages_serve_live_html_files_and_index() {
+    let daemon = TestDaemon::spawn(|_| Ok(())).await.unwrap();
+    let pages = tempfile::tempdir().unwrap();
+    std::fs::write(
+        pages.path().join("index.html"),
+        "<!doctype html><h1>Home</h1>",
+    )
+    .unwrap();
+    std::fs::write(
+        pages.path().join("report.html"),
+        "<!doctype html><h1>First</h1>",
+    )
+    .unwrap();
+    std::fs::write(
+        pages.path().join("Skills Bank.html"),
+        "<!doctype html><h1>Bank</h1>",
+    )
+    .unwrap();
+
+    let response = mount(&daemon, "skills_bank", pages.path()).await;
+    assert_eq!(response.status(), 201);
+    let mounted: serde_json::Value = response.json().await.unwrap();
+    assert_eq!(
+        mounted["directory"],
+        pages.path().canonicalize().unwrap().to_str().unwrap()
+    );
+
+    let root = reqwest::get(format!("{}/pages/skills_bank/", daemon.url()))
+        .await
+        .unwrap();
+    assert_eq!(root.status(), 200);
+    assert!(content_type(&root).starts_with("text/html"));
+    assert!(root.text().await.unwrap().contains("Home"));
+
+    let report_url = format!("{}/pages/skills_bank/report.html", daemon.url());
+    let report = reqwest::get(&report_url).await.unwrap();
+    assert_eq!(report.status(), 200);
+    assert!(content_type(&report).starts_with("text/html"));
+    assert!(report.text().await.unwrap().contains("First"));
+
+    let spaced = reqwest::get(format!(
+        "{}/pages/skills_bank/Skills%20Bank.html",
+        daemon.url()
+    ))
+    .await
+    .unwrap();
+    assert_eq!(spaced.status(), 200);
+    assert!(content_type(&spaced).starts_with("text/html"));
+
+    std::fs::write(
+        pages.path().join("report.html"),
+        "<!doctype html><h1>Edited</h1>",
+    )
+    .unwrap();
+    let edited = reqwest::get(report_url).await.unwrap();
+    assert!(edited.text().await.unwrap().contains("Edited"));
+}
+
+#[tokio::test]
+async fn mount_root_redirects_to_the_trailing_slash_form() {
+    let daemon = TestDaemon::spawn(|_| Ok(())).await.unwrap();
+    let pages = tempfile::tempdir().unwrap();
+    std::fs::write(pages.path().join("index.html"), "home").unwrap();
+    assert_eq!(mount(&daemon, "demo", pages.path()).await.status(), 201);
+
+    let client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let response = client
+        .get(format!("{}/pages/demo", daemon.url()))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 308);
+    assert_eq!(response.headers().get(LOCATION).unwrap(), "/pages/demo/");
+}
+
+#[tokio::test]
+async fn missing_and_traversal_requests_are_plain_404s() {
+    let daemon = TestDaemon::spawn(|_| Ok(())).await.unwrap();
+    let pages = tempfile::tempdir().unwrap();
+    std::fs::write(pages.path().join("index.html"), "home").unwrap();
+    assert_eq!(mount(&daemon, "demo", pages.path()).await.status(), 201);
+
+    let missing = reqwest::get(format!("{}/pages/demo/missing.html", daemon.url()))
+        .await
+        .unwrap();
+    assert_eq!(missing.status(), 404);
+    assert!(!content_type(&missing).starts_with("text/html"));
+
+    let traversal = raw_get(&daemon, "/pages/demo/%2e%2e/%2e%2e/etc/passwd").await;
+    assert!(
+        traversal.starts_with("HTTP/1.1 404"),
+        "traversal must be rejected: {traversal}"
+    );
+    assert!(!traversal
+        .to_ascii_lowercase()
+        .contains("content-type: text/html"));
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn symlinks_cannot_escape_a_mounted_directory() {
+    use std::os::unix::fs::symlink;
+
+    let daemon = TestDaemon::spawn(|_| Ok(())).await.unwrap();
+    let pages = tempfile::tempdir().unwrap();
+    let outside = tempfile::tempdir().unwrap();
+    std::fs::write(outside.path().join("secret.html"), "outside").unwrap();
+    symlink(outside.path(), pages.path().join("escape")).unwrap();
+    assert_eq!(mount(&daemon, "demo", pages.path()).await.status(), 201);
+
+    let response = reqwest::get(format!("{}/pages/demo/escape/secret.html", daemon.url()))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 404);
+    assert!(!content_type(&response).starts_with("text/html"));
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn replacing_a_mount_ancestor_with_a_symlink_cannot_escape() {
+    use std::os::unix::fs::symlink;
+
+    let daemon = TestDaemon::spawn(|_| Ok(())).await.unwrap();
+    let parent = tempfile::tempdir().unwrap();
+    let ancestor = parent.path().join("ancestor");
+    let mounted = ancestor.join("site");
+    std::fs::create_dir_all(&mounted).unwrap();
+    std::fs::write(mounted.join("secret.html"), "original").unwrap();
+    assert_eq!(mount(&daemon, "demo", &mounted).await.status(), 201);
+
+    std::fs::rename(&ancestor, parent.path().join("original-ancestor")).unwrap();
+    let outside = tempfile::tempdir().unwrap();
+    std::fs::create_dir(outside.path().join("site")).unwrap();
+    std::fs::write(outside.path().join("site/secret.html"), "outside").unwrap();
+    symlink(outside.path(), &ancestor).unwrap();
+
+    let response = reqwest::get(format!("{}/pages/demo/secret.html", daemon.url()))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 404);
+}
+
+#[tokio::test]
+async fn mount_refusals_have_the_documented_statuses() {
+    let daemon = TestDaemon::spawn(|_| Ok(())).await.unwrap();
+    let root = tempfile::tempdir().unwrap();
+    let valid = root.path().join("valid");
+    let file = root.path().join("file.txt");
+    let artifacts = root.path().join(".pdo/artifacts/demo");
+    std::fs::create_dir(&valid).unwrap();
+    std::fs::write(&file, "not a directory").unwrap();
+    std::fs::create_dir_all(&artifacts).unwrap();
+
+    assert_eq!(mount(&daemon, "Bad Name", &valid).await.status(), 400);
+    assert_eq!(
+        mount(&daemon, "missing", &root.path().join("missing"))
+            .await
+            .status(),
+        400
+    );
+    assert_eq!(mount(&daemon, "file", &file).await.status(), 400);
+    assert_eq!(mount(&daemon, "artifacts", &artifacts).await.status(), 400);
+    assert_eq!(mount(&daemon, "demo", &valid).await.status(), 201);
+    assert_eq!(mount(&daemon, "demo", &valid).await.status(), 409);
+}
+
+#[tokio::test]
+async fn list_and_unmount_expose_the_mount_lifecycle() {
+    let daemon = TestDaemon::spawn(|_| Ok(())).await.unwrap();
+    let pages = tempfile::tempdir().unwrap();
+    std::fs::write(pages.path().join("index.html"), "home").unwrap();
+    assert_eq!(mount(&daemon, "demo", pages.path()).await.status(), 201);
+
+    let listed: serde_json::Value = reqwest::get(format!("{}/pages", daemon.url()))
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(listed.as_array().unwrap().len(), 1);
+    assert_eq!(listed[0]["name"], "demo");
+    assert!(listed[0]["run_id"].is_null());
+    assert!(listed[0]["created_at"].is_string());
+
+    let removed = reqwest::Client::new()
+        .delete(format!("{}/pages/demo", daemon.url()))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(removed.status(), 200);
+    assert_eq!(
+        reqwest::get(format!("{}/pages/demo/", daemon.url()))
+            .await
+            .unwrap()
+            .status(),
+        404
+    );
+    let listed: serde_json::Value = reqwest::get(format!("{}/pages", daemon.url()))
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert!(listed.as_array().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn operator_mutations_are_written_to_the_audit_log() {
+    let daemon = TestDaemon::spawn(|_| Ok(())).await.unwrap();
+    let pages = tempfile::tempdir().unwrap();
+    let client = reqwest::Client::new();
+    let response = client
+        .post(format!("{}/pages", daemon.url()))
+        .header("X-PDO-Actor", "cli")
+        .json(&json!({ "name": "demo", "directory": pages.path() }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 201);
+    assert_eq!(
+        client
+            .delete(format!("{}/pages/demo", daemon.url()))
+            .header("X-PDO-Actor", "cli")
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        200
+    );
+
+    let audit: serde_json::Value =
+        reqwest::get(format!("{}/audit?target_kind=page_mount", daemon.url()))
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+    assert_eq!(audit.as_array().unwrap().len(), 2);
+    assert_eq!(audit[0]["action"], "page_mount.unmounted");
+    assert_eq!(audit[0]["actor_hint"], "cli");
+    assert_eq!(audit[1]["action"], "page_mount.mounted");
+}
+
+#[tokio::test]
+async fn archiving_a_run_drops_its_mount_and_keeps_the_run_event() {
+    let daemon = TestDaemon::spawn(seed_running_pipeline).await.unwrap();
+    let run_id = create_running_run(&daemon).await;
+    let pages = tempfile::tempdir().unwrap();
+    std::fs::write(pages.path().join("index.html"), "owned").unwrap();
+
+    let mounted = reqwest::Client::new()
+        .post(format!("{}/pages", daemon.url()))
+        .header("X-PDO-Session-Run-Id", &run_id)
+        .header("X-PDO-Session-Node-Id", "worker")
+        .json(&json!({ "name": "owned", "directory": pages.path() }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(mounted.status(), 201);
+    let body: serde_json::Value = mounted.json().await.unwrap();
+    assert_eq!(body["run_id"], run_id);
+
+    let events: serde_json::Value = reqwest::get(format!("{}/runs/{run_id}/events", daemon.url()))
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert!(events.as_array().unwrap().iter().any(|event| {
+        event["kind"] == "command_issued" && event["payload"]["command"] == "page_mount.mounted"
+    }));
+
+    let archived = reqwest::Client::new()
+        .post(format!("{}/runs/{run_id}/commands", daemon.url()))
+        .json(&json!({ "kind": "cleanup_run" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(archived.status(), 200);
+    assert_eq!(
+        reqwest::get(format!("{}/pages/owned/", daemon.url()))
+            .await
+            .unwrap()
+            .status(),
+        404
+    );
+
+    let recreated = reqwest::Client::new()
+        .post(format!("{}/pages", daemon.url()))
+        .header("X-PDO-Session-Run-Id", &run_id)
+        .header("X-PDO-Session-Node-Id", "worker")
+        .json(&json!({ "name": "late", "directory": pages.path() }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(recreated.status(), 403);
+    let mounts: serde_json::Value = reqwest::get(format!("{}/pages", daemon.url()))
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert!(mounts.as_array().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn mounts_survive_a_daemon_restart() {
+    let root = tempfile::tempdir().unwrap();
+    let pages = tempfile::tempdir().unwrap();
+    std::fs::write(pages.path().join("index.html"), "persistent").unwrap();
+
+    let first = TestDaemon::spawn_at(root.path()).await.unwrap();
+    assert_eq!(mount(&first, "demo", pages.path()).await.status(), 201);
+    drop(first);
+
+    let second = TestDaemon::spawn_at(root.path()).await.unwrap();
+    let response = reqwest::get(format!("{}/pages/demo/", second.url()))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), 200);
+    assert!(response.text().await.unwrap().contains("persistent"));
+}
+
+#[tokio::test]
+async fn page_cli_mounts_lists_unmounts_and_surfaces_refusals() {
+    let daemon = TestDaemon::spawn(|_| Ok(())).await.unwrap();
+    let pages = tempfile::tempdir().unwrap();
+    std::fs::write(pages.path().join("index.html"), "home").unwrap();
+    let mounted = run_cli(
+        &daemon,
+        vec![
+            "page".into(),
+            "mount".into(),
+            "demo".into(),
+            pages.path().display().to_string(),
+        ],
+    )
+    .await;
+    assert!(mounted.status.success());
+    let stdout = String::from_utf8_lossy(&mounted.stdout);
+    assert!(stdout.contains("Mounted demo"));
+    assert!(stdout.contains(pages.path().canonicalize().unwrap().to_str().unwrap()));
+
+    let listed = run_cli(&daemon, vec!["page".into(), "list".into()]).await;
+    assert!(listed.status.success());
+    assert!(String::from_utf8_lossy(&listed.stdout).contains("demo"));
+
+    let duplicate = run_cli(
+        &daemon,
+        vec![
+            "page".into(),
+            "mount".into(),
+            "demo".into(),
+            pages.path().display().to_string(),
+        ],
+    )
+    .await;
+    assert!(!duplicate.status.success());
+    assert!(String::from_utf8_lossy(&duplicate.stderr).contains("already mounted"));
+
+    let removed = run_cli(
+        &daemon,
+        vec!["page".into(), "unmount".into(), "demo".into()],
+    )
+    .await;
+    assert!(removed.status.success());
+    assert!(String::from_utf8_lossy(&removed.stdout).contains("Unmounted demo"));
+}

--- a/docs/adr/0028-html-output-port.md
+++ b/docs/adr/0028-html-output-port.md
@@ -1,6 +1,6 @@
 # ADR-0028 — Type de port de sortie `html` : artefact HTML rendu, statique et sandboxé
 
-Date : 2026-07-18 · Statut : accepté · Issue : #333
+Date : 2026-07-18 · Statut : accepté · Issue : #333 · Amendé par ADR-0066 : l'interdiction du `text/html` vise les **artefacts** ; un *page mount* explicite (`/pages/<nom>/`) sert du HTML navigable.
 
 ## Contexte
 

--- a/docs/adr/0066-les-page-mounts-servent-du-html-navigable-sur-geste-explicite.md
+++ b/docs/adr/0066-les-page-mounts-servent-du-html-navigable-sur-geste-explicite.md
@@ -1,0 +1,58 @@
+# ADR-0066 — Les page mounts servent du HTML navigable à l'origine du daemon, sur geste explicite
+
+> Statut : accepted (grilling #674). Amende ADR-0028 (l'interdiction « jamais de `text/html` » ne vise que les artefacts). Vocabulaire : CONTEXT.md § « Page mount ».
+
+## Contexte
+
+Le frontend est embarqué dans le binaire et la route de repli renvoie `index.html` pour tout chemin
+inconnu : un agent (ou un opérateur) qui produit un prototype HTML, un rapport, un mockup, n'a aucun
+moyen de le montrer via l'instance PDO. Mesuré sur #668 : le mockup de la Banque de skills a dû être
+servi par un `python -m http.server` sur un port à part, hors tunnel, hors UI.
+
+ADR-0028 interdit au daemon de servir un artefact en `text/html`, parce qu'un document navigable à
+l'origine du daemon exécute du script écrit par un agent avec accès complet à une API sans auth.
+Un **page mount** demande précisément cela.
+
+## Décision
+
+Un **page mount** lie un nom à un répertoire du disque ; le daemon le sert en lecture seule sous
+`/pages/<nom>/`, en **vrai HTML** (type MIME deviné, scripts exécutés). L'exception à ADR-0028 tient
+à la nature du geste : un mount est une **décision explicite** d'un opérateur ou d'un agent (`pdo page
+mount`), pas le rendu automatique d'une sortie de node. Le daemon est mono-utilisateur et local
+(hors périmètre : auth, upload).
+
+Garde-fous qui restent non négociables :
+
+- **Jamais de repli SPA sous `/pages/`** : un fichier absent est un vrai 404. Un prototype ne peut
+  pas masquer l'app, et un test d'existence de route reste fiable.
+- **Un artefact ne devient jamais une page par accident** : monter un répertoire situé sous le
+  Blackboard (`.pdo/artifacts/`) est refusé. ADR-0028 reste vrai pour les ports `html`.
+- **Confinement** : le chemin demandé est canonicalisé et doit rester dans le répertoire monté,
+  sinon 404. Le contenu est celui du disque à l'instant de la requête (pas de rebuild pour itérer).
+- **Nom** : `[a-z0-9_-]{1,64}` ; un nom déjà monté refuse (409) — on démonte avant de rediriger.
+  Le préfixe `/pages` étant libre dans le routeur, aucune collision avec une route API n'existe ;
+  la clause « 409 si le nom vaut `runs` » du ticket d'origine était sans cible.
+
+## Cycle de vie
+
+Un mount **persiste** (SQLite) et survit aux redémarrages. Monté depuis une session de node, il porte
+le `run_id` du node et **tombe à l'archivage du Run** (`cleanup_run`) — le worktree disparaît, la page
+pendrait. Monté depuis un shell d'opérateur, il est instance-level et ne tombe que sur `pdo page
+unmount`. Dans les deux cas `unmount` reste disponible pour qu'un agent nettoie derrière lui. L'origine
+est un `actor_hint` best-effort (ADR-0044) ; le mount/unmount hors-Run va dans l'`audit_log`, celui
+d'un node dans l'event log du Run.
+
+## Alternatives écartées
+
+- **CSP sans script sur `/pages/`** : rend inutilisable le cas motivant (mockups React), pour un gain
+  de sécurité que le modèle mono-utilisateur local ne réclame pas.
+- **Seconde origine (second port)** : isole vraiment par same-origin, mais double le port à ouvrir
+  dans les tunnels et l'allowlist d'origines WS, pour un bénéfice que personne n'a demandé.
+- **Servir via le port `html` existant** : le port `html` est une surface de relecture sandboxée par
+  design (ADR-0028) ; en faire une page navigable casserait cette garantie pour tous les Runs.
+
+## Conséquences
+
+- Le rail du run pourra lister les pages actives d'un Run (follow-up, hors du premier ticket).
+- Tout nouveau préfixe racine doit aussi entrer dans la whitelist du proxy de dev Vite, sinon le
+  mode dev répond la coquille SPA en 200 (piège documenté par le routeur et `fs_browse`).

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -48,6 +48,7 @@ export default defineConfig({
       // as `/nodes`/`/stats`/`/fs`: without it a dev GET /audit answers 200 with
       // the SPA.
       '/audit': daemonTarget,
+      '/pages': daemonTarget,
       // #552: Projets (harness middle tier + group-header pencil). New top-level
       // `/projects` prefix — same trap as `/audit`: without it a dev
       // GET/POST /projects answers 200 with the SPA and the pencil would silently


### PR DESCRIPTION
## Tickets inclus

- **#743** — page mounts : `pdo page mount|unmount|list` et serving `/pages/<name>/` (v1.74.0). Sous-ticket mergé via PR #744 (auto-merge, gate local vert : `cargo check --workspace`, `cargo nextest run -p pdo-daemon` 2961/2961, FP 7/7 sans blocking finding).
- **docs #674** — entrée glossaire « page mounts », ADR-0066, amendement ADR-0028 (sortie de grilling).

## Validation

- ⚠️ Suite HP **non exécutée** — sautée à la demande explicite de l'utilisateur.
- FP du sous-ticket #743 : 7/7 étapes, aucun blocking finding (rapporté lors du run d'implémentation).

## Suivis non bloquants (issus de la FP)

- Le CLI résout `PDO_DAEMON_URL` avant `PDO_PORT` ; à documenter dans l'aide de `pdo page`.
- Le refus de répertoire inexistant est formulé côté client (`cannot resolve …`) plutôt que via le 400 du daemon.