### PR TITLE
feat(daemon+ui): release completion of an interactive node — 1.80.0 (#764)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ ascendante** : la casse se signale ici et par un bump majeur, jamais en gardant 
 morts. Seule contrainte non négociable — les **données historiques restent lisibles** : un Run
 archivé s'ouvre et se chiffre quelle que soit la version qui a écrit son payload.
 
+## 1.80.0
+**Nœud interactif — « Mark ready for completion » rend la complétion à l'agent** (#764 ; story #763, ADR-0068).
+Sur un nœud `interactive`, `pdo complete` lancé par l'agent est désormais **refusé** (exit 3, garde
+`completion_not_released`) tant que l'utilisateur n'a pas libéré la complétion : l'agent est invité à demander le clic.
+Le panneau du nœud propose deux boutons côte à côte : **Mark complete** (prend les artefacts tels quels, complète
+immédiatement — comportement inchangé) et **Mark ready for completion** (`POST /runs/{id}/nodes/{node}/release`,
+commande `release_node_completion`, évènement `node_completion_released`, idempotent). Une fois libéré, le nœud repasse
+`running`, le Run n'est plus `awaiting_user`, et c'est l'agent qui complète quand il a fini. La libération est
+refusée (409 `run_not_live`) sans session vivante.
 ## 1.79.0
 **Page de Review — report / outdated des commentaires, accès rapide Review, onglet Repositories** (#752 ; story #746, ADR-0067).
 Quand la paire affichée a bougé depuis l'écriture d'un commentaire (relivraison d'un nœud, merge-back), le daemon

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "1.79.1"
+version = "1.80.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "1.79.1"
+version = "1.80.0"
 license = "MIT"
 description = "Prompt-Driven Orchestrator — a local daemon that runs and supervises agentic coding pipelines"
 repository = "https://github.com/Loulen/prompt-driven-orchestrator"

--- a/crates/pdo-daemon/src/completion_refusal.rs
+++ b/crates/pdo-daemon/src/completion_refusal.rs
@@ -32,6 +32,9 @@ pub(crate) enum CompletionRefusal {
     CompletionRejected {
         message: String,
     },
+    /// An interactive node remains under human control until the user releases
+    /// this exact session. No terminal event is written.
+    CompletionNotReleased,
     /// La livraison (#654 / ADR-0060) a échoué — staging, commit ou merge. Panne,
     /// pas verdict, donc `500`. Un `NodeInterrupted` est déjà appendé et le Run
     /// est parqué `AwaitingUser` : le travail reste sur disque, intact.
@@ -120,6 +123,7 @@ impl CompletionRefusal {
             Self::RunNotFound => "run_not_found",
             Self::Internal { .. } => "internal_error",
             Self::CompletionRejected { .. } => "completion_rejected",
+            Self::CompletionNotReleased => "completion_not_released",
             Self::DeliveryFailed { .. } => "delivery_failed",
             Self::MergeConflict { .. } => "merge_conflict",
             Self::MissingOutputs { .. } => "missing_outputs",
@@ -142,6 +146,7 @@ impl CompletionRefusal {
         matches!(
             self,
             Self::MissingOutputs { .. }
+                | Self::CompletionNotReleased
                 | Self::FrontmatterRetryPending { .. }
                 // Des enfants simplement en cours : l'agent garde la main — il
                 // attend qu'ils se terminent et re-complète. Avec un enfant
@@ -162,6 +167,7 @@ impl CompletionRefusal {
                 StatusCode::INTERNAL_SERVER_ERROR
             }
             Self::CompletionRejected { .. }
+            | Self::CompletionNotReleased
             | Self::MergeConflict { .. }
             | Self::MissingOutputs { .. }
             | Self::ScriptValidationFailed { .. }
@@ -185,6 +191,9 @@ impl CompletionRefusal {
             Self::RunNotFound => serde_json::json!({ "message": "run not found" }),
             Self::Internal { error } => serde_json::json!({ "message": error }),
             Self::CompletionRejected { message } => serde_json::json!({ "message": message }),
+            Self::CompletionNotReleased => serde_json::json!({
+                "message": "this interactive node has not been released; ask the user to click \"Mark ready for completion\" (or \"Mark complete\"), then retry"
+            }),
             Self::AppendFailed { error } => serde_json::json!({ "message": error }),
             Self::DeliveryFailed { node_id, error } => serde_json::json!({
                 "message": format!("failed to deliver {node_id}'s work: {error}")
@@ -230,6 +239,9 @@ impl CompletionRefusal {
             Self::RunNotFound => "run not found".into(),
             Self::Internal { error } => error.clone(),
             Self::CompletionRejected { message } => message.clone(),
+            Self::CompletionNotReleased => {
+                "interactive node completion has not been released by the user".into()
+            }
             Self::DeliveryFailed { node_id, error } => {
                 format!("failed to deliver {node_id}'s work: {error}")
             }
@@ -328,6 +340,7 @@ mod tests {
             CompletionRefusal::CompletionRejected {
                 message: "resume the run first".into(),
             },
+            CompletionRefusal::CompletionNotReleased,
             CompletionRefusal::DeliveryFailed {
                 node_id: "impl".into(),
                 error: "git add -A failed".into(),
@@ -379,6 +392,7 @@ mod tests {
                 CompletionRefusal::RunNotFound => "RunNotFound",
                 CompletionRefusal::Internal { .. } => "Internal",
                 CompletionRefusal::CompletionRejected { .. } => "CompletionRejected",
+                CompletionRefusal::CompletionNotReleased => "CompletionNotReleased",
                 CompletionRefusal::DeliveryFailed { .. } => "DeliveryFailed",
                 CompletionRefusal::MergeConflict { .. } => "MergeConflict",
                 CompletionRefusal::MissingOutputs { .. } => "MissingOutputs",
@@ -446,11 +460,12 @@ mod tests {
 
     /// `recoverable` arbitre entre exit `3` et exit `4` de `pdo complete`.
     #[test]
-    fn only_the_two_still_your_turn_refusals_are_recoverable() {
+    fn only_still_your_turn_refusals_are_recoverable() {
         for r in every_refusal() {
             let expected = matches!(
                 r,
                 CompletionRefusal::MissingOutputs { .. }
+                    | CompletionRefusal::CompletionNotReleased
                     | CompletionRefusal::FrontmatterRetryPending { .. }
                     // La liaison forte laisse la main à l'agent tant qu'aucun
                     // enfant n'a échoué (#724).

--- a/crates/pdo-daemon/src/event_log.rs
+++ b/crates/pdo-daemon/src/event_log.rs
@@ -74,6 +74,7 @@ pub enum EventKind {
     /// holds no tmux session yet and waits for an admission slot (#159).
     NodeWaiting,
     NodeAwaitingUser,
+    NodeCompletionReleased,
     NodeCompleted,
     NodeFailed,
     /// An **infra** incident killed the node's session — session death, boot
@@ -556,6 +557,10 @@ pub struct IterationInfo {
     pub status: NodeStatus,
     pub started_at: Option<String>,
     pub completed_at: Option<String>,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub interactive: bool,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub completion_released: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1474,6 +1479,8 @@ fn entry_node_ids(edges: &[EdgeInfo], node_defs: &[NodeDefInfo]) -> Vec<String> 
 fn upsert_iteration(iterations: &mut Vec<IterationInfo>, new: IterationInfo) {
     if let Some(existing) = iterations.iter_mut().find(|i| i.iter == new.iter) {
         existing.status = new.status;
+        existing.interactive = new.interactive;
+        existing.completion_released = new.completion_released;
         if new.started_at.is_some() {
             existing.started_at = new.started_at;
         }
@@ -1511,6 +1518,7 @@ pub(crate) fn project(events: &[Event]) -> Option<RunState> {
 
             EventKind::NodeWaiting
             | EventKind::NodeStarted
+            | EventKind::NodeCompletionReleased
             | EventKind::NodeCompleted
             | EventKind::NodeAutoCompleted
             | EventKind::NodeAwaitingUser
@@ -2102,6 +2110,13 @@ fn apply_node_event(state: &mut RunState, event: &Event) {
                     status: NodeStatus::Running,
                     started_at: Some(event.ts.clone()),
                     completed_at: None,
+                    interactive: event
+                        .payload
+                        .as_ref()
+                        .and_then(|p| p.get("interactive"))
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(false),
+                    completion_released: false,
                 };
                 let node = state
                     .nodes
@@ -2189,6 +2204,20 @@ fn apply_node_event(state: &mut RunState, event: &Event) {
                 upsert_iteration(&mut node.iterations, iteration);
             }
         }
+        EventKind::NodeCompletionReleased => {
+            if let Some(ref node_id) = event.node_id {
+                if let Some(node) = state.nodes.get_mut(node_id) {
+                    let iter = event.iter.unwrap_or(node.iter);
+                    if iter == node.iter {
+                        node.status = NodeStatus::Running;
+                    }
+                    if let Some(it) = node.iterations.iter_mut().find(|i| i.iter == iter) {
+                        it.status = NodeStatus::Running;
+                        it.completion_released = true;
+                    }
+                }
+            }
+        }
         EventKind::NodeCompleted | EventKind::NodeAutoCompleted => {
             if let Some(ref node_id) = event.node_id {
                 // #600: a **skip** (`skip_node` / reachability auto-skip) can
@@ -2247,6 +2276,8 @@ fn apply_node_event(state: &mut RunState, event: &Event) {
                                 status: done_status.clone(),
                                 started_at: Some(event.ts.clone()),
                                 completed_at: Some(event.ts.clone()),
+                                interactive: false,
+                                completion_released: false,
                             }],
                             frontmatter_retries: 0,
                             frontmatter_violations: Vec::new(),
@@ -2530,6 +2561,8 @@ fn apply_switch_event(state: &mut RunState, event: &Event) {
                     status: NodeStatus::Completed,
                     started_at: Some(event.ts.clone()),
                     completed_at: Some(event.ts.clone()),
+                    interactive: false,
+                    completion_released: false,
                 },
             );
         }
@@ -4487,6 +4520,41 @@ mod tests {
         let state = project(&events).unwrap();
         assert_eq!(state.status, RunStatus::AwaitingUser);
         assert_eq!(state.nodes["griller"].status, NodeStatus::AwaitingUser);
+    }
+
+    #[test]
+    fn completion_release_is_iteration_scoped_and_restart_rearms_it() {
+        let mut events = vec![
+            make_event_with_payload(
+                EventKind::RunStarted,
+                None,
+                serde_json::json!({ "pipeline_name": "interactive-pipe" }),
+            ),
+            make_event_with_payload(
+                EventKind::NodeStarted,
+                Some("griller"),
+                serde_json::json!({ "interactive": true }),
+            ),
+            make_event(EventKind::NodeAwaitingUser, Some("griller"), Some(1)),
+            make_event(EventKind::NodeCompletionReleased, Some("griller"), Some(1)),
+        ];
+
+        let released = project(&events).unwrap();
+        assert_eq!(released.status, RunStatus::Running);
+        assert_eq!(released.nodes["griller"].status, NodeStatus::Running);
+        assert!(released.nodes["griller"].iterations[0].interactive);
+        assert!(released.nodes["griller"].iterations[0].completion_released);
+
+        events.push(make_event(EventKind::NodeStarted, Some("griller"), Some(1)));
+        events.push(make_event(
+            EventKind::NodeAwaitingUser,
+            Some("griller"),
+            Some(1),
+        ));
+
+        let restarted = project(&events).unwrap();
+        assert_eq!(restarted.status, RunStatus::AwaitingUser);
+        assert!(!restarted.nodes["griller"].iterations[0].completion_released);
     }
 
     #[test]
@@ -6679,6 +6747,8 @@ mod tests {
                     status: s.clone(),
                     started_at: None,
                     completed_at: None,
+                    interactive: false,
+                    completion_released: false,
                 })
                 .collect(),
             frontmatter_retries: 0,

--- a/crates/pdo-daemon/src/input_resolution.rs
+++ b/crates/pdo-daemon/src/input_resolution.rs
@@ -223,6 +223,8 @@ mod tests {
                     status: status.clone(),
                     started_at: None,
                     completed_at: None,
+                    interactive: false,
+                    completion_released: false,
                 })
                 .collect(),
             frontmatter_retries: 0,

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -890,6 +890,12 @@ struct NodeDoneRequest {
 }
 
 #[derive(Deserialize)]
+struct ReleaseNodeCompletionRequest {
+    #[serde(default)]
+    iter: Option<i64>,
+}
+
+#[derive(Deserialize)]
 struct NodeFailRequest {
     reason: String,
     #[serde(default)]
@@ -1032,14 +1038,19 @@ pub fn run_complete(auto: bool) -> std::process::ExitCode {
         )),
     }
     out.push_str(&refusal_detail_lines(slug, &body));
-    out.push_str(match recoverable {
-        Some(true) => {
+    out.push_str(match (slug, recoverable) {
+        ("completion_not_released", Some(true)) => {
+            "Ask the user to click **Mark ready for completion** (or **Mark complete** to \
+             force completion). After release, run `pdo complete` again.\n\
+             Do NOT run `pdo fail`."
+        }
+        (_, Some(true)) => {
             "Fix what is listed above, then run `pdo complete` again.\nDo NOT run `pdo fail`."
         }
-        Some(false) => {
+        (_, Some(false)) => {
             "Do NOT run `pdo fail` — the failure is already recorded. Stop here and report it."
         }
-        None => "Re-read the run state before acting. Do NOT run `pdo fail` blindly.",
+        (_, None) => "Re-read the run state before acting. Do NOT run `pdo fail` blindly.",
     });
     eprintln!("{out}");
 
@@ -1090,6 +1101,9 @@ fn refusal_headline(slug: &str, body: &serde_json::Value) -> String {
             .and_then(|v| v.as_str())
             .unwrap_or("the run does not accept this completion")
             .to_string(),
+        "completion_not_released" => {
+            "the user has not released this interactive node for completion".into()
+        }
         "run_forgotten" => "this run has been forgotten (archived); it accepts nothing".into(),
         // Unknown slug: hand it over as-is, plus whatever prose came with it.
         other => match body.get("message").and_then(|v| v.as_str()) {
@@ -4580,6 +4594,10 @@ fn build_router(state: Arc<AppState>) -> Router {
         .route("/runs/{run_id}/children", get(list_run_children))
         .route("/runs/{run_id}/events", get(get_run_events))
         .route("/runs/{run_id}/nodes/{node_id}/done", post(node_done))
+        .route(
+            "/runs/{run_id}/nodes/{node_id}/release",
+            post(node_release_completion),
+        )
         .route("/runs/{run_id}/nodes/{node_id}/fail", post(node_fail))
         .route("/runs/{run_id}/nodes/{node_id}/skip", post(node_skip))
         .route("/runs/{run_id}/nodes/{node_id}/pane", get(node_pane))
@@ -17084,6 +17102,10 @@ pub(crate) async fn complete_node_iteration(
         };
     }
 
+    if let Some(refusal) = interactive_completion_refusal(&pre_run_state, &node_id, iter) {
+        return CompletionAttempt::refused(refusal);
+    }
+
     // Liaison forte orchestrateur ↔ enfants (#724 / ADR-0064): a node with the
     // « Orchestrator » toggle does not terminate while its child runs are
     // non-terminal. The gate sits after the transition guard but BEFORE any
@@ -17210,6 +17232,128 @@ pub(crate) async fn complete_node_iteration(
         }
     });
     CompletionAttempt::Completed
+}
+
+fn interactive_completion_refusal(
+    run_state: &event_log::RunState,
+    node_id: &str,
+    iter: i64,
+) -> Option<completion_refusal::CompletionRefusal> {
+    let attempt = run_state
+        .nodes
+        .get(node_id)?
+        .iterations
+        .iter()
+        .find(|attempt| attempt.iter == iter)?;
+    (attempt.interactive && !attempt.completion_released)
+        .then_some(completion_refusal::CompletionRefusal::CompletionNotReleased)
+}
+
+fn release_refusal(slug: &str, message: impl Into<String>) -> Response {
+    (
+        StatusCode::CONFLICT,
+        Json(serde_json::json!({
+            "error": slug,
+            "recoverable": false,
+            "message": message.into(),
+        })),
+    )
+        .into_response()
+}
+
+pub(crate) async fn release_node_completion(
+    state: &Arc<AppState>,
+    run_id: &str,
+    node_id: &str,
+    iter: i64,
+) -> Response {
+    let events = match load_events(&state.db, run_id).await {
+        Ok(events) => events,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": format!("error: {e}") })),
+            )
+                .into_response();
+        }
+    };
+    let Some(run_state) = event_log::project(&events) else {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({ "error": "run_not_found", "recoverable": false })),
+        )
+            .into_response();
+    };
+    if !run_state.status.is_live() {
+        return release_refusal(
+            "run_not_live",
+            format!("run {run_id} has no live session to release"),
+        );
+    }
+    let Some(node) = run_state.nodes.get(node_id) else {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({ "error": "node_not_found", "recoverable": false })),
+        )
+            .into_response();
+    };
+    let Some(attempt) = node.iterations.iter().find(|attempt| attempt.iter == iter) else {
+        return release_refusal(
+            "node_session_not_live",
+            format!("node {node_id} iter {iter} has no live session"),
+        );
+    };
+    if !attempt.interactive {
+        return release_refusal(
+            "node_not_interactive",
+            format!("node {node_id} is not interactive"),
+        );
+    }
+    if !attempt.status.holds_session() {
+        return release_refusal(
+            "node_session_not_live",
+            format!("node {node_id} iter {iter} has no live session"),
+        );
+    }
+    if attempt.completion_released {
+        return (
+            StatusCode::OK,
+            Json(serde_json::json!({ "ok": true, "released": true, "noop": true })),
+        )
+            .into_response();
+    }
+
+    let event = event_log::Event {
+        id: None,
+        run_id: run_id.to_string(),
+        ts: event_log::now_iso(),
+        kind: event_log::EventKind::NodeCompletionReleased,
+        node_id: Some(node_id.to_string()),
+        iter: Some(iter),
+        payload: None,
+    };
+    if let Err(e) = append_event(state, &event).await {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({ "error": format!("error: {e}") })),
+        )
+            .into_response();
+    }
+
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({ "ok": true, "released": true })),
+    )
+        .into_response()
+}
+
+async fn node_release_completion(
+    State(state): State<Arc<AppState>>,
+    AxumPath((run_id, node_id)): AxumPath<(String, String)>,
+    body: Option<Json<ReleaseNodeCompletionRequest>>,
+) -> Response {
+    let iter = body.and_then(|Json(body)| body.iter).unwrap_or(1);
+    release_node_completion(&state, &run_id, &node_id, iter).await
 }
 
 /// Resolve a node's effective `auto_fail` (ADR-0049) — gather all four tiers and
@@ -26956,7 +27100,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn mark_node_done_command_completes_awaiting_node() {
+    async fn mark_node_done_force_completes_unreleased_interactive_node() {
         let state = test_state().await;
 
         let run_id = "test-interactive-run";
@@ -26978,7 +27122,7 @@ mod tests {
                 kind: event_log::EventKind::NodeStarted,
                 node_id: Some("griller".into()),
                 iter: Some(1),
-                payload: None,
+                payload: Some(serde_json::json!({ "interactive": true })),
             },
             event_log::Event {
                 id: None,
@@ -27023,6 +27167,12 @@ mod tests {
         assert_eq!(
             run_state.nodes["griller"].status,
             event_log::NodeStatus::Completed
+        );
+        assert!(
+            !events
+                .iter()
+                .any(|event| event.kind == event_log::EventKind::NodeCompletionReleased),
+            "force completion must bypass the release guard"
         );
     }
 
@@ -27088,6 +27238,260 @@ mod tests {
         let payload = cmd_events[0].payload.as_ref().unwrap();
         assert_eq!(payload["command"], "mark_node_done");
         assert_eq!(payload["node_id"], "griller");
+        assert!(
+            !events
+                .iter()
+                .any(|event| event.kind == event_log::EventKind::NodeCompletionReleased),
+            "force completion must not require a prior release"
+        );
+    }
+
+    async fn seed_interactive_node(
+        state: &Arc<AppState>,
+        run_id: &str,
+        status: event_log::EventKind,
+    ) {
+        for event in [
+            event_log::Event {
+                id: None,
+                run_id: run_id.into(),
+                ts: event_log::now_iso(),
+                kind: event_log::EventKind::RunStarted,
+                node_id: None,
+                iter: None,
+                payload: Some(serde_json::json!({ "pipeline_name": "interactive" })),
+            },
+            event_log::Event {
+                id: None,
+                run_id: run_id.into(),
+                ts: event_log::now_iso(),
+                kind: event_log::EventKind::NodeStarted,
+                node_id: Some("griller".into()),
+                iter: Some(1),
+                payload: Some(serde_json::json!({ "interactive": true })),
+            },
+            event_log::Event {
+                id: None,
+                run_id: run_id.into(),
+                ts: event_log::now_iso(),
+                kind: status,
+                node_id: Some("griller".into()),
+                iter: Some(1),
+                payload: None,
+            },
+        ] {
+            append_event(state, &event).await.unwrap();
+        }
+    }
+
+    async fn response_json(response: Response) -> serde_json::Value {
+        serde_json::from_slice(
+            &axum::body::to_bytes(response.into_body(), usize::MAX)
+                .await
+                .unwrap(),
+        )
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn every_completion_source_is_refused_until_interactive_release() {
+        let state = test_state().await;
+        let run_id = "interactive-completion-guard";
+        seed_interactive_node(&state, run_id, event_log::EventKind::NodeAwaitingUser).await;
+
+        for source in [
+            CompletionSource::Explicit,
+            CompletionSource::StopHook,
+            CompletionSource::TurnEnded,
+            CompletionSource::ChildrenSettled,
+        ] {
+            let attempt =
+                complete_node_iteration(&state, run_id.into(), "griller".into(), 1, source).await;
+            assert!(matches!(
+                attempt,
+                CompletionAttempt::Refused {
+                    refusal: completion_refusal::CompletionRefusal::CompletionNotReleased
+                }
+            ));
+        }
+
+        let response = build_router(state.clone())
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/runs/{run_id}/nodes/griller/done"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"iter":1}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        let body = response_json(response).await;
+        assert_eq!(body["error"], "completion_not_released");
+        assert_eq!(body["recoverable"], true);
+        let events = load_events(&state.db, run_id).await.unwrap();
+        assert!(!events.iter().any(|event| matches!(
+            event.kind,
+            event_log::EventKind::NodeCompleted
+                | event_log::EventKind::NodeAutoCompleted
+                | event_log::EventKind::NodeFailed
+        )));
+    }
+
+    #[tokio::test]
+    async fn release_route_is_projection_backed_and_idempotent() {
+        let state = test_state().await;
+        let run_id = "interactive-release-route";
+        seed_interactive_node(&state, run_id, event_log::EventKind::NodeAwaitingUser).await;
+
+        for expected_noop in [false, true] {
+            let response = build_router(state.clone())
+                .oneshot(
+                    Request::builder()
+                        .method("POST")
+                        .uri(format!("/runs/{run_id}/nodes/griller/release"))
+                        .header("content-type", "application/json")
+                        .body(Body::from(r#"{"iter":1}"#))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            let body = response_json(response).await;
+            assert_eq!(body["released"], true);
+            assert_eq!(
+                body.get("noop").and_then(|v| v.as_bool()),
+                expected_noop.then_some(true)
+            );
+        }
+
+        let events = load_events(&state.db, run_id).await.unwrap();
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| event.kind == event_log::EventKind::NodeCompletionReleased)
+                .count(),
+            1
+        );
+        let run = event_log::project(&events).unwrap();
+        assert_eq!(run.status, event_log::RunStatus::Running);
+        assert_eq!(run.nodes["griller"].status, event_log::NodeStatus::Running);
+        assert!(run.nodes["griller"].iterations[0].completion_released);
+        assert!(interactive_completion_refusal(&run, "griller", 1).is_none());
+    }
+
+    #[tokio::test]
+    async fn release_command_uses_the_same_operation() {
+        let state = test_state().await;
+        let run_id = "interactive-release-command";
+        seed_interactive_node(&state, run_id, event_log::EventKind::NodeAwaitingUser).await;
+
+        let response = build_router(state.clone())
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/runs/{run_id}/commands"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        r#"{"kind":"release_node_completion","node_id":"griller","iter":1}"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let events = load_events(&state.db, run_id).await.unwrap();
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| event.kind == event_log::EventKind::NodeCompletionReleased)
+                .count(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn release_refuses_noninteractive_and_dead_sessions() {
+        let state = test_state().await;
+        for (run_id, interactive, terminal_node, terminal_run, expected) in [
+            (
+                "release-noninteractive",
+                false,
+                false,
+                false,
+                "node_not_interactive",
+            ),
+            (
+                "release-dead-session",
+                true,
+                true,
+                false,
+                "node_session_not_live",
+            ),
+            ("release-dead-run", true, true, true, "run_not_live"),
+        ] {
+            for event in [
+                event_log::Event {
+                    id: None,
+                    run_id: run_id.into(),
+                    ts: event_log::now_iso(),
+                    kind: event_log::EventKind::RunStarted,
+                    node_id: None,
+                    iter: None,
+                    payload: Some(serde_json::json!({ "pipeline_name": "interactive" })),
+                },
+                event_log::Event {
+                    id: None,
+                    run_id: run_id.into(),
+                    ts: event_log::now_iso(),
+                    kind: event_log::EventKind::NodeStarted,
+                    node_id: Some("worker".into()),
+                    iter: Some(1),
+                    payload: Some(serde_json::json!({ "interactive": interactive })),
+                },
+            ] {
+                append_event(&state, &event).await.unwrap();
+            }
+            if terminal_node {
+                append_event(
+                    &state,
+                    &event_log::Event {
+                        id: None,
+                        run_id: run_id.into(),
+                        ts: event_log::now_iso(),
+                        kind: event_log::EventKind::NodeCompleted,
+                        node_id: Some("worker".into()),
+                        iter: Some(1),
+                        payload: None,
+                    },
+                )
+                .await
+                .unwrap();
+            }
+            if terminal_run {
+                append_event(
+                    &state,
+                    &event_log::Event {
+                        id: None,
+                        run_id: run_id.into(),
+                        ts: event_log::now_iso(),
+                        kind: event_log::EventKind::RunCompleted,
+                        node_id: None,
+                        iter: None,
+                        payload: None,
+                    },
+                )
+                .await
+                .unwrap();
+            }
+
+            let response = release_node_completion(&state, run_id, "worker", 1).await;
+            assert_eq!(response.status(), StatusCode::CONFLICT);
+            assert_eq!(response_json(response).await["error"], expected);
+        }
     }
 
     // Node-completion tail convergence: the *observable* behaviour `complete_node`
@@ -28309,6 +28713,8 @@ mod tests {
                             status: event_log::NodeStatus::Completed,
                             started_at: None,
                             completed_at: None,
+                            interactive: false,
+                            completion_released: false,
                         })
                         .collect(),
                     frontmatter_retries: 0,

--- a/crates/pdo-daemon/src/node_io_resolver.rs
+++ b/crates/pdo-daemon/src/node_io_resolver.rs
@@ -314,6 +314,8 @@ mod tests {
                     status: status.clone(),
                     started_at: None,
                     completed_at: None,
+                    interactive: false,
+                    completion_released: false,
                 })
                 .collect(),
             frontmatter_retries: 0,

--- a/crates/pdo-daemon/src/node_primitives.rs
+++ b/crates/pdo-daemon/src/node_primitives.rs
@@ -550,6 +550,7 @@ pub(crate) fn start_node(params: &StartNodeParams<'_>) -> StartNodeResult {
         payload: Some(serde_json::json!({
             "prompt_preview": full_prompt.chars().take(500).collect::<String>(),
             "node_type": node_type_str(&node.node_type),
+            "interactive": node.interactive,
             // #653/ADR-0060: FREEZE where this NodeRun works. Mirrors the
             // `spawn_node` payload — every later reader asks this event.
             "isolated_worktree": has_sub_worktree,
@@ -1046,6 +1047,8 @@ mod tests {
                 status: NodeStatus::Running,
                 started_at: Some("t0".into()),
                 completed_at: None,
+                interactive: false,
+                completion_released: false,
             }],
             frontmatter_retries: 0,
             frontmatter_violations: Vec::new(),
@@ -1074,6 +1077,8 @@ mod tests {
                 status: NodeStatus::Completed,
                 started_at: Some("t0".into()),
                 completed_at: Some("t1".into()),
+                interactive: false,
+                completion_released: false,
             }],
             frontmatter_retries: 0,
             frontmatter_violations: Vec::new(),
@@ -1690,6 +1695,8 @@ mod tests {
                     status: status.clone(),
                     started_at: Some("t0".into()),
                     completed_at: None,
+                    interactive: false,
+                    completion_released: false,
                 })
                 .collect(),
             frontmatter_retries: 0,

--- a/crates/pdo-daemon/src/node_spawn.rs
+++ b/crates/pdo-daemon/src/node_spawn.rs
@@ -1165,6 +1165,7 @@ pub(crate) async fn spawn_node(
             payload: Some(serde_json::json!({
                 "prompt_preview": full_prompt.chars().take(500).collect::<String>(),
                 "node_type": node.node_type.as_str(),
+                "interactive": node.interactive,
                 // #653/ADR-0060: FREEZE where this NodeRun works. Every later
                 // reader — the re-spawn above, the restart probe, the completion
                 // path's merge-back decision — asks this event, never the

--- a/crates/pdo-daemon/src/prompt_augmenter.rs
+++ b/crates/pdo-daemon/src/prompt_augmenter.rs
@@ -763,10 +763,15 @@ pub(crate) fn build_preamble(ctx: &AugmentContext<'_>) -> String {
     preamble.push_str("## Completion\n\n");
     if ctx.node.interactive {
         preamble.push_str(
-            "This is an **interactive** node. Do NOT call `pdo complete`.\n\
-             The user will attach to this terminal session, interact with you,\n\
-             and click **\"Mark complete\"** in the PDO UI when done.\n\
-             Write your outputs to the paths listed above before the user marks complete.\n\n\
+            "For this **interactive** node, once the user says they are done, finish your \
+             work, write the outputs listed above, and run `pdo complete`.\n\
+             Completion is guarded until the user clicks **\"Mark ready for completion\"** \
+             in the PDO UI. If you call `pdo complete` before that release, the daemon \
+             refuses it with `completion_not_released` and exit code 3. Ask the user to \
+             click **\"Mark ready for completion\"**, then run `pdo complete` again.\n\
+             The user may instead click **\"Mark complete\"** to force completion with the \
+             artifacts as they are.\n\
+             A refused completion leaves this node running. **Do NOT run `pdo fail`.**\n\n\
              If you cannot complete the task, signal failure:\n\
              ```\n\
              pdo fail --reason \"<description of the problem>\"\n\
@@ -1045,7 +1050,19 @@ curl -X POST {daemon_url}/runs/{run_id}/commands \
 
 This goes through the same shared completion body as `pdo complete`, so it answers truthfully (#490): `200 {{"ok":true}}` when the node completed, `200 {{"ok":true,"noop":true,"reason":"…"}}` on a legal duplicate, and **`409 {{"error":"<slug>","recoverable":<bool>, …}}`** when the completion is refused — `missing_outputs`, `frontmatter_retry_pending`, `frontmatter_retry_exhausted`, `script_validation_failed`, `completion_rejected`, … Discriminate on `error`, never on the status. `recoverable:false` means the runtime already recorded the terminal event: do not try to record it again.
 
-### 7. inject_artifact
+### 7. release_node_completion
+
+Release the daemon completion guard for one live interactive NodeRun. The agent may then call `pdo complete` when ready. This is idempotent and does not inject text into the node session.
+
+```bash
+curl -X POST {daemon_url}/runs/{run_id}/commands \
+  -H 'Content-Type: application/json' \
+  -d '{{"kind":"release_node_completion","node_id":"<node-id>","iter":<N>}}'
+```
+
+Returns `200 {{"ok":true,"released":true}}`, with `"noop":true` when already released. Named `409` refusals include `node_not_interactive` and `node_session_not_live`; discriminate on `error`, never on the status.
+
+### 8. inject_artifact
 
 Write an artifact directly into the Blackboard.
 
@@ -1055,7 +1072,7 @@ curl -X POST {daemon_url}/runs/{run_id}/commands \
   -d '{{"kind":"inject_artifact","path":"<node-id>/iter-<N>/<port>/output.md","content":"<markdown content>"}}'
 ```
 
-### 8. cleanup_run
+### 9. cleanup_run
 
 Archive the run: remove worktrees, branches, and artifacts from disk. Events are preserved.
 
@@ -1067,7 +1084,7 @@ curl -X POST {daemon_url}/runs/{run_id}/commands \
 
 **Never call `cleanup_run` on your own initiative.** It is destructive and irreversible: it kills every active node session and removes the run's worktrees, branches, and artifacts from disk. Always check with the user first and wait for explicit confirmation before issuing it — even if you believe the run is stuck or finished.
 
-### 9. rename_run
+### 10. rename_run
 
 Set or update the display name of this run.
 
@@ -1077,7 +1094,7 @@ curl -X POST {daemon_url}/runs/{run_id}/commands \
   -d '{{"kind":"rename_run","name":"<display name>"}}'
 ```
 
-### 10. start_node
+### 11. start_node
 
 Force-spawn a node now, without waiting for its upstream producers to complete. Use when you deliberately want to start a node ahead of its dependencies. Inputs resolve best-effort: any not-yet-produced upstream artifact resolves to the path where it *will* appear, so the node may run against missing or stale inputs. This is reversible — `restart_node` or `kill_node` it if it ran too early.
 
@@ -1087,7 +1104,7 @@ curl -X POST {daemon_url}/runs/{run_id}/commands \
   -d '{{"kind":"start_node","node_id":"<node-id>"}}'
 ```
 
-### 11. extend_cycle (legacy)
+### 12. extend_cycle (legacy)
 
 Increment the iteration ceiling of a *legacy drawn cycle* (a pipeline without a `loops:` block) and re-evaluate. `node_id` is the node whose **outgoing exit condition** references the `$max_iter`-style variable to bump — never the cycle's head/entry node. For any node that belongs to a bounded loop region this command is rejected with 409 — use `bump_region` instead. An unknown `node_id` is rejected with 400. Same truthful response body as `bump_region`.
 
@@ -1902,12 +1919,10 @@ mod tests {
         let ctx = sample_ctx(&pipeline, node, &vars);
 
         let preamble = build_preamble(&ctx);
-        assert!(
-            !preamble.contains("signal completion by running"),
-            "interactive node should not instruct to run pdo complete"
-        );
-        assert!(preamble.contains("Do NOT call `pdo complete`"));
-        assert!(preamble.contains("Mark complete"));
+        assert!(preamble.contains("once the user says they are done"));
+        assert!(preamble.contains("completion_not_released"));
+        assert!(preamble.contains("Mark ready for completion"));
+        assert!(preamble.contains("Do NOT run `pdo fail`"));
         assert!(preamble.contains("pdo fail --reason"));
     }
 
@@ -2353,6 +2368,7 @@ mod tests {
             "kill_node",
             "restart_node",
             "mark_node_done",
+            "release_node_completion",
             "inject_artifact",
             "cleanup_run",
             "rename_run",
@@ -2455,15 +2471,15 @@ mod tests {
         let preamble =
             build_manager_preamble("run-1", "http://localhost:5172", RunNameHint::UserProvided);
         let section = preamble
-            .split("### 8. cleanup_run")
+            .split("### 9. cleanup_run")
             .nth(1)
             .expect("preamble should contain the cleanup_run section")
-            .split("### 9.")
+            .split("### 10.")
             .next()
-            .expect("cleanup_run section should be delimited by section 9");
+            .expect("cleanup_run section should be delimited by section 10");
         assert!(
-            preamble.contains("### 9. rename_run"),
-            "renumbering drifted: section 9 should be rename_run"
+            preamble.contains("### 10. rename_run"),
+            "renumbering drifted: section 10 should be rename_run"
         );
         assert!(
             section.contains("Never call `cleanup_run` on your own initiative"),

--- a/crates/pdo-daemon/src/run_advance.rs
+++ b/crates/pdo-daemon/src/run_advance.rs
@@ -1133,6 +1133,8 @@ mod tests {
                 status,
                 started_at: Some("t0".into()),
                 completed_at,
+                interactive: false,
+                completion_released: false,
             }],
             frontmatter_retries: 0,
             frontmatter_violations: Vec::new(),

--- a/crates/pdo-daemon/src/run_command.rs
+++ b/crates/pdo-daemon/src/run_command.rs
@@ -82,6 +82,10 @@ enum RunCommand {
         node_id: String,
         iter: i64,
     },
+    ReleaseNodeCompletion {
+        node_id: String,
+        iter: i64,
+    },
     ExtendCycle {
         node_id: String,
         additional_iter: i64,
@@ -191,6 +195,7 @@ impl RunCommand {
     fn kind_str(&self) -> &'static str {
         match self {
             RunCommand::MarkNodeDone { .. } => "mark_node_done",
+            RunCommand::ReleaseNodeCompletion { .. } => "release_node_completion",
             RunCommand::ExtendCycle { .. } => "extend_cycle",
             RunCommand::Region {
                 action: RegionAction::Bump { .. },
@@ -253,6 +258,10 @@ fn parse_run_command(req: RunCommandRequest) -> Result<RunCommand, CommandParseE
     match req.kind.as_str() {
         "mark_node_done" => Ok(RunCommand::MarkNodeDone {
             node_id: required(req.node_id, "node_id", "mark_node_done")?,
+            iter: req.iter.unwrap_or(1),
+        }),
+        "release_node_completion" => Ok(RunCommand::ReleaseNodeCompletion {
+            node_id: required(req.node_id, "node_id", "release_node_completion")?,
             iter: req.iter.unwrap_or(1),
         }),
         "extend_cycle" => {
@@ -498,6 +507,9 @@ async fn dispatch(state: Arc<AppState>, run_id: String, cmd: RunCommand) -> Resp
     let kind_str = cmd.kind_str();
 
     match cmd {
+        RunCommand::ReleaseNodeCompletion { node_id, iter } => {
+            crate::release_node_completion(&state, &run_id, &node_id, iter).await
+        }
         RunCommand::MarkNodeDone { node_id, iter } => {
             // NOT `load_projected`, which would 404 on an unstarted run: this arm
             // needs the `Option<RunState>` itself, so `None` maps to `Allow` and
@@ -2680,11 +2692,18 @@ mod tests {
     }
 
     #[test]
-    fn parse_accepts_the_fourteen_kinds() {
-        let cases: [(serde_json::Value, RunCommand); 14] = [
+    fn parse_accepts_the_fifteen_kinds() {
+        let cases: [(serde_json::Value, RunCommand); 15] = [
             (
                 serde_json::json!({ "kind": "mark_node_done", "node_id": "n1", "iter": 3 }),
                 RunCommand::MarkNodeDone {
+                    node_id: "n1".into(),
+                    iter: 3,
+                },
+            ),
+            (
+                serde_json::json!({ "kind": "release_node_completion", "node_id": "n1", "iter": 3 }),
+                RunCommand::ReleaseNodeCompletion {
                     node_id: "n1".into(),
                     iter: 3,
                 },
@@ -2781,6 +2800,10 @@ mod tests {
             (
                 serde_json::json!({ "kind": "mark_node_done" }),
                 "node_id required for mark_node_done",
+            ),
+            (
+                serde_json::json!({ "kind": "release_node_completion" }),
+                "node_id required for release_node_completion",
             ),
             (
                 serde_json::json!({ "kind": "extend_cycle" }),
@@ -2927,6 +2950,7 @@ mod tests {
         // distinguished in the type.
         for kind in [
             "mark_node_done",
+            "release_node_completion",
             "extend_cycle",
             "bump_region",
             "end_region",

--- a/crates/pdo-daemon/src/scheduler.rs
+++ b/crates/pdo-daemon/src/scheduler.rs
@@ -4427,6 +4427,8 @@ mod tests {
                 status: NodeStatus::Completed,
                 started_at: Some("t0".into()),
                 completed_at: Some("t1".into()),
+                interactive: false,
+                completion_released: false,
             })
             .collect();
         ns

--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -12,6 +12,7 @@ import {
   editRunRepos,
   fetchPipeline,
   markNodeDone,
+  releaseNodeCompletion,
   request,
   savePipeline,
   saveRunPipeline,
@@ -323,6 +324,32 @@ describe("markNodeDone outcome union (#490)", () => {
   it("reads a plain 200 as completed", async () => {
     stubFetchWith(200, { ok: true });
     await expect(markNodeDone("r1", "n1", 1)).resolves.toEqual({ kind: "completed" });
+  });
+
+  describe("releaseNodeCompletion (#764)", () => {
+    it("posts the displayed iteration to the release route", async () => {
+      const fetchMock = captureFetch(200, { ok: true, released: true });
+      await expect(releaseNodeCompletion("r1", "n1", 3)).resolves.toEqual({
+        kind: "released",
+      });
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toContain("/runs/r1/nodes/n1/release");
+      expect(JSON.parse(init?.body as string)).toEqual({ iter: 3 });
+    });
+
+    it("returns a named 409 refusal as a verdict", async () => {
+      stubFetchWith(409, {
+        error: "node_session_not_live",
+        recoverable: true,
+        message: "no live session",
+      });
+      await expect(releaseNodeCompletion("r1", "n1", 1)).resolves.toEqual({
+        kind: "refused",
+        slug: "node_session_not_live",
+        recoverable: true,
+        message: "no live session",
+      });
+    });
   });
 
   it("reads a 200 with noop:true as a legal duplicate, not a refusal", async () => {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -568,6 +568,47 @@ export async function markNodeDone(
   return { kind: "completed" };
 }
 
+export type ReleaseNodeCompletionOutcome =
+  | { kind: "released" }
+  | {
+      kind: "refused";
+      slug: string | null;
+      recoverable: boolean | null;
+      message: string;
+    };
+
+export async function releaseNodeCompletion(
+  runId: string,
+  nodeId: string,
+  iter: number,
+): Promise<ReleaseNodeCompletionOutcome> {
+  const resp = await request<Response>(
+    "POST",
+    `/runs/${encodeURIComponent(runId)}/nodes/${encodeURIComponent(nodeId)}/release`,
+    { body: { iter }, responseMode: "raw" },
+  );
+  const body: unknown = await resp.json().catch(() => null);
+  if (resp.status === 409) {
+    const refusal = body as
+      | { error?: unknown; recoverable?: unknown; message?: unknown }
+      | null;
+    return {
+      kind: "refused",
+      slug: typeof refusal?.error === "string" ? refusal.error : null,
+      recoverable:
+        typeof refusal?.recoverable === "boolean" ? refusal.recoverable : null,
+      message: apiErrorMessage(body, `release refused: ${resp.status}`),
+    };
+  }
+  if (!resp.ok) {
+    throw new ApiError(
+      apiErrorMessage(body, `release completion failed: ${resp.status}`),
+      { status: resp.status, body },
+    );
+  }
+  return { kind: "released" };
+}
+
 export function attachSession(sessionId: string): Promise<void> {
   return request<void>(
     "POST",

--- a/frontend/src/components/NodeDetailPanel.test.tsx
+++ b/frontend/src/components/NodeDetailPanel.test.tsx
@@ -34,11 +34,13 @@ const previewProvisioningMock = vi.fn().mockResolvedValue({
 // had ever exercised a *Mark complete* click. Made controllable so the verdict
 // branches can be driven. Vitest compares arity strictly, hence the spread.
 const markNodeDoneMock = vi.fn().mockResolvedValue({ kind: "completed" });
+const releaseNodeCompletionMock = vi.fn().mockResolvedValue({ kind: "released" });
 
 vi.mock("../api", () => ({
   fetchPrompt: (...args: unknown[]) => fetchPromptMock(...args),
   fetchNodeIO: (...args: unknown[]) => fetchNodeIOMock(...args),
   markNodeDone: (...args: unknown[]) => markNodeDoneMock(...args),
+  releaseNodeCompletion: (...args: unknown[]) => releaseNodeCompletionMock(...args),
   killNode: (...args: unknown[]) => killNodeMock(...args),
   restartNode: (...args: unknown[]) => restartNodeMock(...args),
   stopNode: (...args: unknown[]) => stopNodeMock(...args),
@@ -142,6 +144,8 @@ describe("NodeDetailPanel", () => {
     retryNodePreviewMock.mockResolvedValue({ downstream: [], affected_count: 0, with_artifacts: [] });
     markNodeDoneMock.mockClear();
     markNodeDoneMock.mockResolvedValue({ kind: "completed" });
+    releaseNodeCompletionMock.mockClear();
+    releaseNodeCompletionMock.mockResolvedValue({ kind: "released" });
     tmuxMountCount.current = 0;
     tmuxUnmountCount.current = 0;
   });
@@ -1810,6 +1814,142 @@ describe("NodeDetailPanel", () => {
         fireEvent.click(option);
       });
       expect(screen.queryByTestId("mark-complete-verdict")).not.toBeInTheDocument();
+    });
+
+    describe("release completion (#764)", () => {
+      const liveInteractive = (overrides?: Partial<NodeState>) =>
+        makeNode({
+          status: "awaiting_user",
+          iterations: [
+            {
+              iter: 1,
+              status: "awaiting_user",
+              started_at: null,
+              completed_at: null,
+              interactive: true,
+              completion_released: false,
+            },
+          ],
+          ...overrides,
+        });
+
+      it("shows both exits only for a live interactive iteration", () => {
+        const { rerender } = render(
+          <TooltipProvider>
+            <NodeDetailPanel node={liveInteractive()} runId="run-1" />
+          </TooltipProvider>,
+        );
+        expect(screen.getByTestId("release-completion-btn")).toBeInTheDocument();
+        expect(screen.getByTestId("mark-complete-btn")).toBeInTheDocument();
+
+        rerender(
+          <TooltipProvider>
+            <NodeDetailPanel
+              node={liveInteractive({
+                iterations: [
+                  {
+                    iter: 1,
+                    status: "awaiting_user",
+                    started_at: null,
+                    completed_at: null,
+                    interactive: false,
+                    completion_released: false,
+                  },
+                ],
+              })}
+              runId="run-1"
+            />
+          </TooltipProvider>,
+        );
+        expect(screen.queryByTestId("release-completion-btn")).not.toBeInTheDocument();
+
+        rerender(
+          <TooltipProvider>
+            <NodeDetailPanel
+              node={liveInteractive({ status: "completed" })}
+              runId="run-1"
+            />
+          </TooltipProvider>,
+        );
+        expect(screen.queryByTestId("release-completion-btn")).not.toBeInTheDocument();
+      });
+
+      it("calls release and renders the projected released state", async () => {
+        const { rerender } = render(
+          <TooltipProvider>
+            <NodeDetailPanel node={liveInteractive()} runId="run-1" />
+          </TooltipProvider>,
+        );
+        await act(async () => {
+          fireEvent.click(screen.getByTestId("release-completion-btn"));
+        });
+        expect(releaseNodeCompletionMock).toHaveBeenCalledWith("run-1", "test-node", 1);
+        expect(screen.queryByTestId("release-verdict")).not.toBeInTheDocument();
+
+        rerender(
+          <TooltipProvider>
+            <NodeDetailPanel
+              node={liveInteractive({
+                status: "running",
+                iterations: [
+                  {
+                    iter: 1,
+                    status: "running",
+                    started_at: null,
+                    completed_at: null,
+                    interactive: true,
+                    completion_released: true,
+                  },
+                ],
+              })}
+              runId="run-1"
+            />
+          </TooltipProvider>,
+        );
+        expect(screen.getByTestId("release-verdict")).toHaveAttribute(
+          "data-verdict",
+          "released",
+        );
+        expect(screen.getByTestId("release-verdict")).toHaveTextContent(
+          "tell the agent in the terminal",
+        );
+      });
+
+      it("renders projected release state after reload and scopes it to the displayed iteration", () => {
+        render(
+          <TooltipProvider>
+            <NodeDetailPanel
+              node={liveInteractive({
+                status: "running",
+                iter: 2,
+                iterations: [
+                  {
+                    iter: 1,
+                    status: "running",
+                    started_at: null,
+                    completed_at: null,
+                    interactive: true,
+                    completion_released: true,
+                  },
+                  {
+                    iter: 2,
+                    status: "awaiting_user",
+                    started_at: null,
+                    completed_at: null,
+                    interactive: true,
+                    completion_released: false,
+                  },
+                ],
+              })}
+              runId="run-1"
+            />
+          </TooltipProvider>,
+        );
+
+        expect(screen.getByTestId("release-completion-btn")).toHaveTextContent(
+          "Mark ready for completion",
+        );
+      });
     });
   });
 });

--- a/frontend/src/components/NodeDetailPanel.tsx
+++ b/frontend/src/components/NodeDetailPanel.tsx
@@ -9,6 +9,8 @@ import {
   Play,
   Maximize2,
   GitCompareArrows,
+  LockOpen,
+  LoaderCircle,
 } from "lucide-react";
 import type {
   IterationInfo,
@@ -20,7 +22,7 @@ import { artifactUrl } from "../api";
 import type { PortIO, FileInfo } from "../api";
 import type { PortType } from "../types";
 import { useNodeRun } from "../hooks/useNodeRun";
-import type { MarkVerdict } from "../hooks/useNodeRun";
+import type { MarkVerdict, ReleaseVerdict } from "../hooks/useNodeRun";
 import {
   ResizablePanelGroup,
   ResizablePanel,
@@ -209,6 +211,60 @@ function MarkCompleteVerdict({ verdict }: { verdict: MarkVerdict }) {
   );
 }
 
+function ReleaseCompletionVerdict({
+  verdict,
+}: {
+  verdict: ReleaseVerdict | { kind: "released" };
+}) {
+  const refused = verdict.kind === "refused" ? verdict : null;
+  const failed = verdict.kind === "refused" || verdict.kind === "error";
+  const toneClass =
+    verdict.kind === "released"
+      ? "border-st-running/30 bg-st-running-bg text-st-running"
+      : failed
+        ? "border-st-failed/30 bg-st-failed-bg text-st-failed"
+        : "border-line-strong bg-bg-3 text-fg-3";
+  const headline =
+    verdict.kind === "released"
+      ? "Completion released — the agent will complete when ready."
+      : verdict.kind === "pending"
+        ? "Releasing completion…"
+        : verdict.kind === "error"
+          ? `Could not reach the daemon — ${verdict.message}`
+          : `Release refused — ${verdict.message}`;
+
+  return (
+    <div
+      className={`flex flex-col gap-1 rounded-md border px-2.5 py-1.5 ${toneClass}`}
+      style={{ fontSize: "10.5px" }}
+      data-testid="release-verdict"
+      data-verdict={verdict.kind}
+      data-slug={refused?.slug ?? ""}
+      data-recoverable={refused ? String(refused.recoverable) : ""}
+    >
+      <div className="flex items-start gap-1.5">
+        {verdict.kind === "released" ? (
+          <CheckCircle size={12} className="mt-px shrink-0" />
+        ) : verdict.kind === "pending" ? (
+          <LoaderCircle size={12} className="mt-px shrink-0 animate-spin" />
+        ) : (
+          <AlertCircle size={12} className="mt-px shrink-0" />
+        )}
+        <span>{headline}</span>
+      </div>
+      {verdict.kind === "released" && (
+        <span className="pl-5">
+          Now tell the agent in the terminal that you are done. Mark complete still
+          forces it.
+        </span>
+      )}
+      {verdict.kind === "refused" && (
+        <span className="pl-5">Retry the node, then release again.</span>
+      )}
+    </div>
+  );
+}
+
 // The session is settled — the tmux session is gone, so the terminal WebSocket
 // would attach to a dead session. `{completed, skipped, failed, stopped,
 // interrupted}` is exactly the "settled" tier of `pollInterval` (5s). A `skipped`
@@ -304,6 +360,7 @@ export default function NodeDetailPanel({
     inputs,
     outputs,
     markVerdict,
+    releaseVerdict,
     actionVerdict,
     retryConfirm,
     stop,
@@ -312,6 +369,7 @@ export default function NodeDetailPanel({
     cancelRetry,
     start,
     markComplete,
+    releaseCompletion,
     killStale,
     restartIteration,
   } = useNodeRun(runId, node, selectedIter, {
@@ -329,6 +387,14 @@ export default function NodeDetailPanel({
   // The terminal reads this to decide whether to attach or to read the frozen pane.
   const selectedIterStatus =
     node.iterations?.find((i) => i.iter === selectedIter)?.status ?? node.status;
+  const selectedIteration = node.iterations?.find((i) => i.iter === selectedIter);
+  const completionReleased = selectedIteration?.completion_released === true;
+  const isReleasing =
+    releaseVerdict?.iter === selectedIter && releaseVerdict.kind === "pending";
+  const canReleaseCompletion =
+    selectedIteration?.interactive === true &&
+    (selectedIterStatus === "running" || selectedIterStatus === "awaiting_user") &&
+    !isArchived;
 
   // #369: the I/O poll (`setInputs`/`setOutputs`) re-renders this panel every
   // tick (1s live, 5s settled). Building the modal's `source` prop as an inline
@@ -513,15 +579,29 @@ export default function NodeDetailPanel({
         </div>
       )}
 
+      {completionReleased && selectedIterStatus === "running" && (
+        <div className="flex items-center gap-2 border-b border-st-running/30 bg-st-running-bg px-3 py-2">
+          <CheckCircle size={14} className="shrink-0 text-st-running" />
+          <span
+            className="text-st-running"
+            style={{ fontSize: "11.5px", fontWeight: 500 }}
+          >
+            Running — completion released. Tell the agent when you are done.
+          </span>
+        </div>
+      )}
+
       {/* Awaiting user banner */}
-      {node.status === "awaiting_user" && (
+      {selectedIterStatus === "awaiting_user" && !completionReleased && (
         <div className="flex items-center gap-2 border-b border-st-await/30 bg-st-await-bg px-3 py-2">
           <AlertCircle size={14} className="shrink-0 text-st-await" />
           <span
             className="text-st-await"
             style={{ fontSize: "11.5px", fontWeight: 500 }}
           >
-            Awaiting user — interact in the terminal below, then mark complete
+            {selectedIteration?.interactive
+              ? "Awaiting user — when done, release completion so the agent can finish, or mark complete to take the artifacts as they are"
+              : "Awaiting user — interact in the terminal below, then mark complete"}
           </span>
         </div>
       )}
@@ -789,15 +869,52 @@ export default function NodeDetailPanel({
                   is genuinely incomplete. */}
               {(node.status === "awaiting_user" || node.status === "running" || node.status === "failed" || node.status === "stale" || node.status === "interrupted") && !isArchived && (
                 <>
-                  <button
-                    onClick={markComplete}
-                    data-testid="mark-complete-btn"
-                    className="flex w-full cursor-pointer items-center justify-center gap-1.5 rounded-md border border-st-done/40 bg-st-done-bg px-3 py-1.5 text-st-done transition-colors hover:border-st-done/60 hover:bg-st-done/20"
-                    style={{ fontSize: "11.5px", fontWeight: 500 }}
-                  >
-                    <CheckCircle size={12} />
-                    Mark complete
-                  </button>
+                  <div className="flex flex-wrap gap-1.5">
+                    {canReleaseCompletion && (
+                        <button
+                          onClick={releaseCompletion}
+                          title="Enables the node to call pdo complete when it chooses and to proceed with the run"
+                          disabled={isReleasing}
+                          data-testid="release-completion-btn"
+                          className={`flex min-w-[140px] flex-1 cursor-pointer items-center justify-center gap-1.5 rounded-md border border-st-await/40 bg-st-await-bg px-3 py-1.5 text-st-await transition-colors hover:border-st-await/60 hover:bg-st-await/20 disabled:cursor-wait disabled:opacity-70 ${
+                            completionReleased ? "border-dashed" : ""
+                          }`}
+                          style={{ fontSize: "11.5px", fontWeight: 500 }}
+                        >
+                          {isReleasing ? (
+                            <LoaderCircle size={12} className="animate-spin" />
+                          ) : completionReleased ? (
+                            <CheckCircle size={12} />
+                          ) : (
+                            <LockOpen size={12} />
+                          )}
+                          {isReleasing
+                            ? "Releasing…"
+                            : completionReleased
+                              ? "Completion released"
+                              : "Mark ready for completion"}
+                        </button>
+                    )}
+                      <button
+                        onClick={markComplete}
+                        title="Take the artifacts as they are and complete the node now"
+                        data-testid="mark-complete-btn"
+                        className="flex min-w-[140px] flex-1 cursor-pointer items-center justify-center gap-1.5 rounded-md border border-st-done/40 bg-st-done-bg px-3 py-1.5 text-st-done transition-colors hover:border-st-done/60 hover:bg-st-done/20"
+                        style={{ fontSize: "11.5px", fontWeight: 500 }}
+                      >
+                        <CheckCircle size={12} />
+                        Mark complete
+                      </button>
+                  </div>
+
+                  {completionReleased ? (
+                    <ReleaseCompletionVerdict verdict={{ kind: "released" }} />
+                  ) : (
+                    releaseVerdict &&
+                    releaseVerdict.iter === selectedIter && (
+                      <ReleaseCompletionVerdict verdict={releaseVerdict} />
+                    )
+                  )}
 
                   {/* #490: the verdict of the click, AT the gesture. Rendered for
                       every outcome including `pending`, so nothing ever blinks out

--- a/frontend/src/hooks/useNodeRun.test.ts
+++ b/frontend/src/hooks/useNodeRun.test.ts
@@ -9,6 +9,7 @@ vi.mock("../api", () => ({
   fetchPrompt: vi.fn(),
   fetchNodeIO: vi.fn(),
   markNodeDone: vi.fn(),
+  releaseNodeCompletion: vi.fn(),
   killNode: vi.fn(),
   restartNode: vi.fn(),
   startNode: vi.fn(),
@@ -58,6 +59,7 @@ beforeEach(() => {
   vi.mocked(api.fetchPrompt).mockReset().mockResolvedValue("PROMPT");
   vi.mocked(api.fetchNodeIO).mockReset().mockResolvedValue(IO);
   vi.mocked(api.markNodeDone).mockReset().mockResolvedValue({ kind: "completed" });
+  vi.mocked(api.releaseNodeCompletion).mockReset().mockResolvedValue({ kind: "released" });
   vi.mocked(api.retryNodePreview)
     .mockReset()
     .mockResolvedValue({ downstream: [], affected_count: 0, with_artifacts: [] });
@@ -215,6 +217,7 @@ describe("useNodeRun — mark complete (#490)", () => {
     await act(async () => {
       result.current.markComplete();
     });
+
     expect(result.current.markVerdict).toEqual({ iter: 3, kind: "pending" });
   });
 
@@ -269,6 +272,45 @@ describe("useNodeRun — mark complete (#490)", () => {
       await result.current.markComplete();
     });
     expect(result.current.markVerdict).toEqual({ iter: 1, kind: "error", message: "boom" });
+  });
+});
+
+describe("useNodeRun — release completion (#764)", () => {
+  it("stamps the release verdict with the selected iteration", async () => {
+    const { result } = renderHook(() =>
+      useNodeRun("run-1", makeNode({ status: "awaiting_user", iter: 4 }), 2, {}),
+    );
+    await flush();
+
+    await act(async () => {
+      await result.current.releaseCompletion();
+    });
+
+    expect(api.releaseNodeCompletion).toHaveBeenCalledWith("run-1", "n1", 2);
+    expect(result.current.releaseVerdict).toBeNull();
+  });
+
+  it("surfaces a release refusal at the gesture", async () => {
+    vi.mocked(api.releaseNodeCompletion).mockResolvedValue({
+      kind: "refused",
+      slug: "node_session_not_live",
+      recoverable: true,
+      message: "no live session",
+    });
+    const { result } = renderHook(() =>
+      useNodeRun("run-1", makeNode({ status: "awaiting_user" }), 1, {}),
+    );
+    await flush();
+
+    await act(async () => {
+      await result.current.releaseCompletion();
+    });
+
+    expect(result.current.releaseVerdict).toMatchObject({
+      iter: 1,
+      kind: "refused",
+      slug: "node_session_not_live",
+    });
   });
 });
 

--- a/frontend/src/hooks/useNodeRun.ts
+++ b/frontend/src/hooks/useNodeRun.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import {
   markNodeDone,
+  releaseNodeCompletion,
   killNode,
   restartNode,
   startNode,
@@ -10,7 +11,11 @@ import {
   fetchPrompt,
   fetchNodeIO,
 } from "../api";
-import type { PortIO, MarkNodeDoneOutcome } from "../api";
+import type {
+  PortIO,
+  MarkNodeDoneOutcome,
+  ReleaseNodeCompletionOutcome,
+} from "../api";
 import type { NodeState, NodeStatus } from "../types";
 
 function pollInterval(status: NodeStatus): number | null {
@@ -44,6 +49,11 @@ function pollInterval(status: NodeStatus): number | null {
 export type MarkVerdict =
   | { kind: "pending" }
   | MarkNodeDoneOutcome
+  | { kind: "error"; message: string };
+
+export type ReleaseVerdict =
+  | { kind: "pending" }
+  | Extract<ReleaseNodeCompletionOutcome, { kind: "refused" }>
   | { kind: "error"; message: string };
 
 /**
@@ -112,6 +122,9 @@ export function useNodeRun(
   // kills a latent second bug: a verdict from iter 3 surviving a switch back to iter 1.
   const [markVerdict, setMarkVerdict] = useState<
     ({ iter: number } & MarkVerdict) | null
+  >(null);
+  const [releaseVerdict, setReleaseVerdict] = useState<
+    ({ iter: number } & ReleaseVerdict) | null
   >(null);
   const [retryConfirm, setRetryConfirm] = useState<{
     affectedCount: number;
@@ -275,6 +288,23 @@ export function useNodeRun(
     }
   }, [runId, node.node_id, selectedIter]);
 
+  const releaseCompletion = useCallback(async () => {
+    const iter = selectedIter;
+    setReleaseVerdict({ iter, kind: "pending" });
+    try {
+      const outcome = await releaseNodeCompletion(runId, node.node_id, iter);
+      setReleaseVerdict(
+        outcome.kind === "released" ? null : { iter, ...outcome },
+      );
+    } catch (e) {
+      setReleaseVerdict({
+        iter,
+        kind: "error",
+        message: e instanceof Error ? e.message : String(e),
+      });
+    }
+  }, [runId, node.node_id, selectedIter]);
+
   // The two stale-banner actions (ADR-0032 §1: historical runs only). Iter-scoped
   // like the reads — the banner acts on the iteration on screen, not on
   // `node.iter`.
@@ -300,6 +330,7 @@ export function useNodeRun(
     inputs,
     outputs,
     markVerdict,
+    releaseVerdict,
     actionVerdict,
     retryConfirm,
     stop,
@@ -308,6 +339,7 @@ export function useNodeRun(
     cancelRetry,
     start,
     markComplete,
+    releaseCompletion,
     killStale,
     restartIteration,
   };

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -792,6 +792,8 @@ export interface IterationInfo {
   status: NodeStatus;
   started_at: string | null;
   completed_at: string | null;
+  interactive?: boolean;
+  completion_released?: boolean;
 }
 
 /**


### PR DESCRIPTION
Sub-ticket #764 of story #763 (ADR-0068). Closes #764.

## What
- Daemon: `completion_not_released` guard — `pdo complete` from an `interactive` node returns exit 3 until the user releases it; `POST /runs/{id}/nodes/{node}/release` (`release_node_completion` command, `node_completion_released` event, idempotent; 409 `run_not_live` without a live session).
- UI: node panel shows **Mark complete** and **Mark ready for completion** side by side; released state ("Completion released") + banner + inline verdict.
- Release: 1.80.0 (Cargo.toml, Cargo.lock, CHANGELOG).

## Local gate
- Agentic FP (#764 Feature Path) run on a debug build of `66b2042` with an isolated daemon and two real claude sessions: **5/5 steps pass**, no blocking finding (see run `20260910-162834-b4a0718`, node `b4kko9SV`).
- Non-blocking nit: the `node_completed` event after the agent's own `pdo complete` carries a `null` payload, so the FP's expected `source: explicit` is not visible in the log (pre-existing on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)