### PR TITLE
feat(run create): pass files and images to a child run (#779) — release 1.83.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ Le dépôt n'avait aucun fichier `LICENSE` depuis sa création ; seules les mét
 déclaraient MIT. Le fichier existe désormais et confirme ces termes ; les règles de
 contribution sont dans `CONTRIBUTING.md`.
 
+## 1.83.0
+**Fichiers et images transmis au run enfant** (#779).
+`POST /runs` multipart accepte un champ répétable `files` à côté d'`images` : tout fichier atterrit dans
+`_input/` du worktree enfant, le nœud d'entrée le voit sous `## Input Files` dans son préambule et sur son
+port d'entrée. Un doublon de nom est **refusé** (400 nommé) au lieu d'écraser en silence. `pdo run create`
+gagne `--input-file`, `--image` et `--file` et bascule en multipart dès qu'une pièce jointe est présente.
+La modale « New run » remplace le champ « Images » par « Attachments » (vignettes + puces, compteur, budget).
+**Nouveau réglage** `max_attachments_mb` (défaut 50, env `PDO_MAX_ATTACHMENTS_MB`) : un seul budget par run,
+partagé entre la limite du corps `POST /runs` et la garde côté client. Le skill seedé `pdo-orchestrate` passe
+en `skill_version: 2` et corrige ses exemples (`--pipeline`/`--project`/`--variable` n'existaient pas).
+
 ## 1.81.0
 **Déploiement derrière un reverse proxy** (#769 ; story #766, ADR-0019).
 `pdo daemon` et `pdo service install` acceptent désormais `--bind <ip>` ou `PDO_BIND`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "1.82.3"
+version = "1.83.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2416,6 +2416,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "quinn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "1.82.3"
+version = "1.83.0"
 license = "MIT"
 description = "Prompt-Driven Orchestrator — a local daemon that runs and supervises agentic coding pipelines"
 repository = "https://github.com/Loulen/prompt-driven-orchestrator"

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Run `pdo service install` to start PDO at boot and keep it running after logout.
 | `pdo migrate [--dir <path>] [--dry-run]` | Migrate legacy pipeline YAML files. |
 | `pdo reap [--count] [--dry-run] [--ttl-hours <hours>] [--terminal-ttl-hours <hours>] [--budget-secs <seconds>]` | Report or archive old terminal runs according to the retention policy. |
 | `pdo docs support-table [--check\|--write] [--file <path>]` | Check or regenerate the README harness support table. |
-| `pdo run create <pipeline> [options]` | Create a run through the daemon, with optional input, repository, harness, sandbox, and provisioning settings. |
+| `pdo run create <pipeline> [options]` | Create a run through the daemon, with optional input, repository, harness, sandbox, and provisioning settings. `--input-file <path>` reads the prompt from a file; `--image <path>` / `--file <path>` (repeatable) attach files the entry node sees under `## Input Images` / `## Input Files` (one budget per run, `max_attachments_mb` in Settings). |
 | `pdo page mount <name> <directory>` | Serve a directory under `/pages/<name>/`. |
 | `pdo page list` | List active page mounts. |
 | `pdo page unmount <name>` | Remove a page mount. |

--- a/crates/pdo-daemon/Cargo.toml
+++ b/crates/pdo-daemon/Cargo.toml
@@ -64,7 +64,7 @@ ignore.workspace = true
 # TLS via rustls (pure-Rust, `ring`) instead of the default native-tls/OpenSSL:
 # openssl-sys can't cross-compile to aarch64-unknown-linux-gnu in the release
 # build (no target OpenSSL). rustls removes the C dependency entirely.
-reqwest = { version = "0.12", default-features = false, features = ["charset", "http2", "system-proxy", "rustls-tls", "json", "blocking"] }
+reqwest = { version = "0.12", default-features = false, features = ["charset", "http2", "system-proxy", "rustls-tls", "json", "blocking", "multipart"] }
 # Skills sidecar of the portable pipeline document (#673 / ADR-0062): a zip of
 # `<pipeline>.skills/<id>/…` the browser can download and hand back, base64 in
 # the import request. Deflate only — no bzip2/zstd/lzma, nothing to read there.

--- a/crates/pdo-daemon/src/event_log.rs
+++ b/crates/pdo-daemon/src/event_log.rs
@@ -681,6 +681,10 @@ pub struct StartNodeInfo {
     /// the Start node and in the Start inspector (issue #145).
     #[serde(default)]
     pub input_images: Vec<String>,
+    /// Filenames of the NON-image files uploaded alongside the prompt (#779),
+    /// also stored in `_input/`. Empty for a run launched without files.
+    #[serde(default)]
+    pub input_files: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1882,21 +1886,26 @@ fn apply_run_event(state: &mut RunState, event: &Event) {
                     state.pipeline_id = Some(pid.to_string());
                 }
 
-                let input_images = payload
-                    .get("image_filenames")
-                    .and_then(|v| v.as_array())
-                    .map(|arr| {
-                        arr.iter()
-                            .filter_map(|v| v.as_str().map(str::to_string))
-                            .collect()
-                    })
-                    .unwrap_or_default();
+                let string_list = |key: &str| -> Vec<String> {
+                    payload
+                        .get(key)
+                        .and_then(|v| v.as_array())
+                        .map(|arr| {
+                            arr.iter()
+                                .filter_map(|v| v.as_str().map(str::to_string))
+                                .collect()
+                        })
+                        .unwrap_or_default()
+                };
+                let input_images = string_list("image_filenames");
+                let input_files = string_list("file_filenames");
 
                 state.start_node = Some(StartNodeInfo {
                     input_path: "_input/output.md".to_string(),
                     started_at: event.ts.clone(),
                     target_node_ids: entry_node_ids(&state.edges, &state.node_defs),
                     input_images,
+                    input_files,
                 });
 
                 if let Some(end_def) = state.node_defs.iter().find(|n| n.node_type == "end") {
@@ -7683,6 +7692,7 @@ mod tests {
             "sessions_spawned": 8,
             "source_branch": "main",
             "start_node": {
+                "input_files": [],
                 "input_images": [ "screenshot.png" ],
                 "input_path": "_input/output.md",
                 "started_at": "2026-02-01T00:00:00.000Z",

--- a/crates/pdo-daemon/src/instance_config.rs
+++ b/crates/pdo-daemon/src/instance_config.rs
@@ -166,6 +166,12 @@ pub(crate) struct InstanceConfig {
     /// time, never a silent rewrite of the stored value (the #432 tombstone
     /// treatment; `GET /settings` names the dangle in the UI).
     pub manager_profile: Option<String>,
+    /// Stored per-run attachment budget in MB (#779), or `None` when unset
+    /// (`stored → env PDO_MAX_ATTACHMENTS_MB → default 50`). The SAME value
+    /// bounds the `POST /runs` multipart body and is disclosed to the « New
+    /// run » modal through `GET /settings`, so the client-side gate and the
+    /// daemon's refusal cannot disagree.
+    pub max_attachments_mb: Option<i64>,
     /// RFC3339-millis UTC timestamp of the last write (or the seed).
     pub updated_at: String,
 }
@@ -248,6 +254,9 @@ pub(crate) struct UpdateInstanceConfig {
     /// back to unset (« Follow the Run », same `""`-sentinel as
     /// `default_model`); `None` leaves it untouched.
     pub manager_profile: Option<String>,
+    /// Set the per-run attachment budget in MB (#779). Set-only like the other
+    /// numeric knobs; `PUT /settings` refuses `< 1`.
+    pub max_attachments_mb: Option<i64>,
 }
 
 impl UpdateInstanceConfig {
@@ -269,6 +278,7 @@ impl UpdateInstanceConfig {
             && self.skills.is_none()
             && self.manager_enabled.is_none()
             && self.manager_profile.is_none()
+            && self.max_attachments_mb.is_none()
     }
 }
 
@@ -520,6 +530,20 @@ pub(crate) async fn init(db: &SqlitePool) -> Result<(), sqlx::Error> {
             .await?;
     }
 
+    // Additive migration (#779): the per-run attachment budget, NULLABLE so
+    // unset falls through to env → default.
+    let has_max_attachments = sqlx::query(
+        "SELECT 1 FROM pragma_table_info('instance_config') WHERE name = 'max_attachments_mb'",
+    )
+    .fetch_optional(db)
+    .await?
+    .is_some();
+    if !has_max_attachments {
+        sqlx::query("ALTER TABLE instance_config ADD COLUMN max_attachments_mb INTEGER")
+            .execute(db)
+            .await?;
+    }
+
     Ok(())
 }
 
@@ -559,6 +583,7 @@ fn row_to_config(row: &sqlx::sqlite::SqliteRow) -> InstanceConfig {
         // still maps (same posture as `update_check` above).
         manager_enabled: row.try_get("manager_enabled").unwrap_or(None),
         manager_profile: row.try_get("manager_profile").unwrap_or(None),
+        max_attachments_mb: row.try_get("max_attachments_mb").unwrap_or(None),
         updated_at: row.get("updated_at"),
     }
 }
@@ -636,6 +661,9 @@ pub(crate) async fn update(
     }
     if edit.manager_profile.is_some() {
         sets.push("manager_profile = ?");
+    }
+    if edit.max_attachments_mb.is_some() {
+        sets.push("max_attachments_mb = ?");
     }
     // Always bump the write timestamp on a real edit.
     sets.push("updated_at = ?");
@@ -726,6 +754,9 @@ pub(crate) async fn update(
         // default_model/default_harness: a stored "" would win precedence and be
         // read as a pin to nothing.
         query = query.bind(if v.is_empty() { None } else { Some(v) });
+    }
+    if let Some(v) = edit.max_attachments_mb {
+        query = query.bind(v);
     }
     query = query.bind(crate::event_log::now_iso());
     query.execute(db).await?;

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -318,8 +318,23 @@ pub enum RunAction {
         pipeline: String,
         /// Prompt for the Run's start node. A prompt-optional pipeline accepts
         /// the empty default.
-        #[arg(short, long, default_value = "")]
+        #[arg(short, long, default_value = "", conflicts_with = "input_file")]
         input: String,
+        /// Read the prompt from a file instead of `--input` (#779) — e.g. the
+        /// spec an upstream node wrote: `--input-file "$PDO_INPUT_SPEC"`.
+        #[arg(long, value_name = "PATH")]
+        input_file: Option<std::path::PathBuf>,
+        /// Attach an image (#779, repeatable): sent in the multipart `images`
+        /// field, written to the child's `_input/`, listed under
+        /// `## Input Images` in its entry node's preamble.
+        #[arg(long, value_name = "PATH")]
+        image: Vec<std::path::PathBuf>,
+        /// Attach any file (#779, repeatable): sent in the multipart `files`
+        /// field, written to the child's `_input/`, listed under
+        /// `## Input Files`. Any extension; one size budget per run
+        /// (`max_attachments_mb` in Settings); duplicate names are refused.
+        #[arg(long, value_name = "PATH")]
+        file: Vec<std::path::PathBuf>,
         /// Run variables as a JSON object: `--variables '{"pool":"a"}'`.
         #[arg(long)]
         variables: Option<String>,
@@ -1279,6 +1294,9 @@ pub fn run_run_create(action: RunAction) -> Result<()> {
     let RunAction::Create {
         pipeline,
         input,
+        input_file,
+        image,
+        file,
         variables,
         skills,
         agent_choice,
@@ -1294,6 +1312,15 @@ pub fn run_run_create(action: RunAction) -> Result<()> {
     } = action;
 
     let url = cli_daemon_url();
+
+    // #779: `--input-file` reads the prompt from disk (clap already refuses it
+    // together with `--input`). Read eagerly so a missing file fails before
+    // the daemon is even reached.
+    let input = match input_file {
+        Some(path) => std::fs::read_to_string(&path)
+            .with_context(|| format!("failed to read --input-file {}", path.display()))?,
+        None => input,
+    };
 
     let mut body = serde_json::Map::new();
     body.insert("pipeline".into(), serde_json::json!(pipeline));
@@ -1339,9 +1366,16 @@ pub fn run_run_create(action: RunAction) -> Result<()> {
     }
 
     let session = session_env_claim();
-    let mut req = reqwest::blocking::Client::new()
-        .post(format!("{url}/runs"))
-        .json(&body);
+    let client = reqwest::blocking::Client::new().post(format!("{url}/runs"));
+    // #779: any `--image` / `--file` switches the body to multipart — the same
+    // text fields as the JSON shape (non-scalars as JSON strings, like the UI),
+    // plus one `images` / `files` part per attachment. Files are read here so a
+    // missing path is named locally, before any request.
+    let mut req = if image.is_empty() && file.is_empty() {
+        client.json(&body)
+    } else {
+        client.multipart(run_create_multipart(&body, &image, &file)?)
+    };
     if let Some((run_id, node_id)) = &session {
         req = req
             .header(SESSION_RUN_HEADER, run_id)
@@ -1377,6 +1411,40 @@ pub fn run_run_create(action: RunAction) -> Result<()> {
         None => println!("Run {run_id} created (root run)."),
     }
     Ok(())
+}
+
+/// The multipart body of a `pdo run create` carrying attachments (#779). Text
+/// fields mirror the JSON body one-to-one: strings verbatim, everything else
+/// (`variables`, `skills`, `auto_name`, …) serialised the way the daemon's
+/// multipart parser reads them back — JSON text for objects/lists, `true`/
+/// `false` for bools.
+fn run_create_multipart(
+    body: &serde_json::Map<String, serde_json::Value>,
+    images: &[std::path::PathBuf],
+    files: &[std::path::PathBuf],
+) -> Result<reqwest::blocking::multipart::Form> {
+    let mut form = reqwest::blocking::multipart::Form::new();
+    for (key, value) in body {
+        let text = match value {
+            serde_json::Value::String(s) => s.clone(),
+            other => other.to_string(),
+        };
+        form = form.text(key.clone(), text);
+    }
+    for (field, paths) in [("images", images), ("files", files)] {
+        for path in paths {
+            let data = std::fs::read(path)
+                .with_context(|| format!("failed to read --{} {}", field.trim_end_matches('s'), path.display()))?;
+            let filename = path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .with_context(|| format!("--{} {} has no usable filename", field.trim_end_matches('s'), path.display()))?
+                .to_string();
+            let part = reqwest::blocking::multipart::Part::bytes(data).file_name(filename);
+            form = form.part(field, part);
+        }
+    }
+    Ok(form)
 }
 
 /// One-shot `pdo review list` / `pdo review reply` (#751): the thin CLI client of
@@ -4620,7 +4688,14 @@ fn build_router(state: Arc<AppState>) -> Router {
             axum::routing::put(save_pipeline).delete(delete_pipeline),
         )
         .route("/pipelines", post(create_pipeline))
-        .route("/runs", post(create_run))
+        // #779: the multipart body of `POST /runs` is bounded by the
+        // `max_attachments_mb` setting, enforced IN the handler on the attachment
+        // parts (read fresh per request) — not by a static limit frozen at
+        // router build. The JSON branch keeps its own 10 MB `to_bytes` cap.
+        .route(
+            "/runs",
+            post(create_run).route_layer(axum::extract::DefaultBodyLimit::disable()),
+        )
         .route("/runs", get(list_runs))
         .route("/pages", get(list_page_mounts).post(create_page_mount))
         .route("/pages/", get(list_page_mounts))
@@ -8761,13 +8836,105 @@ fn resolve_completed_frontmatter(
     by_node
 }
 
-struct ImageFile {
+/// One attachment of a `POST /runs` multipart body (#779): an image (the
+/// `images` field, image extension required) or any other file (the `files`
+/// field). Both land in the child's `_input/` beside `output.md`; the entry
+/// node sees them under `## Input Images` / `## Input Files`.
+struct InputFile {
     filename: String,
     data: Vec<u8>,
+    /// Classified by EXTENSION, whatever field carried the file — so a `.png`
+    /// sent under `files` is still discovered as an image at spawn.
+    is_image: bool,
 }
 
 pub(crate) const ALLOWED_IMAGE_EXTENSIONS: &[&str] =
     &["png", "jpg", "jpeg", "gif", "webp", "svg", "bmp"];
+
+/// Built-in per-run attachment budget (images + files, bytes counted on the
+/// multipart parts) when neither the stored setting nor
+/// [`MAX_ATTACHMENTS_MB_ENV`] speaks: 50 MB. The modal reads the SAME value
+/// from `GET /settings` so its client-side gate and the daemon's agree (#779).
+pub(crate) const MAX_ATTACHMENTS_MB_DEFAULT: i64 = 50;
+/// Env seam of the attachment budget, read only inside
+/// [`resolve_max_attachments_mb`].
+pub(crate) const MAX_ATTACHMENTS_MB_ENV: &str = "PDO_MAX_ATTACHMENTS_MB";
+
+/// The attachment budget in MB, `stored → env → default(50)`. A stored `0` or
+/// negative is impossible (`PUT /settings` refuses `< 1`), an unparsable env
+/// falls through to the default.
+pub(crate) fn resolve_max_attachments_mb(stored: Option<i64>) -> i64 {
+    if let Some(n) = stored.filter(|&n| n >= 1) {
+        return n;
+    }
+    if let Some(n) = env_max_attachments_mb() {
+        return n;
+    }
+    MAX_ATTACHMENTS_MB_DEFAULT
+}
+
+pub(crate) fn env_max_attachments_mb() -> Option<i64> {
+    std::env::var(MAX_ATTACHMENTS_MB_ENV)
+        .ok()
+        .and_then(|s| s.trim().parse::<i64>().ok())
+        .filter(|&n| n >= 1)
+}
+
+/// The prompt file every Run writes into `_input/` — an attachment may not
+/// take its name, it would clobber the user prompt.
+const INPUT_PROMPT_FILENAME: &str = "output.md";
+
+/// Sanitize the filename of a `files` attachment: keep the last path component
+/// only (no traversal), refuse empty / dot names and a collision with the
+/// prompt file. Every extension is accepted — the per-run size budget is the
+/// guard, not a type list (#779).
+fn sanitize_attachment_filename(raw: &str) -> Result<String, String> {
+    let name = Path::new(raw)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("")
+        .trim();
+    if name.is_empty() || name == "." || name == ".." {
+        return Err(format!("invalid attachment filename: {raw:?}"));
+    }
+    if name == INPUT_PROMPT_FILENAME {
+        return Err(format!(
+            "attachment `{name}` is reserved for the run prompt; rename the file"
+        ));
+    }
+    Ok(name.to_string())
+}
+
+fn has_image_extension(name: &str) -> bool {
+    let ext = Path::new(name)
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.to_lowercase())
+        .unwrap_or_default();
+    ALLOWED_IMAGE_EXTENSIONS.contains(&ext.as_str())
+}
+
+/// A refused multipart body: the status the client gets and the sentence that
+/// names why. `PAYLOAD_TOO_LARGE` for the budget, `BAD_REQUEST` otherwise.
+struct MultipartRefusal {
+    status: StatusCode,
+    message: String,
+}
+
+impl From<String> for MultipartRefusal {
+    fn from(message: String) -> Self {
+        MultipartRefusal {
+            status: StatusCode::BAD_REQUEST,
+            message,
+        }
+    }
+}
+
+impl From<&str> for MultipartRefusal {
+    fn from(message: &str) -> Self {
+        MultipartRefusal::from(message.to_string())
+    }
+}
 
 fn sanitize_image_filename(raw: &str) -> Option<String> {
     let name = Path::new(raw)
@@ -8788,7 +8955,8 @@ fn sanitize_image_filename(raw: &str) -> Option<String> {
 
 async fn parse_multipart_create_run(
     mut multipart: Multipart,
-) -> std::result::Result<(CreateRunRequest, Vec<ImageFile>), String> {
+    max_attachment_bytes: u64,
+) -> std::result::Result<(CreateRunRequest, Vec<InputFile>), MultipartRefusal> {
     let mut pipeline = None;
     let mut input = None;
     let mut variables: HashMap<String, serde_yaml::Value> = HashMap::new();
@@ -8804,7 +8972,43 @@ async fn parse_multipart_create_run(
     let mut auto_name: Option<bool> = None;
     let mut auto_fail: Option<bool> = None;
     let mut provisioning = provisioning::ProvisioningRules::default();
-    let mut images = Vec::new();
+    let mut attachments: Vec<InputFile> = Vec::new();
+    let mut attachment_bytes: u64 = 0;
+
+    // The budget is enforced on the ATTACHMENT parts (what the user chose),
+    // never on the text fields — a long prompt does not eat the file budget.
+    // Refused at the first part that crosses the line, so a runaway upload is
+    // cut without buffering the whole body.
+    let mut push_attachment = |filename: String,
+                               data: Vec<u8>,
+                               attachments: &mut Vec<InputFile>|
+     -> std::result::Result<(), MultipartRefusal> {
+        attachment_bytes += data.len() as u64;
+        if attachment_bytes > max_attachment_bytes {
+            return Err(MultipartRefusal {
+                status: StatusCode::PAYLOAD_TOO_LARGE,
+                message: format!(
+                    "attachments exceed the per-run limit of {} MB (at `{filename}`); \
+                     raise `max_attachments_mb` in Settings or attach less",
+                    max_attachment_bytes / (1024 * 1024)
+                ),
+            });
+        }
+        // #779: a duplicate name never overwrites — today the second silently
+        // replaced the first. Named 400 so the caller can rename or drop one.
+        if attachments.iter().any(|a| a.filename == filename) {
+            return Err(MultipartRefusal::from(format!(
+                "duplicate attachment filename `{filename}`: each attachment needs a distinct name"
+            )));
+        }
+        let is_image = has_image_extension(&filename);
+        attachments.push(InputFile {
+            filename,
+            data,
+            is_image,
+        });
+        Ok(())
+    };
 
     while let Ok(Some(field)) = multipart.next_field().await {
         let field_name = field.name().unwrap_or("").to_string();
@@ -8968,19 +9172,29 @@ async fn parse_multipart_create_run(
                 }
                 let filename = sanitize_image_filename(&raw_filename)
                     .ok_or_else(|| format!("unsupported image type: {raw_filename}"))?;
-                images.push(ImageFile {
-                    filename,
-                    data: data.to_vec(),
-                });
+                push_attachment(filename, data.to_vec(), &mut attachments)?;
+            }
+            "files" => {
+                // #779: any file. Extension-free, budget-guarded, name-checked.
+                let raw_filename = field.file_name().unwrap_or("").to_string();
+                let data = field
+                    .bytes()
+                    .await
+                    .map_err(|e| format!("failed to read file: {e}"))?;
+                if data.is_empty() {
+                    continue;
+                }
+                let filename = sanitize_attachment_filename(&raw_filename)?;
+                push_attachment(filename, data.to_vec(), &mut attachments)?;
             }
             // An unknown form field is a client mistake, named — never silently
-            // dropped. `images` is the multipart-only field; the rest mirror
-            // `CREATE_RUN_FIELDS`.
+            // dropped. `images` and `files` are the multipart-only fields; the
+            // rest mirror `CREATE_RUN_FIELDS`.
             other => {
-                return Err(format!(
-                    "unknown field `{other}` in POST /runs multipart body; accepted fields: {}, images",
+                return Err(MultipartRefusal::from(format!(
+                    "unknown field `{other}` in POST /runs multipart body; accepted fields: {}, images, files",
                     CREATE_RUN_FIELDS.join(", ")
-                ));
+                )));
             }
         }
     }
@@ -9003,7 +9217,7 @@ async fn parse_multipart_create_run(
         auto_fail,
         provisioning,
     };
-    Ok((req, images))
+    Ok((req, attachments))
 }
 
 /// The session identity a `POST /runs` caller carries via the
@@ -9093,7 +9307,17 @@ async fn create_run(State(state): State<Arc<AppState>>, req: axum::extract::Requ
         .unwrap_or("")
         .to_string();
 
-    let (parsed_req, images) = if content_type.starts_with("multipart/form-data") {
+    let (parsed_req, attachments) = if content_type.starts_with("multipart/form-data") {
+        // #779: the body limit of this route is the attachment budget, read
+        // FRESH from the instance setting (the route has no static
+        // `DefaultBodyLimit`, see the router). Text fields ride on top of it.
+        let max_mb = resolve_max_attachments_mb(
+            instance_config::get(&state.db)
+                .await
+                .ok()
+                .and_then(|cfg| cfg.max_attachments_mb),
+        );
+        let max_attachment_bytes = (max_mb as u64) * 1024 * 1024;
         let multipart = match Multipart::from_request(req, &()).await {
             Ok(m) => m,
             Err(e) => {
@@ -9104,12 +9328,12 @@ async fn create_run(State(state): State<Arc<AppState>>, req: axum::extract::Requ
                     .into_response();
             }
         };
-        match parse_multipart_create_run(multipart).await {
+        match parse_multipart_create_run(multipart, max_attachment_bytes).await {
             Ok(r) => r,
-            Err(msg) => {
+            Err(refusal) => {
                 return (
-                    StatusCode::BAD_REQUEST,
-                    Json(serde_json::json!({ "error": msg })),
+                    refusal.status,
+                    Json(serde_json::json!({ "error": refusal.message })),
                 )
                     .into_response();
             }
@@ -9153,7 +9377,7 @@ async fn create_run(State(state): State<Arc<AppState>>, req: axum::extract::Requ
         (parsed, Vec::new())
     };
 
-    create_run_core(&state, parsed_req, images, session).await
+    create_run_core(&state, parsed_req, attachments, session).await
 }
 
 /// Validate the user input against the pipeline's `prompt_required` flag. A
@@ -9203,10 +9427,10 @@ fn run_name_hint(
 async fn create_run_core(
     state: &Arc<AppState>,
     req: CreateRunRequest,
-    images: Vec<ImageFile>,
+    attachments: Vec<InputFile>,
     session: Option<SessionClaim>,
 ) -> Response {
-    match create_run_inner(state, req, images, session).await {
+    match create_run_inner(state, req, attachments, session).await {
         Ok(run_id) => (StatusCode::CREATED, Json(CreateRunResponse { run_id })).into_response(),
         Err((status, body)) => (status, Json(body)).into_response(),
     }
@@ -9220,7 +9444,7 @@ async fn create_run_core(
 async fn create_run_inner(
     state: &Arc<AppState>,
     req: CreateRunRequest,
-    images: Vec<ImageFile>,
+    attachments: Vec<InputFile>,
     session: Option<SessionClaim>,
 ) -> Result<String, (StatusCode, serde_json::Value)> {
     // ADR-0064: provenance is mechanical. Verify the session claim FIRST — before
@@ -9735,9 +9959,23 @@ async fn create_run_inner(
             run_payload["pipeline_id"] = serde_json::json!(pid);
         }
     }
-    if !images.is_empty() {
-        let image_names: Vec<&str> = images.iter().map(|i| i.filename.as_str()).collect();
+    // Upload order is kept: what the user sees on the Start node is what they
+    // attached, in that order.
+    let image_names: Vec<&str> = attachments
+        .iter()
+        .filter(|a| a.is_image)
+        .map(|a| a.filename.as_str())
+        .collect();
+    if !image_names.is_empty() {
         run_payload["image_filenames"] = serde_json::json!(image_names);
+    }
+    let file_names: Vec<&str> = attachments
+        .iter()
+        .filter(|a| !a.is_image)
+        .map(|a| a.filename.as_str())
+        .collect();
+    if !file_names.is_empty() {
+        run_payload["file_filenames"] = serde_json::json!(file_names);
     }
     if frozen_provisioning
         .iter()
@@ -9906,10 +10144,10 @@ async fn create_run_inner(
         error!("failed to write _input/output.md: {e}");
     }
 
-    for image in &images {
-        let image_path = input_dir.join(&image.filename);
-        if let Err(e) = std::fs::write(&image_path, &image.data) {
-            error!("failed to write image {}: {e}", image.filename);
+    for attachment in &attachments {
+        let path = input_dir.join(&attachment.filename);
+        if let Err(e) = std::fs::write(&path, &attachment.data) {
+            error!("failed to write attachment {}: {e}", attachment.filename);
         }
     }
 
@@ -10761,6 +10999,18 @@ async fn build_settings_view(state: &AppState) -> Result<serde_json::Value, sqlx
     } else {
         "default"
     };
+    // #779: the per-run attachment budget, `stored → env → default(50 MB)` —
+    // the SAME resolver the `POST /runs` multipart branch consumes.
+    let att_stored = cfg.max_attachments_mb.filter(|&n| n >= 1);
+    let att_env = env_max_attachments_mb();
+    let att_effective = resolve_max_attachments_mb(cfg.max_attachments_mb);
+    let att_source = if att_stored.is_some() {
+        "stored"
+    } else if att_env.is_some() {
+        "env"
+    } else {
+        "default"
+    };
     // The profile pin: a stored agent-profile NAME, or unset (« Follow the
     // Run »). No env tier — unlike the flag, a pin is a pure stored decision.
     let mp_stored = cfg.manager_profile.as_deref().filter(|s| !s.is_empty());
@@ -10988,6 +11238,15 @@ async fn build_settings_view(state: &AppState) -> Result<serde_json::Value, sqlx
         // name whose profile was deleted dangles: the UI renders the #432
         // tombstone, and the spawn falls back to « Follow the Run ».
         "manager_profile": settings_field_str(mp_stored, mp_source, mp_stored, None),
+        // #779: images + files budget per Run, in MB. Bounds the multipart body
+        // of `POST /runs` and drives the modal's client-side gate.
+        "max_attachments_mb": settings_field(
+            att_effective,
+            att_source,
+            att_stored,
+            att_env,
+            MAX_ATTACHMENTS_MB_DEFAULT,
+        ),
         "updated_at": cfg.updated_at,
     }))
 }
@@ -11949,6 +12208,13 @@ async fn put_settings(
     if let Some(g) = req.guard_timeout_secs {
         if !(1..=600).contains(&g) {
             return bad("guard_timeout_secs must be between 1 and 600 seconds");
+        }
+    }
+    if let Some(m) = req.max_attachments_mb {
+        // #779: at least 1 MB, and bounded so the budget stays a sane
+        // in-memory multipart body (the parts are buffered before the write).
+        if !(1..=4096).contains(&m) {
+            return bad("max_attachments_mb must be between 1 and 4096");
         }
     }
     if let Some(s) = req.default_sandbox.as_deref() {
@@ -32415,6 +32681,9 @@ edges:
         let RunAction::Create {
             pipeline,
             input,
+            input_file,
+            image,
+            file,
             variables,
             skills,
             agent_choice,
@@ -32430,6 +32699,9 @@ edges:
         } = *action;
         assert_eq!(pipeline, "my-pipeline");
         assert_eq!(input, "do the work");
+        assert!(input_file.is_none());
+        assert!(image.is_empty());
+        assert!(file.is_empty());
         assert_eq!(variables.as_deref(), Some(r#"{"pool":"a"}"#));
         assert_eq!(skills.as_deref(), Some("alpha,beta"));
         assert_eq!(
@@ -32448,6 +32720,56 @@ edges:
         assert_eq!(auto_name, Some(false));
         assert_eq!(auto_fail, Some(true));
         assert_eq!(provisioning.as_deref(), Some("{}"));
+    }
+
+    #[test]
+    fn cli_parses_run_create_attachments() {
+        // #779: `--image` / `--file` repeat, `--input-file` replaces `--input`.
+        let cli = Cli::try_parse_from([
+            "pdo",
+            "run",
+            "create",
+            "my-pipeline",
+            "--input-file",
+            "/tmp/spec.md",
+            "--image",
+            "/tmp/a.png",
+            "--image",
+            "/tmp/b.png",
+            "--file",
+            "/tmp/fixtures.json",
+        ])
+        .unwrap();
+        let Commands::Run { action } = cli.command else {
+            panic!("expected Run subcommand")
+        };
+        let RunAction::Create {
+            input_file,
+            image,
+            file,
+            ..
+        } = *action;
+        assert_eq!(
+            input_file.as_deref(),
+            Some(std::path::Path::new("/tmp/spec.md"))
+        );
+        assert_eq!(image.len(), 2);
+        assert_eq!(file.len(), 1);
+    }
+
+    #[test]
+    fn cli_refuses_input_and_input_file_together() {
+        assert!(Cli::try_parse_from([
+            "pdo",
+            "run",
+            "create",
+            "p",
+            "--input",
+            "x",
+            "--input-file",
+            "/tmp/spec.md",
+        ])
+        .is_err());
     }
 
     #[test]
@@ -38336,6 +38658,40 @@ edges: []
     }
 
     #[test]
+    fn sanitize_attachment_filename_accepts_any_extension_and_strips_paths() {
+        assert_eq!(
+            sanitize_attachment_filename("SPEC-779.md"),
+            Ok("SPEC-779.md".into())
+        );
+        assert_eq!(
+            sanitize_attachment_filename("../../etc/fixtures.json"),
+            Ok("fixtures.json".into())
+        );
+        assert_eq!(
+            sanitize_attachment_filename("/tmp/dump.sql"),
+            Ok("dump.sql".into())
+        );
+        assert_eq!(sanitize_attachment_filename("noext"), Ok("noext".into()));
+    }
+
+    #[test]
+    fn sanitize_attachment_filename_refuses_empty_dots_and_the_prompt_name() {
+        assert!(sanitize_attachment_filename("").is_err());
+        assert!(sanitize_attachment_filename("..").is_err());
+        assert!(sanitize_attachment_filename("/").is_err());
+        let err = sanitize_attachment_filename("output.md").unwrap_err();
+        assert!(err.contains("reserved"), "{err}");
+    }
+
+    #[test]
+    fn resolve_max_attachments_mb_stored_beats_default() {
+        assert_eq!(resolve_max_attachments_mb(Some(120)), 120);
+        // A stored value below 1 cannot be persisted, but the resolver still
+        // treats it as unset rather than a 0-byte budget.
+        assert!(resolve_max_attachments_mb(Some(0)) >= 1);
+    }
+
+    #[test]
     fn passthrough_switch_artifact_noop_when_no_source() {
         let tmp = tempfile::tempdir().unwrap();
         let artifacts_dir = tmp.path().join("artifacts");
@@ -38393,13 +38749,15 @@ edges: []
         std::fs::write(input_dir.join("output.md"), "hello").unwrap();
 
         let images = vec![
-            ImageFile {
+            InputFile {
                 filename: "screenshot.png".into(),
                 data: vec![0x89, 0x50, 0x4E, 0x47],
+                is_image: true,
             },
-            ImageFile {
+            InputFile {
                 filename: "diagram.jpg".into(),
                 data: vec![0xFF, 0xD8, 0xFF],
+                is_image: true,
             },
         ];
         for image in &images {

--- a/crates/pdo-daemon/src/node_io_resolver.rs
+++ b/crates/pdo-daemon/src/node_io_resolver.rs
@@ -80,11 +80,17 @@ pub(crate) fn resolve(
     let mut input_index: HashMap<String, usize> = HashMap::new();
 
     for input in resolved {
-        let files: Vec<FileInfo> = input
+        let mut files: Vec<FileInfo> = input
             .paths
             .iter()
             .map(|p| file_info(artifacts_dir, p))
             .collect();
+        // #779: a Start-sourced input also exposes the run's non-image
+        // attachments (`_input/<file>`), so the panel shows they arrived. Images
+        // stay on the Start inspector's thumbnails (`input_images`).
+        if input.from_start {
+            files.extend(input_attachment_files(artifacts_dir));
+        }
 
         match input_index.get(&input.port) {
             // Two edges sharing a target name make the input a list, whatever
@@ -110,11 +116,13 @@ pub(crate) fn resolve(
     // `task` reads the run's `_input` (preserves existing single-entry pipelines).
     if inputs.is_empty() && node.inputs.iter().any(|p| p.name == "task") {
         let path = crate::blackboard::input_path(artifacts_dir);
+        let mut files = vec![file_info(artifacts_dir, &path)];
+        files.extend(input_attachment_files(artifacts_dir));
         inputs.push(PortIO {
             port: "task".into(),
             repeated: false,
             port_type: PortType::Markdown,
-            files: vec![file_info(artifacts_dir, &path)],
+            files,
         });
     }
 
@@ -174,6 +182,16 @@ fn relative_path(artifacts_dir: &Path, abs_path: &Path) -> String {
         .strip_prefix(artifacts_dir)
         .map(|p| p.to_string_lossy().to_string())
         .unwrap_or_else(|_| abs_path.to_string_lossy().to_string())
+}
+
+/// The non-image attachments of `_input/` as `FileInfo`s (#779) — the same
+/// discovery the preamble's `## Input Files` uses, so the two never disagree.
+fn input_attachment_files(artifacts_dir: &Path) -> Vec<FileInfo> {
+    let input_dir = artifacts_dir.join("_input");
+    crate::prompt_augmenter::discover_input_files(artifacts_dir)
+        .iter()
+        .map(|name| file_info(artifacts_dir, &input_dir.join(name)))
+        .collect()
 }
 
 fn file_info(artifacts_dir: &Path, path: &Path) -> FileInfo {
@@ -731,6 +749,30 @@ mod tests {
         assert_eq!(io.inputs[0].files.len(), 1);
         assert_eq!(io.inputs[0].files[0].path, "_input/output.md");
         assert!(io.inputs[0].files[0].exists);
+    }
+
+    #[test]
+    fn entry_node_input_exposes_non_image_attachments() {
+        // #779: the files uploaded with the run ride on the entry node's input
+        // port after the prompt; images do not (they have their own surface).
+        let tmp = tempfile::tempdir().unwrap();
+        let artifacts = tmp.path().join("artifacts");
+        let input_dir = artifacts.join("_input");
+        fs::create_dir_all(&input_dir).unwrap();
+        fs::write(input_dir.join("output.md"), "Do the thing").unwrap();
+        fs::write(input_dir.join("SPEC-779.md"), "# spec").unwrap();
+        fs::write(input_dir.join("fixtures.json"), "{}").unwrap();
+        fs::write(input_dir.join("proto.png"), b"\x89PNG").unwrap();
+
+        let pipeline = simple_pipeline();
+        let io = resolve(&pipeline, &artifacts, "planner", 1, &empty_run_state());
+
+        let paths: Vec<&str> = io.inputs[0].files.iter().map(|f| f.path.as_str()).collect();
+        assert_eq!(
+            paths,
+            vec!["_input/output.md", "_input/SPEC-779.md", "_input/fixtures.json"]
+        );
+        assert!(io.inputs[0].files.iter().all(|f| f.exists));
     }
 
     #[test]

--- a/crates/pdo-daemon/src/node_primitives.rs
+++ b/crates/pdo-daemon/src/node_primitives.rs
@@ -344,6 +344,7 @@ pub(crate) fn start_node(params: &StartNodeParams<'_>) -> StartNodeResult {
         // two are exhaustive and mutually exclusive.
         shared_worktree_dir: (!has_sub_worktree).then_some(working_dir.as_path()),
         input_images: Vec::new(),
+        input_files: Vec::new(),
         start_prompt_present,
         source_iters: crate::input_resolution::resolved_source_iters(
             params.pipeline,

--- a/crates/pdo-daemon/src/node_spawn.rs
+++ b/crates/pdo-daemon/src/node_spawn.rs
@@ -1041,10 +1041,13 @@ pub(crate) async fn spawn_node(
                     .iter()
                     .any(|n| n.id == e.source.node && n.node_type == pipeline::NodeType::Start)
         });
-        let input_images = if is_entry_node {
-            prompt_augmenter::discover_input_images(spawn_ctx.artifacts_dir)
+        let (input_images, input_files) = if is_entry_node {
+            (
+                prompt_augmenter::discover_input_images(spawn_ctx.artifacts_dir),
+                prompt_augmenter::discover_input_files(spawn_ctx.artifacts_dir),
+            )
         } else {
-            Vec::new()
+            (Vec::new(), Vec::new())
         };
 
         // Canonical input resolution (#194 / #210): re-project the run state at
@@ -1129,6 +1132,7 @@ pub(crate) async fn spawn_node(
             // two are exhaustive and mutually exclusive.
             shared_worktree_dir: (!has_sub_worktree).then_some(working_dir.as_path()),
             input_images,
+            input_files,
             start_prompt_present,
             source_iters,
             repeated_iters,

--- a/crates/pdo-daemon/src/prompt_augmenter.rs
+++ b/crates/pdo-daemon/src/prompt_augmenter.rs
@@ -84,6 +84,9 @@ pub(crate) struct AugmentContext<'a> {
     /// and `None` for anything that spawns no session.
     pub shared_worktree_dir: Option<&'a Path>,
     pub input_images: Vec<String>,
+    /// Non-image files uploaded alongside the prompt (#779), discovered in
+    /// `_input/` at spawn like `input_images`. Entry nodes only.
+    pub input_files: Vec<String>,
     /// Whether the Start node's user prompt carries non-whitespace content.
     /// Precomputed by the daemon (which owns the artifacts dir and the read
     /// error) so `build_preamble` stays pure. Only consulted for the
@@ -145,6 +148,41 @@ pub(crate) fn discover_input_images(artifacts_dir: &Path) -> Vec<String> {
     }
     images.sort();
     images
+}
+
+/// The NON-image attachments of `_input/` (#779): every regular file that is
+/// neither the prompt (`output.md`) nor an image (those are
+/// [`discover_input_images`]). Sorted for a stable preamble.
+pub(crate) fn discover_input_files(artifacts_dir: &Path) -> Vec<String> {
+    let input_dir = artifacts_dir.join("_input");
+    let entries = match std::fs::read_dir(&input_dir) {
+        Ok(e) => e,
+        Err(_) => return Vec::new(),
+    };
+    let mut files = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        if name == "output.md" {
+            continue;
+        }
+        let ext = path
+            .extension()
+            .and_then(|e| e.to_str())
+            .map(|e| e.to_lowercase())
+            .unwrap_or_default();
+        if crate::ALLOWED_IMAGE_EXTENSIONS.contains(&ext.as_str()) {
+            continue;
+        }
+        files.push(name.to_string());
+    }
+    files.sort();
+    files
 }
 
 /// `Ok(false)` when the file is absent — the expected prompt-optional case, not
@@ -502,6 +540,20 @@ pub(crate) fn build_preamble(ctx: &AugmentContext<'_>) -> String {
         preamble.push('\n');
     }
 
+    if !ctx.input_files.is_empty() {
+        preamble.push_str("## Input Files\n\n");
+        preamble.push_str(
+            "The following files were passed to the entry node alongside the text \
+             prompt (the run's attachments). Read them as part of your input:\n",
+        );
+        let input_dir = ctx.artifacts_dir.join("_input");
+        for filename in &ctx.input_files {
+            let path = input_dir.join(filename);
+            preamble.push_str(&format!("- `{}`\n", path.display()));
+        }
+        preamble.push('\n');
+    }
+
     preamble.push_str("## Outputs\n\n");
     if outputs.is_empty() {
         preamble.push_str("No outputs declared.\n\n");
@@ -831,6 +883,13 @@ pub(crate) fn build_preamble(ctx: &AugmentContext<'_>) -> String {
          `--harness`, `--sandbox`, `--target-repo`, `--target-repos '<json>'`, \
          `--source-branch`, `--name`, `--auto-name`, `--auto-fail`, \
          `--provisioning '<json>'`.\n\
+         - Pass artifacts to the child: `--input-file <path>` reads the prompt \
+         from a file (exclusive with `--input`), `--image <path>` and \
+         `--file <path>` (both repeatable) attach files the child's entry node \
+         finds in its own preamble (input images / input files sections) — e.g. \
+         `--input-file \"$PDO_INPUT_SPEC\" --image \"$PDO_INPUT_PROTO\"/*.png`. \
+         One budget per run (default 50 MB, `max_attachments_mb` in Settings); \
+         a duplicate filename is refused.\n\
          - The daemon's refusals (unknown pipeline, …) print on stderr with a \
          non-zero exit.\n\
          - Mount a directory of generated pages with `pdo page mount <name> <dir>`; \
@@ -1275,6 +1334,7 @@ mod tests {
             source_worktree_dir: None,
             shared_worktree_dir: None,
             input_images: Vec::new(),
+            input_files: Vec::new(),
             start_prompt_present: false,
             source_iters: HashMap::new(),
             repeated_iters: HashMap::new(),
@@ -2711,6 +2771,43 @@ mod tests {
 
         let images = discover_input_images(&artifacts_dir);
         assert!(images.is_empty());
+    }
+
+    #[test]
+    fn discover_input_files_skips_prompt_and_images() {
+        // #779: every non-image regular file but `output.md`, sorted.
+        let tmp = tempfile::tempdir().unwrap();
+        let artifacts_dir = tmp.path().join("artifacts");
+        let input_dir = artifacts_dir.join("_input");
+        std::fs::create_dir_all(&input_dir).unwrap();
+        std::fs::write(input_dir.join("output.md"), "text prompt").unwrap();
+        std::fs::write(input_dir.join("screenshot.PNG"), [0x89]).unwrap();
+        std::fs::write(input_dir.join("SPEC-779.md"), "# spec").unwrap();
+        std::fs::write(input_dir.join("fixtures.json"), "{}").unwrap();
+        std::fs::write(input_dir.join("noext"), "raw").unwrap();
+
+        let files = discover_input_files(&artifacts_dir);
+        assert_eq!(files, vec!["SPEC-779.md", "fixtures.json", "noext"]);
+        assert!(discover_input_files(tmp.path()).is_empty(), "no _input dir");
+    }
+
+    #[test]
+    fn preamble_includes_file_section_when_files_present() {
+        let pipeline = sample_pipeline();
+        let node = &pipeline.nodes[0];
+        let vars = HashMap::new();
+        let mut ctx = sample_ctx(&pipeline, node, &vars);
+        ctx.input_files = vec!["SPEC-779.md".into(), "fixtures.json".into()];
+
+        let preamble = build_preamble(&ctx);
+        assert!(preamble.contains("## Input Files"), "{preamble}");
+        assert!(preamble.contains("passed to the entry node"), "{preamble}");
+        assert!(preamble.contains("_input/SPEC-779.md"));
+        assert!(preamble.contains("_input/fixtures.json"));
+        assert!(!preamble.contains("## Input Images"));
+
+        ctx.input_files.clear();
+        assert!(!build_preamble(&ctx).contains("Input Files"));
     }
 
     #[test]

--- a/crates/pdo-daemon/src/skill_bank.rs
+++ b/crates/pdo-daemon/src/skill_bank.rs
@@ -1162,7 +1162,7 @@ pub(crate) fn is_seeded(id: &str) -> bool {
 pub(crate) const SEEDED_SKILL_MD: &str = r#"---
 name: pdo-orchestrate
 description: Orchestrate child runs with PDO — create runs from this node session, follow them, and complete truthfully.
-skill_version: 1
+skill_version: 2
 ---
 
 # Orchestrating with PDO
@@ -1178,12 +1178,38 @@ and node — the daemon sets the parent itself; you never declare it.
 Prefer the CLI (same session, one short command):
 
 ```bash
-pdo run create --pipeline <pipeline-name> --input "<what the child must do>"
+pdo run create <pipeline-name> --input "<what the child must do>"
 ```
 
-The child inherits your run's project by default; pass `--project`, `--input`
-or `--variable key=value` to steer it. Out of a node session the same command
-works, without a parent.
+The pipeline is **positional**. The child inherits your run's project by
+default; steer it with `--target-repo <path>`, `--variables '{"key":"value"}'`
+(one JSON object), `--name "<title>"`, `--skills a,b`. Out of a node session the
+same command works, without a parent.
+
+### Passing files and images to the child
+
+Your inputs are files on disk — `PDO_INPUT_<PORT>` names each input port's
+path (a file, or a directory for an image list). Hand them to the child with:
+
+- `--input-file <path>`: the child's prompt read from a file (instead of
+  `--input`) — e.g. the spec an upstream node wrote.
+- `--image <path>` (repeatable): sent as `images`; the child's entry node sees
+  them under `## Input Images`.
+- `--file <path>` (repeatable): any other file, sent as `files`; listed under
+  `## Input Files` and exposed on the entry node's input port.
+
+```bash
+pdo run create <pipeline-name> \
+  --input-file "$PDO_INPUT_SPEC" \
+  --image "$PDO_INPUT_PROTO"/*.png \
+  --file "$PDO_INPUT_FIXTURES" \
+  --name "Implement the prototype"
+```
+
+All attachments land in the child's `.pdo/artifacts/_input/`. One size budget
+per run (default 50 MB, `max_attachments_mb` in Settings); a duplicate
+filename or an over-budget upload is refused with a named error — rename or
+attach less, then retry.
 
 The HTTP surface is equivalent — the CLI is a thin client:
 
@@ -2074,7 +2100,7 @@ mod tests {
         seed(&db, root.path()).await.unwrap();
         let before = get(&db, SEEDED_SKILL_ID).await.unwrap().unwrap();
 
-        let bumped = SEEDED_SKILL_MD.replace("skill_version: 1", "skill_version: 2");
+        let bumped = SEEDED_SKILL_MD.replace("skill_version: 2", "skill_version: 3");
         let outcome = seed_with(
             &db,
             root.path(),

--- a/crates/pdo-daemon/tests/cli_run_create.rs
+++ b/crates/pdo-daemon/tests/cli_run_create.rs
@@ -343,3 +343,124 @@ async fn daemon_refusals_surface_readably() {
     assert_ne!(code, Some(0));
     assert!(stderr.contains("failed to reach daemon"), "{stderr}");
 }
+
+/// Fetch a raw artifact of a run (`GET /runs/{id}/artifact?path=…`).
+async fn get_artifact(daemon: &TestDaemon, run_id: &str, rel: &str) -> (u16, String) {
+    let resp = reqwest::get(format!(
+        "{}/runs/{run_id}/artifact?path={rel}",
+        daemon.url()
+    ))
+    .await
+    .unwrap();
+    (resp.status().as_u16(), resp.text().await.unwrap_or_default())
+}
+
+#[tokio::test]
+async fn attachments_reach_the_child_input_dir() {
+    // #779: `--input-file` / `--image` / `--file` from a node session — the
+    // body switches to multipart, provenance is kept, and every attachment
+    // lands in the child's `_input/` where the entry node's preamble lists it.
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+    let parent = create_root_run(&daemon).await;
+    wait_node_running(&daemon, &parent, "worker").await;
+
+    let scratch = tempfile::tempdir().unwrap();
+    let spec = scratch.path().join("SPEC-779.md");
+    std::fs::write(&spec, "# Spec 779\n\nImplement the prototype.\n").unwrap();
+    let proto = scratch.path().join("proto.png");
+    std::fs::write(&proto, b"\x89PNG\r\n\x1a\nfake").unwrap();
+    let fixtures = scratch.path().join("fixtures.json");
+    std::fs::write(&fixtures, r#"{"ok":true}"#).unwrap();
+
+    let (code, stdout, stderr) = run_pdo_run_create(
+        &daemon.url(),
+        &[
+            CHILD_PIPELINE_NAME,
+            "--input-file",
+            spec.to_str().unwrap(),
+            "--image",
+            proto.to_str().unwrap(),
+            "--file",
+            fixtures.to_str().unwrap(),
+            "--name",
+            "with attachments",
+            "--auto-fail",
+            "true",
+        ],
+        Some((&parent, "worker")),
+    )
+    .await;
+    assert_eq!(code, Some(0), "stderr=\n{stderr}\nstdout=\n{stdout}");
+    let child_id = run_id_from_stdout(&stdout);
+
+    let (status, run) = get_json(&daemon, &format!("/runs/{child_id}")).await;
+    assert_eq!(status, 200);
+    assert_eq!(run["parent_run_id"], parent, "multipart keeps provenance");
+    assert_eq!(run["name"], "with attachments", "text fields ride along");
+    assert_eq!(run["auto_fail"], true, "bools survive the multipart round trip");
+    assert_eq!(
+        run["start_node"]["input_images"],
+        serde_json::json!(["proto.png"])
+    );
+    assert_eq!(
+        run["start_node"]["input_files"],
+        serde_json::json!(["fixtures.json"])
+    );
+
+    // The prompt came from the file, the attachments sit beside it.
+    let (st, prompt) = get_artifact(&daemon, &child_id, "_input/output.md").await;
+    assert_eq!(st, 200);
+    assert!(prompt.contains("Implement the prototype"), "{prompt}");
+    let (st, body) = get_artifact(&daemon, &child_id, "_input/fixtures.json").await;
+    assert_eq!(st, 200, "{body}");
+    assert_eq!(body, r#"{"ok":true}"#);
+    let (st, _) = get_artifact(&daemon, &child_id, "_input/proto.png").await;
+    assert_eq!(st, 200);
+}
+
+#[tokio::test]
+async fn attachment_refusals_surface_readably() {
+    let daemon = TestDaemon::spawn(seed).await.unwrap();
+    let scratch = tempfile::tempdir().unwrap();
+    let a = scratch.path().join("a").join("notes.md");
+    let b = scratch.path().join("b").join("notes.md");
+    std::fs::create_dir_all(a.parent().unwrap()).unwrap();
+    std::fs::create_dir_all(b.parent().unwrap()).unwrap();
+    std::fs::write(&a, "one").unwrap();
+    std::fs::write(&b, "two").unwrap();
+
+    // Two files with the same name: the daemon refuses, nothing is overwritten.
+    let (code, stdout, stderr) = run_pdo_run_create(
+        &daemon.url(),
+        &[
+            CHILD_PIPELINE_NAME,
+            "--target-repo",
+            &daemon.target_repo(),
+            "--file",
+            a.to_str().unwrap(),
+            "--file",
+            b.to_str().unwrap(),
+        ],
+        None,
+    )
+    .await;
+    assert_ne!(code, Some(0));
+    assert!(stderr.contains("duplicate attachment filename"), "{stderr}");
+    assert!(stdout.trim().is_empty());
+
+    // A missing local file is named before any request.
+    let (code, _stdout, stderr) = run_pdo_run_create(
+        &daemon.url(),
+        &[
+            CHILD_PIPELINE_NAME,
+            "--target-repo",
+            &daemon.target_repo(),
+            "--file",
+            "/nonexistent/thing.bin",
+        ],
+        None,
+    )
+    .await;
+    assert_ne!(code, Some(0));
+    assert!(stderr.contains("failed to read --file"), "{stderr}");
+}

--- a/crates/pdo-daemon/tests/skill_seed.rs
+++ b/crates/pdo-daemon/tests/skill_seed.rs
@@ -50,7 +50,8 @@ async fn startup_seeds_the_skill_in_the_pdo_folder_and_flags_it_locked() {
     let detail = get_json(&daemon, &format!("/settings/skills/{SEEDED_ID}")).await;
     assert_eq!(detail["name"], "pdo-orchestrate");
     assert_eq!(detail["locked"], true);
-    assert_eq!(detail["frontmatter"]["skill_version"], 1);
+    // #779 bumped the seeded guidance (attachment flags, fixed examples).
+    assert_eq!(detail["frontmatter"]["skill_version"], 2);
     assert!(detail["content"]
         .as_str()
         .unwrap()

--- a/frontend/e2e/new-run-attachments.spec.ts
+++ b/frontend/e2e/new-run-attachments.spec.ts
@@ -1,0 +1,121 @@
+import { test, expect } from "@playwright/test";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { E2E_TARGET_REPO } from "./helpers";
+
+// Layer 3b — « New run » attachments (#779).
+// Verifies: the drop zone accepts a non-image file next to an image, shows it as
+// a chip with the running counter, sends images in `images` and the rest in
+// `files`, and the created Run carries both in `start_node`.
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const WORKSPACE_ROOT = path.resolve(__dirname, "..", "..");
+const PIPELINE_NAME = `e2e-attachments-${process.pid}-${Date.now()}`;
+const PIPELINE_DIR = path.join(WORKSPACE_ROOT, ".pdo", "pipelines");
+const PIPELINE_PATH = path.join(PIPELINE_DIR, `${PIPELINE_NAME}.yaml`);
+
+// Start → End only: nothing spawns, the run completes on its own.
+const SEED_YAML = `name: ${PIPELINE_NAME}
+version: "1.0"
+nodes:
+  - id: start
+    name: Start
+    type: start
+    outputs:
+      - { name: user_prompt, side: bottom }
+    view: { x: 100, y: 0 }
+  - id: end
+    name: End
+    type: end
+    inputs:
+      - { name: result, side: top }
+    view: { x: 100, y: 200 }
+edges:
+  - source: { node: start, port: user_prompt }
+    target: { node: end, port: result }
+`;
+
+test.beforeAll(async () => {
+  await fs.mkdir(PIPELINE_DIR, { recursive: true });
+  await fs.writeFile(PIPELINE_PATH, SEED_YAML);
+});
+
+test.afterAll(async () => {
+  await fs.rm(PIPELINE_PATH, { force: true });
+});
+
+test("a dropped file becomes a chip and reaches the run as `files`", async ({
+  page,
+  baseURL,
+}) => {
+  await page.goto("/");
+  await expect(page.getByText("Daemon: connected")).toBeVisible({ timeout: 10_000 });
+
+  await page.getByRole("button", { name: "New Run" }).click();
+  await expect(page.getByTestId("target-repo-input")).toBeVisible();
+  await page.getByTestId("target-repo-input").fill(E2E_TARGET_REPO);
+  await page.getByTestId("pipeline-select").selectOption({ label: PIPELINE_NAME });
+  await page.getByPlaceholder(/free-text prompt/i).fill("e2e attachments");
+
+  // Empty state: the helper names the budget the daemon enforces.
+  const zone = page.getByTestId("image-drop-zone");
+  await expect(zone).toBeVisible();
+  await expect(page.getByText(/up to .* MB per run/i)).toBeVisible();
+
+  // The hidden <input type=file> has no accept filter any more — any file goes.
+  const input = page.getByTestId("image-file-input");
+  await expect(input).toHaveAttribute("accept", "");
+  await input.setInputFiles([
+    {
+      name: "SPEC-779.md",
+      mimeType: "text/markdown",
+      buffer: Buffer.from("# Spec 779\n\nImplement the prototype.\n"),
+    },
+    {
+      name: "proto.png",
+      mimeType: "image/png",
+      // 1×1 transparent PNG.
+      buffer: Buffer.from(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=",
+        "base64",
+      ),
+    },
+  ]);
+
+  const chip = page.getByTestId("file-chip");
+  await expect(chip).toHaveCount(1);
+  await expect(chip).toContainText("MD");
+  await expect(chip).toContainText("SPEC-779.md");
+  await expect(page.getByTestId("image-thumbnail")).toHaveCount(1);
+  await expect(page.getByTestId("attachments-counter")).toContainText("1 image, 1 file");
+  await expect(page.getByTestId("attachments-meter")).toBeVisible();
+
+  // Launch: one multipart request, `images` and `files` split by MIME.
+  const [request] = await Promise.all([
+    page.waitForRequest((r) => r.url().endsWith("/runs") && r.method() === "POST"),
+    page.getByTestId("launch-button").click(),
+  ]);
+  const body = request.postData() ?? "";
+  expect(request.headers()["content-type"]).toContain("multipart/form-data");
+  expect(body).toContain('name="images"; filename="proto.png"');
+  expect(body).toContain('name="files"; filename="SPEC-779.md"');
+
+  // The daemon wrote both into `_input/` and lists them on the Start node.
+  await expect
+    .poll(
+      async () => {
+        const resp = await page.request.get(`${baseURL}/runs`);
+        const runs = (await resp.json()) as Array<{ run_id: string; pipeline: string }>;
+        const mine = runs.find((r) => r.pipeline === PIPELINE_NAME);
+        if (!mine) return null;
+        const detail = await (await page.request.get(`${baseURL}/runs/${mine.run_id}`)).json();
+        return {
+          images: detail.start_node?.input_images,
+          files: detail.start_node?.input_files,
+        };
+      },
+      { timeout: 10_000 },
+    )
+    .toEqual({ images: ["proto.png"], files: ["SPEC-779.md"] });
+});

--- a/frontend/src/App.settingsClose.test.tsx
+++ b/frontend/src/App.settingsClose.test.tsx
@@ -82,6 +82,7 @@ vi.mock("./api", () => {
     session_cap: { effective: 20, source: "default", stored: null, env: null, default: 20 },
     reaper_ttl_secs: { effective: 3600, source: "default", stored: null, env: null, default: 3600 },
     guard_timeout_secs: { effective: 60, source: "default", stored: null, env: null, default: 60 },
+    max_attachments_mb: { effective: 50, source: "default", stored: null, env: null, default: 50 },
     default_model: { effective: null, source: "default", stored: null, env: null, default: null },
     default_harness: { effective: null, source: "default", stored: null, env: null, default: null },
     default_harness_model: { effective: {}, stored: {} },

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -821,6 +821,8 @@ export interface CreateRunRequest {
    *  the server resolves back-compat by the presence of `name`, then the instance default. */
   auto_name?: boolean;
   images?: File[];
+  /** #779: non-image attachments, sent as the multipart `files` field. */
+  files?: File[];
   provisioning?: ProvisioningRules;
 }
 
@@ -830,8 +832,9 @@ export interface CreateRunResponse {
 
 export function createRun(req: CreateRunRequest): Promise<CreateRunResponse> {
   const hasImages = req.images && req.images.length > 0;
+  const hasFiles = req.files && req.files.length > 0;
 
-  if (hasImages) {
+  if (hasImages || hasFiles) {
     const form = new FormData();
     form.append("pipeline", req.pipeline);
     form.append("input", req.input);
@@ -851,8 +854,13 @@ export function createRun(req: CreateRunRequest): Promise<CreateRunResponse> {
     if (req.skills && req.skills.length > 0) form.append("skills", JSON.stringify(req.skills));
     if (req.auto_name !== undefined) form.append("auto_name", String(req.auto_name));
     if (req.provisioning) form.append("provisioning", JSON.stringify(req.provisioning));
-    for (const file of req.images!) {
+    for (const file of req.images ?? []) {
       form.append("images", file, file.name);
+    }
+    // #779: everything that is not an image rides in `files` — same `_input/`
+    // destination on the daemon, listed under `## Input Files` for the entry node.
+    for (const file of req.files ?? []) {
+      form.append("files", file, file.name);
     }
 
     // FormData → no manual Content-Type, so the browser sets the boundary.
@@ -860,7 +868,7 @@ export function createRun(req: CreateRunRequest): Promise<CreateRunResponse> {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { images: _omitted, ...jsonBody } = req;
+  const { images: _omitted, files: _omittedFiles, ...jsonBody } = req;
   return request<CreateRunResponse>("POST", "/runs", { body: jsonBody, label: "POST /runs" });
 }
 

--- a/frontend/src/components/NewRunModal.test.tsx
+++ b/frontend/src/components/NewRunModal.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import NewRunModal from "./NewRunModal";
+import { mergeAttachments, overLimitIndices } from "../lib/attachments";
 import { useEditStore } from "../stores/editStore";
 import type { BranchRef, InstanceSettings, PipelineListEntry, Trigger } from "../types";
 
@@ -32,6 +33,7 @@ vi.mock("../api", () => ({
     session_cap: { effective: 20, source: "default", stored: null, env: null, default: 20 },
     reaper_ttl_secs: { effective: 3600, source: "default", stored: null, env: null, default: 3600 },
     guard_timeout_secs: { effective: 60, source: "default", stored: null, env: null, default: 60 },
+    max_attachments_mb: { effective: 50, source: "default", stored: null, env: null, default: 50 },
     default_model: { effective: null, source: "default", stored: null, env: null, default: null },
     default_harness: { effective: null, source: "default", stored: null, env: null, default: null },
     default_harness_model: { effective: {}, stored: {} },
@@ -564,7 +566,8 @@ describe("NewRunModal — image upload", () => {
       const thumbnails = screen.getAllByTestId("image-thumbnail");
       expect(thumbnails).toHaveLength(1);
     });
-    expect(screen.getByText("1 image attached")).toBeInTheDocument();
+    expect(screen.getByTestId("attachments-counter")).toHaveTextContent(/^1 image · /);
+    expect(screen.getByTestId("attachments-counter")).toHaveTextContent("/ 50.0 MB");
   });
 
   it("shows remove button and removes image on click", async () => {
@@ -598,7 +601,7 @@ describe("NewRunModal — image upload", () => {
     await waitFor(() => {
       expect(screen.getAllByTestId("image-thumbnail")).toHaveLength(2);
     });
-    expect(screen.getByText("2 images attached")).toBeInTheDocument();
+    expect(screen.getByTestId("attachments-counter")).toHaveTextContent(/^2 images · /);
   });
 
   it("shows add-more button when images exist", async () => {
@@ -689,17 +692,185 @@ describe("NewRunModal — image upload", () => {
     });
   });
 
-  it("filters non-image files from file input", async () => {
+  // #779: the field is « Attachments » — any file is accepted, non-images as chips.
+  it("shows non-image files as chips beside the thumbnails", async () => {
     renderModal();
     const fileInput = screen.getByTestId("image-file-input") as HTMLInputElement;
+    expect(fileInput.accept).toBe("");
 
-    const textFile = new File(["text"], "notes.txt", { type: "text/plain" });
+    const textFile = new File(["# spec"], "SPEC-779.md", { type: "text/markdown" });
     const imageFile = new File(["png"], "img.png", { type: "image/png" });
     fireEvent.change(fileInput, { target: { files: [textFile, imageFile] } });
 
     await waitFor(() => {
       expect(screen.getAllByTestId("image-thumbnail")).toHaveLength(1);
     });
+    const chips = screen.getAllByTestId("file-chip");
+    expect(chips).toHaveLength(1);
+    expect(chips[0]).toHaveTextContent("MD");
+    expect(chips[0]).toHaveTextContent("SPEC-779.md");
+    expect(chips[0]).toHaveTextContent("6 B");
+    expect(screen.getByTestId("attachments-counter")).toHaveTextContent(/^1 image, 1 file · /);
+    expect(screen.getByText(/passed to the entry node as/i)).toBeInTheDocument();
+    expect(screen.getByTestId("attachments-meter")).toBeInTheDocument();
+  });
+
+  it("removes a chip with its × button or the Delete key", async () => {
+    renderModal();
+    const fileInput = screen.getByTestId("image-file-input") as HTMLInputElement;
+    fireEvent.change(fileInput, {
+      target: {
+        files: [
+          new File(["{}"], "fixtures.json", { type: "application/json" }),
+          new File(["x"], "dump.sql", { type: "" }),
+        ],
+      },
+    });
+    await waitFor(() => expect(screen.getAllByTestId("file-chip")).toHaveLength(2));
+
+    fireEvent.click(screen.getAllByTestId("file-remove-button")[0]);
+    await waitFor(() => expect(screen.getAllByTestId("file-chip")).toHaveLength(1));
+    expect(screen.getByTestId("file-chip")).toHaveTextContent("dump.sql");
+
+    fireEvent.keyDown(screen.getByTestId("file-chip"), { key: "Delete" });
+    await waitFor(() => expect(screen.queryAllByTestId("file-chip")).toHaveLength(0));
+    expect(screen.getByText(/optional — passed to the entry node/i)).toBeInTheDocument();
+  });
+
+  it("replaces an attachment with the same name and says so", async () => {
+    renderModal();
+    const fileInput = screen.getByTestId("image-file-input") as HTMLInputElement;
+    fireEvent.change(fileInput, {
+      target: { files: [new File(["v1"], "SPEC-779.md", { type: "text/markdown" })] },
+    });
+    await waitFor(() => expect(screen.getAllByTestId("file-chip")).toHaveLength(1));
+    fireEvent.change(fileInput, {
+      target: { files: [new File(["v2 longer"], "SPEC-779.md", { type: "text/markdown" })] },
+    });
+    await waitFor(() => expect(screen.getByText(/Replaced SPEC-779.md\./)).toBeInTheDocument());
+    expect(screen.getAllByTestId("file-chip")).toHaveLength(1);
+    expect(screen.getByTestId("file-chip")).toHaveTextContent("9 B");
+    expect(screen.getByTestId("attachments-counter")).toHaveTextContent(/^1 file · /);
+  });
+
+  it("refuses a drop that would exceed the per-run budget, keeps the rest", async () => {
+    // The budget comes from Settings: 1 MB here.
+    const base = await fetchSettings();
+    vi.mocked(fetchSettings).mockResolvedValueOnce({
+      ...base,
+      max_attachments_mb: { effective: 1, source: "stored", stored: 1, env: null, default: 50 },
+    });
+    renderModal();
+    await waitFor(() =>
+      expect(screen.getByText(/up to 1\.0 MB per run/i)).toBeInTheDocument(),
+    );
+
+    const zone = screen.getByTestId("image-drop-zone");
+    const small = new File(["ok"], "notes.md", { type: "text/markdown" });
+    const big = new File([new Uint8Array(2 * 1024 * 1024)], "recording.mov", {
+      type: "video/quicktime",
+    });
+    fireEvent.drop(zone, { dataTransfer: { files: [big, small] } });
+
+    await waitFor(() => expect(screen.getByTestId("attachments-error")).toBeInTheDocument());
+    expect(screen.getByTestId("attachments-error")).toHaveTextContent(
+      "recording.mov (2.0 MB) not added: total would exceed 1.0 MB per run.",
+    );
+    expect(screen.getAllByTestId("file-chip")).toHaveLength(1);
+    expect(screen.getByTestId("file-chip")).toHaveTextContent("notes.md");
+  });
+
+  it("highlights the zone while dragging over it", () => {
+    renderModal();
+    const zone = screen.getByTestId("image-drop-zone");
+    fireEvent.dragOver(zone, { dataTransfer: { files: [] } });
+    expect(zone).toHaveAttribute("data-drag-over", "true");
+    fireEvent.dragLeave(zone);
+    expect(zone).not.toHaveAttribute("data-drag-over");
+  });
+
+  it("passes non-image files to createRun in `files`, images in `images`", async () => {
+    vi.mocked(fetchPipelines).mockResolvedValue([
+      makePipeline({ id: "p1", name: "Test Pipeline" }),
+    ]);
+    render(<NewRunModal open={true} onClose={noop} onCreated={noop} />);
+    await enterValidRepo();
+    fireEvent.change(screen.getByPlaceholderText(/free-text prompt/i), {
+      target: { value: "implement the spec" },
+    });
+    const fileInput = screen.getByTestId("image-file-input") as HTMLInputElement;
+    fireEvent.change(fileInput, {
+      target: {
+        files: [
+          new File(["png"], "proto.png", { type: "image/png" }),
+          new File(["# spec"], "SPEC-779.md", { type: "text/markdown" }),
+        ],
+      },
+    });
+    await waitFor(() => expect(screen.getAllByTestId("file-chip")).toHaveLength(1));
+
+    vi.useRealTimers();
+    fireEvent.click(screen.getByRole("button", { name: /launch/i }));
+    await waitFor(() => {
+      expect(createRun).toHaveBeenCalledWith(
+        expect.objectContaining({
+          images: [expect.objectContaining({ name: "proto.png" })],
+          files: [expect.objectContaining({ name: "SPEC-779.md" })],
+        }),
+      );
+    });
+  });
+
+  it("warns once before closing with attachments present", async () => {
+    const onClose = vi.fn();
+    render(<NewRunModal open={true} onClose={onClose} onCreated={noop} />);
+    const fileInput = screen.getByTestId("image-file-input") as HTMLInputElement;
+    fireEvent.change(fileInput, {
+      target: { files: [new File(["{}"], "fixtures.json", { type: "application/json" })] },
+    });
+    await waitFor(() => expect(screen.getAllByTestId("file-chip")).toHaveLength(1));
+
+    fireEvent.click(screen.getByRole("button", { name: /^cancel$/i }));
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByTestId("attachments-close-warning")).toHaveTextContent(
+      "1 attachment will be lost",
+    );
+    fireEvent.click(screen.getByRole("button", { name: /^cancel$/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("NewRunModal — attachment budget rules (#779)", () => {
+  const mb = 1024 * 1024;
+  const file = (name: string, size: number, type = "application/octet-stream") =>
+    new File([new Uint8Array(size)], name, { type });
+
+  it("replaces a same-named file and refuses only what overflows", () => {
+    const current = [file("a.bin", 10), file("b.bin", 20)];
+    const { next, replaced, refused } = mergeAttachments(
+      current,
+      [file("a.bin", 15), file("huge.bin", 2 * mb), file("c.bin", 5)],
+      mb,
+    );
+    expect(next.map((f) => [f.name, f.size])).toEqual([
+      ["a.bin", 15],
+      ["b.bin", 20],
+      ["c.bin", 5],
+    ]);
+    expect(replaced).toEqual(["a.bin"]);
+    expect(refused.map((f) => f.name)).toEqual(["huge.bin"]);
+  });
+
+  it("a single file may use the whole budget", () => {
+    const { next, refused } = mergeAttachments([], [file("all.bin", mb)], mb);
+    expect(next).toHaveLength(1);
+    expect(refused).toHaveLength(0);
+  });
+
+  it("flags the chips past the budget line when the limit was lowered", () => {
+    const list = [file("a.parquet", 0.4 * mb), file("b.parquet", 0.4 * mb), file("c.sql", 0.4 * mb)];
+    expect([...overLimitIndices(list, mb)]).toEqual([2]);
+    expect([...overLimitIndices(list, 2 * mb)]).toEqual([]);
   });
 });
 
@@ -850,6 +1021,7 @@ describe("NewRunModal — auto-naming default (#338)", () => {
       session_cap: { effective: 20, source: "default", stored: null, env: null, default: 20 },
       reaper_ttl_secs: { effective: 3600, source: "default", stored: null, env: null, default: 3600 },
       guard_timeout_secs: { effective: 60, source: "default", stored: null, env: null, default: 60 },
+      max_attachments_mb: { effective: 50, source: "default", stored: null, env: null, default: 50 },
       default_model: { effective: null, source: "default", stored: null, env: null, default: null },
       default_harness: { effective: null, source: "default", stored: null, env: null, default: null },
       default_harness_model: { effective: {}, stored: {} },
@@ -1598,6 +1770,7 @@ describe("NewRunModal — sandbox selector (#410)", () => {
       session_cap: { effective: 20, source: "default", stored: null, env: null, default: 20 },
       reaper_ttl_secs: { effective: 3600, source: "default", stored: null, env: null, default: 3600 },
       guard_timeout_secs: { effective: 60, source: "default", stored: null, env: null, default: 60 },
+      max_attachments_mb: { effective: 50, source: "default", stored: null, env: null, default: 50 },
       default_model: { effective: null, source: "default", stored: null, env: null, default: null },
       default_harness: { effective: null, source: "default", stored: null, env: null, default: null },
       default_harness_model: { effective: {}, stored: {} },
@@ -1937,6 +2110,7 @@ describe("NewRunModal — the launch dialog can defer to default_sandbox (#452)"
       session_cap: { effective: 20, source: "default", stored: null, env: null, default: 20 },
       reaper_ttl_secs: { effective: 3600, source: "default", stored: null, env: null, default: 3600 },
       guard_timeout_secs: { effective: 60, source: "default", stored: null, env: null, default: 60 },
+      max_attachments_mb: { effective: 50, source: "default", stored: null, env: null, default: 50 },
       default_model: { effective: null, source: "default", stored: null, env: null, default: null },
       default_harness: { effective: null, source: "default", stored: null, env: null, default: null },
       default_harness_model: { effective: {}, stored: {} },
@@ -2154,6 +2328,7 @@ describe("NewRunModal — the target repo is required at the boundary (#470)", (
       session_cap: { effective: 20, source: "default", stored: null, env: null, default: 20 },
       reaper_ttl_secs: { effective: 3600, source: "default", stored: null, env: null, default: 3600 },
       guard_timeout_secs: { effective: 60, source: "default", stored: null, env: null, default: 60 },
+      max_attachments_mb: { effective: 50, source: "default", stored: null, env: null, default: 50 },
       default_model: { effective: null, source: "default", stored: null, env: null, default: null },
       default_harness: { effective: null, source: "default", stored: null, env: null, default: null },
       default_harness_model: { effective: {}, stored: {} },
@@ -2516,6 +2691,7 @@ describe("NewRunModal — harness selector (#551)", () => {
       session_cap: { effective: 20, source: "default", stored: null, env: null, default: 20 },
       reaper_ttl_secs: { effective: 3600, source: "default", stored: null, env: null, default: 3600 },
       guard_timeout_secs: { effective: 60, source: "default", stored: null, env: null, default: 60 },
+      max_attachments_mb: { effective: 50, source: "default", stored: null, env: null, default: 50 },
       default_model: { effective: null, source: "default", stored: null, env: null, default: null },
       default_harness: { effective: null, source: "default", stored: null, env: null, default: null },
       default_harness_model: { effective: {}, stored: {} },

--- a/frontend/src/components/NewRunModal.tsx
+++ b/frontend/src/components/NewRunModal.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { ChevronDown, Clock, FolderGit2, GitBranch, ImagePlus, Save, Sparkles, X } from "lucide-react";
+import { ChevronDown, Clock, FolderGit2, GitBranch, Paperclip, Plus, Save, Sparkles, X } from "lucide-react";
 import type { InstanceSettings, Trigger } from "../types";
 import type { TestGuardResponse } from "../api";
 import { createRun, createTrigger, updateTrigger, fetchSettings, testGuard } from "../api";
@@ -23,11 +23,17 @@ import { CRON_PRESETS, cronToPreset, parseDailyTime, type CronPresetId } from ".
 import { useLaunchTargets } from "../hooks/useLaunchTargets";
 import { useRepoValidation } from "../hooks/useRepoValidation";
 import * as newRunForm from "../lib/newRunForm";
+import {
+  DEFAULT_MAX_ATTACHMENTS_MB,
+  attachmentBadge,
+  formatAttachmentSize,
+  mergeAttachments,
+  overLimitIndices,
+} from "../lib/attachments";
 import ProvisioningRulesEditor from "./ProvisioningRulesEditor";
 import { EMPTY_PROVISIONING_RULES, hasProvisioningRules } from "../lib/provisioning";
 import type { ProvisioningRules } from "../types";
 
-const ACCEPTED_IMAGE_TYPES = ["image/png", "image/jpeg", "image/gif", "image/webp", "image/svg+xml", "image/bmp"];
 
 /**
  * How the always-mounted modal should open (#386). Because the modal is never
@@ -138,7 +144,17 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
   // `[1..]` lines.
   const [secondaryRepos, setSecondaryRepos] = useState<SecondaryRepo[]>([]);
 
-  const [images, setImages] = useState<File[]>([]);
+  // #779: images AND files, one list in upload order. Split by MIME at submit
+  // (`image/*` → `images`, the rest → `files`). File objects are never persisted
+  // in the draft store, hence the close warning below.
+  const [attachments, setAttachments] = useState<File[]>([]);
+  const [attachmentError, setAttachmentError] = useState<string | null>(null);
+  const [attachmentHint, setAttachmentHint] = useState<string | null>(null);
+  const [attachmentDragOver, setAttachmentDragOver] = useState(false);
+  const [attachmentShake, setAttachmentShake] = useState(false);
+  // Set when the user asked to close with attachments present: the second
+  // Cancel / ✕ closes for real (a one-line warning, not a modal).
+  const [closeWarning, setCloseWarning] = useState(false);
 
   // Sandbox (#410/#432/#452). `settings` carries the instance `default_sandbox` (it
   // LABELS the inherit option — it no longer seeds the value), the advisory
@@ -500,45 +516,88 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
     setOverrides((prev) => ({ ...prev, [key]: value }));
   }, []);
 
-  const addImages = useCallback((files: FileList | File[]) => {
-    const valid = Array.from(files).filter((f) => ACCEPTED_IMAGE_TYPES.includes(f.type));
-    if (valid.length > 0) {
-      setImages((prev) => [...prev, ...valid]);
-    }
+  // #779: the per-run budget the daemon enforces on `POST /runs`, read from the
+  // same setting so the client-side gate and the refusal cannot disagree.
+  const maxAttachmentsMb = settings?.max_attachments_mb?.effective ?? DEFAULT_MAX_ATTACHMENTS_MB;
+  const maxAttachmentBytes = maxAttachmentsMb * 1024 * 1024;
+  const attachmentsTotal = attachments.reduce((sum, f) => sum + f.size, 0);
+  const attachmentsOverLimit = attachmentsTotal > maxAttachmentBytes;
+  const overLimitChips = useMemo(
+    () => overLimitIndices(attachments, maxAttachmentBytes),
+    [attachments, maxAttachmentBytes],
+  );
+  const imageCount = attachments.filter(newRunForm.isImageAttachment).length;
+  const fileCount = attachments.length - imageCount;
+
+  const addAttachments = useCallback(
+    (files: FileList | File[]) => {
+      const incoming = Array.from(files).filter((f) => f.size > 0 || f.type !== "");
+      if (incoming.length === 0) return;
+      const { next, replaced, refused } = mergeAttachments(attachments, incoming, maxAttachmentBytes);
+      setAttachments(next);
+      setAttachmentHint(replaced.length > 0 ? `Replaced ${replaced.join(", ")}.` : null);
+      if (refused.length > 0) {
+        const names = refused.map((f) => `${f.name} (${formatAttachmentSize(f.size)})`).join(", ");
+        setAttachmentError(
+          `${names} not added: total would exceed ${maxAttachmentsMb.toFixed(1)} MB per run.`,
+        );
+        setAttachmentShake(true);
+        window.setTimeout(() => setAttachmentShake(false), 300);
+      } else {
+        setAttachmentError(null);
+      }
+    },
+    [attachments, maxAttachmentBytes, maxAttachmentsMb],
+  );
+
+  const removeAttachment = useCallback((index: number) => {
+    setAttachments((prev) => prev.filter((_, i) => i !== index));
+    setAttachmentError(null);
+    setAttachmentHint(null);
   }, []);
 
-  const removeImage = useCallback((index: number) => {
-    setImages((prev) => prev.filter((_, i) => i !== index));
-  }, []);
-
+  // Modal-wide: pasting a file anywhere in the dialog attaches it; a text paste
+  // is left alone (no preventDefault).
   const handlePaste = useCallback(
     (e: React.ClipboardEvent) => {
       const files = e.clipboardData?.files;
       if (files && files.length > 0) {
-        const imageFiles = Array.from(files).filter((f) => ACCEPTED_IMAGE_TYPES.includes(f.type));
-        if (imageFiles.length > 0) {
-          e.preventDefault();
-          addImages(imageFiles);
-        }
+        e.preventDefault();
+        addAttachments(files);
       }
     },
-    [addImages],
+    [addAttachments],
   );
 
+  // Drop target: the zone only, not the whole modal.
   const handleDrop = useCallback(
     (e: React.DragEvent) => {
       e.preventDefault();
+      setAttachmentDragOver(false);
       const files = e.dataTransfer?.files;
       if (files && files.length > 0) {
-        addImages(files);
+        addAttachments(files);
       }
     },
-    [addImages],
+    [addAttachments],
   );
 
   const handleDragOver = useCallback((e: React.DragEvent) => {
     e.preventDefault();
+    setAttachmentDragOver(true);
   }, []);
+
+  const handleDragLeave = useCallback(() => setAttachmentDragOver(false), []);
+
+  // Close with attachments present: warn once, close on the second ask.
+  const requestClose = useCallback(() => {
+    if (attachments.length > 0 && !closeWarning) {
+      setCloseWarning(true);
+      return;
+    }
+    setCloseWarning(false);
+    onClose();
+  }, [attachments.length, closeWarning, onClose]);
 
   // Whether this pipeline may launch with an empty prompt (#158) — see `newRunForm`.
   const promptOptional = newRunForm.promptOptional(selectedPipeline);
@@ -615,7 +674,7 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
           sandbox,
           harness,
           skills,
-          images,
+          attachments,
           // #465: full list ([0] = primary, [1..] = secondaries), or undefined
           // for a mono-repo Run (keeps the request byte-identical).
           targetRepos: buildTargetRepos(),
@@ -631,7 +690,9 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
       setAutoName(settings?.default_auto_name.effective ?? true);
       setInput("");
       setOverrides({});
-      setImages([]);
+      setAttachments([]);
+      setAttachmentError(null);
+      setAttachmentHint(null);
       setSkills([]);
       setProvisioning(EMPTY_PROVISIONING_RULES);
       onClose();
@@ -640,9 +701,9 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
     } finally {
       setSubmitting(false);
     }
-  }, [selectedPipeline, input, hasRequiredPrompt, overrides, onCreated, onClose, flushPendingSaves, repoValid, targetRepo, sourceBranch, buildTargetRepos, autoName, runName, images, sandbox, harness, skills, agentChoice, settings, refreshRecentRepos, provisioning]);
+  }, [selectedPipeline, input, hasRequiredPrompt, overrides, onCreated, onClose, flushPendingSaves, repoValid, targetRepo, sourceBranch, buildTargetRepos, autoName, runName, attachments, sandbox, harness, skills, agentChoice, settings, refreshRecentRepos, provisioning]);
 
-  const canLaunch = provisioningValid && newRunForm.canLaunch({
+  const canLaunch = provisioningValid && !attachmentsOverLimit && newRunForm.canLaunch({
     repoValid,
     selectedPipeline,
     hasRequiredPrompt,
@@ -795,7 +856,8 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-      onClick={onClose}
+      onClick={requestClose}
+      onPaste={handlePaste}
     >
       <div
         className="w-[480px] max-h-[85vh] flex flex-col rounded-lg border border-line bg-bg-4 shadow-xl"
@@ -847,8 +909,9 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
             </div>
           </div>
           <button
-            onClick={onClose}
+            onClick={requestClose}
             className="grid h-6 w-6 place-items-center rounded text-fg-3 transition-colors hover:bg-bg-5 hover:text-fg"
+            aria-label="Close"
           >
             <X size={14} />
           </button>
@@ -1484,7 +1547,6 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
                 placeholder="Free-text prompt, a GitHub issue link, or a mix."
                 value={input}
                 onChange={(e) => setInput(e.target.value)}
-                onPaste={handlePaste}
                 data-testid="input-textarea"
               />
               <span className="text-fg-4" style={{ fontSize: "10.5px" }}>
@@ -1496,34 +1558,59 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
               </span>
             </div>
 
-            {/* Image upload area */}
-            <div className="flex flex-col gap-1.5">
-              <label
-                className="font-medium text-fg-2"
-                style={{ fontSize: "11.5px" }}
-              >
-                Images
-              </label>
+            {/* #779 Attachments — images as thumbnails, other files as chips, one
+                wrapping row. One budget per run, read from Settings. */}
+            <div className="flex flex-col gap-1.5" data-testid="attachments-field">
+              <div className="flex items-baseline justify-between gap-2">
+                <label
+                  className="font-medium text-fg-2"
+                  style={{ fontSize: "11.5px" }}
+                >
+                  Attachments
+                </label>
+                {attachments.length > 0 && (
+                  <span
+                    className={attachmentsOverLimit ? "text-st-failed" : "text-fg-4"}
+                    style={{ fontSize: "10.5px" }}
+                    data-testid="attachments-counter"
+                  >
+                    {[
+                      imageCount > 0 ? `${imageCount} image${imageCount > 1 ? "s" : ""}` : null,
+                      fileCount > 0 ? `${fileCount} file${fileCount > 1 ? "s" : ""}` : null,
+                    ]
+                      .filter(Boolean)
+                      .join(", ")}
+                    {" · "}
+                    {formatAttachmentSize(attachmentsTotal)} / {maxAttachmentsMb.toFixed(1)} MB
+                  </span>
+                )}
+              </div>
               <input
                 ref={fileInputRef}
                 type="file"
-                accept={ACCEPTED_IMAGE_TYPES.join(",")}
                 multiple
                 className="hidden"
                 data-testid="image-file-input"
                 onChange={(e) => {
-                  if (e.target.files) addImages(e.target.files);
+                  if (e.target.files) addAttachments(e.target.files);
                   e.target.value = "";
                 }}
               />
               <div
-                className="flex min-h-[60px] flex-wrap items-center gap-2 rounded-md border border-dashed border-line-strong bg-bg-3 px-2.5 py-2 transition-colors hover:border-fg-4"
+                className={`flex min-h-[60px] flex-wrap items-center gap-2 rounded-md border bg-bg-3 px-2.5 py-2 transition-colors ${
+                  attachmentDragOver
+                    ? "border-solid border-acc bg-acc/10"
+                    : attachmentsOverLimit
+                      ? "border-dashed border-st-failed"
+                      : "border-dashed border-line-strong hover:border-fg-4"
+                } ${attachmentShake ? "pdo-attach-shake border-st-failed" : ""}`}
                 data-testid="image-drop-zone"
+                data-drag-over={attachmentDragOver ? "true" : undefined}
                 onDrop={handleDrop}
                 onDragOver={handleDragOver}
-                onPaste={handlePaste}
+                onDragLeave={handleDragLeave}
               >
-                {images.length === 0 && (
+                {attachments.length === 0 && (
                   <button
                     type="button"
                     className="flex w-full items-center justify-center gap-1.5 py-1 text-fg-4 transition-colors hover:text-fg-3"
@@ -1531,50 +1618,151 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
                     onClick={() => fileInputRef.current?.click()}
                     data-testid="image-upload-button"
                   >
-                    <ImagePlus size={14} />
-                    Paste, drag-drop, or click to add images
+                    <Paperclip size={14} />
+                    Paste, drag-drop, or click to add images or files
                   </button>
                 )}
-                {images.map((file, idx) => (
-                  <div
-                    key={`${file.name}-${idx}`}
-                    className="group relative h-12 w-12 flex-shrink-0 overflow-hidden rounded border border-line"
-                    data-testid="image-thumbnail"
-                  >
-                    <img
-                      src={URL.createObjectURL(file)}
-                      alt={file.name}
-                      className="h-full w-full object-cover"
+                {attachments.map((file, idx) => {
+                  const over = overLimitChips.has(idx);
+                  const remove = () => removeAttachment(idx);
+                  const onKeyDown = (e: React.KeyboardEvent) => {
+                    if (e.key === "Delete" || e.key === "Backspace") {
+                      e.preventDefault();
+                      remove();
+                    }
+                  };
+                  if (newRunForm.isImageAttachment(file)) {
+                    return (
+                      <div
+                        key={`${file.name}-${idx}`}
+                        className={`group relative h-12 w-12 flex-shrink-0 overflow-hidden rounded border focus:outline-none focus:ring-1 focus:ring-acc ${
+                          over ? "border-st-failed" : "border-line"
+                        }`}
+                        data-testid="image-thumbnail"
+                        tabIndex={0}
+                        onKeyDown={onKeyDown}
+                        title={over ? `${file.name} · over limit` : file.name}
+                      >
+                        <img
+                          src={URL.createObjectURL(file)}
+                          alt={file.name}
+                          className="h-full w-full object-cover"
+                          title={file.name}
+                        />
+                        <button
+                          type="button"
+                          className="absolute -right-0.5 -top-0.5 grid h-4 w-4 place-items-center rounded-full bg-bg-4 text-fg-3 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100"
+                          onClick={remove}
+                          data-testid="image-remove-button"
+                          aria-label={`Remove ${file.name}`}
+                        >
+                          <X size={10} />
+                        </button>
+                      </div>
+                    );
+                  }
+                  return (
+                    <div
+                      key={`${file.name}-${idx}`}
+                      className={`group relative flex h-12 max-w-[220px] flex-shrink-0 items-center gap-2 rounded border bg-bg-2 px-2 focus:outline-none focus:ring-1 focus:ring-acc ${
+                        over ? "border-st-failed" : "border-line"
+                      }`}
+                      data-testid="file-chip"
+                      data-over-limit={over ? "true" : undefined}
+                      tabIndex={0}
+                      onKeyDown={onKeyDown}
                       title={file.name}
-                    />
-                    <button
-                      type="button"
-                      className="absolute -right-0.5 -top-0.5 grid h-4 w-4 place-items-center rounded-full bg-bg-4 text-fg-3 opacity-0 transition-opacity group-hover:opacity-100"
-                      onClick={() => removeImage(idx)}
-                      data-testid="image-remove-button"
-                      aria-label={`Remove ${file.name}`}
                     >
-                      <X size={10} />
-                    </button>
-                  </div>
-                ))}
-                {images.length > 0 && (
+                      <span
+                        className="grid h-8 w-8 flex-shrink-0 place-items-center rounded border border-line bg-bg-3 font-mono font-medium text-fg-3"
+                        style={{ fontSize: "8.5px", letterSpacing: "0.02em" }}
+                        aria-hidden="true"
+                      >
+                        {attachmentBadge(file.name)}
+                      </span>
+                      <span className="flex min-w-0 flex-col leading-tight">
+                        <span className="truncate text-fg" style={{ fontSize: "11.5px" }}>
+                          {file.name}
+                        </span>
+                        <span
+                          className={over ? "text-st-failed" : "text-fg-4"}
+                          style={{ fontSize: "10px" }}
+                        >
+                          {formatAttachmentSize(file.size)}
+                          {over ? " · over limit" : ""}
+                        </span>
+                      </span>
+                      <button
+                        type="button"
+                        className="absolute -right-0.5 -top-0.5 grid h-4 w-4 place-items-center rounded-full bg-bg-4 text-fg-3 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100"
+                        onClick={remove}
+                        data-testid="file-remove-button"
+                        aria-label={`Remove ${file.name}`}
+                      >
+                        <X size={10} />
+                      </button>
+                    </div>
+                  );
+                })}
+                {attachments.length > 0 && (
                   <button
                     type="button"
                     className="grid h-12 w-12 flex-shrink-0 place-items-center rounded border border-dashed border-line-strong text-fg-4 transition-colors hover:border-fg-3 hover:text-fg-3"
                     onClick={() => fileInputRef.current?.click()}
                     data-testid="image-add-more-button"
-                    aria-label="Add more images"
+                    aria-label="Add more attachments"
                   >
-                    <ImagePlus size={14} />
+                    <Plus size={14} />
                   </button>
                 )}
               </div>
-              <span className="text-fg-4" style={{ fontSize: "10.5px" }}>
-                {images.length > 0
-                  ? `${images.length} image${images.length > 1 ? "s" : ""} attached`
-                  : "Optional — images are passed to the entry node."}
-              </span>
+              {attachments.length > 0 && (
+                <div
+                  className="h-[3px] w-full overflow-hidden rounded-full bg-bg-4"
+                  data-testid="attachments-meter"
+                  aria-hidden="true"
+                >
+                  <div
+                    className={`h-full rounded-full transition-[width] ${
+                      attachmentsOverLimit ? "bg-st-failed" : "bg-acc"
+                    }`}
+                    style={{
+                      width: `${Math.min(100, (attachmentsTotal / maxAttachmentBytes) * 100)}%`,
+                    }}
+                  />
+                </div>
+              )}
+              {attachmentError ? (
+                <span
+                  className="text-st-failed"
+                  style={{ fontSize: "10.5px" }}
+                  data-testid="attachments-error"
+                >
+                  {attachmentError}
+                </span>
+              ) : attachmentsOverLimit ? (
+                <span
+                  className="text-st-failed"
+                  style={{ fontSize: "10.5px" }}
+                  data-testid="attachments-error"
+                >
+                  Total exceeds {maxAttachmentsMb.toFixed(1)} MB per run. Remove{" "}
+                  {formatAttachmentSize(attachmentsTotal - maxAttachmentBytes)} to continue.
+                </span>
+              ) : (
+                <span className="text-fg-4" style={{ fontSize: "10.5px" }}>
+                  {attachmentHint ? `${attachmentHint} ` : ""}
+                  {attachments.length > 0 ? (
+                    <>
+                      Passed to the entry node as{" "}
+                      <span className="font-mono">images</span> and{" "}
+                      <span className="font-mono">files</span>.
+                    </>
+                  ) : (
+                    `Optional — passed to the entry node. Up to ${maxAttachmentsMb.toFixed(1)} MB per run (configurable in Settings).`
+                  )}
+                </span>
+              )}
             </div>
           </div>
 
@@ -1674,8 +1862,27 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
 
         {/* Footer */}
         <div className="flex items-center justify-end gap-2 border-t border-line px-4 py-3">
+          {closeWarning && attachments.length > 0 && (
+            <span
+              className="mr-auto text-st-await"
+              style={{ fontSize: "10.5px" }}
+              data-testid="attachments-close-warning"
+            >
+              {attachments.length} attachment{attachments.length > 1 ? "s" : ""} will be lost
+              when the dialog closes — Cancel again to confirm.
+            </span>
+          )}
+          {mode === "run" && attachmentsOverLimit && (
+            <span
+              className="text-fg-4"
+              style={{ fontSize: "10.5px" }}
+              data-testid="attachments-fix-hint"
+            >
+              Fix attachments to create the run
+            </span>
+          )}
           <button
-            onClick={onClose}
+            onClick={requestClose}
             className="rounded-md border border-line-strong bg-bg-3 px-3 py-1.5 text-fg-2 transition-colors hover:bg-bg-4"
             style={{ fontSize: "11.5px" }}
           >
@@ -1690,7 +1897,7 @@ export default function NewRunModal({ open, onClose, onCreated, openIntent = RUN
               data-testid="launch-button"
             >
               <Sparkles size={12} />
-              {submitting ? "Launching…" : "Launch"}
+              {submitting ? (attachments.length > 0 ? "Uploading…" : "Launching…") : "Launch"}
             </button>
           ) : (
             <button

--- a/frontend/src/components/NodeDetailPanel.test.tsx
+++ b/frontend/src/components/NodeDetailPanel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, act } from "@testing-library/react";
+import { render, screen, fireEvent, act, within } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { useEffect } from "react";
 
@@ -787,6 +787,43 @@ describe("NodeDetailPanel", () => {
 
       await act(async () => {});
       expect(screen.getByTestId("port-type-badge")).toHaveTextContent("image_list");
+    });
+
+    // #779: a Start-sourced input carries the run's non-image attachments after
+    // the prompt — shown as « Input files » chips, never as thumbnails.
+    it("lists input files as chips under a start-sourced markdown input", async () => {
+      fetchNodeIOMock.mockResolvedValue({
+        inputs: [
+          {
+            port: "task",
+            repeated: false,
+            port_type: "markdown",
+            files: [
+              { path: "_input/output.md", exists: true, size: 100, frontmatter: null },
+              { path: "_input/SPEC-779.md", exists: true, size: 18_432, frontmatter: null },
+              { path: "_input/fixtures.json", exists: true, size: 402_432, frontmatter: null },
+            ],
+          },
+        ],
+        outputs: [],
+      });
+
+      render(
+        <TooltipProvider>
+          <NodeDetailPanel node={makeNode({ status: "running" })} runId="run-1" />
+        </TooltipProvider>,
+      );
+
+      await act(async () => {});
+      const list = screen.getByTestId("input-files");
+      const chips = within(list).getAllByTestId("input-file-chip");
+      expect(chips).toHaveLength(2);
+      expect(chips[0]).toHaveTextContent("MD");
+      expect(chips[0]).toHaveTextContent("SPEC-779.md");
+      expect(chips[0]).toHaveTextContent("18.0 KB");
+      expect(chips[1]).toHaveTextContent("JSON");
+      expect(chips[1]).toHaveAttribute("href", expect.stringContaining("_input%2Ffixtures.json"));
+      expect(screen.queryByTestId("image-thumbnails")).not.toBeInTheDocument();
     });
 
     it("does not show thumbnails for markdown ports", async () => {

--- a/frontend/src/components/NodeDetailPanel.tsx
+++ b/frontend/src/components/NodeDetailPanel.tsx
@@ -1341,6 +1341,13 @@ function isImageFile(path: string): boolean {
   return IMAGE_EXTENSIONS.has(ext);
 }
 
+/** #779: the uppercase extension badge of an input-file chip (`MD`, `JSON`, `PARQ`). */
+function fileBadge(name: string): string {
+  const dot = name.lastIndexOf(".");
+  if (dot <= 0 || dot === name.length - 1) return "FILE";
+  return name.slice(dot + 1).toUpperCase().slice(0, 4);
+}
+
 function PortRow({
   port,
   runId,
@@ -1385,6 +1392,13 @@ function PortRow({
   const imageFiles = isImage
     ? port.files.filter((f) => f.exists && isImageFile(f.path))
     : [];
+  // #779: a Start-sourced input carries the run's non-image attachments after
+  // the prompt (`_input/<file>`). A single (non-repeated) port otherwise has
+  // exactly one file, so anything past the first here IS an attachment.
+  const attachmentFiles =
+    !isImage && !port.repeated && port.files.length > 1
+      ? port.files.slice(1).filter((f) => f.exists && !isImageFile(f.path))
+      : [];
 
   const gridStyle = {
     gridTemplateColumns: "8px 1fr auto",
@@ -1483,6 +1497,50 @@ function PortRow({
               +{imageFiles.length - 4}
             </span>
           )}
+        </div>
+      )}
+
+      {/* #779: input files — the chips of the New run dialog, read-only */}
+      {attachmentFiles.length > 0 && (
+        <div className="col-span-3 mt-1 flex flex-col gap-1" data-testid="input-files">
+          <div className="text-fg-4" style={{ fontSize: "10px", fontWeight: 500 }}>
+            Input files
+          </div>
+          <div className="flex flex-wrap gap-1.5">
+            {attachmentFiles.map((f) => {
+              const name = f.path.split("/").pop() ?? f.path;
+              return (
+                <a
+                  key={f.path}
+                  href={artifactUrl(runId, f.path)}
+                  target="_blank"
+                  rel="noreferrer"
+                  onClick={(e) => e.stopPropagation()}
+                  className="flex h-9 max-w-[220px] items-center gap-1.5 rounded border border-line bg-bg-0 px-1.5 transition-colors hover:border-fg-4"
+                  title={name}
+                  data-testid="input-file-chip"
+                >
+                  <span
+                    className="grid h-6 w-6 flex-shrink-0 place-items-center rounded border border-line bg-bg-3 font-mono font-medium text-fg-3"
+                    style={{ fontSize: "7.5px" }}
+                    aria-hidden="true"
+                  >
+                    {fileBadge(name)}
+                  </span>
+                  <span className="flex min-w-0 flex-col leading-tight">
+                    <span className="truncate text-fg-2" style={{ fontSize: "10.5px" }}>
+                      {name}
+                    </span>
+                    {f.size != null && (
+                      <span className="font-mono text-fg-4" style={{ fontSize: "9px" }}>
+                        {formatSize(f.size)}
+                      </span>
+                    )}
+                  </span>
+                </a>
+              );
+            })}
+          </div>
         </div>
       )}
 

--- a/frontend/src/components/SettingsSurface.test.tsx
+++ b/frontend/src/components/SettingsSurface.test.tsx
@@ -96,6 +96,7 @@ function sample(overrides: Partial<InstanceSettings> = {}): InstanceSettings {
     session_cap: { effective: 9, source: "env", stored: null, env: 9, default: 20 },
     reaper_ttl_secs: { effective: 3600, source: "default", stored: null, env: null, default: 3600 },
     guard_timeout_secs: { effective: 60, source: "default", stored: null, env: null, default: 60 },
+    max_attachments_mb: { effective: 50, source: "default", stored: null, env: null, default: 50 },
     // Unset by default (account default): effective/stored/env/default all null.
     default_model: { effective: null, source: "default", stored: null, env: null, default: null },
     default_harness: { effective: null, source: "default", stored: null, env: null, default: null },
@@ -350,6 +351,31 @@ describe("SettingsSurface", () => {
     expect(cap.value).toBe("9");
     expect((screen.getByTestId("setting-reaper-ttl") as HTMLInputElement).value).toBe("3600");
     expect((screen.getByTestId("setting-guard-timeout") as HTMLInputElement).value).toBe("60");
+    // #779: the per-run attachment budget sits with the other runtime limits.
+    expect((screen.getByTestId("setting-max-attachments-mb") as HTMLInputElement).value).toBe("50");
+  });
+
+  it("saves the attachment budget and refuses one outside 1–4096 MB (#779)", async () => {
+    fetchSettingsMock.mockResolvedValue(sample());
+    updateSettingsMock.mockResolvedValue(
+      sample({
+        max_attachments_mb: { effective: 120, source: "stored", stored: 120, env: null, default: 50 },
+      }),
+    );
+    render(<SettingsSurface open onClose={() => {}} />);
+    const field = await screen.findByTestId("setting-max-attachments-mb");
+
+    fireEvent.change(field, { target: { value: "5000" } });
+    fireEvent.click(screen.getByTestId("settings-save"));
+    expect(await screen.findByTestId("settings-error")).toHaveTextContent(
+      /between 1 and 4096 MB/,
+    );
+    expect(updateSettingsMock).not.toHaveBeenCalled();
+
+    fireEvent.change(field, { target: { value: "120" } });
+    fireEvent.click(screen.getByTestId("settings-save"));
+    await waitFor(() => expect(updateSettingsMock).toHaveBeenCalledTimes(1));
+    expect(updateSettingsMock).toHaveBeenCalledWith({ max_attachments_mb: 120 });
   });
 
   it("names both price paths even though neither file exists", async () => {

--- a/frontend/src/components/SettingsSurface.tsx
+++ b/frontend/src/components/SettingsSurface.tsx
@@ -105,6 +105,8 @@ interface DraftValues {
   capStr: string;
   ttlStr: string;
   guardStr: string;
+  /** #779: the per-run attachment budget (MB), as typed. */
+  attachmentsStr: string;
   model: string | null;
   defaultHarness: string;
   agentChoice: AgentChoice | null;
@@ -124,6 +126,7 @@ function seedFrom(settings: InstanceSettings): DraftValues {
     capStr: String(settings.session_cap.effective),
     ttlStr: String(settings.reaper_ttl_secs.effective),
     guardStr: String(settings.guard_timeout_secs.effective),
+    attachmentsStr: String(settings.max_attachments_mb.effective),
     model: settings.default_model.effective,
     defaultHarness: settings.default_harness.effective ?? "",
     agentChoice: settings.agent_choice ?? null,
@@ -172,6 +175,9 @@ function computeDirty(values: DraftValues, settings: InstanceSettings): Set<Sett
   if (numericDirty(values.ttlStr, settings.reaper_ttl_secs.effective)) dirty.add("reaper-ttl");
   if (numericDirty(values.guardStr, settings.guard_timeout_secs.effective)) {
     dirty.add("guard-timeout");
+  }
+  if (numericDirty(values.attachmentsStr, settings.max_attachments_mb.effective)) {
+    dirty.add("max-attachments-mb");
   }
   if (values.autocompleteTurnEnd !== settings.autocomplete_turn_end.effective) {
     dirty.add("autocomplete-turn-end");
@@ -355,6 +361,17 @@ export default function SettingsSurface({
       }
     } else if (guard !== settings.guard_timeout_secs.effective) {
       patch.guard_timeout_secs = guard;
+    }
+
+    // #779: the attachment budget — the daemon refuses outside 1–4096 MB.
+    const attT = values.attachmentsStr.trim();
+    const att = Number(attT);
+    if (attT === "" || !Number.isInteger(att) || att < 1 || att > 4096) {
+      if (attT !== "" || rollup.fields.has("max-attachments-mb")) {
+        return { error: "Max attachments per run must be a whole number between 1 and 4096 MB." };
+      }
+    } else if (att !== settings.max_attachments_mb.effective) {
+      patch.max_attachments_mb = att;
     }
 
     // Model: `null` (Default) clears via the "" sentinel; a string sets it.
@@ -666,6 +683,20 @@ export default function SettingsSurface({
                         envVar="PDO_GUARD_TIMEOUT_MS"
                         unit=" ms"
                         envIsMs
+                      />
+                      {/* #779: one budget for images + files per Run. Bounds the
+                          multipart body of POST /runs; the New run dialog reads the
+                          same value for its client-side gate. */}
+                      <SettingRow
+                        id="max-attachments-mb"
+                        label="Max attachments per run (MB)"
+                        help="Total size of the images and files attached to a Run (New run dialog, `pdo run create --image/--file`). One budget per run; a single file may use all of it. 1–4096 MB."
+                        value={values.attachmentsStr}
+                        onChange={(v) => setField("attachmentsStr", v)}
+                        dirty={rollup.fields.has("max-attachments-mb")}
+                        field={settings.max_attachments_mb}
+                        envVar="PDO_MAX_ATTACHMENTS_MB"
+                        unit=" MB"
                       />
                     </Section>
                     <Section section={item.sections[2]}>

--- a/frontend/src/components/SettingsSurface.versionUpdate.test.tsx
+++ b/frontend/src/components/SettingsSurface.versionUpdate.test.tsx
@@ -54,6 +54,7 @@ function settings(): InstanceSettings {
     session_cap: { effective: 20, source: "default", stored: null, env: null, default: 20 },
     reaper_ttl_secs: { effective: 3600, source: "default", stored: null, env: null, default: 3600 },
     guard_timeout_secs: { effective: 60, source: "default", stored: null, env: null, default: 60 },
+    max_attachments_mb: { effective: 50, source: "default", stored: null, env: null, default: 50 },
     default_model: { effective: null, source: "default", stored: null, env: null, default: null },
     default_harness: { effective: null, source: "default", stored: null, env: null, default: null },
     default_harness_model: { effective: {}, stored: {} },

--- a/frontend/src/components/StartInspector.test.tsx
+++ b/frontend/src/components/StartInspector.test.tsx
@@ -12,14 +12,48 @@ vi.mock("../api", () => ({
 import StartInspector from "./StartInspector";
 import type { StartNodeInfo } from "../types";
 
-function makeStart(input_images: string[] = []): StartNodeInfo {
+function makeStart(input_images: string[] = [], input_files: string[] = []): StartNodeInfo {
   return {
     input_path: "_input/output.md",
     started_at: "2026-01-01T00:00:00.000Z",
     target_node_ids: ["work"],
     input_images,
+    input_files,
   };
 }
+
+describe("StartInspector — input files (#779)", () => {
+  beforeEach(() => {
+    fetchArtifactMock.mockReset();
+    fetchArtifactMock.mockResolvedValue("look at these");
+  });
+
+  it("lists one chip per non-image attachment, linking to its _input artifact", async () => {
+    render(
+      <StartInspector
+        startNode={makeStart(["proto.png"], ["SPEC-779.md", "fixtures.json"])}
+        runId="run-1"
+        nodeId="start"
+      />,
+    );
+    const section = await screen.findByTestId("start-inspector-files");
+    const chips = within(section).getAllByTestId("start-input-file");
+    expect(chips).toHaveLength(2);
+    expect(chips[0]).toHaveTextContent("MD");
+    expect(chips[0]).toHaveTextContent("SPEC-779.md");
+    expect(chips[0].getAttribute("href")).toBe(
+      "/runs/run-1/artifact?path=_input%2FSPEC-779.md",
+    );
+    // Images keep their own surface.
+    expect(within(screen.getByTestId("start-inspector-images")).getAllByTestId("start-input-thumbnail")).toHaveLength(1);
+  });
+
+  it("renders no file section when the run has none (or the field is absent)", async () => {
+    render(<StartInspector startNode={{ ...makeStart([]), input_files: undefined }} runId="run-1" nodeId="start" />);
+    await screen.findByText("look at these");
+    expect(screen.queryByTestId("start-inspector-files")).toBeNull();
+  });
+});
 
 describe("StartInspector — input images (issue #145)", () => {
   beforeEach(() => {

--- a/frontend/src/components/StartInspector.tsx
+++ b/frontend/src/components/StartInspector.tsx
@@ -11,6 +11,13 @@ interface Props {
   nodeId: string;
 }
 
+/** #779: the uppercase extension badge of an input-file chip. */
+function startFileBadge(name: string): string {
+  const dot = name.lastIndexOf(".");
+  if (dot <= 0 || dot === name.length - 1) return "FILE";
+  return name.slice(dot + 1).toUpperCase().slice(0, 4);
+}
+
 export default function StartInspector({ startNode, runId, nodeId }: Props) {
   const [inputText, setInputText] = useState<string | null>(null);
   const [modalOpen, setModalOpen] = useState(false);
@@ -20,6 +27,8 @@ export default function StartInspector({ startNode, runId, nodeId }: Props) {
 
   // Images uploaded with the run are stored in `_input/` alongside the prompt.
   const inputImages = startNode.input_images ?? [];
+  // #779: the non-image attachments, same folder.
+  const inputFiles = startNode.input_files ?? [];
 
   useEffect(() => {
     let cancelled = false;
@@ -119,6 +128,41 @@ export default function StartInspector({ startNode, runId, nodeId }: Props) {
                   </button>
                 );
               })}
+            </div>
+          </div>
+        )}
+
+        {inputFiles.length > 0 && (
+          <div className="mt-3" data-testid="start-inspector-files">
+            <div
+              className="mb-2 text-fg-3"
+              style={{ fontSize: "11px", fontWeight: 500 }}
+            >
+              Input files
+            </div>
+            <div className="flex flex-wrap gap-1.5">
+              {inputFiles.map((name) => (
+                <a
+                  key={name}
+                  href={artifactUrl(runId, `_input/${name}`)}
+                  target="_blank"
+                  rel="noreferrer"
+                  title={name}
+                  className="flex h-9 max-w-[220px] items-center gap-1.5 rounded border border-line bg-bg-0 px-1.5 transition-colors hover:border-fg-4"
+                  data-testid="start-input-file"
+                >
+                  <span
+                    className="grid h-6 w-6 flex-shrink-0 place-items-center rounded border border-line bg-bg-3 font-mono font-medium text-fg-3"
+                    style={{ fontSize: "7.5px" }}
+                    aria-hidden="true"
+                  >
+                    {startFileBadge(name)}
+                  </span>
+                  <span className="truncate text-fg-2" style={{ fontSize: "10.5px" }}>
+                    {name}
+                  </span>
+                </a>
+              ))}
             </div>
           </div>
         )}

--- a/frontend/src/components/settingsCategories.ts
+++ b/frontend/src/components/settingsCategories.ts
@@ -160,6 +160,7 @@ export type SettingsFieldId =
   | "session-cap"
   | "reaper-ttl"
   | "guard-timeout"
+  | "max-attachments-mb"
   | "autocomplete-turn-end"
   | "default-auto-name"
   | "review-agent-can-resolve"
@@ -177,6 +178,7 @@ export const FIELD_SECTION: Record<SettingsFieldId, SettingsSectionId> = {
   "session-cap": "runtime-limits",
   "reaper-ttl": "runtime-limits",
   "guard-timeout": "runtime-limits",
+  "max-attachments-mb": "runtime-limits",
   "autocomplete-turn-end": "runs",
   "default-auto-name": "runs",
   "review-agent-can-resolve": "runs",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1058,3 +1058,14 @@ body {
 .pdo-review-flash {
   animation: pdo-review-flash 2.4s ease-out;
 }
+
+/* #779: the attachments zone flashes once when a drop is refused. */
+@keyframes pdo-attach-shake {
+  0%, 100% { transform: translateX(0); }
+  25% { transform: translateX(-3px); }
+  50% { transform: translateX(3px); }
+  75% { transform: translateX(-2px); }
+}
+.pdo-attach-shake {
+  animation: pdo-attach-shake 300ms ease-in-out;
+}

--- a/frontend/src/lib/attachments.ts
+++ b/frontend/src/lib/attachments.ts
@@ -1,0 +1,56 @@
+/** The « New run » attachments zone (#779): the pure rules the modal applies. */
+
+/** #779: the built-in per-run attachment budget, used until `GET /settings` answers. */
+export const DEFAULT_MAX_ATTACHMENTS_MB = 50;
+
+/** `18 KB`, `2.4 MB` — the sizes the attachment chips and counter show (#779). */
+export function formatAttachmentSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/** The uppercase extension badge of a non-image chip: `MD`, `JSON`, `PARQ` (≤ 4 chars). */
+export function attachmentBadge(name: string): string {
+  const dot = name.lastIndexOf(".");
+  if (dot <= 0 || dot === name.length - 1) return "FILE";
+  return name.slice(dot + 1).toUpperCase().slice(0, 4);
+}
+
+/** The result of merging a drop into the current attachments (#779). Pure, so the
+ *  refusal rules are testable without a DOM: same name ⇒ replace the earlier one;
+ *  a file that would push the total over the budget is refused, the rest of the
+ *  same drop is still added. */
+export function mergeAttachments(
+  current: File[],
+  incoming: File[],
+  maxBytes: number,
+): { next: File[]; replaced: string[]; refused: File[] } {
+  let next = [...current];
+  const replaced: string[] = [];
+  const refused: File[] = [];
+  for (const file of incoming) {
+    const dup = next.findIndex((f) => f.name === file.name);
+    const without = dup >= 0 ? next.filter((_, i) => i !== dup) : next;
+    const total = without.reduce((sum, f) => sum + f.size, 0) + file.size;
+    if (total > maxBytes) {
+      refused.push(file);
+      continue;
+    }
+    if (dup >= 0) replaced.push(file.name);
+    next = dup >= 0 ? [...without.slice(0, dup), file, ...without.slice(dup)] : [...without, file];
+  }
+  return { next, replaced, refused };
+}
+
+/** Indices of the attachments sitting past the budget line (total already over,
+ *  e.g. after the limit was lowered in Settings). Cumulative, in display order. */
+export function overLimitIndices(attachments: File[], maxBytes: number): Set<number> {
+  const over = new Set<number>();
+  let running = 0;
+  attachments.forEach((f, i) => {
+    running += f.size;
+    if (running > maxBytes) over.add(i);
+  });
+  return over;
+}

--- a/frontend/src/lib/newRunForm.test.ts
+++ b/frontend/src/lib/newRunForm.test.ts
@@ -35,6 +35,7 @@ function settings(over: Partial<InstanceSettings> = {}): InstanceSettings {
     session_cap: { effective: 20, source: "default", stored: null, env: null, default: 20 },
     reaper_ttl_secs: { effective: 3600, source: "default", stored: null, env: null, default: 3600 },
     guard_timeout_secs: { effective: 60, source: "default", stored: null, env: null, default: 60 },
+    max_attachments_mb: { effective: 50, source: "default", stored: null, env: null, default: 50 },
     default_model: { effective: null, source: "default", stored: null, env: null, default: null },
     default_harness: { effective: null, source: "default", stored: null, env: null, default: null },
     default_harness_model: { effective: {}, stored: {} },
@@ -144,7 +145,7 @@ describe("buildVariables", () => {
       runName: "",
       sandbox: "",
       harness: "",
-      images: [],
+      attachments: [],
     };
     const triggerFields = {
       selectedPipeline: declared,
@@ -547,7 +548,10 @@ describe("buildRunPayload", () => {
     runName: "  Fix bug  ",
     sandbox: "full",
     harness: "",
-    images: [new File(["png"], "design.png", { type: "image/png" })],
+    attachments: [
+      new File(["png"], "design.png", { type: "image/png" }),
+      new File(["{}"], "fixtures.json", { type: "application/json" }),
+    ],
   };
 
   /**
@@ -573,6 +577,8 @@ describe("buildRunPayload", () => {
       sandbox: "full",
     });
     expect(buildRunPayload(fields).images).toHaveLength(1);
+    expect(buildRunPayload(fields).files).toHaveLength(1);
+    expect(buildRunPayload(fields).files?.[0].name).toBe("fixtures.json");
   });
 
   // #338: the box wins over whatever is left in the name field — the daemon never has to
@@ -590,7 +596,7 @@ describe("buildRunPayload", () => {
       runName: "   ",
       targetRepo: "  ",
       sourceBranch: "",
-      images: [],
+      attachments: [],
     });
     expect(payload.name).toBeUndefined();
     expect(payload.target_repo).toBeUndefined();

--- a/frontend/src/lib/newRunForm.ts
+++ b/frontend/src/lib/newRunForm.ts
@@ -362,7 +362,9 @@ export interface RunPayloadInput {
   harness: string;
   /** #669: the Run tier of the skills selection. Empty ⇒ the key is omitted. */
   skills?: SkillRef[];
-  images: File[];
+  /** #779: every attachment of the modal, images and files alike. Split by MIME at
+   *  build time: `image/*` → `images`, the rest → `files`. */
+  attachments: File[];
   /** #465: `[0]` = primary, `[1..]` = secondaries. Omit / `undefined` for a mono-repo Run. */
   targetRepos?: TargetRepoInput[];
 }
@@ -378,9 +380,11 @@ export function buildRunPayload({
   sandbox,
   harness,
   skills,
-  images,
+  attachments,
   targetRepos,
 }: RunPayloadInput): CreateRunRequest {
+  const images = attachments.filter(isImageAttachment);
+  const files = attachments.filter((f) => !isImageAttachment(f));
   return {
     pipeline: selectedPipeline.name,
     input: input.trim(),
@@ -408,7 +412,13 @@ export function buildRunPayload({
     // Run adds none and the payload stays byte-identical to the pre-#669 shape.
     skills: skills && skills.length > 0 ? skills : undefined,
     images: images.length > 0 ? images : undefined,
+    files: files.length > 0 ? files : undefined,
   };
+}
+
+/** #779: an attachment is an image when its MIME type says so (`image/*`). */
+export function isImageAttachment(file: File): boolean {
+  return file.type.startsWith("image/");
 }
 
 /** The form values a Trigger create / edit reads. */

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -247,6 +247,9 @@ export interface InstanceSettings {
   session_cap: SettingField;
   reaper_ttl_secs: SettingField;
   guard_timeout_secs: SettingField;
+  /** #779: images + files budget per Run, in MB (`stored → env → default 50`). Bounds the
+   *  multipart body of `POST /runs` and drives the « New run » modal's client-side gate. */
+  max_attachments_mb: SettingField;
   default_model: StringSettingField;
   /** #550/ADR-0046: instance-wide default harness (`stored → env → floor claude`).
    *  `effective: null` ⇒ the `claude` floor applies at resolve. */
@@ -470,6 +473,8 @@ export interface UpdateSettingsRequest {
   session_cap?: number;
   reaper_ttl_secs?: number;
   guard_timeout_secs?: number;
+  /** #779: per-run attachment budget in MB (1–4096). */
+  max_attachments_mb?: number;
   default_model?: string;
   /** #550: instance default harness; `""` clears it (same sentinel as
    *  `default_model`). */
@@ -948,6 +953,9 @@ export interface StartNodeInfo {
   // Filenames of images uploaded alongside the text prompt (stored in
   // `_input/`). Empty when the run was launched without images (issue #145).
   input_images: string[];
+  // Filenames of the NON-image files uploaded alongside the prompt (#779),
+  // also stored in `_input/`. Empty when the run was launched without files.
+  input_files?: string[];
 }
 
 export interface EndPortStatus {


### PR DESCRIPTION
Closes #779.

- \`pdo run create\` gains \`--input-file\`, \`--image\` and \`--file\`; provenance kept from a node session.
- \`POST /runs\` multipart accepts a \`files\` part; attachments land in \`_input/\`, are listed in the entry-node preamble and node I/O, duplicates and the reserved \`output.md\` name are refused (400).
- New Run modal accepts non-image files, splits \`images\`/\`files\`, shows the per-run attachment budget (new \`max_attachments_mb\` setting, 1–4096 MB, 413 on overflow).
- Seeded \`pdo-orchestrate\` skill documents the flags (\`skill_version: 2\`).
- Version bumped 1.82.3 -> 1.83.0.

Agentic tests: all 7 FPs pass against a real daemon (see run artifact). Non-blocking follow-ups noted: close-warning copy vs draft restore, budget not refreshed live while the modal is open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)