### PR TITLE
feat(review): Review page — Run refs, side-by-side diff, file list, context expansion (#749)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ ascendante** : la casse se signale ici et par un bump majeur, jamais en gardant 
 morts. Seule contrainte non négociable — les **données historiques restent lisibles** : un Run
 archivé s'ouvre et se chiffre quelle que soit la version qui a écrit son payload.
 
+## 1.76.0
+
+**Page de Review — relecture de diff GitHub-like** (#749 ; story #746, ADR-0067). Depuis l'onglet Diff,
+« Expand and comment » ouvre `/runs/<id>/review`, une page à part entière (nouvel onglet, rechargeable,
+paire de refs dans l'URL). Elle liste les fichiers à gauche avec leurs +/−, rend le diff **side-by-side**
+par défaut (bascule unifiée mémorisée en local) via un composant tiers (`@git-diff-view/react`), et
+permet d'**étendre le contexte** caché entre les hunks depuis le contenu du fichier à une ref. Un
+sélecteur **source → destination** propose les refs du Run exposées par le nouveau `GET /runs/{id}/refs` :
+point de fork, tip, et pour chaque nœud livré ses `before`/`after` libellés par nom et itération ;
+défaut fork → tip, ref inconnue → repli sur le défaut avec avis. Le panneau d'un nœud livré ou en cours
+gagne le raccourci « Review this node's delivery ». Aucune surface « diff de nœud » ; les commentaires
+viendront dans un ticket suivant.
+
 ## 1.75.0
 
 **Onglet Diff de niveau Run qui fonctionne** (#748 ; story #746, ADR-0067). Le diff d'un Run est

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "1.75.0"
+version = "1.76.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "1.75.0"
+version = "1.76.0"
 license = "MIT"
 description = "Prompt-Driven Orchestrator — a local daemon that runs and supervises agentic coding pipelines"
 repository = "https://github.com/Loulen/prompt-driven-orchestrator"

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -64,6 +64,7 @@ pub(crate) mod retry_verdict;
 mod run_advance;
 mod run_command;
 mod run_cost;
+mod run_refs;
 mod sandbox_container;
 mod sandbox_image;
 mod sandbox_profile;
@@ -4470,6 +4471,7 @@ fn build_router(state: Arc<AppState>) -> Router {
         .route("/runs/{run_id}/diff", get(run_diff))
         .route("/runs/{run_id}/diff/structured", get(run_diff_structured))
         .route("/runs/{run_id}/file", get(run_file_at_ref))
+        .route("/runs/{run_id}/refs", get(run_refs))
         .route("/runs/{run_id}/nodes/{node_id}/diff", get(node_diff))
         .route("/runs/{run_id}/artifact", get(artifact))
         .route("/runs/{run_id}/pipeline", get(get_run_pipeline))
@@ -13605,23 +13607,25 @@ async fn run_diff_structured(
     AxumPath(run_id): AxumPath<String>,
     Query(q): Query<StructuredDiffQuery>,
 ) -> Response {
-    let (_, run_state) = match load_projected(&state, &run_id).await {
+    let (events, run_state) = match load_projected(&state, &run_id).await {
         Ok(t) => t,
         Err(resp) => return *resp,
     };
-    for r in [&q.from, &q.to].into_iter().flatten() {
-        if !structured_diff::is_safe_ref(r) {
-            return (StatusCode::BAD_REQUEST, format!("invalid ref: {r:?}")).into_response();
-        }
-    }
-    let explicit = q.from.is_some() || q.to.is_some();
-    let from = q
-        .from
-        .clone()
-        .unwrap_or_else(|| run_diff_base(&run_state).to_string());
-    let to = q.to.clone().unwrap_or_else(|| format!("pdo/run-{run_id}"));
+    // #749: a side is a stable Run ref id (`fork`, `tip`, `node:<id>:<iter>:before`,
+    // `live:<id>`) resolved against the log, or — compatibility — a raw git ref.
+    let from = match resolve_ref_param(&run_id, &run_state, &events, q.from.as_deref(), run_refs::FORK_ID) {
+        Ok(r) => r,
+        Err(resp) => return *resp,
+    };
+    let to = match resolve_ref_param(&run_id, &run_state, &events, q.to.as_deref(), run_refs::TIP_ID) {
+        Ok(r) => r,
+        Err(resp) => return *resp,
+    };
+    // Three-dot only for the fork → tip default (the LOC bounds); any other pair
+    // is two arbitrary Run refs compared two-dot.
+    let three_dot = run_refs::is_default_pair(q.from.as_deref(), q.to.as_deref());
     let repo = effective_repo_root(&state, &run_state);
-    match structured_diff::compute(&repo, &from, &to, !explicit) {
+    match structured_diff::compute(&repo, &from, &to, three_dot) {
         Ok(d) => Json(d).into_response(),
         Err(e) if e.is_unknown_revision() => {
             (StatusCode::NOT_FOUND, "run branch not found").into_response()
@@ -13647,7 +13651,7 @@ async fn run_file_at_ref(
     AxumPath(run_id): AxumPath<String>,
     Query(q): Query<FileAtRefQuery>,
 ) -> Response {
-    let (_, run_state) = match load_projected(&state, &run_id).await {
+    let (events, run_state) = match load_projected(&state, &run_id).await {
         Ok(t) => t,
         Err(resp) => return *resp,
     };
@@ -13658,10 +13662,11 @@ async fn run_file_at_ref(
         )
             .into_response();
     }
-    let git_ref = q.git_ref.unwrap_or_else(|| format!("pdo/run-{run_id}"));
-    if !structured_diff::is_safe_ref(&git_ref) {
-        return (StatusCode::BAD_REQUEST, format!("invalid ref: {git_ref:?}")).into_response();
-    }
+    // #749: stable Run ref ids resolve like on the structured diff endpoint.
+    let git_ref = match resolve_ref_param(&run_id, &run_state, &events, q.git_ref.as_deref(), run_refs::TIP_ID) {
+        Ok(r) => r,
+        Err(resp) => return *resp,
+    };
     let repo = effective_repo_root(&state, &run_state);
     match structured_diff::file_at_ref(&repo, &git_ref, &q.path) {
         Ok(bytes) => match String::from_utf8(bytes) {
@@ -13690,6 +13695,55 @@ async fn run_file_at_ref(
         }
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }
+}
+
+/// Resolve one `from`/`to`/`ref` query value (#749): absent ⇒ `default_id`; a
+/// stable Run ref id ⇒ its git ref (404 when the Run knows no such ref); anything
+/// else ⇒ a raw git ref, kept for compatibility once it passes the injection guard.
+fn resolve_ref_param(
+    run_id: &str,
+    run_state: &event_log::RunState,
+    events: &[event_log::Event],
+    value: Option<&str>,
+    default_id: &str,
+) -> Result<String, Box<Response>> {
+    let value = value.unwrap_or(default_id);
+    match run_refs::resolve_id(run_id, run_state, events, value) {
+        run_refs::Resolved::Git(r) => Ok(r),
+        run_refs::Resolved::Unknown => Err(Box::new(
+            (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({ "error": format!("unknown run ref: {value}") })),
+            )
+                .into_response(),
+        )),
+        run_refs::Resolved::NotAnId => {
+            if !structured_diff::is_safe_ref(value) {
+                return Err(Box::new(
+                    (StatusCode::BAD_REQUEST, format!("invalid ref: {value:?}")).into_response(),
+                ));
+            }
+            Ok(value.to_string())
+        }
+    }
+}
+
+/// `GET /runs/<id>/refs` (#749, ADR-0067 §1): the Run's refs — fork point, Run
+/// tip, every node delivery's `before`/`after` from the event log (labelled by
+/// node name and `iter`), and the live sub-worktree branch of a running isolated
+/// node — plus the ready-made delivery pairs. Labels are built here so the UI
+/// and the CLI agree. SHAs are resolved in the Run's effective repository.
+async fn run_refs(
+    State(state): State<Arc<AppState>>,
+    AxumPath(run_id): AxumPath<String>,
+) -> Response {
+    let (events, run_state) = match load_projected(&state, &run_id).await {
+        Ok(t) => t,
+        Err(resp) => return *resp,
+    };
+    let repo = effective_repo_root(&state, &run_state);
+    let sha_of = |r: &str| structured_diff::rev_parse(&repo, r);
+    Json(run_refs::collect(&run_id, &run_state, &events, &sha_of)).into_response()
 }
 
 async fn node_diff(
@@ -19380,11 +19434,7 @@ fn parse_numstat(stdout: &str) -> event_log::LocStat {
 /// wandering-HEAD defect. NB: this is the Run's fork point, NOT the per-node
 /// `NodeStarted.base_sha` (ADR-0036).
 fn run_diff_base(run_state: &event_log::RunState) -> &str {
-    run_state
-        .fork_sha
-        .as_deref()
-        .or(run_state.source_branch.as_deref())
-        .unwrap_or("HEAD")
+    run_refs::fork_base(run_state)
 }
 
 /// Lines changed for a Run, with `.pdo/` excluded. `None` when the diff is
@@ -35276,6 +35326,188 @@ edges: []
         assert_eq!(bin["binary"], serde_json::json!(true));
         assert_eq!(bin["status"], serde_json::json!("added"));
         assert_eq!(bin["hunks"].as_array().unwrap().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn run_refs_lists_deliveries_and_stable_ids_resolve_on_diff_and_file() {
+        // #749 AC1/AC5: the refs endpoint reads deliveries from the event log,
+        // labels them by node and iter, and the stable ids resolve on the
+        // structured diff and file-at-ref endpoints (URLs never carry SHAs).
+        let daemon_dir = tempfile::tempdir().unwrap();
+        init_test_repo(daemon_dir.path());
+        let target_dir = tempfile::tempdir().unwrap();
+        let target = target_dir.path();
+        let run_id = "refs-run";
+        let state = test_state_with_dir(daemon_dir.path()).await;
+        let wt_dir = seed_run_in_other_repo(&state, target, run_id).await;
+        let fork = git_in(target, &["rev-parse", "HEAD"]);
+        let c0 = git_in(&wt_dir, &["rev-parse", "HEAD"]);
+        std::fs::write(wt_dir.join("one.rs"), "1\n").unwrap();
+        git_in(&wt_dir, &["add", "-A"]);
+        git_in(&wt_dir, &["commit", "-q", "-m", "one"]);
+        let c1 = git_in(&wt_dir, &["rev-parse", "HEAD"]);
+        std::fs::write(wt_dir.join("two.rs"), "2\n").unwrap();
+        git_in(&wt_dir, &["add", "-A"]);
+        git_in(&wt_dir, &["commit", "-q", "-m", "two"]);
+        let c2 = git_in(&wt_dir, &["rev-parse", "HEAD"]);
+        // impl-1 delivered c0 → c1 at iter 1; a second node delivered c1 → c2.
+        for (node, before, after) in [("impl-1", &c0, &c1), ("worker-2", &c1, &c2)] {
+            append_event(
+                &state,
+                &event_log::Event {
+                    id: None,
+                    run_id: run_id.into(),
+                    ts: event_log::now_iso(),
+                    kind: event_log::EventKind::NodeDelivered,
+                    node_id: Some(node.into()),
+                    iter: Some(1),
+                    payload: Some(serde_json::json!({ "before": before, "after": after })),
+                },
+            )
+            .await
+            .unwrap();
+        }
+        // impl-1 is still running and isolated: give it a live sub-worktree branch.
+        let live_branch = worktree_ops::sub_worktree_branch(run_id, "impl-1", 1);
+        git_in(target, &["branch", &live_branch, &c2]);
+
+        let app = build_router(state);
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/runs/{run_id}/refs"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let json: serde_json::Value = serde_json::from_str(&body_string(resp).await).unwrap();
+        let ids: Vec<&str> = json["refs"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|r| r["id"].as_str().unwrap())
+            .collect();
+        assert_eq!(
+            ids,
+            vec![
+                "fork",
+                "node:impl-1:1:before",
+                "node:impl-1:1:after",
+                "node:worker-2:1:before",
+                "node:worker-2:1:after",
+                "live:impl-1",
+                "tip",
+            ]
+        );
+        let refs = json["refs"].as_array().unwrap();
+        assert_eq!(refs[0]["sha"], serde_json::json!(fork));
+        assert_eq!(refs[2]["sha"], serde_json::json!(c1));
+        assert_eq!(refs[2]["label"], serde_json::json!("impl-1 · iter 1 · after"));
+        assert_eq!(refs[5]["sha"], serde_json::json!(c2));
+        assert_eq!(refs[6]["sha"], serde_json::json!(c2));
+        assert_eq!(json["default_from"], serde_json::json!("fork"));
+        assert_eq!(json["default_to"], serde_json::json!("tip"));
+        let deliveries = json["deliveries"].as_array().unwrap();
+        assert_eq!(deliveries.len(), 3);
+        assert_eq!(deliveries[0]["status"], serde_json::json!("delivered"));
+        assert_eq!(deliveries[2]["status"], serde_json::json!("running"));
+        assert_eq!(deliveries[2]["live"], serde_json::json!("live:impl-1"));
+
+        // The delivery pair, by id: only impl-1's file, two-dot.
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(format!(
+                        "/runs/{run_id}/diff/structured?from=node:impl-1:1:before&to=node:impl-1:1:after"
+                    ))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let json: serde_json::Value = serde_json::from_str(&body_string(resp).await).unwrap();
+        assert_eq!(json["three_dot"], serde_json::json!(false));
+        assert_eq!(json["from_sha"], serde_json::json!(c0));
+        assert_eq!(json["to_sha"], serde_json::json!(c1));
+        let paths: Vec<&str> = json["files"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|f| f["new_path"].as_str().unwrap())
+            .collect();
+        assert_eq!(paths, vec!["one.rs"]);
+
+        // `fork` → `tip` spelled out is the three-dot default.
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/runs/{run_id}/diff/structured?from=fork&to=tip"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let json: serde_json::Value = serde_json::from_str(&body_string(resp).await).unwrap();
+        assert_eq!(json["three_dot"], serde_json::json!(true));
+        assert_eq!(json["files_changed"], serde_json::json!(2));
+
+        // tip → live branch resolves too.
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/runs/{run_id}/diff/structured?from=tip&to=live:impl-1"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // An id the Run does not know is a 404, never handed to git.
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/runs/{run_id}/diff/structured?from=node:impl-1:2:before"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        assert!(body_string(resp).await.contains("unknown run ref"));
+
+        // The file endpoint resolves ids as well.
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/runs/{run_id}/file?path=one.rs&ref=node:impl-1:1:after"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(body_string(resp).await, "1\n");
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/runs/{run_id}/file?path=one.rs&ref=node:impl-1:1:before"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND, "one.rs did not exist before");
     }
 
     #[tokio::test]

--- a/crates/pdo-daemon/src/run_refs.rs
+++ b/crates/pdo-daemon/src/run_refs.rs
@@ -1,0 +1,604 @@
+//! Refs of the Run (#749, ADR-0067 §1; CONTEXT.md § "Ref de Run").
+//!
+//! A **Run ref** is a persistent git point the Run knows about, offered as the
+//! source or destination of the Review page: the **fork point**, the **Run tip**,
+//! and for every node delivery its **`before`/`after`** SHAs (read from the
+//! `NodeDelivered` events of the log, labelled by node name and `iter`). A
+//! running isolated node adds its **live** sub-worktree branch.
+//!
+//! Every ref carries a **stable id** — `fork`, `tip`, `node:<id>:<iter>:before`,
+//! `node:<id>:<iter>:after`, `live:<id>` — that the Review page puts in its URL
+//! instead of a SHA: a link keeps its meaning while the Run moves, and the
+//! `pdo/sub-*` branches, which die at merge-back, never become an identity
+//! (ADR-0067 §1). The diff and file-at-ref endpoints accept those ids and
+//! resolve them here, so the labels and the resolution have one source.
+
+use serde::Serialize;
+
+use crate::event_log::{Event, EventKind, NodeStatus, RunState};
+
+pub(crate) const FORK_ID: &str = "fork";
+pub(crate) const TIP_ID: &str = "tip";
+
+#[derive(Serialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum RefKind {
+    Fork,
+    Tip,
+    Before,
+    After,
+    Live,
+}
+
+/// One Run ref, as the UI and the CLI see it.
+#[derive(Serialize, Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RunRef {
+    /// Stable id, the only thing a URL should carry.
+    pub id: String,
+    pub kind: RefKind,
+    /// Human label built server-side, e.g. `implement · iter 1 · after`.
+    pub label: String,
+    /// What the id resolves to for git: a SHA for a delivery, a branch for the
+    /// tip and a live node, the fork SHA (or source branch) for the fork point.
+    pub git_ref: String,
+    /// `git_ref` resolved to a commit SHA; `None` when it does not resolve any
+    /// more (an archived Run, a live branch already merged back).
+    pub sha: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub node_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub node_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub iter: Option<i64>,
+}
+
+#[derive(Serialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum DeliveryStatus {
+    Delivered,
+    Running,
+}
+
+/// One node delivery (or one running node's live branch), as a ready-made pair
+/// the Review page can select in one click.
+#[derive(Serialize, Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Delivery {
+    pub node_id: String,
+    pub node_name: String,
+    pub iter: i64,
+    pub status: DeliveryStatus,
+    /// Ref id of the pair's source.
+    pub before: String,
+    /// Ref id of the pair's destination when delivered.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub after: Option<String>,
+    /// Ref id of the live sub-worktree branch when running.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub live: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub delivered_at: Option<String>,
+}
+
+/// The answer of `GET /runs/<id>/refs`.
+#[derive(Serialize, Debug, Clone)]
+pub(crate) struct RunRefs {
+    /// Order: fork, deliveries in delivery order, live branches, tip.
+    pub refs: Vec<RunRef>,
+    pub deliveries: Vec<Delivery>,
+    pub default_from: &'static str,
+    pub default_to: &'static str,
+}
+
+/// The Run's branch — the tip.
+pub(crate) fn tip_branch(run_id: &str) -> String {
+    format!("pdo/run-{run_id}")
+}
+
+/// The Run's stable base: its frozen fork SHA, else the source branch, else
+/// `HEAD` (pre-fork-sha logs only). Never the shared checkout's wandering HEAD
+/// when a fork point is known (#417).
+pub(crate) fn fork_base(run_state: &RunState) -> &str {
+    run_state
+        .fork_sha
+        .as_deref()
+        .or(run_state.source_branch.as_deref())
+        .unwrap_or("HEAD")
+}
+
+pub(crate) fn before_id(node_id: &str, iter: i64) -> String {
+    format!("node:{node_id}:{iter}:before")
+}
+
+pub(crate) fn after_id(node_id: &str, iter: i64) -> String {
+    format!("node:{node_id}:{iter}:after")
+}
+
+pub(crate) fn live_id(node_id: &str) -> String {
+    format!("live:{node_id}")
+}
+
+fn node_name(run_state: &RunState, node_id: &str) -> String {
+    run_state
+        .node_defs
+        .iter()
+        .find(|d| d.id == node_id)
+        .and_then(|d| d.name.clone())
+        .filter(|n| !n.trim().is_empty())
+        .unwrap_or_else(|| node_id.to_string())
+}
+
+/// One `NodeDelivered` event, read back from the log.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DeliveredEvent {
+    node_id: String,
+    iter: i64,
+    before: String,
+    after: String,
+    ts: String,
+}
+
+/// Every delivery in the log, in delivery order; a re-delivery of the same
+/// (node, iter) replaces the earlier one in place (the last one is what the
+/// branch carries).
+fn deliveries_in_log(events: &[Event]) -> Vec<DeliveredEvent> {
+    let mut out: Vec<DeliveredEvent> = Vec::new();
+    for e in events {
+        if e.kind != EventKind::NodeDelivered {
+            continue;
+        }
+        let (Some(node_id), Some(payload)) = (&e.node_id, &e.payload) else {
+            continue;
+        };
+        let (Some(before), Some(after)) = (
+            payload.get("before").and_then(|v| v.as_str()),
+            payload.get("after").and_then(|v| v.as_str()),
+        ) else {
+            continue;
+        };
+        let iter = e.iter.unwrap_or(1);
+        let d = DeliveredEvent {
+            node_id: node_id.clone(),
+            iter,
+            before: before.to_string(),
+            after: after.to_string(),
+            ts: e.ts.clone(),
+        };
+        if let Some(slot) = out
+            .iter_mut()
+            .find(|x| x.node_id == d.node_id && x.iter == d.iter)
+        {
+            *slot = d;
+        } else {
+            out.push(d);
+        }
+    }
+    out
+}
+
+/// A running node whose sub-worktree branch may still exist: isolated, and
+/// live. Its branch name is deterministic (`worktree_ops::sub_worktree_branch`).
+fn live_nodes(run_id: &str, run_state: &RunState) -> Vec<(String, i64, String)> {
+    let mut out: Vec<(String, i64, String)> = run_state
+        .nodes
+        .values()
+        .filter(|n| matches!(n.status, NodeStatus::Running | NodeStatus::AwaitingUser))
+        .filter(|n| n.isolated_worktree == Some(true))
+        .map(|n| {
+            (
+                n.node_id.clone(),
+                n.iter,
+                crate::worktree_ops::sub_worktree_branch(run_id, &n.node_id, n.iter),
+            )
+        })
+        .collect();
+    // HashMap order is arbitrary; the list must be stable for the UI.
+    out.sort_by(|a, b| a.0.cmp(&b.0));
+    out
+}
+
+/// Build the Run's refs. `sha_of` resolves a git ref to a commit SHA (`None`
+/// when it does not exist) — injected so the listing is testable without a
+/// repository; the HTTP handler passes `structured_diff::rev_parse`.
+///
+/// A live branch that no longer resolves (merged back between two projections)
+/// is dropped: offering it would make the picker lie.
+pub(crate) fn collect(
+    run_id: &str,
+    run_state: &RunState,
+    events: &[Event],
+    sha_of: &dyn Fn(&str) -> Option<String>,
+) -> RunRefs {
+    let mut refs: Vec<RunRef> = Vec::new();
+    let mut deliveries: Vec<Delivery> = Vec::new();
+
+    let fork = fork_base(run_state).to_string();
+    refs.push(RunRef {
+        id: FORK_ID.to_string(),
+        kind: RefKind::Fork,
+        label: "Fork point".to_string(),
+        sha: sha_of(&fork),
+        git_ref: fork,
+        node_id: None,
+        node_name: None,
+        iter: None,
+    });
+
+    for d in deliveries_in_log(events) {
+        let name = node_name(run_state, &d.node_id);
+        refs.push(RunRef {
+            id: before_id(&d.node_id, d.iter),
+            kind: RefKind::Before,
+            label: format!("{name} · iter {} · before", d.iter),
+            sha: Some(d.before.clone()),
+            git_ref: d.before.clone(),
+            node_id: Some(d.node_id.clone()),
+            node_name: Some(name.clone()),
+            iter: Some(d.iter),
+        });
+        refs.push(RunRef {
+            id: after_id(&d.node_id, d.iter),
+            kind: RefKind::After,
+            label: format!("{name} · iter {} · after", d.iter),
+            sha: Some(d.after.clone()),
+            git_ref: d.after.clone(),
+            node_id: Some(d.node_id.clone()),
+            node_name: Some(name.clone()),
+            iter: Some(d.iter),
+        });
+        deliveries.push(Delivery {
+            node_id: d.node_id.clone(),
+            node_name: name,
+            iter: d.iter,
+            status: DeliveryStatus::Delivered,
+            before: before_id(&d.node_id, d.iter),
+            after: Some(after_id(&d.node_id, d.iter)),
+            live: None,
+            delivered_at: Some(d.ts),
+        });
+    }
+
+    for (node_id, iter, branch) in live_nodes(run_id, run_state) {
+        let Some(sha) = sha_of(&branch) else { continue };
+        let name = node_name(run_state, &node_id);
+        refs.push(RunRef {
+            id: live_id(&node_id),
+            kind: RefKind::Live,
+            label: format!("{name} · iter {iter} · live"),
+            sha: Some(sha),
+            git_ref: branch,
+            node_id: Some(node_id.clone()),
+            node_name: Some(name.clone()),
+            iter: Some(iter),
+        });
+        deliveries.push(Delivery {
+            node_id: node_id.clone(),
+            node_name: name,
+            iter,
+            status: DeliveryStatus::Running,
+            // What the node was cut from is the Run's branch; its live branch is
+            // what it has not merged back yet.
+            before: TIP_ID.to_string(),
+            after: None,
+            live: Some(live_id(&node_id)),
+            delivered_at: None,
+        });
+    }
+
+    let tip = tip_branch(run_id);
+    refs.push(RunRef {
+        id: TIP_ID.to_string(),
+        kind: RefKind::Tip,
+        label: "Run tip".to_string(),
+        sha: sha_of(&tip),
+        git_ref: tip,
+        node_id: None,
+        node_name: None,
+        iter: None,
+    });
+
+    RunRefs {
+        refs,
+        deliveries,
+        default_from: FORK_ID,
+        default_to: TIP_ID,
+    }
+}
+
+/// What a `from`/`to` query value turned out to be.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum Resolved {
+    /// A Run ref id, resolved to the git ref to hand to `git`.
+    Git(String),
+    /// Shaped like a Run ref id but the Run knows no such ref (a node that never
+    /// delivered at that iter, a node that is not running, …).
+    Unknown,
+    /// Not a Run ref id at all: the caller decides (a raw ref for compatibility).
+    NotAnId,
+}
+
+/// Resolve a stable ref id against the Run's log. Pure: no git call.
+pub(crate) fn resolve_id(run_id: &str, run_state: &RunState, events: &[Event], id: &str) -> Resolved {
+    if id == FORK_ID {
+        return Resolved::Git(fork_base(run_state).to_string());
+    }
+    if id == TIP_ID {
+        return Resolved::Git(tip_branch(run_id));
+    }
+    if let Some(rest) = id.strip_prefix("node:") {
+        // `<node id>:<iter>:<side>` — the node id may itself contain `:`, so
+        // split from the right.
+        let Some((head, side)) = rest.rsplit_once(':') else {
+            return Resolved::Unknown;
+        };
+        let Some((node_id, iter)) = head.rsplit_once(':') else {
+            return Resolved::Unknown;
+        };
+        let Ok(iter) = iter.parse::<i64>() else {
+            return Resolved::Unknown;
+        };
+        let Some(d) = deliveries_in_log(events)
+            .into_iter()
+            .find(|d| d.node_id == node_id && d.iter == iter)
+        else {
+            return Resolved::Unknown;
+        };
+        return match side {
+            "before" => Resolved::Git(d.before),
+            "after" => Resolved::Git(d.after),
+            _ => Resolved::Unknown,
+        };
+    }
+    if let Some(node_id) = id.strip_prefix("live:") {
+        return match live_nodes(run_id, run_state)
+            .into_iter()
+            .find(|(n, _, _)| n == node_id)
+        {
+            Some((_, _, branch)) => Resolved::Git(branch),
+            None => Resolved::Unknown,
+        };
+    }
+    Resolved::NotAnId
+}
+
+/// `true` when the pair is the fork → tip default, which is compared three-dot
+/// (merge-base) like the LOC stat. `None` = the side was not given.
+pub(crate) fn is_default_pair(from: Option<&str>, to: Option<&str>) -> bool {
+    matches!(from, None | Some(FORK_ID)) && matches!(to, None | Some(TIP_ID))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::event_log::{now_iso, project};
+
+    fn run_started(run_id: &str, node_defs: serde_json::Value) -> Event {
+        Event {
+            id: None,
+            run_id: run_id.into(),
+            ts: now_iso(),
+            kind: EventKind::RunStarted,
+            node_id: None,
+            iter: None,
+            payload: Some(serde_json::json!({
+                "pipeline_name": "p",
+                "fork_sha": "f0f0f0f",
+                "source_branch": "main",
+                "node_defs": node_defs,
+                "edges": [],
+            })),
+        }
+    }
+
+    fn node_started(run_id: &str, node: &str, iter: i64, isolated: bool) -> Event {
+        Event {
+            id: None,
+            run_id: run_id.into(),
+            ts: now_iso(),
+            kind: EventKind::NodeStarted,
+            node_id: Some(node.into()),
+            iter: Some(iter),
+            payload: Some(serde_json::json!({ "isolated_worktree": isolated })),
+        }
+    }
+
+    fn delivered(run_id: &str, node: &str, iter: i64, before: &str, after: &str) -> Event {
+        Event {
+            id: None,
+            run_id: run_id.into(),
+            ts: format!("2026-09-09T10:00:0{iter}Z"),
+            kind: EventKind::NodeDelivered,
+            node_id: Some(node.into()),
+            iter: Some(iter),
+            payload: Some(serde_json::json!({ "before": before, "after": after })),
+        }
+    }
+
+    fn completed(run_id: &str, node: &str, iter: i64) -> Event {
+        Event {
+            id: None,
+            run_id: run_id.into(),
+            ts: now_iso(),
+            kind: EventKind::NodeCompleted,
+            node_id: Some(node.into()),
+            iter: Some(iter),
+            payload: None,
+        }
+    }
+
+    const RUN: &str = "20260909-run";
+
+    fn two_deliveries_and_a_live_node() -> Vec<Event> {
+        vec![
+            run_started(
+                RUN,
+                serde_json::json!([
+                    { "id": "design", "name": "Design", "node_type": "agent", "inputs": [], "outputs": [] },
+                    { "id": "impl", "name": "Implement", "node_type": "agent", "inputs": [], "outputs": [] },
+                    { "id": "review", "name": "Review", "node_type": "agent", "inputs": [], "outputs": [] },
+                ]),
+            ),
+            node_started(RUN, "design", 1, true),
+            delivered(RUN, "design", 1, "aaa1", "bbb2"),
+            completed(RUN, "design", 1),
+            node_started(RUN, "impl", 1, false),
+            delivered(RUN, "impl", 1, "bbb2", "ccc3"),
+            completed(RUN, "impl", 1),
+            node_started(RUN, "review", 1, true),
+        ]
+    }
+
+    #[test]
+    fn lists_fork_deliveries_live_and_tip_in_order_with_labels() {
+        let events = two_deliveries_and_a_live_node();
+        let state = project(&events).unwrap();
+        let sha_of = |r: &str| -> Option<String> {
+            match r {
+                "f0f0f0f" => Some("f0f0f0f".into()),
+                "pdo/run-20260909-run" => Some("ccc3".into()),
+                "pdo/sub-20260909-run-review-iter-1" => Some("ddd4".into()),
+                _ => None,
+            }
+        };
+        let refs = collect(RUN, &state, &events, &sha_of);
+
+        let ids: Vec<&str> = refs.refs.iter().map(|r| r.id.as_str()).collect();
+        assert_eq!(
+            ids,
+            vec![
+                "fork",
+                "node:design:1:before",
+                "node:design:1:after",
+                "node:impl:1:before",
+                "node:impl:1:after",
+                "live:review",
+                "tip",
+            ]
+        );
+        let labels: Vec<&str> = refs.refs.iter().map(|r| r.label.as_str()).collect();
+        assert_eq!(
+            labels,
+            vec![
+                "Fork point",
+                "Design · iter 1 · before",
+                "Design · iter 1 · after",
+                "Implement · iter 1 · before",
+                "Implement · iter 1 · after",
+                "Review · iter 1 · live",
+                "Run tip",
+            ]
+        );
+        // Delivery refs are the frozen SHAs of the log; the tip and the live
+        // branch resolve through git.
+        assert_eq!(refs.refs[2].sha.as_deref(), Some("bbb2"));
+        assert_eq!(refs.refs[2].git_ref, "bbb2");
+        assert_eq!(refs.refs[5].git_ref, "pdo/sub-20260909-run-review-iter-1");
+        assert_eq!(refs.refs[5].sha.as_deref(), Some("ddd4"));
+        assert_eq!(refs.refs[6].git_ref, "pdo/run-20260909-run");
+        assert_eq!(refs.refs[0].git_ref, "f0f0f0f");
+
+        assert_eq!(refs.deliveries.len(), 3);
+        assert_eq!(refs.deliveries[0].node_name, "Design");
+        assert_eq!(refs.deliveries[0].status, DeliveryStatus::Delivered);
+        assert_eq!(refs.deliveries[0].before, "node:design:1:before");
+        assert_eq!(refs.deliveries[0].after.as_deref(), Some("node:design:1:after"));
+        assert_eq!(refs.deliveries[2].status, DeliveryStatus::Running);
+        assert_eq!(refs.deliveries[2].before, "tip");
+        assert_eq!(refs.deliveries[2].live.as_deref(), Some("live:review"));
+        assert_eq!(refs.default_from, "fork");
+        assert_eq!(refs.default_to, "tip");
+    }
+
+    #[test]
+    fn a_live_branch_that_no_longer_resolves_is_dropped() {
+        let events = two_deliveries_and_a_live_node();
+        let state = project(&events).unwrap();
+        let sha_of = |_: &str| -> Option<String> { None };
+        let refs = collect(RUN, &state, &events, &sha_of);
+        assert!(refs.refs.iter().all(|r| r.kind != RefKind::Live));
+        assert_eq!(refs.deliveries.len(), 2);
+        // Fork and tip stay listed even unresolved (an archived Run): the UI
+        // says "not preserved", the picker does not lie about a missing ref.
+        assert_eq!(refs.refs[0].sha, None);
+        assert_eq!(refs.refs.last().unwrap().sha, None);
+    }
+
+    #[test]
+    fn a_redelivery_of_the_same_iter_replaces_in_place() {
+        let mut events = two_deliveries_and_a_live_node();
+        events.push(delivered(RUN, "design", 1, "aaa1", "eee5"));
+        let state = project(&events).unwrap();
+        let refs = collect(RUN, &state, &events, &|_| None);
+        let design_after = refs
+            .refs
+            .iter()
+            .find(|r| r.id == "node:design:1:after")
+            .unwrap();
+        assert_eq!(design_after.sha.as_deref(), Some("eee5"));
+        // Still first among the deliveries.
+        assert_eq!(refs.deliveries[0].node_id, "design");
+        assert_eq!(refs.deliveries.iter().filter(|d| d.node_id == "design").count(), 1);
+    }
+
+    #[test]
+    fn a_node_without_a_name_is_labelled_by_its_id() {
+        let events = vec![
+            run_started(
+                RUN,
+                serde_json::json!([{ "id": "w-1", "node_type": "agent", "inputs": [], "outputs": [] }]),
+            ),
+            node_started(RUN, "w-1", 2, false),
+            delivered(RUN, "w-1", 2, "a", "b"),
+        ];
+        let state = project(&events).unwrap();
+        let refs = collect(RUN, &state, &events, &|_| None);
+        assert_eq!(refs.refs[1].label, "w-1 · iter 2 · before");
+    }
+
+    #[test]
+    fn resolves_stable_ids_and_refuses_unknown_ones() {
+        let events = two_deliveries_and_a_live_node();
+        let state = project(&events).unwrap();
+        let r = |id: &str| resolve_id(RUN, &state, &events, id);
+        assert_eq!(r("fork"), Resolved::Git("f0f0f0f".into()));
+        assert_eq!(r("tip"), Resolved::Git("pdo/run-20260909-run".into()));
+        assert_eq!(r("node:design:1:before"), Resolved::Git("aaa1".into()));
+        assert_eq!(r("node:design:1:after"), Resolved::Git("bbb2".into()));
+        assert_eq!(r("node:impl:1:after"), Resolved::Git("ccc3".into()));
+        assert_eq!(
+            r("live:review"),
+            Resolved::Git("pdo/sub-20260909-run-review-iter-1".into())
+        );
+        // Unknown shapes of a known prefix are refused, never passed to git.
+        assert_eq!(r("node:design:2:after"), Resolved::Unknown);
+        assert_eq!(r("node:ghost:1:after"), Resolved::Unknown);
+        assert_eq!(r("node:design:1:sideways"), Resolved::Unknown);
+        assert_eq!(r("node:design"), Resolved::Unknown);
+        assert_eq!(r("node:design:x:after"), Resolved::Unknown);
+        assert_eq!(r("live:impl"), Resolved::Unknown, "impl is not running");
+        assert_eq!(r("live:nobody"), Resolved::Unknown);
+        // A raw ref is not an id: the caller keeps the compatibility path.
+        assert_eq!(r("HEAD~1"), Resolved::NotAnId);
+        assert_eq!(r("deadbeef"), Resolved::NotAnId);
+    }
+
+    #[test]
+    fn fork_base_prefers_the_frozen_fork_sha() {
+        let events = two_deliveries_and_a_live_node();
+        let mut state = project(&events).unwrap();
+        assert_eq!(fork_base(&state), "f0f0f0f");
+        state.fork_sha = None;
+        assert_eq!(fork_base(&state), "main");
+        state.source_branch = None;
+        assert_eq!(fork_base(&state), "HEAD");
+    }
+
+    #[test]
+    fn default_pair_is_fork_to_tip_or_nothing() {
+        assert!(is_default_pair(None, None));
+        assert!(is_default_pair(Some("fork"), Some("tip")));
+        assert!(is_default_pair(Some("fork"), None));
+        assert!(!is_default_pair(Some("tip"), Some("fork")));
+        assert!(!is_default_pair(Some("node:a:1:before"), Some("node:a:1:after")));
+        assert!(!is_default_pair(None, Some("abc123")));
+    }
+}

--- a/frontend/e2e/review-page-fp.spec.ts
+++ b/frontend/e2e/review-page-fp.spec.ts
@@ -1,0 +1,311 @@
+import { test, expect } from "@playwright/test";
+import type { Page } from "@playwright/test";
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { cleanupRuns, openRunNodeDetails, runMultipart, E2E_TARGET_REPO } from "./helpers";
+
+// FP validation — #749 (ADR-0067): the Review page.
+//
+//  1. On a finished Run where two nodes delivered different files, open the
+//     Diff tab then « Expand and comment » → the Review page opens, pair
+//     fork → tip, every file listed on the left, side-by-side.
+//  2. Pick the first node's `after` as destination and its `before` as source →
+//     only that node's files remain listed (checked against git).
+//  3. Expand the context between two hunks of a file → the hidden lines appear.
+//  4. From the second node's panel, use the shortcut → the Review opens with
+//     that node's delivery preselected.
+//
+// Real daemon (webServer), real Run branch, real deliveries: each node's work is
+// written into the Run's shared worktree and its completion is signalled on
+// `POST /runs/<id>/nodes/<node>/done` — exactly what `pdo complete` does — so
+// the daemon itself commits the delivery and records `NodeDelivered`.
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const WORKSPACE_ROOT = path.resolve(__dirname, "..", "..");
+const SHOTS = process.env.PDO_FP_SHOTS_DIR ?? path.join(WORKSPACE_ROOT, "fp-shots");
+const PIPELINE_NAME = `e2e-review-fp-${process.pid}-${Date.now()}`;
+const PIPELINE_DIR = path.join(os.homedir(), ".pdo", "pipelines");
+const PIPELINE_PATH = path.join(PIPELINE_DIR, `${PIPELINE_NAME}.yaml`);
+
+const SEED_YAML = `name: ${PIPELINE_NAME}
+version: "1.0"
+nodes:
+  - id: start
+    name: Start
+    type: start
+    outputs:
+      - { name: user_prompt, side: bottom }
+    view: { x: 100, y: 0 }
+  - id: alpha
+    name: alpha
+    type: agent
+    isolated_worktree: false
+    inputs:
+      - { name: task, side: top }
+    outputs:
+      - { name: summary, side: bottom }
+    view: { x: 100, y: 150 }
+  - id: beta
+    name: beta
+    type: agent
+    isolated_worktree: false
+    inputs:
+      - { name: task, side: top }
+    outputs:
+      - { name: summary, side: bottom }
+    view: { x: 100, y: 300 }
+  - id: end
+    name: End
+    type: end
+    inputs:
+      - { name: result, side: top }
+    view: { x: 100, y: 450 }
+edges:
+  - source: { node: start, port: user_prompt }
+    target: { node: alpha, port: task }
+  - source: { node: alpha, port: summary }
+    target: { node: beta, port: task }
+  - source: { node: beta, port: summary }
+    target: { node: end, port: result }
+`;
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+}
+
+const createdRuns: string[] = [];
+
+test.beforeAll(async () => {
+  await fs.mkdir(SHOTS, { recursive: true });
+  await fs.mkdir(PIPELINE_DIR, { recursive: true });
+  await fs.writeFile(PIPELINE_PATH, SEED_YAML);
+});
+
+test.afterAll(async () => {
+  await cleanupRuns(...createdRuns);
+  await fs.rm(PIPELINE_PATH, { force: true });
+});
+
+interface RunView {
+  status: string;
+  nodes: Record<string, { status: string; delivery?: { before: string; after: string } | null }>;
+}
+
+async function waitForNode(page: Page, baseURL: string, runId: string, nodeId: string, pred: (n: RunView["nodes"][string]) => boolean) {
+  await expect
+    .poll(
+      async () => {
+        const r = await page.request.get(`${baseURL}/runs/${runId}`);
+        if (!r.ok()) return false;
+        const view = (await r.json()) as RunView;
+        const n = view.nodes[nodeId];
+        return !!n && pred(n);
+      },
+      { timeout: 30_000 },
+    )
+    .toBe(true);
+}
+
+/** A node's work: files written into the Run's worktree, then `done` (what `pdo complete` does). */
+async function deliver(page: Page, baseURL: string, runId: string, wt: string, nodeId: string, write: () => Promise<void>) {
+  await waitForNode(page, baseURL, runId, nodeId, (n) => n.status === "running" || n.status === "awaiting_user");
+  await write();
+  const artifact = path.join(wt, ".pdo", "artifacts", nodeId, "iter-1", "summary");
+  await fs.mkdir(artifact, { recursive: true });
+  await fs.writeFile(path.join(artifact, "output.md"), `# ${nodeId}\n\ndone\n`);
+  const done = await page.request.post(`${baseURL}/runs/${runId}/nodes/${nodeId}/done`, {
+    data: { iter: 1 },
+  });
+  expect(done.ok(), `node ${nodeId} done: ${done.status()} ${await done.text()}`).toBe(true);
+  await waitForNode(page, baseURL, runId, nodeId, (n) => !!n.delivery);
+}
+
+async function openInfoPanel(page: Page, runId: string) {
+  await page
+    .getByText(runId.slice(0, 20))
+    .first()
+    .click({ timeout: 5_000, position: { x: 5, y: 5 } });
+  await page.waitForTimeout(500);
+  await page.getByTestId("toolbar-info").click();
+  await expect(page.getByTestId("pipeline-info-panel")).toBeVisible({ timeout: 3_000 });
+}
+
+test("Review page: fork → tip, one node's delivery, context expansion, node shortcut", async ({ page, baseURL }) => {
+  test.setTimeout(150_000);
+  await page.goto("/");
+  await expect(page.getByText("Daemon: connected")).toBeVisible({ timeout: 10_000 });
+
+  const resp = await page.request.post(`${baseURL}/runs`, {
+    multipart: runMultipart({ pipeline: PIPELINE_NAME, input: "review fp" }),
+  });
+  expect(resp.status()).toBe(201);
+  const { run_id } = await resp.json();
+  createdRuns.push(run_id);
+
+  const wt = path.join(E2E_TARGET_REPO, ".pdo", "runs", run_id, "worktree");
+  await expect
+    .poll(async () => fs.stat(wt).then(() => true, () => false), { timeout: 10_000 })
+    .toBe(true);
+
+  // --- alpha delivers: README edited in TWO places (a gap of hidden lines
+  // between the hunks) + a new file.
+  const readmePath = path.join(wt, "README.md");
+  const original = (await fs.readFile(readmePath, "utf8")).split("\n");
+  expect(original.length).toBeGreaterThan(80);
+  // Line 13 sits between the two hunks (lines 3 and 62) and stays untouched:
+  // it is hidden until the context is expanded.
+  const HIDDEN_PROBE = original[12];
+  expect(HIDDEN_PROBE.length).toBeGreaterThan(20);
+  await deliver(page, baseURL!, run_id, wt, "alpha", async () => {
+    const lines = [...original];
+    lines[2] = "alpha edited line 3 (#749 FP)";
+    lines[61] = "alpha edited line 62 (#749 FP)";
+    await fs.writeFile(readmePath, lines.join("\n"));
+    await fs.writeFile(path.join(wt, "alpha-note.md"), "# alpha\n\nwritten by alpha\n");
+  });
+
+  // --- beta delivers: a different file.
+  await deliver(page, baseURL!, run_id, wt, "beta", async () => {
+    await fs.writeFile(path.join(wt, "beta-note.md"), "# beta\n\nwritten by beta\n");
+  });
+
+  // Ground truth from git, through the refs the daemon exposes.
+  const refsResp = await page.request.get(`${baseURL}/runs/${run_id}/refs`);
+  expect(refsResp.ok()).toBe(true);
+  const refs = (await refsResp.json()) as {
+    refs: { id: string; sha: string | null; label: string }[];
+    deliveries: { node_id: string; iter: number; before: string; after?: string }[];
+  };
+  expect(refs.refs.map((r) => r.id)).toEqual([
+    "fork",
+    "node:alpha:1:before",
+    "node:alpha:1:after",
+    "node:beta:1:before",
+    "node:beta:1:after",
+    "tip",
+  ]);
+  const sha = (id: string) => refs.refs.find((r) => r.id === id)!.sha!;
+  const alphaFiles = git(E2E_TARGET_REPO, [
+    "diff", "--name-only", sha("node:alpha:1:before"), sha("node:alpha:1:after"), "--", ".", ":(exclude).pdo/",
+  ])
+    .split("\n")
+    .filter(Boolean)
+    .sort();
+  expect(alphaFiles).toEqual(["README.md", "alpha-note.md"]);
+  const allFiles = git(E2E_TARGET_REPO, [
+    "diff", "--name-only", `${sha("fork")}...pdo/run-${run_id}`, "--", ".", ":(exclude).pdo/",
+  ])
+    .split("\n")
+    .filter(Boolean)
+    .sort();
+  expect(allFiles).toEqual(["README.md", "alpha-note.md", "beta-note.md"]);
+
+  // ===== Step 1 — Diff tab → « Expand and comment » → Review page, fork → tip.
+  await page.reload();
+  await expect(page.getByText("Daemon: connected")).toBeVisible({ timeout: 10_000 });
+  await openInfoPanel(page, run_id);
+  await page.getByTestId("info-tab-diff").click();
+  await expect(page.getByTestId("diff-tab")).toBeVisible({ timeout: 10_000 });
+  const expand = page.getByTestId("diff-review-button");
+  await expect(expand).toHaveText(/Expand and comment/);
+  await expand.click();
+
+  await expect(page).toHaveURL(new RegExp(`/runs/${run_id}/review$`));
+  await expect(page.getByTestId("review-page")).toBeVisible({ timeout: 10_000 });
+  await expect(page.getByTestId("review-from")).toHaveText(/Fork point/, { timeout: 10_000 });
+  await expect(page.getByTestId("review-to")).toHaveText(/Run tip/);
+  await expect(page.getByTestId("review-view-toggle")).toHaveAttribute("data-view", "split");
+  const rows = page.getByTestId("review-file-row");
+  await expect(rows).toHaveCount(3, { timeout: 10_000 });
+  const listed = async () =>
+    (await rows.evaluateAll((els) => els.map((e) => e.getAttribute("data-path")))).filter(Boolean).sort();
+  expect(await listed()).toEqual(allFiles);
+  await expect(page.getByTestId("review-stats")).toContainText("3 files");
+  // Side-by-side: the third-party body renders both columns.
+  const readmeCard = page.locator('[data-testid="review-file"][data-path="README.md"]');
+  await expect(readmeCard.locator('tr[data-side="old"]').first()).toBeVisible({ timeout: 10_000 });
+  await expect(readmeCard.locator('tr[data-side="new"]').first()).toBeVisible();
+  await page.screenshot({ path: path.join(SHOTS, "749-review-fork-tip.png") });
+
+  // The page is a real URL: reload keeps it.
+  await page.reload();
+  await expect(page.getByTestId("review-page")).toBeVisible({ timeout: 10_000 });
+  await expect(rows).toHaveCount(3, { timeout: 10_000 });
+
+  // ===== Step 2 — destination = alpha's after, source = alpha's before.
+  await page.getByTestId("review-to").click();
+  await page.getByTestId("review-ref-popover-to").getByTestId("review-ref-option-node:alpha:1:after").click();
+  await expect(page.getByTestId("review-to")).toHaveText(/alpha · iter 1 · after/);
+  await page.getByTestId("review-from").click();
+  await page.getByTestId("review-ref-popover-from").getByTestId("review-ref-option-node:alpha:1:before").click();
+  await expect(page.getByTestId("review-from")).toHaveText(/alpha · iter 1 · before/);
+  await expect(page).toHaveURL(/from=node%3Aalpha%3A1%3Abefore&to=node%3Aalpha%3A1%3Aafter/);
+  await expect(page.getByTestId("review-delivery-chip")).toContainText("Reviewing the delivery of alpha · iter 1");
+  await expect(rows).toHaveCount(2, { timeout: 10_000 });
+  expect(await listed()).toEqual(alphaFiles);
+  await page.screenshot({ path: path.join(SHOTS, "749-review-alpha-delivery.png") });
+
+  // ===== Step 3 — expand the context between README's two hunks.
+  await expect(readmeCard).toHaveAttribute("data-content", "ready", { timeout: 10_000 });
+  const probe = readmeCard.getByText(HIDDEN_PROBE, { exact: true });
+  await expect(probe).toHaveCount(0);
+  const hunkRowsBefore = await readmeCard.locator('tr[data-state="hunk"]').count();
+  expect(hunkRowsBefore).toBeGreaterThanOrEqual(2);
+  // The gap is ~58 lines: GitHub-style ↑/↓ (20 lines each) or ⇕ when small.
+  const expander = readmeCard
+    .locator('button[title="Expand All"], button[title="Expand Down"], button[title="Expand Up"]')
+    .first();
+  await expect(expander).toBeVisible({ timeout: 10_000 });
+  let clicks = 0;
+  while ((await probe.count()) === 0 && clicks < 6) {
+    const btn = readmeCard
+      .locator('button[title="Expand All"], button[title="Expand Down"], button[title="Expand Up"]')
+      .first();
+    await btn.click();
+    clicks += 1;
+    await page.waitForTimeout(150);
+  }
+  await expect(probe.first()).toBeVisible();
+  await page.screenshot({ path: path.join(SHOTS, "749-review-context-expanded.png") });
+
+  // ===== Step 4 — from beta's node panel, the shortcut preselects its delivery.
+  await page.goto("/");
+  await expect(page.getByText("Daemon: connected")).toBeVisible({ timeout: 10_000 });
+  await openRunNodeDetails(page, run_id, "beta");
+  const shortcut = page.getByTestId("node-review-shortcut");
+  await expect(shortcut).toHaveText(/Review this node's delivery/);
+  await shortcut.click();
+  await expect(page).toHaveURL(/from=node%3Abeta%3A1%3Abefore&to=node%3Abeta%3A1%3Aafter/);
+  await expect(page.getByTestId("review-delivery-chip")).toContainText("Reviewing the delivery of beta · iter 1", {
+    timeout: 10_000,
+  });
+  await expect(rows).toHaveCount(1, { timeout: 10_000 });
+  expect(await listed()).toEqual(["beta-note.md"]);
+  await page.screenshot({ path: path.join(SHOTS, "749-review-beta-shortcut.png") });
+});
+
+test("the Split | Unified toggle is remembered and « Nothing to compare » for the same ref", async ({ page, baseURL }) => {
+  await page.goto("/");
+  await expect(page.getByText("Daemon: connected")).toBeVisible({ timeout: 10_000 });
+  const resp = await page.request.post(`${baseURL}/runs`, {
+    multipart: runMultipart({ pipeline: PIPELINE_NAME, input: "review toggle" }),
+  });
+  expect(resp.status()).toBe(201);
+  const { run_id } = await resp.json();
+  createdRuns.push(run_id);
+
+  await page.goto(`/runs/${run_id}/review`);
+  await expect(page.getByTestId("review-page")).toBeVisible({ timeout: 10_000 });
+  await expect(page.getByTestId("review-view-toggle")).toHaveAttribute("data-view", "split");
+  await page.getByTestId("review-view-unified").click();
+  await expect(page.getByTestId("review-view-toggle")).toHaveAttribute("data-view", "unified");
+  await page.reload();
+  await expect(page.getByTestId("review-view-toggle")).toHaveAttribute("data-view", "unified", { timeout: 10_000 });
+  expect(await page.evaluate(() => localStorage.getItem("pdo.review.view"))).toBe("unified");
+
+  await page.goto(`/runs/${run_id}/review?from=tip&to=tip`);
+  await expect(page.getByTestId("review-empty")).toContainText("Nothing to compare", { timeout: 10_000 });
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@base-ui/react": "^1.4.1",
     "@fontsource-variable/geist": "^5.2.8",
+    "@git-diff-view/react": "^0.1.7",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@tailwindcss/vite": "^4.2.4",
     "@xterm/addon-fit": "^0.11.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@fontsource-variable/geist':
         specifier: ^5.2.8
         version: 5.2.8
+      '@git-diff-view/react':
+        specifier: ^0.1.7
+        version: 0.1.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@radix-ui/react-tooltip':
         specifier: ^1.2.8
         version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -449,6 +452,18 @@ packages:
 
   '@fontsource-variable/geist@5.2.8':
     resolution: {integrity: sha512-cJ6m9e+8MQ5dCYJsLylfZrgBh6KkG4bOLckB35Tr9J/EqdkEM6QllH5PxqP1dhTvFup+HtMRPuz9xOjxXJggxw==}
+
+  '@git-diff-view/core@0.1.7':
+    resolution: {integrity: sha512-ZW/kumNoUQ8+DgawYhcrABa7TOALYzn3pe723uTHSy6/r35qAwgswJxF1bkdV9Zr+KHuhlFeRLiVhjij59qdIA==}
+
+  '@git-diff-view/lowlight@0.1.7':
+    resolution: {integrity: sha512-Rkv2ERr83xTSsjlrJxjYVWndREEARG11viTrJ7qyUU+lnPPmSNF1aemp1lKiOLs6sNCeJJdIMhxLFJtKfmRIZw==}
+
+  '@git-diff-view/react@0.1.7':
+    resolution: {integrity: sha512-EMBFgeSpP3nF8hJwy/3bz8sZpxmyuWV20925oTGhslWXpIgg6AZg+KMRmQkz/WjX0D/2LrC3gQZJLE/5x6mfnw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   '@hono/node-server@1.19.14':
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
@@ -1331,6 +1346,12 @@ packages:
   '@vitest/utils@4.1.5':
     resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
 
+  '@vue/reactivity@3.5.42':
+    resolution: {integrity: sha512-TzNNfKpb7hDxbQltwAut8VDQA5YP+BuRlxntHUuRjyKwlMvmAPbs3unhCvieijifY6vFfVBwsS7wG/C7uq+bEQ==}
+
+  '@vue/shared@3.5.42':
+    resolution: {integrity: sha512-2rPxex1jQf4jvl9MOHl6YaXCPcrNqz/FstMOEh3QWY+/OME9nQTvl9WYeCwhW7AFjaR0SnngZGlp/wkR6rkI6g==}
+
   '@xterm/addon-fit@0.11.0':
     resolution: {integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==}
 
@@ -2031,6 +2052,9 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
+  fast-diff@1.3.0:
+    resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
+
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
@@ -2208,6 +2232,14 @@ packages:
 
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
+
+  highlight.js@11.11.2:
+    resolution: {integrity: sha512-oaXMACAU0kzOMXBjWpNcX+vlwSBCIAiZ9BHa7gA15NOTtT2L/l8OSZDuqS2XppOhZBPJ7hm4o8ep2kyuip2uEQ==}
+    engines: {node: '>=12.0.0'}
+
+  highlight.js@11.12.0:
+    resolution: {integrity: sha512-nbfWpyRMcMrPMmDwJB+dhX/eiaPKtc2RB+0QZskqJ3WjRA/FDS0e9hZrx8EC/lbEv8gXy98FcDbNa/dspAaJMg==}
+    engines: {node: '>=12.0.0'}
 
   hono@4.12.17:
     resolution: {integrity: sha512-FbJJNb/XgX7YW0hX/V8w5oYLztKEsRLykCMZWt1WdLtsfjzMvmoqWBA4H4t5norinq8/rh20oiZYr+WSl4UzAQ==}
@@ -2560,6 +2592,9 @@ packages:
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
+  lowlight@3.3.0:
+    resolution: {integrity: sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==}
 
   lru-cache@11.3.6:
     resolution: {integrity: sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==}
@@ -3047,6 +3082,11 @@ packages:
   react@19.2.5:
     resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
     engines: {node: '>=0.10.0'}
+
+  reactivity-store@0.4.0:
+    resolution: {integrity: sha512-uL9uoREOBg2o4zUa8vMU0AbvAOk0osPloizscmyZqMvJzcuuKX3ELFYYr1DX8gAcfvlhPduz4QuLZn1eChCu4Q==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   recast@0.23.11:
     resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
@@ -4039,6 +4079,31 @@ snapshots:
 
   '@fontsource-variable/geist@5.2.8': {}
 
+  '@git-diff-view/core@0.1.7':
+    dependencies:
+      '@git-diff-view/lowlight': 0.1.7
+      fast-diff: 1.3.0
+      highlight.js: 11.12.0
+      lowlight: 3.3.0
+
+  '@git-diff-view/lowlight@0.1.7':
+    dependencies:
+      '@types/hast': 3.0.5
+      highlight.js: 11.12.0
+      lowlight: 3.3.0
+
+  '@git-diff-view/react@0.1.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@git-diff-view/core': 0.1.7
+      '@types/hast': 3.0.5
+      fast-diff: 1.3.0
+      highlight.js: 11.12.0
+      lowlight: 3.3.0
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      reactivity-store: 0.4.0(react@19.2.5)
+      use-sync-external-store: 1.6.0(react@19.2.5)
+
   '@hono/node-server@1.19.14(hono@4.12.17)':
     dependencies:
       hono: 4.12.17
@@ -4880,6 +4945,12 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  '@vue/reactivity@3.5.42':
+    dependencies:
+      '@vue/shared': 3.5.42
+
+  '@vue/shared@3.5.42': {}
+
   '@xterm/addon-fit@0.11.0': {}
 
   '@xterm/addon-web-links@0.12.0': {}
@@ -5601,6 +5672,8 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
+  fast-diff@1.3.0: {}
+
   fast-glob@3.3.3:
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -5788,6 +5861,10 @@ snapshots:
   hermes-parser@0.25.1:
     dependencies:
       hermes-estree: 0.25.1
+
+  highlight.js@11.11.2: {}
+
+  highlight.js@11.12.0: {}
 
   hono@4.12.17: {}
 
@@ -6060,6 +6137,12 @@ snapshots:
       is-unicode-supported: 1.3.0
 
   longest-streak@3.1.0: {}
+
+  lowlight@3.3.0:
+    dependencies:
+      '@types/hast': 3.0.5
+      devlop: 1.1.0
+      highlight.js: 11.11.2
 
   lru-cache@11.3.6: {}
 
@@ -6766,6 +6849,13 @@ snapshots:
       react-dom: 19.2.5(react@19.2.5)
 
   react@19.2.5: {}
+
+  reactivity-store@0.4.0(react@19.2.5):
+    dependencies:
+      '@vue/reactivity': 3.5.42
+      '@vue/shared': 3.5.42
+      react: 19.2.5
+      use-sync-external-store: 1.6.0(react@19.2.5)
 
   recast@0.23.11:
     dependencies:

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,4 +1,4 @@
-import type { PipelineListEntry, PipelineDetail, PipelineDef, RunListEntry, RunState, PortDef, PortSide, PortType, FrontmatterFieldDecl, FrontmatterViolation, Trigger, TriggerFire, DaemonStatus, InstanceSettings, UpdateSettingsRequest, StatsOverview, StatsCost, StatsPerformance, SandboxProfile, SandboxProfileImage, SandboxProfileReferents, SyncCostPricesReport, UpdateStatus, UpdateChangelog, UpdateApplyResponse, Project, BranchRef, AgentChoice, AgentProfile, AgentProfileReferents, ProvisioningPlan, ProvisioningRules, Skill, SkillBank, SkillDetail, SkillFile, SkillFileContent, SkillFilesUpload, SkillFolder, SkillReferents, SkillRef, SkillScanResult, SkillImportItem, SkillImportReport, SkillRescanReport, RecentSkillSource, StructuredDiff } from "./types";
+import type { PipelineListEntry, PipelineDetail, PipelineDef, RunListEntry, RunState, PortDef, PortSide, PortType, FrontmatterFieldDecl, FrontmatterViolation, Trigger, TriggerFire, DaemonStatus, InstanceSettings, UpdateSettingsRequest, StatsOverview, StatsCost, StatsPerformance, SandboxProfile, SandboxProfileImage, SandboxProfileReferents, SyncCostPricesReport, UpdateStatus, UpdateChangelog, UpdateApplyResponse, Project, BranchRef, AgentChoice, AgentProfile, AgentProfileReferents, ProvisioningPlan, ProvisioningRules, Skill, SkillBank, SkillDetail, SkillFile, SkillFileContent, SkillFilesUpload, SkillFolder, SkillReferents, SkillRef, SkillScanResult, SkillImportItem, SkillImportReport, SkillRescanReport, RecentSkillSource, StructuredDiff, RunRefs } from "./types";
 import { foldHarnessOntoNode } from "./lib/harness";
 
 const BASE = "";
@@ -1835,12 +1835,15 @@ export function fetchRunFileAtRef(
   );
 }
 
-export function fetchNodeDiff(runId: string, nodeId: string): Promise<string> {
-  return request<string>(
-    "GET",
-    `/runs/${encodeURIComponent(runId)}/nodes/${encodeURIComponent(nodeId)}/diff`,
-    { responseMode: "text", label: `GET /runs/${runId}/nodes/${nodeId}/diff` },
-  );
+/**
+ * The Run's refs (#749, ADR-0067 §1): fork point, Run tip, every node delivery's
+ * `before`/`after`, the live branch of a running isolated node — with the
+ * ready-made delivery pairs. Ids are stable; SHAs are informative only.
+ */
+export function fetchRunRefs(runId: string): Promise<RunRefs> {
+  return request<RunRefs>("GET", `/runs/${encodeURIComponent(runId)}/refs`, {
+    label: `GET /runs/${runId}/refs`,
+  });
 }
 
 export function deleteLibraryPipeline(id: string): Promise<void> {

--- a/frontend/src/components/DiffTab.test.tsx
+++ b/frontend/src/components/DiffTab.test.tsx
@@ -420,15 +420,17 @@ describe("DiffTab", () => {
     expect(screen.getAllByTestId("diff-file")[0]).toHaveAttribute("data-collapsed", "true");
   });
 
-  it("shows the Review button, disabled, with its coming-soon tooltip", async () => {
+  it("links « Expand and comment » to the Run's Review page, fork → tip (#749)", async () => {
     mockedFetch.mockResolvedValue(TWO_FILES);
     render(<Host run={makeRun()} />);
     await waitFor(() => {
       expect(screen.getByTestId("diff-review-button")).toBeInTheDocument();
     });
-    const btn = screen.getByTestId("diff-review-button");
-    expect(btn).toBeDisabled();
-    expect(btn).toHaveAttribute("title", "Review page coming");
+    const link = screen.getByTestId("diff-review-button");
+    expect(link.tagName).toBe("A");
+    expect(link).toHaveTextContent("Expand and comment");
+    // The default pair is the short canonical URL: no query.
+    expect(link).toHaveAttribute("href", "/runs/test-run-1/review");
   });
 
   it("shows an error state with Retry when the endpoint fails", async () => {

--- a/frontend/src/components/DiffTab.tsx
+++ b/frontend/src/components/DiffTab.tsx
@@ -10,6 +10,7 @@ import {
 } from "lucide-react";
 import { fetchRunStructuredDiff } from "../api";
 import { wordDiff } from "../lib/wordDiff";
+import { reviewUrl } from "../lib/runRefs";
 import {
   LARGE_DIFF_FILES,
   TRUNCATE_LINES,
@@ -260,18 +261,17 @@ export default function DiffTab({ run, collapsed, onCollapsedChange }: Props) {
               Files
             </button>
           )}
-          {/* The Review page is the next ticket: visible, sober, disabled. */}
-          <button
-            disabled
-            aria-disabled
-            title="Review page coming"
-            className="flex items-center gap-1 rounded border border-line-strong bg-bg-3 px-2 py-0.5 text-fg-3 opacity-50"
+          {/* #749: the way to the Review page (fork → tip, same tab). */}
+          <a
+            href={reviewUrl(run.run_id)}
+            title="Open the Review page (fork → tip)"
+            className="flex items-center gap-1 rounded border border-line-strong bg-bg-3 px-2 py-0.5 text-fg-3 transition-colors hover:text-fg-2"
             style={{ fontSize: "10.5px" }}
             data-testid="diff-review-button"
           >
             <SquareArrowOutUpRight size={11} />
-            Review
-          </button>
+            Expand and comment
+          </a>
         </span>
       </div>
 
@@ -363,6 +363,7 @@ export default function DiffTab({ run, collapsed, onCollapsedChange }: Props) {
             {!isCollapsed && !f.binary && (
               <FileBody
                 file={f}
+                reviewHref={reviewUrl(run.run_id)}
                 full={fullFiles.has(key)}
                 onShowAll={() => setFullFiles((prev) => new Set(prev).add(key))}
               />
@@ -580,10 +581,13 @@ function buildRows(file: DiffFile): Row[] {
 
 function FileBody({
   file,
+  reviewHref,
   full,
   onShowAll,
 }: {
   file: DiffFile;
+  /** The Review page, where context expansion lives (#749). */
+  reviewHref: string;
   full: boolean;
   onShowAll: () => void;
 }) {
@@ -628,10 +632,15 @@ function FileBody({
                           {r.text}
                           {r.header && <span className="text-fg-4"> {r.header}</span>}
                         </span>
-                        {/* Ghost: context expansion lands with the Review page. */}
-                        <span className="ml-auto pl-4 text-fg-5" aria-hidden>
+                        {/* Context expansion lives on the Review page (#749). */}
+                        <a
+                          href={reviewHref}
+                          className="ml-auto pl-4 text-fg-5 hover:text-fg-3"
+                          title="Expand context on the Review page"
+                          tabIndex={-1}
+                        >
                           ↕ expand
-                        </span>
+                        </a>
                       </span>
                     </td>
                   </tr>

--- a/frontend/src/components/NodeDetailPanel.review749.test.tsx
+++ b/frontend/src/components/NodeDetailPanel.review749.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+
+// #749: the node panel's shortcut to the Review page. There is no "node diff"
+// surface (ADR-0067 §1): the panel only opens the Review with this node's
+// delivery preselected, and only when there is something to review.
+
+globalThis.ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+vi.mock("../api", () => ({
+  fetchPrompt: vi.fn().mockResolvedValue("prompt"),
+  fetchNodeIO: vi.fn().mockResolvedValue({ inputs: [], outputs: [] }),
+  markNodeDone: vi.fn().mockResolvedValue({ kind: "completed" }),
+  killNode: vi.fn(),
+  restartNode: vi.fn(),
+  stopNode: vi.fn(),
+  retryNode: vi.fn(),
+  retryNodePreview: vi.fn().mockResolvedValue({ downstream: [], affected_count: 0, with_artifacts: [] }),
+  previewProvisioning: vi.fn().mockResolvedValue({ entries: [], rules: [], conflicts: [] }),
+  startNode: vi.fn(),
+  attachSession: vi.fn(),
+  artifactUrl: (runId: string, path: string) => `/runs/${runId}/artifact?path=${encodeURIComponent(path)}`,
+}));
+
+vi.mock("./TmuxTerminal", () => ({
+  default: () => <div data-testid="tmux-terminal" />,
+}));
+
+vi.mock("./ui/resizable", () => ({
+  ResizablePanelGroup: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ResizablePanel: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ResizableHandle: () => <div />,
+}));
+
+vi.mock("./MarkdownArtifactModal", () => ({ default: () => null }));
+
+import NodeDetailPanel from "./NodeDetailPanel";
+import type { NodeState } from "../types";
+
+function makeNode(overrides?: Partial<NodeState>): NodeState {
+  return {
+    node_id: "impl",
+    status: "completed",
+    iter: 1,
+    started_at: "2026-09-09T00:00:00Z",
+    completed_at: "2026-09-09T00:01:00Z",
+    failure_reason: null,
+    iterations: [],
+    ...overrides,
+  };
+}
+
+describe("NodeDetailPanel — Review shortcut (#749)", () => {
+  it("offers « Review this node's delivery » for a delivered node, linking to its before → after", () => {
+    render(
+      <NodeDetailPanel
+        node={makeNode({ delivery: { before: "aaa", after: "bbb" }, iter: 2 })}
+        runId="run-1"
+        nodeName="Implement"
+      />,
+    );
+    const link = screen.getByTestId("node-review-shortcut");
+    expect(link).toHaveTextContent("Review this node's delivery");
+    expect(link).toHaveAttribute("href", "/runs/run-1/review?from=node%3Aimpl%3A2%3Abefore&to=node%3Aimpl%3A2%3Aafter");
+  });
+
+  it("offers « Review live changes » for a running isolated node, tip → live", () => {
+    render(
+      <NodeDetailPanel
+        node={makeNode({ status: "running", completed_at: null, isolated_worktree: true })}
+        runId="run-1"
+      />,
+    );
+    const link = screen.getByTestId("node-review-shortcut");
+    expect(link).toHaveTextContent("Review live changes");
+    expect(link).toHaveAttribute("href", "/runs/run-1/review?from=tip&to=live%3Aimpl");
+  });
+
+  it("offers nothing for a node with nothing to review", () => {
+    const { unmount } = render(<NodeDetailPanel node={makeNode({ status: "pending", completed_at: null })} runId="run-1" />);
+    expect(screen.queryByTestId("node-review-shortcut")).toBeNull();
+    unmount();
+    // Running in the shared worktree: no live branch of its own.
+    render(<NodeDetailPanel node={makeNode({ status: "running", completed_at: null, isolated_worktree: false })} runId="run-1" />);
+    expect(screen.queryByTestId("node-review-shortcut")).toBeNull();
+  });
+
+  it("offers nothing on an archived Run (the branch is gone)", () => {
+    render(
+      <NodeDetailPanel node={makeNode({ delivery: { before: "aaa", after: "bbb" } })} runId="run-1" isArchived />,
+    );
+    expect(screen.queryByTestId("node-review-shortcut")).toBeNull();
+  });
+});

--- a/frontend/src/components/NodeDetailPanel.tsx
+++ b/frontend/src/components/NodeDetailPanel.tsx
@@ -8,6 +8,7 @@ import {
   RotateCcw,
   Play,
   Maximize2,
+  GitCompareArrows,
 } from "lucide-react";
 import type {
   IterationInfo,
@@ -36,6 +37,7 @@ import type { ArtifactSource } from "./MarkdownArtifactModal";
 import ImageLightbox from "./ImageLightbox";
 import TmuxTerminal from "./TmuxTerminal";
 import { formatCostAmount, nodeCostTitle } from "../lib/costLabel";
+import { nodeReviewTarget, reviewUrl } from "../lib/runRefs";
 import ProvisioningRulesEditor from "./ProvisioningRulesEditor";
 import {
   EMPTY_PROVISIONING_RULES,
@@ -259,6 +261,8 @@ export default function NodeDetailPanel({
   const childrenData = useRunChildren(runId, isOrchestratorNode);
   const nodeChildren = childrenOfNode(childrenData, runId, node.node_id);
   const childCounts = countChildren(nodeChildren);
+  // #749: what the Review shortcut opens, if anything.
+  const reviewTarget = nodeReviewTarget(node);
   // Seed at mount only (no reactive effect on status): the issue trigger is
   // "clicking the node" (= selection / mount), not a live transition. A node
   // is `key`-ed by node_id at both mount sites, so selecting another terminated
@@ -760,6 +764,23 @@ export default function NodeDetailPanel({
           >
             {/* Actions */}
             <div className="flex flex-col gap-1.5 px-3 py-2">
+              {/* #749: the shortcut to the Review page with this node's delivery
+                  preselected (`before → after`, or `tip → live` while it runs
+                  isolated). There is no "node diff" surface (ADR-0067 §1): the
+                  panel only preselects a pair. Absent for a node that has
+                  nothing to review yet (pending, skipped, failed before
+                  delivering). */}
+              {reviewTarget && !isArchived && (
+                <a
+                  href={reviewUrl(runId, reviewTarget.pair)}
+                  data-testid="node-review-shortcut"
+                  className="flex w-full items-center justify-center gap-1.5 rounded-md border border-line-strong bg-bg-3 px-3 py-1.5 text-fg-2 transition-colors hover:border-fg-4 hover:text-fg"
+                  style={{ fontSize: "11.5px", fontWeight: 500 }}
+                >
+                  <GitCompareArrows size={12} />
+                  {reviewTarget.label}
+                </a>
+              )}
               {/* `interrupted` is included (#598 / ADR-0049): an interrupted
                   interactive node parks the run `awaiting_user`, so the "take the
                   artifacts as they are" escape must stay reachable — the daemon

--- a/frontend/src/components/review/RefPicker.tsx
+++ b/frontend/src/components/review/RefPicker.tsx
@@ -1,0 +1,290 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Check, ChevronDown, Search } from "lucide-react";
+import type { RunRefs } from "../../types";
+import { pairOfDelivery, refById, shortSha } from "../../lib/runRefs";
+import type { RefPair } from "../../lib/runRefs";
+
+/**
+ * One side of the Review page's `source → destination` pair (#749, design
+ * option A): a button showing the chosen Run ref, opening a popover with the
+ * **Run** group (fork point, Run tip) and the **Deliveries** group — one row per
+ * node delivery, whose `before`/`after` (or `● live`) buttons pick that side,
+ * and whose header sets **both** sides to the delivery in one click.
+ *
+ * A ref already used on the other side is disabled: "same ref twice" is an
+ * empty state, not a choice worth offering.
+ */
+
+interface Props {
+  side: "from" | "to";
+  value: string;
+  /** The ref chosen on the other side (disabled here). */
+  other: string;
+  refs: RunRefs | null;
+  disabled?: boolean;
+  onPick: (id: string) => void;
+  onPickPair: (pair: RefPair) => void;
+}
+
+export default function RefPicker({ side, value, other, refs, disabled, onPick, onPickPair }: Props) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const current = refs ? refById(refs, value) : undefined;
+
+  useEffect(() => {
+    if (!open) return;
+    const onDoc = (e: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
+        setOpen(false);
+        setQuery("");
+      }
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        setOpen(false);
+        setQuery("");
+      }
+    };
+    document.addEventListener("mousedown", onDoc);
+    document.addEventListener("keydown", onKey, true);
+    const t = window.setTimeout(() => inputRef.current?.focus(), 0);
+    return () => {
+      document.removeEventListener("mousedown", onDoc);
+      document.removeEventListener("keydown", onKey, true);
+      window.clearTimeout(t);
+    };
+  }, [open]);
+
+  const q = query.trim().toLowerCase();
+  const matches = (text: string) => !q || text.toLowerCase().includes(q);
+
+  const runRefs = useMemo(
+    () => (refs ? refs.refs.filter((r) => r.kind === "fork" || r.kind === "tip") : []),
+    [refs],
+  );
+
+  const close = () => {
+    setOpen(false);
+    setQuery("");
+  };
+
+  const pick = (id: string) => {
+    if (id === other) return;
+    close();
+    onPick(id);
+  };
+
+  const isNode = current && current.kind !== "fork" && current.kind !== "tip";
+  const isLive = current?.kind === "live";
+
+  return (
+    <div ref={rootRef} className="relative">
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={() => (open ? close() : setOpen(true))}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        data-testid={`review-${side}`}
+        data-ref={value}
+        title={current ? `${current.label}${current.sha ? ` · ${current.sha}` : ""}` : value}
+        className={`flex max-w-[280px] items-center gap-1.5 rounded border px-2 py-0.5 text-left transition-colors ${
+          open ? "border-fg-4 bg-bg-4" : "border-line-strong bg-bg-3 hover:border-fg-4 hover:bg-bg-4"
+        } ${disabled ? "cursor-not-allowed opacity-50" : "cursor-pointer"}`}
+        style={{ fontSize: "10.5px" }}
+      >
+        {isNode && (
+          <span className="uppercase tracking-wider text-fg-4" style={{ fontSize: "9.5px" }}>
+            node
+          </span>
+        )}
+        {isLive && (
+          <span
+            className="inline-block h-1.5 w-1.5 shrink-0 animate-pulse rounded-full bg-st-running"
+            aria-hidden
+          />
+        )}
+        <span className="truncate text-fg">{current?.label ?? (refs ? value : "…")}</span>
+        {current && (
+          <span className="font-mono text-fg-4" style={{ fontSize: "10px" }}>
+            {shortSha(current.sha ?? (current.kind === "live" ? current.git_ref : null))}
+          </span>
+        )}
+        <ChevronDown size={10} className="shrink-0 text-fg-4" />
+      </button>
+
+      {open && refs && (
+        <div
+          role="listbox"
+          data-testid={`review-ref-popover-${side}`}
+          className="absolute left-0 top-[30px] z-50 w-[340px] overflow-hidden rounded-md border border-line-strong bg-bg-2 shadow-[0_12px_32px_rgba(0,0,0,0.55)]"
+        >
+          <div className="flex items-center gap-1.5 border-b border-line px-2 py-1.5">
+            <Search size={11} className="text-fg-4" />
+            <input
+              ref={inputRef}
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Filter refs by node or sha…"
+              data-testid={`review-ref-filter-${side}`}
+              className="flex-1 rounded border border-line-strong bg-bg-3 px-1.5 py-0.5 text-fg outline-none focus:border-acc-border"
+              style={{ fontSize: "11px" }}
+            />
+          </div>
+
+          <div className="py-1">
+            <div
+              className="px-2.5 pb-0.5 pt-1 uppercase tracking-wider text-fg-4"
+              style={{ fontSize: "9.5px" }}
+            >
+              Run
+            </div>
+            {runRefs
+              .filter((r) => matches(`${r.label} ${r.sha ?? ""} ${r.git_ref}`))
+              .map((r) => {
+                const dis = r.id === other;
+                const sel = r.id === value;
+                return (
+                  <button
+                    key={r.id}
+                    type="button"
+                    role="option"
+                    aria-selected={sel}
+                    disabled={dis}
+                    onClick={() => pick(r.id)}
+                    data-testid={`review-ref-option-${r.id}`}
+                    title={dis ? "Already used on the other side" : r.git_ref}
+                    className={`grid w-full grid-cols-[14px_1fr_auto] items-center gap-2 px-2.5 py-1 text-left ${
+                      sel ? "bg-acc-bg" : ""
+                    } ${dis ? "cursor-not-allowed opacity-45" : "cursor-pointer hover:bg-bg-3"}`}
+                    style={{ fontSize: "11px" }}
+                  >
+                    <span className="text-acc">{sel && <Check size={11} />}</span>
+                    <span className="truncate">
+                      <span className="text-fg">{r.label}</span>
+                      <span className="text-fg-4" style={{ fontSize: "10px" }}>
+                        {" "}
+                        · {r.git_ref}
+                      </span>
+                    </span>
+                    <span className="font-mono text-fg-4" style={{ fontSize: "10px" }}>
+                      {shortSha(r.sha)}
+                    </span>
+                  </button>
+                );
+              })}
+          </div>
+
+          <div className="border-t border-line py-1">
+            <div
+              className="flex items-center justify-between px-2.5 pb-0.5 pt-1 uppercase tracking-wider text-fg-4"
+              style={{ fontSize: "9.5px" }}
+            >
+              <span>Deliveries</span>
+              <span className="normal-case tracking-normal text-fg-5">click a node to set both sides</span>
+            </div>
+            {refs.deliveries.length === 0 && (
+              <div className="px-2.5 py-1 text-fg-4" style={{ fontSize: "10.5px" }}>
+                No node has delivered yet.
+              </div>
+            )}
+            {refs.deliveries
+              .filter((d) => matches(`${d.node_name} ${d.node_id} iter ${d.iter}`))
+              .map((d) => {
+                const before = refById(refs, d.before);
+                const after = d.after ? refById(refs, d.after) : undefined;
+                const live = d.live ? refById(refs, d.live) : undefined;
+                const pair = pairOfDelivery(d);
+                const sideBtn = (
+                  id: string,
+                  label: string,
+                  sha: string,
+                  liveStyle = false,
+                ) => {
+                  const dis = id === other;
+                  const sel = id === value;
+                  return (
+                    <button
+                      key={id}
+                      type="button"
+                      role="option"
+                      aria-selected={sel}
+                      disabled={dis}
+                      onClick={() => pick(id)}
+                      data-testid={`review-ref-option-${id}`}
+                      title={dis ? "Already used on the other side" : id}
+                      className={`flex items-center gap-1 rounded border px-1.5 py-px ${
+                        sel
+                          ? "border-acc-border bg-acc-bg text-acc"
+                          : liveStyle
+                            ? "border-st-running/40 bg-st-running-bg text-st-running"
+                            : "border-line-strong bg-bg-3 text-fg-3 hover:border-fg-4 hover:text-fg"
+                      } ${dis ? "cursor-not-allowed opacity-40" : "cursor-pointer"}`}
+                      style={{ fontSize: "10px" }}
+                    >
+                      {liveStyle && (
+                        <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-current" aria-hidden />
+                      )}
+                      {label}
+                      <span className="font-mono text-fg-4">{sha}</span>
+                    </button>
+                  );
+                };
+                return (
+                  <div key={`${d.node_id}:${d.iter}`}>
+                    <button
+                      type="button"
+                      disabled={!pair}
+                      onClick={() => {
+                        if (!pair) return;
+                        close();
+                        onPickPair(pair);
+                      }}
+                      data-testid={`review-delivery-${d.node_id}-${d.iter}`}
+                      title={
+                        d.status === "delivered"
+                          ? "Review this delivery: before → after"
+                          : "Review the live branch: Run tip → live"
+                      }
+                      className="flex w-full cursor-pointer items-center gap-1.5 px-2.5 pb-px pt-0.5 text-left text-fg-3 hover:bg-bg-3"
+                      style={{ fontSize: "10.5px" }}
+                    >
+                      <span className="text-fg-2">{d.node_name}</span>
+                      <span className="font-mono text-fg-4" style={{ fontSize: "9.5px" }}>
+                        {d.node_id}
+                      </span>
+                      <span className="text-fg-4">iter {d.iter}</span>
+                      <span
+                        className={`rounded-full border px-1.5 ${
+                          d.status === "delivered"
+                            ? "border-acc-border bg-acc-bg text-acc"
+                            : "border-st-running/40 bg-st-running-bg text-st-running"
+                        }`}
+                        style={{ fontSize: "9.5px" }}
+                      >
+                        {d.status}
+                      </span>
+                    </button>
+                    <div className="flex gap-1 px-2.5 pb-1 pl-8">
+                      {before && sideBtn(d.before, "before", shortSha(before.sha))}
+                      {after && d.after && sideBtn(d.after, "after", shortSha(after.sha))}
+                      {live && d.live && sideBtn(d.live, "live", live.git_ref, true)}
+                    </div>
+                  </div>
+                );
+              })}
+          </div>
+
+          <div className="border-t border-line px-2.5 py-1 text-fg-4" style={{ fontSize: "10px" }}>
+            Refs are frozen SHAs from the event log; <span className="text-st-running">live</span> follows
+            the node's sub-worktree.
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/review/ReviewFileCard.tsx
+++ b/frontend/src/components/review/ReviewFileCard.tsx
@@ -1,0 +1,262 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { ChevronDown, ChevronRight, Copy, SquareArrowOutUpRight } from "lucide-react";
+import { DiffView, DiffModeEnum } from "@git-diff-view/react";
+import type { DiffFile } from "../../types";
+import { fetchRunFileAtRef } from "../../api";
+import { baseName, fileHunks, filePath, langOf, statusLetter } from "../../lib/runRefs";
+import type { RefPair, ViewMode } from "../../lib/runRefs";
+
+/**
+ * One file of the Review page (#749): a sticky header (chevron, status letter,
+ * `dir/` + basename, `+a −d`, copy path, open at destination ref) and the
+ * third-party diff body — split or unified, with GitHub-style `↑ ⇕ ↓` context
+ * expansion in every hunk separator.
+ *
+ * The daemon's structured diff carries the hunks; the component needs the
+ * **full content at each ref** to expand context. It is fetched lazily — the
+ * first time the card scrolls into view — from `GET /runs/<id>/file`, and the
+ * card renders its hunks meanwhile (without the expanders, which appear once
+ * the content is in). A side that does not exist at its ref (an added file's
+ * old side, a deleted file's new side) is not fetched: the component composes
+ * it from the diff.
+ */
+
+interface Props {
+  runId: string;
+  file: DiffFile;
+  pair: RefPair;
+  view: ViewMode;
+  collapsed: boolean;
+  onToggle: () => void;
+  /** Lets the page track the card for scroll-spy and "click a file → scroll". */
+  registerEl: (path: string, el: HTMLDivElement | null) => void;
+}
+
+type Contents =
+  | { kind: "idle" }
+  | { kind: "loading" }
+  | { kind: "ready"; old: string | null; new: string | null }
+  | { kind: "failed" };
+
+const LETTER_CLASS: Record<"A" | "M" | "D" | "R", string> = {
+  A: "text-st-done",
+  M: "text-st-await",
+  D: "text-st-failed",
+  R: "text-edit-tint",
+};
+
+export default function ReviewFileCard({ runId, file, pair, view, collapsed, onToggle, registerEl }: Props) {
+  const path = filePath(file);
+  const letter = statusLetter(file);
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const [contents, setContents] = useState<Contents>({ kind: "idle" });
+  const [copied, setCopied] = useState(false);
+
+  const pureRename = file.status === "renamed" && file.hunks.length === 0;
+  const hasBody = !file.binary && !pureRename && file.hunks.length > 0;
+
+  useEffect(() => {
+    registerEl(path, rootRef.current);
+    return () => registerEl(path, null);
+  }, [path, registerEl]);
+
+  // The page keys each card by (pair, path): a pair change remounts the card,
+  // so the lazily fetched content never survives the refs it was fetched at.
+
+  const load = useCallback(() => {
+    if (!hasBody) return;
+    setContents({ kind: "loading" });
+    const wantOld = file.old_path && file.status !== "added";
+    const wantNew = file.new_path && file.status !== "deleted";
+    const oldP = wantOld ? fetchRunFileAtRef(runId, file.old_path!, pair.from) : Promise.resolve(null);
+    const newP = wantNew ? fetchRunFileAtRef(runId, file.new_path!, pair.to) : Promise.resolve(null);
+    Promise.all([oldP, newP])
+      .then(([o, n]) => setContents({ kind: "ready", old: o, new: n }))
+      .catch(() => setContents({ kind: "failed" }));
+  }, [hasBody, runId, file.old_path, file.new_path, file.status, pair.from, pair.to]);
+
+  // Fetch when the card first becomes visible (and only while expanded).
+  useEffect(() => {
+    if (contents.kind !== "idle" || collapsed || !hasBody) return;
+    const el = rootRef.current;
+    if (!el) return;
+    if (typeof IntersectionObserver === "undefined") {
+      // jsdom / very old browsers: fetch right away, off the effect body.
+      const t = window.setTimeout(load, 0);
+      return () => window.clearTimeout(t);
+    }
+    const io = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((e) => e.isIntersecting)) {
+          io.disconnect();
+          load();
+        }
+      },
+      { rootMargin: "400px 0px" },
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  }, [contents.kind, collapsed, hasBody, load]);
+
+  const hunks = useMemo(() => fileHunks(file), [file]);
+  const data = useMemo(() => {
+    const ready = contents.kind === "ready" ? contents : null;
+    return {
+      oldFile: {
+        fileName: file.old_path ?? file.new_path ?? "",
+        fileLang: langOf(file.old_path ?? file.new_path),
+        content: ready?.old ?? "",
+      },
+      newFile: {
+        fileName: file.new_path ?? file.old_path ?? "",
+        fileLang: langOf(file.new_path ?? file.old_path),
+        content: ready?.new ?? "",
+      },
+      hunks,
+    };
+  }, [file.old_path, file.new_path, hunks, contents]);
+
+  const copyPath = () => {
+    navigator.clipboard?.writeText(path).then(
+      () => {
+        setCopied(true);
+        window.setTimeout(() => setCopied(false), 1200);
+      },
+      () => {},
+    );
+  };
+
+  const dir = path.includes("/") ? path.slice(0, path.lastIndexOf("/") + 1) : "";
+  const openHref =
+    file.new_path && file.status !== "deleted"
+      ? `/runs/${encodeURIComponent(runId)}/file?path=${encodeURIComponent(file.new_path)}&ref=${encodeURIComponent(pair.to)}`
+      : null;
+
+  return (
+    <div
+      ref={rootRef}
+      data-testid="review-file"
+      data-path={path}
+      data-collapsed={collapsed}
+      data-content={contents.kind}
+      className="mx-3 my-2.5 overflow-hidden rounded-md border border-line bg-bg-2"
+    >
+      <div
+        role="button"
+        tabIndex={0}
+        aria-expanded={!collapsed}
+        onClick={onToggle}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            onToggle();
+          }
+        }}
+        data-testid="review-file-header"
+        className={`sticky top-0 z-10 flex cursor-pointer select-none items-center gap-2 bg-bg-2 px-2.5 py-[5px] ${
+          collapsed ? "" : "border-b border-line"
+        }`}
+        style={{ fontSize: "11px" }}
+      >
+        <span className="text-fg-4">
+          {collapsed ? <ChevronRight size={11} /> : <ChevronDown size={11} />}
+        </span>
+        <span className={`w-[14px] text-center font-mono font-semibold ${LETTER_CLASS[letter]}`} style={{ fontSize: "9.5px" }}>
+          {letter}
+        </span>
+        <span className="truncate font-mono" style={{ fontSize: "10.5px" }}>
+          {file.status === "renamed" && file.old_path && (
+            <span className="text-fg-4">{file.old_path} → </span>
+          )}
+          <span className="text-fg-4">{dir}</span>
+          <span className="font-medium text-fg">{baseName(path)}</span>
+        </span>
+        {file.binary ? (
+          <span className="text-fg-4" style={{ fontSize: "10px" }}>
+            binary
+          </span>
+        ) : pureRename ? (
+          <span className="text-fg-4" style={{ fontSize: "10px" }}>
+            renamed
+          </span>
+        ) : (
+          <span className="font-mono" style={{ fontSize: "10px" }}>
+            <span className="text-st-done">+{file.additions}</span> <span className="text-st-failed">−{file.deletions}</span>
+          </span>
+        )}
+        <span className="ml-auto flex items-center gap-1" onClick={(e) => e.stopPropagation()}>
+          <button
+            type="button"
+            onClick={copyPath}
+            title={copied ? "Copied" : "Copy path"}
+            data-testid="review-copy-path"
+            className="grid h-5 w-[22px] cursor-pointer place-items-center rounded text-fg-4 hover:bg-bg-3 hover:text-fg-2"
+          >
+            <Copy size={11} />
+          </button>
+          {openHref && (
+            <a
+              href={openHref}
+              target="_blank"
+              rel="noreferrer"
+              title="Open file at destination ref"
+              data-testid="review-open-file"
+              className="grid h-5 w-[22px] place-items-center rounded text-fg-4 hover:bg-bg-3 hover:text-fg-2"
+            >
+              <SquareArrowOutUpRight size={11} />
+            </a>
+          )}
+        </span>
+      </div>
+
+      {!collapsed && (
+        <div data-testid="review-file-body" className="overflow-x-auto">
+          {file.binary ? (
+            <div className="px-4 py-[18px] text-center text-fg-4" style={{ fontSize: "11px" }}>
+              Binary file, not shown
+            </div>
+          ) : pureRename ? (
+            <div className="px-4 py-[18px] text-center text-fg-4" style={{ fontSize: "11px" }}>
+              Renamed without changes
+            </div>
+          ) : file.hunks.length === 0 ? (
+            <div className="px-4 py-[18px] text-center text-fg-4" style={{ fontSize: "11px" }}>
+              No content changes
+            </div>
+          ) : (
+            <DiffView
+              data={data}
+              diffViewMode={view === "split" ? DiffModeEnum.Split : DiffModeEnum.Unified}
+              diffViewTheme="dark"
+              diffViewFontSize={11}
+              diffViewHighlight={false}
+              diffViewWrap={false}
+              diffViewAddWidget
+              renderWidgetLine={({ onClose }) => (
+                <div
+                  className="flex items-center gap-2 border-y border-line bg-bg-3 px-3 py-1.5 text-fg-3"
+                  style={{ fontSize: "10.5px" }}
+                  data-testid="review-comment-placeholder"
+                >
+                  Review comments arrive with the next ticket (#750).
+                  <button
+                    type="button"
+                    onClick={onClose}
+                    className="ml-auto cursor-pointer rounded border border-line-strong px-1.5 text-fg-3 hover:text-fg"
+                  >
+                    Close
+                  </button>
+                </div>
+              )}
+            />
+          )}
+          {contents.kind === "failed" && hasBody && (
+            <div className="border-t border-line px-3 py-1 text-fg-4" style={{ fontSize: "10px" }}>
+              Full file content unavailable at these refs — context expansion disabled for this file.
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/review/ReviewFileList.tsx
+++ b/frontend/src/components/review/ReviewFileList.tsx
@@ -1,0 +1,179 @@
+import { PanelLeftClose } from "lucide-react";
+import type { RefObject } from "react";
+import type { DiffFile } from "../../types";
+import { baseName, filePath, groupByDir, miniBar, statusLetter } from "../../lib/runRefs";
+
+/**
+ * The Review page's left column (#749, design option "flat list grouped by
+ * directory"): filter box, directory headers, one row per file with its status
+ * letter, `+a −d` and a 5-block mini bar. The current file follows the scroll;
+ * clicking a row scrolls to it.
+ */
+
+interface Props {
+  files: DiffFile[];
+  filter: string;
+  onFilterChange: (v: string) => void;
+  filterRef: RefObject<HTMLInputElement | null>;
+  currentIndex: number;
+  onSelect: (index: number) => void;
+  onClose: () => void;
+}
+
+const LETTER_CLASS: Record<"A" | "M" | "D" | "R", string> = {
+  A: "text-st-done",
+  M: "text-st-await",
+  D: "text-st-failed",
+  R: "text-edit-tint",
+};
+
+export default function ReviewFileList({
+  files,
+  filter,
+  onFilterChange,
+  filterRef,
+  currentIndex,
+  onSelect,
+  onClose,
+}: Props) {
+  const q = filter.trim().toLowerCase();
+  const shown = files
+    .map((file, index) => ({ file, index }))
+    .filter(({ file }) => !q || filePath(file).toLowerCase().includes(q));
+  const groups = groupByDir(shown.map((s) => s.file)).map((g) => ({
+    dir: g.dir,
+    files: g.files.map((f) => ({ file: f.file, index: shown[f.index].index })),
+  }));
+
+  return (
+    <aside
+      className="flex min-h-0 flex-col overflow-hidden border-r border-line bg-bg-1"
+      data-testid="review-file-list"
+    >
+      <div className="flex items-center gap-1.5 px-2.5 pb-1.5 pt-2 text-fg-3" style={{ fontSize: "10.5px" }}>
+        <button
+          type="button"
+          onClick={onClose}
+          title="Hide file list  ( [ )"
+          data-testid="review-list-close"
+          className="grid h-5 w-5 cursor-pointer place-items-center rounded text-fg-4 hover:bg-bg-3 hover:text-fg-2"
+        >
+          <PanelLeftClose size={12} />
+        </button>
+        <input
+          ref={filterRef}
+          value={filter}
+          onChange={(e) => onFilterChange(e.target.value)}
+          placeholder="Filter files…   /"
+          data-testid="review-file-filter"
+          className="min-w-0 flex-1 rounded border border-line bg-bg-2 px-1.5 py-0.5 text-fg outline-none focus:border-acc-border"
+          style={{ fontSize: "11px" }}
+        />
+        <span className="font-mono text-fg-4" data-testid="review-file-count">
+          {shown.length}
+        </span>
+      </div>
+
+      <div className="flex-1 overflow-y-auto px-1.5 pb-2.5">
+        {groups.length === 0 && (
+          <div className="px-2 py-2.5 text-fg-4" style={{ fontSize: "11px" }}>
+            {files.length === 0 ? "No files" : "No file matches"}
+          </div>
+        )}
+        {groups.map((g) => (
+          <div key={g.dir || "."}>
+            <div
+              className="truncate px-1.5 pb-0.5 pt-1.5 font-mono text-fg-4"
+              style={{ fontSize: "10px" }}
+              title={g.dir ? `${g.dir}/` : "./"}
+            >
+              {g.dir ? `${g.dir}/` : "./"}
+            </div>
+            {g.files.map(({ file, index }) => {
+              const p = filePath(file);
+              const letter = statusLetter(file);
+              const cur = index === currentIndex;
+              const pureRename = file.status === "renamed" && file.additions + file.deletions === 0;
+              return (
+                <button
+                  key={p}
+                  type="button"
+                  onClick={() => onSelect(index)}
+                  title={p}
+                  data-testid="review-file-row"
+                  data-path={p}
+                  data-current={cur}
+                  className={`grid w-full cursor-pointer grid-cols-[14px_1fr_auto] items-center gap-1.5 rounded px-1.5 py-[3px] text-left ${
+                    cur ? "bg-bg-3 shadow-[inset_2px_0_0_var(--color-acc)]" : "hover:bg-bg-3"
+                  }`}
+                  style={{ fontSize: "11px" }}
+                >
+                  <span
+                    className={`w-[14px] text-center font-mono font-semibold ${LETTER_CLASS[letter]}`}
+                    style={{ fontSize: "9.5px" }}
+                  >
+                    {letter}
+                  </span>
+                  <span className={`truncate font-mono ${cur ? "text-fg" : "text-fg-2"}`} style={{ fontSize: "10.5px" }}>
+                    {baseName(p)}
+                  </span>
+                  <span className="flex items-center gap-1 font-mono" style={{ fontSize: "10px" }}>
+                    {file.binary ? (
+                      <span className="text-fg-4">bin</span>
+                    ) : pureRename ? (
+                      <span className="text-fg-4">→</span>
+                    ) : (
+                      <>
+                        <span className="text-st-done">+{file.additions}</span>
+                        <span className="text-st-failed">−{file.deletions}</span>
+                      </>
+                    )}
+                    <span className="ml-0.5 inline-flex gap-px" aria-hidden>
+                      {miniBar(file).map((b, i) => (
+                        <i
+                          key={i}
+                          className={`block h-2 w-[3px] rounded-[1px] ${
+                            b === "a" ? "bg-st-done" : b === "d" ? "bg-st-failed" : "bg-bg-4"
+                          }`}
+                        />
+                      ))}
+                    </span>
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        ))}
+      </div>
+
+      <div
+        className="mt-auto flex flex-wrap gap-2 border-t border-line px-2.5 py-2 text-fg-4"
+        style={{ fontSize: "10px" }}
+      >
+        <span>
+          <Kbd>j</Kbd>/<Kbd>k</Kbd> file
+        </span>
+        <span>
+          <Kbd>n</Kbd>/<Kbd>p</Kbd> hunk
+        </span>
+        <span>
+          <Kbd>u</Kbd> view
+        </span>
+        <span>
+          <Kbd>[</Kbd> list
+        </span>
+      </div>
+    </aside>
+  );
+}
+
+function Kbd({ children }: { children: string }) {
+  return (
+    <kbd
+      className="rounded-[3px] border border-b-2 border-line-strong bg-bg-3 px-1 font-mono text-fg-3"
+      style={{ fontSize: "10px" }}
+    >
+      {children}
+    </kbd>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -884,3 +884,39 @@ body {
   outline-offset: 12px;
   animation: pdo-section-land 2.2s ease-out both;
 }
+
+/* ---------------------------------------------------------------------------
+ * Review page (#749): map @git-diff-view/react's dark theme onto PDO tokens so
+ * the third-party body reads like the rest of the app (added = st-done,
+ * deleted = st-failed, plain = bg-2). Scoped to the page so nothing else moves.
+ * ------------------------------------------------------------------------- */
+.pdo-review .diff-tailwindcss-wrapper[data-theme="dark"] {
+  --diff-border--: #1f242c;
+  --diff-plain-content--: #14171d;
+  --diff-plain-lineNumber--: #14171d;
+  --diff-plain-lineNumber-color--: #525a68;
+  --diff-expand-content--: #14171d;
+  --diff-expand-lineNumber--: #14171d;
+  --diff-expand-lineNumber-color--: #525a68;
+  --diff-add-content--: rgba(16, 185, 129, 0.1);
+  --diff-add-content-highlight--: rgba(16, 185, 129, 0.28);
+  --diff-add-lineNumber--: rgba(16, 185, 129, 0.16);
+  --diff-del-content--: rgba(239, 68, 68, 0.1);
+  --diff-del-content-highlight--: rgba(239, 68, 68, 0.3);
+  --diff-del-lineNumber--: rgba(239, 68, 68, 0.16);
+  --diff-empty-content--: #1a1e25;
+  --diff-hunk-content--: #1a1e25;
+  --diff-hunk-content-color--: #525a68;
+  --diff-hunk-lineNumber--: #1a1e25;
+  --diff-hunk-lineNumber-hover--: #2c323d;
+  --diff-add-widget--: #10b981;
+  --diff-add-widget-color--: #04140d;
+  color: #e6e8eb;
+}
+.pdo-review .diff-tailwindcss-wrapper .diff-style-root {
+  font-family: var(--font-mono);
+}
+/* The hunk-separator expanders: PDO accent on hover, like the prototype. */
+.pdo-review .diff-line-hunk-action button:hover {
+  color: #10b981;
+}

--- a/frontend/src/lib/runRefs.test.ts
+++ b/frontend/src/lib/runRefs.test.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect } from "vitest";
+import {
+  deliveryOfPair,
+  defaultCollapsed,
+  fileHunks,
+  groupByDir,
+  hunkToUnified,
+  isDefaultPair,
+  miniBar,
+  nodeReviewTarget,
+  pairFromSearch,
+  pairOfDelivery,
+  readView,
+  reconcilePair,
+  reviewRunIdFromPath,
+  reviewUrl,
+  shortSha,
+  statusLetter,
+  writeView,
+  deliverySignature,
+} from "./runRefs";
+import type { DiffFile, RunRefs } from "../types";
+
+const REFS: RunRefs = {
+  default_from: "fork",
+  default_to: "tip",
+  refs: [
+    { id: "fork", kind: "fork", label: "Fork point", git_ref: "aaaa", sha: "aaaa" },
+    { id: "node:impl:1:before", kind: "before", label: "implement · iter 1 · before", git_ref: "aaaa", sha: "aaaa", node_id: "impl", node_name: "implement", iter: 1 },
+    { id: "node:impl:1:after", kind: "after", label: "implement · iter 1 · after", git_ref: "bbbb", sha: "bbbb", node_id: "impl", node_name: "implement", iter: 1 },
+    { id: "live:rev", kind: "live", label: "review · iter 1 · live", git_ref: "pdo/sub-x-rev-iter-1", sha: "cccc", node_id: "rev", node_name: "review", iter: 1 },
+    { id: "tip", kind: "tip", label: "Run tip", git_ref: "pdo/run-x", sha: "bbbb" },
+  ],
+  deliveries: [
+    { node_id: "impl", node_name: "implement", iter: 1, status: "delivered", before: "node:impl:1:before", after: "node:impl:1:after" },
+    { node_id: "rev", node_name: "review", iter: 1, status: "running", before: "tip", live: "live:rev" },
+  ],
+};
+
+function file(overrides: Partial<DiffFile> & { path: string }): DiffFile {
+  const { path, ...rest } = overrides;
+  return {
+    old_path: path,
+    new_path: path,
+    status: "modified",
+    binary: false,
+    additions: 1,
+    deletions: 1,
+    hunks: [],
+    ...rest,
+  };
+}
+
+describe("Review URL contract (#749)", () => {
+  it("recognises /runs/<id>/review and nothing else", () => {
+    expect(reviewRunIdFromPath("/runs/20260909-1259-abc/review")).toBe("20260909-1259-abc");
+    expect(reviewRunIdFromPath("/runs/20260909-1259-abc/review/")).toBe("20260909-1259-abc");
+    expect(reviewRunIdFromPath("/runs/a%20b/review")).toBe("a b");
+    expect(reviewRunIdFromPath("/")).toBeNull();
+    expect(reviewRunIdFromPath("/runs/abc")).toBeNull();
+    expect(reviewRunIdFromPath("/runs/abc/review/extra")).toBeNull();
+  });
+
+  it("omits the default pair from the URL and carries any other pair as ids", () => {
+    expect(reviewUrl("r1")).toBe("/runs/r1/review");
+    expect(reviewUrl("r1", { from: "fork", to: "tip" })).toBe("/runs/r1/review");
+    expect(reviewUrl("r1", { from: "node:impl:1:before", to: "node:impl:1:after" })).toBe(
+      "/runs/r1/review?from=node%3Aimpl%3A1%3Abefore&to=node%3Aimpl%3A1%3Aafter",
+    );
+    expect(reviewUrl("r/1", { to: "live:rev" })).toBe("/runs/r%2F1/review?from=fork&to=live%3Arev");
+  });
+
+  it("reads a pair back from the query string with defaults", () => {
+    expect(pairFromSearch("")).toEqual({ from: "fork", to: "tip" });
+    expect(pairFromSearch("?from=node%3Aimpl%3A1%3Abefore&to=node%3Aimpl%3A1%3Aafter")).toEqual({
+      from: "node:impl:1:before",
+      to: "node:impl:1:after",
+    });
+    expect(pairFromSearch("?to=live:rev")).toEqual({ from: "fork", to: "live:rev" });
+    expect(isDefaultPair(pairFromSearch(""))).toBe(true);
+    expect(isDefaultPair({ from: "tip", to: "fork" })).toBe(false);
+  });
+
+  it("falls back to the default side for an unknown ref, with a notice", () => {
+    expect(reconcilePair({ from: "fork", to: "tip" }, REFS)).toEqual({
+      pair: { from: "fork", to: "tip" },
+      notice: null,
+    });
+    const r = reconcilePair({ from: "node:ghost:1:before", to: "node:impl:1:after" }, REFS);
+    expect(r.pair).toEqual({ from: "fork", to: "node:impl:1:after" });
+    expect(r.notice).toContain('"node:ghost:1:before"');
+    const both = reconcilePair({ from: "x", to: "y" }, REFS);
+    expect(both.pair).toEqual({ from: "fork", to: "tip" });
+    expect(both.notice).toContain("Unknown refs");
+  });
+});
+
+describe("delivery pairs", () => {
+  it("recognises a pair that is exactly one node's delivery (or live branch)", () => {
+    expect(deliveryOfPair({ from: "node:impl:1:before", to: "node:impl:1:after" }, REFS)?.node_name).toBe(
+      "implement",
+    );
+    expect(deliveryOfPair({ from: "tip", to: "live:rev" }, REFS)?.node_name).toBe("review");
+    expect(deliveryOfPair({ from: "fork", to: "tip" }, REFS)).toBeNull();
+    expect(deliveryOfPair({ from: "fork", to: "node:impl:1:after" }, REFS)).toBeNull();
+  });
+
+  it("a delivery row selects before → after, or before → live while running", () => {
+    expect(pairOfDelivery(REFS.deliveries[0])).toEqual({ from: "node:impl:1:before", to: "node:impl:1:after" });
+    expect(pairOfDelivery(REFS.deliveries[1])).toEqual({ from: "tip", to: "live:rev" });
+    expect(pairOfDelivery({ node_id: "n", node_name: "n", iter: 1, status: "running", before: "tip" })).toBeNull();
+  });
+
+  it("shortens a 40-char SHA and leaves branches alone", () => {
+    expect(shortSha("0123456789abcdef0123456789abcdef01234567")).toBe("0123456");
+    expect(shortSha("pdo/sub-x")).toBe("pdo/sub-x");
+    expect(shortSha(null)).toBe("");
+  });
+});
+
+describe("node panel shortcut (#749 AC7)", () => {
+  it("opens before → after for a node with a recorded delivery, whatever its status", () => {
+    const t = nodeReviewTarget({
+      node_id: "impl",
+      iter: 2,
+      status: "completed",
+      delivery: { before: "a", after: "b" },
+      isolated_worktree: false,
+    });
+    expect(t).toEqual({
+      pair: { from: "node:impl:2:before", to: "node:impl:2:after" },
+      label: "Review this node's delivery",
+    });
+  });
+
+  it("opens tip → live for a running isolated node without a delivery yet", () => {
+    const t = nodeReviewTarget({ node_id: "rev", iter: 1, status: "running", isolated_worktree: true });
+    expect(t).toEqual({ pair: { from: "tip", to: "live:rev" }, label: "Review live changes" });
+    expect(nodeReviewTarget({ node_id: "rev", iter: 1, status: "awaiting_user", isolated_worktree: true })?.label).toBe(
+      "Review live changes",
+    );
+  });
+
+  it("offers nothing for a node with nothing to review", () => {
+    expect(nodeReviewTarget({ node_id: "p", iter: 1, status: "pending" })).toBeNull();
+    expect(nodeReviewTarget({ node_id: "p", iter: 1, status: "skipped" })).toBeNull();
+    expect(nodeReviewTarget({ node_id: "p", iter: 1, status: "failed", delivery: null })).toBeNull();
+    // Running but sharing the Run's worktree: no live branch of its own.
+    expect(nodeReviewTarget({ node_id: "p", iter: 1, status: "running", isolated_worktree: false })).toBeNull();
+    expect(nodeReviewTarget({ node_id: "p", iter: 1, status: "running" })).toBeNull();
+  });
+});
+
+describe("structured hunks → the diff component", () => {
+  it("re-serialises a hunk as unified text without parsing anything", () => {
+    const text = hunkToUnified({
+      old_start: 3,
+      old_lines: 2,
+      new_start: 3,
+      new_lines: 3,
+      header: "fn main()",
+      lines: [
+        { kind: "context", content: "a", old_no: 3, new_no: 3 },
+        { kind: "del", content: "b", old_no: 4, new_no: null },
+        { kind: "add", content: "B", old_no: null, new_no: 4 },
+        { kind: "add", content: "", old_no: null, new_no: 5 },
+      ],
+    });
+    expect(text).toBe("@@ -3,2 +3,3 @@ fn main()\n a\n-b\n+B\n+");
+    expect(hunkToUnified({ old_start: 0, old_lines: 0, new_start: 1, new_lines: 1, header: "", lines: [] })).toBe(
+      "@@ -0,0 +1,1 @@",
+    );
+  });
+
+  it("maps every hunk of a file, each behind the ---/+++ header the parser needs", () => {
+    const f = file({
+      path: "a.rs",
+      hunks: [
+        { old_start: 1, old_lines: 1, new_start: 1, new_lines: 1, header: "", lines: [] },
+        { old_start: 9, old_lines: 1, new_start: 9, new_lines: 1, header: "", lines: [] },
+      ],
+    });
+    expect(fileHunks(f)).toEqual([
+      "--- a/a.rs\n+++ b/a.rs\n@@ -1,1 +1,1 @@",
+      "--- a/a.rs\n+++ b/a.rs\n@@ -9,1 +9,1 @@",
+    ]);
+    const added = file({
+      path: "new.rs",
+      old_path: null,
+      status: "added",
+      hunks: [{ old_start: 0, old_lines: 0, new_start: 1, new_lines: 1, header: "", lines: [] }],
+    });
+    expect(fileHunks(added)).toEqual(["--- /dev/null\n+++ b/new.rs\n@@ -0,0 +1,1 @@"]);
+  });
+});
+
+describe("file list helpers", () => {
+  it("letters the status", () => {
+    expect(statusLetter(file({ path: "a", status: "added" }))).toBe("A");
+    expect(statusLetter(file({ path: "a", status: "copied" }))).toBe("A");
+    expect(statusLetter(file({ path: "a", status: "deleted" }))).toBe("D");
+    expect(statusLetter(file({ path: "a", status: "renamed" }))).toBe("R");
+    expect(statusLetter(file({ path: "a", status: "modified" }))).toBe("M");
+  });
+
+  it("groups files by directory in patch order, merging consecutive runs only", () => {
+    const groups = groupByDir([
+      file({ path: "src/a.ts" }),
+      file({ path: "src/b.ts" }),
+      file({ path: "README.md" }),
+      file({ path: "src/c.ts" }),
+    ]);
+    expect(groups.map((g) => [g.dir, g.files.map((f) => f.index)])).toEqual([
+      ["src", [0, 1]],
+      ["", [2]],
+      ["src", [3]],
+    ]);
+  });
+
+  it("splits the mini bar between additions and deletions, empty for binaries and pure renames", () => {
+    expect(miniBar(file({ path: "a", additions: 8, deletions: 2 }))).toEqual(["a", "a", "a", "a", "d"]);
+    expect(miniBar(file({ path: "a", additions: 0, deletions: 3 }))).toEqual(["d", "d", "d", "d", "d"]);
+    expect(miniBar(file({ path: "a", binary: true }))).toEqual(["", "", "", "", ""]);
+    expect(miniBar(file({ path: "a", status: "renamed", additions: 0, deletions: 0 }))).toEqual(["", "", "", "", ""]);
+  });
+
+  it("starts collapsed only past the large-diff or large-file thresholds", () => {
+    const small = [file({ path: "a" }), file({ path: "b" })];
+    expect(defaultCollapsed(small).size).toBe(0);
+    const huge = [file({ path: "a", additions: 1000, deletions: 600 }), file({ path: "b" })];
+    expect([...defaultCollapsed(huge)]).toEqual(["a"]);
+    const many = Array.from({ length: 41 }, (_, i) => file({ path: `f${i}` }));
+    expect(defaultCollapsed(many).size).toBe(41);
+  });
+});
+
+describe("browser persistence", () => {
+  it("reads split by default and writes the toggle", () => {
+    const store = new Map<string, string>();
+    const storage = {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => void store.set(k, v),
+    };
+    expect(readView(storage)).toBe("split");
+    writeView("unified", storage);
+    expect(readView(storage)).toBe("unified");
+    store.set("pdo.review.view", "garbage");
+    expect(readView(storage)).toBe("split");
+  });
+
+  it("signs the Run's deliveries so a moved tip is detectable", () => {
+    expect(deliverySignature({ a: { delivery: { before: "x", after: "y" } }, b: {} })).toBe("y|");
+    expect(deliverySignature({})).toBe("");
+  });
+});

--- a/frontend/src/lib/runRefs.ts
+++ b/frontend/src/lib/runRefs.ts
@@ -1,0 +1,295 @@
+import type { DiffFile, DiffHunk, NodeState, RunDelivery, RunRef, RunRefs } from "../types";
+
+// Shared helpers of the Review page (#749, ADR-0067; CONTEXT.md § "Relecture de
+// diff"). Pure: no React, no fetch — so the URL contract, the pair semantics and
+// the hunk re-serialisation are unit-testable, and the page file stays a view.
+
+/** The default pair — the same bounds as the Diff tab and the LOC stat. */
+export const DEFAULT_FROM = "fork";
+export const DEFAULT_TO = "tip";
+
+/** Split | Unified, remembered on this browser (AC: "mémorisée localement"). */
+export type ViewMode = "split" | "unified";
+export const VIEW_KEY = "pdo.review.view";
+/** File list open/closed, remembered on this browser. */
+export const LIST_OPEN_KEY = "pdo.review.list";
+
+export function readView(storage: Pick<Storage, "getItem"> = localStorage): ViewMode {
+  try {
+    return storage.getItem(VIEW_KEY) === "unified" ? "unified" : "split";
+  } catch {
+    return "split";
+  }
+}
+
+export function writeView(view: ViewMode, storage: Pick<Storage, "setItem"> = localStorage): void {
+  try {
+    storage.setItem(VIEW_KEY, view);
+  } catch {
+    // Private mode / quota: the toggle still works for the session.
+  }
+}
+
+export function readListOpen(storage: Pick<Storage, "getItem"> = localStorage): boolean {
+  try {
+    return storage.getItem(LIST_OPEN_KEY) !== "closed";
+  } catch {
+    return true;
+  }
+}
+
+export function writeListOpen(open: boolean, storage: Pick<Storage, "setItem"> = localStorage): void {
+  try {
+    storage.setItem(LIST_OPEN_KEY, open ? "open" : "closed");
+  } catch {
+    // ignore
+  }
+}
+
+/** A source → destination pair of stable ref ids. */
+export interface RefPair {
+  from: string;
+  to: string;
+}
+
+/** `/runs/<id>/review` — the only real URL of the app so far. */
+export const REVIEW_PATH_RE = /^\/runs\/([^/]+)\/review\/?$/;
+
+/** The Run id when `pathname` is a Review page, else null. */
+export function reviewRunIdFromPath(pathname: string): string | null {
+  const m = REVIEW_PATH_RE.exec(pathname);
+  return m ? decodeURIComponent(m[1]) : null;
+}
+
+/**
+ * The Review page URL for a pair. The default pair is left out of the query so
+ * the canonical link is the short one; ids, never SHAs, so the link keeps its
+ * meaning while the Run moves.
+ */
+export function reviewUrl(runId: string, pair?: Partial<RefPair>): string {
+  const from = pair?.from ?? DEFAULT_FROM;
+  const to = pair?.to ?? DEFAULT_TO;
+  const params = new URLSearchParams();
+  if (from !== DEFAULT_FROM || to !== DEFAULT_TO) {
+    params.set("from", from);
+    params.set("to", to);
+  }
+  const qs = params.toString();
+  return `/runs/${encodeURIComponent(runId)}/review${qs ? `?${qs}` : ""}`;
+}
+
+/** The pair carried by a query string, defaults filled in. */
+export function pairFromSearch(search: string): RefPair {
+  const params = new URLSearchParams(search);
+  return {
+    from: params.get("from") || DEFAULT_FROM,
+    to: params.get("to") || DEFAULT_TO,
+  };
+}
+
+export function isDefaultPair(pair: RefPair): boolean {
+  return pair.from === DEFAULT_FROM && pair.to === DEFAULT_TO;
+}
+
+/**
+ * Validate a URL pair against the Run's refs. A side the Run does not know
+ * falls back to its default, and `notice` says so (the page shows it once).
+ */
+export function reconcilePair(pair: RefPair, refs: RunRefs): { pair: RefPair; notice: string | null } {
+  const known = new Set(refs.refs.map((r) => r.id));
+  const bad: string[] = [];
+  let { from, to } = pair;
+  if (!known.has(from)) {
+    bad.push(from);
+    from = refs.default_from || DEFAULT_FROM;
+  }
+  if (!known.has(to)) {
+    bad.push(to);
+    to = refs.default_to || DEFAULT_TO;
+  }
+  return {
+    pair: { from, to },
+    notice: bad.length
+      ? `Unknown ref${bad.length > 1 ? "s" : ""} ${bad.map((b) => `"${b}"`).join(", ")} — showing ${from} → ${to} instead.`
+      : null,
+  };
+}
+
+/** The delivery a pair is, when it is exactly one node's `before → after` (or `→ live`). */
+export function deliveryOfPair(pair: RefPair, refs: RunRefs): RunDelivery | null {
+  return (
+    refs.deliveries.find(
+      (d) => d.before === pair.from && (d.after === pair.to || d.live === pair.to),
+    ) ?? null
+  );
+}
+
+/** The pair a delivery row selects: `before → after`, or `before → live` while running. */
+export function pairOfDelivery(d: RunDelivery): RefPair | null {
+  const to = d.after ?? d.live;
+  return to ? { from: d.before, to } : null;
+}
+
+export function refById(refs: RunRefs, id: string): RunRef | undefined {
+  return refs.refs.find((r) => r.id === id);
+}
+
+/** 7-char SHA for display; a branch name is shown as is. */
+export function shortSha(sha: string | null | undefined): string {
+  if (!sha) return "";
+  return /^[0-9a-f]{40}$/i.test(sha) ? sha.slice(0, 7) : sha;
+}
+
+/**
+ * The node panel's shortcut (#749): what pair the "Review this node's delivery"
+ * action opens, or null when the node has neither a recorded delivery nor a live
+ * sub-worktree (pending, skipped, failed before delivering…). There is no "node
+ * diff" surface: the panel only preselects a pair on the Review page.
+ */
+export function nodeReviewTarget(
+  node: Pick<NodeState, "node_id" | "iter" | "status" | "delivery" | "isolated_worktree">,
+): { pair: RefPair; label: string } | null {
+  if (node.delivery) {
+    return {
+      pair: {
+        from: `node:${node.node_id}:${node.iter}:before`,
+        to: `node:${node.node_id}:${node.iter}:after`,
+      },
+      label: "Review this node's delivery",
+    };
+  }
+  const live = node.status === "running" || node.status === "awaiting_user";
+  if (live && node.isolated_worktree === true) {
+    return {
+      pair: { from: DEFAULT_TO, to: `live:${node.node_id}` },
+      label: "Review live changes",
+    };
+  }
+  return null;
+}
+
+// --- structured diff → the third-party component --------------------------
+
+/** The path a file is keyed on: its destination, else its source. */
+export function filePath(f: DiffFile): string {
+  return f.new_path ?? f.old_path ?? "";
+}
+
+/** `A` / `M` / `D` / `R` — the status letter of the file list. */
+export function statusLetter(f: DiffFile): "A" | "M" | "D" | "R" {
+  switch (f.status) {
+    case "added":
+    case "copied":
+      return "A";
+    case "deleted":
+      return "D";
+    case "renamed":
+      return "R";
+    default:
+      return "M";
+  }
+}
+
+/**
+ * Re-serialise one structured hunk as the unified text the diff component
+ * consumes. The daemon parsed the patch once (#748); the browser never parses,
+ * it only prints back what it received.
+ */
+export function hunkToUnified(h: DiffHunk): string {
+  const head = `@@ -${h.old_start},${h.old_lines} +${h.new_start},${h.new_lines} @@${h.header ? ` ${h.header}` : ""}`;
+  const body = h.lines.map((l) => (l.kind === "add" ? "+" : l.kind === "del" ? "-" : " ") + l.content);
+  return [head, ...body].join("\n");
+}
+
+/**
+ * Every hunk of a file, as the component's `hunks` array. The component's
+ * parser (GitHub Desktop's) reads a patch, not a bare hunk: it needs the
+ * `---`/`+++` header before the first `@@`, so each entry carries one.
+ */
+export function fileHunks(f: DiffFile): string[] {
+  const header = `--- ${f.old_path ? `a/${f.old_path}` : "/dev/null"}\n+++ ${f.new_path ? `b/${f.new_path}` : "/dev/null"}\n`;
+  return f.hunks.map((h) => header + hunkToUnified(h));
+}
+
+/** A rough language hint from the extension, for the component's `fileLang`. */
+export function langOf(path: string | null): string {
+  if (!path) return "";
+  const ext = path.split(".").pop()?.toLowerCase() ?? "";
+  const map: Record<string, string> = {
+    ts: "typescript",
+    tsx: "tsx",
+    js: "javascript",
+    jsx: "jsx",
+    mjs: "javascript",
+    rs: "rust",
+    py: "python",
+    md: "markdown",
+    json: "json",
+    yaml: "yaml",
+    yml: "yaml",
+    toml: "toml",
+    css: "css",
+    html: "html",
+    sh: "bash",
+    bash: "bash",
+    sql: "sql",
+    go: "go",
+    java: "java",
+  };
+  return map[ext] ?? "";
+}
+
+/** Files grouped by directory, in patch order, for the flat-grouped list. */
+export function groupByDir(files: DiffFile[]): { dir: string; files: { file: DiffFile; index: number }[] }[] {
+  const groups: { dir: string; files: { file: DiffFile; index: number }[] }[] = [];
+  files.forEach((file, index) => {
+    const p = filePath(file);
+    const i = p.lastIndexOf("/");
+    const dir = i >= 0 ? p.slice(0, i) : "";
+    const last = groups[groups.length - 1];
+    if (last && last.dir === dir) last.files.push({ file, index });
+    else groups.push({ dir, files: [{ file, index }] });
+  });
+  return groups;
+}
+
+export function baseName(path: string): string {
+  const i = path.lastIndexOf("/");
+  return i >= 0 ? path.slice(i + 1) : path;
+}
+
+/** Five blocks: additions green, deletions red, the rest empty. */
+export function miniBar(f: DiffFile, blocks = 5): ("a" | "d" | "")[] {
+  if (f.binary || (f.status === "renamed" && f.additions + f.deletions === 0)) {
+    return Array<"">(blocks).fill("");
+  }
+  const total = Math.max(1, f.additions + f.deletions);
+  const a = Math.round((f.additions / total) * blocks);
+  const d = blocks - a;
+  return [...Array<"a">(a).fill("a"), ...Array<"d">(d).fill("d")];
+}
+
+/** Past this many files the page starts collapsed (like the Diff tab). */
+export const LARGE_REVIEW_FILES = 40;
+/** A single file past this many changed lines starts collapsed. */
+export const LARGE_FILE_LINES = 1500;
+
+export function defaultCollapsed(files: DiffFile[]): Set<string> {
+  const init = new Set<string>();
+  const large = files.length > LARGE_REVIEW_FILES;
+  for (const f of files) {
+    if (large || f.additions + f.deletions > LARGE_FILE_LINES) init.add(filePath(f));
+  }
+  return init;
+}
+
+/**
+ * The signature of "what the Run has delivered so far" — every node's latest
+ * `delivery.after`. When it changes while the page is open, the tip moved: the
+ * page shows a banner instead of re-rendering under the reader.
+ */
+export function deliverySignature(nodes: Record<string, Pick<NodeState, "delivery">>): string {
+  return Object.values(nodes)
+    .map((n) => n.delivery?.after ?? "")
+    .join("|");
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,9 +2,17 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import ReviewPage from './pages/ReviewPage.tsx'
+import { reviewRunIdFromPath } from './lib/runRefs'
+
+// The app has no router: navigation is state (selected run, pane owner). The
+// Review page (#749) is its first real URL — `/runs/<id>/review` — rendered
+// full-window here; everything else renders `App` untouched. A router can
+// replace this switch later without moving the URL.
+const reviewRunId = reviewRunIdFromPath(window.location.pathname)
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    {reviewRunId ? <ReviewPage runId={reviewRunId} /> : <App />}
   </StrictMode>,
 )

--- a/frontend/src/pages/ReviewPage.test.tsx
+++ b/frontend/src/pages/ReviewPage.test.tsx
@@ -1,0 +1,325 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+import ReviewPage from "./ReviewPage";
+import type { RunRefs, RunState, StructuredDiff, DiffFile } from "../types";
+
+// The Review page (#749): pair from the URL, refs from the daemon, files from the
+// structured diff, the third-party body mocked to a marker (its own rendering is
+// the library's business; the e2e FP exercises the real one).
+
+vi.mock("../api", () => ({
+  fetchRun: vi.fn(),
+  fetchRunRefs: vi.fn(),
+  fetchRunStructuredDiff: vi.fn(),
+  fetchRunFileAtRef: vi.fn(),
+}));
+
+vi.mock("../hooks/useDaemonSocket", () => ({
+  useDaemonSocket: () => ({ status: "connected", subscribe: () => () => {} }),
+}));
+
+vi.mock("@git-diff-view/react", () => ({
+  DiffModeEnum: { Split: "split", Unified: "unified" },
+  DiffView: (props: { diffViewMode: string; data: { hunks: string[]; oldFile: { content: string }; newFile: { content: string } } }) => (
+    <div
+      data-testid="mock-diff-view"
+      data-mode={props.diffViewMode}
+      data-hunks={props.data.hunks.length}
+      data-has-content={Boolean(props.data.oldFile.content || props.data.newFile.content)}
+    />
+  ),
+}));
+
+import { fetchRun, fetchRunRefs, fetchRunStructuredDiff, fetchRunFileAtRef } from "../api";
+
+const mockedRun = vi.mocked(fetchRun);
+const mockedRefs = vi.mocked(fetchRunRefs);
+const mockedDiff = vi.mocked(fetchRunStructuredDiff);
+const mockedFile = vi.mocked(fetchRunFileAtRef);
+
+const RUN_ID = "20260909-125942-c7e2c65";
+
+function makeRun(overrides: Partial<RunState> = {}): RunState {
+  return {
+    run_id: RUN_ID,
+    status: "completed",
+    pipeline_name: "implement-loop",
+    input: "x",
+    started_at: "2026-09-09T00:00:00Z",
+    completed_at: "2026-09-09T01:00:00Z",
+    nodes: {},
+    edges: [],
+    node_defs: [],
+    start_node: null,
+    end_node: null,
+    merge_resolver: null,
+    loop_states: {},
+    foreach_states: {},
+    ...overrides,
+  };
+}
+
+const REFS: RunRefs = {
+  default_from: "fork",
+  default_to: "tip",
+  refs: [
+    { id: "fork", kind: "fork", label: "Fork point", git_ref: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", sha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" },
+    { id: "node:impl:1:before", kind: "before", label: "implement · iter 1 · before", git_ref: "a", sha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", node_id: "impl", node_name: "implement", iter: 1 },
+    { id: "node:impl:1:after", kind: "after", label: "implement · iter 1 · after", git_ref: "b", sha: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", node_id: "impl", node_name: "implement", iter: 1 },
+    { id: "tip", kind: "tip", label: "Run tip", git_ref: `pdo/run-${RUN_ID}`, sha: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" },
+  ],
+  deliveries: [
+    { node_id: "impl", node_name: "implement", iter: 1, status: "delivered", before: "node:impl:1:before", after: "node:impl:1:after" },
+  ],
+};
+
+function file(overrides: Partial<DiffFile> & { path: string }): DiffFile {
+  const { path, ...rest } = overrides;
+  return {
+    old_path: path,
+    new_path: path,
+    status: "modified",
+    binary: false,
+    additions: 2,
+    deletions: 1,
+    hunks: [
+      {
+        old_start: 1,
+        old_lines: 2,
+        new_start: 1,
+        new_lines: 3,
+        header: "",
+        lines: [
+          { kind: "context", content: "a", old_no: 1, new_no: 1 },
+          { kind: "del", content: "b", old_no: 2, new_no: null },
+          { kind: "add", content: "B", old_no: null, new_no: 2 },
+          { kind: "add", content: "C", old_no: null, new_no: 3 },
+        ],
+      },
+    ],
+    ...rest,
+  };
+}
+
+function diff(files: DiffFile[], extra: Partial<StructuredDiff> = {}): StructuredDiff {
+  return {
+    from_ref: "fork",
+    to_ref: "tip",
+    from_sha: "a",
+    to_sha: "b",
+    three_dot: true,
+    files,
+    additions: files.reduce((s, f) => s + f.additions, 0),
+    deletions: files.reduce((s, f) => s + f.deletions, 0),
+    files_changed: files.length,
+    ...extra,
+  };
+}
+
+const TWO = diff([file({ path: "src/main.tsx" }), file({ path: "docs/adr/0068.md", status: "added", old_path: null, deletions: 0 })]);
+
+function goto(search = "") {
+  window.history.replaceState(null, "", `/runs/${RUN_ID}/review${search}`);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+  mockedRun.mockResolvedValue(makeRun());
+  mockedRefs.mockResolvedValue(REFS);
+  mockedDiff.mockResolvedValue(TWO);
+  mockedFile.mockResolvedValue("a\nB\nC\n");
+  goto();
+});
+
+describe("ReviewPage (#749)", () => {
+  it("loads fork → tip by default: file list, stats, both pickers labelled", async () => {
+    render(<ReviewPage runId={RUN_ID} />);
+    await waitFor(() => expect(screen.getAllByTestId("review-file")).toHaveLength(2));
+    expect(mockedDiff).toHaveBeenCalledWith(RUN_ID, undefined);
+    expect(screen.getByTestId("review-stats")).toHaveTextContent("2 files");
+    expect(screen.getByTestId("review-stats")).toHaveTextContent("+4");
+    expect(screen.getByTestId("review-stats")).toHaveTextContent("−1");
+    await waitFor(() => expect(screen.getByTestId("review-from")).toHaveTextContent("Fork point"));
+    expect(screen.getByTestId("review-to")).toHaveTextContent("Run tip");
+    expect(screen.getByTestId("review-to")).toHaveTextContent("bbbbbbb");
+    // Left list: grouped by directory, +/- per row.
+    const rows = screen.getAllByTestId("review-file-row");
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toHaveTextContent("main.tsx");
+    expect(rows[0]).toHaveTextContent("+2");
+    expect(rows[0]).toHaveTextContent("−1");
+    const list = screen.getByTestId("review-file-list");
+    expect(within(list).getByText("src/")).toBeInTheDocument();
+    expect(within(list).getByText("docs/adr/")).toBeInTheDocument();
+    // Default pair: no reset, no delivery chip.
+    expect(screen.queryByTestId("review-reset")).toBeNull();
+    expect(screen.queryByTestId("review-delivery-chip")).toBeNull();
+    // Split is the default; the body gets it.
+    expect(screen.getByTestId("review-view-toggle")).toHaveAttribute("data-view", "split");
+    expect(screen.getAllByTestId("mock-diff-view")[0]).toHaveAttribute("data-mode", "split");
+    expect(screen.getByTestId("review-back")).toHaveTextContent("implement-loop");
+  });
+
+  it("fetches the full content at both refs for context expansion, only for existing sides", async () => {
+    render(<ReviewPage runId={RUN_ID} />);
+    await waitFor(() => expect(screen.getAllByTestId("review-file")).toHaveLength(2));
+    await waitFor(() => expect(mockedFile).toHaveBeenCalledTimes(3));
+    // Modified file: both sides at their ref ids.
+    expect(mockedFile).toHaveBeenCalledWith(RUN_ID, "src/main.tsx", "fork");
+    expect(mockedFile).toHaveBeenCalledWith(RUN_ID, "src/main.tsx", "tip");
+    // Added file: only the new side.
+    expect(mockedFile).toHaveBeenCalledWith(RUN_ID, "docs/adr/0068.md", "tip");
+    await waitFor(() =>
+      expect(screen.getAllByTestId("mock-diff-view")[0]).toHaveAttribute("data-has-content", "true"),
+    );
+  });
+
+  it("opens a delivery pair from the URL: chip, reset, two-dot fetch by ids", async () => {
+    goto("?from=node%3Aimpl%3A1%3Abefore&to=node%3Aimpl%3A1%3Aafter");
+    mockedDiff.mockResolvedValue(diff([file({ path: "src/main.tsx" })], { three_dot: false }));
+    render(<ReviewPage runId={RUN_ID} />);
+    await waitFor(() => expect(screen.getAllByTestId("review-file")).toHaveLength(1));
+    expect(mockedDiff).toHaveBeenCalledWith(RUN_ID, { from: "node:impl:1:before", to: "node:impl:1:after" });
+    await waitFor(() => expect(screen.getByTestId("review-delivery-chip")).toBeInTheDocument());
+    expect(screen.getByTestId("review-delivery-chip")).toHaveTextContent("Reviewing the delivery of implement · iter 1");
+    expect(screen.getByTestId("review-from")).toHaveTextContent("implement · iter 1 · before");
+    expect(screen.getByTestId("review-to")).toHaveTextContent("implement · iter 1 · after");
+    expect(screen.getByTestId("review-reset")).toBeInTheDocument();
+
+    // "Whole Run instead" goes back to the default pair and the short URL.
+    fireEvent.click(screen.getByTestId("review-whole-run"));
+    await waitFor(() => expect(mockedDiff).toHaveBeenLastCalledWith(RUN_ID, undefined));
+    expect(window.location.search).toBe("");
+  });
+
+  it("picking a delivery row in a picker sets both sides and the URL", async () => {
+    render(<ReviewPage runId={RUN_ID} />);
+    await waitFor(() => expect(screen.getByTestId("review-from")).toHaveTextContent("Fork point"));
+    fireEvent.click(screen.getByTestId("review-to"));
+    const pop = screen.getByTestId("review-ref-popover-to");
+    expect(within(pop).getByTestId("review-ref-option-fork")).toBeDisabled(); // used on the other side
+    fireEvent.click(within(pop).getByTestId("review-delivery-impl-1"));
+    await waitFor(() =>
+      expect(mockedDiff).toHaveBeenLastCalledWith(RUN_ID, { from: "node:impl:1:before", to: "node:impl:1:after" }),
+    );
+    expect(window.location.search).toBe("?from=node%3Aimpl%3A1%3Abefore&to=node%3Aimpl%3A1%3Aafter");
+    expect(screen.queryByTestId("review-ref-popover-to")).toBeNull();
+  });
+
+  it("picking one side only changes that side; swap exchanges them", async () => {
+    render(<ReviewPage runId={RUN_ID} />);
+    await waitFor(() => expect(screen.getByTestId("review-from")).toHaveTextContent("Fork point"));
+    fireEvent.click(screen.getByTestId("review-to"));
+    fireEvent.click(within(screen.getByTestId("review-ref-popover-to")).getByTestId("review-ref-option-node:impl:1:after"));
+    await waitFor(() => expect(mockedDiff).toHaveBeenLastCalledWith(RUN_ID, { from: "fork", to: "node:impl:1:after" }));
+    fireEvent.click(screen.getByTestId("review-swap"));
+    await waitFor(() => expect(mockedDiff).toHaveBeenLastCalledWith(RUN_ID, { from: "node:impl:1:after", to: "fork" }));
+  });
+
+  it("shows « Nothing to compare » for the same ref twice, without fetching", async () => {
+    goto("?from=tip&to=tip");
+    render(<ReviewPage runId={RUN_ID} />);
+    await waitFor(() => expect(screen.getByTestId("review-empty")).toHaveTextContent("Nothing to compare"));
+    expect(mockedDiff).not.toHaveBeenCalled();
+  });
+
+  it("shows « No changes » for identical trees", async () => {
+    mockedDiff.mockResolvedValue(diff([]));
+    render(<ReviewPage runId={RUN_ID} />);
+    await waitFor(() => expect(screen.getByTestId("review-empty")).toHaveTextContent("No changes"));
+  });
+
+  it("falls back to the default side for an unknown ref in the URL, with a notice", async () => {
+    goto("?from=node%3Aghost%3A1%3Abefore&to=tip");
+    render(<ReviewPage runId={RUN_ID} />);
+    await waitFor(() => expect(screen.getByTestId("review-notice")).toBeInTheDocument());
+    expect(screen.getByTestId("review-notice")).toHaveTextContent('Unknown ref "node:ghost:1:before"');
+    await waitFor(() => expect(screen.getByTestId("review-from")).toHaveTextContent("Fork point"));
+    expect(window.location.search).toBe("");
+  });
+
+  it("remembers the Split | Unified toggle on this browser", async () => {
+    render(<ReviewPage runId={RUN_ID} />);
+    await waitFor(() => expect(screen.getAllByTestId("mock-diff-view")).toHaveLength(2));
+    fireEvent.click(screen.getByTestId("review-view-unified"));
+    expect(localStorage.getItem("pdo.review.view")).toBe("unified");
+    expect(screen.getByTestId("review-view-toggle")).toHaveAttribute("data-view", "unified");
+    expect(screen.getAllByTestId("mock-diff-view")[0]).toHaveAttribute("data-mode", "unified");
+  });
+
+  it("starts unified when the browser remembers it", async () => {
+    localStorage.setItem("pdo.review.view", "unified");
+    render(<ReviewPage runId={RUN_ID} />);
+    await waitFor(() => expect(screen.getAllByTestId("mock-diff-view")).toHaveLength(2));
+    expect(screen.getAllByTestId("mock-diff-view")[0]).toHaveAttribute("data-mode", "unified");
+  });
+
+  it("collapses and expands a file from its header; the list click scrolls and expands", async () => {
+    render(<ReviewPage runId={RUN_ID} />);
+    await waitFor(() => expect(screen.getAllByTestId("review-file")).toHaveLength(2));
+    const card = screen.getAllByTestId("review-file")[0];
+    fireEvent.click(within(card).getByTestId("review-file-header"));
+    expect(card).toHaveAttribute("data-collapsed", "true");
+    expect(within(card).queryByTestId("review-file-body")).toBeNull();
+    fireEvent.click(screen.getAllByTestId("review-file-row")[0]);
+    expect(card).toHaveAttribute("data-collapsed", "false");
+    // Collapse all, then expand all.
+    fireEvent.click(screen.getByTestId("review-collapse-all"));
+    for (const c of screen.getAllByTestId("review-file")) expect(c).toHaveAttribute("data-collapsed", "true");
+    fireEvent.click(screen.getByTestId("review-collapse-all"));
+    for (const c of screen.getAllByTestId("review-file")) expect(c).toHaveAttribute("data-collapsed", "false");
+  });
+
+  it("filters the file list", async () => {
+    render(<ReviewPage runId={RUN_ID} />);
+    await waitFor(() => expect(screen.getAllByTestId("review-file-row")).toHaveLength(2));
+    fireEvent.change(screen.getByTestId("review-file-filter"), { target: { value: "adr" } });
+    expect(screen.getAllByTestId("review-file-row")).toHaveLength(1);
+    expect(screen.getByTestId("review-file-count")).toHaveTextContent("1");
+  });
+
+  it("says the diff is not preserved for an archived Run and disables the pickers", async () => {
+    mockedRun.mockResolvedValue(makeRun({ status: "archived" }));
+    render(<ReviewPage runId={RUN_ID} />);
+    await waitFor(() => expect(screen.getByTestId("review-archived")).toBeInTheDocument());
+    expect(screen.getByText("Diff not preserved for archived runs")).toBeInTheDocument();
+    expect(screen.getByTestId("review-from")).toBeDisabled();
+    expect(screen.getByTestId("review-to")).toBeDisabled();
+  });
+
+  it("renders binary and pure-rename bodies as words, not tables", async () => {
+    mockedDiff.mockResolvedValue(
+      diff([
+        file({ path: "img.png", status: "added", old_path: null, binary: true, additions: 0, deletions: 0, hunks: [] }),
+        file({ path: "b.ts", status: "renamed", old_path: "a.ts", additions: 0, deletions: 0, hunks: [] }),
+      ]),
+    );
+    render(<ReviewPage runId={RUN_ID} />);
+    await waitFor(() => expect(screen.getAllByTestId("review-file")).toHaveLength(2));
+    expect(screen.getByText("Binary file, not shown")).toBeInTheDocument();
+    expect(screen.getByText("Renamed without changes")).toBeInTheDocument();
+    expect(screen.queryByTestId("mock-diff-view")).toBeNull();
+    expect(mockedFile).not.toHaveBeenCalled();
+  });
+
+  it("shows an error with Retry when the diff endpoint fails", async () => {
+    mockedDiff.mockRejectedValueOnce(Object.assign(new Error("run branch not found"), { status: 404 }));
+    mockedDiff.mockResolvedValueOnce(TWO);
+    render(<ReviewPage runId={RUN_ID} />);
+    await waitFor(() => expect(screen.getByTestId("review-error")).toHaveTextContent("Run branch not found"));
+    fireEvent.click(screen.getByText("Retry"));
+    await waitFor(() => expect(screen.getAllByTestId("review-file")).toHaveLength(2));
+  });
+
+  it("carries the pair in the open-in-new-tab link and keeps the Send pill disabled (#750)", async () => {
+    goto("?from=fork&to=node%3Aimpl%3A1%3Aafter");
+    render(<ReviewPage runId={RUN_ID} />);
+    await waitFor(() => expect(screen.getAllByTestId("review-file")).toHaveLength(2));
+    expect(screen.getByTestId("review-open-new-tab")).toHaveAttribute(
+      "href",
+      `/runs/${RUN_ID}/review?from=fork&to=node%3Aimpl%3A1%3Aafter`,
+    );
+    expect(screen.getByTestId("review-send-placeholder")).toHaveAttribute("aria-disabled");
+  });
+});

--- a/frontend/src/pages/ReviewPage.tsx
+++ b/frontend/src/pages/ReviewPage.tsx
@@ -1,0 +1,704 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  ArrowLeftRight,
+  ArrowLeft,
+  Archive,
+  Columns2,
+  ListMinus,
+  MessageSquare,
+  PanelLeftOpen,
+  Rows3,
+  SquareArrowOutUpRight,
+} from "lucide-react";
+import "@git-diff-view/react/styles/diff-view.css";
+import { fetchRun, fetchRunRefs, fetchRunStructuredDiff } from "../api";
+import { useDaemonSocket } from "../hooks/useDaemonSocket";
+import type { RunRefs, RunState, StructuredDiff } from "../types";
+import RefPicker from "../components/review/RefPicker";
+import ReviewFileList from "../components/review/ReviewFileList";
+import ReviewFileCard from "../components/review/ReviewFileCard";
+import {
+  DEFAULT_FROM,
+  DEFAULT_TO,
+  defaultCollapsed,
+  deliveryOfPair,
+  deliverySignature,
+  filePath,
+  isDefaultPair,
+  pairFromSearch,
+  readListOpen,
+  readView,
+  reconcilePair,
+  reviewUrl,
+  writeListOpen,
+  writeView,
+} from "../lib/runRefs";
+import type { RefPair, ViewMode } from "../lib/runRefs";
+
+/**
+ * The **Review page** (#749, ADR-0067; CONTEXT.md § "Relecture de diff"): a
+ * dedicated URL — `/runs/<id>/review?from=<ref>&to=<ref>` — rendering the diff
+ * between two **Run refs** the way a GitHub PR's "Files changed" does: files on
+ * the left with their stats, side-by-side by default (unified toggle remembered
+ * on this browser), context expansion between hunks, and a `source →
+ * destination` pair picked among the Run's refs (fork point, Run tip, every
+ * node delivery's before/after, a running node's live branch).
+ *
+ * Mounted full-window by `main.tsx` when the path matches; the app has no
+ * router. The URL carries stable ref ids, never SHAs. Comments (#750) are not
+ * here yet: the gutter and the "Send to manager" pill are reserved for them.
+ */
+
+interface Props {
+  runId: string;
+}
+
+/**
+ * The loaded diff, tagged with the key it was fetched for (`from|to|reloadTick`):
+ * a key mismatch *is* the loading state, so no effect ever writes "loading".
+ */
+type Load =
+  | { kind: "none" }
+  | { kind: "ready"; key: string; diff: StructuredDiff }
+  | { kind: "error"; key: string; message: string; status?: number };
+
+const NARROW_QUERY = "(max-width: 900px)";
+
+export default function ReviewPage({ runId }: Props) {
+  const [run, setRun] = useState<RunState | null>(null);
+  const [runError, setRunError] = useState<string | null>(null);
+  const [refs, setRefs] = useState<RunRefs | null>(null);
+  const [pair, setPairState] = useState<RefPair>(() => pairFromSearch(window.location.search));
+  const [notice, setNotice] = useState<string | null>(null);
+  const [view, setView] = useState<ViewMode>(() => readView());
+  const [narrow, setNarrow] = useState<boolean>(() => window.matchMedia?.(NARROW_QUERY).matches ?? false);
+  const [listOpen, setListOpen] = useState<boolean>(() => readListOpen());
+  const [filter, setFilter] = useState("");
+  const [collapsed, setCollapsed] = useState<Set<string> | null>(null);
+  const [currentIdx, setCurrentIdx] = useState(0);
+  const [load, setLoad] = useState<Load>({ kind: "none" });
+  const [reloadTick, setReloadTick] = useState(0);
+  const [tipMoved, setTipMoved] = useState(false);
+  const [nodeDelivered, setNodeDelivered] = useState<{ nodeId: string; iter: number } | null>(null);
+
+  const mainRef = useRef<HTMLDivElement | null>(null);
+  const filterRef = useRef<HTMLInputElement | null>(null);
+  const cardEls = useRef<Map<string, HTMLDivElement>>(new Map());
+  const runRef = useRef<RunState | null>(null);
+  const sigAtLoad = useRef<string | null>(null);
+  const pairRef = useRef(pair);
+  useEffect(() => {
+    pairRef.current = pair;
+  }, [pair]);
+
+  const isArchived = run?.status === "archived";
+  const effectiveView: ViewMode = narrow ? "unified" : view;
+
+  // --- Run + refs -----------------------------------------------------------
+  useEffect(() => {
+    let stale = false;
+    fetchRun(runId)
+      .then((r) => {
+        if (stale) return;
+        runRef.current = r;
+        setRun(r);
+        // The signature at first sight, if the diff loaded before the Run did.
+        if (sigAtLoad.current === null) sigAtLoad.current = deliverySignature(r.nodes);
+      })
+      .catch((e: unknown) => {
+        if (!stale) setRunError(e instanceof Error ? e.message : String(e));
+      });
+    fetchRunRefs(runId)
+      .then((r) => {
+        if (stale) return;
+        setRefs(r);
+      })
+      .catch(() => {
+        // The pickers show ids; the diff loads with the URL pair anyway.
+      });
+    return () => {
+      stale = true;
+    };
+  }, [runId, reloadTick]);
+
+  useEffect(() => {
+    if (run) document.title = `Review · ${run.pipeline_name} · ${runId}`;
+  }, [run, runId]);
+
+  // Validate the URL pair once the refs are known; a bad ref falls back with a notice.
+  const reconciledFor = useRef<RunRefs | null>(null);
+  useEffect(() => {
+    if (!refs || reconciledFor.current === refs) return;
+    reconciledFor.current = refs;
+    const { pair: next, notice: n } = reconcilePair(pairRef.current, refs);
+    if (n) {
+      setNotice(n);
+      setPairState(next);
+      window.history.replaceState(null, "", reviewUrl(runId, next));
+    }
+  }, [refs, runId]);
+
+  // --- Diff -------------------------------------------------------------------
+  const sameRef = pair.from === pair.to;
+  const { from: pairFrom, to: pairTo } = pair;
+  const loadKey = `${pairFrom}|${pairTo}|${reloadTick}`;
+  useEffect(() => {
+    if (isArchived || sameRef) return;
+    let stale = false;
+    const key = `${pairFrom}|${pairTo}|${reloadTick}`;
+    const query = pairFrom === DEFAULT_FROM && pairTo === DEFAULT_TO ? undefined : { from: pairFrom, to: pairTo };
+    fetchRunStructuredDiff(runId, query)
+      .then((d) => {
+        if (stale) return;
+        sigAtLoad.current = runRef.current ? deliverySignature(runRef.current.nodes) : null;
+        setTipMoved(false);
+        setLoad({ kind: "ready", key, diff: d });
+      })
+      .catch((e: unknown) => {
+        if (stale) return;
+        const status = (e as { status?: number })?.status;
+        setLoad({ kind: "error", key, message: e instanceof Error ? e.message : String(e), status });
+      });
+    return () => {
+      stale = true;
+    };
+  }, [runId, pairFrom, pairTo, reloadTick, isArchived, sameRef]);
+  /** What the current key has: the loaded diff, an error, or nothing yet. */
+  const current = useMemo<Load>(
+    () => (load.kind !== "none" && load.key === loadKey ? load : { kind: "none" }),
+    [load, loadKey],
+  );
+
+  // --- Live: the Run's WebSocket, only to detect "tip moved" / "node delivered".
+  const { subscribe } = useDaemonSocket();
+  useEffect(() => {
+    return subscribe((msg) => {
+      if (msg.type !== "event" || !msg.event || msg.event.run_id !== runId) return;
+      const ev = msg.event;
+      fetchRun(runId)
+        .then((r) => {
+          runRef.current = r;
+          setRun(r);
+          const sig = deliverySignature(r.nodes);
+          if (sigAtLoad.current !== null && sig !== sigAtLoad.current) setTipMoved(true);
+        })
+        .catch(() => {});
+      if (ev.kind === "node_delivered" && ev.node_id && pairRef.current.to === `live:${ev.node_id}`) {
+        setNodeDelivered({ nodeId: ev.node_id, iter: ev.iter ?? 1 });
+      }
+    });
+  }, [subscribe, runId]);
+
+  // --- URL ↔ pair -------------------------------------------------------------
+  const setPair = useCallback(
+    (next: RefPair) => {
+      setPairState(next);
+      setCollapsed(null);
+      setCurrentIdx(0);
+      setNotice(null);
+      setNodeDelivered(null);
+      window.history.replaceState(null, "", reviewUrl(runId, next));
+      mainRef.current?.scrollTo?.({ top: 0 });
+    },
+    [runId],
+  );
+  useEffect(() => {
+    const onPop = () => setPairState(pairFromSearch(window.location.search));
+    window.addEventListener("popstate", onPop);
+    return () => window.removeEventListener("popstate", onPop);
+  }, []);
+
+  // --- View persistence -------------------------------------------------------
+  const changeView = (v: ViewMode) => {
+    setView(v);
+    writeView(v);
+  };
+  const toggleList = () => {
+    setListOpen((o) => {
+      writeListOpen(!o);
+      return !o;
+    });
+  };
+  useEffect(() => {
+    const mq = window.matchMedia?.(NARROW_QUERY);
+    if (!mq) return;
+    const onChange = () => setNarrow(mq.matches);
+    mq.addEventListener?.("change", onChange);
+    return () => mq.removeEventListener?.("change", onChange);
+  }, []);
+
+  // --- Files ------------------------------------------------------------------
+  const files = useMemo(() => (current.kind === "ready" ? current.diff.files : []), [current]);
+  const collapsedSet = useMemo(() => collapsed ?? defaultCollapsed(files), [collapsed, files]);
+  const toggleFile = (path: string) => {
+    const next = new Set(collapsedSet);
+    if (next.has(path)) next.delete(path);
+    else next.add(path);
+    setCollapsed(next);
+  };
+  const collapseAll = () => {
+    const anyOpen = files.some((f) => !collapsedSet.has(filePath(f)));
+    setCollapsed(anyOpen ? new Set(files.map(filePath)) : new Set());
+  };
+
+  const registerEl = useCallback((path: string, el: HTMLDivElement | null) => {
+    if (el) cardEls.current.set(path, el);
+    else cardEls.current.delete(path);
+  }, []);
+
+  const onScroll = useCallback(() => {
+    const el = mainRef.current;
+    if (!el) return;
+    const top = el.scrollTop;
+    let idx = 0;
+    files.forEach((f, i) => {
+      const card = cardEls.current.get(filePath(f));
+      if (card && card.offsetTop <= top + 40) idx = i;
+    });
+    setCurrentIdx(idx);
+  }, [files]);
+
+  const goFile = useCallback(
+    (index: number) => {
+      const f = files[index];
+      if (!f) return;
+      const path = filePath(f);
+      if (collapsedSet.has(path)) {
+        const next = new Set(collapsedSet);
+        next.delete(path);
+        setCollapsed(next);
+      }
+      setCurrentIdx(index);
+      const card = cardEls.current.get(path);
+      const el = mainRef.current;
+      if (card && el) el.scrollTo?.({ top: Math.max(0, card.offsetTop - 8), behavior: "smooth" });
+    },
+    [files, collapsedSet],
+  );
+
+  const goHunk = useCallback((dir: 1 | -1) => {
+    const el = mainRef.current;
+    if (!el) return;
+    const rows = Array.from(el.querySelectorAll<HTMLElement>('tr[data-state="hunk"]'));
+    const base = el.getBoundingClientRect().top + 48;
+    const target =
+      dir === 1
+        ? rows.find((r) => r.getBoundingClientRect().top > base + 4)
+        : [...rows].reverse().find((r) => r.getBoundingClientRect().top < base - 4);
+    if (target) el.scrollBy?.({ top: target.getBoundingClientRect().top - base, behavior: "smooth" });
+  }, []);
+
+  // --- Keyboard ---------------------------------------------------------------
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const t = e.target as HTMLElement | null;
+      if (t && (t.tagName === "INPUT" || t.tagName === "TEXTAREA" || t.isContentEditable)) {
+        if (e.key === "Escape") t.blur();
+        return;
+      }
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+      switch (e.key) {
+        case "j":
+          goFile(Math.min(files.length - 1, currentIdx + 1));
+          break;
+        case "k":
+          goFile(Math.max(0, currentIdx - 1));
+          break;
+        case "n":
+          goHunk(1);
+          break;
+        case "p":
+          goHunk(-1);
+          break;
+        case "u":
+          changeView(view === "split" ? "unified" : "split");
+          break;
+        case "[":
+          toggleList();
+          break;
+        case "/":
+          e.preventDefault();
+          if (!listOpen) toggleList();
+          window.setTimeout(() => filterRef.current?.focus(), 0);
+          break;
+        default:
+          return;
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [files.length, currentIdx, view, listOpen, goFile, goHunk]);
+
+  // --- Exit -------------------------------------------------------------------
+  const goBack = () => {
+    const sameOrigin = document.referrer && document.referrer.startsWith(window.location.origin);
+    if (sameOrigin && window.history.length > 1) window.history.back();
+    else window.location.assign("/");
+  };
+
+  const reload = () => {
+    setTipMoved(false);
+    setNodeDelivered(null);
+    setReloadTick((t) => t + 1);
+  };
+
+  const delivery = refs ? deliveryOfPair(pair, refs) : null;
+  const stats = current.kind === "ready" ? current.diff : null;
+  const pairIsDefault = isDefaultPair(pair);
+
+  if (runError) {
+    return (
+      <div className="flex h-screen flex-col items-center justify-center gap-2 bg-bg-1 text-fg-3" data-testid="review-page">
+        <div style={{ fontSize: "12px" }}>Run not found</div>
+        <div className="text-fg-4" style={{ fontSize: "11px" }}>
+          {runError}
+        </div>
+        <a href="/" className="mt-2 text-acc" style={{ fontSize: "11px" }}>
+          Back to the app
+        </a>
+      </div>
+    );
+  }
+
+  return (
+    <div className="pdo-review grid h-screen grid-rows-[36px_1fr] bg-bg-1 text-fg" data-testid="review-page">
+      {/* ===== Top bar ===== */}
+      <div className="relative z-20 flex items-center gap-2 border-b border-line bg-bg-2 px-2.5" style={{ fontSize: "11px" }}>
+        <button
+          type="button"
+          onClick={goBack}
+          data-testid="review-back"
+          title="Back to the Run (canvas stays where you left it)"
+          className="flex cursor-pointer items-center gap-1.5 rounded px-1.5 py-[3px] text-fg-2 hover:bg-bg-3 hover:text-fg"
+        >
+          <ArrowLeft size={12} />
+          <span className="text-fg-4">
+            <span className="font-medium text-fg-2">{run?.pipeline_name ?? "…"}</span> · {runId}
+          </span>
+        </button>
+        <span className="h-4 w-px bg-line-strong" />
+        <span className="text-fg-3">Review</span>
+        <span className="h-4 w-px bg-line-strong" />
+
+        <div className="flex items-center gap-1" data-testid="review-refpair">
+          <RefPicker
+            side="from"
+            value={pair.from}
+            other={pair.to}
+            refs={refs}
+            disabled={isArchived}
+            onPick={(id) => setPair({ from: id, to: pair.to })}
+            onPickPair={setPair}
+          />
+          <span className="px-0.5 text-fg-4">→</span>
+          <RefPicker
+            side="to"
+            value={pair.to}
+            other={pair.from}
+            refs={refs}
+            disabled={isArchived}
+            onPick={(id) => setPair({ from: pair.from, to: id })}
+            onPickPair={setPair}
+          />
+          <button
+            type="button"
+            onClick={() => setPair({ from: pair.to, to: pair.from })}
+            disabled={isArchived}
+            title="Swap source and destination"
+            data-testid="review-swap"
+            className="cursor-pointer rounded p-[3px] text-fg-4 hover:bg-bg-3 hover:text-fg-2 disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            <ArrowLeftRight size={11} />
+          </button>
+          {!pairIsDefault && (
+            <button
+              type="button"
+              onClick={() => setPair({ from: DEFAULT_FROM, to: DEFAULT_TO })}
+              title="Back to the default pair"
+              data-testid="review-reset"
+              className="cursor-pointer rounded px-1.5 py-0.5 text-fg-4 hover:bg-bg-3 hover:text-fg-2"
+              style={{ fontSize: "10px" }}
+            >
+              fork → tip
+            </button>
+          )}
+        </div>
+
+        <span className="flex-1" />
+
+        {stats && (
+          <span className="flex items-center gap-1.5 text-fg-2" data-testid="review-stats">
+            <span>
+              {stats.files_changed} file{stats.files_changed === 1 ? "" : "s"}
+            </span>
+            <span className="font-mono text-st-done">+{stats.additions}</span>
+            <span className="font-mono text-st-failed">−{stats.deletions}</span>
+          </span>
+        )}
+        <span className="h-4 w-px bg-line-strong" />
+        <div
+          className="inline-flex overflow-hidden rounded border border-line-strong"
+          title={narrow ? "Unified on narrow windows; your preference is kept" : "Remembered on this browser"}
+          role="group"
+          data-testid="review-view-toggle"
+          data-view={effectiveView}
+        >
+          <button
+            type="button"
+            onClick={() => changeView("split")}
+            aria-pressed={effectiveView === "split"}
+            data-testid="review-view-split"
+            className={`flex cursor-pointer items-center gap-1 px-2 py-0.5 ${
+              effectiveView === "split" ? "bg-bg-4 text-fg" : "text-fg-3 hover:text-fg-2"
+            }`}
+            style={{ fontSize: "10.5px" }}
+          >
+            <Columns2 size={11} /> Split
+          </button>
+          <button
+            type="button"
+            onClick={() => changeView("unified")}
+            aria-pressed={effectiveView === "unified"}
+            data-testid="review-view-unified"
+            className={`flex cursor-pointer items-center gap-1 border-l border-line-strong px-2 py-0.5 ${
+              effectiveView === "unified" ? "bg-bg-4 text-fg" : "text-fg-3 hover:text-fg-2"
+            }`}
+            style={{ fontSize: "10.5px" }}
+          >
+            <Rows3 size={11} /> Unified
+          </button>
+        </div>
+        <button
+          type="button"
+          onClick={collapseAll}
+          disabled={files.length === 0}
+          title="Collapse all / expand all"
+          data-testid="review-collapse-all"
+          className="flex cursor-pointer items-center gap-1 rounded border border-line-strong bg-bg-3 px-2 py-0.5 text-fg-3 hover:text-fg-2 disabled:cursor-not-allowed disabled:opacity-50"
+          style={{ fontSize: "10.5px" }}
+        >
+          <ListMinus size={11} /> Collapse all
+        </button>
+        {/* Reserved for #750: comments and their send gesture. Visible, sober, disabled. */}
+        <span
+          className="flex items-center gap-1 rounded border border-line-strong bg-bg-3 px-2 py-0.5 text-fg-3 opacity-50"
+          title="Comments arrive in the next ticket (#750)."
+          aria-disabled
+          data-testid="review-send-placeholder"
+          style={{ fontSize: "10.5px" }}
+        >
+          <MessageSquare size={11} /> 0 · Send to manager
+        </span>
+        <a
+          href={reviewUrl(runId, pair)}
+          target="_blank"
+          rel="noreferrer"
+          title="Open in a new tab — the URL carries the pair"
+          data-testid="review-open-new-tab"
+          className="grid h-5 w-[22px] place-items-center rounded border border-line-strong bg-bg-3 text-fg-3 hover:text-fg-2"
+        >
+          <SquareArrowOutUpRight size={11} />
+        </a>
+      </div>
+
+      {/* ===== Body ===== */}
+      <div className={`grid min-h-0 ${listOpen ? "grid-cols-[272px_1fr]" : "grid-cols-[0_1fr]"}`} data-testid="review-body">
+        {listOpen ? (
+          <ReviewFileList
+            files={files}
+            filter={filter}
+            onFilterChange={setFilter}
+            filterRef={filterRef}
+            currentIndex={currentIdx}
+            onSelect={goFile}
+            onClose={toggleList}
+          />
+        ) : (
+          <div />
+        )}
+
+        <div ref={mainRef} onScroll={onScroll} className="relative min-h-0 min-w-0 overflow-y-auto" data-testid="review-main">
+          {!listOpen && (
+            <button
+              type="button"
+              onClick={toggleList}
+              title="Show file list  ( [ )"
+              data-testid="review-list-open"
+              className="absolute left-2 top-2 z-20 grid h-6 w-6 cursor-pointer place-items-center rounded border border-line-strong bg-bg-2 text-fg-4 hover:text-fg-2"
+            >
+              <PanelLeftOpen size={12} />
+            </button>
+          )}
+
+          {tipMoved && !isArchived && (
+            <div
+              className="sticky top-0 z-[15] flex items-center gap-2.5 border-b border-st-running/35 bg-st-running-bg px-3 py-1.5 text-st-running"
+              style={{ fontSize: "11px" }}
+              data-testid="review-tip-moved"
+            >
+              <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-current" />
+              The Run tip moved since this diff was loaded ·
+              <button
+                type="button"
+                onClick={reload}
+                className="cursor-pointer rounded border border-st-running/50 px-2 py-px hover:bg-st-running/20"
+              >
+                Reload
+              </button>
+              <span className="text-fg-4">Your scroll position is kept.</span>
+            </div>
+          )}
+          {nodeDelivered && refs && (
+            <div
+              className="sticky top-0 z-[15] flex items-center gap-2.5 border-b border-st-running/35 bg-st-running-bg px-3 py-1.5 text-st-running"
+              style={{ fontSize: "11px" }}
+              data-testid="review-node-delivered"
+            >
+              Node delivered · its live branch is gone ·
+              <button
+                type="button"
+                onClick={() =>
+                  setPair({
+                    from: `node:${nodeDelivered.nodeId}:${nodeDelivered.iter}:before`,
+                    to: `node:${nodeDelivered.nodeId}:${nodeDelivered.iter}:after`,
+                  })
+                }
+                className="cursor-pointer rounded border border-st-running/50 px-2 py-px hover:bg-st-running/20"
+              >
+                Switch to its after ref
+              </button>
+            </div>
+          )}
+
+          {notice && (
+            <div
+              className="mx-3 mt-2.5 flex items-center gap-2 rounded-md border border-st-await/35 bg-st-await-bg px-2.5 py-1.5 text-fg-2"
+              style={{ fontSize: "11px" }}
+              data-testid="review-notice"
+            >
+              {notice}
+              <button type="button" onClick={() => setNotice(null)} className="ml-auto cursor-pointer text-fg-3 hover:text-fg">
+                ✕
+              </button>
+            </div>
+          )}
+
+          {delivery && !isArchived && (
+            <div
+              className="mx-3 mt-2.5 flex items-center gap-2 rounded-md border border-acc-border bg-acc-bg px-2.5 py-1.5 text-fg-2"
+              style={{ fontSize: "11px" }}
+              data-testid="review-delivery-chip"
+            >
+              ◈ Reviewing the delivery of <span className="font-medium text-acc">{delivery.node_name}</span> · iter{" "}
+              {delivery.iter}
+              {delivery.status === "running" && (
+                <span className="text-fg-4">(live sub-worktree, not merged back yet)</span>
+              )}
+              <button
+                type="button"
+                onClick={() => setPair({ from: DEFAULT_FROM, to: DEFAULT_TO })}
+                className="ml-auto cursor-pointer text-fg-3 hover:text-fg"
+                style={{ fontSize: "10.5px" }}
+                data-testid="review-whole-run"
+              >
+                Whole Run instead (fork → tip)
+              </button>
+            </div>
+          )}
+
+          {isArchived ? (
+            <EmptyState
+              testId="review-archived"
+              icon={<Archive size={22} className="text-fg-5" />}
+              title="Diff not preserved for archived runs"
+              hint="The run branch was deleted at cleanup."
+            />
+          ) : sameRef ? (
+            <EmptyState
+              testId="review-empty"
+              icon={<span className="text-fg-5" style={{ fontSize: "24px" }}>≡</span>}
+              title="Nothing to compare"
+              hint="Source and destination are the same ref. Pick another destination."
+            />
+          ) : current.kind === "none" ? (
+            <div className="px-4 py-10 text-center text-fg-4" style={{ fontSize: "11px" }} data-testid="review-loading">
+              Loading diff…
+            </div>
+          ) : current.kind === "error" ? (
+            <div className="flex flex-col items-center gap-2 px-4 py-14 text-center" data-testid="review-error">
+              <div className="text-fg-3" style={{ fontSize: "12px" }}>
+                {current.status === 404 ? "Run branch not found" : "Could not load the diff"}
+              </div>
+              <div className="text-fg-4" style={{ fontSize: "11px" }}>
+                {current.message}
+              </div>
+              <button
+                type="button"
+                onClick={reload}
+                className="mt-1 cursor-pointer rounded border border-line-strong bg-bg-3 px-2 py-0.5 text-fg-2 hover:text-fg"
+                style={{ fontSize: "10.5px" }}
+              >
+                Retry
+              </button>
+            </div>
+          ) : files.length === 0 ? (
+            <EmptyState
+              testId="review-empty"
+              icon={<span className="text-fg-5" style={{ fontSize: "24px" }}>≡</span>}
+              title="No changes"
+              hint="The two refs have identical trees."
+            />
+          ) : (
+            <>
+              {files.length > 40 && (
+                <div className="mx-3 mt-2.5 rounded border border-line bg-bg-3 px-2.5 py-1 text-fg-3" style={{ fontSize: "10.5px" }}>
+                  Large diff — files collapsed
+                </div>
+              )}
+              {files.map((f) => {
+                const p = filePath(f);
+                return (
+                  <ReviewFileCard
+                    key={`${pair.from}|${pair.to}|${p}`}
+                    runId={runId}
+                    file={f}
+                    pair={pair}
+                    view={effectiveView}
+                    collapsed={collapsedSet.has(p)}
+                    onToggle={() => toggleFile(p)}
+                    registerEl={registerEl}
+                  />
+                );
+              })}
+              <div className="h-[40vh]" />
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function EmptyState({
+  testId,
+  icon,
+  title,
+  hint,
+}: {
+  testId: string;
+  icon: React.ReactNode;
+  title: string;
+  hint: string;
+}) {
+  return (
+    <div className="flex flex-col items-center gap-1 px-4 pt-20 text-center" data-testid={testId}>
+      <div className="mb-1">{icon}</div>
+      <div className="text-fg-3" style={{ fontSize: "12px" }}>
+        {title}
+      </div>
+      <div className="text-fg-4" style={{ fontSize: "11px" }}>
+        {hint}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1967,6 +1967,53 @@ export interface DiffFile {
   hunks: DiffHunk[];
 }
 
+// ---------------------------------------------------------------------------
+// Refs of the Run (#749, ADR-0067 §1) — `GET /runs/<id>/refs`. Stable ids
+// (`fork`, `tip`, `node:<id>:<iter>:before|after`, `live:<id>`) are what the
+// Review page's URL carries; labels are built by the daemon.
+// ---------------------------------------------------------------------------
+
+export type RunRefKind = "fork" | "tip" | "before" | "after" | "live";
+
+export interface RunRef {
+  id: string;
+  kind: RunRefKind;
+  /** e.g. `implement · iter 1 · after`. */
+  label: string;
+  /** The git ref the id resolves to (SHA, branch, fork SHA). */
+  git_ref: string;
+  /** Resolved commit SHA; null when it no longer resolves (archived, merged back). */
+  sha: string | null;
+  node_id?: string;
+  node_name?: string;
+  iter?: number;
+}
+
+export type RunDeliveryStatus = "delivered" | "running";
+
+/** One node delivery (or one running node's live branch) as a one-click pair. */
+export interface RunDelivery {
+  node_id: string;
+  node_name: string;
+  iter: number;
+  status: RunDeliveryStatus;
+  /** Ref id of the pair's source. */
+  before: string;
+  /** Ref id of the pair's destination when delivered. */
+  after?: string;
+  /** Ref id of the live sub-worktree branch when running. */
+  live?: string;
+  delivered_at?: string;
+}
+
+export interface RunRefs {
+  /** Order: fork, deliveries in delivery order, live branches, tip. */
+  refs: RunRef[];
+  deliveries: RunDelivery[];
+  default_from: string;
+  default_to: string;
+}
+
 export interface StructuredDiff {
   from_ref: string;
   to_ref: string;


### PR DESCRIPTION
Closes #749 · story #746 · spec #747 · ADR-0067

## What
- `GET /runs/{id}/refs`: fork, tip, per-node/iter `before`/`after` deliveries (from the event log), live sub-worktree branch of a running node, readable labels, `default_from`/`default_to`.
- Dedicated route `/runs/<id>/review?from=…&to=…`: opens in a new tab, reloadable; unknown ref falls back to fork → tip with a notice; same ref → empty state.
- Third-party diff renderer (`@git-diff-view/react`): split by default, unified toggle remembered in `localStorage`, context expansion between hunks and at file edges via the file-content-at-ref endpoint.
- Left file list grouped by directory with +/− and mini bars; clicking a row scrolls to the file card.
- « Expand and comment » button in the Diff tab; « Review this node's delivery » shortcut in the Node panel, only for delivered or running nodes.
- No « node diff » surface left (`fetchNodeDiff`, `DiffSection`, `parseUnifiedDiff` removed).
- Release 1.76.0 (changelog entry).

## Verification
Agentic FP run against a daemon built from this branch (isolated HOME, 4-node pipeline, real deliveries): 4/4 FP steps pass, all acceptance criteria checked, stats match `git diff --name-status`. Scripted FP `frontend/e2e/review-page-fp.spec.ts`: 2 passed. Three non-blocking cosmetic findings (hunk separator lacks « N hidden lines » caption, expand reveals the whole gap instead of 20-line steps, popover repeats id when id == name).

🤖 Generated with [Claude Code](https://claude.com/claude-code)