### PR TITLE
feat(review): inline review comments — draft, sent in the event log, send to manager (#750)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ ascendante** : la casse se signale ici et par un bump majeur, jamais en gardant 
 morts. Seule contrainte non négociable — les **données historiques restent lisibles** : un Run
 archivé s'ouvre et se chiffre quelle que soit la version qui a écrit son payload.
 
+## 1.77.0
+
+**Page de Review — commentaires inline, brouillons et envoi au manager** (#750 ; story #746, ADR-0067).
+Le widget `+` d'une ligne du diff ouvre un éditeur sous la ligne (Write/Preview markdown, ⌘/Ctrl+Entrée,
+Échap, Cancel · Send now · Save draft). Un **brouillon** vit dans le navigateur (`localStorage` par Run,
+texte en cours en `sessionStorage`), éditable et supprimable, marqué d'un point ambre sur la ligne.
+L'envoi — par carte, via la pastille de la barre d'outils ou la barre de pied de page « Send all » —
+écrit un évènement `review_comment_sent` par commentaire (ids `rc-001…`, `batch_id` partagé, paire de
+refs et SHAs), projeté dans `RunState.review_comments` (absent quand vide : payloads historiques
+inchangés), et colle **un seul message** dans le pane du manager (démarré à la demande) via
+`load-buffer` + `paste-buffer`. Un commentaire envoyé devient immuable et affiche `rc-NNN · paire ·
+Awaiting manager reply`. Nouveaux endpoints `GET /runs/{id}/review/comments` et
+`POST /runs/{id}/review/comments/send` ; branche du Run disparue ou Run archivé → `409 run_branch_gone`,
+envoi désactivé avec la raison, rien n'est écrit. Les évènements `review_comment_replied` /
+`resolved` / `reopened` sont définis mais pas encore émis (#751). Le prompt builtin du manager gagne
+une section « Review comments ». Navigation entre commentaires : `c` / `C`.
+
 ## 1.76.0
 
 **Page de Review — relecture de diff GitHub-like** (#749 ; story #746, ADR-0067). Depuis l'onglet Diff,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "1.76.0"
+version = "1.77.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "1.76.0"
+version = "1.77.0"
 license = "MIT"
 description = "Prompt-Driven Orchestrator — a local daemon that runs and supervises agentic coding pipelines"
 repository = "https://github.com/Loulen/prompt-driven-orchestrator"

--- a/crates/pdo-daemon/src/event_log.rs
+++ b/crates/pdo-daemon/src/event_log.rs
@@ -211,6 +211,25 @@ pub enum EventKind {
     /// Projects nothing — same observed-fact discipline as
     /// [`EventKind::ManagerStarted`]. Wire form: `"manager_stopped"`.
     ManagerStopped,
+    /// A review comment left `sent` (#750, ADR-0067 §2): the operator handed a
+    /// remark anchored on one diff line to the Pipeline Manager. The payload is
+    /// the whole [`crate::review_comments::ReviewComment`] (id, anchor, ref pair
+    /// with SHAs, text, hunk excerpt, author, batch). Folded into
+    /// `RunState::review_comments`, **additively on a terminal Run too** — review
+    /// happens post-mortem, so this never re-opens anything. A sent comment is
+    /// immutable: no event edits or deletes it. Wire form: `"review_comment_sent"`.
+    ReviewCommentSent,
+    /// An agent's reply to a sent comment (#751 emits it via `pdo review reply`;
+    /// the projection is ready here). Payload: `id`, `author`, `text`,
+    /// `proposes_resolution`. Wire form: `"review_comment_replied"`.
+    ReviewCommentReplied,
+    /// A comment resolved (by the human, or by the agent under the
+    /// `review_agent_can_resolve` setting — #751). Payload: `id`. Wire form:
+    /// `"review_comment_resolved"`.
+    ReviewCommentResolved,
+    /// A resolved comment reopened by the human (#751). Payload: `id`. Wire form:
+    /// `"review_comment_reopened"`.
+    ReviewCommentReopened,
     CommandIssued,
 }
 
@@ -1141,6 +1160,12 @@ pub struct RunState {
     /// `(node, iter)` (restart/recovery) counts again, so this is always ≥ the
     /// number of distinct iterations shown. The Pipeline Manager emits no
     /// `NodeStarted`, so it is excluded by construction.
+    /// Sent review comments (#750, ADR-0067 §2), in send order, with their
+    /// replies and resolution state. Folded from `review_comment_*` events; drafts
+    /// never reach here (browser-only). Empty — and byte-identically absent — for
+    /// every Run nobody reviewed.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) review_comments: Vec<crate::review_comments::ReviewComment>,
     #[serde(default)]
     pub sessions_spawned: u64,
     /// Lines changed for the Run (issue #100). `None` (not `Some(0)`) when the
@@ -1202,6 +1227,7 @@ impl RunState {
             parent_run_id: None,
             parent_node_id: None,
             pipeline_id: None,
+            review_comments: Vec::new(),
             sessions_spawned: 0,
             loc: None,
             cost: None,
@@ -1527,6 +1553,15 @@ pub(crate) fn project(events: &[Event]) -> Option<RunState> {
             // Informational only (manager on demand): the manager's existence is
             // an observed tmux fact, never projected — see the variants' docs.
             EventKind::ManagerStarted | EventKind::ManagerStopped => {}
+
+            // #750: review comments are additive metadata — folded whatever the
+            // Run's status (review is a post-mortem gesture), never a transition.
+            EventKind::ReviewCommentSent
+            | EventKind::ReviewCommentReplied
+            | EventKind::ReviewCommentResolved
+            | EventKind::ReviewCommentReopened => {
+                crate::review_comments::fold(&mut state.review_comments, event)
+            }
 
             EventKind::CommandIssued => apply_command_event(&mut state, event),
         }
@@ -3729,6 +3764,55 @@ mod tests {
     #[test]
     fn projects_empty_events_to_none() {
         assert!(project(&[]).is_none());
+    }
+
+    #[test]
+    fn review_comment_sent_folds_on_a_completed_run_without_reopening_it() {
+        // #750: a review is a post-mortem gesture. The comment lands in
+        // `review_comments`, the status stays Completed, and a Run nobody reviewed
+        // serializes without the key at all.
+        let bare = project(&[
+            make_event_with_payload(
+                EventKind::RunStarted,
+                None,
+                serde_json::json!({ "pipeline_name": "p" }),
+            ),
+            make_event(EventKind::RunCompleted, None, None),
+        ])
+        .unwrap();
+        assert!(bare.review_comments.is_empty());
+        assert!(serde_json::to_value(&bare)
+            .unwrap()
+            .get("review_comments")
+            .is_none());
+
+        let comment = serde_json::json!({
+            "id": "rc-001", "path": "src/a.rs", "side": "new", "line": 3,
+            "from_ref": "fork", "to_ref": "tip", "text": "why?", "excerpt": "> 3 | x",
+            "author": "user", "sent_at": "2026-09-09T10:00:00.000Z", "batch_id": "b1"
+        });
+        let events = vec![
+            make_event_with_payload(
+                EventKind::RunStarted,
+                None,
+                serde_json::json!({ "pipeline_name": "p" }),
+            ),
+            make_event(EventKind::RunCompleted, None, None),
+            make_event_with_payload(EventKind::ReviewCommentSent, None, comment),
+            make_event_with_payload(
+                EventKind::ReviewCommentReplied,
+                None,
+                serde_json::json!({ "id": "rc-001", "author": "manager", "text": "fixed" }),
+            ),
+        ];
+        let state = project(&events).unwrap();
+        assert_eq!(state.status, RunStatus::Completed);
+        assert_eq!(state.review_comments.len(), 1);
+        assert_eq!(state.review_comments[0].id, "rc-001");
+        assert_eq!(state.review_comments[0].replies.len(), 1);
+        let wire = serde_json::to_value(&state).unwrap();
+        assert_eq!(wire["review_comments"][0]["side"], "new");
+        assert_eq!(wire["review_comments"][0]["status"], "sent");
     }
 
     #[test]

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -61,6 +61,7 @@ pub(crate) mod recovery;
 pub(crate) mod repo_edit_refusal;
 pub(crate) mod restart_verdict;
 pub(crate) mod retry_verdict;
+mod review_comments;
 mod run_advance;
 mod run_command;
 mod run_cost;
@@ -4472,6 +4473,11 @@ fn build_router(state: Arc<AppState>) -> Router {
         .route("/runs/{run_id}/diff/structured", get(run_diff_structured))
         .route("/runs/{run_id}/file", get(run_file_at_ref))
         .route("/runs/{run_id}/refs", get(run_refs))
+        .route("/runs/{run_id}/review/comments", get(list_review_comments))
+        .route(
+            "/runs/{run_id}/review/comments/send",
+            post(send_review_comments),
+        )
         .route("/runs/{run_id}/nodes/{node_id}/diff", get(node_diff))
         .route("/runs/{run_id}/artifact", get(artifact))
         .route("/runs/{run_id}/pipeline", get(get_run_pipeline))
@@ -13613,11 +13619,23 @@ async fn run_diff_structured(
     };
     // #749: a side is a stable Run ref id (`fork`, `tip`, `node:<id>:<iter>:before`,
     // `live:<id>`) resolved against the log, or — compatibility — a raw git ref.
-    let from = match resolve_ref_param(&run_id, &run_state, &events, q.from.as_deref(), run_refs::FORK_ID) {
+    let from = match resolve_ref_param(
+        &run_id,
+        &run_state,
+        &events,
+        q.from.as_deref(),
+        run_refs::FORK_ID,
+    ) {
         Ok(r) => r,
         Err(resp) => return *resp,
     };
-    let to = match resolve_ref_param(&run_id, &run_state, &events, q.to.as_deref(), run_refs::TIP_ID) {
+    let to = match resolve_ref_param(
+        &run_id,
+        &run_state,
+        &events,
+        q.to.as_deref(),
+        run_refs::TIP_ID,
+    ) {
         Ok(r) => r,
         Err(resp) => return *resp,
     };
@@ -13663,7 +13681,13 @@ async fn run_file_at_ref(
             .into_response();
     }
     // #749: stable Run ref ids resolve like on the structured diff endpoint.
-    let git_ref = match resolve_ref_param(&run_id, &run_state, &events, q.git_ref.as_deref(), run_refs::TIP_ID) {
+    let git_ref = match resolve_ref_param(
+        &run_id,
+        &run_state,
+        &events,
+        q.git_ref.as_deref(),
+        run_refs::TIP_ID,
+    ) {
         Ok(r) => r,
         Err(resp) => return *resp,
     };
@@ -13744,6 +13768,245 @@ async fn run_refs(
     let repo = effective_repo_root(&state, &run_state);
     let sha_of = |r: &str| structured_diff::rev_parse(&repo, r);
     Json(run_refs::collect(&run_id, &run_state, &events, &sha_of)).into_response()
+}
+
+/// `GET /runs/<id>/review/comments` (#750): the Run's **sent** review comments as
+/// projected from the event log — the same list `GET /runs/<id>` carries under
+/// `review_comments`, exposed on its own for the CLI (#751) and the tests.
+async fn list_review_comments(
+    State(state): State<Arc<AppState>>,
+    AxumPath(run_id): AxumPath<String>,
+) -> Response {
+    let (_, run_state) = match load_projected(&state, &run_id).await {
+        Ok(t) => t,
+        Err(resp) => return *resp,
+    };
+    Json(serde_json::json!({ "comments": run_state.review_comments })).into_response()
+}
+
+/// One draft the browser hands over for sending (#750). `from`/`to` are stable
+/// Run ref ids (default `fork` → `tip`), never SHAs.
+#[derive(Deserialize)]
+struct SendReviewCommentInput {
+    path: String,
+    side: String,
+    line: i64,
+    #[serde(default)]
+    from: Option<String>,
+    #[serde(default)]
+    to: Option<String>,
+    text: String,
+}
+
+#[derive(Deserialize)]
+struct SendReviewCommentsRequest {
+    comments: Vec<SendReviewCommentInput>,
+}
+
+/// Context lines kept on each side of the anchored line in the excerpt.
+const REVIEW_EXCERPT_CONTEXT: usize = 2;
+/// How long a manager spawned by the send waits before the batch is pasted —
+/// the harness has to be reading its input, or the paste lands in a shell.
+const REVIEW_PASTE_DELAY_AFTER_SPAWN: Duration = Duration::from_secs(8);
+
+/// `POST /runs/<id>/review/comments/send` (#750, ADR-0067 §2–3; CONTEXT.md
+/// « Envoi au manager »): turn a batch of browser drafts into `sent` comments.
+///
+/// Order of operations, each step a reason the drafts **stay drafts**:
+/// 1. the Run branch must still exist — an archived Run, or a `pdo/run-<id>`
+///    branch that is gone, answers `409 run_branch_gone` with the reason the UI
+///    shows on its disabled buttons (nothing for the manager to act on);
+/// 2. every anchor is validated (safe path, `old|new`, line ≥ 1, non-empty
+///    text, known ref ids) — `400` names the offending index;
+/// 3. the Pipeline Manager is started **on demand** if it is not running
+///    (`ensure_run_manager`; its refusals pass through);
+/// 4. one `review_comment_sent` event per comment lands in the log (ids
+///    `rc-NNN` continue the Run's sequence; the batch shares a `batch_id`);
+/// 5. **one** message for the whole batch is pasted into the manager's tmux
+///    session, detached — after a short grace when this call spawned it.
+///
+/// The response carries the sent comments so the browser can drop its drafts
+/// without waiting for the WebSocket round-trip (which also arrives: every
+/// append broadcasts).
+async fn send_review_comments(
+    State(state): State<Arc<AppState>>,
+    AxumPath(run_id): AxumPath<String>,
+    Json(req): Json<SendReviewCommentsRequest>,
+) -> Response {
+    let (events, run_state) = match load_projected(&state, &run_id).await {
+        Ok(t) => t,
+        Err(resp) => return *resp,
+    };
+    if req.comments.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": "no comments to send" })),
+        )
+            .into_response();
+    }
+
+    // 1. Branch gone ⇒ sending is disabled, with the reason.
+    let tip = run_refs::tip_branch(&run_id);
+    let repo = effective_repo_root(&state, &run_state);
+    let branch_gone = run_state.status == event_log::RunStatus::Archived
+        || structured_diff::rev_parse(&repo, &tip).is_none();
+    if branch_gone {
+        return (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({
+                "error": "run_branch_gone",
+                "recoverable": false,
+                "message": format!(
+                    "Run branch {tip} no longer exists — nothing for the manager to act on. Comments stay readable; sending is disabled."
+                ),
+            })),
+        )
+            .into_response();
+    }
+
+    // 2. Validate + resolve every anchor before touching anything.
+    let sha_of = |r: &str| structured_diff::rev_parse(&repo, r);
+    let refs = run_refs::collect(&run_id, &run_state, &events, &sha_of);
+    let label_of = |id: &str| -> String {
+        refs.refs
+            .iter()
+            .find(|r| r.id == id)
+            .map(|r| r.label.clone())
+            .unwrap_or_else(|| id.to_string())
+    };
+    let bad = |i: usize, why: &str| -> Response {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": format!("comment #{}: {why}", i + 1) })),
+        )
+            .into_response()
+    };
+    let now = event_log::now_iso();
+    let batch_id = uuid::Uuid::new_v4().to_string();
+    let mut prepared: Vec<review_comments::ReviewComment> = Vec::with_capacity(req.comments.len());
+    for (i, c) in req.comments.iter().enumerate() {
+        if !structured_diff::is_safe_path(&c.path) {
+            return bad(i, &format!("invalid path {:?}", c.path));
+        }
+        let Some(side) = review_comments::ReviewSide::parse(&c.side) else {
+            return bad(i, &format!("side must be `old` or `new`, got {:?}", c.side));
+        };
+        if c.line < 1 {
+            return bad(i, "line must be ≥ 1");
+        }
+        if c.text.trim().is_empty() {
+            return bad(i, "empty text");
+        }
+        let from_id = c.from.as_deref().unwrap_or(run_refs::FORK_ID);
+        let to_id = c.to.as_deref().unwrap_or(run_refs::TIP_ID);
+        let resolve = |id: &str| -> Option<String> {
+            match run_refs::resolve_id(&run_id, &run_state, &events, id) {
+                run_refs::Resolved::Git(r) => Some(r),
+                _ => None,
+            }
+        };
+        let Some(from_git) = resolve(from_id) else {
+            return bad(i, &format!("unknown run ref {from_id:?}"));
+        };
+        let Some(to_git) = resolve(to_id) else {
+            return bad(i, &format!("unknown run ref {to_id:?}"));
+        };
+        // The excerpt reads the anchored side's file at its ref. Best-effort: a
+        // path that no longer resolves sends with an empty excerpt.
+        let anchored_ref = match side {
+            review_comments::ReviewSide::Old => &from_git,
+            review_comments::ReviewSide::New => &to_git,
+        };
+        let excerpt = structured_diff::file_at_ref(&repo, anchored_ref, &c.path)
+            .ok()
+            .and_then(|b| String::from_utf8(b).ok())
+            .map(|content| review_comments::excerpt(&content, c.line, REVIEW_EXCERPT_CONTEXT))
+            .unwrap_or_default();
+        prepared.push(review_comments::ReviewComment {
+            id: String::new(), // assigned below, once the manager is up
+            path: c.path.clone(),
+            side,
+            line: c.line,
+            from_ref: from_id.to_string(),
+            to_ref: to_id.to_string(),
+            from_sha: sha_of(&from_git),
+            to_sha: sha_of(&to_git),
+            text: c.text.trim_end().to_string(),
+            excerpt,
+            author: "user".to_string(),
+            sent_at: now.clone(),
+            batch_id: Some(batch_id.clone()),
+            status: review_comments::ReviewCommentStatus::Sent,
+            replies: Vec::new(),
+        });
+    }
+
+    // 3. Manager on demand — before any event, so a refusal leaves drafts intact.
+    let created = match ensure_run_manager(&state, &run_id, &run_state).await {
+        Ok(created) => created,
+        Err((status, body)) => return (status, Json(body)).into_response(),
+    };
+
+    // 4. Durable first: one event per comment, ids continuing the Run's sequence.
+    let base = run_state.review_comments.len();
+    for (i, c) in prepared.iter_mut().enumerate() {
+        c.id = review_comments::comment_id(base + i + 1);
+        let event = event_log::Event {
+            id: None,
+            run_id: run_id.clone(),
+            ts: now.clone(),
+            kind: event_log::EventKind::ReviewCommentSent,
+            node_id: None,
+            iter: None,
+            payload: Some(serde_json::to_value(&*c).expect("ReviewComment serializes")),
+        };
+        if let Err(e) = append_event(&state, &event).await {
+            error!(
+                "run {run_id}: failed to append review_comment_sent {}: {e}",
+                c.id
+            );
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({
+                    "error": format!("failed to record comment {} ({} of the batch recorded): {e}", c.id, i)
+                })),
+            )
+                .into_response();
+        }
+    }
+
+    // 5. One message for the batch, handed over off the request.
+    let (from_label, to_label) = {
+        let first = &prepared[0];
+        (label_of(&first.from_ref), label_of(&first.to_ref))
+    };
+    let message = review_comments::batch_message(&run_id, &from_label, &to_label, &prepared);
+    let socket = state.tmux_socket();
+    let session = tmux_session_manager::manager_session_name(&run_id);
+    let delay = if created {
+        REVIEW_PASTE_DELAY_AFTER_SPAWN
+    } else {
+        Duration::from_millis(300)
+    };
+    tokio::spawn(async move {
+        time::sleep(delay).await;
+        tmux_session_manager::paste_text(&socket, &session, &message);
+    });
+    info!(
+        "run {run_id}: {} review comment(s) sent to the manager as one message (batch {batch_id}{})",
+        prepared.len(),
+        if created { ", manager started" } else { "" }
+    );
+
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({
+            "sent": prepared,
+            "batch_id": batch_id,
+            "manager_started": created,
+        })),
+    )
+        .into_response()
 }
 
 async fn node_diff(
@@ -17466,33 +17729,54 @@ async fn start_run_manager(
         Ok(t) => t,
         Err(resp) => return *resp,
     };
-
-    let session_name = tmux_session_manager::manager_session_name(&run_id);
-    let socket = state.tmux_socket();
-    if tmux_session_manager::session_exists(&socket, &session_name) {
-        return (
+    match ensure_run_manager(&state, &run_id, &run_state).await {
+        Ok(created) => (
             StatusCode::OK,
             Json(ManagerStartResponse {
                 ok: true,
-                session: session_name,
-                created: false,
+                session: tmux_session_manager::manager_session_name(&run_id),
+                created,
             }),
         )
-            .into_response();
+            .into_response(),
+        Err((status, body)) => (status, Json(body)).into_response(),
+    }
+}
+
+/// Make sure the Run's Pipeline Manager session is up, spawning it on demand
+/// (manager on demand; #750 reuses it for "send to manager"). `Ok(true)` when
+/// THIS call spawned it, `Ok(false)` when it already existed; `Err` carries the
+/// status + JSON body the HTTP surfaces answer with (`409` no worktree, `500`
+/// the session did not come up).
+///
+/// Idempotency and the racing discipline are the run shell's create-then-verify
+/// rule: `session_exists` first (a benign re-answer), spawn, then verify again —
+/// a concurrent start may have won the `new-session`, and a spawn failure after
+/// our own reservation event must read as an error, not a silent success (the
+/// projection ignores `ManagerStarted`; the wire's `has_manager` stays the
+/// observed tmux fact).
+async fn ensure_run_manager(
+    state: &Arc<AppState>,
+    run_id: &str,
+    run_state: &event_log::RunState,
+) -> Result<bool, (StatusCode, serde_json::Value)> {
+    let session_name = tmux_session_manager::manager_session_name(run_id);
+    let socket = state.tmux_socket();
+    if tmux_session_manager::session_exists(&socket, &session_name) {
+        return Ok(false);
     }
 
     // The manager works in the Run's worktree; an archived/cleaned Run has none
     // left, and a session spawned into a dead cwd would only fail at tmux.
-    let repo_root = effective_repo_root(&state, &run_state);
-    let worktree_dir = crate::worktree_ops::worktree_dir_for_run(&repo_root, &run_id);
+    let repo_root = effective_repo_root(state, run_state);
+    let worktree_dir = crate::worktree_ops::worktree_dir_for_run(&repo_root, run_id);
     if !worktree_dir.exists() {
-        return (
+        return Err((
             StatusCode::CONFLICT,
-            Json(serde_json::json!({
+            serde_json::json!({
                 "error": "this run's worktree no longer exists (archived or cleaned) — there is nothing for a manager to work in"
-            })),
-        )
-            .into_response();
+            }),
+        ));
     }
 
     // The create path's name_hint discipline, reconstructed from the projected
@@ -17513,8 +17797,8 @@ async fn start_run_manager(
     };
 
     spawn_manager_session(
-        &state,
-        &run_id,
+        state,
+        run_id,
         &worktree_dir,
         name_hint,
         !run_state.sandbox.is_off(),
@@ -17523,23 +17807,14 @@ async fn start_run_manager(
 
     // Create-then-verify (the run shell's benign-race rule).
     if !tmux_session_manager::session_exists(&socket, &session_name) {
-        return (
+        return Err((
             StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({
+            serde_json::json!({
                 "error": "the manager tmux session did not come up (see the daemon logs)"
-            })),
-        )
-            .into_response();
+            }),
+        ));
     }
-    (
-        StatusCode::OK,
-        Json(ManagerStartResponse {
-            ok: true,
-            session: session_name,
-            created: true,
-        }),
-    )
-        .into_response()
+    Ok(true)
 }
 
 /// Stop the Run's Pipeline Manager (manager on demand). Cost control is the
@@ -24523,6 +24798,119 @@ mod tests {
                 .contains("worktree no longer exists"),
             "got {body}"
         );
+    }
+
+    #[tokio::test]
+    async fn send_review_comments_refuses_when_the_run_branch_is_gone() {
+        // #750: the seeded run never had a `pdo/run-<id>` branch in this
+        // checkout (nor an archived Run has one) — sending answers 409
+        // `run_branch_gone` with the reason the UI prints on its disabled
+        // buttons, and NO event is appended: drafts stay drafts.
+        let state = test_state().await;
+        let run_id = "review-send-branch-gone";
+        seed_completed_run(&state, run_id).await;
+
+        let app = build_router(state.clone());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/runs/{run_id}/review/comments/send"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({
+                            "comments": [{ "path": "src/a.rs", "side": "new", "line": 3, "text": "why?" }]
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+        let body: serde_json::Value = serde_json::from_slice(
+            &axum::body::to_bytes(resp.into_body(), usize::MAX)
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(body["error"], "run_branch_gone");
+        assert!(
+            body["message"]
+                .as_str()
+                .unwrap()
+                .contains(&format!("pdo/run-{run_id} no longer exists")),
+            "got {body}"
+        );
+        let events = load_events(&state.db, run_id).await.unwrap();
+        assert!(
+            !events
+                .iter()
+                .any(|e| e.kind == event_log::EventKind::ReviewCommentSent),
+            "no comment recorded on a refused send"
+        );
+    }
+
+    #[tokio::test]
+    async fn send_review_comments_validates_the_batch_and_lists_nothing_by_default() {
+        // #750: an empty batch and an unknown run are refused before any git or
+        // tmux work; the list endpoint of a never-reviewed Run is `[]`.
+        let state = test_state().await;
+        let run_id = "review-send-validation";
+        seed_completed_run(&state, run_id).await;
+
+        let app = build_router(state.clone());
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/runs/{run_id}/review/comments/send"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({ "comments": [] }).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/runs/no-such-run/review/comments/send")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({ "comments": [{ "path": "a", "side": "new", "line": 1, "text": "t" }] })
+                            .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri(format!("/runs/{run_id}/review/comments"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: serde_json::Value = serde_json::from_slice(
+            &axum::body::to_bytes(resp.into_body(), usize::MAX)
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(body["comments"], serde_json::json!([]));
     }
 
     #[tokio::test]
@@ -35405,7 +35793,10 @@ edges: []
         let refs = json["refs"].as_array().unwrap();
         assert_eq!(refs[0]["sha"], serde_json::json!(fork));
         assert_eq!(refs[2]["sha"], serde_json::json!(c1));
-        assert_eq!(refs[2]["label"], serde_json::json!("impl-1 · iter 1 · after"));
+        assert_eq!(
+            refs[2]["label"],
+            serde_json::json!("impl-1 · iter 1 · after")
+        );
         assert_eq!(refs[5]["sha"], serde_json::json!(c2));
         assert_eq!(refs[6]["sha"], serde_json::json!(c2));
         assert_eq!(json["default_from"], serde_json::json!("fork"));
@@ -35463,7 +35854,9 @@ edges: []
             .clone()
             .oneshot(
                 Request::builder()
-                    .uri(format!("/runs/{run_id}/diff/structured?from=tip&to=live:impl-1"))
+                    .uri(format!(
+                        "/runs/{run_id}/diff/structured?from=tip&to=live:impl-1"
+                    ))
                     .body(Body::empty())
                     .unwrap(),
             )
@@ -35476,7 +35869,9 @@ edges: []
             .clone()
             .oneshot(
                 Request::builder()
-                    .uri(format!("/runs/{run_id}/diff/structured?from=node:impl-1:2:before"))
+                    .uri(format!(
+                        "/runs/{run_id}/diff/structured?from=node:impl-1:2:before"
+                    ))
                     .body(Body::empty())
                     .unwrap(),
             )
@@ -35490,7 +35885,9 @@ edges: []
             .clone()
             .oneshot(
                 Request::builder()
-                    .uri(format!("/runs/{run_id}/file?path=one.rs&ref=node:impl-1:1:after"))
+                    .uri(format!(
+                        "/runs/{run_id}/file?path=one.rs&ref=node:impl-1:1:after"
+                    ))
                     .body(Body::empty())
                     .unwrap(),
             )
@@ -35501,13 +35898,19 @@ edges: []
         let resp = app
             .oneshot(
                 Request::builder()
-                    .uri(format!("/runs/{run_id}/file?path=one.rs&ref=node:impl-1:1:before"))
+                    .uri(format!(
+                        "/runs/{run_id}/file?path=one.rs&ref=node:impl-1:1:before"
+                    ))
                     .body(Body::empty())
                     .unwrap(),
             )
             .await
             .unwrap();
-        assert_eq!(resp.status(), StatusCode::NOT_FOUND, "one.rs did not exist before");
+        assert_eq!(
+            resp.status(),
+            StatusCode::NOT_FOUND,
+            "one.rs did not exist before"
+        );
     }
 
     #[tokio::test]

--- a/crates/pdo-daemon/src/review_comments.rs
+++ b/crates/pdo-daemon/src/review_comments.rs
@@ -1,0 +1,447 @@
+//! Review comments (#750, ADR-0067 §2; CONTEXT.md § "Commentaire de review",
+//! "Envoi au manager").
+//!
+//! A review comment is a remark anchored on one line of one file of the diff
+//! between two Run refs: `(path, side, line, from, to)`. Its `draft` state lives
+//! in the browser only. From `sent` on, everything is a **Run event**: the
+//! comment itself (`review_comment_sent`), and — for the next ticket (#751) — the
+//! agent's replies, the resolutions and the reopenings. This module owns the
+//! projected shape of those events, the id scheme, the hunk excerpt and the
+//! **single batch message** the Pipeline Manager receives per send.
+//!
+//! Sent comments are immutable: no event edits or deletes one, and nothing here
+//! offers to. The fold is additive on a terminal Run — review happens on a
+//! completed Run, post-mortem, so the projection must never treat these events
+//! as a re-opening.
+
+use serde::{Deserialize, Serialize};
+
+use crate::event_log::{Event, EventKind};
+
+/// The side of the diff a comment is anchored on. `old` = the source ref's
+/// content (a deleted or context line numbered on the left), `new` = the
+/// destination ref's (an added or context line numbered on the right).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ReviewSide {
+    Old,
+    New,
+}
+
+impl ReviewSide {
+    /// GitHub's letter for the anchor label: `L` for the left (old) side, `R`
+    /// for the right (new) side — `ReviewPage.tsx:R48`.
+    pub(crate) fn letter(self) -> char {
+        match self {
+            ReviewSide::Old => 'L',
+            ReviewSide::New => 'R',
+        }
+    }
+
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            ReviewSide::Old => "old",
+            ReviewSide::New => "new",
+        }
+    }
+
+    pub(crate) fn parse(s: &str) -> Option<ReviewSide> {
+        match s {
+            "old" => Some(ReviewSide::Old),
+            "new" => Some(ReviewSide::New),
+            _ => None,
+        }
+    }
+}
+
+/// Lifecycle after `sent`. `Resolved` and the reopen path are folded here so
+/// #751 only adds emitters; nothing in #750 produces them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ReviewCommentStatus {
+    Sent,
+    Resolved,
+}
+
+/// One reply of an agent (manager or node of the Run, author recorded) to a
+/// sent comment — `review_comment_replied`. Folded for #751's `pdo review reply`;
+/// the shape is fixed here so the message the manager receives can already name
+/// the contract.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct ReviewReply {
+    pub author: String,
+    pub text: String,
+    pub at: String,
+    /// The agent proposes a resolution with this reply (#751 decides whether it
+    /// resolves directly, under `review_agent_can_resolve`).
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub proposes_resolution: bool,
+}
+
+/// A sent comment as projected into `RunState::review_comments`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct ReviewComment {
+    /// `rc-001`, `rc-002`, … — sequential per Run, the id the manager echoes in
+    /// `pdo review reply`.
+    pub id: String,
+    pub path: String,
+    pub side: ReviewSide,
+    pub line: i64,
+    /// Stable Run ref ids of the pair the comment was written against
+    /// (`fork`, `tip`, `node:<id>:<iter>:after`, …).
+    pub from_ref: String,
+    pub to_ref: String,
+    /// The SHAs those ids resolved to at send time — what makes the anchor
+    /// meaningful once the Run tip moved (#752's outdated logic reads these).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub from_sha: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub to_sha: Option<String>,
+    pub text: String,
+    /// The hunk excerpt around the anchored line at send time, `>` marking it.
+    /// Kept so the comment reads post-mortem even when the file is gone.
+    #[serde(default)]
+    pub excerpt: String,
+    pub author: String,
+    pub sent_at: String,
+    /// The send batch this comment travelled in — one message to the manager
+    /// per batch.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub batch_id: Option<String>,
+    #[serde(default = "default_status")]
+    pub status: ReviewCommentStatus,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub replies: Vec<ReviewReply>,
+}
+
+fn default_status() -> ReviewCommentStatus {
+    ReviewCommentStatus::Sent
+}
+
+/// `rc-NNN` for the `n`-th comment of the Run (1-based). Three digits keep the
+/// ids aligned in the manager's message; past 999 the number simply widens.
+pub(crate) fn comment_id(n: usize) -> String {
+    format!("rc-{n:03}")
+}
+
+/// The excerpt of `content` around `line` (1-based): `context` lines on each
+/// side, numbered, the anchored line marked with `>`. Empty when the line is
+/// outside the file (the anchor no longer resolves — the comment still sends).
+pub(crate) fn excerpt(content: &str, line: i64, context: usize) -> String {
+    if line < 1 {
+        return String::new();
+    }
+    let lines: Vec<&str> = content.lines().collect();
+    let idx = (line - 1) as usize;
+    if idx >= lines.len() {
+        return String::new();
+    }
+    let start = idx.saturating_sub(context);
+    let end = (idx + context + 1).min(lines.len());
+    let width = end.to_string().len();
+    let mut out = String::new();
+    for (i, l) in lines.iter().enumerate().take(end).skip(start) {
+        let marker = if i == idx { '>' } else { ' ' };
+        out.push_str(&format!("{marker} {:>width$} | {l}\n", i + 1));
+    }
+    out.trim_end_matches('\n').to_string()
+}
+
+/// The **one message** a batch of freshly sent comments produces for the
+/// Pipeline Manager (CONTEXT.md « Envoi au manager »): per comment its id, the
+/// anchor, the ref pair, the hunk excerpt, the text, and the instruction to
+/// answer through `pdo review reply`. Never one message per comment — the
+/// manager would answer N times.
+pub(crate) fn batch_message(
+    run_id: &str,
+    from_label: &str,
+    to_label: &str,
+    comments: &[ReviewComment],
+) -> String {
+    let n = comments.len();
+    let mut out = format!(
+        "Review comments — {n} new on Run {run_id} ({from_label} → {to_label}).\n\
+         A human reviewed the diff between these two Run refs and left the remarks below. \
+         Each one is an immutable Run event with its own id.\n\n"
+    );
+    for c in comments {
+        let short =
+            |s: &Option<String>| s.as_deref().map(|x| x.chars().take(7).collect::<String>());
+        let shas = match (short(&c.from_sha), short(&c.to_sha)) {
+            (Some(f), Some(t)) => format!(" ({f} → {t})"),
+            _ => String::new(),
+        };
+        out.push_str(&format!(
+            "[{id}] {path}:{letter}{line} · {side} side · {from} → {to}{shas}\n",
+            id = c.id,
+            path = c.path,
+            letter = c.side.letter(),
+            line = c.line,
+            side = c.side.as_str(),
+            from = c.from_ref,
+            to = c.to_ref,
+        ));
+        if !c.excerpt.is_empty() {
+            for l in c.excerpt.lines() {
+                out.push_str("    ");
+                out.push_str(l);
+                out.push('\n');
+            }
+        }
+        out.push_str("  Comment:\n");
+        for l in c.text.lines() {
+            out.push_str("  ");
+            out.push_str(l);
+            out.push('\n');
+        }
+        out.push('\n');
+    }
+    out.push_str(
+        "Reply to each comment with `pdo review reply <id> --text \"<your answer>\"` \
+         (add `--resolved` once you consider it addressed; `pdo review list` lists the open ones). \
+         Address the code the comment points at — fix it on the Run branch, or explain why not. \
+         Comments themselves are immutable: never try to edit or delete one.",
+    );
+    out
+}
+
+/// Fold one review event into the projected list. Additive only; unknown ids
+/// on a reply/resolve/reopen are ignored with a warning (a hand-crafted or
+/// replayed event must never panic the projection).
+pub(crate) fn fold(comments: &mut Vec<ReviewComment>, event: &Event) {
+    let Some(payload) = event.payload.as_ref() else {
+        return;
+    };
+    match event.kind {
+        EventKind::ReviewCommentSent => {
+            match serde_json::from_value::<ReviewComment>(payload.clone()) {
+                Ok(mut c) => {
+                    if c.sent_at.is_empty() {
+                        c.sent_at = event.ts.clone();
+                    }
+                    if comments.iter().any(|x| x.id == c.id) {
+                        tracing::warn!(
+                            "review_comment_sent replays id {} on run {}; keeping the first",
+                            c.id,
+                            event.run_id
+                        );
+                        return;
+                    }
+                    comments.push(c);
+                }
+                Err(e) => tracing::warn!(
+                    "review_comment_sent carries an unreadable payload ({payload}): {e}; skipped"
+                ),
+            }
+        }
+        EventKind::ReviewCommentReplied => {
+            let Some(id) = payload.get("id").and_then(|v| v.as_str()) else {
+                return;
+            };
+            let Some(c) = comments.iter_mut().find(|c| c.id == id) else {
+                tracing::warn!("review_comment_replied names unknown comment {id}; skipped");
+                return;
+            };
+            c.replies.push(ReviewReply {
+                author: payload
+                    .get("author")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("agent")
+                    .to_string(),
+                text: payload
+                    .get("text")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_default()
+                    .to_string(),
+                at: event.ts.clone(),
+                proposes_resolution: payload
+                    .get("proposes_resolution")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false),
+            });
+        }
+        EventKind::ReviewCommentResolved | EventKind::ReviewCommentReopened => {
+            let Some(id) = payload.get("id").and_then(|v| v.as_str()) else {
+                return;
+            };
+            let Some(c) = comments.iter_mut().find(|c| c.id == id) else {
+                tracing::warn!("{:?} names unknown comment {id}; skipped", event.kind);
+                return;
+            };
+            c.status = if event.kind == EventKind::ReviewCommentResolved {
+                ReviewCommentStatus::Resolved
+            } else {
+                ReviewCommentStatus::Sent
+            };
+        }
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sent(id: &str, line: i64) -> ReviewComment {
+        ReviewComment {
+            id: id.into(),
+            path: "frontend/src/pages/ReviewPage.tsx".into(),
+            side: ReviewSide::New,
+            line,
+            from_ref: "fork".into(),
+            to_ref: "tip".into(),
+            from_sha: Some("a1b2c3d4e5f6a7b8".into()),
+            to_sha: Some("d4e5f6a7b8c9d0e1".into()),
+            text: "`canSend` should be false\nwhile sending.".into(),
+            excerpt: excerpt("l1\nl2\nl3\nl4\nl5\nl6", line, 2),
+            author: "user".into(),
+            sent_at: "2026-09-09T10:00:00.000Z".into(),
+            batch_id: Some("b1".into()),
+            status: ReviewCommentStatus::Sent,
+            replies: vec![],
+        }
+    }
+
+    fn ev(kind: EventKind, payload: serde_json::Value) -> Event {
+        Event {
+            id: None,
+            run_id: "r1".into(),
+            ts: "2026-09-09T10:00:00.000Z".into(),
+            kind,
+            node_id: None,
+            iter: None,
+            payload: Some(payload),
+        }
+    }
+
+    #[test]
+    fn ids_are_sequential_and_padded() {
+        assert_eq!(comment_id(1), "rc-001");
+        assert_eq!(comment_id(42), "rc-042");
+        assert_eq!(comment_id(1000), "rc-1000");
+    }
+
+    #[test]
+    fn excerpt_marks_the_line_and_clamps_at_the_edges() {
+        let e = excerpt("a\nb\nc\nd\ne", 2, 2);
+        assert_eq!(e, "  1 | a\n> 2 | b\n  3 | c\n  4 | d");
+        let tail = excerpt("a\nb\nc", 3, 1);
+        assert_eq!(tail, "  2 | b\n> 3 | c");
+        assert_eq!(excerpt("a\nb", 5, 2), "");
+        assert_eq!(excerpt("a\nb", 0, 2), "");
+    }
+
+    #[test]
+    fn batch_message_is_one_message_with_ids_anchors_refs_excerpts_and_reply_instruction() {
+        let msg = batch_message(
+            "run-1",
+            "Fork point",
+            "Run tip",
+            &[sent("rc-001", 3), sent("rc-002", 5)],
+        );
+        assert!(msg.starts_with("Review comments — 2 new on Run run-1 (Fork point → Run tip)."));
+        assert!(msg.contains("[rc-001] frontend/src/pages/ReviewPage.tsx:R3 · new side · fork → tip (a1b2c3d → d4e5f6a)"));
+        assert!(msg.contains("[rc-002] frontend/src/pages/ReviewPage.tsx:R5"));
+        assert!(msg.contains("    > 3 | l3"), "excerpt with marker: {msg}");
+        assert!(msg.contains("  `canSend` should be false\n  while sending."));
+        assert!(msg.contains("pdo review reply <id> --text"));
+        assert!(msg.contains("pdo review list"));
+        assert!(msg.contains("immutable"));
+    }
+
+    #[test]
+    fn fold_appends_sent_comments_and_ignores_replays() {
+        let mut list = vec![];
+        let c = sent("rc-001", 3);
+        fold(
+            &mut list,
+            &ev(
+                EventKind::ReviewCommentSent,
+                serde_json::to_value(&c).unwrap(),
+            ),
+        );
+        fold(
+            &mut list,
+            &ev(
+                EventKind::ReviewCommentSent,
+                serde_json::to_value(&c).unwrap(),
+            ),
+        );
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0], c);
+    }
+
+    #[test]
+    fn fold_fills_sent_at_from_the_event_when_absent_and_skips_garbage() {
+        let mut list = vec![];
+        let mut v = serde_json::to_value(sent("rc-001", 3)).unwrap();
+        v["sent_at"] = serde_json::json!("");
+        fold(&mut list, &ev(EventKind::ReviewCommentSent, v));
+        assert_eq!(list[0].sent_at, "2026-09-09T10:00:00.000Z");
+        fold(
+            &mut list,
+            &ev(
+                EventKind::ReviewCommentSent,
+                serde_json::json!({ "nope": 1 }),
+            ),
+        );
+        assert_eq!(list.len(), 1);
+    }
+
+    #[test]
+    fn fold_replies_resolves_and_reopens_by_id() {
+        let mut list = vec![];
+        fold(
+            &mut list,
+            &ev(
+                EventKind::ReviewCommentSent,
+                serde_json::to_value(sent("rc-001", 3)).unwrap(),
+            ),
+        );
+        fold(
+            &mut list,
+            &ev(
+                EventKind::ReviewCommentReplied,
+                serde_json::json!({ "id": "rc-001", "author": "manager", "text": "done", "proposes_resolution": true }),
+            ),
+        );
+        assert_eq!(list[0].replies.len(), 1);
+        assert_eq!(list[0].replies[0].author, "manager");
+        assert!(list[0].replies[0].proposes_resolution);
+        fold(
+            &mut list,
+            &ev(
+                EventKind::ReviewCommentResolved,
+                serde_json::json!({ "id": "rc-001" }),
+            ),
+        );
+        assert_eq!(list[0].status, ReviewCommentStatus::Resolved);
+        fold(
+            &mut list,
+            &ev(
+                EventKind::ReviewCommentReopened,
+                serde_json::json!({ "id": "rc-001" }),
+            ),
+        );
+        assert_eq!(list[0].status, ReviewCommentStatus::Sent);
+        // Unknown id: ignored, never a panic.
+        fold(
+            &mut list,
+            &ev(
+                EventKind::ReviewCommentReplied,
+                serde_json::json!({ "id": "rc-999", "text": "x" }),
+            ),
+        );
+        assert_eq!(list[0].replies.len(), 1);
+    }
+
+    #[test]
+    fn serde_round_trip_keeps_the_wire_names() {
+        let v = serde_json::to_value(sent("rc-001", 3)).unwrap();
+        assert_eq!(v["side"], "new");
+        assert_eq!(v["status"], "sent");
+        assert!(v.get("replies").is_none(), "empty replies are skipped");
+        let back: ReviewComment = serde_json::from_value(v).unwrap();
+        assert_eq!(back.side, ReviewSide::New);
+    }
+}

--- a/crates/pdo-daemon/src/run_refs.rs
+++ b/crates/pdo-daemon/src/run_refs.rs
@@ -317,7 +317,12 @@ pub(crate) enum Resolved {
 }
 
 /// Resolve a stable ref id against the Run's log. Pure: no git call.
-pub(crate) fn resolve_id(run_id: &str, run_state: &RunState, events: &[Event], id: &str) -> Resolved {
+pub(crate) fn resolve_id(
+    run_id: &str,
+    run_state: &RunState,
+    events: &[Event],
+    id: &str,
+) -> Resolved {
     if id == FORK_ID {
         return Resolved::Git(fork_base(run_state).to_string());
     }
@@ -500,7 +505,10 @@ mod tests {
         assert_eq!(refs.deliveries[0].node_name, "Design");
         assert_eq!(refs.deliveries[0].status, DeliveryStatus::Delivered);
         assert_eq!(refs.deliveries[0].before, "node:design:1:before");
-        assert_eq!(refs.deliveries[0].after.as_deref(), Some("node:design:1:after"));
+        assert_eq!(
+            refs.deliveries[0].after.as_deref(),
+            Some("node:design:1:after")
+        );
         assert_eq!(refs.deliveries[2].status, DeliveryStatus::Running);
         assert_eq!(refs.deliveries[2].before, "tip");
         assert_eq!(refs.deliveries[2].live.as_deref(), Some("live:review"));
@@ -536,7 +544,13 @@ mod tests {
         assert_eq!(design_after.sha.as_deref(), Some("eee5"));
         // Still first among the deliveries.
         assert_eq!(refs.deliveries[0].node_id, "design");
-        assert_eq!(refs.deliveries.iter().filter(|d| d.node_id == "design").count(), 1);
+        assert_eq!(
+            refs.deliveries
+                .iter()
+                .filter(|d| d.node_id == "design")
+                .count(),
+            1
+        );
     }
 
     #[test]
@@ -598,7 +612,10 @@ mod tests {
         assert!(is_default_pair(Some("fork"), Some("tip")));
         assert!(is_default_pair(Some("fork"), None));
         assert!(!is_default_pair(Some("tip"), Some("fork")));
-        assert!(!is_default_pair(Some("node:a:1:before"), Some("node:a:1:after")));
+        assert!(!is_default_pair(
+            Some("node:a:1:before"),
+            Some("node:a:1:after")
+        ));
         assert!(!is_default_pair(None, Some("abc123")));
     }
 }

--- a/crates/pdo-daemon/src/tmux_session_manager.rs
+++ b/crates/pdo-daemon/src/tmux_session_manager.rs
@@ -1101,6 +1101,45 @@ pub fn send_keys(socket: &str, session_name: &str, text: &str) {
         .output();
 }
 
+/// Paste a **multi-line** message into a tmux session as one bracketed paste,
+/// then submit it with Enter (#750, the review batch to the manager).
+///
+/// `send_keys` types its text as keystrokes, so an embedded newline is a
+/// keystroke too — for a chat harness that is a premature submit, and a
+/// twenty-comment batch would arrive as twenty half-messages. `load-buffer`
+/// from stdin + `paste-buffer -p` hands the whole text over as a paste the
+/// harness keeps as one message. Best-effort — a missing session is not an
+/// error here (the caller verified it exists).
+pub fn paste_text(socket: &str, session_name: &str, text: &str) {
+    use std::io::Write;
+    let buffer = format!("pdo-paste-{}", std::process::id());
+    let child = tmux(socket)
+        .args(["load-buffer", "-b", &buffer, "-"])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn();
+    let Ok(mut child) = child else { return };
+    if let Some(mut stdin) = child.stdin.take() {
+        let _ = stdin.write_all(text.as_bytes());
+    }
+    let _ = child.wait();
+    let _ = tmux(socket)
+        .args([
+            "paste-buffer",
+            "-p",
+            "-d",
+            "-b",
+            &buffer,
+            "-t",
+            session_name,
+        ])
+        .output();
+    let _ = tmux(socket)
+        .args(["send-keys", "-t", session_name, "Enter"])
+        .output();
+}
+
 /// Kill a tmux session. Best-effort — does not fail if the session is absent.
 pub fn kill(socket: &str, session_name: &str) {
     let _ = tmux(socket)

--- a/crates/pdo-daemon/tests/it.rs
+++ b/crates/pdo-daemon/tests/it.rs
@@ -142,6 +142,9 @@ mod retry_loop_member;
 #[path = "run_diff_range.rs"]
 mod run_diff_range;
 
+#[path = "review_comments.rs"]
+mod review_comments;
+
 #[path = "run_naming.rs"]
 mod run_naming;
 

--- a/crates/pdo-daemon/tests/review_comments.rs
+++ b/crates/pdo-daemon/tests/review_comments.rs
@@ -1,0 +1,319 @@
+//! Layer 3 — review comments over a real daemon (#750, ADR-0067 §2–3).
+//!
+//! Closes the backend ACs end-to-end against a booted daemon: `POST
+//! /runs/<id>/review/comments/send` turns a batch of drafts into `sent`
+//! comments that
+//!   - land as `review_comment_sent` events in the Run's log, one per comment,
+//!     with sequential `rc-NNN` ids and a shared batch id,
+//!   - are projected into `GET /runs/<id>` (`review_comments`) and listed by
+//!     `GET /runs/<id>/review/comments`, with the hunk excerpt and the SHAs,
+//!   - are pushed over the WebSocket (the browser refreshes from them),
+//!   - **start the manager on demand** (its tmux session exists after the send),
+//!   - and are refused with `run_branch_gone` once the Run branch is deleted,
+//!     leaving the log untouched.
+//!
+//! The entry node runs under `exec sleep 600`, so the Run stays live with its
+//! branch and worktree in place; the manager session is spawned by the daemon
+//! under the same override (a sleeping pane — the paste is best-effort and lands
+//! in it harmlessly).
+
+use crate::common::{ws_text, TestDaemon};
+use futures_util::StreamExt;
+
+const PIPELINE_NAME: &str = "review-solo";
+const PIPELINE_YAML: &str = r#"name: review-solo
+version: "1.0"
+nodes:
+  - id: start
+    name: Start
+    type: start
+    outputs:
+      - name: user_prompt
+  - id: solo
+    name: solo
+    type: agent
+    isolated_worktree: false
+    inputs:
+      - name: in
+    outputs:
+      - name: out
+  - id: end
+    name: End
+    type: end
+    inputs:
+      - name: result
+edges:
+  - source: { node: start, port: user_prompt }
+    target: { node: solo, port: in }
+"#;
+
+fn seed(repo: &std::path::Path) -> anyhow::Result<()> {
+    let pipelines_dir = repo.join(".pdo").join("pipelines");
+    std::fs::create_dir_all(&pipelines_dir)?;
+    std::fs::write(
+        pipelines_dir.join(format!("{PIPELINE_NAME}.yaml")),
+        PIPELINE_YAML,
+    )?;
+    let run = |args: &[&str]| -> anyhow::Result<()> {
+        let out = std::process::Command::new("git")
+            .args(args)
+            .current_dir(repo)
+            .output()?;
+        if !out.status.success() {
+            anyhow::bail!(
+                "git {:?} failed: {}",
+                args,
+                String::from_utf8_lossy(&out.stderr)
+            );
+        }
+        Ok(())
+    };
+    run(&["init", "-q", "-b", "main"])?;
+    run(&["config", "user.email", "test@example.com"])?;
+    run(&["config", "user.name", "Test"])?;
+    run(&["config", "commit.gpgsign", "false"])?;
+    std::fs::write(repo.join(".gitignore"), ".pdo/runs/\n")?;
+    std::fs::write(repo.join("lib.rs"), "fn a() {}\nfn b() {}\nfn c() {}\n")?;
+    run(&["add", "."])?;
+    run(&["commit", "-q", "-m", "init"])?;
+    Ok(())
+}
+
+async fn create_run(daemon_url: String, target_repo: String) -> Option<String> {
+    let resp = reqwest::Client::new()
+        .post(format!("{daemon_url}/runs"))
+        .json(&serde_json::json!({
+            "pipeline": PIPELINE_NAME,
+            "input": "go",
+            "target_repo": target_repo,
+        }))
+        .send()
+        .await
+        .ok()?;
+    let json: serde_json::Value = resp.json().await.ok()?;
+    json["run_id"].as_str().map(String::from)
+}
+
+fn git(dir: &std::path::Path, args: &[&str]) -> std::process::Output {
+    let out = std::process::Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    out
+}
+
+#[tokio::test]
+async fn sent_comments_are_events_projected_pushed_and_start_the_manager() {
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+    let repo = daemon.repo_root().to_path_buf();
+    let run_id = create_run(daemon.url(), daemon.target_repo())
+        .await
+        .expect("run created");
+
+    let wt_dir = repo.join(".pdo/runs").join(&run_id).join("worktree");
+    for _ in 0..100 {
+        if wt_dir.exists() {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+    assert!(
+        wt_dir.exists(),
+        "pipeline worktree should exist for {run_id}"
+    );
+
+    // A real change on the Run branch: lib.rs gains a line 4 the reviewer comments on.
+    std::fs::write(
+        wt_dir.join("lib.rs"),
+        "fn a() {}\nfn b() {}\nfn c() {}\nfn d() {}\n",
+    )
+    .unwrap();
+    git(&wt_dir, &["add", "lib.rs"]);
+    git(&wt_dir, &["commit", "-q", "-m", "run work"]);
+
+    let mut ws = daemon.connect_ws().await.unwrap();
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .post(format!("{}/runs/{run_id}/review/comments/send", daemon.url()))
+        .json(&serde_json::json!({
+            "comments": [
+                { "path": "lib.rs", "side": "new", "line": 4, "text": "Name this `fn delta`." },
+                { "path": "lib.rs", "side": "old", "line": 1, "from": "fork", "to": "tip", "text": "Still needed?" }
+            ]
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        200,
+        "{}",
+        resp.text().await.unwrap_or_default()
+    );
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(
+        body["manager_started"], true,
+        "the manager was started on demand: {body}"
+    );
+    let sent = body["sent"].as_array().unwrap();
+    assert_eq!(sent.len(), 2);
+    assert_eq!(sent[0]["id"], "rc-001");
+    assert_eq!(sent[1]["id"], "rc-002");
+    assert_eq!(sent[0]["batch_id"], sent[1]["batch_id"]);
+    assert_eq!(sent[0]["from_ref"], "fork");
+    assert_eq!(sent[0]["to_ref"], "tip");
+    assert!(sent[0]["from_sha"].as_str().unwrap().len() == 40, "{body}");
+    assert!(sent[0]["to_sha"].as_str().unwrap().len() == 40, "{body}");
+    assert_ne!(sent[0]["from_sha"], sent[0]["to_sha"]);
+    let excerpt = sent[0]["excerpt"].as_str().unwrap();
+    assert!(
+        excerpt.contains("> 4 | fn d() {}"),
+        "excerpt marks the anchored line: {excerpt}"
+    );
+    assert!(
+        excerpt.contains("  2 | fn b() {}"),
+        "two lines of context: {excerpt}"
+    );
+    // The old side reads the source ref: line 1 of the fork's lib.rs.
+    assert!(
+        sent[1]["excerpt"]
+            .as_str()
+            .unwrap()
+            .contains("> 1 | fn a() {}"),
+        "{body}"
+    );
+
+    // The manager session exists — spawned by the send.
+    let socket = daemon.tmux_socket();
+    let session = format!("pdo-mgr-{run_id}");
+    let exists = std::process::Command::new("tmux")
+        .args(["-L", &socket, "has-session", "-t", &session])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    assert!(
+        exists,
+        "manager session {session} should be up after the send"
+    );
+
+    // Projected into the Run state, listed on its own endpoint, in the log.
+    let run: serde_json::Value = client
+        .get(format!("{}/runs/{run_id}", daemon.url()))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(run["review_comments"].as_array().unwrap().len(), 2);
+    assert_eq!(run["review_comments"][0]["status"], "sent");
+    assert_eq!(run["review_comments"][0]["text"], "Name this `fn delta`.");
+    assert_eq!(run["has_manager"], true);
+
+    let list: serde_json::Value = client
+        .get(format!("{}/runs/{run_id}/review/comments", daemon.url()))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(list["comments"].as_array().unwrap().len(), 2);
+
+    let events: Vec<serde_json::Value> = client
+        .get(format!("{}/runs/{run_id}/events", daemon.url()))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let sent_events: Vec<&serde_json::Value> = events
+        .iter()
+        .filter(|e| e["kind"] == "review_comment_sent")
+        .collect();
+    assert_eq!(sent_events.len(), 2, "one event per comment");
+    assert!(
+        events.iter().any(|e| e["kind"] == "manager_started"),
+        "the on-demand start reserved its session in the log"
+    );
+
+    // Pushed over the WebSocket: the browser sees `review_comment_sent` for this run.
+    let mut seen = false;
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+    while tokio::time::Instant::now() < deadline && !seen {
+        let next = tokio::time::timeout(std::time::Duration::from_millis(500), ws.next()).await;
+        let Ok(Some(Ok(msg))) = next else { continue };
+        if let Some(text) = ws_text(&msg) {
+            if text.contains("review_comment_sent") && text.contains(&run_id) {
+                seen = true;
+            }
+        }
+    }
+    assert!(seen, "the WebSocket carried the review_comment_sent event");
+
+    // A second batch continues the id sequence.
+    let resp = client
+        .post(format!(
+            "{}/runs/{run_id}/review/comments/send",
+            daemon.url()
+        ))
+        .json(&serde_json::json!({
+            "comments": [{ "path": "lib.rs", "side": "new", "line": 2, "text": "third" }]
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["sent"][0]["id"], "rc-003");
+    assert_eq!(
+        body["manager_started"], false,
+        "already running: reused, not respawned"
+    );
+
+    // Branch gone ⇒ refused with the reason, nothing appended.
+    git(
+        &repo,
+        &["worktree", "remove", "--force", wt_dir.to_str().unwrap()],
+    );
+    git(&repo, &["branch", "-D", &format!("pdo/run-{run_id}")]);
+    let resp = client
+        .post(format!(
+            "{}/runs/{run_id}/review/comments/send",
+            daemon.url()
+        ))
+        .json(&serde_json::json!({
+            "comments": [{ "path": "lib.rs", "side": "new", "line": 2, "text": "late" }]
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 409);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["error"], "run_branch_gone");
+    assert!(body["message"]
+        .as_str()
+        .unwrap()
+        .contains("no longer exists"));
+    let list: serde_json::Value = client
+        .get(format!("{}/runs/{run_id}/review/comments", daemon.url()))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(
+        list["comments"].as_array().unwrap().len(),
+        3,
+        "the refused one was not recorded"
+    );
+}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,4 +1,8 @@
-import type { PipelineListEntry, PipelineDetail, PipelineDef, RunListEntry, RunState, PortDef, PortSide, PortType, FrontmatterFieldDecl, FrontmatterViolation, Trigger, TriggerFire, DaemonStatus, InstanceSettings, UpdateSettingsRequest, StatsOverview, StatsCost, StatsPerformance, SandboxProfile, SandboxProfileImage, SandboxProfileReferents, SyncCostPricesReport, UpdateStatus, UpdateChangelog, UpdateApplyResponse, Project, BranchRef, AgentChoice, AgentProfile, AgentProfileReferents, ProvisioningPlan, ProvisioningRules, Skill, SkillBank, SkillDetail, SkillFile, SkillFileContent, SkillFilesUpload, SkillFolder, SkillReferents, SkillRef, SkillScanResult, SkillImportItem, SkillImportReport, SkillRescanReport, RecentSkillSource, StructuredDiff, RunRefs } from "./types";
+import type { PipelineListEntry, PipelineDetail, PipelineDef, RunListEntry, RunState, PortDef, PortSide, PortType, FrontmatterFieldDecl, FrontmatterViolation, Trigger, TriggerFire, DaemonStatus, InstanceSettings, UpdateSettingsRequest, StatsOverview, StatsCost, StatsPerformance, SandboxProfile, SandboxProfileImage, SandboxProfileReferents, SyncCostPricesReport, UpdateStatus, UpdateChangelog, UpdateApplyResponse, Project, BranchRef, AgentChoice, AgentProfile, AgentProfileReferents, ProvisioningPlan, ProvisioningRules, Skill, SkillBank, SkillDetail, SkillFile, SkillFileContent, SkillFilesUpload, SkillFolder, SkillReferents, SkillRef, SkillScanResult, SkillImportItem, SkillImportReport, SkillRescanReport, RecentSkillSource, StructuredDiff, RunRefs,
+  ReviewComment,
+  SendReviewCommentInput,
+  SendReviewCommentsResponse,
+} from "./types";
 import { foldHarnessOntoNode } from "./lib/harness";
 
 const BASE = "";
@@ -382,6 +386,26 @@ export function fetchRun(runId: string): Promise<RunState> {
 
 export function fetchRunEvents(runId: string): Promise<unknown[]> {
   return request<unknown[]>("GET", `/runs/${encodeURIComponent(runId)}/events`);
+}
+
+/** #750: the Run's sent review comments, on their own endpoint. */
+export function fetchReviewComments(runId: string): Promise<{ comments: ReviewComment[] }> {
+  return request<{ comments: ReviewComment[] }>("GET", `/runs/${encodeURIComponent(runId)}/review/comments`);
+}
+
+/**
+ * #750: send a batch of drafts to the manager — one message for the batch, the
+ * manager started on demand. A `409 run_branch_gone` (branch deleted / archived
+ * Run) surfaces as an `ApiError` whose message is the daemon's reason.
+ */
+export function sendReviewComments(
+  runId: string,
+  comments: SendReviewCommentInput[],
+): Promise<SendReviewCommentsResponse> {
+  return request<SendReviewCommentsResponse>("POST", `/runs/${encodeURIComponent(runId)}/review/comments/send`, {
+    body: { comments },
+    label: "Send review comments",
+  });
 }
 
 /** Refusal slugs this client knows how to phrase (#490, ADR-0035 §3). */

--- a/frontend/src/components/DiffTab.tsx
+++ b/frontend/src/components/DiffTab.tsx
@@ -11,6 +11,7 @@ import {
 import { fetchRunStructuredDiff } from "../api";
 import { wordDiff } from "../lib/wordDiff";
 import { reviewUrl } from "../lib/runRefs";
+import { pendingCount } from "../lib/reviewComments";
 import {
   LARGE_DIFF_FILES,
   TRUNCATE_LINES,
@@ -271,6 +272,17 @@ export default function DiffTab({ run, collapsed, onCollapsedChange }: Props) {
           >
             <SquareArrowOutUpRight size={11} />
             Expand and comment
+            {pendingCount(run.review_comments) > 0 && (
+              // #750: pending review comments (sent, not resolved) — CONTEXT.md « Accès rapide Review ».
+              <span
+                className="ml-0.5 inline-flex h-[14px] items-center rounded-[7px] bg-st-running-bg px-[5px] font-medium text-st-running"
+                style={{ fontSize: "9.5px" }}
+                title={`${pendingCount(run.review_comments)} review comment(s) awaiting the manager`}
+                data-testid="diff-review-pending"
+              >
+                {pendingCount(run.review_comments)}
+              </span>
+            )}
           </a>
         </span>
       </div>

--- a/frontend/src/components/review/CommentCard.tsx
+++ b/frontend/src/components/review/CommentCard.tsx
@@ -1,0 +1,210 @@
+import { Lock, Pencil, Trash2 } from "lucide-react";
+import Markdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import type { ReviewEntry } from "../../lib/reviewComments";
+import { anchorLabel, relativeTime } from "../../lib/reviewComments";
+
+/**
+ * One review comment rendered under its diff line (#750): a **draft** card
+ * (amber `✎ Draft`, edit / delete on hover, footer "Only in this browser until
+ * sent" + `↗ Send to manager` always visible), a **sending** card (greyed,
+ * spinner, "starting the manager…" when the send has to start it), or a
+ * **sent** card (blue `↗ Sent`, lock, footer `rc-002 · fork → tip · Awaiting
+ * manager reply` — the slot where #751's replies land). No edit, no delete on
+ * a sent comment: it is a Run event.
+ */
+
+interface Props {
+  entry: ReviewEntry;
+  /** True while this draft travels in a send. */
+  sending: boolean;
+  /** The send is starting the manager first (message nuance while sending). */
+  startingManager: boolean;
+  /** Labels of the pair for the sent footer (`Fork point → Run tip`). */
+  pairLabel: string;
+  sendDisabledReason: string | null;
+  onEdit: () => void;
+  onDelete: () => void;
+  onSend: () => void;
+}
+
+const REMARK_PLUGINS = [remarkGfm];
+
+export default function CommentCard({
+  entry,
+  sending,
+  startingManager,
+  pairLabel,
+  sendDisabledReason,
+  onEdit,
+  onDelete,
+  onSend,
+}: Props) {
+  const label = anchorLabel(entry.anchor);
+  const body = (text: string) => (
+    <div
+      className="artifact-markdown px-2.5 py-2 text-fg [&_ol]:list-decimal [&_ol]:pl-5 [&_ul]:list-disc [&_ul]:pl-5"
+      style={{ fontSize: "11.5px", lineHeight: 1.5 }}
+      data-testid="review-comment-body"
+    >
+      <Markdown remarkPlugins={REMARK_PLUGINS}>{text}</Markdown>
+    </div>
+  );
+
+  if (entry.kind === "sent") {
+    const c = entry.comment;
+    return (
+      <div
+        className="group my-2 ml-3 mr-3 max-w-[720px] overflow-hidden rounded-md border border-line-strong bg-bg-2 font-sans"
+        style={{ fontSize: "11px", whiteSpace: "normal" }}
+        data-testid="review-comment"
+        data-state={c.status}
+        data-anchor={label}
+        data-comment-id={c.id}
+      >
+        <div
+          className="flex items-center gap-2 border-b border-line px-2.5 py-[5px] text-fg-3"
+          style={{ fontSize: "10.5px", background: "rgba(59,130,246,.07)" }}
+        >
+          <Badge kind="sent">↗ Sent</Badge>
+          <span className="font-medium text-fg-2">{c.author === "user" ? "you" : c.author}</span>
+          <span className="font-mono text-fg-4" style={{ fontSize: "10px" }}>
+            {label}
+          </span>
+          <span className="text-fg-4">· {relativeTime(c.sent_at)}</span>
+          <span
+            className="ml-auto grid h-5 w-[22px] cursor-help place-items-center text-fg-4"
+            title="Sent comments are Run events: immutable, readable post-mortem. Replies and Resolve/Reopen arrive with the next ticket."
+            data-testid="review-comment-lock"
+          >
+            <Lock size={11} />
+          </span>
+        </div>
+        {body(c.text)}
+        <div className="flex items-center gap-2 border-t border-line px-2.5 py-[5px] text-fg-4" style={{ fontSize: "10px" }}>
+          <span className="font-mono" data-testid="review-comment-id">
+            {c.id}
+          </span>
+          <span>· {pairLabel}</span>
+          <span className="ml-auto inline-flex items-center gap-1.5">
+            {c.status === "resolved" ? (
+              <span className="text-st-done">Resolved</span>
+            ) : (
+              <>
+                <Spinner dim />
+                Awaiting manager reply
+              </>
+            )}
+          </span>
+        </div>
+      </div>
+    );
+  }
+
+  const d = entry.draft;
+  if (sending) {
+    return (
+      <div
+        className="my-2 ml-3 mr-3 max-w-[720px] overflow-hidden rounded-md border border-line-strong bg-bg-2 font-sans opacity-70"
+        style={{ fontSize: "11px", whiteSpace: "normal" }}
+        data-testid="review-comment"
+        data-state="sending"
+        data-anchor={label}
+      >
+        <div className="flex items-center gap-2 border-b border-line bg-bg-3 px-2.5 py-[5px] text-fg-3" style={{ fontSize: "10.5px" }}>
+          <Badge kind="sent">
+            <Spinner /> Sending
+          </Badge>
+          <span className="font-medium text-fg-2">you</span>
+          <span className="font-mono text-fg-4" style={{ fontSize: "10px" }}>
+            {label}
+          </span>
+          <span className="text-fg-4">· {startingManager ? "starting the manager…" : "handing over…"}</span>
+        </div>
+        {body(d.text)}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="group my-2 ml-3 mr-3 max-w-[720px] overflow-hidden rounded-md border border-line-strong bg-bg-2 font-sans"
+      style={{ fontSize: "11px", whiteSpace: "normal" }}
+      data-testid="review-comment"
+      data-state="draft"
+      data-anchor={label}
+    >
+      <div className="flex items-center gap-2 border-b border-line bg-bg-3 px-2.5 py-[5px] text-fg-3" style={{ fontSize: "10.5px" }}>
+        <Badge kind="draft">✎ Draft</Badge>
+        <span className="font-medium text-fg-2">you</span>
+        <span className="font-mono text-fg-4" style={{ fontSize: "10px" }}>
+          {label}
+        </span>
+        <span className="text-fg-4">· {relativeTime(d.updated_at)}</span>
+        <span className="ml-auto inline-flex gap-0.5 opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100">
+          <button
+            type="button"
+            onClick={onEdit}
+            title="Edit draft"
+            data-testid="review-comment-edit"
+            className="grid h-5 w-[22px] cursor-pointer place-items-center rounded text-fg-4 hover:bg-bg-4 hover:text-fg-2"
+          >
+            <Pencil size={11} />
+          </button>
+          <button
+            type="button"
+            onClick={onDelete}
+            title="Delete draft"
+            data-testid="review-comment-delete"
+            className="grid h-5 w-[22px] cursor-pointer place-items-center rounded text-fg-4 hover:bg-bg-4 hover:text-st-failed"
+          >
+            <Trash2 size={11} />
+          </button>
+        </span>
+      </div>
+      {body(d.text)}
+      <div className="flex items-center gap-2 border-t border-line px-2.5 py-[5px] text-fg-4" style={{ fontSize: "10px" }}>
+        <span>Only in this browser until sent.</span>
+        <span className="ml-auto">
+          <button
+            type="button"
+            onClick={onSend}
+            disabled={!!sendDisabledReason}
+            title={sendDisabledReason ?? "Send this comment to the manager (one message)"}
+            data-testid="review-comment-send"
+            className="cursor-pointer rounded border border-line-strong bg-bg-3 px-2 py-0.5 text-fg-2 hover:bg-bg-4 hover:text-fg disabled:cursor-not-allowed disabled:opacity-45"
+            style={{ fontSize: "10.5px" }}
+          >
+            ↗ Send to manager
+          </button>
+        </span>
+      </div>
+    </div>
+  );
+}
+
+/** The amber (draft) / blue (sent) pill the badges, sidebar and headers share. */
+export function Badge({ kind, children, title }: { kind: "draft" | "sent"; children: React.ReactNode; title?: string }) {
+  return (
+    <span
+      title={title}
+      className={`inline-flex h-[14px] items-center gap-[3px] rounded-[7px] px-[5px] font-medium ${
+        kind === "draft" ? "bg-st-await-bg text-st-await" : "bg-st-running-bg text-st-running"
+      }`}
+      style={{ fontSize: "9.5px" }}
+      data-testid={`review-badge-${kind}`}
+    >
+      {children}
+    </span>
+  );
+}
+
+export function Spinner({ dim }: { dim?: boolean }) {
+  return (
+    <span
+      aria-hidden
+      className="inline-block h-[9px] w-[9px] animate-spin rounded-full border-[1.5px] border-fg-4"
+      style={{ borderTopColor: dim ? "var(--color-fg-3)" : "var(--color-st-running)" }}
+    />
+  );
+}

--- a/frontend/src/components/review/CommentEditor.tsx
+++ b/frontend/src/components/review/CommentEditor.tsx
@@ -1,0 +1,202 @@
+import { useEffect, useRef, useState } from "react";
+import Markdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import type { Anchor } from "../../lib/reviewComments";
+import { anchorLabel, sideLabel } from "../../lib/reviewComments";
+
+/**
+ * The inline comment editor of the Review page (#750), opened under a diff line
+ * from the `+` widget (new comment) or from a draft card (edit). Draft-first:
+ * **Save draft** is the primary action (⌘/Ctrl+Enter), **Send now** the quick
+ * path for a single remark, **Cancel** (Esc) closes. Write | Preview tabs render
+ * the markdown the manager will read.
+ *
+ * The half-typed text is mirrored to `sessionStorage` under `wipKey` on every
+ * keystroke and cleared on save/cancel, so a stray reload never loses a remark.
+ */
+
+interface Props {
+  anchor: Anchor;
+  /** Editing an existing draft: its current text. */
+  initial?: string;
+  /** The sessionStorage key of the work-in-progress text. */
+  wipKey: string;
+  /** Null when sending is allowed; else the reason shown as the button's title. */
+  sendDisabledReason: string | null;
+  onSave: (text: string) => void;
+  onSend: (text: string) => void;
+  onCancel: () => void;
+}
+
+const REMARK_PLUGINS = [remarkGfm];
+
+function readWip(key: string): string {
+  try {
+    return sessionStorage.getItem(key) ?? "";
+  } catch {
+    return "";
+  }
+}
+
+function writeWip(key: string, text: string): void {
+  try {
+    if (text) sessionStorage.setItem(key, text);
+    else sessionStorage.removeItem(key);
+  } catch {
+    // ignore
+  }
+}
+
+export default function CommentEditor({ anchor, initial, wipKey, sendDisabledReason, onSave, onSend, onCancel }: Props) {
+  const [text, setText] = useState<string>(() => initial ?? readWip(wipKey));
+  const [tab, setTab] = useState<"write" | "preview">("write");
+  const ref = useRef<HTMLTextAreaElement | null>(null);
+  const editing = initial !== undefined;
+
+  useEffect(() => {
+    const t = window.setTimeout(() => ref.current?.focus(), 0);
+    return () => window.clearTimeout(t);
+  }, []);
+
+  const change = (v: string) => {
+    setText(v);
+    writeWip(wipKey, v);
+  };
+  const clearWip = () => writeWip(wipKey, "");
+  const canSubmit = text.trim().length > 0;
+
+  const save = () => {
+    if (!canSubmit) return;
+    clearWip();
+    onSave(text);
+  };
+  const send = () => {
+    if (!canSubmit || sendDisabledReason) return;
+    clearWip();
+    onSend(text);
+  };
+  const cancel = () => {
+    clearWip();
+    onCancel();
+  };
+
+  return (
+    <div
+      className="my-2 ml-3 mr-3 max-w-[720px] overflow-hidden rounded-md border border-line-strong bg-bg-2 font-sans"
+      style={{ fontSize: "11px", whiteSpace: "normal" }}
+      data-testid="review-comment-editor"
+      data-anchor={anchorLabel(anchor)}
+    >
+      <div className="flex items-center gap-2 border-b border-line bg-bg-3 px-2.5 py-[5px] text-fg-3" style={{ fontSize: "10.5px" }}>
+        <span className="font-medium text-fg-2">{editing ? "Edit draft" : "New comment"}</span>
+        <span className="font-mono text-fg-4" style={{ fontSize: "10px" }}>
+          {anchorLabel(anchor)} · {sideLabel(anchor.side)}
+        </span>
+        <span className="ml-auto inline-flex overflow-hidden rounded border border-line-strong" role="tablist">
+          <button
+            type="button"
+            role="tab"
+            aria-selected={tab === "write"}
+            onClick={() => setTab("write")}
+            data-testid="review-editor-write"
+            className={`cursor-pointer px-2 py-px ${tab === "write" ? "bg-bg-4 text-fg" : "text-fg-3 hover:text-fg-2"}`}
+            style={{ fontSize: "10px" }}
+          >
+            Write
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={tab === "preview"}
+            onClick={() => setTab("preview")}
+            data-testid="review-editor-preview"
+            className={`cursor-pointer border-l border-line-strong px-2 py-px ${tab === "preview" ? "bg-bg-4 text-fg" : "text-fg-3 hover:text-fg-2"}`}
+            style={{ fontSize: "10px" }}
+          >
+            Preview
+          </button>
+        </span>
+      </div>
+
+      {tab === "write" ? (
+        <textarea
+          ref={ref}
+          value={text}
+          onChange={(e) => change(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Escape") {
+              e.preventDefault();
+              e.stopPropagation();
+              cancel();
+            } else if (e.key === "Enter" && (e.metaKey || e.ctrlKey) && !e.nativeEvent.isComposing) {
+              e.preventDefault();
+              save();
+            }
+          }}
+          placeholder="Leave a comment for the manager… Markdown supported."
+          data-testid="review-editor-text"
+          className="block w-full resize-y border-0 border-b border-line bg-bg-1 px-2.5 py-2 text-fg outline-none focus:shadow-[inset_0_-1px_0_var(--color-acc)]"
+          style={{ minHeight: 72, fontSize: "11.5px", lineHeight: 1.5, fontFamily: "inherit" }}
+        />
+      ) : (
+        <div
+          className="artifact-markdown border-b border-line px-2.5 py-2 text-fg [&_ol]:list-decimal [&_ol]:pl-5 [&_ul]:list-disc [&_ul]:pl-5"
+          style={{ minHeight: 72, fontSize: "11.5px", lineHeight: 1.5 }}
+          data-testid="review-editor-preview-body"
+        >
+          {text.trim() ? (
+            <Markdown remarkPlugins={REMARK_PLUGINS}>{text}</Markdown>
+          ) : (
+            <span className="italic text-fg-4">Nothing to preview</span>
+          )}
+        </div>
+      )}
+
+      <div className="flex items-center gap-2 px-2.5 py-[5px] text-fg-4" style={{ fontSize: "10px" }}>
+        <span>
+          <Kbd>⌘↵</Kbd> save draft · <Kbd>Esc</Kbd> cancel · markdown
+        </span>
+        <span className="ml-auto inline-flex gap-1.5">
+          <button
+            type="button"
+            onClick={cancel}
+            data-testid="review-editor-cancel"
+            className="cursor-pointer rounded border border-transparent px-2 py-0.5 text-fg-3 hover:bg-bg-3 hover:text-fg"
+            style={{ fontSize: "10.5px" }}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={send}
+            disabled={!canSubmit || !!sendDisabledReason}
+            title={sendDisabledReason ?? "Save as draft and send this one comment now"}
+            data-testid="review-editor-send"
+            className="cursor-pointer rounded border border-line-strong bg-bg-3 px-2 py-0.5 text-fg-2 hover:bg-bg-4 hover:text-fg disabled:cursor-not-allowed disabled:opacity-45"
+            style={{ fontSize: "10.5px" }}
+          >
+            Send now
+          </button>
+          <button
+            type="button"
+            onClick={save}
+            disabled={!canSubmit}
+            data-testid="review-editor-save"
+            className="cursor-pointer rounded border border-acc bg-acc px-2 py-0.5 font-semibold text-[#04140d] hover:bg-[#14cf92] disabled:cursor-not-allowed disabled:opacity-45"
+            style={{ fontSize: "10.5px" }}
+          >
+            {editing ? "Update draft" : "Save draft"}
+          </button>
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function Kbd({ children }: { children: string }) {
+  return (
+    <kbd className="rounded-[3px] border border-line-strong bg-bg-4 px-1 font-mono text-fg-3" style={{ fontSize: "9.5px" }}>
+      {children}
+    </kbd>
+  );
+}

--- a/frontend/src/components/review/ReviewFileCard.tsx
+++ b/frontend/src/components/review/ReviewFileCard.tsx
@@ -1,16 +1,20 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 import { ChevronDown, ChevronRight, Copy, SquareArrowOutUpRight } from "lucide-react";
-import { DiffView, DiffModeEnum } from "@git-diff-view/react";
-import type { DiffFile } from "../../types";
+import { DiffView, DiffModeEnum, SplitSide } from "@git-diff-view/react";
+import type { DiffFile, ReviewSide } from "../../types";
 import { fetchRunFileAtRef } from "../../api";
 import { baseName, fileHunks, filePath, langOf, statusLetter } from "../../lib/runRefs";
 import type { RefPair, ViewMode } from "../../lib/runRefs";
+import type { Anchor, ReviewEntry } from "../../lib/reviewComments";
+import { entryAt, plural, wipKey } from "../../lib/reviewComments";
+import CommentEditor from "./CommentEditor";
+import CommentCard, { Badge } from "./CommentCard";
 
 /**
  * One file of the Review page (#749): a sticky header (chevron, status letter,
- * `dir/` + basename, `+a −d`, copy path, open at destination ref) and the
- * third-party diff body — split or unified, with GitHub-style `↑ ⇕ ↓` context
- * expansion in every hunk separator.
+ * `dir/` + basename, `+a −d`, comment badges, copy path, open at destination
+ * ref) and the third-party diff body — split or unified, with GitHub-style
+ * `↑ ⇕ ↓` context expansion in every hunk separator.
  *
  * The daemon's structured diff carries the hunks; the component needs the
  * **full content at each ref** to expand context. It is fetched lazily — the
@@ -19,7 +23,37 @@ import type { RefPair, ViewMode } from "../../lib/runRefs";
  * the content is in). A side that does not exist at its ref (an added file's
  * old side, a deleted file's new side) is not fetched: the component composes
  * it from the diff.
+ *
+ * Review comments (#750): every entry of this file (draft or sent) occupies the
+ * library's **extend slot** under its line — `extendData[side][line]` — and the
+ * `+` widget on a line number opens the editor (widget row) for a line without
+ * a comment, re-opens the draft for edit when there is one, and only toasts on
+ * a sent (immutable) comment: **one comment per line**. Anchored lines carry a
+ * dot on the number and a 2px bar on the content cell, amber for a draft, blue
+ * for a sent comment, through a per-card `<style>` scoped to the card's id.
  */
+
+/** What the page hands every card to act on comments (#750). */
+export interface ReviewCommentsApi {
+  /** Draft key currently opened for edit (its card becomes the editor). */
+  editingKey: string | null;
+  /** Draft keys travelling in a send right now. */
+  sendingKeys: ReadonlySet<string>;
+  /** The in-flight send has to start the manager first. */
+  startingManager: boolean;
+  /** `Fork point → Run tip` for the sent card's footer. */
+  pairLabel: string;
+  sendDisabledReason: string | null;
+  saveNew: (anchor: Anchor, text: string) => void;
+  sendNew: (anchor: Anchor, text: string) => void;
+  editDraft: (key: string) => void;
+  updateDraft: (key: string, text: string) => void;
+  cancelEdit: () => void;
+  deleteDraft: (key: string) => void;
+  sendDraft: (key: string) => void;
+  /** The `+` landed on a sent comment: nothing to open, the page explains. */
+  sentLineClicked: () => void;
+}
 
 interface Props {
   runId: string;
@@ -30,6 +64,9 @@ interface Props {
   onToggle: () => void;
   /** Lets the page track the card for scroll-spy and "click a file → scroll". */
   registerEl: (path: string, el: HTMLDivElement | null) => void;
+  /** This file's comments for the current pair (drafts + sent). */
+  entries?: ReviewEntry[];
+  comments?: ReviewCommentsApi;
 }
 
 type Contents =
@@ -45,12 +82,29 @@ const LETTER_CLASS: Record<"A" | "M" | "D" | "R", string> = {
   R: "text-edit-tint",
 };
 
-export default function ReviewFileCard({ runId, file, pair, view, collapsed, onToggle, registerEl }: Props) {
+const NO_ENTRIES: ReviewEntry[] = [];
+
+function sideOf(s: SplitSide): ReviewSide {
+  return s === SplitSide.old ? "old" : "new";
+}
+
+export default function ReviewFileCard({
+  runId,
+  file,
+  pair,
+  view,
+  collapsed,
+  onToggle,
+  registerEl,
+  entries = NO_ENTRIES,
+  comments,
+}: Props) {
   const path = filePath(file);
   const letter = statusLetter(file);
   const rootRef = useRef<HTMLDivElement | null>(null);
   const [contents, setContents] = useState<Contents>({ kind: "idle" });
   const [copied, setCopied] = useState(false);
+  const cssId = `rc-${useId().replace(/[^a-zA-Z0-9_-]/g, "")}`;
 
   const pureRename = file.status === "renamed" && file.hunks.length === 0;
   const hasBody = !file.binary && !pureRename && file.hunks.length > 0;
@@ -116,6 +170,43 @@ export default function ReviewFileCard({ runId, file, pair, view, collapsed, onT
     };
   }, [file.old_path, file.new_path, hunks, contents]);
 
+  // --- Comments (#750) --------------------------------------------------------
+  const extendData = useMemo(() => {
+    const oldFile: Record<string, { data: ReviewEntry }> = {};
+    const newFile: Record<string, { data: ReviewEntry }> = {};
+    for (const e of entries) {
+      const slot = e.anchor.side === "old" ? oldFile : newFile;
+      // Sent wins over a stale draft on the same line (entries are sorted so).
+      if (!slot[String(e.anchor.line)]) slot[String(e.anchor.line)] = { data: e };
+    }
+    return { oldFile, newFile };
+  }, [entries]);
+
+  const nDrafts = entries.filter((e) => e.kind === "draft").length;
+  const nSent = entries.length - nDrafts;
+
+  /** Per-card CSS: dot + bar on anchored lines, `+` hidden where a comment sits. */
+  const anchorCss = useMemo(() => {
+    if (entries.length === 0) return "";
+    const rules: string[] = [];
+    for (const e of entries) {
+      const color = e.kind === "draft" ? "var(--color-st-await)" : "var(--color-st-running)";
+      const { side, line } = e.anchor;
+      // Split: `td.diff-line-<side>-num > span[data-line-num]`, content cell next.
+      const num = `#${cssId} td.diff-line-${side}-num:has(> span[data-line-num="${line}"])`;
+      rules.push(`${num}::before{content:"";position:absolute;left:5px;top:7px;width:6px;height:6px;border-radius:50%;background:${color}}`);
+      rules.push(`${num} + td.diff-line-${side}-content{box-shadow:inset 2px 0 0 ${color}}`);
+      rules.push(`${num} [data-add-widget]{display:none}`);
+      // Unified: both numbers on one row, `span[data-line-<side>-num]`.
+      const row = `#${cssId} tr.diff-line:has(span[data-line-${side}-num="${line}"])`;
+      rules.push(`${row} td.diff-line-num{position:relative}`);
+      rules.push(`${row} td.diff-line-num::before{content:"";position:absolute;left:5px;top:7px;width:6px;height:6px;border-radius:50%;background:${color}}`);
+      rules.push(`${row} td.diff-line-content{box-shadow:inset 2px 0 0 ${color}}`);
+      rules.push(`${row} [data-add-widget]{display:none}`);
+    }
+    return rules.join("\n");
+  }, [entries, cssId]);
+
   const copyPath = () => {
     navigator.clipboard?.writeText(path).then(
       () => {
@@ -135,12 +226,16 @@ export default function ReviewFileCard({ runId, file, pair, view, collapsed, onT
   return (
     <div
       ref={rootRef}
+      id={cssId}
       data-testid="review-file"
       data-path={path}
       data-collapsed={collapsed}
       data-content={contents.kind}
+      data-drafts={nDrafts}
+      data-sent={nSent}
       className="mx-3 my-2.5 overflow-hidden rounded-md border border-line bg-bg-2"
     >
+      {anchorCss && <style>{anchorCss}</style>}
       <div
         role="button"
         tabIndex={0}
@@ -184,7 +279,9 @@ export default function ReviewFileCard({ runId, file, pair, view, collapsed, onT
             <span className="text-st-done">+{file.additions}</span> <span className="text-st-failed">−{file.deletions}</span>
           </span>
         )}
-        <span className="ml-auto flex items-center gap-1" onClick={(e) => e.stopPropagation()}>
+        <span className="ml-auto flex items-center gap-1.5" onClick={(e) => e.stopPropagation()}>
+          {nDrafts > 0 && <Badge kind="draft">✎ {plural(nDrafts, "draft")}</Badge>}
+          {nSent > 0 && <Badge kind="sent">↗ {nSent} sent</Badge>}
           <button
             type="button"
             onClick={copyPath}
@@ -224,30 +321,80 @@ export default function ReviewFileCard({ runId, file, pair, view, collapsed, onT
               No content changes
             </div>
           ) : (
-            <DiffView
+            <DiffView<ReviewEntry>
               data={data}
+              extendData={extendData}
               diffViewMode={view === "split" ? DiffModeEnum.Split : DiffModeEnum.Unified}
               diffViewTheme="dark"
               diffViewFontSize={11}
               diffViewHighlight={false}
               diffViewWrap={false}
               diffViewAddWidget
-              renderWidgetLine={({ onClose }) => (
-                <div
-                  className="flex items-center gap-2 border-y border-line bg-bg-3 px-3 py-1.5 text-fg-3"
-                  style={{ fontSize: "10.5px" }}
-                  data-testid="review-comment-placeholder"
-                >
-                  Review comments arrive with the next ticket (#750).
-                  <button
-                    type="button"
-                    onClick={onClose}
-                    className="ml-auto cursor-pointer rounded border border-line-strong px-1.5 text-fg-3 hover:text-fg"
-                  >
-                    Close
-                  </button>
-                </div>
-              )}
+              renderWidgetLine={({ side, lineNumber, onClose }) => {
+                if (!comments) return null;
+                const anchor: Anchor = { path, side: sideOf(side), line: lineNumber };
+                const existing = entryAt(entries, anchor);
+                if (existing) {
+                  return (
+                    <WidgetRedirect
+                      onMount={() => {
+                        if (existing.kind === "draft") comments.editDraft(existing.draft.key);
+                        else comments.sentLineClicked();
+                        onClose();
+                      }}
+                    />
+                  );
+                }
+                return (
+                  <CommentEditor
+                    anchor={anchor}
+                    wipKey={wipKey(runId, anchor, pair)}
+                    sendDisabledReason={comments.sendDisabledReason}
+                    onSave={(text) => {
+                      comments.saveNew(anchor, text);
+                      onClose();
+                    }}
+                    onSend={(text) => {
+                      comments.sendNew(anchor, text);
+                      onClose();
+                    }}
+                    onCancel={onClose}
+                  />
+                );
+              }}
+              renderExtendLine={({ data: entry }) => {
+                // The library probes both sides of a line; only the anchored one carries data.
+                if (!comments || !entry) return null;
+                if (entry.kind === "draft" && comments.editingKey === entry.draft.key) {
+                  return (
+                    <CommentEditor
+                      anchor={entry.anchor}
+                      initial={entry.draft.text}
+                      wipKey={wipKey(runId, entry.anchor, pair)}
+                      sendDisabledReason={comments.sendDisabledReason}
+                      onSave={(text) => comments.updateDraft(entry.draft.key, text)}
+                      onSend={(text) => {
+                        comments.updateDraft(entry.draft.key, text);
+                        comments.sendDraft(entry.draft.key);
+                      }}
+                      onCancel={comments.cancelEdit}
+                    />
+                  );
+                }
+                const key = entry.kind === "draft" ? entry.draft.key : null;
+                return (
+                  <CommentCard
+                    entry={entry}
+                    sending={key !== null && comments.sendingKeys.has(key)}
+                    startingManager={comments.startingManager}
+                    pairLabel={comments.pairLabel}
+                    sendDisabledReason={comments.sendDisabledReason}
+                    onEdit={() => key && comments.editDraft(key)}
+                    onDelete={() => key && comments.deleteDraft(key)}
+                    onSend={() => key && comments.sendDraft(key)}
+                  />
+                );
+              }}
             />
           )}
           {contents.kind === "failed" && hasBody && (
@@ -259,4 +406,19 @@ export default function ReviewFileCard({ runId, file, pair, view, collapsed, onT
       )}
     </div>
   );
+}
+
+/**
+ * The `+` landed on a line that already carries a comment: the widget row must
+ * close itself and hand over (edit the draft / explain the sent one). Done in an
+ * effect — never during render — because closing is the library's state.
+ */
+function WidgetRedirect({ onMount }: { onMount: () => void }) {
+  const ran = useRef(false);
+  useEffect(() => {
+    if (ran.current) return;
+    ran.current = true;
+    onMount();
+  }, [onMount]);
+  return null;
 }

--- a/frontend/src/components/review/ReviewFileList.tsx
+++ b/frontend/src/components/review/ReviewFileList.tsx
@@ -2,12 +2,20 @@ import { PanelLeftClose } from "lucide-react";
 import type { RefObject } from "react";
 import type { DiffFile } from "../../types";
 import { baseName, filePath, groupByDir, miniBar, statusLetter } from "../../lib/runRefs";
+import type { ReviewEntry } from "../../lib/reviewComments";
+import { anchorLabel, plural } from "../../lib/reviewComments";
+import { Badge } from "./CommentCard";
 
 /**
  * The Review page's left column (#749, design option "flat list grouped by
  * directory"): filter box, directory headers, one row per file with its status
  * letter, `+a −d` and a 5-block mini bar. The current file follows the scroll;
  * clicking a row scrolls to it.
+ *
+ * #750: each row carries its comment badges (drafts amber, sent blue), and a
+ * **Comments** section lists every comment of the Run — badge, anchor, first
+ * words — click to jump. Comments written against another ref pair are greyed
+ * with their pair; clicking one restores that pair first.
  */
 
 interface Props {
@@ -18,6 +26,12 @@ interface Props {
   currentIndex: number;
   onSelect: (index: number) => void;
   onClose: () => void;
+  /** #750: per-path comment counts for the row badges. */
+  counts?: Map<string, { drafts: number; sent: number }>;
+  /** #750: the Comments section — current pair first, other pairs greyed. */
+  comments?: { current: ReviewEntry[]; other: { entry: ReviewEntry; pair: string }[] };
+  onJumpEntry?: (entry: ReviewEntry) => void;
+  onJumpOther?: (entry: ReviewEntry) => void;
 }
 
 const LETTER_CLASS: Record<"A" | "M" | "D" | "R", string> = {
@@ -35,6 +49,10 @@ export default function ReviewFileList({
   currentIndex,
   onSelect,
   onClose,
+  counts,
+  comments,
+  onJumpEntry,
+  onJumpOther,
 }: Props) {
   const q = filter.trim().toLowerCase();
   const shown = files
@@ -118,6 +136,8 @@ export default function ReviewFileList({
                     {baseName(p)}
                   </span>
                   <span className="flex items-center gap-1 font-mono" style={{ fontSize: "10px" }}>
+                    {(counts?.get(p)?.drafts ?? 0) > 0 && <Badge kind="draft">{counts!.get(p)!.drafts}</Badge>}
+                    {(counts?.get(p)?.sent ?? 0) > 0 && <Badge kind="sent">{counts!.get(p)!.sent}</Badge>}
                     {file.binary ? (
                       <span className="text-fg-4">bin</span>
                     ) : pureRename ? (
@@ -144,6 +164,37 @@ export default function ReviewFileList({
             })}
           </div>
         ))}
+
+        {comments && (
+          <div className="mt-3" data-testid="review-comments-section">
+            <div
+              className="flex items-center justify-between px-1.5 pb-1 pt-1.5 uppercase text-fg-4"
+              style={{ fontSize: "10px", letterSpacing: ".04em" }}
+            >
+              <span>Comments</span>
+              {comments.current.length + comments.other.length > 0 && (
+                <span className="normal-case tracking-normal" data-testid="review-comments-count">
+                  {plural(comments.current.filter((e) => e.kind === "draft").length, "draft")} ·{" "}
+                  {comments.current.filter((e) => e.kind === "sent").length} sent
+                </span>
+              )}
+            </div>
+            {comments.current.length + comments.other.length === 0 ? (
+              <div className="px-1.5 py-1 text-fg-4" style={{ fontSize: "10px" }}>
+                None yet. Hover a line number and press +.
+              </div>
+            ) : (
+              <>
+                {comments.current.map((e) => (
+                  <CommentRow key={entryKey(e)} entry={e} onClick={() => onJumpEntry?.(e)} />
+                ))}
+                {comments.other.map(({ entry, pair }) => (
+                  <CommentRow key={entryKey(entry)} entry={entry} pair={pair} onClick={() => onJumpOther?.(entry)} />
+                ))}
+              </>
+            )}
+          </div>
+        )}
       </div>
 
       <div
@@ -162,6 +213,9 @@ export default function ReviewFileList({
         <span>
           <Kbd>[</Kbd> list
         </span>
+        <span>
+          <Kbd>c</Kbd>/<Kbd>C</Kbd> comment
+        </span>
       </div>
     </aside>
   );
@@ -175,5 +229,34 @@ function Kbd({ children }: { children: string }) {
     >
       {children}
     </kbd>
+  );
+}
+
+function entryKey(e: ReviewEntry): string {
+  return e.kind === "draft" ? `d:${e.draft.key}` : `s:${e.comment.id}`;
+}
+
+function CommentRow({ entry, pair, onClick }: { entry: ReviewEntry; pair?: string; onClick: () => void }) {
+  const text = entry.kind === "draft" ? entry.draft.text : entry.comment.text;
+  const first = text.split("\n")[0].slice(0, 28);
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={pair ? `${text.slice(0, 120)}\n(at ${pair})` : text.slice(0, 120)}
+      data-testid="review-comment-row"
+      data-kind={entry.kind}
+      data-other-pair={pair ? "true" : undefined}
+      className={`grid w-full cursor-pointer grid-cols-[auto_auto_1fr] items-center gap-1.5 rounded px-1.5 py-[3px] text-left hover:bg-bg-3 ${
+        pair ? "opacity-55" : ""
+      }`}
+      style={{ fontSize: "10.5px" }}
+    >
+      <Badge kind={entry.kind}>{entry.kind === "draft" ? "✎" : "↗"}</Badge>
+      <span className="font-mono text-fg-3" style={{ fontSize: "10px" }}>
+        {anchorLabel(entry.anchor)}
+      </span>
+      <span className="truncate text-fg-4">{pair ? `at ${pair}` : first}</span>
+    </button>
   );
 }

--- a/frontend/src/components/review/ReviewSendBar.tsx
+++ b/frontend/src/components/review/ReviewSendBar.tsx
@@ -1,0 +1,70 @@
+import type { ReviewDraft } from "../../lib/reviewComments";
+import { anchorLabel, plural } from "../../lib/reviewComments";
+import { Badge, Spinner } from "./CommentCard";
+
+/**
+ * The sticky footer bar of the Review page (#750): appears **only while drafts
+ * exist** — `✎ 2 · 2 drafts ready to send · 1 already sent`, one clickable chip
+ * per draft (jump to it before committing), the note "One message to the
+ * manager · starts it first" when the manager is stopped (or the disabled
+ * reason instead), and the primary **Send all to manager**. It disappears once
+ * nothing is left to send, so the page is quiet by default.
+ */
+
+interface Props {
+  drafts: ReviewDraft[];
+  sentCount: number;
+  sending: boolean;
+  managerRunning: boolean;
+  sendDisabledReason: string | null;
+  onJump: (draft: ReviewDraft) => void;
+  onSendAll: () => void;
+}
+
+export default function ReviewSendBar({ drafts, sentCount, sending, managerRunning, sendDisabledReason, onJump, onSendAll }: Props) {
+  if (drafts.length === 0) return null;
+  return (
+    <div className="sticky bottom-2 z-[15] mx-3" data-testid="review-send-bar">
+      <div
+        className="flex items-center gap-2.5 rounded-md border border-acc-border px-3 py-1.5 text-fg-2 shadow-[0_-6px_24px_rgba(0,0,0,.35)] backdrop-blur-[4px]"
+        style={{ fontSize: "11px", background: "rgba(20,23,29,.96)" }}
+      >
+        <Badge kind="draft">✎ {drafts.length}</Badge>
+        <span>
+          <span className="font-medium text-fg">{plural(drafts.length, "draft")}</span> ready to send
+          {sentCount > 0 && <span> · {sentCount} already sent</span>}
+        </span>
+        <span className="inline-flex flex-wrap gap-1">
+          {drafts.map((d) => (
+            <button
+              key={d.key}
+              type="button"
+              onClick={() => onJump(d)}
+              title={d.text.slice(0, 80)}
+              data-testid="review-send-chip"
+              className="cursor-pointer rounded-[3px] border border-line-strong bg-bg-3 px-[5px] font-mono text-fg-3 hover:border-st-await hover:text-fg"
+              style={{ fontSize: "9.5px" }}
+            >
+              {anchorLabel(d)}
+            </button>
+          ))}
+        </span>
+        <span className="flex-1" />
+        <span className="text-fg-4" data-testid="review-send-bar-note">
+          {sendDisabledReason ?? `One message to the manager${managerRunning ? "" : " · starts it first"}`}
+        </span>
+        <button
+          type="button"
+          onClick={onSendAll}
+          disabled={!!sendDisabledReason || sending}
+          title={sendDisabledReason ?? undefined}
+          data-testid="review-send-all"
+          className="inline-flex cursor-pointer items-center gap-1.5 rounded border border-acc bg-acc px-2 py-0.5 font-semibold text-[#04140d] hover:bg-[#14cf92] disabled:cursor-not-allowed disabled:opacity-45"
+          style={{ fontSize: "10.5px" }}
+        >
+          {sending ? <Spinner /> : "↗"} Send all to manager
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/lib/reviewComments.test.ts
+++ b/frontend/src/lib/reviewComments.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from "vitest";
+import {
+  addDraft,
+  anchorLabel,
+  countsByPath,
+  draftsForPair,
+  entryAt,
+  mergeEntries,
+  pendingCount,
+  readDrafts,
+  relativeTime,
+  removeDrafts,
+  sendDisabledReason,
+  toSendInputs,
+  updateDraft,
+  wipKey,
+  writeDrafts,
+} from "./reviewComments";
+import type { ReviewComment, RunRefs } from "../types";
+
+const PAIR = { from: "fork", to: "tip" };
+
+function sent(overrides: Partial<ReviewComment> = {}): ReviewComment {
+  return {
+    id: "rc-001",
+    path: "b.ts",
+    side: "new",
+    line: 5,
+    from_ref: "fork",
+    to_ref: "tip",
+    text: "t",
+    author: "user",
+    sent_at: "2026-09-09T10:00:00Z",
+    status: "sent",
+    ...overrides,
+  };
+}
+
+describe("reviewComments (#750)", () => {
+  it("round-trips drafts through storage and drops garbage", () => {
+    localStorage.clear();
+    let drafts = addDraft([], { path: "a.ts", side: "new", line: 3 }, PAIR, "hello");
+    drafts = addDraft(drafts, { path: "a.ts", side: "old", line: 1 }, PAIR, "old side");
+    writeDrafts("r1", drafts);
+    expect(readDrafts("r1")).toEqual(drafts);
+    expect(readDrafts("r2")).toEqual([]);
+    localStorage.setItem("pdo.review.drafts.r3", JSON.stringify([{ nope: 1 }, drafts[0]]));
+    expect(readDrafts("r3")).toEqual([drafts[0]]);
+    localStorage.setItem("pdo.review.drafts.r4", "{not json");
+    expect(readDrafts("r4")).toEqual([]);
+    writeDrafts("r1", []);
+    expect(localStorage.getItem("pdo.review.drafts.r1")).toBeNull();
+  });
+
+  it("updates and removes by key; keys are unique", () => {
+    let drafts = addDraft([], { path: "a.ts", side: "new", line: 3 }, PAIR, "a");
+    drafts = addDraft(drafts, { path: "a.ts", side: "new", line: 4 }, PAIR, "b");
+    expect(drafts[0].key).not.toBe(drafts[1].key);
+    const upd = updateDraft(drafts, drafts[0].key, "A");
+    expect(upd[0].text).toBe("A");
+    expect(upd[1].text).toBe("b");
+    expect(removeDrafts(upd, [drafts[1].key])).toHaveLength(1);
+  });
+
+  it("merges drafts and sent comments of the pair in diff order, sent first on a shared line", () => {
+    const drafts = [
+      ...addDraft([], { path: "b.ts", side: "new", line: 9 }, PAIR, "late"),
+      ...addDraft([], { path: "a.ts", side: "new", line: 2 }, PAIR, "early"),
+      ...addDraft([], { path: "a.ts", side: "old", line: 2 }, PAIR, "left"),
+      ...addDraft([], { path: "a.ts", side: "new", line: 1 }, { from: "fork", to: "node:x:1:after" }, "other pair"),
+      ...addDraft([], { path: "b.ts", side: "new", line: 5 }, PAIR, "stale"),
+    ];
+    const entries = mergeEntries(drafts, [sent()], PAIR, ["a.ts", "b.ts"]);
+    expect(entries.map((e) => `${e.kind}:${anchorLabel(e.anchor)}`)).toEqual([
+      "draft:a.ts:L2",
+      "draft:a.ts:R2",
+      "sent:b.ts:R5",
+      "draft:b.ts:R5",
+      "draft:b.ts:R9",
+    ]);
+    expect(entryAt(entries, { path: "b.ts", side: "new", line: 5 })?.kind).toBe("sent");
+    expect(entryAt(entries, { path: "zz", side: "new", line: 5 })).toBeUndefined();
+    expect(draftsForPair(drafts, PAIR)).toHaveLength(4);
+    const counts = countsByPath(entries);
+    expect(counts.get("a.ts")).toEqual({ drafts: 2, sent: 0 });
+    expect(counts.get("b.ts")).toEqual({ drafts: 2, sent: 1 });
+  });
+
+  it("labels anchors GitHub-style and builds the wire inputs", () => {
+    expect(anchorLabel({ path: "frontend/src/pages/ReviewPage.tsx", side: "new", line: 48 })).toBe("ReviewPage.tsx:R48");
+    expect(anchorLabel({ path: "review.rs", side: "old", line: 123 })).toBe("review.rs:L123");
+    const drafts = addDraft([], { path: "a.ts", side: "new", line: 3 }, PAIR, "x");
+    expect(toSendInputs(drafts)).toEqual([{ path: "a.ts", side: "new", line: 3, from: "fork", to: "tip", text: "x" }]);
+    expect(wipKey("r1", { path: "a.ts", side: "new", line: 3 }, PAIR)).toBe("pdo.review.wip.r1|a.ts|new|3|fork|tip");
+  });
+
+  it("explains why sending is disabled: archived, or a tip that no longer resolves", () => {
+    const refs: RunRefs = {
+      default_from: "fork",
+      default_to: "tip",
+      deliveries: [],
+      refs: [
+        { id: "fork", kind: "fork", label: "Fork point", git_ref: "a", sha: "a" },
+        { id: "tip", kind: "tip", label: "Run tip", git_ref: "pdo/run-r1", sha: "b" },
+      ],
+    };
+    expect(sendDisabledReason(null, refs)).toBeNull();
+    expect(sendDisabledReason({ run_id: "r1", status: "completed" }, refs)).toBeNull();
+    expect(sendDisabledReason({ run_id: "r1", status: "completed" }, null)).toBeNull();
+    expect(sendDisabledReason({ run_id: "r1", status: "archived" }, refs)).toContain("pdo/run-r1");
+    const gone = { ...refs, refs: refs.refs.map((r) => (r.id === "tip" ? { ...r, sha: null } : r)) };
+    expect(sendDisabledReason({ run_id: "r1", status: "completed" }, gone)).toContain("no longer exists");
+  });
+
+  it("counts pending (sent, unresolved) comments and formats relative time", () => {
+    expect(pendingCount(undefined)).toBe(0);
+    expect(pendingCount([sent(), sent({ id: "rc-002", status: "resolved" })])).toBe(1);
+    const now = new Date("2026-09-09T10:10:00Z");
+    expect(relativeTime("2026-09-09T10:09:50Z", now)).toBe("just now");
+    expect(relativeTime("2026-09-09T10:05:00Z", now)).toBe("5 min ago");
+    expect(relativeTime("garbage", now)).toBe("");
+    expect(relativeTime("2026-09-09T08:00:00Z", now)).toMatch(/\d/);
+  });
+});

--- a/frontend/src/lib/reviewComments.ts
+++ b/frontend/src/lib/reviewComments.ts
@@ -1,0 +1,237 @@
+import type { ReviewComment, ReviewSide, RunRefs, RunState, SendReviewCommentInput } from "../types";
+import type { RefPair } from "./runRefs";
+
+// Review comments of the Review page (#750, ADR-0067 §2; CONTEXT.md
+// § "Commentaire de review", "Envoi au manager"). Pure: no React, no fetch.
+//
+// Two populations share one anchor vocabulary `(path, side, line, from, to)`:
+// - **drafts**, browser-only (localStorage per Run; the half-typed text of an
+//   open editor in sessionStorage so a stray reload loses nothing);
+// - **sent** comments, read from the projected Run state (`review_comments`),
+//   immutable, pushed over the WebSocket.
+// The page merges both into one list per file and per line.
+
+/** A draft: editable, deletable, only in this browser until sent. */
+export interface ReviewDraft {
+  /** Local identity (uuid-ish); never sent to the daemon. */
+  key: string;
+  path: string;
+  side: ReviewSide;
+  line: number;
+  from: string;
+  to: string;
+  text: string;
+  created_at: string;
+  updated_at: string;
+}
+
+/** The anchor of a comment, draft or sent — what "one comment per line" keys on. */
+export interface Anchor {
+  path: string;
+  side: ReviewSide;
+  line: number;
+}
+
+/** One entry of the merged list the page renders. */
+export type ReviewEntry =
+  | { kind: "draft"; anchor: Anchor; draft: ReviewDraft }
+  | { kind: "sent"; anchor: Anchor; comment: ReviewComment };
+
+export const DRAFTS_KEY_PREFIX = "pdo.review.drafts.";
+export const WIP_KEY_PREFIX = "pdo.review.wip.";
+
+export function draftsKey(runId: string): string {
+  return `${DRAFTS_KEY_PREFIX}${runId}`;
+}
+
+/** The sessionStorage key of an editor's half-typed text. */
+export function wipKey(runId: string, anchor: Anchor, pair: RefPair): string {
+  return `${WIP_KEY_PREFIX}${runId}|${anchor.path}|${anchor.side}|${anchor.line}|${pair.from}|${pair.to}`;
+}
+
+export function readDrafts(runId: string, storage: Pick<Storage, "getItem"> = localStorage): ReviewDraft[] {
+  try {
+    const raw = storage.getItem(draftsKey(runId));
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(isDraft);
+  } catch {
+    return [];
+  }
+}
+
+export function writeDrafts(
+  runId: string,
+  drafts: ReviewDraft[],
+  storage: Pick<Storage, "setItem" | "removeItem"> = localStorage,
+): void {
+  try {
+    if (drafts.length === 0) storage.removeItem(draftsKey(runId));
+    else storage.setItem(draftsKey(runId), JSON.stringify(drafts));
+  } catch {
+    // Private mode / quota: the drafts still live for the session in memory.
+  }
+}
+
+function isDraft(v: unknown): v is ReviewDraft {
+  const d = v as Partial<ReviewDraft> | null;
+  return (
+    !!d &&
+    typeof d.key === "string" &&
+    typeof d.path === "string" &&
+    (d.side === "old" || d.side === "new") &&
+    typeof d.line === "number" &&
+    typeof d.from === "string" &&
+    typeof d.to === "string" &&
+    typeof d.text === "string"
+  );
+}
+
+export function newDraftKey(): string {
+  const c = globalThis.crypto as Crypto | undefined;
+  if (c?.randomUUID) return c.randomUUID();
+  return `d-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+/** Add a draft at `anchor` for `pair`; the caller persists the returned list. */
+export function addDraft(drafts: ReviewDraft[], anchor: Anchor, pair: RefPair, text: string, now = new Date()): ReviewDraft[] {
+  const ts = now.toISOString();
+  return [
+    ...drafts,
+    { key: newDraftKey(), ...anchor, from: pair.from, to: pair.to, text, created_at: ts, updated_at: ts },
+  ];
+}
+
+export function updateDraft(drafts: ReviewDraft[], key: string, text: string, now = new Date()): ReviewDraft[] {
+  return drafts.map((d) => (d.key === key ? { ...d, text, updated_at: now.toISOString() } : d));
+}
+
+export function removeDrafts(drafts: ReviewDraft[], keys: Iterable<string>): ReviewDraft[] {
+  const set = new Set(keys);
+  return drafts.filter((d) => !set.has(d.key));
+}
+
+export function sameAnchor(a: Anchor, b: Anchor): boolean {
+  return a.path === b.path && a.side === b.side && a.line === b.line;
+}
+
+/** The drafts written against exactly this pair (others stay stored, hidden from the diff body). */
+export function draftsForPair(drafts: ReviewDraft[], pair: RefPair): ReviewDraft[] {
+  return drafts.filter((d) => d.from === pair.from && d.to === pair.to);
+}
+
+/** The sent comments of this pair. */
+export function sentForPair(comments: ReviewComment[] | undefined, pair: RefPair): ReviewComment[] {
+  return (comments ?? []).filter((c) => c.from_ref === pair.from && c.to_ref === pair.to);
+}
+
+/**
+ * The merged list for one pair, in diff order: by path (patch order given), then
+ * line, then side (old before new — the left column first). Sent before draft on
+ * the same anchor is impossible by construction (one comment per line), but a
+ * stale draft on a line just sent still resolves deterministically: sent wins.
+ */
+export function mergeEntries(
+  drafts: ReviewDraft[],
+  comments: ReviewComment[] | undefined,
+  pair: RefPair,
+  pathOrder: string[],
+): ReviewEntry[] {
+  const order = new Map(pathOrder.map((p, i) => [p, i]));
+  const rank = (p: string) => order.get(p) ?? Number.MAX_SAFE_INTEGER;
+  const entries: ReviewEntry[] = [
+    ...sentForPair(comments, pair).map<ReviewEntry>((c) => ({
+      kind: "sent",
+      anchor: { path: c.path, side: c.side, line: c.line },
+      comment: c,
+    })),
+    ...draftsForPair(drafts, pair).map<ReviewEntry>((d) => ({
+      kind: "draft",
+      anchor: { path: d.path, side: d.side, line: d.line },
+      draft: d,
+    })),
+  ];
+  return entries.sort((a, b) => {
+    const r = rank(a.anchor.path) - rank(b.anchor.path);
+    if (r !== 0) return r;
+    if (a.anchor.path !== b.anchor.path) return a.anchor.path < b.anchor.path ? -1 : 1;
+    if (a.anchor.line !== b.anchor.line) return a.anchor.line - b.anchor.line;
+    if (a.anchor.side !== b.anchor.side) return a.anchor.side === "old" ? -1 : 1;
+    // Same anchor: sent first, so the page shows the immutable one.
+    if (a.kind !== b.kind) return a.kind === "sent" ? -1 : 1;
+    return 0;
+  });
+}
+
+/** The entry anchored on this exact line, if any (the "one comment per line" lookup). */
+export function entryAt(entries: ReviewEntry[], anchor: Anchor): ReviewEntry | undefined {
+  return entries.find((e) => sameAnchor(e.anchor, anchor));
+}
+
+/** Per-file counts for the sidebar badges and the card headers. */
+export function countsByPath(entries: ReviewEntry[]): Map<string, { drafts: number; sent: number }> {
+  const m = new Map<string, { drafts: number; sent: number }>();
+  for (const e of entries) {
+    const c = m.get(e.anchor.path) ?? { drafts: 0, sent: 0 };
+    if (e.kind === "draft") c.drafts += 1;
+    else c.sent += 1;
+    m.set(e.anchor.path, c);
+  }
+  return m;
+}
+
+/** `ReviewPage.tsx:R48` — basename, GitHub's side letter, line. */
+export function anchorLabel(anchor: Anchor): string {
+  const base = anchor.path.includes("/") ? anchor.path.slice(anchor.path.lastIndexOf("/") + 1) : anchor.path;
+  return `${base}:${anchor.side === "old" ? "L" : "R"}${anchor.line}`;
+}
+
+/** `destination side` / `source side` — the header spells the side out. */
+export function sideLabel(side: ReviewSide): string {
+  return side === "new" ? "destination side" : "source side";
+}
+
+/** Drafts → the wire shape of the send endpoint. */
+export function toSendInputs(drafts: ReviewDraft[]): SendReviewCommentInput[] {
+  return drafts.map((d) => ({ path: d.path, side: d.side, line: d.line, from: d.from, to: d.to, text: d.text }));
+}
+
+/**
+ * Why sending is disabled, or null when it is allowed. Mirrors the daemon's
+ * `run_branch_gone` refusal so the buttons grey out *before* a click: an
+ * archived Run has no branch; a `tip` ref whose SHA no longer resolves means
+ * `pdo/run-<id>` was deleted.
+ */
+export function sendDisabledReason(run: Pick<RunState, "run_id" | "status"> | null, refs: RunRefs | null): string | null {
+  if (!run) return null;
+  const branch = `pdo/run-${run.run_id}`;
+  if (run.status === "archived") {
+    return `Run archived — branch ${branch} no longer exists. Comments stay readable; sending to the manager is disabled.`;
+  }
+  const tip = refs?.refs.find((r) => r.id === "tip");
+  if (refs && tip && tip.sha === null) {
+    return `Run branch ${branch} no longer exists — nothing for the manager to act on. Comments stay readable; sending is disabled.`;
+  }
+  return null;
+}
+
+/** `just now` / `3 min ago` / `14:05` — the cards' relative time. */
+export function relativeTime(iso: string, now = new Date()): string {
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return "";
+  const s = Math.round((now.getTime() - t) / 1000);
+  if (s < 60) return "just now";
+  if (s < 3600) return `${Math.round(s / 60)} min ago`;
+  return new Date(t).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+
+/** Pending for the Diff tab badge (CONTEXT.md « Accès rapide Review »): sent, not resolved. */
+export function pendingCount(comments: ReviewComment[] | undefined): number {
+  return (comments ?? []).filter((c) => c.status !== "resolved").length;
+}
+
+/** `2 drafts` / `1 draft` — pluralised counter. */
+export function plural(n: number, word: string): string {
+  return `${n} ${word}${n === 1 ? "" : "s"}`;
+}

--- a/frontend/src/pages/ReviewPage.test.tsx
+++ b/frontend/src/pages/ReviewPage.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
 import ReviewPage from "./ReviewPage";
-import type { RunRefs, RunState, StructuredDiff, DiffFile } from "../types";
+import type { ReviewComment, RunRefs, RunState, StructuredDiff, DiffFile } from "../types";
 
 // The Review page (#749): pair from the URL, refs from the daemon, files from the
 // structured diff, the third-party body mocked to a marker (its own rendering is
@@ -12,30 +12,68 @@ vi.mock("../api", () => ({
   fetchRunRefs: vi.fn(),
   fetchRunStructuredDiff: vi.fn(),
   fetchRunFileAtRef: vi.fn(),
+  sendReviewComments: vi.fn(),
 }));
 
 vi.mock("../hooks/useDaemonSocket", () => ({
   useDaemonSocket: () => ({ status: "connected", subscribe: () => () => {} }),
 }));
 
-vi.mock("@git-diff-view/react", () => ({
-  DiffModeEnum: { Split: "split", Unified: "unified" },
-  DiffView: (props: { diffViewMode: string; data: { hunks: string[]; oldFile: { content: string }; newFile: { content: string } } }) => (
-    <div
-      data-testid="mock-diff-view"
-      data-mode={props.diffViewMode}
-      data-hunks={props.data.hunks.length}
-      data-has-content={Boolean(props.data.oldFile.content || props.data.newFile.content)}
-    />
-  ),
-}));
+// The body mock exposes the two seams #750 plugs into: a `+` per side/line that
+// opens `renderWidgetLine`, and one extend slot per `extendData` entry rendered
+// through `renderExtendLine`.
+vi.mock("@git-diff-view/react", async () => {
+  const React = await import("react");
+  const SplitSide = { old: 1, new: 2 } as const;
+  type Slot = { data: unknown };
+  type Props = {
+    diffViewMode: string;
+    data: { hunks: string[]; oldFile: { content: string }; newFile: { content: string } };
+    extendData?: { oldFile?: Record<string, Slot>; newFile?: Record<string, Slot> };
+    renderWidgetLine?: (a: { side: number; lineNumber: number; diffFile: unknown; onClose: () => void }) => React.ReactNode;
+    renderExtendLine?: (a: { side: number; lineNumber: number; data: unknown; diffFile: unknown; onUpdate: () => void }) => React.ReactNode;
+  };
+  const DiffView = (props: Props) => {
+    const [widget, setWidget] = React.useState<{ side: number; line: number } | null>(null);
+    const slots: React.ReactNode[] = [];
+    for (const [sideName, side] of [["old", SplitSide.old], ["new", SplitSide.new]] as const) {
+      const rec = props.extendData?.[sideName === "old" ? "oldFile" : "newFile"] ?? {};
+      for (const [line, slot] of Object.entries(rec)) {
+        slots.push(
+          <div key={`${sideName}-${line}`} data-testid="mock-extend" data-side={sideName} data-line={line}>
+            {props.renderExtendLine?.({ side, lineNumber: Number(line), data: slot.data, diffFile: null, onUpdate: () => {} })}
+          </div>,
+        );
+      }
+    }
+    return (
+      <div
+        data-testid="mock-diff-view"
+        data-mode={props.diffViewMode}
+        data-hunks={props.data.hunks.length}
+        data-has-content={Boolean(props.data.oldFile.content || props.data.newFile.content)}
+      >
+        <button type="button" data-testid="mock-add-new-2" onClick={() => setWidget({ side: SplitSide.new, line: 2 })} />
+        <button type="button" data-testid="mock-add-old-2" onClick={() => setWidget({ side: SplitSide.old, line: 2 })} />
+        {widget && (
+          <div data-testid="mock-widget">
+            {props.renderWidgetLine?.({ side: widget.side, lineNumber: widget.line, diffFile: null, onClose: () => setWidget(null) })}
+          </div>
+        )}
+        {slots}
+      </div>
+    );
+  };
+  return { DiffModeEnum: { Split: "split", Unified: "unified" }, SplitSide, DiffView };
+});
 
-import { fetchRun, fetchRunRefs, fetchRunStructuredDiff, fetchRunFileAtRef } from "../api";
+import { fetchRun, fetchRunRefs, fetchRunStructuredDiff, fetchRunFileAtRef, sendReviewComments } from "../api";
 
 const mockedRun = vi.mocked(fetchRun);
 const mockedRefs = vi.mocked(fetchRunRefs);
 const mockedDiff = vi.mocked(fetchRunStructuredDiff);
 const mockedFile = vi.mocked(fetchRunFileAtRef);
+const mockedSend = vi.mocked(sendReviewComments);
 
 const RUN_ID = "20260909-125942-c7e2c65";
 
@@ -125,6 +163,7 @@ function goto(search = "") {
 beforeEach(() => {
   vi.clearAllMocks();
   localStorage.clear();
+  sessionStorage.clear();
   mockedRun.mockResolvedValue(makeRun());
   mockedRefs.mockResolvedValue(REFS);
   mockedDiff.mockResolvedValue(TWO);
@@ -312,7 +351,7 @@ describe("ReviewPage (#749)", () => {
     await waitFor(() => expect(screen.getAllByTestId("review-file")).toHaveLength(2));
   });
 
-  it("carries the pair in the open-in-new-tab link and keeps the Send pill disabled (#750)", async () => {
+  it("carries the pair in the open-in-new-tab link; the comments pill is a disabled counter without comments", async () => {
     goto("?from=fork&to=node%3Aimpl%3A1%3Aafter");
     render(<ReviewPage runId={RUN_ID} />);
     await waitFor(() => expect(screen.getAllByTestId("review-file")).toHaveLength(2));
@@ -320,6 +359,200 @@ describe("ReviewPage (#749)", () => {
       "href",
       `/runs/${RUN_ID}/review?from=fork&to=node%3Aimpl%3A1%3Aafter`,
     );
-    expect(screen.getByTestId("review-send-placeholder")).toHaveAttribute("aria-disabled");
+    expect(screen.getByTestId("review-comments-pill")).toBeDisabled();
+    expect(screen.getByTestId("review-comments-pill")).toHaveTextContent("0 comments");
+    expect(screen.queryByTestId("review-send-bar")).toBeNull();
+  });
+});
+
+// --- #750: review comments ---------------------------------------------------
+
+function sentComment(overrides: Partial<ReviewComment> = {}): ReviewComment {
+  return {
+    id: "rc-001",
+    path: "src/main.tsx",
+    side: "new",
+    line: 3,
+    from_ref: "fork",
+    to_ref: "tip",
+    text: "Sent remark",
+    author: "user",
+    sent_at: "2026-09-09T00:30:00Z",
+    status: "sent",
+    ...overrides,
+  };
+}
+
+async function openEditorAndSave(text: string, testId = "mock-add-new-2") {
+  fireEvent.click(within(screen.getAllByTestId("review-file")[0]).getByTestId(testId));
+  const editor = await screen.findByTestId("review-comment-editor");
+  fireEvent.change(within(editor).getByTestId("review-editor-text"), { target: { value: text } });
+  fireEvent.click(within(editor).getByTestId("review-editor-save"));
+}
+
+describe("ReviewPage — review comments (#750)", () => {
+  it("opens the inline editor from +, saves a draft that renders markdown under the line and persists across a reload", async () => {
+    const { unmount } = render(<ReviewPage runId={RUN_ID} />);
+    await waitFor(() => expect(screen.getAllByTestId("review-file")).toHaveLength(2));
+    fireEvent.click(within(screen.getAllByTestId("review-file")[0]).getByTestId("mock-add-new-2"));
+    const editor = await screen.findByTestId("review-comment-editor");
+    expect(editor).toHaveTextContent("New comment");
+    expect(editor).toHaveTextContent("main.tsx:R2 · destination side");
+    expect(within(editor).getByTestId("review-editor-save")).toBeDisabled();
+    fireEvent.change(within(editor).getByTestId("review-editor-text"), { target: { value: "Use `const` here" } });
+    // The half-typed text survives a reload (sessionStorage).
+    expect(sessionStorage.getItem(`pdo.review.wip.${RUN_ID}|src/main.tsx|new|2|fork|tip`)).toBe("Use `const` here");
+    fireEvent.click(within(editor).getByTestId("review-editor-preview"));
+    expect(within(editor).getByTestId("review-editor-preview-body").querySelector("code")).toHaveTextContent("const");
+    fireEvent.click(within(editor).getByTestId("review-editor-write"));
+    fireEvent.click(within(editor).getByTestId("review-editor-save"));
+
+    const card = await screen.findByTestId("review-comment");
+    expect(card).toHaveAttribute("data-state", "draft");
+    expect(card).toHaveAttribute("data-anchor", "main.tsx:R2");
+    expect(card.querySelector("code")).toHaveTextContent("const");
+    expect(card).toHaveTextContent("Only in this browser until sent.");
+    expect(screen.getByTestId("review-toast")).toHaveTextContent("Draft saved");
+    expect(screen.queryByTestId("review-comment-editor")).toBeNull();
+    expect(sessionStorage.getItem(`pdo.review.wip.${RUN_ID}|src/main.tsx|new|2|fork|tip`)).toBeNull();
+    // Chrome: pill, footer bar with a chip, header + sidebar badges, Comments section.
+    expect(screen.getByTestId("review-send-pill")).toHaveTextContent("Send 1 draft to manager");
+    expect(screen.getByTestId("review-send-bar")).toHaveTextContent("1 draft ready to send");
+    expect(screen.getByTestId("review-send-chip")).toHaveTextContent("main.tsx:R2");
+    expect(screen.getAllByTestId("review-file")[0]).toHaveAttribute("data-drafts", "1");
+    expect(screen.getAllByTestId("review-comment-row")).toHaveLength(1);
+    expect(screen.getByTestId("review-comments-count")).toHaveTextContent("1 draft · 0 sent");
+
+    // Reload: the draft is still there.
+    unmount();
+    render(<ReviewPage runId={RUN_ID} />);
+    await waitFor(() => expect(screen.getByTestId("review-comment")).toHaveAttribute("data-state", "draft"));
+  });
+
+  it("edits and deletes a draft; + on a drafted line re-opens that draft (one comment per line)", async () => {
+    render(<ReviewPage runId={RUN_ID} />);
+    await waitFor(() => expect(screen.getAllByTestId("review-file")).toHaveLength(2));
+    await openEditorAndSave("first");
+    // + again on the same line: edit, not a second comment.
+    fireEvent.click(within(screen.getAllByTestId("review-file")[0]).getByTestId("mock-add-new-2"));
+    const editor = await screen.findByTestId("review-comment-editor");
+    expect(editor).toHaveTextContent("Edit draft");
+    expect(within(editor).getByTestId("review-editor-text")).toHaveValue("first");
+    fireEvent.change(within(editor).getByTestId("review-editor-text"), { target: { value: "second" } });
+    fireEvent.keyDown(within(editor).getByTestId("review-editor-text"), { key: "Enter", ctrlKey: true });
+    await waitFor(() => expect(screen.getByTestId("review-comment")).toHaveTextContent("second"));
+    expect(screen.getAllByTestId("review-comment")).toHaveLength(1);
+    expect(JSON.parse(localStorage.getItem(`pdo.review.drafts.${RUN_ID}`)!)[0].text).toBe("second");
+    // Esc cancels an edit without touching the text.
+    fireEvent.click(screen.getByTestId("review-comment-edit"));
+    fireEvent.keyDown(await screen.findByTestId("review-editor-text"), { key: "Escape" });
+    await waitFor(() => expect(screen.queryByTestId("review-comment-editor")).toBeNull());
+    expect(screen.getByTestId("review-comment")).toHaveTextContent("second");
+    // Delete.
+    fireEvent.click(screen.getByTestId("review-comment-delete"));
+    await waitFor(() => expect(screen.queryByTestId("review-comment")).toBeNull());
+    expect(localStorage.getItem(`pdo.review.drafts.${RUN_ID}`)).toBeNull();
+    expect(screen.queryByTestId("review-send-bar")).toBeNull();
+  });
+
+  it("Send all posts every draft of the pair as one batch, drops them and shows the sent cards from the projected state", async () => {
+    render(<ReviewPage runId={RUN_ID} />);
+    await waitFor(() => expect(screen.getAllByTestId("review-file")).toHaveLength(2));
+    await openEditorAndSave("one");
+    await openEditorAndSave("two", "mock-add-old-2");
+    expect(screen.getAllByTestId("review-comment")).toHaveLength(2);
+    expect(screen.getByTestId("review-send-bar")).toHaveTextContent("2 drafts ready to send");
+    expect(screen.getByTestId("review-send-bar-note")).toHaveTextContent("starts it first");
+
+    const sent = [sentComment({ id: "rc-001", side: "new", line: 2, text: "one" }), sentComment({ id: "rc-002", side: "old", line: 2, text: "two" })];
+    mockedSend.mockResolvedValue({ sent, batch_id: "b1", manager_started: true });
+    mockedRun.mockResolvedValue(makeRun({ has_manager: true, review_comments: sent }));
+    fireEvent.click(screen.getByTestId("review-send-all"));
+
+    await waitFor(() => expect(mockedSend).toHaveBeenCalledTimes(1));
+    expect(mockedSend).toHaveBeenCalledWith(RUN_ID, [
+      { path: "src/main.tsx", side: "new", line: 2, from: "fork", to: "tip", text: "one" },
+      { path: "src/main.tsx", side: "old", line: 2, from: "fork", to: "tip", text: "two" },
+    ]);
+    await waitFor(() => expect(screen.getAllByTestId("review-comment").every((c) => c.dataset.state === "sent")).toBe(true));
+    expect(screen.getAllByTestId("review-comment")).toHaveLength(2);
+    expect(screen.getByTestId("review-toast")).toHaveTextContent("2 comments sent as one message — manager started");
+    expect(localStorage.getItem(`pdo.review.drafts.${RUN_ID}`)).toBeNull();
+    expect(screen.queryByTestId("review-send-bar")).toBeNull();
+    expect(screen.getByTestId("review-comments-pill")).toHaveTextContent("2 sent");
+    // Sent card: id, pair, lock, no edit/delete.
+    const first = screen.getAllByTestId("review-comment").find((c) => c.dataset.commentId === "rc-001")!;
+    expect(within(first).getByTestId("review-comment-id")).toHaveTextContent("rc-001");
+    expect(first).toHaveTextContent("Fork point → Run tip");
+    expect(first).toHaveTextContent("Awaiting manager reply");
+    expect(within(first).getByTestId("review-comment-lock")).toBeInTheDocument();
+    expect(within(first).queryByTestId("review-comment-edit")).toBeNull();
+    expect(within(first).queryByTestId("review-comment-delete")).toBeNull();
+    // + on a sent line: nothing opens, a toast explains.
+    fireEvent.click(within(screen.getAllByTestId("review-file")[0]).getByTestId("mock-add-new-2"));
+    await waitFor(() => expect(screen.getByTestId("review-toast")).toHaveTextContent("already has a sent comment"));
+    expect(screen.queryByTestId("review-comment-editor")).toBeNull();
+  });
+
+  it("keeps the drafts when the send fails and says so", async () => {
+    render(<ReviewPage runId={RUN_ID} />);
+    await waitFor(() => expect(screen.getAllByTestId("review-file")).toHaveLength(2));
+    await openEditorAndSave("one");
+    mockedSend.mockRejectedValue(new Error("the manager tmux session did not come up"));
+    fireEvent.click(screen.getByTestId("review-comment-send"));
+    await waitFor(() => expect(screen.getByTestId("review-toast")).toHaveAttribute("data-error", "true"));
+    expect(screen.getByTestId("review-toast")).toHaveTextContent("did not come up");
+    expect(screen.getByTestId("review-comment")).toHaveAttribute("data-state", "draft");
+    expect(JSON.parse(localStorage.getItem(`pdo.review.drafts.${RUN_ID}`)!)).toHaveLength(1);
+  });
+
+  it("Send now from the editor saves and sends that one comment", async () => {
+    render(<ReviewPage runId={RUN_ID} />);
+    await waitFor(() => expect(screen.getAllByTestId("review-file")).toHaveLength(2));
+    const sent = [sentComment({ id: "rc-001", line: 2, text: "quick" })];
+    mockedSend.mockResolvedValue({ sent, batch_id: "b1", manager_started: false });
+    mockedRun.mockResolvedValue(makeRun({ has_manager: true, review_comments: sent }));
+    fireEvent.click(within(screen.getAllByTestId("review-file")[0]).getByTestId("mock-add-new-2"));
+    const editor = await screen.findByTestId("review-comment-editor");
+    fireEvent.change(within(editor).getByTestId("review-editor-text"), { target: { value: "quick" } });
+    fireEvent.click(within(editor).getByTestId("review-editor-send"));
+    await waitFor(() => expect(mockedSend).toHaveBeenCalledWith(RUN_ID, [expect.objectContaining({ text: "quick", line: 2 })]));
+    await waitFor(() => expect(screen.getByTestId("review-comment")).toHaveAttribute("data-state", "sent"));
+    expect(screen.getByTestId("review-toast")).toHaveTextContent("1 comment sent as one message.");
+  });
+
+  it("shows sent comments from the projected state on load and greys those of another pair in the sidebar", async () => {
+    mockedRun.mockResolvedValue(
+      makeRun({
+        review_comments: [sentComment(), sentComment({ id: "rc-002", from_ref: "node:impl:1:before", to_ref: "node:impl:1:after", line: 1 })],
+      }),
+    );
+    render(<ReviewPage runId={RUN_ID} />);
+    await waitFor(() => expect(screen.getAllByTestId("review-comment")).toHaveLength(1));
+    expect(screen.getAllByTestId("review-file")[0]).toHaveAttribute("data-sent", "1");
+    const rows = screen.getAllByTestId("review-comment-row");
+    expect(rows).toHaveLength(2);
+    expect(rows[1]).toHaveAttribute("data-other-pair", "true");
+    expect(rows[1]).toHaveTextContent("at implement · iter 1 · before → implement · iter 1 · after");
+    expect(screen.getByTestId("review-comments-pill")).toHaveTextContent("1 sent");
+  });
+
+  it("disables every send gesture with the reason when the Run branch is gone", async () => {
+    mockedRefs.mockResolvedValue({ ...REFS, refs: REFS.refs.map((r) => (r.id === "tip" ? { ...r, sha: null } : r)) });
+    render(<ReviewPage runId={RUN_ID} />);
+    await waitFor(() => expect(screen.getAllByTestId("review-file")).toHaveLength(2));
+    await waitFor(() => expect(screen.getByTestId("review-branch-gone")).toHaveTextContent(`pdo/run-${RUN_ID} no longer exists`));
+    fireEvent.click(within(screen.getAllByTestId("review-file")[0]).getByTestId("mock-add-new-2"));
+    const editor = await screen.findByTestId("review-comment-editor");
+    fireEvent.change(within(editor).getByTestId("review-editor-text"), { target: { value: "late" } });
+    expect(within(editor).getByTestId("review-editor-send")).toBeDisabled();
+    expect(within(editor).getByTestId("review-editor-send")).toHaveAttribute("title", expect.stringContaining("no longer exists"));
+    fireEvent.click(within(editor).getByTestId("review-editor-save"));
+    await screen.findByTestId("review-comment");
+    expect(screen.getByTestId("review-comment-send")).toBeDisabled();
+    expect(screen.getByTestId("review-send-all")).toBeDisabled();
+    expect(screen.getByTestId("review-send-pill")).toBeDisabled();
+    expect(screen.getByTestId("review-send-bar-note")).toHaveTextContent("no longer exists");
+    expect(mockedSend).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/ReviewPage.tsx
+++ b/frontend/src/pages/ReviewPage.tsx
@@ -11,12 +11,28 @@ import {
   SquareArrowOutUpRight,
 } from "lucide-react";
 import "@git-diff-view/react/styles/diff-view.css";
-import { fetchRun, fetchRunRefs, fetchRunStructuredDiff } from "../api";
+import { fetchRun, fetchRunRefs, fetchRunStructuredDiff, sendReviewComments } from "../api";
 import { useDaemonSocket } from "../hooks/useDaemonSocket";
 import type { RunRefs, RunState, StructuredDiff } from "../types";
 import RefPicker from "../components/review/RefPicker";
 import ReviewFileList from "../components/review/ReviewFileList";
 import ReviewFileCard from "../components/review/ReviewFileCard";
+import type { ReviewCommentsApi } from "../components/review/ReviewFileCard";
+import ReviewSendBar from "../components/review/ReviewSendBar";
+import {
+  addDraft,
+  countsByPath,
+  draftsForPair,
+  mergeEntries,
+  plural,
+  readDrafts,
+  removeDrafts,
+  sendDisabledReason as sendReasonOf,
+  toSendInputs,
+  updateDraft,
+  writeDrafts,
+} from "../lib/reviewComments";
+import type { Anchor, ReviewDraft, ReviewEntry } from "../lib/reviewComments";
 import {
   DEFAULT_FROM,
   DEFAULT_TO,
@@ -45,8 +61,16 @@ import type { RefPair, ViewMode } from "../lib/runRefs";
  * node delivery's before/after, a running node's live branch).
  *
  * Mounted full-window by `main.tsx` when the path matches; the app has no
- * router. The URL carries stable ref ids, never SHAs. Comments (#750) are not
- * here yet: the gutter and the "Send to manager" pill are reserved for them.
+ * router. The URL carries stable ref ids, never SHAs.
+ *
+ * Review comments (#750, ADR-0067 §2): the `+` on a line number opens an inline
+ * editor; a saved **draft** lives in this browser (localStorage per Run) until
+ * it is **sent** — per card, from the editor, or all at once from the sticky
+ * footer bar / the toolbar pill. Sending posts the batch to the daemon, which
+ * starts the manager on demand and hands it **one message**; the comments come
+ * back as immutable Run events (`review_comments` in the projected state,
+ * refreshed over the WebSocket). A Run whose branch is gone shows why sending
+ * is disabled instead of a dead button.
  */
 
 interface Props {
@@ -80,6 +104,14 @@ export default function ReviewPage({ runId }: Props) {
   const [reloadTick, setReloadTick] = useState(0);
   const [tipMoved, setTipMoved] = useState(false);
   const [nodeDelivered, setNodeDelivered] = useState<{ nodeId: string; iter: number } | null>(null);
+  // --- Review comments (#750) --------------------------------------------------
+  const [drafts, setDrafts] = useState<ReviewDraft[]>(() => readDrafts(runId));
+  const [editingKey, setEditingKey] = useState<string | null>(null);
+  const [sendingKeys, setSendingKeys] = useState<ReadonlySet<string>>(() => new Set());
+  const [startingManager, setStartingManager] = useState(false);
+  const [toast, setToast] = useState<{ text: string; error?: boolean } | null>(null);
+  const [commentCursor, setCommentCursor] = useState(-1);
+  const toastTimer = useRef<number | undefined>(undefined);
 
   const mainRef = useRef<HTMLDivElement | null>(null);
   const filterRef = useRef<HTMLInputElement | null>(null);
@@ -288,6 +320,173 @@ export default function ReviewPage({ runId }: Props) {
     if (target) el.scrollBy?.({ top: target.getBoundingClientRect().top - base, behavior: "smooth" });
   }, []);
 
+  // --- Review comments (#750) --------------------------------------------------
+  const showToast = useCallback((text: string, error = false) => {
+    setToast({ text, error });
+    window.clearTimeout(toastTimer.current);
+    toastTimer.current = window.setTimeout(() => setToast(null), error ? 6000 : 3600);
+  }, []);
+  useEffect(() => () => window.clearTimeout(toastTimer.current), []);
+
+  const persistDrafts = useCallback(
+    (next: ReviewDraft[]) => {
+      setDrafts(next);
+      writeDrafts(runId, next);
+    },
+    [runId],
+  );
+
+  const pathOrder = useMemo(() => files.map(filePath), [files]);
+  const entries = useMemo<ReviewEntry[]>(
+    () => mergeEntries(drafts, run?.review_comments, pair, pathOrder),
+    [drafts, run?.review_comments, pair, pathOrder],
+  );
+  const entriesByPath = useMemo(() => {
+    const m = new Map<string, ReviewEntry[]>();
+    for (const e of entries) {
+      const list = m.get(e.anchor.path) ?? [];
+      list.push(e);
+      m.set(e.anchor.path, list);
+    }
+    return m;
+  }, [entries]);
+  const counts = useMemo(() => countsByPath(entries), [entries]);
+  const pairDrafts = useMemo(() => draftsForPair(drafts, pair), [drafts, pair]);
+  const sentCount = entries.length - pairDrafts.length;
+  /** Comments written against another pair: listed greyed, never lost. */
+  const otherEntries = useMemo(() => {
+    const label = (from: string, to: string) => {
+      const name = (id: string) => refs?.refs.find((r) => r.id === id)?.label ?? id;
+      return `${name(from)} → ${name(to)}`;
+    };
+    const out: { entry: ReviewEntry; pair: string; refPair: RefPair }[] = [];
+    for (const d of drafts) {
+      if (d.from === pair.from && d.to === pair.to) continue;
+      out.push({ entry: { kind: "draft", anchor: d, draft: d }, pair: label(d.from, d.to), refPair: { from: d.from, to: d.to } });
+    }
+    for (const c of run?.review_comments ?? []) {
+      if (c.from_ref === pair.from && c.to_ref === pair.to) continue;
+      out.push({
+        entry: { kind: "sent", anchor: { path: c.path, side: c.side, line: c.line }, comment: c },
+        pair: label(c.from_ref, c.to_ref),
+        refPair: { from: c.from_ref, to: c.to_ref },
+      });
+    }
+    return out;
+  }, [drafts, run?.review_comments, pair, refs]);
+
+  const sendDisabledReason = sendReasonOf(run, refs);
+  const pairLabel = useMemo(() => {
+    const name = (id: string) => refs?.refs.find((r) => r.id === id)?.label ?? id;
+    return `${name(pair.from)} → ${name(pair.to)}`;
+  }, [refs, pair]);
+
+  /** Scroll the anchored line of an entry into view, expanding its file first. */
+  const jumpTo = useCallback(
+    (anchor: Anchor) => {
+      if (collapsedSet.has(anchor.path)) {
+        const next = new Set(collapsedSet);
+        next.delete(anchor.path);
+        setCollapsed(next);
+      }
+      const attempt = (left: number) => {
+        const card = cardEls.current.get(anchor.path);
+        const el =
+          card?.querySelector<HTMLElement>(`td.diff-line-${anchor.side}-num > span[data-line-num="${anchor.line}"]`) ??
+          card?.querySelector<HTMLElement>(`span[data-line-${anchor.side}-num="${anchor.line}"]`);
+        if (el) el.closest("tr")?.scrollIntoView?.({ behavior: "smooth", block: "center" });
+        else if (card && left > 0) window.setTimeout(() => attempt(left - 1), 60);
+        else if (card) {
+          const main = mainRef.current;
+          if (main) main.scrollTo?.({ top: Math.max(0, card.offsetTop - 8), behavior: "smooth" });
+        }
+      };
+      attempt(5);
+    },
+    [collapsedSet],
+  );
+  const jumpComment = useCallback(
+    (dir: 1 | -1) => {
+      if (entries.length === 0) return;
+      const next = (commentCursor + dir + entries.length) % entries.length;
+      setCommentCursor(next);
+      jumpTo(entries[next].anchor);
+    },
+    [entries, commentCursor, jumpTo],
+  );
+
+  /** Send `keys` out of `source` (defaults to the current drafts; `sendNew` passes the list it just grew). */
+  const send = useCallback(
+    async (keys: string[], source: ReviewDraft[] = drafts) => {
+      if (sendDisabledReason) {
+        showToast(sendDisabledReason, true);
+        return;
+      }
+      const targets = source.filter((d) => keys.includes(d.key));
+      if (targets.length === 0) return;
+      setSendingKeys(new Set(keys));
+      const mustStart = !(runRef.current?.has_manager ?? false);
+      setStartingManager(mustStart);
+      if (mustStart) showToast("Manager not running — starting it before sending…");
+      try {
+        const res = await sendReviewComments(runId, toSendInputs(targets));
+        persistDrafts(removeDrafts(source, keys));
+        setEditingKey((k) => (k && keys.includes(k) ? null : k));
+        try {
+          const r = await fetchRun(runId);
+          runRef.current = r;
+          setRun(r);
+        } catch {
+          // The WebSocket refresh lands anyway.
+        }
+        showToast(
+          `${plural(res.sent.length, "comment")} sent as one message${res.manager_started ? " — manager started" : ""}. Open the Manager tab to see it; replies show up inline.`,
+        );
+      } catch (e: unknown) {
+        // Nothing is lost: the drafts stay drafts, the operator retries.
+        showToast(`Send failed — ${e instanceof Error ? e.message : String(e)}. Your drafts are kept.`, true);
+      } finally {
+        setSendingKeys(new Set());
+        setStartingManager(false);
+      }
+    },
+    [drafts, runId, sendDisabledReason, showToast, persistDrafts],
+  );
+
+  const commentsApi = useMemo<ReviewCommentsApi>(
+    () => ({
+      editingKey,
+      sendingKeys,
+      startingManager,
+      pairLabel,
+      sendDisabledReason,
+      saveNew: (anchor, text) => {
+        persistDrafts(addDraft(drafts, anchor, pair, text));
+        showToast("Draft saved — kept in this browser until you send it.");
+      },
+      sendNew: (anchor, text) => {
+        const next = addDraft(drafts, anchor, pair, text);
+        persistDrafts(next);
+        const created = next[next.length - 1];
+        void send([created.key], next);
+      },
+      editDraft: (key) => setEditingKey(key),
+      updateDraft: (key, text) => {
+        persistDrafts(updateDraft(drafts, key, text));
+        setEditingKey(null);
+      },
+      cancelEdit: () => setEditingKey(null),
+      deleteDraft: (key) => {
+        persistDrafts(removeDrafts(drafts, [key]));
+        setEditingKey((k) => (k === key ? null : k));
+        showToast("Draft deleted.");
+      },
+      sendDraft: (key) => void send([key]),
+      sentLineClicked: () => showToast("This line already has a sent comment. Replies arrive with the next ticket.", true),
+    }),
+    [editingKey, sendingKeys, startingManager, pairLabel, sendDisabledReason, drafts, pair, persistDrafts, showToast, send],
+  );
+
   // --- Keyboard ---------------------------------------------------------------
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -298,6 +497,12 @@ export default function ReviewPage({ runId }: Props) {
       }
       if (e.metaKey || e.ctrlKey || e.altKey) return;
       switch (e.key) {
+        case "c":
+          jumpComment(1);
+          break;
+        case "C":
+          jumpComment(-1);
+          break;
         case "j":
           goFile(Math.min(files.length - 1, currentIdx + 1));
           break;
@@ -327,7 +532,7 @@ export default function ReviewPage({ runId }: Props) {
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [files.length, currentIdx, view, listOpen, goFile, goHunk]);
+  }, [files.length, currentIdx, view, listOpen, goFile, goHunk, jumpComment]);
 
   // --- Exit -------------------------------------------------------------------
   const goBack = () => {
@@ -479,16 +684,44 @@ export default function ReviewPage({ runId }: Props) {
         >
           <ListMinus size={11} /> Collapse all
         </button>
-        {/* Reserved for #750: comments and their send gesture. Visible, sober, disabled. */}
-        <span
-          className="flex items-center gap-1 rounded border border-line-strong bg-bg-3 px-2 py-0.5 text-fg-3 opacity-50"
-          title="Comments arrive in the next ticket (#750)."
-          aria-disabled
-          data-testid="review-send-placeholder"
-          style={{ fontSize: "10.5px" }}
-        >
-          <MessageSquare size={11} /> 0 · Send to manager
-        </span>
+        {/* #750: pending drafts → the send-all gesture (also in the footer bar); otherwise a counter + navigator. */}
+        {pairDrafts.length > 0 ? (
+          <>
+            <button
+              type="button"
+              onClick={() => void send(pairDrafts.map((d) => d.key))}
+              disabled={!!sendDisabledReason || sendingKeys.size > 0}
+              title={sendDisabledReason ?? "Send every draft to the manager as one message"}
+              data-testid="review-send-pill"
+              className="flex cursor-pointer items-center gap-1 rounded border border-acc-border bg-acc-bg px-2 py-0.5 text-acc hover:bg-acc/20 disabled:cursor-not-allowed disabled:opacity-45"
+              style={{ fontSize: "10.5px" }}
+            >
+              ↗ Send {plural(pairDrafts.length, "draft")} to manager
+            </button>
+            {sentCount > 0 && (
+              <span
+                className="flex items-center gap-1 rounded border border-line-strong bg-bg-3 px-2 py-0.5 text-st-running"
+                title={`${sentCount} sent, awaiting reply`}
+                data-testid="review-sent-pill"
+                style={{ fontSize: "10.5px" }}
+              >
+                ↗ {sentCount} sent
+              </span>
+            )}
+          </>
+        ) : (
+          <button
+            type="button"
+            onClick={() => jumpComment(1)}
+            disabled={entries.length === 0}
+            title="Jump to the next comment  ( c / C )"
+            data-testid="review-comments-pill"
+            className="flex cursor-pointer items-center gap-1 rounded border border-line-strong bg-bg-3 px-2 py-0.5 text-fg-3 hover:text-fg-2 disabled:cursor-not-allowed disabled:opacity-50"
+            style={{ fontSize: "10.5px" }}
+          >
+            <MessageSquare size={11} /> {sentCount > 0 ? `${sentCount} sent` : "0 comments"}
+          </button>
+        )}
         <a
           href={reviewUrl(runId, pair)}
           target="_blank"
@@ -512,6 +745,15 @@ export default function ReviewPage({ runId }: Props) {
             currentIndex={currentIdx}
             onSelect={goFile}
             onClose={toggleList}
+            counts={counts}
+            comments={{ current: entries, other: otherEntries.map(({ entry, pair: p }) => ({ entry, pair: p })) }}
+            onJumpEntry={(e) => jumpTo(e.anchor)}
+            onJumpOther={(e) => {
+              const o = otherEntries.find((x) => x.entry === e);
+              if (!o) return;
+              setPair(o.refPair);
+              window.setTimeout(() => jumpTo(e.anchor), 400);
+            }}
           />
         ) : (
           <div />
@@ -567,6 +809,16 @@ export default function ReviewPage({ runId }: Props) {
               >
                 Switch to its after ref
               </button>
+            </div>
+          )}
+
+          {sendDisabledReason && !isArchived && (
+            <div
+              className="mx-3 mt-2.5 flex items-center gap-2 rounded-md border border-st-await/35 bg-st-await-bg px-2.5 py-1.5 text-fg-2"
+              style={{ fontSize: "11px" }}
+              data-testid="review-branch-gone"
+            >
+              ⚠ <span>{sendDisabledReason}</span>
             </div>
           )}
 
@@ -667,14 +919,41 @@ export default function ReviewPage({ runId }: Props) {
                     collapsed={collapsedSet.has(p)}
                     onToggle={() => toggleFile(p)}
                     registerEl={registerEl}
+                    entries={entriesByPath.get(p)}
+                    comments={commentsApi}
                   />
                 );
               })}
+              <ReviewSendBar
+                drafts={pairDrafts}
+                sentCount={sentCount}
+                sending={sendingKeys.size > 0}
+                managerRunning={run?.has_manager ?? false}
+                sendDisabledReason={sendDisabledReason}
+                onJump={(d) => jumpTo(d)}
+                onSendAll={() => void send(pairDrafts.map((d) => d.key))}
+              />
               <div className="h-[40vh]" />
             </>
           )}
         </div>
       </div>
+
+      {toast && (
+        <div
+          role="status"
+          data-testid="review-toast"
+          data-error={toast.error ? "true" : undefined}
+          className={`fixed right-3.5 z-[60] max-w-[420px] rounded-md border border-line-strong bg-bg-3 px-2.5 py-[7px] text-fg-2 shadow-[0_8px_30px_rgba(0,0,0,.5)] ${
+            pairDrafts.length > 0 ? "bottom-[52px]" : "bottom-3.5"
+          } ${
+            toast.error ? "border-l-[3px] border-l-st-failed" : "border-l-[3px] border-l-acc"
+          }`}
+          style={{ fontSize: "11px" }}
+        >
+          {toast.text}
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1107,6 +1107,8 @@ export interface RunState {
    * derived flag). Absent on older payloads, read as `false`.
    */
   has_manager?: boolean;
+  /** #750: sent review comments, in send order. Absent when nobody reviewed. */
+  review_comments?: ReviewComment[];
   /**
    * Lines changed for the run (`git diff --numstat` of the run branch, `.pdo/`
    * excluded), or null/absent once the branch is gone (archived/cleaned) — the
@@ -2012,6 +2014,62 @@ export interface RunRefs {
   deliveries: RunDelivery[];
   default_from: string;
   default_to: string;
+}
+
+// ---------------------------------------------------------------------------
+// Review comments (#750, ADR-0067 §2) — `sent` comments are Run events, folded
+// into `RunState.review_comments`; drafts never leave the browser (see
+// `lib/reviewComments.ts`).
+// ---------------------------------------------------------------------------
+
+/** `old` = the source ref's line (left), `new` = the destination ref's (right). */
+export type ReviewSide = "old" | "new";
+export type ReviewCommentStatus = "sent" | "resolved";
+
+/** An agent's reply (#751 emits them; the shape is fixed here). */
+export interface ReviewReply {
+  author: string;
+  text: string;
+  at: string;
+  proposes_resolution?: boolean;
+}
+
+export interface ReviewComment {
+  /** `rc-001`, … — what the manager echoes in `pdo review reply`. */
+  id: string;
+  path: string;
+  side: ReviewSide;
+  line: number;
+  /** Stable Run ref ids of the pair the comment was written against. */
+  from_ref: string;
+  to_ref: string;
+  from_sha?: string;
+  to_sha?: string;
+  text: string;
+  /** Hunk excerpt at send time, the anchored line marked `>`. */
+  excerpt?: string;
+  author: string;
+  sent_at: string;
+  batch_id?: string;
+  status: ReviewCommentStatus;
+  replies?: ReviewReply[];
+}
+
+/** One draft as posted to `POST /runs/<id>/review/comments/send`. */
+export interface SendReviewCommentInput {
+  path: string;
+  side: ReviewSide;
+  line: number;
+  from: string;
+  to: string;
+  text: string;
+}
+
+export interface SendReviewCommentsResponse {
+  sent: ReviewComment[];
+  batch_id: string;
+  /** True when this send started the manager on demand. */
+  manager_started: boolean;
 }
 
 export interface StructuredDiff {

--- a/prompts/builtin/manager.md
+++ b/prompts/builtin/manager.md
@@ -13,3 +13,9 @@ To act on the Run, `POST` to the commands endpoint listed in the preamble. Each 
 You do **not** spawn sub-agents. If the user wants deeper investigation of a specific NodeRun, point them to attach that node's tmux session directly.
 
 Read first, act second. Confirm before any destructive command and treat `cleanup_run` as irreversible — confirm it twice.
+
+## Review comments
+
+A human can review the Run's diff on the Review page and **send** you review comments. They arrive as **one message per batch**, each comment with an id (`rc-001`, `rc-002`, …), its anchor (`<path>:R<line>` on the destination side, `:L<line>` on the source side), the pair of Run refs it was written against, an excerpt of the hunk with the anchored line marked `>`, and the text. Sent comments are immutable Run events: `GET <base URL>/runs/<run-id>/review/comments` lists them (also under `review_comments` in the projected Run state).
+
+Treat each comment as a remark to act on: fix the code it points at on the Run branch (through the Run's own mechanisms — a `restart_node`, an injected instruction, a node session — never by editing the comment), or explain why not. Answer **per comment** with `pdo review reply <id> --text "<your answer>"`, adding `--resolved` when you consider it addressed; `pdo review list` shows the open ones. The human resolves by default — your `--resolved` is a proposal unless the instance setting `review_agent_can_resolve` says otherwise.

--- a/scripts/layout-ratchet.sh
+++ b/scripts/layout-ratchet.sh
@@ -24,9 +24,14 @@ cd "$(git rev-parse --show-toplevel)"
 #   already present on main (the CI ratchet is red there since the run behind
 #   #718); #722 adds no top-level file to either directory, the flat counts are
 #   re-admitted as-is to green the gate again. Ratchet down when tidied.
+# frontend/src/components: 188 and crates/pdo-daemon/src: 87 (#750) — 188 re-admits
+#   three top-level components that landed on main after the previous reconcile
+#   (the review UI itself lives under components/review/, not counted); 87 admits
+#   review_comments.rs, the review-comment concern (ids, excerpt, batch message,
+#   projection fold — ADR-0067 §2). Ratchet down when tidied.
 BASELINES='
-frontend/src/components 185
-crates/pdo-daemon/src 83
+frontend/src/components 188
+crates/pdo-daemon/src 87
 '
 
 fail=0


### PR DESCRIPTION
Closes #750 (sub-ticket of story #746, ADR-0067). Release 1.77.0.

## What
- **Backend**: new `review_comments` module; events `review_comment_sent` (+ `replied`/`resolved`/`reopened` structure for #751) folded into `RunState.review_comments`; `GET /runs/{id}/review/comments`, `POST /runs/{id}/review/comments/send` (409 `run_branch_gone` when the branch is missing / Run archived, nothing written); manager started on demand; one batch message pasted via `load-buffer` + `paste-buffer`.
- **Frontend**: `+` widget opens an inline editor (Write/Preview, ⌘↵/Esc, Cancel · Send now · Save draft); drafts in localStorage per Run; draft/sent cards with amber/blue anchors; toolbar pill + sticky footer bar to send all; branch-gone banner disables sending.
- `prompts/builtin/manager.md`: "Review comments" section. Layout ratchet baselines reconciled.

## Verification
- Agentic Feature Path (FP) for #750: **5/5 steps Pass** on a debug daemon with the built frontend (draft → reload → edit → send all → manager pane shows one batch → reload). Extra checks (unified view, Diff tab badge, branch gone 409, design conformity) pass. No blocking finding.
- Non-blocking follow-ups noted by the test: branch-gone leaves the diff body on a bare 404 error (comments readable via the sidebar only); comment navigation uses `c`/`C` instead of the prototype's `n`/`p` (kept for hunks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)