### PR TITLE
feat(ops): --bind on daemon and service, honest unit PATH, pdo command table in README (#769) — 1.81.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ ascendante** : la casse se signale ici et par un bump majeur, jamais en gardant 
 morts. Seule contrainte non négociable — les **données historiques restent lisibles** : un Run
 archivé s'ouvre et se chiffre quelle que soit la version qui a écrit son payload.
 
+## 1.81.0
+**Déploiement derrière un reverse proxy** (#769 ; story #766, ADR-0019).
+`pdo daemon` et `pdo service install` acceptent désormais `--bind <ip>` ou `PDO_BIND`.
+L'adresse explicite survit aux mises à jour, les unités de service dédupliquent leur `PATH` et
+précisent que les harnais utilisent le `PATH` du shell interactif (ADR-0055). Le README regroupe
+les commandes `pdo` dans une table et documente le drop-in systemd persistant.
+
 ## 1.80.0
 **Nœud interactif — « Mark ready for completion » rend la complétion à l'agent** (#764 ; story #763, ADR-0068).
 Sur un nœud `interactive`, `pdo complete` lancé par l'agent est désormais **refusé** (exit 3, garde

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ ascendante** : la casse se signale ici et par un bump majeur, jamais en gardant 
 morts. Seule contrainte non négociable — les **données historiques restent lisibles** : un Run
 archivé s'ouvre et se chiffre quelle que soit la version qui a écrit son payload.
 
+## 1.80.0
+**Nœud interactif — « Mark ready for completion » rend la complétion à l'agent** (#764 ; story #763, ADR-0068).
+Sur un nœud `interactive`, `pdo complete` lancé par l'agent est désormais **refusé** (exit 3, garde
+`completion_not_released`) tant que l'utilisateur n'a pas libéré la complétion : l'agent est invité à demander le clic.
+Le panneau du nœud propose deux boutons côte à côte : **Mark complete** (prend les artefacts tels quels, complète
+immédiatement — comportement inchangé) et **Mark ready for completion** (`POST /runs/{id}/nodes/{node}/release`,
+commande `release_node_completion`, évènement `node_completion_released`, idempotent). Une fois libéré, le nœud repasse
+`running`, le Run n'est plus `awaiting_user`, et c'est l'agent qui complète quand il a fini. La libération est
+refusée (409 `run_not_live`) sans session vivante.
 ## 1.79.0
 **Page de Review — report / outdated des commentaires, accès rapide Review, onglet Repositories** (#752 ; story #746, ADR-0067).
 Quand la paire affichée a bougé depuis l'écriture d'un commentaire (relivraison d'un nœud, merge-back), le daemon

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -848,6 +848,10 @@ Choix et pourquoi → ADR-0003. Daemon **Rust**, frontend **React + Vite** (canv
 
 **Service unit** : l'unité OS qui fait démarrer le daemon au boot et survivre au logout (systemd `--user` sous Linux, LaunchAgent best-effort sous macOS) — la différence entre « les Triggers ne tournent que tant que tu es loggé » et un orchestrateur autonome fiable. CLI `pdo service {install|uninstall|status}`. Garde de conflit de port à l'install (deux daemons ne partagent jamais un port). La status-bar affiche une pastille `ephemeral` quand le daemon ne survit pas au reboot — le seul signal que le dot de connexion ne peut pas exprimer (joignable ≠ persistant). Lignes load-bearing de l'unité et pourquoi → ADR-0019.
 
+- **Adresse d'écoute (bind)** *(terme, #766)* : l'interface réseau sur laquelle le daemon accepte des connexions TCP — `0.0.0.0` (toutes) par défaut, restreignable à `127.0.0.1` derrière un reverse proxy (`--bind` / `PDO_BIND`, propagé dans l'unité par `pdo service install --bind`, préservé par la réinstallation de l'Update). À distinguer de l'**origine WS** (`PDO_ALLOWED_WS_ORIGINS`), qui filtre *quel site* le navigateur affiche, pas *qui* peut ouvrir un TCP ; les deux étages se complètent. _Éviter_ : « host » (ambigu avec le nom de domaine du proxy), « adresse du daemon » (c'est l'URL annoncée).
+- **Le PATH de l'unité n'est pas celui des harnais** : les harnais se résolvent dans le PATH du shell interactif de l'utilisateur (ADR-0055) ; l'unité générée le dit en commentaire, pour qu'un lecteur ne conclue pas à un harnais introuvable. _Éviter_ : enrichir le PATH de l'unité pour « trouver » un harnais.
+- **Drop-in** *(terme)* : le fichier `pdo.service.d/override.conf` où l'opérateur pose durablement les variables env-only (`PDO_ALLOWED_WS_ORIGINS`) — il survit à chaque réécriture de l'unité, y compris celle de l'Update. Documenté en une phrase dans la table des commandes du README, pas davantage.
+
 ### Versioning (#139)
 
 **Source de vérité unique : le `version` du `Cargo.toml` workspace.** `frontend/package.json` reste à `0.0.0` en permanence — intentionnel. Le daemon expose sa version compilée via `GET /sessions` (l'endpoint de la status-bar — pas de route dédiée : un champ JSON additionnel est rétro-compatible et évite une entrée de whitelist proxy). En prod le binaire embarque le frontend, donc daemon et UI ne divergent pas.
@@ -865,7 +869,7 @@ Choix et pourquoi → ADR-0003. Daemon **Rust**, frontend **React + Vite** (canv
 
 ### Mono-user, local
 
-Le daemon bind **`0.0.0.0:<port>`** — joignable depuis le LAN, c'est **délibéré** (#260 est closed, pas différée). Pas d'auth, pas de TLS, pas de multi-user : single-user local par design, sur un réseau de confiance.
+Le daemon bind **`0.0.0.0:<port>`** par défaut — joignable depuis le LAN, c'est **délibéré** (#260 est closed, pas différée) ; `--bind 127.0.0.1` est l'opt-out derrière un reverse proxy (#766, cf. *Adresse d'écoute*). Pas d'auth, pas de TLS, pas de multi-user : single-user local par design, sur un réseau de confiance.
 
 **Le chemin de lecture ne dépend jamais d'Internet.** Les egress du produit sont tous **opt-in et tolérants à l'échec** : `docker pull`, guards de Trigger shellés, sync de la table de prix. Chaque nœud est par ailleurs une session `claude`, donc le produit ne fonctionne pas hors ligne — « pas de dépendance réseau » n'a jamais été littéral.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -348,7 +348,7 @@ Point clé : **l'autonomie est une propriété du *pipeline*, jamais une faveur 
 Conséquences :
 
 - **Tout NodeRun est attachable** en tmux ; l'utilisateur peut intervenir, converser, corriger.
-- **Un Node peut être marqué `interactive: true`** : son NodeRun attend que l'utilisateur attache la session et signale la complétion.
+- **Un Node peut être marqué `interactive: true`** : son NodeRun attend que l'utilisateur attache la session et signale la complétion — en forçant (« Mark complete ») ou en **libérant** la complétion à l'agent (« Mark ready for completion », ADR-0068).
 - **Le Pipeline Manager** est conversationnel et permet de débloquer des Runs — pas juste de lire l'état.
 - **Aucune action durable auto par le runtime lui-même.** PDO ne merge, ne PR, ne cleanup **jamais de sa propre initiative**. Si ces effets se produisent, c'est qu'un **nœud du pipeline** les exécute — choix explicite du designer, versionné, auditable.
   - **« auto-cleanup » vs « reapable surfacing » (#128)** : faire supprimer worktrees/branches par le runtime de lui-même = interdit (ADR-0012). **Exposer** les candidats sans rien supprimer = autorisé : le runtime *liste* (`GET /runs/reapable`, lecture seule), la suppression reste au pipeline/humain via `cleanup_run`. La recette `docs/recipes/disk-janitor.md` câble ce surfacing à un Trigger cron — l'autonomie reste *dans le pipeline*.
@@ -601,6 +601,7 @@ Exposées comme `POST /runs/<id>/commands` :
 | `kill_node` | Tue un NodeRun en cours (le marque `failed`) |
 | `restart_node` | Re-spawn un NodeRun au **même `iter`** ; sur un nœud isolé, le sous-worktree est réutilisé en place — le travail non commité survit (#489). Préconditions et refus → ADR-0037 |
 | `mark_node_done` | Force la complétion (nœud `interactive`, ou récupération d'un failed corrigé à la main). Même corps que `pdo complete` : refus 409 nommé → ADR-0035 |
+| `release_node_completion` | **Libère la complétion** d'un nœud `interactive` : lève la garde qui refuse `pdo complete` ; le nœud repasse `running`. Idempotent ; refus 409 nommé sur un nœud non interactif ou sans session vivante → ADR-0068 |
 | `inject_artifact` | Pose un artefact à la main dans le Blackboard |
 | `cleanup_run` | Supprime branches, worktrees, artefacts (archive d'abord — ADR-0020) |
 | `rename_run` | Donne au Run un nom descriptif |
@@ -727,7 +728,12 @@ Multi-client par session : gratuit côté tmux. Sécurité : un contrôle d'`Ori
 
 ### Nœuds interactifs — signal de complétion
 
-Un Node `interactive: true` spawn une session normale et **n'auto-complète jamais**. La complétion est signalée **depuis l'UI** par un bouton « Mark complete » (pas de slash-command in-session : le bouton reste accessible sans être attaché). Les artefacts présents sur disque sont alors pris tels quels — le préambule le dit à l'agent et au user.
+Un Node `interactive: true` spawn une session normale et **n'auto-complète jamais tant que sa complétion n'est pas libérée**. Deux gestes, **depuis l'UI**, côte à côte (pas de slash-command in-session : les boutons restent accessibles sans être attaché) :
+
+- **« Mark complete »** (`mark_node_done`) : **force** la complétion ; les artefacts présents sur disque sont pris tels quels. Échappatoire inconditionnelle, disponible aussi après libération.
+- **« Mark ready for completion »** (`release_node_completion`) : **libère** la complétion — l'utilisateur a fini d'interagir et **pré-autorise** l'agent à appeler `pdo complete` quand il le juge bon, pour faire avancer le run. Visible seulement sur un nœud interactif à session vivante.
+
+**Libération de la complétion** *(terme, ADR-0068 — release completion)* : événement sur `(node, iter)` qui lève la **garde de complétion** : tant qu'il est absent, **toute** complétion d'un nœud interactif (`pdo complete` explicite, hook Stop, fin de tour) est refusée — 409 `completion_not_released`, *recoverable* (exit 3 : l'agent garde la main et attend le mot de l'utilisateur). Après libération le nœud repasse **`running`** (l'attente n'est plus sur l'humain). Un retry ou un `restart_node` **réarme** la garde. Le runtime **n'injecte rien** dans le pane (ADR-0051) : l'utilisateur attaché dit lui-même à l'agent qu'il a fini ; le préambule interactif décrit ce contrat à l'agent. _Éviter_ : « débloquer » (= `AwaitingUser` sur incident), « auto-complétion » (ADR-0032 §2, réglage d'instance — la libération ne l'arme pas), « autoriser pdo complete » sans dire par qui (c'est un geste humain, jamais du runtime).
 
 Le bouton **n'est pas une garantie** : il est gaté sur le seul statut, et le garde autorise explicitement « mark complete sur un nœud failed corrigé à la main » comme chemin de récupération. Le clic peut donc être **refusé** (409 nommé, affiché au niveau du bouton) — cf. ADR-0035.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "1.79.1"
+version = "1.80.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "1.80.0"
+version = "1.81.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "1.80.0"
+version = "1.81.0"
 license = "MIT"
 description = "Prompt-Driven Orchestrator — a local daemon that runs and supervises agentic coding pipelines"
 repository = "https://github.com/Loulen/prompt-driven-orchestrator"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "1.79.1"
+version = "1.80.0"
 license = "MIT"
 description = "Prompt-Driven Orchestrator — a local daemon that runs and supervises agentic coding pipelines"
 repository = "https://github.com/Loulen/prompt-driven-orchestrator"

--- a/README.md
+++ b/README.md
@@ -55,21 +55,32 @@ PDO includes descriptors for `claude`, `opencode`, and `copilot`.
 
 ### 3. Start PDO
 
-```bash
-pdo daemon
-```
+Run `pdo daemon`, then open [http://localhost:5172](http://localhost:5172).
 
-Open [http://localhost:5172](http://localhost:5172).
+### 4. Keep PDO running
 
-### 4. Run PDO as a service
+Run `pdo service install` to start PDO at boot and keep it running after logout. Check it with `pdo service status` or remove it with `pdo service uninstall`.
 
-```bash
-pdo service install
-pdo service status
-pdo service uninstall
-```
+## CLI commands
 
-`pdo service install --port <port>` changes the default port, and `--dry-run` previews the service definition.
+| Command | Description |
+| --- | --- |
+| `pdo daemon [--port <port>] [--bind <ip>]` | Start the daemon. `PDO_PORT` and `PDO_BIND` provide defaults, while command-line flags take precedence. |
+| `pdo service install [--port <port>] [--bind <ip>] [--dry-run]` | Install the systemd user service or launchd agent; `--dry-run` prints the definition without changing the host. Keep `PDO_ALLOWED_WS_ORIGINS` in a `pdo.service.d/override.conf` drop-in, which survives unit rewrites including Update. |
+| `pdo service status` | Show the installed service status. |
+| `pdo service uninstall` | Stop, disable, and remove the installed service. |
+| `pdo complete [--auto]` | Complete the current node; `--auto` is reserved for runtime hooks. |
+| `pdo fail --reason <text>` | Fail the current node with a recorded reason. |
+| `pdo skip --reason <text>` | End the current run as skipped when there is legitimately no work. |
+| `pdo migrate [--dir <path>] [--dry-run]` | Migrate legacy pipeline YAML files. |
+| `pdo reap [--count] [--dry-run] [--ttl-hours <hours>] [--terminal-ttl-hours <hours>] [--budget-secs <seconds>]` | Report or archive old terminal runs according to the retention policy. |
+| `pdo docs support-table [--check\|--write] [--file <path>]` | Check or regenerate the README harness support table. |
+| `pdo run create <pipeline> [options]` | Create a run through the daemon, with optional input, repository, harness, sandbox, and provisioning settings. |
+| `pdo page mount <name> <directory>` | Serve a directory under `/pages/<name>/`. |
+| `pdo page list` | List active page mounts. |
+| `pdo page unmount <name>` | Remove a page mount. |
+| `pdo review list [--state <state>] [--run <id>]` | List review comments for a run. |
+| `pdo review reply <id> --text <markdown> [--resolved] [--run <id>]` | Reply to a review comment and optionally propose or record its resolution. |
 
 ## Reverse proxy
 
@@ -77,11 +88,10 @@ The daemon listens on `0.0.0.0:<port>` without authentication or TLS.
 
 Put authentication and TLS in front of PDO before exposing it beyond a trusted network.
 
-Set every public browser origin as an exact `scheme://host[:port]` value.
+Behind a proxy on the same machine, start the daemon with `--bind 127.0.0.1`.
 
-```bash
-PDO_ALLOWED_WS_ORIGINS="https://pdo.example.tld,https://pdo.internal:8443" pdo daemon
-```
+Set every public browser origin as an exact `scheme://host[:port]` value, for example
+`PDO_ALLOWED_WS_ORIGINS="https://pdo.example.tld,https://pdo.internal:8443" pdo daemon`.
 
 | Setting | Behavior |
 | --- | --- |

--- a/crates/pdo-daemon/src/completion_refusal.rs
+++ b/crates/pdo-daemon/src/completion_refusal.rs
@@ -32,6 +32,9 @@ pub(crate) enum CompletionRefusal {
     CompletionRejected {
         message: String,
     },
+    /// An interactive node remains under human control until the user releases
+    /// this exact session. No terminal event is written.
+    CompletionNotReleased,
     /// La livraison (#654 / ADR-0060) a échoué — staging, commit ou merge. Panne,
     /// pas verdict, donc `500`. Un `NodeInterrupted` est déjà appendé et le Run
     /// est parqué `AwaitingUser` : le travail reste sur disque, intact.
@@ -120,6 +123,7 @@ impl CompletionRefusal {
             Self::RunNotFound => "run_not_found",
             Self::Internal { .. } => "internal_error",
             Self::CompletionRejected { .. } => "completion_rejected",
+            Self::CompletionNotReleased => "completion_not_released",
             Self::DeliveryFailed { .. } => "delivery_failed",
             Self::MergeConflict { .. } => "merge_conflict",
             Self::MissingOutputs { .. } => "missing_outputs",
@@ -142,6 +146,7 @@ impl CompletionRefusal {
         matches!(
             self,
             Self::MissingOutputs { .. }
+                | Self::CompletionNotReleased
                 | Self::FrontmatterRetryPending { .. }
                 // Des enfants simplement en cours : l'agent garde la main — il
                 // attend qu'ils se terminent et re-complète. Avec un enfant
@@ -162,6 +167,7 @@ impl CompletionRefusal {
                 StatusCode::INTERNAL_SERVER_ERROR
             }
             Self::CompletionRejected { .. }
+            | Self::CompletionNotReleased
             | Self::MergeConflict { .. }
             | Self::MissingOutputs { .. }
             | Self::ScriptValidationFailed { .. }
@@ -185,6 +191,9 @@ impl CompletionRefusal {
             Self::RunNotFound => serde_json::json!({ "message": "run not found" }),
             Self::Internal { error } => serde_json::json!({ "message": error }),
             Self::CompletionRejected { message } => serde_json::json!({ "message": message }),
+            Self::CompletionNotReleased => serde_json::json!({
+                "message": "this interactive node has not been released; ask the user to click \"Mark ready for completion\" (or \"Mark complete\"), then retry"
+            }),
             Self::AppendFailed { error } => serde_json::json!({ "message": error }),
             Self::DeliveryFailed { node_id, error } => serde_json::json!({
                 "message": format!("failed to deliver {node_id}'s work: {error}")
@@ -230,6 +239,9 @@ impl CompletionRefusal {
             Self::RunNotFound => "run not found".into(),
             Self::Internal { error } => error.clone(),
             Self::CompletionRejected { message } => message.clone(),
+            Self::CompletionNotReleased => {
+                "interactive node completion has not been released by the user".into()
+            }
             Self::DeliveryFailed { node_id, error } => {
                 format!("failed to deliver {node_id}'s work: {error}")
             }
@@ -328,6 +340,7 @@ mod tests {
             CompletionRefusal::CompletionRejected {
                 message: "resume the run first".into(),
             },
+            CompletionRefusal::CompletionNotReleased,
             CompletionRefusal::DeliveryFailed {
                 node_id: "impl".into(),
                 error: "git add -A failed".into(),
@@ -379,6 +392,7 @@ mod tests {
                 CompletionRefusal::RunNotFound => "RunNotFound",
                 CompletionRefusal::Internal { .. } => "Internal",
                 CompletionRefusal::CompletionRejected { .. } => "CompletionRejected",
+                CompletionRefusal::CompletionNotReleased => "CompletionNotReleased",
                 CompletionRefusal::DeliveryFailed { .. } => "DeliveryFailed",
                 CompletionRefusal::MergeConflict { .. } => "MergeConflict",
                 CompletionRefusal::MissingOutputs { .. } => "MissingOutputs",
@@ -446,11 +460,12 @@ mod tests {
 
     /// `recoverable` arbitre entre exit `3` et exit `4` de `pdo complete`.
     #[test]
-    fn only_the_two_still_your_turn_refusals_are_recoverable() {
+    fn only_still_your_turn_refusals_are_recoverable() {
         for r in every_refusal() {
             let expected = matches!(
                 r,
                 CompletionRefusal::MissingOutputs { .. }
+                    | CompletionRefusal::CompletionNotReleased
                     | CompletionRefusal::FrontmatterRetryPending { .. }
                     // La liaison forte laisse la main à l'agent tant qu'aucun
                     // enfant n'a échoué (#724).

--- a/crates/pdo-daemon/src/event_log.rs
+++ b/crates/pdo-daemon/src/event_log.rs
@@ -74,6 +74,7 @@ pub enum EventKind {
     /// holds no tmux session yet and waits for an admission slot (#159).
     NodeWaiting,
     NodeAwaitingUser,
+    NodeCompletionReleased,
     NodeCompleted,
     NodeFailed,
     /// An **infra** incident killed the node's session — session death, boot
@@ -556,6 +557,10 @@ pub struct IterationInfo {
     pub status: NodeStatus,
     pub started_at: Option<String>,
     pub completed_at: Option<String>,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub interactive: bool,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub completion_released: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1474,6 +1479,8 @@ fn entry_node_ids(edges: &[EdgeInfo], node_defs: &[NodeDefInfo]) -> Vec<String> 
 fn upsert_iteration(iterations: &mut Vec<IterationInfo>, new: IterationInfo) {
     if let Some(existing) = iterations.iter_mut().find(|i| i.iter == new.iter) {
         existing.status = new.status;
+        existing.interactive = new.interactive;
+        existing.completion_released = new.completion_released;
         if new.started_at.is_some() {
             existing.started_at = new.started_at;
         }
@@ -1511,6 +1518,7 @@ pub(crate) fn project(events: &[Event]) -> Option<RunState> {
 
             EventKind::NodeWaiting
             | EventKind::NodeStarted
+            | EventKind::NodeCompletionReleased
             | EventKind::NodeCompleted
             | EventKind::NodeAutoCompleted
             | EventKind::NodeAwaitingUser
@@ -2102,6 +2110,13 @@ fn apply_node_event(state: &mut RunState, event: &Event) {
                     status: NodeStatus::Running,
                     started_at: Some(event.ts.clone()),
                     completed_at: None,
+                    interactive: event
+                        .payload
+                        .as_ref()
+                        .and_then(|p| p.get("interactive"))
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(false),
+                    completion_released: false,
                 };
                 let node = state
                     .nodes
@@ -2189,6 +2204,20 @@ fn apply_node_event(state: &mut RunState, event: &Event) {
                 upsert_iteration(&mut node.iterations, iteration);
             }
         }
+        EventKind::NodeCompletionReleased => {
+            if let Some(ref node_id) = event.node_id {
+                if let Some(node) = state.nodes.get_mut(node_id) {
+                    let iter = event.iter.unwrap_or(node.iter);
+                    if iter == node.iter {
+                        node.status = NodeStatus::Running;
+                    }
+                    if let Some(it) = node.iterations.iter_mut().find(|i| i.iter == iter) {
+                        it.status = NodeStatus::Running;
+                        it.completion_released = true;
+                    }
+                }
+            }
+        }
         EventKind::NodeCompleted | EventKind::NodeAutoCompleted => {
             if let Some(ref node_id) = event.node_id {
                 // #600: a **skip** (`skip_node` / reachability auto-skip) can
@@ -2247,6 +2276,8 @@ fn apply_node_event(state: &mut RunState, event: &Event) {
                                 status: done_status.clone(),
                                 started_at: Some(event.ts.clone()),
                                 completed_at: Some(event.ts.clone()),
+                                interactive: false,
+                                completion_released: false,
                             }],
                             frontmatter_retries: 0,
                             frontmatter_violations: Vec::new(),
@@ -2530,6 +2561,8 @@ fn apply_switch_event(state: &mut RunState, event: &Event) {
                     status: NodeStatus::Completed,
                     started_at: Some(event.ts.clone()),
                     completed_at: Some(event.ts.clone()),
+                    interactive: false,
+                    completion_released: false,
                 },
             );
         }
@@ -4487,6 +4520,41 @@ mod tests {
         let state = project(&events).unwrap();
         assert_eq!(state.status, RunStatus::AwaitingUser);
         assert_eq!(state.nodes["griller"].status, NodeStatus::AwaitingUser);
+    }
+
+    #[test]
+    fn completion_release_is_iteration_scoped_and_restart_rearms_it() {
+        let mut events = vec![
+            make_event_with_payload(
+                EventKind::RunStarted,
+                None,
+                serde_json::json!({ "pipeline_name": "interactive-pipe" }),
+            ),
+            make_event_with_payload(
+                EventKind::NodeStarted,
+                Some("griller"),
+                serde_json::json!({ "interactive": true }),
+            ),
+            make_event(EventKind::NodeAwaitingUser, Some("griller"), Some(1)),
+            make_event(EventKind::NodeCompletionReleased, Some("griller"), Some(1)),
+        ];
+
+        let released = project(&events).unwrap();
+        assert_eq!(released.status, RunStatus::Running);
+        assert_eq!(released.nodes["griller"].status, NodeStatus::Running);
+        assert!(released.nodes["griller"].iterations[0].interactive);
+        assert!(released.nodes["griller"].iterations[0].completion_released);
+
+        events.push(make_event(EventKind::NodeStarted, Some("griller"), Some(1)));
+        events.push(make_event(
+            EventKind::NodeAwaitingUser,
+            Some("griller"),
+            Some(1),
+        ));
+
+        let restarted = project(&events).unwrap();
+        assert_eq!(restarted.status, RunStatus::AwaitingUser);
+        assert!(!restarted.nodes["griller"].iterations[0].completion_released);
     }
 
     #[test]
@@ -6679,6 +6747,8 @@ mod tests {
                     status: s.clone(),
                     started_at: None,
                     completed_at: None,
+                    interactive: false,
+                    completion_released: false,
                 })
                 .collect(),
             frontmatter_retries: 0,

--- a/crates/pdo-daemon/src/input_resolution.rs
+++ b/crates/pdo-daemon/src/input_resolution.rs
@@ -223,6 +223,8 @@ mod tests {
                     status: status.clone(),
                     started_at: None,
                     completed_at: None,
+                    interactive: false,
+                    completion_released: false,
                 })
                 .collect(),
             frontmatter_retries: 0,

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -890,6 +890,12 @@ struct NodeDoneRequest {
 }
 
 #[derive(Deserialize)]
+struct ReleaseNodeCompletionRequest {
+    #[serde(default)]
+    iter: Option<i64>,
+}
+
+#[derive(Deserialize)]
 struct NodeFailRequest {
     reason: String,
     #[serde(default)]
@@ -1032,14 +1038,19 @@ pub fn run_complete(auto: bool) -> std::process::ExitCode {
         )),
     }
     out.push_str(&refusal_detail_lines(slug, &body));
-    out.push_str(match recoverable {
-        Some(true) => {
+    out.push_str(match (slug, recoverable) {
+        ("completion_not_released", Some(true)) => {
+            "Ask the user to click **Mark ready for completion** (or **Mark complete** to \
+             force completion). After release, run `pdo complete` again.\n\
+             Do NOT run `pdo fail`."
+        }
+        (_, Some(true)) => {
             "Fix what is listed above, then run `pdo complete` again.\nDo NOT run `pdo fail`."
         }
-        Some(false) => {
+        (_, Some(false)) => {
             "Do NOT run `pdo fail` — the failure is already recorded. Stop here and report it."
         }
-        None => "Re-read the run state before acting. Do NOT run `pdo fail` blindly.",
+        (_, None) => "Re-read the run state before acting. Do NOT run `pdo fail` blindly.",
     });
     eprintln!("{out}");
 
@@ -1090,6 +1101,9 @@ fn refusal_headline(slug: &str, body: &serde_json::Value) -> String {
             .and_then(|v| v.as_str())
             .unwrap_or("the run does not accept this completion")
             .to_string(),
+        "completion_not_released" => {
+            "the user has not released this interactive node for completion".into()
+        }
         "run_forgotten" => "this run has been forgotten (archived); it accepts nothing".into(),
         // Unknown slug: hand it over as-is, plus whatever prose came with it.
         other => match body.get("message").and_then(|v| v.as_str()) {
@@ -4580,6 +4594,10 @@ fn build_router(state: Arc<AppState>) -> Router {
         .route("/runs/{run_id}/children", get(list_run_children))
         .route("/runs/{run_id}/events", get(get_run_events))
         .route("/runs/{run_id}/nodes/{node_id}/done", post(node_done))
+        .route(
+            "/runs/{run_id}/nodes/{node_id}/release",
+            post(node_release_completion),
+        )
         .route("/runs/{run_id}/nodes/{node_id}/fail", post(node_fail))
         .route("/runs/{run_id}/nodes/{node_id}/skip", post(node_skip))
         .route("/runs/{run_id}/nodes/{node_id}/pane", get(node_pane))
@@ -17084,6 +17102,10 @@ pub(crate) async fn complete_node_iteration(
         };
     }
 
+    if let Some(refusal) = interactive_completion_refusal(&pre_run_state, &node_id, iter) {
+        return CompletionAttempt::refused(refusal);
+    }
+
     // Liaison forte orchestrateur ↔ enfants (#724 / ADR-0064): a node with the
     // « Orchestrator » toggle does not terminate while its child runs are
     // non-terminal. The gate sits after the transition guard but BEFORE any
@@ -17210,6 +17232,128 @@ pub(crate) async fn complete_node_iteration(
         }
     });
     CompletionAttempt::Completed
+}
+
+fn interactive_completion_refusal(
+    run_state: &event_log::RunState,
+    node_id: &str,
+    iter: i64,
+) -> Option<completion_refusal::CompletionRefusal> {
+    let attempt = run_state
+        .nodes
+        .get(node_id)?
+        .iterations
+        .iter()
+        .find(|attempt| attempt.iter == iter)?;
+    (attempt.interactive && !attempt.completion_released)
+        .then_some(completion_refusal::CompletionRefusal::CompletionNotReleased)
+}
+
+fn release_refusal(slug: &str, message: impl Into<String>) -> Response {
+    (
+        StatusCode::CONFLICT,
+        Json(serde_json::json!({
+            "error": slug,
+            "recoverable": false,
+            "message": message.into(),
+        })),
+    )
+        .into_response()
+}
+
+pub(crate) async fn release_node_completion(
+    state: &Arc<AppState>,
+    run_id: &str,
+    node_id: &str,
+    iter: i64,
+) -> Response {
+    let events = match load_events(&state.db, run_id).await {
+        Ok(events) => events,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": format!("error: {e}") })),
+            )
+                .into_response();
+        }
+    };
+    let Some(run_state) = event_log::project(&events) else {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({ "error": "run_not_found", "recoverable": false })),
+        )
+            .into_response();
+    };
+    if !run_state.status.is_live() {
+        return release_refusal(
+            "run_not_live",
+            format!("run {run_id} has no live session to release"),
+        );
+    }
+    let Some(node) = run_state.nodes.get(node_id) else {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({ "error": "node_not_found", "recoverable": false })),
+        )
+            .into_response();
+    };
+    let Some(attempt) = node.iterations.iter().find(|attempt| attempt.iter == iter) else {
+        return release_refusal(
+            "node_session_not_live",
+            format!("node {node_id} iter {iter} has no live session"),
+        );
+    };
+    if !attempt.interactive {
+        return release_refusal(
+            "node_not_interactive",
+            format!("node {node_id} is not interactive"),
+        );
+    }
+    if !attempt.status.holds_session() {
+        return release_refusal(
+            "node_session_not_live",
+            format!("node {node_id} iter {iter} has no live session"),
+        );
+    }
+    if attempt.completion_released {
+        return (
+            StatusCode::OK,
+            Json(serde_json::json!({ "ok": true, "released": true, "noop": true })),
+        )
+            .into_response();
+    }
+
+    let event = event_log::Event {
+        id: None,
+        run_id: run_id.to_string(),
+        ts: event_log::now_iso(),
+        kind: event_log::EventKind::NodeCompletionReleased,
+        node_id: Some(node_id.to_string()),
+        iter: Some(iter),
+        payload: None,
+    };
+    if let Err(e) = append_event(state, &event).await {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({ "error": format!("error: {e}") })),
+        )
+            .into_response();
+    }
+
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({ "ok": true, "released": true })),
+    )
+        .into_response()
+}
+
+async fn node_release_completion(
+    State(state): State<Arc<AppState>>,
+    AxumPath((run_id, node_id)): AxumPath<(String, String)>,
+    body: Option<Json<ReleaseNodeCompletionRequest>>,
+) -> Response {
+    let iter = body.and_then(|Json(body)| body.iter).unwrap_or(1);
+    release_node_completion(&state, &run_id, &node_id, iter).await
 }
 
 /// Resolve a node's effective `auto_fail` (ADR-0049) — gather all four tiers and
@@ -26956,7 +27100,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn mark_node_done_command_completes_awaiting_node() {
+    async fn mark_node_done_force_completes_unreleased_interactive_node() {
         let state = test_state().await;
 
         let run_id = "test-interactive-run";
@@ -26978,7 +27122,7 @@ mod tests {
                 kind: event_log::EventKind::NodeStarted,
                 node_id: Some("griller".into()),
                 iter: Some(1),
-                payload: None,
+                payload: Some(serde_json::json!({ "interactive": true })),
             },
             event_log::Event {
                 id: None,
@@ -27023,6 +27167,12 @@ mod tests {
         assert_eq!(
             run_state.nodes["griller"].status,
             event_log::NodeStatus::Completed
+        );
+        assert!(
+            !events
+                .iter()
+                .any(|event| event.kind == event_log::EventKind::NodeCompletionReleased),
+            "force completion must bypass the release guard"
         );
     }
 
@@ -27088,6 +27238,260 @@ mod tests {
         let payload = cmd_events[0].payload.as_ref().unwrap();
         assert_eq!(payload["command"], "mark_node_done");
         assert_eq!(payload["node_id"], "griller");
+        assert!(
+            !events
+                .iter()
+                .any(|event| event.kind == event_log::EventKind::NodeCompletionReleased),
+            "force completion must not require a prior release"
+        );
+    }
+
+    async fn seed_interactive_node(
+        state: &Arc<AppState>,
+        run_id: &str,
+        status: event_log::EventKind,
+    ) {
+        for event in [
+            event_log::Event {
+                id: None,
+                run_id: run_id.into(),
+                ts: event_log::now_iso(),
+                kind: event_log::EventKind::RunStarted,
+                node_id: None,
+                iter: None,
+                payload: Some(serde_json::json!({ "pipeline_name": "interactive" })),
+            },
+            event_log::Event {
+                id: None,
+                run_id: run_id.into(),
+                ts: event_log::now_iso(),
+                kind: event_log::EventKind::NodeStarted,
+                node_id: Some("griller".into()),
+                iter: Some(1),
+                payload: Some(serde_json::json!({ "interactive": true })),
+            },
+            event_log::Event {
+                id: None,
+                run_id: run_id.into(),
+                ts: event_log::now_iso(),
+                kind: status,
+                node_id: Some("griller".into()),
+                iter: Some(1),
+                payload: None,
+            },
+        ] {
+            append_event(state, &event).await.unwrap();
+        }
+    }
+
+    async fn response_json(response: Response) -> serde_json::Value {
+        serde_json::from_slice(
+            &axum::body::to_bytes(response.into_body(), usize::MAX)
+                .await
+                .unwrap(),
+        )
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn every_completion_source_is_refused_until_interactive_release() {
+        let state = test_state().await;
+        let run_id = "interactive-completion-guard";
+        seed_interactive_node(&state, run_id, event_log::EventKind::NodeAwaitingUser).await;
+
+        for source in [
+            CompletionSource::Explicit,
+            CompletionSource::StopHook,
+            CompletionSource::TurnEnded,
+            CompletionSource::ChildrenSettled,
+        ] {
+            let attempt =
+                complete_node_iteration(&state, run_id.into(), "griller".into(), 1, source).await;
+            assert!(matches!(
+                attempt,
+                CompletionAttempt::Refused {
+                    refusal: completion_refusal::CompletionRefusal::CompletionNotReleased
+                }
+            ));
+        }
+
+        let response = build_router(state.clone())
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/runs/{run_id}/nodes/griller/done"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"iter":1}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        let body = response_json(response).await;
+        assert_eq!(body["error"], "completion_not_released");
+        assert_eq!(body["recoverable"], true);
+        let events = load_events(&state.db, run_id).await.unwrap();
+        assert!(!events.iter().any(|event| matches!(
+            event.kind,
+            event_log::EventKind::NodeCompleted
+                | event_log::EventKind::NodeAutoCompleted
+                | event_log::EventKind::NodeFailed
+        )));
+    }
+
+    #[tokio::test]
+    async fn release_route_is_projection_backed_and_idempotent() {
+        let state = test_state().await;
+        let run_id = "interactive-release-route";
+        seed_interactive_node(&state, run_id, event_log::EventKind::NodeAwaitingUser).await;
+
+        for expected_noop in [false, true] {
+            let response = build_router(state.clone())
+                .oneshot(
+                    Request::builder()
+                        .method("POST")
+                        .uri(format!("/runs/{run_id}/nodes/griller/release"))
+                        .header("content-type", "application/json")
+                        .body(Body::from(r#"{"iter":1}"#))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            let body = response_json(response).await;
+            assert_eq!(body["released"], true);
+            assert_eq!(
+                body.get("noop").and_then(|v| v.as_bool()),
+                expected_noop.then_some(true)
+            );
+        }
+
+        let events = load_events(&state.db, run_id).await.unwrap();
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| event.kind == event_log::EventKind::NodeCompletionReleased)
+                .count(),
+            1
+        );
+        let run = event_log::project(&events).unwrap();
+        assert_eq!(run.status, event_log::RunStatus::Running);
+        assert_eq!(run.nodes["griller"].status, event_log::NodeStatus::Running);
+        assert!(run.nodes["griller"].iterations[0].completion_released);
+        assert!(interactive_completion_refusal(&run, "griller", 1).is_none());
+    }
+
+    #[tokio::test]
+    async fn release_command_uses_the_same_operation() {
+        let state = test_state().await;
+        let run_id = "interactive-release-command";
+        seed_interactive_node(&state, run_id, event_log::EventKind::NodeAwaitingUser).await;
+
+        let response = build_router(state.clone())
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/runs/{run_id}/commands"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        r#"{"kind":"release_node_completion","node_id":"griller","iter":1}"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let events = load_events(&state.db, run_id).await.unwrap();
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| event.kind == event_log::EventKind::NodeCompletionReleased)
+                .count(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn release_refuses_noninteractive_and_dead_sessions() {
+        let state = test_state().await;
+        for (run_id, interactive, terminal_node, terminal_run, expected) in [
+            (
+                "release-noninteractive",
+                false,
+                false,
+                false,
+                "node_not_interactive",
+            ),
+            (
+                "release-dead-session",
+                true,
+                true,
+                false,
+                "node_session_not_live",
+            ),
+            ("release-dead-run", true, true, true, "run_not_live"),
+        ] {
+            for event in [
+                event_log::Event {
+                    id: None,
+                    run_id: run_id.into(),
+                    ts: event_log::now_iso(),
+                    kind: event_log::EventKind::RunStarted,
+                    node_id: None,
+                    iter: None,
+                    payload: Some(serde_json::json!({ "pipeline_name": "interactive" })),
+                },
+                event_log::Event {
+                    id: None,
+                    run_id: run_id.into(),
+                    ts: event_log::now_iso(),
+                    kind: event_log::EventKind::NodeStarted,
+                    node_id: Some("worker".into()),
+                    iter: Some(1),
+                    payload: Some(serde_json::json!({ "interactive": interactive })),
+                },
+            ] {
+                append_event(&state, &event).await.unwrap();
+            }
+            if terminal_node {
+                append_event(
+                    &state,
+                    &event_log::Event {
+                        id: None,
+                        run_id: run_id.into(),
+                        ts: event_log::now_iso(),
+                        kind: event_log::EventKind::NodeCompleted,
+                        node_id: Some("worker".into()),
+                        iter: Some(1),
+                        payload: None,
+                    },
+                )
+                .await
+                .unwrap();
+            }
+            if terminal_run {
+                append_event(
+                    &state,
+                    &event_log::Event {
+                        id: None,
+                        run_id: run_id.into(),
+                        ts: event_log::now_iso(),
+                        kind: event_log::EventKind::RunCompleted,
+                        node_id: None,
+                        iter: None,
+                        payload: None,
+                    },
+                )
+                .await
+                .unwrap();
+            }
+
+            let response = release_node_completion(&state, run_id, "worker", 1).await;
+            assert_eq!(response.status(), StatusCode::CONFLICT);
+            assert_eq!(response_json(response).await["error"], expected);
+        }
     }
 
     // Node-completion tail convergence: the *observable* behaviour `complete_node`
@@ -28309,6 +28713,8 @@ mod tests {
                             status: event_log::NodeStatus::Completed,
                             started_at: None,
                             completed_at: None,
+                            interactive: false,
+                            completion_released: false,
                         })
                         .collect(),
                     frontmatter_retries: 0,

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -100,7 +100,7 @@ mod workflow_importer;
 mod worktree_ops;
 
 use std::collections::HashMap;
-use std::net::SocketAddr;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -158,6 +158,9 @@ pub struct Cli {
 pub enum Commands {
     /// Start the PDO daemon
     Daemon {
+        /// Address to listen on. Defaults to all interfaces.
+        #[arg(long, env = "PDO_BIND")]
+        bind: Option<IpAddr>,
         #[arg(short, long, env = "PDO_PORT", default_value_t = DEFAULT_PORT)]
         port: u16,
     },
@@ -387,6 +390,9 @@ pub enum DocsAction {
 pub enum ServiceAction {
     /// Generate + enable the service unit so the daemon starts at boot / survives logout.
     Install {
+        /// Address the service daemon listens on. Omit to keep the default.
+        #[arg(long)]
+        bind: Option<IpAddr>,
         #[arg(short, long, env = "PDO_PORT", default_value_t = DEFAULT_PORT)]
         port: u16,
         /// Print the unit file + the exact commands, make NO changes. Still
@@ -1880,8 +1886,8 @@ trait ServiceEnv {
     fn home(&self) -> Result<PathBuf>;
     /// `$USER` — for `loginctl enable-linger $USER`.
     fn user(&self) -> Result<String>;
-    /// Classify `127.0.0.1:<port>` for the conflict guard.
-    fn probe_port(&self, port: u16) -> PortState;
+    /// Classify the address the service daemon would occupy.
+    fn probe_port(&self, addr: SocketAddr) -> PortState;
     /// Write a unit/plist file, creating parent dirs.
     fn write_file(&self, path: &Path, contents: &str) -> Result<()>;
     /// Remove a unit/plist file (uninstall); Ok if already absent.
@@ -1931,11 +1937,14 @@ impl ServiceEnv for RealServiceEnv {
         std::env::var("USER").context("$USER is not set")
     }
 
-    fn probe_port(&self, port: u16) -> PortState {
+    fn probe_port(&self, addr: SocketAddr) -> PortState {
         use std::net::TcpStream;
-        let addr = SocketAddr::from(([127, 0, 0, 1], port));
-        if TcpStream::connect_timeout(&addr, Duration::from_millis(300)).is_err() {
+        if std::net::TcpListener::bind(addr).is_ok() {
             return PortState::Free;
+        }
+        let addr = connect_addr(addr);
+        if TcpStream::connect_timeout(&addr, Duration::from_millis(300)).is_err() {
+            return PortState::Foreign;
         }
         let client = match reqwest::blocking::Client::builder()
             .timeout(Duration::from_millis(800))
@@ -1944,10 +1953,7 @@ impl ServiceEnv for RealServiceEnv {
             Ok(c) => c,
             Err(_) => return PortState::Foreign,
         };
-        match client
-            .get(format!("http://127.0.0.1:{port}/sessions"))
-            .send()
-        {
+        match client.get(format!("http://{addr}/sessions")).send() {
             Ok(resp) if resp.status().is_success() => {
                 let body = resp.text().unwrap_or_default();
                 // The `/sessions` payload carries `cap` + `version` — markers no
@@ -2007,11 +2013,15 @@ fn run_service_with(
 ) -> Result<()> {
     let is_macos = cfg!(target_os = "macos");
     match action {
-        ServiceAction::Install { port, dry_run } => {
+        ServiceAction::Install {
+            bind,
+            port,
+            dry_run,
+        } => {
             if is_macos {
-                service_install_launchd(env, out, port, dry_run)
+                service_install_launchd(env, out, bind, port, dry_run)
             } else {
-                service_install_systemd(env, out, port, dry_run)
+                service_install_systemd(env, out, bind, port, dry_run)
             }
         }
         ServiceAction::Uninstall => {
@@ -2032,14 +2042,33 @@ fn run_service_with(
 }
 
 /// Human-readable description of a port-probe result, for the plan / guard output.
-fn describe_port_state(port: u16, state: &PortState) -> String {
+fn service_addr(bind: Option<IpAddr>, port: u16) -> SocketAddr {
+    SocketAddr::new(bind.unwrap_or(IpAddr::V4(Ipv4Addr::UNSPECIFIED)), port)
+}
+
+fn connect_addr(listen_addr: SocketAddr) -> SocketAddr {
+    match listen_addr.ip() {
+        IpAddr::V4(ip) if ip.is_unspecified() => {
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), listen_addr.port())
+        }
+        IpAddr::V6(ip) if ip.is_unspecified() => {
+            SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), listen_addr.port())
+        }
+        _ => listen_addr,
+    }
+}
+
+fn describe_port_state(addr: SocketAddr, state: &PortState) -> String {
     match state {
-        PortState::Free => format!("port {port} is free"),
+        PortState::Free => format!("{addr} is free"),
         PortState::PdoDaemon => {
-            format!("a PDO daemon is already answering on 127.0.0.1:{port}")
+            format!(
+                "a PDO daemon is already answering on {}",
+                connect_addr(addr)
+            )
         }
         PortState::Foreign => {
-            format!("port {port} is already bound by a non-PDO process (or a not-yet-ready daemon)")
+            format!("{addr} is already bound by a non-PDO process (or a not-yet-ready daemon)")
         }
     }
 }
@@ -2048,6 +2077,7 @@ fn describe_port_state(port: u16, state: &PortState) -> String {
 fn service_install_systemd(
     env: &dyn ServiceEnv,
     out: &mut dyn std::io::Write,
+    bind: Option<IpAddr>,
     port: u16,
     dry_run: bool,
 ) -> Result<()> {
@@ -2058,8 +2088,9 @@ fn service_install_systemd(
     let user = env.user().unwrap_or_else(|_| "$USER".to_string());
     let config_home = env.config_home()?;
     let unit_path = service_unit::systemd_unit_path(&config_home);
-    let unit = service_unit::render_systemd_unit(&exe, port, &working_dir, &path_env);
-    let state = env.probe_port(port);
+    let unit = service_unit::render_systemd_unit(&exe, port, bind, &working_dir, &path_env);
+    let service_addr = service_addr(bind, port);
+    let state = env.probe_port(service_addr);
 
     // `--now` only when the port is free: never start a competitor onto a port a
     // PDO daemon already owns.
@@ -2080,7 +2111,7 @@ fn service_install_systemd(
 
     if dry_run {
         writeln!(out, "# pdo service install --dry-run (NO changes made)")?;
-        writeln!(out, "# {}", describe_port_state(port, &state))?;
+        writeln!(out, "# {}", describe_port_state(service_addr, &state))?;
         if state == PortState::Foreign {
             writeln!(
                 out,
@@ -2109,14 +2140,14 @@ fn service_install_systemd(
             "refusing to install: {}. The enabled unit's daemon would crash-loop on \
              EADDRINUSE (Restart=on-failure). Stop the process on port {port}, or install \
              with a free --port.",
-            describe_port_state(port, &state)
+            describe_port_state(service_addr, &state)
         );
     }
     if state == PortState::PdoDaemon {
         writeln!(
             out,
             "note: {} — enabling the unit for boot but NOT starting a competing instance.",
-            describe_port_state(port, &state)
+            describe_port_state(service_addr, &state)
         )?;
     }
 
@@ -2204,6 +2235,7 @@ fn service_status_systemd(env: &dyn ServiceEnv, out: &mut dyn std::io::Write) ->
 fn service_install_launchd(
     env: &dyn ServiceEnv,
     out: &mut dyn std::io::Write,
+    bind: Option<IpAddr>,
     port: u16,
     dry_run: bool,
 ) -> Result<()> {
@@ -2213,8 +2245,10 @@ fn service_install_launchd(
     let node_dir = env.node_dir();
     let path_env = service_unit::build_path_env(&exe, node_dir.as_deref());
     let plist_path = service_unit::launchd_plist_path(&home);
-    let plist = service_unit::render_launchd_plist(&exe, port, &working_dir, &home, &path_env);
-    let state = env.probe_port(port);
+    let plist =
+        service_unit::render_launchd_plist(&exe, port, bind, &working_dir, &home, &path_env);
+    let service_addr = service_addr(bind, port);
+    let state = env.probe_port(service_addr);
     let label = service_unit::LAUNCHD_LABEL;
 
     if node_dir.is_none() {
@@ -2227,7 +2261,7 @@ fn service_install_launchd(
 
     if dry_run {
         writeln!(out, "# pdo service install --dry-run (NO changes made)")?;
-        writeln!(out, "# {}", describe_port_state(port, &state))?;
+        writeln!(out, "# {}", describe_port_state(service_addr, &state))?;
         if state == PortState::Foreign {
             writeln!(
                 out,
@@ -2263,7 +2297,7 @@ fn service_install_launchd(
     if state == PortState::Foreign {
         anyhow::bail!(
             "refusing to install: {}. Free the port or pass a free --port.",
-            describe_port_state(port, &state)
+            describe_port_state(service_addr, &state)
         );
     }
 
@@ -3210,21 +3244,29 @@ pub async fn serve_with_config(
     })
 }
 
-pub async fn run_daemon(port: u16) -> Result<()> {
-    let addr = SocketAddr::from(([0, 0, 0, 0], port));
+fn daemon_relaunch_command(exe: &Path, bind: Option<IpAddr>, port: u16) -> Vec<String> {
+    let mut command = vec![
+        exe.display().to_string(),
+        "daemon".to_string(),
+        "--port".to_string(),
+        port.to_string(),
+    ];
+    if let Some(bind) = bind {
+        command.push("--bind".to_string());
+        command.push(bind.to_string());
+    }
+    command
+}
+
+pub async fn run_daemon(bind: Option<IpAddr>, port: u16) -> Result<()> {
+    let addr = SocketAddr::new(bind.unwrap_or(IpAddr::V4(Ipv4Addr::UNSPECIFIED)), port);
     let repo_root = std::env::current_dir().context("failed to determine current directory")?;
     let mut config = DaemonConfig::from_env();
     // #699: the command line an unsupervised update relaunches — the STABLE binary
     // path (Homebrew's `bin/pdo`, not the Cellar target `brew upgrade` deletes) and
     // the same port, whether it came from `--port` or `PDO_PORT`.
-    config.relaunch_command = update_check::invoked_exe_path().map(|exe| {
-        vec![
-            exe.display().to_string(),
-            "daemon".to_string(),
-            "--port".to_string(),
-            port.to_string(),
-        ]
-    });
+    config.relaunch_command =
+        update_check::invoked_exe_path().map(|exe| daemon_relaunch_command(&exe, bind, port));
     let handle = serve_with_config(addr, repo_root, config).await?;
     handle.task.await.context("daemon task join error")?
 }
@@ -11162,6 +11204,7 @@ async fn apply_update(State(state): State<Arc<AppState>>) -> Response {
         supervision,
         exe,
         port: state.port,
+        bind: update_executor::explicit_bind_from_relaunch(&relaunch),
         working_dir: state.repo_root.clone(),
         daemon_pid: std::process::id(),
         relaunch,
@@ -21140,6 +21183,26 @@ mod tests {
         assert_eq!(advertised_url(lo), "http://127.0.0.1:0");
         let lan: SocketAddr = "192.168.1.20:5172".parse().unwrap();
         assert_eq!(advertised_url(lan), "http://192.168.1.20:5172");
+    }
+
+    #[test]
+    fn daemon_relaunch_preserves_only_an_explicit_bind() {
+        let exe = Path::new("/usr/local/bin/pdo");
+        assert_eq!(
+            daemon_relaunch_command(exe, None, 5172),
+            vec!["/usr/local/bin/pdo", "daemon", "--port", "5172"]
+        );
+        assert_eq!(
+            daemon_relaunch_command(exe, Some("127.0.0.1".parse().unwrap()), 5172),
+            vec![
+                "/usr/local/bin/pdo",
+                "daemon",
+                "--port",
+                "5172",
+                "--bind",
+                "127.0.0.1"
+            ]
+        );
     }
 
     /// A unique fake daemon port per test state, so the derived tmux socket
@@ -31338,7 +31401,13 @@ edges:
             .and_then(|v| v.parse::<u16>().ok())
             .unwrap_or(DEFAULT_PORT);
         match cli.command {
-            Commands::Daemon { port } => assert_eq!(port, expected),
+            Commands::Daemon { bind, port } => {
+                assert_eq!(
+                    bind,
+                    std::env::var("PDO_BIND").ok().and_then(|v| v.parse().ok())
+                );
+                assert_eq!(port, expected);
+            }
             _ => panic!("expected Daemon subcommand"),
         }
     }
@@ -31347,7 +31416,20 @@ edges:
     fn cli_parses_daemon_with_port() {
         let cli = Cli::try_parse_from(["pdo", "daemon", "--port", "9999"]).unwrap();
         match cli.command {
-            Commands::Daemon { port } => assert_eq!(port, 9999),
+            Commands::Daemon { port, .. } => assert_eq!(port, 9999),
+            _ => panic!("expected Daemon subcommand"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_daemon_with_bind() {
+        let cli = Cli::try_parse_from(["pdo", "daemon", "--bind", "127.0.0.1", "--port", "9999"])
+            .unwrap();
+        match cli.command {
+            Commands::Daemon { bind, port } => {
+                assert_eq!(bind, Some("127.0.0.1".parse().unwrap()));
+                assert_eq!(port, 9999);
+            }
             _ => panic!("expected Daemon subcommand"),
         }
     }
@@ -31474,8 +31556,14 @@ edges:
             .unwrap_or(DEFAULT_PORT);
         match cli.command {
             Commands::Service {
-                action: ServiceAction::Install { port, dry_run },
+                action:
+                    ServiceAction::Install {
+                        bind,
+                        port,
+                        dry_run,
+                    },
             } => {
+                assert_eq!(bind, None);
                 assert_eq!(port, expected_port);
                 assert!(!dry_run);
             }
@@ -31489,8 +31577,47 @@ edges:
             .unwrap();
         match cli.command {
             Commands::Service {
-                action: ServiceAction::Install { port, dry_run },
+                action:
+                    ServiceAction::Install {
+                        bind,
+                        port,
+                        dry_run,
+                    },
             } => {
+                assert_eq!(
+                    bind,
+                    std::env::var("PDO_BIND").ok().and_then(|v| v.parse().ok())
+                );
+                assert_eq!(port, 6183);
+                assert!(dry_run);
+            }
+            _ => panic!("expected Service Install"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_service_install_with_bind() {
+        let cli = Cli::try_parse_from([
+            "pdo",
+            "service",
+            "install",
+            "--bind",
+            "127.0.0.1",
+            "--port",
+            "6183",
+            "--dry-run",
+        ])
+        .unwrap();
+        match cli.command {
+            Commands::Service {
+                action:
+                    ServiceAction::Install {
+                        bind,
+                        port,
+                        dry_run,
+                    },
+            } => {
+                assert_eq!(bind, Some("127.0.0.1".parse().unwrap()));
                 assert_eq!(port, 6183);
                 assert!(dry_run);
             }
@@ -31720,7 +31847,7 @@ edges:
         fn user(&self) -> Result<String> {
             Ok(self.user.clone())
         }
-        fn probe_port(&self, _port: u16) -> PortState {
+        fn probe_port(&self, _addr: SocketAddr) -> PortState {
             self.port_state.clone()
         }
         fn write_file(&self, path: &Path, contents: &str) -> Result<()> {
@@ -31761,6 +31888,7 @@ edges:
         let mut out: Vec<u8> = Vec::new();
         run_service_with(
             ServiceAction::Install {
+                bind: None,
                 port: 5172,
                 dry_run: true,
             },
@@ -31788,6 +31916,7 @@ edges:
         let mut out: Vec<u8> = Vec::new();
         run_service_with(
             ServiceAction::Install {
+                bind: None,
                 port: 6183,
                 dry_run: true,
             },
@@ -31800,6 +31929,7 @@ edges:
         if !cfg!(target_os = "macos") {
             assert!(s.contains("KillMode=process"), "unit missing KillMode: {s}");
             assert!(s.contains("Environment=PDO_PORT=6183"));
+            assert!(!s.contains("Environment=PDO_BIND="));
             assert!(s.contains("ExecStart=/home/user/.local/bin/pdo daemon"));
             assert!(s.contains("WorkingDirectory=/home/user/.pdo/app"));
             // Command plan, in order.
@@ -31815,6 +31945,54 @@ edges:
         );
     }
 
+    #[test]
+    fn service_dry_run_carries_bind_and_the_harness_path_comment() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let env = FakeServiceEnv::new(tmp.path().to_path_buf(), PortState::Free);
+        let mut out: Vec<u8> = Vec::new();
+        run_service_with(
+            ServiceAction::Install {
+                bind: Some("127.0.0.1".parse().unwrap()),
+                port: 6183,
+                dry_run: true,
+            },
+            &env,
+            &mut out,
+        )
+        .unwrap();
+        let s = String::from_utf8(out).unwrap();
+        if cfg!(target_os = "macos") {
+            assert!(s.contains("<key>PDO_BIND</key><string>127.0.0.1</string>"));
+        } else {
+            assert!(s.contains("Environment=PDO_BIND=127.0.0.1"));
+        }
+        assert!(s.contains("interactive shell PATH (ADR-0055)"));
+    }
+
+    #[test]
+    fn service_conflict_probe_uses_the_effective_bind_address() {
+        assert_eq!(
+            service_addr(Some("192.0.2.10".parse().unwrap()), 6183),
+            "192.0.2.10:6183".parse().unwrap()
+        );
+        assert_eq!(
+            service_addr(Some("0.0.0.0".parse().unwrap()), 6183),
+            "0.0.0.0:6183".parse().unwrap()
+        );
+        assert_eq!(
+            connect_addr(service_addr(Some("::".parse().unwrap()), 6183)),
+            "[::1]:6183".parse().unwrap()
+        );
+    }
+
+    #[test]
+    fn wildcard_service_probe_detects_a_listener_on_another_local_address() {
+        let listener = std::net::TcpListener::bind("127.0.1.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let state = RealServiceEnv.probe_port(SocketAddr::from(([0, 0, 0, 0], port)));
+        assert_eq!(state, PortState::Foreign);
+    }
+
     #[cfg(not(target_os = "macos"))]
     #[test]
     fn service_install_writes_unit_and_runs_exact_systemctl_sequence() {
@@ -31823,6 +32001,7 @@ edges:
         let mut out: Vec<u8> = Vec::new();
         run_service_with(
             ServiceAction::Install {
+                bind: None,
                 port: 6183,
                 dry_run: false,
             },
@@ -31837,6 +32016,7 @@ edges:
         let expected = service_unit::render_systemd_unit(
             Path::new("/home/user/.local/bin/pdo"),
             6183,
+            None,
             Path::new("/home/user/.pdo/app"),
             "/home/user/.local/bin:/opt/node/bin:/usr/local/bin:/usr/bin:/bin",
         );
@@ -31876,6 +32056,7 @@ edges:
         let mut out: Vec<u8> = Vec::new();
         let err = run_service_with(
             ServiceAction::Install {
+                bind: None,
                 port: 6183,
                 dry_run: false,
             },
@@ -31900,6 +32081,7 @@ edges:
         let mut out: Vec<u8> = Vec::new();
         run_service_with(
             ServiceAction::Install {
+                bind: None,
                 port: 6183,
                 dry_run: false,
             },

--- a/crates/pdo-daemon/src/main.rs
+++ b/crates/pdo-daemon/src/main.rs
@@ -21,7 +21,7 @@ fn main() -> ExitCode {
     }
 
     let res: Result<()> = match cli.command {
-        Commands::Daemon { port } => {
+        Commands::Daemon { bind, port } => {
             tracing_subscriber::fmt()
                 .with_env_filter(
                     tracing_subscriber::EnvFilter::try_from_default_env()
@@ -36,7 +36,7 @@ fn main() -> ExitCode {
                 .enable_all()
                 .build()
                 .context("failed to build tokio runtime")
-                .and_then(|rt| rt.block_on(run_daemon(port)))
+                .and_then(|rt| rt.block_on(run_daemon(bind, port)))
         }
         Commands::Complete { .. } => unreachable!("`complete` returns its own ExitCode"),
         Commands::Fail { reason } => run_fail(reason),

--- a/crates/pdo-daemon/src/node_io_resolver.rs
+++ b/crates/pdo-daemon/src/node_io_resolver.rs
@@ -314,6 +314,8 @@ mod tests {
                     status: status.clone(),
                     started_at: None,
                     completed_at: None,
+                    interactive: false,
+                    completion_released: false,
                 })
                 .collect(),
             frontmatter_retries: 0,

--- a/crates/pdo-daemon/src/node_primitives.rs
+++ b/crates/pdo-daemon/src/node_primitives.rs
@@ -550,6 +550,7 @@ pub(crate) fn start_node(params: &StartNodeParams<'_>) -> StartNodeResult {
         payload: Some(serde_json::json!({
             "prompt_preview": full_prompt.chars().take(500).collect::<String>(),
             "node_type": node_type_str(&node.node_type),
+            "interactive": node.interactive,
             // #653/ADR-0060: FREEZE where this NodeRun works. Mirrors the
             // `spawn_node` payload — every later reader asks this event.
             "isolated_worktree": has_sub_worktree,
@@ -1046,6 +1047,8 @@ mod tests {
                 status: NodeStatus::Running,
                 started_at: Some("t0".into()),
                 completed_at: None,
+                interactive: false,
+                completion_released: false,
             }],
             frontmatter_retries: 0,
             frontmatter_violations: Vec::new(),
@@ -1074,6 +1077,8 @@ mod tests {
                 status: NodeStatus::Completed,
                 started_at: Some("t0".into()),
                 completed_at: Some("t1".into()),
+                interactive: false,
+                completion_released: false,
             }],
             frontmatter_retries: 0,
             frontmatter_violations: Vec::new(),
@@ -1690,6 +1695,8 @@ mod tests {
                     status: status.clone(),
                     started_at: Some("t0".into()),
                     completed_at: None,
+                    interactive: false,
+                    completion_released: false,
                 })
                 .collect(),
             frontmatter_retries: 0,

--- a/crates/pdo-daemon/src/node_spawn.rs
+++ b/crates/pdo-daemon/src/node_spawn.rs
@@ -1165,6 +1165,7 @@ pub(crate) async fn spawn_node(
             payload: Some(serde_json::json!({
                 "prompt_preview": full_prompt.chars().take(500).collect::<String>(),
                 "node_type": node.node_type.as_str(),
+                "interactive": node.interactive,
                 // #653/ADR-0060: FREEZE where this NodeRun works. Every later
                 // reader — the re-spawn above, the restart probe, the completion
                 // path's merge-back decision — asks this event, never the

--- a/crates/pdo-daemon/src/prompt_augmenter.rs
+++ b/crates/pdo-daemon/src/prompt_augmenter.rs
@@ -763,10 +763,15 @@ pub(crate) fn build_preamble(ctx: &AugmentContext<'_>) -> String {
     preamble.push_str("## Completion\n\n");
     if ctx.node.interactive {
         preamble.push_str(
-            "This is an **interactive** node. Do NOT call `pdo complete`.\n\
-             The user will attach to this terminal session, interact with you,\n\
-             and click **\"Mark complete\"** in the PDO UI when done.\n\
-             Write your outputs to the paths listed above before the user marks complete.\n\n\
+            "For this **interactive** node, once the user says they are done, finish your \
+             work, write the outputs listed above, and run `pdo complete`.\n\
+             Completion is guarded until the user clicks **\"Mark ready for completion\"** \
+             in the PDO UI. If you call `pdo complete` before that release, the daemon \
+             refuses it with `completion_not_released` and exit code 3. Ask the user to \
+             click **\"Mark ready for completion\"**, then run `pdo complete` again.\n\
+             The user may instead click **\"Mark complete\"** to force completion with the \
+             artifacts as they are.\n\
+             A refused completion leaves this node running. **Do NOT run `pdo fail`.**\n\n\
              If you cannot complete the task, signal failure:\n\
              ```\n\
              pdo fail --reason \"<description of the problem>\"\n\
@@ -1045,7 +1050,19 @@ curl -X POST {daemon_url}/runs/{run_id}/commands \
 
 This goes through the same shared completion body as `pdo complete`, so it answers truthfully (#490): `200 {{"ok":true}}` when the node completed, `200 {{"ok":true,"noop":true,"reason":"…"}}` on a legal duplicate, and **`409 {{"error":"<slug>","recoverable":<bool>, …}}`** when the completion is refused — `missing_outputs`, `frontmatter_retry_pending`, `frontmatter_retry_exhausted`, `script_validation_failed`, `completion_rejected`, … Discriminate on `error`, never on the status. `recoverable:false` means the runtime already recorded the terminal event: do not try to record it again.
 
-### 7. inject_artifact
+### 7. release_node_completion
+
+Release the daemon completion guard for one live interactive NodeRun. The agent may then call `pdo complete` when ready. This is idempotent and does not inject text into the node session.
+
+```bash
+curl -X POST {daemon_url}/runs/{run_id}/commands \
+  -H 'Content-Type: application/json' \
+  -d '{{"kind":"release_node_completion","node_id":"<node-id>","iter":<N>}}'
+```
+
+Returns `200 {{"ok":true,"released":true}}`, with `"noop":true` when already released. Named `409` refusals include `node_not_interactive` and `node_session_not_live`; discriminate on `error`, never on the status.
+
+### 8. inject_artifact
 
 Write an artifact directly into the Blackboard.
 
@@ -1055,7 +1072,7 @@ curl -X POST {daemon_url}/runs/{run_id}/commands \
   -d '{{"kind":"inject_artifact","path":"<node-id>/iter-<N>/<port>/output.md","content":"<markdown content>"}}'
 ```
 
-### 8. cleanup_run
+### 9. cleanup_run
 
 Archive the run: remove worktrees, branches, and artifacts from disk. Events are preserved.
 
@@ -1067,7 +1084,7 @@ curl -X POST {daemon_url}/runs/{run_id}/commands \
 
 **Never call `cleanup_run` on your own initiative.** It is destructive and irreversible: it kills every active node session and removes the run's worktrees, branches, and artifacts from disk. Always check with the user first and wait for explicit confirmation before issuing it — even if you believe the run is stuck or finished.
 
-### 9. rename_run
+### 10. rename_run
 
 Set or update the display name of this run.
 
@@ -1077,7 +1094,7 @@ curl -X POST {daemon_url}/runs/{run_id}/commands \
   -d '{{"kind":"rename_run","name":"<display name>"}}'
 ```
 
-### 10. start_node
+### 11. start_node
 
 Force-spawn a node now, without waiting for its upstream producers to complete. Use when you deliberately want to start a node ahead of its dependencies. Inputs resolve best-effort: any not-yet-produced upstream artifact resolves to the path where it *will* appear, so the node may run against missing or stale inputs. This is reversible — `restart_node` or `kill_node` it if it ran too early.
 
@@ -1087,7 +1104,7 @@ curl -X POST {daemon_url}/runs/{run_id}/commands \
   -d '{{"kind":"start_node","node_id":"<node-id>"}}'
 ```
 
-### 11. extend_cycle (legacy)
+### 12. extend_cycle (legacy)
 
 Increment the iteration ceiling of a *legacy drawn cycle* (a pipeline without a `loops:` block) and re-evaluate. `node_id` is the node whose **outgoing exit condition** references the `$max_iter`-style variable to bump — never the cycle's head/entry node. For any node that belongs to a bounded loop region this command is rejected with 409 — use `bump_region` instead. An unknown `node_id` is rejected with 400. Same truthful response body as `bump_region`.
 
@@ -1902,12 +1919,10 @@ mod tests {
         let ctx = sample_ctx(&pipeline, node, &vars);
 
         let preamble = build_preamble(&ctx);
-        assert!(
-            !preamble.contains("signal completion by running"),
-            "interactive node should not instruct to run pdo complete"
-        );
-        assert!(preamble.contains("Do NOT call `pdo complete`"));
-        assert!(preamble.contains("Mark complete"));
+        assert!(preamble.contains("once the user says they are done"));
+        assert!(preamble.contains("completion_not_released"));
+        assert!(preamble.contains("Mark ready for completion"));
+        assert!(preamble.contains("Do NOT run `pdo fail`"));
         assert!(preamble.contains("pdo fail --reason"));
     }
 
@@ -2353,6 +2368,7 @@ mod tests {
             "kill_node",
             "restart_node",
             "mark_node_done",
+            "release_node_completion",
             "inject_artifact",
             "cleanup_run",
             "rename_run",
@@ -2455,15 +2471,15 @@ mod tests {
         let preamble =
             build_manager_preamble("run-1", "http://localhost:5172", RunNameHint::UserProvided);
         let section = preamble
-            .split("### 8. cleanup_run")
+            .split("### 9. cleanup_run")
             .nth(1)
             .expect("preamble should contain the cleanup_run section")
-            .split("### 9.")
+            .split("### 10.")
             .next()
-            .expect("cleanup_run section should be delimited by section 9");
+            .expect("cleanup_run section should be delimited by section 10");
         assert!(
-            preamble.contains("### 9. rename_run"),
-            "renumbering drifted: section 9 should be rename_run"
+            preamble.contains("### 10. rename_run"),
+            "renumbering drifted: section 10 should be rename_run"
         );
         assert!(
             section.contains("Never call `cleanup_run` on your own initiative"),

--- a/crates/pdo-daemon/src/run_advance.rs
+++ b/crates/pdo-daemon/src/run_advance.rs
@@ -1133,6 +1133,8 @@ mod tests {
                 status,
                 started_at: Some("t0".into()),
                 completed_at,
+                interactive: false,
+                completion_released: false,
             }],
             frontmatter_retries: 0,
             frontmatter_violations: Vec::new(),

--- a/crates/pdo-daemon/src/run_command.rs
+++ b/crates/pdo-daemon/src/run_command.rs
@@ -82,6 +82,10 @@ enum RunCommand {
         node_id: String,
         iter: i64,
     },
+    ReleaseNodeCompletion {
+        node_id: String,
+        iter: i64,
+    },
     ExtendCycle {
         node_id: String,
         additional_iter: i64,
@@ -191,6 +195,7 @@ impl RunCommand {
     fn kind_str(&self) -> &'static str {
         match self {
             RunCommand::MarkNodeDone { .. } => "mark_node_done",
+            RunCommand::ReleaseNodeCompletion { .. } => "release_node_completion",
             RunCommand::ExtendCycle { .. } => "extend_cycle",
             RunCommand::Region {
                 action: RegionAction::Bump { .. },
@@ -253,6 +258,10 @@ fn parse_run_command(req: RunCommandRequest) -> Result<RunCommand, CommandParseE
     match req.kind.as_str() {
         "mark_node_done" => Ok(RunCommand::MarkNodeDone {
             node_id: required(req.node_id, "node_id", "mark_node_done")?,
+            iter: req.iter.unwrap_or(1),
+        }),
+        "release_node_completion" => Ok(RunCommand::ReleaseNodeCompletion {
+            node_id: required(req.node_id, "node_id", "release_node_completion")?,
             iter: req.iter.unwrap_or(1),
         }),
         "extend_cycle" => {
@@ -498,6 +507,9 @@ async fn dispatch(state: Arc<AppState>, run_id: String, cmd: RunCommand) -> Resp
     let kind_str = cmd.kind_str();
 
     match cmd {
+        RunCommand::ReleaseNodeCompletion { node_id, iter } => {
+            crate::release_node_completion(&state, &run_id, &node_id, iter).await
+        }
         RunCommand::MarkNodeDone { node_id, iter } => {
             // NOT `load_projected`, which would 404 on an unstarted run: this arm
             // needs the `Option<RunState>` itself, so `None` maps to `Allow` and
@@ -2680,11 +2692,18 @@ mod tests {
     }
 
     #[test]
-    fn parse_accepts_the_fourteen_kinds() {
-        let cases: [(serde_json::Value, RunCommand); 14] = [
+    fn parse_accepts_the_fifteen_kinds() {
+        let cases: [(serde_json::Value, RunCommand); 15] = [
             (
                 serde_json::json!({ "kind": "mark_node_done", "node_id": "n1", "iter": 3 }),
                 RunCommand::MarkNodeDone {
+                    node_id: "n1".into(),
+                    iter: 3,
+                },
+            ),
+            (
+                serde_json::json!({ "kind": "release_node_completion", "node_id": "n1", "iter": 3 }),
+                RunCommand::ReleaseNodeCompletion {
                     node_id: "n1".into(),
                     iter: 3,
                 },
@@ -2781,6 +2800,10 @@ mod tests {
             (
                 serde_json::json!({ "kind": "mark_node_done" }),
                 "node_id required for mark_node_done",
+            ),
+            (
+                serde_json::json!({ "kind": "release_node_completion" }),
+                "node_id required for release_node_completion",
             ),
             (
                 serde_json::json!({ "kind": "extend_cycle" }),
@@ -2927,6 +2950,7 @@ mod tests {
         // distinguished in the type.
         for kind in [
             "mark_node_done",
+            "release_node_completion",
             "extend_cycle",
             "bump_region",
             "end_region",

--- a/crates/pdo-daemon/src/scheduler.rs
+++ b/crates/pdo-daemon/src/scheduler.rs
@@ -4427,6 +4427,8 @@ mod tests {
                 status: NodeStatus::Completed,
                 started_at: Some("t0".into()),
                 completed_at: Some("t1".into()),
+                interactive: false,
+                completion_released: false,
             })
             .collect();
         ns

--- a/crates/pdo-daemon/src/service_unit.rs
+++ b/crates/pdo-daemon/src/service_unit.rs
@@ -18,8 +18,10 @@
 //!     cgroup on stop/restart, which would nuke the child tmux server holding
 //!     every live Claude session (#234). `process` kills only the daemon pid.
 //!   * `Environment=PATH=…<node dir>…` — the daemon shells out to
-//!     `claude`/`node`/`git`/`tmux`; a bare unit PATH silently breaks spawns.
+//!     `node`/`git`/`tmux`; a bare unit PATH silently breaks those operations.
+//!     Harness binaries use the user's interactive shell PATH (ADR-0055).
 
+use std::net::IpAddr;
 use std::path::{Path, PathBuf};
 
 /// launchd label / plist basename for the macOS LaunchAgent (#156, D6).
@@ -45,9 +47,13 @@ pub(crate) const SYSTEMD_UNIT_NAME: &str = "pdo.service";
 pub(crate) fn render_systemd_unit(
     exe: &Path,
     port: u16,
+    bind: Option<IpAddr>,
     working_dir: &Path,
     path_env: &str,
 ) -> String {
+    let bind_env = bind
+        .map(|ip| format!("Environment=PDO_BIND={ip}\n"))
+        .unwrap_or_default();
     format!(
         "[Unit]\n\
          Description=PDO (Prompt-Driven Orchestrator) daemon\n\
@@ -58,6 +64,8 @@ pub(crate) fn render_systemd_unit(
          Type=simple\n\
          WorkingDirectory={working_dir}\n\
          Environment=PDO_PORT={port}\n\
+         {bind_env}\
+         # Harness binaries resolve through the user's interactive shell PATH (ADR-0055).\n\
          Environment=PATH={path_env}\n\
          ExecStart={exe} daemon\n\
          Restart=on-failure\n\
@@ -68,6 +76,7 @@ pub(crate) fn render_systemd_unit(
          WantedBy=default.target\n",
         working_dir = working_dir.display(),
         port = port,
+        bind_env = bind_env,
         path_env = path_env,
         exe = exe.display(),
     )
@@ -84,10 +93,14 @@ pub(crate) fn render_systemd_unit(
 pub(crate) fn render_launchd_plist(
     exe: &Path,
     port: u16,
+    bind: Option<IpAddr>,
     working_dir: &Path,
     home: &Path,
     path_env: &str,
 ) -> String {
+    let bind_env = bind
+        .map(|ip| format!("\x20 \x20 <key>PDO_BIND</key><string>{ip}</string>\n"))
+        .unwrap_or_default();
     format!(
         "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
          <!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\"\n\
@@ -105,6 +118,8 @@ pub(crate) fn render_launchd_plist(
          \x20 <key>EnvironmentVariables</key>\n\
          \x20 <dict>\n\
          \x20 \x20 <key>PDO_PORT</key><string>{port}</string>\n\
+         {bind_env}\
+         \x20 \x20 <!-- Harness binaries resolve through the user's interactive shell PATH (ADR-0055). -->\n\
          \x20 \x20 <key>PATH</key><string>{path_env}</string>\n\
          \x20 \x20 <key>HOME</key><string>{home}</string>\n\
          \x20 </dict>\n\
@@ -116,6 +131,7 @@ pub(crate) fn render_launchd_plist(
         exe = exe.display(),
         working_dir = working_dir.display(),
         port = port,
+        bind_env = bind_env,
         path_env = path_env,
         home = home.display(),
     )
@@ -126,7 +142,7 @@ pub(crate) fn render_launchd_plist(
 /// Faithful to the Makefile recipe:
 /// `<exe dir>:<node dir>:/usr/local/bin:/usr/bin:/bin`. The exe dir first so the
 /// service resolves the very `pdo` it was installed from; the node dir so
-/// `claude`/`node` spawns work under the minimal env systemd hands a unit.
+/// node-backed operations work under the minimal env systemd hands a unit.
 ///
 /// `node_dir` is passed in (resolved impurely by [`resolve_node_dir`]) to keep
 /// this pure and golden-testable. When `None` (node not found) the node segment
@@ -134,15 +150,19 @@ pub(crate) fn render_launchd_plist(
 /// dir is the single most likely silent-spawn-failure on a shipped unit.
 pub(crate) fn build_path_env(exe: &Path, node_dir: Option<&Path>) -> String {
     let mut parts: Vec<String> = Vec::with_capacity(5);
-    if let Some(dir) = exe.parent() {
-        parts.push(dir.display().to_string());
+    let candidates = [
+        exe.parent(),
+        node_dir,
+        Some(Path::new("/usr/local/bin")),
+        Some(Path::new("/usr/bin")),
+        Some(Path::new("/bin")),
+    ];
+    for dir in candidates.into_iter().flatten() {
+        let dir = dir.display().to_string();
+        if !parts.contains(&dir) {
+            parts.push(dir);
+        }
     }
-    if let Some(dir) = node_dir {
-        parts.push(dir.display().to_string());
-    }
-    parts.push("/usr/local/bin".to_string());
-    parts.push("/usr/bin".to_string());
-    parts.push("/bin".to_string());
     parts.join(":")
 }
 
@@ -207,7 +227,7 @@ mod tests {
         let exe = Path::new("/home/user/.local/bin/pdo");
         let wd = Path::new("/home/user/.pdo/app");
         let path_env = "/home/user/.local/bin:/opt/node/bin:/usr/local/bin:/usr/bin:/bin";
-        let unit = render_systemd_unit(exe, 6160, wd, path_env);
+        let unit = render_systemd_unit(exe, 6160, None, wd, path_env);
 
         let expected = "\
 [Unit]
@@ -219,6 +239,7 @@ Wants=network-online.target
 Type=simple
 WorkingDirectory=/home/user/.pdo/app
 Environment=PDO_PORT=6160
+# Harness binaries resolve through the user's interactive shell PATH (ADR-0055).
 Environment=PATH=/home/user/.local/bin:/opt/node/bin:/usr/local/bin:/usr/bin:/bin
 ExecStart=/home/user/.local/bin/pdo daemon
 Restart=on-failure
@@ -236,6 +257,7 @@ WantedBy=default.target
         let unit = render_systemd_unit(
             Path::new("/x/pdo"),
             5172,
+            None,
             Path::new("/repo"),
             "/x:/opt/node/bin:/usr/bin",
         );
@@ -247,6 +269,9 @@ WantedBy=default.target
         assert!(unit.contains("WorkingDirectory=/repo"));
         assert!(unit.contains("Environment=PDO_PORT=5172"));
         assert!(unit.contains("Environment=PATH=/x:/opt/node/bin:/usr/bin"));
+        assert!(unit.contains(
+            "# Harness binaries resolve through the user's interactive shell PATH (ADR-0055)."
+        ));
         assert!(unit.contains("Restart=on-failure"));
         assert!(unit.contains("RestartSec=3"));
         assert!(unit.contains("WantedBy=default.target"));
@@ -257,6 +282,7 @@ WantedBy=default.target
         let plist = render_launchd_plist(
             Path::new("/Users/u/.local/bin/pdo"),
             6160,
+            None,
             Path::new("/Users/u/.pdo/app"),
             Path::new("/Users/u"),
             "/Users/u/.local/bin:/opt/node/bin:/usr/bin",
@@ -278,6 +304,38 @@ WantedBy=default.target
     }
 
     #[test]
+    fn service_definitions_include_bind_only_when_requested() {
+        let bind = Some("127.0.0.1".parse().unwrap());
+        let unit = render_systemd_unit(
+            Path::new("/x/pdo"),
+            5172,
+            bind,
+            Path::new("/repo"),
+            "/usr/bin",
+        );
+        assert!(unit.contains("Environment=PDO_BIND=127.0.0.1\n"));
+
+        let plist = render_launchd_plist(
+            Path::new("/x/pdo"),
+            5172,
+            bind,
+            Path::new("/repo"),
+            Path::new("/home/user"),
+            "/usr/bin",
+        );
+        assert!(plist.contains("<key>PDO_BIND</key><string>127.0.0.1</string>"));
+
+        let default_unit = render_systemd_unit(
+            Path::new("/x/pdo"),
+            5172,
+            None,
+            Path::new("/repo"),
+            "/usr/bin",
+        );
+        assert!(!default_unit.contains("PDO_BIND"));
+    }
+
+    #[test]
     fn build_path_env_orders_exe_then_node_then_std_dirs() {
         let got = build_path_env(
             Path::new("/home/user/.local/bin/pdo"),
@@ -293,6 +351,15 @@ WantedBy=default.target
     fn build_path_env_omits_node_segment_when_absent() {
         let got = build_path_env(Path::new("/home/user/.local/bin/pdo"), None);
         assert_eq!(got, "/home/user/.local/bin:/usr/local/bin:/usr/bin:/bin");
+    }
+
+    #[test]
+    fn build_path_env_deduplicates_node_and_standard_directories() {
+        let got = build_path_env(
+            Path::new("/home/user/.local/bin/pdo"),
+            Some(Path::new("/usr/bin")),
+        );
+        assert_eq!(got, "/home/user/.local/bin:/usr/bin:/usr/local/bin:/bin");
     }
 
     #[test]

--- a/crates/pdo-daemon/src/update_executor.rs
+++ b/crates/pdo-daemon/src/update_executor.rs
@@ -25,6 +25,7 @@
 //! executor** (`PDO_UPDATE_EXECUTOR`) that receives the plan through env variables.
 
 use serde::{Deserialize, Serialize};
+use std::net::IpAddr;
 use std::path::{Path, PathBuf};
 
 use crate::update_check::{InstallMethod, Supervision};
@@ -86,6 +87,8 @@ pub struct UpdatePlan {
     /// relaunch invoke): Homebrew's `bin/pdo`, never `Cellar/pdo/<v>/bin/pdo`.
     pub exe: PathBuf,
     pub port: u16,
+    /// Explicit bind passed to the daemon, if any. `None` preserves the default.
+    pub bind: Option<IpAddr>,
     /// The daemon's cwd: `service install` derives `WorkingDirectory` from it and
     /// the relaunch must resolve the same repo root.
     pub working_dir: PathBuf,
@@ -126,6 +129,13 @@ pub(crate) fn log_path(home_root: &Path, attempt_id: &str) -> PathBuf {
 /// `<home>/.pdo/update/<attempt_id>.sh`.
 pub(crate) fn script_path(home_root: &Path, attempt_id: &str) -> PathBuf {
     update_dir(home_root).join(format!("{attempt_id}.sh"))
+}
+
+pub(crate) fn explicit_bind_from_relaunch(relaunch: &[String]) -> Option<IpAddr> {
+    relaunch
+        .windows(2)
+        .find(|pair| pair[0] == "--bind")
+        .and_then(|pair| pair[1].parse().ok())
 }
 
 /// A fresh attempt id: UTC timestamp + short random suffix, filesystem-safe.
@@ -276,8 +286,12 @@ pub fn render_update_script(plan: &UpdatePlan) -> String {
                 "echo \"== reinstalling the service unit (stable path {})\"\n",
                 plan.exe.display()
             ));
+            let bind_arg = plan
+                .bind
+                .map(|ip| format!(" --bind {}", sh_quote(&ip.to_string())))
+                .unwrap_or_default();
             s.push_str(&format!(
-                "{} service install --port {}\nrc=$?\n",
+                "{} service install --port {}{bind_arg}\nrc=$?\n",
                 sh_quote(&plan.exe.display().to_string()),
                 plan.port
             ));
@@ -426,6 +440,7 @@ mod tests {
             supervision,
             exe: PathBuf::from("/home/linuxbrew/.linuxbrew/bin/pdo"),
             port: 5172,
+            bind: None,
             working_dir: PathBuf::from("/home/u/.pdo/app"),
             daemon_pid: 4242,
             relaunch: vec![
@@ -476,6 +491,34 @@ mod tests {
         let s = render_update_script(&plan(InstallMethod::Homebrew, Supervision::Launchd));
         assert!(s.contains("launchctl kickstart -k \"gui/$(id -u)/com.pdo.daemon\""));
         assert!(!s.contains("systemctl"));
+    }
+
+    #[test]
+    fn supervised_update_preserves_an_explicit_bind() {
+        let mut plan = plan(InstallMethod::Homebrew, Supervision::Systemd);
+        plan.bind = Some("127.0.0.1".parse().unwrap());
+        let s = render_update_script(&plan);
+        assert!(s.contains("service install --port 5172 --bind 127.0.0.1"));
+    }
+
+    #[test]
+    fn relaunch_bind_is_read_only_when_explicit() {
+        let explicit = vec![
+            "pdo".into(),
+            "daemon".into(),
+            "--port".into(),
+            "5172".into(),
+            "--bind".into(),
+            "127.0.0.1".into(),
+        ];
+        assert_eq!(
+            explicit_bind_from_relaunch(&explicit),
+            Some("127.0.0.1".parse().unwrap())
+        );
+        assert_eq!(
+            explicit_bind_from_relaunch(&["pdo".into(), "daemon".into()]),
+            None
+        );
     }
 
     #[test]

--- a/crates/pdo-daemon/tests/daemon_bind.rs
+++ b/crates/pdo-daemon/tests/daemon_bind.rs
@@ -1,0 +1,70 @@
+//! Layer 3a coverage for the daemon bind and precedence contract in #769.
+
+use std::io::Read;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+fn unused_loopback_port() -> u16 {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("reserve loopback port");
+    listener.local_addr().unwrap().port()
+}
+
+#[test]
+fn daemon_bind_uses_the_environment_and_the_flag_takes_precedence() {
+    let cases: &[(&[&str], &str)] = &[(&[], "127.0.0.1"), (&["--bind", "127.0.0.1"], "0.0.0.0")];
+
+    for (extra_args, env_bind) in cases {
+        let port = unused_loopback_port();
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let mut command = std::process::Command::new(env!("CARGO_BIN_EXE_pdo"));
+        command
+            .current_dir(tempdir.path())
+            .args(["daemon", "--port"])
+            .arg(port.to_string())
+            .args(*extra_args)
+            .env("PDO_BIND", env_bind)
+            .env("PDO_PRICE_SYNC", "off")
+            .env("PDO_DAEMON_NO_CLEANUP", "1")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::piped());
+        let mut child = command.spawn().expect("failed to spawn pdo daemon");
+
+        let stderr = child.stderr.take().expect("stderr pipe missing");
+        let output = Arc::new(Mutex::new(String::new()));
+        let writer = Arc::clone(&output);
+        let reader = std::thread::spawn(move || {
+            let mut stderr = stderr;
+            let mut chunk = [0u8; 4096];
+            while let Ok(n) = stderr.read(&mut chunk) {
+                if n == 0 {
+                    break;
+                }
+                if let Ok(mut text) = writer.lock() {
+                    text.push_str(&String::from_utf8_lossy(&chunk[..n]));
+                }
+            }
+        });
+        let expected = format!("PDO daemon listening on 127.0.0.1:{port}");
+        let deadline = std::time::Instant::now() + Duration::from_secs(20);
+        while std::time::Instant::now() < deadline
+            && !output.lock().is_ok_and(|text| text.contains(&expected))
+        {
+            std::thread::sleep(Duration::from_millis(100));
+        }
+
+        let response = reqwest::blocking::get(format!("http://127.0.0.1:{port}/sessions"));
+        let _ = child.kill();
+        let _ = child.wait();
+        let _ = reader.join();
+        let collected = output.lock().map(|text| text.clone()).unwrap_or_default();
+
+        assert!(
+            collected.contains(&expected),
+            "daemon did not bind to the requested address; stderr:\n{collected}"
+        );
+        assert!(
+            response.is_ok_and(|r| r.status().is_success()),
+            "daemon did not answer on its requested bind address"
+        );
+    }
+}

--- a/crates/pdo-daemon/tests/it.rs
+++ b/crates/pdo-daemon/tests/it.rs
@@ -29,6 +29,9 @@ mod cli_run_create;
 #[path = "cost_prices.rs"]
 mod cost_prices;
 
+#[path = "daemon_bind.rs"]
+mod daemon_bind;
+
 #[path = "stats_cost_by_model.rs"]
 mod stats_cost_by_model;
 
@@ -192,6 +195,9 @@ mod serializer_round_trip;
 
 #[path = "session_cap_admission.rs"]
 mod session_cap_admission;
+
+#[path = "service_bind_cli.rs"]
+mod service_bind_cli;
 
 #[path = "smoke_daemon.rs"]
 mod smoke_daemon;

--- a/crates/pdo-daemon/tests/log_level_default.rs
+++ b/crates/pdo-daemon/tests/log_level_default.rs
@@ -49,6 +49,7 @@ fn info_logs_emitted_when_rust_log_is_unset() {
             if n == 0 {
                 break;
             }
+
             if let Ok(mut g) = buf_w.lock() {
                 g.push_str(&String::from_utf8_lossy(&chunk[..n]));
             }

--- a/crates/pdo-daemon/tests/service_bind_cli.rs
+++ b/crates/pdo-daemon/tests/service_bind_cli.rs
@@ -1,0 +1,31 @@
+//! Layer 3a coverage for the service-install bind contract in #769.
+
+fn dry_run(extra_args: &[&str]) -> String {
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_pdo"))
+        .current_dir(tempdir.path())
+        .args(["service", "install", "--dry-run", "--port", "0"])
+        .args(extra_args)
+        .env("PDO_BIND", "192.0.2.10")
+        .output()
+        .expect("run service install --dry-run");
+    assert!(
+        output.status.success(),
+        "dry-run failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout).expect("dry-run output is UTF-8")
+}
+
+#[test]
+fn service_install_persists_only_an_explicit_bind() {
+    let without_flag = dry_run(&[]);
+    assert!(
+        !without_flag.contains("PDO_BIND"),
+        "PDO_BIND from the caller environment must not enter the service definition"
+    );
+
+    let with_flag = dry_run(&["--bind", "127.0.0.1"]);
+    assert!(with_flag.contains("Environment=PDO_BIND=127.0.0.1"));
+    assert!(!with_flag.contains("Environment=PDO_BIND=192.0.2.10"));
+}

--- a/crates/pdo-daemon/tests/support_table_committed.rs
+++ b/crates/pdo-daemon/tests/support_table_committed.rs
@@ -47,3 +47,43 @@ fn the_readme_carries_the_harness_prerequisites() {
         );
     }
 }
+
+#[test]
+fn the_readme_has_one_command_table_and_no_scattered_daemon_or_service_blocks() {
+    let document = std::fs::read_to_string(readme()).expect("README is readable");
+    let commands = [
+        "pdo daemon",
+        "pdo service install",
+        "pdo service status",
+        "pdo service uninstall",
+        "pdo complete",
+        "pdo fail",
+        "pdo skip",
+        "pdo migrate",
+        "pdo reap",
+        "pdo run create",
+        "pdo page mount",
+        "pdo review list",
+        "pdo review reply",
+    ];
+    for command in commands {
+        assert!(
+            document
+                .lines()
+                .any(|line| line.starts_with("| `pdo ") && line.contains(command)),
+            "CLI command table is missing `{command}`"
+        );
+    }
+
+    let mut in_code_block = false;
+    for line in document.lines() {
+        if line.starts_with("```") {
+            in_code_block = !in_code_block;
+        } else if in_code_block {
+            assert!(
+                !line.contains("pdo daemon") && !line.contains("pdo service"),
+                "daemon and service examples belong in the CLI command table: {line}"
+            );
+        }
+    }
+}

--- a/docs/adr/0019-persistent-daemon-service-unit.md
+++ b/docs/adr/0019-persistent-daemon-service-unit.md
@@ -1,5 +1,8 @@
 # Service unit persistant pour le daemon (systemd `--user` / launchd)
 
+> Amendé par le grilling #766 : `Environment=PDO_BIND=` optionnel dans l'unité ; le `PATH` de l'unité
+> n'est plus la référence des harnais (ADR-0055) et l'unité le dit en commentaire.
+
 Sans cette ADR, on laisse le daemon en `pdo daemon` best-effort (ADR-0012) : fermer son laptop ou
 rebooter arrête silencieusement toute autonomie planifiée — la différence entre « ça tourne tant que
 tu es loggé » et un orchestrateur autonome.
@@ -15,9 +18,11 @@ purement **additive** — aucun couplage au scheduler, à la projection ou au ru
   - `KillMode=process` — le défaut `control-group` SIGKILL-erait tout le cgroup, donc le **serveur
     tmux enfant** (qui tient toutes les sessions live) mourrait ; `process` le laisse ré-adoptable
     (cohérent avec « tuer par nom de session, jamais par pid »).
-  - `Environment=PATH=…` — le daemon shelle vers `claude`/`node`/`git`/`tmux` ; sous l'env minimal
-    d'une unité, un PATH nu casse **silencieusement** les spawns. (Analogue macOS :
-    `AbandonProcessGroup=true` + PATH explicite.)
+  - `Environment=PATH=…` — le daemon shelle vers `node`/`git`/`tmux` ; sous l'env minimal d'une
+    unité, un PATH nu casse **silencieusement** ces appels. Dédupliqué. Les **harnais** ne s'y
+    résolvent **pas** (ADR-0055 : PATH du shell interactif de l'utilisateur) et l'unité porte un
+    commentaire qui le dit — un lecteur voyant `~/.npm-global/bin` absent en déduisait à tort un
+    harnais introuvable (#766). (Analogue macOS : `AbandonProcessGroup=true` + PATH explicite.)
   - `WorkingDirectory=` — le daemon dérive sa racine du cwd ; sans lui il tournerait depuis `/`.
     Depuis ADR-0033 cette racine est celle du **stockage**, **plus jamais** le dépôt qu'un Run mute
     (champ requis de chaque Run). Sans ce qualificatif, la phrase décrit la panne du 2026-07-29 :
@@ -52,7 +57,10 @@ purement **additive** — aucun couplage au scheduler, à la projection ou au ru
   déloggé**.
 - La valeur `persistent` cachée peut être **stale** si on installe le service pendant qu'un daemon
   non-service tourne déjà (reflétée au prochain restart).
-- Le bind réseau du daemon reste inchangé (durcissement = #260).
+- Le bind par défaut reste `0.0.0.0` (#260, accès LAN assumé). Depuis #766, `pdo daemon --bind <ip>`
+  (`PDO_BIND`) restreint l'écoute, et `pdo service install --bind` l'écrit dans l'unité
+  (`Environment=PDO_BIND=`), préservé par la réinstallation de l'Update comme `PDO_PORT`. Défense en
+  profondeur derrière un reverse proxy, pas un substitut à l'auth (toujours hors scope).
 
 ## Relations
 

--- a/docs/adr/0068-la-liberation-de-la-completion-est-une-garde-du-daemon-pas-un-message-dans-le-pane.md
+++ b/docs/adr/0068-la-liberation-de-la-completion-est-une-garde-du-daemon-pas-un-message-dans-le-pane.md
@@ -1,0 +1,47 @@
+# ADR-0068 — La libération de la complétion est une garde du daemon, pas un message dans le pane
+
+> Statut : accepted (grilling #763). Vocabulaire : CONTEXT.md § « Nœuds interactifs — signal de complétion ». Amende ADR-0035 (nouvelle variante de refus) ; ferme un trou de CONTEXT.md § « Cycle de vie process » (l'auto-complétion n'épargnait pas les nœuds interactifs).
+
+## Contexte
+
+Un nœud `interactive: true` n'a qu'une sortie : l'utilisateur force la complétion depuis l'UI
+(« Mark complete », artefacts pris tels quels). Il manque le geste intermédiaire — « j'ai fini
+d'interagir, l'agent finit son travail et complète quand il est prêt ». Or l'interdiction de
+`pdo complete` sur un nœud interactif n'existait **que dans le préambule** : le daemon acceptait
+un `pdo complete` d'un nœud interactif, y compris `--auto` (hook Stop, balayage de fin de tour)
+quand l'auto-complétion d'instance est cochée — en contradiction avec « n'auto-complète jamais ».
+
+## Décisions
+
+**1. Libérer = lever une garde du daemon.** « Mark ready for completion » enregistre un événement
+de libération sur `(node, iter)` ; tant qu'il est absent, **toute** complétion d'un nœud interactif
+est refusée (409 nommé, *recoverable* : l'agent garde la main, exit 3 du contrat #490), quelle que
+soit la source (`explicit`, `stop_hook`, `turn_ended`). Seul `mark_node_done` — le forçage — passe
+outre. Le préambule interactif cesse d'interdire `pdo complete` et décrit ce contrat.
+
+Écartée : **taper un message dans le pane de l'agent** (`send-keys`/`paste_text`) pour lui dire de
+compléter. ADR-0051 l'a déjà mesuré : le seul précédent d'injection (message correctif de
+frontmatter) ne vaut que pour un agent qu'on sait au repos ; un nœud interactif est précisément une
+REPL qu'un humain pilote, et un `Enter` injecté s'insère dans sa phrase. Écartée aussi : une
+**capacité par harnais** « injecter un message » — la bonne forme si un jour un harnais l'exige,
+pas avant qu'un besoin la justifie.
+
+**2. Le nœud repasse `running`.** Après libération, personne n'attend plus l'humain : le Run quitte
+`AwaitingUser` (sauf autre cause). Un retry (itération suivante) ou un `restart_node` (agent frais,
+même iter) **réarme** la garde : l'agent neuf ne connaît pas la conversation qui a libéré.
+
+**3. L'agent apprend la libération par l'humain, pas par le runtime.** Un nœud interactif suppose
+un humain attaché : il clique, puis dit à l'agent qu'il a fini. Un `pdo complete` prématuré revient
+en exit 3 avec la consigne de demander le clic. Écarté : un `pdo complete --wait` bloquant qui
+attendrait la libération — il gèlerait la conversation, qui est la raison d'être du nœud. Reste
+ouvert si un usage « libérer depuis le dashboard sans réattacher » apparaît.
+
+**4. Idempotent, exposé au manager.** Re-cliquer re-libère sans effet ; la commande
+`release_node_completion` porte le même geste depuis le Pipeline Manager (refus nommé sur un nœud
+non interactif ou sans session vivante).
+
+## Conséquences
+
+- Le contrat de refus (ADR-0035) gagne une variante *recoverable*. L'auto-complétion (ADR-0032 §2)
+  devient réellement inopérante sur un nœud interactif non libéré — c'était l'intention écrite.
+- « Mark complete » reste l'échappatoire inconditionnelle, y compris après libération.

--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -12,6 +12,7 @@ import {
   editRunRepos,
   fetchPipeline,
   markNodeDone,
+  releaseNodeCompletion,
   request,
   savePipeline,
   saveRunPipeline,
@@ -323,6 +324,32 @@ describe("markNodeDone outcome union (#490)", () => {
   it("reads a plain 200 as completed", async () => {
     stubFetchWith(200, { ok: true });
     await expect(markNodeDone("r1", "n1", 1)).resolves.toEqual({ kind: "completed" });
+  });
+
+  describe("releaseNodeCompletion (#764)", () => {
+    it("posts the displayed iteration to the release route", async () => {
+      const fetchMock = captureFetch(200, { ok: true, released: true });
+      await expect(releaseNodeCompletion("r1", "n1", 3)).resolves.toEqual({
+        kind: "released",
+      });
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toContain("/runs/r1/nodes/n1/release");
+      expect(JSON.parse(init?.body as string)).toEqual({ iter: 3 });
+    });
+
+    it("returns a named 409 refusal as a verdict", async () => {
+      stubFetchWith(409, {
+        error: "node_session_not_live",
+        recoverable: true,
+        message: "no live session",
+      });
+      await expect(releaseNodeCompletion("r1", "n1", 1)).resolves.toEqual({
+        kind: "refused",
+        slug: "node_session_not_live",
+        recoverable: true,
+        message: "no live session",
+      });
+    });
   });
 
   it("reads a 200 with noop:true as a legal duplicate, not a refusal", async () => {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -568,6 +568,47 @@ export async function markNodeDone(
   return { kind: "completed" };
 }
 
+export type ReleaseNodeCompletionOutcome =
+  | { kind: "released" }
+  | {
+      kind: "refused";
+      slug: string | null;
+      recoverable: boolean | null;
+      message: string;
+    };
+
+export async function releaseNodeCompletion(
+  runId: string,
+  nodeId: string,
+  iter: number,
+): Promise<ReleaseNodeCompletionOutcome> {
+  const resp = await request<Response>(
+    "POST",
+    `/runs/${encodeURIComponent(runId)}/nodes/${encodeURIComponent(nodeId)}/release`,
+    { body: { iter }, responseMode: "raw" },
+  );
+  const body: unknown = await resp.json().catch(() => null);
+  if (resp.status === 409) {
+    const refusal = body as
+      | { error?: unknown; recoverable?: unknown; message?: unknown }
+      | null;
+    return {
+      kind: "refused",
+      slug: typeof refusal?.error === "string" ? refusal.error : null,
+      recoverable:
+        typeof refusal?.recoverable === "boolean" ? refusal.recoverable : null,
+      message: apiErrorMessage(body, `release refused: ${resp.status}`),
+    };
+  }
+  if (!resp.ok) {
+    throw new ApiError(
+      apiErrorMessage(body, `release completion failed: ${resp.status}`),
+      { status: resp.status, body },
+    );
+  }
+  return { kind: "released" };
+}
+
 export function attachSession(sessionId: string): Promise<void> {
   return request<void>(
     "POST",

--- a/frontend/src/components/NodeDetailPanel.test.tsx
+++ b/frontend/src/components/NodeDetailPanel.test.tsx
@@ -34,11 +34,13 @@ const previewProvisioningMock = vi.fn().mockResolvedValue({
 // had ever exercised a *Mark complete* click. Made controllable so the verdict
 // branches can be driven. Vitest compares arity strictly, hence the spread.
 const markNodeDoneMock = vi.fn().mockResolvedValue({ kind: "completed" });
+const releaseNodeCompletionMock = vi.fn().mockResolvedValue({ kind: "released" });
 
 vi.mock("../api", () => ({
   fetchPrompt: (...args: unknown[]) => fetchPromptMock(...args),
   fetchNodeIO: (...args: unknown[]) => fetchNodeIOMock(...args),
   markNodeDone: (...args: unknown[]) => markNodeDoneMock(...args),
+  releaseNodeCompletion: (...args: unknown[]) => releaseNodeCompletionMock(...args),
   killNode: (...args: unknown[]) => killNodeMock(...args),
   restartNode: (...args: unknown[]) => restartNodeMock(...args),
   stopNode: (...args: unknown[]) => stopNodeMock(...args),
@@ -142,6 +144,8 @@ describe("NodeDetailPanel", () => {
     retryNodePreviewMock.mockResolvedValue({ downstream: [], affected_count: 0, with_artifacts: [] });
     markNodeDoneMock.mockClear();
     markNodeDoneMock.mockResolvedValue({ kind: "completed" });
+    releaseNodeCompletionMock.mockClear();
+    releaseNodeCompletionMock.mockResolvedValue({ kind: "released" });
     tmuxMountCount.current = 0;
     tmuxUnmountCount.current = 0;
   });
@@ -1810,6 +1814,142 @@ describe("NodeDetailPanel", () => {
         fireEvent.click(option);
       });
       expect(screen.queryByTestId("mark-complete-verdict")).not.toBeInTheDocument();
+    });
+
+    describe("release completion (#764)", () => {
+      const liveInteractive = (overrides?: Partial<NodeState>) =>
+        makeNode({
+          status: "awaiting_user",
+          iterations: [
+            {
+              iter: 1,
+              status: "awaiting_user",
+              started_at: null,
+              completed_at: null,
+              interactive: true,
+              completion_released: false,
+            },
+          ],
+          ...overrides,
+        });
+
+      it("shows both exits only for a live interactive iteration", () => {
+        const { rerender } = render(
+          <TooltipProvider>
+            <NodeDetailPanel node={liveInteractive()} runId="run-1" />
+          </TooltipProvider>,
+        );
+        expect(screen.getByTestId("release-completion-btn")).toBeInTheDocument();
+        expect(screen.getByTestId("mark-complete-btn")).toBeInTheDocument();
+
+        rerender(
+          <TooltipProvider>
+            <NodeDetailPanel
+              node={liveInteractive({
+                iterations: [
+                  {
+                    iter: 1,
+                    status: "awaiting_user",
+                    started_at: null,
+                    completed_at: null,
+                    interactive: false,
+                    completion_released: false,
+                  },
+                ],
+              })}
+              runId="run-1"
+            />
+          </TooltipProvider>,
+        );
+        expect(screen.queryByTestId("release-completion-btn")).not.toBeInTheDocument();
+
+        rerender(
+          <TooltipProvider>
+            <NodeDetailPanel
+              node={liveInteractive({ status: "completed" })}
+              runId="run-1"
+            />
+          </TooltipProvider>,
+        );
+        expect(screen.queryByTestId("release-completion-btn")).not.toBeInTheDocument();
+      });
+
+      it("calls release and renders the projected released state", async () => {
+        const { rerender } = render(
+          <TooltipProvider>
+            <NodeDetailPanel node={liveInteractive()} runId="run-1" />
+          </TooltipProvider>,
+        );
+        await act(async () => {
+          fireEvent.click(screen.getByTestId("release-completion-btn"));
+        });
+        expect(releaseNodeCompletionMock).toHaveBeenCalledWith("run-1", "test-node", 1);
+        expect(screen.queryByTestId("release-verdict")).not.toBeInTheDocument();
+
+        rerender(
+          <TooltipProvider>
+            <NodeDetailPanel
+              node={liveInteractive({
+                status: "running",
+                iterations: [
+                  {
+                    iter: 1,
+                    status: "running",
+                    started_at: null,
+                    completed_at: null,
+                    interactive: true,
+                    completion_released: true,
+                  },
+                ],
+              })}
+              runId="run-1"
+            />
+          </TooltipProvider>,
+        );
+        expect(screen.getByTestId("release-verdict")).toHaveAttribute(
+          "data-verdict",
+          "released",
+        );
+        expect(screen.getByTestId("release-verdict")).toHaveTextContent(
+          "tell the agent in the terminal",
+        );
+      });
+
+      it("renders projected release state after reload and scopes it to the displayed iteration", () => {
+        render(
+          <TooltipProvider>
+            <NodeDetailPanel
+              node={liveInteractive({
+                status: "running",
+                iter: 2,
+                iterations: [
+                  {
+                    iter: 1,
+                    status: "running",
+                    started_at: null,
+                    completed_at: null,
+                    interactive: true,
+                    completion_released: true,
+                  },
+                  {
+                    iter: 2,
+                    status: "awaiting_user",
+                    started_at: null,
+                    completed_at: null,
+                    interactive: true,
+                    completion_released: false,
+                  },
+                ],
+              })}
+              runId="run-1"
+            />
+          </TooltipProvider>,
+        );
+
+        expect(screen.getByTestId("release-completion-btn")).toHaveTextContent(
+          "Mark ready for completion",
+        );
+      });
     });
   });
 });

--- a/frontend/src/components/NodeDetailPanel.tsx
+++ b/frontend/src/components/NodeDetailPanel.tsx
@@ -9,6 +9,8 @@ import {
   Play,
   Maximize2,
   GitCompareArrows,
+  LockOpen,
+  LoaderCircle,
 } from "lucide-react";
 import type {
   IterationInfo,
@@ -20,7 +22,7 @@ import { artifactUrl } from "../api";
 import type { PortIO, FileInfo } from "../api";
 import type { PortType } from "../types";
 import { useNodeRun } from "../hooks/useNodeRun";
-import type { MarkVerdict } from "../hooks/useNodeRun";
+import type { MarkVerdict, ReleaseVerdict } from "../hooks/useNodeRun";
 import {
   ResizablePanelGroup,
   ResizablePanel,
@@ -209,6 +211,60 @@ function MarkCompleteVerdict({ verdict }: { verdict: MarkVerdict }) {
   );
 }
 
+function ReleaseCompletionVerdict({
+  verdict,
+}: {
+  verdict: ReleaseVerdict | { kind: "released" };
+}) {
+  const refused = verdict.kind === "refused" ? verdict : null;
+  const failed = verdict.kind === "refused" || verdict.kind === "error";
+  const toneClass =
+    verdict.kind === "released"
+      ? "border-st-running/30 bg-st-running-bg text-st-running"
+      : failed
+        ? "border-st-failed/30 bg-st-failed-bg text-st-failed"
+        : "border-line-strong bg-bg-3 text-fg-3";
+  const headline =
+    verdict.kind === "released"
+      ? "Completion released — the agent will complete when ready."
+      : verdict.kind === "pending"
+        ? "Releasing completion…"
+        : verdict.kind === "error"
+          ? `Could not reach the daemon — ${verdict.message}`
+          : `Release refused — ${verdict.message}`;
+
+  return (
+    <div
+      className={`flex flex-col gap-1 rounded-md border px-2.5 py-1.5 ${toneClass}`}
+      style={{ fontSize: "10.5px" }}
+      data-testid="release-verdict"
+      data-verdict={verdict.kind}
+      data-slug={refused?.slug ?? ""}
+      data-recoverable={refused ? String(refused.recoverable) : ""}
+    >
+      <div className="flex items-start gap-1.5">
+        {verdict.kind === "released" ? (
+          <CheckCircle size={12} className="mt-px shrink-0" />
+        ) : verdict.kind === "pending" ? (
+          <LoaderCircle size={12} className="mt-px shrink-0 animate-spin" />
+        ) : (
+          <AlertCircle size={12} className="mt-px shrink-0" />
+        )}
+        <span>{headline}</span>
+      </div>
+      {verdict.kind === "released" && (
+        <span className="pl-5">
+          Now tell the agent in the terminal that you are done. Mark complete still
+          forces it.
+        </span>
+      )}
+      {verdict.kind === "refused" && (
+        <span className="pl-5">Retry the node, then release again.</span>
+      )}
+    </div>
+  );
+}
+
 // The session is settled — the tmux session is gone, so the terminal WebSocket
 // would attach to a dead session. `{completed, skipped, failed, stopped,
 // interrupted}` is exactly the "settled" tier of `pollInterval` (5s). A `skipped`
@@ -304,6 +360,7 @@ export default function NodeDetailPanel({
     inputs,
     outputs,
     markVerdict,
+    releaseVerdict,
     actionVerdict,
     retryConfirm,
     stop,
@@ -312,6 +369,7 @@ export default function NodeDetailPanel({
     cancelRetry,
     start,
     markComplete,
+    releaseCompletion,
     killStale,
     restartIteration,
   } = useNodeRun(runId, node, selectedIter, {
@@ -329,6 +387,14 @@ export default function NodeDetailPanel({
   // The terminal reads this to decide whether to attach or to read the frozen pane.
   const selectedIterStatus =
     node.iterations?.find((i) => i.iter === selectedIter)?.status ?? node.status;
+  const selectedIteration = node.iterations?.find((i) => i.iter === selectedIter);
+  const completionReleased = selectedIteration?.completion_released === true;
+  const isReleasing =
+    releaseVerdict?.iter === selectedIter && releaseVerdict.kind === "pending";
+  const canReleaseCompletion =
+    selectedIteration?.interactive === true &&
+    (selectedIterStatus === "running" || selectedIterStatus === "awaiting_user") &&
+    !isArchived;
 
   // #369: the I/O poll (`setInputs`/`setOutputs`) re-renders this panel every
   // tick (1s live, 5s settled). Building the modal's `source` prop as an inline
@@ -513,15 +579,29 @@ export default function NodeDetailPanel({
         </div>
       )}
 
+      {completionReleased && selectedIterStatus === "running" && (
+        <div className="flex items-center gap-2 border-b border-st-running/30 bg-st-running-bg px-3 py-2">
+          <CheckCircle size={14} className="shrink-0 text-st-running" />
+          <span
+            className="text-st-running"
+            style={{ fontSize: "11.5px", fontWeight: 500 }}
+          >
+            Running — completion released. Tell the agent when you are done.
+          </span>
+        </div>
+      )}
+
       {/* Awaiting user banner */}
-      {node.status === "awaiting_user" && (
+      {selectedIterStatus === "awaiting_user" && !completionReleased && (
         <div className="flex items-center gap-2 border-b border-st-await/30 bg-st-await-bg px-3 py-2">
           <AlertCircle size={14} className="shrink-0 text-st-await" />
           <span
             className="text-st-await"
             style={{ fontSize: "11.5px", fontWeight: 500 }}
           >
-            Awaiting user — interact in the terminal below, then mark complete
+            {selectedIteration?.interactive
+              ? "Awaiting user — when done, release completion so the agent can finish, or mark complete to take the artifacts as they are"
+              : "Awaiting user — interact in the terminal below, then mark complete"}
           </span>
         </div>
       )}
@@ -789,15 +869,52 @@ export default function NodeDetailPanel({
                   is genuinely incomplete. */}
               {(node.status === "awaiting_user" || node.status === "running" || node.status === "failed" || node.status === "stale" || node.status === "interrupted") && !isArchived && (
                 <>
-                  <button
-                    onClick={markComplete}
-                    data-testid="mark-complete-btn"
-                    className="flex w-full cursor-pointer items-center justify-center gap-1.5 rounded-md border border-st-done/40 bg-st-done-bg px-3 py-1.5 text-st-done transition-colors hover:border-st-done/60 hover:bg-st-done/20"
-                    style={{ fontSize: "11.5px", fontWeight: 500 }}
-                  >
-                    <CheckCircle size={12} />
-                    Mark complete
-                  </button>
+                  <div className="flex flex-wrap gap-1.5">
+                    {canReleaseCompletion && (
+                        <button
+                          onClick={releaseCompletion}
+                          title="Enables the node to call pdo complete when it chooses and to proceed with the run"
+                          disabled={isReleasing}
+                          data-testid="release-completion-btn"
+                          className={`flex min-w-[140px] flex-1 cursor-pointer items-center justify-center gap-1.5 rounded-md border border-st-await/40 bg-st-await-bg px-3 py-1.5 text-st-await transition-colors hover:border-st-await/60 hover:bg-st-await/20 disabled:cursor-wait disabled:opacity-70 ${
+                            completionReleased ? "border-dashed" : ""
+                          }`}
+                          style={{ fontSize: "11.5px", fontWeight: 500 }}
+                        >
+                          {isReleasing ? (
+                            <LoaderCircle size={12} className="animate-spin" />
+                          ) : completionReleased ? (
+                            <CheckCircle size={12} />
+                          ) : (
+                            <LockOpen size={12} />
+                          )}
+                          {isReleasing
+                            ? "Releasing…"
+                            : completionReleased
+                              ? "Completion released"
+                              : "Mark ready for completion"}
+                        </button>
+                    )}
+                      <button
+                        onClick={markComplete}
+                        title="Take the artifacts as they are and complete the node now"
+                        data-testid="mark-complete-btn"
+                        className="flex min-w-[140px] flex-1 cursor-pointer items-center justify-center gap-1.5 rounded-md border border-st-done/40 bg-st-done-bg px-3 py-1.5 text-st-done transition-colors hover:border-st-done/60 hover:bg-st-done/20"
+                        style={{ fontSize: "11.5px", fontWeight: 500 }}
+                      >
+                        <CheckCircle size={12} />
+                        Mark complete
+                      </button>
+                  </div>
+
+                  {completionReleased ? (
+                    <ReleaseCompletionVerdict verdict={{ kind: "released" }} />
+                  ) : (
+                    releaseVerdict &&
+                    releaseVerdict.iter === selectedIter && (
+                      <ReleaseCompletionVerdict verdict={releaseVerdict} />
+                    )
+                  )}
 
                   {/* #490: the verdict of the click, AT the gesture. Rendered for
                       every outcome including `pending`, so nothing ever blinks out

--- a/frontend/src/hooks/useNodeRun.test.ts
+++ b/frontend/src/hooks/useNodeRun.test.ts
@@ -9,6 +9,7 @@ vi.mock("../api", () => ({
   fetchPrompt: vi.fn(),
   fetchNodeIO: vi.fn(),
   markNodeDone: vi.fn(),
+  releaseNodeCompletion: vi.fn(),
   killNode: vi.fn(),
   restartNode: vi.fn(),
   startNode: vi.fn(),
@@ -58,6 +59,7 @@ beforeEach(() => {
   vi.mocked(api.fetchPrompt).mockReset().mockResolvedValue("PROMPT");
   vi.mocked(api.fetchNodeIO).mockReset().mockResolvedValue(IO);
   vi.mocked(api.markNodeDone).mockReset().mockResolvedValue({ kind: "completed" });
+  vi.mocked(api.releaseNodeCompletion).mockReset().mockResolvedValue({ kind: "released" });
   vi.mocked(api.retryNodePreview)
     .mockReset()
     .mockResolvedValue({ downstream: [], affected_count: 0, with_artifacts: [] });
@@ -215,6 +217,7 @@ describe("useNodeRun — mark complete (#490)", () => {
     await act(async () => {
       result.current.markComplete();
     });
+
     expect(result.current.markVerdict).toEqual({ iter: 3, kind: "pending" });
   });
 
@@ -269,6 +272,45 @@ describe("useNodeRun — mark complete (#490)", () => {
       await result.current.markComplete();
     });
     expect(result.current.markVerdict).toEqual({ iter: 1, kind: "error", message: "boom" });
+  });
+});
+
+describe("useNodeRun — release completion (#764)", () => {
+  it("stamps the release verdict with the selected iteration", async () => {
+    const { result } = renderHook(() =>
+      useNodeRun("run-1", makeNode({ status: "awaiting_user", iter: 4 }), 2, {}),
+    );
+    await flush();
+
+    await act(async () => {
+      await result.current.releaseCompletion();
+    });
+
+    expect(api.releaseNodeCompletion).toHaveBeenCalledWith("run-1", "n1", 2);
+    expect(result.current.releaseVerdict).toBeNull();
+  });
+
+  it("surfaces a release refusal at the gesture", async () => {
+    vi.mocked(api.releaseNodeCompletion).mockResolvedValue({
+      kind: "refused",
+      slug: "node_session_not_live",
+      recoverable: true,
+      message: "no live session",
+    });
+    const { result } = renderHook(() =>
+      useNodeRun("run-1", makeNode({ status: "awaiting_user" }), 1, {}),
+    );
+    await flush();
+
+    await act(async () => {
+      await result.current.releaseCompletion();
+    });
+
+    expect(result.current.releaseVerdict).toMatchObject({
+      iter: 1,
+      kind: "refused",
+      slug: "node_session_not_live",
+    });
   });
 });
 

--- a/frontend/src/hooks/useNodeRun.ts
+++ b/frontend/src/hooks/useNodeRun.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import {
   markNodeDone,
+  releaseNodeCompletion,
   killNode,
   restartNode,
   startNode,
@@ -10,7 +11,11 @@ import {
   fetchPrompt,
   fetchNodeIO,
 } from "../api";
-import type { PortIO, MarkNodeDoneOutcome } from "../api";
+import type {
+  PortIO,
+  MarkNodeDoneOutcome,
+  ReleaseNodeCompletionOutcome,
+} from "../api";
 import type { NodeState, NodeStatus } from "../types";
 
 function pollInterval(status: NodeStatus): number | null {
@@ -44,6 +49,11 @@ function pollInterval(status: NodeStatus): number | null {
 export type MarkVerdict =
   | { kind: "pending" }
   | MarkNodeDoneOutcome
+  | { kind: "error"; message: string };
+
+export type ReleaseVerdict =
+  | { kind: "pending" }
+  | Extract<ReleaseNodeCompletionOutcome, { kind: "refused" }>
   | { kind: "error"; message: string };
 
 /**
@@ -112,6 +122,9 @@ export function useNodeRun(
   // kills a latent second bug: a verdict from iter 3 surviving a switch back to iter 1.
   const [markVerdict, setMarkVerdict] = useState<
     ({ iter: number } & MarkVerdict) | null
+  >(null);
+  const [releaseVerdict, setReleaseVerdict] = useState<
+    ({ iter: number } & ReleaseVerdict) | null
   >(null);
   const [retryConfirm, setRetryConfirm] = useState<{
     affectedCount: number;
@@ -275,6 +288,23 @@ export function useNodeRun(
     }
   }, [runId, node.node_id, selectedIter]);
 
+  const releaseCompletion = useCallback(async () => {
+    const iter = selectedIter;
+    setReleaseVerdict({ iter, kind: "pending" });
+    try {
+      const outcome = await releaseNodeCompletion(runId, node.node_id, iter);
+      setReleaseVerdict(
+        outcome.kind === "released" ? null : { iter, ...outcome },
+      );
+    } catch (e) {
+      setReleaseVerdict({
+        iter,
+        kind: "error",
+        message: e instanceof Error ? e.message : String(e),
+      });
+    }
+  }, [runId, node.node_id, selectedIter]);
+
   // The two stale-banner actions (ADR-0032 §1: historical runs only). Iter-scoped
   // like the reads — the banner acts on the iteration on screen, not on
   // `node.iter`.
@@ -300,6 +330,7 @@ export function useNodeRun(
     inputs,
     outputs,
     markVerdict,
+    releaseVerdict,
     actionVerdict,
     retryConfirm,
     stop,
@@ -308,6 +339,7 @@ export function useNodeRun(
     cancelRetry,
     start,
     markComplete,
+    releaseCompletion,
     killStale,
     restartIteration,
   };

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -792,6 +792,8 @@ export interface IterationInfo {
   status: NodeStatus;
   started_at: string | null;
   completed_at: string | null;
+  interactive?: boolean;
+  completion_released?: boolean;
 }
 
 /**


### PR DESCRIPTION
Sub-ticket of story #766 (exposed-host deployment). Refs #769 — close the issue explicitly (merge into `integration/*`).

## What changed
- `pdo daemon --bind <ip>` / `PDO_BIND` (flag wins over env; default `0.0.0.0` unchanged). Announced URL follows the bind. Update relaunch keeps `--bind`.
- `pdo service install --bind <ip>` writes `Environment=PDO_BIND=<ip>` next to `PDO_PORT` (systemd + launchd); no line when omitted. Update executor forwards the current bind. Port-conflict guard probes the effective socket.
- Service unit PATH deduplicated; ADR-0055 comment on harness resolution in the unit and in `--dry-run`.
- README: single `## CLI commands` table (one row per command), drop-in sentence for `PDO_ALLOWED_WS_ORIGINS`, `--bind 127.0.0.1` sentence in Reverse proxy.
- Version 1.80.0 → 1.81.0 (minor, `feat`), CHANGELOG entry.

## Local gate
- `make check`, full test suite, `make build`: green (implementation node, commit 700e69e).
- Feature Path (FP, 4 steps): **Pass** — loopback daemon refuses LAN, default daemon reachable on both, `--dry-run` unit carries bind/port/dedup PATH/comment, README table verified.
- Non-blocking finding: the README Reverse proxy section's fenced `PDO_ALLOWED_WS_ORIGINS="…" pdo daemon` example was folded into inline prose (same content, ticket asked to keep the section as is + one sentence). Worth a human glance.

Also brings `main` up to b61d53a (#763–#765) into the integration branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
