### PR TITLE
fix(ui): default theme without stored preference is dark, not system (#781) — release 1.83.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "1.83.0"
+version = "1.83.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "1.83.0"
+version = "1.83.1"
 license = "MIT"
 description = "Prompt-Driven Orchestrator — a local daemon that runs and supervises agentic coding pipelines"
 repository = "https://github.com/Loulen/prompt-driven-orchestrator"

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -20,8 +20,18 @@
         try {
           osDark = matchMedia("(prefers-color-scheme: dark)").matches;
         } catch (e) {}
+        // Same rule as lib/theme.ts (#781): a stored light/dark/system is
+        // honoured (system resolves against the OS); anything else — nothing
+        // stored, unknown value — falls back to DARK, the look PDO has always
+        // had, whatever the OS asks for.
         var theme =
-          stored === "light" || stored === "dark" ? stored : osDark ? "dark" : "light";
+          stored === "light" || stored === "dark"
+            ? stored
+            : stored === "system"
+              ? osDark
+                ? "dark"
+                : "light"
+              : "dark";
         document.documentElement.setAttribute("data-theme", theme);
         document.documentElement.style.colorScheme = theme;
       } catch (e) {}

--- a/frontend/src/components/SettingsSurface.tsx
+++ b/frontend/src/components/SettingsSurface.tsx
@@ -1340,8 +1340,9 @@ function InterfaceSection({ section }: { section: SettingsSection }) {
         </div>
         <ThemeSelect />
         <div className="text-fg-3" style={{ fontSize: "10.5px" }}>
-          System follows your operating system's light/dark setting and keeps following it.
-          Light and dark pin PDO, whatever the system does.
+          With nothing chosen, PDO paints dark — the look it has always had.
+          System follows your operating system's light/dark setting and keeps
+          following it. Light and dark pin PDO, whatever the system does.
         </div>
       </div>
       <div className="flex flex-col gap-1.5">

--- a/frontend/src/components/ThemeSelect.test.tsx
+++ b/frontend/src/components/ThemeSelect.test.tsx
@@ -31,11 +31,11 @@ describe("ThemeSelect — choosing a theme (#759)", () => {
     expect(screen.getAllByRole("radio")).toHaveLength(3);
   });
 
-  it("checks the active preference and only that one", () => {
+  it("checks the active preference and only that one (#781: dark by default)", () => {
     render(<ThemeSelect />);
-    expect(screen.getByTestId("theme-option-system")).toHaveAttribute("aria-checked", "true");
+    expect(screen.getByTestId("theme-option-dark")).toHaveAttribute("aria-checked", "true");
     expect(screen.getByTestId("theme-option-light")).toHaveAttribute("aria-checked", "false");
-    expect(screen.getByTestId("theme-option-dark")).toHaveAttribute("aria-checked", "false");
+    expect(screen.getByTestId("theme-option-system")).toHaveAttribute("aria-checked", "false");
   });
 
   it("repaints the document and persists the choice on click", async () => {
@@ -68,21 +68,21 @@ describe("ThemeSelect — choosing a theme (#759)", () => {
 describe("ThemeSelect — keyboard (#759)", () => {
   it("puts one tab stop on the group: only the checked option is tabbable", () => {
     render(<ThemeSelect />);
-    expect(screen.getByTestId("theme-option-system")).toHaveAttribute("tabindex", "0");
+    expect(screen.getByTestId("theme-option-dark")).toHaveAttribute("tabindex", "0");
     expect(screen.getByTestId("theme-option-light")).toHaveAttribute("tabindex", "-1");
-    expect(screen.getByTestId("theme-option-dark")).toHaveAttribute("tabindex", "-1");
+    expect(screen.getByTestId("theme-option-system")).toHaveAttribute("tabindex", "-1");
   });
 
   it("moves and selects with the arrow keys, wrapping around", async () => {
     const user = userEvent.setup();
     render(<ThemeSelect />);
     await user.tab();
-    expect(screen.getByTestId("theme-option-system")).toHaveFocus();
+    expect(screen.getByTestId("theme-option-dark")).toHaveFocus();
     await user.keyboard("{ArrowRight}");
-    expect(screen.getByTestId("theme-option-light")).toHaveAttribute("aria-checked", "true");
-    expect(screen.getByTestId("theme-option-light")).toHaveFocus();
-    await user.keyboard("{ArrowLeft}");
     expect(screen.getByTestId("theme-option-system")).toHaveAttribute("aria-checked", "true");
+    expect(screen.getByTestId("theme-option-system")).toHaveFocus();
+    await user.keyboard("{ArrowLeft}");
+    expect(screen.getByTestId("theme-option-dark")).toHaveAttribute("aria-checked", "true");
   });
 
   it("selects with Home and End", async () => {

--- a/frontend/src/hooks/useTheme.test.ts
+++ b/frontend/src/hooks/useTheme.test.ts
@@ -32,13 +32,13 @@ afterEach(() => {
 });
 
 describe("useTheme (#759)", () => {
-  it("starts on the OS preference when nothing is stored", () => {
+  it("starts dark when nothing is stored, whatever the OS asks (#781)", () => {
     stubOs(false);
     initTheme();
     const { result } = renderHook(() => useTheme());
-    expect(result.current.preference).toBe("system");
-    expect(result.current.resolved).toBe("light");
-    expect(document.documentElement.getAttribute("data-theme")).toBe("light");
+    expect(result.current.preference).toBe("dark");
+    expect(result.current.resolved).toBe("dark");
+    expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
   });
 
   it("starts on the stored choice, whatever the OS says", () => {
@@ -64,6 +64,9 @@ describe("useTheme (#759)", () => {
     const os = stubOs(true);
     initTheme();
     const { result } = renderHook(() => useTheme());
+    // #781: nothing stored now pins `dark` — following the OS requires an
+    // explicit `system` choice.
+    act(() => result.current.setPreference("system"));
     expect(result.current.resolved).toBe("dark");
     act(() => os.flip(false));
     expect(result.current.resolved).toBe("light");

--- a/frontend/src/hooks/useTheme.ts
+++ b/frontend/src/hooks/useTheme.ts
@@ -30,7 +30,10 @@ export interface ThemeSnapshot {
   systemResolved: ResolvedTheme;
 }
 
-let snapshot: ThemeSnapshot = { preference: "system", resolved: "dark", systemResolved: "dark" };
+// Pre-`initTheme()` placeholder. The default preference is `dark` (#781) — the
+// look PDO has always had — and the OS answer defaults to dark too (see
+// `systemPrefersDark`), so the placeholder resolves dark on every axis.
+let snapshot: ThemeSnapshot = { preference: "dark", resolved: "dark", systemResolved: "dark" };
 
 function computeSnapshot(preference: ThemePreference): ThemeSnapshot {
   const systemDark = systemPrefersDark();

--- a/frontend/src/lib/theme.test.ts
+++ b/frontend/src/lib/theme.test.ts
@@ -30,20 +30,20 @@ describe("theme preference — persistence (#759)", () => {
     expect(localStorage.getItem("pdo.ui.theme")).toBe("light");
   });
 
-  it("defaults to system when nothing is stored", () => {
-    expect(loadThemePreference()).toBe("system");
+  it("defaults to dark when nothing is stored (#781)", () => {
+    expect(loadThemePreference()).toBe("dark");
   });
 
-  it("defaults to system for an unknown stored value", () => {
+  it("defaults to dark for an unknown stored value", () => {
     localStorage.setItem("pdo.ui.theme", "solarized");
-    expect(loadThemePreference()).toBe("system");
+    expect(loadThemePreference()).toBe("dark");
   });
 
-  it("degrades to system when getItem throws (private mode)", () => {
+  it("degrades to dark when getItem throws (private mode)", () => {
     vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
       throw new Error("SecurityError");
     });
-    expect(loadThemePreference()).toBe("system");
+    expect(loadThemePreference()).toBe("dark");
   });
 
   it("swallows a throwing setItem (quota / disabled) without raising", () => {

--- a/frontend/src/lib/theme.ts
+++ b/frontend/src/lib/theme.ts
@@ -8,8 +8,11 @@
  * and write so private mode / a disabled or full store degrades to an in-memory
  * default for the session instead of throwing.
  *
- * `system` is the default (the ticket's recommendation): PDO follows the OS
- * rather than imposing a look. An explicit `light` / `dark` pins it.
+ * `dark` is the default (#781): PDO has always had the dark look, so a client
+ * with no stored preference paints dark whatever the OS asks — a light-mode OS
+ * must not silently restyle the app on first paint. `system` stays available
+ * in Settings for whoever wants to follow the OS; an explicit `light` / `dark`
+ * pins it.
  */
 
 export const THEME_STORAGE_KEY = "pdo.ui.theme";
@@ -26,13 +29,13 @@ function isThemePreference(v: unknown): v is ThemePreference {
   return typeof v === "string" && (PREFERENCES as readonly string[]).includes(v);
 }
 
-/** Stored preference. Absent / unknown / unreadable → `system`. */
+/** Stored preference. Absent / unknown / unreadable → `dark` (#781). */
 export function loadThemePreference(): ThemePreference {
   try {
     const raw = localStorage.getItem(THEME_STORAGE_KEY);
-    return isThemePreference(raw) ? raw : "system";
+    return isThemePreference(raw) ? raw : "dark";
   } catch {
-    return "system";
+    return "dark";
   }
 }
 

--- a/frontend/src/noFlashTheme.test.ts
+++ b/frontend/src/noFlashTheme.test.ts
@@ -46,7 +46,7 @@ describe("index.html theme guard (#759)", () => {
     for (const stored of ["light", "dark", "system", null, "nonsense"]) {
       for (const osDark of [true, false]) {
         const preference = (
-          ["light", "dark", "system"].includes(stored ?? "") ? stored : "system"
+          ["light", "dark", "system"].includes(stored ?? "") ? stored : "dark"
         ) as ThemePreference;
         expect({ stored, osDark, got: runGuard(stored, osDark) }).toEqual({
           stored,


### PR DESCRIPTION
Closes #781.

Without a stored preference, PDO used to follow the OS (`system` fallback, #759): on a light-mode machine the app painted light on first paint. The fallback is now **dark** — the look PDO has always had — whatever the OS asks for.

- `loadThemePreference()` (`frontend/src/lib/theme.ts`): absent / unknown / unreadable stored value → `dark`; docstring updated.
- `index.html` inline anti-FOUC guard duplicates the same rule (nothing stored, `system` resolution, unknown value → dark); `noFlashTheme.test.ts` still asserts the two agree.
- `useTheme.ts` initial snapshot resolved to `dark`.
- `ThemeSelect` / `SettingsSurface`: default option and System hint coherent (System still available and labelled with the OS theme it would paint).
- Tests updated: `theme.test.ts`, `useTheme.test.ts`, `noFlashTheme.test.ts`, `ThemeSelect.test.tsx` — 32/32 green.

Explicit `light` / `dark` / `system` choices are untouched; `system` remains available in Settings for whoever wants to follow the OS.

Agentic tests: all FPs of #781 pass against the worktree frontend (see run artifact); the pre-fix build under identical conditions paints light — the exact bug.

Version bumped 1.83.0 -> 1.83.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
