### PR TITLE
fix(scheduler): dedup Spawn per (target, iter); duplicate-session loser is benign (#785) — 1.83.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "1.83.1"
+version = "1.83.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "1.83.1"
+version = "1.83.2"
 license = "MIT"
 description = "Prompt-Driven Orchestrator — a local daemon that runs and supervises agentic coding pipelines"
 repository = "https://github.com/Loulen/prompt-driven-orchestrator"

--- a/crates/pdo-daemon/src/event_log.rs
+++ b/crates/pdo-daemon/src/event_log.rs
@@ -4451,6 +4451,33 @@ mod tests {
         assert_eq!(state.nodes["planner"].status, NodeStatus::Running);
     }
 
+    /// #785 / ADR-0050 §2: the redundant `NodeStarted` a losing duplicate spawn
+    /// appends on the SAME `(node, iter)` re-stamps the winner's live row — it
+    /// never opens a phantom second iteration.
+    #[test]
+    fn duplicate_node_started_on_same_iter_keeps_one_live_iteration() {
+        let mut loser = make_event(EventKind::NodeStarted, Some("a"), Some(1));
+        loser.ts = "2026-01-01T00:00:00.040Z".into();
+        let events = vec![
+            make_event(EventKind::RunStarted, None, None),
+            make_event(EventKind::NodeStarted, Some("a"), Some(1)),
+            loser,
+        ];
+
+        let state = project(&events).unwrap();
+        let node = &state.nodes["a"];
+        assert_eq!(
+            node.iterations.len(),
+            1,
+            "no phantom iteration: {:?}",
+            node.iterations
+        );
+        assert_eq!(node.iterations[0].iter, 1);
+        assert_eq!(node.iterations[0].status, NodeStatus::Running);
+        assert_eq!(node.status, NodeStatus::Running);
+        assert_eq!(state.status, RunStatus::Running);
+    }
+
     #[test]
     fn sessions_spawned_counts_raw_node_started_not_distinct_iters() {
         // #100: `sessions_spawned` is the RAW count of `NodeStarted` events, so

--- a/crates/pdo-daemon/src/node_spawn.rs
+++ b/crates/pdo-daemon/src/node_spawn.rs
@@ -286,7 +286,10 @@ pub(crate) enum SpawnOutcome {
     /// appended); `retry_waiting_nodes` re-drives it later.
     Throttled,
     /// The transition guard refused the spawn before any side effect
-    /// (already live / already completed iteration).
+    /// (already live / already completed iteration) — or the spawn turned out to
+    /// be the **benign loser** of a duplicate: the same `(node, iter)` already
+    /// owns a live tmux session (#785 / ADR-0050 §2). Either way the work is
+    /// live or done and there is nothing to retry.
     Refused { reason: String },
     /// The Run is sandboxed and its container is not up yet (#445): the spawn was
     /// declined before any side effect and **no event was appended**, so the node
@@ -340,6 +343,33 @@ pub(crate) async fn spawn_node(
             let reason = reason.to_string();
             warn!("spawn_node refused for {} iter {iter}: {reason}", node.id);
             return SpawnOutcome::Refused { reason };
+        }
+    }
+
+    // #785 / ADR-0050 §2 — the BENIGN LOSER, caught before any side effect. The
+    // guard above admits a `NodeStarted` on an iteration that is already live
+    // (a "legal restart": `restart_node` / `retry_node` kill the session FIRST, so
+    // for them the session is gone by the time they get here). A second spawn of
+    // the same `(node, iter)` whose tmux session is STILL ALIVE is not a restart:
+    // it is a racing duplicate (two edges to one target, a `resume_run` ↔ sweep
+    // race, …) and the winner owns the iteration. Refuse it here — no redundant
+    // `NodeStarted`, no sub-worktree work, and above all no `spawn_aborted`
+    // parking of a run whose winner is healthy. The post-`NodeStarted` branch on
+    // the tmux error below covers the residual window where both spawns pass this
+    // probe before either creates its session.
+    if let Some(state) = projected {
+        if transition_guard::live_iteration(state, &node.id) == Some(iter) {
+            let session_name = tmux_session_manager::node_session_name(run_id, &node.id, iter);
+            let socket = tmux_session_manager::tmux_socket_name(deps.port);
+            if tmux_session_manager::session_exists(&socket, &session_name) {
+                let reason = format!(
+                    "node {} iter {iter} already has a live session {session_name}: \
+                     duplicate spawn is a benign no-op (ADR-0050 §2)",
+                    node.id
+                );
+                warn!("Run {run_id}: {reason}");
+                return SpawnOutcome::Refused { reason };
+            }
         }
     }
 
@@ -1349,6 +1379,29 @@ pub(crate) async fn spawn_node(
         sandbox_wrap.as_ref(),
         inject_hook,
     ) {
+        // #785 / ADR-0050 §2: `duplicate session` while the session of this very
+        // `(run, node, iter)` is alive means a WINNER already runs this iteration —
+        // this spawn is the benign loser, never a failure. No `NodeInterrupted`, no
+        // `RunInterrupted`: parking the run `spawn_aborted` over a healthy winner
+        // is exactly what the ADR forbids (and what made "Reopen" fail ten times
+        // in a row on the pipeline `grill-with-docs`). The redundant `NodeStarted`
+        // this loser appended is harmless to the projection: `upsert_iteration`
+        // keeps ONE iteration row per `(node, iter)`, so it re-stamps the winner's
+        // live row rather than opening a phantom one. Nothing is reaped either —
+        // the sub-worktree, if any, is the winner's.
+        let msg = format!("{e:#}");
+        if msg.contains("duplicate session") {
+            let socket = tmux_session_manager::tmux_socket_name(deps.port);
+            if tmux_session_manager::session_exists(&socket, &session_name) {
+                let reason = format!(
+                    "node {} iter {iter}: tmux reported duplicate session {session_name} \
+                     and it is alive — losing spawn is a benign no-op (ADR-0050 §2)",
+                    node.id
+                );
+                warn!("Run {run_id}: {reason}");
+                return SpawnOutcome::Refused { reason };
+            }
+        }
         // #508: the tmux spawn itself failed *after* `NodeStarted` is durable. It
         // used to be swallowed (`error!` + fall through), leaving the node
         // projected `Running` with NO session — the liveness sweep then rewrote it

--- a/crates/pdo-daemon/src/sandbox_container.rs
+++ b/crates/pdo-daemon/src/sandbox_container.rs
@@ -1969,7 +1969,9 @@ mod tests {
     fn binary_present_in_container_true_on_zero_exit() {
         let tmp = tempfile::tempdir().unwrap();
         let (docker, log) = write_fake_docker(tmp.path(), &FakeSpec::default());
-        assert!(binary_present_in_container(&docker, "r1", 1000, 1000, "pi").unwrap());
+        assert!(
+            retry_etxtbsy(|| binary_present_in_container(&docker, "r1", 1000, 1000, "pi")).unwrap()
+        );
         // It really ran a `docker exec` (never the binary itself).
         assert!(log_lines(&log).contains(&"exec".to_string()));
     }
@@ -1984,7 +1986,10 @@ mod tests {
             ..FakeSpec::default()
         };
         let (docker, _log) = write_fake_docker(tmp.path(), &spec);
-        assert!(!binary_present_in_container(&docker, "r1", 1000, 1000, "pi").unwrap());
+        assert!(
+            !retry_etxtbsy(|| binary_present_in_container(&docker, "r1", 1000, 1000, "pi"))
+                .unwrap()
+        );
     }
 
     /// A container that is gone / not running is NOT a binary absence: it is an `Err`,
@@ -1998,7 +2003,8 @@ mod tests {
             ..FakeSpec::default()
         };
         let (docker, _log) = write_fake_docker(tmp.path(), &spec);
-        let err = binary_present_in_container(&docker, "r1", 1000, 1000, "pi").unwrap_err();
+        let err = retry_etxtbsy(|| binary_present_in_container(&docker, "r1", 1000, 1000, "pi"))
+            .unwrap_err();
         assert!(format!("{err:#}").contains("cannot answer a binary probe"));
     }
 

--- a/crates/pdo-daemon/src/scheduler.rs
+++ b/crates/pdo-daemon/src/scheduler.rs
@@ -464,10 +464,20 @@ pub(crate) fn evaluate_outgoing_edges_full(
                                 });
                             }
                         }
-                        actions.push(SchedulerAction::Spawn {
+                        // #785: two edges of this producer wired to the SAME target
+                        // (e.g. `out` and `Chosen design` both → the loop input) must
+                        // yield ONE `Spawn`, exactly as the adjacent `LoopIterStarted`
+                        // is deduplicated. Without this, the completion path (which
+                        // runs `SpawnDedup::InternalOnly`) drove two spawns of the
+                        // same `(node, iter)`: the loser hit tmux `duplicate session`
+                        // and parked the run `spawn_aborted` over a live winner.
+                        let spawn = SchedulerAction::Spawn {
                             node_id: target_id.clone(),
                             iter: next_iter,
-                        });
+                        };
+                        if !actions.contains(&spawn) {
+                            actions.push(spawn);
+                        }
                     }
                 }
             }
@@ -2252,6 +2262,44 @@ mod tests {
             node_id: "c".into(),
             iter: 1,
         }));
+    }
+
+    /// #785: a producer whose TWO fired edges both land on the same target
+    /// (two output ports wired to one input, `in · repeated` in the UI) produces
+    /// ONE `Spawn` — never two spawns of the same `(node, iter)`.
+    #[test]
+    fn two_edges_to_the_same_target_spawn_it_once() {
+        let pipeline = PipelineDef {
+            name: "double-wire".into(),
+            version: None,
+            variables: HashMap::new(),
+            nodes: vec![
+                make_node("prototype", &["task"], &["out", "chosen"]),
+                make_node("implementer", &["in"], &["out"]),
+            ],
+            edges: vec![
+                make_edge("prototype", "out", "implementer", "in"),
+                make_edge("prototype", "chosen", "implementer", "in"),
+            ],
+            loops: Vec::new(),
+            notes: Vec::new(),
+            prompt_required: true,
+        };
+
+        let mut state = empty_run_state();
+        state
+            .nodes
+            .insert("prototype".into(), completed_node("prototype"));
+
+        let actions = evaluate_outgoing_edges(&pipeline, &state, "prototype");
+        assert_eq!(
+            actions,
+            vec![SchedulerAction::Spawn {
+                node_id: "implementer".into(),
+                iter: 1,
+            }],
+            "two edges to one target must not double-spawn it"
+        );
     }
 
     #[test]

--- a/crates/pdo-daemon/src/transition_guard.rs
+++ b/crates/pdo-daemon/src/transition_guard.rs
@@ -147,7 +147,7 @@ fn iteration_status(state: &RunState, node_id: &str, iter: i64) -> Option<NodeSt
 /// The iteration currently holding (or owed) a live agent session for this
 /// node, if any: `Running` or `AwaitingUser` iteration rows, or the node-level
 /// `Waiting` marker (throttled, no iteration row yet — #159).
-fn live_iteration(state: &RunState, node_id: &str) -> Option<i64> {
+pub(crate) fn live_iteration(state: &RunState, node_id: &str) -> Option<i64> {
     let node = state.nodes.get(node_id)?;
     if node.status == NodeStatus::Waiting {
         return Some(node.iter);

--- a/crates/pdo-daemon/tests/tmux_lifecycle.rs
+++ b/crates/pdo-daemon/tests/tmux_lifecycle.rs
@@ -800,6 +800,116 @@ async fn force_spawn_reserves_before_it_spawns() {
     std::env::remove_var(tmux_session_manager::REAPER_INTERVAL_SECS_ENV);
 }
 
+/// #785 / ADR-0050 §2: a spawn that loses to a live session of the SAME
+/// `(run, node, iter)` — tmux answers `duplicate session` — is a **benign
+/// no-op**. Driven through the path the issue names: the completion of the
+/// upstream node, whose scheduler `Spawn` lands in `spawn_node`. It must append
+/// neither `NodeInterrupted` nor `RunInterrupted`, the run stays `running`, the
+/// winner's session stays alive, and the projection keeps exactly one iteration
+/// for the node. Before the fix the loser parked the run `spawn_aborted` over a
+/// healthy winner, and every "Reopen" re-drove the same collision.
+#[tokio::test]
+// Intentional: the guard must span the `.await`s so env-var-sensitive reaper
+// tests can't race.
+#[allow(clippy::await_holding_lock)]
+async fn duplicate_session_loser_is_a_benign_no_op() {
+    if !tmux_available() {
+        eprintln!("tmux not on PATH — skipping");
+        return;
+    }
+    let _serial = serial_guard();
+
+    std::env::set_var(tmux_session_manager::REAPER_TTL_SECS_ENV, "3600");
+    std::env::set_var(tmux_session_manager::REAPER_INTERVAL_SECS_ENV, "3600");
+
+    let daemon = TestDaemon::spawn(seed_two_node).await.unwrap();
+    let socket = daemon.tmux_socket();
+    let run_id = create_run_of(&daemon, TWO_NODE_PIPELINE).await;
+    let worker = tmux_session_manager::node_session_name(&run_id, "worker", 1);
+    assert!(
+        wait_for_session(&socket, &worker, Duration::from_secs(5)).await,
+        "pre-condition: the entry node should be running"
+    );
+
+    // The "winner": a live session already holding the exact name the spawn of
+    // `second` iter 1 will claim. Its `NodeStarted` is not on the log yet, so the
+    // pre-`NodeStarted` probe cannot catch this — it exercises the post-failure
+    // `duplicate session` branch, the residual-race net.
+    let second = tmux_session_manager::node_session_name(&run_id, "second", 1);
+    create_fake_tmux_session(&socket, &second);
+    assert!(
+        tmux_has_session(&socket, &second),
+        "pre-condition: winner alive"
+    );
+
+    // Complete `worker` → the scheduler spawns `second` iter 1 → collision.
+    let port_dir = daemon
+        .repo_root()
+        .join(".pdo/runs")
+        .join(&run_id)
+        .join("worktree/.pdo/artifacts/worker/iter-1/out");
+    std::fs::create_dir_all(&port_dir).unwrap();
+    std::fs::write(port_dir.join("output.md"), "# Output\nDone.").unwrap();
+    let resp = reqwest::Client::new()
+        .post(format!("{}/runs/{run_id}/nodes/worker/done", daemon.url()))
+        .json(&serde_json::json!({ "iter": 1 }))
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.status().is_success(), "node done: {}", resp.status());
+
+    // The completion handler is fire-and-forget: wait for the loser's
+    // `NodeStarted` to land, then give the tmux failure branch a beat.
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while std::time::Instant::now() < deadline
+        && !node_started_is_recorded(&daemon, &run_id, "second", 1).await
+    {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    assert!(
+        node_started_is_recorded(&daemon, &run_id, "second", 1).await,
+        "pre-condition: the completion should have driven a spawn of `second`"
+    );
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let events = run_events(&daemon, &run_id).await;
+    let interrupting: Vec<&serde_json::Value> = events
+        .iter()
+        .filter(|e| e["kind"] == "node_interrupted" || e["kind"] == "run_interrupted")
+        .collect();
+    assert!(
+        interrupting.is_empty(),
+        "#785 REGRESSION: the loser parked the run over a live winner: {interrupting:?}"
+    );
+    assert!(
+        tmux_has_session(&socket, &second),
+        "the winner's session must survive the losing spawn"
+    );
+
+    let run = reqwest::get(format!("{}/runs/{run_id}", daemon.url()))
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    assert_eq!(run["status"], "running", "run state was: {run}");
+    let iterations = run["nodes"]["second"]["iterations"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    assert_eq!(
+        iterations.len(),
+        1,
+        "exactly one live iteration for the node, no phantom: {iterations:?}"
+    );
+    assert_eq!(iterations[0]["status"], "running");
+
+    tmux_session_manager::kill(&socket, &second);
+    tmux_session_manager::kill(&socket, &worker);
+    std::env::remove_var(tmux_session_manager::REAPER_TTL_SECS_ENV);
+    std::env::remove_var(tmux_session_manager::REAPER_INTERVAL_SECS_ENV);
+}
+
 /// Layer 3a (#485, slice A — `node_retry`, the UI **Retry** button): same
 /// invariant on the more exposed of the two paths. Retry appends
 /// `NodeInvalidated` for the node itself, and that applier does an unconditional


### PR DESCRIPTION
Fixes #785.

## Bug
A node with two edges into the same target (e.g. Prototype `out` + `chosen` → Loop entry) emitted two `Spawn` effects for the same (target, iter). The second tmux spawn failed with "duplicate session", and the loser parked the run as `RunInterrupted(spawn_aborted)` even though the winner session was alive (ADR-0050 §2 not implemented).

## Fix
- `scheduler.rs`: dedup `Spawn` effects per (target node, iteration) when a completing node has several edges into the same target.
- `node_spawn.rs` / `transition_guard.rs`: when tmux reports a duplicate session and that session is alive, the losing spawn is a benign no-op (WARN log), per ADR-0050 §2. Only a dead duplicate still aborts.
- `tests/tmux_lifecycle.rs`: regression coverage for both paths.

## Verification
- Unit/integration tests green (implementation node).
- Agentic FP #785: isolated daemon, pipeline with a two-port producer into a bounded loop → exactly one `node_started` per (node, iter), loop turns to completion, no `node_interrupted` / `run_interrupted`. Residual-race case (winner session pre-seeded) → benign no-op, run keeps running. Verdict: **Pass**, no blocking finding.

## Release
`1.83.1` → `1.83.2` (patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
