### PR TITLE
feat(review): reported/outdated comments, Review quick access in the toolbar, Repositories tab (#752)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ ascendante** : la casse se signale ici et par un bump majeur, jamais en gardant 
 morts. Seule contrainte non négociable — les **données historiques restent lisibles** : un Run
 archivé s'ouvre et se chiffre quelle que soit la version qui a écrit son payload.
 
+## 1.79.0
+**Page de Review — report / outdated des commentaires, accès rapide Review, onglet Repositories** (#752 ; story #746, ADR-0067).
+Quand la paire affichée a bougé depuis l'écriture d'un commentaire (relivraison d'un nœud, merge-back), le daemon
+**mappe l'ancre à la lecture** (`GET /runs/{id}/review/comments?from=&to=` ajoute `outdated` / `mapped_line` / `moved`
+et renvoie `from_sha` / `to_sha`) : ligne inchangée → commentaire **reporté** à sa nouvelle position (chip `↳ from R…`
+quand le numéro diffère) ; ligne éditée ou supprimée → **outdated**, replié en tête du fichier avec son hunk d'origine,
+toujours répondable / résolvable. Rien n'est écrit dans l'event log : l'ancre d'origine reste la vérité, et
+`pdo review list` (fork → tip) expose `outdated` au manager. Bascule `Show outdated` (mémorisée par navigateur).
+Toolbar du canvas : le bouton « Run repositories » disparaît, remplacé par un lien **Review** avec pastille des
+commentaires en attente (bleu contour = envoyés non résolus, bleu plein = réponse non lue, ambre = résolution
+proposée), sur tout Run non archivé. La sidebar `RunInfoSidebar` est supprimée : **Repositories** devient un onglet
+du panneau du Run (`Info | Diff | Repositories | Manager | YAML`), l'en-tête Info porte la raison d'échec / d'attente
+et la note d'édition. Couvre la seconde moitié de #566 (laissé ouvert).
 ## 1.78.0
 **Page de Review — conversation avec l'agent** (#751 ; story #746, ADR-0067).
 Un commentaire envoyé devient un **fil** : l'agent répond avec `pdo review list [--state open|resolved|all]`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "1.78.0"
+version = "1.79.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "1.78.0"
+version = "1.79.0"
 license = "MIT"
 description = "Prompt-Driven Orchestrator — a local daemon that runs and supervises agentic coding pipelines"
 repository = "https://github.com/Loulen/prompt-driven-orchestrator"

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -258,6 +258,9 @@ pub enum Commands {
 #[derive(Subcommand, Debug)]
 pub enum ReviewAction {
     /// List the Run's review comments as JSON, each with its thread of replies.
+    /// Mapped onto the Run's current fork → tip: `outdated: true` means the line
+    /// a comment points at has changed since it was written (its `excerpt` keeps
+    /// the original hunk); `mapped_line` is where the line sits now.
     List {
         /// `open` (default), `resolved` or `all`.
         #[arg(long, default_value = "open")]
@@ -1389,8 +1392,11 @@ pub fn run_review(action: ReviewAction) -> Result<()> {
             if review_comments::StateFilter::parse(&state).is_none() {
                 anyhow::bail!("--state must be `open`, `resolved` or `all`, got {state:?}");
             }
+            // #752: mapped onto the Run's current fork → tip, so each comment
+            // says `outdated: true` when the line it points at has changed since
+            // (and `mapped_line` when it merely shifted).
             let response = with_identity(client.get(format!(
-                "{url}/runs/{run_id}/review/comments?state={}",
+                "{url}/runs/{run_id}/review/comments?state={}&from=fork&to=tip",
                 state.trim()
             )))
             .send()
@@ -13920,6 +13926,13 @@ struct ListReviewCommentsQuery {
     /// wants everything, resolved ones collapse client-side).
     #[serde(default)]
     state: Option<String>,
+    /// #752: the displayed pair to **re-map** every comment onto (stable Run ref
+    /// ids, defaults `fork` / `tip` when only one side is given). Absent both:
+    /// no mapping, the comments come back as written.
+    #[serde(default)]
+    from: Option<String>,
+    #[serde(default)]
+    to: Option<String>,
 }
 
 /// `GET /runs/<id>/review/comments[?state=open|resolved|all]` (#750, #751): the
@@ -13927,7 +13940,8 @@ struct ListReviewCommentsQuery {
 /// list `GET /runs/<id>` carries under `review_comments`, with each comment's
 /// thread (`replies`), exposed on its own for `pdo review list` and the tests.
 /// Also answers `review_agent_can_resolve` so a CLI can say what `--resolved`
-/// will do.
+/// will do. With `?from=&to=` (#752) every comment is re-mapped onto that pair:
+/// `outdated` / `mapped_line` / `moved` are added, computed on read.
 async fn list_review_comments(
     State(state): State<Arc<AppState>>,
     AxumPath(run_id): AxumPath<String>,
@@ -13948,7 +13962,7 @@ async fn list_review_comments(
             }
         },
     };
-    let (_, run_state) = match load_projected(&state, &run_id).await {
+    let (events, run_state) = match load_projected(&state, &run_id).await {
         Ok(t) => t,
         Err(resp) => return *resp,
     };
@@ -13958,9 +13972,73 @@ async fn list_review_comments(
         .filter(|c| filter.keeps(c))
         .collect();
     let can_resolve = review_agent_can_resolve(&state).await;
+
+    // #752 (ADR-0067 §5): re-map each anchor onto the requested pair, on read.
+    // A comment whose anchored side is unchanged between the SHA it was written
+    // against and the displayed one is *reported* (`mapped_line`, possibly
+    // shifted); otherwise it is `outdated`. Nothing is written back.
+    let wants_map = q.from.is_some() || q.to.is_some();
+    if !wants_map {
+        return Json(serde_json::json!({
+            "comments": comments,
+            "agent_can_resolve": can_resolve,
+        }))
+        .into_response();
+    }
+    let from = match resolve_ref_param(
+        &run_id,
+        &run_state,
+        &events,
+        q.from.as_deref(),
+        run_refs::FORK_ID,
+    ) {
+        Ok(r) => r,
+        Err(resp) => return *resp,
+    };
+    let to = match resolve_ref_param(
+        &run_id,
+        &run_state,
+        &events,
+        q.to.as_deref(),
+        run_refs::TIP_ID,
+    ) {
+        Ok(r) => r,
+        Err(resp) => return *resp,
+    };
+    let repo = effective_repo_root(&state, &run_state);
+    let from_sha = structured_diff::rev_parse(&repo, &from);
+    let to_sha = structured_diff::rev_parse(&repo, &to);
+    let diff_path = |orig: &str, target: &str, path: &str| {
+        if !structured_diff::is_safe_path(path)
+            || !structured_diff::is_safe_ref(orig)
+            || !structured_diff::is_safe_ref(target)
+        {
+            return None;
+        }
+        structured_diff::compute_path(&repo, orig, target, path).ok()
+    };
+    let mapped: Vec<serde_json::Value> = comments
+        .iter()
+        .map(|c| {
+            let mut v = serde_json::to_value(c).expect("ReviewComment serializes");
+            if let Some(m) =
+                review_comments::map_comment(c, from_sha.as_deref(), to_sha.as_deref(), &diff_path)
+            {
+                if let (Some(obj), serde_json::Value::Object(extra)) = (
+                    v.as_object_mut(),
+                    serde_json::to_value(m).expect("AnchorMapping serializes"),
+                ) {
+                    obj.extend(extra);
+                }
+            }
+            v
+        })
+        .collect();
     Json(serde_json::json!({
-        "comments": comments,
+        "comments": mapped,
         "agent_can_resolve": can_resolve,
+        "from_sha": from_sha,
+        "to_sha": to_sha,
     }))
     .into_response()
 }

--- a/crates/pdo-daemon/src/review_comments.rs
+++ b/crates/pdo-daemon/src/review_comments.rs
@@ -312,6 +312,143 @@ pub(crate) fn batch_message(
     out
 }
 
+// ---------------------------------------------------------------------------
+// #752 — re-map of an anchor onto another destination (ADR-0067 §5).
+// ---------------------------------------------------------------------------
+
+/// Where a comment's line is once its anchored side is read at another ref:
+/// **reported** at `line` (the line is unchanged — it may have shifted), or
+/// **outdated** (the line was edited or deleted). Computed on read, never
+/// written to the log: the anchor in the event stays the truth.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LineMapping {
+    Reported { line: i64 },
+    Outdated,
+}
+
+/// Follow `line` (1-based, on the **old** side of `files`) through the hunks of
+/// the two-dot diff `orig → target` of one path. A context line keeps its
+/// content: reported at its new number. A deleted line — an edit is a delete
+/// plus an add — is outdated. A line the diff never mentions shifts by the net
+/// growth of the hunks above it. An empty `files` means identical content: the
+/// line stays where it is. A file added or deleted between the refs has no
+/// line to follow.
+pub(crate) fn map_line(files: &[crate::structured_diff::FileDiff], line: i64) -> LineMapping {
+    use crate::structured_diff::{FileStatus, LineKind};
+    if line < 1 {
+        return LineMapping::Outdated;
+    }
+    let Some(file) = files.first() else {
+        return LineMapping::Reported { line };
+    };
+    if file.binary || matches!(file.status, FileStatus::Added | FileStatus::Deleted) {
+        return LineMapping::Outdated;
+    }
+    let line_u = line as u32;
+    let mut delta: i64 = 0;
+    for hunk in &file.hunks {
+        if hunk.old_lines == 0 {
+            // Pure insertion: `-N,0` inserts AFTER old line N. Line N and
+            // everything above stay; everything below shifts.
+            if line_u <= hunk.old_start {
+                break;
+            }
+            delta += hunk.new_lines as i64;
+            continue;
+        }
+        if line_u < hunk.old_start {
+            break;
+        }
+        if line_u < hunk.old_start + hunk.old_lines {
+            // Inside the hunk: the line itself is listed, one way or another.
+            for l in &hunk.lines {
+                if l.old_no == Some(line_u) {
+                    return match (l.kind, l.new_no) {
+                        (LineKind::Context, Some(n)) => LineMapping::Reported { line: n as i64 },
+                        _ => LineMapping::Outdated,
+                    };
+                }
+            }
+            // Listed hunk without our line (a malformed patch): be conservative.
+            return LineMapping::Outdated;
+        }
+        delta += hunk.new_lines as i64 - hunk.old_lines as i64;
+    }
+    LineMapping::Reported { line: line + delta }
+}
+
+/// The annotation `GET …/review/comments?from=&to=` and `pdo review list` add to
+/// a comment for a displayed pair: `outdated`, and the reported line when the
+/// comment still has one. `None` when the mapping cannot be computed (no SHA
+/// recorded at send time, a ref that no longer resolves): the caller shows the
+/// comment where it was written, without pretending.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub(crate) struct AnchorMapping {
+    pub outdated: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mapped_line: Option<i64>,
+    /// The reported line differs from the written one.
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub moved: bool,
+}
+
+impl AnchorMapping {
+    pub(crate) fn from_line(original: i64, mapping: LineMapping) -> AnchorMapping {
+        match mapping {
+            LineMapping::Reported { line } => AnchorMapping {
+                outdated: false,
+                mapped_line: Some(line),
+                moved: line != original,
+            },
+            LineMapping::Outdated => AnchorMapping {
+                outdated: true,
+                mapped_line: None,
+                moved: false,
+            },
+        }
+    }
+}
+
+/// The SHA a comment's anchored side was written against: `to_sha` for the
+/// destination (`new`) side, `from_sha` for the source (`old`) side — old-side
+/// comments follow the same rule on the source ref.
+pub(crate) fn anchored_sha(c: &ReviewComment) -> Option<&str> {
+    match c.side {
+        ReviewSide::New => c.to_sha.as_deref(),
+        ReviewSide::Old => c.from_sha.as_deref(),
+    }
+}
+
+/// `(orig, target, path) -> parsed two-dot diff of that path`, or `None` when
+/// git cannot answer — the one seam [`map_comment`] needs from the repository.
+pub(crate) type DiffPathFn<'a> =
+    &'a dyn Fn(&str, &str, &str) -> Option<Vec<crate::structured_diff::FileDiff>>;
+
+/// Map one comment onto the displayed pair `(from_sha, to_sha)`. `diff_path`
+/// yields the parsed two-dot diff of the comment's path between two SHAs
+/// (`None` when git cannot answer — unknown revision). Pure apart from that
+/// closure, so the algorithm is testable without a repository.
+pub(crate) fn map_comment(
+    c: &ReviewComment,
+    from_sha: Option<&str>,
+    to_sha: Option<&str>,
+    diff_path: DiffPathFn<'_>,
+) -> Option<AnchorMapping> {
+    let orig = anchored_sha(c)?;
+    let target = match c.side {
+        ReviewSide::New => to_sha?,
+        ReviewSide::Old => from_sha?,
+    };
+    if orig == target {
+        return Some(AnchorMapping::from_line(
+            c.line,
+            LineMapping::Reported { line: c.line },
+        ));
+    }
+    let files = diff_path(orig, target, &c.path)?;
+    Some(AnchorMapping::from_line(c.line, map_line(&files, c.line)))
+}
+
 /// Fold one review event into the projected list. Additive only; unknown ids
 /// on a reply/resolve/reopen are ignored with a warning (a hand-crafted or
 /// replayed event must never panic the projection).
@@ -712,6 +849,100 @@ mod tests {
                 REVIEW_AGENT_CAN_RESOLVE_DEFAULT
             );
         }
+    }
+
+    fn patch(files: &str) -> Vec<crate::structured_diff::FileDiff> {
+        crate::structured_diff::parse_patch(files)
+    }
+
+    const EDIT_ONE_LINE: &str = "diff --git a/f.rs b/f.rs\nindex 1..2 100644\n--- a/f.rs\n+++ b/f.rs\n@@ -3 +3 @@\n-fn c() {}\n+fn c() { 1 }\n";
+    const INSERT_ABOVE: &str = "diff --git a/f.rs b/f.rs\nindex 1..2 100644\n--- a/f.rs\n+++ b/f.rs\n@@ -1,0 +2,2 @@\n+// one\n+// two\n";
+    const DELETE_FILE: &str = "diff --git a/f.rs b/f.rs\ndeleted file mode 100644\nindex 1..0\n--- a/f.rs\n+++ /dev/null\n@@ -1,3 +0,0 @@\n-a\n-b\n-c\n";
+
+    #[test]
+    fn map_line_reports_an_untouched_line_and_shifts_it_below_an_insertion() {
+        // Identical content: the line stays.
+        assert_eq!(map_line(&[], 7), LineMapping::Reported { line: 7 });
+        // Two lines inserted after line 1: line 1 stays, line 2 becomes 4.
+        let p = patch(INSERT_ABOVE);
+        assert_eq!(map_line(&p, 1), LineMapping::Reported { line: 1 });
+        assert_eq!(map_line(&p, 2), LineMapping::Reported { line: 4 });
+        assert_eq!(map_line(&p, 9), LineMapping::Reported { line: 11 });
+    }
+
+    #[test]
+    fn map_line_marks_an_edited_or_deleted_line_outdated_and_keeps_its_neighbours() {
+        let p = patch(EDIT_ONE_LINE);
+        assert_eq!(map_line(&p, 3), LineMapping::Outdated);
+        assert_eq!(map_line(&p, 2), LineMapping::Reported { line: 2 });
+        assert_eq!(map_line(&p, 4), LineMapping::Reported { line: 4 });
+        assert_eq!(map_line(&patch(DELETE_FILE), 2), LineMapping::Outdated);
+        assert_eq!(map_line(&[], 0), LineMapping::Outdated);
+    }
+
+    #[test]
+    fn map_comment_uses_the_anchored_side_and_short_circuits_on_the_same_sha() {
+        let c = sent("rc-001", 3);
+        let calls = std::cell::Cell::new(0);
+        let diff = |_: &str, _: &str, _: &str| {
+            calls.set(calls.get() + 1);
+            Some(patch(EDIT_ONE_LINE))
+        };
+        // Same destination SHA as written: reported in place, no git.
+        let m = map_comment(
+            &c,
+            Some("a1b2c3d4e5f6a7b8"),
+            Some("d4e5f6a7b8c9d0e1"),
+            &diff,
+        )
+        .unwrap();
+        assert_eq!(
+            m,
+            AnchorMapping {
+                outdated: false,
+                mapped_line: Some(3),
+                moved: false
+            }
+        );
+        assert_eq!(calls.get(), 0);
+        // Destination moved: the new side is mapped, line 3 was edited.
+        let m = map_comment(&c, Some("a1b2c3d4e5f6a7b8"), Some("ffff"), &diff).unwrap();
+        assert!(m.outdated && m.mapped_line.is_none());
+        assert_eq!(calls.get(), 1);
+        // Old-side comment follows the SOURCE ref: destination moving is irrelevant.
+        let mut old = sent("rc-002", 2);
+        old.side = ReviewSide::Old;
+        let m = map_comment(&old, Some("a1b2c3d4e5f6a7b8"), Some("ffff"), &diff).unwrap();
+        assert_eq!(
+            m,
+            AnchorMapping {
+                outdated: false,
+                mapped_line: Some(2),
+                moved: false
+            }
+        );
+        let m = map_comment(&old, Some("eeee"), Some("ffff"), &diff).unwrap();
+        assert_eq!(
+            m.mapped_line,
+            Some(2),
+            "line 2 is untouched by the edit of line 3"
+        );
+        // No SHA recorded / ref gone: no verdict.
+        let mut bare = sent("rc-003", 3);
+        bare.to_sha = None;
+        assert!(map_comment(&bare, Some("x"), Some("y"), &diff).is_none());
+        assert!(map_comment(&c, Some("x"), None, &diff).is_none());
+        // git cannot answer: no verdict either.
+        assert!(map_comment(&c, Some("x"), Some("y"), &|_, _, _| None).is_none());
+        let wire = serde_json::to_value(AnchorMapping::from_line(
+            3,
+            LineMapping::Reported { line: 5 },
+        ))
+        .unwrap();
+        assert_eq!(
+            wire,
+            serde_json::json!({ "outdated": false, "mapped_line": 5, "moved": true })
+        );
     }
 
     #[test]

--- a/crates/pdo-daemon/src/structured_diff.rs
+++ b/crates/pdo-daemon/src/structured_diff.rs
@@ -209,6 +209,35 @@ pub(crate) fn compute(
     })
 }
 
+/// The parsed `git diff <from> <to> -- <path>` of **one** path, two-dot, for the
+/// re-map of a review comment's anchor (#752, ADR-0067 §5): the caller walks its
+/// hunks to follow a line from `from` to `to`. Renames are followed so a moved
+/// file still maps. `Ok(vec![])` = identical content at both refs.
+pub(crate) fn compute_path(
+    repo: &Path,
+    from_ref: &str,
+    to_ref: &str,
+    path: &str,
+) -> Result<Vec<FileDiff>, GitError> {
+    let stdout = run_git(
+        repo,
+        &[
+            "-c",
+            "core.quotepath=false",
+            "diff",
+            "--no-color",
+            "--no-ext-diff",
+            "--find-renames",
+            "-U0",
+            from_ref,
+            to_ref,
+            "--",
+            path,
+        ],
+    )?;
+    Ok(parse_patch(&String::from_utf8_lossy(&stdout)))
+}
+
 /// `git show <ref>:<path>` — the full content of one file at one ref, for the
 /// context expansion of the Review page. Returns the raw bytes (a binary file
 /// is a legitimate answer; the handler picks the content type).

--- a/crates/pdo-daemon/tests/review_comments.rs
+++ b/crates/pdo-daemon/tests/review_comments.rs
@@ -279,6 +279,82 @@ async fn sent_comments_are_events_projected_pushed_and_start_the_manager() {
         "already running: reused, not respawned"
     );
 
+    // #752 (ADR-0067 §5): the Run tip moves — a relivery edits line 4 (rc-001's
+    // line) and inserts a line at the top (rc-003's line 2 shifts to 3). Read
+    // against fork → tip, the daemon re-maps on read: rc-001 is outdated, rc-003
+    // is reported at 3 (moved), rc-002 (old side, on the fork) is untouched.
+    // Nothing in the log changes: the anchors stay as written.
+    std::fs::write(
+        wt_dir.join("lib.rs"),
+        "// header\nfn a() {}\nfn b() {}\nfn c() {}\nfn d() { 1 }\n",
+    )
+    .unwrap();
+    git(&wt_dir, &["add", "lib.rs"]);
+    git(&wt_dir, &["commit", "-q", "-m", "relivery"]);
+    let mapped: serde_json::Value = client
+        .get(format!(
+            "{}/runs/{run_id}/review/comments?from=fork&to=tip",
+            daemon.url()
+        ))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let by_id = |id: &str| -> serde_json::Value {
+        mapped["comments"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|c| c["id"] == id)
+            .cloned()
+            .unwrap_or_else(|| panic!("{id} missing in {mapped}"))
+    };
+    assert_eq!(by_id("rc-001")["outdated"], true, "{mapped}");
+    assert!(by_id("rc-001").get("mapped_line").is_none(), "{mapped}");
+    assert_eq!(
+        by_id("rc-001")["line"],
+        4,
+        "the written anchor is untouched"
+    );
+    assert_eq!(by_id("rc-003")["outdated"], false, "{mapped}");
+    assert_eq!(by_id("rc-003")["mapped_line"], 3, "{mapped}");
+    assert_eq!(by_id("rc-003")["moved"], true, "{mapped}");
+    assert_eq!(by_id("rc-002")["outdated"], false, "{mapped}");
+    assert_eq!(
+        by_id("rc-002")["mapped_line"],
+        1,
+        "old side follows the source ref: {mapped}"
+    );
+    assert!(by_id("rc-002").get("moved").is_none(), "{mapped}");
+    assert_eq!(mapped["to_sha"].as_str().unwrap().len(), 40);
+    // Without a pair: no mapping fields at all.
+    let plain: serde_json::Value = client
+        .get(format!("{}/runs/{run_id}/review/comments", daemon.url()))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert!(plain["comments"][0].get("outdated").is_none(), "{plain}");
+    // The event log still carries the original anchors.
+    let events: Vec<serde_json::Value> = client
+        .get(format!("{}/runs/{run_id}/events", daemon.url()))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let first_sent = events
+        .iter()
+        .find(|e| e["kind"] == "review_comment_sent")
+        .unwrap();
+    assert_eq!(first_sent["payload"]["line"], 4);
+    assert!(first_sent["payload"].get("outdated").is_none());
+
     // Branch gone ⇒ refused with the reason, nothing appended.
     git(
         &repo,
@@ -315,6 +391,24 @@ async fn sent_comments_are_events_projected_pushed_and_start_the_manager() {
         list["comments"].as_array().unwrap().len(),
         3,
         "the refused one was not recorded"
+    );
+    // Branch gone: the tip no longer resolves, so a mapped read answers without
+    // a verdict (no `outdated` field) rather than pretending.
+    let mapped: serde_json::Value = client
+        .get(format!(
+            "{}/runs/{run_id}/review/comments?from=fork&to=tip",
+            daemon.url()
+        ))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert!(mapped["to_sha"].is_null(), "{mapped}");
+    assert!(
+        mapped["comments"][0].get("outdated").is_none(),
+        "no verdict once the destination is gone: {mapped}"
     );
 }
 
@@ -408,6 +502,9 @@ async fn cli_review_list_and_reply_drive_the_conversation_end_to_end() {
         .collect();
     assert_eq!(ids, vec!["rc-001", "rc-002"]);
     assert_eq!(listed["comments"][0]["status"], "sent");
+    // #752: the CLI reads mapped onto fork → tip, so the agent knows whether the
+    // line it is asked about has moved (`outdated: true`) or not.
+    assert_eq!(listed["comments"][0]["outdated"], false, "{listed}");
     assert_eq!(listed["agent_can_resolve"], false);
 
     // Out of a session and without --run: a readable refusal, exit 1.

--- a/frontend/e2e/run-edit-toggle.spec.ts
+++ b/frontend/e2e/run-edit-toggle.spec.ts
@@ -87,7 +87,7 @@ test("unified edit mode: selecting a run opens editor canvas automatically", asy
 
   // The opened tab is run-scoped: its id is `__run__<run_id>`, so the editor we
   // see is editing the run's pipeline (run-scoped edits "sync to template").
-  // On a live run a node auto-selects, so the RunInfoSidebar footnote is not a
+  // On a live run a node auto-selects, so the Run panel's Info footnote is not a
   // reliable signal here — the run-scoped tab id is.
   await expect(page.getByTestId(`tab-title-__run__${run_id}`)).toBeVisible();
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,7 +14,6 @@ import SessionCounter from "./components/SessionCounter";
 import ServiceHealthIndicator from "./components/ServiceHealthIndicator";
 import UnifiedLeftPanel from "./components/UnifiedLeftPanel";
 import NodeDetailPanel from "./components/NodeDetailPanel";
-import RunInfoSidebar from "./components/RunInfoSidebar";
 import NewRunModal, { RUN_INTENT } from "./components/NewRunModal";
 import SettingsSurface, { type SettingsPosition, type StatsOpenIntent } from "./components/SettingsSurface";
 import VersionBadge from "./components/VersionBadge";
@@ -917,13 +916,22 @@ export default function App() {
                   <NoteInspector />
                 ) : null}
                 {/* `"none"` reaches this on a terminal/paused run (deselect, or
-                    selecting the run — #503 red-dot panel); `"run"` is the
-                    explicit toggle that keeps it reachable while a live node
-                    runs (#465 slice 2, F1). */}
+                    selecting the run — #503 red-dot panel). #752: the standalone
+                    Run-info sidebar is gone; the Run panel opens on Info, which
+                    now carries the failure / awaiting reason, and Repositories
+                    is one of its tabs (`Info | Diff | Repositories | Manager | YAML`). */}
                 {(selection.kind === "none" || selection.kind === "run") &&
                   isEditingRun &&
                   selectedRun && (
-                    <RunInfoSidebar run={selectedRun} onEdited={refreshRun} />
+                    <PipelineInfoPanel
+                      key={`run-panel-${selectedRun.run_id}`}
+                      run={selectedRun}
+                      pipeline={editTab?.pipeline ?? null}
+                      onClose={handleCloseInfo}
+                      initialTab="info"
+                      onRefreshRun={refreshRun}
+                      onOpenSettings={() => openSettings({ category: "agents", section: "pipeline-manager" })}
+                    />
                   )}
                 {selection.kind === "none" && !isEditingRun && (
                   <PipelineInspector />

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,5 +1,5 @@
 import type { PipelineListEntry, PipelineDetail, PipelineDef, RunListEntry, RunState, PortDef, PortSide, PortType, FrontmatterFieldDecl, FrontmatterViolation, Trigger, TriggerFire, DaemonStatus, InstanceSettings, UpdateSettingsRequest, StatsOverview, StatsCost, StatsPerformance, SandboxProfile, SandboxProfileImage, SandboxProfileReferents, SyncCostPricesReport, UpdateStatus, UpdateChangelog, UpdateApplyResponse, Project, BranchRef, AgentChoice, AgentProfile, AgentProfileReferents, ProvisioningPlan, ProvisioningRules, Skill, SkillBank, SkillDetail, SkillFile, SkillFileContent, SkillFilesUpload, SkillFolder, SkillReferents, SkillRef, SkillScanResult, SkillImportItem, SkillImportReport, SkillRescanReport, RecentSkillSource, StructuredDiff, RunRefs,
-  ReviewComment,
+  ReviewCommentsListResponse,
   ReviewDecisionResponse,
   SendReviewCommentInput,
   SendReviewCommentsResponse,
@@ -389,9 +389,18 @@ export function fetchRunEvents(runId: string): Promise<unknown[]> {
   return request<unknown[]>("GET", `/runs/${encodeURIComponent(runId)}/events`);
 }
 
-/** #750: the Run's sent review comments, on their own endpoint. */
-export function fetchReviewComments(runId: string): Promise<{ comments: ReviewComment[] }> {
-  return request<{ comments: ReviewComment[] }>("GET", `/runs/${encodeURIComponent(runId)}/review/comments`);
+/**
+ * #750: the Run's sent review comments, on their own endpoint. With a `pair`
+ * (#752, ADR-0067 §5) the daemon re-maps every anchor onto it **on read**: each
+ * comment carries `outdated` and, when the line still exists, `mapped_line` /
+ * `moved`. Nothing is written to the event log.
+ */
+export function fetchReviewComments(
+  runId: string,
+  pair?: { from: string; to: string },
+): Promise<ReviewCommentsListResponse> {
+  const qs = pair ? `?from=${encodeURIComponent(pair.from)}&to=${encodeURIComponent(pair.to)}` : "";
+  return request<ReviewCommentsListResponse>("GET", `/runs/${encodeURIComponent(runId)}/review/comments${qs}`);
 }
 
 /**

--- a/frontend/src/components/EditCanvas.tsx
+++ b/frontend/src/components/EditCanvas.tsx
@@ -16,7 +16,10 @@ import {
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import type { LoopKind, NodeDef, NodeStatus, NodeType, PortBrief, PortSide, RunState } from "../types";
-import { isNodeActiveRun, isTerminalRun } from "../types";
+import { isTerminalRun } from "../types";
+import { pendingCount, pendingTone, reviewQuickAccessTitle } from "../lib/reviewComments";
+import { reviewUrl } from "../lib/runRefs";
+import { useReviewSeen } from "../hooks/useReviewUnread";
 import type { LibraryEntry, LibraryPipelineEntry } from "../api";
 import { openRunShell, reopenRun, retryAll } from "../api";
 import RunShellModal from "./RunShellModal";
@@ -295,7 +298,6 @@ function EditCanvasInner({ libraryEntries, onLibraryDelete, infoOpen, onToggleIn
   const openTabs = useEditStore((s) => s.openTabs);
   const activeTabId = useEditStore((s) => s.activeTabId);
   const setSelection = useEditStore((s) => s.setSelection);
-  const selection = useEditStore((s) => s.selection);
   const updateNodeViews = useEditStore((s) => s.updateNodeViews);
   const addEdgeToStore = useEditStore((s) => s.addEdge);
   const deleteNode = useEditStore((s) => s.deleteNode);
@@ -359,13 +361,19 @@ function EditCanvasInner({ libraryEntries, onLibraryDelete, infoOpen, onToggleIn
   // intact for running/completed runs.
   const readOnly = activeRunState?.status === "archived";
 
-  // #465 slice 2 (F1): expose the Run-info / Repositories sidebar toggle only on
-  // the run tabs where the App auto-snaps to the running node — the exact set
-  // where the panel is otherwise unreachable. `"run"` survives the auto-snap;
-  // toggling back to `"none"` lets it re-select the live node (back to terminal).
-  const showRunInfo =
-    activeRunState != null && isNodeActiveRun(activeRunState.status);
-  const runInfoActive = selection.kind === "run";
+  // #752 (CONTEXT.md « Accès rapide Review »): the toolbar's Review quick access
+  // — a link to the Run's Review page with the pending-comment pill — on every
+  // non-archived Run (an archived Run has no diff to review). The tone follows
+  // the same "seen" marker as the Diff tab's unread pill. Repositories moved to
+  // a tab of the Run panel, so the old sidebar toggle is gone.
+  const reviewSeen = useReviewSeen(activeRunState ?? null);
+  const reviewHref =
+    activeRunState != null && activeRunState.status !== "archived"
+      ? reviewUrl(activeRunState.run_id)
+      : undefined;
+  const reviewPending = pendingCount(activeRunState?.review_comments);
+  const reviewTone = pendingTone(activeRunState?.review_comments, reviewSeen);
+  const reviewTitle = reviewQuickAccessTitle(activeRunState?.review_comments, reviewSeen);
 
   // #598 / ADR-0049: the finished-run action group is contextual to a TERMINAL,
   // non-archived run (`isTerminalRun` INCLUDES `archived`, so exclude it — an
@@ -413,14 +421,6 @@ function EditCanvasInner({ libraryEntries, onLibraryDelete, infoOpen, onToggleIn
       // The server gate may 409 if the worktree vanished out-of-band.
     }
   }, [activeRunState]);
-  const toggleRunInfo = useCallback(() => {
-    setSelection(
-      selection.kind === "run"
-        ? { kind: "none", id: null }
-        : { kind: "run", id: null },
-    );
-  }, [selection.kind, setSelection]);
-
   const { profiles: agentProfiles } = useAgentProfiles();
   const agentProfileIds = useMemo(
     () => new Set(agentProfiles.map((profile) => profile.id)),
@@ -814,9 +814,10 @@ function EditCanvasInner({ libraryEntries, onLibraryDelete, infoOpen, onToggleIn
         assistantAvailable={tab != null && tab.runId == null}
         assistantActive={assistantActive}
         onOpenAssistant={onOpenAssistant}
-        showRunInfo={showRunInfo}
-        runInfoActive={runInfoActive}
-        onToggleRunInfo={toggleRunInfo}
+        reviewHref={reviewHref}
+        reviewPending={reviewPending}
+        reviewTone={reviewTone}
+        reviewTitle={reviewTitle}
         readOnly={readOnly}
         finishedRun={finishedRun}
         onReopen={handleReopen}

--- a/frontend/src/components/EditToolbar.test.tsx
+++ b/frontend/src/components/EditToolbar.test.tsx
@@ -170,53 +170,49 @@ describe("EditToolbar", () => {
     });
   });
 
-  // #465 slice 2 (F1): the Run-info / Repositories toggle, shown only on the
-  // live run tabs where the App auto-snaps to the running node — the exact set
-  // where the sidebar is otherwise unreachable.
-  describe("run-info toggle (#465 slice 2, F1)", () => {
+  // #752 (CONTEXT.md « Accès rapide Review »): the Review quick access takes the
+  // slot of the old "Run repositories" toggle (Repositories is a tab of the Run
+  // panel now). A link, not a toggle; pill = pending count, tone = nuance.
+  describe("Review quick access (#752)", () => {
     it("is absent on a non-run canvas (default)", () => {
       renderToolbar({ onToggleInfo: vi.fn() });
+      expect(screen.queryByTestId("toolbar-review")).toBeNull();
       expect(screen.queryByTestId("toolbar-run-info")).toBeNull();
     });
 
-    it("stays absent when shown without a handler wired", () => {
-      renderToolbar({ showRunInfo: true });
+    it("is a real link to the Review page, named, without aria-pressed", () => {
+      renderToolbar({ reviewHref: "/runs/r1/review", reviewTitle: "Review" });
+      const link = screen.getByTestId("toolbar-review");
+      expect(link.tagName).toBe("A");
+      expect(link).toHaveAttribute("href", "/runs/r1/review");
+      expect(link).toHaveAccessibleName("Review");
+      expect(link).not.toHaveAttribute("aria-pressed");
+      expect(screen.queryByTestId("toolbar-review-pill")).toBeNull();
+    });
+
+    it("shows the pending count as an outlined pill, and the title spells it out", () => {
+      renderToolbar({ reviewHref: "/runs/r1/review", reviewPending: 2, reviewTone: "pending", reviewTitle: "Review · 2 pending" });
+      const link = screen.getByTestId("toolbar-review");
+      expect(link).toHaveAccessibleName("Review · 2 pending");
+      expect(link).toHaveAttribute("data-tone", "pending");
+      expect(screen.getByTestId("toolbar-review-pill").textContent).toBe("2");
+    });
+
+    it("turns solid blue on an unread reply and amber on a proposed resolution", () => {
+      const { unmount } = renderToolbar({ reviewHref: "/runs/r1/review", reviewPending: 2, reviewTone: "unread" });
+      expect(screen.getByTestId("toolbar-review")).toHaveAttribute("data-tone", "unread");
+      expect(screen.getByTestId("toolbar-review-pill").className).toContain("bg-st-running ");
+      unmount();
+      renderToolbar({ reviewHref: "/runs/r1/review", reviewPending: 2, reviewTone: "proposed" });
+      expect(screen.getByTestId("toolbar-review")).toHaveAttribute("data-tone", "proposed");
+      expect(screen.getByTestId("toolbar-review-pill").className).toContain("bg-st-await");
+    });
+
+    it("adds no button — the core count is unchanged — and the old toggle is gone", () => {
+      renderToolbar({ reviewHref: "/runs/r1/review", onToggleInfo: vi.fn() });
+      const buttons = [...screen.getByTestId("edit-toolbar").querySelectorAll("button")];
+      expect(buttons).toHaveLength(7); // 7 core; Review is a link
       expect(screen.queryByTestId("toolbar-run-info")).toBeNull();
-    });
-
-    it("renders named, unpressed at rest, and toggles on click", () => {
-      const onToggleRunInfo = vi.fn();
-      renderToolbar({ showRunInfo: true, onToggleRunInfo });
-      const btn = screen.getByTestId("toolbar-run-info");
-      expect(btn).toHaveAccessibleName("Run repositories");
-      expect(btn).toHaveAttribute("aria-pressed", "false");
-      fireEvent.click(btn);
-      expect(onToggleRunInfo).toHaveBeenCalledTimes(1);
-    });
-
-    it("reflects the pressed state while the sidebar is open", () => {
-      renderToolbar({
-        showRunInfo: true,
-        onToggleRunInfo: vi.fn(),
-        runInfoActive: true,
-      });
-      expect(screen.getByTestId("toolbar-run-info")).toHaveAttribute(
-        "aria-pressed",
-        "true",
-      );
-    });
-
-    it("adds exactly one more named button beside Pipeline info", () => {
-      renderToolbar({
-        showRunInfo: true,
-        onToggleRunInfo: vi.fn(),
-        onToggleInfo: vi.fn(),
-      });
-      const buttons = [
-        ...screen.getByTestId("edit-toolbar").querySelectorAll("button"),
-      ];
-      expect(buttons).toHaveLength(8); // 7 core + run-info
-      for (const b of buttons) expect(b).toHaveAccessibleName(/\S/);
     });
   });
 

--- a/frontend/src/components/EditToolbar.tsx
+++ b/frontend/src/components/EditToolbar.tsx
@@ -1,4 +1,5 @@
-import { Plus, GitMerge, Info, Undo2, Redo2, SquareTerminal, Box, StickyNote, FilePlus, FolderGit2, Bot, Play, RotateCcw, Terminal } from "lucide-react";
+import { Plus, GitMerge, Info, Undo2, Redo2, SquareTerminal, Box, StickyNote, FilePlus, FileDiff, Bot, Play, RotateCcw, Terminal } from "lucide-react";
+import type { PendingTone } from "../lib/reviewComments";
 import type { NodeType } from "../types";
 import type { LibraryEntry } from "../api";
 import { Tooltip } from "./ui/tooltip";
@@ -28,13 +29,17 @@ interface Props {
   assistantAvailable?: boolean;
   assistantActive?: boolean;
   onOpenAssistant?: () => void;
-  // #465 slice 2 (F1): on a live run the App auto-snaps the selection to the
-  // running node, so the Run-info / Repositories sidebar (mounted when nothing
-  // is selected) is otherwise unreachable. This toggle opens it explicitly. Only
-  // passed for the run tabs where auto-snap applies (`isNodeActiveRun`).
-  showRunInfo?: boolean;
-  runInfoActive?: boolean;
-  onToggleRunInfo?: () => void;
+  // #752 (CONTEXT.md « Accès rapide Review »): the Review quick access, in the
+  // slot the "Run repositories" toggle used to hold (Repositories is a tab of the
+  // Run panel now). A real link to the Run's Review page — same tab, like the
+  // Diff tab's "Expand and comment" — with a pill = `pendingCount()` (sent, not
+  // resolved). The colour carries the nuance, never the number: outlined blue
+  // pending, solid blue ≥ 1 unread reply, amber ≥ 1 resolution proposed (wins).
+  // Passed for every non-archived Run; absent on templates and archived Runs.
+  reviewHref?: string;
+  reviewPending?: number;
+  reviewTone?: PendingTone;
+  reviewTitle?: string;
   // #315: an archived run's canvas is read-only — hide every editing control
   // (add node/note, library insert, merge/script, undo/redo). Only the
   // Pipeline-info button survives so the archived pipeline stays inspectable.
@@ -52,7 +57,7 @@ interface Props {
   onOpenShell?: () => void;
 }
 
-export default function EditToolbar({ onAddNode, onAddNote, onAddNodeFromYaml, libraryEntries, onLibraryDelete, getDropPosition, infoOpen, onToggleInfo, assistantAvailable = false, assistantActive = false, onOpenAssistant, showRunInfo = false, runInfoActive = false, onToggleRunInfo, readOnly = false, finishedRun = false, onReopen, onRetryAll, onOpenShell }: Props) {
+export default function EditToolbar({ onAddNode, onAddNote, onAddNodeFromYaml, libraryEntries, onLibraryDelete, getDropPosition, infoOpen, onToggleInfo, assistantAvailable = false, assistantActive = false, onOpenAssistant, reviewHref, reviewPending = 0, reviewTone = "pending", reviewTitle = "Review", readOnly = false, finishedRun = false, onReopen, onRetryAll, onOpenShell }: Props) {
   // Read undo/redo straight from the store (ADR-0014 / #226): they have no
   // component-local dependency, unlike the prop-drilled add/merge callbacks, so
   // the point-of-use selector idiom is the right fit. `canUndo`/`canRedo` are
@@ -229,27 +234,39 @@ export default function EditToolbar({ onAddNode, onAddNote, onAddNodeFromYaml, l
         </>
       )}
 
-      {/* #465 slice 2 (F1): reach the Run-info / Repositories sidebar on a live
-          run whose node is running. Shown only for those run tabs — elsewhere
-          the panel is reachable by deselecting, so the button would be a no-op. */}
-      {showRunInfo && onToggleRunInfo && (
+      {/* #752: the Review quick access — navigation, not a toggle (no
+          `aria-pressed`). The pill is the pending count; its tone is the nuance. */}
+      {reviewHref && (
         <>
           {!readOnly && <span className="mx-0.5 h-4 w-px bg-line" />}
 
-          <Tooltip content="Run repositories">
-            <button
-              data-testid="toolbar-run-info"
-              aria-label="Run repositories"
-              aria-pressed={runInfoActive}
-              onClick={onToggleRunInfo}
-              className={`grid h-7 w-7 cursor-pointer place-items-center rounded transition-colors ${
-                runInfoActive
-                  ? "bg-acc text-bg-0"
-                  : "text-fg-3 hover:bg-bg-4 hover:text-fg active:bg-acc active:text-bg-0"
-              }`}
+          <Tooltip content={reviewTitle}>
+            <a
+              href={reviewHref}
+              data-testid="toolbar-review"
+              aria-label={reviewTitle}
+              data-pending={reviewPending > 0 ? reviewPending : undefined}
+              data-tone={reviewPending > 0 ? reviewTone : undefined}
+              className="relative grid h-7 w-7 cursor-pointer place-items-center rounded text-fg-3 transition-colors hover:bg-bg-4 hover:text-fg active:bg-acc active:text-bg-0"
             >
-              <FolderGit2 size={14} />
-            </button>
+              <FileDiff size={14} />
+              {reviewPending > 0 && (
+                <span
+                  data-testid="toolbar-review-pill"
+                  aria-hidden
+                  className={`absolute -right-[5px] -top-1 box-border grid h-[15px] min-w-[15px] place-items-center rounded-[8px] border-2 border-bg-2 px-1 font-sans font-semibold leading-none ${
+                    reviewTone === "proposed"
+                      ? "bg-st-await text-[#1a0f00]"
+                      : reviewTone === "unread"
+                        ? "bg-st-running text-white"
+                        : "bg-st-running-bg text-st-running shadow-[inset_0_0_0_1px_rgba(59,130,246,.35)]"
+                  }`}
+                  style={{ fontSize: "9.5px" }}
+                >
+                  {reviewPending}
+                </span>
+              )}
+            </a>
           </Tooltip>
         </>
       )}
@@ -257,7 +274,7 @@ export default function EditToolbar({ onAddNode, onAddNote, onAddNodeFromYaml, l
       {(onToggleInfo || (assistantAvailable && onOpenAssistant)) && (
         <>
           {/* #315: no leading separator when the info group is the sole control. */}
-          {!readOnly && !showRunInfo && <span className="mx-0.5 h-4 w-px bg-line" />}
+          {!readOnly && !reviewHref && <span className="mx-0.5 h-4 w-px bg-line" />}
 
           {/* #302 / ADR-0048: the "agent" glyph, immediately left of `(i)`, both
               opening the same Pipeline info panel — the Bot jumps straight to the

--- a/frontend/src/components/PipelineInfoPanel.test.tsx
+++ b/frontend/src/components/PipelineInfoPanel.test.tsx
@@ -538,7 +538,7 @@ describe("PipelineInfoPanel — Diff tab (#748)", () => {
     const tabs = screen
       .getAllByTestId(/^info-tab-/)
       .map((t) => t.getAttribute("data-testid"));
-    expect(tabs).toEqual(["info-tab-info", "info-tab-diff", "info-tab-manager", "info-tab-yaml"]);
+    expect(tabs).toEqual(["info-tab-info", "info-tab-diff", "info-tab-repositories", "info-tab-manager", "info-tab-yaml"]);
   });
 
   it("hides the Diff tab for a template (no Run)", () => {
@@ -642,5 +642,90 @@ describe("PipelineInfoPanel — Diff tab (#748)", () => {
     expect(screen.getByTestId("diff-tab-dot")).toBeInTheDocument();
     fireEvent.click(screen.getByTestId("info-tab-diff"));
     expect(screen.queryByTestId("diff-tab-dot")).toBeNull();
+  });
+});
+
+// #752: Repositories is a tab of the Run panel (the second half of #566), and
+// what the deleted `RunInfoSidebar` carried besides it lives in the Info header.
+describe("PipelineInfoPanel — Repositories tab and Info header (#752)", () => {
+  it("offers Info | Diff | Repositories | Manager | YAML for a Run, and no Repositories tab on a template", () => {
+    renderPanel(makeRun());
+    expect(screen.getByTestId("info-tab-repositories")).toHaveTextContent("Repositories");
+    expect(screen.queryByTestId("repositories-tab")).toBeNull();
+    fireEvent.click(screen.getByTestId("info-tab-repositories"));
+    expect(screen.getByTestId("repositories-tab")).toBeInTheDocument();
+    expect(screen.queryByTestId("run-stats")).toBeNull();
+  });
+
+  it("hides the Repositories tab for a template (no Run)", () => {
+    renderPanel(null);
+    expect(screen.queryByTestId("info-tab-repositories")).toBeNull();
+  });
+
+  it("lists the Run's repositories in the tab — primary locked, secondaries with their mode — frozen on a terminal Run", () => {
+    renderPanel(
+      makeRun({
+        status: "completed",
+        target_repo: "/repos/primary",
+        target_repos: [{ repo: "/repos/lib", alias: "lib", sha: "cafebabe1234", base_branch: "main", read_only: true }],
+      }),
+    );
+    fireEvent.click(screen.getByTestId("info-tab-repositories"));
+    expect(screen.getByTestId("run-repositories")).toBeInTheDocument();
+    expect(screen.getByTestId("primary-repo-row")).toHaveTextContent("/repos/primary");
+    expect(screen.getByTestId("secondary-repo-lib")).toHaveTextContent("/repos/lib");
+    expect(screen.getByTestId("secondary-repo-mode-lib")).toHaveTextContent("READ-ONLY");
+    expect(screen.queryByTestId("remove-secondary-repo-lib")).toBeNull();
+    expect(screen.queryByTestId("add-secondary-repo")).toBeNull();
+  });
+
+  it("offers add on a live Run and says so when the Run recorded no repository", () => {
+    const { unmount } = renderPanel(makeRun({ status: "running", target_repo: "/repos/primary", target_repos: [] }));
+    fireEvent.click(screen.getByTestId("info-tab-repositories"));
+    expect(screen.getByTestId("add-secondary-repo")).toBeInTheDocument();
+    expect(screen.getByTestId("spawn-visibility-note")).toBeInTheDocument();
+    unmount();
+    renderPanel(makeRun({ status: "running" }));
+    fireEvent.click(screen.getByTestId("info-tab-repositories"));
+    expect(screen.getByTestId("repositories-tab-empty")).toBeInTheDocument();
+    expect(screen.queryByTestId("run-repositories")).toBeNull();
+  });
+
+  it("Info states why a failed run failed, and names the terminal (#503)", () => {
+    renderPanel(makeRun({ status: "failed", failure_reason: "merge conflict on ship: 20 conflicting file(s)" }));
+    const box = screen.getByTestId("run-failure-reason");
+    expect(box).toHaveTextContent("Failed");
+    expect(box).toHaveTextContent("20 conflicting file(s)");
+    expect(screen.queryByTestId("run-awaiting-reason")).toBeNull();
+  });
+
+  it("Info states why an incident-parked run awaits the user, not an interactive wait (#598)", () => {
+    const { unmount } = renderPanel(
+      makeRun({ status: "awaiting_user", awaiting_reason: "session_died: tmux session … no longer exists", awaiting_reason_code: "session_died" } as Partial<RunState>),
+    );
+    expect(screen.getByTestId("run-awaiting-reason")).toHaveTextContent("Interrupted");
+    expect(screen.getByTestId("run-awaiting-reason")).toHaveTextContent("no longer exists");
+    unmount();
+    renderPanel(makeRun({ status: "awaiting_user" }));
+    expect(screen.queryByTestId("run-awaiting-reason")).toBeNull();
+    expect(screen.queryByTestId("run-failure-reason")).toBeNull();
+  });
+
+  it("Info shows the frozen harness when named (#551) and the editing / archived note (#315)", () => {
+    const { unmount } = renderPanel(makeRun({ status: "running", harness: "opencode" } as Partial<RunState>));
+    expect(screen.getByTestId("run-harness")).toHaveTextContent("opencode");
+    expect(screen.getByTestId("run-info-note")).toHaveTextContent("changes sync to template");
+    unmount();
+    renderPanel(makeRun({ status: "archived" }));
+    expect(screen.queryByTestId("run-harness")).toBeNull();
+    expect(screen.getByTestId("run-info-note")).toHaveTextContent("Archived run");
+    expect(screen.getByTestId("run-info-note")).toHaveTextContent("read-only");
+  });
+
+  it("shows no note, reason or harness on a template", () => {
+    renderPanel(null);
+    expect(screen.queryByTestId("run-info-note")).toBeNull();
+    expect(screen.queryByTestId("run-harness")).toBeNull();
+    expect(screen.queryByTestId("run-failure-reason")).toBeNull();
   });
 });

--- a/frontend/src/components/PipelineInfoPanel.tsx
+++ b/frontend/src/components/PipelineInfoPanel.tsx
@@ -1,8 +1,9 @@
 import { useState, useMemo, useRef, useEffect, useCallback } from "react";
-import { Info, Terminal, X, FileText, Code, Box, Loader, Bot, Copy, Download, ChevronDown, ChevronRight, Play, PowerOff, FileDiff } from "lucide-react";
+import { Info, Terminal, X, FileText, Code, Box, Loader, Bot, Copy, Download, ChevronDown, ChevronRight, Play, PowerOff, FileDiff, FolderGit2 } from "lucide-react";
 import { SectionHead } from "./InspectorPrimitives";
 import TmuxTerminal from "./TmuxTerminal";
 import DiffTab from "./DiffTab";
+import RepositoriesSection from "./RepositoriesSection";
 import { deliverySignature } from "../lib/diffTab";
 import { useReviewUnread } from "../hooks/useReviewUnread";
 import type { CollapsedFiles } from "../lib/diffTab";
@@ -15,7 +16,7 @@ import { formatEstCost } from "../lib/costLabel";
 import { serializePipeline } from "../lib/serializePipeline";
 import { highlightYaml } from "./yamlHighlight";
 
-export type TabId = "info" | "diff" | "manager" | "yaml" | "assistant";
+export type TabId = "info" | "diff" | "repositories" | "manager" | "yaml" | "assistant";
 
 function StatRow({
   label,
@@ -103,7 +104,7 @@ export default function PipelineInfoPanel({
   const hasAssistant = !run && !!assistantId;
   const [activeTab, setActiveTab] = useState<TabId>(initialTab ?? "info");
   const resolvedTab =
-    ((activeTab === "manager" || activeTab === "diff") && !run) ||
+    ((activeTab === "manager" || activeTab === "diff" || activeTab === "repositories") && !run) ||
     (activeTab === "assistant" && !hasAssistant)
       ? "info"
       : activeTab;
@@ -140,6 +141,11 @@ export default function PipelineInfoPanel({
   const tabs: { id: TabId; label: string; icon: typeof Info; show: boolean }[] = [
     { id: "info", label: "Info", icon: FileText, show: true },
     { id: "diff", label: "Diff", icon: FileDiff, show: run != null },
+    // #752 (closing the second half of #566): the Repositories view is a tab of
+    // the Run panel — `Info | Diff | Repositories | Manager | YAML` — reachable
+    // on any selection, archived Runs included (frozen list). No dot: nothing
+    // asynchronous happens to repositories; errors show inline in the tab.
+    { id: "repositories", label: "Repositories", icon: FolderGit2, show: run != null },
     { id: "manager", label: "Manager", icon: Terminal, show: run != null },
     { id: "assistant", label: "Assistant", icon: Bot, show: hasAssistant },
     { id: "yaml", label: "YAML", icon: Code, show: true },
@@ -183,7 +189,7 @@ export default function PipelineInfoPanel({
               key={t.id}
               data-testid={`info-tab-${t.id}`}
               onClick={() => selectTab(t.id)}
-              className={`flex items-center gap-1.5 px-3 py-1.5 transition-colors cursor-pointer ${
+              className={`flex items-center gap-1.5 px-2 py-1.5 transition-colors cursor-pointer ${
                 resolvedTab === t.id
                   ? "border-b-2 border-acc text-fg font-medium"
                   : "text-fg-3 hover:text-fg-2"
@@ -239,6 +245,18 @@ export default function PipelineInfoPanel({
           collapsed={diffCollapsed}
           onCollapsedChange={onDiffCollapsedChange}
         />
+      )}
+
+      {resolvedTab === "repositories" && run && (
+        <div data-testid="repositories-tab" className="flex flex-col">
+          {run.target_repo ? (
+            <RepositoriesSection key={run.run_id} run={run} onEdited={onRefreshRun} />
+          ) : (
+            <div className="px-3 py-3 text-fg-4" style={{ fontSize: "11px" }} data-testid="repositories-tab-empty">
+              This Run recorded no target repository — it works in the daemon's own checkout.
+            </div>
+          )}
+        </div>
       )}
 
       {resolvedTab === "manager" && run && managerSession && (
@@ -615,6 +633,50 @@ function InfoTab({
             </span>
           )}
         </div>
+
+        {/* #752: what the standalone Run-info sidebar carried besides Repositories
+            lives here now — the failure / awaiting reason (#503, #598), the frozen
+            harness (#551) and the editing note (#315). Clicking a red dot lands on
+            this tab, so the failure must be the first thing it says. */}
+        {run?.failure_reason && (
+          <div
+            className="mt-2 rounded border border-st-failed/30 bg-st-failed-bg px-2 py-1.5 text-fg-2"
+            style={{ fontSize: "10.5px" }}
+            data-testid="run-failure-reason"
+          >
+            <div className="font-medium text-st-failed">
+              {run.status === "halted" ? "Halted" : run.status === "skipped" ? "Skipped" : "Failed"}
+            </div>
+            <div className="mt-0.5 break-words">{run.failure_reason}</div>
+          </div>
+        )}
+        {run?.awaiting_reason && (
+          <div
+            className="mt-2 rounded border border-st-await/30 bg-st-await-bg px-2 py-1.5 text-fg-2"
+            style={{ fontSize: "10.5px" }}
+            data-testid="run-awaiting-reason"
+          >
+            <div className="font-medium text-st-await">Interrupted · awaiting you</div>
+            <div className="mt-0.5 break-words">{run.awaiting_reason}</div>
+          </div>
+        )}
+        {run?.harness && (
+          <div className="mt-2 flex items-center gap-1.5 text-fg-3" style={{ fontSize: "10.5px" }} data-testid="run-harness">
+            <span className="text-fg-4">Harness</span>
+            <span className="rounded bg-bg-3 px-1.5 py-0.5 font-mono text-fg-2">{run.harness}</span>
+          </div>
+        )}
+        {run && (
+          <div
+            className="mt-2 rounded border border-line-strong bg-bg-3 px-2 py-1.5 text-fg-3"
+            style={{ fontSize: "10.5px" }}
+            data-testid="run-info-note"
+          >
+            {run.status === "archived"
+              ? "Archived run · read-only · outputs preserved"
+              : "Editing run-scoped pipeline · changes sync to template"}
+          </div>
+        )}
 
         {variables.length > 0 && (
           <div className="mt-3 flex flex-col gap-1" data-testid="info-panel-variables">

--- a/frontend/src/components/RepositoriesSection.test.tsx
+++ b/frontend/src/components/RepositoriesSection.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import RunInfoSidebar from "./RunInfoSidebar";
+import RepositoriesSection from "./RepositoriesSection";
 import type { RunState, RunStatus, RepoPin } from "../types";
 import { editRunRepos, validateRepo, listBranches } from "../api";
 
@@ -52,105 +52,15 @@ function makeMultiRepoRun(
   } as unknown as RunState;
 }
 
-describe("RunInfoSidebar", () => {
-  it("shows the sync-to-template note for a live run", () => {
-    render(<RunInfoSidebar run={makeRun("running")} />);
-    const note = screen.getByTestId("run-info-note");
-    expect(note.textContent).toContain("changes sync to template");
-    expect(note.textContent).not.toContain("read-only");
-  });
-
-  it("shows a read-only archived note for an archived run (#315)", () => {
-    render(<RunInfoSidebar run={makeRun("archived")} />);
-    const note = screen.getByTestId("run-info-note");
-    expect(note.textContent).toContain("Archived run");
-    expect(note.textContent).toContain("read-only");
-    expect(note.textContent).not.toContain("changes sync to template");
-  });
-
-  it("renders the pipeline name and run id in both states", () => {
-    render(<RunInfoSidebar run={makeRun("archived")} />);
-    expect(screen.getByText("My Pipeline")).toBeInTheDocument();
-    expect(screen.getByText("20260704-000000-abc1234")).toBeInTheDocument();
-  });
-
-  // #503: this is the panel a user reaches by clicking a red dot. It used to talk
-  // about pipeline editing and say nothing at all about the failure.
-  it("states why a failed run failed", () => {
-    render(
-      <RunInfoSidebar
-        run={makeRun("failed", "merge conflict on ship: 20 conflicting file(s)")}
-      />,
-    );
-    const box = screen.getByTestId("run-failure-reason");
-    expect(box.textContent).toContain("Failed");
-    expect(box.textContent).toContain("20 conflicting file(s)");
-  });
-
-  it("names the terminal it is explaining", () => {
-    render(<RunInfoSidebar run={makeRun("halted", "stop condition met")} />);
-    expect(screen.getByTestId("run-failure-reason").textContent).toContain("Halted");
-  });
-
-  it("shows no failure box on a green or live run", () => {
-    render(<RunInfoSidebar run={makeRun("completed")} />);
-    expect(screen.queryByTestId("run-failure-reason")).toBeNull();
-  });
-
-  // #601 / ADR-0049: an incident-parked run (awaiting_user with a reason) states
-  // WHY it is parked, without the operator reading journalctl.
-  it("states why an incident-parked run is awaiting the user", () => {
-    render(
-      <RunInfoSidebar
-        run={
-          {
-            ...makeRun("awaiting_user"),
-            awaiting_reason: "session_died: tmux session … no longer exists",
-            awaiting_reason_code: "session_died",
-          } as unknown as RunState
-        }
-      />,
-    );
-    const box = screen.getByTestId("run-awaiting-reason");
-    expect(box.textContent).toContain("Interrupted");
-    expect(box.textContent).toContain("no longer exists");
-  });
-
-  it("shows no awaiting box for an interactive wait (no reason)", () => {
-    // An interactive awaiting_user (a node asking its user) carries no incident
-    // reason, so the box must not appear — the two awaiting causes stay distinct.
-    render(<RunInfoSidebar run={makeRun("awaiting_user")} />);
-    expect(screen.queryByTestId("run-awaiting-reason")).toBeNull();
-  });
-
-  // #551 (ADR-0046): the frozen Run harness is visible in the panel.
-  it("shows the Run's frozen harness when it named one", () => {
-    render(
-      <RunInfoSidebar run={{ ...makeRun("running"), harness: "opencode" } as unknown as RunState} />,
-    );
-    const chip = screen.getByTestId("run-harness");
-    expect(chip.textContent).toContain("Harness");
-    expect(chip.textContent).toContain("opencode");
-  });
-
-  it("shows no harness chip when the Run inherited the default", () => {
-    // Absent harness = inherited the instance default (and the floor) — the panel does
-    // not spell that out per-Run.
-    render(<RunInfoSidebar run={makeRun("running")} />);
-    expect(screen.queryByTestId("run-harness")).toBeNull();
-  });
-
+// #752: the Repositories section moved from the standalone `RunInfoSidebar`
+// (deleted) into the Run panel's Repositories tab. Same content, same test ids.
+describe("RepositoriesSection (Run panel · Repositories tab)", () => {
   // #465 slice 2 — the Repositories section.
-  it("shows no Repositories section for a mono-repo run (no target_repo)", () => {
-    render(<RunInfoSidebar run={makeRun("running")} />);
-    expect(screen.queryByTestId("run-repositories")).toBeNull();
-  });
-
   it("renders the primary locked and the secondaries with a remove button", () => {
     const run = makeMultiRepoRun("running", [
       { repo: "/repos/lib", alias: "lib", sha: "cafebabe1234", base_branch: "main" },
     ]);
-    render(<RunInfoSidebar run={run} onEdited={() => {}} />);
+    render(<RepositoriesSection run={run} onEdited={() => {}} />);
 
     // Primary is locked: badge present, no remove button on its row.
     const primary = screen.getByTestId("primary-repo-row");
@@ -171,14 +81,14 @@ describe("RunInfoSidebar", () => {
       { repo: "/repos/rw", alias: "rw", sha: "aaaa1111" },
       { repo: "/repos/ro", alias: "ro", sha: "bbbb2222", read_only: true },
     ]);
-    render(<RunInfoSidebar run={run} onEdited={() => {}} />);
+    render(<RepositoriesSection run={run} onEdited={() => {}} />);
     expect(screen.getByTestId("secondary-repo-mode-rw").textContent).toBe("WRITABLE");
     expect(screen.getByTestId("secondary-repo-mode-ro").textContent).toBe("READ-ONLY");
   });
 
   it("adds a read-only draft with read_only:true in the PATCH (ADR-0047)", async () => {
     const run = makeMultiRepoRun("running", []);
-    render(<RunInfoSidebar run={run} onEdited={() => {}} />);
+    render(<RepositoriesSection run={run} onEdited={() => {}} />);
 
     fireEvent.click(screen.getByTestId("add-secondary-repo"));
     const draft = screen.getByTestId("secondary-repo-draft");
@@ -209,7 +119,7 @@ describe("RunInfoSidebar", () => {
     const run = makeMultiRepoRun("running", [
       { repo: "/repos/lib", alias: "lib", sha: "cafebabe1234" },
     ]);
-    render(<RunInfoSidebar run={run} onEdited={onEdited} />);
+    render(<RepositoriesSection run={run} onEdited={onEdited} />);
 
     fireEvent.click(screen.getByTestId("remove-secondary-repo-lib"));
 
@@ -219,7 +129,7 @@ describe("RunInfoSidebar", () => {
 
   it("the + Add repository button reveals a self-validating draft row", () => {
     const run = makeMultiRepoRun("running", []);
-    render(<RunInfoSidebar run={run} onEdited={() => {}} />);
+    render(<RepositoriesSection run={run} onEdited={() => {}} />);
 
     expect(screen.queryByTestId("secondary-repo-draft")).toBeNull();
     fireEvent.click(screen.getByTestId("add-secondary-repo"));
@@ -228,7 +138,7 @@ describe("RunInfoSidebar", () => {
 
   it("carries the spawn-time visibility note on a live run", () => {
     const run = makeMultiRepoRun("running", []);
-    render(<RunInfoSidebar run={run} onEdited={() => {}} />);
+    render(<RepositoriesSection run={run} onEdited={() => {}} />);
     expect(screen.getByTestId("spawn-visibility-note").textContent).toContain(
       "launched after",
     );
@@ -238,7 +148,7 @@ describe("RunInfoSidebar", () => {
     const run = makeMultiRepoRun("completed", [
       { repo: "/repos/lib", alias: "lib", sha: "cafebabe1234" },
     ]);
-    render(<RunInfoSidebar run={run} />);
+    render(<RepositoriesSection run={run} />);
 
     // The section and the secondary still render (read-only)...
     expect(screen.getByTestId("run-repositories")).toBeInTheDocument();

--- a/frontend/src/components/RepositoriesSection.tsx
+++ b/frontend/src/components/RepositoriesSection.tsx
@@ -14,104 +14,17 @@ const LIVE_STATUSES: ReadonlySet<string> = new Set([
 ]);
 
 /**
- * Right-panel header shown when a run-scoped edit tab is open with nothing
- * selected on the canvas. For a live/completed run it notes that edits sync
- * back to the template; for an archived run (#315) the canvas is read-only
- * (its worktree + `pipeline.yaml` are gone and Save is disabled), so it says
- * so instead of the misleading "changes sync to template" note.
- *
- * A Run that ended non-green also states **why**, above the editing note (#503).
- * That is the panel a user reaches by clicking a red dot, and it used to talk
- * about pipeline editing while saying nothing at all about the failure.
- *
- * #465 slice 2 (ADR-0042): when the Run names a primary repo, it also hosts the
- * **Repositories** section — the primary locked, the read-only secondaries
- * editable on a live Run (add / remove). Editing here is **spawn-time visible**:
- * a change touches nodes launched after it, never the ones already running.
+ * The **Repositories** tab of the Run panel (#752, closing the second half of
+ * #566): the primary + secondary repositories of a Run, with mid-run add/remove
+ * of secondaries (#465 slice 2, ADR-0042). It used to be a section of the
+ * standalone `RunInfoSidebar` — mounted only when nothing was selected on the
+ * canvas, reached through a toolbar toggle; both are gone. The content is
+ * unchanged: primary locked, secondaries editable on a live Run (add / remove,
+ * writable or read-only per ADR-0047), frozen on a terminal or archived Run,
+ * inline error strip, spawn-visibility note. Editing here is **spawn-time
+ * visible**: a change touches nodes launched after it, never the ones running.
  */
-export default function RunInfoSidebar({
-  run,
-  onEdited,
-}: {
-  run: RunState;
-  /** Called after a successful add/remove so the parent re-fetches the Run. */
-  onEdited?: () => void;
-}) {
-  const archived = run.status === "archived";
-  return (
-    <aside className="flex h-full flex-col bg-bg-2" style={{ fontSize: "12px" }}>
-      <div className="border-b border-line px-3 py-3">
-        <div className="font-medium text-fg">{run.pipeline_name}</div>
-        <div className="mt-0.5 font-mono text-fg-4" style={{ fontSize: "10px" }}>
-          {run.run_id}
-        </div>
-        {run.failure_reason && (
-          <div
-            className="mt-2 rounded border border-st-failed/30 bg-st-failed-bg px-2 py-1.5 text-fg-2"
-            style={{ fontSize: "10.5px" }}
-            data-testid="run-failure-reason"
-          >
-            <div className="font-medium text-st-failed">
-              {run.status === "halted"
-                ? "Halted"
-                : run.status === "skipped"
-                  ? "Skipped"
-                  : "Failed"}
-            </div>
-            <div className="mt-0.5 break-words">{run.failure_reason}</div>
-          </div>
-        )}
-        {/* #598 / ADR-0049: an incident-parked run is `awaiting_user` with an
-            `awaiting_reason` — distinct from an interactive wait (no reason) and
-            from a terminal failure (`failure_reason`). Surface it so the operator
-            sees WHY the run parked and can Reopen/Retry it. */}
-        {run.awaiting_reason && (
-          <div
-            className="mt-2 rounded border border-st-await/30 bg-st-await-bg px-2 py-1.5 text-fg-2"
-            style={{ fontSize: "10.5px" }}
-            data-testid="run-awaiting-reason"
-          >
-            <div className="font-medium text-st-await">Interrupted · awaiting you</div>
-            <div className="mt-0.5 break-words">{run.awaiting_reason}</div>
-          </div>
-        )}
-        <div
-          className="mt-2 rounded border border-line-strong bg-bg-3 px-2 py-1.5 text-fg-3"
-          style={{ fontSize: "10.5px" }}
-          data-testid="run-info-note"
-        >
-          {archived
-            ? "Archived run · read-only · outputs preserved"
-            : "Editing run-scoped pipeline · changes sync to template"}
-        </div>
-        {/* #551 (ADR-0046): the harness this Run was FROZEN on — the `run` tier that
-            made it an A/B of the same pipeline on another harness. Shown only when the
-            Run named one; absence means it inherited the instance default (and the
-            `claude` floor), which the panel does not need to spell out per-Run. */}
-        {run.harness && (
-          <div
-            className="mt-2 flex items-center gap-1.5 text-fg-3"
-            style={{ fontSize: "10.5px" }}
-            data-testid="run-harness"
-          >
-            <span className="text-fg-4">Harness</span>
-            <span className="rounded bg-bg-3 px-1.5 py-0.5 font-mono text-fg-2">
-              {run.harness}
-            </span>
-          </div>
-        )}
-      </div>
-
-      {run.target_repo && (
-        <RepositoriesSection run={run} onEdited={onEdited} />
-      )}
-    </aside>
-  );
-}
-
-/** The primary + secondary repositories of a Run, with mid-run add/remove of
- *  read-only secondaries (#465 slice 2). */
-function RepositoriesSection({
+export default function RepositoriesSection({
   run,
   onEdited,
 }: {

--- a/frontend/src/components/review/CommentCard.tsx
+++ b/frontend/src/components/review/CommentCard.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useRef, useState } from "react";
-import { Bot, Check, CheckCircle2, ChevronRight, Cpu, Hourglass, Lock, MessageSquare, Pencil, Trash2, Undo2, User } from "lucide-react";
+import { Bot, Check, CheckCircle2, ChevronRight, CornerDownRight, Cpu, History, Hourglass, Lock, MessageSquare, Pencil, Trash2, Undo2, User } from "lucide-react";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import type { AuthorKind, CommentState, ReviewEntry } from "../../lib/reviewComments";
-import { anchorLabel, authorKind, authorLabel, commentState, firstWords, footerStatus, plural, relativeTime } from "../../lib/reviewComments";
+import { anchorLabel, authorKind, authorLabel, commentState, firstWords, footerStatus, parseExcerpt, plural, relativeTime } from "../../lib/reviewComments";
 import type { ReviewComment } from "../../types";
 
 /**
@@ -25,6 +25,16 @@ import type { ReviewComment } from "../../types";
  * **collapses** to one line (icon · anchor · time · first words · reply count ·
  * resolved-by); its header click expands it. A reply that lands live flashes
  * the card's outline for two seconds.
+ *
+ * #752 — re-mapped comments (ADR-0067 §5). A **reported** card is identical to a
+ * plain one; only when the line *number* differs does a discreet `↳ from R212`
+ * chip sit in the header. An **outdated** card (its line changed on the displayed
+ * destination) is collapsed by default — history glyph in the stale amber, state
+ * icon, author, `R239 on <ref>`, time, first words, reply count, lock — and
+ * expands to the **original hunk** first (the excerpt stored at send time, the
+ * commented line in the stale tint, captioned with the ref it was written on),
+ * then body, replies and the usual footer: outdated is a display property, not a
+ * state, so Resolve / Reopen work as on any sent card.
  */
 
 interface Props {
@@ -49,6 +59,10 @@ interface Props {
   onReopen?: () => void;
   /** The card was looked at (hovered, or in view for a moment): clear its unread dots. */
   onSeen?: () => void;
+  /** #752 — sent cards only: the line changed on the displayed destination. `writtenOn` labels the ref it was written against. */
+  outdated?: { writtenOn: string };
+  /** #752 — sent cards only: the written line, when the reported number differs. */
+  movedFrom?: number;
 }
 
 const REMARK_PLUGINS = [remarkGfm];
@@ -68,6 +82,8 @@ export default function CommentCard({
   onResolve,
   onReopen,
   onSeen,
+  outdated,
+  movedFrom,
 }: Props) {
   const label = anchorLabel(entry.anchor);
   const body = (text: string) => (
@@ -93,6 +109,8 @@ export default function CommentCard({
         onResolve={onResolve}
         onReopen={onReopen}
         onSeen={onSeen}
+        outdated={outdated}
+        movedFrom={movedFrom}
       />
     );
   }
@@ -199,6 +217,8 @@ function SentCard({
   onResolve,
   onReopen,
   onSeen,
+  outdated,
+  movedFrom,
 }: {
   comment: ReviewComment;
   label: string;
@@ -210,18 +230,23 @@ function SentCard({
   onResolve?: () => void;
   onReopen?: () => void;
   onSeen?: () => void;
+  outdated?: { writtenOn: string };
+  movedFrom?: number;
 }) {
   const state = commentState(c);
   const replies = c.replies ?? [];
   const footer = footerStatus(c);
   // Resolved ⇒ collapsed (GitHub-like), until the header is clicked. The
   // expansion is keyed on the resolution it was opened for, so a comment
-  // resolved again later collapses again without an effect.
+  // resolved again later collapses again without an effect. #752: an outdated
+  // card collapses the same way (keyed on "outdated" while it stays so).
   const [expandedFor, setExpandedFor] = useState<string | null>(null);
-  const resolutionKey = c.resolved_at ?? "resolved";
-  const collapsed = state === "resolved" && expandedFor !== resolutionKey;
+  const collapsible = state === "resolved" || !!outdated;
+  const resolutionKey = outdated ? `outdated:${c.resolved_at ?? ""}` : (c.resolved_at ?? "resolved");
+  const collapsed = collapsible && expandedFor !== resolutionKey;
   const setExpanded = (fn: (open: boolean) => boolean) =>
     setExpandedFor((prev) => (fn(prev === resolutionKey) ? resolutionKey : null));
+  const originalHunk = outdated ? parseExcerpt(c.excerpt) : [];
 
   // Seen: hover, or in view for a moment. Only while something is unread.
   const rootRef = useRef<HTMLDivElement | null>(null);
@@ -266,14 +291,16 @@ function SentCard({
       data-unread={unread > 0 ? unread : undefined}
       data-anchor={label}
       data-comment-id={c.id}
+      data-outdated={outdated ? "true" : undefined}
+      data-moved-from={movedFrom}
     >
       <div
-        role={state === "resolved" ? "button" : undefined}
-        tabIndex={state === "resolved" ? 0 : undefined}
-        aria-expanded={state === "resolved" ? !collapsed : undefined}
-        onClick={state === "resolved" ? () => setExpanded((e) => !e) : undefined}
+        role={collapsible ? "button" : undefined}
+        tabIndex={collapsible ? 0 : undefined}
+        aria-expanded={collapsible ? !collapsed : undefined}
+        onClick={collapsible ? () => setExpanded((e) => !e) : undefined}
         onKeyDown={
-          state === "resolved"
+          collapsible
             ? (e) => {
                 if (e.key === "Enter" || e.key === " ") {
                   e.preventDefault();
@@ -284,15 +311,43 @@ function SentCard({
         }
         data-testid="review-comment-header"
         className={`flex items-center gap-2 bg-bg-3 px-2.5 py-[5px] text-fg-3 ${collapsed ? "cursor-pointer" : "border-b border-line"}`}
-        style={{ fontSize: "10.5px", borderLeft: `2px solid ${STATE_COLOR[state]}` }}
+        style={{ fontSize: "10.5px", borderLeft: `2px solid ${outdated ? "var(--color-st-stale)" : STATE_COLOR[state]}` }}
       >
+        {outdated && (
+          <span className="inline-flex items-center text-st-stale" title="Outdated — the line changed since this comment was written" data-testid="review-comment-outdated">
+            <History size={11} />
+          </span>
+        )}
         <StateIcon state={state} title={stateTitle} />
         <AuthorIcon author={c.author} />
-        <span className="font-mono text-fg-4" style={{ fontSize: "10px" }}>
-          {label}
-        </span>
+        {outdated ? (
+          <span
+            className="font-mono text-fg-4"
+            style={{ fontSize: "10px" }}
+            title={`Written on ${outdated.writtenOn}, at ${label}`}
+            data-testid="review-comment-written-on"
+          >
+            {c.side === "old" ? "L" : "R"}
+            {c.line} <span className="font-sans text-fg-4">on</span> {outdated.writtenOn}
+          </span>
+        ) : (
+          <span className="font-mono text-fg-4" style={{ fontSize: "10px" }}>
+            {label}
+          </span>
+        )}
+        {movedFrom !== undefined && !outdated && (
+          <span
+            className="inline-flex cursor-help items-center gap-0.5 rounded px-1 font-mono text-fg-4 hover:bg-bg-4 hover:text-fg-2"
+            style={{ fontSize: "10px" }}
+            title={`Written at ${c.side === "old" ? "L" : "R"}${movedFrom} on ${pairLabel.split(" → ")[c.side === "old" ? 0 : 1] ?? pairLabel}; the line is unchanged, so it follows it here.`}
+            data-testid="review-comment-moved-from"
+          >
+            <CornerDownRight size={10} /> from {c.side === "old" ? "L" : "R"}
+            {movedFrom}
+          </span>
+        )}
         <span className="text-fg-4">· {relativeTime(c.sent_at)}</span>
-        {state === "resolved" && (
+        {collapsible && (
           <span className={`text-fg-4 transition-transform ${collapsed ? "" : "rotate-90"}`} aria-hidden>
             <ChevronRight size={10} />
           </span>
@@ -327,6 +382,40 @@ function SentCard({
 
       {!collapsed && (
         <>
+          {outdated && (
+            <div className="border-b border-line bg-bg-1" data-testid="review-comment-original-hunk">
+              <div className="flex items-center gap-1.5 border-b border-line bg-bg-3 px-2.5 py-1 text-fg-4" style={{ fontSize: "10px" }}>
+                <History size={10} />
+                Original hunk ·{" "}
+                <span className="rounded border border-line-strong bg-bg-3 px-1.5 font-mono text-fg-2" style={{ fontSize: "10px" }}>
+                  {outdated.writtenOn}
+                </span>{" "}
+                · this is what the comment was written against
+              </div>
+              {originalHunk.length > 0 ? (
+                <div className="font-mono" style={{ fontSize: "10.5px", lineHeight: "18px" }}>
+                  {originalHunk.map((l) => (
+                    <div
+                      key={l.no}
+                      className="grid grid-cols-[44px_1fr]"
+                      data-testid="review-original-line"
+                      data-marked={l.marked ? "true" : undefined}
+                      style={l.marked ? { background: "var(--color-st-stale-bg)", boxShadow: "inset 3px 0 0 var(--color-st-stale)" } : undefined}
+                    >
+                      <span className="select-none pr-2 text-right text-fg-4" style={{ fontSize: "10px" }}>
+                        {l.no}
+                      </span>
+                      <span className="whitespace-pre pl-2.5 text-fg-2">{l.text}</span>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div className="px-2.5 py-1.5 text-fg-4" style={{ fontSize: "10px" }}>
+                  No excerpt was stored with this comment.
+                </div>
+              )}
+            </div>
+          )}
           {body(c.text)}
           {replies.length > 0 && (
             <div className="border-t border-line bg-bg-1" data-testid="review-comment-thread">
@@ -380,6 +469,11 @@ function SentCard({
               {c.id}
             </span>
             <span>· {pairLabel}</span>
+            {outdated && (
+              <span className="inline-flex items-center gap-1 text-st-stale" title="The line this comment points at changed on the displayed destination">
+                <History size={10} /> line changed
+              </span>
+            )}
             <span className="ml-auto inline-flex items-center gap-1.5" data-testid="review-comment-status" data-kind={footer.kind}>
               <FooterStatusView status={footer} />
               {state === "proposed" ? (

--- a/frontend/src/components/review/ReviewFileCard.tsx
+++ b/frontend/src/components/review/ReviewFileCard.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
-import { ChevronDown, ChevronRight, Copy, SquareArrowOutUpRight } from "lucide-react";
+import { ChevronDown, ChevronRight, Copy, History, SquareArrowOutUpRight } from "lucide-react";
 import { DiffView, DiffModeEnum, SplitSide } from "@git-diff-view/react";
 import type { DiffFile, ReviewSide } from "../../types";
 import { fetchRunFileAtRef } from "../../api";
@@ -37,6 +37,15 @@ import CommentCard, { Badge, StateIcon } from "./CommentCard";
  * badges are icon + count per state (proposed first). Hiding resolved comments
  * (the page's eye toggle) drops their cards from the extend slots but keeps the
  * green dot on the line.
+ *
+ * #752 (ADR-0067 §5): a sent entry the daemon re-mapped sits at its **reported**
+ * line like any other. An **outdated** entry (its line changed on the displayed
+ * destination) is not inline — guessing a nearby line would lie — but in an
+ * "N outdated comments" group at the top of the card, collapsed, with its
+ * original hunk inside; the header gets a history glyph. `showOutdated` hides
+ * those cards, never the counts. Drafts are never re-mapped: a draft whose line
+ * no longer exists in the displayed hunks is listed above the body with a small
+ * amber "line changed" hint, still editable, sendable, deletable.
  */
 
 /** What the page hands every card to act on comments (#750). */
@@ -71,6 +80,10 @@ export interface ReviewCommentsApi {
   markSeen: (comment: ReviewComment) => void;
   /** Eye toggle: false hides resolved cards (their anchor dot stays). */
   showResolved: boolean;
+  /** #752: false hides the outdated cards (counts stay). */
+  showOutdated: boolean;
+  /** #752: the label of the ref a sent comment was written against (its anchored side). */
+  writtenOnLabel: (comment: ReviewComment) => string;
 }
 
 interface Props {
@@ -197,30 +210,77 @@ export default function ReviewFileCard({
 
   // --- Comments (#750) --------------------------------------------------------
   const showResolved = comments?.showResolved ?? true;
+  const showOutdated = comments?.showOutdated ?? true;
+  /** #752: outdated entries live in the group at the top, never in the extend slots. */
+  const outdatedEntries = useMemo(() => entries.filter((e) => e.kind === "sent" && e.outdated), [entries]);
+  /** #752: drafts anchored on a line the displayed hunks no longer show — listed above the body. */
+  const orphanDrafts = useMemo<ReviewEntry[]>(() => {
+    const drafts = entries.filter((e) => e.kind === "draft");
+    if (drafts.length === 0) return [];
+    const present = new Set<string>();
+    for (const h of file.hunks) {
+      for (const l of h.lines) {
+        if (l.old_no != null) present.add(`old:${l.old_no}`);
+        if (l.new_no != null) present.add(`new:${l.new_no}`);
+      }
+    }
+    return drafts.filter((e) => !present.has(`${e.anchor.side}:${e.anchor.line}`));
+  }, [entries, file.hunks]);
+  const inlineEntries = useMemo(
+    () => entries.filter((e) => !(e.kind === "sent" && e.outdated) && !orphanDrafts.includes(e)),
+    [entries, orphanDrafts],
+  );
   const extendData = useMemo(() => {
     const oldFile: Record<string, { data: ReviewEntry }> = {};
     const newFile: Record<string, { data: ReviewEntry }> = {};
-    for (const e of entries) {
+    for (const e of inlineEntries) {
       if (!showResolved && e.kind === "sent" && e.comment.status === "resolved") continue;
       const slot = e.anchor.side === "old" ? oldFile : newFile;
       // Sent wins over a stale draft on the same line (entries are sorted so).
       if (!slot[String(e.anchor.line)]) slot[String(e.anchor.line)] = { data: e };
     }
     return { oldFile, newFile };
-  }, [entries, showResolved]);
+  }, [inlineEntries, showResolved]);
 
   const nDrafts = entries.filter((e) => e.kind === "draft").length;
   const nSent = entries.length - nDrafts;
+  const nOutdated = outdatedEntries.length;
   const sentStates = useMemo(
     () => stateCounts(entries.flatMap((e) => (e.kind === "sent" ? [e.comment] : []))),
     [entries],
   );
 
+  const renderCard = (entry: ReviewEntry) => {
+    if (!comments) return null;
+    const key = entry.kind === "draft" ? entry.draft.key : null;
+    const sent = entry.kind === "sent" ? entry.comment : null;
+    return (
+      <CommentCard
+        entry={entry}
+        sending={key !== null && comments.sendingKeys.has(key)}
+        startingManager={comments.startingManager}
+        pairLabel={comments.pairLabel}
+        sendDisabledReason={comments.sendDisabledReason}
+        onEdit={() => key && comments.editDraft(key)}
+        onDelete={() => key && comments.deleteDraft(key)}
+        onSend={() => key && comments.sendDraft(key)}
+        unread={sent ? comments.unreadOf(sent) : 0}
+        flash={sent ? comments.flashing.has(sent.id) : false}
+        deciding={sent ? comments.deciding.has(sent.id) : false}
+        onResolve={sent ? () => comments.resolve(sent) : undefined}
+        onReopen={sent ? () => comments.reopen(sent) : undefined}
+        onSeen={sent ? () => comments.markSeen(sent) : undefined}
+        outdated={entry.kind === "sent" && entry.outdated && sent ? { writtenOn: comments.writtenOnLabel(sent) } : undefined}
+        movedFrom={entry.kind === "sent" ? entry.movedFrom : undefined}
+      />
+    );
+  };
+
   /** Per-card CSS: dot + bar on anchored lines, `+` hidden where a comment sits. */
   const anchorCss = useMemo(() => {
-    if (entries.length === 0) return "";
+    if (inlineEntries.length === 0) return "";
     const rules: string[] = [];
-    for (const e of entries) {
+    for (const e of inlineEntries) {
       const color = e.kind === "draft" ? "var(--color-st-await)" : STATE_VAR[commentState(e.comment)];
       const { side, line } = e.anchor;
       // Split: `td.diff-line-<side>-num > span[data-line-num]`, content cell next.
@@ -236,7 +296,7 @@ export default function ReviewFileCard({
       rules.push(`${row} [data-add-widget]{display:none}`);
     }
     return rules.join("\n");
-  }, [entries, cssId]);
+  }, [inlineEntries, cssId]);
 
   const copyPath = () => {
     navigator.clipboard?.writeText(path).then(
@@ -266,6 +326,7 @@ export default function ReviewFileCard({
       data-sent={nSent}
       data-proposed={sentStates.proposed}
       data-resolved={sentStates.resolved}
+      data-outdated={nOutdated}
       className="mx-3 my-2.5 overflow-hidden rounded-md border border-line bg-bg-2"
     >
       {anchorCss && <style>{anchorCss}</style>}
@@ -314,6 +375,16 @@ export default function ReviewFileCard({
         )}
         <span className="ml-auto flex items-center gap-1.5" onClick={(e) => e.stopPropagation()}>
           {nDrafts > 0 && <Badge kind="draft">✎ {plural(nDrafts, "draft")}</Badge>}
+          {nOutdated > 0 && (
+            <span
+              className="inline-flex items-center gap-0.5 text-st-stale"
+              style={{ fontSize: "10px" }}
+              title={`${plural(nOutdated, "outdated comment")} — the line changed on this destination`}
+              data-testid="review-file-outdated"
+            >
+              <History size={10} /> {nOutdated}
+            </span>
+          )}
           {sentStates.proposed > 0 && (
             <span className="inline-flex items-center gap-0.5 text-st-await" style={{ fontSize: "10px" }} title={`${sentStates.proposed} resolution proposed`} data-testid="review-file-proposed">
               <StateIcon state="proposed" size={10} /> {sentStates.proposed}
@@ -355,6 +426,54 @@ export default function ReviewFileCard({
 
       {!collapsed && (
         <div data-testid="review-file-body" className="overflow-x-auto">
+          {nOutdated > 0 && comments && (
+            <div data-testid="review-outdated-group" data-hidden={showOutdated ? undefined : "true"} className="border-b border-line pb-1">
+              <div className="mx-3 mt-2 flex items-center gap-2 text-fg-3" style={{ fontSize: "10.5px" }}>
+                <span className="inline-flex items-center gap-1 text-st-stale">
+                  <History size={10} /> {plural(nOutdated, "outdated comment")}
+                </span>
+                <span className="h-px flex-1 bg-line" />
+                <span
+                  className="cursor-help"
+                  title="Its line changed between the destination it was written on and this one. Still answerable, still resolvable."
+                >
+                  what is this?
+                </span>
+              </div>
+              {showOutdated && outdatedEntries.map((e) => <div key={e.kind === "sent" ? e.comment.id : e.anchor.line}>{renderCard(e)}</div>)}
+            </div>
+          )}
+          {orphanDrafts.length > 0 && comments && (
+            <div data-testid="review-orphan-drafts" className="border-b border-line pb-1">
+              <div className="mx-3 mt-2 flex items-center gap-2 text-st-await" style={{ fontSize: "10.5px" }}>
+                ✎ {plural(orphanDrafts.length, "draft")} on a line that changed
+                <span className="h-px flex-1 bg-line" />
+                <span className="cursor-help text-fg-4" title="Drafts are never re-mapped: the line this draft was written under is no longer in the diff. Edit, send or delete it.">
+                  line changed
+                </span>
+              </div>
+              {orphanDrafts.map((e) =>
+                e.kind === "draft" && comments.editingKey === e.draft.key ? (
+                  <div key={e.draft.key} className="mx-3 my-2">
+                    <CommentEditor
+                      anchor={e.anchor}
+                      initial={e.draft.text}
+                      wipKey={wipKey(runId, e.anchor, pair)}
+                      sendDisabledReason={comments.sendDisabledReason}
+                      onSave={(text) => comments.updateDraft(e.draft.key, text)}
+                      onSend={(text) => {
+                        comments.updateDraft(e.draft.key, text);
+                        comments.sendDraft(e.draft.key);
+                      }}
+                      onCancel={comments.cancelEdit}
+                    />
+                  </div>
+                ) : (
+                  <div key={e.kind === "draft" ? e.draft.key : e.anchor.line}>{renderCard(e)}</div>
+                ),
+              )}
+            </div>
+          )}
           {file.binary ? (
             <div className="px-4 py-[18px] text-center text-fg-4" style={{ fontSize: "11px" }}>
               Binary file, not shown
@@ -380,7 +499,7 @@ export default function ReviewFileCard({
               renderWidgetLine={({ side, lineNumber, onClose }) => {
                 if (!comments) return null;
                 const anchor: Anchor = { path, side: sideOf(side), line: lineNumber };
-                const existing = entryAt(entries, anchor);
+                const existing = entryAt(inlineEntries, anchor);
                 if (existing) {
                   return (
                     <WidgetRedirect
@@ -428,26 +547,7 @@ export default function ReviewFileCard({
                     />
                   );
                 }
-                const key = entry.kind === "draft" ? entry.draft.key : null;
-                const sent = entry.kind === "sent" ? entry.comment : null;
-                return (
-                  <CommentCard
-                    entry={entry}
-                    sending={key !== null && comments.sendingKeys.has(key)}
-                    startingManager={comments.startingManager}
-                    pairLabel={comments.pairLabel}
-                    sendDisabledReason={comments.sendDisabledReason}
-                    onEdit={() => key && comments.editDraft(key)}
-                    onDelete={() => key && comments.deleteDraft(key)}
-                    onSend={() => key && comments.sendDraft(key)}
-                    unread={sent ? comments.unreadOf(sent) : 0}
-                    flash={sent ? comments.flashing.has(sent.id) : false}
-                    deciding={sent ? comments.deciding.has(sent.id) : false}
-                    onResolve={sent ? () => comments.resolve(sent) : undefined}
-                    onReopen={sent ? () => comments.reopen(sent) : undefined}
-                    onSeen={sent ? () => comments.markSeen(sent) : undefined}
-                  />
-                );
+                return renderCard(entry);
               }}
             />
           )}

--- a/frontend/src/components/review/ReviewFileList.tsx
+++ b/frontend/src/components/review/ReviewFileList.tsx
@@ -2,7 +2,7 @@ import { PanelLeftClose } from "lucide-react";
 import type { RefObject } from "react";
 import type { DiffFile } from "../../types";
 import { baseName, filePath, groupByDir, miniBar, statusLetter } from "../../lib/runRefs";
-import { Hourglass } from "lucide-react";
+import { History, Hourglass } from "lucide-react";
 import type { ReviewEntry, StateCounts } from "../../lib/reviewComments";
 import { anchorLabel, authorKind, authorLabel, commentState, footerStatus, plural, sortForSidebar } from "../../lib/reviewComments";
 import { AuthorGlyph, Badge, StateIcon } from "./CommentCard";
@@ -37,6 +37,8 @@ interface Props {
   counts?: Map<string, { drafts: number; sent: number }>;
   /** #751: per-path sent-comment state counts (replace the plain "sent" badge when given). */
   stateCounts?: Map<string, StateCounts>;
+  /** #752: per-path outdated count — a history glyph on the row when ≥ 1. */
+  outdatedCounts?: Map<string, number>;
   /** #750: the Comments section — current pair first, other pairs greyed. */
   comments?: { current: ReviewEntry[]; other: { entry: ReviewEntry; pair: string }[] };
   onJumpEntry?: (entry: ReviewEntry) => void;
@@ -60,6 +62,7 @@ export default function ReviewFileList({
   onClose,
   counts,
   stateCounts: states,
+  outdatedCounts,
   comments,
   onJumpEntry,
   onJumpOther,
@@ -149,6 +152,15 @@ export default function ReviewFileList({
                   </span>
                   <span className="flex items-center gap-1 font-mono" style={{ fontSize: "10px" }}>
                     {(counts?.get(p)?.drafts ?? 0) > 0 && <Badge kind="draft">{counts!.get(p)!.drafts}</Badge>}
+                    {(outdatedCounts?.get(p) ?? 0) > 0 && (
+                      <span
+                        className="inline-flex items-center text-st-stale"
+                        title={`${outdatedCounts!.get(p)} outdated — the line changed on this destination`}
+                        data-testid="review-file-row-outdated"
+                      >
+                        <History size={9} />
+                      </span>
+                    )}
                     {states?.get(p) ? (
                       <>
                         {states.get(p)!.proposed > 0 && (

--- a/frontend/src/hooks/useReviewUnread.ts
+++ b/frontend/src/hooks/useReviewUnread.ts
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useSyncExternalStore } from "react";
 import type { RunState } from "../types";
 import { readSeen, seenKey, unreadCommentCount } from "../lib/reviewComments";
+import type { SeenMap } from "../lib/reviewComments";
 
 /**
  * How many of a Run's sent review comments carry a reply this browser has not
@@ -10,6 +11,16 @@ import { readSeen, seenKey, unreadCommentCount } from "../lib/reviewComments";
  * WebSocket pushes (through `run`) and the other tab's `storage` events.
  */
 export function useReviewUnread(run: RunState | null): number {
+  const seen = useReviewSeen(run);
+  return useMemo(() => (run ? unreadCommentCount(run.review_comments, seen) : 0), [run, seen]);
+}
+
+/**
+ * The per-browser "seen" marker of a Run's review replies (#751 / #752), live:
+ * follows the other tab's `storage` events. The toolbar's Review pill reads its
+ * tone from it (solid blue while a reply is unread).
+ */
+export function useReviewSeen(run: RunState | null): SeenMap {
   const runId = run?.run_id ?? null;
   const subscribe = useCallback((onChange: () => void) => {
     window.addEventListener("storage", onChange);
@@ -28,6 +39,5 @@ export function useReviewUnread(run: RunState | null): number {
     },
     () => null,
   );
-  const seen = useMemo(() => (runId ? readSeen(runId, { getItem: () => raw }) : {}), [runId, raw]);
-  return useMemo(() => (run ? unreadCommentCount(run.review_comments, seen) : 0), [run, seen]);
+  return useMemo(() => (runId ? readSeen(runId, { getItem: () => raw }) : {}), [runId, raw]);
 }

--- a/frontend/src/lib/reviewComments.test.ts
+++ b/frontend/src/lib/reviewComments.test.ts
@@ -29,6 +29,14 @@ import {
   updateDraft,
   wipKey,
   writeDrafts,
+  homeIds,
+  mappingsOf,
+  outdatedCountByPath,
+  parseExcerpt,
+  pendingTone,
+  remapSummary,
+  reviewQuickAccessTitle,
+  sentEntriesForPair,
 } from "./reviewComments";
 import type { ReviewComment, RunRefs } from "../types";
 
@@ -235,5 +243,65 @@ describe("reviewComments — the conversation (#751)", () => {
     expect(readSeen("r1", storage)).toEqual({});
     writeSeen("r1", {}, storage);
     expect(storage.getItem("pdo.review.seen.r1")).toBeNull();
+  });
+});
+
+// #752 (ADR-0067 §5): reported / outdated comments, and the toolbar pill's tone.
+describe("reviewComments — re-mapped comments and the Review quick access (#752)", () => {
+  it("places mapped comments at their reported line, groups outdated ones, and keeps the rest as 'other'", () => {
+    const a = sent({ id: "rc-001", line: 212 });
+    const b = sent({ id: "rc-002", line: 239, path: "c.ts" });
+    const c = sent({ id: "rc-003", line: 7, path: "gone.ts" });
+    const d = sent({ id: "rc-004", line: 9, from_ref: "node:x:1:before", to_ref: "node:x:1:after" });
+    const mappings = mappingsOf([
+      { ...a, outdated: false, mapped_line: 214, moved: true },
+      { ...b, outdated: true },
+      { ...c, outdated: false, mapped_line: 7 },
+      { ...d, outdated: false, mapped_line: 9 },
+    ]);
+    const entries = sentEntriesForPair([a, b, c, d], PAIR, mappings, ["b.ts", "c.ts"]);
+    expect(entries.map((e) => e.kind === "sent" && [e.comment.id, e.anchor.line, e.outdated ?? false, e.movedFrom])).toEqual([
+      ["rc-001", 214, false, 212],
+      ["rc-002", 239, true, undefined],
+      // rc-003: its file is not in the displayed diff → not at home.
+      ["rc-004", 9, false, undefined], // written on another pair, but its line is here
+    ]);
+    expect(homeIds(entries)).toEqual(new Set(["rc-001", "rc-002", "rc-004"]));
+    expect(remapSummary(entries)).toBe("1 comment moved · 1 outdated");
+    expect(outdatedCountByPath(entries)).toEqual(new Map([["c.ts", 1]]));
+    // No mapping yet: exact-pair comments show where written, others wait.
+    const plain = sentEntriesForPair([a, d], PAIR, undefined, ["b.ts"]);
+    expect(plain).toHaveLength(1);
+    expect(plain[0].anchor.line).toBe(212);
+    expect(remapSummary(plain)).toBeNull();
+    // mergeEntries threads the mapping through and sorts by the reported line.
+    const merged = mergeEntries([], [a, b], PAIR, ["b.ts", "c.ts"], mappings);
+    expect(merged.map((e) => e.anchor.line)).toEqual([214, 239]);
+  });
+
+  it("parses the stored excerpt into numbered lines with the commented one marked", () => {
+    expect(parseExcerpt("  1 | a\n> 2 | b\n  3 | ")).toEqual([
+      { no: 1, text: "a", marked: false },
+      { no: 2, text: "b", marked: true },
+      { no: 3, text: "", marked: false },
+    ]);
+    expect(parseExcerpt(undefined)).toEqual([]);
+    expect(parseExcerpt("garbage")).toEqual([]);
+  });
+
+  it("colours the toolbar pill: pending → unread (blue) → proposed (amber wins), and titles it", () => {
+    const open = sent({ id: "rc-001" });
+    const replied = sent({ id: "rc-002", replies: [{ author: "manager", text: "ok", at: "t" }] });
+    const proposed = sent({ id: "rc-003", proposal_pending: true, replies: [{ author: "manager", text: "done", at: "t", proposes_resolution: true }] });
+    const resolved = sent({ id: "rc-004", status: "resolved" });
+    expect(pendingTone([open, resolved], {})).toBe("pending");
+    expect(reviewQuickAccessTitle([open, resolved], {})).toBe("Review · 1 pending");
+    expect(pendingTone([open, replied], {})).toBe("unread");
+    expect(reviewQuickAccessTitle([open, replied], {})).toBe("Review · 2 pending, 1 unread reply");
+    expect(pendingTone([open, replied], { "rc-002": 1 })).toBe("pending");
+    expect(pendingTone([open, replied, proposed], {})).toBe("proposed");
+    expect(reviewQuickAccessTitle([open, replied, proposed], {})).toBe("Review · 3 pending, 2 unread replies, 1 resolution proposed");
+    expect(reviewQuickAccessTitle([resolved], {})).toBe("Review");
+    expect(reviewQuickAccessTitle(undefined, {})).toBe("Review");
   });
 });

--- a/frontend/src/lib/reviewComments.ts
+++ b/frontend/src/lib/reviewComments.ts
@@ -1,4 +1,4 @@
-import type { ReviewComment, ReviewSide, RunRefs, RunState, SendReviewCommentInput } from "../types";
+import type { ReviewAnchorMapping, ReviewComment, ReviewSide, RunRefs, RunState, SendReviewCommentInput } from "../types";
 import type { RefPair } from "./runRefs";
 
 // Review comments of the Review page (#750, ADR-0067 §2; CONTEXT.md
@@ -32,10 +32,28 @@ export interface Anchor {
   line: number;
 }
 
-/** One entry of the merged list the page renders. */
+/**
+ * One entry of the merged list the page renders. A sent entry's `anchor` is
+ * where the card sits **on the displayed pair** (#752): the reported line when
+ * the daemon mapped it, the written line otherwise. `outdated` marks a comment
+ * whose line changed since (card in the file's outdated group, not inline);
+ * `movedFrom` is the written line when the reported number differs.
+ */
 export type ReviewEntry =
   | { kind: "draft"; anchor: Anchor; draft: ReviewDraft }
-  | { kind: "sent"; anchor: Anchor; comment: ReviewComment };
+  | { kind: "sent"; anchor: Anchor; comment: ReviewComment; outdated?: boolean; movedFrom?: number };
+
+/** Comment id → its mapping onto the displayed pair (from `GET …/review/comments?from&to`). */
+export type MappingMap = ReadonlyMap<string, ReviewAnchorMapping>;
+
+export function mappingsOf(comments: (ReviewComment & Partial<ReviewAnchorMapping>)[]): Map<string, ReviewAnchorMapping> {
+  const m = new Map<string, ReviewAnchorMapping>();
+  for (const c of comments) {
+    if (typeof c.outdated !== "boolean") continue;
+    m.set(c.id, { outdated: c.outdated, mapped_line: c.mapped_line, moved: c.moved });
+  }
+  return m;
+}
 
 export const DRAFTS_KEY_PREFIX = "pdo.review.drafts.";
 export const WIP_KEY_PREFIX = "pdo.review.wip.";
@@ -121,10 +139,101 @@ export function draftsForPair(drafts: ReviewDraft[], pair: RefPair): ReviewDraft
   return drafts.filter((d) => d.from === pair.from && d.to === pair.to);
 }
 
-/** The sent comments of this pair. */
+/** The sent comments written against exactly this pair. */
 export function sentForPair(comments: ReviewComment[] | undefined, pair: RefPair): ReviewComment[] {
   return (comments ?? []).filter((c) => c.from_ref === pair.from && c.to_ref === pair.to);
 }
+
+/**
+ * The sent entries **at home** on the displayed pair (#752): a comment the daemon
+ * mapped onto the pair whose file is in the displayed diff — reported at its
+ * mapped line, or outdated at its written line — and, while no mapping is known
+ * (not fetched yet, or the daemon could not map it), a comment written against
+ * exactly this pair, where it was written. A mapped comment whose file is not
+ * in the displayed diff has no card to live in: it is listed under "other".
+ */
+export function sentEntriesForPair(
+  comments: ReviewComment[] | undefined,
+  pair: RefPair,
+  mappings: MappingMap | undefined,
+  pathOrder: string[],
+): ReviewEntry[] {
+  const paths = new Set(pathOrder);
+  const out: ReviewEntry[] = [];
+  for (const c of comments ?? []) {
+    const m = mappings?.get(c.id);
+    const exact = c.from_ref === pair.from && c.to_ref === pair.to;
+    if (!m) {
+      if (exact) out.push({ kind: "sent", anchor: { path: c.path, side: c.side, line: c.line }, comment: c });
+      continue;
+    }
+    // Mapped, but its file is not in this diff: no card can host it — "other".
+    if (!paths.has(c.path)) continue;
+    if (m.outdated) {
+      out.push({ kind: "sent", anchor: { path: c.path, side: c.side, line: c.line }, comment: c, outdated: true });
+      continue;
+    }
+    const line = m.mapped_line ?? c.line;
+    out.push({
+      kind: "sent",
+      anchor: { path: c.path, side: c.side, line },
+      comment: c,
+      movedFrom: line !== c.line ? c.line : undefined,
+    });
+  }
+  return out;
+}
+
+/** The ids of the comments `sentEntriesForPair` places on the pair — the rest are "other". */
+export function homeIds(entries: ReviewEntry[]): Set<string> {
+  return new Set(entries.flatMap((e) => (e.kind === "sent" ? [e.comment.id] : [])));
+}
+
+/** `1 comment moved · 1 outdated` after a re-map; null when nothing moved or went outdated. */
+export function remapSummary(entries: ReviewEntry[]): string | null {
+  let moved = 0;
+  let outdated = 0;
+  for (const e of entries) {
+    if (e.kind !== "sent") continue;
+    if (e.outdated) outdated += 1;
+    else if (e.movedFrom !== undefined) moved += 1;
+  }
+  if (moved === 0 && outdated === 0) return null;
+  const parts: string[] = [];
+  if (moved > 0) parts.push(`${plural(moved, "comment")} moved`);
+  if (outdated > 0) parts.push(`${outdated} outdated`);
+  return parts.join(" · ");
+}
+
+/** Per-path outdated count — the history glyph on file rows and headers (#752). */
+export function outdatedCountByPath(entries: ReviewEntry[]): Map<string, number> {
+  const m = new Map<string, number>();
+  for (const e of entries) {
+    if (e.kind === "sent" && e.outdated) m.set(e.anchor.path, (m.get(e.anchor.path) ?? 0) + 1);
+  }
+  return m;
+}
+
+/** One line of a stored excerpt (`> 3 | text`): number, text, and whether it is the commented line. */
+export interface ExcerptLine {
+  no: number;
+  text: string;
+  marked: boolean;
+}
+
+/** Parse the hunk excerpt the daemon stored at send time (the outdated card's original hunk). */
+export function parseExcerpt(excerpt: string | undefined): ExcerptLine[] {
+  if (!excerpt) return [];
+  const out: ExcerptLine[] = [];
+  for (const raw of excerpt.split("\n")) {
+    const m = /^([> ]) *(\d+) \| ?(.*)$/.exec(raw);
+    if (!m) continue;
+    out.push({ no: Number(m[2]), text: m[3], marked: m[1] === ">" });
+  }
+  return out;
+}
+
+export const SHOW_OUTDATED_KEY = "pdo.review.showOutdated";
 
 /**
  * The merged list for one pair, in diff order: by path (patch order given), then
@@ -137,15 +246,12 @@ export function mergeEntries(
   comments: ReviewComment[] | undefined,
   pair: RefPair,
   pathOrder: string[],
+  mappings?: MappingMap,
 ): ReviewEntry[] {
   const order = new Map(pathOrder.map((p, i) => [p, i]));
   const rank = (p: string) => order.get(p) ?? Number.MAX_SAFE_INTEGER;
   const entries: ReviewEntry[] = [
-    ...sentForPair(comments, pair).map<ReviewEntry>((c) => ({
-      kind: "sent",
-      anchor: { path: c.path, side: c.side, line: c.line },
-      comment: c,
-    })),
+    ...sentEntriesForPair(comments, pair, mappings, pathOrder),
     ...draftsForPair(drafts, pair).map<ReviewEntry>((d) => ({
       kind: "draft",
       anchor: { path: d.path, side: d.side, line: d.line },
@@ -229,6 +335,34 @@ export function relativeTime(iso: string, now = new Date()): string {
 /** Pending for the Review quick access (CONTEXT.md « Accès rapide Review »): sent, not resolved. */
 export function pendingCount(comments: ReviewComment[] | undefined): number {
   return (comments ?? []).filter((c) => c.status !== "resolved").length;
+}
+
+/**
+ * The colour of the toolbar's Review pill (#752): the number is always
+ * `pendingCount`, the tone carries the nuance — outlined blue while comments
+ * merely wait, solid blue when ≥ 1 reply is unread (the Diff tab's pill colour),
+ * amber when ≥ 1 resolution is proposed (a decision waits on you; wins over blue).
+ */
+export type PendingTone = "pending" | "unread" | "proposed";
+
+export function pendingTone(comments: ReviewComment[] | undefined, seen: SeenMap): PendingTone {
+  const list = comments ?? [];
+  if (list.some((c) => c.status === "sent" && c.proposal_pending)) return "proposed";
+  if (unreadCommentCount(list, seen) > 0) return "unread";
+  return "pending";
+}
+
+/** `Review` / `Review · 2 pending` / `Review · 2 pending, 1 unread reply, 1 resolution proposed`. */
+export function reviewQuickAccessTitle(comments: ReviewComment[] | undefined, seen: SeenMap): string {
+  const list = comments ?? [];
+  const pending = pendingCount(list);
+  if (pending === 0) return "Review";
+  const parts = [`${pending} pending`];
+  const unread = unreadCommentCount(list, seen);
+  if (unread > 0) parts.push(`${unread} unread ${unread === 1 ? "reply" : "replies"}`);
+  const proposed = list.filter((c) => c.status === "sent" && c.proposal_pending).length;
+  if (proposed > 0) parts.push(`${proposed} resolution${proposed === 1 ? "" : "s"} proposed`);
+  return `Review · ${parts.join(", ")}`;
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/pages/ReviewPage.test.tsx
+++ b/frontend/src/pages/ReviewPage.test.tsx
@@ -9,6 +9,7 @@ import type { ReviewComment, RunRefs, RunState, StructuredDiff, DiffFile } from 
 
 vi.mock("../api", () => ({
   fetchRun: vi.fn(),
+  fetchReviewComments: vi.fn(),
   fetchRunRefs: vi.fn(),
   fetchRunStructuredDiff: vi.fn(),
   fetchRunFileAtRef: vi.fn(),
@@ -83,6 +84,7 @@ vi.mock("@git-diff-view/react", async () => {
 
 import {
   fetchRun,
+  fetchReviewComments,
   fetchRunRefs,
   fetchRunStructuredDiff,
   fetchRunFileAtRef,
@@ -92,6 +94,7 @@ import {
 } from "../api";
 
 const mockedRun = vi.mocked(fetchRun);
+const mockedList = vi.mocked(fetchReviewComments);
 const mockedRefs = vi.mocked(fetchRunRefs);
 const mockedDiff = vi.mocked(fetchRunStructuredDiff);
 const mockedFile = vi.mocked(fetchRunFileAtRef);
@@ -190,6 +193,8 @@ beforeEach(() => {
   localStorage.clear();
   sessionStorage.clear();
   mockedRun.mockResolvedValue(makeRun());
+  // #752: by default the daemon maps nothing (no `outdated` field) — comments show where written.
+  mockedList.mockResolvedValue({ comments: [] });
   mockedRefs.mockResolvedValue(REFS);
   mockedDiff.mockResolvedValue(TWO);
   mockedFile.mockResolvedValue("a\nB\nC\n");
@@ -749,5 +754,95 @@ describe("ReviewPage — review conversation (#751)", () => {
     await waitFor(() => expect(screen.getByTestId("review-toast")).toHaveAttribute("data-error", "true"));
     expect(screen.getByTestId("review-toast")).toHaveTextContent("Resolve failed — daemon unreachable");
     expect(screen.getByTestId("review-comment")).toHaveAttribute("data-review-state", "proposed");
+  });
+});
+
+// #752 (ADR-0067 §5): reported / outdated comments — the daemon maps on read,
+// the page places, groups and toggles.
+describe("ReviewPage — reported / outdated comments (#752)", () => {
+  it("places a reported comment at its mapped line with a `from` chip only when the number differs", async () => {
+    const same = sentComment({ id: "rc-001", line: 1 });
+    const moved = sentComment({ id: "rc-002", line: 2, text: "moved one" });
+    mockedRun.mockResolvedValue(makeRun({ review_comments: [same, moved] }));
+    mockedList.mockResolvedValue({
+      comments: [
+        { ...same, outdated: false, mapped_line: 1 },
+        { ...moved, outdated: false, mapped_line: 3, moved: true },
+      ],
+    });
+    render(<ReviewPage runId={RUN_ID} />);
+    await waitFor(() => expect(screen.getAllByTestId("review-comment")).toHaveLength(2));
+    await waitFor(() => expect(mockedList).toHaveBeenCalledWith(RUN_ID, { from: "fork", to: "tip" }));
+    const slots = await screen.findAllByTestId("mock-extend");
+    await waitFor(() => expect(screen.getAllByTestId("mock-extend").map((s) => s.getAttribute("data-line"))).toEqual(["1", "3"]));
+    void slots;
+    const cards = screen.getAllByTestId("review-comment");
+    expect(within(cards[0]).queryByTestId("review-comment-moved-from")).toBeNull();
+    expect(cards[1]).toHaveAttribute("data-moved-from", "2");
+    expect(within(cards[1]).getByTestId("review-comment-moved-from")).toHaveTextContent("from R2");
+    expect(cards[1]).toHaveAttribute("data-anchor", "main.tsx:R3");
+    // The header notes the re-map for a moment.
+    expect(screen.getByTestId("review-remap-note")).toHaveTextContent("1 comment moved");
+    expect(screen.queryByTestId("review-toggle-outdated")).toBeNull();
+  });
+
+  it("groups an outdated comment at the top of its file, collapsed, with its original hunk; it stays resolvable and hideable", async () => {
+    const stale = sentComment({
+      id: "rc-001",
+      line: 2,
+      to_sha: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      excerpt: "  1 | a\n> 2 | b\n  3 | c",
+      replies: [REPLY_MANAGER],
+    });
+    mockedRun.mockResolvedValue(makeRun({ review_comments: [stale] }));
+    mockedList.mockResolvedValue({ comments: [{ ...stale, outdated: true }] });
+    mockedResolve.mockResolvedValue({ comment: { ...stale, status: "resolved", resolved_by: "user", resolved_at: "2026-09-09T02:00:00Z" }, changed: true });
+    render(<ReviewPage runId={RUN_ID} />);
+    const group = await screen.findByTestId("review-outdated-group");
+    expect(group).toHaveTextContent("1 outdated comment");
+    expect(screen.queryAllByTestId("mock-extend")).toHaveLength(0);
+    const card = within(group).getByTestId("review-comment");
+    expect(card).toHaveAttribute("data-outdated", "true");
+    expect(card).toHaveAttribute("data-collapsed", "true");
+    expect(within(card).getByTestId("review-comment-written-on")).toHaveTextContent("R2 on Run tip · bbbbbbb");
+    expect(within(card).getByTestId("review-comment-summary")).toHaveTextContent("Sent remark");
+    expect(await screen.findByTestId("review-remap-note")).toHaveTextContent("1 outdated");
+    // The file header and the sidebar row carry the history glyph; counts stay by state.
+    expect(screen.getByTestId("review-file-outdated")).toHaveTextContent("1");
+    expect(screen.getByTestId("review-file-row-outdated")).toBeInTheDocument();
+    expect(screen.getByTestId("review-comments-pill")).toHaveTextContent("1");
+    // Expand: original hunk first, marked line, then body, reply, footer with Resolve.
+    fireEvent.click(within(card).getByTestId("review-comment-header"));
+    const hunk = within(card).getByTestId("review-comment-original-hunk");
+    expect(hunk).toHaveTextContent("Original hunk");
+    const lines = within(hunk).getAllByTestId("review-original-line");
+    expect(lines.map((l) => l.textContent)).toEqual(["1a", "2b", "3c"]);
+    expect(lines[1]).toHaveAttribute("data-marked", "true");
+    expect(within(card).getByTestId("review-reply")).toBeInTheDocument();
+    fireEvent.click(within(card).getByTestId("review-comment-resolve"));
+    await waitFor(() => expect(mockedResolve).toHaveBeenCalledWith(RUN_ID, "rc-001"));
+    // Show outdated toggle hides the card, keeps the group's count.
+    const toggle = screen.getByTestId("review-toggle-outdated");
+    expect(toggle).toHaveAttribute("aria-pressed", "true");
+    fireEvent.click(toggle);
+    expect(screen.getByTestId("review-outdated-group")).toHaveAttribute("data-hidden", "true");
+    expect(within(screen.getByTestId("review-outdated-group")).queryByTestId("review-comment")).toBeNull();
+    expect(screen.getByTestId("review-file-outdated")).toHaveTextContent("1");
+    expect(localStorage.getItem("pdo.review.showOutdated")).toBe("false");
+  });
+
+  it("re-maps when the destination changes, and a comment whose file is not in the diff is listed under other pairs", async () => {
+    const c = sentComment({ id: "rc-001", line: 1, path: "elsewhere.ts", from_ref: "node:impl:1:before", to_ref: "node:impl:1:after" });
+    mockedRun.mockResolvedValue(makeRun({ review_comments: [c] }));
+    mockedList.mockResolvedValue({ comments: [{ ...c, outdated: false, mapped_line: 1 }] });
+    render(<ReviewPage runId={RUN_ID} />);
+    await waitFor(() => expect(mockedList).toHaveBeenCalledWith(RUN_ID, { from: "fork", to: "tip" }));
+    expect(screen.queryByTestId("review-comment")).toBeNull();
+    const row = await screen.findByTestId("review-comment-row");
+    expect(row).toHaveAttribute("data-other-pair", "true");
+    expect(row).toHaveTextContent("implement · iter 1 · before → implement · iter 1 · after");
+    // Switching the destination asks the daemon again for that pair.
+    fireEvent.click(row);
+    await waitFor(() => expect(mockedList).toHaveBeenCalledWith(RUN_ID, { from: "node:impl:1:before", to: "node:impl:1:after" }));
   });
 });

--- a/frontend/src/pages/ReviewPage.tsx
+++ b/frontend/src/pages/ReviewPage.tsx
@@ -7,6 +7,7 @@ import {
   Columns2,
   Eye,
   EyeOff,
+  History,
   ListMinus,
   MessageSquare,
   PanelLeftOpen,
@@ -15,6 +16,7 @@ import {
 } from "lucide-react";
 import "@git-diff-view/react/styles/diff-view.css";
 import {
+  fetchReviewComments,
   fetchRun,
   fetchRunRefs,
   fetchRunStructuredDiff,
@@ -36,13 +38,19 @@ import {
   authorLabel,
   countsByPath,
   draftsForPair,
+  homeIds,
+  mappingsOf,
   markSeen as markSeenIn,
   mergeEntries,
+  outdatedCountByPath,
   plural,
   readDrafts,
   readSeen,
+  remapSummary,
   removeDrafts,
   sendDisabledReason as sendReasonOf,
+  sentEntriesForPair,
+  SHOW_OUTDATED_KEY,
   stateCounts,
   stateCountsByPath,
   toSendInputs,
@@ -51,7 +59,7 @@ import {
   writeDrafts,
   writeSeen,
 } from "../lib/reviewComments";
-import type { Anchor, ReviewDraft, ReviewEntry, SeenMap } from "../lib/reviewComments";
+import type { Anchor, MappingMap, ReviewDraft, ReviewEntry, SeenMap } from "../lib/reviewComments";
 import {
   DEFAULT_FROM,
   DEFAULT_TO,
@@ -102,6 +110,16 @@ import type { RefPair, ViewMode } from "../lib/runRefs";
  * Opening this page marks every reply seen for this browser (localStorage) —
  * that is what clears the Diff tab's unread badge; the per-card dots clear as
  * each card is looked at.
+ *
+ * Reported / outdated comments (#752, ADR-0067 §5): once the diff of a pair is
+ * loaded, the page asks the daemon to **re-map** every sent comment onto that
+ * pair (`GET …/review/comments?from&to`, one read, nothing written). A comment
+ * whose line is unchanged sits at its new position (a `↳ from R212` chip only
+ * when the number differs); one whose line changed is **outdated**: collapsed in
+ * a group at the top of its file card, original hunk inside, still answerable
+ * and resolvable. A note in the top bar says `1 comment moved · 1 outdated` for a
+ * few seconds after a re-map; a `Show outdated` toggle hides those cards, never
+ * the counts. Drafts are never re-mapped.
  */
 
 const SHOW_RESOLVED_KEY = "pdo.review.showResolved";
@@ -158,6 +176,18 @@ export default function ReviewPage({ runId }: Props) {
     }
   });
   const [deciding, setDeciding] = useState<ReadonlySet<string>>(() => new Set());
+  // --- Reported / outdated (#752) ---------------------------------------------------
+  /** The daemon's mapping of every sent comment onto the displayed pair, tagged with what it was fetched for. */
+  const [mappings, setMappings] = useState<{ key: string; map: MappingMap } | null>(null);
+  const [showOutdated, setShowOutdated] = useState<boolean>(() => {
+    try {
+      return localStorage.getItem(SHOW_OUTDATED_KEY) !== "false";
+    } catch {
+      return true;
+    }
+  });
+  const [remapNote, setRemapNote] = useState<string | null>(null);
+  const remapTimer = useRef<number | undefined>(undefined);
   const [flashing, setFlashing] = useState<ReadonlySet<string>>(() => new Set());
   const flashTimers = useRef<Map<string, number>>(new Map());
   const openedSeenWritten = useRef(false);
@@ -263,6 +293,41 @@ export default function ReviewPage({ runId }: Props) {
     () => (load.kind !== "none" && load.key === loadKey ? load : { kind: "none" }),
     [load, loadKey],
   );
+
+  // #752: re-map the sent comments onto the displayed pair — once its diff is in
+  // (the mapping reads the same SHAs), and again whenever the set of comments
+  // changes (a send, a replay). Keyed like the diff so a pair change never shows
+  // a stale mapping: a key mismatch reads as "not mapped yet".
+  const commentIdsSig = (run?.review_comments ?? []).map((c) => c.id).join(",");
+  const mappingKey = `${loadKey}|${commentIdsSig}`;
+  const diffReady = current.kind === "ready";
+  const pathOrderRef = useRef<string[]>([]);
+  useEffect(() => {
+    if (!diffReady || !commentIdsSig) return;
+    let stale = false;
+    const pair = { from: pairFrom, to: pairTo };
+    fetchReviewComments(runId, pair)
+      .then((res) => {
+        if (stale) return;
+        const map = mappingsOf(res.comments);
+        setMappings({ key: mappingKey, map });
+        // The header note, once per mapping: `1 comment moved · 1 outdated`, a few seconds.
+        const summary = remapSummary(sentEntriesForPair(res.comments, pair, map, pathOrderRef.current));
+        if (summary) {
+          setRemapNote(summary);
+          window.clearTimeout(remapTimer.current);
+          remapTimer.current = window.setTimeout(() => setRemapNote(null), 5000);
+        }
+      })
+      .catch(() => {
+        // Without a mapping the comments show where they were written.
+      });
+    return () => {
+      stale = true;
+    };
+  }, [runId, pairFrom, pairTo, diffReady, commentIdsSig, mappingKey]);
+  const activeMappings = mappings && mappings.key === mappingKey ? mappings.map : undefined;
+  useEffect(() => () => window.clearTimeout(remapTimer.current), []);
 
   // --- Live: the Run's WebSocket, only to detect "tip moved" / "node delivered".
   const { subscribe } = useDaemonSocket();
@@ -423,10 +488,15 @@ export default function ReviewPage({ runId }: Props) {
   );
 
   const pathOrder = useMemo(() => files.map(filePath), [files]);
+  useEffect(() => {
+    pathOrderRef.current = pathOrder;
+  }, [pathOrder]);
   const entries = useMemo<ReviewEntry[]>(
-    () => mergeEntries(drafts, run?.review_comments, pair, pathOrder),
-    [drafts, run?.review_comments, pair, pathOrder],
+    () => mergeEntries(drafts, run?.review_comments, pair, pathOrder, activeMappings),
+    [drafts, run?.review_comments, pair, pathOrder, activeMappings],
   );
+  const outdatedCounts = useMemo(() => outdatedCountByPath(entries), [entries]);
+  const anyOutdated = outdatedCounts.size > 0;
   const entriesByPath = useMemo(() => {
     const m = new Map<string, ReviewEntry[]>();
     for (const e of entries) {
@@ -456,7 +526,8 @@ export default function ReviewPage({ runId }: Props) {
     () => entries.filter((e) => e.kind === "draft" || e.comment.status !== "resolved"),
     [entries],
   );
-  /** Comments written against another pair: listed greyed, never lost. */
+  /** Comments not at home on this pair (written elsewhere, file absent here): listed greyed, never lost. */
+  const home = useMemo(() => homeIds(entries), [entries]);
   const otherEntries = useMemo(() => {
     const label = (from: string, to: string) => {
       const name = (id: string) => refs?.refs.find((r) => r.id === id)?.label ?? id;
@@ -468,7 +539,7 @@ export default function ReviewPage({ runId }: Props) {
       out.push({ entry: { kind: "draft", anchor: d, draft: d }, pair: label(d.from, d.to), refPair: { from: d.from, to: d.to } });
     }
     for (const c of run?.review_comments ?? []) {
-      if (c.from_ref === pair.from && c.to_ref === pair.to) continue;
+      if (home.has(c.id)) continue;
       out.push({
         entry: { kind: "sent", anchor: { path: c.path, side: c.side, line: c.line }, comment: c },
         pair: label(c.from_ref, c.to_ref),
@@ -476,13 +547,33 @@ export default function ReviewPage({ runId }: Props) {
       });
     }
     return out;
-  }, [drafts, run?.review_comments, pair, refs]);
+  }, [drafts, run?.review_comments, pair, refs, home]);
 
   const sendDisabledReason = sendReasonOf(run, refs);
   const pairLabel = useMemo(() => {
     const name = (id: string) => refs?.refs.find((r) => r.id === id)?.label ?? id;
     return `${name(pair.from)} → ${name(pair.to)}`;
   }, [refs, pair]);
+  /** #752: the label of the ref a comment's anchored side was written against. */
+  const writtenOnLabel = useCallback(
+    (c: ReviewComment) => {
+      const id = c.side === "old" ? c.from_ref : c.to_ref;
+      const label = refs?.refs.find((r) => r.id === id)?.label ?? id;
+      const sha = c.side === "old" ? c.from_sha : c.to_sha;
+      return sha ? `${label} · ${sha.slice(0, 7)}` : label;
+    },
+    [refs],
+  );
+  const toggleShowOutdated = () => {
+    setShowOutdated((v) => {
+      try {
+        localStorage.setItem(SHOW_OUTDATED_KEY, String(!v));
+      } catch {
+        // Remembered for the session only.
+      }
+      return !v;
+    });
+  };
 
   /** Scroll the anchored line of an entry into view, expanding its file first. */
   const jumpTo = useCallback(
@@ -656,6 +747,8 @@ export default function ReviewPage({ runId }: Props) {
       flashing,
       markSeen,
       showResolved,
+      showOutdated,
+      writtenOnLabel,
     }),
     [
       editingKey,
@@ -674,6 +767,8 @@ export default function ReviewPage({ runId }: Props) {
       flashing,
       markSeen,
       showResolved,
+      showOutdated,
+      writtenOnLabel,
     ],
   );
 
@@ -818,9 +913,29 @@ export default function ReviewPage({ runId }: Props) {
             </button>
           )}
         </div>
+        {remapNote && (
+          <span className="text-fg-3" style={{ fontSize: "10.5px" }} data-testid="review-remap-note" role="status">
+            {remapNote}
+          </span>
+        )}
 
         <span className="flex-1" />
 
+        {anyOutdated && (
+          <button
+            type="button"
+            onClick={toggleShowOutdated}
+            aria-pressed={showOutdated}
+            title={showOutdated ? "Hide outdated comments (they stay counted)" : "Show outdated comments"}
+            data-testid="review-toggle-outdated"
+            className={`flex cursor-pointer items-center gap-1 rounded border border-line-strong px-2 py-0.5 ${
+              showOutdated ? "bg-bg-3 text-fg-3 hover:text-fg-2" : "bg-bg-4 text-fg"
+            }`}
+            style={{ fontSize: "10.5px" }}
+          >
+            <History size={11} className="text-st-stale" /> Show outdated
+          </button>
+        )}
         {stats && (
           <span className="flex items-center gap-1.5 text-fg-2" data-testid="review-stats">
             <span>
@@ -1003,6 +1118,7 @@ export default function ReviewPage({ runId }: Props) {
             onClose={toggleList}
             counts={counts}
             stateCounts={states}
+            outdatedCounts={outdatedCounts}
             comments={{ current: entries, other: otherEntries.map(({ entry, pair: p }) => ({ entry, pair: p })) }}
             onJumpEntry={(e) => jumpTo(e.anchor)}
             onJumpOther={(e) => {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2076,6 +2076,31 @@ export interface ReviewComment {
   proposal_declined?: boolean;
 }
 
+/**
+ * #752 (ADR-0067 §5): what `GET …/review/comments?from=&to=` adds to a comment
+ * once re-mapped onto the displayed pair. `outdated` = the line was edited or
+ * deleted between the SHA the comment was written against and the displayed
+ * one; otherwise `mapped_line` is where the line sits now (`moved` when the
+ * number differs). Absent when the daemon could not map (no SHA recorded, ref
+ * gone): the comment shows where it was written.
+ */
+export interface ReviewAnchorMapping {
+  outdated: boolean;
+  mapped_line?: number;
+  moved?: boolean;
+}
+
+/** A comment as listed with a pair: the wire shape plus its mapping fields. */
+export type MappedReviewComment = ReviewComment & Partial<ReviewAnchorMapping>;
+
+export interface ReviewCommentsListResponse {
+  comments: MappedReviewComment[];
+  agent_can_resolve?: boolean;
+  /** Present when a pair was given: the SHAs it resolved to. */
+  from_sha?: string | null;
+  to_sha?: string | null;
+}
+
 /** `POST …/review/comments/<id>/resolve|reopen` — the human's verbs (#751). */
 export interface ReviewDecisionResponse {
   comment: ReviewComment;


### PR DESCRIPTION
Sub-ticket #752 of US #746 (spec #747, ADR-0067). Release **1.79.0**.

## What changed
- **Daemon**: `GET /runs/{id}/review/comments?from=&to=` maps each comment's anchor onto the displayed pair on read (`outdated` / `mapped_line` / `moved`, plus `from_sha` / `to_sha`). Unchanged line → reported at its new position; edited or deleted line → outdated. Nothing is materialised in the event log. `pdo review list` uses fork → tip so the manager sees `outdated`.
- **Review page**: reported cards inline at their mapped line with a `↳ from R…` chip; outdated cards collapsed in a group at the top of the file card, expandable to the original hunk, still answerable / resolvable. `Show outdated` toggle, transient `N moved · N outdated` header note, history glyph on file rows.
- **Canvas toolbar**: the "Run repositories" toggle is replaced by a **Review** link with a pending-comments pill (outlined blue pending, solid blue unread reply, amber resolution proposed), on every non-archived Run.
- **Run panel**: `Info | Diff | Repositories | Manager | YAML`. `RunInfoSidebar` deleted, its content extracted to `RepositoriesSection`; tests migrated.
- Covers the second half of #566 (commented, left open).

## Verification
- `pnpm test` 2346 passed, typecheck / lint / build green; `cargo test --workspace` + `cargo clippy -D warnings` green (implementation node).
- Feature Path #752 run against a sandbox daemon: **Pass**, no blocking finding (3 non-blocking notes: original hunk rendered without ± markers, header note transient, resolving needs a manager reply first — #751 behaviour).

Closes #752

🤖 Generated with [Claude Code](https://claude.com/claude-code)