### PR TITLE
fix(terminal): selection survives pointer motion under tmux mouse mode (#788) — 1.84.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ Le dépôt n'avait aucun fichier `LICENSE` depuis sa création ; seules les mét
 déclaraient MIT. Le fichier existe désormais et confirme ces termes ; les règles de
 contribution sont dans `CONTRIBUTING.md`.
 
+## 1.84.1
+**Sélection texte du terminal effacée au premier mouvement de souris** (#788).
+Avec le mode souris de tmux (suivi de tout mouvement, DECSET 1003), xterm.js rapportait chaque
+déplacement du pointeur sans bouton au pty et effaçait sa propre sélection sur cette « saisie »,
+rendant la copie quasi impossible. Ces mouvements sont désormais stoppés en phase de capture tant
+qu'une sélection existe ; glisser, clic et molette passent toujours.
+
 ## 1.84.0
 **Liste de runs en arbre** (#784 ; story #783).
 Les runs enfants (créés via `pdo run create` depuis une session de nœud) se replient sous leur

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "pdo-daemon"
-version = "1.84.0"
+version = "1.84.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/pdo-daemon"]
 
 [workspace.package]
 edition = "2021"
-version = "1.84.0"
+version = "1.84.1"
 license = "MIT"
 description = "Prompt-Driven Orchestrator — a local daemon that runs and supervises agentic coding pipelines"
 repository = "https://github.com/Loulen/prompt-driven-orchestrator"

--- a/frontend/src/components/TmuxTerminal.tsx
+++ b/frontend/src/components/TmuxTerminal.tsx
@@ -10,6 +10,7 @@ import {
   clipboardKeyAction,
   forcedSelectionEvent,
   isMacPlatform,
+  swallowsMotionReport,
   writeClipboardText,
 } from "../lib/terminalClipboard";
 import { resizeAvoidingAltBufferCorruption } from "../lib/altBufferResize";
@@ -230,6 +231,22 @@ export default function TmuxTerminal({
     };
     container.addEventListener("mousedown", handleMouseDown, { capture: true });
 
+    // #788: with all-motion tracking xterm reports every buttonless pointer
+    // move to the pty and clears its own selection on that "user input", so
+    // the selection made above dies as soon as the pointer moves again. Stop
+    // such moves in capture phase; drags, clicks and the wheel still go through.
+    const handleMouseMove = (e: MouseEvent) => {
+      if (
+        swallowsMotionReport(e, {
+          hasSelection: term.hasSelection(),
+          mouseTrackingActive: term.modes.mouseTrackingMode !== "none",
+        })
+      ) {
+        e.stopImmediatePropagation();
+      }
+    };
+    container.addEventListener("mousemove", handleMouseMove, { capture: true });
+
     // Ctrl+C with a selection copies it (SIGINT otherwise); Ctrl+V pastes like
     // Ctrl+Shift+V instead of sending ^V, which Claude Code reads as "paste
     // image". Returning `false` hands the key to the browser, whose native
@@ -355,6 +372,7 @@ export default function TmuxTerminal({
     return () => {
       container.removeEventListener("wheel", handleWheel, { capture: true });
       container.removeEventListener("mousedown", handleMouseDown, { capture: true });
+      container.removeEventListener("mousemove", handleMouseMove, { capture: true });
       selectionDisposable.dispose();
       setHasSelection(false);
       resizeObserver.disconnect();

--- a/frontend/src/lib/terminalClipboard.test.ts
+++ b/frontend/src/lib/terminalClipboard.test.ts
@@ -3,8 +3,36 @@ import {
   clipboardKeyAction,
   forcedSelectionEvent,
   isMacPlatform,
+  swallowsMotionReport,
   writeClipboardText,
 } from "./terminalClipboard";
+
+describe("swallowsMotionReport (#788)", () => {
+  const move = (init: MouseEventInit = {}) => new MouseEvent("mousemove", { buttons: 0, ...init });
+  const tracking = { hasSelection: true, mouseTrackingActive: true };
+
+  it("swallows a buttonless move over the pane while a selection exists", () => {
+    expect(swallowsMotionReport(move(), tracking)).toBe(true);
+  });
+
+  it("lets a drag through (button held) so a new selection can still be made", () => {
+    expect(swallowsMotionReport(move({ buttons: 1 }), tracking)).toBe(false);
+  });
+
+  it("does nothing without a selection: hover reports keep reaching tmux", () => {
+    expect(swallowsMotionReport(move(), { ...tracking, hasSelection: false })).toBe(false);
+  });
+
+  it("does nothing when the pty does not track the mouse", () => {
+    expect(swallowsMotionReport(move(), { ...tracking, mouseTrackingActive: false })).toBe(false);
+  });
+
+  it("only concerns mousemove: clicks and wheel are untouched", () => {
+    expect(swallowsMotionReport(new MouseEvent("mousedown", { buttons: 0 }), tracking)).toBe(false);
+    expect(swallowsMotionReport(new MouseEvent("mouseup", { buttons: 0 }), tracking)).toBe(false);
+    expect(swallowsMotionReport(new WheelEvent("wheel", { buttons: 0 }), tracking)).toBe(false);
+  });
+});
 
 describe("forcedSelectionEvent (#772)", () => {
   const down = (init: MouseEventInit = {}) =>

--- a/frontend/src/lib/terminalClipboard.ts
+++ b/frontend/src/lib/terminalClipboard.ts
@@ -60,6 +60,27 @@ export function forcedSelectionEvent(
   return clone;
 }
 
+/**
+ * #788: should a `mousemove` over the pane be stopped before xterm.js sees it?
+ *
+ * With all-motion tracking (DECSET 1003, what tmux mouse mode requests) xterm
+ * reports every pointer move — button held or not — to the pty, and its
+ * SelectionService clears the selection on *any* user input, mouse reports
+ * included. So the first pixel of pointer travel after releasing a drag wipes
+ * the selection #772 made possible, and Ctrl+C is back to SIGINT. Swallow
+ * buttonless motion while a selection exists: tmux does nothing useful with a
+ * hover, and drags (`buttons !== 0`), clicks and the wheel keep flowing.
+ */
+export function swallowsMotionReport(
+  e: Pick<MouseEvent, "type" | "buttons">,
+  opts: { hasSelection: boolean; mouseTrackingActive: boolean },
+): boolean {
+  if (e.type !== "mousemove") return false;
+  if (!opts.mouseTrackingActive) return false;
+  if (!opts.hasSelection) return false;
+  return e.buttons === 0;
+}
+
 export type ClipboardKeyAction = "copy" | "paste" | "pass";
 
 /**


### PR DESCRIPTION
Closes #788.

## Problem
With tmux mouse mode (all-motion tracking, DECSET 1003), xterm.js reports every buttonless pointer move to the pty and its SelectionService clears the selection on that "user input". A drag-selection died as soon as the pointer moved again, so copy was nearly impossible.

## Fix
`swallowsMotionReport()` in `frontend/src/lib/terminalClipboard.ts`, wired as a capture-phase `mousemove` listener in `TmuxTerminal.tsx`: buttonless motion is stopped while a selection exists and mouse tracking is active. Drags, clicks and the wheel still flow to tmux.

## Verification
- Unit tests: `terminalClipboard.test.ts` (22 passing).
- Agentic FP against a live Running node (playwright-cli): selection survives motion and a 5 s live refresh, Ctrl+C copies the selected text, plain click still clears, wheel still scrolls scrollback.

## Release
Bump 1.84.0 -> 1.84.1 (patch), CHANGELOG entry added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)