### PR TITLE
Run list as a tree: children fold under their parent, aggregated pills (#784) — 1.84.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ Le dépôt n'avait aucun fichier `LICENSE` depuis sa création ; seules les mét
 déclaraient MIT. Le fichier existe désormais et confirme ces termes ; les règles de
 contribution sont dans `CONTRIBUTING.md`.
 
+## 1.84.0
+**Liste de runs en arbre** (#784 ; story #783).
+Les runs enfants (créés via `pdo run create` depuis une session de nœud) se replient sous leur
+parent : seules les racines sont au niveau 0, un chevron déplie chaque parent, et une rangée de
+compteurs agrège le sous-arbre (finished / failed / stale / running). Un bouton global déplie ou
+replie tout ; la préférence « Child runs » des Settings (locale à l'appareil) fixe l'état par
+défaut. Le filtre pipeline garde le parent d'un enfant filtré ; un parent archivé redevient
+feuille et ses enfants remontent en racines. Le nœud orchestrateur et son onglet Orchestration
+affichent une pastille orange pour les enfants « stale ».
+
 ## 1.83.0
 **Fichiers et images transmis au run enfant** (#779).
 `POST /runs` multipart accepte un champ répétable `files` à côté d'`images` : tout fichier atterrit dans

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -478,6 +478,19 @@ Trois commandes agissent sur le **Run entier** — `pause_run`, `resume_run`, `r
 - **Pause / Resume** : `pause_run` fait passer un Run vivant en `Paused` (aucun nouveau spawn, l'horloge continue). `resume_run` est **dual-purpose** : sur un Run `Halted`/`Failed` il **relance** depuis l'état courant. C'est le seul levier qui ré-ouvre un Run failed ; il ne réanime jamais un `completed`.
 - **Retry-all** *(terme canonique)* : sur un Run terminal, archive l'original puis crée un Run **neuf** avec les mêmes paramètres — sans référence de filiation, indiscernable d'un lancement manuel. _Éviter_ : « retry » tout court (réservé au niveau nœud), « relancer le même Run » (le run-id change).
 
+### Orchestration récursive — arbre de runs (#709, ADR-0064 ; #783)
+
+Un run créé depuis la session d'un nœud porte une **filiation** posée par le daemon (`parent_run_id`, jamais déclarée par l'appelant). La liste de runs la rend en **arbre**, pas en liste plate.
+
+- **Run racine** *(terme)* : run sans parent **vivant dans la liste** — soit il n'a pas de parent, soit son parent a été oublié ou archivé. Il s'affiche au premier niveau.
+- **Run enfant** *(terme)* : run dont le parent est présent dans la liste. Il ne s'affiche **jamais** au premier niveau : il se replie sous son parent, indenté, ouvert par la **flèche** du parent (chevron sous le dot de statut). Un enfant suit son parent partout : même section actifs/archivés, même groupe Projet, quels que soient son propre statut ou son propre repo. Un enfant qui a des enfants porte sa propre flèche.
+- **Arbre de runs** *(terme)* : une racine et tous ses descendants. Un filtre (Projet, Pipeline, Trigger) garde un parent dès qu'un descendant matche, et l'ouvre sur les enfants qui matchent. Sélectionner un run masqué (onglet Orchestration, retour arrière) ouvre ses ancêtres.
+- **Compteurs d'enfants** *(terme)* : quatre pastilles à nombre — **finished** (terminal non failed), **failed**, **stale** (vivant et `stalled`, orange), **running** (vivant non stalled : running, awaiting_user, paused) — quatre ensembles disjoints dont la somme est le nombre de descendants. Sur une ligne de la liste ils agrègent **tout le sous-arbre** ; sur un nœud orchestrateur ils portent sur les enfants de ce nœud. Une pastille à zéro ne s'affiche pas. `stalled` d'un enfant est dérivé par le daemon à la lecture, comme sur la liste (#180).
+- **Déplié / replié par défaut** : préférence d'interface **par navigateur** (comme le thème), déplié par défaut. Elle fixe l'état au chargement et celui du bouton global **déplier tout / replier tout** (chevron haut quand tout est déplié) ; les bascules par ligne ne sont pas mémorisées.
+- **Cycle de vie** : inchangé (ADR-0064) — stop, archive et forget du parent ne touchent pas l'enfant, qui remonte alors racine. Une garde interdisant d'archiver un parent aux enfants vivants est une décision **reportée**, hors #783.
+
+_Éviter_ : « run orchestré » pour désigner un enfant (le badge « orchestrated » de #725 disparaît, l'indentation dit la filiation) ; « dropdown » ; « racines seules » comme filtre (remplacé par déplier/replier tout).
+
 ## Repo cible (`target_repo`)
 
 Le **repo cible** d'un Run ou d'un Trigger est le dépôt git dans lequel il travaille. Chemin absolu, stocké **verbatim** — jamais canonicalisé.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "1.83.2"
+version = "1.84.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "1.83.2"
+version = "1.84.0"
 license = "MIT"
 description = "Prompt-Driven Orchestrator — a local daemon that runs and supervises agentic coding pipelines"
 repository = "https://github.com/Loulen/prompt-driven-orchestrator"

--- a/crates/pdo-daemon/src/lib.rs
+++ b/crates/pdo-daemon/src/lib.rs
@@ -13582,6 +13582,12 @@ struct RunChildEntry {
     #[serde(skip_serializing_if = "Option::is_none")]
     name: Option<String>,
     status: event_log::RunStatus,
+    /// Display-only "no forward progress" overlay (#180, #783): true when the
+    /// child has no running/waiting node and a stale node, even though `status`
+    /// stays `running`. Derived per read by `event_log::is_stalled`, exactly as
+    /// on `GET /runs`, so the Orchestration tab's stale pill and the run list's
+    /// amber dot can never disagree about the same child.
+    stalled: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     started_at: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -13648,11 +13654,13 @@ async fn list_run_children(
             continue;
         }
         let cost = derive_run_cost(&state, &child, &events);
+        let stalled = event_log::is_stalled(&child);
         let entry = RunChildEntry {
             run_id: child.run_id,
             pipeline_name: child.pipeline_name,
             name: child.name,
             status: child.status,
+            stalled,
             started_at: child.started_at,
             completed_at: child.completed_at,
             cost,

--- a/crates/pdo-daemon/tests/orchestrator_binding.rs
+++ b/crates/pdo-daemon/tests/orchestrator_binding.rs
@@ -217,8 +217,11 @@ async fn node_status(daemon: &TestDaemon, run_id: &str, node_id: &str) -> String
         .to_string()
 }
 
+/// 30 s budget: under the full `it` target (hundreds of tests spawning tmux
+/// sessions concurrently) a retried child can take well over 10 s to settle,
+/// which made `retrying_the_failed_child_lets_the_node_complete_itself` flaky.
 async fn wait_node_status(daemon: &TestDaemon, run_id: &str, node_id: &str, want: &str) {
-    for _ in 0..200 {
+    for _ in 0..600 {
         if node_status(daemon, run_id, node_id).await == want {
             return;
         }

--- a/crates/pdo-daemon/tests/run_provenance.rs
+++ b/crates/pdo-daemon/tests/run_provenance.rs
@@ -464,6 +464,14 @@ async fn children_endpoint_lists_children_grouped_by_parent_node() {
             child["status"], "running",
             "a child is an ordinary live run"
         );
+        // #783 — `stalled` is derived on read like on `GET /runs` (#180), so the
+        // Orchestration tab's stale pill has a source. A fresh live child is not
+        // stalled; the field is always present (never omitted like `cost`).
+        assert_eq!(
+            child["stalled"], false,
+            "stalled present and false on a fresh live child: {:?}",
+            child
+        );
         assert!(
             child["started_at"].is_string(),
             "started_at present: {:?}",

--- a/crates/pdo-daemon/tests/run_scoped_pipeline.rs
+++ b/crates/pdo-daemon/tests/run_scoped_pipeline.rs
@@ -185,14 +185,18 @@ async fn external_write_to_run_pipeline_emits_pipeline_modified() {
     let updated_yaml = PIPELINE_YAML.replace("version: \"1.0\"", "version: \"2.0\"");
     std::fs::write(&yaml_path, updated_yaml).unwrap();
 
-    // Should receive a pipeline_modified event within the debounce window.
+    // Should receive a pipeline_modified event within the debounce window. The
+    // budget is generous on purpose: under the full parallel suite the file
+    // watcher's notify + debounce can take well over the ~1s it needs alone,
+    // and a tight 4s budget made this flake (#784 run). The assertion is about
+    // the event, not its latency.
     // Filter on kind "yaml": the watcher may also surface a "prompt" event from
     // the initial prompt copy, and grabbing whichever event arrives first would
     // let the test pass without the external YAML edit being detected at all
     // (same under-assertion class as #182).
-    let evt = next_pipeline_modified_event(&mut ws, &run_id, Some("yaml"), Duration::from_secs(4))
+    let evt = next_pipeline_modified_event(&mut ws, &run_id, Some("yaml"), Duration::from_secs(20))
         .await
-        .expect("external write to run-scoped pipeline should emit pipeline_modified within 4s");
+        .expect("external write to run-scoped pipeline should emit pipeline_modified within 20s");
 
     assert_eq!(evt["kind"], "pipeline_modified");
     assert_eq!(evt["run_id"], run_id);

--- a/frontend/src/components/OrchestrationTab.test.tsx
+++ b/frontend/src/components/OrchestrationTab.test.tsx
@@ -1,0 +1,65 @@
+// #723/#783 — the Orchestration tab's shared pastilles: four pills (finished /
+// failed / stale / running), zero pills hidden, the cluster absent without a child.
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { ChildCountPills, OrchestrationTab } from "./OrchestrationTab";
+import { countChildren, type RunChildEntry } from "../lib/orchestration";
+
+const child = (id: string, over: Partial<RunChildEntry> = {}): RunChildEntry => ({
+  run_id: id,
+  pipeline_name: "implement",
+  name: id,
+  status: "running",
+  ...over,
+});
+
+describe("ChildCountPills (#783)", () => {
+  it("renders the four pills, in order, and hides a zero one", () => {
+    render(<ChildCountPills counts={{ finished: 2, failed: 1, stale: 1, running: 0 }} />);
+    expect(screen.getByTestId("child-count-pills-finished")).toHaveTextContent("2");
+    expect(screen.getByTestId("child-count-pills-failed")).toHaveTextContent("1");
+    expect(screen.getByTestId("child-count-pills-stale")).toHaveTextContent("1");
+    expect(screen.queryByTestId("child-count-pills-running")).not.toBeInTheDocument();
+    // Stale wears the same amber as the list's stalled dot.
+    expect(screen.getByTestId("child-count-pills-stale").querySelector(".bg-st-stale")).not.toBeNull();
+    expect(screen.getByTestId("child-count-pills")).toHaveAttribute(
+      "aria-label",
+      "2 finished, 1 failed, 1 stale, 0 running child runs",
+    );
+  });
+
+  it("renders nothing at all without a child", () => {
+    render(<ChildCountPills counts={{ finished: 0, failed: 0, stale: 0, running: 0 }} />);
+    expect(screen.queryByTestId("child-count-pills")).not.toBeInTheDocument();
+  });
+
+  it("is a click target that swallows the click when onClick is given", () => {
+    const onClick = vi.fn();
+    const rowClick = vi.fn();
+    render(
+      <div onClick={rowClick}>
+        <ChildCountPills counts={{ finished: 0, failed: 0, stale: 1, running: 0 }} onClick={onClick} clickHint="click to expand" />
+      </div>,
+    );
+    expect(screen.getByTestId("child-count-pills-stale")).toHaveAttribute("title", "1 stale child run — click to expand");
+    fireEvent.click(screen.getByTestId("child-count-pills"));
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(rowClick).not.toHaveBeenCalled();
+  });
+});
+
+describe("OrchestrationTab with a stalled child (#783)", () => {
+  it("counts a live stalled child as stale on the node's pills", () => {
+    const children = [child("a", { stalled: true }), child("b"), child("c", { status: "failed" })];
+    const counts = countChildren(children);
+    expect(counts).toEqual({ finished: 0, failed: 1, stale: 1, running: 1 });
+    render(
+      <>
+        <ChildCountPills counts={counts} size="xs" testId="tab-child-pills" />
+        <OrchestrationTab childRuns={children} counts={counts} nodeLive nodeAwaiting={false} onOpenChild={() => {}} />
+      </>,
+    );
+    expect(screen.getByTestId("tab-child-pills-stale")).toHaveTextContent("1");
+    expect(screen.getAllByTestId("orchestration-child")).toHaveLength(3);
+  });
+});

--- a/frontend/src/components/OrchestrationTab.tsx
+++ b/frontend/src/components/OrchestrationTab.tsx
@@ -33,29 +33,42 @@ function runStatusDot(status: RunStatus): string {
 }
 
 /**
- * The green / red / blue counters: a coloured dot with the number beside it.
- * Same component on the canvas node and in the tab header, so the two can
- * never disagree; a zero counter is omitted, and the whole cluster is omitted
- * when there is no child at all (nodes that never orchestrated stay clean).
+ * The green / red / orange / blue counters (« compteurs d'enfants », #723/#783):
+ * a coloured dot with the number beside it. ONE component for the canvas node,
+ * the tab header and the run list's parent rows, so the surfaces can never
+ * disagree; a zero counter is omitted, and the whole cluster is omitted when
+ * there is no child at all (nodes that never orchestrated stay clean).
+ *
+ * `onClick` (run list) makes the cluster a button — clicking the pills of a
+ * collapsed parent expands it (design decision 1, 2026-09-11); the tooltip then
+ * says so. `subject` names what is counted in the tooltip ("child run" on a
+ * node, "descendant" would be wrong there).
  */
 export function ChildCountPills({
   counts,
   size = "sm",
   testId = "child-count-pills",
+  onClick,
+  clickHint,
 }: {
   counts: ChildCounts;
   size?: "sm" | "xs";
   testId?: string;
+  /** When set, the cluster is clickable and stops the click from reaching the row. */
+  onClick?: () => void;
+  /** Appended to every pill's tooltip when `onClick` is set (e.g. "click to expand"). */
+  clickHint?: string;
 }) {
   if (totalChildren(counts) === 0) return null;
   const dot = size === "xs" ? 6 : 7;
   const fs = size === "xs" ? 9.5 : 10.5;
+  const hint = onClick && clickHint ? ` — ${clickHint}` : "";
   const item = (n: number, bg: string, label: string, id: string) =>
     n > 0 ? (
       <span
         key={id}
         data-testid={`${testId}-${id}`}
-        title={`${n} ${label} child run${n > 1 ? "s" : ""}`}
+        title={`${n} ${label} child run${n > 1 ? "s" : ""}${hint}`}
         className="inline-flex items-center gap-1 font-mono text-fg-2"
         style={{ fontSize: fs, lineHeight: 1 }}
       >
@@ -63,15 +76,35 @@ export function ChildCountPills({
         {n}
       </span>
     ) : null;
-  return (
-    <span
-      className="inline-flex items-center gap-2"
-      data-testid={testId}
-      aria-label={`${counts.finished} finished, ${counts.failed} failed, ${counts.running} running child runs`}
-    >
+  const label = `${counts.finished} finished, ${counts.failed} failed, ${counts.stale} stale, ${counts.running} running child runs`;
+  const body = (
+    <>
       {item(counts.finished, "bg-st-done", "finished", "finished")}
       {item(counts.failed, "bg-st-failed", "failed", "failed")}
+      {item(counts.stale, "bg-st-stale", "stale", "stale")}
       {item(counts.running, "bg-st-running", "running", "running")}
+    </>
+  );
+  if (onClick) {
+    return (
+      <span
+        role="button"
+        tabIndex={-1}
+        className="inline-flex cursor-pointer items-center gap-2 rounded px-0.5 hover:bg-bg-4"
+        data-testid={testId}
+        aria-label={label}
+        onClick={(e) => {
+          e.stopPropagation();
+          onClick();
+        }}
+      >
+        {body}
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-2" data-testid={testId} aria-label={label}>
+      {body}
     </span>
   );
 }

--- a/frontend/src/components/RunFilters.tsx
+++ b/frontend/src/components/RunFilters.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown, GitFork, X } from "lucide-react";
+import { ChevronDown, ChevronsDownUp, ChevronsUpDown, X } from "lucide-react";
 import type { RunListEntry, Trigger } from "../types";
 import {
   DropdownMenu,
@@ -11,7 +11,6 @@ import {
   MANUAL_TRIGGER,
   NONE,
   isFilterActive,
-  isRootRun,
   pipelineKey,
   repoKey,
   triggerKey,
@@ -105,16 +104,30 @@ function FilterDropdown({
   );
 }
 
+/**
+ * #783 — the expand/collapse-all control's view state, derived by the caller
+ * from the TREE (not from the filter): `null` when no parent exists (the
+ * button is then absent — an instance that never orchestrates sees exactly
+ * the #336 strip).
+ */
+export interface TreeToggle {
+  /** Every visible parent is expanded ⇒ the button offers to collapse. */
+  allExpanded: boolean;
+  onToggle: () => void;
+}
+
 export default function RunFilters({
   runs,
   triggers,
   value,
   onChange,
+  treeToggle = null,
 }: {
   runs: RunListEntry[];
   triggers: Trigger[];
   value: RunFilterValue;
   onChange: (v: RunFilterValue) => void;
+  treeToggle?: TreeToggle | null;
 }) {
   const repoOptions: Option[] = uniqueSorted(runs.map(repoKey)).map((v) => ({
     value: v,
@@ -135,11 +148,6 @@ export default function RunFilters({
         : triggers.find((t) => t.id === v)?.name ?? v,
   }));
 
-  // #725 — the orchestrated toggle is offered only when at least one orchestrated
-  // run exists: an instance that never orchestrates sees exactly the old strip.
-  // Counted over ALL runs, not the filtered view, so the toggle never flickers
-  // away while it is doing the hiding.
-  const childCount = runs.filter((r) => !isRootRun(r)).length;
   const anyActive = isFilterActive(value);
 
   return (
@@ -165,32 +173,22 @@ export default function RunFilters({
         selected={value.trigger}
         onSelect={(trigger) => onChange({ ...value, trigger })}
       />
-      {/* #725 — « show orchestrated runs » as an icon-only chip (lucide GitFork;
-          the words live in the tooltip — user decision 2026-09-06). Deliberate
-          inversion vs the dropdowns, where accent means "narrowing": here ON
-          (accent) means everything is shown; OFF greys the chip and narrows the
-          list to roots. The clear ✕ appearing alongside keeps the strip honest. */}
-      {childCount > 0 && (
+      {/* #783 — expand / collapse all, in the slot the #725 GitFork chip held.
+          NOT a filter: neutral colours (never accent), never part of
+          `isFilterActive`, so it never summons the clear ✕. `ChevronsDownUp`
+          when every visible parent is open (click collapses), `ChevronsUpDown`
+          otherwise (click expands). */}
+      {treeToggle && (
         <button
           type="button"
-          data-testid="run-filter-orchestrated"
-          aria-pressed={value.showOrchestrated}
-          title={
-            value.showOrchestrated
-              ? `Orchestrated runs shown — click to hide the ${childCount} run${childCount === 1 ? "" : "s"} started by another run (roots only).`
-              : `Orchestrated runs hidden — ${childCount} run${childCount === 1 ? "" : "s"} started by another run. Click to show them.`
-          }
-          aria-label={
-            value.showOrchestrated ? "Hide orchestrated runs" : "Show orchestrated runs"
-          }
-          className={`flex shrink-0 cursor-pointer items-center rounded border bg-bg-3 px-2 py-[3px] transition-colors hover:bg-bg-4 ${
-            value.showOrchestrated
-              ? "border-acc text-acc"
-              : "border-line-strong text-fg-4"
-          }`}
-          onClick={() => onChange({ ...value, showOrchestrated: !value.showOrchestrated })}
+          data-testid="run-tree-toggle-all"
+          data-state={treeToggle.allExpanded ? "expanded" : "collapsed"}
+          title={treeToggle.allExpanded ? "Collapse all child runs" : "Expand all child runs"}
+          aria-label={treeToggle.allExpanded ? "Collapse all child runs" : "Expand all child runs"}
+          className="flex shrink-0 cursor-pointer items-center rounded border border-line-strong bg-bg-3 px-2 py-[3px] text-fg-4 transition-colors hover:bg-bg-4 hover:text-fg-2"
+          onClick={treeToggle.onToggle}
         >
-          <GitFork size={10} />
+          {treeToggle.allExpanded ? <ChevronsDownUp size={10} /> : <ChevronsUpDown size={10} />}
         </button>
       )}
       {anyActive && (

--- a/frontend/src/components/SettingsSurface.test.tsx
+++ b/frontend/src/components/SettingsSurface.test.tsx
@@ -1092,6 +1092,40 @@ describe("SettingsSurface — Pipeline Manager section (manager on demand)", () 
   });
 });
 
+describe("SettingsSurface — Interface / child runs default (#783)", () => {
+  beforeEach(() => {
+    fetchSettingsMock.mockReset();
+    updateSettingsMock.mockReset();
+    localStorage.clear();
+  });
+
+  it("defaults to « Expanded by default » and writes the pick to localStorage at once", async () => {
+    fetchSettingsMock.mockResolvedValue(sample());
+    render(<SettingsSurface open onClose={() => {}} />);
+
+    const expanded = await screen.findByTestId("setting-child-runs-expanded");
+    const collapsed = screen.getByTestId("setting-child-runs-collapsed");
+    expect(expanded).toHaveAttribute("aria-checked", "true");
+    expect(collapsed).toHaveAttribute("aria-checked", "false");
+    expect(screen.getByTestId("setting-child-runs-badge")).toHaveTextContent("Device-local · saved immediately");
+
+    fireEvent.click(collapsed);
+    expect(localStorage.getItem("pdo.ui.childRunsExpanded")).toBe("false");
+    expect(collapsed).toHaveAttribute("aria-checked", "true");
+    expect(updateSettingsMock).not.toHaveBeenCalled();
+
+    fireEvent.click(expanded);
+    expect(localStorage.getItem("pdo.ui.childRunsExpanded")).toBe("true");
+  });
+
+  it("seeds the control from the stored preference", async () => {
+    localStorage.setItem("pdo.ui.childRunsExpanded", "false");
+    fetchSettingsMock.mockResolvedValue(sample());
+    render(<SettingsSurface open onClose={() => {}} />);
+    expect(await screen.findByTestId("setting-child-runs-collapsed")).toHaveAttribute("aria-checked", "true");
+  });
+});
+
 describe("SettingsSurface — Interface / single-tab toggle (#342)", () => {
   beforeEach(() => {
     fetchSettingsMock.mockReset();

--- a/frontend/src/components/SettingsSurface.tsx
+++ b/frontend/src/components/SettingsSurface.tsx
@@ -36,6 +36,7 @@ import ModelPicker from "./ModelPicker";
 import SessionCounter from "./SessionCounter";
 import HarnessSelect from "./HarnessSelect";
 import ThemeSelect from "./ThemeSelect";
+import { loadChildRunsExpanded, saveChildRunsExpanded } from "../lib/uiPrefs";
 import { harnessCatalog, findHarnessOption } from "../lib/harness";
 import AgentControl from "./AgentControl";
 import { announceAgentProfilesChanged, useAgentProfiles } from "../hooks/useAgentProfiles";
@@ -1291,6 +1292,13 @@ function Section({ section, children }: { section: SettingsSection; children: Re
 function InterfaceSection({ section }: { section: SettingsSection }) {
   const singleTabMode = useEditStore((s) => s.singleTabMode);
   const setSingleTabMode = useEditStore((s) => s.setSingleTabMode);
+  // #783 — « Child runs » default. Read once from localStorage, written at the
+  // change; the run list reads the key when it mounts (a reload applies it).
+  const [childRunsExpanded, setChildRunsExpanded] = useState(loadChildRunsExpanded);
+  const pickChildRuns = (v: boolean) => {
+    saveChildRunsExpanded(v);
+    setChildRunsExpanded(v);
+  };
 
   return (
     <Section section={section}>
@@ -1351,6 +1359,64 @@ function InterfaceSection({ section }: { section: SettingsSection }) {
         </div>
         <div className="text-fg-3" style={{ fontSize: "10.5px" }}>
           Stored in this browser's localStorage. Not shared with other browsers or the daemon.
+        </div>
+      </div>
+      <div className="flex flex-col gap-1.5">
+        <div className="flex items-center gap-2">
+          <span className="font-medium text-fg-2" style={{ fontSize: "11.5px" }}>
+            Child runs
+          </span>
+          <span
+            className="rounded-full border border-acc-border bg-acc-bg px-2 py-0.5 text-acc"
+            style={{ fontSize: "9.5px" }}
+            data-testid="setting-child-runs-badge"
+          >
+            Device-local · saved immediately
+          </span>
+        </div>
+        <div
+          role="radiogroup"
+          aria-label="Child runs"
+          className="flex gap-1"
+          data-testid="setting-child-runs"
+        >
+          {(
+            [
+              { v: true, id: "expanded", label: "Expanded by default" },
+              { v: false, id: "collapsed", label: "Collapsed by default" },
+            ] as const
+          ).map(({ v, id, label }) => {
+            const selected = childRunsExpanded === v;
+            return (
+              <button
+                key={id}
+                type="button"
+                role="radio"
+                aria-checked={selected}
+                tabIndex={selected ? 0 : -1}
+                data-testid={`setting-child-runs-${id}`}
+                onClick={() => pickChildRuns(v)}
+                onKeyDown={(e) => {
+                  if (["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown"].includes(e.key)) {
+                    e.preventDefault();
+                    pickChildRuns(!v);
+                  }
+                }}
+                className={`flex flex-1 cursor-pointer items-center justify-center rounded border px-2 py-1.5 font-medium transition-colors ${
+                  selected
+                    ? "border-acc bg-acc-bg text-acc"
+                    : "border-line-strong bg-bg-3 text-fg-4 hover:text-fg-3"
+                }`}
+                style={{ fontSize: "10px" }}
+              >
+                {label}
+              </button>
+            );
+          })}
+        </div>
+        <div className="text-fg-3" style={{ fontSize: "10.5px" }}>
+          Applied when the run list loads. Toggling a row or the expand/collapse-all button only
+          affects the current session.
         </div>
       </div>
     </Section>

--- a/frontend/src/components/UnifiedLeftPanel.test.tsx
+++ b/frontend/src/components/UnifiedLeftPanel.test.tsx
@@ -1869,21 +1869,28 @@ describe("UnifiedLeftPanel run tree (#783)", () => {
     expect(scrollSpy).toHaveBeenCalled();
   });
 
-  it("a child of an archived parent follows it into the Archived section; the section count is roots only", () => {
+  it("archiving a parent releases its children as ACTIVE roots; the Archived section holds the parent alone (AC #2, ADR-0064)", () => {
     const archivedParent = runs.map((r) => (r.run_id === "epic" ? { ...r, status: "archived" as const } : r));
     renderPanel({ runs: archivedParent });
-    // Active list: only the orphan and solo remain.
-    expect(labels()).toEqual(["#700 spike", "triage nightly"]);
-    expect(screen.getByTestId("run-archived-count")).toHaveTextContent("(1)");
-    fireEvent.click(screen.getByTestId("run-archived-toggle"));
+    // Active list: the released children climb back to depth 0 (the grandchild
+    // stays under its own live parent), alongside the orphan and solo. A released
+    // child is grouped by its OWN repo again (kid-trig lives in /repos/b).
+    expect(row("kid")).toHaveAttribute("data-depth", "0");
+    expect(row("kid-trig")).toHaveAttribute("data-depth", "0");
+    expect(row("grandkid")).toHaveAttribute("data-depth", "1");
     expect(labels()).toEqual([
-      "#700 spike",
-      "triage nightly",
-      "Refonte auth — orchestrateur",
       "#731 login form",
       "review 731",
+      "#700 spike",
+      "triage nightly",
       "#733 logout — nightly",
     ]);
+    expect(screen.getByTestId("run-archived-count")).toHaveTextContent("(1)");
+    fireEvent.click(screen.getByTestId("run-archived-toggle"));
+    // The archived parent is a leaf: no chevron, no pills, no nested rows.
+    expect(labels().slice(-1)).toEqual(["Refonte auth — orchestrateur"]);
+    expect(within(row("epic")).queryByTestId("run-tree-chevron")).toBeNull();
+    expect(within(row("epic")).queryByTestId("run-child-pills-failed")).toBeNull();
   });
 
   it("an archived parent that is FORGOTTEN releases its children as roots", () => {

--- a/frontend/src/components/UnifiedLeftPanel.test.tsx
+++ b/frontend/src/components/UnifiedLeftPanel.test.tsx
@@ -1,12 +1,13 @@
 import { useState } from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+import { cleanup, render, screen, fireEvent, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import UnifiedLeftPanel from "./UnifiedLeftPanel";
 import type { PipelineListEntry, RunListEntry, Trigger } from "../types";
 import type { LibraryPipelineEntry } from "../api";
 import { cleanupRun, deleteLibraryPipeline, deletePipeline, duplicateLibraryPipeline, fetchPipelines, importPipelineDocument, importWorkflow, openRunShell, pauseRun, renameRun, resumeRun, retryAll } from "../api";
 import { useEditStore } from "../stores/editStore";
+import { useSelectionStore } from "../stores/selectionStore";
 import { useRecentReposStore } from "../stores/recentReposStore";
 
 const mockRenameRun = vi.mocked(renameRun);
@@ -1619,10 +1620,12 @@ describe("UnifiedLeftPanel run filters (#336)", () => {
 });
 
 // #577 — multi-select + bulk actions on the Runs list.
-// #725 — provenance badge « orchestrated » on child runs (click → parent) and
-// the « show orchestrated runs » toggle in the filter strip (ON by default; OFF
-// narrows to roots). Same session-only filter state; the clear ✕ resets it.
-describe("UnifiedLeftPanel orchestrated badge + roots-only toggle (#725)", () => {
+// #783 — the Runs list is a TREE: a child run nests under its parent (chevron
+// under the status dot, 14px indent per level), the parent carries the
+// aggregated child counts, the filter strip's fourth control is expand /
+// collapse all, and Settings › Interface seeds the default. The tree logic is
+// unit-tested in `lib/runTree.test.ts`; this block checks the rendering seams.
+describe("UnifiedLeftPanel run tree (#783)", () => {
   const trig: Trigger = {
     id: "trg-1",
     name: "Nightly audit",
@@ -1637,129 +1640,269 @@ describe("UnifiedLeftPanel orchestrated badge + roots-only toggle (#725)", () =>
   };
 
   const runs: RunListEntry[] = [
-    { run_id: "epic", pipeline_name: "orchestrate-epic", status: "running", started_at: null, name: "Refonte auth — orchestrateur" },
-    { run_id: "kid", pipeline_name: "implement-loop", status: "running", started_at: null, name: "#731 login form", parent_run_id: "epic" },
-    { run_id: "kid-trig", pipeline_name: "implement-loop", status: "running", started_at: null, name: "#733 logout — nightly", parent_run_id: "epic", triggered_by: "trg-1" },
-    { run_id: "orphan", pipeline_name: "implement-loop", status: "failed", started_at: null, name: "#700 spike", parent_run_id: "forgotten" },
-    { run_id: "arch-kid", pipeline_name: "implement-loop", status: "archived", started_at: null, name: "old child", parent_run_id: "epic" },
+    { run_id: "epic", pipeline_name: "orchestrate-epic", status: "running", started_at: null, name: "Refonte auth — orchestrateur", effective_repo: "/repos/a" },
+    { run_id: "kid", pipeline_name: "implement-loop", status: "running", started_at: null, name: "#731 login form", parent_run_id: "epic", effective_repo: "/repos/a" },
+    { run_id: "kid-trig", pipeline_name: "implement-loop", status: "failed", started_at: null, name: "#733 logout — nightly", parent_run_id: "epic", triggered_by: "trg-1", effective_repo: "/repos/b" },
+    { run_id: "grandkid", pipeline_name: "code-review", status: "completed", started_at: null, name: "review 731", parent_run_id: "kid", effective_repo: "/repos/a" },
+    { run_id: "orphan", pipeline_name: "implement-loop", status: "failed", started_at: null, name: "#700 spike", parent_run_id: "forgotten", effective_repo: "/repos/a" },
+    { run_id: "solo", pipeline_name: "triage", status: "completed", started_at: null, name: "triage nightly", effective_repo: "/repos/a" },
   ];
 
-  it("shows the orchestrated badge on a child run and not on a root", () => {
-    renderPanel({ runs: [runs[0], runs[1]] });
-    expect(screen.getByTestId("run-orchestrated-badge")).toBeInTheDocument();
-    // Only the child row carries it — one badge for one child.
-    expect(screen.getAllByTestId("run-orchestrated-badge")).toHaveLength(1);
+  beforeEach(() => {
+    localStorage.clear();
   });
 
-  it("coexists with the trigger badge on the same run", () => {
-    renderPanel({ runs: [runs[2]] });
-    expect(screen.getByTestId("run-trigger-badge")).toBeInTheDocument();
-    expect(screen.getByTestId("run-orchestrated-badge")).toBeInTheDocument();
+  const labels = () => screen.getAllByTestId("run-display-label").map((el) => el.textContent);
+  const row = (id: string) => document.querySelector(`[data-run-row="${id}"]`) as HTMLElement;
+
+  it("nests children under their parent, in list order, indented 14px per level (expanded by default)", () => {
+    renderPanel({ runs });
+    expect(labels()).toEqual([
+      "Refonte auth — orchestrateur",
+      "#731 login form",
+      "review 731",
+      "#733 logout — nightly",
+      "#700 spike",
+      "triage nightly",
+    ]);
+    expect(row("epic")).toHaveAttribute("data-depth", "0");
+    expect(row("kid")).toHaveAttribute("data-depth", "1");
+    expect(row("grandkid")).toHaveAttribute("data-depth", "2");
+    expect(row("kid").style.paddingLeft).toBe("26px");
+    expect(row("grandkid").style.paddingLeft).toBe("40px");
+    // An orphan (parent forgotten) is a root.
+    expect(row("orphan")).toHaveAttribute("data-depth", "0");
   });
 
-  it("names the parent run in the badge tooltip", () => {
-    renderPanel({ runs: [runs[0], runs[1]] });
-    expect(screen.getByTestId("run-orchestrated-badge")).toHaveAttribute(
-      "title",
-      "Orchestrated by “Refonte auth — orchestrateur” — click to open the parent run",
-    );
+  it("a child follows its parent's Project group, whatever its own repo", () => {
+    const twoRepos: RunListEntry[] = [
+      ...runs,
+      { run_id: "other", pipeline_name: "deploy", status: "completed", started_at: null, name: "deploy preview", effective_repo: "/repos/b" },
+    ];
+    renderPanel({ runs: twoRepos });
+    const groups = screen.getAllByTestId("run-repo-group");
+    expect(groups).toHaveLength(2);
+    // kid-trig is on /repos/b but sits under its parent in the /repos/a group.
+    expect(within(groups[0]).getByText("#733 logout — nightly")).toBeInTheDocument();
+    expect(within(groups[1]).queryByText("#733 logout — nightly")).not.toBeInTheDocument();
   });
 
-  it("clicking the badge selects the parent run, not the child", () => {
-    const onSelectRun = vi.fn();
-    render(
-      <UnifiedLeftPanel
-        runs={[runs[0], runs[1]]}
-        selectedRunId={null}
-        onSelectRun={onSelectRun}
-        onNewRun={noop}
-        libraryPipelines={[]}
-        onLibraryPipelinesChanged={noop}
-      />,
-    );
-    fireEvent.click(screen.getByTestId("run-orchestrated-badge"));
-    expect(onSelectRun).toHaveBeenCalledTimes(1);
-    expect(onSelectRun).toHaveBeenCalledWith("epic");
+  it("puts a chevron under the dot of every row with children — and only there", () => {
+    renderPanel({ runs });
+    const chevrons = screen.getAllByTestId("run-tree-chevron");
+    expect(chevrons).toHaveLength(2); // epic + kid
+    expect(within(row("epic")).getByTestId("run-tree-chevron")).toHaveAttribute("aria-expanded", "true");
+    expect(within(row("kid")).getByTestId("run-tree-chevron")).toBeInTheDocument();
+    expect(within(row("grandkid")).queryByTestId("run-tree-chevron")).not.toBeInTheDocument();
+    expect(within(row("solo")).queryByTestId("run-tree-chevron")).not.toBeInTheDocument();
   });
 
-  it("dims an orphan badge (parent forgotten) and makes its click a no-op", () => {
-    const onSelectRun = vi.fn();
-    render(
-      <UnifiedLeftPanel
-        runs={[runs[3]]}
-        selectedRunId={null}
-        onSelectRun={onSelectRun}
-        onNewRun={noop}
-        libraryPipelines={[]}
-        onLibraryPipelinesChanged={noop}
-      />,
-    );
-    const badge = screen.getByTestId("run-orchestrated-badge");
-    expect(badge).toHaveAttribute("aria-disabled", "true");
-    expect(badge).toHaveAttribute(
-      "title",
-      "Orchestrated by a run that was forgotten",
-    );
-    fireEvent.click(badge);
-    expect(onSelectRun).not.toHaveBeenCalled();
-  });
-
-  it("tooltip of the trigger badge names the trigger", () => {
-    renderPanel({ runs: [runs[2]], triggers: [trig] });
+  it("the orchestrated badge is gone; the trigger badge stays", () => {
+    renderPanel({ runs, triggers: [trig] });
+    expect(screen.queryByTestId("run-orchestrated-badge")).not.toBeInTheDocument();
     expect(screen.getByTestId("run-trigger-badge")).toHaveAttribute(
       "title",
       "Created by trigger “Nightly audit” — click to open it in the Triggers tab",
     );
   });
 
-  it("hides the toggle when no orchestrated run exists", () => {
-    renderPanel({ runs: [runs[0]] });
+  it("aggregates the child counts over the whole subtree, zero pills hidden, none on a leaf", () => {
+    renderPanel({ runs });
+    const epicPills = within(row("epic")).getByTestId("run-child-pills");
+    // epic's descendants: kid (running), grandkid (finished), kid-trig (failed).
+    expect(within(epicPills).getByTestId("run-child-pills-finished")).toHaveTextContent("1");
+    expect(within(epicPills).getByTestId("run-child-pills-failed")).toHaveTextContent("1");
+    expect(within(epicPills).getByTestId("run-child-pills-running")).toHaveTextContent("1");
+    expect(within(epicPills).queryByTestId("run-child-pills-stale")).not.toBeInTheDocument();
+    // kid: one finished grandchild only.
+    const kidPills = within(row("kid")).getByTestId("run-child-pills");
+    expect(within(kidPills).getByTestId("run-child-pills-finished")).toHaveTextContent("1");
+    expect(within(kidPills).queryByTestId("run-child-pills-running")).not.toBeInTheDocument();
+    // Leaves and childless roots carry no pills at all.
+    expect(within(row("grandkid")).queryByTestId("run-child-pills")).not.toBeInTheDocument();
+    expect(within(row("solo")).queryByTestId("run-child-pills")).not.toBeInTheDocument();
+  });
+
+  it("counts a live stalled descendant as STALE (orange), disjoint from running", () => {
+    const stalled = runs.map((r) => (r.run_id === "kid" ? { ...r, stalled: true } : r));
+    renderPanel({ runs: stalled });
+    const pills = within(row("epic")).getByTestId("run-child-pills");
+    expect(within(pills).getByTestId("run-child-pills-stale")).toHaveTextContent("1");
+    expect(within(pills).queryByTestId("run-child-pills-running")).not.toBeInTheDocument();
+    expect(within(pills).getByTestId("run-child-pills-stale").querySelector(".bg-st-stale")).not.toBeNull();
+  });
+
+  it("the chevron collapses / expands the subtree without selecting the run", () => {
+    const onSelectRun = vi.fn();
+    render(
+      <UnifiedLeftPanel runs={runs} selectedRunId={null} onSelectRun={onSelectRun} onNewRun={noop} libraryPipelines={[]} onLibraryPipelinesChanged={noop} />,
+    );
+    fireEvent.click(within(row("epic")).getByTestId("run-tree-chevron"));
+    expect(onSelectRun).not.toHaveBeenCalled();
+    expect(labels()).toEqual(["Refonte auth — orchestrateur", "#700 spike", "triage nightly"]);
+    expect(within(row("epic")).getByTestId("run-tree-chevron")).toHaveAttribute("aria-expanded", "false");
+    // The pills describe the real subtree even while collapsed…
+    expect(within(row("epic")).getByTestId("run-child-pills-failed")).toHaveTextContent("1");
+    fireEvent.click(within(row("epic")).getByTestId("run-tree-chevron"));
+    expect(labels()).toHaveLength(6);
+    expect(onSelectRun).not.toHaveBeenCalled();
+  });
+
+  it("clicking the pills of a collapsed parent expands it (decision 1)", () => {
+    const onSelectRun = vi.fn();
+    render(
+      <UnifiedLeftPanel runs={runs} selectedRunId={null} onSelectRun={onSelectRun} onNewRun={noop} libraryPipelines={[]} onLibraryPipelinesChanged={noop} />,
+    );
+    fireEvent.click(within(row("epic")).getByTestId("run-tree-chevron"));
+    const pills = within(row("epic")).getByTestId("run-child-pills");
+    expect(within(pills).getByTestId("run-child-pills-failed")).toHaveAttribute("title", "1 failed child run — click to expand");
+    fireEvent.click(pills);
+    expect(onSelectRun).not.toHaveBeenCalled();
+    expect(labels()).toHaveLength(6);
+    // Once expanded the pills are inert: the click reaches the row.
+    expect(within(row("epic")).getByTestId("run-child-pills-failed")).toHaveAttribute("title", "1 failed child run");
+    fireEvent.click(within(row("epic")).getByTestId("run-child-pills"));
+    expect(onSelectRun).toHaveBeenCalledWith("epic");
+  });
+
+  it("← collapses / climbs to the parent, → expands, on the focused row (decision 2)", () => {
+    renderPanel({ runs });
+    fireEvent.keyDown(row("epic"), { key: "ArrowLeft" });
+    expect(labels()).toHaveLength(3);
+    fireEvent.keyDown(row("epic"), { key: "ArrowRight" });
+    expect(labels()).toHaveLength(6);
+    // On a leaf, ← moves focus to the parent row.
+    row("grandkid").focus();
+    fireEvent.keyDown(row("grandkid"), { key: "ArrowLeft" });
+    expect(document.activeElement).toBe(row("kid"));
+  });
+
+  it("the expand/collapse-all button replaces the GitFork chip: neutral, no clear ✕, absent without a parent", () => {
+    renderPanel({ runs: [runs[5]] });
+    expect(screen.queryByTestId("run-tree-toggle-all")).not.toBeInTheDocument();
     expect(screen.queryByTestId("run-filter-orchestrated")).not.toBeInTheDocument();
-  });
+    cleanup();
 
-  it("shows the toggle pressed ON by default and hides children when switched off", async () => {
-    const user = userEvent.setup();
     renderPanel({ runs });
-    const toggle = screen.getByTestId("run-filter-orchestrated");
-    expect(toggle).toHaveAttribute("aria-pressed", "true");
+    const toggle = screen.getByTestId("run-tree-toggle-all");
+    expect(toggle).toHaveAttribute("data-state", "expanded");
+    expect(toggle).toHaveAttribute("aria-label", "Collapse all child runs");
+    expect(toggle.className).not.toContain("border-acc");
 
-    await user.click(toggle);
-    expect(screen.getByTestId("run-filter-orchestrated")).toHaveAttribute("aria-pressed", "false");
-    // Only roots remain — the epic; every child (incl. the archived one) hides,
-    // and with zero archived runs left the whole section disappears.
-    const labels = screen.getAllByTestId("run-display-label").map((el) => el.textContent);
-    expect(labels).toEqual(["Refonte auth — orchestrateur"]);
-    expect(screen.queryByTestId("run-archived-section")).not.toBeInTheDocument();
-
-    await user.click(screen.getByTestId("run-filter-orchestrated"));
-    expect(screen.getAllByTestId("run-display-label")).toHaveLength(4);
-  });
-
-  it("composes with the other filter axes (AND)", async () => {
-    const user = userEvent.setup();
-    renderPanel({ runs });
-
-    await user.click(screen.getByTestId("run-filter-orchestrated"));
-    await user.click(screen.getByTestId("run-filter-pipeline"));
-    await user.click(await screen.findByTestId("run-filter-option-implement-loop"));
-
-    // implement-loop runs are all children; roots-only leaves nothing.
-    expect(screen.queryAllByTestId("run-display-label")).toHaveLength(0);
-    expect(screen.getByTestId("run-filter-empty")).toBeInTheDocument();
-  });
-
-  it("the clear control resets the toggle to ON", async () => {
-    const user = userEvent.setup();
-    renderPanel({ runs });
-
-    await user.click(screen.getByTestId("run-filter-orchestrated"));
-    // Narrowed to roots ⇒ the strip grew a clear ✕.
-    expect(screen.getByTestId("run-filter-clear")).toBeInTheDocument();
-
-    await user.click(screen.getByTestId("run-filter-clear"));
-    expect(screen.getByTestId("run-filter-orchestrated")).toHaveAttribute("aria-pressed", "true");
+    fireEvent.click(toggle);
+    expect(labels()).toEqual(["Refonte auth — orchestrateur", "#700 spike", "triage nightly"]);
+    expect(screen.getByTestId("run-tree-toggle-all")).toHaveAttribute("data-state", "collapsed");
+    expect(screen.getByTestId("run-tree-toggle-all")).toHaveAttribute("aria-label", "Expand all child runs");
+    // Not a filter: no clear ✕ appears.
     expect(screen.queryByTestId("run-filter-clear")).not.toBeInTheDocument();
-    expect(screen.getAllByTestId("run-display-label")).toHaveLength(4);
+
+    fireEvent.click(screen.getByTestId("run-tree-toggle-all"));
+    expect(labels()).toHaveLength(6);
+    expect(screen.getByTestId("run-tree-toggle-all")).toHaveAttribute("data-state", "expanded");
+  });
+
+  it("one collapsed parent flips the global button to « expand »", () => {
+    renderPanel({ runs });
+    fireEvent.click(within(row("kid")).getByTestId("run-tree-chevron"));
+    expect(screen.getByTestId("run-tree-toggle-all")).toHaveAttribute("data-state", "collapsed");
+  });
+
+  it("honours the « collapsed by default » preference at load", () => {
+    localStorage.setItem("pdo.ui.childRunsExpanded", "false");
+    renderPanel({ runs });
+    expect(labels()).toEqual(["Refonte auth — orchestrateur", "#700 spike", "triage nightly"]);
+    expect(screen.getByTestId("run-tree-toggle-all")).toHaveAttribute("data-state", "collapsed");
+    // Per-row toggles are NOT persisted.
+    fireEvent.click(within(row("epic")).getByTestId("run-tree-chevron"));
+    expect(localStorage.getItem("pdo.ui.childRunsExpanded")).toBe("false");
+  });
+
+  it("a filter keeps a non-matching parent as the path to a matching child, opened, siblings hidden", async () => {
+    const user = userEvent.setup();
+    localStorage.setItem("pdo.ui.childRunsExpanded", "false");
+    renderPanel({ runs });
+    await user.click(screen.getByTestId("run-filter-pipeline"));
+    await user.click(await screen.findByTestId("run-filter-option-code-review"));
+    // epic → kid → grandkid is the only path; kid-trig (implement-loop) and the
+    // roots that don't match are gone. The parents open on the match even
+    // though the default is collapsed.
+    expect(labels()).toEqual(["Refonte auth — orchestrateur", "#731 login form", "review 731"]);
+    // The pills still describe the REAL subtree, not the filtered view.
+    expect(within(row("epic")).getByTestId("run-child-pills-failed")).toHaveTextContent("1");
+    // The chevron stays active under the filter.
+    fireEvent.click(within(row("kid")).getByTestId("run-tree-chevron"));
+    expect(labels()).toEqual(["Refonte auth — orchestrateur", "#731 login form"]);
+    // Clearing the filter brings everything back (default collapsed ⇒ roots).
+    await user.click(screen.getByTestId("run-filter-clear"));
+    expect(labels()).toEqual(["Refonte auth — orchestrateur", "#700 spike", "triage nightly"]);
+  });
+
+  it("a filter matching only a root shows no chevron path for children", async () => {
+    const user = userEvent.setup();
+    renderPanel({ runs });
+    await user.click(screen.getByTestId("run-filter-pipeline"));
+    await user.click(await screen.findByTestId("run-filter-option-triage"));
+    expect(labels()).toEqual(["triage nightly"]);
+  });
+
+  it("selecting a hidden run opens its ancestors and scrolls to it (#725 mechanism)", () => {
+    const scrollSpy = vi.fn();
+    Element.prototype.scrollIntoView = scrollSpy;
+    localStorage.setItem("pdo.ui.childRunsExpanded", "false");
+    const { rerender } = render(
+      <UnifiedLeftPanel runs={runs} selectedRunId={null} onSelectRun={noop} onNewRun={noop} libraryPipelines={[]} onLibraryPipelinesChanged={noop} />,
+    );
+    expect(labels()).toHaveLength(3);
+    rerender(
+      <UnifiedLeftPanel runs={runs} selectedRunId="grandkid" onSelectRun={noop} onNewRun={noop} libraryPipelines={[]} onLibraryPipelinesChanged={noop} />,
+    );
+    // Every ancestor of grandkid (epic, kid) opened — which also reveals epic's
+    // other child, kid-trig: a row is expanded or not, never partially.
+    expect(labels()).toEqual([
+      "Refonte auth — orchestrateur",
+      "#731 login form",
+      "review 731",
+      "#733 logout — nightly",
+      "#700 spike",
+      "triage nightly",
+    ]);
+    expect(scrollSpy).toHaveBeenCalled();
+  });
+
+  it("a child of an archived parent follows it into the Archived section; the section count is roots only", () => {
+    const archivedParent = runs.map((r) => (r.run_id === "epic" ? { ...r, status: "archived" as const } : r));
+    renderPanel({ runs: archivedParent });
+    // Active list: only the orphan and solo remain.
+    expect(labels()).toEqual(["#700 spike", "triage nightly"]);
+    expect(screen.getByTestId("run-archived-count")).toHaveTextContent("(1)");
+    fireEvent.click(screen.getByTestId("run-archived-toggle"));
+    expect(labels()).toEqual([
+      "#700 spike",
+      "triage nightly",
+      "Refonte auth — orchestrateur",
+      "#731 login form",
+      "review 731",
+      "#733 logout — nightly",
+    ]);
+  });
+
+  it("an archived parent that is FORGOTTEN releases its children as roots", () => {
+    const forgotten = runs.filter((r) => r.run_id !== "epic");
+    renderPanel({ runs: forgotten });
+    expect(row("kid")).toHaveAttribute("data-depth", "0");
+    expect(row("kid-trig")).toHaveAttribute("data-depth", "0");
+    expect(row("grandkid")).toHaveAttribute("data-depth", "1");
+  });
+
+  it("shift-range spans only the VISIBLE rows (collapsed subtree skipped)", () => {
+    useSelectionStore.getState().clearAll();
+    renderPanel({ runs });
+    fireEvent.click(within(row("epic")).getByTestId("run-tree-chevron")); // collapse epic
+    const dotOf = (id: string) => within(row(id)).getByRole("checkbox");
+    fireEvent.click(dotOf("epic"));
+    fireEvent.click(dotOf("solo"), { shiftKey: true });
+    expect(useSelectionStore.getState().runs.sort()).toEqual(["epic", "orphan", "solo"]);
+    useSelectionStore.getState().clearAll();
   });
 });
 

--- a/frontend/src/components/UnifiedLeftPanel.tsx
+++ b/frontend/src/components/UnifiedLeftPanel.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { ChevronDown, ChevronRight, Copy, FileUp, GitFork, Pause, Pencil, Play, Plus, RotateCcw, SquareTerminal, Trash2, X, Zap } from "lucide-react";
+import { ChevronDown, ChevronRight, Copy, FileUp, Pause, Pencil, Play, Plus, RotateCcw, SquareTerminal, Trash2, X, Zap } from "lucide-react";
 import { isLiveRun, isTerminalRun, type RunListEntry, type RunStatus, type PipelineListEntry, type Trigger, type Project } from "../types";
 import type { LibraryPipelineEntry } from "../api";
 import { cleanupRun, createPipeline, duplicatePipeline, forgetRun, importPipelineDocument, importWorkflow, openRunShell, pauseRun, renameRun, resumeRun, retryAll } from "../api";
@@ -10,6 +10,17 @@ import { useRecentReposStore } from "../stores/recentReposStore";
 import { handleSelectionKeydown } from "../lib/selectionKeys";
 import { type BulkItem, type BulkOutcome } from "../lib/bulk";
 import { groupByProject, type ProjectRef } from "../lib/groupByRepo";
+import {
+  ancestorIds,
+  buildRunTree,
+  filterRunTree,
+  flattenAll,
+  flattenVisible,
+  parentIds,
+  rootOf,
+  type RunTreeNode,
+} from "../lib/runTree";
+import { loadChildRunsExpanded } from "../lib/uiPrefs";
 import { projectLookup } from "../lib/projectLookup";
 import BulkActionBar from "./BulkActionBar";
 import BulkActionModal from "./BulkActionModal";
@@ -20,6 +31,7 @@ import LibraryRow from "./LibraryRow";
 import ProjectEditModal from "./ProjectEditModal";
 import RunFilters from "./RunFilters";
 import { EMPTY_RUN_FILTER, isFilterActive, runMatchesFilter } from "./runFilter";
+import { ChildCountPills } from "./OrchestrationTab";
 import RunShellModal from "./RunShellModal";
 import SelectControl from "./SelectControl";
 import TriggersListPanel from "./TriggersListPanel";
@@ -252,7 +264,14 @@ export default function UnifiedLeftPanel({
 
   // One run row, rendered identically whether the list is flat or grouped by
   // repo (#258). Extracted so both code paths share the exact same markup.
-  function renderRunRow(run: RunListEntry) {
+  // #783 — the row is a TREE node: indented 14px per level, a chevron under the
+  // status dot when it has children, the aggregated child counts bottom-right.
+  // The tree itself (structure, counts, filter) is computed by `lib/runTree.ts`;
+  // this only renders.
+  function renderRunRow(node: RunTreeNode) {
+    const run = node.run;
+    const hasChildren = node.children.length > 0;
+    const expanded = hasChildren && isExpanded(run.run_id);
     const isSelected = run.run_id === selectedRunId;
     const rowSelected = runSel.has(run.run_id);
     // A stalled run (no node running/waiting, nothing schedulable; #180) is
@@ -284,16 +303,43 @@ export default function UnifiedLeftPanel({
       <button
         key={run.run_id}
         data-run-row={run.run_id}
+        data-depth={node.depth}
+        aria-level={node.depth + 1}
+        aria-expanded={hasChildren ? expanded : undefined}
         onClick={() => onSelectRun(run.run_id)}
-        className={`group flex w-full cursor-pointer items-center gap-2 border-b border-l-2 border-line-soft px-3 py-2 text-left transition-colors ${
+        onKeyDown={(e) => {
+          // #783 decision 2 — ← / → drive the tree from the focused row: → opens
+          // a collapsed parent; ← closes an open one, or climbs to the parent
+          // row when there is nothing left to close.
+          if (e.key === "ArrowRight" && hasChildren && !expanded) {
+            e.preventDefault();
+            setExpanded(run.run_id, true);
+          } else if (e.key === "ArrowLeft") {
+            if (hasChildren && expanded) {
+              e.preventDefault();
+              setExpanded(run.run_id, false);
+            } else if (run.parent_run_id) {
+              e.preventDefault();
+              runsScrollRef.current
+                ?.querySelector<HTMLElement>(`[data-run-row="${run.parent_run_id}"]`)
+                ?.focus();
+            }
+          }
+        }}
+        style={{ fontSize: "11.5px", paddingLeft: 12 + node.depth * 14 }}
+        className={`group flex w-full cursor-pointer items-stretch gap-2 border-b border-l-2 border-line-soft py-2 pr-3 text-left transition-colors ${
           rowSelected
             ? "border-l-acc bg-acc-bg text-fg"
             : isSelected
               ? "border-l-transparent bg-bg-3 text-fg"
               : "border-l-transparent text-fg-2 hover:bg-bg-3/50"
         } ${isArchived ? "opacity-60" : ""}`}
-        style={{ fontSize: "11.5px" }}
       >
+        {/* Left column (16px, shared shape with Library / Triggers rows): the
+            #577 select control, and — only on a row with children — the #783
+            chevron stacked under it. Two distinct targets: the chevron never
+            selects nor opens the run. */}
+        <div className="flex w-4 shrink-0 flex-col items-center gap-1">
         {/* #577 — the status dot doubles as the select control: it goes hollow on
             hover and becomes a green check when selected. #503: the resting dot
             still carries the failure reason so a red Run has something to say. */}
@@ -310,6 +356,23 @@ export default function UnifiedLeftPanel({
             else toggleSel("runs", run.run_id);
           }}
         />
+        {hasChildren && (
+          <span
+            role="button"
+            aria-label={expanded ? "Collapse child runs" : "Expand child runs"}
+            aria-expanded={expanded}
+            title={expanded ? "Collapse child runs" : "Expand child runs"}
+            data-testid="run-tree-chevron"
+            className="grid h-3.5 w-4 cursor-pointer place-items-center rounded text-fg-4 transition-colors hover:bg-bg-4 hover:text-fg-2"
+            onClick={(e) => {
+              e.stopPropagation();
+              setExpanded(run.run_id, !expanded);
+            }}
+          >
+            {expanded ? <ChevronDown size={11} /> : <ChevronRight size={11} />}
+          </span>
+        )}
+        </div>
         <div className="min-w-0 flex-1">
           {isRenaming ? (
             <input
@@ -338,12 +401,10 @@ export default function UnifiedLeftPanel({
             <span className="truncate" data-testid="run-pipeline-name">
               {run.pipeline_name}
             </span>
-            {/* #725 — provenance badges, icon-only (user decision 2026-09-06):
-                the words live in the `title`; `aria-label` carries the word for
-                AT. Same bordered 9px-chip shape so both read as "provenance",
-                different colours so they are never confused: the trigger is
-                accent-green, orchestrated is neutral grey. Both can coexist
-                (a child run may also be trigger-launched). */}
+            {/* Provenance badge, icon-only (#725, user decision 2026-09-06): the
+                words live in the `title`; `aria-label` carries the word for AT.
+                #783 dropped the « orchestrated » badge — the indentation says
+                the filiation; the trigger badge stays. */}
             {run.triggered_by && (
               <span
                 role="button"
@@ -362,41 +423,14 @@ export default function UnifiedLeftPanel({
                 <Zap size={9} />
               </span>
             )}
-            {run.parent_run_id &&
-              (() => {
-                // Parent resolved client-side from the list (no fetch). An
-                // orphan (parent forgotten) keeps its badge — the run WAS
-                // orchestrated — but dimmed and inert.
-                const parent = runs.find((r) => r.run_id === run.parent_run_id);
-                return (
-                  <span
-                    role="button"
-                    aria-label="orchestrated"
-                    aria-disabled={parent ? undefined : true}
-                    title={
-                      parent
-                        ? `Orchestrated by “${parent.name || parent.run_id}” — click to open the parent run`
-                        : "Orchestrated by a run that was forgotten"
-                    }
-                    className={`flex shrink-0 items-center rounded border border-fg-4 px-1.5 py-[2px] text-fg-3 transition-colors ${
-                      parent
-                        ? "cursor-pointer hover:border-fg-3 hover:text-fg-2"
-                        : "cursor-default opacity-70"
-                    }`}
-                    data-testid="run-orchestrated-badge"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      if (!parent) return;
-                      setScrollRequest(parent.run_id);
-                      if (parent.run_id !== selectedRunId) onSelectRun(parent.run_id);
-                    }}
-                  >
-                    <GitFork size={9} />
-                  </span>
-                );
-              })()}
           </div>
         </div>
+        {/* Right column (#783): line 1 = the hover-revealed action icons, line 2
+            = the aggregated child counts, always visible, bottom-right. The
+            actions row keeps its height at rest so the pills never move when the
+            icons appear. */}
+        <div className="flex shrink-0 flex-col items-end justify-between gap-1">
+        <div className="flex h-4 items-center">
         {!isRenaming && (
           <span
             role="button"
@@ -503,45 +537,105 @@ export default function UnifiedLeftPanel({
             <Trash2 size={12} />
           </span>
         )}
+        </div>
+        {hasChildren && (
+          <ChildCountPills
+            counts={node.counts}
+            size="xs"
+            testId="run-child-pills"
+            // Decision 1 — the pills of a COLLAPSED parent expand it; once open
+            // they are inert and the click reaches the row as usual.
+            onClick={expanded ? undefined : () => setExpanded(run.run_id, true)}
+            clickHint="click to expand"
+          />
+        )}
+        </div>
       </button>
     );
   }
 
   // #336 — client-side run filters (project / pipeline / trigger), AND
-  // semantics, session-only state. Applied to `runs` BEFORE the active/archived
-  // split so grouping, the Archived section and its count all see the same
-  // filtered view.
+  // semantics, session-only state. #783: applied to the TREE (a non-matching
+  // parent is kept as a path to a matching descendant) and BEFORE the
+  // active/archived split, so grouping, the Archived section and its count all
+  // see the same filtered view.
   const [runFilter, setRunFilter] = useState(EMPTY_RUN_FILTER);
-  const filteredRuns = useMemo(
-    () => runs.filter((r) => runMatchesFilter(r, runFilter)),
-    [runs, runFilter],
-  );
   const filterActive = isFilterActive(runFilter);
 
-  // #725 — after an orchestrated-badge click, scroll the parent's row into view:
-  // the parent is usually above its children but can sit off-screen on long
-  // lists (and inside the Archived section, whose auto-expand only lands after
-  // the selection re-renders). The request rides STATE (not a ref) so the row
-  // mapper stays ref-free (react-hooks/refs); the effect consumes it one-shot.
+  // #783 — the run tree, built from ALL runs so a child follows its parent into
+  // whatever section / group the ROOT lands in, whatever the child's own status
+  // or repo. The archived split is on the root: a live child of an archived
+  // parent sits in the Archived section under it (the parent stays listed, so
+  // the child is not an orphan); once the parent is forgotten the child is a root.
+  const tree = useMemo(() => buildRunTree(runs), [runs]);
+  const { activeTree, archivedTree } = useMemo(() => {
+    const match = (r: RunListEntry) => runMatchesFilter(r, runFilter);
+    return {
+      activeTree: filterRunTree(tree.filter((n) => n.run.status !== "archived"), match),
+      archivedTree: filterRunTree(tree.filter((n) => n.run.status === "archived"), match),
+    };
+  }, [tree, runFilter]);
+  const filteredRuns = useMemo(
+    () => [...flattenAll(activeTree), ...flattenAll(archivedTree)],
+    [activeTree, archivedTree],
+  );
+
+  // #783 — expand / collapse state. `sessionDefault` is seeded ONCE from the
+  // per-browser preference (Settings › Interface); per-row toggles land in
+  // `expandOverrides`, the global button rewrites both. Nothing here is
+  // persisted (« bascules par ligne non mémorisées »). While a filter is active
+  // a kept parent opens on its matching children unless the user closed it.
+  const [sessionDefault, setSessionDefault] = useState(loadChildRunsExpanded);
+  const [expandOverrides, setExpandOverrides] = useState<ReadonlyMap<string, boolean>>(
+    () => new Map(),
+  );
+  const isExpanded = (runId: string): boolean =>
+    expandOverrides.get(runId) ?? (filterActive ? true : sessionDefault);
+  const setExpanded = (runId: string, v: boolean) =>
+    setExpandOverrides((m) => new Map(m).set(runId, v));
+  const allParentIds = useMemo(() => parentIds(tree), [tree]);
+
+  // #725/#783 — reveal the selected run: when the selection CHANGES to a run
+  // whose ancestors are collapsed (Orchestration tab, URL, back navigation),
+  // open them and scroll the row into view once it exists. Adjusting state
+  // during render on a tracked-key change is React's reset-on-prop pattern
+  // (cf. `prevSelectedArchivedId` below). The request rides STATE so the row
+  // mapper stays ref-free; the effect scrolls once per new request (the value
+  // changes with every selection change, so no reset is needed).
   const runsScrollRef = useRef<HTMLDivElement>(null);
   const [scrollRequest, setScrollRequest] = useState<string | null>(null);
+  const [prevSelectedRunId, setPrevSelectedRunId] = useState(selectedRunId);
+  if (prevSelectedRunId !== selectedRunId) {
+    setPrevSelectedRunId(selectedRunId);
+    if (selectedRunId !== null) {
+      const chain = ancestorIds(runs, selectedRunId);
+      if (chain.some((id) => !isExpanded(id))) {
+        setExpandOverrides((m) => {
+          const next = new Map(m);
+          for (const id of chain) next.set(id, true);
+          return next;
+        });
+      }
+      if (chain.length > 0) setScrollRequest(selectedRunId);
+    }
+  }
   useEffect(() => {
     if (scrollRequest === null || selectedRunId !== scrollRequest) return;
-    setScrollRequest(null);
     runsScrollRef.current
       ?.querySelector(`[data-run-row="${scrollRequest}"]`)
       ?.scrollIntoView({ block: "nearest" });
   }, [scrollRequest, selectedRunId]);
 
   // #136 — archived runs live in their own flat, collapsible section below the
-  // active list; the active list keeps the #258 per-repo grouping.
-  const activeRuns = filteredRuns.filter((r) => r.status !== "archived");
-  const archivedRuns = filteredRuns.filter((r) => r.status === "archived");
+  // active list; the active list keeps the #258 per-repo grouping. #783: the
+  // section holds archived ROOTS and their subtrees.
+  const archivedCount = archivedTree.length;
 
-  // Identity of the selected run *iff* it currently sits in the archived set,
-  // else null — the signal that must reveal the section.
+  // Identity of the selected run *iff* its tree currently sits in the archived
+  // set (its root is archived), else null — the signal that must reveal the
+  // section. A live child of an archived parent counts: it lives there too.
   const selectedArchivedId =
-    selectedRunId != null && archivedRuns.some((r) => r.run_id === selectedRunId)
+    selectedRunId != null && rootOf(runs, selectedRunId)?.status === "archived"
       ? selectedRunId
       : null;
 
@@ -561,6 +655,24 @@ export default function UnifiedLeftPanel({
     if (selectedArchivedId !== null) setArchivedOpen(true);
   }
 
+  // #783 — the expand/collapse-all button's state, derived from the VISIBLE
+  // parents (the archived ones only while the section is open). Neutral: this
+  // is not a filter and never summons the clear ✕.
+  const visibleParentIds = [
+    ...parentIds(activeTree),
+    ...(archivedOpen ? parentIds(archivedTree) : []),
+  ];
+  const allExpanded =
+    visibleParentIds.length > 0 ? visibleParentIds.every(isExpanded) : sessionDefault;
+  const setAllExpanded = (v: boolean) => {
+    setSessionDefault(v);
+    // Under an active filter the default is "open", so collapsing must pin
+    // every visible parent shut explicitly; expanding just drops the pins.
+    setExpandOverrides(
+      !v && filterActive ? new Map(visibleParentIds.map((id) => [id, false])) : new Map(),
+    );
+  };
+
   // #552 — verbatim `path → Projet` lookup, and the candidate repos the pencil
   // can attach (the distinct effective repos across ALL runs, so a filtered view
   // never hides an attachable repo).
@@ -579,15 +691,20 @@ export default function UnifiedLeftPanel({
   }, [projects, recentRepos, runs]);
 
   // Group the active Runs list by Projet (#552), falling back to the #258
-  // per-path grouping when nothing is named; `null` ⇒ the flat list.
-  const runGroups = groupByProject(activeRuns, (r) => r.effective_repo, projectOf);
+  // per-path grouping when nothing is named; `null` ⇒ the flat list. #783: the
+  // grouping key is the ROOT's repo — a child follows its parent whatever its
+  // own repo.
+  const runGroups = groupByProject(activeTree, (n) => n.run.effective_repo, projectOf);
+  const orderedActive: RunTreeNode[] =
+    runGroups === null ? activeTree : runGroups.flatMap((g) => g.items);
 
   // #577 — Runs multi-select derivations. `visibleRunIds` is the flattened visible
-  // order (grouped active list, then the archived section only when expanded) —
-  // the basis for a shift-range and for select-all-visible.
+  // order (grouped active list, then the archived section only when expanded),
+  // collapsed subtrees excluded (#783) — the basis for a shift-range and for
+  // select-all-visible.
   const visibleRunIds = [
-    ...(runGroups === null ? activeRuns : runGroups.flatMap((g) => g.items)).map((r) => r.run_id),
-    ...(archivedOpen ? archivedRuns.map((r) => r.run_id) : []),
+    ...flattenVisible(orderedActive, isExpanded).map((n) => n.run.run_id),
+    ...(archivedOpen ? flattenVisible(archivedTree, isExpanded).map((n) => n.run.run_id) : []),
   ];
   const selectedRuns = filteredRuns.filter((r) => runSel.has(r.run_id));
   const asRunItem = (r: RunListEntry): BulkItem => ({ id: r.run_id, label: r.name || r.run_id });
@@ -761,6 +878,11 @@ export default function UnifiedLeftPanel({
             triggers={triggers}
             value={runFilter}
             onChange={setRunFilter}
+            treeToggle={
+              allParentIds.length > 0
+                ? { allExpanded, onToggle: () => setAllExpanded(!allExpanded) }
+                : null
+            }
           />
         )}
         <div
@@ -805,7 +927,7 @@ export default function UnifiedLeftPanel({
             </div>
           )}
           {runGroups === null
-            ? activeRuns.map(renderRunRow)
+            ? flattenVisible(activeTree, isExpanded).map(renderRunRow)
             : runGroups.map((group) => (
                 <div
                   key={group.key}
@@ -821,10 +943,15 @@ export default function UnifiedLeftPanel({
                     <SelectControl
                       selected={
                         group.items.length > 0 &&
-                        group.items.every((r) => runSel.has(r.run_id))
+                        flattenVisible(group.items, isExpanded).every((n) => runSel.has(n.run.run_id))
                       }
                       label={`Select all in ${group.label}`}
-                      onSelect={() => selectGroup("runs", group.items.map((r) => r.run_id))}
+                      onSelect={() =>
+                        selectGroup(
+                          "runs",
+                          flattenVisible(group.items, isExpanded).map((n) => n.run.run_id),
+                        )
+                      }
                       testId="run-group-select-all"
                     />
                     <span className="truncate" data-testid="run-repo-label">
@@ -841,7 +968,7 @@ export default function UnifiedLeftPanel({
                       <Pencil size={10} />
                     </button>
                   </div>
-                  {group.items.map(renderRunRow)}
+                  {flattenVisible(group.items, isExpanded).map(renderRunRow)}
                 </div>
               ))}
           {/* #136 — archived runs in their own flat, collapsible section below
@@ -849,7 +976,7 @@ export default function UnifiedLeftPanel({
               styling / Forget action). The rendered gate is `archivedOpen`
               ALONE — never `archivedOpen || some(selected)`, which dead-locks
               the chevron while a selected run is archived (see decision 4). */}
-          {archivedRuns.length > 0 && (
+          {archivedCount > 0 && (
             <div data-testid="run-archived-section" className="border-t border-line">
               <button
                 onClick={() => setArchivedOpen((o) => !o)}
@@ -859,10 +986,10 @@ export default function UnifiedLeftPanel({
               >
                 {archivedOpen ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
                 <span className="font-medium">
-                  Archived <span data-testid="run-archived-count">({archivedRuns.length})</span>
+                  Archived <span data-testid="run-archived-count">({archivedCount})</span>
                 </span>
               </button>
-              {archivedOpen && archivedRuns.map(renderRunRow)}
+              {archivedOpen && flattenVisible(archivedTree, isExpanded).map(renderRunRow)}
             </div>
           )}
         </div>

--- a/frontend/src/components/UnifiedLeftPanel.tsx
+++ b/frontend/src/components/UnifiedLeftPanel.tsx
@@ -564,9 +564,9 @@ export default function UnifiedLeftPanel({
 
   // #783 — the run tree, built from ALL runs so a child follows its parent into
   // whatever section / group the ROOT lands in, whatever the child's own status
-  // or repo. The archived split is on the root: a live child of an archived
-  // parent sits in the Archived section under it (the parent stays listed, so
-  // the child is not an orphan); once the parent is forgotten the child is a root.
+  // or repo. The archived split is on the root — and an archived run is always
+  // a leaf (`buildRunTree` releases its children as roots, ADR-0064), so the
+  // Archived section only ever holds archived runs, never a live child.
   const tree = useMemo(() => buildRunTree(runs), [runs]);
   const { activeTree, archivedTree } = useMemo(() => {
     const match = (r: RunListEntry) => runMatchesFilter(r, runFilter);
@@ -628,12 +628,13 @@ export default function UnifiedLeftPanel({
 
   // #136 — archived runs live in their own flat, collapsible section below the
   // active list; the active list keeps the #258 per-repo grouping. #783: the
-  // section holds archived ROOTS and their subtrees.
+  // section holds archived roots (always leaves — an archived parent releases
+  // its children, which climb back to the active section as roots).
   const archivedCount = archivedTree.length;
 
   // Identity of the selected run *iff* its tree currently sits in the archived
-  // set (its root is archived), else null — the signal that must reveal the
-  // section. A live child of an archived parent counts: it lives there too.
+  // set (its root is archived — i.e. it IS archived, since an archived run
+  // retains no children), else null — the signal that must reveal the section.
   const selectedArchivedId =
     selectedRunId != null && rootOf(runs, selectedRunId)?.status === "archived"
       ? selectedRunId

--- a/frontend/src/components/runFilter.test.ts
+++ b/frontend/src/components/runFilter.test.ts
@@ -2,15 +2,14 @@ import { describe, it, expect } from "vitest";
 import {
   EMPTY_RUN_FILTER,
   isFilterActive,
-  isRootRun,
   runMatchesFilter,
   type RunFilterValue,
 } from "./runFilter";
 import type { RunListEntry } from "../types";
 
-/* #725 — the fourth filter axis. `showOrchestrated: false` narrows the list to
-   root runs (no `parent_run_id`); it composes with the three #336 axes with AND
-   semantics and is part of `isFilterActive`, so the strip's clear ✕ resets it. */
+/* #336 filter model; #783 removed the #725 `showOrchestrated` axis — a child run
+   is a tree row under its parent (`lib/runTree.ts`), not a filterable population.
+   The filter is a per-run predicate on three axes with AND semantics. */
 
 const run = (over: Partial<RunListEntry>): RunListEntry => ({
   run_id: "r",
@@ -23,43 +22,25 @@ const run = (over: Partial<RunListEntry>): RunListEntry => ({
 const root = run({ run_id: "root" });
 const child = run({ run_id: "child", parent_run_id: "root" });
 
-describe("runFilter #725 — showOrchestrated axis", () => {
-  it("defaults to showing orchestrated runs (EMPTY_RUN_FILTER)", () => {
-    expect(EMPTY_RUN_FILTER.showOrchestrated).toBe(true);
+describe("runFilter — three axes, filiation-blind (#783)", () => {
+  it("the empty filter matches roots and children alike", () => {
     expect(runMatchesFilter(child, EMPTY_RUN_FILTER)).toBe(true);
     expect(runMatchesFilter(root, EMPTY_RUN_FILTER)).toBe(true);
+    expect("showOrchestrated" in EMPTY_RUN_FILTER).toBe(false);
   });
 
-  it("classifies roots and children from parent_run_id", () => {
-    expect(isRootRun(root)).toBe(true);
-    expect(isRootRun(child)).toBe(false);
-    // A null parent id (daemon ships the field on every entry) is still a root.
-    expect(isRootRun(run({ parent_run_id: null }))).toBe(true);
+  it("composes the axes with AND semantics", () => {
+    const alpha = run({ run_id: "a", effective_repo: "/repos/alpha", pipeline_name: "impl" });
+    const f: RunFilterValue = { repo: "/repos/alpha", pipeline: "impl", trigger: null };
+    expect(runMatchesFilter(alpha, f)).toBe(true);
+    expect(runMatchesFilter(alpha, { ...f, pipeline: "other" })).toBe(false);
+    expect(runMatchesFilter(alpha, { ...f, repo: "/repos/beta" })).toBe(false);
   });
 
-  it("hides children and keeps roots when showOrchestrated is false", () => {
-    const f: RunFilterValue = { ...EMPTY_RUN_FILTER, showOrchestrated: false };
-    expect(runMatchesFilter(child, f)).toBe(false);
-    expect(runMatchesFilter(root, f)).toBe(true);
-  });
-
-  it("composes with the other axes with AND semantics", () => {
-    const alpha = run({ run_id: "a", effective_repo: "/repos/alpha", parent_run_id: "root" });
-    const f: RunFilterValue = {
-      repo: "/repos/alpha",
-      pipeline: null,
-      trigger: null,
-      showOrchestrated: false,
-    };
-    // Matches the repo axis but is a child ⇒ filtered out.
-    expect(runMatchesFilter(alpha, f)).toBe(false);
-    // Relax the toggle ⇒ visible again.
-    expect(runMatchesFilter(alpha, { ...f, showOrchestrated: true })).toBe(true);
-  });
-
-  it("reports the toggle in isFilterActive so the clear ✕ resets it", () => {
+  it("isFilterActive reports exactly the three axes", () => {
     expect(isFilterActive(EMPTY_RUN_FILTER)).toBe(false);
-    expect(isFilterActive({ ...EMPTY_RUN_FILTER, showOrchestrated: false })).toBe(true);
     expect(isFilterActive({ ...EMPTY_RUN_FILTER, repo: "/repos/x" })).toBe(true);
+    expect(isFilterActive({ ...EMPTY_RUN_FILTER, pipeline: "p" })).toBe(true);
+    expect(isFilterActive({ ...EMPTY_RUN_FILTER, trigger: "t" })).toBe(true);
   });
 });

--- a/frontend/src/components/runFilter.ts
+++ b/frontend/src/components/runFilter.ts
@@ -21,19 +21,16 @@ export interface RunFilterValue {
   pipeline: string | null;
   /** A trigger id, or MANUAL_TRIGGER for manually launched runs. */
   trigger: string | null;
-  /**
-   * #725 — whether runs started by another run (orchestrated children) are
-   * listed. ON by default ("déplié par défaut", issue #725): a child parked
-   * `awaiting_user` must stay visible, so hiding it is an explicit act.
-   */
-  showOrchestrated: boolean;
 }
 
+/* #783 — the #725 `showOrchestrated` axis is gone: children are no longer a
+   filterable population but rows nested under their parent (`lib/runTree.ts`),
+   and the strip's fourth control is the expand/collapse-all button, which is
+   NOT a filter (never accent, never part of `isFilterActive`). */
 export const EMPTY_RUN_FILTER: RunFilterValue = {
   repo: null,
   pipeline: null,
   trigger: null,
-  showOrchestrated: true,
 };
 
 /** The filter key for a run on each axis (empty/missing values bucket to a sentinel). */
@@ -48,28 +45,22 @@ export function triggerKey(r: RunListEntry): string {
   return r.triggered_by ?? MANUAL_TRIGGER;
 }
 
-/** #725 — a root run is one no other run started. */
-export function isRootRun(r: RunListEntry): boolean {
-  return !r.parent_run_id;
-}
-
 /**
- * AND predicate over the four axes; a null axis means "All", and
- * `showOrchestrated: false` narrows the list to roots (#725).
+ * AND predicate over the three axes; a null axis means "All". On the tree
+ * (#783) this is the per-run match: `filterRunTree` keeps a non-matching
+ * parent as long as a descendant matches.
  */
 export function runMatchesFilter(r: RunListEntry, f: RunFilterValue): boolean {
   if (f.repo !== null && repoKey(r) !== f.repo) return false;
   if (f.pipeline !== null && pipelineKey(r) !== f.pipeline) return false;
   if (f.trigger !== null && triggerKey(r) !== f.trigger) return false;
-  if (!f.showOrchestrated && !isRootRun(r)) return false;
   return true;
 }
 
 /**
  * True when at least one axis narrows the list — the condition for the strip's
- * clear ✕ (and the empty state's). #725 adds the orchestrated toggle to it, so
- * clearing resets the toggle to ON for free.
+ * clear ✕ (and the empty state's).
  */
 export function isFilterActive(f: RunFilterValue): boolean {
-  return f.repo !== null || f.pipeline !== null || f.trigger !== null || !f.showOrchestrated;
+  return f.repo !== null || f.pipeline !== null || f.trigger !== null;
 }

--- a/frontend/src/lib/orchestration.test.ts
+++ b/frontend/src/lib/orchestration.test.ts
@@ -9,12 +9,16 @@ import {
   type RunChildEntry,
 } from "./orchestration";
 
-function child(status: RunChildEntry["status"], cost?: RunChildEntry["cost"]): RunChildEntry {
-  return { run_id: `run-${status}-${Math.random()}`, pipeline_name: "p", status, cost };
+function child(
+  status: RunChildEntry["status"],
+  cost?: RunChildEntry["cost"],
+  stalled?: boolean,
+): RunChildEntry {
+  return { run_id: `run-${status}-${Math.random()}`, pipeline_name: "p", status, cost, stalled };
 }
 
 describe("countChildren (#723)", () => {
-  it("buckets failed / running / finished with the three pills totalling the children", () => {
+  it("buckets failed / running / finished with the pills totalling the children", () => {
     const counts = countChildren([
       child("completed"),
       child("skipped"),
@@ -23,8 +27,21 @@ describe("countChildren (#723)", () => {
       child("awaiting_user"),
       child("paused"),
     ]);
-    expect(counts).toEqual({ finished: 2, failed: 1, running: 3 });
+    expect(counts).toEqual({ finished: 2, failed: 1, stale: 0, running: 3 });
     expect(totalChildren(counts)).toBe(6);
+  });
+
+  it("#783 — a live stalled child is STALE, carved out of running (disjoint sets)", () => {
+    const counts = countChildren([
+      child("running", undefined, true),
+      child("running", undefined, false),
+      child("awaiting_user", undefined, true),
+      // A terminal run can never be stale, whatever the flag says.
+      child("completed", undefined, true),
+      child("failed", undefined, true),
+    ]);
+    expect(counts).toEqual({ finished: 1, failed: 1, stale: 2, running: 1 });
+    expect(totalChildren(counts)).toBe(5);
   });
 
   it("counts awaiting_user and paused as RUNNING (blue) — design decision 3", () => {

--- a/frontend/src/lib/orchestration.ts
+++ b/frontend/src/lib/orchestration.ts
@@ -11,6 +11,12 @@ export interface RunChildEntry {
   pipeline_name: string;
   name?: string;
   status: RunStatus;
+  /**
+   * #783 — display-only "no forward progress" overlay, derived per read by the
+   * daemon exactly as on `GET /runs` (#180). Optional so a daemon predating the
+   * field (or a fixture omitting it) still typechecks — absent reads as not stalled.
+   */
+  stalled?: boolean;
   started_at?: string;
   completed_at?: string;
   /** The daemon's CostStat, derived on read (ADR-0052) — never persisted.
@@ -35,30 +41,41 @@ export interface RunChildrenResponse {
   nodes: RunChildrenGroup[];
 }
 
-/** Pastille counters: green / red / blue. */
+/**
+ * Pastille counters — the « compteurs d'enfants » of CONTEXT.md (#783): green
+ * finished / red failed / orange stale / blue running. Four DISJOINT sets whose
+ * sum is the number of children (or descendants, on the run list).
+ */
 export interface ChildCounts {
+  /** Terminal, not failed: completed, halted, skipped, archived. */
   finished: number;
   failed: number;
+  /** Live AND `stalled` (#180): no forward progress, amber like the list dot. */
+  stale: number;
+  /** Live and not stalled: running, awaiting_user, paused. */
   running: number;
 }
 
 /**
  * `awaiting_user` / `paused` count as **running** (decision 3 of the design,
- * 2026-09-07): the blue pill is "still to settle", and a failed child is red
- * — the two sets stay disjoint, so the three pills always total the children.
+ * 2026-09-07): the blue pill is "still to settle", and a failed child is red.
+ * #783 carves **stale** out of running (live + `stalled`) — the four sets stay
+ * disjoint, so the pills always total the children.
  */
 export function countChildren(children: RunChildEntry[]): ChildCounts {
-  const counts: ChildCounts = { finished: 0, failed: 0, running: 0 };
+  const counts: ChildCounts = { finished: 0, failed: 0, stale: 0, running: 0 };
   for (const child of children) {
     if (child.status === "failed") counts.failed += 1;
-    else if (isLiveRun(child.status)) counts.running += 1;
-    else counts.finished += 1;
+    else if (isLiveRun(child.status)) {
+      if (child.stalled) counts.stale += 1;
+      else counts.running += 1;
+    } else counts.finished += 1;
   }
   return counts;
 }
 
 export function totalChildren(counts: ChildCounts): number {
-  return counts.finished + counts.failed + counts.running;
+  return counts.finished + counts.failed + counts.stale + counts.running;
 }
 
 /**

--- a/frontend/src/lib/runTree.test.ts
+++ b/frontend/src/lib/runTree.test.ts
@@ -1,0 +1,141 @@
+// #783 — unit tests for the pure run-tree model behind the Runs list.
+import { describe, expect, it } from "vitest";
+import type { RunListEntry } from "../types";
+import {
+  ancestorIds,
+  buildRunTree,
+  filterRunTree,
+  flattenAll,
+  flattenVisible,
+  parentIds,
+  pathOnlyIds,
+  rootOf,
+  runCountBucket,
+} from "./runTree";
+
+const run = (id: string, over: Partial<RunListEntry> = {}): RunListEntry => ({
+  run_id: id,
+  pipeline_name: "p",
+  status: "running",
+  started_at: null,
+  ...over,
+});
+
+const list: RunListEntry[] = [
+  run("epic"),
+  run("kid", { parent_run_id: "epic", stalled: true }),
+  run("kid2", { parent_run_id: "epic", status: "failed", pipeline_name: "impl" }),
+  run("grandkid", { parent_run_id: "kid", status: "completed", pipeline_name: "review" }),
+  run("orphan", { parent_run_id: "forgotten", status: "halted" }),
+  run("solo", { status: "archived" }),
+];
+
+describe("buildRunTree", () => {
+  it("nests a child under a LISTED parent and keeps the list order among siblings", () => {
+    const forest = buildRunTree(list);
+    expect(forest.map((n) => n.run.run_id)).toEqual(["epic", "orphan", "solo"]);
+    const epic = forest[0];
+    expect(epic.children.map((n) => n.run.run_id)).toEqual(["kid", "kid2"]);
+    expect(epic.children[0].children.map((n) => n.run.run_id)).toEqual(["grandkid"]);
+    expect(epic.depth).toBe(0);
+    expect(epic.children[0].depth).toBe(1);
+    expect(epic.children[0].children[0].depth).toBe(2);
+  });
+
+  it("makes a run whose parent is absent (forgotten / never listed) a root", () => {
+    const forest = buildRunTree(list);
+    expect(forest.find((n) => n.run.run_id === "orphan")?.depth).toBe(0);
+  });
+
+  it("aggregates the four disjoint counts over the WHOLE subtree", () => {
+    const [epic] = buildRunTree(list);
+    // kid (live+stalled ⇒ stale), kid2 (failed), grandkid (completed ⇒ finished)
+    expect(epic.counts).toEqual({ finished: 1, failed: 1, stale: 1, running: 0 });
+    expect(epic.children[0].counts).toEqual({ finished: 1, failed: 0, stale: 0, running: 0 });
+    expect(epic.children[1].counts).toEqual({ finished: 0, failed: 0, stale: 0, running: 0 });
+  });
+
+  it("never loses a run to a corrupted parent cycle", () => {
+    const cyclic = [run("a", { parent_run_id: "b" }), run("b", { parent_run_id: "a" })];
+    const ids = flattenAll(buildRunTree(cyclic)).map((r) => r.run_id).sort();
+    expect(ids).toEqual(["a", "b"]);
+  });
+});
+
+describe("runCountBucket", () => {
+  it("buckets by status and stalled: finished / failed / stale / running", () => {
+    expect(runCountBucket(run("x", { status: "completed" }))).toBe("finished");
+    expect(runCountBucket(run("x", { status: "halted" }))).toBe("finished");
+    expect(runCountBucket(run("x", { status: "skipped" }))).toBe("finished");
+    expect(runCountBucket(run("x", { status: "archived" }))).toBe("finished");
+    expect(runCountBucket(run("x", { status: "failed" }))).toBe("failed");
+    expect(runCountBucket(run("x", { status: "failed", stalled: true }))).toBe("failed");
+    expect(runCountBucket(run("x", { status: "running", stalled: true }))).toBe("stale");
+    expect(runCountBucket(run("x", { status: "awaiting_user", stalled: true }))).toBe("stale");
+    expect(runCountBucket(run("x", { status: "running" }))).toBe("running");
+    expect(runCountBucket(run("x", { status: "awaiting_user" }))).toBe("running");
+    expect(runCountBucket(run("x", { status: "paused" }))).toBe("running");
+  });
+});
+
+describe("filterRunTree", () => {
+  it("keeps a non-matching parent as the path to a matching descendant and drops non-matching siblings", () => {
+    const forest = filterRunTree(buildRunTree(list), (r) => r.pipeline_name === "review");
+    expect(forest.map((n) => n.run.run_id)).toEqual(["epic"]);
+    expect(forest[0].children.map((n) => n.run.run_id)).toEqual(["kid"]);
+    expect(forest[0].children[0].children.map((n) => n.run.run_id)).toEqual(["grandkid"]);
+  });
+
+  it("does NOT recompute the counts — the pills describe the real subtree", () => {
+    const forest = filterRunTree(buildRunTree(list), (r) => r.pipeline_name === "review");
+    expect(forest[0].counts).toEqual({ finished: 1, failed: 1, stale: 1, running: 0 });
+  });
+
+  it("a matching parent keeps only its matching children", () => {
+    const forest = filterRunTree(buildRunTree(list), (r) => r.pipeline_name === "p");
+    const epic = forest.find((n) => n.run.run_id === "epic")!;
+    expect(epic.children.map((n) => n.run.run_id)).toEqual(["kid"]); // kid2 is "impl"
+    expect(epic.children[0].children).toEqual([]); // grandkid is "review"
+  });
+
+  it("returns nothing when nothing matches", () => {
+    expect(filterRunTree(buildRunTree(list), () => false)).toEqual([]);
+  });
+
+  it("pathOnlyIds names the parents kept only as a path", () => {
+    const match = (r: RunListEntry) => r.pipeline_name === "review";
+    const forest = filterRunTree(buildRunTree(list), match);
+    expect(pathOnlyIds(forest, match)).toEqual(["epic", "kid"]);
+  });
+});
+
+describe("parentIds / ancestorIds / rootOf", () => {
+  it("lists every node with children, depth-first", () => {
+    expect(parentIds(buildRunTree(list))).toEqual(["epic", "kid"]);
+  });
+
+  it("walks ancestors nearest-first through LISTED parents only", () => {
+    expect(ancestorIds(list, "grandkid")).toEqual(["kid", "epic"]);
+    expect(ancestorIds(list, "epic")).toEqual([]);
+    expect(ancestorIds(list, "orphan")).toEqual([]);
+    expect(ancestorIds(list, "unknown")).toEqual([]);
+  });
+
+  it("resolves the root of a nested run (itself for a root)", () => {
+    expect(rootOf(list, "grandkid")?.run_id).toBe("epic");
+    expect(rootOf(list, "orphan")?.run_id).toBe("orphan");
+    expect(rootOf(list, "nope")).toBeUndefined();
+  });
+});
+
+describe("flattenVisible", () => {
+  it("skips the subtree of a collapsed parent — the shift-range basis", () => {
+    const forest = buildRunTree(list);
+    const all = flattenVisible(forest, () => true).map((n) => n.run.run_id);
+    expect(all).toEqual(["epic", "kid", "grandkid", "kid2", "orphan", "solo"]);
+    const kidClosed = flattenVisible(forest, (id) => id !== "kid").map((n) => n.run.run_id);
+    expect(kidClosed).toEqual(["epic", "kid", "kid2", "orphan", "solo"]);
+    const epicClosed = flattenVisible(forest, (id) => id !== "epic").map((n) => n.run.run_id);
+    expect(epicClosed).toEqual(["epic", "orphan", "solo"]);
+  });
+});

--- a/frontend/src/lib/runTree.test.ts
+++ b/frontend/src/lib/runTree.test.ts
@@ -47,6 +47,26 @@ describe("buildRunTree", () => {
     expect(forest.find((n) => n.run.run_id === "orphan")?.depth).toBe(0);
   });
 
+  it("makes the children of an ARCHIVED parent roots — archive does not touch the child (ADR-0064)", () => {
+    const archived: RunListEntry[] = [
+      run("old", { status: "archived" }),
+      run("live", { parent_run_id: "old" }),
+      run("done", { parent_run_id: "old", status: "completed" }),
+      run("grand", { parent_run_id: "live", status: "failed" }),
+    ];
+    const forest = buildRunTree(archived);
+    expect(forest.map((n) => n.run.run_id)).toEqual(["old", "live", "done"]);
+    // The archived parent is a leaf: no chevron, no pills.
+    expect(forest[0].children).toEqual([]);
+    expect(forest[0].counts).toEqual({ finished: 0, failed: 0, stale: 0, running: 0 });
+    // The released child keeps its own subtree.
+    expect(forest[1].children.map((n) => n.run.run_id)).toEqual(["grand"]);
+    expect(forest[1].counts).toEqual({ finished: 0, failed: 1, stale: 0, running: 0 });
+    expect(ancestorIds(archived, "grand")).toEqual(["live"]);
+    expect(rootOf(archived, "grand")?.run_id).toBe("live");
+    expect(ancestorIds(archived, "live")).toEqual([]);
+  });
+
   it("aggregates the four disjoint counts over the WHOLE subtree", () => {
     const [epic] = buildRunTree(list);
     // kid (live+stalled ⇒ stale), kid2 (failed), grandkid (completed ⇒ finished)

--- a/frontend/src/lib/runTree.ts
+++ b/frontend/src/lib/runTree.ts
@@ -1,0 +1,200 @@
+/**
+ * Run tree (#783 / #784) — the pure read model behind the Runs list's tree
+ * rendering. See CONTEXT.md § "Orchestration récursive — arbre de runs".
+ *
+ * Everything that is NOT rendering lives here: building the tree from the flat
+ * `GET /runs` list (a child hangs under its parent when the parent is listed;
+ * an orphan — parent forgotten or absent — is a root), the aggregated child
+ * counts over a whole subtree (four disjoint pills whose sum is the number of
+ * descendants), the filter that keeps a parent as long as a descendant matches,
+ * the ancestor walk that reveals a hidden run, and the flattening into the
+ * visible row order (the basis for shift-range and select-all-visible).
+ *
+ * "Archived" is NOT a tree concept here: a child follows its parent into the
+ * Archived section whatever its own status, so the caller splits on the ROOT's
+ * status after `buildRunTree` and before `filterRunTree`.
+ */
+import type { RunListEntry } from "../types";
+import { isLiveRun } from "../types";
+import type { ChildCounts } from "./orchestration";
+
+export interface RunTreeNode {
+  run: RunListEntry;
+  children: RunTreeNode[];
+  /** Depth in the tree: 0 for a root. */
+  depth: number;
+  /**
+   * The four pills, aggregated over EVERY descendant (not just direct
+   * children) — always the real subtree, never the filtered view.
+   */
+  counts: ChildCounts;
+}
+
+/** The bucket a single run falls in: the four sets are disjoint by construction. */
+export function runCountBucket(run: RunListEntry): keyof ChildCounts {
+  if (run.status === "failed") return "failed";
+  if (isLiveRun(run.status)) return run.stalled ? "stale" : "running";
+  return "finished";
+}
+
+export function emptyCounts(): ChildCounts {
+  return { finished: 0, failed: 0, stale: 0, running: 0 };
+}
+
+function addCounts(into: ChildCounts, from: ChildCounts): void {
+  into.finished += from.finished;
+  into.failed += from.failed;
+  into.stale += from.stale;
+  into.running += from.running;
+}
+
+/**
+ * Build the forest from the flat list. Sibling order is the list's own order
+ * (the daemon already sorts by start date), so children read like the list.
+ * A run whose `parent_run_id` names a run that is NOT in the list is a root:
+ * a forgotten parent must not swallow its children.
+ *
+ * Cycles cannot arise from real daemon data (a parent always predates its
+ * child), but a defensive guard keeps a corrupted pair from recursing forever:
+ * a run already placed is never placed twice.
+ */
+export function buildRunTree(runs: RunListEntry[]): RunTreeNode[] {
+  const byId = new Map(runs.map((r) => [r.run_id, r]));
+  const childrenOf = new Map<string, RunListEntry[]>();
+  const roots: RunListEntry[] = [];
+  for (const r of runs) {
+    const pid = r.parent_run_id;
+    if (pid && pid !== r.run_id && byId.has(pid)) {
+      const list = childrenOf.get(pid) ?? [];
+      list.push(r);
+      childrenOf.set(pid, list);
+    } else {
+      roots.push(r);
+    }
+  }
+  const placed = new Set<string>();
+  const build = (run: RunListEntry, depth: number): RunTreeNode => {
+    placed.add(run.run_id);
+    const kids = (childrenOf.get(run.run_id) ?? []).filter((k) => !placed.has(k.run_id));
+    const children = kids.map((k) => build(k, depth + 1));
+    const counts = emptyCounts();
+    for (const child of children) {
+      counts[runCountBucket(child.run)] += 1;
+      addCounts(counts, child.counts);
+    }
+    return { run, children, depth, counts };
+  };
+  const forest = roots.map((r) => build(r, 0));
+  // A run caught in a cycle (never reachable from a root) is surfaced as a root
+  // rather than dropped — a list must never lose a run.
+  for (const r of runs) {
+    if (!placed.has(r.run_id)) forest.push(build(r, 0));
+  }
+  return forest;
+}
+
+/**
+ * Keep every node that matches OR has a matching descendant; a kept ancestor
+ * keeps only its matching (or ancestor-of-matching) children. Counts are NOT
+ * recomputed: the pills describe the real subtree, so a filtered parent still
+ * says how many children it truly has.
+ */
+export function filterRunTree(
+  nodes: RunTreeNode[],
+  matches: (run: RunListEntry) => boolean,
+): RunTreeNode[] {
+  const out: RunTreeNode[] = [];
+  for (const node of nodes) {
+    const children = filterRunTree(node.children, matches);
+    if (matches(node.run) || children.length > 0) {
+      out.push({ ...node, children });
+    }
+  }
+  return out;
+}
+
+/** Ids of every node that has at least one child (the rows with a chevron). */
+export function parentIds(nodes: RunTreeNode[]): string[] {
+  const out: string[] = [];
+  const walk = (list: RunTreeNode[]) => {
+    for (const n of list) {
+      if (n.children.length > 0) {
+        out.push(n.run.run_id);
+        walk(n.children);
+      }
+    }
+  };
+  walk(nodes);
+  return out;
+}
+
+/**
+ * Ids of the nodes the filter kept ONLY as a path to a matching descendant
+ * (they do not match themselves). These are the parents the filter opens.
+ */
+export function pathOnlyIds(
+  nodes: RunTreeNode[],
+  matches: (run: RunListEntry) => boolean,
+): string[] {
+  const out: string[] = [];
+  const walk = (list: RunTreeNode[]) => {
+    for (const n of list) {
+      if (n.children.length > 0) {
+        if (!matches(n.run)) out.push(n.run.run_id);
+        walk(n.children);
+      }
+    }
+  };
+  walk(nodes);
+  return out;
+}
+
+/**
+ * The ancestors of `runId` in the flat list, nearest first — following
+ * `parent_run_id` only through parents that ARE listed (an orphan has none).
+ * Guarded against cycles.
+ */
+export function ancestorIds(runs: RunListEntry[], runId: string): string[] {
+  const byId = new Map(runs.map((r) => [r.run_id, r]));
+  const out: string[] = [];
+  const seen = new Set<string>([runId]);
+  let cur = byId.get(runId);
+  while (cur?.parent_run_id && byId.has(cur.parent_run_id) && !seen.has(cur.parent_run_id)) {
+    out.push(cur.parent_run_id);
+    seen.add(cur.parent_run_id);
+    cur = byId.get(cur.parent_run_id);
+  }
+  return out;
+}
+
+/** The root run of `runId`'s tree (itself when it is a root). */
+export function rootOf(runs: RunListEntry[], runId: string): RunListEntry | undefined {
+  const chain = ancestorIds(runs, runId);
+  const rootId = chain.length > 0 ? chain[chain.length - 1] : runId;
+  return runs.find((r) => r.run_id === rootId);
+}
+
+/**
+ * Depth-first flattening in VISIBLE order: a node's children are included only
+ * when `isExpanded(node)` says so. This is the order a shift-range spans and
+ * Ctrl-A selects — a collapsed subtree is not "visible".
+ */
+export function flattenVisible(
+  nodes: RunTreeNode[],
+  isExpanded: (runId: string) => boolean,
+): RunTreeNode[] {
+  const out: RunTreeNode[] = [];
+  const walk = (list: RunTreeNode[]) => {
+    for (const n of list) {
+      out.push(n);
+      if (n.children.length > 0 && isExpanded(n.run.run_id)) walk(n.children);
+    }
+  };
+  walk(nodes);
+  return out;
+}
+
+/** Every run of the forest, depth-first, expanded or not (for "select all in group"). */
+export function flattenAll(nodes: RunTreeNode[]): RunListEntry[] {
+  return flattenVisible(nodes, () => true).map((n) => n.run);
+}

--- a/frontend/src/lib/runTree.ts
+++ b/frontend/src/lib/runTree.ts
@@ -3,16 +3,19 @@
  * rendering. See CONTEXT.md § "Orchestration récursive — arbre de runs".
  *
  * Everything that is NOT rendering lives here: building the tree from the flat
- * `GET /runs` list (a child hangs under its parent when the parent is listed;
- * an orphan — parent forgotten or absent — is a root), the aggregated child
+ * `GET /runs` list (a child hangs under its parent when the parent is listed
+ * AND alive — i.e. not `archived`; an orphan — parent forgotten, absent or
+ * archived — is a root, cf. CONTEXT.md « Run racine »), the aggregated child
  * counts over a whole subtree (four disjoint pills whose sum is the number of
  * descendants), the filter that keeps a parent as long as a descendant matches,
  * the ancestor walk that reveals a hidden run, and the flattening into the
  * visible row order (the basis for shift-range and select-all-visible).
  *
- * "Archived" is NOT a tree concept here: a child follows its parent into the
- * Archived section whatever its own status, so the caller splits on the ROOT's
- * status after `buildRunTree` and before `filterRunTree`.
+ * "Archived" enters the tree in exactly one way: an archived run never RETAINS
+ * children (archive of the parent does not touch the child, which becomes a
+ * root again — ADR-0064), so an archived run is always a leaf. Otherwise a
+ * child follows its parent whatever its own status, and the caller splits on
+ * the ROOT's status after `buildRunTree` and before `filterRunTree`.
  */
 import type { RunListEntry } from "../types";
 import { isLiveRun } from "../types";
@@ -28,6 +31,14 @@ export interface RunTreeNode {
    * children) — always the real subtree, never the filtered view.
    */
   counts: ChildCounts;
+}
+
+/**
+ * Whether `parent` can hold children in the tree: it must be listed and not
+ * archived (an archived parent has released its children, which are roots).
+ */
+function retainsChildren(parent: RunListEntry | undefined): parent is RunListEntry {
+  return parent !== undefined && parent.status !== "archived";
 }
 
 /** The bucket a single run falls in: the four sets are disjoint by construction. */
@@ -51,8 +62,9 @@ function addCounts(into: ChildCounts, from: ChildCounts): void {
 /**
  * Build the forest from the flat list. Sibling order is the list's own order
  * (the daemon already sorts by start date), so children read like the list.
- * A run whose `parent_run_id` names a run that is NOT in the list is a root:
- * a forgotten parent must not swallow its children.
+ * A run whose `parent_run_id` names a run that is NOT in the list — or that is
+ * `archived` — is a root: a forgotten or archived parent must not swallow its
+ * children (they would otherwise vanish from the active section).
  *
  * Cycles cannot arise from real daemon data (a parent always predates its
  * child), but a defensive guard keeps a corrupted pair from recursing forever:
@@ -64,7 +76,7 @@ export function buildRunTree(runs: RunListEntry[]): RunTreeNode[] {
   const roots: RunListEntry[] = [];
   for (const r of runs) {
     const pid = r.parent_run_id;
-    if (pid && pid !== r.run_id && byId.has(pid)) {
+    if (pid && pid !== r.run_id && retainsChildren(byId.get(pid))) {
       const list = childrenOf.get(pid) ?? [];
       list.push(r);
       childrenOf.set(pid, list);
@@ -151,15 +163,19 @@ export function pathOnlyIds(
 
 /**
  * The ancestors of `runId` in the flat list, nearest first — following
- * `parent_run_id` only through parents that ARE listed (an orphan has none).
- * Guarded against cycles.
+ * `parent_run_id` only through parents that ARE listed and not archived (an
+ * orphan has none) — the same rule as `buildRunTree`. Guarded against cycles.
  */
 export function ancestorIds(runs: RunListEntry[], runId: string): string[] {
   const byId = new Map(runs.map((r) => [r.run_id, r]));
   const out: string[] = [];
   const seen = new Set<string>([runId]);
   let cur = byId.get(runId);
-  while (cur?.parent_run_id && byId.has(cur.parent_run_id) && !seen.has(cur.parent_run_id)) {
+  while (
+    cur?.parent_run_id &&
+    retainsChildren(byId.get(cur.parent_run_id)) &&
+    !seen.has(cur.parent_run_id)
+  ) {
     out.push(cur.parent_run_id);
     seen.add(cur.parent_run_id);
     cur = byId.get(cur.parent_run_id);

--- a/frontend/src/lib/uiPrefs.test.ts
+++ b/frontend/src/lib/uiPrefs.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { loadTabsDisabled, saveTabsDisabled } from "./uiPrefs";
+import { loadChildRunsExpanded, loadTabsDisabled, saveChildRunsExpanded, saveTabsDisabled } from "./uiPrefs";
 
 beforeEach(() => {
   localStorage.clear();
@@ -50,5 +50,26 @@ describe("uiPrefs — tabsDisabled (#342)", () => {
       throw new Error("QuotaExceededError");
     });
     expect(() => saveTabsDisabled(true)).not.toThrow();
+  });
+});
+
+describe("uiPrefs — childRunsExpanded (#783)", () => {
+  it("defaults to TRUE when absent — « déplié par défaut »", () => {
+    expect(loadChildRunsExpanded()).toBe(true);
+  });
+
+  it("round-trips under the pdo.ui.childRunsExpanded key", () => {
+    saveChildRunsExpanded(false);
+    expect(localStorage.getItem("pdo.ui.childRunsExpanded")).toBe("false");
+    expect(loadChildRunsExpanded()).toBe(false);
+    saveChildRunsExpanded(true);
+    expect(loadChildRunsExpanded()).toBe(true);
+  });
+
+  it("falls back to true for garbage or a non-boolean", () => {
+    localStorage.setItem("pdo.ui.childRunsExpanded", "nope{");
+    expect(loadChildRunsExpanded()).toBe(true);
+    localStorage.setItem("pdo.ui.childRunsExpanded", JSON.stringify("false"));
+    expect(loadChildRunsExpanded()).toBe(true);
   });
 });

--- a/frontend/src/lib/uiPrefs.ts
+++ b/frontend/src/lib/uiPrefs.ts
@@ -32,3 +32,31 @@ export function saveTabsDisabled(v: boolean): void {
     // quota / disabled / private mode → in-memory only for this session
   }
 }
+
+/**
+ * #783 — whether a parent row's child runs are expanded when the run list
+ * loads (Settings › General › Interface, « Child runs »). Same nature as the
+ * theme: per-browser, saved at the change. Absent / unparseable → `true`
+ * (« déplié par défaut », CONTEXT.md). Per-row toggles and the expand/collapse-all
+ * button are session-only and never write here.
+ */
+const CHILD_RUNS_KEY = "pdo.ui.childRunsExpanded";
+
+export function loadChildRunsExpanded(): boolean {
+  try {
+    const raw = localStorage.getItem(CHILD_RUNS_KEY);
+    if (raw == null) return true;
+    const v: unknown = JSON.parse(raw);
+    return typeof v === "boolean" ? v : true;
+  } catch {
+    return true;
+  }
+}
+
+export function saveChildRunsExpanded(v: boolean): void {
+  try {
+    localStorage.setItem(CHILD_RUNS_KEY, JSON.stringify(v));
+  } catch {
+    // quota / disabled / private mode → in-memory only for this session
+  }
+}

--- a/scripts/layout-ratchet.sh
+++ b/scripts/layout-ratchet.sh
@@ -32,8 +32,10 @@ cd "$(git rev-parse --show-toplevel)"
 # frontend/src/components: 190 re-admits ThemeSelect.tsx and its test (#767, light
 #   theme), which landed on main past the 188 baseline and left the gate red. Ratchet
 #   down when tidied.
+# frontend/src/components: 191 admits OrchestrationTab.test.tsx (#783) — the tab
+#   and its shared pastilles had no component test; the stale pill needed one.
 BASELINES='
-frontend/src/components 190
+frontend/src/components 191
 crates/pdo-daemon/src 87
 '
 


### PR DESCRIPTION
Closes #784. Story #783.

## What
- Run list renders as a tree: only roots at level 0, chevron per parent, children indented by depth (`aria-level`, `data-depth`).
- Pills on parent rows aggregate the subtree: finished / failed / stale / running (stale hidden at 0).
- Global expand/collapse-all button next to the filter chips; Settings « Child runs » radiogroup (device-local, `localStorage`) sets the default.
- Pipeline filter keeps the parent of a matched child; clearing restores everything.
- Opening a child from the parent node's Orchestration tab re-expands the parent and selects the child.
- Archived parent becomes a leaf; its children climb back as roots.
- Orchestrator node and its Orchestration tab show an orange « stale child run » pill.

## Verification
- `cargo test`: 2589 + 473 passed.
- Frontend: `vitest` 2494 passed (18 skipped), `npm run build` OK.
- Agentic FP #784 run twice on an isolated daemon: 8/8 steps pass on iteration 2 (iteration 1 blocking finding on archive fixed).

## Non-blocking findings (out of ticket)
- Run-list stale pill does not refresh live after a raw `node_stale` DB insert (list is WS-pushed; canvas and tab poll). No real stall path exists today (#469).
- After archiving the parent, the right panel still shows the worker node as Running until refreshed.
- Node pills count direct children while row pills aggregate the subtree: per ticket, but two figures for the same parent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)