### PR TITLE
feat(review): conversation with the agent — pdo review list/reply, proposed resolution, review_agent_can_resolve (#751)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ ascendante** : la casse se signale ici et par un bump majeur, jamais en gardant 
 morts. Seule contrainte non négociable — les **données historiques restent lisibles** : un Run
 archivé s'ouvre et se chiffre quelle que soit la version qui a écrit son payload.
 
+## 1.78.0
+**Page de Review — conversation avec l'agent** (#751 ; story #746, ADR-0067).
+Un commentaire envoyé devient un **fil** : l'agent répond avec `pdo review list [--state open|resolved|all]`
+et `pdo review reply <rc-id> --text "…" [--resolved]` (auteur déduit de la session : `manager` ou l'id du
+nœud). Les évènements `review_comment_replied` / `resolved` / `reopened` sont désormais émis et projetés
+(`proposal_pending`, `resolved_by`, `reopened_by`, `proposal_declined`). Par défaut, un `--resolved` de
+l'agent n'est qu'une **proposition** : la carte passe en ambre et l'humain tranche avec **Resolve** /
+**Reopen** (Reopen sur une proposition = refus, le commentaire reste ouvert). Nouveau réglage d'instance
+`review_agent_can_resolve` (`PUT /settings`, env `PDO_REVIEW_AGENT_CAN_RESOLVE`, défaut `false`, case
+Settings › Runs « Let the agent resolve review comments directly ») : quand il est actif, l'agent résout
+directement et l'humain peut rouvrir. Endpoints `POST /runs/{id}/review/comments/{rc}/reply|resolve|reopen`
+(idempotents, `changed: false` sans évènement), `GET …/review/comments?state=`. Côté UI : icônes d'état
+(ouvert / proposé / résolu) et d'auteur, cartes résolues repliées sur une ligne, pastille cloche des
+réponses non lues (mémorisées par navigateur), bascule œil pour masquer le résolu, badge bleu sur l'onglet
+Diff du Run tant qu'une réponse n'est pas lue. Le prompt builtin du manager documente le CLI.
 ## 1.77.0
 
 **Page de Review — commentaires inline, brouillons et envoi au manager** (#750 ; story #746, ADR-0067).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "1.77.0"
+version = "1.78.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "1.77.0"
+version = "1.78.0"
 license = "MIT"
 description = "Prompt-Driven Orchestrator — a local daemon that runs and supervises agentic coding pipelines"
 repository = "https://github.com/Loulen/prompt-driven-orchestrator"

--- a/crates/pdo-daemon/src/instance_config.rs
+++ b/crates/pdo-daemon/src/instance_config.rs
@@ -116,6 +116,13 @@ pub(crate) struct InstanceConfig {
     /// then the built-in default (`true`). A stored `0` is a decision that beats
     /// the env — same `0`-not-`NULL` discipline as [`Self::autocomplete_turn_end`].
     pub update_check: Option<i64>,
+    /// Stored `review_agent_can_resolve` flag as `0`/`1`, or `None` when unset
+    /// (#751, ADR-0067 §4): may an agent's `pdo review reply --resolved` resolve
+    /// the comment directly? `None` falls through to the env seam
+    /// ([`crate::review_comments::REVIEW_AGENT_CAN_RESOLVE_ENV`]) then the
+    /// built-in default (`false`: the reply is a proposal the human decides on).
+    /// Same `0`-not-`NULL` discipline as [`Self::default_auto_name`].
+    pub review_agent_can_resolve: Option<i64>,
     /// The Instance tier of the agentic-profile union (#563, ADR-0057) — the
     /// **coarsest** tier `agent_choice::resolve` consults, just above the
     /// reserved Default profile floor. `None` (unset) preserves the pre-#563
@@ -215,6 +222,10 @@ pub(crate) struct UpdateInstanceConfig {
     /// Set the `update_check` flag (#697): `Some(true)` stores `1`, `Some(false)`
     /// stores `0`, `None` leaves it untouched.
     pub update_check: Option<bool>,
+    /// Set the `review_agent_can_resolve` flag (#751): `Some(true)` stores `1`,
+    /// `Some(false)` stores `0`, `None` leaves it untouched. Same set-only,
+    /// `0`-not-`NULL` discipline as [`Self::default_auto_name`].
+    pub review_agent_can_resolve: Option<bool>,
     /// Set the Instance tier of the agentic-profile union (#563): `Some(None)`
     /// clears it back to unset (legacy `default_harness`/`default_harness_model`
     /// decide again); `Some(Some(choice))` sets it; `None` leaves it untouched.
@@ -253,6 +264,7 @@ impl UpdateInstanceConfig {
             && self.default_harness_model.is_none()
             && self.auto_fail.is_none()
             && self.update_check.is_none()
+            && self.review_agent_can_resolve.is_none()
             && self.agent_choice.is_none()
             && self.skills.is_none()
             && self.manager_enabled.is_none()
@@ -284,6 +296,7 @@ pub(crate) async fn init(db: &SqlitePool) -> Result<(), sqlx::Error> {
             libassist_idle_ttl_secs INTEGER,
             agent_choice       TEXT,
             update_check       INTEGER,
+            review_agent_can_resolve INTEGER,
             manager_enabled    INTEGER,
             manager_profile    TEXT,
             updated_at         TEXT NOT NULL
@@ -463,6 +476,20 @@ pub(crate) async fn init(db: &SqlitePool) -> Result<(), sqlx::Error> {
             .await?;
     }
 
+    // Additive migration, pre-#751: NULLABLE so an existing instance keeps the
+    // built-in default (the human resolves, the agent proposes).
+    let has_review_agent_can_resolve = sqlx::query(
+        "SELECT 1 FROM pragma_table_info('instance_config') WHERE name = 'review_agent_can_resolve'",
+    )
+    .fetch_optional(db)
+    .await?
+    .is_some();
+    if !has_review_agent_can_resolve {
+        sqlx::query("ALTER TABLE instance_config ADD COLUMN review_agent_can_resolve INTEGER")
+            .execute(db)
+            .await?;
+    }
+
     // Additive migration (manager on demand): NULLABLE keeps every existing
     // install on the pre-change behaviour is FALSE here on purpose — the change
     // itself — but the column must stay NULLABLE so a stored `0` remains a
@@ -517,6 +544,8 @@ fn row_to_config(row: &sqlx::sqlite::SqliteRow) -> InstanceConfig {
         auto_fail: row.get("auto_fail"),
         // #697: `try_get` so a row read before the column migration still maps.
         update_check: row.try_get("update_check").unwrap_or(None),
+        // #751: same posture — a row read before the column migration still maps.
+        review_agent_can_resolve: row.try_get("review_agent_can_resolve").unwrap_or(None),
         // #563: NULL / unparseable ⇒ `None` — the tier is simply transparent,
         // never an error (mirrors `default_harness_model`'s degrade-to-empty).
         agent_choice: row
@@ -593,6 +622,9 @@ pub(crate) async fn update(
     if edit.update_check.is_some() {
         sets.push("update_check = ?");
     }
+    if edit.review_agent_can_resolve.is_some() {
+        sets.push("review_agent_can_resolve = ?");
+    }
     if edit.agent_choice.is_some() {
         sets.push("agent_choice = ?");
     }
@@ -665,6 +697,11 @@ pub(crate) async fn update(
     if let Some(v) = edit.update_check {
         // 0/1, never NULL: turning the check off must persist a stored `0` that
         // beats a `PDO_UPDATE_CHECK=1` (#697).
+        query = query.bind(if v { 1_i64 } else { 0_i64 });
+    }
+    if let Some(v) = edit.review_agent_can_resolve {
+        // 0/1, never NULL: unticking must persist a stored `0` that beats a
+        // `PDO_REVIEW_AGENT_CAN_RESOLVE=1`, not fall through to it (#751).
         query = query.bind(if v { 1_i64 } else { 0_i64 });
     }
     if let Some(v) = edit.agent_choice {

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -245,6 +245,43 @@ pub enum Commands {
         #[command(subcommand)]
         action: PageAction,
     },
+    /// Read and answer the review comments a human left on this Run's diff
+    /// (#751, ADR-0067 §4). Run from a node or manager session: the Run id comes
+    /// from `PDO_RUN_ID` (`--run` overrides it) and the author from the session
+    /// (`manager`, or the node id).
+    Review {
+        #[command(subcommand)]
+        action: ReviewAction,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum ReviewAction {
+    /// List the Run's review comments as JSON, each with its thread of replies.
+    List {
+        /// `open` (default), `resolved` or `all`.
+        #[arg(long, default_value = "open")]
+        state: String,
+        /// The Run to read; defaults to the session's `PDO_RUN_ID`.
+        #[arg(long)]
+        run: Option<String>,
+    },
+    /// Reply to one comment (`rc-001`, …). `--resolved` proposes a resolution —
+    /// or resolves directly when the instance setting `review_agent_can_resolve`
+    /// is on. The human can always reopen.
+    Reply {
+        /// The comment id, as shown by `pdo review list` and in the message you received.
+        id: String,
+        /// Your answer (markdown). `--body` is accepted as an alias.
+        #[arg(long, visible_alias = "body")]
+        text: String,
+        /// You consider the comment addressed.
+        #[arg(long)]
+        resolved: bool,
+        /// The Run the comment belongs to; defaults to the session's `PDO_RUN_ID`.
+        #[arg(long)]
+        run: Option<String>,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -1315,6 +1352,79 @@ pub fn run_run_create(action: RunAction) -> Result<()> {
             println!("Run {run_id} created — child of run {parent_run} (node {parent_node}).")
         }
         None => println!("Run {run_id} created (root run)."),
+    }
+    Ok(())
+}
+
+/// One-shot `pdo review list` / `pdo review reply` (#751): the thin CLI client of
+/// the review endpoints. Blocking `reqwest`, no tokio runtime (see `main.rs`);
+/// plain `Result` → `0`/`1` exit mapping. Identity travels in the session headers
+/// — the daemon deduces the author (`manager` for the manager session, else the
+/// node id); `--run` only changes which Run is addressed, never who speaks.
+pub fn run_review(action: ReviewAction) -> Result<()> {
+    let url = cli_daemon_url();
+    let client = reqwest::blocking::Client::new();
+    let session = session_env_claim();
+    let with_identity = |request: reqwest::blocking::RequestBuilder| {
+        let mut request = request.header("X-PDO-Actor", "cli");
+        if let Some((run_id, node_id)) = &session {
+            request = request
+                .header(SESSION_RUN_HEADER, run_id)
+                .header(SESSION_NODE_HEADER, node_id);
+        }
+        request
+    };
+    let run_of = |flag: Option<String>| -> Result<String> {
+        match flag {
+            Some(r) if !r.trim().is_empty() => Ok(r.trim().to_string()),
+            _ => cli_run_id().context(
+                "no Run: pass `--run <run-id>` or run this from a PDO node/manager session",
+            ),
+        }
+    };
+
+    match action {
+        ReviewAction::List { state, run } => {
+            let run_id = run_of(run)?;
+            if review_comments::StateFilter::parse(&state).is_none() {
+                anyhow::bail!("--state must be `open`, `resolved` or `all`, got {state:?}");
+            }
+            let response = with_identity(client.get(format!(
+                "{url}/runs/{run_id}/review/comments?state={}",
+                state.trim()
+            )))
+            .send()
+            .context("failed to reach daemon")?;
+            let body: serde_json::Value = page_cli_response(response, "list review comments")?;
+            println!("{}", serde_json::to_string_pretty(&body)?);
+        }
+        ReviewAction::Reply {
+            id,
+            text,
+            resolved,
+            run,
+        } => {
+            let run_id = run_of(run)?;
+            if text.trim().is_empty() {
+                anyhow::bail!("--text must not be empty");
+            }
+            let response = with_identity(client.post(format!(
+                "{url}/runs/{run_id}/review/comments/{}/reply",
+                id.trim()
+            )))
+            .json(&serde_json::json!({ "text": text, "resolved": resolved }))
+            .send()
+            .context("failed to reach daemon")?;
+            let body: serde_json::Value = page_cli_response(response, "reply to review comment")?;
+            let author = body["author"].as_str().unwrap_or("agent");
+            let outcome = body["outcome"].as_str().unwrap_or("replied");
+            let what = match outcome {
+                "resolved" => "resolved (the instance lets agents resolve; the human can reopen)",
+                "proposed" => "resolution proposed — the human decides with Resolve / Reopen",
+                _ => "reply recorded",
+            };
+            println!("{id}: {what} · author {author} · run {run_id}");
+        }
     }
     Ok(())
 }
@@ -4474,6 +4584,18 @@ fn build_router(state: Arc<AppState>) -> Router {
         .route("/runs/{run_id}/file", get(run_file_at_ref))
         .route("/runs/{run_id}/refs", get(run_refs))
         .route("/runs/{run_id}/review/comments", get(list_review_comments))
+        .route(
+            "/runs/{run_id}/review/comments/{comment_id}/reply",
+            post(reply_review_comment),
+        )
+        .route(
+            "/runs/{run_id}/review/comments/{comment_id}/resolve",
+            post(resolve_review_comment),
+        )
+        .route(
+            "/runs/{run_id}/review/comments/{comment_id}/reopen",
+            post(reopen_review_comment),
+        )
         .route(
             "/runs/{run_id}/review/comments/send",
             post(send_review_comments),
@@ -10167,6 +10289,19 @@ async fn build_settings_view(state: &AppState) -> Result<serde_json::Value, sqlx
     };
 
     // #697: the version-check switch, same `0`/`1` stored discipline.
+    // #751: `review_agent_can_resolve`, against the reply endpoint's resolver.
+    let racr_stored = cfg.review_agent_can_resolve.map(|v| v != 0);
+    let racr_env = review_comments::env_review_agent_can_resolve();
+    let racr_effective =
+        review_comments::review_agent_can_resolve_with(cfg.review_agent_can_resolve);
+    let racr_source = if racr_stored.is_some() {
+        "stored"
+    } else if racr_env.is_some() {
+        "env"
+    } else {
+        "default"
+    };
+
     let uc_stored = cfg.update_check.map(|v| v != 0);
     let uc_env = update_check::env_update_check();
     let uc_effective = update_check::update_check_with(cfg.update_check);
@@ -10401,6 +10536,15 @@ async fn build_settings_view(state: &AppState) -> Result<serde_json::Value, sqlx
             uc_stored,
             uc_env,
             update_check::UPDATE_CHECK_DEFAULT,
+        ),
+        // #751: may an agent's `pdo review reply --resolved` resolve the comment
+        // directly? Default OFF: the human resolves, the agent proposes (ADR-0067 §4).
+        "review_agent_can_resolve": settings_field_bool(
+            racr_effective,
+            racr_source,
+            racr_stored,
+            racr_env,
+            review_comments::REVIEW_AGENT_CAN_RESOLVE_DEFAULT,
         ),
         // Manager on demand: off by default — a Run starts managerless and the
         // Manager tab's Start button (or the Settings toggle for future Runs)
@@ -13770,18 +13914,340 @@ async fn run_refs(
     Json(run_refs::collect(&run_id, &run_state, &events, &sha_of)).into_response()
 }
 
-/// `GET /runs/<id>/review/comments` (#750): the Run's **sent** review comments as
-/// projected from the event log — the same list `GET /runs/<id>` carries under
-/// `review_comments`, exposed on its own for the CLI (#751) and the tests.
+#[derive(Deserialize)]
+struct ListReviewCommentsQuery {
+    /// `open` (default for the CLI) | `resolved` | `all` (default here: the UI
+    /// wants everything, resolved ones collapse client-side).
+    #[serde(default)]
+    state: Option<String>,
+}
+
+/// `GET /runs/<id>/review/comments[?state=open|resolved|all]` (#750, #751): the
+/// Run's **sent** review comments as projected from the event log — the same
+/// list `GET /runs/<id>` carries under `review_comments`, with each comment's
+/// thread (`replies`), exposed on its own for `pdo review list` and the tests.
+/// Also answers `review_agent_can_resolve` so a CLI can say what `--resolved`
+/// will do.
 async fn list_review_comments(
     State(state): State<Arc<AppState>>,
     AxumPath(run_id): AxumPath<String>,
+    Query(q): Query<ListReviewCommentsQuery>,
+) -> Response {
+    let filter = match q.state.as_deref() {
+        None => review_comments::StateFilter::All,
+        Some(raw) => match review_comments::StateFilter::parse(raw) {
+            Some(f) => f,
+            None => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(serde_json::json!({
+                        "error": format!("state must be `open`, `resolved` or `all`, got {raw:?}")
+                    })),
+                )
+                    .into_response();
+            }
+        },
+    };
+    let (_, run_state) = match load_projected(&state, &run_id).await {
+        Ok(t) => t,
+        Err(resp) => return *resp,
+    };
+    let comments: Vec<&review_comments::ReviewComment> = run_state
+        .review_comments
+        .iter()
+        .filter(|c| filter.keeps(c))
+        .collect();
+    let can_resolve = review_agent_can_resolve(&state).await;
+    Json(serde_json::json!({
+        "comments": comments,
+        "agent_can_resolve": can_resolve,
+    }))
+    .into_response()
+}
+
+/// The instance's `review_agent_can_resolve`, read FRESH at the edge (never
+/// cached at boot) through `stored → env → default(false)` — the same chokepoint
+/// discipline as `default_auto_name`.
+async fn review_agent_can_resolve(state: &AppState) -> bool {
+    let stored = instance_config::get(&state.db)
+        .await
+        .ok()
+        .and_then(|c| c.review_agent_can_resolve);
+    review_comments::review_agent_can_resolve_with(stored)
+}
+
+#[derive(Deserialize)]
+struct ReplyReviewCommentRequest {
+    text: String,
+    /// The agent considers the comment addressed: a **proposal** unless the
+    /// instance setting lets agents resolve directly.
+    #[serde(default)]
+    resolved: bool,
+    /// Fallback author when the call carries no session headers (the CLI
+    /// always sends them from a node or manager session).
+    #[serde(default)]
+    author: Option<String>,
+}
+
+/// Find a sent comment by id, or answer the 404 the three verbs share.
+fn find_review_comment<'a>(
+    run_state: &'a event_log::RunState,
+    comment_id: &str,
+) -> Result<&'a review_comments::ReviewComment, Box<Response>> {
+    run_state
+        .review_comments
+        .iter()
+        .find(|c| c.id == comment_id)
+        .ok_or_else(|| {
+            Box::new(
+                (
+                    StatusCode::NOT_FOUND,
+                    Json(serde_json::json!({
+                        "error": format!("unknown review comment {comment_id:?} on this Run (ids read rc-001, rc-002, …; `pdo review list` shows them)")
+                    })),
+                )
+                    .into_response(),
+            )
+        })
+}
+
+/// Append one review event (`replied` / `resolved` / `reopened`) and hand back the
+/// freshly projected comment. Every append broadcasts, so the Review page sees
+/// the reply inline without polling.
+async fn append_review_event(
+    state: &AppState,
+    run_id: &str,
+    kind: event_log::EventKind,
+    payload: serde_json::Value,
+) -> Result<(), Box<Response>> {
+    let event = event_log::Event {
+        id: None,
+        run_id: run_id.to_string(),
+        ts: event_log::now_iso(),
+        kind,
+        node_id: None,
+        iter: None,
+        payload: Some(payload),
+    };
+    append_event(state, &event).await.map_err(|e| {
+        error!("run {run_id}: failed to append {:?}: {e}", event.kind);
+        Box::new(
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": format!("failed to record the event: {e}") })),
+            )
+                .into_response(),
+        )
+    })
+}
+
+/// The projected comment after the appends, for the response body.
+async fn projected_review_comment(
+    state: &AppState,
+    run_id: &str,
+    comment_id: &str,
+) -> Result<review_comments::ReviewComment, Box<Response>> {
+    let (_, run_state) = load_projected(state, run_id).await?;
+    find_review_comment(&run_state, comment_id).cloned()
+}
+
+/// `POST /runs/<id>/review/comments/<rc-id>/reply` (#751, ADR-0067 §4; CONTEXT.md
+/// « Réponse de review »): an agent — the manager or any node of the Run — answers
+/// a sent comment. The author is **deduced from the session** that calls (the
+/// `X-PDO-Session-*` headers `pdo review reply` forwards: the manager session
+/// reads `manager`, a node session its node id). `resolved: true` is a
+/// **proposal** by default (`review_comment_replied` with
+/// `proposes_resolution`); under `review_agent_can_resolve` it also appends
+/// `review_comment_resolved` by the same author — the human keeps Reopen either
+/// way. Replies are welcome on a resolved comment too (the thread stays open to
+/// clarification); `resolved` is then just a reply.
+async fn reply_review_comment(
+    State(state): State<Arc<AppState>>,
+    AxumPath((run_id, comment_id)): AxumPath<(String, String)>,
+    headers: HeaderMap,
+    Json(req): Json<ReplyReviewCommentRequest>,
 ) -> Response {
     let (_, run_state) = match load_projected(&state, &run_id).await {
         Ok(t) => t,
         Err(resp) => return *resp,
     };
-    Json(serde_json::json!({ "comments": run_state.review_comments })).into_response()
+    let text = req.text.trim_end().to_string();
+    if text.trim().is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": "empty reply text" })),
+        )
+            .into_response();
+    }
+    let comment = match find_review_comment(&run_state, &comment_id) {
+        Ok(c) => c.clone(),
+        Err(resp) => return *resp,
+    };
+    let session_node = session_claim_from_headers(&headers).map(|c| c.node_id);
+    let author = review_comments::reply_author(session_node.as_deref(), req.author.as_deref());
+
+    let can_resolve = req.resolved && review_agent_can_resolve(&state).await;
+    let outcome =
+        if !req.resolved || comment.status == review_comments::ReviewCommentStatus::Resolved {
+            review_comments::ReplyOutcome::Replied
+        } else if can_resolve {
+            review_comments::ReplyOutcome::Resolved
+        } else {
+            review_comments::ReplyOutcome::Proposed
+        };
+
+    if let Err(resp) = append_review_event(
+        &state,
+        &run_id,
+        event_log::EventKind::ReviewCommentReplied,
+        serde_json::json!({
+            "id": comment_id,
+            "author": author,
+            "text": text,
+            "proposes_resolution": req.resolved && comment.status != review_comments::ReviewCommentStatus::Resolved,
+        }),
+    )
+    .await
+    {
+        return *resp;
+    }
+    if outcome == review_comments::ReplyOutcome::Resolved {
+        if let Err(resp) = append_review_event(
+            &state,
+            &run_id,
+            event_log::EventKind::ReviewCommentResolved,
+            serde_json::json!({ "id": comment_id, "by": author }),
+        )
+        .await
+        {
+            return *resp;
+        }
+    }
+    info!(
+        "run {run_id}: {author} replied to review comment {comment_id} ({})",
+        match outcome {
+            review_comments::ReplyOutcome::Replied => "reply",
+            review_comments::ReplyOutcome::Proposed => "resolution proposed",
+            review_comments::ReplyOutcome::Resolved => "resolved directly, setting on",
+        }
+    );
+    match projected_review_comment(&state, &run_id, &comment_id).await {
+        Ok(c) => Json(serde_json::json!({
+            "comment": c,
+            "author": author,
+            "outcome": outcome,
+        }))
+        .into_response(),
+        Err(resp) => *resp,
+    }
+}
+
+#[derive(Deserialize, Default)]
+struct ReviewDecisionRequest {
+    /// Who decides — `user` (the Review page, default) or an agent id for a
+    /// scripted resolution.
+    #[serde(default)]
+    by: Option<String>,
+}
+
+/// `POST /runs/<id>/review/comments/<rc-id>/resolve` (#751): the human resolves
+/// (accepts a proposal, or closes a comment outright). Already resolved ⇒ `200`
+/// with `changed: false` and no event — two browsers clicking is not an error.
+async fn resolve_review_comment(
+    State(state): State<Arc<AppState>>,
+    AxumPath((run_id, comment_id)): AxumPath<(String, String)>,
+    headers: HeaderMap,
+    body: Option<Json<ReviewDecisionRequest>>,
+) -> Response {
+    review_decision(
+        &state,
+        &run_id,
+        &comment_id,
+        &headers,
+        body.map(|Json(b)| b).unwrap_or_default(),
+        review_comments::ReviewCommentStatus::Resolved,
+    )
+    .await
+}
+
+/// `POST /runs/<id>/review/comments/<rc-id>/reopen` (#751): back to `sent`. On a
+/// resolved comment it reopens it (whoever resolved it — the human keeps the
+/// last word, ADR-0067 §4); on a `sent` comment carrying a pending proposal it
+/// **declines** the proposal and keeps the comment open for the agent — the
+/// same event, `review_comment_reopened`. A `sent` comment with nothing pending
+/// ⇒ `200`, `changed: false`.
+async fn reopen_review_comment(
+    State(state): State<Arc<AppState>>,
+    AxumPath((run_id, comment_id)): AxumPath<(String, String)>,
+    headers: HeaderMap,
+    body: Option<Json<ReviewDecisionRequest>>,
+) -> Response {
+    review_decision(
+        &state,
+        &run_id,
+        &comment_id,
+        &headers,
+        body.map(|Json(b)| b).unwrap_or_default(),
+        review_comments::ReviewCommentStatus::Sent,
+    )
+    .await
+}
+
+async fn review_decision(
+    state: &AppState,
+    run_id: &str,
+    comment_id: &str,
+    headers: &HeaderMap,
+    req: ReviewDecisionRequest,
+    target: review_comments::ReviewCommentStatus,
+) -> Response {
+    let (_, run_state) = match load_projected(state, run_id).await {
+        Ok(t) => t,
+        Err(resp) => return *resp,
+    };
+    let comment = match find_review_comment(&run_state, comment_id) {
+        Ok(c) => c.clone(),
+        Err(resp) => return *resp,
+    };
+    // A session (agent) decides as itself; the Review page decides as `user`.
+    let by = match session_claim_from_headers(headers).map(|c| c.node_id) {
+        Some(node) => review_comments::reply_author(Some(&node), None),
+        None => req
+            .by
+            .map(|b| b.trim().to_string())
+            .filter(|b| !b.is_empty())
+            .unwrap_or_else(|| "user".to_string()),
+    };
+    let (kind, changes) = match target {
+        review_comments::ReviewCommentStatus::Resolved => (
+            event_log::EventKind::ReviewCommentResolved,
+            comment.status != review_comments::ReviewCommentStatus::Resolved,
+        ),
+        review_comments::ReviewCommentStatus::Sent => (
+            event_log::EventKind::ReviewCommentReopened,
+            comment.status == review_comments::ReviewCommentStatus::Resolved
+                || comment.proposal_pending,
+        ),
+    };
+    if !changes {
+        return Json(serde_json::json!({ "comment": comment, "changed": false })).into_response();
+    }
+    let kind_str = format!("{kind:?}");
+    if let Err(resp) = append_review_event(
+        state,
+        run_id,
+        kind,
+        serde_json::json!({ "id": comment_id, "by": by }),
+    )
+    .await
+    {
+        return *resp;
+    }
+    info!("run {run_id}: review comment {comment_id} {kind_str} by {by}");
+    match projected_review_comment(state, run_id, comment_id).await {
+        Ok(c) => Json(serde_json::json!({ "comment": c, "changed": true })).into_response(),
+        Err(resp) => *resp,
+    }
 }
 
 /// One draft the browser hands over for sending (#750). `from`/`to` are stable
@@ -13938,6 +14404,12 @@ async fn send_review_comments(
             batch_id: Some(batch_id.clone()),
             status: review_comments::ReviewCommentStatus::Sent,
             replies: Vec::new(),
+            proposal_pending: false,
+            resolved_by: None,
+            resolved_at: None,
+            reopened_by: None,
+            reopened_at: None,
+            proposal_declined: false,
         });
     }
 
@@ -24911,6 +25383,318 @@ mod tests {
         )
         .unwrap();
         assert_eq!(body["comments"], serde_json::json!([]));
+    }
+
+    /// Append one `review_comment_sent` straight into the log — the send endpoint
+    /// needs git + tmux, which these handler tests do not.
+    async fn seed_sent_comment(state: &Arc<AppState>, run_id: &str, id: &str) {
+        let c = review_comments::ReviewComment {
+            id: id.into(),
+            path: "lib.rs".into(),
+            side: review_comments::ReviewSide::New,
+            line: 4,
+            from_ref: "fork".into(),
+            to_ref: "tip".into(),
+            from_sha: None,
+            to_sha: None,
+            text: "Name this `fn delta`.".into(),
+            excerpt: String::new(),
+            author: "user".into(),
+            sent_at: event_log::now_iso(),
+            batch_id: Some("b1".into()),
+            status: review_comments::ReviewCommentStatus::Sent,
+            replies: vec![],
+            proposal_pending: false,
+            resolved_by: None,
+            resolved_at: None,
+            reopened_by: None,
+            reopened_at: None,
+            proposal_declined: false,
+        };
+        append_event(
+            state,
+            &event_log::Event {
+                id: None,
+                run_id: run_id.into(),
+                ts: event_log::now_iso(),
+                kind: event_log::EventKind::ReviewCommentSent,
+                node_id: None,
+                iter: None,
+                payload: Some(serde_json::to_value(&c).unwrap()),
+            },
+        )
+        .await
+        .unwrap();
+    }
+
+    async fn review_post(
+        app: &axum::Router,
+        uri: &str,
+        body: serde_json::Value,
+        session: Option<(&str, &str)>,
+    ) -> (StatusCode, serde_json::Value) {
+        let mut req = Request::builder()
+            .method("POST")
+            .uri(uri)
+            .header("content-type", "application/json");
+        if let Some((run, node)) = session {
+            req = req
+                .header(SESSION_RUN_HEADER, run)
+                .header(SESSION_NODE_HEADER, node);
+        }
+        let resp = app
+            .clone()
+            .oneshot(req.body(Body::from(body.to_string())).unwrap())
+            .await
+            .unwrap();
+        let status = resp.status();
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json = serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null);
+        (status, json)
+    }
+
+    async fn review_get(app: &axum::Router, uri: &str) -> (StatusCode, serde_json::Value) {
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri(uri)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = resp.status();
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        (
+            status,
+            serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null),
+        )
+    }
+
+    #[tokio::test]
+    async fn review_reply_from_the_manager_session_is_a_proposal_the_human_resolves_or_reopens() {
+        // #751, ADR-0067 §4 — setting off (default): `resolved: true` PROPOSES.
+        // Author from the session headers (`__manager__` ⇒ `manager`); every
+        // step is an event; resolve / reopen are the human's verbs; a reopen on a
+        // proposal declines it and keeps the comment open.
+        let state = test_state().await;
+        let run_id = "review-reply-proposal";
+        seed_completed_run(&state, run_id).await;
+        seed_sent_comment(&state, run_id, "rc-001").await;
+        let app = build_router(state.clone());
+        let base = format!("/runs/{run_id}/review/comments");
+
+        // Plain reply from a node session: author = node id, still open.
+        let (status, body) = review_post(
+            &app,
+            &format!("{base}/rc-001/reply"),
+            serde_json::json!({ "text": "Looking into it." }),
+            Some((run_id, "xuTJYLUa")),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{body}");
+        assert_eq!(body["outcome"], "replied");
+        assert_eq!(body["author"], "xuTJYLUa");
+        assert_eq!(body["comment"]["replies"][0]["author"], "xuTJYLUa");
+        assert!(body["comment"].get("proposal_pending").is_none());
+
+        // `--resolved` from the manager session: a proposal.
+        let (status, body) = review_post(
+            &app,
+            &format!("{base}/rc-001/reply"),
+            serde_json::json!({ "text": "Renamed in 7f2b0d1.", "resolved": true }),
+            Some((run_id, review_comments::MANAGER_NODE_ID)),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{body}");
+        assert_eq!(body["outcome"], "proposed");
+        assert_eq!(body["author"], "manager");
+        assert_eq!(body["comment"]["status"], "sent");
+        assert_eq!(body["comment"]["proposal_pending"], true);
+        assert_eq!(body["comment"]["replies"][1]["proposes_resolution"], true);
+
+        // The list filters by state and says what `--resolved` does.
+        let (status, list) = review_get(&app, &format!("{base}?state=open")).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(list["comments"].as_array().unwrap().len(), 1);
+        assert_eq!(list["agent_can_resolve"], false);
+        let (_, none) = review_get(&app, &format!("{base}?state=resolved")).await;
+        assert_eq!(none["comments"], serde_json::json!([]));
+        let (status, _) = review_get(&app, &format!("{base}?state=nope")).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+
+        // Reopen on the proposal = declined, still open, recorded.
+        let (status, body) = review_post(
+            &app,
+            &format!("{base}/rc-001/reopen"),
+            serde_json::json!({}),
+            None,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{body}");
+        assert_eq!(body["changed"], true);
+        assert_eq!(body["comment"]["status"], "sent");
+        assert!(body["comment"].get("proposal_pending").is_none());
+        assert_eq!(body["comment"]["proposal_declined"], true);
+        assert_eq!(body["comment"]["reopened_by"], "user");
+        // Nothing pending any more: a second reopen changes nothing, no event.
+        let (status, body) = review_post(
+            &app,
+            &format!("{base}/rc-001/reopen"),
+            serde_json::json!({}),
+            None,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["changed"], false);
+
+        // Resolve by the human, then reopen: back to sent, resolver cleared.
+        let (status, body) = review_post(
+            &app,
+            &format!("{base}/rc-001/resolve"),
+            serde_json::json!({}),
+            None,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{body}");
+        assert_eq!(body["comment"]["status"], "resolved");
+        assert_eq!(body["comment"]["resolved_by"], "user");
+        let (_, again) = review_post(
+            &app,
+            &format!("{base}/rc-001/resolve"),
+            serde_json::json!({}),
+            None,
+        )
+        .await;
+        assert_eq!(again["changed"], false, "already resolved is not an error");
+        let (_, list) = review_get(&app, &format!("{base}?state=resolved")).await;
+        assert_eq!(list["comments"].as_array().unwrap().len(), 1);
+        let (status, body) = review_post(
+            &app,
+            &format!("{base}/rc-001/reopen"),
+            serde_json::json!({}),
+            None,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["comment"]["status"], "sent");
+        assert!(body["comment"].get("resolved_by").is_none());
+        assert!(body["comment"].get("proposal_declined").is_none());
+
+        // Refusals: unknown id, empty text.
+        let (status, body) = review_post(
+            &app,
+            &format!("{base}/rc-999/reply"),
+            serde_json::json!({ "text": "x" }),
+            None,
+        )
+        .await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert!(body["error"].as_str().unwrap().contains("rc-999"));
+        let (status, _) = review_post(
+            &app,
+            &format!("{base}/rc-001/reply"),
+            serde_json::json!({ "text": "   " }),
+            None,
+        )
+        .await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+
+        // Everything above is in the log, immutable and timestamped.
+        let events = load_events(&state.db, run_id).await.unwrap();
+        let kinds: Vec<String> = events
+            .iter()
+            .filter(|e| {
+                matches!(
+                    e.kind,
+                    event_log::EventKind::ReviewCommentReplied
+                        | event_log::EventKind::ReviewCommentResolved
+                        | event_log::EventKind::ReviewCommentReopened
+                )
+            })
+            .map(|e| format!("{:?}", e.kind))
+            .collect();
+        assert_eq!(
+            kinds,
+            vec![
+                "ReviewCommentReplied",
+                "ReviewCommentReplied",
+                "ReviewCommentReopened",
+                "ReviewCommentResolved",
+                "ReviewCommentReopened"
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn review_reply_resolves_directly_when_the_instance_setting_is_on() {
+        // #751 AC: setting on ⇒ `--resolved` resolves on the spot, by the agent; the
+        // human keeps Reopen. Without session headers the declared author is taken.
+        let state = test_state().await;
+        instance_config::update(
+            &state.db,
+            instance_config::UpdateInstanceConfig {
+                review_agent_can_resolve: Some(true),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        let run_id = "review-reply-direct";
+        seed_completed_run(&state, run_id).await;
+        seed_sent_comment(&state, run_id, "rc-001").await;
+        let app = build_router(state.clone());
+        let base = format!("/runs/{run_id}/review/comments");
+
+        let (_, list) = review_get(&app, &base).await;
+        assert_eq!(list["agent_can_resolve"], true);
+
+        let (status, body) = review_post(
+            &app,
+            &format!("{base}/rc-001/reply"),
+            serde_json::json!({ "text": "Fixed.", "resolved": true, "author": "fixer" }),
+            None,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{body}");
+        assert_eq!(body["outcome"], "resolved");
+        assert_eq!(body["author"], "fixer");
+        assert_eq!(body["comment"]["status"], "resolved");
+        assert_eq!(body["comment"]["resolved_by"], "fixer");
+        assert!(body["comment"].get("proposal_pending").is_none());
+
+        // A reply on a resolved comment is just a reply, `resolved` or not.
+        let (status, body) = review_post(
+            &app,
+            &format!("{base}/rc-001/reply"),
+            serde_json::json!({ "text": "Also added a test.", "resolved": true }),
+            Some((run_id, review_comments::MANAGER_NODE_ID)),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{body}");
+        assert_eq!(body["outcome"], "replied");
+        assert_eq!(body["comment"]["replies"].as_array().unwrap().len(), 2);
+        assert!(body["comment"]["replies"][1]
+            .get("proposes_resolution")
+            .is_none());
+
+        // The human keeps the last word.
+        let (status, body) = review_post(
+            &app,
+            &format!("{base}/rc-001/reopen"),
+            serde_json::json!({}),
+            None,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["comment"]["status"], "sent");
+        assert_eq!(body["comment"]["reopened_by"], "user");
     }
 
     #[tokio::test]
@@ -39787,6 +40571,48 @@ edges:
                 .unwrap()
                 .default_auto_name,
             Some(1)
+        );
+    }
+
+    #[tokio::test]
+    async fn put_settings_round_trips_the_review_agent_can_resolve_flag_both_ways() {
+        // #751: default OFF (the human resolves); both directions of a save are a
+        // stored decision — unticking persists a `0` that beats
+        // `PDO_REVIEW_AGENT_CAN_RESOLVE=1`.
+        let state = test_state().await;
+        let fresh = get_settings_json(&state).await;
+        assert_eq!(fresh["review_agent_can_resolve"]["default"], false);
+        assert!(fresh["review_agent_can_resolve"]["stored"].is_null());
+        if fresh["review_agent_can_resolve"]["env"].is_null() {
+            assert_eq!(fresh["review_agent_can_resolve"]["effective"], false);
+            assert_eq!(fresh["review_agent_can_resolve"]["source"], "default");
+        }
+
+        let (status, view) =
+            put_settings_resp(&state, r#"{"review_agent_can_resolve": true}"#).await;
+        assert_eq!(status, StatusCode::OK, "got {view}");
+        assert_eq!(view["review_agent_can_resolve"]["effective"], true);
+        assert_eq!(view["review_agent_can_resolve"]["source"], "stored");
+        assert_eq!(
+            instance_config::get(&state.db)
+                .await
+                .unwrap()
+                .review_agent_can_resolve,
+            Some(1)
+        );
+
+        let (status, view) =
+            put_settings_resp(&state, r#"{"review_agent_can_resolve": false}"#).await;
+        assert_eq!(status, StatusCode::OK, "got {view}");
+        assert_eq!(view["review_agent_can_resolve"]["effective"], false);
+        assert_eq!(view["review_agent_can_resolve"]["source"], "stored");
+        assert_eq!(
+            instance_config::get(&state.db)
+                .await
+                .unwrap()
+                .review_agent_can_resolve,
+            Some(0),
+            "off must persist a stored 0, never NULL"
         );
     }
 

--- a/crates/pdo-daemon/src/main.rs
+++ b/crates/pdo-daemon/src/main.rs
@@ -1,8 +1,8 @@
 use anyhow::{Context, Result};
 use clap::Parser;
 use pdo_daemon::{
-    run_complete, run_daemon, run_docs, run_fail, run_migrate, run_page, run_reap, run_run_create,
-    run_service, run_skip, Cli, Commands,
+    run_complete, run_daemon, run_docs, run_fail, run_migrate, run_page, run_reap, run_review,
+    run_run_create, run_service, run_skip, Cli, Commands,
 };
 use std::process::ExitCode;
 
@@ -55,6 +55,7 @@ fn main() -> ExitCode {
         Commands::Docs { action } => run_docs(action),
         Commands::Run { action } => run_run_create(*action),
         Commands::Page { action } => run_page(action),
+        Commands::Review { action } => run_review(action),
     };
 
     if let Err(e) = res {

--- a/crates/pdo-daemon/src/review_comments.rs
+++ b/crates/pdo-daemon/src/review_comments.rs
@@ -112,6 +112,113 @@ pub(crate) struct ReviewComment {
     pub status: ReviewCommentStatus,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub replies: Vec<ReviewReply>,
+    /// #751: a `--resolved` reply is waiting for the human's decision (the
+    /// setting `review_agent_can_resolve` was off). Cleared by a resolve or a
+    /// reopen — derived, so the UI never has to scan the thread.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub proposal_pending: bool,
+    /// Who resolved (`user`, `manager`, or a node id) and when — `None` while
+    /// `sent`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resolved_by: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resolved_at: Option<String>,
+    /// The last reopen, kept so the footer can read "Reopened by you · time".
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reopened_by: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reopened_at: Option<String>,
+    /// The last reopen landed on a comment that was still `sent`: it declined a
+    /// pending proposal rather than reopening a resolved comment. Cleared by the
+    /// next reply.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub proposal_declined: bool,
+}
+
+/// How the agent's `--resolved` is treated (#751, ADR-0067 §4): a proposal the
+/// human decides on, or a direct resolution under the instance setting.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ReplyOutcome {
+    /// Plain reply, no `--resolved`.
+    Replied,
+    /// `--resolved` with the setting off: "Resolution proposed", Resolve / Reopen.
+    Proposed,
+    /// `--resolved` with the setting on: resolved on the spot (the human keeps Reopen).
+    Resolved,
+}
+
+/// Middle tier of `stored → env → default(false)`; resolved by
+/// [`review_agent_can_resolve_with`].
+pub(crate) const REVIEW_AGENT_CAN_RESOLVE_ENV: &str = "PDO_REVIEW_AGENT_CAN_RESOLVE";
+
+/// Built-in default: **off** — the human resolves, the agent proposes (ADR-0067 §4).
+pub(crate) const REVIEW_AGENT_CAN_RESOLVE_DEFAULT: bool = false;
+
+/// The env tier, through the shared boolean parser so a typo falls through to
+/// the default rather than silently meaning `false`.
+pub(crate) fn env_review_agent_can_resolve() -> Option<bool> {
+    std::env::var(REVIEW_AGENT_CAN_RESOLVE_ENV)
+        .ok()
+        .as_deref()
+        .and_then(crate::stale_detector::parse_bool_setting)
+}
+
+/// Resolve `review_agent_can_resolve`: `stored → env → default(false)`. `stored`
+/// is the raw `instance_config.review_agent_can_resolve` column: `Some(0)` is a
+/// stored **off** and wins over the env; only SQL `NULL` falls through — the
+/// same discipline as `default_auto_name`.
+pub(crate) fn review_agent_can_resolve_with(stored: Option<i64>) -> bool {
+    match stored {
+        Some(v) => v != 0,
+        None => env_review_agent_can_resolve().unwrap_or(REVIEW_AGENT_CAN_RESOLVE_DEFAULT),
+    }
+}
+
+/// The `PDO_NODE_ID` the manager's tmux session is wrapped with (see
+/// `spawn_manager_session`): the one session id that is not a node.
+pub(crate) const MANAGER_NODE_ID: &str = "__manager__";
+
+/// The author of a reply, deduced from the session that issued it: the manager
+/// session reads `manager`, a node session reads its node id. Without a session
+/// claim the caller's own `author` field is taken, else the neutral `agent`.
+pub(crate) fn reply_author(session_node_id: Option<&str>, declared: Option<&str>) -> String {
+    match session_node_id.map(str::trim).filter(|s| !s.is_empty()) {
+        Some(MANAGER_NODE_ID) => "manager".to_string(),
+        Some(node) => node.to_string(),
+        None => declared
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .unwrap_or("agent")
+            .to_string(),
+    }
+}
+
+/// `?state=` of the list endpoint / `--state` of `pdo review list`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum StateFilter {
+    Open,
+    Resolved,
+    All,
+}
+
+impl StateFilter {
+    pub(crate) fn parse(s: &str) -> Option<StateFilter> {
+        match s.trim() {
+            "open" | "sent" => Some(StateFilter::Open),
+            "resolved" => Some(StateFilter::Resolved),
+            "all" | "" => Some(StateFilter::All),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn keeps(self, c: &ReviewComment) -> bool {
+        match self {
+            StateFilter::All => true,
+            StateFilter::Open => c.status == ReviewCommentStatus::Sent,
+            StateFilter::Resolved => c.status == ReviewCommentStatus::Resolved,
+        }
+    }
 }
 
 fn default_status() -> ReviewCommentStatus {
@@ -242,6 +349,10 @@ pub(crate) fn fold(comments: &mut Vec<ReviewComment>, event: &Event) {
                 tracing::warn!("review_comment_replied names unknown comment {id}; skipped");
                 return;
             };
+            let proposes_resolution = payload
+                .get("proposes_resolution")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
             c.replies.push(ReviewReply {
                 author: payload
                     .get("author")
@@ -254,11 +365,14 @@ pub(crate) fn fold(comments: &mut Vec<ReviewComment>, event: &Event) {
                     .unwrap_or_default()
                     .to_string(),
                 at: event.ts.clone(),
-                proposes_resolution: payload
-                    .get("proposes_resolution")
-                    .and_then(|v| v.as_bool())
-                    .unwrap_or(false),
+                proposes_resolution,
             });
+            // A proposal on an open comment waits for the human; a following
+            // `review_comment_resolved` (setting on) clears it right away.
+            if proposes_resolution && c.status == ReviewCommentStatus::Sent {
+                c.proposal_pending = true;
+            }
+            c.proposal_declined = false;
         }
         EventKind::ReviewCommentResolved | EventKind::ReviewCommentReopened => {
             let Some(id) = payload.get("id").and_then(|v| v.as_str()) else {
@@ -268,11 +382,29 @@ pub(crate) fn fold(comments: &mut Vec<ReviewComment>, event: &Event) {
                 tracing::warn!("{:?} names unknown comment {id}; skipped", event.kind);
                 return;
             };
-            c.status = if event.kind == EventKind::ReviewCommentResolved {
-                ReviewCommentStatus::Resolved
+            let by = payload
+                .get("by")
+                .and_then(|v| v.as_str())
+                .unwrap_or("user")
+                .to_string();
+            if event.kind == EventKind::ReviewCommentResolved {
+                c.status = ReviewCommentStatus::Resolved;
+                c.resolved_by = Some(by);
+                c.resolved_at = Some(event.ts.clone());
+                c.proposal_pending = false;
+                c.proposal_declined = false;
             } else {
-                ReviewCommentStatus::Sent
-            };
+                // Reopen on a `sent` comment declines its pending proposal (the
+                // spec keeps one verb for both: the event is the same).
+                let declined = c.status == ReviewCommentStatus::Sent && c.proposal_pending;
+                c.status = ReviewCommentStatus::Sent;
+                c.resolved_by = None;
+                c.resolved_at = None;
+                c.reopened_by = Some(by);
+                c.reopened_at = Some(event.ts.clone());
+                c.proposal_pending = false;
+                c.proposal_declined = declined;
+            }
         }
         _ => {}
     }
@@ -299,6 +431,12 @@ mod tests {
             batch_id: Some("b1".into()),
             status: ReviewCommentStatus::Sent,
             replies: vec![],
+            proposal_pending: false,
+            resolved_by: None,
+            resolved_at: None,
+            reopened_by: None,
+            reopened_at: None,
+            proposal_declined: false,
         }
     }
 
@@ -408,6 +546,10 @@ mod tests {
         assert_eq!(list[0].replies.len(), 1);
         assert_eq!(list[0].replies[0].author, "manager");
         assert!(list[0].replies[0].proposes_resolution);
+        assert!(
+            list[0].proposal_pending,
+            "a --resolved reply waits for the human"
+        );
         fold(
             &mut list,
             &ev(
@@ -416,14 +558,30 @@ mod tests {
             ),
         );
         assert_eq!(list[0].status, ReviewCommentStatus::Resolved);
+        assert_eq!(
+            list[0].resolved_by.as_deref(),
+            Some("user"),
+            "no `by` ⇒ the human"
+        );
+        assert_eq!(
+            list[0].resolved_at.as_deref(),
+            Some("2026-09-09T10:00:00.000Z")
+        );
+        assert!(!list[0].proposal_pending);
         fold(
             &mut list,
             &ev(
                 EventKind::ReviewCommentReopened,
-                serde_json::json!({ "id": "rc-001" }),
+                serde_json::json!({ "id": "rc-001", "by": "user" }),
             ),
         );
         assert_eq!(list[0].status, ReviewCommentStatus::Sent);
+        assert!(list[0].resolved_by.is_none());
+        assert_eq!(list[0].reopened_by.as_deref(), Some("user"));
+        assert!(
+            !list[0].proposal_declined,
+            "reopening a resolved comment is not a decline"
+        );
         // Unknown id: ignored, never a panic.
         fold(
             &mut list,
@@ -433,6 +591,127 @@ mod tests {
             ),
         );
         assert_eq!(list[0].replies.len(), 1);
+    }
+
+    #[test]
+    fn reopen_on_a_sent_comment_declines_the_pending_proposal_and_a_reply_clears_the_decline() {
+        let mut list = vec![];
+        fold(
+            &mut list,
+            &ev(
+                EventKind::ReviewCommentSent,
+                serde_json::to_value(sent("rc-001", 3)).unwrap(),
+            ),
+        );
+        fold(
+            &mut list,
+            &ev(
+                EventKind::ReviewCommentReplied,
+                serde_json::json!({ "id": "rc-001", "author": "xuTJYLUa", "text": "done", "proposes_resolution": true }),
+            ),
+        );
+        assert!(list[0].proposal_pending);
+        fold(
+            &mut list,
+            &ev(
+                EventKind::ReviewCommentReopened,
+                serde_json::json!({ "id": "rc-001", "by": "user" }),
+            ),
+        );
+        assert_eq!(list[0].status, ReviewCommentStatus::Sent);
+        assert!(!list[0].proposal_pending);
+        assert!(
+            list[0].proposal_declined,
+            "Reopen on a proposal = declined, comment stays open"
+        );
+        assert_eq!(list[0].reopened_by.as_deref(), Some("user"));
+        // The agent answers again: the decline is history, the thread grows.
+        fold(
+            &mut list,
+            &ev(
+                EventKind::ReviewCommentReplied,
+                serde_json::json!({ "id": "rc-001", "author": "xuTJYLUa", "text": "second try" }),
+            ),
+        );
+        assert!(!list[0].proposal_declined);
+        assert!(!list[0].proposal_pending);
+        assert_eq!(list[0].replies.len(), 2);
+    }
+
+    #[test]
+    fn agent_resolving_directly_records_the_agent_as_resolver() {
+        let mut list = vec![];
+        fold(
+            &mut list,
+            &ev(
+                EventKind::ReviewCommentSent,
+                serde_json::to_value(sent("rc-001", 3)).unwrap(),
+            ),
+        );
+        fold(
+            &mut list,
+            &ev(
+                EventKind::ReviewCommentReplied,
+                serde_json::json!({ "id": "rc-001", "author": "manager", "text": "fixed", "proposes_resolution": true }),
+            ),
+        );
+        fold(
+            &mut list,
+            &ev(
+                EventKind::ReviewCommentResolved,
+                serde_json::json!({ "id": "rc-001", "by": "manager" }),
+            ),
+        );
+        assert_eq!(list[0].status, ReviewCommentStatus::Resolved);
+        assert_eq!(list[0].resolved_by.as_deref(), Some("manager"));
+        assert!(
+            !list[0].proposal_pending,
+            "the direct resolution clears the proposal flag"
+        );
+        let wire = serde_json::to_value(&list[0]).unwrap();
+        assert_eq!(wire["resolved_by"], "manager");
+        assert!(
+            wire.get("proposal_pending").is_none(),
+            "false flags stay off the wire"
+        );
+    }
+
+    #[test]
+    fn reply_author_comes_from_the_session_then_the_declared_field() {
+        assert_eq!(reply_author(Some(MANAGER_NODE_ID), None), "manager");
+        assert_eq!(reply_author(Some("xuTJYLUa"), Some("ignored")), "xuTJYLUa");
+        assert_eq!(reply_author(None, Some(" fixer ")), "fixer");
+        assert_eq!(reply_author(Some("  "), None), "agent");
+        assert_eq!(reply_author(None, None), "agent");
+    }
+
+    #[test]
+    fn state_filter_parses_and_keeps_by_status() {
+        let mut resolved = sent("rc-002", 5);
+        resolved.status = ReviewCommentStatus::Resolved;
+        let open = sent("rc-001", 3);
+        assert_eq!(StateFilter::parse("open"), Some(StateFilter::Open));
+        assert_eq!(StateFilter::parse("resolved"), Some(StateFilter::Resolved));
+        assert_eq!(StateFilter::parse("all"), Some(StateFilter::All));
+        assert_eq!(StateFilter::parse("nope"), None);
+        assert!(StateFilter::Open.keeps(&open) && !StateFilter::Open.keeps(&resolved));
+        assert!(!StateFilter::Resolved.keeps(&open) && StateFilter::Resolved.keeps(&resolved));
+        assert!(StateFilter::All.keeps(&open) && StateFilter::All.keeps(&resolved));
+    }
+
+    #[test]
+    fn review_agent_can_resolve_stored_beats_env_and_defaults_off() {
+        // Stored decisions win whatever the env says; NULL falls through to the
+        // built-in default (off). The env tier itself is covered by the settings
+        // view test — process-global env is not toggled here.
+        assert!(review_agent_can_resolve_with(Some(1)));
+        assert!(!review_agent_can_resolve_with(Some(0)));
+        if env_review_agent_can_resolve().is_none() {
+            assert_eq!(
+                review_agent_can_resolve_with(None),
+                REVIEW_AGENT_CAN_RESOLVE_DEFAULT
+            );
+        }
     }
 
     #[test]

--- a/crates/pdo-daemon/tests/review_comments.rs
+++ b/crates/pdo-daemon/tests/review_comments.rs
@@ -317,3 +317,253 @@ async fn sent_comments_are_events_projected_pushed_and_start_the_manager() {
         "the refused one was not recorded"
     );
 }
+
+/// Run the real `pdo review …` binary against `daemon`, wrapped with the env of a
+/// node / manager session (`PDO_RUN_ID`, `PDO_NODE_ID`) — the identity the daemon
+/// deduces the author from. On a blocking task so the runtime keeps serving.
+async fn run_pdo_review(
+    daemon_url: &str,
+    args: &[&str],
+    session: Option<(&str, &str)>,
+) -> (Option<i32>, String, String) {
+    let bin = env!("CARGO_BIN_EXE_pdo");
+    let mut cmd = std::process::Command::new(bin);
+    cmd.arg("review").args(args);
+    cmd.env("PDO_DAEMON_URL", daemon_url);
+    cmd.env_remove("PDO_RUN_ID");
+    cmd.env_remove("PDO_NODE_ID");
+    if let Some((run_id, node_id)) = session {
+        cmd.env("PDO_RUN_ID", run_id);
+        cmd.env("PDO_NODE_ID", node_id);
+    }
+    let output =
+        tokio::task::spawn_blocking(move || cmd.output().expect("failed to spawn pdo review"))
+            .await
+            .expect("blocking task panicked");
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    assert!(
+        !stderr.contains("panicked"),
+        "pdo review must not panic. stderr=\n{stderr}\nstdout=\n{stdout}"
+    );
+    (output.status.code(), stdout, stderr)
+}
+
+/// #751 — the Feature Path's shell half, against a real daemon and the real CLI:
+/// `pdo review list` shows the sent comment with its id and state; `pdo review
+/// reply <id> --text … --resolved` from the manager session lands as a reply by
+/// `manager` **proposing** a resolution (setting off); the human's Resolve and
+/// Reopen endpoints flip the state; with `review_agent_can_resolve` on, the same
+/// reply resolves directly. Every step is a Run event pushed over the WebSocket.
+#[tokio::test]
+async fn cli_review_list_and_reply_drive_the_conversation_end_to_end() {
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+    let repo = daemon.repo_root().to_path_buf();
+    let run_id = create_run(daemon.url(), daemon.target_repo())
+        .await
+        .expect("run created");
+    let wt_dir = repo.join(".pdo/runs").join(&run_id).join("worktree");
+    for _ in 0..100 {
+        if wt_dir.exists() {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+    std::fs::write(
+        wt_dir.join("lib.rs"),
+        "fn a() {}\nfn b() {}\nfn c() {}\nfn d() {}\n",
+    )
+    .unwrap();
+    git(&wt_dir, &["add", "lib.rs"]);
+    git(&wt_dir, &["commit", "-q", "-m", "run work"]);
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!(
+            "{}/runs/{run_id}/review/comments/send",
+            daemon.url()
+        ))
+        .json(&serde_json::json!({
+            "comments": [
+                { "path": "lib.rs", "side": "new", "line": 4, "text": "Name this `fn delta`." },
+                { "path": "lib.rs", "side": "new", "line": 2, "text": "Second remark." }
+            ]
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let mut ws = daemon.connect_ws().await.unwrap();
+
+    // 1. `pdo review list` from the manager session: both open, with their ids.
+    let manager = Some((run_id.as_str(), "__manager__"));
+    let (code, stdout, stderr) = run_pdo_review(&daemon.url(), &["list"], manager).await;
+    assert_eq!(code, Some(0), "stderr: {stderr}");
+    let listed: serde_json::Value = serde_json::from_str(&stdout).expect("JSON on stdout");
+    let ids: Vec<&str> = listed["comments"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|c| c["id"].as_str().unwrap())
+        .collect();
+    assert_eq!(ids, vec!["rc-001", "rc-002"]);
+    assert_eq!(listed["comments"][0]["status"], "sent");
+    assert_eq!(listed["agent_can_resolve"], false);
+
+    // Out of a session and without --run: a readable refusal, exit 1.
+    let (code, _, stderr) = run_pdo_review(&daemon.url(), &["list"], None).await;
+    assert_eq!(code, Some(1));
+    assert!(stderr.contains("--run"), "{stderr}");
+
+    // 2. `--resolved` from the manager: a proposal, author `manager`.
+    let (code, stdout, stderr) = run_pdo_review(
+        &daemon.url(),
+        &[
+            "reply",
+            "rc-001",
+            "--text",
+            "Renamed to `fn delta` in the Run branch.",
+            "--resolved",
+        ],
+        manager,
+    )
+    .await;
+    assert_eq!(code, Some(0), "stderr: {stderr}");
+    assert!(stdout.contains("resolution proposed"), "{stdout}");
+    assert!(stdout.contains("author manager"), "{stdout}");
+    let run: serde_json::Value = client
+        .get(format!("{}/runs/{run_id}", daemon.url()))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let c1 = &run["review_comments"][0];
+    assert_eq!(c1["status"], "sent");
+    assert_eq!(c1["proposal_pending"], true);
+    assert_eq!(c1["replies"][0]["author"], "manager");
+    assert_eq!(c1["replies"][0]["proposes_resolution"], true);
+
+    // The reply travelled over the WebSocket.
+    let mut seen = false;
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+    while tokio::time::Instant::now() < deadline && !seen {
+        let next = tokio::time::timeout(std::time::Duration::from_millis(500), ws.next()).await;
+        let Ok(Some(Ok(msg))) = next else { continue };
+        if let Some(text) = ws_text(&msg) {
+            if text.contains("review_comment_replied") && text.contains(&run_id) {
+                seen = true;
+            }
+        }
+    }
+    assert!(
+        seen,
+        "the WebSocket carried the review_comment_replied event"
+    );
+
+    // 3. Resolve → resolved & out of `list` (open); Reopen → back to sent.
+    let resp = client
+        .post(format!(
+            "{}/runs/{run_id}/review/comments/rc-001/resolve",
+            daemon.url()
+        ))
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let (_, stdout, _) = run_pdo_review(&daemon.url(), &["list"], manager).await;
+    let open: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(open["comments"].as_array().unwrap().len(), 1, "{stdout}");
+    assert_eq!(open["comments"][0]["id"], "rc-002");
+    let (_, stdout, _) =
+        run_pdo_review(&daemon.url(), &["list", "--state", "resolved"], manager).await;
+    let resolved: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(resolved["comments"][0]["id"], "rc-001");
+    assert_eq!(resolved["comments"][0]["resolved_by"], "user");
+    let resp = client
+        .post(format!(
+            "{}/runs/{run_id}/review/comments/rc-001/reopen",
+            daemon.url()
+        ))
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["comment"]["status"], "sent");
+    assert_eq!(body["comment"]["reopened_by"], "user");
+
+    // 4. Setting on: a node session's `--resolved` resolves directly, by the node.
+    let resp = client
+        .put(format!("{}/settings", daemon.url()))
+        .json(&serde_json::json!({ "review_agent_can_resolve": true }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let (code, stdout, stderr) = run_pdo_review(
+        &daemon.url(),
+        &[
+            "reply",
+            "rc-002",
+            "--body",
+            "Done.",
+            "--resolved",
+            "--run",
+            &run_id,
+        ],
+        Some((run_id.as_str(), "solo")),
+    )
+    .await;
+    assert_eq!(code, Some(0), "stderr: {stderr}");
+    assert!(
+        stdout.contains("resolved (the instance lets agents resolve"),
+        "{stdout}"
+    );
+    let (_, stdout, _) = run_pdo_review(&daemon.url(), &["list", "--state", "all"], manager).await;
+    let all: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let c2 = all["comments"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|c| c["id"] == "rc-002")
+        .unwrap();
+    assert_eq!(c2["status"], "resolved");
+    assert_eq!(c2["resolved_by"], "solo");
+    assert_eq!(c2["replies"][0]["author"], "solo");
+    assert_eq!(all["agent_can_resolve"], true);
+
+    // Unknown id: the daemon's sentence reaches stderr, exit 1.
+    let (code, _, stderr) =
+        run_pdo_review(&daemon.url(), &["reply", "rc-999", "--text", "x"], manager).await;
+    assert_eq!(code, Some(1));
+    assert!(stderr.contains("rc-999"), "{stderr}");
+
+    // The whole conversation is in the log, in order.
+    let events: Vec<serde_json::Value> = client
+        .get(format!("{}/runs/{run_id}/events", daemon.url()))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let kinds: Vec<&str> = events
+        .iter()
+        .map(|e| e["kind"].as_str().unwrap())
+        .filter(|k| k.starts_with("review_comment_re"))
+        .collect();
+    assert_eq!(
+        kinds,
+        vec![
+            "review_comment_replied",
+            "review_comment_resolved",
+            "review_comment_reopened",
+            "review_comment_replied",
+            "review_comment_resolved",
+        ]
+    );
+}

--- a/frontend/src/App.settingsClose.test.tsx
+++ b/frontend/src/App.settingsClose.test.tsx
@@ -114,6 +114,7 @@ vi.mock("./api", () => {
       default: true,
     },
     manager_enabled: { effective: false, source: "default", stored: null, env: null, default: false },
+    review_agent_can_resolve: { effective: false, source: "default", stored: null, env: null, default: false },
     manager_profile: { effective: null, source: "default", stored: null, env: null, default: null },
     update_check: { effective: true, source: "default", stored: null, env: null, default: true },
     price_table: {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,5 +1,6 @@
 import type { PipelineListEntry, PipelineDetail, PipelineDef, RunListEntry, RunState, PortDef, PortSide, PortType, FrontmatterFieldDecl, FrontmatterViolation, Trigger, TriggerFire, DaemonStatus, InstanceSettings, UpdateSettingsRequest, StatsOverview, StatsCost, StatsPerformance, SandboxProfile, SandboxProfileImage, SandboxProfileReferents, SyncCostPricesReport, UpdateStatus, UpdateChangelog, UpdateApplyResponse, Project, BranchRef, AgentChoice, AgentProfile, AgentProfileReferents, ProvisioningPlan, ProvisioningRules, Skill, SkillBank, SkillDetail, SkillFile, SkillFileContent, SkillFilesUpload, SkillFolder, SkillReferents, SkillRef, SkillScanResult, SkillImportItem, SkillImportReport, SkillRescanReport, RecentSkillSource, StructuredDiff, RunRefs,
   ReviewComment,
+  ReviewDecisionResponse,
   SendReviewCommentInput,
   SendReviewCommentsResponse,
 } from "./types";
@@ -406,6 +407,24 @@ export function sendReviewComments(
     body: { comments },
     label: "Send review comments",
   });
+}
+
+/** #751: the human resolves a comment (accepts a proposal, or closes it outright). */
+export function resolveReviewComment(runId: string, commentId: string): Promise<ReviewDecisionResponse> {
+  return request<ReviewDecisionResponse>(
+    "POST",
+    `/runs/${encodeURIComponent(runId)}/review/comments/${encodeURIComponent(commentId)}/resolve`,
+    { body: {}, label: "Resolve review comment" },
+  );
+}
+
+/** #751: back to `sent` — reopen a resolved comment, or decline a pending proposal. */
+export function reopenReviewComment(runId: string, commentId: string): Promise<ReviewDecisionResponse> {
+  return request<ReviewDecisionResponse>(
+    "POST",
+    `/runs/${encodeURIComponent(runId)}/review/comments/${encodeURIComponent(commentId)}/reopen`,
+    { body: {}, label: "Reopen review comment" },
+  );
 }
 
 /** Refusal slugs this client knows how to phrase (#490, ADR-0035 §3). */

--- a/frontend/src/components/DiffTab.tsx
+++ b/frontend/src/components/DiffTab.tsx
@@ -277,7 +277,7 @@ export default function DiffTab({ run, collapsed, onCollapsedChange }: Props) {
               <span
                 className="ml-0.5 inline-flex h-[14px] items-center rounded-[7px] bg-st-running-bg px-[5px] font-medium text-st-running"
                 style={{ fontSize: "9.5px" }}
-                title={`${pendingCount(run.review_comments)} review comment(s) awaiting the manager`}
+                title={`${pendingCount(run.review_comments)} review comment(s) pending — sent, not resolved`}
                 data-testid="diff-review-pending"
               >
                 {pendingCount(run.review_comments)}

--- a/frontend/src/components/NewRunModal.test.tsx
+++ b/frontend/src/components/NewRunModal.test.tsx
@@ -861,6 +861,7 @@ describe("NewRunModal — auto-naming default (#338)", () => {
       default_auto_name: { effective, source: effective ? "default" : "stored", stored: effective ? null : false, env: null, default: true },
       update_check: { effective: true, source: "default", stored: null, env: null, default: true },
       manager_enabled: { effective: false, source: "default", stored: null, env: null, default: false },
+      review_agent_can_resolve: { effective: false, source: "default", stored: null, env: null, default: false },
       manager_profile: { effective: null, source: "default", stored: null, env: null, default: null },
       price_table: { manual_path: null, fetched_path: null, source: null, fetched_at: null, fetched_rows: 0, manual_keys: [], reason: null },
       updated_at: "2026-07-01T10:00:00.000Z",
@@ -1617,6 +1618,7 @@ describe("NewRunModal — sandbox selector (#410)", () => {
       // #427: required on InstanceSettings; this modal does not read it.
       update_check: { effective: true, source: "default", stored: null, env: null, default: true },
       manager_enabled: { effective: false, source: "default", stored: null, env: null, default: false },
+      review_agent_can_resolve: { effective: false, source: "default", stored: null, env: null, default: false },
       manager_profile: { effective: null, source: "default", stored: null, env: null, default: null },
       price_table: { manual_path: "/home/user/.pdo/prices/models.yaml", fetched_path: "/home/user/.pdo/prices/fetched.json", source: null, fetched_at: null, fetched_rows: 0, manual_keys: [], reason: null },
       updated_at: "2026-07-01T10:00:00.000Z",
@@ -1952,6 +1954,7 @@ describe("NewRunModal — the launch dialog can defer to default_sandbox (#452)"
       // #427: required on InstanceSettings; this modal does not read it.
       update_check: { effective: true, source: "default", stored: null, env: null, default: true },
       manager_enabled: { effective: false, source: "default", stored: null, env: null, default: false },
+      review_agent_can_resolve: { effective: false, source: "default", stored: null, env: null, default: false },
       manager_profile: { effective: null, source: "default", stored: null, env: null, default: null },
       price_table: { manual_path: "/home/user/.pdo/prices/models.yaml", fetched_path: "/home/user/.pdo/prices/fetched.json", source: null, fetched_at: null, fetched_rows: 0, manual_keys: [], reason: null },
       updated_at: "2026-07-01T10:00:00.000Z",
@@ -2167,6 +2170,7 @@ describe("NewRunModal — the target repo is required at the boundary (#470)", (
       // #427: required on InstanceSettings; this modal does not read it.
       update_check: { effective: true, source: "default", stored: null, env: null, default: true },
       manager_enabled: { effective: false, source: "default", stored: null, env: null, default: false },
+      review_agent_can_resolve: { effective: false, source: "default", stored: null, env: null, default: false },
       manager_profile: { effective: null, source: "default", stored: null, env: null, default: null },
       price_table: { manual_path: "/home/user/.pdo/prices/models.yaml", fetched_path: "/home/user/.pdo/prices/fetched.json", source: null, fetched_at: null, fetched_rows: 0, manual_keys: [], reason: null },
       updated_at: "2026-07-01T10:00:00.000Z",
@@ -2523,6 +2527,7 @@ describe("NewRunModal — harness selector (#551)", () => {
       default_auto_name: { effective: true, source: "default", stored: null, env: null, default: true },
       update_check: { effective: true, source: "default", stored: null, env: null, default: true },
       manager_enabled: { effective: false, source: "default", stored: null, env: null, default: false },
+      review_agent_can_resolve: { effective: false, source: "default", stored: null, env: null, default: false },
       manager_profile: { effective: null, source: "default", stored: null, env: null, default: null },
       price_table: { manual_path: null, fetched_path: null, source: null, fetched_at: null, fetched_rows: 0, manual_keys: [], reason: null },
       updated_at: "2026-07-01T10:00:00.000Z",

--- a/frontend/src/components/PipelineInfoPanel.test.tsx
+++ b/frontend/src/components/PipelineInfoPanel.test.tsx
@@ -564,6 +564,56 @@ describe("PipelineInfoPanel — Diff tab (#748)", () => {
     expect(screen.queryByTestId("run-stats")).toBeNull();
   });
 
+  it("counts unread review replies on the Diff tab (#751), replacing the dot, and clears once the Review marked them seen", () => {
+    const replied = {
+      id: "rc-001",
+      path: "a.ts",
+      side: "new" as const,
+      line: 1,
+      from_ref: "fork",
+      to_ref: "tip",
+      text: "t",
+      author: "user",
+      sent_at: "2026-07-01T10:00:00.000Z",
+      status: "sent" as const,
+      replies: [{ author: "manager", text: "done", at: "2026-07-01T10:05:00.000Z" }],
+    };
+    const delivered = {
+      "impl-1": {
+        node_id: "impl-1",
+        status: "completed" as const,
+        iter: 1,
+        started_at: "2026-07-01T10:00:00.000Z",
+        completed_at: "2026-07-01T10:01:00.000Z",
+        failure_reason: null,
+        iterations: [],
+        delivery: { before: "aaa", after: "bbb" },
+      },
+    };
+    const { rerender } = renderPanel(makeRun());
+    rerender(
+      <PipelineInfoPanel
+        run={makeRun({
+          nodes: delivered,
+          review_comments: [replied, { ...replied, id: "rc-002", status: "resolved", resolved_by: "xuTJYLUa" }],
+        })}
+        pipeline={null}
+        libraryPipelines={[]}
+        onLibraryChanged={() => {}}
+        onClose={() => {}}
+      />,
+    );
+    // One open comment with an unread reply; the agent-resolved one does not count.
+    // The count replaces the "tip moved" dot.
+    expect(screen.getByTestId("diff-tab-unread")).toHaveTextContent("1");
+    expect(screen.queryByTestId("diff-tab-dot")).toBeNull();
+    // The Review page (another tab) marked it seen → storage event → badge gone, dot back.
+    localStorage.setItem("pdo.review.seen.run-abc1234567", JSON.stringify({ "rc-001": 1, "rc-002": 1 }));
+    fireEvent(window, new StorageEvent("storage", { key: "pdo.review.seen.run-abc1234567" }));
+    expect(screen.queryByTestId("diff-tab-unread")).toBeNull();
+    expect(screen.getByTestId("diff-tab-dot")).toBeInTheDocument();
+  });
+
   it("dots the Diff tab when a node delivers while another tab is shown, and clears it on open", () => {
     const { rerender } = renderPanel(makeRun());
     expect(screen.queryByTestId("diff-tab-dot")).toBeNull();

--- a/frontend/src/components/PipelineInfoPanel.tsx
+++ b/frontend/src/components/PipelineInfoPanel.tsx
@@ -4,6 +4,7 @@ import { SectionHead } from "./InspectorPrimitives";
 import TmuxTerminal from "./TmuxTerminal";
 import DiffTab from "./DiffTab";
 import { deliverySignature } from "../lib/diffTab";
+import { useReviewUnread } from "../hooks/useReviewUnread";
 import type { CollapsedFiles } from "../lib/diffTab";
 import type { LibraryPipelineEntry } from "../api";
 import { fetchPipelineDocument, fetchPipelineSkillsSidecar, fetchRunPipelineDocument, fetchRunPipelineSkillsSidecar, openLibraryAssistant, startRunManager, stopRunManager } from "../api";
@@ -131,6 +132,10 @@ export default function PipelineInfoPanel({
   };
   const nudgeDiff =
     run != null && resolvedTab !== "diff" && seenDeliverySig !== deliverySig && deliverySig !== "";
+  // #751: sent review comments with an unread reply — a solid count pill that
+  // replaces the blue dot while > 0 (a number beats a dot; both mean "come look").
+  // Cleared by opening the Review page (per browser, localStorage).
+  const unreadReplies = useReviewUnread(run);
 
   const tabs: { id: TabId; label: string; icon: typeof Info; show: boolean }[] = [
     { id: "info", label: "Info", icon: FileText, show: true },
@@ -193,12 +198,24 @@ export default function PipelineInfoPanel({
                   data-testid="manager-tab-dot"
                 />
               )}
-              {t.id === "diff" && nudgeDiff && (
+              {t.id === "diff" && unreadReplies > 0 ? (
                 <span
-                  className="h-1.5 w-1.5 rounded-full bg-st-running"
-                  aria-hidden
-                  data-testid="diff-tab-dot"
-                />
+                  className="inline-flex h-[14px] min-w-[14px] items-center justify-center rounded-[7px] bg-st-running px-1 font-semibold text-white"
+                  style={{ fontSize: "9.5px" }}
+                  title={`${unreadReplies} review comment${unreadReplies === 1 ? "" : "s"} with an unread reply — open the Review page`}
+                  data-testid="diff-tab-unread"
+                >
+                  {unreadReplies}
+                </span>
+              ) : (
+                t.id === "diff" &&
+                nudgeDiff && (
+                  <span
+                    className="h-1.5 w-1.5 rounded-full bg-st-running"
+                    aria-hidden
+                    data-testid="diff-tab-dot"
+                  />
+                )
               )}
             </button>
           ))}

--- a/frontend/src/components/SettingsSurface.test.tsx
+++ b/frontend/src/components/SettingsSurface.test.tsx
@@ -131,6 +131,7 @@ function sample(overrides: Partial<InstanceSettings> = {}): InstanceSettings {
     },
     // Manager on demand: off by default (a Run starts managerless), no pin (« Follow the Run »).
     manager_enabled: { effective: false, source: "default", stored: null, env: null, default: false },
+    review_agent_can_resolve: { effective: false, source: "default", stored: null, env: null, default: false },
     manager_profile: { effective: null, source: "default", stored: null, env: null, default: null },
     // Price table (#427): the default state of every instance — neither file exists,
     // never synced, nothing inert. The paths are reported all the same.
@@ -895,6 +896,33 @@ describe("SettingsSurface — default Run auto-naming (#338)", () => {
     browseFsMock.mockReset();
     browseFsMock.mockResolvedValue(BROWSE_HOME);
     resetProfileMocks();
+  });
+
+  it("#751: « Let the agent resolve review comments directly » sits after auto-name, off by default, and saves `true` as a stored decision", async () => {
+    fetchSettingsMock.mockResolvedValue(sample());
+    updateSettingsMock.mockResolvedValue(
+      sample({
+        review_agent_can_resolve: { effective: true, source: "stored", stored: true, env: null, default: false },
+      }),
+    );
+    render(<SettingsSurface open onClose={() => {}} />);
+    const box = (await screen.findByTestId("setting-review-agent-can-resolve")) as HTMLInputElement;
+    expect(box.checked).toBe(false);
+    expect(screen.getByTestId("setting-source-review-agent-can-resolve")).toHaveTextContent(
+      /built-in default \(off\)/i,
+    );
+    expect(screen.getByTestId("setting-source-review-agent-can-resolve")).toHaveTextContent("PDO_REVIEW_AGENT_CAN_RESOLVE");
+    // Right after auto-name in the DOM.
+    const autoName = screen.getByTestId("setting-default-auto-name");
+    expect(autoName.compareDocumentPosition(box) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+
+    fireEvent.click(box);
+    fireEvent.click(screen.getByTestId("settings-save"));
+    await waitFor(() => expect(updateSettingsMock).toHaveBeenCalledTimes(1));
+    expect(updateSettingsMock).toHaveBeenCalledWith({ review_agent_can_resolve: true });
+    await waitFor(() =>
+      expect(screen.getByTestId("setting-source-review-agent-can-resolve")).toHaveTextContent(/stored value \(on\)/i),
+    );
   });
 
   it("is checked on a fresh instance (default is ON — pre-#338 behaviour)", async () => {

--- a/frontend/src/components/SettingsSurface.tsx
+++ b/frontend/src/components/SettingsSurface.tsx
@@ -114,6 +114,8 @@ interface DraftValues {
   defaultAutoName: boolean;
   managerEnabled: boolean;
   managerProfile: string;
+  /** #751: may an agent's `--resolved` reply resolve a review comment directly? */
+  reviewAgentCanResolve: boolean;
 }
 
 function seedFrom(settings: InstanceSettings): DraftValues {
@@ -132,6 +134,7 @@ function seedFrom(settings: InstanceSettings): DraftValues {
     managerEnabled: settings.manager_enabled.effective,
     // "" = « Follow the Run » (the clear sentinel on the wire too).
     managerProfile: settings.manager_profile.stored ?? "",
+    reviewAgentCanResolve: settings.review_agent_can_resolve.effective,
   };
 }
 
@@ -174,6 +177,9 @@ function computeDirty(values: DraftValues, settings: InstanceSettings): Set<Sett
   }
   if (values.defaultAutoName !== settings.default_auto_name.effective) {
     dirty.add("default-auto-name");
+  }
+  if (values.reviewAgentCanResolve !== settings.review_agent_can_resolve.effective) {
+    dirty.add("review-agent-can-resolve");
   }
   if (values.model !== settings.default_model.effective) dirty.add("default-model");
   if (values.defaultHarness !== (settings.default_harness.effective ?? "")) {
@@ -382,6 +388,10 @@ export default function SettingsSurface({
     }
     if (values.defaultAutoName !== settings.default_auto_name.effective) {
       patch.default_auto_name = values.defaultAutoName;
+    }
+    // #751: same plain-bool discipline — `false` persists as a stored `0`.
+    if (values.reviewAgentCanResolve !== settings.review_agent_can_resolve.effective) {
+      patch.review_agent_can_resolve = values.reviewAgentCanResolve;
     }
     // Manager on demand: the flag is a plain bool (`false` persists as a stored
     // `0`); the pin is a profile NAME with `""` as the clear sentinel (« Follow
@@ -679,6 +689,27 @@ export default function SettingsSurface({
                           </>
                         }
                         source={defaultAutoNameSourceNote(settings.default_auto_name)}
+                      />
+                      {/* #751 (ADR-0067 §4): right after auto-name — both are about how much
+                          the agent may do on its own. Off by default: the human resolves. */}
+                      <CheckboxRow
+                        id="review-agent-can-resolve"
+                        checked={values.reviewAgentCanResolve}
+                        onChange={(v) => setField("reviewAgentCanResolve", v)}
+                        dirty={rollup.fields.has("review-agent-can-resolve")}
+                        label="Let the agent resolve review comments directly"
+                        help={
+                          <>
+                            By default a reply sent with{" "}
+                            <span className="font-mono">pdo review reply --resolved</span> is only a{" "}
+                            <strong>proposal</strong>: the comment shows "Resolution proposed" and you
+                            click Resolve or Reopen. Turn this on and such a reply resolves the comment
+                            on the spot, for every Run of this instance. You can always reopen a
+                            resolved comment, whoever closed it. Off is the safer default: it keeps a
+                            comment from being a ticket the agent validates for itself.
+                          </>
+                        }
+                        source={reviewAgentCanResolveSourceNote(settings.review_agent_can_resolve)}
                       />
                       {/* Turn-end auto-completion (#469). Labelled on what is MEASURED — an
                           end of turn constated in the agent's transcript — and deliberately
@@ -2127,6 +2158,24 @@ function defaultAutoNameSourceNote(field: BoolSettingField): string {
     return `Source: env ${envDisplay ?? "PDO_DEFAULT_AUTO_NAME"}.`;
   }
   return `Source: built-in default (${onOff(field.default)}).`;
+}
+
+/** Which tier `review_agent_can_resolve` comes from (#751). A real built-in default
+ *  (`off`), and both directions of a save are a stored decision — same shape as
+ *  {@link defaultAutoNameSourceNote}. */
+function reviewAgentCanResolveSourceNote(field: BoolSettingField): string {
+  const onOff = (v: boolean) => (v ? "on" : "off");
+  const envDisplay = field.env != null ? `PDO_REVIEW_AGENT_CAN_RESOLVE=${onOff(field.env)}` : null;
+  if (field.source === "stored") {
+    const base = `Source: stored value (${onOff(field.effective)}).`;
+    return envDisplay
+      ? `${base} Env ${envDisplay} is set but overridden.`
+      : `${base} Overrides env and default.`;
+  }
+  if (field.source === "env") {
+    return `Source: env ${envDisplay ?? "PDO_REVIEW_AGENT_CAN_RESOLVE"}.`;
+  }
+  return `Source: built-in default (${onOff(field.default)}). Set PDO_REVIEW_AGENT_CAN_RESOLVE=true in the daemon's environment to change it; a stored value wins over both.`;
 }
 
 /** Which tier the manager auto-start flag comes from (manager on demand). A real

--- a/frontend/src/components/SettingsSurface.versionUpdate.test.tsx
+++ b/frontend/src/components/SettingsSurface.versionUpdate.test.tsx
@@ -67,6 +67,7 @@ function settings(): InstanceSettings {
     autocomplete_turn_end: { effective: false, source: "default", stored: null, env: null, default: false },
     default_auto_name: { effective: true, source: "default", stored: null, env: null, default: true },
     manager_enabled: { effective: false, source: "default", stored: null, env: null, default: false },
+    review_agent_can_resolve: { effective: false, source: "default", stored: null, env: null, default: false },
     manager_profile: { effective: null, source: "default", stored: null, env: null, default: null },
     update_check: { effective: true, source: "default", stored: null, env: null, default: true },
     price_table: {

--- a/frontend/src/components/review/CommentCard.tsx
+++ b/frontend/src/components/review/CommentCard.tsx
@@ -1,17 +1,30 @@
-import { Lock, Pencil, Trash2 } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { Bot, Check, CheckCircle2, ChevronRight, Cpu, Hourglass, Lock, MessageSquare, Pencil, Trash2, Undo2, User } from "lucide-react";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
-import type { ReviewEntry } from "../../lib/reviewComments";
-import { anchorLabel, relativeTime } from "../../lib/reviewComments";
+import type { AuthorKind, CommentState, ReviewEntry } from "../../lib/reviewComments";
+import { anchorLabel, authorKind, authorLabel, commentState, firstWords, footerStatus, plural, relativeTime } from "../../lib/reviewComments";
+import type { ReviewComment } from "../../types";
 
 /**
  * One review comment rendered under its diff line (#750): a **draft** card
  * (amber `✎ Draft`, edit / delete on hover, footer "Only in this browser until
  * sent" + `↗ Send to manager` always visible), a **sending** card (greyed,
  * spinner, "starting the manager…" when the send has to start it), or a
- * **sent** card (blue `↗ Sent`, lock, footer `rc-002 · fork → tip · Awaiting
- * manager reply` — the slot where #751's replies land). No edit, no delete on
- * a sent comment: it is a Run event.
+ * **sent** card. No edit, no delete on a sent comment: it is a Run event.
+ *
+ * #751 — the sent card is a **thread**: the agent's replies stack between the
+ * body and the footer, one row per reply (author icon — person you, bot
+ * manager, chip + id for a node —, time, an hourglass when the reply proposes a
+ * resolution, a blue dot while unread). State is one icon plus a 2px left
+ * border on the header: message-square open (blue), hourglass **Resolution
+ * proposed** (amber), check-circle resolved (green); no filled pills, names
+ * live in tooltips. The footer carries the decision: `Resolve` on an open or
+ * proposed comment, `Reopen` on a resolved one — and on a proposal, where it
+ * declines it and keeps the comment open for the agent. A resolved card
+ * **collapses** to one line (icon · anchor · time · first words · reply count ·
+ * resolved-by); its header click expands it. A reply that lands live flashes
+ * the card's outline for two seconds.
  */
 
 interface Props {
@@ -26,6 +39,16 @@ interface Props {
   onEdit: () => void;
   onDelete: () => void;
   onSend: () => void;
+  /** #751 — sent cards only. Replies this browser has not seen yet (the last N rows). */
+  unread?: number;
+  /** A reply just landed over the WebSocket: outline flash. */
+  flash?: boolean;
+  /** A Resolve / Reopen request is in flight for this comment. */
+  deciding?: boolean;
+  onResolve?: () => void;
+  onReopen?: () => void;
+  /** The card was looked at (hovered, or in view for a moment): clear its unread dots. */
+  onSeen?: () => void;
 }
 
 const REMARK_PLUGINS = [remarkGfm];
@@ -39,6 +62,12 @@ export default function CommentCard({
   onEdit,
   onDelete,
   onSend,
+  unread = 0,
+  flash = false,
+  deciding = false,
+  onResolve,
+  onReopen,
+  onSeen,
 }: Props) {
   const label = anchorLabel(entry.anchor);
   const body = (text: string) => (
@@ -52,52 +81,19 @@ export default function CommentCard({
   );
 
   if (entry.kind === "sent") {
-    const c = entry.comment;
     return (
-      <div
-        className="group my-2 ml-3 mr-3 max-w-[720px] overflow-hidden rounded-md border border-line-strong bg-bg-2 font-sans"
-        style={{ fontSize: "11px", whiteSpace: "normal" }}
-        data-testid="review-comment"
-        data-state={c.status}
-        data-anchor={label}
-        data-comment-id={c.id}
-      >
-        <div
-          className="flex items-center gap-2 border-b border-line px-2.5 py-[5px] text-fg-3"
-          style={{ fontSize: "10.5px", background: "rgba(59,130,246,.07)" }}
-        >
-          <Badge kind="sent">↗ Sent</Badge>
-          <span className="font-medium text-fg-2">{c.author === "user" ? "you" : c.author}</span>
-          <span className="font-mono text-fg-4" style={{ fontSize: "10px" }}>
-            {label}
-          </span>
-          <span className="text-fg-4">· {relativeTime(c.sent_at)}</span>
-          <span
-            className="ml-auto grid h-5 w-[22px] cursor-help place-items-center text-fg-4"
-            title="Sent comments are Run events: immutable, readable post-mortem. Replies and Resolve/Reopen arrive with the next ticket."
-            data-testid="review-comment-lock"
-          >
-            <Lock size={11} />
-          </span>
-        </div>
-        {body(c.text)}
-        <div className="flex items-center gap-2 border-t border-line px-2.5 py-[5px] text-fg-4" style={{ fontSize: "10px" }}>
-          <span className="font-mono" data-testid="review-comment-id">
-            {c.id}
-          </span>
-          <span>· {pairLabel}</span>
-          <span className="ml-auto inline-flex items-center gap-1.5">
-            {c.status === "resolved" ? (
-              <span className="text-st-done">Resolved</span>
-            ) : (
-              <>
-                <Spinner dim />
-                Awaiting manager reply
-              </>
-            )}
-          </span>
-        </div>
-      </div>
+      <SentCard
+        comment={entry.comment}
+        label={label}
+        body={body}
+        pairLabel={pairLabel}
+        unread={unread}
+        flash={flash}
+        deciding={deciding}
+        onResolve={onResolve}
+        onReopen={onReopen}
+        onSeen={onSeen}
+      />
     );
   }
 
@@ -181,6 +177,361 @@ export default function CommentCard({
       </div>
     </div>
   );
+}
+
+const STATE_COLOR: Record<CommentState, string> = {
+  open: "var(--color-st-running)",
+  proposed: "var(--color-st-await)",
+  resolved: "var(--color-st-done)",
+};
+
+/** How long a card has to stay in view before its replies count as seen. */
+const SEEN_DWELL_MS = 1500;
+
+function SentCard({
+  comment: c,
+  label,
+  body,
+  pairLabel,
+  unread,
+  flash,
+  deciding,
+  onResolve,
+  onReopen,
+  onSeen,
+}: {
+  comment: ReviewComment;
+  label: string;
+  body: (text: string) => React.ReactNode;
+  pairLabel: string;
+  unread: number;
+  flash: boolean;
+  deciding: boolean;
+  onResolve?: () => void;
+  onReopen?: () => void;
+  onSeen?: () => void;
+}) {
+  const state = commentState(c);
+  const replies = c.replies ?? [];
+  const footer = footerStatus(c);
+  // Resolved ⇒ collapsed (GitHub-like), until the header is clicked. The
+  // expansion is keyed on the resolution it was opened for, so a comment
+  // resolved again later collapses again without an effect.
+  const [expandedFor, setExpandedFor] = useState<string | null>(null);
+  const resolutionKey = c.resolved_at ?? "resolved";
+  const collapsed = state === "resolved" && expandedFor !== resolutionKey;
+  const setExpanded = (fn: (open: boolean) => boolean) =>
+    setExpandedFor((prev) => (fn(prev === resolutionKey) ? resolutionKey : null));
+
+  // Seen: hover, or in view for a moment. Only while something is unread.
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    if (unread === 0 || !onSeen) return;
+    const el = rootRef.current;
+    if (!el || typeof IntersectionObserver === "undefined") return;
+    let timer: number | undefined;
+    const io = new IntersectionObserver((entries) => {
+      const visible = entries.some((e) => e.isIntersecting);
+      window.clearTimeout(timer);
+      if (visible) timer = window.setTimeout(() => onSeen(), SEEN_DWELL_MS);
+    });
+    io.observe(el);
+    return () => {
+      window.clearTimeout(timer);
+      io.disconnect();
+    };
+  }, [unread, onSeen]);
+
+  const firstUnread = replies.length - unread;
+  const resolver = c.resolved_by ?? "user";
+  const stateTitle =
+    state === "resolved"
+      ? `Resolved by ${authorLabel(resolver)}`
+      : state === "proposed"
+        ? `Resolution proposed by ${authorLabel(footer.kind === "proposed" ? footer.author : "agent")}`
+        : "Sent · open";
+
+  return (
+    <div
+      ref={rootRef}
+      onMouseEnter={unread > 0 ? onSeen : undefined}
+      className={`group my-2 ml-3 mr-3 max-w-[720px] overflow-hidden rounded-md border border-line-strong bg-bg-2 font-sans ${
+        flash ? "pdo-review-flash" : ""
+      }`}
+      style={{ fontSize: "11px", whiteSpace: "normal" }}
+      data-testid="review-comment"
+      data-state={c.status}
+      data-review-state={state}
+      data-collapsed={collapsed ? "true" : undefined}
+      data-unread={unread > 0 ? unread : undefined}
+      data-anchor={label}
+      data-comment-id={c.id}
+    >
+      <div
+        role={state === "resolved" ? "button" : undefined}
+        tabIndex={state === "resolved" ? 0 : undefined}
+        aria-expanded={state === "resolved" ? !collapsed : undefined}
+        onClick={state === "resolved" ? () => setExpanded((e) => !e) : undefined}
+        onKeyDown={
+          state === "resolved"
+            ? (e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  setExpanded((x) => !x);
+                }
+              }
+            : undefined
+        }
+        data-testid="review-comment-header"
+        className={`flex items-center gap-2 bg-bg-3 px-2.5 py-[5px] text-fg-3 ${collapsed ? "cursor-pointer" : "border-b border-line"}`}
+        style={{ fontSize: "10.5px", borderLeft: `2px solid ${STATE_COLOR[state]}` }}
+      >
+        <StateIcon state={state} title={stateTitle} />
+        <AuthorIcon author={c.author} />
+        <span className="font-mono text-fg-4" style={{ fontSize: "10px" }}>
+          {label}
+        </span>
+        <span className="text-fg-4">· {relativeTime(c.sent_at)}</span>
+        {state === "resolved" && (
+          <span className={`text-fg-4 transition-transform ${collapsed ? "" : "rotate-90"}`} aria-hidden>
+            <ChevronRight size={10} />
+          </span>
+        )}
+        {collapsed && (
+          <span className="flex min-w-0 items-center gap-1.5 truncate text-fg-3" style={{ fontSize: "10px" }} data-testid="review-comment-summary">
+            <span className="truncate">“{firstWords(c.text)}”</span>
+            {replies.length > 0 && (
+              <span className="inline-flex items-center gap-0.5 text-fg-4" title={plural(replies.length, "reply").replace("replys", "replies")}>
+                <MessageSquare size={10} /> {replies.length}
+              </span>
+            )}
+          </span>
+        )}
+        <span className="ml-auto inline-flex items-center gap-1 text-fg-4">
+          {state === "resolved" ? (
+            <span className="inline-flex items-center gap-0.5 text-fg-4" title={`Resolved by ${authorLabel(resolver)}`} data-testid="review-comment-resolved-by">
+              <AuthorGlyph kind={authorKind(resolver)} size={10} />
+              <Check size={10} className="text-st-done" />
+            </span>
+          ) : (
+            <span
+              className="grid h-5 w-[22px] cursor-help place-items-center"
+              title="Sent comments are Run events: immutable, readable post-mortem. Replies and Resolve / Reopen are events too."
+              data-testid="review-comment-lock"
+            >
+              <Lock size={11} />
+            </span>
+          )}
+        </span>
+      </div>
+
+      {!collapsed && (
+        <>
+          {body(c.text)}
+          {replies.length > 0 && (
+            <div className="border-t border-line bg-bg-1" data-testid="review-comment-thread">
+              {replies.map((r, i) => {
+                const kind = authorKind(r.author);
+                const isUnread = i >= firstUnread;
+                return (
+                  <div
+                    key={`${r.at}-${i}`}
+                    className={`grid grid-cols-[14px_1fr] gap-2 px-2.5 py-[7px] ${i > 0 ? "border-t border-dashed border-line-soft" : ""}`}
+                    data-testid="review-reply"
+                    data-author={r.author}
+                    data-unread={isUnread ? "true" : undefined}
+                    data-proposes={r.proposes_resolution ? "true" : undefined}
+                  >
+                    <span className="mt-px text-fg-3" title={authorLabel(r.author)}>
+                      <AuthorGlyph kind={kind} size={12} />
+                    </span>
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-1.5 text-fg-3" style={{ fontSize: "10.5px" }}>
+                        {kind === "node" && (
+                          <span className="font-mono text-fg-2" style={{ fontSize: "10px" }} title={`node ${r.author}`}>
+                            {r.author}
+                          </span>
+                        )}
+                        <span className="text-fg-4">{relativeTime(r.at)}</span>
+                        {r.proposes_resolution && (
+                          <span className="inline-flex items-center text-st-await" title="Proposes to resolve" data-testid="review-reply-proposes">
+                            <Hourglass size={10} />
+                          </span>
+                        )}
+                        {isUnread && (
+                          <span className="ml-0.5 h-1.5 w-1.5 rounded-full bg-st-running" title="New reply" data-testid="review-reply-unread" aria-label="new" />
+                        )}
+                      </div>
+                      <div
+                        className="artifact-markdown text-fg [&_ol]:list-decimal [&_ol]:pl-5 [&_ul]:list-disc [&_ul]:pl-5"
+                        style={{ fontSize: "11.5px", lineHeight: 1.5 }}
+                        data-testid="review-reply-body"
+                      >
+                        <Markdown remarkPlugins={REMARK_PLUGINS}>{r.text}</Markdown>
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+          <div className="flex items-center gap-2 border-t border-line px-2.5 py-[5px] text-fg-4" style={{ fontSize: "10px" }}>
+            <span className="font-mono" data-testid="review-comment-id">
+              {c.id}
+            </span>
+            <span>· {pairLabel}</span>
+            <span className="ml-auto inline-flex items-center gap-1.5" data-testid="review-comment-status" data-kind={footer.kind}>
+              <FooterStatusView status={footer} />
+              {state === "proposed" ? (
+                <>
+                  <DecisionButton
+                    primary
+                    onClick={onResolve}
+                    disabled={deciding || !onResolve}
+                    title={`Confirm: mark ${c.id} resolved (you keep Reopen)`}
+                    testId="review-comment-resolve"
+                  >
+                    <Check size={11} /> Resolve
+                  </DecisionButton>
+                  <DecisionButton
+                    onClick={onReopen}
+                    disabled={deciding || !onReopen}
+                    title="Decline the proposal, keep the comment open for the agent"
+                    testId="review-comment-reopen"
+                  >
+                    <Undo2 size={11} /> Reopen
+                  </DecisionButton>
+                </>
+              ) : state === "resolved" ? (
+                <DecisionButton ghost onClick={onReopen} disabled={deciding || !onReopen} title="Reopen this comment" testId="review-comment-reopen">
+                  <Undo2 size={11} /> Reopen
+                </DecisionButton>
+              ) : footer.kind !== "awaiting" ? (
+                <DecisionButton ghost onClick={onResolve} disabled={deciding || !onResolve} title="Resolve this comment yourself" testId="review-comment-resolve">
+                  <Check size={11} /> Resolve
+                </DecisionButton>
+              ) : null}
+            </span>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+function FooterStatusView({ status }: { status: ReturnType<typeof footerStatus> }) {
+  switch (status.kind) {
+    case "awaiting":
+      return (
+        <>
+          <Spinner dim />
+          Awaiting manager reply
+        </>
+      );
+    case "replied":
+      return (
+        <span className="inline-flex items-center gap-1" title={`Replied by ${authorLabel(status.author)}`}>
+          <AuthorGlyph kind={authorKind(status.author)} size={10} /> {relativeTime(status.at)}
+        </span>
+      );
+    case "proposed":
+      return (
+        <span className="inline-flex items-center gap-1 text-st-await" title={`Resolution proposed by ${authorLabel(status.author)}`}>
+          <Hourglass size={10} />
+          <AuthorGlyph kind={authorKind(status.author)} size={10} /> <span className="text-fg-4">{relativeTime(status.at)}</span>
+        </span>
+      );
+    case "resolved":
+      return (
+        <span className="inline-flex items-center gap-1 text-st-done" title={`Resolved by ${authorLabel(status.by)}`}>
+          <CheckCircle2 size={10} />
+          <AuthorGlyph kind={authorKind(status.by)} size={10} /> <span className="text-fg-4">{relativeTime(status.at)}</span>
+        </span>
+      );
+    case "reopened":
+      return (
+        <span className="inline-flex items-center gap-1" title={`Reopened by ${authorLabel(status.by)}`}>
+          <Undo2 size={10} />
+          <AuthorGlyph kind={authorKind(status.by)} size={10} /> {relativeTime(status.at)}
+        </span>
+      );
+    case "declined":
+      return (
+        <span className="inline-flex items-center gap-1" title={`Proposal declined by ${authorLabel(status.by)} — open for the agent`}>
+          <Undo2 size={10} />
+          <AuthorGlyph kind={authorKind(status.by)} size={10} /> {relativeTime(status.at)}
+        </span>
+      );
+  }
+}
+
+function DecisionButton({
+  children,
+  onClick,
+  disabled,
+  title,
+  testId,
+  primary,
+  ghost,
+}: {
+  children: React.ReactNode;
+  onClick?: () => void;
+  disabled: boolean;
+  title: string;
+  testId: string;
+  primary?: boolean;
+  ghost?: boolean;
+}) {
+  const look = primary
+    ? "border-acc bg-acc font-semibold text-[#04140d] hover:bg-[#14cf92]"
+    : ghost
+      ? "border-transparent bg-transparent text-fg-4 hover:bg-bg-4 hover:text-fg-2"
+      : "border-line-strong bg-bg-3 text-fg-2 hover:bg-bg-4 hover:text-fg";
+  return (
+    <button
+      type="button"
+      onClick={(e) => {
+        e.stopPropagation();
+        onClick?.();
+      }}
+      disabled={disabled}
+      title={title}
+      data-testid={testId}
+      className={`inline-flex cursor-pointer items-center gap-1 rounded border px-2 py-0.5 disabled:cursor-not-allowed disabled:opacity-45 ${look}`}
+      style={{ fontSize: "10.5px" }}
+    >
+      {children}
+    </button>
+  );
+}
+
+/** The state icon — message-square open, hourglass proposed, check-circle resolved. */
+export function StateIcon({ state, title, size = 12 }: { state: CommentState; title?: string; size?: number }) {
+  const cls = state === "proposed" ? "text-st-await" : state === "resolved" ? "text-st-done" : "text-fg-3";
+  return (
+    <span className={`inline-flex items-center ${cls}`} title={title} data-testid={`review-state-${state}`}>
+      {state === "proposed" ? <Hourglass size={size} /> : state === "resolved" ? <CheckCircle2 size={size} /> : <MessageSquare size={size} />}
+    </span>
+  );
+}
+
+/** The author icon — person you, bot manager, chip node — name in the tooltip. */
+export function AuthorIcon({ author, size = 12 }: { author: string; size?: number }) {
+  const kind = authorKind(author);
+  return (
+    <span className="inline-flex items-center gap-1 text-fg-3" title={authorLabel(author)} data-testid="review-author" data-author-kind={kind}>
+      <AuthorGlyph kind={kind} size={size} />
+      {kind === "node" && (
+        <span className="font-mono text-fg-2" style={{ fontSize: "10px" }}>
+          {author}
+        </span>
+      )}
+    </span>
+  );
+}
+
+export function AuthorGlyph({ kind, size }: { kind: AuthorKind; size: number }) {
+  return kind === "user" ? <User size={size} /> : kind === "manager" ? <Bot size={size} /> : <Cpu size={size} />;
 }
 
 /** The amber (draft) / blue (sent) pill the badges, sidebar and headers share. */

--- a/frontend/src/components/review/ReviewFileCard.tsx
+++ b/frontend/src/components/review/ReviewFileCard.tsx
@@ -5,10 +5,11 @@ import type { DiffFile, ReviewSide } from "../../types";
 import { fetchRunFileAtRef } from "../../api";
 import { baseName, fileHunks, filePath, langOf, statusLetter } from "../../lib/runRefs";
 import type { RefPair, ViewMode } from "../../lib/runRefs";
-import type { Anchor, ReviewEntry } from "../../lib/reviewComments";
-import { entryAt, plural, wipKey } from "../../lib/reviewComments";
+import type { Anchor, CommentState, ReviewEntry } from "../../lib/reviewComments";
+import { commentState, entryAt, plural, stateCounts, wipKey } from "../../lib/reviewComments";
+import type { ReviewComment } from "../../types";
 import CommentEditor from "./CommentEditor";
-import CommentCard, { Badge } from "./CommentCard";
+import CommentCard, { Badge, StateIcon } from "./CommentCard";
 
 /**
  * One file of the Review page (#749): a sticky header (chevron, status letter,
@@ -29,8 +30,13 @@ import CommentCard, { Badge } from "./CommentCard";
  * `+` widget on a line number opens the editor (widget row) for a line without
  * a comment, re-opens the draft for edit when there is one, and only toasts on
  * a sent (immutable) comment: **one comment per line**. Anchored lines carry a
- * dot on the number and a 2px bar on the content cell, amber for a draft, blue
- * for a sent comment, through a per-card `<style>` scoped to the card's id.
+ * dot on the number and a 2px bar on the content cell, through a per-card
+ * `<style>` scoped to the card's id: amber for a draft; for a sent comment the
+ * colour follows its state (#751) — blue open, amber resolution proposed, green
+ * resolved — so a scan of the file shows what is still open. The header's
+ * badges are icon + count per state (proposed first). Hiding resolved comments
+ * (the page's eye toggle) drops their cards from the extend slots but keeps the
+ * green dot on the line.
  */
 
 /** What the page hands every card to act on comments (#750). */
@@ -53,6 +59,18 @@ export interface ReviewCommentsApi {
   sendDraft: (key: string) => void;
   /** The `+` landed on a sent comment: nothing to open, the page explains. */
   sentLineClicked: () => void;
+  /** #751: the human's decision on a sent comment. */
+  resolve: (comment: ReviewComment) => void;
+  reopen: (comment: ReviewComment) => void;
+  /** Comment ids with a Resolve / Reopen in flight. */
+  deciding: ReadonlySet<string>;
+  /** Unread replies of a comment in this browser (0 = all seen). */
+  unreadOf: (comment: ReviewComment) => number;
+  /** Comment ids whose reply just landed live (outline flash). */
+  flashing: ReadonlySet<string>;
+  markSeen: (comment: ReviewComment) => void;
+  /** Eye toggle: false hides resolved cards (their anchor dot stays). */
+  showResolved: boolean;
 }
 
 interface Props {
@@ -83,6 +101,13 @@ const LETTER_CLASS: Record<"A" | "M" | "D" | "R", string> = {
 };
 
 const NO_ENTRIES: ReviewEntry[] = [];
+
+/** Line dot / bar colour per sent-comment state (#751). */
+const STATE_VAR: Record<CommentState, string> = {
+  open: "var(--color-st-running)",
+  proposed: "var(--color-st-await)",
+  resolved: "var(--color-st-done)",
+};
 
 function sideOf(s: SplitSide): ReviewSide {
   return s === SplitSide.old ? "old" : "new";
@@ -171,26 +196,32 @@ export default function ReviewFileCard({
   }, [file.old_path, file.new_path, hunks, contents]);
 
   // --- Comments (#750) --------------------------------------------------------
+  const showResolved = comments?.showResolved ?? true;
   const extendData = useMemo(() => {
     const oldFile: Record<string, { data: ReviewEntry }> = {};
     const newFile: Record<string, { data: ReviewEntry }> = {};
     for (const e of entries) {
+      if (!showResolved && e.kind === "sent" && e.comment.status === "resolved") continue;
       const slot = e.anchor.side === "old" ? oldFile : newFile;
       // Sent wins over a stale draft on the same line (entries are sorted so).
       if (!slot[String(e.anchor.line)]) slot[String(e.anchor.line)] = { data: e };
     }
     return { oldFile, newFile };
-  }, [entries]);
+  }, [entries, showResolved]);
 
   const nDrafts = entries.filter((e) => e.kind === "draft").length;
   const nSent = entries.length - nDrafts;
+  const sentStates = useMemo(
+    () => stateCounts(entries.flatMap((e) => (e.kind === "sent" ? [e.comment] : []))),
+    [entries],
+  );
 
   /** Per-card CSS: dot + bar on anchored lines, `+` hidden where a comment sits. */
   const anchorCss = useMemo(() => {
     if (entries.length === 0) return "";
     const rules: string[] = [];
     for (const e of entries) {
-      const color = e.kind === "draft" ? "var(--color-st-await)" : "var(--color-st-running)";
+      const color = e.kind === "draft" ? "var(--color-st-await)" : STATE_VAR[commentState(e.comment)];
       const { side, line } = e.anchor;
       // Split: `td.diff-line-<side>-num > span[data-line-num]`, content cell next.
       const num = `#${cssId} td.diff-line-${side}-num:has(> span[data-line-num="${line}"])`;
@@ -233,6 +264,8 @@ export default function ReviewFileCard({
       data-content={contents.kind}
       data-drafts={nDrafts}
       data-sent={nSent}
+      data-proposed={sentStates.proposed}
+      data-resolved={sentStates.resolved}
       className="mx-3 my-2.5 overflow-hidden rounded-md border border-line bg-bg-2"
     >
       {anchorCss && <style>{anchorCss}</style>}
@@ -281,7 +314,21 @@ export default function ReviewFileCard({
         )}
         <span className="ml-auto flex items-center gap-1.5" onClick={(e) => e.stopPropagation()}>
           {nDrafts > 0 && <Badge kind="draft">✎ {plural(nDrafts, "draft")}</Badge>}
-          {nSent > 0 && <Badge kind="sent">↗ {nSent} sent</Badge>}
+          {sentStates.proposed > 0 && (
+            <span className="inline-flex items-center gap-0.5 text-st-await" style={{ fontSize: "10px" }} title={`${sentStates.proposed} resolution proposed`} data-testid="review-file-proposed">
+              <StateIcon state="proposed" size={10} /> {sentStates.proposed}
+            </span>
+          )}
+          {sentStates.open > 0 && (
+            <span className="inline-flex items-center gap-0.5 text-fg-3" style={{ fontSize: "10px" }} title={`${sentStates.open} open`} data-testid="review-file-open">
+              <StateIcon state="open" size={10} /> {sentStates.open}
+            </span>
+          )}
+          {sentStates.resolved > 0 && (
+            <span className="inline-flex items-center gap-0.5 text-st-done" style={{ fontSize: "10px" }} title={`${sentStates.resolved} resolved`} data-testid="review-file-resolved">
+              <StateIcon state="resolved" size={10} /> {sentStates.resolved}
+            </span>
+          )}
           <button
             type="button"
             onClick={copyPath}
@@ -382,6 +429,7 @@ export default function ReviewFileCard({
                   );
                 }
                 const key = entry.kind === "draft" ? entry.draft.key : null;
+                const sent = entry.kind === "sent" ? entry.comment : null;
                 return (
                   <CommentCard
                     entry={entry}
@@ -392,6 +440,12 @@ export default function ReviewFileCard({
                     onEdit={() => key && comments.editDraft(key)}
                     onDelete={() => key && comments.deleteDraft(key)}
                     onSend={() => key && comments.sendDraft(key)}
+                    unread={sent ? comments.unreadOf(sent) : 0}
+                    flash={sent ? comments.flashing.has(sent.id) : false}
+                    deciding={sent ? comments.deciding.has(sent.id) : false}
+                    onResolve={sent ? () => comments.resolve(sent) : undefined}
+                    onReopen={sent ? () => comments.reopen(sent) : undefined}
+                    onSeen={sent ? () => comments.markSeen(sent) : undefined}
                   />
                 );
               }}

--- a/frontend/src/components/review/ReviewFileList.tsx
+++ b/frontend/src/components/review/ReviewFileList.tsx
@@ -2,9 +2,10 @@ import { PanelLeftClose } from "lucide-react";
 import type { RefObject } from "react";
 import type { DiffFile } from "../../types";
 import { baseName, filePath, groupByDir, miniBar, statusLetter } from "../../lib/runRefs";
-import type { ReviewEntry } from "../../lib/reviewComments";
-import { anchorLabel, plural } from "../../lib/reviewComments";
-import { Badge } from "./CommentCard";
+import { Hourglass } from "lucide-react";
+import type { ReviewEntry, StateCounts } from "../../lib/reviewComments";
+import { anchorLabel, authorKind, authorLabel, commentState, footerStatus, plural, sortForSidebar } from "../../lib/reviewComments";
+import { AuthorGlyph, Badge, StateIcon } from "./CommentCard";
 
 /**
  * The Review page's left column (#749, design option "flat list grouped by
@@ -16,6 +17,12 @@ import { Badge } from "./CommentCard";
  * **Comments** section lists every comment of the Run — badge, anchor, first
  * words — click to jump. Comments written against another ref pair are greyed
  * with their pair; clicking one restores that pair first.
+ *
+ * #751: sent comments read by **state**. File rows carry icon + count per state
+ * (proposed first — it needs a decision); the Comments section sorts
+ * proposed → open → resolved, each row ending with two small icons (state,
+ * last author), resolved rows dimmed; the section header carries the "needs
+ * you" count as an hourglass.
  */
 
 interface Props {
@@ -28,6 +35,8 @@ interface Props {
   onClose: () => void;
   /** #750: per-path comment counts for the row badges. */
   counts?: Map<string, { drafts: number; sent: number }>;
+  /** #751: per-path sent-comment state counts (replace the plain "sent" badge when given). */
+  stateCounts?: Map<string, StateCounts>;
   /** #750: the Comments section — current pair first, other pairs greyed. */
   comments?: { current: ReviewEntry[]; other: { entry: ReviewEntry; pair: string }[] };
   onJumpEntry?: (entry: ReviewEntry) => void;
@@ -50,10 +59,13 @@ export default function ReviewFileList({
   onSelect,
   onClose,
   counts,
+  stateCounts: states,
   comments,
   onJumpEntry,
   onJumpOther,
 }: Props) {
+  const current = comments ? sortForSidebar(comments.current) : [];
+  const needsYou = current.filter((e) => e.kind === "sent" && commentState(e.comment) === "proposed").length;
   const q = filter.trim().toLowerCase();
   const shown = files
     .map((file, index) => ({ file, index }))
@@ -137,7 +149,29 @@ export default function ReviewFileList({
                   </span>
                   <span className="flex items-center gap-1 font-mono" style={{ fontSize: "10px" }}>
                     {(counts?.get(p)?.drafts ?? 0) > 0 && <Badge kind="draft">{counts!.get(p)!.drafts}</Badge>}
-                    {(counts?.get(p)?.sent ?? 0) > 0 && <Badge kind="sent">{counts!.get(p)!.sent}</Badge>}
+                    {states?.get(p) ? (
+                      <>
+                        {states.get(p)!.proposed > 0 && (
+                          <span className="inline-flex items-center gap-px text-st-await" title={`${states.get(p)!.proposed} resolution proposed`}>
+                            <StateIcon state="proposed" size={9} />
+                            {states.get(p)!.proposed}
+                          </span>
+                        )}
+                        {states.get(p)!.open > 0 && (
+                          <span className="inline-flex items-center gap-px text-fg-4" title={`${states.get(p)!.open} open`}>
+                            <StateIcon state="open" size={9} />
+                            {states.get(p)!.open}
+                          </span>
+                        )}
+                        {states.get(p)!.resolved > 0 && (
+                          <span className="inline-flex items-center gap-px text-st-done" title={`${states.get(p)!.resolved} resolved`}>
+                            <StateIcon state="resolved" size={9} />
+                          </span>
+                        )}
+                      </>
+                    ) : (
+                      (counts?.get(p)?.sent ?? 0) > 0 && <Badge kind="sent">{counts!.get(p)!.sent}</Badge>
+                    )}
                     {file.binary ? (
                       <span className="text-fg-4">bin</span>
                     ) : pureRename ? (
@@ -173,9 +207,15 @@ export default function ReviewFileList({
             >
               <span>Comments</span>
               {comments.current.length + comments.other.length > 0 && (
-                <span className="normal-case tracking-normal" data-testid="review-comments-count">
+                <span className="inline-flex items-center gap-1.5 normal-case tracking-normal" data-testid="review-comments-count">
                   {plural(comments.current.filter((e) => e.kind === "draft").length, "draft")} ·{" "}
                   {comments.current.filter((e) => e.kind === "sent").length} sent
+                  {needsYou > 0 && (
+                    <span className="inline-flex items-center gap-px text-st-await" title={`${needsYou} need${needsYou === 1 ? "s" : ""} your decision`} data-testid="review-needs-you">
+                      <Hourglass size={9} />
+                      {needsYou}
+                    </span>
+                  )}
                 </span>
               )}
             </div>
@@ -185,7 +225,7 @@ export default function ReviewFileList({
               </div>
             ) : (
               <>
-                {comments.current.map((e) => (
+                {current.map((e) => (
                   <CommentRow key={entryKey(e)} entry={e} onClick={() => onJumpEntry?.(e)} />
                 ))}
                 {comments.other.map(({ entry, pair }) => (
@@ -236,27 +276,53 @@ function entryKey(e: ReviewEntry): string {
   return e.kind === "draft" ? `d:${e.draft.key}` : `s:${e.comment.id}`;
 }
 
+const DOT_CLASS = { open: "bg-st-running", proposed: "bg-st-await", resolved: "bg-st-done" } as const;
+
 function CommentRow({ entry, pair, onClick }: { entry: ReviewEntry; pair?: string; onClick: () => void }) {
   const text = entry.kind === "draft" ? entry.draft.text : entry.comment.text;
   const first = text.split("\n")[0].slice(0, 28);
+  const state = entry.kind === "sent" ? commentState(entry.comment) : null;
+  const status = entry.kind === "sent" ? footerStatus(entry.comment) : null;
+  // The last actor on the thread: who replied / proposed / resolved / reopened.
+  const lastActor =
+    status && status.kind !== "awaiting" ? ("author" in status ? status.author : status.by) : null;
+  const stateTitle =
+    state === "proposed"
+      ? `resolution proposed${lastActor ? ` by ${authorLabel(lastActor)}` : ""}`
+      : state === "resolved"
+        ? `resolved by ${authorLabel(entry.kind === "sent" ? (entry.comment.resolved_by ?? "user") : "user")}`
+        : lastActor
+          ? `replied by ${authorLabel(lastActor)}`
+          : "awaiting reply";
   return (
     <button
       type="button"
       onClick={onClick}
-      title={pair ? `${text.slice(0, 120)}\n(at ${pair})` : text.slice(0, 120)}
+      title={pair ? `${text.slice(0, 120)}\n(at ${pair})` : `${text.slice(0, 120)}${state ? `\n${stateTitle}` : ""}`}
       data-testid="review-comment-row"
       data-kind={entry.kind}
+      data-review-state={state ?? undefined}
       data-other-pair={pair ? "true" : undefined}
-      className={`grid w-full cursor-pointer grid-cols-[auto_auto_1fr] items-center gap-1.5 rounded px-1.5 py-[3px] text-left hover:bg-bg-3 ${
-        pair ? "opacity-55" : ""
+      className={`grid w-full cursor-pointer grid-cols-[auto_auto_1fr_auto] items-center gap-1.5 rounded px-1.5 py-[3px] text-left hover:bg-bg-3 ${
+        pair || state === "resolved" ? "opacity-55" : ""
       }`}
       style={{ fontSize: "10.5px" }}
     >
-      <Badge kind={entry.kind}>{entry.kind === "draft" ? "✎" : "↗"}</Badge>
+      {state ? (
+        <span className={`inline-block h-1.5 w-1.5 rounded-full ${DOT_CLASS[state]}`} aria-hidden />
+      ) : (
+        <Badge kind="draft">✎</Badge>
+      )}
       <span className="font-mono text-fg-3" style={{ fontSize: "10px" }}>
         {anchorLabel(entry.anchor)}
       </span>
       <span className="truncate text-fg-4">{pair ? `at ${pair}` : first}</span>
+      {state && (
+        <span className="inline-flex items-center gap-1 text-fg-4" title={stateTitle}>
+          <StateIcon state={state} size={9} />
+          {lastActor && <AuthorGlyph kind={authorKind(lastActor)} size={9} />}
+        </span>
+      )}
     </button>
   );
 }

--- a/frontend/src/components/settingsCategories.ts
+++ b/frontend/src/components/settingsCategories.ts
@@ -162,6 +162,7 @@ export type SettingsFieldId =
   | "guard-timeout"
   | "autocomplete-turn-end"
   | "default-auto-name"
+  | "review-agent-can-resolve"
   | "agent-choice"
   | "skills"
   | "default-model"
@@ -178,6 +179,7 @@ export const FIELD_SECTION: Record<SettingsFieldId, SettingsSectionId> = {
   "guard-timeout": "runtime-limits",
   "autocomplete-turn-end": "runs",
   "default-auto-name": "runs",
+  "review-agent-can-resolve": "runs",
   "agent-choice": "harness-models",
   skills: "skills",
   "default-model": "harness-models",

--- a/frontend/src/hooks/useReviewUnread.ts
+++ b/frontend/src/hooks/useReviewUnread.ts
@@ -1,0 +1,33 @@
+import { useCallback, useMemo, useSyncExternalStore } from "react";
+import type { RunState } from "../types";
+import { readSeen, seenKey, unreadCommentCount } from "../lib/reviewComments";
+
+/**
+ * How many of a Run's sent review comments carry a reply this browser has not
+ * seen (#751) — the Diff tab's count badge. The "seen" marker lives in
+ * localStorage (written by the Review page: opening it marks everything seen,
+ * looking at a card marks that card), so the count follows both the Run's
+ * WebSocket pushes (through `run`) and the other tab's `storage` events.
+ */
+export function useReviewUnread(run: RunState | null): number {
+  const runId = run?.run_id ?? null;
+  const subscribe = useCallback((onChange: () => void) => {
+    window.addEventListener("storage", onChange);
+    return () => window.removeEventListener("storage", onChange);
+  }, []);
+  // The raw string is the snapshot (stable between writes), parsed below.
+  const raw = useSyncExternalStore(
+    subscribe,
+    () => {
+      if (!runId) return null;
+      try {
+        return localStorage.getItem(seenKey(runId));
+      } catch {
+        return null;
+      }
+    },
+    () => null,
+  );
+  const seen = useMemo(() => (runId ? readSeen(runId, { getItem: () => raw }) : {}), [runId, raw]);
+  return useMemo(() => (run ? unreadCommentCount(run.review_comments, seen) : 0), [run, seen]);
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -920,3 +920,16 @@ body {
 .pdo-review .diff-line-hunk-action button:hover {
   color: #10b981;
 }
+
+/* #751: a review reply that just landed over the WebSocket — 2 s outline flash. */
+@keyframes pdo-review-flash {
+  0% {
+    box-shadow: 0 0 0 2px var(--color-st-running);
+  }
+  100% {
+    box-shadow: 0 0 0 0 transparent;
+  }
+}
+.pdo-review-flash {
+  animation: pdo-review-flash 2.4s ease-out;
+}

--- a/frontend/src/lib/newRunForm.test.ts
+++ b/frontend/src/lib/newRunForm.test.ts
@@ -48,6 +48,7 @@ function settings(over: Partial<InstanceSettings> = {}): InstanceSettings {
     autocomplete_turn_end: { effective: false, source: "default", stored: null, env: null, default: false },
     default_auto_name: { effective: true, source: "default", stored: null, env: null, default: true },
     manager_enabled: { effective: false, source: "default", stored: null, env: null, default: false },
+    review_agent_can_resolve: { effective: false, source: "default", stored: null, env: null, default: false },
     manager_profile: { effective: null, source: "default", stored: null, env: null, default: null },
     update_check: { effective: true, source: "default", stored: null, env: null, default: true },
     price_table: { manual_path: null, fetched_path: null, source: null, fetched_at: null, fetched_rows: 0, manual_keys: [], reason: null },

--- a/frontend/src/lib/reviewComments.test.ts
+++ b/frontend/src/lib/reviewComments.test.ts
@@ -1,8 +1,22 @@
 import { describe, it, expect } from "vitest";
 import {
   addDraft,
+  allSeen,
   anchorLabel,
+  authorKind,
+  authorLabel,
+  commentState,
   countsByPath,
+  firstWords,
+  footerStatus,
+  markSeen,
+  readSeen,
+  sortForSidebar,
+  stateCounts,
+  stateCountsByPath,
+  unreadCommentCount,
+  unreadReplies,
+  writeSeen,
   draftsForPair,
   entryAt,
   mergeEntries,
@@ -120,5 +134,106 @@ describe("reviewComments (#750)", () => {
     expect(relativeTime("2026-09-09T10:05:00Z", now)).toBe("5 min ago");
     expect(relativeTime("garbage", now)).toBe("");
     expect(relativeTime("2026-09-09T08:00:00Z", now)).toMatch(/\d/);
+  });
+});
+
+describe("reviewComments — the conversation (#751)", () => {
+  const replied = (over: Partial<ReviewComment> = {}) =>
+    sent({ id: "rc-002", line: 7, replies: [{ author: "manager", text: "done", at: "2026-09-09T10:05:00Z" }], ...over });
+  const proposed = (over: Partial<ReviewComment> = {}) =>
+    sent({
+      id: "rc-003",
+      line: 9,
+      proposal_pending: true,
+      replies: [{ author: "xuTJYLUa", text: "fixed", at: "2026-09-09T10:06:00Z", proposes_resolution: true }],
+      ...over,
+    });
+  const resolved = (over: Partial<ReviewComment> = {}) =>
+    sent({ id: "rc-004", line: 11, status: "resolved", resolved_by: "user", resolved_at: "2026-09-09T10:07:00Z", ...over });
+
+  it("reads a comment's state: open, proposed, resolved — and counts them", () => {
+    expect(commentState(sent())).toBe("open");
+    expect(commentState(replied())).toBe("open");
+    expect(commentState(proposed())).toBe("proposed");
+    expect(commentState(resolved())).toBe("resolved");
+    expect(stateCounts([sent(), replied(), proposed(), resolved()])).toEqual({ open: 2, proposed: 1, resolved: 1 });
+    const entries = mergeEntries([], [sent(), proposed({ path: "a.ts" }), resolved()], PAIR, ["a.ts", "b.ts"]);
+    expect(stateCountsByPath(entries).get("a.ts")).toEqual({ open: 0, proposed: 1, resolved: 0 });
+    expect(stateCountsByPath(entries).get("b.ts")).toEqual({ open: 1, proposed: 0, resolved: 1 });
+  });
+
+  it("sorts the sidebar drafts → proposed → open → resolved, keeping diff order inside a group", () => {
+    const drafts = addDraft([], { path: "b.ts", side: "new", line: 20 }, PAIR, "d");
+    const entries = mergeEntries(drafts, [resolved(), sent(), proposed(), replied()], PAIR, ["b.ts"]);
+    const order = sortForSidebar(entries).map((e) => (e.kind === "draft" ? "draft" : e.comment.id));
+    expect(order).toEqual(["draft", "rc-003", "rc-001", "rc-002", "rc-004"]);
+  });
+
+  it("names authors by kind and truncates the collapsed summary", () => {
+    expect(authorKind("user")).toBe("user");
+    expect(authorKind("manager")).toBe("manager");
+    expect(authorKind("xuTJYLUa")).toBe("node");
+    expect(authorLabel("user")).toBe("you");
+    expect(authorLabel("xuTJYLUa")).toBe("xuTJYLUa");
+    expect(firstWords("\n  Missing early return on an empty event slice, the loop allocates.\nmore", 44)).toBe(
+      "Missing early return on an empty event slice…",
+    );
+    expect(firstWords("short")).toBe("short");
+  });
+
+  it("describes the footer: awaiting → replied → proposed → resolved → reopened / declined", () => {
+    expect(footerStatus(sent())).toEqual({ kind: "awaiting" });
+    expect(footerStatus(replied())).toEqual({ kind: "replied", author: "manager", at: "2026-09-09T10:05:00Z" });
+    expect(footerStatus(proposed())).toEqual({ kind: "proposed", author: "xuTJYLUa", at: "2026-09-09T10:06:00Z" });
+    expect(footerStatus(resolved())).toEqual({ kind: "resolved", by: "user", at: "2026-09-09T10:07:00Z" });
+    // Reopened after the last reply → reopened; declined proposal → declined.
+    expect(footerStatus(replied({ reopened_by: "user", reopened_at: "2026-09-09T10:08:00Z" }))).toEqual({
+      kind: "reopened",
+      by: "user",
+      at: "2026-09-09T10:08:00Z",
+    });
+    expect(
+      footerStatus(replied({ reopened_by: "user", reopened_at: "2026-09-09T10:08:00Z", proposal_declined: true })),
+    ).toEqual({ kind: "declined", by: "user", at: "2026-09-09T10:08:00Z" });
+    // A reply after the reopen wins.
+    expect(
+      footerStatus(
+        replied({
+          reopened_at: "2026-09-09T10:04:00Z",
+          reopened_by: "user",
+        }),
+      ).kind,
+    ).toBe("replied");
+  });
+
+  it("tracks unread replies per browser and counts the Diff tab badge", () => {
+    const store = new Map<string, string>();
+    const storage = {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => void store.set(k, v),
+      removeItem: (k: string) => void store.delete(k),
+    };
+    expect(readSeen("r1", storage)).toEqual({});
+    const comments = [replied(), proposed(), resolved({ replies: [{ author: "manager", text: "x", at: "t" }] })];
+    // Nothing seen: both open comments with replies count; the resolved one does not.
+    expect(unreadReplies(comments[0], {})).toBe(1);
+    expect(unreadCommentCount(comments, {})).toBe(2);
+    // Opening the Review: everything seen.
+    const seen = allSeen(comments);
+    writeSeen("r1", seen, storage);
+    expect(readSeen("r1", storage)).toEqual({ "rc-002": 1, "rc-003": 1, "rc-004": 1 });
+    expect(unreadCommentCount(comments, seen)).toBe(0);
+    // A second reply lands: one unread again, cleared per card.
+    const grown = replied({ replies: [...replied().replies!, { author: "manager", text: "again", at: "t2" }] });
+    expect(unreadReplies(grown, seen)).toBe(1);
+    expect(unreadCommentCount([grown], seen)).toBe(1);
+    const after = markSeen(seen, grown);
+    expect(unreadReplies(grown, after)).toBe(0);
+    expect(markSeen(after, grown)).toBe(after);
+    // Garbage in storage reads as nothing seen.
+    storage.setItem("pdo.review.seen.r1", "[1,2]");
+    expect(readSeen("r1", storage)).toEqual({});
+    writeSeen("r1", {}, storage);
+    expect(storage.getItem("pdo.review.seen.r1")).toBeNull();
   });
 });

--- a/frontend/src/lib/reviewComments.ts
+++ b/frontend/src/lib/reviewComments.ts
@@ -226,9 +226,172 @@ export function relativeTime(iso: string, now = new Date()): string {
   return new Date(t).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
 }
 
-/** Pending for the Diff tab badge (CONTEXT.md « Accès rapide Review »): sent, not resolved. */
+/** Pending for the Review quick access (CONTEXT.md « Accès rapide Review »): sent, not resolved. */
 export function pendingCount(comments: ReviewComment[] | undefined): number {
   return (comments ?? []).filter((c) => c.status !== "resolved").length;
+}
+
+// ---------------------------------------------------------------------------
+// #751 — the conversation: states, authors, footer status, unread replies.
+// ---------------------------------------------------------------------------
+
+/** The three states a sent comment reads as: open (blue), proposed (amber), resolved (green). */
+export type CommentState = "open" | "proposed" | "resolved";
+
+export function commentState(c: ReviewComment): CommentState {
+  if (c.status === "resolved") return "resolved";
+  return c.proposal_pending ? "proposed" : "open";
+}
+
+/** Sidebar / `c`-cycle order: what needs a decision first, resolved last. */
+export function stateRank(state: CommentState): number {
+  return state === "proposed" ? 0 : state === "open" ? 1 : 2;
+}
+
+export interface StateCounts {
+  open: number;
+  proposed: number;
+  resolved: number;
+}
+
+export function stateCounts(comments: Iterable<ReviewComment>): StateCounts {
+  const n: StateCounts = { open: 0, proposed: 0, resolved: 0 };
+  for (const c of comments) n[commentState(c)] += 1;
+  return n;
+}
+
+/** Per-file state counts for the sidebar rows and the file headers. */
+export function stateCountsByPath(entries: ReviewEntry[]): Map<string, StateCounts> {
+  const m = new Map<string, StateCounts>();
+  for (const e of entries) {
+    if (e.kind !== "sent") continue;
+    const c = m.get(e.anchor.path) ?? { open: 0, proposed: 0, resolved: 0 };
+    c[commentState(e.comment)] += 1;
+    m.set(e.anchor.path, c);
+  }
+  return m;
+}
+
+/**
+ * The sidebar's Comments order: drafts first (the reader's own pending work),
+ * then proposed → open → resolved, each group in diff order.
+ */
+export function sortForSidebar(entries: ReviewEntry[]): ReviewEntry[] {
+  const rank = (e: ReviewEntry) => (e.kind === "draft" ? -1 : stateRank(commentState(e.comment)));
+  return entries
+    .map((e, i) => ({ e, i }))
+    .sort((a, b) => rank(a.e) - rank(b.e) || a.i - b.i)
+    .map(({ e }) => e);
+}
+
+/** Who an author string is: the human (`user`), the manager, or a node of the Run. */
+export type AuthorKind = "user" | "manager" | "node";
+
+export function authorKind(author: string): AuthorKind {
+  if (author === "user" || author === "you") return "user";
+  if (author === "manager" || author === "agent") return "manager";
+  return "node";
+}
+
+/** `you` / `manager` / the node id — the tooltip text next to an author icon. */
+export function authorLabel(author: string): string {
+  const k = authorKind(author);
+  return k === "user" ? "you" : k === "manager" ? "manager" : author;
+}
+
+/** First line, truncated with an ellipsis — the collapsed resolved card's summary. */
+export function firstWords(text: string, max = 44): string {
+  const line = text.split("\n").find((l) => l.trim().length > 0)?.trim() ?? "";
+  return line.length > max ? `${line.slice(0, max).trimEnd()}…` : line;
+}
+
+/** What the sent card's footer says, right of the id and the pair. */
+export type FooterStatus =
+  | { kind: "awaiting" }
+  | { kind: "replied"; author: string; at: string }
+  | { kind: "proposed"; author: string; at: string }
+  | { kind: "resolved"; by: string; at: string }
+  | { kind: "reopened"; by: string; at: string }
+  | { kind: "declined"; by: string; at: string };
+
+export function footerStatus(c: ReviewComment): FooterStatus {
+  const replies = c.replies ?? [];
+  const last = replies[replies.length - 1];
+  if (c.status === "resolved") return { kind: "resolved", by: c.resolved_by ?? "user", at: c.resolved_at ?? last?.at ?? c.sent_at };
+  if (c.proposal_pending) {
+    const proposing = [...replies].reverse().find((r) => r.proposes_resolution) ?? last;
+    return { kind: "proposed", author: proposing?.author ?? "agent", at: proposing?.at ?? c.sent_at };
+  }
+  if (c.reopened_at && (!last || c.reopened_at >= last.at)) {
+    return { kind: c.proposal_declined ? "declined" : "reopened", by: c.reopened_by ?? "user", at: c.reopened_at };
+  }
+  if (last) return { kind: "replied", author: last.author, at: last.at };
+  return { kind: "awaiting" };
+}
+
+// --- Unread replies: a per-browser "seen" marker, never a Run event -----------
+
+export const SEEN_KEY_PREFIX = "pdo.review.seen.";
+
+/** Comment id → number of replies this browser has seen. */
+export type SeenMap = Record<string, number>;
+
+export function seenKey(runId: string): string {
+  return `${SEEN_KEY_PREFIX}${runId}`;
+}
+
+export function readSeen(runId: string, storage: Pick<Storage, "getItem"> = localStorage): SeenMap {
+  try {
+    const raw = storage.getItem(seenKey(runId));
+    if (!raw) return {};
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+    const out: SeenMap = {};
+    for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+      if (typeof v === "number" && Number.isFinite(v)) out[k] = v;
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+export function writeSeen(runId: string, seen: SeenMap, storage: Pick<Storage, "setItem" | "removeItem"> = localStorage): void {
+  try {
+    if (Object.keys(seen).length === 0) storage.removeItem(seenKey(runId));
+    else storage.setItem(seenKey(runId), JSON.stringify(seen));
+  } catch {
+    // Private mode / quota: unread stays in memory for the session.
+  }
+}
+
+/** How many replies of `c` this browser has not seen. */
+export function unreadReplies(c: ReviewComment, seen: SeenMap): number {
+  return Math.max(0, (c.replies?.length ?? 0) - (seen[c.id] ?? 0));
+}
+
+/**
+ * The Diff tab badge (CONTEXT.md « Réponse de review »): **sent** comments with at
+ * least one unread reply. A comment the agent resolved directly is not counted
+ * — nothing waits on the human there — but its replies still read as new on the
+ * card until seen.
+ */
+export function unreadCommentCount(comments: ReviewComment[] | undefined, seen: SeenMap): number {
+  return (comments ?? []).filter((c) => c.status === "sent" && unreadReplies(c, seen) > 0).length;
+}
+
+/** Everything seen — what opening the Review page writes. */
+export function allSeen(comments: ReviewComment[] | undefined, prev: SeenMap = {}): SeenMap {
+  const next: SeenMap = { ...prev };
+  for (const c of comments ?? []) next[c.id] = Math.max(next[c.id] ?? 0, c.replies?.length ?? 0);
+  return next;
+}
+
+/** One card seen (scrolled into view / hovered / acted on). */
+export function markSeen(seen: SeenMap, c: ReviewComment): SeenMap {
+  const n = c.replies?.length ?? 0;
+  if ((seen[c.id] ?? 0) >= n) return seen;
+  return { ...seen, [c.id]: n };
 }
 
 /** `2 drafts` / `1 draft` — pluralised counter. */

--- a/frontend/src/pages/ReviewPage.test.tsx
+++ b/frontend/src/pages/ReviewPage.test.tsx
@@ -13,10 +13,24 @@ vi.mock("../api", () => ({
   fetchRunStructuredDiff: vi.fn(),
   fetchRunFileAtRef: vi.fn(),
   sendReviewComments: vi.fn(),
+  resolveReviewComment: vi.fn(),
+  reopenReviewComment: vi.fn(),
 }));
 
+// The socket mock hands the test the subscriber, so a `review_comment_replied`
+// push can be simulated (#751).
+const socketSubscribers: ((msg: unknown) => void)[] = [];
 vi.mock("../hooks/useDaemonSocket", () => ({
-  useDaemonSocket: () => ({ status: "connected", subscribe: () => () => {} }),
+  useDaemonSocket: () => ({
+    status: "connected",
+    subscribe: (fn: (msg: unknown) => void) => {
+      socketSubscribers.push(fn);
+      return () => {
+        const i = socketSubscribers.indexOf(fn);
+        if (i >= 0) socketSubscribers.splice(i, 1);
+      };
+    },
+  }),
 }));
 
 // The body mock exposes the two seams #750 plugs into: a `+` per side/line that
@@ -67,13 +81,23 @@ vi.mock("@git-diff-view/react", async () => {
   return { DiffModeEnum: { Split: "split", Unified: "unified" }, SplitSide, DiffView };
 });
 
-import { fetchRun, fetchRunRefs, fetchRunStructuredDiff, fetchRunFileAtRef, sendReviewComments } from "../api";
+import {
+  fetchRun,
+  fetchRunRefs,
+  fetchRunStructuredDiff,
+  fetchRunFileAtRef,
+  sendReviewComments,
+  resolveReviewComment,
+  reopenReviewComment,
+} from "../api";
 
 const mockedRun = vi.mocked(fetchRun);
 const mockedRefs = vi.mocked(fetchRunRefs);
 const mockedDiff = vi.mocked(fetchRunStructuredDiff);
 const mockedFile = vi.mocked(fetchRunFileAtRef);
 const mockedSend = vi.mocked(sendReviewComments);
+const mockedResolve = vi.mocked(resolveReviewComment);
+const mockedReopen = vi.mocked(reopenReviewComment);
 
 const RUN_ID = "20260909-125942-c7e2c65";
 
@@ -162,6 +186,7 @@ function goto(search = "") {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  socketSubscribers.length = 0;
   localStorage.clear();
   sessionStorage.clear();
   mockedRun.mockResolvedValue(makeRun());
@@ -479,7 +504,10 @@ describe("ReviewPage — review comments (#750)", () => {
     expect(screen.getByTestId("review-toast")).toHaveTextContent("2 comments sent as one message — manager started");
     expect(localStorage.getItem(`pdo.review.drafts.${RUN_ID}`)).toBeNull();
     expect(screen.queryByTestId("review-send-bar")).toBeNull();
-    expect(screen.getByTestId("review-comments-pill")).toHaveTextContent("2 sent");
+    // #751: the header counts by state — two open, nothing proposed / resolved.
+    expect(screen.getByTestId("review-comments-pill")).toHaveTextContent("2");
+    expect(screen.queryByTestId("review-proposed-pill")).toBeNull();
+    expect(screen.queryByTestId("review-resolved-pill")).toBeNull();
     // Sent card: id, pair, lock, no edit/delete.
     const first = screen.getAllByTestId("review-comment").find((c) => c.dataset.commentId === "rc-001")!;
     expect(within(first).getByTestId("review-comment-id")).toHaveTextContent("rc-001");
@@ -534,7 +562,7 @@ describe("ReviewPage — review comments (#750)", () => {
     expect(rows).toHaveLength(2);
     expect(rows[1]).toHaveAttribute("data-other-pair", "true");
     expect(rows[1]).toHaveTextContent("at implement · iter 1 · before → implement · iter 1 · after");
-    expect(screen.getByTestId("review-comments-pill")).toHaveTextContent("1 sent");
+    expect(screen.getByTestId("review-comments-pill")).toHaveTextContent("1");
   });
 
   it("disables every send gesture with the reason when the Run branch is gone", async () => {
@@ -554,5 +582,172 @@ describe("ReviewPage — review comments (#750)", () => {
     expect(screen.getByTestId("review-send-pill")).toBeDisabled();
     expect(screen.getByTestId("review-send-bar-note")).toHaveTextContent("no longer exists");
     expect(mockedSend).not.toHaveBeenCalled();
+  });
+});
+
+// --- #751: the conversation ---------------------------------------------------
+
+const REPLY_MANAGER = { author: "manager", text: "Done: renamed it (commit `7f2b0d1`).", at: "2026-09-09T00:40:00Z" };
+const REPLY_NODE_PROPOSES = { author: "xuTJYLUa", text: "Handled, test added.", at: "2026-09-09T00:41:00Z", proposes_resolution: true };
+
+function pushEvent(kind: string) {
+  for (const fn of [...socketSubscribers]) fn({ type: "event", event: { run_id: RUN_ID, kind, ts: "2026-09-09T00:45:00Z" } });
+}
+
+describe("ReviewPage — review conversation (#751)", () => {
+  it("shows a reply inline with its author, an unread dot and the bell; opening marks everything seen for the Diff badge", async () => {
+    const c = sentComment({ replies: [REPLY_MANAGER] });
+    mockedRun.mockResolvedValue(makeRun({ review_comments: [c] }));
+    render(<ReviewPage runId={RUN_ID} />);
+    const card = await screen.findByTestId("review-comment");
+    expect(card).toHaveAttribute("data-review-state", "open");
+    expect(card).toHaveAttribute("data-unread", "1");
+    const reply = within(card).getByTestId("review-reply");
+    expect(reply).toHaveAttribute("data-author", "manager");
+    expect(reply).toHaveAttribute("data-unread", "true");
+    expect(within(reply).getByTestId("review-reply-body").querySelector("code")).toHaveTextContent("7f2b0d1");
+    expect(within(card).getByTestId("review-comment-status")).toHaveAttribute("data-kind", "replied");
+    // A plain reply: the human can still resolve; no Reopen.
+    expect(within(card).getByTestId("review-comment-resolve")).toBeInTheDocument();
+    expect(within(card).queryByTestId("review-comment-reopen")).toBeNull();
+    // Opening the Review wrote "seen" for this browser — the Diff tab badge reads 0 now.
+    await waitFor(() => expect(JSON.parse(localStorage.getItem(`pdo.review.seen.${RUN_ID}`)!)).toEqual({ "rc-001": 1 }));
+    // The bell counts the unread card; clicking it marks the card seen.
+    expect(screen.getByTestId("review-unread-pill")).toHaveTextContent("1");
+    fireEvent.click(screen.getByTestId("review-unread-pill"));
+    await waitFor(() => expect(screen.queryByTestId("review-unread-pill")).toBeNull());
+    expect(screen.getByTestId("review-comment")).not.toHaveAttribute("data-unread");
+    expect(within(screen.getByTestId("review-comment")).queryByTestId("review-reply-unread")).toBeNull();
+  });
+
+  it("a reply landing over the WebSocket appears live, flashes the card and re-arms the bell", async () => {
+    mockedRun.mockResolvedValue(makeRun({ review_comments: [sentComment()] }));
+    render(<ReviewPage runId={RUN_ID} />);
+    const card = await screen.findByTestId("review-comment");
+    expect(within(card).getByTestId("review-comment-status")).toHaveAttribute("data-kind", "awaiting");
+    expect(screen.queryByTestId("review-unread-pill")).toBeNull();
+    mockedRun.mockResolvedValue(makeRun({ review_comments: [sentComment({ replies: [REPLY_MANAGER] })] }));
+    pushEvent("review_comment_replied");
+    await waitFor(() => expect(screen.getByTestId("review-reply")).toBeInTheDocument());
+    expect(screen.getByTestId("review-comment").className).toContain("pdo-review-flash");
+    expect(screen.getByTestId("review-reply")).toHaveAttribute("data-unread", "true");
+    expect(screen.getByTestId("review-unread-pill")).toHaveTextContent("1");
+    // Hovering the card is enough to mark it seen.
+    fireEvent.mouseEnter(screen.getByTestId("review-comment"));
+    await waitFor(() => expect(screen.queryByTestId("review-unread-pill")).toBeNull());
+  });
+
+  it("a proposal shows Resolve / Reopen; Resolve collapses the card to one line with Reopen; the header click expands it", async () => {
+    const proposed = sentComment({ replies: [REPLY_NODE_PROPOSES], proposal_pending: true });
+    mockedRun.mockResolvedValue(makeRun({ review_comments: [proposed] }));
+    render(<ReviewPage runId={RUN_ID} />);
+    const card = await screen.findByTestId("review-comment");
+    expect(card).toHaveAttribute("data-review-state", "proposed");
+    expect(within(card).getByTestId("review-state-proposed")).toBeInTheDocument();
+    expect(within(card).getByTestId("review-reply")).toHaveAttribute("data-author", "xuTJYLUa");
+    expect(within(card).getByTestId("review-reply")).toHaveTextContent("xuTJYLUa");
+    expect(within(card).getByTestId("review-reply-proposes")).toBeInTheDocument();
+    expect(within(card).getByTestId("review-comment-status")).toHaveAttribute("data-kind", "proposed");
+    expect(within(card).getByTestId("review-comment-reopen")).toHaveAttribute("title", expect.stringContaining("Decline the proposal"));
+    // Header + sidebar: 1 proposed, "needs you".
+    expect(screen.getByTestId("review-proposed-pill")).toHaveTextContent("1");
+    expect(screen.queryByTestId("review-comments-pill")).toBeNull();
+    expect(screen.getByTestId("review-needs-you")).toHaveTextContent("1");
+    expect(screen.getAllByTestId("review-file")[0]).toHaveAttribute("data-proposed", "1");
+
+    const resolved = sentComment({ ...proposed, status: "resolved", proposal_pending: false, resolved_by: "user", resolved_at: "2026-09-09T00:50:00Z" });
+    mockedResolve.mockResolvedValue({ comment: resolved, changed: true });
+    mockedRun.mockResolvedValue(makeRun({ review_comments: [resolved] }));
+    fireEvent.click(within(card).getByTestId("review-comment-resolve"));
+    await waitFor(() => expect(mockedResolve).toHaveBeenCalledWith(RUN_ID, "rc-001"));
+    await waitFor(() => expect(screen.getByTestId("review-comment")).toHaveAttribute("data-review-state", "resolved"));
+    const done = screen.getByTestId("review-comment");
+    expect(done).toHaveAttribute("data-collapsed", "true");
+    expect(within(done).getByTestId("review-comment-summary")).toHaveTextContent("“Sent remark”");
+    expect(within(done).getByTestId("review-comment-summary")).toHaveTextContent("1");
+    expect(within(done).getByTestId("review-comment-resolved-by")).toHaveAttribute("title", "Resolved by you");
+    expect(within(done).queryByTestId("review-comment-body")).toBeNull();
+    expect(screen.getByTestId("review-toast")).toHaveTextContent("rc-001 resolved");
+    expect(screen.getByTestId("review-resolved-pill")).toHaveTextContent("1");
+    expect(screen.queryByTestId("review-proposed-pill")).toBeNull();
+    // Expand: body, thread and the Reopen footer come back.
+    fireEvent.click(within(done).getByTestId("review-comment-header"));
+    expect(done).not.toHaveAttribute("data-collapsed");
+    expect(within(done).getByTestId("review-comment-body")).toBeInTheDocument();
+    expect(within(done).getByTestId("review-comment-status")).toHaveAttribute("data-kind", "resolved");
+    expect(within(done).getByTestId("review-comment-reopen")).toBeInTheDocument();
+    expect(within(done).queryByTestId("review-comment-resolve")).toBeNull();
+
+    // Reopen → back to sent, footer "Reopened by you".
+    const reopened = sentComment({ ...proposed, proposal_pending: false, reopened_by: "user", reopened_at: "2026-09-09T00:55:00Z" });
+    mockedReopen.mockResolvedValue({ comment: reopened, changed: true });
+    mockedRun.mockResolvedValue(makeRun({ review_comments: [reopened] }));
+    fireEvent.click(within(done).getByTestId("review-comment-reopen"));
+    await waitFor(() => expect(mockedReopen).toHaveBeenCalledWith(RUN_ID, "rc-001"));
+    await waitFor(() => expect(screen.getByTestId("review-comment")).toHaveAttribute("data-review-state", "open"));
+    expect(within(screen.getByTestId("review-comment")).getByTestId("review-comment-status")).toHaveAttribute("data-kind", "reopened");
+    expect(screen.getByTestId("review-toast")).toHaveTextContent("reopened");
+  });
+
+  it("Reopen on a proposal declines it: the comment stays open for the agent", async () => {
+    const proposed = sentComment({ replies: [REPLY_NODE_PROPOSES], proposal_pending: true });
+    mockedRun.mockResolvedValue(makeRun({ review_comments: [proposed] }));
+    render(<ReviewPage runId={RUN_ID} />);
+    const card = await screen.findByTestId("review-comment");
+    const declined = sentComment({ ...proposed, proposal_pending: false, proposal_declined: true, reopened_by: "user", reopened_at: "2026-09-09T00:55:00Z" });
+    mockedReopen.mockResolvedValue({ comment: declined, changed: true });
+    mockedRun.mockResolvedValue(makeRun({ review_comments: [declined] }));
+    fireEvent.click(within(card).getByTestId("review-comment-reopen"));
+    await waitFor(() => expect(screen.getByTestId("review-comment")).toHaveAttribute("data-review-state", "open"));
+    const status = within(screen.getByTestId("review-comment")).getByTestId("review-comment-status");
+    expect(status).toHaveAttribute("data-kind", "declined");
+    expect(status.querySelector("[title]")).toHaveAttribute("title", expect.stringContaining("Proposal declined by you"));
+    expect(screen.getByTestId("review-toast")).toHaveTextContent("proposal declined");
+    expect(screen.getByTestId("review-comments-pill")).toHaveTextContent("1");
+  });
+
+  it("agent-resolved comments read « Resolved by <node> », the eye toggle hides resolved cards, and the sidebar sorts proposed → open → resolved", async () => {
+    const byAgent = sentComment({
+      id: "rc-001",
+      line: 1,
+      status: "resolved",
+      resolved_by: "xuTJYLUa",
+      resolved_at: "2026-09-09T00:50:00Z",
+      replies: [REPLY_NODE_PROPOSES],
+    });
+    const open = sentComment({ id: "rc-002", line: 2, text: "open one" });
+    const proposed = sentComment({ id: "rc-003", line: 3, side: "old", text: "proposed one", replies: [REPLY_NODE_PROPOSES], proposal_pending: true });
+    mockedRun.mockResolvedValue(makeRun({ review_comments: [byAgent, open, proposed] }));
+    render(<ReviewPage runId={RUN_ID} />);
+    await waitFor(() => expect(screen.getAllByTestId("review-comment")).toHaveLength(3));
+    const agentCard = screen.getAllByTestId("review-comment").find((c) => c.dataset.commentId === "rc-001")!;
+    expect(agentCard).toHaveAttribute("data-collapsed", "true");
+    expect(within(agentCard).getByTestId("review-comment-resolved-by")).toHaveAttribute("title", "Resolved by xuTJYLUa");
+    // Not counted as unread-needing-action: the bell counts the proposed one only.
+    expect(screen.getByTestId("review-unread-pill")).toHaveTextContent("1");
+    // Sidebar order and dimming.
+    const rows = screen.getAllByTestId("review-comment-row");
+    expect(rows.map((r) => r.dataset.reviewState)).toEqual(["proposed", "open", "resolved"]);
+    expect(rows[2].className).toContain("opacity-55");
+    expect(screen.getByTestId("review-comments-count")).toHaveTextContent("0 drafts · 3 sent");
+    // Eye toggle: the resolved card leaves the diff, the pill stays.
+    fireEvent.click(screen.getByTestId("review-toggle-resolved"));
+    await waitFor(() => expect(screen.getAllByTestId("review-comment")).toHaveLength(2));
+    expect(screen.getByTestId("review-resolved-pill")).toHaveTextContent("1");
+    expect(localStorage.getItem("pdo.review.showResolved")).toBe("false");
+    fireEvent.click(screen.getByTestId("review-toggle-resolved"));
+    await waitFor(() => expect(screen.getAllByTestId("review-comment")).toHaveLength(3));
+  });
+
+  it("reports a failed decision and keeps the card as it was", async () => {
+    const proposed = sentComment({ replies: [REPLY_NODE_PROPOSES], proposal_pending: true });
+    mockedRun.mockResolvedValue(makeRun({ review_comments: [proposed] }));
+    render(<ReviewPage runId={RUN_ID} />);
+    const card = await screen.findByTestId("review-comment");
+    mockedResolve.mockRejectedValue(new Error("daemon unreachable"));
+    fireEvent.click(within(card).getByTestId("review-comment-resolve"));
+    await waitFor(() => expect(screen.getByTestId("review-toast")).toHaveAttribute("data-error", "true"));
+    expect(screen.getByTestId("review-toast")).toHaveTextContent("Resolve failed — daemon unreachable");
+    expect(screen.getByTestId("review-comment")).toHaveAttribute("data-review-state", "proposed");
   });
 });

--- a/frontend/src/pages/ReviewPage.tsx
+++ b/frontend/src/pages/ReviewPage.tsx
@@ -3,7 +3,10 @@ import {
   ArrowLeftRight,
   ArrowLeft,
   Archive,
+  Bell,
   Columns2,
+  Eye,
+  EyeOff,
   ListMinus,
   MessageSquare,
   PanelLeftOpen,
@@ -11,28 +14,44 @@ import {
   SquareArrowOutUpRight,
 } from "lucide-react";
 import "@git-diff-view/react/styles/diff-view.css";
-import { fetchRun, fetchRunRefs, fetchRunStructuredDiff, sendReviewComments } from "../api";
+import {
+  fetchRun,
+  fetchRunRefs,
+  fetchRunStructuredDiff,
+  reopenReviewComment,
+  resolveReviewComment,
+  sendReviewComments,
+} from "../api";
 import { useDaemonSocket } from "../hooks/useDaemonSocket";
-import type { RunRefs, RunState, StructuredDiff } from "../types";
+import type { ReviewComment, RunRefs, RunState, StructuredDiff } from "../types";
 import RefPicker from "../components/review/RefPicker";
 import ReviewFileList from "../components/review/ReviewFileList";
 import ReviewFileCard from "../components/review/ReviewFileCard";
 import type { ReviewCommentsApi } from "../components/review/ReviewFileCard";
 import ReviewSendBar from "../components/review/ReviewSendBar";
+import { StateIcon } from "../components/review/CommentCard";
 import {
   addDraft,
+  allSeen,
+  authorLabel,
   countsByPath,
   draftsForPair,
+  markSeen as markSeenIn,
   mergeEntries,
   plural,
   readDrafts,
+  readSeen,
   removeDrafts,
   sendDisabledReason as sendReasonOf,
+  stateCounts,
+  stateCountsByPath,
   toSendInputs,
+  unreadReplies,
   updateDraft,
   writeDrafts,
+  writeSeen,
 } from "../lib/reviewComments";
-import type { Anchor, ReviewDraft, ReviewEntry } from "../lib/reviewComments";
+import type { Anchor, ReviewDraft, ReviewEntry, SeenMap } from "../lib/reviewComments";
 import {
   DEFAULT_FROM,
   DEFAULT_TO,
@@ -71,7 +90,23 @@ import type { RefPair, ViewMode } from "../lib/runRefs";
  * back as immutable Run events (`review_comments` in the projected state,
  * refreshed over the WebSocket). A Run whose branch is gone shows why sending
  * is disabled instead of a dead button.
+ *
+ * The conversation (#751, ADR-0067 §4): an agent's `pdo review reply` lands as
+ * a `review_comment_replied` event, pushed live — the reply appears inline
+ * under its comment, the card flashes, the reply carries a blue dot until the
+ * card is seen; when it is off-screen a blue bell pill in the header jumps to
+ * it. A `--resolved` reply is a **resolution proposed** (amber) the human
+ * settles with Resolve / Reopen; a resolved comment collapses (green) and keeps
+ * Reopen. The header counts open / proposed / resolved (icon + count, only when
+ * non-zero) and an eye toggle hides resolved cards; `c` / `C` skip them.
+ * Opening this page marks every reply seen for this browser (localStorage) —
+ * that is what clears the Diff tab's unread badge; the per-card dots clear as
+ * each card is looked at.
  */
+
+const SHOW_RESOLVED_KEY = "pdo.review.showResolved";
+/** How long a card keeps its outline flash after a live reply. */
+const FLASH_MS = 2400;
 
 interface Props {
   runId: string;
@@ -112,6 +147,20 @@ export default function ReviewPage({ runId }: Props) {
   const [toast, setToast] = useState<{ text: string; error?: boolean } | null>(null);
   const [commentCursor, setCommentCursor] = useState(-1);
   const toastTimer = useRef<number | undefined>(undefined);
+  // --- The conversation (#751) ----------------------------------------------------
+  /** What this browser had seen BEFORE this page opened — the unread dots read against it. */
+  const [seen, setSeen] = useState<SeenMap>(() => readSeen(runId));
+  const [showResolved, setShowResolved] = useState<boolean>(() => {
+    try {
+      return localStorage.getItem(SHOW_RESOLVED_KEY) !== "false";
+    } catch {
+      return true;
+    }
+  });
+  const [deciding, setDeciding] = useState<ReadonlySet<string>>(() => new Set());
+  const [flashing, setFlashing] = useState<ReadonlySet<string>>(() => new Set());
+  const flashTimers = useRef<Map<string, number>>(new Map());
+  const openedSeenWritten = useRef(false);
 
   const mainRef = useRef<HTMLDivElement | null>(null);
   const filterRef = useRef<HTMLInputElement | null>(null);
@@ -156,6 +205,20 @@ export default function ReviewPage({ runId }: Props) {
   useEffect(() => {
     if (run) document.title = `Review · ${run.pipeline_name} · ${runId}`;
   }, [run, runId]);
+
+  // Opening the Review clears the Diff tab's unread badge (spec): every reply of
+  // the Run counts as seen for this browser from now on. The `seen` snapshot the
+  // dots read against stays what it was at open, so the page still points at
+  // what is new.
+  useEffect(() => {
+    if (!run || openedSeenWritten.current) return;
+    openedSeenWritten.current = true;
+    writeSeen(runId, allSeen(run.review_comments, readSeen(runId)));
+  }, [run, runId]);
+  useEffect(() => {
+    const timers = flashTimers.current;
+    return () => timers.forEach((t) => window.clearTimeout(t));
+  }, []);
 
   // Validate the URL pair once the refs are known; a bad ref falls back with a notice.
   const reconciledFor = useRef<RunRefs | null>(null);
@@ -209,10 +272,33 @@ export default function ReviewPage({ runId }: Props) {
       const ev = msg.event;
       fetchRun(runId)
         .then((r) => {
+          const before = runRef.current;
           runRef.current = r;
           setRun(r);
           const sig = deliverySignature(r.nodes);
           if (sigAtLoad.current !== null && sig !== sigAtLoad.current) setTipMoved(true);
+          // #751: a reply landed live — flash its card for a moment. The dot
+          // follows from `seen` (the snapshot does not know this reply).
+          if (before) {
+            const prevReplies = new Map((before.review_comments ?? []).map((c) => [c.id, c.replies?.length ?? 0]));
+            const grown = (r.review_comments ?? []).filter((c) => (c.replies?.length ?? 0) > (prevReplies.get(c.id) ?? 0));
+            if (grown.length > 0) {
+              setFlashing((f) => new Set([...f, ...grown.map((c) => c.id)]));
+              for (const c of grown) {
+                window.clearTimeout(flashTimers.current.get(c.id));
+                flashTimers.current.set(
+                  c.id,
+                  window.setTimeout(() => {
+                    setFlashing((f) => {
+                      const next = new Set(f);
+                      next.delete(c.id);
+                      return next;
+                    });
+                  }, FLASH_MS),
+                );
+              }
+            }
+          }
         })
         .catch(() => {});
       if (ev.kind === "node_delivered" && ev.node_id && pairRef.current.to === `live:${ev.node_id}`) {
@@ -351,8 +437,25 @@ export default function ReviewPage({ runId }: Props) {
     return m;
   }, [entries]);
   const counts = useMemo(() => countsByPath(entries), [entries]);
+  const states = useMemo(() => stateCountsByPath(entries), [entries]);
   const pairDrafts = useMemo(() => draftsForPair(drafts, pair), [drafts, pair]);
   const sentCount = entries.length - pairDrafts.length;
+  const sentEntries = useMemo(() => entries.flatMap((e) => (e.kind === "sent" ? [e.comment] : [])), [entries]);
+  const pairStates = useMemo(() => stateCounts(sentEntries), [sentEntries]);
+  /**
+   * Open comments of this pair with replies this browser has not seen, in diff
+   * order — what the bell jumps to. A comment the agent resolved directly is
+   * left out (nothing waits on the human), like the Diff tab badge.
+   */
+  const unreadComments = useMemo(
+    () => sentEntries.filter((c) => c.status === "sent" && unreadReplies(c, seen) > 0),
+    [sentEntries, seen],
+  );
+  /** What `c` / `C` cycle through: drafts and open / proposed comments — resolved are skipped. */
+  const cycleEntries = useMemo(
+    () => entries.filter((e) => e.kind === "draft" || e.comment.status !== "resolved"),
+    [entries],
+  );
   /** Comments written against another pair: listed greyed, never lost. */
   const otherEntries = useMemo(() => {
     const label = (from: string, to: string) => {
@@ -407,12 +510,74 @@ export default function ReviewPage({ runId }: Props) {
   );
   const jumpComment = useCallback(
     (dir: 1 | -1) => {
-      if (entries.length === 0) return;
-      const next = (commentCursor + dir + entries.length) % entries.length;
+      if (cycleEntries.length === 0) return;
+      const next = (commentCursor + dir + cycleEntries.length) % cycleEntries.length;
       setCommentCursor(next);
-      jumpTo(entries[next].anchor);
+      jumpTo(cycleEntries[next].anchor);
     },
-    [entries, commentCursor, jumpTo],
+    [cycleEntries, commentCursor, jumpTo],
+  );
+
+  // --- The conversation (#751) ----------------------------------------------------
+  const markSeen = useCallback(
+    (c: ReviewComment) => {
+      setSeen((prev) => markSeenIn(prev, c));
+      // Storage too: another tab's Diff badge must not keep counting this one.
+      writeSeen(runId, markSeenIn(readSeen(runId), c));
+    },
+    [runId],
+  );
+  /** The bell: jump to the first comment with an unread reply and mark it seen. */
+  const jumpUnread = useCallback(() => {
+    const target = unreadComments[0];
+    if (!target) return;
+    jumpTo({ path: target.path, side: target.side, line: target.line });
+    markSeen(target);
+  }, [unreadComments, jumpTo, markSeen]);
+  const toggleShowResolved = () => {
+    setShowResolved((v) => {
+      try {
+        localStorage.setItem(SHOW_RESOLVED_KEY, String(!v));
+      } catch {
+        // Remembered for the session only.
+      }
+      return !v;
+    });
+  };
+  const decide = useCallback(
+    async (c: ReviewComment, verb: "resolve" | "reopen") => {
+      if (deciding.has(c.id)) return;
+      setDeciding((d) => new Set([...d, c.id]));
+      try {
+        const res = await (verb === "resolve" ? resolveReviewComment(runId, c.id) : reopenReviewComment(runId, c.id));
+        markSeen(res.comment);
+        try {
+          const r = await fetchRun(runId);
+          runRef.current = r;
+          setRun(r);
+        } catch {
+          // The WebSocket refresh lands anyway.
+        }
+        if (!res.changed) {
+          showToast(`${c.id} was already ${verb === "resolve" ? "resolved" : "open"}.`);
+        } else if (verb === "resolve") {
+          showToast(`${c.id} resolved — collapsed; Reopen stays in its footer.`);
+        } else if (c.status === "resolved") {
+          showToast(`${c.id} reopened — back to open, the agent sees it in pdo review list.`);
+        } else {
+          showToast(`${c.id}: proposal declined — the comment stays open for ${authorLabel(res.comment.replies?.at(-1)?.author ?? "agent")}.`);
+        }
+      } catch (e: unknown) {
+        showToast(`${verb === "resolve" ? "Resolve" : "Reopen"} failed — ${e instanceof Error ? e.message : String(e)}`, true);
+      } finally {
+        setDeciding((d) => {
+          const next = new Set(d);
+          next.delete(c.id);
+          return next;
+        });
+      }
+    },
+    [deciding, runId, markSeen, showToast],
   );
 
   /** Send `keys` out of `source` (defaults to the current drafts; `sendNew` passes the list it just grew). */
@@ -482,9 +647,34 @@ export default function ReviewPage({ runId }: Props) {
         showToast("Draft deleted.");
       },
       sendDraft: (key) => void send([key]),
-      sentLineClicked: () => showToast("This line already has a sent comment. Replies arrive with the next ticket.", true),
+      sentLineClicked: () =>
+        showToast("This line already has a sent comment. The agent's replies show up under it; add a new comment on another line.", true),
+      resolve: (c) => void decide(c, "resolve"),
+      reopen: (c) => void decide(c, "reopen"),
+      deciding,
+      unreadOf: (c) => unreadReplies(c, seen),
+      flashing,
+      markSeen,
+      showResolved,
     }),
-    [editingKey, sendingKeys, startingManager, pairLabel, sendDisabledReason, drafts, pair, persistDrafts, showToast, send],
+    [
+      editingKey,
+      sendingKeys,
+      startingManager,
+      pairLabel,
+      sendDisabledReason,
+      drafts,
+      pair,
+      persistDrafts,
+      showToast,
+      send,
+      decide,
+      deciding,
+      seen,
+      flashing,
+      markSeen,
+      showResolved,
+    ],
   );
 
   // --- Keyboard ---------------------------------------------------------------
@@ -710,17 +900,83 @@ export default function ReviewPage({ runId }: Props) {
             )}
           </>
         ) : (
-          <button
-            type="button"
-            onClick={() => jumpComment(1)}
-            disabled={entries.length === 0}
-            title="Jump to the next comment  ( c / C )"
-            data-testid="review-comments-pill"
-            className="flex cursor-pointer items-center gap-1 rounded border border-line-strong bg-bg-3 px-2 py-0.5 text-fg-3 hover:text-fg-2 disabled:cursor-not-allowed disabled:opacity-50"
-            style={{ fontSize: "10.5px" }}
-          >
-            <MessageSquare size={11} /> {sentCount > 0 ? `${sentCount} sent` : "0 comments"}
-          </button>
+          <>
+            {unreadComments.length > 0 && (
+              // The one filled pill: unread replies, click to jump to the first.
+              <button
+                type="button"
+                onClick={jumpUnread}
+                title={`${plural(unreadComments.length, "comment")} with an unread reply — jump to the first`}
+                data-testid="review-unread-pill"
+                className="flex cursor-pointer items-center gap-1 rounded border border-st-running bg-st-running px-2 py-0.5 font-semibold text-white hover:opacity-90"
+                style={{ fontSize: "10.5px" }}
+              >
+                <Bell size={11} /> {unreadComments.length}
+              </button>
+            )}
+            {sentCount === 0 ? (
+              <button
+                type="button"
+                onClick={() => jumpComment(1)}
+                disabled={cycleEntries.length === 0}
+                title="Jump to the next comment  ( c / C )"
+                data-testid="review-comments-pill"
+                className="flex cursor-pointer items-center gap-1 rounded border border-line-strong bg-bg-3 px-2 py-0.5 text-fg-3 hover:text-fg-2 disabled:cursor-not-allowed disabled:opacity-50"
+                style={{ fontSize: "10.5px" }}
+              >
+                <MessageSquare size={11} /> 0 comments
+              </button>
+            ) : (
+              <span className="flex items-center gap-1" data-testid="review-state-pills">
+                {pairStates.open > 0 && (
+                  <button
+                    type="button"
+                    onClick={() => jumpComment(1)}
+                    title={`${plural(pairStates.open, "open comment")} — jump to the next  ( c / C )`}
+                    data-testid="review-comments-pill"
+                    className="flex cursor-pointer items-center gap-1 rounded border border-line-strong bg-bg-3 px-2 py-0.5 text-fg-3 hover:text-fg-2"
+                    style={{ fontSize: "10.5px" }}
+                  >
+                    <StateIcon state="open" size={11} /> {pairStates.open}
+                  </button>
+                )}
+                {pairStates.proposed > 0 && (
+                  <button
+                    type="button"
+                    onClick={() => jumpComment(1)}
+                    title={`${pairStates.proposed} resolution${pairStates.proposed === 1 ? "" : "s"} proposed — your call`}
+                    data-testid="review-proposed-pill"
+                    className="flex cursor-pointer items-center gap-1 rounded border border-line-strong bg-bg-3 px-2 py-0.5 text-fg-3 hover:text-fg-2"
+                    style={{ fontSize: "10.5px" }}
+                  >
+                    <StateIcon state="proposed" size={11} /> {pairStates.proposed}
+                  </button>
+                )}
+                {pairStates.resolved > 0 && (
+                  <span
+                    title={`${pairStates.resolved} resolved (skipped by c / C)`}
+                    data-testid="review-resolved-pill"
+                    className="flex items-center gap-1 rounded border border-line-strong bg-bg-3 px-2 py-0.5 text-fg-3"
+                    style={{ fontSize: "10.5px" }}
+                  >
+                    <StateIcon state="resolved" size={11} /> {pairStates.resolved}
+                  </span>
+                )}
+                <button
+                  type="button"
+                  onClick={toggleShowResolved}
+                  aria-pressed={!showResolved}
+                  title={showResolved ? "Hide resolved comments" : "Show resolved comments"}
+                  data-testid="review-toggle-resolved"
+                  className={`grid h-5 w-[22px] cursor-pointer place-items-center rounded border border-line-strong ${
+                    showResolved ? "bg-bg-3 text-fg-3 hover:text-fg-2" : "bg-bg-4 text-fg"
+                  }`}
+                >
+                  {showResolved ? <Eye size={11} /> : <EyeOff size={11} />}
+                </button>
+              </span>
+            )}
+          </>
         )}
         <a
           href={reviewUrl(runId, pair)}
@@ -746,6 +1002,7 @@ export default function ReviewPage({ runId }: Props) {
             onSelect={goFile}
             onClose={toggleList}
             counts={counts}
+            stateCounts={states}
             comments={{ current: entries, other: otherEntries.map(({ entry, pair: p }) => ({ entry, pair: p })) }}
             onJumpEntry={(e) => jumpTo(e.anchor)}
             onJumpOther={(e) => {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -317,6 +317,13 @@ export interface InstanceSettings {
    */
   update_check: BoolSettingField;
   /**
+   * #751 (ADR-0067 §4): may an agent's `pdo review reply --resolved` resolve the
+   * review comment directly? **Off by default**: the reply is a *proposal* and the
+   * human clicks Resolve / Reopen. On, the comment resolves on the spot and the
+   * human keeps Reopen. Instance-wide, `stored → env → default` like auto-name.
+   */
+  review_agent_can_resolve: BoolSettingField;
+  /**
    * Manager on demand: does every new Run automatically spawn its Pipeline
    * Manager session? **Off by default** — a Run starts managerless and the user
    * starts one from the Manager tab when they want it. Gates ONLY the automatic
@@ -491,6 +498,9 @@ export interface UpdateSettingsRequest {
   /** Version check switch (#697). Same plain-bool discipline: `false` persists as a
    *  stored `0` that beats a `PDO_UPDATE_CHECK=1`. */
   update_check?: boolean;
+  /** #751: let agents resolve review comments directly. Same plain-bool discipline:
+   *  `false` persists as a stored `0` that beats a `PDO_REVIEW_AGENT_CAN_RESOLVE=1`. */
+  review_agent_can_resolve?: boolean;
   /** Manager on demand: auto-spawn the manager with each Run. Same plain-bool
    *  discipline: `false` persists as a stored `0` that beats a
    *  `PDO_MANAGER_ENABLED=1`. */
@@ -2026,11 +2036,12 @@ export interface RunRefs {
 export type ReviewSide = "old" | "new";
 export type ReviewCommentStatus = "sent" | "resolved";
 
-/** An agent's reply (#751 emits them; the shape is fixed here). */
+/** An agent's reply (#751, `pdo review reply`): `manager` or a node id as author. */
 export interface ReviewReply {
   author: string;
   text: string;
   at: string;
+  /** The reply carried `--resolved`: a proposal, or a direct resolution under the setting. */
   proposes_resolution?: boolean;
 }
 
@@ -2053,6 +2064,23 @@ export interface ReviewComment {
   batch_id?: string;
   status: ReviewCommentStatus;
   replies?: ReviewReply[];
+  /** #751: a `--resolved` reply awaits the human (setting off) — "Resolution proposed". */
+  proposal_pending?: boolean;
+  /** `user`, `manager` or a node id; set while `resolved`. */
+  resolved_by?: string;
+  resolved_at?: string;
+  /** The last reopen (a resolved comment reopened, or a proposal declined). */
+  reopened_by?: string;
+  reopened_at?: string;
+  /** The last reopen declined a pending proposal (the comment stayed `sent`). */
+  proposal_declined?: boolean;
+}
+
+/** `POST …/review/comments/<id>/resolve|reopen` — the human's verbs (#751). */
+export interface ReviewDecisionResponse {
+  comment: ReviewComment;
+  /** False when the comment was already in the requested state (no event). */
+  changed: boolean;
 }
 
 /** One draft as posted to `POST /runs/<id>/review/comments/send`. */

--- a/prompts/builtin/manager.md
+++ b/prompts/builtin/manager.md
@@ -16,6 +16,35 @@ Read first, act second. Confirm before any destructive command and treat `cleanu
 
 ## Review comments
 
-A human can review the Run's diff on the Review page and **send** you review comments. They arrive as **one message per batch**, each comment with an id (`rc-001`, `rc-002`, …), its anchor (`<path>:R<line>` on the destination side, `:L<line>` on the source side), the pair of Run refs it was written against, an excerpt of the hunk with the anchored line marked `>`, and the text. Sent comments are immutable Run events: `GET <base URL>/runs/<run-id>/review/comments` lists them (also under `review_comments` in the projected Run state).
+A human can review the Run's diff on the Review page and **send** you review comments. They arrive as **one message per batch**, each comment with an id (`rc-001`, `rc-002`, …), its anchor (`<path>:R<line>` on the destination side, `:L<line>` on the source side), the pair of Run refs it was written against, an excerpt of the hunk with the anchored line marked `>`, and the text. Sent comments are immutable Run events: nothing edits or deletes one.
 
-Treat each comment as a remark to act on: fix the code it points at on the Run branch (through the Run's own mechanisms — a `restart_node`, an injected instruction, a node session — never by editing the comment), or explain why not. Answer **per comment** with `pdo review reply <id> --text "<your answer>"`, adding `--resolved` when you consider it addressed; `pdo review list` shows the open ones. The human resolves by default — your `--resolved` is a proposal unless the instance setting `review_agent_can_resolve` says otherwise.
+Treat each comment as a remark to act on: fix the code it points at on the Run branch (through the Run's own mechanisms — a `restart_node`, an injected instruction, a node session — never by editing the comment), or explain why not. Then answer **per comment**. Your reply appears inline under the comment in real time, with you as its author (`manager`; a node replying from its own session is named by its node id).
+
+**The human resolves by default.** `--resolved` marks your reply as a *resolution proposed*: the Review page shows it as such with Resolve / Reopen buttons, and the human decides. When the instance setting `review_agent_can_resolve` is on, the same `--resolved` resolves the comment on the spot — the human can still reopen it. A reopened comment (or a declined proposal) shows up as `open` again in `pdo review list`: read it as "not addressed yet".
+
+### CLI (from this session — the Run id and your identity come from the session env)
+
+```
+pdo review list                      # open comments, JSON, each with its `replies` thread
+pdo review list --state resolved     # or `all`
+pdo review reply rc-001 --text "Renamed `canSend` → `sendEnabled` and guarded the sending state (commit 7f2b0d1)." --resolved
+pdo review reply rc-002 --text "Kept as is: the clone is needed, `ev` is borrowed by the caller. See the comment I added above the match."
+pdo review list --run <other-run-id> # another Run, explicitly
+```
+
+`pdo review list` prints `{"comments": [...], "agent_can_resolve": <bool>}` — each comment carries `id`, `path`, `side`, `line`, `text`, `excerpt`, `status` (`sent` | `resolved`), `replies` (`author`, `text`, `at`, `proposes_resolution`), and `proposal_pending` when a `--resolved` reply awaits the human. `pdo review reply` prints the outcome: `reply recorded`, `resolution proposed`, or `resolved`.
+
+### Endpoints (same contract, `curl`-able at the base URL)
+
+- `GET <base URL>/runs/<run-id>/review/comments?state=open|resolved|all` — the list above (also under `review_comments` in the projected Run state).
+- `POST <base URL>/runs/<run-id>/review/comments/<rc-id>/reply` with `{"text": "…", "resolved": false}` — a reply; `"resolved": true` proposes (or resolves, under the setting). Send the `X-PDO-Session-Run-Id` / `X-PDO-Session-Node-Id` headers the CLI sends, or the author falls back to the body's `author` / `agent`.
+- `POST <base URL>/runs/<run-id>/review/comments/<rc-id>/resolve` and `…/reopen` — the human's verbs (the Review page's buttons); `{"by": "…"}` optional.
+
+Example:
+
+```
+curl -s "$PDO_DAEMON_URL/runs/$PDO_RUN_ID/review/comments?state=open" | jq '.comments[] | {id, path, line, text}'
+curl -s -X POST "$PDO_DAEMON_URL/runs/$PDO_RUN_ID/review/comments/rc-001/reply" \
+  -H "content-type: application/json" -H "X-PDO-Session-Run-Id: $PDO_RUN_ID" -H "X-PDO-Session-Node-Id: $PDO_NODE_ID" \
+  -d '{"text": "Fixed in 7f2b0d1.", "resolved": true}'
+```


### PR DESCRIPTION
Closes #751 (sub-ticket of story #746, ADR-0067). Release 1.78.0.

## What
- **Backend**: `review_comment_replied` / `resolved` / `reopened` events are now emitted and folded (`proposal_pending`, `resolved_by`, `reopened_by`, `proposal_declined`); `POST /runs/{id}/review/comments/{rc}/reply|resolve|reopen` (idempotent), `GET …/review/comments?state=`; instance setting `review_agent_can_resolve` (stored → env `PDO_REVIEW_AGENT_CAN_RESOLVE` → default false) in `GET/PUT /settings`. Author deduced from the session headers (`manager` or node id).
- **CLI**: `pdo review list [--state …]` and `pdo review reply <rc-id> --text "…" [--resolved]` (`--body` alias). A `--resolved` reply is a proposal unless the setting is on.
- **Frontend**: sent card becomes a thread (author/state icons, proposal card in amber with primary Resolve / Reopen-as-decline, resolved cards collapsed), unread-reply bell pill and per-card dots, eye toggle for resolved, Diff tab solid blue unread count, Settings › Runs checkbox with source note.
- `prompts/builtin/manager.md` documents the CLI.

## Verification
- Agentic Feature Path (FP) for #751: **all 4 steps Pass** plus extras (decline proposal, event order, docs) on a debug daemon driven by two browser sessions and the real `pdo review` binary. No blocking finding. Non-blocking: declined-proposal reply rows keep the hourglass icon; WS flash not captured at screenshot time (covered by vitest).
- Local gate on this branch: `cargo nextest run --workspace` 3016 passed, doctests ok, `pnpm run typecheck` ok, vitest 151 files / 2343 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)